### PR TITLE
Fix orientation of non-solid rectangle3d overlays, too

### DIFF
--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -76,10 +76,10 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
             } else {
                 if (getIsDashedLine()) {
 
-                    glm::vec3 point1(-halfDimensions.x, 0.0f, -halfDimensions.y);
-                    glm::vec3 point2(halfDimensions.x, 0.0f, -halfDimensions.y);
-                    glm::vec3 point3(halfDimensions.x, 0.0f, halfDimensions.y);
-                    glm::vec3 point4(-halfDimensions.x, 0.0f, halfDimensions.y);
+                    glm::vec3 point1(-halfDimensions.x, -halfDimensions.y, 0.0f);
+                    glm::vec3 point2(halfDimensions.x, -halfDimensions.y, 0.0f);
+                    glm::vec3 point3(halfDimensions.x, halfDimensions.y, 0.0f);
+                    glm::vec3 point4(-halfDimensions.x, halfDimensions.y, 0.0f);
                 
                     geometryCache->renderDashedLine(point1, point2, rectangleColor);
                     geometryCache->renderDashedLine(point2, point3, rectangleColor);
@@ -90,11 +90,11 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
                 
                     if (halfDimensions != _previousHalfDimensions) {
                         QVector<glm::vec3> border;
-                        border << glm::vec3(-halfDimensions.x, 0.0f, -halfDimensions.y);
-                        border << glm::vec3(halfDimensions.x, 0.0f, -halfDimensions.y);
-                        border << glm::vec3(halfDimensions.x, 0.0f, halfDimensions.y);
-                        border << glm::vec3(-halfDimensions.x, 0.0f, halfDimensions.y);
-                        border << glm::vec3(-halfDimensions.x, 0.0f, -halfDimensions.y);
+                        border << glm::vec3(-halfDimensions.x, -halfDimensions.y, 0.0f);
+                        border << glm::vec3(halfDimensions.x, -halfDimensions.y, 0.0f);
+                        border << glm::vec3(halfDimensions.x, halfDimensions.y, 0.0f);
+                        border << glm::vec3(-halfDimensions.x, halfDimensions.y, 0.0f);
+                        border << glm::vec3(-halfDimensions.x, -halfDimensions.y, 0.0f);
                         geometryCache->updateVertices(_geometryCacheID, border, rectangleColor);
 
                         _previousHalfDimensions = halfDimensions;


### PR DESCRIPTION
Oops, I only fixed the orientation of solid rectangle3d overlays before.