### PR TITLE
add logging for delete operations in the server

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -920,6 +920,11 @@ int EntityTree::processEraseMessage(const QByteArray& dataByteArray, const Share
             
             EntityItemID entityItemID(entityID);
             entityItemIDsToDelete << entityItemID;
+
+            if (wantEditLogging()) {
+                qDebug() << "User [" << sourceNode->getUUID() << "] deleting entity. ID:" << entityItemID;
+            }
+
         }
         deleteEntities(entityItemIDsToDelete, true, true);
     }
@@ -959,6 +964,11 @@ int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, cons
             
             EntityItemID entityItemID(entityID);
             entityItemIDsToDelete << entityItemID;
+
+            if (wantEditLogging()) {
+                qDebug() << "User [" << sourceNode->getUUID() << "] deleting entity. ID:" << entityItemID;
+            }
+
         }
         deleteEntities(entityItemIDsToDelete, true, true);
     }


### PR DESCRIPTION
In tracking down the "sometimes content doesn't save" issue, I discovered that what was actually happening was a script was deleting entities... this new logging will be useful for server operators so they can determine if/why things are being deleted.