### PR TITLE
don't crash when a child no longer has a containing element

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -226,9 +226,16 @@ bool EntityTree::updateEntityWithElement(EntityItemPointer entity, const EntityI
 
         while (!toProcess.empty()) {
             EntityItemPointer childEntity = std::static_pointer_cast<EntityItem>(toProcess.dequeue());
+            if (!childEntity) {
+                continue;
+            }
             BoundingBoxRelatedProperties newChildBBRelProperties(childEntity);
+            EntityTreeElementPointer containingElement = childEntity->getElement();
+            if (!containingElement) {
+                continue;
+            }
             UpdateEntityOperator theChildOperator(getThisPointer(),
-                                                  childEntity->getElement(),
+                                                  containingElement,
                                                   childEntity, newChildBBRelProperties);
             recurseTreeWithOperator(&theChildOperator);
             foreach (SpatiallyNestablePointer childChild, childEntity->getChildren()) {


### PR DESCRIPTION
- possible fix for flash-light induced crash