### PR TITLE
fix detailed ray picking against models

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1761,7 +1761,7 @@ void Model::setupBatchTransform(gpu::Batch& batch, RenderArgs* args) {
 }
 
 AABox Model::getPartBounds(int meshIndex, int partIndex) {
-    if (!_calculatedMeshPartBoxesValid) {
+    if (!_calculatedMeshPartBoxesValid || !_calculatedMeshBoxesValid) {
         recalculateMeshBoxes(true);
     }
 
@@ -1802,7 +1802,7 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
     
     // we always need these properly calculated before we can render, this will likely already have been done
     // since the engine will call our getPartBounds() before rendering us.
-    if (!_calculatedMeshPartBoxesValid) {
+    if (!_calculatedMeshPartBoxesValid || !_calculatedMeshBoxesValid) {
         recalculateMeshBoxes(true);
     }
     auto textureCache = DependencyManager::get<TextureCache>();


### PR DESCRIPTION
the bug was caused by the mesh boxes not being recalculated after an entity was moved or transformed in some way.