### PR TITLE
Fix SDL breakage due to missing init

### DIFF
--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -79,6 +79,7 @@ const DisplayPluginList& PluginManager::getDisplayPlugins() {
         auto& container = PluginContainer::getInstance();
         for (auto plugin : displayPlugins) {
             plugin->setContainer(&container);
+            plugin->init();
         }
 
     });
@@ -104,6 +105,7 @@ const InputPluginList& PluginManager::getInputPlugins() {
         auto& container = PluginContainer::getInstance();
         for (auto plugin : inputPlugins) {
             plugin->setContainer(&container);
+            plugin->init();
         }
     });
     return inputPlugins;


### PR DESCRIPTION
Missing plugin init function makes the SDL code not work