### PR TITLE
Remove pre-Bullet server-side EntityItem motion

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -691,15 +691,7 @@ void EntityItem::simulate(const quint64& now) {
         }
     }
 
-#ifdef USE_BULLET_PHYSICS
-    // When Bullet is available we assume that "zero velocity" means "at rest"
-    // because of collision conditions this simulation does not know about
-    // so we don't fall in for the non-zero gravity case here.
     if (hasVelocity()) {
-#else // !USE_BULLET_PHYSICS
-    if (hasVelocity() || hasGravity()) {
-#endif // USE_BULLET_PHYSICS
-
         // linear damping
         glm::vec3 velocity = getVelocity();
         if (_damping > 0.0f) {
@@ -733,14 +725,6 @@ void EntityItem::simulate(const quint64& now) {
         // handle bounces off the ground... We bounce at the distance to the bottom of our entity
         if (position.y <= getDistanceToBottomOfEntity()) {
             velocity = velocity * glm::vec3(1,-1,1);
-
-#ifndef USE_BULLET_PHYSICS
-            // if we've slowed considerably, then just stop moving, but only if no BULLET
-            if (glm::length(velocity) <= ENTITY_ITEM_EPSILON_VELOCITY_LENGTH) {
-                velocity = ENTITY_ITEM_ZERO_VEC3;
-            }
-#endif // !USE_BULLET_PHYSICS
-            
             position.y = getDistanceToBottomOfEntity();
         }
 
@@ -756,14 +740,8 @@ void EntityItem::simulate(const quint64& now) {
             }
         }
         
-#ifdef USE_BULLET_PHYSICS
-        // When Bullet is available we assume that it will tell us when velocities go to zero...
-#else // !USE_BULLET_PHYSICS
-        // ... otherwise we help things come to rest by clamping small velocities.
-        if (glm::length(velocity) <= ENTITY_ITEM_EPSILON_VELOCITY_LENGTH) {
-            velocity = ENTITY_ITEM_ZERO_VEC3;
-        }
-#endif // USE_BULLET_PHYSICS
+        // NOTE: we don't zero out very small velocities --> we rely on a remote Bullet simulation 
+        // to tell us when the entity has stopped.
 
         // NOTE: the simulation should NOT set any DirtyFlags on this entity
         setPosition(position); // this will automatically recalculate our collision shape
@@ -781,13 +759,7 @@ void EntityItem::simulate(const quint64& now) {
 }
 
 bool EntityItem::isMoving() const {
-#ifdef USE_BULLET_PHYSICS
-    // When Bullet is available we assume that "zero velocity" means "at rest"
-    // because of collision conditions this simulation does not know about.
     return hasVelocity() || hasAngularVelocity();
-#else // !USE_BULLET_PHYSICS
-    return hasVelocity() || (hasGravity() && !isRestingOnSurface()) || hasAngularVelocity();
-#endif //USE_BULLET_PHYSICS
 }
 
 bool EntityItem::lifetimeHasExpired() const { 


### PR DESCRIPTION
Since the "require Bullet" PR #4111 is on hold I'm submitting this one which removes the pre-bullet behavior in the non-bullet simulation that the EntityServer does.  This should be enough to eliminate some simulation glitches caused by the EntityServer for Bullet enabled clients (perhaps enough for a demo this morning) while causing limited breakage of old content/behavior (1).

(1) In particular the situation where a non-moving entity is given non-zero gravity.  In the old behavior the EntityServer would start integrating the velocity of the object and it would obtain non-zero velocity.  In the new behavior any object with zero velocities is assumed by the EntityServer to be at rest, due perhaps to forces that the EntityServer doesn't know about (such as colliding surfaces).