### PR TITLE
fix slow drift of avatar when wearing HMD

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1299,11 +1299,11 @@ void MyAvatar::prepareForPhysicsSimulation() {
     _characterController.setAvatarPositionAndOrientation(getPosition(), getOrientation());
     if (qApp->isHMDMode()) {
         updateHMDFollowVelocity();
-        _characterController.setHMDVelocity(_hmdFollowVelocity);
-    } else {
-        _characterController.setHMDVelocity(Vectors::ZERO);
+    } else if (_isFollowingHMD) {
         _isFollowingHMD = false;
+        _hmdFollowVelocity = Vectors::ZERO;
     }
+    _characterController.setHMDVelocity(_hmdFollowVelocity);
 }
 
 void MyAvatar::harvestResultsFromPhysicsSimulation() {
@@ -1339,6 +1339,7 @@ void MyAvatar::adjustSensorTransform(glm::vec3 hmdShift) {
         // the "adjustment" is more or less complete so stop following
         _isFollowingHMD = false;
         _hmdFollowSpeed = 0.0f;
+        _hmdFollowVelocity = Vectors::ZERO;
         // and slam the body's transform anyway to eliminate any slight errors
         glm::vec3 finalBodyPosition = extractTranslation(worldBodyMatrix);
         nextAttitude(finalBodyPosition, finalBodyRotation);

--- a/libraries/shared/src/AtRestDetector.cpp
+++ b/libraries/shared/src/AtRestDetector.cpp
@@ -32,7 +32,7 @@ void AtRestDetector::reset(const glm::vec3& startPosition, const glm::quat& star
 
 bool AtRestDetector::update(const glm::vec3& position, const glm::quat& rotation) {
     uint64_t now = usecTimestampNow();
-    float dt = (float)(_lastUpdateTime - now) / (float)USECS_PER_SECOND;
+    float dt = (float)(now - _lastUpdateTime) / (float)USECS_PER_SECOND;
     _lastUpdateTime = now;
     const float TAU = 1.0f;
     float delta = glm::min(dt / TAU, 1.0f);


### PR DESCRIPTION
The "restore avatar under hips" logic was not setting the restore velocity to zero when done.