### PR TITLE
Get rid of avatar tilt

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -996,12 +996,9 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
             _animVars.set("headRotation", realLocalHeadOrientation);
 
             auto rootTrans = _animSkeleton->getAbsoluteBindPose(_rootJointIndex).trans;
-
-            if (params.isInHMD) {
-                _animVars.set("headPosition", params.localHeadPosition + rootTrans);
-            } else {
-                _animVars.unset("headPosition");
-            }
+            // There's a theory that when not in hmd, we should _animVars.unset("headPosition").
+            // However, until that works well, let's always request head be positioned where requested by hmd, camera, or default.
+            _animVars.set("headPosition", params.localHeadPosition + rootTrans);
         } else if (!_enableAnimGraph) {
 
             auto& state = _jointStates[index];


### PR DESCRIPTION
Place head at requested position in all modes. 

The medium-term solution here is to get the underpass position cleanly, without tilt. But until that's done, this will at least allow us to work with the grid animations without tilt. (Or less tilt, anyway.)
