### PR TITLE
Revert "Fix over-calculation of cluster matrices"

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -798,7 +798,7 @@ namespace render {
             return payload->model->renderPart(args, payload->meshIndex, payload->partIndex, payload->transparent);
         }
     }
-    
+
    /* template <> const model::MaterialKey& shapeGetMaterialKey(const MeshPartPayload::Pointer& payload) {
         return payload->model->getPartMaterial(payload->meshIndex, payload->partIndex);
     }*/
@@ -829,9 +829,6 @@ bool Model::addToScene(std::shared_ptr<render::Scene> scene, render::PendingChan
         auto renderData = MeshPartPayload::Pointer(renderItem);
         auto renderPayload = std::make_shared<MeshPartPayload::Payload>(renderData);
         pendingChanges.resetItem(item, renderPayload);
-        pendingChanges.updateItem<MeshPartPayload>(item, [&](MeshPartPayload& data) {
-            data.model->_needsUpdateClusterMatrices = true;
-        });
         _renderItems.insert(item, renderPayload);
         somethingAdded = true;
     }
@@ -841,9 +838,6 @@ bool Model::addToScene(std::shared_ptr<render::Scene> scene, render::PendingChan
         auto renderData = MeshPartPayload::Pointer(renderItem);
         auto renderPayload = std::make_shared<MeshPartPayload::Payload>(renderData);
         pendingChanges.resetItem(item, renderPayload);
-        pendingChanges.updateItem<MeshPartPayload>(item, [&](MeshPartPayload& data) {
-            data.model->_needsUpdateClusterMatrices = true;
-        });
         _renderItems.insert(item, renderPayload);
         somethingAdded = true;
     }
@@ -866,9 +860,6 @@ bool Model::addToScene(std::shared_ptr<render::Scene> scene, render::PendingChan
         auto renderPayload = std::make_shared<MeshPartPayload::Payload>(renderData);
         renderPayload->addStatusGetters(statusGetters);
         pendingChanges.resetItem(item, renderPayload);
-        pendingChanges.updateItem<MeshPartPayload>(item, [&](MeshPartPayload& data) {
-            data.model->_needsUpdateClusterMatrices = true;
-        });
         _renderItems.insert(item, renderPayload);
         somethingAdded = true;
     }
@@ -879,9 +870,6 @@ bool Model::addToScene(std::shared_ptr<render::Scene> scene, render::PendingChan
         auto renderPayload = std::make_shared<MeshPartPayload::Payload>(renderData);
         renderPayload->addStatusGetters(statusGetters);
         pendingChanges.resetItem(item, renderPayload);
-        pendingChanges.updateItem<MeshPartPayload>(item, [&](MeshPartPayload& data) {
-            data.model->_needsUpdateClusterMatrices = true;
-        });
         _renderItems.insert(item, renderPayload);
         somethingAdded = true;
     }
@@ -1305,15 +1293,11 @@ void Model::simulateInternal(float deltaTime) {
     updateRig(deltaTime, parentTransform);
 }
 void Model::updateClusterMatrices() {
-    if (!_needsUpdateClusterMatrices) {
-        return;
-    }
-    _needsUpdateClusterMatrices = false;
     const FBXGeometry& geometry = _geometry->getFBXGeometry();
     glm::mat4 zeroScale(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
-        glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
-        glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
-        glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+                        glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
+                        glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
+                        glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
     auto cauterizeMatrix = _rig->getJointTransform(geometry.neckJointIndex) * zeroScale;
 
     glm::mat4 modelToWorld = glm::mat4_cast(_rotation);
@@ -1819,15 +1803,13 @@ bool Model::initWhenReady(render::ScenePointer scene) {
         segregateMeshGroups();
 
         render::PendingChanges pendingChanges;
+
         foreach (auto renderItem, _transparentRenderItems) {
             auto item = scene->allocateID();
             auto renderData = MeshPartPayload::Pointer(renderItem);
             auto renderPayload = std::make_shared<MeshPartPayload::Payload>(renderData);
             _renderItems.insert(item, renderPayload);
             pendingChanges.resetItem(item, renderPayload);
-            pendingChanges.updateItem<MeshPartPayload>(item, [&](MeshPartPayload& data) {
-                data.model->_needsUpdateClusterMatrices = true;
-            });
         }
 
         foreach (auto renderItem, _opaqueRenderItems) {
@@ -1836,9 +1818,6 @@ bool Model::initWhenReady(render::ScenePointer scene) {
             auto renderPayload = std::make_shared<MeshPartPayload::Payload>(renderData);
             _renderItems.insert(item, renderPayload);
             pendingChanges.resetItem(item, renderPayload);
-            pendingChanges.updateItem<MeshPartPayload>(item, [&](MeshPartPayload& data) {
-                data.model->_needsUpdateClusterMatrices = true;
-            });
         }
         scene->enqueuePendingChanges(pendingChanges);
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -497,7 +497,6 @@ private:
     QMap<render::ItemID, render::PayloadPointer> _renderItems;
     bool _readyWhenAdded = false;
     bool _needsReload = true;
-    bool _needsUpdateClusterMatrices = true;
 
 protected:
     RigPointer _rig;


### PR DESCRIPTION
Reverts highfidelity/hifi#5800

FYI @jherico  - I'm reverting this because according to @RyanDowne - after testing it on the Mac - animations on the mac were broken with this change.
