### PR TITLE
Low level support for URL overrides when loading content

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -704,7 +704,9 @@ void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, const
     if (_tree && !_shuttingDown) {
         EntityItemPointer entity = getTree()->findEntityByEntityItemID(entityID);
         if (entity && !entity->getScript().isEmpty()) {
-            _entitiesScriptEngine->loadEntityScript(entityID, entity->getScript(), reload);
+            QString scriptUrl = entity->getScript();
+            scriptUrl = ResourceManager::normalizeURL(scriptUrl);
+            _entitiesScriptEngine->loadEntityScript(entityID, scriptUrl, reload);
         }
     }
 }

--- a/libraries/networking/src/ResourceManager.cpp
+++ b/libraries/networking/src/ResourceManager.cpp
@@ -17,31 +17,24 @@
 
 #include <SharedUtil.h>
 
+ResourceManager::PrefixMap ResourceManager::_prefixMap;
+QMutex ResourceManager::_prefixMapLock;
 
-using PrefixMap = std::map<QString, QString>;
-static PrefixMap PREFIX_MAP;
-static QMutex PREFIX_MAP_LOCK;
 
 void ResourceManager::setUrlPrefixOverride(const QString& prefix, const QString& replacement) {
-    QMutexLocker locker(&PREFIX_MAP_LOCK);
-    PREFIX_MAP[prefix] = replacement;
+    QMutexLocker locker(&_prefixMapLock);
+    _prefixMap[prefix] = replacement;
 }
 
 QString ResourceManager::normalizeURL(const QString& urlString) {
     QString result = urlString;
-    QMutexLocker locker(&PREFIX_MAP_LOCK);
-    bool modified{ false };
-    foreach(const auto& entry, PREFIX_MAP) {
+    QMutexLocker locker(&_prefixMapLock);
+    foreach(const auto& entry, _prefixMap) {
         const auto& prefix = entry.first;
         const auto& replacement = entry.second;
         if (result.startsWith(prefix)) {
-            qDebug() << prefix;
             result.replace(0, prefix.size(), replacement);
-            modified = true;
         }
-    }
-    if (modified) {
-        qDebug() << result;
     }
     return result;
 }

--- a/libraries/networking/src/ResourceManager.h
+++ b/libraries/networking/src/ResourceManager.h
@@ -14,6 +14,8 @@
 
 #include <functional>
 
+#include <QtCore/QMutex>
+
 #include "ResourceRequest.h"
 
 const QString URL_SCHEME_FILE = "file";
@@ -28,6 +30,11 @@ public:
     static QString normalizeURL(const QString& urlString);
     static QUrl normalizeURL(const QUrl& url);
     static ResourceRequest* createResourceRequest(QObject* parent, const QUrl& url);
+private:
+    using PrefixMap = std::map<QString, QString>;
+
+    static PrefixMap _prefixMap;
+    static QMutex _prefixMapLock;
 };
 
 #endif

--- a/libraries/networking/src/ResourceManager.h
+++ b/libraries/networking/src/ResourceManager.h
@@ -24,6 +24,8 @@ const QString URL_SCHEME_ATP = "atp";
 
 class ResourceManager {
 public:
+    static void setUrlPrefixOverride(const QString& prefix, const QString& replacement);
+    static QString normalizeURL(const QString& urlString);
     static QUrl normalizeURL(const QUrl& url);
     static ResourceRequest* createResourceRequest(QObject* parent, const QUrl& url);
 };

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -88,6 +88,7 @@ void Procedural::parse(const QJsonObject& proceduralData) {
     // Get the path to the shader
     {
         QString shaderUrl = proceduralData[URL_KEY].toString();
+        shaderUrl = ResourceManager::normalizeURL(shaderUrl);
         _shaderUrl = QUrl(shaderUrl);
         if (!_shaderUrl.isValid()) {
             qWarning() << "Invalid shader URL: " << shaderUrl;


### PR DESCRIPTION
This change is to support a content creation workflow.  Imagine that you're a developer with a bunch Hifi content in a local folder which is also mirrored in S3.  

In order to tweak your content, you have to go into Interface, modify the entity to change the URL to point to the local file, make changes, test them, push the content and then edit the entity to change the URL back to the server version.  While the entities point to local files, they can't be viewed by others.  Alternatively, you have to make changes, push to S3 and then zone out and back to see them.  Both workflows are annoying if you want to iterate on content like scripts or shaders quickly especially since both scripts and shaders support automatic reloading if the content is a local file and the modification date changes.

This change starts to enable a new workflow.  Instead of editing the entities at all, you can create a mapping... for instance:  `    ResourceManager::setUrlPrefixOverride("https://s3.amazonaws.com/DreamingContent/", "file:///C:/Users/bdavis/Git/dreaming/");`

When you use ResourceManager::normalizeURL, this mapping will be applied to the URL.  This means that a client running with this mapping can work directly against their local content without disrupting the view of other clients connecting to the server.  When you're happy with the changes, you can push your changes to S3 and everyone else can see them.  This drastically reduces the effort required to make modifications to shader and script content.

This functionality is incomplete right now because there's no mechanism to create or change a mapping right now, short of adding a line of code in the app startup as above.  A future PR will support CRUD operations on mappings through Javascript.  