### PR TITLE
DO NOT MERGE YET -- BUG FIX: Make sure scripts are done running early in application shutdown process

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -587,27 +587,51 @@ void Application::cleanupBeforeQuit() {
 }
 
 Application::~Application() {    
-    EntityTree* tree = _entities.getTree();
-    tree->lockForWrite();
-    _entities.getTree()->setSimulation(NULL);
-    tree->unlock();
+    qDebug() << "Application::~Application() ------------ START -----------------";
 
+
+    qDebug() << "Application::~Application() line:" << __LINE__;
+    EntityTree* tree = _entities.getTree();
+    qDebug() << "Application::~Application() line:" << __LINE__;
+    tree->lockForWrite();
+    qDebug() << "Application::~Application() line:" << __LINE__;
+    _entities.getTree()->setSimulation(NULL);
+    qDebug() << "Application::~Application() line:" << __LINE__;
+    tree->unlock();
+    qDebug() << "Application::~Application() line:" << __LINE__;
+
+    qDebug() << "Application::~Application() line:" << __LINE__;
     qInstallMessageHandler(NULL);
+    qDebug() << "Application::~Application() line:" << __LINE__;
 
     // ask the datagram processing thread to quit and wait until it is done
+    qDebug() << "Application::~Application() line:" << __LINE__;
     _nodeThread->quit();
+    qDebug() << "Application::~Application() line:" << __LINE__;
     _nodeThread->wait();
+    qDebug() << "Application::~Application() line:" << __LINE__;
     
+    qDebug() << "Application::~Application() line:" << __LINE__;
     _octreeProcessor.terminate();
+    qDebug() << "Application::~Application() line:" << __LINE__;
     _entityEditSender.terminate();
+    qDebug() << "Application::~Application() line:" << __LINE__;
 
+    qDebug() << "Application::~Application() line:" << __LINE__;
     Menu::getInstance()->deleteLater();
+    qDebug() << "Application::~Application() line:" << __LINE__;
 
+    qDebug() << "Application::~Application() line:" << __LINE__;
     _myAvatar = NULL;
+    qDebug() << "Application::~Application() line:" << __LINE__;
 
+    qDebug() << "Application::~Application() line:" << __LINE__;
     ModelEntityItem::cleanupLoadedAnimations() ;
+    qDebug() << "Application::~Application() line:" << __LINE__;
     
+    qDebug() << "Application::~Application() line:" << __LINE__;
     DependencyManager::destroy<GLCanvas>();
+    qDebug() << "Application::~Application() line:" << __LINE__;
 
     qDebug() << "start destroying ResourceCaches Application::~Application() line:" << __LINE__;
     DependencyManager::destroy<AnimationCache>();
@@ -616,6 +640,7 @@ Application::~Application() {
     DependencyManager::destroy<ScriptCache>();
     DependencyManager::destroy<SoundCache>();
     qDebug() << "done destroying ResourceCaches Application::~Application() line:" << __LINE__;
+    qDebug() << "Application::~Application() ------------ DONE -----------------";
 }
 
 void Application::initializeGL() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -540,7 +540,7 @@ void Application::cleanupBeforeQuit() {
     _entities.shutdown();
     
     // stop all running scripts
-    ScriptEngine::gracefullyStopAllScripts();
+    ScriptEngine::gracefullyStopAllScripts(this);
     
     
     // first stop all timers directly or by invokeMethod
@@ -3545,7 +3545,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     connect(workerThread, &QThread::started, scriptEngine, &ScriptEngine::run);
 
     // when the thread is terminated, add both scriptEngine and thread to the deleteLater queue
-    connect(scriptEngine, SIGNAL(finished(const QString&)), scriptEngine, SLOT(deleteLater()));
+    connect(scriptEngine, SIGNAL(doneRunning()), scriptEngine, SLOT(deleteLater()));
     connect(workerThread, SIGNAL(finished()), workerThread, SLOT(deleteLater()));
 
     // when the application is about to quit, stop our script engine so it unwinds properly

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -527,21 +527,15 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
 }
 
 void Application::aboutToQuit() {
-qDebug() << "Application::aboutToQuit()";
     _aboutToQuit = true;
     
     cleanupBeforeQuit();
 }
 
 void Application::cleanupBeforeQuit() {
-    qDebug() << "Application::cleanupBeforeQuit() ------------ START -----------------";
-    
-    // stop entities running scripts
-    _entities.shutdown();
-    
-    // stop all running scripts
-    ScriptEngine::gracefullyStopAllScripts(this);
-    
+
+    _entities.shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
+    ScriptEngine::stopAllScripts(this); // stop all currently running global scripts
     
     // first stop all timers directly or by invokeMethod
     // depending on what thread they run in
@@ -582,65 +576,36 @@ void Application::cleanupBeforeQuit() {
     
     // destroy the AudioClient so it and its thread have a chance to go down safely
     DependencyManager::destroy<AudioClient>();
-    
-    qDebug() << "Application::cleanupBeforeQuit() ------------ DONE -----------------";
 }
 
 Application::~Application() {    
-    qDebug() << "Application::~Application() ------------ START -----------------";
-
-
-    qDebug() << "Application::~Application() line:" << __LINE__;
     EntityTree* tree = _entities.getTree();
-    qDebug() << "Application::~Application() line:" << __LINE__;
     tree->lockForWrite();
-    qDebug() << "Application::~Application() line:" << __LINE__;
     _entities.getTree()->setSimulation(NULL);
-    qDebug() << "Application::~Application() line:" << __LINE__;
     tree->unlock();
-    qDebug() << "Application::~Application() line:" << __LINE__;
 
-    qDebug() << "Application::~Application() line:" << __LINE__;
     qInstallMessageHandler(NULL);
-    qDebug() << "Application::~Application() line:" << __LINE__;
 
     // ask the datagram processing thread to quit and wait until it is done
-    qDebug() << "Application::~Application() line:" << __LINE__;
     _nodeThread->quit();
-    qDebug() << "Application::~Application() line:" << __LINE__;
     _nodeThread->wait();
-    qDebug() << "Application::~Application() line:" << __LINE__;
     
-    qDebug() << "Application::~Application() line:" << __LINE__;
     _octreeProcessor.terminate();
-    qDebug() << "Application::~Application() line:" << __LINE__;
     _entityEditSender.terminate();
-    qDebug() << "Application::~Application() line:" << __LINE__;
 
-    qDebug() << "Application::~Application() line:" << __LINE__;
     Menu::getInstance()->deleteLater();
-    qDebug() << "Application::~Application() line:" << __LINE__;
 
-    qDebug() << "Application::~Application() line:" << __LINE__;
     _myAvatar = NULL;
-    qDebug() << "Application::~Application() line:" << __LINE__;
 
-    qDebug() << "Application::~Application() line:" << __LINE__;
     ModelEntityItem::cleanupLoadedAnimations() ;
-    qDebug() << "Application::~Application() line:" << __LINE__;
     
-    qDebug() << "Application::~Application() line:" << __LINE__;
     DependencyManager::destroy<GLCanvas>();
-    qDebug() << "Application::~Application() line:" << __LINE__;
 
-    qDebug() << "start destroying ResourceCaches Application::~Application() line:" << __LINE__;
     DependencyManager::destroy<AnimationCache>();
     DependencyManager::destroy<TextureCache>();
     DependencyManager::destroy<GeometryCache>();
     DependencyManager::destroy<ScriptCache>();
     DependencyManager::destroy<SoundCache>();
-    qDebug() << "done destroying ResourceCaches Application::~Application() line:" << __LINE__;
-    qDebug() << "Application::~Application() ------------ DONE -----------------";
 }
 
 void Application::initializeGL() {
@@ -3469,7 +3434,6 @@ void Application::clearScriptsBeforeRunning() {
 }
 
 void Application::saveScripts() {
-qDebug() << "Application::saveScripts()";
     // Saves all currently running user-loaded scripts
     Settings settings;
     settings.beginWriteArray(SETTINGS_KEY);
@@ -3638,7 +3602,6 @@ void Application::handleScriptLoadError(const QString& scriptFilename) {
 }
 
 void Application::scriptFinished(const QString& scriptName) {
-    qDebug() << "Application::scriptFinished(), scriptName:" << scriptName;
     const QString& scriptURLString = QUrl(scriptName).toString();
     QHash<QString, ScriptEngine*>::iterator it = _scriptEnginesHash.find(scriptURLString);
     if (it != _scriptEnginesHash.end()) {
@@ -3649,7 +3612,6 @@ void Application::scriptFinished(const QString& scriptName) {
 }
 
 void Application::stopAllScripts(bool restart) {
-    qDebug() << "Application::stopAllScripts()... restart:" << restart;
     // stops all current running scripts
     for (QHash<QString, ScriptEngine*>::const_iterator it = _scriptEnginesHash.constBegin();
             it != _scriptEnginesHash.constEnd(); it++) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3538,7 +3538,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     connect(workerThread, SIGNAL(finished()), workerThread, SLOT(deleteLater()));
 
     // when the application is about to quit, stop our script engine so it unwinds properly
-    connect(this, SIGNAL(aboutToQuit()), scriptEngine, SLOT(stop()));
+    //connect(this, SIGNAL(aboutToQuit()), scriptEngine, SLOT(stop()));
 
     auto nodeList = DependencyManager::get<NodeList>();
     connect(nodeList.data(), &NodeList::nodeKilled, scriptEngine, &ScriptEngine::nodeKilled);
@@ -3550,7 +3550,14 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
 }
 
 ScriptEngine* Application::loadScript(const QString& scriptFilename, bool isUserLoaded,
-    bool loadScriptFromEditor, bool activateMainWindow) {
+                                        bool loadScriptFromEditor, bool activateMainWindow) {
+
+    qDebug() << "Application::loadScript() " << scriptFilename << "line:" << __LINE__;
+    if (isAboutToQuit()) {
+        qDebug() << "Application::loadScript() WHILE QUITTING.... what to do????" << scriptFilename << "line:" << __LINE__;
+        return NULL;
+    }
+                                        
     QUrl scriptUrl(scriptFilename);
     const QString& scriptURLString = scriptUrl.toString();
     if (_scriptEnginesHash.contains(scriptURLString) && loadScriptFromEditor

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -63,6 +63,11 @@ EntityTreeRenderer::~EntityTreeRenderer() {
     // automatically but we do need to delete our sandbox script engine.
     
     if (_sandboxScriptEngine) {
+        // NOTE: is it possible this is a problem? I think that we hook the script engine object up to a deleteLater()
+        // call inside of registerScriptEngineWithApplicationServices() but do we not call that for _sandboxScriptEngine???
+        // this _sandboxScriptEngine implementation is confusing and potentially error prone because it's not a full fledged
+        // ScriptEngine that has been fully connected. We did this so that scripts that were ill-formed could be evaluated
+        // but not execute against the application.
         qDebug() << "EntityTreeRenderer::~EntityTreeRenderer() delete _sandboxScriptEngine!!!!!";
         delete _sandboxScriptEngine;
         _sandboxScriptEngine = NULL;
@@ -103,22 +108,6 @@ void EntityTreeRenderer::init() {
 
 void EntityTreeRenderer::shutdown() {
     _shuttingDown = true;
-    
-    /*
-    if (_entitiesScriptEngine) {
-        _entitiesScriptEngine->stop();
-
-        QEventLoop loop;
-        QObject::connect(_entitiesScriptEngine, &ScriptEngine::doneRunning, &loop, &QEventLoop::quit);
-
-        _entitiesScriptEngine->stop();
-        
-        qDebug() << "waiting on Entities sandbox script to stop... ";
-        loop.exec();
-        qDebug() << "done waiting... ";
-
-    }
-    */
 }
 
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -68,7 +68,6 @@ EntityTreeRenderer::~EntityTreeRenderer() {
         // this _sandboxScriptEngine implementation is confusing and potentially error prone because it's not a full fledged
         // ScriptEngine that has been fully connected. We did this so that scripts that were ill-formed could be evaluated
         // but not execute against the application.
-        qDebug() << "EntityTreeRenderer::~EntityTreeRenderer() delete _sandboxScriptEngine!!!!!";
         delete _sandboxScriptEngine;
         _sandboxScriptEngine = NULL;
     }
@@ -171,7 +170,7 @@ QString EntityTreeRenderer::loadScriptContents(const QString& scriptMaybeURLorTe
 
 QScriptValue EntityTreeRenderer::loadEntityScript(EntityItem* entity) {
     if (_shuttingDown) {
-        return QScriptValue(); // no entity...
+        return QScriptValue(); // since we're shutting down, we don't load any more scripts
     }
     
     if (!entity) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -59,6 +59,7 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
 }
 
 EntityTreeRenderer::~EntityTreeRenderer() {
+    qDebug() << "EntityTreeRenderer::~EntityTreeRenderer() -------- BEGIN -----------";
     // NOTE: we don't need to delete _entitiesScriptEngine because it's owned by the application and gets cleaned up 
     // automatically but we do need to delete our sandbox script engine.
     
@@ -71,6 +72,7 @@ EntityTreeRenderer::~EntityTreeRenderer() {
         delete _sandboxScriptEngine;
         _sandboxScriptEngine = NULL;
     }
+    qDebug() << "EntityTreeRenderer::~EntityTreeRenderer() -------- DONE -----------";
 }
 
 void EntityTreeRenderer::clear() {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -61,8 +61,12 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
 EntityTreeRenderer::~EntityTreeRenderer() {
     // NOTE: we don't need to delete _entitiesScriptEngine because it's owned by the application and gets cleaned up 
     // automatically but we do need to delete our sandbox script engine.
-    delete _sandboxScriptEngine;
-    _sandboxScriptEngine = NULL;
+    
+    if (_sandboxScriptEngine) {
+        qDebug() << "EntityTreeRenderer::~EntityTreeRenderer() delete _sandboxScriptEngine!!!!!";
+        delete _sandboxScriptEngine;
+        _sandboxScriptEngine = NULL;
+    }
 }
 
 void EntityTreeRenderer::clear() {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -46,6 +46,7 @@ public:
     virtual int getBoundaryLevelAdjust() const;
     virtual void setTree(Octree* newTree);
 
+    void shutdown();
     void update();
 
     EntityTree* getTree() { return static_cast<EntityTree*>(_tree); }
@@ -153,6 +154,8 @@ private:
     bool _displayModelBounds;
     bool _displayModelElementProxy;
     bool _dontDoPrecisionPicking;
+    
+    bool _shuttingDown = false;
     
 };
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -531,7 +531,6 @@ void ScriptEngine::run() {
         }
 
         if (!_isFinished) {
-            //qDebug() << "ScriptEngine::run()... about to emit update() _scriptName:" << _scriptName << "_fileNameString:" << _fileNameString << "_isFinished:" << _isFinished;
             emit update(deltaTime);
         }
         lastUpdate = now;

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -535,6 +535,9 @@ void ScriptEngine::run() {
         }
         lastUpdate = now;
     }
+    
+    stopAllTimers(); // make sure all our timers are stopped if the script is ending
+
     emit scriptEnding();
 
     // kill the avatar identity timer
@@ -562,6 +565,17 @@ void ScriptEngine::run() {
     emit runningStateChanged();
 
     emit doneRunning();
+}
+
+// NOTE: This is private because it must be called on the same thread that created the timers, which is why
+// we want to only call it in our own run "shutdown" processing.
+void ScriptEngine::stopAllTimers() {
+    QMutableHashIterator<QTimer*, QScriptValue> i(_timerFunctionMap);
+    while (i.hasNext()) {
+        i.next();
+        QTimer* timer = i.key();
+        stopTimer(timer);
+    }
 }
 
 void ScriptEngine::stop() {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -106,7 +106,12 @@ QSet<ScriptEngine*> ScriptEngine::_allKnownScriptEngines;
 
 void ScriptEngine::gracefullyStopAllScripts() {
     qDebug() << "[" << QThread::currentThread() << "]" << "ScriptEngine::gracefullyStopAllScripts() ----------- START ------------------";
-    foreach(ScriptEngine* scriptEngine, _allKnownScriptEngines) {
+
+    QSet<ScriptEngine*>::const_iterator i = _allKnownScriptEngines.constBegin();
+    while (i != _allKnownScriptEngines.constEnd()) {
+        ScriptEngine* scriptEngine = *i;
+        qDebug() << scriptEngine;
+ 
         if (scriptEngine->isRunning()) {
             qDebug() << "scriptEngine still alive:" << scriptEngine->getFilename() << "[" << scriptEngine << "]";
 
@@ -119,6 +124,8 @@ void ScriptEngine::gracefullyStopAllScripts() {
             loop.exec();
             qDebug() << "done waiting... ";
         }
+
+        ++i;
     }
     qDebug() << "[" << QThread::currentThread() << "]" << "ScriptEngine::gracefullyStopAllScripts() ----------- DONE ------------------";
 }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -109,7 +109,7 @@ void ScriptEngine::gracefullyStopAllScripts(QObject* application) {
     qDebug() << "[" << QThread::currentThread() << "]" << "ScriptEngine::gracefullyStopAllScripts() ----------- START ------------------";
 
 
-    QSetIterator<ScriptEngine*> i(_allKnownScriptEngines);
+    QMutableSetIterator<ScriptEngine*> i(_allKnownScriptEngines);
     while (i.hasNext()) {
         ScriptEngine* scriptEngine = i.next();
         qDebug() << (void*)scriptEngine;
@@ -121,7 +121,6 @@ void ScriptEngine::gracefullyStopAllScripts(QObject* application) {
             QObject::connect(scriptEngine, &ScriptEngine::doneRunning, &loop, &QEventLoop::quit);
             
             scriptEngine->disconnect(application);
-
             scriptEngine->stop();
 
             qDebug() << "waiting on script to stop... ";

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -141,6 +141,7 @@ protected:
     int _numAvatarSoundSentBytes;
 
 private:
+    void stopAllTimers();
     void sendAvatarIdentityPacket();
     void sendAvatarBillboardPacket();
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -85,6 +85,7 @@ public:
 
     bool isFinished() const { return _isFinished; }
     bool isRunning() const { return _isRunning; }
+    bool evaluatePending() const { return _evaluatePending; }
 
     void setUserLoaded(bool isUserLoaded) { _isUserLoaded = isUserLoaded;  }
     bool isUserLoaded() const { return _isUserLoaded; }
@@ -131,6 +132,7 @@ protected:
     QString _parentURL;
     bool _isFinished;
     bool _isRunning;
+    bool _evaluatePending = false;
     bool _isInitialized;
     bool _isAvatar;
     QTimer* _avatarIdentityTimer;
@@ -167,6 +169,8 @@ private slots:
 
 private:
     static QSet<ScriptEngine*> _allKnownScriptEngines;
+    static QMutex _allScriptsMutex;
+    static bool _stoppingAllScripts;
 };
 
 #endif // hifi_ScriptEngine_h

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -93,7 +93,7 @@ public:
     
     QString getFilename() const;
     
-    static void gracefullyStopAllScripts(QObject* application);
+    static void stopAllScripts(QObject* application);
 
 public slots:
     void loadURL(const QUrl& scriptURL);

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -43,6 +43,8 @@ public:
                  const QString& fileNameString = QString(""),
                  AbstractControllerScriptingInterface* controllerScriptingInterface = NULL);
 
+    ~ScriptEngine();
+
     /// Access the EntityScriptingInterface in order to initialize it with a custom packet sender and jurisdiction listener
     static EntityScriptingInterface* getEntityScriptingInterface() { return &_entityScriptingInterface; }
 
@@ -88,6 +90,10 @@ public:
     bool isUserLoaded() const { return _isUserLoaded; }
 
     void setParentURL(const QString& parentURL) { _parentURL = parentURL;  }
+    
+    QString getFilename() const;
+    
+    static void gracefullyStopAllScripts();
 
 public slots:
     void loadURL(const QUrl& scriptURL);
@@ -118,6 +124,7 @@ signals:
     void runningStateChanged();
     void evaluationFinished(QScriptValue result, bool isException);
     void loadScript(const QString& scriptName, bool isUserLoaded);
+    void doneRunning();
 
 protected:
     QString _scriptContents;
@@ -156,6 +163,9 @@ private:
     QHash<QUuid, quint16> _outgoingScriptAudioSequenceNumbers;
 private slots:
     void handleScriptDownload();
+
+private:
+    static QSet<ScriptEngine*> _allKnownScriptEngines;
 };
 
 #endif // hifi_ScriptEngine_h

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -93,7 +93,7 @@ public:
     
     QString getFilename() const;
     
-    static void gracefullyStopAllScripts();
+    static void gracefullyStopAllScripts(QObject* application);
 
 public slots:
     void loadURL(const QUrl& scriptURL);


### PR DESCRIPTION
* Fixes bugs related to scripts continuing to run after other application resources like the node list are no longer available.
* Implements the beginning of a fix for crash in timerFired() - still verifying that it fixes all cases.

Fixes: https://app.asana.com/0/26225263936266/27306002443612/f

This might fix:
* The crash in timerFired() - I am still verifying all the potential repros for this bug. It's hard to repro because it only happens some of the time. I think I've got it fixed but will do more testing before I declare victory.

Note: this does not fix several other shutdown related bugs:
* The "WINDOWS: Crash on Shutdown with Heap Corruption Detected error" - https://app.asana.com/0/26225263936266/27493514971485/f
* "Crash on shutdown in serverExists()" - https://app.asana.com/0/26225263936266/27615817115104/f

