### PR TITLE
Fix for mirrored transforms in FBX models

### DIFF
--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -285,7 +285,14 @@ glm::quat glmExtractRotation(const glm::mat4& matrix) {
 }
 
 glm::vec3 extractScale(const glm::mat4& matrix) {
-    return glm::vec3(glm::length(matrix[0]), glm::length(matrix[1]), glm::length(matrix[2]));
+    glm::mat3 m(matrix);
+    float det = glm::determinant(m);
+    if (det < 0) {
+        // left handed matrix, flip sign to compensate.
+        return glm::vec3(-glm::length(m[0]), glm::length(m[1]), glm::length(m[2]));
+    } else {
+        return glm::vec3(glm::length(m[0]), glm::length(m[1]), glm::length(m[2]));
+    }
 }
 
 float extractUniformScale(const glm::mat4& matrix) {

--- a/tests/animation/src/AnimTests.h
+++ b/tests/animation/src/AnimTests.h
@@ -26,6 +26,7 @@ private slots:
     void testLoader();
     void testVariant();
     void testAccumulateTime();
+    void testAnimPose();
 };
 
 #endif // hifi_AnimTests_h


### PR DESCRIPTION
extractScale() will now return negative scale for left-handed matrices.

Added animation unit tests to verify AnimPose decomposition is working.