### PR TITLE
Fix for bad textures when using _glActiveBindTexture

### DIFF
--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -418,6 +418,8 @@ void GLBackend::resetStages() {
 #define DO_IT_NOW(call, offset) 
 
 void Batch::_glActiveBindTexture(GLenum unit, GLenum target, GLuint texture) {
+    setResourceTexture(unit - GL_TEXTURE0, nullptr);
+
     ADD_COMMAND_GL(glActiveBindTexture);
 
     _params.push_back(texture);


### PR DESCRIPTION
Currently we have some renderables that provide texture ID's directly, disallowing the use of the gpu::Texture interface.  This requires us to use `_glActiveBindTexture` to bind the texture during rendering.  However, previously this command didn't update the GLBackend cached state regarding textures, so as far as GLBackend was concerned, whatever texture was bound to a given slot before the call to `_glActiveBindTexture` was still bound.  This meant that if something used texture X, then a web entity was rendered, then something else which used texture X was rendered, the last thing would instead be rendered with the texture from the web entity.

This PR modifies the `_glActiveBindTexture` call in Batch to explicitly unbind corresponding texture slot, so the next render will be aware it needs to rebind whatever it needs.