### PR TITLE
Fix crash in WebWindowClass in debug build setTitle on open WebWindow

### DIFF
--- a/interface/src/scripting/WebWindowClass.cpp
+++ b/interface/src/scripting/WebWindowClass.cpp
@@ -196,5 +196,9 @@ QScriptValue WebWindowClass::constructor(QScriptContext* context, QScriptEngine*
 }
 
 void WebWindowClass::setTitle(const QString& title) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setTitle", Qt::AutoConnection, Q_ARG(QString, title));
+        return;
+    }
     _windowWidget->setWindowTitle(title);
 }


### PR DESCRIPTION
If running a debug build with a WebWindow open, changing domains and using setTitle() to update the window's title was causing Interface to crash.