### PR TITLE
DO NOT MERGE: Moving GL initialization to GLBackend and cleaning the gpu::Context in Application

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -482,6 +482,7 @@ private:
     glm::vec3 getSunDirection();
 
     void renderRearViewMirror(RenderArgs* renderArgs, const QRect& region, bool billboard = false);
+
     void setMenuShortcutsEnabled(bool enabled);
 
     static void attachNewHeadToNode(Node *newNode);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -69,6 +69,7 @@
 #include "octree/OctreePacketProcessor.h"
 #include "UndoStackScriptingInterface.h"
 
+#include "gpu/Context.h"
 #include "render/Engine.h"
 
 class QGLWidget;
@@ -325,6 +326,8 @@ public:
     render::EnginePointer getRenderEngine() { return _renderEngine; }
 
     render::ScenePointer getMain3DScene() const { return _main3DScene; }
+
+    gpu::ContextPointer getGPUContext() const { return _gpuContext; }
 
 signals:
 
@@ -633,6 +636,7 @@ private:
 
     render::ScenePointer _main3DScene{ new render::Scene() };
     render::EnginePointer _renderEngine{ new render::Engine() };
+    gpu::ContextPointer _gpuContext; // initialized during window creation
 
     Overlays _overlays;
     ApplicationOverlay _applicationOverlay;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1524,8 +1524,8 @@ void MyAvatar::maybeUpdateBillboard() {
             return;
         }
     }
-    gpu::Context context(new gpu::GLBackend());
-    RenderArgs renderArgs(&context);
+
+    RenderArgs renderArgs(qApp->getGPUContext());
     QImage image = qApp->renderAvatarBillboard(&renderArgs);
     _billboard.clear();
     QBuffer buffer(&_billboard);

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -49,7 +49,6 @@ private:
     gpu::TexturePointer _overlayDepthTexture;
     gpu::TexturePointer _overlayColorTexture;
     gpu::FramebufferPointer _overlayFramebuffer;
-
 };
 
 #endif // hifi_ApplicationOverlay_h

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -134,7 +134,7 @@ protected:
 
     friend class Shader;
 };
-
+typedef std::shared_ptr<Context> ContextPointer;
 
 };
 

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -91,6 +91,11 @@ GLBackend::GLBackend() :
 {
     initInput();
     initTransform();
+
+    qCDebug(gpulogging) << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
+    qCDebug(gpulogging) << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
+    qCDebug(gpulogging) << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
+    qCDebug(gpulogging) << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
 }
 
 GLBackend::~GLBackend() {

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -8,13 +8,12 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+#include <mutex>
 #include "GPULogging.h"
 #include "GLBackendShared.h"
 #include <glm/gtc/type_ptr.hpp>
 
 using namespace gpu;
-
-bool GLBackend::_initialized = false;
 
 GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] = 
 {
@@ -91,7 +90,8 @@ GLBackend::GLBackend() :
     _pipeline(),
     _output()
 {
-    if (!_initialized) {
+    static std::once_flag once;
+    std::call_once(once, [] {
         qCDebug(gpulogging) << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
         qCDebug(gpulogging) << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
         qCDebug(gpulogging) << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
@@ -118,8 +118,7 @@ GLBackend::GLBackend() :
             qCDebug(gpulogging, "V-Sync is %s\n", (swapInterval > 0 ? "ON" : "OFF"));
         }*/
 #endif
-        _initialized = true;
-    }
+    });
 
     initInput();
     initTransform();

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -448,6 +448,7 @@ protected:
     typedef void (GLBackend::*CommandCall)(Batch&, uint32);
     static CommandCall _commandCalls[Batch::NUM_COMMANDS];
 
+    static bool _initialized;
 };
 
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -447,8 +447,6 @@ protected:
 
     typedef void (GLBackend::*CommandCall)(Batch&, uint32);
     static CommandCall _commandCalls[Batch::NUM_COMMANDS];
-
-    static bool _initialized;
 };
 
 

--- a/libraries/render-utils/src/TextureCache.cpp
+++ b/libraries/render-utils/src/TextureCache.cpp
@@ -237,27 +237,6 @@ GLuint TextureCache::getPrimaryDepthTextureID() {
     return gpu::GLBackend::getTextureID(getPrimaryDepthTexture());
 }
 
-void TextureCache::setPrimaryDrawBuffers(bool color, bool normal, bool specular) {
-    gpu::Batch batch;
-    setPrimaryDrawBuffers(batch, color, normal, specular);
-    gpu::GLBackend::renderBatch(batch);
-}
-    
-void TextureCache::setPrimaryDrawBuffers(gpu::Batch& batch, bool color, bool normal, bool specular) {
-    GLenum buffers[3];
-    int bufferCount = 0;
-    if (color) {
-        buffers[bufferCount++] = GL_COLOR_ATTACHMENT0;
-    }
-    if (normal) {
-        buffers[bufferCount++] = GL_COLOR_ATTACHMENT1;
-    }
-    if (specular) {
-        buffers[bufferCount++] = GL_COLOR_ATTACHMENT2;
-    }
-    batch._glDrawBuffers(bufferCount, buffers);
-}
-
 gpu::FramebufferPointer TextureCache::getSecondaryFramebuffer() {
     if (!_secondaryFramebuffer) {
         _secondaryFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create(gpu::Element::COLOR_RGBA_32, _frameBufferSize.width(), _frameBufferSize.height()));

--- a/libraries/render-utils/src/TextureCache.h
+++ b/libraries/render-utils/src/TextureCache.h
@@ -90,11 +90,6 @@ public:
     /// Returns the framebuffer object used to render shadow maps;
     gpu::FramebufferPointer getShadowFramebuffer();
 
-
-    // The framebuffer used for the selfie view of the avatar. used for creating the billboard view and the rearViewMirror image
-    gpu::FramebufferPointer getSelfieFramebuffer();
-
-
 protected:
 
     virtual QSharedPointer<Resource> createResource(const QUrl& url,

--- a/libraries/render-utils/src/TextureCache.h
+++ b/libraries/render-utils/src/TextureCache.h
@@ -79,10 +79,6 @@ public:
     /// Returns the ID of the primary framebuffer object's depth texture.  This contains the Z buffer used in rendering.
     uint32_t getPrimaryDepthTextureID();
 
-    /// Enables or disables draw buffers on the primary framebuffer.  Note: the primary framebuffer must be bound.
-    void setPrimaryDrawBuffers(bool color, bool normal = false, bool specular = false);
-    void setPrimaryDrawBuffers(gpu::Batch& batch, bool color, bool normal = false, bool specular = false);
-    
     /// Returns a pointer to the secondary framebuffer object, used as an additional render target when performing full
     /// screen effects.
     gpu::FramebufferPointer getSecondaryFramebuffer();
@@ -93,6 +89,11 @@ public:
     
     /// Returns the framebuffer object used to render shadow maps;
     gpu::FramebufferPointer getShadowFramebuffer();
+
+
+    // The framebuffer used for the selfie view of the avatar. used for creating the billboard view and the rearViewMirror image
+    gpu::FramebufferPointer getSelfieFramebuffer();
+
 
 protected:
 

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -80,7 +80,7 @@ public:
         RENDER_DEBUG_SIMULATION_OWNERSHIP = 2,
     };
     
-    RenderArgs(gpu::Context* context = nullptr,
+    RenderArgs(std::shared_ptr<gpu::Context> context = nullptr,
                OctreeRenderer* renderer = nullptr,
                ViewFrustum* viewFrustum = nullptr,
                float sizeScale = 1.0f,
@@ -102,7 +102,7 @@ public:
     _shouldRender(shouldRender) {
     }
 
-    gpu::Context* _context = nullptr;
+    std::shared_ptr<gpu::Context> _context = nullptr;
     OctreeRenderer* _renderer = nullptr;
     ViewFrustum* _viewFrustum = nullptr;
     glm::ivec4 _viewport{ 0, 0, 1, 1 };


### PR DESCRIPTION
- Introduce a smart pointer on the gpuCOntext in the renderArgs and all pointing tto the Application unique gpuContext

- Move the gl initialization in GLBackend on the first time created

