### PR TITLE
No symbolic names for non-entity contants.

### DIFF
--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -69,7 +69,7 @@ PacketVersion versionForPacketType(PacketType::Value packetType) {
         case EntityData:
             return VERSION_ENTITIES_POLYLINE;
         case AvatarData:
-            return VERSION_AVATAR_NO_LEAN;
+            return 12;
         default:
             return 11;
     }

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -142,6 +142,5 @@ const PacketVersion VERSION_ENTITIES_HAVE_SIMULATION_OWNER_AND_ACTIONS_OVER_WIRE
 const PacketVersion VERSION_ENTITIES_NEW_PROTOCOL_LAYER = 35;
 const PacketVersion VERSION_POLYVOX_TEXTURES = 36;
 const PacketVersion VERSION_ENTITIES_POLYLINE = 37;
-const PacketVersion VERSION_AVATAR_NO_LEAN = 38;
 
 #endif // hifi_PacketHeaders_h


### PR DESCRIPTION
Only use symbolic version names for (some of) the entity packets.