### PR TITLE
fix for Controller.getSpatialControlNormal()

### DIFF
--- a/libraries/avatars/src/HandData.cpp
+++ b/libraries/avatars/src/HandData.cpp
@@ -114,12 +114,14 @@ float HandData::getBaseScale() const {
 }
         
 glm::vec3 PalmData::getFingerDirection() const {
-    const glm::vec3 LOCAL_FINGER_DIRECTION(0.0f, 0.0f, 1.0f);
+    // finger points along yAxis in hand-frame
+    const glm::vec3 LOCAL_FINGER_DIRECTION(0.0f, 1.0f, 0.0f);
     return glm::normalize(_owningHandData->localToWorldDirection(_rawRotation * LOCAL_FINGER_DIRECTION));
 }
 
 glm::vec3 PalmData::getNormal() const {
-    const glm::vec3 LOCAL_PALM_DIRECTION(0.0f, -1.0f, 0.0f);
+    // palm normal points along zAxis in hand-frame
+    const glm::vec3 LOCAL_PALM_DIRECTION(0.0f, 0.0f, 1.0f);
     return glm::normalize(_owningHandData->localToWorldDirection(_rawRotation * LOCAL_PALM_DIRECTION));
 }
 


### PR DESCRIPTION
fix finger and palm normals from Controller.getSpatialControlNormal()