### PR TITLE
Tweaks for supporting the new QML UI

### DIFF
--- a/interface/resources/controllers/standard_navigation.json
+++ b/interface/resources/controllers/standard_navigation.json
@@ -11,7 +11,7 @@
         { "from": "Standard.DR", "to": "Actions.UiNavLateral" },
         { "from": "Standard.LB", "to": "Actions.UiNavGroup","filters": "invert" },
         { "from": "Standard.RB", "to": "Actions.UiNavGroup" },
-        { "from": [ "Standard.A", "Standard.X", "Standard.RT", "Standard.LT" ], "to": "Actions.UiNavSelect" },
+        { "from": [ "Standard.A", "Standard.X" ], "to": "Actions.UiNavSelect" },
         { "from": [ "Standard.B", "Standard.Y", "Standard.RightPrimaryThumb", "Standard.LeftPrimaryThumb" ], "to": "Actions.UiNavBack" },
         { 
             "from": [ "Standard.RT", "Standard.LT" ], 

--- a/interface/resources/qml/AddressBarDialog.qml
+++ b/interface/resources/qml/AddressBarDialog.qml
@@ -169,8 +169,10 @@ DialogContainer {
         switch (event.key) {
             case Qt.Key_Escape:
             case Qt.Key_Back:
-                enabled = false
-                event.accepted = true
+                if (enabled) {
+                    enabled = false
+                    event.accepted = true
+                }
                 break
             case Qt.Key_Enter:
             case Qt.Key_Return:

--- a/interface/resources/qml/ErrorDialog.qml
+++ b/interface/resources/qml/ErrorDialog.qml
@@ -96,6 +96,9 @@ DialogContainer {
     }
 
     Keys.onPressed: {
+        if (!enabled) {
+            return
+        }
         switch (event.key) {
             case Qt.Key_Escape:
             case Qt.Key_Back:

--- a/interface/resources/qml/LoginDialog.qml
+++ b/interface/resources/qml/LoginDialog.qml
@@ -343,8 +343,10 @@ DialogContainer {
         switch (event.key) {
             case Qt.Key_Escape:
             case Qt.Key_Back:
-                enabled = false
-                event.accepted = true
+                if (enabled) {
+                    enabled = false
+                    event.accepted = true
+                }
                 break
             case Qt.Key_Enter:
             case Qt.Key_Return:

--- a/interface/resources/qml/MessageDialog.qml
+++ b/interface/resources/qml/MessageDialog.qml
@@ -300,6 +300,10 @@ VrDialog {
 
 
     Keys.onPressed: {
+        if (!enabled) {
+            return
+        }
+
         if (event.modifiers === Qt.ControlModifier)
             switch (event.key) {
             case Qt.Key_A:

--- a/interface/resources/qml/QmlWindow.qml
+++ b/interface/resources/qml/QmlWindow.qml
@@ -10,7 +10,6 @@ import "styles"
 
 VrDialog {
     id: root
-    objectName: "topLevelWindow"
     HifiConstants { id: hifi }
     title: "QmlWindow"
     resizable: true

--- a/interface/resources/qml/QmlWindow.qml
+++ b/interface/resources/qml/QmlWindow.qml
@@ -43,10 +43,6 @@ VrDialog {
             focus: true
             property var dialog: root
             
-            onLoaded: {
-                forceActiveFocus()
-            }
-            
             Keys.onPressed: {
                 console.log("QmlWindow pageLoader keypress")
             }

--- a/interface/resources/qml/Root.qml
+++ b/interface/resources/qml/Root.qml
@@ -1,11 +1,16 @@
 import Hifi 1.0
-import QtQuick 2.3
+import QtQuick 2.5
+import QtQuick.Controls 1.4
 
 // This is our primary 'window' object to which all dialogs and controls will 
 // be childed. 
 Root {
     id: root
+    objectName: "desktopRoot"
     anchors.fill: parent
+    property var rootMenu: Menu {
+        objectName: "rootMenu"
+    }
 
     onParentChanged: {
         forceActiveFocus();

--- a/interface/resources/qml/RootMenu.qml
+++ b/interface/resources/qml/RootMenu.qml
@@ -1,9 +1,0 @@
-import QtQuick 2.4
-import QtQuick.Controls 1.3
-
-Item {
-    Menu {
-        id: root
-        objectName: "rootMenu"
-    }
-}

--- a/interface/resources/qml/controls/DialogBase.qml
+++ b/interface/resources/qml/controls/DialogBase.qml
@@ -5,6 +5,7 @@ import "../styles"
 
 Item {
     id: root
+    objectName: "topLevelWindow"
     HifiConstants { id: hifi }
     implicitHeight: contentImplicitHeight + titleBorder.height + hifi.styles.borderWidth
     implicitWidth: contentImplicitWidth + hifi.styles.borderWidth * 2

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1173,7 +1173,6 @@ void Application::initializeUi() {
     offscreenUi->setProxyWindow(_window->windowHandle());
     offscreenUi->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "/qml/"));
     offscreenUi->load("Root.qml");
-    offscreenUi->load("RootMenu.qml");
     // FIXME either expose so that dialogs can set this themselves or
     // do better detection in the offscreen UI of what has focus
     offscreenUi->setNavigationFocused(false);
@@ -2033,16 +2032,16 @@ void Application::keyPressEvent(QKeyEvent* event) {
 
                 break;
             }
-            case Qt::Key_Escape: {
-                getActiveDisplayPlugin()->abandonCalibration();
-                if (!event->isAutoRepeat()) {
-                    // this starts the HFCancelEvent
-                    HFBackEvent startBackEvent(HFBackEvent::startType());
-                    sendEvent(this, &startBackEvent);
-                }
-
-                break;
-            }
+//            case Qt::Key_Escape: {
+//                getActiveDisplayPlugin()->abandonCalibration();
+//                if (!event->isAutoRepeat()) {
+//                    // this starts the HFCancelEvent
+//                    HFBackEvent startBackEvent(HFBackEvent::startType());
+//                    sendEvent(this, &startBackEvent);
+//                }
+//
+//                break;
+//            }
 
             default:
                 event->ignore();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2032,16 +2032,16 @@ void Application::keyPressEvent(QKeyEvent* event) {
 
                 break;
             }
-//            case Qt::Key_Escape: {
-//                getActiveDisplayPlugin()->abandonCalibration();
-//                if (!event->isAutoRepeat()) {
-//                    // this starts the HFCancelEvent
-//                    HFBackEvent startBackEvent(HFBackEvent::startType());
-//                    sendEvent(this, &startBackEvent);
-//                }
-//
-//                break;
-//            }
+            case Qt::Key_Escape: {
+                getActiveDisplayPlugin()->abandonCalibration();
+                if (!event->isAutoRepeat()) {
+                    // this starts the HFCancelEvent
+                    HFBackEvent startBackEvent(HFBackEvent::startType());
+                    sendEvent(this, &startBackEvent);
+                }
+
+                break;
+            }
 
             default:
                 event->ignore();


### PR DESCRIPTION
This is to support some new functionality that allows various QML controls besides the VR menu to access and manipulate the menu structure.  

To test this, load the script https://raw.githubusercontent.com/jherico/qmlscratch/master/wireFrameTest.js

launching the new UI wireframe will allow you to modify the camera position by selecting view and then choosing one of the options.  

The visible options are pulled directly from the actual menu and choosing an item should change your view immediately, while closing the overlay.
