### PR TITLE
Add support for Color attribute loading from FBX model

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -2504,7 +2504,7 @@ int Model::renderMeshesFromList(QVector<int>& list, gpu::Batch& batch, RenderMod
         }
 
         if (mesh.colors.isEmpty()) {
-            GLBATCH(glColor4f)(0.0f, 1.0f, 0.0f, 1.0f);
+            GLBATCH(glColor4f)(1.0f, 1.0f, 1.0f, 1.0f);
         }
 
         qint64 offset = 0;

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -19,8 +19,10 @@
 uniform sampler2D diffuseMap;
 
 // the interpolated normal
-varying vec3 vertexColor;
 varying vec4 normal;
+
+varying vec3 color;
+
 
 void main(void) {
     // Fetch diffuse map
@@ -31,7 +33,7 @@ void main(void) {
     packDeferredFragment(
         normalize(normal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb * vertexColor,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         getMaterialSpecular(mat),
         getMaterialShininess(mat));
 }

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -19,6 +19,7 @@
 uniform sampler2D diffuseMap;
 
 // the interpolated normal
+varying vec3 vertexColor;
 varying vec4 normal;
 
 void main(void) {
@@ -30,7 +31,7 @@ void main(void) {
     packDeferredFragment(
         normalize(normal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * vertexColor,
         getMaterialSpecular(mat),
         getMaterialShininess(mat));
 }

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -21,12 +21,13 @@ uniform mat4 texcoordMatrices[MAX_TEXCOORDS];
 
 
 // the interpolated normal
+varying vec3 vertexColor;
 varying vec4 normal;
 
 void main(void) {
     
     // pass along the diffuse color
-    gl_FrontColor = gl_Color;
+    vertexColor = gl_Color.xyz;
     
     // and the texture coordinates
     gl_TexCoord[0] = texcoordMatrices[0] * vec4(gl_MultiTexCoord0.xy, 0.0, 1.0);

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -19,15 +19,15 @@ const int MAX_TEXCOORDS = 2;
 
 uniform mat4 texcoordMatrices[MAX_TEXCOORDS];
 
-
 // the interpolated normal
-varying vec3 vertexColor;
 varying vec4 normal;
+
+varying vec3 color;
 
 void main(void) {
     
     // pass along the diffuse color
-    vertexColor = gl_Color.xyz;
+    color = gl_Color.xyz;
     
     // and the texture coordinates
     gl_TexCoord[0] = texcoordMatrices[0] * vec4(gl_MultiTexCoord0.xy, 0.0, 1.0);

--- a/libraries/render-utils/src/model_lightmap.slf
+++ b/libraries/render-utils/src/model_lightmap.slf
@@ -26,6 +26,8 @@ uniform vec2 emissiveParams;
 // the interpolated normal
 varying vec4 normal;
 
+varying vec3 color;
+
 // the interpolated texcoord1
 varying vec2 interpolatedTexcoord1;
 
@@ -39,7 +41,7 @@ void main(void) {
     packDeferredFragmentLightmap(
         normalize(normal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         getMaterialSpecular(mat),
         getMaterialShininess(mat),
         (vec3(emissiveParams.x) + emissiveParams.y * emissive.rgb));

--- a/libraries/render-utils/src/model_lightmap.slv
+++ b/libraries/render-utils/src/model_lightmap.slv
@@ -28,9 +28,12 @@ varying vec4 normal;
 // the interpolated texcoord1
 varying vec2 interpolatedTexcoord1;
 
+varying vec3 color;
+
+
 void main(void) {
     // pass along the diffuse color
-    gl_FrontColor = gl_Color;
+    color = gl_Color.xyz;
     
     // and the texture coordinates
     gl_TexCoord[0] = texcoordMatrices[0] * vec4(gl_MultiTexCoord0.xy, 0.0, 1.0);

--- a/libraries/render-utils/src/model_lightmap_normal_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slf
@@ -34,6 +34,8 @@ varying vec4 interpolatedTangent;
 
 varying vec2 interpolatedTexcoord1;
 
+varying vec3 color;
+
 void main(void) {
     // compute the view normal from the various bits
     vec3 normalizedNormal = normalize(vec3(interpolatedNormal));
@@ -52,7 +54,7 @@ void main(void) {
     packDeferredFragmentLightmap(
         normalize(viewNormal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         getMaterialSpecular(mat),
         getMaterialShininess(mat),
         (vec3(emissiveParams.x) + emissiveParams.y * emissive.rgb));

--- a/libraries/render-utils/src/model_lightmap_normal_map.slv
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slv
@@ -34,13 +34,15 @@ varying vec4 interpolatedTangent;
 // the interpolated texcoord1
 varying vec2 interpolatedTexcoord1;
 
+varying vec3 color;
+
 void main(void) {
     // transform and store the normal and tangent for interpolation
     //interpolatedNormal = gl_ModelViewMatrix * vec4(gl_Normal, 0.0);
     //interpolatedTangent = gl_ModelViewMatrix * vec4(tangent, 0.0);
     
     // pass along the diffuse color
-    gl_FrontColor = gl_Color;
+    color = gl_Color.xyz;
     
     // and the texture coordinates
     gl_TexCoord[0] = texcoordMatrices[0] * vec4(gl_MultiTexCoord0.xy, 0.0, 1.0);

--- a/libraries/render-utils/src/model_lightmap_normal_specular_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_specular_map.slf
@@ -37,6 +37,9 @@ varying vec4 interpolatedTangent;
 
 varying vec2 interpolatedTexcoord1;
 
+varying vec3 color;
+
+
 void main(void) {
     // compute the view normal from the various bits
     vec3 normalizedNormal = normalize(vec3(interpolatedNormal));
@@ -56,7 +59,7 @@ void main(void) {
     packDeferredFragmentLightmap(
         normalize(viewNormal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         specular, // no use of getMaterialSpecular(mat)
         getMaterialShininess(mat),
         (vec3(emissiveParams.x) + emissiveParams.y * emissive.rgb));

--- a/libraries/render-utils/src/model_lightmap_specular_map.slf
+++ b/libraries/render-utils/src/model_lightmap_specular_map.slf
@@ -31,6 +31,8 @@ varying vec4 normal;
 
 varying vec2 interpolatedTexcoord1;
 
+varying vec3 color;
+
 void main(void) {
     // set the diffuse, normal, specular data
     vec4 diffuse = texture2D(diffuseMap, gl_TexCoord[0].st);
@@ -42,7 +44,7 @@ void main(void) {
     packDeferredFragmentLightmap(
         normalize(normal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         specular, // no use of getMaterialSpecular(mat)
         getMaterialShininess(mat),
         (vec3(emissiveParams.x) + emissiveParams.y * emissive.rgb));

--- a/libraries/render-utils/src/model_normal_map.slf
+++ b/libraries/render-utils/src/model_normal_map.slf
@@ -28,6 +28,8 @@ varying vec4 interpolatedNormal;
 // the interpolated tangent
 varying vec4 interpolatedTangent;
 
+varying vec3 color;
+
 void main(void) {
     // compute the view normal from the various bits
     vec3 normalizedNormal = normalize(vec3(interpolatedNormal));
@@ -44,7 +46,7 @@ void main(void) {
     packDeferredFragment(
         normalize(viewNormal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         getMaterialSpecular(mat),
         getMaterialShininess(mat));
 }

--- a/libraries/render-utils/src/model_normal_map.slv
+++ b/libraries/render-utils/src/model_normal_map.slv
@@ -29,13 +29,15 @@ varying vec4 interpolatedNormal;
 // the interpolated tangent
 varying vec4 interpolatedTangent;
 
+varying vec3 color;
+
 void main(void) {
     // transform and store the normal and tangent for interpolation
     //interpolatedNormal = gl_ModelViewMatrix * vec4(gl_Normal, 0.0);
     //interpolatedTangent = gl_ModelViewMatrix * vec4(tangent, 0.0);
     
     // pass along the diffuse color
-    gl_FrontColor = gl_Color;
+    color = gl_Color.xyz;
     
     // and the texture coordinates
     gl_TexCoord[0] = texcoordMatrices[0] * vec4(gl_MultiTexCoord0.xy, 0.0, 1.0);

--- a/libraries/render-utils/src/model_normal_specular_map.slf
+++ b/libraries/render-utils/src/model_normal_specular_map.slf
@@ -31,6 +31,8 @@ varying vec4 interpolatedNormal;
 // the interpolated tangent
 varying vec4 interpolatedTangent;
 
+varying vec3 color;
+
 void main(void) {
     // compute the view normal from the various bits
     vec3 normalizedNormal = normalize(vec3(interpolatedNormal));
@@ -49,7 +51,7 @@ void main(void) {
     packDeferredFragment(
         normalize(viewNormal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         specular, //getMaterialSpecular(mat),
         getMaterialShininess(mat));
 }

--- a/libraries/render-utils/src/model_specular_map.slf
+++ b/libraries/render-utils/src/model_specular_map.slf
@@ -25,6 +25,8 @@ uniform sampler2D specularMap;
 // the interpolated normal
 varying vec4 normal;
 
+varying vec3 color;
+
 void main(void) {
     // set the diffuse, normal, specular data
     vec4 diffuse = texture2D(diffuseMap, gl_TexCoord[0].st);
@@ -35,7 +37,7 @@ void main(void) {
     packDeferredFragment(
         normalize(normal.xyz), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), diffuse.a),
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         specular, //getMaterialSpecular(mat),
         getMaterialShininess(mat));
 }

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -21,6 +21,8 @@ uniform sampler2D diffuseMap;
 
 varying vec4 normal;
 
+varying vec3 color;
+
 void main(void) {
 
     // Fetch diffuse map
@@ -31,7 +33,7 @@ void main(void) {
     packDeferredFragmentTranslucent(
         normalize(normal.xyz), 
         getMaterialOpacity(mat) * diffuse.a,
-        getMaterialDiffuse(mat) * diffuse.rgb,
+        getMaterialDiffuse(mat) * diffuse.rgb * color,
         getMaterialSpecular(mat),
         getMaterialShininess(mat));
 

--- a/libraries/render-utils/src/skin_model.slv
+++ b/libraries/render-utils/src/skin_model.slv
@@ -28,6 +28,8 @@ attribute vec4 clusterWeights;
 // the interpolated normal
 varying vec4 normal;
 
+varying vec3 color;
+
 void main(void) {
     vec4 position = vec4(0.0, 0.0, 0.0, 0.0);
     normal = vec4(0.0, 0.0, 0.0, 0.0);
@@ -39,7 +41,7 @@ void main(void) {
     }
 
     // pass along the diffuse color
-    gl_FrontColor = gl_Color;
+    color = gl_Color.xyz;
 
     // and the texture coordinates
     gl_TexCoord[0] = texcoordMatrices[0] * vec4(gl_MultiTexCoord0.xy, 0.0, 1.0);

--- a/libraries/render-utils/src/skin_model_normal_map.slv
+++ b/libraries/render-utils/src/skin_model_normal_map.slv
@@ -34,6 +34,8 @@ varying vec4 interpolatedNormal;
 // the interpolated tangent
 varying vec4 interpolatedTangent;
 
+varying vec3 color;
+
 void main(void) {
     vec4 interpolatedPosition = vec4(0.0, 0.0, 0.0, 0.0);
     interpolatedNormal = vec4(0.0, 0.0, 0.0, 0.0);
@@ -47,7 +49,7 @@ void main(void) {
     }
 
     // pass along the diffuse color
-    gl_FrontColor = gl_Color;
+    color = gl_Color.xyz;
 
     // and the texture coordinates
     gl_TexCoord[0] = texcoordMatrices[0] * vec4(gl_MultiTexCoord0.xy, 0.0, 1.0);


### PR DESCRIPTION
- load the attribute LayerElementColor from the FBX geometry model and bring it in the model::Geometry used for rendering

- Tweak the model.slv and model.slf to support the color info comming from the mesh

