### PR TITLE
optimizations to RenderableModelEntityItem::render()

### DIFF
--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -91,6 +91,10 @@ QVector<FBXAnimationFrame> Animation::getFrames() const {
     return _geometry.animationFrames;
 }
 
+const QVector<FBXAnimationFrame>& Animation::getFramesReference() const {
+    return _geometry.animationFrames;
+}
+
 void Animation::setGeometry(const FBXGeometry& geometry) {
     _geometry = geometry;
     finishedLoading(true);

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -57,6 +57,8 @@ public:
     Q_INVOKABLE QStringList getJointNames() const;
     
     Q_INVOKABLE QVector<FBXAnimationFrame> getFrames() const;
+
+    const QVector<FBXAnimationFrame>& getFramesReference() const;
     
 protected:
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -275,7 +275,7 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
                     }
 
                     if (jointsMapped()) {
-                        QVector<glm::quat> frameData = getAnimationFrame();
+                        auto frameData = getAnimationFrame();
                         for (int i = 0; i < frameData.size(); i++) {
                             _model->setJointState(i, true, frameData[i]);
                         }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -227,24 +227,30 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
 
     if (hasModel()) {
         if (_model) {
-            if (QUrl(getModelURL()) != _model->getURL()) {
+            if (getModelURL() != _model->getURLAsString()) {
                 qDebug() << "Updating model URL: " << getModelURL();
                 _model->setURL(getModelURL());
             }
 
+            render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
+
             // check to see if when we added our models to the scene they were ready, if they were not ready, then
             // fix them up in the scene
-            render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
-            render::PendingChanges pendingChanges;
             if (_model->needsFixupInScene()) {
+                render::PendingChanges pendingChanges;
+
                 _model->removeFromScene(scene, pendingChanges);
 
                 render::Item::Status::Getters statusGetters;
                 makeEntityItemStatusGetters(this, statusGetters);
                 _model->addToScene(scene, pendingChanges, statusGetters);
-            }
-            scene->enqueuePendingChanges(pendingChanges);
 
+                scene->enqueuePendingChanges(pendingChanges);
+            }
+
+            // FIXME: this seems like it could be optimized if we tracked our last known visible state in
+            //        the renderable item. As it stands now the model checks it's visible/invisible state
+            //        so most of the time we don't do anything in this function.
             _model->setVisibleInScene(getVisible(), scene);
         }
 

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -106,7 +106,7 @@ public:
     float getAnimationLastFrame() const { return _animationLoop.getLastFrame(); }
     
     void mapJoints(const QStringList& modelJointNames);
-    QVector<glm::quat> getAnimationFrame();
+    const QVector<glm::quat>& getAnimationFrame();
     bool jointsMapped() const { return _jointMappingCompleted; }
     
     bool getAnimationIsPlaying() const { return _animationLoop.isRunning(); }
@@ -123,6 +123,9 @@ public:
     static void cleanupLoadedAnimations();
     
 protected:
+    QVector<glm::quat> _lastKnownFrameData;
+    int _lastKnownFrameIndex;
+
 
     bool isAnimatingSomething() const;
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -54,6 +54,7 @@ static int modelPointerTypeId = qRegisterMetaType<QPointer<Model> >();
 static int weakNetworkGeometryPointerTypeId = qRegisterMetaType<QWeakPointer<NetworkGeometry> >();
 static int vec3VectorTypeId = qRegisterMetaType<QVector<glm::vec3> >();
 float Model::FAKE_DIMENSION_PLACEHOLDER = -1.0f;
+#define HTTP_INVALID_COM "http://invalid.com"
 
 Model::Model(RigPointer rig, QObject* parent) :
     QObject(parent),
@@ -67,7 +68,8 @@ Model::Model(RigPointer rig, QObject* parent) :
     _cauterizeBones(false),
     _lodDistance(0.0f),
     _pupilDilation(0.0f),
-    _url("http://invalid.com"),
+    _url(HTTP_INVALID_COM),
+    _urlAsString(HTTP_INVALID_COM),
     _isVisible(true),
     _blendNumber(0),
     _appliedBlendNumber(0),
@@ -181,17 +183,12 @@ void Model::RenderPipelineLib::initLocations(gpu::ShaderPointer& program, Model:
     locations.texcoordMatrices = program->getUniforms().findLocation("texcoordMatrices");
     locations.emissiveParams = program->getUniforms().findLocation("emissiveParams");
     locations.glowIntensity = program->getUniforms().findLocation("glowIntensity");
-
     locations.normalFittingMapUnit = program->getTextures().findLocation("normalFittingMap");
-    
     locations.specularTextureUnit = program->getTextures().findLocation("specularMap");
     locations.emissiveTextureUnit = program->getTextures().findLocation("emissiveMap");
-
     locations.materialBufferUnit = program->getBuffers().findLocation("materialBuffer");
     locations.lightBufferUnit = program->getBuffers().findLocation("lightBuffer");
-
     locations.clusterMatrices = program->getUniforms().findLocation("clusterMatrices");
-
     locations.clusterIndices = program->getInputs().findLocation("inSkinClusterIndex");
     locations.clusterWeights = program->getInputs().findLocation("inSkinClusterWeight");
 }
@@ -1085,6 +1082,7 @@ void Model::setURL(const QUrl& url, const QUrl& fallback, bool retainCurrent, bo
     invalidCalculatedMeshBoxes();
 
     _url = url;
+    _urlAsString = _url.toString();
 
     onInvalidate();
 
@@ -1869,7 +1867,8 @@ void Model::pickPrograms(gpu::Batch& batch, RenderMode mode, bool translucent, f
     }
 
     if ((locations->normalFittingMapUnit > -1)) {
-       batch.setResourceTexture(locations->normalFittingMapUnit, DependencyManager::get<TextureCache>()->getNormalFittingTexture());
+       batch.setResourceTexture(locations->normalFittingMapUnit, 
+                    DependencyManager::get<TextureCache>()->getNormalFittingTexture());
     }
 }
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -74,6 +74,7 @@ public:
     Q_INVOKABLE void setURL(const QUrl& url, const QUrl& fallback = QUrl(),
         bool retainCurrent = false, bool delayLoad = false);
     const QUrl& getURL() const { return _url; }
+    const QString& getURLAsString() const { return _urlAsString; }
 
     // new Scene/Engine rendering support
     void setVisibleInScene(bool newValue, std::shared_ptr<render::Scene> scene);
@@ -328,6 +329,7 @@ private:
     QVector<float> _blendshapeCoefficients;
 
     QUrl _url;
+    QString _urlAsString;
     QUrl _collisionUrl;
     bool _isVisible;
 


### PR DESCRIPTION
* **Optimize how we check to see if the entity's modelURL has changed** - We were checking that the model URL hadn't changed but comparing a constructed QUrl to the _model->getURL()... this was slow because constructing a QUrl from a string required url parsing logic. So to fix this we keep a copy of the string for the url in the model and compare against that. **On cell science, this dropped the RenderableModelEntityItem::render() from 9% cpu to 5% cpu.**

* **Optimize ModelEntityItem::getAnimationFrame()** - we now cache the last known frame state so we aren't recalculating it in case the actual frame hasn't change (consider a low animation FPS case where the frame doesn't change every rendered frame). Also using some better functions that access frame animations through references to prevent unneeded copies of vectors. **In cell science this drops getAnimationFrame() from 1.3% CPU to ~0.4% CPU.**