### PR TITLE
update build instructions -- interface now depends on zlib

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,6 +5,7 @@
 * [OpenSSL](https://www.openssl.org/related/binaries.html) ~> 1.0.1m
   * IMPORTANT: Using the recommended version of OpenSSL is critical to avoid security vulnerabilities.
 * [VHACD](https://github.com/virneo/v-hacd)(clone this repository)(Optional)
+* [zlib](http://www.zlib.net/)
 
 ####CMake External Project Dependencies
 

--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -75,6 +75,16 @@ To prevent these problems, install OpenSSL yourself. Download the following bina
 
 Install OpenSSL into the Windows system directory, to make sure that Qt uses the version that you've just installed, and not some other version.
 
+####zlib
+
+Install zlib from
+
+  [Zlib for Windows](http://gnuwin32.sourceforge.net/packages/zlib.htm)
+
+and fix a header file, as described here:
+
+  [zlib zconf.h bug](http://sourceforge.net/p/gnuwin32/bugs/169/)
+
 ###Build High Fidelity using Visual Studio
 Follow the same build steps from the CMake section of [BUILD.md](BUILD.md), but pass a different generator to CMake.
 


### PR DESCRIPTION
Update build instructions to indicate that zlib is required.