### PR TITLE
remove lock at EntityTreeRenderer::loadEntityScript

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -98,9 +98,7 @@ void EntityTreeRenderer::init() {
 }
 
 QScriptValue EntityTreeRenderer::loadEntityScript(const EntityItemID& entityItemID) {
-    _tree->lockForRead();
     EntityItem* entity = static_cast<EntityTree*>(_tree)->findEntityByEntityItemID(entityItemID);
-    _tree->unlock();
     return loadEntityScript(entity);
 }
 


### PR DESCRIPTION
Philip and Chris report that the interface hangs.  I too saw it hang, but only once in at least 20 runs.  I was able to tell that it was deadlocked on EntityTreeRenderer::loadEntityScript() but I failed to find the other thread.  And then I wasn't able to reproduce.  Nevertheless, there is a deadlock possibility there and we need to undo the locks that I had added (despite the thread safety issue).