### PR TITLE
Fix the cookie cutter issue in stereo

### DIFF
--- a/examples/utilities/tools/cookies.js
+++ b/examples/utilities/tools/cookies.js
@@ -120,6 +120,23 @@ Slider = function(x,y,width,thumbSize) {
 
     this.onValueChanged = function(value) {};
 
+    this.setMaxValue = function(maxValue) {
+        if (this.maxValue == maxValue) {
+            return;
+        }
+        var currentVal = this.getValue();
+        this.maxValue = maxValue;
+        this.setValue(currentVal);
+    }
+    this.setMinValue = function(minValue) {
+        if (this.minValue == minValue) {
+            return;
+        }
+        var currentVal = this.getValue();
+        this.minValue = minValue;
+        this.setValue(currentVal);
+    }    
+
     this.destroy = function() {
         Overlays.deleteOverlay(this.background);
         Overlays.deleteOverlay(this.thumb);
@@ -609,6 +626,14 @@ Panel = function(x, y) {
         var item = this.items[name];
         if (item != null) {
             return item.getter();
+        }
+        return null;
+    }
+
+    this.getWidget = function(name) {
+        var item = this.items[name];
+        if (item != null) {
+            return item.widget;
         }
         return null;
     }

--- a/examples/utilities/tools/renderEngineDebug.js
+++ b/examples/utilities/tools/renderEngineDebug.js
@@ -69,12 +69,31 @@ panel.newSlider("Max Drawn Overlay3Ds", -1, 100,
 var tickTackPeriod = 500;
 
 function updateCounters() {
-        panel.set("Num Feed Opaques", panel.get("Num Feed Opaques"));
-        panel.set("Num Drawn Opaques", panel.get("Num Drawn Opaques"));
-        panel.set("Num Feed Transparents", panel.get("Num Feed Transparents"));
-        panel.set("Num Drawn Transparents", panel.get("Num Drawn Transparents"));
-        panel.set("Num Feed Overlay3Ds", panel.get("Num Feed Overlay3Ds"));
-        panel.set("Num Drawn Overlay3Ds", panel.get("Num Drawn Overlay3Ds"));        
+    var numFeedOpaques = panel.get("Num Feed Opaques");
+    var numFeedTransparents = panel.get("Num Feed Transparents");
+    var numFeedOverlay3Ds = panel.get("Num Feed Overlay3Ds");
+
+    panel.set("Num Feed Opaques", numFeedOpaques);
+    panel.set("Num Drawn Opaques", panel.get("Num Drawn Opaques"));
+    panel.set("Num Feed Transparents", numFeedTransparents);
+    panel.set("Num Drawn Transparents", panel.get("Num Drawn Transparents"));
+    panel.set("Num Feed Overlay3Ds", numFeedOverlay3Ds);
+    panel.set("Num Drawn Overlay3Ds", panel.get("Num Drawn Overlay3Ds"));        
+
+    var numMax = Math.max(numFeedOpaques * 1.2, 1);
+    panel.getWidget("Num Feed Opaques").setMaxValue(numMax);
+    panel.getWidget("Num Drawn Opaques").setMaxValue(numMax);
+    panel.getWidget("Max Drawn Opaques").setMaxValue(numMax);
+
+    numMax = Math.max(numFeedTransparents * 1.2, 1);
+    panel.getWidget("Num Feed Transparents").setMaxValue(numMax);
+    panel.getWidget("Num Drawn Transparents").setMaxValue(numMax);
+    panel.getWidget("Max Drawn Transparents").setMaxValue(numMax);        
+
+    numMax = Math.max(numFeedOverlay3Ds * 1.2, 1);
+    panel.getWidget("Num Feed Overlay3Ds").setMaxValue(numMax);
+    panel.getWidget("Num Drawn Overlay3Ds").setMaxValue(numMax);
+    panel.getWidget("Max Drawn Overlay3Ds").setMaxValue(numMax);
 }
 Script.setInterval(updateCounters, tickTackPeriod);
 

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -450,6 +450,7 @@ void GLBackend::do_glUniform1i(Batch& batch, uint32 paramOffset) {
         // because these uniform setters are deprecated and we don;t want to create side effect
         return;
     }
+    updatePipeline();
     glUniform1f(
         batch._params[paramOffset + 1]._int,
         batch._params[paramOffset + 0]._int);
@@ -472,6 +473,8 @@ void GLBackend::do_glUniform1f(Batch& batch, uint32 paramOffset) {
         // because these uniform setters are deprecated and we don;t want to create side effect
         return;
     }
+    updatePipeline();
+
     glUniform1f(
         batch._params[paramOffset + 1]._int,
         batch._params[paramOffset + 0]._float);
@@ -494,6 +497,7 @@ void GLBackend::do_glUniform2f(Batch& batch, uint32 paramOffset) {
         // because these uniform setters are deprecated and we don;t want to create side effect
         return;
     }
+    updatePipeline();
     glUniform2f(
         batch._params[paramOffset + 2]._int,
         batch._params[paramOffset + 1]._float,
@@ -518,6 +522,7 @@ void GLBackend::do_glUniform3f(Batch& batch, uint32 paramOffset) {
         // because these uniform setters are deprecated and we don;t want to create side effect
         return;
     }
+    updatePipeline();
     glUniform3f(
         batch._params[paramOffset + 3]._int,
         batch._params[paramOffset + 2]._float,
@@ -542,6 +547,7 @@ void GLBackend::do_glUniform3fv(Batch& batch, uint32 paramOffset) {
         // because these uniform setters are deprecated and we don;t want to create side effect
         return;
     }
+    updatePipeline();
     glUniform3fv(
         batch._params[paramOffset + 2]._int,
         batch._params[paramOffset + 1]._uint,
@@ -567,6 +573,7 @@ void GLBackend::do_glUniform4fv(Batch& batch, uint32 paramOffset) {
         // because these uniform setters are deprecated and we don;t want to create side effect
         return;
     }
+    updatePipeline();
     glUniform4fv(
         batch._params[paramOffset + 2]._int,
         batch._params[paramOffset + 1]._uint,
@@ -592,6 +599,7 @@ void GLBackend::do_glUniformMatrix4fv(Batch& batch, uint32 paramOffset) {
         // because these uniform setters are deprecated and we don;t want to create side effect
         return;
     }
+    updatePipeline();
     glUniformMatrix4fv(
         batch._params[paramOffset + 3]._int,
         batch._params[paramOffset + 2]._uint,

--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -343,10 +343,10 @@ GLBackend::GLTexture* GLBackend::syncGPUObject(const Texture& texture) {
                 if (bytes && texture.isAutogenerateMips()) {
                     glGenerateMipmap(GL_TEXTURE_2D);
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-                } else {
+                }/* else {
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-                }
+                }*/
                 
                 object->_target = GL_TEXTURE_2D;
 

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -119,6 +119,8 @@ void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const Rend
         buffers[bufferCount++] = GL_COLOR_ATTACHMENT1;
         buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
         batch._glDrawBuffers(bufferCount, buffers);
+        const float OPAQUE_ALPHA_THRESHOLD = 0.5f;
+        args->_alphaThreshold = OPAQUE_ALPHA_THRESHOLD;
     }
 
     renderItems(sceneContext, renderContext, inItems, renderContext->_maxDrawnOpaqueItems);

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -207,7 +207,6 @@ void render::renderItems(const SceneContextPointer& sceneContext, const RenderCo
             auto item = scene->getItem(itemDetails.id);
             if (numItems + 1 >= maxDrawnItems) {
                 item.render(args);
-
                 return;
             }
             item.render(args);


### PR DESCRIPTION
IN stereo the right side objects with an opacity map wasn't fragment killed correctly because the alphaTreshold wasn;t assigned correctly

THis is now fixed