### PR TITLE
possible fix for invisible other's-avatar bug

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -563,6 +563,9 @@ glm::quat Avatar::computeRotationFromBodyToWorldUp(float proportion) const {
 }
 
 void Avatar::fixupModelsInScene() {
+    if (!(_skeletonModel.isRenderable() && getHead()->getFaceModel().isRenderable())) {
+        return;
+    }
 
     // check to see if when we added our models to the scene they were ready, if they were not ready, then
     // fix them up in the scene


### PR DESCRIPTION
- don't add other avatars to the scene until their models are ready.  possible fix for invisible avatar bug.