### PR TITLE
MVP Task - tweaks to automatic-LOD adjustments & Display warning when LOD is decreased

### DIFF
--- a/examples/defaultScripts.js
+++ b/examples/defaultScripts.js
@@ -18,3 +18,4 @@ Script.load("lobby.js");
 Script.load("notifications.js");
 Script.load("look.js");
 Script.load("users.js");
+Script.load("utilities/LODWarning.js");

--- a/examples/example/ui/LODManagerExample.js
+++ b/examples/example/ui/LODManagerExample.js
@@ -1,0 +1,16 @@
+
+LODManager.LODIncreased.connect(function() {
+    print("LOD has been increased. You can now see " 
+            + LODManager.getLODFeedbackText() 
+            + ", fps:" + LODManager.getFPSAverage()
+            + ", fast fps:" + LODManager.getFastFPSAverage()
+        );
+});
+
+LODManager.LODDecreased.connect(function() {
+    print("LOD has been decreased. You can now see " 
+            + LODManager.getLODFeedbackText() 
+            + ", fps:" + LODManager.getFPSAverage()
+            + ", fast fps:" + LODManager.getFastFPSAverage()
+        );
+});

--- a/examples/hmdDefaults.js
+++ b/examples/hmdDefaults.js
@@ -13,4 +13,5 @@ Script.load("progress.js");
 Script.load("lobby.js");
 Script.load("notifications.js");
 Script.load("controllers/oculus/goTo.js");
+Script.load("utilities/LODWarning.js");
 //Script.load("scripts.js");  // Not created yet

--- a/examples/utilities/LODWarning.js
+++ b/examples/utilities/LODWarning.js
@@ -1,3 +1,15 @@
+//  LODWarning.js
+//  examples
+//
+//  Created by Brad Hefta-Gaub on 3/17/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  This script will display a warning when the LOD is adjusted to do scene complexity.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
 var DISPLAY_WARNING_FOR = 3; // in seconds
 var DISTANCE_FROM_CAMERA = 2;
 var SHOW_LOD_UP_MESSAGE = false; // By default we only display the LOD message when reducing LOD

--- a/examples/utilities/LODWarning.js
+++ b/examples/utilities/LODWarning.js
@@ -1,0 +1,103 @@
+var DISPLAY_WARNING_FOR = 3; // in seconds
+var DISTANCE_FROM_CAMERA = 2;
+var SHOW_LOD_UP_MESSAGE = false; // By default we only display the LOD message when reducing LOD
+
+
+var warningIsVisible = false; // initially the warning is hidden
+var warningShownAt = 0;
+var billboardPosition = Vec3.sum(Camera.getPosition(), 
+                                    Vec3.multiply(DISTANCE_FROM_CAMERA, Quat.getFront(Camera.getOrientation())));
+                                    
+var warningOverlay = Overlays.addOverlay("text3d", {
+                    position: billboardPosition,
+                    dimensions: { x: 2, y: 1.25 },
+                    width: 2,
+                    height: 1.25,
+                    backgroundColor: { red: 0, green: 0, blue: 0 },
+                    color: { red: 255, green: 255, blue: 255},
+                    topMargin: 0.1,
+                    leftMargin: 0.1,
+                    lineHeight: 0.07,
+                    text: "",
+                    alpha: 0.5,
+                    backgroundAlpha: 0.7,
+                    isFacingAvatar: true,
+                    visible: warningIsVisible,
+                });
+
+// Handle moving the billboard to remain in front of the camera
+var billboardNeedsMoving = false;
+Script.update.connect(function() {
+
+    if (warningIsVisible) {
+        var bestBillboardPosition = Vec3.sum(Camera.getPosition(), 
+                                                Vec3.multiply(DISTANCE_FROM_CAMERA, Quat.getFront(Camera.getOrientation())));
+    
+        var MAX_DISTANCE = 0.5;
+        var CLOSE_ENOUGH = 0.01;
+        if (!billboardNeedsMoving && Vec3.distance(bestBillboardPosition, billboardPosition) > MAX_DISTANCE) {
+            billboardNeedsMoving = true;
+        }
+
+        if (billboardNeedsMoving && Vec3.distance(bestBillboardPosition, billboardPosition) <= CLOSE_ENOUGH) {
+            billboardNeedsMoving = false;
+        }
+    
+        if (billboardNeedsMoving) {
+            // slurp the billboard to the best location
+            moveVector = Vec3.multiply(0.05, Vec3.subtract(bestBillboardPosition, billboardPosition));
+            billboardPosition = Vec3.sum(billboardPosition, moveVector);
+            Overlays.editOverlay(warningOverlay, { position: billboardPosition });
+        }
+
+        var now = new Date();
+        var sinceWarningShown = now - warningShownAt;
+        if (sinceWarningShown > 1000 * DISPLAY_WARNING_FOR) {
+            warningIsVisible = false;
+            Overlays.editOverlay(warningOverlay, { visible: warningIsVisible });
+        }
+    }
+});
+
+LODManager.LODIncreased.connect(function() {
+    if (SHOW_LOD_UP_MESSAGE) {
+        // if the warning wasn't visible, then move it before showing it.
+        if (!warningIsVisible) {
+            billboardPosition = Vec3.sum(Camera.getPosition(), 
+                                                    Vec3.multiply(DISTANCE_FROM_CAMERA, Quat.getFront(Camera.getOrientation())));
+            Overlays.editOverlay(warningOverlay, { position: billboardPosition });
+        }
+
+        warningShownAt = new Date();
+        warningIsVisible = true;
+        warningText = "Level of detail has been increased. \n"
+                + "You can now see: \n" 
+                + LODManager.getLODFeedbackText();
+
+        Overlays.editOverlay(warningOverlay, { visible: warningIsVisible, text: warningText });
+    }
+});
+
+LODManager.LODDecreased.connect(function() {
+    // if the warning wasn't visible, then move it before showing it.
+    if (!warningIsVisible) {
+        billboardPosition = Vec3.sum(Camera.getPosition(), 
+                                                Vec3.multiply(DISTANCE_FROM_CAMERA, Quat.getFront(Camera.getOrientation())));
+        Overlays.editOverlay(warningOverlay, { position: billboardPosition });
+    }
+
+    warningShownAt = new Date();
+    warningIsVisible = true;
+    warningText = "\n"
+            + "Due to the complexity of the content, the \n"
+            + "level of detail has been decreased. \n"
+            + "You can now see: \n" 
+            + LODManager.getLODFeedbackText();
+
+    Overlays.editOverlay(warningOverlay, { visible: warningIsVisible, text: warningText });
+});
+
+
+Script.scriptEnding.connect(function() {
+    Overlays.deleteOverlay(warningOverlay);
+});

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3570,6 +3570,8 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
 
     scriptEngine->registerGlobalObject("UndoStack", &_undoStackScriptingInterface);
 
+    scriptEngine->registerGlobalObject("LODManager", DependencyManager::get<LODManager>().data());
+
     QScriptValue hmdInterface = scriptEngine->registerGlobalObject("HMD", &HMDScriptingInterface::getInstance());
     scriptEngine->registerFunction(hmdInterface, "getHUDLookAtPosition2D", HMDScriptingInterface::getHUDLookAtPosition2D, 0);
     scriptEngine->registerFunction(hmdInterface, "getHUDLookAtPosition3D", HMDScriptingInterface::getHUDLookAtPosition3D, 0);

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -75,7 +75,9 @@ void LODManager::autoAdjustLOD(float currentFPS) {
         changed = true;
         _lastAdjust = now;
         qDebug() << "adjusting LOD down... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
-        << "_octreeSizeScale=" << _octreeSizeScale;
+                    << "_octreeSizeScale=" << _octreeSizeScale;
+        
+        emit LODDecreased();
     }
     
     if (elapsed > ADJUST_LOD_UP_DELAY && _fpsAverage.getAverage() > ADJUST_LOD_UP_FPS
@@ -87,7 +89,9 @@ void LODManager::autoAdjustLOD(float currentFPS) {
         changed = true;
         _lastAdjust = now;
         qDebug() << "adjusting LOD up... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
-        << "_octreeSizeScale=" << _octreeSizeScale;
+                    << "_octreeSizeScale=" << _octreeSizeScale;
+
+        emit LODIncreased();
     }
     
     if (changed) {

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -21,13 +21,16 @@ const float ADJUST_LOD_DOWN_FPS = 40.0;
 const float ADJUST_LOD_UP_FPS = 55.0;
 const float DEFAULT_ADJUST_AVATAR_LOD_DOWN_FPS = 30.0f;
 
-const quint64 ADJUST_LOD_DOWN_DELAY = 1000 * 1000 * 5;
+const quint64 ADJUST_LOD_DOWN_DELAY = 1000 * 1000 * 0.5; // Consider adjusting LOD down after half a second
 const quint64 ADJUST_LOD_UP_DELAY = ADJUST_LOD_DOWN_DELAY * 2;
 
 const float ADJUST_LOD_DOWN_BY = 0.9f;
 const float ADJUST_LOD_UP_BY = 1.1f;
 
-const float ADJUST_LOD_MIN_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE * 0.25f;
+// This controls how low the auto-adjust LOD will go a value of 1 means it will adjust to a point where you must be 0.25
+// meters away from an object of TREE_SCALE before you can see it (which is effectively completely blind). The default value
+// DEFAULT_OCTREE_SIZE_SCALE means you can be 400 meters away from a 1 meter object in order to see it (which is ~20:20 vision).
+const float ADJUST_LOD_MIN_SIZE_SCALE = 1.0f;
 const float ADJUST_LOD_MAX_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE;
 
 const float MINIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER = 0.1f;

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -41,7 +41,8 @@ const int ONE_SECOND_OF_FRAMES = 60;
 const int FIVE_SECONDS_OF_FRAMES = 5 * ONE_SECOND_OF_FRAMES;
 
 
-class LODManager : public Dependency {
+class LODManager : public QObject, public Dependency {
+    Q_OBJECT
     SINGLETON_DEPENDENCY
     
 public:
@@ -55,20 +56,26 @@ public:
     float getAvatarLODDistanceMultiplier() const { return _avatarLODDistanceMultiplier; }
     
     // User Tweakable LOD Items
-    QString getLODFeedbackText();
-    void setOctreeSizeScale(float sizeScale);
-    float getOctreeSizeScale() const { return _octreeSizeScale; }
+    Q_INVOKABLE QString getLODFeedbackText();
+    Q_INVOKABLE void setOctreeSizeScale(float sizeScale);
+    Q_INVOKABLE float getOctreeSizeScale() const { return _octreeSizeScale; }
     
-    void setBoundaryLevelAdjust(int boundaryLevelAdjust);
-    int getBoundaryLevelAdjust() const { return _boundaryLevelAdjust; }
+    Q_INVOKABLE void setBoundaryLevelAdjust(int boundaryLevelAdjust);
+    Q_INVOKABLE int getBoundaryLevelAdjust() const { return _boundaryLevelAdjust; }
     
     void autoAdjustLOD(float currentFPS);
-    void resetLODAdjust();
+    Q_INVOKABLE void resetLODAdjust();
+    Q_INVOKABLE float getFPSAverage() const { return _fpsAverage.getAverage(); }
+    Q_INVOKABLE float getFastFPSAverage() const { return _fastFPSAverage.getAverage(); }
     
     bool shouldRenderMesh(float largestDimension, float distanceToCamera);
     
     void loadSettings();
     void saveSettings();
+    
+signals:
+    void LODIncreased();
+    void LODDecreased();
     
 private:
     LODManager() {}

--- a/libraries/octree/src/OctreeConstants.h
+++ b/libraries/octree/src/OctreeConstants.h
@@ -21,6 +21,8 @@ const int   TREE_SCALE = 16384; // ~10 miles.. This is the number of meters of t
 
 // This controls the LOD. Larger number will make smaller voxels visible at greater distance.
 const float DEFAULT_OCTREE_SIZE_SCALE = TREE_SCALE * 400.0f; 
+
+// This is used in the LOD Tools to translate between the size scale slider and the values used to set the OctreeSizeScale
 const float MAX_LOD_SIZE_MULTIPLIER = 2000.0f;
 
 const int NUMBER_OF_CHILDREN = 8;


### PR DESCRIPTION
This PR includes:
* Tweaks to the LOD adjustment knobs to make LOD adjustment more aggressive.
* Exposing the LODManager to the scripting interface to allow implementing support for progressive content as well as warnings for expensive content.
* LODWarning.js script will display a warning as an overlay when the LOD is adjusted downward.
* added LODWarning.js to default scripts

**More details:**

@PhilipRosedale asked that we make the automatic LOD adjustment more aggressive about culling down objects if the LOD list below the minimum threshold. This PR effectively does that.

The primary knobs to turn in the LODManager are the ADJUST_LOD_MIN_SIZE_SCALE which controls how "low" the auto-adjust LOD will go. It used to be set to a lower bound of 5:20 vision, meaning you'd need to be .25 meters from a 1 meter object to see it. We've now made it go as low as 1:1638400 vision... e.g. really blind!

I've also adjusted the delay in the Auto-LOD tool... it used to wait 5 seconds before attempting to adjust the LOD, now it will only wait 0.5 seconds.

Testing this in Apartment on my lower-end mac, I get the behavior we expect. As I turn around and look at the most "expensive" parts of the scene when the FPS drops to ~5-10fps, we see parts of the model start to disappear until the FPS reaches ~55fps. Then if you turn around in the room to look at less expensive parts of the scene, if the FPS remains above 55fps, you'll start to see new elements of the scene pop in.