### PR TITLE
Ensure Oculus session is valid before base class activation

### DIFF
--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -78,7 +78,6 @@ void OculusBaseDisplayPlugin::deinit() {
 }
 
 void OculusBaseDisplayPlugin::activate() {
-    WindowOpenGLDisplayPlugin::activate();
     if (!OVR_SUCCESS(ovr_Initialize(nullptr))) {
         qFatal("Could not init OVR");
     }
@@ -86,6 +85,8 @@ void OculusBaseDisplayPlugin::activate() {
     if (!OVR_SUCCESS(ovr_Create(&_session, &_luid))) {
         qFatal("Failed to acquire HMD");
     }
+
+    WindowOpenGLDisplayPlugin::activate();
 
     _hmdDesc = ovr_GetHmdDesc(_session);
 


### PR DESCRIPTION
Once the base class `activate` method is run, the presentation thread is free to do stuff.  However the presentation thread context customization for oculus depends on the session being available, which isn't guaranteed due to the asynchronicity. The long term solution for all plugins is something similar to what we do with a similar problem with `uncustomizeContext` and `deactivate`... that is, use a conditional variable to ensure that `activate` is done before we proceed with `customizeContext`.  However it's trickier due to the ordering of operations.  

For now, this re-ordering of initializing the session and calling the base class `activate` should suffice.
