### PR TITLE
DO NOT MERGE - QA for #20400 Name tags going through the head

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1013,7 +1013,7 @@ float Avatar::getSkeletonHeight() const {
 }
 
 float Avatar::getHeadHeight() const {
-    Extents extents = getHead()->getFaceModel().getBindExtents();
+    Extents extents = getHead()->getFaceModel().getMeshExtents();
     if (!extents.isEmpty()) {
         return extents.maximum.y - extents.minimum.y;
     }


### PR DESCRIPTION
Calculate head height based on model mesh rather than joints.
This fixes the problem of some head models having display names
rendering through them.