### PR TITLE
Fix ScriptEngine setting _isFinished when it shouldn't, causing scripts to accumulate when restarting

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -673,7 +673,6 @@ void ScriptEngine::run() {
     }
 
     _isRunning = true;
-    _isFinished = false;
     if (_wantSignals) {
         emit runningStateChanged();
     }


### PR DESCRIPTION
There is a race condition, where if a script is stopped before its thread and run() method have been called, it will not be stopped.