### PR TITLE
Display the face blend coefficients and update the value in real time.

### DIFF
--- a/examples/faceBlendCoefficients.js
+++ b/examples/faceBlendCoefficients.js
@@ -1,0 +1,98 @@
+//
+//  coefficients.js
+//
+//  version 2.0
+//
+//  Created by Bob Long, 9/14/2015
+//  A simple panel that can display the blending coefficients of Avatar's face model.
+//  
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+Script.include('utilities/tools/cookies.js')
+
+var panel;
+var coeff;
+var interval;
+var item = 0;
+var DEVELOPER_MENU = "Developer";
+var AVATAR_MENU = DEVELOPER_MENU + " > Avatar";
+var SHOW_FACE_BLEND_COEFFICIENTS = "Show face blend coefficients"
+
+function MenuConnect(menuItem) {
+    if (menuItem == SHOW_FACE_BLEND_COEFFICIENTS) {
+        if(Menu.isOptionChecked(SHOW_FACE_BLEND_COEFFICIENTS)) {
+           panel.show();
+           Overlays.editOverlay(coeff, { visible : true });
+        } else {
+           panel.hide();
+           Overlays.editOverlay(coeff, { visible : false });
+        }        
+    }
+}
+
+// Add a menu item to show/hide the coefficients
+function setupMenu() {   
+   if (!Menu.menuExists(DEVELOPER_MENU)) {
+     Menu.addMenu(DEVELOPER_MENU);
+   }
+   
+   if (!Menu.menuExists(AVATAR_MENU)) {
+     Menu.addMenu(AVATAR_MENU);
+   }
+   
+   Menu.addMenuItem({ menuName: AVATAR_MENU, menuItemName: SHOW_FACE_BLEND_COEFFICIENTS, isCheckable: true, isChecked: true });
+   Menu.menuItemEvent.connect(MenuConnect);
+}
+
+function setupPanel() {
+   panel = new Panel(10, 400);   
+   
+   // Slider to select which coefficient to display
+   panel.newSlider("Select Coefficient Index",
+       0,
+       100,
+       function(value) { item = value.toFixed(0); },
+       function() { return item; },
+       function(value) { return "index = " + item; }
+   );
+   
+   // The raw overlay used to show the actual coefficient value
+   coeff = Overlays.addOverlay("text", {
+       x: 10,
+       y: 420,
+       width: 300,
+       height: 50,
+       color: { red: 255, green: 255, blue: 255 },
+       alpha: 1.0,
+       backgroundColor: { red: 127, green: 127, blue: 127 },
+       backgroundAlpha: 0.5,
+       topMargin: 15,
+       leftMargin: 20,
+       text: "Coefficient: 0.0"
+   });
+    
+    // Set up the interval (0.5 sec) to update the coefficient.
+   interval = Script.setInterval(function() {
+      Overlays.editOverlay(coeff, { text: "Coefficient: " + MyAvatar.getFaceBlendCoef(item).toFixed(4) });
+   }, 500);
+   
+   // Mouse event setup
+   Controller.mouseMoveEvent.connect(function panelMouseMoveEvent(event) { return panel.mouseMoveEvent(event); });
+   Controller.mousePressEvent.connect( function panelMousePressEvent(event) { return panel.mousePressEvent(event); });
+   Controller.mouseReleaseEvent.connect(function(event) { return panel.mouseReleaseEvent(event); });
+}
+
+// Clean up
+function scriptEnding() {   
+   panel.destroy();
+   Overlays.deleteOverlay(coeff);
+   Script.clearInterval(interval);
+   
+   Menu.removeMenuItem(AVATAR_MENU, SHOW_FACE_BLEND_COEFFICIENTS);
+}
+
+setupMenu();
+setupPanel();
+Script.scriptEnding.connect(scriptEnding);

--- a/examples/faceBlendCoefficients.js
+++ b/examples/faceBlendCoefficients.js
@@ -1,10 +1,10 @@
 //
-//  coefficients.js
+//  faceBlendCoefficients.js
 //
 //  version 2.0
 //
 //  Created by Bob Long, 9/14/2015
-//  A simple panel that can display the blending coefficients of Avatar's face model.
+//  A simple panel that can select and display the blending coefficient of the Avatar's face model.
 //  
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -110,6 +110,8 @@ public:
     Q_INVOKABLE float getHeadFinalRoll() const { return getHead()->getFinalRoll(); }
     Q_INVOKABLE float getHeadFinalPitch() const { return getHead()->getFinalPitch(); }
     Q_INVOKABLE float getHeadDeltaPitch() const { return getHead()->getDeltaPitch(); }
+    Q_INVOKABLE int getFaceBlendCoefNum() const { return getHead()->getFaceModel().getBlendshapeCoefficientsNum(); }
+    Q_INVOKABLE float getFaceBlendCoef(int index) const { return getHead()->getFaceModel().getBlendshapeCoefficient(index); }
 
     Q_INVOKABLE glm::vec3 getEyePosition() const { return getHead()->getEyePosition(); }
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -191,6 +191,11 @@ public:
     const std::unordered_set<int>& getCauterizeBoneSet() const { return _cauterizeBoneSet; }
     void setCauterizeBoneSet(const std::unordered_set<int>& boneSet) { _cauterizeBoneSet = boneSet; }
 
+    int getBlendshapeCoefficientsNum() const { return _blendshapeCoefficients.size(); }
+    float getBlendshapeCoefficient(int index) const {
+        return index >= _blendshapeCoefficients.size() || index < 0 ?
+               0.0f : _blendshapeCoefficients.at(index); }
+
 protected:
 
     void setPupilDilation(float dilation) { _pupilDilation = dilation; }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -192,9 +192,9 @@ public:
     void setCauterizeBoneSet(const std::unordered_set<int>& boneSet) { _cauterizeBoneSet = boneSet; }
 
     int getBlendshapeCoefficientsNum() const { return _blendshapeCoefficients.size(); }
-    float getBlendshapeCoefficient(int index) const {
-        return index >= _blendshapeCoefficients.size() || index < 0 ?
-               0.0f : _blendshapeCoefficients.at(index); }
+    float getBlendshapeCoefficient(unsigned int index) const {
+        return index >= _blendshapeCoefficients.size() ? 0.0f : _blendshapeCoefficients.at(index);
+     }
 
 protected:
 


### PR DESCRIPTION
Display the face blend coefficients and update the value in real time.

- Expose the face model blend coefficients from Interface.

- A sample js script is added to read the coefficient data from Interface. Currently the total number of available coefficients is not being used by this script. A slider is used to select which coefficient to display. the coefficient is being periodically updated by an interval timer. A menu item is added under Developer> Avatar to control the show/hide the coefficients in the scene.