### PR TITLE
Fix Web entities

### DIFF
--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -56,7 +56,8 @@ void RenderableTextEntityItem::render(RenderArgs* args) {
         batch.setModelTransform(transformToTopLeft);
     }
     
-    DependencyManager::get<DeferredLightingEffect>()->renderQuad(batch, minCorner, maxCorner, backgroundColor);
+    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, false, false);
+    DependencyManager::get<GeometryCache>()->renderQuad(batch, minCorner, maxCorner, backgroundColor);
     
     float scale = _lineHeight / _textRenderer->getFontSize();
     transformToTopLeft.setScale(scale); // Scale to have the correct line height

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -178,6 +178,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     gpu::Batch& batch = *args->_batch;
     batch.setModelTransform(getTransformToCenter());
     if (_texture) {
+        batch._glActiveTexture(GL_TEXTURE0);
         batch._glBindTexture(GL_TEXTURE_2D, _texture);
         batch._glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         batch._glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -172,10 +172,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     Glower glow(0.0f);
     PerformanceTimer perfTimer("RenderableWebEntityItem::render");
     Q_ASSERT(getType() == EntityTypes::Web);
-    static const glm::vec2 texMin(0.0f);
-    static const glm::vec2 texMax(1.0f);
-    glm::vec2 topLeft(-0.5f, -0.5f);
-    glm::vec2 bottomRight(0.5f, 0.5f);
+    static const glm::vec2 texMin(0.0f), texMax(1.0f), topLeft(-0.5f), bottomRight(0.5f);
 
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -177,12 +177,14 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
     batch.setModelTransform(getTransformToCenter());
+    bool textured = false, culled = false, emissive = false;
     if (_texture) {
         batch._glActiveTexture(GL_TEXTURE0);
         batch._glBindTexture(GL_TEXTURE_2D, _texture);
+        textured = emissive = true;
     }
-    static const bool textured = true, culled = false, emmissive = true;
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, textured, culled, emmissive);
+    
+    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, textured, culled, emissive);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f));
 }
 

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -180,12 +180,10 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     if (_texture) {
         batch._glActiveTexture(GL_TEXTURE0);
         batch._glBindTexture(GL_TEXTURE_2D, _texture);
-        batch._glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        batch._glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     }
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, true, false);
+    static const bool textured = true, culled = false, emmissive = true;
+    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, textured, culled, emmissive);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f));
-    DependencyManager::get<DeferredLightingEffect>()->releaseSimpleProgram(batch);
 }
 
 void RenderableWebEntityItem::setSourceUrl(const QString& value) {

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -185,7 +185,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
         batch._glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         batch._glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     }
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, true);
+    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, true, false);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f));
     DependencyManager::get<DeferredLightingEffect>()->releaseSimpleProgram(batch);
 }

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -174,7 +174,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     Q_ASSERT(getType() == EntityTypes::Web);
     static const glm::vec2 texMin(0.0f);
     static const glm::vec2 texMax(1.0f);
-    glm::vec2 topLeft(-0.5f -0.5f);
+    glm::vec2 topLeft(-0.5f, -0.5f);
     glm::vec2 bottomRight(0.5f, 0.5f);
 
     Q_ASSERT(args->_batch);

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -160,6 +160,10 @@ void GLBackend::do_setUniformBuffer(Batch& batch, uint32 paramOffset) {
     GLuint bo = getBufferID(*uniformBuffer);
     glBindBufferRange(GL_UNIFORM_BUFFER, slot, bo, rangeStart, rangeSize);
 #else
+    // because we rely on the program uniform mechanism we need to have
+    // the program bound, thank you MacOSX Legacy profile.
+    updatePipeline();
+    
     GLfloat* data = (GLfloat*) (uniformBuffer->getData() + rangeStart);
     glUniform4fv(slot, rangeSize / sizeof(GLfloat[4]), data);
  

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -27,8 +27,8 @@
 #include "gpu/GLBackend.h"
 
 #include "simple_vert.h"
-#include "simple_frag.h"
 #include "simple_textured_frag.h"
+#include "simple_textured_emisive_frag.h"
 
 #include "deferred_light_vert.h"
 #include "deferred_light_limited_vert.h"
@@ -52,15 +52,15 @@ static const std::string glowIntensityShaderHandle = "glowIntensity";
 
 void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
     auto VS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(simple_vert)));
-    auto PS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(simple_frag)));
-    auto PSTextured = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(simple_textured_frag)));
+    auto PS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(simple_textured_frag)));
+    auto PSEmissive = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(simple_textured_emisive_frag)));
     
     gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PS));
-    gpu::ShaderPointer programTextured = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PSTextured));
+    gpu::ShaderPointer programEmissive = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PSEmissive));
     
     gpu::Shader::BindingSet slotBindings;
     gpu::Shader::makeProgram(*program, slotBindings);
-    gpu::Shader::makeProgram(*programTextured, slotBindings);
+    gpu::Shader::makeProgram(*programEmissive, slotBindings);
     
     gpu::StatePointer state = gpu::StatePointer(new gpu::State());
     state->setCullMode(gpu::State::CULL_BACK);
@@ -79,8 +79,8 @@ void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
     
     _simpleProgram = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
     _simpleProgramCullNone = gpu::PipelinePointer(gpu::Pipeline::create(program, stateCullNone));
-    _simpleProgramTextured = gpu::PipelinePointer(gpu::Pipeline::create(programTextured, state));
-    _simpleProgramTexturedCullNone = gpu::PipelinePointer(gpu::Pipeline::create(programTextured, stateCullNone));
+    _simpleProgramEmissive = gpu::PipelinePointer(gpu::Pipeline::create(programEmissive, state));
+    _simpleProgramEmissiveCullNone = gpu::PipelinePointer(gpu::Pipeline::create(programEmissive, stateCullNone));
 
     _viewState = viewState;
     loadLightProgram(directional_light_frag, false, _directionalLight, _directionalLightLocations);
@@ -117,14 +117,12 @@ void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
     lp->setAmbientSpherePreset(gpu::SphericalHarmonics::Preset(_ambientLightMode % gpu::SphericalHarmonics::NUM_PRESET));
 }
 
-void DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled) {
-  // DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(batch, true, true, true);
-    
-    if (textured) {
+void DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled, bool emmisive) {
+    if (emmisive) {
         if (culled) {
-            batch.setPipeline(_simpleProgramTextured);
+            batch.setPipeline(_simpleProgramEmissive);
         } else {
-            batch.setPipeline(_simpleProgramTexturedCullNone);
+            batch.setPipeline(_simpleProgramEmissiveCullNone);
         }
     } else {
         if (culled) {
@@ -133,48 +131,42 @@ void DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch, bool textured,
             batch.setPipeline(_simpleProgramCullNone);
         }
     }
-}
-
-void DeferredLightingEffect::releaseSimpleProgram(gpu::Batch& batch) {
-  //  DependencyManager::get<TextureCache>()->setPrimaryDrawBuffers(batch, true, false, false);
+    if (!textured) {
+        // If it is not textured, bind white texture and keep using textured pipeline
+        batch.setUniformTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
+    }
 }
 
 void DeferredLightingEffect::renderSolidSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color) {
     bindSimpleProgram(batch);
     DependencyManager::get<GeometryCache>()->renderSphere(batch, radius, slices, stacks, color);
-    releaseSimpleProgram(batch);
 }
 
 void DeferredLightingEffect::renderWireSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color) {
     bindSimpleProgram(batch);
     DependencyManager::get<GeometryCache>()->renderSphere(batch, radius, slices, stacks, color, false);
-    releaseSimpleProgram(batch);
 }
 
 void DeferredLightingEffect::renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color) {
     bindSimpleProgram(batch);
     DependencyManager::get<GeometryCache>()->renderSolidCube(batch, size, color);
-    releaseSimpleProgram(batch);
 }
 
 void DeferredLightingEffect::renderWireCube(gpu::Batch& batch, float size, const glm::vec4& color) {
     bindSimpleProgram(batch);
     DependencyManager::get<GeometryCache>()->renderWireCube(batch, size, color);
-    releaseSimpleProgram(batch);
 }
 
 void DeferredLightingEffect::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner,
                                         const glm::vec4& color) {
     bindSimpleProgram(batch);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, minCorner, maxCorner, color);
-    releaseSimpleProgram(batch);
 }
 
 void DeferredLightingEffect::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
                                         const glm::vec4& color1, const glm::vec4& color2) {
     bindSimpleProgram(batch);
     DependencyManager::get<GeometryCache>()->renderLine(batch, p1, p2, color1, color2);
-    releaseSimpleProgram(batch);
 }
 
 void DeferredLightingEffect::addPointLight(const glm::vec3& position, float radius, const glm::vec3& color,

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -34,10 +34,7 @@ public:
     void init(AbstractViewStateInterface* viewState);
 
     /// Sets up the state necessary to render static untextured geometry with the simple program.
-    void bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true);
-    
-    /// Tears down the state necessary to render static untextured geometry with the simple program.
-    void releaseSimpleProgram(gpu::Batch& batch);
+    void bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true, bool emmisive = false);
 
     //// Renders a solid sphere with the simple program.
     void renderSolidSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color);
@@ -101,8 +98,8 @@ private:
     
     gpu::PipelinePointer _simpleProgram;
     gpu::PipelinePointer _simpleProgramCullNone;
-    gpu::PipelinePointer _simpleProgramTextured;
-    gpu::PipelinePointer _simpleProgramTexturedCullNone;
+    gpu::PipelinePointer _simpleProgramEmissive;
+    gpu::PipelinePointer _simpleProgramEmissiveCullNone;
 
     ProgramObject _directionalSkyboxLight;
     LightLocations _directionalSkyboxLightLocations;

--- a/libraries/render-utils/src/sdf_text3D.slf
+++ b/libraries/render-utils/src/sdf_text3D.slf
@@ -10,8 +10,6 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
-<@include DeferredBufferWrite.slh@>
-
 uniform sampler2D Font;
 uniform bool Outline;
 uniform vec4 Color;
@@ -48,11 +46,7 @@ void main() {
     }
     
     // final color
-    packDeferredFragmentLightmap(
-         normalize(interpolatedNormal.xyz),
-         glowIntensity * texel.a,
-         gl_Color.rgb,
-         gl_FrontMaterial.specular.rgb,
-         gl_FrontMaterial.shininess,
-         Color.rgb);
+    gl_FragData[0] = vec4(Color.rgb, Color.a * a);
+    gl_FragData[1] = vec4(normalize(interpolatedNormal.xyz), 0.0) * 0.5 + vec4(0.5, 0.5, 0.5, 0.5);
+    gl_FragData[2] = vec4(Color.rgb, gl_FrontMaterial.shininess / 128.0);
 }

--- a/libraries/render-utils/src/sdf_text3D.slf
+++ b/libraries/render-utils/src/sdf_text3D.slf
@@ -10,6 +10,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
+<@include DeferredBufferWrite.slh@>
+
 uniform sampler2D Font;
 uniform bool Outline;
 uniform vec4 Color;
@@ -44,9 +46,13 @@ void main() {
     if (a < 0.01) {
         discard;
     }
-
+    
     // final color
-    gl_FragData[0] = vec4(Color.rgb, Color.a * a);
-    gl_FragData[1] = vec4(interpolatedNormal.xyz, 0.0) * 0.5 + vec4(0.5, 0.5, 0.5, 1.0);
-    gl_FragData[2] = vec4(0.0);
+    packDeferredFragmentLightmap(
+         normalize(interpolatedNormal.xyz),
+         glowIntensity * texel.a,
+         gl_Color.rgb,
+         gl_FrontMaterial.specular.rgb,
+         gl_FrontMaterial.shininess,
+         Color.rgb);
 }

--- a/libraries/render-utils/src/simple_textured_emisive.slf
+++ b/libraries/render-utils/src/simple_textured_emisive.slf
@@ -1,0 +1,33 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  simple.frag
+//  fragment shader
+//
+//  Created by Clément Brisset on 5/29/15.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+
+// the diffuse texture
+uniform sampler2D originalTexture;
+
+// the interpolated normal
+varying vec4 interpolatedNormal;
+
+void main(void) {
+    vec4 texel = texture2D(originalTexture, gl_TexCoord[0].st);
+    
+    packDeferredFragmentLightmap(
+         normalize(interpolatedNormal.xyz),
+         glowIntensity * texel.a,
+         gl_Color.rgb,
+         gl_FrontMaterial.specular.rgb,
+         gl_FrontMaterial.shininess,
+         texel.rgb);
+}


### PR DESCRIPTION
This fixes web entities dimensions being wrong as well as being culled from the back.
I also made them emissive so that they are not affected by lighting and look bright like a screen (done the same thing for text entities)