### PR TITLE
remove shadow menu items

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3335,16 +3335,6 @@ void Application::computeOffAxisFrustum(float& left, float& right, float& bottom
     }
 }
 
-bool Application::getShadowsEnabled() {
-    Menu* menubar = Menu::getInstance();
-    return menubar->isOptionChecked(MenuOption::SimpleShadows) ||
-           menubar->isOptionChecked(MenuOption::CascadedShadows);
-}
-
-bool Application::getCascadeShadowsEnabled() {
-    return Menu::getInstance()->isOptionChecked(MenuOption::CascadedShadows);
-}
-
 glm::vec2 Application::getScaledScreenPoint(glm::vec2 projectedPoint) {
     float horizontalScale = _glWidget->getDeviceWidth() / 2.0f;
     float verticalScale   = _glWidget->getDeviceHeight() / 2.0f;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -268,8 +268,6 @@ public:
         float& farVal, glm::vec4& nearClipPlane, glm::vec4& farClipPlane) const;
 
     virtual ViewFrustum* getCurrentViewFrustum() { return getDisplayViewFrustum(); }
-    virtual bool getShadowsEnabled();
-    virtual bool getCascadeShadowsEnabled();
     virtual QThread* getMainThread() { return thread(); }
     virtual float getSizeScale() const;
     virtual int getBoundaryLevelAdjust() const;

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -346,12 +346,6 @@ Menu::Menu() {
     ambientLightGroup->addAction(addCheckableActionToQMenuAndActionHash(ambientLightMenu, MenuOption::RenderAmbientLight8, 0, false));
     ambientLightGroup->addAction(addCheckableActionToQMenuAndActionHash(ambientLightMenu, MenuOption::RenderAmbientLight9, 0, false));
 
-    MenuWrapper* shadowMenu = renderOptionsMenu->addMenu("Shadows");
-    QActionGroup* shadowGroup = new QActionGroup(shadowMenu);
-    shadowGroup->addAction(addCheckableActionToQMenuAndActionHash(shadowMenu, "None", 0, true));
-    shadowGroup->addAction(addCheckableActionToQMenuAndActionHash(shadowMenu, MenuOption::SimpleShadows, 0, false));
-    shadowGroup->addAction(addCheckableActionToQMenuAndActionHash(shadowMenu, MenuOption::CascadedShadows, 0, false));
-
     {
         MenuWrapper* framerateMenu = renderOptionsMenu->addMenu(MenuOption::RenderTargetFramerate);
         QActionGroup* framerateGroup = new QActionGroup(framerateMenu);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -154,7 +154,6 @@ namespace MenuOption {
     const QString BlueSpeechSphere = "Blue Sphere While Speaking";
     const QString BookmarkLocation = "Bookmark Location";
     const QString Bookmarks = "Bookmarks";
-    const QString CascadedShadows = "Cascaded";
     const QString CachesSize = "RAM Caches Size";
     const QString CalibrateCamera = "Calibrate Camera";
     const QString CenterPlayerInView = "Center Player In View";
@@ -271,7 +270,6 @@ namespace MenuOption {
     const QString ShowIKConstraints = "Show IK Constraints";
     const QString ShowRealtimeEntityStats = "Show Realtime Entity Stats";
     const QString ShowWhosLookingAtMe = "Show Who's Looking at Me";
-    const QString SimpleShadows = "Simple";
     const QString SixenseEnabled = "Enable Hydra Support";
     const QString SixenseMouseInput = "Enable Sixense Mouse Input";
     const QString Stars = "Stars";

--- a/libraries/render-utils/src/AbstractViewStateInterface.h
+++ b/libraries/render-utils/src/AbstractViewStateInterface.h
@@ -47,9 +47,6 @@ public:
     /// gets the shadow view frustum for rendering the view state
     virtual ViewFrustum* getShadowViewFrustum() = 0;
 
-    virtual bool getShadowsEnabled() = 0;
-    virtual bool getCascadeShadowsEnabled() = 0;
-
     virtual QThread* getMainThread() = 0;
 
     virtual bool shouldRenderMesh(float largestDimension, float distanceToCamera) = 0;

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -277,13 +277,19 @@ void DeferredLightingEffect::render(RenderArgs* args) {
 
     auto& program = _directionalLight;
     const LightLocations* locations = &_directionalLightLocations;
-    bool shadowsEnabled = _viewState->getShadowsEnabled();
+
+    // FIXME: Note: we've removed the menu items to enable shadows, so this will always be false for now.
+    //        When we add back shadow support, this old approach may likely be removed and completely replaced
+    //        but I've left it in for now.
+    bool shadowsEnabled = false; 
+    bool cascadeShadowsEnabled = false;
+    
     if (shadowsEnabled) {
         batch.setResourceTexture(4, framebufferCache->getShadowFramebuffer()->getDepthStencilBuffer());
         
         program = _directionalLightShadowMap;
         locations = &_directionalLightShadowMapLocations;
-        if (_viewState->getCascadeShadowsEnabled()) {
+        if (cascadeShadowsEnabled) {
             program = _directionalLightCascadedShadowMap;
             locations = &_directionalLightCascadedShadowMapLocations;
             if (useSkyboxCubemap) {


### PR DESCRIPTION
This removes the menu items for shadows since the shadow rendering code is broken on just renders a dark gray box on the screen.

I left in the old (dead) shadow code for now. Once we have a more clear plan for replacing shadows we may remove it completely or rework/fix it.