### PR TITLE
Fix occasional crashes switching from the Oculus plugin 

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -54,6 +54,7 @@ public:
     }
 
     virtual void run() override {
+        OpenGLDisplayPlugin* currentPlugin{ nullptr };
         Q_ASSERT(_context);
         while (!_shutdown) {
             if (_pendingMainThreadOperation) {
@@ -81,12 +82,13 @@ public:
                 // Check if we have a new plugin to activate
                 if (_newPlugin != nullptr) {
                     // Deactivate the old plugin
-                    if (_activePlugin != nullptr) {
-                        _activePlugin->uncustomizeContext();
+                    if (currentPlugin != nullptr) {
+                        currentPlugin->uncustomizeContext();
+                        currentPlugin->enableDeactivate();
                     }
 
                     _newPlugin->customizeContext();
-                    _activePlugin = _newPlugin;
+                    currentPlugin = _newPlugin;
                     _newPlugin = nullptr;
                 }
                 _context->doneCurrent();
@@ -94,20 +96,21 @@ public:
             }
 
             // If there's no active plugin, just sleep
-            if (_activePlugin == nullptr) {
+            if (currentPlugin == nullptr) {
                 QThread::usleep(100);
                 continue;
             }
 
             // take the latest texture and present it
             _context->makeCurrent();
-            _activePlugin->present();
+            currentPlugin->present();
             _context->doneCurrent();
         }
 
         _context->makeCurrent();
-        if (_activePlugin) {
-            _activePlugin->uncustomizeContext();
+        if (currentPlugin) {
+            currentPlugin->uncustomizeContext();
+            currentPlugin->enableDeactivate();
         }
         _context->doneCurrent();
         _context->moveToThread(qApp->thread());
@@ -147,7 +150,6 @@ private:
     bool _finishedMainThreadOperation { false };
     QThread* _mainThread { nullptr };
     OpenGLDisplayPlugin* _newPlugin { nullptr };
-    OpenGLDisplayPlugin* _activePlugin { nullptr };
     QGLContext* _context { nullptr };
 };
 
@@ -208,11 +210,16 @@ void OpenGLDisplayPlugin::stop() {
 }
 
 void OpenGLDisplayPlugin::deactivate() {
+    {
+        Lock lock(_mutex);
+        _deactivateWait.wait(lock, [&]{ return _uncustomized; });
+    }
     _timer.stop();
     DisplayPlugin::deactivate();
 }
 
 void OpenGLDisplayPlugin::customizeContext() {
+    _uncustomized = false;
     auto presentThread = DependencyManager::get<PresentThread>();
     Q_ASSERT(thread() == presentThread->thread());
 
@@ -232,6 +239,7 @@ void OpenGLDisplayPlugin::uncustomizeContext() {
     _program.reset();
     _plane.reset();
 }
+
 
 // Pressing Alt (and Meta) key alone activates the menubar because its style inherits the
 // SHMenuBarAltKeyNavigation from QWindowsStyle. This makes it impossible for a scripts to
@@ -379,4 +387,10 @@ QImage OpenGLDisplayPlugin::getScreenshot() const {
         result = widget->grabFrameBuffer();
     });
     return result;
+}
+
+void OpenGLDisplayPlugin::enableDeactivate() {
+    Lock lock(_mutex);
+    _uncustomized = true;
+    _deactivateWait.notify_one();
 }

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -9,6 +9,8 @@
 
 #include "DisplayPlugin.h"
 
+#include <condition_variable>
+
 #include <QtCore/QTimer>
 
 #include <GLMHelpers.h>
@@ -18,8 +20,9 @@
 
 class OpenGLDisplayPlugin : public DisplayPlugin {
 protected:
-    using Mutex = std::recursive_mutex;
+    using Mutex = std::mutex;
     using Lock = std::unique_lock<Mutex>;
+    using Condition = std::condition_variable;
 public:
     OpenGLDisplayPlugin();
     virtual void activate() override;
@@ -82,6 +85,12 @@ protected:
     GLTextureEscrow _sceneTextureEscrow;
 
     bool _vsyncSupported { false };
+
+private:
+    void enableDeactivate();
+    Condition _deactivateWait;
+    bool _uncustomized{ false };
+
 };
 
 

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -230,7 +230,7 @@ void OculusDisplayPlugin::internalPresent() {
         viewScaleDesc.HmdToEyeViewOffset[1] = _eyeOffsets[1];
 
         ovrLayerHeader* layers = &_sceneLayer.Header;
-        ovrResult result = ovr_SubmitFrame(_hmd, 0, &viewScaleDesc, &layers, 1);
+        ovrResult result = ovr_SubmitFrame(_hmd, frameIndex, &viewScaleDesc, &layers, 1);
         if (!OVR_SUCCESS(result)) {
             qDebug() << result;
         }


### PR DESCRIPTION
The current system doesn't require that `uncustomizeContext` is (in the present thread) called before `deactivate` (in the main thread).  This means that if the main thread calls `deactivate` and shuts down the Oculus SDK, the `uncustomizeContext` call in the present thread will crash trying to call Oculus SDK functions.  

This PR adds a wait condition in the base OpenGL plugin class to ensure that `uncustomizeContext` always completes before `deactivate` is called.