### PR TITLE
fix physics crash on disconnect from domain-server

### DIFF
--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -79,13 +79,13 @@ public:
     /// \return true if Object added
     void addObject(const ShapeInfo& shapeInfo, btCollisionShape* shape, ObjectMotionState* motionState);
 
-    /// \param motionState pointer to Object's MotionState
-    void removeObject(ObjectMotionState* motionState);
-
     /// process queue of changed from external sources
     void relayIncomingChangesToSimulation();
 
 private:
+    /// \param motionState pointer to Object's MotionState
+    void removeObjectFromBullet(ObjectMotionState* motionState);
+
     void removeContacts(ObjectMotionState* motionState);
 
     // return 'true' of update was successful


### PR DESCRIPTION
The problem was a dangling pointer (to EntityMotionState) inside the PhysicsEngine class.

The repro recipe:

(1) Login.
(2) Create a large model (> 3m on the diagonal of its bounding box)
(3) Kill the domain-server (or connect to different domain)
(4) --> crash in EntitySimulation::clearEntities()

The bad stuff happens in step (2).  The entity is initially added to the physics engine with a default size, but when its (large) size is updated the PhysicsEngine discovers that it can't create a shape for it and deletes the associated EntityMotionState for that entity... but forgets to remove a pointer from one of its list.  The pointer remains unmolested until cleanup of the list.
