### PR TITLE
Add Ability to Pass Parameters When Calling Methods on Entities

### DIFF
--- a/examples/entityScripts/createParamsEntity.js
+++ b/examples/entityScripts/createParamsEntity.js
@@ -1,11 +1,10 @@
 //
 //  createParamsEntity.js
 //
-//
-//  Additions by James B. Pollack @imgntn on 11/6/2015
+//  Created by James B. Pollack @imgntn on 11/6/2015
 //  Copyright 2015 High Fidelity, Inc.
 //
-//  This script demonstrates creates an entity and sends it a method call with parameters.
+//  This script demonstrates creating an entity and sending it a method call with parameters.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/examples/entityScripts/createParamsEntity.js
+++ b/examples/entityScripts/createParamsEntity.js
@@ -1,0 +1,43 @@
+//
+//  createParamsEntity.js
+//
+//
+//  Additions by James B. Pollack @imgntn on 11/6/2015
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  This script demonstrates creates an entity and sends it a method call with parameters.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+var PARAMS_SCRIPT_URL = Script.resolvePath('paramsEntity.js');
+
+var testEntity = Entities.addEntity({
+    name: 'paramsTestEntity',
+    dimensions: {
+        x: 1,
+        y: 1,
+        z: 1
+    },
+    type: 'Box',
+    position: {
+        x: 0,
+        y: 0,
+        z: 0
+    },
+    visible: false,
+    script: PARAMS_SCRIPT_URL
+});
+
+
+var subData1 = ['apple', 'banana', 'orange'];
+var subData2 = {
+    thing: 1,
+    otherThing: 2
+};
+var data = [subData1, JSON.stringify(subData2), 'third'];
+Script.setTimeout(function() {
+    print('sending data to entity')
+    Entities.callEntityMethod(testEntity, 'testParams', data);
+}, 1500)

--- a/examples/entityScripts/paramsEntity.js
+++ b/examples/entityScripts/paramsEntity.js
@@ -1,0 +1,45 @@
+//
+//  paramsEntity.js
+//
+//  Script Type: Entity
+//
+//  Additions by James B. Pollack @imgntn on 11/6/2015
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  This script demonstrates how to recieve parameters from a Entities.callEntityMethod call
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+(function() {
+
+    function ParamsEntity() {
+        return;
+    }
+
+    ParamsEntity.prototype = {
+        preload: function(entityID) {
+            print('entity loaded')
+            this.entityID = entityID;
+        },
+        testParams: function(myID, paramsArray) {
+
+            paramsArray.forEach(function(param) {
+                var p;
+                try {
+                    p = JSON.parse(param);
+                    print("it's a json param")
+                    print('json param property:' + p.thing);
+                } catch (err) {
+                    print('not a json param')
+                    p = param;
+                    print('param is:' + p);
+                }
+
+            });
+
+        }
+
+    }
+
+    return new ParamsEntity();
+});

--- a/examples/entityScripts/paramsEntity.js
+++ b/examples/entityScripts/paramsEntity.js
@@ -3,7 +3,7 @@
 //
 //  Script Type: Entity
 //
-//  Additions by James B. Pollack @imgntn on 11/6/2015
+//  Created by James B. Pollack @imgntn on 11/6/2015
 //  Copyright 2015 High Fidelity, Inc.
 //
 //  This script demonstrates how to recieve parameters from a Entities.callEntityMethod call

--- a/libraries/entities/src/EntitiesScriptEngineProvider.h
+++ b/libraries/entities/src/EntitiesScriptEngineProvider.h
@@ -20,6 +20,7 @@
 class EntitiesScriptEngineProvider {
 public:
     virtual void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName) = 0;
+    virtual void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params) = 0;
 };
 
 #endif // hifi_EntitiesScriptEngineProvider_h

--- a/libraries/entities/src/EntitiesScriptEngineProvider.h
+++ b/libraries/entities/src/EntitiesScriptEngineProvider.h
@@ -19,8 +19,7 @@
 
 class EntitiesScriptEngineProvider {
 public:
-    virtual void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName) = 0;
-    virtual void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params) = 0;
+    virtual void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params = QStringList()) = 0;
 };
 
 #endif // hifi_EntitiesScriptEngineProvider_h

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -217,13 +217,19 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
     }
 }
 
+void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method) {
+    if (_entitiesScriptEngine) {
+        EntityItemID entityID{ id };
+        _entitiesScriptEngine->callEntityScriptMethod(entityID, method);
+    }
+}
+
 void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method, const QStringList& params) {
     if (_entitiesScriptEngine) {
         EntityItemID entityID{ id };
         _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params);
     }
 }
-
 
 QUuid EntityScriptingInterface::findClosestEntity(const glm::vec3& center, float radius) const {
     EntityItemID result;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -217,10 +217,10 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
     }
 }
 
-void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method) {
+void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method, const QStringList& params) {
     if (_entitiesScriptEngine) {
         EntityItemID entityID{ id };
-        _entitiesScriptEngine->callEntityScriptMethod(entityID, method);
+        _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params);
     }
 }
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -217,13 +217,6 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
     }
 }
 
-void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method) {
-    if (_entitiesScriptEngine) {
-        EntityItemID entityID{ id };
-        _entitiesScriptEngine->callEntityScriptMethod(entityID, method);
-    }
-}
-
 void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method, const QStringList& params) {
     if (_entitiesScriptEngine) {
         EntityItemID entityID{ id };

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -94,7 +94,7 @@ public slots:
     /// engine. If the entity does not have an entity script or the method does not exist, this call will have
     /// no effect.
     Q_INVOKABLE void callEntityMethod(QUuid entityID, const QString& method);
-
+    Q_INVOKABLE void callEntityMethod(QUuid entityID, const QString& method, const QStringList& params);
     /// finds the closest model to the center point, within the radius
     /// will return a EntityItemID.isKnownID = false if no models are in the radius
     /// this function will not find any models in script engine contexts which don't have access to models

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -15,6 +15,7 @@
 #define hifi_EntityScriptingInterface_h
 
 #include <QtCore/QObject>
+#include <QtCore/QStringList>
 
 #include <DependencyManager.h>
 #include <Octree.h>

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -94,8 +94,8 @@ public slots:
     /// Allows a script to call a method on an entity's script. The method will execute in the entity script
     /// engine. If the entity does not have an entity script or the method does not exist, this call will have
     /// no effect.
-    Q_INVOKABLE void callEntityMethod(QUuid entityID, const QString& method);
-    Q_INVOKABLE void callEntityMethod(QUuid entityID, const QString& method, const QStringList& params);
+    Q_INVOKABLE void callEntityMethod(QUuid entityID, const QString& method, const QStringList& params = QStringList());
+
     /// finds the closest model to the center point, within the radius
     /// will return a EntityItemID.isKnownID = false if no models are in the radius
     /// this function will not find any models in script engine contexts which don't have access to models

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1170,37 +1170,6 @@ void ScriptEngine::refreshFileScript(const EntityItemID& entityID) {
     recurseGuard = false;
 }
 
-
-void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName) {
-    if (QThread::currentThread() != thread()) {
-        #ifdef THREAD_DEBUGGING
-        qDebug() << "*** WARNING *** ScriptEngine::callEntityScriptMethod() called on wrong thread [" << QThread::currentThread() << "], invoking on correct thread [" << thread() << "]  "
-            "entityID:" << entityID << "methodName:" << methodName;
-        #endif
-
-        QMetaObject::invokeMethod(this, "callEntityScriptMethod",
-            Q_ARG(const EntityItemID&, entityID),
-            Q_ARG(const QString&, methodName));
-        return;
-    }
-    #ifdef THREAD_DEBUGGING
-    qDebug() << "ScriptEngine::callEntityScriptMethod() called on correct thread [" << thread() << "]  "
-        "entityID:" << entityID << "methodName:" << methodName;
-    #endif
-
-    refreshFileScript(entityID);
-    if (_entityScripts.contains(entityID)) {
-        EntityScriptDetails details = _entityScripts[entityID];
-        QScriptValue entityScript = details.scriptObject; // previously loaded
-        if (entityScript.property(methodName).isFunction()) {
-            QScriptValueList args;
-            args << entityID.toScriptValue(this);
-            entityScript.property(methodName).call(entityScript, args);
-        }
-
-    }
-}
-
 void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params) {
     if (QThread::currentThread() != thread()) {
         #ifdef THREAD_DEBUGGING

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -18,6 +18,7 @@
 #include <QtNetwork/QNetworkReply>
 #include <QtScript/QScriptEngine>
 #include <QtScript/QScriptValue>
+#include <QtCore/QStringList>
 
 #include <AudioConstants.h>
 #include <AudioEffectOptions.h>
@@ -1225,6 +1226,7 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
         if (entityScript.property(methodName).isFunction()) {
             QScriptValueList args;
             args << entityID.toScriptValue(this);
+            args << qScriptValueFromSequence(this, params);
             entityScript.property(methodName).call(entityScript, args);
         }
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -116,8 +116,7 @@ public:
     Q_INVOKABLE void loadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload = false); // will call the preload method once loaded
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
-    Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName);
-    Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params);
+    Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params = QStringList());
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const MouseEvent& event);
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const EntityItemID& otherID, const Collision& collision);
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -116,6 +116,7 @@ public:
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName);
+    Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params);
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const MouseEvent& event);
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const EntityItemID& otherID, const Collision& collision);
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -19,6 +19,7 @@
 #include <QtCore/QSet>
 #include <QtCore/QWaitCondition>
 #include <QtScript/QScriptEngine>
+#include <QtCore/QStringList>
 
 #include <AnimationCache.h>
 #include <AnimVariant.h>


### PR DESCRIPTION
This PR adds some useful functionality to entities.  Specifically, when using Entities.callEntityMethod users can now pass an array of parameters with the call that can be accessed from the callee.  

``` Entities.callEntityMethod('entityID','someAwesomeMethod',['array','of','parameters'] ```

and on the entity...

``` someAwesomeMethod:function(myID,parameters){print('parameters are:' + parameters};```