### PR TITLE
Rename gpu::Batch::setUniformTexture into gpu::Batch::setResourceTexture

### DIFF
--- a/interface/src/audio/AudioScope.cpp
+++ b/interface/src/audio/AudioScope.cpp
@@ -130,7 +130,7 @@ void AudioScope::render(RenderArgs* renderArgs, int width, int height) {
     auto geometryCache = DependencyManager::get<GeometryCache>();
     geometryCache->useSimpleDrawPipeline(batch);
     auto textureCache = DependencyManager::get<TextureCache>();
-    batch.setUniformTexture(0, textureCache->getWhiteTexture());
+    batch.setResourceTexture(0, textureCache->getWhiteTexture());
     mat4 legacyProjection = glm::ortho<float>(0, width, height, 0, -1000, 1000);
     batch.setProjectionTransform(legacyProjection);
     batch.setModelTransform(Transform());

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -644,7 +644,7 @@ void Avatar::renderBillboard(RenderArgs* renderArgs) {
     glm::vec2 texCoordBottomRight(1.0f, 1.0f);
     
     gpu::Batch& batch = *renderArgs->_batch;
-    batch.setUniformTexture(0, _billboardTexture->getGPUTexture());
+    batch.setResourceTexture(0, _billboardTexture->getGPUTexture());
     DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, true);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
                                                         glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));

--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -179,7 +179,7 @@ void ApplicationCompositor::bindCursorTexture(gpu::Batch& batch, uint8_t cursorI
         _cursors[iconId] = DependencyManager::get<TextureCache>()->
             getImageTexture(iconPath);
     }
-    batch.setUniformTexture(0, _cursors[iconId]);
+    batch.setResourceTexture(0, _cursors[iconId]);
 }
 
 // Draws the FBO texture for the screen

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -196,7 +196,7 @@ void ApplicationOverlay::renderDomainConnectionStatusBorder(RenderArgs* renderAr
         geometryCache->useSimpleDrawPipeline(batch);
         batch.setProjectionTransform(mat4());
         batch.setModelTransform(mat4());
-        batch.setUniformTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
+        batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
         batch._glLineWidth(CONNECTION_STATUS_BORDER_LINE_WIDTH);
 
         // TODO animate the disconnect border for some excitement while not connected?

--- a/interface/src/ui/overlays/BillboardOverlay.cpp
+++ b/interface/src/ui/overlays/BillboardOverlay.cpp
@@ -87,12 +87,12 @@ void BillboardOverlay::render(RenderArgs* args) {
         transform.postScale(glm::vec3(getDimensions(), 1.0f));
         
         batch->setModelTransform(transform);
-        batch->setUniformTexture(0, _texture->getGPUTexture());
+        batch->setResourceTexture(0, _texture->getGPUTexture());
         
         DependencyManager::get<GeometryCache>()->renderQuad(*batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
                                                             glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha));
     
-        batch->setUniformTexture(0, args->_whiteTexture); // restore default white color after me
+        batch->setResourceTexture(0, args->_whiteTexture); // restore default white color after me
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -50,7 +50,7 @@ void RenderableParticleEffectEntityItem::render(RenderArgs* args) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
     if (textured) {
-        batch.setUniformTexture(0, _texture->getGPUTexture());
+        batch.setResourceTexture(0, _texture->getGPUTexture());
     }
     batch.setModelTransform(getTransformToCenter());
     DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, textured);

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -227,15 +227,15 @@ void Batch::setUniformBuffer(uint32 slot, const BufferView& view) {
 }
 
 
-void Batch::setUniformTexture(uint32 slot, const TexturePointer& texture) {
-    ADD_COMMAND(setUniformTexture);
+void Batch::setResourceTexture(uint32 slot, const TexturePointer& texture) {
+    ADD_COMMAND(setResourceTexture);
 
     _params.push_back(_textures.cache(texture));
     _params.push_back(slot);
 }
 
-void Batch::setUniformTexture(uint32 slot, const TextureView& view) {
-    setUniformTexture(slot, view._texture);
+void Batch::setResourceTexture(uint32 slot, const TextureView& view) {
+    setResourceTexture(slot, view._texture);
 }
 
 void Batch::setFramebuffer(const FramebufferPointer& framebuffer) {

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -102,8 +102,8 @@ public:
     void setUniformBuffer(uint32 slot, const BufferPointer& buffer, Offset offset, Offset size);
     void setUniformBuffer(uint32 slot, const BufferView& view); // not a command, just a shortcut from a BufferView
 
-    void setUniformTexture(uint32 slot, const TexturePointer& view);
-    void setUniformTexture(uint32 slot, const TextureView& view); // not a command, just a shortcut from a TextureView
+    void setResourceTexture(uint32 slot, const TexturePointer& view);
+    void setResourceTexture(uint32 slot, const TextureView& view); // not a command, just a shortcut from a TextureView
 
     // Framebuffer Stage
     void setFramebuffer(const FramebufferPointer& framebuffer);
@@ -172,7 +172,7 @@ public:
         COMMAND_setStateBlendFactor,
 
         COMMAND_setUniformBuffer,
-        COMMAND_setUniformTexture,
+        COMMAND_setResourceTexture,
 
         COMMAND_setFramebuffer,
 

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -35,7 +35,7 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
     (&::gpu::GLBackend::do_setStateBlendFactor),
 
     (&::gpu::GLBackend::do_setUniformBuffer),
-    (&::gpu::GLBackend::do_setUniformTexture),
+    (&::gpu::GLBackend::do_setResourceTexture),
 
     (&::gpu::GLBackend::do_setFramebuffer),
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -309,7 +309,7 @@ protected:
 
     // Uniform Stage
     void do_setUniformBuffer(Batch& batch, uint32 paramOffset);
-    void do_setUniformTexture(Batch& batch, uint32 paramOffset);
+    void do_setResourceTexture(Batch& batch, uint32 paramOffset);
     
     struct UniformStageState {
         

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -188,7 +188,7 @@ void GLBackend::do_setUniformBuffer(Batch& batch, uint32 paramOffset) {
     (void) CHECK_GL_ERROR();
 }
 
-void GLBackend::do_setUniformTexture(Batch& batch, uint32 paramOffset) {
+void GLBackend::do_setResourceTexture(Batch& batch, uint32 paramOffset) {
     GLuint slot = batch._params[paramOffset + 1]._uint;
     TexturePointer uniformTexture = batch._textures.get(batch._params[paramOffset + 0]._uint);
 

--- a/libraries/model/src/model/Skybox.cpp
+++ b/libraries/model/src/model/Skybox.cpp
@@ -103,7 +103,7 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
             batch.setInputBuffer(gpu::Stream::POSITION, theBuffer, 0, 8);
             batch.setUniformBuffer(SKYBOX_CONSTANTS_SLOT, theConstants, 0, theConstants->getSize());
             batch.setInputFormat(theFormat);
-            batch.setUniformTexture(0, skybox.getCubemap());
+            batch.setResourceTexture(0, skybox.getCubemap());
             batch.draw(gpu::TRIANGLE_STRIP, 4);
         }
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -147,7 +147,7 @@ void DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch, bool textured,
     
     if (!config.isTextured()) {
         // If it is not textured, bind white texture and keep using textured pipeline
-        batch.setUniformTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
+        batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
     }
 }
 
@@ -244,13 +244,13 @@ void DeferredLightingEffect::render(RenderArgs* args) {
  
     batch.clearColorFramebuffer(freeFBO->getBufferMask(), glm::vec4(0.0f, 0.0f, 0.0f, 0.0f));
     
-    batch.setUniformTexture(0, textureCache->getPrimaryColorTexture());
+    batch.setResourceTexture(0, textureCache->getPrimaryColorTexture());
 
-    batch.setUniformTexture(1, textureCache->getPrimaryNormalTexture());
+    batch.setResourceTexture(1, textureCache->getPrimaryNormalTexture());
     
-    batch.setUniformTexture(2, textureCache->getPrimarySpecularTexture());
+    batch.setResourceTexture(2, textureCache->getPrimarySpecularTexture());
     
-    batch.setUniformTexture(3, textureCache->getPrimaryDepthTexture());
+    batch.setResourceTexture(3, textureCache->getPrimaryDepthTexture());
         
     // get the viewport side (left, right, both)
     int viewport[4];
@@ -275,7 +275,7 @@ void DeferredLightingEffect::render(RenderArgs* args) {
     const LightLocations* locations = &_directionalLightLocations;
     bool shadowsEnabled = _viewState->getShadowsEnabled();
     if (shadowsEnabled) {
-        batch.setUniformTexture(4, textureCache->getShadowFramebuffer()->getDepthStencilBuffer());
+        batch.setResourceTexture(4, textureCache->getShadowFramebuffer()->getDepthStencilBuffer());
         
         program = _directionalLightShadowMap;
         locations = &_directionalLightShadowMapLocations;
@@ -329,7 +329,7 @@ void DeferredLightingEffect::render(RenderArgs* args) {
         }
     
         if (useSkyboxCubemap) {
-            batch.setUniformTexture(5, _skybox->getCubemap());
+            batch.setResourceTexture(5, _skybox->getCubemap());
         }
 
         if (locations->lightBufferUnit >= 0) {
@@ -377,11 +377,11 @@ void DeferredLightingEffect::render(RenderArgs* args) {
     }
 
     if (useSkyboxCubemap) {
-        batch.setUniformTexture(5, nullptr);
+        batch.setResourceTexture(5, nullptr);
     }
 
     if (shadowsEnabled) {
-        batch.setUniformTexture(4, nullptr);
+        batch.setResourceTexture(4, nullptr);
     }
 
     glm::vec4 sCoefficients(sWidth / 2.0f, 0.0f, 0.0f, sMin + sWidth / 2.0f);
@@ -530,10 +530,10 @@ void DeferredLightingEffect::render(RenderArgs* args) {
     }
     
     // Probably not necessary in the long run because the gpu layer would unbound this texture if used as render target
-    batch.setUniformTexture(0, nullptr);
-    batch.setUniformTexture(1, nullptr);
-    batch.setUniformTexture(2, nullptr);
-    batch.setUniformTexture(3, nullptr);
+    batch.setResourceTexture(0, nullptr);
+    batch.setResourceTexture(1, nullptr);
+    batch.setResourceTexture(2, nullptr);
+    batch.setResourceTexture(3, nullptr);
 
     args->_context->syncCache();
     args->_context->render(batch);
@@ -551,7 +551,7 @@ void DeferredLightingEffect::copyBack(RenderArgs* args) {
     batch.setFramebuffer(textureCache->getPrimaryFramebuffer());
     batch.setPipeline(_blitLightBuffer);
     
-    batch.setUniformTexture(0, freeFBO->getRenderBuffer(0));
+    batch.setResourceTexture(0, freeFBO->getRenderBuffer(0));
 
     batch.setProjectionTransform(glm::mat4());
     batch.setViewTransform(Transform());

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -2031,10 +2031,10 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
             }
             static bool showDiffuse = true;
             if (showDiffuse && diffuseMap) {
-                batch.setUniformTexture(0, diffuseMap->getGPUTexture());
+                batch.setResourceTexture(0, diffuseMap->getGPUTexture());
             
             } else {
-                batch.setUniformTexture(0, textureCache->getWhiteTexture());
+                batch.setResourceTexture(0, textureCache->getWhiteTexture());
             }
 
             if (locations->texcoordMatrices >= 0) {
@@ -2050,14 +2050,14 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
 
             if (!mesh.tangents.isEmpty()) {                 
                 Texture* normalMap = networkPart.normalTexture.data();
-                batch.setUniformTexture(1, !normalMap ?
+                batch.setResourceTexture(1, !normalMap ?
                     textureCache->getBlueTexture() : normalMap->getGPUTexture());
 
             }
     
             if (locations->specularTextureUnit >= 0) {
                 Texture* specularMap = networkPart.specularTexture.data();
-                batch.setUniformTexture(locations->specularTextureUnit, !specularMap ?
+                batch.setResourceTexture(locations->specularTextureUnit, !specularMap ?
                                             textureCache->getWhiteTexture() : specularMap->getGPUTexture());
             }
 
@@ -2074,7 +2074,7 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
                 GLBATCH(glUniform2f)(locations->emissiveParams, emissiveOffset, emissiveScale);
                 
                 Texture* emissiveMap = networkPart.emissiveTexture.data();
-                batch.setUniformTexture(locations->emissiveTextureUnit, !emissiveMap ?
+                batch.setResourceTexture(locations->emissiveTextureUnit, !emissiveMap ?
                                         textureCache->getWhiteTexture() : emissiveMap->getGPUTexture());
             }
             

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -236,7 +236,7 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
     batch.setViewTransform(viewMat);
 
     batch.setPipeline(getOpaquePipeline());
-    batch.setUniformTexture(0, args->_whiteTexture);
+    batch.setResourceTexture(0, args->_whiteTexture);
 
     if (!inItems.empty()) {
         batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTH, glm::vec4(), 1.f, 0);

--- a/libraries/render-utils/src/TextRenderer3D.cpp
+++ b/libraries/render-utils/src/TextRenderer3D.cpp
@@ -423,7 +423,7 @@ void Font3D::drawString(gpu::Batch& batch, float x, float y, const QString& str,
     
     setupGPU();
     batch.setPipeline(_pipeline);
-    batch.setUniformTexture(_fontLoc, _texture);
+    batch.setResourceTexture(_fontLoc, _texture);
     batch._glUniform1i(_outlineLoc, (effectType == TextRenderer3D::OUTLINE_EFFECT));
     batch._glUniform4fv(_colorLoc, 1, (const GLfloat*)color);
     


### PR DESCRIPTION
The reason for that is that the word "uniform" is used for UniformBuffer which lives in a different memory space than  where the texture are.
We also want to introduce another binding point for Buffer which would be similar to Texture so we wanted to get away from "Uniform" and unify on one qualifying name.
We decided on "Resource" so we bind texture via setResourceTexture and we will be able to bind buffer via setResourceBuffer.
We could have gone for just setTexture and setBuffer but thought it was a bit ambiguous compared to the "Uniform" scope and not precise enough.

To compare:
in OpenGL:
gpu::UniformBuffer are UBO
gpu::ResourceTexture are just Texture
gpu::ResourceBuffer are either TextureBuffer (TBO) or the new SSBO (Shared Shader Buffer object).

in D3D10 and above:
gpu::UniformBuffer are ConstBuffer
gpu::ResourceTexture are Texture bound through ShaderResourceView
gpu::ResourceBuffer are Buffer bound through ShaderResourceView

Lastly looking forward we will want to also add the ReadWrite capable resource and thought that tthe scope "Resource" would be good for that too.