### PR TITLE
Removing a 'using namespace' from a header and tweaking error checking

### DIFF
--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -12,6 +12,8 @@
 #include "GLBackendShared.h"
 #include <glm/gtc/type_ptr.hpp>
 
+using namespace gpu;
+
 GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] = 
 {
     (&::gpu::GLBackend::do_draw),
@@ -141,6 +143,14 @@ bool GLBackend::checkGLError(const char* name) {
     }
 }
 
+bool GLBackend::checkGLErrorDebug(const char* name) {
+#ifdef DEBUG
+    checkGLError(name);
+#else
+    Q_UNUSED(name);
+    return false;
+#endif
+}
 
 void GLBackend::syncCache() {
     syncTransformStateCache();

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -47,6 +47,9 @@ public:
 
     static bool checkGLError(const char* name = nullptr);
 
+    // Only checks in debug builds
+    static bool checkGLErrorDebug(const char* name = nullptr);
+
     static bool makeProgram(Shader& shader, const Shader::BindingSet& bindings = Shader::BindingSet());
     
 

--- a/libraries/gpu/src/gpu/GLBackendOutput.cpp
+++ b/libraries/gpu/src/gpu/GLBackendOutput.cpp
@@ -11,6 +11,7 @@
 #include "GPULogging.h"
 #include "GLBackendShared.h"
 
+using namespace gpu;
 
 GLBackend::GLFramebuffer::GLFramebuffer() {}
 

--- a/libraries/gpu/src/gpu/GLBackendShared.h
+++ b/libraries/gpu/src/gpu/GLBackendShared.h
@@ -17,9 +17,7 @@
 
 #include "Batch.h"
 
-using namespace gpu;
-
-static const GLenum _primitiveToGLmode[NUM_PRIMITIVES] = {
+static const GLenum _primitiveToGLmode[gpu::NUM_PRIMITIVES] = {
     GL_POINTS,
     GL_LINES,
     GL_LINE_STRIP,
@@ -30,7 +28,7 @@ static const GLenum _primitiveToGLmode[NUM_PRIMITIVES] = {
     GL_QUAD_STRIP,
 };
 
-static const GLenum _elementTypeToGLType[NUM_TYPES]= {
+static const GLenum _elementTypeToGLType[gpu::NUM_TYPES] = {
     GL_FLOAT,
     GL_INT,
     GL_UNSIGNED_INT,
@@ -49,10 +47,8 @@ static const GLenum _elementTypeToGLType[NUM_TYPES]= {
     GL_UNSIGNED_BYTE
 };
 
-#if _DEBUG
-#define CHECK_GL_ERROR() ::gpu::GLBackend::checkGLError(__FUNCTION__)
-#else
-#define CHECK_GL_ERROR() false
-#endif
+// Stupid preprocessor trick to turn the line macro into a string
+#define CHECK_GL_ERROR_HELPER(x) #x
+#define CHECK_GL_ERROR() gpu::GLBackend::checkGLErrorDebug(__FUNCTION__ ":" CHECK_GL_ERROR_HELPER(__LINE__))
 
 #endif

--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -11,6 +11,7 @@
 #include "GPULogging.h"
 #include "GLBackendShared.h"
 
+using namespace gpu;
 
 GLBackend::GLTexture::GLTexture() :
     _storageStamp(0),


### PR DESCRIPTION
This removes a `using namespace gpu;` declaration from a header file (which can cause compilation errors because of ambiguous symbols if you change the order of headers).

It also tweaks the CHECK_GL_ERROR macro in two ways.  First it adds the line as well as the function to the call so that it's more useful in long functions calling raw GL, and second it pushes the `#ifdef DEBUG` check for whether to turn it on into a cpp file, so it's easier to turn on error checking in release mode without having to do a rebuild of everything that includes that header.  