### PR TITLE
Update light properties (primarily for editEntities.js)

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -132,17 +132,7 @@
             var elLightDiffuseGreen = document.getElementById("property-light-diffuse-green");
             var elLightDiffuseBlue = document.getElementById("property-light-diffuse-blue");
 
-            var elLightAmbientRed = document.getElementById("property-light-ambient-red");
-            var elLightAmbientGreen = document.getElementById("property-light-ambient-green");
-            var elLightAmbientBlue = document.getElementById("property-light-ambient-blue");
-
-            var elLightSpecularRed = document.getElementById("property-light-specular-red");
-            var elLightSpecularGreen = document.getElementById("property-light-specular-green");
-            var elLightSpecularBlue = document.getElementById("property-light-specular-blue");
-
             var elLightConstantAttenuation = document.getElementById("property-light-constant-attenuation");
-            var elLightLinearAttenuation = document.getElementById("property-light-linear-attenuation");
-            var elLightQuadraticAttenuation = document.getElementById("property-light-quadratic-attenuation");
             var elLightExponent = document.getElementById("property-light-exponent");
             var elLightCutoff = document.getElementById("property-light-cutoff");
 
@@ -294,17 +284,7 @@
                                 elLightDiffuseGreen.value = properties.diffuseColor.green;
                                 elLightDiffuseBlue.value = properties.diffuseColor.blue;
 
-                                elLightAmbientRed.value = properties.ambientColor.red;
-                                elLightAmbientGreen.value = properties.ambientColor.green;
-                                elLightAmbientBlue.value = properties.ambientColor.blue;
-
-                                elLightSpecularRed.value = properties.specularColor.red;
-                                elLightSpecularGreen.value = properties.specularColor.green;
-                                elLightSpecularBlue.value = properties.specularColor.blue;
-
                                 elLightConstantAttenuation.value = properties.constantAttenuation;
-                                elLightLinearAttenuation.value = properties.linearAttenuation;
-                                elLightQuadraticAttenuation.value = properties.quadraticAttenuation;
                                 elLightExponent.value = properties.exponent;
                                 elLightCutoff.value = properties.cutoff;
                             }
@@ -381,21 +361,7 @@
             elLightDiffuseGreen.addEventListener('change', lightDiffuseChangeFunction);
             elLightDiffuseBlue.addEventListener('change', lightDiffuseChangeFunction);
 
-            var lightAmbientChangeFunction = createEmitColorPropertyUpdateFunction(
-                'ambientColor', elLightAmbientRed, elLightAmbientGreen, elLightAmbientBlue);
-            elLightAmbientRed.addEventListener('change', lightAmbientChangeFunction);
-            elLightAmbientGreen.addEventListener('change', lightAmbientChangeFunction);
-            elLightAmbientBlue.addEventListener('change', lightAmbientChangeFunction);
-
-            var lightSpecularChangeFunction = createEmitColorPropertyUpdateFunction(
-                'specularColor', elLightSpecularRed, elLightSpecularGreen, elLightSpecularBlue);
-            elLightSpecularRed.addEventListener('change', lightSpecularChangeFunction);
-            elLightSpecularGreen.addEventListener('change', lightSpecularChangeFunction);
-            elLightSpecularBlue.addEventListener('change', lightSpecularChangeFunction);
-
             elLightConstantAttenuation.addEventListener('change', createEmitNumberPropertyUpdateFunction('constantAttenuation'));
-            elLightLinearAttenuation.addEventListener('change', createEmitNumberPropertyUpdateFunction('linearAttenuation'));
-            elLightQuadraticAttenuation.addEventListener('change', createEmitNumberPropertyUpdateFunction('quadraticAttenuation'));
             elLightExponent.addEventListener('change', createEmitNumberPropertyUpdateFunction('exponent'));
             elLightCutoff.addEventListener('change', createEmitNumberPropertyUpdateFunction('cutoff'));
 
@@ -715,7 +681,7 @@
             </div>
         </div>
         <div class="light-section property">
-            <div class="label">Diffuse</div>
+            <div class="label">Color</div>
             <div class="value">
                 <div class="input-area">R <input class="coord" type='number' id="property-light-diffuse-red"></input></div>
                 <div class="input-area">G <input class="coord" type='number' id="property-light-diffuse-green"></input></div>
@@ -723,47 +689,19 @@
             </div>
         </div>
         <div class="light-section property">
-            <div class="label">Ambient</div>
-            <div class="value">
-                <div class="input-area">R <input class="coord" type='number' id="property-light-ambient-red"></input></div>
-                <div class="input-area">G <input class="coord" type='number' id="property-light-ambient-green"></input></div>
-                <div class="input-area">B <input class="coord" type='number' id="property-light-ambient-blue"></input></div>
-            </div>
-        </div>
-        <div class="light-section property">
-            <div class="label">Specular</div>
-            <div class="value">
-                <div class="input-area">R <input class="coord" type='number' id="property-light-specular-red"></input></div>
-                <div class="input-area">G <input class="coord" type='number' id="property-light-specular-green"></input></div>
-                <div class="input-area">B <input class="coord" type='number' id="property-light-specular-blue"></input></div>
-            </div>
-        </div>
-        <div class="light-section property">
-            <div class="label">Constant Attenuation</div>
+            <div class="label">Intensity</div>
             <div class="value">
                 <input class="coord" type='number' id="property-light-constant-attenuation"></input>
             </div>
         </div>
         <div class="light-section property">
-            <div class="label">Linear Attenuation</div>
-            <div class="value">
-                <input class="coord" type='number' id="property-light-linear-attenuation"></input>
-            </div>
-        </div>
-        <div class="light-section property">
-            <div class="label">Quadratic Attenuation</div>
-            <div class="value">
-                <input class="coord" type='number' id="property-light-quadratic-attenuation"></input>
-            </div>
-        </div>
-        <div class="light-section property">
-            <div class="label">Exponent</div>
+            <div class="label">Spot Light Exponent</div>
             <div class="value">
                 <input class="coord" type='number' id="property-light-exponent"></input>
             </div>
         </div>
         <div class="light-section property">
-            <div class="label">Cutoff (degrees)</div>
+            <div class="label">Spot Light Cutoff (degrees)</div>
             <div class="value">
                 <input class="coord" type='number' id="property-light-cutoff"></input>
             </div>

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -380,8 +380,7 @@ void Avatar::render(const glm::vec3& cameraPosition, RenderMode renderMode, bool
             foreach (const AvatarManager::LocalLight& light, DependencyManager::get<AvatarManager>()->getLocalLights()) {
                 glm::vec3 direction = orientation * light.direction;
                 DependencyManager::get<DeferredLightingEffect>()->addSpotLight(position - direction * distance,
-                    distance * 2.0f, glm::vec3(), light.color, light.color, 1.0f, 0.5f, 0.0f, direction,
-                    LIGHT_EXPONENT, LIGHT_CUTOFF);
+                    distance * 2.0f, light.color, 0.5f, orientation, LIGHT_EXPONENT, LIGHT_CUTOFF);
             }
         }
         

--- a/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
@@ -36,30 +36,18 @@ void RenderableLightEntityItem::render(RenderArgs* args) {
     float diffuseG = getDiffuseColor()[GREEN_INDEX] / MAX_COLOR;
     float diffuseB = getDiffuseColor()[BLUE_INDEX] / MAX_COLOR;
 
-    float ambientR = getAmbientColor()[RED_INDEX] / MAX_COLOR;
-    float ambientG = getAmbientColor()[GREEN_INDEX] / MAX_COLOR;
-    float ambientB = getAmbientColor()[BLUE_INDEX] / MAX_COLOR;
+    glm::vec3 color = glm::vec3(diffuseR, diffuseG, diffuseB);
 
-    float specularR = getSpecularColor()[RED_INDEX] / MAX_COLOR;
-    float specularG = getSpecularColor()[GREEN_INDEX] / MAX_COLOR;
-    float specularB = getSpecularColor()[BLUE_INDEX] / MAX_COLOR;
-
-    glm::vec3 ambient = glm::vec3(ambientR, ambientG, ambientB);
-    glm::vec3 diffuse = glm::vec3(diffuseR, diffuseG, diffuseB);
-    glm::vec3 specular = glm::vec3(specularR, specularG, specularB);
-    glm::vec3 direction = IDENTITY_FRONT * rotation;
     float intensity = getConstantAttenuation();
-    float linearAttenuation = getLinearAttenuation();
-    float quadraticAttenuation = getQuadraticAttenuation();
     float exponent = getExponent();
     float cutoff = glm::radians(getCutoff());
 
     if (_isSpotlight) {
-        DependencyManager::get<DeferredLightingEffect>()->addSpotLight(position, largestDiameter / 2.0f, 
-            diffuse, intensity, rotation, exponent, cutoff);
+        DependencyManager::get<DeferredLightingEffect>()->addSpotLight(position, largestDiameter / 2.0f,
+            color, intensity, rotation, exponent, cutoff);
     } else {
-        DependencyManager::get<DeferredLightingEffect>()->addPointLight(position, largestDiameter / 2.0f, 
-            diffuse, intensity);
+        DependencyManager::get<DeferredLightingEffect>()->addPointLight(position, largestDiameter / 2.0f,
+            color, intensity);
     }
 
 #ifdef WANT_DEBUG

--- a/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
@@ -48,7 +48,7 @@ void RenderableLightEntityItem::render(RenderArgs* args) {
     glm::vec3 diffuse = glm::vec3(diffuseR, diffuseG, diffuseB);
     glm::vec3 specular = glm::vec3(specularR, specularG, specularB);
     glm::vec3 direction = IDENTITY_FRONT * rotation;
-    float constantAttenuation = getConstantAttenuation();
+    float intensity = getConstantAttenuation();
     float linearAttenuation = getLinearAttenuation();
     float quadraticAttenuation = getQuadraticAttenuation();
     float exponent = getExponent();
@@ -56,11 +56,10 @@ void RenderableLightEntityItem::render(RenderArgs* args) {
 
     if (_isSpotlight) {
         DependencyManager::get<DeferredLightingEffect>()->addSpotLight(position, largestDiameter / 2.0f, 
-            ambient, diffuse, specular, constantAttenuation, linearAttenuation, quadraticAttenuation,
-            direction, exponent, cutoff);
+            diffuse, intensity, rotation, exponent, cutoff);
     } else {
         DependencyManager::get<DeferredLightingEffect>()->addPointLight(position, largestDiameter / 2.0f, 
-            ambient, diffuse, specular, constantAttenuation, linearAttenuation, quadraticAttenuation);
+            diffuse, intensity);
     }
 
 #ifdef WANT_DEBUG

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -126,15 +126,16 @@ void DeferredLightingEffect::renderSolidCone(float base, float height, int slice
     releaseSimpleProgram();
 }
 
-void DeferredLightingEffect::addPointLight(const glm::vec3& position, float radius, const glm::vec3& ambient,
-        const glm::vec3& diffuse, const glm::vec3& specular, float constantAttenuation,
-        float linearAttenuation, float quadraticAttenuation) {
-    addSpotLight(position, radius, ambient, diffuse, specular, constantAttenuation, linearAttenuation, quadraticAttenuation);    
+void DeferredLightingEffect::addPointLight(const glm::vec3& position, float radius, const glm::vec3& color,
+        float intensity) {
+    addSpotLight(position, radius, color, intensity);    
 }
 
-void DeferredLightingEffect::addSpotLight(const glm::vec3& position, float radius, const glm::vec3& ambient,
-        const glm::vec3& diffuse, const glm::vec3& specular, float constantAttenuation, float linearAttenuation,
-        float quadraticAttenuation, const glm::vec3& direction, float exponent, float cutoff) {
+// Remove: ambient, specular, *Attenuation, direction
+// Add: intensity, radius
+// Rename: diffuseColor -> color
+void DeferredLightingEffect::addSpotLight(const glm::vec3& position, float radius, const glm::vec3& color,
+    float intensity, const glm::quat& orientation, float exponent, float cutoff) {
     
     int lightID = _pointLights.size() + _spotLights.size() + _globalLights.size();
     if (lightID >= _allocatedLights.size()) {
@@ -144,8 +145,8 @@ void DeferredLightingEffect::addSpotLight(const glm::vec3& position, float radiu
 
     lp->setPosition(position);
     lp->setMaximumRadius(radius);
-    lp->setColor(diffuse);
-    lp->setIntensity(1.0f);
+    lp->setColor(color);
+    lp->setIntensity(intensity);
     //lp->setShowContour(quadraticAttenuation);
 
     if (exponent == 0.0f && cutoff == PI) {
@@ -153,7 +154,7 @@ void DeferredLightingEffect::addSpotLight(const glm::vec3& position, float radiu
         _pointLights.push_back(lightID);
         
     } else {
-        lp->setDirection(direction);
+        lp->setOrientation(orientation);
         lp->setSpotAngle(cutoff);
         lp->setSpotExponent(exponent);
         lp->setType(model::Light::SPOT);

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -131,9 +131,6 @@ void DeferredLightingEffect::addPointLight(const glm::vec3& position, float radi
     addSpotLight(position, radius, color, intensity);    
 }
 
-// Remove: ambient, specular, *Attenuation, direction
-// Add: intensity, radius
-// Rename: diffuseColor -> color
 void DeferredLightingEffect::addSpotLight(const glm::vec3& position, float radius, const glm::vec3& color,
     float intensity, const glm::quat& orientation, float exponent, float cutoff) {
     

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -57,15 +57,12 @@ public:
     void renderSolidCone(float base, float height, int slices, int stacks);
     
     /// Adds a point light to render for the current frame.
-    void addPointLight(const glm::vec3& position, float radius, const glm::vec3& ambient = glm::vec3(0.0f, 0.0f, 0.0f),
-        const glm::vec3& diffuse = glm::vec3(1.0f, 1.0f, 1.0f), const glm::vec3& specular = glm::vec3(1.0f, 1.0f, 1.0f),
-        float constantAttenuation = 1.0f, float linearAttenuation = 0.0f, float quadraticAttenuation = 0.0f);
+    void addPointLight(const glm::vec3& position, float radius, const glm::vec3& color = glm::vec3(0.0f, 0.0f, 0.0f),
+        float intensity = 0.5f);
         
     /// Adds a spot light to render for the current frame.
-    void addSpotLight(const glm::vec3& position, float radius, const glm::vec3& ambient = glm::vec3(0.0f, 0.0f, 0.0f),
-        const glm::vec3& diffuse = glm::vec3(1.0f, 1.0f, 1.0f), const glm::vec3& specular = glm::vec3(1.0f, 1.0f, 1.0f),
-        float constantAttenuation = 1.0f, float linearAttenuation = 0.0f, float quadraticAttenuation = 0.0f,
-        const glm::vec3& direction = glm::vec3(0.0f, 0.0f, -1.0f), float exponent = 0.0f, float cutoff = PI);
+    void addSpotLight(const glm::vec3& position, float radius, const glm::vec3& color = glm::vec3(1.0f, 1.0f, 1.0f),
+        float intensity = 0.5f, const glm::quat& orientation = glm::quat(), float exponent = 0.0f, float cutoff = PI);
     
     /// Adds an object to render after performing the deferred lighting for the current frame (e.g., a translucent object).
     void addPostLightingRenderable(PostLightingRenderable* renderable) { _postLightingRenderables.append(renderable); }


### PR DESCRIPTION
This is an intermediate update to move over to Sam's new light model, so that the new properties are accessible from editEntities.js.  Radius hasn't been added, but given its relation to dimensions I think there are still decisions to be made.

Updates:
  * Remove unused properties from the editEntities.js properties window (ambient color, specular color, and attenuations), and rename diffuseColor to color and consantAttenuation to intensity
  * Entity rotation/orientation is used in place of direction.
  * Update DeferredLightingEffect to use the new light properties in the method interfaces
  * Update RenderableLightEntity and Avatar to use the new DeferredLightingEffect interfaces, using constantAttenuation for intensity and diffuseColor for color.

Of particular note is the reuse of constantAttenuation for intensity - when updating the entities themselves, constantAttenuation will be renamed to intensity.  @ZappoMan Please let me know if there are any issues with this.