### PR TITLE
force the HTTPManager to listen on IPv4

### DIFF
--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -173,7 +173,7 @@ void HTTPManager::isTcpServerListening() {
 bool HTTPManager::bindSocket() {
     qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);
     
-    if (false) {
+    if (listen(QHostAddress::AnyIPv4, _port)) {
         qCDebug(embeddedwebserver) << "TCP socket is listening on" << serverAddress() << "and port" << serverPort();
         
         return true;

--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -29,10 +29,14 @@ HTTPManager::HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestH
     _requestHandler(requestHandler),
     _port(port)
 {
-    bindSocket();
-    _isListeningTimer = new QTimer(this);
-    connect(_isListeningTimer, &QTimer::timeout, this, &HTTPManager::isTcpServerListening);
-    _isListeningTimer->start(SOCKET_CHECK_INTERVAL_IN_MS);
+    qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);
+    
+    if (listen(QHostAddress::AnyIPv4, _port)) {
+        qCDebug(embeddedwebserver) << "TCP socket is listening on" << serverAddress() << "and port" << serverPort();
+    } else {
+        qCritical() << "Failed to open HTTP server socket:" << errorString() << " - forcing exit.";
+        QCoreApplication::exit(SOCKET_ERROR_EXIT_CODE);
+    }
 }
 
 void HTTPManager::incomingConnection(qintptr socketDescriptor) {
@@ -162,18 +166,3 @@ bool HTTPManager::requestHandledByRequestHandler(HTTPConnection* connection, con
     return _requestHandler && _requestHandler->handleHTTPRequest(connection, url);
 }
 
-void HTTPManager::isTcpServerListening() {
-    if (!isListening()) {
-        qCWarning(embeddedwebserver) << "Socket on port " << QString::number(_port) << " is no longer listening";
-        bindSocket();
-    }
-}
-
-bool HTTPManager::bindSocket() {
-    qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);
-    if (!listen(QHostAddress::Any, _port)) {
-        qCritical() << "Failed to open HTTP server socket:" << errorString() << " can't continue";
-        QCoreApplication::exit(SOCKET_ERROR_EXIT_CODE);
-    }
-    return true;
-}

--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -20,7 +20,6 @@
 #include "EmbeddedWebserverLogging.h"
 #include "HTTPManager.h"
 
-const int SOCKET_ERROR_EXIT_CODE = 2;
 const int SOCKET_CHECK_INTERVAL_IN_MS = 30000;
 
 HTTPManager::HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestHandler* requestHandler, QObject* parent) :
@@ -30,6 +29,7 @@ HTTPManager::HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestH
     _port(port)
 {
     bindSocket();
+    
     _isListeningTimer = new QTimer(this);
     connect(_isListeningTimer, &QTimer::timeout, this, &HTTPManager::isTcpServerListening);
     _isListeningTimer->start(SOCKET_CHECK_INTERVAL_IN_MS);
@@ -171,9 +171,16 @@ void HTTPManager::isTcpServerListening() {
 
 bool HTTPManager::bindSocket() {
     qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);
-    if (!listen(QHostAddress::Any, _port)) {
+    
+    if (listen(QHostAddress::AnyIPv4, _port)) {
+        qCDebug(embeddedwebserver) << "TCP socket is listening on" << serverAddress() << "and port" << serverPort();
+        
+        return true;
+    } else {
         qCritical() << "Failed to open HTTP server socket:" << errorString() << " can't continue";
-        QCoreApplication::exit(SOCKET_ERROR_EXIT_CODE);
+        QMetaObject::invokeMethod(QCoreApplication::instance(), "quit", Qt::QueuedConnection);
+        
+        return false;
     }
-    return true;
+    
 }

--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -20,6 +20,7 @@
 #include "EmbeddedWebserverLogging.h"
 #include "HTTPManager.h"
 
+const int SOCKET_ERROR_EXIT_CODE = 2;
 const int SOCKET_CHECK_INTERVAL_IN_MS = 30000;
 
 HTTPManager::HTTPManager(quint16 port, const QString& documentRoot, HTTPRequestHandler* requestHandler, QObject* parent) :
@@ -172,15 +173,18 @@ void HTTPManager::isTcpServerListening() {
 bool HTTPManager::bindSocket() {
     qCDebug(embeddedwebserver) << "Attempting to bind TCP socket on port " << QString::number(_port);
     
-    if (listen(QHostAddress::AnyIPv4, _port)) {
+    if (false) {
         qCDebug(embeddedwebserver) << "TCP socket is listening on" << serverAddress() << "and port" << serverPort();
         
         return true;
     } else {
         qCritical() << "Failed to open HTTP server socket:" << errorString() << " can't continue";
-        QMetaObject::invokeMethod(QCoreApplication::instance(), "quit", Qt::QueuedConnection);
+        QMetaObject::invokeMethod(this, "queuedExit", Qt::QueuedConnection);
         
         return false;
     }
-    
+}
+
+void HTTPManager::queuedExit() {
+    QCoreApplication::exit(SOCKET_ERROR_EXIT_CODE);
 }

--- a/libraries/embedded-webserver/src/HTTPManager.h
+++ b/libraries/embedded-webserver/src/HTTPManager.h
@@ -37,6 +37,12 @@ public:
     
     bool handleHTTPRequest(HTTPConnection* connection, const QUrl& url, bool skipSubHandler = false);
 
+private slots:
+    void isTcpServerListening();
+    
+private:
+    bool bindSocket();
+    
 protected:
     /// Accepts all pending connections
     virtual void incomingConnection(qintptr socketDescriptor);
@@ -44,6 +50,7 @@ protected:
     
     QString _documentRoot;
     HTTPRequestHandler* _requestHandler;
+    QTimer* _isListeningTimer;
     const quint16 _port;
 };
 

--- a/libraries/embedded-webserver/src/HTTPManager.h
+++ b/libraries/embedded-webserver/src/HTTPManager.h
@@ -37,12 +37,6 @@ public:
     
     bool handleHTTPRequest(HTTPConnection* connection, const QUrl& url, bool skipSubHandler = false);
 
-private slots:
-    void isTcpServerListening();
-    
-private:
-    bool bindSocket();
-    
 protected:
     /// Accepts all pending connections
     virtual void incomingConnection(qintptr socketDescriptor);
@@ -50,7 +44,6 @@ protected:
     
     QString _documentRoot;
     HTTPRequestHandler* _requestHandler;
-    QTimer* _isListeningTimer;
     const quint16 _port;
 };
 

--- a/libraries/embedded-webserver/src/HTTPManager.h
+++ b/libraries/embedded-webserver/src/HTTPManager.h
@@ -39,6 +39,7 @@ public:
 
 private slots:
     void isTcpServerListening();
+    void queuedExit();
     
 private:
     bool bindSocket();


### PR DESCRIPTION
Fix for HTTPManager to listen only on `QHostAddress:IPv4`