### PR TITLE
Deactivate PerformanceTimer when not in use

### DIFF
--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -979,6 +979,14 @@ void ApplicationOverlay::renderStatsAndLogs() {
     glLineWidth(1.0f);
     glPointSize(1.0f);
 
+    // Determine whether to compute timing details
+    bool shouldDisplayTimingDetail = Menu::getInstance()->isOptionChecked(MenuOption::DisplayDebugTimingDetails) &&
+                                     Menu::getInstance()->isOptionChecked(MenuOption::Stats) &&
+                                     Stats::getInstance()->isExpanded();
+    if (shouldDisplayTimingDetail != PerformanceTimer::isActive()) {
+        PerformanceTimer::setActive(shouldDisplayTimingDetail);
+    }
+    
     if (Menu::getInstance()->isOptionChecked(MenuOption::Stats)) {
         // let's set horizontal offset to give stats some margin to mirror
         int horizontalOffset = MIRROR_VIEW_WIDTH + MIRROR_VIEW_LEFT_PADDING * 2;

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -224,9 +224,10 @@ void Stats::display(
     lines = 5;
     int columnOneWidth = _generalStatsWidth;
 
-    PerformanceTimer::tallyAllTimerRecords(); // do this even if we're not displaying them, so they don't stack up
-    
-    if (_expanded && Menu::getInstance()->isOptionChecked(MenuOption::DisplayDebugTimingDetails)) {
+    bool performanceTimerIsActive = PerformanceTimer::isActive();
+    bool displayPerf = _expanded && Menu::getInstance()->isOptionChecked(MenuOption::DisplayDebugTimingDetails);
+    if (displayPerf && performanceTimerIsActive) {
+        PerformanceTimer::tallyAllTimerRecords(); // do this even if we're not displaying them, so they don't stack up
 
         columnOneWidth = _generalStatsWidth + _pingStatsWidth + _geoStatsWidth; // 3 columns wide...
         // we will also include room for 1 line per timing record and a header of 4 lines
@@ -276,7 +277,7 @@ void Stats::display(
 
     
     // TODO: the display of these timing details should all be moved to JavaScript
-    if (_expanded && Menu::getInstance()->isOptionChecked(MenuOption::DisplayDebugTimingDetails)) {
+    if (displayPerf && performanceTimerIsActive) {
         bool onlyDisplayTopTen = Menu::getInstance()->isOptionChecked(MenuOption::OnlyDisplayTopTen);
         // Timing details...
         verticalOffset += STATS_PELS_PER_LINE * 4; // skip 3 lines to be under the other columns

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -27,6 +27,8 @@ public:
     static void drawBackground(unsigned int rgba, int x, int y, int width, int height);
 
     void toggleExpanded();
+    bool isExpanded() { return _expanded; }
+    
     void checkClick(int mouseX, int mouseY, int mouseDragStartedX, int mouseDragStartedY, int horizontalOffset);
     void resetWidth(int width, int horizontalOffset);
     void display(const float* color, int horizontalOffset, float fps, int inPacketsPerSecond, int outPacketsPerSecond,

--- a/libraries/shared/src/PerfStat.cpp
+++ b/libraries/shared/src/PerfStat.cpp
@@ -105,7 +105,7 @@ PerformanceTimer::~PerformanceTimer() {
 }
 
 // static
-bool PerformanceTimer::PerformanceTimer::isActive() {
+bool PerformanceTimer::isActive() {
     return _isActive;
 }
 

--- a/libraries/shared/src/PerfStat.cpp
+++ b/libraries/shared/src/PerfStat.cpp
@@ -79,29 +79,50 @@ void PerformanceTimerRecord::tallyResult(const quint64& now) {
 // PerformanceTimer
 // ----------------------------------------------------------------------------
 
+std::atomic<bool> PerformanceTimer::_isActive(false);
 QHash<QThread*, QString> PerformanceTimer::_fullNames;
 QMap<QString, PerformanceTimerRecord> PerformanceTimer::_records;
 
 
-PerformanceTimer::PerformanceTimer(const QString& name) :
-    _start(0),
-    _name(name) 
-{
-    QString& fullName = _fullNames[QThread::currentThread()];
-    fullName.append("/");
-    fullName.append(_name);
-    _start = usecTimestampNow();
+PerformanceTimer::PerformanceTimer(const QString& name) {
+    if (_isActive) {
+        _name = name;
+        QString& fullName = _fullNames[QThread::currentThread()];
+        fullName.append("/");
+        fullName.append(_name);
+        _start = usecTimestampNow();
+    }
 }
 
 PerformanceTimer::~PerformanceTimer() {
-    quint64 elapsedusec = (usecTimestampNow() - _start);
-    QString& fullName = _fullNames[QThread::currentThread()];
-    PerformanceTimerRecord& namedRecord = _records[fullName];
-    namedRecord.accumulateResult(elapsedusec);
-    fullName.resize(fullName.size() - (_name.size() + 1));
+    if (_isActive && _start != 0) {
+        quint64 elapsedusec = (usecTimestampNow() - _start);
+        QString& fullName = _fullNames[QThread::currentThread()];
+        PerformanceTimerRecord& namedRecord = _records[fullName];
+        namedRecord.accumulateResult(elapsedusec);
+        fullName.resize(fullName.size() - (_name.size() + 1));
+    }
 }
 
-// static 
+// static
+bool PerformanceTimer::PerformanceTimer::isActive() {
+    return _isActive;
+}
+
+// static
+void PerformanceTimer::setActive(bool active) {
+    if (active != _isActive) {
+        _isActive.store(active);
+        if (!active) {
+            _fullNames.clear();
+            _records.clear();
+        }
+        
+        qDebug() << "PerformanceTimer has been turned" << ((active) ? "on" : "off");
+    }
+}
+
+// static
 void PerformanceTimer::tallyAllTimerRecords() {
     QMap<QString, PerformanceTimerRecord>::iterator recordsItr = _records.begin();
     QMap<QString, PerformanceTimerRecord>::const_iterator recordsEnd = _records.end();

--- a/libraries/shared/src/PerfStat.h
+++ b/libraries/shared/src/PerfStat.h
@@ -76,14 +76,18 @@ public:
     PerformanceTimer(const QString& name);
     ~PerformanceTimer();
     
+    static bool isActive();
+    static void setActive(bool active);
+    
     static const PerformanceTimerRecord& getTimerRecord(const QString& name) { return _records[name]; };
     static const QMap<QString, PerformanceTimerRecord>& getAllTimerRecords() { return _records; };
     static void tallyAllTimerRecords();
     static void dumpAllTimerRecords();
 
 private:
-    quint64 _start;
+    quint64 _start = 0;
     QString _name;
+    static std::atomic<bool> _isActive;
     static QHash<QThread*, QString> _fullNames;
     static QMap<QString, PerformanceTimerRecord> _records;
 };

--- a/libraries/shared/src/PerfStat.h
+++ b/libraries/shared/src/PerfStat.h
@@ -19,6 +19,7 @@
 #include "SharedUtil.h"
 #include "SimpleMovingAverage.h"
 
+#include <atomic>
 #include <cstring>
 #include <string>
 #include <map>


### PR DESCRIPTION
The Performance timer makes a lot of Hash look ups and we use it every where.
But we only need it to run at all time, so I changed it to only record when it is displayed.

I tested on my local server and on cafe, I consistently go up about 10-20 fps when it turns off!