### PR TITLE
Add Reset Buttons for Basketballs and Targets to Toybox

### DIFF
--- a/unpublishedScripts/basketballsResetter.js
+++ b/unpublishedScripts/basketballsResetter.js
@@ -17,7 +17,7 @@ var HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
 
     Resetter.prototype = {
 
-        startFarGrabNonColliding: function() {
+        startNearGrabNonColliding: function() {
             this.resetObjects();
         },
 

--- a/unpublishedScripts/basketballsResetter.js
+++ b/unpublishedScripts/basketballsResetter.js
@@ -1,0 +1,111 @@
+//
+//
+//  Created by James B. Pollack @imgntn on 10/26/2015
+//  Copyright 2015 High Fidelity, Inc.
+//
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+var HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
+
+(function() {
+
+    var _this;
+    Resetter = function() {
+        _this = this;
+    };
+
+    Resetter.prototype = {
+
+        startFarGrabNonColliding: function() {
+            this.resetObjects();
+        },
+
+        clickReleaseOnEntity: function() {
+            this.resetObjects();
+        },
+
+        resetObjects: function() {
+            var ids = Entities.findEntities(this.initialProperties.position, 75);
+            var i;
+            for (i = 0; i < ids.length; i++) {
+                var id = ids[i];
+                var properties = Entities.getEntityProperties(id, "name");
+                if (properties.name === "Hifi-Basketball") {
+                    Entities.deleteEntity(id);
+                }
+            }
+
+            this.createBasketballs();
+        },
+
+        createBasketballs: function() {
+            var NUMBER_OF_BALLS = 4;
+            var DIAMETER = 0.30;
+            var basketballURL = HIFI_PUBLIC_BUCKET + "models/content/basketball2.fbx";
+            var basketballCollisionSoundURL = HIFI_PUBLIC_BUCKET + "sounds/basketball/basketball.wav";
+
+            var position = {
+                x: 542.86,
+                y: 494.84,
+                z: 475.06
+            };
+            var collidingBalls = [];
+
+            var i;
+            for (i = 0; i < NUMBER_OF_BALLS; i++) {
+                var ballPosition = {
+                    x: position.x,
+                    y: position.y + DIAMETER * 2,
+                    z: position.z + (DIAMETER) - (DIAMETER * i)
+                };
+                var newPosition = {
+                    x: position.x + (DIAMETER * 2) - (DIAMETER * i),
+                    y: position.y + DIAMETER * 2,
+                    z: position.z
+                };
+                var collidingBall = Entities.addEntity({
+                    type: "Model",
+                    name: 'Hifi-Basketball',
+                    shapeType: 'Sphere',
+                    position: newPosition,
+                    dimensions: {
+                        x: DIAMETER,
+                        y: DIAMETER,
+                        z: DIAMETER
+                    },
+                    restitution: 1.0,
+                    linearDamping: 0.00001,
+                    gravity: {
+                        x: 0,
+                        y: -9.8,
+                        z: 0
+                    },
+                    collisionsWillMove: true,
+                    collisionsSoundURL: basketballCollisionSoundURL,
+                    ignoreForCollisions: false,
+                    modelURL: basketballURL,
+                    userData: JSON.stringify({
+                        resetMe: {
+                            resetMe: true
+                        },
+                        grabbableKey: {
+                            invertSolidWhileHeld: true
+                        }
+                    })
+                });
+
+                collidingBalls.push(collidingBall);
+
+            }
+        },
+
+        preload: function(entityID) {
+            this.initialProperties = Entities.getEntityProperties(entityID);
+            this.entityID = entityID;
+        },
+
+    };
+
+    return new Resetter();
+});

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -351,7 +351,7 @@
             };
 
             var resetter = Entities.addEntity({
-                type: "Text",
+                type: "Box",
                 position: position,
                 name: "Basketball Resetter",
                 script: basketballResetterScriptURL,

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -22,7 +22,8 @@
     var dollScriptURL = Script.resolvePath("../examples/toybox/doll/doll.js");
     var lightsScriptURL = Script.resolvePath("../examples/toybox/lights/lightSwitch.js");
     var targetsScriptURL = Script.resolvePath('../examples/toybox/ping_pong_gun/wallTarget.js');
-
+    var basketballResetterScriptURL = Script.resolvePath('basketballsResetter.js');
+    var targetsResetterScriptURL = Script.resolvePath('targetsResetter.js');
 
     ResetSwitch = function() {
         _this = this;
@@ -110,17 +111,18 @@
             });
 
             createPingPongBallGun();
+            createTargets();
+            createTargetResetter();
 
             createBasketballHoop();
             createBasketballRack();
+            createBasketballResetter();
 
             createGates();
 
             createFire();
             // Handles toggling of all sconce lights 
             createLights();
-
-
 
             createCat({
                 x: 551.09,
@@ -135,7 +137,6 @@
                 z: 503.91
             });
 
-            createTargets();
 
         }
 
@@ -275,10 +276,11 @@
                 })
             });
 
-            var collidingBalls = [];
+
 
             function createCollidingBalls() {
                 var position = rackStartPosition;
+                var collidingBalls = [];
 
                 var i;
                 for (i = 0; i < NUMBER_OF_BALLS; i++) {
@@ -333,6 +335,103 @@
             createCollidingBalls();
 
         }
+
+        function createBasketballResetter() {
+
+            var position = {
+                x: 542.86,
+                y: 494.44,
+                z: 475.06
+            };
+
+            var dimensions = {
+                x: 0.5,
+                y: 0.1,
+                z: 0.01
+            };
+
+            var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
+
+            var resetter = Entities.addEntity({
+                type: "Text",
+                position: position,
+                name: "Basketball Resetter",
+                script: basketballResetterScriptURL,
+                rotation: rotation,
+                dimensions: dimensions,
+                backgroundColor: {
+                    red: 0,
+                    green: 0,
+                    blue: 0
+                },
+                textColor: {
+                    red: 255,
+                    green: 255,
+                    blue: 255
+                },
+                text: "RESET BALLS",
+                lineHeight: 0.07,
+                faceCamera: true,
+                userData: JSON.stringify({
+                    resetMe: {
+                        resetMe: true
+                    },
+                    grabbableKey: {
+                        wantsTrigger: true
+                    }
+                })
+            });
+
+
+        }
+
+        function createTargetResetter() {
+            var dimensions = {
+                x: 0.5,
+                y: 0.1,
+                z: 0.01
+            };
+
+            var position = {
+                x: 548.68,
+                y: 495.30,
+                z: 509.74
+            };
+
+            var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
+
+            var resetter = Entities.addEntity({
+                type: "Text",
+                position: position,
+                name: "Target Resetter",
+                script: targetsResetterScriptURL,
+                rotation: rotation,
+                dimensions: dimensions,
+                backgroundColor: {
+                    red: 0,
+                    green: 0,
+                    blue: 0
+                },
+                textColor: {
+                    red: 255,
+                    green: 255,
+                    blue: 255
+                },
+                faceCamera: true,
+                text: "RESET TARGETS",
+                lineHeight: 0.07,
+                userData: JSON.stringify({
+                    resetMe: {
+                        resetMe: true
+                    },
+                    grabbableKey: {
+                        wantsTrigger: true
+                    }
+                })
+
+            });
+        }
+
 
         function createTargets() {
 

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -339,39 +339,24 @@
         function createBasketballResetter() {
 
             var position = {
-                x: 542.86,
-                y: 494.44,
-                z: 475.06
+                x: 543.58,
+                y: 495.47,
+                z: 469.59
             };
 
             var dimensions = {
-                x: 0.5,
-                y: 0.1,
-                z: 0.01
+                x: 1.65,
+                y: 1.71,
+                z: 1.75
             };
-
-            var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
 
             var resetter = Entities.addEntity({
                 type: "Text",
                 position: position,
                 name: "Basketball Resetter",
                 script: basketballResetterScriptURL,
-                rotation: rotation,
                 dimensions: dimensions,
-                backgroundColor: {
-                    red: 0,
-                    green: 0,
-                    blue: 0
-                },
-                textColor: {
-                    red: 255,
-                    green: 255,
-                    blue: 255
-                },
-                text: "RESET BALLS",
-                lineHeight: 0.07,
-                faceCamera: true,
+                visible: false,
                 userData: JSON.stringify({
                     resetMe: {
                         resetMe: true
@@ -387,39 +372,24 @@
 
         function createTargetResetter() {
             var dimensions = {
-                x: 1,
-                y: 0.1,
-                z: 0.01
+                x: 0.21,
+                y: 0.61,
+                z: 0.21
             };
 
             var position = {
-                x: 548.68,
-                y: 495.30,
-                z: 509.74
+                x: 548.42,
+                y: 496.40,
+                z: 509.61
             };
 
-            var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
-
             var resetter = Entities.addEntity({
-                type: "Text",
+                type: "Box",
                 position: position,
                 name: "Target Resetter",
                 script: targetsResetterScriptURL,
-                rotation: rotation,
                 dimensions: dimensions,
-                backgroundColor: {
-                    red: 0,
-                    green: 0,
-                    blue: 0
-                },
-                textColor: {
-                    red: 255,
-                    green: 255,
-                    blue: 255
-                },
-                faceCamera: true,
-                text: "RESET TARGETS",
-                lineHeight: 0.07,
+                visible: false,
                 userData: JSON.stringify({
                     resetMe: {
                         resetMe: true
@@ -431,6 +401,7 @@
 
             });
         }
+
 
 
         function createTargets() {

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -387,7 +387,7 @@
 
         function createTargetResetter() {
             var dimensions = {
-                x: 0.5,
+                x: 1,
                 y: 0.1,
                 z: 0.01
             };

--- a/unpublishedScripts/immediateClientReset.js
+++ b/unpublishedScripts/immediateClientReset.js
@@ -8,14 +8,10 @@
 
 /*global print, MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, Audio, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, pointInExtents, vec3equal, setEntityCustomData, getEntityCustomData */
 
-
 var masterResetScript = Script.resolvePath("masterReset.js");
 var hiddenEntityScriptURL = Script.resolvePath("hiddenEntityReset.js");
 
-
 Script.include(masterResetScript);
-
-
 
 function createHiddenMasterSwitch() {
 
@@ -31,7 +27,6 @@ function createHiddenMasterSwitch() {
     });
 }
 
-
 var entities = Entities.findEntities(MyAvatar.position, 100);
 
 entities.forEach(function(entity) {
@@ -41,5 +36,7 @@ entities.forEach(function(entity) {
         Entities.deleteEntity(entity);
     }
 });
+
 createHiddenMasterSwitch();
+
 MasterReset();

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -317,39 +317,24 @@ MasterReset = function() {
     function createBasketballResetter() {
 
         var position = {
-            x: 542.86,
-            y: 494.44,
-            z: 475.06
+            x: 543.58,
+            y: 495.47,
+            z: 469.59
         };
 
         var dimensions = {
-            x: 0.5,
-            y: 0.1,
-            z: 0.01
+            x: 1.65,
+            y: 1.71,
+            z: 1.75
         };
-
-        var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
 
         var resetter = Entities.addEntity({
             type: "Text",
             position: position,
             name: "Basketball Resetter",
             script: basketballResetterScriptURL,
-            rotation: rotation,
             dimensions: dimensions,
-            backgroundColor: {
-                red: 0,
-                green: 0,
-                blue: 0
-            },
-            textColor: {
-                red: 255,
-                green: 255,
-                blue: 255
-            },
-            text: "RESET BALLS",
-            lineHeight: 0.07,
-            faceCamera: true,
+            visible:false,
             userData: JSON.stringify({
                 resetMe: {
                     resetMe: true
@@ -365,39 +350,24 @@ MasterReset = function() {
 
     function createTargetResetter() {
         var dimensions = {
-            x: 1,
-            y: 0.1,
-            z: 0.01
+            x: 0.21,
+            y: 0.61,
+            z: 0.21
         };
 
         var position = {
-            x: 548.68,
-            y: 495.30,
-            z: 509.74
+            x: 548.42,
+            y: 496.40,
+            z: 509.61
         };
 
-        var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
-
         var resetter = Entities.addEntity({
-            type: "Text",
+            type: "Box",
             position: position,
             name: "Target Resetter",
             script: targetsResetterScriptURL,
-            rotation: rotation,
             dimensions: dimensions,
-            backgroundColor: {
-                red: 0,
-                green: 0,
-                blue: 0
-            },
-            textColor: {
-                red: 255,
-                green: 255,
-                blue: 255
-            },
-            faceCamera: true,
-            text: "RESET TARGETS",
-            lineHeight: 0.07,
+            visible:false,
             userData: JSON.stringify({
                 resetMe: {
                     resetMe: true

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -14,16 +14,16 @@
 var utilitiesScript = Script.resolvePath("../examples/libraries/utils.js");
 Script.include(utilitiesScript);
 
-    var sprayPaintScriptURL = Script.resolvePath("../examples/toybox/spray_paint/sprayPaintCan.js");
-    var catScriptURL = Script.resolvePath("../examples/toybox/cat/cat.js");
-    var flashlightScriptURL = Script.resolvePath('../examples/toybox/flashlight/flashlight.js');
-    var pingPongScriptURL = Script.resolvePath('../examples/toybox/ping_pong_gun/pingPongGun.js');
-    var wandScriptURL = Script.resolvePath("../examples/toybox/bubblewand/wand.js");
-    var dollScriptURL = Script.resolvePath("../examples/toybox/doll/doll.js");
-    var lightsScriptURL = Script.resolvePath("../examples/toybox/lights/lightSwitch.js");
-    var targetsScriptURL = Script.resolvePath('../examples/toybox/ping_pong_gun/wallTarget.js');
-
-
+var sprayPaintScriptURL = Script.resolvePath("../examples/toybox/spray_paint/sprayPaintCan.js");
+var catScriptURL = Script.resolvePath("../examples/toybox/cat/cat.js");
+var flashlightScriptURL = Script.resolvePath('../examples/toybox/flashlight/flashlight.js');
+var pingPongScriptURL = Script.resolvePath('../examples/toybox/ping_pong_gun/pingPongGun.js');
+var wandScriptURL = Script.resolvePath("../examples/toybox/bubblewand/wand.js");
+var dollScriptURL = Script.resolvePath("../examples/toybox/doll/doll.js");
+var lightsScriptURL = Script.resolvePath("../examples/toybox/lights/lightSwitch.js");
+var targetsScriptURL = Script.resolvePath('../examples/toybox/ping_pong_gun/wallTarget.js');
+var basketballResetterScriptURL = Script.resolvePath('basketballsResetter.js');
+var targetsResetterScriptURL = Script.resolvePath('targetsResetter.js');
 
 MasterReset = function() {
     var resetKey = "resetMe";
@@ -84,9 +84,12 @@ MasterReset = function() {
         });
 
         createPingPongBallGun();
+        createTargets();
+        createTargetResetter();
 
         createBasketballHoop();
         createBasketballRack();
+        createBasketballResetter();
 
         createGates();
 
@@ -109,7 +112,7 @@ MasterReset = function() {
             z: 503.91
         });
 
-        createTargets();
+
 
     }
 
@@ -201,6 +204,7 @@ MasterReset = function() {
         });
     }
 
+
     function createBasketballRack() {
         var NUMBER_OF_BALLS = 4;
         var DIAMETER = 0.30;
@@ -249,10 +253,11 @@ MasterReset = function() {
             })
         });
 
-        var collidingBalls = [];
+
 
         function createCollidingBalls() {
             var position = rackStartPosition;
+            var collidingBalls = [];
 
             var i;
             for (i = 0; i < NUMBER_OF_BALLS; i++) {
@@ -307,6 +312,105 @@ MasterReset = function() {
         createCollidingBalls();
 
     }
+
+
+    function createBasketballResetter() {
+
+        var position = {
+            x: 542.86,
+            y: 494.44,
+            z: 475.06
+        };
+
+        var dimensions = {
+            x: 0.5,
+            y: 0.1,
+            z: 0.01
+        };
+
+        var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
+
+        var resetter = Entities.addEntity({
+            type: "Text",
+            position: position,
+            name: "Basketball Resetter",
+            script: basketballResetterScriptURL,
+            rotation: rotation,
+            dimensions: dimensions,
+            backgroundColor: {
+                red: 0,
+                green: 0,
+                blue: 0
+            },
+            textColor: {
+                red: 255,
+                green: 255,
+                blue: 255
+            },
+            text: "RESET BALLS",
+            lineHeight: 0.07,
+            faceCamera: true,
+            userData: JSON.stringify({
+                resetMe: {
+                    resetMe: true
+                },
+                grabbableKey: {
+                    wantsTrigger: true
+                }
+            })
+        });
+
+
+    }
+
+    function createTargetResetter() {
+        var dimensions = {
+            x: 0.5,
+            y: 0.1,
+            z: 0.01
+        };
+
+        var position = {
+            x: 548.68,
+            y: 495.30,
+            z: 509.74
+        };
+
+        var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
+        
+        var resetter = Entities.addEntity({
+            type: "Text",
+            position: position,
+            name: "Target Resetter",
+            script: targetsResetterScriptURL,
+            rotation: rotation,
+            dimensions: dimensions,
+            backgroundColor: {
+                red: 0,
+                green: 0,
+                blue: 0
+            },
+            textColor: {
+                red: 255,
+                green: 255,
+                blue: 255
+            },
+            faceCamera: true,
+            text: "RESET TARGETS",
+            lineHeight: 0.07,
+            userData: JSON.stringify({
+                resetMe: {
+                    resetMe: true
+                },
+                grabbableKey: {
+                    wantsTrigger: true
+                }
+            })
+
+        });
+    }
+
+
 
     function createTargets() {
 

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -329,7 +329,7 @@ MasterReset = function() {
         };
 
         var resetter = Entities.addEntity({
-            type: "Text",
+            type: "Box",
             position: position,
             name: "Basketball Resetter",
             script: basketballResetterScriptURL,

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -365,7 +365,7 @@ MasterReset = function() {
 
     function createTargetResetter() {
         var dimensions = {
-            x: 0.5,
+            x: 1,
             y: 0.1,
             z: 0.01
         };
@@ -377,7 +377,7 @@ MasterReset = function() {
         };
 
         var rotation = Quat.fromPitchYawRollDegrees(0, 0, 0);
-        
+
         var resetter = Entities.addEntity({
             type: "Text",
             position: position,

--- a/unpublishedScripts/targetsResetter.js
+++ b/unpublishedScripts/targetsResetter.js
@@ -1,0 +1,128 @@
+//
+//
+//  Created by James B. Pollack @imgntn on 10/26/2015
+//  Copyright 2015 High Fidelity, Inc.
+//
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+(function() {
+    var targetsScriptURL = Script.resolvePath('../examples/toybox/ping_pong_gun/wallTarget.js');
+
+    var _this;
+    Resetter = function() {
+        _this = this;
+    };
+
+    Resetter.prototype = {
+
+        startFarGrabNonColliding: function() {
+            this.resetObjects();
+        },
+
+        clickReleaseOnEntity: function() {
+            this.resetObjects();
+        },
+
+        resetObjects: function() {
+            var ids = Entities.findEntities(this.initialProperties.position, 50);
+            for (var i = 0; i < ids.length; i++) {
+                var id = ids[i];
+                var properties = Entities.getEntityProperties(id, "name");
+                if (properties.name === "Hifi-Target") {
+                    Entities.deleteEntity(id);
+                }
+            }
+            this.createTargets();
+        },
+
+        preload: function(entityID) {
+            this.initialProperties = Entities.getEntityProperties(entityID);
+            this.entityID = entityID;
+        },
+
+        createTargets: function() {
+
+            var MODEL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/target.fbx';
+            var COLLISION_HULL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/target_collision_hull.obj';
+
+            var MINIMUM_MOVE_LENGTH = 0.05;
+            var RESET_DISTANCE = 0.5;
+            var TARGET_USER_DATA_KEY = 'hifi-ping_pong_target';
+            var NUMBER_OF_TARGETS = 6;
+            var TARGETS_PER_ROW = 3;
+
+            var TARGET_DIMENSIONS = {
+                x: 0.06,
+                y: 0.42,
+                z: 0.42
+            };
+
+            var VERTICAL_SPACING = TARGET_DIMENSIONS.y + 0.5;
+            var HORIZONTAL_SPACING = TARGET_DIMENSIONS.z + 0.5;
+
+
+            var startPosition = {
+                x: 548.68,
+                y: 497.30,
+                z: 509.74
+            };
+
+            var rotation = Quat.fromPitchYawRollDegrees(0, -55.25, 0);
+
+            var targets = [];
+
+            function addTargets() {
+                var i;
+                var row = -1;
+                for (i = 0; i < NUMBER_OF_TARGETS; i++) {
+
+                    if (i % TARGETS_PER_ROW === 0) {
+                        row++;
+                    }
+
+                    var vHat = Quat.getFront(rotation);
+                    var spacer = HORIZONTAL_SPACING * (i % TARGETS_PER_ROW) + (row * HORIZONTAL_SPACING / 2);
+                    var multiplier = Vec3.multiply(spacer, vHat);
+                    var position = Vec3.sum(startPosition, multiplier);
+                    position.y = startPosition.y - (row * VERTICAL_SPACING);
+
+                    var targetProperties = {
+                        name: 'Hifi-Target',
+                        type: 'Model',
+                        modelURL: MODEL_URL,
+                        shapeType: 'compound',
+                        collisionsWillMove: true,
+                        dimensions: TARGET_DIMENSIONS,
+                        compoundShapeURL: COLLISION_HULL_URL,
+                        position: position,
+                        rotation: rotation,
+                        script: targetsScriptURL,
+                        userData: JSON.stringify({
+                            originalPositionKey: {
+                                originalPosition: position
+                            },
+                            resetMe: {
+                                resetMe: true
+                            },
+                            grabbableKey: {
+                                grabbable: false
+                            }
+                        })
+                    };
+
+                    var target = Entities.addEntity(targetProperties);
+                    targets.push(target);
+
+                }
+            }
+
+            addTargets();
+
+        }
+
+    };
+
+    return new Resetter();
+});

--- a/unpublishedScripts/targetsResetter.js
+++ b/unpublishedScripts/targetsResetter.js
@@ -17,7 +17,7 @@
 
     Resetter.prototype = {
 
-        startFarGrabNonColliding: function() {
+        startNearGrabNonColliding: function() {
             this.resetObjects();
         },
 


### PR DESCRIPTION
This PR adds small buttons that make it possible to reset the targets or the basketballs.  The reset entities react to clicks or near'grabs', and they themselves are part of the master reset script.

Test in toybox with this URL, then clicking on the respective reset button: https://rawgit.com/imgntn/hifi/toybox_reset_buttons/unpublishedScripts/immediateClientReset.js