### PR TITLE
Fix ray picking working intermittently

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3395,9 +3395,6 @@ void Application::renderRearViewMirror(RenderArgs* renderArgs, const QRect& regi
         renderArgs->_context->render(batch);
     }
 
-    bool updateViewFrustum = false;
-    loadViewFrustum(_mirrorCamera, _viewFrustum);
-
     // render rear mirror view
     displaySide(renderArgs, _mirrorCamera, true, billboard);
 


### PR DESCRIPTION
Ray picking relies on the Application's viewFrustum which was being set
to both the main camera and mirror camera for their respective pass
while rendering. This makes sure the viewFrustum only ever holds the
    main camera. Application::_displayViewFrustum still gets updated to
    the current camera while rendering.