### PR TITLE
Fix spotlight dimensions

### DIFF
--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -1213,7 +1213,7 @@ SelectionDisplay = (function () {
                     rotation: rotation,
                     visible: true,
                 });
-                var distance = (properties.dimensions.z / 2) * Math.tan(properties.cutoff * (Math.PI / 180));
+                var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
 
                 Overlays.editOverlay(grabberSpotLightL, {
                     position: EdgeNL,

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -64,7 +64,7 @@ EntityItemProperties::EntityItemProperties() :
     CONSTRUCT_PROPERTY(isSpotlight, false),
     CONSTRUCT_PROPERTY(intensity, 1.0f),
     CONSTRUCT_PROPERTY(exponent, 0.0f),
-    CONSTRUCT_PROPERTY(cutoff, PI),
+    CONSTRUCT_PROPERTY(cutoff, ENTITY_ITEM_DEFAULT_CUTOFF),
     CONSTRUCT_PROPERTY(locked, ENTITY_ITEM_DEFAULT_LOCKED),
     CONSTRUCT_PROPERTY(textures, ""),
     CONSTRUCT_PROPERTY(animationSettings, ""),

--- a/libraries/entities/src/EntityItemPropertiesDefaults.h
+++ b/libraries/entities/src/EntityItemPropertiesDefaults.h
@@ -64,6 +64,8 @@ const float ENTITY_ITEM_DEFAULT_FRICTION = 0.5f;
 const bool ENTITY_ITEM_DEFAULT_IGNORE_FOR_COLLISIONS = false;
 const bool ENTITY_ITEM_DEFAULT_COLLISIONS_WILL_MOVE = false;
 
+const float ENTITY_ITEM_DEFAULT_CUTOFF = PI / 2;
+
 const QString ENTITY_ITEM_DEFAULT_NAME = QString("");
 
 #endif // hifi_EntityItemPropertiesDefaults_h

--- a/libraries/entities/src/LightEntityItem.cpp
+++ b/libraries/entities/src/LightEntityItem.cpp
@@ -46,7 +46,7 @@ void LightEntityItem::setDimensions(const glm::vec3& value) {
         // If we are a spotlight, treat the z value as our radius or length, and
         // recalculate the x/y dimensions to properly encapsulate the spotlight.
         const float length = value.z;
-        const float width = length * glm::tan(glm::radians(_cutoff));
+        const float width = length * glm::sin(glm::radians(_cutoff));
         _dimensions = glm::vec3(width, width, length);
     } else {
         float maxDimension = glm::max(value.x, value.y, value.z);
@@ -73,7 +73,7 @@ void LightEntityItem::setIsSpotlight(bool value) {
 
         if (_isSpotlight) {
             const float length = _dimensions.z;
-            const float width = length * glm::tan(glm::radians(_cutoff));
+            const float width = length * glm::sin(glm::radians(_cutoff));
             _dimensions = glm::vec3(width, width, length);
         } else {
             float maxDimension = glm::max(_dimensions.x, _dimensions.y, _dimensions.z);
@@ -89,7 +89,7 @@ void LightEntityItem::setCutoff(float value) {
         // If we are a spotlight, adjusting the cutoff will affect the area we encapsulate,
         // so update the dimensions to reflect this.
         const float length = _dimensions.z;
-        const float width = length * glm::tan(glm::radians(_cutoff));
+        const float width = length * glm::sin(glm::radians(_cutoff));
         _dimensions = glm::vec3(width, width, length);
     }
 }


### PR DESCRIPTION
The area of effect for a spotlight is the intersection of a cone of length r and a sphere of radius r.  The previous calculation only took the cone into account; this fixes that.