### PR TITLE
Make sure that Audio isPlaying is correct

### DIFF
--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -93,6 +93,7 @@ void AudioInjector::injectAudio() {
 }
 
 void AudioInjector::restart() {
+    _isPlaying = true;
     connect(this, &AudioInjector::finished, this, &AudioInjector::restartPortionAfterFinished);
     if (!_isStarted || _isFinished) {
         emit finished();
@@ -270,6 +271,7 @@ void AudioInjector::injectToMixer() {
     }
 
     setIsFinished(true);
+    _isPlaying = !_isFinished; // Which can be false if a restart was requested
 }
 
 void AudioInjector::stop() {
@@ -277,6 +279,7 @@ void AudioInjector::stop() {
 
     if (_options.localOnly) {
         // we're only a local injector, so we can say we are finished right away too
+        _isPlaying = false;
         setIsFinished(true);
     }
 }
@@ -334,6 +337,7 @@ AudioInjector* AudioInjector::playSound(const QByteArray& buffer, const AudioInj
     injectorThread->setObjectName("Audio Injector Thread");
 
     AudioInjector* injector = new AudioInjector(buffer, options);
+    injector->_isPlaying = true;
     injector->setLocalAudioInterface(localInterface);
 
     injector->moveToThread(injectorThread);

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -62,7 +62,7 @@ public slots:
     
     void setCurrentSendPosition(int currentSendPosition) { _currentSendPosition = currentSendPosition; }
     float getLoudness() const { return _loudness; }
-    bool isPlaying() const { return !_isFinished; }
+    bool isPlaying() const { return _isPlaying; }
     void restartPortionAfterFinished();
     
 signals:
@@ -78,6 +78,7 @@ private:
     AudioInjectorOptions _options;
     bool _shouldStop = false;
     float _loudness = 0.0f;
+    bool _isPlaying = false;
     bool _isStarted = false;
     bool _isFinished = false;
     bool _shouldDeleteAfterFinish = false;


### PR DESCRIPTION
The isPlaying property of audio injectors (result of Audio.playSound in scripts) can be delayed in various combination of playSound()/stop()/restart(). This makes it track better.

Fix https://app.asana.com/0/30233891560551/41734486809354/f