### PR TITLE
remove debug option for disabling physics updates

### DIFF
--- a/examples/utilities/tools/developerMenuItems.js
+++ b/examples/utilities/tools/developerMenuItems.js
@@ -19,7 +19,6 @@ var createdStereoInputMenuItem = false;
 var DEVELOPER_MENU = "Developer";
 
 var ENTITIES_MENU = DEVELOPER_MENU + " > Entities";
-var COLLISION_UPDATES_TO_SERVER = "Don't send collision updates to server";
 
 var RENDER_MENU = DEVELOPER_MENU + " > Render";
 var ENTITIES_ITEM = "Entities";
@@ -66,7 +65,6 @@ function setupMenus() {
         Menu.addMenuItem({ menuName: "Developer > Entities", menuItemName: "Don't Do Precision Picking", isCheckable: true, isChecked: false });
         Menu.addMenuItem({ menuName: "Developer > Entities", menuItemName: "Disable Light Entities", isCheckable: true, isChecked: false });
         */
-        Menu.addMenuItem({ menuName: ENTITIES_MENU, menuItemName: COLLISION_UPDATES_TO_SERVER, isCheckable: true, isChecked: false });
     }
     
     if (!Menu.menuExists(RENDER_MENU)) {
@@ -112,11 +110,7 @@ function setupMenus() {
 Menu.menuItemEvent.connect(function (menuItem) {
     print("menuItemEvent() in JS... menuItem=" + menuItem);
 
-    if (menuItem == COLLISION_UPDATES_TO_SERVER) {
-        var dontSendUpdates = Menu.isOptionChecked(COLLISION_UPDATES_TO_SERVER); 
-        print("  dontSendUpdates... checked=" + dontSendUpdates);
-        Entities.setSendPhysicsUpdates(!dontSendUpdates);
-    } else if (menuItem == ENTITIES_ITEM) {
+    if (menuItem == ENTITIES_ITEM) {
         Scene.shouldRenderEntities = Menu.isOptionChecked(ENTITIES_ITEM);
     } else if (menuItem == AVATARS_ITEM) {
         Scene.shouldRenderAvatars = Menu.isOptionChecked(AVATARS_ITEM);

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -32,7 +32,6 @@
 #include "EntityActionFactoryInterface.h"
 
 
-bool EntityItem::_sendPhysicsUpdates = true;
 int EntityItem::_maxActionsDataSize = 800;
 quint64 EntityItem::_rememberDeletedActionTime = 20 * USECS_PER_SECOND;
 

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -48,25 +48,6 @@ namespace render {
     class PendingChanges;
 }
 
-/*
-// these thesholds determine what updates will be ignored (client and server)
-const float IGNORE_POSITION_DELTA = 0.0001f;
-const float IGNORE_DIMENSIONS_DELTA = 0.0005f;
-const float IGNORE_ALIGNMENT_DOT = 0.99997f;
-const float IGNORE_LINEAR_VELOCITY_DELTA = 0.001f;
-const float IGNORE_DAMPING_DELTA = 0.001f;
-const float IGNORE_GRAVITY_DELTA = 0.001f;
-const float IGNORE_ANGULAR_VELOCITY_DELTA = 0.0002f;
-
-// these thresholds determine what updates will activate the physical object
-const float ACTIVATION_POSITION_DELTA = 0.005f;
-const float ACTIVATION_DIMENSIONS_DELTA = 0.005f;
-const float ACTIVATION_ALIGNMENT_DOT = 0.99990f;
-const float ACTIVATION_LINEAR_VELOCITY_DELTA = 0.01f;
-const float ACTIVATION_GRAVITY_DELTA = 0.1f;
-const float ACTIVATION_ANGULAR_VELOCITY_DELTA = 0.03f;
-*/
-
 #define DONT_ALLOW_INSTANTIATION virtual void pureVirtualFunctionPlaceHolder() = 0;
 #define ALLOW_INSTANTIATION virtual void pureVirtualFunctionPlaceHolder() { };
 
@@ -194,7 +175,7 @@ public:
 
     virtual bool supportsDetailedRayIntersection() const { return false; }
     virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
-                         bool& keepSearching, OctreeElementPointer& element, float& distance, 
+                         bool& keepSearching, OctreeElementPointer& element, float& distance,
                          BoxFace& face, glm::vec3& surfaceNormal,
                          void** intersectedObject, bool precisionPicking) const { return true; }
 
@@ -387,9 +368,6 @@ public:
     EntityTreePointer getTree() const;
     bool wantTerseEditLogging();
 
-    static void setSendPhysicsUpdates(bool value) { _sendPhysicsUpdates = value; }
-    static bool getSendPhysicsUpdates() { return _sendPhysicsUpdates; }
-
     glm::mat4 getEntityToWorldMatrix() const;
     glm::mat4 getWorldToEntityMatrix() const;
     glm::vec3 worldToEntity(const glm::vec3& point) const;
@@ -432,7 +410,6 @@ protected:
     const QByteArray getActionDataInternal() const;
     void setActionDataInternal(QByteArray actionData);
 
-    static bool _sendPhysicsUpdates;
     EntityTypes::EntityType _type;
     QUuid _id;
     quint64 _lastSimulated; // last time this entity called simulate(), this includes velocity, angular velocity,

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -167,8 +167,8 @@ QUuid EntityScriptingInterface::editEntity(QUuid id, EntityItemProperties proper
                     if (hasTerseUpdateChanges) {
                         entity->getAllTerseUpdateProperties(properties);
                     }
-                    // TODO: if we knew that ONLY TerseUpdate properties have changed in properties AND the object 
-                    // is dynamic AND it is active in the physics simulation then we could chose to NOT queue an update 
+                    // TODO: if we knew that ONLY TerseUpdate properties have changed in properties AND the object
+                    // is dynamic AND it is active in the physics simulation then we could chose to NOT queue an update
                     // and instead let the physics simulation decide when to send a terse update.  This would remove
                     // the "slide-no-rotate" glitch (and typical a double-update) that we see during the "poke rolling
                     // balls" test.  However, even if we solve this problem we still need to provide a "slerp the visible
@@ -332,15 +332,6 @@ void EntityScriptingInterface::setDrawZoneBoundaries(bool value) {
 bool EntityScriptingInterface::getDrawZoneBoundaries() const {
     return ZoneEntityItem::getDrawZoneBoundaries();
 }
-
-void EntityScriptingInterface::setSendPhysicsUpdates(bool value) {
-    EntityItem::setSendPhysicsUpdates(value);
-}
-
-bool EntityScriptingInterface::getSendPhysicsUpdates() const {
-    return EntityItem::getSendPhysicsUpdates();
-}
-
 
 RayToEntityIntersectionResult::RayToEntityIntersectionResult() :
     intersects(false),
@@ -548,16 +539,16 @@ bool EntityScriptingInterface::appendPoint(QUuid entityID, const glm::vec3& poin
     if (!entity) {
         qCDebug(entities) << "EntityScriptingInterface::setPoints no entity with ID" << entityID;
     }
-    
+
     EntityTypes::EntityType entityType = entity->getType();
-    
+
     if (entityType == EntityTypes::Line) {
         return setPoints(entityID, [point](LineEntityItem& lineEntity) -> bool
         {
             return (LineEntityItem*)lineEntity.appendPoint(point);
         });
     }
-    
+
     return false;
 }
 

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -127,9 +127,6 @@ public slots:
     Q_INVOKABLE void setDrawZoneBoundaries(bool value);
     Q_INVOKABLE bool getDrawZoneBoundaries() const;
 
-    Q_INVOKABLE void setSendPhysicsUpdates(bool value);
-    Q_INVOKABLE bool getSendPhysicsUpdates() const;
-
     Q_INVOKABLE bool setVoxelSphere(QUuid entityID, const glm::vec3& center, float radius, int value);
     Q_INVOKABLE bool setVoxel(QUuid entityID, const glm::vec3& position, int value);
     Q_INVOKABLE bool setAllVoxels(QUuid entityID, int value);

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -492,20 +492,14 @@ void EntityMotionState::sendUpdate(OctreeEditPacketSender* packetSender, const Q
         _nextOwnershipBid = now + USECS_BETWEEN_OWNERSHIP_BIDS;
     }
 
-    if (EntityItem::getSendPhysicsUpdates()) {
-        EntityItemID id(_entity->getID());
-        EntityEditPacketSender* entityPacketSender = static_cast<EntityEditPacketSender*>(packetSender);
-        #ifdef WANT_DEBUG
-            qCDebug(physics) << "EntityMotionState::sendUpdate()... calling queueEditEntityMessage()...";
-        #endif
+    EntityItemID id(_entity->getID());
+    EntityEditPacketSender* entityPacketSender = static_cast<EntityEditPacketSender*>(packetSender);
+    #ifdef WANT_DEBUG
+        qCDebug(physics) << "EntityMotionState::sendUpdate()... calling queueEditEntityMessage()...";
+    #endif
 
-        entityPacketSender->queueEditEntityMessage(PacketType::EntityEdit, id, properties);
-        _entity->setLastBroadcast(usecTimestampNow());
-    } else {
-        #ifdef WANT_DEBUG
-            qCDebug(physics) << "EntityMotionState::sendUpdate()... NOT sending update as requested.";
-        #endif
-    }
+    entityPacketSender->queueEditEntityMessage(PacketType::EntityEdit, id, properties);
+    _entity->setLastBroadcast(usecTimestampNow());
 
     _lastStep = step;
 }


### PR DESCRIPTION
We have a technical writeer who is working on some documentation of our JS API and was puzzling over these calls:

Entities.setSendPhysicsUpdates()
Entities.getSendPhysicsUpdates()

They are JS hooks for turning on an old debug feature that was useful when we were debugging the distributed physics system.

I'm pulling this feature out since it isn't very useful anymore.  When we next have to debug the physics system we'll make new temporary tools.