### PR TITLE
fix hydra sensor matrix when no HMD is attached

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -122,11 +122,7 @@ MyAvatar::MyAvatar(RigPointer rig) :
             this, &MyAvatar::goToLocation);
     _characterController.setEnabled(true);
 
-    _hmdSensorMatrix = glm::mat4();
-    _hmdSensorPosition = extractTranslation(_hmdSensorMatrix);
-    _hmdSensorOrientation = glm::quat_cast(_hmdSensorMatrix);
     _bodySensorMatrix = deriveBodyFromHMDSensor();
-    updateSensorToWorldMatrix();
 }
 
 MyAvatar::~MyAvatar() {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -121,6 +121,12 @@ MyAvatar::MyAvatar(RigPointer rig) :
     connect(DependencyManager::get<AddressManager>().data(), &AddressManager::locationChangeRequired,
             this, &MyAvatar::goToLocation);
     _characterController.setEnabled(true);
+
+    _hmdSensorMatrix = glm::mat4();
+    _hmdSensorPosition = extractTranslation(_hmdSensorMatrix);
+    _hmdSensorOrientation = glm::quat_cast(_hmdSensorMatrix);
+    _bodySensorMatrix = deriveBodyFromHMDSensor();
+    updateSensorToWorldMatrix();
 }
 
 MyAvatar::~MyAvatar() {


### PR DESCRIPTION
This is the right fix in the short (initialize _bodySensorMatrix to a reasonable default value) but  the long term solution is to compute a default _bodySensorMatrix when we load the avatar model.