### PR TITLE
Add ability to update title of WebWindow after it's created

### DIFF
--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -142,3 +142,7 @@ QScriptValue WebWindowClass::constructor(QScriptContext* context, QScriptEngine*
 
     return engine->newQObject(retVal);
 }
+
+void WebWindowClass::setTitle(const QString& title) {
+    _windowWidget->setWindowTitle(title);
+}

--- a/interface/src/scripting/WebWindowClass.h
+++ b/interface/src/scripting/WebWindowClass.h
@@ -48,6 +48,7 @@ public slots:
     void raise();
     ScriptEventBridge* getEventBridge() const { return _eventBridge; }
     void addEventBridgeToWindowObject();
+    void setTitle(const QString& title);
 
 signals:
     void closed();


### PR DESCRIPTION
Enables the following in JavaScript

window = new WebWindow("title", ...);
...
window.setTitle("new title");