### PR TITLE
fix bug where observers don't see a held/equipped object moving

### DIFF
--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -328,5 +328,5 @@ void AvatarActionHold::deserialize(QByteArray serializedArguments) {
         _active = true;
     });
 
-    activateBody();
+    forceBodyNonStatic();
 }

--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -326,6 +326,7 @@ void AvatarActionHold::deserialize(QByteArray serializedArguments) {
         #endif
 
         _active = true;
-        activateBody();
     });
+
+    activateBody();
 }

--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -326,5 +326,6 @@ void AvatarActionHold::deserialize(QByteArray serializedArguments) {
         #endif
 
         _active = true;
+        activateBody();
     });
 }

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -398,6 +398,7 @@ public:
     void getAllTerseUpdateProperties(EntityItemProperties& properties) const;
 
     void flagForOwnership() { _dirtyFlags |= Simulation::DIRTY_SIMULATOR_OWNERSHIP; }
+    void flagForMotionStateChange() { _dirtyFlags |= Simulation::DIRTY_MOTION_TYPE; }
 
     bool addAction(EntitySimulation* simulation, EntityActionPointer action);
     bool updateAction(EntitySimulation* simulation, const QUuid& actionID, const QVariantMap& arguments);

--- a/libraries/physics/src/ObjectAction.cpp
+++ b/libraries/physics/src/ObjectAction.cpp
@@ -244,6 +244,15 @@ void ObjectAction::activateBody() {
     if (rigidBody) {
         rigidBody->activate();
     }
+    auto ownerEntity = _ownerEntity.lock();
+    if (!ownerEntity) {
+        return;
+    }
+    void* physicsInfo = ownerEntity->getPhysicsInfo();
+    ObjectMotionState* motionState = static_cast<ObjectMotionState*>(physicsInfo);
+    if (motionState && motionState->getMotionType() == MOTION_TYPE_STATIC) {
+        ownerEntity->flagForMotionStateChange();
+    }
 }
 
 bool ObjectAction::lifetimeIsOver() {

--- a/libraries/physics/src/ObjectAction.cpp
+++ b/libraries/physics/src/ObjectAction.cpp
@@ -244,6 +244,9 @@ void ObjectAction::activateBody() {
     if (rigidBody) {
         rigidBody->activate();
     }
+}
+
+void ObjectAction::forceBodyNonStatic() {
     auto ownerEntity = _ownerEntity.lock();
     if (!ownerEntity) {
         return;

--- a/libraries/physics/src/ObjectAction.h
+++ b/libraries/physics/src/ObjectAction.h
@@ -63,6 +63,7 @@ protected:
     virtual glm::vec3 getAngularVelocity();
     virtual void setAngularVelocity(glm::vec3 angularVelocity);
     virtual void activateBody();
+    virtual void forceBodyNonStatic();
 
     EntityItemWeakPointer _ownerEntity;
     QString _tag;


### PR DESCRIPTION
- fix a bug where a held object's motion-state might have a type of "static" so it wouldn't appear to move
