### PR TITLE
Removing flickering mouse cursor in HMD

### DIFF
--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -394,42 +394,13 @@ bool ApplicationCompositor::calculateRayUICollisionPoint(const glm::vec3& positi
 void ApplicationCompositor::renderPointers(gpu::Batch& batch) {
     if (qApp->isHMDMode() && !qApp->getLastMouseMoveWasSimulated() && !qApp->isMouseHidden()) {
         //If we are in oculus, render reticle later
-        if (_lastMouseMove == 0) {
-            _lastMouseMove = usecTimestampNow();
-        }
         QPoint position = QPoint(qApp->getTrueMouseX(), qApp->getTrueMouseY());
-
-        static const int MAX_IDLE_TIME = 3;
-        if (_reticlePosition[MOUSE] != position) {
-            _lastMouseMove = usecTimestampNow();
-        } else if (usecTimestampNow() - _lastMouseMove > MAX_IDLE_TIME * USECS_PER_SECOND) {
-            //float pitch = 0.0f, yaw = 0.0f, roll = 0.0f; // radians
-            //OculusManager::getEulerAngles(yaw, pitch, roll);
-            glm::quat orientation = qApp->getHeadOrientation(); // (glm::vec3(pitch, yaw, roll));
-            glm::vec3 result;
-
-            MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-            if (calculateRayUICollisionPoint(myAvatar->getEyePosition(),
-                myAvatar->getOrientation() * orientation * IDENTITY_FRONT,
-                result)) {
-                glm::vec3 lookAtDirection = glm::inverse(myAvatar->getOrientation()) * (result - myAvatar->getDefaultEyePosition());
-                glm::vec2 spericalPos = directionToSpherical(glm::normalize(lookAtDirection));
-                glm::vec2 screenPos = sphericalToScreen(spericalPos);
-                position = QPoint(screenPos.x, screenPos.y);
-                // FIXME
-                //glCanvas->cursor().setPos(glCanvas->mapToGlobal(position));
-            } else {
-                qDebug() << "No collision point";
-            }
-        }
-
         _reticlePosition[MOUSE] = position;
         _reticleActive[MOUSE] = true;
         _magActive[MOUSE] = _magnifier;
         _reticleActive[LEFT_CONTROLLER] = false;
         _reticleActive[RIGHT_CONTROLLER] = false;
     } else if (qApp->getLastMouseMoveWasSimulated() && Menu::getInstance()->isOptionChecked(MenuOption::SixenseMouseInput)) {
-        _lastMouseMove = 0;
         //only render controller pointer if we aren't already rendering a mouse pointer
         _reticleActive[MOUSE] = false;
         _magActive[MOUSE] = false;

--- a/interface/src/ui/ApplicationCompositor.h
+++ b/interface/src/ui/ApplicationCompositor.h
@@ -97,7 +97,6 @@ private:
     QPoint _reticlePosition[NUMBER_OF_RETICLES];
     bool _magActive[NUMBER_OF_RETICLES];
     float _magSizeMult[NUMBER_OF_RETICLES];
-    quint64 _lastMouseMove{ 0 };
     bool _magnifier{ true };
 
     float _alpha{ 1.0f };


### PR DESCRIPTION
the compositor is attempting to force the position of the mouse cursor in the HMD to the center, if the mouse has not moved for a given amount of time.  However, the next frame always immediately updates it with the real mouse position, causing a single-frame flicker of the mouse position.  

This corrects that by always using the actual system mouse position.  