### PR TITLE
Fix entities rendering wrong when avatar scale !== 1.0

### DIFF
--- a/interface/src/Camera.cpp
+++ b/interface/src/Camera.cpp
@@ -55,7 +55,6 @@ Camera::Camera() :
     _farClip(DEFAULT_FAR_CLIP), // default
     _hmdPosition(),
     _hmdRotation(),
-    _scale(1.0f),
     _isKeepLookingAt(false),
     _lookingAt(0.0f, 0.0f, 0.0f)
 {
@@ -94,8 +93,8 @@ void Camera::setHmdRotation(const glm::quat& hmdRotation) {
 }
 
 float Camera::getFarClip() const {
-    return (_scale * _farClip < std::numeric_limits<int16_t>::max())
-            ? _scale * _farClip
+    return (_farClip < std::numeric_limits<int16_t>::max())
+            ? _farClip
             : std::numeric_limits<int16_t>::max() - 1;
 }
 

--- a/interface/src/Camera.h
+++ b/interface/src/Camera.h
@@ -54,7 +54,6 @@ public:
     void setFarClip(float f);
     void setEyeOffsetPosition(const glm::vec3& p) { _eyeOffsetPosition = p; }
     void setEyeOffsetOrientation(const glm::quat& o) { _eyeOffsetOrientation = o; }
-    void setScale(const float s) { _scale = s; }
     
     glm::quat getRotation() const { return _rotation * _hmdRotation; }
     const glm::vec3& getHmdPosition() const { return _hmdPosition; }
@@ -63,11 +62,10 @@ public:
     CameraMode getMode() const { return _mode; }
     float getFieldOfView() const { return _fieldOfView; }
     float getAspectRatio() const { return _aspectRatio; }
-    float getNearClip() const { return _scale * _nearClip; }
+    float getNearClip() const { return _nearClip; }
     float getFarClip() const;
     const glm::vec3& getEyeOffsetPosition() const { return _eyeOffsetPosition;   }
     const glm::quat& getEyeOffsetOrientation() const { return _eyeOffsetOrientation; }
-    float getScale() const { return _scale; }
 public slots:
     QString getModeString() const;
     void setModeString(const QString& mode);
@@ -107,7 +105,6 @@ private:
     glm::quat _rotation;
     glm::vec3 _hmdPosition;
     glm::quat _hmdRotation;
-    float _scale;
     bool _isKeepLookingAt;
     glm::vec3 _lookingAt;
 };

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -166,7 +166,7 @@ void MyAvatar::simulate(float deltaTime) {
     if (_scale != _targetScale) {
         float scale = (1.0f - SMOOTHING_RATIO) * _scale + SMOOTHING_RATIO * _targetScale;
         setScale(scale);
-        Application::getInstance()->getCamera()->setScale(scale);
+        //Application::getInstance()->getCamera()->setScale(scale);
     }
 
     {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -672,8 +672,6 @@ void MyAvatar::loadData() {
     _leanScale = loadSetting(settings, "leanScale", 0.05f);
     _targetScale = loadSetting(settings, "scale", 1.0f);
     setScale(_scale);
-    Application::getInstance()->getCamera()->setScale(_scale);
-
 
     // The old preferences only stored the face and skeleton URLs, we didn't track if the user wanted to use 1 or 2 urls 
     // for their avatar, So we need to attempt to detect this old case and set our new preferences accordingly. If

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -166,7 +166,6 @@ void MyAvatar::simulate(float deltaTime) {
     if (_scale != _targetScale) {
         float scale = (1.0f - SMOOTHING_RATIO) * _scale + SMOOTHING_RATIO * _targetScale;
         setScale(scale);
-        //Application::getInstance()->getCamera()->setScale(scale);
     }
 
     {


### PR DESCRIPTION
When the avatar's scale was set, it would also set the Camera object scale. From what I can tell the only thing that did was change the nearClip/farClip of the camera... but that was side effecting how primitive objects rendered. 