### PR TITLE
Make scribe generated shaders more readable

### DIFF
--- a/tools/scribe/src/main.cpp
+++ b/tools/scribe/src/main.cpp
@@ -192,17 +192,10 @@ int main (int argc, char** argv) {
         targetStringStream << "#ifndef scribe_" << targetName << "_h" << std::endl;
         targetStringStream << "#define scribe_" << targetName << "_h" << std::endl << std::endl;
 
-       // targetStringStream << "const char " << targetName << "[] = R\"XXXX(" << destStringStream.str() << ")XXXX\";";
-       std::istringstream destStringStreamAgain(destStringStream.str());
-        targetStringStream << "const char " << targetName << "[] = \n";
-        while (!destStringStreamAgain.eof()) {
-            std::string lineToken;
-            std::getline(destStringStreamAgain, lineToken);
-           // targetStringStream << "\"" << lineToken << "\"\n";
-            targetStringStream << "R\"X(" << lineToken << ")X\"\"\\n\"\n";
-        }
-
-        targetStringStream << ";\n" << std::endl << std::endl;
+        // targetStringStream << "const char " << targetName << "[] = R\"XXXX(" << destStringStream.str() << ")XXXX\";";
+        targetStringStream << "const char " << targetName << "[] = R\"SCRIBE(";
+        targetStringStream << destStringStream.str();
+        targetStringStream << "\n)SCRIBE\";\n\n";
         targetStringStream << "#endif" << std::endl;
     } else {
         targetStringStream << destStringStream.str();


### PR DESCRIPTION
This changes the generation of the scribe generated headers to look like this:

```
const char shader[] = R"SCRIBE(
foo 
bar 
baz
)SCRIBE"
```

instead of this

```
const char shader[] = 
R"X(foo)X\n"
R"X(bar)X\n" 
R"X(baz)X\n";
```
