### PR TITLE
Refactor ShouldRenderFunctor to be out of RenderArgs

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -672,7 +672,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     initializeGL();
 
     // Start rendering
-    _renderEngine->addTask(make_shared<RenderDeferredTask>());
+    _renderEngine->addTask(make_shared<RenderDeferredTask>(LODManager::shouldRender));
     _renderEngine->registerScene(_main3DScene);
 
     _offscreenContext->makeCurrent();
@@ -3820,7 +3820,6 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         auto renderInterface = DependencyManager::get<RenderScriptingInterface>();
         auto renderContext = renderInterface->getRenderContext();
 
-        renderArgs->_shouldRender = LODManager::shouldRender;
         renderArgs->_viewFrustum = getDisplayViewFrustum();
         renderContext.setArgs(renderArgs);
 

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -72,7 +72,9 @@ void ToneMappingDeferred::run(const SceneContextPointer& sceneContext, const Ren
     _toneMappingEffect.render(renderContext->getArgs());
 }
 
-RenderDeferredTask::RenderDeferredTask() : Task() {
+RenderDeferredTask::RenderDeferredTask(CullFunctor cullFunctor) : Task() {
+    cullFunctor = cullFunctor ? cullFunctor : [](const RenderArgs*, const AABox&){ return true; };
+
     // Prepare the ShapePipelines
     ShapePlumberPointer shapePlumber = std::make_shared<ShapePlumber>();
     initDeferredPipelines(*shapePlumber);
@@ -81,7 +83,7 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     auto fetchedOpaques = addJob<FetchItems>("FetchOpaque", FetchItems([](const RenderContextPointer& context, int count) {
         context->getItemsConfig().opaque.numFeed = count;
     }));
-    auto culledOpaques = addJob<CullItems<RenderDetails::OPAQUE_ITEM>>("CullOpaque", fetchedOpaques);
+    auto culledOpaques = addJob<CullItems<RenderDetails::OPAQUE_ITEM>>("CullOpaque", fetchedOpaques, cullFunctor);
     auto opaques = addJob<DepthSortItems>("DepthSortOpaque", culledOpaques);
 
     // CPU only, create the list of renderedTransparents items
@@ -91,7 +93,7 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
             context->getItemsConfig().transparent.numFeed = count;
         }
     ));
-    auto culledTransparents = addJob<CullItems<RenderDetails::TRANSLUCENT_ITEM>>("CullTransparent", fetchedTransparents);
+    auto culledTransparents = addJob<CullItems<RenderDetails::TRANSLUCENT_ITEM>>("CullTransparent", fetchedTransparents, cullFunctor);
     auto transparents = addJob<DepthSortItems>("DepthSortTransparent", culledTransparents, DepthSortItems(false));
 
     // GPU Jobs: Start preparing the deferred and lighting buffer
@@ -107,7 +109,7 @@ RenderDeferredTask::RenderDeferredTask() : Task() {
     addJob<DrawBackgroundDeferred>("DrawBackgroundDeferred");
 
     // Draw Lights just add the lights to the current list of lights to deal with. NOt really gpu job for now.
-    addJob<DrawLight>("DrawLight");
+    addJob<DrawLight>("DrawLight", cullFunctor);
 
     // DeferredBuffer is complete, now let's shade it into the LightingBuffer
     addJob<RenderDeferred>("RenderDeferred");
@@ -174,6 +176,7 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
     setAntialiasingStatus(renderContext->getFxaaStatus());
     setToneMappingExposure(renderContext->getTone().exposure);
     setToneMappingToneCurve(renderContext->getTone().toneCurve);
+    // TODO: Allow runtime manipulation of culling ShouldRenderFunctor
 
     for (auto job : _jobs) {
         job.run(sceneContext, renderContext);

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -12,9 +12,9 @@
 #ifndef hifi_RenderDeferredTask_h
 #define hifi_RenderDeferredTask_h
 
-#include "render/Engine.h"
-
 #include "gpu/Pipeline.h"
+
+#include "render/DrawTask.h"
 
 #include "ToneMappingEffect.h"
 
@@ -113,15 +113,8 @@ public:
 
 class RenderDeferredTask : public render::Task {
 public:
-    RenderDeferredTask();
+    RenderDeferredTask(render::CullFunctor cullFunctor);
 
-    int _drawDebugDeferredBufferIndex;
-    int _drawStatusJobIndex;
-    int _drawHitEffectJobIndex;
-    int _occlusionJobIndex;
-    int _antialiasingJobIndex;
-    int _toneMappingJobIndex;
-    
     void setDrawDebugDeferredBuffer(int draw) { enableJob(_drawDebugDeferredBufferIndex, draw >= 0); }
     bool doDrawDebugDeferredBuffer() const { return getEnableJob(_drawDebugDeferredBufferIndex); }
     
@@ -147,6 +140,14 @@ public:
     int getToneMappingToneCurve() const;
 
     virtual void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
+
+protected:
+    int _drawDebugDeferredBufferIndex;
+    int _drawStatusJobIndex;
+    int _drawHitEffectJobIndex;
+    int _occlusionJobIndex;
+    int _antialiasingJobIndex;
+    int _toneMappingJobIndex;
 };
 
 #endif // hifi_RenderDeferredTask_h

--- a/libraries/render-utils/src/RenderShadowTask.cpp
+++ b/libraries/render-utils/src/RenderShadowTask.cpp
@@ -77,7 +77,9 @@ void RenderShadowMap::run(const render::SceneContextPointer& sceneContext, const
     });
 }
 
-RenderShadowTask::RenderShadowTask() : Task() {
+RenderShadowTask::RenderShadowTask(CullFunctor cullFunctor) : Task() {
+    cullFunctor = cullFunctor ? cullFunctor : [](const RenderArgs*, const AABox&){ return true; };
+
     // Prepare the ShapePipeline
     ShapePlumberPointer shapePlumber = std::make_shared<ShapePlumber>();
     {
@@ -104,7 +106,7 @@ RenderShadowTask::RenderShadowTask() : Task() {
     auto fetchedItems = addJob<FetchItems>("FetchShadowMap");
 
     // CPU: Cull against KeyLight frustum (nearby viewing camera)
-    auto culledItems = addJob<CullItems<RenderDetails::SHADOW_ITEM>>("CullShadowMap", fetchedItems);
+    auto culledItems = addJob<CullItems<RenderDetails::SHADOW_ITEM>>("CullShadowMap", fetchedItems, cullFunctor);
 
     // CPU: Sort by pipeline
     auto sortedShapes = addJob<PipelineSortShapes>("PipelineSortShadowSort", culledItems);
@@ -142,6 +144,7 @@ void RenderShadowTask::run(const SceneContextPointer& sceneContext, const Render
 
     // Set the keylight frustum
     args->_viewFrustum = globalLight->shadow.getFrustum().get();
+    // TODO: Allow runtime manipulation of culling ShouldRenderFunctor
 
     for (auto job : _jobs) {
         job.run(sceneContext, renderContext);

--- a/libraries/render-utils/src/RenderShadowTask.h
+++ b/libraries/render-utils/src/RenderShadowTask.h
@@ -15,7 +15,6 @@
 #include <gpu/Framebuffer.h>
 #include <gpu/Pipeline.h>
 
-#include <render/Scene.h>
 #include <render/DrawTask.h>
 
 class ViewFrustum;
@@ -33,7 +32,7 @@ protected:
 
 class RenderShadowTask : public render::Task {
 public:
-    RenderShadowTask();
+    RenderShadowTask(render::CullFunctor shouldRender);
 
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
 };

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -28,9 +28,6 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
     RenderArgs* args = renderContext->getArgs();
     ViewFrustum* frustum = args->_viewFrustum;
 
-    outItems.clear();
-    outItems.reserve(inItems.size());
-
     details._considered += inItems.size();
     
     // Culling / LOD
@@ -208,6 +205,7 @@ void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContext
 
     auto& details = args->_details.edit(RenderDetails::OTHER_ITEM);
     ItemIDsBounds culledItems;
+    culledItems.reserve(inItems.size());
     cullItems(renderContext, _cullFunctor, details, inItems, culledItems);
 
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -20,14 +20,18 @@
 
 using namespace render;
 
-void render::cullItems(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemIDsBounds& inItems, ItemIDsBounds& outItems) {
+void render::cullItems(const RenderContextPointer& renderContext, const CullFunctor& cullFunctor, RenderDetails::Item& details,
+                       const ItemIDsBounds& inItems, ItemIDsBounds& outItems) {
     assert(renderContext->getArgs());
     assert(renderContext->getArgs()->_viewFrustum);
 
     RenderArgs* args = renderContext->getArgs();
-    auto renderDetails = renderContext->getArgs()->_details._item;
+    ViewFrustum* frustum = args->_viewFrustum;
 
-    renderDetails->_considered += inItems.size();
+    outItems.clear();
+    outItems.reserve(inItems.size());
+
+    details._considered += inItems.size();
     
     // Culling / LOD
     for (auto item : inItems) {
@@ -41,24 +45,24 @@ void render::cullItems(const SceneContextPointer& sceneContext, const RenderCont
         bool outOfView;
         {
             PerformanceTimer perfTimer("boxInFrustum");
-            outOfView = args->_viewFrustum->boxInFrustum(item.bounds) == ViewFrustum::OUTSIDE;
+            outOfView = frustum->boxInFrustum(item.bounds) == ViewFrustum::OUTSIDE;
         }
         if (!outOfView) {
             bool bigEnoughToRender;
             {
                 PerformanceTimer perfTimer("shouldRender");
-                bigEnoughToRender = (args->_shouldRender) ? args->_shouldRender(args, item.bounds) : true;
+                bigEnoughToRender = cullFunctor(args, item.bounds);
             }
             if (bigEnoughToRender) {
                 outItems.emplace_back(item); // One more Item to render
             } else {
-                renderDetails->_tooSmall++;
+                details._tooSmall++;
             }
         } else {
-            renderDetails->_outOfView++;
+            details._outOfView++;
         }
     }
-    renderDetails->_rendered += outItems.size();
+    details._rendered += outItems.size();
 }
 
 struct ItemBound {
@@ -202,10 +206,9 @@ void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContext
 
     RenderArgs* args = renderContext->getArgs();
 
+    auto& details = args->_details.edit(RenderDetails::OTHER_ITEM);
     ItemIDsBounds culledItems;
-    culledItems.reserve(inItems.size());
-    args->_details.pointTo(RenderDetails::OTHER_ITEM);
-    cullItems(sceneContext, renderContext, inItems, culledItems);
+    cullItems(renderContext, _cullFunctor, details, inItems, culledItems);
 
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         args->_batch = &batch;

--- a/libraries/render/src/render/DrawTask.h
+++ b/libraries/render/src/render/DrawTask.h
@@ -49,6 +49,8 @@ public:
     void run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemIDsBounds& inItems, ItemIDsBounds& outItems) {
         const auto& args = renderContext->getArgs();
         auto& details = args->_details.edit(T);
+        outItems.clear();
+        outItems.reserve(inItems.size());
         render::cullItems(renderContext, _cullFunctor, details, inItems, outItems);
     }
 

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -56,34 +56,25 @@ public:
     Item _translucent;
     Item _other;
     
-    Item* _item = &_other;
-    
-    void pointTo(Type type) {
+    Item& edit(Type type) {
         switch (type) {
             case OPAQUE_ITEM:
-                _item = &_opaque;
-                break;
+                return _opaque;
             case SHADOW_ITEM:
-                _item = &_shadow;
-                break;
+                return _shadow;
             case TRANSLUCENT_ITEM:
-                _item = &_translucent;
-                break;
+                return _translucent;
             case OTHER_ITEM:
-                _item = &_other;
-                break;
+            default:
+                return _other;
         }
     }
 };
 
 class RenderArgs {
 public:
-    typedef std::function<bool(const RenderArgs* args, const AABox& bounds)> ShoudRenderFunctor;
-
     enum RenderMode { DEFAULT_RENDER_MODE, SHADOW_RENDER_MODE, DIFFUSE_RENDER_MODE, NORMAL_RENDER_MODE, MIRROR_RENDER_MODE };
-
     enum RenderSide { MONO, STEREO_LEFT, STEREO_RIGHT };
-
     enum DebugFlags {
         RENDER_DEBUG_NONE = 0,
         RENDER_DEBUG_HULLS = 1
@@ -97,8 +88,7 @@ public:
                RenderMode renderMode = DEFAULT_RENDER_MODE,
                RenderSide renderSide = MONO,
                DebugFlags debugFlags = RENDER_DEBUG_NONE,
-               gpu::Batch* batch = nullptr,
-               ShoudRenderFunctor shouldRender = nullptr) :
+               gpu::Batch* batch = nullptr) :
     _context(context),
     _renderer(renderer),
     _viewFrustum(viewFrustum),
@@ -107,8 +97,7 @@ public:
     _renderMode(renderMode),
     _renderSide(renderSide),
     _debugFlags(debugFlags),
-    _batch(batch),
-    _shouldRender(shouldRender) {
+    _batch(batch) {
     }
 
     std::shared_ptr<gpu::Context> _context = nullptr;
@@ -123,7 +112,6 @@ public:
     RenderSide _renderSide = MONO;
     DebugFlags _debugFlags = RENDER_DEBUG_NONE;
     gpu::Batch* _batch = nullptr;
-    ShoudRenderFunctor _shouldRender;
     
     std::shared_ptr<gpu::Texture> _whiteTexture;
 


### PR DESCRIPTION
- Moves RenderArgs::ShoudRenderFunctor to render::CullFunctor, and passes it in explicitly to its tasks/jobs