### PR TITLE
fix issues with HMD lookout 2D, and cleanup

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3514,7 +3514,7 @@ int Application::getBoundaryLevelAdjust() const {
 }
 
 PickRay Application::computePickRay(float x, float y) const {
-    vec2 pickPoint{ x, y };
+    vec2 pickPoint { x, y };
     PickRay result;
     if (isHMDMode()) {
         getApplicationCompositor().computeHmdPickRay(pickPoint, result.origin, result.direction);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1708,24 +1708,6 @@ void MyAvatar::updateMotionBehaviorFromMenu() {
     _characterController.setEnabled(menu->isOptionChecked(MenuOption::EnableCharacterController));
 }
 
-//Gets the tip position for the laser pointer
-glm::vec3 MyAvatar::getLaserPointerTipPosition(const PalmData* palm) {
-    glm::vec3 direction = glm::normalize(palm->getTipPosition() - palm->getPosition());
-
-    glm::vec3 position = palm->getPosition();
-    //scale the position with the avatar
-    scaleVectorRelativeToPosition(position);
-
-
-    glm::vec3 result;
-    const auto& compositor = qApp->getApplicationCompositor();
-    if (compositor.calculateRayUICollisionPoint(position, direction, result)) {
-        return result;
-    }
-
-    return palm->getPosition();
-}
-
 void MyAvatar::clearDriveKeys() {
     for (int i = 0; i < MAX_DRIVE_KEYS; ++i) {
         _driveKeys[i] = 0.0f;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -214,10 +214,6 @@ public:
 
     void clearScriptableSettings();
 
-    /// Renders a laser pointer for UI picking
-
-    glm::vec3 getLaserPointerTipPosition(const PalmData* palm);
-
     float getBoomLength() const { return _boomLength; }
     void setBoomLength(float boomLength) { _boomLength = boomLength; }
 

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -27,10 +27,9 @@ QScriptValue HMDScriptingInterface::getHUDLookAtPosition2D(QScriptContext* conte
         MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
         glm::vec3 sphereCenter = myAvatar->getDefaultEyePosition();
         glm::vec3 direction = glm::inverse(myAvatar->getOrientation()) * (hudIntersection - sphereCenter);
-        glm::quat rotation = ::rotationBetween(glm::vec3(0.0f, 0.0f, -1.0f), direction);
-        glm::vec3 eulers = ::safeEulerAngles(rotation);
-        return qScriptValueFromValue<glm::vec2>(engine, qApp->getApplicationCompositor()
-            .sphericalToOverlay(glm::vec2(eulers.y, -eulers.x)));
+        glm::vec2 polar = glm::vec2(glm::atan(direction.x, -direction.z), glm::asin(direction.y)) * -1.0f;
+        auto overlayPos = qApp->getApplicationCompositor().sphericalToOverlay(polar);
+        return qScriptValueFromValue<glm::vec2>(engine, overlayPos);
     }
     return QScriptValue::NullValue;
 }
@@ -42,14 +41,6 @@ QScriptValue HMDScriptingInterface::getHUDLookAtPosition3D(QScriptContext* conte
         return qScriptValueFromValue<glm::vec3>(engine, result);
     }
     return QScriptValue::NullValue;
-}
-
-void HMDScriptingInterface::toggleMagnifier() {
-    qApp->getApplicationCompositor().toggleMagnifier();
-}
-
-bool HMDScriptingInterface::getMagnifier() const {
-    return qApp->getApplicationCompositor().hasMagnifier();
 }
 
 bool HMDScriptingInterface::getHUDLookAtPosition3D(glm::vec3& result) const {

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -23,7 +23,6 @@ class QScriptEngine;
 
 class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Dependency {
     Q_OBJECT
-    Q_PROPERTY(bool magnifier READ getMagnifier)
     Q_PROPERTY(glm::vec3 position READ getPosition)
     Q_PROPERTY(glm::quat orientation READ getOrientation)
 public:
@@ -31,11 +30,8 @@ public:
     static QScriptValue getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine);
     static QScriptValue getHUDLookAtPosition3D(QScriptContext* context, QScriptEngine* engine);
 
-public slots:
-    void toggleMagnifier();
 
 private:
-    bool getMagnifier() const; 
     // Get the position of the HMD
     glm::vec3 getPosition() const;
     

--- a/interface/src/ui/ApplicationCompositor.cpp
+++ b/interface/src/ui/ApplicationCompositor.cpp
@@ -117,8 +117,6 @@ ApplicationCompositor::ApplicationCompositor() :
     auto geometryCache = DependencyManager::get<GeometryCache>();
 
     _reticleQuad = geometryCache->allocateID();
-    _magnifierQuad = geometryCache->allocateID();
-    _magnifierBorder = geometryCache->allocateID();
 
     auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
     connect(entityScriptingInterface.data(), &EntityScriptingInterface::hoverEnterEntity, [=](const EntityItemID& entityItemID, const MouseEvent& event) {
@@ -231,25 +229,6 @@ void ApplicationCompositor::displayOverlayTexture(RenderArgs* renderArgs) {
     });
 }
 
-
-vec2 ApplicationCompositor::getPolarCoordinates(const PalmData& palm) const {
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-    glm::vec3 tip = myAvatar->getLaserPointerTipPosition(&palm);
-    glm::vec3 relativePos = myAvatar->getDefaultEyePosition();
-    glm::quat rotation = myAvatar->getOrientation();
-    if (Menu::getInstance()->isOptionChecked(MenuOption::StandingHMDSensorMode)) {
-        relativePos = _modelTransform.getTranslation();
-        rotation = _modelTransform.getRotation();
-    }
-    glm::vec3 tipDirection = tip - relativePos;
-    tipDirection = glm::inverse(rotation) * tipDirection;
-    // Normalize for trig functions
-    tipDirection = glm::normalize(tipDirection);
-    // Convert to polar coordinates
-    glm::vec2 polar(glm::atan(tipDirection.x, -tipDirection.z), glm::asin(tipDirection.y));
-    return polar;
-}
-
 // Draws the FBO texture for Oculus rift.
 void ApplicationCompositor::displayOverlayTextureHmd(RenderArgs* renderArgs, int eye) {
     PROFILE_RANGE(__FUNCTION__);
@@ -343,36 +322,6 @@ void ApplicationCompositor::computeHmdPickRay(glm::vec2 cursorPos, glm::vec3& or
 
     origin = worldSpaceHeadPosition;
     direction = glm::normalize(worldSpaceIntersection - worldSpaceHeadPosition);
-}
-
-//Caculate the click location using one of the sixense controllers. Scale is not applied
-QPoint ApplicationCompositor::getPalmClickLocation(const PalmData *palm) const {
-    QPoint rv;
-    auto canvasSize = qApp->getCanvasSize();
-    if (qApp->isHMDMode()) {
-        glm::vec2 polar = getPolarCoordinates(*palm);
-        glm::vec2 point = sphericalToScreen(-polar);
-        rv.rx() = point.x;
-        rv.ry() = point.y;
-    } else {
-        MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-        glm::mat4 projection;
-        qApp->getDisplayViewFrustum()->evalProjectionMatrix(projection);
-        glm::quat invOrientation = glm::inverse(myAvatar->getOrientation());
-        glm::vec3 eyePos = myAvatar->getDefaultEyePosition();
-        glm::vec3 tip = myAvatar->getLaserPointerTipPosition(palm);
-        glm::vec3 tipPos = invOrientation * (tip - eyePos);
-
-        glm::vec4 clipSpacePos = glm::vec4(projection * glm::vec4(tipPos, 1.0f));
-        glm::vec3 ndcSpacePos;
-        if (clipSpacePos.w != 0) {
-            ndcSpacePos = glm::vec3(clipSpacePos) / clipSpacePos.w;
-        }
-
-        rv.setX(((ndcSpacePos.x + 1.0f) / 2.0f) * canvasSize.x);
-        rv.setY((1.0f - ((ndcSpacePos.y + 1.0f) / 2.0f)) * canvasSize.y);
-    }
-    return rv;
 }
 
 //Finds the collision point of a world space ray
@@ -496,27 +445,6 @@ void ApplicationCompositor::drawSphereSection(gpu::Batch& batch) {
     batch.setInputBuffer(COLOR_DATA_SLOT, colView);
     batch.setIndexBuffer(gpu::UINT16, _hemiIndices, 0);
     batch.drawIndexed(gpu::TRIANGLES, _hemiIndexCount);
-}
-
-glm::vec2 ApplicationCompositor::directionToSpherical(const glm::vec3& direction) {
-    glm::vec2 result;
-    // Compute yaw
-    glm::vec3 normalProjection = glm::normalize(glm::vec3(direction.x, 0.0f, direction.z));
-    result.x = glm::acos(glm::dot(IDENTITY_FRONT, normalProjection));
-    if (glm::dot(IDENTITY_RIGHT, normalProjection) > 0.0f) {
-        result.x = -glm::abs(result.x);
-    } else {
-        result.x = glm::abs(result.x);
-    }
-    // Compute pitch
-    result.y = angleBetween(IDENTITY_UP, direction) - PI_OVER_TWO;
-
-    return result;
-}
-
-glm::vec3 ApplicationCompositor::sphericalToDirection(const glm::vec2& sphericalPos) {
-    glm::quat rotation(glm::vec3(sphericalPos.y, sphericalPos.x, 0.0f));
-    return rotation * IDENTITY_FRONT;
 }
 
 glm::vec2 ApplicationCompositor::screenToSpherical(const glm::vec2& screenPos) {

--- a/interface/src/ui/ApplicationCompositor.h
+++ b/interface/src/ui/ApplicationCompositor.h
@@ -43,20 +43,15 @@ public:
     void displayOverlayTexture(RenderArgs* renderArgs);
     void displayOverlayTextureHmd(RenderArgs* renderArgs, int eye);
 
-    QPoint getPalmClickLocation(const PalmData *palm) const;
     bool calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction, glm::vec3& result) const;
-
-    bool hasMagnifier() const { return _magnifier; }
-    void toggleMagnifier() { _magnifier = !_magnifier; }
 
     float getHmdUIAngularSize() const { return _hmdUIAngularSize; }
     void setHmdUIAngularSize(float hmdUIAngularSize) { _hmdUIAngularSize = hmdUIAngularSize; }
 
     // Converter from one frame of reference to another.
     // Frame of reference:
-    // Direction: Ray that represents the spherical values
     // Screen: Position on the screen (x,y)
-    // Spherical: Pitch and yaw that gives the position on the sphere we project on (yaw,pitch)
+    // Spherical: Polar coordinates that gives the position on the sphere we project on (yaw,pitch)
     // Overlay: Position on the overlay (x,y)
     // (x,y) in Overlay are similar than (x,y) in Screen except they can be outside of the bound of te screen.
     // This allows for picking outside of the screen projection in 3D.
@@ -80,8 +75,6 @@ public:
     float getAlpha() const { return _alpha; }
     void setAlpha(float alpha) { _alpha = alpha; }
 
-    static glm::vec2 directionToSpherical(const glm::vec3 & direction);
-    static glm::vec3 sphericalToDirection(const glm::vec2 & sphericalPos);
     static glm::vec2 screenToSpherical(const glm::vec2 & screenPos);
     static glm::vec2 sphericalToScreen(const glm::vec2 & sphericalPos);
 
@@ -92,8 +85,6 @@ private:
     void drawSphereSection(gpu::Batch& batch);
     void updateTooltips();
 
-    vec2 getPolarCoordinates(const PalmData& palm) const;
-
     // Support for hovering and tooltips
     static EntityItemID _noItemId;
     EntityItemID _hoverItemId { _noItemId };
@@ -101,31 +92,22 @@ private:
     QString _hoverItemDescription;
     quint64 _hoverItemEnterUsecs { 0 };
 
-    float _hmdUIAngularSize = DEFAULT_HMD_UI_ANGULAR_SIZE;
-    float _textureFov{ glm::radians(DEFAULT_HMD_UI_ANGULAR_SIZE) };
-    float _textureAspectRatio{ 1.0f };
-    int _hemiVerticesID{ GeometryCache::UNKNOWN_ID };
+    float _hmdUIAngularSize { DEFAULT_HMD_UI_ANGULAR_SIZE };
+    float _textureFov { glm::radians(DEFAULT_HMD_UI_ANGULAR_SIZE) };
+    float _textureAspectRatio { 1.0f };
+    int _hemiVerticesID { GeometryCache::UNKNOWN_ID };
 
-    bool _magnifier{ true };
-
-    float _alpha{ 1.0f };
-    float _prevAlpha{ 1.0f };
-    float _fadeInAlpha{ true };
-    float _oculusUIRadius{ 1.0f };
+    float _alpha { 1.0f };
+    float _prevAlpha { 1.0f };
+    float _fadeInAlpha { true };
+    float _oculusUIRadius { 1.0f };
 
     QMap<uint16_t, gpu::TexturePointer> _cursors;
 
     int _reticleQuad;
-    int _magnifierQuad;
-    int _magnifierBorder;
 
-    int _previousBorderWidth{ -1 };
-    int _previousBorderHeight{ -1 };
-
-    glm::vec3 _previousMagnifierBottomLeft;
-    glm::vec3 _previousMagnifierBottomRight;
-    glm::vec3 _previousMagnifierTopLeft;
-    glm::vec3 _previousMagnifierTopRight;
+    int _previousBorderWidth { -1 };
+    int _previousBorderHeight { -1 };
 
     Transform _modelTransform;
     Transform _cameraBaseTransform;


### PR DESCRIPTION
- fixes a bug in `HMDScriptingInterface::getHUDLookAtPosition2D()` that was returning incorrect values for the 2D position of what you were looking at.
- removed a bunch of dead code