### PR TITLE
reset skybox on changing domains

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3429,10 +3429,10 @@ namespace render {
 
         // Background rendering decision
         auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
-        auto skybox = model::SkyboxPointer();
         if (skyStage->getBackgroundMode() == model::SunSkyStage::NO_BACKGROUND) {
+            // this line intentionally left blank
         } else if (skyStage->getBackgroundMode() == model::SunSkyStage::SKY_DOME) {
-           if (/*!selfAvatarOnly &&*/ Menu::getInstance()->isOptionChecked(MenuOption::Stars)) {
+            if (Menu::getInstance()->isOptionChecked(MenuOption::Stars)) {
                 PerformanceTimer perfTimer("stars");
                 PerformanceWarning warn(Menu::getInstance()->isOptionChecked(MenuOption::PipelineWarnings),
                     "Application::payloadRender<BackgroundRenderData>() ... stars...");
@@ -3498,8 +3498,7 @@ namespace render {
             }
         } else if (skyStage->getBackgroundMode() == model::SunSkyStage::SKY_BOX) {
             PerformanceTimer perfTimer("skybox");
-
-            skybox = skyStage->getSkybox();
+            auto skybox = skyStage->getSkybox();
             if (skybox) {
                 skybox->render(batch, *(qApp->getDisplayViewFrustum()));
             }
@@ -3765,6 +3764,10 @@ void Application::clearDomainOctreeDetails() {
 
     // reset the model renderer
     getEntities()->clear();
+
+    auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
+    skyStage->setBackgroundMode(model::SunSkyStage::SKY_DOME);
+
 }
 
 void Application::domainChanged(const QString& domainHostname) {


### PR DESCRIPTION
This fixes the bug that when you switch domains, the skybox stays the same as the skybox for the domain you left.