### PR TITLE
Temporarily re-enable audio selection on Windows

### DIFF
--- a/interface/src/Audio.cpp
+++ b/interface/src/Audio.cpp
@@ -118,7 +118,9 @@ void Audio::audioMixerKilled() {
 
 QAudioDeviceInfo getNamedAudioDeviceForMode(QAudio::Mode mode, const QString& deviceName) {
     QAudioDeviceInfo result;
-#ifdef WIN32
+// Temporarily enable audio device selection in Windows again to test how it behaves now
+//#ifdef WIN32
+#if FALSE
     // NOTE
     // this is a workaround for a windows only QtBug https://bugreports.qt-project.org/browse/QTBUG-16117
     // static QAudioDeviceInfo objects get deallocated when QList<QAudioDevieInfo> objects go out of scope


### PR DESCRIPTION
This is to test current behavior on different users' PCs, now that Qt has been updated. If after a week there are no problems it will be re-enabled permanently and the old code removed.