### PR TITLE
Add common vector constants to JS, add some missing Quat functionality

### DIFF
--- a/libraries/script-engine/src/Quat.cpp
+++ b/libraries/script-engine/src/Quat.cpp
@@ -18,6 +18,26 @@
 #include "ScriptEngineLogging.h"
 #include "Quat.h"
 
+quat Quat::normalize(const glm::quat& q) {
+    return glm::normalize(q);
+}
+
+glm::quat Quat::rotationBetween(const glm::vec3& v1, const glm::vec3& v2) {
+    return ::rotationBetween(v1, v2);
+}
+
+glm::quat Quat::lookAt(const glm::vec3& eye, const glm::vec3& center, const glm::vec3& up) {
+    return glm::quat_cast(glm::lookAt(eye, center, up));
+}
+
+glm::quat Quat::lookAtSimple(const glm::vec3& eye, const glm::vec3& center) {
+    auto dir = glm::normalize(center - eye);
+    // if the direction is nearly aligned with the Y axis, then use the X axis for 'up'
+    if (dir.x < 0.001f && dir.z < 0.001f) {
+        return lookAt(eye, center, Vectors::UNIT_X);
+    }
+    return lookAt(eye, center, Vectors::UNIT_Y);
+}
 
 glm::quat Quat::multiply(const glm::quat& q1, const glm::quat& q2) { 
     return q1 * q2; 

--- a/libraries/script-engine/src/Quat.h
+++ b/libraries/script-engine/src/Quat.h
@@ -25,6 +25,10 @@ class Quat : public QObject {
 
 public slots:
     glm::quat multiply(const glm::quat& q1, const glm::quat& q2);
+    glm::quat normalize(const glm::quat& q);
+    glm::quat lookAt(const glm::vec3& eye, const glm::vec3& center, const glm::vec3& up);
+    glm::quat lookAtSimple(const glm::vec3& eye, const glm::vec3& center);
+    glm::quat rotationBetween(const glm::vec3& v1, const glm::vec3& v2);
     glm::quat fromVec3Degrees(const glm::vec3& vec3); // degrees
     glm::quat fromVec3Radians(const glm::vec3& vec3); // radians
     glm::quat fromPitchYawRollDegrees(float pitch, float yaw, float roll); // degrees

--- a/libraries/script-engine/src/Vec3.cpp
+++ b/libraries/script-engine/src/Vec3.cpp
@@ -13,66 +13,26 @@
 
 #include <QDebug>
 
+#include <GLMHelpers.h>
+
 #include "ScriptEngineLogging.h"
 #include "NumericalConstants.h"
 #include "Vec3.h"
 
-glm::vec3 Vec3::reflect(const glm::vec3& v1, const glm::vec3& v2) {
-    return glm::reflect(v1, v2);
-}
-glm::vec3 Vec3::cross(const glm::vec3& v1, const glm::vec3& v2) {
-    return glm::cross(v1,v2);
-}
-
-float Vec3::dot(const glm::vec3& v1, const glm::vec3& v2) {
-    return glm::dot(v1,v2);
-}
-
-glm::vec3 Vec3::multiply(const glm::vec3& v1, float f) {
-    return v1 * f;
-}
-
-glm::vec3 Vec3::multiply(float f, const glm::vec3& v1) {
-    return v1 * f;
-}
-
-glm::vec3 Vec3::multiplyQbyV(const glm::quat& q, const glm::vec3& v) {
-    return q * v;
-}
-
-glm::vec3 Vec3::sum(const glm::vec3& v1, const glm::vec3& v2) { 
-    return v1 + v2;
-}
-glm::vec3 Vec3::subtract(const glm::vec3& v1, const glm::vec3& v2) {
-    return v1 - v2;
-}
-
-float Vec3::length(const glm::vec3& v) {
-    return glm::length(v);
-}
-
-float Vec3::distance(const glm::vec3& v1, const glm::vec3& v2) {
-    return glm::distance(v1, v2);
-}
 
 float Vec3::orientedAngle(const glm::vec3& v1, const glm::vec3& v2, const glm::vec3& v3) {
-    return glm::degrees(glm::orientedAngle(glm::normalize(v1), glm::normalize(v2), glm::normalize(v3)));
+    float radians = glm::orientedAngle(glm::normalize(v1), glm::normalize(v2), glm::normalize(v3));
+    return glm::degrees(radians);
 }
 
-glm::vec3 Vec3::normalize(const glm::vec3& v) {
-    return glm::normalize(v);
-}
-
-glm::vec3 Vec3::mix(const glm::vec3& v1, const glm::vec3& v2, float m) {
-    return glm::mix(v1, v2, m);
-}
 
 void Vec3::print(const QString& lable, const glm::vec3& v) {
     qCDebug(scriptengine) << qPrintable(lable) << v.x << "," << v.y << "," << v.z;
 }
 
-bool Vec3::equal(const glm::vec3& v1, const glm::vec3& v2) {
-    return v1 == v2;
+bool Vec3::withinEpsilon(const glm::vec3& v1, const glm::vec3& v2, float epsilon) {
+    float distanceSquared = glm::length2(v1 - v2);
+    return (epsilon*epsilon) >= distanceSquared;
 }
 
 glm::vec3 Vec3::toPolar(const glm::vec3& v) {

--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -11,40 +11,59 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#pragma once
 #ifndef hifi_Vec3_h
 #define hifi_Vec3_h
 
-#include <glm/glm.hpp>
-#include <glm/gtc/quaternion.hpp>
+#include <QtCore/QObject>
+#include <QtCore/QString>
 
-#include <QObject>
-#include <QString>
+#include "GLMHelpers.h"
 
 /// Scriptable interface a Vec3ernion helper class object. Used exclusively in the JavaScript API
 class Vec3 : public QObject {
     Q_OBJECT
 
 public slots:
-    glm::vec3 reflect(const glm::vec3& v1, const glm::vec3& v2);
-    glm::vec3 cross(const glm::vec3& v1, const glm::vec3& v2);
-    float dot(const glm::vec3& v1, const glm::vec3& v2);
-    glm::vec3 multiply(const glm::vec3& v1, float f);
-    glm::vec3 multiply(float, const glm::vec3& v1);
-    glm::vec3 multiplyQbyV(const glm::quat& q, const glm::vec3& v);
-    glm::vec3 sum(const glm::vec3& v1, const glm::vec3& v2);
-    glm::vec3 subtract(const glm::vec3& v1, const glm::vec3& v2);
-    float length(const glm::vec3& v);
-    float distance(const glm::vec3& v1, const glm::vec3& v2);
+    glm::vec3 reflect(const glm::vec3& v1, const glm::vec3& v2) { return glm::reflect(v1, v2); }
+    glm::vec3 cross(const glm::vec3& v1, const glm::vec3& v2) { return glm::cross(v1, v2); }
+    float dot(const glm::vec3& v1, const glm::vec3& v2) { return glm::dot(v1, v2); }
+    glm::vec3 multiply(const glm::vec3& v1, float f) { return v1 * f; }
+    glm::vec3 multiply(float f, const glm::vec3& v1) { return v1 * f; }
+    glm::vec3 multiplyQbyV(const glm::quat& q, const glm::vec3& v) { return q * v; }
+    glm::vec3 sum(const glm::vec3& v1, const glm::vec3& v2) { return v1 + v2; }
+    glm::vec3 subtract(const glm::vec3& v1, const glm::vec3& v2) { return v1 - v2; }
+    float length(const glm::vec3& v) { return glm::length(v); }
+    float distance(const glm::vec3& v1, const glm::vec3& v2) { return glm::distance(v1, v2); }
     float orientedAngle(const glm::vec3& v1, const glm::vec3& v2, const glm::vec3& v3);
-    glm::vec3 normalize(const glm::vec3& v);
-    glm::vec3 mix(const glm::vec3& v1, const glm::vec3& v2, float m);
-    void print(const QString& lable, const glm::vec3& v);
-    bool equal(const glm::vec3& v1, const glm::vec3& v2);
+    glm::vec3 normalize(const glm::vec3& v) { return glm::normalize(v); };
+    glm::vec3 mix(const glm::vec3& v1, const glm::vec3& v2, float m) { return glm::mix(v1, v2, m); }
+    void print(const QString& label, const glm::vec3& v);
+    bool equal(const glm::vec3& v1, const glm::vec3& v2) { return v1 == v2; }
+    bool withinEpsilon(const glm::vec3& v1, const glm::vec3& v2, float epsilon);
+    // FIXME misnamed, should be 'spherical' or 'euler' depending on the implementation
     glm::vec3 toPolar(const glm::vec3& v);
     glm::vec3 fromPolar(const glm::vec3& polar);
     glm::vec3 fromPolar(float elevation, float azimuth);
+    const glm::vec3& UNIT_X() { return Vectors::UNIT_X; }
+    const glm::vec3& UNIT_Y() { return Vectors::UNIT_Y; }
+    const glm::vec3& UNIT_Z() { return Vectors::UNIT_Z; }
+    const glm::vec3& UNIT_NEG_X() { return Vectors::UNIT_NEG_X; }
+    const glm::vec3& UNIT_NEG_Y() { return Vectors::UNIT_NEG_Y; }
+    const glm::vec3& UNIT_NEG_Z() { return Vectors::UNIT_NEG_Z; }
+    const glm::vec3& UNIT_XY() { return Vectors::UNIT_XY; }
+    const glm::vec3& UNIT_XZ() { return Vectors::UNIT_XZ; }
+    const glm::vec3& UNIT_YZ() { return Vectors::UNIT_YZ; }
+    const glm::vec3& UNIT_XYZ() { return Vectors::UNIT_XYZ; }
+    const glm::vec3& FLOAT_MAX() { return Vectors::MAX; }
+    const glm::vec3& FLOAT_MIN() { return Vectors::MIN; }
+    const glm::vec3& ZERO() { return Vectors::ZERO; }
+    const glm::vec3& ONE() { return Vectors::ONE; }
+    const glm::vec3& TWO() { return Vectors::TWO; }
+    const glm::vec3& HALF() { return Vectors::HALF; }
+    const glm::vec3& RIGHT() { return Vectors::RIGHT; }
+    const glm::vec3& UP() { return Vectors::UNIT_X; }
+    const glm::vec3& FRONT() { return Vectors::FRONT; }
 };
-
-
 
 #endif // hifi_Vec3_h

--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -27,6 +27,8 @@ const vec3 Vectors::MAX{ FLT_MAX };
 const vec3 Vectors::MIN{ -FLT_MAX };
 const vec3 Vectors::ZERO{ 0.0f };
 const vec3 Vectors::ONE{ 1.0f };
+const vec3 Vectors::TWO{ 2.0f };
+const vec3 Vectors::HALF{ 0.5f };
 const vec3& Vectors::RIGHT = Vectors::UNIT_X;
 const vec3& Vectors::UP = Vectors::UNIT_Y;
 const vec3& Vectors::FRONT = Vectors::UNIT_NEG_Z;

--- a/libraries/shared/src/GLMHelpers.h
+++ b/libraries/shared/src/GLMHelpers.h
@@ -64,12 +64,13 @@ public:
     static const vec3 UNIT_XY;
     static const vec3 UNIT_XZ;
     static const vec3 UNIT_YZ;
-    static const vec3 UNIT_ZX;
     static const vec3 UNIT_XYZ;
     static const vec3 MAX;
     static const vec3 MIN;
     static const vec3 ZERO;
     static const vec3 ONE;
+    static const vec3 TWO;
+    static const vec3 HALF;
     static const vec3& RIGHT;
     static const vec3& UP;
     static const vec3& FRONT;


### PR DESCRIPTION
Second attempt since my first broke scripts owing to the important distinction between glm::vec3 and vec3 when registering metatypes.