### PR TITLE
Fixes Assignment-Agents to have no constantly reconnecting Avatar/AudioMixer

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -107,6 +107,7 @@ void Agent::handleAudioPacket(QSharedPointer<NLPacket> packet) {
 }
 
 const QString AGENT_LOGGING_NAME = "agent";
+const int PING_INTERVAL = 1000;
 
 void Agent::run() {
     ThreadedAssignment::commonInit(AGENT_LOGGING_NAME, NodeType::Agent);
@@ -117,6 +118,10 @@ void Agent::run() {
                                                  << NodeType::AvatarMixer
                                                  << NodeType::EntityServer
                                                 );
+
+    _pingTimer = new QTimer(this);
+    connect(_pingTimer, SIGNAL(timeout()), SLOT(sendPingRequests()));
+    _pingTimer->start(PING_INTERVAL);
 
     // figure out the URL for the script for this agent assignment
     QUrl scriptURL;
@@ -193,7 +198,27 @@ void Agent::run() {
 
 void Agent::aboutToFinish() {
     _scriptEngine.stop();
-    
+
+    _pingTimer->stop();
+    delete _pingTimer;
+
     // our entity tree is going to go away so tell that to the EntityScriptingInterface
     DependencyManager::get<EntityScriptingInterface>()->setEntityTree(NULL);
+}
+
+void Agent::sendPingRequests() {
+    auto nodeList = DependencyManager::get<NodeList>();
+
+    nodeList->eachMatchingNode([](const SharedNodePointer& node)->bool {
+        switch (node->getType()) {
+        case NodeType::AvatarMixer:
+        case NodeType::AudioMixer:
+        case NodeType::EntityServer:
+            return true;
+        default:
+            return false;
+        }
+    }, [nodeList](const SharedNodePointer& node) {
+        nodeList->sendPacket(nodeList->constructPingPacket(), *node);
+    });
 }

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -58,11 +58,13 @@ private slots:
     void handleAudioPacket(QSharedPointer<NLPacket> packet);
     void handleOctreePacket(QSharedPointer<NLPacket> packet, SharedNodePointer senderNode);
     void handleJurisdictionPacket(QSharedPointer<NLPacket> packet, SharedNodePointer senderNode);
+    void sendPingRequests();
 
 private:
     ScriptEngine _scriptEngine;
     EntityEditPacketSender _entityEditSender;
     EntityTreeHeadlessViewer _entityViewer;
+    QTimer* _pingTimer;
     
     MixedAudioStream _receivedAudioStream;
     float _lastReceivedAudioLoudness;


### PR DESCRIPTION
Send ping requests to the nodes (AvatarMixer, AudioMixer, EntityServer) that the Assignment agent connected with to keep the connections alive.