### PR TITLE
Allow Assignment Client scripts to do edits in their shutdown handler

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -710,7 +710,13 @@ void ScriptEngine::run() {
 
         // since we're in non-threaded mode, call process so that the packets are sent
         if (!entityScriptingInterface->getEntityPacketSender()->isThreaded()) {
-            entityScriptingInterface->getEntityPacketSender()->process();
+            // wait here till the edit packet sender is completely done sending
+            while (entityScriptingInterface->getEntityPacketSender()->hasPacketsToSend()) {
+                entityScriptingInterface->getEntityPacketSender()->process();
+                QCoreApplication::processEvents();
+            }
+        } else {
+            // FIXME - do we need to have a similar "wait here" loop for non-threaded packet senders?
         }
     }
 


### PR DESCRIPTION
On script shutdown, wait to process all pending edit messages before ending the script engine. This fixes an issue where AC scripts that attempt to delete or edit entities on their shutdown would not have those edits properly get sent.