### PR TITLE
Smoother motion for physical objects as viewed by remote observer

### DIFF
--- a/examples/stick.js
+++ b/examples/stick.js
@@ -22,10 +22,12 @@ Script.setTimeout(function() {
         type: "Model",
         modelURL: "https://hifi-public.s3.amazonaws.com/eric/models/stick.fbx",
         compoundShapeURL: "https://hifi-public.s3.amazonaws.com/eric/models/stick.obj",
-        dimensions: {x: .11, y: .11, z: .59},
+        dimensions: {x: .11, y: .11, z: 1.0},
         position: MyAvatar.getRightPalmPosition(), // initial position doesn't matter, as long as it's close
         rotation: MyAvatar.orientation,
         damping: .1,
+        collisionSoundURL: "http://public.highfidelity.io/sounds/Collisions-hitsandslaps/67LCollision07.wav",
+        restitution: 0.01,
         collisionsWillMove: true
     });
     actionID = Entities.addAction("hold", stickID, {relativePosition: {x: 0.0, y: 0.0, z: -0.9},

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -245,7 +245,7 @@ bool EntityMotionState::remoteSimulationOutOfSync(uint32_t simulationStep) {
     
     float dx2 = glm::distance2(position, _serverPosition);
 
-    const float MAX_POSITION_ERROR_SQUARED = 0.001f; // 0.001 m^2 ~~> 0.03 m
+    const float MAX_POSITION_ERROR_SQUARED = 0.000004f; //  Sqrt() - corresponds to 2 millimeters
     if (dx2 > MAX_POSITION_ERROR_SQUARED) {
 
         #ifdef WANT_DEBUG
@@ -270,7 +270,7 @@ bool EntityMotionState::remoteSimulationOutOfSync(uint32_t simulationStep) {
             _serverRotation = glm::normalize(computeBulletRotationStep(_serverAngularVelocity, PHYSICS_ENGINE_FIXED_SUBSTEP) * _serverRotation);
         }
     }
-    const float MIN_ROTATION_DOT = 0.99f; // 0.99 dot threshold coresponds to about 16 degrees of slop
+    const float MIN_ROTATION_DOT = 0.99999f; // This corresponds to about 0.5 degrees of rotation
     glm::quat actualRotation = bulletToGLM(worldTrans.getRotation());
 
     #ifdef WANT_DEBUG


### PR DESCRIPTION
Reduced tolerance that triggers transmission to entity server by simulation owner.  

This may result in two problems, but we'll address those as they come up:  

  1.  Too much bandwidth for some types of physical collisions (piles of things). 
  2.  Piles of things settle down too slowly.  

