### PR TITLE
Fix the skybox jiggle in the HMD

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3314,7 +3314,7 @@ void Application::displaySide(Camera& theCamera, bool selfAvatarOnly, bool billb
         skybox = skyStage->getSkybox();
         if (skybox) {
             gpu::Batch batch;
-            model::Skybox::render(batch, _viewFrustum, *skybox);
+            model::Skybox::render(batch, _displayViewFrustum, *skybox);
 
             gpu::GLBackend::renderBatch(batch);
             glUseProgram(0);


### PR DESCRIPTION
rendering always needs to be done using the display view frustum, not the base view frustum.  