### PR TITLE
walk.js disable audio by default

### DIFF
--- a/examples/libraries/walkApi.js
+++ b/examples/libraries/walkApi.js
@@ -40,7 +40,7 @@ Avatar = function() {
     // settings
     this.headFree = true;
     this.armsFree = this.hydraCheck(); // automatically sets true to enable Hydra support - temporary fix
-    this.makesFootStepSounds = true;
+    this.makesFootStepSounds = false;
     this.blenderPreRotations = false; // temporary fix
     this.animationSet = undefined; // currently just one animation set
     this.setAnimationSet = function(animationSet) {


### PR DESCRIPTION
There is currently a bug that causes the first call to Audio.playSound to be distorted (see here for discussion: https://github.com/highfidelity/hifi/pull/5179) It makes a pretty unpleasant noise!

This PR simply sets the play audio option for walk.js to off.