### PR TITLE
unreasonably deep recursion

### DIFF
--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -350,8 +350,6 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
         }
     } else {
         // we we couldn't add the entity count, then we couldn't add anything for this element and we're in a NONE state
-        if (this == _myTree->getRoot())
-            qDebug() << "OctreeElement::NONE 0";;
         appendElementState = OctreeElement::NONE;
     }
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -350,6 +350,8 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
         }
     } else {
         // we we couldn't add the entity count, then we couldn't add anything for this element and we're in a NONE state
+        if (this == _myTree->getRoot())
+            qDebug() << "OctreeElement::NONE 0";;
         appendElementState = OctreeElement::NONE;
     }
 
@@ -392,17 +394,20 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
     
     // If we wrote fewer entities than we expected, update the number of entities in our packet
     bool successUpdateEntityCount = true;
-    if (!noEntitiesFit && numberOfEntities != actualNumberOfEntities) {
+    if (numberOfEntities != actualNumberOfEntities) {
         successUpdateEntityCount = packetData->updatePriorBytes(numberOfEntitiesOffset,
                                             (const unsigned char*)&actualNumberOfEntities, sizeof(actualNumberOfEntities));
     }
 
     // If we weren't able to update our entity count, or we couldn't fit any entities, then
     // we should discard our element and return a result of NONE
-    if (!successUpdateEntityCount || noEntitiesFit) {
+    if (!successUpdateEntityCount) {
         packetData->discardLevel(elementLevel);
         appendElementState = OctreeElement::NONE;
     } else {
+        if (noEntitiesFit) {
+            appendElementState = OctreeElement::PARTIAL;
+        }
         packetData->endLevel(elementLevel);
     }
     return appendElementState;


### PR DESCRIPTION
make sure that the root node always appends an entity count (even if it's zero).  This keeps the unreasonably-deep-recursion warnings from happening.
