### PR TITLE
Make log more readable

### DIFF
--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -120,11 +120,11 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
     }
     
     // log prefix is in the following format
-    // [DEBUG] [TIMESTAMP] [PID] [TARGET] logged string
+    // [TIMESTAMP] [DEBUG] [PID] [TARGET] logged string
     
-    QString prefixString = QString("[%1]").arg(stringForLogType(type));
+    QString prefixString = QString("[%1]").arg(QDateTime::currentDateTime().toString(DATE_STRING_FORMAT));
     
-    prefixString.append(QString(" [%1]").arg(QDateTime::currentDateTime().toString(DATE_STRING_FORMAT)));
+    prefixString.append(QString(" [%1]").arg(stringForLogType(type)));
     
     if (_shouldOutputPID) {
         prefixString.append(QString(" [%1]").arg(QCoreApplication::instance()->applicationPid()));


### PR DESCRIPTION
Simple change that makes the log a bit more readable.
Now:
```
[10/05 14:31:06] [DEBUG] DDE Face Tracker: Socket:  "Unconnected"
[10/05 14:31:06] [DEBUG] DDE Face Tracker: Socket:  "Bound"
[10/05 14:31:06] [WARNING] Attempted to remove menu action with no found QML object
[10/05 14:31:06] [WARNING] Attempted to remove menu action with no found QML object
[10/05 14:31:06] [DEBUG] DDE Face Tracker: Socket:  "Closing"
[10/05 14:31:06] [DEBUG] DDE Face Tracker: Socket:  “Unconnected”
```
Before:
```
[DEBUG] [10/05 14:31:06] DDE Face Tracker: Socket:  "Unconnected"
[DEBUG] [10/05 14:31:06] DDE Face Tracker: Socket:  "Bound"
[WARNING] [10/05 14:31:06] Attempted to remove menu action with no found QML object
[WARNING] [10/05 14:31:06] Attempted to remove menu action with no found QML object
[DEBUG] [10/05 14:31:06] DDE Face Tracker: Socket:  "Closing"
[DEBUG] [10/05 14:31:06] DDE Face Tracker: Socket:  “Unconnected”
```