### PR TITLE
Some Stats cleanup and minor FPS improvements

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -773,9 +773,8 @@ void Application::paintGL() {
 
         {
             PerformanceTimer perfTimer("renderOverlay");
-            // PrioVR will only work if renderOverlay is called, calibration is connected to Application::renderingOverlay() 
-            _applicationOverlay.renderOverlay(true);
             if (Menu::getInstance()->isOptionChecked(MenuOption::UserInterface)) {
+                _applicationOverlay.renderOverlay(true);
                 _applicationOverlay.displayOverlayTexture();
             }
         }

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -453,7 +453,8 @@ Menu::Menu() {
 
     QMenu* timingMenu = developerMenu->addMenu("Timing and Stats");
     QMenu* perfTimerMenu = timingMenu->addMenu("Performance Timer");
-    addCheckableActionToQMenuAndActionHash(perfTimerMenu, MenuOption::DisplayTimingDetails, 0, true);
+    addCheckableActionToQMenuAndActionHash(perfTimerMenu, MenuOption::DisplayDebugTimingDetails, 0, false);
+    addCheckableActionToQMenuAndActionHash(perfTimerMenu, MenuOption::OnlyDisplayTopTen, 0, true);
     addCheckableActionToQMenuAndActionHash(perfTimerMenu, MenuOption::ExpandUpdateTiming, 0, false);
     addCheckableActionToQMenuAndActionHash(perfTimerMenu, MenuOption::ExpandMyAvatarTiming, 0, false);
     addCheckableActionToQMenuAndActionHash(perfTimerMenu, MenuOption::ExpandMyAvatarSimulateTiming, 0, false);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -150,7 +150,7 @@ namespace MenuOption {
     const QString DisplayModelTriangles = "Display Model Triangles";
     const QString DisplayModelElementChildProxies = "Display Model Element Children";
     const QString DisplayModelElementProxy = "Display Model Element Bounds";
-    const QString DisplayTimingDetails = "Display Timing Details";
+    const QString DisplayDebugTimingDetails = "Display Timing Details";
     const QString DontDoPrecisionPicking = "Don't Do Precision Picking";
     const QString DontFadeOnOctreeServerChanges = "Don't Fade In/Out on Octree Server Changes";
     const QString DontRenderEntitiesAsScene = "Don't Render Entities as Scene";
@@ -198,6 +198,7 @@ namespace MenuOption {
     const QString OctreeStats = "Voxel and Entity Statistics";
     const QString OffAxisProjection = "Off-Axis Projection";
     const QString OldVoxelCullingMode = "Old Voxel Culling Mode";
+    const QString OnlyDisplayTopTen = "Only Display Top Ten";
     const QString Pair = "Pair";
     const QString PipelineWarnings = "Log Render Pipeline Warnings";
     const QString Preferences = "Preferences...";


### PR DESCRIPTION
* cleans up the stats display which had gotten slightly broken with new text and changes to stats
* added an option to only display top 10 slowest functions in the performance stats display
* made performance stats display OFF by default
* fixed rendering of overlay when overlay was disabled - https://app.asana.com/0/search/28182611043532/27994384431321