### PR TITLE
Hide cursor at MainWindow level when in VRMode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2137,7 +2137,9 @@ void Application::updateCursor(float deltaTime) {
 }
 
 void Application::updateCursorVisibility() {
-    if (!_cursorVisible || Menu::getInstance()->isOptionChecked(MenuOption::EnableVRMode)) {
+    if (!_cursorVisible ||
+        Menu::getInstance()->isOptionChecked(MenuOption::EnableVRMode) ||
+        Menu::getInstance()->isOptionChecked(MenuOption::Enable3DTVMode)) {
         _window->setCursor(Qt::BlankCursor);
     } else {
         _window->unsetCursor();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2138,9 +2138,9 @@ void Application::updateCursor(float deltaTime) {
 
 void Application::updateCursorVisibility() {
     if (!_cursorVisible || Menu::getInstance()->isOptionChecked(MenuOption::EnableVRMode)) {
-        _glWidget->setCursor(Qt::BlankCursor);
+        _window->setCursor(Qt::BlankCursor);
     } else {
-        _glWidget->unsetCursor();
+        _window->unsetCursor();
     }
 }
 


### PR DESCRIPTION
Some Qt magic here, it turns out the cursor shape isn't applied when set on the QGLWidget.