### PR TITLE
collision groups for physical objects

### DIFF
--- a/interface/src/avatar/AvatarMotionState.cpp
+++ b/interface/src/avatar/AvatarMotionState.cpp
@@ -10,6 +10,7 @@
 //
 
 #include <PhysicsHelpers.h>
+#include <PhysicsEngine.h>
 
 #include "Avatar.h"
 #include "AvatarMotionState.h"
@@ -149,6 +150,11 @@ QUuid AvatarMotionState::getSimulatorID() const {
 
 // virtual
 void AvatarMotionState::bump() {
+}
+
+// virtual 
+int16_t AvatarMotionState::computeCollisionGroup() {
+    return COLLISION_GROUP_OTHER_AVATAR;
 }
 
 // virtual 

--- a/interface/src/avatar/AvatarMotionState.cpp
+++ b/interface/src/avatar/AvatarMotionState.cpp
@@ -10,7 +10,7 @@
 //
 
 #include <PhysicsHelpers.h>
-#include <PhysicsEngine.h>
+#include <PhysicsCollisionGroups.h>
 
 #include "Avatar.h"
 #include "AvatarMotionState.h"

--- a/interface/src/avatar/AvatarMotionState.h
+++ b/interface/src/avatar/AvatarMotionState.h
@@ -61,6 +61,8 @@ public:
 
     void addDirtyFlags(uint32_t flags) { _dirtyFlags |= flags; }
 
+    virtual int16_t computeCollisionGroup();
+
     friend class AvatarManager;
 
 protected:

--- a/libraries/entities-renderer/src/RenderableDebugableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableDebugableEntityItem.cpp
@@ -80,7 +80,8 @@ void RenderableDebugableEntityItem::render(EntityItem* entity, RenderArgs* args)
             renderBoundingBox(entity, args, 0.3f, yellowColor);
         }
 
-        if (PhysicsEngine::physicsInfoIsActive(entity->getPhysicsInfo())) {
+        ObjectMotionState* motionState = static_cast<ObjectMotionState*>(entity->getPhysicsInfo());
+        if (motionState && motionState->isActive()) {
             renderHoverDot(entity, args);
         }
     }

--- a/libraries/physics/src/DynamicCharacterController.cpp
+++ b/libraries/physics/src/DynamicCharacterController.cpp
@@ -3,9 +3,10 @@
 #include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
 #include <LinearMath/btDefaultMotionState.h>
 
+#include <PhysicsCollisionGroups.h>
+
 #include "BulletUtil.h"
 #include "DynamicCharacterController.h"
-#include "PhysicsEngine.h"
 
 const btVector3 LOCAL_UP_AXIS(0.0f, 1.0f, 0.0f);
 const float DEFAULT_GRAVITY = -5.0f;

--- a/libraries/physics/src/DynamicCharacterController.cpp
+++ b/libraries/physics/src/DynamicCharacterController.cpp
@@ -5,6 +5,7 @@
 
 #include "BulletUtil.h"
 #include "DynamicCharacterController.h"
+#include "PhysicsEngine.h"
 
 const btVector3 LOCAL_UP_AXIS(0.0f, 1.0f, 0.0f);
 const float DEFAULT_GRAVITY = -5.0f;
@@ -267,7 +268,7 @@ void DynamicCharacterController::setDynamicsWorld(btDynamicsWorld* world) {
         if (world && _rigidBody) {
             _dynamicsWorld = world;
             _pendingFlags &= ~ PENDING_FLAG_JUMP;
-            _dynamicsWorld->addRigidBody(_rigidBody);
+            _dynamicsWorld->addRigidBody(_rigidBody, COLLISION_GROUP_MY_AVATAR, COLLISION_MASK_MY_AVATAR);
             _dynamicsWorld->addAction(this);
             //reset(_dynamicsWorld);
         }

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -517,3 +517,8 @@ QString EntityMotionState::getName() {
     }
     return "";
 }
+
+// virtual 
+int16_t EntityMotionState::computeCollisionGroup() {
+    return COLLISION_GROUP_DEFAULT;
+}

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -11,6 +11,7 @@
 
 #include <EntityItem.h>
 #include <EntityEditPacketSender.h>
+#include <PhysicsCollisionGroups.h>
 
 #include "BulletUtil.h"
 #include "EntityMotionState.h"

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -521,5 +521,13 @@ QString EntityMotionState::getName() {
 
 // virtual 
 int16_t EntityMotionState::computeCollisionGroup() {
+    switch (computeObjectMotionType()){
+        case MOTION_TYPE_STATIC:
+            return COLLISION_GROUP_STATIC;
+        case MOTION_TYPE_KINEMATIC:
+            return COLLISION_GROUP_KINEMATIC;
+        default:
+            break;
+    }
     return COLLISION_GROUP_DEFAULT;
 }

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -77,6 +77,8 @@ public:
 
     virtual QString getName();
 
+    virtual int16_t computeCollisionGroup();
+
     friend class PhysicalEntitySimulation;
 
 protected:

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -200,3 +200,4 @@ void ObjectMotionState::updateBodyMassProperties() {
     _body->setMassProps(mass, inertia);
     _body->updateInertiaTensor();
 }
+

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -123,6 +123,8 @@ public:
 
     virtual QString getName() { return ""; }
 
+    virtual int16_t computeCollisionGroup() = 0;
+
     friend class PhysicsEngine;
 
 protected:

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -125,6 +125,8 @@ public:
 
     virtual int16_t computeCollisionGroup() = 0;
 
+    bool isActive() const { return _body ? _body->isActive() : false; }
+
     friend class PhysicsEngine;
 
 protected:

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <PhysicsCollisionGroups.h>
+
 #include "ObjectMotionState.h"
 #include "PhysicsEngine.h"
 #include "PhysicsHelpers.h"

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -23,8 +23,19 @@ uint32_t PhysicsEngine::getNumSubsteps() {
 }
 
 PhysicsEngine::PhysicsEngine(const glm::vec3& offset) :
-    _originOffset(offset),
-    _characterController(nullptr) {
+        _originOffset(offset),
+        _characterController(nullptr) {
+    // build table of masks with their group as the key
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_DEFAULT), COLLISION_MASK_DEFAULT);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_STATIC), COLLISION_MASK_STATIC);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_KINEMATIC), COLLISION_MASK_KINEMATIC);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_DEBRIS), COLLISION_MASK_DEBRIS);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_TRIGGER), COLLISION_MASK_TRIGGER);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_MY_AVATAR), COLLISION_MASK_MY_AVATAR);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_MY_ATTACHMENT), COLLISION_MASK_MY_ATTACHMENT);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_OTHER_AVATAR), COLLISION_MASK_OTHER_AVATAR);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_OTHER_ATTACHMENT), COLLISION_MASK_OTHER_ATTACHMENT);
+    _collisionMasks.insert(btHashInt((int)COLLISION_GROUP_COLLISIONLESS), COLLISION_MASK_COLLISIONLESS);
 }
 
 PhysicsEngine::~PhysicsEngine() {
@@ -125,7 +136,8 @@ void PhysicsEngine::addObject(ObjectMotionState* motionState) {
     body->setFlags(BT_DISABLE_WORLD_GRAVITY);
     motionState->updateBodyMaterialProperties();
 
-    _dynamicsWorld->addRigidBody(body);
+    int16_t group = motionState->computeCollisionGroup();
+    _dynamicsWorld->addRigidBody(body, group, getCollisionMask(group));
 
     motionState->getAndClearIncomingDirtyFlags();
 }
@@ -417,6 +429,7 @@ void PhysicsEngine::setCharacterController(DynamicCharacterController* character
     }
 }
 
+// static
 bool PhysicsEngine::physicsInfoIsActive(void* physicsInfo) {
     if (!physicsInfo) {
         return false;
@@ -431,6 +444,7 @@ bool PhysicsEngine::physicsInfoIsActive(void* physicsInfo) {
     return body->isActive();
 }
 
+// static
 bool PhysicsEngine::getBodyLocation(void* physicsInfo, glm::vec3& positionReturn, glm::quat& rotationReturn) {
     if (!physicsInfo) {
         return false;
@@ -447,4 +461,9 @@ bool PhysicsEngine::getBodyLocation(void* physicsInfo, glm::vec3& positionReturn
     rotationReturn = bulletToGLM(worldTrans.getRotation());
 
     return true;
+}
+
+int16_t PhysicsEngine::getCollisionMask(int16_t group) const {
+    const int16_t* mask = _collisionMasks.find(btHashInt((int)group));
+    return mask ? *mask : COLLISION_MASK_DEFAULT;
 }

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -431,40 +431,6 @@ void PhysicsEngine::setCharacterController(DynamicCharacterController* character
     }
 }
 
-// static
-bool PhysicsEngine::physicsInfoIsActive(void* physicsInfo) {
-    if (!physicsInfo) {
-        return false;
-    }
-
-    ObjectMotionState* motionState = static_cast<ObjectMotionState*>(physicsInfo);
-    btRigidBody* body = motionState->getRigidBody();
-    if (!body) {
-        return false;
-    }
-
-    return body->isActive();
-}
-
-// static
-bool PhysicsEngine::getBodyLocation(void* physicsInfo, glm::vec3& positionReturn, glm::quat& rotationReturn) {
-    if (!physicsInfo) {
-        return false;
-    }
-
-    ObjectMotionState* motionState = static_cast<ObjectMotionState*>(physicsInfo);
-    btRigidBody* body = motionState->getRigidBody();
-    if (!body) {
-        return false;
-    }
-
-    const btTransform& worldTrans = body->getCenterOfMassTransform();
-    positionReturn = bulletToGLM(worldTrans.getOrigin()) + ObjectMotionState::getWorldOffset();
-    rotationReturn = bulletToGLM(worldTrans.getRotation());
-
-    return true;
-}
-
 int16_t PhysicsEngine::getCollisionMask(int16_t group) const {
     const int16_t* mask = _collisionMasks.find(btHashInt((int)group));
     return mask ? *mask : COLLISION_MASK_DEFAULT;

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -91,10 +91,6 @@ public:
 
     void dumpNextStats() { _dumpNextStats = true; }
 
-    // TODO: Andrew to move these to ObjectMotionState
-    static bool physicsInfoIsActive(void* physicsInfo);
-    static bool getBodyLocation(void* physicsInfo, glm::vec3& positionReturn, glm::quat& rotationReturn);
-
     int16_t getCollisionMask(int16_t group) const;
 
 private:

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -25,6 +25,61 @@
 #include "ObjectMotionState.h"
 #include "ThreadSafeDynamicsWorld.h"
 
+/* Note: These are the collision groups defined in btBroadphaseProxy. Only 
+ * DefaultFilter and StaticFilter are explicitly used by Bullet (when the 
+ * collision filter of an object is not manually specified), the rest are 
+ * merely suggestions.
+ *
+enum CollisionFilterGroups {
+    DefaultFilter = 1,
+    StaticFilter = 2,
+    KinematicFilter = 4,
+    DebrisFilter = 8,
+    SensorTrigger = 16,
+    CharacterFilter = 32,
+    AllFilter = -1
+}
+ *
+ * When using custom collision filters we pretty much need to do all or nothing. 
+ * We'll be doing it all which means we define our own groups and build custom masks 
+ * for everything.
+ *
+*/
+
+const int16_t COLLISION_GROUP_DEFAULT = 1 << 0;
+const int16_t COLLISION_GROUP_STATIC = 1 << 1;
+const int16_t COLLISION_GROUP_KINEMATIC = 1 << 2;
+const int16_t COLLISION_GROUP_DEBRIS = 1 << 3;
+const int16_t COLLISION_GROUP_TRIGGER = 1 << 4;
+const int16_t COLLISION_GROUP_MY_AVATAR = 1 << 5;
+const int16_t COLLISION_GROUP_OTHER_AVATAR = 1 << 6;
+const int16_t COLLISION_GROUP_MY_ATTACHMENT = 1 << 7;
+const int16_t COLLISION_GROUP_OTHER_ATTACHMENT = 1 << 8;
+// ...
+const int16_t COLLISION_GROUP_COLLISIONLESS = 1 << 15;
+
+
+/* Note: In order for objectA to collide with objectB at the filter stage 
+ * both (groupA & maskB) and (groupB & maskA) must be non-zero.
+ */
+// DEFAULT collides with everything except COLLISIONLESS
+const int16_t COLLISION_MASK_DEFAULT = ~ COLLISION_GROUP_COLLISIONLESS;
+const int16_t COLLISION_MASK_STATIC = COLLISION_MASK_DEFAULT;
+const int16_t COLLISION_MASK_KINEMATIC = COLLISION_MASK_DEFAULT;
+// DEBRIS also doesn't collide with: other DEBRIS, and TRIGGER
+const int16_t COLLISION_MASK_DEBRIS = ~ (COLLISION_GROUP_COLLISIONLESS
+        | COLLISION_GROUP_DEBRIS
+        | COLLISION_GROUP_TRIGGER);
+// TRIGGER also doesn't collide with: DEBRIS, TRIGGER, and STATIC (TRIGGER only detects moveable things that matter)
+const int16_t COLLISION_MASK_TRIGGER = COLLISION_MASK_DEBRIS & ~(COLLISION_GROUP_STATIC);
+// AVATAR also doesn't collide with: corresponding ATTACHMENT
+const int16_t COLLISION_MASK_MY_AVATAR = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_MY_ATTACHMENT);
+const int16_t COLLISION_MASK_MY_ATTACHMENT = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_MY_AVATAR);
+const int16_t COLLISION_MASK_OTHER_AVATAR = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_OTHER_ATTACHMENT);
+const int16_t COLLISION_MASK_OTHER_ATTACHMENT = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_OTHER_AVATAR);
+// ...
+const int16_t COLLISION_MASK_COLLISIONLESS = 0;
+
 const float HALF_SIMULATION_EXTENT = 512.0f; // meters
 
 // simple class for keeping track of contacts
@@ -91,8 +146,11 @@ public:
 
     void dumpNextStats() { _dumpNextStats = true; }
 
+    // TODO: Andrew to move these to ObjectMotionState
     static bool physicsInfoIsActive(void* physicsInfo);
     static bool getBodyLocation(void* physicsInfo, glm::vec3& positionReturn, glm::quat& rotationReturn);
+
+    int16_t getCollisionMask(int16_t group) const;
 
 private:
     void removeContacts(ObjectMotionState* motionState);
@@ -121,6 +179,7 @@ private:
 
     QUuid _sessionID;
     CollisionEvents _collisionEvents;
+    btHashMap<btHashInt, int16_t> _collisionMasks;
 };
 
 #endif // hifi_PhysicsEngine_h

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -25,61 +25,6 @@
 #include "ObjectMotionState.h"
 #include "ThreadSafeDynamicsWorld.h"
 
-/* Note: These are the collision groups defined in btBroadphaseProxy. Only 
- * DefaultFilter and StaticFilter are explicitly used by Bullet (when the 
- * collision filter of an object is not manually specified), the rest are 
- * merely suggestions.
- *
-enum CollisionFilterGroups {
-    DefaultFilter = 1,
-    StaticFilter = 2,
-    KinematicFilter = 4,
-    DebrisFilter = 8,
-    SensorTrigger = 16,
-    CharacterFilter = 32,
-    AllFilter = -1
-}
- *
- * When using custom collision filters we pretty much need to do all or nothing. 
- * We'll be doing it all which means we define our own groups and build custom masks 
- * for everything.
- *
-*/
-
-const int16_t COLLISION_GROUP_DEFAULT = 1 << 0;
-const int16_t COLLISION_GROUP_STATIC = 1 << 1;
-const int16_t COLLISION_GROUP_KINEMATIC = 1 << 2;
-const int16_t COLLISION_GROUP_DEBRIS = 1 << 3;
-const int16_t COLLISION_GROUP_TRIGGER = 1 << 4;
-const int16_t COLLISION_GROUP_MY_AVATAR = 1 << 5;
-const int16_t COLLISION_GROUP_OTHER_AVATAR = 1 << 6;
-const int16_t COLLISION_GROUP_MY_ATTACHMENT = 1 << 7;
-const int16_t COLLISION_GROUP_OTHER_ATTACHMENT = 1 << 8;
-// ...
-const int16_t COLLISION_GROUP_COLLISIONLESS = 1 << 15;
-
-
-/* Note: In order for objectA to collide with objectB at the filter stage 
- * both (groupA & maskB) and (groupB & maskA) must be non-zero.
- */
-// DEFAULT collides with everything except COLLISIONLESS
-const int16_t COLLISION_MASK_DEFAULT = ~ COLLISION_GROUP_COLLISIONLESS;
-const int16_t COLLISION_MASK_STATIC = COLLISION_MASK_DEFAULT;
-const int16_t COLLISION_MASK_KINEMATIC = COLLISION_MASK_DEFAULT;
-// DEBRIS also doesn't collide with: other DEBRIS, and TRIGGER
-const int16_t COLLISION_MASK_DEBRIS = ~ (COLLISION_GROUP_COLLISIONLESS
-        | COLLISION_GROUP_DEBRIS
-        | COLLISION_GROUP_TRIGGER);
-// TRIGGER also doesn't collide with: DEBRIS, TRIGGER, and STATIC (TRIGGER only detects moveable things that matter)
-const int16_t COLLISION_MASK_TRIGGER = COLLISION_MASK_DEBRIS & ~(COLLISION_GROUP_STATIC);
-// AVATAR also doesn't collide with: corresponding ATTACHMENT
-const int16_t COLLISION_MASK_MY_AVATAR = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_MY_ATTACHMENT);
-const int16_t COLLISION_MASK_MY_ATTACHMENT = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_MY_AVATAR);
-const int16_t COLLISION_MASK_OTHER_AVATAR = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_OTHER_ATTACHMENT);
-const int16_t COLLISION_MASK_OTHER_ATTACHMENT = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_OTHER_AVATAR);
-// ...
-const int16_t COLLISION_MASK_COLLISIONLESS = 0;
-
 const float HALF_SIMULATION_EXTENT = 512.0f; // meters
 
 // simple class for keeping track of contacts

--- a/libraries/shared/src/PhysicsCollisionGroups.h
+++ b/libraries/shared/src/PhysicsCollisionGroups.h
@@ -1,0 +1,79 @@
+//
+//  PhysicsCollisionGroups.h
+//  libraries/shared/src
+//
+//  Created by Andrew Meadows 2015.06.03
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_PhysicsCollisionGroups_h
+#define hifi_PhysicsCollisionGroups_h
+
+#include <stdint.h>
+
+/* Note: These are the Bullet collision groups defined in btBroadphaseProxy. Only 
+ * DefaultFilter and StaticFilter are explicitly used by Bullet (when the collision 
+ * filter of an object is not manually specified), the rest are merely suggestions.
+ *
+enum CollisionFilterGroups {
+    DefaultFilter = 1,
+    StaticFilter = 2,
+    KinematicFilter = 4,
+    DebrisFilter = 8,
+    SensorTrigger = 16,
+    CharacterFilter = 32,
+    AllFilter = -1
+}
+ *
+ * When using custom collision filters we pretty much need to do all or nothing. 
+ * We'll be doing it all which means we define our own groups and build custom masks 
+ * for everything.
+ *
+*/
+
+const int16_t COLLISION_GROUP_DEFAULT = 1 << 0;
+const int16_t COLLISION_GROUP_STATIC = 1 << 1;
+const int16_t COLLISION_GROUP_KINEMATIC = 1 << 2;
+const int16_t COLLISION_GROUP_DEBRIS = 1 << 3;
+const int16_t COLLISION_GROUP_TRIGGER = 1 << 4;
+const int16_t COLLISION_GROUP_MY_AVATAR = 1 << 5;
+const int16_t COLLISION_GROUP_OTHER_AVATAR = 1 << 6;
+const int16_t COLLISION_GROUP_MY_ATTACHMENT = 1 << 7;
+const int16_t COLLISION_GROUP_OTHER_ATTACHMENT = 1 << 8;
+// ...
+const int16_t COLLISION_GROUP_COLLISIONLESS = 1 << 15;
+
+
+/* Note: In order for objectA to collide with objectB at the filter stage 
+ * both (groupA & maskB) and (groupB & maskA) must be non-zero.
+ */
+
+// DEFAULT collides with everything except COLLISIONLESS
+const int16_t COLLISION_MASK_DEFAULT = ~ COLLISION_GROUP_COLLISIONLESS;
+
+// STATIC also doesn't collide with other STATIC
+const int16_t COLLISION_MASK_STATIC = ~ (COLLISION_GROUP_COLLISIONLESS | COLLISION_MASK_STATIC);
+
+const int16_t COLLISION_MASK_KINEMATIC = COLLISION_MASK_DEFAULT;
+
+// DEBRIS also doesn't collide with other DEBRIS, or TRIGGER
+const int16_t COLLISION_MASK_DEBRIS = ~ (COLLISION_GROUP_COLLISIONLESS
+        | COLLISION_GROUP_DEBRIS
+        | COLLISION_GROUP_TRIGGER);
+
+// TRIGGER also doesn't collide with DEBRIS, TRIGGER, or STATIC (TRIGGER only detects moveable things that matter)
+const int16_t COLLISION_MASK_TRIGGER = COLLISION_MASK_DEBRIS & ~(COLLISION_GROUP_STATIC);
+
+// AVATAR also doesn't collide with corresponding ATTACHMENTs
+const int16_t COLLISION_MASK_MY_AVATAR = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_MY_ATTACHMENT);
+const int16_t COLLISION_MASK_MY_ATTACHMENT = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_MY_AVATAR);
+const int16_t COLLISION_MASK_OTHER_AVATAR = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_OTHER_ATTACHMENT);
+const int16_t COLLISION_MASK_OTHER_ATTACHMENT = ~(COLLISION_GROUP_COLLISIONLESS | COLLISION_GROUP_OTHER_AVATAR);
+
+// COLLISIONLESS gets an empty mask.
+const int16_t COLLISION_MASK_COLLISIONLESS = 0;
+
+#endif // hifi_PhysicsCollisionGroups_h

--- a/libraries/shared/src/PhysicsHelpers.cpp
+++ b/libraries/shared/src/PhysicsHelpers.cpp
@@ -5,7 +5,7 @@
 //  Created by Andrew Meadows 2015.01.27
 //  Unless otherwise copyrighted: Copyright 2015 High Fidelity, Inc.
 //
-//  Unless otherwise licensced: Distributed under the Apache License, Version 2.0.
+//  Unless otherwise licensed: Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 


### PR DESCRIPTION
This lays the foundation for using collision groups in the physics engine.  This PR doesn't actually make any visible changes -- objects should still collide (or not, as the case may be) as they used to.  The good news is that it will now be relatively easy to USE the new collision groups to make new features/behavior.