### PR TITLE
call setup_memory_debugger from common macros rather than from everywhere

### DIFF
--- a/assignment-client/CMakeLists.txt
+++ b/assignment-client/CMakeLists.txt
@@ -19,6 +19,4 @@ endif (UNIX)
 
 include_application_version()
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/cmake/macros/LinkHifiLibraries.cmake
+++ b/cmake/macros/LinkHifiLibraries.cmake
@@ -33,4 +33,7 @@ macro(LINK_HIFI_LIBRARIES)
       list(APPEND ${TARGET_NAME}_DEPENDENCY_INCLUDES ${LINKED_TARGET_DEPENDENCY_INCLUDES})
     endif()
   endforeach()
+
+  setup_memory_debugger()
+
 endmacro(LINK_HIFI_LIBRARIES)

--- a/cmake/macros/SetupHifiLibrary.cmake
+++ b/cmake/macros/SetupHifiLibrary.cmake
@@ -15,6 +15,8 @@ macro(SETUP_HIFI_LIBRARY)
   file(GLOB_RECURSE LIB_SRCS "src/*.h" "src/*.cpp" "src/*.c")
   list(APPEND ${TARGET_NAME}_SRCS ${LIB_SRCS})
 
+  setup_memory_debugger()
+
   # create a library and set the property so it can be referenced later
   if (${${TARGET_NAME}_SHARED})
     add_library(${TARGET_NAME} SHARED ${LIB_SRCS} ${AUTOMTC_SRC} ${AUTOSCRIBE_SHADER_LIB_SRC} ${QT_RESOURCES_FILE})

--- a/domain-server/CMakeLists.txt
+++ b/domain-server/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME domain-server)
 
-setup_memory_debugger()
-
 if (UPPER_CMAKE_BUILD_TYPE MATCHES DEBUG AND NOT WIN32)
   set(_SHOULD_SYMLINK_RESOURCES TRUE)
 else ()

--- a/gvr-interface/CMakeLists.txt
+++ b/gvr-interface/CMakeLists.txt
@@ -88,6 +88,4 @@ if (ANDROID)
   
 endif (ANDROID)
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/ice-server/CMakeLists.txt
+++ b/ice-server/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME ice-server)
 
-setup_memory_debugger()
-
 # setup the project and link required Qt modules
 setup_hifi_project(Network)
 

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -205,6 +205,4 @@ else (APPLE)
   endif()
 endif (APPLE)
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/libraries/animation/CMakeLists.txt
+++ b/libraries/animation/CMakeLists.txt
@@ -3,6 +3,4 @@ set(TARGET_NAME animation)
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Network Script)
 
-setup_memory_debugger()
-
 link_hifi_libraries(shared gpu model fbx)

--- a/libraries/audio-client/CMakeLists.txt
+++ b/libraries/audio-client/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME audio-client)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Network Multimedia)
 

--- a/libraries/audio/CMakeLists.txt
+++ b/libraries/audio/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME audio)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Network)
 

--- a/libraries/auto-updater/CMakeLists.txt
+++ b/libraries/auto-updater/CMakeLists.txt
@@ -1,6 +1,4 @@
 set(TARGET_NAME auto-updater)
 
-setup_memory_debugger()
-
 setup_hifi_library(Network)
 link_hifi_libraries(shared networking)

--- a/libraries/avatars/CMakeLists.txt
+++ b/libraries/avatars/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME avatars)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Network Script)
 

--- a/libraries/display-plugins/CMakeLists.txt
+++ b/libraries/display-plugins/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME display-plugins)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(OpenGL)
 

--- a/libraries/embedded-webserver/CMakeLists.txt
+++ b/libraries/embedded-webserver/CMakeLists.txt
@@ -1,6 +1,4 @@
 set(TARGET_NAME embedded-webserver)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Network)

--- a/libraries/entities-renderer/CMakeLists.txt
+++ b/libraries/entities-renderer/CMakeLists.txt
@@ -26,6 +26,4 @@ find_package(PolyVox REQUIRED)
 target_include_directories(${TARGET_NAME} SYSTEM PUBLIC ${POLYVOX_INCLUDE_DIRS})
 target_link_libraries(${TARGET_NAME} ${POLYVOX_LIBRARIES})
 
-setup_memory_debugger()
-
 link_hifi_libraries(shared gpu script-engine render render-utils)

--- a/libraries/entities/CMakeLists.txt
+++ b/libraries/entities/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME entities)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Network Script)
 

--- a/libraries/environment/CMakeLists.txt
+++ b/libraries/environment/CMakeLists.txt
@@ -7,6 +7,4 @@ add_dependency_external_projects(glm)
 find_package(GLM REQUIRED)
 target_include_directories(${TARGET_NAME} PUBLIC ${GLM_INCLUDE_DIRS})
 
-setup_memory_debugger()
-
 link_hifi_libraries(shared networking)

--- a/libraries/fbx/CMakeLists.txt
+++ b/libraries/fbx/CMakeLists.txt
@@ -7,6 +7,4 @@ add_dependency_external_projects(glm)
 find_package(GLM REQUIRED)
 target_include_directories(${TARGET_NAME} PUBLIC ${GLM_INCLUDE_DIRS})
 
-setup_memory_debugger()
-
 link_hifi_libraries(shared gpu model networking octree)

--- a/libraries/gpu/CMakeLists.txt
+++ b/libraries/gpu/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME gpu)
 
-setup_memory_debugger()
-
 AUTOSCRIBE_SHADER_LIB(gpu)
 
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules

--- a/libraries/input-plugins/CMakeLists.txt
+++ b/libraries/input-plugins/CMakeLists.txt
@@ -33,8 +33,6 @@ endif()
 #target_include_directories(${TARGET_NAME} PRIVATE ${SIXENSE_INCLUDE_DIRS})
 #target_link_libraries(${TARGET_NAME} ${SIXENSE_LIBRARIES})
 
-setup_memory_debugger()
-
 # perform standard include and linking for found externals
 foreach(EXTERNAL ${OPTIONAL_EXTERNALS})
   

--- a/libraries/model/CMakeLists.txt
+++ b/libraries/model/CMakeLists.txt
@@ -2,8 +2,6 @@ set(TARGET_NAME model)
 
 AUTOSCRIBE_SHADER_LIB(gpu model)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library()
 

--- a/libraries/networking/CMakeLists.txt
+++ b/libraries/networking/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME networking)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Network)
 

--- a/libraries/octree/CMakeLists.txt
+++ b/libraries/octree/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME octree)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library()
 

--- a/libraries/physics/CMakeLists.txt
+++ b/libraries/physics/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME physics)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library()
 

--- a/libraries/plugins/CMakeLists.txt
+++ b/libraries/plugins/CMakeLists.txt
@@ -8,6 +8,4 @@ link_hifi_libraries(shared)
 add_dependency_external_projects(glm)
 find_package(GLM REQUIRED)
 
-setup_memory_debugger()
-
 target_include_directories(${TARGET_NAME} PUBLIC ${GLM_INCLUDE_DIRS})

--- a/libraries/render-utils/CMakeLists.txt
+++ b/libraries/render-utils/CMakeLists.txt
@@ -40,6 +40,4 @@ add_dependency_external_projects(oglplus)
 find_package(OGLPLUS REQUIRED)
 target_include_directories(${TARGET_NAME} PUBLIC ${OGLPLUS_INCLUDE_DIRS})
 
-setup_memory_debugger()
-
 link_hifi_libraries(animation fbx shared gpu model render environment)

--- a/libraries/render/CMakeLists.txt
+++ b/libraries/render/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME render)
 
-setup_memory_debugger()
-
 AUTOSCRIBE_SHADER_LIB(gpu model)
 
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules

--- a/libraries/script-engine/CMakeLists.txt
+++ b/libraries/script-engine/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME script-engine)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 setup_hifi_library(Gui Network Script WebSockets Widgets)
 

--- a/libraries/shared/CMakeLists.txt
+++ b/libraries/shared/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TARGET_NAME shared)
 
-setup_memory_debugger()
-
 # use setup_hifi_library macro to setup our project and link appropriate Qt modules
 # TODO: there isn't really a good reason to have Script linked here - let's get what is requiring it out (RegisteredMetaTypes.cpp)
 setup_hifi_library(Gui Network Script Widgets)

--- a/libraries/ui/CMakeLists.txt
+++ b/libraries/ui/CMakeLists.txt
@@ -8,6 +8,4 @@ link_hifi_libraries(render-utils shared)
 add_dependency_external_projects(glm)
 find_package(GLM REQUIRED)
 
-setup_memory_debugger()
-
 target_include_directories(${TARGET_NAME} PUBLIC ${GLM_INCLUDE_DIRS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,5 +35,3 @@ set_target_properties("all-tests" PROPERTIES FOLDER "hidden/test-targets")
 set_target_properties("all-tests" PROPERTIES
     EXCLUDE_FROM_DEFAULT_BUILD TRUE
     EXCLUDE_FROM_ALL TRUE)
-
-setup_memory_debugger()

--- a/tests/animation/CMakeLists.txt
+++ b/tests/animation/CMakeLists.txt
@@ -6,6 +6,4 @@ macro (setup_testcase_dependencies)
   copy_dlls_beside_windows_executable()
 endmacro ()
 
-setup_memory_debugger()
-
 setup_hifi_testcase()

--- a/tests/audio/CMakeLists.txt
+++ b/tests/audio/CMakeLists.txt
@@ -6,6 +6,4 @@ macro (SETUP_TESTCASE_DEPENDENCIES)
   copy_dlls_beside_windows_executable()
 endmacro ()
 
-setup_memory_debugger()
-
 setup_hifi_testcase()

--- a/tests/entities/CMakeLists.txt
+++ b/tests/entities/CMakeLists.txt
@@ -9,6 +9,4 @@ set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Tests/manual-tests/")
 # link in the shared libraries
 link_hifi_libraries(entities avatars shared octree gpu model fbx networking animation environment)
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/tests/jitter/CMakeLists.txt
+++ b/tests/jitter/CMakeLists.txt
@@ -7,6 +7,4 @@ macro (setup_testcase_dependencies)
   copy_dlls_beside_windows_executable()
 endmacro()
 
-setup_memory_debugger()
-
 setup_hifi_testcase()

--- a/tests/networking/CMakeLists.txt
+++ b/tests/networking/CMakeLists.txt
@@ -7,6 +7,4 @@ macro (setup_testcase_dependencies)
   copy_dlls_beside_windows_executable()
 endmacro ()
 
-setup_memory_debugger()
-
 setup_hifi_testcase()

--- a/tests/octree/CMakeLists.txt
+++ b/tests/octree/CMakeLists.txt
@@ -7,6 +7,4 @@ macro (setup_testcase_dependencies)
   copy_dlls_beside_windows_executable()
 endmacro ()
 
-setup_memory_debugger()
-
 setup_hifi_testcase(Script Network)

--- a/tests/physics/CMakeLists.txt
+++ b/tests/physics/CMakeLists.txt
@@ -21,6 +21,4 @@ macro (SETUP_TESTCASE_DEPENDENCIES)
   copy_dlls_beside_windows_executable()
 endmacro ()
 
-setup_memory_debugger()
-
 setup_hifi_testcase(Script)

--- a/tests/render-utils/CMakeLists.txt
+++ b/tests/render-utils/CMakeLists.txt
@@ -10,6 +10,4 @@ link_hifi_libraries(render-utils gpu shared)
 
 message(${PROJECT_BINARY_DIR})
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/tests/shaders/CMakeLists.txt
+++ b/tests/shaders/CMakeLists.txt
@@ -19,6 +19,4 @@ include_directories("${PROJECT_BINARY_DIR}/../../libraries/model/")
 
 message(${PROJECT_BINARY_DIR})
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -8,6 +8,4 @@ macro (setup_testcase_dependencies)
   copy_dlls_beside_windows_executable()
 endmacro ()
 
-setup_memory_debugger()
-
 setup_hifi_testcase()

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -13,6 +13,4 @@ endif()
 # link in the shared libraries
 link_hifi_libraries(ui render-utils gpu shared)
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,3 @@
-setup_memory_debugger()
-
 # add the tool directories
 add_subdirectory(mtc)
 set_target_properties(mtc PROPERTIES FOLDER "Tools")

--- a/tools/mtc/CMakeLists.txt
+++ b/tools/mtc/CMakeLists.txt
@@ -1,6 +1,4 @@
 set(TARGET_NAME mtc)
 setup_hifi_project()
 
-setup_memory_debugger()
-
 copy_dlls_beside_windows_executable()

--- a/tools/scribe/CMakeLists.txt
+++ b/tools/scribe/CMakeLists.txt
@@ -1,5 +1,3 @@
 set(TARGET_NAME scribe)
 
-setup_memory_debugger()
-
 setup_hifi_project()

--- a/tools/vhacd-util/CMakeLists.txt
+++ b/tools/vhacd-util/CMakeLists.txt
@@ -8,8 +8,6 @@ find_package(VHACD REQUIRED)
 target_include_directories(${TARGET_NAME} PUBLIC ${VHACD_INCLUDE_DIRS})
 target_link_libraries(${TARGET_NAME} ${VHACD_LIBRARIES})
 
-setup_memory_debugger()
-
 if (UNIX AND NOT APPLE)
   include(FindOpenMP)
   if(OPENMP_FOUND)


### PR DESCRIPTION
- clean up setup_memory_debugger cmake macro use
