### PR TITLE
Fix a couple of bugs with the new offscreen UI

### DIFF
--- a/interface/src/GLCanvas.cpp
+++ b/interface/src/GLCanvas.cpp
@@ -115,6 +115,7 @@ void GLCanvas::throttleRender() {
             OculusManager::beginFrameTiming();
         }
 
+        makeCurrent();
         Application::getInstance()->paintGL();
         swapBuffers();
 

--- a/libraries/render-utils/src/OffscreenUi.cpp
+++ b/libraries/render-utils/src/OffscreenUi.cpp
@@ -298,8 +298,11 @@ bool OffscreenUi::eventFilter(QObject* originalDestination, QEvent* event) {
                     mapWindowToUi(wheelEvent->pos(), originalDestination),
                     wheelEvent->delta(),  wheelEvent->buttons(),
                     wheelEvent->modifiers(), wheelEvent->orientation());
-            QCoreApplication::sendEvent(_quickWindow, &mappedEvent);
-            return true;
+            mappedEvent.ignore();
+            if (QCoreApplication::sendEvent(_quickWindow, &mappedEvent)) {
+                return mappedEvent.isAccepted();
+            }
+            break;
         }
 
         // Fall through
@@ -314,8 +317,11 @@ bool OffscreenUi::eventFilter(QObject* originalDestination, QEvent* event) {
                     mapWindowToUi(transformedPos, originalDestination),
                     mouseEvent->screenPos(), mouseEvent->button(),
                     mouseEvent->buttons(), mouseEvent->modifiers());
-            QCoreApplication::sendEvent(_quickWindow, &mappedEvent);
-            return QObject::event(event);
+            mappedEvent.ignore();
+            if (QCoreApplication::sendEvent(_quickWindow, &mappedEvent)) {
+                return mappedEvent.isAccepted();
+            }
+            break;
         }
 
         default:


### PR DESCRIPTION
This modifies the behavior of the event filter on the offscreen UI.  Previously all mouse wheel events ended up filtered, while all other mouse events ended up being passed through (regardless of whether they had been consumed by the offscreen UI).  

This changes both mechanisms to work similar to the keyboard interception code, where we send an event to the offscreen UI and then check whether it was consumed to determine our return value.  

Quick testing shows that this resolves the problem with clicks on dialogs over the mirror causing the fullscreen mirror to open.  It should also fix the mouse wheel issues that have been reported, but I'm unable to test this.