### PR TITLE
remove functional code from inside assert

### DIFF
--- a/libraries/entities/src/UpdateEntityOperator.cpp
+++ b/libraries/entities/src/UpdateEntityOperator.cpp
@@ -239,7 +239,7 @@ bool UpdateEntityOperator::preRecursion(OctreeElement* element) {
 
                 if (oldElement != _containingElement) {
                     qDebug() << "WARNING entity moved during UpdateEntityOperator recursion";
-                    assert(! _containingElement->removeEntityItem(_existingEntity));
+                    _containingElement->removeEntityItem(_existingEntity);
                 }
 
                 if (_wantDebug) {


### PR DESCRIPTION
There was one more place where I had put functional code inside an assert().  This was inside some "hail mary" code that I don't think can actually be called -- I put it in back when I was trying to figure stuff out but was never able to actually fall into it.