### PR TITLE
TEAM TEACHING - implement meta item for model entities

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -77,6 +77,8 @@ private:
     QStringList _originalTextures;
     bool _originalTexturesRead;
     QVector<QVector<glm::vec3>> _points;
+    
+    render::ItemID _myMetaItem;
 };
 
 #endif // hifi_RenderableModelEntityItem_h


### PR DESCRIPTION
This basically fixes the "models not moving when you edit them" and a couple other issues related to how model items need to be synced with application state.