### PR TITLE
Add /LARGEADDRESSAWARE linker flag for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ if (WIN32)
   message (WINDOW_SDK_PATH= ${WINDOW_SDK_PATH})
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${WINDOW_SDK_PATH})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  # /LARGEADDRESSAWARE enables 32-bit apps to use more than 2GB of memory.
+  # Caveats: http://stackoverflow.com/questions/2288728/drawbacks-of-using-largeaddressaware-for-32-bit-windows-executables
+  # TODO: Remove when building 64-bit.
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
 elseif (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
   #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic")
   #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unknown-pragmas")


### PR DESCRIPTION
Enables Interface to use more than 2GB of memory.
Reduces the incidence of bad_alloc crashes.
Can be removed once Interface is built 64-bit.