### PR TITLE
fix crash when creating a box with edit.js

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -957,15 +957,22 @@ bool EntityItem::setProperties(const EntityItemProperties& properties) {
         #endif
         setLastEdited(now);
         somethingChangedNotification(); // notify derived classes that something has changed
-        if (_created == UNKNOWN_CREATED_TIME) {
-            _created = now;
-        }
         if (getDirtyFlags() & (EntityItem::DIRTY_TRANSFORM | EntityItem::DIRTY_VELOCITIES)) {
             // anything that sets the transform or velocity must update _lastSimulated which is used
             // for kinematic extrapolation (e.g. we want to extrapolate forward from this moment
             // when position and/or velocity was changed).
             _lastSimulated = now;
         }
+    }
+
+    // timestamps
+    quint64 timestamp = properties.getCreated();
+    if (_created == UNKNOWN_CREATED_TIME && timestamp != UNKNOWN_CREATED_TIME) {
+        quint64 now = usecTimestampNow();
+        if (timestamp > now) {
+            timestamp = now;
+        }
+        _created = timestamp;
     }
 
     return somethingChanged;

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -93,16 +93,16 @@ void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
 }
 
 void DeferredLightingEffect::bindSimpleProgram() {
- //   DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(true, true, true);
+    DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(true, true, true);
     _simpleProgram.bind();
     _simpleProgram.setUniformValue(_glowIntensityLocation, DependencyManager::get<GlowEffect>()->getIntensity());
-  //  glDisable(GL_BLEND);
+    glDisable(GL_BLEND);
 }
 
 void DeferredLightingEffect::releaseSimpleProgram() {
- //   glEnable(GL_BLEND);
+    glEnable(GL_BLEND);
     _simpleProgram.release();
- //   DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(true, false, false);
+    DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(true, false, false);
 }
 
 void DeferredLightingEffect::renderSolidSphere(float radius, int slices, int stacks, const glm::vec4& color) {

--- a/tests/physics/src/MeshMassPropertiesTests.h
+++ b/tests/physics/src/MeshMassPropertiesTests.h
@@ -15,7 +15,7 @@ namespace MeshMassPropertiesTests{
     void testParallelAxisTheorem();
     void testTetrahedron();
     void testOpenTetrahedonMesh();
-	void testClosedTetrahedronMesh();
+    void testClosedTetrahedronMesh();
     void testBoxAsMesh();
     void runAllTests();
 }


### PR DESCRIPTION
I was crashing on an assert when creating a new box entity with edit.js.  The problem is related to some special handling of EntityItem::_created in EntityItem::setProperties() that was removed in PR #4983.  I'm adding that bit of magic back to the codebase which should also remove some priority on PR #4988.

Also, fixing a problem where box entities do not render when in an otherwise empty domain.  This problem was introduced in PR #4979.