### PR TITLE
use "collidesWith" instead of "collisionMask"

### DIFF
--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -163,13 +163,6 @@ var STATE_CONTINUE_EQUIP = 14;
 var STATE_WAITING_FOR_BUMPER_RELEASE = 15;
 var STATE_EQUIP_SPRING = 16;
 
-// Used by the HandAnimaitonBuddy to play hand animations
-var IDLE_HAND_STATES = [STATE_OFF, STATE_RELEASE];
-var OPEN_HAND_STATES = [STATE_SEARCHING, STATE_EQUIP_SEARCHING];
-var POINT_HAND_STATES = [STATE_NEAR_TRIGGER, STATE_CONTINUE_NEAR_TRIGGER, STATE_FAR_TRIGGER, STATE_CONTINUE_FAR_TRIGGER];
-var FAR_GRASP_HAND_STATES = [STATE_DISTANCE_HOLDING, STATE_CONTINUE_DISTANCE_HOLDING];
-// otherwise grasp
-
 // "collidesWith" is specified by comma-separated list of group names
 // the possible group names are:  static, dynamic, kinematic, myAvatar, otherAvatar
 var COLLIDES_WITH_WHILE_GRABBED = "dynamic,otherAvatar";

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -108,7 +108,7 @@ var GRABBABLE_PROPERTIES = [
     "position",
     "rotation",
     "gravity",
-    "collisionMask",
+    "collidesWith",
     "collisionsWillMove",
     "locked",
     "name",
@@ -163,9 +163,16 @@ var STATE_CONTINUE_EQUIP = 14;
 var STATE_WAITING_FOR_BUMPER_RELEASE = 15;
 var STATE_EQUIP_SPRING = 16;
 
-// collision masks are specified by comma-separated list of group names
-// the possible list of names is:  static, dynamic, kinematic, myAvatar, otherAvatar
-var COLLISION_MASK_WHILE_GRABBED = "dynamic,otherAvatar";
+// Used by the HandAnimaitonBuddy to play hand animations
+var IDLE_HAND_STATES = [STATE_OFF, STATE_RELEASE];
+var OPEN_HAND_STATES = [STATE_SEARCHING, STATE_EQUIP_SEARCHING];
+var POINT_HAND_STATES = [STATE_NEAR_TRIGGER, STATE_CONTINUE_NEAR_TRIGGER, STATE_FAR_TRIGGER, STATE_CONTINUE_FAR_TRIGGER];
+var FAR_GRASP_HAND_STATES = [STATE_DISTANCE_HOLDING, STATE_CONTINUE_DISTANCE_HOLDING];
+// otherwise grasp
+
+// "collidesWith" is specified by comma-separated list of group names
+// the possible group names are:  static, dynamic, kinematic, myAvatar, otherAvatar
+var COLLIDES_WITH_WHILE_GRABBED = "dynamic,otherAvatar";
 
 function stateToName(state) {
     switch (state) {
@@ -1654,7 +1661,7 @@ function MyController(hand) {
         // zero gravity and set ignoreForCollisions in a way that lets us put them back, after all grabs are done
         if (data["refCount"] == 1) {
             data["gravity"] = grabbedProperties.gravity;
-            data["collisionMask"] = grabbedProperties.collisionMask;
+            data["collidesWith"] = grabbedProperties.collidesWith;
             data["collisionsWillMove"] = grabbedProperties.collisionsWillMove;
             data["parentID"] = grabbedProperties.parentID;
             data["parentJointIndex"] = grabbedProperties.parentJointIndex;
@@ -1664,7 +1671,10 @@ function MyController(hand) {
                     y: 0,
                     z: 0
                 },
-                "collisionMask": COLLISION_MASK_WHILE_GRABBED
+                // bummer, it isn't easy to do bitwise collisionMask operations like this:
+                //"collisionMask": COLLISION_MASK_WHILE_GRABBED | grabbedProperties.collisionMask
+                // when using string values
+                "collidesWith": COLLIDES_WITH_WHILE_GRABBED
             };
             Entities.editEntity(entityID, whileHeldProperties);
         }
@@ -1680,7 +1690,7 @@ function MyController(hand) {
             if (data["refCount"] < 1) {
                 Entities.editEntity(entityID, {
                     gravity: data["gravity"],
-                    collisionMask: data["collisionMask"],
+                    collidesWith: data["collidesWith"],
                     collisionsWillMove: data["collisionsWillMove"],
                     ignoreForCollisions: data["ignoreForCollisions"],
                     parentID: data["parentID"],

--- a/examples/toybox/bow/bow.js
+++ b/examples/toybox/bow/bow.js
@@ -540,7 +540,7 @@
                 var arrowProperties = {
                     dynamic: true,
                     collisionless: false,
-                    collisionMask: "static,dynamic,otherAvatar", // workaround: not with kinematic --> no collision with bow
+                    collidesWith: "static,dynamic,otherAvatar", // workaround: not with kinematic --> no collision with bow
                     velocity: releaseVelocity,
                     gravity: ARROW_GRAVITY,
                     lifetime: 10,

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -374,7 +374,8 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_VISIBLE, visible);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COLLISIONLESS, collisionless);
     COPY_PROXY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_COLLISIONLESS, collisionless, ignoreForCollisions, getCollisionless()); // legacy support
-    COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_COLLISION_MASK, collisionMask, getCollisionMaskAsString());
+    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COLLISION_MASK, collisionMask);
+    COPY_PROXY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_COLLISION_MASK, collisionMask, collidesWith, getCollisionMaskAsString());
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_DYNAMIC, dynamic);
     COPY_PROXY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_DYNAMIC, dynamic, collisionsWillMove, getDynamic()); // legacy support
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_HREF, href);
@@ -602,7 +603,8 @@ void EntityItemProperties::copyFromScriptValue(const QScriptValue& object, bool 
     COPY_PROPERTY_FROM_QSCRIPTVALUE(localRenderAlpha, float, setLocalRenderAlpha);
     COPY_PROPERTY_FROM_QSCRIPTVALUE(collisionless, bool, setCollisionless);
     COPY_PROPERTY_FROM_QSCRIPTVALUE_GETTER(ignoreForCollisions, bool, setCollisionless, getCollisionless); // legacy support
-    COPY_PROPERTY_FROM_QSCRITPTVALUE_ENUM(collisionMask, CollisionMask);
+    COPY_PROPERTY_FROM_QSCRIPTVALUE(collisionMask, uint8_t, setCollisionMask);
+    COPY_PROPERTY_FROM_QSCRITPTVALUE_ENUM(collidesWith, CollisionMask);
     COPY_PROPERTY_FROM_QSCRIPTVALUE_GETTER(collisionsWillMove, bool, setDynamic, getDynamic); // legacy support
     COPY_PROPERTY_FROM_QSCRIPTVALUE(dynamic, bool, setDynamic);
     COPY_PROPERTY_FROM_QSCRIPTVALUE(isSpotlight, bool, setIsSpotlight);
@@ -767,7 +769,8 @@ void EntityItemProperties::entityPropertyFlagsFromScriptValue(const QScriptValue
         ADD_PROPERTY_TO_MAP(PROP_ANGULAR_DAMPING, AngularDamping, angularDamping, float);
         ADD_PROPERTY_TO_MAP(PROP_COLLISIONLESS, Collisionless, collisionless, bool);
         ADD_PROPERTY_TO_MAP(PROP_DYNAMIC, unused, ignoreForCollisions, unused); // legacy support
-        ADD_PROPERTY_TO_MAP(PROP_COLLISION_MASK, CollisionMask, collisionMask, uint8_t);
+        ADD_PROPERTY_TO_MAP(PROP_COLLISION_MASK, unused, collisionMask, unused);
+        ADD_PROPERTY_TO_MAP(PROP_COLLISION_MASK, unused, collidesWith, unused);
         ADD_PROPERTY_TO_MAP(PROP_DYNAMIC, unused, collisionsWillMove, unused); // legacy support
         ADD_PROPERTY_TO_MAP(PROP_DYNAMIC, unused, dynamic, unused);
         ADD_PROPERTY_TO_MAP(PROP_IS_SPOTLIGHT, IsSpotlight, isSpotlight, bool);
@@ -876,6 +879,7 @@ void EntityItemProperties::entityPropertyFlagsFromScriptValue(const QScriptValue
     });
 
     if (object.isString()) {
+        // TODO: figure out how to do this without a double lookup in the map
         if (_propertyStringsToEnums.contains(object.toString())) {
             flags << _propertyStringsToEnums[object.toString()];
         }
@@ -883,6 +887,7 @@ void EntityItemProperties::entityPropertyFlagsFromScriptValue(const QScriptValue
         quint32 length = object.property("length").toInt32();
         for (quint32 i = 0; i < length; i++) {
             QString propertyName = object.property(i).toString();
+            // TODO: figure out how to do this without a double lookup in the map
             if (_propertyStringsToEnums.contains(propertyName)) {
                 flags << _propertyStringsToEnums[propertyName];
             }

--- a/libraries/entities/src/EntityItemPropertiesMacros.h
+++ b/libraries/entities/src/EntityItemPropertiesMacros.h
@@ -191,9 +191,9 @@ typedef QVector<bool> qVectorBool;
 typedef QVector<float> qVectorFloat;
 inline float float_convertFromScriptValue(const QScriptValue& v, bool& isValid) { return v.toVariant().toFloat(&isValid); }
 inline quint64 quint64_convertFromScriptValue(const QScriptValue& v, bool& isValid) { return v.toVariant().toULongLong(&isValid); }
-inline quint32 quint32_convertFromScriptValue(const QScriptValue& v, bool& isValid) { 
+inline quint32 quint32_convertFromScriptValue(const QScriptValue& v, bool& isValid) {
     // Use QString::toUInt() so that isValid is set to false if the number is outside the quint32 range.
-    return v.toString().toUInt(&isValid); 
+    return v.toString().toUInt(&isValid);
 }
 inline quint16 quint16_convertFromScriptValue(const QScriptValue& v, bool& isValid) { return v.toVariant().toInt(&isValid); }
 inline uint16_t uint16_t_convertFromScriptValue(const QScriptValue& v, bool& isValid) { return v.toVariant().toInt(&isValid); }


### PR DESCRIPTION
...but make "collisionMask" work for those who want it

After thinking about it I decided that the string based "collisionMask" setting is a Bad Idea.  The problem is that it is not easy to do bitwise operations on strings.  This PR is a proposal for something else:

(1) Use "collidesWith" for people who want to use strings

(2) Reserve "collisionMask" for the correct way to do it

This is for you @zappoman and @imgntn 