### PR TITLE
basic mono preview for the oculus display plugin

### DIFF
--- a/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/oculus/OculusDisplayPlugin.h
@@ -14,6 +14,7 @@ using SwapFboPtr = QSharedPointer<SwapFramebufferWrapper>;
 
 class OculusDisplayPlugin : public OculusBaseDisplayPlugin {
 public:
+    virtual void activate() override;
     virtual void deactivate() override;
     virtual const QString & getName() const override;
 
@@ -25,7 +26,8 @@ protected:
 
 private:
     static const QString NAME;
-    bool _enableMirror{ false };
+    bool _enablePreview { false };
+    bool _monoPreview { true };
 
 #if (OVR_MAJOR_VERSION >= 6)
     SwapFboPtr       _sceneFbo;

--- a/libraries/display-plugins/src/display-plugins/stereo/StereoDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/stereo/StereoDisplayPlugin.cpp
@@ -61,6 +61,8 @@ glm::mat4 StereoDisplayPlugin::getProjection(Eye eye, const glm::mat4& baseProje
     return eyeProjection;
 }
 
+static const QString FRAMERATE = DisplayPlugin::MENU_PATH() + ">Framerate";
+
 std::vector<QAction*> _screenActions;
 void StereoDisplayPlugin::activate() {
     auto screens = qApp->screens();
@@ -76,6 +78,9 @@ void StereoDisplayPlugin::activate() {
             [this](bool clicked) { updateScreen(); }, true, checked, "Screens");
         _screenActions[i] = action;
     }
+
+    CONTAINER->removeMenu(FRAMERATE);
+
     CONTAINER->setFullscreen(qApp->primaryScreen());
     WindowOpenGLDisplayPlugin::activate();
 }


### PR DESCRIPTION
* Adds a default "mono preview" mode for the desktop window when using Oculus plugin (uses left eye view)
* Adds menu item to switch off of mono preview mode to the oculus display plugin menu
* removes unused Framerate menus from the stereo rendering plugins and Oculus plugin