### PR TITLE
Controllers : Fixing the pose transmission

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -630,7 +630,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     connect(userInputMapper.data(), &UserInputMapper::actionEvent, _controllerScriptingInterface, &ControllerScriptingInterface::actionEvent);
     connect(userInputMapper.data(), &UserInputMapper::actionEvent, [this](int action, float state) {
         if (state) {
-            switch (action) {
+            switch (controller::Action(action)) {
             case controller::Action::TOGGLE_MUTE:
                 DependencyManager::get<AudioClient>()->toggleMute();
                 break;


### PR DESCRIPTION
The pose route is communicating the pose value if valid
this fixes the fact that the pose was not tagged as valid when it was
now the LeftHand and RIghtHand Actions can be used correctly