### PR TITLE
Fix for sending translation for non-animated joints.

### DIFF
--- a/libraries/animation/src/JointState.cpp
+++ b/libraries/animation/src/JointState.cpp
@@ -215,7 +215,7 @@ bool JointState::rotationIsDefault(const glm::quat& rotation, float tolerance) c
 }
 
 bool JointState::translationIsDefault(const glm::vec3& translation, float tolerance) const {
-    return glm::distance(_defaultTranslation * _unitsScale, translation * _unitsScale) < tolerance;
+    return glm::distance(_defaultTranslation * _unitsScale, translation) < tolerance;
 }
 
 glm::quat JointState::getDefaultRotationInParentFrame() const {


### PR DESCRIPTION
Only the JointState._defaultTranslation needs to be multiplied
by the unitScale in JointState::translationIsDefault().  This
was incorrectly flagging some non-animated joints as animated.