### PR TITLE
Fixing crash in vive controllers

### DIFF
--- a/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
@@ -65,7 +65,14 @@ ViveControllerManager::ViveControllerManager() :
 
 bool ViveControllerManager::isSupported() const {
 #ifdef Q_OS_WIN
-    return vr::VR_IsHmdPresent();
+    bool success = vr::VR_IsHmdPresent();
+    if (success) {
+        vr::HmdError eError = vr::HmdError_None;
+        auto hmd = vr::VR_Init(&eError);
+        success = (hmd != nullptr);
+        vr::VR_Shutdown();
+    }
+    return success;
 #else 
     return false;
 #endif


### PR DESCRIPTION
The OpenVR software appears to be a little over-eager and is causing me to crash because of inaccurate detection.  This adds some more checking before we consider the controller to be 'supported' and matches the behavior to the Vive display plugin.  