### PR TITLE
CR for #20561 - Fix address bar dialog text

### DIFF
--- a/interface/resources/qml/AddressBarDialog.qml
+++ b/interface/resources/qml/AddressBarDialog.qml
@@ -22,6 +22,7 @@ Item {
 
     property int animationDuration: hifi.effects.fadeInDuration
     property bool destroyOnInvisible: false
+    property real scale: 1.25  // Make this dialog a little larger than normal
 
     implicitWidth: addressBarDialog.implicitWidth
     implicitHeight: addressBarDialog.implicitHeight
@@ -41,9 +42,9 @@ Item {
             id: backgroundImage
 
             source: "../images/address-bar.svg"
-            width: 576
-            height: 80
-            property int inputAreaHeight: 56  // Height of the background's input area
+            width: 576 * root.scale
+            height: 80 * root.scale
+            property int inputAreaHeight: 56.0 * root.scale  // Height of the background's input area
             property int inputAreaStep: (height - inputAreaHeight) / 2
 
             TextInput {
@@ -57,6 +58,8 @@ Item {
                     bottomMargin: parent.inputAreaStep + hifi.layout.spacing
 
                 }
+
+                font.pixelSize: hifi.fonts.pixelSize * root.scale
 
                 helperText: "Go to: place, @user, /path, network address"
 

--- a/interface/resources/qml/AddressBarDialog.qml
+++ b/interface/resources/qml/AddressBarDialog.qml
@@ -58,7 +58,6 @@ Item {
 
                 }
 
-                font.pointSize: 15
                 helperText: "Go to: place, @user, /path, network address"
 
                 onAccepted: {

--- a/interface/resources/qml/controls/SpinBox.qml
+++ b/interface/resources/qml/controls/SpinBox.qml
@@ -9,7 +9,7 @@ Original.SpinBox {
     style: SpinBoxStyle {
         HifiConstants { id: hifi }
         font.family: hifi.fonts.fontFamily
-        font.pointSize: hifi.fonts.fontSize
+        font.pixelSize: hifi.fonts.pixelSize
     }
     
 }

--- a/interface/resources/qml/controls/Text.qml
+++ b/interface/resources/qml/controls/Text.qml
@@ -4,6 +4,6 @@ import "../styles"
 Original.Text {
     HifiConstants { id: hifi }
     font.family: hifi.fonts.fontFamily
-    font.pointSize: hifi.fonts.fontSize
+    font.pixelSize: hifi.fonts.pixelSize
 }
 

--- a/interface/resources/qml/controls/TextArea.qml
+++ b/interface/resources/qml/controls/TextArea.qml
@@ -4,6 +4,6 @@ import "../styles"
 Original.TextArea {
     HifiConstants { id: hifi }
     font.family: hifi.fonts.fontFamily
-    font.pointSize: hifi.fonts.fontSize
+    font.pixelSize: hifi.fonts.pixelSize
 }
 

--- a/interface/resources/qml/controls/TextEdit.qml
+++ b/interface/resources/qml/controls/TextEdit.qml
@@ -4,6 +4,6 @@ import "../styles"
 Original.TextEdit {
     HifiConstants { id: hifi }
     font.family: hifi.fonts.fontFamily
-    font.pointSize: hifi.fonts.fontSize
+    font.pixelSize: hifi.fonts.pixelSize
 }
 

--- a/interface/resources/qml/controls/TextHeader.qml
+++ b/interface/resources/qml/controls/TextHeader.qml
@@ -4,6 +4,6 @@ import "../styles"
 Text {
     HifiConstants { id: hifi }
     color: hifi.colors.hifiBlue
-    font.pointSize: hifi.fonts.headerPointSize
+    font.pixelSize: hifi.fonts.headerPixelSize
     font.bold: true
 }

--- a/interface/resources/qml/controls/TextInput.qml
+++ b/interface/resources/qml/controls/TextInput.qml
@@ -11,7 +11,7 @@ Original.TextInput {
     color: hifi.colors.text
     verticalAlignment: Original.TextInput.AlignVCenter
     font.family: hifi.fonts.fontFamily
-    font.pointSize: hifi.fonts.fontSize
+    font.pixelSize: hifi.fonts.pixelSize
 
 /*
     Original.Rectangle {
@@ -23,7 +23,7 @@ Original.TextInput {
 */
     Text {
         anchors.fill: parent
-        font.pointSize: parent.font.pointSize
+        font.pixelSize: parent.font.pixelSize
         font.family: parent.font.family
         verticalAlignment: parent.verticalAlignment
         horizontalAlignment: parent.horizontalAlignment

--- a/interface/resources/qml/styles/HifiConstants.qml
+++ b/interface/resources/qml/styles/HifiConstants.qml
@@ -36,9 +36,9 @@ Item {
 
     QtObject {
         id: fonts
-        readonly property real headerPointSize: 24
-        readonly property string fontFamily: "Helvetica"
-        readonly property real fontSize: 18
+        readonly property string fontFamily: "Arial"  // Available on both Windows and OSX
+        readonly property real pixelSize: 22  // Logical pixel size; works on Windows and OSX at varying physical DPIs
+        readonly property real headerPixelSize: 32
     }
 
     QtObject {

--- a/interface/resources/qml/styles/HifiConstants.qml
+++ b/interface/resources/qml/styles/HifiConstants.qml
@@ -18,7 +18,7 @@ Item {
         readonly property color background: sysPalette.dark
         readonly property color text: sysPalette.text
         readonly property color disabledText: "gray"
-        readonly property color hintText: sysPalette.dark
+        readonly property color hintText: "gray"  // A bit darker than sysPalette.dark so that it is visible on the DK2
         readonly property color light: sysPalette.light
         readonly property alias activeWindow: activeWindow
         readonly property alias inactiveWindow: inactiveWindow


### PR DESCRIPTION
This PR should make QML dialog's font sizes consistent across platforms. In particular, the login and address bar dialogs on OSX retina displays should have font sizes very similar to that shown
in the accompanying screen snaps from Windows on a 1920 x 1080 display. Similarly for Windows at 150% UI magnification.

@RyanDowne 

Could you please test the OSX retina display case?

I'll check the Windows @ 150% case.

![windows-login](https://cloud.githubusercontent.com/assets/7455448/7948411/9ac97274-0938-11e5-9db7-c21bcf55bd4b.png)

![windows-address-bar](https://cloud.githubusercontent.com/assets/7455448/7948413/9f3a284e-0938-11e5-81de-5a8be50011b3.png)
