### PR TITLE
blend rotations between distinct IK end effector solutions

### DIFF
--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -262,12 +262,10 @@ const AnimPoseVec& AnimInverseKinematics::evaluate(const AnimVariantMap& animVar
             }
 
             // only update the absolutePoses that need it: those between lowestMovedIndex and _maxTargetIndex
-            if (lowestMovedIndex < _maxTargetIndex) {
-                for (int i = lowestMovedIndex; i < _maxTargetIndex; ++i) {
-                    int parentIndex = _skeleton->getParentIndex(i);
-                    if (parentIndex != -1) {
-                        absolutePoses[i] = absolutePoses[parentIndex] * _relativePoses[i];
-                    }
+            for (int i = lowestMovedIndex; i <= _maxTargetIndex; ++i) {
+                int parentIndex = _skeleton->getParentIndex(i);
+                if (parentIndex != -1) {
+                    absolutePoses[i] = absolutePoses[parentIndex] * _relativePoses[i];
                 }
             }
         } while (largestError > ACCEPTABLE_RELATIVE_ERROR && numLoops < MAX_IK_LOOPS && usecTimestampNow() < expiry);

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -263,7 +263,7 @@ const AnimPoseVec& AnimInverseKinematics::evaluate(const AnimVariantMap& animVar
 
             // only update the absolutePoses that need it: those between lowestMovedIndex and _maxTargetIndex
             if (lowestMovedIndex < _maxTargetIndex) {
-                for (int i = lowestMovedIndex; i <= _maxTargetIndex; ++i) {
+                for (int i = lowestMovedIndex; i < _maxTargetIndex; ++i) {
                     int parentIndex = _skeleton->getParentIndex(i);
                     if (parentIndex != -1) {
                         absolutePoses[i] = absolutePoses[parentIndex] * _relativePoses[i];

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -12,40 +12,14 @@
 
 #include <string>
 
+#include <map>
+#include <vector>
+
 #include "AnimNode.h"
 
+#include "RotationAccumulator.h"
+
 class RotationConstraint;
-
-class RotationAccumulator {
-public:
-    RotationAccumulator() {}
-
-    uint32_t size() const { return _rotations.size(); }
-
-    void add(const glm::quat& rotation) { _rotations.push_back(rotation); }
-
-    glm::quat getAverage() {
-        glm::quat average;
-        uint32_t numRotations = _rotations.size();
-        if (numRotations > 0) {
-            average = _rotations[0];
-            for (uint32_t i = 1; i < numRotations; ++i) {
-                glm::quat rotation = _rotations[i];
-                if (glm::dot(average, rotation) < 0.0f) {
-                    rotation = -rotation;
-                }
-                average += rotation;
-            }
-            average = glm::normalize(average);
-        }
-        return average;
-    }
-
-    void clear() { _rotations.clear(); }
-
-private:
-    std::vector<glm::quat> _rotations;
-};
 
 class AnimInverseKinematics : public AnimNode {
 public:

--- a/libraries/animation/src/RotationAccumulator.cpp
+++ b/libraries/animation/src/RotationAccumulator.cpp
@@ -12,14 +12,12 @@
 #include <glm/gtx/quaternion.hpp>
 
 void RotationAccumulator::add(glm::quat rotation) {
-    if (_numRotations == 0) {
-        _rotationSum = rotation;
-    } else {
-        if (glm::dot(_rotationSum, rotation) < 0.0f) {
-            rotation = -rotation;
-        }
-        _rotationSum += rotation;
+    // make sure both quaternions are on the same hyper-hemisphere before we add them
+    if (glm::dot(_rotationSum, rotation) < 0.0f) {
+        rotation = -rotation;
     }
+    // sum the rotation linearly (lerp)
+    _rotationSum += rotation;
     ++_numRotations;
 }
 

--- a/libraries/animation/src/RotationAccumulator.cpp
+++ b/libraries/animation/src/RotationAccumulator.cpp
@@ -11,19 +11,18 @@
 
 #include <glm/gtx/quaternion.hpp>
 
-glm::quat RotationAccumulator::getAverage() {
-    glm::quat average;
-    uint32_t numRotations = _rotations.size();
-    if (numRotations > 0) {
-        average = _rotations[0];
-        for (uint32_t i = 1; i < numRotations; ++i) {
-            glm::quat rotation = _rotations[i];
-            if (glm::dot(average, rotation) < 0.0f) {
-                rotation = -rotation;
-            }
-            average += rotation;
+void RotationAccumulator::add(glm::quat rotation) {
+    if (_numRotations == 0) {
+        _rotationSum = rotation;
+    } else {
+        if (glm::dot(_rotationSum, rotation) < 0.0f) {
+            rotation = -rotation;
         }
-        average = glm::normalize(average);
+        _rotationSum += rotation;
     }
-    return average;
+    ++_numRotations;
+}
+
+glm::quat RotationAccumulator::getAverage() {
+    return (_numRotations > 0) ?  glm::normalize(_rotationSum) : glm::quat();
 }

--- a/libraries/animation/src/RotationAccumulator.cpp
+++ b/libraries/animation/src/RotationAccumulator.cpp
@@ -1,0 +1,29 @@
+//
+//  RotationAccumulator.h
+//
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "RotationAccumulator.h"
+
+#include <glm/gtx/quaternion.hpp>
+
+glm::quat RotationAccumulator::getAverage() {
+    glm::quat average;
+    uint32_t numRotations = _rotations.size();
+    if (numRotations > 0) {
+        average = _rotations[0];
+        for (uint32_t i = 1; i < numRotations; ++i) {
+            glm::quat rotation = _rotations[i];
+            if (glm::dot(average, rotation) < 0.0f) {
+                rotation = -rotation;
+            }
+            average += rotation;
+        }
+        average = glm::normalize(average);
+    }
+    return average;
+}

--- a/libraries/animation/src/RotationAccumulator.cpp
+++ b/libraries/animation/src/RotationAccumulator.cpp
@@ -20,3 +20,8 @@ void RotationAccumulator::add(glm::quat rotation) {
 glm::quat RotationAccumulator::getAverage() {
     return (_numRotations > 0) ?  glm::normalize(_rotationSum) : glm::quat();
 }
+
+void RotationAccumulator::clear() { 
+    _rotationSum *= 0.0f;
+    _numRotations = 0;
+}

--- a/libraries/animation/src/RotationAccumulator.cpp
+++ b/libraries/animation/src/RotationAccumulator.cpp
@@ -12,12 +12,8 @@
 #include <glm/gtx/quaternion.hpp>
 
 void RotationAccumulator::add(glm::quat rotation) {
-    // make sure both quaternions are on the same hyper-hemisphere before we add them
-    if (glm::dot(_rotationSum, rotation) < 0.0f) {
-        rotation = -rotation;
-    }
-    // sum the rotation linearly (lerp)
-    _rotationSum += rotation;
+    // make sure both quaternions are on the same hyper-hemisphere before we add them linearly (lerp)
+    _rotationSum += copysignf(1.0f, glm::dot(_rotationSum, rotation)) * rotation;
     ++_numRotations;
 }
 

--- a/libraries/animation/src/RotationAccumulator.h
+++ b/libraries/animation/src/RotationAccumulator.h
@@ -22,7 +22,7 @@ public:
 
     glm::quat getAverage();
 
-    void clear() { _numRotations = 0; }
+    void clear();
 
 private:
     glm::quat _rotationSum;

--- a/libraries/animation/src/RotationAccumulator.h
+++ b/libraries/animation/src/RotationAccumulator.h
@@ -14,6 +14,8 @@
 
 class RotationAccumulator {
 public:
+    RotationAccumulator() : _rotationSum(0.0f, 0.0f, 0.0f, 0.0f), _numRotations(0) { }
+
     int size() const { return _numRotations; }
 
     void add(glm::quat rotation);
@@ -24,7 +26,7 @@ public:
 
 private:
     glm::quat _rotationSum;
-    int _numRotations = 0;
+    int _numRotations;
 };
 
 #endif // hifi_RotationAccumulator_h

--- a/libraries/animation/src/RotationAccumulator.h
+++ b/libraries/animation/src/RotationAccumulator.h
@@ -10,25 +10,21 @@
 #ifndef hifi_RotationAccumulator_h
 #define hifi_RotationAccumulator_h
 
-#include <vector>
-
 #include <glm/gtc/quaternion.hpp>
-#include <glm/gtx/quaternion.hpp>
 
 class RotationAccumulator {
 public:
-    RotationAccumulator() {}
+    int size() const { return _numRotations; }
 
-    uint32_t size() const { return _rotations.size(); }
-
-    void add(const glm::quat& rotation) { _rotations.push_back(rotation); }
+    void add(glm::quat rotation);
 
     glm::quat getAverage();
 
-    void clear() { _rotations.clear(); }
+    void clear() { _numRotations = 0; }
 
 private:
-    std::vector<glm::quat> _rotations;
+    glm::quat _rotationSum;
+    int _numRotations = 0;
 };
 
 #endif // hifi_RotationAccumulator_h

--- a/libraries/animation/src/RotationAccumulator.h
+++ b/libraries/animation/src/RotationAccumulator.h
@@ -1,0 +1,34 @@
+//
+//  RotationAccumulator.h
+//
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_RotationAccumulator_h
+#define hifi_RotationAccumulator_h
+
+#include <vector>
+
+#include <glm/gtc/quaternion.hpp>
+#include <glm/gtx/quaternion.hpp>
+
+class RotationAccumulator {
+public:
+    RotationAccumulator() {}
+
+    uint32_t size() const { return _rotations.size(); }
+
+    void add(const glm::quat& rotation) { _rotations.push_back(rotation); }
+
+    glm::quat getAverage();
+
+    void clear() { _rotations.clear(); }
+
+private:
+    std::vector<glm::quat> _rotations;
+};
+
+#endif // hifi_RotationAccumulator_h


### PR DESCRIPTION
This PR fixes most of the "locked shoulders" problem where movement of the avatar hands has zero effect on the rotation of the shoulders.  As we iterate over the skeleton for each IK target we solve the rotations without moving the skeleton and accumulate all of the rotation changes for each joint.  Then once we've made a pass for all of the constraints we average the final results.  Wash, rinse, repeat.  The final effect is to give the IK targets equal influence over the joints further up the hierarchy.

Note: the head still has a translation target for screener mode so the spine doesn't move much for this case, however once we remove the translation aspect of that target the head and shoulders should move around fine.  I tested this disabling the third (head) target but didn't want to commit that hack since I suspect it the code is still necessary for passing the head translation for HMD mode.