### PR TITLE
Fixing differing highlights between left and right eyes in stereo modes

### DIFF
--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -44,6 +44,10 @@ void Context::enableStereo(bool enable) {
     _backend->enableStereo(enable);
 }
 
+bool Context::isStereo() {
+    return _backend->isStereo();
+}
+
 void Context::setStereoProjections(const mat4 eyeProjections[2]) {
     _backend->setStereoProjections(eyeProjections);
 }

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -45,6 +45,10 @@ public:
         _stereo._enable = enable;
     }
 
+    virtual bool isStereo() {
+        return _stereo._enable;
+    }
+
     void setStereoProjections(const mat4 eyeProjections[2]) {
         for (int i = 0; i < 2; ++i) {
             _stereo._eyeProjections[i] = eyeProjections[i];
@@ -169,6 +173,7 @@ public:
 
     void render(Batch& batch);
     void enableStereo(bool enable = true);
+    bool isStereo();
     void setStereoProjections(const mat4 eyeProjections[2]);
     void setStereoViews(const mat4 eyeViews[2]);
     void syncCache();

--- a/libraries/render-utils/src/DeferredBuffer.slh
+++ b/libraries/render-utils/src/DeferredBuffer.slh
@@ -11,6 +11,8 @@
 <@if not DEFERRED_BUFFER_SLH@>
 <@def DEFERRED_BUFFER_SLH@>
 
+uniform bool stereoMode = false;
+
 // the diffuse texture
 uniform sampler2D diffuseMap;
 
@@ -55,6 +57,12 @@ DeferredFragment unpackDeferredFragment(vec2 texcoord) {
     frag.diffuseVal = texture(diffuseMap, texcoord);
     frag.specularVal = texture(specularMap, texcoord);
 
+    if (stereoMode) {
+        if (texcoord.x > 0.5) {
+            texcoord.x -= 0.5;
+        }
+        texcoord.x *= 2.0;
+    }
     // compute the view space position using the depth
     float z = near / (frag.depthVal * depthScale - 1.0);
     frag.position = vec4((depthTexCoordOffset + texcoord * depthTexCoordScale) * z, z, 1.0);

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -24,7 +24,8 @@
 class AbstractViewStateInterface;
 class RenderArgs;
 class SimpleProgramKey;
-
+struct LightLocations;
+using LightLocationsPtr = std::shared_ptr<LightLocations>;
 /// Handles deferred lighting for the bits that require it (voxels...)
 class DeferredLightingEffect : public Dependency {
     SINGLETON_DEPENDENCY
@@ -82,28 +83,9 @@ private:
     DeferredLightingEffect() {}
     virtual ~DeferredLightingEffect() { }
 
-    class LightLocations {
-    public:
-        int shadowDistances;
-        int shadowScale;
-        int nearLocation;
-        int depthScale;
-        int depthTexCoordOffset;
-        int depthTexCoordScale;
-        int radius;
-        int ambientSphere;
-        int lightBufferUnit;
-        int atmosphereBufferUnit;
-        int invViewMat;
-        int texcoordMat;
-        int coneParam;
-    };
-
     model::MeshPointer _spotLightMesh;
     model::MeshPointer getSpotLightMesh();
 
-    static void loadLightProgram(const char* vertSource, const char* fragSource, bool lightVolume, gpu::PipelinePointer& program, LightLocations& locations);
-  
     gpu::PipelinePointer getPipeline(SimpleProgramKey config);
     
     gpu::ShaderPointer _simpleShader;
@@ -113,30 +95,30 @@ private:
     gpu::PipelinePointer _blitLightBuffer;
 
     gpu::PipelinePointer _directionalSkyboxLight;
-    LightLocations _directionalSkyboxLightLocations;
+    LightLocationsPtr _directionalSkyboxLightLocations;
     gpu::PipelinePointer _directionalSkyboxLightShadowMap;
-    LightLocations _directionalSkyboxLightShadowMapLocations;
+    LightLocationsPtr _directionalSkyboxLightShadowMapLocations;
     gpu::PipelinePointer _directionalSkyboxLightCascadedShadowMap;
-    LightLocations _directionalSkyboxLightCascadedShadowMapLocations;
+    LightLocationsPtr _directionalSkyboxLightCascadedShadowMapLocations;
 
     gpu::PipelinePointer _directionalAmbientSphereLight;
-    LightLocations _directionalAmbientSphereLightLocations;
+    LightLocationsPtr _directionalAmbientSphereLightLocations;
     gpu::PipelinePointer _directionalAmbientSphereLightShadowMap;
-    LightLocations _directionalAmbientSphereLightShadowMapLocations;
+    LightLocationsPtr _directionalAmbientSphereLightShadowMapLocations;
     gpu::PipelinePointer _directionalAmbientSphereLightCascadedShadowMap;
-    LightLocations _directionalAmbientSphereLightCascadedShadowMapLocations;
+    LightLocationsPtr _directionalAmbientSphereLightCascadedShadowMapLocations;
 
     gpu::PipelinePointer _directionalLight;
-    LightLocations _directionalLightLocations;
+    LightLocationsPtr _directionalLightLocations;
     gpu::PipelinePointer _directionalLightShadowMap;
-    LightLocations _directionalLightShadowMapLocations;
+    LightLocationsPtr _directionalLightShadowMapLocations;
     gpu::PipelinePointer _directionalLightCascadedShadowMap;
-    LightLocations _directionalLightCascadedShadowMapLocations;
+    LightLocationsPtr _directionalLightCascadedShadowMapLocations;
 
     gpu::PipelinePointer _pointLight;
-    LightLocations _pointLightLocations;
+    LightLocationsPtr _pointLightLocations;
     gpu::PipelinePointer _spotLight;
-    LightLocations _spotLightLocations;
+    LightLocationsPtr _spotLightLocations;
 
     class PointLight {
     public:


### PR DESCRIPTION
This adds a stereo flag to the deferred rendering so that the highlights calculations are compensating for the stereo framebuffer when calculating the position and subsequently the specular highlights of an object.  

This is an incomplete fix because it doesn't provide the proper left / right projection matrices for unprojection back into eye space, but the difference should be slight enough to avoid making people ill.