### PR TITLE
Fixing web entity glow and 'back' behavior

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -29,6 +29,7 @@ private:
     OffscreenQmlSurface* _webSurface{ nullptr };
     QMetaObject::Connection _connection;
     uint32_t _texture{ 0 };
+    ivec2  _lastPress{ INT_MIN };
     QMutex _textureLock;
 };
 


### PR DESCRIPTION
This should correct the excessive glow of web page entities (at the cost of supporting transparency).

It also modifies the 'back on right click' behavior to only go back if the mouse hasn't moved significantly between the press and release events.