### PR TITLE
Attempt to stop the crashing on exit caused by the Oculus SDK

### DIFF
--- a/interface/src/devices/OculusManager.cpp
+++ b/interface/src/devices/OculusManager.cpp
@@ -114,13 +114,22 @@ void OculusManager::initSdk() {
 }
 
 void OculusManager::shutdownSdk() {
-    ovrHmd_Destroy(_ovrHmd);
-    ovr_Shutdown();
+    if (_ovrHmd) {
+        ovrHmd_Destroy(_ovrHmd);
+        _ovrHmd = nullptr;
+        ovr_Shutdown();
+    }
 }
 
 void OculusManager::init() {
 #ifdef OVR_DIRECT_MODE
 	initSdk();
+#endif
+}
+
+void OculusManager::deinit() {
+#ifdef OVR_DIRECT_MODE
+    shutdownSdk();
 #endif
 }
 

--- a/interface/src/devices/OculusManager.h
+++ b/interface/src/devices/OculusManager.h
@@ -51,6 +51,7 @@ class Text3DOverlay;
 class OculusManager {
 public:
     static void init();
+    static void deinit();
     static void connect();
     static void disconnect();
     static bool isConnected();

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -112,6 +112,7 @@ int main(int argc, const char* argv[]) {
         exitCode = app.exec();
     }
 
+    OculusManager::deinit();
 #ifdef Q_OS_WIN
     ReleaseMutex(mutex);
 #endif


### PR DESCRIPTION
This should ensure a proper shutdown of the Oculus SDK on exiting the app when using direct HMD mode.  