### PR TITLE
Correct collision capsule for scaled avatars

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1260,15 +1260,14 @@ void Application::paintGL() {
                 hmdOffset.x = -hmdOffset.x;
 
                 _myCamera.setPosition(myAvatar->getDefaultEyePosition()
-                    + glm::vec3(0, _raiseMirror * myAvatar->getAvatarScale(), 0)
+                    + glm::vec3(0, _raiseMirror * myAvatar->getUniformScale(), 0)
                    + mirrorBodyOrientation * glm::vec3(0.0f, 0.0f, 1.0f) * MIRROR_FULLSCREEN_DISTANCE * _scaleMirror
                    + mirrorBodyOrientation * hmdOffset);
-
             } else {
                 _myCamera.setRotation(myAvatar->getWorldAlignedOrientation()
                     * glm::quat(glm::vec3(0.0f, PI + _rotateMirror, 0.0f)));
                 _myCamera.setPosition(myAvatar->getDefaultEyePosition()
-                    + glm::vec3(0, _raiseMirror * myAvatar->getAvatarScale(), 0)
+                    + glm::vec3(0, _raiseMirror * myAvatar->getUniformScale(), 0)
                     + (myAvatar->getOrientation() * glm::quat(glm::vec3(0.0f, _rotateMirror, 0.0f))) *
                     glm::vec3(0.0f, 0.0f, -1.0f) * MIRROR_FULLSCREEN_DISTANCE * _scaleMirror);
             }

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -454,7 +454,8 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
         bool renderBounding = Menu::getInstance()->isOptionChecked(MenuOption::RenderBoundingCollisionShapes);
         if (renderBounding && shouldRenderHead(renderArgs) && _skeletonModel.isRenderable()) {
             PROFILE_RANGE_BATCH(batch, __FUNCTION__":skeletonBoundingCollisionShapes");
-            _skeletonModel.renderBoundingCollisionShapes(*renderArgs->_batch, 0.7f);
+            const float BOUNDING_SHAPE_ALPHA = 0.7f;
+            _skeletonModel.renderBoundingCollisionShapes(*renderArgs->_batch, getUniformScale(), BOUNDING_SHAPE_ALPHA);
         }
 
         // If this is the avatar being looked at, render a little ball above their head

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -150,14 +150,17 @@ float Avatar::getLODDistance() const {
 void Avatar::animateScaleChanges(float deltaTime) {
     float currentScale = getUniformScale();
     if (currentScale != _targetScale) {
+        // use exponential decay toward _targetScale
         const float SCALE_ANIMATION_TIMESCALE = 0.5f;
-        float scaleVelocity = (_targetScale - currentScale) / SCALE_ANIMATION_TIMESCALE;
-        float animatedScale = currentScale + deltaTime * scaleVelocity;
-        const float MIN_SCALE_SPEED = 0.3f;
-        if (fabsf(scaleVelocity) < MIN_SCALE_SPEED) {
-            // close enough
+        float blendFactor = glm::clamp(deltaTime / SCALE_ANIMATION_TIMESCALE, 0.0f, 1.0f);
+        float animatedScale = (1.0f - blendFactor) * currentScale + blendFactor * _targetScale;
+
+        // snap to the end when we get close enough
+        const float MIN_RELATIVE_SCALE_ERROR = 0.03f;
+        if (fabsf(_targetScale - currentScale) / _targetScale < 0.03f) {
             animatedScale = _targetScale;
         }
+
         setScale(glm::vec3(animatedScale)); // avatar scale is uniform
         rebuildCollisionShape();
     }

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -167,7 +167,7 @@ void Avatar::simulate(float deltaTime) {
     PerformanceTimer perfTimer("simulate");
 
     if (!isDead() && !_motionState) {
-        DependencyManager::get<AvatarManager>()->updateAvatarPhysicsShape(this);
+        DependencyManager::get<AvatarManager>()->addAvatarToSimulation(this);
     }
     animateScaleChanges(deltaTime);
 

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -99,7 +99,8 @@ Avatar::Avatar(RigPointer rig) :
     // we may have been created in the network thread, but we live in the main thread
     moveToThread(qApp->thread());
 
-    setAvatarScale(1.0f);
+    setScale(glm::vec3(1.0f)); // avatar scale is uniform
+
     // give the pointer to our head to inherited _headData variable from AvatarData
     _headData = static_cast<HeadData*>(new Head(this));
     _handData = static_cast<HandData*>(new Hand(this));
@@ -143,15 +144,28 @@ AABox Avatar::getBounds() const {
 
 float Avatar::getLODDistance() const {
     return DependencyManager::get<LODManager>()->getAvatarLODDistanceMultiplier() *
-        glm::distance(qApp->getCamera()->getPosition(), getPosition()) / getAvatarScale();
+        glm::distance(qApp->getCamera()->getPosition(), getPosition()) / getUniformScale();
+}
+
+void Avatar::animateScaleChanges(float deltaTime) {
+    float currentScale = getUniformScale();
+    if (currentScale != _targetScale) {
+        const float SCALE_ANIMATION_TIMESCALE = 1.0f;
+        float blendFactor = deltaTime / SCALE_ANIMATION_TIMESCALE;
+        float animatedScale = (1.0f - blendFactor) * currentScale + blendFactor * _targetScale;
+        const float CLOSE_ENOUGH = 0.05f;
+        if (fabsf(animatedScale - _targetScale) / _targetScale < CLOSE_ENOUGH) {
+            animatedScale = _targetScale;
+        }
+        setScale(glm::vec3(animatedScale)); // avatar scale is uniform
+        rebuildCollisionShape();
+    }
 }
 
 void Avatar::simulate(float deltaTime) {
     PerformanceTimer perfTimer("simulate");
 
-    if (getAvatarScale() != _targetScale) {
-        setAvatarScale(_targetScale);
-    }
+    animateScaleChanges(deltaTime);
 
     // update the billboard render flag
     const float BILLBOARD_HYSTERESIS_PROPORTION = 0.1f;
@@ -164,7 +178,7 @@ void Avatar::simulate(float deltaTime) {
         _shouldRenderBillboard = true;
         qCDebug(interfaceapp) << "Billboarding" << (isMyAvatar() ? "myself" : getSessionUUID()) << "for LOD" << getLODDistance();
     }
-    
+
     const bool isControllerLogging = DependencyManager::get<AvatarManager>()->getRenderDistanceControllerIsLogging();
     float renderDistance = DependencyManager::get<AvatarManager>()->getRenderDistance();
     const float SKIP_HYSTERESIS_PROPORTION = isControllerLogging ? 0.0f : BILLBOARD_HYSTERESIS_PROPORTION;
@@ -210,7 +224,7 @@ void Avatar::simulate(float deltaTime) {
             _skeletonModel.getHeadPosition(headPosition);
             Head* head = getHead();
             head->setPosition(headPosition);
-            head->setScale(getAvatarScale());
+            head->setScale(getUniformScale());
             head->simulate(deltaTime, false, _shouldRenderBillboard);
         }
     }
@@ -238,12 +252,12 @@ void Avatar::simulate(float deltaTime) {
     measureMotionDerivatives(deltaTime);
 }
 
-bool Avatar::isLookingAtMe(AvatarSharedPointer avatar) {
+bool Avatar::isLookingAtMe(AvatarSharedPointer avatar) const {
     const float HEAD_SPHERE_RADIUS = 0.1f;
     glm::vec3 theirLookAt = dynamic_pointer_cast<Avatar>(avatar)->getHead()->getLookAtPosition();
     glm::vec3 myEyePosition = getHead()->getEyePosition();
 
-    return glm::distance(theirLookAt, myEyePosition) <= (HEAD_SPHERE_RADIUS * getAvatarScale());
+    return glm::distance(theirLookAt, myEyePosition) <= (HEAD_SPHERE_RADIUS * getUniformScale());
 }
 
 void Avatar::slamPosition(const glm::vec3& newPosition) {
@@ -423,7 +437,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
             const float BASE_LIGHT_DISTANCE = 2.0f;
             const float LIGHT_EXPONENT = 1.0f;
             const float LIGHT_CUTOFF = glm::radians(80.0f);
-            float distance = BASE_LIGHT_DISTANCE * getAvatarScale();
+            float distance = BASE_LIGHT_DISTANCE * getUniformScale();
             glm::vec3 position = glm::mix(_skeletonModel.getTranslation(), getHead()->getFaceModel().getTranslation(), 0.9f);
             glm::quat orientation = getOrientation();
             foreach (const AvatarManager::LocalLight& light, DependencyManager::get<AvatarManager>()->getLocalLights()) {
@@ -479,7 +493,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                     }
 
                     DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch,
-                        Transform(transform).postScale(eyeDiameter * getAvatarScale() / 2.0f + RADIUS_INCREMENT),
+                        Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT),
                         glm::vec4(LOOKING_AT_ME_COLOR, alpha));
 
                     position = getHead()->getRightEyePosition();
@@ -489,7 +503,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
                     DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch,
-                        Transform(transform).postScale(eyeDiameter * getAvatarScale() / 2.0f + RADIUS_INCREMENT),
+                        Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT),
                         glm::vec4(LOOKING_AT_ME_COLOR, alpha));
 
                 }
@@ -590,9 +604,9 @@ void Avatar::simulateAttachments(float deltaTime) {
         glm::quat jointRotation;
         if (_skeletonModel.getJointPositionInWorldFrame(jointIndex, jointPosition) &&
             _skeletonModel.getJointRotationInWorldFrame(jointIndex, jointRotation)) {
-            model->setTranslation(jointPosition + jointRotation * attachment.translation * getAvatarScale());
+            model->setTranslation(jointPosition + jointRotation * attachment.translation * getUniformScale());
             model->setRotation(jointRotation * attachment.rotation);
-            model->setScaleToFit(true, getAvatarScale() * attachment.scale, true); // hack to force rescale
+            model->setScaleToFit(true, getUniformScale() * attachment.scale, true); // hack to force rescale
             model->setSnapModelToCenter(false); // hack to force resnap
             model->setSnapModelToCenter(true);
             model->simulate(deltaTime);
@@ -647,7 +661,7 @@ void Avatar::renderBillboard(RenderArgs* renderArgs) {
 }
 
 float Avatar::getBillboardSize() const {
-    return getAvatarScale() * BILLBOARD_DISTANCE * glm::tan(glm::radians(BILLBOARD_FIELD_OF_VIEW / 2.0f));
+    return getUniformScale() * BILLBOARD_DISTANCE * glm::tan(glm::radians(BILLBOARD_FIELD_OF_VIEW / 2.0f));
 }
 
 #ifdef DEBUG
@@ -796,7 +810,7 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& frustum, co
 }
 
 void Avatar::setSkeletonOffset(const glm::vec3& offset) {
-    const float MAX_OFFSET_LENGTH = getAvatarScale() * 0.5f;
+    const float MAX_OFFSET_LENGTH = getUniformScale() * 0.5f;
     float offsetLength = glm::length(offset);
     if (offsetLength > MAX_OFFSET_LENGTH) {
         _skeletonOffset = (MAX_OFFSET_LENGTH / offsetLength) * offset;
@@ -905,7 +919,7 @@ glm::vec3 Avatar::getJointPosition(const QString& name) const {
 
 void Avatar::scaleVectorRelativeToPosition(glm::vec3 &positionToScale) const {
     //Scale a world space vector as if it was relative to the position
-    positionToScale = getPosition() + getAvatarScale() * (positionToScale - getPosition());
+    positionToScale = getPosition() + getUniformScale() * (positionToScale - getPosition());
 }
 
 void Avatar::setFaceModelURL(const QUrl& faceModelURL) {
@@ -945,7 +959,7 @@ void Avatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) {
     for (int i = 0; i < attachmentData.size(); i++) {
         _attachmentModels[i]->setURL(attachmentData.at(i).modelURL);
         _attachmentModels[i]->setSnapModelToCenter(true);
-        _attachmentModels[i]->setScaleToFit(true, getAvatarScale() * _attachmentData.at(i).scale);
+        _attachmentModels[i]->setScaleToFit(true, getUniformScale() * _attachmentData.at(i).scale);
     }
 }
 
@@ -1033,15 +1047,6 @@ void Avatar::renderJointConnectingCone(gpu::Batch& batch, glm::vec3 position1, g
     }
 }
 
-void Avatar::setAvatarScale(float scale) {
-    if (_targetScale * (1.0f - RESCALING_TOLERANCE) < scale &&
-        scale < _targetScale * (1.0f + RESCALING_TOLERANCE)) {
-        setScale(glm::vec3(_targetScale));
-    } else {
-        setScale(glm::vec3(scale));
-    }
-}
-
 float Avatar::getSkeletonHeight() const {
     Extents extents = _skeletonModel.getBindExtents();
     return extents.maximum.y - extents.minimum.y;
@@ -1053,7 +1058,7 @@ float Avatar::getHeadHeight() const {
 
         // HACK: We have a really odd case when fading out for some models where this value explodes
         float result = extents.maximum.y - extents.minimum.y;
-        if (result >= 0.0f && result < 100.0f * getAvatarScale() ) {
+        if (result >= 0.0f && result < 100.0f * getUniformScale() ) {
             return result;
         }
     }
@@ -1096,13 +1101,20 @@ void Avatar::setShowDisplayName(bool showDisplayName) {
 
 // virtual
 void Avatar::computeShapeInfo(ShapeInfo& shapeInfo) {
-    shapeInfo.setCapsuleY(_skeletonModel.getBoundingCapsuleRadius(), 0.5f * _skeletonModel.getBoundingCapsuleHeight());
-    shapeInfo.setOffset(_skeletonModel.getBoundingCapsuleOffset());
+    float uniformScale = getUniformScale();
+    shapeInfo.setCapsuleY(uniformScale * _skeletonModel.getBoundingCapsuleRadius(),
+            0.5f * uniformScale *  _skeletonModel.getBoundingCapsuleHeight());
+    shapeInfo.setOffset(uniformScale * _skeletonModel.getBoundingCapsuleOffset());
 }
 
 // virtual
-void Avatar::rebuildSkeletonBody() {
-    DependencyManager::get<AvatarManager>()->updateAvatarPhysicsShape(this);
+void Avatar::rebuildCollisionShape() {
+    if (_motionState) {
+        _motionState->addDirtyFlags(Simulation::DIRTY_SHAPE);
+    } else {
+        // adebug TODO: move most of updateAvatarPhysicsShape() to here
+        DependencyManager::get<AvatarManager>()->updateAvatarPhysicsShape(this);
+    }
 }
 
 glm::vec3 Avatar::getLeftPalmPosition() {

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -157,7 +157,6 @@ public:
 
     virtual void computeShapeInfo(ShapeInfo& shapeInfo);
 
-    void setMotionState(AvatarMotionState* motionState) { _motionState = motionState; }
     AvatarMotionState* getMotionState() { return _motionState; }
 
     virtual void setPosition(const glm::vec3& position) override;
@@ -172,6 +171,10 @@ public slots:
     glm::quat getRightPalmRotation();
 
 protected:
+    friend class AvatarManager;
+
+    void setMotionState(AvatarMotionState* motionState);
+
     SkeletonModel _skeletonModel;
     glm::vec3 _skeletonOffset;
     QVector<Model*> _attachmentModels;

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -36,7 +36,6 @@ namespace render {
 
 static const float SCALING_RATIO = .05f;
 static const float SMOOTHING_RATIO = .05f; // 0 < ratio < 1
-static const float RESCALING_TOLERANCE = .02f;
 
 static const float BILLBOARD_FIELD_OF_VIEW = 30.0f; // degrees
 static const float BILLBOARD_DISTANCE = 5.56f;       // meters
@@ -89,7 +88,7 @@ public:
     SkeletonModel& getSkeletonModel() { return _skeletonModel; }
     const SkeletonModel& getSkeletonModel() const { return _skeletonModel; }
     glm::vec3 getChestPosition() const;
-    float getAvatarScale() const { return getScale().y; }
+    float getUniformScale() const { return getScale().y; }
     const Head* getHead() const { return static_cast<const Head*>(_headData); }
     Head* getHead() { return static_cast<Head*>(_headData); }
     Hand* getHand() { return static_cast<Hand*>(_handData); }
@@ -154,7 +153,7 @@ public:
     // (otherwise floating point error will cause problems at large positions).
     void applyPositionDelta(const glm::vec3& delta);
 
-    virtual void rebuildSkeletonBody();
+    virtual void rebuildCollisionShape();
 
     virtual void computeShapeInfo(ShapeInfo& shapeInfo);
 
@@ -199,14 +198,15 @@ protected:
     float _stringLength;
     bool _moving; ///< set when position is changing
 
-    bool isLookingAtMe(AvatarSharedPointer avatar);
-
     // protected methods...
+    bool isLookingAtMe(AvatarSharedPointer avatar) const;
+
+    virtual void animateScaleChanges(float deltaTime);
+
     glm::vec3 getBodyRightDirection() const { return getOrientation() * IDENTITY_RIGHT; }
     glm::vec3 getBodyUpDirection() const { return getOrientation() * IDENTITY_UP; }
     glm::vec3 getBodyFrontDirection() const { return getOrientation() * IDENTITY_FRONT; }
     glm::quat computeRotationFromBodyToWorldUp(float proportion = 1.0f) const;
-    void setAvatarScale(float scale);
     void measureMotionDerivatives(float deltaTime);
 
     float getSkeletonHeight() const;

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -375,13 +375,14 @@ void AvatarManager::handleCollisionEvents(const CollisionEvents& collisionEvents
     }
 }
 
-void AvatarManager::updateAvatarPhysicsShape(Avatar* avatar) {
+void AvatarManager::addAvatarToSimulation(Avatar* avatar) {
     assert(!avatar->getMotionState());
 
     ShapeInfo shapeInfo;
     avatar->computeShapeInfo(shapeInfo);
     btCollisionShape* shape = ObjectMotionState::getShapeManager()->getShape(shapeInfo);
     if (shape) {
+        // we don't add to the simulation now, we put it on a list to be added later
         AvatarMotionState* motionState = new AvatarMotionState(avatar, shape);
         avatar->setMotionState(motionState);
         _motionStatesToAdd.insert(motionState);

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -203,7 +203,7 @@ void AvatarManager::simulateAvatarFades(float deltaTime) {
     while (fadingIterator != _avatarFades.end()) {
         auto avatar = std::static_pointer_cast<Avatar>(*fadingIterator);
         avatar->startUpdate();
-        avatar->setTargetScale(avatar->getAvatarScale() * SHRINK_RATE);
+        avatar->setTargetScale(avatar->getUniformScale() * SHRINK_RATE);
         if (avatar->getTargetScale() <= MIN_FADE_SCALE) {
             avatar->removeFromScene(*fadingIterator, scene, pendingChanges);
             fadingIterator = _avatarFades.erase(fadingIterator);
@@ -375,19 +375,17 @@ void AvatarManager::handleCollisionEvents(const CollisionEvents& collisionEvents
 }
 
 void AvatarManager::updateAvatarPhysicsShape(Avatar* avatar) {
-    AvatarMotionState* motionState = avatar->getMotionState();
-    if (motionState) {
-        motionState->addDirtyFlags(Simulation::DIRTY_SHAPE);
-    } else {
-        ShapeInfo shapeInfo;
-        avatar->computeShapeInfo(shapeInfo);
-        btCollisionShape* shape = ObjectMotionState::getShapeManager()->getShape(shapeInfo);
-        if (shape) {
-            AvatarMotionState* motionState = new AvatarMotionState(avatar, shape);
-            avatar->setMotionState(motionState);
-            _motionStatesToAdd.insert(motionState);
-            _avatarMotionStates.insert(motionState);
-        }
+    // adebug TODO: move most of this logic to MyAvatar class
+    assert(!avatar->getMotionState());
+
+    ShapeInfo shapeInfo;
+    avatar->computeShapeInfo(shapeInfo);
+    btCollisionShape* shape = ObjectMotionState::getShapeManager()->getShape(shapeInfo);
+    if (shape) {
+        AvatarMotionState* motionState = new AvatarMotionState(avatar, shape);
+        avatar->setMotionState(motionState);
+        _motionStatesToAdd.insert(motionState);
+        _avatarMotionStates.insert(motionState);
     }
 }
 

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -66,7 +66,7 @@ public:
     void handleOutgoingChanges(const VectorOfMotionStates& motionStates);
     void handleCollisionEvents(const CollisionEvents& collisionEvents);
 
-    void updateAvatarPhysicsShape(Avatar* avatar);
+    void addAvatarToSimulation(Avatar* avatar);
 
     // Expose results and parameter-tuning operations to other systems, such as stats and javascript.
     Q_INVOKABLE float getRenderDistance() { return _renderDistance; }

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -52,7 +52,7 @@ public:
         glm::vec3 color;
         glm::vec3 direction;
     };
-    
+
     Q_INVOKABLE void setLocalLights(const QVector<AvatarManager::LocalLight>& localLights);
     Q_INVOKABLE QVector<AvatarManager::LocalLight> getLocalLights() const;
     // Currently, your own avatar will be included as the null avatar id.
@@ -67,7 +67,7 @@ public:
     void handleCollisionEvents(const CollisionEvents& collisionEvents);
 
     void updateAvatarPhysicsShape(Avatar* avatar);
-    
+
     // Expose results and parameter-tuning operations to other systems, such as stats and javascript.
     Q_INVOKABLE float getRenderDistance() { return _renderDistance; }
     Q_INVOKABLE float getRenderDistanceInverseLowLimit() { return _renderDistanceController.getControlledValueLowLimit(); }
@@ -80,7 +80,7 @@ public:
     Q_INVOKABLE void setRenderDistanceKD(float newValue) { _renderDistanceController.setKD(newValue); }
     Q_INVOKABLE void setRenderDistanceInverseLowLimit(float newValue) { _renderDistanceController.setControlledValueLowLimit(newValue); }
     Q_INVOKABLE void setRenderDistanceInverseHighLimit(float newValue);
-   
+
 public slots:
     void setShouldShowReceiveStats(bool shouldShowReceiveStats) { _shouldShowReceiveStats = shouldShowReceiveStats; }
     void updateAvatarRenderStatus(bool shouldRenderAvatars);
@@ -90,19 +90,19 @@ private:
     AvatarManager(const AvatarManager& other);
 
     void simulateAvatarFades(float deltaTime);
-    
+
     // virtual overrides
     virtual AvatarSharedPointer newSharedAvatar();
     virtual AvatarSharedPointer addAvatar(const QUuid& sessionUUID, const QWeakPointer<Node>& mixerWeakPointer);
     void removeAvatarMotionState(AvatarSharedPointer avatar);
-    
+
     virtual void removeAvatar(const QUuid& sessionUUID);
     virtual void handleRemovedAvatar(const AvatarSharedPointer& removedAvatar);
-    
+
     QVector<AvatarSharedPointer> _avatarFades;
     std::shared_ptr<MyAvatar> _myAvatar;
     quint64 _lastSendAvatarDataTime = 0; // Controls MyAvatar send data rate.
-    
+
     QVector<AvatarManager::LocalLight> _localLights;
 
     bool _shouldShowReceiveStats = false;

--- a/interface/src/avatar/AvatarMotionState.h
+++ b/interface/src/avatar/AvatarMotionState.h
@@ -46,7 +46,7 @@ public:
     virtual float getObjectFriction() const;
     virtual float getObjectLinearDamping() const;
     virtual float getObjectAngularDamping() const;
-    
+
     virtual glm::vec3 getObjectPosition() const;
     virtual glm::quat getObjectRotation() const;
     virtual glm::vec3 getObjectLinearVelocity() const;

--- a/interface/src/avatar/Hand.cpp
+++ b/interface/src/avatar/Hand.cpp
@@ -37,7 +37,7 @@ void Hand::simulate(float deltaTime, bool isMine) {
 void Hand::renderHandTargets(RenderArgs* renderArgs, bool isMine) {
     float avatarScale = 1.0f;
     if (_owningAvatar) {
-        avatarScale = _owningAvatar->getAvatarScale();
+        avatarScale = _owningAvatar->getUniformScale();
     }
 
     const float alpha = 1.0f;
@@ -62,7 +62,7 @@ void Hand::renderHandTargets(RenderArgs* renderArgs, bool isMine) {
             transform.setRotation(palm.getRotation());
             transform.postScale(SPHERE_RADIUS);
             DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch, transform, grayColor);
-    
+
             // draw a green sphere at the old "finger tip"
             transform = Transform();
             position = palm.getTipPosition();
@@ -72,7 +72,7 @@ void Hand::renderHandTargets(RenderArgs* renderArgs, bool isMine) {
             DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch, transform, greenColor);
         }
     }
-    
+
     const float AXIS_RADIUS = 0.1f * SPHERE_RADIUS;
     const float AXIS_LENGTH = 10.0f * SPHERE_RADIUS;
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -694,7 +694,7 @@ void MyAvatar::loadData() {
 
     _leanScale = loadSetting(settings, "leanScale", 0.05f);
     _targetScale = loadSetting(settings, "scale", 1.0f);
-    setScale(glm::vec3(getUniformScale()));
+    setScale(glm::vec3(_targetScale));
 
     _animGraphUrl = settings.value("animGraphURL", "").toString();
     _fullAvatarURLFromPreferences = settings.value("fullAvatarURL", AvatarData::defaultFullAvatarModelUrl()).toUrl();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -284,22 +284,6 @@ void MyAvatar::update(float deltaTime) {
 extern QByteArray avatarStateToFrame(const AvatarData* _avatar);
 extern void avatarStateFromFrame(const QByteArray& frameData, AvatarData* _avatar);
 
-void MyAvatar::animateScaleChanges(float deltaTime) {
-    // HACK: override Avatar::animateScaleChanges() until MyAvatar has a MotionState
-    float currentScale = getUniformScale();
-    if (currentScale != _targetScale) {
-        const float SCALE_ANIMATION_TIMESCALE = 1.0f;
-        float blendFactor = deltaTime / SCALE_ANIMATION_TIMESCALE;
-        float animatedScale = (1.0f - blendFactor) * currentScale + blendFactor * _targetScale;
-        const float CLOSE_ENOUGH = 0.05f;
-        if (fabsf(animatedScale - _targetScale) / _targetScale < CLOSE_ENOUGH) {
-            animatedScale = _targetScale;
-        }
-        setScale(glm::vec3(animatedScale));
-        rebuildCollisionShape();
-    }
-}
-
 void MyAvatar::simulate(float deltaTime) {
     PerformanceTimer perfTimer("simulate");
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -263,9 +263,6 @@ public slots:
     glm::vec3 getPositionForAudio();
     glm::quat getOrientationForAudio();
 
-protected:
-    void animateScaleChanges(float deltaTime);
-
 signals:
     void audioListenerModeChanged();
     void transformChanged();

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -249,7 +249,7 @@ public slots:
 
     Q_INVOKABLE void updateMotionBehaviorFromMenu();
 
-    virtual void rebuildSkeletonBody() override;
+    virtual void rebuildCollisionShape() override;
 
     Q_INVOKABLE QUrl getAnimGraphUrl() const { return _animGraphUrl; }
 
@@ -262,6 +262,9 @@ public slots:
 
     glm::vec3 getPositionForAudio();
     glm::quat getOrientationForAudio();
+
+protected:
+    void animateScaleChanges(float deltaTime);
 
 signals:
     void audioListenerModeChanged();

--- a/interface/src/avatar/MyCharacterController.cpp
+++ b/interface/src/avatar/MyCharacterController.cpp
@@ -32,7 +32,7 @@ MyCharacterController::~MyCharacterController() {
 
 void MyCharacterController::updateShapeIfNecessary() {
     if (_pendingFlags & PENDING_FLAG_UPDATE_SHAPE) {
-        _pendingFlags &= ~ PENDING_FLAG_UPDATE_SHAPE;
+        _pendingFlags &= ~PENDING_FLAG_UPDATE_SHAPE;
 
         // compute new dimensions from avatar's bounding box
         float x = _boxScale.x;

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -338,35 +338,38 @@ void SkeletonModel::computeBoundingShape() {
         return;
     }
 
-    _rig->computeAvatarBoundingCapsule(geometry,
-            _boundingCapsuleRadius,
-            _boundingCapsuleHeight,
-            _boundingCapsuleLocalOffset);
+    float radius, height;
+    glm::vec3 offset;
+    _rig->computeAvatarBoundingCapsule(geometry, radius, height, offset);
+    float invScale = 1.0f / _owningAvatar->getUniformScale();
+    _boundingCapsuleRadius = invScale * radius;
+    _boundingCapsuleHeight = invScale * height;
+    _boundingCapsuleLocalOffset = invScale * offset;
 }
 
-void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float alpha) {
+void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float scale, float alpha) {
     auto geometryCache = DependencyManager::get<GeometryCache>();
     auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
     // draw a blue sphere at the capsule top point
-    glm::vec3 topPoint = _translation + getRotation() * (_boundingCapsuleLocalOffset + (0.5f * _boundingCapsuleHeight) * glm::vec3(0.0f, 1.0f, 0.0f));
+    glm::vec3 topPoint = _translation + getRotation() * (scale * (_boundingCapsuleLocalOffset + (0.5f * _boundingCapsuleHeight) * Vectors::UNIT_Y));
 
     deferredLighting->renderSolidSphereInstance(batch,
-        Transform().setTranslation(topPoint).postScale(_boundingCapsuleRadius),
+        Transform().setTranslation(topPoint).postScale(scale * _boundingCapsuleRadius),
     	glm::vec4(0.6f, 0.6f, 0.8f, alpha));
 
     // draw a yellow sphere at the capsule bottom point
-    glm::vec3 bottomPoint = topPoint - glm::vec3(0.0f, _boundingCapsuleHeight, 0.0f);
+    glm::vec3 bottomPoint = topPoint - glm::vec3(0.0f, scale * _boundingCapsuleHeight, 0.0f);
     glm::vec3 axis = topPoint - bottomPoint;
 
     deferredLighting->renderSolidSphereInstance(batch,
-        Transform().setTranslation(bottomPoint).postScale(_boundingCapsuleRadius),
+        Transform().setTranslation(bottomPoint).postScale(scale * _boundingCapsuleRadius),
         glm::vec4(0.8f, 0.8f, 0.6f, alpha));
 
     // draw a green cylinder between the two points
     glm::vec3 origin(0.0f);
     batch.setModelTransform(Transform().setTranslation(bottomPoint));
     deferredLighting->bindSimpleProgram(batch);
-    Avatar::renderJointConnectingCone(batch, origin, axis, _boundingCapsuleRadius, _boundingCapsuleRadius,
+    Avatar::renderJointConnectingCone(batch, origin, axis, scale * _boundingCapsuleRadius, scale * _boundingCapsuleRadius,
                                       glm::vec4(0.6f, 0.8f, 0.6f, alpha));
 }
 

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -69,7 +69,7 @@ void SkeletonModel::initJointStates() {
     _headClipDistance = -(meshExtents.minimum.z / _scale.z - _defaultEyeModelPosition.z);
     _headClipDistance = std::max(_headClipDistance, DEFAULT_NEAR_CLIP);
 
-    _owningAvatar->rebuildSkeletonBody();
+    _owningAvatar->rebuildCollisionShape();
     emit skeletonLoaded();
 }
 

--- a/interface/src/avatar/SkeletonModel.h
+++ b/interface/src/avatar/SkeletonModel.h
@@ -89,7 +89,7 @@ public:
     /// \return whether or not the head was found.
     glm::vec3 getDefaultEyeModelPosition() const;
 
-    void renderBoundingCollisionShapes(gpu::Batch& batch, float alpha);
+    void renderBoundingCollisionShapes(gpu::Batch& batch, float scale, float alpha);
     float getBoundingCapsuleRadius() const { return _boundingCapsuleRadius; }
     float getBoundingCapsuleHeight() const { return _boundingCapsuleHeight; }
     const glm::vec3 getBoundingCapsuleOffset() const { return _boundingCapsuleLocalOffset; }

--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -386,7 +386,7 @@ bool ApplicationCompositor::calculateRayUICollisionPoint(const glm::vec3& positi
     glm::vec3 relativeDirection = glm::normalize(inverseOrientation * direction);
 
     float t;
-    if (raySphereIntersect(relativeDirection, relativePosition, _oculusUIRadius * myAvatar->getAvatarScale(), &t)){
+    if (raySphereIntersect(relativeDirection, relativePosition, _oculusUIRadius * myAvatar->getUniformScale(), &t)){
         result = position + direction * t;
         return true;
     }

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -256,7 +256,7 @@ void PreferencesDialog::savePreferences() {
 
     myAvatar->getHead()->setPupilDilation(ui.pupilDilationSlider->value() / (float)ui.pupilDilationSlider->maximum());
     myAvatar->setLeanScale(ui.leanScaleSpin->value());
-    myAvatar->setClampedTargetScale(ui.avatarScaleSpin->value());
+    myAvatar->setTargetScaleVerbose(ui.avatarScaleSpin->value());
     if (myAvatar->getAnimGraphUrl() != ui.avatarAnimationEdit->text()) { // If changed, destroy the old and start with the new
         myAvatar->setAnimGraphUrl(ui.avatarAnimationEdit->text());
     }

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -199,7 +199,7 @@ void PreferencesDialog::loadPreferences() {
     
     ui.leanScaleSpin->setValue(myAvatar->getLeanScale());
 
-    ui.avatarScaleSpin->setValue(myAvatar->getAvatarScale());
+    ui.avatarScaleSpin->setValue(myAvatar->getUniformScale());
     ui.avatarAnimationEdit->setText(myAvatar->getAnimGraphUrl().toString());
     
     ui.maxOctreePPSSpin->setValue(qApp->getMaxOctreePacketsPerSecond());

--- a/interface/src/ui/overlays/OverlaysPayload.cpp
+++ b/interface/src/ui/overlays/OverlaysPayload.cpp
@@ -68,7 +68,7 @@ namespace render {
                 glm::vec3 myAvatarPosition = avatar->getPosition();
                 float angle = glm::degrees(glm::angle(myAvatarRotation));
                 glm::vec3 axis = glm::axis(myAvatarRotation);
-                float myAvatarScale = avatar->getAvatarScale();
+                float myAvatarScale = avatar->getUniformScale();
                 Transform transform = Transform();
                 transform.setTranslation(myAvatarPosition);
                 transform.setRotation(glm::angleAxis(angle, axis));

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -90,7 +90,7 @@ const QUrl& AvatarData::defaultFullAvatarModelUrl() {
 // There are a number of possible strategies for this set of tools through endRender, below.
 void AvatarData::nextAttitude(glm::vec3 position, glm::quat orientation) {
     avatarLock.lock();
-    Transform trans;
+    Transform trans = getTransform();
     trans.setTranslation(position);
     trans.setRotation(orientation);
     SpatiallyNestable::setTransform(trans);

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -132,10 +132,7 @@ void AvatarData::setTargetScale(float targetScale) {
     _targetScale = std::max(MIN_AVATAR_SCALE, std::min(MAX_AVATAR_SCALE, targetScale));
 }
 
-void AvatarData::setClampedTargetScale(float targetScale) {
-
-    targetScale =  glm::clamp(targetScale, MIN_AVATAR_SCALE, MAX_AVATAR_SCALE);
-
+void AvatarData::setTargetScaleVerbose(float targetScale) {
     setTargetScale(targetScale);
     qCDebug(avatars) << "Changed scale to " << _targetScale;
 }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -129,7 +129,7 @@ float AvatarData::getTargetScale() const {
 }
 
 void AvatarData::setTargetScale(float targetScale) {
-    _targetScale = std::max(MIN_AVATAR_SCALE, std::min(MAX_AVATAR_SCALE, targetScale));
+    _targetScale = glm::clamp(targetScale, MIN_AVATAR_SCALE, MAX_AVATAR_SCALE);
 }
 
 void AvatarData::setTargetScaleVerbose(float targetScale) {

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -172,7 +172,7 @@ public:
 
     AvatarData();
     virtual ~AvatarData();
-    
+
     static const QUrl& defaultFullAvatarModelUrl();
 
     virtual bool isMyAvatar() const { return false; }
@@ -237,7 +237,7 @@ public:
     //  Scale
     float getTargetScale() const;
     void setTargetScale(float targetScale);
-    void setClampedTargetScale(float targetScale);
+    void setTargetScaleVerbose(float targetScale);
 
     //  Hand State
     Q_INVOKABLE void setHandState(char s) { _handState = s; }
@@ -261,7 +261,7 @@ public:
     Q_INVOKABLE bool isJointDataValid(const QString& name) const;
     Q_INVOKABLE glm::quat getJointRotation(const QString& name) const;
     Q_INVOKABLE glm::vec3 getJointTranslation(const QString& name) const;
-    
+
     Q_INVOKABLE virtual QVector<glm::quat> getJointRotations() const;
     Q_INVOKABLE virtual void setJointRotations(QVector<glm::quat> jointRotations);
     Q_INVOKABLE virtual void setJointTranslations(QVector<glm::vec3> jointTranslations);

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -342,6 +342,9 @@ public:
 
     glm::vec3 getClientGlobalPosition() { return _globalPosition; }
 
+    void die() { _isDead = true; }
+    bool isDead() const { return _isDead; }
+
 public slots:
     void sendAvatarDataPacket();
     void sendIdentityPacket();
@@ -412,6 +415,8 @@ protected:
     // where Entities are located.  This is currently only used by the mixer to decide how often to send
     // updates about one avatar to another.
     glm::vec3 _globalPosition;
+
+    bool _isDead { false };
 
 private:
     friend void avatarStateFromFrame(const QByteArray& frameData, AvatarData* _avatar);


### PR DESCRIPTION
The size collision capsule now agrees with the avatar's scale.

Somehow I accidentally invalidated the previous PR... maybe by force pushing the master branch onto the branch.  I was able to salvage the work from my other local sandbox and now am opening a replacement PR.