### PR TITLE
Instrument the inter-idle time and tweaking the timeout setting

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -91,6 +91,7 @@
 #include <SceneScriptingInterface.h>
 #include <ScriptCache.h>
 #include <SettingHandle.h>
+#include <SimpleAverage.h>
 #include <SoundCache.h>
 #include <TextRenderer.h>
 #include <Tooltip.h>
@@ -178,6 +179,7 @@ using namespace std;
 //  Starfield information
 static unsigned STARFIELD_NUM_STARS = 50000;
 static unsigned STARFIELD_SEED = 1;
+static uint8_t THROTTLED_IDLE_TIMER_DELAY = 2;
 
 const qint64 MAXIMUM_CACHE_SIZE = 10 * BYTES_PER_GIGABYTES;  // 10GB
 
@@ -1784,17 +1786,17 @@ void Application::checkFPS() {
     DependencyManager::get<NodeList>()->sendDomainServerCheckIn();
 }
 
-static SimpleMovingAverage interIdleDurations;
-static uint64_t lastIdleEnd{ 0 };
-
 void Application::idle() {
+    static SimpleAverage<float> interIdleDurations;
+    static uint64_t lastIdleEnd{ 0 };
+
     if (lastIdleEnd != 0) {
         uint64_t now = usecTimestampNow();
-        interIdleDurations.updateAverage(now - lastIdleEnd);
+        interIdleDurations.update(now - lastIdleEnd);
         static uint64_t lastReportTime = now;
-        if ((now - lastReportTime) >= (1000 * 1000)) {
+        if ((now - lastReportTime) >= (USECS_PER_SECOND)) {
             int avgIdleDuration = (int)interIdleDurations.getAverage();
-            qDebug() << "Average inter-idle time: " << avgIdleDuration << "s for " << interIdleDurations.getSampleCount() << " samples";
+            qCDebug(interfaceapp_timing) << "Average inter-idle time: " << avgIdleDuration << "s for " << interIdleDurations.getCount() << " samples";
             interIdleDurations.reset();
             lastReportTime = now;
         }
@@ -1845,7 +1847,7 @@ void Application::idle() {
 
             // After finishing all of the above work, restart the idle timer, allowing 2ms to process events.
         }
-        idleTimer->start(_glWidget->isThrottleRendering() ? 10 : 0);
+        idleTimer->start(_glWidget->isThrottleRendering() ? THROTTLED_IDLE_TIMER_DELAY : 0);
     } 
 
     // check for any requested background downloads.

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1845,8 +1845,9 @@ void Application::idle() {
                 _idleLoopStdev.reset();
             }
 
-            // After finishing all of the above work, restart the idle timer, allowing 2ms to process events.
         }
+        // After finishing all of the above work, ensure the idle timer is set to the proper interval,
+        // depending on whether we're throttling or not
         idleTimer->start(_glWidget->isThrottleRendering() ? THROTTLED_IDLE_TIMER_DELAY : 0);
     } 
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -179,7 +179,7 @@ using namespace std;
 //  Starfield information
 static unsigned STARFIELD_NUM_STARS = 50000;
 static unsigned STARFIELD_SEED = 1;
-static uint8_t THROTTLED_IDLE_TIMER_DELAY = 2;
+static uint8_t THROTTLED_IDLE_TIMER_DELAY = 10;
 
 const qint64 MAXIMUM_CACHE_SIZE = 10 * BYTES_PER_GIGABYTES;  // 10GB
 
@@ -1795,8 +1795,8 @@ void Application::idle() {
         interIdleDurations.update(now - lastIdleEnd);
         static uint64_t lastReportTime = now;
         if ((now - lastReportTime) >= (USECS_PER_SECOND)) {
-            int avgIdleDuration = (int)interIdleDurations.getAverage();
-            qCDebug(interfaceapp_timing) << "Average inter-idle time: " << avgIdleDuration << "s for " << interIdleDurations.getCount() << " samples";
+            static QString LOGLINE("Average inter-idle time: %1 us for %2 samples");
+            qCDebug(interfaceapp_timing) << LOGLINE.arg((int)interIdleDurations.getAverage()).arg(interIdleDurations.getCount());
             interIdleDurations.reset();
             lastReportTime = now;
         }

--- a/interface/src/InterfaceLogging.cpp
+++ b/interface/src/InterfaceLogging.cpp
@@ -12,3 +12,4 @@
 #include "InterfaceLogging.h"
 
 Q_LOGGING_CATEGORY(interfaceapp, "hifi.interface")
+Q_LOGGING_CATEGORY(interfaceapp_timing, "hifi.interface.timing")

--- a/interface/src/InterfaceLogging.h
+++ b/interface/src/InterfaceLogging.h
@@ -15,5 +15,6 @@
 #include <QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(interfaceapp)
+Q_DECLARE_LOGGING_CATEGORY(interfaceapp_timing)
 
 #endif // hifi_InterfaceLogging_h

--- a/libraries/shared/src/SimpleAverage.h
+++ b/libraries/shared/src/SimpleAverage.h
@@ -1,0 +1,33 @@
+//
+//  Created by Bradley Austin Davis on 2015/07/01.
+//  Copyright 2013 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+#ifndef hifi_SimpleAverage_h
+#define hifi_SimpleAverage_h
+
+template<typename T>
+class SimpleAverage {
+public:
+    void update(T sample) {
+        _sum += sample;
+        ++_count;
+    }
+    void reset() {
+        _sum = 0;
+        _count = 0;
+    }
+
+    int getCount() const { return _count; };
+    T getAverage() const { return _sum / (T)_count; };
+
+private:
+    int _count;
+    T _sum;
+};
+
+#endif


### PR DESCRIPTION
This reports the inter-idle timing to the debug log rather than on the screen, since reporting it on the screen involves frequent QML updates, which in turn changes the inter-idle timing.  