### PR TITLE
Bug fix for hand IK when using the Owen avatar.

### DIFF
--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -366,7 +366,7 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
             if (offsetLength > MIN_HIPS_OFFSET_LENGTH) {
                 // but only if offset is long enough
                 float scaleFactor = ((offsetLength - MIN_HIPS_OFFSET_LENGTH) / offsetLength);
-                _relativePoses[0].trans = underPoses[0].trans + scaleFactor * _hipsOffset;
+                _relativePoses[_hipsIndex].trans = underPoses[_hipsIndex].trans + scaleFactor * _hipsOffset;
             }
 
             solveWithCyclicCoordinateDescent(targets);
@@ -758,8 +758,10 @@ void AnimInverseKinematics::setSkeletonInternal(AnimSkeleton::ConstPointer skele
     if (skeleton) {
         initConstraints();
         _headIndex = _skeleton->nameToJointIndex("Head");
+        _hipsIndex = _skeleton->nameToJointIndex("Hips");
     } else {
         clearConstraints();
         _headIndex = -1;
+        _hipsIndex = -1;
     }
 }

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -80,6 +80,7 @@ protected:
 
     // experimental data for moving hips during IK
     int _headIndex = -1;
+    int _hipsIndex = -1;
     glm::vec3 _hipsOffset = Vectors::ZERO;
 
     // _maxTargetIndex is tracked to help optimize the recalculation of absolute poses


### PR DESCRIPTION
The IK was assiming that the "Hips" bone index was always 0.
This was not the case for Owen.  Now, we lookup the Hips index
and cache it for use during the hipsOffset computation.