### PR TITLE
some cleanup of dead code related to timers

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -12,7 +12,6 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QEventLoop>
 #include <QtCore/QStandardPaths>
-#include <QtCore/QTimer>
 #include <QtNetwork/QNetworkDiskCache>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -37,7 +37,6 @@
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonValue>
 #include <QtCore/QThread>
-#include <QtCore/QTimer>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
 

--- a/interface/src/ui/BandwidthDialog.h
+++ b/interface/src/ui/BandwidthDialog.h
@@ -16,6 +16,7 @@
 #include <QLabel>
 #include <QFormLayout>
 #include <QVector>
+#include <QTimer>
 
 #include "Node.h"
 #include "BandwidthRecorder.h"

--- a/libraries/networking/src/BandwidthRecorder.h
+++ b/libraries/networking/src/BandwidthRecorder.h
@@ -16,7 +16,6 @@
 
 #include <QObject>
 #include <QElapsedTimer>
-#include <QTimer>
 #include "DependencyManager.h"
 #include "Node.h"
 #include "SimpleMovingAverage.h"

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -32,7 +32,6 @@ DomainHandler::DomainHandler(QObject* parent) :
     _iceServerSockAddr(),
     _icePeer(),
     _isConnected(false),
-    _handshakeTimer(NULL),
     _settingsObject(),
     _failedSettingsRequests(0)
 {
@@ -50,12 +49,6 @@ void DomainHandler::clearConnectionInfo() {
     }
     
     setIsConnected(false);
-    
-    if (_handshakeTimer) {
-        _handshakeTimer->stop();
-        delete _handshakeTimer;
-        _handshakeTimer = NULL;
-    }
 }
 
 void DomainHandler::clearSettings() {

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -100,7 +100,6 @@ private:
     HifiSockAddr _iceServerSockAddr;
     NetworkPeer _icePeer;
     bool _isConnected;
-    QTimer* _handshakeTimer;
     QJsonObject _settingsObject;
     int _failedSettingsRequests;
 };


### PR DESCRIPTION
NOTE: DomainHandler::_handshakeTimer is never set. So this is dead code to be cleaned up. I also found several places including QTimer that don't actually use QTimer.