### PR TITLE
reset simulation bid counters whenever an object is activated

### DIFF
--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "RenderableBoxEntityItem.h"
+
 #include <glm/gtx/quaternion.hpp>
 
 #include <gpu/GPUConfig.h>
@@ -18,7 +20,7 @@
 #include <ObjectMotionState.h>
 #include <PerfStat.h>
 
-#include "RenderableBoxEntityItem.h"
+#include "RenderableDebugableEntityItem.h"
 
 EntityItemPointer RenderableBoxEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
     return EntityItemPointer(new RenderableBoxEntityItem(entityID, properties));
@@ -34,39 +36,5 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
     batch.setModelTransform(getTransformToCenter());
     DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(batch, 1.0f, cubeColor);
 
-    // TODO: use RenderableDebugableEntityItem::render (instead of the hack below) 
-    // when we fix the scaling bug that breaks RenderableDebugableEntityItem for boxes.
-    if (args->_debugFlags & RenderArgs::RENDER_DEBUG_SIMULATION_OWNERSHIP) {
-        Q_ASSERT(args->_batch);
-        gpu::Batch& batch = *args->_batch;
-        Transform transform = getTransformToCenter();
-        //transform.postScale(entity->getDimensions()); // HACK: this line breaks for BoxEntityItem
-        batch.setModelTransform(transform);
-
-        auto nodeList = DependencyManager::get<NodeList>();
-        const QUuid& myNodeID = nodeList->getSessionUUID();
-        bool highlightSimulationOwnership = (getSimulatorID() == myNodeID);
-        if (highlightSimulationOwnership) {
-            glm::vec4 greenColor(0.0f, 1.0f, 0.2f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.08f, greenColor);
-        }
-
-        quint64 now = usecTimestampNow();
-        if (now - getLastEditedFromRemote() < 0.1f * USECS_PER_SECOND) {
-            glm::vec4 redColor(1.0f, 0.0f, 0.0f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.16f, redColor);
-        }
-
-        if (now - getLastBroadcast() < 0.2f * USECS_PER_SECOND) {
-            glm::vec4 yellowColor(1.0f, 1.0f, 0.2f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.24f, yellowColor);
-        }
-
-        ObjectMotionState* motionState = static_cast<ObjectMotionState*>(getPhysicsInfo());
-        if (motionState && motionState->isActive()) {
-            glm::vec4 blueColor(0.0f, 0.0f, 1.0f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.32f, blueColor);
-        }
-    }
-    //RenderableDebugableEntityItem::render(this, args); // TODO: use this instead of the hack above
+    RenderableDebugableEntityItem::render(this, args);
 };

--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.h
@@ -13,7 +13,6 @@
 #define hifi_RenderableBoxEntityItem_h
 
 #include <BoxEntityItem.h>
-#include "RenderableDebugableEntityItem.h"
 #include "RenderableEntityItem.h"
 
 class RenderableBoxEntityItem : public BoxEntityItem {

--- a/libraries/entities-renderer/src/RenderableDebugableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableDebugableEntityItem.cpp
@@ -15,9 +15,8 @@
 
 #include <gpu/GPUConfig.h>
 #include <gpu/Batch.h>
-
 #include <DeferredLightingEffect.h>
-#include <PhysicsEngine.h>
+#include <ObjectMotionState.h>
 
 #include "RenderableDebugableEntityItem.h"
 
@@ -26,42 +25,43 @@ void RenderableDebugableEntityItem::renderBoundingBox(EntityItem* entity, Render
                                                       float puffedOut, glm::vec4& color) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
-    batch.setModelTransform(entity->getTransformToCenter());
+    Transform transform = entity->getTransformToCenter();
+    transform.postScale(entity->getDimensions());
+    batch.setModelTransform(transform);
     DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.0f + puffedOut, color);
 }
 
-void RenderableDebugableEntityItem::renderHoverDot(EntityItem* entity, RenderArgs* args) {
-    const int SLICES = 8, STACKS = 8;
-    float radius = 0.05f;
-    glm::vec4 blueColor(0.0f, 0.0f, 1.0f, 1.0f);
-    
-    Q_ASSERT(args->_batch);
-    gpu::Batch& batch = *args->_batch;
-    Transform transform = entity->getTransformToCenter();
-    // Cancel true dimensions and set scale to 2 * radius (diameter)
-    transform.postScale(2.0f * glm::vec3(radius, radius, radius) / entity->getDimensions());
-    batch.setModelTransform(transform);
-    DependencyManager::get<DeferredLightingEffect>()->renderSolidSphere(batch, 0.5f, SLICES, STACKS, blueColor);
-}
-
 void RenderableDebugableEntityItem::render(EntityItem* entity, RenderArgs* args) {
-    bool debugSimulationOwnership = args->_debugFlags & RenderArgs::RENDER_DEBUG_SIMULATION_OWNERSHIP;
+    if (args->_debugFlags & RenderArgs::RENDER_DEBUG_SIMULATION_OWNERSHIP) {
+        Q_ASSERT(args->_batch);
+        gpu::Batch& batch = *args->_batch;
+        Transform transform = entity->getTransformToCenter();
+        transform.postScale(entity->getDimensions());
+        batch.setModelTransform(transform);
 
-    if (debugSimulationOwnership) {
+        auto nodeList = DependencyManager::get<NodeList>();
+        const QUuid& myNodeID = nodeList->getSessionUUID();
+        bool highlightSimulationOwnership = (entity->getSimulatorID() == myNodeID);
+        if (highlightSimulationOwnership) {
+            glm::vec4 greenColor(0.0f, 1.0f, 0.2f, 1.0f);
+            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.08f, greenColor);
+        }
+
         quint64 now = usecTimestampNow();
         if (now - entity->getLastEditedFromRemote() < 0.1f * USECS_PER_SECOND) {
             glm::vec4 redColor(1.0f, 0.0f, 0.0f, 1.0f);
-            renderBoundingBox(entity, args, 0.2f, redColor);
+            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.16f, redColor);
         }
 
         if (now - entity->getLastBroadcast() < 0.2f * USECS_PER_SECOND) {
             glm::vec4 yellowColor(1.0f, 1.0f, 0.2f, 1.0f);
-            renderBoundingBox(entity, args, 0.3f, yellowColor);
+            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.24f, yellowColor);
         }
 
         ObjectMotionState* motionState = static_cast<ObjectMotionState*>(entity->getPhysicsInfo());
         if (motionState && motionState->isActive()) {
-            renderHoverDot(entity, args);
+            glm::vec4 blueColor(0.0f, 0.0f, 1.0f, 1.0f);
+            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.32f, blueColor);
         }
     }
 }

--- a/libraries/entities-renderer/src/RenderableDebugableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableDebugableEntityItem.cpp
@@ -10,6 +10,7 @@
 //
 
 
+#include "RenderableDebugableEntityItem.h"
 
 #include <glm/gtx/quaternion.hpp>
 
@@ -18,15 +19,13 @@
 #include <DeferredLightingEffect.h>
 #include <ObjectMotionState.h>
 
-#include "RenderableDebugableEntityItem.h"
-
 
 void RenderableDebugableEntityItem::renderBoundingBox(EntityItem* entity, RenderArgs* args,
                                                       float puffedOut, glm::vec4& color) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
     Transform transform = entity->getTransformToCenter();
-    transform.postScale(entity->getDimensions());
+    //transform.postScale(entity->getDimensions());
     batch.setModelTransform(transform);
     DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.0f + puffedOut, color);
 }
@@ -44,24 +43,24 @@ void RenderableDebugableEntityItem::render(EntityItem* entity, RenderArgs* args)
         bool highlightSimulationOwnership = (entity->getSimulatorID() == myNodeID);
         if (highlightSimulationOwnership) {
             glm::vec4 greenColor(0.0f, 1.0f, 0.2f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.08f, greenColor);
+            renderBoundingBox(entity, args, 0.08f, greenColor);
         }
 
         quint64 now = usecTimestampNow();
         if (now - entity->getLastEditedFromRemote() < 0.1f * USECS_PER_SECOND) {
             glm::vec4 redColor(1.0f, 0.0f, 0.0f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.16f, redColor);
+            renderBoundingBox(entity, args, 0.16f, redColor);
         }
 
         if (now - entity->getLastBroadcast() < 0.2f * USECS_PER_SECOND) {
             glm::vec4 yellowColor(1.0f, 1.0f, 0.2f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.24f, yellowColor);
+            renderBoundingBox(entity, args, 0.24f, yellowColor);
         }
 
         ObjectMotionState* motionState = static_cast<ObjectMotionState*>(entity->getPhysicsInfo());
         if (motionState && motionState->isActive()) {
             glm::vec4 blueColor(0.0f, 0.0f, 1.0f, 1.0f);
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.32f, blueColor);
+            renderBoundingBox(entity, args, 0.32f, blueColor);
         }
     }
 }

--- a/libraries/entities-renderer/src/RenderableDebugableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableDebugableEntityItem.h
@@ -17,7 +17,6 @@
 class RenderableDebugableEntityItem {
 public:
     static void renderBoundingBox(EntityItem* entity, RenderArgs* args, float puffedOut, glm::vec4& color);
-    static void renderHoverDot(EntityItem* entity, RenderArgs* args);
     static void render(EntityItem* entity, RenderArgs* args);
 };
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -201,14 +201,6 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
     glm::vec3 position = getPosition();
     glm::vec3 dimensions = getDimensions();
 
-    bool debugSimulationOwnership = args->_debugFlags & RenderArgs::RENDER_DEBUG_SIMULATION_OWNERSHIP;
-    bool highlightSimulationOwnership = false;
-    if (debugSimulationOwnership) {
-        auto nodeList = DependencyManager::get<NodeList>();
-        const QUuid& myNodeID = nodeList->getSessionUUID();
-        highlightSimulationOwnership = (getSimulatorID() == myNodeID);
-    }
-
     if (hasModel()) {
         if (_model) {
             if (QUrl(getModelURL()) != _model->getURL()) {
@@ -273,11 +265,6 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
                     _needsInitialSimulation = false;
                 }
             }
-        }
-
-        if (highlightSimulationOwnership) {
-            glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);
-            RenderableDebugableEntityItem::renderBoundingBox(this, args, 0.0f, greenColor);
         }
     } else {
         glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);

--- a/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "RenderableSphereEntityItem.h"
+
 #include <glm/gtx/quaternion.hpp>
 
 #include <gpu/GPUConfig.h>
@@ -18,7 +20,7 @@
 #include <DeferredLightingEffect.h>
 #include <PerfStat.h>
 
-#include "RenderableSphereEntityItem.h"
+#include "RenderableDebugableEntityItem.h"
 
 EntityItemPointer RenderableSphereEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
     return EntityItemPointer(new RenderableSphereEntityItem(entityID, properties));
@@ -39,4 +41,6 @@ void RenderableSphereEntityItem::render(RenderArgs* args) {
     gpu::Batch& batch = *args->_batch;
     batch.setModelTransform(getTransformToCenter());
     DependencyManager::get<DeferredLightingEffect>()->renderSolidSphere(batch, 0.5f, SLICES, STACKS, sphereColor);
+
+    RenderableDebugableEntityItem::render(this, args);
 };

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -53,8 +53,6 @@ const uint32_t OUTGOING_DIRTY_PHYSICS_FLAGS = EntityItem::DIRTY_TRANSFORM | Enti
 class OctreeEditPacketSender;
 class PhysicsEngine;
 
-extern const int MAX_NUM_NON_MOVING_UPDATES;
-
 class ObjectMotionState : public btMotionState {
 public:
     // These poroperties of the PhysicsEngine are "global" within the context of all ObjectMotionStates

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -227,8 +227,7 @@ void PhysicsEngine::stepSimulation() {
     // (3) synchronize outgoing motion states
     // (4) send outgoing packets
 
-    const int MAX_NUM_SUBSTEPS = 4;
-    const float MAX_TIMESTEP = (float)MAX_NUM_SUBSTEPS * PHYSICS_ENGINE_FIXED_SUBSTEP;
+    const float MAX_TIMESTEP = (float)PHYSICS_ENGINE_MAX_NUM_SUBSTEPS * PHYSICS_ENGINE_FIXED_SUBSTEP;
     float dt = 1.0e-6f * (float)(_clock.getTimeMicroseconds());
     _clock.reset();
     float timeStep = btMin(dt, MAX_TIMESTEP);
@@ -245,7 +244,7 @@ void PhysicsEngine::stepSimulation() {
         _characterController->preSimulation(timeStep);
     }
 
-    int numSubsteps = _dynamicsWorld->stepSimulation(timeStep, MAX_NUM_SUBSTEPS, PHYSICS_ENGINE_FIXED_SUBSTEP);
+    int numSubsteps = _dynamicsWorld->stepSimulation(timeStep, PHYSICS_ENGINE_MAX_NUM_SUBSTEPS, PHYSICS_ENGINE_FIXED_SUBSTEP);
     if (numSubsteps > 0) {
         BT_PROFILE("postSimulation");
         _numSubsteps += (uint32_t)numSubsteps;

--- a/libraries/shared/src/PhysicsHelpers.h
+++ b/libraries/shared/src/PhysicsHelpers.h
@@ -15,6 +15,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 
+const int PHYSICS_ENGINE_MAX_NUM_SUBSTEPS = 4;
 const float PHYSICS_ENGINE_FIXED_SUBSTEP = 1.0f / 60.0f;
 
 // return incremental rotation (Bullet-style) caused by angularVelocity over timeStep


### PR DESCRIPTION
The problem was that remote simulators were being too quick to bid on simulation ownership of objects that were activated by an object owned by another simulation.

A partial solution is to clear the simulation-bid counters whenever an object wakes up.  This tends to give the owning simulation a slight lead on claiming newly awakened objects.