### PR TITLE
QA for #20590 - Delete Interface.ini.lock file at start-up if it exists

### DIFF
--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -11,6 +11,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <QFile>
 #include <QThread>
 
 #include "PathUtils.h"
@@ -53,7 +54,15 @@ namespace Setting {
         
         privateInstance = new Manager();
         Q_CHECK_PTR(privateInstance);
-        
+
+        // Delete Interface.ini.lock file if it exists, otherwise Interface freezes.
+        QString settingsLockFilename = privateInstance->fileName() + ".lock";
+        QFile settingsLockFile(settingsLockFilename);
+        if (settingsLockFile.exists()) {
+            bool deleted = settingsLockFile.remove();
+            qCDebug(shared) << (deleted ? "Deleted" : "Failed to delete") << "settings lock file" << settingsLockFilename;
+        }
+
         QObject::connect(privateInstance, SIGNAL(destroyed()), thread, SLOT(quit()));
         QObject::connect(thread, SIGNAL(started()), privateInstance, SLOT(startTimer()));
         QObject::connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));


### PR DESCRIPTION
Interface.ini.lock is written while Interface.ini is being updated. If Interface crashes while Interfae.ini is being updated, the .lock file remains and Interface freezes at start-up unless it is deleted.