### PR TITLE
Only grab/release mouse grab with left button

### DIFF
--- a/examples/grab.js
+++ b/examples/grab.js
@@ -309,7 +309,7 @@ Grabber.prototype.computeNewGrabPlane = function() {
 }
 
 Grabber.prototype.pressEvent = function(event) {
-    if (!event.isLeftButton) {
+    if (event.isLeftButton!==true ||event.isRightButton===true || event.isMiddleButton===true) {
         return;
     }
 
@@ -374,7 +374,11 @@ Grabber.prototype.pressEvent = function(event) {
     //Audio.playSound(grabSound, { position: entityProperties.position, volume: VOLUME });
 }
 
-Grabber.prototype.releaseEvent = function() {
+Grabber.prototype.releaseEvent = function(event) {
+        if (event.isLeftButton!==true ||event.isRightButton===true || event.isMiddleButton===true) {
+        return;
+    }
+
     if (this.isGrabbing) {
         this.deactivateEntity(this.entityID);
         this.isGrabbing = false


### PR DESCRIPTION
Previously, it was possible to pick up an object with mouse grab, and get the object into a unrecoverable state by pressing another mouse button.  Now only left clicks will have an effect.