### PR TITLE
Add New Collision Hull and Collision Sound to Ping Pong Gun

### DIFF
--- a/examples/toybox/ping_pong_gun/createPingPongGun.js
+++ b/examples/toybox/ping_pong_gun/createPingPongGun.js
@@ -14,8 +14,8 @@ Script.include("../../utilities.js");
 var scriptURL = Script.resolvePath('pingPongGun.js');
 
 var MODEL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun.fbx'
-var COLLISION_HULL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun_collision_hull.obj';
-
+var COLLISION_HULL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun_convex.obj';
+var COLLISION_SOUND_URL = 'http://hifi-public.s3.amazonaws.com/sounds/Collisions-otherorganic/plastic_impact.L.wav';
 var center = Vec3.sum(Vec3.sum(MyAvatar.position, {
     x: 0,
     y: 0.5,
@@ -25,9 +25,8 @@ var center = Vec3.sum(Vec3.sum(MyAvatar.position, {
 var pingPongGun = Entities.addEntity({
     type: "Model",
     modelURL: MODEL_URL,
-    shapeType:'box',
-    // shapeType: 'compound',
-    // compoundShapeURL: COLLISION_HULL_URL,
+    shapeType: 'compound',
+    compoundShapeURL: COLLISION_HULL_URL,
     script: scriptURL,
     position: center,
     dimensions: {
@@ -36,6 +35,7 @@ var pingPongGun = Entities.addEntity({
         z: 0.47
     },
     collisionsWillMove: true,
+    collisionSoundURL: COLLISION_SOUND_URL
 });
 
 function cleanUp() {

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -887,8 +887,8 @@
 
         function createPingPongBallGun() {
             var MODEL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun.fbx';
-            var COLLISION_HULL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun_collision_hull.obj';
-
+            var COLLISION_HULL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun_convex.obj';
+            var COLLISION_SOUND_URL = 'http://hifi-public.s3.amazonaws.com/sounds/Collisions-otherorganic/plastic_impact.L.wav';
             var position = {
                 x: 548.6,
                 y: 495.4,
@@ -900,7 +900,8 @@
             var pingPongGun = Entities.addEntity({
                 type: "Model",
                 modelURL: MODEL_URL,
-                shapeType: 'box',
+                shapeType: 'compound',
+                compoundShapeURL: COLLISION_SOUND_URL,
                 script: pingPongScriptURL,
                 position: position,
                 rotation: rotation,
@@ -915,6 +916,7 @@
                     z: 0.47
                 },
                 collisionsWillMove: true,
+                collisionSoundURL: COLLISION_SOUND_URL,
                 userData: JSON.stringify({
                     resetMe: {
                         resetMe: true

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -869,8 +869,8 @@ MasterReset = function() {
 
     function createPingPongBallGun() {
         var MODEL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun.fbx';
-        var COLLISION_HULL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun_collision_hull.obj';
-
+        var COLLISION_HULL_URL = 'http://hifi-public.s3.amazonaws.com/models/ping_pong_gun/ping_pong_gun_convex.obj';
+        var COLLISION_SOUND_URL = 'http://hifi-public.s3.amazonaws.com/sounds/Collisions-otherorganic/plastic_impact.L.wav';
         var position = {
             x: 548.6,
             y: 495.4,
@@ -882,7 +882,8 @@ MasterReset = function() {
         var pingPongGun = Entities.addEntity({
             type: "Model",
             modelURL: MODEL_URL,
-            shapeType: 'box',
+            shapeType: 'compound',
+            compoundShapeURL:COLLISION_SOUND_URL,
             script: pingPongScriptURL,
             position: position,
             rotation: rotation,
@@ -897,6 +898,7 @@ MasterReset = function() {
                 z: 0.47
             },
             collisionsWillMove: true,
+            collisionSoundURL: COLLISION_SOUND_URL,
             userData: JSON.stringify({
                 resetMe: {
                     resetMe: true


### PR DESCRIPTION
This PR adds a new collision hull + sound to the ping pong gun in Toybox.

To test: https://rawgit.com/imgntn/hifi/pongupdates/examples/toybox/ping_pong_gun/createPingPongGun.js