### PR TITLE
Fix crash when getting MyAvatar.sessionUUID from AvatarManager

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -310,8 +310,8 @@ QVector<QUuid> AvatarManager::getAvatarIdentifiers() {
 }
 
 AvatarData* AvatarManager::getAvatar(QUuid avatarID) {
-    QReadLocker locker(&_hashLock);
-    return _avatarHash[avatarID].get();  // Non-obvious: A bogus avatarID answers your own avatar.
+    // Null/Default-constructed QUuids will return MyAvatar
+    return getAvatarBySessionID(avatarID).get();
 }
 
 


### PR DESCRIPTION
The previous code inadvertently added a default constructed shared pointer
to the avatar hash, causing it to crash when dereferencing it in
the update loop.