### PR TITLE
allow the QEvent queue in Application to get behind

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1798,13 +1798,6 @@ void Application::idle() {
     }
     double timeSinceLastUpdate = (double)_lastTimeUpdated.nsecsElapsed() / 1000000.0;
     if (timeSinceLastUpdate > targetFramePeriod) {
-        
-        {
-            static const int IDLE_EVENT_PROCESS_MAX_TIME_MS = 2;
-            PerformanceTimer perfTimer("processEvents");
-            processEvents(QEventLoop::AllEvents, IDLE_EVENT_PROCESS_MAX_TIME_MS);
-        }
-        
         _lastTimeUpdated.start();
         {
             PerformanceTimer perfTimer("update");
@@ -1836,12 +1829,8 @@ void Application::idle() {
         // Once rendering is off on another thread we should be able to have Application::idle run at start(0) in
         // perpetuity and not expect events to get backed up.
         
-        static const int IDLE_TIMER_DELAY_MS = 0;
-        int desiredInterval = _glWidget->isThrottleRendering() ? THROTTLED_IDLE_TIMER_DELAY : IDLE_TIMER_DELAY_MS;
-        
-        if (idleTimer->interval() != desiredInterval) {
-            idleTimer->start(desiredInterval);
-        }
+        static const int IDLE_TIMER_DELAY_MS = 2;
+        idleTimer->start(_glWidget->isThrottleRendering() ? THROTTLED_IDLE_TIMER_DELAY : IDLE_TIMER_DELAY_MS);
     }
 
     // check for any requested background downloads.


### PR DESCRIPTION
This brings back the previous idleTimer restart we had that allowed the Application to stay mostly in time for UI events but with touch events definitely getting backed up. For now this is better than having the window lock up.

Tomorrow I'll see if I can find which events specifically are taking lots of time to process on the main thread.