### PR TITLE
Fix VSync menu item on Windows

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -334,7 +334,7 @@ Menu::Menu() {
 #if defined(Q_OS_MAC)
 #else
         addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::RenderTargetFramerateVSyncOn, 0, true,
-                                               qApp, SLOT(changeVSync()));
+                                               qApp, SLOT(setVSyncEnabled()));
 #endif
     }
 


### PR DESCRIPTION
This makes the VSync On menu item that is available on Windows work again: you can turn VSync off rather than it always being on.