### PR TITLE
cleanup of EntityItem ctors and friends

### DIFF
--- a/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
@@ -39,15 +39,7 @@ void RenderableSphereEntityItem::render(RenderArgs* args) {
     
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
-#define USE_MAGIC_WORKAROUND
-#ifdef USE_MAGIC_WORKAROUND
-    // It's a mystery how this actually works!
-    Transform transform = getTransformToCenter();
-    transform.setScale(transform.getScale());
-    batch.setModelTransform(transform); // use a transform with scale, rotation, registration point and translation
-#else // USE_MAGIC_WORKAROUND
     batch.setModelTransform(getTransformToCenter()); // use a transform with scale, rotation, registration point and translation
-#endif // USE_MAGIC_WORKAROUND
     DependencyManager::get<DeferredLightingEffect>()->renderSolidSphere(batch, 0.5f, SLICES, STACKS, sphereColor);
 
     RenderableDebugableEntityItem::render(this, args);

--- a/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
@@ -39,7 +39,15 @@ void RenderableSphereEntityItem::render(RenderArgs* args) {
     
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
+#define USE_MAGIC_WORKAROUND
+#ifdef USE_MAGIC_WORKAROUND
+    // It's a mystery how this actually works!
+    Transform transform = getTransformToCenter();
+    transform.setScale(transform.getScale());
+    batch.setModelTransform(transform); // use a transform with scale, rotation, registration point and translation
+#else // USE_MAGIC_WORKAROUND
     batch.setModelTransform(getTransformToCenter()); // use a transform with scale, rotation, registration point and translation
+#endif // USE_MAGIC_WORKAROUND
     DependencyManager::get<DeferredLightingEffect>()->renderSolidSphere(batch, 0.5f, SLICES, STACKS, sphereColor);
 
     RenderableDebugableEntityItem::render(this, args);

--- a/libraries/entities/src/BoxEntityItem.cpp
+++ b/libraries/entities/src/BoxEntityItem.cpp
@@ -29,7 +29,6 @@ BoxEntityItem::BoxEntityItem(const EntityItemID& entityItemID, const EntityItemP
         EntityItem(entityItemID) 
 {
     _type = EntityTypes::Box;
-    _created = properties.getCreated();
     setProperties(properties);
 }
 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -45,9 +45,7 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) :
     _lastEditedFromRemoteInRemoteTime(0),
     _created(UNKNOWN_CREATED_TIME),
     _changedOnServer(0),
-    _transform(ENTITY_ITEM_DEFAULT_ROTATION,
-               ENTITY_ITEM_DEFAULT_DIMENSIONS,
-               ENTITY_ITEM_DEFAULT_POSITION),
+    _transform(),
     _glowLevel(ENTITY_ITEM_DEFAULT_GLOW_LEVEL),
     _localRenderAlpha(ENTITY_ITEM_DEFAULT_LOCAL_RENDER_ALPHA),
     _density(ENTITY_ITEM_DEFAULT_DENSITY),
@@ -80,6 +78,10 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) :
     _physicsInfo(nullptr),
     _simulated(false)
 {
+    // explicitly set transform parts to set dirty flags used by batch rendering
+    _transform.setTranslation(ENTITY_ITEM_DEFAULT_POSITION);
+    _transform.setRotation(ENTITY_ITEM_DEFAULT_ROTATION);
+    _transform.setScale(ENTITY_ITEM_DEFAULT_DIMENSIONS);
     quint64 now = usecTimestampNow();
     _lastSimulated = now;
     _lastUpdated = now;

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1072,8 +1072,6 @@ void EntityItem::getAllTerseUpdateProperties(EntityItemProperties& properties) c
 
 bool EntityItem::setProperties(const EntityItemProperties& properties) {
     bool somethingChanged = false;
-    // just in case _created must be properly set before the rest we do it first
-    SET_ENTITY_PROPERTY_FROM_PROPERTIES(created, updateCreated);
 
     // these affect TerseUpdate properties
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(simulationOwner, setSimulationOwner);
@@ -1096,6 +1094,7 @@ bool EntityItem::setProperties(const EntityItemProperties& properties) {
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(friction, updateFriction);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(ignoreForCollisions, updateIgnoreForCollisions);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(collisionsWillMove, updateCollisionsWillMove);
+    SET_ENTITY_PROPERTY_FROM_PROPERTIES(created, updateCreated);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(lifetime, updateLifetime);
 
     // non-simulation properties below

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -85,11 +85,6 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) :
     _lastUpdated = now;
 }
 
-EntityItem::EntityItem(const EntityItemID& entityItemID, const EntityItemProperties& properties) : EntityItem(entityItemID)
-{
-    setProperties(properties);
-}
-
 EntityItem::~EntityItem() {
     // clear out any left-over actions
     EntityTree* entityTree = _element ? _element->getTree() : nullptr;
@@ -1077,6 +1072,8 @@ void EntityItem::getAllTerseUpdateProperties(EntityItemProperties& properties) c
 
 bool EntityItem::setProperties(const EntityItemProperties& properties) {
     bool somethingChanged = false;
+    // just in case _created must be properly set before the rest we do it first
+    SET_ENTITY_PROPERTY_FROM_PROPERTIES(created, updateCreated);
 
     // these affect TerseUpdate properties
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(simulationOwner, setSimulationOwner);
@@ -1099,7 +1096,6 @@ bool EntityItem::setProperties(const EntityItemProperties& properties) {
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(friction, updateFriction);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(ignoreForCollisions, updateIgnoreForCollisions);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(collisionsWillMove, updateCollisionsWillMove);
-    SET_ENTITY_PROPERTY_FROM_PROPERTIES(created, updateCreated);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(lifetime, updateLifetime);
 
     // non-simulation properties below

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -119,7 +119,6 @@ public:
     DONT_ALLOW_INSTANTIATION // This class can not be instantiated directly
 
     EntityItem(const EntityItemID& entityItemID);
-    EntityItem(const EntityItemID& entityItemID, const EntityItemProperties& properties);
     virtual ~EntityItem();
 
     // ID and EntityItemID related methods

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -772,6 +772,9 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
                         entityItemID = entityItem->getEntityItemID();
                         _myTree->setContainingElement(entityItemID, this);
                         _myTree->postAddEntity(entityItem);
+                        if (entityItem->getCreated() == UNKNOWN_CREATED_TIME) {
+                            entityItem->recordCreationTime();
+                        }
                     }
                 }
                 // Move the buffer forward to read more entities

--- a/libraries/entities/src/LightEntityItem.cpp
+++ b/libraries/entities/src/LightEntityItem.cpp
@@ -29,7 +29,7 @@ EntityItemPointer LightEntityItem::factory(const EntityItemID& entityID, const E
 
 // our non-pure virtual subclass for now...
 LightEntityItem::LightEntityItem(const EntityItemID& entityItemID, const EntityItemProperties& properties) :
-        EntityItem(entityItemID, properties) 
+        EntityItem(entityItemID) 
 {
     _type = EntityTypes::Light;
     

--- a/libraries/entities/src/LineEntityItem.cpp
+++ b/libraries/entities/src/LineEntityItem.cpp
@@ -38,7 +38,6 @@ LineEntityItem::LineEntityItem(const EntityItemID& entityItemID, const EntityIte
     _points(QVector<glm::vec3>(0))
 {
     _type = EntityTypes::Line;
-    _created = properties.getCreated();
     setProperties(properties);
     
     

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -33,7 +33,7 @@ EntityItemPointer ModelEntityItem::factory(const EntityItemID& entityID, const E
 }
 
 ModelEntityItem::ModelEntityItem(const EntityItemID& entityItemID, const EntityItemProperties& properties) :
-        EntityItem(entityItemID, properties)
+        EntityItem(entityItemID)
 {
     _type = EntityTypes::Model;
     setProperties(properties);

--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -61,7 +61,7 @@ EntityItemPointer ParticleEffectEntityItem::factory(const EntityItemID& entityID
 
 // our non-pure virtual subclass for now...
 ParticleEffectEntityItem::ParticleEffectEntityItem(const EntityItemID& entityItemID, const EntityItemProperties& properties) :
-    EntityItem(entityItemID, properties),
+    EntityItem(entityItemID),
     _maxParticles(DEFAULT_MAX_PARTICLES),
     _lifespan(DEFAULT_LIFESPAN),
     _emitRate(DEFAULT_EMIT_RATE),

--- a/libraries/entities/src/PolyVoxEntityItem.cpp
+++ b/libraries/entities/src/PolyVoxEntityItem.cpp
@@ -57,7 +57,6 @@ PolyVoxEntityItem::PolyVoxEntityItem(const EntityItemID& entityItemID, const Ent
     _voxelSurfaceStyle(PolyVoxEntityItem::DEFAULT_VOXEL_SURFACE_STYLE)
 {
     _type = EntityTypes::PolyVox;
-    _created = properties.getCreated();
     setProperties(properties);
 }
 

--- a/libraries/entities/src/SphereEntityItem.cpp
+++ b/libraries/entities/src/SphereEntityItem.cpp
@@ -30,7 +30,7 @@ EntityItemPointer SphereEntityItem::factory(const EntityItemID& entityID, const 
 
 // our non-pure virtual subclass for now...
 SphereEntityItem::SphereEntityItem(const EntityItemID& entityItemID, const EntityItemProperties& properties) :
-        EntityItem(entityItemID, properties) 
+        EntityItem(entityItemID) 
 { 
     _type = EntityTypes::Sphere;
     setProperties(properties);

--- a/libraries/entities/src/TextEntityItem.cpp
+++ b/libraries/entities/src/TextEntityItem.cpp
@@ -37,7 +37,6 @@ TextEntityItem::TextEntityItem(const EntityItemID& entityItemID, const EntityIte
         EntityItem(entityItemID) 
 {
     _type = EntityTypes::Text;
-    _created = properties.getCreated();
     setProperties(properties);
 }
 

--- a/libraries/entities/src/WebEntityItem.cpp
+++ b/libraries/entities/src/WebEntityItem.cpp
@@ -30,7 +30,6 @@ WebEntityItem::WebEntityItem(const EntityItemID& entityItemID, const EntityItemP
         EntityItem(entityItemID) 
 {
     _type = EntityTypes::Web;
-    _created = properties.getCreated();
     setProperties(properties);
 }
 

--- a/libraries/entities/src/ZoneEntityItem.cpp
+++ b/libraries/entities/src/ZoneEntityItem.cpp
@@ -37,7 +37,6 @@ ZoneEntityItem::ZoneEntityItem(const EntityItemID& entityItemID, const EntityIte
         EntityItem(entityItemID) 
 {
     _type = EntityTypes::Zone;
-    _created = properties.getCreated();
 
     _keyLightColor[RED_INDEX] = DEFAULT_KEYLIGHT_COLOR.red;
     _keyLightColor[GREEN_INDEX] = DEFAULT_KEYLIGHT_COLOR.green;


### PR DESCRIPTION
Philip noticed a bug where sphere entities were being created via script and would momentarily show up with DEFAULT dimensions before their correct size.  While trying to look into it I noticed some cruft in the Entity constructors and decided to clean them up.