### PR TITLE
fix avatar reset

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -428,7 +428,7 @@ void MyAvatar::updateHMDFollowVelocity() {
         }
         if (_followSpeed > 0.0f) {
             // to compute new velocity we must rotate offset into the world-frame
-            glm::quat sensorToWorldRotation = extractRotation(_sensorToWorldMatrix);
+            glm::quat sensorToWorldRotation = glm::normalize(glm::quat_cast(_sensorToWorldMatrix));
             _followVelocity = _followSpeed * glm::normalize(sensorToWorldRotation * offset);
         }
     }

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -29,6 +29,7 @@ glm::mat4 OculusBaseDisplayPlugin::getProjection(Eye eye, const glm::mat4& baseP
 void OculusBaseDisplayPlugin::resetSensors() {
 #if (OVR_MAJOR_VERSION >= 6)
     ovr_RecenterPose(_hmd);
+    preRender();
 #endif
 }
 


### PR DESCRIPTION
Sometimes resetting the avatar didn't work. The reason was that, despite the fact the HmdSensor was being reset **before** the avatar reset code was reached, the hmd transform used in the reset calculations was stale.

The fix is to update the cached HmdSensor transform immediately after re-centering the sensor.