### PR TITLE
Removing reported logspam from release builds

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2799,18 +2799,22 @@ QImage Application::renderAvatarBillboard() {
 static QThread * activeRenderingThread = nullptr;
 
 ViewFrustum* Application::getViewFrustum() {
+#ifdef DEBUG
     if (QThread::currentThread() == activeRenderingThread) {
         // FIXME, should this be an assert?
         qWarning() << "Calling Application::getViewFrustum() from the active rendering thread, did you mean Application::getDisplayViewFrustum()?";
     }
+#endif
     return &_viewFrustum;
 }
 
 ViewFrustum* Application::getDisplayViewFrustum() {
+#ifdef DEBUG
     if (QThread::currentThread() != activeRenderingThread) {
         // FIXME, should this be an assert?
         qWarning() << "Calling Application::getDisplayViewFrustum() from outside the active rendering thread or outside rendering, did you mean Application::getViewFrustum()?";
     }
+#endif
     return &_displayViewFrustum;
 }
 


### PR DESCRIPTION
Apparently some users are reporting enormous amounts of logspam caused by my new log warnings.  These are developer only warnings and should not appear in release mode.  This CR should resolve the issue.  