### PR TITLE
lower threshold for ignoring rotation updates

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1002,7 +1002,7 @@ void EntityItem::computeShapeInfo(ShapeInfo& info) const {
 }
 
 const float MIN_POSITION_DELTA = 0.0001f;
-const float MIN_ALIGNMENT_DOT = 0.9999f;
+const float MIN_ALIGNMENT_DOT = 0.999999f;
 const float MIN_VELOCITY_DELTA = 0.01f;
 const float MIN_DAMPING_DELTA = 0.001f;
 const float MIN_GRAVITY_DELTA = 0.001f;


### PR DESCRIPTION
We were ignoring rotation updates that were not significantly different.  The threshold used to be about 1.62 degrees.  I've reduced it to a tenth of that (0.16 degrees) to see if that solves a problem that @PhilipRosedale is having when trying to update entities to slave to avatar hand rotations via JS script.