### PR TITLE
Trim entity properties set from JS that are strings

### DIFF
--- a/libraries/entities/src/EntityItemPropertiesMacros.h
+++ b/libraries/entities/src/EntityItemPropertiesMacros.h
@@ -201,7 +201,7 @@
 #define COPY_PROPERTY_FROM_QSCRIPTVALUE_STRING(P, S)\
     QScriptValue P = object.property(#P);           \
     if (P.isValid()) {                              \
-        QString newValue = P.toVariant().toString();\
+        QString newValue = P.toVariant().toString().trimmed();\
         if (_defaultSettings || newValue != _##P) { \
             S(newValue);                            \
         }                                           \


### PR DESCRIPTION
Will remove white spaces before/after URLs and also will prevent setting a property containing only white spaces.