### PR TITLE
Fixing bad success macro for the Oculus SDK on windows

### DIFF
--- a/libraries/display-plugins/src/display-plugins/oculus/OculusBaseDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/oculus/OculusBaseDisplayPlugin.h
@@ -24,7 +24,3 @@ public:
     virtual glm::mat4 getHeadPose() const override;
 
 };
-
-#if (OVR_MAJOR_VERSION < 6)
-#define OVR_SUCCESS(x) x
-#endif

--- a/libraries/display-plugins/src/display-plugins/oculus/OculusHelpers.h
+++ b/libraries/display-plugins/src/display-plugins/oculus/OculusHelpers.h
@@ -12,6 +12,10 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
+#if (OVR_MAJOR_VERSION < 6)
+#define OVR_SUCCESS(x) x
+#endif
+
 // Convenience method for looping over each eye with a lambda
 template <typename Function>
 inline void ovr_for_each_eye(Function function) {


### PR DESCRIPTION
I moved the OVR_CAPI.h header out of the public plugin header, but failed to move the conditional OVR_SUCCESS macro definition along with it.  This meant I was overriding the Oculus OVR_SUCCESS macro on version 0.6 builds, leading to a reversed interpretation of success / fail.  

