### PR TITLE
coalesce scattered unit-test helper functions

### DIFF
--- a/libraries/animation/src/ElbowConstraint.cpp
+++ b/libraries/animation/src/ElbowConstraint.cpp
@@ -67,7 +67,7 @@ bool ElbowConstraint::apply(glm::quat& rotation) const {
 
     // update rotation
     const float MIN_SWING_REAL_PART = 0.99999f;
-    if (twistWasClamped || fabsf(swingRotation.w < MIN_SWING_REAL_PART)) {
+    if (twistWasClamped || fabsf(swingRotation.w) < MIN_SWING_REAL_PART) {
         if (twistWasClamped) {
             twistRotation = glm::angleAxis(clampedTwistAngle, _axis);
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(DIR ${TEST_SUBDIRS})
   endif()
 endforeach()
 
-file(GLOB SHARED_TEST_HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.h" "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
+file(GLOB SHARED_TEST_HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.h " "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
 
 add_custom_target("test-extensions"
     SOURCES "${SHARED_TEST_HEADER_FILES}")

--- a/tests/GLMTestUtils.h
+++ b/tests/GLMTestUtils.h
@@ -59,4 +59,8 @@ inline QTextStream& operator<< (QTextStream& stream, const glm::mat4& matrix) {
     stream << "]\n\t";   // hacky as hell, but this should work...
     return stream;
 }
+
+#define QCOMPARE_QUATS(rotationA, rotationB, angle) \
+    QVERIFY(fabsf(1.0f - fabsf(glm::dot(rotationA, rotationB))) < 2.0f * sinf(angle))
+
 #endif

--- a/tests/GLMTestUtils.h
+++ b/tests/GLMTestUtils.h
@@ -14,15 +14,49 @@
 
 #include <glm/glm.hpp>
 #include <glm/gtx/quaternion.hpp>
+#include <QTextStream>
 
 // Implements functionality in QTestExtensions.h for glm types
 
+// Computes the error value between two quaternions (using glm::dot)
+float getErrorDifference(const glm::quat& a, const glm::quat& b) {
+    return fabsf(glm::dot(a, b)) - 1.0f;
+}       
+
 inline float getErrorDifference(const glm::vec3& a, const glm::vec3& b) {
     return glm::distance(a, b);
+}
+
+inline float getErrorDifference(const glm::mat4& a, const glm::mat4& b) {
+    float maxDiff = 0;
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            float diff = fabs(a[i][j] - b[i][j]);
+            maxDiff = std::max(diff, maxDiff);
+        }
+    }
+    return maxDiff;
 }
 
 inline QTextStream& operator<<(QTextStream& stream, const glm::vec3& v) {
     return stream << "glm::vec3 { " << v.x << ", " << v.y << ", " << v.z << " }";
 }
 
+QTextStream& operator<<(QTextStream& stream, const glm::quat& q) {
+            return stream << "glm::quat { " << q.x << ", " << q.y << ", " << q.z << ", " << q.w << " }";
+} 
+
+inline QTextStream& operator<< (QTextStream& stream, const glm::mat4& matrix) {
+    stream << "[\n\t\t";
+    stream.setFieldWidth(15);
+    for (int r = 0; r < 4; ++r) {
+        for (int c = 0; c < 4; ++c) {
+            stream << matrix[c][r];
+        }
+        stream << "\n\t\t";
+    }
+    stream.setFieldWidth(0);
+    stream << "]\n\t";   // hacky as hell, but this should work...
+    return stream;
+}
 #endif

--- a/tests/GLMTestUtils.h
+++ b/tests/GLMTestUtils.h
@@ -20,6 +20,7 @@
 inline float getErrorDifference(const glm::vec3& a, const glm::vec3& b) {
     return glm::distance(a, b);
 }
+
 inline QTextStream& operator<<(QTextStream& stream, const glm::vec3& v) {
     return stream << "glm::vec3 { " << v.x << ", " << v.y << ", " << v.z << " }";
 }

--- a/tests/QTestExtensions.h
+++ b/tests/QTestExtensions.h
@@ -15,6 +15,8 @@
 #include <QtTest/QtTest>
 #include <functional>
 
+#include "GLMTestUtils.h"
+
 // Implements several extensions to QtTest.
 //
 // Problems with QtTest:

--- a/tests/QTestExtensions.h
+++ b/tests/QTestExtensions.h
@@ -37,6 +37,10 @@
 //
 
 
+float getErrorDifference(const float& a, const float& b) {
+    return fabsf(a - b);
+}
+
 // Generates a QCOMPARE-style failure message that can be passed to QTest::qFail.
 //
 // Formatting looks like this:
@@ -281,3 +285,20 @@ bool compareData (const char* data, const char* expectedData, size_t length) {
 
 #define COMPARE_DATA(actual, expected, length) \
     QCOMPARE_WITH_EXPR((ByteData ( actual, length )), (ByteData ( expected, length )), compareData(actual, expected, length))
+
+
+// Produces a relative error test for float usable QCOMPARE_WITH_LAMBDA.
+inline auto errorTest (float actual, float expected, float acceptableRelativeError)
+-> std::function<bool ()> {
+    return [actual, expected, acceptableRelativeError] () {
+        if (fabsf(expected) <= acceptableRelativeError) {
+            return fabsf(actual - expected) < fabsf(acceptableRelativeError);
+        }
+        return fabsf((actual - expected) / expected) < fabsf(acceptableRelativeError);
+    };
+}
+
+#define QCOMPARE_WITH_RELATIVE_ERROR(actual, expected, relativeError) \
+    QCOMPARE_WITH_LAMBDA(actual, expected, errorTest(actual, expected, relativeError))
+
+

--- a/tests/animation/src/RotationConstraintTests.cpp
+++ b/tests/animation/src/RotationConstraintTests.cpp
@@ -16,33 +16,7 @@
 #include <NumericalConstants.h>
 #include <SwingTwistConstraint.h>
 
-// HACK -- these helper functions need to be defined BEFORE including magic inside QTestExtensions.h
-// TODO: fix QTestExtensions so we don't need to do this in every test.
-
-// Computes the error value between two quaternions (using glm::dot)
-float getErrorDifference(const glm::quat& a, const glm::quat& b) {
-        return fabsf(glm::dot(a, b)) - 1.0f;
-}       
-
-QTextStream& operator<<(QTextStream& stream, const glm::quat& q) {
-        return stream << "glm::quat { " << q.x << ", " << q.y << ", " << q.z << ", " << q.w << " }";
-} 
-
-// Produces a relative error test for float usable QCOMPARE_WITH_LAMBDA.
-inline auto errorTest (float actual, float expected, float acceptableRelativeError)
--> std::function<bool ()> {
-    return [actual, expected, acceptableRelativeError] () {
-        if (fabsf(expected) <= acceptableRelativeError) {
-            return fabsf(actual - expected) < fabsf(acceptableRelativeError);
-        }
-        return fabsf((actual - expected) / expected) < fabsf(acceptableRelativeError);
-    };
-}
-
 #include "../QTestExtensions.h"
-
-#define QCOMPARE_WITH_RELATIVE_ERROR(actual, expected, relativeError) \
-    QCOMPARE_WITH_LAMBDA(actual, expected, errorTest(actual, expected, relativeError))
 
 
 QTEST_MAIN(RotationConstraintTests)

--- a/tests/physics/src/BulletTestUtils.h
+++ b/tests/physics/src/BulletTestUtils.h
@@ -24,10 +24,6 @@
 //      (this is only used by btMatrix3x3 in MeshMassPropertiesTests.cpp, so it's only defined for the Mat3 type)
 
 // Return the error between values a and b; used to implement QCOMPARE_WITH_ABS_ERROR
-inline btScalar getErrorDifference(const btScalar& a, const btScalar& b) {
-    return fabs(a - b);
-}
-// Return the error between values a and b; used to implement QCOMPARE_WITH_ABS_ERROR
 inline btScalar getErrorDifference(const btVector3& a, const btVector3& b) {
     return (a - b).length();
 }

--- a/tests/physics/src/BulletUtilTests.cpp
+++ b/tests/physics/src/BulletUtilTests.cpp
@@ -17,7 +17,6 @@
 #include <NumericalConstants.h>
 
 // Add additional qtest functionality (the include order is important!)
-#include "GLMTestUtils.h"
 #include "../QTestExtensions.h"
 
 // Constants

--- a/tests/physics/src/BulletUtilTests.cpp
+++ b/tests/physics/src/BulletUtilTests.cpp
@@ -17,7 +17,7 @@
 #include <NumericalConstants.h>
 
 // Add additional qtest functionality (the include order is important!)
-#include "GlmTestUtils.h"
+#include "GLMTestUtils.h"
 #include "../QTestExtensions.h"
 
 // Constants

--- a/tests/physics/src/GLMTestUtils.h
+++ b/tests/physics/src/GLMTestUtils.h
@@ -1,5 +1,5 @@
 //
-//  GlmTestUtils.h
+//  GLMTestUtils.h
 //  tests/physics/src
 //
 //  Created by Seiji Emery on 6/22/15
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#ifndef hifi_GlmTestUtils_h
-#define hifi_GlmTestUtils_h
+#ifndef hifi_GLMTestUtils_h
+#define hifi_GLMTestUtils_h
 
 #include <glm/glm.hpp>
 #include <glm/gtx/quaternion.hpp>

--- a/tests/physics/src/MeshMassPropertiesTests.cpp
+++ b/tests/physics/src/MeshMassPropertiesTests.cpp
@@ -16,7 +16,7 @@
 
 // Add additional qtest functionality (the include order is important!)
 #include "BulletTestUtils.h"
-#include "GlmTestUtils.h"
+#include "GLMTestUtils.h"
 #include "../QTestExtensions.h"
 
 const btScalar acceptableRelativeError(1.0e-5f);

--- a/tests/physics/src/MeshMassPropertiesTests.cpp
+++ b/tests/physics/src/MeshMassPropertiesTests.cpp
@@ -16,7 +16,6 @@
 
 // Add additional qtest functionality (the include order is important!)
 #include "BulletTestUtils.h"
-#include "GLMTestUtils.h"
 #include "../QTestExtensions.h"
 
 const btScalar acceptableRelativeError(1.0e-5f);

--- a/tests/shared/src/AngularConstraintTests.cpp
+++ b/tests/shared/src/AngularConstraintTests.cpp
@@ -9,22 +9,16 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AngularConstraintTests.h"
+
 #include <iostream>
 
 #include <AngularConstraint.h>
 #include <NumericalConstants.h>
 #include <StreamUtils.h>
 
-#include "AngularConstraintTests.h"
 #include "../QTestExtensions.h"
 
-// Computes the error value between two quaternions (using glm::dot)
-float getErrorDifference(const glm::quat& a, const glm::quat& b) {
-    return fabsf(glm::dot(a, b) - 1.0f);
-}
-QTextStream& operator<<(QTextStream& stream, const glm::quat& q) {
-    return stream << "glm::quat { " << q.x << ", " << q.y << ", " << q.z << ", " << q.w << " }";
-}
 
 QTEST_MAIN(AngularConstraintTests)
 

--- a/tests/shared/src/GeometryUtilTests.cpp
+++ b/tests/shared/src/GeometryUtilTests.cpp
@@ -22,13 +22,6 @@
 
 QTEST_MAIN(GeometryUtilTests)
 
-float getErrorDifference(const float& a, const float& b) {
-    return fabsf(a - b);
-}
-
-float getErrorDifference(const glm::vec3& a, const glm::vec3& b) {
-    return glm::distance(a, b);
-}
 
 void GeometryUtilTests::testLocalRayRectangleIntersection() {
     glm::vec3 xAxis(1.0f, 0.0f, 0.0f);

--- a/tests/shared/src/MovingMinMaxAvgTests.cpp
+++ b/tests/shared/src/MovingMinMaxAvgTests.cpp
@@ -13,7 +13,12 @@
 
 #include <qqueue.h>
 
+#include <MovingMinMaxAvg.h>
 #include <NumericalConstants.h>
+#include <SharedUtil.h>
+
+#include "../QTestExtensions.h"
+
 
 QTEST_MAIN(MovingMinMaxAvgTests)
 

--- a/tests/shared/src/MovingMinMaxAvgTests.h
+++ b/tests/shared/src/MovingMinMaxAvgTests.h
@@ -14,15 +14,6 @@
 
 #include <QtTest/QtTest>
 
-inline float getErrorDifference(float a, float b) {
-    return fabsf(a - b);
-}
-
-#include "../QTestExtensions.h"
-
-#include "MovingMinMaxAvg.h"
-#include "SharedUtil.h"
-
 class MovingMinMaxAvgTests : public QObject {
     
 private slots:

--- a/tests/shared/src/TransformTests.cpp
+++ b/tests/shared/src/TransformTests.cpp
@@ -10,10 +10,13 @@
 
 #include "TransformTests.h"
 
+#include <algorithm>
+#include <glm/glm.hpp>
+
+#include <SharedLogging.h>
 #include <Transform.h>
 
-#include "SharedLogging.h"
-#include <../QTestExtensions.h>
+#include "../QTestExtensions.h"
 
 using namespace glm;
 

--- a/tests/shared/src/TransformTests.h
+++ b/tests/shared/src/TransformTests.h
@@ -12,33 +12,6 @@
 #define hifi_TransformTests_h
 
 #include <QtTest/QtTest>
-#include <glm/glm.hpp>
-#include <algorithm>
-
-inline float getErrorDifference(const glm::mat4& a, const glm::mat4& b) {
-    float maxDiff = 0;
-    for (int i = 0; i < 4; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            float diff = fabs(a[i][j] - b[i][j]);
-            maxDiff = std::max(diff, maxDiff);
-        }
-    }
-    return maxDiff;
-}
-
-inline QTextStream& operator<< (QTextStream& stream, const glm::mat4& matrix) {
-    stream << "[\n\t\t";
-    stream.setFieldWidth(15);
-    for (int r = 0; r < 4; ++r) {
-        for (int c = 0; c < 4; ++c) {
-            stream << matrix[c][r];
-        }
-        stream << "\n\t\t";
-    }
-    stream.setFieldWidth(0);
-    stream << "]\n\t";   // hacky as hell, but this should work...
-    return stream;
-}
 
 class TransformTests : public QObject {
     Q_OBJECT


### PR DESCRIPTION
There were some unit-test helper functions and macros that were duplicated in different tests.  While working on another project it was driving me nuts to have to duplicate these even more times.  I decided to take a small detour in a branch closer to the tip of upstream/master to find and coalesce all of these helper functions in a more sane way.

Unit test cpp files should now be able to just include "../CTestExtensions.h" to get access to all necessary helper functions.