### PR TITLE
Use static GLEW in render-utils for Windows

### DIFF
--- a/libraries/render-utils/CMakeLists.txt
+++ b/libraries/render-utils/CMakeLists.txt
@@ -9,5 +9,10 @@ include_glm()
 
 link_hifi_libraries(animation fbx shared gpu)
 
+if (WIN32)
+  # we're using static GLEW, so define GLEW_STATIC
+  add_definitions(-DGLEW_STATIC)
+endif ()
+
 # call macro to include our dependency includes and bubble them up via a property on our target
 include_dependency_includes()


### PR DESCRIPTION
Same as for interface and gpu library. Fixes LNK4049 locally defined symbol warnings. Thanks to @thoys for the pointer.