### PR TITLE
force reconnection after successful login

### DIFF
--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -58,6 +58,9 @@ NodeList::NodeList(char newOwnerType, unsigned short socketListenPort, unsigned 
     
     // handle ICE signal from DS so connection is attempted immediately
     connect(&_domainHandler, &DomainHandler::requestICEConnectionAttempt, this, &NodeList::handleICEConnectionToDomainServer);
+
+    // clear out NodeList when login is finished
+    connect(&AccountManager::getInstance(), &AccountManager::loginComplete , this, &NodeList::reset);
     
     // clear our NodeList when logout is requested
     connect(&AccountManager::getInstance(), &AccountManager::logoutComplete , this, &NodeList::reset);


### PR DESCRIPTION
https://app.asana.com/0/26485730907942/28039823100807/f

If you are:
* connected to a domain which does not require authentication but does have an editors list
* not authenticated

and then you authenticate as someone on that editors list, you don't receive the ability to edit.  This PR forces a reconnection after a login in order to force the update of your node's permissions flags.
