### PR TITLE
Let the AssertClient JS interface use global vars

### DIFF
--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -16,6 +16,7 @@
 #include <QtCore/QBuffer>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QThread>
+#include <QtScript/QScriptEngine>
 #include <QtNetwork/QNetworkDiskCache>
 
 #include "AssetRequest.h"
@@ -374,14 +375,19 @@ void AssetScriptingInterface::uploadData(QString data, QString extension, QScrip
         return;
     }
 
-    QObject::connect(upload, &AssetUpload::finished, this, [callback, extension](AssetUpload* upload, const QString& hash) mutable {
+    QObject::connect(upload, &AssetUpload::finished, this, [this, callback, extension](AssetUpload* upload, const QString& hash) mutable {
         if (callback.isFunction()) {
             QString url = "atp://" + hash + "." + extension;
             QScriptValueList args { url };
-            callback.call(QScriptValue(), args);
+            callback.call(_engine->currentContext()->thisObject(), args);
         }
     });
     upload->start();
+}
+
+AssetScriptingInterface::AssetScriptingInterface(QScriptEngine* engine) :
+    _engine(engine)
+{
 }
 
 void AssetScriptingInterface::downloadData(QString urlString, QScriptValue callback) {
@@ -410,14 +416,14 @@ void AssetScriptingInterface::downloadData(QString urlString, QScriptValue callb
 
     _pendingRequests << assetRequest;
 
-    connect(assetRequest, &AssetRequest::finished, [this, callback](AssetRequest* request) mutable {
+    connect(assetRequest, &AssetRequest::finished, this, [this, callback](AssetRequest* request) mutable {
         Q_ASSERT(request->getState() == AssetRequest::Finished);
 
         if (request->getError() == AssetRequest::Error::NoError) {
             if (callback.isFunction()) {
                 QString data = QString::fromUtf8(request->getData());
                 QScriptValueList args { data };
-                callback.call(QScriptValue(), args);
+                callback.call(_engine->currentContext()->thisObject(), args);
             }
         }
 

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -74,10 +74,13 @@ private:
 class AssetScriptingInterface : public QObject {
     Q_OBJECT
 public:
+    AssetScriptingInterface(QScriptEngine* engine);
+
     Q_INVOKABLE void uploadData(QString data, QString extension, QScriptValue callback);
     Q_INVOKABLE void downloadData(QString url, QScriptValue downloadComplete);
 protected:
     QSet<AssetRequest*> _pendingRequests;
+    QScriptEngine* _engine;
 };
 
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -196,7 +196,7 @@ private:
 
     ArrayBufferClass* _arrayBufferClass;
 
-    AssetScriptingInterface _assetScriptingInterface;
+    AssetScriptingInterface _assetScriptingInterface{ this };
 
     QHash<EntityItemID, RegisteredEventHandlers> _registeredHandlers;
     void forwardHandlerCall(const EntityItemID& entityID, const QString& eventName, QScriptValueList eventHanderArgs);


### PR DESCRIPTION
Fix a problem with the implementation of the call to uploadData and downloadData in the AssetClient interface