### PR TITLE
BUG FIXES: Crash on Exit with partially loaded scene & (near)-infinite loop in skipForward physics

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -73,6 +73,7 @@
 #include <PhysicsEngine.h>
 #include <ProgramObject.h>
 #include <ResourceCache.h>
+#include <ScriptCache.h>
 #include <SettingHandle.h>
 #include <SoundCache.h>
 #include <TextRenderer.h>
@@ -188,6 +189,7 @@ bool setupEssentials(int& argc, char** argv) {
     auto jsConsole = DependencyManager::set<StandAloneJSConsole>();
     auto dialogsManager = DependencyManager::set<DialogsManager>();
     auto bandwidthRecorder = DependencyManager::set<BandwidthRecorder>();
+    auto resouceCacheSharedItems = DependencyManager::set<ResouceCacheSharedItems>();
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     auto speechRecognizer = DependencyManager::set<SpeechRecognizer>();
 #endif
@@ -514,6 +516,11 @@ Application::~Application() {
     _myAvatar = NULL;
     
     DependencyManager::destroy<GLCanvas>();
+    DependencyManager::destroy<AnimationCache>();
+    DependencyManager::destroy<TextureCache>();
+    DependencyManager::destroy<GeometryCache>();
+    DependencyManager::destroy<ScriptCache>();
+    DependencyManager::destroy<SoundCache>();
 }
 
 void Application::initializeGL() {

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -548,7 +548,10 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
             // is sending us data with a known "last simulated" time. That time is likely in the past, and therefore
             // this "new" data is actually slightly out of date. We calculate the time we need to skip forward and
             // use our simulation helper routine to get a best estimate of where the entity should be.
-            float skipTimeForward = (float)(now - _lastSimulated) / (float)(USECS_PER_SECOND);
+            const float MIN_TIME_SKIP = 0.0f;
+            const float MAX_TIME_SKIP = 1.0f; // in seconds
+            float skipTimeForward = glm::clamp((float)(now - _lastSimulated) / (float)(USECS_PER_SECOND), 
+                                        MIN_TIME_SKIP, MAX_TIME_SKIP);
             if (skipTimeForward > 0.0f) {
                 #ifdef WANT_DEBUG
                     qDebug() << "skipTimeForward:" << skipTimeForward;

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -132,8 +132,7 @@ void ResourceCache::requestCompleted(Resource* resource) {
     // look for the highest priority pending request
     int highestIndex = -1;
     float highestPriority = -FLT_MAX;
-    int pendingRequests = sharedItems->_pendingRequests.size();
-    for (int i = 0; i < pendingRequests; ) {
+    for (int i = 0; i < sharedItems->_pendingRequests.size(); ) {
         Resource* resource = sharedItems->_pendingRequests.at(i).data();
         if (!resource) {
             sharedItems->_pendingRequests.removeAt(i);

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -112,27 +112,31 @@ void ResourceCache::reserveUnusedResource(qint64 resourceSize) {
 }
 
 void ResourceCache::attemptRequest(Resource* resource) {
+    auto sharedItems = DependencyManager::get<ResouceCacheSharedItems>();
     if (_requestLimit <= 0) {
         // wait until a slot becomes available
-        _pendingRequests.append(resource);
+        sharedItems->_pendingRequests.append(resource);
         return;
     }
     _requestLimit--;
-    _loadingRequests.append(resource);
+    sharedItems->_loadingRequests.append(resource);
     resource->makeRequest();
 }
 
 void ResourceCache::requestCompleted(Resource* resource) {
-    _loadingRequests.removeOne(resource);
+    
+    auto sharedItems = DependencyManager::get<ResouceCacheSharedItems>();
+    sharedItems->_loadingRequests.removeOne(resource);
     _requestLimit++;
     
     // look for the highest priority pending request
     int highestIndex = -1;
     float highestPriority = -FLT_MAX;
-    for (int i = 0; i < _pendingRequests.size(); ) {
-        Resource* resource = _pendingRequests.at(i).data();
+    int pendingRequests = sharedItems->_pendingRequests.size();
+    for (int i = 0; i < pendingRequests; ) {
+        Resource* resource = sharedItems->_pendingRequests.at(i).data();
         if (!resource) {
-            _pendingRequests.removeAt(i);
+            sharedItems->_pendingRequests.removeAt(i);
             continue;
         }
         float priority = resource->getLoadPriority();
@@ -143,15 +147,12 @@ void ResourceCache::requestCompleted(Resource* resource) {
         i++;
     }
     if (highestIndex >= 0) {
-        attemptRequest(_pendingRequests.takeAt(highestIndex));
+        attemptRequest(sharedItems->_pendingRequests.takeAt(highestIndex));
     }
 }
 
 const int DEFAULT_REQUEST_LIMIT = 10;
 int ResourceCache::_requestLimit = DEFAULT_REQUEST_LIMIT;
-
-QList<QPointer<Resource> > ResourceCache::_pendingRequests;
-QList<Resource*> ResourceCache::_loadingRequests;
 
 Resource::Resource(const QUrl& url, bool delayLoad) :
     _url(url),


### PR DESCRIPTION
BUG FIX 1 - Crash on exit

There was a random (~50% likelihood) crash on exit if you exited the app while some resources were still downloading. The problem was that the "loading" and "pending" resource download requests were being managed in a static member of ResourceCache - but because of C++ static member ctr/dtr management, sometimes those static members are deleted before the users are deleted we'd get a crash.

The fix was to make these members a singleton instead of static members.

Testing:
* open interface - go to apartment
* while content is in process of loading (some entities visible, others not yet visible) Quit the application
* old behavior: crash about 50% of the time
* new behavior: no crash

BUG FIX 2 - Near-infinite loop on skip physics forward

Sometimes the update from the server for changed physics/animated/kinematic objects can result in a dT that is negative or very large. In the very large case we'd end up with what appeared to be a thread deadlock. It was actually a near-infinite loop. We now clamp the dT between 0 and 1 seconds to prevent this.