### PR TITLE
simplify MyAvatar::deriveBodyFromHMDSensor() take 2

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -125,7 +125,7 @@ MyAvatar::MyAvatar(RigPointer rig) :
         AVATAR_FRAME_TYPE = recording::Frame::registerFrameType(HEADER_NAME);
     });
 
-    // FIXME how to deal with driving multiple avatars locally?  
+    // FIXME how to deal with driving multiple avatars locally?
     Frame::registerFrameHandler(AVATAR_FRAME_TYPE, [this](Frame::ConstPointer frame) {
         qDebug() << "Playback of avatar frame length: " << frame->data.size();
         avatarStateFromFrame(frame->data, this);
@@ -363,7 +363,6 @@ void MyAvatar::updateHMDFollowVelocity() {
     bool avatarIsMoving = glm::length(_velocity - _followVelocity) > FOLLOW_THRESHOLD_SPEED;
     bool shouldFollow = hmdIsAtRest || avatarIsMoving;
 
-    // linear part
     _followOffsetDistance = glm::length(offset);
     if (_followOffsetDistance < FOLLOW_MIN_DISTANCE) {
         // close enough

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -356,18 +356,20 @@ void MyAvatar::updateHMDFollowVelocity() {
 
     const float FOLLOW_TIMESCALE = 0.5f;
     const float FOLLOW_THRESHOLD_SPEED = 0.2f;
-    const float FOLLOW_MIN_DISTANCE = 0.02f;
+    const float FOLLOW_MIN_DISTANCE = 0.01f;
     const float FOLLOW_THRESHOLD_DISTANCE = 0.2f;
+    const float FOLLOW_MAX_IDLE_DISTANCE = 0.1f;
 
     bool hmdIsAtRest = _hmdAtRestDetector.update(_hmdSensorPosition, _hmdSensorOrientation);
-    bool avatarIsMoving = glm::length(_velocity - _followVelocity) > FOLLOW_THRESHOLD_SPEED;
-    bool shouldFollow = hmdIsAtRest || avatarIsMoving;
 
     _followOffsetDistance = glm::length(offset);
     if (_followOffsetDistance < FOLLOW_MIN_DISTANCE) {
         // close enough
         _followOffsetDistance = 0.0f;
     } else {
+        bool avatarIsMoving = glm::length(_velocity - _followVelocity) > FOLLOW_THRESHOLD_SPEED;
+        bool shouldFollow = (hmdIsAtRest || avatarIsMoving) && _followOffsetDistance > FOLLOW_MAX_IDLE_DISTANCE;
+
         glm::vec3 truncatedOffset = offset;
         if (truncatedOffset.y < 0.0f) {
             truncatedOffset.y = 0.0f;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -330,7 +330,7 @@ private:
     PalmData getActivePalmData(int palmIndex) const;
 
     // derive avatar body position and orientation from the current HMD Sensor location.
-    // results are in sensor space
+    // results are in HMD frame
     glm::mat4 deriveBodyFromHMDSensor() const;
 
     float _driveKeys[MAX_DRIVE_KEYS];

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -208,7 +208,7 @@ public:
 
     void prepareForPhysicsSimulation();
     void harvestResultsFromPhysicsSimulation();
-    void adjustSensorTransform(glm::vec3 hmdShift);
+    void adjustSensorTransform();
 
     const QString& getCollisionSoundURL() { return _collisionSoundURL; }
     void setCollisionSoundURL(const QString& url);
@@ -394,9 +394,10 @@ private:
 
     // used to transform any sensor into world space, including the _hmdSensorMat, or hand controllers.
     glm::mat4 _sensorToWorldMatrix;
-    glm::vec3 _hmdFollowOffset { Vectors::ZERO };
-    glm::vec3 _hmdFollowVelocity { Vectors::ZERO };
-    float _hmdFollowSpeed { 0.0f };
+
+    glm::vec3 _followVelocity { Vectors::ZERO };
+    float _followSpeed { 0.0f };
+    float _followOffsetDistance { 0.0f };
 
     bool _goToPending;
     glm::vec3 _goToPosition;
@@ -413,9 +414,6 @@ private:
     AudioListenerMode _audioListenerMode;
     glm::vec3 _customListenPosition;
     glm::quat _customListenOrientation;
-
-    bool _isFollowingHMD { false };
-    float _followHMDAlpha { 0.0f };
 
     AtRestDetector _hmdAtRestDetector;
     bool _lastIsMoving { false };

--- a/interface/src/avatar/MyCharacterController.h
+++ b/interface/src/avatar/MyCharacterController.h
@@ -64,8 +64,8 @@ public:
     void getAvatarPositionAndOrientation(glm::vec3& position, glm::quat& rotation) const;
 
     void setTargetVelocity(const glm::vec3& velocity);
-    void setHMDVelocity(const glm::vec3& velocity);
-    glm::vec3 getHMDShift() const { return _lastStepDuration * bulletToGLM(_hmdVelocity); }
+    void setFollowVelocity(const glm::vec3& velocity);
+    float getFollowTime() const { return _followTime; }
 
     glm::vec3 getLinearVelocity() const;
 
@@ -75,7 +75,7 @@ protected:
 protected:
     btVector3 _currentUp;
     btVector3 _walkVelocity;
-    btVector3 _hmdVelocity;
+    btVector3 _followVelocity;
     btTransform _avatarBodyTransform;
 
     glm::vec3 _shapeLocalOffset;
@@ -93,7 +93,7 @@ protected:
     btScalar _gravity;
 
     btScalar _jumpSpeed;
-    btScalar _lastStepDuration;
+    btScalar _followTime;
 
     bool _enabled;
     bool _isOnGround;

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -214,6 +214,8 @@ public:
 
     bool getModelOffset(glm::vec3& modelOffsetOut) const;
 
+    const glm::vec3& getEyesInRootFrame() const { return _eyesInRootFrame; }
+
  protected:
     void updateAnimationStateHandlers();
 
@@ -221,6 +223,8 @@ public:
     void updateNeckJoint(int index, const HeadParameters& params);
     void updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::quat& worldHeadOrientation, const glm::vec3& lookAt, const glm::vec3& saccade);
     void calcAnimAlpha(float speed, const std::vector<float>& referenceSpeeds, float* alphaOut) const;
+
+    void computeEyesInRootFrame(const AnimPoseVec& poses);
 
     QVector<JointState> _jointStates;
     int _rootJointIndex = -1;
@@ -241,6 +245,7 @@ public:
     glm::vec3 _lastFront;
     glm::vec3 _lastPosition;
     glm::vec3 _lastVelocity;
+    glm::vec3 _eyesInRootFrame { Vectors::ZERO };
 
     std::shared_ptr<AnimNode> _animNode;
     std::shared_ptr<AnimSkeleton> _animSkeleton;


### PR DESCRIPTION
This is another attempt to salvage some code I've been working on for a while.

We are now using a more correct measure of "eyes to hips" using the current animation state rather than an approximation.

I also simplified the logic that decides when to start/stop "straightening" the animation state, which happens when the location of the hips deviates significantly from that of the avatar's position.