### PR TITLE
Removing debug hack to load resources from source folder

### DIFF
--- a/libraries/shared/src/PathUtils.cpp
+++ b/libraries/shared/src/PathUtils.cpp
@@ -19,19 +19,10 @@
 
 
 QString& PathUtils::resourcesPath() {
-#ifdef DEBUG
-    static QString staticResourcePath;
-    if (staticResourcePath.isEmpty()) {
-        QDir path(__FILE__);
-        path.cdUp();
-        staticResourcePath = path.cleanPath(path.absoluteFilePath("../../../interface/resources/")) + "/";
-    }
-#else
 #ifdef Q_OS_MAC
     static QString staticResourcePath = QCoreApplication::applicationDirPath() + "/../Resources/";
 #else
     static QString staticResourcePath = QCoreApplication::applicationDirPath() + "/resources/";
-#endif
 #endif
 
     return staticResourcePath;


### PR DESCRIPTION
Sam reported a problem building / loading shaders, and I suspect this change I made is the cause as the shaders come from the render library, not from interface.  reverting to old behavior.  