### PR TITLE
Fix the missing textures not loaded in gpu::Texture because their size doesn't match their description 

### DIFF
--- a/interface/src/ui/overlays/ImageOverlay.cpp
+++ b/interface/src/ui/overlays/ImageOverlay.cpp
@@ -56,8 +56,6 @@ void ImageOverlay::setImageURL(const QUrl& url) {
 }
 
 void ImageOverlay::render(RenderArgs* args) {
-    QString problem("http://s3.amazonaws.com/hifi-public/images/tools/grid-toolbar.svg");
-    bool theONE = (_imageURL == problem);
     if (!_isLoaded && _renderImage) {
         _isLoaded = true;
         _texture = DependencyManager::get<TextureCache>()->getTexture(_imageURL);
@@ -70,17 +68,8 @@ void ImageOverlay::render(RenderArgs* args) {
     }
 
     if (_renderImage) {
-
         glEnable(GL_TEXTURE_2D);
-        if (theONE) {
-            std::string name = _imageURL.toString().toStdString();
-        }
-        GLuint texID = _texture->getID();
-        if (texID == 27) {
-            std::string name = _imageURL.toString().toStdString();
-            glBindTexture(GL_TEXTURE_2D, texID);
-        } else
-            glBindTexture(GL_TEXTURE_2D, _texture->getID());
+        glBindTexture(GL_TEXTURE_2D, _texture->getID());
     }
 
     const float MAX_COLOR = 255.0f;

--- a/interface/src/ui/overlays/ImageOverlay.cpp
+++ b/interface/src/ui/overlays/ImageOverlay.cpp
@@ -45,7 +45,6 @@ ImageOverlay::~ImageOverlay() {
 // TODO: handle setting image multiple times, how do we manage releasing the bound texture?
 void ImageOverlay::setImageURL(const QUrl& url) {
     _imageURL = url;
-
     if (url.isEmpty()) {
         _isLoaded = true;
         _renderImage = false;
@@ -57,6 +56,8 @@ void ImageOverlay::setImageURL(const QUrl& url) {
 }
 
 void ImageOverlay::render(RenderArgs* args) {
+    QString problem("http://s3.amazonaws.com/hifi-public/images/tools/grid-toolbar.svg");
+    bool theONE = (_imageURL == problem);
     if (!_isLoaded && _renderImage) {
         _isLoaded = true;
         _texture = DependencyManager::get<TextureCache>()->getTexture(_imageURL);
@@ -69,8 +70,17 @@ void ImageOverlay::render(RenderArgs* args) {
     }
 
     if (_renderImage) {
+
         glEnable(GL_TEXTURE_2D);
-        glBindTexture(GL_TEXTURE_2D, _texture->getID());
+        if (theONE) {
+            std::string name = _imageURL.toString().toStdString();
+        }
+        GLuint texID = _texture->getID();
+        if (texID == 27) {
+            std::string name = _imageURL.toString().toStdString();
+            glBindTexture(GL_TEXTURE_2D, texID);
+        } else
+            glBindTexture(GL_TEXTURE_2D, _texture->getID());
     }
 
     const float MAX_COLOR = 255.0f;

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -254,7 +254,16 @@ bool Texture::assignStoredMip(uint16 level, const Element& format, Size size, co
     }
 
     // THen check that the mem buffer passed make sense with its format
-    if (size == evalStoredMipSize(level, format)) {
+    Size expectedSize = evalStoredMipSize(level, format);
+    if (size == expectedSize) {
+        _storage->assignMipData(level, format, size, bytes);
+        _stamp++;
+        return true;
+    } else if (size > expectedSize) {
+        // NOTE: We are facing this case sometime because apparently QImage (from where we get the bits) is generating images
+        // and alligning the line of pixels to 32 bits.
+        // We should probably consider something a bit more smart to get the correct result but for now (UI elements)
+        // it seems to work...
         _storage->assignMipData(level, format, size, bytes);
         _stamp++;
         return true;

--- a/libraries/render-utils/src/TextureCache.cpp
+++ b/libraries/render-utils/src/TextureCache.cpp
@@ -387,7 +387,7 @@ NetworkTexture::NetworkTexture(const QUrl& url, TextureType type, const QByteArr
     if (!url.isValid()) {
         _loaded = true;
     }
-    
+
     // default to white/blue/black
   /*  glBindTexture(GL_TEXTURE_2D, getID());
     switch (type) {


### PR DESCRIPTION
Turns out that QImage load textures and make them available for Texture loading. At this point we expect a memory chunck that is exactly of size = width*height*pixelNumBytes 
But alas Qt decided it shouldn't be that simple and in fact align each lines of the QImage to the upper 4bytes.

I don't know exactly how this is working correctly but it seems that even with that alignment issue the image meaningful bytes are actually from byte 0 until the actual expected size ( without the per line alignment). so the issue is just that Qt over allocate...

THe problem is that in the case the size provided to assign to a mip in the gpu::Texture is not exactly what we expect then the assignment doesn't happen so no bytes are going into the gl texture.
I fixed that relaxing the check, we know need at least the expected size or more...


