### PR TITLE
Hydra hand and mouse fixes

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1568,7 +1568,9 @@ void Application::mouseMoveEvent(QMouseEvent* event, unsigned int deviceID) {
         return;
     }
 
-    _keyboardMouseDevice.mouseMoveEvent(event, deviceID);
+    if (deviceID == 0) {
+        _keyboardMouseDevice.mouseMoveEvent(event, deviceID);
+    }
 
 }
 
@@ -1589,7 +1591,9 @@ void Application::mousePressEvent(QMouseEvent* event, unsigned int deviceID) {
 
 
     if (activeWindow() == _window) {
-        _keyboardMouseDevice.mousePressEvent(event);
+        if (deviceID == 0) {
+            _keyboardMouseDevice.mousePressEvent(event);
+        }
 
         if (event->button() == Qt::LeftButton) {
             _mouseDragStarted = getTrueMouse();
@@ -1629,7 +1633,9 @@ void Application::mouseReleaseEvent(QMouseEvent* event, unsigned int deviceID) {
     }
 
     if (activeWindow() == _window) {
-        _keyboardMouseDevice.mouseReleaseEvent(event);
+        if (deviceID == 0) {
+            _keyboardMouseDevice.mouseReleaseEvent(event);
+        }
 
         if (event->button() == Qt::LeftButton) {
             _mousePressed = false;

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -120,8 +120,8 @@ void SkeletonModel::simulate(float deltaTime, bool fullUpdate) {
     Hand* hand = _owningAvatar->getHand();
     hand->getLeftRightPalmIndices(leftPalmIndex, rightPalmIndex);
 
-    const float HAND_RESTORATION_RATE = 0.25f;    
-    if (leftPalmIndex == -1 || rightPalmIndex == -1) {
+    const float HAND_RESTORATION_RATE = 0.25f;
+    if (leftPalmIndex == -1 && rightPalmIndex == -1) {
         // palms are not yet set, use mouse
         if (_owningAvatar->getHandState() == HAND_STATE_NULL) {
             restoreRightHandPosition(HAND_RESTORATION_RATE, PALM_PRIORITY);
@@ -138,8 +138,16 @@ void SkeletonModel::simulate(float deltaTime, bool fullUpdate) {
         restoreLeftHandPosition(HAND_RESTORATION_RATE, PALM_PRIORITY);
 
     } else {
-        applyPalmData(geometry.leftHandJointIndex, hand->getPalms()[leftPalmIndex]);
-        applyPalmData(geometry.rightHandJointIndex, hand->getPalms()[rightPalmIndex]);
+        if (leftPalmIndex != -1) {
+            applyPalmData(geometry.leftHandJointIndex, hand->getPalms()[leftPalmIndex]);
+        } else {
+            restoreLeftHandPosition(HAND_RESTORATION_RATE, PALM_PRIORITY);
+        }
+        if (rightPalmIndex != -1) {
+            applyPalmData(geometry.rightHandJointIndex, hand->getPalms()[rightPalmIndex]);
+        } else {
+            restoreRightHandPosition(HAND_RESTORATION_RATE, PALM_PRIORITY);
+        }
     }
 
     if (_isFirstPerson) {

--- a/interface/src/devices/SixenseManager.cpp
+++ b/interface/src/devices/SixenseManager.cpp
@@ -244,14 +244,6 @@ void SixenseManager::update(float deltaTime) {
             palm->setTrigger(data->trigger);
             palm->setJoystick(data->joystick_x, data->joystick_y);
 
-            handleButtonEvent(data->buttons, numActiveControllers - 1);
-            handleAxisEvent(data->joystick_x, data->joystick_y, data->trigger, numActiveControllers - 1);
-
-            // Emulate the mouse so we can use scripts
-            if (Menu::getInstance()->isOptionChecked(MenuOption::SixenseMouseInput) && !_controllersAtBase) {
-                emulateMouse(palm, numActiveControllers - 1);
-            }
-
             // NOTE: Sixense API returns pos data in millimeters but we IMMEDIATELY convert to meters.
             glm::vec3 position(data->pos[0], data->pos[1], data->pos[2]);
             position *= METERS_PER_MILLIMETER;
@@ -260,6 +252,15 @@ void SixenseManager::update(float deltaTime) {
             const float CONTROLLER_AT_BASE_DISTANCE = 0.075f;
             if (glm::length(position) < CONTROLLER_AT_BASE_DISTANCE) {
                 numControllersAtBase++;
+                palm->setActive(false);
+            } else {
+                handleButtonEvent(data->buttons, numActiveControllers - 1);
+                handleAxisEvent(data->joystick_x, data->joystick_y, data->trigger, numActiveControllers - 1);
+                
+                // Emulate the mouse so we can use scripts
+                if (Menu::getInstance()->isOptionChecked(MenuOption::SixenseMouseInput) && !_controllersAtBase) {
+                    emulateMouse(palm, numActiveControllers - 1);
+                }
             }
 
             // Transform the measured position into body frame.


### PR DESCRIPTION
- Hydras are handled separately
    - Moving either controller to the base station will deactivate that hand individually
    - Ignore input from controller if it's at the base station

- Emulated mouse events are no long sent back to the KeyboardMouseDevice
    - This will disable hydra right-click and drag to rotate camera (which was broken anyways), but it's possible to recreate this behavior via script.