### PR TITLE
Update ImageOverlay to use TextureCache

### DIFF
--- a/interface/src/ui/overlays/ImageOverlay.cpp
+++ b/interface/src/ui/overlays/ImageOverlay.cpp
@@ -52,7 +52,6 @@ void ImageOverlay::render(RenderArgs* args) {
     if (!_isLoaded && !_imageURL.isEmpty()) {
         _isLoaded = true;
         _renderImage = true;
-        qDebug() << "Now loding texture for ImageOverlay";
         _texture = DependencyManager::get<TextureCache>()->getTexture(_imageURL);
     }
 

--- a/interface/src/ui/overlays/ImageOverlay.cpp
+++ b/interface/src/ui/overlays/ImageOverlay.cpp
@@ -22,9 +22,7 @@
 #include "ImageOverlay.h"
 
 ImageOverlay::ImageOverlay() :
-    _textureID(0),
     _renderImage(false),
-    _textureBound(false),
     _wantClipFromImage(false)
 {
     _isLoaded = false;
@@ -32,63 +30,48 @@ ImageOverlay::ImageOverlay() :
 
 ImageOverlay::ImageOverlay(const ImageOverlay* imageOverlay) :
     Overlay2D(imageOverlay),
+    _texture(imageOverlay->_texture),
     _imageURL(imageOverlay->_imageURL),
     _textureImage(imageOverlay->_textureImage),
-    _textureID(0),
-    _fromImage(),
+    _fromImage(imageOverlay->_fromImage),
     _renderImage(imageOverlay->_renderImage),
-    _textureBound(false),
-    _wantClipFromImage(false)
+    _wantClipFromImage(imageOverlay->_wantClipFromImage)
 {
 }
 
 ImageOverlay::~ImageOverlay() {
-    if (_parent && _textureID) {
-        // do we need to call this?
-        //_parent->deleteTexture(_textureID);
-    }
 }
 
 // TODO: handle setting image multiple times, how do we manage releasing the bound texture?
 void ImageOverlay::setImageURL(const QUrl& url) {
     _imageURL = url;
     _isLoaded = false;
-    QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
-    QNetworkReply* reply = networkAccessManager.get(QNetworkRequest(url));
-    connect(reply, &QNetworkReply::finished, this, &ImageOverlay::replyFinished);
-}
-
-void ImageOverlay::replyFinished() {
-    QNetworkReply* reply = static_cast<QNetworkReply*>(sender());
-    
-    // replace our byte array with the downloaded data
-    QByteArray rawData = reply->readAll();
-    _textureImage.loadFromData(rawData);
-    _renderImage = true;
-    _isLoaded = true;
-    reply->deleteLater();
 }
 
 void ImageOverlay::render(RenderArgs* args) {
-    if (!_visible || !_isLoaded) {
-        return; // do nothing if we're not visible
+    if (!_isLoaded && !_imageURL.isEmpty()) {
+        _isLoaded = true;
+        _renderImage = true;
+        qDebug() << "Now loding texture for ImageOverlay";
+        _texture = DependencyManager::get<TextureCache>()->getTexture(_imageURL);
     }
-    if (_renderImage && !_textureBound) {
-        _textureID = _parent->bindTexture(_textureImage);
-        _textureBound = true;
+
+    if (!_visible || !_isLoaded || !_texture || !_texture->isLoaded()) {
+        return;
     }
 
     if (_renderImage) {
+        qDebug() << "Rendering: " << _imageURL << ", " << _texture->getWidth() << ", " << _texture->getHeight();
         glEnable(GL_TEXTURE_2D);
-        glBindTexture(GL_TEXTURE_2D, _textureID);
+        glBindTexture(GL_TEXTURE_2D, _texture->getID());
     }
     const float MAX_COLOR = 255.0f;
     xColor color = getColor();
     float alpha = getAlpha();
     glColor4f(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
 
-    float imageWidth = _textureImage.width();
-    float imageHeight = _textureImage.height();
+    float imageWidth = _texture->getWidth();
+    float imageHeight = _texture->getHeight();
     
     QRect fromImage;
     if (_wantClipFromImage) {
@@ -111,8 +94,8 @@ void ImageOverlay::render(RenderArgs* args) {
 
     glm::vec2 topLeft(left, top);
     glm::vec2 bottomRight(right, bottom);
-    glm::vec2 texCoordTopLeft(x, 1.0f - y);
-    glm::vec2 texCoordBottomRight(x + w, 1.0f - (y + h));
+    glm::vec2 texCoordTopLeft(x, y);
+    glm::vec2 texCoordBottomRight(x + w, y + h);
 
     if (_renderImage) {
         DependencyManager::get<GeometryCache>()->renderQuad(topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight);

--- a/interface/src/ui/overlays/ImageOverlay.h
+++ b/interface/src/ui/overlays/ImageOverlay.h
@@ -24,6 +24,7 @@
 
 #include <NetworkAccessManager.h>
 #include <SharedUtil.h>
+#include <TextureCache.h>
 
 #include "Overlay.h"
 #include "Overlay2D.h"
@@ -49,18 +50,14 @@ public:
 
     virtual ImageOverlay* createClone() const;
 
-private slots:
-    void replyFinished(); // we actually want to hide this...
-
 private:
 
     QUrl _imageURL;
     QImage _textureImage;
 
-    GLuint _textureID;
+    NetworkTexturePointer _texture;
     QRect _fromImage; // where from in the image to sample
     bool _renderImage; // is there an image associated with this overlay, or is it just a colored rectangle
-    bool _textureBound; // has the texture been bound
     bool _wantClipFromImage;
 };
 

--- a/libraries/render-utils/src/TextureCache.cpp
+++ b/libraries/render-utils/src/TextureCache.cpp
@@ -385,7 +385,9 @@ Texture::~Texture() {
 NetworkTexture::NetworkTexture(const QUrl& url, TextureType type, const QByteArray& content) :
     Resource(url, !content.isEmpty()),
     _type(type),
-    _translucent(false) {
+    _translucent(false),
+    _width(0),
+    _height(0) {
     
     if (!url.isValid()) {
         _loaded = true;
@@ -532,6 +534,8 @@ void NetworkTexture::loadContent(const QByteArray& content) {
 void NetworkTexture::setImage(const QImage& image, bool translucent, const QColor& averageColor) {
     _translucent = translucent;
     _averageColor = averageColor;
+    _width = image.width();
+    _height = image.height();
     
     finishedLoading(true);
     imageLoaded(image);

--- a/libraries/render-utils/src/TextureCache.h
+++ b/libraries/render-utils/src/TextureCache.h
@@ -150,6 +150,9 @@ public:
     /// Returns the lazily-computed average texture color.
     const QColor& getAverageColor() const { return _averageColor; }
 
+    int getWidth() const { return _width; }
+    int getHeight() const { return _height; }
+
 protected:
 
     virtual void downloadFinished(QNetworkReply* reply);
@@ -163,6 +166,8 @@ private:
     TextureType _type;
     bool _translucent;
     QColor _averageColor;
+    int _width;
+    int _height;
 };
 
 /// Caches derived, dilated textures.


### PR DESCRIPTION
For cases where a spritesheet is being used, using the TextureCache is beneficial.

I also fixed the issue with "colored rectangles" not working with the ImageOverlay, despite it being implemented in the render function.