### PR TITLE
fix for avatar URL text editing, assert in Model.cpp

### DIFF
--- a/interface/src/ui/PreferencesDialog.h
+++ b/interface/src/ui/PreferencesDialog.h
@@ -49,6 +49,7 @@ private slots:
     void openFullAvatarModelBrowser();
     void openSnapshotLocationBrowser();
     void openScriptsLocationBrowser();
+    void changeFullAvatarURL();
     void fullAvatarURLChanged(const QString& newValue, const QString& modelName);
 };
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -544,6 +544,7 @@ void Model::removeFromScene(std::shared_ptr<render::Scene> scene, render::Pendin
         pendingChanges.removeItem(item);
     }
     _renderItems.clear();
+    _renderItemsSet.clear();
     _readyWhenAdded = false;
 }
 


### PR DESCRIPTION
- fixes a bug with user input being overwritten in Avatar appearance text field in preferences
- fixes an assert on `_renderItemsSet.isEmpty()` when changing the URL of an existing model