### PR TITLE
Fix broken aspect ratio in mirror

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2795,11 +2795,12 @@ QImage Application::renderAvatarBillboard() {
     return image;
 }
 
-
+// FIXME, preprocessor guard this check to occur only in DEBUG builds
 static QThread * activeRenderingThread = nullptr;
 
 ViewFrustum* Application::getViewFrustum() {
     if (QThread::currentThread() == activeRenderingThread) {
+        // FIXME, should this be an assert?
         qWarning() << "Calling Application::getViewFrustum() from the active rendering thread, did you mean Application::getDisplayViewFrustum()?";
     }
     return &_viewFrustum;
@@ -2807,6 +2808,7 @@ ViewFrustum* Application::getViewFrustum() {
 
 ViewFrustum* Application::getDisplayViewFrustum() {
     if (QThread::currentThread() != activeRenderingThread) {
+        // FIXME, should this be an assert?
         qWarning() << "Calling Application::getDisplayViewFrustum() from outside the active rendering thread or outside rendering, did you mean Application::getViewFrustum()?";
     }
     return &_displayViewFrustum;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -174,7 +174,11 @@ public:
     bool isThrottleRendering() const { return _glWidget->isThrottleRendering(); }
 
     Camera* getCamera() { return &_myCamera; }
+    // Represents the current view frustum of the avatar.  
     ViewFrustum* getViewFrustum() { return &_viewFrustum; }
+    // Represents the view frustum of the current rendering pass, 
+    // which might be different from the viewFrustum, i.e. shadowmap 
+    // passes, mirror window passes, etc
     ViewFrustum* getDisplayViewFrustum() { return &_displayViewFrustum; }
     ViewFrustum* getShadowViewFrustum() { return &_shadowViewFrustum; }
     const OctreePacketProcessor& getOctreePacketProcessor() const { return _octreeProcessor; }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -175,11 +175,11 @@ public:
 
     Camera* getCamera() { return &_myCamera; }
     // Represents the current view frustum of the avatar.  
-    ViewFrustum* getViewFrustum() { return &_viewFrustum; }
+    ViewFrustum* getViewFrustum();
     // Represents the view frustum of the current rendering pass, 
     // which might be different from the viewFrustum, i.e. shadowmap 
     // passes, mirror window passes, etc
-    ViewFrustum* getDisplayViewFrustum() { return &_displayViewFrustum; }
+    ViewFrustum* getDisplayViewFrustum();
     ViewFrustum* getShadowViewFrustum() { return &_shadowViewFrustum; }
     const OctreePacketProcessor& getOctreePacketProcessor() const { return _octreeProcessor; }
     EntityTreeRenderer* getEntities() { return &_entities; }

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -338,7 +338,7 @@ void Avatar::render(const glm::vec3& cameraPosition, RenderMode renderMode, bool
     // simple frustum check
     float boundingRadius = getBillboardSize();
     ViewFrustum* frustum = (renderMode == Avatar::SHADOW_RENDER_MODE) ?
-        Application::getInstance()->getShadowViewFrustum() : Application::getInstance()->getViewFrustum();
+        Application::getInstance()->getShadowViewFrustum() : Application::getInstance()->getDisplayViewFrustum();
     if (frustum->sphereInFrustum(getPosition(), boundingRadius) == ViewFrustum::OUTSIDE) {
         return;
     }

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -122,7 +122,7 @@ void Overlays::renderWorld(bool drawFront, RenderArgs::RenderMode renderMode, Re
     float myAvatarScale = 1.0f;
     
     auto lodManager = DependencyManager::get<LODManager>();
-    RenderArgs args = { NULL, Application::getInstance()->getViewFrustum(),
+    RenderArgs args = { NULL, Application::getInstance()->getDisplayViewFrustum(),
                         lodManager->getOctreeSizeScale(),
                         lodManager->getBoundaryLevelAdjust(),
                         renderMode, renderSide,


### PR DESCRIPTION
This is a different approach to fixing the aspect ratio bug in the mirror window.  This one fixes it by having the avatar rendering code fetch the *correct* frustum for the current rendering, rather than relying on the mirror rendering code to update the primary application view frustum.  

This also adds some additional code that checks callers using `Application::getViewFrustum()` and `Application::getDisplayViewFrustum()` in an attempt to ensure they are calling the correct variant.  This code immediately discovered another location that was using the former where the latter should be used.  