### PR TITLE
Ray-pick blacklisting

### DIFF
--- a/examples/painting/whiteboard/whiteboardSpawner.js
+++ b/examples/painting/whiteboard/whiteboardSpawner.js
@@ -15,7 +15,7 @@
 /*global hexToRgb */
 
 Script.include("../../libraries/utils.js");
-var scriptURL = Script.resolvePath("whiteboardEntityScript.js?v1" + Math.random());
+var scriptURL = Script.resolvePath("whiteboardEntityScript.js";
 var modelURL = "https://s3.amazonaws.com/hifi-public/eric/models/whiteboard.fbx";
 
 var colorIndicatorBorderModelURL = "https://s3.amazonaws.com/hifi-public/eric/models/colorIndicatorBorder.fbx";
@@ -247,4 +247,4 @@ function cleanup() {
 
 
 // Uncomment this line to delete whiteboard and all associated entity on script close
-Script.scriptEnding.connect(cleanup);
+// Script.scriptEnding.connect(cleanup);

--- a/examples/painting/whiteboard/whiteboardSpawner.js
+++ b/examples/painting/whiteboard/whiteboardSpawner.js
@@ -15,7 +15,7 @@
 /*global hexToRgb */
 
 Script.include("../../libraries/utils.js");
-var scriptURL = Script.resolvePath("whiteboardEntityScript.js";
+var scriptURL = Script.resolvePath("whiteboardEntityScript.js");
 var modelURL = "https://s3.amazonaws.com/hifi-public/eric/models/whiteboard.fbx";
 
 var colorIndicatorBorderModelURL = "https://s3.amazonaws.com/hifi-public/eric/models/colorIndicatorBorder.fbx";

--- a/examples/painting/whiteboard/whiteboardSpawner.js
+++ b/examples/painting/whiteboard/whiteboardSpawner.js
@@ -15,7 +15,7 @@
 /*global hexToRgb */
 
 Script.include("../../libraries/utils.js");
-var scriptURL = Script.resolvePath("whiteboardEntityScript.js");
+var scriptURL = Script.resolvePath("whiteboardEntityScript.js?v1" + Math.random());
 var modelURL = "https://s3.amazonaws.com/hifi-public/eric/models/whiteboard.fbx";
 
 var colorIndicatorBorderModelURL = "https://s3.amazonaws.com/hifi-public/eric/models/colorIndicatorBorder.fbx";
@@ -247,4 +247,4 @@ function cleanup() {
 
 
 // Uncomment this line to delete whiteboard and all associated entity on script close
-//Script.scriptEnding.connect(cleanup);
+Script.scriptEnding.connect(cleanup);

--- a/examples/rayPickingFilterExample.js
+++ b/examples/rayPickingFilterExample.js
@@ -1,50 +1,72 @@
-    var center = Vec3.sum(MyAvatar.position, Vec3.multiply(3, Quat.getFront(Camera.getOrientation())));
-
-    var whiteListBox = Entities.addEntity({
-        type: "Box",
-        color: {
-            red: 10,
-            green: 200,
-            blue: 10
-        },
-        dimensions: {
-            x: .2,
-            y: .2,
-            z: .2
-        },
-        position: center
-    });
-
-    var blackListBox = Entities.addEntity({
-        type: "Box",
-        color: {
-            red: 100,
-            green: 10,
-            blue: 10
-        },
-        dimensions: {
-            x: .2,
-            y: .2,
-            z: .2
-        },
-        position: Vec3.sum(center, {x: 0, y: .3, z: 0})
-    });
+   //
+   //  rayPickingFilterExample.js
+   //  examples
+   //
+   //  Created by Eric Levin on 12/24/2015
+   //  Copyright 2015 High Fidelity, Inc.
+   //
+   //  This is an example script that demonstrates the use of filtering entities for ray picking
+   //
+   //  Distributed under the Apache License, Version 2.0.
+   //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+   //
 
 
-    function castRay(event) {
-        var pickRay = Camera.computePickRay(event.x, event.y);
-        var pickResults = Entities.findRayIntersection(pickRay, true, [], [blackListBox]);
+   var center = Vec3.sum(MyAvatar.position, Vec3.multiply(3, Quat.getFront(Camera.getOrientation())));
 
-        if(pickResults.intersects) {
-            print("INTERSECTION");
-        }
+   var whiteListBox = Entities.addEntity({
+       type: "Box",
+       color: {
+           red: 10,
+           green: 200,
+           blue: 10
+       },
+       dimensions: {
+           x: 0.2,
+           y: 0.2,
+           z: 0.2
+       },
+       position: center
+   });
 
-    }
+   var blackListBox = Entities.addEntity({
+       type: "Box",
+       color: {
+           red: 100,
+           green: 10,
+           blue: 10
+       },
+       dimensions: {
+           x: 0.2,
+           y: 0.2,
+           z: 0.2
+       },
+       position: Vec3.sum(center, {
+           x: 0,
+           y: 0.3,
+           z: 0
+       })
+   });
 
-    function cleanup() {
-        Entities.deleteEntity(whiteListBox);
-        Entities.deleteEntity(blackListBox);
-    }
 
-    Script.scriptEnding.connect(cleanup);
-    Controller.mousePressEvent.connect(castRay);
+   function castRay(event) {
+       var pickRay = Camera.computePickRay(event.x, event.y);
+       // In this example every entity will be pickable except the entities in the blacklist array
+       // the third arg is the whitelist array,a nd the fourth and final is the blacklist array
+       var pickResults = Entities.findRayIntersection(pickRay, true, [], [blackListBox]);
+       // With below example, only entities adde dto whitelist will be pickable
+       // var pickResults = Entities.findRayIntersection(pickRay, true, [whiteListBox], []);
+
+       if (pickResults.intersects) {
+           print("INTERSECTION!");
+       }
+
+   }
+
+   function cleanup() {
+       Entities.deleteEntity(whiteListBox);
+       Entities.deleteEntity(blackListBox);
+   }
+
+   Script.scriptEnding.connect(cleanup);
+   Controller.mousePressEvent.connect(castRay);

--- a/examples/rayPickingFilterExample.js
+++ b/examples/rayPickingFilterExample.js
@@ -1,0 +1,50 @@
+    var center = Vec3.sum(MyAvatar.position, Vec3.multiply(3, Quat.getFront(Camera.getOrientation())));
+
+    var whiteListBox = Entities.addEntity({
+        type: "Box",
+        color: {
+            red: 10,
+            green: 200,
+            blue: 10
+        },
+        dimensions: {
+            x: .2,
+            y: .2,
+            z: .2
+        },
+        position: center
+    });
+
+    var blackListBox = Entities.addEntity({
+        type: "Box",
+        color: {
+            red: 100,
+            green: 10,
+            blue: 10
+        },
+        dimensions: {
+            x: .2,
+            y: .2,
+            z: .2
+        },
+        position: Vec3.sum(center, {x: 0, y: .3, z: 0})
+    });
+
+
+    function castRay(event) {
+        var pickRay = Camera.computePickRay(event.x, event.y);
+        var pickResults = Entities.findRayIntersection(pickRay, true, [whiteListBox]);
+
+        if(pickResults.intersects) {
+            print("INTERSECTION");
+        }
+
+    }
+
+    function cleanup() {
+        Entities.deleteEntity(whiteListBox);
+        Entities.deleteEntity(blackListBox);
+    }
+
+    Script.scriptEnding.connect(cleanup);
+    Controller.mousePressEvent.connect(castRay);

--- a/examples/rayPickingFilterExample.js
+++ b/examples/rayPickingFilterExample.js
@@ -52,9 +52,10 @@
    function castRay(event) {
        var pickRay = Camera.computePickRay(event.x, event.y);
        // In this example every entity will be pickable except the entities in the blacklist array
-       // the third arg is the whitelist array,a nd the fourth and final is the blacklist array
+       // the third argument is the whitelist array,and the fourth and final is the blacklist array
        var pickResults = Entities.findRayIntersection(pickRay, true, [], [blackListBox]);
-       // With below example, only entities adde dto whitelist will be pickable
+       
+       // With below example, only entities added to whitelist will be pickable
        // var pickResults = Entities.findRayIntersection(pickRay, true, [whiteListBox], []);
 
        if (pickResults.intersects) {

--- a/examples/rayPickingFilterExample.js
+++ b/examples/rayPickingFilterExample.js
@@ -33,7 +33,7 @@
 
     function castRay(event) {
         var pickRay = Camera.computePickRay(event.x, event.y);
-        var pickResults = Entities.findRayIntersection(pickRay, true, [whiteListBox]);
+        var pickResults = Entities.findRayIntersection(pickRay, true, [], [blackListBox]);
 
         if(pickResults.intersects) {
             print("INTERSECTION");

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -487,7 +487,8 @@ void EntityTreeRenderer::deleteReleasedModels() {
 }
 
 RayToEntityIntersectionResult EntityTreeRenderer::findRayIntersectionWorker(const PickRay& ray, Octree::lockType lockType,
-                                                                                    bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude) {
+                                                                                    bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude,
+                                                                                    const QVector<EntityItemID>& entityIdsToDiscard) {
     RayToEntityIntersectionResult result;
     if (_tree) {
         EntityTreePointer entityTree = std::static_pointer_cast<EntityTree>(_tree);
@@ -495,7 +496,7 @@ RayToEntityIntersectionResult EntityTreeRenderer::findRayIntersectionWorker(cons
         OctreeElementPointer element;
         EntityItemPointer intersectedEntity = NULL;
         result.intersects = entityTree->findRayIntersection(ray.origin, ray.direction, element, result.distance, 
-                                                            result.face, result.surfaceNormal, entityIdsToInclude,
+                                                            result.face, result.surfaceNormal, entityIdsToInclude, entityIdsToDiscard,
                                                             (void**)&intersectedEntity, lockType, &result.accurate,
                                                             precisionPicking);
         if (result.intersects && intersectedEntity) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -130,7 +130,8 @@ private:
 
     QList<Model*> _releasedModels;
     RayToEntityIntersectionResult findRayIntersectionWorker(const PickRay& ray, Octree::lockType lockType,
-                                                                bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude = QVector<EntityItemID>());
+                                                                bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude = QVector<EntityItemID>(),
+                                                                const QVector<EntityItemID>& entityIdsToDiscard = QVector<EntityItemID>());
 
     EntityItemID _currentHoverOverEntityID;
     EntityItemID _currentClickingOnEntityID;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -357,19 +357,21 @@ QVector<QUuid> EntityScriptingInterface::findEntitiesInBox(const glm::vec3& corn
     return result;
 }
 
-RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersection(const PickRay& ray, bool precisionPicking, const QScriptValue& entityIdsToInclude) {
-    QVector<EntityItemID> entities = qVectorEntityItemIDFromScriptValue(entityIdsToInclude);
-    return findRayIntersectionWorker(ray, Octree::TryLock, precisionPicking, entities);
+RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersection(const PickRay& ray, bool precisionPicking, const QScriptValue& entityIdsToInclude, const QScriptValue& entityIdsToDiscard) {
+    QVector<EntityItemID> entitiesToInclude = qVectorEntityItemIDFromScriptValue(entityIdsToInclude);
+    QVector<EntityItemID> entitiesToDiscard = qVectorEntityItemIDFromScriptValue(entityIdsToDiscard);
+    return findRayIntersectionWorker(ray, Octree::TryLock, precisionPicking, entitiesToInclude, entitiesToDiscard);
 }
 
-RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersectionBlocking(const PickRay& ray, bool precisionPicking, const QScriptValue& entityIdsToInclude) {
-    const QVector<EntityItemID>& entities = qVectorEntityItemIDFromScriptValue(entityIdsToInclude);
-    return findRayIntersectionWorker(ray, Octree::Lock, precisionPicking, entities);
+RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersectionBlocking(const PickRay& ray, bool precisionPicking, const QScriptValue& entityIdsToInclude, const QScriptValue& entityIdsToDiscard) {
+    const QVector<EntityItemID>& entitiesToInclude = qVectorEntityItemIDFromScriptValue(entityIdsToInclude);
+    const QVector<EntityItemID> entitiesToDiscard = qVectorEntityItemIDFromScriptValue(entityIdsToDiscard);
+    return findRayIntersectionWorker(ray, Octree::Lock, precisionPicking, entitiesToInclude, entitiesToDiscard);
 }
 
 RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersectionWorker(const PickRay& ray,
                                                                                     Octree::lockType lockType,
-                                                                                    bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude) {
+                                                                                    bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude, const QVector<EntityItemID>& entityIdsToDiscard) {
 
 
     RayToEntityIntersectionResult result;
@@ -377,7 +379,7 @@ RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersectionWorke
         OctreeElementPointer element;
         EntityItemPointer intersectedEntity = NULL;
         result.intersects = _entityTree->findRayIntersection(ray.origin, ray.direction, element, result.distance, result.face,
-                                                                result.surfaceNormal, entityIdsToInclude, (void**)&intersectedEntity, lockType, &result.accurate,
+            result.surfaceNormal, entityIdsToInclude, entityIdsToDiscard, (void**)&intersectedEntity, lockType, &result.accurate,
                                                                 precisionPicking);
         if (result.intersects && intersectedEntity) {
             result.entityID = intersectedEntity->getEntityItemID();

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -112,11 +112,11 @@ public slots:
     /// If the scripting context has visible entities, this will determine a ray intersection, the results
     /// may be inaccurate if the engine is unable to access the visible entities, in which case result.accurate
     /// will be false.
-    Q_INVOKABLE RayToEntityIntersectionResult findRayIntersection(const PickRay& ray, bool precisionPicking = false, const QScriptValue& entityIdsToInclude = QScriptValue());
+    Q_INVOKABLE RayToEntityIntersectionResult findRayIntersection(const PickRay& ray, bool precisionPicking = false, const QScriptValue& entityIdsToInclude = QScriptValue(), const QScriptValue& entityIdsToDiscard = QScriptValue());
 
     /// If the scripting context has visible entities, this will determine a ray intersection, and will block in
     /// order to return an accurate result
-    Q_INVOKABLE RayToEntityIntersectionResult findRayIntersectionBlocking(const PickRay& ray, bool precisionPicking = false, const QScriptValue& entityIdsToInclude = QScriptValue());
+    Q_INVOKABLE RayToEntityIntersectionResult findRayIntersectionBlocking(const PickRay& ray, bool precisionPicking = false, const QScriptValue& entityIdsToInclude = QScriptValue(), const QScriptValue& entityIdsToDiscard = QScriptValue());
 
     Q_INVOKABLE void setLightsArePickable(bool value);
     Q_INVOKABLE bool getLightsArePickable() const;
@@ -189,7 +189,7 @@ private:
 
     /// actually does the work of finding the ray intersection, can be called in locking mode or tryLock mode
     RayToEntityIntersectionResult findRayIntersectionWorker(const PickRay& ray, Octree::lockType lockType,
-                                                            bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude);
+        bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude, const QVector<EntityItemID>& entityIdsToDiscard);
 
     EntityTreePointer _entityTree;
     EntitiesScriptEngineProvider* _entitiesScriptEngine = nullptr;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -498,6 +498,7 @@ public:
     BoxFace& face;
     glm::vec3& surfaceNormal;
     const QVector<EntityItemID>& entityIdsToInclude;
+    const QVector<EntityItemID>& entityIdsToDiscard;
     void** intersectedObject;
     bool found;
     bool precisionPicking;
@@ -510,7 +511,7 @@ bool findRayIntersectionOp(OctreeElementPointer element, void* extraData) {
     EntityTreeElementPointer entityTreeElementPointer = std::dynamic_pointer_cast<EntityTreeElement>(element);
     if (entityTreeElementPointer ->findRayIntersection(args->origin, args->direction, keepSearching,
         args->element, args->distance, args->face, args->surfaceNormal, args->entityIdsToInclude,
-        args->intersectedObject, args->precisionPicking)) {
+        args->entityIdsToDiscard, args->intersectedObject, args->precisionPicking)) {
         args->found = true;
     }
     return keepSearching;
@@ -518,9 +519,9 @@ bool findRayIntersectionOp(OctreeElementPointer element, void* extraData) {
 
 bool EntityTree::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
                                     OctreeElementPointer& element, float& distance, 
-                                    BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude, void** intersectedObject,
+                                    BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude, const QVector<EntityItemID>& entityIdsToDiscard, void** intersectedObject,
                                     Octree::lockType lockType, bool* accurateResult, bool precisionPicking) {
-    RayArgs args = { origin, direction, element, distance, face, surfaceNormal, entityIdsToInclude, intersectedObject, false, precisionPicking };
+    RayArgs args = { origin, direction, element, distance, face, surfaceNormal, entityIdsToInclude, entityIdsToDiscard, intersectedObject, false, precisionPicking };
     distance = FLT_MAX;
 
     bool requireLock = lockType == Octree::Lock;

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -84,6 +84,7 @@ public:
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
         OctreeElementPointer& node, float& distance, BoxFace& face, glm::vec3& surfaceNormal,
         const QVector<EntityItemID>& entityIdsToInclude = QVector<EntityItemID>(),
+        const QVector<EntityItemID>& entityIdsToDiscard = QVector<EntityItemID>(),
         void** intersectedObject = NULL,
         Octree::lockType lockType = Octree::TryLock,
         bool* accurateResult = NULL,

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -522,7 +522,7 @@ bool EntityTreeElement::findDetailedRayIntersection(const glm::vec3& origin, con
     int entityNumber = 0;
     bool somethingIntersected = false;
     forEachEntity([&](EntityItemPointer entity) {
-        if (entityIdsToInclude.size() > 0 && !entityIdsToInclude.contains(entity->getID())) {
+        if ( (entityIdsToInclude.size() > 0 && !entityIdsToInclude.contains(entity->getID())) || (entityIDsToDiscard.size() > 0 && entityIDsToDiscard.contains(entity->getID())) ) {
             return;
         }
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -475,8 +475,8 @@ bool EntityTreeElement::bestFitBounds(const glm::vec3& minPoint, const glm::vec3
 
 bool EntityTreeElement::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
     bool& keepSearching, OctreeElementPointer& element, float& distance,
-    BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
-    void** intersectedObject, bool precisionPicking) {
+    BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude, 
+    const QVector<EntityItemID>& entityIdsToDiscard, void** intersectedObject, bool precisionPicking) {
 
     keepSearching = true; // assume that we will continue searching after this.
 
@@ -501,7 +501,7 @@ bool EntityTreeElement::findRayIntersection(const glm::vec3& origin, const glm::
     if (_cube.contains(origin) || distanceToElementCube < distance) {
 
         if (findDetailedRayIntersection(origin, direction, keepSearching, element, distanceToElementDetails,
-            face, localSurfaceNormal, entityIdsToInclude, intersectedObject, precisionPicking, distanceToElementCube)) {
+            face, localSurfaceNormal, entityIdsToInclude, entityIdsToDiscard, intersectedObject, precisionPicking, distanceToElementCube)) {
 
             if (distanceToElementDetails < distance) {
                 distance = distanceToElementDetails;
@@ -516,7 +516,7 @@ bool EntityTreeElement::findRayIntersection(const glm::vec3& origin, const glm::
 
 bool EntityTreeElement::findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction, bool& keepSearching,
                                     OctreeElementPointer& element, float& distance, BoxFace& face, glm::vec3& surfaceNormal,
-                                    const QVector<EntityItemID>& entityIdsToInclude, void** intersectedObject, bool precisionPicking, float distanceToElementCube) {
+                                    const QVector<EntityItemID>& entityIdsToInclude, const QVector<EntityItemID>& entityIDsToDiscard, void** intersectedObject, bool precisionPicking, float distanceToElementCube) {
 
     // only called if we do intersect our bounding cube, but find if we actually intersect with entities...
     int entityNumber = 0;

--- a/libraries/entities/src/EntityTreeElement.h
+++ b/libraries/entities/src/EntityTreeElement.h
@@ -144,11 +144,13 @@ public:
     virtual bool canRayIntersect() const { return hasEntities(); }
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
         bool& keepSearching, OctreeElementPointer& node, float& distance,
-        BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
+        BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude, 
+        const QVector<EntityItemID>& entityIdsToDiscard,
         void** intersectedObject = NULL, bool precisionPicking = false);
     virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
                          bool& keepSearching, OctreeElementPointer& element, float& distance, 
                          BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
+                         const QVector<EntityItemID>& entityIdsToDiscard,
                          void** intersectedObject, bool precisionPicking, float distanceToElementCube);
     virtual bool findSpherePenetration(const glm::vec3& center, float radius,
                         glm::vec3& penetration, void** penetratedObject) const;


### PR DESCRIPTION
This PR adds support for filtering out, or blacklisting, entities that one does not wish to be included in a ray pick. One example of how this may be used will be for creating collaborative, in-world UIs, where the content-creator wishes to create a semi-transparent panel to back the UI components visible to all users, but does not want such a panel to get in the way of users distance grabbing, or shooting, or interacting in any other way with objects behind that panel.