### PR TITLE
assignment-client shouldn't try to save contents of its nonexistent address bar

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -465,6 +465,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
     addressManager->setOrientationGetter(getOrientationForPath);
     
     connect(addressManager.data(), &AddressManager::rootPlaceNameChanged, this, &Application::updateWindowTitle);
+    connect(this, &QCoreApplication::aboutToQuit, addressManager.data(), &AddressManager::storeCurrentAddress);
 
     #ifdef _WIN32
     WSADATA WsaData;

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -35,7 +35,6 @@ AddressManager::AddressManager() :
     _positionGetter(NULL),
     _orientationGetter(NULL)
 {
-    connect(qApp, &QCoreApplication::aboutToQuit, this, &AddressManager::storeCurrentAddress);
 }
 
 bool AddressManager::isConnected() {


### PR DESCRIPTION
This may be the root cause of assignment-clients failing to exit cleanly.

https://app.asana.com/0/26485730907942/32638756267756/f
