### PR TITLE
Fix for model entities with non-uniform scaled mesh

### DIFF
--- a/libraries/animation/src/AnimPose.cpp
+++ b/libraries/animation/src/AnimPose.cpp
@@ -11,6 +11,7 @@
 #include "AnimPose.h"
 #include <GLMHelpers.h>
 #include <algorithm>
+#include <glm/gtc/matrix_transform.hpp>
 
 const AnimPose AnimPose::identity = AnimPose(glm::vec3(1.0f),
                                              glm::quat(),
@@ -18,7 +19,9 @@ const AnimPose AnimPose::identity = AnimPose(glm::vec3(1.0f),
 
 AnimPose::AnimPose(const glm::mat4& mat) {
     scale = extractScale(mat);
-    rot = glmExtractRotation(mat);
+    // quat_cast doesn't work so well with scaled matrices, so cancel it out.
+    glm::mat4 tmp = glm::scale(mat, 1.0f / scale);
+    rot = glm::normalize(glm::quat_cast(tmp));
     trans = extractTranslation(mat);
 }
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -928,7 +928,7 @@ void Model::simulate(float deltaTime, bool fullUpdate) {
 //virtual
 void Model::updateRig(float deltaTime, glm::mat4 parentTransform) {
     _needsUpdateClusterMatrices = true;
-     _rig->updateAnimations(deltaTime, parentTransform);
+    _rig->updateAnimations(deltaTime, parentTransform);
 }
 void Model::simulateInternal(float deltaTime) {
     // update the world space transforms for all joints

--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -279,14 +279,9 @@ glm::quat extractRotation(const glm::mat4& matrix, bool assumeOrthogonal) {
 
 glm::quat glmExtractRotation(const glm::mat4& matrix) {
     glm::vec3 scale = extractScale(matrix);
-    float maxScale = std::max(std::max(scale.x, scale.y), scale.z);
-    if (maxScale > 1.01f || maxScale <= 0.99f) {
-        // quat_cast doesn't work so well with scaled matrices, so cancel it out.
-        glm::mat4 tmp = glm::scale(matrix, 1.0f / scale);
-        return glm::normalize(glm::quat_cast(tmp));
-    } else {
-        return glm::normalize(glm::quat_cast(matrix));
-    }
+    // quat_cast doesn't work so well with scaled matrices, so cancel it out.
+    glm::mat4 tmp = glm::scale(matrix, 1.0f / scale);
+    return glm::normalize(glm::quat_cast(tmp));
 }
 
 glm::vec3 extractScale(const glm::mat4& matrix) {


### PR DESCRIPTION
the code the extracted rotations from a non-uniformly scaled matrices was sometimes incorrect.

This should fix the roads in Qbit as well as the blocks in toybox.