### PR TITLE
remove underpose attenuation from IK relaxation step

### DIFF
--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -635,8 +635,6 @@ void SkeletonModel::computeBoundingShape() {
 }
 
 void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float alpha) {
-    const int BALL_SUBDIVISIONS = 10;
-
     auto geometryCache = DependencyManager::get<GeometryCache>();
     auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
     // draw a blue sphere at the capsule top point

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -50,8 +50,6 @@ protected:
     // for AnimDebugDraw rendering
     virtual const AnimPoseVec& getPosesInternal() const override { return _relativePoses; }
 
-    void relaxTowardDefaults(float dt);
-
     RotationConstraint* getConstraint(int index);
     void clearConstraints();
     void initConstraints();
@@ -72,7 +70,7 @@ protected:
     };
 
     std::map<int, RotationConstraint*> _constraints;
-    std::map<int, RotationAccumulator> _accumulators; // class-member to exploit temporal coherency
+    std::vector<RotationAccumulator> _accumulators;
     std::vector<IKTargetVar> _targetVarVec;
     AnimPoseVec _defaultRelativePoses; // poses of the relaxed state
     AnimPoseVec _relativePoses; // current relative poses

--- a/libraries/animation/src/RotationAccumulator.cpp
+++ b/libraries/animation/src/RotationAccumulator.cpp
@@ -11,17 +11,23 @@
 
 #include <glm/gtx/quaternion.hpp>
 
-void RotationAccumulator::add(glm::quat rotation) {
+void RotationAccumulator::add(const glm::quat& rotation) {
     // make sure both quaternions are on the same hyper-hemisphere before we add them linearly (lerp)
     _rotationSum += copysignf(1.0f, glm::dot(_rotationSum, rotation)) * rotation;
     ++_numRotations;
+    _isDirty = true;
 }
 
 glm::quat RotationAccumulator::getAverage() {
     return (_numRotations > 0) ?  glm::normalize(_rotationSum) : glm::quat();
 }
 
-void RotationAccumulator::clear() { 
+void RotationAccumulator::clear() {
     _rotationSum *= 0.0f;
     _numRotations = 0;
+}
+
+void RotationAccumulator::clearAndClean() { 
+    clear();
+    _isDirty = false;
 }

--- a/libraries/animation/src/RotationAccumulator.h
+++ b/libraries/animation/src/RotationAccumulator.h
@@ -14,19 +14,27 @@
 
 class RotationAccumulator {
 public:
-    RotationAccumulator() : _rotationSum(0.0f, 0.0f, 0.0f, 0.0f), _numRotations(0) { }
+    RotationAccumulator() : _rotationSum(0.0f, 0.0f, 0.0f, 0.0f), _numRotations(0), _isDirty(false) { }
 
     int size() const { return _numRotations; }
 
-    void add(glm::quat rotation);
+    void add(const glm::quat& rotation);
 
     glm::quat getAverage();
 
+    /// \return true if any rotations were accumulated
+    bool isDirty() const { return _isDirty; }
+
+    /// \brief clear accumulated rotation but don't change _isDirty
     void clear();
+
+    /// \brief clear accumulated rotation and set _isDirty to false
+    void clearAndClean();
 
 private:
     glm::quat _rotationSum;
     int _numRotations;
+    bool _isDirty;
 };
 
 #endif // hifi_RotationAccumulator_h

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1727,9 +1727,7 @@ void Model::segregateMeshGroups() {
     // Run through all of the meshes, and place them into their segregated, but unsorted buckets
     int shapeID = 0;
     for (int i = 0; i < (int)networkMeshes.size(); i++) {
-        const NetworkMesh& networkMesh = *(networkMeshes.at(i).get());
         const FBXMesh& mesh = geometry.meshes.at(i);
-        const MeshState& state = _meshStates.at(i);
 
         // Create the render payloads
         int totalParts = mesh.parts.size();

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -193,7 +193,7 @@ public:
 
     int getBlendshapeCoefficientsNum() const { return _blendshapeCoefficients.size(); }
     float getBlendshapeCoefficient(unsigned int index) const {
-        return index >= _blendshapeCoefficients.size() ? 0.0f : _blendshapeCoefficients.at(index);
+        return index >= (unsigned int)_blendshapeCoefficients.size() ? 0.0f : _blendshapeCoefficients.at(index);
      }
 
 protected:


### PR DESCRIPTION
This PR fixes a bug where the IK relaxation step was impeding the underpose animation orientations for joints that were not being moved by the IK logic.