### PR TITLE
don't request a cert from peer in HTTPSManager

### DIFF
--- a/libraries/embedded-webserver/src/HTTPSManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPSManager.cpp
@@ -30,6 +30,7 @@ void HTTPSManager::incomingConnection(qintptr socketDescriptor) {
     
     sslSocket->setLocalCertificate(_certificate);
     sslSocket->setPrivateKey(_privateKey);
+    sslSocket->setPeerVerifyMode(QSslSocket::VerifyNone);
     
     if (sslSocket->setSocketDescriptor(socketDescriptor)) {
         new HTTPSConnection(sslSocket, this);


### PR DESCRIPTION
Connecting to our OAuth/HTTPs domains can be annoying because you have to first accept our self-signed cert and then say you don't want to present a cert. This stops the server from asking for a certificate from the connecting client.