### PR TITLE
Fix Philip's entity delete crash

### DIFF
--- a/libraries/entities/src/DeleteEntityOperator.cpp
+++ b/libraries/entities/src/DeleteEntityOperator.cpp
@@ -92,7 +92,8 @@ bool DeleteEntityOperator::preRecursion(OctreeElement* element) {
             // and we can stop searching.
             if (entityTreeElement == details.containingElement) {
                 EntityItem* theEntity = details.entity;
-                assert(entityTreeElement->removeEntityItem(theEntity)); // remove it from the element
+                bool entityDeleted = entityTreeElement->removeEntityItem(theEntity); // remove it from the element
+                assert(entityDeleted);
                 _tree->setContainingElement(details.entity->getEntityItemID(), NULL); // update or id to element lookup
                 _foundCount++;
             }


### PR DESCRIPTION
The call to entityTreeElement->removeEntityItem(theEntity) was inside of an assert() so it was "compiled out" of release builds. This caused the entity item to not get deleted and would cause these crashes.

The crash occurred because the tree element that the entity used to be in still existed (maybe there was other content in that element) and the entity should have been removed from the elements list of entities, but wasn't, as a result if the tree element still existed it would have a pointer to an entity that was already deleted. Any operation like rendering, or simulation, or others that referenced entities in the tree element would crash.

This only happened on release build built with the build system settings (unix makefiles, release with debug symbols, etc) it would not occur if you used XCode to make a release build because of how xcode defines asserts.

It would also only reproduce if you had other entities in the same "tree element" of the play-sound sphere. Because otherwise the entire element would get deleted, and there wouldn't be a dangling entity item to attempt to render.

I verified the bug occurred in the old code by adding debug output to the removeEntityItem() method. I could see that it wasn't being called in a release build. I also saw the crash in this case.
I then changed the call to removeEntityItem() to not be inside an assert and saw that it was being called, and the crash no longer occurs.