### PR TITLE
Terminate DDE earlier during shut-down and always at start-up

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -786,6 +786,14 @@ void Application::aboutToQuit() {
 }
 
 void Application::cleanupBeforeQuit() {
+    // Terminate third party processes so that they're not left running in the event of a subsequent shutdown crash
+#ifdef HAVE_DDE
+    DependencyManager::destroy<DdeFaceTracker>();
+#endif
+#ifdef HAVE_IVIEWHMD
+    DependencyManager::destroy<EyeTracker>();
+#endif
+
     if (_keyboardFocusHighlightID > 0) {
         getOverlays().deleteOverlay(_keyboardFocusHighlightID);
         _keyboardFocusHighlightID = -1;
@@ -833,13 +841,6 @@ void Application::cleanupBeforeQuit() {
 
     // destroy the AudioClient so it and its thread have a chance to go down safely
     DependencyManager::destroy<AudioClient>();
-
-#ifdef HAVE_DDE
-    DependencyManager::destroy<DdeFaceTracker>();
-#endif
-#ifdef HAVE_IVIEWHMD
-    DependencyManager::destroy<EyeTracker>();
-#endif
 }
 
 void Application::emptyLocalCache() {

--- a/interface/src/devices/DdeFaceTracker.cpp
+++ b/interface/src/devices/DdeFaceTracker.cpp
@@ -254,9 +254,8 @@ void DdeFaceTracker::setEnabled(bool enabled) {
         _ddeProcess = new QProcess(qApp);
         connect(_ddeProcess, SIGNAL(finished(int, QProcess::ExitStatus)), SLOT(processFinished(int, QProcess::ExitStatus)));
         _ddeProcess->start(QCoreApplication::applicationDirPath() + DDE_PROGRAM_PATH, DDE_ARGUMENTS);
-    }
-
-    if (!enabled && _ddeProcess) {
+    } else {
+        // Send a command to stop face tracker evening if no _ddeProcess in case DDE has been left running after a crash
         _ddeStopping = true;
         _udpSocket.writeDatagram(DDE_EXIT_COMMAND, DDE_SERVER_ADDR, _controlPort);
         qCDebug(interfaceapp) << "DDE Face Tracker: Stopping";

--- a/interface/src/devices/DdeFaceTracker.cpp
+++ b/interface/src/devices/DdeFaceTracker.cpp
@@ -236,28 +236,25 @@ void DdeFaceTracker::setEnabled(bool enabled) {
         cancelCalibration();
     }
 
-
     // isOpen() does not work as one might expect on QUdpSocket; don't test isOpen() before closing socket.
     _udpSocket.close();
-    if (enabled) {
-        _udpSocket.bind(_host, _serverPort);
-    }
 
+    // Terminate any existing DDE process, perhaps left running after an Interface crash.
+    // Do this even if !enabled in case user reset their settings after crash.
     const char* DDE_EXIT_COMMAND = "exit";
+    _udpSocket.bind(_host, _serverPort);
+    _udpSocket.writeDatagram(DDE_EXIT_COMMAND, DDE_SERVER_ADDR, _controlPort);
 
     if (enabled && !_ddeProcess) {
-        // Terminate any existing DDE process, perhaps left running after an Interface crash
-        _udpSocket.writeDatagram(DDE_EXIT_COMMAND, DDE_SERVER_ADDR, _controlPort);
         _ddeStopping = false;
-
         qCDebug(interfaceapp) << "DDE Face Tracker: Starting";
         _ddeProcess = new QProcess(qApp);
         connect(_ddeProcess, SIGNAL(finished(int, QProcess::ExitStatus)), SLOT(processFinished(int, QProcess::ExitStatus)));
         _ddeProcess->start(QCoreApplication::applicationDirPath() + DDE_PROGRAM_PATH, DDE_ARGUMENTS);
-    } else {
-        // Send a command to stop face tracker evening if no _ddeProcess in case DDE has been left running after a crash
+    }
+    
+    if (!enabled && _ddeProcess) {
         _ddeStopping = true;
-        _udpSocket.writeDatagram(DDE_EXIT_COMMAND, DDE_SERVER_ADDR, _controlPort);
         qCDebug(interfaceapp) << "DDE Face Tracker: Stopping";
     }
 #endif


### PR DESCRIPTION
To reduce the instances of the Installer failing because DDE is left running from a crash
 - Terminate DDE earlier on in the Interface shutdown process (i.e., before any shutdown crashes if possible).
 - Terminate DDE at Interface start-up even if DDE isn't enabled (e.g., user may have selected one of the post -crash options at start-up to wipe settings).