### PR TITLE
Exposing Input Key Binding To JavaScript

### DIFF
--- a/examples/example/scripts/controllerScriptingExamples.js
+++ b/examples/example/scripts/controllerScriptingExamples.js
@@ -1,0 +1,94 @@
+//
+//  controllerScriptingExamples.js
+//  examples
+//
+//  Created by Sam Gondelman on 6/2/15
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+// Resets every device to its default key bindings:
+Controller.resetAllDeviceBindings()
+
+// Query all actions
+print("All Actions: \n" + Controller.getAllActions())
+
+// Each action stores:
+// action: int representation of enum
+print("Action 5 int: \n" + Controller.getAllActions()[5].action)
+
+// actionName: string representation of enum
+print("Action 5 name: \n" + Controller.getAllActions()[5].actionName)
+
+// inputChannels: list of all inputchannels that control that action
+print("Action 5 input channels: \n" + Controller.getAllActions()[5].inputChannels + "\n")
+
+
+// Each input channel stores:
+// action: Action that this InputChannel maps to
+print("Input channel action: \n" + Controller.getAllActions()[5].inputChannels[0].action)
+
+// scale: sensitivity of input
+print("Input channel scale: \n" + Controller.getAllActions()[5].inputChannels[0].scale)
+
+// input and modifier: Inputs
+print("Input channel input and modifier: \n" + Controller.getAllActions()[5].inputChannels[0].input + "\n" + Controller.getAllActions()[5].inputChannels[0].modifier + "\n")
+
+
+// Each Input stores:
+// device: device of input
+print("Input device: \n" + Controller.getAllActions()[5].inputChannels[0].input.device)
+
+// channel: channel of input
+print("Input channel: \n" + Controller.getAllActions()[5].inputChannels[0].input.channel)
+
+// type: type of input (Unknown, Button, Axis, Joint)
+print("Input type: \n" + Controller.getAllActions()[5].inputChannels[0].input.type)
+
+// id: id of input
+print("Input id: \n" + Controller.getAllActions()[5].inputChannels[0].input.id + "\n")
+
+
+// You can get the name of a device from its id
+print("Device 1 name: \n" + Controller.getDeviceName(Controller.getAllActions()[5].inputChannels[0].input.id))
+
+// You can also get all of a devices input channels
+print("Device 1's input channels: \n" + Controller.getAllInputsForDevice(1) + "\n")
+
+
+// Modifying properties:
+// The following code will switch the "w" and "s" key functionality and adjust their scales
+var s = Controller.getAllActions()[0].inputChannels[0]
+var w = Controller.getAllActions()[1].inputChannels[0]
+
+// You must remove an input controller before modifying it so the old input controller isn't registered anymore
+// removeInputChannel and addInputChannel return true if successful, false otherwise
+Controller.removeInputChannel(s)
+Controller.removeInputChannel(w)
+print(s.scale)
+s.action = 1
+s.scale = .01
+
+w.action = 0
+w.scale = 10000
+Controller.addInputChannel(s)
+Controller.addInputChannel(w)
+print(s.scale)
+
+// You can get all the available inputs for any device
+// Each AvailableInput has:
+// input: the Input itself
+// inputName: string representing the input
+var availableInputs = Controller.getAvailableInputs(1)
+for (i = 0; i < availableInputs.length; i++) {
+	print(availableInputs[i].inputName);
+}
+
+// You can modify key bindings by using these avaiable inputs
+// This will replace e (up) with 6
+var e = Controller.getAllActions()[5].inputChannels[0]
+Controller.removeInputChannel(e)
+e.input = availableInputs[6].input
+Controller.addInputChannel(e)

--- a/examples/example/scripts/controllerScriptingExamples.js
+++ b/examples/example/scripts/controllerScriptingExamples.js
@@ -9,86 +9,88 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+// Assumes you only have the default keyboard connected
+
 // Resets every device to its default key bindings:
-Controller.resetAllDeviceBindings()
+Controller.resetAllDeviceBindings();
 
 // Query all actions
-print("All Actions: \n" + Controller.getAllActions())
+print("All Actions: \n" + Controller.getAllActions());
 
 // Each action stores:
 // action: int representation of enum
-print("Action 5 int: \n" + Controller.getAllActions()[5].action)
+print("Action 5 int: \n" + Controller.getAllActions()[5].action);
 
 // actionName: string representation of enum
-print("Action 5 name: \n" + Controller.getAllActions()[5].actionName)
+print("Action 5 name: \n" + Controller.getAllActions()[5].actionName);
 
 // inputChannels: list of all inputchannels that control that action
-print("Action 5 input channels: \n" + Controller.getAllActions()[5].inputChannels + "\n")
+print("Action 5 input channels: \n" + Controller.getAllActions()[5].inputChannels + "\n");
 
 
 // Each input channel stores:
 // action: Action that this InputChannel maps to
-print("Input channel action: \n" + Controller.getAllActions()[5].inputChannels[0].action)
+print("Input channel action: \n" + Controller.getAllActions()[5].inputChannels[0].action);
 
 // scale: sensitivity of input
-print("Input channel scale: \n" + Controller.getAllActions()[5].inputChannels[0].scale)
+print("Input channel scale: \n" + Controller.getAllActions()[5].inputChannels[0].scale);
 
 // input and modifier: Inputs
-print("Input channel input and modifier: \n" + Controller.getAllActions()[5].inputChannels[0].input + "\n" + Controller.getAllActions()[5].inputChannels[0].modifier + "\n")
+print("Input channel input and modifier: \n" + Controller.getAllActions()[5].inputChannels[0].input + "\n" + Controller.getAllActions()[5].inputChannels[0].modifier + "\n");
 
 
 // Each Input stores:
 // device: device of input
-print("Input device: \n" + Controller.getAllActions()[5].inputChannels[0].input.device)
+print("Input device: \n" + Controller.getAllActions()[5].inputChannels[0].input.device);
 
 // channel: channel of input
-print("Input channel: \n" + Controller.getAllActions()[5].inputChannels[0].input.channel)
+print("Input channel: \n" + Controller.getAllActions()[5].inputChannels[0].input.channel);
 
 // type: type of input (Unknown, Button, Axis, Joint)
-print("Input type: \n" + Controller.getAllActions()[5].inputChannels[0].input.type)
+print("Input type: \n" + Controller.getAllActions()[5].inputChannels[0].input.type);
 
 // id: id of input
-print("Input id: \n" + Controller.getAllActions()[5].inputChannels[0].input.id + "\n")
+print("Input id: \n" + Controller.getAllActions()[5].inputChannels[0].input.id + "\n");
 
 
 // You can get the name of a device from its id
-print("Device 1 name: \n" + Controller.getDeviceName(Controller.getAllActions()[5].inputChannels[0].input.id))
+print("Device 1 name: \n" + Controller.getDeviceName(Controller.getAllActions()[5].inputChannels[0].input.id));
 
 // You can also get all of a devices input channels
-print("Device 1's input channels: \n" + Controller.getAllInputsForDevice(1) + "\n")
+print("Device 1's input channels: \n" + Controller.getAllInputsForDevice(1) + "\n");
 
 
 // Modifying properties:
 // The following code will switch the "w" and "s" key functionality and adjust their scales
-var s = Controller.getAllActions()[0].inputChannels[0]
-var w = Controller.getAllActions()[1].inputChannels[0]
+var s = Controller.getAllActions()[0].inputChannels[0];
+var w = Controller.getAllActions()[1].inputChannels[0];
 
 // You must remove an input controller before modifying it so the old input controller isn't registered anymore
 // removeInputChannel and addInputChannel return true if successful, false otherwise
-Controller.removeInputChannel(s)
-Controller.removeInputChannel(w)
-print(s.scale)
-s.action = 1
-s.scale = .01
+Controller.removeInputChannel(s);
+Controller.removeInputChannel(w);
+print(s.scale);
+s.action = 1;
+s.scale = .01;
 
-w.action = 0
-w.scale = 10000
-Controller.addInputChannel(s)
-Controller.addInputChannel(w)
-print(s.scale)
+w.action = 0;
+w.scale = 10000;
+Controller.addInputChannel(s);
+Controller.addInputChannel(w);
+print(s.scale);
 
 // You can get all the available inputs for any device
 // Each AvailableInput has:
 // input: the Input itself
 // inputName: string representing the input
-var availableInputs = Controller.getAvailableInputs(1)
+var availableInputs = Controller.getAvailableInputs(1);
 for (i = 0; i < availableInputs.length; i++) {
 	print(availableInputs[i].inputName);
 }
 
 // You can modify key bindings by using these avaiable inputs
 // This will replace e (up) with 6
-var e = Controller.getAllActions()[5].inputChannels[0]
-Controller.removeInputChannel(e)
-e.input = availableInputs[6].input
-Controller.addInputChannel(e)
+var e = Controller.getAllActions()[5].inputChannels[0];
+Controller.removeInputChannel(e);
+e.input = availableInputs[6].input;
+Controller.addInputChannel(e);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -148,6 +148,7 @@ public:
     static glm::quat getOrientationForPath() { return getInstance()->_myAvatar->getOrientation(); }
     static glm::vec3 getPositionForAudio() { return getInstance()->_myAvatar->getHead()->getPosition(); }
     static glm::quat getOrientationForAudio() { return getInstance()->_myAvatar->getHead()->getFinalOrientationInWorldFrame(); }
+    static UserInputMapper* getUserInputMapper() { return &getInstance()->_userInputMapper; }
     static void initPlugins();
     static void shutdownPlugins();
 

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -173,9 +173,9 @@ void KeyboardMouseDevice::registerToUserInputMapper(UserInputMapper& mapper) {
         availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key_Space), QKeySequence(Qt::Key_Space).toString()));
         return availableInputs;
     };
-    proxy->resetDeviceBindings = [this, &_mapper = mapper, &device = _deviceID] () -> bool {
-        _mapper.removeAllInputChannelsForDevice(device);
-        this->assignDefaultInputMapping(_mapper);
+    proxy->resetDeviceBindings = [this, &mapper] () -> bool {
+        mapper.removeAllInputChannelsForDevice(_deviceID);
+        this->assignDefaultInputMapping(mapper);
         return true;
     };
     mapper.registerDevice(_deviceID, proxy);

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -164,11 +164,11 @@ void KeyboardMouseDevice::registerToUserInputMapper(UserInputMapper& mapper) {
     proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input._channel); };
     proxy->getAvailabeInputs = [this] () -> QVector<UserInputMapper::InputPair> {
         QVector<UserInputMapper::InputPair> availableInputs;
-        for (int i = 0; i <= 9; i++) {
-            availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(48 + i)), QKeySequence(Qt::Key(48 + i)).toString()));
+        for (int i = (int) Qt::Key_0; i <= (int) Qt::Key_9; i++) {
+            availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(i)), QKeySequence(Qt::Key(i)).toString()));
         }
-        for (int i = 0; i < 26; i++) {
-            availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(65 + i)), QKeySequence(Qt::Key(65 + i)).toString()));
+        for (int i = (int) Qt::Key_A; i <= (int) Qt::Key_Z; i++) {
+            availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(i)), QKeySequence(Qt::Key(i)).toString()));
         }
         availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key_Space), QKeySequence(Qt::Key_Space).toString()));
         return availableInputs;

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -159,9 +159,25 @@ void KeyboardMouseDevice::registerToUserInputMapper(UserInputMapper& mapper) {
     // Grab the current free device ID
     _deviceID = mapper.getFreeDeviceID();
 
-    auto proxy = UserInputMapper::DeviceProxy::Pointer(new UserInputMapper::DeviceProxy());
+    auto proxy = UserInputMapper::DeviceProxy::Pointer(new UserInputMapper::DeviceProxy("Keyboard"));
     proxy->getButton = [this] (const UserInputMapper::Input& input, int timestamp) -> bool { return this->getButton(input._channel); };
     proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input._channel); };
+    proxy->getAvailabeInputs = [this] () -> QVector<UserInputMapper::InputPair> {
+        QVector<UserInputMapper::InputPair> availableInputs;
+        for (int i = 0; i <= 9; i++) {
+            availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(48 + i)), QKeySequence(Qt::Key(48 + i)).toString()));
+        }
+        for (int i = 0; i < 26; i++) {
+            availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(65 + i)), QKeySequence(Qt::Key(65 + i)).toString()));
+        }
+        availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key_Space), QKeySequence(Qt::Key_Space).toString()));
+        return availableInputs;
+    };
+    proxy->resetDeviceBindings = [this, &_mapper = mapper, &device = _deviceID] () -> bool {
+        _mapper.removeAllInputChannelsForDevice(device);
+        this->assignDefaultInputMapping(_mapper);
+        return true;
+    };
     mapper.registerDevice(_deviceID, proxy);
 }
 

--- a/interface/src/scripting/ControllerScriptingInterface.cpp
+++ b/interface/src/scripting/ControllerScriptingInterface.cpp
@@ -28,6 +28,90 @@ ControllerScriptingInterface::ControllerScriptingInterface() :
 {
 
 }
+static int actionMetaTypeId = qRegisterMetaType<UserInputMapper::Action>();
+static int inputChannelMetaTypeId = qRegisterMetaType<UserInputMapper::InputChannel>();
+static int inputMetaTypeId = qRegisterMetaType<UserInputMapper::Input>();
+static int inputPairMetaTypeId = qRegisterMetaType<UserInputMapper::InputPair>();
+
+QScriptValue inputToScriptValue(QScriptEngine* engine, const UserInputMapper::Input& input);
+void inputFromScriptValue(const QScriptValue& object, UserInputMapper::Input& input);
+QScriptValue inputChannelToScriptValue(QScriptEngine* engine, const UserInputMapper::InputChannel& inputChannel);
+void inputChannelFromScriptValue(const QScriptValue& object, UserInputMapper::InputChannel& inputChannel);
+QScriptValue actionToScriptValue(QScriptEngine* engine, const UserInputMapper::Action& action);
+void actionFromScriptValue(const QScriptValue& object, UserInputMapper::Action& action);
+QScriptValue inputPairToScriptValue(QScriptEngine* engine, const UserInputMapper::InputPair& inputPair);
+void inputPairFromScriptValue(const QScriptValue& object, UserInputMapper::InputPair& inputPair);
+
+QScriptValue inputToScriptValue(QScriptEngine* engine, const UserInputMapper::Input& input) {
+    QScriptValue obj = engine->newObject();
+    obj.setProperty("device", input.getDevice());
+    obj.setProperty("channel", input.getChannel());
+    obj.setProperty("type", input._type);
+    obj.setProperty("id", input.getID());
+    return obj;
+}
+
+void inputFromScriptValue(const QScriptValue& object, UserInputMapper::Input& input) {
+    input._device = object.property("device").toUInt16();
+    input._channel = object.property("channel").toUInt16();
+    input._type = object.property("type").toUInt16();
+    input._id = object.property("id").toInt32();
+}
+
+QScriptValue inputChannelToScriptValue(QScriptEngine* engine, const UserInputMapper::InputChannel& inputChannel) {
+    QScriptValue obj = engine->newObject();
+    obj.setProperty("input", inputToScriptValue(engine, inputChannel._input));
+    obj.setProperty("modifier", inputToScriptValue(engine, inputChannel._modifier));
+    obj.setProperty("action", inputChannel._action);
+    obj.setProperty("scale", inputChannel._scale);
+    return obj;
+}
+
+void inputChannelFromScriptValue(const QScriptValue& object, UserInputMapper::InputChannel& inputChannel) {
+    inputFromScriptValue(object.property("input"), inputChannel._input);
+    inputFromScriptValue(object.property("modifier"), inputChannel._modifier);
+    inputChannel._action = UserInputMapper::Action(object.property("action").toVariant().toInt());
+    inputChannel._scale = object.property("scale").toVariant().toFloat();
+}
+
+QScriptValue actionToScriptValue(QScriptEngine* engine, const UserInputMapper::Action& action) {
+    QScriptValue obj = engine->newObject();
+    QVector<UserInputMapper::InputChannel> inputChannels = Application::getUserInputMapper()->getInputChannelsForAction(action);
+    QScriptValue _inputChannels = engine->newArray(inputChannels.size());
+    for (int i = 0; i < inputChannels.size(); i++) {
+        _inputChannels.setProperty(i, inputChannelToScriptValue(engine, inputChannels[i]));
+    }
+    obj.setProperty("action", (int) action);
+    obj.setProperty("actionName", Application::getUserInputMapper()->getActionName(action));
+    obj.setProperty("inputChannels", _inputChannels);
+    return obj;
+}
+
+void actionFromScriptValue(const QScriptValue& object, UserInputMapper::Action& action) {
+    action = UserInputMapper::Action(object.property("action").toVariant().toInt());
+}
+
+QScriptValue inputPairToScriptValue(QScriptEngine* engine, const UserInputMapper::InputPair& inputPair) {
+    QScriptValue obj = engine->newObject();
+    obj.setProperty("input", inputToScriptValue(engine, inputPair.first));
+    obj.setProperty("inputName", inputPair.second);
+    return obj;
+}
+
+void inputPairFromScriptValue(const QScriptValue& object, UserInputMapper::InputPair& inputPair) {
+    inputFromScriptValue(object.property("input"), inputPair.first);
+    inputPair.second = QString(object.property("inputName").toVariant().toString());
+}
+
+void ControllerScriptingInterface::registerControllerTypes(QScriptEngine* engine) {
+    qScriptRegisterSequenceMetaType<QVector<UserInputMapper::Action> >(engine);
+    qScriptRegisterSequenceMetaType<QVector<UserInputMapper::InputChannel> >(engine);
+    qScriptRegisterSequenceMetaType<QVector<UserInputMapper::InputPair> >(engine);
+    qScriptRegisterMetaType(engine, actionToScriptValue, actionFromScriptValue);
+    qScriptRegisterMetaType(engine, inputChannelToScriptValue, inputChannelFromScriptValue);
+    qScriptRegisterMetaType(engine, inputToScriptValue, inputFromScriptValue);
+    qScriptRegisterMetaType(engine, inputPairToScriptValue, inputPairFromScriptValue);
+}
 
 void ControllerScriptingInterface::handleMetaEvent(HFMetaEvent* event) {
     if (event->type() == HFActionEvent::startType()) {
@@ -337,6 +421,37 @@ void ControllerScriptingInterface::updateInputControllers() {
     }
 }
 
+QVector<UserInputMapper::Action> ControllerScriptingInterface::getAllActions() {
+    return Application::getUserInputMapper()->getAllActions();
+}
+
+QVector<UserInputMapper::InputChannel> ControllerScriptingInterface::getInputChannelsForAction(UserInputMapper::Action action) {
+    return Application::getUserInputMapper()->getInputChannelsForAction(action);
+}
+
+QString ControllerScriptingInterface::getDeviceName(unsigned int device) {
+    return Application::getUserInputMapper()->getDeviceName((unsigned short) device);
+}
+
+QVector<UserInputMapper::InputChannel> ControllerScriptingInterface::getAllInputsForDevice(unsigned int device) {
+    return Application::getUserInputMapper()->getAllInputsForDevice(device);
+}
+
+bool ControllerScriptingInterface::addInputChannel(UserInputMapper::InputChannel inputChannel) {
+    return Application::getUserInputMapper()->addInputChannel(inputChannel._action, inputChannel._input, inputChannel._modifier, inputChannel._scale);
+}
+
+bool ControllerScriptingInterface::removeInputChannel(UserInputMapper::InputChannel inputChannel) {
+    return Application::getUserInputMapper()->removeInputChannel(inputChannel);
+}
+
+QVector<UserInputMapper::InputPair> ControllerScriptingInterface::getAvailableInputs(unsigned int device) {
+    return Application::getUserInputMapper()->getAvailableInputs((unsigned short) device);
+}
+
+void ControllerScriptingInterface::resetAllDeviceBindings() {
+    Application::getUserInputMapper()->resetAllDeviceBindings();
+}
 
 InputController::InputController(int deviceTrackerId, int subTrackerId, QObject* parent) :
     AbstractInputController(),

--- a/interface/src/scripting/ControllerScriptingInterface.cpp
+++ b/interface/src/scripting/ControllerScriptingInterface.cpp
@@ -46,32 +46,36 @@ QScriptValue inputToScriptValue(QScriptEngine* engine, const UserInputMapper::In
     QScriptValue obj = engine->newObject();
     obj.setProperty("device", input.getDevice());
     obj.setProperty("channel", input.getChannel());
-    obj.setProperty("type", input._type);
+    obj.setProperty("type", (unsigned short) input.getType());
     obj.setProperty("id", input.getID());
     return obj;
 }
 
 void inputFromScriptValue(const QScriptValue& object, UserInputMapper::Input& input) {
-    input._device = object.property("device").toUInt16();
-    input._channel = object.property("channel").toUInt16();
-    input._type = object.property("type").toUInt16();
-    input._id = object.property("id").toInt32();
+    input.setDevice(object.property("device").toUInt16());
+    input.setChannel(object.property("channel").toUInt16());
+    input.setType(object.property("type").toUInt16());
+    input.setID(object.property("id").toInt32());
 }
 
 QScriptValue inputChannelToScriptValue(QScriptEngine* engine, const UserInputMapper::InputChannel& inputChannel) {
     QScriptValue obj = engine->newObject();
-    obj.setProperty("input", inputToScriptValue(engine, inputChannel._input));
-    obj.setProperty("modifier", inputToScriptValue(engine, inputChannel._modifier));
-    obj.setProperty("action", inputChannel._action);
-    obj.setProperty("scale", inputChannel._scale);
+    obj.setProperty("input", inputToScriptValue(engine, inputChannel.getInput()));
+    obj.setProperty("modifier", inputToScriptValue(engine, inputChannel.getModifier()));
+    obj.setProperty("action", inputChannel.getAction());
+    obj.setProperty("scale", inputChannel.getScale());
     return obj;
 }
 
 void inputChannelFromScriptValue(const QScriptValue& object, UserInputMapper::InputChannel& inputChannel) {
-    inputFromScriptValue(object.property("input"), inputChannel._input);
-    inputFromScriptValue(object.property("modifier"), inputChannel._modifier);
-    inputChannel._action = UserInputMapper::Action(object.property("action").toVariant().toInt());
-    inputChannel._scale = object.property("scale").toVariant().toFloat();
+    UserInputMapper::Input input;
+    UserInputMapper::Input modifier;
+    inputFromScriptValue(object.property("input"), input);
+    inputChannel.setInput(input);
+    inputFromScriptValue(object.property("modifier"), modifier);
+    inputChannel.setModifier(modifier);
+    inputChannel.setAction(UserInputMapper::Action(object.property("action").toVariant().toInt()));
+    inputChannel.setScale(object.property("scale").toVariant().toFloat());
 }
 
 QScriptValue actionToScriptValue(QScriptEngine* engine, const UserInputMapper::Action& action) {

--- a/interface/src/scripting/ControllerScriptingInterface.h
+++ b/interface/src/scripting/ControllerScriptingInterface.h
@@ -14,9 +14,10 @@
 
 #include <QtCore/QObject>
 
+#include "ui/UserInputMapper.h"
+
 #include <AbstractControllerScriptingInterface.h>
 class PalmData;
-
 
 class InputController : public  AbstractInputController {
     Q_OBJECT
@@ -54,6 +55,9 @@ class ControllerScriptingInterface : public AbstractControllerScriptingInterface
 
 public:    
     ControllerScriptingInterface();
+    
+    virtual void registerControllerTypes(QScriptEngine* engine);
+    
     void emitKeyPressEvent(QKeyEvent* event) { emit keyPressEvent(KeyEvent(*event)); }
     void emitKeyReleaseEvent(QKeyEvent* event) { emit keyReleaseEvent(KeyEvent(*event)); }
     
@@ -79,6 +83,14 @@ public:
     void updateInputControllers();
 
 public slots:
+    Q_INVOKABLE virtual QVector<UserInputMapper::Action> getAllActions();
+    Q_INVOKABLE virtual QVector<UserInputMapper::InputChannel> getInputChannelsForAction(UserInputMapper::Action action);
+    Q_INVOKABLE virtual QString getDeviceName(unsigned int device);
+    Q_INVOKABLE virtual QVector<UserInputMapper::InputChannel> getAllInputsForDevice(unsigned int device);
+    Q_INVOKABLE virtual bool addInputChannel(UserInputMapper::InputChannel inputChannel);
+    Q_INVOKABLE virtual bool removeInputChannel(UserInputMapper::InputChannel inputChannel);
+    Q_INVOKABLE virtual QVector<UserInputMapper::InputPair> getAvailableInputs(unsigned int device);
+    Q_INVOKABLE virtual void resetAllDeviceBindings();
     virtual bool isPrimaryButtonPressed() const;
     virtual glm::vec2 getPrimaryJoystickPosition() const;
 

--- a/interface/src/ui/UserInputMapper.h
+++ b/interface/src/ui/UserInputMapper.h
@@ -52,8 +52,13 @@ public:
         uint16 getDevice() const { return _device; }
         uint16 getChannel() const { return _channel; }
         uint32 getID() const { return _id; }
-
         ChannelType getType() const { return (ChannelType) _type; }
+        
+        void setDevice(uint16 device) { _device = device; }
+        void setChannel(uint16 channel) { _channel = channel; }
+        void setType(uint16 type) { _type = type; }
+        void setID(uint32 ID) { _id = ID; }
+
         bool isButton() const { return getType() == ChannelType::BUTTON; }
         bool isAxis() const { return getType() == ChannelType::AXIS; }
         bool isJoint() const { return getType() == ChannelType::JOINT; }
@@ -157,6 +162,16 @@ public:
         Input _modifier = Input(); // make it invalid by default, meaning no modifier
         Action _action = LONGITUDINAL_BACKWARD;
         float _scale = 0.0f;
+        
+        Input getInput() const { return _input; }
+        Input getModifier() const { return _modifier; }
+        Action getAction() const { return _action; }
+        float getScale() const { return _scale; }
+        
+        void setInput(Input input) { _input = input; }
+        void setModifier(Input modifier) { _modifier = modifier; }
+        void setAction(Action action) { _action = action; }
+        void setScale(float scale) { _scale = scale; }
 
         InputChannel() {}
         InputChannel(const Input& input, const Input& modifier, Action action, float scale = 1.0f) :

--- a/interface/src/ui/UserInputMapper.h
+++ b/interface/src/ui/UserInputMapper.h
@@ -142,7 +142,6 @@ public:
     QVector<Action> getAllActions();
     QString getActionName(Action action) { return UserInputMapper::_actionNames[(int) action]; }
     float getActionState(Action action) const { return _actionStates[action]; }
-//    QVector<InputChannel>
     void assignDefaulActionScales();
 
     // Add input channel to the mapper and check that all the used channels are registered.

--- a/libraries/script-engine/src/AbstractControllerScriptingInterface.h
+++ b/libraries/script-engine/src/AbstractControllerScriptingInterface.h
@@ -52,6 +52,8 @@ class AbstractControllerScriptingInterface : public QObject {
     Q_OBJECT
 
 public slots:
+    virtual void registerControllerTypes(QScriptEngine* engine) = 0;
+    
     virtual bool isPrimaryButtonPressed() const = 0;
     virtual glm::vec2 getPrimaryJoystickPosition() const = 0;
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -317,6 +317,7 @@ void ScriptEngine::init() {
     registerAnimationTypes(this);
     registerAvatarTypes(this);
     registerAudioMetaTypes(this);
+    _controllerScriptingInterface->registerControllerTypes(this);
 
     qScriptRegisterMetaType(this, EntityItemPropertiesToScriptValue, EntityItemPropertiesFromScriptValueHonorReadOnly);
     qScriptRegisterMetaType(this, EntityItemIDtoScriptValue, EntityItemIDfromScriptValue);


### PR DESCRIPTION
Enables users to remap key bindings and adjust action sensitivities via javascript

More functionality will be added as more devices are moved to this new system and desired functionality becomes evident, but right now you should be able to do pretty much anything with the keyboard and mouse bindings (see the provided example script).

Known Issue:  Adjusting sensitivity for directional motion won't have any effect because the acceleration curve is hardcoded elsewhere, but that's unrelated to actually exposing the functions.  You can test sensitivity adjustment by changing something like the "a" and "d" keys