### PR TITLE
Fixing step yaw to move by consistent amounts, be 'tappable'

### DIFF
--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -12,28 +12,49 @@
         { "from": "Keyboard.W", "when": "Keyboard.Shift", "to": "Actions.PITCH_UP" },
 
         
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
+        { "comment" : "Mouse turn need to be small continuous increments",
+          "from": { "makeAxis" : [
+                [ "Keyboard.MouseMoveLeft" ],
+                [ "Keyboard.MouseMoveRight" ] 
+            ]
+          },
           "when": [ "Application.InHMD", "Application.ComfortMode", "Keyboard.RightMouseButton" ],
           "to": "Actions.StepYaw",
           "filters":
             [
                 "constrainToInteger",
-                { "type": "pulse", "interval": 0.5 },
-                { "type": "scale", "scale": 15 }
+                { "type": "pulse", "interval": 0.2 },
+                { "type": "scale", "scale": 22.5 }
+            ]
+        },
+
+        { "comment" : "Touchpad turn need to be small continuous increments, but without the RMB constraint",
+          "from": { "makeAxis" : [
+                [ "Keyboard.TouchpadLeft" ],
+                [ "Keyboard.TouchpadRight" ] 
+            ] 
+          },
+          "when": [ "Application.InHMD", "Application.ComfortMode" ],
+          "to": "Actions.StepYaw",
+          "filters":
+            [
+                "constrainToInteger",
+                { "type": "pulse", "interval": 0.2 },
+                { "type": "scale", "scale": 22.5 }
             ]
         },
 
         { "from": { "makeAxis" : [
-                ["Keyboard.A", "Keyboard.Left", "Keyboard.TouchpadLeft"],
-                ["Keyboard.D", "Keyboard.Right", "Keyboard.TouchpadRight"]
+                ["Keyboard.A", "Keyboard.Left" ],
+                ["Keyboard.D", "Keyboard.Right"]
             ]
           },
           "when": [ "Application.InHMD", "Application.ComfortMode" ],
           "to": "Actions.StepYaw",
           "filters":
             [
-                { "type": "pulse", "interval": 0.5 },
-                { "type": "scale", "scale": 15 }
+                { "type": "pulse", "interval": 0.5, "resetOnZero": true },
+                { "type": "scale", "scale": 22.5 }
             ]
         },
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2795,7 +2795,7 @@ void Application::update(float deltaTime) {
                 float timeFactor = EXPECTED_FRAME_RATE * deltaTime;
                 myAvatar->setDriveKeys(PITCH, -1.0f * userInputMapper->getActionState(controller::Action::PITCH) / timeFactor);
                 myAvatar->setDriveKeys(YAW, -1.0f * userInputMapper->getActionState(controller::Action::YAW) / timeFactor);
-                myAvatar->setDriveKeys(STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW) / timeFactor);
+                myAvatar->setDriveKeys(STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW));
             }
         }
         myAvatar->setDriveKeys(ZOOM, userInputMapper->getActionState(controller::Action::TRANSLATE_CAMERA_Z));

--- a/libraries/controllers/src/controllers/impl/filters/PulseFilter.cpp
+++ b/libraries/controllers/src/controllers/impl/filters/PulseFilter.cpp
@@ -13,7 +13,7 @@
 
 using namespace controller;
 
-
+const float PulseFilter::DEFAULT_LAST_EMIT_TIME = -::std::numeric_limits<float>::max();
 
 float PulseFilter::apply(float value) const {
     float result = 0.0f;
@@ -25,13 +25,22 @@ float PulseFilter::apply(float value) const {
             _lastEmitTime = now;
             result = value;
         }
+    } else if (_resetOnZero) {
+        _lastEmitTime = DEFAULT_LAST_EMIT_TIME;
     }
 
     return result;
 }
 
 bool PulseFilter::parseParameters(const QJsonValue& parameters) {
-    static const QString JSON_MIN = QStringLiteral("interval");
-    return parseSingleFloatParameter(parameters, JSON_MIN, _interval);
+    static const QString JSON_INTERVAL = QStringLiteral("interval");
+    static const QString JSON_RESET = QStringLiteral("resetOnZero");
+    if (parameters.isObject()) {
+        auto obj = parameters.toObject();
+        if (obj.contains(JSON_RESET)) {
+            _resetOnZero = obj[JSON_RESET].toBool();
+        }
+    }
+    return parseSingleFloatParameter(parameters, JSON_INTERVAL, _interval);
 }
 

--- a/libraries/controllers/src/controllers/impl/filters/PulseFilter.h
+++ b/libraries/controllers/src/controllers/impl/filters/PulseFilter.h
@@ -21,14 +21,15 @@ public:
     PulseFilter() {}
     PulseFilter(float interval) : _interval(interval) {}
 
-
     virtual float apply(float value) const override;
 
     virtual bool parseParameters(const QJsonValue& parameters);
 
 private:
-    mutable float _lastEmitTime { -::std::numeric_limits<float>::max() };
-    float _interval = 1.0f;
+    static const float DEFAULT_LAST_EMIT_TIME;
+    mutable float _lastEmitTime { DEFAULT_LAST_EMIT_TIME };
+    bool _resetOnZero { false };
+    float _interval { 1.0f };
 };
 
 }


### PR DESCRIPTION
This lets you tap the keyboard to turn faster than the normal interval of 0.5 seconds.  It also fixes the angle turned which was previously somewhat random due to incorrectly being divided by a timeslice (which isn't a valid thing to do for pulsed inputs).