### PR TITLE
fix skybox not always loading when you haven't moved or if the texture is slow in loading

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -138,7 +138,10 @@ private:
     QScriptValueList createEntityArgs(const EntityItemID& entityID);
     void checkEnterLeaveEntities();
     void leaveAllEntities();
+    void forceRecheckEntities();
+
     glm::vec3 _lastAvatarPosition;
+    bool _pendingSkyboxTextureDownload = false;
     QVector<EntityItemID> _currentEntitiesInside;
     
     bool _wantScripts;


### PR DESCRIPTION
Two bug fixes:
* If you are stationary and not moving, and a zone loaded around you, we weren't detecting enter/leave entity and therefore weren't setting zone properties
* If we did apply zone properties for a skybox, but the texture wasn't loaded, it would set the texture to black, and never reset the texture when the texture was actually eventually downloaded

This fixes both of those issues.