### PR TITLE
Clean Up JointState

### DIFF
--- a/interface/src/avatar/FaceModel.cpp
+++ b/interface/src/avatar/FaceModel.cpp
@@ -56,12 +56,12 @@ void FaceModel::simulate(float deltaTime, bool fullUpdate) {
     }
 }
 
-void FaceModel::maybeUpdateNeckRotation(const JointState& parentState, const FBXJoint& joint, int index) {
+void FaceModel::maybeUpdateNeckRotation(const JointState& parentState, const JointState& state, int index) {
     // get the rotation axes in joint space and use them to adjust the rotation
     glm::mat3 axes = glm::mat3_cast(glm::quat());
     glm::mat3 inverse = glm::mat3(glm::inverse(parentState.getTransform() *
                                                glm::translate(_rig->getJointDefaultTranslationInConstrainedFrame(index)) *
-                                               joint.preTransform * glm::mat4_cast(joint.preRotation)));
+                                               state.getPreTransform() * glm::mat4_cast(state.getPreRotation())));
     glm::vec3 pitchYawRoll = safeEulerAngles(_owningHead->getFinalOrientationInLocalFrame());
     glm::vec3 lean = glm::radians(glm::vec3(_owningHead->getFinalLeanForward(),
                                             _owningHead->getTorsoTwist(),
@@ -71,15 +71,15 @@ void FaceModel::maybeUpdateNeckRotation(const JointState& parentState, const FBX
                                              glm::angleAxis(-pitchYawRoll.z, glm::normalize(inverse * axes[2]))
                                              * glm::angleAxis(pitchYawRoll.y, glm::normalize(inverse * axes[1]))
                                              * glm::angleAxis(-pitchYawRoll.x, glm::normalize(inverse * axes[0]))
-                                             * joint.rotation, DEFAULT_PRIORITY);
+                                             * state.getOriginalRotation(), DEFAULT_PRIORITY);
 }
 
-void FaceModel::maybeUpdateEyeRotation(Model* model, const JointState& parentState, const FBXJoint& joint, int index) {
+void FaceModel::maybeUpdateEyeRotation(Model* model, const JointState& parentState, const JointState& state, int index) {
     // likewise with the eye joints
     // NOTE: at the moment we do the math in the world-frame, hence the inverse transform is more complex than usual.
     glm::mat4 inverse = glm::inverse(glm::mat4_cast(model->getRotation()) * parentState.getTransform() *
                                      glm::translate(_rig->getJointDefaultTranslationInConstrainedFrame(index)) *
-                                     joint.preTransform * glm::mat4_cast(joint.preRotation * joint.rotation));
+                                     state.getPreTransform() * glm::mat4_cast(state.getPreRotation() * state.getOriginalRotation()));
     glm::vec3 front = glm::vec3(inverse * glm::vec4(_owningHead->getFinalOrientationInWorldFrame() * IDENTITY_FRONT, 0.0f));
     glm::vec3 lookAtDelta = _owningHead->getCorrectedLookAtPosition() - model->getTranslation();
     glm::vec3 lookAt = glm::vec3(inverse * glm::vec4(lookAtDelta + glm::length(lookAtDelta) * _owningHead->getSaccade(), 1.0f));
@@ -87,22 +87,22 @@ void FaceModel::maybeUpdateEyeRotation(Model* model, const JointState& parentSta
     const float MAX_ANGLE = 30.0f * RADIANS_PER_DEGREE;
     _rig->setJointRotationInConstrainedFrame(index, glm::angleAxis(glm::clamp(glm::angle(between),
                                                                               -MAX_ANGLE, MAX_ANGLE), glm::axis(between)) *
-                                             joint.rotation, DEFAULT_PRIORITY);
+                                             state.getOriginalRotation(), DEFAULT_PRIORITY);
 }
 
 void FaceModel::maybeUpdateNeckAndEyeRotation(int index) {
     const JointState& state = _rig->getJointState(index);
-    const FBXJoint& joint = state.getFBXJoint();
     const FBXGeometry& geometry = _geometry->getFBXGeometry();
+    const int parentIndex = state.getParentIndex();
 
     // guard against out-of-bounds access to _jointStates
-    if (joint.parentIndex != -1 && joint.parentIndex >= 0 && joint.parentIndex < _rig->getJointStateCount()) {
-        const JointState& parentState = _rig->getJointState(joint.parentIndex);
+    if (parentIndex != -1 && parentIndex >= 0 && parentIndex < _rig->getJointStateCount()) {
+        const JointState& parentState = _rig->getJointState(parentIndex);
         if (index == geometry.neckJointIndex) {
-            maybeUpdateNeckRotation(parentState, joint, index);
+            maybeUpdateNeckRotation(parentState, state, index);
 
         } else if (index == geometry.leftEyeJointIndex || index == geometry.rightEyeJointIndex) {
-            maybeUpdateEyeRotation(this, parentState, joint, index);
+            maybeUpdateEyeRotation(this, parentState, state, index);
         }
     }
 }

--- a/interface/src/avatar/FaceModel.cpp
+++ b/interface/src/avatar/FaceModel.cpp
@@ -71,7 +71,7 @@ void FaceModel::maybeUpdateNeckRotation(const JointState& parentState, const Joi
                                              glm::angleAxis(-pitchYawRoll.z, glm::normalize(inverse * axes[2]))
                                              * glm::angleAxis(pitchYawRoll.y, glm::normalize(inverse * axes[1]))
                                              * glm::angleAxis(-pitchYawRoll.x, glm::normalize(inverse * axes[0]))
-                                             * state.getOriginalRotation(), DEFAULT_PRIORITY);
+                                             * state.getDefaultRotation(), DEFAULT_PRIORITY);
 }
 
 void FaceModel::maybeUpdateEyeRotation(Model* model, const JointState& parentState, const JointState& state, int index) {
@@ -79,7 +79,7 @@ void FaceModel::maybeUpdateEyeRotation(Model* model, const JointState& parentSta
     // NOTE: at the moment we do the math in the world-frame, hence the inverse transform is more complex than usual.
     glm::mat4 inverse = glm::inverse(glm::mat4_cast(model->getRotation()) * parentState.getTransform() *
                                      glm::translate(_rig->getJointDefaultTranslationInConstrainedFrame(index)) *
-                                     state.getPreTransform() * glm::mat4_cast(state.getPreRotation() * state.getOriginalRotation()));
+                                     state.getPreTransform() * glm::mat4_cast(state.getPreRotation() * state.getDefaultRotation()));
     glm::vec3 front = glm::vec3(inverse * glm::vec4(_owningHead->getFinalOrientationInWorldFrame() * IDENTITY_FRONT, 0.0f));
     glm::vec3 lookAtDelta = _owningHead->getCorrectedLookAtPosition() - model->getTranslation();
     glm::vec3 lookAt = glm::vec3(inverse * glm::vec4(lookAtDelta + glm::length(lookAtDelta) * _owningHead->getSaccade(), 1.0f));
@@ -87,7 +87,7 @@ void FaceModel::maybeUpdateEyeRotation(Model* model, const JointState& parentSta
     const float MAX_ANGLE = 30.0f * RADIANS_PER_DEGREE;
     _rig->setJointRotationInConstrainedFrame(index, glm::angleAxis(glm::clamp(glm::angle(between),
                                                                               -MAX_ANGLE, MAX_ANGLE), glm::axis(between)) *
-                                             state.getOriginalRotation(), DEFAULT_PRIORITY);
+                                             state.getDefaultRotation(), DEFAULT_PRIORITY);
 }
 
 void FaceModel::maybeUpdateNeckAndEyeRotation(int index) {

--- a/interface/src/avatar/FaceModel.h
+++ b/interface/src/avatar/FaceModel.h
@@ -26,8 +26,8 @@ public:
 
     virtual void simulate(float deltaTime, bool fullUpdate = true);
 
-    void maybeUpdateNeckRotation(const JointState& parentState, const FBXJoint& joint, int index);
-    void maybeUpdateEyeRotation(Model* model, const JointState& parentState, const FBXJoint& joint, int index);
+    void maybeUpdateNeckRotation(const JointState& parentState, const JointState& state, int index);
+    void maybeUpdateEyeRotation(Model* model, const JointState& parentState, const JointState& state, int index);
     void maybeUpdateNeckAndEyeRotation(int index);
 
     /// Retrieve the positions of up to two eye meshes.

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -401,7 +401,7 @@ bool SkeletonModel::getNeckParentRotationFromDefaultOrientation(glm::quat& neckP
     glm::quat worldFrameRotation;
     bool success = getJointRotationInWorldFrame(parentIndex, worldFrameRotation);
     if (success) {
-        neckParentRotation = worldFrameRotation * _rig->getJointState(parentIndex).getFBXJoint().inverseDefaultRotation;
+        neckParentRotation = worldFrameRotation * _rig->getJointState(parentIndex).getInverseDefaultRotation();
     }
     return success;
 }
@@ -477,18 +477,17 @@ void SkeletonModel::computeBoundingShape(const FBXGeometry& geometry) {
     for (int i = 0; i < numStates; i++) {
         // compute the default transform of this joint
         const JointState& state = _rig->getJointState(i);
-        const FBXJoint& joint = state.getFBXJoint();
-        int parentIndex = joint.parentIndex;
+        int parentIndex = state.getParentIndex();
         if (parentIndex == -1) {
             transforms[i] = _rig->getJointTransform(i);
         } else {
-            glm::quat modifiedRotation = joint.preRotation * joint.rotation * joint.postRotation;    
-            transforms[i] = transforms[parentIndex] * glm::translate(joint.translation) 
-                * joint.preTransform * glm::mat4_cast(modifiedRotation) * joint.postTransform;
+            glm::quat modifiedRotation = state.getPreRotation() * state.getOriginalRotation() * state.getPostRotation();
+            transforms[i] = transforms[parentIndex] * glm::translate(state.getTranslation())
+                * state.getPreTransform() * glm::mat4_cast(modifiedRotation) * state.getPostTransform();
         }
 
         // Each joint contributes a sphere at its position
-        glm::vec3 axis(joint.boneRadius);
+        glm::vec3 axis(state.getBoneRadius());
         glm::vec3 jointPosition = extractTranslation(transforms[i]);
         totalExtents.addPoint(jointPosition + axis);
         totalExtents.addPoint(jointPosition - axis);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -481,7 +481,7 @@ void SkeletonModel::computeBoundingShape(const FBXGeometry& geometry) {
         if (parentIndex == -1) {
             transforms[i] = _rig->getJointTransform(i);
         } else {
-            glm::quat modifiedRotation = state.getPreRotation() * state.getOriginalRotation() * state.getPostRotation();
+            glm::quat modifiedRotation = state.getPreRotation() * state.getDefaultRotation() * state.getPostRotation();
             transforms[i] = transforms[parentIndex] * glm::translate(state.getTranslation())
                 * state.getPreTransform() * glm::mat4_cast(modifiedRotation) * state.getPostTransform();
         }

--- a/libraries/animation/src/AvatarRig.cpp
+++ b/libraries/animation/src/AvatarRig.cpp
@@ -17,7 +17,6 @@ void AvatarRig::updateJointState(int index, glm::mat4 parentTransform) {
         return; // bail
     }
     JointState& state = _jointStates[index];
-    const FBXJoint& joint = state.getFBXJoint();
 
     // compute model transforms
     if (index == _rootJointIndex) {
@@ -26,7 +25,7 @@ void AvatarRig::updateJointState(int index, glm::mat4 parentTransform) {
         clearJointTransformTranslation(index);
     } else {
         // guard against out-of-bounds access to _jointStates
-        int parentIndex = joint.parentIndex;
+        int parentIndex = state.getParentIndex();
         if (parentIndex >= 0 && parentIndex < _jointStates.size()) {
             const JointState& parentState = _jointStates.at(parentIndex);
             state.computeTransform(parentState.getTransform(), parentState.getTransformChanged());
@@ -53,8 +52,8 @@ void AvatarRig::setHandPosition(int jointIndex,
     }
 
     // precomputed lengths
-    float upperArmLength = _jointStates[elbowJointIndex].getFBXJoint().distanceToParent * scale;
-    float lowerArmLength = _jointStates[jointIndex].getFBXJoint().distanceToParent * scale;
+    float upperArmLength = _jointStates[elbowJointIndex].getDistanceToParent() * scale;
+    float lowerArmLength = _jointStates[jointIndex].getDistanceToParent() * scale;
 
     // first set wrist position
     glm::vec3 wristPosition = position;

--- a/libraries/animation/src/EntityRig.cpp
+++ b/libraries/animation/src/EntityRig.cpp
@@ -14,15 +14,14 @@
 /// Updates the state of the joint at the specified index.
 void EntityRig::updateJointState(int index, glm::mat4 parentTransform) {
     JointState& state = _jointStates[index];
-    const FBXJoint& joint = state.getFBXJoint();
 
     // compute model transforms
-    int parentIndex = joint.parentIndex;
+    int parentIndex = state.getParentIndex();
     if (parentIndex == -1) {
         state.computeTransform(parentTransform);
     } else {
         // guard against out-of-bounds access to _jointStates
-        if (joint.parentIndex >= 0 && joint.parentIndex < _jointStates.size()) {
+        if (parentIndex >= 0 && parentIndex < _jointStates.size()) {
             const JointState& parentState = _jointStates.at(parentIndex);
             state.computeTransform(parentState.getTransform(), parentState.getTransformChanged());
         }

--- a/libraries/animation/src/JointState.cpp
+++ b/libraries/animation/src/JointState.cpp
@@ -42,7 +42,7 @@ JointState::JointState(const JointState& other) : _constraint(NULL) {
     _boneRadius = other._boneRadius;
     _parentIndex = other._parentIndex;
     _translation = other._translation;
-    _originalRotation = other._originalRotation;
+    _defaultRotation = other._defaultRotation;
     _inverseDefaultRotation = other._inverseDefaultRotation;
     _rotationMin = other._rotationMin;
     _rotationMax = other._rotationMax;
@@ -82,7 +82,7 @@ void JointState::setFBXJoint(const FBXJoint* joint) {
     _boneRadius = joint->boneRadius;
     _parentIndex = joint->parentIndex;
     _translation = joint->translation;
-    _originalRotation = joint->rotation;
+    _defaultRotation = joint->rotation;
     _inverseDefaultRotation = joint->inverseDefaultRotation;
     _rotationMin = joint->rotationMin;
     _rotationMax = joint->rotationMax;
@@ -127,7 +127,7 @@ void JointState::copyState(const JointState& state) {
     _isFree = state._isFree;
     _boneRadius = state._boneRadius;
     _parentIndex = state._parentIndex;
-    _originalRotation = state._originalRotation;
+    _defaultRotation = state._defaultRotation;
     _inverseDefaultRotation = state._inverseDefaultRotation;
     _translation = state._translation;
     _rotationMin = state._rotationMin;
@@ -182,7 +182,7 @@ glm::quat JointState::getVisibleRotationInParentFrame() const {
 
 void JointState::restoreRotation(float fraction, float priority) {
     if (priority == _animationPriority || _animationPriority == 0.0f) {
-        setRotationInConstrainedFrameInternal(safeMix(_rotationInConstrainedFrame, _originalRotation, fraction));
+        setRotationInConstrainedFrameInternal(safeMix(_rotationInConstrainedFrame, _defaultRotation, fraction));
         _animationPriority = 0.0f;
     }
 }
@@ -237,7 +237,7 @@ void JointState::mixRotationDelta(const glm::quat& delta, float mixFactor, float
     _animationPriority = priority;
     glm::quat targetRotation = _rotationInConstrainedFrame * glm::inverse(getRotation()) * delta * getRotation();
     if (mixFactor > 0.0f && mixFactor <= 1.0f) {
-        targetRotation = safeMix(targetRotation, _originalRotation, mixFactor);
+        targetRotation = safeMix(targetRotation, _defaultRotation, mixFactor);
     }
     if (_constraint) {
         _constraint->softClamp(targetRotation, _rotationInConstrainedFrame, 0.5f);
@@ -290,7 +290,7 @@ void JointState::setVisibleRotationInConstrainedFrame(const glm::quat& targetRot
 }
 
 bool JointState::rotationIsDefault(const glm::quat& rotation, float tolerance) const {
-    glm::quat defaultRotation = _originalRotation;
+    glm::quat defaultRotation = _defaultRotation;
     return glm::abs(rotation.x - defaultRotation.x) < tolerance &&
         glm::abs(rotation.y - defaultRotation.y) < tolerance &&
         glm::abs(rotation.z - defaultRotation.z) < tolerance &&
@@ -299,7 +299,7 @@ bool JointState::rotationIsDefault(const glm::quat& rotation, float tolerance) c
 
 glm::quat JointState::getDefaultRotationInParentFrame() const {
     // NOTE: the result is constant and could be cached
-    return _preRotation * _originalRotation * _postRotation;
+    return _preRotation * _defaultRotation * _postRotation;
 }
 
 const glm::vec3& JointState::getDefaultTranslationInConstrainedFrame() const {

--- a/libraries/animation/src/JointState.h
+++ b/libraries/animation/src/JointState.h
@@ -26,15 +26,13 @@ class AngularConstraint;
 
 class JointState {
 public:
-    JointState();
-    JointState(const JointState& other);
+    JointState() {}
+    JointState(const JointState& other) : _constraint(NULL) { copyState(other); }
+    JointState(const FBXJoint& joint);
     ~JointState();
-
-    void setFBXJoint(const FBXJoint* joint); 
-
-    void buildConstraint();
     void copyState(const JointState& state);
-
+    void buildConstraint();
+ 
     void initTransform(const glm::mat4& parentTransform);
     // if synchronousRotationCompute is true, then _transform is still computed synchronously,
     // but _rotation will be asynchronously extracted
@@ -98,9 +96,7 @@ public:
 
     void slaveVisibleTransform();
 
-    float _animationPriority; // the priority of the animation affecting this joint
-
-    /// \return parent model-frame rotation 
+    /// \return parent model-frame rotation
     // (used to keep _rotation consistent when modifying _rotationInWorldFrame directly)
     glm::quat computeParentRotation() const;
     glm::quat computeVisibleParentRotation() const;
@@ -118,19 +114,24 @@ public:
     const QString& getName() const { return _name; }
     float getBoneRadius() const { return _boneRadius; }
     bool getIsFree() const { return _isFree; }
+    float getAnimationPriority() const { return _animationPriority; }
+    void setAnimationPriority(float priority) { _animationPriority = priority; }
 
 private:
     void setRotationInConstrainedFrameInternal(const glm::quat& targetRotation);
     /// debug helper function
     void loadBindRotation();
 
-    bool _transformChanged;
+    bool _transformChanged {true};
+    bool _rotationIsValid {false};
+    glm::vec3 _positionInParentFrame {0.0f}; // only changes when the Model is scaled
+    float _animationPriority {0.0f}; // the priority of the animation affecting this joint
+    float _distanceToParent {0.0f};
+    AngularConstraint* _constraint{nullptr}; // JointState owns its AngularConstraint
+    
     glm::mat4 _transform; // joint- to model-frame
-    bool _rotationIsValid;
     glm::quat _rotation;  // joint- to model-frame
     glm::quat _rotationInConstrainedFrame; // rotation in frame where angular constraints would be applied
-    glm::vec3 _positionInParentFrame; // only changes when the Model is scaled
-    float _distanceToParent;
 
     glm::mat4 _visibleTransform;
     glm::quat _visibleRotation;
@@ -139,8 +140,10 @@ private:
     glm::quat _defaultRotation; // Not necessarilly bind rotation. See FBXJoint transform/bindTransform
     glm::quat _inverseDefaultRotation;
     glm::vec3 _translation;
-    float _boneRadius;
+    QString _name;
+    int _parentIndex;
     bool _isFree;
+    float _boneRadius;
     glm::vec3 _rotationMin;
     glm::vec3 _rotationMax;
     glm::quat _preRotation;
@@ -148,9 +151,6 @@ private:
     glm::mat4 _preTransform;
     glm::mat4 _postTransform;
     glm::quat _inverseBindRotation;
-    int _parentIndex;
-    QString _name;
-    AngularConstraint* _constraint; // JointState owns its AngularConstraint
 };
 
 #endif // hifi_JointState_h

--- a/libraries/animation/src/JointState.h
+++ b/libraries/animation/src/JointState.h
@@ -113,7 +113,7 @@ public:
     const glm::mat4& getPostTransform() const { return _postTransform; }
     const glm::quat& getPreRotation() const { return _preRotation; }
     const glm::quat& getPostRotation() const { return _postRotation; }
-    const glm::quat& getOriginalRotation() const { return _originalRotation; }
+    const glm::quat& getDefaultRotation() const { return _defaultRotation; }
     const glm::quat& getInverseDefaultRotation() const { return _inverseDefaultRotation; }
     const QString& getName() const { return _name; }
     float getBoneRadius() const { return _boneRadius; }
@@ -136,7 +136,7 @@ private:
     glm::quat _visibleRotation;
     glm::quat _visibleRotationInConstrainedFrame;
 
-    glm::quat _originalRotation; // Not necessarilly bind rotation. See FBXJoint transform/bindTransform
+    glm::quat _defaultRotation; // Not necessarilly bind rotation. See FBXJoint transform/bindTransform
     glm::quat _inverseDefaultRotation;
     glm::vec3 _translation;
     float _boneRadius;

--- a/libraries/animation/src/JointState.h
+++ b/libraries/animation/src/JointState.h
@@ -31,7 +31,6 @@ public:
     ~JointState();
 
     void setFBXJoint(const FBXJoint* joint); 
-    const FBXJoint& getFBXJoint() const { return *_fbxJoint; }
 
     void buildConstraint();
     void copyState(const JointState& state);
@@ -61,7 +60,7 @@ public:
     const glm::vec3& getPositionInParentFrame() const { return _positionInParentFrame; }
     float getDistanceToParent() const { return _distanceToParent; }
 
-    int getParentIndex() const { return _fbxJoint->parentIndex; }
+    int getParentIndex() const { return _parentIndex; }
 
     /// \param delta is in the model-frame
     void applyRotationDelta(const glm::quat& delta, bool constrain = true, float priority = 1.0f);
@@ -108,6 +107,17 @@ public:
 
     void setTransform(const glm::mat4& transform) { _transform = transform; }
     void setVisibleTransform(const glm::mat4& transform) { _visibleTransform = transform; }
+    
+    const glm::vec3& getTranslation() const { return _translation; }
+    const glm::mat4& getPreTransform() const { return _preTransform; }
+    const glm::mat4& getPostTransform() const { return _postTransform; }
+    const glm::quat& getPreRotation() const { return _preRotation; }
+    const glm::quat& getPostRotation() const { return _postRotation; }
+    const glm::quat& getOriginalRotation() const { return _originalRotation; }
+    const glm::quat& getInverseDefaultRotation() const { return _inverseDefaultRotation; }
+    const QString& getName() const { return _name; }
+    float getBoneRadius() const { return _boneRadius; }
+    bool getIsFree() const { return _isFree; }
 
 private:
     void setRotationInConstrainedFrameInternal(const glm::quat& targetRotation);
@@ -126,7 +136,20 @@ private:
     glm::quat _visibleRotation;
     glm::quat _visibleRotationInConstrainedFrame;
 
-    const FBXJoint* _fbxJoint; // JointState does NOT own its FBXJoint
+    glm::quat _originalRotation; // Not necessarilly bind rotation. See FBXJoint transform/bindTransform
+    glm::quat _inverseDefaultRotation;
+    glm::vec3 _translation;
+    float _boneRadius;
+    bool _isFree;
+    glm::vec3 _rotationMin;
+    glm::vec3 _rotationMax;
+    glm::quat _preRotation;
+    glm::quat _postRotation;
+    glm::mat4 _preTransform;
+    glm::mat4 _postTransform;
+    glm::quat _inverseBindRotation;
+    int _parentIndex;
+    QString _name;
     AngularConstraint* _constraint; // JointState owns its AngularConstraint
 };
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -299,20 +299,20 @@ void Rig::clearJointStates() {
 
 void Rig::clearJointAnimationPriority(int index) {
     if (index != -1 && index < _jointStates.size()) {
-        _jointStates[index]._animationPriority = 0.0f;
+        _jointStates[index].setAnimationPriority(0.0f);
     }
 }
 
 float Rig::getJointAnimatinoPriority(int index) {
     if (index != -1 && index < _jointStates.size()) {
-        return _jointStates[index]._animationPriority;
+        return _jointStates[index].getAnimationPriority();
     }
     return 0.0f;
 }
 
 void Rig::setJointAnimatinoPriority(int index, float newPriority) {
     if (index != -1 && index < _jointStates.size()) {
-        _jointStates[index]._animationPriority = newPriority;
+        _jointStates[index].setAnimationPriority(newPriority);
     }
 }
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -222,7 +222,7 @@ float Rig::initJointStates(QVector<JointState> states, glm::mat4 parentTransform
 // Should we be using .fst mapping instead/also?
 int Rig::indexOfJoint(const QString& jointName) {
     for (int i = 0; i < _jointStates.count(); i++) {
-        if (_jointStates[i].getFBXJoint().name == jointName) {
+        if (_jointStates[i].getName() == jointName) {
             return i;
         }
     }
@@ -235,8 +235,7 @@ void Rig::initJointTransforms(glm::mat4 parentTransform) {
     int numStates = _jointStates.size();
     for (int i = 0; i < numStates; ++i) {
         JointState& state = _jointStates[i];
-        const FBXJoint& joint = state.getFBXJoint();
-        int parentIndex = joint.parentIndex;
+        int parentIndex = state.getParentIndex();
         if (parentIndex == -1) {
             state.initTransform(parentTransform);
         } else {
@@ -528,8 +527,7 @@ bool Rig::setJointPosition(int jointIndex, const glm::vec3& position, const glm:
         for (int j = 1; freeLineage.at(j - 1) != lastFreeIndex; j++) {
             int index = freeLineage.at(j);
             JointState& state = _jointStates[index];
-            const FBXJoint& joint = state.getFBXJoint();
-            if (!(joint.isFree || allIntermediatesFree)) {
+            if (!(state.getIsFree() || allIntermediatesFree)) {
                 continue;
             }
             glm::vec3 jointPosition = extractTranslation(state.getTransform());
@@ -598,8 +596,7 @@ void Rig::inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::q
     {
         int index = freeLineage.last();
         const JointState& state = _jointStates.at(index);
-        const FBXJoint& joint = state.getFBXJoint();
-        int parentIndex = joint.parentIndex;
+        int parentIndex = state.getParentIndex();
         if (parentIndex == -1) {
             topParentTransform = parentTransform;
         } else {
@@ -624,8 +621,7 @@ void Rig::inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::q
         for (int j = 1; j < numFree; j++) {
             int nextIndex = freeLineage.at(j);
             JointState& nextState = _jointStates[nextIndex];
-            FBXJoint nextJoint = nextState.getFBXJoint();
-            if (! nextJoint.isFree) {
+            if (! nextState.getIsFree()) {
                 continue;
             }
 
@@ -799,20 +795,20 @@ void Rig::updateLeanJoint(int index, float leanSideways, float leanForward, floa
                                            glm::angleAxis(- RADIANS_PER_DEGREE * leanSideways, inverse * zAxis) *
                                            glm::angleAxis(- RADIANS_PER_DEGREE * leanForward, inverse * xAxis) *
                                            glm::angleAxis(RADIANS_PER_DEGREE * torsoTwist, inverse * yAxis) *
-                                           getJointState(index).getFBXJoint().rotation, DEFAULT_PRIORITY);
+                                           getJointState(index).getOriginalRotation(), DEFAULT_PRIORITY);
     }
 }
 
 void Rig::updateNeckJoint(int index, const glm::quat& localHeadOrientation, float leanSideways, float leanForward, float torsoTwist) {
     if (index >= 0 && _jointStates[index].getParentIndex() >= 0) {
-        auto& parentState = _jointStates[_jointStates[index].getParentIndex()];
-        auto joint = _jointStates[index].getFBXJoint();
+        auto& state = _jointStates[index];
+        auto& parentState = _jointStates[state.getParentIndex()];
 
         // get the rotation axes in joint space and use them to adjust the rotation
         glm::mat3 axes = glm::mat3_cast(glm::quat());
         glm::mat3 inverse = glm::mat3(glm::inverse(parentState.getTransform() *
                                                    glm::translate(getJointDefaultTranslationInConstrainedFrame(index)) *
-                                                   joint.preTransform * glm::mat4_cast(joint.preRotation)));
+                                                   state.getPreTransform() * glm::mat4_cast(state.getPreRotation())));
         glm::vec3 pitchYawRoll = safeEulerAngles(localHeadOrientation);
         glm::vec3 lean = glm::radians(glm::vec3(leanForward, torsoTwist, leanSideways));
         pitchYawRoll -= lean;
@@ -820,19 +816,19 @@ void Rig::updateNeckJoint(int index, const glm::quat& localHeadOrientation, floa
                                            glm::angleAxis(-pitchYawRoll.z, glm::normalize(inverse * axes[2])) *
                                            glm::angleAxis(pitchYawRoll.y, glm::normalize(inverse * axes[1])) *
                                            glm::angleAxis(-pitchYawRoll.x, glm::normalize(inverse * axes[0])) *
-                                           joint.rotation, DEFAULT_PRIORITY);
+                                           state.getOriginalRotation(), DEFAULT_PRIORITY);
     }
 }
 
 void Rig::updateEyeJoint(int index, const glm::quat& worldHeadOrientation, const glm::vec3& lookAt, const glm::vec3& saccade) {
     if (index >= 0 && _jointStates[index].getParentIndex() >= 0) {
-        auto& parentState = _jointStates[_jointStates[index].getParentIndex()];
-        auto joint = _jointStates[index].getFBXJoint();
+        auto& state = _jointStates[index];
+        auto& parentState = _jointStates[state.getParentIndex()];
 
         // NOTE: at the moment we do the math in the world-frame, hence the inverse transform is more complex than usual.
         glm::mat4 inverse = glm::inverse(parentState.getTransform() *
                                          glm::translate(getJointDefaultTranslationInConstrainedFrame(index)) *
-                                         joint.preTransform * glm::mat4_cast(joint.preRotation * joint.rotation));
+                                         state.getPreTransform() * glm::mat4_cast(state.getPreRotation() * state.getOriginalRotation()));
         glm::vec3 front = glm::vec3(inverse * glm::vec4(worldHeadOrientation * IDENTITY_FRONT, 0.0f));
         glm::vec3 lookAtDelta = lookAt;
         glm::vec3 lookAt = glm::vec3(inverse * glm::vec4(lookAtDelta + glm::length(lookAtDelta) * saccade, 1.0f));
@@ -840,6 +836,6 @@ void Rig::updateEyeJoint(int index, const glm::quat& worldHeadOrientation, const
         const float MAX_ANGLE = 30.0f * RADIANS_PER_DEGREE;
         float angle = glm::clamp(glm::angle(between), -MAX_ANGLE, MAX_ANGLE);
         glm::quat rot = glm::angleAxis(angle, glm::axis(between));
-        setJointRotationInConstrainedFrame(index, rot * joint.rotation, DEFAULT_PRIORITY);
+        setJointRotationInConstrainedFrame(index, rot * state.getOriginalRotation(), DEFAULT_PRIORITY);
     }
 }

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -795,7 +795,7 @@ void Rig::updateLeanJoint(int index, float leanSideways, float leanForward, floa
                                            glm::angleAxis(- RADIANS_PER_DEGREE * leanSideways, inverse * zAxis) *
                                            glm::angleAxis(- RADIANS_PER_DEGREE * leanForward, inverse * xAxis) *
                                            glm::angleAxis(RADIANS_PER_DEGREE * torsoTwist, inverse * yAxis) *
-                                           getJointState(index).getOriginalRotation(), DEFAULT_PRIORITY);
+                                           getJointState(index).getDefaultRotation(), DEFAULT_PRIORITY);
     }
 }
 
@@ -816,7 +816,7 @@ void Rig::updateNeckJoint(int index, const glm::quat& localHeadOrientation, floa
                                            glm::angleAxis(-pitchYawRoll.z, glm::normalize(inverse * axes[2])) *
                                            glm::angleAxis(pitchYawRoll.y, glm::normalize(inverse * axes[1])) *
                                            glm::angleAxis(-pitchYawRoll.x, glm::normalize(inverse * axes[0])) *
-                                           state.getOriginalRotation(), DEFAULT_PRIORITY);
+                                           state.getDefaultRotation(), DEFAULT_PRIORITY);
     }
 }
 
@@ -828,7 +828,7 @@ void Rig::updateEyeJoint(int index, const glm::quat& worldHeadOrientation, const
         // NOTE: at the moment we do the math in the world-frame, hence the inverse transform is more complex than usual.
         glm::mat4 inverse = glm::inverse(parentState.getTransform() *
                                          glm::translate(getJointDefaultTranslationInConstrainedFrame(index)) *
-                                         state.getPreTransform() * glm::mat4_cast(state.getPreRotation() * state.getOriginalRotation()));
+                                         state.getPreTransform() * glm::mat4_cast(state.getPreRotation() * state.getDefaultRotation()));
         glm::vec3 front = glm::vec3(inverse * glm::vec4(worldHeadOrientation * IDENTITY_FRONT, 0.0f));
         glm::vec3 lookAtDelta = lookAt;
         glm::vec3 lookAt = glm::vec3(inverse * glm::vec4(lookAtDelta + glm::length(lookAtDelta) * saccade, 1.0f));
@@ -836,6 +836,6 @@ void Rig::updateEyeJoint(int index, const glm::quat& worldHeadOrientation, const
         const float MAX_ANGLE = 30.0f * RADIANS_PER_DEGREE;
         float angle = glm::clamp(glm::angle(between), -MAX_ANGLE, MAX_ANGLE);
         glm::quat rot = glm::angleAxis(angle, glm::axis(between));
-        setJointRotationInConstrainedFrame(index, rot * state.getOriginalRotation(), DEFAULT_PRIORITY);
+        setJointRotationInConstrainedFrame(index, rot * state.getDefaultRotation(), DEFAULT_PRIORITY);
     }
 }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -226,9 +226,7 @@ QVector<JointState> Model::createJointStates(const FBXGeometry& geometry) {
     for (int i = 0; i < geometry.joints.size(); ++i) {
         const FBXJoint& joint = geometry.joints[i];
         // store a pointer to the FBXJoint in the JointState
-        JointState state;
-        state.setFBXJoint(&joint);
-
+        JointState state(joint);
         jointStates.append(state);
     }
     return jointStates;

--- a/tests/animation/src/RigTests.cpp
+++ b/tests/animation/src/RigTests.cpp
@@ -79,7 +79,7 @@ void RigTests::initTestCase() {
 
 static void reportJoint(int index, JointState joint) { // Handy for debugging
     std::cout << "\n";
-    std::cout << index << " " << joint.getFBXJoint().name.toUtf8().data() << "\n";
+    std::cout << index << " " << joint.getName.toUtf8().data() << "\n";
     std::cout << " pos:" << joint.getPosition() << "/" << joint.getPositionInParentFrame() << " from " << joint.getParentIndex() << "\n";
     std::cout << " rot:" << safeEulerAngles(joint.getRotation()) << "/" << safeEulerAngles(joint.getRotationInParentFrame()) << "/" << safeEulerAngles(joint.getRotationInBindFrame()) << "\n";
     std::cout << "\n";


### PR DESCRIPTION
JointState has our own copy of any ivars we want from FBXJoint, instead of keeping a reference to the fbx.