### PR TITLE
Optimize getVertexStream() by using a const&

### DIFF
--- a/libraries/model/src/model/Geometry.h
+++ b/libraries/model/src/model/Geometry.h
@@ -58,7 +58,7 @@ public:
     const gpu::Stream::FormatPointer getVertexFormat() const { return _vertexFormat; }
 
     // BufferStream on the mesh vertices and attributes matching the vertex format
-    const gpu::BufferStream getVertexStream() const { return _vertexStream; }
+    const gpu::BufferStream& getVertexStream() const { return _vertexStream; }
 
     // Index Buffer
     void setIndexBuffer(const BufferView& buffer);

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -819,8 +819,6 @@ model::MeshPointer DeferredLightingEffect::getSpotLightMesh() {
         //DEBUG: model::Mesh::Part part(0, indices, 0, model::Mesh::LINE_STRIP);
         
         _spotLightMesh->setPartBuffer(gpu::BufferView(new gpu::Buffer(sizeof(part), (gpu::Byte*) &part), gpu::Element::PART_DRAWCALL));
-
-        _spotLightMesh->getVertexStream();
     }
     return _spotLightMesh;
 }


### PR DESCRIPTION
Tony mentioned that this was a large vector copy when he was looking at performance.