### PR TITLE
don't persist the octree if it never loaded

### DIFF
--- a/libraries/octree/src/OctreePersistThread.cpp
+++ b/libraries/octree/src/OctreePersistThread.cpp
@@ -248,7 +248,7 @@ QByteArray OctreePersistThread::getPersistFileContents() const {
 }
 
 void OctreePersistThread::persist() {
-    if (_tree->isDirty()) {
+    if (_tree->isDirty() && _initialLoadComplete) {
 
         _tree->withWriteLock([&] {
             qCDebug(octree) << "pruning Octree before saving...";


### PR DESCRIPTION
- fixes a case where a constantly restarting server could overwrite a good content file with empty content