### PR TITLE
Fix release hand message for bow

### DIFF
--- a/examples/toybox/bow/bow.js
+++ b/examples/toybox/bow/bow.js
@@ -216,7 +216,7 @@
             //  print('RELEASE GRAB EVENT')
             if (this.isGrabbed === true && this.hand === this.initialHand) {
 
-                Messages.sendMessage('Hifi-Beam-Disabler', "none")
+                Messages.sendMessage('Hifi-Hand-Disabler', "none")
 
                 this.isGrabbed = false;
                 this.stringDrawn = false;


### PR DESCRIPTION
This PR fixes the message that is sent to the handcontrollergrab scrtipt when the bow is released.  Now, your hand should become available as expected.