### PR TITLE
Separated AvatarMixer inbound and outbound bandwidth on stats overlay

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -142,8 +142,15 @@ Item {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
                         visible: root.expanded;
-                        text: "Avatar Mixer: " + root.avatarMixerKbps + " kbps, " +
-                            root.avatarMixerPps + "pps";
+                        text: "Avatar Mixer In: " + root.avatarMixerInKbps + " kbps, " +
+                            root.avatarMixerInPps + "pps";
+                    }
+                    Text {
+                        color: root.fontColor;
+                        font.pixelSize: root.fontSize
+                        visible: root.expanded;
+                        text: "Avatar Mixer Out: " + root.avatarMixerOutKbps + " kbps, " +
+                            root.avatarMixerOutPps + "pps";
                     }
                     Text {
                         color: root.fontColor;

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -167,15 +167,15 @@ void Stats::updateStats(bool force) {
     if (_expanded || force) {
         SharedNodePointer avatarMixer = nodeList->soloNodeOfType(NodeType::AvatarMixer);
         if (avatarMixer) {
-            STAT_UPDATE(avatarMixerKbps, roundf(
-                bandwidthRecorder->getAverageInputKilobitsPerSecond(NodeType::AvatarMixer) +
-                bandwidthRecorder->getAverageOutputKilobitsPerSecond(NodeType::AvatarMixer)));
-            STAT_UPDATE(avatarMixerPps, roundf(
-                bandwidthRecorder->getAverageInputPacketsPerSecond(NodeType::AvatarMixer) +
-                bandwidthRecorder->getAverageOutputPacketsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerInKbps, roundf(bandwidthRecorder->getAverageInputKilobitsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerInPps, roundf(bandwidthRecorder->getAverageInputPacketsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerOutKbps, roundf(bandwidthRecorder->getAverageOutputKilobitsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerOutPps, roundf(bandwidthRecorder->getAverageOutputPacketsPerSecond(NodeType::AvatarMixer)));
         } else {
-            STAT_UPDATE(avatarMixerKbps, -1);
-            STAT_UPDATE(avatarMixerPps, -1);
+            STAT_UPDATE(avatarMixerInKbps, -1);
+            STAT_UPDATE(avatarMixerInPps, -1);
+            STAT_UPDATE(avatarMixerOutKbps, -1);
+            STAT_UPDATE(avatarMixerOutPps, -1);
         }
         SharedNodePointer audioMixerNode = nodeList->soloNodeOfType(NodeType::AudioMixer);
         if (audioMixerNode || force) {

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -47,8 +47,10 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(QVector3D, position, QVector3D(0, 0, 0) )
     STATS_PROPERTY(float, velocity, 0)
     STATS_PROPERTY(float, yaw, 0)
-    STATS_PROPERTY(int, avatarMixerKbps, 0)
-    STATS_PROPERTY(int, avatarMixerPps, 0)
+    STATS_PROPERTY(int, avatarMixerInKbps, 0)
+    STATS_PROPERTY(int, avatarMixerInPps, 0)
+    STATS_PROPERTY(int, avatarMixerOutKbps, 0)
+    STATS_PROPERTY(int, avatarMixerOutPps, 0)
     STATS_PROPERTY(int, audioMixerKbps, 0)
     STATS_PROPERTY(int, audioMixerPps, 0)
     STATS_PROPERTY(int, downloads, 0)
@@ -122,8 +124,10 @@ signals:
     void positionChanged();
     void velocityChanged();
     void yawChanged();
-    void avatarMixerKbpsChanged();
-    void avatarMixerPpsChanged();
+    void avatarMixerInKbpsChanged();
+    void avatarMixerInPpsChanged();
+    void avatarMixerOutKbpsChanged();
+    void avatarMixerOutPpsChanged();
     void audioMixerKbpsChanged();
     void audioMixerPpsChanged();
     void downloadsChanged();

--- a/libraries/networking/src/BandwidthRecorder.cpp
+++ b/libraries/networking/src/BandwidthRecorder.cpp
@@ -27,9 +27,9 @@ float BandwidthRecorder::Channel::getAverageInputPacketsPerSecond() {
 }
 
 float BandwidthRecorder::Channel::getAverageOutputPacketsPerSecond() {
-    float delt = _input.getEventDeltaAverage();
+    float delt = _output.getEventDeltaAverage();
     if (delt > 0.0f) {
-        return (1.0f / _output.getEventDeltaAverage());
+        return (1.0f / delt);
     }
     return 0.0f;
 }

--- a/libraries/networking/src/BandwidthRecorder.cpp
+++ b/libraries/networking/src/BandwidthRecorder.cpp
@@ -19,17 +19,17 @@ BandwidthRecorder::Channel::Channel() {
 }
 
 float BandwidthRecorder::Channel::getAverageInputPacketsPerSecond() {
-    float delt = _input.getEventDeltaAverage();
-    if (delt > 0.0f) {
-        return (1.0f / delt);
+    float averageTimeBetweenPackets = _input.getEventDeltaAverage();
+    if (averageTimeBetweenPackets > 0.0f) {
+        return (1.0f / averageTimeBetweenPackets);
     }
     return 0.0f;
 }
 
 float BandwidthRecorder::Channel::getAverageOutputPacketsPerSecond() {
-    float delt = _output.getEventDeltaAverage();
-    if (delt > 0.0f) {
-        return (1.0f / delt);
+    float averageTimeBetweenPackets = _output.getEventDeltaAverage();
+    if (averageTimeBetweenPackets > 0.0f) {
+        return (1.0f / averageTimeBetweenPackets);
     }
     return 0.0f;
 }


### PR DESCRIPTION
Also, small bug fix to BandwidthRecorder. It would incorrectly
calculate outbound pps if the input pps was 0.