### PR TITLE
Cruft removal machine

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3648,14 +3648,6 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         sceneInterface->setEngineDrawnOverlay3DItems(engineRC->_numDrawnOverlay3DItems);
     }
 
-    if (!selfAvatarOnly) {
-        // give external parties a change to hook in
-        {
-            PerformanceTimer perfTimer("inWorldInterface");
-            emit renderingInWorldInterface();
-        }
-    }
-
     activeRenderingThread = nullptr;
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1063,7 +1063,7 @@ void Application::paintGL() {
     auto lodManager = DependencyManager::get<LODManager>();
 
 
-    RenderArgs renderArgs(_gpuContext, nullptr, getViewFrustum(), lodManager->getOctreeSizeScale(),
+    RenderArgs renderArgs(_gpuContext, getEntities(), getViewFrustum(), lodManager->getOctreeSizeScale(),
                           lodManager->getBoundaryLevelAdjust(), RenderArgs::DEFAULT_RENDER_MODE,
                           RenderArgs::MONO, RenderArgs::RENDER_DEBUG_NONE);
 
@@ -3562,7 +3562,6 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
                     (RenderArgs::DebugFlags) (renderDebugFlags | (int)RenderArgs::RENDER_DEBUG_SIMULATION_OWNERSHIP);
             }
             renderArgs->_debugFlags = renderDebugFlags;
-            _entities.render(renderArgs);
             //ViveControllerManager::getInstance().updateRendering(renderArgs, _main3DScene, pendingChanges);
         }
     }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -347,9 +347,6 @@ signals:
     /// Fired when we're simulating; allows external parties to hook in.
     void simulating(float deltaTime);
 
-    /// Fired when we're rendering in-world interface elements; allows external parties to hook in.
-    void renderingInWorldInterface();
-
     /// Fired when the import window is closed
     void importDone();
 

--- a/interface/src/scripting/GlobalServicesScriptingInterface.cpp
+++ b/interface/src/scripting/GlobalServicesScriptingInterface.cpp
@@ -22,8 +22,10 @@ GlobalServicesScriptingInterface::GlobalServicesScriptingInterface() {
     connect(&accountManager, &AccountManager::logoutComplete, this, &GlobalServicesScriptingInterface::loggedOut);
 
     _downloading = false;
-    connect(Application::getInstance(), &Application::renderingInWorldInterface, 
-            this, &GlobalServicesScriptingInterface::checkDownloadInfo);
+    QTimer* checkDownloadTimer = new QTimer(this);
+    connect(checkDownloadTimer, &QTimer::timeout, this, &GlobalServicesScriptingInterface::checkDownloadInfo);
+    const int CHECK_DOWNLOAD_INTERVAL = MSECS_PER_SECOND / 2;
+    checkDownloadTimer->start(CHECK_DOWNLOAD_INTERVAL);
 
     auto discoverabilityManager = DependencyManager::get<DiscoverabilityManager>();
     connect(discoverabilityManager.data(), &DiscoverabilityManager::discoverabilityModeChanged,

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -149,6 +149,7 @@ void EntityTreeRenderer::update() {
         }
 
     }
+    deleteReleasedModels();
 }
 
 void EntityTreeRenderer::checkEnterLeaveEntities() {
@@ -332,13 +333,6 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
         _viewState->endOverrideEnvironmentData();
         scene->getSkyStage()->setBackgroundMode(model::SunSkyStage::SKY_DOME);  // let the application atmosphere through
     }
-}
-
-void EntityTreeRenderer::render(RenderArgs* renderArgs) {
-    // FIXME - currently the EntityItem rendering code still depends on knowing about the EntityTreeRenderer
-    // because it uses it as a model loading service. We don't actually do anything in rendering other than this.
-    renderArgs->_renderer = this;
-    deleteReleasedModels(); // seems like as good as any other place to do some memory cleanup
 }
 
 const FBXGeometry* EntityTreeRenderer::getGeometryForEntity(EntityItemPointer entityItem) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -40,7 +40,7 @@ public:
     virtual char getMyNodeType() const { return NodeType::EntityServer; }
     virtual PacketType getMyQueryMessageType() const { return PacketType::EntityQuery; }
     virtual PacketType getExpectedPacketType() const { return PacketType::EntityData; }
-    virtual void renderElement(OctreeElementPointer element, RenderArgs* args);
+    virtual void renderElement(OctreeElementPointer element, RenderArgs* args) { }
     virtual float getSizeScale() const;
     virtual int getBoundaryLevelAdjust() const;
     virtual void setTree(OctreePointer newTree);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -40,7 +40,6 @@ public:
     virtual char getMyNodeType() const { return NodeType::EntityServer; }
     virtual PacketType getMyQueryMessageType() const { return PacketType::EntityQuery; }
     virtual PacketType getExpectedPacketType() const { return PacketType::EntityData; }
-    virtual void renderElement(OctreeElementPointer element, RenderArgs* args) { }
     virtual float getSizeScale() const;
     virtual int getBoundaryLevelAdjust() const;
     virtual void setTree(OctreePointer newTree);
@@ -53,7 +52,6 @@ public:
     void processEraseMessage(NLPacket& packet, const SharedNodePointer& sourceNode);
 
     virtual void init();
-    virtual void render(RenderArgs* renderArgs) override { }
 
     virtual const FBXGeometry* getGeometryForEntity(EntityItemPointer entityItem);
     virtual const Model* getModelForEntityItem(EntityItemPointer entityItem);
@@ -128,7 +126,6 @@ private:
     void addEntityToScene(EntityItemPointer entity);
 
     void applyZonePropertiesToScene(std::shared_ptr<ZoneEntityItem> zone);
-    void renderElementProxy(EntityTreeElementPointer entityTreeElement, RenderArgs* args);
     void checkAndCallPreload(const EntityItemID& entityID, const bool reload = false);
 
     QList<Model*> _releasedModels;

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -53,7 +53,7 @@ public:
     void processEraseMessage(NLPacket& packet, const SharedNodePointer& sourceNode);
 
     virtual void init();
-    virtual void render(RenderArgs* renderArgs) override;
+    virtual void render(RenderArgs* renderArgs) override { }
 
     virtual const FBXGeometry* getGeometryForEntity(EntityItemPointer entityItem);
     virtual const Model* getModelForEntityItem(EntityItemPointer entityItem);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -114,9 +114,7 @@ public slots:
     void updateEntityRenderStatus(bool shouldRenderEntities);
 
     // optional slots that can be wired to menu items
-    void setDisplayElementChildProxies(bool value) { _displayElementChildProxies = value; }
     void setDisplayModelBounds(bool value) { _displayModelBounds = value; }
-    void setDisplayModelElementProxy(bool value) { _displayModelElementProxy = value; }
     void setDontDoPrecisionPicking(bool value) { _dontDoPrecisionPicking = value; }
 
 protected:
@@ -134,7 +132,6 @@ private:
     void checkAndCallPreload(const EntityItemID& entityID, const bool reload = false);
 
     QList<Model*> _releasedModels;
-    void renderProxies(EntityItemPointer entity, RenderArgs* args);
     RayToEntityIntersectionResult findRayIntersectionWorker(const PickRay& ray, Octree::lockType lockType,
                                                                 bool precisionPicking);
 
@@ -157,9 +154,7 @@ private:
     MouseEvent _lastMouseEvent;
     AbstractViewStateInterface* _viewState;
     AbstractScriptingServicesInterface* _scriptingServices;
-    bool _displayElementChildProxies;
     bool _displayModelBounds;
-    bool _displayModelElementProxy;
     bool _dontDoPrecisionPicking;
     
     bool _shuttingDown = false;

--- a/libraries/octree/src/OctreeRenderer.h
+++ b/libraries/octree/src/OctreeRenderer.h
@@ -38,7 +38,7 @@ public:
     virtual char getMyNodeType() const = 0;
     virtual PacketType getMyQueryMessageType() const = 0;
     virtual PacketType getExpectedPacketType() const = 0;
-    virtual void renderElement(OctreeElementPointer element, RenderArgs* args) = 0;
+    virtual void renderElement(OctreeElementPointer element, RenderArgs* args) { }
     virtual float getSizeScale() const { return DEFAULT_OCTREE_SIZE_SCALE; }
     virtual int getBoundaryLevelAdjust() const { return 0; }
 


### PR DESCRIPTION
Clean up how Application::displaySide() works:
* remove the EntityTreeRenderer::render() since all rendering is now done as true render items.
* move the best zone logic out of render and into update where the other check enter/leave entities was happening.
* remove the old renderingInWorldInterface signal and one user of it
* change GlobalServicesScriptingInterface to use a timer instead of renderingInWorldInterface