### PR TITLE
Improvments to Bubblewand

### DIFF
--- a/examples/toybox/bubblewand/createWand.js
+++ b/examples/toybox/bubblewand/createWand.js
@@ -12,8 +12,8 @@
 
 Script.include("../../libraries/utils.js");
 
-var WAND_MODEL = 'http://hifi-public.s3.amazonaws.com/models/bubblewand/wand.fbx';
-var WAND_COLLISION_SHAPE = 'http://hifi-public.s3.amazonaws.com/models/bubblewand/actual_no_top_collision_hull.obj';
+var WAND_MODEL = 'http://hifi-content.s3.amazonaws.com/james/bubblewand/wand.fbx';
+var WAND_COLLISION_SHAPE = 'http://hifi-content.s3.amazonaws.com/james/bubblewand/wand_collision_hull.obj';
 
 var WAND_SCRIPT_URL = Script.resolvePath("wand.js");
 
@@ -48,8 +48,8 @@ var wand = Entities.addEntity({
         grabbableKey:{
             invertSolidWhileHeld:true,
             spatialKey:{
-               relativePosition:{x:0,y:1,z:0},
-               relativeRotation:Quat.fromPitchYawRollDegrees(0,90,0)
+               relativePosition:{x:0,y:0.1,z:0},
+               relativeRotation:Quat.fromPitchYawRollDegrees(0,0,90)
             }
         }
     })

--- a/examples/toybox/bubblewand/createWand.js
+++ b/examples/toybox/bubblewand/createWand.js
@@ -43,5 +43,14 @@ var wand = Entities.addEntity({
     //must be enabled to be grabbable in the physics engine
     collisionsWillMove: true,
     compoundShapeURL: WAND_COLLISION_SHAPE,
-    script: WAND_SCRIPT_URL
+    script: WAND_SCRIPT_URL,
+    userData:JSON.stringify({
+        grabbableKey:{
+            invertSolidWhileHeld:true,
+            spatialKey:{
+               relativePosition:{x:0,y:1,z:0},
+               relativeRotation:Quat.fromPitchYawRollDegrees(0,90,0)
+            }
+        }
+    })
 });

--- a/examples/toybox/bubblewand/createWand.js
+++ b/examples/toybox/bubblewand/createWand.js
@@ -44,12 +44,16 @@ var wand = Entities.addEntity({
     collisionsWillMove: true,
     compoundShapeURL: WAND_COLLISION_SHAPE,
     script: WAND_SCRIPT_URL,
-    userData:JSON.stringify({
-        grabbableKey:{
-            invertSolidWhileHeld:true,
-            spatialKey:{
-               relativePosition:{x:0,y:0.1,z:0},
-               relativeRotation:Quat.fromPitchYawRollDegrees(0,0,90)
+    userData: JSON.stringify({
+        grabbableKey: {
+            invertSolidWhileHeld: true,
+            spatialKey: {
+                relativePosition: {
+                    x: 0,
+                    y: 0.1,
+                    z: 0
+                },
+                relativeRotation: Quat.fromPitchYawRollDegrees(0, 0, 90)
             }
         }
     })

--- a/examples/toybox/bubblewand/wand.js
+++ b/examples/toybox/bubblewand/wand.js
@@ -12,7 +12,7 @@
 
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 
-(function () {
+(function() {
 
     Script.include("../../libraries/utils.js");
 
@@ -58,23 +58,23 @@
     BubbleWand.prototype = {
         timePassed: null,
         currentBubble: null,
-        preload: function (entityID) {
+        preload: function(entityID) {
             this.entityID = entityID;
         },
-        getWandTipPosition: function (properties) {
+        getWandTipPosition: function(properties) {
             //the tip of the wand is going to be in a different place than the center, so we move in space relative to the model to find that position
             var upVector = Quat.getUp(properties.rotation);
             var upOffset = Vec3.multiply(upVector, WAND_TIP_OFFSET);
             var wandTipPosition = Vec3.sum(properties.position, upOffset);
             return wandTipPosition;
         },
-        addCollisionsToBubbleAfterCreation: function (bubble) {
+        addCollisionsToBubbleAfterCreation: function(bubble) {
             //if the bubble collide immediately, we get weird effects.  so we add collisions after release
             Entities.editEntity(bubble, {
                 collisionsWillMove: true
             });
         },
-        randomizeBubbleGravity: function () {
+        randomizeBubbleGravity: function() {
             //change up the gravity a little bit for variation in floating effects
             var randomNumber = randFloat(BUBBLE_GRAVITY_MIN, BUBBLE_GRAVITY_MAX);
             var gravity = {
@@ -84,7 +84,7 @@
             };
             return gravity;
         },
-        growBubbleWithWandVelocity: function (properties, deltaTime) {
+        growBubbleWithWandVelocity: function(properties, deltaTime) {
             //get the wand and tip position for calculations
             var wandPosition = properties.position;
             this.getWandTipPosition(properties);
@@ -113,7 +113,6 @@
                     Entities.editEntity(this.currentBubble, {
                         velocity: velocity,
                         lifetime: lifetime,
-                        ignoreForCollisions:false,
                         gravity: this.randomizeBubbleGravity()
                     });
 
@@ -146,7 +145,7 @@
                 dimensions: dimensions
             });
         },
-        createBubbleAtTipOfWand: function () {
+        createBubbleAtTipOfWand: function() {
 
             //create a new bubble at the tip of the wand
             var properties = Entities.getEntityProperties(this.entityID, ["position", "rotation"]);
@@ -169,17 +168,16 @@
             });
 
         },
-        startNearGrab: function () {
+        startNearGrab: function() {
             //create a bubble to grow at the start of the grab
             if (this.currentBubble === null) {
                 this.createBubbleAtTipOfWand();
             }
         },
-        continueNearGrab: function () {
+        continueNearGrab: function() {
             var deltaTime = checkInterval();
             //only get the properties that we need
             var properties = Entities.getEntityProperties(this.entityID, ["position", "rotation"]);
-
 
             var wandTipPosition = this.getWandTipPosition(properties);
 
@@ -190,7 +188,7 @@
             this.growBubbleWithWandVelocity(properties, deltaTime);
 
         },
-        releaseGrab: function () {
+        releaseGrab: function() {
             //delete the  current buble and reset state when the wand is released
             Entities.deleteEntity(this.currentBubble);
             this.currentBubble = null;

--- a/examples/toybox/bubblewand/wand.js
+++ b/examples/toybox/bubblewand/wand.js
@@ -113,6 +113,7 @@
                     Entities.editEntity(this.currentBubble, {
                         velocity: velocity,
                         lifetime: lifetime,
+                        ignoreForCollisions:false,
                         gravity: this.randomizeBubbleGravity()
                     });
 
@@ -162,7 +163,7 @@
                 position: this.getWandTipPosition(properties),
                 dimensions: BUBBLE_INITIAL_DIMENSIONS,
                 collisionsWillMove: false,
-                ignoreForCollisions: false,
+                ignoreForCollisions: true,
                 linearDamping: BUBBLE_LINEAR_DAMPING,
                 shapeType: "sphere"
             });


### PR DESCRIPTION
This PR:
- Swaps the collision hull
- Inverts wand solidity while you hold it
- Makes bubbles solid once they're released
- Adds a spatial key for when the wand is equipped
 
Known Issue: The spatial key should be mirrored per hand, right now the wand is upright in your left hand when equipped and upside down in your right hand when equipped.  There is a fix for this in the Baseball PR, and once that's merged this may need an update in its userData to work with that API