### PR TITLE
Fix the lighting issue when the Rear View mirror is enabled

### DIFF
--- a/libraries/gpu/src/gpu/Resource.h
+++ b/libraries/gpu/src/gpu/Resource.h
@@ -160,15 +160,22 @@ typedef std::vector< BufferPointer > Buffers;
 
 
 class BufferView {
+protected: 
+    void initFromBuffer(const BufferPointer& buffer) {
+        _buffer = (buffer);
+        if (_buffer) {
+            _size = (buffer->getSize());
+        }
+    }
 public:
     typedef Resource::Size Size;
     typedef int Index;
 
     BufferPointer _buffer;
-    Size _offset;
-    Size _size;
+    Size _offset{ 0 };
+    Size _size{ 0 };
     Element _element;
-    uint16 _stride;
+    uint16 _stride{ 1 };
 
     BufferView() :
         _buffer(NULL),
@@ -188,19 +195,19 @@ public:
 
     // create the BufferView and own the Buffer
     BufferView(Buffer* newBuffer, const Element& element = Element(gpu::SCALAR, gpu::UINT8, gpu::RAW)) :
-        _buffer(newBuffer),
         _offset(0),
-        _size(newBuffer->getSize()),
         _element(element),
         _stride(uint16(element.getSize()))
-    {};
+    {
+        initFromBuffer(BufferPointer(newBuffer));
+    };
     BufferView(const BufferPointer& buffer, const Element& element = Element(gpu::SCALAR, gpu::UINT8, gpu::RAW)) :
-        _buffer(buffer),
         _offset(0),
-        _size(buffer->getSize()),
         _element(element),
         _stride(uint16(element.getSize()))
-    {};
+    {
+        initFromBuffer(buffer);
+    };
     BufferView(const BufferPointer& buffer, Size offset, Size size, const Element& element = Element(gpu::SCALAR, gpu::UINT8, gpu::RAW)) :
         _buffer(buffer),
         _offset(offset),

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -582,6 +582,7 @@ void DeferredLightingEffect::render(RenderArgs* args) {
     batch.setResourceTexture(1, nullptr);
     batch.setResourceTexture(2, nullptr);
     batch.setResourceTexture(3, nullptr);
+    batch.setUniformBuffer(_directionalLightLocations->deferredTransformBuffer, nullptr);
 
     args->_context->render(batch);
 


### PR DESCRIPTION
- We have the issue that the uniform buffer when bound to the COntext cannot be updated correctly by the sync / version mechanism
 I will need to look at that into more details


- For now just unbind the "deferredTransformBuffer" at the end of the deferred pass and we are good

- added a simple check on the BufferView so we can initialize it with nullptr for the buffer