### PR TITLE
Toggle mute while holding the hydras

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -612,6 +612,15 @@ Application::Application(int& argc, char** argv, QElapsedTimer &startup_time) :
     // Setup the userInputMapper with the actions
     auto userInputMapper = DependencyManager::get<UserInputMapper>();
     connect(userInputMapper.data(), &UserInputMapper::actionEvent, &_controllerScriptingInterface, &AbstractControllerScriptingInterface::actionEvent);
+    connect(userInputMapper.data(), &UserInputMapper::actionEvent, [this](int action, float state) {
+        if (state) {
+            switch (action) {
+            case UserInputMapper::Action::TOGGLE_MUTE:
+                DependencyManager::get<AudioClient>()->toggleMute();
+                break;
+            }
+        }
+    });
 
     // Setup the keyboardMouseDevice and the user input mapper with the default bindings
     _keyboardMouseDevice->registerToUserInputMapper(*userInputMapper);

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
@@ -595,6 +595,10 @@ void SixenseManager::assignDefaultInputMapping(UserInputMapper& mapper) {
     mapper.addInputChannel(UserInputMapper::LEFT_HAND_CLICK, makeInput(BACK_TRIGGER, 0));
     mapper.addInputChannel(UserInputMapper::RIGHT_HAND_CLICK, makeInput(BACK_TRIGGER, 1));
 
+    // TODO find a mechanism to allow users to navigate the context menu via
+    mapper.addInputChannel(UserInputMapper::CONTEXT_MENU, makeInput(BUTTON_0, 0));
+    mapper.addInputChannel(UserInputMapper::TOGGLE_MUTE, makeInput(BUTTON_0, 1));
+
 }
 
 UserInputMapper::Input SixenseManager::makeInput(unsigned int button, int index) {

--- a/libraries/input-plugins/src/input-plugins/UserInputMapper.h
+++ b/libraries/input-plugins/src/input-plugins/UserInputMapper.h
@@ -162,6 +162,9 @@ public:
         ACTION1,
         ACTION2,
 
+        CONTEXT_MENU,
+        TOGGLE_MUTE,
+
         NUM_ACTIONS,
     };
     


### PR DESCRIPTION
Right now to toggle mute while in the HMD and using hydra navigation I have to either tilt my head to peer down my nose at my keyboard, or I have to remove my headset.  Since I'm using the hydras it looks very odd to anyone else.  I explicitly got called out about fiddling my headset in the alpha meeting.

As a quick path this PR adds a new toggle mute action to the user input mapper and binds it to the 0 button on the right controller, allow people in HMD/hand controllers to easily switch their mic on and off.    

Longer term I think we need to evaluate whether the SixenseManager is the right place to bind between controls and semantic meanings (I don't think it is...  the input plugins should expose abstracted spatial / joystick / keyboard mouse controllers as events and then the application / scripts should be free to modify the bindings to semantic meanings.  For instance, I also wanted to add an easy way to bring up the menu from the hydras, but there's no easy way for me to navigate the menu from there.  Rather some higher level like the application would need to be getting events like up / down / left / right from the controller and mapping it on to either avatar movement or to menu selection, depending on whether the menu was currently active.  However, such a change is outside the scope of this PR.
