### PR TITLE
Fix over-calculation of cluster matrices

### DIFF
--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -497,6 +497,7 @@ private:
     QMap<render::ItemID, render::PayloadPointer> _renderItems;
     bool _readyWhenAdded = false;
     bool _needsReload = true;
+    bool _needsUpdateClusterMatrices = true;
 
 protected:
     RigPointer _rig;


### PR DESCRIPTION
Currently the model parts of an FBX call updateClusterMatrices on the model each time any part is rendered.  If you have an FBX mesh with 400 parts and they're all visible, then you're updating the cluster matrices for 400 parts 400 times, i.e. 159,999 more times more than you need to.  Since the update involves multiple matrix compositions, this impacts framerates.

This adds an update hook to the model parts so that they reset a flag.  In the above situation we'll technically reset the flag 399 more times than we need to, but that's pretty cheap.  We'll update the cluster matrices only once and trip the flag, so that subsequent parts don't repeat the calculation needlessly.