### PR TITLE
Add Dynamic Lifetimes to Grab Beam Particle Systems

### DIFF
--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -1865,7 +1865,7 @@ Script.update.connect(update);
 // we can't create the search system on-demand since it takes some time for the particles to reach their entire length.  
 // thus the system cannot have a fixed lifetime.  this loop updates the lifetimes and will stop updating if a user crashes.
 
-if(USE_PARTICLE_BEAM_FOR_SEARCHING===true || USE_PARTICLE_BEAM_FOR_SEARCHING ===true){
+if(USE_PARTICLE_BEAM_FOR_SEARCHING===true || USE_PARTICLE_BEAM_FOR_MOVING ===true){
 Script.update.connect(renewParticleBeamLifetimes)
 }
 

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -577,7 +577,6 @@ function MyController(hand) {
         Entities.editEntity(this.particleBeam,{
             lifetime: TEMPORARY_PARTICLE_BEAM_LIFETIME + props.age // renew lifetime
         })
-        var lifetime = Entities.getEntityProperties(this.particleBeam,"lfietime").lifetime;
     }
 
     this.evalLightWorldTransform = function(modelPos, modelRot) {

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -1856,8 +1856,10 @@ function cleanup() {
     rightController.cleanup();
     leftController.cleanup();
     Controller.disableMapping(MAPPING_NAME);
+    if (USE_PARTICLE_BEAM_FOR_SEARCHING === true || USE_PARTICLE_BEAM_FOR_MOVING === true) {
+        Script.update.disconnect(renewParticleBeamLifetimes);
+    }
 }
-
 Script.scriptEnding.connect(cleanup);
 Script.update.connect(update);
 

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -56,7 +56,6 @@ var LINE_ENTITY_DIMENSIONS = {
 
 var LINE_LENGTH = 500;
 var PICK_MAX_DISTANCE = 500; // max length of pick-ray
-
 //
 // near grabbing
 //
@@ -129,6 +128,7 @@ var USE_PARTICLE_BEAM_FOR_SEARCHING = true;
 var USE_ENTITY_LINES_FOR_MOVING = false;
 var USE_OVERLAY_LINES_FOR_MOVING = false;
 var USE_PARTICLE_BEAM_FOR_MOVING = true;
+var TEMPORARY_PARTICLE_BEAM_LIFETIME = 30;
 
 var USE_SPOTLIGHT = false;
 var USE_POINTLIGHT = false;
@@ -548,6 +548,14 @@ function MyController(hand) {
         })
 
     };
+
+    this.renewParticleBeamLifetime = function(){
+        var props = Entities.getEntityProperties(this.particleBeam,"age");
+        Entities.editEntity(this.particleBeam,{
+            lifetime: TEMPORARY_PARTICLE_BEAM_LIFETIME + props.age // renew lifetime
+        })
+        var lifetime = Entities.getEntityProperties(this.particleBeam,"lfietime").lifetime;
+    }
 
     this.evalLightWorldTransform = function(modelPos, modelRot) {
 
@@ -1804,3 +1812,25 @@ function cleanup() {
 
 Script.scriptEnding.connect(cleanup);
 Script.update.connect(update);
+
+// particle systems can end up hanging around if a user crashes or something else causes controller cleanup not to get called. 
+// we can't create the search system on-demand since it takes some time for the particles to reach their entire length.  
+// thus the system cannot have a fixed lifetime.  this loop updates the lifetimes and will stop updating if a user crashes.
+
+if(USE_PARTICLE_BEAM_FOR_SEARCHING===true || USE_PARTICLE_BEAM_FOR_SEARCHING ===true){
+Script.update.connect(renewParticleBeamLifetimes)
+}
+
+var sinceLastParticleLifetimeUpdate = 0;
+
+function renewParticleBeamLifetimes(deltaTime) {
+    //debounce this call since we don't want it 60x a second
+    sinceLastParticleLifetimeUpdate = sinceLastParticleLifetimeUpdate + deltaTime;
+    if (sinceLastParticleLifetimeUpdate > TEMPORARY_PARTICLE_BEAM_LIFETIME - 10) {
+        sinceLastParticleLifetimeUpdate = 0;
+    } else {
+        return;
+    }
+    rightController.renewParticleBeamLifetime();
+    leftController.renewParticleBeamLifetime();
+}

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -1874,7 +1874,7 @@ var sinceLastParticleLifetimeUpdate = 0;
 function renewParticleBeamLifetimes(deltaTime) {
     //debounce this call since we don't want it 60x a second
     sinceLastParticleLifetimeUpdate = sinceLastParticleLifetimeUpdate + deltaTime;
-    if (sinceLastParticleLifetimeUpdate > TEMPORARY_PARTICLE_BEAM_LIFETIME - 10) {
+    if (sinceLastParticleLifetimeUpdate > TEMPORARY_PARTICLE_BEAM_LIFETIME - 2) {
         sinceLastParticleLifetimeUpdate = 0;
     } else {
         return;


### PR DESCRIPTION
This PR adds a dynamic lifetime to particle beam systems created by the grab script.  It's possible that when someone crashes, controller cleanup doesn't get called.  Fix for stranded particle systems in demo.