### PR TITLE
Hifi Interview Question: Updating the startup time print statement. -- Iris Cheung

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -503,6 +503,14 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
         loadScripts();
     }
     
+    // Now that the scripts have been loaded, print the time elapsed since the
+    // application was started.
+    if (_justStarted) {
+        float startupTime = (float)_applicationStartupTime.elapsed() / 1000.0;
+        _justStarted = false;
+        qDebug("Startup time: %4.2f seconds.", startupTime);
+    }
+    
     loadSettings();
     int SAVE_SETTINGS_INTERVAL = 10 * MSECS_PER_SECOND; // Let's save every seconds for now
     connect(&_settingsTimer, &QTimer::timeout, this, &Application::saveSettings);
@@ -663,12 +671,6 @@ void Application::initializeGL() {
     connect(idleTimer, SIGNAL(timeout()), SLOT(idle()));
     idleTimer->start(0);
     _idleLoopStdev.reset();
-
-    if (_justStarted) {
-        float startupTime = (float)_applicationStartupTime.elapsed() / 1000.0;
-        _justStarted = false;
-        qDebug("Startup time: %4.2f seconds.", startupTime);
-    }
 
     // update before the first render
     update(1.0f / _fps);


### PR DESCRIPTION
***  Do not merge this into master without reviewing. ***
*** This pull request was completed for the sake of evaluating me (Iris Cheung) for a software position. ***

Previously the startup-time being logged was measured from the top of the Application class's constructor to when the function Application::initializeGL() completes.

This duration does not capture the time it takes to load and render any entities that are loaded from js scripts at the start of the application.

This is a minor change to move the startup-time calculation to after the js scripts have been loaded to account for the time it takes to load the scripts.