### PR TITLE
Use a constant log file 

### DIFF
--- a/interface/src/FileLogger.h
+++ b/interface/src/FileLogger.h
@@ -27,7 +27,7 @@ public:
     virtual void locateLog() override;
 
 private:
-    QString _fileName;
+    const QString _fileName;
     friend class FilePersistThread;
 };
 


### PR DESCRIPTION
This PR allows Interface to constantly log to the file hifi-log.txt without a date or hostname as part of the file name.  As the file grows it will rollover the accumulated content to a new file based on new instance startup, time (greater than 1 hour) or size (greater than 1 MB) using the old filename format.

This will allow easier debugging because you can tail the main log file continuously even through application restarts, which is probably why this kind of behavior us typically standard for logging.