### PR TITLE
Eliminate excessive debug logging from procedural setup

### DIFF
--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -162,7 +162,7 @@ void Procedural::prepare(gpu::Batch& batch, const glm::vec3& size) {
         if (replaceIndex != std::string::npos) {
             fragmentShaderSource.replace(replaceIndex, PROCEDURAL_BLOCK.size(), _shaderSource.toLocal8Bit().data());
         }
-        qDebug() << "FragmentShader:\n" << fragmentShaderSource.c_str();
+        //qDebug() << "FragmentShader:\n" << fragmentShaderSource.c_str();
         _fragmentShader = gpu::ShaderPointer(gpu::Shader::createPixel(fragmentShaderSource));
         _shader = gpu::ShaderPointer(gpu::Shader::createProgram(_vertexShader, _fragmentShader));
         gpu::Shader::makeProgram(*_shader);


### PR DESCRIPTION
The procedural stuff currently prints out the full fragment shader after construction.  This was handy during initial debugging but spams the log too much right now.  