### PR TITLE
Hide Menubar on non-mac OS when going to fullscreen

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1744,7 +1744,7 @@ void Application::mouseMoveEvent(QMouseEvent* event, unsigned int deviceID) {
         return;
     }
 
-#if 1 //ndef Q_OS_MAC
+#ifndef Q_OS_MAC
     // If in full screen, and our main windows menu bar is hidden, and we're close to the top of the QMainWindow
     // then show the menubar.
     if (_window->isFullScreen()) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4985,6 +4985,12 @@ void Application::setFullscreen(const QScreen* target) {
 #endif
     _window->windowHandle()->setScreen((QScreen*)target);
     _window->showFullScreen();
+    
+    // also hide the QMainWindow's menuBar
+    QMenuBar* menuBar = _window->menuBar();
+    if (menuBar) {
+        menuBar->setVisible(false);
+    }
 }
 
 void Application::unsetFullscreen(const QScreen* avoid) {
@@ -5015,6 +5021,12 @@ void Application::unsetFullscreen(const QScreen* avoid) {
 #else
     _window->setGeometry(targetGeometry);
 #endif
+
+    // also show the QMainWindow's menuBar
+    QMenuBar* menuBar = _window->menuBar();
+    if (menuBar) {
+        menuBar->setVisible(true);
+    }
 }
 
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1744,6 +1744,27 @@ void Application::mouseMoveEvent(QMouseEvent* event, unsigned int deviceID) {
         return;
     }
 
+#if 1 //ndef Q_OS_MAC
+    // If in full screen, and our main windows menu bar is hidden, and we're close to the top of the QMainWindow
+    // then show the menubar.
+    if (_window->isFullScreen()) {
+        QMenuBar* menuBar = _window->menuBar();
+        if (menuBar) {
+            static const int MENU_TOGGLE_AREA = 10;
+            if (!menuBar->isVisible()) {
+                if (event->pos().y() <= MENU_TOGGLE_AREA) {
+                    menuBar->setVisible(true);
+                }
+            } else {
+                if (event->pos().y() > MENU_TOGGLE_AREA) {
+                    menuBar->setVisible(false);
+                }
+            }
+        }
+    }
+#endif
+
+
     _entities.mouseMoveEvent(event, deviceID);
 
     _controllerScriptingInterface.emitMouseMoveEvent(event, deviceID); // send events to any registered scripts
@@ -4986,11 +5007,13 @@ void Application::setFullscreen(const QScreen* target) {
     _window->windowHandle()->setScreen((QScreen*)target);
     _window->showFullScreen();
     
+#ifndef Q_OS_MAC
     // also hide the QMainWindow's menuBar
     QMenuBar* menuBar = _window->menuBar();
     if (menuBar) {
         menuBar->setVisible(false);
     }
+#endif
 }
 
 void Application::unsetFullscreen(const QScreen* avoid) {
@@ -5022,11 +5045,13 @@ void Application::unsetFullscreen(const QScreen* avoid) {
     _window->setGeometry(targetGeometry);
 #endif
 
+#ifndef Q_OS_MAC
     // also show the QMainWindow's menuBar
     QMenuBar* menuBar = _window->menuBar();
     if (menuBar) {
         menuBar->setVisible(true);
     }
+#endif
 }
 
 


### PR DESCRIPTION
When you go into full screen on non-Mac platforms, hide the main application menubar. If you move the mouse near the top of the screen, show the menubar temporarily, hide it when you move away from top.