### PR TITLE
couple of entity server corner cases

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -142,7 +142,7 @@ void EntityServer::pruneDeletedEntities() {
     }
 }
 
-void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectionObject) {
+bool EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectionObject) {
     bool wantEditLogging = false;
     readOptionBool(QString("wantEditLogging"), settingsSectionObject, wantEditLogging);
     qDebug("wantEditLogging=%s", debug::valueOf(wantEditLogging));
@@ -150,4 +150,6 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
 
     EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
     tree->setWantEditLogging(wantEditLogging);
+
+    return true;
 }

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -41,7 +41,7 @@ public:
     virtual int sendSpecialPackets(const SharedNodePointer& node, OctreeQueryNode* queryNode, int& packetsSent);
 
     virtual void entityCreated(const EntityItem& newEntity, const SharedNodePointer& senderNode);
-    virtual void readAdditionalConfiguration(const QJsonObject& settingsSectionObject);
+    virtual bool readAdditionalConfiguration(const QJsonObject& settingsSectionObject) override;
 
 public slots:
     void pruneDeletedEntities();

--- a/assignment-client/src/octree/OctreeQueryNode.cpp
+++ b/assignment-client/src/octree/OctreeQueryNode.cpp
@@ -242,7 +242,8 @@ bool OctreeQueryNode::updateCurrentViewFrustum() {
 
     if (0.0f != getCameraAspectRatio() &&
         0.0f != getCameraNearClip() &&
-        0.0f != getCameraFarClip()) {
+        0.0f != getCameraFarClip() &&
+        getCameraNearClip() != getCameraFarClip()) {
         newestViewFrustum.setProjection(glm::perspective(
             glm::radians(wideFOV), // hack
             getCameraAspectRatio(),

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -908,11 +908,11 @@ void OctreeServer::readConfiguration() {
 
     qDebug() << "Got domain settings from domain-server.";
 
-    if (domainHandler.getSettingsObject().isEmpty()) {
-        qDebug() << "No settings object from domain-server.";
-    }
     QJsonObject settingsObject { domainHandler.getSettingsObject() };
 
+    if (settingsObject.isEmpty()) {
+        qDebug() << "No settings object from domain-server.";
+    }
 
     QString settingsKey = getMyDomainSettingsKey();
     QJsonObject settingsSectionObject = settingsObject[settingsKey].toObject();

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -906,10 +906,14 @@ void OctreeServer::readConfiguration() {
     domainHandler.requestDomainSettings();
     loop.exec();
 
+    qDebug() << "Got domain settings from domain-server.";
+
     if (domainHandler.getSettingsObject().isEmpty()) {
         qDebug() << "No settings object from domain-server.";
     }
-    const QJsonObject& settingsObject = domainHandler.getSettingsObject();
+    QJsonObject settingsObject { domainHandler.getSettingsObject() };
+
+
     QString settingsKey = getMyDomainSettingsKey();
     QJsonObject settingsSectionObject = settingsObject[settingsKey].toObject();
     _settings = settingsSectionObject; // keep this for later
@@ -1333,19 +1337,22 @@ void OctreeServer::sendStatsPacket() {
     QJsonObject statsObject2;
     statsObject2["data"] = dataObject1;
     statsObject2["timing"] = timingArray1;
-    
-    // Stats Object 3
+
     QJsonObject dataArray2;
-    dataArray2["1. packetQueue"] = (double)_octreeInboundPacketProcessor->packetsToProcessCount();
-    dataArray2["2. totalPackets"] = (double)_octreeInboundPacketProcessor->getTotalPacketsProcessed();
-    dataArray2["3. totalElements"] = (double)_octreeInboundPacketProcessor->getTotalElementsProcessed();
-    
     QJsonObject timingArray2;
-    timingArray2["1. avgTransitTimePerPacket"] = (double)_octreeInboundPacketProcessor->getAverageTransitTimePerPacket();
-    timingArray2["2. avgProcessTimePerPacket"] = (double)_octreeInboundPacketProcessor->getAverageProcessTimePerPacket();
-    timingArray2["3. avgLockWaitTimePerPacket"] = (double)_octreeInboundPacketProcessor->getAverageLockWaitTimePerPacket();
-    timingArray2["4. avgProcessTimePerElement"] = (double)_octreeInboundPacketProcessor->getAverageProcessTimePerElement();
-    timingArray2["5. avgLockWaitTimePerElement"] = (double)_octreeInboundPacketProcessor->getAverageLockWaitTimePerElement();
+
+    // Stats Object 3
+    if (_octreeInboundPacketProcessor) {
+        dataArray2["1. packetQueue"] = (double)_octreeInboundPacketProcessor->packetsToProcessCount();
+        dataArray2["2. totalPackets"] = (double)_octreeInboundPacketProcessor->getTotalPacketsProcessed();
+        dataArray2["3. totalElements"] = (double)_octreeInboundPacketProcessor->getTotalElementsProcessed();
+
+        timingArray2["1. avgTransitTimePerPacket"] = (double)_octreeInboundPacketProcessor->getAverageTransitTimePerPacket();
+        timingArray2["2. avgProcessTimePerPacket"] = (double)_octreeInboundPacketProcessor->getAverageProcessTimePerPacket();
+        timingArray2["3. avgLockWaitTimePerPacket"] = (double)_octreeInboundPacketProcessor->getAverageLockWaitTimePerPacket();
+        timingArray2["4. avgProcessTimePerElement"] = (double)_octreeInboundPacketProcessor->getAverageProcessTimePerElement();
+        timingArray2["5. avgLockWaitTimePerElement"] = (double)_octreeInboundPacketProcessor->getAverageLockWaitTimePerElement();
+    }
     
     QJsonObject statsObject3;
     statsObject3["data"] = dataArray2;

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -135,8 +135,8 @@ protected:
     bool readOptionBool(const QString& optionName, const QJsonObject& settingsSectionObject, bool& result);
     bool readOptionInt(const QString& optionName, const QJsonObject& settingsSectionObject, int& result);
     bool readOptionString(const QString& optionName, const QJsonObject& settingsSectionObject, QString& result);
-    void readConfiguration();
-    virtual void readAdditionalConfiguration(const QJsonObject& settingsSectionObject) { };
+    bool readConfiguration();
+    virtual bool readAdditionalConfiguration(const QJsonObject& settingsSectionObject) { return true;  };
     void parsePayload();
     void initHTTPManager(int port);
     void resetSendingStats();

--- a/libraries/networking/src/ThreadedAssignment.cpp
+++ b/libraries/networking/src/ThreadedAssignment.cpp
@@ -65,7 +65,7 @@ void ThreadedAssignment::commonInit(const QString& targetName, NodeType_t nodeTy
     auto nodeList = DependencyManager::get<NodeList>();
     nodeList->setOwnerType(nodeType);
 
-    _domainServerTimer = new QTimer();
+    _domainServerTimer = new QTimer(this);
     connect(_domainServerTimer, SIGNAL(timeout()), this, SLOT(checkInWithDomainServerOrExit()));
     _domainServerTimer->start(DOMAIN_SERVER_CHECK_IN_MSECS);
 


### PR DESCRIPTION
* fix for crash in OctreeServer::sendStatsPacket() for timer firing before the inbound packet processor is setup
* fix for crash in empty settings object
* fix for debug assert in glm::perspective() if query ever has near and far clip set to same value