### PR TITLE
fix the rendering bug on mac release

### DIFF
--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -95,35 +95,36 @@ void GLBackend::renderBatch(Batch& batch) {
     backend.render(batch);
 }
 
-void GLBackend::checkGLError() {
+bool GLBackend::checkGLError(const char* name) {
     GLenum error = glGetError();
     if (!error) {
-        return;
+        return false;
     }
     else {
         switch (error) {
         case GL_INVALID_ENUM:
-            qCDebug(gpulogging) << "An unacceptable value is specified for an enumerated argument.The offending command is ignored and has no other side effect than to set the error flag.";
+            qCDebug(gpulogging) << "GLBackend::" << name << ": An unacceptable value is specified for an enumerated argument.The offending command is ignored and has no other side effect than to set the error flag.";
             break;
         case GL_INVALID_VALUE:
-            qCDebug(gpulogging) << "A numeric argument is out of range.The offending command is ignored and has no other side effect than to set the error flag";
+            qCDebug(gpulogging) << "GLBackend" << name << ": A numeric argument is out of range.The offending command is ignored and has no other side effect than to set the error flag";
             break;
         case GL_INVALID_OPERATION:
-            qCDebug(gpulogging) << "The specified operation is not allowed in the current state.The offending command is ignored and has no other side effect than to set the error flag..";
+            qCDebug(gpulogging) << "GLBackend" << name << ": The specified operation is not allowed in the current state.The offending command is ignored and has no other side effect than to set the error flag..";
             break;
         case GL_INVALID_FRAMEBUFFER_OPERATION:
-            qCDebug(gpulogging) << "The framebuffer object is not complete.The offending command is ignored and has no other side effect than to set the error flag.";
+            qCDebug(gpulogging) << "GLBackend" << name << ": The framebuffer object is not complete.The offending command is ignored and has no other side effect than to set the error flag.";
             break;
         case GL_OUT_OF_MEMORY:
-            qCDebug(gpulogging) << "There is not enough memory left to execute the command.The state of the GL is undefined, except for the state of the error flags, after this error is recorded.";
+            qCDebug(gpulogging) << "GLBackend" << name << ": There is not enough memory left to execute the command.The state of the GL is undefined, except for the state of the error flags, after this error is recorded.";
             break;
         case GL_STACK_UNDERFLOW:
-            qCDebug(gpulogging) << "An attempt has been made to perform an operation that would cause an internal stack to underflow.";
+            qCDebug(gpulogging) << "GLBackend" << name << ": An attempt has been made to perform an operation that would cause an internal stack to underflow.";
             break;
         case GL_STACK_OVERFLOW:
-            qCDebug(gpulogging) << "An attempt has been made to perform an operation that would cause an internal stack to overflow.";
+            qCDebug(gpulogging) << "GLBackend" << name << ": An attempt has been made to perform an operation that would cause an internal stack to overflow.";
             break;
         }
+        return true;
     }
 }
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -31,7 +31,7 @@ public:
 
     static void renderBatch(Batch& batch);
 
-    static void checkGLError();
+    static bool checkGLError(const char* name = nullptr);
 
     static bool makeProgram(Shader& shader, const Shader::BindingSet& bindings = Shader::BindingSet());
     

--- a/libraries/gpu/src/gpu/GLBackendShared.h
+++ b/libraries/gpu/src/gpu/GLBackendShared.h
@@ -50,9 +50,9 @@ static const GLenum _elementTypeToGLType[NUM_TYPES]= {
 };
 
 #if _DEBUG
-#define CHECK_GL_ERROR() ::gpu::GLBackend::checkGLError()
+#define CHECK_GL_ERROR() ::gpu::GLBackend::checkGLError(__FUNCTION__)
 #else
-#define CHECK_GL_ERROR()
+#define CHECK_GL_ERROR() false
 #endif
 
 #endif

--- a/libraries/gpu/src/gpu/GLBackendState.cpp
+++ b/libraries/gpu/src/gpu/GLBackendState.cpp
@@ -598,9 +598,14 @@ void GLBackend::do_setStateDepthTest(State::DepthTest test) {
         } else {
             glDisable(GL_DEPTH_TEST);
         }
-        CHECK_GL_ERROR();
+        if (CHECK_GL_ERROR()) {
+            qDebug() << "DepthTest" << (test.isEnabled() ? "Enabled" : "Disabled")
+                    << "Mask=" << (test.getWriteMask() ? "Write" : "no Write")
+                    << "Func=" << test.getFunction()
+                    << "Raw=" << test.getRaw();
+        }
 
-         _pipeline._stateCache.depthTest = test;
+        _pipeline._stateCache.depthTest = test;
     }
 }
 
@@ -712,7 +717,7 @@ void GLBackend::do_setStateBlend(State::BlendFunction function) {
 }
 
 void GLBackend::do_setStateColorWriteMask(uint32 mask) {
-    if (_pipeline._stateCache.colorWriteMask = mask) {
+    if (_pipeline._stateCache.colorWriteMask != mask) {
         glColorMask(mask & State::ColorMask::WRITE_RED,
                 mask & State::ColorMask::WRITE_GREEN,
                 mask & State::ColorMask::WRITE_BLUE,

--- a/libraries/gpu/src/gpu/State.h
+++ b/libraries/gpu/src/gpu/State.h
@@ -127,10 +127,11 @@ public:
 
     class DepthTest {
         uint8 _function = LESS;
-        bool _writeMask = true;
-        bool _enabled = false;
+        uint8 _writeMask = true;
+        uint8 _enabled = false;
+        uint8 _spare;
     public:
-        DepthTest(bool enabled, bool writeMask, ComparisonFunction func) : 
+        DepthTest(bool enabled = false, bool writeMask = true, ComparisonFunction func = LESS) :
             _function(func), _writeMask(writeMask), _enabled(enabled) {}
 
         bool isEnabled() const { return _enabled; }


### PR DESCRIPTION
...due to the State::DepthTest not properly aligned to 4bytes. Fixed by padding the DepthTest class with spare space.
- Improved the glCheckError for knowing where the error comes from
- Catch a typo in a test, the classic = instead of == yeah

