### PR TITLE
fix premature octree query before preferences are loaded

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2653,6 +2653,8 @@ void Application::loadSettings() {
 
     Menu::getInstance()->loadSettings();
     getMyAvatar()->loadData();
+
+    _settingsLoaded = true;
 }
 
 void Application::saveSettings() {
@@ -3275,6 +3277,10 @@ int Application::sendNackPackets() {
 }
 
 void Application::queryOctree(NodeType_t serverType, PacketType packetType, NodeToJurisdictionMap& jurisdictions) {
+
+    if (!_settingsLoaded) {
+        return; // bail early if settings are not loaded
+    }
 
     //qCDebug(interfaceapp) << ">>> inside... queryOctree()... _viewFrustum.getFieldOfView()=" << _viewFrustum.getFieldOfView();
     bool wantExtraDebugging = getLogger()->extraDebugging();

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -510,6 +510,8 @@ private:
     bool _reticleClickPressed { false };
 
     int _avatarAttachmentRequest = 0;
+
+    bool _settingsLoaded { false };
 };
 
 #endif // hifi_Application_h


### PR DESCRIPTION
In the case of starting up while looking away from content, we would send queries to the octree server before the preferences were actually loaded, causing us to end up getting some domain content that might not be in the direction we were looking.