### PR TITLE
Putting the GLERRORCHECK only in debug

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendShared.h
+++ b/libraries/gpu/src/gpu/GLBackendShared.h
@@ -49,7 +49,10 @@ static const GLenum _elementTypeToGLType[NUM_TYPES]= {
     GL_UNSIGNED_BYTE
 };
 
+#if _DEBUG
 #define CHECK_GL_ERROR() ::gpu::GLBackend::checkGLError()
-//#define CHECK_GL_ERROR()
+#else
+#define CHECK_GL_ERROR()
+#endif
 
 #endif


### PR DESCRIPTION
this doesn't really solve the problem of why we have the messages sometimes but at least it's not showing in release and we won;t have to remember to change the define before committing.