### PR TITLE
Fix the broken skybox and simplify a bit the vertex shader used

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3503,7 +3503,7 @@ namespace render {
 
             skybox = skyStage->getSkybox();
             if (skybox) {
-                skybox->render(batch, *(qApp->getDisplayViewFrustum()));
+                skybox->render(batch, *(args->_viewFrustum));
             }
         }
     }

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -135,7 +135,7 @@ TransformCamera getTransformCamera() {
 
 <@func transformClipToEyeDir(cameraTransform, clipPos, eyeDir)@>
     { // transformClipToEyeDir
-        <$eyeDir$> = vec3(<$cameraTransform$>._projectionInverse * vec4(<$clipPos$>.xyz, 0.0));
+        <$eyeDir$> = vec3(<$cameraTransform$>._projectionInverse * vec4(<$clipPos$>.xyz, 1.0)); // Must be 1.0 here
     }
 <@endfunc@>
 

--- a/libraries/model/src/model/Skybox.cpp
+++ b/libraries/model/src/model/Skybox.cpp
@@ -71,22 +71,12 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& frustum) const {
 
 void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Skybox& skybox) {
     // Create the static shared elements used to render the skybox
-    static gpu::BufferPointer theBuffer;
-    static gpu::Stream::FormatPointer theFormat;
     static gpu::BufferPointer theConstants;
     static gpu::PipelinePointer thePipeline;
     const int SKYBOX_SKYMAP_SLOT = 0;
     const int SKYBOX_CONSTANTS_SLOT = 0;
     static std::once_flag once;
     std::call_once(once, [&] {
-        {
-            const float CLIP = 1.0f;
-            const glm::vec2 vertices[4] = { { -CLIP, -CLIP }, { CLIP, -CLIP }, { -CLIP, CLIP }, { CLIP, CLIP } };
-            theBuffer = std::make_shared<gpu::Buffer>(sizeof(vertices), (const gpu::Byte*) vertices);
-            theFormat = std::make_shared<gpu::Stream::Format>();
-            theFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
-        }
-
         {
             auto skyVS = gpu::Shader::createVertex(std::string(Skybox_vert));
             auto skyFS = gpu::Shader::createPixel(std::string(Skybox_frag));
@@ -115,8 +105,6 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
     batch.setProjectionTransform(projMat);
     batch.setViewTransform(viewTransform);
     batch.setModelTransform(Transform()); // only for Mac
-    batch.setInputBuffer(gpu::Stream::POSITION, theBuffer, 0, 8);
-    batch.setInputFormat(theFormat);
 
     gpu::TexturePointer skymap;
     if (skybox.getCubemap() && skybox.getCubemap()->isDefined()) {

--- a/libraries/model/src/model/Skybox.slv
+++ b/libraries/model/src/model/Skybox.slv
@@ -11,21 +11,26 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-
-<@include gpu/Inputs.slh@>
-
 <@include gpu/Transform.slh@>
 
 <$declareStandardTransform()$>
 
 out vec3 _normal;
 
-void main(void) {    
+void main(void) {
+    const float depth = 0.0;
+    const vec4 UNIT_QUAD[4] = vec4[4](
+        vec4(-1.0, -1.0, depth, 1.0),
+        vec4(1.0, -1.0, depth, 1.0),
+        vec4(-1.0, 1.0, depth, 1.0),
+        vec4(1.0, 1.0, depth, 1.0)
+    );
+    vec4 inPosition = UNIT_QUAD[gl_VertexID];
+
     // standard transform
     TransformCamera cam = getTransformCamera();
     vec3 clipDir = vec3(inPosition.xy, 0.0);
     vec3 eyeDir;
-    
     <$transformClipToEyeDir(cam, clipDir, eyeDir)$>
     <$transformEyeToWorldDir(cam, eyeDir, _normal)$>
     

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -51,14 +51,6 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
     static gpu::Stream::FormatPointer theFormat;
 
     if (skybox._procedural && skybox._procedural->_enabled && skybox._procedural->ready()) {
-        if (!theBuffer) {
-            const float CLIP = 1.0f;
-            const glm::vec2 vertices[4] = { { -CLIP, -CLIP }, { CLIP, -CLIP }, { -CLIP, CLIP }, { CLIP, CLIP } };
-            theBuffer = std::make_shared<gpu::Buffer>(sizeof(vertices), (const gpu::Byte*) vertices);
-            theFormat = std::make_shared<gpu::Stream::Format>();
-            theFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
-        }
-
         glm::mat4 projMat;
         viewFrustum.evalProjectionMatrix(projMat);
 
@@ -67,8 +59,6 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewTransform);
         batch.setModelTransform(Transform()); // only for Mac
-        batch.setInputBuffer(gpu::Stream::POSITION, theBuffer, 0, 8);
-        batch.setInputFormat(theFormat);
 
         if (skybox.getCubemap() && skybox.getCubemap()->isDefined()) {
             batch.setResourceTexture(0, skybox.getCubemap());


### PR DESCRIPTION
- Fix the function transformClipToEyeDir 

- Replace the vertex buffers used to draw the full screen quad by a  vertex shader relying on the VertexID.

