### PR TITLE
Fix particle radius, color, and alpha starts/finishes

### DIFF
--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -1573,14 +1573,17 @@ void EntityItemProperties::markAllChanged() {
     _accelerationSpreadChanged = true;
     _particleRadiusChanged = true;
     _radiusSpreadChanged = true;
-    _radiusStartChanged = true;
-    _radiusFinishChanged = true;
     _colorSpreadChanged = true;
-    _colorStartChanged = true;
-    _colorFinishChanged = true;
     _alphaSpreadChanged = true;
-    _alphaStartChanged = true;
-    _alphaFinishChanged = true;
+
+    // Only mark the following as changed if their values are specified in the properties when the particle is created. If their
+    // values are specified then they are marked as changed in getChangedProperties().
+    //_radiusStartChanged = true;
+    //_radiusFinishChanged = true;
+    //_colorStartChanged = true;
+    //_colorFinishChanged = true;
+    //_alphaStartChanged = true;
+    //_alphaFinishChanged = true;
 
     _marketplaceIDChanged = true;
 

--- a/libraries/entities/src/ParticleEffectEntityItem.h
+++ b/libraries/entities/src/ParticleEffectEntityItem.h
@@ -177,12 +177,12 @@ public:
     float getParticleRadius() const { return _particleRadius; }
 
     static const float DEFAULT_RADIUS_START;
-    bool _isRadiusStartInitialized;
+    bool _isRadiusStartInitialized = false;
     void setRadiusStart(float radiusStart) { _radiusStart = radiusStart; _isRadiusStartInitialized = true; }
     float getRadiusStart() const { return _isRadiusStartInitialized ? _radiusStart : _particleRadius; }
 
     static const float DEFAULT_RADIUS_FINISH;
-    bool _isRadiusFinishInitialized;
+    bool _isRadiusFinishInitialized = false;
     void setRadiusFinish(float radiusFinish) { _radiusFinish = radiusFinish; _isRadiusFinishInitialized = true; }
     float getRadiusFinish() const { return _isRadiusFinishInitialized ? _radiusFinish : _particleRadius; }
 


### PR DESCRIPTION
Particle radius, color, and alpha start and finish values now stay in sync with the base particle radius, color, and alpha values until such time as start/finish values are explicitly set.