### PR TITLE
BUG FIX: Hang on exit

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -215,7 +215,6 @@ bool setupEssentials(int& argc, char** argv) {
     DependencyManager::registerInheritance<AvatarHashMap, AvatarManager>();
     
     // Set dependencies
-    //auto glCanvasGlobal = DependencyManager::set<GLCanvasGlobal>();
     auto addressManager = DependencyManager::set<AddressManager>();
     auto nodeList = DependencyManager::set<NodeList>(NodeType::Agent, listenPort);
     auto geometryCache = DependencyManager::set<GeometryCache>();
@@ -532,8 +531,6 @@ void Application::aboutToQuit() {
 }
 
 void Application::cleanupBeforeQuit() {
-    qDebug() << "Application::cleanupBeforeQuit() ------------ BEGIN --------------";
-
     _datagramProcessor.shutdown(); // tell the datagram processor we're shutting down, so it can short circuit
     _entities.shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
     ScriptEngine::stopAllScripts(this); // stop all currently running global scripts
@@ -577,12 +574,9 @@ void Application::cleanupBeforeQuit() {
     
     // destroy the AudioClient so it and its thread have a chance to go down safely
     DependencyManager::destroy<AudioClient>();
-
-    qDebug() << "Application::cleanupBeforeQuit() ------------ END --------------";
 }
 
 Application::~Application() {    
-    qDebug() << "Application::~Application() ------------ BEGIN --------------";
     EntityTree* tree = _entities.getTree();
     tree->lockForWrite();
     _entities.getTree()->setSimulation(NULL);
@@ -601,19 +595,13 @@ Application::~Application() {
 
     ModelEntityItem::cleanupLoadedAnimations() ;
     
-    //DependencyManager::destroy<GLCanvasGlobal>();
-
-    qDebug() << "Application::~Application() ------------ BEGIN CACHE CLEANUP --------------";
     DependencyManager::destroy<AnimationCache>();
     DependencyManager::destroy<TextureCache>();
     DependencyManager::destroy<GeometryCache>();
     DependencyManager::destroy<ScriptCache>();
     DependencyManager::destroy<SoundCache>();
-    qDebug() << "Application::~Application() ------------ END CACHE CLEANUP --------------";
 
     qInstallMessageHandler(NULL); // NOTE: Do this as late as possible so we continue to get our log messages
-
-    qDebug() << "Application::~Application() ------------ END --------------";
 }
 
 void Application::initializeGL() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -534,6 +534,7 @@ void Application::aboutToQuit() {
 
 void Application::cleanupBeforeQuit() {
 
+    _datagramProcessor.shutdown(); // tell the datagram processor we're shutting down, so it can short circuit
     _entities.shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
     ScriptEngine::stopAllScripts(this); // stop all currently running global scripts
     
@@ -584,8 +585,6 @@ Application::~Application() {
     _entities.getTree()->setSimulation(NULL);
     tree->unlock();
 
-    qInstallMessageHandler(NULL);
-
     // ask the datagram processing thread to quit and wait until it is done
     _nodeThread->quit();
     _nodeThread->wait();
@@ -606,6 +605,8 @@ Application::~Application() {
     DependencyManager::destroy<GeometryCache>();
     DependencyManager::destroy<ScriptCache>();
     DependencyManager::destroy<SoundCache>();
+
+    qInstallMessageHandler(NULL); // NOTE: Do this as late as possible so we continue to get our log messages
 }
 
 void Application::initializeGL() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -473,7 +473,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
 
     checkVersion();
 
-    _overlays.init(_glWidget); // do this before scripts load
+    _overlays.init(); // do this before scripts load
 
     _runningScriptsWidget->setRunningScripts(getRunningScripts());
     connect(_runningScriptsWidget, &RunningScriptsWidget::stopScriptName, this, &Application::stopScript);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -171,7 +171,8 @@ public:
     bool event(QEvent* event);
     bool eventFilter(QObject* object, QEvent* event);
 
-    bool isThrottleRendering() const { return DependencyManager::get<GLCanvas>()->isThrottleRendering(); }
+    GLCanvas* getGLWidget() { return _glWidget; }
+    bool isThrottleRendering() const { return _glWidget->isThrottleRendering(); }
 
     Camera* getCamera() { return &_myCamera; }
     ViewFrustum* getViewFrustum() { return &_viewFrustum; }
@@ -195,8 +196,8 @@ public:
     bool mouseOnScreen() const;
     int getMouseX() const;
     int getMouseY() const;
-    int getTrueMouseX() const { return DependencyManager::get<GLCanvas>()->mapFromGlobal(QCursor::pos()).x(); }
-    int getTrueMouseY() const { return DependencyManager::get<GLCanvas>()->mapFromGlobal(QCursor::pos()).y(); }
+    int getTrueMouseX() const { return _glWidget->mapFromGlobal(QCursor::pos()).x(); }
+    int getTrueMouseY() const { return _glWidget->mapFromGlobal(QCursor::pos()).y(); }
     int getMouseDragStartedX() const;
     int getMouseDragStartedY() const;
     int getTrueMouseDragStartedX() const { return _mouseDragStartedX; }
@@ -270,8 +271,8 @@ public:
 
     FileLogger* getLogger() { return _logger; }
 
-    glm::vec2 getViewportDimensions() const { return glm::vec2(DependencyManager::get<GLCanvas>()->getDeviceWidth(),
-                                                               DependencyManager::get<GLCanvas>()->getDeviceHeight()); }
+    glm::vec2 getViewportDimensions() const { return glm::vec2(_glWidget->getDeviceWidth(),
+                                                               _glWidget->getDeviceHeight()); }
     NodeToJurisdictionMap& getEntityServerJurisdictions() { return _entityServerJurisdictions; }
 
     void skipVersion(QString latestVersion);
@@ -593,6 +594,8 @@ private:
     
     QThread _settingsThread;
     QTimer _settingsTimer;
+    
+    GLCanvas* _glWidget = new GLCanvas(); // our GLCanvas has a couple extra features
 };
 
 #endif // hifi_Application_h

--- a/interface/src/Camera.cpp
+++ b/interface/src/Camera.cpp
@@ -122,7 +122,7 @@ void Camera::setFarClip(float f) {
 }
 
 PickRay Camera::computePickRay(float x, float y) {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     return computeViewPickRay(x / glCanvas->width(), y / glCanvas->height());
 }
 

--- a/interface/src/DatagramProcessor.cpp
+++ b/interface/src/DatagramProcessor.cpp
@@ -30,6 +30,10 @@ DatagramProcessor::DatagramProcessor(QObject* parent) :
 void DatagramProcessor::processDatagrams() {
     PerformanceWarning warn(Menu::getInstance()->isOptionChecked(MenuOption::PipelineWarnings),
                             "DatagramProcessor::processDatagrams()");
+
+    if (_isShuttingDown) {
+        return; // bail early... we're shutting down.
+    }
     
     HifiSockAddr senderSockAddr;
     

--- a/interface/src/DatagramProcessor.h
+++ b/interface/src/DatagramProcessor.h
@@ -25,14 +25,17 @@ public:
     int getOutByteCount() const { return _outByteCount; }
     
     void resetCounters() { _inPacketCount = 0; _outPacketCount = 0; _inByteCount = 0; _outByteCount = 0; }
+
+    void shutdown() { _isShuttingDown = true; }
 public slots:
     void processDatagrams();
     
 private:
-    int _inPacketCount;
-    int _outPacketCount;
-    int _inByteCount;
-    int _outByteCount;
+    int _inPacketCount = 0;
+    int _outPacketCount = 0;
+    int _inByteCount = 0;
+    int _outByteCount = 0;
+    bool _isShuttingDown = false;
 };
 
 #endif // hifi_DatagramProcessor_h

--- a/interface/src/GLCanvas.h
+++ b/interface/src/GLCanvas.h
@@ -16,17 +16,12 @@
 #include <QGLWidget>
 #include <QTimer>
 
-//#include <DependencyManager.h>
-
 /// customized canvas that simply forwards requests/events to the singleton application
 class GLCanvas : public QGLWidget {
     Q_OBJECT
     
 public:
     GLCanvas();
-    virtual ~GLCanvas() {
-        qDebug() << "Deleting GLCanvas";
-    }
 
     bool isThrottleRendering() const;
     

--- a/interface/src/GLCanvas.h
+++ b/interface/src/GLCanvas.h
@@ -16,14 +16,18 @@
 #include <QGLWidget>
 #include <QTimer>
 
-#include <DependencyManager.h>
+//#include <DependencyManager.h>
 
 /// customized canvas that simply forwards requests/events to the singleton application
-class GLCanvas : public QGLWidget, public Dependency {
+class GLCanvas : public QGLWidget {
     Q_OBJECT
-    SINGLETON_DEPENDENCY
     
 public:
+    GLCanvas();
+    virtual ~GLCanvas() {
+        qDebug() << "Deleting GLCanvas";
+    }
+
     bool isThrottleRendering() const;
     
     int getDeviceWidth() const;
@@ -60,12 +64,8 @@ private slots:
     void activeChanged(Qt::ApplicationState state);
     void throttleRender();
     bool eventFilter(QObject*, QEvent* event);
-    
-private:
-    GLCanvas();
-    ~GLCanvas() {
-        qDebug() << "Deleting GLCanvas";
-    }
+   
 };
+
 
 #endif // hifi_GLCanvas_h

--- a/interface/src/UIUtil.cpp
+++ b/interface/src/UIUtil.cpp
@@ -12,8 +12,6 @@
 #include <QStyle>
 #include <QStyleOptionTitleBar>
 
-//#include "DependencyManager.h"
-#include "Application.h"
 #include "GLCanvas.h"
 
 #include "UIUtil.h"
@@ -45,8 +43,6 @@ int UIUtil::getWindowTitleBarHeight(const QWidget* window) {
 // this function at all.  If you mix both you will end up with inconsistent results
 // across platforms.
 void UIUtil::scaleWidgetFontSizes(QWidget* widget) {
-    auto glCanvas = Application::getInstance()->getGLWidget();
-
     // This is the base dpi that we are targetting.  This is based on Mac OSXs default DPI,
     // and is the basis for all font sizes.
     const float BASE_DPI = 72.0f;

--- a/interface/src/UIUtil.cpp
+++ b/interface/src/UIUtil.cpp
@@ -12,7 +12,8 @@
 #include <QStyle>
 #include <QStyleOptionTitleBar>
 
-#include "DependencyManager.h"
+//#include "DependencyManager.h"
+#include "Application.h"
 #include "GLCanvas.h"
 
 #include "UIUtil.h"
@@ -44,7 +45,7 @@ int UIUtil::getWindowTitleBarHeight(const QWidget* window) {
 // this function at all.  If you mix both you will end up with inconsistent results
 // across platforms.
 void UIUtil::scaleWidgetFontSizes(QWidget* widget) {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
 
     // This is the base dpi that we are targetting.  This is based on Mac OSXs default DPI,
     // and is the basis for all font sizes.

--- a/interface/src/audio/AudioToolBox.cpp
+++ b/interface/src/audio/AudioToolBox.cpp
@@ -16,6 +16,7 @@
 #include <PathUtils.h>
 #include <GeometryCache.h>
 
+#include "Application.h"
 #include "AudioToolBox.h"
 
 // Mute icon configration
@@ -37,7 +38,7 @@ bool AudioToolBox::mousePressEvent(int x, int y) {
 void AudioToolBox::render(int x, int y, bool boxed) {
     glEnable(GL_TEXTURE_2D);
     
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     if (_micTextureId == 0) {
         _micTextureId =  glCanvas->bindTexture(QImage(PathUtils::resourcesPath() + "images/mic.svg"));
     }

--- a/interface/src/audio/AudioToolBox.cpp
+++ b/interface/src/audio/AudioToolBox.cpp
@@ -106,8 +106,12 @@ void AudioToolBox::render(int x, int y, bool boxed) {
     glm::vec2 bottomRight(_iconBounds.right(), _iconBounds.bottom());
     glm::vec2 texCoordTopLeft(1,1);
     glm::vec2 texCoordBottomRight(0,0);
+    
+    if (_boxQuadID == GeometryCache::UNKNOWN_ID) {
+        _boxQuadID = DependencyManager::get<GeometryCache>()->allocateID();
+    }
 
-    DependencyManager::get<GeometryCache>()->renderQuad(topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight, quadColor);
+    DependencyManager::get<GeometryCache>()->renderQuad(topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight, quadColor, _boxQuadID);
     
     glDisable(GL_TEXTURE_2D);
 }

--- a/interface/src/audio/AudioToolBox.h
+++ b/interface/src/audio/AudioToolBox.h
@@ -13,6 +13,7 @@
 #define hifi_AudioToolBox_h
 
 #include <DependencyManager.h>
+#include <GeometryCache.h>
 
 class AudioToolBox : public Dependency {
     SINGLETON_DEPENDENCY
@@ -26,6 +27,7 @@ private:
     GLuint _micTextureId = 0;
     GLuint _muteTextureId = 0;
     GLuint _boxTextureId = 0;
+    int _boxQuadID = GeometryCache::UNKNOWN_ID;
     QRect _iconBounds;
     qint64 _iconPulseTimeReference = 0;
 };

--- a/interface/src/devices/OculusManager.cpp
+++ b/interface/src/devices/OculusManager.cpp
@@ -566,7 +566,7 @@ void OculusManager::display(const glm::quat &bodyOrientation, const glm::vec3 &p
     }
 
     // restore our normal viewport
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     glViewport(0, 0, glCanvas->getDeviceWidth(), glCanvas->getDeviceHeight());
 
     glMatrixMode(GL_PROJECTION);
@@ -585,7 +585,7 @@ void OculusManager::display(const glm::quat &bodyOrientation, const glm::vec3 &p
 void OculusManager::renderDistortionMesh(ovrPosef eyeRenderPose[ovrEye_Count]) {
 
     glLoadIdentity();
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     glOrtho(0, glCanvas->getDeviceWidth(), 0, glCanvas->getDeviceHeight(), -1.0, 1.0);
 
     glDisable(GL_DEPTH_TEST);

--- a/interface/src/devices/PrioVR.cpp
+++ b/interface/src/devices/PrioVR.cpp
@@ -216,7 +216,7 @@ void PrioVR::renderCalibrationCountdown() {
     static TextRenderer* textRenderer = TextRenderer::getInstance(MONO_FONT_FAMILY, 18, QFont::Bold,
         false, TextRenderer::OUTLINE_EFFECT, 2);
     QByteArray text = "Assume T-Pose in " + QByteArray::number(secondsRemaining) + "...";
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     textRenderer->draw((glCanvas->width() - textRenderer->computeExtent(text.constData()).x) / 2,
                        glCanvas->height() / 2,
                        text, glm::vec4(1,1,1,1));

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -472,7 +472,7 @@ void SixenseManager::updateCalibration(const sixenseControllerData* controllers)
 //Injecting mouse movements and clicks
 void SixenseManager::emulateMouse(PalmData* palm, int index) {
     MyAvatar* avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     QPoint pos;
     
     Qt::MouseButton bumperButton;

--- a/interface/src/devices/TV3DManager.cpp
+++ b/interface/src/devices/TV3DManager.cpp
@@ -35,7 +35,7 @@ bool TV3DManager::isConnected() {
 }
 
 void TV3DManager::connect() {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     int width = glCanvas->getDeviceWidth();
     int height = glCanvas->getDeviceHeight();
     Camera& camera = *Application::getInstance()->getCamera();
@@ -93,7 +93,7 @@ void TV3DManager::display(Camera& whichCamera) {
     // left eye portal
     int portalX = 0;
     int portalY = 0;
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     QSize deviceSize = glCanvas->getDeviceSize() *
         Application::getInstance()->getRenderResolutionScale();
     int portalW = deviceSize.width() / 2;

--- a/interface/src/scripting/ControllerScriptingInterface.cpp
+++ b/interface/src/scripting/ControllerScriptingInterface.cpp
@@ -15,6 +15,7 @@
 #include <HandData.h>
 #include <HFBackEvent.h>
 
+#include "Application.h"
 #include "devices/MotionTracker.h"
 #include "devices/SixenseManager.h"
 #include "ControllerScriptingInterface.h"
@@ -285,7 +286,7 @@ void ControllerScriptingInterface::releaseJoystick(int joystickIndex) {
 }
 
 glm::vec2 ControllerScriptingInterface::getViewportDimensions() const {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     return glm::vec2(glCanvas->width(), glCanvas->height());
 }
 

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -44,7 +44,7 @@ WebWindowClass* WindowScriptingInterface::doCreateWebWindow(const QString& title
 }
 
 QScriptValue WindowScriptingInterface::hasFocus() {
-    return DependencyManager::get<GLCanvas>()->hasFocus();
+    return Application::getInstance()->getGLWidget()->hasFocus();
 }
 
 void WindowScriptingInterface::setFocus() {

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -170,7 +170,7 @@ ApplicationOverlay::~ApplicationOverlay() {
 void ApplicationOverlay::renderOverlay(bool renderToTexture) {
     PerformanceWarning warn(Menu::getInstance()->isOptionChecked(MenuOption::PipelineWarnings), "ApplicationOverlay::displayOverlay()");
     Overlays& overlays = qApp->getOverlays();
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     
     _textureFov = glm::radians(_oculusUIAngularSize);
     _textureAspectRatio = (float)glCanvas->getDeviceWidth() / (float)glCanvas->getDeviceHeight();
@@ -239,7 +239,7 @@ void ApplicationOverlay::displayOverlayTexture() {
     if (_alpha == 0.0f) {
         return;
     }
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
 
     glEnable(GL_TEXTURE_2D);
     glActiveTexture(GL_TEXTURE0);
@@ -401,7 +401,7 @@ void ApplicationOverlay::displayOverlayTexture3DTV(Camera& whichCamera, float as
                                                 glm::vec2(1.0f, 0.0f), glm::vec2(0.0f, 0.0f),
                                                 overlayColor);
     
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     if (_crosshairTexture == 0) {
         _crosshairTexture = glCanvas->bindTexture(QImage(PathUtils::resourcesPath() + "images/sixense-reticle.png"));
     }
@@ -451,7 +451,7 @@ void ApplicationOverlay::computeOculusPickRay(float x, float y, glm::vec3& origi
 
 //Caculate the click location using one of the sixense controllers. Scale is not applied
 QPoint ApplicationOverlay::getPalmClickLocation(const PalmData *palm) const {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
 
     glm::vec3 tip = myAvatar->getLaserPointerTipPosition(palm);
@@ -528,7 +528,7 @@ bool ApplicationOverlay::calculateRayUICollisionPoint(const glm::vec3& position,
 
 //Renders optional pointers
 void ApplicationOverlay::renderPointers() {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
 
     //lazily load crosshair texture
     if (_crosshairTexture == 0) {
@@ -575,7 +575,7 @@ void ApplicationOverlay::renderPointers() {
 }
 
 void ApplicationOverlay::renderControllerPointers() {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
 
     //Static variables used for storing controller state
@@ -722,7 +722,7 @@ void ApplicationOverlay::renderMagnifier(glm::vec2 magPos, float sizeMult, bool 
     if (!_magnifier) {
         return;
     }
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     
     const int widgetWidth = glCanvas->width();
     const int widgetHeight = glCanvas->height();
@@ -787,7 +787,7 @@ void ApplicationOverlay::renderMagnifier(glm::vec2 magPos, float sizeMult, bool 
 }
 
 void ApplicationOverlay::renderAudioMeter() {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     auto audio = DependencyManager::get<AudioClient>();
 
     //  Audio VU Meter and Mute Icon
@@ -905,7 +905,7 @@ void ApplicationOverlay::renderStatsAndLogs() {
     Application* application = Application::getInstance();
     QSharedPointer<BandwidthRecorder> bandwidthRecorder = DependencyManager::get<BandwidthRecorder>();
     
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     const OctreePacketProcessor& octreePacketProcessor = application->getOctreePacketProcessor();
     NodeBounds& nodeBoundsDisplay = application->getNodeBoundsDisplay();
 
@@ -943,7 +943,7 @@ void ApplicationOverlay::renderDomainConnectionStatusBorder() {
     auto nodeList = DependencyManager::get<NodeList>();
 
     if (nodeList && !nodeList->getDomainHandler().isConnected()) {
-        auto glCanvas = DependencyManager::get<GLCanvas>();
+        auto glCanvas = Application::getInstance()->getGLWidget();
         auto geometryCache = DependencyManager::get<GeometryCache>();
         int width = glCanvas->width();
         int height = glCanvas->height();
@@ -1087,7 +1087,7 @@ void ApplicationOverlay::TexturedHemisphere::cleanupVBO() {
 }
 
 void ApplicationOverlay::TexturedHemisphere::buildFramebufferObject() {
-    QSize size = DependencyManager::get<GLCanvas>()->getDeviceSize();
+    QSize size = Application::getInstance()->getGLWidget()->getDeviceSize();
     if (_framebufferObject != NULL && size == _framebufferObject->size()) {
         // Already build
         return;
@@ -1138,7 +1138,7 @@ void ApplicationOverlay::TexturedHemisphere::render() {
 
 
 glm::vec2 ApplicationOverlay::screenToSpherical(glm::vec2 screenPos) const {
-    QSize screenSize = DependencyManager::get<GLCanvas>()->getDeviceSize();
+    QSize screenSize = Application::getInstance()->getGLWidget()->getDeviceSize();
     float yaw = -(screenPos.x / screenSize.width() - 0.5f) * MOUSE_YAW_RANGE;
     float pitch = (screenPos.y / screenSize.height() - 0.5f) * MOUSE_PITCH_RANGE;
     
@@ -1146,7 +1146,7 @@ glm::vec2 ApplicationOverlay::screenToSpherical(glm::vec2 screenPos) const {
 }
 
 glm::vec2 ApplicationOverlay::sphericalToScreen(glm::vec2 sphericalPos) const {
-    QSize screenSize = DependencyManager::get<GLCanvas>()->getDeviceSize();
+    QSize screenSize = Application::getInstance()->getGLWidget()->getDeviceSize();
     float x = (-sphericalPos.x / MOUSE_YAW_RANGE + 0.5f) * screenSize.width();
     float y = (sphericalPos.y / MOUSE_PITCH_RANGE + 0.5f) * screenSize.height();
     
@@ -1154,7 +1154,7 @@ glm::vec2 ApplicationOverlay::sphericalToScreen(glm::vec2 sphericalPos) const {
 }
 
 glm::vec2 ApplicationOverlay::sphericalToOverlay(glm::vec2 sphericalPos) const {
-    QSize screenSize = DependencyManager::get<GLCanvas>()->getDeviceSize();
+    QSize screenSize = Application::getInstance()->getGLWidget()->getDeviceSize();
     float x = (-sphericalPos.x / (_textureFov * _textureAspectRatio) + 0.5f) * screenSize.width();
     float y = (sphericalPos.y / _textureFov + 0.5f) * screenSize.height();
     
@@ -1162,7 +1162,7 @@ glm::vec2 ApplicationOverlay::sphericalToOverlay(glm::vec2 sphericalPos) const {
 }
 
 glm::vec2 ApplicationOverlay::overlayToSpherical(glm::vec2 overlayPos) const {
-    QSize screenSize = DependencyManager::get<GLCanvas>()->getDeviceSize();
+    QSize screenSize = Application::getInstance()->getGLWidget()->getDeviceSize();
     float yaw = -(overlayPos.x / screenSize.width() - 0.5f) * _textureFov * _textureAspectRatio;
     float pitch = (overlayPos.y / screenSize.height() - 0.5f) * _textureFov;
     

--- a/interface/src/ui/MetavoxelEditor.cpp
+++ b/interface/src/ui/MetavoxelEditor.cpp
@@ -140,7 +140,7 @@ MetavoxelEditor::MetavoxelEditor(QWidget* parent) :
     connect(Application::getInstance()->getMetavoxels(), &MetavoxelSystem::rendering,
         this, &MetavoxelEditor::renderPreview);
     
-    DependencyManager::get<GLCanvas>()->installEventFilter(this);
+    Application::getInstance()->getGLWidget()->installEventFilter(this);
     
     show();
     

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -235,7 +235,7 @@ void PreferencesDialog::savePreferences() {
     myAvatar->setLeanScale(ui.leanScaleSpin->value());
     myAvatar->setClampedTargetScale(ui.avatarScaleSpin->value());
     
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     Application::getInstance()->resizeGL(glCanvas->width(), glCanvas->height());
 
     DependencyManager::get<AvatarManager>()->getMyAvatar()->setRealWorldFieldOfView(ui.realWorldFieldOfViewSpin->value());

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -23,6 +23,7 @@
 #include <GLCanvas.h>
 #include <NodeList.h>
 
+#include "Application.h"
 #include "Snapshot.h"
 
 // filename format: hifi-snap-by-%username%-on-%date%_%time%_@-%location%.jpg
@@ -93,7 +94,7 @@ QTemporaryFile* Snapshot::saveTempSnapshot() {
 }
 
 QFile* Snapshot::savedFileForSnapshot(bool isTemporary) {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     QImage shot = glCanvas->grabFrameBuffer();
     
     Avatar* avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -62,7 +62,7 @@ Stats::Stats():
         _metavoxelReceiveProgress(0),
         _metavoxelReceiveTotal(0)
 {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     resetWidth(glCanvas->width(), 0);
 }
 
@@ -73,7 +73,7 @@ void Stats::toggleExpanded() {
 // called on mouse click release
 // check for clicks over stats  in order to expand or contract them
 void Stats::checkClick(int mouseX, int mouseY, int mouseDragStartedX, int mouseDragStartedY, int horizontalOffset) {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
 
     if (0 != glm::compMax(glm::abs(glm::ivec2(mouseX - mouseDragStartedX, mouseY - mouseDragStartedY)))) {
         // not worried about dragging on stats
@@ -128,7 +128,7 @@ void Stats::checkClick(int mouseX, int mouseY, int mouseDragStartedX, int mouseD
 }
 
 void Stats::resetWidth(int width, int horizontalOffset) {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
     int extraSpace = glCanvas->width() - horizontalOffset -2
                    - STATS_GENERAL_MIN_WIDTH
                    - (Menu::getInstance()->isOptionChecked(MenuOption::TestPing) ? STATS_PING_MIN_WIDTH -1 : 0)
@@ -202,7 +202,7 @@ void Stats::display(
         int outKbitsPerSecond,
         int voxelPacketsToProcess) 
 {
-    auto glCanvas = DependencyManager::get<GLCanvas>();
+    auto glCanvas = Application::getInstance()->getGLWidget();
 
     unsigned int backgroundColor = 0x33333399;
     int verticalOffset = 0, lines = 0;

--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -11,7 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <SharedUtil.h>
 
 #include "Application.h"

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -11,7 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <GeometryCache.h>
 #include <GlowEffect.h>
 #include <SharedUtil.h>

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -11,8 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
-
 #include <DeferredLightingEffect.h>
 #include <GlowEffect.h>
 #include <SharedUtil.h>

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -17,8 +17,6 @@
 
 #include <glm/glm.hpp>
 
-#include <QGLWidget>
-
 #include <ProgramObject.h>
 #include <SharedUtil.h>
 

--- a/interface/src/ui/overlays/ImageOverlay.cpp
+++ b/interface/src/ui/overlays/ImageOverlay.cpp
@@ -11,7 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <QPainter>
 #include <QSvgRenderer>
 

--- a/interface/src/ui/overlays/ImageOverlay.h
+++ b/interface/src/ui/overlays/ImageOverlay.h
@@ -14,7 +14,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <QImage>
 #include <QNetworkReply>
 #include <QRect>

--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -20,7 +20,6 @@
 
 
 Overlay::Overlay() :
-    _parent(NULL),
     _isLoaded(true),
     _alpha(DEFAULT_ALPHA),
     _glowLevel(0.0f),
@@ -40,7 +39,6 @@ Overlay::Overlay() :
 }
 
 Overlay::Overlay(const Overlay* overlay) :
-    _parent(NULL),
     _isLoaded(overlay->_isLoaded),
     _alpha(overlay->_alpha),
     _glowLevel(overlay->_glowLevel),
@@ -60,8 +58,7 @@ Overlay::Overlay(const Overlay* overlay) :
 {
 }
 
-void Overlay::init(QGLWidget* parent, QScriptEngine* scriptEngine) {
-    _parent = parent;
+void Overlay::init(QScriptEngine* scriptEngine) {
     _scriptEngine = scriptEngine;
 }
 

--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -11,9 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QSvgRenderer>
-#include <QPainter>
-#include <QGLWidget>
 #include <SharedUtil.h>
 
 #include "Overlay.h"

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -14,7 +14,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <QRect>
 #include <QScriptValue>
 #include <QString>

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -38,7 +38,7 @@ public:
     Overlay();
     Overlay(const Overlay* overlay);
     ~Overlay();
-    void init(QGLWidget* parent, QScriptEngine* scriptEngine);
+    void init(QScriptEngine* scriptEngine);
     virtual void update(float deltatime) {}
     virtual void render(RenderArgs* args) = 0;
 
@@ -85,7 +85,6 @@ public:
 protected:
     float updatePulse();
 
-    QGLWidget* _parent;
     bool _isLoaded;
     float _alpha;
     float _glowLevel;

--- a/interface/src/ui/overlays/Overlay2D.cpp
+++ b/interface/src/ui/overlays/Overlay2D.cpp
@@ -11,9 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QSvgRenderer>
-#include <QPainter>
-#include <QGLWidget>
 #include <SharedUtil.h>
 
 #include "Overlay2D.h"

--- a/interface/src/ui/overlays/Overlay2D.h
+++ b/interface/src/ui/overlays/Overlay2D.h
@@ -14,7 +14,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <QRect>
 #include <QScriptValue>
 #include <QString>

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -58,8 +58,7 @@ Overlays::~Overlays() {
     
 }
 
-void Overlays::init(QGLWidget* parent) {
-    _parent = parent;
+void Overlays::init() {
     _scriptEngine = new QScriptEngine();
 }
 
@@ -202,7 +201,7 @@ unsigned int Overlays::addOverlay(const QString& type, const QScriptValue& prope
 }
 
 unsigned int Overlays::addOverlay(Overlay* overlay) {
-    overlay->init(_parent, _scriptEngine);
+    overlay->init(_scriptEngine);
 
     QWriteLocker lock(&_lock);
     unsigned int thisID = _nextOverlayID;

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -51,7 +51,7 @@ class Overlays : public QObject {
 public:
     Overlays();
     ~Overlays();
-    void init(QGLWidget* parent);
+    void init();
     void update(float deltatime);
     void renderWorld(bool drawFront, RenderArgs::RenderMode renderMode = RenderArgs::DEFAULT_RENDER_MODE,
                         RenderArgs::RenderSide renderSide = RenderArgs::MONO);
@@ -95,7 +95,6 @@ private:
     QMap<unsigned int, Overlay*> _overlaysWorld;
     QList<Overlay*> _overlaysToDelete;
     unsigned int _nextOverlayID;
-    QGLWidget* _parent;
     QReadWriteLock _lock;
     QReadWriteLock _deleteLock;
     QScriptEngine* _scriptEngine;

--- a/interface/src/ui/overlays/Planar3DOverlay.cpp
+++ b/interface/src/ui/overlays/Planar3DOverlay.cpp
@@ -11,7 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <PlaneShape.h>
 #include <RayIntersectionInfo.h>
 #include <SharedUtil.h>

--- a/interface/src/ui/overlays/Planar3DOverlay.h
+++ b/interface/src/ui/overlays/Planar3DOverlay.h
@@ -16,7 +16,6 @@
 
 #include <glm/glm.hpp>
 
-#include <QGLWidget>
 #include <QScriptValue>
 
 #include "Base3DOverlay.h"

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -11,8 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
-
 #include <GeometryCache.h>
 #include <GlowEffect.h>
 #include <SharedUtil.h>

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -11,8 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
-
 #include <GlowEffect.h>
 #include <SharedUtil.h>
 

--- a/interface/src/ui/overlays/TextOverlay.cpp
+++ b/interface/src/ui/overlays/TextOverlay.cpp
@@ -11,8 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
-
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <SharedUtil.h>

--- a/interface/src/ui/overlays/TextOverlay.h
+++ b/interface/src/ui/overlays/TextOverlay.h
@@ -14,13 +14,9 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
-#include <QImage>
-#include <QNetworkReply>
 #include <QRect>
 #include <QScriptValue>
 #include <QString>
-#include <QUrl>
 
 #include <SharedUtil.h>
 

--- a/interface/src/ui/overlays/Volume3DOverlay.cpp
+++ b/interface/src/ui/overlays/Volume3DOverlay.cpp
@@ -14,7 +14,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "InterfaceConfig.h"
 
-#include <QGLWidget>
 #include <AABox.h>
 #include <SharedUtil.h>
 #include <StreamUtils.h>

--- a/interface/src/ui/overlays/Volume3DOverlay.h
+++ b/interface/src/ui/overlays/Volume3DOverlay.h
@@ -16,7 +16,6 @@
 
 #include <glm/glm.hpp>
 
-#include <QGLWidget>
 #include <QScriptValue>
 
 #include "Base3DOverlay.h"

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -11,7 +11,6 @@
 #ifndef hifi_gpu_Context_h
 #define hifi_gpu_Context_h
 
-#include <QDebug>
 #include <assert.h>
 
 #include "Resource.h"

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -11,6 +11,7 @@
 #ifndef hifi_gpu_Context_h
 #define hifi_gpu_Context_h
 
+#include <QDebug>
 #include <assert.h>
 
 #include "Resource.h"
@@ -21,7 +22,7 @@ namespace gpu {
 class GPUObject {
 public:
     GPUObject() {}
-    ~GPUObject() {}
+    virtual ~GPUObject() {}
 };
 
 class Batch;

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -32,7 +32,7 @@ public:
     static void checkGLError();
 
 
-    class GLBuffer {
+    class GLBuffer : public GPUObject {
     public:
         Stamp _stamp;
         GLuint _buffer;


### PR DESCRIPTION
This PR fixes a couple different problems that were contributing to the hang on exit.

* Moved GLCanvas back to be a member of Application. This is because the GLCanvas aka QGLWidget derived class needs to be "owned" by the QMainWindow object. Having it be a DependencyManager class opens the door to potential memory corrupts and double deletes.

* Fixed a resource leak in gpu related to the GLBuffer not properly deriving from GPUObject [Hat tip to @samcake for figuring this one out].

* Fixed a over-use of gpu::Buffer in the AudioToolBox. Which was rendering quads as unregistered, but was changing the geometry properties each frame... the result was a massive "run-up" of quad geometries that would rarely get reused and not deleted until shutdown.

* Also cleaned up a bunch of unused copies of pointers to QGLWidget... these weren't leaking but are unused cruft.

* Also added a short circuit to DatagramProcessor to tell it to not process packets after we've shut down... this fixes some warnings caused by Audio packets arriving after we've already destroyed the AudioClient.