### PR TITLE
Agent avatar sequenceNumber

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -267,7 +267,10 @@ void Agent::processAgentAvatarAndAudio(float deltaTime) {
 
         QByteArray avatarByteArray = _avatarData->toByteArray(true, randFloat() < AVATAR_SEND_FULL_UPDATE_RATIO);
         _avatarData->doneEncoding(true);
-        auto avatarPacket = NLPacket::create(PacketType::AvatarData, avatarByteArray.size());
+
+        static AvatarDataSequenceNumber sequenceNumber = 0;
+        auto avatarPacket = NLPacket::create(PacketType::AvatarData, avatarByteArray.size() + sizeof(sequenceNumber));
+        avatarPacket->writePrimitive(sequenceNumber++);
 
         avatarPacket->write(avatarByteArray);
 


### PR DESCRIPTION
Update agent's outgoing avatar data packet with sequenceNumber as is now used in interface's MyAvatar.

Without this, the avatar mixer does not properly interpret the data it receives from the avatar agent.