### PR TITLE
fix bug in default avatars

### DIFF
--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -365,8 +365,8 @@ protected:
     HeadData* _headData;
     HandData* _handData;
 
-    QUrl _faceModelURL = DEFAULT_HEAD_MODEL_URL;
-    QUrl _skeletonModelURL = DEFAULT_BODY_MODEL_URL;
+    QUrl _faceModelURL; // These need to be empty so that on first time setting them they will not short circuit
+    QUrl _skeletonModelURL; // These need to be empty so that on first time setting them they will not short circuit
     QVector<AttachmentData> _attachmentData;
     QString _displayName;
 


### PR DESCRIPTION
This fixes the bug where people who've never changed their avatar body appear as a billboard.

The problem is caused by the fact that the AvatarHashMap will short circuit setting the avatar skeleton in a case where the new value is the same as the current value. Because we initialized this member to the default value, it looked like things were not changing, and so the code optimized ignoring the change.