### PR TITLE
Restored addReverb default arg

### DIFF
--- a/interface/src/Audio.cpp
+++ b/interface/src/Audio.cpp
@@ -507,9 +507,9 @@ void Audio::setReverbOptions(const AudioEffectOptions* options) {
     }
 }
 
-void Audio::addReverb(ty_gverb* gverb, int16_t* samplesData, int numSamples, QAudioFormat& audioFormat) {
+void Audio::addReverb(ty_gverb* gverb, int16_t* samplesData, int numSamples, QAudioFormat& audioFormat, bool noEcho) {
     float wetFraction = DB_CO(_reverbOptions->getWetLevel());
-    float dryFraction = (!_shouldEchoLocally) ? 0.0f : (1.0f - wetFraction);
+    float dryFraction = (noEcho) ? 0.0f : (1.0f - wetFraction);
     
     float lValue,rValue;
     for (int sample = 0; sample < numSamples; sample += audioFormat.channelCount()) {
@@ -568,7 +568,7 @@ void Audio::handleLocalEchoAndReverb(QByteArray& inputByteArray) {
         int16_t* loopbackSamples = reinterpret_cast<int16_t*>(loopBackByteArray.data());
         int numLoopbackSamples = loopBackByteArray.size() / sizeof(int16_t);
         updateGverbOptions();
-        addReverb(_gverbLocal, loopbackSamples, numLoopbackSamples, _outputFormat);
+        addReverb(_gverbLocal, loopbackSamples, numLoopbackSamples, _outputFormat, !_shouldEchoLocally);
     }
     
     if (_loopbackOutputDevice) {

--- a/interface/src/Audio.h
+++ b/interface/src/Audio.h
@@ -208,7 +208,7 @@ private:
     // Adds Reverb
     void initGverb();
     void updateGverbOptions();
-    void addReverb(ty_gverb* gverb, int16_t* samples, int numSamples, QAudioFormat& format);
+    void addReverb(ty_gverb* gverb, int16_t* samples, int numSamples, QAudioFormat& format, bool noEcho = false);
 
     void handleLocalEchoAndReverb(QByteArray& inputByteArray);
 


### PR DESCRIPTION
Normal and local reverb have different behavior.
Normal reverb will always have echo and use the default argument.
As for the local reverb, it depends on _shouldEchoLocally.