### PR TITLE
fix crash for convex hull of co-planar points

### DIFF
--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -43,9 +43,18 @@ btConvexHullShape* ShapeFactory::createConvexHull(const QVector<glm::vec3>& poin
 
     const float MIN_MARGIN = 0.01f;
     glm::vec3 diagonal = maxCorner - minCorner;
-    float minDimension = glm::min(diagonal[0], diagonal[1]);
-    minDimension = glm::min(minDimension, diagonal[2]);
-    margin = glm::min(glm::max(0.5f * minDimension, MIN_MARGIN), margin);
+    float smallestDimension = glm::min(diagonal[0], diagonal[1]);
+    smallestDimension = glm::min(smallestDimension, diagonal[2]);
+    const float MIN_DIMENSION = 2.0f * MIN_MARGIN + 0.001f;
+    if (smallestDimension < MIN_DIMENSION) {
+        for (int i = 0; i < 3; ++i) {
+            if (diagonal[i] < MIN_DIMENSION) {
+                diagonal[i] = MIN_DIMENSION;
+            }
+        }
+        smallestDimension = MIN_DIMENSION;
+    }
+    margin = glm::min(glm::max(0.5f * smallestDimension, MIN_MARGIN), margin);
     hull->setMargin(margin);
 
     // add the points, correcting for margin


### PR DESCRIPTION
This is a theoretical fix for a crash bug that @birarda noticed at the **entry** location.

The problem is that we're trying to compute the convex-hull of 4 co-planar points.  We perform some "margin reduction" magic when the collection of points have small dimensions (less than the default margin of the convex-hull shape) and these margin reduction calculations are dividing by zero when the bounding box of the point collection has a zero width along one of the cardinal axes.

The solution is to make sure the "measured" bounding box never has a component that is smaller than some non-zero minimum (2 * MIN_MARGIN + 0.001 = 22mm).