### PR TITLE
Split JS global Scene into Scene and Render

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -89,6 +89,7 @@
 #include <RenderableWebEntityItem.h>
 #include <RenderDeferredTask.h>
 #include <ResourceCache.h>
+#include <RenderScriptingInterface.h>
 #include <SceneScriptingInterface.h>
 #include <RecordingScriptingInterface.h>
 #include <ScriptCache.h>
@@ -341,6 +342,7 @@ bool setupEssentials(int& argc, char** argv) {
 #endif
     DependencyManager::set<DiscoverabilityManager>();
     DependencyManager::set<SceneScriptingInterface>();
+    DependencyManager::set<RenderScriptingInterface>();
     DependencyManager::set<OffscreenUi>();
     DependencyManager::set<AutoUpdater>();
     DependencyManager::set<PathUtils>();
@@ -3674,40 +3676,22 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
     // For now every frame pass the renderContext
     {
         PerformanceTimer perfTimer("EngineRun");
-        render::RenderContext renderContext;
-
-        auto sceneInterface = DependencyManager::get<SceneScriptingInterface>();
-
-        renderContext._cullOpaque = sceneInterface->doEngineCullOpaque();
-        renderContext._sortOpaque = sceneInterface->doEngineSortOpaque();
-        renderContext._renderOpaque = sceneInterface->doEngineRenderOpaque();
-        renderContext._cullTransparent = sceneInterface->doEngineCullTransparent();
-        renderContext._sortTransparent = sceneInterface->doEngineSortTransparent();
-        renderContext._renderTransparent = sceneInterface->doEngineRenderTransparent();
-
-        renderContext._maxDrawnOpaqueItems = sceneInterface->getEngineMaxDrawnOpaqueItems();
-        renderContext._maxDrawnTransparentItems = sceneInterface->getEngineMaxDrawnTransparentItems();
-        renderContext._maxDrawnOverlay3DItems = sceneInterface->getEngineMaxDrawnOverlay3DItems();
-        
-        renderContext._deferredDebugMode = sceneInterface->getEngineDeferredDebugMode();
-        renderContext._deferredDebugSize = sceneInterface->getEngineDeferredDebugSize();
-        
-        renderContext._drawItemStatus = sceneInterface->doEngineDisplayItemStatus();
-        if (Menu::getInstance()->isOptionChecked(MenuOption::PhysicsShowOwned)) {
-            renderContext._drawItemStatus |= render::showNetworkStatusFlag;
-        }
-        renderContext._drawHitEffect = sceneInterface->doEngineDisplayHitEffect();
-
-        renderContext._occlusionStatus = Menu::getInstance()->isOptionChecked(MenuOption::DebugAmbientOcclusion);
-        renderContext._fxaaStatus = Menu::getInstance()->isOptionChecked(MenuOption::Antialiasing);
-
-        renderContext._toneMappingExposure = sceneInterface->getEngineToneMappingExposure();
-        renderContext._toneMappingToneCurve = sceneInterface->getEngineToneMappingToneCurveValue();
 
         renderArgs->_shouldRender = LODManager::shouldRender;
-
-        renderContext.args = renderArgs;
         renderArgs->_viewFrustum = getDisplayViewFrustum();
+
+        auto renderInterface = DependencyManager::get<RenderScriptingInterface>();
+        auto renderItemsMeta = renderInterface->getItemsMeta();
+        auto renderTone = renderInterface->getTone();
+        int drawStatus = renderInterface->getDrawStatus();
+        bool drawHitEffect = renderInterface->getDrawHitEffect();
+
+        bool occlusionStatus = Menu::getInstance()->isOptionChecked(MenuOption::DebugAmbientOcclusion);
+        bool antialiasingStatus = Menu::getInstance()->isOptionChecked(MenuOption::Antialiasing);
+        bool showOwnedStatus = Menu::getInstance()->isOptionChecked(MenuOption::PhysicsShowOwned);
+
+        render::RenderContext renderContext{renderArgs, renderItemsMeta, renderTone};
+        renderContext.setOptions(drawStatus, drawHitEffect, occlusionStatus, antialiasingStatus, showOwnedStatus);
         _renderEngine->setRenderContext(renderContext);
 
         // Before the deferred pass, let's try to use the render engine
@@ -3715,15 +3699,8 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         _renderEngine->run();
         myAvatar->endRenderRun();
 
-        auto engineRC = _renderEngine->getRenderContext();
-        sceneInterface->setEngineFeedOpaqueItems(engineRC->_numFeedOpaqueItems);
-        sceneInterface->setEngineDrawnOpaqueItems(engineRC->_numDrawnOpaqueItems);
-
-        sceneInterface->setEngineFeedTransparentItems(engineRC->_numFeedTransparentItems);
-        sceneInterface->setEngineDrawnTransparentItems(engineRC->_numDrawnTransparentItems);
-
-        sceneInterface->setEngineFeedOverlay3DItems(engineRC->_numFeedOverlay3DItems);
-        sceneInterface->setEngineDrawnOverlay3DItems(engineRC->_numDrawnOverlay3DItems);
+        auto engineContext = _renderEngine->getRenderContext();
+        renderInterface->setItemCounts(engineContext->getItemsMeta());
     }
 
     activeRenderingThread = nullptr;
@@ -4177,6 +4154,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     scriptEngine->registerFunction("HMD", "getHUDLookAtPosition3D", HMDScriptingInterface::getHUDLookAtPosition3D, 0);
 
     scriptEngine->registerGlobalObject("Scene", DependencyManager::get<SceneScriptingInterface>().data());
+    scriptEngine->registerGlobalObject("Render", DependencyManager::get<RenderScriptingInterface>().data());
 
     scriptEngine->registerGlobalObject("ScriptDiscoveryService", this->getRunningScriptsWidget());
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3681,7 +3681,7 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         renderArgs->_viewFrustum = getDisplayViewFrustum();
 
         auto renderInterface = DependencyManager::get<RenderScriptingInterface>();
-        auto renderItemsMeta = renderInterface->getItemsMeta();
+        auto renderItemsConfig = renderInterface->getItemsConfig();
         auto renderTone = renderInterface->getTone();
         int drawStatus = renderInterface->getDrawStatus();
         bool drawHitEffect = renderInterface->getDrawHitEffect();
@@ -3690,7 +3690,7 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         bool antialiasingStatus = Menu::getInstance()->isOptionChecked(MenuOption::Antialiasing);
         bool showOwnedStatus = Menu::getInstance()->isOptionChecked(MenuOption::PhysicsShowOwned);
 
-        render::RenderContext renderContext{renderArgs, renderItemsMeta, renderTone};
+        render::RenderContext renderContext{renderArgs, renderItemsConfig, renderTone};
         renderContext.setOptions(drawStatus, drawHitEffect, occlusionStatus, antialiasingStatus, showOwnedStatus);
         _renderEngine->setRenderContext(renderContext);
 
@@ -3700,7 +3700,7 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         myAvatar->endRenderRun();
 
         auto engineContext = _renderEngine->getRenderContext();
-        renderInterface->setItemCounts(engineContext->getItemsMeta());
+        renderInterface->setItemCounts(engineContext->getItemsConfig());
     }
 
     activeRenderingThread = nullptr;

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -175,10 +175,10 @@ const gpu::PipelinePointer& AmbientOcclusion::getBlendPipeline() {
 }
 
 void AmbientOcclusion::run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
         auto framebufferCache = DependencyManager::get<FramebufferCache>();
         QSize framebufferSize = framebufferCache->getFrameBufferSize();

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -93,14 +93,14 @@ const gpu::PipelinePointer& Antialiasing::getBlendPipeline() {
 }
 
 void Antialiasing::run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
-    if (renderContext->args->_renderMode == RenderArgs::MIRROR_RENDER_MODE) {
+    if (renderContext->getArgs()->_renderMode == RenderArgs::MIRROR_RENDER_MODE) {
         return;
     }
 
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
         batch.enableStereo(false);
 

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -179,9 +179,9 @@ const gpu::PipelinePointer& DebugDeferredBuffer::getPipeline(Modes mode, std::st
 
 
 void DebugDeferredBuffer::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
-    const RenderArgs* args = renderContext->args;
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
+    RenderArgs* args = renderContext->getArgs();
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         const auto geometryBuffer = DependencyManager::get<GeometryCache>();
         const auto framebufferCache = DependencyManager::get<FramebufferCache>();

--- a/libraries/render-utils/src/HitEffect.cpp
+++ b/libraries/render-utils/src/HitEffect.cpp
@@ -61,9 +61,9 @@ const gpu::PipelinePointer& HitEffect::getHitEffectPipeline() {
 }
 
 void HitEffect::run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
-    RenderArgs* args = renderContext->args;
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
+    RenderArgs* args = renderContext->getArgs();
     gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
     
         glm::mat4 projMat;

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -37,23 +37,24 @@ using namespace render;
 
 
 void PrepareDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    DependencyManager::get<DeferredLightingEffect>()->prepare(renderContext->args);
+    DependencyManager::get<DeferredLightingEffect>()->prepare(renderContext->getArgs());
 }
 
 void RenderDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    DependencyManager::get<DeferredLightingEffect>()->render(renderContext->args);
+    DependencyManager::get<DeferredLightingEffect>()->render(renderContext->getArgs());
 }
 
 void ToneMappingDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
     PerformanceTimer perfTimer("ToneMappingDeferred");
-    _toneMappingEffect.render(renderContext->args);
+    _toneMappingEffect.render(renderContext->getArgs());
 }
 
 RenderDeferredTask::RenderDeferredTask() : Task() {
     // CPU only, create the list of renderedOpaques items
     _jobs.push_back(Job(new FetchItems::JobModel("FetchOpaque",
         FetchItems([](const RenderContextPointer& context, int count) {
-                context->_numFeedOpaqueItems = count;
+            context->getItemsMeta()._opaque._numFeed = count;
+            auto& opaque = context->getItemsMeta()._opaque;
         })
     )));
     _jobs.push_back(Job(new CullItemsOpaque::JobModel("CullOpaque", _jobs.back().getOutput())));
@@ -64,7 +65,7 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     _jobs.push_back(Job(new FetchItems::JobModel("FetchTransparent",
         FetchItems(ItemFilter::Builder::transparentShape().withoutLayered(),
             [](const RenderContextPointer& context, int count) {
-                context->_numFeedTransparentItems = count;
+                context->getItemsMeta()._transparent._numFeed = count;
         })
      )));
     _jobs.push_back(Job(new CullItemsTransparent::JobModel("CullTransparent", _jobs.back().getOutput())));
@@ -146,7 +147,7 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
 
 
     // Is it possible that we render without a viewFrustum ?
-    if (!(renderContext->args && renderContext->args->_viewFrustum)) {
+    if (!(renderContext->getArgs() && renderContext->getArgs()->_viewFrustum)) {
         return;
     }
 
@@ -154,21 +155,21 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
     setDrawDebugDeferredBuffer(renderContext->_deferredDebugMode);
     
     // Make sure we turn the displayItemStatus on/off
-    setDrawItemStatus(renderContext->_drawItemStatus);
+    setDrawItemStatus(renderContext->getDrawStatus());
     
     // Make sure we display hit effect on screen, as desired from a script
-    setDrawHitEffect(renderContext->_drawHitEffect);
+    setDrawHitEffect(renderContext->getDrawHitEffect());
     
 
     // TODO: turn on/off AO through menu item
-    setOcclusionStatus(renderContext->_occlusionStatus);
+    setOcclusionStatus(renderContext->getOcclusionStatus());
 
-    setAntialiasingStatus(renderContext->_fxaaStatus);
+    setAntialiasingStatus(renderContext->getFxaaStatus());
 
-    setToneMappingExposure(renderContext->_toneMappingExposure);
-    setToneMappingToneCurve(renderContext->_toneMappingToneCurve);
+    setToneMappingExposure(renderContext->getTone()._exposure);
+    setToneMappingToneCurve(renderContext->getTone()._toneCurve);
 
-    renderContext->args->_context->syncCache();
+    renderContext->getArgs()->_context->syncCache();
 
     for (auto job : _jobs) {
         job.run(sceneContext, renderContext);
@@ -177,16 +178,17 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
 };
 
 void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemIDsBounds& inItems) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
         batch.setViewportTransform(args->_viewport);
         batch.setStateScissorRect(args->_viewport);
         args->_batch = &batch;
 
-        renderContext->_numDrawnOpaqueItems = (int)inItems.size();
+        auto& opaque = renderContext->getItemsMeta()._opaque;
+        opaque._numDrawn = (int)inItems.size();
 
         glm::mat4 projMat;
         Transform viewMat;
@@ -200,22 +202,23 @@ void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const Rend
             const float OPAQUE_ALPHA_THRESHOLD = 0.5f;
             args->_alphaThreshold = OPAQUE_ALPHA_THRESHOLD;
         }
-        renderItems(sceneContext, renderContext, inItems, renderContext->_maxDrawnOpaqueItems);
+        renderItems(sceneContext, renderContext, inItems, opaque._maxDrawn);
         args->_batch = nullptr;
     });
 }
 
 void DrawTransparentDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemIDsBounds& inItems) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
         batch.setViewportTransform(args->_viewport);
         batch.setStateScissorRect(args->_viewport);
         args->_batch = &batch;
     
-        renderContext->_numDrawnTransparentItems = (int)inItems.size();
+        auto& transparent = renderContext->getItemsMeta()._transparent;
+        transparent._numDrawn = (int)inItems.size();
 
         glm::mat4 projMat;
         Transform viewMat;
@@ -228,7 +231,7 @@ void DrawTransparentDeferred::run(const SceneContextPointer& sceneContext, const
         const float TRANSPARENT_ALPHA_THRESHOLD = 0.0f;
         args->_alphaThreshold = TRANSPARENT_ALPHA_THRESHOLD;
     
-        renderItems(sceneContext, renderContext, inItems, renderContext->_maxDrawnTransparentItems);
+        renderItems(sceneContext, renderContext, inItems, transparent._maxDrawn);
         args->_batch = nullptr;
     });
 }
@@ -251,8 +254,8 @@ const gpu::PipelinePointer& DrawOverlay3D::getOpaquePipeline() {
 }
 
 void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
     // render backgrounds
     auto& scene = sceneContext->_scene;
@@ -267,11 +270,12 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
             inItems.emplace_back(id);
         }
     }
-    renderContext->_numFeedOverlay3DItems = (int)inItems.size();
-    renderContext->_numDrawnOverlay3DItems = (int)inItems.size();
+    auto& overlay3D = renderContext->getItemsMeta()._overlay3D;
+    overlay3D._numFeed = (int)inItems.size();
+    overlay3D._numDrawn = (int)inItems.size();
 
     if (!inItems.empty()) {
-        RenderArgs* args = renderContext->args;
+        RenderArgs* args = renderContext->getArgs();
 
         // Clear the framebuffer without stereo
         // Needs to be distinct from the other batch because using the clear call 
@@ -300,7 +304,7 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
 
             batch.setPipeline(getOpaquePipeline());
             batch.setResourceTexture(0, args->_whiteTexture);
-            renderItems(sceneContext, renderContext, inItems, renderContext->_maxDrawnOverlay3DItems);
+            renderItems(sceneContext, renderContext, inItems, renderContext->getItemsMeta()._overlay3D._maxDrawn);
         });
         args->_batch = nullptr;
         args->_whiteTexture.reset();
@@ -329,11 +333,11 @@ const gpu::PipelinePointer& DrawStencilDeferred::getOpaquePipeline() {
 }
 
 void DrawStencilDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
     // from the touched pixel generate the stencil buffer 
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     doInBatch(args->_context, [=](gpu::Batch& batch) {
         args->_batch = &batch;
 
@@ -355,8 +359,8 @@ void DrawStencilDeferred::run(const SceneContextPointer& sceneContext, const Ren
 }
 
 void DrawBackgroundDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
     // render backgrounds
     auto& scene = sceneContext->_scene;
@@ -368,7 +372,7 @@ void DrawBackgroundDeferred::run(const SceneContextPointer& sceneContext, const 
     for (auto id : items) {
         inItems.emplace_back(id);
     }
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     doInBatch(args->_context, [=](gpu::Batch& batch) {
         args->_batch = &batch;
 

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -53,8 +53,8 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     // CPU only, create the list of renderedOpaques items
     _jobs.push_back(Job(new FetchItems::JobModel("FetchOpaque",
         FetchItems([](const RenderContextPointer& context, int count) {
-            context->getItemsMeta()._opaque._numFeed = count;
-            auto& opaque = context->getItemsMeta()._opaque;
+            context->getItemsConfig()._opaque._numFeed = count;
+            auto& opaque = context->getItemsConfig()._opaque;
         })
     )));
     _jobs.push_back(Job(new CullItemsOpaque::JobModel("CullOpaque", _jobs.back().getOutput())));
@@ -65,7 +65,7 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     _jobs.push_back(Job(new FetchItems::JobModel("FetchTransparent",
         FetchItems(ItemFilter::Builder::transparentShape().withoutLayered(),
             [](const RenderContextPointer& context, int count) {
-                context->getItemsMeta()._transparent._numFeed = count;
+                context->getItemsConfig()._transparent._numFeed = count;
         })
      )));
     _jobs.push_back(Job(new CullItemsTransparent::JobModel("CullTransparent", _jobs.back().getOutput())));
@@ -187,7 +187,7 @@ void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const Rend
         batch.setStateScissorRect(args->_viewport);
         args->_batch = &batch;
 
-        auto& opaque = renderContext->getItemsMeta()._opaque;
+        auto& opaque = renderContext->getItemsConfig()._opaque;
         opaque._numDrawn = (int)inItems.size();
 
         glm::mat4 projMat;
@@ -217,7 +217,7 @@ void DrawTransparentDeferred::run(const SceneContextPointer& sceneContext, const
         batch.setStateScissorRect(args->_viewport);
         args->_batch = &batch;
     
-        auto& transparent = renderContext->getItemsMeta()._transparent;
+        auto& transparent = renderContext->getItemsConfig()._transparent;
         transparent._numDrawn = (int)inItems.size();
 
         glm::mat4 projMat;
@@ -270,7 +270,7 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
             inItems.emplace_back(id);
         }
     }
-    auto& overlay3D = renderContext->getItemsMeta()._overlay3D;
+    auto& overlay3D = renderContext->getItemsConfig()._overlay3D;
     overlay3D._numFeed = (int)inItems.size();
     overlay3D._numDrawn = (int)inItems.size();
 
@@ -304,7 +304,7 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
 
             batch.setPipeline(getOpaquePipeline());
             batch.setResourceTexture(0, args->_whiteTexture);
-            renderItems(sceneContext, renderContext, inItems, renderContext->getItemsMeta()._overlay3D._maxDrawn);
+            renderItems(sceneContext, renderContext, inItems, renderContext->getItemsConfig()._overlay3D._maxDrawn);
         });
         args->_batch = nullptr;
         args->_whiteTexture.reset();

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -53,8 +53,8 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     // CPU only, create the list of renderedOpaques items
     _jobs.push_back(Job(new FetchItems::JobModel("FetchOpaque",
         FetchItems([](const RenderContextPointer& context, int count) {
-            context->getItemsConfig()._opaque._numFeed = count;
-            auto& opaque = context->getItemsConfig()._opaque;
+            context->getItemsConfig().opaque.numFeed = count;
+            auto& opaque = context->getItemsConfig().opaque;
         })
     )));
     _jobs.push_back(Job(new CullItemsOpaque::JobModel("CullOpaque", _jobs.back().getOutput())));
@@ -65,7 +65,7 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     _jobs.push_back(Job(new FetchItems::JobModel("FetchTransparent",
         FetchItems(ItemFilter::Builder::transparentShape().withoutLayered(),
             [](const RenderContextPointer& context, int count) {
-                context->getItemsConfig()._transparent._numFeed = count;
+                context->getItemsConfig().transparent.numFeed = count;
         })
      )));
     _jobs.push_back(Job(new CullItemsTransparent::JobModel("CullTransparent", _jobs.back().getOutput())));
@@ -166,8 +166,8 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
 
     setAntialiasingStatus(renderContext->getFxaaStatus());
 
-    setToneMappingExposure(renderContext->getTone()._exposure);
-    setToneMappingToneCurve(renderContext->getTone()._toneCurve);
+    setToneMappingExposure(renderContext->getTone().exposure);
+    setToneMappingToneCurve(renderContext->getTone().toneCurve);
 
     renderContext->getArgs()->_context->syncCache();
 
@@ -187,8 +187,8 @@ void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const Rend
         batch.setStateScissorRect(args->_viewport);
         args->_batch = &batch;
 
-        auto& opaque = renderContext->getItemsConfig()._opaque;
-        opaque._numDrawn = (int)inItems.size();
+        auto& opaque = renderContext->getItemsConfig().opaque;
+        opaque.numDrawn = (int)inItems.size();
 
         glm::mat4 projMat;
         Transform viewMat;
@@ -202,7 +202,7 @@ void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const Rend
             const float OPAQUE_ALPHA_THRESHOLD = 0.5f;
             args->_alphaThreshold = OPAQUE_ALPHA_THRESHOLD;
         }
-        renderItems(sceneContext, renderContext, inItems, opaque._maxDrawn);
+        renderItems(sceneContext, renderContext, inItems, opaque.maxDrawn);
         args->_batch = nullptr;
     });
 }
@@ -217,8 +217,8 @@ void DrawTransparentDeferred::run(const SceneContextPointer& sceneContext, const
         batch.setStateScissorRect(args->_viewport);
         args->_batch = &batch;
     
-        auto& transparent = renderContext->getItemsConfig()._transparent;
-        transparent._numDrawn = (int)inItems.size();
+        auto& transparent = renderContext->getItemsConfig().transparent;
+        transparent.numDrawn = (int)inItems.size();
 
         glm::mat4 projMat;
         Transform viewMat;
@@ -231,7 +231,7 @@ void DrawTransparentDeferred::run(const SceneContextPointer& sceneContext, const
         const float TRANSPARENT_ALPHA_THRESHOLD = 0.0f;
         args->_alphaThreshold = TRANSPARENT_ALPHA_THRESHOLD;
     
-        renderItems(sceneContext, renderContext, inItems, transparent._maxDrawn);
+        renderItems(sceneContext, renderContext, inItems, transparent.maxDrawn);
         args->_batch = nullptr;
     });
 }
@@ -270,9 +270,9 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
             inItems.emplace_back(id);
         }
     }
-    auto& overlay3D = renderContext->getItemsConfig()._overlay3D;
-    overlay3D._numFeed = (int)inItems.size();
-    overlay3D._numDrawn = (int)inItems.size();
+    auto& overlay3D = renderContext->getItemsConfig().overlay3D;
+    overlay3D.numFeed = (int)inItems.size();
+    overlay3D.numDrawn = (int)inItems.size();
 
     if (!inItems.empty()) {
         RenderArgs* args = renderContext->getArgs();
@@ -304,7 +304,7 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
 
             batch.setPipeline(getOpaquePipeline());
             batch.setResourceTexture(0, args->_whiteTexture);
-            renderItems(sceneContext, renderContext, inItems, renderContext->getItemsConfig()._overlay3D._maxDrawn);
+            renderItems(sceneContext, renderContext, inItems, renderContext->getItemsConfig().overlay3D.maxDrawn);
         });
         args->_batch = nullptr;
         args->_whiteTexture.reset();

--- a/libraries/render-utils/src/RenderScriptingInterface.cpp
+++ b/libraries/render-utils/src/RenderScriptingInterface.cpp
@@ -1,0 +1,41 @@
+//
+//  RenderScriptingInterface.cpp
+//  libraries/render-utils
+//
+//  Created by Zach Pomerantz on 12/16/15.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "RenderScriptingInterface.h"
+
+RenderScriptingInterface::RenderScriptingInterface() {};
+
+void RenderScriptingInterface::setEngineToneMappingToneCurve(const QString& toneCurve) {
+    if (toneCurve == QString("None")) {
+        _tone._toneCurve = 0;
+    } else if (toneCurve == QString("Gamma22")) {
+        _tone._toneCurve = 1;
+    } else if (toneCurve == QString("Reinhard")) {
+        _tone._toneCurve = 2;
+    } else if (toneCurve == QString("Filmic")) {
+        _tone._toneCurve = 3;
+    }
+}
+
+QString RenderScriptingInterface::getEngineToneMappingToneCurve() const {
+    switch (_tone._toneCurve) {
+    case 0:
+        return QString("None");
+    case 1:
+        return QString("Gamma22");
+    case 2:
+        return QString("Reinhard");
+    case 3:
+        return QString("Filmic");
+    default:
+        return QString("Filmic");
+    };
+}

--- a/libraries/render-utils/src/RenderScriptingInterface.cpp
+++ b/libraries/render-utils/src/RenderScriptingInterface.cpp
@@ -15,18 +15,18 @@ RenderScriptingInterface::RenderScriptingInterface() {};
 
 void RenderScriptingInterface::setEngineToneMappingToneCurve(const QString& toneCurve) {
     if (toneCurve == QString("None")) {
-        _tone._toneCurve = 0;
+        _tone.toneCurve = 0;
     } else if (toneCurve == QString("Gamma22")) {
-        _tone._toneCurve = 1;
+        _tone.toneCurve = 1;
     } else if (toneCurve == QString("Reinhard")) {
-        _tone._toneCurve = 2;
+        _tone.toneCurve = 2;
     } else if (toneCurve == QString("Filmic")) {
-        _tone._toneCurve = 3;
+        _tone.toneCurve = 3;
     }
 }
 
 QString RenderScriptingInterface::getEngineToneMappingToneCurve() const {
-    switch (_tone._toneCurve) {
+    switch (_tone.toneCurve) {
     case 0:
         return QString("None");
     case 1:

--- a/libraries/render-utils/src/RenderScriptingInterface.h
+++ b/libraries/render-utils/src/RenderScriptingInterface.h
@@ -72,15 +72,15 @@ class RenderScriptingInterface : public QObject, public Dependency {
 
     inline int getDrawStatus() { return _drawStatus; }
     inline bool getDrawHitEffect() { return _drawHitEffect; }
-    inline const render::RenderContext::ItemsMeta& getItemsMeta() { return _items; }
+    inline const render::RenderContext::ItemsConfig& getItemsConfig() { return _items; }
     inline const render::RenderContext::Tone& getTone() { return _tone;  }
-    void setItemCounts(const render::RenderContext::ItemsMeta& items) { _items.setCounts(items); };
+    void setItemCounts(const render::RenderContext::ItemsConfig& items) { _items.setCounts(items); };
 
 protected:
     RenderScriptingInterface();
     ~RenderScriptingInterface() {};
 
-    render::RenderContext::ItemsMeta _items;
+    render::RenderContext::ItemsConfig _items;
     render::RenderContext::Tone _tone;
 
     // Options

--- a/libraries/render-utils/src/RenderScriptingInterface.h
+++ b/libraries/render-utils/src/RenderScriptingInterface.h
@@ -1,0 +1,95 @@
+//
+//  RenderScriptingInterface.h
+//  libraries/render-utils
+//
+//  Created by Zach Pomerantz on 12/16/15.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_RenderScriptingInterface_h
+#define hifi_RenderScriptingInterface_h
+
+#include <qscriptengine.h> // QObject
+#include <DependencyManager.h> // Dependency
+
+#include "render/Engine.h"
+
+class RenderScriptingInterface : public QObject, public Dependency {
+    Q_OBJECT
+    SINGLETON_DEPENDENCY
+    
+ public:
+     Q_INVOKABLE void setEngineRenderOpaque(bool renderOpaque) { _items._opaque._render = renderOpaque; };
+    Q_INVOKABLE bool doEngineRenderOpaque() const { return _items._opaque._render; }
+    Q_INVOKABLE void setEngineRenderTransparent(bool renderTransparent) { _items._transparent._render = renderTransparent; };
+    Q_INVOKABLE bool doEngineRenderTransparent() const { return _items._transparent._render; }
+    
+    Q_INVOKABLE void setEngineCullOpaque(bool cullOpaque) { _items._opaque._cull = cullOpaque; };
+    Q_INVOKABLE bool doEngineCullOpaque() const { return _items._opaque._cull; }
+    Q_INVOKABLE void setEngineCullTransparent(bool cullTransparent) { _items._transparent._cull = cullTransparent; };
+    Q_INVOKABLE bool doEngineCullTransparent() const { return _items._transparent._cull; }
+
+    Q_INVOKABLE void setEngineSortOpaque(bool sortOpaque) { _items._opaque._sort = sortOpaque; };
+    Q_INVOKABLE bool doEngineSortOpaque() const { return _items._opaque._sort; }
+    Q_INVOKABLE void setEngineSortTransparent(bool sortTransparent) { _items._transparent._sort = sortTransparent; };
+    Q_INVOKABLE bool doEngineSortTransparent() const { return _items._transparent._sort; }
+
+    Q_INVOKABLE int getEngineNumDrawnOpaqueItems() { return _items._opaque._numDrawn; }
+    Q_INVOKABLE int getEngineNumDrawnTransparentItems() { return _items._transparent._numDrawn; }
+    Q_INVOKABLE int getEngineNumDrawnOverlay3DItems() { return _items._overlay3D._numDrawn; }
+
+    Q_INVOKABLE int getEngineNumFeedOpaqueItems() { return _items._opaque._numFeed; }
+    Q_INVOKABLE int getEngineNumFeedTransparentItems() { return _items._transparent._numFeed; }
+    Q_INVOKABLE int getEngineNumFeedOverlay3DItems() { return _items._overlay3D._numFeed; }
+
+    Q_INVOKABLE void setEngineMaxDrawnOpaqueItems(int count) { _items._opaque._maxDrawn = count; }
+    Q_INVOKABLE int getEngineMaxDrawnOpaqueItems() { return _items._opaque._maxDrawn; }
+    Q_INVOKABLE void setEngineMaxDrawnTransparentItems(int count) { _items._transparent._maxDrawn = count; }
+    Q_INVOKABLE int getEngineMaxDrawnTransparentItems() { return _items._transparent._maxDrawn; }
+    Q_INVOKABLE void setEngineMaxDrawnOverlay3DItems(int count) { _items._overlay3D._maxDrawn = count; }
+    Q_INVOKABLE int getEngineMaxDrawnOverlay3DItems() { return _items._overlay3D._maxDrawn; }
+    
+    Q_INVOKABLE void setEngineDeferredDebugMode(int mode) { _deferredDebugMode = mode; }
+    Q_INVOKABLE int getEngineDeferredDebugMode() { return _deferredDebugMode; }
+    Q_INVOKABLE void setEngineDeferredDebugSize(glm::vec4 size) { _deferredDebugSize = size; }
+    Q_INVOKABLE glm::vec4 getEngineDeferredDebugSize() { return _deferredDebugSize; }
+    
+    Q_INVOKABLE void setEngineDisplayItemStatus(int display) { _drawStatus = display; }
+    Q_INVOKABLE int doEngineDisplayItemStatus() { return _drawStatus; }
+
+    Q_INVOKABLE void setEngineDisplayHitEffect(bool display) { _drawHitEffect = display; }
+    Q_INVOKABLE bool doEngineDisplayHitEffect() { return _drawHitEffect; }
+
+    Q_INVOKABLE void setEngineToneMappingExposure(float exposure) { _tone._exposure = exposure; }
+    Q_INVOKABLE float getEngineToneMappingExposure() const { return _tone._exposure; }
+
+    Q_INVOKABLE void setEngineToneMappingToneCurve(const QString& curve);
+    Q_INVOKABLE QString getEngineToneMappingToneCurve() const;
+    int getEngineToneMappingToneCurveValue() const { return _tone._toneCurve; }
+
+    inline int getDrawStatus() { return _drawStatus; }
+    inline bool getDrawHitEffect() { return _drawHitEffect; }
+    inline const render::RenderContext::ItemsMeta& getItemsMeta() { return _items; }
+    inline const render::RenderContext::Tone& getTone() { return _tone;  }
+    void setItemCounts(const render::RenderContext::ItemsMeta& items) { _items.setCounts(items); };
+
+protected:
+    RenderScriptingInterface();
+    ~RenderScriptingInterface() {};
+
+    render::RenderContext::ItemsMeta _items;
+    render::RenderContext::Tone _tone;
+
+    // Options
+    int _drawStatus = 0;
+    bool _drawHitEffect = false;
+
+    // Debugging
+    int _deferredDebugMode = -1;
+    glm::vec4 _deferredDebugSize { 0.0f, -1.0f, 1.0f, 1.0f };
+};
+
+#endif // hifi_RenderScriptingInterface_h

--- a/libraries/render-utils/src/RenderScriptingInterface.h
+++ b/libraries/render-utils/src/RenderScriptingInterface.h
@@ -22,35 +22,35 @@ class RenderScriptingInterface : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
     
  public:
-     Q_INVOKABLE void setEngineRenderOpaque(bool renderOpaque) { _items._opaque._render = renderOpaque; };
-    Q_INVOKABLE bool doEngineRenderOpaque() const { return _items._opaque._render; }
-    Q_INVOKABLE void setEngineRenderTransparent(bool renderTransparent) { _items._transparent._render = renderTransparent; };
-    Q_INVOKABLE bool doEngineRenderTransparent() const { return _items._transparent._render; }
+     Q_INVOKABLE void setEngineRenderOpaque(bool renderOpaque) { _items.opaque.render = renderOpaque; };
+    Q_INVOKABLE bool doEngineRenderOpaque() const { return _items.opaque.render; }
+    Q_INVOKABLE void setEngineRenderTransparent(bool renderTransparent) { _items.transparent.render = renderTransparent; };
+    Q_INVOKABLE bool doEngineRenderTransparent() const { return _items.transparent.render; }
     
-    Q_INVOKABLE void setEngineCullOpaque(bool cullOpaque) { _items._opaque._cull = cullOpaque; };
-    Q_INVOKABLE bool doEngineCullOpaque() const { return _items._opaque._cull; }
-    Q_INVOKABLE void setEngineCullTransparent(bool cullTransparent) { _items._transparent._cull = cullTransparent; };
-    Q_INVOKABLE bool doEngineCullTransparent() const { return _items._transparent._cull; }
+    Q_INVOKABLE void setEngineCullOpaque(bool cullOpaque) { _items.opaque.cull = cullOpaque; };
+    Q_INVOKABLE bool doEngineCullOpaque() const { return _items.opaque.cull; }
+    Q_INVOKABLE void setEngineCullTransparent(bool cullTransparent) { _items.transparent.cull = cullTransparent; };
+    Q_INVOKABLE bool doEngineCullTransparent() const { return _items.transparent.cull; }
 
-    Q_INVOKABLE void setEngineSortOpaque(bool sortOpaque) { _items._opaque._sort = sortOpaque; };
-    Q_INVOKABLE bool doEngineSortOpaque() const { return _items._opaque._sort; }
-    Q_INVOKABLE void setEngineSortTransparent(bool sortTransparent) { _items._transparent._sort = sortTransparent; };
-    Q_INVOKABLE bool doEngineSortTransparent() const { return _items._transparent._sort; }
+    Q_INVOKABLE void setEngineSortOpaque(bool sortOpaque) { _items.opaque.sort = sortOpaque; };
+    Q_INVOKABLE bool doEngineSortOpaque() const { return _items.opaque.sort; }
+    Q_INVOKABLE void setEngineSortTransparent(bool sortTransparent) { _items.transparent.sort = sortTransparent; };
+    Q_INVOKABLE bool doEngineSortTransparent() const { return _items.transparent.sort; }
 
-    Q_INVOKABLE int getEngineNumDrawnOpaqueItems() { return _items._opaque._numDrawn; }
-    Q_INVOKABLE int getEngineNumDrawnTransparentItems() { return _items._transparent._numDrawn; }
-    Q_INVOKABLE int getEngineNumDrawnOverlay3DItems() { return _items._overlay3D._numDrawn; }
+    Q_INVOKABLE int getEngineNumDrawnOpaqueItems() { return _items.opaque.numDrawn; }
+    Q_INVOKABLE int getEngineNumDrawnTransparentItems() { return _items.transparent.numDrawn; }
+    Q_INVOKABLE int getEngineNumDrawnOverlay3DItems() { return _items.overlay3D.numDrawn; }
 
-    Q_INVOKABLE int getEngineNumFeedOpaqueItems() { return _items._opaque._numFeed; }
-    Q_INVOKABLE int getEngineNumFeedTransparentItems() { return _items._transparent._numFeed; }
-    Q_INVOKABLE int getEngineNumFeedOverlay3DItems() { return _items._overlay3D._numFeed; }
+    Q_INVOKABLE int getEngineNumFeedOpaqueItems() { return _items.opaque.numFeed; }
+    Q_INVOKABLE int getEngineNumFeedTransparentItems() { return _items.transparent.numFeed; }
+    Q_INVOKABLE int getEngineNumFeedOverlay3DItems() { return _items.overlay3D.numFeed; }
 
-    Q_INVOKABLE void setEngineMaxDrawnOpaqueItems(int count) { _items._opaque._maxDrawn = count; }
-    Q_INVOKABLE int getEngineMaxDrawnOpaqueItems() { return _items._opaque._maxDrawn; }
-    Q_INVOKABLE void setEngineMaxDrawnTransparentItems(int count) { _items._transparent._maxDrawn = count; }
-    Q_INVOKABLE int getEngineMaxDrawnTransparentItems() { return _items._transparent._maxDrawn; }
-    Q_INVOKABLE void setEngineMaxDrawnOverlay3DItems(int count) { _items._overlay3D._maxDrawn = count; }
-    Q_INVOKABLE int getEngineMaxDrawnOverlay3DItems() { return _items._overlay3D._maxDrawn; }
+    Q_INVOKABLE void setEngineMaxDrawnOpaqueItems(int count) { _items.opaque.maxDrawn = count; }
+    Q_INVOKABLE int getEngineMaxDrawnOpaqueItems() { return _items.opaque.maxDrawn; }
+    Q_INVOKABLE void setEngineMaxDrawnTransparentItems(int count) { _items.transparent.maxDrawn = count; }
+    Q_INVOKABLE int getEngineMaxDrawnTransparentItems() { return _items.transparent.maxDrawn; }
+    Q_INVOKABLE void setEngineMaxDrawnOverlay3DItems(int count) { _items.overlay3D.maxDrawn = count; }
+    Q_INVOKABLE int getEngineMaxDrawnOverlay3DItems() { return _items.overlay3D.maxDrawn; }
     
     Q_INVOKABLE void setEngineDeferredDebugMode(int mode) { _deferredDebugMode = mode; }
     Q_INVOKABLE int getEngineDeferredDebugMode() { return _deferredDebugMode; }
@@ -63,12 +63,12 @@ class RenderScriptingInterface : public QObject, public Dependency {
     Q_INVOKABLE void setEngineDisplayHitEffect(bool display) { _drawHitEffect = display; }
     Q_INVOKABLE bool doEngineDisplayHitEffect() { return _drawHitEffect; }
 
-    Q_INVOKABLE void setEngineToneMappingExposure(float exposure) { _tone._exposure = exposure; }
-    Q_INVOKABLE float getEngineToneMappingExposure() const { return _tone._exposure; }
+    Q_INVOKABLE void setEngineToneMappingExposure(float exposure) { _tone.exposure = exposure; }
+    Q_INVOKABLE float getEngineToneMappingExposure() const { return _tone.exposure; }
 
     Q_INVOKABLE void setEngineToneMappingToneCurve(const QString& curve);
     Q_INVOKABLE QString getEngineToneMappingToneCurve() const;
-    int getEngineToneMappingToneCurveValue() const { return _tone._toneCurve; }
+    int getEngineToneMappingToneCurveValue() const { return _tone.toneCurve; }
 
     inline int getDrawStatus() { return _drawStatus; }
     inline bool getDrawHitEffect() { return _drawHitEffect; }

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -97,9 +97,9 @@ const gpu::TexturePointer DrawStatus::getStatusIconMap() const {
 void DrawStatus::run(const SceneContextPointer& sceneContext,
                      const RenderContextPointer& renderContext,
                      const ItemIDsBounds& inItems) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
-    RenderArgs* args = renderContext->args;
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
+    RenderArgs* args = renderContext->getArgs();
     auto& scene = sceneContext->_scene;
     const int NUM_STATUS_VEC4_PER_ITEM = 2;
     const int VEC4_LENGTH = 4;
@@ -179,7 +179,7 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
 
         const unsigned int VEC3_ADRESS_OFFSET = 3;
 
-        if ((renderContext->_drawItemStatus & showDisplayStatusFlag) > 0) {
+        if ((renderContext->getDrawStatus() & showDisplayStatusFlag) > 0) {
             for (int i = 0; i < nbItems; i++) {
                 batch._glUniform3fv(_drawItemBoundPosLoc, 1, (const float*) (itemAABox + i));
                 batch._glUniform3fv(_drawItemBoundDimLoc, 1, ((const float*) (itemAABox + i)) + VEC3_ADRESS_OFFSET);
@@ -192,7 +192,7 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
 
         batch.setPipeline(getDrawItemStatusPipeline());
 
-        if ((renderContext->_drawItemStatus & showNetworkStatusFlag) > 0) {
+        if ((renderContext->getDrawStatus() & showNetworkStatusFlag) > 0) {
             for (int i = 0; i < nbItems; i++) {
                 batch._glUniform3fv(_drawItemStatusPosLoc, 1, (const float*) (itemAABox + i));
                 batch._glUniform3fv(_drawItemStatusDimLoc, 1, ((const float*) (itemAABox + i)) + VEC3_ADRESS_OFFSET);

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -37,7 +37,7 @@ void DrawSceneTask::run(const SceneContextPointer& sceneContext, const RenderCon
 
 
     // Is it possible that we render without a viewFrustum ?
-    if (!(renderContext->args && renderContext->args->_viewFrustum)) {
+    if (!(renderContext->getArgs() && renderContext->getArgs()->_viewFrustum)) {
         return;
     }
 
@@ -54,11 +54,11 @@ Job::~Job() {
 
 
 void render::cullItems(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemIDsBounds& inItems, ItemIDsBounds& outItems) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
-    RenderArgs* args = renderContext->args;
-    auto renderDetails = renderContext->args->_details._item;
+    RenderArgs* args = renderContext->getArgs();
+    auto renderDetails = renderContext->getArgs()->_details._item;
 
     renderDetails->_considered += inItems.size();
     
@@ -115,7 +115,7 @@ void CullItems::run(const SceneContextPointer& sceneContext, const RenderContext
 
     outItems.clear();
     outItems.reserve(inItems.size());
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     args->_details.pointTo(RenderDetails::OTHER_ITEM);
     cullItems(sceneContext, renderContext, inItems, outItems);
 }
@@ -124,7 +124,7 @@ void CullItemsOpaque::run(const SceneContextPointer& sceneContext, const RenderC
 
     outItems.clear();
     outItems.reserve(inItems.size());
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     args->_details.pointTo(RenderDetails::OPAQUE_ITEM);
     cullItems(sceneContext, renderContext, inItems, outItems);
 }
@@ -133,7 +133,7 @@ void CullItemsTransparent::run(const SceneContextPointer& sceneContext, const Re
 
     outItems.clear();
     outItems.reserve(inItems.size());
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     args->_details.pointTo(RenderDetails::TRANSLUCENT_ITEM);
     cullItems(sceneContext, renderContext, inItems, outItems);
 }
@@ -163,11 +163,11 @@ struct BackToFrontSort {
 };
 
 void render::depthSortItems(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, bool frontToBack, const ItemIDsBounds& inItems, ItemIDsBounds& outItems) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
     
     auto& scene = sceneContext->_scene;
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     
 
     // Allocate and simply copy
@@ -211,7 +211,7 @@ void DepthSortItems::run(const SceneContextPointer& sceneContext, const RenderCo
 
 void render::renderItems(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemIDsBounds& inItems, int maxDrawnItems) {
     auto& scene = sceneContext->_scene;
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     // render
     if ((maxDrawnItems < 0) || (maxDrawnItems > (int) inItems.size())) {
         for (auto itemDetails : inItems) {
@@ -236,8 +236,8 @@ void render::renderItems(const SceneContextPointer& sceneContext, const RenderCo
 }
 
 void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
     // render lights
     auto& scene = sceneContext->_scene;
@@ -253,7 +253,7 @@ void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContext
 
     ItemIDsBounds culledItems;
     culledItems.reserve(inItems.size());
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     args->_details.pointTo(RenderDetails::OTHER_ITEM);
     cullItems(sceneContext, renderContext, inItems, culledItems);
 
@@ -265,8 +265,8 @@ void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContext
 }
 
 void DrawBackground::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
-    assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->getArgs());
+    assert(renderContext->getArgs()->_viewFrustum);
 
     // render backgrounds
     auto& scene = sceneContext->_scene;
@@ -278,7 +278,7 @@ void DrawBackground::run(const SceneContextPointer& sceneContext, const RenderCo
     for (auto id : items) {
         inItems.emplace_back(id);
     }
-    RenderArgs* args = renderContext->args;
+    RenderArgs* args = renderContext->getArgs();
     doInBatch(args->_context, [=](gpu::Batch& batch) {
         args->_batch = &batch;
         batch.enableSkybox(true);

--- a/libraries/render/src/render/Engine.cpp
+++ b/libraries/render/src/render/Engine.cpp
@@ -13,6 +13,16 @@
 #include "DrawTask.h"
 using namespace render;
 
+void RenderContext::setOptions(int drawStatus, bool drawHitEffect, bool occlusion, bool fxaa, bool showOwned) {
+    _drawStatus = drawStatus;
+    _occlusionStatus = occlusion;
+    _fxaaStatus = fxaa;
+    _drawHitEffect = drawHitEffect;
+
+    if (showOwned) {
+        _drawStatus |= render::showNetworkStatusFlag;
+    }
+};
 
 Engine::Engine() :
     _sceneContext(std::make_shared<SceneContext>()),

--- a/libraries/render/src/render/Engine.h
+++ b/libraries/render/src/render/Engine.h
@@ -32,59 +32,63 @@ const int showNetworkStatusFlag = 2;
 
 class RenderContext {
 public:
-    struct ItemsConfig {
+    class ItemsConfig {
+    public:
         inline void setCounts(const ItemsConfig& items) {
-            _opaque.setCounts(items._opaque);
-            _transparent.setCounts(items._transparent);
-            _overlay3D.setCounts(items._overlay3D);
+            opaque.setCounts(items.opaque);
+            transparent.setCounts(items.transparent);
+            overlay3D.setCounts(items.overlay3D);
         };
 
-        struct Counter {
+        class Counter {
+        public:
             Counter() {};
             Counter(const Counter& counter) {
-                _numFeed = _numDrawn = 0;
-                _maxDrawn = counter._maxDrawn;
+                numFeed = numDrawn = 0;
+                maxDrawn = counter.maxDrawn;
             };
 
             inline void setCounts(const Counter& counter) {
-                _numFeed = counter._numFeed;
-                _numDrawn = counter._numDrawn;
+                numFeed = counter.numFeed;
+                numDrawn = counter.numDrawn;
             };
 
-            int _numFeed = 0;
-            int _numDrawn = 0;
-            int _maxDrawn = -1;
+            int numFeed = 0;
+            int numDrawn = 0;
+            int maxDrawn = -1;
         };
 
-        struct State : public Counter {
-            bool _render = true;
-            bool _cull = true;
-            bool _sort = true;
+        class State : public Counter {
+        public:
+            bool render = true;
+            bool cull = true;
+            bool sort = true;
 
-            Counter _counter{};
+            Counter counter{};
         };
 
-        // TODO: Store state/counter in a map instead of manually enumerated members
-        State _opaque{};
-        State _transparent{};
-        Counter _overlay3D{};
+        // TODO: If member count increases, store counters in a map instead of multiple members
+        State opaque{};
+        State transparent{};
+        Counter overlay3D{};
     };
 
-    struct Tone {
-        int _toneCurve = 3;
-        float _exposure = 0.0;
+    class Tone {
+    public:
+        int toneCurve = 3;
+        float exposure = 0.0;
     };
     
     RenderContext(RenderArgs* args, ItemsConfig items, Tone tone) : _args{args}, _items{items}, _tone{tone} {};
     RenderContext() : RenderContext(nullptr, {}, {}) {};
 
     inline RenderArgs* getArgs() { return _args; }
+    inline ItemsConfig& getItemsConfig() { return _items; }
+    inline Tone& getTone() { return _tone; }
     inline int getDrawStatus() { return _drawStatus; }
     inline bool getDrawHitEffect() { return _drawHitEffect; }
     inline bool getOcclusionStatus() { return _occlusionStatus; }
     inline bool getFxaaStatus() { return _fxaaStatus; }
-    inline ItemsConfig& getItemsConfig() { return _items; }
-    inline Tone& getTone() { return _tone; }
     void setOptions(int drawStatus, bool drawHitEffect, bool occlusion, bool fxaa, bool showOwned);
 
     // Debugging

--- a/libraries/render/src/render/Engine.h
+++ b/libraries/render/src/render/Engine.h
@@ -32,8 +32,8 @@ const int showNetworkStatusFlag = 2;
 
 class RenderContext {
 public:
-    struct ItemsMeta {
-        inline void setCounts(const ItemsMeta& items) {
+    struct ItemsConfig {
+        inline void setCounts(const ItemsConfig& items) {
             _opaque.setCounts(items._opaque);
             _transparent.setCounts(items._transparent);
             _overlay3D.setCounts(items._overlay3D);
@@ -75,7 +75,7 @@ public:
         float _exposure = 0.0;
     };
     
-    RenderContext(RenderArgs* args, ItemsMeta items, Tone tone) : _args{args}, _items{items}, _tone{tone} {};
+    RenderContext(RenderArgs* args, ItemsConfig items, Tone tone) : _args{args}, _items{items}, _tone{tone} {};
     RenderContext() : RenderContext(nullptr, {}, {}) {};
 
     inline RenderArgs* getArgs() { return _args; }
@@ -83,7 +83,7 @@ public:
     inline bool getDrawHitEffect() { return _drawHitEffect; }
     inline bool getOcclusionStatus() { return _occlusionStatus; }
     inline bool getFxaaStatus() { return _fxaaStatus; }
-    inline ItemsMeta& getItemsMeta() { return _items; }
+    inline ItemsConfig& getItemsConfig() { return _items; }
     inline Tone& getTone() { return _tone; }
     void setOptions(int drawStatus, bool drawHitEffect, bool occlusion, bool fxaa, bool showOwned);
 
@@ -100,7 +100,7 @@ protected:
     bool _occlusionStatus = false;
     bool _fxaaStatus = false;
 
-    ItemsMeta _items;
+    ItemsConfig _items;
     Tone _tone;
 };
 typedef std::shared_ptr<RenderContext> RenderContextPointer;

--- a/libraries/script-engine/src/SceneScriptingInterface.cpp
+++ b/libraries/script-engine/src/SceneScriptingInterface.cpp
@@ -1,6 +1,6 @@
 //
 //  SceneScriptingInterface.cpp
-//  interface/src/scripting
+//  libraries/script-engine
 //
 //  Created by Sam Gateau on 2/24/15.
 //  Copyright 2014 High Fidelity, Inc.
@@ -11,14 +11,25 @@
 
 #include "SceneScriptingInterface.h"
 
-#include <AddressManager.h>
-
-
 #include <procedural/ProceduralSkybox.h>
 
 SceneScriptingInterface::SceneScriptingInterface() {
-    // Let's make sure the sunSkyStage is using a proceduralSKybox
+    // Let's make sure the sunSkyStage is using a proceduralSkybox
     _skyStage->setSkybox(model::SkyboxPointer(new ProceduralSkybox()));
+}
+
+void SceneScriptingInterface::setShouldRenderAvatars(bool shouldRenderAvatars) {
+    if (shouldRenderAvatars != _shouldRenderAvatars) {
+        _shouldRenderAvatars = shouldRenderAvatars;
+        emit shouldRenderAvatarsChanged(_shouldRenderAvatars);
+    }
+}
+
+void SceneScriptingInterface::setShouldRenderEntities(bool shouldRenderEntities) {
+    if (shouldRenderEntities != _shouldRenderEntities) {
+        _shouldRenderEntities = shouldRenderEntities;
+        emit shouldRenderEntitiesChanged(_shouldRenderEntities);
+    }
 }
 
 void SceneScriptingInterface::setStageOrientation(const glm::quat& orientation) {
@@ -119,78 +130,4 @@ QString SceneScriptingInterface::getBackgroundMode() const {
 
 model::SunSkyStagePointer SceneScriptingInterface::getSkyStage() const {
     return _skyStage;
-}
-
-void SceneScriptingInterface::setShouldRenderAvatars(bool shouldRenderAvatars) {
-    if (shouldRenderAvatars != _shouldRenderAvatars) {
-        _shouldRenderAvatars = shouldRenderAvatars;
-        emit shouldRenderAvatarsChanged(_shouldRenderAvatars);
-    }
-}
-
-void SceneScriptingInterface::setShouldRenderEntities(bool shouldRenderEntities) {
-    if (shouldRenderEntities != _shouldRenderEntities) {
-        _shouldRenderEntities = shouldRenderEntities;
-        emit shouldRenderEntitiesChanged(_shouldRenderEntities);
-    }
-}
-
-void SceneScriptingInterface::setEngineRenderOpaque(bool renderOpaque) {
-    _engineRenderOpaque = renderOpaque;
-}
-
-void SceneScriptingInterface::setEngineRenderTransparent(bool renderTransparent) {
-    _engineRenderTransparent = renderTransparent;
-}
-
-void SceneScriptingInterface::setEngineCullOpaque(bool cullOpaque) {
-    _engineCullOpaque = cullOpaque;
-}
-
-void SceneScriptingInterface::setEngineCullTransparent(bool cullTransparent) {
-    _engineCullTransparent = cullTransparent;
-}
-
-void SceneScriptingInterface::setEngineSortOpaque(bool sortOpaque) {
-    _engineSortOpaque = sortOpaque;
-}
-
-void SceneScriptingInterface::setEngineSortTransparent(bool sortTransparent) {
-    _engineSortOpaque = sortTransparent;
-}
-
-void SceneScriptingInterface::clearEngineCounters() {
-    _numFeedOpaqueItems = 0;
-    _numDrawnOpaqueItems = 0;
-    _numFeedTransparentItems = 0;
-    _numDrawnTransparentItems = 0;
-    _numFeedOverlay3DItems = 0;
-    _numDrawnOverlay3DItems = 0;
-}
-
-
-void SceneScriptingInterface::setEngineToneMappingToneCurve(const QString& toneCurve) {
-    if (toneCurve == QString("None")) {
-        _engineToneMappingToneCurve = 0;
-    } else if (toneCurve == QString("Gamma22")) {
-        _engineToneMappingToneCurve = 1;
-    } else if (toneCurve == QString("Reinhard")) {
-        _engineToneMappingToneCurve = 2;
-    } else if (toneCurve == QString("Filmic")) {
-        _engineToneMappingToneCurve = 3;
-    }
-}
-QString SceneScriptingInterface::getEngineToneMappingToneCurve() const {
-    switch (_engineToneMappingToneCurve) {
-    case 0:
-        return QString("None");
-    case 1:
-        return QString("Gamma22");
-    case 2:
-        return QString("Reinhard");
-    case 3:
-        return QString("Filmic");
-    default:
-        return QString("Filmic");
-    };
 }

--- a/libraries/script-engine/src/SceneScriptingInterface.h
+++ b/libraries/script-engine/src/SceneScriptingInterface.h
@@ -1,6 +1,6 @@
 //
 //  SceneScriptingInterface.h
-//  interface/src/scripting
+//  libraries/script-engine
 //
 //  Created by Sam Gateau on 2/24/15.
 //  Copyright 2014 High Fidelity, Inc.
@@ -12,9 +12,8 @@
 #ifndef hifi_SceneScriptingInterface_h
 #define hifi_SceneScriptingInterface_h
 
-#include <qscriptengine.h>
-
-#include <DependencyManager.h>
+#include <qscriptengine.h> // QObject
+#include <DependencyManager.h> // Dependency
 
 #include "model/Stage.h"
 
@@ -22,10 +21,16 @@ class SceneScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
     SINGLETON_DEPENDENCY
     
+public:
     Q_PROPERTY(bool shouldRenderAvatars READ shouldRenderAvatars WRITE setShouldRenderAvatars)
     Q_PROPERTY(bool shouldRenderEntities READ shouldRenderEntities WRITE setShouldRenderEntities)
 
-public:
+    Q_INVOKABLE void setShouldRenderAvatars(bool shouldRenderAvatars);
+    Q_INVOKABLE bool shouldRenderAvatars() const { return _shouldRenderAvatars; }
+    
+    Q_INVOKABLE void setShouldRenderEntities(bool shouldRenderEntities);
+    Q_INVOKABLE bool shouldRenderEntities() const { return _shouldRenderEntities; }
+
     Q_INVOKABLE void setStageOrientation(const glm::quat& orientation);
 
     Q_INVOKABLE void setStageLocation(float longitude, float latitude, float altitude);
@@ -42,7 +47,6 @@ public:
     // the sun light based on the location of the stage trelative to earth and the current time 
     Q_INVOKABLE void setStageSunModelEnable(bool isEnabled);
     Q_INVOKABLE bool isStageSunModelEnabled() const;
-
 
     Q_INVOKABLE void setKeyLightColor(const glm::vec3& color);
     Q_INVOKABLE glm::vec3 getKeyLightColor() const;
@@ -61,108 +65,19 @@ public:
     Q_INVOKABLE QString getBackgroundMode() const;
 
     model::SunSkyStagePointer getSkyStage() const;
-    
-    Q_INVOKABLE void setShouldRenderAvatars(bool shouldRenderAvatars);
-    Q_INVOKABLE bool shouldRenderAvatars() const { return _shouldRenderAvatars; }
-    
-    Q_INVOKABLE void setShouldRenderEntities(bool shouldRenderEntities);
-    Q_INVOKABLE bool shouldRenderEntities() const { return _shouldRenderEntities; }
-
-
-    // Controlling the rendering engine
-    Q_INVOKABLE void setEngineRenderOpaque(bool renderOpaque);
-    Q_INVOKABLE bool doEngineRenderOpaque() const { return _engineRenderOpaque; }
-    Q_INVOKABLE void setEngineRenderTransparent(bool renderTransparent);
-    Q_INVOKABLE bool doEngineRenderTransparent() const { return _engineRenderTransparent; }
-    
-    Q_INVOKABLE void setEngineCullOpaque(bool cullOpaque);
-    Q_INVOKABLE bool doEngineCullOpaque() const { return _engineCullOpaque; }
-    Q_INVOKABLE void setEngineCullTransparent(bool cullTransparent);
-    Q_INVOKABLE bool doEngineCullTransparent() const { return _engineCullTransparent; }
-
-    Q_INVOKABLE void setEngineSortOpaque(bool sortOpaque);
-    Q_INVOKABLE bool doEngineSortOpaque() const { return _engineSortOpaque; }
-    Q_INVOKABLE void setEngineSortTransparent(bool sortTransparent);
-    Q_INVOKABLE bool doEngineSortTransparent() const { return _engineSortTransparent; }
-
-    void clearEngineCounters();
-    void setEngineDrawnOpaqueItems(int count) { _numDrawnOpaqueItems = count; }
-    Q_INVOKABLE int getEngineNumDrawnOpaqueItems() { return _numDrawnOpaqueItems; }
-    void setEngineDrawnTransparentItems(int count) { _numDrawnTransparentItems = count; }
-    Q_INVOKABLE int getEngineNumDrawnTransparentItems() { return _numDrawnTransparentItems; }
-    void setEngineDrawnOverlay3DItems(int count) { _numDrawnOverlay3DItems = count; }
-    Q_INVOKABLE int getEngineNumDrawnOverlay3DItems() { return _numDrawnOverlay3DItems; }
-
-    void setEngineFeedOpaqueItems(int count) { _numFeedOpaqueItems = count; }
-    Q_INVOKABLE int getEngineNumFeedOpaqueItems() { return _numFeedOpaqueItems; }
-    void setEngineFeedTransparentItems(int count) { _numFeedTransparentItems = count; }
-    Q_INVOKABLE int getEngineNumFeedTransparentItems() { return _numFeedTransparentItems; }
-    void setEngineFeedOverlay3DItems(int count) { _numFeedOverlay3DItems = count; }
-    Q_INVOKABLE int getEngineNumFeedOverlay3DItems() { return _numFeedOverlay3DItems; }
-
-    Q_INVOKABLE void setEngineMaxDrawnOpaqueItems(int count) { _maxDrawnOpaqueItems = count; }
-    Q_INVOKABLE int getEngineMaxDrawnOpaqueItems() { return _maxDrawnOpaqueItems; }
-    Q_INVOKABLE void setEngineMaxDrawnTransparentItems(int count) { _maxDrawnTransparentItems = count; }
-    Q_INVOKABLE int getEngineMaxDrawnTransparentItems() { return _maxDrawnTransparentItems; }
-    Q_INVOKABLE void setEngineMaxDrawnOverlay3DItems(int count) { _maxDrawnOverlay3DItems = count; }
-    Q_INVOKABLE int getEngineMaxDrawnOverlay3DItems() { return _maxDrawnOverlay3DItems; }
-    
-    Q_INVOKABLE void setEngineDeferredDebugMode(int mode) { _deferredDebugMode = mode; }
-    Q_INVOKABLE int getEngineDeferredDebugMode() { return _deferredDebugMode; }
-    Q_INVOKABLE void setEngineDeferredDebugSize(glm::vec4 size) { _deferredDebugSize = size; }
-    Q_INVOKABLE glm::vec4 getEngineDeferredDebugSize() { return _deferredDebugSize; }
-    
-    Q_INVOKABLE void setEngineDisplayItemStatus(int display) { _drawItemStatus = display; }
-    Q_INVOKABLE int doEngineDisplayItemStatus() { return _drawItemStatus; }
-
-    Q_INVOKABLE void setEngineDisplayHitEffect(bool display) { _drawHitEffect = display; }
-    Q_INVOKABLE bool doEngineDisplayHitEffect() { return _drawHitEffect; }
-
-    Q_INVOKABLE void setEngineToneMappingExposure(float exposure) { _engineToneMappingExposure = exposure; }
-    Q_INVOKABLE float getEngineToneMappingExposure() const { return _engineToneMappingExposure; }
-
-    Q_INVOKABLE void setEngineToneMappingToneCurve(const QString& curve);
-    Q_INVOKABLE QString getEngineToneMappingToneCurve() const;
-    int getEngineToneMappingToneCurveValue() const { return _engineToneMappingToneCurve; }
 
 signals:
     void shouldRenderAvatarsChanged(bool shouldRenderAvatars);
     void shouldRenderEntitiesChanged(bool shouldRenderEntities);
+
 protected:
     SceneScriptingInterface();
     ~SceneScriptingInterface() {};
 
     model::SunSkyStagePointer _skyStage = std::make_shared<model::SunSkyStage>();
-    
+
     bool _shouldRenderAvatars = true;
     bool _shouldRenderEntities = true;
-
-    bool _engineRenderOpaque = true;
-    bool _engineRenderTransparent = true;
-    bool _engineCullOpaque = true;
-    bool _engineCullTransparent = true;
-    bool _engineSortOpaque = true;
-    bool _engineSortTransparent = true;
-
-    int _numFeedOpaqueItems = 0;
-    int _numDrawnOpaqueItems = 0;
-    int _numFeedTransparentItems = 0;
-    int _numDrawnTransparentItems = 0;
-    int _numFeedOverlay3DItems = 0;
-    int _numDrawnOverlay3DItems = 0;
-
-    int _maxDrawnOpaqueItems = -1;
-    int _maxDrawnTransparentItems = -1;
-    int _maxDrawnOverlay3DItems = -1;
-    
-    int _deferredDebugMode = -1;
-    glm::vec4 _deferredDebugSize { 0.0f, -1.0f, 1.0f, 1.0f };
-    int _drawItemStatus = 0;
-
-    bool _drawHitEffect = false;
-
-    float _engineToneMappingExposure = 0.0f;
-    int _engineToneMappingToneCurve = 3;
 };
 
 #endif // hifi_SceneScriptingInterface_h

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -46,7 +46,6 @@
 #include "XMLHttpRequestClass.h"
 #include "WebSocketClass.h"
 
-#include "SceneScriptingInterface.h"
 #include "RecordingScriptingInterface.h"
 
 #include "MIDIEvent.h"


### PR DESCRIPTION
- Split render interface into `render-utils/RenderScriptingInterface`
- Grouped most `render::RenderContext` options into `ItemsMeta` and `Tone` subclasses
- Added accessors for `RenderContext` properties

`ItemsMeta` could be named nicer - `ItemsConfig`?