### PR TITLE
make sure UserActivityLogger::close() waits for the pending log message to complete

### DIFF
--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -72,6 +72,8 @@ public:
     void requestProfile();
 
     DataServerAccountInfo& getAccountInfo() { return _accountInfo; }
+    
+    void waitForAllPendingReplies();
 
 public slots:
     void requestAccessToken(const QString& login, const QString& password);
@@ -93,6 +95,8 @@ signals:
     void loginFailed();
     void logoutComplete();
     void balanceChanged(qint64 newBalance);
+    void replyFinished();
+
 private slots:
     void processReply();
     void handleKeypairGenerationError();

--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -61,7 +61,7 @@ void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCall
         params.errorCallbackReceiver = this;
         params.errorCallbackMethod = "requestError";
     }
-    
+
     accountManager.authenticatedRequest(USER_ACTIVITY_URL,
                                         QNetworkAccessManager::PostOperation,
                                         params,
@@ -89,6 +89,8 @@ void UserActivityLogger::launch(QString applicationVersion) {
 void UserActivityLogger::close() {
     const QString ACTION_NAME = "close";
     logAction(ACTION_NAME, QJsonObject());
+    
+    AccountManager::getInstance().waitForAllPendingReplies();
 }
 
 void UserActivityLogger::changedDisplayName(QString displayName) {


### PR DESCRIPTION
The "close" activity wasn't always getting processed because it would send the request, but we wouldn't wait for the network reply to complete before exiting. This PR fixes that by adding a new waitForAllPendingReplies to AccountManager, and then to have UserActivityLogger call that on close.