### PR TITLE
Fix stop/reload all scripts affecting already-stopped scripts

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3889,6 +3889,9 @@ void Application::stopAllScripts(bool restart) {
     // stops all current running scripts
     for (QHash<QString, ScriptEngine*>::const_iterator it = _scriptEnginesHash.constBegin();
             it != _scriptEnginesHash.constEnd(); it++) {
+        if (it.value()->isFinished()) {
+            continue;
+        }
         if (restart && it.value()->isUserLoaded()) {
             connect(it.value(), SIGNAL(finished(const QString&)), SLOT(loadScript(const QString&)));
         }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -647,8 +647,10 @@ void ScriptEngine::stopAllTimers() {
 }
 
 void ScriptEngine::stop() {
-    _isFinished = true;
-    emit runningStateChanged();
+    if (!_isFinished) {
+        _isFinished = true;
+        emit runningStateChanged();
+    }
 }
 
 void ScriptEngine::timerFired() {


### PR DESCRIPTION
This was causing scripts to be restarted multiple times in cases where it takes awhile for scripts to shut down or restart-all is pressed quickly 2+ times.