### PR TITLE
fix issue with preload not being called on import

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -101,7 +101,7 @@ void EntityTreeRenderer::init() {
     _lastAvatarPosition = _viewState->getAvatarPosition() + glm::vec3((float)TREE_SCALE);
     
     connect(entityTree, &EntityTree::deletingEntity, this, &EntityTreeRenderer::deletingEntity);
-    connect(entityTree, &EntityTree::addingEntity, this, &EntityTreeRenderer::checkAndCallPreload);
+    connect(entityTree, &EntityTree::addingEntity, this, &EntityTreeRenderer::addingEntity);
     connect(entityTree, &EntityTree::entityScriptChanging, this, &EntityTreeRenderer::entitySciptChanging);
     connect(entityTree, &EntityTree::changingEntityID, this, &EntityTreeRenderer::changingEntityID);
 }
@@ -193,7 +193,7 @@ QScriptValue EntityTreeRenderer::loadEntityScript(EntityItem* entity, bool isPre
     // can accomplish all we need to here with just the script "text" and the ID.
     EntityItemID entityID = entity->getEntityItemID();
     QString entityScript = entity->getScript();
-    
+
     if (_entityScripts.contains(entityID)) {
         EntityScriptDetails details = _entityScripts[entityID];
         
@@ -217,7 +217,6 @@ QScriptValue EntityTreeRenderer::loadEntityScript(EntityItem* entity, bool isPre
     
     if (isPending && isPreload && isURL) {
         _waitingOnPreload.insert(url, entityID);
-        
     }
 
     auto scriptCache = DependencyManager::get<ScriptCache>();
@@ -939,6 +938,10 @@ void EntityTreeRenderer::deletingEntity(const EntityItemID& entityID) {
         checkAndCallUnload(entityID);
     }
     _entityScripts.remove(entityID);
+}
+
+void EntityTreeRenderer::addingEntity(const EntityItemID& entityID) {
+    checkAndCallPreload(entityID);
 }
 
 void EntityTreeRenderer::entitySciptChanging(const EntityItemID& entityID) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -105,6 +105,7 @@ signals:
     void leaveEntity(const EntityItemID& entityItemID);
 
 public slots:
+    void addingEntity(const EntityItemID& entityID);
     void deletingEntity(const EntityItemID& entityID);
     void changingEntityID(const EntityItemID& oldEntityID, const EntityItemID& newEntityID);
     void entitySciptChanging(const EntityItemID& entityID);

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -195,6 +195,7 @@ private:
     EntityItemFBXService* _fbxService;
 
     QHash<EntityItemID, EntityTreeElement*> _entityToElementMap;
+    QHash<EntityItemID, EntityItemID> _changedEntityIDs;
 
     EntitySimulation* _simulation;
     


### PR DESCRIPTION
This bug is related to server side assigned Entity IDs. Basically on import the ID was being changed from the temporary client ID to the server assigned ID. We weren't able to find the old ID and so we could find the entity to call it's preload.

The fix is a bit of a hack until we move over to fully client assigned IDs.