### PR TITLE
Documentation for overlay changes.

### DIFF
--- a/examples/libraries/overlayManager.js
+++ b/examples/libraries/overlayManager.js
@@ -5,6 +5,9 @@
 //  Created by Zander Otavka on 7/24/15
 //  Copyright 2015 High Fidelity, Inc.
 //
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
 //  Manage overlays with object oriented goodness, instead of ugly `Overlays.h` methods.
 //  Instead of:
 //
@@ -22,14 +25,27 @@
 //      ...
 //      billboard.destroy();
 //
-//  See more on usage below.
+//  More on usage below.  Examples in `examples/example/overlayPanelExample.js`.
 //
-//  Note that including this file will delete Overlays from the global scope.  All the
-//  functionality of Overlays is represented here, just better.  If you try to use Overlays in
-//  tandem, there may be performance problems or nasty surprises.
+//  Note that including this file will delete `Overlays` from the global scope.  All the
+//  functionality of `Overlays` is represented here, just better.  If you try to use `Overlays`
+//  in tandem, there may be performance problems or nasty surprises.
 //
-//  Distributed under the Apache License, Version 2.0.
-//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//  Names added to the global scope:
+//      OverlayManager
+//      ImageOverlay
+//      Image3DOverlay
+//      TextOverlay
+//      Text3DOverlay
+//      Cube3DOverlay
+//      Sphere3DOverlay
+//      Circle3DOverlay
+//      Rectangle3DOverlay
+//      Line3DOverlay
+//      Grid3DOverlay
+//      LocalModelsOverlay
+//      ModelOverlay
+//      OverlayPanel
 //
 
 
@@ -197,8 +213,8 @@
     //      billboard.destroy();
     //
     //      // Remember, there is a poor orphaned JavaScript object left behind.  You should
-    //      // remove any references to it so you don't accidentally try to modify an overlay that
-    //      // isn't there.
+    //      // remove any references to it so you don't accidentally try to modify an overlay
+    //      // that isn't there.
     //      billboard = undefined;
     //
     (function() {

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -5,13 +5,14 @@
 //  Modified by Zander Otavka on 7/15/15
 //  Copyright 2014 High Fidelity, Inc.
 //
-//  Exposes methods for managing `Overlay`s and `OverlayPanel`s to scripts.
-//
-//  YOU SHOULD NOT USE `Overlays` DIRECTLY, unless you like pain and deprecation.  Instead, use the
-//  object oriented abstraction layer found in `examples/libraries/overlayUtils.js`.
-//
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+//  Exposes methods to scripts for managing `Overlay`s and `OverlayPanel`s.
+//
+//  YOU SHOULD NOT USE `Overlays` DIRECTLY, unless you like pain and deprecation.  Instead, use
+//  the object oriented API replacement found in `examples/libraries/overlayManager.js`.  See
+//  that file for docs and usage.
 //
 
 #ifndef hifi_Overlays_h
@@ -57,11 +58,11 @@ void RayToOverlayIntersectionResultFromScriptValue(const QScriptValue& object, R
 
 class Overlays : public QObject {
     Q_OBJECT
-    
+
 public:
     Overlays();
     ~Overlays();
-    
+
     void init();
     void update(float deltatime);
     void renderHUD(RenderArgs* renderArgs);
@@ -103,7 +104,7 @@ public slots:
 
     /// returns details about the closest 3D Overlay hit by the pick ray
     RayToOverlayIntersectionResult findRayIntersection(const PickRay& ray);
-    
+
     /// returns whether the overlay's assets are loaded or not
     bool isLoaded(unsigned int id);
 
@@ -153,5 +154,5 @@ private:
 };
 
 
- 
+
 #endif // hifi_Overlays_h

--- a/interface/src/ui/overlays/PanelAttachable.cpp
+++ b/interface/src/ui/overlays/PanelAttachable.cpp
@@ -1,6 +1,6 @@
 //
 //  PanelAttachable.cpp
-//  hifi
+//  interface/src/ui/overlays
 //
 //  Created by Zander Otavka on 7/15/15.
 //  Copyright 2015 High Fidelity, Inc.

--- a/interface/src/ui/overlays/PanelAttachable.h
+++ b/interface/src/ui/overlays/PanelAttachable.h
@@ -8,6 +8,24 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+//  Base class for anything that can attach itself to an `OverlayPanel` as a child.
+//  `PanelAttachable keeps an `std::shared_ptr` to it's parent panel, and sets its
+//  transformations and visibility based on the parent.
+//
+//  When subclassing `PanelAttachable`, make sure `applyTransformTo`, `getProperty`, and
+//  `setProperties are all called in the appropriate places.  Look through `Image3DOverlay` and
+//  `Billboard3DOverlay` for examples.  Pay special attention to `applyTransformTo`; it should
+//  be called in three places for `Overlay`s: `render`, `update`, and `findRayIntersection`.
+//
+//  When overriding `applyTransformTo`, make sure to wrap all of your code, including the call
+//  to the superclass method, with the following `if` block.  Then call the superclass method
+//  with force = true.
+//
+//      if (force || usecTimestampNow() > _transformExpiry) {
+//          PanelAttachable::applyTransformTo(transform, true);
+//          ...
+//      }
+//
 
 #ifndef hifi_PanelAttachable_h
 #define hifi_PanelAttachable_h
@@ -42,6 +60,8 @@ protected:
     QScriptValue getProperty(QScriptEngine* scriptEngine, const QString& property);
     void setProperties(const QScriptValue& properties);
 
+    /// set position, rotation and scale on transform based on offsets, and parent panel offsets
+    /// if force is false, only apply transform if it hasn't been applied in the last .1 seconds
     virtual void applyTransformTo(Transform& transform, bool force = false);
     quint64 _transformExpiry = 0;
 


### PR DESCRIPTION
## About Overlay Changes

I made two major changes to the overlays API in the past five weeks.  Firstly, I extended the API that already existed in `Overlays.h`.  In `Overlays.h`, I added the ability to attach certain 3D overlays to an `OverlayPanel`.  An `OverlayPanel` applies a series of transforms on its children, and enables creation of complex UI in 3D space.  `OverlayPanel`s can be positioned relative to your avatar, or relative to entities in the world.  `OverlayPanel`s can also be nested.  If a class wants to be able to be attached to a panel, it must subclass from `PanelAttachable`.  See documentation in `PanelAttachable.h` for more on how to subclass from it.

The second major change was the addition of an object oriented replacement to the Overlays API written in JavaScript.  Including `examples/libraries/overlayManager.js` in a script will delete `Overlays` from the global scope.  In it's place, JavaScript classes corresponding to each non-abstract overlay class are added to the global scope, including an `OverlayPanel` class.  The `OverlayManager` object also has a few methods for selecting overlays at a 2D point or with a pick ray.  **Every** feature implemented in `Overlays.h` is accessible with `overlayManager.js`.  It is just easier to use, because overlays are actual objects, not just IDs.

I recommend deprecation of `Overlays.h` in favor of `overlayManager.js`.  `overlayManager.js` still relies on `Overlays` being accessible to the script engine, because it is a wrapper around `Overlays`, not a complete replacement.  Changes made to the API in `Overlays.h` should be reflected in `overlayManager.js`, including adding or changing property names for individual overlays.