### PR TITLE
Grid shader updates

### DIFF
--- a/examples/libraries/gridTool.js
+++ b/examples/libraries/gridTool.js
@@ -9,7 +9,7 @@ Grid = function(opts) {
         { red: 255, green: 0, blue: 0 },
     ];
     var colorIndex = 0;
-    var gridAlpha = 1.0;
+    var gridAlpha = 0.6;
     var origin = { x: 0, y: 0, z: 0 };
     var majorGridEvery = 5;
     var minorGridWidth = 0.2;
@@ -24,7 +24,7 @@ Grid = function(opts) {
         position: { x: 0 , y: 0, z: 0 },
         visible: true,
         color: colors[0],
-        alpha: 1.0,
+        alpha: gridAlpha,
         rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         minorGridWidth: 0.1,
         majorGridEvery: 2,

--- a/interface/resources/shaders/grid.frag
+++ b/interface/resources/shaders/grid.frag
@@ -5,14 +5,23 @@
 //  fragment shader
 //
 //  Created by Andrzej Kapolka on 1/21/14.
+//  Update by Ryan Huffman on 12/30/14.
 //  Copyright 2013 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+varying vec2 modelCoords;
+
+// Squared distance from center of 1x1 square to an edge along a single axis (0.5 * 0.5)
+const float SQUARED_DISTANCE_TO_EDGE = 0.25;
+
 void main(void) {
-    // use the standard exponential fog calculation
-    const float FOG_DENSITY = 0.5;
-    gl_FragColor = vec4(gl_Color.rgb, exp(-FOG_DENSITY / gl_FragCoord.w));
+    // Squared distance from grid center - this assumes the grid lines are from
+    // 0.0 ... 1.0 in model space.
+    float sqDist = pow(modelCoords.x - 0.5, 2) + pow(modelCoords.y - 0.5, 2);
+    float alpha = max(0, SQUARED_DISTANCE_TO_EDGE - sqDist) / SQUARED_DISTANCE_TO_EDGE;
+    alpha *= gl_Color.a;
+    gl_FragColor = vec4(gl_Color.rgb, alpha);
 }

--- a/interface/resources/shaders/grid.vert
+++ b/interface/resources/shaders/grid.vert
@@ -1,0 +1,20 @@
+#version 120
+
+//
+//  grid.vert
+//  vertex shader
+//
+//  Created by Ryan Huffman on 12/30/14
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+varying vec2 modelCoords;
+
+void main(void) {
+    modelCoords = gl_Vertex.xy;
+    gl_Position = gl_ModelViewProjectionMatrix * vec4(gl_Vertex.xy, 0, 1);
+    gl_FrontColor = gl_Color;
+}

--- a/interface/src/ui/MetavoxelEditor.cpp
+++ b/interface/src/ui/MetavoxelEditor.cpp
@@ -148,6 +148,7 @@ MetavoxelEditor::MetavoxelEditor() :
         return;
     }
         
+    _gridProgram.addShaderFromSourceFile(QGLShader::Vertex, PathUtils::resourcesPath() + "shaders/grid.vert");
     _gridProgram.addShaderFromSourceFile(QGLShader::Fragment, PathUtils::resourcesPath() + "shaders/grid.frag");
     _gridProgram.link();
 }

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -37,6 +37,10 @@ void Grid3DOverlay::render(RenderArgs* args) {
     }
 
     if (!_gridProgram.isLinked()) {
+        if (!_gridProgram.addShaderFromSourceFile(QGLShader::Vertex, PathUtils::resourcesPath() + "shaders/grid.vert")) {
+            qDebug() << "Failed to compile: " + _gridProgram.log();
+            return;
+        }
         if (!_gridProgram.addShaderFromSourceFile(QGLShader::Fragment, PathUtils::resourcesPath() + "shaders/grid.frag")) {
             qDebug() << "Failed to compile: " + _gridProgram.log();
             return;
@@ -70,8 +74,8 @@ void Grid3DOverlay::render(RenderArgs* args) {
     xColor color = getColor();
     glm::vec3 position = getPosition();
 
-    const int MINOR_GRID_DIVISIONS = 100;
-    const int MAJOR_GRID_DIVISIONS = 50;
+    const int MINOR_GRID_DIVISIONS = 200;
+    const int MAJOR_GRID_DIVISIONS = 100;
     const float MAX_COLOR = 255.0f;
 
 


### PR DESCRIPTION
One of the issues with editing large entities is that the grid fades away as soon as the camera is far away from it.  This updates the grid to fade out based on the distance from the center of the grid rather than the camera.  The falloff is a little different here, being squared rather than exponential.

@ey6es This affects the metavoxel grid as well, but shouldn't make a huge difference.  I can put this change in a separate shader if preferred, though.

Feedback appreciated.