### PR TITLE
Make KeyEvent objects equal even if they have differing isAutoRepeat val...

### DIFF
--- a/libraries/script-engine/src/KeyEvent.cpp
+++ b/libraries/script-engine/src/KeyEvent.cpp
@@ -121,8 +121,7 @@ bool KeyEvent::operator==(const KeyEvent& other) const {
     && other.isControl == isControl
     && other.isMeta == isMeta
     && other.isAlt == isAlt
-    && other.isKeypad == isKeypad
-    && other.isAutoRepeat == isAutoRepeat;
+    && other.isKeypad == isKeypad;
 }
 
 


### PR DESCRIPTION
...ues

This fixes an issue where captured keys don't get captured when holding a key down.