### PR TITLE
fix for mirror rendering on windows

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3386,14 +3386,6 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
     // load the view frustum
     loadViewFrustum(theCamera, _displayViewFrustum);
 
-    // flip x if in mirror mode (also requires reversing winding order for backface culling)
-    if (theCamera.getMode() == CAMERA_MODE_MIRROR) {
-        //glScalef(-1.0f, 1.0f, 1.0f);
-        //glFrontFace(GL_CW);
-    } else {
-        glFrontFace(GL_CCW);
-    }
-
     // transform view according to theCamera
     // could be myCamera (if in normal mode)
     // or could be viewFrustumOffsetCamera if in offset mode
@@ -3411,9 +3403,6 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
     Transform viewTransform;
     viewTransform.setTranslation(theCamera.getPosition());
     viewTransform.setRotation(rotation);
-    if (theCamera.getMode() == CAMERA_MODE_MIRROR) {
-//         viewTransform.setScale(Transform::Vec3(-1.0f, 1.0f, 1.0f));
-    }
     if (renderArgs->_renderSide != RenderArgs::MONO) {
         glm::mat4 invView = glm::inverse(_untranslatedViewMatrix);
 

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -118,7 +118,7 @@ void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const Rend
     args->_viewFrustum->evalProjectionMatrix(projMat);
     args->_viewFrustum->evalViewTransform(viewMat);
     if (args->_renderMode == RenderArgs::MIRROR_RENDER_MODE) {
-        viewMat.postScale(glm::vec3(-1.0f, 1.0f, 1.0f));
+        viewMat.preScale(glm::vec3(-1.0f, 1.0f, 1.0f));
     }
     batch.setProjectionTransform(projMat);
     batch.setViewTransform(viewMat);

--- a/libraries/shared/src/Transform.h
+++ b/libraries/shared/src/Transform.h
@@ -97,6 +97,8 @@ public:
     const Vec3& getScale() const;
     void setScale(float scale);
     void setScale(const Vec3& scale);  // [new this] = [this.translation] * [this.rotation] * [scale]
+    void preScale(float scale);
+    void preScale(const Vec3& scale);
     void postScale(float scale);       // [new this] = [this] * [scale] equivalent to glScale
     void postScale(const Vec3& scale); // [new this] = [this] * [scale] equivalent to glScale
 
@@ -320,6 +322,14 @@ inline void Transform::setScale(const Vec3& scale) {
         flagNonUniform();
         _scale = scale;
     }
+}
+
+inline void Transform::preScale(float scale) {
+    setScale(getScale() * scale);
+}
+
+inline void Transform::preScale(const Vec3& scale) {
+    setScale(getScale() * scale);
 }
 
 inline void Transform::postScale(float scale) {


### PR DESCRIPTION
* added preScale to Transform class.
* preScale by -1 about the xAxis instead of post scale.
  I think this was working on Mac due to the different code paths in
  GLBackendTransform::updateTransform for core vs legacy gl profile.