### PR TITLE
Fix Wall Targets Collision Callback

### DIFF
--- a/examples/toybox/ping_pong_gun/wallTarget.js
+++ b/examples/toybox/ping_pong_gun/wallTarget.js
@@ -17,6 +17,7 @@
     }
 
     Target.prototype = {
+        hasBecomePhysical: false,
         hasPlayedSound: false,
         preload: function(entityID) {
             this.entityID = entityID;
@@ -24,19 +25,22 @@
             this.hitSound = SoundCache.getSound(SOUND_URL);
         },
         collisionWithEntity: function(me, otherEntity) {
-            var position = Entities.getEntityProperties(me, "position").position;
-            Entities.editEntity(me, {
-                gravity: {
-                    x: 0,
-                    y: -9.8,
-                    z: 0
-                },
-                velocity: {
-                    x: 0,
-                    y: -0.01,
-                    z: 0
-                }
-            });
+            if (this.hasBecomePhysical === false) {
+                var position = Entities.getEntityProperties(me, "position").position;
+                Entities.editEntity(me, {
+                    gravity: {
+                        x: 0,
+                        y: -9.8,
+                        z: 0
+                    },
+                    velocity: {
+                        x: 0,
+                        y: -0.01,
+                        z: 0
+                    }
+                });
+                this.hasBecomePhysical = true;
+            }
 
             if (this.hasPlayedSound === false) {
                 this.audioInjector = Audio.playSound(this.hitSound, {

--- a/examples/toybox/ping_pong_gun/wallTarget.js
+++ b/examples/toybox/ping_pong_gun/wallTarget.js
@@ -17,15 +17,14 @@
     }
 
     Target.prototype = {
-        hasBecomePhysical: false,
-        hasPlayedSound: false,
+        hasBecomeActive: false,
         preload: function(entityID) {
             this.entityID = entityID;
             var SOUND_URL = "http://hifi-public.s3.amazonaws.com/sounds/Clay_Pigeon_02.L.wav";
             this.hitSound = SoundCache.getSound(SOUND_URL);
         },
         collisionWithEntity: function(me, otherEntity) {
-            if (this.hasBecomePhysical === false) {
+            if (this.hasBecomeActive === false) {
                 var position = Entities.getEntityProperties(me, "position").position;
                 Entities.editEntity(me, {
                     gravity: {
@@ -39,16 +38,13 @@
                         z: 0
                     }
                 });
-                this.hasBecomePhysical = true;
-            }
 
-            if (this.hasPlayedSound === false) {
                 this.audioInjector = Audio.playSound(this.hitSound, {
                     position: position,
                     volume: 0.5
                 });
 
-                this.hasPlayedSound = true;
+                this.hasBecomeActive = true;
 
             }
 


### PR DESCRIPTION
This PR makes it so that the targets on the wall in toybox only call their collision callback one time per viewer. Previously, the collision callback could be called repeatedly.