### PR TITLE
Enabling the use of #ifdef DEBUG as a platform neutral idiom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMakeTargets")
 
 project(hifi)
 add_definitions(-DGLM_FORCE_RADIANS)
+set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG") 
 
 if (WIN32)
   add_definitions(-DNOMINMAX -D_CRT_SECURE_NO_WARNINGS)

--- a/libraries/shared/src/StreamUtils.cpp
+++ b/libraries/shared/src/StreamUtils.cpp
@@ -66,7 +66,9 @@ QDataStream& operator>>(QDataStream& in, glm::quat& quaternion) {
 }
 
 // less common utils can be enabled with DEBUG
-#ifdef DEBUG
+// FIXME, remove the second defined clause once these compile, or remove the
+// functions.
+#if defined(DEBUG) && defined(FIXED_STREAMS)
 
 std::ostream& operator<<(std::ostream& s, const CollisionInfo& c) {
     s << "{penetration=" << c._penetration 


### PR DESCRIPTION
I'd like to be able to add debug functionality that doesn't impact the release build (for instance, lowering the minimum FPS before LOD kicks in when running debug builds).  using an ifdef block is a common way of doing this, but there doesn't seem to be an existing mechanism in our code to do so.  This PR should allow us to consistently use `#ifdef DEBUG` for this behavior across platforms.

Needs testing on Windows.  