### PR TITLE
changing texture size limit from 1024*1024 to 2M  i.e. (1024 * 2048).

### DIFF
--- a/libraries/render-utils/src/TextureCache.cpp
+++ b/libraries/render-utils/src/TextureCache.cpp
@@ -459,14 +459,14 @@ void ImageReader::run() {
     int originalHeight = image.height();
     
     // enforce a fixed maximum area (1024 * 2048)
-    const float MAXIMUM_AREA_SIZE = 2097152.0f;
+    const int MAXIMUM_AREA_SIZE = 2097152;
     int imageArea = image.width() * image.height();
     if (imageArea > MAXIMUM_AREA_SIZE) {
-        float scaleRatio = sqrtf(MAXIMUM_AREA_SIZE) / sqrtf((float)imageArea);
+        float scaleRatio = sqrtf((float)MAXIMUM_AREA_SIZE) / sqrtf((float)imageArea);
         int resizeWidth = static_cast<int>(std::floor(scaleRatio * static_cast<float>(image.width())));
         int resizeHeight = static_cast<int>(std::floor(scaleRatio * static_cast<float>(image.height())));
         qDebug() << "Image greater than maximum size:" << _url << image.width() << image.height() <<
-            " scaled to :" << resizeWidth << resizeHeight;
+            " scaled to:" << resizeWidth << resizeHeight;
         image = image.scaled(resizeWidth, resizeHeight, Qt::IgnoreAspectRatio);
         imageArea = image.width() * image.height();
     }

--- a/libraries/render-utils/src/TextureCache.cpp
+++ b/libraries/render-utils/src/TextureCache.cpp
@@ -458,13 +458,18 @@ void ImageReader::run() {
     int originalWidth = image.width();
     int originalHeight = image.height();
     
-    // enforce a fixed maximum
-    const int MAXIMUM_SIZE = 1024;
-    if (image.width() > MAXIMUM_SIZE || image.height() > MAXIMUM_SIZE) {
-        qDebug() << "Image greater than maximum size:" << _url << image.width() << image.height();
-        image = image.scaled(MAXIMUM_SIZE, MAXIMUM_SIZE, Qt::KeepAspectRatio);
-    }
+    // enforce a fixed maximum area (1024 * 2048)
+    const float MAXIMUM_AREA_SIZE = 2097152.0f;
     int imageArea = image.width() * image.height();
+    if (imageArea > MAXIMUM_AREA_SIZE) {
+        float scaleRatio = sqrtf(MAXIMUM_AREA_SIZE) / sqrtf((float)imageArea);
+        int resizeWidth = static_cast<int>(std::floor(scaleRatio * static_cast<float>(image.width())));
+        int resizeHeight = static_cast<int>(std::floor(scaleRatio * static_cast<float>(image.height())));
+        qDebug() << "Image greater than maximum size:" << _url << image.width() << image.height() <<
+            " scaled to :" << resizeWidth << resizeHeight;
+        image = image.scaled(resizeWidth, resizeHeight, Qt::IgnoreAspectRatio);
+        imageArea = image.width() * image.height();
+    }
     
     const int EIGHT_BIT_MAXIMUM = 255;
     if (!image.hasAlphaChannel()) {


### PR DESCRIPTION
 It's dynamic and resizes the texture to the best fit within the 2M area.