### PR TITLE
fix crash in ~OffscreenGlCanvas on linux shutdown

### DIFF
--- a/libraries/render-utils/src/OffscreenGlCanvas.cpp
+++ b/libraries/render-utils/src/OffscreenGlCanvas.cpp
@@ -16,6 +16,17 @@
 OffscreenGlCanvas::OffscreenGlCanvas() {
 }
 
+OffscreenGlCanvas::~OffscreenGlCanvas() {
+#ifdef DEBUG
+    if (_logger) {
+        makeCurrent();
+        delete _logger;
+        _logger = nullptr;
+    }
+#endif
+    _context.doneCurrent();
+}
+
 void OffscreenGlCanvas::create(QOpenGLContext* sharedContext) {
     if (nullptr != sharedContext) {
         sharedContext->doneCurrent();

--- a/libraries/render-utils/src/OffscreenGlCanvas.h
+++ b/libraries/render-utils/src/OffscreenGlCanvas.h
@@ -20,6 +20,7 @@ class QOpenGLDebugLogger;
 class OffscreenGlCanvas : public QObject {
 public:
     OffscreenGlCanvas();
+    ~OffscreenGlCanvas();
     void create(QOpenGLContext* sharedContext = nullptr);
     bool makeCurrent();
     void doneCurrent();


### PR DESCRIPTION
I was getting this crash mode on linux:

    #0  0x00007ffff66c434e in QOpenGLContext::functions() const () from ~/Qt/5.4/gcc_64/lib/libQt5Gui.so.5
    #1  0x00007ffff69c89da in QOpenGLDebugLogger::stopLogging() () from ~/Qt/5.4/gcc_64/lib/libQt5Gui.so.5
    #2  0x00007ffff69c8fad in ?? () from ~/Qt/5.4/gcc_64/lib/libQt5Gui.so.5
    #3  0x00007ffff007501a in QMetaObject::activate(QObject*, int, int, void**) () from ~/Qt/5.4/gcc_64/lib/libQt5Core.so.5
    #4  0x00007ffff66c65b8 in QOpenGLContext::destroy() () from ~/Qt/5.4/gcc_64/lib/libQt5Gui.so.5
    #5  0x00007ffff66c6847 in QOpenGLContext::~QOpenGLContext() () from ~/Qt/5.4/gcc_64/lib/libQt5Gui.so.5
    #6  0x0000000000d2cb58 in OffscreenGlCanvas::~OffscreenGlCanvas (this=0x176d300, __in_chrg=<optimized out>)
        at ~/upstream/libraries/render-utils/src/OffscreenGlCanvas.h:20
    #7  0x0000000000d2a376 in OffscreenQmlSurface::~OffscreenQmlSurface (this=0x176d300, __in_chrg=<optimized out>)
        at ~/upstream/libraries/render-utils/src/OffscreenQmlSurface.cpp:27
    #8  0x0000000000da6271 in OffscreenUi::~OffscreenUi (this=0x176d300, __in_chrg=<optimized out>) at ~/upstream/libraries/ui/src/OffscreenUi.cpp:62
    #9  0x0000000000da62aa in OffscreenUi::~OffscreenUi (this=0x176d300, __in_chrg=<optimized out>) at ~/upstream/libraries/ui/src/OffscreenUi.cpp:63
    #10 0x0000000000827f6e in Dependency::_customDeleter::{lambda(Dependency*)#1}::operator()(Dependency::_customDeleter) const (__closure=0x1798f40, pointer=0x176d400)
        at ~/upstream/libraries/shared/src/DependencyManager.h:37
    #11 0x00000000008287d7 in std::_Function_handler<void (Dependency*), Dependency::_customDeleter::{lambda(Dependency*)#1}>::_M_invoke(std::_Any_data const&, Dependency*) (
        __functor=..., __args#0=0x176d400) at /usr/include/c++/4.8/functional:2071
    #12 0x00000000008281b9 in std::function<void (Dependency*)>::operator()(Dependency*) const (this=0x176d408, __args#0=0x176d400) at /usr/include/c++/4.8/functional:2464
    #13 0x0000000000828019 in Dependency::customDeleter (this=0x176d400) at ~/upstream/libraries/shared/src/DependencyManager.h:33
    #14 0x00000000009282b1 in QtSharedPointer::executeDeleter<OffscreenUi, Dependency, void> (t=0x176d300, memberDeleter=&virtual Dependency::customDeleter())
        at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:113
    #15 0x0000000000926293 in QtSharedPointer::CustomDeleter<OffscreenUi, void (Dependency::*)()>::execute (this=0x1786460)
        at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:173
    #16 0x0000000000922f7e in QtSharedPointer::ExternalRefCountWithCustomDeleter<OffscreenUi, void (Dependency::*)()>::deleter (self=0x1786450)
        at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:207
    #17 0x0000000000805ef7 in QtSharedPointer::ExternalRefCountData::destroy (this=0x1786450) at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:151
    #18 0x00000000009212bd in QSharedPointer<Dependency>::deref (d=0x1786450) at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:469
    #19 0x000000000091a6ec in QSharedPointer<Dependency>::deref (this=0x7fffffffac20) at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:464
    #20 0x0000000000913b34 in QSharedPointer<Dependency>::~QSharedPointer (this=0x7fffffffac20, __in_chrg=<optimized out>)
        at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:305
    #21 0x0000000000913a6a in QSharedPointer<Dependency>::clear (this=0x17aa898) at ~/Qt/5.4/gcc_64/include/QtCore/qsharedpointer_impl.h:392
    #22 0x000000000090e00a in DependencyManager::destroy<OffscreenUi> () at ~/upstream/libraries/shared/src/DependencyManager.h:105
    #23 0x00000000008e8223 in Application::~Application (this=0x7fffffffad50, __in_chrg=<optimized out>) at ~/upstream/interface/src/Application.cpp:695
    #24 0x00000000008e07eb in main (argc=1, argv=0x7fffffffdbd8) at ~/upstream/interface/src/main.cpp:110

I fixed it by perfecting what appears to be a cargo-cult copy of some code from the GlWindow implementation.
