### PR TITLE
prevent initial bad IK targets for hands 

### DIFF
--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -211,8 +211,8 @@ const AnimPoseVec& AnimInverseKinematics::evaluate(const AnimVariantMap& animVar
                                 // compute joint's new parent-relative rotation
                                 // Q' = dQ * Q   and   Q = Qp * q   -->   q' = Qp^ * dQ * Q
                                 glm::quat newRot = glm::normalize(glm::inverse(
-                                        absolutePoses[parentIndex].rot) * 
-                                        deltaRotation * 
+                                        absolutePoses[parentIndex].rot) *
+                                        deltaRotation *
                                         absolutePoses[pivotIndex].rot);
                                 RotationConstraint* constraint = getConstraint(pivotIndex);
                                 if (constraint) {
@@ -221,8 +221,8 @@ const AnimPoseVec& AnimInverseKinematics::evaluate(const AnimVariantMap& animVar
                                         // the constraint will modify the movement of the tip so we have to compute the modified
                                         // model-frame deltaRotation
                                         // Q' = Qp^ * dQ * Q  -->  dQ =   Qp * Q' * Q^
-                                        deltaRotation = absolutePoses[parentIndex].rot * 
-                                            newRot * 
+                                        deltaRotation = absolutePoses[parentIndex].rot *
+                                            newRot *
                                             glm::inverse(absolutePoses[pivotIndex].rot);
                                     }
                                 }
@@ -319,7 +319,7 @@ void AnimInverseKinematics::initConstraints() {
     // We create constraints for the joints shown here
     // (and their Left counterparts if applicable).
     //
-    //                           
+    //
     //                                    O RightHand
     //                      Head         /
     //                          O       /
@@ -473,7 +473,7 @@ void AnimInverseKinematics::initConstraints() {
             const float MAX_HAND_SWING = PI / 2.0f;
             minDots.push_back(cosf(MAX_HAND_SWING));
             stConstraint->setSwingLimits(minDots);
-            
+
             constraint = static_cast<RotationConstraint*>(stConstraint);
         } else if (baseName.startsWith("Shoulder", Qt::CaseInsensitive)) {
             SwingTwistConstraint* stConstraint = new SwingTwistConstraint();

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -50,23 +50,17 @@ protected:
             rotationVar(rotationVarIn),
             jointName(jointNameIn),
             jointIndex(-1),
-            hasPerformedJointLookup(false) {}
+            rootIndex(-1) {}
 
         std::string positionVar;
         std::string rotationVar;
         QString jointName;
         int jointIndex; // cached joint index
-        bool hasPerformedJointLookup = false;
-    };
-
-    struct IKTarget {
-        AnimPose pose;
-        int rootIndex;
+        int rootIndex; // cached root index
     };
 
     std::map<int, RotationConstraint*> _constraints;
     std::vector<IKTargetVar> _targetVarVec;
-    std::map<int, IKTarget> _absoluteTargets; // IK targets of end-points
     AnimPoseVec _defaultRelativePoses; // poses of the relaxed state
     AnimPoseVec _relativePoses; // current relative poses
 

--- a/libraries/animation/src/AnimVariant.h
+++ b/libraries/animation/src/AnimVariant.h
@@ -154,6 +154,8 @@ public:
     void setTrigger(const std::string& key) { _triggers.insert(key); }
     void clearTriggers() { _triggers.clear(); }
 
+    bool hasKey(const std::string& key) const { return _map.find(key) != _map.end(); }
+
 protected:
     std::map<std::string, AnimVariant> _map;
     std::set<std::string> _triggers;


### PR DESCRIPTION
This PR fixes two bugs:

(1)  On login: the avatar's IK targets are above the head but get corrected as soon as the hand controllers are actually used.

(2) Sometimes the IK solution will "flutter" with small glitches (these small glitches actually corresponded to momentarily bad FPS).

The bug below is NOT yet fixed:

(1) The hand IK targets should be disabled when the hydra controllers are placed on their orb station.