### PR TITLE
Script-accessible animation-state

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -56,9 +56,18 @@ static void localLightFromScriptValue(const QScriptValue& value, AvatarManager::
     vec3FromScriptValue(value.property("color"), light.color);
 }
 
+static QScriptValue animationStateToScriptValue(QScriptEngine* engine, SharedAnimationState* const &in) {
+    return engine->newQObject(in);
+}
+
+static void animationStateFromScriptValue(const QScriptValue &object, SharedAnimationState* &out) {
+    out = qobject_cast<SharedAnimationState*>(object.toQObject());
+}
+
 void AvatarManager::registerMetaTypes(QScriptEngine* engine) {
     qScriptRegisterMetaType(engine, localLightToScriptValue, localLightFromScriptValue);
     qScriptRegisterSequenceMetaType<QVector<AvatarManager::LocalLight> >(engine);
+    qScriptRegisterMetaType(engine, animationStateToScriptValue, animationStateFromScriptValue);
 }
 
 AvatarManager::AvatarManager(QObject* parent) :

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -56,12 +56,12 @@ static void localLightFromScriptValue(const QScriptValue& value, AvatarManager::
     vec3FromScriptValue(value.property("color"), light.color);
 }
 
-static QScriptValue animationStateToScriptValue(QScriptEngine* engine, SharedAnimationState* const &in) {
+static QScriptValue animationStateToScriptValue(QScriptEngine* engine, ScriptableRigStateVariables* const &in) {
     return engine->newQObject(in);
 }
 
-static void animationStateFromScriptValue(const QScriptValue &object, SharedAnimationState* &out) {
-    out = qobject_cast<SharedAnimationState*>(object.toQObject());
+static void animationStateFromScriptValue(const QScriptValue &object, ScriptableRigStateVariables* &out) {
+    out = qobject_cast<ScriptableRigStateVariables*>(object.toQObject());
 }
 
 void AvatarManager::registerMetaTypes(QScriptEngine* engine) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -66,6 +66,7 @@ public:
 
     float getRealWorldFieldOfView() { return _realWorldFieldOfView.get(); }
 
+    Q_INVOKABLE SharedAnimationState* getAnimationState() { return _rig->getAnimationState(); }
     const QList<AnimationHandlePointer>& getAnimationHandles() const { return _rig->getAnimationHandles(); }
     AnimationHandlePointer addAnimationHandle() { return _rig->createAnimationHandle(); }
     void removeAnimationHandle(const AnimationHandlePointer& handle) { _rig->removeAnimationHandle(handle); }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -66,7 +66,7 @@ public:
 
     float getRealWorldFieldOfView() { return _realWorldFieldOfView.get(); }
 
-    Q_INVOKABLE SharedAnimationState* getAnimationState() { return _rig->getAnimationState(); }
+    Q_INVOKABLE ScriptableRigStateVariables* getAnimationState() { return _rig->getAnimationState(); }
     const QList<AnimationHandlePointer>& getAnimationHandles() const { return _rig->getAnimationHandles(); }
     AnimationHandlePointer addAnimationHandle() { return _rig->createAnimationHandle(); }
     void removeAnimationHandle(const AnimationHandlePointer& handle) { _rig->removeAnimationHandle(handle); }

--- a/libraries/animation/src/AnimVariant.h
+++ b/libraries/animation/src/AnimVariant.h
@@ -16,6 +16,7 @@
 #include <glm/gtx/quaternion.hpp>
 #include <map>
 #include <set>
+#include "AnimationLogging.h"
 
 class AnimVariant {
 public:
@@ -153,6 +154,14 @@ public:
 
     void setTrigger(const std::string& key) { _triggers.insert(key); }
     void clearTriggers() { _triggers.clear(); }
+    void updateFromHash(const QHash<QString, AnimVariant>& source) {
+        QHashIterator<QString, AnimVariant> i(source);
+        while (i.hasNext()) {
+            i.next();
+            _map[i.key().toStdString()] = i.value();
+        }
+
+    }
 
 protected:
     std::map<std::string, AnimVariant> _map;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -438,6 +438,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
     if (_enableAnimGraph) {
 
+        _animVars.updateFromHash(_sharedVars.hash);
         glm::vec3 localVel = glm::inverse(worldRotation) * workingVelocity;
         float forwardSpeed = glm::dot(localVel, IDENTITY_FRONT);
         float lateralSpeed = glm::dot(localVel, IDENTITY_RIGHT);

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -438,7 +438,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
     if (_enableAnimGraph) {
 
-        _animVars.updateFromHash(_sharedVars.hash);
+        _sharedVars.doHash([this](const QHash<QString, AnimVariant>& hash) { _animVars.updateFromHash(hash); });
         glm::vec3 localVel = glm::inverse(worldRotation) * workingVelocity;
         float forwardSpeed = glm::dot(localVel, IDENTITY_FRONT);
         float lateralSpeed = glm::dot(localVel, IDENTITY_RIGHT);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -49,6 +49,21 @@ typedef std::shared_ptr<AnimationHandle> AnimationHandlePointer;
 class Rig;
 typedef std::shared_ptr<Rig> RigPointer;
 
+class SharedAnimationState : public QObject {
+    Q_OBJECT
+public:
+    // locked so that multiple scripts (and the rig) can access from different threads.
+    Q_INVOKABLE bool get(const QString& key, const bool& defaultValue) const { QMutexLocker locker(&_mutex); return hash.contains(key) ? hash.value(key).getBool() : defaultValue; }
+    Q_INVOKABLE float get(const QString& key, const float& defaultValue) const { QMutexLocker locker(&_mutex); return hash.contains(key) ? hash.value(key).getFloat() : defaultValue; }
+    Q_INVOKABLE void set(const QString& key, bool value) { QMutexLocker locker(&_mutex);  hash.insert(key, AnimVariant(value)); }
+    Q_INVOKABLE void set(const QString& key, float value) { QMutexLocker locker(&_mutex);  hash.insert(key, AnimVariant(value)); }
+    // Note that Javascript [] notation affects QObject properties, not any operator[] that might be defined here.
+    QHash<QString, AnimVariant> hash {};
+private:
+    mutable QMutex _mutex;
+};
+Q_DECLARE_METATYPE(SharedAnimationState*)
+
 class Rig : public QObject, public std::enable_shared_from_this<Rig> {
 public:
 
@@ -179,6 +194,8 @@ public:
 
     AnimNode::ConstPointer getAnimNode() const { return _animNode; }
     AnimSkeleton::ConstPointer getAnimSkeleton() const { return _animSkeleton; }
+    SharedAnimationState* getAnimationState() { return &_sharedVars; }
+    AnimVariantMap& getAnimVars() { return _animVars; } // for testing
 
  protected:
 
@@ -209,6 +226,7 @@ public:
     std::shared_ptr<AnimSkeleton> _animSkeleton;
     std::unique_ptr<AnimNodeLoader> _animLoader;
     AnimVariantMap _animVars;
+    SharedAnimationState _sharedVars {}; // Exposed to all scripts through MyAvatar
     enum class RigRole {
         Idle = 0,
         Turn,

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -181,7 +181,7 @@ public:
     AnimNode::ConstPointer getAnimNode() const { return _animNode; }
     AnimSkeleton::ConstPointer getAnimSkeleton() const { return _animSkeleton; }
     ScriptableRigStateVariables* getAnimationState() { return &_sharedVars; }
-    AnimVariantMap& getAnimVars() { return _animVars; } // for testing
+    const AnimVariantMap& getAnimVars() const { return _animVars; } // for observation, e.g., testing
 
  protected:
 

--- a/libraries/animation/src/ScriptableRigStateVariables.cpp
+++ b/libraries/animation/src/ScriptableRigStateVariables.cpp
@@ -1,0 +1,37 @@
+//
+//  ScriptableRigStateVariables.cpp
+//  libraries/animation/src/
+//
+//  Created by Howard Stearns on 9/15/15.
+//  Copyright (c) 2015 High Fidelity, Inc. All rights reserved.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ScriptableRigStateVariables.h"
+
+// locker allows multiple scripts (and the rig) safe access from different threads.
+// Future: dry this up with a macro, and include other AnimVariant types.
+
+bool ScriptableRigStateVariables::get(const QString& key, const bool& defaultValue) const {
+    QMutexLocker locker(&_mutex);
+    return _hash.contains(key) ? _hash.value(key).getBool() : defaultValue;
+}
+float ScriptableRigStateVariables::get(const QString& key, const float& defaultValue) const {
+    QMutexLocker locker(&_mutex);
+    return _hash.contains(key) ? _hash.value(key).getFloat() : defaultValue;
+}
+void ScriptableRigStateVariables::set(const QString& key, bool value) {
+    QMutexLocker locker(&_mutex);
+    _hash.insert(key, AnimVariant(value));
+}
+void ScriptableRigStateVariables::set(const QString& key, float value) {
+    QMutexLocker locker(&_mutex);
+    _hash.insert(key, AnimVariant(value));
+}
+
+void ScriptableRigStateVariables::doHash(std::function<void(const QHash<QString, AnimVariant>& _hash)> functionOfHash) {
+    QMutexLocker locker(&_mutex);
+    functionOfHash(_hash);
+}

--- a/libraries/animation/src/ScriptableRigStateVariables.h
+++ b/libraries/animation/src/ScriptableRigStateVariables.h
@@ -12,6 +12,7 @@
 #ifndef hifi_ScriptableRigStateVariables_h
 #define hifi_ScriptableRigStateVariables_h
 
+#include <functional>
 #include <QObject>
 #include <QMutex>
 #include <QString>

--- a/libraries/animation/src/ScriptableRigStateVariables.h
+++ b/libraries/animation/src/ScriptableRigStateVariables.h
@@ -1,0 +1,35 @@
+//
+//  ScriptableRigStateVariables.h
+//  libraries/animation/src/
+//
+//  Created by Howard Stearns on 9/15/15.
+//  Copyright (c) 2015 High Fidelity, Inc. All rights reserved.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_ScriptableRigStateVariables_h
+#define hifi_ScriptableRigStateVariables_h
+
+#include <QObject>
+#include <QMutex>
+#include <QString>
+#include "AnimVariant.h"
+
+class ScriptableRigStateVariables : public QObject {
+    Q_OBJECT
+public:
+    // Note that Javascript [] notation affects QObject properties, not any operator[] that might be defined here.
+    Q_INVOKABLE bool get(const QString& key, const bool& defaultValue) const;
+    Q_INVOKABLE float get(const QString& key, const float& defaultValue) const;
+    Q_INVOKABLE void set(const QString& key, bool value);
+    Q_INVOKABLE void set(const QString& key, float value);
+    void doHash(std::function<void(const QHash<QString, AnimVariant>& hash)> functionOfHash); // Safe access of hash, using lambda.
+private:
+    mutable QMutex _mutex;
+    QHash<QString, AnimVariant> _hash {};
+};
+Q_DECLARE_METATYPE(ScriptableRigStateVariables*);
+
+#endif

--- a/tests/animation/src/RigTests.cpp
+++ b/tests/animation/src/RigTests.cpp
@@ -103,3 +103,14 @@ void RigTests::initTestCase() {
 void RigTests::initialPoseArmsDown() {
     reportSome(_rig);
 }
+
+void RigTests::animationState() {
+    _rig->getAnimationState()->set("foo", true); // These can also be set from Javascript MyAvatar
+    _rig->getAnimationState()->set("bar", 99.0f);
+    QVERIFY(_rig->getAnimationState()->get("foo", false) == true);
+    QVERIFY(_rig->getAnimationState()->get("bar", -1.0f) == 99.0f);
+    _rig->setEnableAnimGraph(true); // Otherwise the rig machinery doesn't run.
+    _rig->computeMotionAnimationState(0.1f, glm::vec3(0.0f), glm::vec3(0.0f), glm::quat()); // transfers state to anim vars
+    QVERIFY(_rig->getAnimVars().lookup("foo", false) == true);
+    QVERIFY(_rig->getAnimVars().lookup("bar", -1.0f) == 99.0f);
+}

--- a/tests/animation/src/RigTests.h
+++ b/tests/animation/src/RigTests.h
@@ -47,6 +47,7 @@ class RigTests : public QObject {
  private slots:
     void initTestCase();
     void initialPoseArmsDown();
+    void animationState();
 
  private:
     RigPointer _rig;


### PR DESCRIPTION
Create a thread-safe copy of anim vars exposed to javascript.

This is a minimal version in which javascript can only write and read new vars (not the ones maintained by the Rig), and only bool and float of those.