### PR TITLE
Resource fix for textures in FBX files.

### DIFF
--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1723,7 +1723,7 @@ void GeometryReader::run() {
 NetworkGeometry::NetworkGeometry(const QUrl& url, bool delayLoad, const QVariantHash& mapping, const QUrl& textureBaseUrl) :
     _url(url),
     _mapping(mapping),
-    _textureBaseUrl(textureBaseUrl) {
+    _textureBaseUrl(textureBaseUrl.isValid() ? textureBaseUrl : url) {
 
     if (delayLoad) {
         _state = DelayState;


### PR DESCRIPTION
The baseTexturePath url for textures in FBXGeometry
should default to the same base url as the fbx file itself.
This error was introduced in my recent refactoring.
Textures fully embedded in FBXs should be un-affected
by this change, and continue to work.