### PR TITLE
fix crash when visiting new domain with gun in hand

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -157,7 +157,7 @@ void Avatar::animateScaleChanges(float deltaTime) {
 
         // snap to the end when we get close enough
         const float MIN_RELATIVE_SCALE_ERROR = 0.03f;
-        if (fabsf(_targetScale - currentScale) / _targetScale < 0.03f) {
+        if (fabsf(_targetScale - currentScale) / _targetScale < MIN_RELATIVE_SCALE_ERROR) {
             animatedScale = _targetScale;
         }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -385,7 +385,7 @@ Model* RenderableModelEntityItem::getModel(EntityTreeRenderer* renderer) {
             _needsInitialSimulation = true;
         }
     }
-    
+
     return result;
 }
 
@@ -398,14 +398,14 @@ void RenderableModelEntityItem::update(const quint64& now) {
         EntityItemProperties properties;
         auto extents = _model->getMeshExtents();
         properties.setDimensions(extents.maximum - extents.minimum);
-        
+
         qCDebug(entitiesrenderer) << "Autoresizing:" << (!getName().isEmpty() ? getName() : getModelURL());
         QMetaObject::invokeMethod(DependencyManager::get<EntityScriptingInterface>().data(), "editEntity",
                                   Qt::QueuedConnection,
                                   Q_ARG(QUuid, getEntityItemID()),
                                   Q_ARG(EntityItemProperties, properties));
     }
-    
+
     ModelEntityItem::update(now);
 }
 
@@ -427,7 +427,7 @@ bool RenderableModelEntityItem::findDetailedRayIntersection(const glm::vec3& ori
     //                           << precisionPicking;
 
     QString extraInfo;
-    return _model->findRayIntersectionAgainstSubMeshes(origin, direction, distance, 
+    return _model->findRayIntersectionAgainstSubMeshes(origin, direction, distance,
                                                        face, surfaceNormal, extraInfo, precisionPicking);
 }
 
@@ -447,24 +447,22 @@ bool RenderableModelEntityItem::isReadyToComputeShape() {
     ShapeType type = getShapeType();
 
     if (type == SHAPE_TYPE_COMPOUND) {
-        if (!_model) {
+        if (!_model || _model->getCollisionURL().isEmpty()) {
             EntityTreePointer tree = getTree();
             if (tree) {
                 QMetaObject::invokeMethod(tree.get(), "callLoader", Qt::QueuedConnection, Q_ARG(EntityItemID, getID()));
             }
-            return false; // hmm...
+            return false;
         }
 
-        assert(!_model->getCollisionURL().isEmpty());
-    
         if (_model->getURL().isEmpty()) {
             // we need a render geometry with a scale to proceed, so give up.
             return false;
         }
-    
+
         const QSharedPointer<NetworkGeometry> collisionNetworkGeometry = _model->getCollisionGeometry();
         const QSharedPointer<NetworkGeometry> renderNetworkGeometry = _model->getGeometry();
-    
+
         if ((collisionNetworkGeometry && collisionNetworkGeometry->isLoaded()) &&
             (renderNetworkGeometry && renderNetworkGeometry->isLoaded())) {
             // we have both URLs AND both geometries AND they are both fully loaded.

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -44,7 +44,7 @@ void PhysicalEntitySimulation::updateEntitiesInternal(const quint64& now) {
 
 void PhysicalEntitySimulation::addEntityInternal(EntityItemPointer entity) {
     assert(entity);
-    if (entity->shouldBePhysical()) { 
+    if (entity->shouldBePhysical()) {
         EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
         if (!motionState) {
             _pendingAdds.insert(entity);
@@ -117,6 +117,7 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
     _pendingRemoves.clear();
     _pendingAdds.clear();
     _pendingChanges.clear();
+    _outgoingChanges.clear();
 }
 // end EntitySimulation overrides
 


### PR DESCRIPTION
The bug was: sometimes when leaving one domain for another while holding the ping-pong gun the interface would crash.

The problem was one of the lists (of MotionStates) inside **PhysicalEntitySimulation** was not properly being cleared, leaving a dangling pointer that would be dereferenced later.