### PR TITLE
cleanup in preparation for smarter collision grouping

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -92,6 +92,7 @@
 #include <PathUtils.h>
 #include <PerfStat.h>
 #include <PhysicsEngine.h>
+#include <PhysicsHelpers.h>
 #include <plugins/PluginContainer.h>
 #include <plugins/PluginManager.h>
 #include <RenderableWebEntityItem.h>
@@ -3135,7 +3136,7 @@ void Application::update(float deltaTime) {
             PerformanceTimer perfTimer("havestChanges");
             if (_physicsEngine->hasOutgoingChanges()) {
                 getEntities()->getTree()->withWriteLock([&] {
-                    _entitySimulation.handleOutgoingChanges(_physicsEngine->getOutgoingChanges(), _physicsEngine->getSessionID());
+                    _entitySimulation.handleOutgoingChanges(_physicsEngine->getOutgoingChanges(), Physics::getSessionUUID());
                     avatarManager->handleOutgoingChanges(_physicsEngine->getOutgoingChanges());
                 });
 
@@ -4296,6 +4297,9 @@ bool Application::acceptURL(const QString& urlString, bool defaultUpload) {
 }
 
 void Application::setSessionUUID(const QUuid& sessionUUID) {
+    // HACK: until we swap the library dependency order between physics and entities
+    // we cache the sessionID in two distinct places for physics.
+    Physics::setSessionUUID(sessionUUID); // TODO: remove this one
     _physicsEngine->setSessionUUID(sessionUUID);
 }
 

--- a/interface/src/avatar/AvatarMotionState.cpp
+++ b/interface/src/avatar/AvatarMotionState.cpp
@@ -146,6 +146,6 @@ QUuid AvatarMotionState::getSimulatorID() const {
 // virtual
 void AvatarMotionState::computeCollisionGroupAndMask(int16_t& group, int16_t& mask) const {
     group = BULLET_COLLISION_GROUP_OTHER_AVATAR;
-    mask = PhysicsEngine::getCollisionMask(group);
+    mask = Physics::getDefaultCollisionMask(group);
 }
 

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -275,8 +275,9 @@ public:
     void setCollisionless(bool value) { _collisionless = value; }
 
     uint8_t getCollisionMask() const { return _collisionMask; }
-    uint8_t getFinalCollisionMask() const { return _collisionless ? 0 : _collisionMask; }
     void setCollisionMask(uint8_t value) { _collisionMask = value; }
+
+    void computeCollisionGroupAndFinalMask(int16_t& group, int16_t& mask) const;
 
     bool getDynamic() const { return _dynamic; }
     void setDynamic(bool value) { _dynamic = value; }
@@ -370,8 +371,8 @@ public:
     bool clearActions(EntitySimulation* simulation);
     void setActionData(QByteArray actionData);
     const QByteArray getActionData() const;
-    bool hasActions() { return !_objectActions.empty(); }
-    QList<QUuid> getActionIDs() { return _objectActions.keys(); }
+    bool hasActions() const { return !_objectActions.empty(); }
+    QList<QUuid> getActionIDs() const { return _objectActions.keys(); }
     QVariantMap getActionArguments(const QUuid& actionID) const;
     void deserializeActions();
 

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -162,8 +162,8 @@ QString EntityItemProperties::getCollisionMaskAsString() const {
 void EntityItemProperties::setCollisionMaskFromString(const QString& maskString) {
     QVector<QStringRef> groups = maskString.splitRef(',');
     uint8_t mask = 0x00;
-    for (auto group : groups) {
-        mask |= getCollisionGroupAsBitMask(group);
+    for (auto groupName : groups) {
+        mask |= getCollisionGroupAsBitMask(groupName);
     }
     _collisionMask = mask;
     _collisionMaskChanged = true;

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -18,47 +18,10 @@
 #include "ThreadSafeDynamicsWorld.h"
 #include "PhysicsLogging.h"
 
-uint32_t PhysicsEngine::getNumSubsteps() {
-    return _numSubsteps;
-}
-
-btHashMap<btHashInt, int16_t> _collisionMasks;
-
-void initCollisionMaskTable() {
-    if (_collisionMasks.size() == 0) {
-        // build table of masks with their group as the key
-        _collisionMasks.insert(btHashInt((int)BULLET_COLLISION_GROUP_DYNAMIC), BULLET_COLLISION_MASK_DYNAMIC);
-        _collisionMasks.insert(btHashInt((int)BULLET_COLLISION_GROUP_STATIC), BULLET_COLLISION_MASK_STATIC);
-        _collisionMasks.insert(btHashInt((int)BULLET_COLLISION_GROUP_KINEMATIC), BULLET_COLLISION_MASK_KINEMATIC);
-        _collisionMasks.insert(btHashInt((int)BULLET_COLLISION_GROUP_MY_AVATAR), BULLET_COLLISION_MASK_MY_AVATAR);
-        _collisionMasks.insert(btHashInt((int)BULLET_COLLISION_GROUP_OTHER_AVATAR), BULLET_COLLISION_MASK_OTHER_AVATAR);
-        _collisionMasks.insert(btHashInt((int)BULLET_COLLISION_GROUP_COLLISIONLESS), BULLET_COLLISION_MASK_COLLISIONLESS);
-    }
-}
-
-// static
-int16_t PhysicsEngine::getCollisionMask(int16_t group) {
-    const int16_t* mask = _collisionMasks.find(btHashInt((int)group));
-    return mask ? *mask : BULLET_COLLISION_MASK_DEFAULT;
-}
-
-QUuid _sessionID;
-
-// static
-void PhysicsEngine::setSessionUUID(const QUuid& sessionID) {
-    _sessionID = sessionID;
-}
-
-// static
-const QUuid& PhysicsEngine::getSessionID() {
-    return _sessionID;
-}
-
-
 PhysicsEngine::PhysicsEngine(const glm::vec3& offset) :
         _originOffset(offset),
+        _sessionID(),
         _myAvatarController(nullptr) {
-    initCollisionMaskTable();
 }
 
 PhysicsEngine::~PhysicsEngine() {
@@ -88,6 +51,10 @@ void PhysicsEngine::init() {
         // TODO: set up gravity zones
         _dynamicsWorld->setGravity(btVector3(0.0f, 0.0f, 0.0f));
     }
+}
+
+uint32_t PhysicsEngine::getNumSubsteps() {
+    return _numSubsteps;
 }
 
 // private

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -45,16 +45,11 @@ typedef QVector<Collision> CollisionEvents;
 
 class PhysicsEngine {
 public:
-    static int16_t getCollisionMask(int16_t group);
-
-    uint32_t getNumSubsteps();
-
     PhysicsEngine(const glm::vec3& offset);
     ~PhysicsEngine();
     void init();
 
-    static void setSessionUUID(const QUuid& sessionID);
-    static const QUuid& getSessionID();
+    uint32_t getNumSubsteps();
 
     void removeObjects(const VectorOfMotionStates& objects);
     void removeObjects(const SetOfMotionStates& objects); // only called during teardown
@@ -95,6 +90,8 @@ public:
     void removeAction(const QUuid actionID);
     void forEachAction(std::function<void(EntityActionPointer)> actor);
 
+    void setSessionUUID(const QUuid& sessionID) { _sessionID = sessionID; }
+
 private:
     void addObjectToDynamicsWorld(ObjectMotionState* motionState);
     void removeObjectFromDynamicsWorld(ObjectMotionState* motionState);
@@ -111,23 +108,21 @@ private:
     ThreadSafeDynamicsWorld* _dynamicsWorld = NULL;
     btGhostPairCallback* _ghostPairCallback = NULL;
 
-    glm::vec3 _originOffset;
-
     ContactMap _contactMap;
-    uint32_t _numContactFrames = 0;
+    CollisionEvents _collisionEvents;
+    QHash<QUuid, EntityActionPointer> _objectActions;
 
-    /// character collisions
+    glm::vec3 _originOffset;
+    QUuid _sessionID;
+
     CharacterController* _myAvatarController;
+
+    uint32_t _numContactFrames = 0;
+    uint32_t _numSubsteps;
 
     bool _dumpNextStats = false;
     bool _hasOutgoingChanges = false;
 
-    CollisionEvents _collisionEvents;
-
-    QHash<QUuid, EntityActionPointer> _objectActions;
-
-
-    uint32_t _numSubsteps;
 };
 
 typedef std::shared_ptr<PhysicsEngine> PhysicsEnginePointer;

--- a/libraries/shared/src/PhysicsHelpers.cpp
+++ b/libraries/shared/src/PhysicsHelpers.cpp
@@ -11,6 +11,9 @@
 
 #include "PhysicsHelpers.h"
 #include "NumericalConstants.h"
+#include <QUuid>
+
+#include "PhysicsCollisionGroups.h"
 
 // This chunk of code was copied from Bullet-2.82, so we include the Bullet license here:
 /*
@@ -19,12 +22,12 @@
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the use of this software.
- * Permission is granted to anyone to use this software for any purpose, 
- * including commercial applications, and to alter it and redistribute it freely, 
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it freely,
  * subject to the following restrictions:
  *
- * 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. 
- *    If you use this software in a product, an acknowledgment in the product documentation would be appreciated but 
+ * 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
+ *    If you use this software in a product, an acknowledgment in the product documentation would be appreciated but
  *    is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
@@ -56,3 +59,33 @@ glm::quat computeBulletRotationStep(const glm::vec3& angularVelocity, float time
     }
     return glm::quat(cosf(0.5f * speed * timeStep), axis.x, axis.y, axis.z);
 }
+/* end Bullet code derivation*/
+
+int16_t Physics::getDefaultCollisionMask(int16_t group) {
+    switch(group) {
+        case  BULLET_COLLISION_GROUP_STATIC:
+            return BULLET_COLLISION_MASK_STATIC;
+        case  BULLET_COLLISION_GROUP_DYNAMIC:
+            return BULLET_COLLISION_MASK_DYNAMIC;
+        case  BULLET_COLLISION_GROUP_KINEMATIC:
+            return BULLET_COLLISION_MASK_KINEMATIC;
+        case  BULLET_COLLISION_GROUP_MY_AVATAR:
+            return BULLET_COLLISION_MASK_MY_AVATAR;
+        case  BULLET_COLLISION_GROUP_OTHER_AVATAR:
+            return BULLET_COLLISION_MASK_OTHER_AVATAR;
+        default:
+            break;
+    };
+    return BULLET_COLLISION_MASK_COLLISIONLESS;
+}
+
+QUuid _sessionID;
+
+void Physics::setSessionUUID(const QUuid& sessionID) {
+    _sessionID = sessionID;
+}
+
+const QUuid& Physics::getSessionUUID() {
+    return _sessionID;
+}
+

--- a/libraries/shared/src/PhysicsHelpers.h
+++ b/libraries/shared/src/PhysicsHelpers.h
@@ -14,11 +14,22 @@
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <QUuid>
+
+// TODO: move everything in here to the physics library after the physics/entities library
+// dependency order is swapped.
 
 const int PHYSICS_ENGINE_MAX_NUM_SUBSTEPS = 6; // Bullet will start to "lose time" at 10 FPS.
 const float PHYSICS_ENGINE_FIXED_SUBSTEP = 1.0f / 90.0f;
 
 // return incremental rotation (Bullet-style) caused by angularVelocity over timeStep
 glm::quat computeBulletRotationStep(const glm::vec3& angularVelocity, float timeStep);
+
+namespace Physics {
+    int16_t getDefaultCollisionMask(int16_t group);
+
+    void setSessionUUID(const QUuid& sessionID);
+    const QUuid& getSessionUUID();
+};
 
 #endif // hifi_PhysicsHelpers_h


### PR DESCRIPTION
This PR moves the collision group calculations into EntityItem where all of the input data lives.  There are no noticeable changes from the user perspective now but this work paves the way for more intelligent collision grouping such as automatically making attachments use the same collision group as their avatar.