### PR TITLE
Crash fix for AvatarManager when iterating over _avatarHash

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -366,5 +366,10 @@ AvatarSharedPointer AvatarManager::getAvatarBySessionID(const QUuid& sessionID) 
         return std::static_pointer_cast<Avatar>(_myAvatar);
     }
     QReadLocker locker(&_hashLock);
-    return _avatarHash[sessionID];
+    auto iter = _avatarHash.find(sessionID);
+    if (iter != _avatarHash.end()) {
+        return iter.value();
+    } else {
+        return AvatarSharedPointer();
+    }
 }


### PR DESCRIPTION
The main problem is that a null shared pointer was inserted into the _avatarHash
via the AvatarManager::getAvatarBySessionID().  When the sessionID is not present
in the _avatarHash, [QHash](http://doc.qt.io/qt-5/qhash.html#operator-5b-5d) will *insert* an empty smart_ptr into the hash.