### PR TITLE
Integrating gamepads/hydras to input mapping system, zooming

### DIFF
--- a/examples/defaultScripts.js
+++ b/examples/defaultScripts.js
@@ -11,7 +11,6 @@
 Script.load("progress.js");
 Script.load("edit.js");
 Script.load("selectAudioDevice.js");
-Script.load("controllers/hydra/hydraMove.js");
 Script.load("inspect.js");
 Script.load("lobby.js");
 Script.load("notifications.js");

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -881,8 +881,7 @@ void Application::paintGL() {
 
     glEnable(GL_LINE_SMOOTH);
     
-    const float CAMERA_PERSON_THRESHOLD = MyAvatar::ZOOM_MIN * _myAvatar->getScale();
-    Menu::getInstance()->setIsOptionChecked("First Person", _myAvatar->getBoomLength() * _myAvatar->getScale() <= CAMERA_PERSON_THRESHOLD);
+    Menu::getInstance()->setIsOptionChecked("First Person", _myAvatar->getBoomLength() <= MyAvatar::ZOOM_MIN);
     Application::getInstance()->cameraMenuChanged();
 
     if (_myCamera.getMode() == CAMERA_MODE_FIRST_PERSON) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -113,6 +113,7 @@
 #include "devices/Faceshift.h"
 #include "devices/Leapmotion.h"
 #include "devices/RealSense.h"
+#include "devices/SDL2Manager.h"
 #include "devices/MIDIManager.h"
 #include "devices/OculusManager.h"
 #include "devices/TV3DManager.h"
@@ -127,7 +128,6 @@
 #include "scripting/AudioDeviceScriptingInterface.h"
 #include "scripting/ClipboardScriptingInterface.h"
 #include "scripting/HMDScriptingInterface.h"
-#include "scripting/JoystickScriptingInterface.h"
 #include "scripting/GlobalServicesScriptingInterface.h"
 #include "scripting/LocationScriptingInterface.h"
 #include "scripting/MenuScriptingInterface.h"
@@ -1455,6 +1455,7 @@ void Application::keyReleaseEvent(QKeyEvent* event) {
 
 void Application::focusOutEvent(QFocusEvent* event) {
     _keyboardMouseDevice.focusOutEvent(event);
+    SDL2Manager::getInstance()->focusOutEvent();
 
     // synthesize events for keys currently pressed, since we may not get their release events
     foreach (int key, _keysPressed) {
@@ -2450,7 +2451,7 @@ void Application::update(float deltaTime) {
         }
 
         SixenseManager::getInstance().update(deltaTime);
-        JoystickScriptingInterface::getInstance().update();
+        SDL2Manager::getInstance()->update();
     }
 
     _userInputMapper.update(deltaTime);
@@ -4045,7 +4046,6 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
 
     scriptEngine->registerGlobalObject("AvatarManager", DependencyManager::get<AvatarManager>().data());
 
-    scriptEngine->registerGlobalObject("Joysticks", &JoystickScriptingInterface::getInstance());
     qScriptRegisterMetaType(scriptEngine, joystickToScriptValue, joystickFromScriptValue);
 
     scriptEngine->registerGlobalObject("UndoStack", &_undoStackScriptingInterface);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1456,6 +1456,7 @@ void Application::keyReleaseEvent(QKeyEvent* event) {
 
 void Application::focusOutEvent(QFocusEvent* event) {
     _keyboardMouseDevice.focusOutEvent(event);
+    SixenseManager::getInstance().focusOutEvent();
     SDL2Manager::getInstance()->focusOutEvent();
 
     // synthesize events for keys currently pressed, since we may not get their release events

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -52,6 +52,8 @@ enum DriveKeys {
     ROT_RIGHT,
     ROT_UP,
     ROT_DOWN,
+    BOOM_IN,
+    BOOM_OUT,
     MAX_DRIVE_KEYS
 };
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -70,6 +70,10 @@ const int SCRIPTED_MOTOR_CAMERA_FRAME = 0;
 const int SCRIPTED_MOTOR_AVATAR_FRAME = 1;
 const int SCRIPTED_MOTOR_WORLD_FRAME = 2;
 
+const float MyAvatar::ZOOM_MIN = .5f;
+const float MyAvatar::ZOOM_MAX = 10.0f;
+const float MyAvatar::ZOOM_DEFAULT = 1.5f;
+
 MyAvatar::MyAvatar() :
 	Avatar(),
     _turningKeyPressTime(0.0f),
@@ -77,6 +81,7 @@ MyAvatar::MyAvatar() :
     _wasPushing(false),
     _isPushing(false),
     _isBraking(false),
+    _boomLength(ZOOM_DEFAULT),
     _trapDuration(0.0f),
     _thrust(0.0f),
     _keyboardMotorVelocity(0.0f),
@@ -1347,6 +1352,9 @@ glm::vec3 MyAvatar::applyKeyboardMotor(float deltaTime, const glm::vec3& localVe
             }
         }
     }
+    
+    _boomLength += _driveKeys[BOOM_OUT] - _driveKeys[BOOM_IN];
+    _boomLength = glm::clamp<float>(_boomLength, ZOOM_MIN, ZOOM_MAX);
 
     return newLocalVelocity;
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -70,7 +70,7 @@ const int SCRIPTED_MOTOR_CAMERA_FRAME = 0;
 const int SCRIPTED_MOTOR_AVATAR_FRAME = 1;
 const int SCRIPTED_MOTOR_WORLD_FRAME = 2;
 
-const float MyAvatar::ZOOM_MIN = .5f;
+const float MyAvatar::ZOOM_MIN = 0.5f;
 const float MyAvatar::ZOOM_MAX = 10.0f;
 const float MyAvatar::ZOOM_DEFAULT = 1.5f;
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -162,6 +162,13 @@ public:
     const RecorderPointer getRecorder() const { return _recorder; }
     const PlayerPointer getPlayer() const { return _player; }
     
+    float getBoomLength() const { return _boomLength; }
+    void setBoomLength(float boomLength) { _boomLength = boomLength; }
+    
+    static const float ZOOM_MIN;
+    static const float ZOOM_MAX;
+    static const float ZOOM_DEFAULT;
+    
 public slots:
     void increaseSize();
     void decreaseSize();
@@ -210,6 +217,8 @@ private:
     bool _wasPushing;
     bool _isPushing;
     bool _isBraking;
+    
+    float _boomLength;
 
     float _trapDuration; // seconds that avatar has been trapped by collisions
     glm::vec3 _thrust;  // impulse accumulator for outside sources

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -109,6 +109,16 @@ void Joystick::registerToUserInputMapper(UserInputMapper& mapper) {
         
         availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_LEFTSHOULDER), "L1"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), "R1"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(LEFT_AXIS_Y_NEG), "Left Stick Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(LEFT_AXIS_Y_POS), "Left Stick Down"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(LEFT_AXIS_X_POS), "Left Stick Right"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(LEFT_AXIS_X_NEG), "Left Stick Left"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(RIGHT_AXIS_Y_NEG), "Right Stick Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(RIGHT_AXIS_Y_POS), "Right Stick Down"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(RIGHT_AXIS_X_POS), "Right Stick Right"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(RIGHT_AXIS_X_NEG), "Right Stick Left"));
+
 #endif
         return availableInputs;
     };

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -59,20 +59,30 @@ void Joystick::focusOutEvent() {
 void Joystick::handleAxisEvent(const SDL_ControllerAxisEvent& event) {
     SDL_GameControllerAxis axis = (SDL_GameControllerAxis) event.axis;
     
-    if (axis == SDL_CONTROLLER_AXIS_LEFTX) {
-        _axisStateMap[makeInput(LEFT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-        _axisStateMap[makeInput(LEFT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
-    } else if (axis == SDL_CONTROLLER_AXIS_LEFTY) {
-        _axisStateMap[makeInput(LEFT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-        _axisStateMap[makeInput(LEFT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
-    } else if (axis == SDL_CONTROLLER_AXIS_RIGHTX) {
-        _axisStateMap[makeInput(RIGHT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-        _axisStateMap[makeInput(RIGHT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
-    } else if (axis == SDL_CONTROLLER_AXIS_RIGHTY) {
-        _axisStateMap[makeInput(RIGHT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-        _axisStateMap[makeInput(RIGHT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+    switch (axis) {
+        case SDL_CONTROLLER_AXIS_LEFTX:
+            _axisStateMap[makeInput(LEFT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(LEFT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            break;
+        case SDL_CONTROLLER_AXIS_LEFTY:
+            _axisStateMap[makeInput(LEFT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(LEFT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            break;
+        case SDL_CONTROLLER_AXIS_RIGHTX:
+            _axisStateMap[makeInput(RIGHT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(RIGHT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            break;
+        case SDL_CONTROLLER_AXIS_RIGHTY:
+            _axisStateMap[makeInput(RIGHT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(RIGHT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            break;
+        case SDL_CONTROLLER_AXIS_TRIGGERRIGHT:
+            _axisStateMap[makeInput(RIGHT_SHOULDER).getChannel()] = event.value / MAX_AXIS;
+            break;
+        case SDL_CONTROLLER_AXIS_TRIGGERLEFT:
+            _axisStateMap[makeInput(LEFT_SHOULDER).getChannel()] = event.value / MAX_AXIS;
+            break;
     }
-
 }
 
 void Joystick::handleButtonEvent(const SDL_ControllerButtonEvent& event) {
@@ -109,6 +119,8 @@ void Joystick::registerToUserInputMapper(UserInputMapper& mapper) {
         
         availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_LEFTSHOULDER), "L1"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), "R1"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(RIGHT_SHOULDER), "L2"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(LEFT_SHOULDER), "R2"));
         
         availableInputs.append(UserInputMapper::InputPair(makeInput(LEFT_AXIS_Y_NEG), "Left Stick Up"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(LEFT_AXIS_Y_POS), "Left Stick Down"));
@@ -136,6 +148,7 @@ void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
     const float DPAD_MOVE_SPEED = .5f;
     const float JOYSTICK_YAW_SPEED = 0.5f;
     const float JOYSTICK_PITCH_SPEED = 0.25f;
+    const float BOOM_SPEED = 0.1f;
     
     // Y axes are flipped (up is negative)
     // Left Joystick: Movement, strafing
@@ -162,6 +175,10 @@ void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
     mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), JOYSTICK_YAW_SPEED);
     mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), JOYSTICK_YAW_SPEED);
     
+    // Zoom
+    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(RIGHT_SHOULDER), BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(LEFT_SHOULDER), BOOM_SPEED);
+    
     
     // Hold front right shoulder button for precision controls
     // Left Joystick: Movement, strafing
@@ -187,6 +204,10 @@ void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
     mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_A), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
     mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
     mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
+    
+    // Zoom
+    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(RIGHT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(LEFT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.);
 #endif
 }
 

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -13,8 +13,11 @@
 
 #include <glm/glm.hpp>
 
+#include "Application.h"
+
 #include "Joystick.h"
 
+const float CONTROLLER_THRESHOLD = .25f;
 
 #ifdef HAVE_SDL2
 const float MAX_AXIS = 32768.0f;
@@ -22,10 +25,7 @@ const float MAX_AXIS = 32768.0f;
 Joystick::Joystick(SDL_JoystickID instanceId, const QString& name, SDL_GameController* sdlGameController) :
     _sdlGameController(sdlGameController),
     _sdlJoystick(SDL_GameControllerGetJoystick(_sdlGameController)),
-    _instanceId(instanceId),
-    _name(name),
-    _axes(QVector<float>(SDL_JoystickNumAxes(_sdlJoystick))),
-    _buttons(QVector<bool>(SDL_JoystickNumButtons(_sdlJoystick)))
+    _instanceId(instanceId)
 {
     
 }
@@ -42,24 +42,171 @@ void Joystick::closeJoystick() {
 #endif
 }
 
+void Joystick::update() {
+    for (auto axisState : _axisStateMap) {
+        if (axisState.second < CONTROLLER_THRESHOLD && axisState.second > -CONTROLLER_THRESHOLD) {
+            _axisStateMap[axisState.first] = 0;
+        }
+    }
+}
+
+void Joystick::focusOutEvent() {
+    _axisStateMap.clear();
+    _buttonPressedMap.clear();
+};
 
 #ifdef HAVE_SDL2
 void Joystick::handleAxisEvent(const SDL_ControllerAxisEvent& event) {
-    if (_axes.size() <= event.axis) {
-        _axes.resize(event.axis + 1);
+    SDL_GameControllerAxis axis = (SDL_GameControllerAxis) event.axis;
+    
+    if (axis == SDL_CONTROLLER_AXIS_LEFTX) {
+        _axisStateMap[makeInput(LEFT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+        _axisStateMap[makeInput(LEFT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+    } else if (axis == SDL_CONTROLLER_AXIS_LEFTY) {
+        _axisStateMap[makeInput(LEFT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+        _axisStateMap[makeInput(LEFT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+    } else if (axis == SDL_CONTROLLER_AXIS_RIGHTX) {
+        _axisStateMap[makeInput(RIGHT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+        _axisStateMap[makeInput(RIGHT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+    } else if (axis == SDL_CONTROLLER_AXIS_RIGHTY) {
+        _axisStateMap[makeInput(RIGHT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
+        _axisStateMap[makeInput(RIGHT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
     }
-    
-    float oldValue = _axes[event.axis];
-    float newValue = event.value / MAX_AXIS;
-    _axes[event.axis] = newValue;
-    
-    emit axisValueChanged(event.axis, newValue, oldValue);
+
 }
 
 void Joystick::handleButtonEvent(const SDL_ControllerButtonEvent& event) {
-    bool oldValue = _buttons[event.button];
+    auto input = makeInput((SDL_GameControllerButton) event.button);
     bool newValue = event.state == SDL_PRESSED;
-    _buttons[event.button] = newValue;
-    emit buttonStateChanged(event.button, newValue, oldValue);
+    if (newValue) {
+        _buttonPressedMap.insert(input.getChannel());
+    } else {
+        _buttonPressedMap.erase(input.getChannel());
+    }
 }
 #endif
+
+
+void Joystick::registerToUserInputMapper(UserInputMapper& mapper) {
+    // Grab the current free device ID
+    _deviceID = mapper.getFreeDeviceID();
+    
+    auto proxy = UserInputMapper::DeviceProxy::Pointer(new UserInputMapper::DeviceProxy(_name));
+    proxy->getButton = [this] (const UserInputMapper::Input& input, int timestamp) -> bool { return this->getButton(input._channel); };
+    proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input._channel); };
+    proxy->getAvailabeInputs = [this] () -> QVector<UserInputMapper::InputPair> {
+        QVector<UserInputMapper::InputPair> availableInputs;
+#ifdef HAVE_SDL2
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_A), "Bottom Button"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_B), "Right Button"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_X), "Left Button"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_Y), "Top Button"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_DPAD_UP), "DPad Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_DPAD_DOWN), "DPad Down"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_DPAD_LEFT), "DPad Left"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_DPAD_RIGHT), "DPad Right"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_LEFTSHOULDER), "L1"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), "R1"));
+#endif
+        return availableInputs;
+    };
+    proxy->resetDeviceBindings = [this, &mapper] () -> bool {
+        mapper.removeAllInputChannelsForDevice(_deviceID);
+        this->assignDefaultInputMapping(mapper);
+        return true;
+    };
+    mapper.registerDevice(_deviceID, proxy);
+}
+
+void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
+#ifdef HAVE_SDL2
+    const float JOYSTICK_MOVE_SPEED = 1.0f;
+    const float DPAD_MOVE_SPEED = .5f;
+    const float JOYSTICK_YAW_SPEED = 0.5f;
+    const float JOYSTICK_PITCH_SPEED = 0.25f;
+    
+    // Y axes are flipped (up is negative)
+    // Left Joystick: Movement, strafing
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(LEFT_AXIS_Y_NEG), JOYSTICK_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(LEFT_AXIS_Y_POS), JOYSTICK_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(LEFT_AXIS_X_POS), JOYSTICK_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(LEFT_AXIS_X_NEG), JOYSTICK_MOVE_SPEED);
+    
+    // Right Joystick: Camera orientation
+    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(RIGHT_AXIS_X_POS), JOYSTICK_YAW_SPEED);
+    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(RIGHT_AXIS_X_NEG), JOYSTICK_YAW_SPEED);
+    mapper.addInputChannel(UserInputMapper::PITCH_UP, makeInput(RIGHT_AXIS_Y_NEG), JOYSTICK_PITCH_SPEED);
+    mapper.addInputChannel(UserInputMapper::PITCH_DOWN, makeInput(RIGHT_AXIS_Y_POS), JOYSTICK_PITCH_SPEED);
+    
+    // Dpad movement
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_UP), DPAD_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_DOWN), DPAD_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_RIGHT), DPAD_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_LEFT), DPAD_MOVE_SPEED);
+    
+    // Button controls
+    mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(SDL_CONTROLLER_BUTTON_Y), DPAD_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_A), DPAD_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), JOYSTICK_YAW_SPEED);
+    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), JOYSTICK_YAW_SPEED);
+    
+    
+    // Hold front right shoulder button for precision controls
+    // Left Joystick: Movement, strafing
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(LEFT_AXIS_Y_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(LEFT_AXIS_Y_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(LEFT_AXIS_X_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(LEFT_AXIS_X_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
+    
+    // Right Joystick: Camera orientation
+    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(RIGHT_AXIS_X_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(RIGHT_AXIS_X_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::PITCH_UP, makeInput(RIGHT_AXIS_Y_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_PITCH_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::PITCH_DOWN, makeInput(RIGHT_AXIS_Y_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_PITCH_SPEED/2.);
+    
+    // Dpad movement
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_UP), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_DOWN), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_RIGHT), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_LEFT), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
+    
+    // Button controls
+    mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(SDL_CONTROLLER_BUTTON_Y), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_A), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
+#endif
+}
+
+float Joystick::getButton(int channel) const {
+    if (!_buttonPressedMap.empty()) {
+        if (_buttonPressedMap.find(channel) != _buttonPressedMap.end()) {
+            return 1.0f;
+        } else {
+            return 0.0f;
+        }
+    }
+    return 0.0f;
+}
+
+float Joystick::getAxis(int channel) const {
+    auto axis = _axisStateMap.find(channel);
+    if (axis != _axisStateMap.end()) {
+        return (*axis).second;
+    } else {
+        return 0.0f;
+    }
+}
+
+#ifdef HAVE_SDL2
+UserInputMapper::Input Joystick::makeInput(SDL_GameControllerButton button) {
+    return UserInputMapper::Input(_deviceID, button, UserInputMapper::ChannelType::BUTTON);
+}
+#endif
+
+UserInputMapper::Input Joystick::makeInput(Joystick::JoystickAxisChannel axis) {
+    return UserInputMapper::Input(_deviceID, axis, UserInputMapper::ChannelType::AXIS);
+}
+

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -82,6 +82,8 @@ void Joystick::handleAxisEvent(const SDL_ControllerAxisEvent& event) {
         case SDL_CONTROLLER_AXIS_TRIGGERLEFT:
             _axisStateMap[makeInput(LEFT_SHOULDER).getChannel()] = event.value / MAX_AXIS;
             break;
+        default:
+            break;
     }
 }
 
@@ -102,8 +104,8 @@ void Joystick::registerToUserInputMapper(UserInputMapper& mapper) {
     _deviceID = mapper.getFreeDeviceID();
     
     auto proxy = UserInputMapper::DeviceProxy::Pointer(new UserInputMapper::DeviceProxy(_name));
-    proxy->getButton = [this] (const UserInputMapper::Input& input, int timestamp) -> bool { return this->getButton(input._channel); };
-    proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input._channel); };
+    proxy->getButton = [this] (const UserInputMapper::Input& input, int timestamp) -> bool { return this->getButton(input.getChannel()); };
+    proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input.getChannel()); };
     proxy->getAvailabeInputs = [this] () -> QVector<UserInputMapper::InputPair> {
         QVector<UserInputMapper::InputPair> availableInputs;
 #ifdef HAVE_SDL2

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -17,7 +17,7 @@
 
 #include "Joystick.h"
 
-const float CONTROLLER_THRESHOLD = .25f;
+const float CONTROLLER_THRESHOLD = 0.25f;
 
 #ifdef HAVE_SDL2
 const float MAX_AXIS = 32768.0f;
@@ -147,7 +147,7 @@ void Joystick::registerToUserInputMapper(UserInputMapper& mapper) {
 void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
 #ifdef HAVE_SDL2
     const float JOYSTICK_MOVE_SPEED = 1.0f;
-    const float DPAD_MOVE_SPEED = .5f;
+    const float DPAD_MOVE_SPEED = 0.5f;
     const float JOYSTICK_YAW_SPEED = 0.5f;
     const float JOYSTICK_PITCH_SPEED = 0.25f;
     const float BOOM_SPEED = 0.1f;

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -44,8 +44,8 @@ void Joystick::closeJoystick() {
 
 void Joystick::update() {
     for (auto axisState : _axisStateMap) {
-        if (axisState.second < CONTROLLER_THRESHOLD && axisState.second > -CONTROLLER_THRESHOLD) {
-            _axisStateMap[axisState.first] = 0;
+        if (fabsf(axisState.second) < CONTROLLER_THRESHOLD) {
+            _axisStateMap[axisState.first] = 0.0f;
         }
     }
 }

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -61,20 +61,20 @@ void Joystick::handleAxisEvent(const SDL_ControllerAxisEvent& event) {
     
     switch (axis) {
         case SDL_CONTROLLER_AXIS_LEFTX:
-            _axisStateMap[makeInput(LEFT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-            _axisStateMap[makeInput(LEFT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(LEFT_AXIS_X_POS).getChannel()] = (event.value > 0.0f) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(LEFT_AXIS_X_NEG).getChannel()] = (event.value < 0.0f) ? -event.value / MAX_AXIS : 0.0f;
             break;
         case SDL_CONTROLLER_AXIS_LEFTY:
-            _axisStateMap[makeInput(LEFT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-            _axisStateMap[makeInput(LEFT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(LEFT_AXIS_Y_POS).getChannel()] = (event.value > 0.0f) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(LEFT_AXIS_Y_NEG).getChannel()] = (event.value < 0.0f) ? -event.value / MAX_AXIS : 0.0f;
             break;
         case SDL_CONTROLLER_AXIS_RIGHTX:
-            _axisStateMap[makeInput(RIGHT_AXIS_X_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-            _axisStateMap[makeInput(RIGHT_AXIS_X_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(RIGHT_AXIS_X_POS).getChannel()] = (event.value > 0.0f) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(RIGHT_AXIS_X_NEG).getChannel()] = (event.value < 0.0f) ? -event.value / MAX_AXIS : 0.0f;
             break;
         case SDL_CONTROLLER_AXIS_RIGHTY:
-            _axisStateMap[makeInput(RIGHT_AXIS_Y_POS).getChannel()] = (event.value > 0) ? event.value / MAX_AXIS : 0.0f;
-            _axisStateMap[makeInput(RIGHT_AXIS_Y_NEG).getChannel()] = (event.value < 0) ? -event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(RIGHT_AXIS_Y_POS).getChannel()] = (event.value > 0.0f) ? event.value / MAX_AXIS : 0.0f;
+            _axisStateMap[makeInput(RIGHT_AXIS_Y_NEG).getChannel()] = (event.value < 0.0f) ? -event.value / MAX_AXIS : 0.0f;
             break;
         case SDL_CONTROLLER_AXIS_TRIGGERRIGHT:
             _axisStateMap[makeInput(RIGHT_SHOULDER).getChannel()] = event.value / MAX_AXIS;
@@ -184,32 +184,32 @@ void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
     
     // Hold front right shoulder button for precision controls
     // Left Joystick: Movement, strafing
-    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(LEFT_AXIS_Y_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(LEFT_AXIS_Y_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(LEFT_AXIS_X_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(LEFT_AXIS_X_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(LEFT_AXIS_Y_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(LEFT_AXIS_Y_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(LEFT_AXIS_X_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(LEFT_AXIS_X_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_MOVE_SPEED/2.0f);
     
     // Right Joystick: Camera orientation
-    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(RIGHT_AXIS_X_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(RIGHT_AXIS_X_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::PITCH_UP, makeInput(RIGHT_AXIS_Y_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_PITCH_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::PITCH_DOWN, makeInput(RIGHT_AXIS_Y_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_PITCH_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(RIGHT_AXIS_X_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(RIGHT_AXIS_X_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::PITCH_UP, makeInput(RIGHT_AXIS_Y_NEG), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_PITCH_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::PITCH_DOWN, makeInput(RIGHT_AXIS_Y_POS), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_PITCH_SPEED/2.0f);
     
     // Dpad movement
-    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_UP), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_DOWN), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_RIGHT), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_LEFT), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_UP), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(SDL_CONTROLLER_BUTTON_DPAD_DOWN), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_RIGHT), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(SDL_CONTROLLER_BUTTON_DPAD_LEFT), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
     
     // Button controls
-    mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(SDL_CONTROLLER_BUTTON_Y), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_A), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(SDL_CONTROLLER_BUTTON_Y), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_A), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.0f);
     
     // Zoom
-    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(RIGHT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.);
-    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(LEFT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.);
+    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(RIGHT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(LEFT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.0f);
 #endif
 }
 

--- a/interface/src/devices/Joystick.h
+++ b/interface/src/devices/Joystick.h
@@ -41,6 +41,8 @@ public:
         RIGHT_AXIS_X_NEG,
         RIGHT_AXIS_Y_POS,
         RIGHT_AXIS_Y_NEG,
+        RIGHT_SHOULDER,
+        LEFT_SHOULDER,
     };
     
     Joystick();

--- a/interface/src/devices/Joystick.h
+++ b/interface/src/devices/Joystick.h
@@ -20,6 +20,8 @@
 #undef main
 #endif
 
+#include "ui/UserInputMapper.h"
+
 class Joystick : public QObject {
     Q_OBJECT
     
@@ -29,11 +31,37 @@ class Joystick : public QObject {
     Q_PROPERTY(int instanceId READ getInstanceId)
 #endif
     
-    Q_PROPERTY(int numAxes READ getNumAxes)
-    Q_PROPERTY(int numButtons READ getNumButtons)
 public:
+    enum JoystickAxisChannel {
+        LEFT_AXIS_X_POS = 0,
+        LEFT_AXIS_X_NEG,
+        LEFT_AXIS_Y_POS,
+        LEFT_AXIS_Y_NEG,
+        RIGHT_AXIS_X_POS,
+        RIGHT_AXIS_X_NEG,
+        RIGHT_AXIS_Y_POS,
+        RIGHT_AXIS_Y_NEG,
+    };
+    
     Joystick();
     ~Joystick();
+    
+    typedef std::unordered_set<int> ButtonPressedMap;
+    typedef std::map<int, float> AxisStateMap;
+    
+    float getButton(int channel) const;
+    float getAxis(int channel) const;
+    
+#ifdef HAVE_SDL2
+    UserInputMapper::Input makeInput(SDL_GameControllerButton button);
+#endif
+    UserInputMapper::Input makeInput(Joystick::JoystickAxisChannel axis);
+    
+    void registerToUserInputMapper(UserInputMapper& mapper);
+    void assignDefaultInputMapping(UserInputMapper& mapper);
+    
+    void update();
+    void focusOutEvent();
     
 #ifdef HAVE_SDL2
     Joystick(SDL_JoystickID instanceId, const QString& name, SDL_GameController* sdlGameController);
@@ -51,15 +79,8 @@ public:
     int getInstanceId() const { return _instanceId; }
 #endif
     
-    const QVector<float>& getAxes() const { return _axes; }
-    const QVector<bool>& getButtons() const { return _buttons; }
+    int getDeviceID() { return _deviceID; }
     
-    int getNumAxes() const { return _axes.size(); }
-    int getNumButtons() const { return _buttons.size(); }
-    
-signals:
-    void axisValueChanged(int axis, float newValue, float oldValue);
-    void buttonStateChanged(int button, float newValue, float oldValue);
 private:
 #ifdef HAVE_SDL2
     SDL_GameController* _sdlGameController;
@@ -68,8 +89,12 @@ private:
 #endif
 
     QString _name;
-    QVector<float> _axes;
-    QVector<bool> _buttons;
+    
+protected:
+    int _deviceID = 0;
+    
+    ButtonPressedMap _buttonPressedMap;
+    AxisStateMap _axisStateMap;
 };
 
-#endif // hifi_JoystickTracker_h
+#endif // hifi_Joystick_h

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -160,8 +160,8 @@ void KeyboardMouseDevice::registerToUserInputMapper(UserInputMapper& mapper) {
     _deviceID = mapper.getFreeDeviceID();
 
     auto proxy = UserInputMapper::DeviceProxy::Pointer(new UserInputMapper::DeviceProxy("Keyboard"));
-    proxy->getButton = [this] (const UserInputMapper::Input& input, int timestamp) -> bool { return this->getButton(input._channel); };
-    proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input._channel); };
+    proxy->getButton = [this] (const UserInputMapper::Input& input, int timestamp) -> bool { return this->getButton(input.getChannel()); };
+    proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input.getChannel()); };
     proxy->getAvailabeInputs = [this] () -> QVector<UserInputMapper::InputPair> {
         QVector<UserInputMapper::InputPair> availableInputs;
         for (int i = (int) Qt::Key_0; i <= (int) Qt::Key_9; i++) {

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -170,7 +170,33 @@ void KeyboardMouseDevice::registerToUserInputMapper(UserInputMapper& mapper) {
         for (int i = (int) Qt::Key_A; i <= (int) Qt::Key_Z; i++) {
             availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(i)), QKeySequence(Qt::Key(i)).toString()));
         }
+        for (int i = (int) Qt::Key_Left; i <= (int) Qt::Key_Down; i++) {
+            availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key(i)), QKeySequence(Qt::Key(i)).toString()));
+        }
         availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key_Space), QKeySequence(Qt::Key_Space).toString()));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key_Shift), "Shift"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key_PageUp), QKeySequence(Qt::Key_PageUp).toString()));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::Key_PageDown), QKeySequence(Qt::Key_PageDown).toString()));
+
+        availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::LeftButton), "Left Mouse Click"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::MiddleButton), "Middle Mouse Click"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(Qt::RightButton), "Right Mouse Click"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_X_POS), "Mouse Move Right"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_X_NEG), "Mouse Move Left"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_Y_POS), "Mouse Move Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_Y_NEG), "Mouse Move Down"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_WHEEL_Y_POS), "Mouse Wheel Right"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_WHEEL_Y_NEG), "Mouse Wheel Left"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_WHEEL_X_POS), "Mouse Wheel Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(MOUSE_AXIS_WHEEL_X_NEG), "Mouse Wheel Down"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(TOUCH_AXIS_X_POS), "Touchpad Right"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(TOUCH_AXIS_X_NEG), "Touchpad Left"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(TOUCH_AXIS_Y_POS), "Touchpad Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(TOUCH_AXIS_Y_NEG), "Touchpad Down"));
+
         return availableInputs;
     };
     proxy->resetDeviceBindings = [this, &mapper] () -> bool {

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -215,7 +215,7 @@ void KeyboardMouseDevice::assignDefaultInputMapping(UserInputMapper& mapper) {
     const float MOUSE_PITCH_SPEED = 0.25f;
     const float TOUCH_YAW_SPEED = 0.5f;
     const float TOUCH_PITCH_SPEED = 0.25f;
-    //const float BUTTON_BOOM_SPEED = 0.1f;
+    const float BUTTON_BOOM_SPEED = 0.1f;
  
     // AWSD keys mapping
     mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(Qt::Key_S), BUTTON_MOVE_SPEED);
@@ -225,8 +225,8 @@ void KeyboardMouseDevice::assignDefaultInputMapping(UserInputMapper& mapper) {
     mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(Qt::Key_C), BUTTON_MOVE_SPEED);
     mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(Qt::Key_E), BUTTON_MOVE_SPEED);
 
-  //  mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(Qt::Key_W), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
-  //  mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(Qt::Key_S), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(Qt::Key_W), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(Qt::Key_S), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(Qt::Key_A), makeInput(Qt::RightButton), BUTTON_YAW_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(Qt::Key_D), makeInput(Qt::RightButton), BUTTON_YAW_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(Qt::Key_A), makeInput(Qt::Key_Shift), BUTTON_YAW_SPEED);
@@ -242,8 +242,8 @@ void KeyboardMouseDevice::assignDefaultInputMapping(UserInputMapper& mapper) {
     mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(Qt::Key_PageDown), BUTTON_MOVE_SPEED);
     mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(Qt::Key_PageUp), BUTTON_MOVE_SPEED);
 
- //   mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(Qt::Key_Up), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
- //   mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(Qt::Key_Down), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(Qt::Key_Up), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(Qt::Key_Down), makeInput(Qt::Key_Shift), BUTTON_BOOM_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(Qt::Key_Left), makeInput(Qt::RightButton), BUTTON_YAW_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(Qt::Key_Right), makeInput(Qt::RightButton), BUTTON_YAW_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(Qt::Key_Left), makeInput(Qt::Key_Shift), BUTTON_YAW_SPEED);
@@ -272,8 +272,8 @@ void KeyboardMouseDevice::assignDefaultInputMapping(UserInputMapper& mapper) {
     mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(TOUCH_AXIS_X_POS), TOUCH_YAW_SPEED);
     
     // Wheel move
-    //mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(MOUSE_AXIS_WHEEL_Y_NEG), BUTTON_BOOM_SPEED);
-    //mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(MOUSE_AXIS_WHEEL_Y_POS), BUTTON_BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(MOUSE_AXIS_WHEEL_Y_NEG), BUTTON_BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(MOUSE_AXIS_WHEEL_Y_POS), BUTTON_BOOM_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(MOUSE_AXIS_WHEEL_X_NEG), BUTTON_YAW_SPEED);
     mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(MOUSE_AXIS_WHEEL_X_POS), BUTTON_YAW_SPEED);
 

--- a/interface/src/devices/SDL2Manager.h
+++ b/interface/src/devices/SDL2Manager.h
@@ -1,77 +1,46 @@
 //
-//  JoystickScriptingInterface.h
+//  SDL2Manager.h
 //  interface/src/devices
 //
-//  Created by Andrzej Kapolka on 5/15/14.
-//  Copyright 2014 High Fidelity, Inc.
+//  Created by Sam Gondelman on 6/5/15.
+//  Copyright 2015 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#ifndef hifi_JoystickScriptingInterface_h
-#define hifi_JoystickScriptingInterface_h
-
-#include <QObject>
-#include <QVector>
+#ifndef hifi__SDL2Manager_h
+#define hifi__SDL2Manager_h
 
 #ifdef HAVE_SDL2
 #include <SDL.h>
 #endif
 
+#include "ui/UserInputMapper.h"
+
 #include "devices/Joystick.h"
 
-/// Handles joystick input through SDL.
-class JoystickScriptingInterface : public QObject {
+class SDL2Manager : public QObject {
     Q_OBJECT
-
-#ifdef HAVE_SDL2
-    Q_PROPERTY(int AXIS_INVALID READ axisInvalid)
-    Q_PROPERTY(int AXIS_LEFT_X READ axisLeftX)
-    Q_PROPERTY(int AXIS_LEFT_Y READ axisLeftY)
-    Q_PROPERTY(int AXIS_RIGHT_X READ axisRightX)
-    Q_PROPERTY(int AXIS_RIGHT_Y READ axisRightY)
-    Q_PROPERTY(int AXIS_TRIGGER_LEFT READ axisTriggerLeft)
-    Q_PROPERTY(int AXIS_TRIGGER_RIGHT READ axisTriggerRight)
-    Q_PROPERTY(int AXIS_MAX READ axisMax)
-
-    Q_PROPERTY(int BUTTON_INVALID READ buttonInvalid)
-    Q_PROPERTY(int BUTTON_FACE_BOTTOM READ buttonFaceBottom)
-    Q_PROPERTY(int BUTTON_FACE_RIGHT READ buttonFaceRight)
-    Q_PROPERTY(int BUTTON_FACE_LEFT READ buttonFaceLeft)
-    Q_PROPERTY(int BUTTON_FACE_TOP READ buttonFaceTop)
-    Q_PROPERTY(int BUTTON_BACK READ buttonBack)
-    Q_PROPERTY(int BUTTON_GUIDE READ buttonGuide)
-    Q_PROPERTY(int BUTTON_START READ buttonStart)
-    Q_PROPERTY(int BUTTON_LEFT_STICK READ buttonLeftStick)
-    Q_PROPERTY(int BUTTON_RIGHT_STICK READ buttonRightStick)
-    Q_PROPERTY(int BUTTON_LEFT_SHOULDER READ buttonLeftShoulder)
-    Q_PROPERTY(int BUTTON_RIGHT_SHOULDER READ buttonRightShoulder)
-    Q_PROPERTY(int BUTTON_DPAD_UP READ buttonDpadUp)
-    Q_PROPERTY(int BUTTON_DPAD_DOWN READ buttonDpadDown)
-    Q_PROPERTY(int BUTTON_DPAD_LEFT READ buttonDpadLeft)
-    Q_PROPERTY(int BUTTON_DPAD_RIGHT READ buttonDpadRight)
-    Q_PROPERTY(int BUTTON_MAX READ buttonMax)
-
-    Q_PROPERTY(int BUTTON_PRESSED READ buttonPressed)
-    Q_PROPERTY(int BUTTON_RELEASED READ buttonRelease)
-#endif
-
+    
 public:
-    static JoystickScriptingInterface& getInstance();
-
+    SDL2Manager();
+    ~SDL2Manager();
+    
+    void focusOutEvent();
+    
     void update();
-
-public slots:
-    Joystick* joystickWithName(const QString& name);
-    const QObjectList getAllJoysticks() const;
-
+    
+    static SDL2Manager* getInstance();
+    
 signals:
     void joystickAdded(Joystick* joystick);
     void joystickRemoved(Joystick* joystick);
-
+    
 private:
 #ifdef HAVE_SDL2
+    SDL_JoystickID getInstanceId(SDL_GameController* controller);
+    
     int axisInvalid() const { return SDL_CONTROLLER_AXIS_INVALID; }
     int axisLeftX() const { return SDL_CONTROLLER_AXIS_LEFTX; }
     int axisLeftY() const { return SDL_CONTROLLER_AXIS_LEFTY; }
@@ -80,7 +49,7 @@ private:
     int axisTriggerLeft() const { return SDL_CONTROLLER_AXIS_TRIGGERLEFT; }
     int axisTriggerRight() const { return SDL_CONTROLLER_AXIS_TRIGGERRIGHT; }
     int axisMax() const { return SDL_CONTROLLER_AXIS_MAX; }
-
+    
     int buttonInvalid() const { return SDL_CONTROLLER_BUTTON_INVALID; }
     int buttonFaceBottom() const { return SDL_CONTROLLER_BUTTON_A; }
     int buttonFaceRight() const { return SDL_CONTROLLER_BUTTON_B; }
@@ -98,18 +67,15 @@ private:
     int buttonDpadLeft() const { return SDL_CONTROLLER_BUTTON_DPAD_LEFT; }
     int buttonDpadRight() const { return SDL_CONTROLLER_BUTTON_DPAD_RIGHT; }
     int buttonMax() const { return SDL_CONTROLLER_BUTTON_MAX; }
-
+    
     int buttonPressed() const { return SDL_PRESSED; }
     int buttonRelease() const { return SDL_RELEASED; }
 #endif
-
-    JoystickScriptingInterface();
-    ~JoystickScriptingInterface();
-
+    
 #ifdef HAVE_SDL2
     QMap<SDL_JoystickID, Joystick*> _openJoysticks;
 #endif
     bool _isInitialized;
 };
 
-#endif // hifi_JoystickScriptingInterface_h
+#endif // hifi__SDL2Manager_h

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -38,6 +38,10 @@ typedef int (*SixenseTakeIntFunction)(int);
 typedef int (*SixenseTakeIntAndSixenseControllerData)(int, sixenseControllerData*);
 #endif
 
+// These bits aren't used for buttons, so they can be used as masks:
+const unsigned int LEFT_MASK = 0;
+const unsigned int RIGHT_MASK = 1U << 1;
+
 #endif
 
 SixenseManager& SixenseManager::getInstance() {
@@ -147,6 +151,7 @@ void SixenseManager::update(float deltaTime) {
 #ifdef HAVE_SIXENSE
     Hand* hand = DependencyManager::get<AvatarManager>()->getMyAvatar()->getHand();
     if (_isInitialized && _isEnabled) {
+        _buttonPressedMap.clear();
 #ifdef __APPLE__
         SixenseBaseFunction sixenseGetNumActiveControllers =
         (SixenseBaseFunction) _sixenseLibrary->resolve("sixenseGetNumActiveControllers");
@@ -154,12 +159,18 @@ void SixenseManager::update(float deltaTime) {
         
         if (sixenseGetNumActiveControllers() == 0) {
             _hydrasConnected = false;
+            if (_deviceID) {
+                Application::getUserInputMapper()->removeDevice(_deviceID);
+                _deviceID = 0;
+            }
             return;
         }
         
         PerformanceTimer perfTimer("sixense");
         if (!_hydrasConnected) {
             _hydrasConnected = true;
+            registerToUserInputMapper(*Application::getUserInputMapper());
+            getInstance().assignDefaultInputMapping(*Application::getUserInputMapper());
             UserActivityLogger::getInstance().connectedDevice("spatial_controller", "hydra");
         }
         
@@ -216,11 +227,13 @@ void SixenseManager::update(float deltaTime) {
                 palm->setActive(false); // if this isn't a Sixsense ID palm, always make it inactive
             }
             
-            
             //  Read controller buttons and joystick into the hand
             palm->setControllerButtons(data->buttons);
             palm->setTrigger(data->trigger);
             palm->setJoystick(data->joystick_x, data->joystick_y);
+            
+            handleButtonEvent(data->buttons, numActiveControllers - 1);
+            handleAxisEvent(data->joystick_x, data->joystick_y, data->trigger, numActiveControllers - 1);
             
             // Emulate the mouse so we can use scripts
             if (Menu::getInstance()->isOptionChecked(MenuOption::SixenseMouseInput) && !_controllersAtBase) {
@@ -590,3 +603,137 @@ void SixenseManager::emulateMouse(PalmData* palm, int index) {
 
 #endif  // HAVE_SIXENSE
 
+void SixenseManager::focusOutEvent() {
+    _axisStateMap.clear();
+    _buttonPressedMap.clear();
+};
+
+void SixenseManager::handleAxisEvent(float stickX, float stickY, float trigger, int index) {
+    _axisStateMap[makeInput(AXIS_Y_POS, index).getChannel()] = (stickY > 0) ? stickY : 0.0f;
+    _axisStateMap[makeInput(AXIS_Y_NEG, index).getChannel()] = (stickY < 0) ? -stickY : 0.0f;
+    _axisStateMap[makeInput(AXIS_X_POS, index).getChannel()] = (stickX > 0) ? stickX : 0.0f;
+    _axisStateMap[makeInput(AXIS_X_NEG, index).getChannel()] = (stickX < 0) ? -stickX : 0.0f;
+    _axisStateMap[makeInput(BACK_TRIGGER, index).getChannel()] = trigger;
+}
+
+void SixenseManager::handleButtonEvent(unsigned int buttons, int index) {
+    if (buttons & BUTTON_0) {
+        _buttonPressedMap.insert(makeInput(BUTTON_0, index).getChannel());
+    }
+    if (buttons & BUTTON_1) {
+        _buttonPressedMap.insert(makeInput(BUTTON_1, index).getChannel());
+    }
+    if (buttons & BUTTON_2) {
+        _buttonPressedMap.insert(makeInput(BUTTON_2, index).getChannel());
+    }
+    if (buttons & BUTTON_3) {
+        _buttonPressedMap.insert(makeInput(BUTTON_3, index).getChannel());
+    }
+    if (buttons & BUTTON_4) {
+        _buttonPressedMap.insert(makeInput(BUTTON_4, index).getChannel());
+    }
+    if (buttons & BUTTON_FWD) {
+        _buttonPressedMap.insert(makeInput(BUTTON_FWD, index).getChannel());
+    }
+}
+
+void SixenseManager::registerToUserInputMapper(UserInputMapper& mapper) {
+    // Grab the current free device ID
+    _deviceID = mapper.getFreeDeviceID();
+    
+    auto proxy = UserInputMapper::DeviceProxy::Pointer(new UserInputMapper::DeviceProxy("Hydra"));
+    proxy->getButton = [this] (const UserInputMapper::Input& input, int timestamp) -> bool { return this->getButton(input.getChannel()); };
+    proxy->getAxis = [this] (const UserInputMapper::Input& input, int timestamp) -> float { return this->getAxis(input.getChannel()); };
+    proxy->getAvailabeInputs = [this] () -> QVector<UserInputMapper::InputPair> {
+        QVector<UserInputMapper::InputPair> availableInputs;
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_0, 0), "Left Start"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_1, 0), "Left Button 1"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_2, 0), "Left Button 2"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_3, 0), "Left Button 3"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_4, 0), "Left Button 4"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_FWD, 0), "L1"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BACK_TRIGGER, 0), "L2"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_Y_POS, 0), "Left Stick Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_Y_NEG, 0), "Left Stick Down"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_POS, 0), "Left Stick Right"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_NEG, 0), "Left Stick Left"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_0, 1), "Right Start"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_1, 1), "Right Button 1"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_2, 1), "Right Button 2"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_3, 1), "Right Button 3"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_4, 1), "Right Button 4"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_FWD, 1), "R1"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BACK_TRIGGER, 1), "R2"));
+        
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_Y_POS, 1), "Right Stick Up"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_Y_NEG, 1), "Right Stick Down"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_POS, 1), "Right Stick Right"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_NEG, 1), "Right Stick Left"));
+        return availableInputs;
+    };
+    proxy->resetDeviceBindings = [this, &mapper] () -> bool {
+        mapper.removeAllInputChannelsForDevice(_deviceID);
+        this->assignDefaultInputMapping(mapper);
+        return true;
+    };
+    mapper.registerDevice(_deviceID, proxy);
+}
+
+void SixenseManager::assignDefaultInputMapping(UserInputMapper& mapper) {
+    const float JOYSTICK_MOVE_SPEED = 1.0f;
+    const float JOYSTICK_YAW_SPEED = 0.5f;
+    const float JOYSTICK_PITCH_SPEED = 0.25f;
+    const float BUTTON_MOVE_SPEED = 1.0f;
+    const float BOOM_SPEED = .1f;
+    
+    // Left Joystick: Movement, strafing
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(AXIS_Y_POS, 0), JOYSTICK_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(AXIS_Y_NEG, 0), JOYSTICK_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(AXIS_X_POS, 0), JOYSTICK_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(AXIS_X_NEG, 0), JOYSTICK_MOVE_SPEED);
+    
+    // Right Joystick: Camera orientation
+    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(AXIS_X_POS, 1), JOYSTICK_YAW_SPEED);
+    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(AXIS_X_NEG, 1), JOYSTICK_YAW_SPEED);
+    mapper.addInputChannel(UserInputMapper::PITCH_UP, makeInput(AXIS_Y_POS, 1), JOYSTICK_PITCH_SPEED);
+    mapper.addInputChannel(UserInputMapper::PITCH_DOWN, makeInput(AXIS_Y_NEG, 1), JOYSTICK_PITCH_SPEED);
+    
+    // Buttons
+    mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(BUTTON_3, 0), BOOM_SPEED);
+    mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(BUTTON_1, 0), BOOM_SPEED);
+    
+    mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(BUTTON_3, 1), BUTTON_MOVE_SPEED);
+    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(BUTTON_1, 1), BUTTON_MOVE_SPEED);
+}
+
+float SixenseManager::getButton(int channel) const {
+    if (!_buttonPressedMap.empty()) {
+        if (_buttonPressedMap.find(channel) != _buttonPressedMap.end()) {
+            return 1.0f;
+        } else {
+            return 0.0f;
+        }
+    }
+    return 0.0f;
+}
+
+float SixenseManager::getAxis(int channel) const {
+    auto axis = _axisStateMap.find(channel);
+    if (axis != _axisStateMap.end()) {
+        return (*axis).second;
+    } else {
+        return 0.0f;
+    }
+}
+
+UserInputMapper::Input SixenseManager::makeInput(unsigned int button, int index) {
+    return UserInputMapper::Input(_deviceID, button | (index == 0 ? LEFT_MASK : RIGHT_MASK), UserInputMapper::ChannelType::BUTTON);
+}
+
+UserInputMapper::Input SixenseManager::makeInput(SixenseManager::JoystickAxisChannel axis, int index) {
+    return UserInputMapper::Input(_deviceID, axis | (index == 0 ? LEFT_MASK : RIGHT_MASK), UserInputMapper::ChannelType::AXIS);
+}

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -65,6 +65,8 @@ SixenseManager::SixenseManager() :
     _bumperPressed[1] = false;
     _oldX[1] = -1;
     _oldY[1] = -1;
+    _prevPalms[0] = nullptr;
+    _prevPalms[1] = nullptr;
 }
 
 SixenseManager::~SixenseManager() {
@@ -162,6 +164,12 @@ void SixenseManager::update(float deltaTime) {
             if (_deviceID) {
                 Application::getUserInputMapper()->removeDevice(_deviceID);
                 _deviceID = 0;
+                if (_prevPalms[0]) {
+                    _prevPalms[0]->setActive(false);
+                }
+                if (_prevPalms[1]) {
+                    _prevPalms[1]->setActive(false);
+                }
             }
             return;
         }
@@ -209,6 +217,7 @@ void SixenseManager::update(float deltaTime) {
             for (size_t j = 0; j < hand->getNumPalms(); j++) {
                 if (hand->getPalms()[j].getSixenseID() == data->controller_index) {
                     palm = &(hand->getPalms()[j]);
+                    _prevPalms[numActiveControllers - 1] = palm;
                     foundHand = true;
                 }
             }
@@ -217,6 +226,7 @@ void SixenseManager::update(float deltaTime) {
                 hand->getPalms().push_back(newPalm);
                 palm = &(hand->getPalms()[hand->getNumPalms() - 1]);
                 palm->setSixenseID(data->controller_index);
+                _prevPalms[numActiveControllers - 1] = palm;
                 qCDebug(interfaceapp, "Found new Sixense controller, ID %i", data->controller_index);
             }
             

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -645,6 +645,9 @@ void SixenseManager::handleButtonEvent(unsigned int buttons, int index) {
     if (buttons & BUTTON_FWD) {
         _buttonPressedMap.insert(makeInput(BUTTON_FWD, index).getChannel());
     }
+    if (buttons & BUTTON_TRIGGER) {
+        _buttonPressedMap.insert(makeInput(BUTTON_TRIGGER, index).getChannel());
+    }
 }
 
 void SixenseManager::registerToUserInputMapper(UserInputMapper& mapper) {
@@ -669,6 +672,7 @@ void SixenseManager::registerToUserInputMapper(UserInputMapper& mapper) {
         availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_Y_NEG, 0), "Left Stick Down"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_POS, 0), "Left Stick Right"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_NEG, 0), "Left Stick Left"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_TRIGGER, 0), "Left Trigger Press"));
         
         availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_0, 1), "Right Start"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_1, 1), "Right Button 1"));
@@ -683,6 +687,8 @@ void SixenseManager::registerToUserInputMapper(UserInputMapper& mapper) {
         availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_Y_NEG, 1), "Right Stick Down"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_POS, 1), "Right Stick Right"));
         availableInputs.append(UserInputMapper::InputPair(makeInput(AXIS_X_NEG, 1), "Right Stick Left"));
+        availableInputs.append(UserInputMapper::InputPair(makeInput(BUTTON_TRIGGER, 1), "Right Trigger Press"));
+
         return availableInputs;
     };
     proxy->resetDeviceBindings = [this, &mapper] () -> bool {

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -619,10 +619,10 @@ void SixenseManager::focusOutEvent() {
 };
 
 void SixenseManager::handleAxisEvent(float stickX, float stickY, float trigger, int index) {
-    _axisStateMap[makeInput(AXIS_Y_POS, index).getChannel()] = (stickY > 0) ? stickY : 0.0f;
-    _axisStateMap[makeInput(AXIS_Y_NEG, index).getChannel()] = (stickY < 0) ? -stickY : 0.0f;
-    _axisStateMap[makeInput(AXIS_X_POS, index).getChannel()] = (stickX > 0) ? stickX : 0.0f;
-    _axisStateMap[makeInput(AXIS_X_NEG, index).getChannel()] = (stickX < 0) ? -stickX : 0.0f;
+    _axisStateMap[makeInput(AXIS_Y_POS, index).getChannel()] = (stickY > 0.0f) ? stickY : 0.0f;
+    _axisStateMap[makeInput(AXIS_Y_NEG, index).getChannel()] = (stickY < 0.0f) ? -stickY : 0.0f;
+    _axisStateMap[makeInput(AXIS_X_POS, index).getChannel()] = (stickX > 0.0f) ? stickX : 0.0f;
+    _axisStateMap[makeInput(AXIS_X_NEG, index).getChannel()] = (stickX < 0.0f) ? -stickX : 0.0f;
     _axisStateMap[makeInput(BACK_TRIGGER, index).getChannel()] = trigger;
 }
 

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -19,6 +19,10 @@
 #include "UserActivityLogger.h"
 #include "InterfaceLogging.h"
 
+// These bits aren't used for buttons, so they can be used as masks:
+const unsigned int LEFT_MASK = 0;
+const unsigned int RIGHT_MASK = 1U << 1;
+
 #ifdef HAVE_SIXENSE
 
 const int CALIBRATION_STATE_IDLE = 0;
@@ -37,10 +41,6 @@ typedef int (*SixenseBaseFunction)();
 typedef int (*SixenseTakeIntFunction)(int);
 typedef int (*SixenseTakeIntAndSixenseControllerData)(int, sixenseControllerData*);
 #endif
-
-// These bits aren't used for buttons, so they can be used as masks:
-const unsigned int LEFT_MASK = 0;
-const unsigned int RIGHT_MASK = 1U << 1;
 
 #endif
 

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -161,7 +161,7 @@ void SixenseManager::update(float deltaTime) {
         
         if (sixenseGetNumActiveControllers() == 0) {
             _hydrasConnected = false;
-            if (_deviceID) {
+            if (_deviceID != 0) {
                 Application::getUserInputMapper()->removeDevice(_deviceID);
                 _deviceID = 0;
                 if (_prevPalms[0]) {
@@ -704,7 +704,7 @@ void SixenseManager::assignDefaultInputMapping(UserInputMapper& mapper) {
     const float JOYSTICK_YAW_SPEED = 0.5f;
     const float JOYSTICK_PITCH_SPEED = 0.25f;
     const float BUTTON_MOVE_SPEED = 1.0f;
-    const float BOOM_SPEED = .1f;
+    const float BOOM_SPEED = 0.1f;
     
     // Left Joystick: Movement, strafing
     mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(AXIS_Y_POS, 0), JOYSTICK_MOVE_SPEED);

--- a/interface/src/devices/SixenseManager.h
+++ b/interface/src/devices/SixenseManager.h
@@ -132,6 +132,7 @@ private:
     bool _bumperPressed[2];
     int _oldX[2];
     int _oldY[2];
+    PalmData* _prevPalms[2];
     
     bool _lowVelocityFilter;
     bool _controllersAtBase;

--- a/interface/src/devices/SixenseManager.h
+++ b/interface/src/devices/SixenseManager.h
@@ -36,6 +36,7 @@ const unsigned int BUTTON_2 = 1U << 6;
 const unsigned int BUTTON_3 = 1U << 3;
 const unsigned int BUTTON_4 = 1U << 4;
 const unsigned int BUTTON_FWD = 1U << 7;
+const unsigned int BUTTON_TRIGGER = 1U << 8;
 
 // Event type that represents using the controller
 const unsigned int CONTROLLER_0_EVENT = 1500U;

--- a/interface/src/devices/SixenseManager.h
+++ b/interface/src/devices/SixenseManager.h
@@ -96,9 +96,9 @@ private:
     SixenseManager();
     ~SixenseManager();
     
-#ifdef HAVE_SIXENSE
     void handleButtonEvent(unsigned int buttons, int index);
     void handleAxisEvent(float x, float y, float trigger, int index);
+#ifdef HAVE_SIXENSE
     void updateCalibration(const sixenseControllerData* controllers);
     void emulateMouse(PalmData* palm, int index);
 

--- a/interface/src/ui/UserInputMapper.cpp
+++ b/interface/src/ui/UserInputMapper.cpp
@@ -106,6 +106,11 @@ void UserInputMapper::removeAllInputChannelsForDevice(uint16 device) {
     }
 }
 
+void UserInputMapper::removeDevice(int device) {
+    removeAllInputChannelsForDevice((uint16) device);
+    _registeredDevices.erase(device);
+}
+
 int UserInputMapper::getInputChannels(InputChannels& channels) const {
     for (auto& channel : _actionToInputsMap) {
         channels.push_back(channel.second);

--- a/interface/src/ui/UserInputMapper.h
+++ b/interface/src/ui/UserInputMapper.h
@@ -189,6 +189,7 @@ public:
     bool removeInputChannel(InputChannel channel);
     void removeAllInputChannels();
     void removeAllInputChannelsForDevice(uint16 device);
+    void removeDevice(int device);
     //Grab all the input channels currently in use, return the number
     int getInputChannels(InputChannels& channels) const;
     QVector<InputChannel> getAllInputsForDevice(uint16 device);


### PR DESCRIPTION
Default key mapping support for gamepads and hydras without need for gamepad.js and hydraMove.js

Ability to easily remap key bindings for gamepads and hydras

Support for remappable zooming (shift + w/s on keyboard, back triggers on gamepads, left 3/1 buttons on hydra), snaps to first person if you zoom in enough

Some hydra events are still forwarded back to the application as mouse events which will likely be changed in the future, but for right now, "mouse" behavior with the hydras shouldn't have changed