### PR TITLE
TEAM TEACHING : Improving the transparent rendering

### DIFF
--- a/examples/utilities/tools/renderEngineDebug.js
+++ b/examples/utilities/tools/renderEngineDebug.js
@@ -66,19 +66,19 @@ panel.newCheckbox("Enable Render Transparent",
     function(value) { return (value); }
 );
 
-panel.newSlider("Num Feed Transparents", 0, 1000, 
+panel.newSlider("Num Feed Transparents", 0, 100, 
     function(value) { },
     function() { return Scene.getEngineNumFeedTransparentItems(); },
     function(value) { return (value); }
 );
 
-panel.newSlider("Num Drawn Transparents", 0, 1000, 
+panel.newSlider("Num Drawn Transparents", 0, 100, 
     function(value) { },
     function() { return Scene.getEngineNumDrawnTransparentItems(); },
     function(value) { return (value); }
 );
 
-panel.newSlider("Max Drawn Transparents", -1, 1000, 
+panel.newSlider("Max Drawn Transparents", -1, 100, 
     function(value) { Scene.setEngineMaxDrawnTransparentItems(value); },
     function() { return Scene.getEngineMaxDrawnTransparentItems(); },
     function(value) { return (value); }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3190,12 +3190,15 @@ namespace render {
     template <> void payloadRender(const WorldBoxRenderData::Pointer& stuff, RenderArgs* args) {
         if (args->_renderMode != CAMERA_MODE_MIRROR && Menu::getInstance()->isOptionChecked(MenuOption::Stats)) {
             PerformanceTimer perfTimer("worldBox");
+            
+            DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram((*args->_batch));
+            
             renderWorldBox(args);
 
             // FIXME: there's currently a bug in the new render engine, if this origin dot is rendered out of view it will
             // screw up the state of textures on models so they all end up rendering in the incorrect tint/color/texture
             float originSphereRadius = 0.05f;
-            DependencyManager::get<GeometryCache>()->renderSphere(originSphereRadius, 15, 15, glm::vec4(1.0f, 0.0f, 0.0f, 1.0f));
+            DependencyManager::get<GeometryCache>()->renderSphere((*args->_batch), originSphereRadius, 15, 15, glm::vec4(1.0f, 0.0f, 0.0f, 1.0f));
         }
     }
 }

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -13,20 +13,14 @@
 
 #include <assert.h>
 
+#include "Batch.h"
+
 #include "Resource.h"
 #include "Texture.h"
 #include "Pipeline.h"
 #include "Framebuffer.h"
 
 namespace gpu {
-
-class GPUObject {
-public:
-    GPUObject() {}
-    virtual ~GPUObject() {}
-};
-
-class Batch;
 
 class Backend {
 public:

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -16,7 +16,11 @@
 
 namespace gpu {
 
-class GPUObject;
+class GPUObject {
+public:
+    GPUObject() {}
+    virtual ~GPUObject() {}
+};
 
 typedef int  Stamp;
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -292,14 +292,18 @@ protected:
             _lastMode(GL_TEXTURE) {}
     } _transform;
 
-    // Pipeline Stage
-    void do_setPipeline(Batch& batch, uint32 paramOffset);
-
-    void do_setStateBlendFactor(Batch& batch, uint32 paramOffset);
-
+    // Uniform Stage
     void do_setUniformBuffer(Batch& batch, uint32 paramOffset);
     void do_setUniformTexture(Batch& batch, uint32 paramOffset);
- 
+    
+    struct UniformStageState {
+        
+    };
+    
+    // Pipeline Stage
+    void do_setPipeline(Batch& batch, uint32 paramOffset);
+    void do_setStateBlendFactor(Batch& batch, uint32 paramOffset);
+    
     // Standard update pipeline check that the current Program and current State or good to go for a
     void updatePipeline();
     // Force to reset all the state fields indicated by the 'toBeReset" signature

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -84,8 +84,8 @@ public:
         GLuint _shader;
         GLuint _program;
 
-        GLuint _transformCameraSlot = -1;
-        GLuint _transformObjectSlot = -1;
+        GLint _transformCameraSlot = -1;
+        GLint _transformObjectSlot = -1;
 
 #if (GPU_TRANSFORM_PROFILE == GPU_CORE)
 #else
@@ -318,7 +318,7 @@ protected:
 
 #if (GPU_TRANSFORM_PROFILE == GPU_CORE)
 #else
-        GLuint _program_transformCamera_viewInverse = -1;
+        GLint _program_transformCamera_viewInverse = -1;
 #endif
 
         State::Data _stateCache;

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -87,6 +87,11 @@ public:
         GLuint _transformCameraSlot = -1;
         GLuint _transformObjectSlot = -1;
 
+#if (GPU_TRANSFORM_PROFILE == GPU_CORE)
+#else
+        GLuint _transformCamera_viewInverse = -1;
+#endif
+
         GLShader();
         ~GLShader();
     };
@@ -310,6 +315,11 @@ protected:
 
         GLuint _program;
         bool _invalidProgram;
+
+#if (GPU_TRANSFORM_PROFILE == GPU_CORE)
+#else
+        GLuint _program_transformCamera_viewInverse = -1;
+#endif
 
         State::Data _stateCache;
         State::Signature _stateSignatureCache;

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -144,9 +144,8 @@ void GLBackend::updatePipeline() {
 #if (GPU_TRANSFORM_PROFILE == GPU_CORE)
 #else
     // If shader program needs the inverseView we need to provide it
-    // YES InverseView in the shade is called View on the Batch interface
     if (_pipeline._program_transformCamera_viewInverse >= 0) {
-        glUniformMatrix4fv(_pipeline._program_transformCamera_viewInverse, 1, false, (const GLfloat*) &_transform._view);
+        glUniformMatrix4fv(_pipeline._program_transformCamera_viewInverse, 1, false, (const GLfloat*) &_transform._transformCamera._viewInverse);
     }
 #endif
 }

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -71,6 +71,11 @@ void GLBackend::do_setPipeline(Batch& batch, uint32 paramOffset) {
         _pipeline._program = 0;
         _pipeline._invalidProgram = true;
 
+#if (GPU_TRANSFORM_PROFILE == GPU_CORE)
+#else
+        _pipeline._program_transformCamera_viewInverse = -1
+#endif
+
         _pipeline._state = nullptr;
         _pipeline._invalidState = true;
     } else {
@@ -83,6 +88,11 @@ void GLBackend::do_setPipeline(Batch& batch, uint32 paramOffset) {
         if (_pipeline._program != pipelineObject->_program->_program) {
             _pipeline._program = pipelineObject->_program->_program;
             _pipeline._invalidProgram = true;
+
+#if (GPU_TRANSFORM_PROFILE == GPU_CORE)
+#else
+            _pipeline._program_transformCamera_viewInverse = pipelineObject->_program->_transformCamera_viewInverse;
+#endif
         }
 
         // Now for the state
@@ -130,6 +140,15 @@ void GLBackend::updatePipeline() {
         }
         _pipeline._invalidState = false;
     }
+
+#if (GPU_TRANSFORM_PROFILE == GPU_CORE)
+#else
+    // If shader program needs the inverseView we need to provide it
+    // YES InverseView in the shade is called View on the Batch interface
+    if (_pipeline._program_transformCamera_viewInverse >= 0) {
+        glUniformMatrix4fv(_pipeline._program_transformCamera_viewInverse, 1, false, &_transform._view);
+    }
+#endif
 }
 
 void GLBackend::do_setUniformBuffer(Batch& batch, uint32 paramOffset) {

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -73,7 +73,7 @@ void GLBackend::do_setPipeline(Batch& batch, uint32 paramOffset) {
 
 #if (GPU_TRANSFORM_PROFILE == GPU_CORE)
 #else
-        _pipeline._program_transformCamera_viewInverse = -1
+        _pipeline._program_transformCamera_viewInverse = -1;
 #endif
 
         _pipeline._state = nullptr;

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -146,7 +146,7 @@ void GLBackend::updatePipeline() {
     // If shader program needs the inverseView we need to provide it
     // YES InverseView in the shade is called View on the Batch interface
     if (_pipeline._program_transformCamera_viewInverse >= 0) {
-        glUniformMatrix4fv(_pipeline._program_transformCamera_viewInverse, 1, false, &_transform._view);
+        glUniformMatrix4fv(_pipeline._program_transformCamera_viewInverse, 1, false, (const GLfloat*) &_transform._view);
     }
 #endif
 }

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -106,6 +106,11 @@ void makeBindings(GLBackend::GLShader* shader) {
         glUniformBlockBinding(glprogram, loc, gpu::TRANSFORM_CAMERA_SLOT);
         shader->_transformCameraSlot = gpu::TRANSFORM_CAMERA_SLOT;
     }
+#else
+    loc = glGetUniformLocation(glprogram, "transformCamera_viewInverse");
+    if (loc >= 0) {
+        shader->_transformCamera_viewInverse = loc;
+    }
 #endif
 }
 

--- a/libraries/gpu/src/gpu/Resource.cpp
+++ b/libraries/gpu/src/gpu/Resource.cpp
@@ -8,8 +8,6 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-
-#include "Context.h"
 #include "Resource.h"
 
 #include <QDebug>

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -86,7 +86,7 @@ TransformCamera getTransformCamera() {
     return camera;
 }
 
-uniform mat4 cameraTransform_viewInverse;
+uniform mat4 transformCamera_viewInverse;
 
 <@endif@>
 <@endfunc@>
@@ -146,7 +146,7 @@ uniform mat4 cameraTransform_viewInverse;
         <$worldDir$> = vec3(<$cameraTransform$>._viewInverse * vec4(<$eyeDir$>.xyz, 0.0));
     }
 <@else@>
-    <$worldDir$> = vec3(cameraTransform_viewInverse * vec4(<$eyeDir$>.xyz, 0.0));
+    <$worldDir$> = vec3(transformCamera_viewInverse * vec4(<$eyeDir$>.xyz, 0.0));
 <@endif@>
 <@endfunc@>
 

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -86,6 +86,8 @@ TransformCamera getTransformCamera() {
     return camera;
 }
 
+uniform mat4 cameraTransform_viewInverse;
+
 <@endif@>
 <@endfunc@>
 
@@ -109,10 +111,10 @@ TransformCamera getTransformCamera() {
       //return camera._projection * camera._view * object._model * pos; !>
     { // transformModelToClipPos
         vec4 _worldpos = (<$objectTransform$>._model * <$modelPos$>);
-      //  <$eyePos$> = (<$cameraTransform$>._viewInverse * _worldpos);
+        <$eyePos$> = (<$cameraTransform$>._view * _worldpos);
         vec4 _eyepos =(<$objectTransform$>._model * <$modelPos$>) + vec4(-<$modelPos$>.w * <$cameraTransform$>._viewInverse[3].xyz, 0.0);
         <$clipPos$> = <$cameraTransform$>._projectionViewUntranslated * _eyepos;
-        <$eyePos$> = (<$cameraTransform$>._projectionInverse * <$clipPos$>);
+      //  <$eyePos$> = (<$cameraTransform$>._projectionInverse * <$clipPos$>);
     }
 <@else@>
     <$eyePos$> = gl_ModelViewMatrix * <$modelPos$>;
@@ -144,7 +146,7 @@ TransformCamera getTransformCamera() {
         <$worldDir$> = vec3(<$cameraTransform$>._viewInverse * vec4(<$eyeDir$>.xyz, 0.0));
     }
 <@else@>
-    <$worldDir$> = vec3(gl_ModelViewMatrixInverse * vec4(<$eyeDir$>.xyz, 0.0));
+    <$worldDir$> = vec3(cameraTransform_viewInverse * vec4(<$eyeDir$>.xyz, 0.0));
 <@endif@>
 <@endfunc@>
 

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -103,6 +103,22 @@ TransformCamera getTransformCamera() {
 <@endif@>
 <@endfunc@>
 
+<@func $transformModelToEyeAndClipPos(cameraTransform, objectTransform, modelPos, eyePos, clipPos)@>
+<@if GPU_TRANSFORM_PROFILE == GPU_CORE@>
+    <!// Equivalent to the following but hoppefully a tad more accurate
+      //return camera._projection * camera._view * object._model * pos; !>
+    { // transformModelToClipPos
+        vec4 _worldpos = (<$objectTransform$>._model * <$modelPos$>);
+        <$eyePos$> = (<$cameraTransform$>._viewInverse * _worldpos);
+        vec4 _eyepos =(<$objectTransform$>._model * <$modelPos$>) + vec4(-<$modelPos$>.w * <$cameraTransform$>._viewInverse[3].xyz, 0.0);
+        <$clipPos$> = <$cameraTransform$>._projectionViewUntranslated * _eyepos;
+    }
+<@else@>
+    <$eyePos$> = gl_ModelViewMatrix * <$modelPos$>;
+    <$clipPos$> = gl_ModelViewProjectionMatrix * <$modelPos$>;
+<@endif@>
+<@endfunc@>
+
 <@func transformModelToEyeDir(cameraTransform, objectTransform, modelDir, eyeDir)@>
 <@if GPU_TRANSFORM_PROFILE == GPU_CORE@>
     { // transformModelToEyeDir

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -555,9 +555,9 @@ void DeferredLightingEffect::copyBack(RenderArgs* args) {
     glPopMatrix();
 }
 
-void DeferredLightingEffect::setupTransparent(RenderArgs* args) {
+void DeferredLightingEffect::setupTransparent(RenderArgs* args, int lightBufferUnit) {
     auto globalLight = _allocatedLights[_globalLights.front()];
-    args->_batch->setUniformBuffer(4, globalLight->getSchemaBuffer());
+    args->_batch->setUniformBuffer(lightBufferUnit, globalLight->getSchemaBuffer());
 }
 
 void DeferredLightingEffect::loadLightProgram(const char* fragSource, bool limited, ProgramObject& program, LightLocations& locations) {

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -70,7 +70,7 @@ public:
     void render();
     void copyBack(RenderArgs* args);
 
-    void setupTransparent(RenderArgs* args);
+    void setupTransparent(RenderArgs* args, int lightBufferUnit);
 
     // update global lighting
     void setAmbientLightMode(int preset);

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -23,7 +23,7 @@
 #include "model/Stage.h"
 
 class AbstractViewStateInterface;
-class PostLightingRenderable;
+class RenderArgs;
 
 /// Handles deferred lighting for the bits that require it (voxels...)
 class DeferredLightingEffect : public Dependency {
@@ -66,11 +66,11 @@ public:
     void addSpotLight(const glm::vec3& position, float radius, const glm::vec3& color = glm::vec3(1.0f, 1.0f, 1.0f),
         float intensity = 0.5f, const glm::quat& orientation = glm::quat(), float exponent = 0.0f, float cutoff = PI);
     
-    /// Adds an object to render after performing the deferred lighting for the current frame (e.g., a translucent object).
-    void addPostLightingRenderable(PostLightingRenderable* renderable) { _postLightingRenderables.append(renderable); }
-    
     void prepare();
     void render();
+    void copyBack(RenderArgs* args);
+
+    void setupTransparent(RenderArgs* args);
 
     // update global lighting
     void setAmbientLightMode(int preset);
@@ -153,19 +153,12 @@ private:
     std::vector<int> _globalLights;
     std::vector<int> _pointLights;
     std::vector<int> _spotLights;
-    QVector<PostLightingRenderable*> _postLightingRenderables;
     
     AbstractViewStateInterface* _viewState;
 
     int _ambientLightMode = 0;
     model::AtmospherePointer _atmosphere;
     model::SkyboxPointer _skybox;
-};
-
-/// Simple interface for objects that require something to be rendered after deferred lighting.
-class PostLightingRenderable {
-public:
-    virtual void renderPostLighting() = 0;
 };
 
 #endif // hifi_DeferredLightingEffect_h

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -197,13 +197,17 @@ void Model::RenderPipelineLib::initLocations(gpu::ShaderPointer& program, Model:
 
 #if (GPU_FEATURE_PROFILE == GPU_CORE)
     locations.materialBufferUnit = program->getBuffers().findLocation("materialBuffer");
+    locations.lightBufferUnit = program->getBuffers().findLocation("lightBuffer");
 #else
     locations.materialBufferUnit = program->getUniforms().findLocation("materialBuffer");
+    locations.lightBufferUnit = program->getUniforms().findLocation("lightBuffer");
 #endif
     locations.clusterMatrices = program->getUniforms().findLocation("clusterMatrices");
 
     locations.clusterIndices = program->getInputs().findLocation("clusterIndices");;
     locations.clusterWeights = program->getInputs().findLocation("clusterWeights");;
+    
+
 
 }
 
@@ -2250,6 +2254,10 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
                 Texture* emissiveMap = networkPart.emissiveTexture.data();
                 batch.setUniformTexture(locations->emissiveTextureUnit, !emissiveMap ?
                                         textureCache->getWhiteTexture() : emissiveMap->getGPUTexture());
+            }
+            
+            if (translucent && locations->lightBufferUnit >= 0) {
+                DependencyManager::get<DeferredLightingEffect>()->setupTransparent(args, locations->lightBufferUnit);
             }
         }
     }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -140,8 +140,7 @@ void Model::RenderPipelineLib::addRenderPipeline(Model::RenderKey key,
 
     // Blend on transparent
     state->setBlendFunction(key.isTranslucent(),
-     //   gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
-        gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+        gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA, // For transparent only, this keep the highlight intensity
         gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
     // Good to go add the brand new pipeline

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -2329,20 +2329,28 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
         return; // FIXME!
     }
     
-    if (state.clusterMatrices.size() > 1) {
+    if (isSkinned) {
+    //if (state.clusterMatrices.size() > 1) {
         GLBATCH(glUniformMatrix4fv)(locations->clusterMatrices, state.clusterMatrices.size(), false,
             (const float*)state.clusterMatrices.constData());
- //       batch.setModelTransform(Transform());
+      
+       _transforms[0].setIdentity();
        _transforms[0].setTranslation(_translation);
+       // batch.setModelTransform(Transform());
+       batch.setModelTransform(_transforms[0]);
 
+        //_transforms[0] = _viewState->getViewTransform();
+      //  args->_viewFrustum->evalViewTransform(_transforms[0]);
+     //   _transforms[0].preTranslate(-_translation);
+      //  batch.setViewTransform(_transforms[0]);
     } else {
        _transforms[0] = Transform(state.clusterMatrices[0]);
        _transforms[0].preTranslate(_translation);
 
         //batch.setModelTransform(Transform(state.clusterMatrices[0]));
+       batch.setModelTransform(_transforms[0]);
     }
-    batch.setModelTransform(_transforms[0]);
-
+ 
 
     if (mesh.blendshapes.isEmpty()) {
         batch.setInputFormat(networkMesh._vertexFormat);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -140,7 +140,8 @@ void Model::RenderPipelineLib::addRenderPipeline(Model::RenderKey key,
 
     // Blend on transparent
     state->setBlendFunction(key.isTranslucent(),
-        gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+     //   gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+        gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
         gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
     // Good to go add the brand new pipeline
@@ -2174,11 +2175,6 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
     const NetworkMeshPart& networkPart = networkMesh.parts.at(partIndex);
     const FBXMeshPart& part = mesh.parts.at(partIndex);
     model::MaterialPointer material = part._material;
-
-    float shininess = 0;
-    if (translucent) {
-        shininess = material->getShininess();
-    }
 
     if (material == nullptr) {
     //    qCDebug(renderutils) << "WARNING: material == nullptr!!!";

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -112,6 +112,7 @@ void Model::RenderPipelineLib::addRenderPipeline(Model::RenderKey key,
     slotBindings.insert(gpu::Shader::Binding(std::string("normalMap"), 1));
     slotBindings.insert(gpu::Shader::Binding(std::string("specularMap"), 2));
     slotBindings.insert(gpu::Shader::Binding(std::string("emissiveMap"), 3));
+    slotBindings.insert(gpu::Shader::Binding(std::string("lightBuffer"), 4));
 
     gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vertexShader, pixelShader));
     gpu::Shader::makeProgram(*program, slotBindings);
@@ -2157,6 +2158,11 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
     const NetworkMeshPart& networkPart = networkMesh.parts.at(partIndex);
     const FBXMeshPart& part = mesh.parts.at(partIndex);
     model::MaterialPointer material = part._material;
+
+    float shininess = 0;
+    if (translucent) {
+        shininess = material->getShininess();
+    }
 
     if (material == nullptr) {
     //    qCDebug(renderutils) << "WARNING: material == nullptr!!!";

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -374,6 +374,7 @@ private:
         int clusterMatrices;
         int clusterIndices;
         int clusterWeights;
+        int lightBufferUnit;
     };
 
     QHash<QPair<int,int>, AABox> _calculatedMeshPartBoxes; // world coordinate AABoxes for all sub mesh part boxes

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -130,18 +130,6 @@ template <> void render::jobRun(const DrawTransparentDeferred& job, const SceneC
         const float MOSTLY_OPAQUE_THRESHOLD = 0.75f;
         const float TRANSPARENT_ALPHA_THRESHOLD = 0.0f;
 
-  /*      // render translucent meshes afterwards
-        {
-            GLenum buffers[2];
-            int bufferCount = 0;
-            buffers[bufferCount++] = GL_COLOR_ATTACHMENT1;
-            buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
-            batch._glDrawBuffers(bufferCount, buffers);
-            args->_alphaThreshold = MOSTLY_OPAQUE_THRESHOLD;
-         }
-
-        renderItems(sceneContext, renderContext, renderedItems, renderContext->_maxDrawnTransparentItems);
-*/
         {
             GLenum buffers[3];
             int bufferCount = 0;
@@ -155,5 +143,8 @@ template <> void render::jobRun(const DrawTransparentDeferred& job, const SceneC
 
         args->_context->render((*args->_batch));
         args->_batch = nullptr;
+
+        // reset blend function to standard...
+        glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_CONSTANT_ALPHA, GL_ONE);
     }
 }

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -115,7 +115,7 @@ template <> void render::jobRun(const DrawTransparentDeferred& job, const SceneC
         gpu::Batch batch;
         args->_batch = &batch;
 
-        DependencyManager::get<DeferredLightingEffect>()->setupTransparent(renderContext->args);
+        
 
 
         glm::mat4 projMat;

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -10,7 +10,11 @@
 //
 #include "RenderDeferredTask.h"
 
+#include "gpu/Batch.h"
 #include "gpu/Context.h"
+#include "DeferredLightingEffect.h"
+#include "ViewFrustum.h"
+#include "RenderArgs.h"
 
 #include <PerfStat.h>
 
@@ -22,9 +26,15 @@ template <> void render::jobRun(const PrepareDeferred& job, const SceneContextPo
     DependencyManager::get<DeferredLightingEffect>()->prepare();
 }
 
+template <> void render::jobRun(const RenderDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
+    PerformanceTimer perfTimer("RenderDeferred");
+    DependencyManager::get<DeferredLightingEffect>()->render();
+//    renderContext->args->_context->syncCache();
+}
+
 template <> void render::jobRun(const ResolveDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
     PerformanceTimer perfTimer("ResolveDeferred");
-    DependencyManager::get<DeferredLightingEffect>()->render();
+    DependencyManager::get<DeferredLightingEffect>()->copyBack(renderContext->args);
 }
 
 
@@ -34,10 +44,11 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
    _jobs.push_back(Job(DrawBackground()));
    _jobs.push_back(Job(DrawOpaque()));
    _jobs.push_back(Job(DrawLight()));
-   _jobs.push_back(Job(DrawTransparent()));
    _jobs.push_back(Job(ResetGLState()));
+   _jobs.push_back(Job(RenderDeferred()));
    _jobs.push_back(Job(ResolveDeferred()));
-
+   _jobs.push_back(Job(DrawTransparentDeferred()));
+   _jobs.push_back(Job(ResetGLState()));
 }
 
 RenderDeferredTask::~RenderDeferredTask() {
@@ -62,3 +73,85 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
         job.run(sceneContext, renderContext);
     }
 };
+
+
+
+template <> void render::jobRun(const DrawTransparentDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
+    PerformanceTimer perfTimer("DrawTransparentDeferred");
+    assert(renderContext->args);
+    assert(renderContext->args->_viewFrustum);
+
+    // render transparents
+    auto& scene = sceneContext->_scene;
+    auto& items = scene->getMasterBucket().at(ItemFilter::Builder::transparentShape());
+
+    ItemIDs inItems;
+    inItems.reserve(items.size());
+    for (auto id : items) {
+        inItems.push_back(id);
+    }
+    ItemIDs& renderedItems = inItems;
+
+    renderContext->_numFeedTransparentItems = renderedItems.size();
+
+    ItemIDs culledItems;
+    if (renderContext->_cullTransparent) {
+        cullItems(sceneContext, renderContext, inItems, culledItems);
+        renderedItems = culledItems;
+    }
+
+    renderContext->_numDrawnTransparentItems = renderedItems.size();
+
+    ItemIDs sortedItems;
+    if (renderContext->_sortTransparent) {
+        depthSortItems(sceneContext, renderContext, false, renderedItems, sortedItems); // Sort Back to front transparent items!
+        renderedItems = sortedItems;
+    }
+
+    if (renderContext->_renderTransparent) {
+        RenderArgs* args = renderContext->args;
+        gpu::Batch batch;
+        args->_batch = &batch;
+
+        DependencyManager::get<DeferredLightingEffect>()->setupTransparent(renderContext->args);
+
+
+        glm::mat4 projMat;
+        Transform viewMat;
+        args->_viewFrustum->evalProjectionMatrix(projMat);
+        args->_viewFrustum->evalViewTransform(viewMat);
+        batch.setProjectionTransform(projMat);
+        batch.setViewTransform(viewMat);
+
+        args->_renderMode = RenderArgs::NORMAL_RENDER_MODE;
+
+        const float MOSTLY_OPAQUE_THRESHOLD = 0.75f;
+        const float TRANSPARENT_ALPHA_THRESHOLD = 0.0f;
+
+  /*      // render translucent meshes afterwards
+        {
+            GLenum buffers[2];
+            int bufferCount = 0;
+            buffers[bufferCount++] = GL_COLOR_ATTACHMENT1;
+            buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
+            batch._glDrawBuffers(bufferCount, buffers);
+            args->_alphaThreshold = MOSTLY_OPAQUE_THRESHOLD;
+         }
+
+        renderItems(sceneContext, renderContext, renderedItems, renderContext->_maxDrawnTransparentItems);
+*/
+        {
+            GLenum buffers[3];
+            int bufferCount = 0;
+            buffers[bufferCount++] = GL_COLOR_ATTACHMENT0;
+            batch._glDrawBuffers(bufferCount, buffers);
+            args->_alphaThreshold = TRANSPARENT_ALPHA_THRESHOLD;
+        }
+
+
+        renderItems(sceneContext, renderContext, renderedItems, renderContext->_maxDrawnTransparentItems);
+
+        args->_context->render((*args->_batch));
+        args->_batch = nullptr;
+    }
+}

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -14,8 +14,6 @@
 
 #include "render/DrawTask.h"
 
-#include "DeferredLightingEffect.h"
-
 class PrepareDeferred {
 public:
 };
@@ -23,11 +21,25 @@ namespace render {
 template <> void jobRun(const PrepareDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext);
 }
 
+class RenderDeferred {
+public:
+};
+namespace render {
+template <> void jobRun(const RenderDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext);
+}
+
 class ResolveDeferred {
 public:
 };
 namespace render {
 template <> void jobRun(const ResolveDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext);
+}
+
+class DrawTransparentDeferred {
+public:
+};
+namespace render {
+template <> void jobRun(const DrawTransparentDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext);
 }
 
 class RenderDeferredTask : public render::Task {

--- a/libraries/render-utils/src/TextureCache.cpp
+++ b/libraries/render-utils/src/TextureCache.cpp
@@ -52,8 +52,6 @@ void TextureCache::setFrameBufferSize(QSize frameBufferSize) {
         _primaryNormalTexture.reset();
         _primarySpecularTexture.reset();
 
-        _transparentFramebuffer.reset();
-
         _secondaryFramebuffer.reset();
 
         _tertiaryFramebuffer.reset();
@@ -264,14 +262,6 @@ void TextureCache::setPrimaryDrawBuffers(gpu::Batch& batch, bool color, bool nor
         buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
     }
     batch._glDrawBuffers(bufferCount, buffers);
-}
-
-gpu::FramebufferPointer TextureCache::getTransparentFramebuffer() {
-    if (!_transparentFramebuffer) {
-        _transparentFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create(gpu::Element::COLOR_RGBA_32, _frameBufferSize.width(), _frameBufferSize.height()));
-        _transparentFramebuffer->setDepthStencilBuffer(getPrimaryDepthTexture(), getPrimaryDepthTexture()->getTexelFormat());
-    }
-    return _transparentFramebuffer;
 }
 
 gpu::FramebufferPointer TextureCache::getSecondaryFramebuffer() {

--- a/libraries/render-utils/src/TextureCache.cpp
+++ b/libraries/render-utils/src/TextureCache.cpp
@@ -52,6 +52,8 @@ void TextureCache::setFrameBufferSize(QSize frameBufferSize) {
         _primaryNormalTexture.reset();
         _primarySpecularTexture.reset();
 
+        _transparentFramebuffer.reset();
+
         _secondaryFramebuffer.reset();
 
         _tertiaryFramebuffer.reset();
@@ -262,6 +264,14 @@ void TextureCache::setPrimaryDrawBuffers(gpu::Batch& batch, bool color, bool nor
         buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
     }
     batch._glDrawBuffers(bufferCount, buffers);
+}
+
+gpu::FramebufferPointer TextureCache::getTransparentFramebuffer() {
+    if (!_transparentFramebuffer) {
+        _transparentFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create(gpu::Element::COLOR_RGBA_32, _frameBufferSize.width(), _frameBufferSize.height()));
+        _transparentFramebuffer->setDepthStencilBuffer(getPrimaryDepthTexture(), getPrimaryDepthTexture()->getTexelFormat());
+    }
+    return _transparentFramebuffer;
 }
 
 gpu::FramebufferPointer TextureCache::getSecondaryFramebuffer() {

--- a/libraries/render-utils/src/TextureCache.h
+++ b/libraries/render-utils/src/TextureCache.h
@@ -71,6 +71,8 @@ public:
     gpu::TexturePointer getPrimaryNormalTexture();
     gpu::TexturePointer getPrimarySpecularTexture();
 
+    gpu::FramebufferPointer getTransparentFramebuffer();
+
     /// Returns the ID of the primary framebuffer object's depth texture.  This contains the Z buffer used in rendering.
     GLuint getPrimaryDepthTextureID();
     GLuint getPrimaryColorTextureID();
@@ -123,6 +125,8 @@ private:
     gpu::TexturePointer _primarySpecularTexture;
     gpu::FramebufferPointer _primaryFramebuffer;
     void createPrimaryFramebuffer();
+
+    gpu::FramebufferPointer _transparentFramebuffer;
 
     gpu::FramebufferPointer _secondaryFramebuffer;
     gpu::FramebufferPointer _tertiaryFramebuffer;

--- a/libraries/render-utils/src/TextureCache.h
+++ b/libraries/render-utils/src/TextureCache.h
@@ -71,8 +71,6 @@ public:
     gpu::TexturePointer getPrimaryNormalTexture();
     gpu::TexturePointer getPrimarySpecularTexture();
 
-    gpu::FramebufferPointer getTransparentFramebuffer();
-
     /// Returns the ID of the primary framebuffer object's depth texture.  This contains the Z buffer used in rendering.
     GLuint getPrimaryDepthTextureID();
     GLuint getPrimaryColorTextureID();
@@ -125,8 +123,6 @@ private:
     gpu::TexturePointer _primarySpecularTexture;
     gpu::FramebufferPointer _primaryFramebuffer;
     void createPrimaryFramebuffer();
-
-    gpu::FramebufferPointer _transparentFramebuffer;
 
     gpu::FramebufferPointer _secondaryFramebuffer;
     gpu::FramebufferPointer _tertiaryFramebuffer;

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -40,6 +40,6 @@ void main(void) {
     TransformObject obj = getTransformObject();
     <$transformModelToEyeAndClipPos(cam, obj, gl_Vertex, interpolatedPosition, gl_Position)$>
     <$transformModelToEyeDir(cam, obj, gl_Normal, interpolatedNormal.xyz)$>
- //   interpolatedPosition = (gl_Vertex);
+
     interpolatedNormal = vec4(normalize(interpolatedNormal.xyz), 0.0);
 }

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -19,6 +19,9 @@ const int MAX_TEXCOORDS = 2;
 
 uniform mat4 texcoordMatrices[MAX_TEXCOORDS];
 
+// interpolated eye position
+varying vec4 interpolatedPosition;
+
 // the interpolated normal
 varying vec4 interpolatedNormal;
 
@@ -35,7 +38,7 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToClipPos(cam, obj, gl_Vertex, gl_Position)$>
+    <$transformModelToEyeAndClipPos(cam, obj, gl_Vertex, interpolatedPosition, gl_Position)$>
     <$transformModelToEyeDir(cam, obj, gl_Normal, interpolatedNormal.xyz)$>
 
     interpolatedNormal = vec4(normalize(interpolatedNormal.xyz), 0.0);

--- a/libraries/render-utils/src/model_normal_map.slv
+++ b/libraries/render-utils/src/model_normal_map.slv
@@ -23,6 +23,9 @@ uniform mat4 texcoordMatrices[MAX_TEXCOORDS];
 // the tangent vector
 attribute vec3 tangent;
 
+// interpolated eye position
+varying vec4 interpolatedPosition;
+
 // the interpolated normal
 varying vec4 interpolatedNormal;
 
@@ -45,7 +48,7 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToClipPos(cam, obj, gl_Vertex, gl_Position)$>
+    <$transformModelToEyeAndClipPos(cam, obj, gl_Vertex, interpolatedPosition, gl_Position)$>
     <$transformModelToEyeDir(cam, obj, gl_Normal, interpolatedNormal.xyz)$>
     <$transformModelToEyeDir(cam, obj, tangent, interpolatedTangent.xyz)$>
 

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -78,7 +78,6 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 d
     // Need the light now
     Light light = getLight();
     TransformCamera cam = getTransformCamera();
-  //  mat4 viewMat = cam._viewInverse;
     vec3 fragNormal;
     <$transformEyeToWorldDir(cam, normal, fragNormal)$>
     vec3 fragEyeVectorView = normalize(-position);
@@ -91,7 +90,10 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 d
 
     color += vec3(opacity * diffuse + shading.rgb) * shading.w * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
 
+    //return vec4(color, opacity);
     return vec4(color, opacity);
+    //return vec4(diffuse.rgb, opacity);
+    //return evalNormalColor(fragEyeDir, opacity);
 }
 
 // the diffuse texture

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -11,8 +11,7 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-
-<@include DeferredBufferWrite.slh@>
+<!/*<@include DeferredBufferWrite.slh@>
 
 <@include model/Material.slh@>
 
@@ -39,4 +38,72 @@ void main(void) {
 
     // set the diffuse data
  //   gl_FragData[0] = gl_Color * texture2D(diffuseMap, gl_TexCoord[0].st);
+}*/!>
+<@include model/Material.slh@>
+
+// Everything about global lighting
+
+<@include DeferredLighting.slh@>
+<@include gpu/Transform.slh@>
+<$declareStandardTransform()$>
+
+
+// Everything about light
+<@include model/Light.slh@>
+
+// The view Matrix
+//uniform mat4 invViewMat;
+
+vec3 evalAmbienGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 diffuse, vec3 specular, float gloss) {
+
+    // Need the light now
+    Light light = getLight();
+    TransformCamera cam = getTransformCamera();
+    mat4 invViewMat = cam._viewInverse;
+
+    vec3 fragNormal = vec3(invViewMat * vec4(normal, 0.0));
+    vec4 fragEyeVector = invViewMat * vec4(-position, 0.0);
+    vec3 fragEyeDir = normalize(fragEyeVector.xyz);
+
+    vec3 color = diffuse.rgb * getLightColor(light) * getLightAmbientIntensity(light);
+
+    vec4 shading = evalFragShading(fragNormal, -getLightDirection(light), fragEyeDir, specular, gloss);
+
+    color += vec3(diffuse + shading.rgb) * shading.w * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
+
+    return color;
+}
+
+// the diffuse texture
+uniform sampler2D diffuseMap;
+
+// the interpolated view position
+varying vec4 interpolatedPosition;
+
+// the interpolated normal
+varying vec4 interpolatedNormal;
+
+varying vec3 color;
+
+void main(void) {
+    vec3 fragPosition = interpolatedPosition.xyz;
+
+    // Fetch diffuse map
+    vec4 diffuse = texture2D(diffuseMap, gl_TexCoord[0].st);
+
+    Material mat = getMaterial();
+    vec3 fragNormal = normalize(interpolatedNormal.xyz);
+    float fragOpacity = getMaterialOpacity(mat) * diffuse.a;
+    vec3 fragDiffuse = getMaterialDiffuse(mat) * diffuse.rgb * color;
+    vec3 fragSpecular = getMaterialSpecular(mat);
+    float fragGloss = getMaterialShininess(mat);
+
+    vec3 color =  evalAmbienGlobalColor(1.0,
+                                    fragPosition,
+                                    fragNormal,
+                                    fragDiffuse,
+                                    fragSpecular,
+                                    fragGloss);
+
+    gl_FragColor = vec4(color, fragOpacity);
 }

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -73,7 +73,7 @@ vec4 evalNormalColor(vec3 dir, float opacity) {
     return vec4(0.5 * dir + vec3(0.5), opacity);
 }
 
-vec4 evalAmbienGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 diffuse, vec3 specular, float gloss, float opacity) {
+vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 diffuse, vec3 specular, float gloss, float opacity) {
 
     // Need the light now
     Light light = getLight();
@@ -85,7 +85,7 @@ vec4 evalAmbienGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, 
     vec3 fragEyeDir;
     <$transformEyeToWorldDir(cam, fragEyeVectorView, fragEyeDir)$>
 
-    vec3 color = diffuse.rgb * getLightColor(light) * getLightAmbientIntensity(light);
+    vec3 color = opacity * diffuse.rgb * getLightColor(light) * getLightAmbientIntensity(light);
 
     vec4 shading = evalFragShading(fragNormal, -getLightDirection(light), fragEyeDir, specular, gloss);
 
@@ -118,7 +118,7 @@ void main(void) {
     vec3 fragSpecular = getMaterialSpecular(mat);
     float fragGloss = getMaterialShininess(mat);
 
-    vec4 fragColor =  evalAmbienGlobalColor(1.0,
+    vec4 fragColor =  evalGlobalColor(1.0,
                                     fragPosition,
                                     fragNormal,
                                     fragDiffuse,
@@ -126,5 +126,5 @@ void main(void) {
                                     fragGloss,
                                     fragOpacity);
 
-    gl_FragColor = fragColor; //vec4(fragColor, fragOpacity);
+    gl_FragColor = fragColor;
 }

--- a/libraries/render-utils/src/skin_model.slv
+++ b/libraries/render-utils/src/skin_model.slv
@@ -52,7 +52,7 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToWorldAndClipPos(cam, obj, gl_Vertex, interpolatedPosition, gl_Position)$>
+    <$transformModelToEyeAndClipPos(cam, obj, gl_Vertex, interpolatedPosition, gl_Position)$>
     <$transformModelToEyeDir(cam, obj, interpolatedNormal.xyz, interpolatedNormal.xyz)$>
 
     interpolatedNormal = vec4(normalize(interpolatedNormal.xyz), 0.0);

--- a/libraries/render-utils/src/skin_model.slv
+++ b/libraries/render-utils/src/skin_model.slv
@@ -25,6 +25,9 @@ uniform mat4 texcoordMatrices[MAX_TEXCOORDS];
 attribute vec4 clusterIndices;
 attribute vec4 clusterWeights;
 
+// interpolated eye position
+varying vec4 interpolatedPosition;
+
 // the interpolated normal
 varying vec4 interpolatedNormal;
 
@@ -49,7 +52,7 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToClipPos(cam, obj, position, gl_Position)$>
+    <$transformModelToWorldAndClipPos(cam, obj, gl_Vertex, interpolatedPosition, gl_Position)$>
     <$transformModelToEyeDir(cam, obj, interpolatedNormal.xyz, interpolatedNormal.xyz)$>
 
     interpolatedNormal = vec4(normalize(interpolatedNormal.xyz), 0.0);

--- a/libraries/render-utils/src/skin_model_normal_map.slv
+++ b/libraries/render-utils/src/skin_model_normal_map.slv
@@ -28,6 +28,9 @@ attribute vec3 tangent;
 attribute vec4 clusterIndices;
 attribute vec4 clusterWeights;
 
+// interpolated eye position
+varying vec4 interpolatedPosition;
+
 // the interpolated normal
 varying vec4 interpolatedNormal;
 
@@ -37,13 +40,13 @@ varying vec4 interpolatedTangent;
 varying vec3 color;
 
 void main(void) {
-    vec4 interpolatedPosition = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 position = vec4(0.0, 0.0, 0.0, 0.0);
     interpolatedNormal = vec4(0.0, 0.0, 0.0, 0.0);
     interpolatedTangent = vec4(0.0, 0.0, 0.0, 0.0);
     for (int i = 0; i < INDICES_PER_VERTEX; i++) {
         mat4 clusterMatrix = clusterMatrices[int(clusterIndices[i])];
         float clusterWeight = clusterWeights[i];
-        interpolatedPosition += clusterMatrix * gl_Vertex * clusterWeight;
+        position += clusterMatrix * gl_Vertex * clusterWeight;
         interpolatedNormal += clusterMatrix * vec4(gl_Normal, 0.0) * clusterWeight;
         interpolatedTangent += clusterMatrix * vec4(tangent, 0.0) * clusterWeight;
     }
@@ -60,7 +63,7 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToClipPos(cam, obj, interpolatedPosition, gl_Position)$>
+    <$transformModelToEyeAndClipPos(cam, obj, position, interpolatedPosition, gl_Position)$>
     <$transformModelToEyeDir(cam, obj, interpolatedNormal.xyz, interpolatedNormal.xyz)$>
     <$transformModelToEyeDir(cam, obj, interpolatedTangent.xyz, interpolatedTangent.xyz)$>
 


### PR DESCRIPTION
- THis work move the rendering of the transparent objects after the gBuffer opaque layer is fully lit.
THis provide a clean correct rendering of the opaque layer
THe transparent objects are blended from back to front according to the opacity blending. There still would be issues with resolving transparency within one transparent object with overlapping but this will be solved in a future sprint.

- The transparent object are rendered and lit solely by the key light and not affected by the spherical harmonics yet.

- Moved the definition of GPUObject to Format.h for visibility of all the gpu classes more easily

- Removed the "post LIghting Objects" from the deferred lighting effect as this has never been used and won;t work with the new technique used 

- the Glowing effect is maybe affected by this, will need to be checked