### PR TITLE
check for NULL before using pointer to EntityItem

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -85,8 +85,8 @@ EntityItemID EntityScriptingInterface::addEntity(const EntityItemProperties& pro
     if (_entityTree) {
         _entityTree->lockForWrite();
         EntityItem* entity = _entityTree->addEntity(id, propertiesWithSimID);
-        entity->setLastBroadcast(usecTimestampNow());
         if (entity) {
+            entity->setLastBroadcast(usecTimestampNow());
             // This Node is creating a new object.  If it's in motion, set this Node as the simulator.
             bidForSimulationOwnership(propertiesWithSimID);
         } else {


### PR DESCRIPTION
I tried to reproduce another crash and encountered this one instead.  A simple fix -- move the line that uses an EntityItem pointer down below the check for valid pointer.