### PR TITLE
Fix ScriptEngine crash

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -685,9 +685,8 @@ void ScriptEngine::run() {
         }
         lastUpdate = now;
 
-        if (hadUncauchtExceptions(*this, _fileNameString)) {
-            stop();
-        }
+        // Debug and clear exceptions
+        hadUncauchtExceptions(*this, _fileNameString);
     }
 
     stopAllTimers(); // make sure all our timers are stopped if the script is ending

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -96,7 +96,7 @@ static bool hasCorrectSyntax(const QScriptProgram& program) {
     return true;
 }
 
-static bool hadUncauchtExceptions(QScriptEngine& engine, const QString& fileName) {
+static bool hadUncaughtExceptions(QScriptEngine& engine, const QString& fileName) {
     if (engine.hasUncaughtException()) {
         const auto backtrace = engine.uncaughtExceptionBacktrace();
         const auto exception = engine.uncaughtException().toString();
@@ -616,7 +616,7 @@ QScriptValue ScriptEngine::evaluate(const QString& sourceCode, const QString& fi
     const auto result = QScriptEngine::evaluate(program);
     --_evaluatesPending;
     
-    const auto hadUncaughtException = hadUncauchtExceptions(*this, program.fileName());
+    const auto hadUncaughtException = hadUncaughtExceptions(*this, program.fileName());
     if (_wantSignals) {
         emit evaluationFinished(result, hadUncaughtException);
     }
@@ -686,7 +686,7 @@ void ScriptEngine::run() {
         lastUpdate = now;
 
         // Debug and clear exceptions
-        hadUncauchtExceptions(*this, _fileNameString);
+        hadUncaughtExceptions(*this, _fileNameString);
     }
 
     stopAllTimers(); // make sure all our timers are stopped if the script is ending
@@ -1021,7 +1021,7 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
 
     QScriptEngine sandbox;
     QScriptValue testConstructor = sandbox.evaluate(program);
-    if (hadUncauchtExceptions(sandbox, program.fileName())) {
+    if (hadUncaughtExceptions(sandbox, program.fileName())) {
         return;
     }
     


### PR DESCRIPTION
Fix bug that would shut down the Entities' script engine and cause a crash when an entity script throws an exception.