### PR TITLE
allow voxels.js to work on an empty voxel-space

### DIFF
--- a/examples/voxels.js
+++ b/examples/voxels.js
@@ -2,6 +2,32 @@ var controlHeld = false;
 var shiftHeld = false;
 
 
+function attemptVoxelChange(intersection) {
+    var ids = Entities.findEntities(intersection.intersection, 10);
+    var success = false;
+    for (var i = 0; i < ids.length; i++) {
+        var id = ids[i];
+        if (controlHeld) {
+            // hold control to erase a sphere
+            if (Entities.setVoxelSphere(id, intersection.intersection, 1.0, 0)) {
+                success = true;
+            }
+        } else if (shiftHeld) {
+            // hold shift to set all voxels to 255
+            if (Entities.setAllVoxels(id, 255)) {
+                success = true;
+            }
+        } else {
+            // no modifier key means to add a sphere
+            if (Entities.setVoxelSphere(id, intersection.intersection, 1.0, 255)) {
+                success = true;
+            }
+        }
+    }
+    return success;
+}
+
+
 function mousePressEvent(event) {
     if (!event.isLeftButton) {
         return;
@@ -9,19 +35,20 @@ function mousePressEvent(event) {
 
     var pickRay = Camera.computePickRay(event.x, event.y);
     var intersection = Entities.findRayIntersection(pickRay, true); // accurate picking
-    // var props = Entities.getEntityProperties(intersection.entityID);
+
+    // we've used a picking ray to decide where to add the new sphere of voxels.  If we pick nothing
+    // or if we pick a non-PolyVox entity, we fall through to the next picking attempt.
     if (intersection.intersects) {
-        var ids = Entities.findEntities(intersection.intersection, 10);
-        for (var i = 0; i < ids.length; i++) {
-            var id = ids[i];
-            if (controlHeld) {
-                Entities.setVoxelSphere(id, intersection.intersection, 1.0, 0);
-            } else if (shiftHeld) {
-                Entities.setAllVoxels(id, 255);
-            } else {
-                Entities.setVoxelSphere(id, intersection.intersection, 1.0, 255);
-            }
+        if (attemptVoxelChange(intersection)) {
+            return;
         }
+    }
+
+    // if the PolyVox entity is empty, we can't pick against its voxel.  try picking against its
+    // bounding box, instead.
+    intersection = Entities.findRayIntersection(pickRay, false); // bounding box picking
+    if (intersection.intersects) {
+        attemptVoxelChange(intersection);
     }
 }
 


### PR DESCRIPTION
The voxel editing script works by doing a ray-pick and setting the values of a sphere around the intersection point.  If a voxel-entity is empty and it's not up against another entity, this script couldn't set voxels to "on".