### PR TITLE
don't stop a non-started timer, debug cleanup

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -435,17 +435,23 @@ SharedNodePointer LimitedNodeList::nodeWithUUID(const QUuid& nodeUUID) {
  }
 
 void LimitedNodeList::eraseAllNodes() {
-    qCDebug(networking) << "Clearing the NodeList. Deleting all nodes in list.";
-
     QSet<SharedNodePointer> killedNodes;
-    eachNode([&killedNodes](const SharedNodePointer& node){
-        killedNodes.insert(node);
-    });
 
     {
-        // iterate the current nodes, emit that they are dying and remove them from the hash
+        // iterate the current nodes - grab them so we can emit that they are dying
+        // and then remove them from the hash
         QWriteLocker writeLocker(&_nodeMutex);
-        _nodeHash.clear();
+
+        if (_nodeHash.size() > 0) {
+            qCDebug(networking) << "LimitedNodeList::eraseAllNodes() removing all nodes from NodeList.";
+
+            auto it = _nodeHash.begin();
+
+            while (it != _nodeHash.end())  {
+                killedNodes.insert(it->second);
+                it = _nodeHash.unsafe_erase(it);
+            }
+        }
     }
     
     foreach(const SharedNodePointer& killedNode, killedNodes) {

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -94,7 +94,7 @@ NodeList::NodeList(char newOwnerType, unsigned short socketListenPort, unsigned 
     _keepAlivePingTimer.setInterval(KEEPALIVE_PING_INTERVAL_MS);
     connect(&_keepAlivePingTimer, &QTimer::timeout, this, &NodeList::sendKeepAlivePings);
     connect(&_domainHandler, SIGNAL(connectedToDomain(QString)), &_keepAlivePingTimer, SLOT(start()));
-    connect(&_domainHandler, &DomainHandler::disconnectedFromDomain, &_keepAlivePingTimer, &QTimer::stop);
+    connect(&_domainHandler, &DomainHandler::disconnectedFromDomain, this, &NodeList::stopKeepalivePingTimer);
 
     // we definitely want STUN to update our public socket, so call the LNL to kick that off
     startSTUNPublicSocketUpdate();
@@ -643,6 +643,12 @@ void NodeList::activateSocketFromNodeCommunication(QSharedPointer<NLPacket> pack
 
     if (sendingNode->getType() == NodeType::AudioMixer) {
        flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::SetAudioMixerSocket);
+    }
+}
+
+void NodeList::stopKeepalivePingTimer() {
+    if (_keepAlivePingTimer.isActive()) {
+        _keepAlivePingTimer.stop();
     }
 }
 

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -89,6 +89,7 @@ public slots:
 signals:
     void limitOfSilentDomainCheckInsReached();
 private slots:
+    void stopKeepalivePingTimer();
     void sendPendingDSPathQuery();
     void handleICEConnectionToDomainServer();
 

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -194,10 +194,12 @@ void Socket::clearConnections() {
         QMetaObject::invokeMethod(this, "clearConnections", Qt::BlockingQueuedConnection);
         return;
     }
-    
-    // clear all of the current connections in the socket
-    qDebug() << "Clearing all remaining connections in Socket.";
-    _connectionsHash.clear();
+
+    if (_connectionsHash.size() > 0) {
+        // clear all of the current connections in the socket
+        qDebug() << "Clearing all remaining connections in Socket.";
+        _connectionsHash.clear();
+    }
 }
 
 void Socket::cleanupConnection(HifiSockAddr sockAddr) {


### PR DESCRIPTION
- fixes a bug on linux where we would crash attempting to stop a non-started QTimer (for NodeList keepalive pings)