### PR TITLE
CR for Animation fixes

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -640,6 +640,7 @@ void MyAvatar::saveData() {
         settings.setValue("firstFrame", pointer->getFirstFrame());
         settings.setValue("lastFrame", pointer->getLastFrame());
         settings.setValue("maskedJoints", pointer->getMaskedJoints());
+        settings.setValue("running", pointer->getLoop() && pointer->isRunning());
     }
     settings.endArray();
     
@@ -713,6 +714,9 @@ void MyAvatar::loadData() {
         handle->setFirstFrame(settings.value("firstFrame", 0.0f).toFloat());
         handle->setLastFrame(settings.value("lastFrame", INT_MAX).toFloat());
         handle->setMaskedJoints(settings.value("maskedJoints").toStringList());
+        if (settings.value("loop", true).toBool() && settings.value("running", false).toBool()) {
+            handle->setRunning(true);
+        }
     }
     settings.endArray();
     

--- a/interface/src/ui/AnimationsDialog.cpp
+++ b/interface/src/ui/AnimationsDialog.cpp
@@ -118,7 +118,7 @@ AnimationPanel::AnimationPanel(AnimationsDialog* dialog, const AnimationHandlePo
     QHBoxLayout* maskedJointBox = new QHBoxLayout();
     layout->addRow("Masked Joints:", maskedJointBox);
     maskedJointBox->addWidget(_maskedJoints = new QLineEdit(handle->getMaskedJoints().join(", ")), 1);
-    connect(_maskedJoints, SIGNAL(returnPressed()), SLOT(updateHandle()));
+    connect(_maskedJoints, SIGNAL(editingFinished()), SLOT(updateHandle()));
     maskedJointBox->addWidget(_chooseMaskedJoints = new QPushButton("Choose"));
     connect(_chooseMaskedJoints, SIGNAL(clicked(bool)), SLOT(chooseMaskedJoints()));
     

--- a/interface/src/ui/AnimationsDialog.cpp
+++ b/interface/src/ui/AnimationsDialog.cpp
@@ -96,7 +96,7 @@ AnimationPanel::AnimationPanel(AnimationsDialog* dialog, const AnimationHandlePo
     QHBoxLayout* urlBox = new QHBoxLayout();
     layout->addRow("URL:", urlBox);
     urlBox->addWidget(_url = new QLineEdit(handle->getURL().toString()), 1);
-    connect(_url, SIGNAL(returnPressed()), SLOT(updateHandle()));
+    connect(_url, SIGNAL(editingFinished()), SLOT(updateHandle()));
     QPushButton* chooseURL = new QPushButton("Choose");
     urlBox->addWidget(chooseURL);
     connect(chooseURL, SIGNAL(clicked(bool)), SLOT(chooseURL()));
@@ -168,7 +168,7 @@ void AnimationPanel::chooseURL() {
     }
     _animationDirectory.set(QFileInfo(filename).path());
     _url->setText(QUrl::fromLocalFile(filename).toString());
-    emit _url->returnPressed();
+    emit _url->editingFinished();
 }
 
 void AnimationPanel::chooseMaskedJoints() {

--- a/interface/src/ui/AttachmentsDialog.cpp
+++ b/interface/src/ui/AttachmentsDialog.cpp
@@ -113,7 +113,7 @@ AttachmentPanel::AttachmentPanel(AttachmentsDialog* dialog, const AttachmentData
     layout->addRow("Model URL:", urlBox);
     urlBox->addWidget(_modelURL = new QLineEdit(data.modelURL.toString()), 1);
     _modelURL->setText(data.modelURL.toString());
-    connect(_modelURL, SIGNAL(returnPressed()), SLOT(modelURLChanged()));
+    connect(_modelURL, SIGNAL(editingFinished()), SLOT(modelURLChanged()));
     QPushButton* chooseURL = new QPushButton("Choose");
     urlBox->addWidget(chooseURL);
     connect(chooseURL, SIGNAL(clicked(bool)), SLOT(chooseModelURL()));

--- a/libraries/render-utils/src/AnimationHandle.cpp
+++ b/libraries/render-utils/src/AnimationHandle.cpp
@@ -64,8 +64,8 @@ void AnimationHandle::setRunning(bool running) {
         if (running) {
             // move back to the beginning
             setFrameIndex(getFirstFrame());
+            return;
         }
-        return;
     }
     _animationLoop.setRunning(running);
     if (isRunning()) {


### PR DESCRIPTION
Fix manually entered animation URL not being able to be started
Also fixed manually entered animation joint mask values not taking effect.
And fixed manually entered attachment model URL not taking effect.
Automatically start looped animation at start-up if it was running at shut-down.
And fixed Stop button not working at the end of a non-looped animation.