### PR TITLE
Avatar: Fix for one frame lag in hold action

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1224,22 +1224,9 @@ void Avatar::setOrientation(const glm::quat& orientation) {
 }
 
 void Avatar::updatePalms() {
-
-    // get palm rotations
-    glm::quat leftPalmRotation, rightPalmRotation;
-    getSkeletonModel().getJointRotationInWorldFrame(getSkeletonModel().getLeftHandJointIndex(), leftPalmRotation);
-    getSkeletonModel().getJointRotationInWorldFrame(getSkeletonModel().getRightHandJointIndex(), rightPalmRotation);
-
-    // get palm positions
-    glm::vec3 leftPalmPosition, rightPalmPosition;
-    getSkeletonModel().getLeftHandPosition(leftPalmPosition);
-    getSkeletonModel().getRightHandPosition(rightPalmPosition);
-    leftPalmPosition += HAND_TO_PALM_OFFSET * glm::inverse(leftPalmRotation);
-    rightPalmPosition += HAND_TO_PALM_OFFSET * glm::inverse(rightPalmRotation);
-
     // update thread-safe caches
-    _leftPalmRotationCache.set(leftPalmRotation);
-    _rightPalmRotationCache.set(rightPalmRotation);
-    _leftPalmPositionCache.set(leftPalmPosition);
-    _rightPalmPositionCache.set(rightPalmPosition);
+    _leftPalmRotationCache.set(getUncachedLeftPalmRotation());
+    _rightPalmRotationCache.set(getUncachedRightPalmRotation());
+    _leftPalmPositionCache.set(getUncachedLeftPalmPosition());
+    _rightPalmPositionCache.set(getUncachedRightPalmPosition());
 }

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1160,23 +1160,57 @@ void Avatar::rebuildCollisionShape() {
 }
 
 // thread-safe
-glm::vec3 Avatar::getLeftPalmPosition() {
+glm::vec3 Avatar::getLeftPalmPosition() const {
     return _leftPalmPositionCache.get();
 }
 
 // thread-safe
-glm::quat Avatar::getLeftPalmRotation() {
+glm::quat Avatar::getLeftPalmRotation() const {
     return _leftPalmRotationCache.get();
 }
 
 // thread-safe
-glm::vec3 Avatar::getRightPalmPosition() {
+glm::vec3 Avatar::getRightPalmPosition() const {
     return _rightPalmPositionCache.get();
 }
 
 // thread-safe
-glm::quat Avatar::getRightPalmRotation() {
+glm::quat Avatar::getRightPalmRotation() const {
     return _rightPalmRotationCache.get();
+}
+
+glm::vec3 Avatar::getUncachedLeftPalmPosition() const {
+    assert(QThread::currentThread() == thread());  // main thread access only
+    glm::quat leftPalmRotation;
+    getSkeletonModel().getJointRotationInWorldFrame(getSkeletonModel().getLeftHandJointIndex(), leftPalmRotation);
+    glm::vec3 leftPalmPosition;
+    getSkeletonModel().getLeftHandPosition(leftPalmPosition);
+    leftPalmPosition += HAND_TO_PALM_OFFSET * glm::inverse(leftPalmRotation);
+    return leftPalmPosition;
+}
+
+glm::quat Avatar::getUncachedLeftPalmRotation() const {
+    assert(QThread::currentThread() == thread());  // main thread access only
+    glm::quat leftPalmRotation;
+    getSkeletonModel().getJointRotationInWorldFrame(getSkeletonModel().getLeftHandJointIndex(), leftPalmRotation);
+    return leftPalmRotation;
+}
+
+glm::vec3 Avatar::getUncachedRightPalmPosition() const {
+    assert(QThread::currentThread() == thread());  // main thread access only
+    glm::quat rightPalmRotation;
+    getSkeletonModel().getJointRotationInWorldFrame(getSkeletonModel().getRightHandJointIndex(), rightPalmRotation);
+    glm::vec3 rightPalmPosition;
+    getSkeletonModel().getRightHandPosition(rightPalmPosition);
+    rightPalmPosition += HAND_TO_PALM_OFFSET * glm::inverse(rightPalmRotation);
+    return rightPalmPosition;
+}
+
+glm::quat Avatar::getUncachedRightPalmRotation() const {
+    assert(QThread::currentThread() == thread());  // main thread access only
+    glm::quat rightPalmRotation;
+    getSkeletonModel().getJointRotationInWorldFrame(getSkeletonModel().getRightHandJointIndex(), rightPalmRotation);
+    return rightPalmRotation;
 }
 
 void Avatar::setPosition(const glm::vec3& position) {

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -167,13 +167,20 @@ public:
     using SpatiallyNestable::setOrientation;
     virtual void setOrientation(const glm::quat& orientation) override;
 
+    // NOT thread safe, must be called on main thread.
+    glm::vec3 getUncachedLeftPalmPosition() const;
+    glm::quat getUncachedLeftPalmRotation() const;
+    glm::vec3 getUncachedRightPalmPosition() const;
+    glm::quat getUncachedRightPalmRotation() const;
+
 public slots:
 
     // FIXME - these should be migrated to use Pose data instead
-    glm::vec3 getLeftPalmPosition();
-    glm::quat getLeftPalmRotation();
-    glm::vec3 getRightPalmPosition();
-    glm::quat getRightPalmRotation();
+    // thread safe, will return last valid palm from cache
+    glm::vec3 getLeftPalmPosition() const;
+    glm::quat getLeftPalmRotation() const;
+    glm::vec3 getRightPalmPosition() const;
+    glm::quat getRightPalmRotation() const;
 
 protected:
     friend class AvatarManager;

--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -60,11 +60,11 @@ void AvatarActionHold::prepareForPhysicsSimulation() {
         glm::vec3 palmPosition;
         glm::quat palmRotation;
         if (_hand == "right") {
-            palmPosition = holdingAvatar->getRightPalmPosition();
-            palmRotation = holdingAvatar->getRightPalmRotation();
+            palmPosition = holdingAvatar->getUncachedRightPalmPosition();
+            palmRotation = holdingAvatar->getUncachedRightPalmRotation();
         } else {
-            palmPosition = holdingAvatar->getLeftPalmPosition();
-            palmRotation = holdingAvatar->getLeftPalmRotation();
+            palmPosition = holdingAvatar->getUncachedLeftPalmPosition();
+            palmRotation = holdingAvatar->getUncachedLeftPalmRotation();
         }
 
         glm::vec3 avatarRigidBodyPosition;


### PR DESCRIPTION
AvatarActionHold now uses the most recent un-cached palm positions/orientations
instead of the cached version from the previous frame.