### PR TITLE
Fix avatar and other model animations

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1295,6 +1295,7 @@ void Model::simulate(float deltaTime, bool fullUpdate) {
 
 //virtual
 void Model::updateRig(float deltaTime, glm::mat4 parentTransform) {
+    _needsUpdateClusterMatrices = true;
      _rig->updateAnimations(deltaTime, parentTransform);
 }
 void Model::simulateInternal(float deltaTime) {

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -497,6 +497,7 @@ private:
     QMap<render::ItemID, render::PayloadPointer> _renderItems;
     bool _readyWhenAdded = false;
     bool _needsReload = true;
+    bool _needsUpdateClusterMatrices = true;
 
 protected:
     RigPointer _rig;


### PR DESCRIPTION
A change yesterday to correct performance issues with models with many sub-meshes apparently broke other kinds of animations.  This is because of the radically different paths through Model.cpp that are taken between different kinds of models.  This PR should correct the animation for avatars and some entities (the cat in Toybox, for instance).

