### PR TITLE
Add Raypick Blacklisting to handControllerGrab.js

### DIFF
--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -116,6 +116,11 @@ var DEFAULT_GRABBABLE_DATA = {
     invertSolidWhileHeld: false
 };
 
+
+// sometimes we want to exclude objects from being picked
+var USE_BLACKLIST = true;
+var blacklist = [];
+
 //we've created various ways of visualizing looking for and moving distant objects
 var USE_ENTITY_LINES_FOR_SEARCHING = false;
 var USE_OVERLAY_LINES_FOR_SEARCHING = false;
@@ -771,7 +776,14 @@ function MyController(hand) {
                 })
             }
 
-            var intersection = Entities.findRayIntersection(pickRayBacked, true);
+            var intersection;
+            
+            if(USE_BLACKLIST===true){
+             intersection = Entities.findRayIntersection(pickRay, true, [], blacklist);
+            }
+            else{
+             intersection = Entities.findRayIntersection(pickRayBacked, true);
+            }
 
             if (intersection.intersects) {
                 // the ray is intersecting something we can move.
@@ -1626,6 +1638,7 @@ function update() {
 
 Messages.subscribe('Hifi-Hand-Disabler');
 Messages.subscribe('Hifi-Hand-Grab');
+Messages.subscribe('Hifi-Hand-RayPick-Blacklist');
 
 handleHandMessages = function(channel, message, sender) {
     if (sender === MyAvatar.sessionUUID) {
@@ -1648,6 +1661,24 @@ handleHandMessages = function(channel, message, sender) {
                  selectedController.grabbedEntity = data.entityID;
                  
             } catch (e) { }
+        }
+        else if (channel === 'Hifi-Hand-RayPick-Blacklist') {
+            try {
+                var data = JSON.parse(message);
+                var action = data.action;
+                var id = data.id;
+                var index = blacklist.indexOf(id);
+         
+                if (action === 'add' && index ===-1) {
+                    blacklist.push(id);
+                }
+                if (action === 'remove') {
+                    if (index > -1) {
+                        blacklist.splice(index, 1);
+                    }
+                }
+
+            } catch (e) {}
         }
     }
 }

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -777,7 +777,7 @@ function MyController(hand) {
             }
 
             var intersection;
-            
+
             if(USE_BLACKLIST===true){
              intersection = Entities.findRayIntersection(pickRay, true, [], blacklist);
             }
@@ -1662,7 +1662,7 @@ handleHandMessages = function(channel, message, sender) {
                  
             } catch (e) { }
         }
-        else if (channel === 'Hifi-Hand-RayPick-Blacklist') {
+        else if (channel === 'Hifi-Hand-RayPick-Blacklist' && sender === MyAvatar.sessionUUID) {
             try {
                 var data = JSON.parse(message);
                 var action = data.action;

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -778,13 +778,12 @@ function MyController(hand) {
 
             var intersection;
 
-            if(USE_BLACKLIST===true){
-             intersection = Entities.findRayIntersection(pickRay, true, [], blacklist);
+            if (USE_BLACKLIST === true && blacklist.length !== 0) {
+                intersection = Entities.findRayIntersection(pickRay, true, [], blacklist);
+            } else {
+                intersection = Entities.findRayIntersection(pickRayBacked, true);
             }
-            else{
-             intersection = Entities.findRayIntersection(pickRayBacked, true);
-            }
-
+            
             if (intersection.intersects) {
                 // the ray is intersecting something we can move.
                 var intersectionDistance = Vec3.distance(pickRay.origin, intersection.intersection);


### PR DESCRIPTION
This PR adds the ability to add/remove items from the blacklist for raypicking during the search for things to grab.  Simply send a message with the ID of the entity you wish to add/remove from the blacklist, along with the action.  Items on the blacklist will not only be ungrabbable, but your search beams will go through blacklist items and grab whatever is behind / inside of them.

```var data = {action:'add', id:'55e967b9-ebea-430a-bd58-d4c44816beb2' };```
``` Messages.sendMessage ('Hifi-Hand-RayPick-Blacklist',JSON.stringify(data))```

```var data = {action:'remove', id:'55e967b9-ebea-430a-bd58-d4c44816beb2' };```
``` Messages.sendMessage ('Hifi-Hand-RayPick-Blacklist',JSON.stringify(data))```