### PR TITLE
Update edit.js to buffer mouseMove events

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -592,7 +592,11 @@ var idleMouseTimerId = null;
 var IDLE_MOUSE_TIMEOUT = 200;
 var DEFAULT_ENTITY_DRAG_DROP_DISTANCE = 2.0;
 
-function mouseMoveEvent(event) {
+var lastMouseMoveEvent = null;
+function mouseMoveEventBuffered(event) {
+    lastMouseMoveEvent = event;
+}
+function mouseMove(event) {
     mouseHasMovedSincePress = true;
 
     if (placingEntityID) {
@@ -661,6 +665,10 @@ function highlightEntityUnderCursor(position, accurateRay) {
 
 
 function mouseReleaseEvent(event) {
+    if (lastMouseMoveEvent) {
+        mouseMove(lastMouseMoveEvent);
+        lastMouseMoveEvent = null;
+    }
     if (propertyMenu.mouseReleaseEvent(event) || toolBar.mouseReleaseEvent(event)) {
         return true;
     }
@@ -772,7 +780,7 @@ function mouseClickEvent(event) {
 }
 
 Controller.mousePressEvent.connect(mousePressEvent);
-Controller.mouseMoveEvent.connect(mouseMoveEvent);
+Controller.mouseMoveEvent.connect(mouseMoveEventBuffered);
 Controller.mouseReleaseEvent.connect(mouseReleaseEvent);
 
 
@@ -881,6 +889,10 @@ Script.update.connect(function (deltaTime) {
         propertyMenu.hide();
         lastOrientation = Camera.orientation;
         lastPosition = Camera.position;
+    }
+    if (lastMouseMoveEvent) {
+        mouseMove(lastMouseMoveEvent);
+        lastMouseMoveEvent = null;
     }
 });
 


### PR DESCRIPTION
This helps keep events from getting backed up on the event queue by
handling move events in the update() loop and dropping extra move events
that might come before an update.