### PR TITLE
MVP Task - tweaks to automatic-LOD adjustments

### DIFF
--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -21,13 +21,16 @@ const float ADJUST_LOD_DOWN_FPS = 40.0;
 const float ADJUST_LOD_UP_FPS = 55.0;
 const float DEFAULT_ADJUST_AVATAR_LOD_DOWN_FPS = 30.0f;
 
-const quint64 ADJUST_LOD_DOWN_DELAY = 1000 * 1000 * 5;
+const quint64 ADJUST_LOD_DOWN_DELAY = 1000 * 1000 * 0.5; // Consider adjusting LOD down after half a second
 const quint64 ADJUST_LOD_UP_DELAY = ADJUST_LOD_DOWN_DELAY * 2;
 
 const float ADJUST_LOD_DOWN_BY = 0.9f;
 const float ADJUST_LOD_UP_BY = 1.1f;
 
-const float ADJUST_LOD_MIN_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE * 0.25f;
+// This controls how low the auto-adjust LOD will go a value of 1 means it will adjust to a point where you must be 0.25
+// meters away from an object of TREE_SCALE before you can see it (which is effectively completely blind). The default value
+// DEFAULT_OCTREE_SIZE_SCALE means you can be 400 meters away from a 1 meter object in order to see it (which is ~20:20 vision).
+const float ADJUST_LOD_MIN_SIZE_SCALE = 1.0f;
 const float ADJUST_LOD_MAX_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE;
 
 const float MINIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER = 0.1f;

--- a/libraries/octree/src/OctreeConstants.h
+++ b/libraries/octree/src/OctreeConstants.h
@@ -21,6 +21,8 @@ const int   TREE_SCALE = 16384; // ~10 miles.. This is the number of meters of t
 
 // This controls the LOD. Larger number will make smaller voxels visible at greater distance.
 const float DEFAULT_OCTREE_SIZE_SCALE = TREE_SCALE * 400.0f; 
+
+// This is used in the LOD Tools to translate between the size scale slider and the values used to set the OctreeSizeScale
 const float MAX_LOD_SIZE_MULTIPLIER = 2000.0f;
 
 const int NUMBER_OF_CHILDREN = 8;


### PR DESCRIPTION
@PhilipRosedale asked that we make the automatic LOD adjustment more aggressive about culling down objects if the LOD list below the minimum threshold. This PR effectively does that.

The primary knobs to turn in the LODManager are the ADJUST_LOD_MIN_SIZE_SCALE which controls how "low" the auto-adjust LOD will go. It used to be set to a lower bound of 5:20 vision, meaning you'd need to be .25 meters from a 1 meter object to see it. We've now made it go as low as 1:1638400 vision... e.g. really blind!

I've also adjusted the delay in the Auto-LOD tool... it used to wait 5 seconds before attempting to adjust the LOD, now it will only wait 0.5 seconds.

Testing this in Apartment on my lower-end mac, I get the behavior we expect. As I turn around and look at the most "expensive" parts of the scene when the FPS drops to ~5-10fps, we see parts of the model start to disappear until the FPS reaches ~55fps. Then if you turn around in the room to look at less expensive parts of the scene, if the FPS remains above 55fps, you'll start to see new elements of the scene pop in.