### PR TITLE
gpu::Shader::create* return shared_ptr

### DIFF
--- a/interface/src/Stars.cpp
+++ b/interface/src/Stars.cpp
@@ -130,9 +130,9 @@ void Stars::render(RenderArgs* renderArgs, float alpha) {
 
     std::call_once(once, [&] {
         {
-            auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(standardTransformPNTC_vert)));
-            auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(starsGrid_frag)));
-            auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+            auto vs = gpu::Shader::createVertex(std::string(standardTransformPNTC_vert));
+            auto ps = gpu::Shader::createPixel(std::string(starsGrid_frag));
+            auto program = gpu::Shader::createProgram(vs, ps);
             gpu::Shader::makeProgram((*program));
             _timeSlot = program->getBuffers().findLocation(UNIFORM_TIME_NAME);
             if (_timeSlot == gpu::Shader::INVALID_LOCATION) {
@@ -143,12 +143,12 @@ void Stars::render(RenderArgs* renderArgs, float alpha) {
             state->setDepthTest(gpu::State::DepthTest(false));
             state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
             state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
-            _gridPipeline.reset(gpu::Pipeline::create(program, state));
+            _gridPipeline = gpu::Pipeline::create(program, state);
         }
         {
-            auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(stars_vert)));
-            auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(stars_frag)));
-            auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+            auto vs = gpu::Shader::createVertex(std::string(stars_vert));
+            auto ps = gpu::Shader::createPixel(std::string(stars_frag));
+            auto program = gpu::Shader::createProgram(vs, ps);
             gpu::Shader::makeProgram((*program));
             auto state = gpu::StatePointer(new gpu::State());
             // enable decal blend
@@ -156,7 +156,7 @@ void Stars::render(RenderArgs* renderArgs, float alpha) {
             state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
             state->setAntialiasedLineEnable(true); // line smoothing also smooth points
             state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
-            _starsPipeline.reset(gpu::Pipeline::create(program, state));
+            _starsPipeline = gpu::Pipeline::create(program, state);
             
         }
 

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -334,10 +334,10 @@ void RenderableParticleEffectEntityItem::createPipelines() {
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD,
                                 destinationColorBlendArg, gpu::State::FACTOR_ALPHA,
                                 gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-        auto vertShader = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(untextured_particle_vert)));
-        auto fragShader = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(untextured_particle_frag)));
-        auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vertShader, fragShader));
-        _untexturedPipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+        auto vertShader = gpu::Shader::createVertex(std::string(untextured_particle_vert));
+        auto fragShader = gpu::Shader::createPixel(std::string(untextured_particle_frag));
+        auto program = gpu::Shader::createProgram(vertShader, fragShader);
+        _untexturedPipeline = gpu::Pipeline::create(program, state);
     }
     if (!_texturedPipeline) {
         auto state = std::make_shared<gpu::State>();
@@ -349,17 +349,16 @@ void RenderableParticleEffectEntityItem::createPipelines() {
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD,
                                 destinationColorBlendArg, gpu::State::FACTOR_ALPHA,
                                 gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-        auto vertShader = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(textured_particle_vert)));
+        auto vertShader = gpu::Shader::createVertex(std::string(textured_particle_vert));
         gpu::ShaderPointer fragShader;
         if (_additiveBlending) {
-           fragShader = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(textured_particle_frag)));
+           fragShader = gpu::Shader::createPixel(std::string(textured_particle_frag));
         }
         else {
             //If we are sorting and have no additive blending, we want to discard pixels with low alpha to avoid inter-particle entity artifacts
-            fragShader = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(textured_particle_alpha_discard_frag)));
+            fragShader = gpu::Shader::createPixel(std::string(textured_particle_alpha_discard_frag));
         }
-        auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vertShader, fragShader));
-        _texturedPipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
-   
+        auto program = gpu::Shader::createProgram(vertShader, fragShader);
+        _texturedPipeline = gpu::Pipeline::create(program, state);
     }
 }

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -50,9 +50,9 @@ void RenderablePolyLineEntityItem::createPipeline() {
     _format->setAttribute(gpu::Stream::COLOR, 0, gpu::Element::COLOR_RGBA_32, COLOR_OFFSET);
     _format->setAttribute(gpu::Stream::TEXCOORD, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::UV), TEXTURE_OFFSET);
 
-    auto VS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(paintStroke_vert)));
-    auto PS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(paintStroke_frag)));
-    gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PS));
+    auto VS = gpu::Shader::createVertex(std::string(paintStroke_vert));
+    auto PS = gpu::Shader::createPixel(std::string(paintStroke_frag));
+    gpu::ShaderPointer program = gpu::Shader::createProgram(VS, PS);
 
     gpu::Shader::BindingSet slotBindings;
     PAINTSTROKE_GPU_SLOT = 0;
@@ -64,7 +64,7 @@ void RenderablePolyLineEntityItem::createPipeline() {
     state->setBlendFunction(true,
         gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
         gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-    _pipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+    _pipeline = gpu::Pipeline::create(program, state);
 }
 
 void RenderablePolyLineEntityItem::updateGeometry() {

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -477,8 +477,8 @@ void RenderablePolyVoxEntityItem::render(RenderArgs* args) {
     _meshLock.unlock();
 
     if (!_pipeline) {
-        gpu::ShaderPointer vertexShader = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(polyvox_vert)));
-        gpu::ShaderPointer pixelShader = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(polyvox_frag)));
+        gpu::ShaderPointer vertexShader = gpu::Shader::createVertex(std::string(polyvox_vert));
+        gpu::ShaderPointer pixelShader = gpu::Shader::createPixel(std::string(polyvox_frag));
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("materialBuffer"), MATERIAL_GPU_SLOT));
@@ -486,14 +486,14 @@ void RenderablePolyVoxEntityItem::render(RenderArgs* args) {
         slotBindings.insert(gpu::Shader::Binding(std::string("yMap"), 1));
         slotBindings.insert(gpu::Shader::Binding(std::string("zMap"), 2));
 
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vertexShader, pixelShader));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vertexShader, pixelShader);
         gpu::Shader::makeProgram(*program, slotBindings);
 
         auto state = std::make_shared<gpu::State>();
         state->setCullMode(gpu::State::CULL_BACK);
         state->setDepthTest(true, true, gpu::LESS_EQUAL);
 
-        _pipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+        _pipeline = gpu::Pipeline::create(program, state);
     }
 
     gpu::Batch& batch = *args->_batch;

--- a/libraries/gpu/src/gpu/Pipeline.cpp
+++ b/libraries/gpu/src/gpu/Pipeline.cpp
@@ -15,9 +15,7 @@
 
 using namespace gpu;
 
-Pipeline::Pipeline():
-    _program(),
-    _state()
+Pipeline::Pipeline()
 {
 }
 
@@ -25,8 +23,8 @@ Pipeline::~Pipeline()
 {
 }
 
-Pipeline* Pipeline::create(const ShaderPointer& program, const StatePointer& state) {
-    Pipeline* pipeline = new Pipeline();
+Pipeline::Pointer Pipeline::create(const ShaderPointer& program, const StatePointer& state) {
+    auto pipeline = Pointer(new Pipeline());
     pipeline->_program = program;
     pipeline->_state = state;
 

--- a/libraries/gpu/src/gpu/Pipeline.h
+++ b/libraries/gpu/src/gpu/Pipeline.h
@@ -22,7 +22,9 @@ namespace gpu {
 
 class Pipeline {
 public:
-    static Pipeline* create(const ShaderPointer& program, const StatePointer& state);
+    using Pointer = std::shared_ptr< Pipeline >;
+
+    static Pointer create(const ShaderPointer& program, const StatePointer& state);
     ~Pipeline();
 
     const ShaderPointer& getProgram() const { return _program; }
@@ -44,7 +46,7 @@ protected:
     friend class Backend;
 };
 
-typedef std::shared_ptr< Pipeline > PipelinePointer;
+typedef Pipeline::Pointer PipelinePointer;
 typedef std::vector< PipelinePointer > Pipelines;
 
 };

--- a/libraries/gpu/src/gpu/Shader.cpp
+++ b/libraries/gpu/src/gpu/Shader.cpp
@@ -36,24 +36,20 @@ Shader::~Shader()
 {
 }
 
-Shader* Shader::createVertex(const Source& source) {
-    Shader* shader = new Shader(VERTEX, source);
-    return shader;
+Shader::Pointer Shader::createVertex(const Source& source) {
+    return Pointer(new Shader(VERTEX, source));
 }
 
-Shader* Shader::createPixel(const Source& source) {
-    Shader* shader = new Shader(PIXEL, source);
-    return shader;
+Shader::Pointer Shader::createPixel(const Source& source) {
+    return Pointer(new Shader(PIXEL, source));
 }
 
-Shader* Shader::createProgram(Pointer& vertexShader, Pointer& pixelShader) {
-    if (vertexShader && vertexShader->getType() == VERTEX) {
-        if (pixelShader && pixelShader->getType() == PIXEL) {
-            Shader* shader = new Shader(PROGRAM, vertexShader, pixelShader);
-            return shader;
-        }
+Shader::Pointer Shader::createProgram(Pointer& vertexShader, Pointer& pixelShader) {
+    if (vertexShader && vertexShader->getType() == VERTEX &&
+        pixelShader && pixelShader->getType() == PIXEL) {
+        return Pointer(new Shader(PROGRAM, vertexShader, pixelShader));
     }
-    return nullptr;
+    return Pointer();
 }
 
 void Shader::defineSlots(const SlotSet& uniforms, const SlotSet& buffers, const SlotSet& textures, const SlotSet& samplers, const SlotSet& inputs, const SlotSet& outputs) {

--- a/libraries/gpu/src/gpu/Shader.h
+++ b/libraries/gpu/src/gpu/Shader.h
@@ -108,10 +108,10 @@ public:
         PROGRAM,
     };
 
-    static Shader* createVertex(const Source& source);
-    static Shader* createPixel(const Source& source);
+    static Pointer createVertex(const Source& source);
+    static Pointer createPixel(const Source& source);
 
-    static Shader* createProgram(Pointer& vertexShader, Pointer& pixelShader);
+    static Pointer createProgram(Pointer& vertexShader, Pointer& pixelShader);
 
 
     ~Shader();

--- a/libraries/gpu/src/gpu/StandardShaderLib.cpp
+++ b/libraries/gpu/src/gpu/StandardShaderLib.cpp
@@ -39,7 +39,7 @@ ShaderPointer StandardShaderLib::getProgram(GetShader getVS, GetShader getPS) {
     } else {
         auto vs = (getVS)();
         auto ps = (getPS)();
-        auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto program = gpu::Shader::createProgram(vs, ps);
         if (program) {
             // Program created, let's try to make it
             if (gpu::Shader::makeProgram((*program))) {
@@ -59,42 +59,42 @@ ShaderPointer StandardShaderLib::getProgram(GetShader getVS, GetShader getPS) {
 
 ShaderPointer StandardShaderLib::getDrawUnitQuadTexcoordVS() {
     if (!_drawUnitQuadTexcoordVS) {
-        _drawUnitQuadTexcoordVS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(DrawUnitQuadTexcoord_vert)));
+        _drawUnitQuadTexcoordVS = gpu::Shader::createVertex(std::string(DrawUnitQuadTexcoord_vert));
     }
     return _drawUnitQuadTexcoordVS;
 }
 
 ShaderPointer StandardShaderLib::getDrawTransformUnitQuadVS() {
     if (!_drawTransformUnitQuadVS) {
-        _drawTransformUnitQuadVS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(DrawTransformUnitQuad_vert)));
+        _drawTransformUnitQuadVS = gpu::Shader::createVertex(std::string(DrawTransformUnitQuad_vert));
     }
     return _drawTransformUnitQuadVS;
 }
 
 ShaderPointer StandardShaderLib::getDrawTexcoordRectTransformUnitQuadVS() {
     if (!_drawTexcoordRectTransformUnitQuadVS) {
-        _drawTexcoordRectTransformUnitQuadVS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(DrawTexcoordRectTransformUnitQuad_vert)));
+        _drawTexcoordRectTransformUnitQuadVS = gpu::Shader::createVertex(std::string(DrawTexcoordRectTransformUnitQuad_vert));
     }
     return _drawTexcoordRectTransformUnitQuadVS;
 }
 
 ShaderPointer StandardShaderLib::getDrawViewportQuadTransformTexcoordVS() {
     if (!_drawViewportQuadTransformTexcoordVS) {
-        _drawViewportQuadTransformTexcoordVS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(DrawViewportQuadTransformTexcoord_vert)));
+        _drawViewportQuadTransformTexcoordVS = gpu::Shader::createVertex(std::string(DrawViewportQuadTransformTexcoord_vert));
     }
     return _drawViewportQuadTransformTexcoordVS;
 }
 
 ShaderPointer StandardShaderLib::getDrawTexturePS() {
     if (!_drawTexturePS) {
-        _drawTexturePS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(DrawTexture_frag)));
+        _drawTexturePS = gpu::Shader::createPixel(std::string(DrawTexture_frag));
     }
     return _drawTexturePS;
 }
 
 ShaderPointer StandardShaderLib::getDrawTextureOpaquePS() {
     if (!_drawTextureOpaquePS) {
-        _drawTextureOpaquePS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(DrawTextureOpaque_frag)));
+        _drawTextureOpaquePS = gpu::Shader::createPixel(std::string(DrawTextureOpaque_frag));
     }
     return _drawTextureOpaquePS;
 }
@@ -103,7 +103,7 @@ ShaderPointer StandardShaderLib::getDrawTextureOpaquePS() {
 
 ShaderPointer StandardShaderLib::getDrawColoredTexturePS() {
     if (!_drawColoredTexturePS) {
-        _drawColoredTexturePS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(DrawColoredTexture_frag)));
+        _drawColoredTexturePS = gpu::Shader::createPixel(std::string(DrawColoredTexture_frag));
     }
     return _drawColoredTexturePS;
 }

--- a/libraries/model/src/model/Skybox.cpp
+++ b/libraries/model/src/model/Skybox.cpp
@@ -88,9 +88,9 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
         }
 
         {
-            auto skyVS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(Skybox_vert)));
-            auto skyFS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(Skybox_frag)));
-            auto skyShader = gpu::ShaderPointer(gpu::Shader::createProgram(skyVS, skyFS));
+            auto skyVS = gpu::Shader::createVertex(std::string(Skybox_vert));
+            auto skyFS = gpu::Shader::createPixel(std::string(Skybox_frag));
+            auto skyShader = gpu::Shader::createProgram(skyVS, skyFS);
 
             gpu::Shader::BindingSet bindings;
             bindings.insert(gpu::Shader::Binding(std::string("cubeMap"), SKYBOX_SKYMAP_SLOT));
@@ -102,7 +102,7 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
             auto skyState = std::make_shared<gpu::State>();
             skyState->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 
-            thePipeline = gpu::PipelinePointer(gpu::Pipeline::create(skyShader, skyState));
+            thePipeline = gpu::Pipeline::create(skyShader, skyState);
         }
     });
 

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -170,7 +170,7 @@ void Procedural::prepare(gpu::Batch& batch, const glm::vec3& position, const glm
     if (!_pipeline || _pipelineDirty) {
         _pipelineDirty = true;
         if (!_vertexShader) {
-            _vertexShader = gpu::ShaderPointer(gpu::Shader::createVertex(_vertexSource));
+            _vertexShader = gpu::Shader::createVertex(_vertexSource);
         }
 
         // Build the fragment shader
@@ -193,8 +193,8 @@ void Procedural::prepare(gpu::Batch& batch, const glm::vec3& position, const glm
             fragmentShaderSource.replace(replaceIndex, PROCEDURAL_BLOCK.size(), _shaderSource.toLocal8Bit().data());
         }
         //qDebug() << "FragmentShader:\n" << fragmentShaderSource.c_str();
-        _fragmentShader = gpu::ShaderPointer(gpu::Shader::createPixel(fragmentShaderSource));
-        _shader = gpu::ShaderPointer(gpu::Shader::createProgram(_vertexShader, _fragmentShader));
+        _fragmentShader = gpu::Shader::createPixel(fragmentShaderSource);
+        _shader = gpu::Shader::createProgram(_vertexShader, _fragmentShader);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("iChannel0"), 0));
@@ -203,7 +203,7 @@ void Procedural::prepare(gpu::Batch& batch, const glm::vec3& position, const glm
         slotBindings.insert(gpu::Shader::Binding(std::string("iChannel3"), 3));
         gpu::Shader::makeProgram(*_shader, slotBindings);
 
-        _pipeline = gpu::PipelinePointer(gpu::Pipeline::create(_shader, _state));
+        _pipeline = gpu::Pipeline::create(_shader, _state);
         for (size_t i = 0; i < NUM_STANDARD_UNIFORMS; ++i) {
             const std::string& name = STANDARD_UNIFORM_NAMES[i];
             _standardUniformSlots[i] = _shader->getUniforms().findLocation(name);

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -37,9 +37,9 @@ AmbientOcclusion::AmbientOcclusion() {
 
 const gpu::PipelinePointer& AmbientOcclusion::getOcclusionPipeline() {
     if (!_occlusionPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(ambient_occlusion_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(ambient_occlusion_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(ambient_occlusion_vert));
+        auto ps = gpu::Shader::createPixel(std::string(ambient_occlusion_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("depthTexture"), 0));
@@ -78,16 +78,16 @@ const gpu::PipelinePointer& AmbientOcclusion::getOcclusionPipeline() {
         _occlusionTexture = gpu::TexturePointer(gpu::Texture::create2D(format, width, height, defaultSampler));
 
         // Good to go add the brand new pipeline
-        _occlusionPipeline.reset(gpu::Pipeline::create(program, state));
+        _occlusionPipeline = gpu::Pipeline::create(program, state);
     }
     return _occlusionPipeline;
 }
 
 const gpu::PipelinePointer& AmbientOcclusion::getVBlurPipeline() {
     if (!_vBlurPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(gaussian_blur_vertical_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(gaussian_blur_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(gaussian_blur_vertical_vert));
+        auto ps = gpu::Shader::createPixel(std::string(gaussian_blur_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         gpu::Shader::makeProgram(*program, slotBindings);
@@ -111,16 +111,16 @@ const gpu::PipelinePointer& AmbientOcclusion::getVBlurPipeline() {
         _vBlurTexture = gpu::TexturePointer(gpu::Texture::create2D(format, width, height, defaultSampler));
 
         // Good to go add the brand new pipeline
-        _vBlurPipeline.reset(gpu::Pipeline::create(program, state));
+        _vBlurPipeline = gpu::Pipeline::create(program, state);
     }
     return _vBlurPipeline;
 }
 
 const gpu::PipelinePointer& AmbientOcclusion::getHBlurPipeline() {
     if (!_hBlurPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(gaussian_blur_horizontal_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(gaussian_blur_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(gaussian_blur_horizontal_vert));
+        auto ps = gpu::Shader::createPixel(std::string(gaussian_blur_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         gpu::Shader::makeProgram(*program, slotBindings);
@@ -144,16 +144,16 @@ const gpu::PipelinePointer& AmbientOcclusion::getHBlurPipeline() {
         _hBlurTexture = gpu::TexturePointer(gpu::Texture::create2D(format, width, height, defaultSampler));
 
         // Good to go add the brand new pipeline
-        _hBlurPipeline.reset(gpu::Pipeline::create(program, state));
+        _hBlurPipeline = gpu::Pipeline::create(program, state);
     }
     return _hBlurPipeline;
 }
 
 const gpu::PipelinePointer& AmbientOcclusion::getBlendPipeline() {
     if (!_blendPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(ambient_occlusion_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(occlusion_blend_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(ambient_occlusion_vert));
+        auto ps = gpu::Shader::createPixel(std::string(occlusion_blend_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("blurredOcclusionTexture"), 0));
@@ -169,7 +169,7 @@ const gpu::PipelinePointer& AmbientOcclusion::getBlendPipeline() {
             gpu::State::INV_SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::SRC_ALPHA);
 
         // Good to go add the brand new pipeline
-        _blendPipeline.reset(gpu::Pipeline::create(program, state));
+        _blendPipeline = gpu::Pipeline::create(program, state);
     }
     return _blendPipeline;
 }

--- a/libraries/render-utils/src/AnimDebugDraw.cpp
+++ b/libraries/render-utils/src/AnimDebugDraw.cpp
@@ -95,10 +95,10 @@ AnimDebugDraw::AnimDebugDraw() :
     state->setBlendFunction(false, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD,
                             gpu::State::INV_SRC_ALPHA, gpu::State::FACTOR_ALPHA,
                             gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-    auto vertShader = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(animdebugdraw_vert)));
-    auto fragShader = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(animdebugdraw_frag)));
-    auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vertShader, fragShader));
-    _pipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+    auto vertShader = gpu::Shader::createVertex(std::string(animdebugdraw_vert));
+    auto fragShader = gpu::Shader::createPixel(std::string(animdebugdraw_frag));
+    auto program = gpu::Shader::createProgram(vertShader, fragShader);
+    _pipeline = gpu::Pipeline::create(program, state);
 
     _animDebugDrawData = std::make_shared<AnimDebugDrawData>();
     _animDebugDrawPayload = std::make_shared<AnimDebugDrawPayload>(_animDebugDrawData);

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -34,9 +34,9 @@ Antialiasing::Antialiasing() {
 
 const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
     if (!_antialiasingPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(fxaa_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(fxaa_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(fxaa_vert));
+        auto ps = gpu::Shader::createPixel(std::string(fxaa_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("colorTexture"), 0));
@@ -59,7 +59,7 @@ const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
         _antialiasingTexture = gpu::TexturePointer(gpu::Texture::create2D(format, width, height, defaultSampler));
 
         // Good to go add the brand new pipeline
-        _antialiasingPipeline.reset(gpu::Pipeline::create(program, state));
+        _antialiasingPipeline = gpu::Pipeline::create(program, state);
     }
 
     int w = DependencyManager::get<FramebufferCache>()->getFrameBufferSize().width();
@@ -73,9 +73,9 @@ const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
 
 const gpu::PipelinePointer& Antialiasing::getBlendPipeline() {
     if (!_blendPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(fxaa_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(fxaa_blend_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(fxaa_vert));
+        auto ps = gpu::Shader::createPixel(std::string(fxaa_blend_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("colorTexture"), 0));
@@ -87,7 +87,7 @@ const gpu::PipelinePointer& Antialiasing::getBlendPipeline() {
         state->setDepthTest(false, false, gpu::LESS_EQUAL);
 
         // Good to go add the brand new pipeline
-        _blendPipeline.reset(gpu::Pipeline::create(program, state));
+        _blendPipeline = gpu::Pipeline::create(program, state);
     }
     return _blendPipeline;
 }

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -87,18 +87,18 @@ gpu::PipelinePointer DeferredLightingEffect::getPipeline(SimpleProgramKey config
                             gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
     
     gpu::ShaderPointer program = (config.isEmissive()) ? _emissiveShader : _simpleShader;
-    gpu::PipelinePointer pipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+    gpu::PipelinePointer pipeline = gpu::Pipeline::create(program, state);
     _simplePrograms.insert(config, pipeline);
     return pipeline;
 }
 
 void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
-    auto VS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(simple_vert)));
-    auto PS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(simple_textured_frag)));
-    auto PSEmissive = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(simple_textured_emisive_frag)));
+    auto VS = gpu::Shader::createVertex(std::string(simple_vert));
+    auto PS = gpu::Shader::createPixel(std::string(simple_textured_frag));
+    auto PSEmissive = gpu::Shader::createPixel(std::string(simple_textured_emisive_frag));
     
-    _simpleShader = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PS));
-    _emissiveShader = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PSEmissive));
+    _simpleShader = gpu::Shader::createProgram(VS, PS);
+    _emissiveShader = gpu::Shader::createProgram(VS, PSEmissive);
     
     gpu::Shader::BindingSet slotBindings;
     slotBindings.insert(gpu::Shader::Binding(std::string("normalFittingMap"), DeferredLightingEffect::NORMAL_FITTING_MAP_SLOT));
@@ -150,7 +150,7 @@ void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
                                 gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
                                 gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
         blitState->setColorWriteMask(true, true, true, false);
-        _blitLightBuffer = gpu::PipelinePointer(gpu::Pipeline::create(blitProgram, blitState));
+        _blitLightBuffer = gpu::Pipeline::create(blitProgram, blitState);
     }
 
     // Allocate a global light representing the Global Directional light casting shadow (the sun) and the ambient light
@@ -721,10 +721,10 @@ void DeferredLightingEffect::setupTransparent(RenderArgs* args, int lightBufferU
 }
 
 static void loadLightProgram(const char* vertSource, const char* fragSource, bool lightVolume, gpu::PipelinePointer& pipeline, LightLocationsPtr& locations) {
-    auto VS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(vertSource)));
-    auto PS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(fragSource)));
+    auto VS = gpu::Shader::createVertex(std::string(vertSource));
+    auto PS = gpu::Shader::createPixel(std::string(fragSource));
     
-    gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PS));
+    gpu::ShaderPointer program = gpu::Shader::createProgram(VS, PS);
 
     gpu::Shader::BindingSet slotBindings;
     slotBindings.insert(gpu::Shader::Binding(std::string("diffuseMap"), 0));
@@ -769,7 +769,7 @@ static void loadLightProgram(const char* vertSource, const char* fragSource, boo
     } else {
         state->setCullMode(gpu::State::CULL_BACK);
     }
-    pipeline.reset(gpu::Pipeline::create(program, state));
+    pipeline = gpu::Pipeline::create(program, state);
 
 }
 

--- a/libraries/render-utils/src/Environment.cpp
+++ b/libraries/render-utils/src/Environment.cpp
@@ -51,10 +51,10 @@ void Environment::init() {
 
 void Environment::setupAtmosphereProgram(const char* vertSource, const char* fragSource, gpu::PipelinePointer& pipeline, int* locations) {
 
-    auto VS = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(vertSource)));
-    auto PS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(fragSource)));
+    auto VS = gpu::Shader::createVertex(std::string(vertSource));
+    auto PS = gpu::Shader::createPixel(std::string(fragSource));
     
-    gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(VS, PS));
+    gpu::ShaderPointer program = gpu::Shader::createProgram(VS, PS);
     
     gpu::Shader::BindingSet slotBindings;
     gpu::Shader::makeProgram(*program, slotBindings);
@@ -67,7 +67,7 @@ void Environment::setupAtmosphereProgram(const char* vertSource, const char* fra
                             gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
                             gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
     
-    pipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+    pipeline = gpu::Pipeline::create(program, state);
 
     locations[CAMERA_POS_LOCATION] = program->getUniforms().findLocation("v3CameraPos");
     locations[LIGHT_POS_LOCATION] = program->getUniforms().findLocation("v3LightPos");

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1701,9 +1701,9 @@ void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm
 
 void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
     if (!_standardDrawPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(standardTransformPNTC_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(standardDrawTexture_frag)));
-        auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(standardTransformPNTC_vert));
+        auto ps = gpu::Shader::createPixel(std::string(standardDrawTexture_frag));
+        auto program = gpu::Shader::createProgram(vs, ps);
         gpu::Shader::makeProgram((*program));
 
         auto state = std::make_shared<gpu::State>();
@@ -1712,14 +1712,14 @@ void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
         // enable decal blend
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
 
-        _standardDrawPipeline.reset(gpu::Pipeline::create(program, state));
+        _standardDrawPipeline = gpu::Pipeline::create(program, state);
 
 
         auto stateNoBlend = std::make_shared<gpu::State>();
         auto noBlendPS = gpu::StandardShaderLib::getDrawTextureOpaquePS();
-        auto programNoBlend = gpu::ShaderPointer(gpu::Shader::createProgram(vs, noBlendPS));
+        auto programNoBlend = gpu::Shader::createProgram(vs, noBlendPS);
         gpu::Shader::makeProgram((*programNoBlend));
-        _standardDrawPipelineNoBlend.reset(gpu::Pipeline::create(programNoBlend, stateNoBlend));
+        _standardDrawPipelineNoBlend = gpu::Pipeline::create(programNoBlend, stateNoBlend);
     }
     if (noBlend) {
         batch.setPipeline(_standardDrawPipelineNoBlend);

--- a/libraries/render-utils/src/HitEffect.cpp
+++ b/libraries/render-utils/src/HitEffect.cpp
@@ -36,9 +36,9 @@ HitEffect::HitEffect() {
 
 const gpu::PipelinePointer& HitEffect::getHitEffectPipeline() {
     if (!_hitEffectPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(hit_effect_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(hit_effect_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(hit_effect_vert));
+        auto ps = gpu::Shader::createPixel(std::string(hit_effect_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
         
         
         gpu::Shader::BindingSet slotBindings;
@@ -54,7 +54,7 @@ const gpu::PipelinePointer& HitEffect::getHitEffectPipeline() {
                                 gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
     
         // Good to go add the brand new pipeline
-        _hitEffectPipeline.reset(gpu::Pipeline::create(program, state));
+        _hitEffectPipeline = gpu::Pipeline::create(program, state);
     }
     return _hitEffectPipeline;
 }

--- a/libraries/render-utils/src/ModelRender.cpp
+++ b/libraries/render-utils/src/ModelRender.cpp
@@ -42,26 +42,26 @@ ModelRender::RenderPipelineLib ModelRender::_renderPipelineLib;
 const ModelRender::RenderPipelineLib& ModelRender::getRenderPipelineLib() {
     if (_renderPipelineLib.empty()) {
         // Vertex shaders
-        auto modelVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(model_vert)));
-        auto modelNormalMapVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(model_normal_map_vert)));
-        auto modelLightmapVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(model_lightmap_vert)));
-        auto modelLightmapNormalMapVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(model_lightmap_normal_map_vert)));
-        auto modelShadowVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(model_shadow_vert)));
-        auto skinModelVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(skin_model_vert)));
-        auto skinModelNormalMapVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(skin_model_normal_map_vert)));
-        auto skinModelShadowVertex = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(skin_model_shadow_vert)));
+        auto modelVertex = gpu::Shader::createVertex(std::string(model_vert));
+        auto modelNormalMapVertex = gpu::Shader::createVertex(std::string(model_normal_map_vert));
+        auto modelLightmapVertex = gpu::Shader::createVertex(std::string(model_lightmap_vert));
+        auto modelLightmapNormalMapVertex = gpu::Shader::createVertex(std::string(model_lightmap_normal_map_vert));
+        auto modelShadowVertex = gpu::Shader::createVertex(std::string(model_shadow_vert));
+        auto skinModelVertex = gpu::Shader::createVertex(std::string(skin_model_vert));
+        auto skinModelNormalMapVertex = gpu::Shader::createVertex(std::string(skin_model_normal_map_vert));
+        auto skinModelShadowVertex = gpu::Shader::createVertex(std::string(skin_model_shadow_vert));
 
         // Pixel shaders
-        auto modelPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_frag)));
-        auto modelNormalMapPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_normal_map_frag)));
-        auto modelSpecularMapPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_specular_map_frag)));
-        auto modelNormalSpecularMapPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_normal_specular_map_frag)));
-        auto modelTranslucentPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_translucent_frag)));
-        auto modelShadowPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_shadow_frag)));
-        auto modelLightmapPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_lightmap_frag)));
-        auto modelLightmapNormalMapPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_lightmap_normal_map_frag)));
-        auto modelLightmapSpecularMapPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_lightmap_specular_map_frag)));
-        auto modelLightmapNormalSpecularMapPixel = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(model_lightmap_normal_specular_map_frag)));
+        auto modelPixel = gpu::Shader::createPixel(std::string(model_frag));
+        auto modelNormalMapPixel = gpu::Shader::createPixel(std::string(model_normal_map_frag));
+        auto modelSpecularMapPixel = gpu::Shader::createPixel(std::string(model_specular_map_frag));
+        auto modelNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(model_normal_specular_map_frag));
+        auto modelTranslucentPixel = gpu::Shader::createPixel(std::string(model_translucent_frag));
+        auto modelShadowPixel = gpu::Shader::createPixel(std::string(model_shadow_frag));
+        auto modelLightmapPixel = gpu::Shader::createPixel(std::string(model_lightmap_frag));
+        auto modelLightmapNormalMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_normal_map_frag));
+        auto modelLightmapSpecularMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_specular_map_frag));
+        auto modelLightmapNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_normal_specular_map_frag));
 
         // Fill the renderPipelineLib
 
@@ -181,7 +181,7 @@ void ModelRender::RenderPipelineLib::addRenderPipeline(ModelRender::RenderKey ke
     slotBindings.insert(gpu::Shader::Binding(std::string("lightBuffer"), ModelRender::LIGHT_BUFFER_SLOT));
     slotBindings.insert(gpu::Shader::Binding(std::string("normalFittingMap"), DeferredLightingEffect::NORMAL_FITTING_MAP_SLOT));
 
-    gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vertexShader, pixelShader));
+    gpu::ShaderPointer program = gpu::Shader::createProgram(vertexShader, pixelShader);
     gpu::Shader::makeProgram(*program, slotBindings);
 
 
@@ -209,7 +209,7 @@ void ModelRender::RenderPipelineLib::addRenderPipeline(ModelRender::RenderKey ke
         gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
     // Good to go add the brand new pipeline
-    auto pipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+    auto pipeline = gpu::Pipeline::create(program, state);
     insert(value_type(key.getRaw(), RenderPipeline(pipeline, locations)));
 
 
@@ -221,7 +221,7 @@ void ModelRender::RenderPipelineLib::addRenderPipeline(ModelRender::RenderKey ke
         wireframeState->setFillMode(gpu::State::FILL_LINE);
 
         // create a new RenderPipeline with the same shader side and the wireframe state
-        auto wireframePipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, wireframeState));
+        auto wireframePipeline = gpu::Pipeline::create(program, wireframeState);
         insert(value_type(wireframeKey.getRaw(), RenderPipeline(wireframePipeline, locations)));
     }
 }

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -231,16 +231,16 @@ void DrawTransparentDeferred::run(const SceneContextPointer& sceneContext, const
 gpu::PipelinePointer DrawOverlay3D::_opaquePipeline;
 const gpu::PipelinePointer& DrawOverlay3D::getOpaquePipeline() {
     if (!_opaquePipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(overlay3D_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(overlay3D_frag)));
-        auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(overlay3D_vert));
+        auto ps = gpu::Shader::createPixel(std::string(overlay3D_frag));
+        auto program = gpu::Shader::createProgram(vs, ps);
         
         auto state = std::make_shared<gpu::State>();
         state->setDepthTest(false);
         // additive blending
         state->setBlendFunction(true, gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
-        _opaquePipeline.reset(gpu::Pipeline::create(program, state));
+        _opaquePipeline = gpu::Pipeline::create(program, state);
     }
     return _opaquePipeline;
 }
@@ -307,8 +307,8 @@ const gpu::PipelinePointer& DrawStencilDeferred::getOpaquePipeline() {
     if (!_opaquePipeline) {
         const gpu::int8 STENCIL_OPAQUE = 1;
         auto vs = gpu::StandardShaderLib::getDrawUnitQuadTexcoordVS();
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(drawOpaqueStencil_frag)));
-        auto program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto ps = gpu::Shader::createPixel(std::string(drawOpaqueStencil_frag));
+        auto program = gpu::Shader::createProgram(vs, ps);
         
 
         gpu::Shader::makeProgram((*program));
@@ -318,7 +318,7 @@ const gpu::PipelinePointer& DrawStencilDeferred::getOpaquePipeline() {
         state->setStencilTest(true, 0xFF, gpu::State::StencilTest(STENCIL_OPAQUE, 0xFF, gpu::ALWAYS, gpu::State::STENCIL_OP_REPLACE, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_REPLACE)); 
         state->setColorWriteMask(0);
 
-        _opaquePipeline.reset(gpu::Pipeline::create(program, state));
+        _opaquePipeline = gpu::Pipeline::create(program, state);
     }
     return _opaquePipeline;
 }

--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -216,9 +216,9 @@ void Font::setupGPU() {
 
         // Setup render pipeline
         {
-            auto vertexShader = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(sdf_text3D_vert)));
-            auto pixelShader = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(sdf_text3D_frag)));
-            gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vertexShader, pixelShader));
+            auto vertexShader = gpu::Shader::createVertex(std::string(sdf_text3D_vert));
+            auto pixelShader = gpu::Shader::createPixel(std::string(sdf_text3D_frag));
+            gpu::ShaderPointer program = gpu::Shader::createProgram(vertexShader, pixelShader);
 
             gpu::Shader::BindingSet slotBindings;
             gpu::Shader::makeProgram(*program, slotBindings);
@@ -233,7 +233,7 @@ void Font::setupGPU() {
             state->setBlendFunction(true,
                 gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
                 gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-            _pipeline = gpu::PipelinePointer(gpu::Pipeline::create(program, state));
+            _pipeline = gpu::Pipeline::create(program, state);
         }
 
         // Sanity checks

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -31,9 +31,9 @@ using namespace render;
 
 const gpu::PipelinePointer DrawStatus::getDrawItemBoundsPipeline() {
     if (!_drawItemBoundsPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(drawItemBounds_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(drawItemBounds_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(drawItemBounds_vert));
+        auto ps = gpu::Shader::createPixel(std::string(drawItemBounds_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         gpu::Shader::makeProgram(*program, slotBindings);
@@ -51,16 +51,16 @@ const gpu::PipelinePointer DrawStatus::getDrawItemBoundsPipeline() {
             gpu::State::DEST_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ZERO);
 
         // Good to go add the brand new pipeline
-        _drawItemBoundsPipeline.reset(gpu::Pipeline::create(program, state));
+        _drawItemBoundsPipeline = gpu::Pipeline::create(program, state);
     }
     return _drawItemBoundsPipeline;
 }
 
 const gpu::PipelinePointer DrawStatus::getDrawItemStatusPipeline() {
     if (!_drawItemStatusPipeline) {
-        auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(drawItemStatus_vert)));
-        auto ps = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(drawItemStatus_frag)));
-        gpu::ShaderPointer program = gpu::ShaderPointer(gpu::Shader::createProgram(vs, ps));
+        auto vs = gpu::Shader::createVertex(std::string(drawItemStatus_vert));
+        auto ps = gpu::Shader::createPixel(std::string(drawItemStatus_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("iconStatusMap"), 0));
@@ -81,7 +81,7 @@ const gpu::PipelinePointer DrawStatus::getDrawItemStatusPipeline() {
             gpu::State::DEST_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ZERO);
 
         // Good to go add the brand new pipeline
-        _drawItemStatusPipeline.reset(gpu::Pipeline::create(program, state));
+        _drawItemStatusPipeline = gpu::Pipeline::create(program, state);
     }
     return _drawItemStatusPipeline;
 }

--- a/tests/gpu-test/src/main.cpp
+++ b/tests/gpu-test/src/main.cpp
@@ -85,9 +85,9 @@ public:
 uint32_t toCompactColor(const glm::vec4& color);
 
 gpu::ShaderPointer makeShader(const std::string & vertexShaderSrc, const std::string & fragmentShaderSrc, const gpu::Shader::BindingSet & bindings) {
-    auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(vertexShaderSrc));
-    auto fs = gpu::ShaderPointer(gpu::Shader::createPixel(fragmentShaderSrc));
-    auto shader = gpu::ShaderPointer(gpu::Shader::createProgram(vs, fs));
+    auto vs = gpu::Shader::createVertex(vertexShaderSrc);
+    auto fs = gpu::Shader::createPixel(fragmentShaderSrc);
+    auto shader = gpu::Shader::createProgram(vs, fs);
     if (!gpu::Shader::makeProgram(*shader, bindings)) {
         printf("Could not compile shader\n");
         exit(-1);
@@ -172,7 +172,7 @@ public:
         auto state = std::make_shared<gpu::State>();
         state->setMultisampleEnable(true);
         state->setDepthTest(gpu::State::DepthTest { true });
-        _pipeline = gpu::PipelinePointer(gpu::Pipeline::create(shader, state));
+        _pipeline = gpu::Pipeline::create(shader, state);
         _instanceLocation = _pipeline->getProgram()->getUniforms().findLocation("Instanced");
         
         // Clear screen

--- a/tests/render-utils/src/main.cpp
+++ b/tests/render-utils/src/main.cpp
@@ -170,9 +170,9 @@ static const glm::vec3 COLORS[4] = { { 1.0, 1.0, 1.0 }, { 0.5, 1.0, 0.5 }, {
 
 
 void testShaderBuild(const char* vs_src, const char * fs_src) {
-    auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(vs_src)));
-    auto fs = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(fs_src)));
-    auto pr = gpu::ShaderPointer(gpu::Shader::createProgram(vs, fs));
+    auto vs = gpu::Shader::createVertex(std::string(vs_src));
+    auto fs = gpu::Shader::createPixel(std::string(fs_src));
+    auto pr = gpu::Shader::createProgram(vs, fs);
     gpu::Shader::makeProgram(*pr);
 }
 

--- a/tests/shaders/src/main.cpp
+++ b/tests/shaders/src/main.cpp
@@ -160,9 +160,9 @@ public:
 };
 
 void testShaderBuild(const char* vs_src, const char * fs_src) {
-    auto vs = gpu::ShaderPointer(gpu::Shader::createVertex(std::string(vs_src)));
-    auto fs = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(fs_src)));
-    auto pr = gpu::ShaderPointer(gpu::Shader::createProgram(vs, fs));
+    auto vs = gpu::Shader::createVertex(std::string(vs_src));
+    auto fs = gpu::Shader::createPixel(std::string(fs_src));
+    auto pr = gpu::Shader::createProgram(vs, fs);
     if (!gpu::Shader::makeProgram(*pr)) {
         throw std::runtime_error("Failed to compile shader");
     }


### PR DESCRIPTION
I updated the `create*` functions of the gpu library to return smart pointers directly while I was working on particles.
I'm putting it as a separate PR as @hyperlogic suggested.

This will prevent accidental memory leaks and removes a lot of boiler plate code.