### PR TITLE
Fix crash in Oculus simulator

### DIFF
--- a/plugins/oculus/src/OculusDebugDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDebugDisplayPlugin.cpp
@@ -25,7 +25,7 @@ bool OculusDebugDisplayPlugin::isSupported() const {
 }
 
 void OculusDebugDisplayPlugin::customizeContext() {
-    WindowOpenGLDisplayPlugin::customizeContext();
+    OculusBaseDisplayPlugin::customizeContext();
     enableVsync(false);
 }
 


### PR DESCRIPTION
Simulator code wasn't calling the right base class for `customizeContext` and so missing out on the required glew initialization.