### PR TITLE
remove GL_QUADS from code base

### DIFF
--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -119,19 +119,21 @@ void Circle3DOverlay::render(RenderArgs* args) {
             
             float angle = startAt;
             float angleInRadians = glm::radians(angle);
-            glm::vec2 firstInnerPoint(cosf(angleInRadians) * innerRadius, sinf(angleInRadians) * innerRadius);
-            glm::vec2 firstOuterPoint(cosf(angleInRadians) * outerRadius, sinf(angleInRadians) * outerRadius);
-            
-            points << firstInnerPoint << firstOuterPoint;
+            glm::vec2 mostRecentInnerPoint(cosf(angleInRadians) * innerRadius, sinf(angleInRadians) * innerRadius);
+            glm::vec2 mostRecentOuterPoint(cosf(angleInRadians) * outerRadius, sinf(angleInRadians) * outerRadius);
             
             while (angle < endAt) {
                 angleInRadians = glm::radians(angle);
                 glm::vec2 thisInnerPoint(cosf(angleInRadians) * innerRadius, sinf(angleInRadians) * innerRadius);
                 glm::vec2 thisOuterPoint(cosf(angleInRadians) * outerRadius, sinf(angleInRadians) * outerRadius);
                 
-                points << thisOuterPoint << thisInnerPoint;
+                points << mostRecentInnerPoint << mostRecentOuterPoint << thisOuterPoint; // first triangle
+                points << mostRecentInnerPoint << thisInnerPoint << thisOuterPoint; // second triangle
                 
                 angle += SLICE_ANGLE;
+
+                mostRecentInnerPoint = thisInnerPoint;
+                mostRecentOuterPoint = thisOuterPoint;
             }
             
             // get the last slice portion....
@@ -139,13 +141,14 @@ void Circle3DOverlay::render(RenderArgs* args) {
             angleInRadians = glm::radians(angle);
             glm::vec2 lastInnerPoint(cosf(angleInRadians) * innerRadius, sinf(angleInRadians) * innerRadius);
             glm::vec2 lastOuterPoint(cosf(angleInRadians) * outerRadius, sinf(angleInRadians) * outerRadius);
-            
-            points << lastOuterPoint << lastInnerPoint;
+
+            points << mostRecentInnerPoint << mostRecentOuterPoint << lastOuterPoint; // first triangle
+            points << mostRecentInnerPoint << lastInnerPoint << lastOuterPoint; // second triangle
             
             geometryCache->updateVertices(_quadVerticesID, points, color);
         }
         
-        geometryCache->renderVertices(batch, gpu::QUAD_STRIP, _quadVerticesID);
+        geometryCache->renderVertices(batch, gpu::TRIANGLES, _quadVerticesID);
         
     } else {
         if (_lineVerticesID == GeometryCache::UNKNOWN_ID) {

--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -830,6 +830,56 @@ public:
     std::vector<AttributeData> attributes;
 };
 
+gpu::BufferPointer FBXMeshPart::getTrianglesForQuads() const {
+    // if we've been asked for our triangulation of the original quads, but we don't yet have them
+    // then create them now.
+    if (!trianglesForQuadsAvailable) {
+        trianglesForQuadsAvailable = true;
+
+        quadsAsTrianglesIndicesBuffer = std::make_shared<gpu::Buffer>();
+
+        // QVector<int> quadIndices; // original indices from the FBX mesh
+         QVector<quint32> quadsAsTrianglesIndices; // triangle versions of quads converted when first needed
+        const int INDICES_PER_ORIGINAL_QUAD = 4;
+        const int INDICES_PER_TRIANGULATED_QUAD = 6;
+        int numberOfQuads = quadIndices.size() / INDICES_PER_ORIGINAL_QUAD;
+        
+        quadsAsTrianglesIndices.resize(numberOfQuads * INDICES_PER_TRIANGULATED_QUAD);
+        
+        int originalIndex = 0;
+        int triangulatedIndex = 0;
+        for (int fromQuad = 0; fromQuad < numberOfQuads; fromQuad++) {
+            int i0 = quadIndices[originalIndex + 0];
+            int i1 = quadIndices[originalIndex + 1];
+            int i2 = quadIndices[originalIndex + 2];
+            int i3 = quadIndices[originalIndex + 3];
+            
+            // Sam's recommended triangle slices
+            // Triangle tri1 = { v0, v1, v3 };
+            // Triangle tri2 = { v1, v2, v3 };
+            // NOTE: Random guy on the internet's recommended triangle slices
+            // Triangle tri1 = { v0, v1, v2 };
+            // Triangle tri2 = { v2, v3, v0 };
+            
+            quadsAsTrianglesIndices[triangulatedIndex + 0] = i0;
+            quadsAsTrianglesIndices[triangulatedIndex + 1] = i1;
+            quadsAsTrianglesIndices[triangulatedIndex + 2] = i3;
+
+            quadsAsTrianglesIndices[triangulatedIndex + 3] = i1;
+            quadsAsTrianglesIndices[triangulatedIndex + 4] = i2;
+            quadsAsTrianglesIndices[triangulatedIndex + 5] = i3;
+            
+            originalIndex += INDICES_PER_ORIGINAL_QUAD;
+            triangulatedIndex += INDICES_PER_TRIANGULATED_QUAD;
+        }
+
+        trianglesForQuadsIndicesCount = INDICES_PER_TRIANGULATED_QUAD * numberOfQuads;
+        quadsAsTrianglesIndicesBuffer->append(quadsAsTrianglesIndices.size() * sizeof(quint32), (gpu::Byte*)quadsAsTrianglesIndices.data());
+
+    }
+    return quadsAsTrianglesIndicesBuffer;
+}
+
 void appendIndex(MeshData& data, QVector<int>& indices, int index) {
     if (index >= data.polygonIndices.size()) {
         return;
@@ -1089,7 +1139,6 @@ ExtractedMesh extractMesh(const FBXNode& object, unsigned int& meshIndex) {
             appendIndex(data, part.quadIndices, beginIndex++);
             appendIndex(data, part.quadIndices, beginIndex++);
             appendIndex(data, part.quadIndices, beginIndex++);
-
         } else {
             for (int nextIndex = beginIndex + 1;; ) {
                 appendIndex(data, part.triangleIndices, beginIndex);

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -109,9 +109,10 @@ public:
 class FBXMeshPart {
 public:
     
-    QVector<int> quadIndices;
-    QVector<int> triangleIndices;
-    
+    QVector<int> quadIndices; // original indices from the FBX mesh
+    QVector<int> triangleIndices; // original indices from the FBX mesh
+    mutable gpu::BufferPointer quadsAsTrianglesIndicesBuffer;
+
     glm::vec3 diffuseColor;
     glm::vec3 specularColor;
     glm::vec3 emissiveColor;
@@ -126,6 +127,10 @@ public:
 
     QString materialID;
     model::MaterialPointer _material;
+    mutable bool trianglesForQuadsAvailable = false;
+    mutable int trianglesForQuadsIndicesCount = 0;
+
+    gpu::BufferPointer getTrianglesForQuads() const;
 };
 
 /// A single mesh (with optional blendshapes) extracted from an FBX document.

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -213,11 +213,6 @@ enum Primitive {
     TRIANGLES,
     TRIANGLE_STRIP,
     TRIANGLE_FAN,
-
-    // FIXME - remove these
-    QUADS,
-    QUAD_STRIP,
-
     NUM_PRIMITIVES,
 };
 

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -213,6 +213,8 @@ enum Primitive {
     TRIANGLES,
     TRIANGLE_STRIP,
     TRIANGLE_FAN,
+
+    // FIXME - remove these
     QUADS,
     QUAD_STRIP,
 

--- a/libraries/gpu/src/gpu/GLBackendShared.h
+++ b/libraries/gpu/src/gpu/GLBackendShared.h
@@ -23,8 +23,6 @@ static const GLenum _primitiveToGLmode[gpu::NUM_PRIMITIVES] = {
     GL_TRIANGLES,
     GL_TRIANGLE_STRIP,
     GL_TRIANGLE_FAN,
-    GL_QUADS,
-    GL_QUAD_STRIP,
 };
 
 static const GLenum _elementTypeToGLType[gpu::NUM_TYPES] = {

--- a/libraries/model/src/model/Geometry.h
+++ b/libraries/model/src/model/Geometry.h
@@ -71,7 +71,7 @@ public:
         LINE_STRIP,
         TRIANGLES,
         TRIANGLE_STRIP,
-        QUADS,
+        QUADS,  // NOTE: These must be translated to triangles before rendering
         QUAD_STRIP,
 
         NUM_TOPOLOGIES,

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1012,21 +1012,27 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
     }
 
     const int FLOATS_PER_VERTEX = 2; // vertices
-    const int vertices = 4;
+    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
+    const int VERTICES = 4; // 1 quad = 4 vertices
 
     if (!details.isCreated) {
 
         details.isCreated = true;
-        details.vertices = vertices;
+        details.vertices = VERTICES;
+        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX;
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
+        auto indicesBuffer = std::make_shared<gpu::Buffer>();
+
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
+        details.indicesBuffer = indicesBuffer;
+        
         details.streamFormat = streamFormat;
         details.stream = stream;
     
@@ -1037,7 +1043,7 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
         details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
 
 
-        float vertexBuffer[vertices * FLOATS_PER_VERTEX] = {    
+        float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {    
                             minCorner.x, minCorner.y,
                             maxCorner.x, minCorner.y,
                             maxCorner.x, maxCorner.y,
@@ -1050,14 +1056,24 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
+        // Sam's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v3 };
+        // Triangle tri2 = { v1, v2, v3 };
+        // NOTE: Random guy on the internet's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v2 };
+        // Triangle tri2 = { v2, v3, v0 };
+
+        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
 
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.draw(gpu::QUADS, 4, 0);
+    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
+    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
 }
 
 void GeometryCache::renderUnitCube(gpu::Batch& batch) {
@@ -1102,23 +1118,29 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
     }
 
     const int FLOATS_PER_VERTEX = 2 * 2; // text coords & vertices
-    const int vertices = 4;
+    const int VERTICES = 4; // 1 quad = 4 vertices
     const int NUM_POS_COORDS = 2;
     const int VERTEX_TEXCOORD_OFFSET = NUM_POS_COORDS * sizeof(float);
+    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
 
     if (!details.isCreated) {
 
         details.isCreated = true;
-        details.vertices = vertices;
+        details.vertices = VERTICES;
+        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX;
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
+        auto indicesBuffer = std::make_shared<gpu::Buffer>();
+
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
+        details.indicesBuffer = indicesBuffer;
+
         details.streamFormat = streamFormat;
         details.stream = stream;
     
@@ -1130,7 +1152,7 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
         details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
 
 
-        float vertexBuffer[vertices * FLOATS_PER_VERTEX] = {    
+        float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {    
                                                         minCorner.x, minCorner.y, texCoordMinCorner.x, texCoordMinCorner.y,
                                                         maxCorner.x, minCorner.y, texCoordMaxCorner.x, texCoordMinCorner.y,
                                                         maxCorner.x, maxCorner.y, texCoordMaxCorner.x, texCoordMaxCorner.y,
@@ -1144,14 +1166,24 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
+        // Sam's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v3 };
+        // Triangle tri2 = { v1, v2, v3 };
+        // NOTE: Random guy on the internet's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v2 };
+        // Triangle tri2 = { v2, v3, v0 };
+
+        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
 
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.draw(gpu::QUADS, 4, 0);
+    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
+    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id) {
@@ -1177,21 +1209,27 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
     }
 
     const int FLOATS_PER_VERTEX = 3; // vertices
-    const int vertices = 4;
+    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
+    const int VERTICES = 4; // 1 quad = 4 vertices
 
     if (!details.isCreated) {
 
         details.isCreated = true;
-        details.vertices = vertices;
+        details.vertices = VERTICES;
+        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX;
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
+        auto indicesBuffer = std::make_shared<gpu::Buffer>();
+
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
+        details.indicesBuffer = indicesBuffer;
+
         details.streamFormat = streamFormat;
         details.stream = stream;
     
@@ -1202,7 +1240,7 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
         details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
 
 
-        float vertexBuffer[vertices * FLOATS_PER_VERTEX] = {    
+        float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {    
                             minCorner.x, minCorner.y, minCorner.z,
                             maxCorner.x, minCorner.y, minCorner.z,
                             maxCorner.x, maxCorner.y, maxCorner.z,
@@ -1215,14 +1253,24 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
+        // Sam's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v3 };
+        // Triangle tri2 = { v1, v2, v3 };
+        // NOTE: Random guy on the internet's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v2 };
+        // Triangle tri2 = { v2, v3, v0 };
+
+        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
 
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.draw(gpu::QUADS, 4, 0);
+    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
+    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
@@ -1267,23 +1315,29 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
     }
 
     const int FLOATS_PER_VERTEX = 3 + 2; // 3d vertices + text coords
-    const int vertices = 4;
+    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
+    const int VERTICES = 4; // 1 quad = 4 vertices
     const int NUM_POS_COORDS = 3;
     const int VERTEX_TEXCOORD_OFFSET = NUM_POS_COORDS * sizeof(float);
 
     if (!details.isCreated) {
 
         details.isCreated = true;
-        details.vertices = vertices;
+        details.vertices = VERTICES;
+        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX; // NOTE: this isn't used for BatchItemDetails maybe we can get rid of it
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
+        auto indicesBuffer = std::make_shared<gpu::Buffer>();
+
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
+        details.indicesBuffer = indicesBuffer;
+
         details.streamFormat = streamFormat;
         details.stream = stream;
     
@@ -1295,7 +1349,7 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
         details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
 
 
-        float vertexBuffer[vertices * FLOATS_PER_VERTEX] = {
+        float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {
                                 topLeft.x, topLeft.y, topLeft.z, texCoordTopLeft.x, texCoordTopLeft.y,
                                 bottomLeft.x, bottomLeft.y, bottomLeft.z, texCoordBottomLeft.x, texCoordBottomLeft.y,
                                 bottomRight.x, bottomRight.y, bottomRight.z, texCoordBottomRight.x, texCoordBottomRight.y,
@@ -1309,13 +1363,24 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
+        // Sam's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v3 };
+        // Triangle tri2 = { v1, v2, v3 };
+        // NOTE: Random guy on the internet's recommended triangle slices
+        // Triangle tri1 = { v0, v1, v2 };
+        // Triangle tri2 = { v2, v3, v0 };
+
+        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
+
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.draw(gpu::QUADS, 4, 0);
+    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
+    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
 }
 
 void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id) {

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1041,7 +1041,7 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
                             minCorner.x, minCorner.y,
                             maxCorner.x, minCorner.y,
                             minCorner.x, maxCorner.y,
-                            maxCorner.x, maxCorner.y 
+                            maxCorner.x, maxCorner.y,
         };
 
         const int NUM_COLOR_SCALARS_PER_QUAD = 4;
@@ -1136,7 +1136,7 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
                                                         minCorner.x, minCorner.y, texCoordMinCorner.x, texCoordMinCorner.y,
                                                         maxCorner.x, minCorner.y, texCoordMaxCorner.x, texCoordMinCorner.y,
                                                         minCorner.x, maxCorner.y, texCoordMinCorner.x, texCoordMaxCorner.y,
-                                                        maxCorner.x, maxCorner.y, texCoordMaxCorner.x, texCoordMaxCorner.y
+                                                        maxCorner.x, maxCorner.y, texCoordMaxCorner.x, texCoordMaxCorner.y,
         };
 
 
@@ -1210,7 +1210,7 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
                             minCorner.x, minCorner.y, minCorner.z,
                             maxCorner.x, minCorner.y, minCorner.z,
                             minCorner.x, maxCorner.y, maxCorner.z,
-                            maxCorner.x, maxCorner.y, maxCorner.z
+                            maxCorner.x, maxCorner.y, maxCorner.z,
         };
 
         const int NUM_COLOR_SCALARS_PER_QUAD = 4;

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1012,27 +1012,21 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
     }
 
     const int FLOATS_PER_VERTEX = 2; // vertices
-    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
     const int VERTICES = 4; // 1 quad = 4 vertices
 
     if (!details.isCreated) {
 
         details.isCreated = true;
         details.vertices = VERTICES;
-        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX;
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
-        auto indicesBuffer = std::make_shared<gpu::Buffer>();
-
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
-        details.indicesBuffer = indicesBuffer;
-        
         details.streamFormat = streamFormat;
         details.stream = stream;
     
@@ -1046,8 +1040,9 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {    
                             minCorner.x, minCorner.y,
                             maxCorner.x, minCorner.y,
-                            maxCorner.x, maxCorner.y,
-                            minCorner.x, maxCorner.y };
+                            minCorner.x, maxCorner.y,
+                            maxCorner.x, maxCorner.y 
+        };
 
         const int NUM_COLOR_SCALARS_PER_QUAD = 4;
         int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
@@ -1056,24 +1051,13 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
-        // Sam's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v3 };
-        // Triangle tri2 = { v1, v2, v3 };
-        // NOTE: Random guy on the internet's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v2 };
-        // Triangle tri2 = { v2, v3, v0 };
-
-        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
-        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
-    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
+    batch.draw(gpu::TRIANGLE_STRIP, 4, 0);
 }
 
 void GeometryCache::renderUnitCube(gpu::Batch& batch) {
@@ -1121,25 +1105,21 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
     const int VERTICES = 4; // 1 quad = 4 vertices
     const int NUM_POS_COORDS = 2;
     const int VERTEX_TEXCOORD_OFFSET = NUM_POS_COORDS * sizeof(float);
-    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
 
     if (!details.isCreated) {
 
         details.isCreated = true;
         details.vertices = VERTICES;
-        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX;
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
-        auto indicesBuffer = std::make_shared<gpu::Buffer>();
 
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
-        details.indicesBuffer = indicesBuffer;
 
         details.streamFormat = streamFormat;
         details.stream = stream;
@@ -1155,8 +1135,9 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {    
                                                         minCorner.x, minCorner.y, texCoordMinCorner.x, texCoordMinCorner.y,
                                                         maxCorner.x, minCorner.y, texCoordMaxCorner.x, texCoordMinCorner.y,
-                                                        maxCorner.x, maxCorner.y, texCoordMaxCorner.x, texCoordMaxCorner.y,
-                                                        minCorner.x, maxCorner.y, texCoordMinCorner.x, texCoordMaxCorner.y };
+                                                        minCorner.x, maxCorner.y, texCoordMinCorner.x, texCoordMaxCorner.y,
+                                                        maxCorner.x, maxCorner.y, texCoordMaxCorner.x, texCoordMaxCorner.y
+        };
 
 
         const int NUM_COLOR_SCALARS_PER_QUAD = 4;
@@ -1166,24 +1147,13 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
-        // Sam's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v3 };
-        // Triangle tri2 = { v1, v2, v3 };
-        // NOTE: Random guy on the internet's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v2 };
-        // Triangle tri2 = { v2, v3, v0 };
-
-        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
-        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
-    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
+    batch.draw(gpu::TRIANGLE_STRIP, 4, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id) {
@@ -1209,26 +1179,22 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
     }
 
     const int FLOATS_PER_VERTEX = 3; // vertices
-    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
     const int VERTICES = 4; // 1 quad = 4 vertices
 
     if (!details.isCreated) {
 
         details.isCreated = true;
         details.vertices = VERTICES;
-        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX;
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
-        auto indicesBuffer = std::make_shared<gpu::Buffer>();
 
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
-        details.indicesBuffer = indicesBuffer;
 
         details.streamFormat = streamFormat;
         details.stream = stream;
@@ -1243,8 +1209,9 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {    
                             minCorner.x, minCorner.y, minCorner.z,
                             maxCorner.x, minCorner.y, minCorner.z,
-                            maxCorner.x, maxCorner.y, maxCorner.z,
-                            minCorner.x, maxCorner.y, maxCorner.z };
+                            minCorner.x, maxCorner.y, maxCorner.z,
+                            maxCorner.x, maxCorner.y, maxCorner.z
+        };
 
         const int NUM_COLOR_SCALARS_PER_QUAD = 4;
         int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
@@ -1253,24 +1220,13 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
-        // Sam's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v3 };
-        // Triangle tri2 = { v1, v2, v3 };
-        // NOTE: Random guy on the internet's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v2 };
-        // Triangle tri2 = { v2, v3, v0 };
-
-        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
-        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
-    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
+    batch.draw(gpu::TRIANGLE_STRIP, 4, 0);
 }
 
 void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
@@ -1315,7 +1271,6 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
     }
 
     const int FLOATS_PER_VERTEX = 3 + 2; // 3d vertices + text coords
-    const int NUMBER_OF_INDICES = 6; // 1 quad = 2 triangles
     const int VERTICES = 4; // 1 quad = 4 vertices
     const int NUM_POS_COORDS = 3;
     const int VERTEX_TEXCOORD_OFFSET = NUM_POS_COORDS * sizeof(float);
@@ -1324,20 +1279,15 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
 
         details.isCreated = true;
         details.vertices = VERTICES;
-        details.indices = NUMBER_OF_INDICES;
         details.vertexSize = FLOATS_PER_VERTEX; // NOTE: this isn't used for BatchItemDetails maybe we can get rid of it
         
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
-        auto indicesBuffer = std::make_shared<gpu::Buffer>();
-
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
         details.colorBuffer = colorBuffer;
-        details.indicesBuffer = indicesBuffer;
-
         details.streamFormat = streamFormat;
         details.stream = stream;
     
@@ -1350,9 +1300,9 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
 
 
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {
-                                topLeft.x, topLeft.y, topLeft.z, texCoordTopLeft.x, texCoordTopLeft.y,
                                 bottomLeft.x, bottomLeft.y, bottomLeft.z, texCoordBottomLeft.x, texCoordBottomLeft.y,
                                 bottomRight.x, bottomRight.y, bottomRight.z, texCoordBottomRight.x, texCoordBottomRight.y,
+                                topLeft.x, topLeft.y, topLeft.z, texCoordTopLeft.x, texCoordTopLeft.y,
                                 topRight.x, topRight.y, topRight.z, texCoordTopRight.x, texCoordTopRight.y,
                             };
 
@@ -1363,24 +1313,13 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
                             ((int(color.w * 255.0f) & 0xFF) << 24);
         int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
 
-        // Sam's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v3 };
-        // Triangle tri2 = { v1, v2, v3 };
-        // NOTE: Random guy on the internet's recommended triangle slices
-        // Triangle tri1 = { v0, v1, v2 };
-        // Triangle tri2 = { v2, v3, v0 };
-
-        quint16 indices[NUMBER_OF_INDICES] = { 0, 1, 3, 1, 2, 3 };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
         details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
-        details.indicesBuffer->append(sizeof(indices), (gpu::Byte*) indices);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
-    batch.setIndexBuffer(gpu::UINT16, details.indicesBuffer, 0);
-    batch.drawIndexed(gpu::TRIANGLES, NUMBER_OF_INDICES, 0);
+    batch.draw(gpu::TRIANGLE_STRIP, 4, 0);
 }
 
 void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id) {

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -235,10 +235,12 @@ private:
         static int population;
         gpu::BufferPointer verticesBuffer;
         gpu::BufferPointer colorBuffer;
+        gpu::BufferPointer indicesBuffer;
         gpu::Stream::FormatPointer streamFormat;
         gpu::BufferStreamPointer stream;
 
         int vertices;
+        int indices;
         int vertexSize;
         bool isCreated;
         

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -235,12 +235,10 @@ private:
         static int population;
         gpu::BufferPointer verticesBuffer;
         gpu::BufferPointer colorBuffer;
-        gpu::BufferPointer indicesBuffer;
         gpu::Stream::FormatPointer streamFormat;
         gpu::BufferStreamPointer stream;
 
         int vertices;
-        int indices;
         int vertexSize;
         bool isCreated;
         

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -2096,8 +2096,11 @@ void Model::renderPart(RenderArgs* args, int meshIndex, int partIndex, bool tran
     }
 
     if (part.quadIndices.size() > 0) {
-        batch.drawIndexed(gpu::QUADS, part.quadIndices.size(), offset);
+        batch.setIndexBuffer(gpu::UINT32, part.getTrianglesForQuads(), 0);
+        batch.drawIndexed(gpu::TRIANGLES, part.trianglesForQuadsIndicesCount, 0);
+
         offset += part.quadIndices.size() * sizeof(int);
+        batch.setIndexBuffer(gpu::UINT32, (networkMesh._indexBuffer), 0); // restore this in case there are triangles too
     }
 
     if (part.triangleIndices.size() > 0) {

--- a/libraries/render-utils/src/text/Font.h
+++ b/libraries/render-utils/src/text/Font.h
@@ -64,8 +64,10 @@ private:
     gpu::TexturePointer _texture;
     gpu::Stream::FormatPointer _format;
     gpu::BufferPointer _verticesBuffer;
+    gpu::BufferPointer _indicesBuffer;
     gpu::BufferStreamPointer _stream;
     unsigned int _numVertices = 0;
+    unsigned int _numIndices = 0;
 
     int _fontLoc = -1;
     int _outlineLoc = -1;


### PR DESCRIPTION
As part of the move to core profile, we can no longer use GL_QUADS or GL_QUAD_STRIP. This PR will remove our use of these primitives. Callers will still be able to use some higher level methods which present "quad" interfaces to them, e.g. GeometryCache::renderQuad(), but the lower level implementation will use triangles.

* change GeometryCache::renderQuad() to use TRIANGLE_STRIP as lower level render primitive
* change Font::drawString() to use TRIANGLES as lower level render primitive
* change Model::renderPart() and FBXMeshPart to have a triangulated version of the quads and to use TRIANGLES as lower level render primitive
* change Circle3DOverlay::render() to not use QUAD_STRIP and use TRIANGLES instead