### PR TITLE
Disabling billboard rendering, source of the evil black rectangles

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -661,6 +661,9 @@ void Avatar::updateJointMappings() {
 }
 
 void Avatar::renderBillboard(RenderArgs* renderArgs) {
+    // FIXME disabling the billboard because it doesn't appear to work reliably
+    // the billboard is ending up with a random texture and position.
+    return;
     if (_billboard.isEmpty()) {
         return;
     }


### PR DESCRIPTION
The billboard logic seems to be messed up somehow and is triggering when it shouldn't.  Disabling for now until we can resolve billboarding properly.  