### PR TITLE
fixes for EntityServer crashes

### DIFF
--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -404,6 +404,13 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
 
             bool lastNodeDidntFit = false; // assume each node fits
             if (!nodeData->elementBag.isEmpty()) {
+                
+                quint64 lockWaitStart = usecTimestampNow();
+                _myServer->getOctree()->lockForRead();
+                quint64 lockWaitEnd = usecTimestampNow();
+                lockWaitElapsedUsec = (float)(lockWaitEnd - lockWaitStart);
+                quint64 encodeStart = usecTimestampNow();
+
                 OctreeElement* subTree = nodeData->elementBag.extract();
 
                 /* TODO: Looking for a way to prevent locking and encoding a tree that is not
@@ -447,12 +454,6 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
                 // it seems like it may be a good idea to include the lock time as part of the encode time
                 // are reported to client. Since you can encode without the lock
                 nodeData->stats.encodeStarted();
-                
-                quint64 lockWaitStart = usecTimestampNow();
-                _myServer->getOctree()->lockForRead();
-                quint64 lockWaitEnd = usecTimestampNow();
-                lockWaitElapsedUsec = (float)(lockWaitEnd - lockWaitStart);
-                quint64 encodeStart = usecTimestampNow();
 
                 bytesWritten = _myServer->getOctree()->encodeTreeBitstream(subTree, &_packetData, nodeData->elementBag, params);
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -98,7 +98,9 @@ void EntityTreeRenderer::init() {
 }
 
 QScriptValue EntityTreeRenderer::loadEntityScript(const EntityItemID& entityItemID) {
+    _tree->lockForRead();
     EntityItem* entity = static_cast<EntityTree*>(_tree)->findEntityByEntityItemID(entityItemID);
+    _tree->unlock();
     return loadEntityScript(entity);
 }
 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -95,6 +95,7 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) {
     _physicsInfo = NULL;
     _dirtyFlags = 0;
     _changedOnServer = 0;
+    _element = NULL;
     initFromEntityItemID(entityItemID);
 }
 
@@ -110,6 +111,7 @@ EntityItem::EntityItem(const EntityItemID& entityItemID, const EntityItemPropert
     _physicsInfo = NULL;
     _dirtyFlags = 0;
     _changedOnServer = 0;
+    _element = NULL;
     initFromEntityItemID(entityItemID);
     setProperties(properties);
 }
@@ -117,6 +119,7 @@ EntityItem::EntityItem(const EntityItemID& entityItemID, const EntityItemPropert
 EntityItem::~EntityItem() {
     // be sure to clean up _physicsInfo before calling this dtor
     assert(_physicsInfo == NULL);
+    assert(_element == NULL);
 }
 
 EntityPropertyFlags EntityItem::getEntityProperties(EncodeBitstreamParams& params) const {

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -39,6 +39,7 @@ class EntityTreeElementExtraEncodeData;
 /// to all other entity types. In particular: postion, size, rotation, age, lifetime, velocity, gravity. You can not instantiate
 /// one directly, instead you must only construct one of it's derived classes with additional features.
 class EntityItem  {
+    friend class EntityTreeElement;
 
 public:
     enum EntityDirtyFlags {
@@ -301,6 +302,7 @@ public:
     void* getPhysicsInfo() const { return _physicsInfo; }
     void setPhysicsInfo(void* data) { _physicsInfo = data; }
     
+    EntityTreeElement* getElement() const { return _element; }
 protected:
 
     virtual void initFromEntityItemID(const EntityItemID& entityItemID); // maybe useful to allow subclasses to init
@@ -362,6 +364,8 @@ protected:
 
     // DirtyFlags are set whenever a property changes that the EntitySimulation needs to know about.
     uint32_t _dirtyFlags;   // things that have changed from EXTERNAL changes (via script or packet) but NOT from simulation
+
+    EntityTreeElement* _element;    // back pointer to containing Element
 };
 
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -682,6 +682,7 @@ void EntityTreeElement::cleanupEntities() {
     uint16_t numberOfEntities = _entityItems->size();
     for (uint16_t i = 0; i < numberOfEntities; i++) {
         EntityItem* entity = (*_entityItems)[i];
+        entity->_element = NULL;
         delete entity;
     }
     _entityItems->clear();
@@ -693,6 +694,7 @@ bool EntityTreeElement::removeEntityWithEntityItemID(const EntityItemID& id) {
     for (uint16_t i = 0; i < numberOfEntities; i++) {
         if ((*_entityItems)[i]->getEntityItemID() == id) {
             foundEntity = true;
+            (*_entityItems)[i]->_element = NULL;
             _entityItems->removeAt(i);
             break;
         }
@@ -701,7 +703,13 @@ bool EntityTreeElement::removeEntityWithEntityItemID(const EntityItemID& id) {
 }
 
 bool EntityTreeElement::removeEntityItem(EntityItem* entity) {
-    return _entityItems->removeAll(entity) > 0;
+    int numEntries = _entityItems->removeAll(entity);
+    if (numEntries > 0) {
+        assert(entity->_element == this);
+        entity->_element = NULL;
+        return true;
+    }
+    return false;
 }
 
 
@@ -808,7 +816,10 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
 }
 
 void EntityTreeElement::addEntityItem(EntityItem* entity) {
+    assert(entity);
+    assert(entity->_element == NULL);
     _entityItems->push_back(entity);
+    entity->_element = this;
 }
 
 // will average a "common reduced LOD view" from the the child elements...

--- a/libraries/entities/src/UpdateEntityOperator.cpp
+++ b/libraries/entities/src/UpdateEntityOperator.cpp
@@ -231,18 +231,19 @@ bool UpdateEntityOperator::preRecursion(OctreeElement* element) {
                     qDebug() << "    *** REMOVING from ELEMENT ***";
                 }
 
-                entityTreeElement->removeEntityItem(_existingEntity); // NOTE: only removes the entity, doesn't delete it
+                // the entity knows what element it's in, so we remove it from that one
+                // NOTE: we know we haven't yet added it to its new element because _removeOld is true
+                EntityTreeElement* oldElement = _existingEntity->getElement();
+                oldElement->removeEntityItem(_existingEntity);
+                _tree->setContainingElement(_entityItemID, NULL);
 
-                // If we haven't yet found the new location, then we need to 
-                // make sure to remove our entity to element map, because for
-                // now we're not in that map
-                if (!_foundNew) {
-                    _tree->setContainingElement(_entityItemID, NULL);
+                if (oldElement != _containingElement) {
+                    qDebug() << "WARNING entity moved during UpdateEntityOperator recursion";
+                    assert(! _containingElement->removeEntityItem(_existingEntity));
+                }
 
-                    if (_wantDebug) {
-                        qDebug() << "    *** REMOVING from MAP ***";
-                    }
-
+                if (_wantDebug) {
+                    qDebug() << "    *** REMOVING from MAP ***";
                 }
             }
             _foundOld = true;
@@ -263,7 +264,6 @@ bool UpdateEntityOperator::preRecursion(OctreeElement* element) {
             qDebug() << "    entityTreeElement->bestFitBounds(_newEntityBox)=" << entityTreeElement->bestFitBounds(_newEntityBox);
         }
 
-
         // If this element is the best fit for the new entity properties, then add/or update it
         if (entityTreeElement->bestFitBounds(_newEntityBox)) {
 
@@ -271,33 +271,14 @@ bool UpdateEntityOperator::preRecursion(OctreeElement* element) {
                 qDebug() << "    *** THIS ELEMENT IS BEST FIT ***";
             }
 
+            EntityTreeElement* oldElement = _existingEntity->getElement();
             // if we are the existing containing element, then we can just do the update of the entity properties
-            if (entityTreeElement == _containingElement) {
+            if (entityTreeElement == oldElement) {
 
                 if (_wantDebug) {
                     qDebug() << "    *** This is the same OLD ELEMENT ***";
                 }
             
-                // TODO: We shouldn't be in a remove old case and also be the new best fit. This indicates that
-                // we have some kind of a logic error in this operator. But, it can handle it properly by setting
-                // the new properties for the entity and moving on. Still going to output a warning that if we
-                // see consistently we will want to address this.
-                if (_removeOld) {
-                    qDebug() << "UNEXPECTED - UpdateEntityOperator - "
-                                "we thought we needed to removeOld, but the old entity is our best fit.";
-                    _removeOld = false;
-                    
-                    // if we thought we were supposed to remove the old item, and we already did, then we need
-                    // to repair this case.
-                    if (_foundOld) {
-                        if (_wantDebug) {
-                            qDebug() << "    *** REPAIRING PREVIOUS REMOVAL from ELEMENT and MAP ***";
-                        }
-                        entityTreeElement->addEntityItem(_existingEntity);
-                        _tree->setContainingElement(_entityItemID, entityTreeElement);
-                    }
-                }
-
                 // set the entity properties and mark our element as changed.
                 _existingEntity->setProperties(_properties);
                 if (_wantDebug) {
@@ -305,14 +286,22 @@ bool UpdateEntityOperator::preRecursion(OctreeElement* element) {
                 }
             } else {
                 // otherwise, this is an add case.
+                if (oldElement) {
+                    oldElement->removeEntityItem(_existingEntity);
+                    if (oldElement != _containingElement) {
+                        qDebug() << "WARNING entity moved during UpdateEntityOperator recursion";
+                    }
+                }
                 entityTreeElement->addEntityItem(_existingEntity);
-                _existingEntity->setProperties(_properties); // still need to update the properties!
                 _tree->setContainingElement(_entityItemID, entityTreeElement);
+
+                _existingEntity->setProperties(_properties); // still need to update the properties!
                 if (_wantDebug) {
                     qDebug() << "    *** ADDING ENTITY to ELEMENT and MAP and SETTING PROPERTIES ***";
                 }
             }
-            _foundNew = true; // we found the new item!
+            _foundNew = true; // we found the new element
+            _removeOld = false; // and it has already been removed from the old
         } else {
             keepSearching = true;
         }


### PR DESCRIPTION
This fixes the crash for me.

As far as I can tell the final problem was in one or both of MovingEntityOperator or UpdateEntityOperator -- I think a pointer was sometimes not being removed properly from an old EntityTreeElement and would eventually cause a problem when it was deleted and not cleaned up.  Once I had a reliable fix I tried to scale it back to something less invasive that just fixed the operators but I couldn't figure it out, so this is what I've got.

I added EntityItem::_element as a protected backpointer to its containing EntityTreeElement.  This is scrupulously maintained by EntityTreeElement (which is a friend of EntityItem) whenever an entity is added or removed, and is used to make sure the entity is only ever in one element at a time.  There are asserts in place such that if we ever get it wrong it should crash much closer to the actual problem.

It isn't fully utilized to simplify the Operator logic because we're not sure we want to fully commit to this architecture change -- it was going to be a topic of discussion between Brad and I this coming week.  It won't be hard to pull out if we come up with an alternative fix for the operators later.