### PR TITLE
Fixing the initial missing UI on retina displays, again

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1063,9 +1063,7 @@ void Application::resizeGL() {
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
 
     auto canvasSize = _glWidget->size();
-    if (canvasSize != offscreenUi->getWindow()->size()) {
-        offscreenUi->resize(canvasSize);
-    }
+    offscreenUi->resize(canvasSize);
     _glWidget->makeCurrent();
 
 }


### PR DESCRIPTION
resize always needs to hit the QML surface, to correct for the retina bug in Qt.