### PR TITLE
Guard against unloaded skymap tex

### DIFF
--- a/libraries/model/src/model/Skybox.cpp
+++ b/libraries/model/src/model/Skybox.cpp
@@ -96,7 +96,12 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
         }
     });
 
+
     // Render
+    gpu::TexturePointer skymap = skybox.getCubemap();
+    // FIXME: skymap->isDefined may not be threadsafe
+    assert(skymap && skymap->isDefined());
+
     glm::mat4 projMat;
     viewFrustum.evalProjectionMatrix(projMat);
 
@@ -106,11 +111,6 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
     batch.setViewTransform(viewTransform);
     batch.setModelTransform(Transform()); // only for Mac
 
-    gpu::TexturePointer skymap;
-    if (skybox.getCubemap() && skybox.getCubemap()->isDefined()) {
-        skymap = skybox.getCubemap();
-    }
-
     batch.setPipeline(thePipeline);
     batch.setUniformBuffer(SKYBOX_CONSTANTS_SLOT, skybox._dataBuffer);
     batch.setResourceTexture(SKYBOX_SKYMAP_SLOT, skymap);
@@ -118,6 +118,5 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
     batch.draw(gpu::TRIANGLE_STRIP, 4);
 
     batch.setResourceTexture(SKYBOX_SKYMAP_SLOT, nullptr);
-
 }
 

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -48,6 +48,10 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
     }
 
     if (skybox._procedural && skybox._procedural->_enabled && skybox._procedural->ready()) {
+        gpu::TexturePointer skymap = skybox.getCubemap();
+        // FIXME: skymap->isDefined may not be threadsafe
+        assert(skymap && skymap->isDefined());
+
         glm::mat4 projMat;
         viewFrustum.evalProjectionMatrix(projMat);
 
@@ -56,10 +60,7 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewTransform);
         batch.setModelTransform(Transform()); // only for Mac
-
-        if (skybox.getCubemap() && skybox.getCubemap()->isDefined()) {
-            batch.setResourceTexture(0, skybox.getCubemap());
-        }
+        batch.setResourceTexture(0, skybox.getCubemap());
 
         skybox._procedural->prepare(batch, glm::vec3(0), glm::vec3(1));
         batch.draw(gpu::TRIANGLE_STRIP, 4);


### PR DESCRIPTION
Note that the skybox will *not* load because you move - it will just load when the texture is loaded. This fix just changes the "limbo" screen from black (an uninitialized texture) to the starscape.