### PR TITLE
Quit VRMode before aboutToQuit runs

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -564,8 +564,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
 }
 
 void Application::aboutToQuit() {
-    _aboutToQuit = true;
+    emit beforeAboutToQuit();
     
+    _aboutToQuit = true;
     cleanupBeforeQuit();
 }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -337,6 +337,8 @@ signals:
 
     void faceURLChanged(const QString& newValue);
     void skeletonURLChanged(const QString& newValue);
+    
+    void beforeAboutToQuit();
 
 public slots:
     void domainChanged(const QString& domainHostname);

--- a/interface/src/ui/HMDToolsDialog.cpp
+++ b/interface/src/ui/HMDToolsDialog.cpp
@@ -87,7 +87,7 @@ HMDToolsDialog::HMDToolsDialog(QWidget* parent) :
     }
     
     // when the application is about to quit, leave HDM mode
-    connect(Application::getInstance(), SIGNAL(aboutToQuit()), this, SLOT(aboutToQuit()));
+    connect(Application::getInstance(), SIGNAL(beforeAboutToQuit()), this, SLOT(aboutToQuit()));
 
     // keep track of changes to the number of screens
     connect(QApplication::desktop(), &QDesktopWidget::screenCountChanged, this, &HMDToolsDialog::screenCountChanged);


### PR DESCRIPTION
I think this got broken when we changed the close up routines.