### PR TITLE
Messaging Improvements

### DIFF
--- a/assignment-client/src/messages/MessagesMixer.cpp
+++ b/assignment-client/src/messages/MessagesMixer.cpp
@@ -37,7 +37,9 @@ MessagesMixer::~MessagesMixer() {
 }
 
 void MessagesMixer::nodeKilled(SharedNodePointer killedNode) {
-    // FIXME - remove the node from the subscription maps
+    for (auto& channel : _channelSubscribers) {
+        channel.remove(killedNode->getUUID());
+    }
 }
 
 void MessagesMixer::handleMessages(QSharedPointer<NLPacketList> packetList, SharedNodePointer senderNode) {

--- a/examples/example/messagesExample.js
+++ b/examples/example/messagesExample.js
@@ -38,6 +38,6 @@ Script.update.connect(function (deltaTime) {
 });
 
 
-Messages.messageReceived.connect(function (channel, message) {
-    print("message received on channel:" + channel + ", message:" + message);
+Messages.messageReceived.connect(function (channel, message, senderID) {
+    print("message received on channel:" + channel + ", message:" + message + ", senderID:" + senderID);
 });

--- a/examples/example/messagesExample.js
+++ b/examples/example/messagesExample.js
@@ -12,29 +12,25 @@ Script.update.connect(function (deltaTime) {
         subscribedForTime += deltaTime;
     }
 
-    if (totalTime > 5) {
-
-        // if we've been unsubscribed for SWITCH_SUBSCRIPTION_TIME seconds, subscribe
-        if (!subscribed && unsubscribedForTime > SWITCH_SUBSCRIPTION_TIME) {
-            print("---- subscribing ----");
-            Messages.subscribe(channel);
-            subscribed = true;
-            subscribedForTime = 0;
-        }
-
-        // if we've been subscribed for SWITCH_SUBSCRIPTION_TIME seconds, unsubscribe
-        if (subscribed && subscribedForTime > SWITCH_SUBSCRIPTION_TIME) {
-            print("---- unsubscribing ----");
-            Messages.unsubscribe(channel);
-            subscribed = false;
-            unsubscribedForTime = 0;
-        }
-
-        // Even if not subscribed, still publish
-        var message = "update() deltaTime:" + deltaTime;
-        //print(message);
-        Messages.sendMessage(channel, message);
+    // if we've been unsubscribed for SWITCH_SUBSCRIPTION_TIME seconds, subscribe
+    if (!subscribed && unsubscribedForTime > SWITCH_SUBSCRIPTION_TIME) {
+        print("---- subscribing ----");
+        Messages.subscribe(channel);
+        subscribed = true;
+        subscribedForTime = 0;
     }
+
+    // if we've been subscribed for SWITCH_SUBSCRIPTION_TIME seconds, unsubscribe
+    if (subscribed && subscribedForTime > SWITCH_SUBSCRIPTION_TIME) {
+        print("---- unsubscribing ----");
+        Messages.unsubscribe(channel);
+        subscribed = false;
+        unsubscribedForTime = 0;
+    }
+
+    // Even if not subscribed, still publish
+    var message = "update() deltaTime:" + deltaTime;
+    Messages.sendMessage(channel, message);
 });
 
 

--- a/examples/example/messagesReceiverExample.js
+++ b/examples/example/messagesReceiverExample.js
@@ -16,7 +16,6 @@ function myUpdate(deltaTime) {
 
 Script.update.connect(myUpdate);
 
-Messages.messageReceived.connect(function (channel, message) {
-    print("message received on channel:" + channel + ", message:" + message);
+Messages.messageReceived.connect(function (channel, message, senderID) {
+    print("message received on channel:" + channel + ", message:" + message + ", senderID:" + senderID);
 });
-

--- a/examples/example/messagesReceiverExample.js
+++ b/examples/example/messagesReceiverExample.js
@@ -1,21 +1,7 @@
-var totalTime = 0;
-var subscribed = false;
-var WAIT_FOR_SUBSCRIPTION_TIME = 10;
-function myUpdate(deltaTime) {
-    var channel = "example";
-    totalTime += deltaTime;
-
-    if (totalTime > WAIT_FOR_SUBSCRIPTION_TIME && !subscribed) {
-
-        print("---- subscribing ----");
-        Messages.subscribe(channel);
-        subscribed = true;
-        Script.update.disconnect(myUpdate);
-    }
-}
-
-Script.update.connect(myUpdate);
+print("---- subscribing ----");
+Messages.subscribe(channel);
 
 Messages.messageReceived.connect(function (channel, message, senderID) {
     print("message received on channel:" + channel + ", message:" + message + ", senderID:" + senderID);
 });
+

--- a/examples/example/messagesReceiverExample.js
+++ b/examples/example/messagesReceiverExample.js
@@ -1,5 +1,5 @@
 print("---- subscribing ----");
-Messages.subscribe(channel);
+Messages.subscribe("example");
 
 Messages.messageReceived.connect(function (channel, message, senderID) {
     print("message received on channel:" + channel + ", message:" + message + ", senderID:" + senderID);

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -530,10 +530,20 @@ SharedNodePointer LimitedNodeList::addOrUpdateNode(const QUuid& uuid, NodeType_t
         qCDebug(networking) << "Added" << *newNode;
 
         emit nodeAdded(newNodePointer);
+        if (newNodePointer->getActiveSocket()) {
+            emit nodeActivated(newNodePointer);
+        } else {
+            connect(newNodePointer.data(), &NetworkPeer::socketActivated, this, [=] {
+                emit nodeActivated(newNodePointer);
+                disconnect(newNodePointer.data(), &NetworkPeer::socketActivated, this, 0);
+            });
+        }
 
         return newNodePointer;
     }
 }
+
+
 
 std::unique_ptr<NLPacket> LimitedNodeList::constructPingPacket(PingType_t pingType) {
     int packetSize = sizeof(PingType_t) + sizeof(quint64);

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -239,6 +239,7 @@ signals:
     void uuidChanged(const QUuid& ownerUUID, const QUuid& oldUUID);
     void nodeAdded(SharedNodePointer);
     void nodeKilled(SharedNodePointer);
+    void nodeActivated(SharedNodePointer);
 
     void localSockAddrChanged(const HifiSockAddr& localSockAddr);
     void publicSockAddrChanged(const HifiSockAddr& publicSockAddr);

--- a/libraries/networking/src/MessagesClient.cpp
+++ b/libraries/networking/src/MessagesClient.cpp
@@ -101,7 +101,9 @@ void MessagesClient::unsubscribe(const QString& channel) {
 
 void MessagesClient::handleNodeAdded(SharedNodePointer node) {
     if (node->getType() == NodeType::MessagesMixer) {
+        qDebug() << "messages-mixer node type added...";
         for (const auto& channel : _subscribedChannels) {
+            qDebug() << "subscribing to channel:" << channel;
             subscribe(channel);
         }
     }

--- a/libraries/networking/src/MessagesClient.cpp
+++ b/libraries/networking/src/MessagesClient.cpp
@@ -84,6 +84,7 @@ void MessagesClient::subscribe(const QString& channel) {
         auto packetList = NLPacketList::create(PacketType::MessagesSubscribe, QByteArray(), true, true);
         packetList->write(channel.toUtf8());
         nodeList->sendPacketList(std::move(packetList), *messagesMixer);
+        qDebug() << "sending MessagesSubscribe for channel:" << channel;
     }
 }
 

--- a/libraries/networking/src/MessagesClient.cpp
+++ b/libraries/networking/src/MessagesClient.cpp
@@ -51,7 +51,7 @@ void MessagesClient::handleMessagesPacket(QSharedPointer<NLPacketList> packetLis
     auto messageData = packet.read(messageLength);
     QString message = QString::fromUtf8(messageData);
 
-    emit messageReceived(channel, message);
+    emit messageReceived(channel, message, senderNode->getUUID());
 }
 
 void MessagesClient::sendMessage(const QString& channel, const QString& message) {

--- a/libraries/networking/src/MessagesClient.h
+++ b/libraries/networking/src/MessagesClient.h
@@ -37,7 +37,10 @@ signals:
 
 private slots:
     void handleMessagesPacket(QSharedPointer<NLPacketList> packetList, SharedNodePointer senderNode);
-    void handleNodeKilled(SharedNodePointer node);
+    void handleNodeAdded(SharedNodePointer node);
+
+protected:
+    QSet<QString> _subscribedChannels;
 };
 
 #endif

--- a/libraries/networking/src/MessagesClient.h
+++ b/libraries/networking/src/MessagesClient.h
@@ -37,11 +37,9 @@ signals:
 
 private slots:
     void handleMessagesPacket(QSharedPointer<NLPacketList> packetList, SharedNodePointer senderNode);
-    void handleNodeAdded(SharedNodePointer node);
-    void socketActivated(const HifiSockAddr& sockAddr);
+    void handleNodeActivated(SharedNodePointer node);
 
 protected:
-    void resubscribeToAll();
     QSet<QString> _subscribedChannels;
 };
 

--- a/libraries/networking/src/MessagesClient.h
+++ b/libraries/networking/src/MessagesClient.h
@@ -33,7 +33,7 @@ public:
     Q_INVOKABLE void unsubscribe(const QString& channel);
 
 signals:
-    void messageReceived(const QString& channel, const QString& message);
+    void messageReceived(const QString& channel, const QString& message, const QUuid& senderUUID);
 
 private slots:
     void handleMessagesPacket(QSharedPointer<NLPacketList> packetList, SharedNodePointer senderNode);

--- a/libraries/networking/src/MessagesClient.h
+++ b/libraries/networking/src/MessagesClient.h
@@ -38,8 +38,10 @@ signals:
 private slots:
     void handleMessagesPacket(QSharedPointer<NLPacketList> packetList, SharedNodePointer senderNode);
     void handleNodeAdded(SharedNodePointer node);
+    void socketActivated(const HifiSockAddr& sockAddr);
 
 protected:
+    void resubscribeToAll();
     QSet<QString> _subscribedChannels;
 };
 


### PR DESCRIPTION
- include senderUUID in the `messageReceived()` event
- properly remove subscribers from channels when the node disconnects
- handle `Messages.subscribe()` when no messages mixer is available or if it disconnects and reconnects
