### PR TITLE
Fixing bug in text renderer causing glyphs to float at different depths

### DIFF
--- a/libraries/render-utils/src/TextRenderer.cpp
+++ b/libraries/render-utils/src/TextRenderer.cpp
@@ -345,7 +345,7 @@ void Font::setupGL() {
     int posLoc = _program->attributeLocation("Position");
     int texLoc = _program->attributeLocation("TexCoord");
     glEnableVertexAttribArray(posLoc);
-    glVertexAttribPointer(posLoc, 3, GL_FLOAT, false, stride, nullptr);
+    glVertexAttribPointer(posLoc, 2, GL_FLOAT, false, stride, nullptr);
     glEnableVertexAttribArray(texLoc);
     glVertexAttribPointer(texLoc, 2, GL_FLOAT, false, stride, offset);
     _vao->release();

--- a/libraries/render-utils/src/sdf_text.slv
+++ b/libraries/render-utils/src/sdf_text.slv
@@ -13,12 +13,12 @@
 uniform mat4 Projection;
 uniform mat4 ModelView;
 
-attribute vec3 Position;
+attribute vec2 Position;
 attribute vec2 TexCoord;
 
 varying vec2 vTexCoord;
 
 void main() {
   vTexCoord = TexCoord;
-  gl_Position = Projection * ModelView * vec4(Position, 1.0);
+  gl_Position = Projection * ModelView * vec4(Position, 0.0, 1.0);
 }


### PR DESCRIPTION
A number of the entities that were rendering text were displaying letters at different depths.  I initially though this was some kind of floating point error due to non-uniform scaling, but I've since realized that it was because I was using incorrectly setting up the vertex attribute to want 3 floating point values instead of two.  

As a result, the Z coordinate of the Position value in the shader would be initialized with the same value as the X value of the texture coordinate.  This diff fixes the incorrect count passed to `glVertexAttribPointer` in the text renderer code and also forces the shader to treat the vertex as a vec2 instead of a vec3.  