### PR TITLE
Graphics: Adding gamma correction to color vertex attribute

### DIFF
--- a/libraries/entities-renderer/src/paintStroke.slv
+++ b/libraries/entities-renderer/src/paintStroke.slv
@@ -13,8 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 // the interpolated normal
@@ -30,7 +30,7 @@ void main(void) {
     varTexcoord = inTexCoord0.st;
     
     // pass along the diffuse color
-    varColor = inColor;
+    varColor = colorToLinearRGBA(inColor);
 
     // standard transform
     TransformCamera cam = getTransformCamera();

--- a/libraries/gpu/src/gpu/Color.slh
+++ b/libraries/gpu/src/gpu/Color.slh
@@ -1,0 +1,52 @@
+<!
+//  Color.slh
+//  libraries/gpu/src
+//
+//  Created by Sam Gateau on 2015/12/18.
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+!>
+<@if not GPU_COLOR_SLH@>
+<@def GPU_COLOR_SLH@>
+<!
+float colorComponentToLinear(float cs) {
+    // sRGB to linear conversion
+    //      {  cs / 12.92,                 cs <= 0.04045
+    // cl = {
+    //      {  ((cs + 0.055)/1.055)^2.4,   cs >  0.04045
+    // constants:
+    // T = 0.04045
+    // A = 1 / 1.055 = 0.94786729857
+    // B = 0.055 * A = 0.05213270142
+    // C = 1 / 12.92 = 0.0773993808
+    // G = 2.4
+    const float T = 0.04045;
+    const float A = 0.947867;
+    const float B = 0.052132;
+    const float C = 0.077399;
+    const float G = 2.4;
+
+    if (cs > T) {
+        return pow((cs * A + B), G);
+    } else {
+        return cs * C;
+    }
+}
+
+vec3 colorToLinear(vec3 srgb) {
+    return vec3(colorComponentToLinear(srgb.x), colorComponentToLinear(srgb.y), colorComponentToLinear(srgb.z));
+}
+!>
+
+vec3 colorToLinearRGB(vec3 srgb) {
+    const float GAMMA_22 = 2.2;
+    return pow(srgb, vec3(GAMMA_22));
+}
+
+vec4 colorToLinearRGBA(vec4 srgba) {
+    return vec4(colorToLinearRGB(srgba.xyz), srgba.w);
+}
+
+<@endif@>

--- a/libraries/render-utils/src/FramebufferCache.cpp
+++ b/libraries/render-utils/src/FramebufferCache.cpp
@@ -89,9 +89,10 @@ void FramebufferCache::createPrimaryFramebuffer() {
 
     auto smoothSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR);
 
+    // FIXME: Decide on the proper one, let s stick to R11G11B10 for now
     //_lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, width, height, defaultSampler));
-    //lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC3, gpu::NUINT8, gpu::R11G11B10), width, height, defaultSampler));
-    _lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC4, gpu::HALF, gpu::RGBA), width, height, smoothSampler));
+    _lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC3, gpu::NUINT8, gpu::R11G11B10), width, height, defaultSampler));
+    //_lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC4, gpu::HALF, gpu::RGBA), width, height, defaultSampler));
     _lightingFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create());
     _lightingFramebuffer->setRenderBuffer(0, _lightingTexture);
     _lightingFramebuffer->setDepthStencilBuffer(_primaryDepthTexture, depthFormat);

--- a/libraries/render-utils/src/ToneMappingEffect.cpp
+++ b/libraries/render-utils/src/ToneMappingEffect.cpp
@@ -64,13 +64,9 @@ void ToneMappingEffect::init() {
         out vec4 outFragColor;
         
         void main(void) {
-            vec4 fragColorRaw = textureLod(colorMap, varTexCoord0, 0);
+            vec4 fragColorRaw = texture(colorMap, varTexCoord0);
             vec3 fragColor = fragColorRaw.xyz;
-/*
-           vec4 fragColorAverage = textureLod(colorMap, varTexCoord0, 10);
-            float averageIntensity = length(fragColorAverage.xyz);
-            fragColor /= averageIntensity;
-*/
+
             vec3 srcColor = fragColor * getTwoPowExposure();
 
             int toneCurve = getToneCurve();
@@ -124,7 +120,8 @@ void ToneMappingEffect::render(RenderArgs* args) {
         auto destFbo = framebufferCache->getPrimaryFramebuffer();
         batch.setFramebuffer(destFbo);
 
-        batch.generateTextureMips(lightingBuffer);
+        // FIXME: Generate the Luminosity map
+        //batch.generateTextureMips(lightingBuffer);
 
         batch.setViewportTransform(args->_viewport);
         batch.setProjectionTransform(glm::mat4());

--- a/libraries/render-utils/src/animdebugdraw.slv
+++ b/libraries/render-utils/src/animdebugdraw.slv
@@ -9,16 +9,15 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 out vec4 _color;
 
 void main(void) {
     // pass along the diffuse color
-    _color = inColor.rgba;
+    _color = colorToLinearRGBA(inColor.rgba);
 
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -12,9 +12,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 const int MAX_TEXCOORDS = 2;
@@ -27,9 +26,8 @@ out vec3 _color;
 out vec2 _texCoord0;
 
 void main(void) {
-    
-    // pass along the diffuse color
-    _color = inColor.xyz;
+    // pass along the diffuse color in linear space
+    _color = colorToLinearRGB(inColor.xyz);
 
     // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.st, 0.0, 1.0)).st;

--- a/libraries/render-utils/src/model_lightmap.slv
+++ b/libraries/render-utils/src/model_lightmap.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 const int MAX_TEXCOORDS = 2;
@@ -29,7 +28,8 @@ out vec3 _normal;
 out vec3 _color;
 
 void main(void) {
-    _color = inColor.xyz;
+    // pass along the diffuse color in linear space
+    _color = colorToLinearRGB(inColor.xyz);
 
     // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.st, 0.0, 1.0)).st;

--- a/libraries/render-utils/src/model_lightmap_normal_map.slv
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 const int MAX_TEXCOORDS = 2;
@@ -30,7 +29,8 @@ out vec3 _tangent;
 out vec3 _color;
 
 void main(void) {
-    _color = inColor.xyz;
+    // pass along the diffuse color in linear space
+    _color = colorToLinearRGB(inColor.xyz);
 
     // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.st, 0.0, 1.0)).st;

--- a/libraries/render-utils/src/model_normal_map.slv
+++ b/libraries/render-utils/src/model_normal_map.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 const int MAX_TEXCOORDS = 2;
@@ -30,7 +29,7 @@ out vec3 _color;
 
 void main(void) {
     // pass along the diffuse color
-    _color = inColor.rgb;
+    _color = colorToLinearRGB(inColor.xyz);
 
     // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.xy, 0.0, 1.0)).st;

--- a/libraries/render-utils/src/overlay3D.slv
+++ b/libraries/render-utils/src/overlay3D.slv
@@ -11,9 +11,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 out vec2 varTexcoord;
@@ -30,7 +29,7 @@ void main(void) {
     varTexcoord = inTexCoord0.xy;
 
     // pass along the color
-    varColor = inColor;
+    varColor = colorToLinearRGBA(inColor);
 
     // standard transform
     TransformCamera cam = getTransformCamera();

--- a/libraries/render-utils/src/simple.slv
+++ b/libraries/render-utils/src/simple.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 uniform bool Instanced = false;
@@ -28,7 +27,7 @@ out vec2 _texCoord0;
 out vec4 _position;
 
 void main(void) {
-    _color = inColor.rgb;
+    _color = colorToLinearRGB(inColor.rgb);
     _texCoord0 = inTexCoord0.st;
     _position = inPosition;
     _modelNormal = inNormal.xyz;

--- a/libraries/render-utils/src/skin_model.slv
+++ b/libraries/render-utils/src/skin_model.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 <@include Skinning.slh@>
@@ -34,7 +33,7 @@ void main(void) {
     skinPositionNormal(inSkinClusterIndex, inSkinClusterWeight, inPosition, inNormal.xyz, position, interpolatedNormal);
 
     // pass along the diffuse color
-    _color = inColor.rgb;
+    _color = colorToLinearRGB(inColor.rgb);
 
     // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.st, 0.0, 1.0)).st;

--- a/libraries/render-utils/src/skin_model_normal_map.slv
+++ b/libraries/render-utils/src/skin_model_normal_map.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 <@include Skinning.slh@>
@@ -36,7 +35,7 @@ void main(void) {
     skinPositionNormalTangent(inSkinClusterIndex, inSkinClusterWeight, inPosition, inNormal.xyz, inTangent.xyz, position, interpolatedNormal.xyz, interpolatedTangent.xyz);
 
     // pass along the diffuse color
-    _color = inColor.rgb;
+    _color = colorToLinearRGB(inColor.rgb);
 
     // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.st, 0.0, 1.0)).st;

--- a/libraries/render-utils/src/standardTransformPNTC.slv
+++ b/libraries/render-utils/src/standardTransformPNTC.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 out vec3 varPosition;
@@ -25,7 +24,7 @@ out vec4 varColor;
 
 void main(void) {
     varTexCoord0 = inTexCoord0.st;
-    varColor = inColor;
+    varColor = colorToLinearRGBA(inColor);
     
     // standard transform
     TransformCamera cam = getTransformCamera();

--- a/libraries/render-utils/src/stars.slv
+++ b/libraries/render-utils/src/stars.slv
@@ -13,9 +13,8 @@
 //
 
 <@include gpu/Inputs.slh@>
-
+<@include gpu/Color.slh@>
 <@include gpu/Transform.slh@>
-
 <$declareStandardTransform()$>
 
 // TODO we need to get the viewport resolution and FOV passed to us so we can modify the point size
@@ -26,7 +25,7 @@ out vec4 varColor;
 out float varSize;
 
 void main(void) {
-    varColor = inColor.rgba;
+    varColor = colorToLinearRGBA(inColor);
     
     // standard transform
     TransformCamera cam = getTransformCamera();


### PR DESCRIPTION
- Add the COlor.slh file in gpu to provide the standard conversion function from sRGB to linear

- Gamma correct all the vertex attribute color values used as color for shading