### PR TITLE
merge model part quads and triangles together to reduce the number of draw calls

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -168,7 +168,7 @@ Item {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
                         text: "Triangles: " + root.triangles +
-                            " / Quads: " + root.quads + " / Material Switches: " + root.materialSwitches
+                            " / Material Switches: " + root.materialSwitches
                     }
                     Text {
                         color: root.fontColor;

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -337,7 +337,6 @@ void Stats::updateStats() {
 
 void Stats::setRenderDetails(const RenderDetails& details) {
     STAT_UPDATE(triangles, details._trianglesRendered);
-    STAT_UPDATE(quads, details._quadsRendered);
     STAT_UPDATE(materialSwitches, details._materialSwitches);
     if (_expanded) {
         STAT_UPDATE(meshOpaque, details._opaque._rendered);

--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -829,24 +829,30 @@ public:
     std::vector<AttributeData> attributes;
 };
 
-gpu::BufferPointer FBXMeshPart::getTrianglesForQuads() const {
+gpu::BufferPointer FBXMeshPart::getMergedTriangles() const {
     // if we've been asked for our triangulation of the original quads, but we don't yet have them
     // then create them now.
-    if (!trianglesForQuadsAvailable) {
-        trianglesForQuadsAvailable = true;
+    if (!mergedTrianglesAvailable) {
+        mergedTrianglesAvailable = true;
 
-        quadsAsTrianglesIndicesBuffer = std::make_shared<gpu::Buffer>();
+        mergedTrianglesIndicesBuffer = std::make_shared<gpu::Buffer>();
 
         // QVector<int> quadIndices; // original indices from the FBX mesh
-         QVector<quint32> quadsAsTrianglesIndices; // triangle versions of quads converted when first needed
+        QVector<quint32> mergedTrianglesIndices; // triangle versions of quads converted when first needed
+        const int INDICES_PER_ORIGINAL_TRIANGLE = 3;
         const int INDICES_PER_ORIGINAL_QUAD = 4;
         const int INDICES_PER_TRIANGULATED_QUAD = 6;
         int numberOfQuads = quadIndices.size() / INDICES_PER_ORIGINAL_QUAD;
-        
-        quadsAsTrianglesIndices.resize(numberOfQuads * INDICES_PER_TRIANGULATED_QUAD);
+        int numberOfTriangles = triangleIndices.size() / INDICES_PER_ORIGINAL_TRIANGLE;
+        int mergedNumberOfIndices = (numberOfQuads * INDICES_PER_TRIANGULATED_QUAD) + triangleIndices.size();
+
+        // resized our merged indices to be enough room for our triangulated quads and our original triangles        
+        mergedTrianglesIndices.resize(mergedNumberOfIndices);
         
         int originalIndex = 0;
         int triangulatedIndex = 0;
+
+        // triangulate our quads
         for (int fromQuad = 0; fromQuad < numberOfQuads; fromQuad++) {
             int i0 = quadIndices[originalIndex + 0];
             int i1 = quadIndices[originalIndex + 1];
@@ -860,23 +866,38 @@ gpu::BufferPointer FBXMeshPart::getTrianglesForQuads() const {
             // Triangle tri1 = { v0, v1, v2 };
             // Triangle tri2 = { v2, v3, v0 };
             
-            quadsAsTrianglesIndices[triangulatedIndex + 0] = i0;
-            quadsAsTrianglesIndices[triangulatedIndex + 1] = i1;
-            quadsAsTrianglesIndices[triangulatedIndex + 2] = i3;
+            mergedTrianglesIndices[triangulatedIndex + 0] = i0;
+            mergedTrianglesIndices[triangulatedIndex + 1] = i1;
+            mergedTrianglesIndices[triangulatedIndex + 2] = i3;
 
-            quadsAsTrianglesIndices[triangulatedIndex + 3] = i1;
-            quadsAsTrianglesIndices[triangulatedIndex + 4] = i2;
-            quadsAsTrianglesIndices[triangulatedIndex + 5] = i3;
+            mergedTrianglesIndices[triangulatedIndex + 3] = i1;
+            mergedTrianglesIndices[triangulatedIndex + 4] = i2;
+            mergedTrianglesIndices[triangulatedIndex + 5] = i3;
             
             originalIndex += INDICES_PER_ORIGINAL_QUAD;
             triangulatedIndex += INDICES_PER_TRIANGULATED_QUAD;
         }
 
-        trianglesForQuadsIndicesCount = INDICES_PER_TRIANGULATED_QUAD * numberOfQuads;
-        quadsAsTrianglesIndicesBuffer->append(quadsAsTrianglesIndices.size() * sizeof(quint32), (gpu::Byte*)quadsAsTrianglesIndices.data());
+        // add our original triangs
+        originalIndex = 0;
+        for (int fromTriangle = 0; fromTriangle < numberOfTriangles; fromTriangle++) {
+            int i0 = triangleIndices[originalIndex + 0];
+            int i1 = triangleIndices[originalIndex + 1];
+            int i2 = triangleIndices[originalIndex + 2];
+
+            mergedTrianglesIndices[triangulatedIndex + 0] = i0;
+            mergedTrianglesIndices[triangulatedIndex + 1] = i1;
+            mergedTrianglesIndices[triangulatedIndex + 2] = i2;
+
+            originalIndex += INDICES_PER_ORIGINAL_TRIANGLE;
+            triangulatedIndex += INDICES_PER_ORIGINAL_TRIANGLE;
+        }
+
+        mergedTrianglesIndicesCount = mergedNumberOfIndices;
+        mergedTrianglesIndicesBuffer->append(mergedNumberOfIndices * sizeof(quint32), (gpu::Byte*)mergedTrianglesIndices.data());
 
     }
-    return quadsAsTrianglesIndicesBuffer;
+    return mergedTrianglesIndicesBuffer;
 }
 
 void appendIndex(MeshData& data, QVector<int>& indices, int index) {

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -117,10 +117,10 @@ public:
 /// A single part of a mesh (with the same material).
 class FBXMeshPart {
 public:
-    
+
     QVector<int> quadIndices; // original indices from the FBX mesh
     QVector<int> triangleIndices; // original indices from the FBX mesh
-    mutable gpu::BufferPointer quadsAsTrianglesIndicesBuffer;
+    mutable gpu::BufferPointer mergedTrianglesIndicesBuffer; // both the quads and the triangles merged into a single set of triangles
 
     glm::vec3 diffuseColor;
     glm::vec3 specularColor;
@@ -136,10 +136,10 @@ public:
 
     QString materialID;
     model::MaterialPointer _material;
-    mutable bool trianglesForQuadsAvailable = false;
-    mutable int trianglesForQuadsIndicesCount = 0;
+    mutable bool mergedTrianglesAvailable = false;
+    mutable int mergedTrianglesIndicesCount = 0;
 
-    gpu::BufferPointer getTrianglesForQuads() const;
+    gpu::BufferPointer getMergedTriangles() const;
 };
 
 /// A single mesh (with optional blendshapes) extracted from an FBX document.

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -352,9 +352,6 @@ private:
     };
 
     QHash<QPair<int,int>, AABox> _calculatedMeshPartBoxes; // world coordinate AABoxes for all sub mesh part boxes
-    QHash<QPair<int,int>, qint64> _calculatedMeshPartOffset;
-    bool _calculatedMeshPartOffsetValid;
-
 
     bool _calculatedMeshPartBoxesValid;
     QVector<AABox> _calculatedMeshBoxes; // world coordinate AABoxes for all sub mesh boxes
@@ -365,7 +362,6 @@ private:
     QMutex _mutex;
 
     void recalculateMeshBoxes(bool pickAgainstTriangles = false);
-    void recalculateMeshPartOffsets();
 
     void segregateMeshGroups(); // used to calculate our list of translucent vs opaque meshes
 

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -43,7 +43,6 @@ public:
     
     int _materialSwitches = 0;
     int _trianglesRendered = 0;
-    int _quadsRendered = 0;
     
     Item _opaque;
     Item _translucent;


### PR DESCRIPTION
* merges the model part triangles and quads together into a singe buffer
* removes the old quads render stat (since it was not accurate)
* removes a bunch of cruft that was managing these different offsets into a shared array of indices in the model
