### PR TITLE
Fixing consecutive spaces issue with text renderer

### DIFF
--- a/libraries/render-utils/src/TextRenderer.cpp
+++ b/libraries/render-utils/src/TextRenderer.cpp
@@ -359,8 +359,12 @@ void Font::setupGL() {
 // FIXME there has to be a cleaner way of doing this
 QStringList Font::tokenizeForWrapping(const QString & str) const {
     QStringList result;
-    foreach(const QString & token1, str.split(" ", QString::SkipEmptyParts)) {
+    foreach(const QString & token1, str.split(" ")) {
         bool lineFeed = false;
+        if (token1.isEmpty()) {
+            result << token1;
+            continue;
+        }
         foreach(const QString & token2, token1.split("\n")) {
             if (lineFeed) {
                 result << "\n";


### PR DESCRIPTION
https://worklist.net/20387

The problem was that my code originally got rid of consecutive spaces by using the flag for dropping empty items returned from the split.  But we need to retain consecutive spaces for monospace alignment.  The solution is to keep the empty parts and add them to the stringlist passed to the renderer.  Since it renders a single space width after every token (including empty ones) this works.

However, before we get any deeper into creating our own text layout engine, we may wish to consider how we might be able to leverage the Qt system via QML.  