### PR TITLE
No more right-click-move editing in edit.js

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -738,6 +738,10 @@ var mousePressStartPosition = {
 var mouseDown = false;
 
 function mousePressEvent(event) {
+    if (!event.isLeftButton) {
+        // If another mouse button than left is pressed ignore it
+        return false;
+    }
     mouseDown = true;
     mousePressStartPosition = {
         x: event.x,

--- a/examples/edit.js
+++ b/examples/edit.js
@@ -392,6 +392,11 @@ var toolBar = (function() {
             url,
             file;
 
+        if (!event.isLeftButton) {
+            // if another mouse button than left is pressed ignore it
+            return false;
+        }
+
         clickedOverlay = Overlays.getOverlayAtPoint({
             x: event.x,
             y: event.y
@@ -738,10 +743,6 @@ var mousePressStartPosition = {
 var mouseDown = false;
 
 function mousePressEvent(event) {
-    if (!event.isLeftButton) {
-        // If another mouse button than left is pressed ignore it
-        return false;
-    }
     mouseDown = true;
     mousePressStartPosition = {
         x: event.x,

--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -2340,6 +2340,11 @@ SelectionDisplay = (function () {
 
     that.mousePressEvent = function(event) {
 
+        if (!event.isLeftButton) {
+            // if another mouse button than left is pressed ignore it
+            return false;
+        }
+
         var somethingClicked = false;
         var pickRay = Camera.computePickRay(event.x, event.y);
         


### PR DESCRIPTION
ignore other than left press events in edit.js, this makes the rightclick camera more comfortable while in edit.js/edit mode. The no-market info available is still present on right clicking an entity ;).