### PR TITLE
fix infinite loop on shutdown in OctreeInboundPacketProcessor

### DIFF
--- a/assignment-client/src/octree/OctreeInboundPacketProcessor.h
+++ b/assignment-client/src/octree/OctreeInboundPacketProcessor.h
@@ -94,16 +94,16 @@ private:
     OctreeServer* _myServer;
     int _receivedPacketCount;
     
-    quint64 _totalTransitTime;
-    quint64 _totalProcessTime;
-    quint64 _totalLockWaitTime;
-    quint64 _totalElementsInPacket;
-    quint64 _totalPackets;
+    std::atomic<uint64_t> _totalTransitTime;
+    std::atomic<uint64_t> _totalProcessTime;
+    std::atomic<uint64_t> _totalLockWaitTime;
+    std::atomic<uint64_t> _totalElementsInPacket;
+    std::atomic<uint64_t> _totalPackets;
     
     NodeToSenderStatsMap _singleSenderStats;
     QReadWriteLock _senderStatsLock;
 
-    quint64 _lastNackTime;
+    std::atomic<uint64_t> _lastNackTime;
     bool _shuttingDown;
 };
 #endif // hifi_OctreeInboundPacketProcessor_h

--- a/assignment-client/src/octree/OctreeInboundPacketProcessor.h
+++ b/assignment-client/src/octree/OctreeInboundPacketProcessor.h
@@ -72,7 +72,7 @@ public:
 
     void resetStats();
 
-    NodeToSenderStatsMap& getSingleSenderStats() { return _singleSenderStats; }
+    NodeToSenderStatsMap getSingleSenderStats() { QReadLocker locker(&_senderStatsLock); return _singleSenderStats; }
 
     virtual void terminating() { _shuttingDown = true; ReceivedPacketProcessor::terminating(); }
 
@@ -101,6 +101,7 @@ private:
     quint64 _totalPackets;
     
     NodeToSenderStatsMap _singleSenderStats;
+    QReadWriteLock _senderStatsLock;
 
     quint64 _lastNackTime;
     bool _shuttingDown;

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -711,7 +711,7 @@ bool OctreeServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
 
 
         int senderNumber = 0;
-        NodeToSenderStatsMap& allSenderStats = _octreeInboundPacketProcessor->getSingleSenderStats();
+        NodeToSenderStatsMap allSenderStats = _octreeInboundPacketProcessor->getSingleSenderStats();
         for (NodeToSenderStatsMapConstIterator i = allSenderStats.begin(); i != allSenderStats.end(); i++) {
             senderNumber++;
             QUuid senderID = i.key();


### PR DESCRIPTION
- fixes an infinite loop in `OctreeInboundPacketProcessor::sendNackPackets()` that would occur if a node was removed between `isAlive` and `nodeWithUUID`