### PR TITLE
fix for bad bounding capsules for avatars

### DIFF
--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -558,6 +558,10 @@ void SkeletonModel::computeBoundingShape() {
             totalExtents.addPoint(transformedPoint + radius);
             totalExtents.addPoint(transformedPoint - radius);
         }
+        // HACK so that default legless robot doesn't knuckle-drag
+        if (shapeInfo.points.size() == 0 && (state.getName() == "LeftFoot" || state.getName() == "RightFoot")) {
+            totalExtents.addPoint(extractTranslation(jointTransform));
+        }
     }
 
     // compute bounding shape parameters

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -544,14 +544,20 @@ void SkeletonModel::computeBoundingShape() {
     totalExtents.addPoint(glm::vec3(0.0f));
     int numStates = _rig->getJointStateCount();
     for (int i = 0; i < numStates; i++) {
-        // compute the default transform of this joint
         const JointState& state = _rig->getJointState(i);
 
-        // Each joint contributes a sphere at its position
-        glm::vec3 axis(state.getBoneRadius());
-        glm::vec3 jointPosition = state.getPosition();
-        totalExtents.addPoint(jointPosition + axis);
-        totalExtents.addPoint(jointPosition - axis);
+        const glm::mat4& jointTransform = state.getTransform();
+        float scale = extractUniformScale(jointTransform);
+
+        // Each joint contributes a capsule defined by FBXJoint.shapeInfo.
+        // For totalExtents we use the capsule endpoints expanded by the radius.
+        const FBXJointShapeInfo& shapeInfo = geometry.joints.at(i).shapeInfo;
+        for (int j = 0; j < shapeInfo.points.size(); ++j) {
+            glm::vec3 transformedPoint = extractTranslation(jointTransform * glm::translate(shapeInfo.points[j]));
+            vec3 radius(scale * shapeInfo.radius);
+            totalExtents.addPoint(transformedPoint + radius);
+            totalExtents.addPoint(transformedPoint - radius);
+        }
     }
 
     // compute bounding shape parameters

--- a/libraries/animation/src/JointState.cpp
+++ b/libraries/animation/src/JointState.cpp
@@ -41,7 +41,7 @@ void JointState::copyState(const JointState& other) {
     // DO NOT copy _constraint
     _name = other._name;
     _isFree = other._isFree;
-    _boneRadius = other._boneRadius;
+//    _boneRadius = other._boneRadius;
     _parentIndex = other._parentIndex;
     _defaultRotation = other._defaultRotation;
     _inverseDefaultRotation = other._inverseDefaultRotation;
@@ -58,7 +58,7 @@ JointState::JointState(const FBXJoint& joint) {
     _rotationInConstrainedFrame = joint.rotation;
     _name = joint.name;
     _isFree = joint.isFree;
-    _boneRadius = joint.boneRadius;
+//    _boneRadius = joint.boneRadius;
     _parentIndex = joint.parentIndex;
     _translation = joint.translation;
     _defaultRotation = joint.rotation;

--- a/libraries/animation/src/JointState.cpp
+++ b/libraries/animation/src/JointState.cpp
@@ -41,7 +41,6 @@ void JointState::copyState(const JointState& other) {
     // DO NOT copy _constraint
     _name = other._name;
     _isFree = other._isFree;
-//    _boneRadius = other._boneRadius;
     _parentIndex = other._parentIndex;
     _defaultRotation = other._defaultRotation;
     _inverseDefaultRotation = other._inverseDefaultRotation;
@@ -58,7 +57,6 @@ JointState::JointState(const FBXJoint& joint) {
     _rotationInConstrainedFrame = joint.rotation;
     _name = joint.name;
     _isFree = joint.isFree;
-//    _boneRadius = joint.boneRadius;
     _parentIndex = joint.parentIndex;
     _translation = joint.translation;
     _defaultRotation = joint.rotation;

--- a/libraries/animation/src/JointState.h
+++ b/libraries/animation/src/JointState.h
@@ -118,7 +118,6 @@ public:
     const glm::quat& getDefaultRotation() const { return _defaultRotation; }
     const glm::quat& getInverseDefaultRotation() const { return _inverseDefaultRotation; }
     const QString& getName() const { return _name; }
-//    float getBoneRadius() const { return _boneRadius; }
     bool getIsFree() const { return _isFree; }
     float getAnimationPriority() const { return _animationPriority; }
     void setAnimationPriority(float priority) { _animationPriority = priority; }
@@ -149,7 +148,6 @@ private:
     QString _name;
     int _parentIndex;
     bool _isFree;
-//    float _boneRadius;
     glm::vec3 _rotationMin;
     glm::vec3 _rotationMax;
     glm::quat _preRotation;

--- a/libraries/animation/src/JointState.h
+++ b/libraries/animation/src/JointState.h
@@ -118,7 +118,7 @@ public:
     const glm::quat& getDefaultRotation() const { return _defaultRotation; }
     const glm::quat& getInverseDefaultRotation() const { return _inverseDefaultRotation; }
     const QString& getName() const { return _name; }
-    float getBoneRadius() const { return _boneRadius; }
+//    float getBoneRadius() const { return _boneRadius; }
     bool getIsFree() const { return _isFree; }
     float getAnimationPriority() const { return _animationPriority; }
     void setAnimationPriority(float priority) { _animationPriority = priority; }
@@ -149,7 +149,7 @@ private:
     QString _name;
     int _parentIndex;
     bool _isFree;
-    float _boneRadius;
+//    float _boneRadius;
     glm::vec3 _rotationMin;
     glm::vec3 _rotationMax;
     glm::quat _preRotation;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -477,7 +477,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
         }
 
         if (glm::length(localVel) > moveThresh) {
-            if (fabs(forwardSpeed) > 0.5f * fabs(lateralSpeed)) {
+            if (fabsf(forwardSpeed) > 0.5f * fabsf(lateralSpeed)) {
                 if (forwardSpeed > 0.0f) {
                     // forward
                     _animVars.set("isMovingForward", true);
@@ -501,7 +501,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             }
             _state = RigRole::Move;
         } else {
-            if (fabs(turningSpeed) > turnThresh) {
+            if (fabsf(turningSpeed) > turnThresh) {
                 if (turningSpeed > 0.0f) {
                     // turning right
                     _animVars.set("isTurningRight", true);
@@ -905,13 +905,6 @@ void Rig::updateVisibleJointStates() {
     for (int i = 0; i < _jointStates.size(); i++) {
         _jointStates[i].slaveVisibleTransform();
     }
-}
-
-void Rig::setJointTransform(int jointIndex, glm::mat4 newTransform) {
-    if (jointIndex == -1 || jointIndex >= _jointStates.size()) {
-        return;
-    }
-    _jointStates[jointIndex].setTransform(newTransform);
 }
 
 void Rig::setJointVisibleTransform(int jointIndex, glm::mat4 newTransform) {

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -133,7 +133,6 @@ public:
                                              glm::vec3 translation, glm::quat rotation) const;
     bool getVisibleJointRotationInWorldFrame(int jointIndex, glm::quat& result, glm::quat rotation) const;
     glm::mat4 getJointTransform(int jointIndex) const;
-    void setJointTransform(int jointIndex, glm::mat4 newTransform);
     glm::mat4 getJointVisibleTransform(int jointIndex) const;
     void setJointVisibleTransform(int jointIndex, glm::mat4 newTransform);
     // Start or stop animations as needed.

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -55,15 +55,21 @@ public:
     QVector<glm::vec3> normals;
 };
 
+struct FBXJointShapeInfo {
+    // same units and frame as FBXJoint.translation
+    QVector<glm::vec3> points;
+    float radius;
+};
+
 /// A single joint (transformation node) extracted from an FBX document.
 class FBXJoint {
 public:
 
-    bool isFree;
+    FBXJointShapeInfo shapeInfo;
     QVector<int> freeLineage;
+    bool isFree;
     int parentIndex;
     float distanceToParent;
-    float boneRadius;
 
     // http://download.autodesk.com/us/fbx/20112/FBX_SDK_HELP/SDKRef/a00209.html
 

--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -444,7 +444,6 @@ FBXGeometry* OBJReader::readOBJ(QIODevice* device, const QVariantHash& mapping, 
         geometry.joints[0].isFree = false;
         geometry.joints[0].parentIndex = -1;
         geometry.joints[0].distanceToParent = 0;
-        geometry.joints[0].boneRadius = 0;
         geometry.joints[0].translation = glm::vec3(0, 0, 0);
         geometry.joints[0].rotationMin = glm::vec3(0, 0, 0);
         geometry.joints[0].rotationMax = glm::vec3(0, 0, 0);
@@ -620,7 +619,6 @@ void fbxDebugDump(const FBXGeometry& fbxgeo) {
         qCDebug(modelformat) << "    freeLineage" << joint.freeLineage;
         qCDebug(modelformat) << "    parentIndex" << joint.parentIndex;
         qCDebug(modelformat) << "    distanceToParent" << joint.distanceToParent;
-        qCDebug(modelformat) << "    boneRadius" << joint.boneRadius;
         qCDebug(modelformat) << "    translation" << joint.translation;
         qCDebug(modelformat) << "    preTransform" << joint.preTransform;
         qCDebug(modelformat) << "    preRotation" << joint.preRotation;


### PR DESCRIPTION
We were using the skeleton joint endpoints to compute the bounding shape for avatars, however it turns out that the joint endpoints may (often will) have **nothing** to do with the shape of the joint and everything to do with offsets of the mesh data.  Therefore we **must** measure the dimensions of the mesh data when computing the bounding shape.