### PR TITLE
Add some debugging stats to entity server

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -269,14 +269,18 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
 
 
 // FIXME - this stats tracking is somewhat temporary to debug the Whiteboard issues. It's not a bad
-// set of stats to have, but we'd probably want a different data-structure if we keep it very long.
-// Since this version uses a single shared QMap for all senders, there can be a fair amount of lock
-// contention on this QWriteLocker
+// set of stats to have, but we'd probably want a different data structure if we keep it very long.
+// Since this version uses a single shared QMap for all senders, there could be some lock contention 
+// on this QWriteLocker
 void EntityServer::trackSend(const QUuid& dataID, quint64 dataLastEdited, const QUuid& viewerNode) {
     QWriteLocker locker(&_viewerSendingStatsLock);
     _viewerSendingStats[viewerNode][dataID] = { usecTimestampNow(), dataLastEdited };
 }
 
+void EntityServer::trackViewerGone(const QUuid& viewerNode) {
+    QWriteLocker locker(&_viewerSendingStatsLock);
+    _viewerSendingStats.remove(viewerNode);
+}
 
 QString EntityServer::serverSubclassStats() {
     QLocale locale(QLocale::English);

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -44,6 +44,9 @@ public:
 
     virtual void entityCreated(const EntityItem& newEntity, const SharedNodePointer& senderNode) override;
     virtual void readAdditionalConfiguration(const QJsonObject& settingsSectionObject) override;
+    virtual QString serverSubclassStats();
+
+    virtual void trackSend(const QUuid& dataID, const QUuid& viewerNode);
 
 public slots:
     void pruneDeletedEntities();
@@ -57,6 +60,9 @@ private slots:
 private:
     EntitySimulation* _entitySimulation;
     QTimer* _pruneDeletedEntitiesTimer = nullptr;
+
+    QReadWriteLock _viewerSendingStatsLock;
+    QMap<QUuid,quint64> _viewerSendingStats;
 };
 
 #endif // hifi_EntityServer_h

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -21,6 +21,12 @@
 #include "EntityTree.h"
 
 /// Handles assignments of type EntityServer - sending entities to various clients.
+
+struct ViewerSendingStats {
+    quint64 lastSent;
+    quint64 lastEdited;
+};
+
 class EntityServer : public OctreeServer, public NewlyCreatedEntityHook {
     Q_OBJECT
 public:
@@ -46,7 +52,7 @@ public:
     virtual void readAdditionalConfiguration(const QJsonObject& settingsSectionObject) override;
     virtual QString serverSubclassStats();
 
-    virtual void trackSend(const QUuid& dataID, const QUuid& viewerNode);
+    virtual void trackSend(const QUuid& dataID, quint64 dataLastEdited, const QUuid& viewerNode);
 
 public slots:
     void pruneDeletedEntities();
@@ -62,7 +68,7 @@ private:
     QTimer* _pruneDeletedEntitiesTimer = nullptr;
 
     QReadWriteLock _viewerSendingStatsLock;
-    QMap<QUuid,quint64> _viewerSendingStats;
+    QMap<QUuid, QMap<QUuid, ViewerSendingStats>> _viewerSendingStats;
 };
 
 #endif // hifi_EntityServer_h

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -53,6 +53,7 @@ public:
     virtual QString serverSubclassStats();
 
     virtual void trackSend(const QUuid& dataID, quint64 dataLastEdited, const QUuid& viewerNode);
+    virtual void trackViewerGone(const QUuid& viewerNode);
 
 public slots:
     void pruneDeletedEntities();

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -469,8 +469,8 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
 
                     // Our trackSend() function is implemented by the server subclass, and will be called back
                     // during the encodeTreeBitstream() as new entities/data elements are sent 
-                    params.trackSend = [this](const QUuid& id) {
-                        _myServer->trackSend(id, _nodeUUID);
+                    params.trackSend = [this](const QUuid& dataID, quint64 dataEdited) {
+                        _myServer->trackSend(dataID, dataEdited, _nodeUUID);
                     };
 
                     // TODO: should this include the lock time or not? This stat is sent down to the client,

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -467,6 +467,12 @@ int OctreeSendThread::packetDistributor(OctreeQueryNode* nodeData, bool viewFrus
                                                  isFullScene, &nodeData->stats, _myServer->getJurisdiction(),
                                                  &nodeData->extraEncodeData);
 
+                    // Our trackSend() function is implemented by the server subclass, and will be called back
+                    // during the encodeTreeBitstream() as new entities/data elements are sent 
+                    params.trackSend = [this](const QUuid& id) {
+                        _myServer->trackSend(id, _nodeUUID);
+                    };
+
                     // TODO: should this include the lock time or not? This stat is sent down to the client,
                     // it seems like it may be a good idea to include the lock time as part of the encode time
                     // are reported to client. Since you can encode without the lock

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -1184,6 +1184,8 @@ void OctreeServer::nodeKilled(SharedNodePointer node) {
     if (usecsElapsed > 1000) {
         qDebug() << qPrintable(_safeServerName) << "server nodeKilled() took: " << usecsElapsed << " usecs for node:" << *node;
     }
+
+    trackViewerGone(node->getUUID());
 }
 
 void OctreeServer::forceNodeShutdown(SharedNodePointer node) {

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -821,6 +821,11 @@ bool OctreeServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
             .arg(locale.toString((uint)checkSum).rightJustified(16, ' '));
 
         statsString += "\r\n\r\n";
+
+        statsString += serverSubclassStats();
+
+        statsString += "\r\n\r\n";
+
         statsString += "</pre>\r\n";
         statsString += "</doc></html>";
 

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -79,6 +79,8 @@ public:
     virtual void beforeRun() { }
     virtual bool hasSpecialPacketsToSend(const SharedNodePointer& node) { return false; }
     virtual int sendSpecialPackets(const SharedNodePointer& node, OctreeQueryNode* queryNode, int& packetsSent) { return 0; }
+    virtual QString serverSubclassStats() { return QString(); }
+    virtual void trackSend(const QUuid& dataID, const QUuid& viewerNode) { }
 
     static float SKIP_TIME; // use this for trackXXXTime() calls for non-times
 

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -81,6 +81,7 @@ public:
     virtual int sendSpecialPackets(const SharedNodePointer& node, OctreeQueryNode* queryNode, int& packetsSent) { return 0; }
     virtual QString serverSubclassStats() { return QString(); }
     virtual void trackSend(const QUuid& dataID, quint64 dataLastEdited, const QUuid& viewerNode) { }
+    virtual void trackViewerGone(const QUuid& viewerNode) { }
 
     static float SKIP_TIME; // use this for trackXXXTime() calls for non-times
 

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -80,7 +80,7 @@ public:
     virtual bool hasSpecialPacketsToSend(const SharedNodePointer& node) { return false; }
     virtual int sendSpecialPackets(const SharedNodePointer& node, OctreeQueryNode* queryNode, int& packetsSent) { return 0; }
     virtual QString serverSubclassStats() { return QString(); }
-    virtual void trackSend(const QUuid& dataID, const QUuid& viewerNode) { }
+    virtual void trackSend(const QUuid& dataID, quint64 dataLastEdited, const QUuid& viewerNode) { }
 
     static float SKIP_TIME; // use this for trackXXXTime() calls for non-times
 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -313,7 +313,7 @@ OctreeElement::AppendState EntityItem::appendEntityData(OctreePacketData* packet
 
     // if any part of our entity was sent, call trackSend
     if (appendState != OctreeElement::NONE) {
-        params.trackSend(getID());
+        params.trackSend(getID(), getLastEdited());
     }
 
     return appendState;

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -311,6 +311,11 @@ OctreeElement::AppendState EntityItem::appendEntityData(OctreePacketData* packet
         entityTreeElementExtraEncodeData->entities.insert(getEntityItemID(), propertiesDidntFit);
     }
 
+    // if any part of our entity was sent, call trackSend
+    if (appendState != OctreeElement::NONE) {
+        params.trackSend(getID());
+    }
+
     return appendState;
 }
 

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -176,6 +176,8 @@ public:
             case OCCLUDED: return QString("OCCLUDED"); break;
         }
     }
+
+    std::function<void(const QUuid&)> trackSend { [](const QUuid&){} };
 };
 
 class ReadElementBufferToTreeArgs {

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -177,7 +177,7 @@ public:
         }
     }
 
-    std::function<void(const QUuid&)> trackSend { [](const QUuid&){} };
+    std::function<void(const QUuid& dataID, quint64 itemLastEdited)> trackSend { [](const QUuid&, quint64){} };
 };
 
 class ReadElementBufferToTreeArgs {


### PR DESCRIPTION
This adds some additional viewer/sending stats to the entity server so we can see if/when viewers have been sent the latest data about an entity vs when that entity was last edited.