### PR TITLE
reduced avatar max fly speed

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -64,7 +64,7 @@ const float MIN_AVATAR_SPEED = 0.05f; // speed is set to zero below this
 
 // TODO: normalize avatar speed for standard avatar size, then scale all motion logic
 // to properly follow avatar size.
-float MAX_AVATAR_SPEED = 300.0f;
+float MAX_AVATAR_SPEED = 30.0f;
 float MAX_KEYBOARD_MOTOR_SPEED = MAX_AVATAR_SPEED;
 float DEFAULT_KEYBOARD_MOTOR_TIMESCALE = 0.25f;
 float MIN_SCRIPTED_MOTOR_TIMESCALE = 0.005f;


### PR DESCRIPTION
The max fly speed used to be 300m/sec, I reduced it to 30m/sec (~67mph).  For comparison, as I recall the max unassisted fly speed in SL was about 50m/sec.

I considered making it a preference so that users could play with it but:

(1) I think maybe someone is currently overhauling the preferences window (?), so I figured we could wait until that is done.

(2) Its hard to tune it with our current animation and position glitches  -- it doesn't look good at any high speed.