### PR TITLE
Fix text overlay font rendering

### DIFF
--- a/interface/src/ui/overlays/TextOverlay.h
+++ b/interface/src/ui/overlays/TextOverlay.h
@@ -23,7 +23,7 @@
 const xColor DEFAULT_BACKGROUND_COLOR = { 0, 0, 0 };
 const float DEFAULT_BACKGROUND_ALPHA = 0.7f;
 const int DEFAULT_MARGIN = 10;
-const int DEFAULT_FONTSIZE = 11;
+const int DEFAULT_FONTSIZE = 12;
 const int DEFAULT_FONT_WEIGHT = 50;
 
 class TextRenderer;


### PR DESCRIPTION
Use the same font size as used in TextRenderer to avoid scaling issues.

This fixes (brings the legibility back up to where it was until recently) the problem of blurry text in users.js on standard resolution displays, reported in https://alphas.highfidelity.io/t/blurry-text-in-users-list/6730