### PR TITLE
don't persist entites with invalid parentIDs

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1291,12 +1291,13 @@ void EntityTree::remapIDs() {
     recurseTreeWithOperator(&theOperator);
 }
 
-bool EntityTree::writeToMap(QVariantMap& entityDescription, OctreeElementPointer element, bool skipDefaultValues) {
+bool EntityTree::writeToMap(QVariantMap& entityDescription, OctreeElementPointer element, bool skipDefaultValues,
+                            bool skipThoseWithBadParents) {
     if (! entityDescription.contains("Entities")) {
         entityDescription["Entities"] = QVariantList();
     }
     QScriptEngine scriptEngine;
-    RecurseOctreeToMapOperator theOperator(entityDescription, element, &scriptEngine, skipDefaultValues);
+    RecurseOctreeToMapOperator theOperator(entityDescription, element, &scriptEngine, skipDefaultValues, skipThoseWithBadParents);
     recurseTreeWithOperator(&theOperator);
     return true;
 }

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -199,7 +199,8 @@ public:
 
     void remapIDs();
 
-    virtual bool writeToMap(QVariantMap& entityDescription, OctreeElementPointer element, bool skipDefaultValues) override;
+    virtual bool writeToMap(QVariantMap& entityDescription, OctreeElementPointer element, bool skipDefaultValues,
+                            bool skipThoseWithBadParents) override;
     virtual bool readFromMap(QVariantMap& entityDescription) override;
 
     float getContentsLargestDimension();

--- a/libraries/entities/src/RecurseOctreeToMapOperator.cpp
+++ b/libraries/entities/src/RecurseOctreeToMapOperator.cpp
@@ -16,12 +16,14 @@
 RecurseOctreeToMapOperator::RecurseOctreeToMapOperator(QVariantMap& map,
                                                        OctreeElementPointer top,
                                                        QScriptEngine* engine,
-                                                       bool skipDefaultValues) :
+                                                       bool skipDefaultValues,
+                                                       bool skipThoseWithBadParents) :
         RecurseOctreeOperator(),
         _map(map),
         _top(top),
         _engine(engine),
-        _skipDefaultValues(skipDefaultValues)
+        _skipDefaultValues(skipDefaultValues),
+        _skipThoseWithBadParents(skipThoseWithBadParents)
 {
     // if some element "top" was given, only save information for that element and its children.
     if (_top) {
@@ -47,6 +49,10 @@ bool RecurseOctreeToMapOperator::postRecursion(OctreeElementPointer element) {
     QVariantList entitiesQList = qvariant_cast<QVariantList>(_map["Entities"]);
 
     entityTreeElement->forEachEntity([&](EntityItemPointer entityItem) {
+        if (_skipThoseWithBadParents && !entityItem->isParentIDValid()) {
+            return;  // we weren't able to resolve a parent from _parentID, so don't save this entity.
+        }
+
         EntityItemProperties properties = entityItem->getProperties();
         QScriptValue qScriptValues;
         if (_skipDefaultValues) {

--- a/libraries/entities/src/RecurseOctreeToMapOperator.h
+++ b/libraries/entities/src/RecurseOctreeToMapOperator.h
@@ -13,7 +13,8 @@
 
 class RecurseOctreeToMapOperator : public RecurseOctreeOperator {
 public:
-    RecurseOctreeToMapOperator(QVariantMap& map, OctreeElementPointer top, QScriptEngine* engine, bool skipDefaultValues);
+    RecurseOctreeToMapOperator(QVariantMap& map, OctreeElementPointer top, QScriptEngine* engine, bool skipDefaultValues,
+                               bool skipThoseWithBadParents);
     bool preRecursion(OctreeElementPointer element);
     bool postRecursion(OctreeElementPointer element);
  private:
@@ -22,4 +23,5 @@ public:
     QScriptEngine* _engine;
     bool _withinTop;
     bool _skipDefaultValues;
+    bool _skipThoseWithBadParents;
 };

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -1919,7 +1919,7 @@ void Octree::writeToJSONFile(const char* fileName, OctreeElementPointer element,
     entityDescription["Version"] = (int) expectedVersion;
 
     // store the entity data
-    bool entityDescriptionSuccess = writeToMap(entityDescription, top, true);
+    bool entityDescriptionSuccess = writeToMap(entityDescription, top, true, true);
     if (!entityDescriptionSuccess) {
         qCritical("Failed to convert Entities to QVariantMap while saving to json.");
         return;

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -304,7 +304,8 @@ public:
     void writeToFile(const char* filename, OctreeElementPointer element = NULL, QString persistAsFileType = "svo");
     void writeToJSONFile(const char* filename, OctreeElementPointer element = NULL, bool doGzip = false);
     void writeToSVOFile(const char* filename, OctreeElementPointer element = NULL);
-    virtual bool writeToMap(QVariantMap& entityDescription, OctreeElementPointer element, bool skipDefaultValues) = 0;
+    virtual bool writeToMap(QVariantMap& entityDescription, OctreeElementPointer element, bool skipDefaultValues,
+                            bool skipThoseWithBadParents) = 0;
 
     // Octree importers
     bool readFromFile(const char* filename);

--- a/libraries/shared/src/SpatiallyNestable.h
+++ b/libraries/shared/src/SpatiallyNestable.h
@@ -118,6 +118,8 @@ public:
     void die() { _isDead = true; }
     bool isDead() const { return _isDead; }
 
+    bool isParentIDValid() const { bool success = false; getParentPointer(success); return success; }
+
 protected:
     const NestableType _nestableType; // EntityItem or an AvatarData
     QUuid _id;


### PR DESCRIPTION
- entity server won't persist entities that have a (non-null) parentID which doesn't resolve to an entity.
