### PR TITLE
fix-gaze debugging aid

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2397,7 +2397,9 @@ void Application::updateMyAvatarLookAtPosition() {
 
             if (faceAngle < MAXIMUM_FACE_ANGLE) {
                 // Randomly look back and forth between look targets
-                switch (_myAvatar->getEyeContactTarget()) {
+                eyeContactTarget target = Menu::getInstance()->isOptionChecked(MenuOption::FixGaze) ?
+                LEFT_EYE : _myAvatar->getEyeContactTarget();
+                switch (target) {
                     case LEFT_EYE:
                         lookAtSpot = lookingAtHead->getLeftEyePosition();
                         break;

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -453,6 +453,7 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderLookAtTargets, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderFocusIndicator, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ShowWhosLookingAtMe, 0, false);
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::FixGaze, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu,
                                            MenuOption::Connexion,
                                            0, false,

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -193,6 +193,7 @@ namespace MenuOption {
     const QString Faceshift = "Faceshift";
     const QString FirstPerson = "First Person";
     const QString FivePointCalibration = "5 Point Calibration";
+    const QString FixGaze = "Fix Gaze (no saccade)";
     const QString Forward = "Forward";
     const QString FrameTimer = "Show Timer";
     const QString FullscreenMirror = "Fullscreen Mirror";

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -277,7 +277,7 @@ void Head::calculateMouthShapes() {
 void Head::applyEyelidOffset(glm::quat headOrientation) {
     // Adjusts the eyelid blendshape coefficients so that the eyelid follows the iris as the head pitches.
 
-    glm::quat eyeRotation = rotationBetween(headOrientation * IDENTITY_FRONT, getCorrectedLookAtPosition() - _eyePosition);
+    glm::quat eyeRotation = rotationBetween(headOrientation * IDENTITY_FRONT, getLookAtPosition() - _eyePosition);
     eyeRotation = eyeRotation * glm::angleAxis(safeEulerAngles(headOrientation).y, IDENTITY_UP);  // Rotation w.r.t. head
     float eyePitch = safeEulerAngles(eyeRotation).x;
 

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -229,6 +229,9 @@ void Head::simulate(float deltaTime, bool isMine, bool billboard) {
     } else {
         _saccade = glm::vec3();
     }
+    if (Menu::getInstance()->isOptionChecked(MenuOption::FixGaze)) { // if debug menu turns off, use no saccade
+        _saccade = glm::vec3();
+    }
     
     if (!isMine) {
         _faceModel.setLODDistance(static_cast<Avatar*>(_owningAvatar)->getLODDistance());


### PR DESCRIPTION
Developer->Avatar->Fix Gaze menu option to not move the eyes around while we're debugging.

Also fix small bug in which the sender-side eyelid position was incorrectly using the receiver-side corrected look at spot instead of the one shared by everyone.