### PR TITLE
Make Particle Explorer Particles Visible

### DIFF
--- a/examples/particle_explorer/particleExplorer.js
+++ b/examples/particle_explorer/particleExplorer.js
@@ -128,7 +128,6 @@ function setUp() {
             blue: 255
         },
         lifespan: 5.0,
-        visible: false,
         locked: false,
         isEmitting: true,
         lifetime: 3600 // 1 hour; just in case


### PR DESCRIPTION
This PR makes it so that the particle explorer is visible.  Previously, it was erroneously set to visible:false, which wasn't respected.  Now that the setting is respected, it should be visible by default.  To test: https://rawgit.com/imgntn/hifi/explorer_visibility/examples/particle_explorer/particleExplorer.js