### PR TITLE
treat a "o" in an obj file as if it were a "g"

### DIFF
--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -306,7 +306,8 @@ bool OBJReader::parseOBJGroup(OBJTokenizer& tokenizer, const QVariantHash& mappi
         }
         QByteArray token = tokenizer.getDatum();
         //qCDebug(modelformat) << token;
-        if (token == "g") {
+        // we don't support separate objects in the same file, so treat "o" the same as "g".
+        if (token == "g" || token == "o") {
             if (sawG) {
                 // we've encountered the beginning of the next group.
                 tokenizer.pushBackToken(OBJTokenizer::DATUM_TOKEN);


### PR DESCRIPTION
Models in Wavefront OBJ files can be divided into mesh-parts with "g" tokens.  The file can be divided into separate objects with "o" tokens.  We don't support multiple objects per OBJ file, so treat an "o" like a "g" rather than ignore it.
