### PR TITLE
Updating oglplus version and switching to url based dist

### DIFF
--- a/cmake/externals/oglplus/CMakeLists.txt
+++ b/cmake/externals/oglplus/CMakeLists.txt
@@ -4,8 +4,8 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 include(ExternalProject)
 ExternalProject_Add(
     ${EXTERNAL_NAME}
-    GIT_REPOSITORY https://github.com/matus-chochlik/oglplus.git
-    GIT_TAG a2681383928b1166f176512cbe0f95e96fe68d08
+    URL http://iweb.dl.sourceforge.net/project/oglplus/oglplus-0.63.x/oglplus-0.63.0.zip
+    URL_MD5 de984ab245b185b45c87415c0e052135
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""


### PR DESCRIPTION
Builds were sometimes hanging for me while attempting to check out the oglplus repo.  Switching to a URL based approach seems to fix that.  