### PR TITLE
Suppress warnings about inconsistent DLL linkage of lrintf in Windows

### DIFF
--- a/interface/src/Audio.h
+++ b/interface/src/Audio.h
@@ -49,6 +49,7 @@
 
 #ifdef _WIN32
 #pragma warning( push )
+#pragma warning( disable : 4273 )
 #pragma warning( disable : 4305 )
 #endif
 extern "C" {


### PR DESCRIPTION
This warning in Windows builds is due to redefinition of lrintf in gverb
library's ladspa-util.h file.