### PR TITLE
Set creation stamp for spheres. 

### DIFF
--- a/libraries/entities/src/SphereEntityItem.cpp
+++ b/libraries/entities/src/SphereEntityItem.cpp
@@ -33,6 +33,7 @@ SphereEntityItem::SphereEntityItem(const EntityItemID& entityItemID, const Entit
         EntityItem(entityItemID, properties) 
 { 
     _type = EntityTypes::Sphere;
+    _created = properties.getCreated();
     setProperties(properties);
     _volumeMultiplier *= PI / 6.0f;
 }


### PR DESCRIPTION
(All other entities were already doing this.)

Without this, creating a sphere on the fly (e.g., in a script) would have it ignore non-default (e.g., dimension) property values.