### PR TITLE
Fixing the lighting view matrix for stereo again

### DIFF
--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -442,7 +442,7 @@ void DeferredLightingEffect::render(RenderArgs* args) {
 
                 deferredTransforms[i].projection = projMats[i];
 
-                auto sideViewMat =  eyeViews[i] * monoViewMat;
+                auto sideViewMat = monoViewMat * glm::inverse(eyeViews[i]);
                 viewTransforms[i].evalFromRawMatrix(sideViewMat);
                 deferredTransforms[i].viewInverse = sideViewMat;
 
@@ -574,10 +574,8 @@ void DeferredLightingEffect::render(RenderArgs* args) {
 
                 for (auto lightID : _pointLights) {
                     auto& light = _allocatedLights[lightID];
-                    // IN DEBUG:  light->setShowContour(true);
-                    if (_pointLightLocations->lightBufferUnit >= 0) {
-                        batch.setUniformBuffer(_pointLightLocations->lightBufferUnit, light->getSchemaBuffer());
-                    }
+                    // IN DEBUG: light->setShowContour(true);
+                    batch.setUniformBuffer(_pointLightLocations->lightBufferUnit, light->getSchemaBuffer());
 
                     float expandedRadius = light->getMaximumRadius() * (1.0f + SCALE_EXPANSION);
                     // TODO: We shouldn;t have to do that test and use a different volume geometry for when inside the vlight volume,
@@ -612,8 +610,7 @@ void DeferredLightingEffect::render(RenderArgs* args) {
 
                 for (auto lightID : _spotLights) {
                     auto light = _allocatedLights[lightID];
-                    // IN DEBUG:  light->setShowContour(true);
-
+                    // IN DEBUG: light->setShowContour(true);
                     batch.setUniformBuffer(_spotLightLocations->lightBufferUnit, light->getSchemaBuffer());
 
                     auto eyeLightPos = eyePoint - light->getPosition();


### PR DESCRIPTION
This randomly chosen combination of head and eye matrix seems to finally work in stereo... :)

Just kidding we actually know what we are doing here, we are professionals!
The eyeView we get from the Context is the matrix going from the mono eye space to the stereo eye space. to create the correct "ViewTransform" for a given side is the matrix going from the stereo eye space back to the world space. So that s why we need monoView * inv(stereoView).
Long term we should put the eye offset in the projection matrix and not fool around with different view matrices for stereo.