### PR TITLE
ModelEntityItem: fix for incorrect joint mapping

### DIFF
--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -194,7 +194,7 @@ AnimationPointer ModelEntityItem::getAnimation(const QString& url) {
 
 void ModelEntityItem::mapJoints(const QStringList& modelJointNames) {
     // if we don't have animation, or we're already joint mapped then bail early
-    if (!hasAnimation() || _jointMappingCompleted) {
+    if (!hasAnimation() || jointsMapped()) {
         return;
     }
 
@@ -208,6 +208,7 @@ void ModelEntityItem::mapJoints(const QStringList& modelJointNames) {
                 _jointMapping[i] = animationJointNames.indexOf(modelJointNames[i]);
             }
             _jointMappingCompleted = true;
+            _jointMappingURL = _animationProperties.getURL();
         }
     }
 }

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -104,7 +104,7 @@ public:
     
     void mapJoints(const QStringList& modelJointNames);
     void getAnimationFrame(bool& newFrame, QVector<glm::quat>& rotationsResult, QVector<glm::vec3>& translationsResult);
-    bool jointsMapped() const { return _jointMappingCompleted; }
+    bool jointsMapped() const { return _jointMappingURL == getAnimationURL() && _jointMappingCompleted; }
     
     bool getAnimationIsPlaying() const { return _animationLoop.getRunning(); }
     float getAnimationCurrentFrame() const { return _animationLoop.getCurrentFrame(); }
@@ -146,6 +146,7 @@ protected:
     // used on client side
     bool _jointMappingCompleted;
     QVector<int> _jointMapping;
+    QString _jointMappingURL;
 
     static AnimationPointer getAnimation(const QString& url);
     static QMap<QString, AnimationPointer> _loadedAnimations;


### PR DESCRIPTION
This could happen when switching the animation url between two fbx files with different joint mappings.  Only the first one would take effect.

This should fix the issue in the demo domain, with the contorted doll model.