### PR TITLE
Instanced rendering for Box entities

### DIFF
--- a/examples/cubePerfTest.js
+++ b/examples/cubePerfTest.js
@@ -16,7 +16,7 @@ var PARTICLE_MAX_SIZE = 2.50;
 var LIFETIME = 600;
 var boxes = [];
 
-var ids = Entities.findEntities({ x: 512, y: 512, z: 512 }, 50);
+var ids = Entities.findEntities(MyAvatar.position, 50);
 for (var i = 0; i < ids.length; i++) {
     var id = ids[i];
     var properties = Entities.getEntityProperties(id);
@@ -33,10 +33,10 @@ for (var x = 0; x < SIDE_SIZE; x++) {
             var gray = Math.random() * 155;
             var cube = Math.random() > 0.5;
             var color = { red: 100 + gray, green: 100 + gray, blue: 100 + gray };
-            var position = { x: 512 + x * 0.2, y: 512 + y * 0.2, z: 512 + z * 0.2};
+            var position = Vec3.sum(MyAvatar.position, { x: x * 0.2, y: y * 0.2, z: z * 0.2});
             var radius = Math.random() * 0.1;
             boxes.push(Entities.addEntity({ 
-                type: cube ? "Box" : "Sphere",
+                type: cube ? "Box" : "Box",
                 name: "PerfTest",
                 position: position,  
                 dimensions: { x: radius, y: radius, z: radius }, 

--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
@@ -39,9 +39,6 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
     PerformanceTimer perfTimer("RenderableBoxEntityItem::render");
     Q_ASSERT(getType() == EntityTypes::Box);
     Q_ASSERT(args->_batch);
-    gpu::Batch& batch = *args->_batch;
-    batch.setModelTransform(getTransformToCenter()); // we want to include the scale as well
-    glm::vec4 cubeColor(toGlm(getXColor()), getLocalRenderAlpha());
 
     if (!_procedural) {
         _procedural.reset(new Procedural(this->getUserData()));
@@ -54,11 +51,15 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
             gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
     }
 
+    gpu::Batch& batch = *args->_batch;
+    glm::vec4 cubeColor(toGlm(getXColor()), getLocalRenderAlpha());
+
     if (_procedural->ready()) {
+        batch.setModelTransform(getTransformToCenter()); // we want to include the scale as well
         _procedural->prepare(batch, this->getDimensions());
         DependencyManager::get<GeometryCache>()->renderSolidCube(batch, 1.0f, _procedural->getColor(cubeColor));
     } else {
-        DependencyManager::get<DeferredLightingEffect>()->renderSolidCube(batch, 1.0f, cubeColor);
+        DependencyManager::get<DeferredLightingEffect>()->renderSolidCubeInstance(batch, getTransformToCenter(), cubeColor);
     }
 
     RenderableDebugableEntityItem::render(this, args);

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -120,6 +120,18 @@ enum Dimension {
     MAT4,
     NUM_DIMENSIONS,
 };
+
+// Count (of scalars) in an Element for a given Dimension
+static const int LOCATION_COUNT[NUM_DIMENSIONS] = {
+    1,
+    1,
+    1,
+    1,
+    1,
+    3,
+    4,
+};
+
 // Count (of scalars) in an Element for a given Dimension
 static const int DIMENSION_COUNT[NUM_DIMENSIONS] = {
     1,
@@ -127,8 +139,8 @@ static const int DIMENSION_COUNT[NUM_DIMENSIONS] = {
     3,
     4,
     4,
-    9,
-    16,
+    3,
+    4,
 };
 
 // Semantic of an Element
@@ -184,6 +196,7 @@ public:
 
     Dimension getDimension() const { return (Dimension)_dimension; }
     uint8 getDimensionCount() const { return  DIMENSION_COUNT[(Dimension)_dimension]; }
+    uint8 getLocationCount() const { return  LOCATION_COUNT[(Dimension)_dimension]; }
 
     Type getType() const { return (Type)_type; }
     bool isNormalized() const { return (getType() >= NFLOAT); }

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -191,6 +191,9 @@ void GLBackend::renderPassDraw(Batch& batch) {
 }
 
 void GLBackend::render(Batch& batch) {
+    // Finalize the batch by moving all the instanced rendering into the command buffer
+    batch.preExecute();
+
     _stereo._skybox = batch.isSkyboxEnabled();
     // Allow the batch to override the rendering stereo settings
     // for things like full framebuffer copy operations (deferred lighting passes)
@@ -316,7 +319,19 @@ void GLBackend::do_drawInstanced(Batch& batch, uint32 paramOffset) {
 }
 
 void GLBackend::do_drawIndexedInstanced(Batch& batch, uint32 paramOffset) {
-    (void) CHECK_GL_ERROR();
+    updateInput();
+    updateTransform();
+    updatePipeline();
+
+    GLint numInstances = batch._params[paramOffset + 4]._uint;
+    GLenum mode = _primitiveToGLmode[(Primitive)batch._params[paramOffset + 3]._uint];
+    uint32 numIndices = batch._params[paramOffset + 2]._uint;
+    uint32 startIndex = batch._params[paramOffset + 1]._uint;
+    uint32 startInstance = batch._params[paramOffset + 0]._uint;
+    GLenum glType = _elementTypeToGLType[_input._indexBufferType];
+
+    glDrawElementsInstanced(mode, numIndices, glType, nullptr, numInstances);
+    (void)CHECK_GL_ERROR();
 }
 
 void GLBackend::do_resetStages(Batch& batch, uint32 paramOffset) {

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -75,6 +75,11 @@ void makeBindings(GLBackend::GLShader* shader) {
         glBindAttribLocation(glprogram, gpu::Stream::SKIN_CLUSTER_WEIGHT, "inSkinClusterWeight");
     }
 
+    loc = glGetAttribLocation(glprogram, "inInstanceTransform");
+    if (loc >= 0 && loc != gpu::Stream::INSTANCE_XFM) {
+        glBindAttribLocation(glprogram, gpu::Stream::INSTANCE_XFM, "inInstanceTransform");
+    }
+
     // Link again to take into account the assigned attrib location
     glLinkProgram(glprogram);
 

--- a/libraries/gpu/src/gpu/Inputs.slh
+++ b/libraries/gpu/src/gpu/Inputs.slh
@@ -18,4 +18,5 @@ in vec4 inTangent;
 in vec4 inSkinClusterIndex;
 in vec4 inSkinClusterWeight;
 in vec4 inTexCoord1;
+in mat4 inInstanceTransform;
 <@endif@>

--- a/libraries/gpu/src/gpu/Resource.h
+++ b/libraries/gpu/src/gpu/Resource.h
@@ -139,6 +139,11 @@ public:
     // \return the number of bytes copied
     Size append(Size size, const Byte* data);
 
+    template <typename T> 
+    Size append(const T& t) {
+        return append(sizeof(t), reinterpret_cast<const Byte*>(&t));
+    }
+
     // Access the sysmem object.
     const Sysmem& getSysmem() const { assert(_sysmem); return (*_sysmem); }
     Sysmem& editSysmem() { assert(_sysmem); return (*_sysmem); }

--- a/libraries/gpu/src/gpu/Stream.h
+++ b/libraries/gpu/src/gpu/Stream.h
@@ -35,11 +35,12 @@ public:
         SKIN_CLUSTER_INDEX = 5,
         SKIN_CLUSTER_WEIGHT = 6,
         TEXCOORD1 = 7,
-        INSTANCE_XFM = 8,
-        INSTANCE_SCALE = 9,
-        INSTANCE_TRANSLATE = 10,
+        INSTANCE_SCALE = 8,
+        INSTANCE_TRANSLATE = 9,
+        INSTANCE_XFM = 10,
 
-        NUM_INPUT_SLOTS,
+        // Instance XFM is a mat4, and as such takes up 4 slots
+        NUM_INPUT_SLOTS = INSTANCE_XFM + 4,
     };
 
     typedef uint8 Slot;

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -53,6 +53,15 @@ TransformCamera getTransformCamera() {
     }
 <@endfunc@>
 
+<@func transformInstancedModelToClipPos(cameraTransform, objectTransform, modelPos, clipPos)@>
+    <!// Equivalent to the following but hoppefully a tad more accurate
+      //return camera._projection * camera._view * object._model * pos; !>
+    { // transformModelToClipPos
+        vec4 _eyepos = (inInstanceTransform * <$modelPos$>) + vec4(-<$modelPos$>.w * <$cameraTransform$>._viewInverse[3].xyz, 0.0);
+        <$clipPos$> = <$cameraTransform$>._projectionViewUntranslated * _eyepos;
+    }
+<@endfunc@>
+
 <@func $transformModelToEyeAndClipPos(cameraTransform, objectTransform, modelPos, eyePos, clipPos)@>
     <!// Equivalent to the following but hoppefully a tad more accurate
       //return camera._projection * camera._view * object._model * pos; !>
@@ -65,9 +74,28 @@ TransformCamera getTransformCamera() {
     }
 <@endfunc@>
 
+<@func $transformInstancedModelToEyeAndClipPos(cameraTransform, objectTransform, modelPos, eyePos, clipPos)@>
+    <!// Equivalent to the following but hoppefully a tad more accurate
+      //return camera._projection * camera._view * object._model * pos; !>
+    { // transformModelToClipPos
+        vec4 _worldpos = (inInstanceTransform * <$modelPos$>);
+        <$eyePos$> = (<$cameraTransform$>._view * _worldpos);
+        vec4 _eyepos =(inInstanceTransform * <$modelPos$>) + vec4(-<$modelPos$>.w * <$cameraTransform$>._viewInverse[3].xyz, 0.0);
+        <$clipPos$> = <$cameraTransform$>._projectionViewUntranslated * _eyepos;
+      //  <$eyePos$> = (<$cameraTransform$>._projectionInverse * <$clipPos$>);
+    }
+<@endfunc@>
+
+
 <@func transformModelToWorldPos(objectTransform, modelPos, worldPos)@>
     { // transformModelToWorldPos
         <$worldPos$> = (<$objectTransform$>._model * <$modelPos$>);
+    }
+<@endfunc@>
+
+<@func transformInstancedModelToWorldPos(objectTransform, modelPos, worldPos)@>
+    { // transformModelToWorldPos
+        <$worldPos$> = (inInstanceTransform * <$modelPos$>);
     }
 <@endfunc@>
 
@@ -76,6 +104,21 @@ TransformCamera getTransformCamera() {
         vec3 mr0 = vec3(<$objectTransform$>._modelInverse[0].x, <$objectTransform$>._modelInverse[1].x, <$objectTransform$>._modelInverse[2].x);
         vec3 mr1 = vec3(<$objectTransform$>._modelInverse[0].y, <$objectTransform$>._modelInverse[1].y, <$objectTransform$>._modelInverse[2].y);
         vec3 mr2 = vec3(<$objectTransform$>._modelInverse[0].z, <$objectTransform$>._modelInverse[1].z, <$objectTransform$>._modelInverse[2].z);
+
+        vec3 mvc0 = vec3(dot(<$cameraTransform$>._viewInverse[0].xyz, mr0), dot(<$cameraTransform$>._viewInverse[0].xyz, mr1), dot(<$cameraTransform$>._viewInverse[0].xyz, mr2));
+        vec3 mvc1 = vec3(dot(<$cameraTransform$>._viewInverse[1].xyz, mr0), dot(<$cameraTransform$>._viewInverse[1].xyz, mr1), dot(<$cameraTransform$>._viewInverse[1].xyz, mr2));
+        vec3 mvc2 = vec3(dot(<$cameraTransform$>._viewInverse[2].xyz, mr0), dot(<$cameraTransform$>._viewInverse[2].xyz, mr1), dot(<$cameraTransform$>._viewInverse[2].xyz, mr2));
+
+        <$eyeDir$> = vec3(dot(mvc0, <$modelDir$>), dot(mvc1, <$modelDir$>), dot(mvc2, <$modelDir$>));
+    }
+<@endfunc@>
+
+<@func transformInstancedModelToEyeDir(cameraTransform, objectTransform, modelDir, eyeDir)@>
+    { // transformModelToEyeDir
+        mat4 modelInverse = inverse(inInstanceTransform);
+        vec3 mr0 = vec3(modelInverse[0].x, modelInverse[1].x, modelInverse[2].x);
+        vec3 mr1 = vec3(modelInverse[0].y, modelInverse[1].y, modelInverse[2].y);
+        vec3 mr2 = vec3(modelInverse[0].z, modelInverse[1].z, modelInverse[2].z);
 
         vec3 mvc0 = vec3(dot(<$cameraTransform$>._viewInverse[0].xyz, mr0), dot(<$cameraTransform$>._viewInverse[0].xyz, mr1), dot(<$cameraTransform$>._viewInverse[0].xyz, mr2));
         vec3 mvc1 = vec3(dot(<$cameraTransform$>._viewInverse[1].xyz, mr0), dot(<$cameraTransform$>._viewInverse[1].xyz, mr1), dot(<$cameraTransform$>._viewInverse[1].xyz, mr2));

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -37,8 +37,12 @@ public:
     void init(AbstractViewStateInterface* viewState);
 
     /// Sets up the state necessary to render static untextured geometry with the simple program.
-    void bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
+    gpu::PipelinePointer bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
                            bool emmisive = false, bool depthBias = false);
+
+    /// Sets up the state necessary to render static untextured geometry with the simple program.
+    void bindInstanceProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
+        bool emmisive = false, bool depthBias = false);
 
     //// Renders a solid sphere with the simple program.
     void renderSolidSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color);
@@ -46,6 +50,9 @@ public:
     //// Renders a wireframe sphere with the simple program.
     void renderWireSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec4& color);
     
+    //// Renders a solid cube using instancing.  Transform should include scaling.
+    void renderSolidCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
+
     //// Renders a solid cube with the simple program.
     void renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color);
 

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -131,6 +131,11 @@ public:
     virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
                                                     bool delayLoad, const void* extra);
 
+    gpu::BufferPointer getCubeVertices(float size);
+    void setupCubeVertices(gpu::Batch& batch, gpu::BufferPointer& verticesBuffer);
+
+    gpu::BufferPointer getSolidCubeIndices();
+
     void renderSphere(gpu::Batch& batch, float radius, int slices, int stacks, const glm::vec3& color, bool solid = true, int id = UNKNOWN_ID) 
                 { renderSphere(batch, radius, slices, stacks, glm::vec4(color, 1.0f), solid, id); }
                 
@@ -139,6 +144,7 @@ public:
     void renderGrid(gpu::Batch& batch, int xDivisions, int yDivisions, const glm::vec4& color);
     void renderGrid(gpu::Batch& batch, int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id = UNKNOWN_ID);
 
+    void renderSolidCubeInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer transformBuffer, gpu::BufferPointer colorBuffer);
     void renderSolidCube(gpu::Batch& batch, float size, const glm::vec4& color);
     void renderWireCube(gpu::Batch& batch, float size, const glm::vec4& color);
     void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id = UNKNOWN_ID);

--- a/libraries/render-utils/src/simple.slv
+++ b/libraries/render-utils/src/simple.slv
@@ -18,6 +18,7 @@
 
 <$declareStandardTransform()$>
 
+uniform bool Instanced = false;
 // the interpolated normal
 
 out vec3 _normal;
@@ -33,6 +34,11 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
-    <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
+    if (Instanced) {
+        <$transformInstancedModelToClipPos(cam, obj, inPosition, gl_Position)$>
+        <$transformInstancedModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
+    } else {
+        <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
+        <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
+    }
 }


### PR DESCRIPTION
The primary purpose of this PR is to prototype a technique that is needed in our rendering system.  Right now all something that's rendering a batch can do is call functions that result in renders.  What we want to enable is the ability to *register* functions that will be called when the batch is executed, as well as appending to buffers used by those registered functions.  This will enable us to use GL functions like `glDrawInstanced`, `glMultiDrawIndirect`, etc.  

Using such functions will produce the same rendered content on our screens as the current code, but requires far fewer calls per object.  So if we want to render 1000 cubes, instead of calling 1000 functions, we call 1, with a buffer that contains 1000 transforms.

Completing this task will serve as a template for implementing multi-draw indirect functionality which in turn will improve the performance in large complex scenes like the toybox windmill.