### PR TITLE
Ensure the frame timer doesn't re-engage on exit

### DIFF
--- a/interface/src/GLCanvas.cpp
+++ b/interface/src/GLCanvas.cpp
@@ -123,7 +123,7 @@ void GLCanvas::activeChanged(Qt::ApplicationState state) {
 
         default:
             // Otherwise, throttle.
-            if (!_throttleRendering) {
+            if (!_throttleRendering && !Application::getInstance()->isAboutToQuit()) {
                 _frameTimer.start(_idleRenderInterval);
                 _throttleRendering = true;
             }


### PR DESCRIPTION
On my Win32 system, the GL canvas gets an ApplicationInactive message after the dependency manager has destroyed most of it's stuff, leading to an GLCanvas::throttleRender() call triggered by the timer, and a subsequent crash.  

Andrew wasn't able to reproduce the crash on exit, so I'm not sure what the differences in our systems are that are responsible for different behavior.  

Additionally, even after resolving this, I'm getting a lot of memory corruption errors on exit, and a deadlock.  