### PR TITLE
Getting rid of HTTPS external dependencies

### DIFF
--- a/cmake/externals/boostconfig/CMakeLists.txt
+++ b/cmake/externals/boostconfig/CMakeLists.txt
@@ -4,7 +4,8 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 include(ExternalProject)
 ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL https://github.com/boostorg/config/archive/boost-1.58.0.zip
+    #URL https://github.com/boostorg/config/archive/boost-1.58.0.zip
+    URL http://hifi-public.s3.amazonaws.com/dependencies/config-boost-1.58.0.zip
     URL_MD5 42fa673bae2b7645a22736445e80eb8d
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/cmake/externals/bullet/CMakeLists.txt
+++ b/cmake/externals/bullet/CMakeLists.txt
@@ -17,7 +17,8 @@ include(ExternalProject)
 if (WIN32)  
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL https://bullet.googlecode.com/files/bullet-2.82-r2704.zip
+    # URL https://bullet.googlecode.com/files/bullet-2.82-r2704.zip
+    URL http://hifi-public.s3.amazonaws.com/dependencies/bullet-2.82-r2704.zip
     URL_MD5 f5e8914fc9064ad32e0d62d19d33d977
     CMAKE_ARGS ${PLATFORM_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DBUILD_EXTRAS=0 -DINSTALL_LIBS=1 -DBUILD_DEMOS=0 -DUSE_GLUT=0 -DUSE_DX11=0
     LOG_DOWNLOAD 1
@@ -28,7 +29,8 @@ if (WIN32)
 else ()
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://bullet.googlecode.com/files/bullet-2.82-r2704.tgz
+    #URL http://bullet.googlecode.com/files/bullet-2.82-r2704.tgz
+    URL http://hifi-public.s3.amazonaws.com/dependencies/bullet-2.82-r2704.tgz
     URL_MD5 70b3c8d202dee91a0854b4cbc88173e8
     CMAKE_ARGS ${PLATFORM_CMAKE_ARGS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DBUILD_EXTRAS=0 -DINSTALL_LIBS=1 -DBUILD_DEMOS=0 -DUSE_GLUT=0
     LOG_DOWNLOAD 1

--- a/cmake/externals/openvr/CMakeLists.txt
+++ b/cmake/externals/openvr/CMakeLists.txt
@@ -7,7 +7,8 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL https://github.com/ValveSoftware/openvr/archive/0.9.1.zip
+  #URL https://github.com/ValveSoftware/openvr/archive/0.9.1.zip
+  URL http://hifi-public.s3.amazonaws.com/dependencies/openvr-0.9.1.zip
   URL_MD5 f986f5a6815e9454c53c5bf58ce02fdc
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/cmake/externals/sdl2/CMakeLists.txt
+++ b/cmake/externals/sdl2/CMakeLists.txt
@@ -7,7 +7,7 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 if (WIN32)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://www.libsdl.org/release/SDL2-devel-2.0.3-VC.zip
+    URL http://hifi-public.s3.amazonaws.com/dependencies/SDL2-devel-2.0.3-VC.zip
     URL_MD5 30a333bcbe94bc5016e8799c73e86233
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
@@ -18,7 +18,7 @@ elseif (APPLE)
 
     ExternalProject_Add(
       ${EXTERNAL_NAME}
-      URL https://hifi-public.s3.amazonaws.com/dependencies/SDL2-2.0.3.zip
+      URL http://hifi-public.s3.amazonaws.com/dependencies/SDL2-2.0.3.zip
       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DVIDEO_OPENGL=OFF
       BINARY_DIR ${EXTERNAL_PROJECT_PREFIX}/build
       LOG_DOWNLOAD 1

--- a/cmake/externals/sixense/CMakeLists.txt
+++ b/cmake/externals/sixense/CMakeLists.txt
@@ -4,15 +4,15 @@ set(EXTERNAL_NAME sixense)
 
 string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 
-#set(SIXENSE_URL "https://hifi-public.s3.amazonaws.com/dependencies/SixenseSDK_062612.zip")
+#set(SIXENSE_URL "http://hifi-public.s3.amazonaws.com/dependencies/SixenseSDK_062612.zip")
 #set(SIXENSE_URL_MD5 "10cc8dc470d2ac1244a88cf04bc549cc")
 #set(SIXENSE_NEW_LAYOUT 0)
 
-#set(SIXENSE_URL "https://public.s3.amazonaws.com/dependencies/SixenseSDK_071615.zip")
+#set(SIXENSE_URL "http://public.s3.amazonaws.com/dependencies/SixenseSDK_071615.zip")
 #set(SIXENSE_URL_MD5 "752a3901f334124e9cffc2ba4136ef7d")
 #set(SIXENSE_NEW_LAYOUT 1)
 
-set(SIXENSE_URL "https://hifi-public.s3.amazonaws.com/dependencies/SixenseSDK_102215.zip")
+set(SIXENSE_URL "http://hifi-public.s3.amazonaws.com/dependencies/SixenseSDK_102215.zip")
 set(SIXENSE_URL_MD5 "93c3a6795cce777a0f472b09532935f1")
 set(SIXENSE_NEW_LAYOUT 1)
 
@@ -43,7 +43,7 @@ if (WIN32)
     endif()
     
     if (${SIXENSE_NEW_LAYOUT})
-        # for 2015 SDKs (using the 2013 versions may be causing the crash)
+        # for 2015 SDKs (using the VS2013 versions may be causing the crash, so use the VS2010 versions)
         set(${EXTERNAL_NAME_UPPER}_DLL_PATH "${SOURCE_DIR}/bin/${ARCH_DIR}/VS2010/release_dll")
         set(${EXTERNAL_NAME_UPPER}_LIB_PATH "${SOURCE_DIR}/lib/${ARCH_DIR}/VS2010/release_dll")
     else()


### PR DESCRIPTION
CentOS builds seem to have trouble with our cmake due to HTTPS URLs.  Moving existing https external dependencies to http by pushing them to our S3 bucket.