### PR TITLE
Remove the console window created when you start interface on win32 platforms

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -103,7 +103,13 @@ if (APPLE)
 endif()
 
 # create the executable, make it a bundle on OS X
-add_executable(${TARGET_NAME} MACOSX_BUNDLE ${INTERFACE_SRCS} ${QM})
+if (APPLE)
+  add_executable(${TARGET_NAME} MACOSX_BUNDLE ${INTERFACE_SRCS} ${QM})
+elseif(WIN32)
+  add_executable(${TARGET_NAME} WIN32 ${INTERFACE_SRCS} ${QM})
+else()
+  add_executable(${TARGET_NAME} ${INTERFACE_SRCS} ${QM})
+endif()
 
 # set up the external glm library
 add_dependency_external_projects(glm bullet)


### PR DESCRIPTION
Open task https://app.asana.com/0/30464270885583/30666750543058/f

This initial pull will probably fail to build as I need to either find the compiler switch to tell VS to use `main` even though we're a Win32 application or I need to add some preprocessor trickery to the main.cpp to use `WinMain` when building on Win32