### PR TITLE
IK moves hips

### DIFF
--- a/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
+++ b/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
@@ -16,12 +16,14 @@
                         {
                             "jointName": "RightHand",
                             "positionVar": "rightHandPosition",
-                            "rotationVar": "rightHandRotation"
+                            "rotationVar": "rightHandRotation",
+                            "typeVar": "rightHandType"
                         },
                         {
                             "jointName": "LeftHand",
                             "positionVar": "leftHandPosition",
-                            "rotationVar": "leftHandRotation"
+                            "rotationVar": "leftHandRotation",
+                            "typeVar": "leftHandType"
                         },
                         {
                             "jointName": "RightFoot",
@@ -39,13 +41,13 @@
                             "jointName": "Neck",
                             "positionVar": "neckPosition",
                             "rotationVar": "neckRotation",
-                            "typeVar": "headAndNeckType"
+                            "typeVar": "neckType"
                         },
                         {
                             "jointName": "Head",
                             "positionVar": "headPosition",
                             "rotationVar": "headRotation",
-                            "typeVar": "headAndNeckType"
+                            "typeVar": "headType"
                         }
                     ]
                 },
@@ -63,7 +65,7 @@
                         "id": "spineLean",
                         "type": "manipulator",
                         "data": {
-                            "alpha": 1.0,
+                            "alpha": 0.0,
                             "joints": [
                                 { "var": "lean", "jointName": "Spine" }
                             ]

--- a/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
+++ b/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
@@ -27,15 +27,15 @@
                         },
                         {
                             "jointName": "RightFoot",
-                            "positionVar": "rightToePosition",
-                            "rotationVar": "rightToeRotation",
-                            "typeVar": "rightToeType"
+                            "positionVar": "rightFootPosition",
+                            "rotationVar": "rightFootRotation",
+                            "typeVar": "rightFootType"
                         },
                         {
                             "jointName": "LeftFoot",
-                            "positionVar": "leftToePosition",
-                            "rotationVar": "leftToeRotation",
-                            "typeVar": "leftToeType"
+                            "positionVar": "leftFootPosition",
+                            "rotationVar": "leftFootRotation",
+                            "typeVar": "leftFootType"
                         },
                         {
                             "jointName": "Neck",

--- a/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
+++ b/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
@@ -24,6 +24,18 @@
                             "rotationVar": "leftHandRotation"
                         },
                         {
+                            "jointName": "RightFoot",
+                            "positionVar": "rightToePosition",
+                            "rotationVar": "rightToeRotation",
+                            "typeVar": "rightToeType"
+                        },
+                        {
+                            "jointName": "LeftFoot",
+                            "positionVar": "leftToePosition",
+                            "rotationVar": "leftToeRotation",
+                            "typeVar": "leftToeType"
+                        },
+                        {
                             "jointName": "Neck",
                             "positionVar": "neckPosition",
                             "rotationVar": "neckRotation",

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -337,16 +337,18 @@ void MyAvatar::updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix) {
     const float STRAIGHTENING_LEAN_DURATION = 0.5f;  // seconds
 
     // define a vertical capsule
+    static float adebug = 1.0f; // adebug
     const float STRAIGHTENING_LEAN_CAPSULE_RADIUS = 0.2f;  // meters
     const float STRAIGHTENING_LEAN_CAPSULE_LENGTH = 0.05f;  // length of the cylinder part of the capsule in meters.
 
     auto newBodySensorMatrix = deriveBodyFromHMDSensor();
     glm::vec3 diff = extractTranslation(newBodySensorMatrix) - extractTranslation(_bodySensorMatrix);
-    if (!_straighteningLean && (capsuleCheck(diff, STRAIGHTENING_LEAN_CAPSULE_LENGTH, STRAIGHTENING_LEAN_CAPSULE_RADIUS) || hmdIsAtRest)) {
+    if (!_straighteningLean && (capsuleCheck(diff, adebug * STRAIGHTENING_LEAN_CAPSULE_LENGTH, adebug * STRAIGHTENING_LEAN_CAPSULE_RADIUS) || hmdIsAtRest)) {
 
         // begin homing toward derived body position.
         _straighteningLean = true;
         _straighteningLeanAlpha = 0.0f;
+        adebug = 1000.0f; // adebug
 
     } else if (_straighteningLean) {
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -337,18 +337,16 @@ void MyAvatar::updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix) {
     const float STRAIGHTENING_LEAN_DURATION = 0.5f;  // seconds
 
     // define a vertical capsule
-    static float adebug = 1.0f; // adebug
     const float STRAIGHTENING_LEAN_CAPSULE_RADIUS = 0.2f;  // meters
     const float STRAIGHTENING_LEAN_CAPSULE_LENGTH = 0.05f;  // length of the cylinder part of the capsule in meters.
 
     auto newBodySensorMatrix = deriveBodyFromHMDSensor();
     glm::vec3 diff = extractTranslation(newBodySensorMatrix) - extractTranslation(_bodySensorMatrix);
-    if (!_straighteningLean && (capsuleCheck(diff, adebug * STRAIGHTENING_LEAN_CAPSULE_LENGTH, adebug * STRAIGHTENING_LEAN_CAPSULE_RADIUS) || hmdIsAtRest)) {
+    if (!_straighteningLean && (capsuleCheck(diff, STRAIGHTENING_LEAN_CAPSULE_LENGTH, STRAIGHTENING_LEAN_CAPSULE_RADIUS) || hmdIsAtRest)) {
 
         // begin homing toward derived body position.
         _straighteningLean = true;
         _straighteningLeanAlpha = 0.0f;
-        adebug = 1000.0f; // adebug
 
     } else if (_straighteningLean) {
 

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -162,7 +162,7 @@ void AnimInverseKinematics::solveWithCyclicCoordinateDescent(const std::vector<I
             }
 
             glm::vec3 tipPosition = absolutePoses[tipIndex].trans;
-            //glm::quat tipRotation = absolutePoses[tipIndex].rot;
+            glm::quat tipRotation = absolutePoses[tipIndex].rot;
 
             // cache tip's parent's absolute rotation so we can recompute the tip's parent-relative 
             // as we proceed walking down the joint chain
@@ -220,11 +220,11 @@ void AnimInverseKinematics::solveWithCyclicCoordinateDescent(const std::vector<I
                         }
                     }
                 } else if (targetType == IKTarget::Type::HmdHead) {
-                    /* TODO: implement this
                     // An HmdHead target slaves the orientation of the end-effector by distributing rotation 
                     // deltas up the hierarchy.  Its target position is enforced later by shifting the hips.
                     deltaRotation = target.getRotation() * glm::inverse(tipRotation);
-                    */
+                    float dotSign = copysignf(1.0f, deltaRotation.w);
+                    deltaRotation = glm::normalize(glm::lerp(glm::quat(), dotSign * deltaRotation, 0.15f));
                 }
 
                 // compute joint's new parent-relative rotation after swing
@@ -258,6 +258,7 @@ void AnimInverseKinematics::solveWithCyclicCoordinateDescent(const std::vector<I
 
                 // keep track of tip's new transform as we descend towards root
                 tipPosition = jointPosition + deltaRotation * leverArm;
+                tipRotation = glm::normalize(deltaRotation * tipRotation);
                 tipParentRotation = glm::normalize(deltaRotation * tipParentRotation);
 
                 pivotIndex = pivotsParentIndex;

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -131,10 +131,6 @@ void AnimInverseKinematics::computeTargets(const AnimVariantMap& animVars, std::
             }
         }
     }
-    static int adebug = 0; ++adebug; bool verbose = (0 == (adebug % 100));
-    if (verbose) {
-        std::cout << "adebug num targets = " << targets.size() << std::endl;  // adebug
-    }
 }
 
 void AnimInverseKinematics::solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets) {
@@ -408,7 +404,6 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
             // smooth transitions by relaxing _hipsOffset toward the new value
             const float HIPS_OFFSET_SLAVE_TIMESCALE = 0.15f;
             _hipsOffset += (newHipsOffset - _hipsOffset) * (dt / HIPS_OFFSET_SLAVE_TIMESCALE);
-            //_hipsOffset *= 0.0f; // adebug
             if (glm::length2(hmdHipsOffset) < 100.0f) {
                 _hipsOffset = hmdHipsOffset;
             }

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -95,14 +95,16 @@ void AnimInverseKinematics::computeTargets(const AnimVariantMap& animVars, std::
             }
         } else {
             IKTarget target;
-            AnimPose defaultPose = _skeleton->getAbsolutePose(targetVar.jointIndex, underPoses);
-            target.setPose(animVars.lookup(targetVar.rotationVar, defaultPose.rot), 
-                        animVars.lookup(targetVar.positionVar, defaultPose.trans));
-            target.setType(animVars.lookup(targetVar.typeVar, (int)IKTarget::Type::Unknown));
-            target.setIndex(targetVar.jointIndex);
-            targets.push_back(target);
-            if (targetVar.jointIndex > _maxTargetIndex) {
-                _maxTargetIndex = targetVar.jointIndex;
+            target.setType(animVars.lookup(targetVar.typeVar, (int)IKTarget::Type::RotationAndPosition));
+            if (target.getType() != IKTarget::Type::Unknown) {
+                AnimPose defaultPose = _skeleton->getAbsolutePose(targetVar.jointIndex, underPoses);
+                target.setPose(animVars.lookup(targetVar.rotationVar, defaultPose.rot), 
+                            animVars.lookup(targetVar.positionVar, defaultPose.trans));
+                target.setIndex(targetVar.jointIndex);
+                targets.push_back(target);
+                if (targetVar.jointIndex > _maxTargetIndex) {
+                    _maxTargetIndex = targetVar.jointIndex;
+                }
             }
         }
     }

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -356,12 +356,12 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
             }
         } else {
             // shift the hips according to the offset from the previous frame
-            float offsetLength = glm::length(_actualHipsOffset);
+            float offsetLength = glm::length(_hipsOffset);
             const float MIN_OFFSET_LENGTH = 0.03f;
             if (offsetLength > MIN_OFFSET_LENGTH) {
                 // but only if actual offset is long enough
                 float scaleFactor = ((offsetLength - MIN_OFFSET_LENGTH) / offsetLength);
-                _relativePoses[0].trans = underPoses[0].trans + scaleFactor * _actualHipsOffset;
+                _relativePoses[0].trans = underPoses[0].trans + scaleFactor * _hipsOffset;
             }
 
             solveWithCyclicCoordinateDescent(targets);
@@ -369,7 +369,7 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
             // compute the new target hips offset (for next frame)
             // by looking for discrepancies between where a targeted endEffector is
             // and where it wants to be (after IK solutions are done)
-            _targetHipsOffset = Vectors::ZERO;
+            glm::vec3 newOffset = Vectors::ZERO;
             for (auto& target: targets) {
                 if (target.index == _headIndex && _headIndex != -1) {
                     // special handling for headTarget
@@ -382,18 +382,18 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
                     }
                     glm::vec3 headOffset = headOverPose.trans - headUnderPose.trans;
                     const float HEAD_OFFSET_SLAVE_FACTOR = 0.65f;
-                    _targetHipsOffset += HEAD_OFFSET_SLAVE_FACTOR * headOffset;
+                    newOffset += HEAD_OFFSET_SLAVE_FACTOR * headOffset;
                 } else if (target.type == IKTarget::Type::RotationAndPosition) {
                     glm::vec3 actualPosition = _skeleton->getAbsolutePose(target.index, _relativePoses).trans;
                     glm::vec3 targetPosition = target.pose.trans;
-                    _targetHipsOffset += targetPosition - actualPosition;
+                    newOffset += targetPosition - actualPosition;
                 }
             }
 
-            // smooth transitions by relaxing targetHipsOffset onto actualHipsOffset over some timescale
+            // smooth transitions by relaxing _hipsOffset toward the new value
             const float HIPS_OFFSET_SLAVE_TIMESCALE = 0.15f;
-            glm::vec3 deltaOffset = (_targetHipsOffset - _actualHipsOffset) * (dt / HIPS_OFFSET_SLAVE_TIMESCALE);
-            _actualHipsOffset += deltaOffset;
+            glm::vec3 deltaOffset = (newOffset - _hipsOffset) * (dt / HIPS_OFFSET_SLAVE_TIMESCALE);
+            _hipsOffset += deltaOffset;
         }
     }
     return _relativePoses;

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -60,6 +60,10 @@ protected:
     void clearConstraints();
     void initConstraints();
 
+    // no copies
+    AnimInverseKinematics(const AnimInverseKinematics&) = delete;
+    AnimInverseKinematics& operator=(const AnimInverseKinematics&) = delete;
+
     struct IKTargetVar {
         IKTargetVar(const QString& jointNameIn, 
                 const QString& positionVarIn, 
@@ -85,9 +89,10 @@ protected:
     AnimPoseVec _defaultRelativePoses; // poses of the relaxed state
     AnimPoseVec _relativePoses; // current relative poses
 
-    // no copies
-    AnimInverseKinematics(const AnimInverseKinematics&) = delete;
-    AnimInverseKinematics& operator=(const AnimInverseKinematics&) = delete;
+    // experimental data for moving hips during IK
+    int _headIndex = -1;
+    glm::vec3 _targetHipsOffset = Vectors::ZERO; // offset we want
+    glm::vec3 _actualHipsOffset = Vectors::ZERO; // offset we have
 
     // _maxTargetIndex is tracked to help optimize the recalculation of absolute poses
     // during the the cyclic coordinate descent algorithm

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "AnimNode.h"
+#include "IKTarget.h"
 
 #include "RotationAccumulator.h"
 
@@ -37,18 +38,6 @@ public:
     virtual const AnimPoseVec& overlay(const AnimVariantMap& animVars, float dt, Triggers& triggersOut, const AnimPoseVec& underPoses) override;
 
 protected:
-    struct IKTarget {
-        enum class Type {
-            RotationAndPosition,
-            RotationOnly 
-        };
-        AnimPose pose;
-        int index;
-        Type type = Type::RotationAndPosition;
-
-        void setType(const QString& typeVar) { type = ((typeVar == "RotationOnly") ?  Type::RotationOnly : Type::RotationAndPosition); }
-    };
-
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets, const AnimPoseVec& underPoses);
     void solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets);
     virtual void setSkeletonInternal(AnimSkeleton::ConstPointer skeleton) override;

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -91,8 +91,7 @@ protected:
 
     // experimental data for moving hips during IK
     int _headIndex = -1;
-    glm::vec3 _targetHipsOffset = Vectors::ZERO; // offset we want
-    glm::vec3 _actualHipsOffset = Vectors::ZERO; // offset we have
+    glm::vec3 _hipsOffset = Vectors::ZERO;
 
     // _maxTargetIndex is tracked to help optimize the recalculation of absolute poses
     // during the the cyclic coordinate descent algorithm

--- a/libraries/animation/src/IKTarget.cpp
+++ b/libraries/animation/src/IKTarget.cpp
@@ -1,0 +1,31 @@
+//
+//  IKTarget.cpp
+//
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "IKTarget.h"
+
+void IKTarget::setPose(const glm::quat& rotation, const glm::vec3& translation) {
+    _pose.rot = rotation;
+    _pose.trans = translation;
+}
+
+void IKTarget::setType(int type) {
+    switch (type) {
+        case (int)Type::RotationAndPosition:
+            _type = Type::RotationAndPosition;
+            break;
+        case (int)Type::RotationOnly:
+            _type = Type::RotationOnly;
+            break;
+        case (int)Type::HmdHead:
+            _type = Type::HmdHead;
+            break;
+        default:
+            _type = Type::Unknown;
+    }
+}

--- a/libraries/animation/src/IKTarget.cpp
+++ b/libraries/animation/src/IKTarget.cpp
@@ -25,6 +25,9 @@ void IKTarget::setType(int type) {
         case (int)Type::HmdHead:
             _type = Type::HmdHead;
             break;
+        case (int)Type::HipsRelativeRotationAndPosition:
+            _type = Type::HipsRelativeRotationAndPosition;
+            break;
         default:
             _type = Type::Unknown;
     }

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -1,0 +1,42 @@
+//
+//  IKTarget.h
+//
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_IKTarget_h
+#define hifi_IKTarget_h
+
+#include "AnimSkeleton.h"
+
+class IKTarget {
+public:
+    enum class Type {
+        RotationAndPosition,
+        RotationOnly,
+        HmdHead,
+        Unknown,
+    };
+
+    IKTarget() {}
+
+    const glm::vec3& getTranslation() const { return _pose.trans; }
+    const glm::quat& getRotation() const { return _pose.rot; }
+    int getIndex() const { return _index; }
+    Type getType() const { return _type; }
+
+    void setPose(const glm::quat& rotation, const glm::vec3& translation);
+    void setIndex(int index) { _index = index; }
+    void setType(int);
+
+private:
+    AnimPose _pose;
+    int _index = -1;
+    Type _type = Type::RotationAndPosition;
+
+};
+
+#endif // hifi_IKTarget_h

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -18,6 +18,7 @@ public:
         RotationAndPosition,
         RotationOnly,
         HmdHead,
+        HipsRelativeRotationAndPosition,
         Unknown,
     };
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -14,13 +14,14 @@
 #include <glm/gtx/vector_angle.hpp>
 #include <queue>
 
-#include "NumericalConstants.h"
+#include <NumericalConstants.h>
+#include <DebugDraw.h>
+
 #include "AnimationHandle.h"
 #include "AnimationLogging.h"
 #include "AnimSkeleton.h"
-#include "DebugDraw.h"
+#include "IKTarget.h"
 
-#include "Rig.h"
 
 void Rig::HeadParameters::dump() const {
     qCDebug(animation, "HeadParameters =");
@@ -1057,7 +1058,7 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
 
                 _animVars.set("headPosition", headPos);
                 _animVars.set("headRotation", headRot);
-                _animVars.set("headAndNeckType", QString("RotationAndPosition"));
+                _animVars.set("headAndNeckType", (int)IKTarget::Type::RotationAndPosition);
                 _animVars.set("neckPosition", neckPos);
                 _animVars.set("neckRotation", neckRot);
 
@@ -1070,7 +1071,7 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
 
                 _animVars.unset("headPosition");
                 _animVars.set("headRotation", realLocalHeadOrientation);
-                _animVars.set("headAndNeckType", QString("RotationOnly"));
+                _animVars.set("headAndNeckType", (int)IKTarget::Type::RotationOnly);
                 _animVars.unset("neckPosition");
                 _animVars.unset("neckRotation");
             }

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1058,9 +1058,11 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
 
                 _animVars.set("headPosition", headPos);
                 _animVars.set("headRotation", headRot);
-                _animVars.set("headAndNeckType", (int)IKTarget::Type::RotationAndPosition);
+                _animVars.set("headType", (int)IKTarget::Type::HmdHead);
                 _animVars.set("neckPosition", neckPos);
                 _animVars.set("neckRotation", neckRot);
+                //_animVars.set("neckType", (int)IKTarget::Type::RotationOnly);
+                _animVars.set("neckType", (int)IKTarget::Type::Unknown); // 'Unknown' disables the target
 
             } else {
 
@@ -1072,8 +1074,10 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
                 _animVars.unset("headPosition");
                 _animVars.set("headRotation", realLocalHeadOrientation);
                 _animVars.set("headAndNeckType", (int)IKTarget::Type::RotationOnly);
+                _animVars.set("headType", (int)IKTarget::Type::RotationOnly);
                 _animVars.unset("neckPosition");
                 _animVars.unset("neckRotation");
+                _animVars.set("neckType", (int)IKTarget::Type::RotationOnly);
             }
         } else if (!_enableAnimGraph) {
 
@@ -1131,16 +1135,20 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
         if (params.isLeftEnabled) {
             _animVars.set("leftHandPosition", rootBindPose.trans + rootBindPose.rot * yFlipHACK * params.leftPosition);
             _animVars.set("leftHandRotation", rootBindPose.rot * yFlipHACK * params.leftOrientation);
+            _animVars.set("leftHandType", (int)IKTarget::Type::RotationAndPosition);
         } else {
             _animVars.unset("leftHandPosition");
             _animVars.unset("leftHandRotation");
+            _animVars.set("leftHandType", (int)IKTarget::Type::HipsRelativeRotationAndPosition);
         }
         if (params.isRightEnabled) {
             _animVars.set("rightHandPosition", rootBindPose.trans + rootBindPose.rot * yFlipHACK * params.rightPosition);
             _animVars.set("rightHandRotation", rootBindPose.rot * yFlipHACK * params.rightOrientation);
+            _animVars.set("rightHandType", (int)IKTarget::Type::RotationAndPosition);
         } else {
             _animVars.unset("rightHandPosition");
             _animVars.unset("rightHandRotation");
+            _animVars.set("rightHandType", (int)IKTarget::Type::HipsRelativeRotationAndPosition);
         }
 
         // set leftHand grab vars


### PR DESCRIPTION
The inverse kinematics (IK) system computes a hip offset as a function of head and other IK targets, then shifts the skeleton's hips accordingly.  Works in 2D-screenie mode and also with HMD.