### PR TITLE
CORE PROFILE: Removing the line width completely from gpu::lib

### DIFF
--- a/interface/src/audio/AudioScope.cpp
+++ b/interface/src/audio/AudioScope.cpp
@@ -137,7 +137,7 @@ void AudioScope::render(RenderArgs* renderArgs, int width, int height) {
     batch.setProjectionTransform(legacyProjection);
     batch.setModelTransform(Transform());
     batch.setViewTransform(Transform());
-    batch._glLineWidth(1.0f); // default
+
     geometryCache->renderQuad(batch, x, y, w, h, backgroundColor, _audioScopeBackground);
     geometryCache->renderGrid(batch, x, y, w, h, gridRows, gridCols, gridColor, _audioScopeGrid);
     renderLineStrip(batch, _inputID, inputColor, x, y, _samplesPerScope, _scopeInputOffset, _scopeInput);

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -397,7 +397,6 @@ void Head::renderLookatVectors(RenderArgs* renderArgs, glm::vec3 leftEyePosition
     auto& batch = *renderArgs->_batch;
     auto transform = Transform{};
     batch.setModelTransform(transform);
-    batch._glLineWidth(2.0f);
 
     auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
     deferredLighting->bindSimpleProgram(batch);

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -397,6 +397,7 @@ void Head::renderLookatVectors(RenderArgs* renderArgs, glm::vec3 leftEyePosition
     auto& batch = *renderArgs->_batch;
     auto transform = Transform{};
     batch.setModelTransform(transform);
+    // FIXME: THe line width of 2.0f is not supported anymore, we ll need a workaround
 
     auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
     deferredLighting->bindSimpleProgram(batch);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -248,7 +248,7 @@ void SkeletonModel::renderJointConstraints(gpu::Batch& batch, int jointIndex) {
     const FBXGeometry& geometry = _geometry->getFBXGeometry();
     const float BASE_DIRECTION_SIZE = 0.3f;
     float directionSize = BASE_DIRECTION_SIZE * extractUniformScale(_scale);
-    batch._glLineWidth(3.0f);
+
     do {
         const FBXJoint& joint = geometry.joints.at(jointIndex);
         const JointState& jointState = _rig->getJointState(jointIndex);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -248,6 +248,7 @@ void SkeletonModel::renderJointConstraints(gpu::Batch& batch, int jointIndex) {
     const FBXGeometry& geometry = _geometry->getFBXGeometry();
     const float BASE_DIRECTION_SIZE = 0.3f;
     float directionSize = BASE_DIRECTION_SIZE * extractUniformScale(_scale);
+    // FIXME: THe line width of 3.0f is not supported anymore, we ll need a workaround
 
     do {
         const FBXJoint& joint = geometry.joints.at(jointIndex);

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -245,6 +245,7 @@ void ApplicationOverlay::renderDomainConnectionStatusBorder(RenderArgs* renderAr
         batch.setModelTransform(Transform());
         batch.setViewTransform(Transform());
         batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
+        // FIXME: THe line width of CONNECTION_STATUS_BORDER_LINE_WIDTH is not supported anymore, we ll need a workaround
 
         // TODO animate the disconnect border for some excitement while not connected?
         //double usecs = usecTimestampNow();

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -137,8 +137,7 @@ void ApplicationOverlay::renderAudioScope(RenderArgs* renderArgs) {
     batch.setProjectionTransform(legacyProjection);
     batch.setModelTransform(Transform());
     batch.setViewTransform(Transform());
-    batch._glLineWidth(1.0f); // default
-    
+
     // Render the audio scope
     DependencyManager::get<AudioScope>()->render(renderArgs, width, height);
 }
@@ -157,8 +156,7 @@ void ApplicationOverlay::renderOverlays(RenderArgs* renderArgs) {
     batch.setProjectionTransform(legacyProjection);
     batch.setModelTransform(Transform());
     batch.setViewTransform(Transform());
-    batch._glLineWidth(1.0f); // default
-    
+
     // Render all of the Script based "HUD" aka 2D overlays.
     // note: we call them HUD, as opposed to 2D, only because there are some cases of 3D HUD overlays, like the
     // cameral controls for the edit.js
@@ -247,7 +245,6 @@ void ApplicationOverlay::renderDomainConnectionStatusBorder(RenderArgs* renderAr
         batch.setModelTransform(Transform());
         batch.setViewTransform(Transform());
         batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
-        batch._glLineWidth(CONNECTION_STATUS_BORDER_LINE_WIDTH);
 
         // TODO animate the disconnect border for some excitement while not connected?
         //double usecs = usecTimestampNow();

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -101,7 +101,6 @@ void Circle3DOverlay::render(RenderArgs* args) {
     
     Q_ASSERT(args->_batch);
     auto& batch = *args->_batch;
-    batch._glLineWidth(_lineWidth);
     
     auto transform = _transform;
     transform.postScale(glm::vec3(getDimensions(), 1.0f));

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -101,7 +101,9 @@ void Circle3DOverlay::render(RenderArgs* args) {
     
     Q_ASSERT(args->_batch);
     auto& batch = *args->_batch;
-    
+
+    // FIXME: THe line width of _lineWidth is not supported anymore, we ll need a workaround
+
     auto transform = _transform;
     transform.postScale(glm::vec3(getDimensions(), 1.0f));
     batch.setModelTransform(transform);

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -60,7 +60,6 @@ void Grid3DOverlay::render(RenderArgs* args) {
 
         // Minor grid
         {
-            batch->_glLineWidth(1.0f);
             auto position = glm::vec3(_minorGridWidth * (floorf(rotated.x / spacing) - MINOR_GRID_DIVISIONS / 2),
                                       spacing * (floorf(rotated.y / spacing) - MINOR_GRID_DIVISIONS / 2),
                                       getPosition().z);
@@ -76,7 +75,6 @@ void Grid3DOverlay::render(RenderArgs* args) {
 
         // Major grid
         {
-            batch->_glLineWidth(4.0f);
             spacing *= _majorGridEvery;
             auto position = glm::vec3(spacing * (floorf(rotated.x / spacing) - MAJOR_GRID_DIVISIONS / 2),
                                       spacing * (floorf(rotated.y / spacing) - MAJOR_GRID_DIVISIONS / 2),

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -84,6 +84,8 @@ void Grid3DOverlay::render(RenderArgs* args) {
             transform.setTranslation(position);
             transform.setScale(scale);
 
+            // FIXME: THe line width of 4.0f is not supported anymore, we ll need a workaround
+
             batch->setModelTransform(transform);
 
             DependencyManager::get<GeometryCache>()->renderGrid(*batch, MAJOR_GRID_DIVISIONS, MAJOR_GRID_DIVISIONS, gridColor);

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -119,7 +119,6 @@ void Overlays::renderHUD(RenderArgs* renderArgs) {
         batch.setProjectionTransform(legacyProjection);
         batch.setModelTransform(Transform());
         batch.setViewTransform(Transform());
-        batch._glLineWidth(1.0f); // default
 
         thisOverlay->render(renderArgs);
     }

--- a/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
@@ -46,13 +46,11 @@ void RenderableLineEntityItem::render(RenderArgs* args) {
     transform.setTranslation(getPosition());
     transform.setRotation(getRotation());
     batch.setModelTransform(transform);
-    
-    batch._glLineWidth(getLineWidth());
+
     if (getLinePoints().size() > 1) {
         DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch);
         DependencyManager::get<GeometryCache>()->renderVertices(batch, gpu::LINE_STRIP, _lineVerticesID);
     }
-    batch._glLineWidth(1.0f);
-    
+
     RenderableDebugableEntityItem::render(this, args);
 };

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -134,7 +134,6 @@ public:
     void _glUniformMatrix4fv(int location, int count, unsigned char transpose, const float* value);
 
     void _glColor4f(float red, float green, float blue, float alpha);
-    void _glLineWidth(float width);
 
     enum Command {
         COMMAND_draw = 0,
@@ -183,7 +182,6 @@ public:
         COMMAND_glUniformMatrix4fv,
 
         COMMAND_glColor4f,
-        COMMAND_glLineWidth,
 
         NUM_COMMANDS,
     };

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -60,7 +60,6 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
     (&::gpu::GLBackend::do_glUniformMatrix4fv),
 
     (&::gpu::GLBackend::do_glColor4f),
-    (&::gpu::GLBackend::do_glLineWidth),
 };
 
 void GLBackend::init() {
@@ -494,18 +493,5 @@ void GLBackend::do_glColor4f(Batch& batch, uint32 paramOffset) {
         batch._params[paramOffset + 2]._float,
         batch._params[paramOffset + 1]._float,
         batch._params[paramOffset + 0]._float);
-    (void) CHECK_GL_ERROR();
-}
-
-void Batch::_glLineWidth(GLfloat width) {
-    ADD_COMMAND_GL(glLineWidth);
-    
-    _params.push_back(width);
-    
-    DO_IT_NOW(_glLineWidth, 1);
-}
-void GLBackend::do_glLineWidth(Batch& batch, uint32 paramOffset) {
-    // FIXME CORE
-    //glLineWidth(batch._params[paramOffset]._float);
     (void) CHECK_GL_ERROR();
 }

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -445,7 +445,6 @@ protected:
     void do_glUniformMatrix4fv(Batch& batch, uint32 paramOffset);
 
     void do_glColor4f(Batch& batch, uint32 paramOffset);
-    void do_glLineWidth(Batch& batch, uint32 paramOffset);
 
     typedef void (GLBackend::*CommandCall)(Batch&, uint32);
     static CommandCall _commandCalls[Batch::NUM_COMMANDS];

--- a/libraries/gpu/src/gpu/GLBackendState.cpp
+++ b/libraries/gpu/src/gpu/GLBackendState.cpp
@@ -586,12 +586,9 @@ void GLBackend::do_setStateMultisampleEnable(bool enable) {
 
 void GLBackend::do_setStateAntialiasedLineEnable(bool enable) {
     if (_pipeline._stateCache.antialisedLineEnable != enable) {
-        // FIXME CORE
         if (enable) {
-        //    glEnable(GL_POINT_SMOOTH);
             glEnable(GL_LINE_SMOOTH);
         } else {
-        //    glDisable(GL_POINT_SMOOTH);
             glDisable(GL_LINE_SMOOTH);
         }
         (void) CHECK_GL_ERROR();

--- a/libraries/gpu/src/gpu/GLBackendState.cpp
+++ b/libraries/gpu/src/gpu/GLBackendState.cpp
@@ -489,6 +489,9 @@ void GLBackend::syncPipelineStateCache() {
     glEnable(GL_PROGRAM_POINT_SIZE_EXT);
     glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
 
+    // Default line width accross the board
+    glLineWidth(1.0f);
+
     getCurrentGLState(state);
     State::Signature signature = State::evalSignature(state);
 

--- a/libraries/gpu/src/gpu/State.h
+++ b/libraries/gpu/src/gpu/State.h
@@ -260,7 +260,7 @@ public:
             depthClampEnable(false),
             scissorEnable(false),
             multisampleEnable(false),
-            antialisedLineEnable(false),
+            antialisedLineEnable(true),
             alphaToCoverageEnable(false)
         {}
     };


### PR DESCRIPTION
Because it s not supporting wide lines correctly and universally anymore on core profile and we would rather have a specialized pipeline for this

So the idea is too remove the lineWidth from the Batch interface

Also turn the state "antialisedLineEnable" true by default 