### PR TITLE
Exposing emmisive property of the Image3DOverlay

### DIFF
--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -26,14 +26,16 @@
 QString const Image3DOverlay::TYPE = "image3d";
 
 Image3DOverlay::Image3DOverlay() {
-      _isLoaded = false;
+    _isLoaded = false;
+    _emmisive = false;
 }
 
 Image3DOverlay::Image3DOverlay(const Image3DOverlay* image3DOverlay) :
     Billboard3DOverlay(image3DOverlay),
     _url(image3DOverlay->_url),
     _texture(image3DOverlay->_texture),
-    _fromImage(image3DOverlay->_fromImage)
+    _fromImage(image3DOverlay->_fromImage),
+    _emmisive(image3DOverlay->_emmisive)
 {
 }
 
@@ -93,8 +95,8 @@ void Image3DOverlay::render(RenderArgs* args) {
 
     batch->setModelTransform(transform);
     batch->setResourceTexture(0, _texture->getGPUTexture());
-    
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(*batch, true, false, false, true);
+
+    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(*batch, true, false, _emmisive, true);
     DependencyManager::get<GeometryCache>()->renderQuad(
         *batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
         glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha)
@@ -144,6 +146,11 @@ void Image3DOverlay::setProperties(const QScriptValue &properties) {
             setClipFromSource(subImageRect);
         }
     }
+
+    QScriptValue emmisiveValue = properties.property("emmisive");
+    if (emmisiveValue.isValid()) {
+        _emmisive = emmisiveValue.toBool();
+    }
 }
 
 QScriptValue Image3DOverlay::getProperty(const QString& property) {
@@ -155,6 +162,9 @@ QScriptValue Image3DOverlay::getProperty(const QString& property) {
     }
     if (property == "offsetPosition") {
         return vec3toScriptValue(_scriptEngine, getOffsetPosition());
+    }
+    if (property == "emmisive") {
+        return _emmisive;
     }
 
     return Billboard3DOverlay::getProperty(property);

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -27,7 +27,7 @@ QString const Image3DOverlay::TYPE = "image3d";
 
 Image3DOverlay::Image3DOverlay() {
     _isLoaded = false;
-    _emmisive = false;
+    _emissive = false;
 }
 
 Image3DOverlay::Image3DOverlay(const Image3DOverlay* image3DOverlay) :
@@ -35,7 +35,7 @@ Image3DOverlay::Image3DOverlay(const Image3DOverlay* image3DOverlay) :
     _url(image3DOverlay->_url),
     _texture(image3DOverlay->_texture),
     _fromImage(image3DOverlay->_fromImage),
-    _emmisive(image3DOverlay->_emmisive)
+    _emissive(image3DOverlay->_emissive)
 {
 }
 
@@ -96,7 +96,7 @@ void Image3DOverlay::render(RenderArgs* args) {
     batch->setModelTransform(transform);
     batch->setResourceTexture(0, _texture->getGPUTexture());
 
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(*batch, true, false, _emmisive, true);
+    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(*batch, true, false, _emissive, true);
     DependencyManager::get<GeometryCache>()->renderQuad(
         *batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
         glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha)
@@ -147,9 +147,9 @@ void Image3DOverlay::setProperties(const QScriptValue &properties) {
         }
     }
 
-    QScriptValue emmisiveValue = properties.property("emmisive");
-    if (emmisiveValue.isValid()) {
-        _emmisive = emmisiveValue.toBool();
+    QScriptValue emissiveValue = properties.property("emissive");
+    if (emissiveValue.isValid()) {
+        _emissive = emissiveValue.toBool();
     }
 }
 
@@ -163,8 +163,8 @@ QScriptValue Image3DOverlay::getProperty(const QString& property) {
     if (property == "offsetPosition") {
         return vec3toScriptValue(_scriptEngine, getOffsetPosition());
     }
-    if (property == "emmisive") {
-        return _emmisive;
+    if (property == "emissive") {
+        return _emissive;
     }
 
     return Billboard3DOverlay::getProperty(property);

--- a/interface/src/ui/overlays/Image3DOverlay.h
+++ b/interface/src/ui/overlays/Image3DOverlay.h
@@ -46,7 +46,7 @@ public:
 private:
     QString _url;
     NetworkTexturePointer _texture;
-    bool _emmisive;
+    bool _emissive;
 
     QRect _fromImage; // where from in the image to sample
 };

--- a/interface/src/ui/overlays/Image3DOverlay.h
+++ b/interface/src/ui/overlays/Image3DOverlay.h
@@ -46,6 +46,7 @@ public:
 private:
     QString _url;
     NetworkTexturePointer _texture;
+    bool _emmisive;
 
     QRect _fromImage; // where from in the image to sample
 };

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -169,8 +169,8 @@ void DeferredLightingEffect::init(AbstractViewStateInterface* viewState) {
 
 
 gpu::PipelinePointer DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled,
-                                               bool emmisive, bool depthBias) {
-    SimpleProgramKey config{textured, culled, emmisive, depthBias};
+                                               bool emissive, bool depthBias) {
+    SimpleProgramKey config{textured, culled, emissive, depthBias};
     gpu::PipelinePointer pipeline = getPipeline(config);
     batch.setPipeline(pipeline);
 

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -38,7 +38,7 @@ public:
 
     /// Sets up the state necessary to render static untextured geometry with the simple program.
     gpu::PipelinePointer bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
-                           bool emmisive = false, bool depthBias = false);
+                           bool emissive = false, bool depthBias = false);
 
     void renderSolidSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
     void renderSolidSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) { 


### PR DESCRIPTION
This PR allows to set the emmisive property of an Image3DOverlay. In this way via JS it's possible to choose if the created Image3DOverlay will be shaded or not by setting its new 'emmisive' property to false or true.