### PR TITLE
Scripting - Fix Vec3 properties and added multiplyVbyV function

### DIFF
--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -23,6 +23,25 @@
 /// Scriptable interface a Vec3ernion helper class object. Used exclusively in the JavaScript API
 class Vec3 : public QObject {
     Q_OBJECT
+    Q_PROPERTY(glm::vec3 UNIT_X READ UNIT_X CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_Y READ UNIT_Y CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_Z READ UNIT_Z CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_NEG_X READ UNIT_NEG_X CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_NEG_Y READ UNIT_NEG_Y CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_NEG_Z READ UNIT_NEG_Z CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_XY READ UNIT_XY CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_XZ READ UNIT_XZ CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_YZ READ UNIT_YZ CONSTANT)
+    Q_PROPERTY(glm::vec3 UNIT_XYZ READ UNIT_XYZ CONSTANT)
+    Q_PROPERTY(glm::vec3 FLOAT_MAX READ FLOAT_MAX CONSTANT)
+    Q_PROPERTY(glm::vec3 FLOAT_MIN READ FLOAT_MIN CONSTANT)
+    Q_PROPERTY(glm::vec3 ZERO READ ZERO CONSTANT)
+    Q_PROPERTY(glm::vec3 ONE READ ONE CONSTANT)
+    Q_PROPERTY(glm::vec3 TWO READ TWO CONSTANT)
+    Q_PROPERTY(glm::vec3 HALF READ HALF CONSTANT)
+    Q_PROPERTY(glm::vec3 RIGHT READ RIGHT CONSTANT)
+    Q_PROPERTY(glm::vec3 UP READ UP CONSTANT)
+    Q_PROPERTY(glm::vec3 FRONT READ FRONT CONSTANT)
 
 public slots:
     glm::vec3 reflect(const glm::vec3& v1, const glm::vec3& v2) { return glm::reflect(v1, v2); }
@@ -30,6 +49,7 @@ public slots:
     float dot(const glm::vec3& v1, const glm::vec3& v2) { return glm::dot(v1, v2); }
     glm::vec3 multiply(const glm::vec3& v1, float f) { return v1 * f; }
     glm::vec3 multiply(float f, const glm::vec3& v1) { return v1 * f; }
+    glm::vec3 multiplyVbyV(const glm::vec3& v1, const glm::vec3& v2) { return v1 * v2; }
     glm::vec3 multiplyQbyV(const glm::quat& q, const glm::vec3& v) { return q * v; }
     glm::vec3 sum(const glm::vec3& v1, const glm::vec3& v2) { return v1 + v2; }
     glm::vec3 subtract(const glm::vec3& v1, const glm::vec3& v2) { return v1 - v2; }
@@ -45,6 +65,8 @@ public slots:
     glm::vec3 toPolar(const glm::vec3& v);
     glm::vec3 fromPolar(const glm::vec3& polar);
     glm::vec3 fromPolar(float elevation, float azimuth);
+
+private:
     const glm::vec3& UNIT_X() { return Vectors::UNIT_X; }
     const glm::vec3& UNIT_Y() { return Vectors::UNIT_Y; }
     const glm::vec3& UNIT_Z() { return Vectors::UNIT_Z; }


### PR DESCRIPTION
fix the constants of Vec3 ,  const glm::vec3& UNIT_***() weren't accessible in javascript. Solved it by making them properties that are CONSTANT. Also added function to multiply a vec3 by a vec3 called multiplyVbyV since overloading it over multiply gave me some problems