### PR TITLE
Fix TP text in welcome page

### DIFF
--- a/interface/resources/html/interface-welcome.html
+++ b/interface/resources/html/interface-welcome.html
@@ -90,7 +90,7 @@
                     Move around with WASD & fly<br>
                     up or down with E & C.<br>
                     Cmnd/Ctrl+G will send you<br>
-                    home. @ (Shift+2) will let you<br>
+                    home. Hitting Enter will let you<br>
                     teleport to a user or location.
                 </p>
             </div>


### PR DESCRIPTION
Removed the no longer used (at) and replaced it with Enter.