### PR TITLE
Ability to make cursor invisible again (both OS-cursor and oculus rectile) and js-interface to cursorVisible boolean

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1940,32 +1940,14 @@ void Application::updateCursor(float deltaTime) {
 
     static QPoint lastMousePos = QPoint();
     _lastMouseMove = (lastMousePos == QCursor::pos()) ? _lastMouseMove : usecTimestampNow();
-    bool hideMouse = false;
-    bool underMouse = QGuiApplication::topLevelAt(QCursor::pos()) ==
-                      Application::getInstance()->getWindow()->windowHandle();
-    
-    static const int HIDE_CURSOR_TIMEOUT = 3 * USECS_PER_SECOND; // 3 second
-    int elapsed = usecTimestampNow() - _lastMouseMove;
-    if ((elapsed > HIDE_CURSOR_TIMEOUT)  ||
-        (OculusManager::isConnected() && Menu::getInstance()->isOptionChecked(MenuOption::EnableVRMode))) {
-        hideMouse = underMouse;
-    }
-    
-    setCursorVisible(!hideMouse);
     lastMousePos = QCursor::pos();
 }
 
 void Application::setCursorVisible(bool visible) {
     if (visible) {
-        if (overrideCursor() != NULL) {
-            restoreOverrideCursor();
-        }
+        DependencyManager::get<GLCanvas>()->unsetCursor();
     } else {
-        if (overrideCursor() != NULL) {
-            changeOverrideCursor(Qt::BlankCursor);
-        } else {
-            setOverrideCursor(Qt::BlankCursor);
-        }
+        DependencyManager::get<GLCanvas>()->setCursor(Qt::BlankCursor);
     }
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -228,6 +228,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
         _touchAvgX(0.0f),
         _touchAvgY(0.0f),
         _isTouchPressed(false),
+        _cursorVisible(true),
         _mousePressed(false),
         _enableProcessOctreeThread(true),
         _octreeProcessor(),
@@ -1473,6 +1474,8 @@ void Application::setEnableVRMode(bool enableVRMode) {
     
     auto glCanvas = DependencyManager::get<GLCanvas>();
     resizeGL(glCanvas->getDeviceWidth(), glCanvas->getDeviceHeight());
+    
+    updateCursorVisibility();
 }
 
 void Application::setLowVelocityFilter(bool lowVelocityFilter) {
@@ -1943,12 +1946,17 @@ void Application::updateCursor(float deltaTime) {
     lastMousePos = QCursor::pos();
 }
 
-void Application::setCursorVisible(bool visible) {
-    if (visible) {
-        DependencyManager::get<GLCanvas>()->unsetCursor();
-    } else {
+void Application::updateCursorVisibility() {
+    if (!_cursorVisible || Menu::getInstance()->isOptionChecked(MenuOption::EnableVRMode)) {
         DependencyManager::get<GLCanvas>()->setCursor(Qt::BlankCursor);
+    } else {
+        DependencyManager::get<GLCanvas>()->unsetCursor();
     }
+}
+
+void Application::setCursorVisible(bool visible) {
+    _cursorVisible = visible;
+    updateCursorVisibility();
 }
 
 void Application::update(float deltaTime) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -186,7 +186,7 @@ public:
     EntityTreeRenderer* getEntityClipboardRenderer() { return &_entityClipboardRenderer; }
     
     bool isMousePressed() const { return _mousePressed; }
-    bool isMouseHidden() const { return DependencyManager::get<GLCanvas>()->cursor().shape() == Qt::BlankCursor; }
+    bool isMouseHidden() const { return !_cursorVisible; }
     const glm::vec3& getMouseRayOrigin() const { return _mouseRayOrigin; }
     const glm::vec3& getMouseRayDirection() const { return _mouseRayDirection; }
     bool mouseOnScreen() const;
@@ -404,6 +404,8 @@ private:
     void updateProjectionMatrix();
     void updateProjectionMatrix(Camera& camera, bool updateViewFrustum = true);
 
+    void updateCursorVisibility();
+
     void sendPingPackets();
 
     void initDisplay();
@@ -515,6 +517,7 @@ private:
 
     Environment _environment;
 
+    bool _cursorVisible;
     int _mouseDragStartedX;
     int _mouseDragStartedY;
     quint64 _lastMouseMove;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -187,7 +187,6 @@ public:
     
     bool isMousePressed() const { return _mousePressed; }
     bool isMouseHidden() const { return DependencyManager::get<GLCanvas>()->cursor().shape() == Qt::BlankCursor; }
-    void setCursorVisible(bool visible);
     const glm::vec3& getMouseRayOrigin() const { return _mouseRayOrigin; }
     const glm::vec3& getMouseRayDirection() const { return _mouseRayDirection; }
     bool mouseOnScreen() const;
@@ -397,6 +396,8 @@ private slots:
     void runTests();
     
     void audioMuteToggled();
+
+    void setCursorVisible(bool visible);
 
 private:
     void resetCamerasOnResizeGL(Camera& camera, int width, int height);

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -50,7 +50,12 @@ void WindowScriptingInterface::setFocus() {
 }
 
 void WindowScriptingInterface::setCursorVisible(bool visible) {
-    Application::getInstance()->setCursorVisible(visible);
+    QMetaObject::invokeMethod(Application::getInstance(), "setCursorVisible", Qt::BlockingQueuedConnection,
+                              Q_ARG(bool, visible));
+}
+
+bool WindowScriptingInterface::isCursorVisible() const {
+    return !Application::getInstance()->isMouseHidden();
 }
 
 void WindowScriptingInterface::setCursorPosition(int x, int y) {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -27,7 +27,7 @@ class WindowScriptingInterface : public QObject {
     Q_PROPERTY(int innerHeight READ getInnerHeight)
     Q_PROPERTY(int x READ getX)
     Q_PROPERTY(int y READ getY)
-    Q_PROPERTY(bool cursorVisible READ isCursorVisible)
+    Q_PROPERTY(bool cursorVisible READ isCursorVisible WRITE setCursorVisible)
 public:
     static WindowScriptingInterface* getInstance();
     int getInnerWidth();

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -27,12 +27,14 @@ class WindowScriptingInterface : public QObject {
     Q_PROPERTY(int innerHeight READ getInnerHeight)
     Q_PROPERTY(int x READ getX)
     Q_PROPERTY(int y READ getY)
+    Q_PROPERTY(bool cursorVisible READ isCursorVisible)
 public:
     static WindowScriptingInterface* getInstance();
     int getInnerWidth();
     int getInnerHeight();
     int getX();
     int getY();
+    bool isCursorVisible() const;
 
 public slots:
     QScriptValue getCursorPositionX();

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -330,8 +330,9 @@ void ApplicationOverlay::displayOverlayTextureOculus(Camera& whichCamera) {
             _overlays.buildVBO(_textureFov, _textureAspectRatio, 80, 80);
         }
         _overlays.render();
-        renderPointersOculus(myAvatar->getDefaultEyePosition());
-        
+        if (!Application::getInstance()->isMouseHidden()) {
+            renderPointersOculus(myAvatar->getDefaultEyePosition());
+        }
         glDepthMask(GL_TRUE);
         _overlays.releaseTexture();
         glDisable(GL_TEXTURE_2D);
@@ -542,7 +543,7 @@ void ApplicationOverlay::renderPointers() {
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, _crosshairTexture);
     
-    if (OculusManager::isConnected() && !application->getLastMouseMoveWasSimulated()) {
+    if (OculusManager::isConnected() && !application->getLastMouseMoveWasSimulated() && !application->isMouseHidden()) {
         //If we are in oculus, render reticle later
         if (_lastMouseMove == 0) {
             _lastMouseMove = usecTimestampNow();


### PR DESCRIPTION
@Atlante45 I have removed some of your code here. I believe your code was for making the cursor visible above other widgets. This is not necessary anymore since I only replace the GLWidget cursor to blank with this code. Thanks @huffman for the invoke code. 