### PR TITLE
Removing unmatched QReadWriteLock::unlock() call

### DIFF
--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -342,7 +342,6 @@ void PhysicsEngine::stepSimulation() {
         }
 
         unlock();
-        _avatarData->unlock();
         _entityTree->unlock();
     
         computeCollisionEvents();


### PR DESCRIPTION
Having this was generating a FATAL message in my log and causing interface to lock up on start.  