### PR TITLE
Allow a script to set a resource override.

### DIFF
--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -30,6 +30,7 @@
 #include <SharedUtil.h>
 #include <ShutdownEventListener.h>
 #include <SoundCache.h>
+#include <ResourceScriptingInterface.h>
 
 #include "AssignmentFactory.h"
 #include "AssignmentActionFactory.h"
@@ -61,6 +62,7 @@ AssignmentClient::AssignmentClient(Assignment::Type requestAssignmentType, QStri
 
     DependencyManager::registerInheritance<EntityActionFactoryInterface, AssignmentActionFactory>();
     auto actionFactory = DependencyManager::set<AssignmentActionFactory>();
+    DependencyManager::set<ResourceScriptingInterface>();
 
     // setup a thread for the NodeList and its PacketReceiver
     QThread* nodeThread = new QThread(this);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -47,6 +47,7 @@
 #include <gl/Config.h>
 #include <gl/QOpenGLContextWrapper.h>
 
+#include <ResourceScriptingInterface.h>
 #include <AccountManager.h>
 #include <AddressManager.h>
 #include <ApplicationVersion.h>
@@ -337,6 +338,8 @@ bool setupEssentials(int& argc, char** argv) {
     DependencyManager::set<RecordingScriptingInterface>();
     DependencyManager::set<WindowScriptingInterface>();
     DependencyManager::set<HMDScriptingInterface>();
+    DependencyManager::set<ResourceScriptingInterface>();
+    
 
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     DependencyManager::set<SpeechRecognizer>();

--- a/libraries/networking/src/ResourceScriptingInterface.cpp
+++ b/libraries/networking/src/ResourceScriptingInterface.cpp
@@ -1,0 +1,15 @@
+//
+//  Created by Bradley Austin Davis on 2015/12/29
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ResourceScriptingInterface.h"
+
+#include "ResourceManager.h"
+
+void ResourceScriptingInterface::overrideUrlPrefix(const QString& prefix, const QString& replacement) {
+    ResourceManager::setUrlPrefixOverride(prefix, replacement);
+}

--- a/libraries/networking/src/ResourceScriptingInterface.h
+++ b/libraries/networking/src/ResourceScriptingInterface.h
@@ -1,0 +1,31 @@
+//
+//  AssetClient.h
+//  libraries/networking/src
+//
+//  Created by Ryan Huffman on 2015/07/21
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+
+#ifndef hifi_networking_ResourceScriptingInterface_h
+#define hifi_networking_ResourceScriptingInterface_h
+
+#include <QtCore/QObject>
+
+#include <DependencyManager.h>
+
+class ResourceScriptingInterface : public QObject, public Dependency {
+    Q_OBJECT
+public:
+    Q_INVOKABLE void overrideUrlPrefix(const QString& prefix, const QString& replacement);
+
+    Q_INVOKABLE void restoreUrlPrefix(const QString& prefix) {
+        overrideUrlPrefix(prefix, "");
+    }
+};
+
+
+#endif

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -26,6 +26,7 @@
 #include <EntityScriptingInterface.h>
 #include <MessagesClient.h>
 #include <NetworkAccessManager.h>
+#include <ResourceScriptingInterface.h>
 #include <NodeList.h>
 #include <udt/PacketHeaders.h>
 #include <UUID.h>
@@ -391,7 +392,7 @@ void ScriptEngine::init() {
     registerGlobalObject("Recording", recordingInterface.data());
 
     registerGlobalObject("Assets", &_assetScriptingInterface);
-
+    registerGlobalObject("Resources", DependencyManager::get<ResourceScriptingInterface>().data());
 }
 
 void ScriptEngine::registerValue(const QString& valueName, QScriptValue value) {


### PR DESCRIPTION
This allows a script to set a resource override path, allow rapid iteration of content development from locally hosted content without having to change the entity properties of the object(s) being developed.  

For instance, I can load a script with the following code

```
var publicPath = "https://s3.amazonaws.com/DreamingContent/";
var basePath = Script.resolvePath("..");
print("Base path " + basePath);
Resources.overrideUrlPrefix(publicPath, "file:///" + basePath);
```

and restart my client.  Now, all content that would normally be fetched from my S3 bucket will instead be loaded from my local disk, relative the parent folder of the script. This allows me to modify shaders and model files and rapidly see the results before pushing the finished content back to S3 for public consumption.  