### PR TITLE
Remove avatar->shift hips for idle animations.

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -249,8 +249,6 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::BlueSpeechSphere, 0, true);
     addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::EnableCharacterController, 0, true,
             avatar, SLOT(updateMotionBehavior()));
-    addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::ShiftHipsForIdleAnimations, 0, false,
-            avatar, SLOT(updateMotionBehavior()));
 
     MenuWrapper* viewMenu = addMenu("View");
 

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -273,7 +273,6 @@ namespace MenuOption {
     const QString SimpleShadows = "Simple";
     const QString SixenseEnabled = "Enable Hydra Support";
     const QString SixenseMouseInput = "Enable Sixense Mouse Input";
-    const QString ShiftHipsForIdleAnimations = "Shift hips for idle animations";
     const QString Stars = "Stars";
     const QString Stats = "Stats";
     const QString StopAllScripts = "Stop All Scripts";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -98,7 +98,6 @@ MyAvatar::MyAvatar() :
     _lookAtTargetAvatar(),
     _shouldRender(true),
     _billboardValid(false),
-    _feetTouchFloor(true),
     _eyeContactTarget(LEFT_EYE),
     _realWorldFieldOfView("realWorldFieldOfView",
                           DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES),
@@ -166,9 +165,6 @@ void MyAvatar::update(float deltaTime) {
     head->setAudioAverageLoudness(audio->getAudioAverageInputLoudness());
 
     simulate(deltaTime);
-    if (_feetTouchFloor) {
-        _skeletonModel.updateStandingFoot();
-    }
 }
 
 void MyAvatar::simulate(float deltaTime) {
@@ -1140,11 +1136,7 @@ glm::vec3 MyAvatar::getSkeletonPosition() const {
         // The avatar is rotated PI about the yAxis, so we have to correct for it
         // to get the skeleton offset contribution in the world-frame.
         const glm::quat FLIP = glm::angleAxis(PI, glm::vec3(0.0f, 1.0f, 0.0f));
-        glm::vec3 skeletonOffset = _skeletonOffset;
-        if (_feetTouchFloor) {
-            skeletonOffset += _skeletonModel.getStandingOffset();
-        }
-        return _position + getOrientation() * FLIP * skeletonOffset;
+        return _position + getOrientation() * FLIP * _skeletonOffset;
     }
     return Avatar::getPosition();
 }
@@ -1622,7 +1614,6 @@ void MyAvatar::updateMotionBehavior() {
         _motionBehaviors &= ~AVATAR_MOTION_SCRIPTED_MOTOR_ENABLED;
     }
     _characterController.setEnabled(menu->isOptionChecked(MenuOption::EnableCharacterController));
-    _feetTouchFloor = menu->isOptionChecked(MenuOption::ShiftHipsForIdleAnimations);
 }
 
 //Renders sixense laser pointers for UI selection with controllers

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -258,7 +258,6 @@ private:
 
     QList<AnimationHandlePointer> _animationHandles;
     
-    bool _feetTouchFloor;
     eyeContactTarget _eyeContactTarget;
 
     RecorderPointer _recorder;

--- a/interface/src/avatar/SkeletonModel.h
+++ b/interface/src/avatar/SkeletonModel.h
@@ -96,10 +96,6 @@ public:
     /// \return whether or not the head was found.
     glm::vec3 getDefaultEyeModelPosition() const;
 
-    /// skeleton offset caused by moving feet
-    void updateStandingFoot();
-    const glm::vec3& getStandingOffset() const { return _standingOffset; }
-
     void computeBoundingShape(const FBXGeometry& geometry);
     void renderBoundingCollisionShapes(gpu::Batch& batch, float alpha);
     float getBoundingShapeRadius() const { return _boundingShape.getRadius(); }
@@ -169,9 +165,6 @@ private:
     glm::vec3 _boundingShapeLocalOffset;
 
     glm::vec3 _defaultEyeModelPosition;
-    int _standingFoot;
-    glm::vec3 _standingOffset;
-    glm::vec3 _clampedFootPosition;
 
     float _headClipDistance;  // Near clip distance to use if no separate head model
 

--- a/tests/ui/src/main.cpp
+++ b/tests/ui/src/main.cpp
@@ -215,7 +215,6 @@ public:
         SixenseEnabled,
         SixenseMouseInput,
         SixenseLasers,
-        ShiftHipsForIdleAnimations,
         Stars,
         Stats,
         StereoAudio,


### PR DESCRIPTION
This was experimental code for keeping the feet from sliding around while doing idle animations, accomplished by determining how the feet were moving and translating the hip position accordingly.

It had a number of problems, including:
* Not turning off correctly. (When you restart, it acts as as though it is on, even if the checkbox is off. You have to manually toggle on and then off again.)
* Precessing the avatar when there are repeated animations of the legs back and forth (or side to side).

See https://app.asana.com/0/32622044445063/43127903156601