### PR TITLE
menu and display tweaks at Philip's request

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -789,7 +789,7 @@ void Application::paintGL() {
 
         DependencyManager::get<GlowEffect>()->render();
 
-        if (Menu::getInstance()->isOptionChecked(MenuOption::UserInterface)) {
+        {
             PerformanceTimer perfTimer("renderOverlay");
             _applicationOverlay.renderOverlay(true);
             _applicationOverlay.displayOverlayTexture();
@@ -1127,13 +1127,10 @@ void Application::keyPressEvent(QKeyEvent* event) {
                     Menu::getInstance()->triggerOption(MenuOption::FullscreenMirror);
                 }
                 break;
-            case Qt::Key_Slash:
-                Menu::getInstance()->triggerOption(MenuOption::UserInterface);
-                break;
             case Qt::Key_P:
                  Menu::getInstance()->triggerOption(MenuOption::FirstPerson);
                  break;
-            case Qt::Key_Percent:
+            case Qt::Key_Slash:
                 Menu::getInstance()->triggerOption(MenuOption::Stats);
                 break;
             case Qt::Key_Plus:
@@ -3019,8 +3016,7 @@ void Application::displaySide(Camera& theCamera, bool selfAvatarOnly, RenderArgs
         _nodeBoundsDisplay.draw();
     
         //  Render the world box
-        if (theCamera.getMode() != CAMERA_MODE_MIRROR && Menu::getInstance()->isOptionChecked(MenuOption::Stats) && 
-                Menu::getInstance()->isOptionChecked(MenuOption::UserInterface)) {
+        if (theCamera.getMode() != CAMERA_MODE_MIRROR && Menu::getInstance()->isOptionChecked(MenuOption::Stats)) {
             PerformanceTimer perfTimer("worldBox");
             renderWorldBox();
         }

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -230,7 +230,6 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::Mirror, Qt::SHIFT | Qt::Key_H, true);
     addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::FullscreenMirror, Qt::Key_H, false,
                                             qApp, SLOT(cameraMenuChanged()));
-    addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::UserInterface, Qt::Key_Slash, true);
 
     addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::HMDTools, Qt::META | Qt::Key_H,
                                            false,
@@ -259,14 +258,13 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::TurnWithHead, 0, false);
 
 
-    addDisabledActionAndSeparator(viewMenu, "Stats");
-    addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::Stats, Qt::Key_Percent);
+    addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::Stats, Qt::Key_Slash);
     addActionToQMenuAndActionHash(viewMenu, MenuOption::Log, Qt::CTRL | Qt::Key_L, qApp, SLOT(toggleLogDialog()));
     addActionToQMenuAndActionHash(viewMenu, MenuOption::BandwidthDetails, 0,
                                   dialogsManager.data(), SLOT(bandwidthDetails()));
     addActionToQMenuAndActionHash(viewMenu, MenuOption::OctreeStats, 0,
                                   dialogsManager.data(), SLOT(octreeStatsDetails()));
-    addActionToQMenuAndActionHash(viewMenu, MenuOption::EditEntitiesHelp, 0, qApp, SLOT(showEditEntitiesHelp()));
+
 
     QMenu* developerMenu = addMenu("Developer");
 
@@ -538,10 +536,12 @@ Menu::Menu() {
                                             statsRenderer.data(),
                                             SLOT(toggleShowInjectedStreams()));
 
-#ifndef Q_OS_MAC
     QMenu* helpMenu = addMenu("Help");
-    QAction* helpAction = helpMenu->addAction(MenuOption::AboutApp);
-    connect(helpAction, SIGNAL(triggered()), qApp, SLOT(aboutApp()));
+    addActionToQMenuAndActionHash(helpMenu, MenuOption::EditEntitiesHelp, 0, qApp, SLOT(showEditEntitiesHelp()));
+
+#ifndef Q_OS_MAC
+    QAction* aboutAction = helpMenu->addAction(MenuOption::AboutApp);
+    connect(aboutAction, SIGNAL(triggered()), qApp, SLOT(aboutApp()));
 #endif
 }
 

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -184,12 +184,10 @@ namespace MenuOption {
     const QString Mirror = "Mirror";
     const QString MuteAudio = "Mute Microphone";
     const QString MuteEnvironment = "Mute Environment";
-    const QString NewVoxelCullingMode = "New Voxel Culling Mode";
     const QString NoFaceTracking = "None";
     const QString ObeyEnvironmentalGravity = "Obey Environmental Gravity";
-    const QString OctreeStats = "Voxel and Entity Statistics";
+    const QString OctreeStats = "Entity Statistics";
     const QString OffAxisProjection = "Off-Axis Projection";
-    const QString OldVoxelCullingMode = "Old Voxel Culling Mode";
     const QString OnlyDisplayTopTen = "Only Display Top Ten";
     const QString Pair = "Pair";
     const QString PipelineWarnings = "Log Render Pipeline Warnings";
@@ -233,7 +231,6 @@ namespace MenuOption {
     const QString ScriptEditor = "Script Editor...";
     const QString ScriptedMotorControl = "Enable Scripted Motor Control";
     const QString ShowBordersEntityNodes = "Show Entity Nodes";
-    const QString ShowBordersVoxelNodes = "Show Voxel Nodes";
     const QString ShowIKConstraints = "Show IK Constraints";
     const QString SimpleShadows = "Simple";
     const QString SixenseEnabled = "Enable Hydra Support";
@@ -251,7 +248,6 @@ namespace MenuOption {
     const QString TransmitterDrive = "Transmitter Drive";
     const QString TurnWithHead = "Turn using Head";
     const QString PackageModel = "Package Model";
-    const QString UserInterface = "User Interface";
     const QString Visage = "Visage";
     const QString Wireframe = "Wireframe";
 }

--- a/interface/src/devices/TV3DManager.cpp
+++ b/interface/src/devices/TV3DManager.cpp
@@ -104,7 +104,6 @@ void TV3DManager::display(Camera& whichCamera) {
     // We only need to render the overlays to a texture once, then we just render the texture as a quad
     // PrioVR will only work if renderOverlay is called, calibration is connected to Application::renderingOverlay() 
     applicationOverlay.renderOverlay(true);
-    const bool displayOverlays = Menu::getInstance()->isOptionChecked(MenuOption::UserInterface);
 
     DependencyManager::get<GlowEffect>()->prepare();
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -135,9 +134,7 @@ void TV3DManager::display(Camera& whichCamera) {
         eyeCamera.setEyeOffsetPosition(glm::vec3(-_activeEye->modelTranslation,0,0));
         Application::getInstance()->displaySide(eyeCamera, false, RenderArgs::MONO);
 
-        if (displayOverlays) {
-            applicationOverlay.displayOverlayTexture3DTV(whichCamera, _aspect, fov);
-        }
+        applicationOverlay.displayOverlayTexture3DTV(whichCamera, _aspect, fov);
         _activeEye = NULL;
     }
     glPopMatrix();
@@ -166,9 +163,7 @@ void TV3DManager::display(Camera& whichCamera) {
         eyeCamera.setEyeOffsetPosition(glm::vec3(-_activeEye->modelTranslation,0,0));
         Application::getInstance()->displaySide(eyeCamera, false, RenderArgs::MONO);
 
-        if (displayOverlays) {
-            applicationOverlay.displayOverlayTexture3DTV(whichCamera, _aspect, fov);
-        }
+        applicationOverlay.displayOverlayTexture3DTV(whichCamera, _aspect, fov);
         _activeEye = NULL;
     }
     glPopMatrix();

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -176,18 +176,7 @@ void ApplicationOverlay::renderOverlay(bool renderToTexture) {
     _textureAspectRatio = (float)glCanvas->getDeviceWidth() / (float)glCanvas->getDeviceHeight();
 
     //Handle fading and deactivation/activation of UI
-    if (Menu::getInstance()->isOptionChecked(MenuOption::UserInterface)) {
-        _alpha += FADE_SPEED;
-        if (_alpha > 1.0f) {
-            _alpha = 1.0f;
-        }
-    } else {
-        _alpha -= FADE_SPEED;
-        if (_alpha <= 0.0f) {
-            _alpha = 0.0f;
-        }
-    }
-
+    
     // Render 2D overlay
     glMatrixMode(GL_PROJECTION);
     glDisable(GL_DEPTH_TEST);

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -114,7 +114,7 @@ private:
     quint64 _lastMouseMove;
     bool _magnifier;
 
-    float _alpha;
+    float _alpha = 1.0f;
     float _oculusUIRadius;
     float _trailingAudioLoudness;
 


### PR DESCRIPTION
clean up of a couple of menu item and display behaviors at @PhilipRosedale's request

* now you can't accidentally hide the user interface display (overlays)
* "/" now toggles the stats that used to be controlled by "%"
* cleaned up some menu item placements