### PR TITLE
Unowned object sounds

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1107,6 +1107,17 @@ void EntityTreeRenderer::playEntityCollisionSound(const QUuid& myNodeID, EntityT
         return;
     }
     QUuid simulatorID = entity->getSimulatorID();
+    if (simulatorID.isNull()) {
+        // Can be null if it has never moved since being created or coming out of persistence.
+        // However, for there to be a collission, one of the two objects must be moving.
+        const EntityItemID& otherID = (id == collision.idA) ? collision.idB : collision.idA;
+        EntityItemPointer otherEntity = entityTree->findEntityByEntityItemID(otherID);
+        if (!otherEntity) {
+            return;
+        }
+        simulatorID = otherEntity->getSimulatorID();
+    }
+
     if (simulatorID.isNull() || (simulatorID != myNodeID)) {
         return; // Only one injector per simulation, please.
     }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -83,6 +83,7 @@ QUuid EntityScriptingInterface::addEntity(const EntityItemProperties& properties
             entity->setLastBroadcast(usecTimestampNow());
             // This Node is creating a new object.  If it's in motion, set this Node as the simulator.
             bidForSimulationOwnership(propertiesWithSimID);
+            entity->setSimulatorID(propertiesWithSimID.getSimulatorID()); // and make note of it now, so we can act on it right away.
         } else {
             qCDebug(entities) << "script failed to add new Entity to local Octree";
             success = false;


### PR DESCRIPTION
Play collision sounds for objects that are not yet owned by anyone, while keeping things so that sounds are only injected by one participant.  There are two cases:

1) Objects that are not moving, and thus not owned by anyone. E.g., put a collisionSoundURL on the floor and hit it.

2) Objects that have just been created by a script using Entities.addEntity. E.g., the dice.