### PR TITLE
DO NOT MERGE - Node versioning

### DIFF
--- a/assignment-client/CMakeLists.txt
+++ b/assignment-client/CMakeLists.txt
@@ -17,4 +17,5 @@ if (UNIX)
   target_link_libraries(${TARGET_NAME} ${CMAKE_DL_LIBS})
 endif (UNIX)
 
+include_application_version()
 copy_dlls_beside_windows_executable()

--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -129,6 +129,7 @@ AssignmentClient::AssignmentClient(Assignment::Type requestAssignmentType, QStri
     packetReceiver.registerListener(PacketType::CreateAssignment, this, "handleCreateAssignmentPacket");
     packetReceiver.registerListener(PacketType::StopNode, this, "handleStopNodePacket");
 }
+
 void AssignmentClient::stopAssignmentClient() {
     qDebug() << "Forced stop of assignment-client.";
 
@@ -171,7 +172,6 @@ void AssignmentClient::aboutToQuit() {
     // clear the log handler so that Qt doesn't call the destructor on LogHandler
     qInstallMessageHandler(0);
 }
-
 
 void AssignmentClient::setUpStatusToMonitor() {
     // send a stats packet every 1 seconds
@@ -217,7 +217,6 @@ void AssignmentClient::sendAssignmentRequest() {
                 qDebug() << "Failed to read local assignment server port from shared memory"
                     << "- will send assignment request to previous assignment server socket.";
             }
-
         }
 
         nodeList->sendAssignment(_requestAssignment);

--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -12,6 +12,7 @@
 #include <QCommandLineParser>
 #include <QThread>
 
+#include <ApplicationVersion.h>
 #include <LogHandler.h>
 #include <SharedUtil.h>
 #include <HifiConfigVariantMap.h>
@@ -40,6 +41,7 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     setOrganizationName("High Fidelity");
     setOrganizationDomain("highfidelity.io");
     setApplicationName("assignment-client");
+    setApplicationName(BUILD_VERSION);
 
     // use the verbose message handler in Logging
     qInstallMessageHandler(LogHandler::verboseMessageHandler);
@@ -93,9 +95,7 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
         Q_UNREACHABLE();
     }
 
-
     const QVariantMap argumentVariantMap = HifiConfigVariantMap::mergeCLParametersWithJSONConfig(arguments());
-
 
     unsigned int numForks = 0;
     if (parser.isSet(numChildsOption)) {
@@ -138,7 +138,6 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     if (parser.isSet(poolOption)) {
         assignmentPool = parser.value(poolOption);
     }
-
 
     QUuid walletUUID;
     if (argumentVariantMap.contains(ASSIGNMENT_WALLET_DESTINATION_ID_OPTION)) {

--- a/cmake/macros/ApplicationVersion.h.in
+++ b/cmake/macros/ApplicationVersion.h.in
@@ -1,11 +1,9 @@
 //
-//  InterfaceVersion.h
-//  interface/src
+//  ApplicationVersion.h.in
+//  cmake/macros
 //
-//  Created by Leonardo Murillo on 12/16/13.
-//  Copyright 2013 High Fidelity, Inc.
-//
-//  Declaration of version and build data
+//  Created by Leonardo Murillo on 8/13/15.
+//  Copyright 2015 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/cmake/macros/IncludeApplicationVersion.cmake
+++ b/cmake/macros/IncludeApplicationVersion.cmake
@@ -1,0 +1,22 @@
+# 
+#  IncludeApplicationVersion.cmake
+#  cmake/macros
+#
+#  Created by Leonardo Murillo on 07/14/2015.
+#  Copyright 2015 High Fidelity, Inc.
+#
+#  Distributed under the Apache License, Version 2.0.
+#  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+# 
+
+macro(INCLUDE_APPLICATION_VERSION)
+  if (DEFINED ENV{JOB_ID})
+    set (BUILD_SEQ $ENV{JOB_ID})
+  elseif (DEFINED ENV{ghprbPullId})
+    set (BUILD_SEQ "PR: $ENV{ghprbPullId} - Commit: $ENV{ghprbActualCommit}")
+  else ()
+    set(BUILD_SEQ "dev")
+  endif ()
+  configure_file("${MACRO_DIR}/ApplicationVersion.h.in" "${PROJECT_BINARY_DIR}/includes/ApplicationVersion.h")
+  include_directories("${PROJECT_BINARY_DIR}/includes")
+endmacro(INCLUDE_APPLICATION_VERSION)

--- a/domain-server/CMakeLists.txt
+++ b/domain-server/CMakeLists.txt
@@ -31,4 +31,5 @@ include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
 # append OpenSSL to our list of libraries to link
 target_link_libraries(${TARGET_NAME} ${OPENSSL_LIBRARIES})
 
+include_application_version()
 copy_dlls_beside_windows_executable()

--- a/domain-server/resources/web/index.shtml
+++ b/domain-server/resources/web/index.shtml
@@ -9,6 +9,7 @@
         <thead>
           <tr>
             <th>Type</th>
+            <th>Version</th>
             <th>UUID</th>
             <th>Pool</th>
             <th>Username</th>
@@ -24,6 +25,7 @@
             <% _.each(nodes, function(node, node_index){ %>
               <tr>
                 <td><%- node.type %></td>
+                <td><%- node.version %></td>
                 <td><a href="stats/?uuid=<%- node.uuid %>"><%- node.uuid %></a></td>
                 <td><%- node.pool %></td>
                 <td><%- node.username %></td>

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -740,6 +740,7 @@ void DomainServer::processConnectRequestPacket(QSharedPointer<NLPacket> packet) 
         if (isAssignment) {
             nodeData->setAssignmentUUID(matchingQueuedAssignment->getUUID());
             nodeData->setWalletUUID(pendingAssigneeData->getWalletUUID());
+            nodeData->setNodeVersion(pendingAssigneeData->getNodeVersion());
 
             // always allow assignment clients to create and destroy entities
             newNode->setCanAdjustLocks(true);
@@ -1170,7 +1171,8 @@ void DomainServer::processRequestAssignmentPacket(QSharedPointer<NLPacket> packe
 
         // add the information for that deployed assignment to the hash of pending assigned nodes
         PendingAssignedNodeData* pendingNodeData = new PendingAssignedNodeData(assignmentToDeploy->getUUID(),
-                                                                               requestAssignment.getWalletUUID());
+                                                                               requestAssignment.getWalletUUID(),
+                                                                               requestAssignment.getNodeVersion());
         _pendingAssignedNodes.insert(uniqueAssignment.getUUID(), pendingNodeData);
     } else {
         if (requestAssignment.getType() != Assignment::AgentType
@@ -1480,6 +1482,7 @@ const char JSON_KEY_POOL[] = "pool";
 const char JSON_KEY_PENDING_CREDITS[] = "pending_credits";
 const char JSON_KEY_WAKE_TIMESTAMP[] = "wake_timestamp";
 const char JSON_KEY_USERNAME[] = "username";
+const char JSON_KEY_VERSION[] = "version";
 QJsonObject DomainServer::jsonObjectForNode(const SharedNodePointer& node) {
     QJsonObject nodeJson;
 
@@ -1506,6 +1509,7 @@ QJsonObject DomainServer::jsonObjectForNode(const SharedNodePointer& node) {
 
     // add the node username, if it exists
     nodeJson[JSON_KEY_USERNAME] = nodeData->getUsername();
+    nodeJson[JSON_KEY_VERSION] = nodeData->getNodeVersion();
 
     SharedAssignmentPointer matchingAssignment = _allAssignments.value(nodeData->getAssignmentUUID());
     if (matchingAssignment) {

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -24,6 +24,7 @@
 #include <QUrlQuery>
 
 #include <AccountManager.h>
+#include <ApplicationVersion.h>
 #include <HifiConfigVariantMap.h>
 #include <HTTPConnection.h>
 #include <JSONBreakableMarshal.h>
@@ -75,6 +76,7 @@ DomainServer::DomainServer(int argc, char* argv[]) :
     setOrganizationName("High Fidelity");
     setOrganizationDomain("highfidelity.io");
     setApplicationName("domain-server");
+    setApplicationVersion(BUILD_VERSION);
     QSettings::setDefaultFormat(QSettings::IniFormat);
 
     // make sure we have a fresh AccountManager instance
@@ -1478,7 +1480,6 @@ const char JSON_KEY_POOL[] = "pool";
 const char JSON_KEY_PENDING_CREDITS[] = "pending_credits";
 const char JSON_KEY_WAKE_TIMESTAMP[] = "wake_timestamp";
 const char JSON_KEY_USERNAME[] = "username";
-
 QJsonObject DomainServer::jsonObjectForNode(const SharedNodePointer& node) {
     QJsonObject nodeJson;
 
@@ -1527,7 +1528,6 @@ QJsonObject DomainServer::jsonObjectForNode(const SharedNodePointer& node) {
 }
 
 const char ASSIGNMENT_SCRIPT_HOST_LOCATION[] = "resources/web/assignment";
-
 QString pathForAssignmentScript(const QUuid& assignmentUUID) {
     QString newPath(ASSIGNMENT_SCRIPT_HOST_LOCATION);
     newPath += "/scripts/";
@@ -1537,7 +1537,6 @@ QString pathForAssignmentScript(const QUuid& assignmentUUID) {
 }
 
 const QString URI_OAUTH = "/oauth";
-
 bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url, bool skipSubHandler) {
     const QString JSON_MIME_TYPE = "application/json";
 
@@ -2024,8 +2023,6 @@ bool DomainServer::isAuthenticatedRequest(HTTPConnection* connection, const QUrl
 }
 
 const QString OAUTH_JSON_ACCESS_TOKEN_KEY = "access_token";
-
-
 QNetworkReply* DomainServer::profileRequestGivenTokenReply(QNetworkReply* tokenReply) {
     // pull the access token from the returned JSON and store it with the matching session UUID
     QJsonDocument returnedJSON = QJsonDocument::fromJson(tokenReply->readAll());
@@ -2042,7 +2039,6 @@ QNetworkReply* DomainServer::profileRequestGivenTokenReply(QNetworkReply* tokenR
 }
 
 const QString DS_SETTINGS_SESSIONS_GROUP = "web-sessions";
-
 Headers DomainServer::setupCookieHeadersFromProfileReply(QNetworkReply* profileReply) {
     Headers cookieHeaders;
 

--- a/domain-server/src/DomainServerNodeData.h
+++ b/domain-server/src/DomainServerNodeData.h
@@ -50,6 +50,10 @@ public:
 
     const NodeSet& getNodeInterestSet() const { return _nodeInterestSet; }
     void setNodeInterestSet(const NodeSet& nodeInterestSet) { _nodeInterestSet = nodeInterestSet; }
+    
+    void setNodeVersion(const QString& nodeVersion) { _nodeVersion = nodeVersion; }
+    const QString& getNodeVersion() { return _nodeVersion; }
+    
 private:
     QJsonObject mergeJSONStatsFromNewObject(const QJsonObject& newObject, QJsonObject destinationObject);
 
@@ -62,6 +66,7 @@ private:
     HifiSockAddr _sendingSockAddr;
     bool _isAuthenticated;
     NodeSet _nodeInterestSet;
+    QString _nodeVersion;
 };
 
 #endif // hifi_DomainServerNodeData_h

--- a/domain-server/src/PendingAssignedNodeData.cpp
+++ b/domain-server/src/PendingAssignedNodeData.cpp
@@ -11,9 +11,10 @@
 
 #include "PendingAssignedNodeData.h"
 
-PendingAssignedNodeData::PendingAssignedNodeData(const QUuid& assignmentUUID, const QUuid& walletUUID) :
+PendingAssignedNodeData::PendingAssignedNodeData(const QUuid& assignmentUUID, const QUuid& walletUUID, const QString& nodeVersion) :
     _assignmentUUID(assignmentUUID),
-    _walletUUID(walletUUID)
+    _walletUUID(walletUUID),
+    _nodeVersion(nodeVersion)
 {
     
 }

--- a/domain-server/src/PendingAssignedNodeData.h
+++ b/domain-server/src/PendingAssignedNodeData.h
@@ -18,16 +18,20 @@
 class PendingAssignedNodeData : public QObject {
     Q_OBJECT
 public:
-    PendingAssignedNodeData(const QUuid& assignmentUUID, const QUuid& walletUUID);
+    PendingAssignedNodeData(const QUuid& assignmentUUID, const QUuid& walletUUID, const QString& nodeVersion);
     
     void setAssignmentUUID(const QUuid& assignmentUUID) { _assignmentUUID = assignmentUUID; }
     const QUuid& getAssignmentUUID() const { return _assignmentUUID; }
     
     void setWalletUUID(const QUuid& walletUUID) { _walletUUID = walletUUID; }
     const QUuid& getWalletUUID() const { return _walletUUID; }
+    
+    const QString& getNodeVersion() const { return _nodeVersion; }
+
 private:
     QUuid _assignmentUUID;
     QUuid _walletUUID;
+    QString _nodeVersion;
 };
 
 #endif // hifi_PendingAssignedNodeData_h

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -14,20 +14,12 @@ endforeach()
 find_package(Qt5LinguistTools REQUIRED)
 find_package(Qt5LinguistToolsMacros)
 
-if (DEFINED ENV{JOB_ID})
-  set(BUILD_SEQ $ENV{JOB_ID})
-elseif (DEFINED ENV{ghprbPullId})
-  set(BUILD_SEQ "PR: $ENV{ghprbPullId} - Commit: $ENV{ghprbActualCommit}")
-else ()
-  set(BUILD_SEQ "dev")
-endif ()
-
 if (WIN32)
   add_definitions(-D_USE_MATH_DEFINES) # apparently needed to get M_PI and other defines from cmath/math.h		
   add_definitions(-DWINDOWS_LEAN_AND_MEAN) # needed to make sure windows doesn't go to crazy with its defines		
 endif()
 
-configure_file(InterfaceVersion.h.in "${PROJECT_BINARY_DIR}/includes/InterfaceVersion.h")
+include_application_version()
 
 # grab the implementation and header files from src dirs
 file(GLOB_RECURSE INTERFACE_SRCS "src/*.cpp" "src/*.h")
@@ -174,7 +166,7 @@ if (RTMIDI_FOUND AND NOT DISABLE_RTMIDI AND APPLE)
 endif ()
 
 # include headers for interface and InterfaceConfig.
-include_directories("${PROJECT_SOURCE_DIR}/src" "${PROJECT_BINARY_DIR}/includes")
+include_directories("${PROJECT_SOURCE_DIR}/src")
 
 target_link_libraries(
   ${TARGET_NAME}

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -52,6 +52,7 @@
 
 #include <AccountManager.h>
 #include <AddressManager.h>
+#include <ApplicationVersion.h>
 #include <CursorManager.h>
 #include <AudioInjector.h>
 #include <AutoUpdater.h>
@@ -100,7 +101,6 @@
 #include "AudioClient.h"
 #include "DiscoverabilityManager.h"
 #include "GLCanvas.h"
-#include "InterfaceVersion.h"
 #include "LODManager.h"
 #include "Menu.h"
 #include "ModelPackager.h"

--- a/libraries/networking/CMakeLists.txt
+++ b/libraries/networking/CMakeLists.txt
@@ -29,3 +29,4 @@ target_link_libraries(${TARGET_NAME} ${OPENSSL_LIBRARIES} ${TBB_LIBRARIES})
 
 # append tbb includes to our list of includes to bubble
 target_include_directories(${TARGET_NAME} SYSTEM PUBLIC ${TBB_INCLUDE_DIRS})
+include_application_version()

--- a/libraries/networking/src/Assignment.cpp
+++ b/libraries/networking/src/Assignment.cpp
@@ -66,7 +66,9 @@ Assignment::Assignment(NLPacket& packet) :
     _payload(),
     _walletUUID()
 {
+    qDebug() << "LEOTEST: We are building an Assignment from a packet";
     if (packet.getType() == PacketType::RequestAssignment) {
+        qDebug() << "LEOTEST: This is a request assignment packet";
         _command = Assignment::RequestCommand;
     } else if (packet.getType() == PacketType::CreateAssignment) {
         _command = Assignment::CreateCommand;
@@ -151,11 +153,16 @@ QDataStream& operator<<(QDataStream &out, const Assignment& assignment) {
 QDataStream& operator>>(QDataStream &in, Assignment& assignment) {
     quint8 packedType;
     in >> packedType;
+    if (assignment._command == Assignment::RequestCommand) {
+        qDebug() << "We are extracting the version";
+        in >> assignment._nodeVersion;
+    }
     assignment._type = (Assignment::Type) packedType;
     
     in >> assignment._uuid >> assignment._pool >> assignment._payload;
     
     if (assignment._command == Assignment::RequestCommand) {
+        qDebug() << "LEOTEST: Operator for >> in case of RequestCommand";
         in >> assignment._walletUUID;
     }
     

--- a/libraries/networking/src/Assignment.cpp
+++ b/libraries/networking/src/Assignment.cpp
@@ -13,7 +13,6 @@
 #include "SharedUtil.h"
 #include "UUID.h"
 
-#include <QtCore/QCoreApplication>
 #include <QtCore/QDataStream>
 
 #include <ApplicationVersion.h>

--- a/libraries/networking/src/Assignment.h
+++ b/libraries/networking/src/Assignment.h
@@ -83,6 +83,8 @@ public:
     void setWalletUUID(const QUuid& walletUUID) { _walletUUID = walletUUID; }
     const QUuid& getWalletUUID() const { return _walletUUID; }
     
+    const QString& getNodeVersion() const { return _nodeVersion; }
+    
     const char* getTypeName() const;
 
     friend QDebug operator<<(QDebug debug, const Assignment& assignment);

--- a/libraries/networking/src/Assignment.h
+++ b/libraries/networking/src/Assignment.h
@@ -98,6 +98,7 @@ protected:
     QByteArray _payload; /// an optional payload attached to this assignment, a maximum for 1024 bytes will be packed
     bool _isStatic; /// defines if this assignment needs to be re-queued in the domain-server if it stops being fulfilled
     QUuid _walletUUID; /// the UUID for the wallet that should be paid for this assignment
+    QString _nodeVersion;
 };
 
 #endif // hifi_Assignment_h

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -17,6 +17,7 @@
 #include <QtCore/QThread>
 #include <QtNetwork/QHostInfo>
 
+#include <ApplicationVersion.h>
 #include <LogHandler.h>
 
 #include "AccountManager.h"
@@ -367,7 +368,6 @@ void NodeList::sendDSPathQuery(const QString& newPath) {
     }
 }
 
-
 void NodeList::processDomainServerPathResponse(QSharedPointer<NLPacket> packet) {
     // This is a response to a path query we theoretically made.
     // In the future we may want to check that this was actually from our DS and for a query we actually made.
@@ -456,7 +456,6 @@ void NodeList::pingPunchForDomainServer() {
         _domainHandler.getICEPeer().incrementConnectionAttempts();
     }
 }
-
 
 void NodeList::processDomainServerConnectionTokenPacket(QSharedPointer<NLPacket> packet) {
     if (_domainHandler.getSockAddr().isNull()) {
@@ -547,9 +546,14 @@ void NodeList::sendAssignment(Assignment& assignment) {
         ? PacketType::CreateAssignment
         : PacketType::RequestAssignment;
 
+    qDebug() << "LEOTEST: Packet type name " << nameForPacketType(assignmentPacketType);
     auto assignmentPacket = NLPacket::create(assignmentPacketType);
-
+    
     QDataStream packetStream(assignmentPacket.get());
+    if (assignmentPacketType == PacketType::RequestAssignment) {
+        qDebug() << "LEOTEST: This is an assignment request, lets send the node version here " << BUILD_VERSION;
+        packetStream << BUILD_VERSION;
+    }
     packetStream << assignment;
 
     // TODO: should this be a non sourced packet?

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -546,14 +546,9 @@ void NodeList::sendAssignment(Assignment& assignment) {
         ? PacketType::CreateAssignment
         : PacketType::RequestAssignment;
 
-    qDebug() << "LEOTEST: Packet type name " << nameForPacketType(assignmentPacketType);
     auto assignmentPacket = NLPacket::create(assignmentPacketType);
     
     QDataStream packetStream(assignmentPacket.get());
-    if (assignmentPacketType == PacketType::RequestAssignment) {
-        qDebug() << "LEOTEST: This is an assignment request, lets send the node version here " << BUILD_VERSION;
-        packetStream << BUILD_VERSION;
-    }
     packetStream << assignment;
 
     // TODO: should this be a non sourced packet?


### PR DESCRIPTION
Another take at node versioning:

1) assignment-client version is only sent on AssignmentRequest
2) Version for ACs is stored in DS pendingAssignedNodeData and DomainServerNodeData only, we don't broadcast this detail to other nodes on the list.

This approach is lighter on the wire, however, multiple instances come to mind in which every node knowing the version of the sofware running on every node comes in handy, for choosing which nodes you want to talk to, in scenarios of rolling updates (we want you to talk to version X while version Y is deployed, and then switch to version Y), etc.

@PhilipRosedale @birarda 