### PR TITLE
QA for #20589 - Vertical field of view preference change should be applied immediately

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1029,7 +1029,7 @@ void Application::showEditEntitiesHelp() {
     InfoView::show(INFO_EDIT_ENTITIES_PATH);
 }
 
-void Application::resetCamerasOnResizeGL(Camera& camera, const glm::uvec2& size) {
+void Application::resetCameras(Camera& camera, const glm::uvec2& size) {
     if (OculusManager::isConnected()) {
         OculusManager::configureCamera(camera);
     } else if (TV3DManager::isConnected()) {
@@ -1052,13 +1052,14 @@ void Application::resizeGL() {
     if (_renderResolution != toGlm(renderSize)) {
         _renderResolution = toGlm(renderSize);
         DependencyManager::get<TextureCache>()->setFrameBufferSize(renderSize);
-        resetCamerasOnResizeGL(_myCamera, _renderResolution);
 
         glViewport(0, 0, _renderResolution.x, _renderResolution.y); // shouldn't this account for the menu???
 
         updateProjectionMatrix();
         glLoadIdentity();
     }
+
+    resetCameras(_myCamera, _renderResolution);
 
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -479,7 +479,7 @@ private slots:
     void setCursorVisible(bool visible);
 
 private:
-    void resetCamerasOnResizeGL(Camera& camera, const glm::uvec2& size);
+    void resetCameras(Camera& camera, const glm::uvec2& size);
     void updateProjectionMatrix();
     void updateProjectionMatrix(Camera& camera, bool updateViewFrustum = true);
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -221,8 +221,6 @@ void PreferencesDialog::savePreferences() {
     myAvatar->setLeanScale(ui.leanScaleSpin->value());
     myAvatar->setClampedTargetScale(ui.avatarScaleSpin->value());
     
-    Application::getInstance()->resizeGL();
-
     DependencyManager::get<AvatarManager>()->getMyAvatar()->setRealWorldFieldOfView(ui.realWorldFieldOfViewSpin->value());
     
     qApp->setFieldOfView(ui.fieldOfViewSpin->value());


### PR DESCRIPTION
When the vertical field of view preference value is changed, apply it immediately (instead of having to restart Interface for it to take effect).