### PR TITLE
fix crash on exit related to AvatarManager using TextureCach resources

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -612,7 +612,8 @@ Application::~Application() {
     
     // stop the glWidget frame timer so it doesn't call paintGL
     _glWidget->stopFrameTimer();
-    
+
+    DependencyManager::destroy<AvatarManager>();
     DependencyManager::destroy<AnimationCache>();
     DependencyManager::destroy<TextureCache>();
     DependencyManager::destroy<GeometryCache>();


### PR DESCRIPTION
pretty simple fix here. The AvatarManager would crash in cleaning up of MyAvatar on some shutdown cases. The problem was that MyAvatar would use TextureCache which was already deleted... so moving the AvatarManager to be destroyed before TextureCache fixes the problem.