### PR TITLE
Fix rotation of image3d overlays

### DIFF
--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -90,7 +90,6 @@ void Image3DOverlay::render(RenderArgs* args) {
     applyTransformTo(_transform, true);
     Transform transform = _transform;
     transform.postScale(glm::vec3(getDimensions(), 1.0f));
-    transform.postRotate(glm::angleAxis(glm::pi<float>(), IDENTITY_UP));
 
     batch->setModelTransform(transform);
     batch->setResourceTexture(0, _texture->getGPUTexture());


### PR DESCRIPTION
This rotation was added with the panel overlay work, which causes inconsistent orientations when compared to the old code. Looking down the -z axis (forward in hifi coordinate system), the image shows correctly without this rotation. With this rotation it is flipped horizontally. I think the former behavior is correct.