### PR TITLE
fix rapid attenuation of angular velocity

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -647,27 +647,30 @@ void EntityItem::simulate(const quint64& now) {
         glm::quat rotation = getRotation();
 
         // angular damping
-        glm::vec3 angularVelocity = glm::radians(getAngularVelocity());
+        glm::vec3 angularVelocity = getAngularVelocity();
         if (_angularDamping > 0.0f) {
             angularVelocity *= powf(1.0f - _angularDamping, timeElapsed);
             if (wantDebug) {        
                 qDebug() << "    angularDamping :" << _angularDamping;
                 qDebug() << "    newAngularVelocity:" << angularVelocity;
             }
+            setAngularVelocity(angularVelocity);
         }
 
-        float angularSpeed = glm::length(angularVelocity);
+        float angularSpeed = glm::length(_angularVelocity);
         
-        const float EPSILON_ANGULAR_VELOCITY_LENGTH = 0.0017453f; // ~0.1 degree/sec
+        const float EPSILON_ANGULAR_VELOCITY_LENGTH = 0.1; // 
         if (angularSpeed < EPSILON_ANGULAR_VELOCITY_LENGTH) {
-            angularVelocity = NO_ANGULAR_VELOCITY;
+            setAngularVelocity(NO_ANGULAR_VELOCITY);
         } else {
-            float angle = timeElapsed * angularSpeed;
-            glm::quat  dQ = glm::angleAxis(angle, glm::normalize(angularVelocity));
+            // NOTE: angularSpeed is currently in degrees/sec!!!
+            // TODO: Andrew to convert to radians/sec
+            float angle = timeElapsed * glm::radians(angularSpeed);
+            glm::vec3 axis = _angularVelocity / angularSpeed;
+            glm::quat  dQ = glm::angleAxis(angle, axis);
             rotation = glm::normalize(dQ * rotation);
             setRotation(rotation);
         }
-        setAngularVelocity(angularVelocity);
     }
 
 #ifdef USE_BULLET_PHYSICS

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -659,7 +659,7 @@ void EntityItem::simulate(const quint64& now) {
 
         float angularSpeed = glm::length(_angularVelocity);
         
-        const float EPSILON_ANGULAR_VELOCITY_LENGTH = 0.1; // 
+        const float EPSILON_ANGULAR_VELOCITY_LENGTH = 0.1f; // 
         if (angularSpeed < EPSILON_ANGULAR_VELOCITY_LENGTH) {
             setAngularVelocity(NO_ANGULAR_VELOCITY);
         } else {


### PR DESCRIPTION
The problem was that angular velocity was being stored as degrees/sec, then converted to radians/sec (required for proper rotation calculations) and then NOT converted back to degrees/sec later.

The solution is to keep the angular velocity in degrees/sec for attenutation and only convert to radians when computing the incremental rotation.