### PR TITLE
Fix oculus crash on switching display plugin to something else

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -673,6 +673,7 @@ private:
     int _simsPerSecondReport = 0;
     quint64 _lastSimsPerSecondUpdate = 0;
     bool _isForeground = true; // starts out assumed to be in foreground
+    bool _inPaint = false;
 
     friend class PluginContainerProxy;
 };

--- a/interface/src/PluginContainerProxy.cpp
+++ b/interface/src/PluginContainerProxy.cpp
@@ -147,15 +147,3 @@ void PluginContainerProxy::showDisplayPluginsTools() {
 QGLWidget* PluginContainerProxy::getPrimarySurface() {
     return qApp->_glWidget;
 }
-
-void Application::setActiveDisplayPlugin(const QString& pluginName) {
-    auto menu = Menu::getInstance();
-    foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getDisplayPlugins()) {
-        QString name = displayPlugin->getName();
-        QAction* action = menu->getActionForOption(name);
-        if (pluginName == name) {
-            action->setChecked(true);
-        }
-    }
-    updateDisplayMode();
-}

--- a/libraries/display-plugins/src/display-plugins/DisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/DisplayPlugin.h
@@ -57,6 +57,11 @@ public:
 
     // Rendering support
 
+    // Stop requesting renders, but don't do full deactivation
+    // needed to work around the issues caused by Oculus 
+    // processing messages in the middle of submitFrame
+    virtual void stop() = 0;
+
     /**
      *  Called by the application before the frame rendering.  Can be used for
      *  render timing related calls (for instance, the Oculus begin frame timing
@@ -119,6 +124,7 @@ public:
     virtual void abandonCalibration() {}
     virtual void resetSensors() {}
     virtual float devicePixelRatio() { return 1.0;  }
+
 
     static const QString& MENU_PATH();
 signals:

--- a/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.cpp
@@ -30,3 +30,4 @@ void NullDisplayPlugin::finishFrame() {}
 
 void NullDisplayPlugin::activate() {}
 void NullDisplayPlugin::deactivate() {}
+void NullDisplayPlugin::stop() {}

--- a/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.h
@@ -17,6 +17,7 @@ public:
 
     void activate() override;
     void deactivate() override;
+    void stop() override;
 
     virtual glm::uvec2 getRecommendedRenderSize() const override;
     virtual bool hasFocus() const override;

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -16,7 +16,9 @@
 
 OpenGLDisplayPlugin::OpenGLDisplayPlugin() {
     connect(&_timer, &QTimer::timeout, this, [&] {
-        emit requestRender();
+        if (_active) {
+            emit requestRender();
+        }
     });
 }
 
@@ -56,10 +58,17 @@ void OpenGLDisplayPlugin::customizeContext() {
 }
 
 void OpenGLDisplayPlugin::activate() {
+    _active = true;
     _timer.start(1);
 }
 
+void OpenGLDisplayPlugin::stop() {
+    _active = false;
+    _timer.stop();
+}
+
 void OpenGLDisplayPlugin::deactivate() {
+    _active = false;
     _timer.stop();
 
     makeCurrent();

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -25,7 +25,7 @@ public:
 
     virtual void activate() override;
     virtual void deactivate() override;
-
+    virtual void stop() override;
     virtual bool eventFilter(QObject* receiver, QEvent* event) override;
 
     virtual void display(GLuint sceneTexture, const glm::uvec2& sceneSize) override;
@@ -44,6 +44,7 @@ protected:
     mutable QTimer _timer;
     ProgramPtr _program;
     ShapeWrapperPtr _plane;
+    bool _active{ false };
     bool _vsyncSupported{ false };
 };
 

--- a/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.cpp
@@ -350,11 +350,6 @@ void OculusDisplayPlugin::deactivate() {
 }
 
 void OculusDisplayPlugin::display(GLuint finalTexture, const glm::uvec2& sceneSize) {
-    static bool inDisplay = false;
-    if (inDisplay) {
-        return;
-    }
-    inDisplay = true;
 #if (OVR_MAJOR_VERSION >= 6)
     using namespace oglplus;
     // Need to make sure only the display plugin is responsible for 
@@ -420,7 +415,6 @@ void OculusDisplayPlugin::display(GLuint finalTexture, const glm::uvec2& sceneSi
 
     ++_frameIndex;
 #endif
-    inDisplay = false;
 }
 
 // Pass input events on to the application

--- a/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.cpp
@@ -325,19 +325,18 @@ void OculusDisplayPlugin::customizeContext() {
     //_texture = DependencyManager::get<TextureCache>()->
     //    getImageTexture(PathUtils::resourcesPath() + "/images/cube_texture.png");
     uvec2 mirrorSize = toGlm(_window->geometry().size());
-    _mirrorFbo = MirrorFboPtr(new MirrorFramebufferWrapper(_hmd));
-    _mirrorFbo->Init(mirrorSize);
 
     _sceneFbo = SwapFboPtr(new SwapFramebufferWrapper(_hmd));
     _sceneFbo->Init(getRecommendedRenderSize());
 #endif
+    enableVsync(false);
+    isVsyncEnabled();
 }
 
 void OculusDisplayPlugin::deactivate() {
 #if (OVR_MAJOR_VERSION >= 6)
     makeCurrent();
     _sceneFbo.reset();
-    _mirrorFbo.reset();
     doneCurrent();
     PerformanceTimer::setActive(false);
 
@@ -378,12 +377,14 @@ void OculusDisplayPlugin::display(GLuint finalTexture, const glm::uvec2& sceneSi
        the UI visible in the output window (unlikely).  This should be done before 
        _sceneFbo->Increment or we're be using the wrong texture
     */
-    _sceneFbo->Bound(Framebuffer::Target::Read, [&] {
-        glBlitFramebuffer(
-            0, 0, _sceneFbo->size.x, _sceneFbo->size.y,
-            0, 0, windowSize.x, windowSize.y,
-            GL_COLOR_BUFFER_BIT, GL_NEAREST);
-    });
+    if (_enableMirror) {
+        _sceneFbo->Bound(Framebuffer::Target::Read, [&] {
+            glBlitFramebuffer(
+                0, 0, _sceneFbo->size.x, _sceneFbo->size.y,
+                0, 0, windowSize.x, windowSize.y,
+                GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        });
+    }
 
     {
         PerformanceTimer("OculusSubmit");
@@ -404,6 +405,7 @@ void OculusDisplayPlugin::display(GLuint finalTexture, const glm::uvec2& sceneSi
         The other alternative for mirroring is to use the Oculus mirror texture support, which 
         will contain the post-distorted and fully composited scene regardless of how many layers 
         we send.
+        Currently generates an error.
     */
     //auto mirrorSize = _mirrorFbo->size;
     //_mirrorFbo->Bound(Framebuffer::Target::Read, [&] {
@@ -419,16 +421,6 @@ void OculusDisplayPlugin::display(GLuint finalTexture, const glm::uvec2& sceneSi
 
 // Pass input events on to the application
 bool OculusDisplayPlugin::eventFilter(QObject* receiver, QEvent* event) {
-#if (OVR_MAJOR_VERSION >= 6)
-    if (event->type() == QEvent::Resize) {
-        QResizeEvent* resizeEvent = static_cast<QResizeEvent*>(event);
-        qDebug() << resizeEvent->size().width() << " x " << resizeEvent->size().height();
-        auto newSize = toGlm(resizeEvent->size());
-        makeCurrent();
-        _mirrorFbo->Resize(newSize);
-        doneCurrent();
-    }
-#endif
     return WindowOpenGLDisplayPlugin::eventFilter(receiver, event);
 }
 
@@ -438,7 +430,9 @@ bool OculusDisplayPlugin::eventFilter(QObject* receiver, QEvent* event) {
     otherwise the swapbuffer delay will interefere with the framerate of the headset
 */
 void OculusDisplayPlugin::finishFrame() {
-    //swapBuffers();
+    if (_enableMirror) {
+        swapBuffers();
+    }
     doneCurrent();
 };
 

--- a/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.h
@@ -58,6 +58,7 @@ private:
     mat4 _compositeEyeProjections[2];
     uvec2 _desiredFramebufferSize;
     ovrTrackingState _trackingState;
+    bool _enableMirror{ false };
 
 #if (OVR_MAJOR_VERSION >= 6)
     ovrHmd _hmd;
@@ -70,7 +71,6 @@ private:
     ovrLayerEyeFov&  getSceneLayer();
     ovrHmdDesc       _hmdDesc;
     SwapFboPtr       _sceneFbo;
-    MirrorFboPtr     _mirrorFbo;
     ovrLayerEyeFov   _sceneLayer;
 #endif
 #if (OVR_MAJOR_VERSION == 7)

--- a/libraries/shared/src/Finally.h
+++ b/libraries/shared/src/Finally.h
@@ -1,0 +1,27 @@
+//
+//  Created by Bradley Austin Davis on 2015/09/01
+//  Copyright 2013-2105 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+// Simulates a java finally block by executing a lambda when an instance leaves
+// scope
+
+#include <functional>
+
+#pragma once
+#ifndef hifi_Finally_h
+#define hifi_Finally_h
+
+class Finally {
+public:
+    template <typename F>
+    Finally(F f) : _f(f) {}
+    ~Finally() { _f(); }
+private:
+    std::function<void()> _f;
+};
+
+#endif


### PR DESCRIPTION
The oculus ovr_SubmitFrame call apparently can process window messages inside it.  This has the potential to allow the display plugin to be changed *while* inside the `OculusDisplayPlugin::display` method, which deactivates `OculusDisplayPlugin` leading to crashes and buggy behavior.  

This code prevents the `Application::paintGL` method from being entered more than once in the call stack and ensures that if we are already in `paintGL` that we defer the change in the display plugin, while at the same time instructing the active plugin to stop requesting renders (a kind of partial deactivation that won't cause crashes).

