### PR TITLE
Fix models resizing

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -89,11 +89,7 @@ void Model::setScale(const glm::vec3& scale) {
 }
 
 void Model::setScaleInternal(const glm::vec3& scale) {
-    float scaleLength = glm::length(_scale);
-    float relativeDeltaScale = glm::length(_scale - scale) / scaleLength;
-
-    const float ONE_PERCENT = 0.01f;
-    if (relativeDeltaScale > ONE_PERCENT || scaleLength < EPSILON) {
+    if (glm::distance(_scale, scale) > METERS_PER_MILLIMETER) {
         _scale = scale;
         initJointTransforms();
     }


### PR DESCRIPTION
When models are MUCH bigger one one axis than the others
and we modify the scale only of one of those small axis,
it wouldn't propagate because the change was relatively
too small conpared to the size of the model