### PR TITLE
fix queryAABox bug

### DIFF
--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -598,7 +598,8 @@ AACube SpatiallyNestable::getQueryAACube(bool& success) const {
         return _queryAACube;
     }
     success = false;
-    return AACube(getPosition(success) - glm::vec3(defaultAACubeSize / 2.0f), defaultAACubeSize);
+    bool getPositionSuccess;
+    return AACube(getPosition(getPositionSuccess) - glm::vec3(defaultAACubeSize / 2.0f), defaultAACubeSize);
 }
 
 AACube SpatiallyNestable::getQueryAACube() const {


### PR DESCRIPTION
- fix a bug that caused queryAABox of some entities to be a unit cube instead of the correct size
