### PR TITLE
Move final blit into RenderDeferredTask

### DIFF
--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -408,7 +408,6 @@ void Blit::run(const SceneContextPointer& sceneContext, const RenderContextPoint
 
     gpu::doInBatch(renderArgs->_context, [=](gpu::Batch& batch) {
         batch.setFramebuffer(blitFbo);
-        batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, glm::vec4(0.0f, 0.0f, 1.0f, 0.0f));
 
         if (renderArgs->_renderMode == RenderArgs::MIRROR_RENDER_MODE) {
             if (renderArgs->_context->isStereo()) {

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -90,6 +90,13 @@ public:
     typedef render::Job::Model<DrawOverlay3D> JobModel;
 };
 
+class Blit {
+public:
+    void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
+
+    typedef render::Job::Model<Blit> JobModel;
+};
+
 class RenderDeferredTask : public render::Task {
 public:
 

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -24,6 +24,7 @@ namespace gpu {
 class Batch;
 class Context;
 class Texture;
+class Framebuffer;
 }
 
 class RenderDetails {
@@ -101,6 +102,7 @@ public:
     }
 
     std::shared_ptr<gpu::Context> _context = nullptr;
+    std::shared_ptr<gpu::Framebuffer> _blitFramebuffer = nullptr;
     OctreeRenderer* _renderer = nullptr;
     ViewFrustum* _viewFrustum = nullptr;
     glm::ivec4 _viewport{ 0, 0, 1, 1 };


### PR DESCRIPTION
- Also changes color buffer clearing, such that
anything run through Blit will now clear BUFFER_COLOR0  to 0,0,1,0.
- Blit will always be added to RenderDeferredTask, but
will only run if renderArgs._blitFramebuffer is set.

@samcake, is it OK to clear the color buffer in this way? Is it *necessary* to clear it at all, if we are doing a blit anyways? Can you explain what the existing calls to clearColorFramebuffer *were* doing?

The only time that Blit will not run is when an avatar billboard is rendered, as it is downloaded and not copied to the screen (AFAICT).

EDIT: Blit will no longer clear BUFFER_COLOR0, as that was redundant with blitting.