### PR TITLE
WL#20632 - Remove unused postLighting variable from code

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -586,7 +586,7 @@ void Avatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool
             getHand()->render(renderArgs, false);
         }
     }
-    getHead()->render(renderArgs, 1.0f, renderFrustum, postLighting);
+    getHead()->render(renderArgs, 1.0f, renderFrustum);
 }
 
 bool Avatar::shouldRenderHead(const RenderArgs* renderArgs) const {

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -316,15 +316,14 @@ void Avatar::removeFromScene(AvatarSharedPointer self, std::shared_ptr<render::S
     }
 }
 
-void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, bool postLighting) {
+void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
     if (_referential) {
         _referential->update();
     }
 
     auto& batch = *renderArgs->_batch;
 
-    if (postLighting &&
-        glm::distance(DependencyManager::get<AvatarManager>()->getMyAvatar()->getPosition(), _position) < 10.0f) {
+    if (glm::distance(DependencyManager::get<AvatarManager>()->getMyAvatar()->getPosition(), _position) < 10.0f) {
         auto geometryCache = DependencyManager::get<GeometryCache>();
         auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
 
@@ -414,9 +413,9 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, boo
                       : GLOW_FROM_AVERAGE_LOUDNESS;
 
         // render body
-        renderBody(renderArgs, frustum, postLighting, glowLevel);
+        renderBody(renderArgs, frustum, glowLevel);
 
-        if (!postLighting && renderArgs->_renderMode != RenderArgs::SHADOW_RENDER_MODE) {
+        if (renderArgs->_renderMode != RenderArgs::SHADOW_RENDER_MODE) {
             // add local lights
             const float BASE_LIGHT_DISTANCE = 2.0f;
             const float LIGHT_EXPONENT = 1.0f;
@@ -431,21 +430,17 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, boo
             }
         }
 
-        if (postLighting) {
-            bool renderSkeleton = Menu::getInstance()->isOptionChecked(MenuOption::RenderSkeletonCollisionShapes);
-            bool renderHead = Menu::getInstance()->isOptionChecked(MenuOption::RenderHeadCollisionShapes);
-            bool renderBounding = Menu::getInstance()->isOptionChecked(MenuOption::RenderBoundingCollisionShapes);
-
-            if (renderSkeleton) {
-                _skeletonModel.renderJointCollisionShapes(0.7f);
-            }
-
-            if (renderHead && shouldRenderHead(renderArgs)) {
-                getHead()->getFaceModel().renderJointCollisionShapes(0.7f);
-            }
-            if (renderBounding && shouldRenderHead(renderArgs)) {
-                _skeletonModel.renderBoundingCollisionShapes(*renderArgs->_batch, 0.7f);
-            }
+        bool renderSkeleton = Menu::getInstance()->isOptionChecked(MenuOption::RenderSkeletonCollisionShapes);
+        bool renderHead = Menu::getInstance()->isOptionChecked(MenuOption::RenderHeadCollisionShapes);
+        bool renderBounding = Menu::getInstance()->isOptionChecked(MenuOption::RenderBoundingCollisionShapes);
+        if (renderSkeleton) {
+            _skeletonModel.renderJointCollisionShapes(0.7f);
+        }
+        if (renderHead && shouldRenderHead(renderArgs)) {
+            getHead()->getFaceModel().renderJointCollisionShapes(0.7f);
+        }
+        if (renderBounding && shouldRenderHead(renderArgs)) {
+            _skeletonModel.renderBoundingCollisionShapes(*renderArgs->_batch, 0.7f);
         }
 
         // Stack indicator spheres
@@ -569,22 +564,18 @@ void Avatar::fixupModelsInScene() {
     scene->enqueuePendingChanges(pendingChanges);
 }
 
-void Avatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool postLighting, float glowLevel) {
+void Avatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, float glowLevel) {
 
     fixupModelsInScene();
     
     {
         if (_shouldRenderBillboard || !(_skeletonModel.isRenderable() && getHead()->getFaceModel().isRenderable())) {
-            if (postLighting || renderArgs->_renderMode == RenderArgs::SHADOW_RENDER_MODE) {
-                // render the billboard until both models are loaded
-                renderBillboard(renderArgs);
-            }
+            // render the billboard until both models are loaded
+            renderBillboard(renderArgs);
             return;
         }
 
-        if (postLighting) {
-            getHand()->render(renderArgs, false);
-        }
+        getHand()->render(renderArgs, false);
     }
     getHead()->render(renderArgs, 1.0f, renderFrustum);
 }

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -81,8 +81,7 @@ public:
     void init();
     void simulate(float deltaTime);
 
-    virtual void render(RenderArgs* renderArgs, const glm::vec3& cameraPosition,
-        bool postLighting = false);
+    virtual void render(RenderArgs* renderArgs, const glm::vec3& cameraPosition);
 
     bool addToScene(AvatarSharedPointer self, std::shared_ptr<render::Scene> scene,
                             render::PendingChanges& pendingChanges);
@@ -235,7 +234,7 @@ protected:
 
     Transform calculateDisplayNameTransform(const ViewFrustum& frustum, float fontSize, const glm::ivec4& viewport) const;
     void renderDisplayName(gpu::Batch& batch, const ViewFrustum& frustum, const glm::ivec4& viewport) const;
-    virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool postLighting, float glowLevel = 0.0f);
+    virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, float glowLevel = 0.0f);
     virtual bool shouldRenderHead(const RenderArgs* renderArgs) const;
     virtual void fixupModelsInScene();
 

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -293,7 +293,7 @@ void Head::relaxLean(float deltaTime) {
     _deltaLeanForward *= relaxationFactor;
 }
 
-void Head::render(RenderArgs* renderArgs, float alpha, ViewFrustum* renderFrustum, bool postLighting) {
+void Head::render(RenderArgs* renderArgs, float alpha, ViewFrustum* renderFrustum) {
     if (_renderLookatVectors) {
         renderLookatVectors(renderArgs, _leftEyePosition, _rightEyePosition, getCorrectedLookAtPosition());
     }

--- a/interface/src/avatar/Head.h
+++ b/interface/src/avatar/Head.h
@@ -33,7 +33,7 @@ public:
     void init();
     void reset();
     void simulate(float deltaTime, bool isMine, bool billboard = false);
-    void render(RenderArgs* renderArgs, float alpha, ViewFrustum* renderFrustum, bool postLighting);
+    void render(RenderArgs* renderArgs, float alpha, ViewFrustum* renderFrustum);
     void setScale(float scale);
     void setPosition(glm::vec3 position) { _position = position; }
     void setAverageLoudness(float averageLoudness) { _averageLoudness = averageLoudness; }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1236,7 +1236,7 @@ void MyAvatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bo
 
     //  Render head so long as the camera isn't inside it
     if (shouldRenderHead(renderArgs)) {
-        getHead()->render(renderArgs, 1.0f, renderFrustum, postLighting);
+        getHead()->render(renderArgs, 1.0f, renderFrustum);
     }
     getHand()->render(renderArgs, true);
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -332,13 +332,13 @@ void MyAvatar::updateFromTrackers(float deltaTime) {
 
 
 // virtual
-void MyAvatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, bool postLighting) {
+void MyAvatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
     // don't render if we've been asked to disable local rendering
     if (!_shouldRender) {
         return; // exit early
     }
 
-    Avatar::render(renderArgs, cameraPosition, postLighting);
+    Avatar::render(renderArgs, cameraPosition);
 
     // don't display IK constraints in shadow mode
     if (Menu::getInstance()->isOptionChecked(MenuOption::ShowIKConstraints) &&
@@ -1226,7 +1226,7 @@ void MyAvatar::attach(const QString& modelURL, const QString& jointName, const g
     Avatar::attach(modelURL, jointName, translation, rotation, scale, allowDuplicates, useSaved);
 }
 
-void MyAvatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool postLighting, float glowLevel) {
+void MyAvatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, float glowLevel) {
 
     if (!(_skeletonModel.isRenderable() && getHead()->getFaceModel().isRenderable())) {
         return; // wait until all models are loaded

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -45,8 +45,8 @@ public:
     void preRender(RenderArgs* renderArgs);
     void updateFromTrackers(float deltaTime);
 
-    virtual void render(RenderArgs* renderArgs, const glm::vec3& cameraPosition, bool postLighting = false) override;
-    virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, bool postLighting, float glowLevel = 0.0f) override;
+    virtual void render(RenderArgs* renderArgs, const glm::vec3& cameraPositio) override;
+    virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, float glowLevel = 0.0f) override;
     virtual bool shouldRenderHead(const RenderArgs* renderArgs) const override;
 
     // setters

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -13,6 +13,7 @@
 #include <QMultiMap>
 
 #include <CapsuleShape.h>
+#include <DeferredLightingEffect.h>
 #include <SphereShape.h>
 
 #include "Application.h"
@@ -785,31 +786,34 @@ void SkeletonModel::resetShapePositionsToDefaultPose() {
 void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float alpha) {
     const int BALL_SUBDIVISIONS = 10;
     if (_shapes.isEmpty()) {
-        // the bounding shape has not been propery computed
+        // the bounding shape has not been properly computed
         // so no need to render it
         return;
     }
 
-    // draw a blue sphere at the capsule endpoint
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
+    Transform transform; // = Transform();
+
+    // draw a blue sphere at the capsule end point
     glm::vec3 endPoint;
     _boundingShape.getEndPoint(endPoint);
     endPoint = endPoint + _translation;
-    Transform transform = Transform();
     transform.setTranslation(endPoint);
     batch.setModelTransform(transform);
-    auto geometryCache = DependencyManager::get<GeometryCache>();
-    geometryCache->renderSphere(batch, _boundingShape.getRadius(), BALL_SUBDIVISIONS, BALL_SUBDIVISIONS, 
+    deferredLighting->bindSimpleProgram(batch);
+    geometryCache->renderSphere(batch, _boundingShape.getRadius(), BALL_SUBDIVISIONS, BALL_SUBDIVISIONS,
                                 glm::vec4(0.6f, 0.6f, 0.8f, alpha));
 
-    // draw a yellow sphere at the capsule startpoint
+    // draw a yellow sphere at the capsule start point
     glm::vec3 startPoint;
     _boundingShape.getStartPoint(startPoint);
     startPoint = startPoint + _translation;
     glm::vec3 axis = endPoint - startPoint;
-    Transform axisTransform = Transform();
-    axisTransform.setTranslation(-axis);
-    batch.setModelTransform(axisTransform);
-    geometryCache->renderSphere(batch, _boundingShape.getRadius(), BALL_SUBDIVISIONS, BALL_SUBDIVISIONS, 
+    transform.setTranslation(startPoint);
+    batch.setModelTransform(transform);
+    deferredLighting->bindSimpleProgram(batch);
+    geometryCache->renderSphere(batch, _boundingShape.getRadius(), BALL_SUBDIVISIONS, BALL_SUBDIVISIONS,
                                 glm::vec4(0.8f, 0.8f, 0.6f, alpha));
 
     // draw a green cylinder between the two points


### PR DESCRIPTION
It was always false, preventing rendering of certain items:
- Avatar collision bounds
- Hand information
- Hand IK constraints
- Avatar billboard

Note: Rendering of hand IK constraints and avatar billboards are still broken; these are separate issues.