### PR TITLE
hmdControls.js for movement when wearing an HMD

### DIFF
--- a/examples/defaultScripts.js
+++ b/examples/defaultScripts.js
@@ -19,4 +19,5 @@ Script.load("grab.js");
 Script.load("pointer.js");
 Script.load("directory.js");
 Script.load("mouseLook.js");
+Script.load("hmdControls.js");
 Script.load("dialTone.js");

--- a/examples/hmdControls.js
+++ b/examples/hmdControls.js
@@ -197,10 +197,6 @@ var hmdControls = (function () {
         if (active) {
             Controller.captureActionEvents();
 
-            print(yawChange);
-            print(pitchChange);
-            print(JSON.stringify(velocity));
-
             MyAvatar.bodyYaw = MyAvatar.bodyYaw + yawChange;
             MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch + pitchChange));
             yawChange = 0;

--- a/examples/hmdControls.js
+++ b/examples/hmdControls.js
@@ -17,7 +17,6 @@ var BOOM_SPEED = 0.5;
 var THRESHOLD = 0.2;
 
 var CAMERA_UPDATE_TIME = 0.5;
-var pitchTimer = CAMERA_UPDATE_TIME;
 var yawTimer = CAMERA_UPDATE_TIME;
 
 var shifted = false;
@@ -153,9 +152,6 @@ var hmdControls = (function () {
     function update(dt) {
         if (yawTimer >= 0.0) {
             yawTimer = yawTimer - dt;
-        }
-        if (pitchTimer >= 0.0) {
-             pitchTimer = pitchTimer - dt;
         }
         if (shiftTimer >= 0.0) {
             shiftTimer = shiftTimer - dt;

--- a/examples/hmdControls.js
+++ b/examples/hmdControls.js
@@ -1,0 +1,87 @@
+//
+//  hmdControls.js
+//  examples
+//
+//  Created by Sam Gondelman on 6/17/15
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+var MOVE_DISTANCE = 0.5;
+var PITCH_INCREMENT = Math.PI / 8;
+var YAW_INCREMENT = Math.PI / 8;
+var BOOM_SPEED = 0.5;
+var THRESHOLD = 0.2;
+
+var hmdControls = (function () {
+
+	function onActionEvent(action, state) {
+        if (state < THRESHOLD) {
+            return;
+        }
+        switch (action) {
+            case 0: // backward
+                var direction = Quat.getFront(Camera.getOrientation());
+                direction = Vec3.multiply(-1, direction);
+                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
+                break;
+            case 1: // forward
+                var direction = Quat.getFront(Camera.getOrientation());
+                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
+                break;
+            case 2: // left
+                var direction = Quat.getRight(Camera.getOrientation());
+                direction = Vec3.multiply(-1, direction);
+                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
+                break;
+            case 3: // right
+                var direction = Quat.getRight(Camera.getOrientation());
+                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
+                break;
+            case 4: // down
+                var direction = Quat.getUp(Camera.getOrientation());
+                direction = Vec3.multiply(-1, direction);
+                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
+                break;
+            case 5: // up
+                var direction = Quat.getUp(Camera.getOrientation());
+                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
+                break;
+            case 6: // yaw left
+                MyAvatar.bodyYaw = MyAvatar.bodyYaw + YAW_INCREMENT;
+                break;
+            case 7: // yaw right
+                MyAvatar.bodyYaw = MyAvatar.bodyYaw - YAW_INCREMENT;
+                break;
+            case 8: // pitch down
+                MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch - PITCH_INCREMENT));
+                break;
+            case 9: // pitch up
+                MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch + PITCH_INCREMENT));
+                break;
+            default:
+                break;
+        }
+    }
+
+	function setUp() {
+		Controller.captureActionEvents();
+
+        Controller.actionEvent.connect(onActionEvent);
+    }
+
+    function tearDown() {
+    	Controller.releaseActionEvents();
+    }
+
+    setUp();
+    Script.scriptEnding.connect(tearDown);
+}());

--- a/examples/hmdControls.js
+++ b/examples/hmdControls.js
@@ -9,66 +9,120 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var MOVE_DISTANCE = 0.5;
-var PITCH_INCREMENT = Math.PI / 8;
-var YAW_INCREMENT = Math.PI / 8;
+var MOVE_DISTANCE = 0.3;
+var PITCH_INCREMENT = 0.5; // degrees
+var VR_PITCH_INCREMENT = 15.0; // degrees
+var YAW_INCREMENT = 0.5; // degrees
+var VR_YAW_INCREMENT = 15.0; // degrees
 var BOOM_SPEED = 0.5;
 var THRESHOLD = 0.2;
+
+var CAMERA_UPDATE_TIME = 0.5;
+var pitchTimer = CAMERA_UPDATE_TIME;
+var yawTimer = CAMERA_UPDATE_TIME;
+
+var shifted = false;
+var SHIFT_UPDATE_TIME = 0.5;
+var shiftTimer = SHIFT_UPDATE_TIME;
+var SHIFT_MAG = 4.0;
 
 var hmdControls = (function () {
 
 	function onActionEvent(action, state) {
         if (state < THRESHOLD) {
+            if (action == 6 || action == 7) {
+                yawTimer = CAMERA_UPDATE_TIME;
+            } else if (action == 8 || action == 9) {
+                pitchTimer = CAMERA_UPDATE_TIME;
+            }
             return;
         }
         switch (action) {
             case 0: // backward
                 var direction = Quat.getFront(Camera.getOrientation());
                 direction = Vec3.multiply(-1, direction);
-                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                direction = Vec3.multiply(Vec3.normalize(direction), shifted ? SHIFT_MAG * MOVE_DISTANCE : MOVE_DISTANCE);
                 MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
                 break;
             case 1: // forward
                 var direction = Quat.getFront(Camera.getOrientation());
-                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                direction = Vec3.multiply(Vec3.normalize(direction), shifted ? SHIFT_MAG * MOVE_DISTANCE : MOVE_DISTANCE);
                 MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
                 break;
             case 2: // left
                 var direction = Quat.getRight(Camera.getOrientation());
                 direction = Vec3.multiply(-1, direction);
-                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                direction = Vec3.multiply(Vec3.normalize(direction), shifted ? SHIFT_MAG * MOVE_DISTANCE : MOVE_DISTANCE);
                 MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
                 break;
             case 3: // right
                 var direction = Quat.getRight(Camera.getOrientation());
-                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                direction = Vec3.multiply(Vec3.normalize(direction), shifted ? SHIFT_MAG * MOVE_DISTANCE : MOVE_DISTANCE);
                 MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
                 break;
             case 4: // down
                 var direction = Quat.getUp(Camera.getOrientation());
                 direction = Vec3.multiply(-1, direction);
-                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                direction = Vec3.multiply(Vec3.normalize(direction), shifted ? SHIFT_MAG * MOVE_DISTANCE : MOVE_DISTANCE);
                 MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
                 break;
             case 5: // up
                 var direction = Quat.getUp(Camera.getOrientation());
-                direction = Vec3.multiply(Vec3.normalize(direction), MOVE_DISTANCE);
+                direction = Vec3.multiply(Vec3.normalize(direction), shifted ? SHIFT_MAG * MOVE_DISTANCE : MOVE_DISTANCE);
                 MyAvatar.position = Vec3.sum(MyAvatar.position, direction);
                 break;
             case 6: // yaw left
-                MyAvatar.bodyYaw = MyAvatar.bodyYaw + YAW_INCREMENT;
+                if (yawTimer < 0.0 && Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.bodyYaw = MyAvatar.bodyYaw + (shifted ? SHIFT_MAG * VR_YAW_INCREMENT : VR_YAW_INCREMENT);
+                    yawTimer = CAMERA_UPDATE_TIME;
+                } else if (!Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.bodyYaw = MyAvatar.bodyYaw + (shifted ? SHIFT_MAG * YAW_INCREMENT : YAW_INCREMENT);
+                }
                 break;
             case 7: // yaw right
-                MyAvatar.bodyYaw = MyAvatar.bodyYaw - YAW_INCREMENT;
+                if (yawTimer < 0.0 && Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.bodyYaw = MyAvatar.bodyYaw - (shifted ? SHIFT_MAG * VR_YAW_INCREMENT : VR_YAW_INCREMENT);
+                    yawTimer = CAMERA_UPDATE_TIME;
+                } else if (!Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.bodyYaw = MyAvatar.bodyYaw - (shifted ? SHIFT_MAG * YAW_INCREMENT : YAW_INCREMENT);
+                }
                 break;
             case 8: // pitch down
-                MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch - PITCH_INCREMENT));
+                if (pitchTimer < 0.0 && Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch - (shifted ? SHIFT_MAG * VR_PITCH_INCREMENT : VR_PITCH_INCREMENT)));
+                    pitchTimer = CAMERA_UPDATE_TIME;
+                } else if (!Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch - (shifted ? SHIFT_MAG * PITCH_INCREMENT : PITCH_INCREMENT)));
+                }
                 break;
             case 9: // pitch up
-                MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch + PITCH_INCREMENT));
+                if (pitchTimer < 0.0 && Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch + (shifted ? SHIFT_MAG * VR_PITCH_INCREMENT : VR_PITCH_INCREMENT)));
+                    pitchTimer = CAMERA_UPDATE_TIME;
+                } else if (!Menu.isOptionChecked("Enable VR Mode")) {
+                    MyAvatar.headPitch = Math.max(-180, Math.min(180, MyAvatar.headPitch + (shifted ? SHIFT_MAG * PITCH_INCREMENT : PITCH_INCREMENT)));
+                }
+                break;
+            case 12: // shift
+                if (shiftTimer < 0.0) {
+                    shifted = !shifted;
+                    shiftTimer = SHIFT_UPDATE_TIME;
+                }
                 break;
             default:
                 break;
+        }
+    }
+
+    function update(dt) {
+        if (yawTimer >= 0.0) {
+            yawTimer = yawTimer - dt;
+        }
+        if (pitchTimer >= 0.0) {
+             pitchTimer = pitchTimer - dt;
+        }
+        if (shiftTimer >= 0.0) {
+            shiftTimer = shiftTimer - dt;
         }
     }
 
@@ -76,6 +130,8 @@ var hmdControls = (function () {
 		Controller.captureActionEvents();
 
         Controller.actionEvent.connect(onActionEvent);
+
+        Script.update.connect(update);
     }
 
     function tearDown() {

--- a/examples/hmdDefaults.js
+++ b/examples/hmdDefaults.js
@@ -13,4 +13,5 @@ Script.load("progress.js");
 Script.load("lobby.js");
 Script.load("notifications.js");
 Script.load("controllers/oculus/goTo.js");
+Script.load("hmdControls.js");
 //Script.load("scripts.js");  // Not created yet

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2505,16 +2505,18 @@ void Application::update(float deltaTime) {
 
     // Transfer the user inputs to the driveKeys
     _myAvatar->clearDriveKeys();
-    _myAvatar->setDriveKeys(FWD, _userInputMapper.getActionState(UserInputMapper::LONGITUDINAL_FORWARD));
-    _myAvatar->setDriveKeys(BACK, _userInputMapper.getActionState(UserInputMapper::LONGITUDINAL_BACKWARD));
-    _myAvatar->setDriveKeys(UP, _userInputMapper.getActionState(UserInputMapper::VERTICAL_UP));
-    _myAvatar->setDriveKeys(DOWN, _userInputMapper.getActionState(UserInputMapper::VERTICAL_DOWN));
-    _myAvatar->setDriveKeys(LEFT, _userInputMapper.getActionState(UserInputMapper::LATERAL_LEFT));
-    _myAvatar->setDriveKeys(RIGHT, _userInputMapper.getActionState(UserInputMapper::LATERAL_RIGHT));
-    _myAvatar->setDriveKeys(ROT_UP, _userInputMapper.getActionState(UserInputMapper::PITCH_UP));
-    _myAvatar->setDriveKeys(ROT_DOWN, _userInputMapper.getActionState(UserInputMapper::PITCH_DOWN));
-    _myAvatar->setDriveKeys(ROT_LEFT, _userInputMapper.getActionState(UserInputMapper::YAW_LEFT));
-    _myAvatar->setDriveKeys(ROT_RIGHT, _userInputMapper.getActionState(UserInputMapper::YAW_RIGHT));
+    if (!_controllerScriptingInterface.areActionsCaptured()) {
+        _myAvatar->setDriveKeys(FWD, _userInputMapper.getActionState(UserInputMapper::LONGITUDINAL_FORWARD));
+        _myAvatar->setDriveKeys(BACK, _userInputMapper.getActionState(UserInputMapper::LONGITUDINAL_BACKWARD));
+        _myAvatar->setDriveKeys(UP, _userInputMapper.getActionState(UserInputMapper::VERTICAL_UP));
+        _myAvatar->setDriveKeys(DOWN, _userInputMapper.getActionState(UserInputMapper::VERTICAL_DOWN));
+        _myAvatar->setDriveKeys(LEFT, _userInputMapper.getActionState(UserInputMapper::LATERAL_LEFT));
+        _myAvatar->setDriveKeys(RIGHT, _userInputMapper.getActionState(UserInputMapper::LATERAL_RIGHT));
+        _myAvatar->setDriveKeys(ROT_UP, _userInputMapper.getActionState(UserInputMapper::PITCH_UP));
+        _myAvatar->setDriveKeys(ROT_DOWN, _userInputMapper.getActionState(UserInputMapper::PITCH_DOWN));
+        _myAvatar->setDriveKeys(ROT_LEFT, _userInputMapper.getActionState(UserInputMapper::YAW_LEFT));
+        _myAvatar->setDriveKeys(ROT_RIGHT, _userInputMapper.getActionState(UserInputMapper::YAW_RIGHT));
+    }
     _myAvatar->setDriveKeys(BOOM_IN, _userInputMapper.getActionState(UserInputMapper::BOOM_IN));
     _myAvatar->setDriveKeys(BOOM_OUT, _userInputMapper.getActionState(UserInputMapper::BOOM_OUT));
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -76,7 +76,6 @@ const float MyAvatar::ZOOM_DEFAULT = 1.5f;
 
 MyAvatar::MyAvatar() :
 	Avatar(),
-    _turningKeyPressTime(0.0f),
     _gravity(0.0f, 0.0f, 0.0f),
     _wasPushing(false),
     _isPushing(false),
@@ -1205,28 +1204,9 @@ bool MyAvatar::shouldRenderHead(const RenderArgs* renderArgs, const glm::vec3& c
 }
 
 void MyAvatar::updateOrientation(float deltaTime) {
-    //  Gather rotation information from keyboard
-    const float TIME_BETWEEN_HMD_TURNS = 0.5f;
-    const float HMD_TURN_DEGREES = 22.5f;
-    if (!qApp->isHMDMode()) {
-        //  Smoothly rotate body with arrow keys if not in HMD
-        _bodyYawDelta -= _driveKeys[ROT_RIGHT] * YAW_SPEED * deltaTime;
-        _bodyYawDelta += _driveKeys[ROT_LEFT] * YAW_SPEED * deltaTime;
-    } else {
-        //  Jump turns if in HMD
-        if (_driveKeys[ROT_RIGHT] || _driveKeys[ROT_LEFT]) {
-            if (_turningKeyPressTime == 0.0f) {
-                setOrientation(getOrientation() *
-                               glm::quat(glm::radians(glm::vec3(0.f, _driveKeys[ROT_LEFT] ? HMD_TURN_DEGREES : -HMD_TURN_DEGREES, 0.0f))));
-            }
-            _turningKeyPressTime += deltaTime;
-            if (_turningKeyPressTime > TIME_BETWEEN_HMD_TURNS) {
-                _turningKeyPressTime = 0.0f;
-            }
-        } else {
-            _turningKeyPressTime = 0.0f;
-        }
-    }
+    //  Smoothly rotate body with arrow keys
+    _bodyYawDelta -= _driveKeys[ROT_RIGHT] * YAW_SPEED * deltaTime;
+    _bodyYawDelta += _driveKeys[ROT_LEFT] * YAW_SPEED * deltaTime;
     getHead()->setBasePitch(getHead()->getBasePitch() + (_driveKeys[ROT_UP] - _driveKeys[ROT_DOWN]) * PITCH_SPEED * deltaTime);
 
     // update body orientation by movement inputs

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -210,7 +210,6 @@ private:
     virtual void setFaceModelURL(const QUrl& faceModelURL);
     virtual void setSkeletonModelURL(const QUrl& skeletonModelURL);
 
-    float _turningKeyPressTime;
     glm::vec3 _gravity;
 
     float _driveKeys[MAX_DRIVE_KEYS];

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -173,9 +173,7 @@ void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
     
     // Button controls
     mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(SDL_CONTROLLER_BUTTON_Y), DPAD_MOVE_SPEED);
-    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_A), DPAD_MOVE_SPEED);
-    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), JOYSTICK_YAW_SPEED);
-    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), JOYSTICK_YAW_SPEED);
+    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_X), DPAD_MOVE_SPEED);
     
     // Zoom
     mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(RIGHT_SHOULDER), BOOM_SPEED);
@@ -203,15 +201,16 @@ void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
     
     // Button controls
     mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(SDL_CONTROLLER_BUTTON_Y), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
-    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_A), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
-    mapper.addInputChannel(UserInputMapper::YAW_LEFT, makeInput(SDL_CONTROLLER_BUTTON_X), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.0f);
-    mapper.addInputChannel(UserInputMapper::YAW_RIGHT, makeInput(SDL_CONTROLLER_BUTTON_B), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), JOYSTICK_YAW_SPEED/2.0f);
+    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(SDL_CONTROLLER_BUTTON_X), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), DPAD_MOVE_SPEED/2.0f);
     
     // Zoom
     mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(RIGHT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.0f);
     mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(LEFT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.0f);
     
     mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(SDL_CONTROLLER_BUTTON_LEFTSHOULDER));
+    
+    mapper.addInputChannel(UserInputMapper::ACTION1, makeInput(SDL_CONTROLLER_BUTTON_B));
+    mapper.addInputChannel(UserInputMapper::ACTION2, makeInput(SDL_CONTROLLER_BUTTON_A));
 #endif
 }
 

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -210,6 +210,8 @@ void Joystick::assignDefaultInputMapping(UserInputMapper& mapper) {
     // Zoom
     mapper.addInputChannel(UserInputMapper::BOOM_IN, makeInput(RIGHT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.0f);
     mapper.addInputChannel(UserInputMapper::BOOM_OUT, makeInput(LEFT_SHOULDER), makeInput(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER), BOOM_SPEED/2.0f);
+    
+    mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(SDL_CONTROLLER_BUTTON_LEFTSHOULDER));
 #endif
 }
 

--- a/interface/src/devices/Joystick.cpp
+++ b/interface/src/devices/Joystick.cpp
@@ -17,7 +17,7 @@
 
 #include "Joystick.h"
 
-const float CONTROLLER_THRESHOLD = 0.25f;
+const float CONTROLLER_THRESHOLD = 0.3f;
 
 #ifdef HAVE_SDL2
 const float MAX_AXIS = 32768.0f;

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -276,6 +276,8 @@ void KeyboardMouseDevice::assignDefaultInputMapping(UserInputMapper& mapper) {
     mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(MOUSE_AXIS_WHEEL_X_POS), BUTTON_YAW_SPEED);
 
 #endif
+    
+    mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(Qt::Key_Space));
 
 }
 

--- a/interface/src/devices/KeyboardMouseDevice.cpp
+++ b/interface/src/devices/KeyboardMouseDevice.cpp
@@ -278,7 +278,8 @@ void KeyboardMouseDevice::assignDefaultInputMapping(UserInputMapper& mapper) {
 #endif
     
     mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(Qt::Key_Space));
-
+    mapper.addInputChannel(UserInputMapper::ACTION1, makeInput(Qt::Key_R));
+    mapper.addInputChannel(UserInputMapper::ACTION2, makeInput(Qt::Key_T));
 }
 
 float KeyboardMouseDevice::getButton(int channel) const {

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -724,6 +724,10 @@ void SixenseManager::assignDefaultInputMapping(UserInputMapper& mapper) {
     
     mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(BUTTON_3, 1), BUTTON_MOVE_SPEED);
     mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(BUTTON_1, 1), BUTTON_MOVE_SPEED);
+    
+    mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(BUTTON_2, 0));
+    mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(BUTTON_2, 1));
+
 }
 
 float SixenseManager::getButton(int channel) const {

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -727,6 +727,9 @@ void SixenseManager::assignDefaultInputMapping(UserInputMapper& mapper) {
     
     mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(BUTTON_2, 0));
     mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(BUTTON_2, 1));
+    
+    mapper.addInputChannel(UserInputMapper::ACTION1, makeInput(BUTTON_4, 0));
+    mapper.addInputChannel(UserInputMapper::ACTION2, makeInput(BUTTON_4, 1));
 
 }
 

--- a/interface/src/scripting/ControllerScriptingInterface.cpp
+++ b/interface/src/scripting/ControllerScriptingInterface.cpp
@@ -28,6 +28,7 @@ ControllerScriptingInterface::ControllerScriptingInterface() :
 {
 
 }
+
 static int actionMetaTypeId = qRegisterMetaType<UserInputMapper::Action>();
 static int inputChannelMetaTypeId = qRegisterMetaType<UserInputMapper::InputChannel>();
 static int inputMetaTypeId = qRegisterMetaType<UserInputMapper::Input>();

--- a/interface/src/scripting/ControllerScriptingInterface.h
+++ b/interface/src/scripting/ControllerScriptingInterface.h
@@ -72,12 +72,15 @@ public:
     void emitTouchUpdateEvent(const TouchEvent& event) { emit touchUpdateEvent(event); }
     
     void emitWheelEvent(QWheelEvent* event) { emit wheelEvent(*event); }
+    
+    void emitActionEvents();
 
     bool isKeyCaptured(QKeyEvent* event) const;
     bool isKeyCaptured(const KeyEvent& event) const;
     bool isMouseCaptured() const { return _mouseCaptured; }
     bool isTouchCaptured() const { return _touchCaptured; }
     bool isWheelCaptured() const { return _wheelCaptured; }
+    bool areActionsCaptured() const { return _actionsCaptured; }
     bool isJoystickCaptured(int joystickIndex) const;
 
     void updateInputControllers();
@@ -122,6 +125,9 @@ public slots:
 
     virtual void captureWheelEvents() { _wheelCaptured = true; }
     virtual void releaseWheelEvents() { _wheelCaptured = false; }
+    
+    virtual void captureActionEvents() { _actionsCaptured = true; }
+    virtual void releaseActionEvents() { _actionsCaptured = false; }
 
     virtual void captureJoystick(int joystickIndex);
     virtual void releaseJoystick(int joystickIndex);
@@ -142,6 +148,7 @@ private:
     bool _mouseCaptured;
     bool _touchCaptured;
     bool _wheelCaptured;
+    bool _actionsCaptured;
     QMultiMap<int,KeyEvent> _capturedKeys;
     QSet<int> _capturedJoysticks;
 

--- a/interface/src/scripting/ControllerScriptingInterface.h
+++ b/interface/src/scripting/ControllerScriptingInterface.h
@@ -72,8 +72,6 @@ public:
     void emitTouchUpdateEvent(const TouchEvent& event) { emit touchUpdateEvent(event); }
     
     void emitWheelEvent(QWheelEvent* event) { emit wheelEvent(*event); }
-    
-    void emitActionEvents();
 
     bool isKeyCaptured(QKeyEvent* event) const;
     bool isKeyCaptured(const KeyEvent& event) const;

--- a/interface/src/ui/UserInputMapper.cpp
+++ b/interface/src/ui/UserInputMapper.cpp
@@ -247,6 +247,7 @@ void UserInputMapper::assignDefaulActionScales() {
     _actionScales[PITCH_UP] = 1.0f; // 1 degree per unit
     _actionScales[BOOM_IN] = 1.0f; // 1m per unit
     _actionScales[BOOM_OUT] = 1.0f; // 1m per unit
+    _actionStates[SHIFT] = 1.0f; // on
 }
 
 // This is only necessary as long as the actions are hardcoded
@@ -264,4 +265,5 @@ void UserInputMapper::createActionNames() {
     _actionNames[PITCH_UP] = "PITCH_UP";
     _actionNames[BOOM_IN] = "BOOM_IN";
     _actionNames[BOOM_OUT] = "BOOM_OUT";
+    _actionNames[SHIFT] = "SHIFT";
 }

--- a/interface/src/ui/UserInputMapper.cpp
+++ b/interface/src/ui/UserInputMapper.cpp
@@ -248,6 +248,8 @@ void UserInputMapper::assignDefaulActionScales() {
     _actionScales[BOOM_IN] = 1.0f; // 1m per unit
     _actionScales[BOOM_OUT] = 1.0f; // 1m per unit
     _actionStates[SHIFT] = 1.0f; // on
+    _actionStates[ACTION1] = 1.0f; // default
+    _actionStates[ACTION2] = 1.0f; // default
 }
 
 // This is only necessary as long as the actions are hardcoded
@@ -266,4 +268,6 @@ void UserInputMapper::createActionNames() {
     _actionNames[BOOM_IN] = "BOOM_IN";
     _actionNames[BOOM_OUT] = "BOOM_OUT";
     _actionNames[SHIFT] = "SHIFT";
+    _actionNames[ACTION1] = "ACTION1";
+    _actionNames[ACTION2] = "ACTION2";
 }

--- a/interface/src/ui/UserInputMapper.cpp
+++ b/interface/src/ui/UserInputMapper.cpp
@@ -8,8 +8,11 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-#include "UserInputMapper.h"
 #include <algorithm>
+
+#include "Application.h"
+
+#include "UserInputMapper.h"
 
 
 // UserInputMapper Class
@@ -207,6 +210,9 @@ void UserInputMapper::update(float deltaTime) {
     // Scale all the channel step with the scale
     for (auto i = 0; i < NUM_ACTIONS; i++) {
         _actionStates[i] *= _actionScales[i];
+        if (_actionStates[i] > 0) {
+            emit Application::getInstance()->getControllerScriptingInterface()->actionEvent(i, _actionStates[i]);
+        }
     }
 }
 

--- a/interface/src/ui/UserInputMapper.h
+++ b/interface/src/ui/UserInputMapper.h
@@ -139,6 +139,8 @@ public:
  
         BOOM_IN,
         BOOM_OUT,
+        
+        SHIFT,
 
         NUM_ACTIONS,
     };

--- a/interface/src/ui/UserInputMapper.h
+++ b/interface/src/ui/UserInputMapper.h
@@ -141,6 +141,9 @@ public:
         BOOM_OUT,
         
         SHIFT,
+        
+        ACTION1,
+        ACTION2,
 
         NUM_ACTIONS,
     };

--- a/libraries/script-engine/src/AbstractControllerScriptingInterface.h
+++ b/libraries/script-engine/src/AbstractControllerScriptingInterface.h
@@ -83,6 +83,9 @@ public slots:
 
     virtual void captureWheelEvents() = 0;
     virtual void releaseWheelEvents() = 0;
+    
+    virtual void captureActionEvents() = 0;
+    virtual void releaseActionEvents() = 0;
 
     virtual void captureJoystick(int joystickIndex) = 0;
     virtual void releaseJoystick(int joystickIndex) = 0;
@@ -111,6 +114,8 @@ signals:
     void touchUpdateEvent(const TouchEvent& event);
     
     void wheelEvent(const WheelEvent& event);
+    
+    void actionEvent(int action, float state);
 
 };
 


### PR DESCRIPTION
Provides movement controls for use with HMDs to prevent getting sick, including constant velocity movement and set-increment camera rotation (15 degrees when in VR mode).  Can also be used while not in VR mode (camera moves much smoother).

Automatically turns on when you enter VR mode and turns off when you exit, but you can also toggle it with CTRL+G.

Additional functionality:

Fast mode doubles your speed and camera rotation.
Controls:
    - Keyboard: press spacebar to toggle
    - Gamepad: press L1 to toggle
    - Hydra: press 2 on either hand to toggle

Warping (press once to start, increase/decrease pitch to change distance, press again to warp or press cancel to disable).
Controls:
    - Keyboard: 'r' to enable and warp, 't' to cancel
    - Gamepad: right button to enable and warp, bottom button to cancel
    - Hydra: L4 to enable and warp, R4 to cancel

Issues:
    - rendering is broken so the warp sphere rendering is messed up
    - ray picking causes crashes so the warp line is turned off for now
    - for some reason (threading?), sometimes action events will build up and fire even after you've stopped pressing buttons