### PR TITLE
Stop the menu from breaking on leaving HMD mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1585,6 +1585,10 @@ void Application::setFullscreen(bool fullscreen) {
         Menu::getInstance()->getActionForOption(MenuOption::Fullscreen)->setChecked(fullscreen);
     }
 
+// The following code block is useful on platforms that can have a visible
+// app menu in a fullscreen window.  However the OSX mechanism hides the
+// application menu for fullscreen apps, so the check is not required.
+#ifndef Q_OS_MAC
     if (Menu::getInstance()->isOptionChecked(MenuOption::EnableVRMode)) {
         if (fullscreen) {
             // Menu hide() disables menu commands, and show() after hide() doesn't work with Rift VR display.
@@ -1607,6 +1611,7 @@ void Application::setFullscreen(bool fullscreen) {
             _window->menuBar()->setMaximumHeight(QWIDGETSIZE_MAX);
         }
     }
+#endif
 
     // Work around Qt bug that prevents floating menus being shown when in fullscreen mode.
     // https://bugreports.qt.io/browse/QTBUG-41883

--- a/interface/src/ui/HMDToolsDialog.cpp
+++ b/interface/src/ui/HMDToolsDialog.cpp
@@ -184,8 +184,8 @@ void HMDToolsDialog::leaveHDMMode() {
         _switchModeButton->setText("Enter HMD Mode");
         _debugDetails->setText(getDebugDetails());
 
-        Application::getInstance()->setFullscreen(false);
         Application::getInstance()->setEnableVRMode(false);
+        Application::getInstance()->setFullscreen(false);
         Application::getInstance()->getWindow()->activateWindow();
 
         if (_wasMoved) {


### PR DESCRIPTION
Right now if you enter and then leave HMD mode, the menu breaks.  This appears to be because the logic in Application::setFullscreen changes behavior based on whether 'vr enabled' is checked.  However the HMD tools dialog disables fullscreen and *then* disables VR mode, causing the problem.  

This is a simple first pass fix that corrects the problem by reversing the order of those operations in the HMD tools dialog.  

Additionally, I'm adding code that disables the menu fiddling altogether on OSX, because the OSX mechanism for application menus in fullscreen precludes the need for any effort.