### PR TITLE
Mirror zoom

### DIFF
--- a/interface/src/ui/AvatarInputs.cpp
+++ b/interface/src/ui/AvatarInputs.cpp
@@ -35,7 +35,8 @@ AvatarInputs* AvatarInputs::getInstance() {
 
 AvatarInputs::AvatarInputs(QQuickItem* parent) :  QQuickItem(parent) {
     INSTANCE = this;
-    _mirrorZoomed = rearViewZoomLevel.get() != 0;
+    int zoomSetting = rearViewZoomLevel.get();
+    _mirrorZoomed = zoomSetting == 0;
 }
 
 #define AI_UPDATE(name, src) \

--- a/interface/src/ui/AvatarInputs.cpp
+++ b/interface/src/ui/AvatarInputs.cpp
@@ -51,7 +51,7 @@ AvatarInputs::AvatarInputs(QQuickItem* parent) :  QQuickItem(parent) {
 #define AI_UPDATE_FLOAT(name, src, epsilon) \
     { \
         float val = src; \
-        if (abs(_##name - val) >= epsilon) { \
+        if (fabs(_##name - val) >= epsilon) { \
             _##name = val; \
             emit name##Changed(); \
         } \

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -86,7 +86,7 @@ bool Stats::includeTimingRecord(const QString& name) {
 #define STAT_UPDATE_FLOAT(name, src, epsilon) \
     { \
         float val = src; \
-        if (abs(_##name - val) >= epsilon) { \
+        if (fabs(_##name - val) >= epsilon) { \
             _##name = val; \
             emit name##Changed(); \
         } \


### PR DESCRIPTION
the meaning of the save 'zoom' value is being inverted.  Correcting.  Also using fabs instead of abs for a couple of floating point comparisons.  