### PR TITLE
fix for crash when deleting physical entity that departs the domain

### DIFF
--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -99,10 +99,11 @@ void EntitySimulation::sortEntitiesThatMoved() {
             _mortalEntities.remove(entity);
             _updateableEntities.remove(entity);
             removeEntityInternal(entity);
+            itemItr = _entitiesToBeSorted.erase(itemItr);
         } else {
             moveOperator.addEntityToMoveList(entity, newCube);
+            ++itemItr;
         }
-        ++itemItr;
     }
     if (moveOperator.hasMovingEntities()) {
         PerformanceTimer perfTimer("recurseTreeWithOperator");

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -616,7 +616,7 @@ void PhysicsEngine::setAvatarData(AvatarData *avatarData) {
                                                       glmToBullet(_avatarData->getPosition())));
 
     // XXX these values should be computed from the character model.
-    btScalar characterRadius = 0.3;
+    btScalar characterRadius = 0.3f;
     btScalar characterHeight = 1.75 - 2.0f * characterRadius;
     btScalar stepHeight = btScalar(0.35);
 


### PR DESCRIPTION
There is a crash in the PhysicsEngine that was triggered when deleting an entity that has left the domain bounds.  The problem was that after the EntityItem's deletion a dangling pointer to it was being left in EntitySimulation::_entitiesToBeDeleted long enough to be accessed by the PhysicsEngine before that list was cleared.