### PR TITLE
Add gettable naturalPosition property for model entities

### DIFF
--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -129,9 +129,9 @@ void EntityItemProperties::setSittingPoints(const QVector<SittingPoint>& sitting
     }
 }
 
-void EntityItemProperties::setNaturalPosition(const glm::vec3& min, const glm::vec3& max) {
-    glm::vec3 radius = (max - min) / 2.0f;
-    _naturalPosition = max - radius;
+void EntityItemProperties::calculateNaturalPosition(const glm::vec3& min, const glm::vec3& max) {
+    glm::vec3 halfDimension = (max - min) / 2.0f;
+    _naturalPosition = max - halfDimension;
 }
 
 bool EntityItemProperties::animationSettingsChanged() const {

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -114,7 +114,8 @@ _glowLevelChanged(false),
 _localRenderAlphaChanged(false),
 
 _defaultSettings(true),
-_naturalDimensions(1.0f, 1.0f, 1.0f)
+_naturalDimensions(1.0f, 1.0f, 1.0f),
+_naturalPosition(0.0f, 0.0f, 0.0f)
 {
 }
 
@@ -126,6 +127,11 @@ void EntityItemProperties::setSittingPoints(const QVector<SittingPoint>& sitting
     foreach (SittingPoint sitPoint, sittingPoints) {
         _sittingPoints.append(sitPoint);
     }
+}
+
+void EntityItemProperties::setNaturalPosition(const glm::vec3& min, const glm::vec3& max) {
+    glm::vec3 radius = (max - min) / 2.0f;
+    _naturalPosition = max - radius;
 }
 
 bool EntityItemProperties::animationSettingsChanged() const {
@@ -378,6 +384,7 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     COPY_PROPERTY_TO_QSCRIPTVALUE(dimensions);
     if (!skipDefaults) {
         COPY_PROPERTY_TO_QSCRIPTVALUE(naturalDimensions); // gettable, but not settable
+        COPY_PROPERTY_TO_QSCRIPTVALUE(naturalPosition);
     }
     COPY_PROPERTY_TO_QSCRIPTVALUE(rotation);
     COPY_PROPERTY_TO_QSCRIPTVALUE(velocity);

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -192,7 +192,10 @@ public:
 
     const glm::vec3& getNaturalDimensions() const { return _naturalDimensions; }
     void setNaturalDimensions(const glm::vec3& value) { _naturalDimensions = value; }
-
+    
+    const glm::vec3& getNaturalPosition() const { return _naturalPosition; }
+    void setNaturalPosition(const glm::vec3& min, const glm::vec3& max);
+    
     const QStringList& getTextureNames() const { return _textureNames; }
     void setTextureNames(const QStringList& value) { _textureNames = value; }
 
@@ -232,6 +235,7 @@ private:
     QVector<SittingPoint> _sittingPoints;
     QStringList _textureNames;
     glm::vec3 _naturalDimensions;
+    glm::vec3 _naturalPosition;
 };
 
 Q_DECLARE_METATYPE(EntityItemProperties);

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -194,7 +194,7 @@ public:
     void setNaturalDimensions(const glm::vec3& value) { _naturalDimensions = value; }
     
     const glm::vec3& getNaturalPosition() const { return _naturalPosition; }
-    void setNaturalPosition(const glm::vec3& min, const glm::vec3& max);
+    void calculateNaturalPosition(const glm::vec3& min, const glm::vec3& max);
     
     const QStringList& getTextureNames() const { return _textureNames; }
     void setTextureNames(const QStringList& value) { _textureNames = value; }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -118,6 +118,7 @@ EntityItemProperties EntityScriptingInterface::getEntityProperties(QUuid identit
                     results.setSittingPoints(geometry->sittingPoints);
                     Extents meshExtents = geometry->getUnscaledMeshExtents();
                     results.setNaturalDimensions(meshExtents.maximum - meshExtents.minimum);
+                    results.setNaturalPosition(meshExtents.minimum, meshExtents.maximum);
                 }
             }
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -118,7 +118,7 @@ EntityItemProperties EntityScriptingInterface::getEntityProperties(QUuid identit
                     results.setSittingPoints(geometry->sittingPoints);
                     Extents meshExtents = geometry->getUnscaledMeshExtents();
                     results.setNaturalDimensions(meshExtents.maximum - meshExtents.minimum);
-                    results.setNaturalPosition(meshExtents.minimum, meshExtents.maximum);
+                    results.calculateNaturalPosition(meshExtents.minimum, meshExtents.maximum);
                 }
             }
 


### PR DESCRIPTION
Creates a new gettable (not settable) naturalPosition property for models, similar to naturalDimensions.
The naturalPosition is set to roughly the center of the entity's bounding box (determined by meshExtents), and is gettable via script. Will be used mainly to get relative Maya/Blender-stored positions of objects to allow for positioning with correct offsets from an origin. 