### PR TITLE
Avatars rendered correctly based on Scene.shouldRenderAvatars

### DIFF
--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -91,6 +91,14 @@ public:
     void removeFromScene(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene, 
                                 render::PendingChanges& pendingChanges);
 
+    //For Scene.shouldRenderAvatars
+    /*bool addToSceneOnStatusUpdate(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene,
+        render::PendingChanges& pendingChanges);
+
+    void removeFromSceneOnStatusUpdate(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene,
+        render::PendingChanges& pendingChanges);*/
+
+
     //setters
     void setDisplayingLookatVectors(bool displayingLookatVectors) { getHead()->setRenderLookatVectors(displayingLookatVectors); }
     void setIsLookAtTarget(const bool isLookAtTarget) { _isLookAtTarget = isLookAtTarget; }

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -91,7 +91,6 @@ public:
     void removeFromScene(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene, 
                                 render::PendingChanges& pendingChanges);
 
-
     //setters
     void setDisplayingLookatVectors(bool displayingLookatVectors) { getHead()->setRenderLookatVectors(displayingLookatVectors); }
     void setIsLookAtTarget(const bool isLookAtTarget) { _isLookAtTarget = isLookAtTarget; }

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -91,13 +91,6 @@ public:
     void removeFromScene(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene, 
                                 render::PendingChanges& pendingChanges);
 
-    //For Scene.shouldRenderAvatars
-    /*bool addToSceneOnStatusUpdate(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene,
-        render::PendingChanges& pendingChanges);
-
-    void removeFromSceneOnStatusUpdate(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene,
-        render::PendingChanges& pendingChanges);*/
-
 
     //setters
     void setDisplayingLookatVectors(bool displayingLookatVectors) { getHead()->setRenderLookatVectors(displayingLookatVectors); }

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -319,18 +319,16 @@ void AvatarManager::updateAvatarPhysicsShape(const QUuid& id) {
 
 void AvatarManager::updateAvatarRenderStatus(bool shouldRenderAvatars) {
     if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()) {
-        for (auto avatarData : _avatarsLastInScene) {
+        for (auto avatarData : _avatarHash) {
             auto avatar = std::dynamic_pointer_cast<Avatar>(avatarData);
             render::ScenePointer scene = Application::getInstance()->getMain3DScene();
             render::PendingChanges pendingChanges;
             avatar->addToScene(avatar, scene, pendingChanges);
             scene->enqueuePendingChanges(pendingChanges);
         }
-        _avatarsLastInScene.clear();
     }
     else {
-        _avatarsLastInScene = _avatarHash.values();
-        for (auto avatarData : _avatarsLastInScene) {
+        for (auto avatarData : _avatarHash) {
             auto avatar = std::dynamic_pointer_cast<Avatar>(avatarData);
             render::ScenePointer scene = Application::getInstance()->getMain3DScene();
             render::PendingChanges pendingChanges;

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -72,7 +72,7 @@ void AvatarManager::init() {
     _myAvatar->init();
     _avatarHash.insert(MY_AVATAR_KEY, _myAvatar);
 
-    connect(&(*DependencyManager::get<SceneScriptingInterface>()), &SceneScriptingInterface::shouldRenderAvatarsChanged, this, &AvatarManager::updateAvatarRenderStatus, Qt::QueuedConnection);
+    connect(DependencyManager::get<SceneScriptingInterface>().data(), &SceneScriptingInterface::shouldRenderAvatarsChanged, this, &AvatarManager::updateAvatarRenderStatus, Qt::QueuedConnection);
 
     render::ScenePointer scene = Application::getInstance()->getMain3DScene();
     render::PendingChanges pendingChanges;
@@ -326,8 +326,7 @@ void AvatarManager::updateAvatarRenderStatus(bool shouldRenderAvatars) {
             avatar->addToScene(avatar, scene, pendingChanges);
             scene->enqueuePendingChanges(pendingChanges);
         }
-    }
-    else {
+    } else {
         for (auto avatarData : _avatarHash) {
             auto avatar = std::dynamic_pointer_cast<Avatar>(avatarData);
             render::ScenePointer scene = Application::getInstance()->getMain3DScene();

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -72,9 +72,13 @@ void AvatarManager::init() {
     _myAvatar->init();
     _avatarHash.insert(MY_AVATAR_KEY, _myAvatar);
 
+    connect(&(*DependencyManager::get<SceneScriptingInterface>()), &SceneScriptingInterface::shouldRenderAvatarsChanged, this, &AvatarManager::updateAvatarRenderStatus, Qt::QueuedConnection);
+
     render::ScenePointer scene = Application::getInstance()->getMain3DScene();
     render::PendingChanges pendingChanges;
-    _myAvatar->addToScene(_myAvatar, scene, pendingChanges);
+    if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()) {
+        _myAvatar->addToScene(_myAvatar, scene, pendingChanges);
+    }
     scene->enqueuePendingChanges(pendingChanges);
 }
 
@@ -158,7 +162,9 @@ AvatarSharedPointer AvatarManager::addAvatar(const QUuid& sessionUUID, const QWe
     auto avatar = std::dynamic_pointer_cast<Avatar>(AvatarHashMap::addAvatar(sessionUUID, mixerWeakPointer));
     render::ScenePointer scene = Application::getInstance()->getMain3DScene();
     render::PendingChanges pendingChanges;
-    avatar->addToScene(avatar, scene, pendingChanges);
+    if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()) {
+        avatar->addToScene(avatar, scene, pendingChanges);
+    }
     scene->enqueuePendingChanges(pendingChanges);
     return avatar;
 }
@@ -307,6 +313,29 @@ void AvatarManager::updateAvatarPhysicsShape(const QUuid& id) {
                 _motionStatesToAdd.insert(motionState);
                 _avatarMotionStates.insert(motionState);
             }
+        }
+    }
+}
+
+void AvatarManager::updateAvatarRenderStatus(bool shouldRenderAvatars) {
+    if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()) {
+        for (auto avatarData : _avatarsLastInScene) {
+            auto avatar = std::dynamic_pointer_cast<Avatar>(avatarData);
+            render::ScenePointer scene = Application::getInstance()->getMain3DScene();
+            render::PendingChanges pendingChanges;
+            avatar->addToScene(avatar, scene, pendingChanges);
+            scene->enqueuePendingChanges(pendingChanges);
+        }
+        _avatarsLastInScene.clear();
+    }
+    else {
+        _avatarsLastInScene = _avatarHash.values();
+        for (auto avatarData : _avatarsLastInScene) {
+            auto avatar = std::dynamic_pointer_cast<Avatar>(avatarData);
+            render::ScenePointer scene = Application::getInstance()->getMain3DScene();
+            render::PendingChanges pendingChanges;
+            avatar->removeFromScene(avatar, scene, pendingChanges);
+            scene->enqueuePendingChanges(pendingChanges);
         }
     }
 }

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -62,7 +62,7 @@ public:
     void updateAvatarPhysicsShape(const QUuid& id);
 
     // For Scene.shouldRenderEntities
-    QList<AvatarSharedPointer>& getAvatarsLastInScene() { return _avatarIDsLastInScene; }
+    QList<AvatarSharedPointer>& getAvatarsLastInScene() { return _avatarsLastInScene; }
    
 public slots:
     void setShouldShowReceiveStats(bool shouldShowReceiveStats) { _shouldShowReceiveStats = shouldShowReceiveStats; }

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -60,9 +60,13 @@ public:
     void handleCollisionEvents(CollisionEvents& collisionEvents);
 
     void updateAvatarPhysicsShape(const QUuid& id);
+
+    // For Scene.shouldRenderEntities
+    QList<AvatarSharedPointer>& getAvatarsLastInScene() { return _avatarIDsLastInScene; }
    
 public slots:
     void setShouldShowReceiveStats(bool shouldShowReceiveStats) { _shouldShowReceiveStats = shouldShowReceiveStats; }
+    void updateAvatarRenderStatus(bool shouldRenderAvatars);
 
 private:
     AvatarManager(QObject* parent = 0);
@@ -88,6 +92,9 @@ private:
     SetOfMotionStates _motionStatesToAdd;
     VectorOfMotionStates _motionStatesToDelete;
     VectorOfMotionStates _tempMotionStates;
+
+    // For Scene.shouldRenderAvatars
+    QList<AvatarSharedPointer> _avatarsLastInScene;
 };
 
 Q_DECLARE_METATYPE(AvatarManager::LocalLight)

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -89,7 +89,6 @@ private:
     SetOfMotionStates _motionStatesToAdd;
     VectorOfMotionStates _motionStatesToDelete;
     VectorOfMotionStates _tempMotionStates;
-
 };
 
 Q_DECLARE_METATYPE(AvatarManager::LocalLight)

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -60,9 +60,6 @@ public:
     void handleCollisionEvents(CollisionEvents& collisionEvents);
 
     void updateAvatarPhysicsShape(const QUuid& id);
-
-    // For Scene.shouldRenderEntities
-    QList<AvatarSharedPointer>& getAvatarsLastInScene() { return _avatarsLastInScene; }
    
 public slots:
     void setShouldShowReceiveStats(bool shouldShowReceiveStats) { _shouldShowReceiveStats = shouldShowReceiveStats; }
@@ -93,8 +90,6 @@ private:
     VectorOfMotionStates _motionStatesToDelete;
     VectorOfMotionStates _tempMotionStates;
 
-    // For Scene.shouldRenderAvatars
-    QList<AvatarSharedPointer> _avatarsLastInScene;
 };
 
 Q_DECLARE_METATYPE(AvatarManager::LocalLight)

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -803,7 +803,7 @@ void EntityTreeRenderer::connectSignalsToSlots(EntityScriptingInterface* entityS
     connect(this, &EntityTreeRenderer::leaveEntity, entityScriptingInterface, &EntityScriptingInterface::leaveEntity);
     connect(this, &EntityTreeRenderer::collisionWithEntity, entityScriptingInterface, &EntityScriptingInterface::collisionWithEntity);
 
-    connect(&(*DependencyManager::get<SceneScriptingInterface>()), &SceneScriptingInterface::shouldRenderEntitiesChanged, this, &EntityTreeRenderer::updateEntityRenderStatus, Qt::QueuedConnection);
+    connect(DependencyManager::get<SceneScriptingInterface>().data(), &SceneScriptingInterface::shouldRenderEntitiesChanged, this, &EntityTreeRenderer::updateEntityRenderStatus, Qt::QueuedConnection);
 }
 
 QScriptValueList EntityTreeRenderer::createMouseEventArgs(const EntityItemID& entityID, QMouseEvent* event, unsigned int deviceID) {


### PR DESCRIPTION
Providing a fix for avatar rendering not turning on/off in real time when the developer menu item is checked/unchecked.