### PR TITLE
Fix render rate.

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -157,7 +157,7 @@ OpenGLDisplayPlugin::OpenGLDisplayPlugin() {
     });
 
     connect(&_timer, &QTimer::timeout, this, [&] {
-        if (_active && _sceneTextureEscrow.depth() < 1) {
+        if (_active && _sceneTextureEscrow.depth() <= 1) {
             emit requestRender();
         }
     });

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -152,7 +152,14 @@ OpenGLDisplayPlugin::OpenGLDisplayPlugin() {
     });
 
     connect(&_timer, &QTimer::timeout, this, [&] {
+#ifdef Q_OS_MAC
+        // On Mac, QT thread timing is such that we can miss one or even two cycles quite often, giving a render rate (including update/simulate)
+        // far lower than what we want. This hack keeps that rate more natural, at the expense of some wasted rendering.
+        // This is likely to be mooted by further planned changes.
         if (_active && _sceneTextureEscrow.depth() <= 1) {
+#else
+        if (_active && _sceneTextureEscrow.depth() < 1) {
+#endif
             emit requestRender();
         }
     });


### PR DESCRIPTION
Depending on how the threads get assigned, the actual render rate (not just the stats) could be as little as a third of what is targetted.

That's because the code was insisting on an empty texture escrow before our update/render cycle could begin, and otherwise just waits for the next whole cycle.
On my MacbookPro, this was regularly giving a render average of 20fps instead of 60 (and that plays havoc with anything that depends on anything that targets a particular frame rate, such as the avatar render controller).