### PR TITLE
Controllers : Wiring the Endpoint to actions and actually replace the legacy system

### DIFF
--- a/examples/controllers/controllerMappings.js
+++ b/examples/controllers/controllerMappings.js
@@ -14,7 +14,7 @@
 
 myFirstMapping = function() {
 return {
-    "name": "example mapping from Standard to actions",
+    "name": "example",
     "channels": [ {
             "from": "Keyboard.A",
             "filters": [ {
@@ -55,6 +55,8 @@ var myFirstMappingJSON = myFirstMapping();
 print('myFirstMappingJSON' + JSON.stringify(myFirstMappingJSON));
 
 var mapping = Controller.parseMapping(JSON.stringify(myFirstMappingJSON));
+
+Controller.enableMapping("example");
 
 Object.keys(Controller.Standard).forEach(function (input) {
     print("Controller.Standard." + input + ":" + Controller.Standard[input]);

--- a/examples/controllers/controllerMappings.js
+++ b/examples/controllers/controllerMappings.js
@@ -15,32 +15,26 @@
 myFirstMapping = function() {
 return {
     "name": "example",
-    "channels": [ {
-            "from": "Keyboard.A",
-            "filters": [ {
-                    "type": "clamp",
-                    "params": [0, 1],
-                }
-            ],
-            "to": "Actions.LONGITUDINAL_FORWARD",
-        }, {
-            "from": "Keyboard.Left",
-            "filters": [ {
-                    "type": "clamp",
-                    "params": [0, 1],
-                }, {
-                    "type": "invert"
-                }
-            ],
-            "to": "Actions.LONGITUDINAL_BACKWARD",
-        }, {
-            "from": "Keyboard.C",
+    "channels": [
+        { "from": "Keyboard.W", "to": "Actions.LONGITUDINAL_FORWARD" },
+        { "from": "Keyboard.S", "to": "Actions.LONGITUDINAL_BACKWARD" },
+
+        { "from": "Keyboard.Left", "to": "Actions.LATERAL_LEFT" },
+        { "from": "Keyboard.Right", "to": "Actions.LATERAL_RIGHT" },
+
+        { "from": "Keyboard.A", "to": "Actions.YAW_LEFT" },
+        { "from": "Keyboard.D", "to": "Actions.YAW_RIGHT" },
+
+        { "from": "Keyboard.C", "to": "Actions.VERTICAL_DOWN" }, 
+        { "from": "Keyboard.E", "to": "Actions.VERTICAL_UP" },
+        {
+            "from": "Standard.LX",
             "filters": [ {
                     "type": "scale",
                     "params": [2.0],
                 }
             ],
-            "to": "Actions.Yaw",
+            "to": "Actions.LATERAL_LEFT",
         }, {
             "from": "Keyboard.B",
             "to": "Actions.Yaw"
@@ -57,7 +51,7 @@ print('myFirstMappingJSON' + JSON.stringify(myFirstMappingJSON));
 var mapping = Controller.parseMapping(JSON.stringify(myFirstMappingJSON));
 
 Controller.enableMapping("example");
-
+/*
 Object.keys(Controller.Standard).forEach(function (input) {
     print("Controller.Standard." + input + ":" + Controller.Standard[input]);
 });
@@ -71,3 +65,4 @@ Object.keys(Controller.Hardware).forEach(function (deviceName) {
 Object.keys(Controller.Actions).forEach(function (actionName) {
     print("Controller.Actions." + actionName + ":" + Controller.Actions[actionName]);
 });
+*/

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2692,7 +2692,7 @@ void Application::update(float deltaTime) {
     auto myAvatar = getMyAvatar();
     auto userInputMapper = DependencyManager::get<UserInputMapper>();
     userInputMapper->setSensorToWorldMat(myAvatar->getSensorToWorldMatrix());
-    userInputMapper->update(deltaTime);
+  //  userInputMapper->update(deltaTime);
 
     // This needs to go after userInputMapper->update() because of the keyboard
     bool jointsCaptured = false;

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -103,10 +103,10 @@ namespace controller {
         virtual float value() override { return _currentValue; }
         virtual void apply(float newValue, float oldValue, const Pointer& source) override { 
             
-            _currentValue = newValue;
+            _currentValue += newValue;
             if (!(_id == UserInputMapper::Input::INVALID_INPUT)) {
                 auto userInputMapper = DependencyManager::get<UserInputMapper>();
-                userInputMapper->setActionState(UserInputMapper::Action(_id.getChannel()), newValue);
+                userInputMapper->deltaActionState(UserInputMapper::Action(_id.getChannel()), newValue);
             }
         }
 
@@ -159,7 +159,7 @@ namespace controller {
             // Create the endpoints
             // FIXME action endpoints need to accumulate values, and have them cleared at each frame
            // _endpoints[actionInput] = std::make_shared<VirtualEndpoint>();
-            _endpoints[actionInput] = std::make_shared<ActionEndpoint>();
+            _endpoints[actionInput] = std::make_shared<ActionEndpoint>(actionInput);
         }
 
         updateMaps();

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -94,6 +94,25 @@ namespace controller {
         Endpoint::Pointer _second;
     };
 
+    class ActionEndpoint : public Endpoint {
+    public:
+        ActionEndpoint(const UserInputMapper::Input& id = UserInputMapper::Input(-1))
+            : Endpoint(id) {
+        }
+
+        virtual float value() override { return _currentValue; }
+        virtual void apply(float newValue, float oldValue, const Pointer& source) override { 
+            
+            _currentValue = newValue;
+            if (!(_id == UserInputMapper::Input::INVALID_INPUT)) {
+                auto userInputMapper = DependencyManager::get<UserInputMapper>();
+                userInputMapper->setActionState(UserInputMapper::Action(_id.getChannel()), newValue);
+            }
+        }
+
+    private:
+        float _currentValue{ 0.0f };
+    };
 
     QRegularExpression ScriptingInterface::SANITIZE_NAME_EXPRESSION{ "[\\(\\)\\.\\s]" };
 
@@ -139,7 +158,8 @@ namespace controller {
 
             // Create the endpoints
             // FIXME action endpoints need to accumulate values, and have them cleared at each frame
-            _endpoints[actionInput] = std::make_shared<VirtualEndpoint>();
+           // _endpoints[actionInput] = std::make_shared<VirtualEndpoint>();
+            _endpoints[actionInput] = std::make_shared<ActionEndpoint>();
         }
 
         updateMaps();
@@ -171,6 +191,7 @@ namespace controller {
 
                 _mappingsByName[mapping->_name] = mapping;
 
+                return mappingBuilder;
             } else {
                 qDebug() << "Mapping json Document is not an object" << endl;
             }

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -26,7 +26,7 @@ namespace controller {
 
     class VirtualEndpoint : public Endpoint {
     public:
-        VirtualEndpoint(const UserInputMapper::Input& id = UserInputMapper::Input(-1))
+        VirtualEndpoint(const UserInputMapper::Input& id = UserInputMapper::Input::INVALID_INPUT)
             : Endpoint(id) {
         }
 
@@ -41,7 +41,7 @@ namespace controller {
     class JSEndpoint : public Endpoint {
     public:
         JSEndpoint(const QJSValue& callable) 
-            : Endpoint(UserInputMapper::Input(-1)), _callable(callable) {}
+            : Endpoint(UserInputMapper::Input::INVALID_INPUT), _callable(callable) {}
 
         virtual float value() {
             float result = (float)_callable.call().toNumber();;
@@ -59,7 +59,7 @@ namespace controller {
     class ScriptEndpoint : public Endpoint {
     public:
         ScriptEndpoint(const QScriptValue& callable)
-            : Endpoint(UserInputMapper::Input(-1)), _callable(callable) {
+            : Endpoint(UserInputMapper::Input::INVALID_INPUT), _callable(callable) {
         }
 
         virtual float value() {
@@ -78,7 +78,7 @@ namespace controller {
     class CompositeEndpoint : public Endpoint, Endpoint::Pair {
     public:
         CompositeEndpoint(Endpoint::Pointer first, Endpoint::Pointer second)
-            : Endpoint(UserInputMapper::Input(-1)), Pair(first, second) { }
+            : Endpoint(UserInputMapper::Input(UserInputMapper::Input::INVALID_INPUT)), Pair(first, second) { }
 
         virtual float value() {
             float result = first->value() * -1.0 + second->value();
@@ -96,7 +96,7 @@ namespace controller {
 
     class ActionEndpoint : public Endpoint {
     public:
-        ActionEndpoint(const UserInputMapper::Input& id = UserInputMapper::Input(-1))
+        ActionEndpoint(const UserInputMapper::Input& id = UserInputMapper::Input::INVALID_INPUT)
             : Endpoint(id) {
         }
 
@@ -156,9 +156,7 @@ namespace controller {
             QString cleanActionName = QString(actionName).remove(ScriptingInterface::SANITIZE_NAME_EXPRESSION);
             _actions.insert(cleanActionName, actionInput.getID());
 
-            // Create the endpoints
-            // FIXME action endpoints need to accumulate values, and have them cleared at each frame
-           // _endpoints[actionInput] = std::make_shared<VirtualEndpoint>();
+            // Create the action endpoints
             _endpoints[actionInput] = std::make_shared<ActionEndpoint>(actionInput);
         }
 

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -295,7 +295,12 @@ void UserInputMapper::update(float deltaTime) {
     // Scale all the channel step with the scale
     static const float EPSILON =  0.01f;
     for (auto i = 0; i < NUM_ACTIONS; i++) {
+        if (_externalActionStates[i] != 0) {
+            _actionStates[i] += _externalActionStates[i];
+            _externalActionStates[i] = 0.0f;
+        }
         _actionStates[i] *= _actionScales[i];
+
         // Emit only on change, and emit when moving back to 0
         if (fabsf(_actionStates[i] - _lastActionStates[i]) > EPSILON) {
             _lastActionStates[i] = _actionStates[i];
@@ -359,15 +364,15 @@ void UserInputMapper::assignDefaulActionScales() {
     _actionScales[RIGHT_HAND] = 1.0f; // default
     _actionScales[LEFT_HAND_CLICK] = 1.0f; // on
     _actionScales[RIGHT_HAND_CLICK] = 1.0f; // on
-    _actionStates[SHIFT] = 1.0f; // on
-    _actionStates[ACTION1] = 1.0f; // default
-    _actionStates[ACTION2] = 1.0f; // default
-    _actionStates[TRANSLATE_X] = 1.0f; // default
-    _actionStates[TRANSLATE_Y] = 1.0f; // default
-    _actionStates[TRANSLATE_Z] = 1.0f; // default
-    _actionStates[ROLL] = 1.0f; // default
-    _actionStates[PITCH] = 1.0f; // default
-    _actionStates[YAW] = 1.0f; // default
+    _actionScales[SHIFT] = 1.0f; // on
+    _actionScales[ACTION1] = 1.0f; // default
+    _actionScales[ACTION2] = 1.0f; // default
+    _actionScales[TRANSLATE_X] = 1.0f; // default
+    _actionScales[TRANSLATE_Y] = 1.0f; // default
+    _actionScales[TRANSLATE_Z] = 1.0f; // default
+    _actionScales[ROLL] = 1.0f; // default
+    _actionScales[PITCH] = 1.0f; // default
+    _actionScales[YAW] = 1.0f; // default
 }
 
 // This is only necessary as long as the actions are hardcoded

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -19,6 +19,7 @@ const uint16_t UserInputMapper::Input::INVALID_DEVICE = INVALID_INPUT.getDevice(
 const uint16_t UserInputMapper::Input::INVALID_CHANNEL = INVALID_INPUT.getChannel();
 const uint16_t UserInputMapper::Input::INVALID_TYPE = (uint16_t)INVALID_INPUT.getType();
 const uint16_t UserInputMapper::Input::ACTIONS_DEVICE = INVALID_DEVICE - (uint16)1;
+const uint16_t UserInputMapper::Input::STANDARD_DEVICE = 0;
 
 // Default contruct allocate the poutput size with the current hardcoded action channels
 UserInputMapper::UserInputMapper() {
@@ -37,6 +38,13 @@ bool UserInputMapper::registerDevice(uint16 deviceID, const DeviceProxy::Pointer
     qCDebug(controllers) << "Registered input device <" << proxy->_name << "> deviceID = " << deviceID;
     return true;
 }
+
+bool UserInputMapper::registerStandardDevice(const DeviceProxy::Pointer& device) {
+    device->_name = "Standard"; // Just to make sure
+    _registeredDevices[getStandardDeviceID()] = device;
+    return true;
+}
+
 
 UserInputMapper::DeviceProxy::Pointer UserInputMapper::getDeviceProxy(const Input& input) {
     auto device = _registeredDevices.find(input.getDevice());
@@ -69,10 +77,6 @@ void UserInputMapper::resetDevice(uint16 deviceID) {
 }
 
 int UserInputMapper::findDevice(QString name) const {
-    if (_standardDevice && (_standardDevice->getName() == name)) {
-        return getStandardDeviceID();
-    }
-
     for (auto device : _registeredDevices) {
         if (device.second->_name.split(" (")[0] == name) {
             return device.first;

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -86,6 +86,7 @@ public:
         static const uint16 INVALID_CHANNEL;
         static const uint16 INVALID_TYPE;
         static const uint16 ACTIONS_DEVICE;
+        static const uint16 STANDARD_DEVICE;
     };
 
 
@@ -138,7 +139,7 @@ public:
     uint16 getFreeDeviceID() { return _nextFreeDeviceID++; }
 
     bool registerDevice(uint16 deviceID, const DeviceProxy::Pointer& device);
-    bool registerStandardDevice(const DeviceProxy::Pointer& device) { _standardDevice = device; _registeredDevices[getStandardDeviceID()] = device; return true; }
+    bool registerStandardDevice(const DeviceProxy::Pointer& device);
     DeviceProxy::Pointer getDeviceProxy(const Input& input);
     QString getDeviceName(uint16 deviceID);
     QVector<InputPair> getAvailableInputs(uint16 deviceID) { return _registeredDevices[deviceID]->getAvailabeInputs(); }
@@ -275,8 +276,8 @@ public:
     typedef std::map<int, DeviceProxy::Pointer> DevicesMap;
     DevicesMap getDevices() { return _registeredDevices; }
 
-    uint16 getStandardDeviceID() const { return _standardDeviceID; }
-    DeviceProxy::Pointer getStandardDevice() { return _standardDevice; }
+    uint16 getStandardDeviceID() const { return Input::STANDARD_DEVICE; }
+    DeviceProxy::Pointer getStandardDevice() { return _registeredDevices[getStandardDeviceID()]; }
 
 signals:
     void actionEvent(int action, float state);
@@ -284,12 +285,10 @@ signals:
 
 protected:
     void registerStandardDevice();
-    uint16 _standardDeviceID = 0;
-    DeviceProxy::Pointer _standardDevice;
     StandardControllerPointer _standardController;
         
     DevicesMap _registeredDevices;
-    uint16 _nextFreeDeviceID = 1;
+    uint16 _nextFreeDeviceID = Input::STANDARD_DEVICE + 1;
 
     typedef std::map<int, Modifiers> InputToMoModifiersMap;
     InputToMoModifiersMap _inputToModifiersMap;

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -138,7 +138,7 @@ public:
     uint16 getFreeDeviceID() { return _nextFreeDeviceID++; }
 
     bool registerDevice(uint16 deviceID, const DeviceProxy::Pointer& device);
-    bool registerStandardDevice(const DeviceProxy::Pointer& device) { _standardDevice = device; return true; }
+    bool registerStandardDevice(const DeviceProxy::Pointer& device) { _standardDevice = device; _registeredDevices[getStandardDeviceID()] = device; return true; }
     DeviceProxy::Pointer getDeviceProxy(const Input& input);
     QString getDeviceName(uint16 deviceID);
     QVector<InputPair> getAvailableInputs(uint16 deviceID) { return _registeredDevices[deviceID]->getAvailabeInputs(); }
@@ -214,7 +214,8 @@ public:
     QVector<QString> getActionNames() const;
     void assignDefaulActionScales();
 
-    void setActionState(Action action, float value) { _actionStates[action] = value; }
+    void setActionState(Action action, float value) { _externalActionStates[action] = value; }
+    void deltaActionState(Action action, float delta) { _externalActionStates[action] += delta; }
 
     // Add input channel to the mapper and check that all the used channels are registered.
     // Return true if theinput channel is created correctly, false either
@@ -297,6 +298,7 @@ protected:
     ActionToInputsMap _actionToInputsMap;
  
     std::vector<float> _actionStates = std::vector<float>(NUM_ACTIONS, 0.0f);
+    std::vector<float> _externalActionStates = std::vector<float>(NUM_ACTIONS, 0.0f);
     std::vector<float> _actionScales = std::vector<float>(NUM_ACTIONS, 1.0f);
     std::vector<float> _lastActionStates = std::vector<float>(NUM_ACTIONS, 0.0f);
     std::vector<PoseValue> _poseStates = std::vector<PoseValue>(NUM_ACTIONS);

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -214,6 +214,8 @@ public:
     QVector<QString> getActionNames() const;
     void assignDefaulActionScales();
 
+    void setActionState(Action action, float value) { _actionStates[action] = value; }
+
     // Add input channel to the mapper and check that all the used channels are registered.
     // Return true if theinput channel is created correctly, false either
     bool addInputChannel(Action action, const Input& input, float scale = 1.0f);


### PR DESCRIPTION
- Introduce the ActionEndpoint to add the value to the current action State of the UserINputMapper

- have a spearate list of "externalActionStates" in the userINputMApper to collect the values mordifed from outside (the ScriptingController) and combine thme with the legacy system correctly

- put _standardDevice as a regular _proxyDevice so not having to differenciate the code between standard and non standard

- typos