### PR TITLE
Update script engine path resolution behavior to behave consistently

### DIFF
--- a/examples/example/games/satellite.js
+++ b/examples/example/games/satellite.js
@@ -15,7 +15,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-Script.include('../utilities/tools/vector.js');
+Script.include('../../utilities/tools/vector.js');
 
 var URL = "https://s3.amazonaws.com/hifi-public/marketplace/hificontent/Scripts/planets/";
 

--- a/examples/libraries/entityCameraTool.js
+++ b/examples/libraries/entityCameraTool.js
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-Script.include("libraries/overlayUtils.js");
+Script.include("overlayUtils.js");
 
 var MOUSE_SENSITIVITY = 0.9;
 var SCROLL_SENSITIVITY = 0.05;

--- a/examples/libraries/entityList.js
+++ b/examples/libraries/entityList.js
@@ -1,7 +1,9 @@
+var ENTITY_LIST_HTML_URL = Script.resolvePath('../html/entityList.html');
+
 EntityListTool = function(opts) {
     var that = {};
 
-    var url = Script.resolvePath('html/entityList.html');
+    var url = ENTITY_LIST_HTML_URL;
     var webView = new WebWindow('Entities', url, 200, 280, true);
 
     var searchRadius = 100;

--- a/examples/libraries/gridTool.js
+++ b/examples/libraries/gridTool.js
@@ -1,3 +1,5 @@
+var GRID_CONTROLS_HTML_URL = Script.resolvePath('../html/gridControls.html');
+
 Grid = function(opts) {
     var that = {};
 
@@ -228,7 +230,7 @@ GridTool = function(opts) {
     var verticalGrid = opts.verticalGrid;
     var listeners = [];
 
-    var url = Script.resolvePath('html/gridControls.html');
+    var url = GRID_CONTROLS_HTML_URL;
     var webView = new WebWindow('Grid', url, 200, 280, true);
 
     horizontalGrid.addListener(function(data) {

--- a/examples/libraries/omniTool/modules/breakdanceOmniToolModule.js
+++ b/examples/libraries/omniTool/modules/breakdanceOmniToolModule.js
@@ -11,7 +11,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-Script.include("../toys/breakdanceCore.js");
+Script.include("../../../breakdanceCore.js");
 
 OmniToolModules.Breakdance = function() {
     print("OmniToolModules.Breakdance...");

--- a/examples/libraries/omniTool/modules/test.js
+++ b/examples/libraries/omniTool/modules/test.js
@@ -1,5 +1,5 @@
 
-Script.include("avatarRelativeOverlays.js");
+Script.include("../../avatarRelativeOverlays.js");
 
 OmniToolModules.Test = function(omniTool, activeEntityId) {
     this.omniTool = omniTool;

--- a/examples/libraries/walkApi.js
+++ b/examples/libraries/walkApi.js
@@ -14,7 +14,7 @@
 //
 
 // included here to ensure walkApi.js can be used as an API, separate from walk.js
-Script.include("./libraries/walkConstants.js");
+Script.include("walkConstants.js");
 
 Avatar = function() {
     // if Hydras are connected, the only way to enable use is to never set any arm joint rotation

--- a/examples/libraries/walkSettings.js
+++ b/examples/libraries/walkSettings.js
@@ -13,6 +13,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+var WALK_SETTINGS_HTML_URL = Script.resolvePath('../html/walkSettings.html');
+
 WalkSettings = function() {
     var _visible = false;
     var _innerWidth = Window.innerWidth;
@@ -69,7 +71,7 @@ WalkSettings = function() {
     // web window
     const PANEL_WIDTH = 200;
     const PANEL_HEIGHT = 180;
-    var _url = Script.resolvePath('html/walkSettings.html');
+    var _url = WALK_SETTINGS_HTML_URL;
     var _webWindow = new WebWindow('Walk Settings', _url, PANEL_WIDTH, PANEL_HEIGHT, false);
     _webWindow.setVisible(false);
     _webWindow.eventBridge.webEventReceived.connect(function(data) {

--- a/examples/magBalls.js
+++ b/examples/magBalls.js
@@ -7,11 +7,11 @@
 //
 
 // FIXME Script paths have to be relative to the caller, in this case libraries/OmniTool.js
-Script.include("../magBalls/constants.js");
-Script.include("../magBalls/graph.js");
-Script.include("../magBalls/edgeSpring.js");
-Script.include("../magBalls/magBalls.js");
-Script.include("avatarRelativeOverlays.js");
+Script.include("magBalls/constants.js");
+Script.include("magBalls/graph.js");
+Script.include("magBalls/edgeSpring.js");
+Script.include("magBalls/magBalls.js");
+Script.include("libraries/avatarRelativeOverlays.js");
 
 OmniToolModuleType = "MagBallsController"
 

--- a/examples/magBalls.js
+++ b/examples/magBalls.js
@@ -34,7 +34,7 @@ MODE_INFO[BALL_EDIT_MODE_ADD] = {
     },
     colors: [ COLORS.GREEN, COLORS.BLUE ],
     // FIXME use an http path or find a way to get the relative path to the file
-    url: Script.resolvePath('../html/magBalls/addMode.html'),
+    url: Script.resolvePath('html/magBalls/addMode.html'),
 };
 
 MODE_INFO[BALL_EDIT_MODE_DELETE] = {
@@ -45,7 +45,7 @@ MODE_INFO[BALL_EDIT_MODE_DELETE] = {
     },
     colors: [ COLORS.RED, COLORS.BLUE ],
     // FIXME use an http path or find a way to get the relative path to the file
-    url: Script.resolvePath('../html/magBalls/deleteMode.html'),
+    url: Script.resolvePath('html/magBalls/deleteMode.html'),
 };
 
 var UI_POSITION_MODE_LABEL = Vec3.multiply(0.5,

--- a/examples/painting/closePaint.js
+++ b/examples/painting/closePaint.js
@@ -11,7 +11,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-Script.include("libraries/utils.js");
+Script.include("../libraries/utils.js");
 
 
 var RIGHT_HAND = 1;

--- a/examples/toybox/bubblewand/createWand.js
+++ b/examples/toybox/bubblewand/createWand.js
@@ -10,7 +10,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 
-Script.include("../../utilities.js");
 Script.include("../../libraries/utils.js");
 
 var WAND_MODEL = 'http://hifi-public.s3.amazonaws.com/models/bubblewand/wand.fbx';

--- a/examples/toybox/bubblewand/wand.js
+++ b/examples/toybox/bubblewand/wand.js
@@ -14,7 +14,6 @@
 
 (function () {
 
-    Script.include("../../utilities.js");
     Script.include("../../libraries/utils.js");
 
     var BUBBLE_MODEL = "http://hifi-public.s3.amazonaws.com/models/bubblewand/bubble.fbx";

--- a/examples/toybox/doll/doll.js
+++ b/examples/toybox/doll/doll.js
@@ -13,7 +13,6 @@
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, Audio, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 
 (function() {
-    Script.include("../../utilities.js");
     Script.include("../../libraries/utils.js");
     var _this;
     // this is the "constructor" for the entity as a JS object we don't do much here

--- a/examples/toybox/ping_pong_gun/createPingPongGun.js
+++ b/examples/toybox/ping_pong_gun/createPingPongGun.js
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
-Script.include("../../utilities.js");
+Script.include("../../libraries/utils.js");
 
 var scriptURL = Script.resolvePath('pingPongGun.js');
 

--- a/examples/toybox/ping_pong_gun/createTargets.js
+++ b/examples/toybox/ping_pong_gun/createTargets.js
@@ -10,7 +10,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
-Script.include("../../utilities.js");
+
 Script.include("../../libraries/utils.js");
 var scriptURL = Script.resolvePath('wallTarget.js');
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -901,14 +901,19 @@ void ScriptEngine::include(const QStringList& includeFiles, QScriptValue callbac
     BatchLoader* loader = new BatchLoader(urls);
 
     auto evaluateScripts = [=](const QMap<QUrl, QString>& data) {
+        auto parentURL = _parentURL;
         for (QUrl url : urls) {
             QString contents = data[url];
             if (contents.isNull()) {
                 qCDebug(scriptengine) << "Error loading file: " << url << "line:" << __LINE__;
             } else {
+                // Set the parent url so that path resolution will be relative
+                // to this script's url during its initial evaluation
+                _parentURL = url.toString();
                 QScriptValue result = evaluate(contents, url.toString());
             }
         }
+        _parentURL = parentURL;
 
         if (callback.isFunction()) {
             QScriptValue(callback).call();


### PR DESCRIPTION
Do not merge yet, feedback welcome.

The path resolution will now be relative to the script currently
being evaluated *on its initial evaluation.* The previous behavior
was that all paths would be resolved relative to the root script
for client scripts, and inconsistent for entity scripts depending
on the order that scripts were loaded. The entity script situation
was particularly bad because including more than 1 level deep produced
inconsistent results.