### PR TITLE
Fixes for Mac build and crash on startup

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -940,14 +940,12 @@ void Application::initializeGL() {
     qCDebug(interfaceapp) << "Created Display Window.";
 
     // initialize glut for shape drawing; Qt apparently initializes it on OS X
-    #ifndef __APPLE__
-    static bool isInitialized = false;
-    if (isInitialized) {
+    if (_isGLInitialized) {
         return;
     } else {
-        isInitialized = true;
+        _isGLInitialized = true;
     }
-    #endif
+
     // Where the gpuContext is initialized and where the TRUE Backend is created and assigned
     gpu::Context::init<gpu::GLBackend>();
     _gpuContext = std::make_shared<gpu::Context>();
@@ -1059,7 +1057,9 @@ void Application::paintGL() {
         _lastFramesPerSecondUpdate = now;
     }
 
-    idle(now);
+    if (_isGLInitialized) {
+        idle(now);
+    }
 
     PROFILE_RANGE(__FUNCTION__);
     PerformanceTimer perfTimer("paintGL");

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -414,7 +414,7 @@ private:
 
     bool _dependencyManagerIsSetup;
 
-    OffscreenGlCanvas* _offscreenContext {nullptr};
+    OffscreenGlCanvas* _offscreenContext { nullptr };
     DisplayPluginPointer _displayPlugin;
     InputPluginList _activeInputPlugins;
 
@@ -548,7 +548,7 @@ private:
     quint64 _lastSimsPerSecondUpdate = 0;
     bool _isForeground = true; // starts out assumed to be in foreground
     bool _inPaint = false;
-    bool _isGLInitialized {false};
+    bool _isGLInitialized { false };
 };
 
 #endif // hifi_Application_h

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -414,7 +414,7 @@ private:
 
     bool _dependencyManagerIsSetup;
 
-    OffscreenGlCanvas* _offscreenContext;
+    OffscreenGlCanvas* _offscreenContext {nullptr};
     DisplayPluginPointer _displayPlugin;
     InputPluginList _activeInputPlugins;
 
@@ -548,6 +548,7 @@ private:
     quint64 _lastSimsPerSecondUpdate = 0;
     bool _isForeground = true; // starts out assumed to be in foreground
     bool _inPaint = false;
+    bool _isGLInitialized {false};
 };
 
 #endif // hifi_Application_h

--- a/interface/src/devices/3DConnexionClient.h
+++ b/interface/src/devices/3DConnexionClient.h
@@ -218,7 +218,7 @@ public:
     void handleAxisEvent();
 };
 
-#endif
+#else // #if 0
 
 #include <QObject>
 #include <QLibrary>
@@ -234,5 +234,7 @@ public:
 public slots:
     void toggleConnexion(bool shouldEnable) {};
 };
+
+#endif
 
 #endif // defined(hifi_3DConnexionClient_h)

--- a/interface/src/devices/3DConnexionClient.h
+++ b/interface/src/devices/3DConnexionClient.h
@@ -220,4 +220,19 @@ public:
 
 #endif
 
+#include <QObject>
+#include <QLibrary>
+
+// stub
+class ConnexionClient : public QObject {
+    Q_OBJECT
+public:
+    static ConnexionClient& getInstance();
+    void init() {};
+    void destroy() {};
+    bool Is3dmouseAttached() { return false; };
+public slots:
+    void toggleConnexion(bool shouldEnable) {};
+};
+
 #endif // defined(hifi_3DConnexionClient_h)

--- a/libraries/animation/src/AvatarRig.cpp
+++ b/libraries/animation/src/AvatarRig.cpp
@@ -13,7 +13,7 @@
 
 /// Updates the state of the joint at the specified index.
 void AvatarRig::updateJointState(int index, glm::mat4 rootTransform) {
-    if (index < 0 && index >= _jointStates.size()) {
+    if (index < 0 || index >= _jointStates.size()) {
         return; // bail
     }
     JointState& state = _jointStates[index];

--- a/libraries/input-plugins/src/input-plugins/SpacemouseManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/SpacemouseManager.cpp
@@ -130,6 +130,9 @@ void SpacemouseManager::ManagerFocusOutEvent() {
     instance->focusOutEvent();
 }
 
+void SpacemouseManager::init() {
+}
+
 #ifdef HAVE_3DCONNEXIONCLIENT
 
 #ifdef Q_OS_WIN

--- a/libraries/input-plugins/src/input-plugins/SpacemouseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SpacemouseManager.h
@@ -11,8 +11,6 @@
 #ifndef hifi_SpacemouseManager_h
 #define hifi_SpacemouseManager_h
 
-#define HAVE_3DCONNEXIONCLIENT
-
 #include <QObject>
 #include <QLibrary>
 #include <controllers/UserInputMapper.h>

--- a/libraries/input-plugins/src/input-plugins/SpacemouseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SpacemouseManager.h
@@ -25,7 +25,7 @@ class SpacemouseManager : public QObject {
 public:
     static SpacemouseManager& getInstance();
     void ManagerFocusOutEvent();
-    void init() {};
+    void init();
     void destroy() {};
     bool Is3dmouseAttached() { return false; };
     public slots:


### PR DESCRIPTION
For some reason the qt code gen is getting confused by the #if 0
in 3DConnextionClient.h, so I added a stub implementation.  This should fix this error:

    /Users/ajt/code/hifi/interface/src/devices/3DConnexionClient.h:0: Note: No relevant classes found. No output generated.
    Command /bin/sh emitted errors but did not return a nonzero exit code to indicate failure

In Application.cpp the change of moving idle into paintGL had a sideeffect
of calling OffscreenGlCanvas before it was initialized.  To work around this
I added a guard to prevent calling idle before all the gl windows/widgets have
been initialized.