### PR TITLE
Delete Leap and RealSense devices on shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -690,6 +690,9 @@ Application::~Application() {
     nodeThread->quit();
     nodeThread->wait();
 
+    Leapmotion::destroy();
+    RealSense::destroy();
+
     qInstallMessageHandler(NULL); // NOTE: Do this as late as possible so we continue to get our log messages
 }
 

--- a/interface/src/devices/DeviceTracker.cpp
+++ b/interface/src/devices/DeviceTracker.cpp
@@ -66,6 +66,13 @@ DeviceTracker::ID DeviceTracker::registerDevice(const Name& name, DeviceTracker*
     return deviceID;
 }
 
+void DeviceTracker::destroyDevice(const Name& name) {
+    DeviceTracker::ID deviceID = getDeviceID(name);
+    if (deviceID != INVALID_DEVICE) {
+        delete Singleton::get()->_devicesVector[getDeviceID(name)];
+    }
+}
+
 void DeviceTracker::updateAll() {
     //TODO C++11 for (auto deviceIt = Singleton::get()->_devicesVector.begin(); deviceIt != Singleton::get()->_devicesVector.end(); deviceIt++) {
     for (Vector::iterator deviceIt = Singleton::get()->_devicesVector.begin(); deviceIt != Singleton::get()->_devicesVector.end(); deviceIt++) {

--- a/interface/src/devices/DeviceTracker.h
+++ b/interface/src/devices/DeviceTracker.h
@@ -79,6 +79,8 @@ public:
     ///         INVALID_DEVICE_NAME if the name is already taken
     static ID registerDevice(const Name& name, DeviceTracker* tracker);
 
+    static void destroyDevice(const Name& name);
+
     // DeviceTracker interface
 
     virtual void update();

--- a/interface/src/devices/Leapmotion.cpp
+++ b/interface/src/devices/Leapmotion.cpp
@@ -51,6 +51,11 @@ void Leapmotion::init() {
 }
 
 // static
+void Leapmotion::destroy() {
+    DeviceTracker::destroyDevice(NAME);
+}
+
+// static
 Leapmotion* Leapmotion::getInstance() {
     DeviceTracker* device = DeviceTracker::getDevice(NAME);
     if (!device) {

--- a/interface/src/devices/Leapmotion.h
+++ b/interface/src/devices/Leapmotion.h
@@ -26,6 +26,7 @@ public:
     static const Name NAME;
 
     static void init();
+    static void destroy();
 
     /// Leapmotion MotionTracker factory
     static Leapmotion* getInstance();

--- a/interface/src/devices/RealSense.cpp
+++ b/interface/src/devices/RealSense.cpp
@@ -55,6 +55,11 @@ void RealSense::init() {
 }
 
 // static
+void RealSense::destroy() {
+    DeviceTracker::destroyDevice(NAME);
+}
+
+// static
 RealSense* RealSense::getInstance() {
     DeviceTracker* device = DeviceTracker::getDevice(NAME);
     if (!device) {

--- a/interface/src/devices/RealSense.h
+++ b/interface/src/devices/RealSense.h
@@ -32,6 +32,7 @@ public:
     static const Name NAME;
 
     static void init();
+    static void destroy();
 
     /// RealSense MotionTracker factory
     static RealSense* getInstance();


### PR DESCRIPTION
Leaving them running prevents a clean shutdown on Windows when running Interface.exe from a command line: the interface.exe process stays alive preventing Interface from being run again from the command line without manually terminating the running process.