### PR TITLE
Remove camera wobble caused by having a face tracker enabled

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -819,13 +819,18 @@ void Application::paintGL() {
     glEnable(GL_LINE_SMOOTH);
 
     if (_myCamera.getMode() == CAMERA_MODE_FIRST_PERSON) {
+        // Always use the default eye position, not the actual head eye position.
+        // Using the latter will cause the camera to wobble with idle animations,
+        // or with changes from the face tracker
+        _myCamera.setPosition(_myAvatar->getDefaultEyePosition());
         if (!OculusManager::isConnected()) {
-            //  If there isn't an HMD, match exactly to avatar's head
-            _myCamera.setPosition(_myAvatar->getHead()->getEyePosition());
+            // If not using an HMD, grab the camera orientation directly
             _myCamera.setRotation(_myAvatar->getHead()->getCameraOrientation());
         } else {
-            //  For an HMD, set the base position and orientation to that of the avatar body
-            _myCamera.setPosition(_myAvatar->getDefaultEyePosition());
+            // In an HMD, people can look up and down with their actual neck, and the
+            // per-eye HMD pose will be applied later.  So set the camera orientation
+            // to only the yaw, excluding pitch and roll, i.e. an orientation that
+            // is orthongonal to the (body's) Y axis
             _myCamera.setRotation(_myAvatar->getWorldAlignedOrientation());
         }
 


### PR DESCRIPTION
The face tracker directly impacts the positional data of the avatar's head.  However, this causes the view of the scene to move in unpleasant ways.  This PR removes this, and also removes the slight wobble in positioning caused by the idle animations.

One possible alternative to removing this effect would be to fix the apparent view change, by translating the projection matrix in the opposite direction from the eye, causing the view of the scene to appear to be visible through a kind of 'window' represented by the monitor.  However, to do this well would probably require exposing lots of preferences and getting the user to input their actual distance to the camera, and would never be awesome.  