### PR TITLE
make sure .options works from scripted AudioInjector

### DIFF
--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -77,9 +77,9 @@ void AudioInjector::injectAudio() {
             int byteOffset = (int) floorf(AudioConstants::SAMPLE_RATE * _options.secondOffset * (_options.stereo ? 2.0f : 1.0f));
             byteOffset *= sizeof(int16_t);
 
-            _currentSendPosition = byteOffset;
+            _currentSendOffset = byteOffset;
         } else {
-            _currentSendPosition = 0;
+            _currentSendOffset = 0;
         }
 
         if (_options.localOnly) {
@@ -119,7 +119,7 @@ void AudioInjector::injectLocally() {
             _localBuffer->setVolume(_options.volume);
 
             // give our current send position to the local buffer
-            _localBuffer->setCurrentOffset(_currentSendPosition);
+            _localBuffer->setCurrentOffset(_currentSendOffset);
 
             success = _localAudioInterface->outputLocalInjector(_options.stereo, this);
 
@@ -144,9 +144,9 @@ void AudioInjector::injectLocally() {
 const uchar MAX_INJECTOR_VOLUME = 0xFF;
 
 void AudioInjector::injectToMixer() {
-    if (_currentSendPosition < 0 ||
-        _currentSendPosition >= _audioData.size()) {
-        _currentSendPosition = 0;
+    if (_currentSendOffset < 0 ||
+        _currentSendOffset >= _audioData.size()) {
+        _currentSendOffset = 0;
     }
 
     auto nodeList = DependencyManager::get<NodeList>();
@@ -203,15 +203,15 @@ void AudioInjector::injectToMixer() {
         // loop to send off our audio in NETWORK_BUFFER_LENGTH_SAMPLES_PER_CHANNEL byte chunks
         quint16 outgoingInjectedAudioSequenceNumber = 0;
 
-        while (_currentSendPosition < _audioData.size() && !_shouldStop) {
+        while (_currentSendOffset < _audioData.size() && !_shouldStop) {
 
             int bytesToCopy = std::min(((_options.stereo) ? 2 : 1) * AudioConstants::NETWORK_FRAME_BYTES_PER_CHANNEL,
-                                       _audioData.size() - _currentSendPosition);
+                                       _audioData.size() - _currentSendOffset);
 
             //  Measure the loudness of this frame
             _loudness = 0.0f;
             for (int i = 0; i < bytesToCopy; i += sizeof(int16_t)) {
-                _loudness += abs(*reinterpret_cast<int16_t*>(_audioData.data() + _currentSendPosition + i)) /
+                _loudness += abs(*reinterpret_cast<int16_t*>(_audioData.data() + _currentSendOffset + i)) /
                 (AudioConstants::MAX_SAMPLE_VALUE / 2.0f);
             }
             _loudness /= (float)(bytesToCopy / sizeof(int16_t));
@@ -220,7 +220,7 @@ void AudioInjector::injectToMixer() {
             
             // pack the sequence number
             audioPacket->writePrimitive(outgoingInjectedAudioSequenceNumber);
-
+            
             audioPacket->seek(positionOptionOffset);
             audioPacket->writePrimitive(_options.position);
             audioPacket->writePrimitive(_options.orientation);
@@ -232,7 +232,7 @@ void AudioInjector::injectToMixer() {
             audioPacket->seek(audioDataOffset);
 
             // copy the next NETWORK_BUFFER_LENGTH_BYTES_PER_CHANNEL bytes to the packet
-            audioPacket->write(_audioData.data() + _currentSendPosition, bytesToCopy);
+            audioPacket->write(_audioData.data() + _currentSendOffset, bytesToCopy);
 
             // set the correct size used for this packet
             audioPacket->setPayloadSize(audioPacket->pos());
@@ -246,11 +246,11 @@ void AudioInjector::injectToMixer() {
                 outgoingInjectedAudioSequenceNumber++;
             }
 
-            _currentSendPosition += bytesToCopy;
+            _currentSendOffset += bytesToCopy;
 
             // send two packets before the first sleep so the mixer can start playback right away
 
-            if (_currentSendPosition != bytesToCopy && _currentSendPosition < _audioData.size()) {
+            if (_currentSendOffset != bytesToCopy && _currentSendOffset < _audioData.size()) {
 
                 // process events in case we have been told to stop and be deleted
                 QCoreApplication::processEvents();
@@ -268,8 +268,8 @@ void AudioInjector::injectToMixer() {
                 }
             }
 
-            if (shouldLoop && _currentSendPosition >= _audioData.size()) {
-                _currentSendPosition = 0;
+            if (shouldLoop && _currentSendOffset >= _audioData.size()) {
+                _currentSendOffset = 0;
             }
         }
     }

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -31,7 +31,6 @@ class AbstractAudioInterface;
 class AudioInjector : public QObject {
     Q_OBJECT
     
-    Q_PROPERTY(AudioInjectorOptions options WRITE setOptions READ getOptions)
 public:
     AudioInjector(QObject* parent);
     AudioInjector(Sound* sound, const AudioInjectorOptions& injectorOptions);
@@ -39,7 +38,8 @@ public:
     
     bool isFinished() const { return _isFinished; }
     
-    int getCurrentSendPosition() const { return _currentSendPosition; }
+    int getCurrentSendOffset() const { return _currentSendOffset; }
+    void setCurrentSendOffset(int currentSendOffset) { _currentSendOffset = currentSendOffset; }
     
     AudioInjectorLocalBuffer* getLocalBuffer() const { return _localBuffer; }
     bool isLocalOnly() const { return _options.localOnly; }
@@ -58,9 +58,8 @@ public slots:
     void stopAndDeleteLater();
     
     const AudioInjectorOptions& getOptions() const { return _options; }
-    void setOptions(const AudioInjectorOptions& options) { _options = options; }
+    void setOptions(const AudioInjectorOptions& options) { _options = options;  }
     
-    void setCurrentSendPosition(int currentSendPosition) { _currentSendPosition = currentSendPosition; }
     float getLoudness() const { return _loudness; }
     bool isPlaying() const { return _isPlaying; }
     void restartPortionAfterFinished();
@@ -82,7 +81,7 @@ private:
     bool _isStarted = false;
     bool _isFinished = false;
     bool _shouldDeleteAfterFinish = false;
-    int _currentSendPosition = 0;
+    int _currentSendOffset = 0;
     AbstractAudioInterface* _localAudioInterface = NULL;
     AudioInjectorLocalBuffer* _localBuffer = NULL;
 };

--- a/libraries/avatars/src/Player.cpp
+++ b/libraries/avatars/src/Player.cpp
@@ -371,7 +371,7 @@ void Player::setAudioInjectorPosition() {
     int MSEC_PER_SEC = 1000;
     int FRAME_SIZE = sizeof(AudioConstants::AudioSample) * _recording->numberAudioChannel();
     int currentAudioFrame = elapsed() * FRAME_SIZE * (AudioConstants::SAMPLE_RATE / MSEC_PER_SEC);
-    _injector->setCurrentSendPosition(currentAudioFrame);
+    _injector->setCurrentSendOffset(currentAudioFrame);
 }
 
 void Player::setPlayFromCurrentLocation(bool playFromCurrentLocation) {

--- a/libraries/script-engine/src/ScriptAudioInjector.h
+++ b/libraries/script-engine/src/ScriptAudioInjector.h
@@ -21,13 +21,15 @@ class ScriptAudioInjector : public QObject {
     
     Q_PROPERTY(bool isPlaying READ isPlaying)
     Q_PROPERTY(float loudness READ getLoudness)
+    Q_PROPERTY(AudioInjectorOptions options WRITE setOptions READ getOptions)
 public:
     ScriptAudioInjector(AudioInjector* injector);
     ~ScriptAudioInjector();
 public slots:
     void restart() { _injector->restart(); }
     void stop() { _injector->stop(); }
-    
+   
+    const AudioInjectorOptions& getOptions() const { return _injector->getOptions(); }
     void setOptions(const AudioInjectorOptions& options) { _injector->setOptions(options); }
     
     float getLoudness() const { return _injector->getLoudness(); }


### PR DESCRIPTION
Fix for a bug I introduced with separation of `AudioInjector` and `ScriptedAudioInjector` - the `.options` property was no longer being exposed to JS.

I also renamed `_currentSendPosition` to `_currentSendOffset` to not collide in name with the `Vec3` position.