### PR TITLE
movable audio bar

### DIFF
--- a/interface/resources/qml/AvatarInputs.qml
+++ b/interface/resources/qml/AvatarInputs.qml
@@ -10,21 +10,32 @@ import Hifi 1.0 as Hifi
 import QtQuick 2.4
 import QtQuick.Controls 1.3
 import QtGraphicalEffects 1.0
+import Qt.labs.settings 1.0
 
 Hifi.AvatarInputs {
     id: root
     objectName: "AvatarInputs"
-    anchors.fill: parent
+    width: mirrorWidth
+    height: controls.height + mirror.height 
+    x: 10; y: 5
 
-//    width: 800
-//    height: 600
-//    color: "black"
-    readonly property int iconPadding: 5
     readonly property int mirrorHeight: 215
     readonly property int mirrorWidth: 265
-    readonly property int mirrorTopPad: iconPadding
-    readonly property int mirrorLeftPad: 10
     readonly property int iconSize: 24
+    readonly property int iconPadding: 5
+    
+    Settings {
+        category: "Overlay.AvatarInputs"
+        property alias x: root.x
+        property alias y: root.y
+    }
+    
+    MouseArea {
+        id: hover
+        hoverEnabled: true
+        drag.target: parent
+        anchors.fill: parent
+    }
 
     Item {
         id: mirror
@@ -32,17 +43,7 @@ Hifi.AvatarInputs {
         height: root.mirrorVisible ? root.mirrorHeight : 0
         visible: root.mirrorVisible
         anchors.left: parent.left
-        anchors.leftMargin: root.mirrorLeftPad
-        anchors.top: parent.top
-        anchors.topMargin: root.mirrorTopPad
         clip: true
-
-        MouseArea {
-             id: hover
-             anchors.fill: parent
-             hoverEnabled: true
-             propagateComposedEvents: true
-         }
 
         Image {
             id: closeMirror
@@ -64,7 +65,7 @@ Hifi.AvatarInputs {
 
         Image {
             id: zoomIn
-            visible:  hover.containsMouse
+            visible: hover.containsMouse
             width: root.iconSize
             height: root.iconSize
             anchors.bottom: parent.bottom
@@ -82,14 +83,11 @@ Hifi.AvatarInputs {
     }
 
     Item {
+        id: controls
         width: root.mirrorWidth
         height: 44
         visible: !root.isHMD
-
-        x: root.mirrorLeftPad
-        y: root.mirrorVisible ? root.mirrorTopPad + root.mirrorHeight : 5
-
-
+        anchors.top: mirror.bottom
 
         Rectangle {
             anchors.fill: parent


### PR DESCRIPTION
This makes the mute / face mute / audio meter bar movable and also persists the location on shutdown.  

However, this is slightly problematic when you have the mirror on, because the mirror render location is hard coded in the C++.  