### PR TITLE
All multiple local sounds

### DIFF
--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -209,9 +209,6 @@ protected:
         deleteLater();
     }
 
-private slots:
-    void audioStateChanged(QAudio::State state);
-
 private:
     void outputFormatChanged();
 


### PR DESCRIPTION
There is a bug in which any local sound finishing will stop other local sounds from looping.

For example, consider:
var piano1 = SoundCache.getSound("http://howard-stearns.github.io/models/sounds/piano1.wav");
var lmono = {localOnly: true, stereo: false, volume: 1};
var lmonoLoop = {localOnly: true, stereo: false, volume: 1, loop: true};
var injectorLoop = Audio.playSound(piano1, lmonoLoop);
// and then, a moment later:
var injector = Audio.playSound(piano1, lmono);

When the single injector finishes, the injectorLoop will stop looping. This pr fixes that case.

Fixes https://app.asana.com/0/32622044445063/43589567731045