### PR TITLE
Add More Methods to stringHelpers.js

### DIFF
--- a/examples/libraries/stringHelpers.js
+++ b/examples/libraries/stringHelpers.js
@@ -1,39 +1,36 @@
-
-
-
 if (typeof String.prototype.fileName !== "function") {
-    String.prototype.fileName = function () {
+    String.prototype.fileName = function() {
         return this.replace(/^(.*[\/\\])*/, "");
     };
 }
 
 if (typeof String.prototype.fileBase !== "function") {
-    String.prototype.fileBase = function () {
+    String.prototype.fileBase = function() {
         var filename = this.fileName();
         return filename.slice(0, filename.indexOf("."));
     };
 }
 
 if (typeof String.prototype.fileType !== "function") {
-    String.prototype.fileType = function () {
+    String.prototype.fileType = function() {
         return this.slice(this.lastIndexOf(".") + 1);
     };
 }
 
 if (typeof String.prototype.path !== "function") {
-    String.prototype.path = function () {
+    String.prototype.path = function() {
         return this.replace(/[\\\/][^\\\/]*$/, "");
     };
 }
 
 if (typeof String.prototype.regExpEscape !== "function") {
-    String.prototype.regExpEscape = function () {
+    String.prototype.regExpEscape = function() {
         return this.replace(/([$\^.+*?|\\\/{}()\[\]])/g, '\\$1');
     };
 }
 
 if (typeof String.prototype.toArrayBuffer !== "function") {
-    String.prototype.toArrayBuffer = function () {
+    String.prototype.toArrayBuffer = function() {
         var length,
             buffer,
             view,
@@ -63,4 +60,417 @@ if (typeof String.prototype.toArrayBuffer !== "function") {
 
         return buffer;
     };
+}
+// Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*! https://mths.be/includes v1.0.0 by @mathias */
+if (!String.prototype.includes) {
+    (function() {
+        'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+        var toString = {}.toString;
+        var defineProperty = (function() {
+            // IE 8 only supports `Object.defineProperty` on DOM elements
+            try {
+                var object = {};
+                var $defineProperty = Object.defineProperty;
+                var result = $defineProperty(object, object, object) && $defineProperty;
+            } catch (error) {}
+            return result;
+        }());
+        var indexOf = ''.indexOf;
+        var includes = function(search) {
+            if (this == null) {
+                throw TypeError();
+            }
+            var string = String(this);
+            if (search && toString.call(search) == '[object RegExp]') {
+                throw TypeError();
+            }
+            var stringLength = string.length;
+            var searchString = String(search);
+            var searchLength = searchString.length;
+            var position = arguments.length > 1 ? arguments[1] : undefined;
+            // `ToInteger`
+            var pos = position ? Number(position) : 0;
+            if (pos != pos) { // better `isNaN`
+                pos = 0;
+            }
+            var start = Math.min(Math.max(pos, 0), stringLength);
+            // Avoid the `indexOf` call if no match is possible
+            if (searchLength + start > stringLength) {
+                return false;
+            }
+            return indexOf.call(string, searchString, pos) != -1;
+        };
+        if (defineProperty) {
+            defineProperty(String.prototype, 'includes', {
+                'value': includes,
+                'configurable': true,
+                'writable': true
+            });
+        } else {
+            String.prototype.includes = includes;
+        }
+    }());
+}
+
+/*! https://mths.be/startswith v0.2.0 by @mathias */
+if (!String.prototype.startsWith) {
+    (function() {
+        'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+        var defineProperty = (function() {
+            // IE 8 only supports `Object.defineProperty` on DOM elements
+            try {
+                var object = {};
+                var $defineProperty = Object.defineProperty;
+                var result = $defineProperty(object, object, object) && $defineProperty;
+            } catch (error) {}
+            return result;
+        }());
+        var toString = {}.toString;
+        var startsWith = function(search) {
+            if (this == null) {
+                throw TypeError();
+            }
+            var string = String(this);
+            if (search && toString.call(search) == '[object RegExp]') {
+                throw TypeError();
+            }
+            var stringLength = string.length;
+            var searchString = String(search);
+            var searchLength = searchString.length;
+            var position = arguments.length > 1 ? arguments[1] : undefined;
+            // `ToInteger`
+            var pos = position ? Number(position) : 0;
+            if (pos != pos) { // better `isNaN`
+                pos = 0;
+            }
+            var start = Math.min(Math.max(pos, 0), stringLength);
+            // Avoid the `indexOf` call if no match is possible
+            if (searchLength + start > stringLength) {
+                return false;
+            }
+            var index = -1;
+            while (++index < searchLength) {
+                if (string.charCodeAt(start + index) != searchString.charCodeAt(index)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        if (defineProperty) {
+            defineProperty(String.prototype, 'startsWith', {
+                'value': startsWith,
+                'configurable': true,
+                'writable': true
+            });
+        } else {
+            String.prototype.startsWith = startsWith;
+        }
+    }());
+}
+if (!String.prototype.endsWith) {
+    (function() {
+        'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+        var defineProperty = (function() {
+            // IE 8 only supports `Object.defineProperty` on DOM elements
+            try {
+                var object = {};
+                var $defineProperty = Object.defineProperty;
+                var result = $defineProperty(object, object, object) && $defineProperty;
+            } catch (error) {}
+            return result;
+        }());
+        var toString = {}.toString;
+        var endsWith = function(search) {
+            if (this == null) {
+                throw TypeError();
+            }
+            var string = String(this);
+            if (search && toString.call(search) == '[object RegExp]') {
+                throw TypeError();
+            }
+            var stringLength = string.length;
+            var searchString = String(search);
+            var searchLength = searchString.length;
+            var pos = stringLength;
+            if (arguments.length > 1) {
+                var position = arguments[1];
+                if (position !== undefined) {
+                    // `ToInteger`
+                    pos = position ? Number(position) : 0;
+                    if (pos != pos) { // better `isNaN`
+                        pos = 0;
+                    }
+                }
+            }
+            var end = Math.min(Math.max(pos, 0), stringLength);
+            var start = end - searchLength;
+            if (start < 0) {
+                return false;
+            }
+            var index = -1;
+            while (++index < searchLength) {
+                if (string.charCodeAt(start + index) != searchString.charCodeAt(index)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        if (defineProperty) {
+            defineProperty(String.prototype, 'endsWith', {
+                'value': endsWith,
+                'configurable': true,
+                'writable': true
+            });
+        } else {
+            String.prototype.endsWith = endsWith;
+        }
+    }());
+}
+
+/*! https://mths.be/repeat v0.2.0 by @mathias */
+if (!String.prototype.repeat) {
+    (function() {
+        'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+        var defineProperty = (function() {
+            // IE 8 only supports `Object.defineProperty` on DOM elements
+            try {
+                var object = {};
+                var $defineProperty = Object.defineProperty;
+                var result = $defineProperty(object, object, object) && $defineProperty;
+            } catch (error) {}
+            return result;
+        }());
+        var repeat = function(count) {
+            if (this == null) {
+                throw TypeError();
+            }
+            var string = String(this);
+            // `ToInteger`
+            var n = count ? Number(count) : 0;
+            if (n != n) { // better `isNaN`
+                n = 0;
+            }
+            // Account for out-of-bounds indices
+            if (n < 0 || n == Infinity) {
+                throw RangeError();
+            }
+            var result = '';
+            while (n) {
+                if (n % 2 == 1) {
+                    result += string;
+                }
+                if (n > 1) {
+                    string += string;
+                }
+                n >>= 1;
+            }
+            return result;
+        };
+        if (defineProperty) {
+            defineProperty(String.prototype, 'repeat', {
+                'value': repeat,
+                'configurable': true,
+                'writable': true
+            });
+        } else {
+            String.prototype.repeat = repeat;
+        }
+    }());
+}
+
+if (!String.prototype.at) {
+    (function() {
+        'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+        var defineProperty = (function() {
+            // IE 8 only supports `Object.defineProperty` on DOM elements.
+            try {
+                var object = {};
+                var $defineProperty = Object.defineProperty;
+                var result = $defineProperty(object, object, object) && $defineProperty;
+            } catch (exception) {}
+            return result;
+        }());
+        var at = function(position) {
+            if (this == null) {
+                throw TypeError();
+            }
+            var string = String(this);
+            var size = string.length;
+            // `ToInteger`
+            var index = position ? Number(position) : 0;
+            if (index != index) { // better `isNaN`
+                index = 0;
+            }
+            // Account for out-of-bounds indices
+            // The odd lower bound is because the ToInteger operation is
+            // going to round `n` to `0` for `-1 < n <= 0`.
+            if (index <= -1 || index >= size) {
+                return '';
+            }
+            // Second half of `ToInteger`
+            index = index | 0;
+            // Get the first code unit and code unit value
+            var cuFirst = string.charCodeAt(index);
+            var cuSecond;
+            var nextIndex = index + 1;
+            var len = 1;
+            if ( // Check if it’s the start of a surrogate pair.
+                cuFirst >= 0xD800 && cuFirst <= 0xDBFF && // high surrogate
+                size > nextIndex // there is a next code unit
+            ) {
+                cuSecond = string.charCodeAt(nextIndex);
+                if (cuSecond >= 0xDC00 && cuSecond <= 0xDFFF) { // low surrogate
+                    len = 2;
+                }
+            }
+            return string.slice(index, index + len);
+        };
+        if (defineProperty) {
+            defineProperty(String.prototype, 'at', {
+                'value': at,
+                'configurable': true,
+                'writable': true
+            });
+        } else {
+            String.prototype.at = at;
+        }
+    }());
+}
+
+/*! https://mths.be/codepointat v0.2.0 by @mathias */
+if (!String.prototype.codePointAt) {
+    (function() {
+        'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+        var defineProperty = (function() {
+            // IE 8 only supports `Object.defineProperty` on DOM elements
+            try {
+                var object = {};
+                var $defineProperty = Object.defineProperty;
+                var result = $defineProperty(object, object, object) && $defineProperty;
+            } catch (error) {}
+            return result;
+        }());
+        var codePointAt = function(position) {
+            if (this == null) {
+                throw TypeError();
+            }
+            var string = String(this);
+            var size = string.length;
+            // `ToInteger`
+            var index = position ? Number(position) : 0;
+            if (index != index) { // better `isNaN`
+                index = 0;
+            }
+            // Account for out-of-bounds indices:
+            if (index < 0 || index >= size) {
+                return undefined;
+            }
+            // Get the first code unit
+            var first = string.charCodeAt(index);
+            var second;
+            if ( // check if it’s the start of a surrogate pair
+                first >= 0xD800 && first <= 0xDBFF && // high surrogate
+                size > index + 1 // there is a next code unit
+            ) {
+                second = string.charCodeAt(index + 1);
+                if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate
+                    // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+                    return (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
+                }
+            }
+            return first;
+        };
+        if (defineProperty) {
+            defineProperty(String.prototype, 'codePointAt', {
+                'value': codePointAt,
+                'configurable': true,
+                'writable': true
+            });
+        } else {
+            String.prototype.codePointAt = codePointAt;
+        }
+    }());
+}
+
+/*! https://mths.be/fromcodepoint v0.2.1 by @mathias */
+if (!String.fromCodePoint) {
+    (function() {
+        var defineProperty = (function() {
+            // IE 8 only supports `Object.defineProperty` on DOM elements
+            try {
+                var object = {};
+                var $defineProperty = Object.defineProperty;
+                var result = $defineProperty(object, object, object) && $defineProperty;
+            } catch (error) {}
+            return result;
+        }());
+        var stringFromCharCode = String.fromCharCode;
+        var floor = Math.floor;
+        var fromCodePoint = function(_) {
+            var MAX_SIZE = 0x4000;
+            var codeUnits = [];
+            var highSurrogate;
+            var lowSurrogate;
+            var index = -1;
+            var length = arguments.length;
+            if (!length) {
+                return '';
+            }
+            var result = '';
+            while (++index < length) {
+                var codePoint = Number(arguments[index]);
+                if (!isFinite(codePoint) || // `NaN`, `+Infinity`, or `-Infinity`
+                    codePoint < 0 || // not a valid Unicode code point
+                    codePoint > 0x10FFFF || // not a valid Unicode code point
+                    floor(codePoint) != codePoint // not an integer
+                ) {
+                    throw RangeError('Invalid code point: ' + codePoint);
+                }
+                if (codePoint <= 0xFFFF) { // BMP code point
+                    codeUnits.push(codePoint);
+                } else { // Astral code point; split in surrogate halves
+                    // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+                    codePoint -= 0x10000;
+                    highSurrogate = (codePoint >> 10) + 0xD800;
+                    lowSurrogate = (codePoint % 0x400) + 0xDC00;
+                    codeUnits.push(highSurrogate, lowSurrogate);
+                }
+                if (index + 1 == length || codeUnits.length > MAX_SIZE) {
+                    result += stringFromCharCode.apply(null, codeUnits);
+                    codeUnits.length = 0;
+                }
+            }
+            return result;
+        };
+        if (defineProperty) {
+            defineProperty(String, 'fromCodePoint', {
+                'value': fromCodePoint,
+                'configurable': true,
+                'writable': true
+            });
+        } else {
+            String.fromCodePoint = fromCodePoint;
+        }
+    }());
 }


### PR DESCRIPTION
This PR adds some polyfills that provide the following useful string methods:

```String.prototype.includes
String.prototype.startsWith
String.prototype.endsWith
String.prototype.repeat
String.prototype.at
String.prototype.fromCodePoint
String.prototype.codePointAt