### PR TITLE
Graphics: Intoducing the LIghting Buffer where to accumulate the lighted information

### DIFF
--- a/libraries/render-utils/src/DeferredLighting.slh
+++ b/libraries/render-utils/src/DeferredLighting.slh
@@ -33,7 +33,7 @@ vec4 evalPBRShading(vec3 fragNormal, vec3 fragLightDir, vec3 fragEyeDir, vec3 sp
     vec3 schlick = specular * (1.0 - shlickPower5) + vec3(shlickPower5);
     vec3 reflect = specularPower * schlick;
 
-    return vec4(reflect, diffuse);
+    return vec4(reflect, diffuse * (1 - length(schlick)));
 }
 <@endfunc@>
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -143,7 +143,39 @@ void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
     {
         //auto VSFS = gpu::StandardShaderLib::getDrawViewportQuadTransformTexcoordVS();
         //auto PSBlit = gpu::StandardShaderLib::getDrawTexturePS();
-        auto blitProgram = gpu::StandardShaderLib::getProgram(gpu::StandardShaderLib::getDrawViewportQuadTransformTexcoordVS, gpu::StandardShaderLib::getDrawTexturePS);
+        const char BlitTextureGamma_frag[] = R"SCRIBE(#version 410 core
+        //  Generated on Sat Oct 24 09:34:37 2015
+        //
+        //  Draw texture 0 fetched at texcoord.xy
+        //
+        //  Created by Sam Gateau on 6/22/2015
+        //  Copyright 2015 High Fidelity, Inc.
+        //
+        //  Distributed under the Apache License, Version 2.0.
+        //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+        //
+        
+        
+        uniform sampler2D colorMap;
+        
+        in vec2 varTexCoord0;
+        out vec4 outFragColor;
+        
+        void main(void) {
+            outFragColor = texture(colorMap, varTexCoord0);
+            if (gl_FragCoord.x > 1000) {
+                outFragColor.xyz = pow( outFragColor.xyz , vec3(1.0/2.2) );
+            }
+        }
+        
+        )SCRIBE";
+        auto blitPS = gpu::ShaderPointer(gpu::Shader::createPixel(std::string(BlitTextureGamma_frag)));
+ 
+        //auto blitProgram = gpu::StandardShaderLib::getProgram(gpu::StandardShaderLib::getDrawViewportQuadTransformTexcoordVS, gpu::StandardShaderLib::getDrawTexturePS);
+        auto blitVS = gpu::StandardShaderLib::getDrawViewportQuadTransformTexcoordVS();
+        auto blitProgram = gpu::ShaderPointer(gpu::Shader::createProgram(blitVS, blitPS));
+        
+        //auto blitProgram = gpu::StandardShaderLib::getProgram(gpu::StandardShaderLib::getDrawViewportQuadTransformTexcoordVS, gpu::StandardShaderLib::getDrawTexturePS);
         gpu::Shader::makeProgram(*blitProgram);
         auto blitState = std::make_shared<gpu::State>();
         blitState->setBlendFunction(true,

--- a/libraries/render-utils/src/FramebufferCache.cpp
+++ b/libraries/render-utils/src/FramebufferCache.cpp
@@ -41,6 +41,8 @@ void FramebufferCache::setFrameBufferSize(QSize frameBufferSize) {
         _primarySpecularTexture.reset();
         _selfieFramebuffer.reset();
         _cachedFramebuffers.clear();
+        _lightingTexture.reset();
+        _lightingFramebuffer.reset();
     }
 }
 
@@ -74,6 +76,12 @@ void FramebufferCache::createPrimaryFramebuffer() {
     _selfieFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create());
     auto tex = gpu::TexturePointer(gpu::Texture::create2D(colorFormat, width * 0.5, height * 0.5, defaultSampler));
     _selfieFramebuffer->setRenderBuffer(0, tex);
+
+    _lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), width, height, defaultSampler));
+        //_lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::SRGBA), width, height, defaultSampler));
+        // _lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC4, gpu::HALF, gpu::RGBA), width, height, defaultSampler));
+        _lightingFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create());
+    _lightingFramebuffer->setRenderBuffer(0, _lightingTexture);
 }
 
 gpu::FramebufferPointer FramebufferCache::getPrimaryFramebuffer() {
@@ -116,6 +124,20 @@ gpu::TexturePointer FramebufferCache::getPrimarySpecularTexture() {
         createPrimaryFramebuffer();
     }
     return _primarySpecularTexture;
+}
+
+gpu::FramebufferPointer FramebufferCache::getLightingFramebuffer() {
+    if (!_lightingFramebuffer) {
+        createPrimaryFramebuffer();
+    }
+    return _lightingFramebuffer;
+}
+
+gpu::TexturePointer FramebufferCache::getLightingTexture() {
+    if (!_lightingTexture) {
+        createPrimaryFramebuffer();
+    }
+    return _lightingTexture;
 }
 
 gpu::FramebufferPointer FramebufferCache::getFramebuffer() {

--- a/libraries/render-utils/src/FramebufferCache.h
+++ b/libraries/render-utils/src/FramebufferCache.h
@@ -37,6 +37,10 @@ public:
     gpu::TexturePointer getPrimaryNormalTexture();
     gpu::TexturePointer getPrimarySpecularTexture();
 
+    
+    gpu::TexturePointer getLightingTexture();
+    gpu::FramebufferPointer getLightingFramebuffer();
+
     /// Returns the framebuffer object used to render shadow maps;
     gpu::FramebufferPointer getShadowFramebuffer();
 
@@ -63,7 +67,10 @@ private:
     gpu::TexturePointer _primaryColorTexture;
     gpu::TexturePointer _primaryNormalTexture;
     gpu::TexturePointer _primarySpecularTexture;
-    
+
+    gpu::TexturePointer _lightingTexture;
+    gpu::FramebufferPointer _lightingFramebuffer;
+
     gpu::FramebufferPointer _shadowFramebuffer;
 
     gpu::FramebufferPointer _selfieFramebuffer;


### PR DESCRIPTION
- Introduce the LIghting Buffer and Framebuffer where to accumulate the lighting passes from deferred and transparent (to be done)

- Made a custom pixel shader to do the current copyBack pass of the deferred effect to gamma correct the lighted pixels back into the "final" color buffer

- Removed the unnecessary blending which was happening during this step 