### PR TITLE
fix animation unit tests

### DIFF
--- a/libraries/animation/src/SwingTwistConstraint.cpp
+++ b/libraries/animation/src/SwingTwistConstraint.cpp
@@ -72,7 +72,7 @@ SwingTwistConstraint::SwingTwistConstraint() :
         _swingLimitFunction(),
         _minTwist(-PI),
         _maxTwist(PI),
-        _lastTwistBoundary(0)
+        _lastTwistBoundary(LAST_CLAMP_NO_BOUNDARY)
 {
 }
 
@@ -249,3 +249,6 @@ bool SwingTwistConstraint::apply(glm::quat& rotation) const {
     return false;
 }
 
+void SwingTwistConstraint::clearHistory() {
+    _lastTwistBoundary = LAST_CLAMP_NO_BOUNDARY;
+}

--- a/libraries/animation/src/SwingTwistConstraint.h
+++ b/libraries/animation/src/SwingTwistConstraint.h
@@ -73,6 +73,9 @@ public:
     /// \return reference to SwingLimitFunction instance for unit-testing
     const SwingLimitFunction& getSwingLimitFunction() const { return _swingLimitFunction; }
 
+    /// \brief exposed for unit testing
+    void clearHistory();
+
 protected:
     SwingLimitFunction _swingLimitFunction;
     float _minTwist;

--- a/tests/animation/src/RotationConstraintTests.cpp
+++ b/tests/animation/src/RotationConstraintTests.cpp
@@ -193,6 +193,7 @@ void RotationConstraintTests::testSwingTwistConstraint() {
                 glm::quat inputRotation = swingRotation * twistRotation * referenceRotation;
                 glm::quat outputRotation = inputRotation;
 
+                shoulder.clearHistory();
                 bool updated = shoulder.apply(outputRotation);
                 QVERIFY(updated == false);
                 QCOMPARE_WITH_ABS_ERROR(inputRotation, outputRotation, EPSILON);
@@ -223,6 +224,7 @@ void RotationConstraintTests::testSwingTwistConstraint() {
                 glm::quat inputRotation = swingRotation * twistRotation * referenceRotation;
                 glm::quat outputRotation = inputRotation;
 
+                shoulder.clearHistory();
                 bool updated = shoulder.apply(outputRotation);
                 QVERIFY(updated == true);
 
@@ -257,6 +259,7 @@ void RotationConstraintTests::testSwingTwistConstraint() {
                 glm::quat inputRotation = swingRotation * twistRotation * referenceRotation;
                 glm::quat outputRotation = inputRotation;
 
+                shoulder.clearHistory();
                 bool updated = shoulder.apply(outputRotation);
                 QVERIFY(updated == true);
 
@@ -291,6 +294,7 @@ void RotationConstraintTests::testSwingTwistConstraint() {
                 glm::quat inputRotation = swingRotation * twistRotation * referenceRotation;
                 glm::quat outputRotation = inputRotation;
 
+                shoulder.clearHistory();
                 bool updated = shoulder.apply(outputRotation);
                 QVERIFY(updated == true);
 


### PR DESCRIPTION
The **animation-tests** build target was failing to compile and some tests were failing.  Now fixed.