### PR TITLE
correct menu shortcut for mouselook

### DIFF
--- a/examples/mouseLook.js
+++ b/examples/mouseLook.js
@@ -171,7 +171,7 @@ var mouseLook = (function () {
     }
 
     function setupMenu() {
-        Menu.addMenuItem({ menuName: "View", menuItemName: "Mouselook Mode", shortcutKey: "META+M", 
+        Menu.addMenuItem({ menuName: "View", menuItemName: "Mouselook Mode", shortcutKey: "SHIFT+M", 
                         afterItem: "Mirror", isCheckable: true, isChecked: false });
     }
 


### PR DESCRIPTION
The keyboard shortcut for mouselook mode was changed from meta+m to shift+m to avoid interfering with other commands on windows.  The menu will now display the correct shortcut when mouseLook.js is running.