### PR TITLE
added userData manipulations to grab script

### DIFF
--- a/examples/controllers/hydra/hydraGrab.js
+++ b/examples/controllers/hydra/hydraGrab.js
@@ -11,8 +11,12 @@
 //
 
 
+Script.include("https://hifi-public.s3.amazonaws.com/scripts/libraries/utils.js");
+
 var RIGHT_HAND_CLICK = Controller.findAction("RIGHT_HAND_CLICK");
 var rightTriggerAction = RIGHT_HAND_CLICK;
+
+var GRAB_USER_DATA_KEY = "grabKey";
 
 var LEFT_HAND_CLICK = Controller.findAction("LEFT_HAND_CLICK");
 var leftTriggerAction = LEFT_HAND_CLICK;
@@ -37,7 +41,7 @@ var INTERSECT_COLOR = {
     blue: 10
 };
 
-var GRAB_RADIUS = 2;
+var GRAB_RADIUS = 0.5;
 
 var GRAB_COLOR = {
     red: 250,
@@ -154,7 +158,6 @@ controller.prototype.attemptMove = function() {
 
         var newPosition = Vec3.sum(handPosition, Vec3.multiply(direction, this.distanceToEntity))
         this.distanceHolding = true;
-        //TO DO : USE SPRING ACTION UPDATE FOR MOVING
         if (this.actionID === null) {
             this.actionID = Entities.addAction("spring", this.grabbedEntity, {
                 targetPosition: newPosition,
@@ -184,7 +187,10 @@ controller.prototype.hidePointer = function() {
 
 
 controller.prototype.letGo = function() {
-    Entities.deleteAction(this.grabbedEntity, this.actionID);
+    if (this.grabbedEntity && this.actionID) {
+        this.deactivateEntity(this.grabbedEntity);
+        Entities.deleteAction(this.grabbedEntity, this.actionID);
+    }
     this.grabbedEntity = null;
     this.actionID = null;
     this.distanceHolding = false;
@@ -264,11 +270,29 @@ controller.prototype.checkForInRangeObject = function() {
     if (grabbedEntity === null) {
         return false;
     } else {
+        //We are grabbing an entity, so let it know we've grabbed it
         this.grabbedEntity = grabbedEntity;
+        this.activateEntity(this.grabbedEntity);
+
         return true;
     }
 }
 
+controller.prototype.activateEntity = function(entity) {
+    var data = {
+        activated: true,
+        avatarId: MyAvatar.sessionUUID
+    };
+    setEntityCustomData(GRAB_USER_DATA_KEY, this.grabbedEntity, data);
+}
+
+controller.prototype.deactivateEntity = function(entity) {
+    var data = {
+        activated: false,
+        avatarId: null
+    };
+    setEntityCustomData(GRAB_USER_DATA_KEY, this.grabbedEntity, data);
+}
 
 controller.prototype.onActionEvent = function(action, state) {
     if (this.pullAction === action && state === 1) {
@@ -293,7 +317,9 @@ controller.prototype.onActionEvent = function(action, state) {
 
 controller.prototype.cleanup = function() {
     Entities.deleteEntity(this.pointer);
-    Entities.deleteAction(this.grabbedEntity, this.actionID);
+    if (this.grabbedEntity) {
+        Entities.deleteAction(this.grabbedEntity, this.actionID);
+    }
 }
 
 function update() {
@@ -312,6 +338,7 @@ function cleanup() {
     rightController.cleanup();
     leftController.cleanup();
 }
+
 
 
 Script.scriptEnding.connect(cleanup);

--- a/examples/controllers/hydra/hydraGrab.js
+++ b/examples/controllers/hydra/hydraGrab.js
@@ -11,7 +11,7 @@
 //
 
 
-Script.include("https://hifi-public.s3.amazonaws.com/scripts/libraries/utils.js");
+Script.include("../../libraries/utils.js");
 
 var RIGHT_HAND_CLICK = Controller.findAction("RIGHT_HAND_CLICK");
 var rightTriggerAction = RIGHT_HAND_CLICK;


### PR DESCRIPTION
This PR adds logic to the hydraGrab script which sets a field called "activate" on the grabbed entities userData. This is useful because an entity with an attached entity script can now query for this field, and if it's set, can run whatever logic it wants. For example, a gun that is "grabbed" can now be fired, but if it is let go of, this is no longer the case.

This also sets the sessionUUID in the user data field, so an entity script can run a check and only execute code on the client that is actually holding the object.