### PR TITLE
Improved ScriptEngine debug messages

### DIFF
--- a/examples/libraries/entityCameraTool.js
+++ b/examples/libraries/entityCameraTool.js
@@ -564,12 +564,12 @@ CameraTool = function(cameraManager) {
 
     var ORIENTATION_OVERLAY_SIZE = 26;
     var ORIENTATION_OVERLAY_HALF_SIZE = ORIENTATION_OVERLAY_SIZE / 2;
-    var ORIENTATION_OVERLAY_CUBE_SIZE = 10.5,
+    var ORIENTATION_OVERLAY_CUBE_SIZE = 10.5;
 
-        var ORIENTATION_OVERLAY_OFFSET = {
-            x: 30,
-            y: 30,
-        }
+    var ORIENTATION_OVERLAY_OFFSET = {
+        x: 30,
+        y: 30,
+    }
 
     var UI_WIDTH = 70;
     var UI_HEIGHT = 70;

--- a/examples/libraries/soundArray.js
+++ b/examples/libraries/soundArray.js
@@ -6,7 +6,7 @@ SoundArray = function(audioOptions, autoUpdateAudioPosition) {
     this.audioOptions = audioOptions !== undefined ? audioOptions : {};
     this.autoUpdateAudioPosition = autoUpdateAudioPosition !== undefined ? autoUpdateAudioPosition : false;
     if (this.audioOptions.position === undefined) {
-        this.audioOptions.position = Vec3.sum(MyAvatar.position, { x: 0, y: 1, z: 0}),
+        this.audioOptions.position = Vec3.sum(MyAvatar.position, { x: 0, y: 1, z: 0});
     }
     if (this.audioOptions.volume === undefined) {
         this.audioOptions.volume = 1.0;

--- a/interface/src/ui/JSConsole.cpp
+++ b/interface/src/ui/JSConsole.cpp
@@ -106,8 +106,11 @@ void JSConsole::executeCommand(const QString& command) {
 
 QScriptValue JSConsole::executeCommandInWatcher(const QString& command) {
     QScriptValue result;
+    static const QString filename = "JSConcole";
     QMetaObject::invokeMethod(_scriptEngine, "evaluate", Qt::ConnectionType::BlockingQueuedConnection,
-        Q_RETURN_ARG(QScriptValue, result), Q_ARG(const QString&, command));
+                              Q_RETURN_ARG(QScriptValue, result),
+                              Q_ARG(const QString&, command),
+                              Q_ARG(const QString&, filename));
     return result;
 }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -509,18 +509,22 @@ void ScriptEngine::addEventHandler(const EntityItemID& entityID, const QString& 
         });
         
         // Two common cases of event handler, differing only in argument signature.
-        auto makeSingleEntityHandler = [&](QString eventName) {
+        using SingleEntityHandler = std::function<void(const EntityItemID&)>;
+        auto makeSingleEntityHandler = [this](QString eventName) -> SingleEntityHandler {
             return [this, eventName](const EntityItemID& entityItemID) {
                 forwardHandlerCall(entityItemID, eventName, { entityItemID.toScriptValue(this) });
             };
         };
-        auto makeMouseHandler = [&](QString eventName) {
+        
+        using MouseHandler = std::function<void(const EntityItemID&, const MouseEvent&)>;
+        auto makeMouseHandler = [this](QString eventName) -> MouseHandler {
             return [this, eventName](const EntityItemID& entityItemID, const MouseEvent& event) {
                 forwardHandlerCall(entityItemID, eventName, { entityItemID.toScriptValue(this), event.toScriptValue(this) });
             };
         };
         
-        auto makeCollisionHandler = [&](QString eventName) {
+        using CollisionHandler = std::function<void(const EntityItemID&, const EntityItemID&, const Collision&)>;
+        auto makeCollisionHandler = [this](QString eventName) -> CollisionHandler {
             return [this, eventName](const EntityItemID& idA, const EntityItemID& idB, const Collision& collision) {
                 forwardHandlerCall(idA, eventName, { idA.toScriptValue(this), idB.toScriptValue(this),
                                                      collisionToScriptValue(this, collision) });

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -575,9 +575,9 @@ QScriptValue ScriptEngine::evaluate(const QString& sourceCode, const QString& fi
         return result;
     }
     
-    // Check synthax
+    // Check syntax
     const QScriptProgram program(sourceCode, fileName, lineNumber);
-    if (!checkSynthax(program)) {
+    if (!checkSyntax(program)) {
         return QScriptValue();
     }
 
@@ -892,7 +892,7 @@ void ScriptEngine::load(const QString& loadFile) {
 }
 
 
-bool ScriptEngine::checkSynthax(const QScriptProgram& program) {
+bool ScriptEngine::checkSyntax(const QScriptProgram& program) {
     const auto syntaxCheck = QScriptEngine::checkSyntax(program.sourceCode());
     if (syntaxCheck.state() != QScriptSyntaxCheckResult::Valid) {
         const auto error = syntaxCheck.errorMessage();

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -183,7 +183,7 @@ private:
     void stopTimer(QTimer* timer);
 
     static bool checkSyntax(const QScriptProgram& program);
-    static bool checkExceptions(QScriptEngine* engine, const QString& fileName);
+    static bool checkExceptions(QScriptEngine& engine, const QString& fileName);
     
     AbstractControllerScriptingInterface* _controllerScriptingInterface;
     QString _fileNameString;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -181,9 +181,6 @@ private:
 
     QObject* setupTimerWithInterval(const QScriptValue& function, int intervalMS, bool isSingleShot);
     void stopTimer(QTimer* timer);
-
-    static bool checkSyntax(const QScriptProgram& program);
-    static bool checkExceptions(QScriptEngine& engine, const QString& fileName);
     
     AbstractControllerScriptingInterface* _controllerScriptingInterface;
     QString _fileNameString;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -193,7 +193,7 @@ private:
     ArrayBufferClass* _arrayBufferClass;
 
     QHash<EntityItemID, RegisteredEventHandlers> _registeredHandlers;
-    void generalHandler(const EntityItemID& entityID, const QString& eventName, std::function<QScriptValueList()> argGenerator);
+    void forwardHandlerCall(const EntityItemID& entityID, const QString& eventName, QScriptValueList eventHanderArgs);
     Q_INVOKABLE void entityScriptContentAvailable(const EntityItemID& entityID, const QString& scriptOrURL, const QString& contents, bool isURL, bool success);
 
     static QSet<ScriptEngine*> _allKnownScriptEngines;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -88,7 +88,7 @@ public:
     Q_INVOKABLE void registerValue(const QString& valueName, QScriptValue value);
 
     /// evaluate some code in the context of the ScriptEngine and return the result
-    Q_INVOKABLE QScriptValue evaluate(const QString& program, const QString& fileName = QString(), int lineNumber = 1); // this is also used by the script tool widget
+    Q_INVOKABLE QScriptValue evaluate(const QString& program, const QString& fileName, int lineNumber = 1); // this is also used by the script tool widget
 
     /// if the script engine is not already running, this will download the URL and start the process of seting it up
     /// to run... NOTE - this is used by Application currently to load the url. We don't really want it to be exposed 
@@ -182,6 +182,9 @@ private:
     QObject* setupTimerWithInterval(const QScriptValue& function, int intervalMS, bool isSingleShot);
     void stopTimer(QTimer* timer);
 
+    static bool checkSynthax(const QScriptProgram& program);
+    static bool checkExceptions(QScriptEngine* engine, const QString& fileName);
+    
     AbstractControllerScriptingInterface* _controllerScriptingInterface;
     QString _fileNameString;
     Quat _quatLibrary;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -182,7 +182,7 @@ private:
     QObject* setupTimerWithInterval(const QScriptValue& function, int intervalMS, bool isSingleShot);
     void stopTimer(QTimer* timer);
 
-    static bool checkSynthax(const QScriptProgram& program);
+    static bool checkSyntax(const QScriptProgram& program);
     static bool checkExceptions(QScriptEngine* engine, const QString& fileName);
     
     AbstractControllerScriptingInterface* _controllerScriptingInterface;

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -135,7 +135,7 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
         prefixString.append(QString(" [%1]").arg(_targetName));
     }
     
-    QString logMessage = QString("%1 %2").arg(prefixString, message);
+    QString logMessage = QString("%1 %2").arg(prefixString, message.split("\n").join("\n" + prefixString + " "));
     fprintf(stdout, "%s\n", qPrintable(logMessage));
     return logMessage;
 }


### PR DESCRIPTION
- Check local scripts syntax before evaluating them.
- Display backtrace in case of exceptions.
- Make sure to pass a filename to `evaluate` for easier exception tracking.
- Cleaned up handler callbacks code.

Since we're checking the syntax before running a local script now, it might break scripts that had a syntax error in a very rarely used code path. I fixed 2 scripts and made sure all the script in defaultScript.js ran correctly.

But if you notice a script is not running, check your log for those tags: `[SyntaxError]` `[UncaughtException]`

New messages:
```
[10/26 11:43:06] [WARNING] [SyntaxError] Expected `identifier' in file:///Users/clement/hifi/examples/libraries/entityCameraTool.js:569(5)
```

```
[10/26 11:47:16] [WARNING] [UncaughtException] ReferenceError: Can't find variable: event in /Users/clement/hifi/examples/edit.js:1719
[10/26 11:47:16] [WARNING] [Backtrace]
[10/26 11:47:16] [WARNING]     <anonymous>(name = 'Show in Marketplace') at /Users/clement/hifi/examples/edit.js:1719
[10/26 11:47:16] [WARNING]     <global>() at /Users/clement/hifi/examples/edit.js:1847
```