### PR TITLE
Fix for getEyePose in OpenVRDisplayPlugin

### DIFF
--- a/libraries/display-plugins/src/display-plugins/openvr/OpenVrDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/openvr/OpenVrDisplayPlugin.cpp
@@ -161,7 +161,7 @@ void OpenVrDisplayPlugin::resetSensors() {
 }
 
 glm::mat4 OpenVrDisplayPlugin::getEyePose(Eye eye) const {
-    return _eyesData[eye]._eyeOffset * getHeadPose();
+    return getHeadPose() * _eyesData[eye]._eyeOffset;
 }
 
 glm::mat4 OpenVrDisplayPlugin::getHeadPose() const {


### PR DESCRIPTION
This should fix a rather painful bug in the Vive where the IPD was not correct for all head orientations.