### PR TITLE
Added tests for GLMHelpers::safeEulerAngles.

### DIFF
--- a/tests/shared/src/GLMHelpersTests.cpp
+++ b/tests/shared/src/GLMHelpersTests.cpp
@@ -1,0 +1,57 @@
+//
+//  GLMHelpersTests.cpp
+//  tests/shared/src
+//
+//  Created by Anthony Thibault on 2015.12.29
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "GLMHelpersTests.h"
+
+#include <NumericalConstants.h>
+#include <StreamUtils.h>
+
+#include <../QTestExtensions.h>
+
+
+QTEST_MAIN(GLMHelpersTests)
+
+void GLMHelpersTests::testEulerDecomposition() {
+    // quat to euler and back again....
+
+    const glm::quat ROT_X_90 = glm::angleAxis(PI / 2.0f, glm::vec3(1.0f, 0.0f, 0.0f));
+    const glm::quat ROT_Y_180 = glm::angleAxis(PI, glm::vec3(0.0f, 1.0, 0.0f));
+    const glm::quat ROT_Z_30 = glm::angleAxis(PI / 6.0f, glm::vec3(1.0f, 0.0f, 0.0f));
+
+    const float EPSILON = 0.00001f;
+
+    std::vector<glm::quat> quatVec = {
+        glm::quat(),
+        ROT_X_90,
+        ROT_Y_180,
+        ROT_Z_30,
+        ROT_X_90 * ROT_Y_180 * ROT_Z_30,
+        ROT_X_90 * ROT_Z_30 * ROT_Y_180,
+        ROT_Y_180 * ROT_Z_30 * ROT_X_90,
+        ROT_Y_180 * ROT_X_90 * ROT_Z_30,
+        ROT_Z_30 * ROT_X_90 * ROT_Y_180,
+        ROT_Z_30 * ROT_Y_180 * ROT_X_90,
+    };
+
+    for (auto& q : quatVec) {
+        glm::vec3 euler = safeEulerAngles(q);
+        glm::quat r(euler);
+
+        // when the axis and angle are flipped.
+        if (glm::dot(q, r) < 0.0f) {
+            r = -r;
+        }
+
+        QCOMPARE_WITH_ABS_ERROR(q, r, EPSILON);
+    }
+}
+
+

--- a/tests/shared/src/GLMHelpersTests.h
+++ b/tests/shared/src/GLMHelpersTests.h
@@ -1,0 +1,27 @@
+//
+//  GLMHelpersTests.h
+//  tests/shared/src
+//
+//  Created by Anthony thibault on 2015.12.29
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_GLMHelpersTests_h
+#define hifi_GLMHelpersTests_h
+
+#include <QtTest/QtTest>
+#include <GLMHelpers.h>
+
+class GLMHelpersTests : public QObject {
+    Q_OBJECT
+private slots:
+    void testEulerDecomposition();
+};
+
+float getErrorDifference(const float& a, const float& b);
+float getErrorDifference(const glm::vec3& a, const glm::vec3& b);
+
+#endif // hifi_GLMHelpersTest_h

--- a/tests/shared/src/GeometryUtilTests.cpp
+++ b/tests/shared/src/GeometryUtilTests.cpp
@@ -1,6 +1,6 @@
 //
 //  GeometryUtilTests.cpp
-//  tests/physics/src
+//  tests/shared/src
 //
 //  Created by Andrew Meadows on 2015.07.27
 //  Copyright 2015 High Fidelity, Inc.

--- a/tests/shared/src/GeometryUtilTests.h
+++ b/tests/shared/src/GeometryUtilTests.h
@@ -1,6 +1,6 @@
 //
 //  GeometryUtilTests.h
-//  tests/physics/src
+//  tests/shared/src
 //
 //  Created by Andrew Meadows on 2014.05.30
 //  Copyright 2014 High Fidelity, Inc.
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#ifndef hifi_AngularConstraintTests_h
-#define hifi_AngularConstraintTests_h
+#ifndef hifi_GeometryUtilTests_h
+#define hifi_GeometryUtilTests_h
 
 #include <QtTest/QtTest>
 #include <glm/glm.hpp>
@@ -26,4 +26,4 @@ private slots:
 float getErrorDifference(const float& a, const float& b);
 float getErrorDifference(const glm::vec3& a, const glm::vec3& b);
 
-#endif // hifi_AngularConstraintTests_h
+#endif // hifi_GeometryUtilTests_h


### PR DESCRIPTION
To verify that converting to and from quats and eulers will use the same angle order.

Also I fixed some naming inconsistencies in GeometryUtilTests.