### PR TITLE
remove ground collision hack for physics testing

### DIFF
--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -186,22 +186,6 @@ void PhysicsEngine::init(EntityEditPacketSender* packetSender) {
         // default gravity of the world is zero, so each object must specify its own gravity
         // TODO: set up gravity zones
         _dynamicsWorld->setGravity(btVector3(0.0f, 0.0f, 0.0f));
-        
-        // GROUND HACK: add a big planar floor (and walls for testing) to catch falling objects
-        btTransform groundTransform;
-        groundTransform.setIdentity();
-        for (int i = 0; i < 3; ++i) {
-            btVector3 normal(0.0f, 0.0f, 0.0f);
-            normal[i] = 1.0f;
-            btCollisionShape* plane = new btStaticPlaneShape(normal, 0.0f);
-
-            btCollisionObject* groundObject = new btCollisionObject();
-            groundObject->setCollisionFlags(btCollisionObject::CF_STATIC_OBJECT);
-            groundObject->setCollisionShape(plane);
-
-            groundObject->setWorldTransform(groundTransform);
-            _dynamicsWorld->addCollisionObject(groundObject);
-        }
     }
 
     assert(packetSender);


### PR DESCRIPTION
Back when I was testing Bullet I created three infinite collision planes to catch falling objects.  These are no longer needed, and cause falling dynamic objects to pile up at y=0.