### PR TITLE
Fix for ATI discrete graphics on 2015 macbook pro / mac pro.

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -133,7 +133,7 @@ void GLBackend::updateTransform() {
     if (offset >= 0) {
         glBindBufferRange(GL_UNIFORM_BUFFER, TRANSFORM_CAMERA_SLOT, 
             _transform._transformCameraBuffer,
-            offset, sizeof(Backend::TransformObject));
+            offset, sizeof(Backend::TransformCamera));
     }
 
     (void)CHECK_GL_ERROR();


### PR DESCRIPTION
Fixed incorrect size for camera transform uniforms passed via
glBindBufferRange.   This is a legitimate bug on our side.
I guess Intel and nVidia drivers just happen to ignore this field.
This was likely causing many of the shader TransformCamera members
to be identity or un-initialized, specifically, the projection
matrix values.

This was resulting in a black screen on ATI gpus.