### PR TITLE
Attempting to resolve possible crash case for scripts playing sounds

### DIFF
--- a/libraries/script-engine/src/ScriptAudioInjector.cpp
+++ b/libraries/script-engine/src/ScriptAudioInjector.cpp
@@ -13,8 +13,12 @@
 #include "ScriptAudioInjector.h"
 
 QScriptValue injectorToScriptValue(QScriptEngine* engine, ScriptAudioInjector* const& in) {
+    // The AudioScriptingInterface::playSound method can return null, so we need to account for that.
+    if (!in) {
+        return QScriptValue(QScriptValue::NullValue);
+    }
+
     // when the script goes down we want to cleanup the injector
-    
     QObject::connect(engine, &QScriptEngine::destroyed, in, &ScriptAudioInjector::stopInjectorImmediately,
                      Qt::DirectConnection);
     


### PR DESCRIPTION
Looking at https://app.asana.com/0/26225263936266/30137470162432 I discovered that `AudioScriptingInterface::playSound` can return null, so we need to guard against attempting to connect a signal to a slot on a null pointer.

