### PR TITLE
Don't call delete later unless you have to

### DIFF
--- a/libraries/shared/src/DependencyManager.h
+++ b/libraries/shared/src/DependencyManager.h
@@ -13,6 +13,7 @@
 #define hifi_DependencyManager_h
 
 #include <QSharedPointer>
+#include <QDebug>
 
 #include <typeinfo>
 
@@ -22,10 +23,12 @@ public:\
 private:\
     void customDeleter() {\
         QObject* thisObject = dynamic_cast<QObject*>(this);\
-        if (thisObject) {\
+        if (thisObject && thisObject->parent()) {\
             thisObject->deleteLater();\
+            qDebug() << "Delete later:" << #T;\
         } else {\
             delete this;\
+            qDebug() << "Deleted:" << #T;\
         }\
     }\
     friend class DependencyManager;


### PR DESCRIPTION
Can take out the debug if you want but I think for now it's good to see what's being delayed.
Right now only GLCanvas does and is the whole reason this is in place.
Something weird is happening where Qt deallocates it but doesn't call the constructor which cause an EXC_BAD_ACCESS when we try to delete.