### PR TITLE
Fix bug where change of entity dimensions would not update physics for others

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -524,9 +524,9 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
             }
         } else {
             if (useMeters) {
-                READ_ENTITY_PROPERTY_SETTER(PROP_DIMENSIONS, glm::vec3, setDimensions);
+                READ_ENTITY_PROPERTY_SETTER(PROP_DIMENSIONS, glm::vec3, updateDimensions);
             } else {
-                READ_ENTITY_PROPERTY_SETTER(PROP_DIMENSIONS, glm::vec3, setDimensionsInDomainUnits);
+                READ_ENTITY_PROPERTY_SETTER(PROP_DIMENSIONS, glm::vec3, updateDimensionsInDomainUnits);
             }
         }
         


### PR DESCRIPTION
The bug: when someone else would change the dimensions of an entity its collision shape would not update on remote interfaces.

The solution: use EntityItem::updateDimensions() instead of EntityItem::setDimensions() when unpacking EntityItemProperties.  The updateFoo() methods properly set dirty bits that are then used to trigger changes to the physics engine.