### PR TITLE
Cache mod time

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -142,7 +142,7 @@ QString EntityTreeRenderer::loadScriptContents(const QString& scriptMaybeURLorTe
     QUrl url(scriptMaybeURLorText);
     
     // If the url is not valid, this must be script text...
-    if (!url.isValid()) {
+    if (!url.isValid() || scriptMaybeURLorText.startsWith("(")) {
         isURL = false;
         return scriptMaybeURLorText;
     }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -142,7 +142,7 @@ QString EntityTreeRenderer::loadScriptContents(const QString& scriptMaybeURLorTe
     QUrl url(scriptMaybeURLorText);
     
     // If the url is not valid, this must be script text...
-    if (!url.isValid() || scriptMaybeURLorText.startsWith("(")) {
+    if (!url.isValid()) {
         isURL = false;
         return scriptMaybeURLorText;
     }

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -350,7 +350,7 @@ void Resource::maybeRefresh() {
             QDateTime lastModified = variant.value<QDateTime>();
             QDateTime lastModifiedOld = metaData.lastModified();
             if (lastModified.isValid() && lastModifiedOld.isValid() &&
-                lastModifiedOld == lastModified) {
+                lastModifiedOld >= lastModified) {
                 qCDebug(networking) << "Using cached version of" << _url.fileName();
                 // We don't need to update, return
                 return;

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -350,7 +350,7 @@ void Resource::maybeRefresh() {
             QDateTime lastModified = variant.value<QDateTime>();
             QDateTime lastModifiedOld = metaData.lastModified();
             if (lastModified.isValid() && lastModifiedOld.isValid() &&
-                lastModifiedOld >= lastModified) {
+                lastModifiedOld >= lastModified) { // With >=, cache won't thrash in eventually-consistent cdn.
                 qCDebug(networking) << "Using cached version of" << _url.fileName();
                 // We don't need to update, return
                 return;


### PR DESCRIPTION
Make caching work in the presence of:
- network resources that give different mod times for get and head.
- "eventually consistent" content-distribution-networks that give different mod times for different requests