### PR TITLE
Possible fix for infrequent inability to move on Windows startup

### DIFF
--- a/interface/src/scripting/ControllerScriptingInterface.cpp
+++ b/interface/src/scripting/ControllerScriptingInterface.cpp
@@ -24,7 +24,8 @@
 ControllerScriptingInterface::ControllerScriptingInterface() :
     _mouseCaptured(false),
     _touchCaptured(false),
-    _wheelCaptured(false)
+    _wheelCaptured(false),
+    _actionsCaptured(false)
 {
 
 }


### PR DESCRIPTION
It seems that _actionsCaptured wasn't being initialized so on Windows it was just garbage and would sometimes be true, leaving you unable to move or rotate the camera.  Starting default scripts often fixed it, likely because one of the default scripts probably sets it to false.

However, there might be a separate issue relating to the Keyboard/Scripted Motor Controls menu options on startup, which could prevent you from moving but would NOT prevent you from rotating the camera.