### PR TITLE
Tie shadow frustum to boom offset

### DIFF
--- a/libraries/render-utils/src/RenderShadowTask.cpp
+++ b/libraries/render-utils/src/RenderShadowTask.cpp
@@ -146,9 +146,9 @@ void RenderShadowTask::run(const SceneContextPointer& sceneContext, const render
     RenderArgs::RenderMode mode = args->_renderMode;
 
     auto nearClip = viewFrustum->getNearClip();
-    const int SHADOW_NEAR_DEPTH = -2;
+    float nearDepth = -args->_boomOffset.z;
     const int SHADOW_FAR_DEPTH = 20;
-    globalLight->shadow.setKeylightFrustum(viewFrustum, nearClip + SHADOW_NEAR_DEPTH, nearClip + SHADOW_FAR_DEPTH);
+    globalLight->shadow.setKeylightFrustum(viewFrustum, nearDepth, nearClip + SHADOW_FAR_DEPTH);
 
     // Set the keylight render args
     args->_viewFrustum = globalLight->shadow.getFrustum().get();

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -105,7 +105,8 @@ public:
     std::shared_ptr<render::ShapePipeline> _pipeline = nullptr;
     OctreeRenderer* _renderer = nullptr;
     ViewFrustum* _viewFrustum = nullptr;
-    glm::ivec4 _viewport{ 0, 0, 1, 1 };
+    glm::ivec4 _viewport{ 0.0f, 0.0f, 1.0f, 1.0f };
+    glm::vec3 _boomOffset{ 0.0f, 0.0f, 1.0f };
     float _sizeScale = 1.0f;
     int _boundaryLevelAdjust = 0;
     RenderMode _renderMode = DEFAULT_RENDER_MODE;


### PR DESCRIPTION
The frustum when rendering a shadowmap was fitted to planes parallel to the view frustum's near/far clips. Before, it was arbitrarily fitted to a plane -2 units behind the camera position for the view frustum.

This led to rooms with walls being overtaken by the walls' shadows, when the rooms' contents' shadows would be more interesting/visually appealing.

This changes the rear plane to which the shadow frustum is fitted to that defined by the third-person camera boom. This way, large objects behind an avatar will only cast shadows if they are immediately visible (as they would otherwise occlude the view of the avatar, and the player would move anyways), and will otherwise not block rooms' contents' shadows.