### PR TITLE
Limit the amount of time consumed by QML rendering

### DIFF
--- a/libraries/render-utils/src/OffscreenQmlSurface.h
+++ b/libraries/render-utils/src/OffscreenQmlSurface.h
@@ -86,6 +86,7 @@ private:
     QQuickItem* _rootItem{ nullptr };
     QTimer _updateTimer;
     FboCache* _fboCache;
+    quint64 _lastRenderTime{ 0 };
     bool _polish{ true };
     bool _paused{ true };
     MouseTranslator _mouseTranslator{ [](const QPointF& p) { return p;  } };


### PR DESCRIPTION
QML rendering can consume 10ms per call and occurs on the main thread currently.  Until we move it to a distinct thread, this modification should limit QML updates to no more than 10 times per second.  This introduces some choppiness in the QML items (most noticeable during scrolling or dragging operations) but should stop the gorging of runtime by QML during touch events.