### PR TITLE
Fix crash in "entry" from procedural skybox

### DIFF
--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -51,6 +51,14 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
     static gpu::Stream::FormatPointer theFormat;
 
     if (skybox._procedural && skybox._procedural->_enabled && skybox._procedural->ready()) {
+        if (!theBuffer) {
+            const float CLIP = 1.0f;
+            const glm::vec2 vertices[4] = { { -CLIP, -CLIP }, { CLIP, -CLIP }, { -CLIP, CLIP }, { CLIP, CLIP } };
+            theBuffer = std::make_shared<gpu::Buffer>(sizeof(vertices), (const gpu::Byte*) vertices);
+            theFormat = std::make_shared<gpu::Stream::Format>();
+            theFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
+        }
+
         glm::mat4 projMat;
         viewFrustum.evalProjectionMatrix(projMat);
 
@@ -59,6 +67,8 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewTransform);
         batch.setModelTransform(Transform()); // only for Mac
+        batch.setInputBuffer(gpu::Stream::POSITION, theBuffer, 0, 8);
+        batch.setInputFormat(theFormat);
 
         if (skybox.getCubemap() && skybox.getCubemap()->isDefined()) {
             batch.setResourceTexture(0, skybox.getCubemap());


### PR DESCRIPTION
Revert "Fix the broken skybox and simplify a bit the vertex shader used"

This reverts commit 68134aafe5d22fe1efe19bbdc65fac32f9dfa4bc.