### PR TITLE
Update BUILD_OSX for CMake env vars.

### DIFF
--- a/BUILD_OSX.md
+++ b/BUILD_OSX.md
@@ -7,11 +7,18 @@ Please read the [general build guide](BUILD.md) for information on dependencies 
 
 We no longer require install of qt5 via our [homebrew formulas repository](https://github.com/highfidelity/homebrew-formulas). Versions of Qt that are 5.5.x and above provide a mechanism to disable the wireless scanning we previously had a custom patch for.
 
-###Qt
+###OpenSSL and Qt
 
-Assuming you've installed Qt 5 using the homebrew instructions above, you'll need to set QT_CMAKE_PREFIX_PATH so CMake can find your installation of Qt. For Qt 5.5.1 installed via homebrew, set QT_CMAKE_PREFIX_PATH as follows.
+Assuming you've installed OpenSSL or Qt 5 using the homebrew instructions above, you'll need to set OPENSSL_ROOT_DIR and QT_CMAKE_PREFIX_PATH so CMake can find your installations.
+For OpenSSL installed via homebrew, set OPENSSL_ROOT_DIR:
 
-    export QT_CMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.5.1/lib/cmake
+    export OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2d_1
+    
+For Qt 5.5.1 installed via homebrew, set QT_CMAKE_PREFIX_PATH as follows.
+
+    export QT_CMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.5.1_2/lib/cmake
+
+Not that these use the versions from homebrew formulae at the time of this writing, and the version in the path will likely change.
 
 ###Xcode
 If Xcode is your editor of choice, you can ask CMake to generate Xcode project files instead of Unix Makefiles.


### PR DESCRIPTION
- openssl requires OPENSSL_ROOT_DIR to be set.
- qt5 QT_CMAKE_PREFIX_PATH was outdated.