### PR TITLE
Json skip default values

### DIFF
--- a/interface/resources/qml/controls/Dialog.qml
+++ b/interface/resources/qml/controls/Dialog.qml
@@ -66,7 +66,7 @@ DialogBase {
 
     // our close function performs the same way as the OffscreenUI class:
     // don't do anything but manipulate the enabled flag and let the other 
-    // mechanisms decide if the window should be destoryed after the close
+    // mechanisms decide if the window should be destroyed after the close
     // animation completes
     function close() {
         if (destroyOnCloseButton) {

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -159,7 +159,7 @@ public:
     EntityTypes::EntityType getType() const { return _type; }
     void setType(EntityTypes::EntityType type) { _type = type; }
 
-    virtual QScriptValue copyToScriptValue(QScriptEngine* engine) const;
+    virtual QScriptValue copyToScriptValue(QScriptEngine* engine, bool skipDefaults) const;
     virtual void copyFromScriptValue(const QScriptValue& object);
 
     // editing related features supported by all entities
@@ -307,6 +307,7 @@ private:
 };
 Q_DECLARE_METATYPE(EntityItemProperties);
 QScriptValue EntityItemPropertiesToScriptValue(QScriptEngine* engine, const EntityItemProperties& properties);
+QScriptValue EntityItemNonDefaultPropertiesToScriptValue(QScriptEngine* engine, const EntityItemProperties& properties);
 void EntityItemPropertiesFromScriptValue(const QScriptValue &object, EntityItemProperties& properties);
 
 

--- a/libraries/entities/src/EntityItemPropertiesMacros.h
+++ b/libraries/entities/src/EntityItemPropertiesMacros.h
@@ -198,26 +198,41 @@
 
 
 #define COPY_PROPERTY_TO_QSCRIPTVALUE_VEC3(P) \
-    QScriptValue P = vec3toScriptValue(engine, _##P); \
-    properties.setProperty(#P, P);
+    if (!skipDefaults || defaultEntityProperties._##P != _##P) { \
+        QScriptValue P = vec3toScriptValue(engine, _##P); \
+        properties.setProperty(#P, P); \
+    }
 
 #define COPY_PROPERTY_TO_QSCRIPTVALUE_QUAT(P) \
-    QScriptValue P = quatToScriptValue(engine, _##P); \
-    properties.setProperty(#P, P);
+    if (!skipDefaults || defaultEntityProperties._##P != _##P) { \
+        QScriptValue P = quatToScriptValue(engine, _##P); \
+        properties.setProperty(#P, P); \
+    }
 
 #define COPY_PROPERTY_TO_QSCRIPTVALUE_COLOR(P) \
-    QScriptValue P = xColorToScriptValue(engine, _##P); \
-    properties.setProperty(#P, P);
+    if (!skipDefaults || defaultEntityProperties._##P != _##P) { \
+        QScriptValue P = xColorToScriptValue(engine, _##P); \
+        properties.setProperty(#P, P); \
+    }
 
 #define COPY_PROPERTY_TO_QSCRIPTVALUE_COLOR_GETTER(P,G) \
-    QScriptValue P = xColorToScriptValue(engine, G); \
-    properties.setProperty(#P, P);
+    if (!skipDefaults || defaultEntityProperties._##P != _##P) { \
+        QScriptValue P = xColorToScriptValue(engine, G); \
+        properties.setProperty(#P, P); \
+    }
 
-#define COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(P, G) \
+#define COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER_NO_SKIP(P, G) \
     properties.setProperty(#P, G);
 
+#define COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(P, G) \
+    if (!skipDefaults || defaultEntityProperties._##P != _##P) { \
+        properties.setProperty(#P, G); \
+    }
+
 #define COPY_PROPERTY_TO_QSCRIPTVALUE(P) \
-    properties.setProperty(#P, _##P);
+    if (!skipDefaults || defaultEntityProperties._##P != _##P) { \
+        properties.setProperty(#P, _##P); \
+    }
 
 #define COPY_PROPERTY_FROM_QSCRIPTVALUE_FLOAT(P, S) \
     QScriptValue P = object.property(#P);           \

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1137,10 +1137,10 @@ bool EntityTree::sendEntitiesOperation(OctreeElement* element, void* extraData) 
     return true;
 }
 
-bool EntityTree::writeToMap(QVariantMap& entityDescription, OctreeElement* element) {
+bool EntityTree::writeToMap(QVariantMap& entityDescription, OctreeElement* element, bool skipDefaultValues) {
     entityDescription["Entities"] = QVariantList();
     QScriptEngine scriptEngine;
-    RecurseOctreeToMapOperator theOperator(entityDescription, element, &scriptEngine);
+    RecurseOctreeToMapOperator theOperator(entityDescription, element, &scriptEngine, skipDefaultValues);
     recurseTreeWithOperator(&theOperator);
     return true;
 }

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -163,7 +163,7 @@ public:
     bool wantEditLogging() const { return _wantEditLogging; }
     void setWantEditLogging(bool value) { _wantEditLogging = value; }
 
-    bool writeToMap(QVariantMap& entityDescription, OctreeElement* element);
+    bool writeToMap(QVariantMap& entityDescription, OctreeElement* element, bool skipDefaultValues);
     bool readFromMap(QVariantMap& entityDescription);
 
 signals:

--- a/libraries/entities/src/RecurseOctreeToMapOperator.h
+++ b/libraries/entities/src/RecurseOctreeToMapOperator.h
@@ -13,7 +13,7 @@
 
 class RecurseOctreeToMapOperator : public RecurseOctreeOperator {
 public:
-    RecurseOctreeToMapOperator(QVariantMap& map, OctreeElement *top, QScriptEngine *engine);
+    RecurseOctreeToMapOperator(QVariantMap& map, OctreeElement *top, QScriptEngine *engine, bool skipDefaultValues);
     bool preRecursion(OctreeElement* element);
     bool postRecursion(OctreeElement* element);
  private:
@@ -21,4 +21,5 @@ public:
     OctreeElement *_top;
     QScriptEngine *_engine;
     bool _withinTop;
+    bool _skipDefaultValues;
 };

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -203,6 +203,16 @@ public:
     glm::quat rotation; // relative orientation
 };
 
+inline bool operator==(const SittingPoint& lhs, const SittingPoint& rhs)
+{
+    return (lhs.name == rhs.name) && (lhs.position == rhs.position) && (lhs.rotation == rhs.rotation);
+}
+
+inline bool operator!=(const SittingPoint& lhs, const SittingPoint& rhs)
+{
+    return (lhs.name != rhs.name) || (lhs.position != rhs.position) || (lhs.rotation != rhs.rotation);
+}
+
 /// A set of meshes extracted from an FBX document.
 class FBXGeometry {
 public:

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -2087,7 +2087,7 @@ void Octree::writeToJSONFile(const char* fileName, OctreeElement* element) {
     QFile persistFile(fileName);
     QVariantMap entityDescription;
 
-    qCDebug(octree, "Saving to file %s...", fileName);
+    qCDebug(octree, "Saving JSON SVO to file %s...", fileName);
 
     OctreeElement* top;
     if (element) {
@@ -2096,7 +2096,7 @@ void Octree::writeToJSONFile(const char* fileName, OctreeElement* element) {
         top = _rootElement;
     }
 
-    bool entityDescriptionSuccess = writeToMap(entityDescription, top);
+    bool entityDescriptionSuccess = writeToMap(entityDescription, top, true);
     if (entityDescriptionSuccess && persistFile.open(QIODevice::WriteOnly)) {
         persistFile.write(QJsonDocument::fromVariant(entityDescription).toJson());
     } else {
@@ -2108,7 +2108,7 @@ void Octree::writeToSVOFile(const char* fileName, OctreeElement* element) {
     std::ofstream file(fileName, std::ios::out|std::ios::binary);
 
     if(file.is_open()) {
-        qCDebug(octree, "Saving to file %s...", fileName);
+        qCDebug(octree, "Saving binary SVO to file %s...", fileName);
 
         PacketType expectedType = expectedDataPacketType();
         PacketVersion expectedVersion = versionForPacketType(expectedType);

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -331,7 +331,7 @@ public:
     void writeToFile(const char* filename, OctreeElement* element = NULL, QString persistAsFileType = "svo");
     void writeToJSONFile(const char* filename, OctreeElement* element = NULL);
     void writeToSVOFile(const char* filename, OctreeElement* element = NULL);
-    virtual bool writeToMap(QVariantMap& entityDescription, OctreeElement* element) = 0;
+    virtual bool writeToMap(QVariantMap& entityDescription, OctreeElement* element, bool skipDefaultValues) = 0;
 
     // Octree importers
     bool readFromFile(const char* filename);

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -43,6 +43,17 @@ inline QDebug& operator<<(QDebug& dbg, const xColor& c) {
     return dbg;
 }
 
+inline bool operator==(const xColor& lhs, const xColor& rhs)
+{
+    return (lhs.red == rhs.red) && (lhs.green == rhs.green) && (lhs.blue == rhs.blue);
+}
+
+inline bool operator!=(const xColor& lhs, const xColor& rhs)
+{
+    return (lhs.red != rhs.red) || (lhs.green != rhs.green) || (lhs.blue != rhs.blue);
+}
+
+
 static const float ZERO             = 0.0f;
 static const float ONE              = 1.0f;
 static const float ONE_HALF			= 0.5f;


### PR DESCRIPTION
When writing json files, don't include entity-item properties which aren't changed from their default values.  Also skip fields which aren't settable.