### PR TITLE
Applicant test project

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1083,6 +1083,12 @@ void Application::paintGL() {
     if (_aboutToQuit) {
         return;
     }
+    
+    // Don't render anything if this is checked
+	if (Menu::getInstance()->isOptionChecked(MenuOption::NoRender)){
+		return;
+	}
+    
     _frameCount++;
 
     // update fps moving average

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -306,7 +306,9 @@ Menu::Menu() {
         true);
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::DebugAmbientOcclusion);
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::Antialiasing);
-
+	
+	addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::NoRender);
+	
     MenuWrapper* ambientLightMenu = renderOptionsMenu->addMenu(MenuOption::RenderAmbientLight);
     QActionGroup* ambientLightGroup = new QActionGroup(ambientLightMenu);
     ambientLightGroup->setExclusive(true);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -289,6 +289,7 @@ namespace MenuOption {
     const QString VisibleToFriends = "Friends";
     const QString VisibleToNoOne = "No one";
     const QString WorldAxes = "World Axes";
+    const QString NoRender = "Halt rendering of the world";
 }
 
 #endif // hifi_Menu_h


### PR DESCRIPTION
The code changes involved adding the following few lines:

-- hifi\interface\src\Menu.h: --
const QString NoRender = "Halt rendering of the world";

-- hifi\interface\src\Menu.cpp: --
addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::NoRender);

-- hifi\interface\src\Application.cpp: --
// Don't render anything if this is checked
if (Menu::getInstance()->isOptionChecked(MenuOption::NoRender)){
return;
}
