### PR TITLE
Add gpu::context to RenderArgs and start using RenderArgs in place of the flags

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3105,7 +3105,7 @@ QImage Application::renderAvatarBillboard() {
     Glower glower;
 
     const int BILLBOARD_SIZE = 64;
-    // TODO: Pass a RenderArgs renderAvatarBillboard
+    // TODO: Pass a RenderArgs to renderAvatarBillboard
     auto lodManager = DependencyManager::get<LODManager>();
     RenderArgs renderArgs(NULL, Application::getInstance()->getViewFrustum(),
                           lodManager->getOctreeSizeScale(),

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -270,7 +270,7 @@ public:
 
     QImage renderAvatarBillboard();
 
-    void displaySide(Camera& whichCamera, bool selfAvatarOnly = false, RenderArgs::RenderSide renderSide = RenderArgs::MONO);
+    void displaySide(RenderArgs& renderArgs, Camera& whichCamera, bool selfAvatarOnly = false);
 
     /// Stores the current modelview matrix as the untranslated view matrix to use for transforms and the supplied vector as
     /// the view matrix translation.
@@ -499,8 +499,8 @@ private:
 
     glm::vec3 getSunDirection();
 
-    void updateShadowMap();
-    void renderRearViewMirror(const QRect& region, bool billboard = false);
+    void updateShadowMap(RenderArgs& renderArgs);
+    void renderRearViewMirror(RenderArgs& renderArgs, const QRect& region, bool billboard = false);
     void setMenuShortcutsEnabled(bool enabled);
 
     static void attachNewHeadToNode(Node *newNode);

--- a/interface/src/devices/OculusManager.cpp
+++ b/interface/src/devices/OculusManager.cpp
@@ -465,7 +465,7 @@ void OculusManager::configureCamera(Camera& camera) {
 }
 
 //Displays everything for the oculus, frame timing must be active
-void OculusManager::display(QGLWidget * glCanvas, const glm::quat &bodyOrientation, const glm::vec3 &position, Camera& whichCamera) {
+void OculusManager::display(QGLWidget * glCanvas, RenderArgs& renderArgs, const glm::quat &bodyOrientation, const glm::vec3 &position, Camera& whichCamera) {
 
 #ifdef DEBUG
     // Ensure the frame counter always increments by exactly 1
@@ -532,7 +532,7 @@ void OculusManager::display(QGLWidget * glCanvas, const glm::quat &bodyOrientati
 
     //Bind our framebuffer object. If we are rendering the glow effect, we let the glow effect shader take care of it
     if (Menu::getInstance()->isOptionChecked(MenuOption::EnableGlowEffect)) {
-        DependencyManager::get<GlowEffect>()->prepare();
+        DependencyManager::get<GlowEffect>()->prepare(renderArgs);
     } else {
         auto primaryFBO = DependencyManager::get<TextureCache>()->getPrimaryFramebuffer();
         glBindFramebuffer(GL_FRAMEBUFFER, gpu::GLBackend::getFramebufferID(primaryFBO));
@@ -613,7 +613,8 @@ void OculusManager::display(QGLWidget * glCanvas, const glm::quat &bodyOrientati
 
         glViewport(vp.Pos.x, vp.Pos.y, vp.Size.w, vp.Size.h);
 
-        qApp->displaySide(*_camera, false, RenderArgs::MONO);
+        renderArgs._renderSide = RenderArgs::MONO;
+        qApp->displaySide(renderArgs, *_camera, false);
         qApp->getApplicationOverlay().displayOverlayTextureHmd(*_camera);
     });
     _activeEye = ovrEye_Count;
@@ -625,7 +626,7 @@ void OculusManager::display(QGLWidget * glCanvas, const glm::quat &bodyOrientati
     if (Menu::getInstance()->isOptionChecked(MenuOption::EnableGlowEffect)) {
         //Full texture viewport for glow effect
         glViewport(0, 0, _renderTargetSize.w, _renderTargetSize.h);
-        finalFbo = DependencyManager::get<GlowEffect>()->render();
+        finalFbo = DependencyManager::get<GlowEffect>()->render(renderArgs);
     } else {
         finalFbo = DependencyManager::get<TextureCache>()->getPrimaryFramebuffer(); 
         glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/interface/src/devices/OculusManager.h
+++ b/interface/src/devices/OculusManager.h
@@ -20,6 +20,8 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include "RenderArgs.h"
+
 class Camera;
 class PalmData;
 class Text3DOverlay;
@@ -61,7 +63,7 @@ public:
     static void endFrameTiming();
     static bool allowSwap();
     static void configureCamera(Camera& camera);
-    static void display(QGLWidget * glCanvas, const glm::quat &bodyOrientation, const glm::vec3 &position, Camera& whichCamera);
+    static void display(QGLWidget * glCanvas, RenderArgs& renderArgs, const glm::quat &bodyOrientation, const glm::vec3 &position, Camera& whichCamera);
     static void reset();
     
     /// param \yaw[out] yaw in radians

--- a/interface/src/devices/TV3DManager.cpp
+++ b/interface/src/devices/TV3DManager.cpp
@@ -80,7 +80,7 @@ void TV3DManager::configureCamera(Camera& whichCamera, int screenWidth, int scre
     glLoadIdentity();
 }
 
-void TV3DManager::display(Camera& whichCamera) {
+void TV3DManager::display(RenderArgs& renderArgs, Camera& whichCamera) {
     double nearZ = DEFAULT_NEAR_CLIP; // near clipping plane
     double farZ = DEFAULT_FAR_CLIP; // far clipping plane
 
@@ -93,7 +93,7 @@ void TV3DManager::display(Camera& whichCamera) {
     int portalH = deviceSize.height();
 
 
-    DependencyManager::get<GlowEffect>()->prepare();
+    DependencyManager::get<GlowEffect>()->prepare(renderArgs);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     Camera eyeCamera;
@@ -118,7 +118,8 @@ void TV3DManager::display(Camera& whichCamera) {
 
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
-        qApp->displaySide(eyeCamera, false, RenderArgs::MONO);
+        renderArgs._renderSide = RenderArgs::MONO;
+        qApp->displaySide(renderArgs, eyeCamera, false);
         qApp->getApplicationOverlay().displayOverlayTextureStereo(whichCamera, _aspect, fov);
         _activeEye = NULL;
     }, [&]{
@@ -128,7 +129,7 @@ void TV3DManager::display(Camera& whichCamera) {
     glPopMatrix();
     glDisable(GL_SCISSOR_TEST);
 
-    auto finalFbo = DependencyManager::get<GlowEffect>()->render();
+    auto finalFbo = DependencyManager::get<GlowEffect>()->render(renderArgs);
     auto fboSize = finalFbo->getSize();
     // Get the ACTUAL device size for the BLIT
     deviceSize = qApp->getDeviceSize();

--- a/interface/src/devices/TV3DManager.h
+++ b/interface/src/devices/TV3DManager.h
@@ -33,7 +33,7 @@ public:
     static void connect();
     static bool isConnected();
     static void configureCamera(Camera& camera, int screenWidth, int screenHeight);
-    static void display(Camera& whichCamera);
+    static void display(RenderArgs& renderArgs, Camera& whichCamera);
     static void overrideOffAxisFrustum(float& left, float& right, float& bottom, float& top, float& nearVal,
         float& farVal, glm::vec4& nearClipPlane, glm::vec4& farClipPlane);
 private:    

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -185,7 +185,7 @@ ApplicationOverlay::~ApplicationOverlay() {
 }
 
 // Renders the overlays either to a texture or to the screen
-void ApplicationOverlay::renderOverlay() {
+void ApplicationOverlay::renderOverlay(const RenderArgs& renderArgs) {
     PerformanceWarning warn(Menu::getInstance()->isOptionChecked(MenuOption::PipelineWarnings), "ApplicationOverlay::displayOverlay()");
     Overlays& overlays = qApp->getOverlays();
     

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -185,7 +185,7 @@ ApplicationOverlay::~ApplicationOverlay() {
 }
 
 // Renders the overlays either to a texture or to the screen
-void ApplicationOverlay::renderOverlay(const RenderArgs& renderArgs) {
+void ApplicationOverlay::renderOverlay(RenderArgs& renderArgs) {
     PerformanceWarning warn(Menu::getInstance()->isOptionChecked(MenuOption::PipelineWarnings), "ApplicationOverlay::displayOverlay()");
     Overlays& overlays = qApp->getOverlays();
     

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -32,7 +32,7 @@ public:
     ApplicationOverlay();
     ~ApplicationOverlay();
 
-    void renderOverlay(const RenderArgs& renderArgs);
+    void renderOverlay(RenderArgs& renderArgs);
     void displayOverlayTexture();
     void displayOverlayTextureStereo(Camera& whichCamera, float aspectRatio, float fov);
     void displayOverlayTextureHmd(Camera& whichCamera);

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -32,7 +32,7 @@ public:
     ApplicationOverlay();
     ~ApplicationOverlay();
 
-    void renderOverlay();
+    void renderOverlay(const RenderArgs& renderArgs);
     void displayOverlayTexture();
     void displayOverlayTextureStereo(Camera& whichCamera, float aspectRatio, float fov);
     void displayOverlayTextureHmd(Camera& whichCamera);

--- a/interface/src/ui/overlays/LocalModelsOverlay.cpp
+++ b/interface/src/ui/overlays/LocalModelsOverlay.cpp
@@ -47,7 +47,7 @@ void LocalModelsOverlay::render(RenderArgs* args) {
             Application* app = Application::getInstance();
             glm::vec3 oldTranslation = app->getViewMatrixTranslation();
             app->setViewMatrixTranslation(oldTranslation + _position);
-            _entityTreeRenderer->render();
+            _entityTreeRenderer->render(*args);
             Application::getInstance()->setViewMatrixTranslation(oldTranslation);
         } glPopMatrix();
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -58,9 +58,7 @@ public:
     void processEraseMessage(const QByteArray& dataByteArray, const SharedNodePointer& sourceNode);
 
     virtual void init();
-    virtual void render(RenderArgs::RenderMode renderMode = RenderArgs::DEFAULT_RENDER_MODE, 
-                        RenderArgs::RenderSide renderSide = RenderArgs::MONO,
-                        RenderArgs::DebugFlags renderDebugFlags = RenderArgs::RENDER_DEBUG_NONE);
+    virtual void render(RenderArgs& renderArgs) override;
 
     virtual const FBXGeometry* getGeometryForEntity(const EntityItem* entityItem);
     virtual const Model* getModelForEntityItem(const EntityItem* entityItem);

--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
@@ -11,6 +11,7 @@
 
 #include <glm/gtx/quaternion.hpp>
 
+#include <gpu/GLBackend.h>
 #include <gpu/GPUConfig.h>
 #include <gpu/Batch.h>
 
@@ -44,6 +45,7 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
     } else {
         DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(batch, 1.0f, cubeColor);
     }
+    args->_context->enqueueBatch(batch);
 
     RenderableDebugableEntityItem::render(this, args);
 };

--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
@@ -11,7 +11,6 @@
 
 #include <glm/gtx/quaternion.hpp>
 
-#include <gpu/GLBackend.h>
 #include <gpu/GPUConfig.h>
 #include <gpu/Batch.h>
 
@@ -45,7 +44,6 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
     } else {
         DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(batch, 1.0f, cubeColor);
     }
-    args->_context->enqueueBatch(batch);
 
     RenderableDebugableEntityItem::render(this, args);
 };

--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -15,9 +15,22 @@
 
 using namespace gpu;
 
+Context::Context() {
+}
+
+Context::Context(const Context& context) {
+}
+
+Context::~Context() {
+}
+
 bool Context::makeProgram(Shader& shader, const Shader::BindingSet& bindings) {
     if (shader.isProgram()) {
         return GLBackend::makeProgram(shader, bindings);
     }
     return false;
+}
+
+void Context::enqueueBatch(Batch& batch) {
+    GLBackend::renderBatch(batch);
 }

--- a/libraries/octree/src/OctreeHeadlessViewer.h
+++ b/libraries/octree/src/OctreeHeadlessViewer.h
@@ -33,9 +33,7 @@ public:
     virtual void renderElement(OctreeElement* element, RenderArgs* args) { /* swallow these */ }
 
     virtual void init();
-    virtual void render(RenderArgs::RenderMode renderMode = RenderArgs::DEFAULT_RENDER_MODE,
-                        RenderArgs::RenderSide renderSide = RenderArgs::MONO,
-                        RenderArgs::DebugFlags renderDebugFlags = RenderArgs::RENDER_DEBUG_NONE) { /* swallow these */ }
+    virtual void render(RenderArgs& renderArgs) override { /* swallow these */ }
 
     void setJurisdictionListener(JurisdictionListener* jurisdictionListener) { _jurisdictionListener = jurisdictionListener; }
 

--- a/libraries/octree/src/OctreeRenderer.cpp
+++ b/libraries/octree/src/OctreeRenderer.cpp
@@ -164,32 +164,29 @@ bool OctreeRenderer::renderOperation(OctreeElement* element, void* extraData) {
     return false;
 }
 
-void OctreeRenderer::render(RenderArgs::RenderMode renderMode,
-                            RenderArgs::RenderSide renderSide,
-                            RenderArgs::DebugFlags renderDebugFlags) {
-    RenderArgs args(this, _viewFrustum, getSizeScale(), getBoundaryLevelAdjust(),
-                    renderMode, renderSide, renderDebugFlags);
+void OctreeRenderer::render(RenderArgs& renderArgs) {
     if (_tree) {
+        renderArgs._renderer = this;
         _tree->lockForRead();
-        _tree->recurseTreeWithOperation(renderOperation, &args);
+        _tree->recurseTreeWithOperation(renderOperation, &renderArgs);
         _tree->unlock();
     }
-    _meshesConsidered = args._meshesConsidered;
-    _meshesRendered = args._meshesRendered;
-    _meshesOutOfView = args._meshesOutOfView;
-    _meshesTooSmall = args._meshesTooSmall;
+    _meshesConsidered = renderArgs._meshesConsidered;
+    _meshesRendered = renderArgs._meshesRendered;
+    _meshesOutOfView = renderArgs._meshesOutOfView;
+    _meshesTooSmall = renderArgs._meshesTooSmall;
 
-    _elementsTouched = args._elementsTouched;
-    _itemsRendered = args._itemsRendered;
-    _itemsOutOfView = args._itemsOutOfView;
-    _itemsTooSmall = args._itemsTooSmall;
+    _elementsTouched = renderArgs._elementsTouched;
+    _itemsRendered = renderArgs._itemsRendered;
+    _itemsOutOfView = renderArgs._itemsOutOfView;
+    _itemsTooSmall = renderArgs._itemsTooSmall;
 
-    _materialSwitches = args._materialSwitches;
-    _trianglesRendered = args._trianglesRendered;
-    _quadsRendered = args._quadsRendered;
+    _materialSwitches = renderArgs._materialSwitches;
+    _trianglesRendered = renderArgs._trianglesRendered;
+    _quadsRendered = renderArgs._quadsRendered;
 
-    _translucentMeshPartsRendered = args._translucentMeshPartsRendered;
-    _opaqueMeshPartsRendered = args._opaqueMeshPartsRendered;
+    _translucentMeshPartsRendered = renderArgs._translucentMeshPartsRendered;
+    _opaqueMeshPartsRendered = renderArgs._opaqueMeshPartsRendered;
 
 }
 

--- a/libraries/octree/src/OctreeRenderer.h
+++ b/libraries/octree/src/OctreeRenderer.h
@@ -51,9 +51,7 @@ public:
     virtual void init();
 
     /// render the content of the octree
-    virtual void render(RenderArgs::RenderMode renderMode = RenderArgs::DEFAULT_RENDER_MODE, 
-                        RenderArgs::RenderSide renderSide = RenderArgs::MONO,
-                        RenderArgs::DebugFlags renderDebugFlags = RenderArgs::RENDER_DEBUG_NONE);
+    virtual void render(RenderArgs& renderArgs);
 
     ViewFrustum* getViewFrustum() const { return _viewFrustum; }
     void setViewFrustum(ViewFrustum* viewFrustum) { _viewFrustum = viewFrustum; }

--- a/libraries/render-utils/src/GlowEffect.cpp
+++ b/libraries/render-utils/src/GlowEffect.cpp
@@ -94,7 +94,7 @@ void GlowEffect::init(bool enabled) {
     _enabled = enabled;
 }
 
-void GlowEffect::prepare(const RenderArgs& renderArgs) {
+void GlowEffect::prepare(RenderArgs& renderArgs) {
     auto primaryFBO = DependencyManager::get<TextureCache>()->getPrimaryFramebuffer();
     GLuint fbo = gpu::GLBackend::getFramebufferID(primaryFBO);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
@@ -117,7 +117,7 @@ void GlowEffect::end() {
     glBlendColor(0.0f, 0.0f, 0.0f, _intensity = _intensityStack.pop());
 }
 
-gpu::FramebufferPointer GlowEffect::render(const RenderArgs& renderArgs) {
+gpu::FramebufferPointer GlowEffect::render(RenderArgs& renderArgs) {
     PerformanceTimer perfTimer("glowEffect");
 
     auto textureCache = DependencyManager::get<TextureCache>();

--- a/libraries/render-utils/src/GlowEffect.cpp
+++ b/libraries/render-utils/src/GlowEffect.cpp
@@ -94,7 +94,7 @@ void GlowEffect::init(bool enabled) {
     _enabled = enabled;
 }
 
-void GlowEffect::prepare() {
+void GlowEffect::prepare(const RenderArgs& renderArgs) {
     auto primaryFBO = DependencyManager::get<TextureCache>()->getPrimaryFramebuffer();
     GLuint fbo = gpu::GLBackend::getFramebufferID(primaryFBO);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
@@ -117,7 +117,7 @@ void GlowEffect::end() {
     glBlendColor(0.0f, 0.0f, 0.0f, _intensity = _intensityStack.pop());
 }
 
-gpu::FramebufferPointer GlowEffect::render() {
+gpu::FramebufferPointer GlowEffect::render(const RenderArgs& renderArgs) {
     PerformanceTimer perfTimer("glowEffect");
 
     auto textureCache = DependencyManager::get<TextureCache>();

--- a/libraries/render-utils/src/GlowEffect.h
+++ b/libraries/render-utils/src/GlowEffect.h
@@ -39,7 +39,7 @@ public:
     void init(bool enabled);
     
     /// Prepares the glow effect for rendering the current frame.  To be called before rendering the scene.
-    void prepare(const RenderArgs& renderArgs);
+    void prepare(RenderArgs& renderArgs);
     
     /// Starts using the glow effect.
     /// \param intensity the desired glow intensity, from zero to one
@@ -54,7 +54,7 @@ public:
     /// Renders the glow effect.  To be called after rendering the scene.
     /// \param toTexture whether to render to a texture, rather than to the frame buffer
     /// \return the framebuffer object to which we rendered, or NULL if to the frame buffer
-    gpu::FramebufferPointer render(const RenderArgs& renderArgs);
+    gpu::FramebufferPointer render(RenderArgs& renderArgs);
 
 public slots:
     void toggleGlowEffect(bool enabled);

--- a/libraries/render-utils/src/GlowEffect.h
+++ b/libraries/render-utils/src/GlowEffect.h
@@ -15,6 +15,8 @@
 #include <gpu/GPUConfig.h>
 #include <gpu/Framebuffer.h>
 
+#include "RenderArgs.h"
+
 #include <QObject>
 #include <QGLWidget>
 #include <QStack>
@@ -37,7 +39,7 @@ public:
     void init(bool enabled);
     
     /// Prepares the glow effect for rendering the current frame.  To be called before rendering the scene.
-    void prepare();
+    void prepare(const RenderArgs& renderArgs);
     
     /// Starts using the glow effect.
     /// \param intensity the desired glow intensity, from zero to one
@@ -52,7 +54,7 @@ public:
     /// Renders the glow effect.  To be called after rendering the scene.
     /// \param toTexture whether to render to a texture, rather than to the frame buffer
     /// \return the framebuffer object to which we rendered, or NULL if to the frame buffer
-    gpu::FramebufferPointer render();
+    gpu::FramebufferPointer render(const RenderArgs& renderArgs);
 
 public slots:
     void toggleGlowEffect(bool enabled);

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -16,6 +16,7 @@ class ViewFrustum;
 class OctreeRenderer;
 namespace gpu {
 class Batch;
+class Context;
 }
 
 class RenderArgs {
@@ -38,6 +39,7 @@ public:
                RenderSide renderSide = MONO,
                DebugFlags debugFlags = RENDER_DEBUG_NONE,
                gpu::Batch* batch = nullptr,
+               gpu::Context* context = nullptr,
                
                int elementsTouched = 0,
                int itemsRendered = 0,
@@ -90,6 +92,7 @@ public:
     RenderSide _renderSide;
     DebugFlags _debugFlags;
     gpu::Batch* _batch;
+    gpu::Context* _context;
 
     int _elementsTouched;
     int _itemsRendered;


### PR DESCRIPTION
I originally replaced cases where Render* flags was being used with a single RenderArgs object (w/ the gpu::Context) but ran into issues in several cases where gl calls were being made outside of the render loop (in the step/update loop, for instance).  I ended up dropping several of those (MyAvatar::maybeUpdateBillboard() is one such case).