### PR TITLE
Fixes hand IK for some avatars

### DIFF
--- a/libraries/animation/src/AnimSkeleton.cpp
+++ b/libraries/animation/src/AnimSkeleton.cpp
@@ -49,23 +49,6 @@ const AnimPose& AnimSkeleton::getAbsoluteBindPose(int jointIndex) const {
     return _absoluteBindPoses[jointIndex];
 }
 
-AnimPose AnimSkeleton::getRootAbsoluteBindPoseByChildName(const QString& childName) const {
-    AnimPose pose = AnimPose::identity;
-    int jointIndex = nameToJointIndex(childName);
-    if (jointIndex >= 0) {
-        int numJoints = (int)(_absoluteBindPoses.size());
-        if (jointIndex < numJoints) {
-            int parentIndex = getParentIndex(jointIndex);
-            while (parentIndex != -1 && parentIndex < numJoints) {
-                jointIndex = parentIndex;
-                parentIndex = getParentIndex(jointIndex);
-            }
-            pose = _absoluteBindPoses[jointIndex];
-        }
-    }
-    return pose;
-}
-
 const AnimPose& AnimSkeleton::getRelativeBindPose(int jointIndex) const {
     return _relativeBindPoses[jointIndex];
 }

--- a/libraries/animation/src/AnimSkeleton.h
+++ b/libraries/animation/src/AnimSkeleton.h
@@ -31,7 +31,6 @@ public:
 
     // absolute pose, not relative to parent
     const AnimPose& getAbsoluteBindPose(int jointIndex) const;
-    AnimPose getRootAbsoluteBindPoseByChildName(const QString& childName) const;
 
     // relative to parent pose
     const AnimPose& getRelativeBindPose(int jointIndex) const;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1306,10 +1306,10 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
 
         // TODO: figure out how to obtain the yFlip from where it is actually stored
         glm::quat yFlipHACK = glm::angleAxis(PI, glm::vec3(0.0f, 1.0f, 0.0f));
-        AnimPose rootBindPose = _animSkeleton->getRootAbsoluteBindPoseByChildName("LeftHand");
+        AnimPose hipsBindPose = _animSkeleton->getAbsoluteBindPose(_animSkeleton->nameToJointIndex("Hips"));
         if (params.isLeftEnabled) {
-            _animVars.set("leftHandPosition", rootBindPose.trans + rootBindPose.rot * yFlipHACK * params.leftPosition);
-            _animVars.set("leftHandRotation", rootBindPose.rot * yFlipHACK * params.leftOrientation);
+            _animVars.set("leftHandPosition", hipsBindPose.trans + hipsBindPose.rot * yFlipHACK * params.leftPosition);
+            _animVars.set("leftHandRotation", hipsBindPose.rot * yFlipHACK * params.leftOrientation);
             _animVars.set("leftHandType", (int)IKTarget::Type::RotationAndPosition);
         } else {
             _animVars.unset("leftHandPosition");
@@ -1317,8 +1317,8 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
             _animVars.set("leftHandType", (int)IKTarget::Type::HipsRelativeRotationAndPosition);
         }
         if (params.isRightEnabled) {
-            _animVars.set("rightHandPosition", rootBindPose.trans + rootBindPose.rot * yFlipHACK * params.rightPosition);
-            _animVars.set("rightHandRotation", rootBindPose.rot * yFlipHACK * params.rightOrientation);
+            _animVars.set("rightHandPosition", hipsBindPose.trans + hipsBindPose.rot * yFlipHACK * params.rightPosition);
+            _animVars.set("rightHandRotation", hipsBindPose.rot * yFlipHACK * params.rightOrientation);
             _animVars.set("rightHandType", (int)IKTarget::Type::RotationAndPosition);
         } else {
             _animVars.unset("rightHandPosition");


### PR DESCRIPTION
Specifically:

   https://hifi-content.s3.amazonaws.com/ozan/dev/avatars/hifi_team/ryan/_test/ryan.fst
   https://hifi-content.s3.amazonaws.com/ozan/dev/avatars/hifi_team/brad/brad.fst
   https://s3.amazonaws.com/hifi-public/tony/blackmery/blackmery.fst

These avatars have "Hips" joints that are NOT the root of the skeleton.
This would cause the getRootAbsoluteBindPoseByChildName() to return (0,0,0).
Causing the IK targets to be lower then they should have.