### PR TITLE
restart animations at specified parameters

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -58,15 +58,18 @@ void Rig::removeAnimationHandle(const AnimationHandlePointer& handle) {
 
 void Rig::startAnimation(const QString& url, float fps, float priority,
                               bool loop, bool hold, float firstFrame, float lastFrame, const QStringList& maskedJoints) {
-    //qCDebug(animation) << "startAnimation" << url << fps << priority << loop << hold << firstFrame << lastFrame << maskedJoints;
+    // This is different than startAnimationByRole, in which we use the existing values if the animation already exists.
+    // Here we reuse the animation handle if possible, but in any case, we set the values to those given (or defaulted).
+    AnimationHandlePointer handle = nullptr;
     foreach (const AnimationHandlePointer& candidate, _animationHandles) {
         if (candidate->getURL() == url) {
-            candidate->start();
-            return;
+            handle = candidate;
         }
     }
-    AnimationHandlePointer handle = createAnimationHandle();
-    handle->setURL(url);
+    if (!handle) {
+        handle = createAnimationHandle();
+        handle->setURL(url);
+    }
     handle->setFPS(fps);
     handle->setPriority(priority);
     handle->setLoop(loop);


### PR DESCRIPTION
For startAnimation (but not startAnimationByRole), use the specified parameters even if the animation was already playing.  This fixes the behavior exercised by the squeezeHands.js script.
Fixes https://app.asana.com/0/32622044445063/44025709513292