### PR TITLE
QT 5.5 - NodeConnectionData QDataStream #include

### DIFF
--- a/domain-server/src/NodeConnectionData.cpp
+++ b/domain-server/src/NodeConnectionData.cpp
@@ -11,6 +11,8 @@
 
 #include "NodeConnectionData.h"
 
+#include <QtCore/QDataStream>
+
 NodeConnectionData NodeConnectionData::fromDataStream(QDataStream& dataStream, const HifiSockAddr& senderSockAddr,
                                                       bool isConnectRequest) {
     NodeConnectionData newHeader;


### PR DESCRIPTION
Similar to #5535, QT 5.5+ requires a QDataStream reference when using its `>>` operator's overloads.

```
/home/nivardus/work/hifi/src/domain-server/src/NodeConnectionData.cpp: In static member function ‘static NodeConnectionData NodeConnectionData::fromDataStream(QDataStream&, const HifiSockAddr&, bool)’:
/home/nivardus/work/hifi/src/domain-server/src/NodeConnectionData.cpp:24:29: error: invalid conversion from ‘NodeType_t {aka unsigned char}’ to ‘QVariant::Type’ [-fpermissive]
     dataStream >> newHeader.nodeType
                             ^
In file included from /usr/include/qt/QtCore/qlocale.h:37:0,
                 from /usr/include/qt/QtCore/qtextstream.h:40,
                 from /usr/include/qt/QtCore/qdebug.h:42,
                 from /usr/include/qt/QtCore/QDebug:1,
                 from /home/nivardus/work/hifi/src/libraries/networking/src/Node.h:18,
                 from /home/nivardus/work/hifi/src/domain-server/src/NodeConnectionData.h:17,
                 from /home/nivardus/work/hifi/src/domain-server/src/NodeConnectionData.cpp:12:
/usr/include/qt/QtCore/qvariant.h:535:28: note:   initializing argument 2 of ‘QDataStream& operator>>(QDataStream&, QVariant::Type&)’
 Q_CORE_EXPORT QDataStream& operator>> (QDataStream& s, QVariant::Type& p);
                            ^
/home/nivardus/work/hifi/src/domain-server/src/NodeConnectionData.cpp:24:29: error: cannot bind rvalue ‘(QVariant::Type)newHeader.NodeConnectionData::nodeType’ to ‘QVariant::Type&’
     dataStream >> newHeader.nodeType
                             ^
domain-server/CMakeFiles/domain-server.dir/build.make:182: recipe for target 'domain-server/CMakeFiles/domain-server.dir/src/NodeConnectionData.cpp.o' failed
```