### PR TITLE
Change sun location tpo be the direction for lighting

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2505,8 +2505,10 @@ void Application::loadViewFrustum(Camera& camera, ViewFrustum& viewFrustum) {
 }
 
 glm::vec3 Application::getSunDirection() {
-    return glm::normalize(_environment.getClosestData(_myCamera.getPosition()).getSunLocation(_myCamera.getPosition()) -
-        _myCamera.getPosition());
+ /*   return glm::normalize(_environment.getClosestData(_myCamera.getPosition()).getSunLocation(_myCamera.getPosition()) -
+        _myCamera.getPosition());*/
+    // Sun direction is in fact just the location of the sun relative to the origin
+    return glm::normalize(_environment.getClosestData(_myCamera.getPosition()).getSunLocation(_myCamera.getPosition()));
 }
 
 void Application::updateShadowMap() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2505,8 +2505,6 @@ void Application::loadViewFrustum(Camera& camera, ViewFrustum& viewFrustum) {
 }
 
 glm::vec3 Application::getSunDirection() {
- /*   return glm::normalize(_environment.getClosestData(_myCamera.getPosition()).getSunLocation(_myCamera.getPosition()) -
-        _myCamera.getPosition());*/
     // Sun direction is in fact just the location of the sun relative to the origin
     return glm::normalize(_environment.getClosestData(_myCamera.getPosition()).getSunLocation(_myCamera.getPosition()));
 }

--- a/libraries/environment/src/EnvironmentData.cpp
+++ b/libraries/environment/src/EnvironmentData.cpp
@@ -21,12 +21,12 @@ EnvironmentData::EnvironmentData(int id) :
     _flat(true),
     _gravity(0.0f),
     _atmosphereCenter(0, -1000, 0),
-    _atmosphereInnerRadius(1000),
-    _atmosphereOuterRadius(1025),
+    _atmosphereInnerRadius(1000.0),
+    _atmosphereOuterRadius(1100.0),
     _rayleighScattering(0.0025f),
     _mieScattering(0.0010f),
     _scatteringWavelengths(0.650f, 0.570f, 0.475f),
-    _sunLocation(1000, 1000, 0),
+    _sunLocation(1000, 900, 1000),
     _sunBrightness(20.0f) {
 }
 
@@ -35,7 +35,7 @@ glm::vec3 EnvironmentData::getAtmosphereCenter(const glm::vec3& cameraPosition) 
 }
 
 glm::vec3 EnvironmentData::getSunLocation(const glm::vec3& cameraPosition) const {
-    return _sunLocation + (_flat ? glm::vec3(cameraPosition.x, 0.0f, cameraPosition.z) : glm::vec3());
+    return _sunLocation;
 }
 
 int EnvironmentData::getBroadcastData(unsigned char* destinationBuffer) const {

--- a/libraries/environment/src/EnvironmentData.cpp
+++ b/libraries/environment/src/EnvironmentData.cpp
@@ -22,7 +22,7 @@ EnvironmentData::EnvironmentData(int id) :
     _gravity(0.0f),
     _atmosphereCenter(0, -1000, 0),
     _atmosphereInnerRadius(1000.0),
-    _atmosphereOuterRadius(1100.0),
+    _atmosphereOuterRadius(1025.0),
     _rayleighScattering(0.0025f),
     _mieScattering(0.0010f),
     _scatteringWavelengths(0.650f, 0.570f, 0.475f),


### PR DESCRIPTION
- Changed the sun Direction call to return the location of the sun normalized as the light direction
 This gives us a constant lighting direction for a domain independently of the position in the domain.

- got rid of the impact the "_flat" flag for the sun location

- Set the default of the sun location to 1000, 900, 1000 which looks ok-ish on the main demo scenes
  basically if we consider Z axis to be the South, it's a morning light on the north hemisphere.

