### PR TITLE
Quit application when main window is closed

### DIFF
--- a/interface/src/MainWindow.cpp
+++ b/interface/src/MainWindow.cpp
@@ -55,6 +55,10 @@ void MainWindow::saveGeometry() {
     }
 }
 
+void MainWindow::closeEvent(QCloseEvent* event) {
+    qApp->quit();
+}
+
 void MainWindow::moveEvent(QMoveEvent* event) {
     emit windowGeometryChanged(QRect(event->pos(), size()));
     QMainWindow::moveEvent(event);

--- a/interface/src/MainWindow.h
+++ b/interface/src/MainWindow.h
@@ -30,6 +30,7 @@ signals:
     void windowShown(bool shown);
 
 protected:
+    virtual void closeEvent(QCloseEvent* event);
     virtual void moveEvent(QMoveEvent* event);
     virtual void resizeEvent(QResizeEvent* event);
     virtual void showEvent(QShowEvent* event);


### PR DESCRIPTION
Currently if you have other windows open (such as the edit tools window) the application will continue running after you have closed the main window.

@ZappoMan @jherico Are there any cases where the main window might be closed but we don't want to quit the application? Are there cases where going into a fullscreen hmd mode "closes" the main window?  I didn't see this happening when I tested, but wanted to check.