### PR TITLE
Menu polish

### DIFF
--- a/interface/resources/qml/TestMenu.qml
+++ b/interface/resources/qml/TestMenu.qml
@@ -108,6 +108,10 @@ Item {
             MenuItem { action: animations }
         }
         Menu {
+            title: "Long menu name top menu"
+            MenuItem { action: aboutApp }
+        }
+        Menu {
             title: "Help"
             MenuItem { action: aboutApp }
         }

--- a/interface/resources/qml/VrMenu.qml
+++ b/interface/resources/qml/VrMenu.qml
@@ -121,6 +121,9 @@ Hifi.VrMenu {
             property var root
             property var listView
             property var border
+
+
+
             implicitHeight: row.implicitHeight + 4
             implicitWidth: row.implicitWidth + label.height 
             // FIXME uncommenting this line results in menus that have blank spots
@@ -137,8 +140,7 @@ Hifi.VrMenu {
                 FontAwesome {
                     id: check
                     verticalAlignment: Text.AlignVCenter
-                    y: 2
-                    size: label.height
+                    size: row.height
                     text: checkText()
                     color: label.color
                     function checkText() {
@@ -156,7 +158,10 @@ Hifi.VrMenu {
                 }
                 Text {
                   id: label
+//                  anchors.top: parent.top
+//                  anchors.bottom: parent.bottom
                   text: typedText()
+                  verticalAlignment: Text.AlignVCenter
                   color: source.enabled ? hifi.colors.text : hifi.colors.disabledText
                   enabled: source.enabled && source.visible
                   function typedText() {
@@ -189,13 +194,11 @@ Hifi.VrMenu {
            }
             
            MouseArea {
-               anchors {
-                   top: parent.top
-                   bottom: parent.bottom
-                   left: parent.left
-                   right: tag.right
-                   rightMargin: -4
-               }
+               anchors.top: parent.top
+               anchors.bottom: parent.bottom
+               anchors.right: tag.right
+               anchors.left: parent.left
+               anchors.rightMargin: -4
                acceptedButtons: Qt.LeftButton
                hoverEnabled: true
                Rectangle {

--- a/interface/resources/qml/VrMenu.qml
+++ b/interface/resources/qml/VrMenu.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls.Styles 1.3
 import "controls"
 import "styles"
 
+
 Hifi.VrMenu {
     id: root
     HifiConstants { id: hifi }
@@ -12,15 +13,14 @@ Hifi.VrMenu {
     anchors.fill: parent
 
     objectName: "VrMenu"
-
     enabled: false
     opacity: 0.0
+    z: 10000
 
     property int animationDuration: 200
     property var models: []
     property var columns: []
 
-    z: 10000
 
     onEnabledChanged: {
         if (enabled && columns.length == 0) {
@@ -51,20 +51,22 @@ Hifi.VrMenu {
     property var menuBuilder: Component {
         Border {
             HifiConstants { id: hifi }
+            property int menuDepth
+
             Component.onCompleted: {
                 menuDepth = root.models.length - 1
                 if (menuDepth == 0) {
                     x = lastMousePosition.x - 20
                     y = lastMousePosition.y - 20
                 } else {
-                    var lastColumn = root.columns[menuDepth - 1] 
+                    var lastColumn = root.columns[menuDepth - 1]
                     x = lastColumn.x + 64;
                     y = lastMousePosition.y - height / 2;
                 }
             }
+
             border.color: hifi.colors.hifiBlue
             color: hifi.colors.window
-            property int menuDepth
             implicitHeight: listView.implicitHeight + 16
             implicitWidth: listView.implicitWidth + 16
 
@@ -84,169 +86,26 @@ Hifi.VrMenu {
                     model: root.models[menuDepth]
                     delegate: Loader {
                         id: loader
-                        sourceComponent: root.itemBuilder
+                        source: "VrMenuItem.qml"
                         Binding {
                             target: loader.item
-                            property: "root"
+                            property: "menuContainer"
                             value: root
                             when: loader.status == Loader.Ready
-                        }        
+                        }
                         Binding {
                             target: loader.item
                             property: "source"
                             value: modelData
                             when: loader.status == Loader.Ready
-                        } 
-                        Binding {
-                            target: loader.item
-                            property: "border"
-                            value: listView.parent
-                            when: loader.status == Loader.Ready
-                        }        
+                        }
                         Binding {
                             target: loader.item
                             property: "listView"
                             value: listView
                             when: loader.status == Loader.Ready
-                        }        
-                    }
-                }
-            }
-        }
-    }
-
-    property var itemBuilder: Component {
-        Item {
-            property var source
-            property var root
-            property var listView
-            property var border
-
-
-
-            implicitHeight: row.implicitHeight + 4
-            implicitWidth: row.implicitWidth + label.height 
-            // FIXME uncommenting this line results in menus that have blank spots
-            // rather than having the correct size
-            // visible: source.visible
-            Row {
-                id: row
-                spacing: 2
-                anchors {
-                    top: parent.top
-                    topMargin: 2
-                }
-                Spacer { size: 4 }
-                FontAwesome {
-                    id: check
-                    verticalAlignment: Text.AlignVCenter
-                    size: row.height
-                    text: checkText()
-                    color: label.color
-                    function checkText() {
-                        if (!source || source.type != 1 || !source.checkable) {
-                            return "";
                         }
-
-                        // FIXME this works for native QML menus but I don't think it will
-                        // for proxied QML menus
-                        if (source.exclusiveGroup) {
-                            return source.checked ? "\uF05D" : "\uF10C"
-                        }
-                        return source.checked ? "\uF046" : "\uF096"
                     }
-                }
-                Text {
-                  id: label
-//                  anchors.top: parent.top
-//                  anchors.bottom: parent.bottom
-                  text: typedText()
-                  verticalAlignment: Text.AlignVCenter
-                  color: source.enabled ? hifi.colors.text : hifi.colors.disabledText
-                  enabled: source.enabled && source.visible
-                  function typedText() {
-                      if (source) {
-                          switch(source.type) {
-                          case 2:
-                              return source.title;
-                          case 1: 
-                              return source.text;
-                          case 0:
-                              return "-----"
-                          }
-                      }
-                      return ""
-                  }
-              }
-           } // row
-
-           FontAwesome {
-               anchors {
-                   top: row.top
-               }
-               id: tag
-               size: label.height
-               width: implicitWidth
-               visible: source.type == 2
-               x: listView.width - width - 4
-               text: "\uF0DA"
-               color: label.color
-           }
-            
-           MouseArea {
-               anchors.top: parent.top
-               anchors.bottom: parent.bottom
-               anchors.right: tag.right
-               anchors.left: parent.left
-               anchors.rightMargin: -4
-               acceptedButtons: Qt.LeftButton
-               hoverEnabled: true
-               Rectangle {
-                   id: highlight
-                   visible: false
-                   anchors.fill: parent 
-                   color: "#7f0e7077"
-               }
-               Timer {
-                   id: timer
-                   interval: 1000
-                   onTriggered: parent.select();
-               }
-               onEntered: {
-                   /*  
-                    * Uncomment below to have menus auto-popup
-                    * 
-                    * FIXME if we enabled timer based menu popup, either the timer has 
-                    * to be very very short or after auto popup there has to be a small 
-                    * amount of time, or a test if the mouse has moved before a click 
-                    * will be accepted, otherwise it's too easy to accidently click on
-                    * something immediately after the auto-popup appears underneath your 
-                    * cursor
-                    *
-                    */
-                   //if (source.type == 2 && enabled) {
-                   //    timer.start()
-                   //}
-                   highlight.visible = source.enabled
-               }
-               onExited: {
-                   timer.stop()
-                   highlight.visible = false
-               }
-               onClicked: {
-                   select();
-               }
-               function select() {
-                   //timer.stop();
-                   var popped = false;
-                   while (columns.length - 1 > listView.parent.menuDepth) {
-                       popColumn();
-                       popped = true;
-                   }
-
-                   if (!popped || source.type != 1) {
-                       parent.root.selectItem(parent.source);
-                   }
                 }
             }
         }
@@ -262,7 +121,7 @@ Hifi.VrMenu {
             var oldColumn = lastColumn();
             //oldColumn.enabled = false
         }
-        var newColumn = menuBuilder.createObject(root); 
+        var newColumn = menuBuilder.createObject(root);
         columns.push(newColumn);
         newColumn.forceActiveFocus();
     }
@@ -295,11 +154,11 @@ Hifi.VrMenu {
             source.trigger()
             enabled = false
             break;
-        case 0: 
+        case 0:
             break;
         }
     }
-    
+
     function reset() {
         while (columns.length > 0) {
             popColumn();

--- a/interface/resources/qml/VrMenuItem.qml
+++ b/interface/resources/qml/VrMenuItem.qml
@@ -1,0 +1,130 @@
+import QtQuick 2.4
+import QtQuick.Controls 1.3
+import QtQuick.Controls.Styles 1.3
+import "controls"
+import "styles"
+
+Item {
+    id: root
+    HifiConstants {
+        id: hifi
+    }
+
+    property var source
+    property var menuContainer
+    property var listView
+
+    MouseArea {
+        anchors.left: parent.left
+        anchors.right: tag.right
+        anchors.rightMargin: -4
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        acceptedButtons: Qt.LeftButton
+        hoverEnabled: true
+
+        Rectangle {
+            id: highlight
+            visible: false
+            anchors.fill: parent
+            color: "#7f0e7077"
+        }
+
+        onEntered: {
+            //if (source.type == 2 && enabled) {
+            //    timer.start()
+            //}
+            highlight.visible = source.enabled
+        }
+
+        onExited: {
+            timer.stop()
+            highlight.visible = false
+        }
+
+        onClicked: {
+            select()
+        }
+   }
+
+    implicitHeight: label.implicitHeight + 4
+    implicitWidth: label.implicitWidth + label.height * 2
+
+    Timer {
+        id: timer
+        interval: 1000
+        onTriggered: parent.select()
+    }
+
+
+    FontAwesome {
+        clip: true
+        id: check
+        verticalAlignment:  Text.AlignBottom
+        horizontalAlignment: Text.AlignHCenter
+        anchors.verticalCenter: parent.verticalCenter
+        color: label.color
+        text: checkText()
+        size: label.height
+        font.pixelSize: size - 4
+        function checkText() {
+            if (!source || source.type != 1 || !source.checkable) {
+                return ""
+            }
+            // FIXME this works for native QML menus but I don't think it will
+            // for proxied QML menus
+            if (source.exclusiveGroup) {
+                return source.checked ? "\uF05D" : "\uF10C"
+            }
+            return source.checked ? "\uF046" : "\uF096"
+        }
+    }
+
+    Text {
+        id: label
+        text: typedText()
+        anchors.left: check.right
+        anchors.leftMargin: 4
+        anchors.verticalCenter: parent.verticalCenter
+        verticalAlignment: Text.AlignVCenter
+        color: source.enabled ? hifi.colors.text : hifi.colors.disabledText
+        enabled: source.enabled && source.visible
+        function typedText() {
+            if (source) {
+                switch (source.type) {
+                case 2:
+                    return source.title
+                case 1:
+                    return source.text
+                case 0:
+                    return "-----"
+                }
+            }
+            return ""
+        }
+    }
+
+    FontAwesome {
+        id: tag
+        x: listView.width - width - 4
+        size: label.height
+        width: implicitWidth
+        visible: source.type == 2
+        text: "\uF0DA"
+        anchors.verticalCenter: parent.verticalCenter
+        color: label.color
+    }
+
+    function select() {
+        //timer.stop();
+        var popped = false
+        while (columns.length - 1 > listView.parent.menuDepth) {
+            popColumn()
+            popped = true
+        }
+
+        if (!popped || source.type != 1) {
+            root.menuContainer.selectItem(source)
+        }
+    }
+}

--- a/interface/resources/qml/VrMenuItem.qml
+++ b/interface/resources/qml/VrMenuItem.qml
@@ -47,8 +47,8 @@ Item {
         }
    }
 
-    implicitHeight: label.implicitHeight + 4
-    implicitWidth: label.implicitWidth + label.height * 2
+    implicitHeight: label.implicitHeight * 1.5
+    implicitWidth: label.implicitWidth + label.height * 2.5
 
     Timer {
         id: timer
@@ -60,13 +60,13 @@ Item {
     FontAwesome {
         clip: true
         id: check
-        verticalAlignment:  Text.AlignBottom
+        verticalAlignment:  Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
         anchors.verticalCenter: parent.verticalCenter
         color: label.color
         text: checkText()
         size: label.height
-        font.pixelSize: size - 4
+        font.pixelSize: size
         function checkText() {
             if (!source || source.type != 1 || !source.checkable) {
                 return ""

--- a/interface/src/devices/OculusManager.cpp
+++ b/interface/src/devices/OculusManager.cpp
@@ -795,7 +795,6 @@ void OculusManager::getEulerAngles(float& yaw, float& pitch, float& roll) {
 glm::vec3 OculusManager::getRelativePosition() {
     ovrTrackingState trackingState = ovrHmd_GetTrackingState(_ovrHmd, ovr_GetTimeInSeconds());
     ovrVector3f headPosition = trackingState.HeadPose.ThePose.Position;
-    
     return glm::vec3(headPosition.x, headPosition.y, headPosition.z);
 }
 

--- a/tests/ui/src/main.cpp
+++ b/tests/ui/src/main.cpp
@@ -36,6 +36,7 @@
 
 #include "MessageDialog.h"
 #include "VrMenu.h"
+#include <QDesktopWidget>
 
 class RateCounter {
     std::vector<float> times;
@@ -339,8 +340,10 @@ public:
         makeCurrent();
 
         offscreenUi->setProxyWindow(this);
-        setFramePosition(QPoint(-1000, 0));
-        resize(QSize(800, 600));
+        QDesktopWidget* desktop = QApplication::desktop();
+        setGeometry(desktop->availableGeometry(desktop->screenCount()-1));
+//        setFramePosition(QPoint(-1000, 0));
+//        resize(QSize(800, 600));
 
 #ifdef QML_CONTROL_GALLERY
         offscreenUi->setBaseUrl(QUrl::fromLocalFile(getTestQmlDir()));
@@ -474,16 +477,8 @@ hifi.offscreen.focus.debug=false
 qt.quick.mouse.debug=false
 )V0G0N";
 
-//int main(int argc, char *argv[]) {
-//    QGuiApplication app(argc, argv);
-//    QQmlApplicationEngine engine;
-//    engine.setBaseUrl(QUrl::fromLocalFile(getQmlDir()));
-//    engine.load(QUrl("Main.qml"));
-//    return app.exec();
-//}
-
 int main(int argc, char** argv) {    
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
     QLoggingCategory::setFilterRules(LOG_FILTER_RULES);
     QTestWindow window;
     app.exec();

--- a/tests/ui/src/main.cpp
+++ b/tests/ui/src/main.cpp
@@ -341,7 +341,11 @@ public:
 
         offscreenUi->setProxyWindow(this);
         QDesktopWidget* desktop = QApplication::desktop();
-        setGeometry(desktop->availableGeometry(desktop->screenCount()-1));
+        QRect rect = desktop->availableGeometry(desktop->screenCount() - 1);
+        int height = rect.height();
+        //rect.setHeight(height / 2);
+        rect.setY(rect.y() + height / 2);
+        setGeometry(rect);
 //        setFramePosition(QPoint(-1000, 0));
 //        resize(QSize(800, 600));
 


### PR DESCRIPTION
The OSX and Win32 looks of the menu didn't quite match.  I want them to both look polished and good, so I had to go through several iterations of trying to make changes on one system and then moving it over to see how it looks.  This PR should provide a reasonably nice looking menu with the checkboxes and text well placed in the highlight rectangle on both platforms.  