### PR TITLE
entity-server sends initial planky more reliably

### DIFF
--- a/assignment-client/src/octree/OctreeQueryNode.cpp
+++ b/assignment-client/src/octree/OctreeQueryNode.cpp
@@ -325,8 +325,7 @@ void OctreeQueryNode::updateLastKnownViewFrustum() {
     }
 
     // save that we know the view has been sent.
-    quint64 now = usecTimestampNow();
-    setLastTimeBagEmpty(now); // is this what we want? poor names
+    setLastTimeBagEmpty();
 }
 
 

--- a/assignment-client/src/octree/OctreeQueryNode.h
+++ b/assignment-client/src/octree/OctreeQueryNode.h
@@ -77,7 +77,7 @@ public:
     bool moveShouldDump() const;
 
     quint64 getLastTimeBagEmpty() const { return _lastTimeBagEmpty; }
-    void setLastTimeBagEmpty(quint64 lastTimeBagEmpty) { _lastTimeBagEmpty = lastTimeBagEmpty; }
+    void setLastTimeBagEmpty() { _lastTimeBagEmpty = _sceneSendStartTime; }
 
     bool getCurrentPacketIsColor() const { return _currentPacketIsColor; }
     bool getCurrentPacketIsCompressed() const { return _currentPacketIsCompressed; }
@@ -98,6 +98,8 @@ public:
     void setLastRootTimestamp(quint64 timestamp) { _lastRootTimestamp = timestamp; }
     unsigned int getlastOctreePacketLength() const { return _lastOctreePacketLength; }
     int getDuplicatePacketCount() const { return _duplicatePacketCount; }
+
+    void sceneStart(quint64 sceneSendStartTime) { _sceneSendStartTime = sceneSendStartTime; }
     
     void nodeKilled();
     void forceNodeShutdown();
@@ -158,6 +160,8 @@ private:
 
     SentPacketHistory _sentPacketHistory;
     QQueue<OCTREE_PACKET_SEQUENCE> _nackedSequenceNumbers;
+
+    quint64 _sceneSendStartTime = 0;
 };
 
 #endif // hifi_OctreeQueryNode_h

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -563,7 +563,8 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
 
 
         if (somethingToSend) {
-            qDebug() << "Hit PPS Limit";
+            qDebug() << "Hit PPS Limit, packetsSentThisInterval =" << packetsSentThisInterval
+                     << "  maxPacketsPerInterval = " << maxPacketsPerInterval;
         }
 
 

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -564,7 +564,8 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
 
         if (somethingToSend) {
             qDebug() << "Hit PPS Limit, packetsSentThisInterval =" << packetsSentThisInterval
-                     << "  maxPacketsPerInterval = " << maxPacketsPerInterval;
+                     << "  maxPacketsPerInterval = " << maxPacketsPerInterval
+                     << "  clientMaxPacketsPerInterval = " << clientMaxPacketsPerInterval;
         }
 
 

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -343,8 +343,7 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
 
         if (!viewFrustumChanged && !nodeData->getWantDelta()) {
             // only set our last sent time if we weren't resetting due to frustum change
-            quint64 now = usecTimestampNow();
-            nodeData->setLastTimeBagEmpty(now);
+            nodeData->setLastTimeBagEmpty();
         }
 
         // track completed scenes and send out the stats packet accordingly
@@ -368,9 +367,11 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
 
         // TODO: add these to stats page
         //::startSceneSleepTime = _usleepTime;
-        
+
+        nodeData->sceneStart(usecTimestampNow() - CHANGE_FUDGE);
         // start tracking our stats
-        nodeData->stats.sceneStarted(isFullScene, viewFrustumChanged, _myServer->getOctree()->getRoot(), _myServer->getJurisdiction());
+        nodeData->stats.sceneStarted(isFullScene, viewFrustumChanged,
+                                     _myServer->getOctree()->getRoot(), _myServer->getJurisdiction());
 
         // This is the start of "resending" the scene.
         bool dontRestartSceneOnMove = false; // this is experimental
@@ -558,6 +559,11 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
             quint64 endInside = usecTimestampNow();
             quint64 elapsedInsideUsecs = endInside - startInside;
             OctreeServer::trackInsideTime((float)elapsedInsideUsecs);
+        }
+
+
+        if (somethingToSend) {
+            qDebug() << "Hit PPS Limit";
         }
 
 


### PR DESCRIPTION
adjust logic used by the entity-server to decide if the contents of an octree-element have already been sent to a particular interface with a particular frustum