### PR TITLE
CR for 20525 - Fix lobby not displaying in HMD mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3241,6 +3241,7 @@ void Application::displaySide(Camera& theCamera, bool selfAvatarOnly, RenderArgs
     {
         PerformanceTimer perfTimer("3dOverlaysFront");
         glClear(GL_DEPTH_BUFFER_BIT);
+        Glower glower;  // Sets alpha to 1.0
         _overlays.renderWorld(true);
     }
     activeRenderingThread = nullptr;


### PR DESCRIPTION
This usage of Glower is similar to that in renderAvatarBillboard(). Both may indicate that something needs changing in the graphics pipeline.

@ZappoMan , @samcake Is this a OK fix to include, at least for now, to solve the problem of the lobby not displaying in HMD mode?