### PR TITLE
Fix: Vec3.UP was pointed to Vectors::UNIT_X

### DIFF
--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -84,7 +84,7 @@ private:
     const glm::vec3& TWO() { return Vectors::TWO; }
     const glm::vec3& HALF() { return Vectors::HALF; }
     const glm::vec3& RIGHT() { return Vectors::RIGHT; }
-    const glm::vec3& UP() { return Vectors::UNIT_X; }
+    const glm::vec3& UP() { return Vectors::UP; }
     const glm::vec3& FRONT() { return Vectors::FRONT; }
 };
 


### PR DESCRIPTION
This fixes the scripting property Vec3.UP to point to Vectors::UP which is equal to {X: 0, Y: 1, Z: 0}.