### PR TITLE
more correct management of MotionState pointers

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -108,7 +108,13 @@ Avatar::Avatar(RigPointer rig) :
 }
 
 Avatar::~Avatar() {
-    assert(_motionState == nullptr);
+    for(auto attachment : _unusedAttachments) {
+        delete attachment;
+    }
+    if (_motionState) {
+        delete _motionState;
+        _motionState = nullptr;
+    }
 }
 
 const float BILLBOARD_LOD_DISTANCE = 40.0f;

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1,4 +1,4 @@
-/3/
+//
 //  Avatar.cpp
 //  interface/src/avatar
 //

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -109,9 +109,6 @@ Avatar::Avatar(RigPointer rig) :
 
 Avatar::~Avatar() {
     assert(isDead()); // mark dead before calling the dtor
-    for(auto attachment : _unusedAttachments) {
-        delete attachment;
-    }
     if (_motionState) {
         delete _motionState;
         _motionState = nullptr;

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1,4 +1,4 @@
-//
+/3/
 //  Avatar.cpp
 //  interface/src/avatar
 //
@@ -108,6 +108,7 @@ Avatar::Avatar(RigPointer rig) :
 }
 
 Avatar::~Avatar() {
+    assert(isDead()); // mark dead before calling the dtor
     for(auto attachment : _unusedAttachments) {
         delete attachment;
     }

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -215,6 +215,8 @@ void AvatarManager::removeAvatar(const QUuid& sessionUUID) {
 void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar) {
     AvatarHashMap::handleRemovedAvatar(removedAvatar);
 
+    // removedAvatar is a shared pointer to an AvatarData but we need to get to the derived Avatar
+    // class in this context so we can call methods that don't exist at the base class.
     Avatar* avatar = static_cast<Avatar*>(removedAvatar.get());
     avatar->die();
 

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -76,6 +76,10 @@ AvatarManager::AvatarManager(QObject* parent) :
     packetReceiver.registerListener(PacketType::AvatarBillboard, this, "processAvatarBillboardPacket");
 }
 
+AvatarManager::~AvatarManager() {
+    _myAvatar->die();
+}
+
 void AvatarManager::init() {
     _myAvatar->init();
     {

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -34,6 +34,8 @@ public:
     /// Registers the script types associated with the avatar manager.
     static void registerMetaTypes(QScriptEngine* engine);
 
+    virtual ~AvatarManager();
+
     void init();
 
     MyAvatar* getMyAvatar() { return _myAvatar.get(); }

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -59,8 +59,8 @@ public:
     Q_INVOKABLE AvatarData* getAvatar(QUuid avatarID);
 
 
-    void getObjectsToDelete(VectorOfMotionStates& motionStates);
-    void getObjectsToAdd(VectorOfMotionStates& motionStates);
+    void getObjectsToRemoveFromPhysics(VectorOfMotionStates& motionStates);
+    void getObjectsToAddToPhysics(VectorOfMotionStates& motionStates);
     void getObjectsToChange(VectorOfMotionStates& motionStates);
     void handleOutgoingChanges(const VectorOfMotionStates& motionStates);
     void handleCollisionEvents(const CollisionEvents& collisionEvents);
@@ -80,7 +80,6 @@ private:
     // virtual overrides
     virtual AvatarSharedPointer newSharedAvatar();
     virtual AvatarSharedPointer addAvatar(const QUuid& sessionUUID, const QWeakPointer<Node>& mixerWeakPointer);
-    void removeAvatarMotionState(AvatarSharedPointer avatar);
 
     virtual void removeAvatar(const QUuid& sessionUUID);
     virtual void handleRemovedAvatar(const AvatarSharedPointer& removedAvatar);
@@ -93,9 +92,9 @@ private:
 
     bool _shouldShowReceiveStats = false;
 
-    SetOfAvatarMotionStates _avatarMotionStates;
-    SetOfMotionStates _motionStatesToAdd;
-    VectorOfMotionStates _motionStatesToDelete;
+    SetOfAvatarMotionStates _motionStatesThatMightUpdate;
+    SetOfMotionStates _motionStatesToAddToPhysics;
+    VectorOfMotionStates _motionStatesToRemoveFromPhysics;
 };
 
 Q_DECLARE_METATYPE(AvatarManager::LocalLight)

--- a/interface/src/avatar/AvatarMotionState.cpp
+++ b/interface/src/avatar/AvatarMotionState.cpp
@@ -143,7 +143,7 @@ QUuid AvatarMotionState::getSimulatorID() const {
 }
 
 // virtual
-int16_t AvatarMotionState::computeCollisionGroup() {
+int16_t AvatarMotionState::computeCollisionGroup() const {
     return COLLISION_GROUP_OTHER_AVATAR;
 }
 

--- a/interface/src/avatar/AvatarMotionState.cpp
+++ b/interface/src/avatar/AvatarMotionState.cpp
@@ -25,20 +25,17 @@ AvatarMotionState::AvatarMotionState(Avatar* avatar, btCollisionShape* shape) : 
 }
 
 AvatarMotionState::~AvatarMotionState() {
+    assert(_avatar);
     _avatar = nullptr;
 }
 
 // virtual
 uint32_t AvatarMotionState::getIncomingDirtyFlags() {
-    uint32_t dirtyFlags = 0;
-    if (_body && _avatar) {
-        dirtyFlags = _dirtyFlags;
-    }
-    return dirtyFlags;
+    return _body ? _dirtyFlags : 0;
 }
 
 void AvatarMotionState::clearIncomingDirtyFlags() {
-    if (_body && _avatar) {
+    if (_body) {
         _dirtyFlags = 0;
     }
 }
@@ -50,12 +47,9 @@ MotionType AvatarMotionState::computeObjectMotionType() const {
 
 // virtual and protected
 btCollisionShape* AvatarMotionState::computeNewShape() {
-    if (_avatar) {
-        ShapeInfo shapeInfo;
-        _avatar->computeShapeInfo(shapeInfo);
-        return getShapeManager()->getShape(shapeInfo);
-    }
-    return nullptr;
+    ShapeInfo shapeInfo;
+    _avatar->computeShapeInfo(shapeInfo);
+    return getShapeManager()->getShape(shapeInfo);
 }
 
 // virtual
@@ -65,9 +59,6 @@ bool AvatarMotionState::isMoving() const {
 
 // virtual
 void AvatarMotionState::getWorldTransform(btTransform& worldTrans) const {
-    if (!_avatar) {
-        return;
-    }
     worldTrans.setOrigin(glmToBullet(getObjectPosition()));
     worldTrans.setRotation(glmToBullet(getObjectRotation()));
     if (_body) {
@@ -78,9 +69,6 @@ void AvatarMotionState::getWorldTransform(btTransform& worldTrans) const {
 
 // virtual
 void AvatarMotionState::setWorldTransform(const btTransform& worldTrans) {
-    if (!_avatar) {
-        return;
-    }
     // HACK: The PhysicsEngine does not actually move OTHER avatars -- instead it slaves their local RigidBody to the transform
     // as specified by a remote simulation.  However, to give the remote simulation time to respond to our own objects we tie
     // the other avatar's body to its true position with a simple spring. This is a HACK that will have to be improved later.
@@ -158,11 +146,4 @@ QUuid AvatarMotionState::getSimulatorID() const {
 int16_t AvatarMotionState::computeCollisionGroup() {
     return COLLISION_GROUP_OTHER_AVATAR;
 }
-
-// virtual
-void AvatarMotionState::clearObjectBackPointer() {
-    ObjectMotionState::clearObjectBackPointer();
-    _avatar = nullptr;
-}
-
 

--- a/interface/src/avatar/AvatarMotionState.cpp
+++ b/interface/src/avatar/AvatarMotionState.cpp
@@ -76,7 +76,7 @@ void AvatarMotionState::getWorldTransform(btTransform& worldTrans) const {
     }
 }
 
-// virtual 
+// virtual
 void AvatarMotionState::setWorldTransform(const btTransform& worldTrans) {
     if (!_avatar) {
         return;
@@ -154,12 +154,12 @@ QUuid AvatarMotionState::getSimulatorID() const {
     return _avatar->getSessionUUID();
 }
 
-// virtual 
+// virtual
 int16_t AvatarMotionState::computeCollisionGroup() {
     return COLLISION_GROUP_OTHER_AVATAR;
 }
 
-// virtual 
+// virtual
 void AvatarMotionState::clearObjectBackPointer() {
     ObjectMotionState::clearObjectBackPointer();
     _avatar = nullptr;

--- a/interface/src/avatar/AvatarMotionState.h
+++ b/interface/src/avatar/AvatarMotionState.h
@@ -68,8 +68,7 @@ public:
 protected:
     virtual bool isReadyToComputeShape() { return true; }
     virtual btCollisionShape* computeNewShape();
-    virtual void clearObjectBackPointer();
-    Avatar* _avatar;
+    Avatar* _avatar; // do NOT use smartpointer here
     uint32_t _dirtyFlags;
 };
 

--- a/interface/src/avatar/AvatarMotionState.h
+++ b/interface/src/avatar/AvatarMotionState.h
@@ -21,54 +21,65 @@ class Avatar;
 class AvatarMotionState : public ObjectMotionState {
 public:
     AvatarMotionState(Avatar* avatar, btCollisionShape* shape);
-    ~AvatarMotionState();
 
-    virtual MotionType getMotionType() const { return _motionType; }
+    virtual MotionType getMotionType() const override { return _motionType; }
 
-    virtual uint32_t getIncomingDirtyFlags();
-    virtual void clearIncomingDirtyFlags();
+    virtual uint32_t getIncomingDirtyFlags() override;
+    virtual void clearIncomingDirtyFlags() override;
 
-    virtual MotionType computeObjectMotionType() const;
+    virtual MotionType computeObjectMotionType() const override;
 
-    virtual bool isMoving() const;
+    virtual bool isMoving() const override;
 
     // this relays incoming position/rotation to the RigidBody
-    virtual void getWorldTransform(btTransform& worldTrans) const;
+    virtual void getWorldTransform(btTransform& worldTrans) const override;
 
     // this relays outgoing position/rotation to the EntityItem
-    virtual void setWorldTransform(const btTransform& worldTrans);
+    virtual void setWorldTransform(const btTransform& worldTrans) override;
 
 
     // These pure virtual methods must be implemented for each MotionState type
     // and make it possible to implement more complicated methods in this base class.
 
-    virtual float getObjectRestitution() const;
-    virtual float getObjectFriction() const;
-    virtual float getObjectLinearDamping() const;
-    virtual float getObjectAngularDamping() const;
+    // pure virtual overrides from ObjectMotionState
+    virtual float getObjectRestitution() const override;
+    virtual float getObjectFriction() const override;
+    virtual float getObjectLinearDamping() const override;
+    virtual float getObjectAngularDamping() const override;
 
-    virtual glm::vec3 getObjectPosition() const;
-    virtual glm::quat getObjectRotation() const;
-    virtual glm::vec3 getObjectLinearVelocity() const;
-    virtual glm::vec3 getObjectAngularVelocity() const;
-    virtual glm::vec3 getObjectGravity() const;
+    virtual glm::vec3 getObjectPosition() const override;
+    virtual glm::quat getObjectRotation() const override;
+    virtual glm::vec3 getObjectLinearVelocity() const override;
+    virtual glm::vec3 getObjectAngularVelocity() const override;
+    virtual glm::vec3 getObjectGravity() const override;
 
-    virtual const QUuid& getObjectID() const;
+    virtual const QUuid& getObjectID() const override;
 
-    virtual QUuid getSimulatorID() const;
+    virtual QUuid getSimulatorID() const override;
 
     void setBoundingBox(const glm::vec3& corner, const glm::vec3& diagonal);
 
     void addDirtyFlags(uint32_t flags) { _dirtyFlags |= flags; }
 
-    virtual int16_t computeCollisionGroup();
+    virtual int16_t computeCollisionGroup() const override;
 
     friend class AvatarManager;
+    friend class Avatar;
 
 protected:
-    virtual bool isReadyToComputeShape() { return true; }
+    // the dtor had been made protected to force the compiler to verify that it is only
+    // ever called by the Avatar class dtor.
+    ~AvatarMotionState();
+
+    virtual bool isReadyToComputeShape() const override { return true; }
     virtual btCollisionShape* computeNewShape();
-    Avatar* _avatar; // do NOT use smartpointer here
+
+    // The AvatarMotionState keeps a RAW backpointer to its Avatar because all AvatarMotionState
+    // instances are "owned" by their corresponding Avatar instance and are deleted in the Avatar dtor.
+    // In other words, it is impossible for the Avatar to be deleted out from under its MotionState.
+    // In conclusion: weak pointer shennanigans would be pure overhead.
+    Avatar* _avatar; // do NOT use smartpointer here, no need for weakpointer
+
     uint32_t _dirtyFlags;
 };
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -344,9 +344,6 @@ public:
 
     glm::vec3 getClientGlobalPosition() { return _globalPosition; }
 
-    void die() { _isDead = true; }
-    bool isDead() const { return _isDead; }
-
 public slots:
     void sendAvatarDataPacket();
     void sendIdentityPacket();
@@ -422,8 +419,6 @@ protected:
     // where Entities are located.  This is currently only used by the mixer to decide how often to send
     // updates about one avatar to another.
     glm::vec3 _globalPosition;
-
-    bool _isDead { false };
 
 private:
     friend void avatarStateFromFrame(const QByteArray& frameData, AvatarData* _avatar);

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -122,13 +122,19 @@ void RenderablePolyLineEntityItem::updateVertices() {
     glm::vec3 v1, v2, tangent, binormal, point;
 
     int finalIndex = minVectorSize - 1;
+
+    // Guard against an empty polyline
+    if (finalIndex < 0) {
+        return;
+    }
+
     for (int i = 0; i < finalIndex; i++) {
         float width = _strokeWidths.at(i);
         point = _points.at(i);
 
         tangent = _points.at(i);
 
-        tangent = _points.at(i + 1) - point; 
+        tangent = _points.at(i + 1) - point;
         glm::vec3 normal = _normals.at(i);
         binormal = glm::normalize(glm::cross(tangent, normal)) * width;
 
@@ -139,11 +145,6 @@ void RenderablePolyLineEntityItem::updateVertices() {
         v1 = point + binormal;
         v2 = point - binormal;
         _vertices << v1 << v2;
-    }
-
-    // Guard against an empty polyline
-    if (finalIndex < 0) {
-        return;
     }
 
     // For last point we can assume binormals are the same since it represents the last two vertices of quad

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
@@ -77,7 +77,7 @@ public:
     glm::mat4 localToVoxelMatrix() const;
 
     virtual ShapeType getShapeType() const;
-    virtual bool shouldBePhysical() const { return true; }
+    virtual bool shouldBePhysical() const { return !isDead(); }
     virtual bool isReadyToComputeShape();
     virtual void computeShapeInfo(ShapeInfo& info);
 

--- a/libraries/entities/src/BoxEntityItem.h
+++ b/libraries/entities/src/BoxEntityItem.h
@@ -53,7 +53,7 @@ public:
     }
     
     virtual ShapeType getShapeType() const { return SHAPE_TYPE_BOX; }
-    virtual bool shouldBePhysical() const { return true; }
+    virtual bool shouldBePhysical() const { return !isDead(); }
 
     virtual void debugDump() const;
 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -85,7 +85,6 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) :
 }
 
 EntityItem::~EntityItem() {
-    assert(isDead()); // mark as dead before calling dtor
     // clear out any left-over actions
     EntityTreePointer entityTree = _element ? _element->getTree() : nullptr;
     EntitySimulation* simulation = entityTree ? entityTree->getSimulation() : nullptr;

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -85,6 +85,7 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) :
 }
 
 EntityItem::~EntityItem() {
+    assert(isDead()); // mark as dead before calling dtor
     // clear out any left-over actions
     EntityTreePointer entityTree = _element ? _element->getTree() : nullptr;
     EntitySimulation* simulation = entityTree ? entityTree->getSimulation() : nullptr;

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -337,6 +337,8 @@ public:
 
     bool isMoving() const;
 
+    bool isSimulated() const { return _simulated; }
+
     void* getPhysicsInfo() const { return _physicsInfo; }
 
     void setPhysicsInfo(void* data) { _physicsInfo = data; }
@@ -390,6 +392,8 @@ public:
     virtual void loader() {} // called indirectly when urls for geometry are updated
 
 protected:
+
+    void setSimulated(bool simulated) { _simulated = simulated; }
 
     const QByteArray getActionDataInternal() const;
     void setActionDataInternal(QByteArray actionData);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -302,7 +302,7 @@ public:
 
     virtual bool contains(const glm::vec3& point) const;
 
-    virtual bool isReadyToComputeShape() { return true; }
+    virtual bool isReadyToComputeShape() { return !isDead(); }
     virtual void computeShapeInfo(ShapeInfo& info);
     virtual float getVolumeEstimate() const { return getDimensions().x * getDimensions().y * getDimensions().z; }
 

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -53,16 +53,15 @@ void EntitySimulation::removeEntityInternal(EntityItemPointer entity) {
     _entitiesToSort.remove(entity);
     _simpleKinematicEntities.remove(entity);
     _allEntities.remove(entity);
-    entity->_simulated = false;
+    entity->setSimulated(false);
 }
 
 void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     assert(entity);
-    if (entity->_simulated) {
-        entity->clearActions(this);
-        _entitiesToDelete.insert(entity);
-        removeEntityInternal(entity);
-    }
+    assert(entity->isSimulated());
+    entity->clearActions(this);
+    removeEntityInternal(entity);
+    _entitiesToDelete.insert(entity);
 }
 
 void EntitySimulation::addEntityInternal(EntityItemPointer entity) {
@@ -166,7 +165,7 @@ void EntitySimulation::addEntity(EntityItemPointer entity) {
     addEntityInternal(entity);
 
     _allEntities.insert(entity);
-    entity->_simulated = true;
+    entity->setSimulated(true);
 
     // DirtyFlags are used to signal changes to entities that have already been added,
     // so we can clear them for this entity which has just been added.
@@ -176,7 +175,7 @@ void EntitySimulation::addEntity(EntityItemPointer entity) {
 void EntitySimulation::changeEntity(EntityItemPointer entity) {
     QMutexLocker lock(&_mutex);
     assert(entity);
-    if (!entity->_simulated) {
+    if (!entity->isSimulated()) {
         // This entity was either never added to the simulation or has been removed
         // (probably for pending delete), so we don't want to keep a pointer to it
         // on any internal lists.
@@ -232,7 +231,7 @@ void EntitySimulation::clearEntities() {
     clearEntitiesInternal();
 
     for (auto entityItr : _allEntities) {
-        entityItr->_simulated = false;
+        entityItr->setSimulated(false);
     }
     _allEntities.clear();
 }

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -59,11 +59,12 @@ void EntitySimulation::removeEntityInternal(EntityItemPointer entity) {
 
 void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     assert(entity);
-    assert(entity->isSimulated());
     assert(entity->isDead());
-    entity->clearActions(this);
-    removeEntityInternal(entity);
-    _entitiesToDelete.insert(entity);
+    if (entity->isSimulated()) {
+        entity->clearActions(this);
+        removeEntityInternal(entity);
+        _entitiesToDelete.insert(entity);
+    }
 }
 
 void EntitySimulation::addEntityInternal(EntityItemPointer entity) {

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -63,25 +63,20 @@ public:
     /// \sideeffect sets relevant backpointers in entity, but maybe later when appropriate data structures are locked
     void addEntity(EntityItemPointer entity);
 
-    /// \param entity pointer to EntityItem to be removed
-    /// \brief the actual removal may happen later when appropriate data structures are locked
-    /// \sideeffect nulls relevant backpointers in entity
-    void removeEntity(EntityItemPointer entity);
-
-    /// \param entity pointer to EntityItem to that may have changed in a way that would affect its simulation
+    /// \param entity pointer to EntityItem that may have changed in a way that would affect its simulation
     /// call this whenever an entity was changed from some EXTERNAL event (NOT by the EntitySimulation itself)
     void changeEntity(EntityItemPointer entity);
 
     void clearEntities();
 
     void moveSimpleKinematics(const quint64& now);
-protected: // these only called by the EntityTree?
-
-public:
 
     EntityTreePointer getEntityTree() { return _entityTree; }
 
     void getEntitiesToDelete(VectorOfEntities& entitiesToDelete);
+
+    /// \param entity pointer to EntityItem that needs to be put on the entitiesToDelete list and removed from others.
+    virtual void prepareEntityForDelete(EntityItemPointer entity);
 
 signals:
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -101,6 +101,9 @@ protected:
     QList<EntityActionPointer> _actionsToAdd;
     QSet<QUuid> _actionsToRemove;
 
+protected:
+    SetOfEntities _entitiesToDelete; // entities simulation decided needed to be deleted (EntityTree will actually delete)
+
 private:
     void moveSimpleKinematics();
 
@@ -115,7 +118,6 @@ private:
 
 
     SetOfEntities _entitiesToUpdate; // entities that need to call EntityItem::update()
-    SetOfEntities _entitiesToDelete; // entities simulation decided needed to be deleted (EntityTree will actually delete)
 
 };
 

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -73,7 +73,7 @@ public:
 
     EntityTreePointer getEntityTree() { return _entityTree; }
 
-    void getEntitiesToDelete(VectorOfEntities& entitiesToDelete);
+    virtual void takeEntitiesToDelete(VectorOfEntities& entitiesToDelete);
 
     /// \param entity pointer to EntityItem that needs to be put on the entitiesToDelete list and removed from others.
     virtual void prepareEntityForDelete(EntityItemPointer entity);

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -442,6 +442,7 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
     const RemovedEntities& entities = theOperator.getEntities();
     foreach(const EntityToDeleteDetails& details, entities) {
         EntityItemPointer theEntity = details.entity;
+        theEntity->die();
 
         if (getIsServer()) {
             // set up the deleted entities ID
@@ -1005,7 +1006,7 @@ void EntityTree::update() {
         withWriteLock([&] {
             _simulation->updateEntities();
             VectorOfEntities pendingDeletes;
-            _simulation->getEntitiesToDelete(pendingDeletes);
+            _simulation->takeEntitiesToDelete(pendingDeletes);
 
             if (pendingDeletes.size() > 0) {
                 // translate into list of ID's

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -453,8 +453,7 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
         }
 
         if (_simulation) {
-            theEntity->clearActions(_simulation);
-            _simulation->removeEntity(theEntity);
+            _simulation->prepareEntityForDelete(theEntity);
         }
     }
 }

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -377,7 +377,7 @@ void ModelEntityItem::setAnimationFPS(float value) {
 
 // virtual
 bool ModelEntityItem::shouldBePhysical() const {
-    return getShapeType() != SHAPE_TYPE_NONE;
+    return !isDead() && getShapeType() != SHAPE_TYPE_NONE;
 }
 
 void ModelEntityItem::resizeJointArrays(int newSize) {

--- a/libraries/entities/src/SimpleEntitySimulation.cpp
+++ b/libraries/entities/src/SimpleEntitySimulation.cpp
@@ -53,6 +53,7 @@ void SimpleEntitySimulation::addEntityInternal(EntityItemPointer entity) {
 }
 
 void SimpleEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
+    EntitySimulation::removeEntityInternal(entity);
     _entitiesWithSimulator.remove(entity);
 }
 

--- a/libraries/entities/src/SimpleEntitySimulation.h
+++ b/libraries/entities/src/SimpleEntitySimulation.h
@@ -22,11 +22,11 @@ public:
     virtual ~SimpleEntitySimulation() { clearEntitiesInternal(); }
 
 protected:
-    virtual void updateEntitiesInternal(const quint64& now);
-    virtual void addEntityInternal(EntityItemPointer entity);
-    virtual void removeEntityInternal(EntityItemPointer entity);
-    virtual void changeEntityInternal(EntityItemPointer entity);
-    virtual void clearEntitiesInternal();
+    virtual void updateEntitiesInternal(const quint64& now) override;
+    virtual void addEntityInternal(EntityItemPointer entity) override;
+    virtual void removeEntityInternal(EntityItemPointer entity) override;
+    virtual void changeEntityInternal(EntityItemPointer entity) override;
+    virtual void clearEntitiesInternal() override;
 
     SetOfEntities _entitiesWithSimulator;
 };

--- a/libraries/entities/src/SphereEntityItem.h
+++ b/libraries/entities/src/SphereEntityItem.h
@@ -52,7 +52,7 @@ public:
     }
 
     virtual ShapeType getShapeType() const { return SHAPE_TYPE_SPHERE; }
-    virtual bool shouldBePhysical() const { return true; }
+    virtual bool shouldBePhysical() const { return !isDead(); }
     
     virtual bool supportsDetailedRayIntersection() const { return true; }
     virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,

--- a/libraries/entities/src/ZoneEntityItem.h
+++ b/libraries/entities/src/ZoneEntityItem.h
@@ -57,7 +57,7 @@ public:
     static bool getDrawZoneBoundaries() { return _drawZoneBoundaries; }
     static void setDrawZoneBoundaries(bool value) { _drawZoneBoundaries = value; }
     
-    virtual bool isReadyToComputeShape() { return true; }
+    virtual bool isReadyToComputeShape() { return false; }
     void updateShapeType(ShapeType type) { _shapeType = type; }
     virtual ShapeType getShapeType() const;
     

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -48,9 +48,10 @@ bool entityTreeIsLocked() {
 #endif
 
 
-EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItem* entity) :
+EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer entity) :
     ObjectMotionState(shape),
-    _entity(entity),
+    _entityPtr(entity),
+    _entity(entity.get()),
     _sentInactive(true),
     _lastStep(0),
     _serverPosition(0.0f),

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -34,7 +34,7 @@ const quint64 USECS_BETWEEN_OWNERSHIP_BIDS = USECS_PER_SECOND / 5;
 
 #ifdef WANT_DEBUG_ENTITY_TREE_LOCKS
 bool EntityMotionState::entityTreeIsLocked() const {
-    EntityTreeElementPointer element = _entity ? _entity->getElement() : nullptr;
+    EntityTreeElementPointer element = _entity->getElement();
     EntityTreePointer tree = element ? element->getTree() : nullptr;
     if (!tree) {
         return true;
@@ -48,7 +48,7 @@ bool entityTreeIsLocked() {
 #endif
 
 
-EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer entity) :
+EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItem* entity) :
     ObjectMotionState(shape),
     _entity(entity),
     _sentInactive(true),
@@ -69,14 +69,14 @@ EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer 
     _loopsWithoutOwner(0)
 {
     _type = MOTIONSTATE_TYPE_ENTITY;
-    assert(_entity != nullptr);
+    assert(_entity);
     assert(entityTreeIsLocked());
     setMass(_entity->computeMass());
 }
 
 EntityMotionState::~EntityMotionState() {
-    // be sure to clear _entity before calling the destructor
-    assert(!_entity);
+    assert(_entity);
+    _entity = nullptr;
 }
 
 void EntityMotionState::updateServerPhysicsVariables(const QUuid& sessionID) {
@@ -136,11 +136,6 @@ bool EntityMotionState::handleEasyChanges(uint32_t& flags, PhysicsEngine* engine
 bool EntityMotionState::handleHardAndEasyChanges(uint32_t& flags, PhysicsEngine* engine) {
     updateServerPhysicsVariables(engine->getSessionID());
     return ObjectMotionState::handleHardAndEasyChanges(flags, engine);
-}
-
-void EntityMotionState::clearObjectBackPointer() {
-    ObjectMotionState::clearObjectBackPointer();
-    _entity = nullptr;
 }
 
 MotionType EntityMotionState::computeObjectMotionType() const {
@@ -222,21 +217,15 @@ void EntityMotionState::setWorldTransform(const btTransform& worldTrans) {
 
 // virtual and protected
 bool EntityMotionState::isReadyToComputeShape() {
-    if (_entity) {
-        return _entity->isReadyToComputeShape();
-    }
-    return false;
+    return _entity->isReadyToComputeShape();
 }
 
 // virtual and protected
 btCollisionShape* EntityMotionState::computeNewShape() {
-    if (_entity) {
-        ShapeInfo shapeInfo;
-        assert(entityTreeIsLocked());
-        _entity->computeShapeInfo(shapeInfo);
-        return getShapeManager()->getShape(shapeInfo);
-    }
-    return nullptr;
+    ShapeInfo shapeInfo;
+    assert(entityTreeIsLocked());
+    _entity->computeShapeInfo(shapeInfo);
+    return getShapeManager()->getShape(shapeInfo);
 }
 
 bool EntityMotionState::isCandidateForOwnership(const QUuid& sessionID) const {
@@ -553,26 +542,17 @@ void EntityMotionState::clearIncomingDirtyFlags() {
 
 // virtual
 quint8 EntityMotionState::getSimulationPriority() const {
-    if (_entity) {
-        return _entity->getSimulationPriority();
-    }
-    return NO_PRORITY;
+    return _entity->getSimulationPriority();
 }
 
 // virtual
 QUuid EntityMotionState::getSimulatorID() const {
-    if (_entity) {
-        assert(entityTreeIsLocked());
-        return _entity->getSimulatorID();
-    }
-    return QUuid();
+    assert(entityTreeIsLocked());
+    return _entity->getSimulatorID();
 }
 
-// virtual
 void EntityMotionState::bump(quint8 priority) {
-    if (_entity) {
-        setOutgoingPriority(glm::max(VOLUNTEER_SIMULATION_PRIORITY, --priority));
-    }
+    setOutgoingPriority(glm::max(VOLUNTEER_SIMULATION_PRIORITY, --priority));
 }
 
 void EntityMotionState::resetMeasuredBodyAcceleration() {
@@ -624,18 +604,12 @@ void EntityMotionState::setMotionType(MotionType motionType) {
 
 // virtual
 QString EntityMotionState::getName() {
-    if (_entity) {
-        assert(entityTreeIsLocked());
-        return _entity->getName();
-    }
-    return "";
+    assert(entityTreeIsLocked());
+    return _entity->getName();
 }
 
 // virtual
 int16_t EntityMotionState::computeCollisionGroup() {
-    if (!_entity) {
-        return COLLISION_GROUP_STATIC;
-    }
     if (_entity->getIgnoreForCollisions()) {
         return COLLISION_GROUP_COLLISIONLESS;
     }

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -217,7 +217,7 @@ void EntityMotionState::setWorldTransform(const btTransform& worldTrans) {
 
 
 // virtual and protected
-bool EntityMotionState::isReadyToComputeShape() {
+bool EntityMotionState::isReadyToComputeShape() const {
     return _entity->isReadyToComputeShape();
 }
 
@@ -604,13 +604,13 @@ void EntityMotionState::setMotionType(MotionType motionType) {
 
 
 // virtual
-QString EntityMotionState::getName() {
+QString EntityMotionState::getName() const {
     assert(entityTreeIsLocked());
     return _entity->getName();
 }
 
 // virtual
-int16_t EntityMotionState::computeCollisionGroup() {
+int16_t EntityMotionState::computeCollisionGroup() const {
     if (_entity->getIgnoreForCollisions()) {
         return COLLISION_GROUP_COLLISIONLESS;
     }

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -25,7 +25,7 @@ class EntityItem;
 class EntityMotionState : public ObjectMotionState {
 public:
 
-    EntityMotionState(btCollisionShape* shape, EntityItemPointer item);
+    EntityMotionState(btCollisionShape* shape, EntityItem* item);
     virtual ~EntityMotionState();
 
     void updateServerPhysicsVariables(const QUuid& sessionID);
@@ -73,7 +73,7 @@ public:
     virtual QUuid getSimulatorID() const;
     virtual void bump(quint8 priority);
 
-    EntityItemPointer getEntity() const { return _entity; }
+    EntityItem* getEntity() const { return _entity; }
 
     void resetMeasuredBodyAcceleration();
     void measureBodyAcceleration();
@@ -94,10 +94,9 @@ protected:
 
     virtual bool isReadyToComputeShape();
     virtual btCollisionShape* computeNewShape();
-    virtual void clearObjectBackPointer();
     virtual void setMotionType(MotionType motionType);
 
-    EntityItemPointer _entity;
+    EntityItem* _entity { nullptr }; // do NOT use smartpointer here
 
     bool _sentInactive;   // true if body was inactive when we sent last update
 

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -38,10 +38,10 @@ public:
     virtual bool isMoving() const;
 
     // this relays incoming position/rotation to the RigidBody
-    virtual void getWorldTransform(btTransform& worldTrans) const;
+    virtual void getWorldTransform(btTransform& worldTrans) const override;
 
     // this relays outgoing position/rotation to the EntityItem
-    virtual void setWorldTransform(const btTransform& worldTrans);
+    virtual void setWorldTransform(const btTransform& worldTrans) override;
 
     bool isCandidateForOwnership(const QUuid& sessionID) const;
     bool remoteSimulationOutOfSync(uint32_t simulationStep);
@@ -55,32 +55,32 @@ public:
     void resetAccelerationNearlyGravityCount() { _accelerationNearlyGravityCount = 0; }
     quint8 getAccelerationNearlyGravityCount() { return _accelerationNearlyGravityCount; }
 
-    virtual float getObjectRestitution() const { return _entity->getRestitution(); }
-    virtual float getObjectFriction() const { return _entity->getFriction(); }
-    virtual float getObjectLinearDamping() const { return _entity->getDamping(); }
-    virtual float getObjectAngularDamping() const { return _entity->getAngularDamping(); }
+    virtual float getObjectRestitution() const override { return _entity->getRestitution(); }
+    virtual float getObjectFriction() const override { return _entity->getFriction(); }
+    virtual float getObjectLinearDamping() const override { return _entity->getDamping(); }
+    virtual float getObjectAngularDamping() const override { return _entity->getAngularDamping(); }
 
-    virtual glm::vec3 getObjectPosition() const { return _entity->getPosition() - ObjectMotionState::getWorldOffset(); }
-    virtual glm::quat getObjectRotation() const { return _entity->getRotation(); }
-    virtual glm::vec3 getObjectLinearVelocity() const { return _entity->getVelocity(); }
-    virtual glm::vec3 getObjectAngularVelocity() const { return _entity->getAngularVelocity(); }
-    virtual glm::vec3 getObjectGravity() const { return _entity->getGravity(); }
-    virtual glm::vec3 getObjectLinearVelocityChange() const;
+    virtual glm::vec3 getObjectPosition() const override { return _entity->getPosition() - ObjectMotionState::getWorldOffset(); }
+    virtual glm::quat getObjectRotation() const override { return _entity->getRotation(); }
+    virtual glm::vec3 getObjectLinearVelocity() const override { return _entity->getVelocity(); }
+    virtual glm::vec3 getObjectAngularVelocity() const override { return _entity->getAngularVelocity(); }
+    virtual glm::vec3 getObjectGravity() const override { return _entity->getGravity(); }
+    virtual glm::vec3 getObjectLinearVelocityChange() const override;
 
-    virtual const QUuid& getObjectID() const { return _entity->getID(); }
+    virtual const QUuid& getObjectID() const override { return _entity->getID(); }
 
-    virtual quint8 getSimulationPriority() const;
-    virtual QUuid getSimulatorID() const;
-    virtual void bump(quint8 priority);
+    virtual quint8 getSimulationPriority() const override;
+    virtual QUuid getSimulatorID() const override;
+    virtual void bump(quint8 priority) override;
 
     EntityItemPointer getEntity() const { return _entityPtr.lock(); }
 
     void resetMeasuredBodyAcceleration();
     void measureBodyAcceleration();
 
-    virtual QString getName();
+    virtual QString getName() const override;
 
-    virtual int16_t computeCollisionGroup();
+    virtual int16_t computeCollisionGroup() const override;
 
     // eternal logic can suggest a simuator priority bid for the next outgoing update
     void setOutgoingPriority(quint8 priority);
@@ -92,7 +92,7 @@ protected:
     bool entityTreeIsLocked() const;
     #endif
 
-    virtual bool isReadyToComputeShape();
+    virtual bool isReadyToComputeShape() const override;
     virtual btCollisionShape* computeNewShape();
     virtual void setMotionType(MotionType motionType);
 

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -71,9 +71,9 @@ ObjectMotionState::ObjectMotionState(btCollisionShape* shape) :
 }
 
 ObjectMotionState::~ObjectMotionState() {
-    // adebug TODO: move shape release out of PhysicsEngine and into into the ObjectMotionState dtor
     assert(!_body);
-    assert(!_shape);
+    releaseShape();
+    _type = MOTIONSTATE_TYPE_INVALID;
 }
 
 void ObjectMotionState::setBodyLinearVelocity(const glm::vec3& velocity) const {

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -71,6 +71,7 @@ ObjectMotionState::ObjectMotionState(btCollisionShape* shape) :
 }
 
 ObjectMotionState::~ObjectMotionState() {
+    // adebug TODO: move shape release out of PhysicsEngine and into into the ObjectMotionState dtor
     assert(!_body);
     assert(!_shape);
 }

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -153,9 +153,6 @@ protected:
     void setMotionType(MotionType motionType);
     void updateCCDConfiguration();
 
-    // clearObjectBackPointer() overrrides should call the base method, then actually clear the object back pointer.
-    virtual void clearObjectBackPointer() { _type = MOTIONSTATE_TYPE_INVALID; }
-
     void setRigidBody(btRigidBody* body);
 
     MotionStateType _type = MOTIONSTATE_TYPE_INVALID; // type of MotionState

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -134,9 +134,9 @@ public:
     virtual QUuid getSimulatorID() const = 0;
     virtual void bump(quint8 priority) {}
 
-    virtual QString getName() { return ""; }
+    virtual QString getName() const { return ""; }
 
-    virtual int16_t computeCollisionGroup() = 0;
+    virtual int16_t computeCollisionGroup() const = 0;
 
     bool isActive() const { return _body ? _body->isActive() : false; }
 
@@ -148,7 +148,7 @@ public:
     friend class PhysicsEngine;
 
 protected:
-    virtual bool isReadyToComputeShape() = 0;
+    virtual bool isReadyToComputeShape() const = 0;
     virtual btCollisionShape* computeNewShape() = 0;
     void setMotionType(MotionType motionType);
     void updateCCDConfiguration();

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -55,6 +55,7 @@ void PhysicalEntitySimulation::addEntityInternal(EntityItemPointer entity) {
 }
 
 void PhysicalEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
+    EntitySimulation::removeEntityInternal(entity);
     EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
     if (motionState) {
         motionState->clearObjectBackPointer();

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -150,7 +150,6 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
 // virtual
 void PhysicalEntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     assert(entity);
-    assert(entity->isSimulated());
     assert(entity->isDead());
     entity->clearActions(this);
     removeEntityInternal(entity);

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -44,6 +44,8 @@ protected: // only called by EntitySimulation
     virtual void clearEntitiesInternal() override;
 
 public:
+    virtual void prepareEntityForDelete(EntityItemPointer entity) override;
+
     void getObjectsToDelete(VectorOfMotionStates& result);
     void getObjectsToAdd(VectorOfMotionStates& result);
     void setObjectsToChange(const VectorOfMotionStates& objectsToChange);
@@ -55,12 +57,12 @@ public:
     EntityEditPacketSender* getPacketSender() { return _entityPacketSender; }
 
 private:
-    // incoming changes
-    SetOfEntityMotionStates _pendingRemoves; // EntityMotionStates to be removed from PhysicsEngine (and deleted)
-    SetOfEntities _pendingAdds; // entities to be be added to PhysicsEngine (and a their EntityMotionState created)
+    // incoming changes to physics simulation
+    SetOfEntities _entitiesToRemoveFromPhysics;
+    SetOfEntities _entitiesToAddToPhysics; // entities to be be added to PhysicsEngine (and a their EntityMotionState created)
     SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed
 
-    // outgoing changes
+    // outgoing changes from physics simulation
     SetOfEntityMotionStates _outgoingChanges; // EntityMotionStates for which we need to send updates to entity-server
 
     SetOfMotionStates _physicalObjects; // MotionStates of entities in PhysicsEngine

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -35,6 +35,8 @@ public:
     virtual void addAction(EntityActionPointer action) override;
     virtual void applyActionChanges() override;
 
+    virtual void takeEntitiesToDelete(VectorOfEntities& entitiesToDelete) override;
+
 protected: // only called by EntitySimulation
     // overrides for EntitySimulation
     virtual void updateEntitiesInternal(const quint64& now) override;
@@ -46,8 +48,8 @@ protected: // only called by EntitySimulation
 public:
     virtual void prepareEntityForDelete(EntityItemPointer entity) override;
 
-    void getObjectsToDelete(VectorOfMotionStates& result);
-    void getObjectsToAdd(VectorOfMotionStates& result);
+    void getObjectsToRemoveFromPhysics(VectorOfMotionStates& result);
+    void getObjectsToAddToPhysics(VectorOfMotionStates& result);
     void setObjectsToChange(const VectorOfMotionStates& objectsToChange);
     void getObjectsToChange(VectorOfMotionStates& result);
 
@@ -58,7 +60,7 @@ public:
 
 private:
     SetOfEntities _entitiesToRemoveFromPhysics;
-    SetOfEntities _entitiesToAddToPhysics; // entities to be be added to PhysicsEngine (and a their EntityMotionState created)
+    SetOfEntities _entitiesToAddToPhysics;
 
     SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed
     SetOfEntityMotionStates _outgoingChanges; // EntityMotionStates for which we need to send updates to entity-server

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -57,12 +57,10 @@ public:
     EntityEditPacketSender* getPacketSender() { return _entityPacketSender; }
 
 private:
-    // incoming changes to physics simulation
     SetOfEntities _entitiesToRemoveFromPhysics;
     SetOfEntities _entitiesToAddToPhysics; // entities to be be added to PhysicsEngine (and a their EntityMotionState created)
-    SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed
 
-    // outgoing changes from physics simulation
+    SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed
     SetOfEntityMotionStates _outgoingChanges; // EntityMotionStates for which we need to send updates to entity-server
 
     SetOfMotionStates _physicalObjects; // MotionStates of entities in PhysicsEngine

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -67,7 +67,8 @@ void PhysicsEngine::init() {
     }
 }
 
-void PhysicsEngine::addObject(ObjectMotionState* motionState) {
+// private
+void PhysicsEngine::addObjectToDynamicsWorld(ObjectMotionState* motionState) {
     assert(motionState);
 
     btVector3 inertia(0.0f, 0.0f, 0.0f);
@@ -144,7 +145,8 @@ void PhysicsEngine::addObject(ObjectMotionState* motionState) {
     motionState->clearIncomingDirtyFlags();
 }
 
-void PhysicsEngine::removeObject(ObjectMotionState* object) {
+// private
+void PhysicsEngine::removeObjectFromDynamicsWorld(ObjectMotionState* object) {
     // wake up anything touching this object
     bump(object);
     removeContacts(object);
@@ -156,13 +158,14 @@ void PhysicsEngine::removeObject(ObjectMotionState* object) {
 
 void PhysicsEngine::deleteObjects(const VectorOfMotionStates& objects) {
     for (auto object : objects) {
-        removeObject(object);
+        removeObjectFromDynamicsWorld(object);
 
         // NOTE: setRigidBody() modifies body->m_userPointer so we should clear the MotionState's body BEFORE deleting it.
         btRigidBody* body = object->getRigidBody();
         object->setRigidBody(nullptr);
         body->setMotionState(nullptr);
         delete body;
+        // adebug TODO: move this into ObjectMotionState dtor
         object->releaseShape();
         delete object;
     }
@@ -172,12 +175,13 @@ void PhysicsEngine::deleteObjects(const VectorOfMotionStates& objects) {
 void PhysicsEngine::deleteObjects(const SetOfMotionStates& objects) {
     for (auto object : objects) {
         btRigidBody* body = object->getRigidBody();
-        removeObject(object);
+        removeObjectFromDynamicsWorld(object);
 
         // NOTE: setRigidBody() modifies body->m_userPointer so we should clear the MotionState's body BEFORE deleting it.
         object->setRigidBody(nullptr);
         body->setMotionState(nullptr);
         delete body;
+        // adebug TODO: move this into ObjectMotionState dtor
         object->releaseShape();
         delete object;
     }
@@ -185,7 +189,7 @@ void PhysicsEngine::deleteObjects(const SetOfMotionStates& objects) {
 
 void PhysicsEngine::addObjects(const VectorOfMotionStates& objects) {
     for (auto object : objects) {
-        addObject(object);
+        addObjectToDynamicsWorld(object);
     }
 }
 
@@ -211,8 +215,8 @@ VectorOfMotionStates PhysicsEngine::changeObjects(const VectorOfMotionStates& ob
 }
 
 void PhysicsEngine::reinsertObject(ObjectMotionState* object) {
-    removeObject(object);
-    addObject(object);
+    removeObjectFromDynamicsWorld(object);
+    addObjectToDynamicsWorld(object);
 }
 
 void PhysicsEngine::removeContacts(ObjectMotionState* motionState) {

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -156,7 +156,7 @@ void PhysicsEngine::removeObjectFromDynamicsWorld(ObjectMotionState* object) {
     _dynamicsWorld->removeRigidBody(body);
 }
 
-void PhysicsEngine::deleteObjects(const VectorOfMotionStates& objects) {
+void PhysicsEngine::removeObjects(const VectorOfMotionStates& objects) {
     for (auto object : objects) {
         removeObjectFromDynamicsWorld(object);
 
@@ -165,14 +165,11 @@ void PhysicsEngine::deleteObjects(const VectorOfMotionStates& objects) {
         object->setRigidBody(nullptr);
         body->setMotionState(nullptr);
         delete body;
-        // adebug TODO: move this into ObjectMotionState dtor
-        object->releaseShape();
-        delete object;
     }
 }
 
 // Same as above, but takes a Set instead of a Vector.  Should only be called during teardown.
-void PhysicsEngine::deleteObjects(const SetOfMotionStates& objects) {
+void PhysicsEngine::removeObjects(const SetOfMotionStates& objects) {
     for (auto object : objects) {
         btRigidBody* body = object->getRigidBody();
         removeObjectFromDynamicsWorld(object);
@@ -181,9 +178,6 @@ void PhysicsEngine::deleteObjects(const SetOfMotionStates& objects) {
         object->setRigidBody(nullptr);
         body->setMotionState(nullptr);
         delete body;
-        // adebug TODO: move this into ObjectMotionState dtor
-        object->releaseShape();
-        delete object;
     }
 }
 

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -54,11 +54,9 @@ public:
     void setSessionUUID(const QUuid& sessionID) { _sessionID = sessionID; }
     const QUuid& getSessionID() const { return _sessionID; }
 
-    void addObject(ObjectMotionState* motionState);
-    void removeObject(ObjectMotionState* motionState);
-
     void deleteObjects(const VectorOfMotionStates& objects);
     void deleteObjects(const SetOfMotionStates& objects); // only called during teardown
+
     void addObjects(const VectorOfMotionStates& objects);
     VectorOfMotionStates changeObjects(const VectorOfMotionStates& objects);
     void reinsertObject(ObjectMotionState* object);
@@ -100,6 +98,9 @@ public:
     void forEachAction(std::function<void(EntityActionPointer)> actor);
 
 private:
+    void addObjectToDynamicsWorld(ObjectMotionState* motionState);
+    void removeObjectFromDynamicsWorld(ObjectMotionState* motionState);
+
     void removeContacts(ObjectMotionState* motionState);
 
     void doOwnershipInfection(const btCollisionObject* objectA, const btCollisionObject* objectB);

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -115,7 +115,6 @@ private:
 
     ContactMap _contactMap;
     uint32_t _numContactFrames = 0;
-    uint32_t _lastNumSubstepsAtUpdateInternal = 0;
 
     /// character collisions
     CharacterController* _myAvatarController;

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -54,8 +54,8 @@ public:
     void setSessionUUID(const QUuid& sessionID) { _sessionID = sessionID; }
     const QUuid& getSessionID() const { return _sessionID; }
 
-    void deleteObjects(const VectorOfMotionStates& objects);
-    void deleteObjects(const SetOfMotionStates& objects); // only called during teardown
+    void removeObjects(const VectorOfMotionStates& objects);
+    void removeObjects(const SetOfMotionStates& objects); // only called during teardown
 
     void addObjects(const VectorOfMotionStates& objects);
     VectorOfMotionStates changeObjects(const VectorOfMotionStates& objects);
@@ -83,8 +83,6 @@ public:
 
     /// \brief call bump on any objects that touch the object corresponding to motionState
     void bump(ObjectMotionState* motionState);
-
-    void removeRigidBody(btRigidBody* body);
 
     void setCharacterController(CharacterController* character);
 

--- a/libraries/shared/src/SpatiallyNestable.h
+++ b/libraries/shared/src/SpatiallyNestable.h
@@ -34,7 +34,7 @@ enum class NestableType {
 class SpatiallyNestable : public std::enable_shared_from_this<SpatiallyNestable> {
 public:
     SpatiallyNestable(NestableType nestableType, QUuid id);
-    virtual ~SpatiallyNestable() { }
+    virtual ~SpatiallyNestable() { assert(_isDead); }
 
     virtual const QUuid& getID() const { return _id; }
     virtual void setID(const QUuid& id) { _id = id; }
@@ -115,6 +115,9 @@ public:
     void forEachChild(std::function<void(SpatiallyNestablePointer)> actor);
     void forEachDescendant(std::function<void(SpatiallyNestablePointer)> actor);
 
+    void die() { _isDead = true; }
+    bool isDead() const { return _isDead; }
+
 protected:
     const NestableType _nestableType; // EntityItem or an AvatarData
     QUuid _id;
@@ -141,7 +144,8 @@ protected:
 private:
     mutable ReadWriteLockable _transformLock;
     Transform _transform; // this is to be combined with parent's world-transform to produce this' world-transform.
-    mutable bool _parentKnowsMe = false;
+    mutable bool _parentKnowsMe { false };
+    bool _isDead { false };
 };
 
 

--- a/libraries/shared/src/SpatiallyNestable.h
+++ b/libraries/shared/src/SpatiallyNestable.h
@@ -34,7 +34,7 @@ enum class NestableType {
 class SpatiallyNestable : public std::enable_shared_from_this<SpatiallyNestable> {
 public:
     SpatiallyNestable(NestableType nestableType, QUuid id);
-    virtual ~SpatiallyNestable() { assert(_isDead); }
+    virtual ~SpatiallyNestable() { }
 
     virtual const QUuid& getID() const { return _id; }
     virtual void setID(const QUuid& id) { _id = id; }


### PR DESCRIPTION
We've had some crash modes for dangling MotionState pointers.  This PR is an effort to reorganize the code to make it harder to get things wrong.  In short:

* EntityItems's are removed from the PhysicsEngine BEFORE they are deleted.
* The deletion of the MotionState happens AFTER it has been removed from the PhysicsEngine.
* More asserts added in destructors to help make sure things are done in the right order
* More correct names for methods