### PR TITLE
allow head translation when using hand IK in 3rd person screenie mode

### DIFF
--- a/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
+++ b/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
@@ -31,7 +31,8 @@
                         {
                             "jointName": "Head",
                             "positionVar": "headPosition",
-                            "rotationVar": "headRotation"
+                            "rotationVar": "headRotation",
+                            "typeVar": "headType"
                         }
                     ]
                 },

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -141,6 +141,7 @@ QByteArray MyAvatar::toByteArray(bool cullSmallChanges, bool sendAll) {
 }
 
 void MyAvatar::reset() {
+    _skeletonModel.reset();
     getHead()->reset();
 
     _targetVelocity = glm::vec3(0.0f);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -141,7 +141,6 @@ QByteArray MyAvatar::toByteArray(bool cullSmallChanges, bool sendAll) {
 }
 
 void MyAvatar::reset() {
-    _skeletonModel.reset();
     getHead()->reset();
 
     _targetVelocity = glm::vec3(0.0f);

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -31,20 +31,33 @@ public:
     void loadPoses(const AnimPoseVec& poses);
     void computeAbsolutePoses(AnimPoseVec& absolutePoses) const;
 
-    void setTargetVars(const QString& jointName, const QString& positionVar, const QString& rotationVar);
+    void setTargetVars(const QString& jointName, const QString& positionVar, const QString& rotationVar, const QString& typeVar);
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, float dt, AnimNode::Triggers& triggersOut) override;
     virtual const AnimPoseVec& overlay(const AnimVariantMap& animVars, float dt, Triggers& triggersOut, const AnimPoseVec& underPoses) override;
 
 protected:
     struct IKTarget {
+        enum class Type {
+            RotationAndPosition,
+            RotationOnly 
+        };
         AnimPose pose;
         int index;
         int rootIndex;
+        Type type = Type::RotationAndPosition;
+
+        void setType(const QString& typeVar) {
+            if (typeVar == "RotationOnly") {
+                type = Type::RotationOnly;
+            } else {
+                type = Type::RotationAndPosition;
+            }
+        }
     };
 
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets);
-    void solveWithCyclicCoordinateDescent(std::vector<IKTarget>& targets);
+    void solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets);
     virtual void setSkeletonInternal(AnimSkeleton::ConstPointer skeleton);
 
     // for AnimDebugDraw rendering
@@ -55,15 +68,20 @@ protected:
     void initConstraints();
 
     struct IKTargetVar {
-        IKTargetVar(const QString& jointNameIn, const QString& positionVarIn, const QString& rotationVarIn) :
+        IKTargetVar(const QString& jointNameIn, 
+                const QString& positionVarIn, 
+                const QString& rotationVarIn, 
+                const QString& typeVarIn) :
             positionVar(positionVarIn),
             rotationVar(rotationVarIn),
+            typeVar(typeVarIn),
             jointName(jointNameIn),
             jointIndex(-1),
             rootIndex(-1) {}
 
         QString positionVar;
         QString rotationVar;
+        QString typeVar;
         QString jointName;
         int jointIndex; // cached joint index
         int rootIndex; // cached root index

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -47,13 +47,7 @@ protected:
         int rootIndex;
         Type type = Type::RotationAndPosition;
 
-        void setType(const QString& typeVar) {
-            if (typeVar == "RotationOnly") {
-                type = Type::RotationOnly;
-            } else {
-                type = Type::RotationAndPosition;
-            }
-        }
+        void setType(const QString& typeVar) { type = ((typeVar == "RotationOnly") ?  Type::RotationOnly : Type::RotationAndPosition); }
     };
 
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets);

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -342,8 +342,9 @@ AnimNode::Pointer loadInverseKinematicsNode(const QJsonObject& jsonObj, const QS
         READ_STRING(jointName, targetObj, id, jsonUrl, nullptr);
         READ_STRING(positionVar, targetObj, id, jsonUrl, nullptr);
         READ_STRING(rotationVar, targetObj, id, jsonUrl, nullptr);
+        READ_OPTIONAL_STRING(typeVar, targetObj);
 
-        node->setTargetVars(jointName, positionVar, rotationVar);
+        node->setTargetVars(jointName, positionVar, rotationVar, typeVar);
     };
 
     return node;

--- a/libraries/animation/src/AnimOverlay.cpp
+++ b/libraries/animation/src/AnimOverlay.cpp
@@ -51,8 +51,8 @@ const AnimPoseVec& AnimOverlay::evaluate(const AnimVariantMap& animVars, float d
     _alpha = animVars.lookup(_alphaVar, _alpha);
 
     if (_children.size() >= 2) {
-        auto underPoses = _children[1]->evaluate(animVars, dt, triggersOut);
-        auto overPoses = _children[0]->overlay(animVars, dt, triggersOut, underPoses);
+        auto& underPoses = _children[1]->evaluate(animVars, dt, triggersOut);
+        auto& overPoses = _children[0]->overlay(animVars, dt, triggersOut, underPoses);
 
         if (underPoses.size() > 0 && underPoses.size() == overPoses.size()) {
             _poses.resize(underPoses.size());

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1065,6 +1065,7 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
 
                 _animVars.set("headPosition", headPos);
                 _animVars.set("headRotation", headRot);
+                _animVars.set("headType", QString("RotationAndPosition"));
                 _animVars.set("neckPosition", neckPos);
                 _animVars.set("neckRotation", neckRot);
 
@@ -1077,6 +1078,7 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
 
                 _animVars.unset("headPosition");
                 _animVars.set("headRotation", realLocalHeadOrientation);
+                _animVars.set("headType", QString("RotationOnly"));
                 _animVars.unset("neckPosition");
                 _animVars.unset("neckRotation");
             }


### PR DESCRIPTION
The IK now supports a target that adjusts rotation and not position.  This allows us to orient the head during 3rd person screenie mode but allowing the head to translate when the hand targets pull the torso and neck around.

Also cleaned up the IK solver and fixed a bug that was preventing the solver from actually taking advantage of multiple iterations.