### PR TITLE
Fix for RenderableParticleffectEntityItem assert.

### DIFF
--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -219,6 +219,14 @@ void RenderableParticleEffectEntityItem::updateRenderItem() {
         // update vertex buffer
         auto vertexBuffer = payload.getVertexBuffer();
         size_t numBytes = sizeof(Vertex) * _vertices.size();
+
+        if (numBytes == 0) {
+            vertexBuffer->resize(0);
+            auto indexBuffer = payload.getIndexBuffer();
+            indexBuffer->resize(0);
+            return;
+        }
+
         vertexBuffer->resize(numBytes);
         gpu::Byte* data = vertexBuffer->editData();
         memcpy(data, &(_vertices[0]), numBytes);
@@ -284,7 +292,7 @@ void RenderableParticleEffectEntityItem::updateRenderItem() {
             payload.setPipeline(_untexturedPipeline);
         }
     });
-    
+
     _scene->enqueuePendingChanges(pendingChanges);
 }
 


### PR DESCRIPTION
When a particle system had no living particles, PendingChanges::updateItem
would assert, due to the access to _vertices[0].  In release this might be
harmless as this memory is never accessed, but different implementations of
std::vector might do different things here.  So, let's be safe and early
return when the number of particles is 0.