### PR TITLE
avoid repeatedly calling QAudioDeviceInfo::availableDevices on linux

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1281,6 +1281,9 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
 }
 
 void AudioClient::checkDevices() {
+#   ifdef Q_OS_LINUX
+    // on linux, this makes the audio stream hiccup
+#   else
     QVector<QString> inputDevices = getDeviceNames(QAudio::AudioInput);
     QVector<QString> outputDevices = getDeviceNames(QAudio::AudioOutput);
 
@@ -1290,6 +1293,7 @@ void AudioClient::checkDevices() {
 
         emit deviceChanged();
     }
+#   endif
 }
 
 void AudioClient::loadSettings() {


### PR DESCRIPTION
It's called once per second and blocks the audio thread for about a second.  This causes weird buffering problems and makes the audio-client on linux unusable.  It might be worth understanding why it's blocking the thread, but I didn't manage to do this.  There are various Qt bugs that may be related, but nothing I found looked exactly like this.
