### PR TITLE
QTryRead/WriteLocker

### DIFF
--- a/libraries/shared/src/shared/QTryReadLocker.h
+++ b/libraries/shared/src/shared/QTryReadLocker.h
@@ -1,0 +1,92 @@
+//
+//  QTryReadLocker.h
+//  shared/src/shared/QTryReadLocker.h
+//
+//  Created by Clément Brisset on 10/29/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_QTryReadLocker_h
+#define hifi_QTryReadLocker_h
+
+#include <QtCore/QReadWriteLock>
+
+class QTryReadLocker {
+public:
+    QTryReadLocker(QReadWriteLock* readWriteLock);
+    QTryReadLocker(QReadWriteLock* readWriteLock, int timeout);
+    ~QTryReadLocker();
+    
+    bool isLocked() const;
+    
+    void unlock();
+    bool tryRelock();
+    bool tryRelock(int timeout);
+    
+    QReadWriteLock* readWriteLock() const;
+    
+private:
+    Q_DISABLE_COPY(QTryReadLocker)
+    quintptr q_val;
+};
+
+// Implementation
+inline QTryReadLocker::QTryReadLocker(QReadWriteLock *areadWriteLock) :
+    q_val(reinterpret_cast<quintptr>(areadWriteLock))
+{
+    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+               "QTryReadLocker", "QTryReadLocker pointer is misaligned");
+    tryRelock();
+}
+
+inline QTryReadLocker::QTryReadLocker(QReadWriteLock *areadWriteLock, int timeout) :
+    q_val(reinterpret_cast<quintptr>(areadWriteLock))
+{
+    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+               "QTryReadLocker", "QTryReadLocker pointer is misaligned");
+    tryRelock(timeout);
+}
+
+inline QTryReadLocker::~QTryReadLocker() {
+    unlock();
+}
+
+inline bool QTryReadLocker::isLocked() const {
+    return (q_val & quintptr(1u)) == quintptr(1u);
+}
+
+inline void QTryReadLocker::unlock() {
+    if (q_val && isLocked()) {
+        q_val &= ~quintptr(1u);
+        readWriteLock()->unlock();
+    }
+}
+
+inline bool QTryReadLocker::tryRelock() {
+    if (q_val && !isLocked()) {
+        if (readWriteLock()->tryLockForRead()) {
+            q_val |= quintptr(1u);
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool QTryReadLocker::tryRelock(int timeout) {
+    if (q_val && !isLocked()) {
+        if (readWriteLock()->tryLockForRead(timeout)) {
+            q_val |= quintptr(1u);
+            return true;
+        }
+    }
+    return false;
+}
+
+inline QReadWriteLock* QTryReadLocker::readWriteLock() const {
+    return reinterpret_cast<QReadWriteLock*>(q_val & ~quintptr(1u));
+}
+
+#endif // hifi_QTryReadLocker_h

--- a/libraries/shared/src/shared/QTryReadLocker.h
+++ b/libraries/shared/src/shared/QTryReadLocker.h
@@ -30,22 +30,22 @@ public:
     
 private:
     Q_DISABLE_COPY(QTryReadLocker)
-    quintptr q_val;
+    quintptr _val;
 };
 
 // Implementation
-inline QTryReadLocker::QTryReadLocker(QReadWriteLock *areadWriteLock) :
-    q_val(reinterpret_cast<quintptr>(areadWriteLock))
+inline QTryReadLocker::QTryReadLocker(QReadWriteLock* areadWriteLock) :
+    _val(reinterpret_cast<quintptr>(areadWriteLock))
 {
-    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+    Q_ASSERT_X((_val & quintptr(1u)) == quintptr(0),
                "QTryReadLocker", "QTryReadLocker pointer is misaligned");
     tryRelock();
 }
 
-inline QTryReadLocker::QTryReadLocker(QReadWriteLock *areadWriteLock, int timeout) :
-    q_val(reinterpret_cast<quintptr>(areadWriteLock))
+inline QTryReadLocker::QTryReadLocker(QReadWriteLock* areadWriteLock, int timeout) :
+    _val(reinterpret_cast<quintptr>(areadWriteLock))
 {
-    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+    Q_ASSERT_X((_val & quintptr(1u)) == quintptr(0),
                "QTryReadLocker", "QTryReadLocker pointer is misaligned");
     tryRelock(timeout);
 }
@@ -55,20 +55,20 @@ inline QTryReadLocker::~QTryReadLocker() {
 }
 
 inline bool QTryReadLocker::isLocked() const {
-    return (q_val & quintptr(1u)) == quintptr(1u);
+    return (_val & quintptr(1u)) == quintptr(1u);
 }
 
 inline void QTryReadLocker::unlock() {
-    if (q_val && isLocked()) {
-        q_val &= ~quintptr(1u);
+    if (_val && isLocked()) {
+        _val &= ~quintptr(1u);
         readWriteLock()->unlock();
     }
 }
 
 inline bool QTryReadLocker::tryRelock() {
-    if (q_val && !isLocked()) {
+    if (_val && !isLocked()) {
         if (readWriteLock()->tryLockForRead()) {
-            q_val |= quintptr(1u);
+            _val |= quintptr(1u);
             return true;
         }
     }
@@ -76,9 +76,9 @@ inline bool QTryReadLocker::tryRelock() {
 }
 
 inline bool QTryReadLocker::tryRelock(int timeout) {
-    if (q_val && !isLocked()) {
+    if (_val && !isLocked()) {
         if (readWriteLock()->tryLockForRead(timeout)) {
-            q_val |= quintptr(1u);
+            _val |= quintptr(1u);
             return true;
         }
     }
@@ -86,7 +86,7 @@ inline bool QTryReadLocker::tryRelock(int timeout) {
 }
 
 inline QReadWriteLock* QTryReadLocker::readWriteLock() const {
-    return reinterpret_cast<QReadWriteLock*>(q_val & ~quintptr(1u));
+    return reinterpret_cast<QReadWriteLock*>(_val & ~quintptr(1u));
 }
 
 #endif // hifi_QTryReadLocker_h

--- a/libraries/shared/src/shared/QTryWriteLocker.h
+++ b/libraries/shared/src/shared/QTryWriteLocker.h
@@ -30,22 +30,22 @@ public:
     
 private:
     Q_DISABLE_COPY(QTryWriteLocker)
-    quintptr q_val;
+    quintptr _val;
 };
 
 // Implementation
-inline QTryWriteLocker::QTryWriteLocker(QReadWriteLock *readWriteLock) :
-    q_val(reinterpret_cast<quintptr>(readWriteLock))
+inline QTryWriteLocker::QTryWriteLocker(QReadWriteLock* readWriteLock) :
+    _val(reinterpret_cast<quintptr>(readWriteLock))
 {
-    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+    Q_ASSERT_X((_val & quintptr(1u)) == quintptr(0),
                "QTryWriteLocker", "QTryWriteLocker pointer is misaligned");
     tryRelock();
 }
 
-inline QTryWriteLocker::QTryWriteLocker(QReadWriteLock *readWriteLock, int timeout) :
-    q_val(reinterpret_cast<quintptr>(readWriteLock))
+inline QTryWriteLocker::QTryWriteLocker(QReadWriteLock* readWriteLock, int timeout) :
+    _val(reinterpret_cast<quintptr>(readWriteLock))
 {
-    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+    Q_ASSERT_X((_val & quintptr(1u)) == quintptr(0),
                "QTryWriteLocker", "QTryWriteLocker pointer is misaligned");
     tryRelock(timeout);
 }
@@ -55,20 +55,20 @@ inline QTryWriteLocker::~QTryWriteLocker() {
 }
 
 inline bool QTryWriteLocker::isLocked() const {
-    return (q_val & quintptr(1u)) == quintptr(1u);
+    return (_val & quintptr(1u)) == quintptr(1u);
 }
 
 inline void QTryWriteLocker::unlock() {
-    if (q_val && isLocked()) {
-        q_val &= ~quintptr(1u);
+    if (_val && isLocked()) {
+        _val &= ~quintptr(1u);
         readWriteLock()->unlock();
     }
 }
 
 inline bool QTryWriteLocker::tryRelock() {
-    if (q_val && !isLocked()) {
+    if (_val && !isLocked()) {
         if (readWriteLock()->tryLockForWrite()) {
-            q_val |= quintptr(1u);
+            _val |= quintptr(1u);
             return true;
         }
     }
@@ -76,9 +76,9 @@ inline bool QTryWriteLocker::tryRelock() {
 }
 
 inline bool QTryWriteLocker::tryRelock(int timeout) {
-    if (q_val && !isLocked()) {
+    if (_val && !isLocked()) {
         if (readWriteLock()->tryLockForWrite(timeout)) {
-            q_val |= quintptr(1u);
+            _val |= quintptr(1u);
             return true;
         }
     }
@@ -86,7 +86,7 @@ inline bool QTryWriteLocker::tryRelock(int timeout) {
 }
 
 inline QReadWriteLock* QTryWriteLocker::readWriteLock() const {
-    return reinterpret_cast<QReadWriteLock*>(q_val & ~quintptr(1u));
+    return reinterpret_cast<QReadWriteLock*>(_val & ~quintptr(1u));
 }
 
 #endif // hifi_QTryWriteLocker_h

--- a/libraries/shared/src/shared/QTryWriteLocker.h
+++ b/libraries/shared/src/shared/QTryWriteLocker.h
@@ -1,0 +1,92 @@
+//
+//  QTryWriteLocker.h
+//  shared/src/shared/QTryWriteLocker.h
+//
+//  Created by Clément Brisset on 10/29/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_QTryWriteLocker_h
+#define hifi_QTryWriteLocker_h
+
+#include <QtCore/QReadWriteLock>
+
+class QTryWriteLocker {
+public:
+    QTryWriteLocker(QReadWriteLock* readWriteLock);
+    QTryWriteLocker(QReadWriteLock* readWriteLock, int timeout);
+    ~QTryWriteLocker();
+    
+    bool isLocked() const;
+    
+    void unlock();
+    bool tryRelock();
+    bool tryRelock(int timeout);
+    
+    QReadWriteLock* readWriteLock() const;
+    
+private:
+    Q_DISABLE_COPY(QTryWriteLocker)
+    quintptr q_val;
+};
+
+// Implementation
+inline QTryWriteLocker::QTryWriteLocker(QReadWriteLock *readWriteLock) :
+    q_val(reinterpret_cast<quintptr>(readWriteLock))
+{
+    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+               "QTryWriteLocker", "QTryWriteLocker pointer is misaligned");
+    tryRelock();
+}
+
+inline QTryWriteLocker::QTryWriteLocker(QReadWriteLock *readWriteLock, int timeout) :
+    q_val(reinterpret_cast<quintptr>(readWriteLock))
+{
+    Q_ASSERT_X((q_val & quintptr(1u)) == quintptr(0),
+               "QTryWriteLocker", "QTryWriteLocker pointer is misaligned");
+    tryRelock(timeout);
+}
+
+inline QTryWriteLocker::~QTryWriteLocker() {
+    unlock();
+}
+
+inline bool QTryWriteLocker::isLocked() const {
+    return (q_val & quintptr(1u)) == quintptr(1u);
+}
+
+inline void QTryWriteLocker::unlock() {
+    if (q_val && isLocked()) {
+        q_val &= ~quintptr(1u);
+        readWriteLock()->unlock();
+    }
+}
+
+inline bool QTryWriteLocker::tryRelock() {
+    if (q_val && !isLocked()) {
+        if (readWriteLock()->tryLockForWrite()) {
+            q_val |= quintptr(1u);
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool QTryWriteLocker::tryRelock(int timeout) {
+    if (q_val && !isLocked()) {
+        if (readWriteLock()->tryLockForWrite(timeout)) {
+            q_val |= quintptr(1u);
+            return true;
+        }
+    }
+    return false;
+}
+
+inline QReadWriteLock* QTryWriteLocker::readWriteLock() const {
+    return reinterpret_cast<QReadWriteLock*>(q_val & ~quintptr(1u));
+}
+
+#endif // hifi_QTryWriteLocker_h

--- a/libraries/shared/src/shared/ReadWriteLockable.h
+++ b/libraries/shared/src/shared/ReadWriteLockable.h
@@ -9,54 +9,118 @@
 #pragma once
 #ifndef hifi_ReadWriteLockable_h
 #define hifi_ReadWriteLockable_h
+
+#include <utility>
+
 #include <QtCore/QReadWriteLock>
+
+#include "QTryReadLocker.h"
+#include "QTryWriteLocker.h"
 
 class ReadWriteLockable {
 public:
+    // Write locks
     template <typename F>
-    bool withWriteLock(F f, bool require = true) const {
-        if (!require) {
-            bool result = _lock.tryLockForWrite();
-            if (result) {
-                f();
-                _lock.unlock();
-            }
-            return result;
-        }
-
-        QWriteLocker locker(&_lock);
-        f();
-        return true;
-    }
+    bool withWriteLock(F f) const;
+    
+    template <typename F>
+    bool withWriteLock(F&& f, bool require) const;
 
     template <typename F>
-    bool withTryWriteLock(F f) const {
-        return withWriteLock(f, false);
-    }
-
+    bool withTryWriteLock(F f) const;
+    
     template <typename F>
-    bool withReadLock(F f, bool require = true) const {
-        if (!require) {
-            bool result = _lock.tryLockForRead();
-            if (result) {
-                f();
-                _lock.unlock();
-            }
-            return result;
-        }
-
-        QReadLocker locker(&_lock);
-        f();
-        return true;
-    }
-
+    bool withTryWriteLock(F f, int timeout) const;
+    
+    // Read locks
     template <typename F>
-    bool withTryReadLock(F f) const {
-        return withReadLock(f, false);
-    }
+    bool withReadLock(F f) const;
+    
+    template <typename F>
+    bool withReadLock(F&& f, bool require) const;
+    
+    template <typename F>
+    bool withTryReadLock(F f) const;
+    
+    template <typename F>
+    bool withTryReadLock(F f, int timeout) const;
 
 private:
     mutable QReadWriteLock _lock{ QReadWriteLock::Recursive };
 };
+
+// ReadWriteLockable
+template <typename F>
+inline bool ReadWriteLockable::withWriteLock(F f) const {
+    QWriteLocker locker(&_lock);
+    f();
+    return true;
+}
+
+template <typename F>
+inline bool ReadWriteLockable::withWriteLock(F&& f, bool require) const {
+    if (require) {
+        return withWriteLock(std::forward<F>(f));
+    } else {
+        return withTryReadLock(std::forward<F>(f));
+    }
+}
+
+template <typename F>
+inline bool ReadWriteLockable::withTryWriteLock(F f) const {
+    QTryWriteLocker locker(&_lock);
+    if (locker.isLocked()) {
+        f();
+        return true;
+    }
+    return false;
+}
+
+template <typename F>
+inline bool ReadWriteLockable::withTryWriteLock(F f, int timeout) const {
+    QTryWriteLocker locker(&_lock, timeout);
+    if (locker.isLocked()) {
+        f();
+        return true;
+    }
+    return false;
+}
+
+template <typename F>
+inline bool ReadWriteLockable::withReadLock(F f) const {
+    QReadLocker locker(&_lock);
+    f();
+    return true;
+}
+
+template <typename F>
+inline bool ReadWriteLockable::withReadLock(F&& f, bool require) const {
+    if (require) {
+        return withReadLock(std::forward<F>(f));
+    } else {
+        return withTryReadLock(std::forward<F>(f));
+    }
+}
+
+template <typename F>
+inline bool ReadWriteLockable::withTryReadLock(F f) const {
+    QTryReadLocker locker(&_lock);
+    if (locker.isLocked()) {
+        f();
+        return true;
+    }
+    return false;
+}
+
+template <typename F>
+inline bool ReadWriteLockable::withTryReadLock(F f, int timeout) const {
+    QTryReadLocker locker(&_lock, timeout);
+    if (locker.isLocked()) {
+        f();
+        return true;
+    }
+    return false;
+}
+
 
 #endif

--- a/libraries/shared/src/shared/ReadWriteLockable.h
+++ b/libraries/shared/src/shared/ReadWriteLockable.h
@@ -21,37 +21,37 @@ class ReadWriteLockable {
 public:
     // Write locks
     template <typename F>
-    bool withWriteLock(F f) const;
+    bool withWriteLock(F&& f) const;
     
     template <typename F>
     bool withWriteLock(F&& f, bool require) const;
 
     template <typename F>
-    bool withTryWriteLock(F f) const;
+    bool withTryWriteLock(F&& f) const;
     
     template <typename F>
-    bool withTryWriteLock(F f, int timeout) const;
+    bool withTryWriteLock(F&& f, int timeout) const;
     
     // Read locks
     template <typename F>
-    bool withReadLock(F f) const;
+    bool withReadLock(F&& f) const;
     
     template <typename F>
     bool withReadLock(F&& f, bool require) const;
     
     template <typename F>
-    bool withTryReadLock(F f) const;
+    bool withTryReadLock(F&& f) const;
     
     template <typename F>
-    bool withTryReadLock(F f, int timeout) const;
+    bool withTryReadLock(F&& f, int timeout) const;
 
 private:
-    mutable QReadWriteLock _lock{ QReadWriteLock::Recursive };
+    mutable QReadWriteLock _lock { QReadWriteLock::Recursive };
 };
 
 // ReadWriteLockable
 template <typename F>
-inline bool ReadWriteLockable::withWriteLock(F f) const {
+inline bool ReadWriteLockable::withWriteLock(F&& f) const {
     QWriteLocker locker(&_lock);
     f();
     return true;
@@ -67,7 +67,7 @@ inline bool ReadWriteLockable::withWriteLock(F&& f, bool require) const {
 }
 
 template <typename F>
-inline bool ReadWriteLockable::withTryWriteLock(F f) const {
+inline bool ReadWriteLockable::withTryWriteLock(F&& f) const {
     QTryWriteLocker locker(&_lock);
     if (locker.isLocked()) {
         f();
@@ -77,7 +77,7 @@ inline bool ReadWriteLockable::withTryWriteLock(F f) const {
 }
 
 template <typename F>
-inline bool ReadWriteLockable::withTryWriteLock(F f, int timeout) const {
+inline bool ReadWriteLockable::withTryWriteLock(F&& f, int timeout) const {
     QTryWriteLocker locker(&_lock, timeout);
     if (locker.isLocked()) {
         f();
@@ -87,7 +87,7 @@ inline bool ReadWriteLockable::withTryWriteLock(F f, int timeout) const {
 }
 
 template <typename F>
-inline bool ReadWriteLockable::withReadLock(F f) const {
+inline bool ReadWriteLockable::withReadLock(F&& f) const {
     QReadLocker locker(&_lock);
     f();
     return true;
@@ -103,7 +103,7 @@ inline bool ReadWriteLockable::withReadLock(F&& f, bool require) const {
 }
 
 template <typename F>
-inline bool ReadWriteLockable::withTryReadLock(F f) const {
+inline bool ReadWriteLockable::withTryReadLock(F&& f) const {
     QTryReadLocker locker(&_lock);
     if (locker.isLocked()) {
         f();
@@ -113,7 +113,7 @@ inline bool ReadWriteLockable::withTryReadLock(F f) const {
 }
 
 template <typename F>
-inline bool ReadWriteLockable::withTryReadLock(F f, int timeout) const {
+inline bool ReadWriteLockable::withTryReadLock(F&& f, int timeout) const {
     QTryReadLocker locker(&_lock, timeout);
     if (locker.isLocked()) {
         f();

--- a/libraries/shared/src/shared/ReadWriteLockable.h
+++ b/libraries/shared/src/shared/ReadWriteLockable.h
@@ -21,7 +21,7 @@ class ReadWriteLockable {
 public:
     // Write locks
     template <typename F>
-    bool withWriteLock(F&& f) const;
+    void withWriteLock(F&& f) const;
     
     template <typename F>
     bool withWriteLock(F&& f, bool require) const;
@@ -34,7 +34,7 @@ public:
     
     // Read locks
     template <typename F>
-    bool withReadLock(F&& f) const;
+    void withReadLock(F&& f) const;
     
     template <typename F>
     bool withReadLock(F&& f, bool require) const;
@@ -51,16 +51,16 @@ private:
 
 // ReadWriteLockable
 template <typename F>
-inline bool ReadWriteLockable::withWriteLock(F&& f) const {
+inline void ReadWriteLockable::withWriteLock(F&& f) const {
     QWriteLocker locker(&_lock);
     f();
-    return true;
 }
 
 template <typename F>
 inline bool ReadWriteLockable::withWriteLock(F&& f, bool require) const {
     if (require) {
-        return withWriteLock(std::forward<F>(f));
+        withWriteLock(std::forward<F>(f));
+        return true;
     } else {
         return withTryReadLock(std::forward<F>(f));
     }
@@ -87,16 +87,16 @@ inline bool ReadWriteLockable::withTryWriteLock(F&& f, int timeout) const {
 }
 
 template <typename F>
-inline bool ReadWriteLockable::withReadLock(F&& f) const {
+inline void ReadWriteLockable::withReadLock(F&& f) const {
     QReadLocker locker(&_lock);
     f();
-    return true;
 }
 
 template <typename F>
 inline bool ReadWriteLockable::withReadLock(F&& f, bool require) const {
     if (require) {
-        return withReadLock(std::forward<F>(f));
+        withReadLock(std::forward<F>(f));
+        return true;
     } else {
         return withTryReadLock(std::forward<F>(f));
     }


### PR DESCRIPTION
Makes ReadWriteLocker safe against function that might throw.

The reason I named those classes QTryReadLocker/QTryWriteLocker is because I'm hoping I can get those accepted into Qt, then we'll just have to remove those files.