### PR TITLE
fix grab.js when using the spring action

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -610,6 +610,9 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
     int bytesRead = parser.offset();
 #endif
 
+    auto nodeList = DependencyManager::get<NodeList>();
+    const QUuid& myNodeID = nodeList->getSessionUUID();
+    bool weOwnSimulation = _simulationOwner.matchesValidID(myNodeID);
 
     if (args.bitstreamVersion >= VERSION_ENTITIES_HAVE_SIMULATION_OWNER_AND_ACTIONS_OVER_WIRE) {
         // pack SimulationOwner and terse update properties near each other
@@ -632,10 +635,8 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         }
         {   // When we own the simulation we don't accept updates to the entity's transform/velocities
             // but since we're using macros below we have to temporarily modify overwriteLocalData.
-            auto nodeList = DependencyManager::get<NodeList>();
-            bool weOwnIt = _simulationOwner.matchesValidID(nodeList->getSessionUUID());
             bool oldOverwrite = overwriteLocalData;
-            overwriteLocalData = overwriteLocalData && !weOwnIt;
+            overwriteLocalData = overwriteLocalData && !weOwnSimulation;
             READ_ENTITY_PROPERTY(PROP_POSITION, glm::vec3, updatePosition);
             READ_ENTITY_PROPERTY(PROP_ROTATION, glm::quat, updateRotation);
             READ_ENTITY_PROPERTY(PROP_VELOCITY, glm::vec3, updateVelocity);
@@ -657,6 +658,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         READ_ENTITY_PROPERTY(PROP_REGISTRATION_POINT, glm::vec3, setRegistrationPoint);
     } else {
         // legacy order of packing here
+        // TODO: purge this logic in a few months from now (2015.07)
         READ_ENTITY_PROPERTY(PROP_POSITION, glm::vec3, updatePosition);
         READ_ENTITY_PROPERTY(PROP_DIMENSIONS, glm::vec3, updateDimensions);
         READ_ENTITY_PROPERTY(PROP_ROTATION, glm::quat, updateRotation);
@@ -702,7 +704,16 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
     READ_ENTITY_PROPERTY(PROP_HREF, QString, setHref);
     READ_ENTITY_PROPERTY(PROP_DESCRIPTION, QString, setDescription);
 
-    READ_ENTITY_PROPERTY(PROP_ACTION_DATA, QByteArray, setActionData);
+    {   // When we own the simulation we don't accept updates to the entity's actions
+        // but since we're using macros below we have to temporarily modify overwriteLocalData.
+        // NOTE: this prevents userB from adding an action to an object1 when UserA 
+        // has simulation ownership of it.
+        // TODO: figure out how to allow multiple users to update actions simultaneously
+        bool oldOverwrite = overwriteLocalData;
+        overwriteLocalData = overwriteLocalData && !weOwnSimulation;
+        READ_ENTITY_PROPERTY(PROP_ACTION_DATA, QByteArray, setActionData);
+        overwriteLocalData = oldOverwrite;
+    }
 
     bytesRead += readEntitySubclassDataFromBuffer(dataAt, (bytesLeftToRead - bytesRead), args,
                                                   propertyFlags, overwriteLocalData);
@@ -713,7 +724,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
     // NOTE: we had a bad version of the stream that we added stream data after the subclass. We can attempt to recover
     // by doing this parsing here... but it's not likely going to fully recover the content.
     //
-    // TODO: Remove this conde once we've sufficiently migrated content past this damaged version
+    // TODO: Remove this code once we've sufficiently migrated content past this damaged version
     if (args.bitstreamVersion == VERSION_ENTITIES_HAS_MARKETPLACE_ID_DAMAGED) {
         READ_ENTITY_PROPERTY(PROP_MARKETPLACE_ID, QString, setMarketplaceID);
     }
@@ -738,8 +749,6 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         }
     }
 
-    auto nodeList = DependencyManager::get<NodeList>();
-    const QUuid& myNodeID = nodeList->getSessionUUID();
     if (overwriteLocalData) {
         if (!_simulationOwner.matchesValidID(myNodeID)) {
             


### PR DESCRIPTION
grab.js was not behaving well after being converted to use the **spring** action.

The problem was that the action's instance was being thrashed (constantly created and deleted) by old updates coming from the entity-server.  The action would be created locally and then sent up to the entity-server, however if there were an incoming update from the entity-server then the action would be deleted when it was not found inside the action data -- its absence is interpreted as a deletion.  Meanwhile the update echo from the entity-server from the creation of the action would eventually re-create it, or maybe the grab.js script would re-create it when trying to update it by **id**.

Similarly there would be thrashing when the grabbed object was let go while moving -- the script would delete the action but unprocessed entity-server updates would recreate it, then still later updates would delete it, etc.  Sometimes the final result was that the action was deleted, but sometimes it would survive the cycles creating a "leaked" action that the script had forgotten about, and the object would now be pinned in place and future grabs would fight new action against old (who would win depended on how they were ordered in Bullet's list of actions -- typically the newer action would win).

The solution is to ignore entity-server updates on actions when the local interface owns the simulation.  This introduces a problem where multiple participants cannot edit actions simultaneously -- the owner of the simulation will ignore updates from others and re-assert their view of the object's state to the entity-server.  We'll have to live with this wart until we overhaul how the action properties are created/updated/deleted (e.g. maybe they should be REST-ful, and maybe we need server-side permission filters for some operations on actions).