### PR TITLE
fix crash on shutdown related to entity scripts connecting to signals

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -566,6 +566,9 @@ void Application::aboutToQuit() {
 }
 
 void Application::cleanupBeforeQuit() {
+
+    _entities.clear(); // this will allow entity scripts to properly shutdown
+
     _datagramProcessor->shutdown(); // tell the datagram processor we're shutting down, so it can short circuit
     _entities.shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
     ScriptEngine::stopAllScripts(this); // stop all currently running global scripts

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -81,6 +81,7 @@ void EntityTreeRenderer::clear() {
     }
     OctreeRenderer::clear();
     _entityScripts.clear();
+    _entitiesScriptEngine->disconnect();
 }
 
 void EntityTreeRenderer::init() {
@@ -969,10 +970,6 @@ void EntityTreeRenderer::checkAndCallUnload(const EntityItemID& entityID) {
             QScriptValueList entityArgs = createEntityArgs(entityID);
             entityScript.property("unload").call(entityScript, entityArgs);
         }
-        
-        // In the event that the entity script connected to any of our signals
-        // we want to disconnect it so we don't have anything dangling
-        _entitiesScriptEngine->disconnect(entityScript.toQObject());
     }
 }
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -2,7 +2,7 @@
 //  EntityTreeRenderer.cpp
 //  interface/src
 //
-//  Created by Brad Hefta>Gaub on 12/6/13.
+//  Created by Brad Hefta-Gaub on 12/6/13.
 //  Copyright 2013 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -969,6 +969,10 @@ void EntityTreeRenderer::checkAndCallUnload(const EntityItemID& entityID) {
             QScriptValueList entityArgs = createEntityArgs(entityID);
             entityScript.property("unload").call(entityScript, entityArgs);
         }
+        
+        // In the event that the entity script connected to any of our signals
+        // we want to disconnect it so we don't have anything dangling
+        _entitiesScriptEngine->disconnect(entityScript.toQObject());
     }
 }
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -2,7 +2,7 @@
 //  EntityTreeRenderer.cpp
 //  interface/src
 //
-//  Created by Brad Hefta-Gaub on 12/6/13.
+//  Created by Brad Hefta>Gaub on 12/6/13.
 //  Copyright 2013 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
@@ -81,7 +81,6 @@ void EntityTreeRenderer::clear() {
     }
     OctreeRenderer::clear();
     _entityScripts.clear();
-    _entitiesScriptEngine->disconnect();
 }
 
 void EntityTreeRenderer::init() {
@@ -108,6 +107,7 @@ void EntityTreeRenderer::init() {
 }
 
 void EntityTreeRenderer::shutdown() {
+    _entitiesScriptEngine->disconnect(); // disconnect all slots/signals from the script engine
     _shuttingDown = true;
 }
 


### PR DESCRIPTION
The avatarMover.js script is connecting to scriptEnding... which is not a safe thing to do since the scriptEnding signal isn't sent for the Entities script engine until application shutdown. Since we can't prevent script writers from doing this, we need to make sure we disconnect any entityScript object from all engine signals when they are cleared.