### PR TITLE
Address missing rendering pieplines for translucent and simplify Model rendering code

### DIFF
--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -1705,7 +1705,12 @@ FBXGeometry extractFBXGeometry(const FBXNode& node, const QVariantHash& mapping,
                     material._material->setDiffuse(material.diffuse); 
                     material._material->setSpecular(material.specular); 
                     material._material->setShininess(material.shininess); 
-                    material._material->setOpacity(material.opacity); 
+
+                    if (material.opacity <= 0.0f) {
+                        material._material->setOpacity(1.0f); 
+                    } else {
+                        material._material->setOpacity(material.opacity); 
+                    }
 
                     materials.insert(material.id, material);
 

--- a/libraries/render-utils/CMakeLists.txt
+++ b/libraries/render-utils/CMakeLists.txt
@@ -12,4 +12,16 @@ add_dependency_external_projects(glm)
 find_package(GLM REQUIRED)
 target_include_directories(${TARGET_NAME} PUBLIC ${GLM_INCLUDE_DIRS})
 
+if (WIN32)
+  if (USE_NSIGHT)
+    # try to find the Nsight package and add it to the build if we find it
+    find_package(NSIGHT)
+    if (NSIGHT_FOUND)
+      include_directories(${NSIGHT_INCLUDE_DIRS})
+      add_definitions(-DNSIGHT_FOUND)
+      target_link_libraries(${TARGET_NAME} "${NSIGHT_LIBRARIES}")
+    endif ()
+  endif()
+endif (WIN32)
+
 link_hifi_libraries(animation fbx shared gpu)

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -244,13 +244,6 @@ void Model::initJointTransforms() {
 
 void Model::init() {
     if (_renderPipelineLib.empty()) {
-        gpu::Shader::BindingSet slotBindings;
-        slotBindings.insert(gpu::Shader::Binding(std::string("materialBuffer"), MATERIAL_GPU_SLOT));
-        slotBindings.insert(gpu::Shader::Binding(std::string("diffuseMap"), 0));
-        slotBindings.insert(gpu::Shader::Binding(std::string("normalMap"), 1));
-        slotBindings.insert(gpu::Shader::Binding(std::string("specularMap"), 2));
-        slotBindings.insert(gpu::Shader::Binding(std::string("emissiveMap"), 3));
-
         // Vertex shaders
         auto modelVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(model_vert)));
         auto modelNormalMapVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(model_normal_map_vert)));
@@ -291,10 +284,24 @@ void Model::init() {
             RenderKey(RenderKey::HAS_TANGENTS | RenderKey::HAS_SPECULAR),
             modelNormalMapVertex, modelNormalSpecularMapPixel);
 
+
         _renderPipelineLib.addRenderPipeline(
             RenderKey(RenderKey::IS_TRANSLUCENT),
             modelVertex, modelTranslucentPixel);
  
+        _renderPipelineLib.addRenderPipeline(
+            RenderKey(RenderKey::HAS_TANGENTS | RenderKey::IS_TRANSLUCENT),
+            modelNormalMapVertex, modelTranslucentPixel);
+
+        _renderPipelineLib.addRenderPipeline(
+            RenderKey(RenderKey::HAS_SPECULAR | RenderKey::IS_TRANSLUCENT),
+            modelVertex, modelTranslucentPixel);
+
+        _renderPipelineLib.addRenderPipeline(
+            RenderKey(RenderKey::HAS_TANGENTS | RenderKey::HAS_SPECULAR | RenderKey::IS_TRANSLUCENT),
+            modelNormalMapVertex, modelTranslucentPixel);
+
+
         _renderPipelineLib.addRenderPipeline(
             RenderKey(RenderKey::HAS_LIGHTMAP),
             modelLightmapVertex, modelLightmapPixel);
@@ -309,6 +316,7 @@ void Model::init() {
         _renderPipelineLib.addRenderPipeline(
             RenderKey(RenderKey::HAS_LIGHTMAP | RenderKey::HAS_TANGENTS | RenderKey::HAS_SPECULAR),
             modelLightmapNormalMapVertex, modelLightmapNormalSpecularMapPixel);
+
 
         _renderPipelineLib.addRenderPipeline(
             RenderKey(RenderKey::IS_SKINNED),
@@ -326,14 +334,28 @@ void Model::init() {
             RenderKey(RenderKey::IS_SKINNED | RenderKey::HAS_TANGENTS | RenderKey::HAS_SPECULAR),
             skinModelNormalMapVertex, modelNormalSpecularMapPixel);
 
+
         _renderPipelineLib.addRenderPipeline(
             RenderKey(RenderKey::IS_SKINNED | RenderKey::IS_TRANSLUCENT),
             skinModelVertex, modelTranslucentPixel);
+
+        _renderPipelineLib.addRenderPipeline(
+            RenderKey(RenderKey::IS_SKINNED | RenderKey::HAS_TANGENTS | RenderKey::IS_TRANSLUCENT),
+            skinModelNormalMapVertex, modelTranslucentPixel);
+
+        _renderPipelineLib.addRenderPipeline(
+            RenderKey(RenderKey::IS_SKINNED | RenderKey::HAS_SPECULAR | RenderKey::IS_TRANSLUCENT),
+            skinModelVertex, modelTranslucentPixel);
+
+        _renderPipelineLib.addRenderPipeline(
+            RenderKey(RenderKey::IS_SKINNED | RenderKey::HAS_TANGENTS | RenderKey::HAS_SPECULAR | RenderKey::IS_TRANSLUCENT),
+            skinModelNormalMapVertex, modelTranslucentPixel);
 
 
         _renderPipelineLib.addRenderPipeline(
             RenderKey(RenderKey::IS_DEPTH_ONLY | RenderKey::IS_SHADOW),
             modelShadowVertex, modelShadowPixel);
+
 
         _renderPipelineLib.addRenderPipeline(
             RenderKey(RenderKey::IS_SKINNED | RenderKey::IS_DEPTH_ONLY | RenderKey::IS_SHADOW),
@@ -1935,55 +1957,7 @@ bool Model::renderInScene(float alpha, RenderArgs* args) {
 }
 
 void Model::segregateMeshGroups() {
-    _meshesTranslucentTangents.clear();
-    _meshesTranslucent.clear();
-    _meshesTranslucentTangentsSpecular.clear();
-    _meshesTranslucentSpecular.clear();
-
-    _meshesTranslucentTangentsSkinned.clear();
-    _meshesTranslucentSkinned.clear();
-    _meshesTranslucentTangentsSpecularSkinned.clear();
-    _meshesTranslucentSpecularSkinned.clear();
-
-    _meshesOpaqueTangents.clear();
-    _meshesOpaque.clear();
-    _meshesOpaqueTangentsSpecular.clear();
-    _meshesOpaqueSpecular.clear();
-
-    _meshesOpaqueTangentsSkinned.clear();
-    _meshesOpaqueSkinned.clear();
-    _meshesOpaqueTangentsSpecularSkinned.clear();
-    _meshesOpaqueSpecularSkinned.clear();
-
-    _meshesOpaqueLightmapTangents.clear();
-    _meshesOpaqueLightmap.clear();
-    _meshesOpaqueLightmapTangentsSpecular.clear();
-    _meshesOpaqueLightmapSpecular.clear();
-
-    _unsortedMeshesTranslucentTangents.clear();
-    _unsortedMeshesTranslucent.clear();
-    _unsortedMeshesTranslucentTangentsSpecular.clear();
-    _unsortedMeshesTranslucentSpecular.clear();
-
-    _unsortedMeshesTranslucentTangentsSkinned.clear();
-    _unsortedMeshesTranslucentSkinned.clear();
-    _unsortedMeshesTranslucentTangentsSpecularSkinned.clear();
-    _unsortedMeshesTranslucentSpecularSkinned.clear();
-
-    _unsortedMeshesOpaqueTangents.clear();
-    _unsortedMeshesOpaque.clear();
-    _unsortedMeshesOpaqueTangentsSpecular.clear();
-    _unsortedMeshesOpaqueSpecular.clear();
-
-    _unsortedMeshesOpaqueTangentsSkinned.clear();
-    _unsortedMeshesOpaqueSkinned.clear();
-    _unsortedMeshesOpaqueTangentsSpecularSkinned.clear();
-    _unsortedMeshesOpaqueSpecularSkinned.clear();
-
-    _unsortedMeshesOpaqueLightmapTangents.clear();
-    _unsortedMeshesOpaqueLightmap.clear();
-    _unsortedMeshesOpaqueLightmapTangentsSpecular.clear();
-    _unsortedMeshesOpaqueLightmapSpecular.clear();
+    _renderBuckets.clear();
 
     const FBXGeometry& geometry = _geometry->getFBXGeometry();
     const QVector<NetworkMesh>& networkMeshes = _geometry->getMeshes();
@@ -2017,200 +1991,18 @@ void Model::segregateMeshGroups() {
             qCDebug(renderutils) << "materialID:" << materialID << "parts:" << mesh.parts.size();
         }
 
-        if (!hasLightmap) {
-            if (translucentMesh && !hasTangents && !hasSpecular && !isSkinned) {
+        RenderKey key(translucentMesh, hasLightmap, hasTangents, hasSpecular, isSkinned);
 
-                _unsortedMeshesTranslucent.insertMulti(materialID, i);
-
-            } else if (translucentMesh && hasTangents && !hasSpecular && !isSkinned) {
-
-                _unsortedMeshesTranslucentTangents.insertMulti(materialID, i);
-
-            } else if (translucentMesh && hasTangents && hasSpecular && !isSkinned) {
-
-                _unsortedMeshesTranslucentTangentsSpecular.insertMulti(materialID, i);
-
-            } else if (translucentMesh && !hasTangents && hasSpecular && !isSkinned) {
-
-                _unsortedMeshesTranslucentSpecular.insertMulti(materialID, i);
-
-            } else if (translucentMesh && hasTangents && !hasSpecular && isSkinned) {
-
-                _unsortedMeshesTranslucentTangentsSkinned.insertMulti(materialID, i);
-
-            } else if (translucentMesh && !hasTangents && !hasSpecular && isSkinned) {
-
-                _unsortedMeshesTranslucentSkinned.insertMulti(materialID, i);
-
-            } else if (translucentMesh && hasTangents && hasSpecular && isSkinned) {
-
-                _unsortedMeshesTranslucentTangentsSpecularSkinned.insertMulti(materialID, i);
-
-            } else if (translucentMesh && !hasTangents && hasSpecular && isSkinned) {
-
-                _unsortedMeshesTranslucentSpecularSkinned.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && !hasTangents && !hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaque.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && hasTangents && !hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaqueTangents.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && hasTangents && hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaqueTangentsSpecular.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && !hasTangents && hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaqueSpecular.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && hasTangents && !hasSpecular && isSkinned) {
-
-                _unsortedMeshesOpaqueTangentsSkinned.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && !hasTangents && !hasSpecular && isSkinned) {
-
-                _unsortedMeshesOpaqueSkinned.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && hasTangents && hasSpecular && isSkinned) {
-
-                _unsortedMeshesOpaqueTangentsSpecularSkinned.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && !hasTangents && hasSpecular && isSkinned) {
-
-                _unsortedMeshesOpaqueSpecularSkinned.insertMulti(materialID, i);
-            } else {
-                qCDebug(renderutils) << "unexpected!!! this mesh didn't fall into any or our groups???";
-            }
-        } else {
-            if (!translucentMesh && !hasTangents && !hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaqueLightmap.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && hasTangents && !hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaqueLightmapTangents.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && hasTangents && hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaqueLightmapTangentsSpecular.insertMulti(materialID, i);
-
-            } else if (!translucentMesh && !hasTangents && hasSpecular && !isSkinned) {
-
-                _unsortedMeshesOpaqueLightmapSpecular.insertMulti(materialID, i);
-
-            } else {
-                qCDebug(renderutils) << "unexpected!!! this mesh didn't fall into any or our groups???";
-            }
-        }
+        // reuse or create the bucket corresponding to that key and insert the mesh as unsorted
+        _renderBuckets[key.getRaw()]._unsortedMeshes.insertMulti(materialID, i);
     }
     
-    foreach(int i, _unsortedMeshesTranslucent) {
-        _meshesTranslucent.append(i);
+    for(auto& b : _renderBuckets) {
+        foreach(auto i, b.second._unsortedMeshes) {
+            b.second._meshes.append(i);
+            b.second._unsortedMeshes.clear();
+        }
     }
-
-    foreach(int i, _unsortedMeshesTranslucentTangents) {
-        _meshesTranslucentTangents.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesTranslucentTangentsSpecular) {
-        _meshesTranslucentTangentsSpecular.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesTranslucentSpecular) {
-        _meshesTranslucentSpecular.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesTranslucentSkinned) {
-        _meshesTranslucentSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesTranslucentTangentsSkinned) {
-        _meshesTranslucentTangentsSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesTranslucentTangentsSpecularSkinned) {
-        _meshesTranslucentTangentsSpecularSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesTranslucentSpecularSkinned) {
-        _meshesTranslucentSpecularSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaque) {
-        _meshesOpaque.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueTangents) {
-        _meshesOpaqueTangents.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueTangentsSpecular) {
-        _meshesOpaqueTangentsSpecular.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueSpecular) {
-        _meshesOpaqueSpecular.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueSkinned) {
-        _meshesOpaqueSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueTangentsSkinned) {
-        _meshesOpaqueTangentsSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueTangentsSpecularSkinned) {
-        _meshesOpaqueTangentsSpecularSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueSpecularSkinned) {
-        _meshesOpaqueSpecularSkinned.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueLightmap) {
-        _meshesOpaqueLightmap.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueLightmapTangents) {
-        _meshesOpaqueLightmapTangents.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueLightmapTangentsSpecular) {
-        _meshesOpaqueLightmapTangentsSpecular.append(i);
-    }
-
-    foreach(int i, _unsortedMeshesOpaqueLightmapSpecular) {
-        _meshesOpaqueLightmapSpecular.append(i);
-    }
-
-    _unsortedMeshesTranslucentTangents.clear();
-    _unsortedMeshesTranslucent.clear();
-    _unsortedMeshesTranslucentTangentsSpecular.clear();
-    _unsortedMeshesTranslucentSpecular.clear();
-
-    _unsortedMeshesTranslucentTangentsSkinned.clear();
-    _unsortedMeshesTranslucentSkinned.clear();
-    _unsortedMeshesTranslucentTangentsSpecularSkinned.clear();
-    _unsortedMeshesTranslucentSpecularSkinned.clear();
-
-    _unsortedMeshesOpaqueTangents.clear();
-    _unsortedMeshesOpaque.clear();
-    _unsortedMeshesOpaqueTangentsSpecular.clear();
-    _unsortedMeshesOpaqueSpecular.clear();
-
-    _unsortedMeshesOpaqueTangentsSkinned.clear();
-    _unsortedMeshesOpaqueSkinned.clear();
-    _unsortedMeshesOpaqueTangentsSpecularSkinned.clear();
-    _unsortedMeshesOpaqueSpecularSkinned.clear();
-
-    _unsortedMeshesOpaqueLightmapTangents.clear();
-    _unsortedMeshesOpaqueLightmap.clear();
-    _unsortedMeshesOpaqueLightmapTangentsSpecular.clear();
-    _unsortedMeshesOpaqueLightmapSpecular.clear();
 
     _meshGroupsKnown = true;
 }
@@ -2220,52 +2012,14 @@ QVector<int>* Model::pickMeshList(bool translucent, float alphaThreshold, bool h
 
     // depending on which parameters we were called with, pick the correct mesh group to render
     QVector<int>* whichList = NULL;
-    if (translucent && !hasTangents && !hasSpecular && !isSkinned) {
-        whichList = &_meshesTranslucent;
-    } else if (translucent && hasTangents && !hasSpecular && !isSkinned) {
-        whichList = &_meshesTranslucentTangents;
-    } else if (translucent && hasTangents && hasSpecular && !isSkinned) {
-        whichList = &_meshesTranslucentTangentsSpecular;
-    } else if (translucent && !hasTangents && hasSpecular && !isSkinned) {
-        whichList = &_meshesTranslucentSpecular;
-    } else if (translucent && hasTangents && !hasSpecular && isSkinned) {
-        whichList = &_meshesTranslucentTangentsSkinned;
-    } else if (translucent && !hasTangents && !hasSpecular && isSkinned) {
-        whichList = &_meshesTranslucentSkinned;
-    } else if (translucent && hasTangents && hasSpecular && isSkinned) {
-        whichList = &_meshesTranslucentTangentsSpecularSkinned;
-    } else if (translucent && !hasTangents && hasSpecular && isSkinned) {
-        whichList = &_meshesTranslucentSpecularSkinned;
 
-    } else if (!translucent && !hasLightmap && !hasTangents && !hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaque;
-    } else if (!translucent && !hasLightmap && hasTangents && !hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaqueTangents;
-    } else if (!translucent && !hasLightmap && hasTangents && hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaqueTangentsSpecular;
-    } else if (!translucent && !hasLightmap && !hasTangents && hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaqueSpecular;
-    } else if (!translucent && !hasLightmap && hasTangents && !hasSpecular && isSkinned) {
-        whichList = &_meshesOpaqueTangentsSkinned;
-    } else if (!translucent && !hasLightmap && !hasTangents && !hasSpecular && isSkinned) {
-        whichList = &_meshesOpaqueSkinned;
-    } else if (!translucent && !hasLightmap && hasTangents && hasSpecular && isSkinned) {
-        whichList = &_meshesOpaqueTangentsSpecularSkinned;
-    } else if (!translucent && !hasLightmap && !hasTangents && hasSpecular && isSkinned) {
-        whichList = &_meshesOpaqueSpecularSkinned;
+    RenderKey key(translucent, hasLightmap, hasTangents, hasSpecular, isSkinned);
 
-    } else if (!translucent && hasLightmap && !hasTangents && !hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaqueLightmap;
-    } else if (!translucent && hasLightmap && hasTangents && !hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaqueLightmapTangents;
-    } else if (!translucent && hasLightmap && hasTangents && hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaqueLightmapTangentsSpecular;
-    } else if (!translucent && hasLightmap && !hasTangents && hasSpecular && !isSkinned) {
-        whichList = &_meshesOpaqueLightmapSpecular;
-
-    } else {
-        qCDebug(renderutils) << "unexpected!!! this mesh didn't fall into any or our groups???";
+    auto bucket = _renderBuckets.find(key.getRaw());
+    if (bucket != _renderBuckets.end()) {
+        whichList = &(*bucket).second._meshes;
     }
+
     return whichList;
 }
 
@@ -2277,6 +2031,7 @@ void Model::pickPrograms(gpu::Batch& batch, RenderMode mode, bool translucent, f
     auto pipeline = _renderPipelineLib.find(key.getRaw());
     if (pipeline == _renderPipelineLib.end()) {
         qDebug() << "No good, couldn't find a pipeline from the key ?" << key.getRaw();
+        locations = 0;
         return;
     }
 
@@ -2303,7 +2058,7 @@ int Model::renderMeshesForModelsInScene(gpu::Batch& batch, RenderMode mode, bool
     int meshPartsRendered = 0;
 
     bool pickProgramsNeeded = true;
-    Locations* locations;
+    Locations* locations = nullptr;
     
     foreach(Model* model, _modelsInScene) {
         QVector<int>* whichList = model->pickMeshList(translucent, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned);
@@ -2331,20 +2086,19 @@ int Model::renderMeshes(gpu::Batch& batch, RenderMode mode, bool translucent, fl
     PROFILE_RANGE(__FUNCTION__);
     int meshPartsRendered = 0;
 
-    QVector<int>* whichList = pickMeshList(translucent, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned);
-    
+    //Pick the mesh list with the requested render flags
+    QVector<int>* whichList = pickMeshList(translucent, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned);    
     if (!whichList) {
-        qCDebug(renderutils) << "unexpected!!! we don't know which list of meshes to render...";
         return 0;
     }
     QVector<int>& list = *whichList;
 
     // If this list has nothing to render, then don't bother proceeding. This saves us on binding to programs    
-    if (list.size() == 0) {
+    if (list.empty()) {
         return 0;
     }
 
-    Locations* locations;
+    Locations* locations = nullptr;
     pickPrograms(batch, mode, translucent, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned, 
                                 args, locations);
     meshPartsRendered = renderMeshesFromList(list, batch, mode, translucent, alphaThreshold, 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -496,9 +496,6 @@ private:
     class RenderBucketMap : public BaseRenderBucketMap {
     public:
         typedef RenderKey Key;
-
-        
-        void addRenderBucket(Key key, RenderBucket& bucket);
     };
     RenderBucketMap _renderBuckets;
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -350,58 +350,6 @@ private:
 
     bool _meshGroupsKnown;
 
-    QMap<QString, int> _unsortedMeshesTranslucent;
-    QMap<QString, int> _unsortedMeshesTranslucentTangents;
-    QMap<QString, int> _unsortedMeshesTranslucentTangentsSpecular;
-    QMap<QString, int> _unsortedMeshesTranslucentSpecular;
-
-    QMap<QString, int> _unsortedMeshesTranslucentSkinned;
-    QMap<QString, int> _unsortedMeshesTranslucentTangentsSkinned;
-    QMap<QString, int> _unsortedMeshesTranslucentTangentsSpecularSkinned;
-    QMap<QString, int> _unsortedMeshesTranslucentSpecularSkinned;
-
-    QMap<QString, int> _unsortedMeshesOpaque;
-    QMap<QString, int> _unsortedMeshesOpaqueTangents;
-    QMap<QString, int> _unsortedMeshesOpaqueTangentsSpecular;
-    QMap<QString, int> _unsortedMeshesOpaqueSpecular;
-
-    QMap<QString, int> _unsortedMeshesOpaqueSkinned;
-    QMap<QString, int> _unsortedMeshesOpaqueTangentsSkinned;
-    QMap<QString, int> _unsortedMeshesOpaqueTangentsSpecularSkinned;
-    QMap<QString, int> _unsortedMeshesOpaqueSpecularSkinned;
-
-    QMap<QString, int> _unsortedMeshesOpaqueLightmap;
-    QMap<QString, int> _unsortedMeshesOpaqueLightmapTangents;
-    QMap<QString, int> _unsortedMeshesOpaqueLightmapTangentsSpecular;
-    QMap<QString, int> _unsortedMeshesOpaqueLightmapSpecular;
-    
-    typedef std::unordered_map<int, QVector<int>> MeshListMap;
-    MeshListMap _sortedMeshes;
-
-    QVector<int> _meshesTranslucent;
-    QVector<int> _meshesTranslucentTangents;
-    QVector<int> _meshesTranslucentTangentsSpecular;
-    QVector<int> _meshesTranslucentSpecular;
-
-    QVector<int> _meshesTranslucentSkinned;
-    QVector<int> _meshesTranslucentTangentsSkinned;
-    QVector<int> _meshesTranslucentTangentsSpecularSkinned;
-    QVector<int> _meshesTranslucentSpecularSkinned;
-
-    QVector<int> _meshesOpaque;
-    QVector<int> _meshesOpaqueTangents;
-    QVector<int> _meshesOpaqueTangentsSpecular;
-    QVector<int> _meshesOpaqueSpecular;
-
-    QVector<int> _meshesOpaqueSkinned;
-    QVector<int> _meshesOpaqueTangentsSkinned;
-    QVector<int> _meshesOpaqueTangentsSpecularSkinned;
-    QVector<int> _meshesOpaqueSpecularSkinned;
-
-    QVector<int> _meshesOpaqueLightmap;
-    QVector<int> _meshesOpaqueLightmapTangents;
-    QVector<int> _meshesOpaqueLightmapTangentsSpecular;
-    QVector<int> _meshesOpaqueLightmapSpecular;
 
     // debug rendering support
     void renderDebugMeshBoxes();
@@ -490,6 +438,17 @@ private:
 
         int getRaw() { return *reinterpret_cast<int*>(this); }
 
+
+        RenderKey(
+            bool translucent, bool hasLightmap,
+            bool hasTangents, bool hasSpecular, bool isSkinned) :
+            RenderKey(  (translucent ? IS_TRANSLUCENT : 0)
+                      | (hasLightmap ? HAS_LIGHTMAP : 0)
+                      | (hasTangents ? HAS_TANGENTS : 0)
+                      | (hasSpecular ? HAS_SPECULAR : 0)
+                      | (isSkinned ? IS_SKINNED : 0)
+                     ) {}
+
         RenderKey(RenderArgs::RenderMode mode,
             bool translucent, float alphaThreshold, bool hasLightmap,
             bool hasTangents, bool hasSpecular, bool isSkinned) :
@@ -526,6 +485,22 @@ private:
         void initLocations(gpu::ShaderPointer& program, Locations& locations);
     };
     static RenderPipelineLib _renderPipelineLib;
+
+   
+    class RenderBucket {
+    public:
+        QVector<int> _meshes;
+        QMap<QString, int> _unsortedMeshes;
+    };
+    typedef std::unordered_map<int, RenderBucket> BaseRenderBucketMap;
+    class RenderBucketMap : public BaseRenderBucketMap {
+    public:
+        typedef RenderKey Key;
+
+        
+        void addRenderBucket(Key key, RenderBucket& bucket);
+    };
+    RenderBucketMap _renderBuckets;
 
     bool _renderCollisionHull;
 };


### PR DESCRIPTION
- If FBX material has a 0 opacity, force it to 1 since 0 means invisible, we 'll assume that's not what's expected, we could argue that 0 Opacity means that would should still see the specular/reflection. Let's consider that when transparent works correctly...
- Replace all the explicit lists of bucketing in Model by a HashMap using the REnderKey also used for the RenderPIpeline.
- Add Nsight support to Render-Utils
- Add missing RenderPIpeline for Translucent and normals/specular/skinned enven thrugh we don;t have a good rendering path for it yet