### PR TITLE
Added cache-extract to Tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,3 +10,6 @@ set_target_properties(udt-test PROPERTIES FOLDER "Tools")
 
 add_subdirectory(vhacd-util)
 set_target_properties(vhacd-util PROPERTIES FOLDER "Tools")
+
+add_subdirectory(cache-extract)
+set_target_properties(cache-extract PROPERTIES FOLDER "Tools")

--- a/tools/cache-extract/CMakeLists.txt
+++ b/tools/cache-extract/CMakeLists.txt
@@ -3,4 +3,5 @@ set(TARGET_NAME cache-extract)
 setup_hifi_project()
 
 link_hifi_libraries()
+copy_dlls_beside_windows_executable()
 

--- a/tools/cache-extract/CMakeLists.txt
+++ b/tools/cache-extract/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(TARGET_NAME cache-extract)
+
+setup_hifi_project()
+
+link_hifi_libraries()
+

--- a/tools/cache-extract/src/CacheExtractApp.cpp
+++ b/tools/cache-extract/src/CacheExtractApp.cpp
@@ -1,0 +1,125 @@
+//
+//  CacheExtractApp.cpp
+//  tools/cache-extract/src
+//
+//  Created by Anthony Thibault on 11/6/2015.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "CacheExtractApp.h"
+#include <QDebug>
+#include <QStandardPaths>
+#include <QDir>
+#include <QtNetwork/QAbstractNetworkCache>
+
+// extracted from qnetworkdiskcache.cpp
+#define CACHE_VERSION 8
+enum {
+   CacheMagic = 0xe8,
+   CurrentCacheVersion = CACHE_VERSION
+};
+#define DATA_DIR QLatin1String("data")
+
+CacheExtractApp::CacheExtractApp(int& argc, char** argv) :
+    QCoreApplication(argc, argv)
+{
+    QString myDataLoc = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    int lastSlash = myDataLoc.lastIndexOf(QDir::separator());
+    QString cachePath = myDataLoc.leftRef(lastSlash).toString() + QDir::separator() +
+        "High Fidelity" + QDir::separator() + "Interface" + QDir::separator() +
+        DATA_DIR + QString::number(CACHE_VERSION) + QLatin1Char('/');
+
+    QString outputPath = myDataLoc.leftRef(lastSlash).toString() + QDir::separator() +
+        "High Fidelity" + QDir::separator() + "Interface" + QDir::separator() + "extracted";
+
+    qDebug() << "Searching cachePath = " << cachePath << "...";
+
+    // build list of files
+    QList<QString> fileList;
+    QDir dir(cachePath);
+    dir.setFilter(QDir::AllDirs | QDir::NoDotAndDotDot);
+    QFileInfoList list = dir.entryInfoList();
+    for (int i = 0; i < list.size(); ++i) {
+        QFileInfo fileInfo = list.at(i);
+        if (fileInfo.isDir()) {
+            QDir subDir(fileInfo.filePath());
+            subDir.setFilter(QDir::Files);
+            QFileInfoList subList = subDir.entryInfoList();
+            for (int j = 0; j < subList.size(); ++j) {
+                fileList << subList.at(j).filePath();
+            }
+        }
+    }
+
+    // dump each cache file into the outputPath
+    for (int i = 0; i < fileList.size(); ++i) {
+        QByteArray contents;
+        MyMetaData metaData;
+        if (extractFile(fileList.at(i), metaData, contents)) {
+            QString outFileName = outputPath + metaData.url.path();
+            int lastSlash = outFileName.lastIndexOf(QDir::separator());
+            QString outDirName = outFileName.leftRef(lastSlash).toString();
+            QDir dir(outputPath);
+            dir.mkpath(outDirName);
+            QFile out(outFileName);
+            if (out.open(QIODevice::WriteOnly)) {
+                out.write(contents);
+                out.close();
+            }
+        } else {
+            qCritical() << "Error extracting = " << fileList.at(i);
+        }
+    }
+
+    QMetaObject::invokeMethod(this, "quit", Qt::QueuedConnection);
+}
+
+bool CacheExtractApp::extractFile(const QString& filePath, MyMetaData& metaData, QByteArray& data) const {
+    QFile f(filePath);
+    if (!f.open(QIODevice::ReadOnly)) {
+        qDebug() << "error opening " << filePath;
+        return false;
+    }
+    QDataStream in(&f);
+    // from qnetworkdiskcache.cpp QCacheItem::read()
+    qint32 marker, version, streamVersion;
+    in >> marker;
+    if (marker != CacheMagic) {
+        return false;
+    }
+    in >> version;
+    if (version != CurrentCacheVersion) {
+        return false;
+    }
+    in >> streamVersion;
+    if (streamVersion > in.version())
+        return false;
+    in.setVersion(streamVersion);
+
+    bool compressed;
+    in >> metaData;
+    in >> compressed;
+    if (compressed) {
+        QByteArray compressedData;
+        in >> compressedData;
+        QBuffer buffer;
+        buffer.setData(qUncompress(compressedData));
+        buffer.open(QBuffer::ReadOnly);
+        data = buffer.readAll();
+    } else {
+        data = f.readAll();
+    }
+    return true;
+}
+
+QDataStream &operator>>(QDataStream& in, MyMetaData& metaData) {
+    in >> metaData.url;
+    in >> metaData.expirationDate;
+    in >> metaData.lastModified;
+    in >> metaData.saveToDisk;
+    in >> metaData.attributes;
+    in >> metaData.rawHeaders;
+}

--- a/tools/cache-extract/src/CacheExtractApp.cpp
+++ b/tools/cache-extract/src/CacheExtractApp.cpp
@@ -68,6 +68,7 @@ CacheExtractApp::CacheExtractApp(int& argc, char** argv) :
             if (out.open(QIODevice::WriteOnly)) {
                 out.write(contents);
                 out.close();
+                qDebug().noquote() << metaData.url.toDisplayString();
             }
         } else {
             qCritical() << "Error extracting = " << fileList.at(i);

--- a/tools/cache-extract/src/CacheExtractApp.h
+++ b/tools/cache-extract/src/CacheExtractApp.h
@@ -1,0 +1,47 @@
+//
+//  CacheExtractApp.h
+//  tools/cache-extract/src
+//
+//  Created by Anthony Thibault on 11/6/2015
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_CacheExtractApp_h
+#define hifi_CacheExtractApp_h
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QCommandLineParser>
+#include <QtNetwork/QNetworkDiskCache>
+#include <QBuffer>
+#include <QDateTime>
+#include <QtNetwork/QNetworkRequest>
+
+// copy of QNetworkCacheMetaData
+class MyMetaData {
+public:
+    typedef QPair<QByteArray, QByteArray> RawHeader;
+    typedef QList<RawHeader> RawHeaderList;
+    typedef QHash<qint32, QVariant> AttributesMap;
+
+    QUrl url;
+    QDateTime expirationDate;
+    QDateTime lastModified;
+    bool saveToDisk;
+    AttributesMap attributes;
+    RawHeaderList rawHeaders;
+};
+
+QDataStream &operator>>(QDataStream &, MyMetaData &);
+
+class CacheExtractApp : public QCoreApplication {
+    Q_OBJECT
+public:
+    CacheExtractApp(int& argc, char** argv);
+
+    bool extractFile(const QString& filePath, MyMetaData& metaData, QByteArray& data) const;
+};
+
+#endif // hifi_CacheExtractApp_h

--- a/tools/cache-extract/src/CacheExtractApp.h
+++ b/tools/cache-extract/src/CacheExtractApp.h
@@ -22,9 +22,9 @@
 // copy of QNetworkCacheMetaData
 class MyMetaData {
 public:
-    typedef QPair<QByteArray, QByteArray> RawHeader;
-    typedef QList<RawHeader> RawHeaderList;
-    typedef QHash<qint32, QVariant> AttributesMap;
+    using RawHeader = QPair<QByteArray, QByteArray>;
+    using RawHeaderList = QList<RawHeader>;
+    using AttributesMap = QHash<qint32, QVariant>;
 
     QUrl url;
     QDateTime expirationDate;
@@ -34,7 +34,7 @@ public:
     RawHeaderList rawHeaders;
 };
 
-QDataStream &operator>>(QDataStream &, MyMetaData &);
+QDataStream &operator>>(QDataStream& in, MyMetaData& metaData);
 
 class CacheExtractApp : public QCoreApplication {
     Q_OBJECT

--- a/tools/cache-extract/src/main.cpp
+++ b/tools/cache-extract/src/main.cpp
@@ -1,0 +1,17 @@
+//
+//  main.cpp
+//  tools/cache-extract/src
+//
+//  Created by Anthony Thibault on 11/6/2015.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+#include <QtCore/QCoreApplication>
+#include "CacheExtractApp.h"
+
+int main (int argc, char** argv) {
+    CacheExtractApp app(argc, argv);
+    return app.exec();
+}


### PR DESCRIPTION
When run from the command line, it will scan the http cache for High Fidelity/Interface and copy the files in their native format into a temporary directory.

On windows the directory that will contain all the files is
    
    C:\Users\username\AppData\Local\High Fidelity\Interface\extracted

On mac

    /Users/username/Library/Application Support/High Fidelity/Interface/extracted

The url path is preserved under the extracted directory.  For example:  the url:

    https://hifi-public.s3.amazonaws.com/ozan/anim/standard_anims/idle.fbx

will be found in the extracted directory as

    ozan/anim/standard_anims/idle.fbx