### PR TITLE
measure acceleration of object

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2226,6 +2226,7 @@ void Application::update(float deltaTime) {
         PerformanceTimer perfTimer("physics");
         _myAvatar->relayDriveKeysToCharacterController();
         _physicsEngine.stepSimulation();
+        _physicsEngine.dumpStatsIfNecessary();
     }
 
     if (!_aboutToQuit) {

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -62,7 +62,7 @@ void EntityMotionState::stepKinematicSimulation(quint64 now) {
     // which is different from physical kinematic motion (inside getWorldTransform())
     // which steps in physics simulation time.
     _entity->simulate(now);
-    // TODO: we can't use ObjectMotionState::measureVelocityAndAcceleration() here because the entity
+    // TODO: we can't use ObjectMotionState::measureAcceleration() here because the entity
     // has no RigidBody and the timestep is a little bit out of sync with the physics simulation anyway.
     // Hence we must manually measure kinematic velocity and acceleration.
 }
@@ -95,7 +95,7 @@ void EntityMotionState::getWorldTransform(btTransform& worldTrans) const {
 // This callback is invoked by the physics simulation at the end of each simulation step...
 // iff the corresponding RigidBody is DYNAMIC and has moved.
 void EntityMotionState::setWorldTransform(const btTransform& worldTrans) {
-    measureVelocityAndAcceleration();
+    measureAcceleration();
     _entity->setPosition(bulletToGLM(worldTrans.getOrigin()) + ObjectMotionState::getWorldOffset());
     _entity->setRotation(bulletToGLM(worldTrans.getRotation()));
 

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -50,13 +50,13 @@ public:
     virtual void setWorldTransform(const btTransform& worldTrans);
 
     // these relay incoming values to the RigidBody
-    virtual void updateObjectEasy(uint32_t flags, uint32_t frame);
+    virtual void updateObjectEasy(uint32_t flags, uint32_t step);
     virtual void updateObjectVelocities();
 
     virtual void computeShapeInfo(ShapeInfo& shapeInfo);
     virtual float computeMass(const ShapeInfo& shapeInfo) const;
 
-    virtual void sendUpdate(OctreeEditPacketSender* packetSender, uint32_t frame);
+    virtual void sendUpdate(OctreeEditPacketSender* packetSender, uint32_t step);
 
     virtual uint32_t getIncomingDirtyFlags() const;
     virtual void clearIncomingDirtyFlags(uint32_t flags) { _entity->clearDirtyFlags(flags); }

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -68,7 +68,7 @@ ObjectMotionState::~ObjectMotionState() {
     assert(_body == NULL);
 }
 
-void ObjectMotionState::measureVelocityAndAcceleration() {
+void ObjectMotionState::measureAcceleration() {
     // try to manually measure the true acceleration of the object
     uint32_t numSubsteps = _simulationStep - _lastSimulationStep;
     if (numSubsteps > 0) {
@@ -84,7 +84,7 @@ void ObjectMotionState::measureVelocityAndAcceleration() {
     }
 }
 
-void ObjectMotionState::resetMeasuredVelocityAndAcceleration() {
+void ObjectMotionState::resetMeasuredAcceleration() {
     _lastSimulationStep = _simulationStep;
     _lastVelocity = bulletToGLM(_body->getLinearVelocity());
 }

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -60,7 +60,7 @@ ObjectMotionState::ObjectMotionState() :
     _sentAcceleration(0.0f),
     _lastSimulationStep(0),
     _lastVelocity(0.0f),
-    _measuredAcceleration(0.0f)
+    _measuredAcceleration(0.0f) {
 }
 
 ObjectMotionState::~ObjectMotionState() {

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -62,8 +62,8 @@ public:
     ObjectMotionState();
     ~ObjectMotionState();
 
-    void measureVelocityAndAcceleration();
-    void resetMeasuredVelocityAndAcceleration();
+    void measureAcceleration();
+    void resetMeasuredAcceleration();
 
     // An EASY update does not require the object to be removed and then reinserted into the PhysicsEngine
     virtual void updateObjectEasy(uint32_t flags, uint32_t frame) = 0;

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -57,8 +57,13 @@ public:
     static void setWorldOffset(const glm::vec3& offset);
     static const glm::vec3& getWorldOffset();
 
+    static void setSimulationStep(uint32_t step);
+
     ObjectMotionState();
     ~ObjectMotionState();
+
+    void measureVelocityAndAcceleration();
+    void resetMeasuredVelocityAndAcceleration();
 
     // An EASY update does not require the object to be removed and then reinserted into the PhysicsEngine
     virtual void updateObjectEasy(uint32_t flags, uint32_t frame) = 0;
@@ -87,7 +92,7 @@ public:
     void clearOutgoingPacketFlags(uint32_t flags) { _outgoingPacketFlags &= ~flags; }
 
     bool doesNotNeedToSendUpdate() const;
-    virtual bool shouldSendUpdate(uint32_t simulationFrame);
+    virtual bool shouldSendUpdate(uint32_t simulationStep);
     virtual void sendUpdate(OctreeEditPacketSender* packetSender, uint32_t frame) = 0;
 
     virtual MotionType computeMotionType() const = 0;
@@ -126,12 +131,16 @@ protected:
     int _numNonMovingUpdates; // RELIABLE_SEND_HACK for "not so reliable" resends of packets for non-moving objects
 
     uint32_t _outgoingPacketFlags;
-    uint32_t _sentFrame;
+    uint32_t _sentStep;
     glm::vec3 _sentPosition;    // in simulation-frame (not world-frame)
     glm::quat _sentRotation;;
     glm::vec3 _sentVelocity;
     glm::vec3 _sentAngularVelocity; // radians per second
     glm::vec3 _sentAcceleration;
+
+    uint32_t _lastSimulationStep;
+    glm::vec3 _lastVelocity;
+    glm::vec3 _measuredAcceleration;
 };
 
 #endif // hifi_ObjectMotionState_h

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -288,85 +288,79 @@ void PhysicsEngine::init(EntityEditPacketSender* packetSender) {
 }
 
 void PhysicsEngine::stepSimulation() {
-    {
-        lock();
-        CProfileManager::Reset();
-        BT_PROFILE("stepSimulation");
-        // NOTE: the grand order of operations is:
-        // (1) pull incoming changes
-        // (2) step simulation
-        // (3) synchronize outgoing motion states
-        // (4) send outgoing packets
+    lock();
+    CProfileManager::Reset();
+    BT_PROFILE("stepSimulation");
+    // NOTE: the grand order of operations is:
+    // (1) pull incoming changes
+    // (2) step simulation
+    // (3) synchronize outgoing motion states
+    // (4) send outgoing packets
 
-        // This is step (1) pull incoming changes
-        relayIncomingChangesToSimulation();
-    
-        const int MAX_NUM_SUBSTEPS = 4;
-        const float MAX_TIMESTEP = (float)MAX_NUM_SUBSTEPS * PHYSICS_ENGINE_FIXED_SUBSTEP;
-        float dt = 1.0e-6f * (float)(_clock.getTimeMicroseconds());
-        _clock.reset();
-        float timeStep = btMin(dt, MAX_TIMESTEP);
-    
-        // TODO: move character->preSimulation() into relayIncomingChanges
-        if (_characterController) {
-            if (_characterController->needsRemoval()) {
-                _characterController->setDynamicsWorld(NULL);
-            }
-            _characterController->updateShapeIfNecessary();
-            if (_characterController->needsAddition()) {
-                _characterController->setDynamicsWorld(_dynamicsWorld);
-            }
-            _characterController->preSimulation(timeStep);
+    // This is step (1) pull incoming changes
+    relayIncomingChangesToSimulation();
+
+    const int MAX_NUM_SUBSTEPS = 4;
+    const float MAX_TIMESTEP = (float)MAX_NUM_SUBSTEPS * PHYSICS_ENGINE_FIXED_SUBSTEP;
+    float dt = 1.0e-6f * (float)(_clock.getTimeMicroseconds());
+    _clock.reset();
+    float timeStep = btMin(dt, MAX_TIMESTEP);
+
+    // TODO: move character->preSimulation() into relayIncomingChanges
+    if (_characterController) {
+        if (_characterController->needsRemoval()) {
+            _characterController->setDynamicsWorld(NULL);
         }
-    
-        // This is step (2) step simulation
-        int numSubsteps = _dynamicsWorld->stepSimulation(timeStep, MAX_NUM_SUBSTEPS, PHYSICS_ENGINE_FIXED_SUBSTEP);
-        _numSubsteps += (uint32_t)numSubsteps;
-        stepNonPhysicalKinematics(usecTimestampNow());
-        unlock();
-    
-        // TODO: make all of this harvest stuff into one function: relayOutgoingChanges()
-        if (numSubsteps > 0) {
-            BT_PROFILE("postSimulation");
-            // This is step (3) which is done outside of stepSimulation() so we can lock _entityTree.
-            //
-            // Unfortunately we have to unlock the simulation (above) before we try to lock the _entityTree
-            // to avoid deadlock -- the _entityTree may try to lock its EntitySimulation (from which this 
-            // PhysicsEngine derives) when updating/adding/deleting entities so we need to wait for our own
-            // lock on the tree before we re-lock ourselves.
-            //
-            // TODO: untangle these lock sequences.
-            _entityTree->lockForWrite();
-            lock();
-            _dynamicsWorld->synchronizeMotionStates();
-    
-            if (_characterController) {
-                _characterController->postSimulation();
-            }
-    
-            unlock();
-            _entityTree->unlock();
-        
-            computeCollisionEvents();
+        _characterController->updateShapeIfNecessary();
+        if (_characterController->needsAddition()) {
+            _characterController->setDynamicsWorld(_dynamicsWorld);
         }
+        _characterController->preSimulation(timeStep);
     }
-    if (_dumpNextStats) {
-        _dumpNextStats = false;
-        CProfileManager::dumpAll();
+
+    // This is step (2) step simulation
+    int numSubsteps = _dynamicsWorld->stepSimulation(timeStep, MAX_NUM_SUBSTEPS, PHYSICS_ENGINE_FIXED_SUBSTEP);
+    _numSubsteps += (uint32_t)numSubsteps;
+    stepNonPhysicalKinematics(usecTimestampNow());
+    unlock();
+
+    // TODO: make all of this harvest stuff into one function: relayOutgoingChanges()
+    if (numSubsteps > 0) {
+        BT_PROFILE("postSimulation");
+        // This is step (3) which is done outside of stepSimulation() so we can lock _entityTree.
+        //
+        // Unfortunately we have to unlock the simulation (above) before we try to lock the _entityTree
+        // to avoid deadlock -- the _entityTree may try to lock its EntitySimulation (from which this 
+        // PhysicsEngine derives) when updating/adding/deleting entities so we need to wait for our own
+        // lock on the tree before we re-lock ourselves.
+        //
+        // TODO: untangle these lock sequences.
+        ObjectMotionState::setSimulationStep(_numSubsteps);
+        _entityTree->lockForWrite();
+        lock();
+        _dynamicsWorld->synchronizeMotionStates();
+
+        if (_characterController) {
+            _characterController->postSimulation();
+        }
+
+        unlock();
+        _entityTree->unlock();
+    
+        computeCollisionEvents();
     }
 }
 
 void PhysicsEngine::stepNonPhysicalKinematics(const quint64& now) {
     BT_PROFILE("nonPhysicalKinematics");
     QSet<ObjectMotionState*>::iterator stateItr = _nonPhysicalKinematicObjects.begin();
+    // TODO?: need to occasionally scan for stopped non-physical kinematics objects
     while (stateItr != _nonPhysicalKinematicObjects.end()) {
         ObjectMotionState* motionState = *stateItr;
         motionState->stepKinematicSimulation(now);
         ++stateItr;
     }
 }
-
-// TODO?: need to occasionally scan for stopped non-physical kinematics objects
 
 void PhysicsEngine::computeCollisionEvents() {
     BT_PROFILE("computeCollisionEvents");
@@ -442,6 +436,13 @@ void PhysicsEngine::computeCollisionEvents() {
         } else {
             ++contactItr;
         }
+    }
+}
+
+void PhysicsEngine::dumpStatsIfNecessary() {
+    if (_dumpNextStats) {
+        _dumpNextStats = false;
+        CProfileManager::dumpAll();
     }
 }
 

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -194,7 +194,7 @@ void PhysicsEngine::relayIncomingChangesToSimulation() {
                 motionState->updateObjectEasy(flags, _numSubsteps);
             }
             if (flags & (EntityItem::DIRTY_POSITION | EntityItem::DIRTY_VELOCITY)) {
-                motionState->resetMeasuredVelocityAndAcceleration();
+                motionState->resetMeasuredAcceleration();
             }
         } else {
             // the only way we should ever get here (motionState exists but no body) is when the object
@@ -511,7 +511,7 @@ void PhysicsEngine::addObject(const ShapeInfo& shapeInfo, btCollisionShape* shap
     body->setFriction(motionState->_friction);
     body->setDamping(motionState->_linearDamping, motionState->_angularDamping);
     _dynamicsWorld->addRigidBody(body);
-    motionState->resetMeasuredVelocityAndAcceleration();
+    motionState->resetMeasuredAcceleration();
 }
 
 void PhysicsEngine::removeObjectFromBullet(ObjectMotionState* motionState) {

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -193,6 +193,9 @@ void PhysicsEngine::relayIncomingChangesToSimulation() {
                 // hence the MotionState has all the knowledge and authority to perform the update.
                 motionState->updateObjectEasy(flags, _numSubsteps);
             }
+            if (flags & (EntityItem::DIRTY_POSITION | EntityItem::DIRTY_VELOCITY)) {
+                motionState->resetMeasuredVelocityAndAcceleration();
+            }
         } else {
             // the only way we should ever get here (motionState exists but no body) is when the object
             // is undergoing non-physical kinematic motion.
@@ -508,6 +511,7 @@ void PhysicsEngine::addObject(const ShapeInfo& shapeInfo, btCollisionShape* shap
     body->setFriction(motionState->_friction);
     body->setDamping(motionState->_linearDamping, motionState->_angularDamping);
     _dynamicsWorld->addRigidBody(body);
+    motionState->resetMeasuredVelocityAndAcceleration();
 }
 
 void PhysicsEngine::removeObjectFromBullet(ObjectMotionState* motionState) {

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -68,8 +68,9 @@ public:
 
     void stepSimulation();
     void stepNonPhysicalKinematics(const quint64& now);
-
     void computeCollisionEvents();
+
+    void dumpStatsIfNecessary();
 
     /// \param offset position of simulation origin in domain-frame
     void setOriginOffset(const glm::vec3& offset) { _originOffset = offset; }


### PR DESCRIPTION
This is partial completion toward using the **effective acceleration** of the object for motion extrapolation on the server -- I'm only measuring the acceleration and am not yet using it.  I'm creating this PR early for Seth to look at and decide to pull into his own work, or merge, or whatever.

What's next is to use the measured acceleration to decide what to send to the server.  The trick is... we probably don't want to send the measured acceleration.  The pseudo code for what we want to do (first-pass) looks something like this:
[code]
if (measuredAcceleration == gravity for some time threshold) {
    accelerationToSend = gravity;
} else {
    accelerationToSend = <0,0,0>;
}
[/code]
The reason for this is that high-resolution acceleration measurements for tumbling objects tends to be very noisy... except when it is in ballistic motion.  None of the high-resolution measurements are the best acceleration to send.  For _some_ cases a smoothed acceleration might be helpful, but those cases almost always have relatively small effective accelerations and a zero acceleration turns out to be good approximation anyway.