### PR TITLE
removed id "g3322" in start-script.svg because it is no longer used and ...

### DIFF
--- a/interface/resources/icons/start-script.svg
+++ b/interface/resources/icons/start-script.svg
@@ -536,22 +536,5 @@
        height="44.57473"
        x="84.498352"
        y="1050.0748" />
-    <g
-       id="g3322"
-       transform="translate(-46.607143,-3.5714285)">
-      <use
-         x="0"
-         y="0"
-         width="744.09448"
-         height="1052.3622"
-         transform="translate(0.5864354,0.4607839)"
-         xlink:href="#rect899"
-         id="use1503" />
-      <path
-         d="m 75.506508,1023.3478 1.372845,5.4631 -14.094975,-1.152 2.35e-4,7.2772 14.094975,-1.152 -1.372845,5.1249 13.761293,-7.6113 -13.761293,-7.9499 z"
-         id="rect899"
-         inkscape:connector-curvature="0"
-         style="fill:#d3d3d3;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:0.77974033;stroke-linecap:round;stroke-linejoin:round" />
-    </g>
   </g>
 </svg>


### PR DESCRIPTION
...causes a "link rect899 hasn't been detected!" message on script editor open.