### PR TITLE
Fix BillboardOverlay::findRayIntersection

### DIFF
--- a/interface/src/ui/overlays/BillboardOverlay.cpp
+++ b/interface/src/ui/overlays/BillboardOverlay.cpp
@@ -12,6 +12,7 @@
 #include "Application.h"
 
 #include "BillboardOverlay.h"
+#include <PlaneShape.h>
 
 BillboardOverlay::BillboardOverlay() :
     _fromImage(),
@@ -191,18 +192,51 @@ bool BillboardOverlay::findRayIntersection(const glm::vec3& origin, const glm::v
                                                         float& distance, BoxFace& face) {
 
     if (_texture) {
+        // This is taken from Planar3DOverlay.  Although it probably makes more sense for this
+        // overlay type to extend from Planar3DOverlay, the interfaces are different enough (scale vs. dimensions)
+        // that it would break existing scripts and would require other changes to make up for unique
+        // features like `isFacingAvatar`.
+
+        RayIntersectionInfo rayInfo;
+        rayInfo._rayStart = origin;
+        rayInfo._rayDirection = direction;
+        rayInfo._rayLength = std::numeric_limits<float>::max();
+
         bool isNull = _fromImage.isNull();
         float width = isNull ? _texture->getWidth() : _fromImage.width();
         float height = isNull ? _texture->getHeight() : _fromImage.height();
 
-        float maxSize = glm::max(width, height);
-        float x = width / (2.0f * maxSize);
-        float y = -height / (2.0f * maxSize);
-        float maxDimension = glm::max(x,y);
-        float scaledDimension = maxDimension * _scale;
-        glm::vec3 corner = getCenter() - glm::vec3(scaledDimension, scaledDimension, scaledDimension) ;
-        AACube myCube(corner, scaledDimension * 2.0f);
-        return myCube.findRayIntersection(origin, direction, distance, face);
+        PlaneShape plane;
+
+        const glm::vec3 UNROTATED_NORMAL(0.0f, 0.0f, -1.0f);
+        glm::quat rotation;
+        if (_isFacingAvatar) {
+            // rotate about vertical to face the camera
+            rotation = Application::getInstance()->getCamera()->getRotation();
+            rotation *= glm::angleAxis(glm::pi<float>(), glm::vec3(0.0f, 1.0f, 0.0f));
+        } else {
+            rotation = _rotation;
+        }
+        glm::vec3 normal = rotation * UNROTATED_NORMAL;
+        plane.setNormal(normal);
+        plane.setPoint(_position); // the position is definitely a point on our plane
+
+        bool intersects = plane.findRayIntersection(rayInfo);
+
+        if (intersects) {
+            distance = rayInfo._hitDistance;
+
+            glm::vec3 hitPosition = origin + (distance * direction);
+            glm::vec3 localHitPosition = glm::inverse(rotation) * (hitPosition - _position);
+
+            // Produce the dimensions of the billboard based on the image's aspect ratio and the overlay's scale.
+            float maxSize = glm::max(width, height);
+            glm::vec2 halfDimensions = 0.5f * _scale * glm::vec2(width / maxSize, height / maxSize);
+
+            intersects = -halfDimensions.x <= localHitPosition.x && localHitPosition.x <= halfDimensions.x
+                && -halfDimensions.y <= localHitPosition.y && localHitPosition.y <= halfDimensions.y;
+        }
+        return intersects;
     }
     return false;
 }

--- a/interface/src/ui/overlays/Planar3DOverlay.cpp
+++ b/interface/src/ui/overlays/Planar3DOverlay.cpp
@@ -17,6 +17,8 @@
 #include <SharedUtil.h>
 #include <StreamUtils.h>
 
+#include "GeometryUtil.h"
+
 #include "Planar3DOverlay.h"
 
 const float DEFAULT_SIZE = 1.0f;
@@ -93,29 +95,5 @@ QScriptValue Planar3DOverlay::getProperty(const QString& property) {
 
 bool Planar3DOverlay::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
                                                         float& distance, BoxFace& face) {
-    RayIntersectionInfo rayInfo;
-    rayInfo._rayStart = origin;
-    rayInfo._rayDirection = direction;
-    rayInfo._rayLength = std::numeric_limits<float>::max();
-
-    PlaneShape plane;
-
-    const glm::vec3 UNROTATED_NORMAL(0.0f, 0.0f, -1.0f);
-    glm::vec3 normal = _rotation * UNROTATED_NORMAL;
-    plane.setNormal(normal);
-    plane.setPoint(_position); // the position is definitely a point on our plane
-
-    bool intersects = plane.findRayIntersection(rayInfo);
-
-    if (intersects) {
-        distance = rayInfo._hitDistance;
-
-        glm::vec3 hitPosition = origin + (distance * direction);
-        glm::vec3 localHitPosition = glm::inverse(_rotation) * (hitPosition - _position);
-        glm::vec2 halfDimensions = _dimensions / 2.0f;
-
-        intersects = -halfDimensions.x <= localHitPosition.x && localHitPosition.x <= halfDimensions.x
-            && -halfDimensions.y <= localHitPosition.y && localHitPosition.y <= halfDimensions.y;
-    }
-    return intersects;
+    return findRayRectangleIntersection(origin, direction, _rotation, _position, _dimensions);
 }

--- a/libraries/shared/src/GeometryUtil.h
+++ b/libraries/shared/src/GeometryUtil.h
@@ -76,6 +76,9 @@ bool findRaySphereIntersection(const glm::vec3& origin, const glm::vec3& directi
 bool findRayCapsuleIntersection(const glm::vec3& origin, const glm::vec3& direction,
     const glm::vec3& start, const glm::vec3& end, float radius, float& distance);
 
+bool findRayRectangleIntersection(const glm::vec3& origin, const glm::vec3& direction,
+        const glm::quat& rotation, const glm::vec3& position, const glm::vec2& dimensions);
+
 bool findRayTriangleIntersection(const glm::vec3& origin, const glm::vec3& direction, 
                                     const glm::vec3& v0, const glm::vec3& v1, const glm::vec3& v2, float& distance);
 


### PR DESCRIPTION
The previous implementation was ray picking against an AABox which is incorrect in most situations.

I created a new function `findRayRectangleIntersection` mostly pulled from Planar3dOverlay's implementation.