### PR TITLE
Fix deadlock when using textoverlay from main thread

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4474,7 +4474,11 @@ void Application::friendsWindowClosed() {
 }
 
 void Application::postLambdaEvent(std::function<void()> f) {
-    QCoreApplication::postEvent(this, new LambdaEvent(f));
+    if (this->thread() == QThread::currentThread()) {
+        f();
+    } else {
+        QCoreApplication::postEvent(this, new LambdaEvent(f));
+    }
 }
 
 void Application::initPlugins() {

--- a/interface/src/ui/overlays/TextOverlay.cpp
+++ b/interface/src/ui/overlays/TextOverlay.cpp
@@ -85,7 +85,6 @@ TextOverlay::TextOverlay() :
     _topMargin(DEFAULT_MARGIN),
     _fontSize(DEFAULT_FONTSIZE)
 {
-
     qApp->postLambdaEvent([=] {
         static std::once_flag once;
         std::call_once(once, [] {
@@ -117,7 +116,7 @@ TextOverlay::TextOverlay(const TextOverlay* textOverlay) :
         });
     });
     while (!_qmlElement) {
-        QThread::sleep(1);
+        QThread::msleep(1);
     }
 }
 
@@ -147,13 +146,11 @@ xColor TextOverlay::getBackgroundColor() {
 }
 
 void TextOverlay::render(RenderArgs* args) {
+    if (!_qmlElement) {
+        return;
+    }
     if (_visible != _qmlElement->isVisible()) {
         _qmlElement->setVisible(_visible);
-    }
-    float pulseLevel = updatePulse();
-    static float _oldPulseLevel = 0.0f;
-    if (pulseLevel != _oldPulseLevel) {
-
     }
 }
 


### PR DESCRIPTION
This is causing a crash when using the DDE face tracker calibration.  