### PR TITLE
Fix for Oculus timewarp judder introduced by 20d784ba39db

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1055,6 +1055,9 @@ void Application::paintGL() {
     displayPlugin->preRender();
     _offscreenContext->makeCurrent();
 
+    // update the avatar with a fresh HMD pose
+    _myAvatar->updateFromHMDSensorMatrix(getHMDSensorPose());
+
     auto lodManager = DependencyManager::get<LODManager>();
 
 
@@ -2894,9 +2897,6 @@ void Application::update(float deltaTime) {
         emulateMouse(hand, userInputMapper->getActionState(UserInputMapper::RIGHT_HAND_CLICK),
             userInputMapper->getActionState(UserInputMapper::SHIFT), RIGHT_HAND_INDEX);
     }
-
-    // update the avatar with a fresh HMD pose
-    _myAvatar->updateFromHMDSensorMatrix(getHMDSensorPose(), deltaTime);
 
     updateThreads(deltaTime); // If running non-threaded, then give the threads some time to process...
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -272,7 +272,15 @@ glm::mat4 MyAvatar::getSensorToWorldMatrix() const {
 
 // best called at start of main loop just after we have a fresh hmd pose.
 // update internal body position from new hmd pose.
-void MyAvatar::updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix, float deltaTime) {
+void MyAvatar::updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix) {
+
+    auto now = usecTimestampNow();
+    auto deltaUsecs = now - _lastUpdateFromHMDTime;
+    _lastUpdateFromHMDTime = now;
+    double actualDeltaTime = (double)deltaUsecs / (double)USECS_PER_SECOND;
+    const float BIGGEST_DELTA_TIME_SECS = 0.25f;
+    float deltaTime = glm::clamp((float)actualDeltaTime, 0.0f, BIGGEST_DELTA_TIME_SECS);
+
     // update the sensorMatrices based on the new hmd pose
     _hmdSensorMatrix = hmdSensorMatrix;
     _hmdSensorPosition = extractTranslation(hmdSensorMatrix);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -270,8 +270,9 @@ glm::mat4 MyAvatar::getSensorToWorldMatrix() const {
     return _sensorToWorldMatrix;
 }
 
-// best called at start of main loop just after we have a fresh hmd pose.
-// update internal body position from new hmd pose.
+// Pass a recent sample of the HMD to the avatar.
+// This can also update the avatar's position to follow the HMD
+// as it moves through the world.
 void MyAvatar::updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix) {
 
     auto now = usecTimestampNow();

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -68,7 +68,7 @@ public:
 
     // best called at start of main loop just after we have a fresh hmd pose.
     // update internal body position from new hmd pose.
-    void updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix, float deltaTime);
+    void updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix);
 
     // best called at end of main loop, just before rendering.
     // update sensor to world matrix from current body position and hmd sensor.
@@ -361,6 +361,8 @@ private:
 
     bool _straightingLean = false;
     float _straightingLeanAlpha = 0.0f;
+
+    quint64 _lastUpdateFromHMDTime = usecTimestampNow();
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -66,8 +66,9 @@ public:
     const glm::quat& getHMDSensorOrientation() const { return _hmdSensorOrientation; }
     glm::mat4 getSensorToWorldMatrix() const;
 
-    // best called at start of main loop just after we have a fresh hmd pose.
-    // update internal body position from new hmd pose.
+    // Pass a recent sample of the HMD to the avatar.
+    // This can also update the avatar's position to follow the HMD
+    // as it moves through the world.
     void updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix);
 
     // best called at end of main loop, just before rendering.


### PR DESCRIPTION
Moved myAvatar->updateFromHMDSensorMatrix from Application::update
back into Application::paintGL, so it occurs between
displayPlugin->preRender() and displayPlugin->display().

We should render with the most up-to-date camera position as possible,
and sample it at the same frequency as the display rate.