### PR TITLE
Remove idleTimer and call idle directly from paintGL.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -160,7 +160,6 @@ static QTimer balanceUpdateTimer;
 static QTimer identityPacketTimer;
 static QTimer billboardPacketTimer;
 static QTimer checkFPStimer;
-static QTimer idleTimer;
 
 static const QString SNAPSHOT_EXTENSION  = ".jpg";
 static const QString SVO_EXTENSION  = ".svo";
@@ -844,7 +843,6 @@ void Application::cleanupBeforeQuit() {
     identityPacketTimer.stop();
     billboardPacketTimer.stop();
     checkFPStimer.stop();
-    idleTimer.stop();
     QMetaObject::invokeMethod(&_settingsTimer, "stop", Qt::BlockingQueuedConnection);
 
     // save state
@@ -982,9 +980,6 @@ void Application::initializeGL() {
     connect(&checkFPStimer, &QTimer::timeout, this, &Application::checkFPS);
     checkFPStimer.start(1000);
 
-    // call our idle function whenever we can
-    connect(&idleTimer, &QTimer::timeout, this, &Application::idle);
-    idleTimer.start(TARGET_SIM_FRAME_PERIOD_MS);
     _idleLoopStdev.reset();
 
     // update before the first render
@@ -1048,6 +1043,9 @@ void Application::initializeUi() {
 }
 
 void Application::paintGL() {
+
+    idle();
+
     PROFILE_RANGE(__FUNCTION__);
     PerformanceTimer perfTimer("paintGL");
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -307,7 +307,7 @@ public slots:
 private slots:
     void clearDomainOctreeDetails();
     void ping();
-    void idle();
+    void idle(uint64_t now);
     void aboutToQuit();
 
     void handleScriptEngineLoaded(const QString& scriptFilename);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -306,7 +306,7 @@ public slots:
     
 private slots:
     void clearDomainOctreeDetails();
-    void checkFPS();
+    void ping();
     void idle();
     void aboutToQuit();
 
@@ -541,6 +541,8 @@ private:
     EntityItemID _keyboardFocusedItem;
     quint64 _lastAcceptedKeyPress = 0;
 
+    SimpleMovingAverage _framesPerSecond{10};
+    quint64 _lastFramesPerSecondUpdate = 0;
     SimpleMovingAverage _simsPerSecond{10};
     int _simsPerSecondReport = 0;
     quint64 _lastSimsPerSecondUpdate = 0;


### PR DESCRIPTION
Synchronize Application::idle with Application::paintGL.  At high frame rates, this should improve the quality of MyAvatar animations and the motion of locally simulated physics objects.