### PR TITLE
get end collision events in entity collision handler

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2489,19 +2489,20 @@ void Application::update(float deltaTime) {
             _entitySimulation.unlock();
 
             avatarManager->handleOutgoingChanges(_physicsEngine.getOutgoingChanges());
-            avatarManager->handleCollisionEvents(_physicsEngine.getCollisionEvents());
+            auto collisionEvents = _physicsEngine.getCollisionEvents();
+            avatarManager->handleCollisionEvents(collisionEvents);
 
             _physicsEngine.dumpStatsIfNecessary();
-        }
-    }
 
-    if (!_aboutToQuit) {
-        PerformanceTimer perfTimer("entities");
-        // Collision events (and their scripts) must not be handled when we're locked, above. (That would risk deadlock.)
-        _entitySimulation.handleCollisionEvents(_physicsEngine.getCollisionEvents());
-        // NOTE: the _entities.update() call below will wait for lock
-        // and will simulate entity motion (the EntityTree has been given an EntitySimulation).  
-       _entities.update(); // update the models...
+            if (!_aboutToQuit) {
+                PerformanceTimer perfTimer("entities");
+                // Collision events (and their scripts) must not be handled when we're locked, above. (That would risk deadlock.)
+                _entitySimulation.handleCollisionEvents(collisionEvents);
+                // NOTE: the _entities.update() call below will wait for lock
+                // and will simulate entity motion (the EntityTree has been given an EntitySimulation).
+                _entities.update(); // update the models...
+            }
+        }
     }
 
     {


### PR DESCRIPTION
getCollisionEvents has a side-effect on state (removing END events fom further consideration), so it must be called once per step.

Otherwise entities never get to see end events.
Also, entity collision processing should only be done when there are outgoing changes (just like for avatar).