### PR TITLE
Fix the 2D text overlay backgrounds to stop using a previously bound …

### DIFF
--- a/interface/src/ui/overlays/TextOverlay.cpp
+++ b/interface/src/ui/overlays/TextOverlay.cpp
@@ -80,6 +80,7 @@ void TextOverlay::render(RenderArgs* args) {
 
     glm::vec2 topLeft(left, top);
     glm::vec2 bottomRight(right, bottom);
+    glBindTexture(GL_TEXTURE_2D, 0);
     DependencyManager::get<GeometryCache>()->renderQuad(topLeft, bottomRight, quadColor);
     
     const int leftAdjust = -1; // required to make text render relative to left edge of bounds


### PR DESCRIPTION
The Text overlays are still rendering using some raw OpenGL (the TextRenderer needs to be refactored to the GPU model before we can fix the overlays themselves).

This PR adds a line to ensure that previously bound textures are not still bound when rendering the background for the overlay.  This was causing a rendering error on the mac.  