### PR TITLE
hack to reduce hand influence of hips in HMD mode

### DIFF
--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -255,7 +255,7 @@ void AnimInverseKinematics::solveWithCyclicCoordinateDescent(const std::vector<I
                 }
 
                 // store the rotation change in the accumulator
-                _accumulators[pivotIndex].add(newRot);
+                _accumulators[pivotIndex].add(newRot, target.getWeight());
 
                 // this joint has been changed so we check to see if it has the lowest index
                 if (pivotIndex < lowestMovedIndex) {

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -12,6 +12,8 @@
 
 #include "AnimSkeleton.h"
 
+const float HACK_HMD_TARGET_WEIGHT = 8.0f;
+
 class IKTarget {
 public:
     enum class Type {
@@ -33,10 +35,13 @@ public:
     void setIndex(int index) { _index = index; }
     void setType(int);
 
+    // HACK: give HmdHead targets more "weight" during IK algorithm
+    float getWeight() const { return _type == Type::HmdHead ? HACK_HMD_TARGET_WEIGHT : 1.0f; }
+
 private:
     AnimPose _pose;
-    int _index = -1;
-    Type _type = Type::RotationAndPosition;
+    int _index{-1};
+    Type _type{Type::RotationAndPosition};
 
 };
 

--- a/libraries/animation/src/RotationAccumulator.cpp
+++ b/libraries/animation/src/RotationAccumulator.cpp
@@ -11,9 +11,9 @@
 
 #include <glm/gtx/quaternion.hpp>
 
-void RotationAccumulator::add(const glm::quat& rotation) {
+void RotationAccumulator::add(const glm::quat& rotation, float weight) {
     // make sure both quaternions are on the same hyper-hemisphere before we add them linearly (lerp)
-    _rotationSum += copysignf(1.0f, glm::dot(_rotationSum, rotation)) * rotation;
+    _rotationSum += copysignf(weight, glm::dot(_rotationSum, rotation)) * rotation;
     ++_numRotations;
     _isDirty = true;
 }

--- a/libraries/animation/src/RotationAccumulator.h
+++ b/libraries/animation/src/RotationAccumulator.h
@@ -18,7 +18,9 @@ public:
 
     int size() const { return _numRotations; }
 
-    void add(const glm::quat& rotation);
+    /// \param rotation rotation to add
+    /// \param weight contribution factor of this rotation to total accumulation
+    void add(const glm::quat& rotation, float weight = 1.0f);
 
     glm::quat getAverage();
 


### PR DESCRIPTION
There is a bug where during HMD+hydra sessions the hydra hand motion can have too strong of an influence on the hip positions.  This PR reduces the problem but does not completely fix it.  A more correct fix will have to be done later.