### PR TITLE
Avatar Sim Rate Display fix

### DIFF
--- a/interface/src/avatar/AvatarUpdate.cpp
+++ b/interface/src/avatar/AvatarUpdate.cpp
@@ -44,9 +44,11 @@ void AvatarUpdate::synchronousProcess() {
 bool AvatarUpdate::process() {
     PerformanceTimer perfTimer("AvatarUpdate");
     quint64 start = usecTimestampNow();
-    quint64 deltaMicroseconds = 0;
+    quint64 deltaMicroseconds = 10000;
     if (_lastAvatarUpdate > 0) {
         deltaMicroseconds = start - _lastAvatarUpdate;
+    } else {
+        deltaMicroseconds = 10000; // 10 ms
     }
     float deltaSeconds = (float) deltaMicroseconds / (float) USECS_PER_SECOND;
     _lastAvatarUpdate = start;


### PR DESCRIPTION
Division by zero on first update was causing the displayed
avatar simulation rate to be incorrect.