### PR TITLE
Fix mouse picking in the HMD

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3077,13 +3077,10 @@ PickRay Application::computePickRay(float x, float y) const {
     y /= size.y;
     PickRay result;
     if (isHMDMode()) {
-        ApplicationOverlay::computeHmdPickRay(glm::vec2(x, y), result.origin, result.direction);
+        getApplicationOverlay().computeHmdPickRay(glm::vec2(x, y), result.origin, result.direction);
     } else {
-        if (activeRenderingThread) {
-            getDisplayViewFrustum()->computePickRay(x, y, result.origin, result.direction);
-        } else {
-            getViewFrustum()->computePickRay(x, y, result.origin, result.direction);
-        }
+        auto frustum = activeRenderingThread ? getDisplayViewFrustum() : getViewFrustum();
+        frustum->computePickRay(x, y, result.origin, result.direction);
     }
     return result;
 }
@@ -3111,8 +3108,8 @@ QImage Application::renderAvatarBillboard() {
 ViewFrustum* Application::getViewFrustum() {
 #ifdef DEBUG
     if (QThread::currentThread() == activeRenderingThread) {
-        // FIXME, should this be an assert?
-        qWarning() << "Calling Application::getViewFrustum() from the active rendering thread, did you mean Application::getDisplayViewFrustum()?";
+        // FIXME, figure out a better way to do this
+        //qWarning() << "Calling Application::getViewFrustum() from the active rendering thread, did you mean Application::getDisplayViewFrustum()?";
     }
 #endif
     return &_viewFrustum;
@@ -3121,8 +3118,8 @@ ViewFrustum* Application::getViewFrustum() {
 const ViewFrustum* Application::getViewFrustum() const {
 #ifdef DEBUG
     if (QThread::currentThread() == activeRenderingThread) {
-        // FIXME, should this be an assert?
-        qWarning() << "Calling Application::getViewFrustum() from the active rendering thread, did you mean Application::getDisplayViewFrustum()?";
+        // FIXME, figure out a better way to do this
+        //qWarning() << "Calling Application::getViewFrustum() from the active rendering thread, did you mean Application::getDisplayViewFrustum()?";
     }
 #endif
     return &_viewFrustum;
@@ -3131,8 +3128,8 @@ const ViewFrustum* Application::getViewFrustum() const {
 ViewFrustum* Application::getDisplayViewFrustum() {
 #ifdef DEBUG
     if (QThread::currentThread() != activeRenderingThread) {
-        // FIXME, should this be an assert?
-        qWarning() << "Calling Application::getDisplayViewFrustum() from outside the active rendering thread or outside rendering, did you mean Application::getViewFrustum()?";
+        // FIXME, figure out a better way to do this
+        // qWarning() << "Calling Application::getDisplayViewFrustum() from outside the active rendering thread or outside rendering, did you mean Application::getViewFrustum()?";
     }
 #endif
     return &_displayViewFrustum;
@@ -3141,8 +3138,8 @@ ViewFrustum* Application::getDisplayViewFrustum() {
 const ViewFrustum* Application::getDisplayViewFrustum() const {
 #ifdef DEBUG
     if (QThread::currentThread() != activeRenderingThread) {
-        // FIXME, should this be an assert?
-        qWarning() << "Calling Application::getDisplayViewFrustum() from outside the active rendering thread or outside rendering, did you mean Application::getViewFrustum()?";
+        // FIXME, figure out a better way to do this
+        // qWarning() << "Calling Application::getDisplayViewFrustum() from outside the active rendering thread or outside rendering, did you mean Application::getViewFrustum()?";
     }
 #endif
     return &_displayViewFrustum;

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -58,12 +58,12 @@ public:
     glm::vec2 overlayToSpherical(const glm::vec2 & overlayPos) const;
     glm::vec2 screenToOverlay(const glm::vec2 & screenPos) const;
     glm::vec2 overlayToScreen(const glm::vec2 & overlayPos) const;
+    void computeHmdPickRay(glm::vec2 cursorPos, glm::vec3& origin, glm::vec3& direction) const;
 
     static glm::vec2 directionToSpherical(const glm::vec3 & direction);
     static glm::vec3 sphericalToDirection(const glm::vec2 & sphericalPos);
     static glm::vec2 screenToSpherical(const glm::vec2 & screenPos);
     static glm::vec2 sphericalToScreen(const glm::vec2 & sphericalPos);
-    static void computeHmdPickRay(glm::vec2 cursorPos, glm::vec3& origin, glm::vec3& direction);
     
 private:
     // Interleaved vertex data


### PR DESCRIPTION
this updates the code used in ApplicationOverlay::computeHmdPickRay to match the logic used to render the reticles.  

The code now determines the world space reticle position, then determines the direction the the reticle accounting for the actual HMD pose.  Thus, if you move your head so that the reticle is over something else, (without moving your mouse) the reticle will click on the new thing.  

Also changes the overlay behavior so the overlay tracks with the camera position (not the avatar position) so it's still functional in third person mode.  However it specifically renders relative to the *base* camera position, not the camera position plus the HMD pose, because the latter would result in the overlay translating along with the user's head movements, which is annoying and unsettling.  