### PR TITLE
remove log about failure to add to physics engine

### DIFF
--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -66,7 +66,7 @@ void PhysicsEngine::addEntityInternal(EntityItem* entity) {
             _entityMotionStates.insert(motionState);
         } else {
             // We failed to add the entity to the simulation.  Probably because we couldn't create a shape for it.
-            qDebug() << "failed to add entity " << entity->getEntityItemID() << " to physics engine";
+            //qDebug() << "failed to add entity " << entity->getEntityItemID() << " to physics engine";
             delete motionState;
         }
     }


### PR DESCRIPTION
This log is bothering people, and isn't important right now, so I'm commenting it out.

Eventually we'll want to know about failures to find collision shapes for things that need them, but for now the reason this is that many Entities (models, lights, and really really big boxes or spheres) are failing is because we just haven't implemented shape generation for them.