### PR TITLE
Revert "Make sure all entity script callbacks happen on the Entities …

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -242,7 +242,6 @@ QScriptValue EntityTreeRenderer::loadEntityScript(EntityItemPointer entity, bool
     QString scriptContents = loadScriptContents(entityScript, isURL, isPending, url, reload);
     
     if (isPending && isPreload && isURL) {
-        //qDebug() << "attempted to load script, isPending, _waitingOnPreload.insert() url:" << url << "entityID:" << entityID;
         _waitingOnPreload.insert(url, entityID);
     }
 
@@ -325,8 +324,7 @@ void EntityTreeRenderer::update() {
             QScriptValueList currentClickingEntityArgs = createMouseEventArgs(_currentClickingOnEntityID, _lastMouseEvent);
             QScriptValue currentClickingEntity = loadEntityScript(_currentClickingOnEntityID);
             if (currentClickingEntity.property("holdingClickOnEntity").isValid()) {
-                //qDebug() << "About to call holdingClickOnEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-                _entitiesScriptEngine->callScriptMethod("holdingClickOnEntity", currentClickingEntity, currentClickingEntityArgs);
+                currentClickingEntity.property("holdingClickOnEntity").call(currentClickingEntity, currentClickingEntityArgs);
             }
         }
 
@@ -365,9 +363,7 @@ void EntityTreeRenderer::checkEnterLeaveEntities() {
                     QScriptValueList entityArgs = createEntityArgs(entityID);
                     QScriptValue entityScript = loadEntityScript(entityID);
                     if (entityScript.property("leaveEntity").isValid()) {
-
-                        //qDebug() << "About to call leaveEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-                        _entitiesScriptEngine->callScriptMethod("leaveEntity", entityScript, entityArgs);
+                        entityScript.property("leaveEntity").call(entityScript, entityArgs);
                     }
 
                 }
@@ -380,8 +376,7 @@ void EntityTreeRenderer::checkEnterLeaveEntities() {
                     QScriptValueList entityArgs = createEntityArgs(entityID);
                     QScriptValue entityScript = loadEntityScript(entityID);
                     if (entityScript.property("enterEntity").isValid()) {
-                        //qDebug() << "About to call enterEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-                        _entitiesScriptEngine->callScriptMethod("enterEntity", entityScript, entityArgs);
+                        entityScript.property("enterEntity").call(entityScript, entityArgs);
                     }
                 }
             }
@@ -400,8 +395,7 @@ void EntityTreeRenderer::leaveAllEntities() {
             QScriptValueList entityArgs = createEntityArgs(entityID);
             QScriptValue entityScript = loadEntityScript(entityID);
             if (entityScript.property("leaveEntity").isValid()) {
-                //qDebug() << "About to call leaveEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-                _entitiesScriptEngine->callScriptMethod("leaveEntity", entityScript, entityArgs);
+                entityScript.property("leaveEntity").call(entityScript, entityArgs);
             }
         }
         _currentEntitiesInside.clear();
@@ -857,7 +851,7 @@ void EntityTreeRenderer::mousePressEvent(QMouseEvent* event, unsigned int device
     bool precisionPicking = !_dontDoPrecisionPicking;
     RayToEntityIntersectionResult rayPickResult = findRayIntersectionWorker(ray, Octree::Lock, precisionPicking);
     if (rayPickResult.intersects) {
-        qCDebug(entitiesrenderer) << "mousePressEvent over entity:" << rayPickResult.entityID;
+        //qCDebug(entitiesrenderer) << "mousePressEvent over entity:" << rayPickResult.entityID;
 
         QString urlString = rayPickResult.properties.getHref();
         QUrl url = QUrl(urlString, QUrl::StrictMode);
@@ -871,15 +865,13 @@ void EntityTreeRenderer::mousePressEvent(QMouseEvent* event, unsigned int device
         QScriptValueList entityScriptArgs = createMouseEventArgs(rayPickResult.entityID, event, deviceID);
         QScriptValue entityScript = loadEntityScript(rayPickResult.entity);
         if (entityScript.property("mousePressOnEntity").isValid()) {
-            //qDebug() << "About to call mousePressOnEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("mousePressOnEntity", entityScript, entityScriptArgs);
+            entityScript.property("mousePressOnEntity").call(entityScript, entityScriptArgs);
         }
     
         _currentClickingOnEntityID = rayPickResult.entityID;
         emit clickDownOnEntity(_currentClickingOnEntityID, MouseEvent(*event, deviceID));
         if (entityScript.property("clickDownOnEntity").isValid()) {
-            //qDebug() << "About to call clickDownOnEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("clickDownOnEntity", entityScript, entityScriptArgs);
+            entityScript.property("clickDownOnEntity").call(entityScript, entityScriptArgs);
         }
     } else {
         emit mousePressOffEntity(rayPickResult, event, deviceID);
@@ -905,7 +897,7 @@ void EntityTreeRenderer::mouseReleaseEvent(QMouseEvent* event, unsigned int devi
         QScriptValueList entityScriptArgs = createMouseEventArgs(rayPickResult.entityID, event, deviceID);
         QScriptValue entityScript = loadEntityScript(rayPickResult.entity);
         if (entityScript.property("mouseReleaseOnEntity").isValid()) {
-            _entitiesScriptEngine->callScriptMethod("mouseReleaseOnEntity", entityScript, entityScriptArgs);
+            entityScript.property("mouseReleaseOnEntity").call(entityScript, entityScriptArgs);
         }
     }
 
@@ -917,8 +909,7 @@ void EntityTreeRenderer::mouseReleaseEvent(QMouseEvent* event, unsigned int devi
         QScriptValueList currentClickingEntityArgs = createMouseEventArgs(_currentClickingOnEntityID, event, deviceID);
         QScriptValue currentClickingEntity = loadEntityScript(_currentClickingOnEntityID);
         if (currentClickingEntity.property("clickReleaseOnEntity").isValid()) {
-            //qDebug() << "About to call clickReleaseOnEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("clickReleaseOnEntity", currentClickingEntity, currentClickingEntityArgs);
+            currentClickingEntity.property("clickReleaseOnEntity").call(currentClickingEntity, currentClickingEntityArgs);
         }
     }
 
@@ -946,13 +937,11 @@ void EntityTreeRenderer::mouseMoveEvent(QMouseEvent* event, unsigned int deviceI
         // load the entity script if needed...
         QScriptValue entityScript = loadEntityScript(rayPickResult.entity);
         if (entityScript.property("mouseMoveEvent").isValid()) {
-            //qDebug() << "About to call mouseMoveEvent() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("mouseMoveEvent", entityScript, entityScriptArgs);
+            entityScript.property("mouseMoveEvent").call(entityScript, entityScriptArgs);
         }
         emit mouseMoveOnEntity(rayPickResult, event, deviceID);
         if (entityScript.property("mouseMoveOnEntity").isValid()) {
-            //qDebug() << "About to call mouseMoveOnEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("mouseMoveOnEntity", entityScript, entityScriptArgs);
+            entityScript.property("mouseMoveOnEntity").call(entityScript, entityScriptArgs);
         }
     
         // handle the hover logic...
@@ -966,9 +955,7 @@ void EntityTreeRenderer::mouseMoveEvent(QMouseEvent* event, unsigned int deviceI
 
             QScriptValue currentHoverEntity = loadEntityScript(_currentHoverOverEntityID);
             if (currentHoverEntity.property("hoverLeaveEntity").isValid()) {
-                //qDebug() << "About to call hoverLeaveEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-                _entitiesScriptEngine->callScriptMethod("hoverLeaveEntity", currentHoverEntity, currentHoverEntityArgs);
-
+                currentHoverEntity.property("hoverLeaveEntity").call(currentHoverEntity, currentHoverEntityArgs);
             }
         }
 
@@ -977,8 +964,7 @@ void EntityTreeRenderer::mouseMoveEvent(QMouseEvent* event, unsigned int deviceI
         if (rayPickResult.entityID != _currentHoverOverEntityID) {
             emit hoverEnterEntity(rayPickResult.entityID, MouseEvent(*event, deviceID));
             if (entityScript.property("hoverEnterEntity").isValid()) {
-                //qDebug() << "About to call hoverEnterEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-                _entitiesScriptEngine->callScriptMethod("hoverEnterEntity", entityScript, entityScriptArgs);
+                entityScript.property("hoverEnterEntity").call(entityScript, entityScriptArgs);
             }
         }
 
@@ -986,8 +972,7 @@ void EntityTreeRenderer::mouseMoveEvent(QMouseEvent* event, unsigned int deviceI
         // we should send our hover over event
         emit hoverOverEntity(rayPickResult.entityID, MouseEvent(*event, deviceID));
         if (entityScript.property("hoverOverEntity").isValid()) {
-            //qDebug() << "About to call hoverOverEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("hoverOverEntity", entityScript, entityScriptArgs);
+            entityScript.property("hoverOverEntity").call(entityScript, entityScriptArgs);
         }
 
         // remember what we're hovering over
@@ -1004,8 +989,7 @@ void EntityTreeRenderer::mouseMoveEvent(QMouseEvent* event, unsigned int deviceI
 
             QScriptValue currentHoverEntity = loadEntityScript(_currentHoverOverEntityID);
             if (currentHoverEntity.property("hoverLeaveEntity").isValid()) {
-                //qDebug() << "About to call hoverLeaveEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-                _entitiesScriptEngine->callScriptMethod("hoverLeaveEntity", currentHoverEntity, currentHoverEntityArgs);
+                currentHoverEntity.property("hoverLeaveEntity").call(currentHoverEntity, currentHoverEntityArgs);
             }
 
             _currentHoverOverEntityID = UNKNOWN_ENTITY_ID; // makes it the unknown ID
@@ -1021,8 +1005,7 @@ void EntityTreeRenderer::mouseMoveEvent(QMouseEvent* event, unsigned int deviceI
 
         QScriptValue currentClickingEntity = loadEntityScript(_currentClickingOnEntityID);
         if (currentClickingEntity.property("holdingClickOnEntity").isValid()) {
-            //qDebug() << "About to call holdingClickOnEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("holdingClickOnEntity", currentClickingEntity, currentClickingEntityArgs);
+            currentClickingEntity.property("holdingClickOnEntity").call(currentClickingEntity, currentClickingEntityArgs);
         }
     }
     _lastMouseEvent = MouseEvent(*event, deviceID);
@@ -1077,8 +1060,7 @@ void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, const
         QScriptValue entityScript = loadEntityScript(entityID, true, reload); // is preload!
         if (entityScript.property("preload").isValid()) {
             QScriptValueList entityArgs = createEntityArgs(entityID);
-            //qDebug() << "About to call preload() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("preload", entityScript, entityArgs);
+            entityScript.property("preload").call(entityScript, entityArgs);
         }
     }
 }
@@ -1088,8 +1070,7 @@ void EntityTreeRenderer::checkAndCallUnload(const EntityItemID& entityID) {
         QScriptValue entityScript = getPreviouslyLoadedEntityScript(entityID);
         if (entityScript.property("unload").isValid()) {
             QScriptValueList entityArgs = createEntityArgs(entityID);
-            //qDebug() << "About to call unload() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-            _entitiesScriptEngine->callScriptMethod("unload", entityScript, entityArgs);
+            entityScript.property("unload").call(entityScript, entityArgs);
         }
     }
 }
@@ -1174,9 +1155,7 @@ void EntityTreeRenderer::entityCollisionWithEntity(const EntityItemID& idA, cons
         args << idA.toScriptValue(_entitiesScriptEngine);
         args << idB.toScriptValue(_entitiesScriptEngine);
         args << collisionToScriptValue(_entitiesScriptEngine, collision);
-
-        //qDebug() << "About to call collisionWithEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-        _entitiesScriptEngine->callScriptMethod("collisionWithEntity", entityScriptA, args);
+        entityScriptA.property("collisionWithEntity").call(entityScriptA, args);
     }
 
     emit collisionWithEntity(idB, idA, collision);
@@ -1186,9 +1165,7 @@ void EntityTreeRenderer::entityCollisionWithEntity(const EntityItemID& idA, cons
         args << idB.toScriptValue(_entitiesScriptEngine);
         args << idA.toScriptValue(_entitiesScriptEngine);
         args << collisionToScriptValue(_entitiesScriptEngine, collision);
-
-        //qDebug() << "About to call collisionWithEntity() current thread:" << QThread::currentThread() << "entities thread:" << _entitiesScriptEngine->thread();
-        _entitiesScriptEngine->callScriptMethod("collisionWithEntity", entityScriptB, args);
+        entityScriptB.property("collisionWithEntity").call(entityScriptA, args);
     }
 }
 

--- a/libraries/script-engine/src/ScriptCache.cpp
+++ b/libraries/script-engine/src/ScriptCache.cpp
@@ -68,7 +68,6 @@ void ScriptCache::scriptDownloaded() {
         qCDebug(scriptengine) << "Done downloading script at:" << url.toString();
 
         foreach(ScriptUser* user, scriptUsers) {
-            // FIXME - I sometimes get a crash deep below here inside of Qt while evaluating the script
             user->scriptContentsAvailable(url, _scriptCache[url]);
         }
     } else {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -261,20 +261,6 @@ bool ScriptEngine::setScriptContents(const QString& scriptContents, const QStrin
     return true;
 }
 
-void ScriptEngine::callScriptMethod(QString methodName, QScriptValue script, QScriptValueList args) {
-    if (QThread::currentThread() != thread()) {
-            QMetaObject::invokeMethod(this,
-                "callScriptMethod",
-                Q_ARG(QString, methodName),
-                Q_ARG(QScriptValue, script),
-                Q_ARG(QScriptValueList, args));
-        return;
-    }
-
-    //qDebug() << "About to call " << methodName << "() current thread : " << QThread::currentThread() << "engine thread : " << thread();
-    script.property(methodName).call(script, args);
-}
-
 void ScriptEngine::loadURL(const QUrl& scriptURL, bool reload) {
     if (_isRunning) {
         return;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -65,8 +65,6 @@ public:
                           int numArguments = -1);
 
     Q_INVOKABLE void setIsAvatar(bool isAvatar);
-    Q_INVOKABLE void callScriptMethod(QString methodName, QScriptValue script, QScriptValueList args);
-
     bool isAvatar() const { return _isAvatar; }
 
     void setAvatarData(AvatarData* avatarData, const QString& objectName);

--- a/libraries/shared/src/RegisteredMetaTypes.cpp
+++ b/libraries/shared/src/RegisteredMetaTypes.cpp
@@ -26,8 +26,7 @@ static int quatMetaTypeId = qRegisterMetaType<glm::quat>();
 static int xColorMetaTypeId = qRegisterMetaType<xColor>();
 static int pickRayMetaTypeId = qRegisterMetaType<PickRay>();
 static int collisionMetaTypeId = qRegisterMetaType<Collision>();
-static int qMapURLStringMetaTypeId = qRegisterMetaType<QMap<QUrl, QString>>();
-static int qScriptValueListMetaTypeId = qRegisterMetaType<QScriptValueList>("QScriptValueList");
+static int qMapURLStringMetaTypeId = qRegisterMetaType<QMap<QUrl,QString>>();
 
 void registerMetaTypes(QScriptEngine* engine) {
     qScriptRegisterMetaType(engine, vec4toScriptValue, vec4FromScriptValue);


### PR DESCRIPTION
This may seem counter-intuitive, but this will force all entity script stuff BACK ONTO the MAIN THREAD... which now that we've disabled update signals is the easiest way to make all entity scripts activity on a single thread.