### PR TITLE
Move shape rendering code in DeferredLightingEffect to GeometryCache

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3611,7 +3611,7 @@ namespace render {
             PerformanceTimer perfTimer("worldBox");
 
             auto& batch = *args->_batch;
-            DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch);
+            DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch);
             renderWorldBox(batch);
         }
     }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1600,7 +1600,7 @@ void Application::paintGL() {
         Stats::getInstance()->setRenderDetails(renderArgs._details);
         // Reset the gpu::Context Stages
         // Back to the default framebuffer;
-        gpu::doInBatch(renderArgs._context, [=](gpu::Batch& batch) {
+        gpu::doInBatch(renderArgs._context, [&](gpu::Batch& batch) {
             batch.resetStages();
         });
     }

--- a/interface/src/Util.cpp
+++ b/interface/src/Util.cpp
@@ -25,7 +25,6 @@
 #include <QThread>
 
 #include <ByteCountCoding.h>
-#include <DeferredLightingEffect.h>
 #include <GeometryCache.h>
 #include <OctreeConstants.h>
 #include <SharedUtil.h>
@@ -96,28 +95,27 @@ void renderWorldBox(gpu::Batch& batch) {
     geometryCache->renderLine(batch, glm::vec3(-HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE),
                               glm::vec3(HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY);
 
-    auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
-
-    deferredLighting->renderWireCubeInstance(batch, Transform(), GREY4);
+    
+    geometryCache->renderWireCubeInstance(batch, Transform(), GREY4);
 
     //  Draw meter markers along the 3 axis to help with measuring things
     const float MARKER_DISTANCE = 1.0f;
     const float MARKER_RADIUS = 0.05f;
 
     transform = Transform().setScale(MARKER_RADIUS);
-    deferredLighting->renderSolidSphereInstance(batch, transform, RED);
+    geometryCache->renderSolidSphereInstance(batch, transform, RED);
 
     transform = Transform().setTranslation(glm::vec3(MARKER_DISTANCE, 0.0f, 0.0f)).setScale(MARKER_RADIUS);
-    deferredLighting->renderSolidSphereInstance(batch, transform, RED);
+    geometryCache->renderSolidSphereInstance(batch, transform, RED);
 
     transform = Transform().setTranslation(glm::vec3(0.0f, MARKER_DISTANCE, 0.0f)).setScale(MARKER_RADIUS);
-    deferredLighting->renderSolidSphereInstance(batch, transform, GREEN);
+    geometryCache->renderSolidSphereInstance(batch, transform, GREEN);
 
     transform = Transform().setTranslation(glm::vec3(0.0f, 0.0f, MARKER_DISTANCE)).setScale(MARKER_RADIUS);
-    deferredLighting->renderSolidSphereInstance(batch, transform, BLUE);
+    geometryCache->renderSolidSphereInstance(batch, transform, BLUE);
 
     transform = Transform().setTranslation(glm::vec3(MARKER_DISTANCE, 0.0f, MARKER_DISTANCE)).setScale(MARKER_RADIUS);
-    deferredLighting->renderSolidSphereInstance(batch, transform, GREY);
+    geometryCache->renderSolidSphereInstance(batch, transform, GREY);
 }
 
 //  Return a random vector of average length 1

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -331,7 +331,6 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
 
     if (glm::distance(DependencyManager::get<AvatarManager>()->getMyAvatar()->getPosition(), getPosition()) < 10.0f) {
         auto geometryCache = DependencyManager::get<GeometryCache>();
-        auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
 
         // render pointing lasers
         glm::vec3 laserColor = glm::vec3(1.0f, 0.0f, 1.0f);
@@ -359,7 +358,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                 pointerTransform.setTranslation(position);
                 pointerTransform.setRotation(rotation);
                 batch.setModelTransform(pointerTransform);
-                deferredLighting->bindSimpleProgram(batch);
+                geometryCache->bindSimpleProgram(batch);
                 geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor);
             }
         }
@@ -383,7 +382,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                 pointerTransform.setTranslation(position);
                 pointerTransform.setRotation(rotation);
                 batch.setModelTransform(pointerTransform);
-                deferredLighting->bindSimpleProgram(batch);
+                geometryCache->bindSimpleProgram(batch);
                 geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor);
             }
         }
@@ -457,7 +456,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
             Transform transform;
             transform.setTranslation(position);
             transform.postScale(INDICATOR_RADIUS);
-            DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch, transform, LOOK_AT_INDICATOR_COLOR);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, transform, LOOK_AT_INDICATOR_COLOR);
         }
 
         // If the avatar is looking at me, indicate that they are
@@ -485,7 +484,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
 
-                    DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch,
+                    DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch,
                         Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT),
                         glm::vec4(LOOKING_AT_ME_COLOR, alpha));
 
@@ -495,7 +494,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                     if (eyeDiameter == 0.0f) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
-                    DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch,
+                    DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch,
                         Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT),
                         glm::vec4(LOOKING_AT_ME_COLOR, alpha));
 
@@ -655,7 +654,7 @@ void Avatar::renderBillboard(RenderArgs* renderArgs) {
     gpu::Batch& batch = *renderArgs->_batch;
     PROFILE_RANGE_BATCH(batch, __FUNCTION__);
     batch.setResourceTexture(0, _billboardTexture->getGPUTexture());
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, true);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, true);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
                                                         glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
 }
@@ -791,7 +790,7 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& frustum, co
 
         {
             PROFILE_RANGE_BATCH(batch, __FUNCTION__":renderBevelCornersRect");
-            DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, false, true, true, true);
+            DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, true, true, true);
             DependencyManager::get<GeometryCache>()->renderBevelCornersRect(batch, left, bottom, width, height,
                 bevelDistance, backgroundColor);
         }

--- a/interface/src/avatar/Hand.cpp
+++ b/interface/src/avatar/Hand.cpp
@@ -14,7 +14,6 @@
 
 #include <GeometryUtil.h>
 #include <RenderArgs.h>
-#include <DeferredLightingEffect.h>
 
 #include "Avatar.h"
 #include "AvatarManager.h"
@@ -61,7 +60,7 @@ void Hand::renderHandTargets(RenderArgs* renderArgs, bool isMine) {
             transform.setTranslation(position);
             transform.setRotation(palm.getRotation());
             transform.postScale(SPHERE_RADIUS);
-            DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch, transform, grayColor);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, transform, grayColor);
 
             // draw a green sphere at the old "finger tip"
             transform = Transform();
@@ -69,7 +68,7 @@ void Hand::renderHandTargets(RenderArgs* renderArgs, bool isMine) {
             transform.setTranslation(position);
             transform.setRotation(palm.getRotation());
             transform.postScale(SPHERE_RADIUS);
-            DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch, transform, greenColor);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, transform, greenColor);
         }
     }
 

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -11,8 +11,6 @@
 #include <glm/gtx/quaternion.hpp>
 #include <gpu/Batch.h>
 
-#include <DependencyManager.h>
-#include <DeferredLightingEffect.h>
 #include <NodeList.h>
 #include <recording/Deck.h>
 
@@ -451,12 +449,11 @@ void Head::renderLookatVectors(RenderArgs* renderArgs, glm::vec3 leftEyePosition
     batch.setModelTransform(transform);
     // FIXME: THe line width of 2.0f is not supported anymore, we ll need a workaround
 
-    auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
-    deferredLighting->bindSimpleProgram(batch);
-
-    auto geometryCache = DependencyManager::get<GeometryCache>();
     glm::vec4 startColor(0.2f, 0.2f, 0.2f, 1.0f);
     glm::vec4 endColor(1.0f, 1.0f, 1.0f, 0.0f);
+    
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    geometryCache->bindSimpleProgram(batch);
     geometryCache->renderLine(batch, leftEyePosition, lookatPosition, startColor, endColor, _leftEyeLookAtID);
     geometryCache->renderLine(batch, rightEyePosition, lookatPosition, startColor, endColor, _rightEyeLookAtID);
 }
@@ -466,9 +463,9 @@ void Head::renderLookatTarget(RenderArgs* renderArgs, glm::vec3 lookatPosition) 
     auto transform = Transform{};
     transform.setTranslation(lookatPosition);
 
-    auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
+    auto geometryCache = DependencyManager::get<GeometryCache>();
     const float LOOK_AT_TARGET_RADIUS = 0.075f;
     transform.postScale(LOOK_AT_TARGET_RADIUS);
     const glm::vec4 LOOK_AT_TARGET_COLOR = { 0.8f, 0.0f, 0.0f, 0.75f };
-    deferredLighting->renderSolidSphereInstance(batch, transform, LOOK_AT_TARGET_COLOR);
+    geometryCache->renderSolidSphereInstance(batch, transform, LOOK_AT_TARGET_COLOR);
 }

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -12,7 +12,6 @@
 #include <glm/gtx/transform.hpp>
 #include <QMultiMap>
 
-#include <DeferredLightingEffect.h>
 #include <recording/Deck.h>
 
 #include "Application.h"
@@ -347,11 +346,10 @@ void SkeletonModel::computeBoundingShape() {
 
 void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float scale, float alpha) {
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
     // draw a blue sphere at the capsule top point
     glm::vec3 topPoint = _translation + getRotation() * (scale * (_boundingCapsuleLocalOffset + (0.5f * _boundingCapsuleHeight) * Vectors::UNIT_Y));
 
-    deferredLighting->renderSolidSphereInstance(batch,
+    geometryCache->renderSolidSphereInstance(batch,
         Transform().setTranslation(topPoint).postScale(scale * _boundingCapsuleRadius),
     	glm::vec4(0.6f, 0.6f, 0.8f, alpha));
 
@@ -359,14 +357,14 @@ void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float scale
     glm::vec3 bottomPoint = topPoint - glm::vec3(0.0f, scale * _boundingCapsuleHeight, 0.0f);
     glm::vec3 axis = topPoint - bottomPoint;
 
-    deferredLighting->renderSolidSphereInstance(batch,
+    geometryCache->renderSolidSphereInstance(batch,
         Transform().setTranslation(bottomPoint).postScale(scale * _boundingCapsuleRadius),
         glm::vec4(0.8f, 0.8f, 0.6f, alpha));
 
     // draw a green cylinder between the two points
     glm::vec3 origin(0.0f);
     batch.setModelTransform(Transform().setTranslation(bottomPoint));
-    deferredLighting->bindSimpleProgram(batch);
+    geometryCache->bindSimpleProgram(batch);
     Avatar::renderJointConnectingCone(batch, origin, axis, scale * _boundingCapsuleRadius, scale * _boundingCapsuleRadius,
                                       glm::vec4(0.6f, 0.8f, 0.6f, alpha));
 }

--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -202,7 +202,7 @@ void ApplicationCompositor::displayOverlayTexture(RenderArgs* renderArgs) {
     updateTooltips();
 
     //Handle fading and deactivation/activation of UI
-    gpu::doInBatch(renderArgs->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(renderArgs->_context, [&](gpu::Batch& batch) {
 
         auto geometryCache = DependencyManager::get<GeometryCache>();
 
@@ -270,7 +270,7 @@ void ApplicationCompositor::displayOverlayTextureHmd(RenderArgs* renderArgs, int
 
     auto geometryCache = DependencyManager::get<GeometryCache>();
 
-    gpu::doInBatch(renderArgs->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(renderArgs->_context, [&](gpu::Batch& batch) {
         geometryCache->useSimpleDrawPipeline(batch);
 
         batch.setResourceTexture(0, overlayFramebuffer->getRenderBuffer(0));

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -12,7 +12,6 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include <avatar/AvatarManager.h>
-#include <DeferredLightingEffect.h>
 #include <GLMHelpers.h>
 #include <gpu/GLBackendShared.h>
 #include <FramebufferCache.h>

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -70,7 +70,7 @@ void ApplicationOverlay::renderOverlay(RenderArgs* renderArgs) {
     }
 
     // Execute the batch into our framebuffer
-    doInBatch(renderArgs->_context, [=](gpu::Batch& batch) {
+    doInBatch(renderArgs->_context, [&](gpu::Batch& batch) {
         renderArgs->_batch = &batch;
 
         int width = _overlayFramebuffer->getWidth();

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -10,7 +10,6 @@
 
 #include "Circle3DOverlay.h"
 
-#include <DeferredLightingEffect.h>
 #include <GeometryCache.h>
 #include <RegisteredMetaTypes.h>
 
@@ -106,7 +105,7 @@ void Circle3DOverlay::render(RenderArgs* args) {
     auto transform = _transform;
     transform.postScale(glm::vec3(getDimensions(), 1.0f));
     batch.setModelTransform(transform);
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, false, false);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false);
     
     // for our overlay, is solid means we draw a ring between the inner and outer radius of the circle, otherwise
     // we just draw a line...

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -13,7 +13,6 @@
 
 #include <QScriptValue>
 
-#include <DeferredLightingEffect.h>
 #include <SharedUtil.h>
 #include <StreamUtils.h>
 #include <GeometryCache.h>
@@ -61,7 +60,7 @@ void Cube3DOverlay::render(RenderArgs* args) {
             // }
 
             transform.setScale(dimensions);
-            DependencyManager::get<DeferredLightingEffect>()->renderSolidCubeInstance(*batch, transform, cubeColor);
+            DependencyManager::get<GeometryCache>()->renderSolidCubeInstance(*batch, transform, cubeColor);
         } else {
 
             if (getIsDashedLine()) {
@@ -99,7 +98,7 @@ void Cube3DOverlay::render(RenderArgs* args) {
             } else {
                 batch->setModelTransform(Transform());
                 transform.setScale(dimensions);
-                DependencyManager::get<DeferredLightingEffect>()->renderWireCubeInstance(*batch, transform, cubeColor);
+                DependencyManager::get<GeometryCache>()->renderWireCubeInstance(*batch, transform, cubeColor);
             }
         }
     }

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -14,7 +14,6 @@
 
 #include <QScriptValue>
 
-#include <DeferredLightingEffect.h>
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <gpu/Batch.h>
@@ -96,7 +95,7 @@ void Image3DOverlay::render(RenderArgs* args) {
     batch->setModelTransform(transform);
     batch->setResourceTexture(0, _texture->getGPUTexture());
 
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(*batch, true, false, _emissive, true);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(*batch, true, false, _emissive, true);
     DependencyManager::get<GeometryCache>()->renderQuad(
         *batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
         glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha)

--- a/interface/src/ui/overlays/ImageOverlay.cpp
+++ b/interface/src/ui/overlays/ImageOverlay.cpp
@@ -13,7 +13,6 @@
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <gpu/Context.h>
-#include <gpu/StandardShaderLib.h>
 #include <RegisteredMetaTypes.h>
 
 

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -12,7 +12,6 @@
 
 #include <GeometryCache.h>
 #include <RegisteredMetaTypes.h>
-#include <DeferredLightingEffect.h>
 
 
 QString const Line3DOverlay::TYPE = "line3d";
@@ -54,7 +53,7 @@ void Line3DOverlay::render(RenderArgs* args) {
     auto batch = args->_batch;
     if (batch) {
         batch->setModelTransform(_transform);
-        DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(*batch);
+        DependencyManager::get<GeometryCache>()->bindSimpleProgram(*batch);
 
         if (getIsDashedLine()) {
             // TODO: add support for color to renderDashedLine()

--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -222,10 +222,8 @@ float Overlay::updatePulse() {
 }
 
 bool Overlay::addToScene(Overlay::Pointer overlay, std::shared_ptr<render::Scene> scene, render::PendingChanges& pendingChanges) {
-    auto overlayPayload = new Overlay::Payload(overlay);
-    auto overlayPayloadPointer = Overlay::PayloadPointer(overlayPayload);
     _renderItemID = scene->allocateID();
-    pendingChanges.resetItem(_renderItemID, overlayPayloadPointer);
+    pendingChanges.resetItem(_renderItemID, std::make_shared<Overlay::Payload>(overlay));
     return true;
 }
 

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -12,7 +12,6 @@
 
 #include <DependencyManager.h>
 #include <GeometryCache.h>
-#include <DeferredLightingEffect.h>
 #include <gpu/Batch.h>
 #include <SharedUtil.h>
 
@@ -45,12 +44,11 @@ void Sphere3DOverlay::render(RenderArgs* args) {
         Transform transform = _transform;
         transform.postScale(getDimensions() * SPHERE_OVERLAY_SCALE);
         if (_isSolid) {
-            DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(*batch, transform, sphereColor);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(*batch, transform, sphereColor);
         } else {
-            DependencyManager::get<DeferredLightingEffect>()->renderWireSphereInstance(*batch, transform, sphereColor);
+            DependencyManager::get<GeometryCache>()->renderWireSphereInstance(*batch, transform, sphereColor);
         }
     }
-
 }
 
 Sphere3DOverlay* Sphere3DOverlay::createClone() const {

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -10,7 +10,6 @@
 
 #include "Text3DOverlay.h"
 
-#include <DeferredLightingEffect.h>
 #include <GeometryCache.h>
 #include <RegisteredMetaTypes.h>
 #include <RenderDeferredTask.h>
@@ -101,7 +100,7 @@ void Text3DOverlay::render(RenderArgs* args) {
     
     glm::vec3 topLeft(-halfDimensions.x, -halfDimensions.y, SLIGHTLY_BEHIND);
     glm::vec3 bottomRight(halfDimensions.x, halfDimensions.y, SLIGHTLY_BEHIND);
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, false, true, false, true);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, true, false, true);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, quadColor);
     
     // Same font properties as textSize()

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -16,8 +16,6 @@
 #include <QtGui/QOpenGLContext>
 #include <QtQuick/QQuickItem>
 
-
-#include <DeferredLightingEffect.h>
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <GeometryUtil.h>
@@ -103,7 +101,7 @@ void Web3DOverlay::render(RenderArgs* args) {
     }
 
     batch.setModelTransform(transform);
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, true, false, false, true);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, true, false, false, true);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color);
     batch.setResourceTexture(0, args->_whiteTexture); // restore default white color after me
 }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -17,7 +17,6 @@
 #include <ColorUtils.h>
 #include <AbstractScriptingServicesInterface.h>
 #include <AbstractViewStateInterface.h>
-#include <DeferredLightingEffect.h>
 #include <Model.h>
 #include <NetworkAccessManager.h>
 #include <PerfStat.h>

--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
@@ -15,7 +15,6 @@
 
 #include <gpu/Batch.h>
 
-#include <DeferredLightingEffect.h>
 #include <GeometryCache.h>
 #include <ObjectMotionState.h>
 #include <PerfStat.h>
@@ -69,7 +68,7 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
         batch._glColor4f(color.r, color.g, color.b, color.a);
         DependencyManager::get<GeometryCache>()->renderCube(batch);
     } else {
-        DependencyManager::get<DeferredLightingEffect>()->renderSolidCubeInstance(batch, transToCenter, cubeColor);
+        DependencyManager::get<GeometryCache>()->renderSolidCubeInstance(batch, transToCenter, cubeColor);
     }
     static const auto triCount = DependencyManager::get<GeometryCache>()->getCubeTriangleCount();
     args->_details._trianglesRendered += (int)triCount;

--- a/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
@@ -51,7 +51,7 @@ void RenderableLightEntityItem::render(RenderArgs* args) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
     batch.setModelTransform(getTransformToCenter());
-    DependencyManager::get<DeferredLightingEffect>()->renderWireSphere(batch, 0.5f, 15, 15, glm::vec4(color, 1.0f));
+    DependencyManager::get<GeometryCache>()->renderWireSphere(batch, 0.5f, 15, 15, glm::vec4(color, 1.0f));
 #endif
 };
 

--- a/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
@@ -14,7 +14,6 @@
 #include <gpu/Batch.h>
 #include <GeometryCache.h>
 
-#include <DeferredLightingEffect.h>
 #include <PerfStat.h>
 
 #include "RenderableLineEntityItem.h"
@@ -53,7 +52,7 @@ void RenderableLineEntityItem::render(RenderArgs* args) {
     batch.setModelTransform(transform);
 
     if (getLinePoints().size() > 1) {
-        DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch);
+        DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch);
         DependencyManager::get<GeometryCache>()->renderVertices(batch, gpu::LINE_STRIP, _lineVerticesID);
     }
 };

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -16,7 +16,6 @@
 #include <glm/gtx/transform.hpp>
 
 #include <AbstractViewStateInterface.h>
-#include <DeferredLightingEffect.h>
 #include <Model.h>
 #include <PerfStat.h>
 #include <render/Scene.h>
@@ -432,7 +431,7 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
         auto shapeTransform = getTransformToCenter(success);
         if (success) {
             batch.setModelTransform(Transform()); // we want to include the scale as well
-            DependencyManager::get<DeferredLightingEffect>()->renderWireCubeInstance(batch, shapeTransform, greenColor);
+            DependencyManager::get<GeometryCache>()->renderWireCubeInstance(batch, shapeTransform, greenColor);
         }
     }
 }

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -11,7 +11,6 @@
 #include <glm/gtx/quaternion.hpp>
 
 #include <DependencyManager.h>
-#include <DeferredLightingEffect.h>
 #include <PerfStat.h>
 #include <GeometryCache.h>
 #include <AbstractViewStateInterface.h>

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -14,7 +14,6 @@
 #include <GeometryCache.h>
 #include <TextureCache.h>
 #include <PathUtils.h>
-#include <DeferredLightingEffect.h>
 #include <PerfStat.h>
 
 #include "RenderablePolyLineEntityItem.h"

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -27,7 +27,6 @@
 #pragma GCC diagnostic pop
 #endif
 
-#include <DeferredLightingEffect.h>
 #include <Model.h>
 #include <PerfStat.h>
 #include <render/Scene.h>

--- a/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
@@ -16,7 +16,6 @@
 #include <gpu/Batch.h>
 
 #include <DependencyManager.h>
-#include <DeferredLightingEffect.h>
 #include <GeometryCache.h>
 #include <PerfStat.h>
 
@@ -73,7 +72,7 @@ void RenderableSphereEntityItem::render(RenderArgs* args) {
         DependencyManager::get<GeometryCache>()->renderSphere(batch);
     } else {
         batch.setModelTransform(Transform());
-        DependencyManager::get<DeferredLightingEffect>()->renderSolidSphereInstance(batch, modelTransform, sphereColor);
+        DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, modelTransform, sphereColor);
     }
     static const auto triCount = DependencyManager::get<GeometryCache>()->getSphereTriangleCount();
     args->_details._trianglesRendered += (int)triCount;

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -11,7 +11,6 @@
 
 #include <glm/gtx/quaternion.hpp>
 
-#include <DeferredLightingEffect.h>
 #include <GeometryCache.h>
 #include <PerfStat.h>
 #include <Transform.h>
@@ -63,7 +62,7 @@ void RenderableTextEntityItem::render(RenderArgs* args) {
     
     batch.setModelTransform(transformToTopLeft);
     
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, false, false, false, true);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, false, true);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, minCorner, maxCorner, backgroundColor);
     
     float scale = _lineHeight / _textRenderer->getFontSize();

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -15,7 +15,6 @@
 
 #include <glm/gtx/quaternion.hpp>
 
-#include <DeferredLightingEffect.h>
 #include <GeometryCache.h>
 #include <PerfStat.h>
 #include <gl/OffscreenQmlSurface.h>
@@ -69,7 +68,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
         gpu::Batch& batch = *args->_batch;
         batch.setModelTransform(getTransformToCenter()); // we want to include the scale as well
         glm::vec4 cubeColor{ 1.0f, 0.0f, 0.0f, 1.0f};
-        DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.0f, cubeColor);
+        DependencyManager::get<GeometryCache>()->renderWireCube(batch, 1.0f, cubeColor);
     }
     #endif
 
@@ -201,7 +200,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
         textured = emissive = true;
     }
     
-    DependencyManager::get<DeferredLightingEffect>()->bindSimpleProgram(batch, textured, culled, emissive);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, textured, culled, emissive);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f));
 }
 

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -14,7 +14,6 @@
 #include <gpu/Batch.h>
 
 #include <AbstractViewStateInterface.h>
-#include <DeferredLightingEffect.h>
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <PerfStat.h>
@@ -140,12 +139,12 @@ void RenderableZoneEntityItem::render(RenderArgs* args) {
                 if (!success) {
                     break;
                 }
-                auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+                auto geometryCache = DependencyManager::get<GeometryCache>();
                 if (getShapeType() == SHAPE_TYPE_SPHERE) {
                     shapeTransform.postScale(SPHERE_ENTITY_SCALE);
-                    deferredLightingEffect->renderWireSphereInstance(batch, shapeTransform, DEFAULT_COLOR);
+                    geometryCache->renderWireSphereInstance(batch, shapeTransform, DEFAULT_COLOR);
                 } else {
-                    deferredLightingEffect->renderWireCubeInstance(batch, shapeTransform, DEFAULT_COLOR);
+                    geometryCache->renderWireCubeInstance(batch, shapeTransform, DEFAULT_COLOR);
                 }
                 break;
             }

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -362,8 +362,8 @@ bool Batch::isSkyboxEnabled() const {
 
 void Batch::setupNamedCalls(const std::string& instanceName, size_t count, NamedBatchData::Function function) {
     NamedBatchData& instance = _namedData[instanceName];
-    instance._count += count;
-    instance._function = function;
+    instance.count += count;
+    instance.function = function;
 }
 
 void Batch::setupNamedCalls(const std::string& instanceName, NamedBatchData::Function function) {
@@ -372,13 +372,13 @@ void Batch::setupNamedCalls(const std::string& instanceName, NamedBatchData::Fun
 
 BufferPointer Batch::getNamedBuffer(const std::string& instanceName, uint8_t index) {
     NamedBatchData& instance = _namedData[instanceName];
-    if (instance._buffers.size() <= index) {
-        instance._buffers.resize(index + 1);
+    if (instance.buffers.size() <= index) {
+        instance.buffers.resize(index + 1);
     }
-    if (!instance._buffers[index]) {
-        instance._buffers[index].reset(new Buffer());
+    if (!instance.buffers[index]) {
+        instance.buffers[index].reset(new Buffer());
     }
-    return instance._buffers[index];
+    return instance.buffers[index];
 }
 
 void Batch::preExecute() {

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -49,14 +49,13 @@ public:
         using BufferPointers = std::vector<BufferPointer>;
         using Function = std::function<void(gpu::Batch&, NamedBatchData&)>;
 
-        std::once_flag _once;
-        BufferPointers _buffers;
-        size_t _count{ 0 };
-        Function _function;
+        BufferPointers buffers;
+        size_t count { 0 };
+        Function function;
 
         void process(Batch& batch) {
-            if (_function) {
-                _function(batch, *this);
+            if (function) {
+                function(batch, *this);
             }
         }
     };

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -22,8 +22,6 @@
 #include "TextureCache.h"
 #include "ModelNetworkingLogging.h"
 
-#include "gpu/StandardShaderLib.h"
-
 #include "model/TextureMap.h"
 
 //#define WANT_DEBUG

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -48,9 +48,6 @@ public:
     /// \param delayLoad if true, don't load the geometry immediately; wait until load is first requested
     QSharedPointer<NetworkGeometry> getGeometry(const QUrl& url, const QUrl& fallback = QUrl(), bool delayLoad = false);
 
-    /// Set a batch to the simple pipeline, returning the previous pipeline
-    void useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend = false);
-
 private:
     ModelCache();
     virtual ~ModelCache();

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -179,7 +179,7 @@ void AmbientOcclusion::run(const render::SceneContextPointer& sceneContext, cons
     assert(renderContext->getArgs()->_viewFrustum);
 
     RenderArgs* args = renderContext->getArgs();
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         auto framebufferCache = DependencyManager::get<FramebufferCache>();
         QSize framebufferSize = framebufferCache->getFrameBufferSize();
         float fbWidth = framebufferSize.width();

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -16,7 +16,6 @@
 #include <SharedUtil.h>
 #include <gpu/Context.h>
 
-#include "gpu/StandardShaderLib.h"
 #include "AmbientOcclusionEffect.h"
 #include "TextureCache.h"
 #include "FramebufferCache.h"

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -16,7 +16,6 @@
 #include <SharedUtil.h>
 #include <gpu/Context.h>
 
-#include "gpu/StandardShaderLib.h"
 #include "AntialiasingEffect.h"
 #include "TextureCache.h"
 #include "FramebufferCache.h"

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -101,7 +101,7 @@ void Antialiasing::run(const render::SceneContextPointer& sceneContext, const re
     }
 
     RenderArgs* args = renderContext->getArgs();
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         batch.enableStereo(false);
 
         auto framebufferCache = DependencyManager::get<FramebufferCache>();

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -24,11 +24,6 @@
 #include "TextureCache.h"
 #include "FramebufferCache.h"
 
-
-#include "simple_vert.h"
-#include "simple_textured_frag.h"
-#include "simple_textured_emisive_frag.h"
-
 #include "deferred_light_vert.h"
 #include "deferred_light_limited_vert.h"
 #include "deferred_light_spot_vert.h"
@@ -53,47 +48,7 @@ struct LightLocations {
 static void loadLightProgram(const char* vertSource, const char* fragSource, bool lightVolume, gpu::PipelinePointer& program, LightLocationsPtr& locations);
 
 
-gpu::PipelinePointer DeferredLightingEffect::getPipeline(SimpleProgramKey config) {
-    auto it = _simplePrograms.find(config);
-    if (it != _simplePrograms.end()) {
-        return it.value();
-    }
-    
-    auto state = std::make_shared<gpu::State>();
-    if (config.isCulled()) {
-        state->setCullMode(gpu::State::CULL_BACK);
-    } else {
-        state->setCullMode(gpu::State::CULL_NONE);
-    }
-    state->setDepthTest(true, true, gpu::LESS_EQUAL);
-    if (config.hasDepthBias()) {
-        state->setDepthBias(1.0f);
-        state->setDepthBiasSlopeScale(1.0f);
-    }
-    state->setBlendFunction(false,
-                            gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
-                            gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-    
-    gpu::ShaderPointer program = (config.isEmissive()) ? _emissiveShader : _simpleShader;
-    gpu::PipelinePointer pipeline = gpu::Pipeline::create(program, state);
-    _simplePrograms.insert(config, pipeline);
-    return pipeline;
-}
-
 void DeferredLightingEffect::init() {
-    auto VS = gpu::Shader::createVertex(std::string(simple_vert));
-    auto PS = gpu::Shader::createPixel(std::string(simple_textured_frag));
-    auto PSEmissive = gpu::Shader::createPixel(std::string(simple_textured_emisive_frag));
-    
-    _simpleShader = gpu::Shader::createProgram(VS, PS);
-    _emissiveShader = gpu::Shader::createProgram(VS, PSEmissive);
-    
-    gpu::Shader::BindingSet slotBindings;
-    slotBindings.insert(gpu::Shader::Binding(std::string("normalFittingMap"), DeferredLightingEffect::NORMAL_FITTING_MAP_SLOT));
-    gpu::Shader::makeProgram(*_simpleShader, slotBindings);
-    gpu::Shader::makeProgram(*_emissiveShader, slotBindings);
-
-
     _directionalLightLocations = std::make_shared<LightLocations>();
     _directionalAmbientSphereLightLocations = std::make_shared<LightLocations>();
     _directionalSkyboxLightLocations = std::make_shared<LightLocations>();
@@ -121,144 +76,6 @@ void DeferredLightingEffect::init() {
     lp->setIntensity(1.0f);
     lp->setType(model::Light::SUN);
     lp->setAmbientSpherePreset(gpu::SphericalHarmonics::Preset(_ambientLightMode % gpu::SphericalHarmonics::NUM_PRESET));
-}
-
-
-
-gpu::PipelinePointer DeferredLightingEffect::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled,
-                                               bool emissive, bool depthBias) {
-    SimpleProgramKey config{textured, culled, emissive, depthBias};
-    gpu::PipelinePointer pipeline = getPipeline(config);
-    batch.setPipeline(pipeline);
-
-    gpu::ShaderPointer program = (config.isEmissive()) ? _emissiveShader : _simpleShader;
-    
-    if (!config.isTextured()) {
-        // If it is not textured, bind white texture and keep using textured pipeline
-        batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
-    }
-
-    batch.setResourceTexture(NORMAL_FITTING_MAP_SLOT, DependencyManager::get<TextureCache>()->getNormalFittingTexture());
-    return pipeline;
-}
-
-uint32_t toCompactColor(const glm::vec4& color) {
-    uint32_t compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-        ((int(color.y * 255.0f) & 0xFF) << 8) |
-        ((int(color.z * 255.0f) & 0xFF) << 16) |
-        ((int(color.w * 255.0f) & 0xFF) << 24);
-    return compactColor;
-}
-
-static const size_t INSTANCE_TRANSFORM_BUFFER = 0;
-static const size_t INSTANCE_COLOR_BUFFER = 1;
-
-template <typename F>
-void renderInstances(const std::string& name, gpu::Batch& batch, const Transform& transform, const glm::vec4& color, F f) {
-    {
-        gpu::BufferPointer instanceTransformBuffer = batch.getNamedBuffer(name, INSTANCE_TRANSFORM_BUFFER);
-        glm::mat4 glmTransform;
-        instanceTransformBuffer->append(transform.getMatrix(glmTransform));
-
-        gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(name, INSTANCE_COLOR_BUFFER);
-        auto compactColor = toCompactColor(color);
-        instanceColorBuffer->append(compactColor);
-    }
-
-    auto that = DependencyManager::get<DeferredLightingEffect>();
-    batch.setupNamedCalls(name, [=](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        auto pipeline = that->bindSimpleProgram(batch);
-        auto location = pipeline->getProgram()->getUniforms().findLocation("Instanced");
-
-        batch._glUniform1i(location, 1);
-        f(batch, data);
-        batch._glUniform1i(location, 0);
-    });
-}
-
-void DeferredLightingEffect::renderSolidSphereInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
-    static const std::string INSTANCE_NAME = __FUNCTION__;
-    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, GeometryCache::Sphere, data._count,
-            data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
-    });
-}
-
-void DeferredLightingEffect::renderWireSphereInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
-    static const std::string INSTANCE_NAME = __FUNCTION__;
-    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, GeometryCache::Sphere, data._count,
-            data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
-    });
-}
-
-// Enable this in a debug build to cause 'box' entities to iterate through all the 
-// available shape types, both solid and wireframes
-//#define DEBUG_SHAPES
-
-void DeferredLightingEffect::renderSolidCubeInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
-    static const std::string INSTANCE_NAME = __FUNCTION__;
-
-#ifdef DEBUG_SHAPES
-    static auto startTime = usecTimestampNow();
-    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-
-        auto usecs = usecTimestampNow();
-        usecs -= startTime;
-        auto msecs = usecs / USECS_PER_MSEC;
-        float seconds = msecs;
-        seconds /= MSECS_PER_SECOND;
-        float fractionalSeconds = seconds - floor(seconds);
-        int shapeIndex = (int)seconds;
-
-        // Every second we flip to the next shape.
-        static const int SHAPE_COUNT = 5;
-        GeometryCache::Shape shapes[SHAPE_COUNT] = {
-            GeometryCache::Cube,
-            GeometryCache::Tetrahedron,
-            GeometryCache::Sphere,
-            GeometryCache::Icosahedron,
-            GeometryCache::Line,
-        };
-
-        shapeIndex %= SHAPE_COUNT;
-        GeometryCache::Shape shape = shapes[shapeIndex];
-
-        // For the first half second for a given shape, show the wireframe, for the second half, show the solid.
-        if (fractionalSeconds > 0.5f) {
-            DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, shape, data._count,
-                data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
-        } else {
-            DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, shape, data._count,
-                data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
-        }
-    });
-#else
-    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderCubeInstances(batch, data._count,
-            data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
-    });
-#endif
-}
-
-void DeferredLightingEffect::renderWireCubeInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
-    static const std::string INSTANCE_NAME = __FUNCTION__;
-    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderWireCubeInstances(batch, data._count,
-            data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
-    });
-}
-
-void DeferredLightingEffect::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner,
-                                        const glm::vec4& color) {
-    bindSimpleProgram(batch);
-    DependencyManager::get<GeometryCache>()->renderQuad(batch, minCorner, maxCorner, color);
-}
-
-void DeferredLightingEffect::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
-                                        const glm::vec4& color1, const glm::vec4& color2) {
-    bindSimpleProgram(batch);
-    DependencyManager::get<GeometryCache>()->renderLine(batch, p1, p2, color1, color2);
 }
 
 void DeferredLightingEffect::addPointLight(const glm::vec3& position, float radius, const glm::vec3& color,
@@ -663,12 +480,12 @@ static void loadLightProgram(const char* vertSource, const char* fragSource, boo
     slotBindings.insert(gpu::Shader::Binding(std::string("specularMap"), 2));
     slotBindings.insert(gpu::Shader::Binding(std::string("depthMap"), 3));
     slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), 5));
-    const int LIGHT_GPU_SLOT = 3;
+    static const int LIGHT_GPU_SLOT = 3;
     slotBindings.insert(gpu::Shader::Binding(std::string("lightBuffer"), LIGHT_GPU_SLOT));
-    const int ATMOSPHERE_GPU_SLOT = 4;
+    static const int ATMOSPHERE_GPU_SLOT = 4;
     slotBindings.insert(gpu::Shader::Binding(std::string("atmosphereBufferUnit"), ATMOSPHERE_GPU_SLOT));
-
-    slotBindings.insert(gpu::Shader::Binding(std::string("deferredTransformBuffer"), DeferredLightingEffect::DEFERRED_TRANSFORM_BUFFER_SLOT));
+    static const int DEFERRED_TRANSFORM_BUFFER_SLOT = 2;
+    slotBindings.insert(gpu::Shader::Binding(std::string("deferredTransformBuffer"), DEFERRED_TRANSFORM_BUFFER_SLOT));
 
     gpu::Shader::makeProgram(*program, slotBindings);
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -295,7 +295,7 @@ void DeferredLightingEffect::addSpotLight(const glm::vec3& position, float radiu
 }
 
 void DeferredLightingEffect::prepare(RenderArgs* args) {
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         batch.enableStereo(false);
         batch.setViewportTransform(args->_viewport);
         batch.setStateScissorRect(args->_viewport);
@@ -326,7 +326,7 @@ void DeferredLightingEffect::prepare(RenderArgs* args) {
 }
 
 void DeferredLightingEffect::render(RenderArgs* args) {
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         
         // Allocate the parameters buffer used by all the deferred shaders
         if (!_deferredTransformBuffer[0]._buffer) {

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -17,7 +17,6 @@
 
 #include <gpu/Batch.h>
 #include <gpu/Context.h>
-#include <gpu/StandardShaderLib.h>
 
 #include "AbstractViewStateInterface.h"
 #include "GeometryCache.h"

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -21,10 +21,7 @@
 #include "model/Stage.h"
 #include "model/Geometry.h"
 
-#include "render/ShapePipeline.h"
-
 class RenderArgs;
-class SimpleProgramKey;
 struct LightLocations;
 using LightLocationsPtr = std::shared_ptr<LightLocations>;
 /// Handles deferred lighting for the bits that require it (voxels...)
@@ -32,42 +29,7 @@ class DeferredLightingEffect : public Dependency {
     SINGLETON_DEPENDENCY
     
 public:
-    static const int NORMAL_FITTING_MAP_SLOT = render::ShapePipeline::Slot::NORMAL_FITTING_MAP;
-    static const int DEFERRED_TRANSFORM_BUFFER_SLOT = 2;
-
     void init();
-
-    /// Sets up the state necessary to render static untextured geometry with the simple program.
-    gpu::PipelinePointer bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
-                           bool emissive = false, bool depthBias = false);
-
-    void renderSolidSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderSolidSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) { 
-        renderSolidSphereInstance(batch, xfm, glm::vec4(color, 1.0));
-    }
-
-    void renderWireSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderWireSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) {
-        renderWireSphereInstance(batch, xfm, glm::vec4(color, 1.0));
-    }
-
-    void renderSolidCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderSolidCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) {
-        renderSolidCubeInstance(batch, xfm, glm::vec4(color, 1.0));
-    }
-
-    void renderWireCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderWireCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) {
-        renderWireCubeInstance(batch, xfm, glm::vec4(color, 1.0));
-    }
-
-    
-    //// Renders a quad with the simple program.
-    void renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color);
-
-    //// Renders a line with the simple program.
-    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
-                    const glm::vec4& color1, const glm::vec4& color2);
     
     /// Adds a point light to render for the current frame.
     void addPointLight(const glm::vec3& position, float radius, const glm::vec3& color = glm::vec3(0.0f, 0.0f, 0.0f),
@@ -90,17 +52,10 @@ public:
     void setGlobalSkybox(const model::SkyboxPointer& skybox);
 
 private:
-    DeferredLightingEffect() {}
-    virtual ~DeferredLightingEffect() { }
+    DeferredLightingEffect() = default;
 
     model::MeshPointer _spotLightMesh;
     model::MeshPointer getSpotLightMesh();
-
-    gpu::PipelinePointer getPipeline(SimpleProgramKey config);
-    
-    gpu::ShaderPointer _simpleShader;
-    gpu::ShaderPointer _emissiveShader;
-    QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
     
     gpu::PipelinePointer _directionalSkyboxLight;
     LightLocationsPtr _directionalSkyboxLightLocations;
@@ -159,54 +114,5 @@ private:
     typedef gpu::BufferView UniformBufferView;
     UniformBufferView _deferredTransformBuffer[2];
 };
-
-class SimpleProgramKey {
-public:
-    enum FlagBit {
-        IS_TEXTURED_FLAG = 0,
-        IS_CULLED_FLAG,
-        IS_EMISSIVE_FLAG,
-        HAS_DEPTH_BIAS_FLAG,
-        
-        NUM_FLAGS,
-    };
-    
-    enum Flag {
-        IS_TEXTURED = (1 << IS_TEXTURED_FLAG),
-        IS_CULLED = (1 << IS_CULLED_FLAG),
-        IS_EMISSIVE = (1 << IS_EMISSIVE_FLAG),
-        HAS_DEPTH_BIAS = (1 << HAS_DEPTH_BIAS_FLAG),
-    };
-    typedef unsigned short Flags;
-    
-    bool isFlag(short flagNum) const { return bool((_flags & flagNum) != 0); }
-    
-    bool isTextured() const { return isFlag(IS_TEXTURED); }
-    bool isCulled() const { return isFlag(IS_CULLED); }
-    bool isEmissive() const { return isFlag(IS_EMISSIVE); }
-    bool hasDepthBias() const { return isFlag(HAS_DEPTH_BIAS); }
-    
-    Flags _flags = 0;
-    short _spare = 0;
-    
-    int getRaw() const { return *reinterpret_cast<const int*>(this); }
-    
-    
-    SimpleProgramKey(bool textured = false, bool culled = true,
-                     bool emissive = false, bool depthBias = false) {
-        _flags = (textured ? IS_TEXTURED : 0) | (culled ? IS_CULLED : 0) |
-        (emissive ? IS_EMISSIVE : 0) | (depthBias ? HAS_DEPTH_BIAS : 0);
-    }
-    
-    SimpleProgramKey(int bitmask) : _flags(bitmask) {}
-};
-
-inline uint qHash(const SimpleProgramKey& key, uint seed) {
-    return qHash(key.getRaw(), seed);
-}
-
-inline bool operator==(const SimpleProgramKey& a, const SimpleProgramKey& b) {
-    return a.getRaw() == b.getRaw();
-}
 
 #endif // hifi_DeferredLightingEffect_h

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1854,16 +1854,18 @@ void renderInstances(const std::string& name, gpu::Batch& batch, const Transform
 void GeometryCache::renderSolidSphereInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
     static const std::string INSTANCE_NAME = __FUNCTION__;
     renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, GeometryCache::Sphere, data._count,
-                                                                      data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+        DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, GeometryCache::Sphere, data.count,
+                                                                      data.buffers[INSTANCE_TRANSFORM_BUFFER],
+                                                                      data.buffers[INSTANCE_COLOR_BUFFER]);
     });
 }
 
 void GeometryCache::renderWireSphereInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
     static const std::string INSTANCE_NAME = __FUNCTION__;
     renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, GeometryCache::Sphere, data._count,
-                                                                          data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+        DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, GeometryCache::Sphere, data.count,
+                                                                          data.buffers[INSTANCE_TRANSFORM_BUFFER],
+                                                                          data.buffers[INSTANCE_COLOR_BUFFER]);
     });
 }
 
@@ -1901,17 +1903,20 @@ void GeometryCache::renderSolidCubeInstance(gpu::Batch& batch, const Transform& 
         
         // For the first half second for a given shape, show the wireframe, for the second half, show the solid.
         if (fractionalSeconds > 0.5f) {
-            DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, shape, data._count,
-                                                                          data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+            DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, shape, data.count,
+                                                                          data.buffers[INSTANCE_TRANSFORM_BUFFER],
+                                                                          data.buffers[INSTANCE_COLOR_BUFFER]);
         } else {
-            DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, shape, data._count,
-                                                                              data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+            DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, shape, data.count,
+                                                                              data.buffers[INSTANCE_TRANSFORM_BUFFER],
+                                                                              data.buffers[INSTANCE_COLOR_BUFFER]);
         }
     });
 #else
     renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderCubeInstances(batch, data._count,
-                                                                     data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+        DependencyManager::get<GeometryCache>()->renderCubeInstances(batch, data.count,
+                                                                     data.buffers[INSTANCE_TRANSFORM_BUFFER],
+                                                                     data.buffers[INSTANCE_COLOR_BUFFER]);
     });
 #endif
 }
@@ -1919,8 +1924,9 @@ void GeometryCache::renderSolidCubeInstance(gpu::Batch& batch, const Transform& 
 void GeometryCache::renderWireCubeInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
     static const std::string INSTANCE_NAME = __FUNCTION__;
     renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        DependencyManager::get<GeometryCache>()->renderWireCubeInstances(batch, data._count,
-                                                                         data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+        DependencyManager::get<GeometryCache>()->renderWireCubeInstances(batch, data.count,
+                                                                         data.buffers[INSTANCE_TRANSFORM_BUFFER],
+                                                                         data.buffers[INSTANCE_COLOR_BUFFER]);
     });
 }
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1841,9 +1841,8 @@ void renderInstances(const std::string& name, gpu::Batch& batch, const Transform
         instanceColorBuffer->append(compactColor);
     }
     
-    auto that = DependencyManager::get<GeometryCache>();
-    batch.setupNamedCalls(name, [=](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        auto pipeline = that->bindSimpleProgram(batch);
+    batch.setupNamedCalls(name, [f](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+        auto pipeline = DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch);
         auto location = pipeline->getProgram()->getUniforms().findLocation("Instanced");
         
         batch._glUniform1i(location, 1);

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -29,6 +29,10 @@
 
 #include "model/TextureMap.h"
 
+#include "simple_vert.h"
+#include "simple_textured_frag.h"
+#include "simple_textured_emisive_frag.h"
+
 //#define WANT_DEBUG
 
 const int GeometryCache::UNKNOWN_ID = -1;
@@ -1739,5 +1743,185 @@ void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
     } else {
         batch.setPipeline(_standardDrawPipeline);
     }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+gpu::PipelinePointer GeometryCache::getPipeline(SimpleProgramKey config) {
+    static std::once_flag once;
+    std::call_once(once, [&]() {
+        auto VS = gpu::Shader::createVertex(std::string(simple_vert));
+        auto PS = gpu::Shader::createPixel(std::string(simple_textured_frag));
+        auto PSEmissive = gpu::Shader::createPixel(std::string(simple_textured_emisive_frag));
+        
+        _simpleShader = gpu::Shader::createProgram(VS, PS);
+        _emissiveShader = gpu::Shader::createProgram(VS, PSEmissive);
+        
+        gpu::Shader::BindingSet slotBindings;
+        slotBindings.insert(gpu::Shader::Binding(std::string("normalFittingMap"), render::ShapePipeline::Slot::NORMAL_FITTING_MAP));
+        gpu::Shader::makeProgram(*_simpleShader, slotBindings);
+        gpu::Shader::makeProgram(*_emissiveShader, slotBindings);
+    });
+    
+    
+    auto it = _simplePrograms.find(config);
+    if (it != _simplePrograms.end()) {
+        return it.value();
+    }
+    
+    auto state = std::make_shared<gpu::State>();
+    if (config.isCulled()) {
+        state->setCullMode(gpu::State::CULL_BACK);
+    } else {
+        state->setCullMode(gpu::State::CULL_NONE);
+    }
+    state->setDepthTest(true, true, gpu::LESS_EQUAL);
+    if (config.hasDepthBias()) {
+        state->setDepthBias(1.0f);
+        state->setDepthBiasSlopeScale(1.0f);
+    }
+    state->setBlendFunction(false,
+                            gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+                            gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
+    
+    gpu::ShaderPointer program = (config.isEmissive()) ? _emissiveShader : _simpleShader;
+    gpu::PipelinePointer pipeline = gpu::Pipeline::create(program, state);
+    _simplePrograms.insert(config, pipeline);
+    return pipeline;
+}
+
+gpu::PipelinePointer GeometryCache::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled,
+                                                               bool emissive, bool depthBias) {
+    SimpleProgramKey config{textured, culled, emissive, depthBias};
+    gpu::PipelinePointer pipeline = getPipeline(config);
+    batch.setPipeline(pipeline);
+    
+    gpu::ShaderPointer program = (config.isEmissive()) ? _emissiveShader : _simpleShader;
+    
+    if (!config.isTextured()) {
+        // If it is not textured, bind white texture and keep using textured pipeline
+        batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
+    }
+    
+    batch.setResourceTexture(render::ShapePipeline::Slot::NORMAL_FITTING_MAP,
+                             DependencyManager::get<TextureCache>()->getNormalFittingTexture());
+    return pipeline;
+}
+
+uint32_t toCompactColor(const glm::vec4& color) {
+    uint32_t compactColor = ((int(color.x * 255.0f) & 0xFF)) |
+    ((int(color.y * 255.0f) & 0xFF) << 8) |
+    ((int(color.z * 255.0f) & 0xFF) << 16) |
+    ((int(color.w * 255.0f) & 0xFF) << 24);
+    return compactColor;
+}
+
+static const size_t INSTANCE_TRANSFORM_BUFFER = 0;
+static const size_t INSTANCE_COLOR_BUFFER = 1;
+
+template <typename F>
+void renderInstances(const std::string& name, gpu::Batch& batch, const Transform& transform, const glm::vec4& color, F f) {
+    {
+        gpu::BufferPointer instanceTransformBuffer = batch.getNamedBuffer(name, INSTANCE_TRANSFORM_BUFFER);
+        glm::mat4 glmTransform;
+        instanceTransformBuffer->append(transform.getMatrix(glmTransform));
+        
+        gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(name, INSTANCE_COLOR_BUFFER);
+        auto compactColor = toCompactColor(color);
+        instanceColorBuffer->append(compactColor);
+    }
+    
+    auto that = DependencyManager::get<GeometryCache>();
+    batch.setupNamedCalls(name, [=](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+        auto pipeline = that->bindSimpleProgram(batch);
+        auto location = pipeline->getProgram()->getUniforms().findLocation("Instanced");
+        
+        batch._glUniform1i(location, 1);
+        f(batch, data);
+        batch._glUniform1i(location, 0);
+    });
+}
+
+void GeometryCache::renderSolidSphereInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
+    static const std::string INSTANCE_NAME = __FUNCTION__;
+    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+        DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, GeometryCache::Sphere, data._count,
+                                                                      data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+    });
+}
+
+void GeometryCache::renderWireSphereInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
+    static const std::string INSTANCE_NAME = __FUNCTION__;
+    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+        DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, GeometryCache::Sphere, data._count,
+                                                                          data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+    });
+}
+
+// Enable this in a debug build to cause 'box' entities to iterate through all the
+// available shape types, both solid and wireframes
+//#define DEBUG_SHAPES
+
+void GeometryCache::renderSolidCubeInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
+    static const std::string INSTANCE_NAME = __FUNCTION__;
+    
+#ifdef DEBUG_SHAPES
+    static auto startTime = usecTimestampNow();
+    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+        
+        auto usecs = usecTimestampNow();
+        usecs -= startTime;
+        auto msecs = usecs / USECS_PER_MSEC;
+        float seconds = msecs;
+        seconds /= MSECS_PER_SECOND;
+        float fractionalSeconds = seconds - floor(seconds);
+        int shapeIndex = (int)seconds;
+        
+        // Every second we flip to the next shape.
+        static const int SHAPE_COUNT = 5;
+        GeometryCache::Shape shapes[SHAPE_COUNT] = {
+            GeometryCache::Cube,
+            GeometryCache::Tetrahedron,
+            GeometryCache::Sphere,
+            GeometryCache::Icosahedron,
+            GeometryCache::Line,
+        };
+        
+        shapeIndex %= SHAPE_COUNT;
+        GeometryCache::Shape shape = shapes[shapeIndex];
+        
+        // For the first half second for a given shape, show the wireframe, for the second half, show the solid.
+        if (fractionalSeconds > 0.5f) {
+            DependencyManager::get<GeometryCache>()->renderShapeInstances(batch, shape, data._count,
+                                                                          data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+        } else {
+            DependencyManager::get<GeometryCache>()->renderWireShapeInstances(batch, shape, data._count,
+                                                                              data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+        }
+    });
+#else
+    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+        DependencyManager::get<GeometryCache>()->renderCubeInstances(batch, data._count,
+                                                                     data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+    });
+#endif
+}
+
+void GeometryCache::renderWireCubeInstance(gpu::Batch& batch, const Transform& transform, const glm::vec4& color) {
+    static const std::string INSTANCE_NAME = __FUNCTION__;
+    renderInstances(INSTANCE_NAME, batch, transform, color, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+        DependencyManager::get<GeometryCache>()->renderWireCubeInstances(batch, data._count,
+                                                                         data._buffers[INSTANCE_TRANSFORM_BUFFER], data._buffers[INSTANCE_COLOR_BUFFER]);
+    });
 }
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1736,15 +1736,54 @@ void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
 
 
 
+class SimpleProgramKey {
+public:
+    enum FlagBit {
+        IS_TEXTURED_FLAG = 0,
+        IS_CULLED_FLAG,
+        IS_EMISSIVE_FLAG,
+        HAS_DEPTH_BIAS_FLAG,
+
+        NUM_FLAGS,
+    };
+
+    enum Flag {
+        IS_TEXTURED = (1 << IS_TEXTURED_FLAG),
+        IS_CULLED = (1 << IS_CULLED_FLAG),
+        IS_EMISSIVE = (1 << IS_EMISSIVE_FLAG),
+        HAS_DEPTH_BIAS = (1 << HAS_DEPTH_BIAS_FLAG),
+    };
+    typedef unsigned short Flags;
+
+    bool isFlag(short flagNum) const { return bool((_flags & flagNum) != 0); }
+
+    bool isTextured() const { return isFlag(IS_TEXTURED); }
+    bool isCulled() const { return isFlag(IS_CULLED); }
+    bool isEmissive() const { return isFlag(IS_EMISSIVE); }
+    bool hasDepthBias() const { return isFlag(HAS_DEPTH_BIAS); }
+
+    Flags _flags = 0;
+    short _spare = 0;
+
+    int getRaw() const { return *reinterpret_cast<const int*>(this); }
 
 
+    SimpleProgramKey(bool textured = false, bool culled = true,
+                     bool emissive = false, bool depthBias = false) {
+        _flags = (textured ? IS_TEXTURED : 0) | (culled ? IS_CULLED : 0) |
+        (emissive ? IS_EMISSIVE : 0) | (depthBias ? HAS_DEPTH_BIAS : 0);
+    }
 
+    SimpleProgramKey(int bitmask) : _flags(bitmask) {}
+};
 
+inline uint qHash(const SimpleProgramKey& key, uint seed) {
+    return qHash(key.getRaw(), seed);
+}
 
-
-
-
-
+inline bool operator==(const SimpleProgramKey& a, const SimpleProgramKey& b) {
+    return a.getRaw() == b.getRaw();
+}
 
 gpu::PipelinePointer GeometryCache::getPipeline(SimpleProgramKey config) {
     static std::once_flag once;

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -40,17 +40,6 @@ const int GeometryCache::UNKNOWN_ID = -1;
 
 static const int VERTICES_PER_TRIANGLE = 3;
 
-//static const uint FLOATS_PER_VERTEX = 3;
-//static const uint TRIANGLES_PER_QUAD = 2;
-//static const uint CUBE_FACES = 6;
-//static const uint CUBE_VERTICES_PER_FACE = 4;
-//static const uint CUBE_VERTICES = CUBE_FACES * CUBE_VERTICES_PER_FACE;
-//static const uint CUBE_VERTEX_POINTS = CUBE_VERTICES * FLOATS_PER_VERTEX;
-//static const uint CUBE_INDICES = CUBE_FACES * TRIANGLES_PER_QUAD * VERTICES_PER_TRIANGLE;
-//static const uint SPHERE_LATITUDES = 24;
-//static const uint SPHERE_MERIDIANS = SPHERE_LATITUDES * 2;
-//static const uint SPHERE_INDICES = SPHERE_MERIDIANS * (SPHERE_LATITUDES - 1) * TRIANGLES_PER_QUAD * VERTICES_PER_TRIANGLE;
-
 static const gpu::Element POSITION_ELEMENT{ gpu::VEC3, gpu::FLOAT, gpu::XYZ };
 static const gpu::Element NORMAL_ELEMENT{ gpu::VEC3, gpu::FLOAT, gpu::XYZ };
 static const gpu::Element COLOR_ELEMENT{ gpu::VEC4, gpu::NUINT8, gpu::RGBA };

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -364,74 +364,12 @@ private:
 
     QHash<QUrl, QWeakPointer<NetworkGeometry> > _networkGeometry;
     
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
+
     gpu::PipelinePointer getPipeline(SimpleProgramKey config);
     
     gpu::ShaderPointer _simpleShader;
     gpu::ShaderPointer _emissiveShader;
     QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
 };
-
-class SimpleProgramKey {
-public:
-    enum FlagBit {
-        IS_TEXTURED_FLAG = 0,
-        IS_CULLED_FLAG,
-        IS_EMISSIVE_FLAG,
-        HAS_DEPTH_BIAS_FLAG,
-        
-        NUM_FLAGS,
-    };
-    
-    enum Flag {
-        IS_TEXTURED = (1 << IS_TEXTURED_FLAG),
-        IS_CULLED = (1 << IS_CULLED_FLAG),
-        IS_EMISSIVE = (1 << IS_EMISSIVE_FLAG),
-        HAS_DEPTH_BIAS = (1 << HAS_DEPTH_BIAS_FLAG),
-    };
-    typedef unsigned short Flags;
-    
-    bool isFlag(short flagNum) const { return bool((_flags & flagNum) != 0); }
-    
-    bool isTextured() const { return isFlag(IS_TEXTURED); }
-    bool isCulled() const { return isFlag(IS_CULLED); }
-    bool isEmissive() const { return isFlag(IS_EMISSIVE); }
-    bool hasDepthBias() const { return isFlag(HAS_DEPTH_BIAS); }
-    
-    Flags _flags = 0;
-    short _spare = 0;
-    
-    int getRaw() const { return *reinterpret_cast<const int*>(this); }
-    
-    
-    SimpleProgramKey(bool textured = false, bool culled = true,
-                     bool emissive = false, bool depthBias = false) {
-        _flags = (textured ? IS_TEXTURED : 0) | (culled ? IS_CULLED : 0) |
-        (emissive ? IS_EMISSIVE : 0) | (depthBias ? HAS_DEPTH_BIAS : 0);
-    }
-    
-    SimpleProgramKey(int bitmask) : _flags(bitmask) {}
-};
-
-inline uint qHash(const SimpleProgramKey& key, uint seed) {
-    return qHash(key.getRaw(), seed);
-}
-
-inline bool operator==(const SimpleProgramKey& a, const SimpleProgramKey& b) {
-    return a.getRaw() == b.getRaw();
-}
 
 #endif // hifi_GeometryCache_h

--- a/libraries/render-utils/src/HitEffect.cpp
+++ b/libraries/render-utils/src/HitEffect.cpp
@@ -64,7 +64,7 @@ void HitEffect::run(const render::SceneContextPointer& sceneContext, const rende
     assert(renderContext->getArgs());
     assert(renderContext->getArgs()->_viewFrustum);
     RenderArgs* args = renderContext->getArgs();
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
     
         glm::mat4 projMat;
         Transform viewMat;

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -499,7 +499,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
         transform.setTranslation(partBounds.calcCenter());
         transform.setScale(partBounds.getDimensions());
         batch.setModelTransform(transform);
-        DependencyManager::get<DeferredLightingEffect>()->renderWireCube(batch, 1.0f, cubeColor);
+        DependencyManager::get<GeometryCache>()->renderWireCube(batch, 1.0f, cubeColor);
     }
 #endif //def DEBUG_BOUNDING_PARTS
     

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -349,7 +349,7 @@ void DrawStencilDeferred::run(const SceneContextPointer& sceneContext, const Ren
 
     // from the touched pixel generate the stencil buffer 
     RenderArgs* args = renderContext->getArgs();
-    doInBatch(args->_context, [=](gpu::Batch& batch) {
+    doInBatch(args->_context, [&](gpu::Batch& batch) {
         args->_batch = &batch;
 
         auto deferredFboColorDepthStencil = DependencyManager::get<FramebufferCache>()->getDeferredFramebufferDepthColor();
@@ -384,7 +384,7 @@ void DrawBackgroundDeferred::run(const SceneContextPointer& sceneContext, const 
         inItems.emplace_back(id);
     }
     RenderArgs* args = renderContext->getArgs();
-    doInBatch(args->_context, [=](gpu::Batch& batch) {
+    doInBatch(args->_context, [&](gpu::Batch& batch) {
         args->_batch = &batch;
 
         auto lightingFBO = DependencyManager::get<FramebufferCache>()->getLightingFramebuffer();
@@ -428,7 +428,7 @@ void Blit::run(const SceneContextPointer& sceneContext, const RenderContextPoint
     auto framebufferCache = DependencyManager::get<FramebufferCache>();
     auto primaryFbo = framebufferCache->getPrimaryFramebuffer();
 
-    gpu::doInBatch(renderArgs->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(renderArgs->_context, [&](gpu::Batch& batch) {
         batch.setFramebuffer(blitFbo);
 
         if (renderArgs->_renderMode == RenderArgs::MIRROR_RENDER_MODE) {

--- a/libraries/render-utils/src/TextRenderer3D.cpp
+++ b/libraries/render-utils/src/TextRenderer3D.cpp
@@ -29,7 +29,6 @@
 #include "sdf_text3D_frag.h"
 
 #include "GeometryCache.h"
-#include "DeferredLightingEffect.h"
 
 const float TextRenderer3D::DEFAULT_POINT_SIZE = 12;
 

--- a/libraries/render-utils/src/ToneMappingEffect.cpp
+++ b/libraries/render-utils/src/ToneMappingEffect.cpp
@@ -112,7 +112,7 @@ void ToneMappingEffect::render(RenderArgs* args) {
         init();
     }
     auto framebufferCache = DependencyManager::get<FramebufferCache>();
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         batch.enableStereo(false);
         QSize framebufferSize = framebufferCache->getFrameBufferSize();
 

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -160,7 +160,7 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
     }
 
     // Allright, something to render let's do it
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         glm::mat4 projMat;
         Transform viewMat;
         args->_viewFrustum->evalProjectionMatrix(projMat);

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -212,7 +212,7 @@ void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContext
     args->_details.pointTo(RenderDetails::OTHER_ITEM);
     cullItems(sceneContext, renderContext, inItems, culledItems);
 
-    gpu::doInBatch(args->_context, [=](gpu::Batch& batch) {
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         args->_batch = &batch;
         renderLights(sceneContext, renderContext, culledItems);
         args->_batch = nullptr;

--- a/tests/gpu-test/src/main.cpp
+++ b/tests/gpu-test/src/main.cpp
@@ -246,7 +246,7 @@ public:
                 batch.setModelTransform(Transform());
                 batch.setPipeline(_pipeline);
                 batch._glUniform1i(_instanceLocation, 1);
-                geometryCache->renderWireShapeInstances(batch, GeometryCache::Line, data._count, transformBuffer, colorBuffer);
+                geometryCache->renderWireShapeInstances(batch, GeometryCache::Line, data.count, transformBuffer, colorBuffer);
                 batch._glUniform1i(_instanceLocation, 0);
             });
         }

--- a/tests/gpu-test/src/main.cpp
+++ b/tests/gpu-test/src/main.cpp
@@ -30,7 +30,6 @@
 #include <gpu/Context.h>
 #include <gpu/Batch.h>
 #include <gpu/Stream.h>
-#include <gpu/StandardShaderLib.h>
 #include <gpu/GLBackend.h>
 
 #include <gl/QOpenGLContextWrapper.h>


### PR DESCRIPTION
- Moved shape rendering code in DeferredLightingEffect to GeometryCache
- Switch remaining gpu::doInBatch's lambdas to take args by ref instead of copy.
- Removed underscore from NamedBatchData public members

This PR helps laying the ground work for upcoming render engine features.
It'll help reduce the size and spread of those upcoming changes' PRs.