### PR TITLE
Add Ability to set keyhole radius on EntityViewer

### DIFF
--- a/libraries/octree/src/OctreeHeadlessViewer.h
+++ b/libraries/octree/src/OctreeHeadlessViewer.h
@@ -46,6 +46,7 @@ public slots:
     // setters for camera attributes
     void setPosition(const glm::vec3& position) { _viewFrustum.setPosition(position); }
     void setOrientation(const glm::quat& orientation) { _viewFrustum.setOrientation(orientation); }
+    void setKeyholeRadius(float keyholdRadius) { _viewFrustum.setKeyholeRadius(keyholdRadius); }
 
     // setters for LOD and PPS
     void setVoxelSizeScale(float sizeScale) { _voxelSizeScale = sizeScale; }


### PR DESCRIPTION
This PR allows an AC script to easily query an area for entities. By setting the keyhole radius you can guarantee that the server will send you entities from the "position" to the radius.

```    
    EntityViewer.setPosition(searchOrigin);
    EntityViewer.setKeyholeRadius(searchRadius);
    EntityViewer.queryOctree();
```