### PR TITLE
fix bug in parsing root element data

### DIFF
--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -380,9 +380,9 @@ int Octree::readElementData(OctreeElement* destinationElement, const unsigned ch
     }
     
     // if this is the root, and there is more data to read, allow it to read it's element data...
-    if (destinationElement == _rootElement  && rootElementHasData() && (bytesLeftToRead - bytesRead) > 0) {
+    if (destinationElement == _rootElement  && rootElementHasData() && bytesLeftToRead > 0) {
         // tell the element to read the subsequent data
-        int rootDataSize = _rootElement->readElementDataFromBuffer(nodeData + bytesRead, bytesLeftToRead - bytesRead, args);
+        int rootDataSize = _rootElement->readElementDataFromBuffer(nodeData + bytesRead, bytesLeftToRead, args);
         bytesRead += rootDataSize;
         bytesLeftToRead -= rootDataSize;
     }


### PR DESCRIPTION
This fixes a bug we were seeing "domain sized zones".... basically there was a logic bug in determining if the current buffer had enough data in it to include root element data. The bug was that bytesLeftToRead had already been adjusted to account for the previous bytesRead so we were double "counting" those bytes in this use case. This resulted in us dropping/ignoring root element data in many cases.