### PR TITLE
Don't render avatar's renderBoundingCollisionShapes before data is there

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -454,7 +454,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
         */
 
         bool renderBounding = Menu::getInstance()->isOptionChecked(MenuOption::RenderBoundingCollisionShapes);
-        if (renderBounding && shouldRenderHead(renderArgs)) {
+        if (renderBounding && shouldRenderHead(renderArgs) && _skeletonModel.isRenderable()) {
             _skeletonModel.renderBoundingCollisionShapes(*renderArgs->_batch, 0.7f);
         }
 


### PR DESCRIPTION
(Found while trying to repro "Deadlock in AvatarData::nextAttitude() on main thread" https://app.asana.com/0/32622044445063/61023569045356)