### PR TITLE
allow physical objects to be set collisionless

### DIFF
--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
@@ -79,6 +79,7 @@ public:
     glm::mat4 localToVoxelMatrix() const;
 
     virtual ShapeType getShapeType() const;
+    virtual bool shouldBePhysical() const { return true; }
     virtual bool isReadyToComputeShape();
     virtual void computeShapeInfo(ShapeInfo& info);
 

--- a/libraries/entities/src/BoxEntityItem.h
+++ b/libraries/entities/src/BoxEntityItem.h
@@ -52,6 +52,7 @@ public:
     }
     
     virtual ShapeType getShapeType() const { return SHAPE_TYPE_BOX; }
+    virtual bool shouldBePhysical() const { return true; }
 
     virtual void debugDump() const;
 

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -334,7 +334,7 @@ public:
     bool getCollisionsWillMove() const { return _collisionsWillMove; }
     void setCollisionsWillMove(bool value) { _collisionsWillMove = value; }
 
-    virtual bool shouldBePhysical() const { return !_ignoreForCollisions; }
+    virtual bool shouldBePhysical() const { return false; }
 
     bool getLocked() const { return _locked; }
     void setLocked(bool value) { _locked = value; }

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -457,5 +457,5 @@ QString ModelEntityItem::getAnimationSettings() const {
 
 // virtual
 bool ModelEntityItem::shouldBePhysical() const {
-    return EntityItem::shouldBePhysical() && getShapeType() != SHAPE_TYPE_NONE;
+    return getShapeType() != SHAPE_TYPE_NONE;
 }

--- a/libraries/entities/src/SphereEntityItem.h
+++ b/libraries/entities/src/SphereEntityItem.h
@@ -51,6 +51,7 @@ public:
     }
 
     virtual ShapeType getShapeType() const { return SHAPE_TYPE_SPHERE; }
+    virtual bool shouldBePhysical() const { return true; }
     
     virtual bool supportsDetailedRayIntersection() const { return true; }
     virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -596,6 +596,12 @@ QString EntityMotionState::getName() {
 
 // virtual
 int16_t EntityMotionState::computeCollisionGroup() {
+    if (!_entity) {
+        return COLLISION_GROUP_STATIC;
+    }
+    if (_entity->getIgnoreForCollisions()) {
+        return COLLISION_GROUP_COLLISIONLESS;
+    }
     switch (computeObjectMotionType()){
         case MOTION_TYPE_STATIC:
             return COLLISION_GROUP_STATIC;

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -37,11 +37,11 @@ enum MotionStateType {
 
 // The update flags trigger two varieties of updates: "hard" which require the body to be pulled 
 // and re-added to the physics engine and "easy" which just updates the body properties.
-const uint32_t HARD_DIRTY_PHYSICS_FLAGS = (uint32_t)(EntityItem::DIRTY_MOTION_TYPE | EntityItem::DIRTY_SHAPE);
+const uint32_t HARD_DIRTY_PHYSICS_FLAGS = (uint32_t)(EntityItem::DIRTY_MOTION_TYPE | EntityItem::DIRTY_SHAPE | 
+                                                     EntityItem::DIRTY_COLLISION_GROUP);
 const uint32_t EASY_DIRTY_PHYSICS_FLAGS = (uint32_t)(EntityItem::DIRTY_TRANSFORM | EntityItem::DIRTY_VELOCITIES |
-                                                     EntityItem::DIRTY_MASS | EntityItem::DIRTY_COLLISION_GROUP |
-                                                     EntityItem::DIRTY_MATERIAL | EntityItem::DIRTY_SIMULATOR_ID | 
-                                                     EntityItem::DIRTY_SIMULATOR_OWNERSHIP);
+                                                     EntityItem::DIRTY_MASS | EntityItem::DIRTY_MATERIAL | 
+                                                     EntityItem::DIRTY_SIMULATOR_ID | EntityItem::DIRTY_SIMULATOR_OWNERSHIP);
 
 // These are the set of incoming flags that the PhysicsEngine needs to hear about:
 const uint32_t DIRTY_PHYSICS_FLAGS = (uint32_t)(HARD_DIRTY_PHYSICS_FLAGS | EASY_DIRTY_PHYSICS_FLAGS |


### PR DESCRIPTION
This PR makes it so that the **ignoreForCollisions** entity property means: use COLLISION_GROUP_COLLISIONLESS for such objects -- they are still in the physics engine but have a collisionless group.

The idea is that the grabbed object can be set collisionless (set **ignoreForCollisions** true) while grabbed and then set collidable again (set **ignoreForCollisions** false) when done grabbing.