### PR TITLE
Introduce the gpu::Framebuffer and its sidekick the gpu::Swapchain

### DIFF
--- a/interface/src/devices/OculusManager.cpp
+++ b/interface/src/devices/OculusManager.cpp
@@ -34,7 +34,7 @@
 #include "InterfaceLogging.h"
 #include "Application.h"
 
-#include <gpu\GLBackend.h>
+#include <gpu/GLBackend.h>
 
 template <typename Function>
 void for_each_eye(Function function) {

--- a/interface/src/devices/TV3DManager.cpp
+++ b/interface/src/devices/TV3DManager.cpp
@@ -11,8 +11,6 @@
 
 #include "InterfaceConfig.h"
 
-#include <QOpenGLFramebufferObject>
-
 #include <glm/glm.hpp>
 
 #include <GlowEffect.h>

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -25,7 +25,8 @@ Batch::Batch() :
     _textures(),
     _streamFormats(),
     _transforms(),
-    _pipelines()
+    _pipelines(),
+    _framebuffers()
 {
 }
 
@@ -41,7 +42,8 @@ void Batch::clear() {
     _textures.clear();
     _streamFormats.clear();
     _transforms.clear();
-    _pipelines.clear();    
+    _pipelines.clear();
+    _framebuffers.clear();
 }
 
 uint32 Batch::cacheData(uint32 size, const void* data) {
@@ -184,5 +186,12 @@ void Batch::setUniformTexture(uint32 slot, const TexturePointer& texture) {
 
 void Batch::setUniformTexture(uint32 slot, const TextureView& view) {
     setUniformTexture(slot, view._texture);
+}
+
+void Batch::setFramebuffer(const FramebufferPointer& framebuffer) {
+    ADD_COMMAND(setUniformTexture);
+
+    _params.push_back(_framebuffers.cache(framebuffer));
+
 }
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -23,6 +23,8 @@
 
 #include "Pipeline.h"
 
+#include "Framebuffer.h"
+
 #if defined(NSIGHT_FOUND)
     #include "nvToolsExt.h"
     class ProfileRange {
@@ -112,6 +114,8 @@ public:
     void setUniformTexture(uint32 slot, const TexturePointer& view);
     void setUniformTexture(uint32 slot, const TextureView& view); // not a command, just a shortcut from a TextureView
 
+    // Framebuffer Stage
+    void setFramebuffer(const FramebufferPointer& framebuffer);
 
     // TODO: As long as we have gl calls explicitely issued from interface
     // code, we need to be able to record and batch these calls. THe long 
@@ -169,6 +173,8 @@ public:
 
         COMMAND_setUniformBuffer,
         COMMAND_setUniformTexture,
+
+        COMMAND_setFramebuffer,
 
         // TODO: As long as we have gl calls explicitely issued from interface
         // code, we need to be able to record and batch these calls. THe long 
@@ -266,6 +272,7 @@ public:
     typedef Cache<Stream::FormatPointer>::Vector StreamFormatCaches;
     typedef Cache<Transform>::Vector TransformCaches;
     typedef Cache<PipelinePointer>::Vector PipelineCaches;
+    typedef Cache<FramebufferPointer>::Vector FramebufferCaches;
 
     // Cache Data in a byte array if too big to fit in Param
     // FOr example Mat4s are going there
@@ -289,6 +296,7 @@ public:
     StreamFormatCaches _streamFormats;
     TransformCaches _transforms;
     PipelineCaches _pipelines;
+    FramebufferCaches _framebuffers;
 
 protected:
 };

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -15,8 +15,8 @@
 
 #include "Resource.h"
 #include "Texture.h"
-#include "Shader.h"
 #include "Pipeline.h"
+#include "Framebuffer.h"
 
 namespace gpu {
 
@@ -47,8 +47,8 @@ public:
     };
 
     template< typename T >
-    static void setGPUObject(const Buffer& buffer, T* bo) {
-        buffer.setGPUObject(bo);
+    static void setGPUObject(const Buffer& buffer, T* object) {
+        buffer.setGPUObject(object);
     }
     template< typename T >
     static T* getGPUObject(const Buffer& buffer) {
@@ -56,8 +56,8 @@ public:
     }
 
     template< typename T >
-    static void setGPUObject(const Texture& texture, T* to) {
-        texture.setGPUObject(to);
+    static void setGPUObject(const Texture& texture, T* object) {
+        texture.setGPUObject(object);
     }
     template< typename T >
     static T* getGPUObject(const Texture& texture) {
@@ -65,8 +65,8 @@ public:
     }
     
     template< typename T >
-    static void setGPUObject(const Shader& shader, T* so) {
-        shader.setGPUObject(so);
+    static void setGPUObject(const Shader& shader, T* object) {
+        shader.setGPUObject(object);
     }
     template< typename T >
     static T* getGPUObject(const Shader& shader) {
@@ -74,8 +74,8 @@ public:
     }
 
     template< typename T >
-    static void setGPUObject(const Pipeline& pipeline, T* po) {
-        pipeline.setGPUObject(po);
+    static void setGPUObject(const Pipeline& pipeline, T* object) {
+        pipeline.setGPUObject(object);
     }
     template< typename T >
     static T* getGPUObject(const Pipeline& pipeline) {
@@ -83,12 +83,21 @@ public:
     }
 
     template< typename T >
-    static void setGPUObject(const State& state, T* so) {
-        state.setGPUObject(so);
+    static void setGPUObject(const State& state, T* object) {
+        state.setGPUObject(object);
     }
     template< typename T >
     static T* getGPUObject(const State& state) {
         return reinterpret_cast<T*>(state.getGPUObject());
+    }
+
+    template< typename T >
+    static void setGPUObject(const Framebuffer& framebuffer, T* object) {
+        framebuffer.setGPUObject(object);
+    }
+    template< typename T >
+    static T* getGPUObject(const Framebuffer& framebuffer) {
+        return reinterpret_cast<T*>(framebuffer.getGPUObject());
     }
 
 protected:

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -34,6 +34,7 @@ typedef glm::mat3 Mat3;
 typedef glm::vec4 Vec4;
 typedef glm::vec3 Vec3;
 typedef glm::vec2 Vec2;
+typedef glm::ivec2 Vec2i;
 
 // Description of a scalar type
 enum Type {

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -35,6 +35,7 @@ typedef glm::vec4 Vec4;
 typedef glm::vec3 Vec3;
 typedef glm::vec2 Vec2;
 typedef glm::ivec2 Vec2i;
+typedef glm::uvec2 Vec2u;
 
 // Description of a scalar type
 enum Type {

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -179,6 +179,20 @@ public:
     uint8 _type : 4;
 };
 
+  
+enum ComparisonFunction {
+    NEVER = 0,
+    LESS,
+    EQUAL,
+    LESS_EQUAL,
+    GREATER,
+    NOT_EQUAL,
+    GREATER_EQUAL,
+    ALWAYS,
+
+    NUM_COMPARISON_FUNCS,
+};
+
 };
 
 

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -119,7 +119,8 @@ enum Semantic {
     INDEX, //used by index buffer of a mesh
     PART, // used by part buffer of a mesh
 
-    DEPTH, // Depth buffer
+    DEPTH, // Depth only buffer
+    STENCIL, // Stencil only buffer
     DEPTH_STENCIL, // Depth Stencil buffer
 
     SRGB,

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -173,6 +173,8 @@ public:
         return getRaw() != right.getRaw();
     }
 
+    static const Element COLOR_RGBA_32;
+
  protected:
     uint8 _semantic;
     uint8 _dimension : 4;

--- a/libraries/gpu/src/gpu/Framebuffer.cpp
+++ b/libraries/gpu/src/gpu/Framebuffer.cpp
@@ -32,8 +32,8 @@ Framebuffer* Framebuffer::create() {
 Framebuffer* Framebuffer::create( const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height, uint16 numSamples) {
     auto framebuffer = Framebuffer::create();
 
-    auto colorTexture = TexturePointer(Texture::create2D(colorBufferFormat, width, height));
-    auto depthTexture = TexturePointer(Texture::create2D(depthStencilBufferFormat, width, height));
+    auto colorTexture = TexturePointer(Texture::create2D(colorBufferFormat, width, height, Sampler(Sampler::FILTER_MIN_MAG_POINT)));
+    auto depthTexture = TexturePointer(Texture::create2D(depthStencilBufferFormat, width, height, Sampler(Sampler::FILTER_MIN_MAG_POINT)));
 
     framebuffer->setRenderBuffer(0, colorTexture);
     framebuffer->setDepthStencilBuffer(depthTexture, depthStencilBufferFormat);
@@ -44,6 +44,15 @@ Framebuffer* Framebuffer::create( const Format& colorBufferFormat, const Format&
 Framebuffer* Framebuffer::createShadowmap(uint16 width) {
     auto framebuffer = Framebuffer::create();
     auto depthTexture = TexturePointer(Texture::create2D(Element(gpu::SCALAR, gpu::FLOAT, gpu::DEPTH), width, width));
+        
+    Sampler::Desc samplerDesc;
+    samplerDesc._borderColor = glm::vec4(1.0f);
+    samplerDesc._wrapModeU = Sampler::WRAP_BORDER;
+    samplerDesc._wrapModeV = Sampler::WRAP_BORDER;
+    samplerDesc._filter = Sampler::FILTER_MIN_MAG_LINEAR;
+    samplerDesc._comparisonFunc = LESS_EQUAL;
+
+    depthTexture->setSampler(Sampler(samplerDesc));
 
     framebuffer->setDepthStencilBuffer(depthTexture, Element(gpu::SCALAR, gpu::FLOAT, gpu::DEPTH));
 

--- a/libraries/gpu/src/gpu/Framebuffer.cpp
+++ b/libraries/gpu/src/gpu/Framebuffer.cpp
@@ -15,12 +15,7 @@
 
 using namespace gpu;
 
-Framebuffer::Framebuffer()
-{
-}
-
-Framebuffer::~Framebuffer()
-{
+Framebuffer::~Framebuffer() {
 }
 
 Framebuffer* Framebuffer::create() {

--- a/libraries/gpu/src/gpu/Framebuffer.cpp
+++ b/libraries/gpu/src/gpu/Framebuffer.cpp
@@ -41,6 +41,14 @@ Framebuffer* Framebuffer::create( const Format& colorBufferFormat, const Format&
     return framebuffer;
 }
 
+Framebuffer* Framebuffer::createShadowmap(uint16 width) {
+    auto framebuffer = Framebuffer::create();
+    auto depthTexture = TexturePointer(Texture::create2D(Element(gpu::SCALAR, gpu::FLOAT, gpu::DEPTH), width, width));
+
+    framebuffer->setDepthStencilBuffer(depthTexture, Element(gpu::SCALAR, gpu::FLOAT, gpu::DEPTH));
+
+    return framebuffer;
+}
 
 bool Framebuffer::isSwapchain() const {
     return _swapchain != 0;

--- a/libraries/gpu/src/gpu/Framebuffer.cpp
+++ b/libraries/gpu/src/gpu/Framebuffer.cpp
@@ -29,7 +29,18 @@ Framebuffer* Framebuffer::create() {
     return framebuffer;
 }
 
-Framebuffer* Framebuffer::create( const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height, uint16 numSamples) {
+
+Framebuffer* Framebuffer::create( const Format& colorBufferFormat, uint16 width, uint16 height) {
+    auto framebuffer = Framebuffer::create();
+
+    auto colorTexture = TexturePointer(Texture::create2D(colorBufferFormat, width, height, Sampler(Sampler::FILTER_MIN_MAG_POINT)));
+
+    framebuffer->setRenderBuffer(0, colorTexture);
+
+    return framebuffer;
+}
+
+Framebuffer* Framebuffer::create( const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height) {
     auto framebuffer = Framebuffer::create();
 
     auto colorTexture = TexturePointer(Texture::create2D(colorBufferFormat, width, height, Sampler(Sampler::FILTER_MIN_MAG_POINT)));

--- a/libraries/gpu/src/gpu/Framebuffer.cpp
+++ b/libraries/gpu/src/gpu/Framebuffer.cpp
@@ -1,0 +1,267 @@
+//
+//  Framebuffer.cpp
+//  libraries/gpu/src/gpu
+//
+//  Created by Sam Gateau on 4/12/2015.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "Framebuffer.h"
+#include <math.h>
+#include <QDebug>
+
+using namespace gpu;
+
+Framebuffer::Framebuffer()
+{
+}
+
+Framebuffer::~Framebuffer()
+{
+}
+
+Framebuffer* Framebuffer::create() {
+    auto framebuffer = new Framebuffer();
+    framebuffer->_renderBuffers.resize(MAX_NUM_RENDER_BUFFERS);
+    framebuffer->_renderBuffersSubresource.resize(MAX_NUM_RENDER_BUFFERS, 0);
+    return framebuffer;
+}
+
+Framebuffer* Framebuffer::create( const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height, uint16 numSamples) {
+    auto framebuffer = Framebuffer::create();
+
+    auto colorTexture = TexturePointer(Texture::create2D(colorBufferFormat, width, height));
+    auto depthTexture = TexturePointer(Texture::create2D(depthStencilBufferFormat, width, height));
+
+    framebuffer->setRenderBuffer(0, colorTexture);
+    framebuffer->setDepthStencilBuffer(depthTexture);
+
+    return framebuffer;
+}
+
+
+bool Framebuffer::isSwapchain() const {
+    return _swapchain != 0;
+}
+
+uint32 Framebuffer::getFrameCount() const {
+    if (_swapchain) {
+        return _swapchain->getFrameCount();
+    } else {
+        return _frameCount;
+    }
+}
+
+bool Framebuffer::isEmpty() const {
+    return (_buffersMask == 0);
+}
+
+bool Framebuffer::validateTargetCompatibility(const Texture& texture, uint32 subresource) const {
+    if (texture.getType() == Texture::TEX_1D) {
+        return false;
+    }
+
+    if (isEmpty()) {
+        return true;
+    } else {
+        if ((texture.getWidth() == getWidth()) && 
+            (texture.getHeight() == getHeight()) && 
+            (texture.getNumSamples() == getNumSamples())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+
+void Framebuffer::updateSize(const TexturePointer& texture) {
+    if (!isEmpty()) {
+        return;
+    }
+
+    if (texture) {
+        _width = texture->getWidth();
+        _height = texture->getHeight();
+        _numSamples = texture->getNumSamples();
+    } else {
+        _width = _height = _numSamples = 0;
+    }
+}
+
+void Framebuffer::resize(uint16 width, uint16 height, uint16 numSamples) {
+    if (width && height && numSamples && !isEmpty() && !isSwapchain()) {
+        if ((width != _width) || (height != _height) || (numSamples != _numSamples)) {
+            for (uint32 i = 0; i < _renderBuffers.size(); ++i) {
+                if (_renderBuffers[i]) {
+                    _renderBuffers[i]->resize2D(width, height, numSamples);
+                    _numSamples = _renderBuffers[i]->getNumSamples();
+                }
+            }
+
+            if (_depthStencilBuffer) {
+                _depthStencilBuffer->resize2D(width, height, numSamples);
+                _numSamples = _depthStencilBuffer->getNumSamples();
+            }
+
+            _width = width;
+            _height = height;
+         //   _numSamples = numSamples;
+        }
+    }
+}
+
+uint16 Framebuffer::getWidth() const {
+    if (isSwapchain()) {
+        return getSwapchain()->getWidth();
+    } else {
+        return _width;
+    }
+}
+
+uint16 Framebuffer::getHeight() const {
+    if (isSwapchain()) {
+        return getSwapchain()->getHeight();
+    } else {
+        return _height;
+    }
+}
+
+uint16 Framebuffer::getNumSamples() const {
+    if (isSwapchain()) {
+        return getSwapchain()->getNumSamples();
+    } else {
+        return _numSamples;
+    }
+}
+
+// Render buffers
+int Framebuffer::setRenderBuffer(uint32 slot, const TexturePointer& texture, uint32 subresource) {
+    if (isSwapchain()) {
+        return -1;
+    }
+
+    // Check for the slot
+    if (slot >= getMaxNumRenderBuffers()) {
+        return -1;
+    }
+
+    // Check for the compatibility of size
+    if (texture) {
+        if (!validateTargetCompatibility(*texture, subresource)) {
+            return -1;
+        }
+    }
+
+    // everything works, assign
+    // dereference the previously used buffer if exists
+    if (_renderBuffers[slot]) {
+        _renderBuffers[slot].reset();
+        _renderBuffersSubresource[slot] = 0;
+    }
+
+    updateSize(texture);
+
+    // assign the new one
+    _renderBuffers[slot] = texture;
+
+    // Assign the subresource
+    _renderBuffersSubresource[slot] = subresource;
+
+    // update the mask
+    int mask = (1<<slot);
+    _buffersMask = (_buffersMask & ~(mask));
+    if (texture) {
+        _buffersMask |= mask;
+    }
+
+    return slot;
+}
+
+void Framebuffer::removeRenderBuffers() {
+    if (isSwapchain()) {
+        return;
+    }
+
+    _buffersMask = _buffersMask & BUFFER_DEPTHSTENCIL;
+
+    for (auto renderBuffer : _renderBuffers) {
+        renderBuffer.reset();
+    }
+
+    updateSize(TexturePointer(nullptr));
+}
+
+
+uint32 Framebuffer::getNumRenderBuffers() const {
+    uint32 nb = 0;
+    for (auto i : _renderBuffers) {
+        nb += (!i);
+    }
+    return nb;
+}
+
+TexturePointer Framebuffer::getRenderBuffer(uint32 slot) const {
+    if (!isSwapchain() && (slot < getMaxNumRenderBuffers())) {
+        return _renderBuffers[slot];
+    } else {
+        return TexturePointer();
+    }
+
+}
+
+uint32 Framebuffer::getRenderBufferSubresource(uint32 slot) const {
+    if (!isSwapchain() && (slot < getMaxNumRenderBuffers())) {
+        return _renderBuffersSubresource[slot];
+    } else {
+        return 0;
+    }
+}
+
+bool Framebuffer::setDepthStencilBuffer(const TexturePointer& texture, uint32 subresource) {
+    if (isSwapchain()) {
+        return false;
+    }
+
+    // Check for the compatibility of size
+    if (texture) {
+        if (!validateTargetCompatibility(*texture)) {
+            return false;
+        }
+    }
+
+    // Checks ok, assign
+    _depthStencilBuffer.reset();
+    _depthStencilBufferSubresource = 0;
+
+    updateSize(texture);
+
+    // assign the new one
+    _depthStencilBuffer = texture;
+    _depthStencilBufferSubresource = subresource;
+
+    _buffersMask = ( _buffersMask & ~BUFFER_DEPTHSTENCIL);
+    if (texture) {
+        _buffersMask |= BUFFER_DEPTHSTENCIL;
+    }
+
+    return true;
+}
+
+TexturePointer Framebuffer::getDepthStencilBuffer() const {
+    if (isSwapchain()) {
+        return TexturePointer();
+    } else {
+        return _depthStencilBuffer;
+    }
+}
+
+uint32 Framebuffer::getDepthStencilBufferSubresource() const {
+    if (isSwapchain()) {
+        return 0;
+    } else {
+        return _depthStencilBufferSubresource;
+    }
+}

--- a/libraries/gpu/src/gpu/Framebuffer.h
+++ b/libraries/gpu/src/gpu/Framebuffer.h
@@ -155,11 +155,9 @@ public:
     // Get viewport covering the ful Canvas
     Viewport getViewport() const { return Viewport(getWidth(), getHeight(), 0, 0); }
 
+    bool isDefined() const { return _isDefined; }
 
 protected:
-
-    Viewport _viewport;
-
     uint16 _width;
     uint16 _height;
     uint16 _numSamples;
@@ -170,12 +168,10 @@ protected:
 
     SwapchainPointer _swapchain;
 
-    Textures _renderBuffers;
-    std::vector<uint32> _renderBuffersSubresource;
+    TextureViews _renderBuffers;
+    TextureView _depthStencilBuffer;
 
-    TexturePointer _depthStencilBuffer;
-    uint32 _depthStencilBufferSubresource;
-
+    bool _isDefined = false;
 
     void updateSize(const TexturePointer& texture);
 
@@ -189,6 +185,7 @@ protected:
     GPUObject* getGPUObject() const { return _gpuObject; }
     friend class Backend;
 };
+typedef std::shared_ptr<Framebuffer> FramebufferPointer;
 
 }
 

--- a/libraries/gpu/src/gpu/Framebuffer.h
+++ b/libraries/gpu/src/gpu/Framebuffer.h
@@ -1,0 +1,195 @@
+//
+//  Framebuffer.h
+//  libraries/gpu/src/gpu
+//
+//  Created by Sam Gateau on 4/12/2015.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#ifndef hifi_gpu_Framebuffer_h
+#define hifi_gpu_Framebuffer_h
+
+#include "Texture.h"
+#include <memory>
+
+namespace gpu {
+
+typedef Element Format;
+
+class Viewport {
+public:
+    int32  width = 1;
+    int32  height = 1;
+    int32   top = 0;
+    int32   left = 0;
+    float   zmin = 0.f;
+    float   zmax = 1.f;
+
+    Viewport() {}
+    Viewport(int32 w, int32 h, int32 t = 0, int32 l = 0, float zin = 0.f, float zax = 1.f):
+        width(w),
+        height(h),
+        top(t),
+        left(l),
+        zmin(zin),
+        zmax(zax)
+    {}
+    Viewport(const Vec2i& wh, const Vec2i& tl = Vec2i(0), const Vec2& zrange = Vec2(0.f, 1.f)):
+        width(wh.x),
+        height(wh.y),
+        top(tl.x),
+        left(tl.y),
+        zmin(zrange.x),
+        zmax(zrange.y)
+    {}
+    ~Viewport() {}
+};
+
+class Swapchain {
+public:
+    // Properties
+    uint16 getWidth() const { return _width; }
+    uint16 getHeight() const { return _height; }
+    uint16 getNumSamples() const { return _numSamples; }
+
+    bool hasDepthStencil() const { return _hasDepthStencil; }
+    bool isFullscreen() const { return _isFullscreen; }
+
+    uint32 getSwapInterval() const { return _swapInterval; }
+
+    bool isStereo() const { return _isStereo; }
+
+    uint32 getFrameCount() const { return _frameCount; }
+
+    // Pure interface
+    void setSwapInterval(uint32 interval);
+
+    void resize(uint16 width, uint16 height);
+    void setFullscreen(bool fullscreen);
+
+    Swapchain() {}
+    Swapchain(const Swapchain& swapchain) {}
+    virtual ~Swapchain() {}
+
+protected:
+    mutable uint32 _frameCount = 0;
+
+    Format _colorFormat;
+    uint16 _width = 1;
+    uint16 _height = 1;
+    uint16 _numSamples = 1;
+    uint16 _swapInterval = 0;
+
+    bool _hasDepthStencil = false;
+    bool _isFullscreen = false;
+    bool _isStereo = false;
+
+    // Non exposed
+
+    friend class Framebuffer;
+};
+typedef std::shared_ptr<Swapchain> SwapchainPointer;
+
+
+class Framebuffer {
+public:
+    enum BufferMask {
+        BUFFER_COLOR0 = 1,
+        BUFFER_COLOR1 = 2,
+        BUFFER_COLOR2 = 4,
+        BUFFER_COLOR3 = 8,
+        BUFFER_COLOR4 = 16,
+        BUFFER_COLOR5 = 32,
+        BUFFER_COLOR6 = 64,
+        BUFFER_COLOR7 = 128,
+        BUFFER_COLORS = 0x000000FF,
+
+        BUFFER_DEPTH = 0x40000000,
+        BUFFER_STENCIL = 0x80000000,
+        BUFFER_DEPTHSTENCIL = 0xC0000000,
+    };
+
+    ~Framebuffer();
+
+    static Framebuffer* create(const SwapchainPointer& swapchain);
+    static Framebuffer* create();
+    static Framebuffer* create(const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height, uint16 samples );
+
+    bool isSwapchain() const;
+    SwapchainPointer getSwapchain() const { return _swapchain; }
+
+    uint32 getFrameCount() const;
+
+    // Render buffers
+    int32 setRenderBuffer(uint32 slot, const TexturePointer& texture, uint32 subresource = 0);
+    void removeRenderBuffers();
+    uint32 getNumRenderBuffers() const;
+
+    TexturePointer getRenderBuffer(uint32 slot) const;
+    uint32 getRenderBufferSubresource(uint32 slot) const;
+
+    bool setDepthStencilBuffer(const TexturePointer& texture, uint32 subresource = 0);
+    TexturePointer getDepthStencilBuffer() const;
+    uint32 getDepthStencilBufferSubresource() const;
+
+    // Properties
+    uint32 getBuffersMask() const { return _buffersMask; }
+    bool isEmpty() const;
+
+    bool validateTargetCompatibility(const Texture& texture, uint32 subresource = 0) const;
+
+    uint16 getWidth() const;
+    uint16 getHeight() const;
+    uint16 getNumSamples() const;
+
+    float getAspectRatio() const { return getWidth() / (float) getHeight() ; }
+
+    // If not a swapchain canvas, resize can resize all the render buffers and depth stencil attached in one call
+    void resize( uint16 width, uint16 height, uint16 samples = 1 );
+
+    static const uint32 MAX_NUM_RENDER_BUFFERS = 8; 
+    static uint32 getMaxNumRenderBuffers() { return MAX_NUM_RENDER_BUFFERS; }
+
+    // Get viewport covering the ful Canvas
+    Viewport getViewport() const { return Viewport(getWidth(), getHeight(), 0, 0); }
+
+
+protected:
+
+    Viewport _viewport;
+
+    uint16 _width;
+    uint16 _height;
+    uint16 _numSamples;
+
+    uint32 _buffersMask;
+
+    uint32 _frameCount;
+
+    SwapchainPointer _swapchain;
+
+    Textures _renderBuffers;
+    std::vector<uint32> _renderBuffersSubresource;
+
+    TexturePointer _depthStencilBuffer;
+    uint32 _depthStencilBufferSubresource;
+
+
+    void updateSize(const TexturePointer& texture);
+
+    // Non exposed
+    Framebuffer(const Framebuffer& framebuffer) {}
+    Framebuffer();
+    
+    // This shouldn't be used by anything else than the Backend class with the proper casting.
+    mutable GPUObject* _gpuObject = NULL;
+    void setGPUObject(GPUObject* gpuObject) const { _gpuObject = gpuObject; }
+    GPUObject* getGPUObject() const { return _gpuObject; }
+    friend class Backend;
+};
+
+}
+
+#endif

--- a/libraries/gpu/src/gpu/Framebuffer.h
+++ b/libraries/gpu/src/gpu/Framebuffer.h
@@ -116,6 +116,7 @@ public:
     static Framebuffer* create(const SwapchainPointer& swapchain);
     static Framebuffer* create();
     static Framebuffer* create(const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height, uint16 samples );
+    static Framebuffer* createShadowmap(uint16 width);
 
     bool isSwapchain() const;
     SwapchainPointer getSwapchain() const { return _swapchain; }
@@ -135,6 +136,7 @@ public:
     TexturePointer getDepthStencilBuffer() const;
     uint32 getDepthStencilBufferSubresource() const;
     Format getDepthStencilBufferFormat() const;
+
 
     // Properties
     uint32 getBufferMask() const { return _bufferMask; }
@@ -159,23 +161,19 @@ public:
     // Get viewport covering the ful Canvas
     Viewport getViewport() const { return Viewport(getWidth(), getHeight(), 0, 0); }
 
-    bool isDefined() const { return _isDefined; }
-
 protected:
-    uint16 _width;
-    uint16 _height;
-    uint16 _numSamples;
+    uint16 _width = 0;
+    uint16 _height = 0;
+    uint16 _numSamples = 0;
 
-    uint32 _bufferMask;
+    uint32 _bufferMask = 0;
 
-    uint32 _frameCount;
+    uint32 _frameCount = 0;
 
     SwapchainPointer _swapchain;
 
     TextureViews _renderBuffers;
     TextureView _depthStencilBuffer;
-
-    bool _isDefined = false;
 
     void updateSize(const TexturePointer& texture);
 

--- a/libraries/gpu/src/gpu/Framebuffer.h
+++ b/libraries/gpu/src/gpu/Framebuffer.h
@@ -123,20 +123,24 @@ public:
     uint32 getFrameCount() const;
 
     // Render buffers
-    int32 setRenderBuffer(uint32 slot, const TexturePointer& texture, uint32 subresource = 0);
     void removeRenderBuffers();
     uint32 getNumRenderBuffers() const;
+    const TextureViews& getRenderBuffers() const { return _renderBuffers; }
 
+    int32 setRenderBuffer(uint32 slot, const TexturePointer& texture, uint32 subresource = 0);
     TexturePointer getRenderBuffer(uint32 slot) const;
     uint32 getRenderBufferSubresource(uint32 slot) const;
 
-    bool setDepthStencilBuffer(const TexturePointer& texture, uint32 subresource = 0);
+    bool setDepthStencilBuffer(const TexturePointer& texture, const Format& format, uint32 subresource = 0);
     TexturePointer getDepthStencilBuffer() const;
     uint32 getDepthStencilBufferSubresource() const;
+    Format getDepthStencilBufferFormat() const;
 
     // Properties
-    uint32 getBuffersMask() const { return _buffersMask; }
-    bool isEmpty() const;
+    uint32 getBufferMask() const { return _bufferMask; }
+    bool isEmpty() const { return (_bufferMask == 0); }
+    bool hasColor() const { return (getBufferMask() & BUFFER_COLORS); }
+    bool hasDepthStencil() const { return (getBufferMask() & BUFFER_DEPTHSTENCIL); }
 
     bool validateTargetCompatibility(const Texture& texture, uint32 subresource = 0) const;
 
@@ -162,7 +166,7 @@ protected:
     uint16 _height;
     uint16 _numSamples;
 
-    uint32 _buffersMask;
+    uint32 _bufferMask;
 
     uint32 _frameCount;
 

--- a/libraries/gpu/src/gpu/Framebuffer.h
+++ b/libraries/gpu/src/gpu/Framebuffer.h
@@ -149,7 +149,7 @@ protected:
 
     // Non exposed
     Framebuffer(const Framebuffer& framebuffer) {}
-    Framebuffer();
+    Framebuffer() {}
     
     // This shouldn't be used by anything else than the Backend class with the proper casting.
     mutable GPUObject* _gpuObject = NULL;

--- a/libraries/gpu/src/gpu/Framebuffer.h
+++ b/libraries/gpu/src/gpu/Framebuffer.h
@@ -115,7 +115,8 @@ public:
 
     static Framebuffer* create(const SwapchainPointer& swapchain);
     static Framebuffer* create();
-    static Framebuffer* create(const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height, uint16 samples );
+    static Framebuffer* create(const Format& colorBufferFormat, uint16 width, uint16 height);
+    static Framebuffer* create(const Format& colorBufferFormat, const Format& depthStencilBufferFormat, uint16 width, uint16 height);
     static Framebuffer* createShadowmap(uint16 width);
 
     bool isSwapchain() const;

--- a/libraries/gpu/src/gpu/Framebuffer.h
+++ b/libraries/gpu/src/gpu/Framebuffer.h
@@ -18,35 +18,6 @@ namespace gpu {
 
 typedef Element Format;
 
-class Viewport {
-public:
-    int32  width = 1;
-    int32  height = 1;
-    int32   top = 0;
-    int32   left = 0;
-    float   zmin = 0.f;
-    float   zmax = 1.f;
-
-    Viewport() {}
-    Viewport(int32 w, int32 h, int32 t = 0, int32 l = 0, float zin = 0.f, float zax = 1.f):
-        width(w),
-        height(h),
-        top(t),
-        left(l),
-        zmin(zin),
-        zmax(zax)
-    {}
-    Viewport(const Vec2i& wh, const Vec2i& tl = Vec2i(0), const Vec2& zrange = Vec2(0.f, 1.f)):
-        width(wh.x),
-        height(wh.y),
-        top(tl.x),
-        left(tl.y),
-        zmin(zrange.x),
-        zmax(zrange.y)
-    {}
-    ~Viewport() {}
-};
-
 class Swapchain {
 public:
     // Properties
@@ -147,6 +118,7 @@ public:
 
     bool validateTargetCompatibility(const Texture& texture, uint32 subresource = 0) const;
 
+    Vec2u getSize() const { return Vec2u(getWidth(), getHeight()); }
     uint16 getWidth() const;
     uint16 getHeight() const;
     uint16 getNumSamples() const;
@@ -159,22 +131,19 @@ public:
     static const uint32 MAX_NUM_RENDER_BUFFERS = 8; 
     static uint32 getMaxNumRenderBuffers() { return MAX_NUM_RENDER_BUFFERS; }
 
-    // Get viewport covering the ful Canvas
-    Viewport getViewport() const { return Viewport(getWidth(), getHeight(), 0, 0); }
-
 protected:
-    uint16 _width = 0;
-    uint16 _height = 0;
-    uint16 _numSamples = 0;
+    SwapchainPointer _swapchain;
+
+    TextureViews _renderBuffers;
+    TextureView _depthStencilBuffer;
 
     uint32 _bufferMask = 0;
 
     uint32 _frameCount = 0;
 
-    SwapchainPointer _swapchain;
-
-    TextureViews _renderBuffers;
-    TextureView _depthStencilBuffer;
+    uint16 _width = 0;
+    uint16 _height = 0;
+    uint16 _numSamples = 0;
 
     void updateSize(const TexturePointer& texture);
 

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -32,6 +32,9 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
     (&::gpu::GLBackend::do_setUniformBuffer),
     (&::gpu::GLBackend::do_setUniformTexture),
 
+    (&::gpu::GLBackend::do_setFramebuffer),
+
+
     (&::gpu::GLBackend::do_glEnable),
     (&::gpu::GLBackend::do_glDisable),
 
@@ -67,7 +70,8 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
 GLBackend::GLBackend() :
     _input(),
     _transform(),
-    _pipeline()
+    _pipeline(),
+    _output()
 {
     initTransform();
 }

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -133,13 +133,24 @@ public:
 
     class GLPipeline : public GPUObject {
     public:
-        GLShader* _program;
-        GLState* _state;
+        GLShader* _program = 0;
+        GLState* _state = 0;
 
         GLPipeline();
         ~GLPipeline();
     };
     static GLPipeline* syncGPUObject(const Pipeline& pipeline);
+
+
+    class GLFramebuffer : public GPUObject {
+    public:
+        GLuint _fbo = 0;
+
+        GLFramebuffer();
+        ~GLFramebuffer();
+    };
+    static GLFramebuffer* syncGPUObject(const Framebuffer& framebuffer);
+    static GLuint getFramebufferID(const FramebufferPointer& framebuffer);
 
     static const int MAX_NUM_ATTRIBUTES = Stream::NUM_INPUT_SLOTS;
     static const int MAX_NUM_INPUT_BUFFERS = 16;
@@ -276,8 +287,8 @@ protected:
         State::Signature _stateSignatureCache;
 
         GLState* _state;
-        bool _invalidState;
-        bool _needStateSync;
+        bool _invalidState = false;
+        bool _needStateSync = true;
 
         PipelineStageState() :
             _pipeline(),
@@ -290,6 +301,16 @@ protected:
             _needStateSync(true)
              {}
     } _pipeline;
+
+    // Output stage
+    void do_setFramebuffer(Batch& batch, uint32 paramOffset);
+
+    struct OutputStageState {
+
+        FramebufferPointer _framebuffer = nullptr;
+
+        OutputStageState() {}
+    } _output;
 
     // TODO: As long as we have gl calls explicitely issued from interface
     // code, we need to be able to record and batch these calls. THe long 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -53,6 +53,7 @@ public:
         Stamp _storageStamp;
         Stamp _contentStamp;
         GLuint _texture;
+        GLenum _target;
         GLuint _size;
 
         GLTexture();
@@ -60,6 +61,9 @@ public:
     };
     static GLTexture* syncGPUObject(const Texture& texture);
     static GLuint getTextureID(const TexturePointer& texture);
+
+    // very specific for now
+    static void syncSampler(const Sampler& sampler, Texture::Type type, GLTexture* object);
 
     class GLShader : public GPUObject {
     public:

--- a/libraries/gpu/src/gpu/GLBackendOutput.cpp
+++ b/libraries/gpu/src/gpu/GLBackendOutput.cpp
@@ -12,8 +12,7 @@
 #include "GLBackendShared.h"
 
 
-GLBackend::GLFramebuffer::GLFramebuffer()
-{}
+GLBackend::GLFramebuffer::GLFramebuffer() {}
 
 GLBackend::GLFramebuffer::~GLFramebuffer() {
     if (_fbo != 0) {

--- a/libraries/gpu/src/gpu/GLBackendOutput.cpp
+++ b/libraries/gpu/src/gpu/GLBackendOutput.cpp
@@ -1,0 +1,72 @@
+//
+//  GLBackendTexture.cpp
+//  libraries/gpu/src/gpu
+//
+//  Created by Sam Gateau on 1/19/2015.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#include "GPULogging.h"
+#include "GLBackendShared.h"
+
+
+GLBackend::GLFramebuffer::GLFramebuffer()
+{}
+
+GLBackend::GLFramebuffer::~GLFramebuffer() {
+    if (_fbo != 0) {
+        glDeleteFramebuffers(1, &_fbo);
+    }
+}
+
+GLBackend::GLFramebuffer* GLBackend::syncGPUObject(const Framebuffer& framebuffer) {
+    GLFramebuffer* object = Backend::getGPUObject<GLBackend::GLFramebuffer>(framebuffer);
+
+    // If GPU object already created and in sync
+    bool needUpdate = false;
+    if (object) {
+        return object;
+    } else if (!framebuffer.isDefined()) {
+        // NO framebuffer definition yet so let's avoid thinking
+        return nullptr;
+    }
+
+    // need to have a gpu object?
+    if (!object) {
+        object = new GLFramebuffer();
+        glGenFramebuffers(1, &object->_fbo);
+        CHECK_GL_ERROR();
+        Backend::setGPUObject(framebuffer, object);
+    }
+
+
+    CHECK_GL_ERROR();
+
+    return object;
+}
+
+
+
+GLuint GLBackend::getFramebufferID(const FramebufferPointer& framebuffer) {
+    if (!framebuffer) {
+        return 0;
+    }
+    GLFramebuffer* object = GLBackend::syncGPUObject(*framebuffer);
+    if (object) {
+        return object->_fbo;
+    } else {
+        return 0;
+    }
+}
+
+void GLBackend::do_setFramebuffer(Batch& batch, uint32 paramOffset) {
+    auto framebuffer = batch._framebuffers.get(batch._params[paramOffset]._uint);
+
+    if (_output._framebuffer != framebuffer) {
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, getFramebufferID(framebuffer));
+        _output._framebuffer = framebuffer;
+    }
+}
+

--- a/libraries/gpu/src/gpu/GLBackendOutput.cpp
+++ b/libraries/gpu/src/gpu/GLBackendOutput.cpp
@@ -28,7 +28,7 @@ GLBackend::GLFramebuffer* GLBackend::syncGPUObject(const Framebuffer& framebuffe
     bool needUpdate = false;
     if (object) {
         return object;
-    } else if (!framebuffer.isDefined()) {
+    } else if (framebuffer.isEmpty()) {
         // NO framebuffer definition yet so let's avoid thinking
         return nullptr;
     }
@@ -39,7 +39,7 @@ GLBackend::GLFramebuffer* GLBackend::syncGPUObject(const Framebuffer& framebuffe
         glGenFramebuffers(1, &fbo);
         CHECK_GL_ERROR();
 
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 
         unsigned int nbColorBuffers = 0;
         GLenum colorBuffers[16];
@@ -82,7 +82,6 @@ GLBackend::GLFramebuffer* GLBackend::syncGPUObject(const Framebuffer& framebuffe
             if (surface) {
                 auto gltexture = GLBackend::syncGPUObject(*surface);
                 if (gltexture) {
-                    if (surface)
                     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, gltexture->_texture, 0);
                 }
             }

--- a/libraries/gpu/src/gpu/GLBackendState.cpp
+++ b/libraries/gpu/src/gpu/GLBackendState.cpp
@@ -237,26 +237,26 @@ void GLBackend::resetPipelineState(State::Signature nextSignature) {
     }
 }
 
-State::ComparisonFunction comparisonFuncFromGL(GLenum func) {
+ComparisonFunction comparisonFuncFromGL(GLenum func) {
     if (func == GL_NEVER) {
-        return State::NEVER;
+        return NEVER;
     } else if (func == GL_LESS) {
-        return State::LESS;
+        return LESS;
     } else if (func == GL_EQUAL) {
-        return State::EQUAL;
+        return EQUAL;
     } else if (func == GL_LEQUAL) {
-        return State::LESS_EQUAL;
+        return LESS_EQUAL;
     } else if (func == GL_GREATER) {
-        return State::GREATER;
+        return GREATER;
     } else if (func == GL_NOTEQUAL) {
-        return State::NOT_EQUAL;
+        return NOT_EQUAL;
     } else if (func == GL_GEQUAL) {
-        return State::GREATER_EQUAL;
+        return GREATER_EQUAL;
     } else if (func == GL_ALWAYS) {
-        return State::ALWAYS;
+        return ALWAYS;
     }
 
-    return State::ALWAYS;
+    return ALWAYS;
 }
 
 State::StencilOp stencilOpFromGL(GLenum stencilOp) {

--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -144,7 +144,38 @@ public:
                     texel.internalFormat = GL_RED;
                     break;
                 case gpu::DEPTH:
+                    texel.format = GL_DEPTH_COMPONENT; // It's depth component to load it
                     texel.internalFormat = GL_DEPTH_COMPONENT;
+                    switch (dstFormat.getType()) {
+                    case gpu::UINT32:
+                    case gpu::INT32:
+                    case gpu::NUINT32:
+                    case gpu::NINT32: {
+                        texel.internalFormat = GL_DEPTH_COMPONENT32;
+                        break;
+                        }
+                    case gpu::NFLOAT:
+                    case gpu::FLOAT: {
+                        texel.internalFormat = GL_DEPTH_COMPONENT32F;
+                        break;
+                        }
+                    case gpu::UINT16:
+                    case gpu::INT16:
+                    case gpu::NUINT16:
+                    case gpu::NINT16:
+                    case gpu::HALF:
+                    case gpu::NHALF: {
+                        texel.internalFormat = GL_DEPTH_COMPONENT16;
+                        break;
+                        }
+                    case gpu::UINT8:
+                    case gpu::INT8:
+                    case gpu::NUINT8:
+                    case gpu::NINT8: {
+                        texel.internalFormat = GL_DEPTH_COMPONENT24;
+                        break;
+                        }
+                    }
                     break;
                 default:
                     qCDebug(gpulogging) << "Unknown combination of texel format";
@@ -306,6 +337,9 @@ GLBackend::GLTexture* GLBackend::syncGPUObject(const Texture& texture) {
             if (bytes && texture.isAutogenerateMips()) {
                 glGenerateMipmap(GL_TEXTURE_2D);
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+            } else {
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
             }
 
             // At this point the mip piels have been loaded, we can notify

--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -16,7 +16,8 @@ GLBackend::GLTexture::GLTexture() :
     _storageStamp(0),
     _contentStamp(0),
     _texture(0),
-    _size(0)
+    _size(0),
+    _target(GL_TEXTURE_2D)
 {}
 
 GLBackend::GLTexture::~GLTexture() {
@@ -285,69 +286,77 @@ GLBackend::GLTexture* GLBackend::syncGPUObject(const Texture& texture) {
     // GO through the process of allocating the correct storage and/or update the content
     switch (texture.getType()) {
     case Texture::TEX_2D: {
-        if (needUpdate) {
-            if (texture.isStoredMipAvailable(0)) {
-                GLint boundTex = -1;
-                glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTex);
-
-                Texture::PixelsPointer mip = texture.accessStoredMip(0);
-                const GLvoid* bytes = mip->_sysmem.read<Resource::Byte>();
-                Element srcFormat = mip->_format;
-                
-                GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
-
-                glBindTexture(GL_TEXTURE_2D, object->_texture);
-                glTexSubImage2D(GL_TEXTURE_2D, 0,
-                    texelFormat.internalFormat, texture.getWidth(), texture.getHeight(), 0,
-                    texelFormat.format, texelFormat.type, bytes);
-
-                if (texture.isAutogenerateMips()) {
-                    glGenerateMipmap(GL_TEXTURE_2D);
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-                }
-
-                // At this point the mip piels have been loaded, we can notify
-                texture.notifyGPULoaded(0);
-
-                glBindTexture(GL_TEXTURE_2D, boundTex);
-                object->_contentStamp = texture.getDataStamp();
-            }
-        } else {
-            const GLvoid* bytes = 0;
-            Element srcFormat = texture.getTexelFormat();
-            if (texture.isStoredMipAvailable(0)) {
-                Texture::PixelsPointer mip = texture.accessStoredMip(0);
-                
-                bytes = mip->_sysmem.read<Resource::Byte>();
-                srcFormat = mip->_format;
-
-                object->_contentStamp = texture.getDataStamp();
-            }
-
+        if (texture.getNumSlices() == 1) {
             GLint boundTex = -1;
             glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTex);
             glBindTexture(GL_TEXTURE_2D, object->_texture);
 
-            GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
-            
-            glTexImage2D(GL_TEXTURE_2D, 0,
-                texelFormat.internalFormat, texture.getWidth(), texture.getHeight(), 0,
-                texelFormat.format, texelFormat.type, bytes);
+            if (needUpdate) {
+                if (texture.isStoredMipAvailable(0)) {
+                    Texture::PixelsPointer mip = texture.accessStoredMip(0);
+                    const GLvoid* bytes = mip->_sysmem.read<Resource::Byte>();
+                    Element srcFormat = mip->_format;
+                
+                    GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
 
-            if (bytes && texture.isAutogenerateMips()) {
-                glGenerateMipmap(GL_TEXTURE_2D);
-                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+                    glBindTexture(GL_TEXTURE_2D, object->_texture);
+                    glTexSubImage2D(GL_TEXTURE_2D, 0,
+                        texelFormat.internalFormat, texture.getWidth(), texture.getHeight(), 0,
+                        texelFormat.format, texelFormat.type, bytes);
+
+                    if (texture.isAutogenerateMips()) {
+                        glGenerateMipmap(GL_TEXTURE_2D);
+                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+                    }
+
+                object->_target = GL_TEXTURE_2D;
+
+                syncSampler(texture.getSampler(), texture.getType(), object);
+
+
+                    // At this point the mip piels have been loaded, we can notify
+                    texture.notifyGPULoaded(0);
+
+                    object->_contentStamp = texture.getDataStamp();
+                }
             } else {
-                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+                const GLvoid* bytes = 0;
+                Element srcFormat = texture.getTexelFormat();
+                if (texture.isStoredMipAvailable(0)) {
+                    Texture::PixelsPointer mip = texture.accessStoredMip(0);
+                
+                    bytes = mip->_sysmem.read<Resource::Byte>();
+                    srcFormat = mip->_format;
+
+                    object->_contentStamp = texture.getDataStamp();
+                }
+
+                GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
+            
+                glTexImage2D(GL_TEXTURE_2D, 0,
+                    texelFormat.internalFormat, texture.getWidth(), texture.getHeight(), 0,
+                    texelFormat.format, texelFormat.type, bytes);
+
+                if (bytes && texture.isAutogenerateMips()) {
+                    glGenerateMipmap(GL_TEXTURE_2D);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+                } else {
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+                }
+                
+                object->_target = GL_TEXTURE_2D;
+
+                syncSampler(texture.getSampler(), texture.getType(), object);
+
+                // At this point the mip piels have been loaded, we can notify
+                texture.notifyGPULoaded(0);
+
+                object->_storageStamp = texture.getStamp();
+                object->_size = texture.getSize();
             }
 
-            // At this point the mip piels have been loaded, we can notify
-            texture.notifyGPULoaded(0);
-
             glBindTexture(GL_TEXTURE_2D, boundTex);
-            object->_storageStamp = texture.getStamp();
-            object->_size = texture.getSize();
         }
         break;
     }
@@ -373,3 +382,70 @@ GLuint GLBackend::getTextureID(const TexturePointer& texture) {
     }
 }
 
+void GLBackend::syncSampler(const Sampler& sampler, Texture::Type type, GLTexture* object) {
+    if (!object) return;
+    if (!object->_texture) return;
+
+    class GLFilterMode {
+    public:
+        GLint minFilter;
+        GLint magFilter;
+    };
+    static const GLFilterMode filterModes[] = {   
+        {GL_NEAREST,      GL_NEAREST},  //FILTER_MIN_MAG_POINT,
+        {GL_NEAREST,       GL_LINEAR},  //FILTER_MIN_POINT_MAG_LINEAR,
+        {GL_LINEAR,      GL_NEAREST},  //FILTER_MIN_LINEAR_MAG_POINT,
+        {GL_LINEAR,       GL_LINEAR},  //FILTER_MIN_MAG_LINEAR,
+ 
+        {GL_NEAREST_MIPMAP_NEAREST,      GL_NEAREST},  //FILTER_MIN_MAG_MIP_POINT,
+        {GL_NEAREST_MIPMAP_NEAREST,      GL_NEAREST},  //FILTER_MIN_MAG_MIP_POINT,
+        {GL_NEAREST_MIPMAP_LINEAR,       GL_NEAREST},  //FILTER_MIN_MAG_POINT_MIP_LINEAR,
+        {GL_NEAREST_MIPMAP_NEAREST,      GL_LINEAR},  //FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,
+        {GL_NEAREST_MIPMAP_LINEAR,       GL_LINEAR},  //FILTER_MIN_POINT_MAG_MIP_LINEAR,
+        {GL_LINEAR_MIPMAP_NEAREST,       GL_NEAREST},  //FILTER_MIN_LINEAR_MAG_MIP_POINT,
+        {GL_LINEAR_MIPMAP_LINEAR,        GL_NEAREST},  //FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,
+        {GL_LINEAR_MIPMAP_NEAREST,       GL_LINEAR},  //FILTER_MIN_MAG_LINEAR_MIP_POINT,
+        {GL_LINEAR_MIPMAP_LINEAR,        GL_LINEAR},  //FILTER_MIN_MAG_MIP_LINEAR,
+        {GL_LINEAR_MIPMAP_LINEAR,        GL_LINEAR}  //FILTER_ANISOTROPIC,
+    };
+
+    auto fm = filterModes[sampler.getFilter()];
+    glTexParameteri(object->_target, GL_TEXTURE_MIN_FILTER, fm.minFilter);
+    glTexParameteri(object->_target, GL_TEXTURE_MAG_FILTER, fm.magFilter);
+
+    static const GLenum comparisonFuncs[] = { 
+        GL_NEVER,
+        GL_LESS,
+        GL_EQUAL,
+        GL_LEQUAL,
+        GL_GREATER,
+        GL_NOTEQUAL,
+        GL_GEQUAL,
+        GL_ALWAYS };
+
+    if (sampler.doComparison()) {
+        glTexParameteri(object->_target, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_R_TO_TEXTURE);
+        glTexParameteri(object->_target, GL_TEXTURE_COMPARE_FUNC, comparisonFuncs[sampler.getComparisonFunction()]);
+    } else {
+        glTexParameteri(object->_target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+    }
+
+    static const GLenum wrapModes[] = {   
+        GL_REPEAT,                         // WRAP_REPEAT,
+        GL_MIRRORED_REPEAT,                // WRAP_MIRROR,
+        GL_CLAMP_TO_EDGE,                  // WRAP_CLAMP,
+        GL_CLAMP_TO_BORDER,                // WRAP_BORDER,
+        GL_MIRROR_CLAMP_TO_EDGE_EXT };     // WRAP_MIRROR_ONCE,
+
+    glTexParameteri(object->_target, GL_TEXTURE_WRAP_S, wrapModes[sampler.getWrapModeU()]);
+    glTexParameteri(object->_target, GL_TEXTURE_WRAP_T, wrapModes[sampler.getWrapModeV()]);
+    glTexParameteri(object->_target, GL_TEXTURE_WRAP_R, wrapModes[sampler.getWrapModeW()]);
+
+    glTexParameterfv(object->_target, GL_TEXTURE_BORDER_COLOR, (const float*) &sampler.getBorderColor());
+    glTexParameteri(object->_target, GL_TEXTURE_BASE_LEVEL, sampler.getMipOffset());
+    glTexParameterf(object->_target, GL_TEXTURE_MIN_LOD, (float) sampler.getMinMip());
+    glTexParameterf(object->_target, GL_TEXTURE_MAX_LOD, (sampler.getMaxMip() == Sampler::MAX_MIP_LEVEL ? 1000.f : sampler.getMaxMip()));
+    glTexParameterf(object->_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, sampler.getMaxAnisotropy());
+    CHECK_GL_ERROR();
+
+}

--- a/libraries/gpu/src/gpu/Resource.cpp
+++ b/libraries/gpu/src/gpu/Resource.cpp
@@ -16,6 +16,8 @@
 
 using namespace gpu;
 
+const Element Element::COLOR_RGBA_32 = Element(VEC4, UINT8, RGBA);
+
 Resource::Size Resource::Sysmem::allocateMemory(Byte** dataAllocated, Size size) {
     if ( !dataAllocated ) { 
         qWarning() << "Buffer::Sysmem::allocateMemory() : Must have a valid dataAllocated pointer.";

--- a/libraries/gpu/src/gpu/State.h
+++ b/libraries/gpu/src/gpu/State.h
@@ -42,19 +42,8 @@ public:
     virtual ~State();
 
     const Stamp getStamp() const { return _stamp; }
-    
-    enum ComparisonFunction {
-        NEVER = 0,
-        LESS,
-        EQUAL,
-        LESS_EQUAL,
-        GREATER,
-        NOT_EQUAL,
-        GREATER_EQUAL,
-        ALWAYS,
-
-        NUM_COMPARISON_FUNCS,
-    };
+ 
+    typedef ::gpu::ComparisonFunction ComparisonFunction;
 
     enum FillMode {
         FILL_POINT = 0,
@@ -414,6 +403,5 @@ typedef std::shared_ptr< State > StatePointer;
 typedef std::vector< StatePointer > States;
 
 };
-
 
 #endif

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -93,23 +93,23 @@ bool Texture::Storage::assignMipData(uint16 level, const Element& format, Size s
     return allocated == size;
 }
 
-Texture* Texture::create1D(const Element& texelFormat, uint16 width) {
-    return create(TEX_1D, texelFormat, width, 1, 1, 1, 1);
+Texture* Texture::create1D(const Element& texelFormat, uint16 width, const Sampler& sampler) { 
+    return create(TEX_1D, texelFormat, width, 1, 1, 1, 1, sampler);
 }
 
-Texture* Texture::create2D(const Element& texelFormat, uint16 width, uint16 height) {
-    return create(TEX_2D, texelFormat, width, height, 1, 1, 1);
+Texture* Texture::create2D(const Element& texelFormat, uint16 width, uint16 height, const Sampler& sampler) {
+    return create(TEX_2D, texelFormat, width, height, 1, 1, 1, sampler);
 }
 
-Texture* Texture::create3D(const Element& texelFormat, uint16 width, uint16 height, uint16 depth) {
-    return create(TEX_3D, texelFormat, width, height, depth, 1, 1);
+Texture* Texture::create3D(const Element& texelFormat, uint16 width, uint16 height, uint16 depth, const Sampler& sampler) {
+    return create(TEX_3D, texelFormat, width, height, depth, 1, 1, sampler);
 }
 
-Texture* Texture::createCube(const Element& texelFormat, uint16 width) {
-    return create(TEX_CUBE, texelFormat, width, width, 1, 1, 1);
+Texture* Texture::createCube(const Element& texelFormat, uint16 width, const Sampler& sampler) {
+    return create(TEX_CUBE, texelFormat, width, width, 1, 1, 1, sampler);
 }
 
-Texture* Texture::create(Type type, const Element& texelFormat, uint16 width, uint16 height, uint16 depth, uint16 numSamples, uint16 numSlices)
+Texture* Texture::create(Type type, const Element& texelFormat, uint16 width, uint16 height, uint16 depth, uint16 numSamples, uint16 numSlices, const Sampler& sampler)
 {
     Texture* tex = new Texture();
     tex->_storage.reset(new Storage());
@@ -117,6 +117,8 @@ Texture* Texture::create(Type type, const Element& texelFormat, uint16 width, ui
     tex->_type = type;
     tex->_maxMip = 0;
     tex->resize(type, texelFormat, width, height, depth, numSamples, numSlices);
+
+    tex->_sampler = sampler;
 
     return tex;
 }
@@ -345,4 +347,9 @@ uint16 Texture::evalNumSamplesUsed(uint16 numSamplesTried) {
         sample = 8;
 
     return sample;
+}
+
+void Texture::setSampler(const Sampler& sampler) {
+    _sampler = sampler;
+    _samplerStamp++;
 }

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -16,6 +16,85 @@
  
 namespace gpu {
 
+class Sampler {
+public:
+
+    enum Filter {
+        FILTER_MIN_MAG_POINT, // top mip only
+        FILTER_MIN_POINT_MAG_LINEAR, // top mip only
+        FILTER_MIN_LINEAR_MAG_POINT, // top mip only
+        FILTER_MIN_MAG_LINEAR, // top mip only
+
+        FILTER_MIN_MAG_MIP_POINT,
+        FILTER_MIN_MAG_POINT_MIP_LINEAR,
+        FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,
+        FILTER_MIN_POINT_MAG_MIP_LINEAR,
+        FILTER_MIN_LINEAR_MAG_MIP_POINT,
+        FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,
+        FILTER_MIN_MAG_LINEAR_MIP_POINT,
+        FILTER_MIN_MAG_MIP_LINEAR,
+        FILTER_ANISOTROPIC,
+
+        NUM_FILTERS,
+    };
+
+    enum WrapMode {
+        WRAP_REPEAT = 0,
+        WRAP_MIRROR,
+        WRAP_CLAMP,
+        WRAP_BORDER,
+        WRAP_MIRROR_ONCE,
+
+        NUM_WRAP_MODES
+    };
+
+    static const uint8 MAX_MIP_LEVEL = 0xFF;
+
+    class Desc {
+    public:
+        glm::vec4 _borderColor{ 1.0f };
+        uint32 _maxAnisotropy = 16;
+
+        uint8 _wrapModeU = WRAP_REPEAT;
+        uint8 _wrapModeV = WRAP_REPEAT;
+        uint8 _wrapModeW = WRAP_REPEAT;
+
+        uint8 _filter = FILTER_MIN_MAG_POINT;
+        uint8 _comparisonFunc = ALWAYS;
+            
+        uint8 _mipOffset = 0;
+        uint8 _minMip = 0;
+        uint8 _maxMip = MAX_MIP_LEVEL;
+
+        Desc() {}
+        Desc(const Filter filter) : _filter(filter) {}
+    };
+
+    Sampler() {}
+    Sampler(const Filter filter) : _desc(filter) {}
+    Sampler(const Desc& desc) : _desc(desc) {}
+    ~Sampler() {}
+
+    const glm::vec4& getBorderColor() const { return _desc._borderColor; }
+
+    uint32 getMaxAnisotropy() const { return _desc._maxAnisotropy; }
+
+    WrapMode getWrapModeU() const { return WrapMode(_desc._wrapModeU); }
+    WrapMode getWrapModeV() const { return WrapMode(_desc._wrapModeV); }
+    WrapMode getWrapModeW() const { return WrapMode(_desc._wrapModeW); }
+
+    Filter getFilter() const { return Filter(_desc._filter); }
+    ComparisonFunction getComparisonFunction() const { return ComparisonFunction(_desc._comparisonFunc); }
+    bool doComparison() const { return getComparisonFunction() != ALWAYS; }
+
+    uint8 getMipOffset() const { return _desc._mipOffset; }
+    uint8 getMinMip() const { return _desc._minMip; }
+    uint8 getMaxMip() const { return _desc._maxMip; }
+
+protected:
+    Desc _desc;
+};
+
 class Texture : public Resource {
 public:
 
@@ -61,10 +140,10 @@ public:
         TEX_CUBE,
     };
 
-    static Texture* create1D(const Element& texelFormat, uint16 width);
-    static Texture* create2D(const Element& texelFormat, uint16 width, uint16 height);
-    static Texture* create3D(const Element& texelFormat, uint16 width, uint16 height, uint16 depth);
-    static Texture* createCube(const Element& texelFormat, uint16 width);
+    static Texture* create1D(const Element& texelFormat, uint16 width, const Sampler& sampler = Sampler());
+    static Texture* create2D(const Element& texelFormat, uint16 width, uint16 height, const Sampler& sampler = Sampler());
+    static Texture* create3D(const Element& texelFormat, uint16 width, uint16 height, uint16 depth, const Sampler& sampler = Sampler());
+    static Texture* createCube(const Element& texelFormat, uint16 width, const Sampler& sampler = Sampler());
 
     static Texture* createFromStorage(Storage* storage);
 
@@ -181,10 +260,20 @@ public:
  
     bool isDefined() const { return _defined; }
 
+
+    // Own sampler
+    void setSampler(const Sampler& sampler);
+    const Sampler& getSampler() const { return _sampler; }
+    const Stamp getSamplerStamp() const { return _samplerStamp; }
+
 protected:
     std::unique_ptr< Storage > _storage;
  
     Stamp _stamp;
+
+    Sampler _sampler;
+    Stamp _samplerStamp;
+
 
     uint32 _size;
     Element _texelFormat;
@@ -202,7 +291,7 @@ protected:
     bool _autoGenerateMips;
     bool _defined;
    
-    static Texture* create(Type type, const Element& texelFormat, uint16 width, uint16 height, uint16 depth, uint16 numSamples, uint16 numSlices);
+    static Texture* create(Type type, const Element& texelFormat, uint16 width, uint16 height, uint16 depth, uint16 numSamples, uint16 numSlices, const Sampler& sampler);
     Texture();
 
     Size resize(Type type, const Element& texelFormat, uint16 width, uint16 height, uint16 depth, uint16 numSamples, uint16 numSlices);

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -240,15 +240,25 @@ public:
         _subresource(0),
         _element(element)
     {};
-    TextureView(const TexturePointer& texture, const Element& element) :
+    TextureView(const TexturePointer& texture, uint16 subresource, const Element& element) :
         _texture(texture),
-        _subresource(0),
+        _subresource(subresource),
         _element(element)
     {};
+
+    TextureView(const TexturePointer& texture, uint16 subresource) :
+        _texture(texture),
+        _subresource(subresource)
+    {};
+
     ~TextureView() {}
     TextureView(const TextureView& view) = default;
     TextureView& operator=(const TextureView& view) = default;
+
+    explicit operator bool() const { return (_texture); }
+    bool operator !() const { return (!_texture); }
 };
+typedef std::vector<TextureView> TextureViews;
 
 };
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -253,7 +253,7 @@ void DeferredLightingEffect::render() {
             program->bind();
         }
         program->setUniformValue(locations->shadowScale,
-            1.0f / textureCache->getShadowFramebufferObject()->width());
+            1.0f / textureCache->getShadowFramebuffer()->getWidth());
         
     } else {
         if (_ambientLightMode > -1) {

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -183,15 +183,17 @@ void DeferredLightingEffect::render() {
 
     auto textureCache = DependencyManager::get<TextureCache>();
     
-    QOpenGLFramebufferObject* primaryFBO = textureCache->getPrimaryFramebufferObject();
-    primaryFBO->release();
+  //  QOpenGLFramebufferObject* primaryFBO = textureCache->getPrimaryFramebufferObject();
+  //  primaryFBO->release();
+    QSize framebufferSize = textureCache->getFrameBufferSize();
     
     QOpenGLFramebufferObject* freeFBO = DependencyManager::get<GlowEffect>()->getFreeFramebufferObject();
     freeFBO->bind();
     glClear(GL_COLOR_BUFFER_BIT);
    // glEnable(GL_FRAMEBUFFER_SRGB);
 
-    glBindTexture(GL_TEXTURE_2D, primaryFBO->texture());
+   // glBindTexture(GL_TEXTURE_2D, primaryFBO->texture());
+    glBindTexture(GL_TEXTURE_2D, textureCache->getPrimaryColorTextureID());
     
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, textureCache->getPrimaryNormalTextureID());
@@ -209,11 +211,17 @@ void DeferredLightingEffect::render() {
     const int VIEWPORT_Y_INDEX = 1;
     const int VIEWPORT_WIDTH_INDEX = 2;
     const int VIEWPORT_HEIGHT_INDEX = 3;
-    float sMin = viewport[VIEWPORT_X_INDEX] / (float)primaryFBO->width();
+ /*   float sMin = viewport[VIEWPORT_X_INDEX] / (float)primaryFBO->width();
     float sWidth = viewport[VIEWPORT_WIDTH_INDEX] / (float)primaryFBO->width();
     float tMin = viewport[VIEWPORT_Y_INDEX] / (float)primaryFBO->height();
     float tHeight = viewport[VIEWPORT_HEIGHT_INDEX] / (float)primaryFBO->height();
-   
+    */
+    float sMin = viewport[VIEWPORT_X_INDEX] / (float)framebufferSize.width();
+    float sWidth = viewport[VIEWPORT_WIDTH_INDEX] / (float)framebufferSize.width();
+    float tMin = viewport[VIEWPORT_Y_INDEX] / (float)framebufferSize.height();
+    float tHeight = viewport[VIEWPORT_HEIGHT_INDEX] / (float)framebufferSize.height();
+
+
     // Fetch the ViewMatrix;
     glm::mat4 invViewMat;
     _viewState->getViewTransform().getMatrix(invViewMat);
@@ -437,7 +445,10 @@ void DeferredLightingEffect::render() {
     glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_CONSTANT_ALPHA, GL_ONE);
     glColorMask(true, true, true, false);
     
-    primaryFBO->bind();
+    auto primaryFBO = gpu::GLBackend::getFramebufferID(textureCache->getPrimaryOpaqueFramebuffer());
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, primaryFBO);
+
+    //primaryFBO->bind();
     
     glBindTexture(GL_TEXTURE_2D, freeFBO->texture());
     glEnable(GL_TEXTURE_2D);

--- a/libraries/render-utils/src/GlowEffect.cpp
+++ b/libraries/render-utils/src/GlowEffect.cpp
@@ -46,10 +46,10 @@ GlowEffect::~GlowEffect() {
     }
 }
 
-QOpenGLFramebufferObject* GlowEffect::getFreeFramebufferObject() const {
+gpu::FramebufferPointer GlowEffect::getFreeFramebuffer() const {
     return (_isOddFrame ?
-                DependencyManager::get<TextureCache>()->getSecondaryFramebufferObject():
-                DependencyManager::get<TextureCache>()->getTertiaryFramebufferObject());
+                DependencyManager::get<TextureCache>()->getSecondaryFramebuffer():
+                DependencyManager::get<TextureCache>()->getTertiaryFramebuffer());
 }
 
 static ProgramObject* createProgram(const QString& name) {
@@ -106,8 +106,7 @@ int GlowEffect::getDeviceHeight() const {
 
 
 void GlowEffect::prepare() {
-    //DependencyManager::get<TextureCache>()->getPrimaryFramebufferObject()->bind();
-    auto primaryFBO = DependencyManager::get<TextureCache>()->getPrimaryOpaqueFramebuffer();
+    auto primaryFBO = DependencyManager::get<TextureCache>()->getPrimaryFramebuffer();
     GLuint fbo = gpu::GLBackend::getFramebufferID(primaryFBO);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
 
@@ -129,25 +128,26 @@ void GlowEffect::end() {
     glBlendColor(0.0f, 0.0f, 0.0f, _intensity = _intensityStack.pop());
 }
 
-static void maybeBind(QOpenGLFramebufferObject* fbo) {
+static void maybeBind(const gpu::FramebufferPointer& fbo) {
     if (fbo) {
-        fbo->bind();
+        glBindFramebuffer(GL_FRAMEBUFFER, gpu::GLBackend::getFramebufferID(fbo));
     }
 }
 
-static void maybeRelease(QOpenGLFramebufferObject* fbo) {
+static void maybeRelease(const gpu::FramebufferPointer& fbo) {
     if (fbo) {
-        fbo->release();
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
     }
 }
 
-QOpenGLFramebufferObject* GlowEffect::render(bool toTexture) {
+gpu::FramebufferPointer GlowEffect::render(bool toTexture) {
     PerformanceTimer perfTimer("glowEffect");
 
     auto textureCache = DependencyManager::get<TextureCache>();
-   // QOpenGLFramebufferObject* primaryFBO = textureCache->getPrimaryFramebufferObject();
-  //  primaryFBO->release();
-    auto primaryFBO = gpu::GLBackend::getFramebufferID(textureCache->getPrimaryOpaqueFramebuffer());
+
+    auto primaryFBO = gpu::GLBackend::getFramebufferID(textureCache->getPrimaryFramebuffer());
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
     glBindTexture(GL_TEXTURE_2D, textureCache->getPrimaryColorTextureID());
     auto framebufferSize = textureCache->getFrameBufferSize();
 
@@ -162,15 +162,14 @@ QOpenGLFramebufferObject* GlowEffect::render(bool toTexture) {
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
 
-    QOpenGLFramebufferObject* destFBO = toTexture ?
-        textureCache->getSecondaryFramebufferObject() : NULL;
+    gpu::FramebufferPointer destFBO = toTexture ?
+        textureCache->getSecondaryFramebuffer() : nullptr;
     if (!_enabled || _isEmpty) {
         // copy the primary to the screen
         if (destFBO && QOpenGLFramebufferObject::hasOpenGLFramebufferBlit()) {
             glBindFramebuffer(GL_READ_FRAMEBUFFER, primaryFBO);
-            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, destFBO->handle());
+            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, gpu::GLBackend::getFramebufferID(destFBO));
             glBlitFramebuffer(0, 0, framebufferSize.width(), framebufferSize.height(), 0, 0, framebufferSize.width(), framebufferSize.height(), GL_COLOR_BUFFER_BIT, GL_NEAREST);
-        //    QOpenGLFramebufferObject::blitFramebuffer(destFBO, primaryFBO);
         } else {
             maybeBind(destFBO);
             if (!destFBO) {
@@ -185,36 +184,35 @@ QOpenGLFramebufferObject* GlowEffect::render(bool toTexture) {
         }
     } else {
         // diffuse into the secondary/tertiary (alternating between frames)
-        QOpenGLFramebufferObject* oldDiffusedFBO =
-            textureCache->getSecondaryFramebufferObject();
-        QOpenGLFramebufferObject* newDiffusedFBO =
-            textureCache->getTertiaryFramebufferObject();
+        auto oldDiffusedFBO =
+            textureCache->getSecondaryFramebuffer();
+        auto newDiffusedFBO =
+            textureCache->getTertiaryFramebuffer();
         if (_isOddFrame) {
             qSwap(oldDiffusedFBO, newDiffusedFBO);
         }
-        newDiffusedFBO->bind();
+        glBindFramebuffer(GL_FRAMEBUFFER, gpu::GLBackend::getFramebufferID(newDiffusedFBO));
         
         if (_isFirstFrame) {
             glClear(GL_COLOR_BUFFER_BIT);    
             
         } else {
             glActiveTexture(GL_TEXTURE1);
-            glBindTexture(GL_TEXTURE_2D, oldDiffusedFBO->texture());
+            glBindTexture(GL_TEXTURE_2D, gpu::GLBackend::getTextureID(oldDiffusedFBO->getRenderBuffer(0)));
             
             _diffuseProgram->bind();
-            //QSize size = primaryFBO->size();
-            QSize size = framebufferSize;
-            _diffuseProgram->setUniformValue(_diffusionScaleLocation, 1.0f / size.width(), 1.0f / size.height());
+
+            _diffuseProgram->setUniformValue(_diffusionScaleLocation, 1.0f / framebufferSize.width(), 1.0f / framebufferSize.height());
         
             renderFullscreenQuad();
         
             _diffuseProgram->release();
         }
         
-        newDiffusedFBO->release();
-        
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
         // add diffused texture to the primary
-        glBindTexture(GL_TEXTURE_2D, newDiffusedFBO->texture());
+        glBindTexture(GL_TEXTURE_2D, gpu::GLBackend::getTextureID(newDiffusedFBO->getRenderBuffer(0)));
         
         if (toTexture) {
             destFBO = oldDiffusedFBO;

--- a/libraries/render-utils/src/GlowEffect.h
+++ b/libraries/render-utils/src/GlowEffect.h
@@ -13,14 +13,13 @@
 #define hifi_GlowEffect_h
 
 #include <gpu/GPUConfig.h>
+#include <gpu/Framebuffer.h>
 
 #include <QObject>
 #include <QGLWidget>
 #include <QStack>
 
 #include <DependencyManager.h>
-
-class QOpenGLFramebufferObject;
 
 class ProgramObject;
 
@@ -33,7 +32,7 @@ public:
    
     /// Returns a pointer to the framebuffer object that the glow effect is *not* using for persistent state
     /// (either the secondary or the tertiary).
-    QOpenGLFramebufferObject* getFreeFramebufferObject() const;
+    gpu::FramebufferPointer getFreeFramebuffer() const;
     
     void init(QGLWidget* widget, bool enabled);
     
@@ -53,7 +52,7 @@ public:
     /// Renders the glow effect.  To be called after rendering the scene.
     /// \param toTexture whether to render to a texture, rather than to the frame buffer
     /// \return the framebuffer object to which we rendered, or NULL if to the frame buffer
-    QOpenGLFramebufferObject* render(bool toTexture = false);
+    gpu::FramebufferPointer render(bool toTexture = false);
 
 public slots:
     void toggleGlowEffect(bool enabled);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -673,8 +673,6 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
         return false;
     }
 
- //   auto glowEffectIntensity = DependencyManager::get<GlowEffect>()->getIntensity();
-
     // Let's introduce a gpu::Batch to capture all the calls to the graphics api
     _renderBatch.clear();
     gpu::Batch& batch = _renderBatch;
@@ -703,35 +701,12 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
 
     batch.setViewTransform(_transforms[0]);
 
-  //  GLBATCH(glDisable)(GL_COLOR_MATERIAL);
-    
-    // taking care of by the state?
-   /* if (mode == RenderArgs::DIFFUSE_RENDER_MODE || mode == RenderArgs::NORMAL_RENDER_MODE) {
-        GLBATCH(glDisable)(GL_CULL_FACE);
-    } else {
-        GLBATCH(glEnable)(GL_CULL_FACE);
-        if (mode == RenderArgs::SHADOW_RENDER_MODE) {
-            GLBATCH(glCullFace)(GL_FRONT);
-        }
-    }
-    */
-
-    // render opaque meshes with alpha testing
-
-//    GLBATCH(glDisable)(GL_BLEND);
-//    GLBATCH(glEnable)(GL_ALPHA_TEST);
-    
- /*   if (mode == RenderArgs::SHADOW_RENDER_MODE) {
-        GLBATCH(glAlphaFunc)(GL_EQUAL, 0.0f);
-    }
-    */
-
     /*DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(
         mode == RenderArgs::DEFAULT_RENDER_MODE || mode == RenderArgs::DIFFUSE_RENDER_MODE,
         mode == RenderArgs::DEFAULT_RENDER_MODE || mode == RenderArgs::NORMAL_RENDER_MODE,
         mode == RenderArgs::DEFAULT_RENDER_MODE);
         */
-    {
+     /*if (mode != RenderArgs::SHADOW_RENDER_MODE)*/ {
         GLenum buffers[3];
         int bufferCount = 0;
 
@@ -748,6 +723,7 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
             buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
         }
         GLBATCH(glDrawBuffers)(bufferCount, buffers);
+      //  batch.setFramebuffer(DependencyManager::get<TextureCache>()->getPrimaryOpaqueFramebuffer());
     }
 
     const float DEFAULT_ALPHA_THRESHOLD = 0.5f;
@@ -790,12 +766,6 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
     translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, false, args, true);
     translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, true, args, true);
 
- //   GLBATCH(glDisable)(GL_ALPHA_TEST);
-  /*  GLBATCH(glEnable)(GL_BLEND);
-    GLBATCH(glDepthMask)(false);
-    GLBATCH(glDepthFunc)(GL_LEQUAL);
-    */
-    //DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(true);
     {
         GLenum buffers[1];
         int bufferCount = 0;
@@ -805,6 +775,8 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
 
    // if (mode == RenderArgs::DEFAULT_RENDER_MODE || mode == RenderArgs::DIFFUSE_RENDER_MODE) {
     if (mode != RenderArgs::SHADOW_RENDER_MODE) {
+    //    batch.setFramebuffer(DependencyManager::get<TextureCache>()->getPrimaryTransparentFramebuffer());
+
         const float MOSTLY_TRANSPARENT_THRESHOLD = 0.0f;
         translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, false, args, true);
         translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, true, args, true);
@@ -814,6 +786,8 @@ bool Model::renderCore(float alpha, RenderMode mode, RenderArgs* args) {
         translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, false, true, args, true);
         translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, false, args, true);
         translucentMeshPartsRendered += renderMeshes(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, true, args, true);
+
+   //     batch.setFramebuffer(DependencyManager::get<TextureCache>()->getPrimaryOpaqueFramebuffer());
     }
 
     GLBATCH(glDepthMask)(true);
@@ -1758,14 +1732,6 @@ void Model::setupBatchTransform(gpu::Batch& batch, RenderArgs* args) {
 void Model::endScene(RenderMode mode, RenderArgs* args) {
     PROFILE_RANGE(__FUNCTION__);
 
-  //  auto glowEffectIntensity = DependencyManager::get<GlowEffect>()->getIntensity();
-
-
-    #if defined(ANDROID)
-    #else
-        glPushMatrix();
-    #endif
-
     RenderArgs::RenderSide renderSide = RenderArgs::MONO;
     if (args) {
         renderSide = args->_renderSide;
@@ -1792,34 +1758,15 @@ void Model::endScene(RenderMode mode, RenderArgs* args) {
         _sceneRenderBatch.clear();
         gpu::Batch& batch = _sceneRenderBatch;
 
-     //   GLBATCH(glDisable)(GL_COLOR_MATERIAL);
-    
-      /*  if (mode == RenderArgs::DIFFUSE_RENDER_MODE || mode == RenderArgs::NORMAL_RENDER_MODE) {
-            GLBATCH(glDisable)(GL_CULL_FACE);
-        } else {
-            GLBATCH(glEnable)(GL_CULL_FACE);
-            if (mode == RenderArgs::SHADOW_RENDER_MODE) {
-                GLBATCH(glCullFace)(GL_FRONT);
-            }
-        }*/
-    
-        // render opaque meshes with alpha testing
-
-      //  GLBATCH(glDisable)(GL_BLEND);
-      //  GLBATCH(glEnable)(GL_ALPHA_TEST);
-    
-     /*   if (mode == RenderArgs::SHADOW_RENDER_MODE) {
-            GLBATCH(glAlphaFunc)(GL_EQUAL, 0.0f);
-        }
-*/
-
         /*DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(
             mode == RenderArgs::DEFAULT_RENDER_MODE || mode == RenderArgs::DIFFUSE_RENDER_MODE,
             mode == RenderArgs::DEFAULT_RENDER_MODE || mode == RenderArgs::NORMAL_RENDER_MODE,
             mode == RenderArgs::DEFAULT_RENDER_MODE);
             */
-        {
+
+       /*  if (mode != RenderArgs::SHADOW_RENDER_MODE) */{
             GLenum buffers[3];
+
             int bufferCount = 0;
          //   if (mode == RenderArgs::DEFAULT_RENDER_MODE || mode == RenderArgs::DIFFUSE_RENDER_MODE) {
             if (mode != RenderArgs::SHADOW_RENDER_MODE) {
@@ -1834,6 +1781,8 @@ void Model::endScene(RenderMode mode, RenderArgs* args) {
                 buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
             }
             GLBATCH(glDrawBuffers)(bufferCount, buffers);
+        
+           // batch.setFramebuffer(DependencyManager::get<TextureCache>()->getPrimaryOpaqueFramebuffer());
         }
 
         const float DEFAULT_ALPHA_THRESHOLD = 0.5f;
@@ -1856,7 +1805,6 @@ void Model::endScene(RenderMode mode, RenderArgs* args) {
         opaqueMeshPartsRendered += renderMeshesForModelsInScene(batch, mode, false, DEFAULT_ALPHA_THRESHOLD, true, true, true, false, args);
 
         // render translucent meshes afterwards
-        //DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(false, true, true);
         {
             GLenum buffers[2];
             int bufferCount = 0;
@@ -1876,21 +1824,19 @@ void Model::endScene(RenderMode mode, RenderArgs* args) {
         translucentParts += renderMeshesForModelsInScene(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, false, args);
         translucentParts += renderMeshesForModelsInScene(batch, mode, true, MOSTLY_OPAQUE_THRESHOLD, false, true, true, true, args);
 
-     //   GLBATCH(glDisable)(GL_ALPHA_TEST);
-       /* GLBATCH(glEnable)(GL_BLEND);
-        GLBATCH(glDepthMask)(false);
-        GLBATCH(glDepthFunc)(GL_LEQUAL);
-    */
-        //DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(true);
+
         {
             GLenum buffers[1];
             int bufferCount = 0;
             buffers[bufferCount++] = GL_COLOR_ATTACHMENT0;
             GLBATCH(glDrawBuffers)(bufferCount, buffers);
+         //   batch.setFramebuffer(DependencyManager::get<TextureCache>()->getPrimaryTransparentFramebuffer());
         }
     
        // if (mode == RenderArgs::DEFAULT_RENDER_MODE || mode == RenderArgs::DIFFUSE_RENDER_MODE) {
         if (mode != RenderArgs::SHADOW_RENDER_MODE) {
+          //  batch.setFramebuffer(DependencyManager::get<TextureCache>()->getPrimaryTransparentFramebuffer());
+
             const float MOSTLY_TRANSPARENT_THRESHOLD = 0.0f;
             translucentParts += renderMeshesForModelsInScene(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, false, args);
             translucentParts += renderMeshesForModelsInScene(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, false, false, true, args);
@@ -1900,6 +1846,8 @@ void Model::endScene(RenderMode mode, RenderArgs* args) {
             translucentParts += renderMeshesForModelsInScene(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, false, true, args);
             translucentParts += renderMeshesForModelsInScene(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, false, args);
             translucentParts += renderMeshesForModelsInScene(batch, mode, true, MOSTLY_TRANSPARENT_THRESHOLD, false, true, true, true, args);
+        
+          // batch.setFramebuffer(DependencyManager::get<TextureCache>()->getPrimaryOpaqueFramebuffer());
         }
 
         GLBATCH(glDepthMask)(true);
@@ -1938,10 +1886,10 @@ void Model::endScene(RenderMode mode, RenderArgs* args) {
         // Back to no program
         GLBATCH(glUseProgram)(0);
 
-    if (args) {
-        args->_translucentMeshPartsRendered = translucentParts;
-        args->_opaqueMeshPartsRendered = opaqueMeshPartsRendered;
-    }
+        if (args) {
+            args->_translucentMeshPartsRendered = translucentParts;
+            args->_opaqueMeshPartsRendered = opaqueMeshPartsRendered;
+        }
 
     }
 
@@ -1950,12 +1898,6 @@ void Model::endScene(RenderMode mode, RenderArgs* args) {
         PROFILE_RANGE("render Batch");
         backend.render(_sceneRenderBatch);
     }
-
-
-    #if defined(ANDROID)
-    #else
-        glPopMatrix();
-    #endif
 
     // restore all the default material settings
     _viewState->setupWorldLight();
@@ -2334,17 +2276,15 @@ void Model::pickPrograms(gpu::Batch& batch, RenderMode mode, bool translucent, f
     RenderKey key(mode, translucent, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned);
     auto pipeline = _renderPipelineLib.find(key.getRaw());
     if (pipeline == _renderPipelineLib.end()) {
-        qDebug() << "No good, couldn;t find a pipeline from the key ?" << key.getRaw();
+        qDebug() << "No good, couldn't find a pipeline from the key ?" << key.getRaw();
         return;
     }
 
     gpu::ShaderPointer program = (*pipeline).second._pipeline->getProgram();
     locations = (*pipeline).second._locations.get();
 
-    //GLuint glprogram = gpu::GLBackend::getShaderID(program);
-    //GLBATCH(glUseProgram)(glprogram);
     
-    // dare!
+    // Setup the One pipeline
     batch.setPipeline((*pipeline).second._pipeline);
 
     if ((locations->alphaThreshold > -1) && (mode != RenderArgs::SHADOW_RENDER_MODE)) {
@@ -2354,9 +2294,6 @@ void Model::pickPrograms(gpu::Batch& batch, RenderMode mode, bool translucent, f
     if ((locations->glowIntensity > -1) && (mode != RenderArgs::SHADOW_RENDER_MODE)) {
         GLBATCH(glUniform1f)(locations->glowIntensity, DependencyManager::get<GlowEffect>()->getIntensity());
     }
-  //  if (!(translucent && alphaThreshold == 0.0f) && (mode != RenderArgs::SHADOW_RENDER_MODE)) {
- //       GLBATCH(glAlphaFunc)(GL_EQUAL, DependencyManager::get<GlowEffect>()->getIntensity());
- //   }
 }
 
 int Model::renderMeshesForModelsInScene(gpu::Batch& batch, RenderMode mode, bool translucent, float alphaThreshold,
@@ -2383,10 +2320,7 @@ int Model::renderMeshesForModelsInScene(gpu::Batch& batch, RenderMode mode, bool
             }
         }
     }
-    // if we selected a program, then unselect it
-    if (!pickProgramsNeeded) {
- //       GLBATCH(glUseProgram)(0);
-    }
+
     return meshPartsRendered;
 }
 
@@ -2415,8 +2349,6 @@ int Model::renderMeshes(gpu::Batch& batch, RenderMode mode, bool translucent, fl
                                 args, locations);
     meshPartsRendered = renderMeshesFromList(list, batch, mode, translucent, alphaThreshold, 
                                 args, locations, forceRenderSomeMeshes);
-   // GLBATCH(glUseProgram)(0);
-
 
     return meshPartsRendered;
 }
@@ -2427,7 +2359,7 @@ int Model::renderMeshesFromList(QVector<int>& list, gpu::Batch& batch, RenderMod
     PROFILE_RANGE(__FUNCTION__);
 
     auto textureCache = DependencyManager::get<TextureCache>();
- //   auto glowEffect = DependencyManager::get<GlowEffect>();
+
     QString lastMaterialID;
     int meshPartsRendered = 0;
     updateVisibleJointStates();
@@ -2531,13 +2463,6 @@ int Model::renderMeshesFromList(QVector<int>& list, gpu::Batch& batch, RenderMod
                         qCDebug(renderutils) << "NEW part.materialID:" << part.materialID;
                     }
 
-/*                    if (locations->glowIntensity >= 0) {
-                        GLBATCH(glUniform1f)(locations->glowIntensity, glowEffect->getIntensity());
-                    }
-                    if (!(translucent && alphaThreshold == 0.0f)) {
-                        GLBATCH(glAlphaFunc)(GL_EQUAL, glowEffect->getIntensity());
-                    }
-*/
                     if (locations->materialBufferUnit >= 0) {
                         batch.setUniformBuffer(locations->materialBufferUnit, material->getSchemaBuffer());
                     }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -130,7 +130,7 @@ void Model::RenderPipelineLib::addRenderPipeline(Model::RenderKey key,
     }
 
     // Z test depends if transparent or not
-    state->setDepthTest(true, !key.isTranslucent(), gpu::State::LESS_EQUAL);
+    state->setDepthTest(true, !key.isTranslucent(), gpu::LESS_EQUAL);
 
     // Blend on transparent
     state->setBlendFunction(key.isTranslucent(),

--- a/libraries/render-utils/src/TextureCache.h
+++ b/libraries/render-utils/src/TextureCache.h
@@ -23,8 +23,6 @@
 #include <DependencyManager.h>
 #include <ResourceCache.h>
 
-class QOpenGLFramebufferObject;
-
 class NetworkTexture;
 
 typedef QSharedPointer<NetworkTexture> NetworkTexturePointer;
@@ -61,10 +59,7 @@ public:
 
     /// Returns a pointer to the primary framebuffer object.  This render target includes a depth component, and is
     /// used for scene rendering.
-    QOpenGLFramebufferObject* getPrimaryFramebufferObject();
-    
-    gpu::FramebufferPointer getPrimaryOpaqueFramebuffer();
-    gpu::FramebufferPointer getPrimaryTransparentFramebuffer();
+    gpu::FramebufferPointer getPrimaryFramebuffer();
 
     gpu::TexturePointer getPrimaryDepthTexture();
     gpu::TexturePointer getPrimaryColorTexture();
@@ -86,16 +81,13 @@ public:
     
     /// Returns a pointer to the secondary framebuffer object, used as an additional render target when performing full
     /// screen effects.
-    QOpenGLFramebufferObject* getSecondaryFramebufferObject();
+    gpu::FramebufferPointer getSecondaryFramebuffer();
     
-
     /// Returns a pointer to the tertiary framebuffer object, used as an additional render target when performing full
     /// screen effects.
-    QOpenGLFramebufferObject* getTertiaryFramebufferObject();
+    gpu::FramebufferPointer getTertiaryFramebuffer();
     
-    /// Returns a pointer to the framebuffer object used to render shadow maps.
-    QOpenGLFramebufferObject* getShadowFramebufferObject();
-    
+    /// Returns the framebuffer object used to render shadow maps;
     gpu::FramebufferPointer getShadowFramebuffer();
 
 
@@ -113,8 +105,6 @@ private:
     TextureCache();
     virtual ~TextureCache();
     friend class DilatableNetworkTexture;
-    
-    QOpenGLFramebufferObject* createFramebufferObject();
  
     gpu::TexturePointer _permutationNormalTexture;
     gpu::TexturePointer _whiteTexture;
@@ -127,20 +117,11 @@ private:
     gpu::TexturePointer _primaryColorTexture;
     gpu::TexturePointer _primaryNormalTexture;
     gpu::TexturePointer _primarySpecularTexture;
-    gpu::FramebufferPointer _primaryOpaqueFramebuffer;
-    gpu::FramebufferPointer _primaryTransparentFramebuffer;
+    gpu::FramebufferPointer _primaryFramebuffer;
     void createPrimaryFramebuffer();
 
-    GLuint _primaryDepthTextureID;
-    GLuint _primaryNormalTextureID;
-    GLuint _primarySpecularTextureID;
-    QOpenGLFramebufferObject* _primaryFramebufferObject;
-    QOpenGLFramebufferObject* _secondaryFramebufferObject;
-    QOpenGLFramebufferObject* _tertiaryFramebufferObject;
-    
-
-    QOpenGLFramebufferObject* _shadowFramebufferObject;
-    GLuint _shadowDepthTextureID;
+    gpu::FramebufferPointer _secondaryFramebuffer;
+    gpu::FramebufferPointer _tertiaryFramebuffer;
 
     gpu::FramebufferPointer _shadowFramebuffer;
     gpu::TexturePointer _shadowTexture;

--- a/libraries/render-utils/src/TextureCache.h
+++ b/libraries/render-utils/src/TextureCache.h
@@ -14,6 +14,7 @@
 
 #include <gpu/GPUConfig.h>
 #include <gpu/Texture.h>
+#include <gpu/Framebuffer.h>
 
 #include <QImage>
 #include <QMap>
@@ -62,9 +63,18 @@ public:
     /// used for scene rendering.
     QOpenGLFramebufferObject* getPrimaryFramebufferObject();
     
+    gpu::FramebufferPointer getPrimaryOpaqueFramebuffer();
+    gpu::FramebufferPointer getPrimaryTransparentFramebuffer();
+
+    gpu::TexturePointer getPrimaryDepthTexture();
+    gpu::TexturePointer getPrimaryColorTexture();
+    gpu::TexturePointer getPrimaryNormalTexture();
+    gpu::TexturePointer getPrimarySpecularTexture();
+
     /// Returns the ID of the primary framebuffer object's depth texture.  This contains the Z buffer used in rendering.
     GLuint getPrimaryDepthTextureID();
-    
+    GLuint getPrimaryColorTextureID();
+
     /// Returns the ID of the primary framebuffer object's normal texture.
     GLuint getPrimaryNormalTextureID();
     
@@ -78,6 +88,7 @@ public:
     /// screen effects.
     QOpenGLFramebufferObject* getSecondaryFramebufferObject();
     
+
     /// Returns a pointer to the tertiary framebuffer object, used as an additional render target when performing full
     /// screen effects.
     QOpenGLFramebufferObject* getTertiaryFramebufferObject();
@@ -85,6 +96,9 @@ public:
     /// Returns a pointer to the framebuffer object used to render shadow maps.
     QOpenGLFramebufferObject* getShadowFramebufferObject();
     
+    gpu::FramebufferPointer getShadowFramebuffer();
+
+
     /// Returns the ID of the shadow framebuffer object's depth texture.
     GLuint getShadowDepthTextureID();
     
@@ -105,9 +119,18 @@ private:
     gpu::TexturePointer _permutationNormalTexture;
     gpu::TexturePointer _whiteTexture;
     gpu::TexturePointer _blueTexture;
+
     
     QHash<QUrl, QWeakPointer<NetworkTexture> > _dilatableNetworkTextures;
-    
+   
+    gpu::TexturePointer _primaryDepthTexture;
+    gpu::TexturePointer _primaryColorTexture;
+    gpu::TexturePointer _primaryNormalTexture;
+    gpu::TexturePointer _primarySpecularTexture;
+    gpu::FramebufferPointer _primaryOpaqueFramebuffer;
+    gpu::FramebufferPointer _primaryTransparentFramebuffer;
+    void createPrimaryFramebuffer();
+
     GLuint _primaryDepthTextureID;
     GLuint _primaryNormalTextureID;
     GLuint _primarySpecularTextureID;
@@ -115,8 +138,12 @@ private:
     QOpenGLFramebufferObject* _secondaryFramebufferObject;
     QOpenGLFramebufferObject* _tertiaryFramebufferObject;
     
+
     QOpenGLFramebufferObject* _shadowFramebufferObject;
     GLuint _shadowDepthTextureID;
+
+    gpu::FramebufferPointer _shadowFramebuffer;
+    gpu::TexturePointer _shadowTexture;
 
     QSize _frameBufferSize;
     QGLWidget* _associatedWidget;


### PR DESCRIPTION
- The gpu::Framebuffer is the abstraction of the glFramebuffer.
it can be of 2 kinds:
- swapchain: a black box Framebuffer provided by something out from standard GL, typically a OSwindow. but also the final destination for a HMD like Occulus and the place where all the specifities required by these different systems can be managed in a specialized version of Swapchain.
From the point of view of gpu, the swapchain is draw only
At this point the swapchain is not used yet, coming up soun in a later PR

- Offscreen framebuffer: the standard multitude of renderBuffers (aka textures) attached to different units and optionally a depth/stencil buffer

- INtroduce the gpu::Sampler which is a simple class gathereing the parameters for the sampler, it s small, every texture has one.

- Removed almost all the QFramebufferObject from interface and it's working ok

Ready for review