### PR TITLE
Fix rendering of primitive objects on Windows

### DIFF
--- a/libraries/render-utils/src/DeferredBufferWrite.slh
+++ b/libraries/render-utils/src/DeferredBufferWrite.slh
@@ -21,8 +21,8 @@ float evalOpaqueFinalAlpha(float alpha, float mapAlpha) {
     return mix(alpha * glowIntensity, 1.0 - alpha * glowIntensity, step(mapAlpha, alphaThreshold));
 }
 
-const DEFAULT_SPECULAR = vec3(0.1);
-const DEFAULT_SHININESS = 10;
+const vec3 DEFAULT_SPECULAR = vec3(0.1);
+const float DEFAULT_SHININESS = 10;
 
 void packDeferredFragment(vec3 normal, float alpha, vec3 diffuse, vec3 specular, float shininess) {
     if (alpha != glowIntensity) {

--- a/libraries/render-utils/src/DeferredBufferWrite.slh
+++ b/libraries/render-utils/src/DeferredBufferWrite.slh
@@ -21,6 +21,9 @@ float evalOpaqueFinalAlpha(float alpha, float mapAlpha) {
     return mix(alpha * glowIntensity, 1.0 - alpha * glowIntensity, step(mapAlpha, alphaThreshold));
 }
 
+const DEFAULT_SPECULAR = vec3(0.1);
+const DEFAULT_SHININESS = 10;
+
 void packDeferredFragment(vec3 normal, float alpha, vec3 diffuse, vec3 specular, float shininess) {
     if (alpha != glowIntensity) {
         discard;

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -142,6 +142,10 @@ void DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch, bool textured,
                                                bool emmisive, bool depthBias) {
     SimpleProgramKey config{textured, culled, emmisive, depthBias};
     batch.setPipeline(getPipeline(config));
+
+    gpu::ShaderPointer program = (config.isEmissive()) ? _emissiveShader : _simpleShader;
+    int glowIntensity = program->getUniforms().findLocation("glowIntensity");
+    batch._glUniform1f(glowIntensity, 1.0f);
     
     if (!config.isTextured()) {
         // If it is not textured, bind white texture and keep using textured pipeline

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -22,6 +22,5 @@ void main(void) {
         normalize(interpolatedNormal.xyz), 
         glowIntensity,
         gl_Color.rgb,
-        vec3(0.1),
-        10);
+         DEFAULT_SPECULAR, DEFAULT_SHININESS);
 }

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -21,7 +21,7 @@ void main(void) {
     packDeferredFragment(
         normalize(interpolatedNormal.xyz), 
         glowIntensity,
-        vec3(0,0,1), //gl_Color.rgb,
-        vec3(0,0,1), //gl_FrontMaterial.specular.rgb,
-        1); //gl_FrontMaterial.shininess);
+        gl_Color.rgb,
+        vec3(0.1),
+        10);
 }

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -21,7 +21,7 @@ void main(void) {
     packDeferredFragment(
         normalize(interpolatedNormal.xyz), 
         glowIntensity,
-        gl_Color.rgb,
-        gl_FrontMaterial.specular.rgb,
-        gl_FrontMaterial.shininess);
+        vec3(0,0,1), //gl_Color.rgb,
+        vec3(0,0,1), //gl_FrontMaterial.specular.rgb,
+        1); //gl_FrontMaterial.shininess);
 }

--- a/libraries/render-utils/src/simple.slv
+++ b/libraries/render-utils/src/simple.slv
@@ -23,7 +23,7 @@ void main(void) {
     gl_TexCoord[0] = gl_MultiTexCoord0;
     
     // pass along the diffuse color
-    gl_FrontColor = vec4(0,1,0,1); //gl_Color;
+    gl_FrontColor = gl_Color;
     
     // standard transform
     TransformCamera cam = getTransformCamera();

--- a/libraries/render-utils/src/simple.slv
+++ b/libraries/render-utils/src/simple.slv
@@ -23,7 +23,7 @@ void main(void) {
     gl_TexCoord[0] = gl_MultiTexCoord0;
     
     // pass along the diffuse color
-    gl_FrontColor = gl_Color;
+    gl_FrontColor = vec4(0,1,0,1); //gl_Color;
     
     // standard transform
     TransformCamera cam = getTransformCamera();

--- a/libraries/render-utils/src/simple_textured.slf
+++ b/libraries/render-utils/src/simple_textured.slf
@@ -25,8 +25,8 @@ void main(void) {
     
     packDeferredFragment(
          normalize(interpolatedNormal.xyz),
-         glowIntensity * texel.a,
-         gl_Color.rgb * texel.rgb,
-         gl_FrontMaterial.specular.rgb,
-         gl_FrontMaterial.shininess);
+         glowIntensity, // glowIntensity * texel.a,
+         vec3(0,0,1), // gl_Color.rgb * texel.rgb,
+         vec3(0,0,1), // gl_FrontMaterial.specular.rgb,
+         1); // gl_FrontMaterial.shininess);
 }

--- a/libraries/render-utils/src/simple_textured.slf
+++ b/libraries/render-utils/src/simple_textured.slf
@@ -27,6 +27,5 @@ void main(void) {
          normalize(interpolatedNormal.xyz),
          glowIntensity * texel.a,
          gl_Color.rgb * texel.rgb,
-         vec3(0.1),
-         10);
+         DEFAULT_SPECULAR, DEFAULT_SHININESS);
 }

--- a/libraries/render-utils/src/simple_textured.slf
+++ b/libraries/render-utils/src/simple_textured.slf
@@ -25,8 +25,8 @@ void main(void) {
     
     packDeferredFragment(
          normalize(interpolatedNormal.xyz),
-         glowIntensity, // glowIntensity * texel.a,
-         gl_Color.rgb, // gl_Color.rgb * texel.rgb,
-         gl_FrontMaterial.specular.rgb,
-         gl_FrontMaterial.shininess);
+         glowIntensity * texel.a,
+         gl_Color.rgb * texel.rgb,
+         vec3(0.1),
+         10);
 }

--- a/libraries/render-utils/src/simple_textured.slf
+++ b/libraries/render-utils/src/simple_textured.slf
@@ -26,7 +26,7 @@ void main(void) {
     packDeferredFragment(
          normalize(interpolatedNormal.xyz),
          glowIntensity, // glowIntensity * texel.a,
-         vec3(0,0,1), // gl_Color.rgb * texel.rgb,
-         vec3(0,0,1), // gl_FrontMaterial.specular.rgb,
-         1); // gl_FrontMaterial.shininess);
+         gl_Color.rgb, // gl_Color.rgb * texel.rgb,
+         gl_FrontMaterial.specular.rgb,
+         gl_FrontMaterial.shininess);
 }

--- a/libraries/render-utils/src/simple_textured_emisive.slf
+++ b/libraries/render-utils/src/simple_textured_emisive.slf
@@ -27,7 +27,7 @@ void main(void) {
          normalize(interpolatedNormal.xyz),
          glowIntensity * texel.a,
          gl_Color.rgb,
-         gl_FrontMaterial.specular.rgb,
-         gl_FrontMaterial.shininess,
+         vec3(0.1),
+         10,
          texel.rgb);
 }

--- a/libraries/render-utils/src/simple_textured_emisive.slf
+++ b/libraries/render-utils/src/simple_textured_emisive.slf
@@ -27,7 +27,6 @@ void main(void) {
          normalize(interpolatedNormal.xyz),
          glowIntensity * texel.a,
          gl_Color.rgb,
-         vec3(0.1),
-         10,
+         DEFAULT_SPECULAR, DEFAULT_SHININESS,
          texel.rgb);
 }


### PR DESCRIPTION
The simple program fragment shader was referencing gl_FrontMaterial which wasn't set, so we'd get random coloration results on windows.