### PR TITLE
Fix stereo modes aspect ratio

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1269,7 +1269,7 @@ void Application::resizeGL() {
         loadViewFrustum(_myCamera, _viewFrustum);
         float fov = glm::radians(DEFAULT_FIELD_OF_VIEW_DEGREES);
         // FIXME the aspect ratio for stereo displays is incorrect based on this.
-        float aspectRatio = aspect(_renderResolution);
+        float aspectRatio = displayPlugin->getRecommendedAspectRatio();
         _myCamera.setProjection(glm::perspective(fov, aspectRatio, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP));
     }
 

--- a/libraries/display-plugins/src/display-plugins/DisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/DisplayPlugin.h
@@ -8,12 +8,12 @@
 #pragma once
 
 #include "plugins/Plugin.h"
-
 #include <QSize>
 #include <QPoint>
 #include <functional>
 
 #include "gpu/GPUConfig.h"
+#include "GLMHelpers.h"
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
@@ -90,6 +90,11 @@ public:
     // The size of the UI
     virtual glm::uvec2 getRecommendedUiSize() const {
         return getRecommendedRenderSize();
+    }
+
+    // By default the aspect ratio is just the render size
+    virtual float getRecommendedAspectRatio() const {
+        return aspect(getRecommendedRenderSize());
     }
 
     // Stereo specific methods

--- a/libraries/display-plugins/src/display-plugins/stereo/StereoDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/stereo/StereoDisplayPlugin.cpp
@@ -91,3 +91,9 @@ void StereoDisplayPlugin::deactivate() {
     CONTAINER->unsetFullscreen();
     WindowOpenGLDisplayPlugin::deactivate();
 }
+
+// Derived classes will override the recommended render size based on the window size,
+// so here we want to fix the aspect ratio based on the window, not on the render size
+float StereoDisplayPlugin::getRecommendedAspectRatio() const {
+    return aspect(WindowOpenGLDisplayPlugin::getRecommendedRenderSize());
+}

--- a/libraries/display-plugins/src/display-plugins/stereo/StereoDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/stereo/StereoDisplayPlugin.h
@@ -19,6 +19,7 @@ public:
     virtual void activate() override;
     virtual void deactivate() override;
 
+    virtual float getRecommendedAspectRatio() const override;
     virtual glm::mat4 getProjection(Eye eye, const glm::mat4& baseProjection) const override;
     virtual glm::mat4 getEyePose(Eye eye) const override;
 


### PR DESCRIPTION
The stereo monitor modes were not getting a valid projection matrix because the app was calculating the aspect ratio based on the 'recommended render size', which in the case of SBS stereo is twice as wide as the actual screen, and in the case of interleaved, is twice as wide and half as tall.  
