### PR TITLE
BUG FIX - Import entities sometimes fails

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -662,11 +662,23 @@ int EntityTree::processEditPacketData(PacketType packetType, const unsigned char
                     if (senderNode->getCanRez()) {
                         // this is a new entity... assign a new entityID
                         entityItemID = assignEntityID(entityItemID);
+                        if (wantEditLogging()) {
+                            qDebug() << "User [" << senderNode->getUUID() << "] adding entity.";
+                            qDebug() << "   properties:" << properties;
+                        }
                         EntityItem* newEntity = addEntity(entityItemID, properties);
                         if (newEntity) {
                             newEntity->markAsChangedOnServer();
                             notifyNewlyCreatedEntity(*newEntity, senderNode);
+                            if (wantEditLogging()) {
+                                qDebug() << "User [" << senderNode->getUUID() << "] added entity. ID:" 
+                                                << newEntity->getEntityItemID();
+                                qDebug() << "   properties:" << properties;
+                            }
+
                         }
+                    } else {
+                        qDebug() << "User without 'rez rights' [" << senderNode->getUUID() << "] attempted to add an entity.";
                     }
                 }
             }

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -1916,8 +1916,10 @@ bool Octree::readFromStream(unsigned long streamLength, QDataStream& inputStream
     device->ungetChar(firstChar);
 
     if (firstChar == (char) PacketTypeEntityData) {
+        qDebug() << "Reading from SVO Stream length:" << streamLength;
         return readSVOFromStream(streamLength, inputStream);
     } else {
+        qDebug() << "Reading from JSON Stream length:" << streamLength;
         return readJSONFromStream(streamLength, inputStream);
     }
 }
@@ -2053,12 +2055,14 @@ bool Octree::readSVOFromStream(unsigned long streamLength, QDataStream& inputStr
 }
 
 bool Octree::readJSONFromStream(unsigned long streamLength, QDataStream& inputStream) {
-    char *rawData = new char[streamLength];
+    char* rawData = new char[streamLength + 1]; // allocate enough room to null terminate
     inputStream.readRawData(rawData, streamLength);
-    QJsonDocument d = QJsonDocument::fromJson(rawData);
-    QVariant v = d.toVariant();
-    QVariantMap m = v.toMap();
-    readFromMap(m);
+    rawData[streamLength] = 0; // make sure we null terminate this string
+
+    QJsonDocument asDocument = QJsonDocument::fromJson(rawData);
+    QVariant asVariant = asDocument.toVariant();
+    QVariantMap asMap = asVariant.toMap();
+    readFromMap(asMap);
     delete rawData;
     return true;
 }


### PR DESCRIPTION
* We weren't properly null terminating the read in JSON text before handing it off to QJsonDocument for parsing. As a result it would sometimes fail to parse the document and would result in import failing.

* Added server side logging when a user adds an entity (in the event that edit logging is requested)

* Added server side logging when a user without Rez Rights attempts to add an entity