### PR TITLE
Fix for memory corruption in Sixense ctor

### DIFF
--- a/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
@@ -264,7 +264,8 @@ const float MINIMUM_ARM_REACH = 0.3f; // meters
 const float MAXIMUM_NOISE_LEVEL = 0.05f; // meters
 const quint64 LOCK_DURATION = USECS_PER_SECOND / 4;     // time for lock to be acquired
 
-void SixenseManager::updateCalibration(const sixenseControllerData* controllers) {
+void SixenseManager::updateCalibration(void* controllersX) {
+    auto controllers = reinterpret_cast<sixenseControllerData*>(controllersX);
     const sixenseControllerData* dataLeft = controllers;
     const sixenseControllerData* dataRight = controllers + 1;
 

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.h
@@ -27,6 +27,8 @@
 #include "InputPlugin.h"
 #include "InputDevice.h"
 
+class QLibrary;
+
 const unsigned int BUTTON_0 = 1U << 0; // the skinny button between 1 and 2
 const unsigned int BUTTON_1 = 1U << 5;
 const unsigned int BUTTON_2 = 1U << 6;
@@ -90,8 +92,7 @@ private:
     void handleAxisEvent(float x, float y, float trigger, int index);
     void handlePoseEvent(glm::vec3 position, glm::quat rotation, int index);
 
-#ifdef HAVE_SIXENSE
-    void updateCalibration(const sixenseControllerData* controllers);
+    void updateCalibration(void* controllers);
     
     int _calibrationState;
 
@@ -114,7 +115,6 @@ private:
     QLibrary* _sixenseLibrary;
 #endif
     
-#endif
     bool _hydrasConnected;
 
     bool _invertButtons = DEFAULT_INVERT_SIXENSE_MOUSE_BUTTONS;


### PR DESCRIPTION
Note: this is a PR for the plugins branch **NOT** master.

This was due to interface having a different size for SixenseManager then
input-plugins expected.  This would cause the new operator allocation to be too small.