### PR TITLE
Worklist 20624 My mixamo avatar crashing interface.exe

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -365,9 +365,9 @@ void Resource::maybeRefresh() {
         QVariant variant = reply->header(QNetworkRequest::LastModifiedHeader);
         QNetworkCacheMetaData metaData = NetworkAccessManager::getInstance().cache()->metaData(_url);
 
-        QUrl url(reply->url().toString());
+        QUrl replyUrl(reply->url().toString());
         // check if the reply is the same url as the file from the cache
-        if (_url.fileName() == url.fileName()) {
+        if (_url.fileName() == replyUrl.fileName()) {
             if (variant.isValid() && variant.canConvert<QDateTime>() && metaData.isValid()) {
                 QDateTime lastModified = variant.value<QDateTime>();
                 QDateTime lastModifiedOld = metaData.lastModified();


### PR DESCRIPTION
Added a check if the fileName() checked is the same as the file in the
cache.
Move the refresh into the if, so the cache only gets refreshed when
needed.

The fst file is cached ok, and loaded almost instantly when in the
cache. However when the fst is loaded in, it causes the maybeRefresh
being called a second time with the fbx file, this should not trigger a
refresh of the fst file.