### PR TITLE
more consistency of ShapeType for model entities

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -299,7 +299,6 @@ bool RenderableModelEntityItem::isReadyToComputeShape() {
         }
 
         // the model is still being downloaded.
-        std::cout << "adebug still being downloaded" << std::endl;  // adebug
         return false;
     }
     return true;

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -274,54 +274,50 @@ void RenderableModelEntityItem::setCollisionModelURL(const QString& url) {
     }
 }
 
-bool RenderableModelEntityItem::hasCollisionModel() const {
-    if (_model) {
-        return ! _model->getCollisionURL().isEmpty();
-    } else {
-        return !_collisionModelURL.isEmpty();
-    }
-}
-
-const QString& RenderableModelEntityItem::getCollisionModelURL() const {
-    // assert (!_model || _collisionModelURL == _model->getCollisionURL().toString());
-    return _collisionModelURL;
-}
-
 bool RenderableModelEntityItem::isReadyToComputeShape() {
+    ShapeType type = getShapeType();
+    if (type == SHAPE_TYPE_COMPOUND) {
 
-    if (!_model) {
-        return false; // hmm...
+        if (!_model) {
+            return false; // hmm...
+        }
+
+        assert(!_model->getCollisionURL().isEmpty());
+    
+        if (_model->getURL().isEmpty()) {
+            // we need a render geometry with a scale to proceed, so give up.
+            return false;
+        }
+    
+        const QSharedPointer<NetworkGeometry> collisionNetworkGeometry = _model->getCollisionGeometry();
+        const QSharedPointer<NetworkGeometry> renderNetworkGeometry = _model->getGeometry();
+    
+        if ((! collisionNetworkGeometry.isNull() && collisionNetworkGeometry->isLoadedWithTextures()) &&
+            (! renderNetworkGeometry.isNull() && renderNetworkGeometry->isLoadedWithTextures())) {
+            // we have both URLs AND both geometries AND they are both fully loaded.
+            return true;
+        }
+
+        // the model is still being downloaded.
+        std::cout << "adebug still being downloaded" << std::endl;  // adebug
+        return false;
     }
-
-    if (_model->getCollisionURL().isEmpty()) {
-        // no collision-model url, so we're ready to compute a shape (of type None).
-        return true;
-    }
-    if (_model->getURL().isEmpty()) {
-        // we need a render geometry with a scale to proceed, so give up.
-        return true;
-    }
-
-    const QSharedPointer<NetworkGeometry> collisionNetworkGeometry = _model->getCollisionGeometry();
-    const QSharedPointer<NetworkGeometry> renderNetworkGeometry = _model->getGeometry();
-
-    if ((! collisionNetworkGeometry.isNull() && collisionNetworkGeometry->isLoadedWithTextures()) &&
-        (! renderNetworkGeometry.isNull() && renderNetworkGeometry->isLoadedWithTextures())) {
-        // we have both URLs AND both geometries AND they are both fully loaded.
-        return true;
-    }
-
-    // the model is still being downloaded.
-    return false;
+    return true;
 }
 
 void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
-    if (_model->getCollisionURL().isEmpty() || _model->getURL().isEmpty()) {
-        info.setParams(getShapeType(), 0.5f * getDimensions());
+    ShapeType type = getShapeType();
+    if (type != SHAPE_TYPE_COMPOUND) {
+        ModelEntityItem::computeShapeInfo(info);
+        info.setParams(_shapeType, 0.5f * getDimensions());
     } else {
         const QSharedPointer<NetworkGeometry> collisionNetworkGeometry = _model->getCollisionGeometry();
-        const FBXGeometry& collisionGeometry = collisionNetworkGeometry->getFBXGeometry();
 
+        // should never fall in here when collision model not fully loaded
+        // hence we assert collisionNetworkGeometry is not NULL
+        assert(!collisionNetworkGeometry.isNull());
+
+        const FBXGeometry& collisionGeometry = collisionNetworkGeometry->getFBXGeometry();
         const QSharedPointer<NetworkGeometry> renderNetworkGeometry = _model->getGeometry();
         const FBXGeometry& renderGeometry = renderNetworkGeometry->getFBXGeometry();
 
@@ -415,18 +411,8 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         }
 
         glm::vec3 collisionModelDimensions = box.getDimensions();
-        info.setParams(getShapeType(), collisionModelDimensions, _collisionModelURL);
+        info.setParams(_shapeType, collisionModelDimensions, _collisionModelURL);
         info.setConvexHulls(_points);
     }
 }
 
-ShapeType RenderableModelEntityItem::getShapeType() const {
-    // XXX make hull an option in edit.js ?
-    if (!_model || _model->getCollisionURL().isEmpty()) {
-        return _shapeType;
-    } else if (_points.size() == 1) {
-        return SHAPE_TYPE_CONVEX_HULL;
-    } else {
-        return SHAPE_TYPE_COMPOUND;
-    }
-}

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -308,7 +308,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
     ShapeType type = getShapeType();
     if (type != SHAPE_TYPE_COMPOUND) {
         ModelEntityItem::computeShapeInfo(info);
-        info.setParams(_shapeType, 0.5f * getDimensions());
+        info.setParams(type, 0.5f * getDimensions());
     } else {
         const QSharedPointer<NetworkGeometry> collisionNetworkGeometry = _model->getCollisionGeometry();
 
@@ -410,7 +410,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         }
 
         glm::vec3 collisionModelDimensions = box.getDimensions();
-        info.setParams(_shapeType, collisionModelDimensions, _collisionModelURL);
+        info.setParams(type, collisionModelDimensions, _collisionModelURL);
         info.setConvexHulls(_points);
     }
 }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -53,12 +53,9 @@ public:
     bool needsToCallUpdate() const;
 
     virtual void setCollisionModelURL(const QString& url);
-    virtual bool hasCollisionModel() const;
-    virtual const QString& getCollisionModelURL() const;
 
     bool isReadyToComputeShape();
     void computeShapeInfo(ShapeInfo& info);
-    ShapeType getShapeType() const;
 
 private:
     void remapTextures();

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -192,7 +192,7 @@ void buildStringToShapeTypeLookup() {
     stringToShapeTypeLookup["box"] = SHAPE_TYPE_BOX;
     stringToShapeTypeLookup["sphere"] = SHAPE_TYPE_SPHERE;
     stringToShapeTypeLookup["ellipsoid"] = SHAPE_TYPE_ELLIPSOID;
-    stringToShapeTypeLookup["convex-hull"] = SHAPE_TYPE_CONVEX_HULL;
+    stringToShapeTypeLookup["convex-hull"] = SHAPE_TYPE_COMPOUND;
     stringToShapeTypeLookup["plane"] = SHAPE_TYPE_PLANE;
     stringToShapeTypeLookup["compound"] = SHAPE_TYPE_COMPOUND;
     stringToShapeTypeLookup["capsule-x"] = SHAPE_TYPE_CAPSULE_X;

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -282,6 +282,16 @@ void ModelEntityItem::updateShapeType(ShapeType type) {
     }
 }
 
+// virtual 
+ShapeType ModelEntityItem::getShapeType() const {
+    if (_shapeType == SHAPE_TYPE_COMPOUND) {
+        return hasCollisionModel() ? SHAPE_TYPE_COMPOUND : SHAPE_TYPE_NONE;
+    }
+    else {
+        return _shapeType;
+    }
+}
+
 void ModelEntityItem::setCollisionModelURL(const QString& url) {
     if (_collisionModelURL != url) {
         _collisionModelURL = url;

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -276,6 +276,16 @@ void ModelEntityItem::debugDump() const {
 }
 
 void ModelEntityItem::updateShapeType(ShapeType type) {
+    // BEGIN_TEMPORARY_WORKAROUND
+    // we have allowed inconsistent ShapeType's to be stored in SVO files in the past (this was a bug)
+    // but we are now enforcing the entity properties to be consistent.  To make the possible we're 
+    // introducing a temporary workaround: we will ignore ShapeType updates that conflict with the
+    // _collisionModelURL.
+    if (hasCollisionModel()) {
+        type = SHAPE_TYPE_COMPOUND;
+    }
+    // END_TEMPORARY_WORKAROUND
+
     if (type != _shapeType) {
         _shapeType = type;
         _dirtyFlags |= EntityItem::DIRTY_SHAPE | EntityItem::DIRTY_MASS;
@@ -296,6 +306,7 @@ void ModelEntityItem::setCollisionModelURL(const QString& url) {
     if (_collisionModelURL != url) {
         _collisionModelURL = url;
         _dirtyFlags |= EntityItem::DIRTY_SHAPE | EntityItem::DIRTY_MASS;
+        _shapeType = _collisionModelURL.isEmpty() ? SHAPE_TYPE_NONE : SHAPE_TYPE_COMPOUND;
     }
 }
 

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -296,8 +296,7 @@ void ModelEntityItem::updateShapeType(ShapeType type) {
 ShapeType ModelEntityItem::getShapeType() const {
     if (_shapeType == SHAPE_TYPE_COMPOUND) {
         return hasCollisionModel() ? SHAPE_TYPE_COMPOUND : SHAPE_TYPE_NONE;
-    }
-    else {
+    } else {
         return _shapeType;
     }
 }

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -49,7 +49,7 @@ public:
     virtual void debugDump() const;
 
     void updateShapeType(ShapeType type);
-    virtual ShapeType getShapeType() const { return _shapeType; }
+    virtual ShapeType getShapeType() const;
 
     // TODO: Move these to subclasses, or other appropriate abstraction
     // getters/setters applicable to models and particles
@@ -63,7 +63,7 @@ public:
     const QString& getModelURL() const { return _modelURL; }
 
     static const QString DEFAULT_COLLISION_MODEL_URL;
-    virtual const QString& getCollisionModelURL() const { return _collisionModelURL; }
+    const QString& getCollisionModelURL() const { return _collisionModelURL; }
 
     bool hasAnimation() const { return !_animationURL.isEmpty(); }
     static const QString DEFAULT_ANIMATION_URL;

--- a/libraries/physics/src/ShapeInfoUtil.h
+++ b/libraries/physics/src/ShapeInfoUtil.h
@@ -19,16 +19,10 @@
 
 // translates between ShapeInfo and btShape
 
+// TODO: rename this to ShapeFactory
 namespace ShapeInfoUtil {
 
-    // XXX is collectInfoFromShape no longer strictly needed?
-    void collectInfoFromShape(const btCollisionShape* shape, ShapeInfo& info);
-
     btCollisionShape* createShapeFromInfo(const ShapeInfo& info);
-
-    // TODO? just use bullet shape types everywhere?
-    int toBulletShapeType(int shapeInfoType);
-    int fromBulletShapeType(int bulletShapeType);
 };
 
 #endif // hifi_ShapeInfoUtil_h

--- a/libraries/physics/src/ShapeManager.cpp
+++ b/libraries/physics/src/ShapeManager.cpp
@@ -35,7 +35,7 @@ btCollisionShape* ShapeManager::getShape(const ShapeInfo& info) {
     // Very small or large objects are not supported.
     float diagonal = 4.0f * glm::length2(info.getHalfExtents());
     const float MIN_SHAPE_DIAGONAL_SQUARED = 3.0e-4f; // 1 cm cube
-    const float MAX_SHAPE_DIAGONAL_SQUARED = 3.0e6f;  // 1000 m cube
+    //const float MAX_SHAPE_DIAGONAL_SQUARED = 3.0e6f;  // 1000 m cube
     if (diagonal < MIN_SHAPE_DIAGONAL_SQUARED /* || diagonal > MAX_SHAPE_DIAGONAL_SQUARED*/ ) {
         // qCDebug(physics) << "ShapeManager::getShape -- not making shape due to size" << diagonal;
         return NULL;
@@ -104,11 +104,9 @@ void ShapeManager::collectGarbage() {
         ShapeReference* shapeRef = _shapeMap.find(key);
         if (shapeRef && shapeRef->refCount == 0) {
             // if the shape we're about to delete is compound, delete the children first.
-            auto shapeType = ShapeInfoUtil::fromBulletShapeType(shapeRef->shape->getShapeType());
-            if (shapeType == SHAPE_TYPE_COMPOUND) {
+            if (shapeRef->shape->getShapeType() == COMPOUND_SHAPE_PROXYTYPE) {
                 const btCompoundShape* compoundShape = static_cast<const btCompoundShape*>(shapeRef->shape);
                 const int numChildShapes = compoundShape->getNumChildShapes();
-                QVector<QVector<glm::vec3>> points;
                 for (int i = 0; i < numChildShapes; i ++) {
                     const btCollisionShape* childShape = compoundShape->getChildShape(i);
                     delete childShape;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -151,7 +151,7 @@ void Model::RenderPipelineLib::addRenderPipeline(Model::RenderKey key,
 
         // create a new RenderPipeline with the same shader side and the mirrorState
         auto mirrorPipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, mirrorState));
-        auto it = insert(value_type(mirrorKey.getRaw(), RenderPipeline(mirrorPipeline, locations)));
+        insert(value_type(mirrorKey.getRaw(), RenderPipeline(mirrorPipeline, locations)));
     }
 }
 

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -37,12 +37,6 @@ void ShapeInfo::setParams(ShapeType type, const glm::vec3& halfExtents, QString 
             _halfExtents = glm::vec3(radius);
             break;
         }
-        case SHAPE_TYPE_CONVEX_HULL:
-            _url = QUrl(url);
-            // halfExtents aren't used by convex-hull or compound convex-hull except as part of
-            // the generation of the key for the ShapeManager.
-            _halfExtents = halfExtents;
-            break;
         case SHAPE_TYPE_COMPOUND:
             _url = QUrl(url);
             _halfExtents = halfExtents;
@@ -78,12 +72,8 @@ void ShapeInfo::setEllipsoid(const glm::vec3& halfExtents) {
 }
 
 void ShapeInfo::setConvexHulls(const QVector<QVector<glm::vec3>>& points) {
-    if (points.size() == 1) {
-        _type = SHAPE_TYPE_CONVEX_HULL;
-    } else {
-        _type = SHAPE_TYPE_COMPOUND;
-    }
     _points = points;
+    _type = (_points.size() > 0) ? SHAPE_TYPE_COMPOUND : SHAPE_TYPE_NONE;
     _doubleHashKey.clear();
 }
 
@@ -95,6 +85,14 @@ void ShapeInfo::setCapsuleY(float radius, float halfHeight) {
     _doubleHashKey.clear();
 }
 
+uint32_t ShapeInfo::getNumSubShapes() const {
+    if (_type == SHAPE_TYPE_NONE) {
+        return 0;
+    } else if (_type == SHAPE_TYPE_COMPOUND) {
+        return _points.size();
+    }
+    return 1;
+}
 float ShapeInfo::computeVolume() const {
     const float DEFAULT_VOLUME = 1.0f;
     float volume = DEFAULT_VOLUME;

--- a/libraries/shared/src/ShapeInfo.h
+++ b/libraries/shared/src/ShapeInfo.h
@@ -24,7 +24,6 @@ enum ShapeType {
     SHAPE_TYPE_BOX,
     SHAPE_TYPE_SPHERE,
     SHAPE_TYPE_ELLIPSOID,
-    SHAPE_TYPE_CONVEX_HULL,
     SHAPE_TYPE_PLANE,
     SHAPE_TYPE_COMPOUND,
     SHAPE_TYPE_CAPSULE_X,
@@ -52,6 +51,7 @@ public:
     const glm::vec3& getHalfExtents() const { return _halfExtents; }
 
     const QVector<QVector<glm::vec3>>& getPoints() const { return _points; }
+    uint32_t getNumSubShapes() const;
 
     void clearPoints () { _points.clear(); }
     void appendToPoints (const QVector<glm::vec3>& newPoints) { _points << newPoints; }

--- a/tests/physics/src/ShapeInfoTests.cpp
+++ b/tests/physics/src/ShapeInfoTests.cpp
@@ -147,9 +147,7 @@ void ShapeInfoTests::testBoxShape() {
         std::cout << __FILE__ << ":" << __LINE__ << " ERROR: NULL Box shape" << std::endl;
     }
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     DoubleHashKey otherKey = otherInfo.getHash();
     if (key.getHash() != otherKey.getHash()) {
         std::cout << __FILE__ << ":" << __LINE__
@@ -172,9 +170,7 @@ void ShapeInfoTests::testSphereShape() {
 
     btCollisionShape* shape = ShapeInfoUtil::createShapeFromInfo(info);
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     DoubleHashKey otherKey = otherInfo.getHash();
     if (key.getHash() != otherKey.getHash()) {
         std::cout << __FILE__ << ":" << __LINE__
@@ -198,9 +194,7 @@ void ShapeInfoTests::testCylinderShape() {
 
     btCollisionShape* shape = ShapeInfoUtil::createShapeFromInfo(info);
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     DoubleHashKey otherKey = otherInfo.getHash();
     if (key.getHash() != otherKey.getHash()) {
         std::cout << __FILE__ << ":" << __LINE__
@@ -225,9 +219,7 @@ void ShapeInfoTests::testCapsuleShape() {
 
     btCollisionShape* shape = ShapeInfoUtil::createShapeFromInfo(info);
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     DoubleHashKey otherKey = otherInfo.getHash();
     if (key.getHash() != otherKey.getHash()) {
         std::cout << __FILE__ << ":" << __LINE__

--- a/tests/physics/src/ShapeManagerTests.cpp
+++ b/tests/physics/src/ShapeManagerTests.cpp
@@ -187,9 +187,7 @@ void ShapeManagerTests::addBoxShape() {
     ShapeManager shapeManager;
     btCollisionShape* shape = shapeManager.getShape(info);
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     btCollisionShape* otherShape = shapeManager.getShape(otherInfo);
     if (shape != otherShape) {
         std::cout << __FILE__ << ":" << __LINE__
@@ -205,9 +203,7 @@ void ShapeManagerTests::addSphereShape() {
     ShapeManager shapeManager;
     btCollisionShape* shape = shapeManager.getShape(info);
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     btCollisionShape* otherShape = shapeManager.getShape(otherInfo);
     if (shape != otherShape) {
         std::cout << __FILE__ << ":" << __LINE__
@@ -225,9 +221,7 @@ void ShapeManagerTests::addCylinderShape() {
     ShapeManager shapeManager;
     btCollisionShape* shape = shapeManager.getShape(info);
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     btCollisionShape* otherShape = shapeManager.getShape(otherInfo);
     if (shape != otherShape) {
         std::cout << __FILE__ << ":" << __LINE__
@@ -246,9 +240,7 @@ void ShapeManagerTests::addCapsuleShape() {
     ShapeManager shapeManager;
     btCollisionShape* shape = shapeManager.getShape(info);
 
-    ShapeInfo otherInfo;
-    ShapeInfoUtil::collectInfoFromShape(shape, otherInfo);
-
+    ShapeInfo otherInfo = info;
     btCollisionShape* otherShape = shapeManager.getShape(otherInfo);
     if (shape != otherShape) {
         std::cout << __FILE__ << ":" << __LINE__


### PR DESCRIPTION
It was possible for ModelEntityItem::_shapeType to disagree with the actual shape type of the model (e.g. when using collisionURL) so this work helps bring these two data fields into agreement.