### PR TITLE
enable avatar physics by default

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -987,12 +987,6 @@ void Application::keyPressEvent(QKeyEvent* event) {
                 resetSensors();
                 break;
 
-            case Qt::Key_G:
-                if (isShifted) {
-                    Menu::getInstance()->triggerOption(MenuOption::ObeyEnvironmentalGravity);
-                }
-                break;
-
             case Qt::Key_A:
                 if (isShifted) {
                     Menu::getInstance()->triggerOption(MenuOption::Atmosphere);
@@ -1165,10 +1159,6 @@ void Application::keyPressEvent(QKeyEvent* event) {
                 break;
             }
 
-            case Qt::Key_Comma: {
-                _myAvatar->togglePhysicsEnabled();
-            }
-            
             default:
                 event->ignore();
                 break;
@@ -2192,7 +2182,6 @@ void Application::update(float deltaTime) {
 
     {
         PerformanceTimer perfTimer("physics");
-        _myAvatar->preSimulation();
         _physicsEngine.stepSimulation();
     }
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -201,9 +201,7 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::NamesAboveHeads, 0, true);
     addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::GlowWhenSpeaking, 0, true);
     addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::BlueSpeechSphere, 0, true);
-    addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::ObeyEnvironmentalGravity, Qt::SHIFT | Qt::Key_G, false,
-            avatar, SLOT(updateMotionBehavior()));
-    addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::StandOnNearbyFloors, 0, true,
+    addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::EnableCharacterController, 0, true,
             avatar, SLOT(updateMotionBehavior()));
     addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::ShiftHipsForIdleAnimations, 0, false,
             avatar, SLOT(updateMotionBehavior()));

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -153,6 +153,7 @@ namespace MenuOption {
     const QString EchoServerAudio = "Echo Server Audio";
     const QString EditEntitiesHelp = "Edit Entities Help...";
     const QString Enable3DTVMode = "Enable 3DTV Mode";
+    const QString EnableCharacterController = "Enable avatar collisions";
     const QString EnableGlowEffect = "Enable Glow Effect (Warning: Poor Oculus Performance)";
     const QString EnableVRMode = "Enable VR Mode";
     const QString Entities = "Entities";
@@ -185,7 +186,6 @@ namespace MenuOption {
     const QString MuteAudio = "Mute Microphone";
     const QString MuteEnvironment = "Mute Environment";
     const QString NoFaceTracking = "None";
-    const QString ObeyEnvironmentalGravity = "Obey Environmental Gravity";
     const QString OctreeStats = "Entity Statistics";
     const QString OffAxisProjection = "Off-Axis Projection";
     const QString OnlyDisplayTopTen = "Only Display Top Ten";
@@ -236,7 +236,6 @@ namespace MenuOption {
     const QString SixenseEnabled = "Enable Hydra Support";
     const QString SixenseMouseInput = "Enable Sixense Mouse Input";
     const QString SixenseLasers = "Enable Sixense UI Lasers";
-    const QString StandOnNearbyFloors = "Stand on nearby floors";
     const QString ShiftHipsForIdleAnimations = "Shift hips for idle animations";
     const QString Stars = "Stars";
     const QString Stats = "Stats";

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -25,7 +25,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(glm::vec3 motorVelocity READ getScriptedMotorVelocity WRITE setScriptedMotorVelocity)
     Q_PROPERTY(float motorTimescale READ getScriptedMotorTimescale WRITE setScriptedMotorTimescale)
     Q_PROPERTY(QString motorReferenceFrame READ getScriptedMotorFrame WRITE setScriptedMotorFrame)
-    Q_PROPERTY(glm::vec3 gravity READ getGravity WRITE setLocalGravity)
+    //TODO: make gravity feature work Q_PROPERTY(glm::vec3 gravity READ getGravity WRITE setGravity)
 
 public:
 	MyAvatar();
@@ -44,13 +44,11 @@ public:
 
     // setters
     void setLeanScale(float scale) { _leanScale = scale; }
-    void setLocalGravity(glm::vec3 gravity);
     void setShouldRenderLocally(bool shouldRender) { _shouldRender = shouldRender; }
     void setRealWorldFieldOfView(float realWorldFov) { _realWorldFieldOfView.set(realWorldFov); }
 
     // getters
     float getLeanScale() const { return _leanScale; }
-    glm::vec3 getGravity() const { return _gravity; }
     Q_INVOKABLE glm::vec3 getDefaultEyePosition() const;
     bool getShouldRenderLocally() const { return _shouldRender; }
     float getRealWorldFieldOfView() { return _realWorldFieldOfView.get(); }
@@ -148,11 +146,6 @@ public:
     
     const RecorderPointer getRecorder() const { return _recorder; }
     const PlayerPointer getPlayer() const { return _player; }
-
-    void togglePhysicsEnabled() { _enablePhysics = !_enablePhysics; }
-    bool isPhysicsEnabled() { return _enablePhysics; }
-    void setPhysicsEnabled(bool enablePhysics) { _enablePhysics = enablePhysics; }
-    void preSimulation();
     
 public slots:
     void increaseSize();
@@ -209,7 +202,6 @@ private:
     int _scriptedMotorFrame;
     quint32 _motionBehaviors;
 
-    bool _enablePhysics;
     CharacterController _characterController;
 
     QWeakPointer<AvatarData> _lookAtTargetAvatar;
@@ -236,7 +228,6 @@ private:
     void updatePosition(float deltaTime);
     void updateCollisionSound(const glm::vec3& penetration, float deltaTime, float frequency);
     void maybeUpdateBillboard();
-    void setGravity(const glm::vec3& gravity);
 };
 
 #endif // hifi_MyAvatar_h

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -61,21 +61,13 @@ typedef unsigned long long quint64;
 const quint32 AVATAR_MOTION_KEYBOARD_MOTOR_ENABLED = 1U << 0;
 const quint32 AVATAR_MOTION_SCRIPTED_MOTOR_ENABLED = 1U << 1;
 
-const quint32 AVATAR_MOTION_OBEY_ENVIRONMENTAL_GRAVITY = 1U << 2;
-const quint32 AVATAR_MOTION_OBEY_LOCAL_GRAVITY = 1U << 3;
-const quint32 AVATAR_MOTION_STAND_ON_NEARBY_FLOORS = 1U << 4;
-
 const quint32 AVATAR_MOTION_DEFAULTS = 
         AVATAR_MOTION_KEYBOARD_MOTOR_ENABLED |
-        AVATAR_MOTION_SCRIPTED_MOTOR_ENABLED |
-        AVATAR_MOTION_STAND_ON_NEARBY_FLOORS;
+        AVATAR_MOTION_SCRIPTED_MOTOR_ENABLED;
 
 // these bits will be expanded as features are exposed
 const quint32 AVATAR_MOTION_SCRIPTABLE_BITS = 
-        AVATAR_MOTION_SCRIPTED_MOTOR_ENABLED |
-        AVATAR_MOTION_OBEY_ENVIRONMENTAL_GRAVITY | 
-        AVATAR_MOTION_OBEY_LOCAL_GRAVITY | 
-        AVATAR_MOTION_STAND_ON_NEARBY_FLOORS;
+        AVATAR_MOTION_SCRIPTED_MOTOR_ENABLED;
 
 
 // Bitset of state flags - we store the key state, hand state, faceshift, chat circling, and existance of

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -232,6 +232,7 @@ CharacterController::CharacterController(AvatarData* avatarData) {
     _isOnGround = false;
     _isJumping = false;
     _isHovering = true;
+    _jumpToHoverStart = 0;
     setMaxSlope(btRadians(45.0f));
     _lastStepUp = 0.0f;
     _pendingFlags = 0;
@@ -678,6 +679,20 @@ bool CharacterController::canJump() const {
 
 void CharacterController::jump() {
     _pendingFlags |= PENDING_FLAG_JUMP;
+
+    // check for case where user is holding down "jump" key...
+    // we'll eventually tansition to "hover"
+    if (!_isHovering) {
+        if (!_isJumping) {
+            _jumpToHoverStart = usecTimestampNow();
+        } else {
+            quint64 now = usecTimestampNow();
+            const quint64 JUMP_TO_HOVER_PERIOD = USECS_PER_SECOND;
+            if (now - _jumpToHoverStart < JUMP_TO_HOVER_PERIOD) {
+                _isHovering = true;
+            }
+        }
+    }
 }
 
 void CharacterController::setGravity(btScalar gravity) {

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -166,6 +166,7 @@ public:
     bool needsRemoval() const;
     bool needsAddition() const;
     void setEnabled(bool enabled);
+    bool isEnabled() const { return _enabled; }
     void setDynamicsWorld(btDynamicsWorld* world);
 
     void setLocalBoundingBox(const glm::vec3& corner, const glm::vec3& scale);

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -85,6 +85,7 @@ protected:
     bool _isOnGround;
     bool _isJumping;
     bool _isHovering;
+    quint64 _jumpToHoverStart;
     btScalar _velocityTimeInterval;
     btScalar _stepDt;
     uint32_t _pendingFlags;

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -360,10 +360,6 @@ void ScriptEngine::init() {
     globalObject().setProperty("TREE_SCALE", newVariant(QVariant(TREE_SCALE)));
     globalObject().setProperty("COLLISION_GROUP_ENVIRONMENT", newVariant(QVariant(COLLISION_GROUP_ENVIRONMENT)));
     globalObject().setProperty("COLLISION_GROUP_AVATARS", newVariant(QVariant(COLLISION_GROUP_AVATARS)));
-
-    globalObject().setProperty("AVATAR_MOTION_OBEY_LOCAL_GRAVITY", newVariant(QVariant(AVATAR_MOTION_OBEY_LOCAL_GRAVITY)));
-    globalObject().setProperty("AVATAR_MOTION_OBEY_ENVIRONMENTAL_GRAVITY", newVariant(QVariant(AVATAR_MOTION_OBEY_ENVIRONMENTAL_GRAVITY)));
-
 }
 
 QScriptValue ScriptEngine::registerGlobalObject(const QString& name, QObject* object) {


### PR DESCRIPTION
The avatar will collide with objects by default, but can be turned off via the menu.

Removed old "avatar gravity" features -- we'll have to add this back later when it makes sense.

Added ability to transition into "hover" when holding down "jump" key for longer than one second.