### PR TITLE
Fix for HMDTools targeting wrong screen on OSX

### DIFF
--- a/interface/src/ui/HMDToolsDialog.cpp
+++ b/interface/src/ui/HMDToolsDialog.cpp
@@ -162,11 +162,16 @@ void HMDToolsDialog::enterHDMMode() {
             close();
         }
 
-        Application::getInstance()->setFullscreen(true);
         Application::getInstance()->setEnableVRMode(true);
     
         const int SLIGHT_DELAY = 500;
-        QTimer::singleShot(SLIGHT_DELAY, this, SLOT(activateWindowAfterEnterMode()));
+        // If we go to fullscreen immediately, it ends up on the primary monitor,
+        // even though we've already moved the window.  By adding this delay, the
+        // fullscreen target screen ends up correct.
+        QTimer::singleShot(SLIGHT_DELAY, this, [&]{
+            Application::getInstance()->setFullscreen(true);
+            activateWindowAfterEnterMode();
+        });
     
         _inHDMMode = true;
     }


### PR DESCRIPTION
Should fix https://app.asana.com/0/27650181942747/33009221055036

Qt doesn't seem to target the correct screen for fullscreen if you do a move and an immediate switch to fullscreen mode.  This code changes to putting the fullscreen toggle into a codeblock that is triggered after a small timeout.