### PR TITLE
Fix present rate stats display

### DIFF
--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -121,7 +121,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(serverCount, nodeList->size());
     STAT_UPDATE(renderrate, (int)qApp->getFps());
     if (qApp->getActiveDisplayPlugin()) {
-        STAT_UPDATE(presentrate, (int)qApp->getActiveDisplayPlugin()->presentRate());
+        STAT_UPDATE(presentrate, (int)round(qApp->getActiveDisplayPlugin()->presentRate()));
     } else {
         STAT_UPDATE(presentrate, -1);
     }

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -303,7 +303,6 @@ void OpenGLDisplayPlugin::internalPresent() {
     glBindTexture(GL_TEXTURE_2D, _currentSceneTexture);
     drawUnitQuad();
     swapBuffers();
-    updateFramerate();
 }
 
 void OpenGLDisplayPlugin::present() {


### PR DESCRIPTION
which was counting (roughly) twice for 2D display, and flickering.