### PR TITLE
Remove unload callback

### DIFF
--- a/examples/entityScripts/lightController.js
+++ b/examples/entityScripts/lightController.js
@@ -212,11 +212,7 @@
 
     this.preload = function(entityID) {
         this.preOperation(entityID);
-    };
-    this.unload = function(){
-        Entities.deleteEntity(this.lightID);
     }
-    
     
     this.clickReleaseOnEntity = function(entityID, mouseEvent) {
         this.preOperation(entityID);


### PR DESCRIPTION
From what i can see, eric added this callback most likely thinking it would only be called when the entity is deleted.
Looks like it has a really exotic behavior when this is called with an uninitialised this.lightID.
Still trying to figure out why it would delete random content.