### PR TITLE
Fix for addMenuItem separator boolean

### DIFF
--- a/libraries/script-engine/src/MenuItemProperties.cpp
+++ b/libraries/script-engine/src/MenuItemProperties.cpp
@@ -23,12 +23,13 @@ MenuItemProperties::MenuItemProperties() :
     beforeItem(""),
     afterItem(""),
     isCheckable(false),
-    isChecked(false)
+    isChecked(false),
+    isSeparator(false)
 {
 };
 
 MenuItemProperties::MenuItemProperties(const QString& menuName, const QString& menuItemName,
-                        const QString& shortcutKey, bool checkable, bool checked) :
+                        const QString& shortcutKey, bool checkable, bool checked, bool separator) :
     menuName(menuName),
     menuItemName(menuItemName),
     shortcutKey(shortcutKey),
@@ -38,12 +39,13 @@ MenuItemProperties::MenuItemProperties(const QString& menuName, const QString& m
     beforeItem(""),
     afterItem(""),
     isCheckable(checkable),
-    isChecked(checked)
+    isChecked(checked),
+    isSeparator(separator)
 {
 }
 
 MenuItemProperties::MenuItemProperties(const QString& menuName, const QString& menuItemName, 
-                        const KeyEvent& shortcutKeyEvent, bool checkable, bool checked) :
+                        const KeyEvent& shortcutKeyEvent, bool checkable, bool checked, bool separator) :
     menuName(menuName),
     menuItemName(menuItemName),
     shortcutKey(""),
@@ -53,7 +55,8 @@ MenuItemProperties::MenuItemProperties(const QString& menuName, const QString& m
     beforeItem(""),
     afterItem(""),
     isCheckable(checkable),
-    isChecked(checked)
+    isChecked(checked),
+    isSeparator(separator)
 {
 }
 

--- a/libraries/script-engine/src/MenuItemProperties.h
+++ b/libraries/script-engine/src/MenuItemProperties.h
@@ -22,9 +22,9 @@ class MenuItemProperties {
 public:
     MenuItemProperties(); 
     MenuItemProperties(const QString& menuName, const QString& menuItemName, 
-                        const QString& shortcutKey = QString(""), bool checkable = false, bool checked = false);
+                       const QString& shortcutKey = QString(""), bool checkable = false, bool checked = false, bool separator = false);
     MenuItemProperties(const QString& menuName, const QString& menuItemName, 
-                        const KeyEvent& shortcutKeyEvent, bool checkable = false, bool checked = false);
+                       const KeyEvent& shortcutKeyEvent, bool checkable = false, bool checked = false, bool separator = false);
 
     QString menuName;
     QString menuItemName;


### PR DESCRIPTION
In some cases when the addMenuItem function was called the separator boolean was true by default.

This fix addresses this issue by setting it to false.