### PR TITLE
Fix domain connection status border

### DIFF
--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -209,7 +209,8 @@ void ApplicationOverlay::renderDomainConnectionStatusBorder(RenderArgs* renderAr
         auto geometryCache = DependencyManager::get<GeometryCache>();
         geometryCache->useSimpleDrawPipeline(batch);
         batch.setProjectionTransform(mat4());
-        batch.setModelTransform(mat4());
+        batch.setModelTransform(Transform());
+        batch.setViewTransform(Transform());
         batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
         batch._glLineWidth(CONNECTION_STATUS_BORDER_LINE_WIDTH);
 


### PR DESCRIPTION
The domain connection status border will render tiny and follow the mouse in some cases because the view transform wasn't being properly set.  