### PR TITLE
Whitespace correction in reduced complexity notification

### DIFF
--- a/examples/notifications.js
+++ b/examples/notifications.js
@@ -596,7 +596,7 @@ function menuItemEvent(menuItem) {
 LODManager.LODDecreased.connect(function() {
     var warningText = "\n"
             + "Due to the complexity of the content, the \n"
-            + "level of detail has been decreased."
+            + "level of detail has been decreased. "
             + "You can now see: \n" 
             + LODManager.getLODFeedbackText();
 


### PR DESCRIPTION
Added a space to make the reduced complexity notification look better. The current box had the 'Y' too close to the period.