### PR TITLE
ModelEntityItem: Fix for missing pre-rotations for animated models.

### DIFF
--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -252,9 +252,11 @@ void ModelEntityItem::getAnimationFrame(bool& newFrame,
                         if (index < translations.size()) {
                             translationMat = glm::translate(translations[index]);
                         }
-                        glm::mat4 rotationMat;
+                        glm::mat4 rotationMat(glm::mat4::_null);
                         if (index < rotations.size()) {
-                            rotationMat = glm::mat4_cast(rotations[index]);
+                            rotationMat = glm::mat4_cast(fbxJoints[index].preRotation * rotations[index] * fbxJoints[index].postRotation);
+                        } else {
+                            rotationMat = glm::mat4_cast(fbxJoints[index].preRotation * fbxJoints[index].postRotation);
                         }
                         glm::mat4 finalMat = (translationMat * fbxJoints[index].preTransform *
                                               rotationMat * fbxJoints[index].postTransform);


### PR DESCRIPTION
This should fix the issue with the Kaya and Claire models, while also not breaking the windmill model in demo.

To test: Add this model to the scene.

    https://hifi-public.s3.amazonaws.com/cozza13/apartment/kaya/Kaya.fbx

And apply this animation:

    https://hifi-public.s3.amazonaws.com/cozza13/apartment/kaya/Kaya%40t-pose_46.fbx
