### PR TITLE
Fix maximized Windows window unintentionally changing to windowed

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -156,18 +156,27 @@ public:
     bool nativeEventFilter(const QByteArray &eventType, void* msg, long* result) Q_DECL_OVERRIDE {
         if (eventType == "windows_generic_MSG") {
             MSG* message = (MSG*)msg;
+
             if (message->message == UWM_IDENTIFY_INSTANCES) {
                 *result = UWM_IDENTIFY_INSTANCES;
                 return true;
             }
-            if (message->message == WM_SHOWWINDOW) {
-                Application::getInstance()->getWindow()->showNormal();
+
+            if (message->message == UWM_SHOW_APPLICATION) {
+                MainWindow* applicationWindow = Application::getInstance()->getWindow();
+                if (applicationWindow->isMinimized()) {
+                    applicationWindow->showNormal();  // Restores to windowed or maximized state appropriately.
+                }
+                Application::getInstance()->setActiveWindow(applicationWindow);  // Flashes the taskbar icon if not focus.
+                return true;
             }
+
             if (message->message == WM_COPYDATA) {
                 COPYDATASTRUCT* pcds = (COPYDATASTRUCT*)(message->lParam);
                 QUrl url = QUrl((const char*)(pcds->lpData));
                 if (url.isValid() && url.scheme() == HIFI_URL_SCHEME) {
                     DependencyManager::get<AddressManager>()->handleLookupString(url.toString());
+                    return true;
                 }
             }
         }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -117,6 +117,8 @@ static const QString INFO_EDIT_ENTITIES_PATH = "html/edit-entities-commands.html
 #ifdef Q_OS_WIN
 static const UINT UWM_IDENTIFY_INSTANCES = 
     RegisterWindowMessage("UWM_IDENTIFY_INSTANCES_{8AB82783-B74A-4258-955B-8188C22AA0D6}");
+static const UINT UWM_SHOW_APPLICATION =
+    RegisterWindowMessage("UWM_SHOW_APPLICATION_{71123FD6-3DA8-4DC1-9C27-8A12A6250CBA}");
 #endif
 
 class Application;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -8,6 +8,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QCommandLineParser>
 #include <QDebug>
 #include <QDir>
 #include <QSettings>
@@ -36,7 +37,7 @@ static BOOL CALLBACK enumWindowsCallback(HWND hWnd, LPARAM lParam) {
 #endif
 
 
-int main(int argc, const char * argv[]) {
+int main(int argc, const char* argv[]) {
 #ifdef Q_OS_WIN
     // Run only one instance of Interface at a time.
     HANDLE mutex = CreateMutex(NULL, FALSE, "High Fidelity Interface");
@@ -46,14 +47,32 @@ int main(int argc, const char * argv[]) {
         HWND otherInstance = NULL;
         EnumWindows(enumWindowsCallback, (LPARAM)&otherInstance);
         if (otherInstance) {
+            // Show other instance.
             SendMessage(otherInstance, UWM_SHOW_APPLICATION, 0, 0);
 
-            QUrl url = QUrl(argv[1]);
-            if (url.isValid() && url.scheme() == HIFI_URL_SCHEME) {
-                COPYDATASTRUCT cds;
-                cds.cbData = strlen(argv[1]) + 1;
-                cds.lpData = (PVOID)argv[1];
-                SendMessage(otherInstance, WM_COPYDATA, 0, (LPARAM)&cds);
+            // Send command line --url value to other instance.
+            if (argc >= 3) {
+                QStringList arguments;
+                for (int i = 0; i < argc; i += 1) {
+                    arguments << argv[i];
+                }
+
+                QCommandLineParser parser;
+                QCommandLineOption urlOption("url", "", "value");
+                parser.addOption(urlOption);
+                parser.process(arguments);
+
+                if (parser.isSet(urlOption)) {
+                    QUrl url = QUrl(parser.value(urlOption));
+                    if (url.isValid() && url.scheme() == HIFI_URL_SCHEME) {
+                        QByteArray urlBytes = url.toString().toLatin1();
+                        const char* urlChars = urlBytes.data();
+                        COPYDATASTRUCT cds;
+                        cds.cbData = urlBytes.length() + 1;
+                        cds.lpData = (PVOID)urlChars;
+                        SendMessage(otherInstance, WM_COPYDATA, 0, (LPARAM)&cds);
+                    }
+                }
             }
         }
         return 0;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -46,8 +46,7 @@ int main(int argc, const char * argv[]) {
         HWND otherInstance = NULL;
         EnumWindows(enumWindowsCallback, (LPARAM)&otherInstance);
         if (otherInstance) {
-            ShowWindow(otherInstance, SW_RESTORE);
-            SetForegroundWindow(otherInstance);
+            SendMessage(otherInstance, UWM_SHOW_APPLICATION, 0, 0);
 
             QUrl url = QUrl(argv[1]);
             if (url.isValid() && url.scheme() == HIFI_URL_SCHEME) {


### PR DESCRIPTION
This stops a maximized Windows window changing to being windowed when
you click on a menu item.