### PR TITLE
fix crash in UserInputMapper::update() for invalid DeviceProxy

### DIFF
--- a/interface/src/ui/UserInputMapper.cpp
+++ b/interface/src/ui/UserInputMapper.cpp
@@ -90,7 +90,7 @@ void UserInputMapper::update(float deltaTime) {
             bool isActiveModifier = false;
             for (auto& modifier : modifiersIt->second) {
                 auto deviceProxy = getDeviceProxy(modifier);
-                if (deviceProxy->getButton(modifier, currentTimestamp)) {
+                if (deviceProxy && deviceProxy->getButton(modifier, currentTimestamp)) {
                     validModifiers.push_back(modifier);
                     isActiveModifier |= (modifier.getID() == inputMapping._modifier.getID());
                 }
@@ -99,8 +99,8 @@ void UserInputMapper::update(float deltaTime) {
         }
 
         // if enabled: default input or all modifiers on
-        if (enabled) {
-            auto deviceProxy = getDeviceProxy(inputID);
+        auto deviceProxy = getDeviceProxy(inputID);
+        if (enabled && deviceProxy) {
             switch (inputMapping._input.getType()) {
                 case ChannelType::BUTTON: {
                     _actionStates[channelInput.first] += inputMapping._scale * float(deviceProxy->getButton(inputID, currentTimestamp));// * deltaTime; // weight the impulse by the deltaTime

--- a/interface/src/ui/UserInputMapper.cpp
+++ b/interface/src/ui/UserInputMapper.cpp
@@ -90,7 +90,7 @@ void UserInputMapper::update(float deltaTime) {
             bool isActiveModifier = false;
             for (auto& modifier : modifiersIt->second) {
                 auto deviceProxy = getDeviceProxy(modifier);
-                if (deviceProxy && deviceProxy->getButton(modifier, currentTimestamp)) {
+                if (deviceProxy->getButton(modifier, currentTimestamp)) {
                     validModifiers.push_back(modifier);
                     isActiveModifier |= (modifier.getID() == inputMapping._modifier.getID());
                 }
@@ -99,8 +99,8 @@ void UserInputMapper::update(float deltaTime) {
         }
 
         // if enabled: default input or all modifiers on
-        auto deviceProxy = getDeviceProxy(inputID);
-        if (enabled && deviceProxy) {
+        if (enabled) {
+            auto deviceProxy = getDeviceProxy(inputID);
             switch (inputMapping._input.getType()) {
                 case ChannelType::BUTTON: {
                     _actionStates[channelInput.first] += inputMapping._scale * float(deviceProxy->getButton(inputID, currentTimestamp));// * deltaTime; // weight the impulse by the deltaTime

--- a/interface/src/ui/UserInputMapper.h
+++ b/interface/src/ui/UserInputMapper.h
@@ -57,7 +57,9 @@ public:
         bool isAxis() const { return getType() == ChannelType::AXIS; }
         bool isJoint() const { return getType() == ChannelType::JOINT; }
 
-        explicit Input() {}
+        // WORKAROUND: the explicit initializer here avoids a bug in GCC-4.8.2 (but not found in 4.9.2)
+        // where the default initializer (a C++-11ism) for the union data above is not applied.
+        explicit Input() : _id(0) {}
         explicit Input(uint32 id) : _id(id) {}
         explicit Input(uint16 device, uint16 channel, ChannelType type) : _device(device), _channel(channel), _type(uint16(type)) {}
         Input(const Input& src) : _id(src._id) {}


### PR DESCRIPTION
After a recent pull from upstream/master my Interface started crashing.  Looking into it I found that I had an invalid **DeviceProxy** inside **UserInputMapper::update()** but the validity of the pointer was not being checked.  The fix in this PR works for me but I'm not 100% sure the failure behavior is correct -- should we do something more when **DeviceProxy** is invalid?