### PR TITLE
Make web entities responsive to mouse

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -93,9 +93,9 @@ public:
     virtual void errorInLoadingScript(const QUrl& url);
 
 signals:
-    void mousePressOnEntity(const EntityItemID& entityItemID, const MouseEvent& event);
-    void mouseMoveOnEntity(const EntityItemID& entityItemID, const MouseEvent& event);
-    void mouseReleaseOnEntity(const EntityItemID& entityItemID, const MouseEvent& event);
+    void mousePressOnEntity(const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event, unsigned int deviceId);
+    void mouseMoveOnEntity(const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event, unsigned int deviceId);
+    void mouseReleaseOnEntity(const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event, unsigned int deviceId);
 
     void clickDownOnEntity(const EntityItemID& entityItemID, const MouseEvent& event);
     void holdingClickOnEntity(const EntityItemID& entityItemID, const MouseEvent& event);

--- a/libraries/render-utils/src/OffscreenQmlSurface.cpp
+++ b/libraries/render-utils/src/OffscreenQmlSurface.cpp
@@ -374,3 +374,6 @@ void OffscreenQmlSurface::setProxyWindow(QWindow* window) {
     _renderControl->_renderWindow = window;
 }
 
+QQuickWindow* OffscreenQmlSurface::getWindow() {
+    return _quickWindow;
+}

--- a/libraries/render-utils/src/OffscreenQmlSurface.h
+++ b/libraries/render-utils/src/OffscreenQmlSurface.h
@@ -71,6 +71,7 @@ public:
 
     void setBaseUrl(const QUrl& baseUrl);
     QQuickItem* getRootItem();
+    QQuickWindow* getWindow();
 
     virtual bool eventFilter(QObject* originalDestination, QEvent* event);
 


### PR DESCRIPTION
This PR add mouse interaction to web entities, with the following constraints and caveats.

* Clicking on links to navigate only modifies your local view of the web entity, not the entity properties and not anyone else's view of the page.
* Left clicking should act as expected allowing you to click on links and flick-scroll through content as if you were looking at a touchscreen device
* Middle clicking on the page will tell it to go 'home', i.e. to whatever URL is associated with the entity via the properties
* Right clicking on the page will cause it to navigate backwards.  
** This will happen even if you're just using the right mouse button to change your view and happen to have the cursor over the page when you release the button
** If you right click when it's on the starting URL, the page will _navigate back_ to about:blank.  Use the middle mouse button to get back 'home'
* If the entity is locked, all mouse input is ignored

As you can see this PR isn't well thought out, and not really well tested.  Right now the aim is to produce something functional and cool looking for a demo at SVVR.  As such, merging this PR is likely to have side effects, such as causing your computer to catch fire, souring all the dairy products in your household (with the exception of sour-cream, which will be _un-soured_) and summoning unspeakable horrors to your home.  

![Don't look now](http://www.reactiongifs.com/wp-content/uploads/2013/09/danny-oh-no.gif)
