### PR TITLE
Fix gl projection matrix stack overflow when rendering to HUD

### DIFF
--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -197,19 +197,23 @@ void ApplicationOverlay::renderOverlay(bool renderToTexture) {
         const float FAR_CLIP = 10000;
         glLoadIdentity();
         glOrtho(0, glCanvas->width(), glCanvas->height(), 0, NEAR_CLIP, FAR_CLIP);
-        
+
+        glMatrixMode(GL_MODELVIEW);
+
         renderAudioMeter();
-        
+
         renderStatsAndLogs();
-        
+
         // give external parties a change to hook in
         emit application->renderingOverlay();
-        
+
         overlays.renderHUD();
-        
+
         renderPointers();
-        
+
         renderDomainConnectionStatusBorder();
+
+        glMatrixMode(GL_PROJECTION);
     } glPopMatrix();
 
     glMatrixMode(GL_MODELVIEW);


### PR DESCRIPTION
The projection matrix stack is considerably smaller than the modelview
stack and was overflowing on Windows and Linux machines that were tested.