### PR TITLE
remove PerformanceTimer from recalculateMeshBoxes() because it's not thread safe

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -590,7 +590,6 @@ void Model::recalculateMeshBoxes(bool pickAgainstTriangles) {
     bool calculatedMeshTrianglesNeeded = pickAgainstTriangles && !_calculatedMeshTrianglesValid;
 
     if (!_calculatedMeshBoxesValid || calculatedMeshTrianglesNeeded) {
-        PerformanceTimer perfTimer("calculatedMeshBoxes");
         const FBXGeometry& geometry = _geometry->getFBXGeometry();
         int numberOfMeshes = geometry.meshes.size();
         _calculatedMeshBoxes.resize(numberOfMeshes);


### PR DESCRIPTION
It looks like the code in PerformanceTimer that attempts to keep a "stack" of function calls doesn't consider the multi-threaded use case... and so it's possible for two threads to be using PerformanceTimer at the same time and to result in the threads corrupting each others memory. This appears to be happening to Ryan in some cases and so I'm removing calls to PerformanceTimer inside of the Model class to avoid at least one possible case.