### PR TITLE
dont report deleteEntity warnings in client for delete messages coming back from server

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -236,21 +236,28 @@ void EntityTree::setSimulation(EntitySimulation* simulation) {
     _simulation = simulation;
 }
 
-void EntityTree::deleteEntity(const EntityItemID& entityID, bool force) {
+void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ignoreWarnings) {
     EntityTreeElement* containingElement = getContainingElement(entityID);
     if (!containingElement) {
-        qDebug() << "UNEXPECTED!!!!  EntityTree::deleteEntity() entityID doesn't exist!!! entityID=" << entityID;
+        if (!ignoreWarnings) {
+            qDebug() << "UNEXPECTED!!!!  EntityTree::deleteEntity() entityID doesn't exist!!! entityID=" << entityID;
+        }
         return;
     }
 
     EntityItem* existingEntity = containingElement->getEntityWithEntityItemID(entityID);
     if (!existingEntity) {
-        qDebug() << "UNEXPECTED!!!! don't call EntityTree::deleteEntity() on entity items that don't exist. entityID=" << entityID;
+        if (!ignoreWarnings) {
+            qDebug() << "UNEXPECTED!!!! don't call EntityTree::deleteEntity() on entity items that don't exist. "
+                        "entityID=" << entityID;
+        }
         return;
     }
 
     if (existingEntity->getLocked() && !force) {
-        qDebug() << "ERROR! EntityTree::deleteEntity() trying to delete locked entity. entityID=" << entityID;
+        if (!ignoreWarnings) {
+            qDebug() << "ERROR! EntityTree::deleteEntity() trying to delete locked entity. entityID=" << entityID;
+        }
         return;
     }
 
@@ -263,24 +270,31 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force) {
     _isDirty = true;
 }
 
-void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force) {
+void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool ignoreWarnings) {
     // NOTE: callers must lock the tree before using this method
     DeleteEntityOperator theOperator(this);
     foreach(const EntityItemID& entityID, entityIDs) {
         EntityTreeElement* containingElement = getContainingElement(entityID);
         if (!containingElement) {
-            qDebug() << "UNEXPECTED!!!!  EntityTree::deleteEntities() entityID doesn't exist!!! entityID=" << entityID;
+            if (!ignoreWarnings) {
+                qDebug() << "UNEXPECTED!!!!  EntityTree::deleteEntities() entityID doesn't exist!!! entityID=" << entityID;
+            }
             continue;
         }
 
         EntityItem* existingEntity = containingElement->getEntityWithEntityItemID(entityID);
         if (!existingEntity) {
-            qDebug() << "UNEXPECTED!!!! don't call EntityTree::deleteEntities() on entity items that don't exist. entityID=" << entityID;
+            if (!ignoreWarnings) {
+                qDebug() << "UNEXPECTED!!!! don't call EntityTree::deleteEntities() on entity items that don't exist. "
+                            "entityID=" << entityID;
+            }
             continue;
         }
 
         if (existingEntity->getLocked() && !force) {
-            qDebug() << "ERROR! EntityTree::deleteEntities() trying to delete locked entity. entityID=" << entityID;
+            if (!ignoreWarnings) {
+                qDebug() << "ERROR! EntityTree::deleteEntities() trying to delete locked entity. entityID=" << entityID;
+            }
             continue;
         }
 
@@ -849,10 +863,9 @@ int EntityTree::processEraseMessage(const QByteArray& dataByteArray, const Share
             EntityItemID entityItemID(entityID);
             entityItemIDsToDelete << entityItemID;
         }
-        deleteEntities(entityItemIDsToDelete);
+        deleteEntities(entityItemIDsToDelete, true, true);
     }
     unlock();
-    
     return processedBytes;
 }
 
@@ -889,7 +902,7 @@ int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, cons
             EntityItemID entityItemID(entityID);
             entityItemIDsToDelete << entityItemID;
         }
-        deleteEntities(entityItemIDsToDelete);
+        deleteEntities(entityItemIDsToDelete, true, true);
     }
     return processedBytes;
 }

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -92,8 +92,8 @@ public:
     // use this method if you have a pointer to the entity (avoid an extra entity lookup)
     bool updateEntity(EntityItem* entity, const EntityItemProperties& properties, bool allowLockChange);
 
-    void deleteEntity(const EntityItemID& entityID, bool force = false);
-    void deleteEntities(QSet<EntityItemID> entityIDs, bool force = false);
+    void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = false);
+    void deleteEntities(QSet<EntityItemID> entityIDs, bool force = false, bool ignoreWarnings = false);
     void removeEntityFromSimulation(EntityItem* entity);
 
     /// \param position point of query in world-frame (meters)


### PR DESCRIPTION
This PR relates to the issues described in WL 20333 - https://worklist.net/20333

There was a bug where the client would report delete warnings for entities that were already deleted locally when the server would send back the "deleted" informative message. We should consider these messages from the server to be authoritative and always delete and never warn.