### PR TITLE
Batch parameters in GeometryCache

### DIFF
--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -106,30 +106,61 @@ void DeferredLightingEffect::releaseSimpleProgram() {
 }
 
 void DeferredLightingEffect::renderSolidSphere(float radius, int slices, int stacks, const glm::vec4& color) {
+    gpu::Batch batch;
+    renderSolidSphere(batch, radius, slices, stacks, color);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void DeferredLightingEffect::renderSolidSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color) {
     bindSimpleProgram();
     DependencyManager::get<GeometryCache>()->renderSphere(radius, slices, stacks, color);
     releaseSimpleProgram();
 }
 
 void DeferredLightingEffect::renderWireSphere(float radius, int slices, int stacks, const glm::vec4& color) {
+    gpu::Batch batch;
+    renderWireSphere(batch, radius, slices, stacks, color);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void DeferredLightingEffect::renderWireSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color) {
     bindSimpleProgram();
-    DependencyManager::get<GeometryCache>()->renderSphere(radius, slices, stacks, color, false);
+    DependencyManager::get<GeometryCache>()->renderSphere(batch, radius, slices, stacks, color, false);
     releaseSimpleProgram();
 }
 
 void DeferredLightingEffect::renderSolidCube(float size, const glm::vec4& color) {
+    gpu::Batch batch;
+    renderSolidCube(batch, size, color);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void DeferredLightingEffect::renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color) {
     bindSimpleProgram();
     DependencyManager::get<GeometryCache>()->renderSolidCube(size, color);
     releaseSimpleProgram();
 }
 
 void DeferredLightingEffect::renderWireCube(float size, const glm::vec4& color) {
+    gpu::Batch batch;
+    renderWireCube(batch, size, color);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void DeferredLightingEffect::renderWireCube(gpu::Batch& batch, float size, const glm::vec4& color) {
     bindSimpleProgram();
     DependencyManager::get<GeometryCache>()->renderWireCube(size, color);
     releaseSimpleProgram();
 }
 
 void DeferredLightingEffect::renderLine(const glm::vec3& p1, const glm::vec3& p2, 
+                                        const glm::vec4& color1, const glm::vec4& color2) {
+    gpu::Batch batch;
+    renderLine(batch, p1, p2, color1, color2);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void DeferredLightingEffect::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
                                         const glm::vec4& color1, const glm::vec4& color2) {
     bindSimpleProgram();
     DependencyManager::get<GeometryCache>()->renderLine(p1, p2, color1, color2);

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -44,18 +44,24 @@ public:
 
     //// Renders a solid sphere with the simple program.
     void renderSolidSphere(float radius, int slices, int stacks, const glm::vec4& color);
+    void renderSolidSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color);
 
     //// Renders a wireframe sphere with the simple program.
     void renderWireSphere(float radius, int slices, int stacks, const glm::vec4& color);
+    void renderWireSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color);
     
     //// Renders a solid cube with the simple program.
     void renderSolidCube(float size, const glm::vec4& color);
+    void renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color);
 
     //// Renders a wireframe cube with the simple program.
     void renderWireCube(float size, const glm::vec4& color);
+    void renderWireCube(gpu::Batch& batch, float size, const glm::vec4& color);
 
     //// Renders a line with the simple program.
     void renderLine(const glm::vec3& p1, const glm::vec3& p2, 
+                    const glm::vec4& color1, const glm::vec4& color2);
+    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
                     const glm::vec4& color1, const glm::vec4& color2);
 
     //// Renders a solid cone with the simple program.

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -59,6 +59,12 @@ void GeometryCache::renderSphere(float radius, int slices, int stacks, const glm
     gpu::Batch batch;
     renderSphere(batch, radius, slices, stacks, color, solid, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color, bool solid, int id) {
@@ -296,12 +302,6 @@ void GeometryCache::renderSphere(gpu::Batch& batch, float radius, int slices, in
     } else {
         batch.drawIndexed(gpu::LINES, indices);
     }
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderCone(float base, float height, int slices, int stacks) {
@@ -409,6 +409,11 @@ void GeometryCache::renderGrid(int xDivisions, int yDivisions, const glm::vec4& 
     gpu::Batch batch;
     renderGrid(batch, xDivisions, yDivisions, color);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderGrid(gpu::Batch& batch, int xDivisions, int yDivisions, const glm::vec4& color) {
@@ -483,18 +488,17 @@ void GeometryCache::renderGrid(gpu::Batch& batch, int xDivisions, int yDivisions
     batch.setInputBuffer(VERTICES_SLOT, verticesView);
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.draw(gpu::LINES, vertices, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
 }
 
 void GeometryCache::renderGrid(int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id) {
     gpu::Batch batch;
     renderGrid(x, y, width, height, rows, cols, color, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 // TODO: properly handle the x,y,w,h changing for an ID
@@ -596,11 +600,6 @@ void GeometryCache::renderGrid(gpu::Batch& batch, int x, int y, int width, int h
     batch.setInputBuffer(VERTICES_SLOT, verticesView);
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.draw(gpu::LINES, vertices, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::updateVertices(int id, const QVector<glm::vec2>& points, const glm::vec4& color) {
@@ -799,20 +798,22 @@ void GeometryCache::updateVertices(int id, const QVector<glm::vec3>& points, con
 }
 
 void GeometryCache::renderVertices(gpu::Primitive primitiveType, int id) {
+    gpu::Batch batch;
+    renderVertices(batch, primitiveType, id);
+    gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void GeometryCache::renderVertices(gpu::Batch& batch, gpu::Primitive primitiveType, int id) {
     BatchItemDetails& details = _registeredVertices[id];
     if (details.isCreated) {
-        gpu::Batch batch;
-
         batch.setInputFormat(details.streamFormat);
         batch.setInputStream(0, *details.stream);
         batch.draw(primitiveType, details.vertices, 0);
-
-        gpu::GLBackend::renderBatch(batch);
-
-        glDisableClientState(GL_VERTEX_ARRAY);
-        glDisableClientState(GL_COLOR_ARRAY);
-
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
 }
 
@@ -820,6 +821,12 @@ void GeometryCache::renderSolidCube(float size, const glm::vec4& color) {
     gpu::Batch batch;
     renderSolidCube(batch, size, color);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color) {
@@ -934,18 +941,18 @@ void GeometryCache::renderSolidCube(gpu::Batch& batch, float size, const glm::ve
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.setIndexBuffer(gpu::UINT8, _solidCubeIndexBuffer, 0);
     batch.drawIndexed(gpu::TRIANGLES, indices);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderWireCube(float size, const glm::vec4& color) {
     gpu::Batch batch;
     renderWireCube(batch, size, color);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderWireCube(gpu::Batch& batch, float size, const glm::vec4& color) {
@@ -1023,18 +1030,17 @@ void GeometryCache::renderWireCube(gpu::Batch& batch, float size, const glm::vec
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.setIndexBuffer(gpu::UINT8, _wireCubeIndexBuffer, 0);
     batch.drawIndexed(gpu::LINES, indices);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderBevelCornersRect(int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id) {
     gpu::Batch batch;
     renderBevelCornersRect(batch, x, y, width, height, bevelDistance, color, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id) {
@@ -1133,17 +1139,17 @@ void GeometryCache::renderBevelCornersRect(gpu::Batch& batch, int x, int y, int 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id) {
     gpu::Batch batch;
     renderQuad(batch, minCorner, maxCorner, color, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id) {
@@ -1215,11 +1221,6 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxCorner,
@@ -1228,6 +1229,12 @@ void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxC
     gpu::Batch batch;
     renderQuad(batch, minCorner, maxCorner, texCoordMinCorner, texCoordMaxCorner, color, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
@@ -1305,26 +1312,20 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
     }
 
-//    glEnable(GL_TEXTURE_2D);
-    //glBindTexture(GL_TEXTURE_2D, _currentTextureID); // this is quad specific...
-
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-  //  glBindTexture(GL_TEXTURE_2D, 0);
-  //  glDisable(GL_TEXTURE_2D);
 }
 
 void GeometryCache::renderQuad(const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id) {
     gpu::Batch batch;
     renderQuad(batch, minCorner, maxCorner, color, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id) {
@@ -1396,11 +1397,6 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderQuad(const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
@@ -1411,7 +1407,16 @@ void GeometryCache::renderQuad(const glm::vec3& topLeft, const glm::vec3& bottom
     gpu::Batch batch;
     renderQuad(batch, topLeft, bottomLeft, bottomRight, topRight, texCoordTopLeft, texCoordBottomLeft,
                texCoordBottomRight, texCoordTopRight, color, id);
+
+    glEnable(GL_TEXTURE_2D);
+
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
@@ -1502,18 +1507,11 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
     }
 
-    glEnable(GL_TEXTURE_2D);
     //glBindTexture(GL_TEXTURE_2D, _currentTextureID); // this is quad specific...
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
     
     // TODO: The callers of this method (renderMagnifier and renderReticle) assume that we won't disable an unbind
     // the texture after rendering. I'm not sure if this is correct in general but it's currently required for the
@@ -1526,6 +1524,11 @@ void GeometryCache::renderDashedLine(const glm::vec3& start, const glm::vec3& en
     gpu::Batch batch;
     renderDashedLine(batch, start, end, color, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id) {
@@ -1631,11 +1634,6 @@ void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::LINES, details.vertices, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 
@@ -1692,6 +1690,10 @@ void GeometryCache::renderLine(const glm::vec3& p1, const glm::vec3& p2,
     gpu::Batch batch;
     renderLine(batch, p1, p2, color1, color2, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
@@ -1776,16 +1778,16 @@ void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::LINES, 2, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderLine(const glm::vec2& p1, const glm::vec2& p2, const glm::vec4& color1, const glm::vec4& color2, int id) {
     gpu::Batch batch;
     renderLine(batch, p1, p2, color1, color2, id);
     gpu::GLBackend::renderBatch(batch);
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,                                
@@ -1870,10 +1872,6 @@ void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::LINES, 2, 0);
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_COLOR_ARRAY);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -56,6 +56,12 @@ const int NUM_BYTES_PER_VERTEX = NUM_COORDS_PER_VERTEX * sizeof(GLfloat);
 const int NUM_BYTES_PER_INDEX = sizeof(GLushort);
 
 void GeometryCache::renderSphere(float radius, int slices, int stacks, const glm::vec4& color, bool solid, int id) {
+    gpu::Batch batch;
+    renderSphere(batch, radius, slices, stacks, color, solid, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color, bool solid, int id) {
     bool registered = (id != UNKNOWN_ID);
 
     Vec2Pair radiusKey(glm::vec2(radius, slices), glm::vec2(stacks, 0));
@@ -279,8 +285,6 @@ void GeometryCache::renderSphere(float radius, int slices, int stacks, const glm
     gpu::BufferView normalsView(verticesBuffer, streamFormat->getAttributes().at(gpu::Stream::NORMAL)._element);
     gpu::BufferView colorView(colorBuffer, streamFormat->getAttributes().at(gpu::Stream::COLOR)._element);
     
-    gpu::Batch batch;
-
     batch.setInputFormat(streamFormat);
     batch.setInputBuffer(VERTICES_SLOT, verticesView);
     batch.setInputBuffer(NORMALS_SLOT, normalsView);
@@ -292,8 +296,6 @@ void GeometryCache::renderSphere(float radius, int slices, int stacks, const glm
     } else {
         batch.drawIndexed(gpu::LINES, indices);
     }
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -402,7 +404,14 @@ void GeometryCache::renderCone(float base, float height, int slices, int stacks)
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
+
 void GeometryCache::renderGrid(int xDivisions, int yDivisions, const glm::vec4& color) {
+    gpu::Batch batch;
+    renderGrid(batch, xDivisions, yDivisions, color);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderGrid(gpu::Batch& batch, int xDivisions, int yDivisions, const glm::vec4& color) {
     IntPair key(xDivisions, yDivisions);
     Vec3Pair colorKey(glm::vec3(color.x, color.y, yDivisions), glm::vec3(color.z, color.y, xDivisions));
 
@@ -470,14 +479,10 @@ void GeometryCache::renderGrid(int xDivisions, int yDivisions, const glm::vec4& 
     gpu::BufferView verticesView(verticesBuffer, 0, verticesBuffer->getSize(), streamFormat->getAttributes().at(gpu::Stream::POSITION)._element);
     gpu::BufferView colorView(colorBuffer, streamFormat->getAttributes().at(gpu::Stream::COLOR)._element);
     
-    gpu::Batch batch;
-
     batch.setInputFormat(streamFormat);
     batch.setInputBuffer(VERTICES_SLOT, verticesView);
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.draw(gpu::LINES, vertices, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -486,9 +491,15 @@ void GeometryCache::renderGrid(int xDivisions, int yDivisions, const glm::vec4& 
 
 }
 
+void GeometryCache::renderGrid(int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id) {
+    gpu::Batch batch;
+    renderGrid(x, y, width, height, rows, cols, color, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
 // TODO: properly handle the x,y,w,h changing for an ID
 // TODO: why do we seem to create extra BatchItemDetails when we resize the window?? what's that??
-void GeometryCache::renderGrid(int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id) {
+void GeometryCache::renderGrid(gpu::Batch& batch, int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id) {
     #ifdef WANT_DEBUG
         qCDebug(renderutils) << "GeometryCache::renderGrid(x["<<x<<"], "
             "y["<<y<<"],"
@@ -580,15 +591,11 @@ void GeometryCache::renderGrid(int x, int y, int width, int height, int rows, in
 
     gpu::BufferView verticesView(verticesBuffer, 0, verticesBuffer->getSize(), streamFormat->getAttributes().at(gpu::Stream::POSITION)._element);
     gpu::BufferView colorView(colorBuffer, streamFormat->getAttributes().at(gpu::Stream::COLOR)._element);
-    
-    gpu::Batch batch;
 
     batch.setInputFormat(streamFormat);
     batch.setInputBuffer(VERTICES_SLOT, verticesView);
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.draw(gpu::LINES, vertices, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -810,6 +817,12 @@ void GeometryCache::renderVertices(gpu::Primitive primitiveType, int id) {
 }
 
 void GeometryCache::renderSolidCube(float size, const glm::vec4& color) {
+    gpu::Batch batch;
+    renderSolidCube(batch, size, color);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color) {
     Vec2Pair colorKey(glm::vec2(color.x, color.y), glm::vec2(color.z, color.y));
     const int FLOATS_PER_VERTEX = 3;
     const int VERTICES_PER_FACE = 4;
@@ -915,16 +928,12 @@ void GeometryCache::renderSolidCube(float size, const glm::vec4& color) {
     gpu::BufferView normalsView(verticesBuffer, NORMALS_OFFSET, verticesBuffer->getSize(), VERTEX_STRIDE, streamFormat->getAttributes().at(gpu::Stream::NORMAL)._element);
     gpu::BufferView colorView(colorBuffer, streamFormat->getAttributes().at(gpu::Stream::COLOR)._element);
     
-    gpu::Batch batch;
-
     batch.setInputFormat(streamFormat);
     batch.setInputBuffer(VERTICES_SLOT, verticesView);
     batch.setInputBuffer(NORMALS_SLOT, normalsView);
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.setIndexBuffer(gpu::UINT8, _solidCubeIndexBuffer, 0);
     batch.drawIndexed(gpu::TRIANGLES, indices);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -934,6 +943,12 @@ void GeometryCache::renderSolidCube(float size, const glm::vec4& color) {
 }
 
 void GeometryCache::renderWireCube(float size, const glm::vec4& color) {
+    gpu::Batch batch;
+    renderWireCube(batch, size, color);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderWireCube(gpu::Batch& batch, float size, const glm::vec4& color) {
     Vec2Pair colorKey(glm::vec2(color.x, color.y),glm::vec2(color.z, color.y));
     const int FLOATS_PER_VERTEX = 3;
     const int VERTICES_PER_EDGE = 2;
@@ -1003,15 +1018,11 @@ void GeometryCache::renderWireCube(float size, const glm::vec4& color) {
     gpu::BufferView verticesView(verticesBuffer, streamFormat->getAttributes().at(gpu::Stream::POSITION)._element);
     gpu::BufferView colorView(colorBuffer, streamFormat->getAttributes().at(gpu::Stream::COLOR)._element);
     
-    gpu::Batch batch;
-
     batch.setInputFormat(streamFormat);
     batch.setInputBuffer(VERTICES_SLOT, verticesView);
     batch.setInputBuffer(COLOR_SLOT, colorView);
     batch.setIndexBuffer(gpu::UINT8, _wireCubeIndexBuffer, 0);
     batch.drawIndexed(gpu::LINES, indices);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -1021,6 +1032,12 @@ void GeometryCache::renderWireCube(float size, const glm::vec4& color) {
 }
 
 void GeometryCache::renderBevelCornersRect(int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id) {
+    gpu::Batch batch;
+    renderBevelCornersRect(batch, x, y, width, height, bevelDistance, color, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id) {
     bool registered = (id != UNKNOWN_ID);
     Vec3Pair key(glm::vec3(x, y, 0.0f), glm::vec3(width, height, bevelDistance));
     BatchItemDetails& details = registered ? _registeredBevelRects[id] : _bevelRects[key];
@@ -1113,13 +1130,9 @@ void GeometryCache::renderBevelCornersRect(int x, int y, int width, int height, 
         delete[] vertexBuffer;
     }
 
-    gpu::Batch batch;
-
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -1128,6 +1141,12 @@ void GeometryCache::renderBevelCornersRect(int x, int y, int width, int height, 
 }
 
 void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id) {
+    gpu::Batch batch;
+    renderQuad(batch, minCorner, maxCorner, color, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id) {
     bool registered = (id != UNKNOWN_ID);
     Vec4Pair key(glm::vec4(minCorner.x, minCorner.y, maxCorner.x, maxCorner.y), color);
     BatchItemDetails& details = registered ? _registeredQuad2D[id] : _quad2D[key];
@@ -1193,13 +1212,9 @@ void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxC
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
     }
 
-    gpu::Batch batch;
-
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -1208,6 +1223,14 @@ void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxC
 }
 
 void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxCorner,
+                    const glm::vec2& texCoordMinCorner, const glm::vec2& texCoordMaxCorner, 
+                    const glm::vec4& color, int id) {
+    gpu::Batch batch;
+    renderQuad(batch, minCorner, maxCorner, texCoordMinCorner, texCoordMaxCorner, color, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
                     const glm::vec2& texCoordMinCorner, const glm::vec2& texCoordMaxCorner, 
                     const glm::vec4& color, int id) {
 
@@ -1282,16 +1305,12 @@ void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxC
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
     }
 
-    gpu::Batch batch;
-
 //    glEnable(GL_TEXTURE_2D);
     //glBindTexture(GL_TEXTURE_2D, _currentTextureID); // this is quad specific...
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
@@ -1303,6 +1322,12 @@ void GeometryCache::renderQuad(const glm::vec2& minCorner, const glm::vec2& maxC
 }
 
 void GeometryCache::renderQuad(const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id) {
+    gpu::Batch batch;
+    renderQuad(batch, minCorner, maxCorner, color, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id) {
     bool registered = (id != UNKNOWN_ID);
     Vec3PairVec4 key(Vec3Pair(minCorner, maxCorner), color);
     BatchItemDetails& details = registered ? _registeredQuad3D[id] : _quad3D[key];
@@ -1368,13 +1393,9 @@ void GeometryCache::renderQuad(const glm::vec3& minCorner, const glm::vec3& maxC
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
     }
 
-    gpu::Batch batch;
-
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -1383,6 +1404,17 @@ void GeometryCache::renderQuad(const glm::vec3& minCorner, const glm::vec3& maxC
 }
 
 void GeometryCache::renderQuad(const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
+                    const glm::vec3& bottomRight, const glm::vec3& topRight,
+                    const glm::vec2& texCoordTopLeft, const glm::vec2& texCoordBottomLeft,
+                    const glm::vec2& texCoordBottomRight, const glm::vec2& texCoordTopRight, 
+                    const glm::vec4& color, int id) {
+    gpu::Batch batch;
+    renderQuad(batch, topLeft, bottomLeft, bottomRight, topRight, texCoordTopLeft, texCoordBottomLeft,
+               texCoordBottomRight, texCoordTopRight, color, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
                     const glm::vec3& bottomRight, const glm::vec3& topRight,
                     const glm::vec2& texCoordTopLeft, const glm::vec2& texCoordBottomLeft,
                     const glm::vec2& texCoordBottomRight, const glm::vec2& texCoordTopRight, 
@@ -1470,16 +1502,12 @@ void GeometryCache::renderQuad(const glm::vec3& topLeft, const glm::vec3& bottom
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
     }
 
-    gpu::Batch batch;
-
     glEnable(GL_TEXTURE_2D);
     //glBindTexture(GL_TEXTURE_2D, _currentTextureID); // this is quad specific...
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::QUADS, 4, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
@@ -1495,6 +1523,12 @@ void GeometryCache::renderQuad(const glm::vec3& topLeft, const glm::vec3& bottom
 }
 
 void GeometryCache::renderDashedLine(const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id) {
+    gpu::Batch batch;
+    renderDashedLine(batch, start, end, color, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id) {
     bool registered = (id != UNKNOWN_ID);
     Vec3PairVec2Pair key(Vec3Pair(start, end), Vec2Pair(glm::vec2(color.x, color.y), glm::vec2(color.z, color.w)));
     BatchItemDetails& details = registered ? _registeredDashedLines[id] : _dashedLines[key];
@@ -1594,13 +1628,9 @@ void GeometryCache::renderDashedLine(const glm::vec3& start, const glm::vec3& en
         #endif
     }
 
-    gpu::Batch batch;
-
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::LINES, details.vertices, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
@@ -1658,6 +1688,13 @@ void GeometryCache::BatchItemDetails::clear() {
 }
 
 void GeometryCache::renderLine(const glm::vec3& p1, const glm::vec3& p2, 
+                               const glm::vec4& color1, const glm::vec4& color2, int id) {
+    gpu::Batch batch;
+    renderLine(batch, p1, p2, color1, color2, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
                                const glm::vec4& color1, const glm::vec4& color2, int id) {
                                
     bool registered = (id != UNKNOWN_ID);
@@ -1735,21 +1772,23 @@ void GeometryCache::renderLine(const glm::vec3& p1, const glm::vec3& p2,
         #endif
     }
 
-    gpu::Batch batch;
-
     // this is what it takes to render a quad
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::LINES, 2, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
-void GeometryCache::renderLine(const glm::vec2& p1, const glm::vec2& p2,                                
+void GeometryCache::renderLine(const glm::vec2& p1, const glm::vec2& p2, const glm::vec4& color1, const glm::vec4& color2, int id) {
+    gpu::Batch batch;
+    renderLine(batch, p1, p2, color1, color2, id);
+    gpu::GLBackend::renderBatch(batch);
+}
+
+void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,                                
                                 const glm::vec4& color1, const glm::vec4& color2, int id) {
                                
     bool registered = (id != UNKNOWN_ID);
@@ -1827,14 +1866,10 @@ void GeometryCache::renderLine(const glm::vec2& p1, const glm::vec2& p2,
         #endif
     }
 
-    gpu::Batch batch;
-
     // this is what it takes to render a quad
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::LINES, 2, 0);
-
-    gpu::GLBackend::renderBatch(batch);
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -135,31 +135,53 @@ public:
 
     void renderCone(float base, float height, int slices, int stacks);
 
-    void renderSphere(float radius, int slices, int stacks, const glm::vec3& color, bool solid = true, int id = UNKNOWN_ID) 
+    void renderSphere(float radius, int slices, int stacks, const glm::vec3& color, bool solid = true, int id = UNKNOWN_ID)
                 { renderSphere(radius, slices, stacks, glm::vec4(color, 1.0f), solid, id); }
+    void renderSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec3& color, bool solid = true, int id = UNKNOWN_ID) 
+                { renderSphere(batch, radius, slices, stacks, glm::vec4(color, 1.0f), solid, id); }
                 
     void renderSphere(float radius, int slices, int stacks, const glm::vec4& color, bool solid = true, int id = UNKNOWN_ID);
+    void renderSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color, bool solid = true, int id = UNKNOWN_ID);
+
     void renderGrid(int xDivisions, int yDivisions, const glm::vec4& color);
+    void renderGrid(gpu::Batch& batch, int xDivisions, int yDivisions, const glm::vec4& color);
     void renderGrid(int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderGrid(gpu::Batch& batch, int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id = UNKNOWN_ID);
+
     void renderSolidCube(float size, const glm::vec4& color);
+    void renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color);
     void renderWireCube(float size, const glm::vec4& color);
+    void renderWireCube(gpu::Batch& batch, float size, const glm::vec4& color);
     void renderBevelCornersRect(int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id = UNKNOWN_ID);
 
     void renderQuad(int x, int y, int width, int height, const glm::vec4& color, int id = UNKNOWN_ID)
             { renderQuad(glm::vec2(x,y), glm::vec2(x + width, y + height), color, id); }
+    void renderQuad(gpu::Batch& batch, int x, int y, int width, int height, const glm::vec4& color, int id = UNKNOWN_ID)
+            { renderQuad(batch, glm::vec2(x,y), glm::vec2(x + width, y + height), color, id); }
             
     // TODO: I think there's a bug in this version of the renderQuad() that's not correctly rebuilding the vbos
     // if the color changes by the corners are the same, as evidenced by the audio meter which should turn white
     // when it's clipping
     void renderQuad(const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id = UNKNOWN_ID);
 
     void renderQuad(const glm::vec2& minCorner, const glm::vec2& maxCorner,
                     const glm::vec2& texCoordMinCorner, const glm::vec2& texCoordMaxCorner, 
                     const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
+                    const glm::vec2& texCoordMinCorner, const glm::vec2& texCoordMaxCorner, 
+                    const glm::vec4& color, int id = UNKNOWN_ID);
 
     void renderQuad(const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id = UNKNOWN_ID);
 
     void renderQuad(const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
+                    const glm::vec3& bottomRight, const glm::vec3& topRight,
+                    const glm::vec2& texCoordTopLeft, const glm::vec2& texCoordBottomLeft,
+                    const glm::vec2& texCoordBottomRight, const glm::vec2& texCoordTopRight, 
+                    const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
                     const glm::vec3& bottomRight, const glm::vec3& topRight,
                     const glm::vec2& texCoordTopLeft, const glm::vec2& texCoordBottomLeft,
                     const glm::vec2& texCoordBottomRight, const glm::vec2& texCoordTopRight, 
@@ -168,32 +190,52 @@ public:
 
     void renderLine(const glm::vec3& p1, const glm::vec3& p2, const glm::vec3& color, int id = UNKNOWN_ID) 
                     { renderLine(p1, p2, color, color, id); }
+    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, const glm::vec3& color, int id = UNKNOWN_ID) 
+                    { renderLine(batch, p1, p2, color, color, id); }
     
     void renderLine(const glm::vec3& p1, const glm::vec3& p2, 
                     const glm::vec3& color1, const glm::vec3& color2, int id = UNKNOWN_ID)
                     { renderLine(p1, p2, glm::vec4(color1, 1.0f), glm::vec4(color2, 1.0f), id); }
+    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
+                    const glm::vec3& color1, const glm::vec3& color2, int id = UNKNOWN_ID)
+                    { renderLine(batch, p1, p2, glm::vec4(color1, 1.0f), glm::vec4(color2, 1.0f), id); }
 
     void renderLine(const glm::vec3& p1, const glm::vec3& p2, 
                     const glm::vec4& color, int id = UNKNOWN_ID)
                     { renderLine(p1, p2, color, color, id); }
+    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
+                    const glm::vec4& color, int id = UNKNOWN_ID)
+                    { renderLine(batch, p1, p2, color, color, id); }
 
     void renderLine(const glm::vec3& p1, const glm::vec3& p2, 
                     const glm::vec4& color1, const glm::vec4& color2, int id = UNKNOWN_ID);
+    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
+                    const glm::vec4& color1, const glm::vec4& color2, int id = UNKNOWN_ID);
                     
     void renderDashedLine(const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id = UNKNOWN_ID);
 
     void renderLine(const glm::vec2& p1, const glm::vec2& p2, const glm::vec3& color, int id = UNKNOWN_ID)
                     { renderLine(p1, p2, glm::vec4(color, 1.0f), id); }
+    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec3& color, int id = UNKNOWN_ID)
+                    { renderLine(batch, p1, p2, glm::vec4(color, 1.0f), id); }
 
     void renderLine(const glm::vec2& p1, const glm::vec2& p2, const glm::vec4& color, int id = UNKNOWN_ID)
                     { renderLine(p1, p2, color, color, id); }
+    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec4& color, int id = UNKNOWN_ID)
+                    { renderLine(batch, p1, p2, color, color, id); }
 
 
     void renderLine(const glm::vec2& p1, const glm::vec2& p2,                                
                                     const glm::vec3& color1, const glm::vec3& color2, int id = UNKNOWN_ID)
                     { renderLine(p1, p2, glm::vec4(color1, 1.0f), glm::vec4(color2, 1.0f), id); }
+    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,                                
+                                    const glm::vec3& color1, const glm::vec3& color2, int id = UNKNOWN_ID)
+                    { renderLine(batch, p1, p2, glm::vec4(color1, 1.0f), glm::vec4(color2, 1.0f), id); }
                 
     void renderLine(const glm::vec2& p1, const glm::vec2& p2,                                
+                                    const glm::vec4& color1, const glm::vec4& color2, int id = UNKNOWN_ID);
+    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,                                
                                     const glm::vec4& color1, const glm::vec4& color2, int id = UNKNOWN_ID);
 
     void updateVertices(int id, const QVector<glm::vec2>& points, const glm::vec4& color);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -241,6 +241,7 @@ public:
     void updateVertices(int id, const QVector<glm::vec2>& points, const glm::vec4& color);
     void updateVertices(int id, const QVector<glm::vec3>& points, const glm::vec4& color);
     void updateVertices(int id, const QVector<glm::vec3>& points, const QVector<glm::vec2>& texCoords, const glm::vec4& color);
+    void renderVertices(gpu::Batch& batch, gpu::Primitive primitiveType, int id);
     void renderVertices(gpu::Primitive primitiveType, int id);
 
     /// Loads geometry from the specified URL.


### PR DESCRIPTION
This adds a batch parameter to the GeometryCache::render* calls to help begin the process of moving completely to gpu::Batch and removing all gl* calls.  This PR is to merge into branch team-teaching.