### PR TITLE
Fix for avatar eye tracking

### DIFF
--- a/libraries/animation/src/JointState.h
+++ b/libraries/animation/src/JointState.h
@@ -108,6 +108,7 @@ public:
     const glm::quat& getPostRotation() const { return _postRotation; }
     const glm::quat& getDefaultRotation() const { return _defaultRotation; }
     glm::vec3 getDefaultTranslation() const { return _defaultTranslation * _unitsScale; }
+    glm::vec3 getUnscaledDefaultTranslation() const { return _defaultTranslation; }
     const glm::quat& getInverseDefaultRotation() const { return _inverseDefaultRotation; }
     const QString& getName() const { return _name; }
     bool getIsFree() const { return _isFree; }

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1288,7 +1288,7 @@ void Rig::updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm
 
         // NOTE: at the moment we do the math in the world-frame, hence the inverse transform is more complex than usual.
         glm::mat4 inverse = glm::inverse(glm::mat4_cast(modelRotation) * parentState.getTransform() *
-                                         glm::translate(state.getDefaultTranslationInConstrainedFrame()) *
+                                         glm::translate(state.getUnscaledDefaultTranslation()) *
                                          state.getPreTransform() * glm::mat4_cast(state.getPreRotation() * state.getDefaultRotation()));
         glm::vec3 front = glm::vec3(inverse * glm::vec4(worldHeadOrientation * IDENTITY_FRONT, 0.0f));
         glm::vec3 lookAtDelta = lookAtSpot - modelTranslation;


### PR DESCRIPTION
When computing a full eye to world matrix, the translations need to be the geometry coordinate frame, not scaled into meters.