### PR TITLE
Fix for sixense debug draw after migration to plugin.

### DIFF
--- a/libraries/shared/src/DebugDraw.cpp
+++ b/libraries/shared/src/DebugDraw.cpp
@@ -8,10 +8,11 @@
 //
 
 #include "DebugDraw.h"
+#include "SharedUtil.h"
 
 DebugDraw& DebugDraw::getInstance() {
-    static DebugDraw instance;
-    return instance;
+    static DebugDraw* instance = globalInstance<DebugDraw>("com.highfidelity.DebugDraw");
+    return *instance;
 }
 
 DebugDraw::DebugDraw() {


### PR DESCRIPTION
static variables used to hold a Singleton cannot be shared across dll boundaries by default.
This uses the globalInstance template to store the instance as a property on the QApplication.