### PR TITLE
Better handling of socket binding

### DIFF
--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QtCore/QCoreApplication>
 #include <QtCore/QDebug>
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
@@ -19,16 +20,18 @@
 #include "EmbeddedWebserverLogging.h"
 #include "HTTPManager.h"
 
+const int SOCKET_ERROR_EXIT_CODE = 2;
+
 HTTPManager::HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestHandler* requestHandler, QObject* parent) :
     QTcpServer(parent),
     _documentRoot(documentRoot),
-    _requestHandler(requestHandler)
+    _requestHandler(requestHandler),
+    _port(port)
 {
-    // start listening on the passed port
-    if (!listen(QHostAddress("0.0.0.0"), port)) {
-        qCDebug(embeddedwebserver) << "Failed to open HTTP server socket:" << errorString();
-        return;
-    }
+    bindSocket();
+    _isListeningTimer = new QTimer(this);
+    connect(_isListeningTimer, &QTimer::timeout, this, &HTTPManager::isTcpServerListening);
+    _isListeningTimer->start(10000);
 }
 
 void HTTPManager::incomingConnection(qintptr socketDescriptor) {
@@ -156,4 +159,19 @@ bool HTTPManager::handleHTTPRequest(HTTPConnection* connection, const QUrl& url,
 
 bool HTTPManager::requestHandledByRequestHandler(HTTPConnection* connection, const QUrl& url) {
     return _requestHandler && _requestHandler->handleHTTPRequest(connection, url);
+}
+
+void HTTPManager::isTcpServerListening() {
+    if (!isListening()) {
+        qCWarning(embeddedwebserver) << "Socket on port " << QString::number(_port) << " is no longer listening";
+        bindSocket();
+    }}
+
+bool HTTPManager::bindSocket() {
+    qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);
+    if (!listen(QHostAddress::Any, _port)) {
+        qCWarning(embeddedwebserver) << "Failed to open HTTP server socket:" << errorString() << " can't continue";
+        QCoreApplication::exit(SOCKET_ERROR_EXIT_CODE);
+    }
+    return true;
 }

--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -165,7 +165,8 @@ void HTTPManager::isTcpServerListening() {
     if (!isListening()) {
         qCWarning(embeddedwebserver) << "Socket on port " << QString::number(_port) << " is no longer listening";
         bindSocket();
-    }}
+    }
+}
 
 bool HTTPManager::bindSocket() {
     qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);

--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -171,7 +171,7 @@ void HTTPManager::isTcpServerListening() {
 bool HTTPManager::bindSocket() {
     qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);
     if (!listen(QHostAddress::Any, _port)) {
-        qCWarning(embeddedwebserver) << "Failed to open HTTP server socket:" << errorString() << " can't continue";
+        qCritical() << "Failed to open HTTP server socket:" << errorString() << " can't continue";
         QCoreApplication::exit(SOCKET_ERROR_EXIT_CODE);
     }
     return true;

--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -21,6 +21,7 @@
 #include "HTTPManager.h"
 
 const int SOCKET_ERROR_EXIT_CODE = 2;
+const int SOCKET_CHECK_INTERVAL_IN_MS = 30000;
 
 HTTPManager::HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestHandler* requestHandler, QObject* parent) :
     QTcpServer(parent),
@@ -31,7 +32,7 @@ HTTPManager::HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestH
     bindSocket();
     _isListeningTimer = new QTimer(this);
     connect(_isListeningTimer, &QTimer::timeout, this, &HTTPManager::isTcpServerListening);
-    _isListeningTimer->start(10000);
+    _isListeningTimer->start(SOCKET_CHECK_INTERVAL_IN_MS);
 }
 
 void HTTPManager::incomingConnection(qintptr socketDescriptor) {

--- a/libraries/embedded-webserver/src/HTTPManager.h
+++ b/libraries/embedded-webserver/src/HTTPManager.h
@@ -17,6 +17,7 @@
 #define hifi_HTTPManager_h
 
 #include <QtNetwork/QTcpServer>
+#include <QtCore/QTimer>
 
 class HTTPConnection;
 class HTTPSConnection;
@@ -35,14 +36,22 @@ public:
     HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestHandler* requestHandler = NULL, QObject* parent = 0);
     
     bool handleHTTPRequest(HTTPConnection* connection, const QUrl& url, bool skipSubHandler = false);
+
+private slots:
+    void isTcpServerListening();
+    
+private:
+    bool bindSocket();
     
 protected:
     /// Accepts all pending connections
     virtual void incomingConnection(qintptr socketDescriptor);
     virtual bool requestHandledByRequestHandler(HTTPConnection* connection, const QUrl& url);
-protected:
+    
     QString _documentRoot;
     HTTPRequestHandler* _requestHandler;
+    QTimer* _isListeningTimer;
+    const quint16 _port;
 };
 
 #endif // hifi_HTTPManager_h


### PR DESCRIPTION
If the domain-server can't bind to the required ports, it will be inoperational and should not continue running.

If for any reason the server is no longer able to listen on the socket, try to bind to it again and if impossible exit with a non 0 code.