### PR TITLE
ParticleEffectEntityItem: fix for invalid iterator increment

### DIFF
--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -608,10 +608,7 @@ void ParticleEffectEntityItem::stepSimulation(float deltaTime) {
             integrateParticle(particle, deltaTime);
         }
     }
-
-    for (int i = 0; i < popCount; i++) {
-        _particles.pop_front();
-    }
+    _particles.erase(_particles.begin(), _particles.begin() + popCount);
 
     // emit new particles, but only if we are emmitting
     if (getIsEmitting() && _emitRate > 0.0f && _lifespan > 0.0f && _polarStart <= _polarFinish) {

--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -595,17 +595,22 @@ void ParticleEffectEntityItem::integrateParticle(Particle& particle, float delta
 
 void ParticleEffectEntityItem::stepSimulation(float deltaTime) {
     // update particles between head and tail
+    int popCount = 0;
     for (Particle& particle : _particles) {
         particle.lifetime += deltaTime;
 
         // if particle has died.
         if (particle.lifetime >= _lifespan) {
             // move head forward
-            _particles.pop_front();
+            popCount++;
         } else {
             // Otherwise update it
             integrateParticle(particle, deltaTime);
         }
+    }
+
+    for (int i = 0; i < popCount; i++) {
+        _particles.pop_front();
     }
 
     // emit new particles, but only if we are emmitting


### PR DESCRIPTION
Was causing an assert in debug, due to calling ++ on an invalid iterator.
In release this might lead to memory corruption.