### PR TITLE
Fix mouse events for entity scripts

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1825,17 +1825,16 @@ void Application::mouseMoveEvent(QMouseEvent* event, unsigned int deviceID) {
     }
 #endif
 
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    QPointF transformedPos = offscreenUi->mapToVirtualScreen(event->localPos(), _glWidget);
+    QMouseEvent mappedEvent(event->type(),
+        transformedPos,
+        event->screenPos(), event->button(),
+        event->buttons(), event->modifiers());
 
-    _entities.mouseMoveEvent(event, deviceID);
-    {
-        auto offscreenUi = DependencyManager::get<OffscreenUi>();
-        QPointF transformedPos = offscreenUi->mapToVirtualScreen(event->localPos(), _glWidget);
-        QMouseEvent mappedEvent(event->type(),
-            transformedPos,
-            event->screenPos(), event->button(),
-            event->buttons(), event->modifiers());
-        _controllerScriptingInterface.emitMouseMoveEvent(&mappedEvent, deviceID); // send events to any registered scripts
-    }
+
+    _entities.mouseMoveEvent(&mappedEvent, deviceID);
+    _controllerScriptingInterface.emitMouseMoveEvent(&mappedEvent, deviceID); // send events to any registered scripts
 
     // if one of our scripts have asked to capture this event, then stop processing it
     if (_controllerScriptingInterface.isMouseCaptured()) {
@@ -1851,19 +1850,19 @@ void Application::mouseMoveEvent(QMouseEvent* event, unsigned int deviceID) {
 void Application::mousePressEvent(QMouseEvent* event, unsigned int deviceID) {
     // Inhibit the menu if the user is using alt-mouse dragging
     _altPressed = false;
+
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    QPointF transformedPos = offscreenUi->mapToVirtualScreen(event->localPos(), _glWidget);
+    QMouseEvent mappedEvent(event->type(),
+        transformedPos,
+        event->screenPos(), event->button(),
+        event->buttons(), event->modifiers());
+
     if (!_aboutToQuit) {
-        _entities.mousePressEvent(event, deviceID);
+        _entities.mousePressEvent(&mappedEvent, deviceID);
     }
 
-    {
-        auto offscreenUi = DependencyManager::get<OffscreenUi>();
-        QPointF transformedPos = offscreenUi->mapToVirtualScreen(event->localPos(), _glWidget);
-        QMouseEvent mappedEvent(event->type(),
-            transformedPos,
-            event->screenPos(), event->button(),
-            event->buttons(), event->modifiers());
-        _controllerScriptingInterface.emitMousePressEvent(&mappedEvent); // send events to any registered scripts
-    }
+    _controllerScriptingInterface.emitMousePressEvent(&mappedEvent); // send events to any registered scripts
 
     // if one of our scripts have asked to capture this event, then stop processing it
     if (_controllerScriptingInterface.isMouseCaptured()) {
@@ -1879,7 +1878,7 @@ void Application::mousePressEvent(QMouseEvent* event, unsigned int deviceID) {
         if (event->button() == Qt::LeftButton) {
             // nobody handled this - make it an action event on the _window object
             HFActionEvent actionEvent(HFActionEvent::startType(),
-                                      computePickRay(event->x(), event->y()));
+                computePickRay(mappedEvent.x(), mappedEvent.y()));
             sendEvent(this, &actionEvent);
 
         } else if (event->button() == Qt::RightButton) {
@@ -1907,19 +1906,18 @@ void Application::mouseDoublePressEvent(QMouseEvent* event, unsigned int deviceI
 
 void Application::mouseReleaseEvent(QMouseEvent* event, unsigned int deviceID) {
 
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    QPointF transformedPos = offscreenUi->mapToVirtualScreen(event->localPos(), _glWidget);
+    QMouseEvent mappedEvent(event->type(),
+        transformedPos,
+        event->screenPos(), event->button(),
+        event->buttons(), event->modifiers());
+
     if (!_aboutToQuit) {
-        _entities.mouseReleaseEvent(event, deviceID);
+        _entities.mouseReleaseEvent(&mappedEvent, deviceID);
     }
 
-    {
-        auto offscreenUi = DependencyManager::get<OffscreenUi>();
-        QPointF transformedPos = offscreenUi->mapToVirtualScreen(event->localPos(), _glWidget);
-        QMouseEvent mappedEvent(event->type(),
-            transformedPos,
-            event->screenPos(), event->button(),
-            event->buttons(), event->modifiers());
-        _controllerScriptingInterface.emitMouseReleaseEvent(&mappedEvent); // send events to any registered scripts
-    }
+    _controllerScriptingInterface.emitMouseReleaseEvent(&mappedEvent); // send events to any registered scripts
 
     // if one of our scripts have asked to capture this event, then stop processing it
     if (_controllerScriptingInterface.isMouseCaptured()) {
@@ -1934,7 +1932,7 @@ void Application::mouseReleaseEvent(QMouseEvent* event, unsigned int deviceID) {
         if (event->button() == Qt::LeftButton) {
             // fire an action end event
             HFActionEvent actionEvent(HFActionEvent::endType(),
-                                      computePickRay(event->x(), event->y()));
+                computePickRay(mappedEvent.x(), mappedEvent.y()));
             sendEvent(this, &actionEvent);
         }
     }


### PR DESCRIPTION
Entity scripts mouse events weren't getting triggered properly in HMD mode, similar to the other recent fixes for 2D overlay picking and 3D picking in HMDs.  This should resolve.  