### PR TITLE
Fix UserInputMapper event generation

### DIFF
--- a/libraries/input-plugins/src/input-plugins/UserInputMapper.cpp
+++ b/libraries/input-plugins/src/input-plugins/UserInputMapper.cpp
@@ -226,9 +226,12 @@ void UserInputMapper::update(float deltaTime) {
     }
 
     // Scale all the channel step with the scale
+    static const float EPSILON =  0.01f;
     for (auto i = 0; i < NUM_ACTIONS; i++) {
         _actionStates[i] *= _actionScales[i];
-        if (_actionStates[i] > 0) {
+        // Emit only on change, and emit when moving back to 0
+        if (fabs(_actionStates[i] - _lastActionStates[i]) > EPSILON) {
+            _lastActionStates[i] = _actionStates[i];
             emit actionEvent(i, _actionStates[i]);
         }
         // TODO: emit signal for pose changes

--- a/libraries/input-plugins/src/input-plugins/UserInputMapper.h
+++ b/libraries/input-plugins/src/input-plugins/UserInputMapper.h
@@ -248,6 +248,7 @@ protected:
  
     std::vector<float> _actionStates = std::vector<float>(NUM_ACTIONS, 0.0f);
     std::vector<float> _actionScales = std::vector<float>(NUM_ACTIONS, 1.0f);
+    std::vector<float> _lastActionStates = std::vector<float>(NUM_ACTIONS, 0.0f);
     std::vector<PoseValue> _poseStates = std::vector<PoseValue>(NUM_ACTIONS);
 
     glm::mat4 _sensorToWorldMat;


### PR DESCRIPTION
Currently the userinputmapper sends action events for controllers for any non-zero value on every update cycle.  This is unhelpful for two reasons.

* It's no better than polling the value during your script's update method
* It's actually worse than polling because you never get an event telling you the button was released

This PR modifies the event sending logic.  Instead of sending an event whenever a value is non-zero, it stores the last sent state of every action, and sends an event if the current value is different from the one last sent.

This means that instead of getting a series of "1" values as long as the button is held down, you instead get a single "1" value when the button is pressed.  Additionally you now get a "0" value when the button is released.  This will allow for much more natural event based programming patterns inside JS scripts that wish to use events rather than polling for their behavior.  

