### PR TITLE
move DIRTY_FLAGS out of EntityItem namespace

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1034,7 +1034,7 @@ int Avatar::parseDataFromBuffer(const QByteArray& buffer) {
     const float MOVE_DISTANCE_THRESHOLD = 0.001f;
     _moving = glm::distance(oldPosition, _position) > MOVE_DISTANCE_THRESHOLD;
     if (_moving && _motionState) {
-        _motionState->addDirtyFlags(EntityItem::DIRTY_POSITION);
+        _motionState->addDirtyFlags(Simulation::DIRTY_POSITION);
     }
     endUpdate();
 

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -309,7 +309,7 @@ void AvatarManager::updateAvatarPhysicsShape(const QUuid& id) {
         auto avatar = std::static_pointer_cast<Avatar>(avatarItr.value());
         AvatarMotionState* motionState = avatar->getMotionState();
         if (motionState) {
-            motionState->addDirtyFlags(EntityItem::DIRTY_SHAPE);
+            motionState->addDirtyFlags(Simulation::DIRTY_SHAPE);
         } else {
             ShapeInfo shapeInfo;
             avatar->computeShapeInfo(shapeInfo);

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1057,7 +1057,7 @@ void RenderablePolyVoxEntityItem::getMeshAsync() {
                                        gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::RAW)));
 
     _meshLock.lockForWrite();
-    _dirtyFlags |= EntityItem::DIRTY_SHAPE | EntityItem::DIRTY_MASS;
+    _dirtyFlags |= Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS;
     _mesh = mesh;
     _meshDirty = true;
     _meshLock.unlock();

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -29,6 +29,7 @@
 #include "EntityPropertyFlags.h"
 #include "EntityTypes.h"
 #include "SimulationOwner.h"
+#include "SimulationFlags.h"
 
 class EntitySimulation;
 class EntityTreeElement;
@@ -102,24 +103,6 @@ class EntityItem : public std::enable_shared_from_this<EntityItem>, public ReadW
     friend class EntityTreeElement;
     friend class EntitySimulation;
 public:
-    enum EntityDirtyFlags {
-        DIRTY_POSITION = 0x0001,
-        DIRTY_ROTATION = 0x0002,
-        DIRTY_LINEAR_VELOCITY = 0x0004,
-        DIRTY_ANGULAR_VELOCITY = 0x0008,
-        DIRTY_MASS = 0x0010,
-        DIRTY_COLLISION_GROUP = 0x0020,
-        DIRTY_MOTION_TYPE = 0x0040,
-        DIRTY_SHAPE = 0x0080,
-        DIRTY_LIFETIME = 0x0100,
-        DIRTY_UPDATEABLE = 0x0200,
-        DIRTY_MATERIAL = 0x00400,
-        DIRTY_PHYSICS_ACTIVATION = 0x0800, // should activate object in physics engine
-        DIRTY_SIMULATOR_OWNERSHIP = 0x1000, // should claim simulator ownership
-        DIRTY_SIMULATOR_ID = 0x2000, // the simulatorID has changed
-        DIRTY_TRANSFORM = DIRTY_POSITION | DIRTY_ROTATION,
-        DIRTY_VELOCITIES = DIRTY_LINEAR_VELOCITY | DIRTY_ANGULAR_VELOCITY
-    };
 
     DONT_ALLOW_INSTANTIATION // This class can not be instantiated directly
 
@@ -411,7 +394,7 @@ public:
 
     void getAllTerseUpdateProperties(EntityItemProperties& properties) const;
 
-    void flagForOwnership() { _dirtyFlags |= DIRTY_SIMULATOR_OWNERSHIP; }
+    void flagForOwnership() { _dirtyFlags |= Simulation::DIRTY_SIMULATOR_OWNERSHIP; }
 
     bool addAction(EntitySimulation* simulation, EntityActionPointer action);
     bool updateAction(EntitySimulation* simulation, const QUuid& actionID, const QVariantMap& arguments);

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -198,7 +198,7 @@ void EntitySimulation::changeEntity(EntityItemPointer entity) {
     // we must check for that case here, however we rely on the change event to have set DIRTY_POSITION flag.
     bool wasRemoved = false;
     uint32_t dirtyFlags = entity->getDirtyFlags();
-    if (dirtyFlags & EntityItem::DIRTY_POSITION) {
+    if (dirtyFlags & Simulation::DIRTY_POSITION) {
         AACube domainBounds(glm::vec3((float)-HALF_TREE_SCALE), (float)TREE_SCALE);
         AACube newCube = entity->getMaximumAACube();
         if (!domainBounds.touches(newCube)) {
@@ -214,7 +214,7 @@ void EntitySimulation::changeEntity(EntityItemPointer entity) {
         }
     }
     if (!wasRemoved) {
-        if (dirtyFlags & EntityItem::DIRTY_LIFETIME) {
+        if (dirtyFlags & Simulation::DIRTY_LIFETIME) {
             if (entity->isMortal()) {
                 _mortalEntities.insert(entity);
                 quint64 expiry = entity->getExpiry();
@@ -224,7 +224,7 @@ void EntitySimulation::changeEntity(EntityItemPointer entity) {
             } else {
                 _mortalEntities.remove(entity);
             }
-            entity->clearDirtyFlags(EntityItem::DIRTY_LIFETIME);
+            entity->clearDirtyFlags(Simulation::DIRTY_LIFETIME);
         }
         if (entity->needsToCallUpdate()) {
             _entitiesToUpdate.insert(entity);

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -28,18 +28,18 @@ typedef QVector<EntityItemPointer> VectorOfEntities;
 // the EntitySimulation needs to know when these things change on an entity,
 // so it can sort EntityItem or relay its state to the PhysicsEngine.
 const int DIRTY_SIMULATION_FLAGS =
-        EntityItem::DIRTY_POSITION |
-        EntityItem::DIRTY_ROTATION |
-        EntityItem::DIRTY_LINEAR_VELOCITY |
-        EntityItem::DIRTY_ANGULAR_VELOCITY |
-        EntityItem::DIRTY_MASS |
-        EntityItem::DIRTY_COLLISION_GROUP |
-        EntityItem::DIRTY_MOTION_TYPE |
-        EntityItem::DIRTY_SHAPE |
-        EntityItem::DIRTY_LIFETIME |
-        EntityItem::DIRTY_UPDATEABLE |
-        EntityItem::DIRTY_MATERIAL |
-        EntityItem::DIRTY_SIMULATOR_ID;
+        Simulation::DIRTY_POSITION |
+        Simulation::DIRTY_ROTATION |
+        Simulation::DIRTY_LINEAR_VELOCITY |
+        Simulation::DIRTY_ANGULAR_VELOCITY |
+        Simulation::DIRTY_MASS |
+        Simulation::DIRTY_COLLISION_GROUP |
+        Simulation::DIRTY_MOTION_TYPE |
+        Simulation::DIRTY_SHAPE |
+        Simulation::DIRTY_LIFETIME |
+        Simulation::DIRTY_UPDATEABLE |
+        Simulation::DIRTY_MATERIAL |
+        Simulation::DIRTY_SIMULATOR_ID;
 
 class EntitySimulation : public QObject {
 Q_OBJECT

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -66,7 +66,7 @@ bool ModelEntityItem::setProperties(const EntityItemProperties& properties) {
     bool somethingChangedInAnimations = _animationProperties.setProperties(properties);
 
     if (somethingChangedInAnimations) {
-        _dirtyFlags |= EntityItem::DIRTY_UPDATEABLE;
+        _dirtyFlags |= Simulation::DIRTY_UPDATEABLE;
     }
     somethingChanged = somethingChanged || somethingChangedInAnimations;
 
@@ -128,7 +128,7 @@ int ModelEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data,
     READ_ENTITY_PROPERTY(PROP_SHAPE_TYPE, ShapeType, updateShapeType);
 
     if (animationPropertiesChanged) {
-        _dirtyFlags |= EntityItem::DIRTY_UPDATEABLE;
+        _dirtyFlags |= Simulation::DIRTY_UPDATEABLE;
         somethingChanged = true;
     }
 
@@ -300,7 +300,7 @@ void ModelEntityItem::updateShapeType(ShapeType type) {
 
     if (type != _shapeType) {
         _shapeType = type;
-        _dirtyFlags |= EntityItem::DIRTY_SHAPE | EntityItem::DIRTY_MASS;
+        _dirtyFlags |= Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS;
     }
 }
 
@@ -316,13 +316,13 @@ ShapeType ModelEntityItem::getShapeType() const {
 void ModelEntityItem::setCompoundShapeURL(const QString& url) {
     if (_compoundShapeURL != url) {
         _compoundShapeURL = url;
-        _dirtyFlags |= EntityItem::DIRTY_SHAPE | EntityItem::DIRTY_MASS;
+        _dirtyFlags |= Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS;
         _shapeType = _compoundShapeURL.isEmpty() ? SHAPE_TYPE_NONE : SHAPE_TYPE_COMPOUND;
     }
 }
 
 void ModelEntityItem::setAnimationURL(const QString& url) {
-    _dirtyFlags |= EntityItem::DIRTY_UPDATEABLE;
+    _dirtyFlags |= Simulation::DIRTY_UPDATEABLE;
     _animationProperties.setURL(url);
 }
 
@@ -388,16 +388,16 @@ void ModelEntityItem::setAnimationSettings(const QString& value) {
         setAnimationStartAutomatically(startAutomatically);
     }
 
-    _dirtyFlags |= EntityItem::DIRTY_UPDATEABLE;
+    _dirtyFlags |= Simulation::DIRTY_UPDATEABLE;
 }
 
 void ModelEntityItem::setAnimationIsPlaying(bool value) {
-    _dirtyFlags |= EntityItem::DIRTY_UPDATEABLE;
+    _dirtyFlags |= Simulation::DIRTY_UPDATEABLE;
     _animationLoop.setRunning(value);
 }
 
 void ModelEntityItem::setAnimationFPS(float value) {
-    _dirtyFlags |= EntityItem::DIRTY_UPDATEABLE;
+    _dirtyFlags |= Simulation::DIRTY_UPDATEABLE;
     _animationLoop.setFPS(value);
 }
 

--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -597,7 +597,7 @@ void ParticleEffectEntityItem::debugDump() const {
 void ParticleEffectEntityItem::updateShapeType(ShapeType type) {
     if (type != _shapeType) {
         _shapeType = type;
-        _dirtyFlags |= EntityItem::DIRTY_SHAPE | EntityItem::DIRTY_MASS;
+        _dirtyFlags |= Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS;
     }
 }
 

--- a/libraries/entities/src/SimulationFlags.h
+++ b/libraries/entities/src/SimulationFlags.h
@@ -1,0 +1,34 @@
+//
+//  SimulationFlags.h
+//  libraries/physics/src
+//
+//  Created by Andrew Meadows 2015.10.14
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_SimulationFlags_h
+#define hifi_SimulationFlags_h
+
+namespace Simulation {
+    const uint32_t DIRTY_POSITION = 0x0001;
+    const uint32_t DIRTY_ROTATION = 0x0002;
+    const uint32_t DIRTY_LINEAR_VELOCITY = 0x0004;
+    const uint32_t DIRTY_ANGULAR_VELOCITY = 0x0008;
+    const uint32_t DIRTY_MASS = 0x0010;
+    const uint32_t DIRTY_COLLISION_GROUP = 0x0020;
+    const uint32_t DIRTY_MOTION_TYPE = 0x0040;
+    const uint32_t DIRTY_SHAPE = 0x0080;
+    const uint32_t DIRTY_LIFETIME = 0x0100;
+    const uint32_t DIRTY_UPDATEABLE = 0x0200;
+    const uint32_t DIRTY_MATERIAL = 0x00400;
+    const uint32_t DIRTY_PHYSICS_ACTIVATION = 0x0800; // should activate object in physics engine
+    const uint32_t DIRTY_SIMULATOR_OWNERSHIP = 0x1000; // should claim simulator ownership
+    const uint32_t DIRTY_SIMULATOR_ID = 0x2000; // the simulatorID has changed
+    const uint32_t DIRTY_TRANSFORM = DIRTY_POSITION | DIRTY_ROTATION;
+    const uint32_t DIRTY_VELOCITIES = DIRTY_LINEAR_VELOCITY | DIRTY_ANGULAR_VELOCITY;
+};
+
+#endif // hifi_SimulationFlags_h

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -93,13 +93,13 @@ bool EntityMotionState::handleEasyChanges(uint32_t flags, PhysicsEngine* engine)
     updateServerPhysicsVariables();
     ObjectMotionState::handleEasyChanges(flags, engine);
 
-    if (flags & EntityItem::DIRTY_SIMULATOR_ID) {
+    if (flags & Simulation::DIRTY_SIMULATOR_ID) {
         _loopsWithoutOwner = 0;
         if (_entity->getSimulatorID().isNull()) {
             // simulation ownership is being removed
             // remove the ACTIVATION flag because this object is coming to rest
             // according to a remote simulation and we don't want to wake it up again
-            flags &= ~EntityItem::DIRTY_PHYSICS_ACTIVATION;
+            flags &= ~Simulation::DIRTY_PHYSICS_ACTIVATION;
             // hint to Bullet that the object is deactivating
             _body->setActivationState(WANTS_DEACTIVATION);
             _outgoingPriority = NO_PRORITY;
@@ -111,13 +111,13 @@ bool EntityMotionState::handleEasyChanges(uint32_t flags, PhysicsEngine* engine)
             }
         }
     }
-    if (flags & EntityItem::DIRTY_SIMULATOR_OWNERSHIP) {
+    if (flags & Simulation::DIRTY_SIMULATOR_OWNERSHIP) {
         // (DIRTY_SIMULATOR_OWNERSHIP really means "we should bid for ownership with SCRIPT priority")
         // we're manipulating this object directly via script, so we artificially 
         // manipulate the logic to trigger an immediate bid for ownership
         setOutgoingPriority(SCRIPT_EDIT_SIMULATION_PRIORITY);
     }
-    if ((flags & EntityItem::DIRTY_PHYSICS_ACTIVATION) && !_body->isActive()) {
+    if ((flags & Simulation::DIRTY_PHYSICS_ACTIVATION) && !_body->isActive()) {
         _body->activate();
     }
 
@@ -503,7 +503,7 @@ uint32_t EntityMotionState::getIncomingDirtyFlags() {
         bool isMoving = _entity->isMoving();
         if (((bodyFlags & btCollisionObject::CF_STATIC_OBJECT) && isMoving) ||
                 (bodyFlags & btCollisionObject::CF_KINEMATIC_OBJECT && !isMoving)) {
-            dirtyFlags |= EntityItem::DIRTY_MOTION_TYPE;
+            dirtyFlags |= Simulation::DIRTY_MOTION_TYPE;
         }
     }
     return dirtyFlags;

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -126,34 +126,34 @@ void ObjectMotionState::setRigidBody(btRigidBody* body) {
 }
 
 bool ObjectMotionState::handleEasyChanges(uint32_t flags, PhysicsEngine* engine) {
-    if (flags & EntityItem::DIRTY_POSITION) {
+    if (flags & Simulation::DIRTY_POSITION) {
         btTransform worldTrans;
-        if (flags & EntityItem::DIRTY_ROTATION) {
+        if (flags & Simulation::DIRTY_ROTATION) {
             worldTrans.setRotation(glmToBullet(getObjectRotation()));
         } else {
             worldTrans = _body->getWorldTransform();
         }
         worldTrans.setOrigin(glmToBullet(getObjectPosition()));
         _body->setWorldTransform(worldTrans);
-    } else if (flags & EntityItem::DIRTY_ROTATION) {
+    } else if (flags & Simulation::DIRTY_ROTATION) {
         btTransform worldTrans = _body->getWorldTransform();
         worldTrans.setRotation(glmToBullet(getObjectRotation()));
         _body->setWorldTransform(worldTrans);
     }
 
-    if (flags & EntityItem::DIRTY_LINEAR_VELOCITY) {
+    if (flags & Simulation::DIRTY_LINEAR_VELOCITY) {
         _body->setLinearVelocity(glmToBullet(getObjectLinearVelocity()));
         _body->setGravity(glmToBullet(getObjectGravity()));
     }
-    if (flags & EntityItem::DIRTY_ANGULAR_VELOCITY) {
+    if (flags & Simulation::DIRTY_ANGULAR_VELOCITY) {
         _body->setAngularVelocity(glmToBullet(getObjectAngularVelocity()));
     }
 
-    if (flags & EntityItem::DIRTY_MATERIAL) {
+    if (flags & Simulation::DIRTY_MATERIAL) {
         updateBodyMaterialProperties();
     }
 
-    if (flags & EntityItem::DIRTY_MASS) {
+    if (flags & Simulation::DIRTY_MASS) {
         updateBodyMassProperties();
     }
 
@@ -161,7 +161,7 @@ bool ObjectMotionState::handleEasyChanges(uint32_t flags, PhysicsEngine* engine)
 }
 
 bool ObjectMotionState::handleHardAndEasyChanges(uint32_t flags, PhysicsEngine* engine) {
-    if (flags & EntityItem::DIRTY_SHAPE) {
+    if (flags & Simulation::DIRTY_SHAPE) {
         // make sure the new shape is valid
         if (!isReadyToComputeShape()) {
             return false;
@@ -170,7 +170,7 @@ bool ObjectMotionState::handleHardAndEasyChanges(uint32_t flags, PhysicsEngine* 
         if (!newShape) {
             qCDebug(physics) << "Warning: failed to generate new shape!";
             // failed to generate new shape! --> keep old shape and remove shape-change flag
-            flags &= ~EntityItem::DIRTY_SHAPE;
+            flags &= ~Simulation::DIRTY_SHAPE;
             // TODO: force this object out of PhysicsEngine rather than just use the old shape
             if ((flags & HARD_DIRTY_PHYSICS_FLAGS) == 0) {
                 // no HARD flags remain, so do any EASY changes
@@ -186,7 +186,7 @@ bool ObjectMotionState::handleHardAndEasyChanges(uint32_t flags, PhysicsEngine* 
             _body->setCollisionShape(_shape);
         } else {
             // huh... the shape didn't actually change, so we clear the DIRTY_SHAPE flag
-            flags &= ~EntityItem::DIRTY_SHAPE;
+            flags &= ~Simulation::DIRTY_SHAPE;
         }
     }
     if (flags & EASY_DIRTY_PHYSICS_FLAGS) {

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -37,18 +37,18 @@ enum MotionStateType {
 
 // The update flags trigger two varieties of updates: "hard" which require the body to be pulled 
 // and re-added to the physics engine and "easy" which just updates the body properties.
-const uint32_t HARD_DIRTY_PHYSICS_FLAGS = (uint32_t)(EntityItem::DIRTY_MOTION_TYPE | EntityItem::DIRTY_SHAPE | 
-                                                     EntityItem::DIRTY_COLLISION_GROUP);
-const uint32_t EASY_DIRTY_PHYSICS_FLAGS = (uint32_t)(EntityItem::DIRTY_TRANSFORM | EntityItem::DIRTY_VELOCITIES |
-                                                     EntityItem::DIRTY_MASS | EntityItem::DIRTY_MATERIAL | 
-                                                     EntityItem::DIRTY_SIMULATOR_ID | EntityItem::DIRTY_SIMULATOR_OWNERSHIP);
+const uint32_t HARD_DIRTY_PHYSICS_FLAGS = (uint32_t)(Simulation::DIRTY_MOTION_TYPE | Simulation::DIRTY_SHAPE | 
+                                                     Simulation::DIRTY_COLLISION_GROUP);
+const uint32_t EASY_DIRTY_PHYSICS_FLAGS = (uint32_t)(Simulation::DIRTY_TRANSFORM | Simulation::DIRTY_VELOCITIES |
+                                                     Simulation::DIRTY_MASS | Simulation::DIRTY_MATERIAL | 
+                                                     Simulation::DIRTY_SIMULATOR_ID | Simulation::DIRTY_SIMULATOR_OWNERSHIP);
 
 // These are the set of incoming flags that the PhysicsEngine needs to hear about:
 const uint32_t DIRTY_PHYSICS_FLAGS = (uint32_t)(HARD_DIRTY_PHYSICS_FLAGS | EASY_DIRTY_PHYSICS_FLAGS |
-                                                EntityItem::DIRTY_PHYSICS_ACTIVATION);
+                                                Simulation::DIRTY_PHYSICS_ACTIVATION);
 
 // These are the outgoing flags that the PhysicsEngine can affect:
-const uint32_t OUTGOING_DIRTY_PHYSICS_FLAGS = EntityItem::DIRTY_TRANSFORM | EntityItem::DIRTY_VELOCITIES;
+const uint32_t OUTGOING_DIRTY_PHYSICS_FLAGS = Simulation::DIRTY_TRANSFORM | Simulation::DIRTY_VELOCITIES;
 
 
 class OctreeEditPacketSender;


### PR DESCRIPTION
I have a dream of unraveling the spaghetti between the **physics** and **entities** libs.  This PR is a step in that direction.

The **DIRTY_FOO** flags are used to communicate what kind of simulation properties have been changed and need to be relayed to the physics simulation.  They were originally flags for entities but they are necessary for all objects that happen to be in the physics simulation (e.g. avatars).  So I'm pulling them out of the **EntityItem** namespace and putting them in a new one called **Simulation**.  Eventually the **Simulation** namespace will be moved out of the **entities** lib and into the **physics** lib.