### PR TITLE
ModelEntityItem: Fix for incorrect animations with preTranslations

### DIFF
--- a/libraries/animation/src/AnimSkeleton.cpp
+++ b/libraries/animation/src/AnimSkeleton.cpp
@@ -140,6 +140,7 @@ void AnimSkeleton::buildSkeletonFromJoints(const std::vector<FBXJoint>& joints) 
 }
 
 #ifndef NDEBUG
+#define DUMP_FBX_JOINTS
 void AnimSkeleton::dump() const {
     qCDebug(animation) << "[";
     for (int i = 0; i < getNumJoints(); i++) {
@@ -151,21 +152,22 @@ void AnimSkeleton::dump() const {
         qCDebug(animation) << "        absDefaultPose =" << getAbsoluteDefaultPose(i);
         qCDebug(animation) << "        relDefaultPose =" << getRelativeDefaultPose(i);
 #ifdef DUMP_FBX_JOINTS
-        qCDebug(animation) << "        isFree =" << _joints[i].isFree;
-        qCDebug(animation) << "        freeLineage =" << _joints[i].freeLineage;
-        qCDebug(animation) << "        parentIndex =" << _joints[i].parentIndex;
-        qCDebug(animation) << "        translation =" << _joints[i].translation;
-        qCDebug(animation) << "        preTransform =" << _joints[i].preTransform;
-        qCDebug(animation) << "        preRotation =" << _joints[i].preRotation;
-        qCDebug(animation) << "        rotation =" << _joints[i].rotation;
-        qCDebug(animation) << "        postRotation =" << _joints[i].postRotation;
-        qCDebug(animation) << "        postTransform =" << _joints[i].postTransform;
-        qCDebug(animation) << "        transform =" << _joints[i].transform;
-        qCDebug(animation) << "        rotationMin =" << _joints[i].rotationMin << ", rotationMax =" << _joints[i].rotationMax;
-        qCDebug(animation) << "        inverseDefaultRotation" << _joints[i].inverseDefaultRotation;
-        qCDebug(animation) << "        inverseBindRotation" << _joints[i].inverseBindRotation;
-        qCDebug(animation) << "        bindTransform" << _joints[i].bindTransform;
-        qCDebug(animation) << "        isSkeletonJoint" << _joints[i].isSkeletonJoint;
+        qCDebug(animation) << "        fbxJoint =";
+        qCDebug(animation) << "            isFree =" << _joints[i].isFree;
+        qCDebug(animation) << "            freeLineage =" << _joints[i].freeLineage;
+        qCDebug(animation) << "            parentIndex =" << _joints[i].parentIndex;
+        qCDebug(animation) << "            translation =" << _joints[i].translation;
+        qCDebug(animation) << "            preTransform =" << _joints[i].preTransform;
+        qCDebug(animation) << "            preRotation =" << _joints[i].preRotation;
+        qCDebug(animation) << "            rotation =" << _joints[i].rotation;
+        qCDebug(animation) << "            postRotation =" << _joints[i].postRotation;
+        qCDebug(animation) << "            postTransform =" << _joints[i].postTransform;
+        qCDebug(animation) << "            transform =" << _joints[i].transform;
+        qCDebug(animation) << "            rotationMin =" << _joints[i].rotationMin << ", rotationMax =" << _joints[i].rotationMax;
+        qCDebug(animation) << "            inverseDefaultRotation" << _joints[i].inverseDefaultRotation;
+        qCDebug(animation) << "            inverseBindRotation" << _joints[i].inverseBindRotation;
+        qCDebug(animation) << "            bindTransform" << _joints[i].bindTransform;
+        qCDebug(animation) << "            isSkeletonJoint" << _joints[i].isSkeletonJoint;
 #endif
         if (getParentIndex(i) >= 0) {
             qCDebug(animation) << "        parent =" << getJointName(getParentIndex(i));

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -13,6 +13,7 @@
 
 #include <ByteCountCoding.h>
 #include <GLMHelpers.h>
+#include <glm/gtx/transform.hpp>
 
 #include "EntitiesLogging.h"
 #include "EntityItemProperties.h"
@@ -243,13 +244,22 @@ void ModelEntityItem::getAnimationFrame(bool& newFrame,
 
                 _lastKnownFrameDataRotations.resize(_jointMapping.size());
                 _lastKnownFrameDataTranslations.resize(_jointMapping.size());
+
                 for (int j = 0; j < _jointMapping.size(); j++) {
                     int index = _jointMapping[j];
-                    if (index != -1 && index < rotations.size()) {
-                        _lastKnownFrameDataRotations[j] = fbxJoints[index].preRotation * rotations[index];
-                    }
-                    if (index != -1 && index < translations.size()) {
-                        _lastKnownFrameDataTranslations[j] = translations[index];
+                    if (index >= 0) {
+                        glm::mat4 translationMat;
+                        if (index < translations.size()) {
+                            translationMat = glm::translate(translations[index]);
+                        }
+                        glm::mat4 rotationMat;
+                        if (index < rotations.size()) {
+                            rotationMat = glm::mat4_cast(rotations[index]);
+                        }
+                        glm::mat4 finalMat = (translationMat * fbxJoints[index].preTransform *
+                                              rotationMat * fbxJoints[index].postTransform);
+                        _lastKnownFrameDataTranslations[j] = extractTranslation(finalMat);
+                        _lastKnownFrameDataRotations[j] = glmExtractRotation(finalMat);
                     }
                 }
             }


### PR DESCRIPTION
ModelEntities that were playing animations on models with local pivot offsets were not working correctly.  Specifically, the windmill animation in the demo domain.

We now compose a matrix containing all of the FBX's preTranslation, preRotation and postTranformations.