### PR TITLE
Fixes locally rendered eye gaze

### DIFF
--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -224,7 +224,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
         Rig::EyeParameters eyeParams;
         eyeParams.worldHeadOrientation = head->getFinalOrientationInWorldFrame();
         eyeParams.eyeLookAt = head->getCorrectedLookAtPosition();
-        eyeParams.eyeSaccade = glm::vec3(0);
+        eyeParams.eyeSaccade = glm::vec3();
         eyeParams.modelRotation = getRotation();
         eyeParams.modelTranslation = getTranslation();
         eyeParams.leftEyeJointIndex = geometry.leftEyeJointIndex;

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -194,7 +194,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
         eyeParams.leftEyeJointIndex = geometry.leftEyeJointIndex;
         eyeParams.rightEyeJointIndex = geometry.rightEyeJointIndex;
 
-        _rig->updateFromEyeParameters(eyeParams, deltaTime);
+        _rig->updateFromEyeParameters(eyeParams);
 
         // rebuild the jointState transform for the eyes only
         _rig->updateJointState(eyeParams.leftEyeJointIndex, parentTransform);
@@ -229,7 +229,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
         eyeParams.modelTranslation = getTranslation();
         eyeParams.leftEyeJointIndex = geometry.leftEyeJointIndex;
         eyeParams.rightEyeJointIndex = geometry.rightEyeJointIndex;
-        _rig->updateFromEyeParameters(eyeParams, deltaTime);
+        _rig->updateFromEyeParameters(eyeParams);
      }
 }
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -22,34 +22,6 @@
 #include "AnimSkeleton.h"
 #include "IKTarget.h"
 
-
-void Rig::HeadParameters::dump() const {
-    qCDebug(animation, "HeadParameters =");
-    qCDebug(animation, "    leanSideways = %0.5f", (double)leanSideways);
-    qCDebug(animation, "    leanForward = %0.5f", (double)leanForward);
-    qCDebug(animation, "    torsoTwist = %0.5f", (double)torsoTwist);
-    glm::vec3 axis = glm::axis(localHeadOrientation);
-    float theta = glm::angle(localHeadOrientation);
-    qCDebug(animation, "    localHeadOrientation axis = (%.5f, %.5f, %.5f), theta = %0.5f", (double)axis.x, (double)axis.y, (double)axis.z, (double)theta);
-    axis = glm::axis(worldHeadOrientation);
-    theta = glm::angle(worldHeadOrientation);
-    qCDebug(animation, "    localHead pitch = %.5f, yaw = %.5f, roll = %.5f", (double)localHeadPitch, (double)localHeadYaw, (double)localHeadRoll);
-    qCDebug(animation, "    localHeadPosition = (%.5f, %.5f, %.5f)", (double)localHeadPosition.x, (double)localHeadPosition.y, (double)localHeadPosition.z);
-    qCDebug(animation, "    isInHMD = %s", isInHMD ? "true" : "false");
-    qCDebug(animation, "    worldHeadOrientation axis = (%.5f, %.5f, %.5f), theta = %0.5f", (double)axis.x, (double)axis.y, (double)axis.z, (double)theta);
-    axis = glm::axis(modelRotation);
-    theta = glm::angle(modelRotation);
-    qCDebug(animation, "    modelRotation axis = (%.5f, %.5f, %.5f), theta = %0.5f", (double)axis.x, (double)axis.y, (double)axis.z, (double)theta);
-    qCDebug(animation, "    modelTranslation = (%.5f, %.5f, %.5f)", (double)modelTranslation.x, (double)modelTranslation.y, (double)modelTranslation.z);
-    qCDebug(animation, "    eyeLookAt = (%.5f, %.5f, %.5f)", (double)eyeLookAt.x, (double)eyeLookAt.y, (double)eyeLookAt.z);
-    qCDebug(animation, "    eyeSaccade = (%.5f, %.5f, %.5f)", (double)eyeSaccade.x, (double)eyeSaccade.y, (double)eyeSaccade.z);
-    qCDebug(animation, "    leanJointIndex = %.d", leanJointIndex);
-    qCDebug(animation, "    neckJointIndex = %.d", neckJointIndex);
-    qCDebug(animation, "    leftEyeJointIndex = %.d", leftEyeJointIndex);
-    qCDebug(animation, "    rightEyeJointIndex = %.d", rightEyeJointIndex);
-    qCDebug(animation, "    isTalking = %s", isTalking ? "true" : "false");
-}
-
 void insertSorted(QList<AnimationHandlePointer>& handles, const AnimationHandlePointer& handle) {
     for (QList<AnimationHandlePointer>::iterator it = handles.begin(); it != handles.end(); it++) {
         if (handle->getPriority() > (*it)->getPriority()) {
@@ -981,13 +953,16 @@ void Rig::updateFromHeadParameters(const HeadParameters& params, float dt) {
         _animVars.unset("lean");
     }
     updateNeckJoint(params.neckJointIndex, params);
-    updateEyeJoints(params.leftEyeJointIndex, params.rightEyeJointIndex, params.modelTranslation, params.modelRotation,
-                    params.worldHeadOrientation, params.eyeLookAt, params.eyeSaccade);
 
     if (_enableAnimGraph) {
         _animVars.set("isTalking", params.isTalking);
         _animVars.set("notIsTalking", !params.isTalking);
     }
+}
+
+void Rig::updateFromEyeParameters(const EyeParameters& params, float dt) {
+    updateEyeJoints(params.leftEyeJointIndex, params.rightEyeJointIndex, params.modelTranslation, params.modelRotation,
+                    params.worldHeadOrientation, params.eyeLookAt, params.eyeSaccade);
 }
 
 static const glm::vec3 X_AXIS(1.0f, 0.0f, 0.0f);

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -960,7 +960,7 @@ void Rig::updateFromHeadParameters(const HeadParameters& params, float dt) {
     }
 }
 
-void Rig::updateFromEyeParameters(const EyeParameters& params, float dt) {
+void Rig::updateFromEyeParameters(const EyeParameters& params) {
     updateEyeJoint(params.leftEyeJointIndex, params.modelTranslation, params.modelRotation,
                    params.worldHeadOrientation, params.eyeLookAt, params.eyeSaccade);
     updateEyeJoint(params.rightEyeJointIndex, params.modelTranslation, params.modelRotation,

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -961,8 +961,10 @@ void Rig::updateFromHeadParameters(const HeadParameters& params, float dt) {
 }
 
 void Rig::updateFromEyeParameters(const EyeParameters& params, float dt) {
-    updateEyeJoints(params.leftEyeJointIndex, params.rightEyeJointIndex, params.modelTranslation, params.modelRotation,
-                    params.worldHeadOrientation, params.eyeLookAt, params.eyeSaccade);
+    updateEyeJoint(params.leftEyeJointIndex, params.modelTranslation, params.modelRotation,
+                   params.worldHeadOrientation, params.eyeLookAt, params.eyeSaccade);
+    updateEyeJoint(params.rightEyeJointIndex, params.modelTranslation, params.modelRotation,
+                   params.worldHeadOrientation, params.eyeLookAt, params.eyeSaccade);
 }
 
 static const glm::vec3 X_AXIS(1.0f, 0.0f, 0.0f);
@@ -1118,12 +1120,6 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
                                                state.getDefaultRotation(), DEFAULT_PRIORITY);
         }
     }
-}
-
-void Rig::updateEyeJoints(int leftEyeIndex, int rightEyeIndex, const glm::vec3& modelTranslation, const glm::quat& modelRotation,
-                          const glm::quat& worldHeadOrientation, const glm::vec3& lookAtSpot, const glm::vec3& saccade) {
-    updateEyeJoint(leftEyeIndex, modelTranslation, modelRotation, worldHeadOrientation, lookAtSpot, saccade);
-    updateEyeJoint(rightEyeIndex, modelTranslation, modelRotation, worldHeadOrientation, lookAtSpot, saccade);
 }
 
 void Rig::updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::quat& worldHeadOrientation, const glm::vec3& lookAtSpot, const glm::vec3& saccade) {

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -208,8 +208,6 @@ public:
     void updateLeanJoint(int index, float leanSideways, float leanForward, float torsoTwist);
     void updateNeckJoint(int index, const HeadParameters& params);
     void updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::quat& worldHeadOrientation, const glm::vec3& lookAt, const glm::vec3& saccade);
-    void updateEyeJoints(int leftEyeIndex, int rightEyeIndex, const glm::vec3& modelTranslation, const glm::quat& modelRotation,
-                         const glm::quat& worldHeadOrientation, const glm::vec3& lookAtSpot, const glm::vec3& saccade);
 
     QVector<JointState> _jointStates;
     int _rootJointIndex = -1;

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -57,24 +57,26 @@ public:
         float leanForward = 0.0f; // degrees
         float torsoTwist = 0.0f; // degrees
         bool enableLean = false;
-        glm::quat modelRotation = glm::quat();
+        glm::quat worldHeadOrientation = glm::quat();
         glm::quat localHeadOrientation = glm::quat();
         float localHeadPitch = 0.0f; // degrees
         float localHeadYaw = 0.0f; // degrees
         float localHeadRoll = 0.0f; // degrees
         glm::vec3 localHeadPosition = glm::vec3();
         bool isInHMD = false;
+        int leanJointIndex = -1;
+        int neckJointIndex = -1;
+        bool isTalking = false;
+    };
+
+    struct EyeParameters {
         glm::quat worldHeadOrientation = glm::quat();
         glm::vec3 eyeLookAt = glm::vec3();  // world space
         glm::vec3 eyeSaccade = glm::vec3(); // world space
         glm::vec3 modelTranslation = glm::vec3();
-        int leanJointIndex = -1;
-        int neckJointIndex = -1;
+        glm::quat modelRotation = glm::quat();
         int leftEyeJointIndex = -1;
         int rightEyeJointIndex = -1;
-        bool isTalking = false;
-
-        void dump() const;
     };
 
     struct HandParameters {
@@ -185,8 +187,7 @@ public:
     bool getEnableAnimGraph() const { return _enableAnimGraph; }
 
     void updateFromHeadParameters(const HeadParameters& params, float dt);
-    void updateEyeJoints(int leftEyeIndex, int rightEyeIndex, const glm::vec3& modelTranslation, const glm::quat& modelRotation,
-                         const glm::quat& worldHeadOrientation, const glm::vec3& lookAtSpot, const glm::vec3& saccade = glm::vec3(0.0f));
+    void updateFromEyeParameters(const EyeParameters& params, float dt);
 
     void updateFromHandParameters(const HandParameters& params, float dt);
 
@@ -207,6 +208,8 @@ public:
     void updateLeanJoint(int index, float leanSideways, float leanForward, float torsoTwist);
     void updateNeckJoint(int index, const HeadParameters& params);
     void updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::quat& worldHeadOrientation, const glm::vec3& lookAt, const glm::vec3& saccade);
+    void updateEyeJoints(int leftEyeIndex, int rightEyeIndex, const glm::vec3& modelTranslation, const glm::quat& modelRotation,
+                         const glm::quat& worldHeadOrientation, const glm::vec3& lookAtSpot, const glm::vec3& saccade);
 
     QVector<JointState> _jointStates;
     int _rootJointIndex = -1;

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -187,8 +187,7 @@ public:
     bool getEnableAnimGraph() const { return _enableAnimGraph; }
 
     void updateFromHeadParameters(const HeadParameters& params, float dt);
-    void updateFromEyeParameters(const EyeParameters& params, float dt);
-
+    void updateFromEyeParameters(const EyeParameters& params);
     void updateFromHandParameters(const HandParameters& params, float dt);
 
     virtual void setHandPosition(int jointIndex, const glm::vec3& position, const glm::quat& rotation,


### PR DESCRIPTION
The MyAvatar eye gaze should follow the look at target when viewed from the mirror overlay.

This PR also adjusts when AnimVars for head and hand IK are set.  Now they are calculated and set *before* animation is performed.  This should reduce IK latency by one frame.