### PR TITLE
Making nsight usage optional (still defaults to on)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ option(GET_GLM "Get GLM library automatically as external project" 1)
 option(GET_GVERB "Get Gverb library automatically as external project" 1)
 option(GET_SOXR "Get Soxr library automatically as external project" 1)
 option(GET_TBB "Get Threading Building Blocks library automatically as external project" 1)
+option(USE_NSIGHT "Attempt to find the nSight libraries" 1)
 
 if (WIN32)
   option(GET_GLEW "Get GLEW library automatically as external project" 1)

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -220,15 +220,17 @@ else (APPLE)
     find_package(GLEW REQUIRED)
     target_include_directories(${TARGET_NAME} PRIVATE ${GLEW_INCLUDE_DIRS})
 
-    target_link_libraries(${TARGET_NAME} ${GLEW_LIBRARIES} ${NSIGHT_LIBRARIES} wsock32.lib opengl32.lib Winmm.lib)
+    target_link_libraries(${TARGET_NAME} ${GLEW_LIBRARIES} wsock32.lib opengl32.lib Winmm.lib)
 
-    # try to find the Nsight package and add it to the build if we find it
-    find_package(NSIGHT)
-    if (NSIGHT_FOUND)
-      include_directories(${NSIGHT_INCLUDE_DIRS})
-      add_definitions(-DNSIGHT_FOUND)
-      target_link_libraries(${TARGET_NAME} "${NSIGHT_LIBRARIES}")
-    endif ()
+    if (USE_NSIGHT)
+      # try to find the Nsight package and add it to the build if we find it
+      find_package(NSIGHT)
+      if (NSIGHT_FOUND)
+        include_directories(${NSIGHT_INCLUDE_DIRS})
+        add_definitions(-DNSIGHT_FOUND)
+        target_link_libraries(${TARGET_NAME} "${NSIGHT_LIBRARIES}")
+      endif ()
+    endif()
 
   endif()
 endif (APPLE)

--- a/libraries/gpu/CMakeLists.txt
+++ b/libraries/gpu/CMakeLists.txt
@@ -19,13 +19,15 @@ elseif (WIN32)
 
   target_link_libraries(${TARGET_NAME} ${GLEW_LIBRARIES} opengl32.lib)
 
-  # try to find the Nsight package and add it to the build if we find it
-  find_package(NSIGHT)
-  if (NSIGHT_FOUND)
-    include_directories(${NSIGHT_INCLUDE_DIRS})
-    add_definitions(-DNSIGHT_FOUND)
-    target_link_libraries(${TARGET_NAME} "${NSIGHT_LIBRARIES}")
-  endif ()
+  if (USE_NSIGHT)
+    # try to find the Nsight package and add it to the build if we find it
+    find_package(NSIGHT)
+    if (NSIGHT_FOUND)
+      include_directories(${NSIGHT_INCLUDE_DIRS})
+      add_definitions(-DNSIGHT_FOUND)
+      target_link_libraries(${TARGET_NAME} "${NSIGHT_LIBRARIES}")
+    endif ()
+  endif()
 elseif (ANDROID)
   target_link_libraries(${TARGET_NAME} "-lGLESv3" "-lEGL")
 else ()


### PR DESCRIPTION
The nSight integration fails when I attempt to build on my machine.  Ultimately I'll need to fix it, but for now I need a mechanism to disable the integration at project configuration time.  