### PR TITLE
Don't display update dialog if this is a PR build

### DIFF
--- a/libraries/auto-updater/src/AutoUpdater.cpp
+++ b/libraries/auto-updater/src/AutoUpdater.cpp
@@ -104,7 +104,9 @@ void AutoUpdater::parseLatestVersionData() {
 }
 
 void AutoUpdater::checkVersionAndNotify() {
-    if (QCoreApplication::applicationVersion() == "dev" || _builds.empty()) {
+    if (QCoreApplication::applicationVersion() == "dev" ||
+        QCoreApplication::applicationVersion().contains("PR") ||
+        _builds.empty()) {
         // No version checking is required in dev builds or when no build
         // data was found for the platform
         return;


### PR DESCRIPTION
The update dialog should not be displayed when the build came from a pull request test.