### PR TITLE
Menu Items for Disabling Rendering and Physics

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1107,6 +1107,8 @@ void Application::paintGL() {
     if (Menu::getInstance()->isOptionChecked(MenuOption::DisableRendering) || nullptr == _displayPlugin) {
         return;
     }
+    
+    _physicsEngine->setDisableCollisions(Menu::getInstance()->isOptionChecked(MenuOption::PhysicsDisableCollisions));
 
     // Some plugins process message events, potentially leading to
     // re-entering a paint event.  don't allow further processing if this

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1109,6 +1109,7 @@ void Application::paintGL() {
     }
     
     _physicsEngine->setDisableCollisions(Menu::getInstance()->isOptionChecked(MenuOption::PhysicsDisableCollisions));
+    _physicsEngine->setDisableSimulations(Menu::getInstance()->isOptionChecked(MenuOption::PhysicsDisableSimulations));
 
     // Some plugins process message events, potentially leading to
     // re-entering a paint event.  don't allow further processing if this

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1104,7 +1104,7 @@ void Application::paintGL() {
     PROFILE_RANGE(__FUNCTION__);
     PerformanceTimer perfTimer("paintGL");
 
-    if (nullptr == _displayPlugin) {
+    if (Menu::getInstance()->isOptionChecked(MenuOption::DisableRendering) || nullptr == _displayPlugin) {
         return;
     }
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -563,6 +563,7 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowOwned);
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowHulls);
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsDisableCollisions);
+    addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsDisableSimulations);
 
     addCheckableActionToQMenuAndActionHash(developerMenu, MenuOption::DisplayCrashOptions, 0, true);
     addActionToQMenuAndActionHash(developerMenu, MenuOption::CrashInterface, 0, qApp, SLOT(crashApplication()));

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -562,6 +562,7 @@ Menu::Menu() {
     MenuWrapper* physicsOptionsMenu = developerMenu->addMenu("Physics");
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowOwned);
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowHulls);
+    addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsDisableCollisions);
 
     addCheckableActionToQMenuAndActionHash(developerMenu, MenuOption::DisplayCrashOptions, 0, true);
     addActionToQMenuAndActionHash(developerMenu, MenuOption::CrashInterface, 0, qApp, SLOT(crashApplication()));

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -341,6 +341,8 @@ Menu::Menu() {
         0, // QML Qt::SHIFT | Qt::Key_L,
         dialogsManager.data(), SLOT(lodTools()));
     
+    addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::DisableRendering, 0, false);
+    
     MenuWrapper* assetDeveloperMenu = developerMenu->addMenu("Assets");
     
     auto& assetDialogFactory = AssetUploadDialogFactory::getInstance();

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -233,6 +233,7 @@ namespace MenuOption {
     const QString PhysicsShowOwned = "Highlight Simulation Ownership";
     const QString PhysicsShowHulls = "Draw Collision Hulls";
     const QString PhysicsDisableCollisions = "Disable Collisions";
+    const QString PhysicsDisableSimulations = "Disable Simulations";
     const QString PipelineWarnings = "Log Render Pipeline Warnings";
     const QString Preferences = "Preferences...";
     const QString Quit =  "Quit";

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -232,6 +232,7 @@ namespace MenuOption {
     const QString Pair = "Pair";
     const QString PhysicsShowOwned = "Highlight Simulation Ownership";
     const QString PhysicsShowHulls = "Draw Collision Hulls";
+    const QString PhysicsDisableCollisions = "Disable Collisions";
     const QString PipelineWarnings = "Log Render Pipeline Warnings";
     const QString Preferences = "Preferences...";
     const QString Quit =  "Quit";

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -175,6 +175,7 @@ namespace MenuOption {
     const QString DisableEyelidAdjustment = "Disable Eyelid Adjustment";
     const QString DisableLightEntities = "Disable Light Entities";
     const QString DisableNackPackets = "Disable Entity NACK Packets";
+    const QString DisableRendering = "Disable Rendering";
     const QString DiskCacheEditor = "Disk Cache Editor";
     const QString DisplayCrashOptions = "Display Crash Options";
     const QString DisplayHandTargets = "Show Hand Targets";

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -242,6 +242,10 @@ void PhysicsEngine::stepSimulation() {
     float dt = 1.0e-6f * (float)(_clock.getTimeMicroseconds());
     _clock.reset();
     float timeStep = btMin(dt, MAX_TIMESTEP);
+    
+    if (_disableSimulations) {
+        return;
+    }
 
     if (_myAvatarController) {
         // TODO: move this stuff outside and in front of stepSimulation, because

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -53,7 +53,7 @@ PhysicsEngine::~PhysicsEngine() {
 void PhysicsEngine::init() {
     if (!_dynamicsWorld) {
         _collisionConfig = new btDefaultCollisionConfiguration();
-        _collisionDispatcher = new btCollisionDispatcher(_collisionConfig);
+        _collisionDispatcher = new ToggleCollisionDispatcher(_collisionConfig);
         _broadphaseFilter = new btDbvtBroadphase();
         _constraintSolver = new btSequentialImpulseConstraintSolver;
         _dynamicsWorld = new ThreadSafeDynamicsWorld(_collisionDispatcher, _broadphaseFilter, _constraintSolver, _collisionConfig);

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -85,6 +85,8 @@ public:
     const glm::vec3& getOriginOffset() const { return _originOffset; }
     
     void setDisableCollisions(const bool flag) { _collisionDispatcher->setDisableCollisions(flag); }
+    
+    void setDisableSimulations(const bool flag) { _disableSimulations = flag; }
 
     /// \brief call bump on any objects that touch the object corresponding to motionState
     void bump(ObjectMotionState* motionState);
@@ -125,6 +127,7 @@ private:
 
     bool _dumpNextStats = false;
     bool _hasOutgoingChanges = false;
+    bool _disableSimulations = false;
 
     QUuid _sessionID;
     CollisionEvents _collisionEvents;

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -24,6 +24,7 @@
 #include "ObjectMotionState.h"
 #include "ThreadSafeDynamicsWorld.h"
 #include "ObjectAction.h"
+#include "ToggleCollisionDispatcher.h"
 
 const float HALF_SIMULATION_EXTENT = 512.0f; // meters
 
@@ -82,6 +83,8 @@ public:
 
     /// \return position of simulation origin in domain-frame
     const glm::vec3& getOriginOffset() const { return _originOffset; }
+    
+    void setDisableCollisions(const bool flag) { _collisionDispatcher->setDisableCollisions(flag); }
 
     /// \brief call bump on any objects that touch the object corresponding to motionState
     void bump(ObjectMotionState* motionState);
@@ -105,7 +108,7 @@ private:
 
     btClock _clock;
     btDefaultCollisionConfiguration* _collisionConfig = NULL;
-    btCollisionDispatcher* _collisionDispatcher = NULL;
+    ToggleCollisionDispatcher* _collisionDispatcher = NULL;
     btBroadphaseInterface* _broadphaseFilter = NULL;
     btSequentialImpulseConstraintSolver* _constraintSolver = NULL;
     ThreadSafeDynamicsWorld* _dynamicsWorld = NULL;

--- a/libraries/physics/src/ToggleCollisionDispatcher.h
+++ b/libraries/physics/src/ToggleCollisionDispatcher.h
@@ -12,9 +12,6 @@
 #define hifi_ToggleCollisionDispatcher_h
 
 #include <btBulletDynamicsCommon.h>
-#include <BulletCollision/CollisionDispatch/btGhostObject.h>
-
-#include "Menu.h"
 
 class ToggleCollisionDispatcher: public btCollisionDispatcher {
 public:

--- a/libraries/physics/src/ToggleCollisionDispatcher.h
+++ b/libraries/physics/src/ToggleCollisionDispatcher.h
@@ -1,0 +1,33 @@
+//
+//  ToggleCollisionDispatcher.h
+//  libraries/physics/src
+//
+//  Created by Luis Bermudez 2015.12.05
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_ToggleCollisionDispatcher_h
+#define hifi_ToggleCollisionDispatcher_h
+
+#include <btBulletDynamicsCommon.h>
+#include <BulletCollision/CollisionDispatch/btGhostObject.h>
+
+#include "Menu.h"
+
+class ToggleCollisionDispatcher: public btCollisionDispatcher {
+public:
+    using btCollisionDispatcher::btCollisionDispatcher;
+    
+    bool needsCollision(const btCollisionObject* body0,const btCollisionObject* body1) { return !(_disableCollisions) && btCollisionDispatcher::needsCollision( body0, body1 ); };
+    
+    void setDisableCollisions(const bool flag) { _disableCollisions = flag; }
+    
+    bool _disableCollisions = false;
+    
+private:
+    
+};
+
+#endif

--- a/libraries/physics/src/ToggleCollisionDispatcher.h
+++ b/libraries/physics/src/ToggleCollisionDispatcher.h
@@ -15,7 +15,9 @@
 
 class ToggleCollisionDispatcher: public btCollisionDispatcher {
 public:
-    using btCollisionDispatcher::btCollisionDispatcher;
+    
+    ToggleCollisionDispatcher(btCollisionConfiguration* collisionConfiguration)
+    : btCollisionDispatcher(collisionConfiguration) { }
     
     bool needsCollision(const btCollisionObject* body0,const btCollisionObject* body1) { return !(_disableCollisions) && btCollisionDispatcher::needsCollision( body0, body1 ); };
     


### PR DESCRIPTION
(1) Added a new menu option that when checked disables graphics rendering such
that the image on the screen is not redrawn until the menu option is disabled.

(2) Added a new menu option that when checked disables the physics collisions such 
that the avatar does not collide into collidable objects until the menu option is disabled.
Demo Video: https://youtu.be/fGQT_qF2YBc

(3) Added a new menu option that when checked disables the physics simulation
such that moving objects stop until the menu option is disabled.
Demo Video: https://youtu.be/BSq8LaDcECg
