### PR TITLE
Mac Sixense/Oculus init_hid fix

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -535,6 +535,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
     container->setFocus();
     container->installEventFilter(DependencyManager::get<OffscreenUi>().data());
 
+    // Necessary to call this here so Oculus can get inited before Sixense
+    getDisplayPlugins();
+    
     // must be before initializeGL()
     _activeInputPlugins.clear();
     auto inputPlugins = getInputPlugins();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -880,9 +880,6 @@ void Application::initializeUi() {
         }
     });
     
-    // This will prevent the hid_init sixense crash
-    getActiveDisplayPlugin();
-    
     // This will set up the input plugins UI
     _activeInputPlugins.clear();
     auto inputPlugins = getInputPlugins();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -535,21 +535,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
     container->setFocus();
     container->installEventFilter(DependencyManager::get<OffscreenUi>().data());
 
-    // Necessary to call this here so Oculus can get inited before Sixense
-    getDisplayPlugins();
-    
-    // must be before initializeGL()
-    _activeInputPlugins.clear();
-    auto inputPlugins = getInputPlugins();
-    foreach(auto inputPlugin, inputPlugins) {
-        QString name = inputPlugin->getName();
-        if (name == KeyboardMouseDevice::NAME) {
-            _keyboardMouseDevice = static_cast<KeyboardMouseDevice*>(inputPlugin.data()); // TODO: this seems super hacky
-            break;
-        }
-    }
-    updateInputModes();
-
     _offscreenContext->makeCurrent();
     initializeGL();
     // initialization continues in initializeGL when OpenGL context is ready
@@ -894,6 +879,20 @@ void Application::initializeUi() {
             resizeGL();
         }
     });
+    
+    // This will prevent the hid_init sixense crash
+    getActiveDisplayPlugin();
+    
+    // This will set up the input plugins UI
+    _activeInputPlugins.clear();
+    auto inputPlugins = getInputPlugins();
+    foreach(auto inputPlugin, inputPlugins) {
+        QString name = inputPlugin->getName();
+        if (name == KeyboardMouseDevice::NAME) {
+            _keyboardMouseDevice = static_cast<KeyboardMouseDevice*>(inputPlugin.data()); // TODO: this seems super hacky
+        }
+    }
+    updateInputModes();
 }
 
 template<typename F>

--- a/interface/src/InputPlugins.cpp
+++ b/interface/src/InputPlugins.cpp
@@ -28,7 +28,7 @@ static void addInputPluginToMenu(InputPluginPointer inputPlugin, bool active = f
     }
     auto parent = menu->getMenu(MenuOption::InputMenu);
     auto action = menu->addCheckableActionToQMenuAndActionHash(parent,
-        name, 0, true, qApp,
+        name, 0, active, qApp,
         SLOT(updateInputModes()));
     inputPluginGroup->addAction(action);
     inputPluginGroup->setExclusive(false);
@@ -45,10 +45,7 @@ const InputPluginList& getInputPlugins() {
         InputPlugin* PLUGIN_POOL[] = {
             new KeyboardMouseDevice(),
             new SDL2Manager(),
-            // Sixense is causing some sort of memory corruption on OSX
-#ifndef Q_OS_MAC
             new SixenseManager(),
-#endif
             new ViveControllerManager(),
             nullptr
         };

--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -112,7 +112,9 @@ bool raySphereIntersect(const glm::vec3 &dir, const glm::vec3 &origin, float r, 
     }
 }
 
-ApplicationCompositor::ApplicationCompositor() {
+ApplicationCompositor::ApplicationCompositor() :
+    _alphaPropertyAnimation(new QPropertyAnimation(this, "alpha"))
+{
     memset(_reticleActive, 0, sizeof(_reticleActive));
     memset(_magActive, 0, sizeof(_reticleActive));
     memset(_magSizeMult, 0, sizeof(_magSizeMult));

--- a/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.cpp
@@ -56,14 +56,12 @@ void Oculus_0_5_DisplayPlugin::init() {
     if (!_hmd) {
         qFatal("Failed to acquire HMD");
     }
-
 }
 
 void Oculus_0_5_DisplayPlugin::deinit() {
-    ovr_Shutdown();
-    
     ovrHmd_Destroy(_hmd);
     _hmd = nullptr;
+    ovr_Shutdown();
 }
 
 void Oculus_0_5_DisplayPlugin::activate(PluginContainer * container) {

--- a/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.cpp
@@ -47,7 +47,7 @@ bool Oculus_0_5_DisplayPlugin::isSupported() const {
     return result;
 }
 
-void Oculus_0_5_DisplayPlugin::init() {
+void Oculus_0_5_DisplayPlugin::activate(PluginContainer * container) {
     if (!OVR_SUCCESS(ovr_Initialize(nullptr))) {
         Q_ASSERT(false);
         qFatal("Failed to Initialize SDK");
@@ -56,15 +56,7 @@ void Oculus_0_5_DisplayPlugin::init() {
     if (!_hmd) {
         qFatal("Failed to acquire HMD");
     }
-}
-
-void Oculus_0_5_DisplayPlugin::deinit() {
-    ovrHmd_Destroy(_hmd);
-    _hmd = nullptr;
-    ovr_Shutdown();
-}
-
-void Oculus_0_5_DisplayPlugin::activate(PluginContainer * container) {
+    
     OculusBaseDisplayPlugin::activate(container);
 
     _window->makeCurrent();
@@ -112,6 +104,10 @@ void Oculus_0_5_DisplayPlugin::deactivate(PluginContainer* container) {
     _hmdWindow = nullptr;
 
     OculusBaseDisplayPlugin::deactivate(container);
+    
+    ovrHmd_Destroy(_hmd);
+    _hmd = nullptr;
+    ovr_Shutdown();
 }
 
 void Oculus_0_5_DisplayPlugin::preRender() {

--- a/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.cpp
@@ -47,7 +47,7 @@ bool Oculus_0_5_DisplayPlugin::isSupported() const {
     return result;
 }
 
-void Oculus_0_5_DisplayPlugin::activate(PluginContainer * container) {
+void Oculus_0_5_DisplayPlugin::init() {
     if (!OVR_SUCCESS(ovr_Initialize(nullptr))) {
         Q_ASSERT(false);
         qFatal("Failed to Initialize SDK");
@@ -57,6 +57,16 @@ void Oculus_0_5_DisplayPlugin::activate(PluginContainer * container) {
         qFatal("Failed to acquire HMD");
     }
 
+}
+
+void Oculus_0_5_DisplayPlugin::deinit() {
+    ovr_Shutdown();
+    
+    ovrHmd_Destroy(_hmd);
+    _hmd = nullptr;
+}
+
+void Oculus_0_5_DisplayPlugin::activate(PluginContainer * container) {
     OculusBaseDisplayPlugin::activate(container);
 
     _window->makeCurrent();
@@ -104,10 +114,6 @@ void Oculus_0_5_DisplayPlugin::deactivate(PluginContainer* container) {
     _hmdWindow = nullptr;
 
     OculusBaseDisplayPlugin::deactivate(container);
-
-    ovrHmd_Destroy(_hmd);
-    _hmd = nullptr;
-    ovr_Shutdown();
 }
 
 void Oculus_0_5_DisplayPlugin::preRender() {

--- a/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.h
@@ -25,8 +25,6 @@ public:
     virtual bool isSupported() const override;
     virtual const QString & getName() const override;
 
-    virtual void init() override;
-    virtual void deinit() override;
     virtual void activate(PluginContainer * container) override;
     virtual void deactivate(PluginContainer* container) override;
 

--- a/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/oculus/Oculus_0_5_DisplayPlugin.h
@@ -25,6 +25,8 @@ public:
     virtual bool isSupported() const override;
     virtual const QString & getName() const override;
 
+    virtual void init() override;
+    virtual void deinit() override;
     virtual void activate(PluginContainer * container) override;
     virtual void deactivate(PluginContainer* container) override;
 

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.h
@@ -81,7 +81,9 @@ public:
     UserInputMapper::Input makeInput(unsigned int button, int index);
     UserInputMapper::Input makeInput(JoystickAxisChannel axis, int index);
     UserInputMapper::Input makeInput(JointChannel joint);
-    
+
+    static const QString NAME;
+
 public slots:
     void setFilter(bool filter);
 
@@ -118,8 +120,6 @@ private:
     bool _hydrasConnected;
 
     bool _invertButtons = DEFAULT_INVERT_SIXENSE_MOUSE_BUTTONS;
-
-    static const QString NAME;
 };
 
 #endif // hifi_SixenseManager_h

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.h
@@ -84,8 +84,6 @@ public:
     UserInputMapper::Input makeInput(JoystickAxisChannel axis, int index);
     UserInputMapper::Input makeInput(JointChannel joint);
 
-    static const QString NAME;
-
 public slots:
     void setFilter(bool filter);
 
@@ -120,6 +118,8 @@ private:
     bool _hydrasConnected;
 
     bool _invertButtons = DEFAULT_INVERT_SIXENSE_MOUSE_BUTTONS;
+
+    static const QString NAME;
 };
 
 #endif // hifi_SixenseManager_h


### PR DESCRIPTION
NOTE: this is for the plugins branch, not master

In order to run without crashing:

- Run without rift attached.
- Turn off Sixense input device.
- Rerun with Rift attached

If you want to use the hydra with the Rift, do the above and then:
- Detach Rift while running.
- Enable Sixense input device.
- Switch to Oculus display mode.