### PR TITLE
Fix ghost avatars

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -149,7 +149,7 @@ void AvatarManager::simulateAvatarFades(float deltaTime) {
 
     while (fadingIterator != _avatarFades.end()) {
         Avatar* avatar = static_cast<Avatar*>(fadingIterator->data());
-        avatar->setTargetScale(avatar->getScale() * SHRINK_RATE);
+        avatar->setTargetScale(avatar->getScale() * SHRINK_RATE, true);
         if (avatar->getTargetScale() < MIN_FADE_SCALE) {
             fadingIterator = _avatarFades.erase(fadingIterator);
         } else {


### PR DESCRIPTION
If avatars are using a referential, their scale does not get updated and so they are trapped in the avatarFades forever.
This fixes it.