### PR TITLE
Fix wireframe render for meshes with special properties

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -2068,6 +2068,12 @@ void Model::segregateMeshGroups() {
         bool hasSpecular = mesh.hasSpecularTexture();
         bool hasLightmap = mesh.hasEmissiveTexture();
         bool isSkinned = state.clusterMatrices.size() > 1;
+        bool isWireframe = this->isWireframe();
+        
+        if (isWireframe) {
+            translucentMesh = hasTangents = hasSpecular = hasLightmap = isSkinned = false;
+        }
+        
         QString materialID;
 
         // create a material name from all the parts. If there's one part, this will be a single material and its
@@ -2085,7 +2091,7 @@ void Model::segregateMeshGroups() {
             qCDebug(renderutils) << "materialID:" << materialID << "parts:" << mesh.parts.size();
         }
         
-        RenderKey key(translucentMesh, hasLightmap, hasTangents, hasSpecular, isSkinned, isWireframe());
+        RenderKey key(translucentMesh, hasLightmap, hasTangents, hasSpecular, isSkinned, isWireframe);
 
         // reuse or create the bucket corresponding to that key and insert the mesh as unsorted
         _renderBuckets[key.getRaw()]._unsortedMeshes.insertMulti(materialID, i);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -2068,9 +2068,9 @@ void Model::segregateMeshGroups() {
         bool hasSpecular = mesh.hasSpecularTexture();
         bool hasLightmap = mesh.hasEmissiveTexture();
         bool isSkinned = state.clusterMatrices.size() > 1;
-        bool isWireframe = this->isWireframe();
+        bool wireframe = isWireframe();
         
-        if (isWireframe) {
+        if (wireframe) {
             translucentMesh = hasTangents = hasSpecular = hasLightmap = isSkinned = false;
         }
         
@@ -2091,7 +2091,7 @@ void Model::segregateMeshGroups() {
             qCDebug(renderutils) << "materialID:" << materialID << "parts:" << mesh.parts.size();
         }
         
-        RenderKey key(translucentMesh, hasLightmap, hasTangents, hasSpecular, isSkinned, isWireframe);
+        RenderKey key(translucentMesh, hasLightmap, hasTangents, hasSpecular, isSkinned, wireframe);
 
         // reuse or create the bucket corresponding to that key and insert the mesh as unsorted
         _renderBuckets[key.getRaw()]._unsortedMeshes.insertMulti(materialID, i);


### PR DESCRIPTION
Turning off all parameters of the render key for wireframes.
That reduces the number of pass for wireframes from 16 to 1.
@samcake can you confirm this makes sense for all of them?