### PR TITLE
TEAM TEACHING: Adding the update mechanism for the Item's payload of the scene

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3410,7 +3410,8 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         pendingChanges.updateItem<WorldBoxRenderData>(WorldBoxRenderData::_item,  
                 [](WorldBoxRenderData& payload) { 
                     payload._val++;
-                     qCDebug(interfaceapp, "MyFirst update message!!!!! %u", payload._val);
+                    // A test Update to proof the concept is woking
+                    // qCDebug(interfaceapp, "MyFirst update message!!!!! %u", payload._val);
                 });
     }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -119,6 +119,8 @@
 #include "gpu/Context.h"
 #include "gpu/GLBackend.h"
 
+#include "RenderDeferredTask.h"
+
 #include "scripting/AccountScriptingInterface.h"
 #include "scripting/AudioDeviceScriptingInterface.h"
 #include "scripting/ClipboardScriptingInterface.h"
@@ -372,7 +374,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
     _runningScriptsWidget = new RunningScriptsWidget(_window);
   
   
-    _renderEngine->buildStandardTaskPipeline();
+    _renderEngine->addTask(render::TaskPointer(new RenderDeferredTask()));
     _renderEngine->registerScene(_main3DScene);
       
     // start the nodeThread so its event loop is running

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3170,6 +3170,7 @@ public:
     typedef render::Payload<WorldBoxRenderData> Payload;
     typedef Payload::DataPointer Pointer;
 
+    int _val = 0;
     static render::ItemID _item; // unique WorldBoxRenderData
 };
 
@@ -3406,11 +3407,11 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         pendingChanges.resetItem(WorldBoxRenderData::_item, worldBoxRenderPayload);
     } else {
 
-        pendingChanges.updateItem(WorldBoxRenderData::_item,
-            render::UpdateFunctor(
+        pendingChanges.updateItem<WorldBoxRenderData>(WorldBoxRenderData::_item,  
                 [](WorldBoxRenderData& payload) { 
-                     qCDebug(interfaceapp, "MyFirst update message!!!!!");
-                }));
+                    payload._val++;
+                     qCDebug(interfaceapp, "MyFirst update message!!!!! %u", payload._val);
+                });
     }
 
     {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3404,6 +3404,13 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         WorldBoxRenderData::_item = _main3DScene->allocateID();
 
         pendingChanges.resetItem(WorldBoxRenderData::_item, worldBoxRenderPayload);
+    } else {
+
+        pendingChanges.updateItem(WorldBoxRenderData::_item,
+            render::UpdateFunctor(
+                [](WorldBoxRenderData& payload) { 
+                     qCDebug(interfaceapp, "MyFirst update message!!!!!");
+                }));
     }
 
     {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -19,7 +19,6 @@
 #include <EntityScriptingInterface.h> // for RayToEntityIntersectionResult
 #include <MouseEvent.h>
 #include <OctreeRenderer.h>
-//#include <render/Scene.h>
 #include <ScriptCache.h>
 #include <AbstractAudioInterface.h>
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -19,7 +19,7 @@
 #include <EntityScriptingInterface.h> // for RayToEntityIntersectionResult
 #include <MouseEvent.h>
 #include <OctreeRenderer.h>
-#include <render/Scene.h>
+//#include <render/Scene.h>
 #include <ScriptCache.h>
 #include <AbstractAudioInterface.h>
 

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -41,3 +41,4 @@ namespace render {
 }
 
 
+

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -1,0 +1,40 @@
+//
+//  RenderDeferredTask.cpp
+//  render-utils/src/
+//
+//  Created by Sam Gateau on 5/29/15.
+//  Copyright 20154 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#include "RenderDeferredTask.h"
+
+using namespace render;
+
+RenderDeferredTask::RenderDeferredTask() : Task() {
+   _jobs.push_back(Job(DrawOpaque()));
+   _jobs.push_back(Job(DrawLight()));
+   _jobs.push_back(Job(DrawTransparent()));
+}
+
+RenderDeferredTask::~RenderDeferredTask() {
+}
+
+void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
+    // sanity checks
+    assert(sceneContext);
+    if (!sceneContext->_scene) {
+        return;
+    }
+
+
+    // Is it possible that we render without a viewFrustum ?
+    if (!(renderContext->args && renderContext->args->_viewFrustum)) {
+        return;
+    }
+
+    for (auto job : _jobs) {
+        job.run(sceneContext, renderContext);
+    }
+};

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -1,0 +1,31 @@
+//
+//  RenderDeferredTask.h
+//  render-utils/src/
+//
+//  Created by Sam Gateau on 5/29/15.
+//  Copyright 20154 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_RenderDeferredTask_h
+#define hifi_RenderDeferredTask_h
+
+#include "render/DrawTask.h"
+
+
+class RenderDeferredTask : public render::Task {
+public:
+
+    RenderDeferredTask();
+    ~RenderDeferredTask();
+
+    render::Jobs _jobs;
+
+    virtual void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
+
+};
+
+
+#endif // hifi_RenderDeferredTask_h

--- a/libraries/render/src/render/Scene.cpp
+++ b/libraries/render/src/render/Scene.cpp
@@ -66,10 +66,6 @@ void Item::kill() {
     _key._flags.reset();
 }
 
-void Item::update(const UpdateFunctor& functor) {
-    _payload->update(functor);
-}
-
 void PendingChanges::resetItem(ItemID id, const PayloadPointer& payload) {
     _resetItems.push_back(id);
     _resetPayloads.push_back(payload);
@@ -79,7 +75,7 @@ void PendingChanges::removeItem(ItemID id) {
     _removedItems.push_back(id);
 }
 
-void PendingChanges::updateItem(ItemID id, const UpdateFunctor& functor) {
+void PendingChanges::updateItem(ItemID id, const UpdateFunctorPointer& functor) {
     _updatedItems.push_back(id);
     _updateFunctors.push_back(functor);
 }

--- a/libraries/render/src/render/Scene.cpp
+++ b/libraries/render/src/render/Scene.cpp
@@ -66,8 +66,8 @@ void Item::kill() {
     _key._flags.reset();
 }
 
-void Item::move() {
-    
+void Item::update(const UpdateFunctor& functor) {
+    _payload->update(functor);
 }
 
 void PendingChanges::resetItem(ItemID id, const PayloadPointer& payload) {
@@ -79,8 +79,9 @@ void PendingChanges::removeItem(ItemID id) {
     _removedItems.push_back(id);
 }
 
-void PendingChanges::moveItem(ItemID id) {
-    _movedItems.push_back(id);
+void PendingChanges::updateItem(ItemID id, const UpdateFunctor& functor) {
+    _updatedItems.push_back(id);
+    _updateFunctors.push_back(functor);
 }
 
         
@@ -88,7 +89,8 @@ void PendingChanges::merge(PendingChanges& changes) {
     _resetItems.insert(_resetItems.end(), changes._resetItems.begin(), changes._resetItems.end());
     _resetPayloads.insert(_resetPayloads.end(), changes._resetPayloads.begin(), changes._resetPayloads.end());
     _removedItems.insert(_removedItems.end(), changes._removedItems.begin(), changes._removedItems.end());
-    _movedItems.insert(_movedItems.end(), changes._movedItems.begin(), changes._movedItems.end());
+    _updatedItems.insert(_updatedItems.end(), changes._updatedItems.begin(), changes._updatedItems.end());
+    _updateFunctors.insert(_updateFunctors.end(), changes._updateFunctors.begin(), changes._updateFunctors.end());
 }
 
 Scene::Scene() {
@@ -133,7 +135,7 @@ void Scene::processPendingChangesQueue() {
         // capture anything coming from the pendingChanges
         resetItems(consolidatedPendingChanges._resetItems, consolidatedPendingChanges._resetPayloads);
         removeItems(consolidatedPendingChanges._removedItems);
-        moveItems(consolidatedPendingChanges._movedItems);
+        updateItems(consolidatedPendingChanges._updatedItems, consolidatedPendingChanges._updateFunctors);
 
      // ready to go back to rendering activities
     _itemsMutex.unlock();
@@ -159,9 +161,11 @@ void Scene::removeItems(const ItemIDs& ids) {
     }
 }
 
-void Scene::moveItems(const ItemIDs& ids) {
-    for (auto movedID :ids) {
-        _items[movedID].move();
+void Scene::updateItems(const ItemIDs& ids, UpdateFunctors& functors) {
+    auto updateID = ids.begin();
+    auto updateFunctor = functors.begin();
+    for (;updateID != ids.end(); updateID++, updateFunctor++) {
+        _items[(*updateID)].update((*updateFunctor));
     }
 }
 


### PR DESCRIPTION
- Introduce the UpdateFunctor and the update mechanism for passing a lambda through the PendingChanges so it will be executed by the Item->Payload passing the internal _data object
The UpdateFunctor's lambda should allow to pass arbitrary data and execute any method on the payload itself
We should be careful with the memory allocation induce but in theory this should work and be efficient...

- Introduce the RenderDeferredTask class in render-utils in order to implement the full pipeline