### PR TITLE
pull lobby from default scripts to avoid permanent iron man

### DIFF
--- a/examples/defaultScripts.js
+++ b/examples/defaultScripts.js
@@ -14,7 +14,6 @@ Script.load("selectAudioDevice.js");
 Script.load("controllers/hydra/hydraMove.js");
 Script.load("headMove.js");
 Script.load("inspect.js");
-Script.load("lobby.js");
 Script.load("notifications.js");
 Script.load("look.js");
 Script.load("users.js");


### PR DESCRIPTION
Until we can't easily get stuck in a state of wearing the iron man helmet or not rendering anything that should be rendering, let's remove lobby from default scripts.