### PR TITLE
make web entity focus click based

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -674,9 +674,11 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
     packetReceiver.registerListener(PacketType::DomainConnectionDenied, this, "handleDomainConnectionDeniedPacket");
 
     auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
-    connect(entityScriptingInterface.data(), &EntityScriptingInterface::hoverEnterEntity, [this, entityScriptingInterface](const EntityItemID& entityItemID, const MouseEvent& event) {
+    connect(entityScriptingInterface.data(), &EntityScriptingInterface::clickDownOnEntity, 
+        [this, entityScriptingInterface](const EntityItemID& entityItemID, const MouseEvent& event) {
         if (_keyboardFocusedItem != entityItemID) {
             _keyboardFocusedItem = UNKNOWN_ENTITY_ID;
+            qDebug() << "_keyboardFocusedItem:" << UNKNOWN_ENTITY_ID;
             auto properties = entityScriptingInterface->getEntityProperties(entityItemID);
             if (EntityTypes::Web == properties.getType() && !properties.getLocked()) {
                 auto entity = entityScriptingInterface->getEntityTree()->findEntityByID(entityItemID);
@@ -684,16 +686,21 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
                 if (webEntity) {
                     webEntity->setProxyWindow(_window->windowHandle());
                     _keyboardFocusedItem = entityItemID;
+                    qDebug() << "_keyboardFocusedItem:" << entityItemID;
                 }
             }
         }
     });
 
+    /*
+    // FIXME - need a solution for unfocusing on delayed time
     connect(entityScriptingInterface.data(), &EntityScriptingInterface::hoverLeaveEntity, [=](const EntityItemID& entityItemID, const MouseEvent& event) {
         if (_keyboardFocusedItem == entityItemID) {
             _keyboardFocusedItem = UNKNOWN_ENTITY_ID;
+            qDebug() << "_keyboardFocusedItem:" << UNKNOWN_ENTITY_ID;
         }
     });
+    */
 }
 
 void Application::aboutToQuit() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1277,6 +1277,7 @@ bool Application::event(QEvent* event) {
                     QCoreApplication::sendEvent(webEntity->getEventHandler(), event);
                     if (event->isAccepted()) {
                         _lastAcceptedKeyPress = usecTimestampNow();
+                        qDebug() << "Application::event() key event... _lastAcceptedKeyPress:" << _lastAcceptedKeyPress;
                         return true;
                     }
                 }
@@ -1287,6 +1288,7 @@ bool Application::event(QEvent* event) {
                 break;
         }
 
+        /*
         const quint64 LOSE_FOCUS_AFTER_ELAPSED_TIME = 30 * USECS_PER_SECOND; // if idle for 30 seconds, drop focus
         quint64 elapsedSinceAcceptedKeyPress = usecTimestampNow() - _lastAcceptedKeyPress;
         if (elapsedSinceAcceptedKeyPress > LOSE_FOCUS_AFTER_ELAPSED_TIME) {
@@ -1295,6 +1297,7 @@ bool Application::event(QEvent* event) {
         } else {
             qDebug() << "elapsedSinceAcceptedKeyPress:" << elapsedSinceAcceptedKeyPress;
         }
+        */
         
     }
 
@@ -2001,6 +2004,19 @@ void Application::idle() {
     PerformanceTimer perfTimer("idle");
     if (_aboutToQuit) {
         return; // bail early, nothing to do here.
+    }
+
+    if (!_keyboardFocusedItem.isInvalidID()) {
+        const quint64 LOSE_FOCUS_AFTER_ELAPSED_TIME = 30 * USECS_PER_SECOND; // if idle for 30 seconds, drop focus
+        quint64 elapsedSinceAcceptedKeyPress = usecTimestampNow() - _lastAcceptedKeyPress;
+        if (elapsedSinceAcceptedKeyPress > LOSE_FOCUS_AFTER_ELAPSED_TIME) {
+            _keyboardFocusedItem = UNKNOWN_ENTITY_ID;
+            qDebug() << "Application::idle() no key messages for 30 seconds.... _keyboardFocusedItem: UNKNOWN_ENTITY_ID:" << UNKNOWN_ENTITY_ID;
+        } else {
+            qDebug() << "Application::idle() _keyboardFocusedItem:" << _keyboardFocusedItem << "elapsedSinceAcceptedKeyPress:" << elapsedSinceAcceptedKeyPress;
+        }
+    } else {
+        qDebug() << "Application::idle() no focused item, who cares...";
     }
 
     // Normally we check PipelineWarnings, but since idle will often take more than 10ms we only show these idle timing

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -680,6 +680,7 @@ private:
     DialogsManagerScriptingInterface* _dialogsManagerScriptingInterface = new DialogsManagerScriptingInterface();
 
     EntityItemID _keyboardFocusedItem;
+    quint64 _lastAcceptedKeyPress = 0;
 };
 
 #endif // hifi_Application_h

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -861,6 +861,8 @@ void EntityTreeRenderer::mousePressEvent(QMouseEvent* event, unsigned int device
         if (entityScript.property("clickDownOnEntity").isValid()) {
             entityScript.property("clickDownOnEntity").call(entityScript, entityScriptArgs);
         }
+    } else {
+        emit mousePressOffEntity(rayPickResult, event, deviceID);
     }
     _lastMouseEvent = MouseEvent(*event, deviceID);
     _lastMouseEventValid = true;

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -95,6 +95,7 @@ public:
 
 signals:
     void mousePressOnEntity(const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event, unsigned int deviceId);
+    void mousePressOffEntity(const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event, unsigned int deviceId);
     void mouseMoveOnEntity(const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event, unsigned int deviceId);
     void mouseReleaseOnEntity(const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event, unsigned int deviceId);
 

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -56,6 +56,15 @@ RenderableWebEntityItem::~RenderableWebEntityItem() {
 }
 
 void RenderableWebEntityItem::render(RenderArgs* args) {
+    
+    // debug bounds on mac.
+    {
+        gpu::Batch& batch = *args->_batch;
+        batch.setModelTransform(getTransformToCenter()); // we want to include the scale as well
+        glm::vec4 cubeColor{ 1.0f, 0.0f, 0.0f, 1.0f};
+        DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.0f, cubeColor);
+    }
+
     QOpenGLContext * currentContext = QOpenGLContext::currentContext();
     QSurface * currentSurface = currentContext->surface();
     if (!_webSurface) {

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -57,13 +57,14 @@ RenderableWebEntityItem::~RenderableWebEntityItem() {
 
 void RenderableWebEntityItem::render(RenderArgs* args) {
     
-    // debug bounds on mac.
+    #ifdef WANT_EXTRA_DEBUGGING
     {
         gpu::Batch& batch = *args->_batch;
         batch.setModelTransform(getTransformToCenter()); // we want to include the scale as well
         glm::vec4 cubeColor{ 1.0f, 0.0f, 0.0f, 1.0f};
         DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.0f, cubeColor);
     }
+    #endif
 
     QOpenGLContext * currentContext = QOpenGLContext::currentContext();
     QSurface * currentSurface = currentContext->surface();


### PR DESCRIPTION
This changes the behavior for how web entities get keyboard focus. The old behavior was you would simply hover over the web entity. The new behavior is you click the web entity. To drop focus you can click on any other entity and or in blank space. Or if your keyboard has been idle for 30 seconds we also drop focus.