### PR TITLE
Adjust controller offset from 6 inches to 3 inches

### DIFF
--- a/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
@@ -42,7 +42,7 @@ const unsigned int GRIP_BUTTON = 1U << 2;
 const unsigned int TRACKPAD_BUTTON = 1U << 3;
 const unsigned int TRIGGER_BUTTON = 1U << 4;
 
-const float CONTROLLER_LENGTH_OFFSET = 0.175f;
+const float CONTROLLER_LENGTH_OFFSET = 0.0762f;  // three inches
 const QString CONTROLLER_MODEL_STRING = "vr_controller_05_wireless_b";
 
 const QString ViveControllerManager::NAME = "OpenVR";


### PR DESCRIPTION
When using the vive controller the position of your wrist should
match your actual wrist a bit better, unless your name is Shaquille O'Neal.