### PR TITLE
Remove menu item for Show Voxel Nodes which is no longer available

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -354,11 +354,8 @@ Menu::Menu() :
 
     QMenu* nodeBordersMenu = viewMenu->addMenu("Server Borders");
     NodeBounds& nodeBounds = appInstance->getNodeBoundsDisplay();
-    addCheckableActionToQMenuAndActionHash(nodeBordersMenu, MenuOption::ShowBordersVoxelNodes,
-                                           Qt::CTRL | Qt::SHIFT | Qt::Key_1, false,
-                                           &nodeBounds, SLOT(setShowVoxelNodes(bool)));
     addCheckableActionToQMenuAndActionHash(nodeBordersMenu, MenuOption::ShowBordersEntityNodes,
-                                           Qt::CTRL | Qt::SHIFT | Qt::Key_2, false,
+                                           Qt::CTRL | Qt::SHIFT | Qt::Key_1, false,
                                            &nodeBounds, SLOT(setShowEntityNodes(bool)));
 
     addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::OffAxisProjection, 0, false);


### PR DESCRIPTION
And change Show Entity Nodes shortcut from Ctrl-Shift-2 to Ctrl-Shift-1.