### PR TITLE
Import/Export entities fix

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -1035,7 +1035,7 @@ function handeMenuEvent(menuItem) {
 
         var importURL;
         if (menuItem == "Import Entities") {
-            importURL = Window.browse("Select models to import", "", "*.json");
+            importURL = "file:///" + Window.browse("Select models to import", "", "*.json");
         } else {
             importURL = Window.prompt("URL of SVO to import", "");
         }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2337,7 +2337,8 @@ bool Application::exportEntities(const QString& filename, const QVector<EntityIt
     QVector<EntityItemPointer> entities;
 
     auto entityTree = _entities.getTree();
-    EntityTree exportTree;
+    auto exportTree = std::make_shared<EntityTree>();
+    exportTree->createRootElement();
 
     glm::vec3 root(TREE_SCALE, TREE_SCALE, TREE_SCALE);
     for (auto entityID : entityIDs) {
@@ -2364,10 +2365,10 @@ bool Application::exportEntities(const QString& filename, const QVector<EntityIt
         auto properties = entityItem->getProperties();
 
         properties.setPosition(properties.getPosition() - root);
-        exportTree.addEntity(entityItem->getEntityItemID(), properties);
+        exportTree->addEntity(entityItem->getEntityItemID(), properties);
     }
 
-    exportTree.writeToJSONFile(filename.toLocal8Bit().constData());
+    exportTree->writeToJSONFile(filename.toLocal8Bit().constData());
 
     // restore the main window's active state
     _window->activateWindow();
@@ -2380,15 +2381,16 @@ bool Application::exportEntities(const QString& filename, float x, float y, floa
 
     if (entities.size() > 0) {
         glm::vec3 root(x, y, z);
-        EntityTree exportTree;
+        auto exportTree = std::make_shared<EntityTree>();
+        exportTree->createRootElement();
 
         for (int i = 0; i < entities.size(); i++) {
             EntityItemProperties properties = entities.at(i)->getProperties();
             EntityItemID id = entities.at(i)->getEntityItemID();
             properties.setPosition(properties.getPosition() - root);
-            exportTree.addEntity(id, properties);
+            exportTree->addEntity(id, properties);
         }
-        exportTree.writeToSVOFile(filename.toLocal8Bit().constData());
+        exportTree->writeToSVOFile(filename.toLocal8Bit().constData());
     } else {
         qCDebug(interfaceapp) << "No models were selected";
         return false;

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -19,17 +19,40 @@ float ClipboardScriptingInterface::getClipboardContentsLargestDimension() {
 }
 
 bool ClipboardScriptingInterface::exportEntities(const QString& filename, const QVector<EntityItemID>& entityIDs) {
-    return Application::getInstance()->exportEntities(filename, entityIDs);
+    bool retVal;
+    QMetaObject::invokeMethod(Application::getInstance(), "exportEntities", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(bool, retVal),
+                              Q_ARG(const QString&, filename),
+                              Q_ARG(const QVector<EntityItemID>&, entityIDs));
+    return retVal;
 }
 
 bool ClipboardScriptingInterface::exportEntities(const QString& filename, float x, float y, float z, float s) {
-    return Application::getInstance()->exportEntities(filename, x, y, z, s);
+    bool retVal;
+    QMetaObject::invokeMethod(Application::getInstance(), "exportEntities", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(bool, retVal),
+                              Q_ARG(const QString&, filename),
+                              Q_ARG(float, x),
+                              Q_ARG(float, y),
+                              Q_ARG(float, z),
+                              Q_ARG(float, s));
+    return retVal;
 }
 
 bool ClipboardScriptingInterface::importEntities(const QString& filename) {
-    return Application::getInstance()->importEntities(filename);
+    bool retVal;
+    QMetaObject::invokeMethod(Application::getInstance(), "importEntities", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(bool, retVal),
+                              Q_ARG(const QString&, filename));
+    return retVal;
 }
 
 QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(glm::vec3 position) {
-    return Application::getInstance()->pasteEntities(position.x, position.y, position.z);
+    QVector<EntityItemID> retVal;
+    QMetaObject::invokeMethod(Application::getInstance(), "pasteEntities", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(QVector<EntityItemID>, retVal),
+                              Q_ARG(float, position.x),
+                              Q_ARG(float, position.y),
+                              Q_ARG(float, position.z));
+    return retVal;
 }


### PR DESCRIPTION
This fixes a few issues:

- In ClipboardScriptingInterface we were calling Application:: methods on the script engine's thread instead of the main thread.
- `EntityTree` relies on the object having a shared_ptr referencing it because it uses `shared_from_this`.
- `EntityTree` does not create a root element by default, causing operations that rely on it to fail. The root element is now created explicitly where it is being used.