### PR TITLE
Fix not being able to change model textures - part 1

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -129,7 +129,11 @@ void RenderableModelEntityItem::remapTextures() {
     QJsonObject currentTexturesAsJsonObject = currentTexturesAsJson.object();
     QVariantMap currentTextureMap = currentTexturesAsJsonObject.toVariantMap();
 
-    QJsonDocument texturesAsJson = QJsonDocument::fromJson(_textures.toUtf8());
+    QJsonParseError error;
+    QJsonDocument texturesAsJson = QJsonDocument::fromJson(_textures.toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError) {
+        qCWarning(entitiesrenderer) << "Could not evaluate textures property:" << _textures;
+    }
     QJsonObject texturesAsJsonObject = texturesAsJson.object();
     QVariantMap textureMap = texturesAsJsonObject.toVariantMap();
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -101,6 +101,21 @@ int RenderableModelEntityItem::readEntitySubclassDataFromBuffer(const unsigned c
     return bytesRead;
 }
 
+QVariantMap RenderableModelEntityItem::parseTexturesToMap(QString textures) {
+    if (textures == "") {
+        return QVariantMap();
+    }
+
+    QString jsonTextures = "{\"" + textures.replace(":\"", "\":\"").replace(",\n", ",\"") + "}";
+    QJsonParseError error;
+    QJsonDocument texturesAsJson = QJsonDocument::fromJson(jsonTextures.toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError) {
+        qCWarning(entitiesrenderer) << "Could not evaluate textures property value:" << _textures;
+    }
+    QJsonObject texturesAsJsonObject = texturesAsJson.object();
+    return texturesAsJsonObject.toVariantMap();
+}
+
 void RenderableModelEntityItem::remapTextures() {
     if (!_model) {
         return; // nothing to do if we don't have a model
@@ -125,17 +140,8 @@ void RenderableModelEntityItem::remapTextures() {
     // since we're changing here, we need to run through our current texture map
     // and any textures in the recently mapped texture, that is not in our desired
     // textures, we need to "unset"
-    QJsonDocument currentTexturesAsJson = QJsonDocument::fromJson(_currentTextures.toUtf8());
-    QJsonObject currentTexturesAsJsonObject = currentTexturesAsJson.object();
-    QVariantMap currentTextureMap = currentTexturesAsJsonObject.toVariantMap();
-
-    QJsonParseError error;
-    QJsonDocument texturesAsJson = QJsonDocument::fromJson(_textures.toUtf8(), &error);
-    if (error.error != QJsonParseError::NoError) {
-        qCWarning(entitiesrenderer) << "Could not evaluate textures property:" << _textures;
-    }
-    QJsonObject texturesAsJsonObject = texturesAsJson.object();
-    QVariantMap textureMap = texturesAsJsonObject.toVariantMap();
+    QVariantMap currentTextureMap = parseTexturesToMap(_currentTextures);
+    QVariantMap textureMap = parseTexturesToMap(_textures);
 
     foreach(const QString& key, currentTextureMap.keys()) {
         // if the desired texture map (what we're setting the textures to) doesn't

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -80,6 +80,7 @@ public:
     virtual void resizeJointArrays(int newSize = -1) override;
 
 private:
+    QVariantMap parseTexturesToMap(QString textures);
     void remapTextures();
 
     Model* _model = nullptr;

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -171,22 +171,22 @@ QStringList NetworkGeometry::getTextureNames() const {
     for (auto&& material : _materials) {
         if (!material->diffuseTextureName.isEmpty() && material->diffuseTexture) {
             QString textureURL = material->diffuseTexture->getURL().toString();
-            result << material->diffuseTextureName + ":" + textureURL;
+            result << material->diffuseTextureName + ":\"" + textureURL + "\"";
         }
 
         if (!material->normalTextureName.isEmpty() && material->normalTexture) {
             QString textureURL = material->normalTexture->getURL().toString();
-            result << material->normalTextureName + ":" + textureURL;
+            result << material->normalTextureName + ":\"" + textureURL + "\"";
         }
 
         if (!material->specularTextureName.isEmpty() && material->specularTexture) {
             QString textureURL = material->specularTexture->getURL().toString();
-            result << material->specularTextureName + ":" + textureURL;
+            result << material->specularTextureName + ":\"" + textureURL + "\"";
         }
 
         if (!material->emissiveTextureName.isEmpty() && material->emissiveTexture) {
             QString textureURL = material->emissiveTexture->getURL().toString();
-            result << material->emissiveTextureName + ":" + textureURL;
+            result << material->emissiveTextureName + ":\"" + textureURL + "\"";
         }
     }
 

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -72,7 +72,7 @@ void GeometryReader::run() {
             } else if (_url.path().toLower().endsWith(".obj")) {
                 fbxgeo = OBJReader().readOBJ(_data, _mapping, _url);
             } else {
-                QString errorStr("usupported format");
+                QString errorStr("unsupported format");
                 emit onError(NetworkGeometry::ModelParseError, errorStr);
             }
             emit onSuccess(fbxgeo);
@@ -149,7 +149,6 @@ void NetworkGeometry::setTextureWithNameToURL(const QString& name, const QUrl& u
     if (_meshes.size() > 0) {
         auto textureCache = DependencyManager::get<TextureCache>();
         for (auto&& material : _materials) {
-            QSharedPointer<NetworkTexture> matchingTexture = QSharedPointer<NetworkTexture>();
             if (material->diffuseTextureName == name) {
                 material->diffuseTexture = textureCache->getTexture(url, DEFAULT_TEXTURE);
             } else if (material->normalTextureName == name) {


### PR DESCRIPTION
This fixes the "textures" property of model entities not successfully being interpreted. They are now once again loaded through to NetworkGeometry::setTextureWithNameToURL(), as evidenced by program log messages saying that the new texture has been requested and loaded, e.g., "Updating texture named "diffuse" to texture at URL QUrl("http://...")"