### PR TITLE
Remove unneeded texture memory once loaded to GPU and Lightmap control in FBX

### DIFF
--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -1219,7 +1219,7 @@ int matchTextureUVSetToAttributeChannel(const QString& texUVSetName, const QHash
 
 FBXLight extractLight(const FBXNode& object) {
     FBXLight light;
-
+    int unkwnon = 0;
     foreach (const FBXNode& subobject, object.children) {
         QString childname = QString(subobject.name);
         if (subobject.name == "Properties70") {
@@ -1230,6 +1230,8 @@ FBXLight extractLight(const FBXNode& object) {
                     QString propname = property.properties.at(0).toString();
                     if (propname == "Intensity") {
                         light.intensity = 0.01f * property.properties.at(valIndex).value<double>();
+                    } else if (propname == "Color") {
+                        light.color = getVec3(property.properties, valIndex);
                     }
                 }
             }
@@ -1817,6 +1819,7 @@ FBXGeometry extractFBXGeometry(const FBXNode& node, const QVariantHash& mapping,
                                 if (lightmapLevel <= 0.0f) {
                                     loadLightmaps = false;
                                 }
+                                lightmapOffset = glm::clamp((*lit).second.color.x, 0.f, 1.f);
                             }
                         }
                     }
@@ -2127,6 +2130,7 @@ FBXGeometry extractFBXGeometry(const FBXNode& node, const QVariantHash& mapping,
                 glm::vec2 emissiveParams(0.f, 1.f);
                 emissiveParams.x = lightmapOffset;
                 emissiveParams.y = lightmapLevel;
+
                 QString emissiveTextureID = emissiveTextures.value(childID);
                 QString ambientTextureID = ambientTextures.value(childID);
                 if (loadLightmaps && (!emissiveTextureID.isNull() || !ambientTextureID.isNull())) {

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -179,12 +179,14 @@ public:
     QString name;
     Transform transform;
     float intensity;
+    float fogValue;
     glm::vec3 color;
 
     FBXLight() :
         name(),
         transform(),
         intensity(1.0f),
+        fogValue(0.0f),
         color(1.0f)
     {}
 };

--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -271,7 +271,12 @@ void GLBackend::syncGPUObject(const Texture& texture) {
 
                 if (texture.isAutogenerateMips()) {
                     glGenerateMipmap(GL_TEXTURE_2D);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
                 }
+
+                // At this point the mip piels have been loaded, we can notify
+                texture.notifyGPULoaded(0);
+
                 glBindTexture(GL_TEXTURE_2D, boundTex);
                 object->_contentStamp = texture.getDataStamp();
             }
@@ -301,6 +306,9 @@ void GLBackend::syncGPUObject(const Texture& texture) {
                 glGenerateMipmap(GL_TEXTURE_2D);
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
             }
+
+            // At this point the mip piels have been loaded, we can notify
+            texture.notifyGPULoaded(0);
 
             glBindTexture(GL_TEXTURE_2D, boundTex);
             object->_storageStamp = texture.getStamp();

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -17,7 +17,8 @@ using namespace gpu;
 
 Texture::Pixels::Pixels(const Element& format, Size size, const Byte* bytes) :
     _sysmem(size, bytes),
-    _format(format) {
+    _format(format),
+    _isGPULoaded(false) {
 }
 
 Texture::Pixels::~Pixels() {
@@ -51,6 +52,14 @@ const Texture::PixelsPointer Texture::Storage::getMip(uint16 level) const {
         return _mips[level];
     }
     return PixelsPointer();
+}
+
+void Texture::Storage::notifyGPULoaded(uint16 level) const {
+    PixelsPointer mip = getMip(level);
+    if (mip) {
+        mip->_isGPULoaded = true;
+        mip->_sysmem.resize(0);
+    }
 }
 
 bool Texture::Storage::isMipAvailable(uint16 level) const {

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -26,8 +26,9 @@ public:
         Pixels(const Element& format, Size size, const Byte* bytes);
         ~Pixels();
 
-        Sysmem _sysmem;
+        mutable Sysmem _sysmem;
         Element _format;
+        mutable bool _isGPULoaded;
     };
     typedef QSharedPointer< Pixels > PixelsPointer;
 
@@ -42,7 +43,8 @@ public:
         virtual bool allocateMip(uint16 level);
         virtual bool assignMipData(uint16 level, const Element& format, Size size, const Byte* bytes);
         virtual bool isMipAvailable(uint16 level) const;
- 
+        virtual void notifyGPULoaded(uint16 level) const;
+
     protected:
         Texture* _texture;
         std::vector<PixelsPointer> _mips;
@@ -168,7 +170,8 @@ public:
     // Access the the sub mips
     bool isStoredMipAvailable(uint16 level) const { return _storage->isMipAvailable(level); }
     const PixelsPointer accessStoredMip(uint16 level) const { return _storage->getMip(level); }
- 
+    void notifyGPULoaded(uint16 level) const { return _storage->notifyGPULoaded(level); }
+
     // access sizes for the stored mips
     uint16 getStoredMipWidth(uint16 level) const;
     uint16 getStoredMipHeight(uint16 level) const;

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -26,9 +26,9 @@ public:
         Pixels(const Element& format, Size size, const Byte* bytes);
         ~Pixels();
 
-        mutable Sysmem _sysmem;
+        Sysmem _sysmem;
         Element _format;
-        mutable bool _isGPULoaded;
+        bool _isGPULoaded;
     };
     typedef QSharedPointer< Pixels > PixelsPointer;
 


### PR DESCRIPTION
- Notify the gpu::texture::storage once the mip pixels have been loaded in GPU memory so the STorage can free the memory. THis shoudl brings back to the memory usage of before my PR introducing gpu::texture end of january

- In the FBX file, in the "hifi_global" light, we capture the color and use the color.x as the offset parameter for the lightmaps of the model

