### PR TITLE
always persist entities as gzipped json

### DIFF
--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -971,12 +971,7 @@ void OctreeServer::readConfiguration() {
         strcpy(_persistFilename, qPrintable(persistFilename));
         qDebug("persistFilename=%s", _persistFilename);
 
-        QString persistAsFileType;
-        if (!readOptionString(QString("persistAsFileType"), settingsSectionObject, persistAsFileType)) {
-            persistAsFileType = "svo";
-        }
-        _persistAsFileType = persistAsFileType;
-        qDebug() << "persistAsFileType=" << _persistAsFileType;
+        _persistAsFileType = "json.gz";
 
         _persistInterval = OctreePersistThread::DEFAULT_PERSIST_INTERVAL;
         readOptionInt(QString("persistInterval"), settingsSectionObject, _persistInterval);

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -371,30 +371,8 @@
           "name": "persistFilename",
           "label": "Entities Filename",
           "help": "the path to the file entities are stored in. Make sure the path exists.",
-          "placeholder": "resources/models.svo",
-          "default": "resources/models.svo",
-          "advanced": true
-        },
-        {
-          "name": "persistAsFileType",
-          "label": "File format for entity server's persistent data",
-          "help": "This defines how the entity server will save entities to disk.",
-          "default": "svo",
-          "type": "select",
-          "options": [
-            {
-              "value": "svo",
-              "label": "Entity server persists data as SVO"
-            },
-            {
-              "value": "json",
-              "label": "Entity server persists data as JSON"
-            },
-            {
-              "value": "json.gz",
-              "label": "Entity server persists data as gzipped JSON"
-            }
-          ],
+          "placeholder": "resources/models.json.gz",
+          "default": "resources/models.json.gz",
           "advanced": true
         },
         {


### PR DESCRIPTION
- remove entity-server setting which allowed a choice of entity-persist-file types.  gzipped json becomes the only (non)choice.
