### PR TITLE
implement support to download the persist file from entity server status page

### DIFF
--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -59,6 +59,9 @@ public:
     bool isInitialLoadComplete() const { return (_persistThread) ? _persistThread->isInitialLoadComplete() : true; }
     bool isPersistEnabled() const { return (_persistThread) ? true : false; }
     quint64 getLoadElapsedTime() const { return (_persistThread) ? _persistThread->getLoadElapsedTime() : 0; }
+    QString getPersistFilename() const { return (_persistThread) ? _persistThread->getPersistFilename() : ""; }
+    QString getPersistFileMimeType() const { return (_persistThread) ? _persistThread->getPersistFileMimeType() : "text/plain"; }
+    QByteArray getPersistFileContents() const { return (_persistThread) ? _persistThread->getPersistFileContents() : QByteArray(); }
 
     // Subclasses must implement these methods
     virtual OctreeQueryNode* createOctreeQueryNode() = 0;
@@ -173,6 +176,7 @@ protected:
 
     int _persistInterval;
     bool _wantBackup;
+    bool _persistFileDownload;
     QString _backupExtensionFormat;
     int _backupInterval;
     int _maxBackupVersions;

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -477,6 +477,14 @@
           "advanced": true
         },
         {
+          "name": "persistFileDownload",
+          "type": "checkbox",
+          "label": "Persist File Download",
+          "help": "Includes a download link to the persist file in the server status page.",
+          "default": false,
+          "advanced": true
+        },
+        {
           "name": "wantEditLogging",
           "type": "checkbox",
           "label": "Edit Logging",

--- a/libraries/embedded-webserver/src/HTTPConnection.cpp
+++ b/libraries/embedded-webserver/src/HTTPConnection.cpp
@@ -23,7 +23,9 @@ const char* HTTPConnection::StatusCode301 = "301 Moved Permanently";
 const char* HTTPConnection::StatusCode302 = "302 Found";
 const char* HTTPConnection::StatusCode400 = "400 Bad Request";
 const char* HTTPConnection::StatusCode401 = "401 Unauthorized";
+const char* HTTPConnection::StatusCode403 = "403 Forbidden";
 const char* HTTPConnection::StatusCode404 = "404 Not Found";
+const char* HTTPConnection::StatusCode500 = "500 Internal server error";
 const char* HTTPConnection::DefaultContentType = "text/plain; charset=ISO-8859-1";
 
 HTTPConnection::HTTPConnection (QTcpSocket* socket, HTTPManager* parentManager) :

--- a/libraries/embedded-webserver/src/HTTPConnection.h
+++ b/libraries/embedded-webserver/src/HTTPConnection.h
@@ -47,7 +47,9 @@ public:
     static const char* StatusCode302;
     static const char* StatusCode400;
     static const char* StatusCode401;
+    static const char* StatusCode403;
     static const char* StatusCode404;
+    static const char* StatusCode500;
     static const char* DefaultContentType;
 
     /// WebSocket close status codes.

--- a/libraries/octree/src/OctreePersistThread.cpp
+++ b/libraries/octree/src/OctreePersistThread.cpp
@@ -52,6 +52,15 @@ OctreePersistThread::OctreePersistThread(OctreePointer tree, const QString& file
     _filename = sansExt + "." + _persistAsFileType;
 }
 
+QString OctreePersistThread::getPersistFileMimeType() const {
+    if (_persistAsFileType == "json") {
+        return "application/json";
+    } if (_persistAsFileType == "json.gz") {
+        return "application/zip";
+    }
+    return "";
+}
+
 void OctreePersistThread::parseSettings(const QJsonObject& settings) {
     if (settings["backups"].isArray()) {
         const QJsonArray& backupRules = settings["backups"].toArray();
@@ -227,6 +236,15 @@ void OctreePersistThread::aboutToFinish() {
     persist();
     qCDebug(octree) << "Persist thread done with about to finish...";
     _stopThread = true;
+}
+
+QByteArray OctreePersistThread::getPersistFileContents() const {
+    QByteArray fileContents;
+    QFile file(_filename);
+    if (file.open(QIODevice::ReadOnly)) {
+        fileContents = file.readAll();
+    }
+    return fileContents;
 }
 
 void OctreePersistThread::persist() {

--- a/libraries/octree/src/OctreePersistThread.h
+++ b/libraries/octree/src/OctreePersistThread.h
@@ -42,6 +42,10 @@ public:
 
     void aboutToFinish(); /// call this to inform the persist thread that the owner is about to finish to support final persist
 
+    QString getPersistFilename() const { return _filename; }
+    QString getPersistFileMimeType() const;
+    QByteArray getPersistFileContents() const;
+
 signals:
     void loadCompleted();
 


### PR DESCRIPTION
If you've enabled detail entity server stats, that page will now include a download link to allow you to download the most recent persisted file.