### PR TITLE
Left overs bug fix

### DIFF
--- a/assignment-client/src/entities/EntityNodeData.h
+++ b/assignment-client/src/entities/EntityNodeData.h
@@ -18,8 +18,6 @@
 
 class EntityNodeData : public OctreeQueryNode {
 public:
-    EntityNodeData() : OctreeQueryNode() { }
-
     virtual PacketType getMyPacketType() const { return PacketType::EntityData; }
 
     quint64 getLastDeletedEntitiesSentAt() const { return _lastDeletedEntitiesSentAt; }

--- a/assignment-client/src/entities/EntityNodeData.h
+++ b/assignment-client/src/entities/EntityNodeData.h
@@ -18,9 +18,7 @@
 
 class EntityNodeData : public OctreeQueryNode {
 public:
-    EntityNodeData() :
-        OctreeQueryNode(),
-        _lastDeletedEntitiesSentAt(0) { }
+    EntityNodeData() : OctreeQueryNode() { }
 
     virtual PacketType getMyPacketType() const { return PacketType::EntityData; }
 
@@ -28,7 +26,7 @@ public:
     void setLastDeletedEntitiesSentAt(quint64 sentAt) { _lastDeletedEntitiesSentAt = sentAt; }
 
 private:
-    quint64 _lastDeletedEntitiesSentAt;
+    quint64 _lastDeletedEntitiesSentAt { usecTimestampNow() };
 };
 
 #endif // hifi_EntityNodeData_h

--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -82,7 +82,6 @@ bool EntityServer::hasSpecialPacketsToSend(const SharedNodePointer& node) {
     EntityNodeData* nodeData = static_cast<EntityNodeData*>(node->getLinkedData());
     if (nodeData) {
         quint64 deletedEntitiesSentAt = nodeData->getLastDeletedEntitiesSentAt();
-
         EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
         shouldSendDeletedEntities = tree->hasEntitiesDeletedSince(deletedEntitiesSentAt);
     }
@@ -97,7 +96,6 @@ int EntityServer::sendSpecialPackets(const SharedNodePointer& node, OctreeQueryN
     if (nodeData) {
         quint64 deletedEntitiesSentAt = nodeData->getLastDeletedEntitiesSentAt();
         quint64 deletePacketSentAt = usecTimestampNow();
-
         EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
         bool hasMoreToSend = true;
 
@@ -127,7 +125,6 @@ void EntityServer::pruneDeletedEntities() {
     if (tree->hasAnyDeletedEntities()) {
 
         quint64 earliestLastDeletedEntitiesSent = usecTimestampNow() + 1; // in the future
-
         DependencyManager::get<NodeList>()->eachNode([&earliestLastDeletedEntitiesSent](const SharedNodePointer& node) {
             if (node->getLinkedData()) {
                 EntityNodeData* nodeData = static_cast<EntityNodeData*>(node->getLinkedData());
@@ -138,6 +135,8 @@ void EntityServer::pruneDeletedEntities() {
             }
         });
 
+        int EXTRA_SECONDS_TO_KEEP = 4;
+        earliestLastDeletedEntitiesSent -= USECS_PER_SECOND * EXTRA_SECONDS_TO_KEEP;
         tree->forgetEntitiesDeletedBefore(earliestLastDeletedEntitiesSent);
     }
 }

--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -84,6 +84,10 @@ bool EntityServer::hasSpecialPacketsToSend(const SharedNodePointer& node) {
         quint64 deletedEntitiesSentAt = nodeData->getLastDeletedEntitiesSentAt();
         EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
         shouldSendDeletedEntities = tree->hasEntitiesDeletedSince(deletedEntitiesSentAt);
+        if (shouldSendDeletedEntities) {
+            int elapsed = usecTimestampNow() - deletedEntitiesSentAt;
+            qDebug() << "shouldSendDeletedEntities to node:" << node->getUUID() << "deletedEntitiesSentAt:" << deletedEntitiesSentAt << "elapsed:" << elapsed;
+        }
     }
 
     return shouldSendDeletedEntities;
@@ -116,6 +120,10 @@ int EntityServer::sendSpecialPackets(const SharedNodePointer& node, OctreeQueryN
         nodeData->setLastDeletedEntitiesSentAt(deletePacketSentAt);
     }
 
+    if (packetsSent > 0) {
+        qDebug() << "EntityServer::sendSpecialPackets() sent " << packetsSent << "special packets of " << totalBytes << " total bytes to node:" << node->getUUID();
+    }
+
     // TODO: caller is expecting a packetLength, what if we send more than one packet??
     return totalBytes;
 }
@@ -134,9 +142,6 @@ void EntityServer::pruneDeletedEntities() {
                 }
             }
         });
-
-        int EXTRA_SECONDS_TO_KEEP = 4;
-        earliestLastDeletedEntitiesSent -= USECS_PER_SECOND * EXTRA_SECONDS_TO_KEEP;
         tree->forgetEntitiesDeletedBefore(earliestLastDeletedEntitiesSent);
     }
 }

--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -84,10 +84,13 @@ bool EntityServer::hasSpecialPacketsToSend(const SharedNodePointer& node) {
         quint64 deletedEntitiesSentAt = nodeData->getLastDeletedEntitiesSentAt();
         EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
         shouldSendDeletedEntities = tree->hasEntitiesDeletedSince(deletedEntitiesSentAt);
-        if (shouldSendDeletedEntities) {
-            int elapsed = usecTimestampNow() - deletedEntitiesSentAt;
-            qDebug() << "shouldSendDeletedEntities to node:" << node->getUUID() << "deletedEntitiesSentAt:" << deletedEntitiesSentAt << "elapsed:" << elapsed;
-        }
+
+        #ifdef EXTRA_ERASE_DEBUGGING
+            if (shouldSendDeletedEntities) {
+                int elapsed = usecTimestampNow() - deletedEntitiesSentAt;
+                qDebug() << "shouldSendDeletedEntities to node:" << node->getUUID() << "deletedEntitiesSentAt:" << deletedEntitiesSentAt << "elapsed:" << elapsed;
+            }
+        #endif
     }
 
     return shouldSendDeletedEntities;
@@ -120,9 +123,12 @@ int EntityServer::sendSpecialPackets(const SharedNodePointer& node, OctreeQueryN
         nodeData->setLastDeletedEntitiesSentAt(deletePacketSentAt);
     }
 
-    if (packetsSent > 0) {
-        qDebug() << "EntityServer::sendSpecialPackets() sent " << packetsSent << "special packets of " << totalBytes << " total bytes to node:" << node->getUUID();
-    }
+    #ifdef EXTRA_ERASE_DEBUGGING
+        if (packetsSent > 0) {
+            qDebug() << "EntityServer::sendSpecialPackets() sent " << packetsSent << "special packets of " 
+                        << totalBytes << " total bytes to node:" << node->getUUID();
+        }
+    #endif
 
     // TODO: caller is expecting a packetLength, what if we send more than one packet??
     return totalBytes;

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -570,7 +570,7 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
         }
 
 
-        if (somethingToSend) {
+        if (somethingToSend && _myServer->wantsVerboseDebug()) {
             qDebug() << "Hit PPS Limit, packetsSentThisInterval =" << packetsSentThisInterval
                      << "  maxPacketsPerInterval = " << maxPacketsPerInterval
                      << "  clientMaxPacketsPerInterval = " << clientMaxPacketsPerInterval;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -25,7 +25,7 @@
 #include "RecurseOctreeToMapOperator.h"
 #include "LogHandler.h"
 
-const quint64 EntityTree::DELETED_ENTITIES_EXTRA_USECS_TO_CONSIDER = USECS_PER_MSEC * 50;
+static const quint64 DELETED_ENTITIES_EXTRA_USECS_TO_CONSIDER = USECS_PER_MSEC * 50;
 
 EntityTree::EntityTree(bool shouldReaverage) :
     Octree(shouldReaverage),
@@ -392,10 +392,8 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
 
         if (getIsServer()) {
             // set up the deleted entities ID
-            {
-                QWriteLocker locker(&_recentlyDeletedEntitiesLock);
-                _recentlyDeletedEntityItemIDs.insert(deletedAt, theEntity->getEntityItemID());
-            }
+            QWriteLocker locker(&_recentlyDeletedEntitiesLock);
+            _recentlyDeletedEntityItemIDs.insert(deletedAt, theEntity->getEntityItemID());
         }
 
         if (_simulation) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -942,6 +942,7 @@ void EntityTree::forgetEntitiesDeletedBefore(quint64 sinceTime) {
 
 // TODO: consider consolidating processEraseMessageDetails() and processEraseMessage()
 int EntityTree::processEraseMessage(NLPacket& packet, const SharedNodePointer& sourceNode) {
+    qDebug() << "EntityTree::processEraseMessage()";
     withWriteLock([&] {
         packet.seek(sizeof(OCTREE_PACKET_FLAGS) + sizeof(OCTREE_PACKET_SEQUENCE) + sizeof(OCTREE_PACKET_SENT_TIME));
 
@@ -959,6 +960,7 @@ int EntityTree::processEraseMessage(NLPacket& packet, const SharedNodePointer& s
                 }
 
                 QUuid entityID = QUuid::fromRfc4122(packet.readWithoutCopy(NUM_BYTES_RFC4122_UUID));
+                qDebug() << "    ---- EntityTree::processEraseMessage() contained ID:" << entityID;
 
                 EntityItemID entityItemID(entityID);
                 entityItemIDsToDelete << entityItemID;
@@ -978,6 +980,7 @@ int EntityTree::processEraseMessage(NLPacket& packet, const SharedNodePointer& s
 // NOTE: Caller must lock the tree before calling this.
 // TODO: consider consolidating processEraseMessageDetails() and processEraseMessage()
 int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, const SharedNodePointer& sourceNode) {
+    qDebug() << "EntityTree::processEraseMessageDetails()";
     const unsigned char* packetData = (const unsigned char*)dataByteArray.constData();
     const unsigned char* dataAt = packetData;
     size_t packetLength = dataByteArray.size();
@@ -1003,6 +1006,8 @@ int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, cons
             QUuid entityID = QUuid::fromRfc4122(encodedID);
             dataAt += encodedID.size();
             processedBytes += encodedID.size();
+
+            qDebug() << "    ---- EntityTree::processEraseMessageDetails() contains id:" << entityID;
 
             EntityItemID entityItemID(entityID);
             entityItemIDsToDelete << entityItemID;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -862,6 +862,12 @@ std::unique_ptr<NLPacket> EntityTree::encodeEntitiesDeletedSince(OCTREE_PACKET_S
                 // if the timestamp is more recent then out last sent time, include it
                 if (it.key() > considerEntitiesSince) {
                     QUuid entityID = values.at(valueItem);
+
+                    // FIXME - we still seem to see cases where incorrect EntityIDs get sent from the server
+                    // to the client. These were causing "lost" entities like flashlights and laser pointers
+                    // now that we keep around some additional history of the erased entities and resend that
+                    // history for a longer time window, these entities are not "lost". But we haven't yet
+                    // found/fixed the underlying issue that caused bad UUIDs to be sent to some users.
                     deletesPacket->write(entityID.toRfc4122());
                     ++numberOfIDs;
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -147,7 +147,6 @@ public:
     void addNewlyCreatedHook(NewlyCreatedEntityHook* hook);
     void removeNewlyCreatedHook(NewlyCreatedEntityHook* hook);
 
-    static const quint64 DELETED_ENTITIES_EXTRA_USECS_TO_CONSIDER;
     bool hasAnyDeletedEntities() const { return _recentlyDeletedEntityItemIDs.size() > 0; }
     bool hasEntitiesDeletedSince(quint64 sinceTime);
     std::unique_ptr<NLPacket> encodeEntitiesDeletedSince(OCTREE_PACKET_SEQUENCE sequenceNumber, quint64& sinceTime,

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -147,6 +147,7 @@ public:
     void addNewlyCreatedHook(NewlyCreatedEntityHook* hook);
     void removeNewlyCreatedHook(NewlyCreatedEntityHook* hook);
 
+    static const quint64 DELETED_ENTITIES_EXTRA_USECS_TO_CONSIDER;
     bool hasAnyDeletedEntities() const { return _recentlyDeletedEntityItemIDs.size() > 0; }
     bool hasEntitiesDeletedSince(quint64 sinceTime);
     std::unique_ptr<NLPacket> encodeEntitiesDeletedSince(OCTREE_PACKET_SEQUENCE sequenceNumber, quint64& sinceTime,


### PR DESCRIPTION
Sometimes laser beams and flashlight lights are left around. This PR improves that situation by keeping some additional erase entities history and sending it to viewers over a longer time window.

This doesn't address the core issue (which I have still not found yet) where for some reason the entity IDs are mixed up when being sent from the server to some viewers.