### PR TITLE
Exclude avatar scales out of the permissable range

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -178,7 +178,7 @@ float AvatarData::getTargetScale() const {
 
 void AvatarData::setTargetScale(float targetScale, bool overideReferential) {
     if (!_referential || overideReferential) {
-        _targetScale = targetScale;
+        _targetScale = std::max(MIN_AVATAR_SCALE, std::min(MAX_AVATAR_SCALE, targetScale));
     }
 }
 
@@ -532,7 +532,7 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
             }
             return maxAvailableSize;
         }
-        _targetScale = scale;
+        _targetScale = std::max(MIN_AVATAR_SCALE, std::min(MAX_AVATAR_SCALE, scale));
     } // 20 bytes
 
     { // Lookat Position


### PR DESCRIPTION
Working in the recording code, at least twice users have ended up with nonsensical scale values in their INI files, causing problems.  This PR prevents the application of any scale outside of the declared min and max values, eliminating the possibility of things like negative scales.
