### PR TITLE
namechange "ignoreForCollisions" to "collisionless"

### DIFF
--- a/examples/acScripts/rain.js
+++ b/examples/acScripts/rain.js
@@ -76,7 +76,7 @@ var RainSquall = function (properties) {
             velocity: { x: 0, y: -dropFallSpeed, z: 0 },
             damping: 0,
             angularDamping: 0,
-            ignoreForCollisions: true
+            collisionless: true
         };
     }
 

--- a/examples/breakdanceCore.js
+++ b/examples/breakdanceCore.js
@@ -409,7 +409,7 @@ function createPuppet(model, location) {
             registrationPoint: { x: 0.5, y: 0, z: 0.5 },
             animation: ANIMATION_SETTINGS,
             position: location,
-            ignoreForCollisions: true,
+            collisionless: true,
             dimensions: DIMENSIONS,
             lifetime: TEMPORARY_LIFETIME
         });

--- a/examples/data_visualization/earthquakes_live.js
+++ b/examples/data_visualization/earthquakes_live.js
@@ -122,7 +122,7 @@ function createQuakeMarker(earthquake) {
         parentID:earth,
         dimensions: QUAKE_MARKER_DIMENSIONS,
         position: getQuakePosition(earthquake),
-        ignoreForCollisions:true,
+        collisionless:true,
         lifetime: 6000,
         color: getQuakeMarkerColor(earthquake)
     }

--- a/examples/debugging/grabInspector.js
+++ b/examples/debugging/grabInspector.js
@@ -108,7 +108,7 @@ Script.setInterval(function() {
         var grabData = userData["grabKey"]
 
         // {"grabbableKey":{"invertSolidWhileHeld":true},
-        //  "grabKey":{"activated":true,"avatarId":"{6ea8b092-10e0-4058-888b-6facc40d0fe9}","refCount":1,"gravity":{"x":0,"y":0,"z":0},"ignoreForCollisions":0,"dynamic":1}
+        //  "grabKey":{"activated":true,"avatarId":"{6ea8b092-10e0-4058-888b-6facc40d0fe9}","refCount":1,"gravity":{"x":0,"y":0,"z":0},"collisionless":0,"dynamic":1}
         // }
 
         if (typeof grabData != 'undefined') {

--- a/examples/drylake/createAvatarDetector.js
+++ b/examples/drylake/createAvatarDetector.js
@@ -25,7 +25,7 @@ function createAvatarDetector() {
             z: 1
         },
         dynamic: false,
-        ignoreForCollisions: true,
+        collisionless: true,
         visible: false,
         color: {
             red: 255,

--- a/examples/drylake/ratCreator.js
+++ b/examples/drylake/ratCreator.js
@@ -91,7 +91,7 @@ var modelRatProperties = {
     angularDamping: 0.99,
     friction: 0.75,
     dynamic: true,
-    ignoreForCollisions: false,
+    collisionless: false,
     gravity: {
         x: 0,
         y: -9.8,
@@ -195,7 +195,7 @@ function addAvoiderBlock(position) {
         },
         position: position,
         dynamic: false,
-        ignoreForCollisions: true,
+        collisionless: true,
         visible: false
     };
 

--- a/examples/entityScripts/createRecorder.js
+++ b/examples/entityScripts/createRecorder.js
@@ -19,5 +19,5 @@ var recordAreaEntity = Entities.addEntity({
     },
     visible: true,
     script: PARAMS_SCRIPT_URL,
-    ignoreForCollision: true,
+    collisionless: true,
 });

--- a/examples/entityScripts/recordingEntityScript.js
+++ b/examples/entityScripts/recordingEntityScript.js
@@ -54,10 +54,10 @@
         preload: function (entityID) {
             print("RECORDING ENTITY PRELOAD");
             this.entityID = entityID;
-            
+
             var entityProperties = Entities.getEntityProperties(_this.entityID);
-            if (!entityProperties.ignoreForCollisions) {
-                Entities.editEntity(_this.entityID, { ignoreForCollisions: true });
+            if (!entityProperties.collisionless) {
+                Entities.editEntity(_this.entityID, { collisionless: true });
             }
 
             Messages.messageReceived.connect(receivingMessage);

--- a/examples/example/games/color_busters/colorBusterWand.js
+++ b/examples/example/games/color_busters/colorBusterWand.js
@@ -220,7 +220,7 @@
                 dimensions: COLOR_INDICATOR_DIMENSIONS,
                 position: this.currentProperties.position,
                 dynamic: false,
-                ignoreForCollisions: true
+                collisionless: true
             }
 
             this.colorIndicator = Entities.addEntity(properties);

--- a/examples/example/games/color_busters/createColorBusterCubes.js
+++ b/examples/example/games/color_busters/createColorBusterCubes.js
@@ -82,7 +82,7 @@ function createColorBusterCube(row, column, vertical) {
         type: 'Box',
         dimensions: CUBE_DIMENSIONS,
         dynamic: false,
-        ignoreForCollisions: false,
+        collisionless: false,
         color: startingColor[1],
         position: position,
         userData: JSON.stringify({

--- a/examples/example/games/exterminatorGame/pistolScriptSpawnerSpawner.js
+++ b/examples/example/games/exterminatorGame/pistolScriptSpawnerSpawner.js
@@ -7,7 +7,7 @@ var pistolSpawnerEntity = Entities.addEntity({
     dimensions: {x: 0.38, y: 1.9, z: 3.02},
     script: scriptURL,
     visible: false,
-    ignoreForCollisions: true
+    collisionless: true
 });
 
 var pistol = Entities.addEntity({
@@ -17,7 +17,7 @@ var pistol = Entities.addEntity({
     dimensions: {x: 0.38, y: 1.9, z: 3.02},
     script: scriptURL,
     color: {red: 200, green: 0, blue: 20},
-    ignoreForCollisions: true
+    collisionless: true
 });
 
 

--- a/examples/example/games/planky.js
+++ b/examples/example/games/planky.js
@@ -254,7 +254,7 @@ PlankyStack = function() {
             density: _this.options.density,
             velocity: {x: 0, y: 0, z: 0},
             angularVelocity: Quat.fromPitchYawRollDegrees(0, 0, 0),
-            ignoreForCollisions: true
+            collisionless: true
         };
         _this.planks.forEach(function(plank, index, object) {
             if (plank.layer === layer && plank.row === row) {
@@ -289,7 +289,7 @@ PlankyStack = function() {
         }
         if (!editMode) {
             _this.planks.forEach(function(plank, index, object) {
-                Entities.editEntity(plank.entity, {ignoreForCollisions: false, dynamic: true});
+                Entities.editEntity(plank.entity, {collisionless: false, dynamic: true});
             });
         }
     };

--- a/examples/flowArts/arcBall/arcBall.js
+++ b/examples/flowArts/arcBall/arcBall.js
@@ -44,7 +44,7 @@ ArcBall = function(spawnPosition) {
             green: 10,
             blue: 150
         },
-        ignoreForCollisions: true,
+        collisionless: true,
         damping: 0.8,
         dynamic: true,
         userData: JSON.stringify({

--- a/examples/grab.js
+++ b/examples/grab.js
@@ -506,14 +506,14 @@ Grabber.prototype.activateEntity = function(entityID, grabbedProperties) {
     data["activated"] = true;
     data["avatarId"] = MyAvatar.sessionUUID;
     data["refCount"] = data["refCount"] ? data["refCount"] + 1 : 1;
-    // zero gravity and set ignoreForCollisions to true, but in a way that lets us put them back, after all grabs are done
+    // zero gravity and set collisionless to true, but in a way that lets us put them back, after all grabs are done
     if (data["refCount"] == 1) {
         data["gravity"] = grabbedProperties.gravity;
-        data["ignoreForCollisions"] = grabbedProperties.ignoreForCollisions;
+        data["collisionless"] = grabbedProperties.collisionless;
         data["dynamic"] = grabbedProperties.dynamic;
         var whileHeldProperties = {gravity: {x:0, y:0, z:0}};
         if (invertSolidWhileHeld) {
-            whileHeldProperties["ignoreForCollisions"] = ! grabbedProperties.ignoreForCollisions;
+            whileHeldProperties["collisionless"] = ! grabbedProperties.collisionless;
         }
         Entities.editEntity(entityID, whileHeldProperties);
     }
@@ -527,7 +527,7 @@ Grabber.prototype.deactivateEntity = function(entityID) {
         if (data["refCount"] < 1) {
             Entities.editEntity(entityID, {
                 gravity: data["gravity"],
-                ignoreForCollisions: data["ignoreForCollisions"],
+                collisionless: data["collisionless"],
                 dynamic: data["dynamic"]
             });
             data = null;

--- a/examples/harmonicOscillator.js
+++ b/examples/harmonicOscillator.js
@@ -26,7 +26,7 @@ ball = Entities.addEntity(
     dimensions: { x: 0.1, y: 0.1, z: 0.1 },  
     color: { red: 255, green: 0, blue: 255 },
     dynamic: false,
-    ignoreForCollisions: true
+    collisionless: true
   });
 
 disc = Entities.addEntity(

--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -261,7 +261,7 @@
                 var elAccelerationZ = document.getElementById("property-lacc-z");
     
                 var elDensity = document.getElementById("property-density");
-                var elIgnoreForCollisions = document.getElementById("property-ignore-for-collisions");
+                var elCollisionless = document.getElementById("property-collisionless");
                 var elDynamic = document.getElementById("property-dynamic" );
                 var elCollisionSoundURL = document.getElementById("property-collision-sound-url");
                 var elLifetime = document.getElementById("property-lifetime");
@@ -491,7 +491,7 @@
                                 elAccelerationZ.value = properties.acceleration.z.toFixed(2);
     
                                 elDensity.value = properties.density.toFixed(2);
-                                elIgnoreForCollisions.checked = properties.ignoreForCollisions;
+                                elCollisionless.checked = properties.collisionless;
                                 elDynamic.checked = properties.dynamic;
                                 elCollisionSoundURL.value = properties.collisionSoundURL;
                                 elLifetime.value = properties.lifetime;
@@ -718,7 +718,7 @@
                 elAccelerationZ.addEventListener('change', accelerationChangeFunction);
     
                 elDensity.addEventListener('change', createEmitNumberPropertyUpdateFunction('density'));
-                elIgnoreForCollisions.addEventListener('change', createEmitCheckedPropertyUpdateFunction('ignoreForCollisions'));
+                elCollisionless.addEventListener('change', createEmitCheckedPropertyUpdateFunction('collisionless'));
                 elDynamic.addEventListener('change', createEmitCheckedPropertyUpdateFunction('dynamic'));
                 elCollisionSoundURL.addEventListener('change', createEmitTextPropertyUpdateFunction('collisionSoundURL'));
     
@@ -1235,9 +1235,9 @@
         </div>
 
         <div class="property">
-            <span class="label">Ignore For Collisions</span>
+            <span class="label">Collisionless</span>
             <span class="value">
-                <input type='checkbox' id="property-ignore-for-collisions">
+                <input type='checkbox' id="property-collisionless">
             </span>
         </div>
 

--- a/examples/leaves.js
+++ b/examples/leaves.js
@@ -117,7 +117,7 @@ var leafSquall = function (properties) {
             },
             damping: 0,
             angularDamping: 0,
-            ignoreForCollisions: true
+            collisionless: true
 
         };
     }

--- a/examples/libraries/entityPropertyDialogBox.js
+++ b/examples/libraries/entityPropertyDialogBox.js
@@ -199,7 +199,7 @@ EntityPropertyDialogBox = (function () {
         index++;
         array.push({ label: "Density:", value: properties.density.toFixed(decimals) });
         index++;
-        array.push({ label: "Ignore for Collisions:", type: "checkbox", value: properties.ignoreForCollisions });
+        array.push({ label: "Collisionless:", type: "checkbox", value: properties.collisionless });
         index++;
         array.push({ label: "Dynamic:", type: "checkbox", value: properties.dynamic });
         index++;
@@ -412,7 +412,7 @@ EntityPropertyDialogBox = (function () {
 
             index++; // skip header
             properties.density = array[index++].value;
-            properties.ignoreForCollisions = array[index++].value;
+            properties.collisionless = array[index++].value;
             properties.dynamic = array[index++].value;
 
             properties.lifetime = array[index++].value;

--- a/examples/light_modifier/lightModifier.js
+++ b/examples/light_modifier/lightModifier.js
@@ -228,7 +228,7 @@ entitySlider.prototype = {
             name: 'Hifi-Slider-Axis::' + this.sliderType,
             color: this.color,
             dynamic: false,
-            ignoreForCollisions: true,
+            collisionless: true,
             dimensions: {
                 x: 3,
                 y: 3,
@@ -251,7 +251,7 @@ entitySlider.prototype = {
             name: 'Hifi-End-Of-Axis',
             type: 'Box',
             dynamic: false,
-            ignoreForCollisions: true,
+            collisionless: true,
             dimensions: {
                 x: 0.01,
                 y: 0.01,
@@ -364,7 +364,7 @@ entitySlider.prototype = {
             color: this.color,
             position: sliderPosition,
             script: SLIDER_SCRIPT_URL,
-            ignoreForCollisions: true,
+            collisionless: true,
             userData: JSON.stringify({
                 lightModifierKey: {
                     lightID: this.lightID,
@@ -559,7 +559,7 @@ function createPanelEntity(position) {
         },
         visible: false,
         dynamic: false,
-        ignoreForCollisions: true
+        collisionless: true
     }
 
     var panel = Entities.addEntity(panelProperties);
@@ -583,7 +583,7 @@ function createVisiblePanel() {
         },
         visible: true,
         dynamic: false,
-        ignoreForCollisions: true,
+        collisionless: true,
         position: moveDown,
         rotation: avatarRot,
         script: VISIBLE_PANEL_SCRIPT_URL
@@ -640,7 +640,7 @@ function createCloseButton(axisStart) {
         rotation: Quat.multiply(avatarRot, Quat.fromPitchYawRollDegrees(90, 0, 45)),
         //rotation: Quat.fromPitchYawRollDegrees(0, 0, 90),
         dynamic: false,
-        ignoreForCollisions: true,
+        collisionless: true,
         script: CLOSE_BUTTON_SCRIPT_URL,
         userData: JSON.stringify({
             grabbableKey: {

--- a/examples/particle_explorer/main.js
+++ b/examples/particle_explorer/main.js
@@ -65,7 +65,7 @@ var keysToIgnore = [
     'registrationPoint',
     'angularVelocity',
     'angularDamping',
-    'ignoreForCollisions',
+    'collisionless',
     'dynamic',
     'href',
     'actionData',

--- a/examples/pointer.js
+++ b/examples/pointer.js
@@ -102,7 +102,7 @@ function createOrUpdateLine(event) {
         sphereEntityID = Entities.addEntity({
             type: "Sphere",
             position: intersection.intersection,
-            ignoreForCollisions: 1,
+            collisionless: 1,
             dimensions: { x: 0.6, y: 0.6, z: 0.6 },
             color: { red: 0, green: 255, blue: 0 },
             lifetime: 15 // if someone crashes while pointing, don't leave the line there forever.

--- a/examples/toybox/basketball/createRack.js
+++ b/examples/toybox/basketball/createRack.js
@@ -48,7 +48,7 @@ var rack = Entities.addEntity({
         z: 1.73
     },
     dynamic: true,
-    ignoreForCollisions: false,
+    collisionless: false,
     collisionSoundURL: collisionSoundURL,
     compoundShapeURL: rackCollisionHullURL,
     userData: JSON.stringify({
@@ -90,7 +90,7 @@ function createBalls() {
                 z: 0
             },
             dynamic: true,
-            ignoreForCollisions: false,
+            collisionless: false,
             modelURL: basketballURL,
             userData: JSON.stringify({
                 grabbableKey: {

--- a/examples/toybox/bow/bow.js
+++ b/examples/toybox/bow/bow.js
@@ -235,7 +235,7 @@
                 dimensions: ARROW_DIMENSIONS,
                 position: this.bowProperties.position,
                 dynamic: false,
-                ignoreForCollisions: true,
+                collisionless: true,
                 collisionSoundURL: ARROW_HIT_SOUND_URL,
                 damping: 0.01,
                 userData: JSON.stringify({
@@ -287,7 +287,7 @@
                 position: Vec3.sum(this.bowProperties.position, TOP_NOTCH_OFFSET),
                 dimensions: LINE_DIMENSIONS,
                 dynamic: false,
-                ignoreForCollisions: true,
+                collisionless: true,
                 userData: JSON.stringify({
                     grabbableKey: {
                         grabbable: false
@@ -305,7 +305,7 @@
                 position: Vec3.sum(this.bowProperties.position, BOTTOM_NOTCH_OFFSET),
                 dimensions: LINE_DIMENSIONS,
                 dynamic: false,
-                ignoreForCollisions: true,
+                collisionless: true,
                 userData: JSON.stringify({
                     grabbableKey: {
                         grabbable: false
@@ -390,7 +390,7 @@
                 dimensions: LINE_DIMENSIONS,
                 visible: true,
                 dynamic: false,
-                ignoreForCollisions: true,
+                collisionless: true,
                 userData: JSON.stringify({
                     grabbableKey: {
                         grabbable: false
@@ -539,7 +539,7 @@
                 //make the arrow physical, give it gravity, a lifetime, and set our velocity
                 var arrowProperties = {
                     dynamic: true,
-                    ignoreForCollisions: false,
+                    collisionless: false,
                     collisionMask: "static,dynamic,otherAvatar", // workaround: not with kinematic --> no collision with bow
                     velocity: releaseVelocity,
                     gravity: ARROW_GRAVITY,

--- a/examples/toybox/bubblewand/wand.js
+++ b/examples/toybox/bubblewand/wand.js
@@ -162,7 +162,7 @@
                 position: this.getWandTipPosition(properties),
                 dimensions: BUBBLE_INITIAL_DIMENSIONS,
                 dynamic: false,
-                ignoreForCollisions: true,
+                collisionless: true,
                 damping: BUBBLE_LINEAR_DAMPING,
                 shapeType: "sphere"
             });

--- a/examples/toybox/ping_pong_gun/createTargets.js
+++ b/examples/toybox/ping_pong_gun/createTargets.js
@@ -56,7 +56,7 @@ var targetIntervalClearer = Entities.addEntity({
     rotation: rotation,
     visible: false,
     dynamic: false,
-    ignoreForCollisions: true,
+    collisionless: true,
 });
 
 var targets = [];

--- a/examples/winterSmashUp/targetPractice/targetPracticeGame.js
+++ b/examples/winterSmashUp/targetPractice/targetPracticeGame.js
@@ -153,7 +153,7 @@ var onTargetHit = function(targetEntity, projectileEntity, collision) {
                 });
                 // Attach arrow to target for the nice effect
                 Entities.editEntity(projectileEntity, {
-                    ignoreForCollisions: true,
+                    collisionless: true,
                     parentID: targetEntity
                 });
                 Entities.editEntity(targetEntity, {

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -63,7 +63,7 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) :
     _angularVelocity(ENTITY_ITEM_DEFAULT_ANGULAR_VELOCITY),
     _angularDamping(ENTITY_ITEM_DEFAULT_ANGULAR_DAMPING),
     _visible(ENTITY_ITEM_DEFAULT_VISIBLE),
-    _ignoreForCollisions(ENTITY_ITEM_DEFAULT_IGNORE_FOR_COLLISIONS),
+    _collisionless(ENTITY_ITEM_DEFAULT_COLLISIONLESS),
     _collisionMask(ENTITY_COLLISION_MASK_DEFAULT),
     _dynamic(ENTITY_ITEM_DEFAULT_DYNAMIC),
     _locked(ENTITY_ITEM_DEFAULT_LOCKED),
@@ -123,7 +123,7 @@ EntityPropertyFlags EntityItem::getEntityProperties(EncodeBitstreamParams& param
     requestedProperties += PROP_REGISTRATION_POINT;
     requestedProperties += PROP_ANGULAR_DAMPING;
     requestedProperties += PROP_VISIBLE;
-    requestedProperties += PROP_IGNORE_FOR_COLLISIONS;
+    requestedProperties += PROP_COLLISIONLESS;
     requestedProperties += PROP_COLLISION_MASK;
     requestedProperties += PROP_DYNAMIC;
     requestedProperties += PROP_LOCKED;
@@ -260,7 +260,7 @@ OctreeElement::AppendState EntityItem::appendEntityData(OctreePacketData* packet
         APPEND_ENTITY_PROPERTY(PROP_REGISTRATION_POINT, getRegistrationPoint());
         APPEND_ENTITY_PROPERTY(PROP_ANGULAR_DAMPING, getAngularDamping());
         APPEND_ENTITY_PROPERTY(PROP_VISIBLE, getVisible());
-        APPEND_ENTITY_PROPERTY(PROP_IGNORE_FOR_COLLISIONS, getIgnoreForCollisions());
+        APPEND_ENTITY_PROPERTY(PROP_COLLISIONLESS, getCollisionless());
         APPEND_ENTITY_PROPERTY(PROP_COLLISION_MASK, getCollisionMask());
         APPEND_ENTITY_PROPERTY(PROP_DYNAMIC, getDynamic());
         APPEND_ENTITY_PROPERTY(PROP_LOCKED, getLocked());
@@ -680,7 +680,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
 
     READ_ENTITY_PROPERTY(PROP_ANGULAR_DAMPING, float, updateAngularDamping);
     READ_ENTITY_PROPERTY(PROP_VISIBLE, bool, setVisible);
-    READ_ENTITY_PROPERTY(PROP_IGNORE_FOR_COLLISIONS, bool, updateIgnoreForCollisions);
+    READ_ENTITY_PROPERTY(PROP_COLLISIONLESS, bool, updateCollisionless);
     READ_ENTITY_PROPERTY(PROP_COLLISION_MASK, uint8_t, updateCollisionMask);
     READ_ENTITY_PROPERTY(PROP_DYNAMIC, bool, updateDynamic);
     READ_ENTITY_PROPERTY(PROP_LOCKED, bool, setLocked);
@@ -1044,7 +1044,7 @@ EntityItemProperties EntityItem::getProperties(EntityPropertyFlags desiredProper
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(glowLevel, getGlowLevel);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(localRenderAlpha, getLocalRenderAlpha);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(visible, getVisible);
-    COPY_ENTITY_PROPERTY_TO_PROPERTIES(ignoreForCollisions, getIgnoreForCollisions);
+    COPY_ENTITY_PROPERTY_TO_PROPERTIES(collisionless, getCollisionless);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(collisionMask, getCollisionMask);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(dynamic, getDynamic);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(locked, getLocked);
@@ -1100,7 +1100,7 @@ bool EntityItem::setProperties(const EntityItemProperties& properties) {
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(angularDamping, updateAngularDamping);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(restitution, updateRestitution);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(friction, updateFriction);
-    SET_ENTITY_PROPERTY_FROM_PROPERTIES(ignoreForCollisions, updateIgnoreForCollisions);
+    SET_ENTITY_PROPERTY_FROM_PROPERTIES(collisionless, updateCollisionless);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(collisionMask, updateCollisionMask);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(dynamic, updateDynamic);
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(created, updateCreated);
@@ -1444,9 +1444,9 @@ void EntityItem::updateAngularDamping(float value) {
     }
 }
 
-void EntityItem::updateIgnoreForCollisions(bool value) {
-    if (_ignoreForCollisions != value) {
-        _ignoreForCollisions = value;
+void EntityItem::updateCollisionless(bool value) {
+    if (_collisionless != value) {
+        _collisionless = value;
         _dirtyFlags |= Simulation::DIRTY_COLLISION_GROUP;
     }
 }

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -271,11 +271,11 @@ public:
     bool isVisible() const { return _visible; }
     bool isInvisible() const { return !_visible; }
 
-    bool getIgnoreForCollisions() const { return _ignoreForCollisions; }
-    void setIgnoreForCollisions(bool value) { _ignoreForCollisions = value; }
+    bool getCollisionless() const { return _collisionless; }
+    void setCollisionless(bool value) { _collisionless = value; }
 
     uint8_t getCollisionMask() const { return _collisionMask; }
-    uint8_t getFinalCollisionMask() const { return _ignoreForCollisions ? 0 : _collisionMask; }
+    uint8_t getFinalCollisionMask() const { return _collisionless ? 0 : _collisionMask; }
     void setCollisionMask(uint8_t value) { _collisionMask = value; }
 
     bool getDynamic() const { return _dynamic; }
@@ -331,7 +331,7 @@ public:
     void updateGravity(const glm::vec3& value);
     void updateAngularVelocity(const glm::vec3& value);
     void updateAngularDamping(float value);
-    void updateIgnoreForCollisions(bool value);
+    void updateCollisionless(bool value);
     void updateCollisionMask(uint8_t value);
     void updateDynamic(bool value);
     void updateLifetime(float value);
@@ -445,7 +445,7 @@ protected:
     glm::vec3 _angularVelocity;
     float _angularDamping;
     bool _visible;
-    bool _ignoreForCollisions;
+    bool _collisionless;
     uint8_t _collisionMask { ENTITY_COLLISION_MASK_DEFAULT };
     bool _dynamic;
     bool _locked;

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -255,7 +255,7 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
     CHECK_PROPERTY_CHANGE(PROP_REGISTRATION_POINT, registrationPoint);
     CHECK_PROPERTY_CHANGE(PROP_ANGULAR_VELOCITY, angularVelocity);
     CHECK_PROPERTY_CHANGE(PROP_ANGULAR_DAMPING, angularDamping);
-    CHECK_PROPERTY_CHANGE(PROP_IGNORE_FOR_COLLISIONS, ignoreForCollisions);
+    CHECK_PROPERTY_CHANGE(PROP_COLLISIONLESS, collisionless);
     CHECK_PROPERTY_CHANGE(PROP_COLLISION_MASK, collisionMask);
     CHECK_PROPERTY_CHANGE(PROP_DYNAMIC, dynamic);
     CHECK_PROPERTY_CHANGE(PROP_IS_SPOTLIGHT, isSpotlight);
@@ -370,7 +370,8 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_ANGULAR_VELOCITY, angularVelocity);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_ANGULAR_DAMPING, angularDamping);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_VISIBLE, visible);
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_IGNORE_FOR_COLLISIONS, ignoreForCollisions);
+    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COLLISIONLESS, collisionless);
+    COPY_PROXY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_COLLISIONLESS, collisionless, ignoreForCollisions, getCollisionless()); // legacy support
     COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_COLLISION_MASK, collisionMask, getCollisionMaskAsString());
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_DYNAMIC, dynamic);
     COPY_PROXY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_DYNAMIC, dynamic, collisionsWillMove, getDynamic()); // legacy support
@@ -593,7 +594,8 @@ void EntityItemProperties::copyFromScriptValue(const QScriptValue& object, bool 
     COPY_PROPERTY_FROM_QSCRIPTVALUE(compoundShapeURL, QString, setCompoundShapeURL);
     COPY_PROPERTY_FROM_QSCRIPTVALUE(glowLevel, float, setGlowLevel);
     COPY_PROPERTY_FROM_QSCRIPTVALUE(localRenderAlpha, float, setLocalRenderAlpha);
-    COPY_PROPERTY_FROM_QSCRIPTVALUE(ignoreForCollisions, bool, setIgnoreForCollisions);
+    COPY_PROPERTY_FROM_QSCRIPTVALUE(collisionless, bool, setCollisionless);
+    COPY_PROPERTY_FROM_QSCRIPTVALUE_GETTER(ignoreForCollisions, bool, setCollisionless, getCollisionless); // legacy support
     COPY_PROPERTY_FROM_QSCRITPTVALUE_ENUM(collisionMask, CollisionMask);
     COPY_PROPERTY_FROM_QSCRIPTVALUE_GETTER(collisionsWillMove, bool, setDynamic, getDynamic); // legacy support
     COPY_PROPERTY_FROM_QSCRIPTVALUE(dynamic, bool, setDynamic);
@@ -757,7 +759,8 @@ void EntityItemProperties::entityPropertyFlagsFromScriptValue(const QScriptValue
         ADD_PROPERTY_TO_MAP(PROP_REGISTRATION_POINT, RegistrationPoint, registrationPoint, glm::vec3);
         ADD_PROPERTY_TO_MAP(PROP_ANGULAR_VELOCITY, AngularVelocity, angularVelocity, glm::vec3);
         ADD_PROPERTY_TO_MAP(PROP_ANGULAR_DAMPING, AngularDamping, angularDamping, float);
-        ADD_PROPERTY_TO_MAP(PROP_IGNORE_FOR_COLLISIONS, IgnoreForCollisions, ignoreForCollisions, bool);
+        ADD_PROPERTY_TO_MAP(PROP_COLLISIONLESS, Collisionless, collisionless, bool);
+        ADD_PROPERTY_TO_MAP(PROP_DYNAMIC, unused, ignoreForCollisions, unused); // legacy support
         ADD_PROPERTY_TO_MAP(PROP_COLLISION_MASK, CollisionMask, collisionMask, uint8_t);
         ADD_PROPERTY_TO_MAP(PROP_DYNAMIC, unused, collisionsWillMove, unused); // legacy support
         ADD_PROPERTY_TO_MAP(PROP_DYNAMIC, unused, dynamic, unused);
@@ -1005,7 +1008,7 @@ bool EntityItemProperties::encodeEntityEditPacket(PacketType command, EntityItem
             APPEND_ENTITY_PROPERTY(PROP_ANGULAR_VELOCITY, properties.getAngularVelocity());
             APPEND_ENTITY_PROPERTY(PROP_ANGULAR_DAMPING, properties.getAngularDamping());
             APPEND_ENTITY_PROPERTY(PROP_VISIBLE, properties.getVisible());
-            APPEND_ENTITY_PROPERTY(PROP_IGNORE_FOR_COLLISIONS, properties.getIgnoreForCollisions());
+            APPEND_ENTITY_PROPERTY(PROP_COLLISIONLESS, properties.getCollisionless());
             APPEND_ENTITY_PROPERTY(PROP_COLLISION_MASK, properties.getCollisionMask());
             APPEND_ENTITY_PROPERTY(PROP_DYNAMIC, properties.getDynamic());
             APPEND_ENTITY_PROPERTY(PROP_LOCKED, properties.getLocked());
@@ -1298,7 +1301,7 @@ bool EntityItemProperties::decodeEntityEditPacket(const unsigned char* data, int
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_ANGULAR_VELOCITY, glm::vec3, setAngularVelocity);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_ANGULAR_DAMPING, float, setAngularDamping);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_VISIBLE, bool, setVisible);
-    READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_IGNORE_FOR_COLLISIONS, bool, setIgnoreForCollisions);
+    READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_COLLISIONLESS, bool, setCollisionless);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_COLLISION_MASK, uint8_t, setCollisionMask);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_DYNAMIC, bool, setDynamic);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_LOCKED, bool, setLocked);
@@ -1480,7 +1483,7 @@ void EntityItemProperties::markAllChanged() {
     _glowLevelChanged = true;
     _localRenderAlphaChanged = true;
     _isSpotlightChanged = true;
-    _ignoreForCollisionsChanged = true;
+    _collisionlessChanged = true;
     _collisionMaskChanged = true;
     _dynamicChanged = true;
 
@@ -1600,7 +1603,7 @@ bool EntityItemProperties::hasTerseUpdateChanges() const {
 bool EntityItemProperties::hasMiscPhysicsChanges() const {
     return _gravityChanged || _dimensionsChanged || _densityChanged || _frictionChanged
         || _restitutionChanged || _dampingChanged || _angularDampingChanged || _registrationPointChanged ||
-        _compoundShapeURLChanged || _dynamicChanged || _ignoreForCollisionsChanged || _collisionMaskChanged;
+        _compoundShapeURLChanged || _dynamicChanged || _collisionlessChanged || _collisionMaskChanged;
 }
 
 void EntityItemProperties::clearSimulationOwner() {
@@ -1713,8 +1716,8 @@ QList<QString> EntityItemProperties::listChangedProperties() {
     if (angularDampingChanged()) {
         out += "angularDamping";
     }
-    if (ignoreForCollisionsChanged()) {
-        out += "ignoreForCollisions";
+    if (collisionlessChanged()) {
+        out += "collisionless";
     }
     if (collisionMaskChanged()) {
         out += "collisionMask";

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -127,7 +127,7 @@ public:
     DEFINE_PROPERTY_REF(PROP_REGISTRATION_POINT, RegistrationPoint, registrationPoint, glm::vec3, ENTITY_ITEM_DEFAULT_REGISTRATION_POINT);
     DEFINE_PROPERTY_REF(PROP_ANGULAR_VELOCITY, AngularVelocity, angularVelocity, glm::vec3, ENTITY_ITEM_DEFAULT_ANGULAR_VELOCITY);
     DEFINE_PROPERTY(PROP_ANGULAR_DAMPING, AngularDamping, angularDamping, float, ENTITY_ITEM_DEFAULT_ANGULAR_DAMPING);
-    DEFINE_PROPERTY(PROP_IGNORE_FOR_COLLISIONS, IgnoreForCollisions, ignoreForCollisions, bool, ENTITY_ITEM_DEFAULT_IGNORE_FOR_COLLISIONS);
+    DEFINE_PROPERTY(PROP_COLLISIONLESS, Collisionless, collisionless, bool, ENTITY_ITEM_DEFAULT_COLLISIONLESS);
     DEFINE_PROPERTY(PROP_COLLISION_MASK, CollisionMask, collisionMask, uint8_t, ENTITY_COLLISION_MASK_DEFAULT);
     DEFINE_PROPERTY(PROP_DYNAMIC, Dynamic, dynamic, bool, ENTITY_ITEM_DEFAULT_DYNAMIC);
     DEFINE_PROPERTY(PROP_IS_SPOTLIGHT, IsSpotlight, isSpotlight, bool, false);
@@ -355,7 +355,7 @@ inline QDebug operator<<(QDebug debug, const EntityItemProperties& properties) {
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, RegistrationPoint, registrationPoint, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, AngularVelocity, angularVelocity, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, AngularDamping, angularDamping, "");
-    DEBUG_PROPERTY_IF_CHANGED(debug, properties, IgnoreForCollisions, ignoreForCollisions, "");
+    DEBUG_PROPERTY_IF_CHANGED(debug, properties, Collisionless, collisionless, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, Dynamic, dynamic, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, IsSpotlight, isSpotlight, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, Intensity, intensity, "");

--- a/libraries/entities/src/EntityItemPropertiesDefaults.h
+++ b/libraries/entities/src/EntityItemPropertiesDefaults.h
@@ -18,7 +18,7 @@
 
 #include <NumericalConstants.h>
 
-// There is a minor performance gain when comparing/copying an existing glm::vec3 rather than 
+// There is a minor performance gain when comparing/copying an existing glm::vec3 rather than
 // creating a new one on the stack so we declare the ZERO_VEC3 constant as an optimization.
 const glm::vec3 ENTITY_ITEM_ZERO_VEC3 = glm::vec3(0.0f);
 const glm::vec3 ENTITY_ITEM_ONE_VEC3 = glm::vec3(1.0f);
@@ -68,7 +68,7 @@ const float ENTITY_ITEM_MIN_FRICTION = 0.0f;
 const float ENTITY_ITEM_MAX_FRICTION = 0.99f;
 const float ENTITY_ITEM_DEFAULT_FRICTION = 0.5f;
 
-const bool ENTITY_ITEM_DEFAULT_IGNORE_FOR_COLLISIONS = false;
+const bool ENTITY_ITEM_DEFAULT_COLLISIONLESS = false;
 const bool ENTITY_ITEM_DEFAULT_DYNAMIC = false;
 const bool ENTITY_ITEM_DEFAULT_BILLBOARDED = false;
 

--- a/libraries/entities/src/EntityPropertyFlags.h
+++ b/libraries/entities/src/EntityPropertyFlags.h
@@ -45,7 +45,7 @@ enum EntityPropertyList {
     PROP_REGISTRATION_POINT,
     PROP_ANGULAR_VELOCITY,
     PROP_ANGULAR_DAMPING,
-    PROP_IGNORE_FOR_COLLISIONS,
+    PROP_COLLISIONLESS,
     PROP_DYNAMIC,
 
     // property used by Light entity

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -722,15 +722,15 @@ void EntityTree::fixupTerseEditLogging(EntityItemProperties& properties, QList<Q
         }
     }
 
-    if (properties.ignoreForCollisionsChanged()) {
-        int index = changedProperties.indexOf("ignoreForCollisions");
+    if (properties.collisionlessChanged()) {
+        int index = changedProperties.indexOf("collisionless");
         if (index >= 0) {
-            bool value = properties.getIgnoreForCollisions();
+            bool value = properties.getCollisionless();
             QString changeHint = "0";
             if (value) {
                 changeHint = "1";
             }
-            changedProperties[index] = QString("ignoreForCollisions:") + changeHint;
+            changedProperties[index] = QString("collisionless:") + changeHint;
         }
     }
 

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -624,7 +624,7 @@ QString EntityMotionState::getName() const {
 void EntityMotionState::computeCollisionGroupAndMask(int16_t& group, int16_t& mask) const {
     group = BULLET_COLLISION_GROUP_STATIC;
     if (_entity) {
-        if (_entity->getIgnoreForCollisions()) {
+        if (_entity->getCollisionless()) {
             group = BULLET_COLLISION_GROUP_COLLISIONLESS;
         }
         switch (computePhysicsMotionType()){

--- a/unpublishedScripts/basketballsResetter.js
+++ b/unpublishedScripts/basketballsResetter.js
@@ -83,7 +83,7 @@ var HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
                     },
                     dynamic: true,
                     collisionSoundURL: basketballCollisionSoundURL,
-                    ignoreForCollisions: false,
+                    collisionless: false,
                     modelURL: basketballURL,
                     userData: JSON.stringify({
                         resetMe: {

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -494,7 +494,7 @@
                     z: 1.73
                 },
                 dynamic: true,
-                ignoreForCollisions: false,
+                collisionless: false,
                 compoundShapeURL: rackCollisionHullURL,
                 userData: JSON.stringify({
                     resetMe: {
@@ -543,7 +543,7 @@
                         },
                         dynamic: true,
                         collisionSoundURL: 'http://hifi-public.s3.amazonaws.com/sounds/basketball/basketball.wav',
-                        ignoreForCollisions: false,
+                        collisionless: false,
                         modelURL: basketballURL,
                         userData: JSON.stringify({
                             originalPositionKey: {

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -478,7 +478,7 @@ MasterReset = function() {
                 z: 1.73
             },
             dynamic: true,
-            ignoreForCollisions: false,
+            collisionless: false,
             compoundShapeURL: rackCollisionHullURL,
             userData: JSON.stringify({
                 resetMe: {
@@ -528,7 +528,7 @@ MasterReset = function() {
                     },
                     dynamic: true,
                     collisionSoundURL: 'http://hifi-public.s3.amazonaws.com/sounds/basketball/basketball.wav',
-                    ignoreForCollisions: false,
+                    collisionless: false,
                     modelURL: basketballURL,
                     userData: JSON.stringify({
                         originalPositionKey: {


### PR DESCRIPTION
Continuing my campaign toward more correct names for phyisics features: **ignoreForCollisions** becomes **collisionless**.

The old property name still works for JS scripts.  We'll purge it later.

All of the example scripts have been updated to use the new property name except **handControllerGrab.js** because there were so many incoming changes there when I wrote this code that I didn't want to cause more conflicts there (I'll clean it up soon after this PR merges).  The good news is that this provides a way to test that the old property name still works: handControllerGrab.js tests the old property name ("ignoreForCollisions") and any other script that messes with that property (such as **edit.js**) tests the new one ("collisionless").