### PR TITLE
Controllers: Fixing the step pulse behavior and changes to standard mapping

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -2,8 +2,9 @@
     "name": "Standard to Action",
     "channels": [
         { "from": "Standard.LY", "to": "Actions.TranslateZ" },
+        { "from": "Standard.LX", "to": "Actions.TranslateX" },
 
-        { "from": "Standard.LX",
+        { "from": "Standard.RX",
           "when": [ "Application.InHMD", "Application.ComfortMode" ],
           "to": "Actions.StepYaw",
           "filters":
@@ -12,11 +13,8 @@
                 { "type": "scale", "scale": 15 }
             ]
         },
-
-        { "from": "Standard.LX", "to": "Actions.Yaw" },
-
-        { "from": "Standard.RX", "to": "Actions.TranslateX" },
-        { "from": "Standard.RY", "filters": "invert", "to": "Actions.TranslateY" }, 
+        { "from": "Standard.RX", "to": "Actions.Yaw" },
+        { "from": "Standard.RY", "when": "!Application.InHMD", "to": "Actions.Pitch" }, 
 
 
         { "from": [ "Standard.DU", "Standard.DL", "Standard.DR", "Standard.DD" ], "to": "Standard.LeftPrimaryThumb" },

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -10,7 +10,7 @@
           "filters":
             [
                 { "type": "pulse", "interval": 0.5 },
-                { "type": "scale", "scale": 15 }
+                { "type": "scale", "scale": 22.5 }
             ]
         },
         { "from": "Standard.RX", "to": "Actions.Yaw" },

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -53,7 +53,6 @@
 
 using namespace std;
 
-static quint64 COMFORT_MODE_PULSE_TIMING = USECS_PER_SECOND / 2; // turn once per half second
 const glm::vec3 DEFAULT_UP_DIRECTION(0.0f, 1.0f, 0.0f);
 const float YAW_SPEED = 150.0f;   // degrees/sec
 const float PITCH_SPEED = 100.0f; // degrees/sec
@@ -259,23 +258,9 @@ void MyAvatar::simulate(float deltaTime) {
                 stepAction = true;
             }
         }
-        quint64 now = usecTimestampNow();
-        quint64 pulseDeltaTime = now - _lastStepPulse;
-        if (!stepAction) {
-            _lastStepPulse = 0;
-        }
-
-        if (stepAction && pulseDeltaTime > COMFORT_MODE_PULSE_TIMING) {
-            _pulseUpdate = true;
-        }
 
         updateOrientation(deltaTime);
         updatePosition(deltaTime);
-
-        if (_pulseUpdate) {
-            _lastStepPulse = now;
-            _pulseUpdate = false;
-        }
     }
 
     {
@@ -1623,7 +1608,7 @@ void MyAvatar::updateOrientation(float deltaTime) {
     // get an instantaneous 15 degree turn. If you keep holding the key down you'll get another
     // snap turn every half second.
     quint64 now = usecTimestampNow();
-    if (_driveKeys[STEP_YAW] != 0.0f && now - _lastStepPulse > COMFORT_MODE_PULSE_TIMING) {
+    if (_driveKeys[STEP_YAW] != 0.0f) {
         totalBodyYaw += _driveKeys[STEP_YAW];
     }
 
@@ -1692,9 +1677,9 @@ glm::vec3 MyAvatar::applyKeyboardMotor(float deltaTime, const glm::vec3& localVe
     glm::vec3 newLocalVelocity = localVelocity;
     float stepControllerInput = fabsf(_driveKeys[STEP_TRANSLATE_Z]) + fabsf(_driveKeys[STEP_TRANSLATE_Z]) + fabsf(_driveKeys[STEP_TRANSLATE_Z]);
     quint64 now = usecTimestampNow();
+
     // FIXME how do I implement step translation as well?
-    if (stepControllerInput && now - _lastStepPulse > COMFORT_MODE_PULSE_TIMING) {
-    }
+
 
     float keyboardInput = fabsf(_driveKeys[TRANSLATE_Z]) + fabsf(_driveKeys[TRANSLATE_X]) + fabsf(_driveKeys[TRANSLATE_Y]);
     if (keyboardInput) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -420,8 +420,6 @@ private:
 
     AtRestDetector _hmdAtRestDetector;
     bool _lastIsMoving { false };
-    quint64 _lastStepPulse { 0 };
-    bool _pulseUpdate { false };
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);


### PR DESCRIPTION
- Remove the pulsing behavior hardocded in MyAvatar for the stepYaw and instead rely purely on the pulsing of the controller route to the StepYaw axis.

- Updated the standard mapping:
  strafe is back on the left x joystick
  removed vertical moves completely