### PR TITLE
improved bounding shape calculation for Mery model

### DIFF
--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -685,6 +685,10 @@ void SkeletonModel::computeBoundingShape(const FBXGeometry& geometry) {
                 * joint.preTransform * glm::mat4_cast(modifiedRotation) * joint.postTransform;
         }
 
+        // Each joint contributes its point to the bounding box
+        glm::vec3 jointPosition = extractTranslation(transforms[i]);
+        totalExtents.addPoint(jointPosition);
+
         Shape* shape = _shapes[i];
         if (!shape) {
             continue;
@@ -694,8 +698,6 @@ void SkeletonModel::computeBoundingShape(const FBXGeometry& geometry) {
         // that contains the sphere centered at the end of the joint with radius of the bone.
 
         // TODO: skip hand and arm shapes for bounding box calculation
-        glm::vec3 jointPosition = extractTranslation(transforms[i]);
-
         int type = shape->getType();
         if (type == CAPSULE_SHAPE) {
             // add the two furthest surface points of the capsule


### PR DESCRIPTION
The problem was that the model had bad "weights" between the joints and the vertices of the mesh -- sometimes a joint's weight contribution (used for blending of meshes during animations) would not rise above our minimum threshold of 0.25 for any points.  This meant that we couldn't estimate a "bone radius" for that joint and it wouldn't contribute to the bounding measurement.

The quick and easy solution is to include the joint's end-point in the bounding measurement (as if the joint were a thin stick), which improves the bounding shape for bad models.  It isn't perfect: Mery still sinks in a little bit at the feet, but it is much better hence this PR.