### PR TITLE
Rotate the avatar to align with the HMD while moving

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1109,13 +1109,10 @@ void Application::paintGL() {
             }
         } else if (_myCamera.getMode() == CAMERA_MODE_THIRD_PERSON) {
             if (isHMDMode()) {
-                glm::quat hmdRotation = extractRotation(myAvatar->getHMDSensorMatrix());
-                _myCamera.setRotation(myAvatar->getWorldAlignedOrientation() * hmdRotation);
-                // Ignore MenuOption::CenterPlayerInView in HMD view
-                glm::vec3 hmdOffset = extractTranslation(myAvatar->getHMDSensorMatrix());
-                _myCamera.setPosition(myAvatar->getDefaultEyePosition()
-                    + myAvatar->getOrientation() 
-                    * (myAvatar->getScale() * myAvatar->getBoomLength() * glm::vec3(0.0f, 0.0f, 1.0f) + hmdOffset));
+                auto hmdWorldMat = myAvatar->getSensorToWorldMatrix() * myAvatar->getHMDSensorMatrix();
+                _myCamera.setRotation(glm::normalize(glm::quat_cast(hmdWorldMat)));
+                auto worldBoomOffset = myAvatar->getOrientation() * (myAvatar->getScale() * myAvatar->getBoomLength() * glm::vec3(0.0f, 0.0f, 1.0f));
+                _myCamera.setPosition(extractTranslation(hmdWorldMat) + worldBoomOffset);
             } else {
                 _myCamera.setRotation(myAvatar->getHead()->getOrientation());
                 if (Menu::getInstance()->isOptionChecked(MenuOption::CenterPlayerInView)) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -320,6 +320,7 @@ static bool capsuleCheck(const glm::vec3& pos, float capsuleLen, float capsuleRa
 // as it moves through the world.
 void MyAvatar::updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix) {
 
+    // calc deltaTime
     auto now = usecTimestampNow();
     auto deltaUsecs = now - _lastUpdateFromHMDTime;
     _lastUpdateFromHMDTime = now;
@@ -334,21 +335,61 @@ void MyAvatar::updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix) {
 
     bool hmdIsAtRest = _hmdAtRestDetector.update(deltaTime, _hmdSensorPosition, _hmdSensorOrientation);
 
-    const float STRAIGHTENING_LEAN_DURATION = 0.5f;  // seconds
+    // It can be more accurate/smooth to use velocity rather than position,
+    // but some modes (e.g., hmd standing) update position without updating velocity.
+    // So, let's create our own workingVelocity from the worldPosition...
+    glm::vec3 positionDelta = getPosition() - _lastPosition;
+    glm::vec3 workingVelocity = positionDelta / deltaTime;
+    _lastPosition = getPosition();
 
+    const float MOVE_ENTER_SPEED_THRESHOLD = 0.2f; // m/sec
+    const float MOVE_EXIT_SPEED_THRESHOLD = 0.07f;  // m/sec
+    bool isMoving;
+    if (_lastIsMoving) {
+        isMoving = glm::length(workingVelocity) >= MOVE_EXIT_SPEED_THRESHOLD;
+    } else {
+        isMoving = glm::length(workingVelocity) > MOVE_ENTER_SPEED_THRESHOLD;
+    }
+
+    bool justStartedMoving = (_lastIsMoving != isMoving) && isMoving;
+    _lastIsMoving = isMoving;
+
+    if (shouldBeginStraighteningLean() || hmdIsAtRest || justStartedMoving) {
+        beginStraighteningLean();
+    }
+
+    processStraighteningLean(deltaTime);
+}
+
+void MyAvatar::beginStraighteningLean() {
+    // begin homing toward derived body position.
+    if (!_straighteningLean) {
+        _straighteningLean = true;
+        _straighteningLeanAlpha = 0.0f;
+    }
+}
+
+bool MyAvatar::shouldBeginStraighteningLean() const {
     // define a vertical capsule
     const float STRAIGHTENING_LEAN_CAPSULE_RADIUS = 0.2f;  // meters
     const float STRAIGHTENING_LEAN_CAPSULE_LENGTH = 0.05f;  // length of the cylinder part of the capsule in meters.
 
+    // detect if the derived body position is outside of a capsule around the _bodySensorMatrix
     auto newBodySensorMatrix = deriveBodyFromHMDSensor();
     glm::vec3 diff = extractTranslation(newBodySensorMatrix) - extractTranslation(_bodySensorMatrix);
-    if (!_straighteningLean && (capsuleCheck(diff, STRAIGHTENING_LEAN_CAPSULE_LENGTH, STRAIGHTENING_LEAN_CAPSULE_RADIUS) || hmdIsAtRest)) {
+    bool isBodyPosOutsideCapsule = capsuleCheck(diff, STRAIGHTENING_LEAN_CAPSULE_LENGTH, STRAIGHTENING_LEAN_CAPSULE_RADIUS);
 
-        // begin homing toward derived body position.
-        _straighteningLean = true;
-        _straighteningLeanAlpha = 0.0f;
+    if (isBodyPosOutsideCapsule) {
+        return true;
+    } else {
+        return false;
+    }
+}
 
-    } else if (_straighteningLean) {
+void MyAvatar::processStraighteningLean(float deltaTime) {
+    if (_straighteningLean) {
+
+        const float STRAIGHTENING_LEAN_DURATION = 0.5f;  // seconds
 
         auto newBodySensorMatrix = deriveBodyFromHMDSensor();
         auto worldBodyMatrix = _sensorToWorldMatrix * newBodySensorMatrix;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -271,6 +271,10 @@ private:
     const RecorderPointer getRecorder() const { return _recorder; }
     const PlayerPointer getPlayer() const { return _player; }
 
+    void beginStraighteningLean();
+    bool shouldBeginStraighteningLean() const;
+    void processStraighteningLean(float deltaTime);
+
     bool cameraInsideHead() const;
 
     // These are made private for MyAvatar so that you will use the "use" methods instead
@@ -366,6 +370,8 @@ private:
 
     quint64 _lastUpdateFromHMDTime = usecTimestampNow();
     AtRestDetector _hmdAtRestDetector;
+    glm::vec3 _lastPosition;
+    bool _lastIsMoving = false;
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/libraries/animation/src/AnimStateMachine.cpp
+++ b/libraries/animation/src/AnimStateMachine.cpp
@@ -93,7 +93,7 @@ void AnimStateMachine::switchState(const AnimVariantMap& animVars, State::Pointe
     const float dt = 0.0f;
     Triggers triggers;
     _nextPoses = nextStateNode->evaluate(animVars, dt, triggers);
-#if WANT_DEBUGa
+#if WANT_DEBUG
     qCDebug(animation) << "AnimStateMachine::switchState:" << _currentState->getID() << "->" << desiredState->getID() << "duration =" << duration << "targetFrame =" << desiredState->_interpTarget;
 #endif
     _currentState = desiredState;

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -236,6 +236,8 @@ public:
         Move
     };
     RigRole _state = RigRole::Idle;
+    RigRole _desiredState = RigRole::Idle;
+    float _desiredStateAge = 0.0f;
     float _leftHandOverlayAlpha = 0.0f;
     float _rightHandOverlayAlpha = 0.0f;
 };


### PR DESCRIPTION
MyAvatar: refactored updateFromHMDSensorMatrix() a bit by splitting it into several methods, because it was getting quite large and becoming hard to follow.

* beginStraighteningLean() - can be called when we would like to trigger a re-centering action.
* shouldBeginStraighteningLean() - contains some of the logic to decide if we should begin a re-centering action. For now it encapulates the capsule check.
* processStraighteningLean() - performs the actual re-centering calculation.

New code was added to MyAvatar::updateFromHMDSensorMatrix() to trigger re-centering when the avatar speed rises over a threshold.

Secondly the Rig::computeMotionAnimationState() state machine for animGraph added a state change hysteresis of 100ms.  This hysteresis should help smooth over two issues.

1. When the delta position is 0, because the physics timestep was not evaluated.
2. During re-centering due to desired motion, the avatar velocity can fluctuate causing undesired animation state fluctuation.

Thirdly, the third person camera boom is calculated a bit differently when wearing an HMD.  Basically the boom is behind the character's position/orientation i.e. hips, if the character's rotation changes the boom will swing behind the character.  After the addition of rotation comfort mode for avatar rotation, this is not that disorienting.