### PR TITLE
Tweak the overlay rendering

### DIFF
--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -97,10 +97,10 @@ void ApplicationOverlay::renderOverlay(RenderArgs* renderArgs) {
     batch.clearFramebuffer(gpu::Framebuffer::BUFFER_COLOR0 | gpu::Framebuffer::BUFFER_DEPTH, color, depth, stencil);
 
     // Now render the overlay components together into a single texture
+    renderQmlUi(renderArgs); // renders a unit quad with the QML UI texture
     renderOverlays(renderArgs); // renders Scripts Overlay and AudioScope
     renderStatsAndLogs(renderArgs);  // currently renders nothing
     renderDomainConnectionStatusBorder(renderArgs); // renders the connected domain line
-    renderQmlUi(renderArgs); // renders a unit quad with the QML UI texture
 
     renderArgs->_context->syncCache();
     renderArgs->_context->render(batch);

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -34,6 +34,7 @@ private:
     void renderRearViewToFbo(RenderArgs* renderArgs);
     void renderRearView(RenderArgs* renderArgs);
     void renderQmlUi(RenderArgs* renderArgs);
+    void renderAudioScope(RenderArgs* renderArgs);
     void renderOverlays(RenderArgs* renderArgs);
     void buildFramebufferObject();
 


### PR DESCRIPTION
This places the QML overlays in the "back" and the other overlays on top. This is not ideal, but it fixes a couple of issues introduced by moving the text overlays into qml.