### PR TITLE
CR for 20591 - Fix setting WebWindow's width and height

### DIFF
--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -57,7 +57,7 @@ WebWindowClass::WebWindowClass(const QString& title, const QString& url, int wid
     } else {
         auto dialogWidget = new QDialog(Application::getInstance()->getWindow(), Qt::Window);
         dialogWidget->setWindowTitle(title);
-        dialogWidget->setMinimumSize(width, height);
+        dialogWidget->resize(width, height);
         connect(dialogWidget, &QDialog::finished, this, &WebWindowClass::hasClosed);
 
         auto layout = new QVBoxLayout(dialogWidget);


### PR DESCRIPTION
Width and height parameters now set the WebWindow's width and height
instead of its minimum size, when not part of a tool window.