### PR TITLE
Fix http cache

### DIFF
--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -56,12 +56,12 @@ public:
         glm::vec4 _borderColor{ 1.0f };
         uint32 _maxAnisotropy = 16;
 
+        uint8 _filter = FILTER_MIN_MAG_POINT;
+        uint8 _comparisonFunc = ALWAYS;
+
         uint8 _wrapModeU = WRAP_REPEAT;
         uint8 _wrapModeV = WRAP_REPEAT;
         uint8 _wrapModeW = WRAP_REPEAT;
-
-        uint8 _filter = FILTER_MIN_MAG_POINT;
-        uint8 _comparisonFunc = ALWAYS;
             
         uint8 _mipOffset = 0;
         uint8 _minMip = 0;

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -241,7 +241,7 @@ float Resource::getLoadPriority() {
 }
 
 void Resource::refresh() {
-    if (_reply == nullptr && !(_loaded || _failedToLoad)) {
+    if (_reply && !(_loaded || _failedToLoad)) {
         return;
     }
     if (_reply) {
@@ -351,6 +351,7 @@ void Resource::maybeRefresh() {
             QDateTime lastModifiedOld = metaData.lastModified();
             if (lastModified.isValid() && lastModifiedOld.isValid() &&
                 lastModifiedOld == lastModified) {
+                qCDebug(networking) << "Using cached version of" << _url.fileName();
                 // We don't need to update, return
                 return;
             }


### PR DESCRIPTION
when ResourceCache.cpp is asked to get the data from a url, it attempts to do this:

(1) check the local cache
(2) if the requested data is there, do a http HEAD on the original url
(3) when the results of the http HEAD are done, compare lastModified vs what's in the cache
(4) if the lastModified dates aren't the same, then...
(5) do a http GET

In step (5), aka Resource::refresh(), _reply was always NULL, so this wasn't happening.  The result was that we would often print that we were refreshing from some url, but then we wouldn't.
