### PR TITLE
Migrating the rendering of 3D overlay elements to the batch rendering

### DIFF
--- a/interface/src/ui/overlays/BillboardOverlay.cpp
+++ b/interface/src/ui/overlays/BillboardOverlay.cpp
@@ -43,72 +43,88 @@ void BillboardOverlay::render(RenderArgs* args) {
         return;
     }
 
-    glEnable(GL_ALPHA_TEST);
-    glAlphaFunc(GL_GREATER, 0.5f);
+    glm::quat rotation;
+    if (_isFacingAvatar) {
+        // rotate about vertical to face the camera
+        rotation = Application::getInstance()->getCamera()->getRotation();
+        rotation *= glm::angleAxis(glm::pi<float>(), glm::vec3(0.0f, 1.0f, 0.0f));
+        rotation *= getRotation();
+    } else {
+        rotation = getRotation();
+    }
 
-    glEnable(GL_TEXTURE_2D);
-    glDisable(GL_LIGHTING);
+    float imageWidth = _texture->getWidth();
+    float imageHeight = _texture->getHeight();
 
-    glBindTexture(GL_TEXTURE_2D, _texture->getID());
+    QRect fromImage;
+    if (_fromImage.isNull()) {
+        fromImage.setX(0);
+        fromImage.setY(0);
+        fromImage.setWidth(imageWidth);
+        fromImage.setHeight(imageHeight);
+    } else {
+        float scaleX = imageWidth / _texture->getOriginalWidth();
+        float scaleY = imageHeight / _texture->getOriginalHeight();
 
-    glPushMatrix(); {
-        glTranslatef(_position.x, _position.y, _position.z);
-        glm::quat rotation;
-        if (_isFacingAvatar) {
-            // rotate about vertical to face the camera
-            rotation = Application::getInstance()->getCamera()->getRotation();
-            rotation *= glm::angleAxis(glm::pi<float>(), glm::vec3(0.0f, 1.0f, 0.0f));
-            rotation *= getRotation();
-        } else {
-            rotation = getRotation();
-        }
-        glm::vec3 axis = glm::axis(rotation);
-        glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
-        glScalef(_scale, _scale, _scale);
+        fromImage.setX(scaleX * _fromImage.x());
+        fromImage.setY(scaleY * _fromImage.y());
+        fromImage.setWidth(scaleX * _fromImage.width());
+        fromImage.setHeight(scaleY * _fromImage.height());
+    }
 
-        const float MAX_COLOR = 255.0f;
-        xColor color = getColor();
-        float alpha = getAlpha();
+    float maxSize = glm::max(fromImage.width(), fromImage.height());
+    float x = fromImage.width() / (2.0f * maxSize);
+    float y = -fromImage.height() / (2.0f * maxSize);
 
-        float imageWidth = _texture->getWidth();
-        float imageHeight = _texture->getHeight();
+    glm::vec2 topLeft(-x, -y);
+    glm::vec2 bottomRight(x, y);
+    glm::vec2 texCoordTopLeft(fromImage.x() / imageWidth, fromImage.y() / imageHeight);
+    glm::vec2 texCoordBottomRight((fromImage.x() + fromImage.width()) / imageWidth,
+                                  (fromImage.y() + fromImage.height()) / imageHeight);
 
-        QRect fromImage;
-        if (_fromImage.isNull()) {
-            fromImage.setX(0);
-            fromImage.setY(0);
-            fromImage.setWidth(imageWidth);
-            fromImage.setHeight(imageHeight);
-        } else {
-            float scaleX = imageWidth / _texture->getOriginalWidth();
-            float scaleY = imageHeight / _texture->getOriginalHeight();
+    const float MAX_COLOR = 255.0f;
+    xColor color = getColor();
+    float alpha = getAlpha();
 
-            fromImage.setX(scaleX * _fromImage.x());
-            fromImage.setY(scaleY * _fromImage.y());
-            fromImage.setWidth(scaleX * _fromImage.width());
-            fromImage.setHeight(scaleY * _fromImage.height());
-        }
+    auto batch = args->_batch;
 
-        float maxSize = glm::max(fromImage.width(), fromImage.height());
-        float x = fromImage.width() / (2.0f * maxSize);
-        float y = -fromImage.height() / (2.0f * maxSize);
+    if (batch) {
+        Transform transform;
+        transform.setTranslation(_position);
+        transform.setRotation(rotation);
+        transform.setScale(_scale);
 
-        glm::vec2 topLeft(-x, -y);
-        glm::vec2 bottomRight(x, y);
-        glm::vec2 texCoordTopLeft(fromImage.x() / imageWidth, fromImage.y() / imageHeight);
-        glm::vec2 texCoordBottomRight((fromImage.x() + fromImage.width()) / imageWidth,
-                                      (fromImage.y() + fromImage.height()) / imageHeight);
-
-        DependencyManager::get<GeometryCache>()->renderQuad(topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
+        batch->setModelTransform(transform);
+        batch->setUniformTexture(0, _texture->getGPUTexture());
+        
+        DependencyManager::get<GeometryCache>()->renderQuad(*batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
                                                             glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha));
+    } else {
+        glEnable(GL_ALPHA_TEST);
+        glAlphaFunc(GL_GREATER, 0.5f);
 
-    } glPopMatrix();
+        glEnable(GL_TEXTURE_2D);
+        glDisable(GL_LIGHTING);
 
-    glDisable(GL_TEXTURE_2D);
-    glEnable(GL_LIGHTING);
-    glDisable(GL_ALPHA_TEST);
+        glBindTexture(GL_TEXTURE_2D, _texture->getID());
 
-    glBindTexture(GL_TEXTURE_2D, 0);
+        glPushMatrix(); {
+            glTranslatef(_position.x, _position.y, _position.z);
+            glm::vec3 axis = glm::axis(rotation);
+            glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
+            glScalef(_scale, _scale, _scale);
+
+            DependencyManager::get<GeometryCache>()->renderQuad(topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
+                                                                glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha));
+
+        } glPopMatrix();
+
+        glDisable(GL_TEXTURE_2D);
+        glEnable(GL_LIGHTING);
+        glDisable(GL_ALPHA_TEST);
+
+        glBindTexture(GL_TEXTURE_2D, 0);
+    }
 }
 
 void BillboardOverlay::setProperties(const QScriptValue &properties) {

--- a/interface/src/ui/overlays/BillboardOverlay.cpp
+++ b/interface/src/ui/overlays/BillboardOverlay.cpp
@@ -99,6 +99,8 @@ void BillboardOverlay::render(RenderArgs* args) {
         
         DependencyManager::get<GeometryCache>()->renderQuad(*batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
                                                             glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha));
+    
+        batch->setUniformTexture(0, args->_whiteTexture); // restore default white color after me
     } else {
         glEnable(GL_ALPHA_TEST);
         glAlphaFunc(GL_GREATER, 0.5f);

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -35,13 +35,6 @@ void Cube3DOverlay::render(RenderArgs* args) {
         return; // do nothing if we're not visible
     }
 
-
-    float glowLevel = getGlowLevel();
-    Glower* glower = NULL;
-    if (glowLevel > 0.0f) {
-        glower = new Glower(glowLevel);
-    }
-
     float alpha = getAlpha();
     xColor color = getColor();
     const float MAX_COLOR = 255.0f;
@@ -49,91 +42,162 @@ void Cube3DOverlay::render(RenderArgs* args) {
 
     //glDisable(GL_LIGHTING);
 
-    // TODO: handle registration point??    
+    // TODO: handle registration point??
     glm::vec3 position = getPosition();
     glm::vec3 center = getCenter();
     glm::vec3 dimensions = getDimensions();
     glm::quat rotation = getRotation();
-    
-    glPushMatrix();
-        glTranslatef(position.x, position.y, position.z);
-        glm::vec3 axis = glm::axis(rotation);
-        glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
-        glPushMatrix();
-            glm::vec3 positionToCenter = center - position;
-            glTranslatef(positionToCenter.x, positionToCenter.y, positionToCenter.z);
-            if (_isSolid) {
-                if (_borderSize > 0) {
-                    // Draw a cube at a larger size behind the main cube, creating
-                    // a border effect.
-                    // Disable writing to the depth mask so that the "border" cube will not
-                    // occlude the main cube.  This means the border could be covered by
-                    // overlays that are further back and drawn later, but this is good
-                    // enough for the use-case.
-                    glDepthMask(GL_FALSE);
-                    glPushMatrix();
-                        glScalef(dimensions.x * _borderSize, dimensions.y * _borderSize, dimensions.z * _borderSize);
 
-                        if (_drawOnHUD) {
-                            DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, glm::vec4(1.0f, 1.0f, 1.0f, alpha));
-                        } else {
-                            DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, glm::vec4(1.0f, 1.0f, 1.0f, alpha));
-                        }
+    auto batch = args->_batch;
 
-                    glPopMatrix();
-                    glDepthMask(GL_TRUE);
-                }
+    if (batch) {
+        Transform transform;
+        transform.setTranslation(position);
+        transform.setRotation(rotation);
+        if (_isSolid) {
+            // if (_borderSize > 0) {
+            //     // Draw a cube at a larger size behind the main cube, creating
+            //     // a border effect.
+            //     // Disable writing to the depth mask so that the "border" cube will not
+            //     // occlude the main cube.  This means the border could be covered by
+            //     // overlays that are further back and drawn later, but this is good
+            //     // enough for the use-case.
+            //     transform.setScale(dimensions * _borderSize);
+            //     batch->setModelTransform(transform);
+            //     DependencyManager::get<GeometryCache>()->renderSolidCube(*batch, 1.0f, glm::vec4(1.0f, 1.0f, 1.0f, alpha));
+            // }
 
-                glPushMatrix();
-                    glScalef(dimensions.x, dimensions.y, dimensions.z);
-                    if (_drawOnHUD) {
-                        DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, cubeColor);
-                    } else {
-                        DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, cubeColor);
-                    }
-                glPopMatrix();
+            transform.setScale(dimensions);
+            batch->setModelTransform(transform);
+
+            DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(*batch, 1.0f, cubeColor);
+        } else {
+
+            if (getIsDashedLine()) {
+                transform.setScale(1.0f);
+                batch->setModelTransform(transform);
+
+                glm::vec3 halfDimensions = dimensions / 2.0f;
+                glm::vec3 bottomLeftNear(-halfDimensions.x, -halfDimensions.y, -halfDimensions.z);
+                glm::vec3 bottomRightNear(halfDimensions.x, -halfDimensions.y, -halfDimensions.z);
+                glm::vec3 topLeftNear(-halfDimensions.x, halfDimensions.y, -halfDimensions.z);
+                glm::vec3 topRightNear(halfDimensions.x, halfDimensions.y, -halfDimensions.z);
+
+                glm::vec3 bottomLeftFar(-halfDimensions.x, -halfDimensions.y, halfDimensions.z);
+                glm::vec3 bottomRightFar(halfDimensions.x, -halfDimensions.y, halfDimensions.z);
+                glm::vec3 topLeftFar(-halfDimensions.x, halfDimensions.y, halfDimensions.z);
+                glm::vec3 topRightFar(halfDimensions.x, halfDimensions.y, halfDimensions.z);
+
+                auto geometryCache = DependencyManager::get<GeometryCache>();
+
+                geometryCache->renderDashedLine(*batch, bottomLeftNear, bottomRightNear, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomRightNear, bottomRightFar, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomRightFar, bottomLeftFar, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomLeftFar, bottomLeftNear, cubeColor);
+
+                geometryCache->renderDashedLine(*batch, topLeftNear, topRightNear, cubeColor);
+                geometryCache->renderDashedLine(*batch, topRightNear, topRightFar, cubeColor);
+                geometryCache->renderDashedLine(*batch, topRightFar, topLeftFar, cubeColor);
+                geometryCache->renderDashedLine(*batch, topLeftFar, topLeftNear, cubeColor);
+
+                geometryCache->renderDashedLine(*batch, bottomLeftNear, topLeftNear, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomRightNear, topRightNear, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomLeftFar, topLeftFar, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomRightFar, topRightFar, cubeColor);
+
             } else {
-                glLineWidth(_lineWidth);
-
-                if (getIsDashedLine()) {
-                    glm::vec3 halfDimensions = dimensions / 2.0f;
-                    glm::vec3 bottomLeftNear(-halfDimensions.x, -halfDimensions.y, -halfDimensions.z);
-                    glm::vec3 bottomRightNear(halfDimensions.x, -halfDimensions.y, -halfDimensions.z);
-                    glm::vec3 topLeftNear(-halfDimensions.x, halfDimensions.y, -halfDimensions.z);
-                    glm::vec3 topRightNear(halfDimensions.x, halfDimensions.y, -halfDimensions.z);
-
-                    glm::vec3 bottomLeftFar(-halfDimensions.x, -halfDimensions.y, halfDimensions.z);
-                    glm::vec3 bottomRightFar(halfDimensions.x, -halfDimensions.y, halfDimensions.z);
-                    glm::vec3 topLeftFar(-halfDimensions.x, halfDimensions.y, halfDimensions.z);
-                    glm::vec3 topRightFar(halfDimensions.x, halfDimensions.y, halfDimensions.z);
-
-                    auto geometryCache = DependencyManager::get<GeometryCache>();
-                
-                    geometryCache->renderDashedLine(bottomLeftNear, bottomRightNear, cubeColor);
-                    geometryCache->renderDashedLine(bottomRightNear, bottomRightFar, cubeColor);
-                    geometryCache->renderDashedLine(bottomRightFar, bottomLeftFar, cubeColor);
-                    geometryCache->renderDashedLine(bottomLeftFar, bottomLeftNear, cubeColor);
-
-                    geometryCache->renderDashedLine(topLeftNear, topRightNear, cubeColor);
-                    geometryCache->renderDashedLine(topRightNear, topRightFar, cubeColor);
-                    geometryCache->renderDashedLine(topRightFar, topLeftFar, cubeColor);
-                    geometryCache->renderDashedLine(topLeftFar, topLeftNear, cubeColor);
-
-                    geometryCache->renderDashedLine(bottomLeftNear, topLeftNear, cubeColor);
-                    geometryCache->renderDashedLine(bottomRightNear, topRightNear, cubeColor);
-                    geometryCache->renderDashedLine(bottomLeftFar, topLeftFar, cubeColor);
-                    geometryCache->renderDashedLine(bottomRightFar, topRightFar, cubeColor);
-
-                } else {
-                    glScalef(dimensions.x, dimensions.y, dimensions.z);
-                    DependencyManager::get<GeometryCache>()->renderWireCube(1.0f, cubeColor);
-                }
+                transform.setScale(dimensions);
+                batch->setModelTransform(transform);
+                DependencyManager::get<DeferredLightingEffect>()->renderWireCube(*batch, 1.0f, cubeColor);
             }
-        glPopMatrix();
-    glPopMatrix();
+        }
+    } else {
+        float glowLevel = getGlowLevel();
+        Glower* glower = NULL;
+        if (glowLevel > 0.0f) {
+            glower = new Glower(glowLevel);
+        }
 
-    if (glower) {
-        delete glower;
+        glPushMatrix();
+            glTranslatef(position.x, position.y, position.z);
+            glm::vec3 axis = glm::axis(rotation);
+            glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
+            glPushMatrix();
+                glm::vec3 positionToCenter = center - position;
+                glTranslatef(positionToCenter.x, positionToCenter.y, positionToCenter.z);
+                if (_isSolid) {
+                    if (_borderSize > 0) {
+                        // Draw a cube at a larger size behind the main cube, creating
+                        // a border effect.
+                        // Disable writing to the depth mask so that the "border" cube will not
+                        // occlude the main cube.  This means the border could be covered by
+                        // overlays that are further back and drawn later, but this is good
+                        // enough for the use-case.
+                        glDepthMask(GL_FALSE);
+                        glPushMatrix();
+                            glScalef(dimensions.x * _borderSize, dimensions.y * _borderSize, dimensions.z * _borderSize);
+
+                            if (_drawOnHUD) {
+                                DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, glm::vec4(1.0f, 1.0f, 1.0f, alpha));
+                            } else {
+                                DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, glm::vec4(1.0f, 1.0f, 1.0f, alpha));
+                            }
+
+                        glPopMatrix();
+                        glDepthMask(GL_TRUE);
+                    }
+
+                    glPushMatrix();
+                        glScalef(dimensions.x, dimensions.y, dimensions.z);
+                        if (_drawOnHUD) {
+                            DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, cubeColor);
+                        } else {
+                            DependencyManager::get<GeometryCache>()->renderSolidCube(1.0f, cubeColor);
+                        }
+                    glPopMatrix();
+                } else {
+                    glLineWidth(_lineWidth);
+
+                    if (getIsDashedLine()) {
+                        glm::vec3 halfDimensions = dimensions / 2.0f;
+                        glm::vec3 bottomLeftNear(-halfDimensions.x, -halfDimensions.y, -halfDimensions.z);
+                        glm::vec3 bottomRightNear(halfDimensions.x, -halfDimensions.y, -halfDimensions.z);
+                        glm::vec3 topLeftNear(-halfDimensions.x, halfDimensions.y, -halfDimensions.z);
+                        glm::vec3 topRightNear(halfDimensions.x, halfDimensions.y, -halfDimensions.z);
+
+                        glm::vec3 bottomLeftFar(-halfDimensions.x, -halfDimensions.y, halfDimensions.z);
+                        glm::vec3 bottomRightFar(halfDimensions.x, -halfDimensions.y, halfDimensions.z);
+                        glm::vec3 topLeftFar(-halfDimensions.x, halfDimensions.y, halfDimensions.z);
+                        glm::vec3 topRightFar(halfDimensions.x, halfDimensions.y, halfDimensions.z);
+
+                        auto geometryCache = DependencyManager::get<GeometryCache>();
+
+                        geometryCache->renderDashedLine(bottomLeftNear, bottomRightNear, cubeColor);
+                        geometryCache->renderDashedLine(bottomRightNear, bottomRightFar, cubeColor);
+                        geometryCache->renderDashedLine(bottomRightFar, bottomLeftFar, cubeColor);
+                        geometryCache->renderDashedLine(bottomLeftFar, bottomLeftNear, cubeColor);
+
+                        geometryCache->renderDashedLine(topLeftNear, topRightNear, cubeColor);
+                        geometryCache->renderDashedLine(topRightNear, topRightFar, cubeColor);
+                        geometryCache->renderDashedLine(topRightFar, topLeftFar, cubeColor);
+                        geometryCache->renderDashedLine(topLeftFar, topLeftNear, cubeColor);
+
+                        geometryCache->renderDashedLine(bottomLeftNear, topLeftNear, cubeColor);
+                        geometryCache->renderDashedLine(bottomRightNear, topRightNear, cubeColor);
+                        geometryCache->renderDashedLine(bottomLeftFar, topLeftFar, cubeColor);
+                        geometryCache->renderDashedLine(bottomRightFar, topRightFar, cubeColor);
+
+                    } else {
+                        glScalef(dimensions.x, dimensions.y, dimensions.z);
+                        DependencyManager::get<GeometryCache>()->renderWireCube(1.0f, cubeColor);
+                    }
+                }
+            glPopMatrix();
+        glPopMatrix();
+
+        if (glower) {
+            delete glower;
+        }
     }
 }
 

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -69,8 +69,9 @@ void Cube3DOverlay::render(RenderArgs* args) {
 
             transform.setScale(dimensions);
             batch->setModelTransform(transform);
+            DependencyManager::get<GeometryCache>()->renderSolidCube(*batch, 1.0f, cubeColor);
 
-            DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(*batch, 1.0f, cubeColor);
+            //DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(*batch, 1.0f, cubeColor);
         } else {
 
             if (getIsDashedLine()) {

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -70,8 +70,6 @@ void Cube3DOverlay::render(RenderArgs* args) {
             transform.setScale(dimensions);
             batch->setModelTransform(transform);
             DependencyManager::get<GeometryCache>()->renderSolidCube(*batch, 1.0f, cubeColor);
-
-            //DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(*batch, 1.0f, cubeColor);
         } else {
 
             if (getIsDashedLine()) {

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -37,41 +37,57 @@ void Line3DOverlay::render(RenderArgs* args) {
         return; // do nothing if we're not visible
     }
 
-    float glowLevel = getGlowLevel();
-    Glower* glower = NULL;
-    if (glowLevel > 0.0f) {
-        glower = new Glower(glowLevel);
-    }
-
-    glPushMatrix();
-
-    glDisable(GL_LIGHTING);
-    glLineWidth(_lineWidth);
-
     float alpha = getAlpha();
     xColor color = getColor();
     const float MAX_COLOR = 255.0f;
     glm::vec4 colorv4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
 
-    glm::vec3 position = getPosition();
-    glm::quat rotation = getRotation();
+    auto batch = args->_batch;
 
-    glTranslatef(position.x, position.y, position.z);
-    glm::vec3 axis = glm::axis(rotation);
-    glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
+    if (batch) {
+        Transform transform;
+        transform.setTranslation(_position);
+        transform.setRotation(_rotation);
+        batch->setModelTransform(transform);
 
-    if (getIsDashedLine()) {
-        // TODO: add support for color to renderDashedLine()
-        DependencyManager::get<GeometryCache>()->renderDashedLine(_position, _end, colorv4, _geometryCacheID);
+        if (getIsDashedLine()) {
+            // TODO: add support for color to renderDashedLine()
+            DependencyManager::get<GeometryCache>()->renderDashedLine(*batch, _position, _end, colorv4, _geometryCacheID);
+        } else {
+            DependencyManager::get<GeometryCache>()->renderLine(*batch, _start, _end, colorv4, _geometryCacheID);
+        }
     } else {
-        DependencyManager::get<GeometryCache>()->renderLine(_start, _end, colorv4, _geometryCacheID);
-    }
-    glEnable(GL_LIGHTING);
+        float glowLevel = getGlowLevel();
+        Glower* glower = NULL;
+        if (glowLevel > 0.0f) {
+            glower = new Glower(glowLevel);
+        }
 
-    glPopMatrix();
+        glPushMatrix();
 
-    if (glower) {
-        delete glower;
+        glDisable(GL_LIGHTING);
+        glLineWidth(_lineWidth);
+
+        glm::vec3 position = getPosition();
+        glm::quat rotation = getRotation();
+
+        glTranslatef(position.x, position.y, position.z);
+        glm::vec3 axis = glm::axis(rotation);
+        glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
+
+        if (getIsDashedLine()) {
+            // TODO: add support for color to renderDashedLine()
+            DependencyManager::get<GeometryCache>()->renderDashedLine(_position, _end, colorv4, _geometryCacheID);
+        } else {
+            DependencyManager::get<GeometryCache>()->renderLine(_start, _end, colorv4, _geometryCacheID);
+        }
+        glEnable(GL_LIGHTING);
+
+        glPopMatrix();
+
+        if (glower) {
+            delete glower;
+        }
     }
 }
 

--- a/interface/src/ui/overlays/OverlaysPayload.cpp
+++ b/interface/src/ui/overlays/OverlaysPayload.cpp
@@ -66,8 +66,8 @@ namespace render {
     }
     template <> void payloadRender(const Overlay::Pointer& overlay, RenderArgs* args) {
         if (args) {
-            glPushMatrix();
             if (overlay->getAnchor() == Overlay::MY_AVATAR) {
+                glPushMatrix();
                 MyAvatar* avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
                 glm::quat myAvatarRotation = avatar->getOrientation();
                 glm::vec3 myAvatarPosition = avatar->getPosition();
@@ -78,9 +78,11 @@ namespace render {
                 glTranslatef(myAvatarPosition.x, myAvatarPosition.y, myAvatarPosition.z);
                 glRotatef(angle, axis.x, axis.y, axis.z);
                 glScalef(myAvatarScale, myAvatarScale, myAvatarScale);
+                overlay->render(args);
+                glPopMatrix();
+            } else {
+                overlay->render(args);
             }
-            overlay->render(args);
-            glPopMatrix();
         }
     }
 }

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -39,33 +39,45 @@ void Sphere3DOverlay::render(RenderArgs* args) {
     const float MAX_COLOR = 255.0f;
     glm::vec4 sphereColor(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
 
-    glDisable(GL_LIGHTING);
-    
-    glm::vec3 position = getPosition();
-    glm::vec3 center = getCenter();
-    glm::vec3 dimensions = getDimensions();
-    glm::quat rotation = getRotation();
+    auto batch = args->_batch;
 
-    float glowLevel = getGlowLevel();
-    Glower* glower = NULL;
-    if (glowLevel > 0.0f) {
-        glower = new Glower(glowLevel);
-    }
+    if (batch) {
+        Transform transform;
+        transform.setTranslation(_position);
+        transform.setRotation(_rotation);
+        transform.setScale(_dimensions);
 
-    glPushMatrix();
-        glTranslatef(position.x, position.y, position.z);
-        glm::vec3 axis = glm::axis(rotation);
-        glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
+        batch->setModelTransform(transform);
+        DependencyManager::get<GeometryCache>()->renderSphere(*batch, 1.0f, SLICES, SLICES, sphereColor, _isSolid);
+    } else {
+        glDisable(GL_LIGHTING);
+        
+        glm::vec3 position = getPosition();
+        glm::vec3 center = getCenter();
+        glm::vec3 dimensions = getDimensions();
+        glm::quat rotation = getRotation();
+
+        float glowLevel = getGlowLevel();
+        Glower* glower = NULL;
+        if (glowLevel > 0.0f) {
+            glower = new Glower(glowLevel);
+        }
+
         glPushMatrix();
-            glm::vec3 positionToCenter = center - position;
-            glTranslatef(positionToCenter.x, positionToCenter.y, positionToCenter.z);
-            glScalef(dimensions.x, dimensions.y, dimensions.z);
-            DependencyManager::get<GeometryCache>()->renderSphere(1.0f, SLICES, SLICES, sphereColor, _isSolid);
+            glTranslatef(position.x, position.y, position.z);
+            glm::vec3 axis = glm::axis(rotation);
+            glRotatef(glm::degrees(glm::angle(rotation)), axis.x, axis.y, axis.z);
+            glPushMatrix();
+                glm::vec3 positionToCenter = center - position;
+                glTranslatef(positionToCenter.x, positionToCenter.y, positionToCenter.z);
+                glScalef(dimensions.x, dimensions.y, dimensions.z);
+                DependencyManager::get<GeometryCache>()->renderSphere(1.0f, SLICES, SLICES, sphereColor, _isSolid);
+            glPopMatrix();
         glPopMatrix();
-    glPopMatrix();
-    
-    if (glower) {
-        delete glower;
+        
+        if (glower) {
+            delete glower;
+        }
     }
 
 }

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -61,7 +61,11 @@ void makeBindings(GLBackend::GLShader* shader) {
     if (loc >= 0) {
         glBindAttribLocation(glprogram, gpu::Stream::TEXCOORD, "texcoord");
     }
-
+    loc = glGetAttribLocation(glprogram, "attribTexcoord");
+    if (loc >= 0) {
+        glBindAttribLocation(glprogram, gpu::Stream::TEXCOORD, "attribTexcoord");
+    }
+    
     loc = glGetAttribLocation(glprogram, "tangent");
     if (loc >= 0) {
         glBindAttribLocation(glprogram, gpu::Stream::TANGENT, "tangent");

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -15,9 +15,12 @@
 #include "DeferredLightingEffect.h"
 #include "ViewFrustum.h"
 #include "RenderArgs.h"
+#include "TextureCache.h"
 
 #include <PerfStat.h>
 
+#include "overlay3D_vert.h"
+#include "overlay3D_frag.h"
 
 using namespace render;
 
@@ -50,7 +53,7 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
    _jobs.push_back(Job(RenderDeferred()));
    _jobs.push_back(Job(ResolveDeferred()));
    _jobs.push_back(Job(DrawTransparentDeferred()));
-   _jobs.push_back(Job(DrawPostLayered()));
+   _jobs.push_back(Job(DrawOverlay3D()));
    _jobs.push_back(Job(ResetGLState()));
 }
 
@@ -225,10 +228,76 @@ template <> void render::jobRun(const DrawTransparentDeferred& job, const SceneC
 
         renderItems(sceneContext, renderContext, renderedItems, renderContext->_maxDrawnTransparentItems);
 
+        // Before rendering the batch make sure we re in sync with gl state
+        args->_context->syncCache();
         args->_context->render((*args->_batch));
         args->_batch = nullptr;
 
         // reset blend function to standard...
-        glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_CONSTANT_ALPHA, GL_ONE);
+       // glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_CONSTANT_ALPHA, GL_ONE);
     }
+}
+
+const gpu::PipelinePointer& DrawOverlay3D::getOpaquePipeline() const {
+    if (!_opaquePipeline) {
+        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(overlay3D_vert)));
+        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(overlay3D_frag)));
+        
+        auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+
+        auto state = gpu::StatePointer(new gpu::State());
+        state->setDepthTest(true, true, gpu::LESS_EQUAL);
+
+        _opaquePipeline.reset(gpu::Pipeline::create(program, state));
+    }
+    return _opaquePipeline;
+}
+
+template <> void render::jobRun(const DrawOverlay3D& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
+      PerformanceTimer perfTimer("DrawOverlay3D");
+    assert(renderContext->args);
+    assert(renderContext->args->_viewFrustum);
+
+    // render backgrounds
+    auto& scene = sceneContext->_scene;
+    auto& items = scene->getMasterBucket().at(ItemFilter::Builder::opaqueShape().withLayered());
+
+
+    ItemIDsBounds inItems;
+    inItems.reserve(items.size());
+    for (auto id : items) {
+        auto& item = scene->getItem(id);
+        if (item.getKey().isVisible() && (item.getLayer() == 1)) {
+            inItems.emplace_back(id);
+        }
+    }
+ 
+    RenderArgs* args = renderContext->args;
+    gpu::Batch batch;
+    args->_batch = &batch;
+    args->_whiteTexture = DependencyManager::get<TextureCache>()->getWhiteTexture();
+
+
+    glm::mat4 projMat;
+    Transform viewMat;
+    args->_viewFrustum->evalProjectionMatrix(projMat);
+    args->_viewFrustum->evalViewTransform(viewMat);
+    if (args->_renderMode == RenderArgs::MIRROR_RENDER_MODE) {
+        viewMat.postScale(glm::vec3(-1.0f, 1.0f, 1.0f));
+    }
+    batch.setProjectionTransform(projMat);
+    batch.setViewTransform(viewMat);
+    batch.setPipeline(job.getOpaquePipeline());
+    batch.setUniformTexture(0, args->_whiteTexture);
+
+    if (!inItems.empty()) {
+        batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTH, glm::vec4(), 1.f, 0);
+        renderItems(sceneContext, renderContext, inItems);
+    }
+
+    // Before rendering the batch make sure we re in sync with gl state
+    args->_context->syncCache();
+    args->_context->render((*args->_batch));
+    args->_batch = nullptr;
+    args->_whiteTexture.reset();
 }

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -14,6 +14,8 @@
 
 #include "render/DrawTask.h"
 
+#include "gpu/Pipeline.h"
+
 class PrepareDeferred {
 public:
 };
@@ -48,6 +50,15 @@ public:
 };
 namespace render {
 template <> void jobRun(const DrawTransparentDeferred& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext);
+}
+
+class DrawOverlay3D {
+    mutable gpu::PipelinePointer _opaquePipeline; //lazy evaluation hence mutable
+public:
+    const gpu::PipelinePointer& getOpaquePipeline() const;
+};
+namespace render {
+template <> void jobRun(const DrawOverlay3D& job, const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext);
 }
 
 class RenderDeferredTask : public render::Task {

--- a/libraries/render-utils/src/overlay3D.slf
+++ b/libraries/render-utils/src/overlay3D.slf
@@ -25,6 +25,5 @@ void main(void) {
     if (diffuse.a < 0.5) {
         discard;
     }
-    
-    gl_FragColor = vec4(varColor.rgb * (1 - diffuse.a) + diffuse.a * diffuse.rgb, 1.0);
+    gl_FragColor = vec4(varColor * diffuse);
 }

--- a/libraries/render-utils/src/overlay3D.slf
+++ b/libraries/render-utils/src/overlay3D.slf
@@ -1,0 +1,28 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//  model.frag
+//  fragment shader
+//
+//  Created by Sam Gateau on 6/16/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+uniform sampler2D diffuseMap;
+
+varying vec2 varTexcoord;
+
+varying vec3 varEyeNormal;
+
+varying vec4 varColor;
+
+
+void main(void) {
+    vec4 diffuse = texture2D(diffuseMap, varTexcoord.st);
+
+    
+    gl_FragColor = vec4(varColor * diffuse);
+}

--- a/libraries/render-utils/src/overlay3D.slf
+++ b/libraries/render-utils/src/overlay3D.slf
@@ -22,7 +22,9 @@ varying vec4 varColor;
 
 void main(void) {
     vec4 diffuse = texture2D(diffuseMap, varTexcoord.st);
-
+    if (diffuse.a < 0.5) {
+        discard;
+    }
     
-    gl_FragColor = vec4(varColor * diffuse);
+    gl_FragColor = vec4(varColor.rgb * (1 - diffuse.a) + diffuse.a * diffuse.rgb, 1.0);
 }

--- a/libraries/render-utils/src/overlay3D.slv
+++ b/libraries/render-utils/src/overlay3D.slv
@@ -1,0 +1,40 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//  overlay3D.slv
+//
+//  Created by Sam Gateau on 6/16/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include gpu/Transform.slh@>
+
+<$declareStandardTransform()$>
+
+attribute vec2 attribTexcoord;
+
+varying vec2 varTexcoord;
+
+// interpolated eye position
+varying vec4 varEyePosition;
+
+// the interpolated normal
+varying vec3 varEyeNormal;
+
+varying vec4 varColor;
+
+void main(void) {
+    varTexcoord = attribTexcoord;
+
+    // pass along the color
+    varColor = gl_Color;
+
+    // standard transform
+    TransformCamera cam = getTransformCamera();
+    TransformObject obj = getTransformObject();
+    <$transformModelToEyeAndClipPos(cam, obj, gl_Vertex, varEyePosition, gl_Position)$>
+    <$transformModelToEyeDir(cam, obj, gl_Normal, varEyeNormal.xyz)$>
+}

--- a/libraries/render-utils/src/overlay3D.slv
+++ b/libraries/render-utils/src/overlay3D.slv
@@ -14,7 +14,7 @@
 
 <$declareStandardTransform()$>
 
-attribute vec2 attribTexcoord;
+//attribute vec2 texcoord;
 
 varying vec2 varTexcoord;
 
@@ -27,7 +27,7 @@ varying vec3 varEyeNormal;
 varying vec4 varColor;
 
 void main(void) {
-    varTexcoord = attribTexcoord;
+    varTexcoord = gl_MultiTexCoord0.xy;
 
     // pass along the color
     varColor = gl_Color;

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -13,6 +13,8 @@
 #define hifi_RenderArgs_h
 
 #include <functional>
+#include <memory>
+
 
 class AABox;
 class OctreeRenderer;
@@ -20,6 +22,7 @@ class ViewFrustum;
 namespace gpu {
 class Batch;
 class Context;
+class Texture;
 }
 
 class RenderDetails {
@@ -109,6 +112,8 @@ public:
     gpu::Batch* _batch = nullptr;
     ShoudRenderFunctor _shouldRender;
     
+    std::shared_ptr<gpu::Texture> _whiteTexture;
+
     RenderDetails _details;
 
     float _alphaThreshold = 0.5f;


### PR DESCRIPTION
- Taking over Huffman's work

- Adding a gpu::pipeline to render the overlay3D elements
 can support one texture in unit 0

- added the _whiteTexture in the renderARgs as a way to restore default texture when using a different one

- tested on mac and windows and it fixes the drawing of the grabbers in edit.js