### PR TITLE
Update setting drawOnHUD and update to write lock for editOverlay

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -48,13 +48,6 @@ Base3DOverlay::Base3DOverlay(const Base3DOverlay* base3DOverlay) :
 Base3DOverlay::~Base3DOverlay() {
 }
 
-void Base3DOverlay::setDrawOnHUD(bool value) {
-    if (_drawOnHUD != value) {
-        _drawOnHUD = value;
-        Application::getInstance()->getOverlays().overlayDrawOnChanged(this);
-    }
-}
-
 void Base3DOverlay::setProperties(const QScriptValue& properties) {
     Overlay::setProperties(properties);
 

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -47,7 +47,7 @@ public:
     void setRotation(const glm::quat& value) { _rotation = value; }
     void setIgnoreRayIntersection(bool value) { _ignoreRayIntersection = value; }
     void setDrawInFront(bool value) { _drawInFront = value; }
-    void setDrawOnHUD(bool value);
+    void setDrawOnHUD(bool value) { _drawOnHUD = value; }
 
     virtual void setProperties(const QScriptValue& properties);
     virtual QScriptValue getProperty(const QString& property);

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -82,9 +82,6 @@ public slots:
 
     /// returns details about the closest 3D Overlay hit by the pick ray
     RayToOverlayIntersectionResult findRayIntersection(const PickRay& ray);
-
-    // called by Base3DOverlay when drawOnHUD changes
-    void overlayDrawOnChanged(Base3DOverlay* overlay);
     
     /// returns whether the overlay's assets are loaded or not
     bool isLoaded(unsigned int id);


### PR DESCRIPTION
@ZappoMan I ran into issues updating OculusManager because Overlays requires a QScriptValue to update properties, which, AFAIK, can't be created as an object (allowing settable properties) without creating it via a QScriptEngine.  I think we should update the interface to work with something other than QScriptValues, but I think that's beyond this fix.