### PR TITLE
Remove DeviceProxy in favor of InputDevice

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -446,8 +446,8 @@ private:
 
     OctreeQuery _octreeQuery; // NodeData derived class for querying octee cells from octree servers
 
-    controller::StateController* _applicationStateDevice{ nullptr }; // Default ApplicationDevice reflecting the state of different properties of the session
-    KeyboardMouseDevice* _keyboardMouseDevice{ nullptr };   // Default input device, the good old keyboard mouse and maybe touchpad
+    std::shared_ptr<controller::StateController> _applicationStateDevice; // Default ApplicationDevice reflecting the state of different properties of the session
+    std::shared_ptr<KeyboardMouseDevice> _keyboardMouseDevice;   // Default input device, the good old keyboard mouse and maybe touchpad
     AvatarUpdate* _avatarUpdate {nullptr};
     SimpleMovingAverage _avatarSimsPerSecond {10};
     int _avatarSimsPerSecondReport {0};

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -464,11 +464,13 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::MeshVisible, 0, true,
                                            avatar, SLOT(setEnableMeshVisible(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::DisableEyelidAdjustment, 0, false);
+#if 0
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu,
                                            MenuOption::Connexion,
                                            0, false,
                                            &ConnexionClient::getInstance(),
                                            SLOT(toggleConnexion(bool)));
+#endif
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ComfortMode, 0, true);
 
     MenuWrapper* handOptionsMenu = developerMenu->addMenu("Hands");

--- a/interface/src/devices/3DConnexionClient.cpp
+++ b/interface/src/devices/3DConnexionClient.cpp
@@ -9,8 +9,10 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+
 #include "3DConnexionClient.h"
 
+#if 0
 #include <UserActivityLogger.h>
 #include <PathUtils.h>
 
@@ -967,3 +969,4 @@ void MessageHandler(unsigned int connection, unsigned int messageType, void *mes
 #endif // __APPLE__
 
 #endif // HAVE_3DCONNEXIONCLIENT
+#endif

--- a/interface/src/devices/3DConnexionClient.h
+++ b/interface/src/devices/3DConnexionClient.h
@@ -11,6 +11,7 @@
 #ifndef hifi_3DConnexionClient_h
 #define hifi_3DConnexionClient_h
 
+#if 0
 #include <QObject>
 #include <QLibrary>
 #include <controllers/UserInputMapper.h>
@@ -216,5 +217,7 @@ public:
     void setButton(int lastButtonState);
     void handleAxisEvent();
 };
+
+#endif
 
 #endif // defined(hifi_3DConnexionClient_h)

--- a/libraries/controllers/src/controllers/Actions.cpp
+++ b/libraries/controllers/src/controllers/Actions.cpp
@@ -8,7 +8,7 @@
 
 #include "Actions.h"
 
-#include "UserInputMapper.h"
+#include "impl/endpoints/ActionEndpoint.h"
 
 namespace controller {
 
@@ -29,86 +29,80 @@ namespace controller {
         return makePair(ChannelType::POSE, action, name);
     }
 
-    // Device functions
-    void ActionsDevice::buildDeviceProxy(DeviceProxy::Pointer proxy) {
-        proxy->_name = _name;
-        proxy->getButton = [this](const Input& input, int timestamp) -> bool { return false; };
-        proxy->getAxis = [this](const Input& input, int timestamp) -> float { return 0; };
-        proxy->getAvailabeInputs = [this]() -> QVector<Input::NamedPair> {
-            QVector<Input::NamedPair> availableInputs{
-                makeAxisPair(Action::TRANSLATE_X, "TranslateX"),
-                makeAxisPair(Action::TRANSLATE_Y, "TranslateY"),
-                makeAxisPair(Action::TRANSLATE_Z, "TranslateZ"),
-                makeAxisPair(Action::ROLL, "Roll"),
-                makeAxisPair(Action::PITCH, "Pitch"),
-                makeAxisPair(Action::YAW, "Yaw"),
-                makeAxisPair(Action::STEP_YAW, "StepYaw"),
-                makeAxisPair(Action::STEP_PITCH, "StepPitch"),
-                makeAxisPair(Action::STEP_ROLL, "StepRoll"),
-                makeAxisPair(Action::STEP_TRANSLATE_X, "StepTranslateX"),
-                makeAxisPair(Action::STEP_TRANSLATE_X, "StepTranslateY"),
-                makeAxisPair(Action::STEP_TRANSLATE_X, "StepTranslateZ"),
-
-                makePosePair(Action::LEFT_HAND, "LeftHand"),
-                makePosePair(Action::RIGHT_HAND, "RightHand"),
-
-                makeButtonPair(Action::LEFT_HAND_CLICK, "LeftHandClick"),
-                makeButtonPair(Action::RIGHT_HAND_CLICK, "RightHandClick"),
-
-                makeButtonPair(Action::SHIFT, "Shift"),
-                makeButtonPair(Action::ACTION1, "PrimaryAction"),
-                makeButtonPair(Action::ACTION2, "SecondaryAction"),
-                makeButtonPair(Action::CONTEXT_MENU, "ContextMenu"),
-                makeButtonPair(Action::TOGGLE_MUTE, "ToggleMute"),
-
-                // Aliases and bisected versions
-                makeAxisPair(Action::LONGITUDINAL_BACKWARD, "Backward"),
-                makeAxisPair(Action::LONGITUDINAL_FORWARD, "Forward"),
-                makeAxisPair(Action::LATERAL_LEFT, "StrafeLeft"),
-                makeAxisPair(Action::LATERAL_RIGHT, "StrafeRight"),
-                makeAxisPair(Action::VERTICAL_DOWN, "Down"),
-                makeAxisPair(Action::VERTICAL_UP, "Up"),
-                makeAxisPair(Action::YAW_LEFT, "YawLeft"),
-                makeAxisPair(Action::YAW_RIGHT, "YawRight"),
-                makeAxisPair(Action::PITCH_DOWN, "PitchDown"),
-                makeAxisPair(Action::PITCH_UP, "PitchUp"),
-                makeAxisPair(Action::BOOM_IN, "BoomIn"),
-                makeAxisPair(Action::BOOM_OUT, "BoomOut"),
-
-                // Deprecated aliases
-                // FIXME remove after we port all scripts
-                makeAxisPair(Action::LONGITUDINAL_BACKWARD, "LONGITUDINAL_BACKWARD"),
-                makeAxisPair(Action::LONGITUDINAL_FORWARD, "LONGITUDINAL_FORWARD"),
-                makeAxisPair(Action::LATERAL_LEFT, "LATERAL_LEFT"),
-                makeAxisPair(Action::LATERAL_RIGHT, "LATERAL_RIGHT"),
-                makeAxisPair(Action::VERTICAL_DOWN, "VERTICAL_DOWN"),
-                makeAxisPair(Action::VERTICAL_UP, "VERTICAL_UP"),
-                makeAxisPair(Action::YAW_LEFT, "YAW_LEFT"),
-                makeAxisPair(Action::YAW_RIGHT, "YAW_RIGHT"),
-                makeAxisPair(Action::PITCH_DOWN, "PITCH_DOWN"),
-                makeAxisPair(Action::PITCH_UP, "PITCH_UP"),
-                makeAxisPair(Action::BOOM_IN, "BOOM_IN"),
-                makeAxisPair(Action::BOOM_OUT, "BOOM_OUT"),
-
-                makePosePair(Action::LEFT_HAND, "LEFT_HAND"),
-                makePosePair(Action::RIGHT_HAND, "RIGHT_HAND"),
-
-                makeButtonPair(Action::LEFT_HAND_CLICK, "LEFT_HAND_CLICK"),
-                makeButtonPair(Action::RIGHT_HAND_CLICK, "RIGHT_HAND_CLICK"),
-
-                makeButtonPair(Action::SHIFT, "SHIFT"),
-                makeButtonPair(Action::ACTION1, "ACTION1"),
-                makeButtonPair(Action::ACTION2, "ACTION2"),
-                makeButtonPair(Action::CONTEXT_MENU, "CONTEXT_MENU"),
-                makeButtonPair(Action::TOGGLE_MUTE, "TOGGLE_MUTE"),
-            };
-            return availableInputs;
-        };
-
+    EndpointPointer ActionsDevice::createEndpoint(const Input& input) const {
+        return std::make_shared<ActionEndpoint>(input);
     }
 
-    QString ActionsDevice::getDefaultMappingConfig() {
-        return QString();
+    // Device functions
+    Input::NamedVector ActionsDevice::getAvailableInputs() const {
+        static Input::NamedVector availableInputs {
+            makeAxisPair(Action::TRANSLATE_X, "TranslateX"),
+            makeAxisPair(Action::TRANSLATE_Y, "TranslateY"),
+            makeAxisPair(Action::TRANSLATE_Z, "TranslateZ"),
+            makeAxisPair(Action::ROLL, "Roll"),
+            makeAxisPair(Action::PITCH, "Pitch"),
+            makeAxisPair(Action::YAW, "Yaw"),
+            makeAxisPair(Action::STEP_YAW, "StepYaw"),
+            makeAxisPair(Action::STEP_PITCH, "StepPitch"),
+            makeAxisPair(Action::STEP_ROLL, "StepRoll"),
+            makeAxisPair(Action::STEP_TRANSLATE_X, "StepTranslateX"),
+            makeAxisPair(Action::STEP_TRANSLATE_X, "StepTranslateY"),
+            makeAxisPair(Action::STEP_TRANSLATE_X, "StepTranslateZ"),
+
+            makePosePair(Action::LEFT_HAND, "LeftHand"),
+            makePosePair(Action::RIGHT_HAND, "RightHand"),
+
+            makeButtonPair(Action::LEFT_HAND_CLICK, "LeftHandClick"),
+            makeButtonPair(Action::RIGHT_HAND_CLICK, "RightHandClick"),
+
+            makeButtonPair(Action::SHIFT, "Shift"),
+            makeButtonPair(Action::ACTION1, "PrimaryAction"),
+            makeButtonPair(Action::ACTION2, "SecondaryAction"),
+            makeButtonPair(Action::CONTEXT_MENU, "ContextMenu"),
+            makeButtonPair(Action::TOGGLE_MUTE, "ToggleMute"),
+
+            // Aliases and bisected versions
+            makeAxisPair(Action::LONGITUDINAL_BACKWARD, "Backward"),
+            makeAxisPair(Action::LONGITUDINAL_FORWARD, "Forward"),
+            makeAxisPair(Action::LATERAL_LEFT, "StrafeLeft"),
+            makeAxisPair(Action::LATERAL_RIGHT, "StrafeRight"),
+            makeAxisPair(Action::VERTICAL_DOWN, "Down"),
+            makeAxisPair(Action::VERTICAL_UP, "Up"),
+            makeAxisPair(Action::YAW_LEFT, "YawLeft"),
+            makeAxisPair(Action::YAW_RIGHT, "YawRight"),
+            makeAxisPair(Action::PITCH_DOWN, "PitchDown"),
+            makeAxisPair(Action::PITCH_UP, "PitchUp"),
+            makeAxisPair(Action::BOOM_IN, "BoomIn"),
+            makeAxisPair(Action::BOOM_OUT, "BoomOut"),
+
+            // Deprecated aliases
+            // FIXME remove after we port all scripts
+            makeAxisPair(Action::LONGITUDINAL_BACKWARD, "LONGITUDINAL_BACKWARD"),
+            makeAxisPair(Action::LONGITUDINAL_FORWARD, "LONGITUDINAL_FORWARD"),
+            makeAxisPair(Action::LATERAL_LEFT, "LATERAL_LEFT"),
+            makeAxisPair(Action::LATERAL_RIGHT, "LATERAL_RIGHT"),
+            makeAxisPair(Action::VERTICAL_DOWN, "VERTICAL_DOWN"),
+            makeAxisPair(Action::VERTICAL_UP, "VERTICAL_UP"),
+            makeAxisPair(Action::YAW_LEFT, "YAW_LEFT"),
+            makeAxisPair(Action::YAW_RIGHT, "YAW_RIGHT"),
+            makeAxisPair(Action::PITCH_DOWN, "PITCH_DOWN"),
+            makeAxisPair(Action::PITCH_UP, "PITCH_UP"),
+            makeAxisPair(Action::BOOM_IN, "BOOM_IN"),
+            makeAxisPair(Action::BOOM_OUT, "BOOM_OUT"),
+
+            makePosePair(Action::LEFT_HAND, "LEFT_HAND"),
+            makePosePair(Action::RIGHT_HAND, "RIGHT_HAND"),
+
+            makeButtonPair(Action::LEFT_HAND_CLICK, "LEFT_HAND_CLICK"),
+            makeButtonPair(Action::RIGHT_HAND_CLICK, "RIGHT_HAND_CLICK"),
+
+            makeButtonPair(Action::SHIFT, "SHIFT"),
+            makeButtonPair(Action::ACTION1, "ACTION1"),
+            makeButtonPair(Action::ACTION2, "ACTION2"),
+            makeButtonPair(Action::CONTEXT_MENU, "CONTEXT_MENU"),
+            makeButtonPair(Action::TOGGLE_MUTE, "TOGGLE_MUTE"),
+        };
+        return availableInputs;
     }
 
     void ActionsDevice::update(float deltaTime, bool jointsCaptured) {

--- a/libraries/controllers/src/controllers/Actions.h
+++ b/libraries/controllers/src/controllers/Actions.h
@@ -89,11 +89,8 @@ class ActionsDevice : public QObject, public InputDevice {
     Q_PROPERTY(QString name READ getName)
 
 public:
-    const QString& getName() const { return _name; }
-
-    // Device functions
-    virtual void buildDeviceProxy(DeviceProxy::Pointer proxy) override;
-    virtual QString getDefaultMappingConfig() override;
+    virtual EndpointPointer createEndpoint(const Input& input) const override;
+    virtual Input::NamedVector getAvailableInputs() const override;
     virtual void update(float deltaTime, bool jointsCaptured) override;
     virtual void focusOutEvent() override;
 
@@ -102,11 +99,5 @@ public:
 };
 
 }
-
-
-
-
-#include "StandardControls.h"
-
 
 #endif // hifi_StandardController_h

--- a/libraries/controllers/src/controllers/DeviceProxy.cpp
+++ b/libraries/controllers/src/controllers/DeviceProxy.cpp
@@ -10,21 +10,5 @@
 #include "DeviceProxy.h"
 
 namespace controller {
-
-    float DeviceProxy::getValue(const Input& input, int timestamp) const {
-        switch (input.getType()) {
-        case ChannelType::BUTTON:
-            return getButton(input, timestamp) ? 1.0f : 0.0f;
-
-        case ChannelType::AXIS:
-            return getAxis(input, timestamp);
-
-        case ChannelType::POSE:
-            return getPose(input, timestamp).valid ? 1.0f : 0.0f;
-
-        default:
-            return NAN;
-        }
-    }
 }
 

--- a/libraries/controllers/src/controllers/DeviceProxy.h
+++ b/libraries/controllers/src/controllers/DeviceProxy.h
@@ -20,7 +20,7 @@
 #include "Pose.h"
 
 namespace controller {
-
+    /*
     using Modifiers = std::vector<Input>;
     typedef QPair<Input, QString> InputPair;
     class Endpoint;
@@ -38,17 +38,10 @@ namespace controller {
     class DeviceProxy {
     public:
         using Pointer = std::shared_ptr<DeviceProxy>;
-        const QString& getName() const { return _name; }
-        ButtonGetter getButton = [] (const Input& input, int timestamp) -> bool { return false; };
-        AxisGetter getAxis = [] (const Input& input, int timestamp) -> float { return 0.0f; };
-        PoseGetter getPose = [](const Input& input, int timestamp) -> Pose { return Pose(); };
-        AvailableInputGetter getAvailabeInputs = []() -> Input::NamedVector const { return Input::NamedVector(); };
-        float getValue(const Input& input, int timestamp = 0) const;
-        
-        EndpointCreator createEndpoint = [](const Input& input) -> EndpointPtr { return EndpointPtr(); };
 
         QString _name;
     };
+    */
 }
 
 #endif

--- a/libraries/controllers/src/controllers/InputDevice.cpp
+++ b/libraries/controllers/src/controllers/InputDevice.cpp
@@ -11,6 +11,7 @@
 #include "InputDevice.h"
 
 #include "Input.h"
+#include "impl/endpoints/InputEndpoint.h"
 
 namespace controller {
 
@@ -59,29 +60,55 @@ namespace controller {
         }
     }
 
-    Input InputDevice::makeInput(controller::StandardButtonChannel button) {
+    Input InputDevice::makeInput(controller::StandardButtonChannel button) const {
         return Input(_deviceID, button, ChannelType::BUTTON);
     }
 
-    Input InputDevice::makeInput(controller::StandardAxisChannel axis) {
+    Input InputDevice::makeInput(controller::StandardAxisChannel axis) const {
         return Input(_deviceID, axis, ChannelType::AXIS);
     }
 
-    Input InputDevice::makeInput(controller::StandardPoseChannel pose) {
+    Input InputDevice::makeInput(controller::StandardPoseChannel pose) const {
         return Input(_deviceID, pose, ChannelType::POSE);
     }
 
-    Input::NamedPair InputDevice::makePair(controller::StandardButtonChannel button, const QString& name) {
+    Input::NamedPair InputDevice::makePair(controller::StandardButtonChannel button, const QString& name) const {
         return Input::NamedPair(makeInput(button), name);
     }
 
-    Input::NamedPair InputDevice::makePair(controller::StandardAxisChannel axis, const QString& name) {
+    Input::NamedPair InputDevice::makePair(controller::StandardAxisChannel axis, const QString& name) const {
         return Input::NamedPair(makeInput(axis), name);
     }
 
-    Input::NamedPair InputDevice::makePair(controller::StandardPoseChannel pose, const QString& name) {
+    Input::NamedPair InputDevice::makePair(controller::StandardPoseChannel pose, const QString& name) const {
         return Input::NamedPair(makeInput(pose), name);
     }
 
+    float InputDevice::getValue(ChannelType channelType, uint16_t channel) const {
+        switch (channelType) {
+            case ChannelType::AXIS:
+                return getAxis(channel);
+
+            case ChannelType::BUTTON:
+                return getButton(channel);
+
+            case ChannelType::POSE:
+                return getPose(channel).valid ? 1.0f : 0.0f;
+
+            default:
+                break;
+        }
+
+        return 0.0f;
+    }
+
+
+    float InputDevice::getValue(const Input& input) const {
+        return getValue(input.getType(), input.channel);
+    }
+
+    EndpointPointer InputDevice::createEndpoint(const Input& input) const {
+        return std::make_shared<InputEndpoint>(input);
+    }
 
 }

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -27,10 +27,10 @@
 
 static QRegularExpression SANITIZE_NAME_EXPRESSION{ "[\\(\\)\\.\\s]" };
 
-static QVariantMap createDeviceMap(const controller::DeviceProxy::Pointer device) {
+static QVariantMap createDeviceMap(const controller::InputDevice::Pointer device) {
     auto userInputMapper = DependencyManager::get<controller::UserInputMapper>();
     QVariantMap deviceMap;
-    for (const auto& inputMapping : device->getAvailabeInputs()) {
+    for (const auto& inputMapping : userInputMapper->getAvailableInputs(device->getDeviceID())) {
         const auto& input = inputMapping.first;
         const auto inputName = QString(inputMapping.second).remove(SANITIZE_NAME_EXPRESSION);
         qCDebug(controllers) << "\tInput " << input.getChannel() << (int)input.getType()
@@ -179,7 +179,7 @@ namespace controller {
         return DependencyManager::get<UserInputMapper>()->getDeviceName((unsigned short)device);
     }
 
-    QVector<InputPair> ScriptingInterface::getAvailableInputs(unsigned int device) {
+    QVector<Input::NamedPair> ScriptingInterface::getAvailableInputs(unsigned int device) {
         return DependencyManager::get<UserInputMapper>()->getAvailableInputs((unsigned short)device);
     }
 

--- a/libraries/controllers/src/controllers/StandardController.cpp
+++ b/libraries/controllers/src/controllers/StandardController.cpp
@@ -13,8 +13,8 @@
 
 #include <PathUtils.h>
 
-#include "DeviceProxy.h"
 #include "UserInputMapper.h"
+#include "impl/endpoints/StandardEndpoint.h"
 
 namespace controller {
 
@@ -33,91 +33,87 @@ void StandardController::focusOutEvent() {
     _buttonPressedMap.clear();
 };
 
-void StandardController::buildDeviceProxy(DeviceProxy::Pointer proxy) {
-    proxy->_name = _name;
-    proxy->getButton = [this] (const Input& input, int timestamp) -> bool { return getButton(input.getChannel()); };
-    proxy->getAxis = [this] (const Input& input, int timestamp) -> float { return getAxis(input.getChannel()); };
-    proxy->getAvailabeInputs = [this] () -> QVector<Input::NamedPair> {
-        QVector<Input::NamedPair> availableInputs;
+Input::NamedVector StandardController::getAvailableInputs() const {
+    static Input::NamedVector availableInputs {
         // Buttons
-        availableInputs.append(makePair(A, "A"));
-        availableInputs.append(makePair(B, "B"));
-        availableInputs.append(makePair(X, "X"));
-        availableInputs.append(makePair(Y, "Y"));
+        makePair(A, "A"),
+        makePair(B, "B"),
+        makePair(X, "X"),
+        makePair(Y, "Y"),
 
         // DPad
-        availableInputs.append(makePair(DU, "DU"));
-        availableInputs.append(makePair(DD, "DD"));
-        availableInputs.append(makePair(DL, "DL"));
-        availableInputs.append(makePair(DR, "DR"));
+        makePair(DU, "DU"),
+        makePair(DD, "DD"),
+        makePair(DL, "DL"),
+        makePair(DR, "DR"),
 
         // Bumpers
-        availableInputs.append(makePair(LB, "LB"));
-        availableInputs.append(makePair(RB, "RB"));
+        makePair(LB, "LB"),
+        makePair(RB, "RB"),
 
         // Stick press
-        availableInputs.append(makePair(LS, "LS"));
-        availableInputs.append(makePair(RS, "RS"));
+        makePair(LS, "LS"),
+        makePair(RS, "RS"),
 
         // Center buttons
-        availableInputs.append(makePair(START, "Start"));
-        availableInputs.append(makePair(BACK, "Back"));
+        makePair(START, "Start"),
+        makePair(BACK, "Back"),
 
         // Analog sticks
-        availableInputs.append(makePair(LY, "LY"));
-        availableInputs.append(makePair(LX, "LX"));
-        availableInputs.append(makePair(RY, "RY"));
-        availableInputs.append(makePair(RX, "RX"));
+        makePair(LY, "LY"),
+        makePair(LX, "LX"),
+        makePair(RY, "RY"),
+        makePair(RX, "RX"),
 
         // Triggers
-        availableInputs.append(makePair(LT, "LT"));
-        availableInputs.append(makePair(RT, "RT"));
+        makePair(LT, "LT"),
+        makePair(RT, "RT"),
 
 
         // Finger abstractions
-        availableInputs.append(makePair(LEFT_PRIMARY_THUMB, "LeftPrimaryThumb"));
-        availableInputs.append(makePair(LEFT_SECONDARY_THUMB, "LeftSecondaryThumb"));
-        availableInputs.append(makePair(RIGHT_PRIMARY_THUMB, "RightPrimaryThumb"));
-        availableInputs.append(makePair(RIGHT_SECONDARY_THUMB, "RightSecondaryThumb"));
+        makePair(LEFT_PRIMARY_THUMB, "LeftPrimaryThumb"),
+        makePair(LEFT_SECONDARY_THUMB, "LeftSecondaryThumb"),
+        makePair(RIGHT_PRIMARY_THUMB, "RightPrimaryThumb"),
+        makePair(RIGHT_SECONDARY_THUMB, "RightSecondaryThumb"),
 
-        availableInputs.append(makePair(LEFT_PRIMARY_INDEX, "LeftPrimaryIndex"));
-        availableInputs.append(makePair(LEFT_SECONDARY_INDEX, "LeftSecondaryIndex"));
-        availableInputs.append(makePair(RIGHT_PRIMARY_INDEX, "RightPrimaryIndex"));
-        availableInputs.append(makePair(RIGHT_SECONDARY_INDEX, "RightSecondaryIndex"));
+        makePair(LEFT_PRIMARY_INDEX, "LeftPrimaryIndex"),
+        makePair(LEFT_SECONDARY_INDEX, "LeftSecondaryIndex"),
+        makePair(RIGHT_PRIMARY_INDEX, "RightPrimaryIndex"),
+        makePair(RIGHT_SECONDARY_INDEX, "RightSecondaryIndex"),
 
-        availableInputs.append(makePair(LEFT_GRIP, "LeftGrip"));
-        availableInputs.append(makePair(RIGHT_GRIP, "RightGrip"));
+        makePair(LEFT_GRIP, "LeftGrip"),
+        makePair(RIGHT_GRIP, "RightGrip"),
 
         // Poses
-        availableInputs.append(makePair(LEFT_HAND, "LeftHand"));
-        availableInputs.append(makePair(RIGHT_HAND, "RightHand"));
+        makePair(LEFT_HAND, "LeftHand"),
+        makePair(RIGHT_HAND, "RightHand"),
 
 
         // Aliases, PlayStation style names
-        availableInputs.append(makePair(LB, "L1"));
-        availableInputs.append(makePair(RB, "R1"));
-        availableInputs.append(makePair(LT, "L2"));
-        availableInputs.append(makePair(RT, "R2"));
-        availableInputs.append(makePair(LS, "L3"));
-        availableInputs.append(makePair(RS, "R3"));
-        availableInputs.append(makePair(BACK, "Select"));
-        availableInputs.append(makePair(A, "Cross"));
-        availableInputs.append(makePair(B, "Circle"));
-        availableInputs.append(makePair(X, "Square"));
-        availableInputs.append(makePair(Y, "Triangle"));
-        availableInputs.append(makePair(DU, "Up"));
-        availableInputs.append(makePair(DD, "Down"));
-        availableInputs.append(makePair(DL, "Left"));
-        availableInputs.append(makePair(DR, "Right"));
-
-
-
-        return availableInputs;
+        makePair(LB, "L1"),
+        makePair(RB, "R1"),
+        makePair(LT, "L2"),
+        makePair(RT, "R2"),
+        makePair(LS, "L3"),
+        makePair(RS, "R3"),
+        makePair(BACK, "Select"),
+        makePair(A, "Cross"),
+        makePair(B, "Circle"),
+        makePair(X, "Square"),
+        makePair(Y, "Triangle"),
+        makePair(DU, "Up"),
+        makePair(DD, "Down"),
+        makePair(DL, "Left"),
+        makePair(DR, "Right"),
     };
+    return availableInputs;
 }
 
+EndpointPointer StandardController::createEndpoint(const Input& input) const {
+    return std::make_shared<StandardEndpoint>(input);
+}
 
-QString StandardController::getDefaultMappingConfig() {
+QString StandardController::getDefaultMappingConfig() const {
     static const QString DEFAULT_MAPPING_JSON = PathUtils::resourcesPath() + "/controllers/standard.json";
     return DEFAULT_MAPPING_JSON;
 }

--- a/libraries/controllers/src/controllers/StandardController.h
+++ b/libraries/controllers/src/controllers/StandardController.h
@@ -25,11 +25,9 @@ class StandardController : public QObject, public InputDevice {
     Q_PROPERTY(QString name READ getName)
 
 public:
-    const QString& getName() const { return _name; }
-
-    // Device functions
-    virtual void buildDeviceProxy(DeviceProxy::Pointer proxy) override;
-    virtual QString getDefaultMappingConfig() override;
+    virtual EndpointPointer createEndpoint(const Input& input) const override;
+    virtual Input::NamedVector getAvailableInputs() const override;
+    virtual QString getDefaultMappingConfig() const override;
     virtual void update(float deltaTime, bool jointsCaptured) override;
     virtual void focusOutEvent() override;
 

--- a/libraries/controllers/src/controllers/StandardControls.h
+++ b/libraries/controllers/src/controllers/StandardControls.h
@@ -58,9 +58,11 @@ namespace controller {
         // Left Analog stick
         LX = 0,
         LY,
+        LZ,
         // Right Analog stick
         RX,
         RY,
+        RZ,
         // Triggers
         LT,
         RT,

--- a/libraries/controllers/src/controllers/StateController.cpp
+++ b/libraries/controllers/src/controllers/StateController.cpp
@@ -19,7 +19,7 @@
 
 namespace controller {
 
-StateController::StateController(QString name) : InputDevice(name) {
+StateController::StateController() : InputDevice("Application") {
 }
 
 StateController::~StateController() {
@@ -32,30 +32,15 @@ void StateController::focusOutEvent() {}
 void StateController::addInputVariant(QString name, ReadLambda& lambda) {
     _namedReadLambdas.push_back(NamedReadLambda(name, lambda));
 }
-void StateController::buildDeviceProxy(DeviceProxy::Pointer proxy) {
-    proxy->_name = _name;
-    proxy->getButton = [this] (const Input& input, int timestamp) -> bool { return getButton(input.getChannel()); };
-    proxy->getAxis = [this] (const Input& input, int timestamp) -> float { return getAxis(input.getChannel()); };
-    proxy->getAvailabeInputs = [this] () -> QVector<Input::NamedPair> {
-    
-        
-        QVector<Input::NamedPair> availableInputs;
-        
-        int i = 0;
-        for (auto& pair : _namedReadLambdas) {
-            availableInputs.push_back(Input::NamedPair(Input(_deviceID, i, ChannelType::BUTTON), pair.first));
-            i++;
-        }
-        return availableInputs;
-    };
-    proxy->createEndpoint = [this] (const Input& input) -> Endpoint::Pointer {
-        if (input.getChannel() < _namedReadLambdas.size()) {
-            return std::make_shared<LambdaEndpoint>(_namedReadLambdas[input.getChannel()].second);
-        }
 
-        return Endpoint::Pointer();
-    };
+Input::NamedVector StateController::getAvailableInputs() const {
+    Input::NamedVector availableInputs;
+    int i = 0;
+    for (auto& pair : _namedReadLambdas) {
+        availableInputs.push_back(Input::NamedPair(Input(_deviceID, i, ChannelType::BUTTON), pair.first));
+        i++;
+    }
+    return availableInputs;
 }
-
 
 }

--- a/libraries/controllers/src/controllers/StateController.h
+++ b/libraries/controllers/src/controllers/StateController.h
@@ -27,12 +27,11 @@ public:
     const QString& getName() const { return _name; }
 
     // Device functions
-    virtual void buildDeviceProxy(DeviceProxy::Pointer proxy) override;
-    virtual QString getDefaultMappingConfig() override { return QString(); }
+    virtual Input::NamedVector getAvailableInputs() const override;
     virtual void update(float deltaTime, bool jointsCaptured) override;
     virtual void focusOutEvent() override;
 
-    StateController(QString name);
+    StateController();
     virtual ~StateController();
 
     using ReadLambda = std::function<float()>;

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -42,7 +42,6 @@ namespace controller {
             Q_ENUMS(Action)
 
     public:
-        using InputPair = Input::NamedPair;
         // FIXME move to unordered set / map
         using EndpointToInputMap = std::map<EndpointPointer, Input>;
         using MappingNameMap = std::map<QString, MappingPointer>;
@@ -52,7 +51,7 @@ namespace controller {
         using EndpointSet = std::unordered_set<EndpointPointer>;
         using EndpointPair = std::pair<EndpointPointer, EndpointPointer>;
         using EndpointPairMap = std::map<EndpointPair, EndpointPointer>;
-        using DevicesMap = std::map<int, DeviceProxy::Pointer>;
+        using DevicesMap = std::map<int, InputDevice::Pointer>;
         using uint16 = uint16_t;
         using uint32 = uint32_t;
 
@@ -65,9 +64,8 @@ namespace controller {
 
         static void registerControllerTypes(QScriptEngine* engine);
 
-
-        void registerDevice(InputDevice* device);
-        DeviceProxy::Pointer getDeviceProxy(const Input& input);
+        void registerDevice(InputDevice::Pointer device);
+        InputDevice::Pointer getDevice(const Input& input);
         QString getDeviceName(uint16 deviceID);
 
         Input::NamedVector getAvailableInputs(uint16 deviceID) const;
@@ -104,7 +102,7 @@ namespace controller {
 
         DevicesMap getDevices() { return _registeredDevices; }
         uint16 getStandardDeviceID() const { return STANDARD_DEVICE; }
-        DeviceProxy::Pointer getStandardDevice() { return _registeredDevices[getStandardDeviceID()]; }
+        InputDevice::Pointer getStandardDevice() { return _registeredDevices[getStandardDeviceID()]; }
 
         MappingPointer newMapping(const QString& mappingName);
         MappingPointer parseMapping(const QString& json);
@@ -122,7 +120,6 @@ namespace controller {
     protected:
         // GetFreeDeviceID should be called before registering a device to use an ID not used by a different device.
         uint16 getFreeDeviceID() { return _nextFreeDeviceID++; }
-        InputDevice::Pointer _standardController;
         DevicesMap _registeredDevices;
         uint16 _nextFreeDeviceID = STANDARD_DEVICE + 1;
 
@@ -184,9 +181,9 @@ namespace controller {
 
 }
 
-Q_DECLARE_METATYPE(controller::UserInputMapper::InputPair)
+Q_DECLARE_METATYPE(controller::Input::NamedPair)
 Q_DECLARE_METATYPE(controller::Pose)
-Q_DECLARE_METATYPE(QVector<controller::UserInputMapper::InputPair>)
+Q_DECLARE_METATYPE(QVector<controller::Input::NamedPair>)
 Q_DECLARE_METATYPE(controller::Input)
 Q_DECLARE_METATYPE(controller::Action)
 Q_DECLARE_METATYPE(QVector<controller::Action>)

--- a/libraries/controllers/src/controllers/impl/endpoints/InputEndpoint.cpp
+++ b/libraries/controllers/src/controllers/impl/endpoints/InputEndpoint.cpp
@@ -19,11 +19,11 @@ float InputEndpoint::value(){
         return pose().valid ? 1.0f : 0.0f;
     }
     auto userInputMapper = DependencyManager::get<UserInputMapper>();
-    auto deviceProxy = userInputMapper->getDeviceProxy(_input);
+    auto deviceProxy = userInputMapper->getDevice(_input);
     if (!deviceProxy) {
         return 0.0f;
     }
-    return deviceProxy->getValue(_input, 0);
+    return deviceProxy->getValue(_input);
 }
 
 Pose InputEndpoint::pose() {
@@ -32,10 +32,10 @@ Pose InputEndpoint::pose() {
         return Pose();
     }
     auto userInputMapper = DependencyManager::get<UserInputMapper>();
-    auto deviceProxy = userInputMapper->getDeviceProxy(_input);
+    auto deviceProxy = userInputMapper->getDevice(_input);
     if (!deviceProxy) {
         return Pose();
     }
-    return deviceProxy->getPose(_input, 0);
+    return deviceProxy->getPose(_input.channel);
 }
 

--- a/libraries/input-plugins/CMakeLists.txt
+++ b/libraries/input-plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TARGET_NAME input-plugins)
 setup_hifi_library()
-link_hifi_libraries(shared plugins controllers)
+link_hifi_libraries(shared plugins controllers render-utils)
 
 GroupSources("src/input-plugins")
 

--- a/libraries/input-plugins/src/input-plugins/Joystick.cpp
+++ b/libraries/input-plugins/src/input-plugins/Joystick.cpp
@@ -71,63 +71,58 @@ void Joystick::handleButtonEvent(const SDL_ControllerButtonEvent& event) {
 
 #endif
 
-void Joystick::buildDeviceProxy(controller::DeviceProxy::Pointer proxy) {
+controller::Input::NamedVector Joystick::getAvailableInputs() const {
     using namespace controller;
-    proxy->_name = _name;
-    proxy->getButton = [this](const Input& input, int timestamp) -> bool { return this->getButton(input.getChannel()); };
-    proxy->getAxis = [this](const Input& input, int timestamp) -> float { return this->getAxis(input.getChannel()); };
-    proxy->getAvailabeInputs = [this]() -> QVector<Input::NamedPair> {
-        QVector<Input::NamedPair> availableInputs{
-            makePair(A, "A"),
-            makePair(B, "B"),
-            makePair(X, "X"),
-            makePair(Y, "Y"),
-            // DPad
-            makePair(DU, "DU"),
-            makePair(DD, "DD"),
-            makePair(DL, "DL"),
-            makePair(DR, "DR"),
-            // Bumpers
-            makePair(LB, "LB"),
-            makePair(RB, "RB"),
-            // Stick press
-            makePair(LS, "LS"),
-            makePair(RS, "RS"),
-            // Center buttons
-            makePair(START, "Start"),
-            makePair(BACK, "Back"),
-            // Analog sticks
-            makePair(LX, "LX"),
-            makePair(LY, "LY"),
-            makePair(RX, "RX"),
-            makePair(RY, "RY"),
+    static const Input::NamedVector availableInputs{
+        makePair(A, "A"),
+        makePair(B, "B"),
+        makePair(X, "X"),
+        makePair(Y, "Y"),
+        // DPad
+        makePair(DU, "DU"),
+        makePair(DD, "DD"),
+        makePair(DL, "DL"),
+        makePair(DR, "DR"),
+        // Bumpers
+        makePair(LB, "LB"),
+        makePair(RB, "RB"),
+        // Stick press
+        makePair(LS, "LS"),
+        makePair(RS, "RS"),
+        // Center buttons
+        makePair(START, "Start"),
+        makePair(BACK, "Back"),
+        // Analog sticks
+        makePair(LX, "LX"),
+        makePair(LY, "LY"),
+        makePair(RX, "RX"),
+        makePair(RY, "RY"),
  
-            // Triggers
-            makePair(LT, "LT"),
-            makePair(RT, "RT"),
+        // Triggers
+        makePair(LT, "LT"),
+        makePair(RT, "RT"),
 
-            // Aliases, PlayStation style names
-            makePair(LB, "L1"),
-            makePair(RB, "R1"),
-            makePair(LT, "L2"),
-            makePair(RT, "R2"),
-            makePair(LS, "L3"),
-            makePair(RS, "R3"),
-            makePair(BACK, "Select"),
-            makePair(A, "Cross"),
-            makePair(B, "Circle"),
-            makePair(X, "Square"),
-            makePair(Y, "Triangle"),
-            makePair(DU, "Up"),
-            makePair(DD, "Down"),
-            makePair(DL, "Left"),
-            makePair(DR, "Right"),
-        };
-        return availableInputs;
+        // Aliases, PlayStation style names
+        makePair(LB, "L1"),
+        makePair(RB, "R1"),
+        makePair(LT, "L2"),
+        makePair(RT, "R2"),
+        makePair(LS, "L3"),
+        makePair(RS, "R3"),
+        makePair(BACK, "Select"),
+        makePair(A, "Cross"),
+        makePair(B, "Circle"),
+        makePair(X, "Square"),
+        makePair(Y, "Triangle"),
+        makePair(DU, "Up"),
+        makePair(DD, "Down"),
+        makePair(DL, "Left"),
+        makePair(DR, "Right"),
     };
+    return availableInputs;
 }
 
-QString Joystick::getDefaultMappingConfig() {
+QString Joystick::getDefaultMappingConfig() const {
     static const QString MAPPING_JSON = PathUtils::resourcesPath() + "/controllers/xbox.json";
     return MAPPING_JSON;
 }

--- a/libraries/input-plugins/src/input-plugins/Joystick.h
+++ b/libraries/input-plugins/src/input-plugins/Joystick.h
@@ -32,12 +32,13 @@ class Joystick : public QObject, public controller::InputDevice {
 #endif
     
 public:
+    using Pointer = std::shared_ptr<Joystick>;
 
     const QString& getName() const { return _name; }
 
     // Device functions
-    virtual void buildDeviceProxy(controller::DeviceProxy::Pointer proxy) override;
-    virtual QString getDefaultMappingConfig() override;
+    virtual controller::Input::NamedVector getAvailableInputs() const override;
+    virtual QString getDefaultMappingConfig() const override;
     virtual void update(float deltaTime, bool jointsCaptured) override;
     virtual void focusOutEvent() override;
     

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
@@ -72,8 +72,8 @@ public:
     virtual void pluginUpdate(float deltaTime, bool jointsCaptured) override { update(deltaTime, jointsCaptured); }
 
     // Device functions
-    virtual void buildDeviceProxy(controller::DeviceProxy::Pointer proxy) override;
-    virtual QString getDefaultMappingConfig() override;
+    virtual controller::Input::NamedVector getAvailableInputs() const override;
+    virtual QString getDefaultMappingConfig() const override;
     virtual void update(float deltaTime, bool jointsCaptured) override;
     virtual void focusOutEvent() override;
  
@@ -91,11 +91,11 @@ public:
     void wheelEvent(QWheelEvent* event);
     
     // Let's make it easy for Qt because we assume we love Qt forever
-    controller::Input makeInput(Qt::Key code);
-    controller::Input makeInput(Qt::MouseButton code);
-    controller::Input makeInput(MouseAxisChannel axis);
-    controller::Input makeInput(TouchAxisChannel axis);
-    controller::Input makeInput(TouchButtonChannel button);
+    controller::Input makeInput(Qt::Key code) const;
+    controller::Input makeInput(Qt::MouseButton code) const;
+    controller::Input makeInput(MouseAxisChannel axis) const;
+    controller::Input makeInput(TouchAxisChannel axis) const;
+    controller::Input makeInput(TouchButtonChannel button) const;
 
     static const QString NAME;
 

--- a/libraries/input-plugins/src/input-plugins/SDL2Manager.h
+++ b/libraries/input-plugins/src/input-plugins/SDL2Manager.h
@@ -76,7 +76,7 @@ private:
     int buttonPressed() const { return SDL_PRESSED; }
     int buttonRelease() const { return SDL_RELEASED; }
 
-    QMap<SDL_JoystickID, Joystick*> _openJoysticks;
+    QMap<SDL_JoystickID, Joystick::Pointer> _openJoysticks;
 #endif
     bool _isInitialized;
     static const QString NAME;

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
@@ -64,11 +64,12 @@ const QString MENU_PATH = MENU_PARENT + ">" + MENU_NAME;
 const QString TOGGLE_SMOOTH = "Smooth Sixense Movement";
 const float DEFAULT_REACH_LENGTH = 1.5f;
 
-
+static std::shared_ptr<SixenseManager> instance;
 SixenseManager::SixenseManager() :
     InputDevice("Hydra"),
     _reachLength(DEFAULT_REACH_LENGTH) 
 {
+    instance = std::shared_ptr<SixenseManager>(this);
 }
 
 bool SixenseManager::isSupported() const {
@@ -91,7 +92,7 @@ void SixenseManager::activate() {
                            true, true);
 
     auto userInputMapper = DependencyManager::get<controller::UserInputMapper>();
-    userInputMapper->registerDevice(this);
+    userInputMapper->registerDevice(instance);
 
 #ifdef __APPLE__
 
@@ -512,42 +513,37 @@ static const auto R4 = controller::Y;
 
 using namespace controller;
 
-void SixenseManager::buildDeviceProxy(controller::DeviceProxy::Pointer proxy) {
-    proxy->getButton = [this](const Input& input, int timestamp) -> bool { return this->getButton(input.getChannel()); };
-    proxy->getAxis = [this](const Input& input, int timestamp) -> float { 
-        return this->getAxis(input.getChannel()); 
+controller::Input::NamedVector SixenseManager::getAvailableInputs() const {
+    using namespace controller;
+    static const Input::NamedVector availableInputs {
+        makePair(L0, "L0"),
+        makePair(L1, "L1"),
+        makePair(L2, "L2"),
+        makePair(L3, "L3"),
+        makePair(L4, "L4"),
+        makePair(LB, "LB"),
+        makePair(LS, "LS"),
+        makePair(LX, "LX"),
+        makePair(LY, "LY"),
+        makePair(LT, "LT"),
+        makePair(R0, "R0"),
+        makePair(R1, "R1"),
+        makePair(R2, "R2"),
+        makePair(R3, "R3"),
+        makePair(R4, "R4"),
+        makePair(RB, "RB"),
+        makePair(RS, "RS"),
+        makePair(RX, "RX"),
+        makePair(RY, "RY"),
+        makePair(RT, "RT"),
+        makePair(LEFT_HAND, "LeftHand"),
+        makePair(RIGHT_HAND, "RightHand"),
     };
-    proxy->getPose = [this](const Input& input, int timestamp) -> Pose { return this->getPose(input.getChannel()); };
-    proxy->getAvailabeInputs = [this]() -> QVector<Input::NamedPair> {
-        QVector<Input::NamedPair> availableInputs;
-        availableInputs.append(Input::NamedPair(makeInput(L0), "L0"));
-        availableInputs.append(Input::NamedPair(makeInput(L1), "L1"));
-        availableInputs.append(Input::NamedPair(makeInput(L2), "L2"));
-        availableInputs.append(Input::NamedPair(makeInput(L3), "L3"));
-        availableInputs.append(Input::NamedPair(makeInput(L4), "L4"));
-        availableInputs.append(Input::NamedPair(makeInput(LB), "LB"));
-        availableInputs.append(Input::NamedPair(makeInput(LS), "LS"));
-        availableInputs.append(Input::NamedPair(makeInput(LX), "LX"));
-        availableInputs.append(Input::NamedPair(makeInput(LY), "LY"));
-        availableInputs.append(Input::NamedPair(makeInput(LT), "LT"));
-        availableInputs.append(Input::NamedPair(makeInput(R0), "R0"));
-        availableInputs.append(Input::NamedPair(makeInput(R1), "R1"));
-        availableInputs.append(Input::NamedPair(makeInput(R2), "R2"));
-        availableInputs.append(Input::NamedPair(makeInput(R3), "R3"));
-        availableInputs.append(Input::NamedPair(makeInput(R4), "R4"));
-        availableInputs.append(Input::NamedPair(makeInput(RB), "RB"));
-        availableInputs.append(Input::NamedPair(makeInput(RS), "RS"));
-        availableInputs.append(Input::NamedPair(makeInput(RX), "RX"));
-        availableInputs.append(Input::NamedPair(makeInput(RY), "RY"));
-        availableInputs.append(Input::NamedPair(makeInput(RT), "RT"));
-        availableInputs.append(Input::NamedPair(makeInput(LEFT_HAND), "LeftHand"));
-        availableInputs.append(Input::NamedPair(makeInput(RIGHT_HAND), "RightHand"));
-        return availableInputs;
-    };
-}
+    return availableInputs;
+};
 
 
-QString SixenseManager::getDefaultMappingConfig() {
+QString SixenseManager::getDefaultMappingConfig() const {
     static const QString MAPPING_JSON = PathUtils::resourcesPath() + "/controllers/hydra.json";
     return MAPPING_JSON;
 }

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.h
@@ -62,8 +62,8 @@ public:
     virtual void pluginUpdate(float deltaTime, bool jointsCaptured) override { update(deltaTime, jointsCaptured); }
 
     // Device functions
-    virtual void buildDeviceProxy(controller::DeviceProxy::Pointer proxy) override;
-    virtual QString getDefaultMappingConfig() override;
+    virtual controller::Input::NamedVector getAvailableInputs() const override;
+    virtual QString getDefaultMappingConfig() const override;
 
     virtual void update(float deltaTime, bool jointsCaptured) override;
     virtual void focusOutEvent() override;

--- a/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
@@ -44,6 +44,8 @@ const QString MENU_NAME = "Vive Controllers";
 const QString MENU_PATH = MENU_PARENT + ">" + MENU_NAME;
 const QString RENDER_CONTROLLERS = "Render Hand Controllers";
 
+static std::shared_ptr<ViveControllerManager> instance;
+
 ViveControllerManager::ViveControllerManager() :
         InputDevice("Vive"),
     _trackedControllers(0),
@@ -52,7 +54,7 @@ ViveControllerManager::ViveControllerManager() :
     _rightHandRenderID(0),
     _renderControllers(false)
 {
-    
+    instance = std::shared_ptr<ViveControllerManager>(this);
 }
 
 bool ViveControllerManager::isSupported() const {
@@ -278,7 +280,7 @@ void ViveControllerManager::update(float deltaTime, bool jointsCaptured) {
     }
         
     if (_trackedControllers == 0 && numTrackedControllers > 0) {
-        userInputMapper->registerDevice(this);
+        userInputMapper->registerDevice(instance);
         UserActivityLogger::getInstance().connectedDevice("spatial_controller", "steamVR");
     }
         
@@ -392,62 +394,43 @@ void ViveControllerManager::handlePoseEvent(const mat4& mat, bool left) {
     _poseStateMap[left ? controller::LEFT_HAND : controller::RIGHT_HAND] = controller::Pose(position, rotation);
 }
 
-void ViveControllerManager::buildDeviceProxy(controller::DeviceProxy::Pointer proxy) {
+controller::Input::NamedVector ViveControllerManager::getAvailableInputs() const {
     using namespace controller;
-    proxy->_name = _name;
-    proxy->getButton = [this](const Input& input, int timestamp) -> bool { return this->getButton(input.getChannel()); };
-    proxy->getAxis = [this](const Input& input, int timestamp) -> float { return this->getAxis(input.getChannel()); };
-    proxy->getPose = [this](const Input& input, int timestamp) -> Pose { return this->getPose(input.getChannel()); };
-    proxy->getAvailabeInputs = [this]() -> QVector<Input::NamedPair> {
-        QVector<Input::NamedPair> availableInputs{
-            // Trackpad analogs
-            makePair(LX, "LX"),
-            makePair(LY, "LY"),
-            makePair(RX, "RX"),
-            makePair(RY, "RY"),
-            // trigger analogs
-            makePair(LT, "LT"),
-            makePair(RT, "RT"),
+    QVector<Input::NamedPair> availableInputs{
+        // Trackpad analogs
+        makePair(LX, "LX"),
+        makePair(LY, "LY"),
+        makePair(RX, "RX"),
+        makePair(RY, "RY"),
+        // trigger analogs
+        makePair(LT, "LT"),
+        makePair(RT, "RT"),
 
-            makePair(LB, "LB"),
-            makePair(RB, "RB"),
+        makePair(LB, "LB"),
+        makePair(RB, "RB"),
 
-            makePair(LS, "LS"),
-            makePair(RS, "RS"),
-            makePair(LEFT_HAND, "LeftHand"),
-            makePair(RIGHT_HAND, "RightHand"),
-        };
-
-        //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 0), "Left Button A"));
-        //availableInputs.append(Input::NamedPair(makeInput(GRIP_BUTTON, 0), "Left Grip Button"));
-        //availableInputs.append(Input::NamedPair(makeInput(TRACKPAD_BUTTON, 0), "Left Trackpad Button"));
-        //availableInputs.append(Input::NamedPair(makeInput(TRIGGER_BUTTON, 0), "Left Trigger Button"));
-
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_Y_POS, 0), "Left Trackpad Up"));
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_Y_NEG, 0), "Left Trackpad Down"));
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_X_POS, 0), "Left Trackpad Right"));
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_X_NEG, 0), "Left Trackpad Left"));
-        //availableInputs.append(Input::NamedPair(makeInput(BACK_TRIGGER, 0), "Left Back Trigger"));
-
-
-        //availableInputs.append(Input::NamedPair(makeInput(RIGHT_HAND), "Right Hand"));
-
-        //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 1), "Right Button A"));
-        //availableInputs.append(Input::NamedPair(makeInput(GRIP_BUTTON, 1), "Right Grip Button"));
-        //availableInputs.append(Input::NamedPair(makeInput(TRACKPAD_BUTTON, 1), "Right Trackpad Button"));
-        //availableInputs.append(Input::NamedPair(makeInput(TRIGGER_BUTTON, 1), "Right Trigger Button"));
-
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_Y_POS, 1), "Right Trackpad Up"));
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_Y_NEG, 1), "Right Trackpad Down"));
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_X_POS, 1), "Right Trackpad Right"));
-        //availableInputs.append(Input::NamedPair(makeInput(AXIS_X_NEG, 1), "Right Trackpad Left"));
-        //availableInputs.append(Input::NamedPair(makeInput(BACK_TRIGGER, 1), "Right Back Trigger"));
-
-        return availableInputs;
+        makePair(LS, "LS"),
+        makePair(RS, "RS"),
+        makePair(LEFT_HAND, "LeftHand"),
+        makePair(RIGHT_HAND, "RightHand"),
     };
+
+    //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 0), "Left Button A"));
+    //availableInputs.append(Input::NamedPair(makeInput(GRIP_BUTTON, 0), "Left Grip Button"));
+    //availableInputs.append(Input::NamedPair(makeInput(TRACKPAD_BUTTON, 0), "Left Trackpad Button"));
+    //availableInputs.append(Input::NamedPair(makeInput(TRIGGER_BUTTON, 0), "Left Trigger Button"));
+    //availableInputs.append(Input::NamedPair(makeInput(BACK_TRIGGER, 0), "Left Back Trigger"));
+    //availableInputs.append(Input::NamedPair(makeInput(RIGHT_HAND), "Right Hand"));
+    //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 1), "Right Button A"));
+    //availableInputs.append(Input::NamedPair(makeInput(GRIP_BUTTON, 1), "Right Grip Button"));
+    //availableInputs.append(Input::NamedPair(makeInput(TRACKPAD_BUTTON, 1), "Right Trackpad Button"));
+    //availableInputs.append(Input::NamedPair(makeInput(TRIGGER_BUTTON, 1), "Right Trigger Button"));
+    //availableInputs.append(Input::NamedPair(makeInput(BACK_TRIGGER, 1), "Right Back Trigger"));
+
+    return availableInputs;
 }
 
-QString ViveControllerManager::getDefaultMappingConfig() {
+QString ViveControllerManager::getDefaultMappingConfig() const {
     static const QString MAPPING_JSON = PathUtils::resourcesPath() + "/controllers/vive.json";
     return MAPPING_JSON;
 }

--- a/libraries/input-plugins/src/input-plugins/ViveControllerManager.h
+++ b/libraries/input-plugins/src/input-plugins/ViveControllerManager.h
@@ -41,8 +41,8 @@ public:
     virtual void pluginUpdate(float deltaTime, bool jointsCaptured) override { update(deltaTime, jointsCaptured); }
 
     // Device functions
-    virtual void buildDeviceProxy(controller::DeviceProxy::Pointer proxy) override;
-    virtual QString getDefaultMappingConfig() override;
+    virtual controller::Input::NamedVector getAvailableInputs() const override;
+    virtual QString getDefaultMappingConfig() const override;
     virtual void update(float deltaTime, bool jointsCaptured) override;
     virtual void focusOutEvent() override;
 

--- a/tests/controllers/src/main.cpp
+++ b/tests/controllers/src/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
             auto userInputMapper = DependencyManager::get<controller::UserInputMapper>();
             if (name == KeyboardMouseDevice::NAME) {
                 auto keyboardMouseDevice = static_cast<KeyboardMouseDevice*>(inputPlugin.data()); // TODO: this seems super hacky
-                userInputMapper->registerDevice(keyboardMouseDevice);
+                userInputMapper->registerDevice(std::shared_ptr<InputDevice>(keyboardMouseDevice));
             }
             inputPlugin->pluginUpdate(0, false);
         }


### PR DESCRIPTION
This removes the DeviceProxy class, instead letting InputDevices be queried directly for information.  However, since the code for the 3D mouse is actively being developed by others on our team I opted to comment it out rather than attempt to port and possibly duplicate work.

The one problem with this is that the InputDevices are now wrapped in shared_ptrs, but some of them are actually also InputPlugins which are wrapped in the plugin subsystem in QSharedPointer.  

This needs to be resolved at some point, probably be disallowing multiple inheritance in this way and requiring input plugins that which to create only a single input device to have an inner class which implements the functionality.  