### PR TITLE
Update Light to set direction when setting orientation

### DIFF
--- a/libraries/model/src/model/Light.cpp
+++ b/libraries/model/src/model/Light.cpp
@@ -44,6 +44,7 @@ void Light::setPosition(const Vec3& position) {
 }
 
 void Light::setOrientation(const glm::quat& orientation) {
+    setDirection(orientation * glm::vec3(0.0f, 0.0f, -1.0f));
     _transform.setRotation(orientation);
 }
 


### PR DESCRIPTION
@samcake This is a patch to make spot lights work correctly.  I'm not sure if we are dropping direction or not, so I left it (the Scene directional lights use it).