### PR TITLE
CORE PROFILE: Fix star point smoothing... sort of

### DIFF
--- a/libraries/render-utils/src/stars.slf
+++ b/libraries/render-utils/src/stars.slf
@@ -11,8 +11,24 @@
 //
 
 in vec4 varColor;
+in float varSize;
+
 out vec4 outFragColor;
 
+const float EDGE_SIZE = 0.25;
+const float ALPHA_BOUNDARY = 1.0 - EDGE_SIZE;
+
 void main(void) {
-    outFragColor = varColor; //vec4(varColor, 1.0);
+    vec2 coord = gl_PointCoord * vec2(2.0) - vec2(1.0);
+    coord = coord * coord;
+
+    float l = coord.x + coord.y;
+    if (l > 1.0) {
+        discard;
+    }
+    
+    outFragColor = varColor; 
+    if (l >= ALPHA_BOUNDARY) {
+        outFragColor.a = smoothstep(1.0, ALPHA_BOUNDARY, l);
+    }
 }

--- a/libraries/render-utils/src/stars.slv
+++ b/libraries/render-utils/src/stars.slv
@@ -18,9 +18,12 @@
 
 <$declareStandardTransform()$>
 
-out vec3 varPosition;
-out vec4 varColor;
+// TODO we need to get the viewport resolution and FOV passed to us so we can modify the point size
+// and effectively producing a points that take up a constant angular size regardless of the display resolution 
+// or projection matrix
 
+out vec4 varColor;
+out float varSize;
 
 void main(void) {
     varColor = inColor.rgba;
@@ -29,6 +32,6 @@ void main(void) {
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
-    varPosition = inPosition.xyz;
-    gl_PointSize = inColor.a;
+    varSize = inColor.a;
+    gl_PointSize = varSize; 
 }


### PR DESCRIPTION
This should produce stars that are more circular than square, but some polish needs to go into the edge smoothing and the vertex shader should use the resolution and fov to set sizing, since we have a problem now where the size of the stars varies with your resolution (say between a retina display and a non-retina display).