### PR TITLE
add more detailed edit timing to entity server

### DIFF
--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -327,6 +327,7 @@ bool OctreeServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
             showStats = true;
         } else if (url.path() == "/resetStats") {
             _octreeInboundPacketProcessor->resetStats();
+            _tree->resetEditStats();
             resetSendingStats();
             showStats = true;
         }
@@ -636,6 +637,13 @@ bool OctreeServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
         quint64 totalElementsProcessed = _octreeInboundPacketProcessor->getTotalElementsProcessed();
         quint64 totalPacketsProcessed = _octreeInboundPacketProcessor->getTotalPacketsProcessed();
 
+        quint64 averageDecodeTime = _tree->getAverageDecodeTime();
+        quint64 averageLookupTime = _tree->getAverageLookupTime();
+        quint64 averageUpdateTime = _tree->getAverageUpdateTime();
+        quint64 averageCreateTime = _tree->getAverageCreateTime();
+        quint64 averageLoggingTime = _tree->getAverageLoggingTime();
+
+
         float averageElementsPerPacket = totalPacketsProcessed == 0 ? 0 : totalElementsProcessed / totalPacketsProcessed;
 
         statsString += QString("   Current Inbound Packets Queue: %1 packets\r\n")
@@ -657,6 +665,17 @@ bool OctreeServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
             .arg(locale.toString((uint)averageProcessTimePerElement).rightJustified(COLUMN_WIDTH, ' '));
         statsString += QString("  Average Wait Lock Time/Element: %1 usecs\r\n")
             .arg(locale.toString((uint)averageLockWaitTimePerElement).rightJustified(COLUMN_WIDTH, ' '));
+
+        statsString += QString("             Average Decode Time: %1 usecs\r\n")
+            .arg(locale.toString((uint)averageDecodeTime).rightJustified(COLUMN_WIDTH, ' '));
+        statsString += QString("             Average Lookup Time: %1 usecs\r\n")
+            .arg(locale.toString((uint)averageLookupTime).rightJustified(COLUMN_WIDTH, ' '));
+        statsString += QString("             Average Update Time: %1 usecs\r\n")
+            .arg(locale.toString((uint)averageUpdateTime).rightJustified(COLUMN_WIDTH, ' '));
+        statsString += QString("             Average Create Time: %1 usecs\r\n")
+            .arg(locale.toString((uint)averageCreateTime).rightJustified(COLUMN_WIDTH, ' '));
+        statsString += QString("            Average Logging Time: %1 usecs\r\n")
+            .arg(locale.toString((uint)averageLoggingTime).rightJustified(COLUMN_WIDTH, ' '));
 
 
         int senderNumber = 0;

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -168,6 +168,23 @@ public:
 
     float getContentsLargestDimension();
 
+    virtual void resetEditStats() {    
+        _totalEditMessages = 0;
+        _totalUpdates = 0;
+        _totalCreates = 0;
+        _totalDecodeTime = 0;
+        _totalLookupTime = 0;
+        _totalUpdateTime = 0;
+        _totalCreateTime = 0;
+        _totalLoggingTime = 0;
+    }
+
+    virtual quint64 getAverageDecodeTime() const { return _totalEditMessages == 0 ? 0 : _totalDecodeTime / _totalEditMessages; }
+    virtual quint64 getAverageLookupTime() const { return _totalEditMessages == 0 ? 0 : _totalLookupTime / _totalEditMessages; }
+    virtual quint64 getAverageUpdateTime() const { return _totalUpdates == 0 ? 0 : _totalUpdateTime / _totalUpdates; }
+    virtual quint64 getAverageCreateTime() const { return _totalCreates == 0 ? 0 : _totalCreateTime / _totalCreates; }
+    virtual quint64 getAverageLoggingTime() const { return _totalEditMessages == 0 ? 0 : _totalLoggingTime / _totalEditMessages; }
+
 signals:
     void deletingEntity(const EntityItemID& entityID);
     void addingEntity(const EntityItemID& entityID);
@@ -202,6 +219,17 @@ private:
 
     bool _wantEditLogging = false;
     void maybeNotifyNewCollisionSoundURL(const QString& oldCollisionSoundURL, const QString& newCollisionSoundURL);
+    
+    
+    // some performance tracking properties - only used in server trees
+    int _totalEditMessages = 0;
+    int _totalUpdates = 0;
+    int _totalCreates = 0;
+    quint64 _totalDecodeTime = 0;
+    quint64 _totalLookupTime = 0;
+    quint64 _totalUpdateTime = 0;
+    quint64 _totalCreateTime = 0;
+    quint64 _totalLoggingTime = 0;
 };
 
 #endif // hifi_EntityTree_h

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -367,8 +367,16 @@ public:
     bool getIsClient() const { return !_isServer; } /// Is this a client based tree. Allows guards for certain operations
     void setIsClient(bool isClient) { _isServer = !isClient; }
     
-    virtual void dumpTree() { };
-    virtual void pruneTree() { };
+    virtual void dumpTree() { }
+    virtual void pruneTree() { }
+
+    virtual void resetEditStats() { }
+    virtual quint64 getAverageDecodeTime() const { return 0; }
+    virtual quint64 getAverageLookupTime() const { return 0;  }
+    virtual quint64 getAverageUpdateTime() const { return 0;  }
+    virtual quint64 getAverageCreateTime() const { return 0;  }
+    virtual quint64 getAverageLoggingTime() const { return 0;  }
+
 
 signals:
     void importSize(float x, float y, float z);


### PR DESCRIPTION
adds detailed timing stats to entity servers stats page for amount of time doing various portions of the edit message processing.