### PR TITLE
Fix the lightmap not displaying when using the texcoord0

### DIFF
--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -1303,6 +1303,8 @@ FBXGeometry extractFBXGeometry(const FBXNode& node, const QVariantHash& mapping,
     QString jointRightHandID;
     QString jointLeftToeID;
     QString jointRightToeID;
+
+    float lightmapOffset = 0.0f;
     
     QVector<QString> humanIKJointNames;
     for (int i = 0;; i++) {
@@ -2123,6 +2125,7 @@ FBXGeometry extractFBXGeometry(const FBXNode& node, const QVariantHash& mapping,
 
                 FBXTexture emissiveTexture;
                 glm::vec2 emissiveParams(0.f, 1.f);
+                emissiveParams.x = lightmapOffset;
                 emissiveParams.y = lightmapLevel;
                 QString emissiveTextureID = emissiveTextures.value(childID);
                 QString ambientTextureID = ambientTextures.value(childID);

--- a/libraries/gpu/src/gpu/GLBackendShared.h
+++ b/libraries/gpu/src/gpu/GLBackendShared.h
@@ -49,7 +49,7 @@ static const GLenum _elementTypeToGLType[NUM_TYPES]= {
     GL_UNSIGNED_BYTE
 };
 
-#define CHECK_GL_ERROR() ::gpu::GLBackend::checkGLError()
-//#define CHECK_GL_ERROR()
+//#define CHECK_GL_ERROR() ::gpu::GLBackend::checkGLError()
+#define CHECK_GL_ERROR()
 
 #endif


### PR DESCRIPTION
Before this, when using lightmap we would expect a mesh to have 2 UV sets, this relax that requirement and just reuse the texcoord0 attribute and feed it in the texcoord1 unit for lightmap lookup

THe lightmap texcoord can still have it's own texcoord transform matrix different from the one useby the other texture channels