### PR TITLE
Prevent taking a reference to a QUrl rvalue.

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -966,7 +966,8 @@ bool AvatarData::hasIdentityChangedAfterParsing(NLPacket& packet) {
 QByteArray AvatarData::identityByteArray() {
     QByteArray identityData;
     QDataStream identityStream(&identityData, QIODevice::Append);
-    const QUrl& urlToSend = (_skeletonModelURL == AvatarData::defaultFullAvatarModelUrl()) ? QUrl("") : _skeletonModelURL;
+    QUrl emptyURL("");
+    const QUrl& urlToSend = (_skeletonModelURL == AvatarData::defaultFullAvatarModelUrl()) ? emptyURL : _skeletonModelURL;
 
     identityStream << QUuid() << _faceModelURL << urlToSend << _attachmentData << _displayName;
 


### PR DESCRIPTION
This is possibly the cause of the avatar-mixer crash in this stack trace.

http://public.highfidelity.io/crashes/avatar-mixer-production-2-20150930-014352.txt

    Thread 1 (Thread 0x7f02f1fd9700 (LWP 23822)):
    #0  0x00007f02facaa55b in QUrl::QUrl(QUrl const&) () from /usr/local/Qt-5.4.1/lib/libQt5Core.so.5            
    #1  0x000000000059dce0 in AvatarData::identityByteArray() () at /mnt/ebs1/jenkins/jobs/assignment-  client/workspace/libraries/avatars/src/AvatarData.cpp:974
    #2  0x00000000005a33d7 in AvatarData::sendAvatarDataPacket() 