### PR TITLE
fix SDL joysticks

### DIFF
--- a/libraries/controllers/src/controllers/StandardControls.h
+++ b/libraries/controllers/src/controllers/StandardControls.h
@@ -58,15 +58,15 @@ namespace controller {
         // Left Analog stick
         LX = 0,
         LY,
-        LZ,
         // Right Analog stick
         RX,
         RY,
-        RZ,
         // Triggers
         LT,
         RT,
-        NUM_STANDARD_AXES
+        NUM_STANDARD_AXES,
+        LZ = LT,
+        RZ = RT
     };
 
     // No correlation to SDL

--- a/libraries/input-plugins/src/input-plugins/SDL2Manager.cpp
+++ b/libraries/input-plugins/src/input-plugins/SDL2Manager.cpp
@@ -18,6 +18,33 @@
 
 #include "SDL2Manager.h"
 
+#ifdef HAVE_SDL2
+static_assert(
+    controller::A == SDL_CONTROLLER_BUTTON_A &&
+    controller::B == SDL_CONTROLLER_BUTTON_B &&
+    controller::X == SDL_CONTROLLER_BUTTON_X &&
+    controller::Y == SDL_CONTROLLER_BUTTON_Y &&
+    controller::BACK == SDL_CONTROLLER_BUTTON_BACK &&
+    controller::GUIDE == SDL_CONTROLLER_BUTTON_GUIDE &&
+    controller::START == SDL_CONTROLLER_BUTTON_START &&
+    controller::LS == SDL_CONTROLLER_BUTTON_LEFTSTICK &&
+    controller::RS == SDL_CONTROLLER_BUTTON_RIGHTSTICK &&
+    controller::LB == SDL_CONTROLLER_BUTTON_LEFTSHOULDER &&
+    controller::RB == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER &&
+    controller::DU == SDL_CONTROLLER_BUTTON_DPAD_UP &&
+    controller::DD == SDL_CONTROLLER_BUTTON_DPAD_DOWN &&
+    controller::DL == SDL_CONTROLLER_BUTTON_DPAD_LEFT &&
+    controller::DR == SDL_CONTROLLER_BUTTON_DPAD_RIGHT &&
+    controller::LX == SDL_CONTROLLER_AXIS_LEFTX &&
+    controller::LY == SDL_CONTROLLER_AXIS_LEFTY &&
+    controller::RX == SDL_CONTROLLER_AXIS_RIGHTX &&
+    controller::RY == SDL_CONTROLLER_AXIS_RIGHTY &&
+    controller::LT == SDL_CONTROLLER_AXIS_TRIGGERLEFT &&
+    controller::RT == SDL_CONTROLLER_AXIS_TRIGGERRIGHT,
+    "SDL2 equvalence: Enums and values from StandardControls.h are assumed to match enums from SDL_gamecontroller.h");
+#endif
+
+
 const QString SDL2Manager::NAME = "SDL2";
 
 #ifdef HAVE_SDL2


### PR DESCRIPTION
the right joystick axis got misaligned with the SDL sdk... this PR fixes it and adds a static_assert() to prevent this mistake in the future