### PR TITLE
Eliminate per-packet locking for processing

### DIFF
--- a/libraries/networking/src/ReceivedPacketProcessor.cpp
+++ b/libraries/networking/src/ReceivedPacketProcessor.cpp
@@ -40,13 +40,13 @@ bool ReceivedPacketProcessor::process() {
     }
 
     preProcess();
-    QVector<NetworkPacket> currentPackets;
     if (!_packets.size()) {
         return isStillRunning();
     }
 
     lock();
-    std::swap(currentPackets, _packets);
+    QVector<NetworkPacket> currentPackets;
+    currentPackets.swap(_packets);
     unlock();
 
     foreach(auto& packet, currentPackets) {

--- a/libraries/networking/src/ReceivedPacketProcessor.cpp
+++ b/libraries/networking/src/ReceivedPacketProcessor.cpp
@@ -38,19 +38,28 @@ bool ReceivedPacketProcessor::process() {
         _hasPackets.wait(&_waitingOnPacketsMutex, getMaxWait());
         _waitingOnPacketsMutex.unlock();
     }
+
     preProcess();
-    while (_packets.size() > 0) {
-        lock(); // lock to make sure nothing changes on us
-        NetworkPacket& packet = _packets.front(); // get the oldest packet
-        NetworkPacket temporary = packet; // make a copy of the packet in case the vector is resized on us
-        _packets.erase(_packets.begin()); // remove the oldest packet
-        if (!temporary.getNode().isNull()) {
-            _nodePacketCounts[temporary.getNode()->getUUID()]--;
-        }
-        unlock(); // let others add to the packets
-        processPacket(temporary.getNode(), temporary.getByteArray()); // process our temporary copy
+    QVector<NetworkPacket> currentPackets;
+    if (!_packets.size()) {
+        return isStillRunning();
+    }
+
+    lock();
+    std::swap(currentPackets, _packets);
+    unlock();
+
+    foreach(auto& packet, currentPackets) {
+        processPacket(packet.getNode(), packet.getByteArray()); 
         midProcess();
     }
+
+    lock();
+    foreach(auto& packet, currentPackets) {
+        _nodePacketCounts[packet.getNode()->getUUID()]--;
+    }
+    unlock();
+
     postProcess();
     return isStillRunning();  // keep running till they terminate us
 }

--- a/libraries/networking/src/ReceivedPacketProcessor.h
+++ b/libraries/networking/src/ReceivedPacketProcessor.h
@@ -75,7 +75,8 @@ protected:
 
 protected:
 
-    QVector<NetworkPacket> _packets;
+    QVector<NetworkPacket> _queuedPackets;
+    QVector<NetworkPacket> _processingPackets;
     QHash<QUuid, int> _nodePacketCounts;
 
     QWaitCondition _hasPackets;

--- a/libraries/networking/src/ReceivedPacketProcessor.h
+++ b/libraries/networking/src/ReceivedPacketProcessor.h
@@ -75,8 +75,7 @@ protected:
 
 protected:
 
-    QVector<NetworkPacket> _queuedPackets;
-    QVector<NetworkPacket> _processingPackets;
+    QVector<NetworkPacket> _packets;
     QHash<QUuid, int> _nodePacketCounts;
 
     QWaitCondition _hasPackets;


### PR DESCRIPTION
In the packet processor, we lock the packet queue for every single packet both on receiving and on processing.  Per-packet locking is unnecessary on processing however.  If we simply grab ALL the packets to process into a local vector we can now process all of them without locking on each individual one.  

On my windows system this seems to eliminate the 'extremely deep packets to process queue' problem.  