### PR TITLE
Fix broken identity transforms on OSX

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -133,11 +133,11 @@ void GLBackend::updateTransform() {
     }
 
     if (_transform._invalidModel || _transform._invalidView) {
+        if (_transform._lastMode != GL_MODELVIEW) {
+            glMatrixMode(GL_MODELVIEW);
+            _transform._lastMode = GL_MODELVIEW;
+        }
         if (!_transform._model.isIdentity()) {
-            if (_transform._lastMode != GL_MODELVIEW) {
-                glMatrixMode(GL_MODELVIEW);
-                _transform._lastMode = GL_MODELVIEW;
-            }
             Transform::Mat4 modelView;
             if (!_transform._view.isIdentity()) {
                 Transform mvx;
@@ -147,19 +147,12 @@ void GLBackend::updateTransform() {
                 _transform._model.getMatrix(modelView);
             }
             glLoadMatrixf(reinterpret_cast< const GLfloat* >(&modelView));
+        } else if (!_transform._view.isIdentity()) {
+            Transform::Mat4 modelView;
+            _transform._view.getInverseMatrix(modelView);
+            glLoadMatrixf(reinterpret_cast< const GLfloat* >(&modelView));
         } else {
-            if (!_transform._view.isIdentity()) {
-                if (_transform._lastMode != GL_MODELVIEW) {
-                    glMatrixMode(GL_MODELVIEW);
-                    _transform._lastMode = GL_MODELVIEW;
-                }
-                Transform::Mat4 modelView;
-                _transform._view.getInverseMatrix(modelView);
-                glLoadMatrixf(reinterpret_cast< const GLfloat* >(&modelView));
-            } else {
-                // TODO: eventually do something about the matrix when neither view nor model is specified?
-                // glLoadIdentity();
-            }
+            glLoadIdentity();
         }
         (void) CHECK_GL_ERROR();
     }


### PR DESCRIPTION
If both the model and view matrices are identity, the code was failing to actually update the GL_MODELVIEW matrix on OSX.