### PR TITLE
Run cleanup when createWand.js ends; Don't delete bubbles on collision (for now)

### DIFF
--- a/examples/toys/bubblewand/bubble.js
+++ b/examples/toys/bubblewand/bubble.js
@@ -26,7 +26,7 @@
 
     this.collisionWithEntity = function(myID, otherID, collision) {
         //if(Entites.getEntityProperties(otherID).userData.objectType==='') { merge bubbles?}
-        Entities.deleteEntity(myID);
+      // Entities.deleteEntity(myID);
       //  this.burstBubbleSound(collision.contactPoint)
 
     };

--- a/examples/toys/bubblewand/createWand.js
+++ b/examples/toys/bubblewand/createWand.js
@@ -35,7 +35,7 @@ var wand = Entities.addEntity({
 });
 
 function cleanup() {
-	//Entities.deleteEntity(wand);
+	Entities.deleteEntity(wand);
 }
 
 


### PR DESCRIPTION
overlays were getting stranded.  a future PR will have the debug overlays disabled by default.