### PR TITLE
Rig Menu Toggle and new animations

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -431,6 +431,8 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderFocusIndicator, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ShowWhosLookingAtMe, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::FixGaze, 0, false);
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::EnableRigAnimations, 0, false,
+                                           avatar, SLOT(setEnableRigAnimations(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::DisableEyelidAdjustment, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu,
                                            MenuOption::Connexion,

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -188,6 +188,7 @@ namespace MenuOption {
     const QString EditEntitiesHelp = "Edit Entities Help...";
     const QString Enable3DTVMode = "Enable 3DTV Mode";
     const QString EnableCharacterController = "Enable avatar collisions";
+    const QString EnableRigAnimations = "Enable Rig Animations";
     const QString ExpandMyAvatarSimulateTiming = "Expand /myAvatar/simulation";
     const QString ExpandMyAvatarTiming = "Expand /myAvatar";
     const QString ExpandOtherAvatarTiming = "Expand /otherAvatar";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -705,9 +705,10 @@ float loadSetting(QSettings& settings, const char* name, float defaultValue) {
 }
 
 void MyAvatar::setEnableRigAnimations(bool isEnabled) {
-    Settings settings;
-    settings.setValue("enableRig", isEnabled);
     _rig->setEnableRig(isEnabled);
+    if (!isEnabled) {
+        _rig->deleteAnimations();
+    }
 }
 
 void MyAvatar::loadData() {
@@ -769,7 +770,7 @@ void MyAvatar::loadData() {
     setCollisionSoundURL(settings.value("collisionSoundURL", DEFAULT_AVATAR_COLLISION_SOUND_URL).toString());
 
     settings.endGroup();
-    _rig->setEnableRig(settings.value("enableRig").toBool());
+    _rig->setEnableRig(Menu::getInstance()->isOptionChecked(MenuOption::EnableRigAnimations));
 }
 
 void MyAvatar::saveAttachmentData(const AttachmentData& attachment) const {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -87,7 +87,6 @@ public:
     Q_INVOKABLE AnimationDetails getAnimationDetailsByRole(const QString& role);
     Q_INVOKABLE AnimationDetails getAnimationDetails(const QString& url);
     void clearJointAnimationPriorities();
-    Q_INVOKABLE void setEnableRigAnimations(bool isEnabled);
 
     // get/set avatar data
     void saveData();
@@ -190,6 +189,7 @@ public slots:
     void loadLastRecording();
 
     virtual void rebuildSkeletonBody();
+    void setEnableRigAnimations(bool isEnabled);
 
 signals:
     void transformChanged();

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -100,24 +100,21 @@ AnimationHandlePointer Rig::addAnimationByRole(const QString& role, const QStrin
     AnimationHandlePointer handle = createAnimationHandle();
     QString standard = "";
     if (url.isEmpty()) {  // Default animations for fight club
-        const QString& base = "https://hifi-public.s3.amazonaws.com/ozan/";
+        const QString& base = "https://hifi-public.s3.amazonaws.com/ozan/anim/standard_anims/";
         if (role == "walk") {
-            standard = base + "support/FightClubBotTest1/Animations/standard_walk.fbx";
-            lastFrame = 60;
+            standard = base + "walk_fwd.fbx";
+         } else if (role == "backup") {
+            standard = base + "walk_bwd.fbx";
         } else if (role == "leftTurn") {
-            standard = base + "support/FightClubBotTest1/Animations/left_turn_noHipRotation.fbx";
-            lastFrame = 29;
+            standard = base + "turn_left.fbx";
         } else if (role == "rightTurn") {
-            standard = base + "support/FightClubBotTest1/Animations/right_turn_noHipRotation.fbx";
-            lastFrame = 31;
+            standard = base + "turn_right.fbx";
         } else if (role == "leftStrafe") {
-            standard = base + "animations/fightclub_bot_anims/side_step_left_inPlace.fbx";
-            lastFrame = 31;
+            standard = base + "strafe_left.fbx";
         } else if (role == "rightStrafe") {
-            standard = base + "animations/fightclub_bot_anims/side_step_right_inPlace.fbx";
-            lastFrame = 31;
+            standard = base + "strafe_right.fbx";
         } else if (role == "idle") {
-            standard = base + "support/FightClubBotTest1/Animations/standard_idle.fbx";
+            standard = base + "idle.fbx";
             fps = 25.0f;
         }
         if (!standard.isEmpty()) {
@@ -438,11 +435,12 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             }
         }
     };
-    updateRole("walk", std::abs(forwardSpeed) > 0.01f);
+    updateRole("walk", forwardSpeed > 0.01f);
+    updateRole("backup", forwardSpeed < -0.01f);
     bool isTurning = std::abs(rightTurningSpeed) > 0.5f;
     updateRole("rightTurn", isTurning && (rightTurningSpeed > 0));
     updateRole("leftTurn", isTurning && (rightTurningSpeed < 0));
-    bool isStrafing = std::abs(rightLateralSpeed) > 0.01f;
+    bool isStrafing = !isTurning && (std::abs(rightLateralSpeed) > 0.01f);
     updateRole("rightStrafe", isStrafing && (rightLateralSpeed > 0.0f));
     updateRole("leftStrafe", isStrafing && (rightLateralSpeed < 0.0f));
     updateRole("idle", !isMoving); // Must be last, as it makes isMoving bogus.


### PR DESCRIPTION
Enable Rig Animations is now a developer menu item (rather than requiring javascript to set). Also turning it off resets you to bind pose and deliberately throws away old animations.

Default animations are the new ones for our standard T-pose. (Had been for the double-A pose fightbot.)

Rig state machine now does "backup", and doesn't apply strafe while turning.