### PR TITLE
load non-moving dynamic objects as "inactive" in physics engine

### DIFF
--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -63,6 +63,10 @@ void EntityMotionState::stepKinematicSimulation(quint64 now) {
     _entity->simulate(now);
 }
 
+bool EntityMotionState::isMoving() const {
+    return _entity->isMoving();
+}
+
 // This callback is invoked by the physics simulation in two cases:
 // (1) when the RigidBody is first added to the world
 //     (irregardless of MotionType: STATIC, DYNAMIC, or KINEMATIC)

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -36,28 +36,30 @@ public:
     virtual ~EntityMotionState();
 
     /// \return MOTION_TYPE_DYNAMIC or MOTION_TYPE_STATIC based on params set in EntityItem
-    MotionType computeMotionType() const;
+    virtual MotionType computeMotionType() const;
 
-    void updateKinematicState(uint32_t substep);
-    void stepKinematicSimulation(quint64 now);
+    virtual void updateKinematicState(uint32_t substep);
+    virtual void stepKinematicSimulation(quint64 now);
+
+    virtual bool isMoving() const;
 
     // this relays incoming position/rotation to the RigidBody
-    void getWorldTransform(btTransform& worldTrans) const;
+    virtual void getWorldTransform(btTransform& worldTrans) const;
 
     // this relays outgoing position/rotation to the EntityItem
-    void setWorldTransform(const btTransform& worldTrans);
+    virtual void setWorldTransform(const btTransform& worldTrans);
 
     // these relay incoming values to the RigidBody
-    void updateObjectEasy(uint32_t flags, uint32_t frame);
-    void updateObjectVelocities();
+    virtual void updateObjectEasy(uint32_t flags, uint32_t frame);
+    virtual void updateObjectVelocities();
 
-    void computeShapeInfo(ShapeInfo& shapeInfo);
-    float computeMass(const ShapeInfo& shapeInfo) const;
+    virtual void computeShapeInfo(ShapeInfo& shapeInfo);
+    virtual float computeMass(const ShapeInfo& shapeInfo) const;
 
-    void sendUpdate(OctreeEditPacketSender* packetSender, uint32_t frame);
+    virtual void sendUpdate(OctreeEditPacketSender* packetSender, uint32_t frame);
 
-    uint32_t getIncomingDirtyFlags() const;
-    void clearIncomingDirtyFlags(uint32_t flags) { _entity->clearDirtyFlags(flags); }
+    virtual uint32_t getIncomingDirtyFlags() const;
+    virtual void clearIncomingDirtyFlags(uint32_t flags) { _entity->clearDirtyFlags(flags); }
 
     EntityItem* getEntity() const { return _entity; }
 

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -101,6 +101,8 @@ public:
     void setKinematic(bool kinematic, uint32_t substep);
     virtual void stepKinematicSimulation(quint64 now) = 0;
 
+    virtual bool isMoving() const = 0;
+
     friend class PhysicsEngine;
 protected:
     void setRigidBody(btRigidBody* body);

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -439,6 +439,10 @@ void PhysicsEngine::addObject(const ShapeInfo& shapeInfo, btCollisionShape* shap
             const float DYNAMIC_LINEAR_VELOCITY_THRESHOLD = 0.05f;  // 5 cm/sec
             const float DYNAMIC_ANGULAR_VELOCITY_THRESHOLD = 0.087266f;  // ~5 deg/sec
             body->setSleepingThresholds(DYNAMIC_LINEAR_VELOCITY_THRESHOLD, DYNAMIC_ANGULAR_VELOCITY_THRESHOLD);
+            if (!motionState->isMoving()) {
+                // try to initialize this object as inactive
+                body->forceActivationState(ISLAND_SLEEPING);
+            }
             break;
         }
         case MOTION_TYPE_STATIC:


### PR DESCRIPTION
Objects that are at rest should be loaded into the physics engine as inactive -- this is to prevent unnecessary simulation when just loading a scene... until we actually interact with it.