### PR TITLE
Entity events in normal scripts

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1198,7 +1198,7 @@ void EntityTreeRenderer::entityCollisionWithEntity(const EntityItemID& idA, cons
         entityScriptA.property("collisionWithEntity").call(entityScriptA, args);
     }
 
-    emit collisionWithEntity(idB, idB, collision);
+    emit collisionWithEntity(idB, idA, collision);
     QScriptValue entityScriptB = loadEntityScript(idB);
     if (entityScriptB.property("collisionWithEntity").isValid()) {
         QScriptValueList args;

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -874,22 +874,6 @@ void EntityTreeRenderer::connectSignalsToSlots(EntityScriptingInterface* entityS
     connect(this, &EntityTreeRenderer::enterEntity, entityScriptingInterface, &EntityScriptingInterface::enterEntity);
     connect(this, &EntityTreeRenderer::leaveEntity, entityScriptingInterface, &EntityScriptingInterface::leaveEntity);
     connect(this, &EntityTreeRenderer::collisionWithEntity, entityScriptingInterface, &EntityScriptingInterface::collisionWithEntity);
-
-    connect(entityScriptingInterface, &EntityScriptingInterface::addEntityEventHandler, this, &EntityTreeRenderer::addEntityEventHandler);
-    connect(entityScriptingInterface, &EntityScriptingInterface::removeEntityEventHandler, this, &EntityTreeRenderer::addEntityEventHandler);
-}
-
-void EntityTreeRenderer::addEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
-    ScriptEngine* engine = static_cast<ScriptEngine*>(handler.engine());
-    if (engine) { // In case it's gone by the time we get the signal
-        engine->addEntityEventHandler(entityID, entityEventName, handler);
-    }
-}
-void EntityTreeRenderer::removeEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
-    ScriptEngine* engine = static_cast<ScriptEngine*>(handler.engine());
-    if (engine) {
-        engine->removeEntityEventHandler(entityID, entityEventName, handler);
-    }
 }
 
 QScriptValueList EntityTreeRenderer::createMouseEventArgs(const EntityItemID& entityID, QMouseEvent* event, unsigned int deviceID) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -113,7 +113,6 @@ void EntityTreeRenderer::init() {
     connect(entityTree, &EntityTree::deletingEntity, this, &EntityTreeRenderer::deletingEntity);
     connect(entityTree, &EntityTree::addingEntity, this, &EntityTreeRenderer::addingEntity);
     connect(entityTree, &EntityTree::entityScriptChanging, this, &EntityTreeRenderer::entitySciptChanging);
-    connect(entityTree, &EntityTree::changingEntityID, this, &EntityTreeRenderer::changingEntityID);
 }
 
 void EntityTreeRenderer::shutdown() {
@@ -1101,14 +1100,6 @@ void EntityTreeRenderer::checkAndCallUnload(const EntityItemID& entityID) {
     }
 }
 
-
-void EntityTreeRenderer::changingEntityID(const EntityItemID& oldEntityID, const EntityItemID& newEntityID) {
-    if (_entityScripts.contains(oldEntityID)) {
-        EntityScriptDetails details = _entityScripts[oldEntityID];
-        _entityScripts.remove(oldEntityID);
-        _entityScripts[newEntityID] = details;
-    }
-}
 
 void EntityTreeRenderer::playEntityCollisionSound(const QUuid& myNodeID, EntityTree* entityTree, const EntityItemID& id, const Collision& collision) {
     EntityItem* entity = entityTree->findEntityByEntityItemID(id);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -121,7 +121,7 @@ public slots:
     void setDisplayModelBounds(bool value) { _displayModelBounds = value; }
     void setDisplayModelElementProxy(bool value) { _displayModelElementProxy = value; }
     void setDontDoPrecisionPicking(bool value) { _dontDoPrecisionPicking = value; }
-
+    
 protected:
     virtual Octree* createTree() { return new EntityTree(true); }
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -107,6 +107,7 @@ signals:
 
     void enterEntity(const EntityItemID& entityItemID);
     void leaveEntity(const EntityItemID& entityItemID);
+    void collisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 public slots:
     void addingEntity(const EntityItemID& entityID);
@@ -121,6 +122,9 @@ public slots:
     void setDisplayModelElementProxy(bool value) { _displayModelElementProxy = value; }
     void setDontDoPrecisionPicking(bool value) { _dontDoPrecisionPicking = value; }
     
+    void addEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
+    void removeEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
+
 protected:
     virtual Octree* createTree() { return new EntityTree(true); }
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -121,9 +121,6 @@ public slots:
     void setDisplayModelBounds(bool value) { _displayModelBounds = value; }
     void setDisplayModelElementProxy(bool value) { _displayModelElementProxy = value; }
     void setDontDoPrecisionPicking(bool value) { _dontDoPrecisionPicking = value; }
-    
-    void addEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
-    void removeEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
 
 protected:
     virtual Octree* createTree() { return new EntityTree(true); }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -112,7 +112,6 @@ signals:
 public slots:
     void addingEntity(const EntityItemID& entityID);
     void deletingEntity(const EntityItemID& entityID);
-    void changingEntityID(const EntityItemID& oldEntityID, const EntityItemID& newEntityID);
     void entitySciptChanging(const EntityItemID& entityID);
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -46,7 +46,6 @@ void EntityScriptingInterface::setEntityTree(EntityTree* modelTree) {
     if (_entityTree) {
         disconnect(_entityTree, &EntityTree::addingEntity, this, &EntityScriptingInterface::addingEntity);
         disconnect(_entityTree, &EntityTree::deletingEntity, this, &EntityScriptingInterface::deletingEntity);
-        disconnect(_entityTree, &EntityTree::changingEntityID, this, &EntityScriptingInterface::changingEntityID);
         disconnect(_entityTree, &EntityTree::clearingEntities, this, &EntityScriptingInterface::clearingEntities);
     }
 
@@ -55,7 +54,6 @@ void EntityScriptingInterface::setEntityTree(EntityTree* modelTree) {
     if (_entityTree) {
         connect(_entityTree, &EntityTree::addingEntity, this, &EntityScriptingInterface::addingEntity);
         connect(_entityTree, &EntityTree::deletingEntity, this, &EntityScriptingInterface::deletingEntity);
-        connect(_entityTree, &EntityTree::changingEntityID, this, &EntityScriptingInterface::changingEntityID);
         connect(_entityTree, &EntityTree::clearingEntities, this, &EntityScriptingInterface::clearingEntities);
     }
 }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -18,6 +18,7 @@
 #include "ZoneEntityItem.h"
 #include "EntitiesLogging.h"
 
+
 EntityScriptingInterface::EntityScriptingInterface() :
     _entityTree(NULL)
 {

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -47,6 +47,7 @@ void EntityScriptingInterface::setEntityTree(EntityTree* modelTree) {
     if (_entityTree) {
         disconnect(_entityTree, &EntityTree::addingEntity, this, &EntityScriptingInterface::addingEntity);
         disconnect(_entityTree, &EntityTree::deletingEntity, this, &EntityScriptingInterface::deletingEntity);
+        disconnect(_entityTree, &EntityTree::changingEntityID, this, &EntityScriptingInterface::changingEntityID);
         disconnect(_entityTree, &EntityTree::clearingEntities, this, &EntityScriptingInterface::clearingEntities);
     }
 
@@ -55,6 +56,7 @@ void EntityScriptingInterface::setEntityTree(EntityTree* modelTree) {
     if (_entityTree) {
         connect(_entityTree, &EntityTree::addingEntity, this, &EntityScriptingInterface::addingEntity);
         connect(_entityTree, &EntityTree::deletingEntity, this, &EntityScriptingInterface::deletingEntity);
+        connect(_entityTree, &EntityTree::changingEntityID, this, &EntityScriptingInterface::changingEntityID);
         connect(_entityTree, &EntityTree::clearingEntities, this, &EntityScriptingInterface::clearingEntities);
     }
 }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -201,6 +201,13 @@ void EntityScriptingInterface::dumpTree() const {
     }
 }
 
+void EntityScriptingInterface::addEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
+    emit addEntityEventHandler(entityID, entityEventName, handler);
+}
+void EntityScriptingInterface::removeEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
+    emit removeEntityEventHandler(entityID, entityEventName, handler);
+}
+
 QVector<QUuid> EntityScriptingInterface::findEntities(const glm::vec3& center, float radius) const {
     QVector<QUuid> result;
     if (_entityTree) {

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -17,8 +17,6 @@
 #include "ModelEntityItem.h"
 #include "ZoneEntityItem.h"
 #include "EntitiesLogging.h"
-#include "../../script-engine/src/ScriptEngine.h" // FIXME
-
 
 EntityScriptingInterface::EntityScriptingInterface() :
     _entityTree(NULL)
@@ -201,19 +199,6 @@ void EntityScriptingInterface::dumpTree() const {
         _entityTree->lockForRead();
         _entityTree->dumpTree();
         _entityTree->unlock();
-    }
-}
-
-void EntityScriptingInterface::addEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
-    ScriptEngine* engine = static_cast<ScriptEngine*>(handler.engine());
-    if (engine) { // In case it's gone by the time we get the signal
-        engine->addEntityEventHandler(entityID, entityEventName, handler);
-    }
-}
-void EntityScriptingInterface::removeEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
-    ScriptEngine* engine = static_cast<ScriptEngine*>(handler.engine());
-    if (engine) {
-        engine->removeEntityEventHandler(entityID, entityEventName, handler);
     }
 }
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -17,6 +17,7 @@
 #include "ModelEntityItem.h"
 #include "ZoneEntityItem.h"
 #include "EntitiesLogging.h"
+#include "../../script-engine/src/ScriptEngine.h" // FIXME
 
 
 EntityScriptingInterface::EntityScriptingInterface() :
@@ -202,10 +203,16 @@ void EntityScriptingInterface::dumpTree() const {
 }
 
 void EntityScriptingInterface::addEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
-    emit addEntityEventHandler(entityID, entityEventName, handler);
+    ScriptEngine* engine = static_cast<ScriptEngine*>(handler.engine());
+    if (engine) { // In case it's gone by the time we get the signal
+        engine->addEntityEventHandler(entityID, entityEventName, handler);
+    }
 }
 void EntityScriptingInterface::removeEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler) {
-    emit removeEntityEventHandler(entityID, entityEventName, handler);
+    ScriptEngine* engine = static_cast<ScriptEngine*>(handler.engine());
+    if (engine) {
+        engine->removeEntityEventHandler(entityID, entityEventName, handler);
+    }
 }
 
 QVector<QUuid> EntityScriptingInterface::findEntities(const glm::vec3& center, float radius) const {

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -119,14 +119,7 @@ public slots:
 
     Q_INVOKABLE void dumpTree() const;
 
-    // Register a function that will handle the given entityEventName on entityID
-    Q_INVOKABLE void addEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
-    Q_INVOKABLE void removeEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
-
 signals:
-    void addEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
-    void removeEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
-
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
     void collisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -119,8 +119,16 @@ public slots:
 
     Q_INVOKABLE void dumpTree() const;
 
+    // Register a function that will handle the given entityEventName on entityID
+    Q_INVOKABLE void addEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
+    Q_INVOKABLE void removeEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
+
 signals:
+    void addEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
+    void removeEntityEventHandler(EntityItemID entityID, QString entityEventName, QScriptValue handler);
+
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
+    void collisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
     void canAdjustLocksChanged(bool canAdjustLocks);
     void canRezChanged(bool canRez);

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -143,7 +143,6 @@ signals:
 
     void deletingEntity(const EntityItemID& entityID);
     void addingEntity(const EntityItemID& entityID);
-    void changingEntityID(const EntityItemID& oldEntityID, const EntityItemID& newEntityID);
     void clearingEntities();
 
 private:

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -150,6 +150,7 @@ signals:
 
     void deletingEntity(const EntityItemID& entityID);
     void addingEntity(const EntityItemID& entityID);
+    void changingEntityID(const EntityItemID& oldEntityID, const EntityItemID& newEntityID);
     void clearingEntities();
 
 private:

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -171,7 +171,6 @@ signals:
     void deletingEntity(const EntityItemID& entityID);
     void addingEntity(const EntityItemID& entityID);
     void entityScriptChanging(const EntityItemID& entityItemID);
-    void changingEntityID(const EntityItemID& oldEntityID, const EntityItemID& newEntityID);
     void clearingEntities();
 
 private:

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -434,16 +434,16 @@ void ScriptEngine::addEventHandler(const EntityItemID& entityID, const QString& 
                 });
         
         // Two common cases of event handler, differing only in argument signature.
-        auto makeSingleEntityHandler = [=](const QString& eventName) {
-            return [=](const EntityItemID& entityItemID) {
-                generalHandler(entityItemID, eventName, [=]() {
+        auto makeSingleEntityHandler = [=](const QString& eventName) -> std::function<void(const EntityItemID&)> {
+            return [=](const EntityItemID& entityItemID) -> void {
+                generalHandler(entityItemID, eventName, [=]() -> QScriptValueList {
                     return QScriptValueList() << entityItemID.toScriptValue(this);
                 });
             };
         };
-        auto makeMouseHandler = [=](const QString& eventName) {
-            return [=](const EntityItemID& entityItemID, const MouseEvent& event) {
-                generalHandler(entityItemID, eventName, [=]() {
+        auto makeMouseHandler = [=](const QString& eventName) -> std::function<void(const EntityItemID&, const MouseEvent&)>  {
+            return [=](const EntityItemID& entityItemID, const MouseEvent& event) -> void {
+                generalHandler(entityItemID, eventName, [=]() -> QScriptValueList {
                     return QScriptValueList() << entityItemID.toScriptValue(this) << event.toScriptValue(this);
                 });
             };

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -404,7 +404,7 @@ void ScriptEngine::generalHandler(const EntityItemID& entityID, const QString& e
     }
 }
 // Unregister the handlers for this eventName and entityID.
-void ScriptEngine::removeEntityEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler) {
+void ScriptEngine::removeEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler) {
     if (!_registeredHandlers.contains(entityID)) return;
     RegisteredEventHandlers& handlersOnEntity = _registeredHandlers[entityID];
     QScriptValueList& handlersForEvent = handlersOnEntity[eventName];
@@ -417,7 +417,7 @@ void ScriptEngine::removeEntityEventHandler(const EntityItemID& entityID, const 
     }
 }
 // Register the handler.
-void ScriptEngine::addEntityEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler) {
+void ScriptEngine::addEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler) {
     if (_registeredHandlers.count() == 0) { // First time any per-entity handler has been added in this script...
         // Connect up ALL the handlers to the global entities object's signals.
         // (We could go signal by signal, or even handler by handler, but I don't think the efficiency is worth the complexity.)

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -394,7 +394,6 @@ void ScriptEngine::generalHandler(const EntityItemID& entityID, const QString& e
     if (!_registeredHandlers.contains(entityID)) return;
     const RegisteredEventHandlers& handlersOnEntity = _registeredHandlers[entityID];
     if (!handlersOnEntity.contains(eventName)) return;
-    // FIXME: Need one more level of indirection. We need to allow multiple handlers per event, registered by different scripts.
     QScriptValueList handlersForEvent = handlersOnEntity[eventName];
     if (!handlersForEvent.isEmpty()) {
         QScriptValueList args = argGenerator();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -391,9 +391,13 @@ void ScriptEngine::registerGetterSetter(const QString& name, QScriptEngine::Func
 
 // Look up the handler associated with eventName and entityID. If found, evalute the argGenerator thunk and call the handler with those args
 void ScriptEngine::generalHandler(const EntityItemID& entityID, const QString& eventName, std::function<QScriptValueList()> argGenerator) {
-    if (!_registeredHandlers.contains(entityID)) return;
+    if (!_registeredHandlers.contains(entityID)) {
+        return;
+    }
     const RegisteredEventHandlers& handlersOnEntity = _registeredHandlers[entityID];
-    if (!handlersOnEntity.contains(eventName)) return;
+    if (!handlersOnEntity.contains(eventName)) {
+        return;
+    }
     QScriptValueList handlersForEvent = handlersOnEntity[eventName];
     if (!handlersForEvent.isEmpty()) {
         QScriptValueList args = argGenerator();
@@ -404,7 +408,9 @@ void ScriptEngine::generalHandler(const EntityItemID& entityID, const QString& e
 }
 // Unregister the handlers for this eventName and entityID.
 void ScriptEngine::removeEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler) {
-    if (!_registeredHandlers.contains(entityID)) return;
+    if (!_registeredHandlers.contains(entityID)) {
+        return;
+    }
     RegisteredEventHandlers& handlersOnEntity = _registeredHandlers[entityID];
     QScriptValueList& handlersForEvent = handlersOnEntity[eventName];
     // QScriptValue does not have operator==(), so we can't use QList::removeOne and friends. So iterate.

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -426,12 +426,6 @@ void ScriptEngine::addEventHandler(const EntityItemID& entityID, const QString& 
                 [=](const EntityItemID& entityID) {
                     _registeredHandlers.remove(entityID);
                 });
-        connect(entities.data(), &EntityScriptingInterface::changingEntityID, this,
-                [=](const EntityItemID& oldEntityID, const EntityItemID& newEntityID) {
-                    if (!_registeredHandlers.contains(oldEntityID)) return;
-                    _registeredHandlers[newEntityID] = _registeredHandlers[oldEntityID];
-                    _registeredHandlers.remove(oldEntityID);
-                });
         
         // Two common cases of event handler, differing only in argument signature.
         auto makeSingleEntityHandler = [=](const QString& eventName) -> std::function<void(const EntityItemID&)> {

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -23,6 +23,7 @@
 #include <AvatarData.h>
 #include <AvatarHashMap.h>
 #include <LimitedNodeList.h>
+#include <EntityItemID.h>
 
 #include "AbstractControllerScriptingInterface.h"
 #include "ArrayBufferClass.h"
@@ -31,7 +32,6 @@
 #include "ScriptCache.h"
 #include "ScriptUUID.h"
 #include "Vec3.h"
-#include "../../entities/src/EntityItem.h" // FIXME
 
 const QString NO_SCRIPT("");
 
@@ -101,8 +101,8 @@ public:
     virtual void scriptContentsAvailable(const QUrl& url, const QString& scriptContents);
     virtual void errorInLoadingScript(const QUrl& url);
 
-    void addEntityEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler);
-    void removeEntityEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler);
+    Q_INVOKABLE void addEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler);
+    Q_INVOKABLE void removeEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler);
 
 public slots:
     void loadURL(const QUrl& scriptURL);

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -31,7 +31,7 @@
 #include "ScriptCache.h"
 #include "ScriptUUID.h"
 #include "Vec3.h"
-#include "EntityItemID.h"
+#include "../../entities/src/EntityItem.h" // FIXME
 
 const QString NO_SCRIPT("");
 
@@ -120,7 +120,6 @@ public slots:
     QUrl resolvePath(const QString& path) const;
 
     void nodeKilled(SharedNodePointer node);
-    void collisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 signals:
     void scriptLoaded(const QString& scriptFilename);
@@ -172,6 +171,8 @@ private:
 
     QHash<QUuid, quint16> _outgoingScriptAudioSequenceNumbers;
     QHash<EntityItemID, RegisteredEventHandlers> _registeredHandlers;
+    QScriptValue _illegal;
+    QScriptValue getEntityEventHandler(const EntityItemID& entityID, const QString& eventName);
 
 private:
     static QSet<ScriptEngine*> _allKnownScriptEngines;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -171,8 +171,7 @@ private:
 
     QHash<QUuid, quint16> _outgoingScriptAudioSequenceNumbers;
     QHash<EntityItemID, RegisteredEventHandlers> _registeredHandlers;
-    QScriptValue _illegal;
-    QScriptValue getEntityEventHandler(const EntityItemID& entityID, const QString& eventName);
+    void generalHandler(const EntityItemID& entityID, const QString& eventName, std::function<QScriptValueList()> argGenerator);
 
 private:
     static QSet<ScriptEngine*> _allKnownScriptEngines;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -37,7 +37,7 @@ const QString NO_SCRIPT("");
 
 const unsigned int SCRIPT_DATA_CALLBACK_USECS = floor(((1.0 / 60.0f) * 1000 * 1000) + 0.5);
 
-typedef QHash<QString, QScriptValue> RegisteredEventHandlers;
+typedef QHash<QString, QScriptValueList> RegisteredEventHandlers;
 
 class ScriptEngine : public QScriptEngine, public ScriptUser {
     Q_OBJECT

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -31,10 +31,13 @@
 #include "ScriptCache.h"
 #include "ScriptUUID.h"
 #include "Vec3.h"
+#include "EntityItemID.h"
 
 const QString NO_SCRIPT("");
 
 const unsigned int SCRIPT_DATA_CALLBACK_USECS = floor(((1.0 / 60.0f) * 1000 * 1000) + 0.5);
+
+typedef QHash<QString, QScriptValue> RegisteredEventHandlers;
 
 class ScriptEngine : public QScriptEngine, public ScriptUser {
     Q_OBJECT
@@ -98,6 +101,9 @@ public:
     virtual void scriptContentsAvailable(const QUrl& url, const QString& scriptContents);
     virtual void errorInLoadingScript(const QUrl& url);
 
+    void addEntityEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler);
+    void removeEntityEventHandler(const EntityItemID& entityID, const QString& eventName, QScriptValue handler);
+
 public slots:
     void loadURL(const QUrl& scriptURL);
     void stop();
@@ -114,6 +120,7 @@ public slots:
     QUrl resolvePath(const QString& path) const;
 
     void nodeKilled(SharedNodePointer node);
+    void collisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 signals:
     void scriptLoaded(const QString& scriptFilename);
@@ -164,6 +171,7 @@ private:
     ArrayBufferClass* _arrayBufferClass;
 
     QHash<QUuid, quint16> _outgoingScriptAudioSequenceNumbers;
+    QHash<EntityItemID, RegisteredEventHandlers> _registeredHandlers;
 
 private:
     static QSet<ScriptEngine*> _allKnownScriptEngines;


### PR DESCRIPTION
Consider this part one of https://app.asana.com/0/32622044445063/34250577852897 "remove old 'global' collision callback from JS" -- but just the part that implements the new way, without actually removing the old or updating the scripts. I'll make a separate PR for the latter, because I want us to be able to look at the diffs for this part separately.

FUNCTIONAL SPEC:
---------------------------
Allow "normal scripts" (i.e., not "entity scripts") to (un)register handler on a specific entityID for any of the “entity script” events.

For example: 
Script.addEventHandler(missileID, "collisionWithEntity", makeExplosionAtCollisionSite)
Script.addEventHandler(gameLevelDestinationZoneID, “enterEntity", function (ignoredID) {
    // Disarm the missile.
    Script.removeEventHandler(middleID, “collisionWithEntity”, makeExplosionAtCollisionSite);
    playSuccessMusicAndAdvanceToNextLevel();
});

The event names and arguments are exactly the same as for entity scripts.
Multiple different handlers can be added for the same event on the same entityID (just like in a browser). They all fire.
The behavior is undefined, but not catastrophic, if the same handler is added more than once, or one removes a script that hasn’t been added.
Handlers do not fire on a deleted entity, and properly track changes to entityID.


DESIGN:
------------
1. The javascript handlers are, of course, defined within an instance of ScriptInterface, and must be run within that instance. So, e.g.,
  - They must be be queued into the thread for that ScriptInterface. (For example, we can’t have a different thread use QScriptValue::call to try to run something while the ScriptInterface::run is doing update().) 
  - The arguments to the handlers must be interned into the (Q)ScriptEngine that defined the handlers. 
We accomplish this using the QT signal mechanism, such that the event signal gets connected to a slot on the ScriptInterface, and that slot does the marshaling and call.

2. So, on a per ScriptInterface basis:
 - ScriptInterface::add/removeEventHandler updates the wiring, listening for the entity signals (as well as for deletingEntity/changingEntityID). These are accessible from Javascript on the Script global object.
 - When an entity script signal is seen, all and only those handlers that have been registered for that entityID/event are fired.

3. The EntityScriptingInterface singleton is the well-known object on which we have the signals that drive this. Most were already being emitted by EntityTreeRender and wired by it to the EntityScriptInterface object.

4. Cleanup:
 - EntityTreeRenderer now treats collisionWithEntity just like all of its other event script handlers in that it emits this signal and connects it to EntityScriptInterface.
 - EntityScriptInterface now treats changingEntityId just like addingEntity/deletingEntity in how it connects/disconnects it to EntityScriptInterface.



