### PR TITLE
fix direct-url avatars

### DIFF
--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -49,6 +49,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent) :
 
     connect(ui.buttonChangeAppearance, &QPushButton::clicked, this, &PreferencesDialog::openFullAvatarModelBrowser);
     connect(ui.appearanceDescription, &QLineEdit::textChanged, this, [this](const QString& url) {
+        DependencyManager::get<AvatarManager>()->getMyAvatar()->useFullAvatarURL(url, "");
         this->fullAvatarURLChanged(url, "");
     });
     connect(Application::getInstance(), &Application::fullAvatarURLChanged, this, &PreferencesDialog::fullAvatarURLChanged);


### PR DESCRIPTION
When I fixed the selection of avatars through the marketplace button, I broke the changing of avatars by specific direct url (e.g., pasted into) in the preferences dialog.