### PR TITLE
Runtime plugins fixes

### DIFF
--- a/cmake/macros/CopyDllsBesideWindowsExecutable.cmake
+++ b/cmake/macros/CopyDllsBesideWindowsExecutable.cmake
@@ -18,12 +18,19 @@ macro(COPY_DLLS_BESIDE_WINDOWS_EXECUTABLE)
       @ONLY
     )
     
+    if (APPLE) 
+        set(PLUGIN_PATH "interface.app/Contents/MacOS/plugins")
+    else()
+        set(PLUGIN_PATH "plugins")
+    endif()
+    
     # add a post-build command to copy DLLs beside the executable
     add_custom_command(
       TARGET ${TARGET_NAME}
       POST_BUILD
       COMMAND ${CMAKE_COMMAND}
         -DBUNDLE_EXECUTABLE=$<TARGET_FILE:${TARGET_NAME}>
+        -DBUNDLE_PLUGIN_DIR=$<TARGET_FILE_DIR:${TARGET_NAME}>/${PLUGIN_PATH}
         -P ${CMAKE_CURRENT_BINARY_DIR}/FixupBundlePostBuild.cmake
     )
     

--- a/cmake/templates/FixupBundlePostBuild.cmake.in
+++ b/cmake/templates/FixupBundlePostBuild.cmake.in
@@ -41,4 +41,16 @@ function(copy_resolved_item_into_bundle resolved_item resolved_embedded_item)
 endfunction()
 
 message(STATUS "FIXUP_LIBS for fixup_bundle called for bundle ${BUNDLE_EXECUTABLE} are @FIXUP_LIBS@")
-fixup_bundle("${BUNDLE_EXECUTABLE}" "" "@FIXUP_LIBS@")
+
+message(STATUS "Scanning for plugins from ${BUNDLE_PLUGIN_DIR}")
+
+if (APPLE)
+    set(PLUGIN_EXTENSION "dylib")
+elseif (WIN32) 
+    set(PLUGIN_EXTENSION "dll")
+else() 
+    set(PLUGIN_EXTENSION "so")
+endif()
+
+file(GLOB RUNTIME_PLUGINS "${BUNDLE_PLUGIN_DIR}/*.${PLUGIN_EXTENSION}")
+fixup_bundle("${BUNDLE_EXECUTABLE}" "${RUNTIME_PLUGINS}" "@FIXUP_LIBS@")

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -47,8 +47,8 @@
 static const char* const MENU_PROPERTY_NAME = "com.highfidelity.Menu";
 
 Menu* Menu::getInstance() {
-    static Menu& instance = globalInstace<Menu>(MENU_PROPERTY_NAME);
-    return &instance;
+    static Menu* instance = globalInstace<Menu>(MENU_PROPERTY_NAME);
+    return instance;
 }
 
 Menu::Menu() {

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -44,22 +44,11 @@
 
 #include "Menu.h"
 
-Menu* Menu::_instance = NULL;
+static const char* const MENU_PROPERTY_NAME = "com.highfidelity.Menu";
 
 Menu* Menu::getInstance() {
-    static QMutex menuInstanceMutex;
-
-    // lock the menu instance mutex to make sure we don't race and create two menus and crash
-    menuInstanceMutex.lock();
-
-    if (!_instance) {
-        qCDebug(interfaceapp, "First call to Menu::getInstance() - initing menu.");
-        _instance = new Menu();
-    }
-
-    menuInstanceMutex.unlock();
-
-    return _instance;
+    static Menu& instance = globalInstace<Menu>(MENU_PROPERTY_NAME);
+    return &instance;
 }
 
 Menu::Menu() {

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -47,7 +47,7 @@
 static const char* const MENU_PROPERTY_NAME = "com.highfidelity.Menu";
 
 Menu* Menu::getInstance() {
-    static Menu* instance = globalInstace<Menu>(MENU_PROPERTY_NAME);
+    static Menu* instance = globalInstance<Menu>(MENU_PROPERTY_NAME);
     return instance;
 }
 

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -57,6 +57,7 @@ private:
 class Menu : public QMenuBar {
     Q_OBJECT
 public:
+    Menu();
     static Menu* getInstance();
 
     void loadSettings();
@@ -103,9 +104,6 @@ public slots:
     void setIsOptionChecked(const QString& menuOption, bool isChecked);
 
 private:
-    static Menu* _instance;
-    Menu();
-
     typedef void(*settingsAction)(Settings&, QAction&);
     static void loadAction(Settings& settings, QAction& action);
     static void saveAction(Settings& settings, QAction& action);

--- a/libraries/shared/src/DependencyManager.cpp
+++ b/libraries/shared/src/DependencyManager.cpp
@@ -12,12 +12,13 @@
 #include "DependencyManager.h"
 
 #include "SharedUtil.h"
+#include "Finally.h"
 
 static const char* const DEPENDENCY_PROPERTY_NAME = "com.highfidelity.DependencyMananger";
 
 DependencyManager& DependencyManager::manager() {
-    static DependencyManager& instance = globalInstace<DependencyManager>(DEPENDENCY_PROPERTY_NAME);
-    return instance;
+    static DependencyManager* instance = globalInstace<DependencyManager>(DEPENDENCY_PROPERTY_NAME);
+    return *instance;
 }
 
 QSharedPointer<Dependency>& DependencyManager::safeGet(size_t hashCode) {

--- a/libraries/shared/src/DependencyManager.cpp
+++ b/libraries/shared/src/DependencyManager.cpp
@@ -17,7 +17,7 @@
 static const char* const DEPENDENCY_PROPERTY_NAME = "com.highfidelity.DependencyMananger";
 
 DependencyManager& DependencyManager::manager() {
-    static DependencyManager* instance = globalInstace<DependencyManager>(DEPENDENCY_PROPERTY_NAME);
+    static DependencyManager* instance = globalInstance<DependencyManager>(DEPENDENCY_PROPERTY_NAME);
     return *instance;
 }
 

--- a/libraries/shared/src/DependencyManager.cpp
+++ b/libraries/shared/src/DependencyManager.cpp
@@ -11,7 +11,14 @@
 
 #include "DependencyManager.h"
 
-DependencyManager DependencyManager::_manager;
+#include "SharedUtil.h"
+
+static const char* const DEPENDENCY_PROPERTY_NAME = "com.highfidelity.DependencyMananger";
+
+DependencyManager& DependencyManager::manager() {
+    static DependencyManager& instance = globalInstace<DependencyManager>(DEPENDENCY_PROPERTY_NAME);
+    return instance;
+}
 
 QSharedPointer<Dependency>& DependencyManager::safeGet(size_t hashCode) {
     return _instanceHash[hashCode];

--- a/libraries/shared/src/DependencyManager.h
+++ b/libraries/shared/src/DependencyManager.h
@@ -62,8 +62,8 @@ public:
     static void registerInheritance();
     
 private:
-    static DependencyManager _manager;
-    
+    static DependencyManager& manager();
+
     template<typename T>
     size_t getHashCode();
     
@@ -75,11 +75,11 @@ private:
 
 template <typename T>
 QSharedPointer<T> DependencyManager::get() {
-    static size_t hashCode = _manager.getHashCode<T>();
+    static size_t hashCode = manager().getHashCode<T>();
     static QWeakPointer<T> instance;
     
     if (instance.isNull()) {
-        instance = qSharedPointerCast<T>(_manager.safeGet(hashCode));
+        instance = qSharedPointerCast<T>(manager().safeGet(hashCode));
         
         if (instance.isNull()) {
             qWarning() << "DependencyManager::get(): No instance available for" << typeid(T).name();
@@ -91,9 +91,9 @@ QSharedPointer<T> DependencyManager::get() {
 
 template <typename T, typename ...Args>
 QSharedPointer<T> DependencyManager::set(Args&&... args) {
-    static size_t hashCode = _manager.getHashCode<T>();
+    static size_t hashCode = manager().getHashCode<T>();
 
-    QSharedPointer<Dependency>& instance = _manager.safeGet(hashCode);
+    QSharedPointer<Dependency>& instance = manager().safeGet(hashCode);
     instance.clear(); // Clear instance before creation of new one to avoid edge cases
     QSharedPointer<T> newInstance(new T(args...), &T::customDeleter);
     QSharedPointer<Dependency> storedInstance = qSharedPointerCast<Dependency>(newInstance);
@@ -104,9 +104,9 @@ QSharedPointer<T> DependencyManager::set(Args&&... args) {
 
 template <typename T, typename I, typename ...Args>
 QSharedPointer<T> DependencyManager::set(Args&&... args) {
-    static size_t hashCode = _manager.getHashCode<T>();
+    static size_t hashCode = manager().getHashCode<T>();
 
-    QSharedPointer<Dependency>& instance = _manager.safeGet(hashCode);
+    QSharedPointer<Dependency>& instance = manager().safeGet(hashCode);
     instance.clear(); // Clear instance before creation of new one to avoid edge cases
     QSharedPointer<T> newInstance(new I(args...), &I::customDeleter);
     QSharedPointer<Dependency> storedInstance = qSharedPointerCast<Dependency>(newInstance);
@@ -117,15 +117,15 @@ QSharedPointer<T> DependencyManager::set(Args&&... args) {
 
 template <typename T>
 void DependencyManager::destroy() {
-    static size_t hashCode = _manager.getHashCode<T>();
-    _manager.safeGet(hashCode).clear();
+    static size_t hashCode = manager().getHashCode<T>();
+    manager().safeGet(hashCode).clear();
 }
 
 template<typename Base, typename Derived>
 void DependencyManager::registerInheritance() {
     size_t baseHashCode = typeid(Base).hash_code();
     size_t derivedHashCode = typeid(Derived).hash_code();
-    _manager._inheritanceHash.insert(baseHashCode, derivedHashCode);
+    manager()._inheritanceHash.insert(baseHashCode, derivedHashCode);
 }
 
 template<typename T>

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -27,10 +27,10 @@
 // Provides efficient access to a named global type.  By storing the value
 // in the QApplication by name we can implement the singleton pattern and 
 // have the single instance function across DLL boundaries.  
-template <typename T, typename ...Args>
-T* globalInstace(const char* propertyName, Args&&... args) {
-    static std::shared_ptr<T> instancePtr;
-    static T *resultInstance { nullptr };
+template <typename T, typename... Args>
+T* globalInstance(const char* propertyName, Args&&... args) {
+    static std::unique_ptr<T> instancePtr;
+    static T* resultInstance { nullptr };
     static std::mutex mutex;
     if (!resultInstance) {
         std::unique_lock<std::mutex> lock(mutex);
@@ -39,7 +39,8 @@ T* globalInstace(const char* propertyName, Args&&... args) {
             if (variant.isNull()) {
                 // Since we're building the object, store it in a shared_ptr so it's 
                 // destroyed by the destructor of the static instancePtr
-                instancePtr = std::make_shared<T>(args...);
+                instancePtr = std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+
                 void* voidInstance = &(*instancePtr);
                 variant = QVariant::fromValue(voidInstance);
                 qApp->setProperty(propertyName, variant);

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -28,24 +28,27 @@
 // in the QApplication by name we can implement the singleton pattern and 
 // have the single instance function across DLL boundaries.  
 template <typename T, typename ...Args>
-T& globalInstace(const char* propertyName, Args&&... args) {
-    static T *instance { nullptr };
+T* globalInstace(const char* propertyName, Args&&... args) {
+    static std::shared_ptr<T> instancePtr;
+    static T *resultInstance { nullptr };
     static std::mutex mutex;
-    if (!instance) {
+    if (!resultInstance) {
         std::unique_lock<std::mutex> lock(mutex);
-        if (!instance) {
+        if (!resultInstance) {
             auto variant = qApp->property(propertyName);
             if (variant.isNull()) {
-                auto* typedInstance = new T(args...);
-                void* voidInstance = typedInstance;
+                // Since we're building the object, store it in a shared_ptr so it's 
+                // destroyed by the destructor of the static instancePtr
+                instancePtr = std::make_shared<T>(args...);
+                void* voidInstance = &(*instancePtr);
                 variant = QVariant::fromValue(voidInstance);
                 qApp->setProperty(propertyName, variant);
             }
             void* returnedVoidInstance = variant.value<void*>();
-            instance = static_cast<T*>(returnedVoidInstance);
+            resultInstance = static_cast<T*>(returnedVoidInstance);
         }
     }
-    return *instance;
+    return resultInstance;
 }
 
 const int BYTES_PER_COLOR = 3;


### PR DESCRIPTION
This is work to correct two issues with our runtime plugins.  

First, if a runtime plugin attempts to call `Menu::instance()` or `DependencyManager::get()` right now it will fail to return the correct value.  This is because both of these objects use a singleton stored as a static.  However, a runtime plugin operating in its own memory space will have a separate copy of the static.  `Menu::instance()` will return a brand new menu object, while `DependencyManager::get()` will return a null pointer, because it's DLL local instance hasn't had any calls to `DependencyManager::set()`.  

This is corrected by having the QtCoreApplication object store the value as a property.  The property is looked up by name and instantiated it if doesn't exist.  However, the function that does so also has a function local static that will be populated, so subsequent attempts to fetch the value won't suffer any performance hit from the name lookup.  Currently I've applied this to these two singletons, Menu and DependencyManager, but there are probably others we will need to fix.

The second fix is to the build process.  Currently our only plugin is for the Oculus HMD, which functions because it looks up the Oculus DLL which is installed with the runtime.  However many of our plugins will rely on DLLs that have to be packaged with the executable, like SDL.  Right now the plugin is copied because the interface.exe app links to it, but once the functionality is in a plugin, interface.exe no longer has a link to the DLL and the CMake fixup_bundle command won't grab the DLL.  

This is corrected by using the second parameter to fixup_bundle, which takes a list of shared libraries to also scan for dependencies, and appears to be designed for precisely this situation.  