### PR TITLE
Do not shut down hydra when it says there are no devices. 

### DIFF
--- a/libraries/input-plugins/src/input-plugins/SixenseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.h
@@ -114,6 +114,8 @@ private:
 #endif
     
     bool _hydrasConnected;
+    int _badDataCount;
+    int _allowedBadDataCount;
 
     static const QString NAME;
     static const QString HYDRA_ID_STRING;


### PR DESCRIPTION
Count to allowedHydraFailures in settings.