### PR TITLE
hull creation tool ignores walls in fatten-mesh mode

### DIFF
--- a/tools/vhacd-util/src/VHACDUtil.cpp
+++ b/tools/vhacd-util/src/VHACDUtil.cpp
@@ -118,6 +118,13 @@ void vhacd::VHACDUtil::fattenMeshes(const FBXMesh& mesh, FBXMesh& result,
         glm::vec3 p2 = result.vertices[index2];
         glm::vec3 av = (p0 + p1 + p2) / 3.0f; // center of the triangular face
 
+        glm::vec3 normal = glm::normalize(glm::cross(p1 - p0, p2 - p0));
+        float threshold = 1.0f / sqrtf(3.0f);
+        if (normal.y > -threshold && normal.y < threshold) {
+            // this triangle is more a wall than a floor, skip it.
+            continue;
+        }
+
         float dropAmount = 0;
         dropAmount = glm::max(glm::length(p1 - p0), dropAmount);
         dropAmount = glm::max(glm::length(p2 - p1), dropAmount);


### PR DESCRIPTION
Adjustment to command-line hull creation tool -- when creating a walking surface from a flat mesh, ignore triangles with normals that are not mostly up or down.