### PR TITLE
Add temporary debug info for tracking down invalid scale value assert

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -717,6 +717,29 @@ Transform Avatar::calculateDisplayNameTransform(const ViewFrustum& frustum, floa
     
     // Compute correct scale to apply
     float scale = DESIRED_HIGHT_ON_SCREEN / (fontSize * pixelHeight) * devicePixelRatio;
+#ifdef DEBUG
+    // TODO: Temporary logging to track cause of invalid scale vale; remove once cause has been fixed.
+    if (scale == 0.0f || glm::isnan(scale) || glm::isinf(scale)) {
+        if (scale == 0.0f) {
+            qDebug() << "ASSERT because scale == 0.0f";
+        }
+        if (glm::isnan(scale)) {
+            qDebug() << "ASSERT because isnan(scale)";
+        }
+        if (glm::isinf(scale)) {
+            qDebug() << "ASSERT because isinf(scale)";
+        }
+        qDebug() << "windowSizeY =" << windowSizeY;
+        qDebug() << "p1.y =" << p1.y;
+        qDebug() << "p1.w =" << p1.w;
+        qDebug() << "p0.y =" << p0.y;
+        qDebug() << "p0.w =" << p0.w;
+        qDebug() << "qApp->getDevicePixelRatio() =" << qApp->getDevicePixelRatio();
+        qDebug() << "fontSize =" << fontSize;
+        qDebug() << "pixelHeight =" << pixelHeight;
+        qDebug() << "devicePixelRatio =" << devicePixelRatio;
+    }
+#endif
     
     // Compute pixel alignment offset
     float clipToPix = 0.5f * windowSizeY / p1.w; // Got from clip to pixel coordinates


### PR DESCRIPTION
In debug builds, extra information will be written to the program log when an assert on an invalid scale value is encountered trying to render a display name.