### PR TITLE
Tweaks to the LOD UI

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1969,7 +1969,7 @@ bool Application::isLookingAtMyAvatar(Avatar* avatar) {
 void Application::updateLOD() {
     PerformanceTimer perfTimer("LOD");
     // adjust it unless we were asked to disable this feature, or if we're currently in throttleRendering mode
-    if (!Menu::getInstance()->isOptionChecked(MenuOption::DisableAutoAdjustLOD) && !isThrottleRendering()) {
+    if (!isThrottleRendering()) {
         DependencyManager::get<LODManager>()->autoAdjustLOD(_fps);
     } else {
         DependencyManager::get<LODManager>()->resetLODAdjust();

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -17,13 +17,32 @@
 
 #include "LODManager.h"
 
-Setting::Handle<bool> automaticAvatarLOD("automaticAvatarLOD", true);
-Setting::Handle<float> avatarLODDecreaseFPS("avatarLODDecreaseFPS", DEFAULT_ADJUST_AVATAR_LOD_DOWN_FPS);
-Setting::Handle<float> avatarLODIncreaseFPS("avatarLODIncreaseFPS",  ADJUST_LOD_UP_FPS);
+Setting::Handle<bool> automaticLODAdjust("automaticLODAdjust", true);
+Setting::Handle<float> desktopLODDecreaseFPS("desktopLODDecreaseFPS", DEFAULT_DESKTOP_LOD_DOWN_FPS);
+Setting::Handle<float> desktopLODIncreaseFPS("desktopLODIncreaseFPS",  DEFAULT_DESKTOP_LOD_UP_FPS);
+Setting::Handle<float> hmdLODDecreaseFPS("hmdLODDecreaseFPS", DEFAULT_HMD_LOD_DOWN_FPS);
+Setting::Handle<float> hmdLODIncreaseFPS("hmdLODIncreaseFPS",  DEFAULT_HMD_LOD_UP_FPS);
+
+
 Setting::Handle<float> avatarLODDistanceMultiplier("avatarLODDistanceMultiplier",
                                                            DEFAULT_AVATAR_LOD_DISTANCE_MULTIPLIER);
 Setting::Handle<int> boundaryLevelAdjust("boundaryLevelAdjust", 0);
 Setting::Handle<float> octreeSizeScale("octreeSizeScale", DEFAULT_OCTREE_SIZE_SCALE);
+
+
+float LODManager::getLODDecreaseFPS() {
+    if (Application::getInstance()->isHMDMode()) {
+        return getHMDLODDecreaseFPS();
+    }
+    return getDesktopLODDecreaseFPS();
+}
+
+float LODManager::getLODIncreaseFPS() {
+    if (Application::getInstance()->isHMDMode()) {
+        return getHMDLODIncreaseFPS();
+    }
+    return getDesktopLODIncreaseFPS();
+}
 
 
 void LODManager::autoAdjustLOD(float currentFPS) {
@@ -39,66 +58,93 @@ void LODManager::autoAdjustLOD(float currentFPS) {
     _fastFPSAverage.updateAverage(currentFPS);
     
     quint64 now = usecTimestampNow();
-    
-    const quint64 ADJUST_AVATAR_LOD_DOWN_DELAY = 1000 * 1000;
-    if (_automaticAvatarLOD) {
-        if (_fastFPSAverage.getAverage() < _avatarLODDecreaseFPS) {
-            if (now - _lastAvatarDetailDrop > ADJUST_AVATAR_LOD_DOWN_DELAY) {
-                // attempt to lower the detail in proportion to the fps difference
-                float targetFps = (_avatarLODDecreaseFPS + _avatarLODIncreaseFPS) * 0.5f;
-                float averageFps = _fastFPSAverage.getAverage();
-                const float MAXIMUM_MULTIPLIER_SCALE = 2.0f;
-                _avatarLODDistanceMultiplier = qMin(MAXIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER, _avatarLODDistanceMultiplier *
-                                                    (averageFps < EPSILON ? MAXIMUM_MULTIPLIER_SCALE :
-                                                     qMin(MAXIMUM_MULTIPLIER_SCALE, targetFps / averageFps)));
-                _lastAvatarDetailDrop = now;
-            }
-        } else if (_fastFPSAverage.getAverage() > _avatarLODIncreaseFPS) {
-            // let the detail level creep slowly upwards
-            const float DISTANCE_DECREASE_RATE = 0.05f;
-            _avatarLODDistanceMultiplier = qMax(MINIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER,
-                                                _avatarLODDistanceMultiplier - DISTANCE_DECREASE_RATE);
-        }
-    }
-    
+
     bool changed = false;
+    bool octreeChanged = false;
     quint64 elapsed = now - _lastAdjust;
     
-    if (elapsed > ADJUST_LOD_DOWN_DELAY && _fpsAverage.getAverage() < ADJUST_LOD_DOWN_FPS
-        && _octreeSizeScale > ADJUST_LOD_MIN_SIZE_SCALE) {
-        
-        _octreeSizeScale *= ADJUST_LOD_DOWN_BY;
-        
-        if (_octreeSizeScale < ADJUST_LOD_MIN_SIZE_SCALE) {
-            _octreeSizeScale = ADJUST_LOD_MIN_SIZE_SCALE;
-        }
-        changed = true;
-        _lastAdjust = now;
-        qDebug() << "adjusting LOD down... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
-                    << "_octreeSizeScale=" << _octreeSizeScale;
-        
-        emit LODDecreased();
-    }
-    
-    if (elapsed > ADJUST_LOD_UP_DELAY && _fpsAverage.getAverage() > ADJUST_LOD_UP_FPS
-        && _octreeSizeScale < ADJUST_LOD_MAX_SIZE_SCALE) {
-        _octreeSizeScale *= ADJUST_LOD_UP_BY;
-        if (_octreeSizeScale > ADJUST_LOD_MAX_SIZE_SCALE) {
-            _octreeSizeScale = ADJUST_LOD_MAX_SIZE_SCALE;
-        }
-        changed = true;
-        _lastAdjust = now;
-        qDebug() << "adjusting LOD up... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
-                    << "_octreeSizeScale=" << _octreeSizeScale;
+    if (_automaticLODAdjust) {
+        // LOD Downward adjustment    
+        if (elapsed > ADJUST_LOD_DOWN_DELAY && _fpsAverage.getAverage() < getLODDecreaseFPS()) {
 
-        emit LODIncreased();
-    }
+            // Avatars... attempt to lower the detail in proportion to the fps difference
+            float targetFps = (getLODDecreaseFPS() + getLODIncreaseFPS()) * 0.5f;
+            float averageFps = _fastFPSAverage.getAverage();
+            const float MAXIMUM_MULTIPLIER_SCALE = 2.0f;
+            float oldAvatarLODDistanceMultiplier = _avatarLODDistanceMultiplier;
+            _avatarLODDistanceMultiplier = qMin(MAXIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER, _avatarLODDistanceMultiplier *
+                                                (averageFps < EPSILON ? MAXIMUM_MULTIPLIER_SCALE :
+                                                 qMin(MAXIMUM_MULTIPLIER_SCALE, targetFps / averageFps)));
+        
+            if (oldAvatarLODDistanceMultiplier != _avatarLODDistanceMultiplier) {
+                qDebug() << "adjusting LOD down... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
+                            << "_avatarLODDistanceMultiplier=" << _avatarLODDistanceMultiplier;
+                changed = true;
+            }
+
+            // Octree items... stepwise adjustment
+            if (_octreeSizeScale > ADJUST_LOD_MIN_SIZE_SCALE) {
+                _octreeSizeScale *= ADJUST_LOD_DOWN_BY;
+                if (_octreeSizeScale < ADJUST_LOD_MIN_SIZE_SCALE) {
+                    _octreeSizeScale = ADJUST_LOD_MIN_SIZE_SCALE;
+                }
+                octreeChanged = changed = true;
+            }
+
+            if (changed) {        
+                _lastAdjust = now;
+                qDebug() << "adjusting LOD down... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
+                            << "_octreeSizeScale=" << _octreeSizeScale;
+        
+                emit LODDecreased();
+            }
+        }
     
-    if (changed) {
-        _shouldRenderTableNeedsRebuilding = true;
-        auto lodToolsDialog = DependencyManager::get<DialogsManager>()->getLodToolsDialog();
-        if (lodToolsDialog) {
-            lodToolsDialog->reloadSliders();
+        // LOD Upward adjustment
+        if (elapsed > ADJUST_LOD_UP_DELAY && _fpsAverage.getAverage() > getLODIncreaseFPS()) {
+
+            // Avatars... let the detail level creep slowly upwards
+            if (_avatarLODDistanceMultiplier < MAXIMUM_AUTO_ADJUST_AVATAR_LOD_DISTANCE_MULTIPLIER) {
+                const float DISTANCE_DECREASE_RATE = 0.05f;
+                float oldAvatarLODDistanceMultiplier = _avatarLODDistanceMultiplier;
+                _avatarLODDistanceMultiplier = qMax(MINIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER,
+                                                    _avatarLODDistanceMultiplier - DISTANCE_DECREASE_RATE);
+                                                    
+                if (oldAvatarLODDistanceMultiplier != _avatarLODDistanceMultiplier) {
+                    qDebug() << "adjusting LOD up... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
+                                << "_avatarLODDistanceMultiplier=" << _avatarLODDistanceMultiplier;
+                    changed = true;
+                }
+            }
+
+            // Octee items... stepwise adjustment
+            if (_octreeSizeScale < ADJUST_LOD_MAX_SIZE_SCALE) {
+                if (_octreeSizeScale < ADJUST_LOD_MIN_SIZE_SCALE) {
+                    _octreeSizeScale = ADJUST_LOD_MIN_SIZE_SCALE;
+                } else {
+                    _octreeSizeScale *= ADJUST_LOD_UP_BY;
+                }
+                if (_octreeSizeScale > ADJUST_LOD_MAX_SIZE_SCALE) {
+                    _octreeSizeScale = ADJUST_LOD_MAX_SIZE_SCALE;
+                }
+                octreeChanged = changed = true;
+            }
+        
+            if (changed) {
+                _lastAdjust = now;
+                qDebug() << "adjusting LOD up... average fps for last approximately 5 seconds=" << _fpsAverage.getAverage()
+                            << "_octreeSizeScale=" << _octreeSizeScale;
+
+                emit LODIncreased();
+            }
+        }
+    
+        if (changed) {
+            _shouldRenderTableNeedsRebuilding = true;
+            auto lodToolsDialog = DependencyManager::get<DialogsManager>()->getLodToolsDialog();
+            if (lodToolsDialog) {
+                lodToolsDialog->reloadSliders();
+            }
         }
     }
 }
@@ -106,7 +152,7 @@ void LODManager::autoAdjustLOD(float currentFPS) {
 void LODManager::resetLODAdjust() {
     _fpsAverage.reset();
     _fastFPSAverage.reset();
-    _lastAvatarDetailDrop = _lastAdjust = usecTimestampNow();
+    _lastAdjust = usecTimestampNow();
 }
 
 QString LODManager::getLODFeedbackText() {
@@ -116,29 +162,33 @@ QString LODManager::getLODFeedbackText() {
     
     switch (boundaryLevelAdjust) {
         case 0: {
-            granularityFeedback = QString("at standard granularity.");
+            granularityFeedback = QString(".");
         } break;
         case 1: {
-            granularityFeedback = QString("at half of standard granularity.");
+            granularityFeedback = QString(" at half of standard granularity.");
         } break;
         case 2: {
-            granularityFeedback = QString("at a third of standard granularity.");
+            granularityFeedback = QString(" at a third of standard granularity.");
         } break;
         default: {
-            granularityFeedback = QString("at 1/%1th of standard granularity.").arg(boundaryLevelAdjust + 1);
+            granularityFeedback = QString(" at 1/%1th of standard granularity.").arg(boundaryLevelAdjust + 1);
         } break;
     }
     
     // distance feedback
     float octreeSizeScale = getOctreeSizeScale();
     float relativeToDefault = octreeSizeScale / DEFAULT_OCTREE_SIZE_SCALE;
+    int relativeToTwentyTwenty = 20 / relativeToDefault;
+
     QString result;
     if (relativeToDefault > 1.01) {
-        result = QString("%1 further %2").arg(relativeToDefault,8,'f',2).arg(granularityFeedback);
+        result = QString("20:%1 or %2 times further than average vision%3").arg(relativeToTwentyTwenty).arg(relativeToDefault,0,'f',2).arg(granularityFeedback);
     } else if (relativeToDefault > 0.99) {
-        result = QString("the default distance %1").arg(granularityFeedback);
+        result = QString("20:20 or the default distance for average vision%1").arg(granularityFeedback);
+    } else if (relativeToDefault > 0.01) {
+        result = QString("20:%1 or %2 of default distance for average vision%3").arg(relativeToTwentyTwenty).arg(relativeToDefault,0,'f',3).arg(granularityFeedback);
     } else {
-        result = QString("%1 of default %2").arg(relativeToDefault,8,'f',3).arg(granularityFeedback);
+        result = QString("%2 of default distance for average vision%3").arg(relativeToDefault,0,'f',3).arg(granularityFeedback);
     }
     return result;
 }
@@ -194,18 +244,24 @@ void LODManager::setBoundaryLevelAdjust(int boundaryLevelAdjust) {
 
 
 void LODManager::loadSettings() {
-    setAutomaticAvatarLOD(automaticAvatarLOD.get());
-    setAvatarLODDecreaseFPS(avatarLODDecreaseFPS.get());
-    setAvatarLODIncreaseFPS(avatarLODIncreaseFPS.get());
+    setAutomaticLODAdjust(automaticLODAdjust.get());
+    setDesktopLODDecreaseFPS(desktopLODDecreaseFPS.get());
+    setDesktopLODIncreaseFPS(desktopLODIncreaseFPS.get());
+    setHMDLODDecreaseFPS(hmdLODDecreaseFPS.get());
+    setHMDLODIncreaseFPS(hmdLODIncreaseFPS.get());
+
     setAvatarLODDistanceMultiplier(avatarLODDistanceMultiplier.get());
     setBoundaryLevelAdjust(boundaryLevelAdjust.get());
     setOctreeSizeScale(octreeSizeScale.get());
 }
 
 void LODManager::saveSettings() {
-    automaticAvatarLOD.set(getAutomaticAvatarLOD());
-    avatarLODDecreaseFPS.set(getAvatarLODDecreaseFPS());
-    avatarLODIncreaseFPS.set(getAvatarLODIncreaseFPS());
+    automaticLODAdjust.set(getAutomaticLODAdjust());
+    desktopLODDecreaseFPS.set(getDesktopLODDecreaseFPS());
+    desktopLODIncreaseFPS.set(getDesktopLODIncreaseFPS());
+    hmdLODDecreaseFPS.set(getHMDLODDecreaseFPS());
+    hmdLODIncreaseFPS.set(getHMDLODIncreaseFPS());
+
     avatarLODDistanceMultiplier.set(getAvatarLODDistanceMultiplier());
     boundaryLevelAdjust.set(getBoundaryLevelAdjust());
     octreeSizeScale.set(getOctreeSizeScale());

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -17,9 +17,10 @@
 #include <SharedUtil.h>
 #include <SimpleMovingAverage.h>
 
-const float ADJUST_LOD_DOWN_FPS = 40.0;
-const float ADJUST_LOD_UP_FPS = 55.0;
-const float DEFAULT_ADJUST_AVATAR_LOD_DOWN_FPS = 30.0f;
+const float DEFAULT_DESKTOP_LOD_DOWN_FPS = 30.0;
+const float DEFAULT_DESKTOP_LOD_UP_FPS = 50.0;
+const float DEFAULT_HMD_LOD_DOWN_FPS = 60.0;
+const float DEFAULT_HMD_LOD_UP_FPS = 65.0;
 
 const quint64 ADJUST_LOD_DOWN_DELAY = 1000 * 1000 * 0.5; // Consider adjusting LOD down after half a second
 const quint64 ADJUST_LOD_UP_DELAY = ADJUST_LOD_DOWN_DELAY * 2;
@@ -36,6 +37,7 @@ const float ADJUST_LOD_MAX_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE;
 const float MINIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER = 0.1f;
 const float MAXIMUM_AVATAR_LOD_DISTANCE_MULTIPLIER = 15.0f;
 const float DEFAULT_AVATAR_LOD_DISTANCE_MULTIPLIER = 1.0f;
+const float MAXIMUM_AUTO_ADJUST_AVATAR_LOD_DISTANCE_MULTIPLIER = DEFAULT_AVATAR_LOD_DISTANCE_MULTIPLIER;
 
 const int ONE_SECOND_OF_FRAMES = 60;
 const int FIVE_SECONDS_OF_FRAMES = 5 * ONE_SECOND_OF_FRAMES;
@@ -46,14 +48,21 @@ class LODManager : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
     
 public:
-    void setAutomaticAvatarLOD(bool automaticAvatarLOD) { _automaticAvatarLOD = automaticAvatarLOD; }
-    bool getAutomaticAvatarLOD() const { return _automaticAvatarLOD; }
-    void setAvatarLODDecreaseFPS(float avatarLODDecreaseFPS) { _avatarLODDecreaseFPS = avatarLODDecreaseFPS; }
-    float getAvatarLODDecreaseFPS() const { return _avatarLODDecreaseFPS; }
-    void setAvatarLODIncreaseFPS(float avatarLODIncreaseFPS) { _avatarLODIncreaseFPS = avatarLODIncreaseFPS; }
-    float getAvatarLODIncreaseFPS() const { return _avatarLODIncreaseFPS; }
-    void setAvatarLODDistanceMultiplier(float multiplier) { _avatarLODDistanceMultiplier = multiplier; }
-    float getAvatarLODDistanceMultiplier() const { return _avatarLODDistanceMultiplier; }
+    Q_INVOKABLE void setAutomaticLODAdjust(bool value) { _automaticLODAdjust = value; }
+    Q_INVOKABLE bool getAutomaticLODAdjust() const { return _automaticLODAdjust; }
+
+    Q_INVOKABLE void setDesktopLODDecreaseFPS(float value) { _desktopLODDecreaseFPS = value; }
+    Q_INVOKABLE float getDesktopLODDecreaseFPS() const { return _desktopLODDecreaseFPS; }
+    Q_INVOKABLE void setDesktopLODIncreaseFPS(float value) { _desktopLODIncreaseFPS = value; }
+    Q_INVOKABLE float getDesktopLODIncreaseFPS() const { return _desktopLODIncreaseFPS; }
+
+    Q_INVOKABLE void setHMDLODDecreaseFPS(float value) { _hmdLODDecreaseFPS = value; }
+    Q_INVOKABLE float getHMDLODDecreaseFPS() const { return _hmdLODDecreaseFPS; }
+    Q_INVOKABLE void setHMDLODIncreaseFPS(float value) { _hmdLODIncreaseFPS = value; }
+    Q_INVOKABLE float getHMDLODIncreaseFPS() const { return _hmdLODIncreaseFPS; }
+
+    Q_INVOKABLE void setAvatarLODDistanceMultiplier(float multiplier) { _avatarLODDistanceMultiplier = multiplier; }
+    Q_INVOKABLE float getAvatarLODDistanceMultiplier() const { return _avatarLODDistanceMultiplier; }
     
     // User Tweakable LOD Items
     Q_INVOKABLE QString getLODFeedbackText();
@@ -63,12 +72,15 @@ public:
     Q_INVOKABLE void setBoundaryLevelAdjust(int boundaryLevelAdjust);
     Q_INVOKABLE int getBoundaryLevelAdjust() const { return _boundaryLevelAdjust; }
     
-    void autoAdjustLOD(float currentFPS);
     Q_INVOKABLE void resetLODAdjust();
     Q_INVOKABLE float getFPSAverage() const { return _fpsAverage.getAverage(); }
     Q_INVOKABLE float getFastFPSAverage() const { return _fastFPSAverage.getAverage(); }
     
+    Q_INVOKABLE float getLODDecreaseFPS();
+    Q_INVOKABLE float getLODIncreaseFPS();
+    
     bool shouldRenderMesh(float largestDimension, float distanceToCamera);
+    void autoAdjustLOD(float currentFPS);
     
     void loadSettings();
     void saveSettings();
@@ -80,16 +92,18 @@ signals:
 private:
     LODManager() {}
     
-    bool _automaticAvatarLOD = true;
-    float _avatarLODDecreaseFPS = DEFAULT_ADJUST_AVATAR_LOD_DOWN_FPS;
-    float _avatarLODIncreaseFPS = ADJUST_LOD_UP_FPS;
+    bool _automaticLODAdjust = true;
+    float _desktopLODDecreaseFPS = DEFAULT_DESKTOP_LOD_DOWN_FPS;
+    float _desktopLODIncreaseFPS = DEFAULT_DESKTOP_LOD_UP_FPS;
+    float _hmdLODDecreaseFPS = DEFAULT_HMD_LOD_DOWN_FPS;
+    float _hmdLODIncreaseFPS = DEFAULT_HMD_LOD_UP_FPS;
+
     float _avatarLODDistanceMultiplier = DEFAULT_AVATAR_LOD_DISTANCE_MULTIPLIER;
     
     float _octreeSizeScale = DEFAULT_OCTREE_SIZE_SCALE;
     int _boundaryLevelAdjust = 0;
     
     quint64 _lastAdjust = 0;
-    quint64 _lastAvatarDetailDrop = 0;
     SimpleMovingAverage _fpsAverage = FIVE_SECONDS_OF_FRAMES;
     SimpleMovingAverage _fastFPSAverage = ONE_SECOND_OF_FRAMES;
     

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -276,7 +276,6 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::Entities, 0, true);
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::AmbientOcclusion);
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::DontFadeOnOctreeServerChanges);
-    addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::DisableAutoAdjustLOD);
 
     QMenu* ambientLightMenu = renderOptionsMenu->addMenu(MenuOption::RenderAmbientLight);
     QActionGroup* ambientLightGroup = new QActionGroup(ambientLightMenu);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -136,7 +136,6 @@ namespace MenuOption {
     const QString DecreaseAvatarSize = "Decrease Avatar Size";
     const QString DeleteBookmark = "Delete Bookmark...";
     const QString DisableActivityLogger = "Disable Activity Logger";
-    const QString DisableAutoAdjustLOD = "Disable Automatically Adjusting LOD";
     const QString DisableLightEntities = "Disable Light Entities";
     const QString DisableNackPackets = "Disable NACK Packets";
     const QString DiskCacheEditor = "Disk Cache Editor";

--- a/interface/src/ui/LodToolsDialog.h
+++ b/interface/src/ui/LodToolsDialog.h
@@ -31,11 +31,10 @@ signals:
 public slots:
     void reject();
     void sizeScaleValueChanged(int value);
-    void boundaryLevelValueChanged(int value);
     void resetClicked(bool checked);
     void reloadSliders();
-    void updateAvatarLODControls();
-    void updateAvatarLODValues();
+    void updateAutomaticLODAdjust();
+    void updateLODValues();
 
 protected:
 
@@ -44,10 +43,16 @@ protected:
 
 private:
     QSlider* _lodSize;
-    QSlider* _boundaryLevelAdjust;
-    QCheckBox* _automaticAvatarLOD;
-    QDoubleSpinBox* _avatarLODDecreaseFPS;
-    QDoubleSpinBox* _avatarLODIncreaseFPS;
+
+    QCheckBox* _automaticLODAdjust;
+
+    QDoubleSpinBox* _desktopLODDecreaseFPS;
+    QDoubleSpinBox* _desktopLODIncreaseFPS;
+
+    QDoubleSpinBox* _hmdLODDecreaseFPS;
+    QDoubleSpinBox* _hmdLODIncreaseFPS;
+
+
     QDoubleSpinBox* _avatarLOD;
     QLabel* _feedback;
 };

--- a/libraries/octree/src/OctreeConstants.h
+++ b/libraries/octree/src/OctreeConstants.h
@@ -23,7 +23,7 @@ const int   TREE_SCALE = 16384; // ~10 miles.. This is the number of meters of t
 const float DEFAULT_OCTREE_SIZE_SCALE = TREE_SCALE * 400.0f; 
 
 // This is used in the LOD Tools to translate between the size scale slider and the values used to set the OctreeSizeScale
-const float MAX_LOD_SIZE_MULTIPLIER = 2000.0f;
+const float MAX_LOD_SIZE_MULTIPLIER = 800.0f;
 
 const int NUMBER_OF_CHILDREN = 8;
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -725,7 +725,7 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
     const float DEFAULT_ALPHA_THRESHOLD = 0.5f;
     
 
-    //renderMeshes(RenderMode mode, bool translucent, float alphaThreshold, bool hasTangents, bool hasSpecular, book isSkinned, args);
+    //renderMeshes(batch, mode, translucent, alphaThreshold, hasTangents, hasSpecular, isSkinned, args, forceRenderMeshes);
     int opaqueMeshPartsRendered = 0;
     opaqueMeshPartsRendered += renderMeshes(batch, mode, false, DEFAULT_ALPHA_THRESHOLD, false, false, false, false, args, true);
     opaqueMeshPartsRendered += renderMeshes(batch, mode, false, DEFAULT_ALPHA_THRESHOLD, false, false, false, true, args, true);
@@ -753,14 +753,14 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
 
     int translucentMeshPartsRendered = 0;
     const float MOSTLY_OPAQUE_THRESHOLD = 0.75f;
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, false, false, args);
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, false, true, args);
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, true, false, args);
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, true, true, args);
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, false, false, args);
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, false, true, args);
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, false, args);
-    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, true, args);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, false, false, args, true);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, false, true, args, true);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, true, false, args, true);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, false, true, true, args, true);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, false, false, args, true);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, false, true, args, true);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, false, args, true);
+    translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, true, args, true);
 
     GLBATCH(glDisable)(GL_ALPHA_TEST);
     GLBATCH(glEnable)(GL_BLEND);
@@ -777,14 +777,14 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
 
     if (mode == DEFAULT_RENDER_MODE || mode == DIFFUSE_RENDER_MODE) {
         const float MOSTLY_TRANSPARENT_THRESHOLD = 0.0f;
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, false, args);
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, true, args);
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, true, false, args);
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, true, true, args);
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, false, false, args);
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, false, true, args);
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, false, args);
-        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, true, args);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, false, args, true);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, true, args, true);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, true, false, args, true);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, true, true, args, true);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, false, false, args, true);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, false, true, args, true);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, false, args, true);
+        translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, true, args, true);
     }
 
     GLBATCH(glDepthMask)(true);


### PR DESCRIPTION
Changes in this PR:

* Differentiated between Desktop vs HMD fps thresholds. Desktop now defaults to below 30fps with downshift LOD, above 50fps will increase. HMD is set to 60/65.

* Changed the "you can see" wording to reflect relationship to "normal 20:20 vision".

* Removed the "Disable Audio Adjust LOD" menu item. Now it's in the LOD Tools Dialog with the other controls.

* Consolidated Avatar LOD and Models LOD to use the same FPS logic. Although they still adjust different knobs when the LOD changes.

* This also includes an additional bug fix for avatar parts not rendering.
