### PR TITLE
Fix for arrows that stop moving too early

### DIFF
--- a/examples/toybox/bow/bow.js
+++ b/examples/toybox/bow/bow.js
@@ -540,6 +540,7 @@
                 var arrowProperties = {
                     collisionsWillMove: true,
                     ignoreForCollisions: false,
+                    collisionMask: "static,dynamic,otherAvatar", // workaround: not with kinematic --> no collision with bow
                     velocity: releaseVelocity,
                     gravity: ARROW_GRAVITY,
                     lifetime: 10,

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -275,6 +275,7 @@ public:
     void setIgnoreForCollisions(bool value) { _ignoreForCollisions = value; }
 
     uint8_t getCollisionMask() const { return _collisionMask; }
+    uint8_t getFinalCollisionMask() const { return _ignoreForCollisions ? 0 : _collisionMask; }
     void setCollisionMask(uint8_t value) { _collisionMask = value; }
 
     bool getCollisionsWillMove() const { return _collisionsWillMove; }
@@ -446,6 +447,7 @@ protected:
     bool _visible;
     bool _ignoreForCollisions;
     uint8_t _collisionMask { ENTITY_COLLISION_MASK_DEFAULT };
+    uint8_t _collisionGroupOverride;
     bool _collisionsWillMove;
     bool _locked;
     QString _userData;

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -644,7 +644,7 @@ void EntityMotionState::computeCollisionGroupAndMask(int16_t& group, int16_t& ma
 
     mask = PhysicsEngine::getCollisionMask(group);
     if (_entity) {
-        uint8_t entityCollisionMask = _entity->getCollisionMask();
+        uint8_t entityCollisionMask = _entity->getFinalCollisionMask();
         if ((bool)(entityCollisionMask & USER_COLLISION_GROUP_MY_AVATAR) !=
                 (bool)(entityCollisionMask & USER_COLLISION_GROUP_OTHER_AVATAR)) {
             // asymmetric avatar collision mask bits


### PR DESCRIPTION
The new collisionMask feature and changes to the grab script caused the bow and arrow toy to stop working: arrows stop as soon as they are shot.

The problem is that the arrows are colliding with the bow itself and some "freeze in place" code is applied to the arrows as soon as they hit anything.

The solution is to make the arrows NOT collide with kinematic(*) objects when they are let loose.

Also, I noticed that the **collisionMask** feature would fight with **ignoreForCollisions** so I made **ignoreForCollisions" win when it comes to the final collision behavior in the physics engine.  


(*) Due to some idiosyncrasies in the code (which may be a bug, but I'll fix it later) things that have actions on them are currently categorized as "kinematic", and the bow falls into this category when it is held.