### PR TITLE
Don't send a domain-server check in when shutting down

### DIFF
--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -234,6 +234,7 @@ void NodeList::addSetOfNodeTypesToNodeInterestSet(const NodeSet& setOfNodeTypes)
 void NodeList::sendDomainServerCheckIn() {
     if (_isShuttingDown) {
         qCDebug(networking) << "Refusing to send a domain-server check in while shutting down.";
+        return;
     }
     
     if (_publicSockAddr.isNull()) {


### PR DESCRIPTION
Add missing return statement to make the code reflect the program log message.