### PR TITLE
Interface support for avatar attachments from Marketplace

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -340,7 +340,11 @@ private slots:
     bool askToLoadScript(const QString& scriptFilenameOrURL);
     bool askToUploadAsset(const QString& asset);
     void modelUploadFinished(AssetUpload* upload, const QString& hash);
-    
+
+    bool askToWearAvatarAttachmentUrl(const QString& url);
+    void displayAvatarAttachmentWarning(const QString& message) const;
+    bool displayAvatarAttachmentConfirmationDialog(const QString& name) const;
+
     void setSessionUUID(const QUuid& sessionUUID);
     void domainChanged(const QString& domainHostname);
     void updateWindowTitle();
@@ -550,6 +554,8 @@ private:
     bool _physicsEnabled { false };
 
     bool _reticleClickPressed { false };
+
+    int _avatarAttachmentRequest = 0;
 };
 
 #endif // hifi_Application_h


### PR DESCRIPTION
Drag and drop support of ava.json files is also supported and at the moment the only way to test.

To test:

1. Create a cowboyhat.ava.json file on your hard-drive, with the following contents:
<pre>
    {
        "version": "0.1",
        "name": "Cowboy Hat",
        "modelUrl": "https://s3.amazonaws.com/hifi-public/tony/cowboy-hat.fbx",
        "jointName": "Head",
        "transform": {
            "rotation": {"x": 0, "y": 0, "z": 0, "w": 1},
            "translation": {"x": 0, "y": 0, "z": 0},
            "scale": {"x": 1, "y": 1, "z": 1}
        },
        "isSoft": false
    }
</pre>
2. Create a leatherjacket.ava.json file, with the following contents:
<pre>
    {
        "version": "0.1",
        "name": "Leather Jacket",
        "modelUrl": "https://hifi-content.s3.amazonaws.com/ozan/dev/clothes/coat/coat_rig.fbx",
        "isSoft": true
    }
</pre>
3. Run interface
4. Drag-and-Drop cowboyhat.ava.json onto the main Interface window.
5. You should be prompted wear the 'Cowboy Hat' attachment.
6. If you select 'Yes', the cowboy hat should appear on the avatar.
7. Do the same with leatherjacket.ava.json file.