### PR TITLE
Fix JS calls to computePickRay() when mini-mirror is showing

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2963,11 +2963,7 @@ PickRay Application::computePickRay(float x, float y) const {
     if (isHMDMode()) {
         getApplicationCompositor().computeHmdPickRay(glm::vec2(x, y), result.origin, result.direction);
     } else {
-        if (QThread::currentThread() == activeRenderingThread) {
-            getDisplayViewFrustum()->computePickRay(x, y, result.origin, result.direction);
-        } else {
-            getViewFrustum()->computePickRay(x, y, result.origin, result.direction);
-        }
+        getViewFrustum()->computePickRay(x, y, result.origin, result.direction);
     }
     return result;
 }


### PR DESCRIPTION
The mini-mirror will side effect that Application::getDisplayViewFrustum(), which was being used by computeRayPick()... Instead always use the _viewFrustum for caluclating the pick ray, not the _displayViewFrustum.