### PR TITLE
Ensure blending is enabled during starfield rendering

### DIFF
--- a/interface/src/starfield/renderer/Renderer.cpp
+++ b/interface/src/starfield/renderer/Renderer.cpp
@@ -212,6 +212,7 @@ void Renderer::glUpload(GLsizei numStars) {
 void Renderer::glBatch(GLfloat const* matrix, GLsizei n_ranges, float alpha) {
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_LIGHTING);
+    glEnable(GL_BLEND);
 
     // setup modelview matrix
     glPushMatrix();


### PR DESCRIPTION
This is a quick and dirty fix for the bad starfield rendering mentioned here:  https://alphas.highfidelity.io/t/sad-graphics-for-stars/5055 and listed as a bug here: https://app.asana.com/0/26225263936266/31206140614388

However, I believe that the *proper* fix is to determine what is disabling blending and failing to restore it.  