### PR TITLE
Fix Show Eye Focus and Show Look-at Vectors 

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -451,24 +451,24 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, boo
             if (renderBounding && shouldRenderHead(renderArgs)) {
                 _skeletonModel.renderBoundingCollisionShapes(*renderArgs->_batch, 0.7f);
             }
+        }
 
-            // If this is the avatar being looked at, render a little ball above their head
-            if (_isLookAtTarget && Menu::getInstance()->isOptionChecked(MenuOption::RenderFocusIndicator)) {
-                const float LOOK_AT_INDICATOR_RADIUS = 0.03f;
-                const float LOOK_AT_INDICATOR_OFFSET = 0.22f;
-                const glm::vec4 LOOK_AT_INDICATOR_COLOR = { 0.8f, 0.0f, 0.0f, 0.75f };
-                glm::vec3 position;
-                if (_displayName.isEmpty() || _displayNameAlpha == 0.0f) {
-                    position = glm::vec3(_position.x, getDisplayNamePosition().y, _position.z);
-                } else {
-                    position = glm::vec3(_position.x, getDisplayNamePosition().y + LOOK_AT_INDICATOR_OFFSET, _position.z);
-                }
-                Transform transform;
-                transform.setTranslation(position);
-                batch.setModelTransform(transform);
-                DependencyManager::get<DeferredLightingEffect>()->renderSolidSphere(batch, LOOK_AT_INDICATOR_RADIUS
-                                                                                    , 15, 15, LOOK_AT_INDICATOR_COLOR);
+        // If this is the avatar being looked at, render a little ball above their head
+        if (_isLookAtTarget && Menu::getInstance()->isOptionChecked(MenuOption::RenderFocusIndicator)) {
+            const float LOOK_AT_INDICATOR_RADIUS = 0.03f;
+            const float LOOK_AT_INDICATOR_OFFSET = 0.22f;
+            const glm::vec4 LOOK_AT_INDICATOR_COLOR = { 0.8f, 0.0f, 0.0f, 0.75f };
+            glm::vec3 position;
+            if (_displayName.isEmpty() || _displayNameAlpha == 0.0f) {
+                position = glm::vec3(_position.x, getDisplayNamePosition().y, _position.z);
+            } else {
+                position = glm::vec3(_position.x, getDisplayNamePosition().y + LOOK_AT_INDICATOR_OFFSET, _position.z);
             }
+            Transform transform;
+            transform.setTranslation(position);
+            batch.setModelTransform(transform);
+            DependencyManager::get<DeferredLightingEffect>()->renderSolidSphere(batch, LOOK_AT_INDICATOR_RADIUS
+                                                                                , 15, 15, LOOK_AT_INDICATOR_COLOR);
         }
 
         // quick check before falling into the code below:

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -9,9 +9,11 @@
 //
 
 #include <glm/gtx/quaternion.hpp>
+#include <gpu/GPUConfig.h>
+#include <gpu/Batch.h>
 
 #include <DependencyManager.h>
-#include <GlowEffect.h>
+#include <DeferredLightingEffect.h>
 #include <NodeList.h>
 
 #include "Application.h"
@@ -293,10 +295,8 @@ void Head::relaxLean(float deltaTime) {
 }
 
 void Head::render(RenderArgs* renderArgs, float alpha, ViewFrustum* renderFrustum, bool postLighting) {
-    if (postLighting) {
-        if (_renderLookatVectors) {
+    if (_renderLookatVectors) {
             renderLookatVectors(renderArgs, _leftEyePosition, _rightEyePosition, getCorrectedLookAtPosition());    
-        }
     }
 }
 
@@ -380,17 +380,19 @@ void Head::addLeanDeltas(float sideways, float forward) {
 }
 
 void Head::renderLookatVectors(RenderArgs* renderArgs, glm::vec3 leftEyePosition, glm::vec3 rightEyePosition, glm::vec3 lookatPosition) {
+    auto& batch = *renderArgs->_batch;
+    auto transform = Transform{};
+    batch.setModelTransform(transform);
+    batch._glLineWidth(2.0f);
+
+    auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
+    deferredLighting->bindSimpleProgram(batch);
+
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    DependencyManager::get<GlowEffect>()->begin(renderArgs);
-    
-    glLineWidth(2.0);
-    
     glm::vec4 startColor(0.2f, 0.2f, 0.2f, 1.0f);
     glm::vec4 endColor(1.0f, 1.0f, 1.0f, 0.0f);
-    geometryCache->renderLine(leftEyePosition, lookatPosition, startColor, endColor, _leftEyeLookAtID);
-    geometryCache->renderLine(rightEyePosition, lookatPosition, startColor, endColor, _rightEyeLookAtID);
-
-    DependencyManager::get<GlowEffect>()->end(renderArgs);
+    geometryCache->renderLine(batch, leftEyePosition, lookatPosition, startColor, endColor, _leftEyeLookAtID);
+    geometryCache->renderLine(batch, rightEyePosition, lookatPosition, startColor, endColor, _rightEyeLookAtID);
 }
 
 


### PR DESCRIPTION
Fixes rendering of the sphere above the focus avatar (Developer > Avatar > Show Eye Focus) and the look-at vectors (Developer > Avatar > Show Look-At Vectors) so that they display again.