### PR TITLE
hack to fix culling bugs for some subMesh parts in the windmill scene

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1019,7 +1019,7 @@ AABox Model::calculateScaledOffsetAABox(const AABox& box) const {
 
 glm::vec3 Model::calculateScaledOffsetPoint(const glm::vec3& point) const {
     // we need to include any fst scaling, translation, and rotation, which is captured in the offset matrix
-    glm::vec3 offsetPoint = glm::vec3(_geometry->getFBXGeometry().offset * glm::vec4(point, 1.0f)); /// should this be point???
+    glm::vec3 offsetPoint = glm::vec3(_geometry->getFBXGeometry().offset * glm::vec4(point, 1.0f));
     glm::vec3 scaledPoint = ((offsetPoint + _offset) * _scale);
     glm::vec3 rotatedPoint = _rotation * scaledPoint;
     glm::vec3 translatedPoint = rotatedPoint + _translation;
@@ -1840,11 +1840,11 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
 
         glm::vec4 cubeColor;
         if (isSkinned) {
-            cubeColor = glm::vec4(0.0f,1.0f,1.0f,1.0f);
+            cubeColor = glm::vec4(0.0f, 1.0f, 1.0f, 1.0f);
         } else if (inView) {
-            cubeColor = glm::vec4(1.0f,0.0f,1.0f,1.0f);
+            cubeColor = glm::vec4(1.0f, 0.0f, 1.0f, 1.0f);
         } else {
-            cubeColor = glm::vec4(1.0f,1.0f,0.0f,1.0f);
+            cubeColor = glm::vec4(1.0f, 1.0f, 0.0f, 1.0f);
         }
 
         Transform transform;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1832,12 +1832,12 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
     bool isSkinned = state.clusterMatrices.size() > 1;
     bool wireframe = isWireframe();
 
-    AABox partBounds = getPartBounds(meshIndex, partIndex);
-    bool inView = args->_viewFrustum->boxInFrustum(partBounds) != ViewFrustum::OUTSIDE;
-    
     // render the part bounding box
     #ifdef DEBUG_BOUNDING_PARTS
     {
+        AABox partBounds = getPartBounds(meshIndex, partIndex);
+        bool inView = args->_viewFrustum->boxInFrustum(partBounds) != ViewFrustum::OUTSIDE;
+
         glm::vec4 cubeColor;
         if (isSkinned) {
             cubeColor = glm::vec4(0.0f,1.0f,1.0f,1.0f);


### PR DESCRIPTION
This is currently a hack because for some mesh parts our efforts to calculate the bounding box of the mesh part fails. It seems to create boxes that are not consistent with where the geometry actually renders. If instead we make all the parts share the bounds of the entire subMesh things will render properly.