### PR TITLE
Fix concurrency issues for bools in ScriptEngine

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4347,10 +4347,12 @@ void Application::scriptFinished(const QString& scriptName, ScriptEngine* engine
             }
         }
     }
-    postLambdaEvent([this, scriptName]() {
-        _runningScriptsWidget->scriptStopped(scriptName);
-        _runningScriptsWidget->setRunningScripts(getRunningScripts());
-    });
+    if (removed) {
+        postLambdaEvent([this, scriptName]() {
+            _runningScriptsWidget->scriptStopped(scriptName);
+            _runningScriptsWidget->setRunningScripts(getRunningScripts());
+        });
+    }
 }
 
 void Application::stopAllScripts(bool restart) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4013,7 +4013,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     scriptEngine->registerGlobalObject("Clipboard", clipboardScriptable);
     connect(scriptEngine, SIGNAL(finished(const QString&)), clipboardScriptable, SLOT(deleteLater()));
 
-    connect(scriptEngine, SIGNAL(finished(const QString&)), this, SLOT(scriptFinished(const QString&)));
+    connect(scriptEngine, &ScriptEngine::finished, this, &Application::scriptFinished, Qt::DirectConnection);
 
     connect(scriptEngine, SIGNAL(loadScript(const QString&, bool)), this, SLOT(loadScript(const QString&, bool)));
     connect(scriptEngine, SIGNAL(reloadScript(const QString&, bool)), this, SLOT(reloadScript(const QString&, bool)));

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -202,8 +202,8 @@ public:
 
     NodeToJurisdictionMap& getEntityServerJurisdictions() { return _entityServerJurisdictions; }
 
-    QStringList getRunningScripts() { return _scriptEnginesHash.keys(); }
-    ScriptEngine* getScriptEngine(const QString& scriptHash) { return _scriptEnginesHash.value(scriptHash, NULL); }
+    QStringList getRunningScripts();
+    ScriptEngine* getScriptEngine(const QString& scriptHash);
 
     float getRenderResolutionScale() const;
 
@@ -336,7 +336,7 @@ private slots:
     void loadSettings();
     void saveSettings();
     
-    void scriptFinished(const QString& scriptName);
+    void scriptFinished(const QString& scriptName, ScriptEngine* engine);
     void saveScripts();
     void reloadScript(const QString& scriptName, bool isUserLoaded = true);
     

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -505,6 +505,7 @@ private:
 
     TouchEvent _lastTouchEvent;
 
+    QReadWriteLock _scriptEnginesHashLock;
     RunningScriptsWidget* _runningScriptsWidget;
     QHash<QString, ScriptEngine*> _scriptEnginesHash;
     bool _runningScriptsWidgetWasVisible;

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -183,7 +183,7 @@ void ScriptEngine::runInThread() {
 
 QSet<ScriptEngine*> ScriptEngine::_allKnownScriptEngines;
 QMutex ScriptEngine::_allScriptsMutex;
-std::atomic<bool> ScriptEngine::_stoppingAllScripts = false;
+std::atomic<bool> ScriptEngine::_stoppingAllScripts { false };
 
 void ScriptEngine::stopAllScripts(QObject* application) {
     _allScriptsMutex.lock();
@@ -752,7 +752,7 @@ void ScriptEngine::run() {
     }
 
     if (_wantSignals) {
-        emit finished(_fileNameString);
+        emit finished(_fileNameString, this);
     }
 
     _isRunning = false;

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -183,7 +183,7 @@ void ScriptEngine::runInThread() {
 
 QSet<ScriptEngine*> ScriptEngine::_allKnownScriptEngines;
 QMutex ScriptEngine::_allScriptsMutex;
-bool ScriptEngine::_stoppingAllScripts = false;
+std::atomic<bool> ScriptEngine::_stoppingAllScripts = false;
 
 void ScriptEngine::stopAllScripts(QObject* application) {
     _allScriptsMutex.lock();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -775,6 +775,10 @@ void ScriptEngine::stopAllTimers() {
 
 void ScriptEngine::stop() {
     if (!_isFinished) {
+        if (QThread::currentThread() != thread()) {
+            QMetaObject::invokeMethod(this, "stop");
+            return;
+        }
         _isFinished = true;
         if (_wantSignals) {
             emit runningStateChanged();

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -193,7 +193,7 @@ protected:
     Quat _quatLibrary;
     Vec3 _vec3Library;
     ScriptUUID _uuidLibrary;
-    bool _isUserLoaded { false };
+    std::atomic<bool> _isUserLoaded { false };
     bool _isReloading { false };
 
     ArrayBufferClass* _arrayBufferClass;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -166,8 +166,8 @@ signals:
 protected:
     QString _scriptContents;
     QString _parentURL;
-    bool _isFinished { false };
-    bool _isRunning { false };
+    std::atomic<bool> _isFinished { false };
+    std::atomic<bool> _isRunning { false };
     int _evaluatesPending { 0 };
     bool _isInitialized { false };
     QHash<QTimer*, QScriptValue> _timerFunctionMap;
@@ -206,7 +206,7 @@ protected:
 
     static QSet<ScriptEngine*> _allKnownScriptEngines;
     static QMutex _allScriptsMutex;
-    static bool _stoppingAllScripts;
+    static std::atomic<bool> _stoppingAllScripts;
 };
 
 #endif // hifi_ScriptEngine_h

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -153,7 +153,7 @@ signals:
     void errorLoadingScript(const QString& scriptFilename);
     void update(float deltaTime);
     void scriptEnding();
-    void finished(const QString& fileNameString);
+    void finished(const QString& fileNameString, ScriptEngine* engine);
     void cleanupMenuItem(const QString& menuItemString);
     void printedMessage(const QString& message);
     void errorMessage(const QString& message);


### PR DESCRIPTION
Several member variables were unsafely being accessed from multiple threads. Making these variables std::atomic makes this safe.