### PR TITLE
fix crash in PhysicsEngine on shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -608,6 +608,7 @@ Application::~Application() {
 
     Menu::getInstance()->deleteLater();
 
+    _physicsEngine.setCharacterController(NULL);
     _myAvatar = NULL;
 
     ModelEntityItem::cleanupLoadedAnimations();

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -241,6 +241,12 @@ CharacterController::CharacterController(AvatarData* avatarData) {
 }
 
 CharacterController::~CharacterController() {
+    delete _ghostObject;
+    _ghostObject = NULL;
+    delete _convexShape;
+    _convexShape = NULL;
+    // make sure you remove this Character from its DynamicsWorld before reaching this spot
+    assert(_dynamicsWorld == NULL);
 }
 
 btPairCachingGhostObject* CharacterController::getGhostObject() {

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -624,11 +624,9 @@ void PhysicsEngine::setCharacterController(CharacterController* character) {
             _characterController->setDynamicsWorld(NULL);
             _characterController = NULL;
         }
+        // the character will be added to the DynamicsWorld later
+        _characterController = character;
         unlock();
-        if (character) {
-            // the character will be added to the DynamicsWorld later
-            _characterController = character;
-        }
     }
 }
 

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -28,6 +28,9 @@ PhysicsEngine::PhysicsEngine(const glm::vec3& offset)
 }
 
 PhysicsEngine::~PhysicsEngine() {
+    if (_characterController) {
+        _characterController->setDynamicsWorld(NULL);
+    }
     // TODO: delete engine components... if we ever plan to create more than one instance
     delete _collisionConfig;
     delete _collisionDispatcher;
@@ -614,10 +617,18 @@ bool PhysicsEngine::updateObjectHard(btRigidBody* body, ObjectMotionState* motio
 }
 
 void PhysicsEngine::setCharacterController(CharacterController* character) {
-    if (!_characterController) {
+    if (_characterController != character) {
         lock();
-        _characterController = character;
+        if (_characterController) {
+            // remove the character from the DynamicsWorld immediately
+            _characterController->setDynamicsWorld(NULL);
+            _characterController = NULL;
+        }
         unlock();
+        if (character) {
+            // the character will be added to the DynamicsWorld later
+            _characterController = character;
+        }
     }
 }
 


### PR DESCRIPTION
We were not properly cleaning up all objects in the DynamicsEngine before calling its destructor.  In particular, the CharacterController had been deleted out from under the PhysicsEngine which still had a few pointers for it.