### PR TITLE
fix bug where grab.js moves mouse to upper left corner after pressing CTRL

### DIFF
--- a/examples/grab.js
+++ b/examples/grab.js
@@ -140,6 +140,10 @@ function mouseIntersectionWithPlane(pointOnPlane, planeNormal, event) {
 }
 
 function computeNewGrabPlane() {
+    if (!gIsGrabbing) {
+        return;
+    }
+
     var maybeResetMousePosition = false;
     if (gGrabMode !== "rotate") {
         gMouseAtRotateStart = gMouseCursorLocation;

--- a/libraries/render/src/render/Scene.h
+++ b/libraries/render/src/render/Scene.h
@@ -245,7 +245,7 @@ public:
     void update(const UpdateFunctorPointer& updateFunctor)  { _payload->update(updateFunctor); }
 
     // Shape Type Interface
-    const model::MaterialKey& getMaterialKey() const { return _payload->getMaterialKey(); }
+    const model::MaterialKey getMaterialKey() const { return _payload->getMaterialKey(); }
 
 protected:
     PayloadPointer _payload;


### PR DESCRIPTION
grab.js uses CONTROL as the modifier key for "rotate" when grabbing a dynamic object.  It will remember the mouse's location when the rotation motion starts and will reset the mouse back to that position when the rotation is over -- this keeps the mouse on the object after rotating so that the grab can continue to move linearly without having the object glitch to where the mouse ended up after the rotate motion.

There was a bug where the mouse's position would be reset to (0,0) whenever CONTROL was released when not actually grabbing.