### PR TITLE
Fix TextOverlay font size setting

### DIFF
--- a/interface/src/ui/overlays/TextOverlay.cpp
+++ b/interface/src/ui/overlays/TextOverlay.cpp
@@ -170,3 +170,10 @@ QSizeF TextOverlay::textSize(const QString& text) const {
 
     return QSizeF(extents.x, extents.y);
 }
+
+void TextOverlay::setFontSize(int fontSize) {
+    _fontSize = fontSize;
+
+    delete _textRenderer;
+    _textRenderer = TextRenderer::getInstance(SANS_FONT_FAMILY, _fontSize, DEFAULT_FONT_WEIGHT);
+}

--- a/interface/src/ui/overlays/TextOverlay.cpp
+++ b/interface/src/ui/overlays/TextOverlay.cpp
@@ -174,6 +174,7 @@ QSizeF TextOverlay::textSize(const QString& text) const {
 void TextOverlay::setFontSize(int fontSize) {
     _fontSize = fontSize;
 
-    delete _textRenderer;
+    auto oldTextRenderer = _textRenderer;
     _textRenderer = TextRenderer::getInstance(SANS_FONT_FAMILY, _fontSize, DEFAULT_FONT_WEIGHT);
+    delete oldTextRenderer;
 }

--- a/interface/src/ui/overlays/TextOverlay.h
+++ b/interface/src/ui/overlays/TextOverlay.h
@@ -48,7 +48,7 @@ public:
     void setText(const QString& text) { _text = text; }
     void setLeftMargin(int margin) { _leftMargin = margin; }
     void setTopMargin(int margin) { _topMargin = margin; }
-    void setFontSize(int fontSize) { _fontSize = fontSize; }
+    void setFontSize(int fontSize);
 
     virtual void setProperties(const QScriptValue& properties);
     virtual TextOverlay* createClone() const;


### PR DESCRIPTION
This enables scripts to set the font size on 2D text overlays again.