### PR TITLE
Clean up shaders removing  glowIntensity and alphaThreshold legacy

### DIFF
--- a/libraries/entities-renderer/src/RenderableProceduralItemShader.h
+++ b/libraries/entities-renderer/src/RenderableProceduralItemShader.h
@@ -23,8 +23,6 @@ layout(location = 0) out vec4 _fragColor0;
 layout(location = 1) out vec4 _fragColor1;
 layout(location = 2) out vec4 _fragColor2;
 
-// the glow intensity
-uniform float glowIntensity;
 // the alpha threshold
 uniform float alphaThreshold;
 uniform sampler2D normalFittingMap;
@@ -318,8 +316,8 @@ const QString SHADER_TEMPLATE_V1 = SHADER_COMMON + R"SCRIBE(
 void main(void) {
     vec4 emissive = getProceduralColor();
 
-    float alpha = glowIntensity * emissive.a;
-    if (alpha != glowIntensity) {
+    float alpha = emissive.a;
+    if (alpha != 1.0) {
         discard;
     }
 

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -56,7 +56,7 @@ static const std::string DEEFAULT_ROUGHNESS_SHADER {
 };
 static const std::string DEEFAULT_NORMAL_SHADER {
     "vec4 getFragmentColor() {"
-    "    return vec4(texture(normalMap, uv).xyz, 1.0);"
+    "    return vec4(normalize(texture(normalMap, uv).xyz), 1.0);"
     " }"
 };
 static const std::string DEEFAULT_DEPTH_SHADER {

--- a/libraries/render-utils/src/DeferredBufferWrite.slh
+++ b/libraries/render-utils/src/DeferredBufferWrite.slh
@@ -15,12 +15,6 @@ layout(location = 0) out vec4 _fragColor0;
 layout(location = 1) out vec4 _fragColor1;
 layout(location = 2) out vec4 _fragColor2;
 
-// the glow intensity
-uniform float glowIntensity;
-
-// the alpha threshold
-uniform float alphaThreshold;
-
 uniform sampler2D normalFittingMap;
 
 vec3 bestFitNormal(vec3 normal) {
@@ -39,15 +33,18 @@ vec3 bestFitNormal(vec3 normal) {
     return (cN * 0.5 + 0.5);
 }
 
+
+// the alpha threshold
+const float alphaThreshold = 0.5;
 float evalOpaqueFinalAlpha(float alpha, float mapAlpha) {
-    return mix(alpha * glowIntensity, 1.0 - alpha * glowIntensity, step(mapAlpha, alphaThreshold));
+    return mix(alpha, 1.0 - alpha, step(mapAlpha, alphaThreshold));
 }
 
 const vec3 DEFAULT_SPECULAR = vec3(0.1);
 const float DEFAULT_SHININESS = 10;
 
 void packDeferredFragment(vec3 normal, float alpha, vec3 diffuse, vec3 specular, float shininess) {
-    if (alpha != glowIntensity) {
+    if (alpha != 1.0) {
         discard;
     }
 
@@ -57,7 +54,7 @@ void packDeferredFragment(vec3 normal, float alpha, vec3 diffuse, vec3 specular,
 }
 
 void packDeferredFragmentLightmap(vec3 normal, float alpha, vec3 diffuse, vec3 specular, float shininess, vec3 emissive) {
-    if (alpha != glowIntensity) {
+    if (alpha != 1.0) {
         discard;
     }
 
@@ -67,7 +64,7 @@ void packDeferredFragmentLightmap(vec3 normal, float alpha, vec3 diffuse, vec3 s
 }
 
 void packDeferredFragmentTranslucent(vec3 normal, float alpha, vec3 diffuse, vec3 specular, float shininess) {
-    if (alpha <= alphaThreshold) {
+    if (alpha <= 0.0) {
         discard;
     } 
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -40,8 +40,6 @@
 #include "point_light_frag.h"
 #include "spot_light_frag.h"
 
-static const std::string glowIntensityShaderHandle = "glowIntensity";
-
 struct LightLocations {
     int radius;
     int ambientSphere;
@@ -134,8 +132,6 @@ gpu::PipelinePointer DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch
     batch.setPipeline(pipeline);
 
     gpu::ShaderPointer program = (config.isEmissive()) ? _emissiveShader : _simpleShader;
-    int glowIntensity = program->getUniforms().findLocation("glowIntensity");
-    batch._glUniform1f(glowIntensity, 1.0f);
     
     if (!config.isTextured()) {
         // If it is not textured, bind white texture and keep using textured pipeline

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -199,8 +199,6 @@ void MeshPartPayload::render(RenderArgs* args) const {
     gpu::Batch& batch = *(args->_batch);
     auto mode = args->_renderMode;
 
-    auto alphaThreshold = args->_alphaThreshold; //translucent ? TRANSPARENT_ALPHA_THRESHOLD : OPAQUE_ALPHA_THRESHOLD; // FIX ME
-
     model::MaterialKey drawMaterialKey;
     if (_drawMaterial) {
         drawMaterialKey = _drawMaterial->getKey();
@@ -217,7 +215,7 @@ void MeshPartPayload::render(RenderArgs* args) const {
     }
 
     ModelRender::Locations* locations = nullptr;
-    ModelRender::pickPrograms(batch, mode, translucentMesh, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned, wireframe,
+    ModelRender::pickPrograms(batch, mode, translucentMesh, hasLightmap, hasTangents, hasSpecular, isSkinned, wireframe,
         args, locations);
 
 
@@ -395,9 +393,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
 
     gpu::Batch& batch = *(args->_batch);
     auto mode = args->_renderMode;
-    
-    auto alphaThreshold = args->_alphaThreshold; //translucent ? TRANSPARENT_ALPHA_THRESHOLD : OPAQUE_ALPHA_THRESHOLD; // FIX ME
-    
+
     const FBXGeometry& geometry = _model->_geometry->getFBXGeometry();
     const std::vector<std::unique_ptr<NetworkMesh>>& networkMeshes = _model->_geometry->getMeshes();
     
@@ -467,7 +463,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     }
     
     ModelRender::Locations* locations = nullptr;
-    ModelRender::pickPrograms(batch, mode, translucentMesh, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned, wireframe,
+    ModelRender::pickPrograms(batch, mode, translucentMesh, hasLightmap, hasTangents, hasSpecular, isSkinned, wireframe,
                               args, locations);
     
     if (!locations) { // the pipeline could not be found

--- a/libraries/render-utils/src/ModelRender.cpp
+++ b/libraries/render-utils/src/ModelRender.cpp
@@ -228,10 +228,8 @@ void ModelRender::RenderPipelineLib::addRenderPipeline(ModelRender::RenderKey ke
 
 
 void ModelRender::RenderPipelineLib::initLocations(gpu::ShaderPointer& program, ModelRender::Locations& locations) {
-    locations.alphaThreshold = program->getUniforms().findLocation("alphaThreshold");
     locations.texcoordMatrices = program->getUniforms().findLocation("texcoordMatrices");
     locations.emissiveParams = program->getUniforms().findLocation("emissiveParams");
-    locations.glowIntensity = program->getUniforms().findLocation("glowIntensity");
     locations.normalFittingMapUnit = program->getTextures().findLocation("normalFittingMap");
     locations.diffuseTextureUnit = program->getTextures().findLocation("diffuseMap");
     locations.normalTextureUnit = program->getTextures().findLocation("normalMap");
@@ -244,14 +242,14 @@ void ModelRender::RenderPipelineLib::initLocations(gpu::ShaderPointer& program, 
 }
 
 
-void ModelRender::pickPrograms(gpu::Batch& batch, RenderArgs::RenderMode mode, bool translucent, float alphaThreshold,
+void ModelRender::pickPrograms(gpu::Batch& batch, RenderArgs::RenderMode mode, bool translucent,
     bool hasLightmap, bool hasTangents, bool hasSpecular, bool isSkinned, bool isWireframe, RenderArgs* args,
     Locations*& locations) {
 
     PerformanceTimer perfTimer("Model::pickPrograms");
     getRenderPipelineLib();
 
-    RenderKey key(mode, translucent, alphaThreshold, hasLightmap, hasTangents, hasSpecular, isSkinned, isWireframe);
+    RenderKey key(mode, translucent, hasLightmap, hasTangents, hasSpecular, isSkinned, isWireframe);
     auto pipeline = _renderPipelineLib.find(key.getRaw());
     if (pipeline == _renderPipelineLib.end()) {
         qDebug() << "No good, couldn't find a pipeline from the key ?" << key.getRaw();
@@ -265,15 +263,6 @@ void ModelRender::pickPrograms(gpu::Batch& batch, RenderArgs::RenderMode mode, b
 
     // Setup the One pipeline
     batch.setPipeline((*pipeline).second._pipeline);
-
-    if ((locations->alphaThreshold > -1) && (mode != RenderArgs::SHADOW_RENDER_MODE)) {
-        batch._glUniform1f(locations->alphaThreshold, alphaThreshold);
-    }
-
-    if ((locations->glowIntensity > -1) && (mode != RenderArgs::SHADOW_RENDER_MODE)) {
-        const float DEFAULT_GLOW_INTENSITY = 1.0f; // FIXME - glow is removed
-        batch._glUniform1f(locations->glowIntensity, DEFAULT_GLOW_INTENSITY);
-    }
 
     if ((locations->normalFittingMapUnit > -1)) {
         batch.setResourceTexture(locations->normalFittingMapUnit,

--- a/libraries/render-utils/src/ModelRender.h
+++ b/libraries/render-utils/src/ModelRender.h
@@ -29,21 +29,19 @@ public:
 
     class Locations {
     public:
-        int alphaThreshold;
         int texcoordMatrices;
         int diffuseTextureUnit;
         int normalTextureUnit;
         int specularTextureUnit;
         int emissiveTextureUnit;
         int emissiveParams;
-        int glowIntensity;
         int normalFittingMapUnit;
         int skinClusterBufferUnit;
         int materialBufferUnit;
         int lightBufferUnit;
     };
 
-    static void pickPrograms(gpu::Batch& batch, RenderArgs::RenderMode mode, bool translucent, float alphaThreshold,
+    static void pickPrograms(gpu::Batch& batch, RenderArgs::RenderMode mode, bool translucent,
         bool hasLightmap, bool hasTangents, bool hasSpecular, bool isSkinned, bool isWireframe, RenderArgs* args,
         Locations*& locations);
 
@@ -111,9 +109,9 @@ public:
             ) {}
 
         RenderKey(RenderArgs::RenderMode mode,
-            bool translucent, float alphaThreshold, bool hasLightmap,
+            bool translucent, bool hasLightmap,
             bool hasTangents, bool hasSpecular, bool isSkinned, bool isWireframe) :
-            RenderKey(((translucent && (alphaThreshold == 0.0f) && (mode != RenderArgs::SHADOW_RENDER_MODE)) ? IS_TRANSLUCENT : 0)
+            RenderKey(((translucent && (mode != RenderArgs::SHADOW_RENDER_MODE)) ? IS_TRANSLUCENT : 0)
             | (hasLightmap && (mode != RenderArgs::SHADOW_RENDER_MODE) ? HAS_LIGHTMAP : 0) // Lightmap, tangents and specular don't matter for depthOnly
             | (hasTangents && (mode != RenderArgs::SHADOW_RENDER_MODE) ? HAS_TANGENTS : 0)
             | (hasSpecular && (mode != RenderArgs::SHADOW_RENDER_MODE) ? HAS_SPECULAR : 0)

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -126,12 +126,6 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     _jobs.push_back(Job(new HitEffect::JobModel("HitEffect")));
     _jobs.back().setEnabled(false);
     _drawHitEffectJobIndex = (int)_jobs.size() -1;
-
-    // Give ourselves 3 frmaes of timer queries
-    _timerQueries.push_back(std::make_shared<gpu::Query>());
-    _timerQueries.push_back(std::make_shared<gpu::Query>());
-    _timerQueries.push_back(std::make_shared<gpu::Query>());
-    _currentTimerQueryIndex = 0;
 }
 
 RenderDeferredTask::~RenderDeferredTask() {
@@ -197,10 +191,6 @@ void DrawOpaqueDeferred::run(const SceneContextPointer& sceneContext, const Rend
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);
 
-        {
-            const float OPAQUE_ALPHA_THRESHOLD = 0.5f;
-            args->_alphaThreshold = OPAQUE_ALPHA_THRESHOLD;
-        }
         renderItems(sceneContext, renderContext, inItems, opaque.maxDrawn);
         args->_batch = nullptr;
     });
@@ -226,10 +216,7 @@ void DrawTransparentDeferred::run(const SceneContextPointer& sceneContext, const
 
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);
-    
-        const float TRANSPARENT_ALPHA_THRESHOLD = 0.0f;
-        args->_alphaThreshold = TRANSPARENT_ALPHA_THRESHOLD;
-    
+
         renderItems(sceneContext, renderContext, inItems, transparent.maxDrawn);
         args->_batch = nullptr;
     });

--- a/libraries/render-utils/src/SkyFromSpace.slf
+++ b/libraries/render-utils/src/SkyFromSpace.slf
@@ -114,5 +114,6 @@ void main (void)
 
     vec3 finalColor = color + fMiePhase * secondaryColor;
     outFragColor.a = finalColor.b;
-    outFragColor.rgb = pow(finalColor.rgb, vec3(1.0/2.2));
+ //   outFragColor.rgb = pow(finalColor.rgb, vec3(1.0/2.2));
+    outFragColor.rgb = finalColor.rgb;
 }

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -51,9 +51,9 @@ void main(void) {
 
     if (emissiveAmount > 0.0) {
         packDeferredFragmentLightmap(
-            normal, glowIntensity, diffuse, specular, shininess, specular);
+            normal, 1.0, diffuse, specular, shininess, specular);
     } else {
         packDeferredFragment(
-            normal, glowIntensity, diffuse, specular, shininess);
+            normal, 1.0, diffuse, specular, shininess);
     }
 }

--- a/libraries/render-utils/src/simple_textured.slf
+++ b/libraries/render-utils/src/simple_textured.slf
@@ -29,7 +29,7 @@ void main(void) {
     
     packDeferredFragment(
         normalize(_normal.xyz), 
-        glowIntensity * texel.a,
+        texel.a,
         _color.rgb * texel.rgb,
         DEFAULT_SPECULAR, DEFAULT_SHININESS);
 }

--- a/libraries/render-utils/src/simple_textured_emisive.slf
+++ b/libraries/render-utils/src/simple_textured_emisive.slf
@@ -27,7 +27,7 @@ void main(void) {
     
     packDeferredFragmentLightmap(
          normalize(_normal),
-         glowIntensity * texel.a,
+         texel.a,
          _color.rgb,
          DEFAULT_SPECULAR, DEFAULT_SHININESS,
          texel.rgb);

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -115,8 +115,6 @@ public:
     std::shared_ptr<gpu::Texture> _whiteTexture;
 
     RenderDetails _details;
-
-    float _alphaThreshold = 0.5f;
 };
 
 #endif // hifi_RenderArgs_h

--- a/tests/gpu-test/src/unlit.slf
+++ b/tests/gpu-test/src/unlit.slf
@@ -22,7 +22,7 @@ in vec3 _color;
 void main(void) {
     packDeferredFragment(
         normalize(_normal.xyz), 
-        glowIntensity,
+        1.0,
         _color.rgb,
         DEFAULT_SPECULAR, DEFAULT_SHININESS);
 }


### PR DESCRIPTION
These 2 aren't used anymore or can be replaced by hard coded constants avoiding unnecessary shader uniform setup code.