### PR TITLE
Qt 5.5 Compilation: Add QDataStream include

### DIFF
--- a/domain-server/src/DomainServerWebSessionData.cpp
+++ b/domain-server/src/DomainServerWebSessionData.cpp
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QtCore/QDataStream>
 #include <QtCore/QDebug>
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>


### PR DESCRIPTION
Included `QDataStream` to fix compilation error with **Qt 5.5.0**, `QDataStream >> QSet`

```sh
domain-server/src/DomainServerWebSessionData.cpp:60:29: error: no match for ‘operator>>’ (operand types are ‘QDataStream’ and ‘QSet<QString>’)
     in >> session._username >> session._roles;
```