### PR TITLE
Fixing always-on link cursor

### DIFF
--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -146,6 +146,8 @@ ApplicationCompositor::ApplicationCompositor() {
                 _hoverItemDescription = properties.getDescription();
                 cursor->setIcon(Cursor::Icon::LINK);
             } else {
+                _hoverItemTitle.clear();
+                _hoverItemDescription.clear();
                 cursor->setIcon(Cursor::Icon::DEFAULT);
             }
         }

--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -132,19 +132,18 @@ ApplicationCompositor::ApplicationCompositor() {
 
             // check the format of this href string before we parse it
             QString hrefString = properties.getHref();
-            if (!hrefString.startsWith("hifi:")) {
-                hrefString.prepend("hifi://");
-            }
-
-            // parse out a QUrl from the hrefString
-            QUrl href = QUrl(hrefString);
-
-            _hoverItemTitle = href.host();
-            _hoverItemDescription = properties.getDescription();
 
             auto cursor = Cursor::Manager::instance().getCursor();
+            if (!hrefString.isEmpty()) {
+                if (!hrefString.startsWith("hifi:")) {
+                    hrefString.prepend("hifi://");
+                }
 
-            if (!href.isEmpty()) {
+                // parse out a QUrl from the hrefString
+                QUrl href = QUrl(hrefString);
+
+                _hoverItemTitle = href.host();
+                _hoverItemDescription = properties.getDescription();
                 cursor->setIcon(Cursor::Icon::LINK);
             } else {
                 cursor->setIcon(Cursor::Icon::DEFAULT);


### PR DESCRIPTION
order of operations was causing the link cursor to be displayed for all entities.  