### PR TITLE
ViveController - input mapping 

### DIFF
--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -1,23 +1,24 @@
 {
-    "name": "XBox to Standard",
+    "name": "Vive to Standard",
     "channels": [
-        { "from": "Vive.LY", "to": "Standard.LY" }, 
-        { "from": "Vive.LX", "to": "Standard.LX" },
-        { "from": "Vive.LT", "to": "Standard.LT" }, 
-        { "from": "Vive.LB", "to": "Standard.LB" }, 
+        { "from": "Vive.LY", "filters": [ "invert", { "type": "deadZone", "min": 0.7 } ], "to": "Standard.LY" },
+        { "from": "Vive.LX", "filters": { "type": "deadZone", "min": 0.7 }, "to": "Standard.LX" },
+
+        { "from": "Vive.LT", "to": "Standard.LT" },
+        { "from": "Vive.LB", "to": "Standard.LB" },
         { "from": "Vive.LS", "to": "Standard.LS" },
 
-        { "from": "Vive.RY", "to": "Standard.RY" }, 
+        { "from": "Vive.RY", "filters": "invert", "to": "Standard.RY" },
         { "from": "Vive.RX", "to": "Standard.RX" },
-        { "from": "Vive.RT", "to": "Standard.RT" }, 
-        { "from": "Vive.RB", "to": "Standard.RB" }, 
+
+        { "from": "Vive.RT", "to": "Standard.RT" },
+        { "from": "Vive.RB", "to": "Standard.RB" },
         { "from": "Vive.RS", "to": "Standard.RS" },
 
-        { "from": "Vive.Back", "to": "Standard.Back" }, 
-        { "from": "Vive.Start", "to": "Standard.Start" }, 
-        
-        { "from": "Vive.A", "to": "Standard.A" }, 
-        { "from": "Vive.B", "to": "Standard.B" },
+        { "from": "Vive.LeftPrimaryThumb", "to": "Standard.LeftPrimaryThumb" },
+        { "from": "Vive.RightPrimaryThumb", "to": "Standard.RightPrimaryThumb" },
+        { "from": "Vive.LeftSecondaryThumb", "to": "Standard.LeftSecondaryThumb" },
+        { "from": "Vive.RightSecondaryThumb", "to": "Standard.RightSecondaryThumb" },
 
         { "from": "Vive.LeftHand", "to": "Standard.LeftHand" },
         { "from": "Vive.RightHand", "to": "Standard.RightHand" }

--- a/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/ViveControllerManager.cpp
@@ -307,11 +307,13 @@ void ViveControllerManager::focusOutEvent() {
 // These functions do translation from the Steam IDs to the standard controller IDs
 void ViveControllerManager::handleAxisEvent(uint32_t axis, float x, float y, bool left) {
 #ifdef Q_OS_WIN
+    axis += vr::k_EButton_Axis0;
     using namespace controller;
     if (axis == vr::k_EButton_SteamVR_Touchpad) {
         _axisStateMap[left ? LX : RX] = x;
         _axisStateMap[left ? LY : RY] = y;
     } else if (axis == vr::k_EButton_SteamVR_Trigger) {
+        //FIX ME: Seems that enters here everytime
         _axisStateMap[left ? LT : RT] = x;
     }
 #endif
@@ -325,15 +327,17 @@ void ViveControllerManager::handleButtonEvent(uint32_t button, bool pressed, boo
     }
 
     if (button == vr::k_EButton_ApplicationMenu) {
-        // FIXME?
-        _buttonPressedMap.insert(left ? controller::B : controller::A);
+        _buttonPressedMap.insert(left ? controller::LEFT_PRIMARY_THUMB : controller::RIGHT_PRIMARY_THUMB);
     } else if (button == vr::k_EButton_Grip) {
         // Tony says these are harder to reach, so make them the meta buttons
-        _buttonPressedMap.insert(left ? controller::BACK : controller::START);
-    } else if (button == vr::k_EButton_SteamVR_Trigger) {
         _buttonPressedMap.insert(left ? controller::LB : controller::RB);
+    } else if (button == vr::k_EButton_SteamVR_Trigger) {
+        _buttonPressedMap.insert(left ? controller::LT : controller::RT);
     } else if (button == vr::k_EButton_SteamVR_Touchpad) {
         _buttonPressedMap.insert(left ? controller::LS : controller::RS);
+    } else if (button == vr::k_EButton_System) {
+        //FIX ME: not able to ovrewrite the behaviour of this button
+        _buttonPressedMap.insert(left ? controller::LEFT_SECONDARY_THUMB : controller::RIGHT_SECONDARY_THUMB);
     }
 #endif
 }
@@ -425,10 +429,10 @@ controller::Input::NamedVector ViveControllerManager::getAvailableInputs() const
         makePair(LEFT_HAND, "LeftHand"),
         makePair(RIGHT_HAND, "RightHand"),
 
-        makePair(A, "A"),
-        makePair(B, "B"),
-        makePair(BACK, "Back"),
-        makePair(START, "Start"),
+        makePair(LEFT_PRIMARY_THUMB, "LeftPrimaryThumb"),
+        makePair(LEFT_SECONDARY_THUMB, "LeftSecondaryThumb"),
+        makePair(RIGHT_PRIMARY_THUMB, "RightPrimaryThumb"),
+        makePair(RIGHT_SECONDARY_THUMB, "RightSecondaryThumb"),
     };
 
     //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 0), "Left Button A"));


### PR DESCRIPTION
 Runnign the interface it's now possible to move around and rotate the camera using the trackpads. It's even possible to grab but the actions seem inverted  (pressing the left trigger a ray is casted from the right hand). 
All the inputs were mapped following the standar.
In vive.json the deadzone was inserted because the joystick seems broken and produce a lot of noise.