### PR TITLE
make held objects move tightly with hand (again)

### DIFF
--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -109,8 +109,6 @@ void AvatarActionHold::doKinematicUpdate(float deltaTimeStep) {
             if (_previousSet) {
                 glm::vec3 positionalVelocity = (_positionalTarget - _previousPositionalTarget) / deltaTimeStep;
                 rigidBody->setLinearVelocity(glmToBullet(positionalVelocity));
-                // back up along velocity a bit in order to smooth out a "vibrating" appearance
-                _positionalTarget -= positionalVelocity * deltaTimeStep / 2.0f;
             }
         }
 


### PR DESCRIPTION
- fixed a bug in AvatarActionHold where kinematicSetVelocity flag caused objects to lag