### PR TITLE
Move  Edit.js Tool Window Tabs to the Top

### DIFF
--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -52,6 +52,9 @@ WebWindowClass::WebWindowClass(const QString& title, const QString& url, int wid
 
         dockWidget->setWidget(_webView);
 
+        auto titleWidget = new QWidget();
+        dockWidget->setTitleBarWidget(titleWidget);
+
         toolWindow->addDockWidget(Qt::TopDockWidgetArea, dockWidget, Qt::Horizontal);
 
         _windowWidget = dockWidget;

--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -45,6 +45,7 @@ WebWindowClass::WebWindowClass(const QString& title, const QString& url, int wid
 
         auto dockWidget = new QDockWidget(title, toolWindow);
         dockWidget->setFeatures(QDockWidget::DockWidgetMovable);
+        dockWidget->setTitleBarWidget(0);
         connect(dockWidget, &QDockWidget::visibilityChanged, this, &WebWindowClass::visibilityChanged);
 
         _webView = new QWebView(dockWidget);

--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -52,7 +52,7 @@ WebWindowClass::WebWindowClass(const QString& title, const QString& url, int wid
 
         dockWidget->setWidget(_webView);
 
-        auto titleWidget = new QWidget();
+        auto titleWidget = new QWidget(dockWidget);
         dockWidget->setTitleBarWidget(titleWidget);
 
         toolWindow->addDockWidget(Qt::TopDockWidgetArea, dockWidget, Qt::Horizontal);

--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -52,7 +52,7 @@ WebWindowClass::WebWindowClass(const QString& title, const QString& url, int wid
 
         dockWidget->setWidget(_webView);
 
-        toolWindow->addDockWidget(Qt::RightDockWidgetArea, dockWidget);
+		toolWindow->addDockWidget(Qt::TopDockWidgetArea, dockWidget, Qt::Horizontal);
 
         _windowWidget = dockWidget;
     } else {

--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -52,7 +52,7 @@ WebWindowClass::WebWindowClass(const QString& title, const QString& url, int wid
 
         dockWidget->setWidget(_webView);
 
-		toolWindow->addDockWidget(Qt::TopDockWidgetArea, dockWidget, Qt::Horizontal);
+        toolWindow->addDockWidget(Qt::TopDockWidgetArea, dockWidget, Qt::Horizontal);
 
         _windowWidget = dockWidget;
     } else {

--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -45,7 +45,6 @@ WebWindowClass::WebWindowClass(const QString& title, const QString& url, int wid
 
         auto dockWidget = new QDockWidget(title, toolWindow);
         dockWidget->setFeatures(QDockWidget::DockWidgetMovable);
-        dockWidget->setTitleBarWidget(0);
         connect(dockWidget, &QDockWidget::visibilityChanged, this, &WebWindowClass::visibilityChanged);
 
         _webView = new QWebView(dockWidget);

--- a/interface/src/ui/ToolWindow.cpp
+++ b/interface/src/ui/ToolWindow.cpp
@@ -123,7 +123,7 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget,
     
     setTabPosition(Qt::TopDockWidgetArea, QTabWidget::TabPosition::North);
 
-    addDockWidget(area, dockWidget, orientation);
+    QMainWindow::addDockWidget(area, dockWidget, orientation);
 
     // We want to force tabbing, so retabify all of our widgets.
     QDockWidget* lastDockWidget = dockWidget;

--- a/interface/src/ui/ToolWindow.cpp
+++ b/interface/src/ui/ToolWindow.cpp
@@ -22,6 +22,8 @@ ToolWindow::ToolWindow(QWidget* parent) :
     _hasShown(false),
     _lastGeometry() {
 
+    setTabPosition(Qt::TopDockWidgetArea, QTabWidget::TabPosition::North);
+
 #   ifndef Q_OS_LINUX
     setDockOptions(QMainWindow::ForceTabbedDocks);
 #   endif
@@ -120,12 +122,9 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget)
 
 void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget, Qt::Orientation orientation) {
     QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
-    
-    setTabPosition(Qt::TopDockWidgetArea, QTabWidget::TabPosition::North);
 
     QMainWindow::addDockWidget(area, dockWidget, orientation);
 
-    // We want to force tabbing, so retabify all of our widgets.
     QDockWidget* lastDockWidget = dockWidget;
 
     foreach(QDockWidget* nextDockWidget, dockWidgets) {

--- a/interface/src/ui/ToolWindow.cpp
+++ b/interface/src/ui/ToolWindow.cpp
@@ -39,11 +39,8 @@ bool ToolWindow::event(QEvent* event) {
             QMainWindow* mainWindow = qApp->getWindow();
             QRect mainGeometry = mainWindow->geometry();
 
-            int titleBarHeight = UIUtil::getWindowTitleBarHeight(this);
-            int topMargin = titleBarHeight;
-
-            _lastGeometry = QRect(mainGeometry.topLeft().x(),  mainGeometry.topLeft().y() + topMargin,
-                                  DEFAULT_WIDTH, mainGeometry.height() - topMargin);
+            _lastGeometry = QRect(mainGeometry.topLeft().x(),  mainGeometry.topLeft().y(),
+                                  DEFAULT_WIDTH, mainGeometry.height());
         }
         setGeometry(_lastGeometry);
         return true;
@@ -124,8 +121,11 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget,
     QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
 
     QMainWindow::addDockWidget(area, dockWidget, orientation);
-
+    
+   
     QDockWidget* lastDockWidget = dockWidget;
+
+    lastDockWidget->setTitleBarWidget(new QWidget());
 
     foreach(QDockWidget* nextDockWidget, dockWidgets) {
         tabifyDockWidget(lastDockWidget, nextDockWidget);

--- a/interface/src/ui/ToolWindow.cpp
+++ b/interface/src/ui/ToolWindow.cpp
@@ -109,6 +109,7 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget)
 
     // We want to force tabbing, so retabify all of our widgets.
     QDockWidget* lastDockWidget = dockWidget;
+
     foreach (QDockWidget* nextDockWidget, dockWidgets) {
         tabifyDockWidget(lastDockWidget, nextDockWidget);
         lastDockWidget = nextDockWidget;
@@ -118,18 +119,19 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget)
 }
 
 void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget, Qt::Orientation orientation) {
-	QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
-	
-	setTabPosition(Qt::TopDockWidgetArea, QTabWidget::TabPosition::North);
+    QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
+    
+    setTabPosition(Qt::TopDockWidgetArea, QTabWidget::TabPosition::North);
 
-	QMainWindow::addDockWidget(area, dockWidget, orientation);
+    addDockWidget(area, dockWidget, orientation);
 
-	// We want to force tabbing, so retabify all of our widgets.
-	QDockWidget* lastDockWidget = dockWidget;
-	foreach(QDockWidget* nextDockWidget, dockWidgets) {
-		tabifyDockWidget(lastDockWidget, nextDockWidget);
-		lastDockWidget = nextDockWidget;
-	}
+    // We want to force tabbing, so retabify all of our widgets.
+    QDockWidget* lastDockWidget = dockWidget;
+
+    foreach(QDockWidget* nextDockWidget, dockWidgets) {
+        tabifyDockWidget(lastDockWidget, nextDockWidget);
+        lastDockWidget = nextDockWidget;
+    }
 
     connect(dockWidget, &QDockWidget::visibilityChanged, this, &ToolWindow::onChildVisibilityUpdated);
 }

--- a/interface/src/ui/ToolWindow.cpp
+++ b/interface/src/ui/ToolWindow.cpp
@@ -127,10 +127,8 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget,
     QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
 
     QMainWindow::addDockWidget(area, dockWidget, orientation);
-    
    
     QDockWidget* lastDockWidget = dockWidget;
-
 
     foreach(QDockWidget* nextDockWidget, dockWidgets) {
         tabifyDockWidget(lastDockWidget, nextDockWidget);

--- a/interface/src/ui/ToolWindow.cpp
+++ b/interface/src/ui/ToolWindow.cpp
@@ -33,16 +33,22 @@ ToolWindow::ToolWindow(QWidget* parent) :
 bool ToolWindow::event(QEvent* event) {
     QEvent::Type type = event->type();
     if (type == QEvent::Show) {
+
         if (!_hasShown) {
             _hasShown = true;
 
             QMainWindow* mainWindow = qApp->getWindow();
             QRect mainGeometry = mainWindow->geometry();
 
-            _lastGeometry = QRect(mainGeometry.topLeft().x(),  mainGeometry.topLeft().y(),
-                                  DEFAULT_WIDTH, mainGeometry.height());
+            int titleBarHeight = UIUtil::getWindowTitleBarHeight(this);
+            int topMargin = titleBarHeight;
+
+            _lastGeometry = QRect(mainGeometry.topLeft().x(), mainGeometry.topLeft().y() + topMargin,
+                DEFAULT_WIDTH, mainGeometry.height() - topMargin);
         }
+
         setGeometry(_lastGeometry);
+
         return true;
     } else if (type == QEvent::Hide) {
         _lastGeometry = geometry();
@@ -125,7 +131,6 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget,
    
     QDockWidget* lastDockWidget = dockWidget;
 
-    lastDockWidget->setTitleBarWidget(new QWidget());
 
     foreach(QDockWidget* nextDockWidget, dockWidgets) {
         tabifyDockWidget(lastDockWidget, nextDockWidget);

--- a/interface/src/ui/ToolWindow.cpp
+++ b/interface/src/ui/ToolWindow.cpp
@@ -118,7 +118,18 @@ void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget)
 }
 
 void ToolWindow::addDockWidget(Qt::DockWidgetArea area, QDockWidget* dockWidget, Qt::Orientation orientation) {
-    QMainWindow::addDockWidget(area, dockWidget, orientation);
+	QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
+	
+	setTabPosition(Qt::TopDockWidgetArea, QTabWidget::TabPosition::North);
+
+	QMainWindow::addDockWidget(area, dockWidget, orientation);
+
+	// We want to force tabbing, so retabify all of our widgets.
+	QDockWidget* lastDockWidget = dockWidget;
+	foreach(QDockWidget* nextDockWidget, dockWidgets) {
+		tabifyDockWidget(lastDockWidget, nextDockWidget);
+		lastDockWidget = nextDockWidget;
+	}
 
     connect(dockWidget, &QDockWidget::visibilityChanged, this, &ToolWindow::onChildVisibilityUpdated);
 }

--- a/interface/src/ui/ToolWindow.h
+++ b/interface/src/ui/ToolWindow.h
@@ -7,7 +7,7 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-//
+// 
 
 #ifndef hifi_ToolWindow_h
 #define hifi_ToolWindow_h


### PR DESCRIPTION
This PR moves the tabs in the edit.js tool window to the top of the screen and removes the redundant title bar -- it was easy to lose them before

![capture](https://cloud.githubusercontent.com/assets/843228/10501734/3c81d268-7299-11e5-86e5-ed15a6ea7444.PNG)
