### PR TITLE
MyAvatar.clearJointData bug fix

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -967,8 +967,6 @@ void MyAvatar::clearJointData(int index) {
         QMetaObject::invokeMethod(this, "clearJointData", Q_ARG(int, index));
         return;
     }
-    // HACK: ATM only JS scripts call clearJointData() on MyAvatar so we hardcode the priority
-    _rig->setJointState(index, false, glm::quat(), glm::vec3(), 0.0f);
     _rig->clearJointAnimationPriority(index);
 }
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -294,6 +294,7 @@ void Rig::clearJointStates() {
 void Rig::clearJointAnimationPriority(int index) {
     if (isIndexValid(index)) {
         _internalPoseSet._overrideFlags[index] = false;
+        _internalPoseSet._overridePoses[index] = _animSkeleton->getRelativeDefaultPose(index);
     }
 }
 


### PR DESCRIPTION
MyAvatar.setJointRotation() now works properly after MyAvatar.clearJointData()