### PR TITLE
ifdef out buggy texture map code

### DIFF
--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -186,6 +186,8 @@ double mapComponent(double sobelValue) {
 gpu::Texture* TextureUsage::createNormalTextureFromBumpImage(const QImage& srcImage, const std::string& srcImageName) {
     QImage image = srcImage;
     
+
+    #if 0
     // PR 5540 by AlessandroSigna
     // integrated here as a specialized TextureLoader for bumpmaps
     // The conversion is done using the Sobel Filter to calculate the derivatives from the grayscale image
@@ -236,6 +238,7 @@ gpu::Texture* TextureUsage::createNormalTextureFromBumpImage(const QImage& srcIm
             result.setPixel(i, j, qRgbValue);
         }
     }
+    #endif
     
     gpu::Texture* theTexture = nullptr;
     if ((image.width() > 0) && (image.height() > 0)) {


### PR DESCRIPTION
this code is causing a massive flood of QImage.setPixel() warnings on my machine in some domains.. it looking at the code, it appears to not actually do anything because the `QImage result` is not actually used after the removed section.

I've left it in here since Alessandro will be arriving in SF soon, and we can repair it correctly at that point