### PR TITLE
Fixing a bug in the gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,7 @@
 *.png binary
 *.jpg binary
 *.wav binary
-*.fbx text
-*.dds text
-*.svg text
-*.ttf text
+*.fbx binary
+*.dds binary
+*.svg binary
+*.ttf binary


### PR DESCRIPTION
Accidentally marked some binary files as text, causing them to produce bad binaries on checkout.