### PR TITLE
AvatarMixer: remove redundant identity packet send

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -245,9 +245,8 @@ void AvatarMixer::broadcastAvatarData() {
                         return;
                     }
 
-                    // if an avatar has just connected make sure we send out the mesh and billboard
-                    bool forceSend = !nodeData->checkAndSetHasReceivedFirstPackets()
-                        || !otherNodeData->checkAndSetHasReceivedFirstPacketsFrom(node->getUUID());
+                    // make sure we send out identity and billboard packets to and from new arrivals.
+                    bool forceSend = !otherNodeData->checkAndSetHasReceivedFirstPacketsFrom(node->getUUID());
 
                     // we will also force a send of billboard or identity packet
                     // if either has changed in the last frame

--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -21,12 +21,6 @@ int AvatarMixerClientData::parseData(NLPacket& packet) {
     return _avatar.parseDataFromBuffer(packet.readWithoutCopy(packet.bytesLeftToRead()));
 }
 
-bool AvatarMixerClientData::checkAndSetHasReceivedFirstPackets() {
-    bool oldValue = _hasReceivedFirstPackets;
-    _hasReceivedFirstPackets = true;
-    return oldValue;
-}
-
 bool AvatarMixerClientData::checkAndSetHasReceivedFirstPacketsFrom(const QUuid& uuid) {
     if (_hasReceivedFirstPacketsFrom.find(uuid) == _hasReceivedFirstPacketsFrom.end()) {
         _hasReceivedFirstPacketsFrom.insert(uuid);

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -36,7 +36,6 @@ public:
     int parseData(NLPacket& packet);
     AvatarData& getAvatar() { return _avatar; }
 
-    bool checkAndSetHasReceivedFirstPackets();
     bool checkAndSetHasReceivedFirstPacketsFrom(const QUuid& uuid);
 
     uint16_t getLastBroadcastSequenceNumber(const QUuid& nodeUUID) const;
@@ -87,7 +86,6 @@ private:
     std::unordered_map<QUuid, uint16_t> _lastBroadcastSequenceNumbers;
     std::unordered_set<QUuid> _hasReceivedFirstPacketsFrom;
 
-    bool _hasReceivedFirstPackets = false;
     quint64 _billboardChangeTimestamp = 0;
     quint64 _identityChangeTimestamp = 0;
 


### PR DESCRIPTION
Removed AvatarClientData::checkAndSetHasReceivedFirstPackets boolean.
This is handled by the AvatarClientData::checkAndSetHasReceivedFirstPacketsFrom set.