### PR TITLE
Inhibiting log spam unless a menu item is selected

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1796,7 +1796,9 @@ void Application::idle() {
         static uint64_t lastReportTime = now;
         if ((now - lastReportTime) >= (USECS_PER_SECOND)) {
             static QString LOGLINE("Average inter-idle time: %1 us for %2 samples");
-            qCDebug(interfaceapp_timing) << LOGLINE.arg((int)interIdleDurations.getAverage()).arg(interIdleDurations.getCount());
+            if (Menu::getInstance()->isOptionChecked(MenuOption::LogExtraTimings)) {
+                qCDebug(interfaceapp_timing) << LOGLINE.arg((int)interIdleDurations.getAverage()).arg(interIdleDurations.getCount());
+            }
             interIdleDurations.reset();
             lastReportTime = now;
         }

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -529,6 +529,7 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::FrameTimer);
     addActionToQMenuAndActionHash(timingMenu, MenuOption::RunTimingTests, 0, qApp, SLOT(runTests()));
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::PipelineWarnings);
+    addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::LogExtraTimings);
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::SuppressShortTimings);
 
     auto audioIO = DependencyManager::get<AudioClient>();

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -212,6 +212,7 @@ namespace MenuOption {
     const QString LodTools = "LOD Tools";
     const QString Login = "Login";
     const QString Log = "Log";
+    const QString LogExtraTimings = "Log Extra Timing Details";
     const QString LowVelocityFilter = "Low Velocity Filter";
     const QString Mirror = "Mirror";
     const QString MuteAudio = "Mute Microphone";


### PR DESCRIPTION
the inter-idle timing logging is producing lots of logging.  This eliminate the log output unless a menu item is selected for additional logging.  