### PR TITLE
change skyboxMode to backgroundMode

### DIFF
--- a/examples/example/entities/changingAtmosphereExample.js
+++ b/examples/example/entities/changingAtmosphereExample.js
@@ -23,7 +23,7 @@ var zoneEntityA = Entities.addEntity({
     keyLightColor: { red: 255, green: 0, blue: 0 },
     stageSunModelEnabled: false,
     shapeType: "sphere",
-    skyboxMode: "atmosphere",
+    backgroundMode: "atmosphere",
     atmosphere: {
         center: { x: 1000, y: 0, z: 1000}, 
         innerRadius: 1000.0,

--- a/examples/example/entities/zoneAtmosphereExample.js
+++ b/examples/example/entities/zoneAtmosphereExample.js
@@ -23,7 +23,7 @@ var zoneEntityA = Entities.addEntity({
     keyLightColor: { red: 255, green: 0, blue: 0 },
     stageSunModelEnabled: false,
     shapeType: "sphere",
-    skyboxMode: "atmosphere",
+    backgroundMode: "atmosphere",
     atmosphere: {
         center: { x: 1000, y: 0, z: 1000}, 
         innerRadius: 1000.0,

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -428,7 +428,7 @@ void EntityTreeRenderer::render(RenderArgs::RenderMode renderMode,
             scene->setStageDayTime(_bestZone->getStageHour());
             scene->setStageYearTime(_bestZone->getStageDay());
 
-            if (_bestZone->getSkyboxMode() == SKYBOX_MODE_ATMOSPHERE) {
+            if (_bestZone->getBackgroundMode() == BACKGROUND_MODE_ATMOSPHERE) {
                 EnvironmentData data = _bestZone->getEnvironmentData();
                 glm::vec3 keyLightDirection = scene->getKeyLightDirection();
                 glm::vec3 inverseKeyLightDirection = keyLightDirection * -1.0f;

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -89,7 +89,7 @@ EntityItemProperties::EntityItemProperties() :
     CONSTRUCT_PROPERTY(stageDay, ZoneEntityItem::DEFAULT_STAGE_DAY),
     CONSTRUCT_PROPERTY(stageHour, ZoneEntityItem::DEFAULT_STAGE_HOUR),
     CONSTRUCT_PROPERTY(name, ENTITY_ITEM_DEFAULT_NAME),
-    CONSTRUCT_PROPERTY(skyboxMode, SKYBOX_MODE_INHERIT),
+    CONSTRUCT_PROPERTY(backgroundMode, BACKGROUND_MODE_INHERIT),
 
     _id(UNKNOWN_ENTITY_ID),
     _idSet(false),
@@ -237,40 +237,40 @@ void EntityItemProperties::setShapeTypeFromString(const QString& shapeName) {
     }
 }
 
-const char* skyboxModeNames[] = {"inherit", "atmosphere", "texture" };
+const char* backgroundModeNames[] = {"inherit", "atmosphere", "texture" };
 
-QHash<QString, SkyboxMode> stringToSkyboxModeLookup;
+QHash<QString, BackgroundMode> stringToBackgroundModeLookup;
 
-void addSkyboxMode(SkyboxMode type) {
-    stringToSkyboxModeLookup[skyboxModeNames[type]] = type;
+void addBackgroundMode(BackgroundMode type) {
+    stringToBackgroundModeLookup[backgroundModeNames[type]] = type;
 }
 
-void buildStringToSkyboxModeLookup() {
-    addSkyboxMode(SKYBOX_MODE_INHERIT);
-    addSkyboxMode(SKYBOX_MODE_ATMOSPHERE);
-    addSkyboxMode(SKYBOX_MODE_TEXTURE);
+void buildStringToBackgroundModeLookup() {
+    addBackgroundMode(BACKGROUND_MODE_INHERIT);
+    addBackgroundMode(BACKGROUND_MODE_ATMOSPHERE);
+    addBackgroundMode(BACKGROUND_MODE_TEXTURE);
 }
 
-QString EntityItemProperties::getSkyboxModeAsString() const {
-    if (_skyboxMode < sizeof(skyboxModeNames) / sizeof(char *))
-        return QString(skyboxModeNames[_skyboxMode]);
-    return QString(skyboxModeNames[SKYBOX_MODE_INHERIT]);
+QString EntityItemProperties::getBackgroundModeAsString() const {
+    if (_backgroundMode < sizeof(backgroundModeNames) / sizeof(char *))
+        return QString(backgroundModeNames[_backgroundMode]);
+    return QString(backgroundModeNames[BACKGROUND_MODE_INHERIT]);
 }
 
-QString EntityItemProperties::getSkyboxModeString(SkyboxMode mode) {
-    if (mode < sizeof(skyboxModeNames) / sizeof(char *))
-        return QString(skyboxModeNames[mode]);
-    return QString(skyboxModeNames[SKYBOX_MODE_INHERIT]);
+QString EntityItemProperties::getBackgroundModeString(BackgroundMode mode) {
+    if (mode < sizeof(backgroundModeNames) / sizeof(char *))
+        return QString(backgroundModeNames[mode]);
+    return QString(backgroundModeNames[BACKGROUND_MODE_INHERIT]);
 }
 
-void EntityItemProperties::setSkyboxModeFromString(const QString& skyboxMode) {
-    if (stringToSkyboxModeLookup.empty()) {
-        buildStringToSkyboxModeLookup();
+void EntityItemProperties::setBackgroundModeFromString(const QString& backgroundMode) {
+    if (stringToBackgroundModeLookup.empty()) {
+        buildStringToBackgroundModeLookup();
     }
-    auto skyboxModeItr = stringToSkyboxModeLookup.find(skyboxMode.toLower());
-    if (skyboxModeItr != stringToSkyboxModeLookup.end()) {
-        _skyboxMode = skyboxModeItr.value();
-        _skyboxModeChanged = true;
+    auto backgroundModeItr = stringToBackgroundModeLookup.find(backgroundMode.toLower());
+    if (backgroundModeItr != stringToBackgroundModeLookup.end()) {
+        _backgroundMode = backgroundModeItr.value();
+        _backgroundModeChanged = true;
     }
 }
 
@@ -334,7 +334,7 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
     CHECK_PROPERTY_CHANGE(PROP_STAGE_DAY, stageDay);
     CHECK_PROPERTY_CHANGE(PROP_STAGE_HOUR, stageHour);
 
-    CHECK_PROPERTY_CHANGE(PROP_SKYBOX_MODE, skyboxMode);
+    CHECK_PROPERTY_CHANGE(PROP_BACKGROUND_MODE, backgroundMode);
     
     changedProperties += _atmosphere.getChangedProperties();
 
@@ -419,7 +419,7 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     COPY_PROPERTY_TO_QSCRIPTVALUE(stageAltitude);
     COPY_PROPERTY_TO_QSCRIPTVALUE(stageDay);
     COPY_PROPERTY_TO_QSCRIPTVALUE(stageHour);
-    COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(skyboxMode, getSkyboxModeAsString());
+    COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(backgroundMode, getBackgroundModeAsString());
 
     // Sitting properties support
     if (!skipDefaults) {
@@ -524,7 +524,7 @@ void EntityItemProperties::copyFromScriptValue(const QScriptValue& object) {
     COPY_PROPERTY_FROM_QSCRIPTVALUE_FLOAT(stageAltitude, setStageAltitude);
     COPY_PROPERTY_FROM_QSCRIPTVALUE_INT(stageDay, setStageDay);
     COPY_PROPERTY_FROM_QSCRIPTVALUE_FLOAT(stageHour, setStageHour);
-    COPY_PROPERTY_FROM_QSCRITPTVALUE_ENUM(skyboxMode, SkyboxMode);
+    COPY_PROPERTY_FROM_QSCRITPTVALUE_ENUM(backgroundMode, BackgroundMode);
     _atmosphere.copyFromScriptValue(object, _defaultSettings);
     _lastEdited = usecTimestampNow();
 }
@@ -731,7 +731,7 @@ bool EntityItemProperties::encodeEntityEditPacket(PacketType command, EntityItem
                 APPEND_ENTITY_PROPERTY(PROP_SHAPE_TYPE, appendValue, (uint32_t)properties.getShapeType());
                 APPEND_ENTITY_PROPERTY(PROP_COMPOUND_SHAPE_URL, appendValue, properties.getCompoundShapeURL());
 
-                APPEND_ENTITY_PROPERTY(PROP_SKYBOX_MODE, appendValue, (uint32_t)properties.getSkyboxMode());
+                APPEND_ENTITY_PROPERTY(PROP_BACKGROUND_MODE, appendValue, (uint32_t)properties.getBackgroundMode());
                 
                 _staticAtmosphere.setProperties(properties);
                 _staticAtmosphere.appentToEditPacket(packetData, requestedProperties, propertyFlags, propertiesDidntFit,  propertyCount, appendState );
@@ -984,7 +984,7 @@ bool EntityItemProperties::decodeEntityEditPacket(const unsigned char* data, int
         READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_STAGE_HOUR, float, setStageHour);
         READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_SHAPE_TYPE, ShapeType, setShapeType);
         READ_ENTITY_PROPERTY_STRING_TO_PROPERTIES(PROP_COMPOUND_SHAPE_URL, setCompoundShapeURL);
-        READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_SKYBOX_MODE, SkyboxMode, setSkyboxMode);
+        READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_BACKGROUND_MODE, BackgroundMode, setBackgroundMode);
         properties.getAtmosphere().decodeFromEditPacket(propertyFlags, dataAt , processedBytes);
     }
     
@@ -1088,7 +1088,7 @@ void EntityItemProperties::markAllChanged() {
     _stageDayChanged = true;
     _stageHourChanged = true;
     
-    _skyboxModeChanged = true;
+    _backgroundModeChanged = true;
     _atmosphere.markAllChanged();
    
 }

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -139,9 +139,9 @@ public:
     DEFINE_PROPERTY(PROP_STAGE_HOUR, StageHour, stageHour, float);
     DEFINE_PROPERTY_REF(PROP_NAME, Name, name, QString);
     DEFINE_PROPERTY_GROUP(Atmosphere, atmosphere, AtmospherePropertyGroup);
-    DEFINE_PROPERTY_REF_ENUM(PROP_SKYBOX_MODE, SkyboxMode, skyboxMode, SkyboxMode);
+    DEFINE_PROPERTY_REF_ENUM(PROP_BACKGROUND_MODE, BackgroundMode, backgroundMode, BackgroundMode);
 
-    static QString getSkyboxModeString(SkyboxMode mode);
+    static QString getBackgroundModeString(BackgroundMode mode);
 
 
 public:
@@ -276,7 +276,7 @@ inline QDebug operator<<(QDebug debug, const EntityItemProperties& properties) {
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, LocalGravity, localGravity, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, ParticleRadius, particleRadius, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, MarketplaceID, marketplaceID, "");
-    DEBUG_PROPERTY_IF_CHANGED(debug, properties, SkyboxMode, skyboxMode, "");
+    DEBUG_PROPERTY_IF_CHANGED(debug, properties, BackgroundMode, backgroundMode, "");
 
     debug << "  last edited:" << properties.getLastEdited() << "\n";
     debug << "  edited ago:" << properties.getEditedAgo() << "\n";

--- a/libraries/entities/src/EntityPropertyFlags.h
+++ b/libraries/entities/src/EntityPropertyFlags.h
@@ -143,9 +143,7 @@ enum EntityPropertyList {
     PROP_ATMOSPHERE_RAYLEIGH_SCATTERING = PROP_EMIT_STRENGTH,
     PROP_ATMOSPHERE_SCATTERING_WAVELENGTHS = PROP_LOCAL_GRAVITY,
     PROP_ATMOSPHERE_HAS_STARS = PROP_PARTICLE_RADIUS,
-    PROP_SKYBOX_MODE = PROP_MODEL_URL,
-    // SunBrightness - same as KeyLight Intensity?
-    // SunLocation (or direction) - same as KeyLight
+    PROP_BACKGROUND_MODE = PROP_MODEL_URL,
 
     // WARNING!!! DO NOT ADD PROPS_xxx here unless you really really meant to.... Add them UP above
 };
@@ -157,10 +155,10 @@ typedef PropertyFlags<EntityPropertyList> EntityPropertyFlags;
 extern EntityPropertyList PROP_LAST_ITEM;
 
 
-enum SkyboxMode {
-    SKYBOX_MODE_INHERIT,
-    SKYBOX_MODE_ATMOSPHERE,
-    SKYBOX_MODE_TEXTURE,
+enum BackgroundMode {
+    BACKGROUND_MODE_INHERIT,
+    BACKGROUND_MODE_ATMOSPHERE,
+    BACKGROUND_MODE_TEXTURE,
 };
 
 

--- a/libraries/entities/src/ZoneEntityItem.cpp
+++ b/libraries/entities/src/ZoneEntityItem.cpp
@@ -62,7 +62,7 @@ ZoneEntityItem::ZoneEntityItem(const EntityItemID& entityItemID, const EntityIte
     _shapeType = DEFAULT_SHAPE_TYPE;
     _compoundShapeURL = DEFAULT_COMPOUND_SHAPE_URL;
 
-    _skyboxMode = SKYBOX_MODE_INHERIT;
+    _backgroundMode = BACKGROUND_MODE_INHERIT;
     
     setProperties(properties);
 }
@@ -103,7 +103,7 @@ EntityItemProperties ZoneEntityItem::getProperties() const {
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(shapeType, getShapeType);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(compoundShapeURL, getCompoundShapeURL);
 
-    COPY_ENTITY_PROPERTY_TO_PROPERTIES(skyboxMode, getSkyboxMode);
+    COPY_ENTITY_PROPERTY_TO_PROPERTIES(backgroundMode, getBackgroundMode);
 
     _atmospherePropeties.getProperties(properties);
 
@@ -126,7 +126,7 @@ bool ZoneEntityItem::setProperties(const EntityItemProperties& properties) {
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(stageHour, setStageHour);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(shapeType, updateShapeType);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(compoundShapeURL, setCompoundShapeURL);
-    SET_ENTITY_PROPERTY_FROM_PROPERTIES(skyboxMode, setSkyboxMode);
+    SET_ENTITY_PROPERTY_FROM_PROPERTIES(backgroundMode, setBackgroundMode);
 
     bool somethingChangedInAtmosphere = _atmospherePropeties.setProperties(properties);
 
@@ -164,7 +164,7 @@ int ZoneEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, 
     READ_ENTITY_PROPERTY(PROP_STAGE_HOUR, float, _stageHour);
     READ_ENTITY_PROPERTY_SETTER(PROP_SHAPE_TYPE, ShapeType, updateShapeType);
     READ_ENTITY_PROPERTY_STRING(PROP_COMPOUND_SHAPE_URL, setCompoundShapeURL);
-    READ_ENTITY_PROPERTY_SETTER(PROP_SKYBOX_MODE, SkyboxMode, setSkyboxMode);
+    READ_ENTITY_PROPERTY_SETTER(PROP_BACKGROUND_MODE, BackgroundMode, setBackgroundMode);
     bytesRead += _atmospherePropeties.readEntitySubclassDataFromBuffer(dataAt, (bytesLeftToRead - bytesRead), args, 
                                                                            propertyFlags, overwriteLocalData);
 
@@ -188,7 +188,7 @@ EntityPropertyFlags ZoneEntityItem::getEntityProperties(EncodeBitstreamParams& p
     requestedProperties += PROP_STAGE_HOUR;
     requestedProperties += PROP_SHAPE_TYPE;
     requestedProperties += PROP_COMPOUND_SHAPE_URL;
-    requestedProperties += PROP_SKYBOX_MODE;
+    requestedProperties += PROP_BACKGROUND_MODE;
     requestedProperties += _atmospherePropeties.getEntityProperties(params);
     
     return requestedProperties;
@@ -216,7 +216,7 @@ void ZoneEntityItem::appendSubclassData(OctreePacketData* packetData, EncodeBits
     APPEND_ENTITY_PROPERTY(PROP_STAGE_HOUR, appendValue, getStageHour());
     APPEND_ENTITY_PROPERTY(PROP_SHAPE_TYPE, appendValue, (uint32_t)getShapeType());
     APPEND_ENTITY_PROPERTY(PROP_COMPOUND_SHAPE_URL, appendValue, getCompoundShapeURL());
-    APPEND_ENTITY_PROPERTY(PROP_SKYBOX_MODE, appendValue, (uint32_t)getSkyboxMode()); // could this be a uint16??
+    APPEND_ENTITY_PROPERTY(PROP_BACKGROUND_MODE, appendValue, (uint32_t)getBackgroundMode()); // could this be a uint16??
     
     _atmospherePropeties.appendSubclassData(packetData, params, modelTreeElementExtraEncodeData, requestedProperties,
                                     propertyFlags, propertiesDidntFit, propertyCount, appendState);
@@ -239,7 +239,7 @@ void ZoneEntityItem::debugDump() const {
     qCDebug(entities) << "            _stageAltitude:" << _stageAltitude;
     qCDebug(entities) << "                 _stageDay:" << _stageDay;
     qCDebug(entities) << "                _stageHour:" << _stageHour;
-    qCDebug(entities) << "               _skyboxMode:" << EntityItemProperties::getSkyboxModeString(_skyboxMode);
+    qCDebug(entities) << "               _backgroundMode:" << EntityItemProperties::getBackgroundModeString(_backgroundMode);
 
     _atmospherePropeties.debugDump();
 }

--- a/libraries/entities/src/ZoneEntityItem.h
+++ b/libraries/entities/src/ZoneEntityItem.h
@@ -106,8 +106,8 @@ public:
     const QString getCompoundShapeURL() const { return _compoundShapeURL; }
     virtual void setCompoundShapeURL(const QString& url);
 
-    void setSkyboxMode(SkyboxMode value) { _skyboxMode = value; }
-    SkyboxMode getSkyboxMode() const { return _skyboxMode; }
+    void setBackgroundMode(BackgroundMode value) { _backgroundMode = value; }
+    BackgroundMode getBackgroundMode() const { return _backgroundMode; }
 
     EnvironmentData getEnvironmentData() const;
 
@@ -147,7 +147,7 @@ protected:
     ShapeType _shapeType = SHAPE_TYPE_NONE;
     QString _compoundShapeURL;
     
-    SkyboxMode _skyboxMode = SKYBOX_MODE_INHERIT;
+    BackgroundMode _backgroundMode = BACKGROUND_MODE_INHERIT;
     AtmospherePropertyGroup _atmospherePropeties;
 
     static bool _drawZoneBoundaries;


### PR DESCRIPTION
this doesn't change the wire format, so we don't need to bump the packet version. But anyone who saved their entities as JSON will need to reset the properties of any zones which had atmosphere set. (I think this is likely nobody...)