### PR TITLE
correct input plugin load path on linux

### DIFF
--- a/cmake/macros/SetupHifiPlugin.cmake
+++ b/cmake/macros/SetupHifiPlugin.cmake
@@ -10,24 +10,30 @@ macro(SETUP_HIFI_PLUGIN)
     setup_hifi_library(${ARGV})
     add_dependencies(interface ${TARGET_NAME})
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Plugins")
-    
-    if (APPLE) 
+
+    if (APPLE)
         set(PLUGIN_PATH "interface.app/Contents/MacOS/plugins")
     else()
         set(PLUGIN_PATH "plugins")
     endif()
-    
+
+    IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        set(PLUGIN_FULL_PATH "${CMAKE_BINARY_DIR}/interface/${PLUGIN_PATH}/")
+    else()
+        set(PLUGIN_FULL_PATH "${CMAKE_BINARY_DIR}/interface/$<CONFIGURATION>/${PLUGIN_PATH}/")
+    endif()
+
     # create the destination for the plugin binaries
     add_custom_command(
         TARGET ${TARGET_NAME} POST_BUILD
         COMMAND "${CMAKE_COMMAND}" -E make_directory
-        "${CMAKE_BINARY_DIR}/interface/$<CONFIGURATION>/${PLUGIN_PATH}/"
+        ${PLUGIN_FULL_PATH}
     )
-    
+
     add_custom_command(TARGET ${DIR} POST_BUILD
         COMMAND "${CMAKE_COMMAND}" -E copy
         "$<TARGET_FILE:${TARGET_NAME}>"
-        "${CMAKE_BINARY_DIR}/interface/$<CONFIGURATION>/${PLUGIN_PATH}/"
+        ${PLUGIN_FULL_PATH}
     )
 
 endmacro()


### PR DESCRIPTION
The hydra controllers broke on linux a week or so ago but no one noticed.  This PR fixes it.