### PR TITLE
MVP Task: Support for Drag/Drop link avatars

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3680,19 +3680,16 @@ bool Application::askToSetAvatarUrl(const QString& url) {
 
     if (msgBox.clickedButton() == headButton) {
         qDebug() << "Chose to use for head: " << url;
-        //MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
         _myAvatar->setFaceModelURL(url);
         UserActivityLogger::getInstance().changedModel("head", url);
         _myAvatar->sendIdentityPacket();
     } else if (msgBox.clickedButton() == bodyButton) {
         qDebug() << "Chose to use for body: " << url;
-        //MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
         _myAvatar->setSkeletonModelURL(url);
         UserActivityLogger::getInstance().changedModel("skeleton", url);
         _myAvatar->sendIdentityPacket();
     } else if (msgBox.clickedButton() == bodyAndHeadButton) {
         qDebug() << "Chose to use for body + head: " << url;
-        //MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
         _myAvatar->setFaceModelURL(QString());
         _myAvatar->setSkeletonModelURL(url);
         UserActivityLogger::getInstance().changedModel("skeleton", url);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3595,7 +3595,6 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
 
 void Application::initializeAcceptedFiles() {
     if (_acceptedExtensions.size() == 0) {
-        qDebug() << "Application::initializeAcceptedFiles()";
         _acceptedExtensions[SNAPSHOT_EXTENSION] = &Application::acceptSnapshot;
         _acceptedExtensions[SVO_EXTENSION] = &Application::importSVOFromURL;
         _acceptedExtensions[JS_EXTENSION] = &Application::askToLoadScript;
@@ -3604,7 +3603,6 @@ void Application::initializeAcceptedFiles() {
 }
 
 bool Application::canAcceptURL(const QString& urlString) {
-    qDebug() << "Application::canAcceptURL() urlString:" << urlString;
     initializeAcceptedFiles();
     
     QUrl url(urlString);
@@ -3623,7 +3621,6 @@ bool Application::canAcceptURL(const QString& urlString) {
 }
 
 bool Application::acceptURL(const QString& urlString) {
-    qDebug() << "Application::acceptURL() urlString:" << urlString;
     initializeAcceptedFiles();
     
     if (urlString.startsWith(HIFI_URL_SCHEME)) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3706,6 +3706,7 @@ bool Application::askToLoadScript(const QString& scriptFilenameOrURL) {
     } else {
         qDebug() << "Declined to run the script: " << scriptFilenameOrURL;
     }
+    return true;
 }
 
 ScriptEngine* Application::loadScript(const QString& scriptFilename, bool isUserLoaded,

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -96,6 +96,7 @@ static const float NODE_KILLED_BLUE  = 0.0f;
 static const QString SNAPSHOT_EXTENSION  = ".jpg";
 static const QString SVO_EXTENSION  = ".svo";
 static const QString JS_EXTENSION  = ".js";
+static const QString FST_EXTENSION  = ".fst";
 
 static const float BILLBOARD_FIELD_OF_VIEW = 30.0f; // degrees
 static const float BILLBOARD_DISTANCE = 5.56f;       // meters
@@ -341,6 +342,7 @@ public slots:
     void loadDialog();
     void loadScriptURLDialog();
     void toggleLogDialog();
+    void askToSetAvatarUrl(const QString& url);
     void askToLoadScript(const QString& scriptFilenameOrURL);
     ScriptEngine* loadScript(const QString& scriptFilename = QString(), bool isUserLoaded = true, 
         bool loadScriptFromEditor = false, bool activateMainWindow = false);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -128,6 +128,8 @@ class Application;
 #endif
 #define qApp (static_cast<Application*>(QCoreApplication::instance()))
 
+typedef bool (Application::* AcceptURLMethod)(const QString &);
+
 class Application : public QApplication, public AbstractViewStateInterface, AbstractScriptingServicesInterface {
     Q_OBJECT
 
@@ -222,7 +224,7 @@ public:
     float getFieldOfView() { return _fieldOfView.get(); }
     void setFieldOfView(float fov) { _fieldOfView.set(fov); }
 
-    void importSVOFromURL(QUrl url);
+    bool importSVOFromURL(const QString& urlString);
 
     NodeToOctreeSceneStats* getOcteeSceneStats() { return &_octreeServerSceneStats; }
     void lockOctreeSceneStats() { _octreeSceneStatsLock.lockForRead(); }
@@ -307,6 +309,10 @@ public:
     
     QString getScriptsLocation();
     void setScriptsLocation(const QString& scriptsLocation);
+    
+    void initializeAcceptedFiles();
+    bool canAcceptURL(const QString& url);
+    bool acceptURL(const QString& url);
 
 signals:
 
@@ -342,8 +348,8 @@ public slots:
     void loadDialog();
     void loadScriptURLDialog();
     void toggleLogDialog();
-    void askToSetAvatarUrl(const QString& url);
-    void askToLoadScript(const QString& scriptFilenameOrURL);
+    bool askToSetAvatarUrl(const QString& url);
+    bool askToLoadScript(const QString& scriptFilenameOrURL);
     ScriptEngine* loadScript(const QString& scriptFilename = QString(), bool isUserLoaded = true, 
         bool loadScriptFromEditor = false, bool activateMainWindow = false);
     void scriptFinished(const QString& scriptName);
@@ -597,6 +603,8 @@ private:
 
     QWidget* _fullscreenMenuWidget = new QWidget();
     int _menuBarHeight;
+    
+    QHash<QString, AcceptURLMethod> _acceptedExtensions;
 };
 
 #endif // hifi_Application_h

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -348,6 +348,7 @@ public slots:
     void loadDialog();
     void loadScriptURLDialog();
     void toggleLogDialog();
+    bool acceptSnapshot(const QString& urlString);
     bool askToSetAvatarUrl(const QString& url);
     bool askToLoadScript(const QString& scriptFilenameOrURL);
     ScriptEngine* loadScript(const QString& scriptFilename = QString(), bool isUserLoaded = true, 

--- a/interface/src/GLCanvas.cpp
+++ b/interface/src/GLCanvas.cpp
@@ -170,9 +170,8 @@ void GLCanvas::wheelEvent(QWheelEvent* event) {
 void GLCanvas::dragEnterEvent(QDragEnterEvent* event) {
     const QMimeData* mimeData = event->mimeData();
     foreach (QUrl url, mimeData->urls()) {
-        auto lower = url.path().toLower();
         auto urlString = url.toString();
-        if (lower.endsWith(SNAPSHOT_EXTENSION) || Application::getInstance()->canAcceptURL(urlString)) {
+        if (Application::getInstance()->canAcceptURL(urlString)) {
             event->acceptProposedAction();
             break;
         }

--- a/interface/src/GLCanvas.cpp
+++ b/interface/src/GLCanvas.cpp
@@ -171,8 +171,8 @@ void GLCanvas::dragEnterEvent(QDragEnterEvent* event) {
     const QMimeData* mimeData = event->mimeData();
     foreach (QUrl url, mimeData->urls()) {
         auto lower = url.path().toLower();
-        if (lower.endsWith(SNAPSHOT_EXTENSION) || lower.endsWith(SVO_EXTENSION)
-                 || lower.endsWith(JS_EXTENSION)  || lower.endsWith(FST_EXTENSION)) {
+        auto urlString = url.toString();
+        if (lower.endsWith(SNAPSHOT_EXTENSION) || Application::getInstance()->canAcceptURL(urlString)) {
             event->acceptProposedAction();
             break;
         }

--- a/interface/src/GLCanvas.cpp
+++ b/interface/src/GLCanvas.cpp
@@ -171,7 +171,8 @@ void GLCanvas::dragEnterEvent(QDragEnterEvent* event) {
     const QMimeData* mimeData = event->mimeData();
     foreach (QUrl url, mimeData->urls()) {
         auto lower = url.path().toLower();
-        if (lower.endsWith(SNAPSHOT_EXTENSION) || lower.endsWith(SVO_EXTENSION) || lower.endsWith(JS_EXTENSION)) {
+        if (lower.endsWith(SNAPSHOT_EXTENSION) || lower.endsWith(SVO_EXTENSION)
+                 || lower.endsWith(JS_EXTENSION)  || lower.endsWith(FST_EXTENSION)) {
             event->acceptProposedAction();
             break;
         }

--- a/interface/src/ui/DataWebPage.cpp
+++ b/interface/src/ui/DataWebPage.cpp
@@ -32,20 +32,13 @@ void DataWebPage::javaScriptConsoleMessage(const QString& message, int lineNumbe
 }
 
 bool DataWebPage::acceptNavigationRequest(QWebFrame* frame, const QNetworkRequest& request, QWebPage::NavigationType type) {
-    if (!request.url().toString().startsWith(HIFI_URL_SCHEME)) {
-        QString urlString = request.url().toString();
-        if (Application::getInstance()->canAcceptURL(urlString)) {
-            if (Application::getInstance()->acceptURL(urlString)) {
-                return false; // we handled it, so QWebPage doesn't need to handle it
-            }
+    QString urlString = request.url().toString();
+    if (Application::getInstance()->canAcceptURL(urlString)) {
+        if (Application::getInstance()->acceptURL(urlString)) {
+            return false; // we handled it, so QWebPage doesn't need to handle it
         }
-        return true;
-    } else {
-        // this is a hifi URL - have the AddressManager handle it
-        QMetaObject::invokeMethod(DependencyManager::get<AddressManager>().data(), "handleLookupString",
-                                  Qt::AutoConnection, Q_ARG(const QString&, request.url().toString()));
-        return false;
     }
+    return true;
 }
 
 QString DataWebPage::userAgentForUrl(const QUrl& url) const {

--- a/interface/src/ui/DataWebPage.cpp
+++ b/interface/src/ui/DataWebPage.cpp
@@ -32,13 +32,16 @@ void DataWebPage::javaScriptConsoleMessage(const QString& message, int lineNumbe
 }
 
 bool DataWebPage::acceptNavigationRequest(QWebFrame* frame, const QNetworkRequest& request, QWebPage::NavigationType type) {
-
     if (!request.url().toString().startsWith(HIFI_URL_SCHEME)) {
         if (request.url().path().toLower().endsWith(SVO_EXTENSION)) {
             Application::getInstance()->importSVOFromURL(request.url());
             return false;
         } else if (request.url().path().toLower().endsWith(JS_EXTENSION)) {
             Application::getInstance()->askToLoadScript(request.url().toString());
+            return false;
+        } else if (request.url().path().toLower().endsWith(FST_EXTENSION)) {
+        
+            Application::getInstance()->askToSetAvatarUrl(request.url().toString());
             return false;
         }
         return true;

--- a/interface/src/ui/DataWebPage.cpp
+++ b/interface/src/ui/DataWebPage.cpp
@@ -33,16 +33,11 @@ void DataWebPage::javaScriptConsoleMessage(const QString& message, int lineNumbe
 
 bool DataWebPage::acceptNavigationRequest(QWebFrame* frame, const QNetworkRequest& request, QWebPage::NavigationType type) {
     if (!request.url().toString().startsWith(HIFI_URL_SCHEME)) {
-        if (request.url().path().toLower().endsWith(SVO_EXTENSION)) {
-            Application::getInstance()->importSVOFromURL(request.url());
-            return false;
-        } else if (request.url().path().toLower().endsWith(JS_EXTENSION)) {
-            Application::getInstance()->askToLoadScript(request.url().toString());
-            return false;
-        } else if (request.url().path().toLower().endsWith(FST_EXTENSION)) {
-        
-            Application::getInstance()->askToSetAvatarUrl(request.url().toString());
-            return false;
+        QString urlString = request.url().toString();
+        if (Application::getInstance()->canAcceptURL(urlString)) {
+            if (Application::getInstance()->acceptURL(urlString)) {
+                return false; // we handled it, so QWebPage doesn't need to handle it
+            }
         }
         return true;
     } else {


### PR DESCRIPTION
* Implements support for dragging/droping or navigating to links to FST files to set the avatar model.
* Also DRYs up the code for dragging/dropping and opening of all file types.
* As a side effect we get the feature of being able to navigate to snapshot links in web forms as well. You used to only be able to drag from the OS file explorer to navigate to snapshots.