### PR TITLE
Fix Windows C4351 build warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ if (WIN32)
   endif ()
   message (WINDOW_SDK_PATH= ${WINDOW_SDK_PATH})
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${WINDOW_SDK_PATH})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  # /wd4351 disables warning C4351: new behavior: elements of array will be default initialized
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /wd4351")
   # /LARGEADDRESSAWARE enables 32-bit apps to use more than 2GB of memory.
   # Caveats: http://stackoverflow.com/questions/2288728/drawbacks-of-using-largeaddressaware-for-32-bit-windows-executables
   # TODO: Remove when building 64-bit.

--- a/interface/src/devices/DdeFaceTracker.cpp
+++ b/interface/src/devices/DdeFaceTracker.cpp
@@ -141,13 +141,6 @@ static const float STARTING_DDE_MESSAGE_TIME = 0.033f;
 static const float DEFAULT_DDE_EYE_CLOSING_THRESHOLD = 0.8f;
 static const int CALIBRATION_SAMPLES = 150;
 
-#ifdef WIN32
-//  warning C4351: new behavior: elements of array 'DdeFaceTracker::_lastEyeBlinks' will be default initialized 
-//  warning C4351: new behavior: elements of array 'DdeFaceTracker::_filteredEyeBlinks' will be default initialized
-//  warning C4351: new behavior: elements of array 'DdeFaceTracker::_lastEyeCoefficients' will be default initialized
-#pragma warning(disable:4351) 
-#endif
-
 DdeFaceTracker::DdeFaceTracker() :
     DdeFaceTracker(QHostAddress::Any, DDE_SERVER_PORT, DDE_CONTROL_PORT)
 {
@@ -213,10 +206,6 @@ DdeFaceTracker::~DdeFaceTracker() {
         cancelCalibration();
     }
 }
-
-#ifdef WIN32
-#pragma warning(default:4351) 
-#endif
 
 void DdeFaceTracker::init() {
     FaceTracker::init();

--- a/libraries/networking/src/Assignment.cpp
+++ b/libraries/networking/src/Assignment.cpp
@@ -32,12 +32,6 @@ Assignment::Type Assignment::typeForNodeType(NodeType_t nodeType) {
     }
 }
 
-#ifdef WIN32
-//warning C4351: new behavior: elements of array 'Assignment::_payload' will be default initialized 
-// We're disabling this warning because the new behavior which is to initialize the array with 0 is acceptable to us.
-#pragma warning(disable:4351) 
-#endif
-
 Assignment::Assignment() :
     _uuid(),
     _command(Assignment::RequestCommand),


### PR DESCRIPTION
VS2013 warns about default initialization of arrays because it behaved
differently in previous versions. Default initialization is what we expect
now that we're using VS2013 so we can disable this warning globally.

Also stops C4351 warning in Nodebounds.cpp.