### PR TITLE
Thread-safe access to EntityTree in OverlayPanel

### DIFF
--- a/interface/src/ui/overlays/OverlayPanel.cpp
+++ b/interface/src/ui/overlays/OverlayPanel.cpp
@@ -172,7 +172,10 @@ void OverlayPanel::applyTransformTo(Transform& transform, bool force) {
             } else if (!_anchorPositionBindEntity.isNull()) {
                 EntityTreePointer entityTree = DependencyManager::get<EntityScriptingInterface>()->getEntityTree();
                 entityTree->withReadLock([&] {
-                    transform.setTranslation(entityTree->findEntityByID(_anchorPositionBindEntity)->getPosition());
+                    EntityItemPointer foundEntity = entityTree->findEntityByID(_anchorPositionBindEntity);
+                    if (foundEntity != NULL) {
+                        transform.setTranslation(foundEntity->getPosition());
+                    }
                 });
             } else {
                 transform.setTranslation(getAnchorPosition());
@@ -184,7 +187,10 @@ void OverlayPanel::applyTransformTo(Transform& transform, bool force) {
             } else if (!_anchorRotationBindEntity.isNull()) {
                 EntityTreePointer entityTree = DependencyManager::get<EntityScriptingInterface>()->getEntityTree();
                 entityTree->withReadLock([&] {
-                    transform.setRotation(entityTree->findEntityByID(_anchorRotationBindEntity)->getRotation());
+                    EntityItemPointer foundEntity = entityTree->findEntityByID(_anchorRotationBindEntity);
+                    if (foundEntity != NULL) {
+                        transform.setRotation(foundEntity->getRotation());
+                    }
                 });
             } else {
                 transform.setRotation(getAnchorRotation());

--- a/interface/src/ui/overlays/OverlayPanel.cpp
+++ b/interface/src/ui/overlays/OverlayPanel.cpp
@@ -170,9 +170,10 @@ void OverlayPanel::applyTransformTo(Transform& transform, bool force) {
                 transform.setTranslation(DependencyManager::get<AvatarManager>()->getMyAvatar()
                                          ->getPosition());
             } else if (!_anchorPositionBindEntity.isNull()) {
-                transform.setTranslation(DependencyManager::get<EntityScriptingInterface>()
-                                         ->getEntityTree()->findEntityByID(_anchorPositionBindEntity)
-                                         ->getPosition());
+                EntityTreePointer entityTree = DependencyManager::get<EntityScriptingInterface>()->getEntityTree();
+                entityTree->withReadLock([&] {
+                    transform.setTranslation(entityTree->findEntityByID(_anchorPositionBindEntity)->getPosition());
+                });
             } else {
                 transform.setTranslation(getAnchorPosition());
             }
@@ -181,9 +182,10 @@ void OverlayPanel::applyTransformTo(Transform& transform, bool force) {
                 transform.setRotation(DependencyManager::get<AvatarManager>()->getMyAvatar()
                                       ->getOrientation());
             } else if (!_anchorRotationBindEntity.isNull()) {
-                transform.setRotation(DependencyManager::get<EntityScriptingInterface>()
-                                      ->getEntityTree()->findEntityByID(_anchorRotationBindEntity)
-                                      ->getRotation());
+                EntityTreePointer entityTree = DependencyManager::get<EntityScriptingInterface>()->getEntityTree();
+                entityTree->withReadLock([&] {
+                    transform.setRotation(entityTree->findEntityByID(_anchorRotationBindEntity)->getRotation());
+                });
             } else {
                 transform.setRotation(getAnchorRotation());
             }

--- a/interface/src/ui/overlays/OverlayPanel.cpp
+++ b/interface/src/ui/overlays/OverlayPanel.cpp
@@ -173,7 +173,7 @@ void OverlayPanel::applyTransformTo(Transform& transform, bool force) {
                 EntityTreePointer entityTree = DependencyManager::get<EntityScriptingInterface>()->getEntityTree();
                 entityTree->withReadLock([&] {
                     EntityItemPointer foundEntity = entityTree->findEntityByID(_anchorPositionBindEntity);
-                    if (foundEntity != NULL) {
+                    if (foundEntity) {
                         transform.setTranslation(foundEntity->getPosition());
                     }
                 });
@@ -188,7 +188,7 @@ void OverlayPanel::applyTransformTo(Transform& transform, bool force) {
                 EntityTreePointer entityTree = DependencyManager::get<EntityScriptingInterface>()->getEntityTree();
                 entityTree->withReadLock([&] {
                     EntityItemPointer foundEntity = entityTree->findEntityByID(_anchorRotationBindEntity);
-                    if (foundEntity != NULL) {
+                    if (foundEntity) {
                         transform.setRotation(foundEntity->getRotation());
                     }
                 });


### PR DESCRIPTION
Binding an overlay to an entity caused crashes. This PR seems to fix the problem