### PR TITLE
vhacd tool -- make the height of the tetrahedrons in 'fatten' mode less tall.

### DIFF
--- a/tools/vhacd-util/src/VHACDUtil.cpp
+++ b/tools/vhacd-util/src/VHACDUtil.cpp
@@ -125,12 +125,14 @@ void vhacd::VHACDUtil::fattenMeshes(const FBXMesh& mesh, FBXMesh& result,
             continue;
         }
 
+        // from the middle of the triangle, pull a point down to form a tetrahedron.
         float dropAmount = 0;
         dropAmount = glm::max(glm::length(p1 - p0), dropAmount);
         dropAmount = glm::max(glm::length(p2 - p1), dropAmount);
         dropAmount = glm::max(glm::length(p0 - p2), dropAmount);
+        dropAmount *= 0.25f;
 
-        glm::vec3 p3 = av - glm::vec3(0, dropAmount, 0);  // a point 1 meter below the average of this triangle's points
+        glm::vec3 p3 = av - glm::vec3(0, dropAmount, 0);
         int index3 = result.vertices.size();
         result.vertices << p3; // add the new point to the result mesh
 

--- a/tools/vhacd-util/src/VHACDUtil.cpp
+++ b/tools/vhacd-util/src/VHACDUtil.cpp
@@ -12,7 +12,7 @@
 #include <QVector>
 #include "VHACDUtil.h"
 
-const float collisionTetrahedronScale = 0.25f;
+const float COLLISION_TETRAHEDRON_SCALE = 0.25f;
 
 
 // FBXReader jumbles the order of the meshes by reading them back out of a hashtable.  This will put
@@ -132,9 +132,9 @@ void vhacd::VHACDUtil::fattenMeshes(const FBXMesh& mesh, FBXMesh& result,
         dropAmount = glm::max(glm::length(p1 - p0), dropAmount);
         dropAmount = glm::max(glm::length(p2 - p1), dropAmount);
         dropAmount = glm::max(glm::length(p0 - p2), dropAmount);
-        dropAmount *= collisionTetrahedronScale;
+        dropAmount *= COLLISION_TETRAHEDRON_SCALE;
 
-        glm::vec3 p3 = av - glm::vec3(0, dropAmount, 0);
+        glm::vec3 p3 = av - glm::vec3(0.0f, dropAmount, 0.0f);
         int index3 = result.vertices.size();
         result.vertices << p3; // add the new point to the result mesh
 

--- a/tools/vhacd-util/src/VHACDUtil.cpp
+++ b/tools/vhacd-util/src/VHACDUtil.cpp
@@ -12,6 +12,8 @@
 #include <QVector>
 #include "VHACDUtil.h"
 
+const float collisionTetrahedronScale = 0.25f;
+
 
 // FBXReader jumbles the order of the meshes by reading them back out of a hashtable.  This will put
 // them back in the order in which they appeared in the file.
@@ -130,7 +132,7 @@ void vhacd::VHACDUtil::fattenMeshes(const FBXMesh& mesh, FBXMesh& result,
         dropAmount = glm::max(glm::length(p1 - p0), dropAmount);
         dropAmount = glm::max(glm::length(p2 - p1), dropAmount);
         dropAmount = glm::max(glm::length(p0 - p2), dropAmount);
-        dropAmount *= 0.25f;
+        dropAmount *= collisionTetrahedronScale;
 
         glm::vec3 p3 = av - glm::vec3(0, dropAmount, 0);
         int index3 = result.vertices.size();


### PR DESCRIPTION
The tool for creating collision hulls has a "fatten" mode which pulls renderable triangles into collidable tetrahedrons.  Reduce the height of the resulting tetrahedrons.
