### PR TITLE
Revert "Use QDickCache for every QNAM"

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -13,6 +13,7 @@
 #include <QtCore/QEventLoop>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QTimer>
+#include <QtNetwork/QNetworkDiskCache>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
 
@@ -169,6 +170,11 @@ void Agent::run() {
    
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
     QNetworkReply *reply = networkAccessManager.get(QNetworkRequest(scriptURL));
+    
+    QNetworkDiskCache* cache = new QNetworkDiskCache();
+    QString cachePath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    cache->setCacheDirectory(!cachePath.isEmpty() ? cachePath : "agentCache");
+    networkAccessManager.setCache(cache);
     
     qDebug() << "Downloading script at" << scriptURL.toString();
     

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -33,6 +33,7 @@
 #include <QMenuBar>
 #include <QMouseEvent>
 #include <QNetworkReply>
+#include <QNetworkDiskCache>
 #include <QOpenGLFramebufferObject>
 #include <QObject>
 #include <QWheelEvent>
@@ -134,6 +135,9 @@ static unsigned STARFIELD_NUM_STARS = 50000;
 static unsigned STARFIELD_SEED = 1;
 
 static const int BANDWIDTH_METER_CLICK_MAX_DRAG_LENGTH = 6; // farther dragged clicks are ignored
+
+
+const qint64 MAXIMUM_CACHE_SIZE = 10737418240;  // 10GB
 
 static QTimer* idleTimer = NULL;
 
@@ -383,7 +387,12 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
     connect(billboardPacketTimer, &QTimer::timeout, _myAvatar, &MyAvatar::sendBillboardPacket);
     billboardPacketTimer->start(AVATAR_BILLBOARD_PACKET_SEND_INTERVAL_MSECS);
 
+    QString cachePath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
+    QNetworkDiskCache* cache = new QNetworkDiskCache();
+    cache->setMaximumCacheSize(MAXIMUM_CACHE_SIZE);
+    cache->setCacheDirectory(!cachePath.isEmpty() ? cachePath : "interfaceCache");
+    networkAccessManager.setCache(cache);
 
     ResourceCache::setRequestLimit(3);
 

--- a/libraries/networking/src/NetworkAccessManager.cpp
+++ b/libraries/networking/src/NetworkAccessManager.cpp
@@ -9,27 +9,15 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <QNetworkDiskCache>
-#include <QStandardPaths>
 #include <QThreadStorage>
 
 #include "NetworkAccessManager.h"
-
-const qint64 MAXIMUM_CACHE_SIZE = 10737418240;  // 10GB
 
 QThreadStorage<QNetworkAccessManager*> networkAccessManagers;
 
 QNetworkAccessManager& NetworkAccessManager::getInstance() {
     if (!networkAccessManagers.hasLocalData()) {
-        QNetworkAccessManager* networkAccessManager = new QNetworkAccessManager();
-        
-        QString cachePath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-        QNetworkDiskCache* cache = new QNetworkDiskCache();
-        cache->setMaximumCacheSize(MAXIMUM_CACHE_SIZE);
-        cache->setCacheDirectory(!cachePath.isEmpty() ? cachePath : "interfaceCache");
-        networkAccessManager->setCache(cache);
-        
-        networkAccessManagers.setLocalData(networkAccessManager);
+        networkAccessManagers.setLocalData(new QNetworkAccessManager());
     }
     
     return *networkAccessManagers.localData();


### PR DESCRIPTION
This reverts commit 2f39b93823a004ce123f495e9f3317bbeb573c68.

This is the commit that broke the model browser.
I'm not quite sure why it doesn't like that thought.