### PR TITLE
Possible fix to abandoned lines/entities

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -500,6 +500,15 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         }
     }
 
+    // before proceeding, check to see if this is an entity that we know has been deleted, which
+    // might happen in the case of out-of-order and/or recorvered packets, if we've deleted the entity
+    // we can confidently ignore this packet
+    EntityTreePointer tree = getTree();
+    if (tree && tree->isDeletedEntity(_id)) {
+        qDebug() << "Recieved packet for previously deleted entity [" << _id << "] ignoring. (inside " << __FUNCTION__ << ")";
+        ignoreServerPacket = true;
+    }
+
     if (ignoreServerPacket) {
         overwriteLocalData = false;
         #ifdef WANT_DEBUG

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -68,6 +68,7 @@ void EntityTree::eraseAllOctreeElements(bool createNewRoot) {
     Octree::eraseAllOctreeElements(createNewRoot);
 
     resetClientEditStats();
+    clearDeletedEntities();
 }
 
 bool EntityTree::handlesEditPacketType(PacketType packetType) const {
@@ -398,6 +399,9 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
             // set up the deleted entities ID
             QWriteLocker locker(&_recentlyDeletedEntitiesLock);
             _recentlyDeletedEntityItemIDs.insert(deletedAt, theEntity->getEntityItemID());
+        } else {
+            // on the client side, we also remember that we deleted this entity, we don't care about the time
+            trackDeletedEntity(theEntity->getEntityItemID());
         }
 
         if (_simulation) {

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -894,12 +894,19 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
                     entityItem = EntityTypes::constructEntityItem(dataAt, bytesLeftToRead, args);
                     if (entityItem) {
                         bytesForThisEntity = entityItem->readEntityDataFromBuffer(dataAt, bytesLeftToRead, args);
-                        addEntityItem(entityItem); // add this new entity to this elements entities
-                        entityItemID = entityItem->getEntityItemID();
-                        _myTree->setContainingElement(entityItemID, getThisPointer());
-                        _myTree->postAddEntity(entityItem);
-                        if (entityItem->getCreated() == UNKNOWN_CREATED_TIME) {
-                            entityItem->recordCreationTime();
+
+                        // don't add if we've recently deleted....
+                        if (!_myTree->isDeletedEntity(entityItem->getID())) {
+                            addEntityItem(entityItem); // add this new entity to this elements entities
+                            entityItemID = entityItem->getEntityItemID();
+                            _myTree->setContainingElement(entityItemID, getThisPointer());
+                            _myTree->postAddEntity(entityItem);
+                            if (entityItem->getCreated() == UNKNOWN_CREATED_TIME) {
+                                entityItem->recordCreationTime();
+                            }
+                        } else {
+                            qDebug() << "Recieved packet for previously deleted entity [" << 
+                                        entityItem->getID() << "] ignoring. (inside " << __FUNCTION__ << ")";
                         }
                     }
                 }


### PR DESCRIPTION
don't apply out of order edits to entities that have been deleted