### PR TITLE
Qt 5.5 fixes

### DIFF
--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QtCore/QDataStream>
+
 #include <NodeList.h>
 #include <PacketHeaders.h>
 #include <SharedUtil.h>

--- a/libraries/networking/src/DataServerAccountInfo.cpp
+++ b/libraries/networking/src/DataServerAccountInfo.cpp
@@ -13,6 +13,7 @@
 
 #include <qjsondocument.h>
 #include <QtCore/QDebug>
+#include <QtCore/QDataStream>
 
 #include "NetworkLogging.h"
 #include "DataServerAccountInfo.h"

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -12,6 +12,7 @@
 #include <math.h>
 
 #include <QtCore/QJsonDocument>
+#include <QtCore/QDataStream>
 
 #include "Assignment.h"
 #include "HifiSockAddr.h"

--- a/libraries/networking/src/JSONBreakableMarshal.h
+++ b/libraries/networking/src/JSONBreakableMarshal.h
@@ -17,6 +17,7 @@
 #include <QtCore/QJsonValue>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
+#include <QtCore/QVariantMap>
 
 class JSONBreakableMarshal {
 public:

--- a/libraries/networking/src/NetworkPeer.cpp
+++ b/libraries/networking/src/NetworkPeer.cpp
@@ -13,6 +13,7 @@
 
 #include <QtCore/QDateTime>
 #include <QtCore/QDebug>
+#include <QtCore/QDataStream>
 
 #include <SharedUtil.h>
 #include <UUID.h>

--- a/libraries/ui/src/VrMenu.cpp
+++ b/libraries/ui/src/VrMenu.cpp
@@ -102,13 +102,15 @@ class QQuickMenuItem;
 QObject* addItem(QObject* parent, const QString& text) {
     // FIXME add more checking here to ensure no name conflicts
     QQuickMenuItem* returnedValue{ nullptr };
-    #ifndef QT_NO_DEBUG
     bool invokeResult =
-    #endif
         QMetaObject::invokeMethod(parent, "addItem", Qt::DirectConnection, Q_RETURN_ARG(QQuickMenuItem*, returnedValue),
                                   Q_ARG(QString, text));
 
+#ifndef QT_NO_DEBUG
     Q_ASSERT(invokeResult);
+#else
+    Q_UNUSED(invokeResult);
+#endif
     QObject* result = reinterpret_cast<QObject*>(returnedValue);
     return result;
 }
@@ -206,9 +208,7 @@ void VrMenu::insertAction(QAction* before, QAction* action) {
         result = ::addItem(menu, action->text());
     } else {
         QQuickMenuItem* returnedValue{ nullptr };
-        #ifndef QT_NO_DEBUG
         bool invokeResult =
-        #endif
             QMetaObject::invokeMethod(menu, "insertItem", Qt::DirectConnection, Q_RETURN_ARG(QQuickMenuItem*, returnedValue),
                                       Q_ARG(int, index), Q_ARG(QString, action->text()));
         Q_ASSERT(invokeResult);

--- a/libraries/ui/src/VrMenu.cpp
+++ b/libraries/ui/src/VrMenu.cpp
@@ -211,7 +211,11 @@ void VrMenu::insertAction(QAction* before, QAction* action) {
         bool invokeResult =
             QMetaObject::invokeMethod(menu, "insertItem", Qt::DirectConnection, Q_RETURN_ARG(QQuickMenuItem*, returnedValue),
                                       Q_ARG(int, index), Q_ARG(QString, action->text()));
+#ifndef QT_NO_DEBUG
         Q_ASSERT(invokeResult);
+#else
+        Q_UNUSED(invokeResult);
+#endif
         result = reinterpret_cast<QObject*>(returnedValue);
     }
     Q_ASSERT(result);


### PR DESCRIPTION
Apparently some headers in Qt 5.5 don't pull in the same dependencies.  This PR fixes the code so it will build under 5.5.