### PR TITLE
Render a different model when in first person view.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3307,6 +3307,8 @@ namespace render {
 
 void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool selfAvatarOnly, bool billboard) {
 
+    // FIXME: This preRender call is temporary until we create a separate render::scene for the mirror rendering.
+    // Then we can move this logic into the Avatar::simulate call.
     _myAvatar->preRender(renderArgs);
 
     activeRenderingThread = QThread::currentThread();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3306,6 +3306,9 @@ namespace render {
 
 
 void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool selfAvatarOnly, bool billboard) {
+
+    _myAvatar->preRender(renderArgs);
+
     activeRenderingThread = QThread::currentThread();
     PROFILE_RANGE(__FUNCTION__);
     PerformanceTimer perfTimer("display");

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -445,10 +445,10 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, boo
                 _skeletonModel.renderJointCollisionShapes(0.7f);
             }
 
-            if (renderHead && shouldRenderHead(renderArgs, cameraPosition)) {
+            if (renderHead && shouldRenderHead(renderArgs)) {
                 getHead()->getFaceModel().renderJointCollisionShapes(0.7f);
             }
-            if (renderBounding && shouldRenderHead(renderArgs, cameraPosition)) {
+            if (renderBounding && shouldRenderHead(renderArgs)) {
                 _skeletonModel.renderBoundingCollisionShapes(0.7f);
             }
 
@@ -533,6 +533,7 @@ glm::quat Avatar::computeRotationFromBodyToWorldUp(float proportion) const {
 }
 
 void Avatar::fixupModelsInScene() {
+
     // check to see if when we added our models to the scene they were ready, if they were not ready, then
     // fix them up in the scene
     render::ScenePointer scene = Application::getInstance()->getMain3DScene();
@@ -581,7 +582,7 @@ void Avatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool
     getHead()->render(renderArgs, 1.0f, renderFrustum, postLighting);
 }
 
-bool Avatar::shouldRenderHead(const RenderArgs* renderArgs, const glm::vec3& cameraPosition) const {
+bool Avatar::shouldRenderHead(const RenderArgs* renderArgs) const {
     return true;
 }
 

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -237,7 +237,7 @@ protected:
     Transform calculateDisplayNameTransform(const ViewFrustum& frustum, float fontSize) const;
     void renderDisplayName(gpu::Batch& batch, const ViewFrustum& frustum) const;
     virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool postLighting, float glowLevel = 0.0f);
-    virtual bool shouldRenderHead(const RenderArgs* renderArgs, const glm::vec3& cameraPosition) const;
+    virtual bool shouldRenderHead(const RenderArgs* renderArgs) const;
     virtual void fixupModelsInScene();
 
     void simulateAttachments(float deltaTime);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -993,6 +993,7 @@ QString MyAvatar::getModelDescription() const {
 }
 
 void MyAvatar::setFaceModelURL(const QUrl& faceModelURL) {
+
     Avatar::setFaceModelURL(faceModelURL);
     render::ScenePointer scene = Application::getInstance()->getMain3DScene();
     getHead()->getFaceModel().setVisibleInScene(_prevShouldDrawHead, scene);
@@ -1000,19 +1001,27 @@ void MyAvatar::setFaceModelURL(const QUrl& faceModelURL) {
 }
 
 void MyAvatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
+
     Avatar::setSkeletonModelURL(skeletonModelURL);
     render::ScenePointer scene = Application::getInstance()->getMain3DScene();
-    _skeletonModel.setVisibleInScene(_prevShouldDrawHead, scene);
     _billboardValid = false;
 
     if (_useFullAvatar) {
+        _skeletonModel.setVisibleInScene(_prevShouldDrawHead, scene);
+
         const QUrl DEFAULT_SKELETON_MODEL_URL = QUrl::fromLocalFile(PathUtils::resourcesPath() + "meshes/defaultAvatar_body.fst");
         _firstPersonSkeletonModel.setURL(_skeletonModelURL, DEFAULT_SKELETON_MODEL_URL, true, !isMyAvatar());
         _firstPersonSkeletonModel.setVisibleInScene(!_prevShouldDrawHead, scene);
+    } else {
+        _skeletonModel.setVisibleInScene(true, scene);
+
+        _firstPersonSkeletonModel.setVisibleInScene(false, scene);
+        _firstPersonSkeletonModel.reset();
     }
 }
 
 void MyAvatar::useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelName) {
+
     if (QThread::currentThread() != thread()) {
         QMetaObject::invokeMethod(this, "useFullAvatarURL", Qt::BlockingQueuedConnection,
                                   Q_ARG(const QUrl&, fullAvatarURL),

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1188,9 +1188,11 @@ void MyAvatar::attach(const QString& modelURL, const QString& jointName, const g
 
 void MyAvatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool postLighting, float glowLevel) {
 
-    if (!(_skeletonModel.isRenderable() && _firstPersonSkeletonModel.isRenderable() && getHead()->getFaceModel().isRenderable())) {
+    if (!(_skeletonModel.isRenderable() && getHead()->getFaceModel().isRenderable())) {
         return; // wait until all models are loaded
     }
+
+    fixupModelsInScene();
 
     //  Render head so long as the camera isn't inside it
     if (shouldRenderHead(renderArgs)) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -35,11 +35,12 @@ public:
     void reset();
     void update(float deltaTime);
     void simulate(float deltaTime);
+    void preRender(RenderArgs* renderArgs);
     void updateFromTrackers(float deltaTime);
 
     virtual void render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, bool postLighting = false) override;
     virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool postLighting, float glowLevel = 0.0f) override;
-    virtual bool shouldRenderHead(const RenderArgs* renderArgs, const glm::vec3& cameraPosition) const override;
+    virtual bool shouldRenderHead(const RenderArgs* renderArgs) const override;
     void renderDebugBodyPoints();
 
     // setters
@@ -210,6 +211,9 @@ private:
     virtual void setFaceModelURL(const QUrl& faceModelURL);
     virtual void setSkeletonModelURL(const QUrl& skeletonModelURL);
 
+    void setCurrentSkeletonModel(SkeletonModel* skeletonModel);
+    void initModelWhenReady(Model* model);
+
     glm::vec3 _gravity;
 
     float _driveKeys[MAX_DRIVE_KEYS];
@@ -265,6 +269,10 @@ private:
     QString _headModelName;
     QString _bodyModelName;
     QString _fullAvatarModelName;
+
+    // used for rendering when in first person view or when in an HMD.
+    SkeletonModel* _currentSkeletonModel;
+    SkeletonModel _firstPersonSkeletonModel;
 };
 
 #endif // hifi_MyAvatar_h

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -207,6 +207,8 @@ signals:
 
 private:
 
+    bool cameraInsideHead() const;
+
     // These are made private for MyAvatar so that you will use the "use" methods instead
     virtual void setFaceModelURL(const QUrl& faceModelURL);
     virtual void setSkeletonModelURL(const QUrl& skeletonModelURL);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -211,8 +211,7 @@ private:
     virtual void setFaceModelURL(const QUrl& faceModelURL);
     virtual void setSkeletonModelURL(const QUrl& skeletonModelURL);
 
-    void setCurrentSkeletonModel(SkeletonModel* skeletonModel);
-    void initModelWhenReady(Model* model);
+    void setVisibleInSceneIfReady(Model* model, render::ScenePointer scene, bool visiblity);
 
     glm::vec3 _gravity;
 
@@ -271,8 +270,8 @@ private:
     QString _fullAvatarModelName;
 
     // used for rendering when in first person view or when in an HMD.
-    SkeletonModel* _currentSkeletonModel;
     SkeletonModel _firstPersonSkeletonModel;
+    bool _prevShouldDrawHead;
 };
 
 #endif // hifi_MyAvatar_h

--- a/interface/src/avatar/SkeletonModel.h
+++ b/interface/src/avatar/SkeletonModel.h
@@ -112,6 +112,11 @@ public:
 
     float getHeadClipDistance() const { return _headClipDistance; }
 
+    void setIsFirstPerson(bool value) { _isFirstPerson = value; }
+    bool getIsFirstPerson() const { return _isFirstPerson; }
+
+    virtual void onInvalidate() override;
+
 signals:
 
     void skeletonLoaded();
@@ -132,7 +137,11 @@ protected:
     void maybeUpdateLeanRotation(const JointState& parentState, JointState& state);
     void maybeUpdateNeckRotation(const JointState& parentState, const FBXJoint& joint, JointState& state);
     void maybeUpdateEyeRotation(const JointState& parentState, const FBXJoint& joint, JointState& state);
-    
+
+    void cauterizeHead();
+    void initHeadBones();
+    void invalidateHeadBones();
+
 private:
 
     void renderJointConstraints(int jointIndex);
@@ -164,6 +173,9 @@ private:
     glm::vec3 _clampedFootPosition;
 
     float _headClipDistance;  // Near clip distance to use if no separate head model
+
+    bool _isFirstPerson;
+    std::vector<int> _headBones;
 };
 
 #endif // hifi_SkeletonModel_h

--- a/libraries/octree/src/ViewFrustum.h
+++ b/libraries/octree/src/ViewFrustum.h
@@ -30,8 +30,7 @@
 const float DEFAULT_KEYHOLE_RADIUS = 3.0f;
 const float DEFAULT_FIELD_OF_VIEW_DEGREES = 45.0f;
 const float DEFAULT_ASPECT_RATIO = 16.0f/9.0f;
-//const float DEFAULT_NEAR_CLIP = 0.08f;
-const float DEFAULT_NEAR_CLIP = 0.1f;
+const float DEFAULT_NEAR_CLIP = 0.08f;
 const float DEFAULT_FAR_CLIP = (float)TREE_SCALE;
 
 class ViewFrustum {

--- a/libraries/octree/src/ViewFrustum.h
+++ b/libraries/octree/src/ViewFrustum.h
@@ -31,7 +31,7 @@ const float DEFAULT_KEYHOLE_RADIUS = 3.0f;
 const float DEFAULT_FIELD_OF_VIEW_DEGREES = 45.0f;
 const float DEFAULT_ASPECT_RATIO = 16.0f/9.0f;
 //const float DEFAULT_NEAR_CLIP = 0.08f;
-const float DEFAULT_NEAR_CLIP = 0.25f;
+const float DEFAULT_NEAR_CLIP = 0.1f;
 const float DEFAULT_FAR_CLIP = (float)TREE_SCALE;
 
 class ViewFrustum {

--- a/libraries/render-utils/src/JointState.h
+++ b/libraries/render-utils/src/JointState.h
@@ -106,6 +106,9 @@ public:
     glm::quat computeParentRotation() const;
     glm::quat computeVisibleParentRotation() const;
 
+    void setTransform(const glm::mat4& transform) { _transform = transform; }
+    void setVisibleTransform(const glm::mat4& transform) { _visibleTransform = transform; }
+
 private:
     void setRotationInConstrainedFrameInternal(const glm::quat& targetRotation);
     /// debug helper function

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1370,6 +1370,7 @@ void Model::simulate(float deltaTime, bool fullUpdate) {
         //       because ray picking needs valid boxes to work
         _calculatedMeshBoxesValid = false;
         _calculatedMeshTrianglesValid = false;
+        onInvalidate();
 
         // check for scale to fit
         if (_scaleToFit && !_scaledToFit) {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1102,8 +1102,10 @@ void Model::setURL(const QUrl& url, const QUrl& fallback, bool retainCurrent, bo
     _readyWhenAdded = false; // reset out render items.
     _needsReload = true;
     invalidCalculatedMeshBoxes();
-    
+
     _url = url;
+
+    onInvalidate();
 
     // if so instructed, keep the current geometry until the new one is loaded 
     _nextBaseGeometry = _nextGeometry = DependencyManager::get<GeometryCache>()->getGeometry(url, fallback, delayLoad);
@@ -1377,6 +1379,26 @@ void Model::simulate(float deltaTime, bool fullUpdate) {
             snapToRegistrationPoint();
         }
         simulateInternal(deltaTime);
+    }
+}
+
+void Model::updateClusterMatrices() {
+    const FBXGeometry& geometry = _geometry->getFBXGeometry();
+    glm::mat4 modelToWorld = glm::mat4_cast(_rotation);
+    for (int i = 0; i < _meshStates.size(); i++) {
+        MeshState& state = _meshStates[i];
+        const FBXMesh& mesh = geometry.meshes.at(i);
+        if (_showTrueJointTransforms) {
+            for (int j = 0; j < mesh.clusters.size(); j++) {
+                const FBXCluster& cluster = mesh.clusters.at(j);
+                state.clusterMatrices[j] = modelToWorld * _jointStates[cluster.jointIndex].getTransform() * cluster.inverseBindMatrix;
+            }
+        } else {
+            for (int j = 0; j < mesh.clusters.size(); j++) {
+                const FBXCluster& cluster = mesh.clusters.at(j);
+                state.clusterMatrices[j] = modelToWorld * _jointStates[cluster.jointIndex].getVisibleTransform() * cluster.inverseBindMatrix;
+            }
+        }
     }
 }
 
@@ -2120,6 +2142,34 @@ void Model::pickPrograms(gpu::Batch& batch, RenderMode mode, bool translucent, f
     }
 }
 
+bool Model::initWhenReady(render::ScenePointer scene) {
+    if (isActive() && isRenderable() && !_meshGroupsKnown && isLoadedWithTextures()) {
+        segregateMeshGroups();
+
+        render::PendingChanges pendingChanges;
+
+        foreach (auto renderItem, _transparentRenderItems) {
+            auto item = scene->allocateID();
+            auto renderData = MeshPartPayload::Pointer(renderItem);
+            auto renderPayload = render::PayloadPointer(new MeshPartPayload::Payload(renderData));
+            _renderItems.insert(item, renderPayload);
+            pendingChanges.resetItem(item, renderPayload);
+        }
+
+        foreach (auto renderItem, _opaqueRenderItems) {
+            auto item = scene->allocateID();
+            auto renderData = MeshPartPayload::Pointer(renderItem);
+            auto renderPayload = render::PayloadPointer(new MeshPartPayload::Payload(renderData));
+            _renderItems.insert(item, renderPayload);
+            pendingChanges.resetItem(item, renderPayload);
+        }
+        scene->enqueuePendingChanges(pendingChanges);
+
+        _readyWhenAdded = true;
+        return true;
+    }
+    return false;
+}
 
 ModelBlender::ModelBlender() :
     _pendingBlenders(0) {

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -240,6 +240,8 @@ public:
     AABox getPartBounds(int meshIndex, int partIndex);
     void renderPart(RenderArgs* args, int meshIndex, int partIndex, bool translucent);
 
+    bool initWhenReady(render::ScenePointer scene);
+
 protected:
     QSharedPointer<NetworkGeometry> _geometry;
     
@@ -311,6 +313,12 @@ protected:
         _calculatedMeshPartBoxesValid = false;
         _calculatedMeshTrianglesValid = false;
     }
+
+    // rebuild the clusterMatrices from the current jointStates
+    void updateClusterMatrices();
+
+    // hook for derived classes to be notified when setUrl invalidates the current model.
+    virtual void onInvalidate() {};
 
 private:
     


### PR DESCRIPTION
Currently this model is identical to the third person model, except
that the head bones have been 'cauterized' by applying a zero scale transform.
This allows us to set the near clip back to a reasonable value.

This should eliminate the problem where you can see the eyes or teeth of your avatar's head while wearing an HMD.

https://app.asana.com/0/37796130830309/35255696667092
https://app.asana.com/0/37796130830309/37633564937426