### PR TITLE
Fix warning messages about depth and stencil buffers for the QML surfaces

### DIFF
--- a/libraries/render-utils/src/OffscreenGlCanvas.cpp
+++ b/libraries/render-utils/src/OffscreenGlCanvas.cpp
@@ -34,11 +34,9 @@ OffscreenGlCanvas::~OffscreenGlCanvas() {
 void OffscreenGlCanvas::create(QOpenGLContext* sharedContext) {
     if (nullptr != sharedContext) {
         sharedContext->doneCurrent();
-        _context->setFormat(sharedContext->format());
         _context->setShareContext(sharedContext);
-    } else {
-        _context->setFormat(getDefaultOpenGlSurfaceFormat());
     }
+    _context->setFormat(getDefaultOpenGlSurfaceFormat());
     _context->create();
 
     _offscreenSurface->setFormat(_context->format());


### PR DESCRIPTION
We're incorrectly setting the format for offscreen render contexts from the GL widget which has no depth or stencil buffers, triggering a warning in the logs.  I'm concerned that the composition of this possibly bad image with the main window might be the source of the gray screens on the new macs.  