### PR TITLE
Sixense cleanup

### DIFF
--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -473,18 +473,7 @@ void ApplicationCompositor::renderControllerPointers(gpu::Batch& batch) {
             continue;
         }
 
-        int controllerButtons = 0;
-
-        //Check for if we should toggle or drag the magnification window
-        if (controllerButtons & BUTTON_3) {
-            if (isPressed[index] == false) {
-                //We are now dragging the window
-                isPressed[index] = true;
-                //set the pressed time in us
-                pressedTime[index] = usecTimestampNow();
-                stateWhenPressed[index] = _magActive[index];
-            }
-        } else if (isPressed[index]) {
+        if (isPressed[index]) {
             isPressed[index] = false;
             //If the button was only pressed for < 250 ms
             //then disable it.

--- a/libraries/input-plugins/src/input-plugins/InputPluginsLogging.cpp
+++ b/libraries/input-plugins/src/input-plugins/InputPluginsLogging.cpp
@@ -1,0 +1,14 @@
+//
+//  InputPluginsLogging.cpp
+//
+//
+//  Created by Clement on 11/6/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "InputPluginsLogging.h"
+
+Q_LOGGING_CATEGORY(inputplugins, "hifi.inputplugins")

--- a/libraries/input-plugins/src/input-plugins/InputPluginsLogging.cpp
+++ b/libraries/input-plugins/src/input-plugins/InputPluginsLogging.cpp
@@ -1,6 +1,6 @@
 //
 //  InputPluginsLogging.cpp
-//
+//  libraries/input-plugins/src/input-plugins
 //
 //  Created by Clement on 11/6/15.
 //  Copyright 2015 High Fidelity, Inc.

--- a/libraries/input-plugins/src/input-plugins/InputPluginsLogging.h
+++ b/libraries/input-plugins/src/input-plugins/InputPluginsLogging.h
@@ -1,0 +1,18 @@
+//
+//  InputPluginsLogging.h
+//
+//
+//  Created by Clement on 11/6/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_InputPluginsLogging_h
+#define hifi_InputPluginsLogging_h
+
+#include <QLoggingCategory>
+Q_DECLARE_LOGGING_CATEGORY(inputplugins)
+
+#endif // hifi_InputPluginsLogging_h

--- a/libraries/input-plugins/src/input-plugins/InputPluginsLogging.h
+++ b/libraries/input-plugins/src/input-plugins/InputPluginsLogging.h
@@ -1,6 +1,6 @@
 //
 //  InputPluginsLogging.h
-//
+//  libraries/input-plugins/src/input-plugins
 //
 //  Created by Clement on 11/6/15.
 //  Copyright 2015 High Fidelity, Inc.

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
@@ -12,7 +12,7 @@
 #include "SixenseManager.h"
 
 #ifdef HAVE_SIXENSE
-#include "sixense.h"
+#include <sixense.h>
 #endif
 
 #include <QCoreApplication>
@@ -27,6 +27,8 @@
 #include <plugins/PluginContainer.h>
 #include <SettingHandle.h>
 #include <UserActivityLogger.h>
+
+#include "InputPluginsLogging.h"
 
 static const unsigned int BUTTON_0 = 1U << 0; // the skinny button between 1 and 2
 static const unsigned int BUTTON_1 = 1U << 5;

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.cpp
@@ -19,11 +19,6 @@
 #include <QtCore/QSysInfo>
 #include <QtGlobal>
 
-// TODO: This should not be here
-#include <QLoggingCategory>
-Q_DECLARE_LOGGING_CATEGORY(inputplugins)
-Q_LOGGING_CATEGORY(inputplugins, "hifi.inputplugins")
-
 #include <controllers/UserInputMapper.h>
 #include <GLMHelpers.h>
 #include <NumericalConstants.h>

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.h
@@ -19,21 +19,10 @@
 
 #include "InputPlugin.h"
 
-const unsigned int BUTTON_0 = 1U << 0; // the skinny button between 1 and 2
-const unsigned int BUTTON_1 = 1U << 5;
-const unsigned int BUTTON_2 = 1U << 6;
-const unsigned int BUTTON_3 = 1U << 3;
-const unsigned int BUTTON_4 = 1U << 4;
-const unsigned int BUTTON_FWD = 1U << 7;
-const unsigned int BUTTON_TRIGGER = 1U << 8;
-
-const bool DEFAULT_INVERT_SIXENSE_MOUSE_BUTTONS = false;
-
 // Handles interaction with the Sixense SDK (e.g., Razer Hydra).
 class SixenseManager : public InputPlugin {
     Q_OBJECT
 public:
-
     // Plugin functions
     virtual bool isSupported() const override;
     virtual bool isJointController() const override { return true; }
@@ -52,17 +41,18 @@ public:
 public slots:
     void setSixenseFilter(bool filter);
 
-private:    
+private:
     static const int MAX_NUM_AVERAGING_SAMPLES = 50; // At ~100 updates per seconds this means averaging over ~.5s
     static const int CALIBRATION_STATE_IDLE = 0;
     static const int CALIBRATION_STATE_IN_PROGRESS = 1;
     static const int CALIBRATION_STATE_COMPLETE = 2;
     static const glm::vec3 DEFAULT_AVATAR_POSITION; 
     static const float CONTROLLER_THRESHOLD;
-    static const float DEFAULT_REACH_LENGTH;
-
-    using Samples = std::pair<  MovingAverage< glm::vec3, MAX_NUM_AVERAGING_SAMPLES>, MovingAverage< glm::vec4, MAX_NUM_AVERAGING_SAMPLES> >;
-    using MovingAverageMap = std::map< int, Samples >;
+    
+    template<typename T>
+    using SampleAverage = MovingAverage<T, MAX_NUM_AVERAGING_SAMPLES>;
+    using Samples = std::pair<SampleAverage<glm::vec3>, SampleAverage<glm::vec4>>;
+    using MovingAverageMap = std::map<int, Samples>;
 
     class InputDevice : public controller::InputDevice {
     public:
@@ -88,7 +78,6 @@ private:
         glm::vec3 _avatarPosition { DEFAULT_AVATAR_POSITION }; // in hydra-frame
         glm::quat _avatarRotation; // in hydra-frame
     
-        float _reachLength { DEFAULT_REACH_LENGTH };
         float _lastDistance;
         // these are measured values used to compute the calibration results
         quint64 _lockExpiry;

--- a/libraries/input-plugins/src/input-plugins/SixenseManager.h
+++ b/libraries/input-plugins/src/input-plugins/SixenseManager.h
@@ -12,26 +12,12 @@
 #ifndef hifi_SixenseManager_h
 #define hifi_SixenseManager_h
 
-#ifdef HAVE_SIXENSE
-    #include <glm/glm.hpp>
-    #include <glm/gtc/quaternion.hpp>
-    #include "sixense.h"
-
-#ifdef __APPLE__
-    #include <QCoreApplication>
-    #include <qlibrary.h>
-#endif
-
-#endif
-
 #include <SimpleMovingAverage.h>
 
 #include <controllers/InputDevice.h>
 #include <controllers/StandardControls.h>
 
 #include "InputPlugin.h"
-
-class QLibrary;
 
 const unsigned int BUTTON_0 = 1U << 0; // the skinny button between 1 and 2
 const unsigned int BUTTON_1 = 1U << 5;
@@ -75,7 +61,6 @@ private:
     static const float CONTROLLER_THRESHOLD;
     static const float DEFAULT_REACH_LENGTH;
 
-
     using Samples = std::pair<  MovingAverage< glm::vec3, MAX_NUM_AVERAGING_SAMPLES>, MovingAverage< glm::vec4, MAX_NUM_AVERAGING_SAMPLES> >;
     using MovingAverageMap = std::map< int, Samples >;
 
@@ -113,9 +98,6 @@ private:
         glm::vec3 _reachRight;
     };
 
-
-
-    bool _useSixenseFilter = true;
     std::shared_ptr<InputDevice> _inputDevice { std::make_shared<InputDevice>() };
 
     static const QString NAME;

--- a/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
@@ -32,7 +32,7 @@ Callable resolve(const Library& library, const char* name) {
     Q_ASSERT_X(function, __FUNCTION__, std::string("Could not resolve ").append(name).c_str());
     return Callable { function };
 }
-#define FOREWARD resolve(SIXENSE, __FUNCTION__)
+#define FORWARD resolve(SIXENSE, __FUNCTION__)
 
 
 void loadSixense() {
@@ -61,90 +61,90 @@ void unloadSixense() {
 // sixense.h wrapper for OSX dynamic linking
 int sixenseInit() {
     loadSixense();
-    return FOREWARD();
+    return FORWARD();
 }
 int sixenseExit() {
-    auto returnCode = FOREWARD();
+    auto returnCode = FORWARD();
     unloadSixense();
     return returnCode;
 }
 
 int sixenseGetMaxBases() {
-    return FOREWARD();
+    return FORWARD();
 }
 int sixenseSetActiveBase(int i) {
-    return FOREWARD(i);
+    return FORWARD(i);
 }
 int sixenseIsBaseConnected(int i) {
-    return FOREWARD(i);
+    return FORWARD(i);
 }
 
 int sixenseGetMaxControllers() {
-    return FOREWARD();
+    return FORWARD();
 }
 int sixenseIsControllerEnabled(int which) {
-    return FOREWARD(which);
+    return FORWARD(which);
 }
 int sixenseGetNumActiveControllers() {
-    return FOREWARD();
+    return FORWARD();
 }
 
 int sixenseGetHistorySize() {
-    return FOREWARD();
+    return FORWARD();
 }
 
 int sixenseGetData(int which, int index_back, sixenseControllerData* data) {
-    return FOREWARD(which, index_back, data);
+    return FORWARD(which, index_back, data);
 }
 int sixenseGetAllData(int index_back, sixenseAllControllerData* data) {
-    return FOREWARD(index_back, data);
+    return FORWARD(index_back, data);
 }
 int sixenseGetNewestData(int which, sixenseControllerData* data) {
-    return FOREWARD(which, data);
+    return FORWARD(which, data);
 }
 int sixenseGetAllNewestData(sixenseAllControllerData* data) {
-    return FOREWARD(data);
+    return FORWARD(data);
 }
 
 int sixenseSetHemisphereTrackingMode(int which_controller, int state) {
-    return FOREWARD(which_controller, state);
+    return FORWARD(which_controller, state);
 }
 int sixenseGetHemisphereTrackingMode(int which_controller, int* state) {
-    return FOREWARD(which_controller, state);
+    return FORWARD(which_controller, state);
 }
 int sixenseAutoEnableHemisphereTracking(int which_controller) {
-    return FOREWARD(which_controller);
+    return FORWARD(which_controller);
 }
 
 int sixenseSetHighPriorityBindingEnabled(int on_or_off) {
-    return FOREWARD(on_or_off);
+    return FORWARD(on_or_off);
 }
 int sixenseGetHighPriorityBindingEnabled(int* on_or_off) {
-    return FOREWARD(on_or_off);
+    return FORWARD(on_or_off);
 }
 
 int sixenseTriggerVibration(int controller_id, int duration_100ms, int pattern_id) {
-    return FOREWARD(controller_id, duration_100ms, pattern_id);
+    return FORWARD(controller_id, duration_100ms, pattern_id);
 }
 
 int sixenseSetFilterEnabled(int on_or_off) {
-    return FOREWARD(on_or_off);
+    return FORWARD(on_or_off);
 }
 int sixenseGetFilterEnabled(int* on_or_off) {
-    return FOREWARD(on_or_off);
+    return FORWARD(on_or_off);
 }
 
 int sixenseSetFilterParams(float near_range, float near_val, float far_range, float far_val) {
-    return FOREWARD(near_range, near_val, far_range, far_val);
+    return FORWARD(near_range, near_val, far_range, far_val);
 }
 int sixenseGetFilterParams(float* near_range, float* near_val, float* far_range, float* far_val) {
-    return FOREWARD(near_range, near_val, far_range, far_val);
+    return FORWARD(near_range, near_val, far_range, far_val);
 }
 
 int sixenseSetBaseColor(unsigned char red, unsigned char green, unsigned char blue) {
-    return FOREWARD(red, green, blue);
+    return FORWARD(red, green, blue);
 }
 int sixenseGetBaseColor(unsigned char* red, unsigned char* green, unsigned char* blue) {
-    return FOREWARD(red, green, blue);
+    return FORWARD(red, green, blue);
 }
 #endif

--- a/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
@@ -16,13 +16,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QLibrary>
 
-using std::string;
-using std::unique_ptr;
-using SixenseBaseFunction = int (*)();
-using SixenseTakeIntFunction = int (*)(int);
-using SixenseTakeIntAndSixenseControllerData = int (*)(int, sixenseControllerData*);
-
-static unique_ptr<QLibrary> SIXENSE;
+static std::unique_ptr<QLibrary> SIXENSE;
 
 void loadSixense() {
     if (!SIXENSE) {
@@ -51,7 +45,7 @@ template<typename... Args>
 int call(const char* name, Args... args) {
     Q_ASSERT_X(SIXENSE && SIXENSE->isLoaded(), __FUNCTION__, "Sixense library not loaded");
     auto func = reinterpret_cast<int(*)(Args...)>(SIXENSE->resolve(name));
-    Q_ASSERT_X(func, __FUNCTION__, string("Could not resolve ").append(name).c_str());
+    Q_ASSERT_X(func, __FUNCTION__, std::string("Could not resolve ").append(name).c_str());
     return func(args...);
 }
 

--- a/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
@@ -16,6 +16,8 @@
 #include <QtCore/QDebug>
 #include <QtCore/QLibrary>
 
+#include "InputPluginsLogging.h"
+
 using Library = std::unique_ptr<QLibrary>;
 static Library SIXENSE;
 

--- a/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
@@ -20,6 +20,10 @@
 
 #include "InputPluginsLogging.h"
 
+#ifndef SIXENSE_LIB_FILENAME
+#define SIXENSE_LIB_FILENAME QCoreApplication::applicationDirPath() + "/../Frameworks/libsixense_x64"
+#endif
+
 using Library = std::unique_ptr<QLibrary>;
 static Library SIXENSE;
 
@@ -41,15 +45,9 @@ Callable resolve(const Library& library, const char* name) {
 
 
 void loadSixense() {
-    if (!SIXENSE) {
-        static const QString LIBRARY_PATH =
-#ifdef SIXENSE_LIB_FILENAME
-                                SIXENSE_LIB_FILENAME;
-#else
-                                QCoreApplication::applicationDirPath() + "/../Frameworks/libsixense_x64";
-#endif
-        SIXENSE.reset(new QLibrary(LIBRARY_PATH));
-    }
+    Q_ASSERT_X(!(SIXENSE && SIXENSE->isLoaded()), __FUNCTION__, "Sixense library already loaded");
+    SIXENSE.reset(new QLibrary(SIXENSE_LIB_FILENAME));
+    Q_CHECK_PTR(SIXENSE);
     
     if (SIXENSE->load()){
         qDebug() << "Loaded sixense library for hydra support -" << SIXENSE->fileName();

--- a/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
@@ -24,7 +24,7 @@ using SixenseTakeIntAndSixenseControllerData = int (*)(int, sixenseControllerDat
 
 static unique_ptr<QLibrary> SIXENSE;
 
-bool loadSixense() {
+void loadSixense() {
     if (!SIXENSE) {
         static const QString LIBRARY_PATH =
 #ifdef SIXENSE_LIB_FILENAME
@@ -41,57 +41,107 @@ bool loadSixense() {
         qDebug() << "Sixense library at" << SIXENSE->fileName() << "failed to load:" << SIXENSE->errorString();
         qDebug() << "Continuing without hydra support.";
     }
-    return SIXENSE->isLoaded();
 }
 
 void unloadSixense() {
     SIXENSE->unload();
 }
 
-template<typename Func>
-Func resolve(const char* name) {
+template<typename... Args>
+int call(const char* name, Args... args) {
     Q_ASSERT_X(SIXENSE && SIXENSE->isLoaded(), __FUNCTION__, "Sixense library not loaded");
-    auto func = reinterpret_cast<Func>(SIXENSE->resolve(name));
+    auto func = reinterpret_cast<int(*)(Args...)>(SIXENSE->resolve(name));
     Q_ASSERT_X(func, __FUNCTION__, string("Could not resolve ").append(name).c_str());
-    return func;
+    return func(args...);
 }
 
 // sixense.h wrapper for OSX dynamic linking
 int sixenseInit() {
     loadSixense();
-    auto sixenseInit = resolve<SixenseBaseFunction>("sixenseInit");
-    return sixenseInit();
+    return call(__FUNCTION__);
 }
-
 int sixenseExit() {
-    auto sixenseExit = resolve<SixenseBaseFunction>("sixenseExit");
-    auto returnCode = sixenseExit();
+    auto returnCode = call(__FUNCTION__);
     unloadSixense();
     return returnCode;
 }
 
-int sixenseSetFilterEnabled(int input) {
-    auto sixenseSetFilterEnabled = resolve<SixenseTakeIntFunction>("sixenseSetFilterEnabled");
-    return sixenseSetFilterEnabled(input);
+int sixenseGetMaxBases() {
+    return call(__FUNCTION__);
 }
-
-int sixenseGetNumActiveControllers() {
-    auto sixenseGetNumActiveControllers = resolve<SixenseBaseFunction>("sixenseGetNumActiveControllers");
-    return sixenseGetNumActiveControllers();
+int sixenseSetActiveBase(int i) {
+    return call(__FUNCTION__, i);
+}
+int sixenseIsBaseConnected(int i) {
+    return call(__FUNCTION__, i);
 }
 
 int sixenseGetMaxControllers() {
-    auto sixenseGetMaxControllers = resolve<SixenseBaseFunction>("sixenseGetMaxControllers");
-    return sixenseGetMaxControllers();
+    return call(__FUNCTION__);
+}
+int sixenseIsControllerEnabled(int which) {
+    return call(__FUNCTION__, which);
+}
+int sixenseGetNumActiveControllers() {
+    return call(__FUNCTION__);
 }
 
-int sixenseIsControllerEnabled(int input) {
-    auto sixenseIsControllerEnabled = resolve<SixenseTakeIntFunction>("sixenseIsControllerEnabled");
-    return sixenseIsControllerEnabled(input);
+int sixenseGetHistorySize() {
+    return call(__FUNCTION__);
 }
 
-int sixenseGetNewestData(int input1, sixenseControllerData* intput2) {
-    auto sixenseGetNewestData = resolve<SixenseTakeIntAndSixenseControllerData>("sixenseGetNewestData");
-    return sixenseGetNewestData(input1, intput2);
+int sixenseGetData(int which, int index_back, sixenseControllerData* data) {
+    return call(__FUNCTION__, which, index_back, data);
+}
+int sixenseGetAllData(int index_back, sixenseAllControllerData* data) {
+    return call(__FUNCTION__, index_back, data);
+}
+int sixenseGetNewestData(int which, sixenseControllerData* data) {
+    return call(__FUNCTION__, which, data);
+}
+int sixenseGetAllNewestData(sixenseAllControllerData* data) {
+    return call(__FUNCTION__, data);
+}
+
+int sixenseSetHemisphereTrackingMode(int which_controller, int state) {
+    return call(__FUNCTION__, which_controller, state);
+}
+int sixenseGetHemisphereTrackingMode(int which_controller, int* state) {
+    return call(__FUNCTION__, which_controller, state);
+}
+int sixenseAutoEnableHemisphereTracking(int which_controller) {
+    return call(__FUNCTION__, which_controller);
+}
+
+int sixenseSetHighPriorityBindingEnabled(int on_or_off) {
+    return call(__FUNCTION__, on_or_off);
+}
+int sixenseGetHighPriorityBindingEnabled(int* on_or_off) {
+    return call(__FUNCTION__, on_or_off);
+}
+
+int sixenseTriggerVibration(int controller_id, int duration_100ms, int pattern_id) {
+    return call(__FUNCTION__, controller_id, duration_100ms, pattern_id);
+}
+
+int sixenseSetFilterEnabled(int on_or_off) {
+    return call(__FUNCTION__, on_or_off);
+}
+int sixenseGetFilterEnabled(int* on_or_off) {
+    return call(__FUNCTION__, on_or_off);
+}
+
+int sixenseSetFilterParams(float near_range, float near_val, float far_range, float far_val) {
+    return call(__FUNCTION__, near_range, near_val, far_range, far_val);
+}
+int sixenseGetFilterParams(float* near_range, float* near_val, float* far_range, float* far_val) {
+    return call(__FUNCTION__, near_range, near_val, far_range, far_val);
+}
+
+int sixenseSetBaseColor(unsigned char red, unsigned char green, unsigned char blue) {
+    return call(__FUNCTION__, red, green, blue);
+}
+int sixenseGetBaseColor(unsigned char* red, unsigned char* green, unsigned char* blue) {
+    return call(__FUNCTION__, red, green, blue);
 }
 #endif

--- a/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
@@ -1,0 +1,97 @@
+//
+//  SixenseSupportOSX.cpp
+//
+//
+//  Created by Clement on 10/20/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifdef __APPLE__
+#include "sixense.h"
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDebug>
+#include <QtCore/QLibrary>
+
+using std::string;
+using std::unique_ptr;
+using SixenseBaseFunction = int (*)();
+using SixenseTakeIntFunction = int (*)(int);
+using SixenseTakeIntAndSixenseControllerData = int (*)(int, sixenseControllerData*);
+
+static unique_ptr<QLibrary> SIXENSE;
+
+bool loadSixense() {
+    if (!SIXENSE) {
+        static const QString LIBRARY_PATH =
+#ifdef SIXENSE_LIB_FILENAME
+                                SIXENSE_LIB_FILENAME;
+#else
+                                QCoreApplication::applicationDirPath() + "/../Frameworks/libsixense_x64";
+#endif
+        SIXENSE.reset(new QLibrary(LIBRARY_PATH));
+    }
+    
+    if (SIXENSE->load()){
+        qDebug() << "Loaded sixense library for hydra support -" << SIXENSE->fileName();
+    } else {
+        qDebug() << "Sixense library at" << SIXENSE->fileName() << "failed to load:" << SIXENSE->errorString();
+        qDebug() << "Continuing without hydra support.";
+    }
+    return SIXENSE->isLoaded();
+}
+
+void unloadSixense() {
+    SIXENSE->unload();
+}
+
+template<typename Func>
+Func resolve(const char* name) {
+    Q_ASSERT_X(SIXENSE && SIXENSE->isLoaded(), __FUNCTION__, "Sixense library not loaded");
+    auto func = reinterpret_cast<Func>(SIXENSE->resolve(name));
+    Q_ASSERT_X(func, __FUNCTION__, string("Could not resolve ").append(name).c_str());
+    return func;
+}
+
+// sixense.h wrapper for OSX dynamic linking
+int sixenseInit() {
+    loadSixense();
+    auto sixenseInit = resolve<SixenseBaseFunction>("sixenseInit");
+    return sixenseInit();
+}
+
+int sixenseExit() {
+    auto sixenseExit = resolve<SixenseBaseFunction>("sixenseExit");
+    auto returnCode = sixenseExit();
+    unloadSixense();
+    return returnCode;
+}
+
+int sixenseSetFilterEnabled(int input) {
+    auto sixenseSetFilterEnabled = resolve<SixenseTakeIntFunction>("sixenseSetFilterEnabled");
+    return sixenseSetFilterEnabled(input);
+}
+
+int sixenseGetNumActiveControllers() {
+    auto sixenseGetNumActiveControllers = resolve<SixenseBaseFunction>("sixenseGetNumActiveControllers");
+    return sixenseGetNumActiveControllers();
+}
+
+int sixenseGetMaxControllers() {
+    auto sixenseGetMaxControllers = resolve<SixenseBaseFunction>("sixenseGetMaxControllers");
+    return sixenseGetMaxControllers();
+}
+
+int sixenseIsControllerEnabled(int input) {
+    auto sixenseIsControllerEnabled = resolve<SixenseTakeIntFunction>("sixenseIsControllerEnabled");
+    return sixenseIsControllerEnabled(input);
+}
+
+int sixenseGetNewestData(int input1, sixenseControllerData* intput2) {
+    auto sixenseGetNewestData = resolve<SixenseTakeIntAndSixenseControllerData>("sixenseGetNewestData");
+    return sixenseGetNewestData(input1, intput2);
+}
+#endif

--- a/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
+++ b/libraries/input-plugins/src/input-plugins/SixenseSupportOSX.cpp
@@ -9,11 +9,13 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+// Mock implementation of sixense.h to hide dynamic linking on OS X
 #if defined(__APPLE__) && defined(HAVE_SIXENSE)
-#include "sixense.h"
+#include <type_traits>
+
+#include <sixense.h>
 
 #include <QtCore/QCoreApplication>
-#include <QtCore/QDebug>
 #include <QtCore/QLibrary>
 
 #include "InputPluginsLogging.h"
@@ -22,8 +24,9 @@ using Library = std::unique_ptr<QLibrary>;
 static Library SIXENSE;
 
 struct Callable {
-    template<typename... Args> int operator() (Args... args){
-        return reinterpret_cast<int(*)(Args...)>(function)(args...);
+    template<typename... Args>
+    int operator() (Args&&... args){
+        return reinterpret_cast<int(*)(Args...)>(function)(std::forward<Args>(args)...);
     }
     QFunctionPointer function;
 };


### PR DESCRIPTION
Hides sixense's dynamic linking on OS X.
This way all the `#ifdef __APPLE` are isolated and seamless.