### PR TITLE
Unify normal and named draw paths 

### DIFF
--- a/interface/src/Util.cpp
+++ b/interface/src/Util.cpp
@@ -96,26 +96,31 @@ void renderWorldBox(gpu::Batch& batch) {
                               glm::vec3(HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY);
 
     
-    geometryCache->renderWireCubeInstance(batch, Transform(), GREY4);
+    geometryCache->renderWireCubeInstance(batch, GREY4);
 
     //  Draw meter markers along the 3 axis to help with measuring things
     const float MARKER_DISTANCE = 1.0f;
     const float MARKER_RADIUS = 0.05f;
 
     transform = Transform().setScale(MARKER_RADIUS);
-    geometryCache->renderSolidSphereInstance(batch, transform, RED);
+    batch.setModelTransform(transform);
+    geometryCache->renderSolidSphereInstance(batch, RED);
 
     transform = Transform().setTranslation(glm::vec3(MARKER_DISTANCE, 0.0f, 0.0f)).setScale(MARKER_RADIUS);
-    geometryCache->renderSolidSphereInstance(batch, transform, RED);
+    batch.setModelTransform(transform);
+    geometryCache->renderSolidSphereInstance(batch, RED);
 
     transform = Transform().setTranslation(glm::vec3(0.0f, MARKER_DISTANCE, 0.0f)).setScale(MARKER_RADIUS);
-    geometryCache->renderSolidSphereInstance(batch, transform, GREEN);
+    batch.setModelTransform(transform);
+    geometryCache->renderSolidSphereInstance(batch, GREEN);
 
     transform = Transform().setTranslation(glm::vec3(0.0f, 0.0f, MARKER_DISTANCE)).setScale(MARKER_RADIUS);
-    geometryCache->renderSolidSphereInstance(batch, transform, BLUE);
+    batch.setModelTransform(transform);
+    geometryCache->renderSolidSphereInstance(batch, BLUE);
 
     transform = Transform().setTranslation(glm::vec3(MARKER_DISTANCE, 0.0f, MARKER_DISTANCE)).setScale(MARKER_RADIUS);
-    geometryCache->renderSolidSphereInstance(batch, transform, GREY);
+    batch.setModelTransform(transform);
+    geometryCache->renderSolidSphereInstance(batch, GREY);
 }
 
 //  Return a random vector of average length 1

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -456,7 +456,8 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
             Transform transform;
             transform.setTranslation(position);
             transform.postScale(INDICATOR_RADIUS);
-            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, transform, LOOK_AT_INDICATOR_COLOR);
+            batch.setModelTransform(transform);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, LOOK_AT_INDICATOR_COLOR);
         }
 
         // If the avatar is looking at me, indicate that they are
@@ -484,9 +485,9 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
 
+                    batch.setModelTransform(Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT));
                     DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch,
-                        Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT),
-                        glm::vec4(LOOKING_AT_ME_COLOR, alpha));
+                                                                            glm::vec4(LOOKING_AT_ME_COLOR, alpha));
 
                     position = getHead()->getRightEyePosition();
                     transform.setTranslation(position);
@@ -494,9 +495,9 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                     if (eyeDiameter == 0.0f) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
+                    batch.setModelTransform(Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT));
                     DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch,
-                        Transform(transform).postScale(eyeDiameter * getUniformScale() / 2.0f + RADIUS_INCREMENT),
-                        glm::vec4(LOOKING_AT_ME_COLOR, alpha));
+                                                                            glm::vec4(LOOKING_AT_ME_COLOR, alpha));
 
                 }
             }

--- a/interface/src/avatar/Hand.cpp
+++ b/interface/src/avatar/Hand.cpp
@@ -60,7 +60,8 @@ void Hand::renderHandTargets(RenderArgs* renderArgs, bool isMine) {
             transform.setTranslation(position);
             transform.setRotation(palm.getRotation());
             transform.postScale(SPHERE_RADIUS);
-            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, transform, grayColor);
+            batch.setModelTransform(transform);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, grayColor);
 
             // draw a green sphere at the old "finger tip"
             transform = Transform();
@@ -68,7 +69,8 @@ void Hand::renderHandTargets(RenderArgs* renderArgs, bool isMine) {
             transform.setTranslation(position);
             transform.setRotation(palm.getRotation());
             transform.postScale(SPHERE_RADIUS);
-            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, transform, greenColor);
+            batch.setModelTransform(transform);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, greenColor);
         }
     }
 

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -467,5 +467,6 @@ void Head::renderLookatTarget(RenderArgs* renderArgs, glm::vec3 lookatPosition) 
     const float LOOK_AT_TARGET_RADIUS = 0.075f;
     transform.postScale(LOOK_AT_TARGET_RADIUS);
     const glm::vec4 LOOK_AT_TARGET_COLOR = { 0.8f, 0.0f, 0.0f, 0.75f };
-    geometryCache->renderSolidSphereInstance(batch, transform, LOOK_AT_TARGET_COLOR);
+    batch.setModelTransform(transform);
+    geometryCache->renderSolidSphereInstance(batch, LOOK_AT_TARGET_COLOR);
 }

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -349,17 +349,15 @@ void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float scale
     // draw a blue sphere at the capsule top point
     glm::vec3 topPoint = _translation + getRotation() * (scale * (_boundingCapsuleLocalOffset + (0.5f * _boundingCapsuleHeight) * Vectors::UNIT_Y));
 
-    geometryCache->renderSolidSphereInstance(batch,
-        Transform().setTranslation(topPoint).postScale(scale * _boundingCapsuleRadius),
-    	glm::vec4(0.6f, 0.6f, 0.8f, alpha));
+    batch.setModelTransform(Transform().setTranslation(topPoint).postScale(scale * _boundingCapsuleRadius));
+    geometryCache->renderSolidSphereInstance(batch, glm::vec4(0.6f, 0.6f, 0.8f, alpha));
 
     // draw a yellow sphere at the capsule bottom point
     glm::vec3 bottomPoint = topPoint - glm::vec3(0.0f, scale * _boundingCapsuleHeight, 0.0f);
     glm::vec3 axis = topPoint - bottomPoint;
 
-    geometryCache->renderSolidSphereInstance(batch,
-        Transform().setTranslation(bottomPoint).postScale(scale * _boundingCapsuleRadius),
-        glm::vec4(0.8f, 0.8f, 0.6f, alpha));
+    batch.setModelTransform(Transform().setTranslation(bottomPoint).postScale(scale * _boundingCapsuleRadius));
+    geometryCache->renderSolidSphereInstance(batch, glm::vec4(0.8f, 0.8f, 0.6f, alpha));
 
     // draw a green cylinder between the two points
     glm::vec3 origin(0.0f);

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -60,7 +60,8 @@ void Cube3DOverlay::render(RenderArgs* args) {
             // }
 
             transform.setScale(dimensions);
-            DependencyManager::get<GeometryCache>()->renderSolidCubeInstance(*batch, transform, cubeColor);
+            batch->setModelTransform(transform);
+            DependencyManager::get<GeometryCache>()->renderSolidCubeInstance(*batch, cubeColor);
         } else {
 
             if (getIsDashedLine()) {
@@ -96,9 +97,9 @@ void Cube3DOverlay::render(RenderArgs* args) {
                 geometryCache->renderDashedLine(*batch, bottomRightFar, topRightFar, cubeColor);
 
             } else {
-                batch->setModelTransform(Transform());
                 transform.setScale(dimensions);
-                DependencyManager::get<GeometryCache>()->renderWireCubeInstance(*batch, transform, cubeColor);
+                batch->setModelTransform(transform);
+                DependencyManager::get<GeometryCache>()->renderWireCubeInstance(*batch, cubeColor);
             }
         }
     }

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -39,14 +39,13 @@ void Sphere3DOverlay::render(RenderArgs* args) {
     auto batch = args->_batch;
 
     if (batch) {
-        batch->setModelTransform(Transform());
-
         Transform transform = _transform;
         transform.postScale(getDimensions() * SPHERE_OVERLAY_SCALE);
+        batch->setModelTransform(transform);
         if (_isSolid) {
-            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(*batch, transform, sphereColor);
+            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(*batch, sphereColor);
         } else {
-            DependencyManager::get<GeometryCache>()->renderWireSphereInstance(*batch, transform, sphereColor);
+            DependencyManager::get<GeometryCache>()->renderWireSphereInstance(*batch, sphereColor);
         }
     }
 }

--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
@@ -61,14 +61,14 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
         return;
     }
 
+    batch.setModelTransform(transToCenter); // we want to include the scale as well
     if (_procedural->ready()) {
-        batch.setModelTransform(transToCenter); // we want to include the scale as well
         _procedural->prepare(batch, getPosition(), getDimensions());
         auto color = _procedural->getColor(cubeColor);
         batch._glColor4f(color.r, color.g, color.b, color.a);
         DependencyManager::get<GeometryCache>()->renderCube(batch);
     } else {
-        DependencyManager::get<GeometryCache>()->renderSolidCubeInstance(batch, transToCenter, cubeColor);
+        DependencyManager::get<GeometryCache>()->renderSolidCubeInstance(batch, cubeColor);
     }
     static const auto triCount = DependencyManager::get<GeometryCache>()->getCubeTriangleCount();
     args->_details._trianglesRendered += (int)triCount;

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -440,8 +440,8 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
         bool success;
         auto shapeTransform = getTransformToCenter(success);
         if (success) {
-            batch.setModelTransform(Transform()); // we want to include the scale as well
-            DependencyManager::get<GeometryCache>()->renderWireCubeInstance(batch, shapeTransform, greenColor);
+            batch.setModelTransform(shapeTransform); // we want to include the scale as well
+            DependencyManager::get<GeometryCache>()->renderWireCubeInstance(batch, greenColor);
         }
     }
 }

--- a/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
@@ -64,15 +64,14 @@ void RenderableSphereEntityItem::render(RenderArgs* args) {
         return;
     }
     modelTransform.postScale(SPHERE_ENTITY_SCALE);
+    batch.setModelTransform(modelTransform); // use a transform with scale, rotation, registration point and translation
     if (_procedural->ready()) {
-        batch.setModelTransform(modelTransform); // use a transform with scale, rotation, registration point and translation
         _procedural->prepare(batch, getPosition(), getDimensions());
         auto color = _procedural->getColor(sphereColor);
         batch._glColor4f(color.r, color.g, color.b, color.a);
         DependencyManager::get<GeometryCache>()->renderSphere(batch);
     } else {
-        batch.setModelTransform(Transform());
-        DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, modelTransform, sphereColor);
+        DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(batch, sphereColor);
     }
     static const auto triCount = DependencyManager::get<GeometryCache>()->getSphereTriangleCount();
     args->_details._trianglesRendered += (int)triCount;

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -132,7 +132,6 @@ void RenderableZoneEntityItem::render(RenderArgs* args) {
                 
                 Q_ASSERT(args->_batch);
                 gpu::Batch& batch = *args->_batch;
-                batch.setModelTransform(Transform());
 
                 bool success;
                 auto shapeTransform = getTransformToCenter(success);
@@ -142,9 +141,11 @@ void RenderableZoneEntityItem::render(RenderArgs* args) {
                 auto geometryCache = DependencyManager::get<GeometryCache>();
                 if (getShapeType() == SHAPE_TYPE_SPHERE) {
                     shapeTransform.postScale(SPHERE_ENTITY_SCALE);
-                    geometryCache->renderWireSphereInstance(batch, shapeTransform, DEFAULT_COLOR);
+                    batch.setModelTransform(shapeTransform);
+                    geometryCache->renderWireSphereInstance(batch, DEFAULT_COLOR);
                 } else {
-                    geometryCache->renderWireCubeInstance(batch, shapeTransform, DEFAULT_COLOR);
+                    batch.setModelTransform(shapeTransform);
+                    geometryCache->renderWireCubeInstance(batch, DEFAULT_COLOR);
                 }
                 break;
             }

--- a/libraries/gl/src/gl/Config.h
+++ b/libraries/gl/src/gl/Config.h
@@ -49,7 +49,9 @@
 
 
 #if (GPU_INPUT_PROFILE == GPU_CORE_43)
-#define GPU_SSBO_DRAW_CALL_INFO
+// Deactivate SSBO for now, we've run into some issues
+// on GL 4.3 capable GPUs not behaving as expected
+//#define GPU_SSBO_DRAW_CALL_INFO
 #endif
 
 

--- a/libraries/gl/src/gl/Config.h
+++ b/libraries/gl/src/gl/Config.h
@@ -9,8 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#ifndef gpu__GPUConfig__
-#define gpu__GPUConfig__
+#ifndef hifi_gpu_GPUConfig_h
+#define hifi_gpu_GPUConfig_h
 
 
 #define GL_GLEXT_PROTOTYPES 1
@@ -38,8 +38,6 @@
 #define GPU_FEATURE_PROFILE GPU_CORE
 #define GPU_INPUT_PROFILE GPU_CORE_43
 
-#elif defined(ANDROID)
-
 #else
 
 #include <GL/glew.h>
@@ -50,4 +48,9 @@
 #endif
 
 
+#if (GPU_INPUT_PROFILE == GPU_CORE_43)
+#define GPU_SSBO_DRAW_CALL_INFO
 #endif
+
+
+#endif // hifi_gpu_GPUConfig_h

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -378,7 +378,9 @@ void Batch::setupNamedCalls(const std::string& instanceName, NamedBatchData::Fun
         instance.function = function;
     }
 
+    _currentNamedCall = instanceName;
     captureDrawCallInfo();
+    _currentNamedCall.clear();
 }
 
 BufferPointer Batch::getNamedBuffer(const std::string& instanceName, uint8_t index) {
@@ -411,9 +413,8 @@ const Batch::DrawCallInfoBuffer& Batch::getDrawCallInfoBuffer() const {
 }
 
 void Batch::captureDrawCallInfo() {
-    TransformObject object;
-
     if (_invalidModel) {
+        TransformObject object;
         _currentModel.getMatrix(object._model);
 
         // FIXME - we don't want to be using glm::inverse() here but it fixes the flickering issue we are 
@@ -423,10 +424,10 @@ void Batch::captureDrawCallInfo() {
         object._modelInverse = glm::inverse(object._model);
 
         _objects.push_back(object);
-    }
 
-    // Flags are clean
-    _invalidModel = false;
+        // Flag is clean
+        _invalidModel = false;
+    }
 
     auto& drawCallInfos = getDrawCallInfoBuffer();
     drawCallInfos.push_back((uint16)_objects.size() - 1);

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -442,8 +442,6 @@ void Batch::preExecute() {
         instance.process(*this);
         stopNamedCall();
     }
-
-    _namedData.clear();
 }
 
 QDebug& operator<<(QDebug& debug, const Batch::CacheState& cacheState) {

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -344,6 +344,15 @@ void Batch::runLambda(std::function<void()> f) {
     _params.push_back(_lambdas.cache(f));
 }
 
+void Batch::startNamedCall(const std::string& name) {
+    ADD_COMMAND(startNamedCall);
+    _params.push_back(_names.cache(name));
+}
+
+void Batch::stopNamedCall() {
+    ADD_COMMAND(stopNamedCall);
+}
+
 void Batch::enableStereo(bool enable) {
     _enableStereo = enable;
 }
@@ -383,8 +392,14 @@ BufferPointer Batch::getNamedBuffer(const std::string& instanceName, uint8_t ind
 
 void Batch::preExecute() {
     for (auto& mapItem : _namedData) {
-        mapItem.second.process(*this);
+        auto& name = mapItem.first;
+        auto& instance = mapItem.second;
+
+        startNamedCall(name);
+        instance.process(*this);
+        stopNamedCall();
     }
+
     _namedData.clear();
 }
 

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -29,20 +29,6 @@ ProfileRangeBatch::~ProfileRangeBatch() {
 
 using namespace gpu;
 
-Batch::Batch() :
-    _commands(),
-    _commandOffsets(),
-    _params(),
-    _data(),
-    _buffers(),
-    _textures(),
-    _streamFormats(),
-    _transforms(),
-    _pipelines(),
-    _framebuffers()
-{
-}
-
 Batch::Batch(const CacheState& cacheState) : Batch() {
     _commands.reserve(cacheState.commandsSize);
     _commandOffsets.reserve(cacheState.offsetsSize);
@@ -88,6 +74,8 @@ void Batch::draw(Primitive primitiveType, uint32 numVertices, uint32 startVertex
     _params.push_back(startVertex);
     _params.push_back(numVertices);
     _params.push_back(primitiveType);
+
+    captureDrawCallInfo();
 }
 
 void Batch::drawIndexed(Primitive primitiveType, uint32 numIndices, uint32 startIndex) {
@@ -96,6 +84,8 @@ void Batch::drawIndexed(Primitive primitiveType, uint32 numIndices, uint32 start
     _params.push_back(startIndex);
     _params.push_back(numIndices);
     _params.push_back(primitiveType);
+
+    captureDrawCallInfo();
 }
 
 void Batch::drawInstanced(uint32 numInstances, Primitive primitiveType, uint32 numVertices, uint32 startVertex, uint32 startInstance) {
@@ -106,6 +96,8 @@ void Batch::drawInstanced(uint32 numInstances, Primitive primitiveType, uint32 n
     _params.push_back(numVertices);
     _params.push_back(primitiveType);
     _params.push_back(numInstances);
+
+    captureDrawCallInfo();
 }
 
 void Batch::drawIndexedInstanced(uint32 numInstances, Primitive primitiveType, uint32 numIndices, uint32 startIndex, uint32 startInstance) {
@@ -116,6 +108,8 @@ void Batch::drawIndexedInstanced(uint32 numInstances, Primitive primitiveType, u
     _params.push_back(numIndices);
     _params.push_back(primitiveType);
     _params.push_back(numInstances);
+
+    captureDrawCallInfo();
 }
 
 
@@ -123,12 +117,16 @@ void Batch::multiDrawIndirect(uint32 numCommands, Primitive primitiveType) {
     ADD_COMMAND(multiDrawIndirect);
     _params.push_back(numCommands);
     _params.push_back(primitiveType);
+
+    captureDrawCallInfo();
 }
 
 void Batch::multiDrawIndexedIndirect(uint32 nbCommands, Primitive primitiveType) {
     ADD_COMMAND(multiDrawIndexedIndirect);
     _params.push_back(nbCommands);
     _params.push_back(primitiveType);
+
+    captureDrawCallInfo();
 }
 
 void Batch::setInputFormat(const Stream::FormatPointer& format) {
@@ -185,7 +183,8 @@ void Batch::setIndirectBuffer(const BufferPointer& buffer, Offset offset, Offset
 void Batch::setModelTransform(const Transform& model) {
     ADD_COMMAND(setModelTransform);
 
-    _params.push_back(_transforms.cache(model));
+    _currentModel = model;
+    _invalidModel = true;
 }
 
 void Batch::setViewTransform(const Transform& view) {
@@ -347,10 +346,14 @@ void Batch::runLambda(std::function<void()> f) {
 void Batch::startNamedCall(const std::string& name) {
     ADD_COMMAND(startNamedCall);
     _params.push_back(_names.cache(name));
+    
+    _currentNamedCall = name;
 }
 
 void Batch::stopNamedCall() {
     ADD_COMMAND(stopNamedCall);
+
+    _currentNamedCall.clear();
 }
 
 void Batch::enableStereo(bool enable) {
@@ -369,14 +372,13 @@ bool Batch::isSkyboxEnabled() const {
     return _enableSkybox;
 }
 
-void Batch::setupNamedCalls(const std::string& instanceName, size_t count, NamedBatchData::Function function) {
-    NamedBatchData& instance = _namedData[instanceName];
-    instance.count += count;
-    instance.function = function;
-}
-
 void Batch::setupNamedCalls(const std::string& instanceName, NamedBatchData::Function function) {
-    setupNamedCalls(instanceName, 1, function);
+    NamedBatchData& instance = _namedData[instanceName];
+    if (!instance.function) {
+        instance.function = function;
+    }
+
+    captureDrawCallInfo();
 }
 
 BufferPointer Batch::getNamedBuffer(const std::string& instanceName, uint8_t index) {
@@ -385,9 +387,49 @@ BufferPointer Batch::getNamedBuffer(const std::string& instanceName, uint8_t ind
         instance.buffers.resize(index + 1);
     }
     if (!instance.buffers[index]) {
-        instance.buffers[index].reset(new Buffer());
+        instance.buffers[index] = std::make_shared<Buffer>();
     }
     return instance.buffers[index];
+}
+
+Batch::DrawCallInfoBuffer& Batch::getDrawCallInfoBuffer() {
+    if (_currentNamedCall.empty()) {
+        return _drawCallInfos;
+    } else {
+        return _namedData[_currentNamedCall].drawCallInfos;
+    }
+}
+
+const Batch::DrawCallInfoBuffer& Batch::getDrawCallInfoBuffer() const {
+    if (_currentNamedCall.empty()) {
+        return _drawCallInfos;
+    } else {
+        auto it = _namedData.find(_currentNamedCall);
+        Q_ASSERT_X(it != _namedData.end(), Q_FUNC_INFO, (_currentNamedCall + " not in _namedData.").data());
+        return it->second.drawCallInfos;
+    }
+}
+
+void Batch::captureDrawCallInfo() {
+    TransformObject object;
+
+    if (_invalidModel) {
+        _currentModel.getMatrix(object._model);
+
+        // FIXME - we don't want to be using glm::inverse() here but it fixes the flickering issue we are 
+        // seeing with planky blocks in toybox. Our implementation of getInverseMatrix() is buggy in cases
+        // of non-uniform scale. We need to fix that. In the mean time, glm::inverse() works.
+        //_model.getInverseMatrix(_object._modelInverse);
+        object._modelInverse = glm::inverse(object._model);
+
+        _objects.push_back(object);
+    }
+
+    // Flags are clean
+    _invalidModel = false;
+
+    auto& drawCallInfos = getDrawCallInfoBuffer();
+    drawCallInfos.push_back((uint16)_objects.size() - 1);
 }
 
 void Batch::preExecute() {

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -304,6 +304,9 @@ public:
 
         COMMAND_runLambda,
 
+        COMMAND_startNamedCall,
+        COMMAND_stopNamedCall,
+
         // TODO: As long as we have gl calls explicitely issued from interface
         // code, we need to be able to record and batch these calls. THe long 
         // term strategy is to get rid of any GL calls in favor of the HIFI GPU API
@@ -395,7 +398,7 @@ public:
     typedef Cache<PipelinePointer>::Vector PipelineCaches;
     typedef Cache<FramebufferPointer>::Vector FramebufferCaches;
     typedef Cache<QueryPointer>::Vector QueryCaches;
-    typedef Cache<std::string>::Vector ProfileRangeCaches;
+    typedef Cache<std::string>::Vector StringCaches;
     typedef Cache<std::function<void()>>::Vector LambdaCache;
 
     // Cache Data in a byte array if too big to fit in Param
@@ -423,7 +426,8 @@ public:
     FramebufferCaches _framebuffers;
     QueryCaches _queries;
     LambdaCache _lambdas;
-    ProfileRangeCaches _profileRanges;
+    StringCaches _profileRanges;
+    StringCaches _names;
 
     NamedBatchDataMap _namedData;
 
@@ -431,6 +435,9 @@ public:
     bool _enableSkybox{ false };
 
 protected:
+    void startNamedCall(const std::string& name);
+    void stopNamedCall();
+
     // Maybe useful but shoudln't be public. Please convince me otherwise
     void runLambda(std::function<void()> f);
 };

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -52,8 +52,8 @@ public:
 
         DrawCallInfo(Index idx) : index(idx) {}
 
-        Index index{0};
-        uint16_t unused{0}; // Reserved space for later
+        Index index { 0 };
+        uint16_t unused { 0 }; // Reserved space for later
 
     };
     // Make sure DrawCallInfo has no extra padding
@@ -68,6 +68,7 @@ public:
         BufferPointers buffers;
         Function function;
         DrawCallInfoBuffer drawCallInfos;
+        size_t numVertices;
 
         size_t count() const { return drawCallInfos.size();  }
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -30,7 +30,7 @@ namespace gpu {
 
 enum ReservedSlot {
 
-#ifdef WIN32
+#ifdef GPU_SSBO_DRAW_CALL_INFO
     TRANSFORM_OBJECT_SLOT = 6,
 #else
     TRANSFORM_OBJECT_SLOT = 31,

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -91,7 +91,9 @@ public:
 
     const DrawCallInfoBuffer& getDrawCallInfoBuffer() const;
     DrawCallInfoBuffer& getDrawCallInfoBuffer();
+
     void captureDrawCallInfo();
+    void captureNamedDrawCallInfo(std::string name);
 
     class CacheState {
     public:
@@ -478,6 +480,8 @@ protected:
 
     // Maybe useful but shoudln't be public. Please convince me otherwise
     void runLambda(std::function<void()> f);
+
+    void captureDrawCallInfoImpl();
 };
 
 }

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -68,7 +68,6 @@ public:
         BufferPointers buffers;
         Function function;
         DrawCallInfoBuffer drawCallInfos;
-        size_t numVertices;
 
         size_t count() const { return drawCallInfos.size();  }
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -29,7 +29,12 @@ class QDebug;
 namespace gpu {
 
 enum ReservedSlot {
+
+#ifdef WIN32
     TRANSFORM_OBJECT_SLOT = 6,
+#else
+    TRANSFORM_OBJECT_SLOT = 31,
+#endif
     TRANSFORM_CAMERA_SLOT = 7,
 };
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -447,7 +447,7 @@ public:
     };
 
     using TransformObjects = std::vector<TransformObject>;
-    bool _invalidModel { false };
+    bool _invalidModel { true };
     Transform _currentModel;
     TransformObjects _objects;
 

--- a/libraries/gpu/src/gpu/Config.slh
+++ b/libraries/gpu/src/gpu/Config.slh
@@ -13,7 +13,7 @@
 
 <@if GLPROFILE == PC_GL @>
     <@def GPU_FEATURE_PROFILE GPU_CORE@>
-    <@def VERSION_HEADER #version 430 core@>
+    <@def VERSION_HEADER #version 410 core@>
 <@elif GLPROFILE == MAC_GL @>
     <@def GPU_FEATURE_PROFILE GPU_CORE@>
     <@def VERSION_HEADER #version 410 core@>

--- a/libraries/gpu/src/gpu/Config.slh
+++ b/libraries/gpu/src/gpu/Config.slh
@@ -13,7 +13,7 @@
 
 <@if GLPROFILE == PC_GL @>
     <@def GPU_FEATURE_PROFILE GPU_CORE@>
-    <@def VERSION_HEADER #version 410 core@>
+    <@def VERSION_HEADER #version 430 core@>
 <@elif GLPROFILE == MAC_GL @>
     <@def GPU_FEATURE_PROFILE GPU_CORE@>
     <@def VERSION_HEADER #version 410 core@>

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -77,13 +77,6 @@ public:
     virtual void downloadFramebuffer(const FramebufferPointer& srcFramebuffer, const Vec4i& region, QImage& destImage) = 0;
 
     // UBO class... layout MUST match the layout in TransformCamera.slh
-    class TransformObject {
-    public:
-        Mat4 _model;
-        Mat4 _modelInverse;
-    };
-
-    // UBO class... layout MUST match the layout in TransformCamera.slh
     class TransformCamera {
     public:
         Mat4 _view;

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -165,24 +165,25 @@ void GLBackend::renderPassTransfer(Batch& batch) {
 
         for (_commandIndex = 0; _commandIndex < numCommands; ++_commandIndex) {
             switch (*command) {
-            case Batch::COMMAND_draw:
-            case Batch::COMMAND_drawIndexed:
-            case Batch::COMMAND_drawInstanced:
-            case Batch::COMMAND_drawIndexedInstanced:
-                _transform.preUpdate(_commandIndex, _stereo);
-                break;
+                case Batch::COMMAND_draw:
+                case Batch::COMMAND_drawIndexed:
+                case Batch::COMMAND_drawInstanced:
+                case Batch::COMMAND_drawIndexedInstanced:
+                    _transform.preUpdate(_commandIndex, _stereo);
+                    captureDrawCallInfo();
+                    break;
 
-            case Batch::COMMAND_setModelTransform:
-            case Batch::COMMAND_setViewportTransform:
-            case Batch::COMMAND_setViewTransform:
-            case Batch::COMMAND_setProjectionTransform: {
-                CommandCall call = _commandCalls[(*command)];
-                (this->*(call))(batch, *offset);
-                break;
-            }
+                case Batch::COMMAND_setModelTransform:
+                case Batch::COMMAND_setViewportTransform:
+                case Batch::COMMAND_setViewTransform:
+                case Batch::COMMAND_setProjectionTransform: {
+                    CommandCall call = _commandCalls[(*command)];
+                    (this->*(call))(batch, *offset);
+                    break;
+                }
 
-            default:
-                break;
+                default:
+                    break;
             }
             command++;
             offset++;

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -161,6 +161,8 @@ void GLBackend::renderPassTransfer(Batch& batch) {
         _transform._cameras.clear();
         _transform._cameraOffsets.clear();
         _transform._objects.clear();
+        _drawCallInfos.clear();
+        _namedDrawCallInfos.clear();
 
         for (_commandIndex = 0; _commandIndex < numCommands; ++_commandIndex) {
             switch (*command) {
@@ -286,7 +288,7 @@ GLBackend::DrawCallInfoBuffer& GLBackend::getDrawCallInfoBuffer() {
 
 void GLBackend::captureDrawCallInfo() {
     auto& drawCallInfos = getDrawCallInfoBuffer();
-    drawCallInfos.push_back(_transform._objects.size() - 1);
+    drawCallInfos.push_back((uint16)_transform._objects.size() - 1);
 }
 
 bool GLBackend::checkGLError(const char* name) {

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -436,7 +436,7 @@ void GLBackend::do_runLambda(Batch& batch, size_t paramOffset) {
 
 void GLBackend::do_startNamedCall(Batch& batch, size_t paramOffset) {
     _currentNamedCall = batch._names.get(batch._params[paramOffset]._uint);
-    _currentDraw = 0;
+    _currentDraw = -1;
 }
 
 void GLBackend::do_stopNamedCall(Batch& batch, size_t paramOffset) {

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -214,13 +214,17 @@ void GLBackend::renderPassDraw(Batch& batch) {
             case Batch::COMMAND_drawInstanced:
             case Batch::COMMAND_drawIndexedInstanced:
             case Batch::COMMAND_multiDrawIndirect:
-            case Batch::COMMAND_multiDrawIndexedIndirect:
+            case Batch::COMMAND_multiDrawIndexedIndirect: {
                 // updates for draw calls
                 ++_currentDraw;
                 updateInput();
                 updateTransform(batch);
                 updatePipeline();
-                // Fallthrough to next case
+                
+                CommandCall call = _commandCalls[(*command)];
+                (this->*(call))(batch, *offset);
+                break;
+            }
             default: {
                 CommandCall call = _commandCalls[(*command)];
                 (this->*(call))(batch, *offset);

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -200,6 +200,7 @@ void GLBackend::renderPassTransfer(Batch& batch) {
 }
 
 void GLBackend::renderPassDraw(Batch& batch) {
+    _currentDraw = -1;
     _transform._camerasItr = _transform._cameraOffsets.begin();
     const size_t numCommands = batch.getCommands().size();
     const Batch::Commands::value_type* command = batch.getCommands().data();
@@ -220,6 +221,7 @@ void GLBackend::renderPassDraw(Batch& batch) {
             case Batch::COMMAND_drawInstanced:
             case Batch::COMMAND_drawIndexedInstanced:
                 // updates for draw calls
+                ++_currentDraw;
                 updateInput();
                 updateTransform();
                 updatePipeline();
@@ -438,6 +440,7 @@ void GLBackend::do_runLambda(Batch& batch, size_t paramOffset) {
 
 void GLBackend::do_startNamedCall(Batch& batch, size_t paramOffset) {
     _currentNamedCall = batch._names.get(batch._params[paramOffset]._uint);
+    _currentDraw = 0;
 }
 
 void GLBackend::do_stopNamedCall(Batch& batch, size_t paramOffset) {

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -173,6 +173,8 @@ void GLBackend::renderPassTransfer(Batch& batch) {
                     captureDrawCallInfo();
                     break;
 
+                case Batch::COMMAND_startNamedCall:
+                case Batch::COMMAND_stopNamedCall:
                 case Batch::COMMAND_setModelTransform:
                 case Batch::COMMAND_setViewportTransform:
                 case Batch::COMMAND_setViewTransform:
@@ -256,6 +258,20 @@ void GLBackend::render(Batch& batch) {
 
     // Restore the saved stereo state for the next batch
     _stereo._enable = savedStereo;
+}
+
+
+GLBackend::DrawCallInfoBuffer& GLBackend::getDrawCallInfoBuffer() {
+    if (_currentNamedCall.empty()) {
+        return _drawCallInfos;
+    } else {
+        return _namedDrawCallInfos[_currentNamedCall];
+    }
+}
+
+void GLBackend::captureDrawCallInfo() {
+    auto& drawCallInfos = getDrawCallInfoBuffer();
+    drawCallInfos.push_back(_transform._objects.size() - 1);
 }
 
 bool GLBackend::checkGLError(const char* name) {

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -62,6 +62,9 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
 
     (&::gpu::GLBackend::do_runLambda),
 
+    (&::gpu::GLBackend::do_startNamedCall),
+    (&::gpu::GLBackend::do_stopNamedCall),
+
     (&::gpu::GLBackend::do_glActiveBindTexture),
 
     (&::gpu::GLBackend::do_glUniform1i),
@@ -421,6 +424,14 @@ void GLBackend::do_resetStages(Batch& batch, size_t paramOffset) {
 void GLBackend::do_runLambda(Batch& batch, size_t paramOffset) {
     std::function<void()> f = batch._lambdas.get(batch._params[paramOffset]._uint);
     f();
+}
+
+void GLBackend::do_startNamedCall(Batch& batch, size_t paramOffset) {
+    _currentNamedCall = batch._names.get(batch._params[paramOffset]._uint);
+}
+
+void GLBackend::do_stopNamedCall(Batch& batch, size_t paramOffset) {
+    _currentNamedCall.clear();
 }
 
 void GLBackend::resetStages() {

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -168,6 +168,8 @@ void GLBackend::renderPassTransfer(Batch& batch) {
                 case Batch::COMMAND_drawIndexed:
                 case Batch::COMMAND_drawInstanced:
                 case Batch::COMMAND_drawIndexedInstanced:
+                case Batch::COMMAND_multiDrawIndirect:
+                case Batch::COMMAND_multiDrawIndexedIndirect:
                     _transform.preUpdate(_commandIndex, _stereo);
                     captureDrawCallInfo();
                     break;
@@ -220,6 +222,8 @@ void GLBackend::renderPassDraw(Batch& batch) {
             case Batch::COMMAND_drawIndexed:
             case Batch::COMMAND_drawInstanced:
             case Batch::COMMAND_drawIndexedInstanced:
+            case Batch::COMMAND_multiDrawIndirect:
+            case Batch::COMMAND_multiDrawIndexedIndirect:
                 // updates for draw calls
                 ++_currentDraw;
                 updateInput();
@@ -396,10 +400,6 @@ void GLBackend::do_drawIndexedInstanced(Batch& batch, size_t paramOffset) {
 
 void GLBackend::do_multiDrawIndirect(Batch& batch, size_t paramOffset) {
 #if (GPU_INPUT_PROFILE == GPU_CORE_43)
-    updateInput();
-    updateTransform();
-    updatePipeline();
-
     uint commandCount = batch._params[paramOffset + 0]._uint;
     GLenum mode = _primitiveToGLmode[(Primitive)batch._params[paramOffset + 1]._uint];
 
@@ -413,10 +413,6 @@ void GLBackend::do_multiDrawIndirect(Batch& batch, size_t paramOffset) {
 
 void GLBackend::do_multiDrawIndexedIndirect(Batch& batch, size_t paramOffset) {
 #if (GPU_INPUT_PROFILE == GPU_CORE_43)
-    updateInput();
-    updateTransform();
-    updatePipeline();
-
     uint commandCount = batch._params[paramOffset + 0]._uint;
     GLenum mode = _primitiveToGLmode[(Primitive)batch._params[paramOffset + 1]._uint];
     GLenum indexType = _elementTypeToGLType[_input._indexBufferType];

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -158,10 +158,9 @@ void GLBackend::renderPassTransfer(Batch& batch) {
 
     { // Sync all the buffers
         PROFILE_RANGE("syncCPUTransform");
-        _transform._cameras.resize(0);
+        _transform._cameras.clear();
         _transform._cameraOffsets.clear();
-        _transform._objects.resize(0);
-        _transform._objectOffsets.clear();
+        _transform._objects.clear();
 
         for (_commandIndex = 0; _commandIndex < numCommands; ++_commandIndex) {
             switch (*command) {
@@ -196,10 +195,11 @@ void GLBackend::renderPassTransfer(Batch& batch) {
         PROFILE_RANGE("syncGPUTransform");
         _transform.transfer();
     }
+
+
 }
 
 void GLBackend::renderPassDraw(Batch& batch) {
-    _transform._objectsItr = _transform._objectOffsets.begin();
     _transform._camerasItr = _transform._cameraOffsets.begin();
     const size_t numCommands = batch.getCommands().size();
     const Batch::Commands::value_type* command = batch.getCommands().data();

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -412,12 +412,12 @@ void GLBackend::do_runLambda(Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::do_startNamedCall(Batch& batch, size_t paramOffset) {
-    _currentNamedCall = batch._names.get(batch._params[paramOffset]._uint);
+    batch._currentNamedCall = batch._names.get(batch._params[paramOffset]._uint);
     _currentDraw = -1;
 }
 
 void GLBackend::do_stopNamedCall(Batch& batch, size_t paramOffset) {
-    _currentNamedCall.clear();
+    batch._currentNamedCall.clear();
 }
 
 void GLBackend::resetStages() {

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -215,6 +215,15 @@ void GLBackend::renderPassDraw(Batch& batch) {
             case Batch::COMMAND_setProjectionTransform:
                 break;
 
+            case Batch::COMMAND_draw:
+            case Batch::COMMAND_drawIndexed:
+            case Batch::COMMAND_drawInstanced:
+            case Batch::COMMAND_drawIndexedInstanced:
+                // updates for draw calls
+                updateInput();
+                updateTransform();
+                updatePipeline();
+                // Fallthrough to next case
             default: {
                 CommandCall call = _commandCalls[(*command)];
                 (this->*(call))(batch, *offset);
@@ -326,10 +335,6 @@ void GLBackend::syncCache() {
 }
 
 void GLBackend::do_draw(Batch& batch, size_t paramOffset) {
-    updateInput();
-    updateTransform();
-    updatePipeline();
-
     Primitive primitiveType = (Primitive)batch._params[paramOffset + 2]._uint;
     GLenum mode = _primitiveToGLmode[primitiveType];
     uint32 numVertices = batch._params[paramOffset + 1]._uint;
@@ -339,10 +344,6 @@ void GLBackend::do_draw(Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::do_drawIndexed(Batch& batch, size_t paramOffset) {
-    updateInput();
-    updateTransform();
-    updatePipeline();
-
     Primitive primitiveType = (Primitive)batch._params[paramOffset + 2]._uint;
     GLenum mode = _primitiveToGLmode[primitiveType];
     uint32 numIndices = batch._params[paramOffset + 1]._uint;
@@ -358,10 +359,6 @@ void GLBackend::do_drawIndexed(Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::do_drawInstanced(Batch& batch, size_t paramOffset) {
-    updateInput();
-    updateTransform();
-    updatePipeline();
-
     GLint numInstances = batch._params[paramOffset + 4]._uint;
     Primitive primitiveType = (Primitive)batch._params[paramOffset + 3]._uint;
     GLenum mode = _primitiveToGLmode[primitiveType];
@@ -373,10 +370,6 @@ void GLBackend::do_drawInstanced(Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::do_drawIndexedInstanced(Batch& batch, size_t paramOffset) {
-    updateInput();
-    updateTransform();
-    updatePipeline();
-
     GLint numInstances = batch._params[paramOffset + 4]._uint;
     GLenum mode = _primitiveToGLmode[(Primitive)batch._params[paramOffset + 3]._uint];
     uint32 numIndices = batch._params[paramOffset + 2]._uint;

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -260,7 +260,7 @@ protected:
     using DrawCallInfoBuffer = std::vector<DrawCallInfo>;
     using NamedDrawCallInfoBuffer = std::map<std::string, DrawCallInfoBuffer>;
 
-    int _currentDraw = 0;
+    int _currentDraw{ -1 };
     DrawCallInfoBuffer _drawCallInfos;
     NamedDrawCallInfoBuffer _namedDrawCallInfos;
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -329,16 +329,19 @@ protected:
         TransformCamera _camera;
         TransformCameras _cameras;
 
-        GLuint _objectBuffer{ 0 };
-        GLuint _cameraBuffer{ 0 };
-        size_t _cameraUboSize{ 0 };
+        mutable std::map<std::string, GLvoid*> _drawCallInfoOffsets;
+
+        GLuint _objectBuffer { 0 };
+        GLuint _cameraBuffer { 0 };
+        GLuint _drawCallInfoBuffer { 0 };
+        size_t _cameraUboSize { 0 };
         Transform _view;
         Mat4 _projection;
-        Vec4i _viewport{ 0, 0, 1, 1 };
-        Vec2 _depthRange{ 0.0f, 1.0f };
-        bool _invalidView{false};
-        bool _invalidProj{false};
-        bool _invalidViewport{ false };
+        Vec4i _viewport { 0, 0, 1, 1 };
+        Vec2 _depthRange { 0.0f, 1.0f };
+        bool _invalidView { false };
+        bool _invalidProj { false };
+        bool _invalidViewport { false };
 
         using Pair = std::pair<size_t, size_t>;
         using List = std::list<Pair>;

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -245,6 +245,8 @@ protected:
     void renderPassTransfer(Batch& batch);
     void renderPassDraw(Batch& batch);
 
+    std::string _currentNamedCall;
+
     Stats _stats;
 
     // Draw Stage
@@ -464,6 +466,9 @@ protected:
     void do_resetStages(Batch& batch, size_t paramOffset);
 
     void do_runLambda(Batch& batch, size_t paramOffset);
+
+    void do_startNamedCall(Batch& batch, size_t paramOffset);
+    void do_stopNamedCall(Batch& batch, size_t paramOffset);
 
     void resetStages();
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -245,7 +245,38 @@ protected:
     void renderPassTransfer(Batch& batch);
     void renderPassDraw(Batch& batch);
 
+    class DrawCallInfo {
+    public:
+        using Index = uint16_t;
+
+        DrawCallInfo(Index idx) : index(idx) {}
+
+        Index index;
+        uint16_t unused; // Reserved space for later
+    };
+    // Make sure DrawCallInfo has no extra padding
+    static_assert(sizeof(DrawCallInfo) == 4, "DrawCallInfo size is incorrect.");
+
+    using DrawCallInfoBuffer = std::vector<DrawCallInfo>;
+    using NamedDrawCallInfoBuffer = std::map<std::string, DrawCallInfoBuffer>;
+
+    DrawCallInfoBuffer _drawCallInfos;
+    NamedDrawCallInfoBuffer _namedDrawCallInfos;
+
     std::string _currentNamedCall;
+
+    DrawCallInfoBuffer& getDrawCallInfoBuffer() {
+        if (_currentNamedCall.empty()) {
+            return _drawCallInfos;
+        } else {
+            return _namedDrawCallInfos[_currentNamedCall];
+        }
+    }
+
+    void captureDrawCallInfo() {
+        auto& drawCallInfos = getDrawCallInfoBuffer();
+        drawCallInfos.push_back(_transform._objects.size() - 1);
+    }
 
     Stats _stats;
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -482,7 +482,6 @@ protected:
     void do_pushProfileRange(Batch& batch, size_t paramOffset);
     void do_popProfileRange(Batch& batch, size_t paramOffset);
     
-    std::string _currentNamedCall;
     int _currentDraw { -1 };
 
     typedef void (GLBackend::*CommandCall)(Batch&, size_t);

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -334,6 +334,7 @@ protected:
         GLuint _objectBuffer { 0 };
         GLuint _cameraBuffer { 0 };
         GLuint _drawCallInfoBuffer { 0 };
+        GLuint _objectBufferTexture { 0 };
         size_t _cameraUboSize { 0 };
         Transform _view;
         Mat4 _projection;

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -193,7 +193,7 @@ public:
 
 
     static const int MAX_NUM_ATTRIBUTES = Stream::NUM_INPUT_SLOTS;
-    static const int MAX_NUM_INPUT_BUFFERS = 16;
+    static const int MAX_NUM_INPUT_BUFFERS = Stream::NUM_INPUT_SLOTS;
 
     size_t getNumInputBuffers() const { return _input._invalidBuffers.size(); }
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -193,7 +193,7 @@ public:
 
 
     static const int MAX_NUM_ATTRIBUTES = Stream::NUM_INPUT_SLOTS;
-    static const int MAX_NUM_INPUT_BUFFERS = Stream::NUM_INPUT_SLOTS;
+    static const int MAX_NUM_INPUT_BUFFERS = 16;
 
     size_t getNumInputBuffers() const { return _input._invalidBuffers.size(); }
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -355,10 +355,9 @@ protected:
         TransformObjects _objects;
         TransformCameras _cameras;
 
-        size_t _cameraUboSize{ 0 };
-        size_t _objectUboSize{ 0 };
         GLuint _objectBuffer{ 0 };
         GLuint _cameraBuffer{ 0 };
+        size_t _cameraUboSize{ 0 };
         Transform _model;
         Transform _view;
         Mat4 _projection;
@@ -372,8 +371,6 @@ protected:
         using Pair = std::pair<size_t, size_t>;
         using List = std::list<Pair>;
         List _cameraOffsets;
-        List _objectOffsets;
-        mutable List::const_iterator _objectsItr;
         mutable List::const_iterator _camerasItr;
 
         void preUpdate(size_t commandIndex, const StereoState& stereo);

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -260,6 +260,7 @@ protected:
     using DrawCallInfoBuffer = std::vector<DrawCallInfo>;
     using NamedDrawCallInfoBuffer = std::map<std::string, DrawCallInfoBuffer>;
 
+    int _currentDraw = 0;
     DrawCallInfoBuffer _drawCallInfos;
     NamedDrawCallInfoBuffer _namedDrawCallInfos;
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -265,18 +265,8 @@ protected:
 
     std::string _currentNamedCall;
 
-    DrawCallInfoBuffer& getDrawCallInfoBuffer() {
-        if (_currentNamedCall.empty()) {
-            return _drawCallInfos;
-        } else {
-            return _namedDrawCallInfos[_currentNamedCall];
-        }
-    }
-
-    void captureDrawCallInfo() {
-        auto& drawCallInfos = getDrawCallInfoBuffer();
-        drawCallInfos.push_back(_transform._objects.size() - 1);
-    }
+    DrawCallInfoBuffer& getDrawCallInfoBuffer();
+    void captureDrawCallInfo();
 
     Stats _stats;
 

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -251,8 +251,8 @@ protected:
 
         DrawCallInfo(Index idx) : index(idx) {}
 
-        Index index;
-        uint16_t unused; // Reserved space for later
+        Index index { 0 };
+        uint16_t unused { 0 }; // Reserved space for later
     };
     // Make sure DrawCallInfo has no extra padding
     static_assert(sizeof(DrawCallInfo) == 4, "DrawCallInfo size is incorrect.");
@@ -344,7 +344,7 @@ protected:
     void killTransform();
     // Synchronize the state cache of this Backend with the actual real state of the GL Context
     void syncTransformStateCache();
-    void updateTransform() const;
+    void updateTransform();
     void resetTransformStage();
 
     struct TransformStageState {

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -92,11 +92,19 @@ void makeBindings(GLBackend::GLShader* shader) {
     // now assign the ubo binding, then DON't relink!
 
     //Check for gpu specific uniform slotBindings
+#ifdef WIN32
     loc = glGetProgramResourceIndex(glprogram, GL_SHADER_STORAGE_BLOCK, "transformObjectBuffer");
     if (loc >= 0) {
         glShaderStorageBlockBinding(glprogram, loc, gpu::TRANSFORM_OBJECT_SLOT);
         shader->_transformObjectSlot = gpu::TRANSFORM_OBJECT_SLOT;
     }
+#else
+    loc = glGetUniformLocation(glprogram, "transformObjectBuffer");
+    if (loc >= 0) {
+        glProgramUniform1i(glprogram, loc, gpu::TRANSFORM_OBJECT_SLOT);
+        shader->_transformObjectSlot = gpu::TRANSFORM_OBJECT_SLOT;
+    }
+#endif
 
     loc = glGetUniformBlockIndex(glprogram, "transformCameraBuffer");
     if (loc >= 0) {

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -92,9 +92,9 @@ void makeBindings(GLBackend::GLShader* shader) {
     // now assign the ubo binding, then DON't relink!
 
     //Check for gpu specific uniform slotBindings
-    loc = glGetUniformBlockIndex(glprogram, "transformObjectBuffer");
+    loc = glGetProgramResourceIndex(glprogram, GL_SHADER_STORAGE_BLOCK, "transformObjectBuffer");
     if (loc >= 0) {
-        glUniformBlockBinding(glprogram, loc, gpu::TRANSFORM_OBJECT_SLOT);
+        glShaderStorageBlockBinding(glprogram, loc, gpu::TRANSFORM_OBJECT_SLOT);
         shader->_transformObjectSlot = gpu::TRANSFORM_OBJECT_SLOT;
     }
 

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -92,7 +92,7 @@ void makeBindings(GLBackend::GLShader* shader) {
     // now assign the ubo binding, then DON't relink!
 
     //Check for gpu specific uniform slotBindings
-#ifdef WIN32
+#ifdef GPU_SSBO_DRAW_CALL_INFO
     loc = glGetProgramResourceIndex(glprogram, GL_SHADER_STORAGE_BLOCK, "transformObjectBuffer");
     if (loc >= 0) {
         glShaderStorageBlockBinding(glprogram, loc, gpu::TRANSFORM_OBJECT_SLOT);

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -75,9 +75,9 @@ void makeBindings(GLBackend::GLShader* shader) {
         glBindAttribLocation(glprogram, gpu::Stream::SKIN_CLUSTER_WEIGHT, "inSkinClusterWeight");
     }
 
-    loc = glGetAttribLocation(glprogram, "inInstanceTransform");
-    if (loc >= 0 && loc != gpu::Stream::INSTANCE_XFM) {
-        glBindAttribLocation(glprogram, gpu::Stream::INSTANCE_XFM, "inInstanceTransform");
+    loc = glGetAttribLocation(glprogram, "_drawCallInfo");
+    if (loc >= 0 && loc != gpu::Stream::DRAW_CALL_INFO) {
+        glBindAttribLocation(glprogram, gpu::Stream::DRAW_CALL_INFO, "_drawCallInfo");
     }
 
     // Link again to take into account the assigned attrib location

--- a/libraries/gpu/src/gpu/GLBackendShader.cpp
+++ b/libraries/gpu/src/gpu/GLBackendShader.cpp
@@ -103,6 +103,8 @@ void makeBindings(GLBackend::GLShader* shader) {
         glUniformBlockBinding(glprogram, loc, gpu::TRANSFORM_CAMERA_SLOT);
         shader->_transformCameraSlot = gpu::TRANSFORM_CAMERA_SLOT;
     }
+
+    (void)CHECK_GL_ERROR();
 }
 
 GLBackend::GLShader* compileShader(const Shader& shader) {

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -137,7 +137,7 @@ void GLBackend::TransformStageState::transfer(const Batch& batch) const {
         bufferData.resize(byteSize);
         memcpy(bufferData.data(), batch._objects.data(), byteSize);
 
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, _objectBuffer);
         glBufferData(GL_SHADER_STORAGE_BUFFER, bufferData.size(), bufferData.data(), GL_DYNAMIC_DRAW);
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
     }
@@ -157,6 +157,8 @@ void GLBackend::TransformStageState::transfer(const Batch& batch) const {
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
 
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
+
     CHECK_GL_ERROR();
 }
 
@@ -175,8 +177,6 @@ void GLBackend::TransformStageState::update(size_t commandIndex, const StereoSta
         glBindBufferRange(GL_UNIFORM_BUFFER, TRANSFORM_CAMERA_SLOT,
                           _cameraBuffer, offset, sizeof(Backend::TransformCamera));
     }
-
-    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
 
     (void)CHECK_GL_ERROR();
 }

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -143,6 +143,7 @@ void GLBackend::TransformStageState::transfer() const {
         }
         glBindBuffer(GL_UNIFORM_BUFFER, _cameraBuffer);
         glBufferData(GL_UNIFORM_BUFFER, bufferData.size(), bufferData.data(), GL_DYNAMIC_DRAW);
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
     }
 
     if (!_objects.empty()) {
@@ -150,12 +151,9 @@ void GLBackend::TransformStageState::transfer() const {
         bufferData.resize(byteSize);
         memcpy(bufferData.data(), _objects.data(), byteSize);
 
-        glBindBuffer(GL_UNIFORM_BUFFER, _objectBuffer);
-        glBufferData(GL_UNIFORM_BUFFER, bufferData.size(), bufferData.data(), GL_DYNAMIC_DRAW);
-    }
-
-    if (!_objects.empty() || !_cameras.empty()) {
-        glBindBuffer(GL_UNIFORM_BUFFER, 0);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
+        glBufferData(GL_SHADER_STORAGE_BUFFER, bufferData.size(), bufferData.data(), GL_DYNAMIC_DRAW);
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
     }
 
     CHECK_GL_ERROR();
@@ -177,8 +175,7 @@ void GLBackend::TransformStageState::update(size_t commandIndex, const StereoSta
             _cameraBuffer, offset, sizeof(Backend::TransformCamera));
     }
 
-    glBindBufferBase(GL_UNIFORM_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
-
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
 
     (void)CHECK_GL_ERROR();
 }

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -180,10 +180,10 @@ void GLBackend::TransformStageState::update(size_t commandIndex, const StereoSta
     (void)CHECK_GL_ERROR();
 }
 
-void GLBackend::updateTransform() const {
+void GLBackend::updateTransform() {
     _transform.update(_commandIndex, _stereo);
 
-    auto& drawCallInfo = _drawCallInfos[_currentDraw];
+    auto& drawCallInfo = getDrawCallInfoBuffer()[_currentDraw];
     glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, drawCallInfo.index, drawCallInfo.unused);
 }
 

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -185,6 +185,9 @@ void GLBackend::TransformStageState::update(size_t commandIndex, const StereoSta
 
 void GLBackend::updateTransform() const {
     _transform.update(_commandIndex, _stereo);
+
+    auto& drawCallInfo = _drawCallInfos[_currentDraw];
+    glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, drawCallInfo.index, drawCallInfo.unused);
 }
 
 void GLBackend::resetTransformStage() {

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -169,6 +169,7 @@ void GLBackend::updateTransform(const Batch& batch) {
 
     auto& drawCallInfoBuffer = batch.getDrawCallInfoBuffer();
     if (batch._currentNamedCall.empty()) {
+        glDisableVertexAttribArray(gpu::Stream::DRAW_CALL_INFO);
         auto& drawCallInfo = drawCallInfoBuffer[_currentDraw];
         glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, (GLint)drawCallInfo.index, (GLint)drawCallInfo.unused);
     } else {

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -183,8 +183,14 @@ void GLBackend::TransformStageState::update(size_t commandIndex, const StereoSta
 void GLBackend::updateTransform() {
     _transform.update(_commandIndex, _stereo);
 
-    auto& drawCallInfo = getDrawCallInfoBuffer()[_currentDraw];
-    glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, drawCallInfo.index, drawCallInfo.unused);
+    auto& drawCallInfoBuffer = getDrawCallInfoBuffer();
+    if (_currentNamedCall.empty()) {
+        auto& drawCallInfo = drawCallInfoBuffer[_currentDraw];
+        glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, (GLint)drawCallInfo.index, (GLint)drawCallInfo.unused);
+    } else {
+        glEnableVertexAttribArray(gpu::Stream::DRAW_CALL_INFO);
+        glVertexAttribIPointer(gpu::Stream::DRAW_CALL_INFO, 2, GL_SHORT, 4, drawCallInfoBuffer.data());
+    }
 }
 
 void GLBackend::resetTransformStage() {

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -173,7 +173,7 @@ void GLBackend::TransformStageState::update(size_t commandIndex, const StereoSta
             offset += _cameraUboSize;
         }
         glBindBufferRange(GL_UNIFORM_BUFFER, TRANSFORM_CAMERA_SLOT,
-            _cameraBuffer, offset, sizeof(Backend::TransformCamera));
+                          _cameraBuffer, offset, sizeof(Backend::TransformCamera));
     }
 
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
@@ -196,6 +196,8 @@ void GLBackend::updateTransform(const Batch& batch) {
                                _transform._drawCallInfoOffsets[batch._currentNamedCall]);
         glVertexAttribDivisor(gpu::Stream::DRAW_CALL_INFO, 1);
     }
+    
+    (void)CHECK_GL_ERROR();
 }
 
 void GLBackend::resetTransformStage() {

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -168,7 +168,7 @@ void GLBackend::updateTransform(const Batch& batch) {
     _transform.update(_commandIndex, _stereo);
 
     auto& drawCallInfoBuffer = batch.getDrawCallInfoBuffer();
-    if (_currentNamedCall.empty()) {
+    if (batch._currentNamedCall.empty()) {
         auto& drawCallInfo = drawCallInfoBuffer[_currentDraw];
         glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, (GLint)drawCallInfo.index, (GLint)drawCallInfo.unused);
     } else {

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -62,7 +62,7 @@ void GLBackend::initTransform() {
     glGenBuffers(1, &_transform._objectBuffer);
     glGenBuffers(1, &_transform._cameraBuffer);
     glGenBuffers(1, &_transform._drawCallInfoBuffer);
-#ifndef WIN32
+#ifndef GPU_SSBO_DRAW_CALL_INFO
     glGenTextures(1, &_transform._objectBufferTexture);
 #endif
     size_t cameraSize = sizeof(TransformCamera);
@@ -75,7 +75,7 @@ void GLBackend::killTransform() {
     glDeleteBuffers(1, &_transform._objectBuffer);
     glDeleteBuffers(1, &_transform._cameraBuffer);
     glDeleteBuffers(1, &_transform._drawCallInfoBuffer);
-#ifndef WIN32
+#ifndef GPU_SSBO_DRAW_CALL_INFO
     glDeleteTextures(1, &_transform._objectBufferTexture);
 #endif
 }
@@ -143,7 +143,7 @@ void GLBackend::TransformStageState::transfer(const Batch& batch) const {
         bufferData.resize(byteSize);
         memcpy(bufferData.data(), batch._objects.data(), byteSize);
 
-#ifdef WIN32
+#ifdef GPU_SSBO_DRAW_CALL_INFO
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, _objectBuffer);
         glBufferData(GL_SHADER_STORAGE_BUFFER, bufferData.size(), bufferData.data(), GL_DYNAMIC_DRAW);
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
@@ -169,7 +169,7 @@ void GLBackend::TransformStageState::transfer(const Batch& batch) const {
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
 
-#ifdef WIN32
+#ifdef GPU_SSBO_DRAW_CALL_INFO
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, TRANSFORM_OBJECT_SLOT, _objectBuffer);
 #else
     glActiveTexture(GL_TEXTURE0 + TRANSFORM_OBJECT_SLOT);

--- a/libraries/gpu/src/gpu/GLBackendTransform.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTransform.cpp
@@ -190,17 +190,11 @@ void GLBackend::updateTransform(const Batch& batch) {
         glDisableVertexAttribArray(gpu::Stream::DRAW_CALL_INFO); // Make sure attrib array is disabled
         glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, drawCallInfo.index, drawCallInfo.unused);
     } else {
-        if (false) {
-            auto& drawCallInfo = drawCallInfoBuffer[0];
-            glDisableVertexAttribArray(gpu::Stream::DRAW_CALL_INFO); // Make sure attrib array is disabled
-            glVertexAttribI2i(gpu::Stream::DRAW_CALL_INFO, drawCallInfo.index, drawCallInfo.unused);
-        } else {
-            glEnableVertexAttribArray(gpu::Stream::DRAW_CALL_INFO); // Make sure attrib array is enabled
-            glBindBuffer(GL_ARRAY_BUFFER, _transform._drawCallInfoBuffer);
-            glVertexAttribIPointer(gpu::Stream::DRAW_CALL_INFO, 2, GL_UNSIGNED_SHORT, 0,
-                                   _transform._drawCallInfoOffsets[batch._currentNamedCall]);
-            glVertexAttribDivisor(gpu::Stream::DRAW_CALL_INFO, 100000);
-        }
+        glEnableVertexAttribArray(gpu::Stream::DRAW_CALL_INFO); // Make sure attrib array is enabled
+        glBindBuffer(GL_ARRAY_BUFFER, _transform._drawCallInfoBuffer);
+        glVertexAttribIPointer(gpu::Stream::DRAW_CALL_INFO, 2, GL_UNSIGNED_SHORT, 0,
+                               _transform._drawCallInfoOffsets[batch._currentNamedCall]);
+        glVertexAttribDivisor(gpu::Stream::DRAW_CALL_INFO, 1);
     }
 }
 

--- a/libraries/gpu/src/gpu/Inputs.slh
+++ b/libraries/gpu/src/gpu/Inputs.slh
@@ -18,5 +18,4 @@ in vec4 inTangent;
 in vec4 inSkinClusterIndex;
 in vec4 inSkinClusterWeight;
 in vec4 inTexCoord1;
-in mat4 inInstanceTransform;
 <@endif@>

--- a/libraries/gpu/src/gpu/Inputs.slh
+++ b/libraries/gpu/src/gpu/Inputs.slh
@@ -10,12 +10,12 @@
 !>
 <@if not GPU_INPUTS_SLH@>
 <@def GPU_INPUTS_SLH@>
-in vec4 inPosition;
-in vec4 inNormal;
-in vec4 inColor;
-in vec4 inTexCoord0;
-in vec4 inTangent;
-in vec4 inSkinClusterIndex;
-in vec4 inSkinClusterWeight;
-in vec4 inTexCoord1;
+layout(location = 0) in vec4 inPosition;
+layout(location = 1) in vec4 inNormal;
+layout(location = 2) in vec4 inColor;
+layout(location = 3) in vec4 inTexCoord0;
+layout(location = 4) in vec4 inTangent;
+layout(location = 5) in vec4 inSkinClusterIndex;
+layout(location = 6) in vec4 inSkinClusterWeight;
+layout(location = 7) in vec4 inTexCoord1;
 <@endif@>

--- a/libraries/gpu/src/gpu/Stream.cpp
+++ b/libraries/gpu/src/gpu/Stream.cpp
@@ -38,10 +38,7 @@ const ElementArray& getDefaultElements() {
         //INSTANCE_SCALE = 8,
         Element::VEC3F_XYZ,
         //INSTANCE_TRANSLATE = 9,
-        Element::VEC3F_XYZ,
-        //INSTANCE_XFM = 10, 
-        // FIXME make a matrix element
-        Element::VEC4F_XYZW
+        Element::VEC3F_XYZ
     }};
     return defaultElements;
 }

--- a/libraries/gpu/src/gpu/Stream.cpp
+++ b/libraries/gpu/src/gpu/Stream.cpp
@@ -34,11 +34,7 @@ const ElementArray& getDefaultElements() {
         //SKIN_CLUSTER_WEIGHT = 6,
         Element::VEC4F_XYZW,
         //TEXCOORD1 = 7,
-        Element::VEC2F_UV,
-        //INSTANCE_SCALE = 8,
-        Element::VEC3F_XYZ,
-        //INSTANCE_TRANSLATE = 9,
-        Element::VEC3F_XYZ
+        Element::VEC2F_UV
     }};
     return defaultElements;
 }

--- a/libraries/gpu/src/gpu/Stream.h
+++ b/libraries/gpu/src/gpu/Stream.h
@@ -37,9 +37,7 @@ public:
         SKIN_CLUSTER_INDEX = 5,
         SKIN_CLUSTER_WEIGHT = 6,
         TEXCOORD1 = 7,
-        INSTANCE_SCALE = 8,
-        INSTANCE_TRANSLATE = 9,
-        NUM_INPUT_SLOTS = INSTANCE_TRANSLATE + 1,
+        NUM_INPUT_SLOTS = TEXCOORD1 + 1,
 
 
         DRAW_CALL_INFO = 15, // Reserve last input slot for draw call infos

--- a/libraries/gpu/src/gpu/Stream.h
+++ b/libraries/gpu/src/gpu/Stream.h
@@ -40,7 +40,6 @@ public:
         INSTANCE_SCALE = 8,
         INSTANCE_TRANSLATE = 9,
 
-
         DRAW_CALL_INFO = 15, // Reserve last input slot for draw call infos
         NUM_INPUT_SLOTS = DRAW_CALL_INFO + 1,
     };

--- a/libraries/gpu/src/gpu/Stream.h
+++ b/libraries/gpu/src/gpu/Stream.h
@@ -39,10 +39,10 @@ public:
         TEXCOORD1 = 7,
         INSTANCE_SCALE = 8,
         INSTANCE_TRANSLATE = 9,
+        NUM_INPUT_SLOTS = INSTANCE_TRANSLATE + 1,
 
 
         DRAW_CALL_INFO = 15, // Reserve last input slot for draw call infos
-        NUM_INPUT_SLOTS = DRAW_CALL_INFO
     };
 
     typedef uint8 Slot;

--- a/libraries/gpu/src/gpu/Stream.h
+++ b/libraries/gpu/src/gpu/Stream.h
@@ -39,10 +39,10 @@ public:
         TEXCOORD1 = 7,
         INSTANCE_SCALE = 8,
         INSTANCE_TRANSLATE = 9,
-        INSTANCE_XFM = 10,
 
-        // Instance XFM is a mat4, and as such takes up 4 slots
-        NUM_INPUT_SLOTS = INSTANCE_XFM + 4,
+
+        DRAW_CALL_INFO = 15, // Reserve last input slot for draw call infos
+        NUM_INPUT_SLOTS = DRAW_CALL_INFO + 1,
     };
 
     typedef uint8 Slot;

--- a/libraries/gpu/src/gpu/Stream.h
+++ b/libraries/gpu/src/gpu/Stream.h
@@ -40,8 +40,9 @@ public:
         INSTANCE_SCALE = 8,
         INSTANCE_TRANSLATE = 9,
 
+
         DRAW_CALL_INFO = 15, // Reserve last input slot for draw call infos
-        NUM_INPUT_SLOTS = DRAW_CALL_INFO + 1,
+        NUM_INPUT_SLOTS = DRAW_CALL_INFO
     };
 
     typedef uint8 Slot;

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -37,12 +37,32 @@ struct TransformObject {
 
 in ivec2 _drawCallInfo;
 
+<@if GLPROFILE == PC_GL @>
 layout(std140) buffer transformObjectBuffer {
     TransformObject _object[];
 };
 TransformObject getTransformObject() {
     return _object[_drawCallInfo.x];
 }
+<@else@>
+uniform samplerBuffer transformObjectBuffer;
+
+TransformObject getTransformObject() {
+    int offset = 8 * _drawCallInfo.x;
+    TransformObject object;
+    object._model[0] = texelFetch(transformObjectBuffer, offset);
+    object._model[1] = texelFetch(transformObjectBuffer, offset + 1);
+    object._model[2] = texelFetch(transformObjectBuffer, offset + 2);
+    object._model[3] = texelFetch(transformObjectBuffer, offset + 3);
+
+    object._modelInverse[0] = texelFetch(transformObjectBuffer, offset + 4);
+    object._modelInverse[1] = texelFetch(transformObjectBuffer, offset + 5);
+    object._modelInverse[2] = texelFetch(transformObjectBuffer, offset + 6);
+    object._modelInverse[3] = texelFetch(transformObjectBuffer, offset + 7);
+
+    return object;
+}
+<@endif@>
 <@endfunc@>
 
 

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -10,19 +10,29 @@
 <@if not GPU_TRANSFORM_STATE_SLH@>
 <@def GPU_TRANSFORM_STATE_SLH@>
 
-<@func declareStandardTransform()@>
-struct TransformObject { 
-    mat4 _model;
-    mat4 _modelInverse;
-};
-
-struct TransformCamera { 
+<@func declareStandardCameraTransform()@>
+struct TransformCamera {
     mat4 _view;
     mat4 _viewInverse;
     mat4 _projectionViewUntranslated;
     mat4 _projection;
     mat4 _projectionInverse;
     vec4 _viewport;
+};
+
+layout(std140) uniform transformCameraBuffer {
+    TransformCamera _camera;
+};
+TransformCamera getTransformCamera() {
+    return _camera;
+}
+<@endfunc@>
+
+
+<@func declareStandardObjectTransform()@>
+struct TransformObject {
+    mat4 _model;
+    mat4 _modelInverse;
 };
 
 in ivec2 _drawCallInfo;
@@ -33,13 +43,12 @@ layout(std140) buffer transformObjectBuffer {
 TransformObject getTransformObject() {
     return _object[_drawCallInfo.x];
 }
+<@endfunc@>
 
-layout(std140) uniform transformCameraBuffer {
-    TransformCamera _camera;
-};
-TransformCamera getTransformCamera() {
-    return _camera;
-}
+
+<@func declareStandardTransform()@>
+<$declareStandardObjectTransform()$>
+<$declareStandardCameraTransform()$>
 <@endfunc@>
 
 <@func transformCameraViewport(cameraTransform, viewport)@>

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -37,7 +37,8 @@ struct TransformObject {
 
 layout(location=15) in ivec2 _drawCallInfo;
 
-<@if GLPROFILE == PC_GL @>
+<@if FALSE @>
+// Disable SSBOs for now
 layout(std140) buffer transformObjectBuffer {
     TransformObject _object[];
 };

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -35,7 +35,7 @@ struct TransformObject {
     mat4 _modelInverse;
 };
 
-in ivec2 _drawCallInfo;
+layout(location=15) in ivec2 _drawCallInfo;
 
 <@if GLPROFILE == PC_GL @>
 layout(std140) buffer transformObjectBuffer {

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -25,8 +25,10 @@ struct TransformCamera {
     vec4 _viewport;
 };
 
+const int MAX_OBJECTS = 512; // NEEDS to match GLBackend::TransformStageState::update's MAX_OBJECT
+
 layout(std140) uniform transformObjectBuffer {
-    TransformObject _object;
+    TransformObject _object[MAX_OBJECTS];
 };
 TransformObject getTransformObject() {
     return _object;

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -27,7 +27,7 @@ struct TransformCamera {
 
 in ivec2 _drawCallInfo;
 
-layout(std430, binding=6) buffer transformObjectBuffer {
+layout(std140) buffer transformObjectBuffer {
     TransformObject _object[];
 };
 TransformObject getTransformObject() {

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -27,11 +27,13 @@ struct TransformCamera {
 
 const int MAX_OBJECTS = 512; // NEEDS to match GLBackend::TransformStageState::update's MAX_OBJECT
 
+in ivec2 _drawCallInfo;
+
 layout(std140) uniform transformObjectBuffer {
     TransformObject _object[MAX_OBJECTS];
 };
 TransformObject getTransformObject() {
-    return _object;
+    return _object[_drawCallInfo.x];
 }
 
 layout(std140) uniform transformCameraBuffer {
@@ -55,15 +57,6 @@ TransformCamera getTransformCamera() {
     }
 <@endfunc@>
 
-<@func transformInstancedModelToClipPos(cameraTransform, objectTransform, modelPos, clipPos)@>
-    <!// Equivalent to the following but hoppefully a tad more accurate
-      //return camera._projection * camera._view * object._model * pos; !>
-    { // transformModelToClipPos
-        vec4 _eyepos = (inInstanceTransform * <$modelPos$>) + vec4(-<$modelPos$>.w * <$cameraTransform$>._viewInverse[3].xyz, 0.0);
-        <$clipPos$> = <$cameraTransform$>._projectionViewUntranslated * _eyepos;
-    }
-<@endfunc@>
-
 <@func $transformModelToEyeAndClipPos(cameraTransform, objectTransform, modelPos, eyePos, clipPos)@>
     <!// Equivalent to the following but hoppefully a tad more accurate
       //return camera._projection * camera._view * object._model * pos; !>
@@ -76,27 +69,9 @@ TransformCamera getTransformCamera() {
     }
 <@endfunc@>
 
-<@func $transformInstancedModelToEyeAndClipPos(cameraTransform, objectTransform, modelPos, eyePos, clipPos)@>
-    <!// Equivalent to the following but hoppefully a tad more accurate
-      //return camera._projection * camera._view * object._model * pos; !>
-    { // transformModelToClipPos
-        vec4 _worldpos = (inInstanceTransform * <$modelPos$>);
-        <$eyePos$> = (<$cameraTransform$>._view * _worldpos);
-        vec4 _eyepos =(inInstanceTransform * <$modelPos$>) + vec4(-<$modelPos$>.w * <$cameraTransform$>._viewInverse[3].xyz, 0.0);
-        <$clipPos$> = <$cameraTransform$>._projectionViewUntranslated * _eyepos;
-      //  <$eyePos$> = (<$cameraTransform$>._projectionInverse * <$clipPos$>);
-    }
-<@endfunc@>
-
 <@func transformModelToWorldPos(objectTransform, modelPos, worldPos)@>
     { // transformModelToWorldPos
         <$worldPos$> = (<$objectTransform$>._model * <$modelPos$>);
-    }
-<@endfunc@>
-
-<@func transformInstancedModelToWorldPos(objectTransform, modelPos, worldPos)@>
-    { // transformModelToWorldPos
-        <$worldPos$> = (inInstanceTransform * <$modelPos$>);
     }
 <@endfunc@>
 
@@ -105,21 +80,6 @@ TransformCamera getTransformCamera() {
         vec3 mr0 = vec3(<$objectTransform$>._modelInverse[0].x, <$objectTransform$>._modelInverse[1].x, <$objectTransform$>._modelInverse[2].x);
         vec3 mr1 = vec3(<$objectTransform$>._modelInverse[0].y, <$objectTransform$>._modelInverse[1].y, <$objectTransform$>._modelInverse[2].y);
         vec3 mr2 = vec3(<$objectTransform$>._modelInverse[0].z, <$objectTransform$>._modelInverse[1].z, <$objectTransform$>._modelInverse[2].z);
-
-        vec3 mvc0 = vec3(dot(<$cameraTransform$>._viewInverse[0].xyz, mr0), dot(<$cameraTransform$>._viewInverse[0].xyz, mr1), dot(<$cameraTransform$>._viewInverse[0].xyz, mr2));
-        vec3 mvc1 = vec3(dot(<$cameraTransform$>._viewInverse[1].xyz, mr0), dot(<$cameraTransform$>._viewInverse[1].xyz, mr1), dot(<$cameraTransform$>._viewInverse[1].xyz, mr2));
-        vec3 mvc2 = vec3(dot(<$cameraTransform$>._viewInverse[2].xyz, mr0), dot(<$cameraTransform$>._viewInverse[2].xyz, mr1), dot(<$cameraTransform$>._viewInverse[2].xyz, mr2));
-
-        <$eyeDir$> = vec3(dot(mvc0, <$modelDir$>), dot(mvc1, <$modelDir$>), dot(mvc2, <$modelDir$>));
-    }
-<@endfunc@>
-
-<@func transformInstancedModelToEyeDir(cameraTransform, objectTransform, modelDir, eyeDir)@>
-    { // transformModelToEyeDir
-        mat4 modelInverse = inverse(inInstanceTransform);
-        vec3 mr0 = vec3(modelInverse[0].x, modelInverse[1].x, modelInverse[2].x);
-        vec3 mr1 = vec3(modelInverse[0].y, modelInverse[1].y, modelInverse[2].y);
-        vec3 mr2 = vec3(modelInverse[0].z, modelInverse[1].z, modelInverse[2].z);
 
         vec3 mvc0 = vec3(dot(<$cameraTransform$>._viewInverse[0].xyz, mr0), dot(<$cameraTransform$>._viewInverse[0].xyz, mr1), dot(<$cameraTransform$>._viewInverse[0].xyz, mr2));
         vec3 mvc1 = vec3(dot(<$cameraTransform$>._viewInverse[1].xyz, mr0), dot(<$cameraTransform$>._viewInverse[1].xyz, mr1), dot(<$cameraTransform$>._viewInverse[1].xyz, mr2));

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -25,12 +25,10 @@ struct TransformCamera {
     vec4 _viewport;
 };
 
-const int MAX_OBJECTS = 512; // NEEDS to match GLBackend::TransformStageState::update's MAX_OBJECT
-
 in ivec2 _drawCallInfo;
 
-layout(std140) uniform transformObjectBuffer {
-    TransformObject _object[MAX_OBJECTS];
+layout(std430, binding=6) buffer transformObjectBuffer {
+    TransformObject _object[];
 };
 TransformObject getTransformObject() {
     return _object[_drawCallInfo.x];

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1850,8 +1850,7 @@ uint32_t toCompactColor(const glm::vec4& color) {
     return compactColor;
 }
 
-static const size_t INSTANCE_TRANSFORM_BUFFER = 0;
-static const size_t INSTANCE_COLOR_BUFFER = 1;
+static const size_t INSTANCE_COLOR_BUFFER = 0;
 
 template <typename F>
 void renderInstances(const std::string& name, gpu::Batch& batch, const glm::vec4& color, F f) {

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -154,41 +154,41 @@ public:
     gpu::PipelinePointer bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
                                            bool emissive = false, bool depthBias = false);
     
-    void renderSolidSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderSolidSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) {
-        renderSolidSphereInstance(batch, xfm, glm::vec4(color, 1.0));
+    void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec4& color);
+    void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec3& color) {
+        renderSolidSphereInstance(batch, glm::vec4(color, 1.0));
     }
     
-    void renderWireSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderWireSphereInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) {
-        renderWireSphereInstance(batch, xfm, glm::vec4(color, 1.0));
+    void renderWireSphereInstance(gpu::Batch& batch, const glm::vec4& color);
+    void renderWireSphereInstance(gpu::Batch& batch, const glm::vec3& color) {
+        renderWireSphereInstance(batch, glm::vec4(color, 1.0));
     }
     
-    void renderSolidCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderSolidCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) {
-        renderSolidCubeInstance(batch, xfm, glm::vec4(color, 1.0));
+    void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec4& color);
+    void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec3& color) {
+        renderSolidCubeInstance(batch, glm::vec4(color, 1.0));
     }
     
-    void renderWireCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec4& color);
-    void renderWireCubeInstance(gpu::Batch& batch, const Transform& xfm, const glm::vec3& color) {
-        renderWireCubeInstance(batch, xfm, glm::vec4(color, 1.0));
+    void renderWireCubeInstance(gpu::Batch& batch, const glm::vec4& color);
+    void renderWireCubeInstance(gpu::Batch& batch, const glm::vec3& color) {
+        renderWireCubeInstance(batch, glm::vec4(color, 1.0));
     }
     
 
-    void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& transformBuffer, gpu::BufferPointer& colorBuffer);
-    void renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& transformBuffer, gpu::BufferPointer& colorBuffer);
+    void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
+    void renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
     void renderShape(gpu::Batch& batch, Shape shape);
     void renderWireShape(gpu::Batch& batch, Shape shape);
     size_t getShapeTriangleCount(Shape shape);
 
-    void renderCubeInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer transformBuffer, gpu::BufferPointer colorBuffer);
-    void renderWireCubeInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer transformBuffer, gpu::BufferPointer colorBuffer);
+    void renderCubeInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
+    void renderWireCubeInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
     void renderCube(gpu::Batch& batch);
     void renderWireCube(gpu::Batch& batch);
     size_t getCubeTriangleCount();
 
-    void renderSphereInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer transformBuffer, gpu::BufferPointer colorBuffer);
-    void renderWireSphereInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer transformBuffer, gpu::BufferPointer colorBuffer);
+    void renderSphereInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
+    void renderWireSphereInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
     void renderSphere(gpu::Batch& batch);
     void renderWireSphere(gpu::Batch& batch);
     size_t getSphereTriangleCount();

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -17,7 +17,7 @@
 
 <@include DeferredLighting.slh@>
 <@include gpu/Transform.slh@>
-<$declareStandardTransform()$>
+<$declareStandardCameraTransform()$>
 
 
 // Everything about light

--- a/libraries/render-utils/src/simple.slv
+++ b/libraries/render-utils/src/simple.slv
@@ -17,9 +17,7 @@
 <@include gpu/Transform.slh@>
 <$declareStandardTransform()$>
 
-uniform bool Instanced = false;
 // the interpolated normal
-
 out vec3 _normal;
 out vec3 _modelNormal;
 out vec3 _color;
@@ -35,11 +33,6 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    if (Instanced) {
-        <$transformInstancedModelToClipPos(cam, obj, inPosition, gl_Position)$>
-        <$transformInstancedModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
-    } else {
-        <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
-        <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
-    }
+    <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
+    <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
 }

--- a/tests/gpu-test/src/main.cpp
+++ b/tests/gpu-test/src/main.cpp
@@ -216,16 +216,16 @@ public:
             static const std::string GRID_INSTANCE = "Grid";
             static auto compactColor1 = toCompactColor(vec4{ 0.35f, 0.25f, 0.15f, 1.0f });
             static auto compactColor2 = toCompactColor(vec4{ 0.15f, 0.25f, 0.35f, 1.0f });
-            static gpu::BufferPointer transformBuffer; 
+            static std::vector<glm::mat4> transforms;
             static gpu::BufferPointer colorBuffer;
-            if (!transformBuffer) {
-                transformBuffer = std::make_shared<gpu::Buffer>();
+            if (!transforms.empty()) {
+                transforms.reserve(200);
                 colorBuffer = std::make_shared<gpu::Buffer>();
                 for (int i = 0; i < 100; ++i) {
                     {
                         glm::mat4 transform = glm::translate(mat4(), vec3(0, -1, -50 + i));
                         transform = glm::scale(transform, vec3(100, 1, 1));
-                        transformBuffer->append(transform);
+                        transforms.push_back(transform);
                         colorBuffer->append(compactColor1);
                     }
 
@@ -233,18 +233,20 @@ public:
                         glm::mat4 transform = glm::mat4_cast(quat(vec3(0, PI / 2.0f, 0)));
                         transform = glm::translate(transform, vec3(0, -1, -50 + i));
                         transform = glm::scale(transform, vec3(100, 1, 1));
-                        transformBuffer->append(transform);
+                        transforms.push_back(transform);
                         colorBuffer->append(compactColor2);
                     }
                 }
             }
-            
-            batch.setupNamedCalls(GRID_INSTANCE, 200, [=](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-                batch.setViewTransform(camera);
-                batch.setModelTransform(Transform());
-                batch.setPipeline(_pipeline);
-                geometryCache->renderWireShapeInstances(batch, GeometryCache::Line, data.count, transformBuffer, colorBuffer);
-            });
+
+            for (auto& transform : transforms) {
+                batch.setModelTransform(transform);
+                batch.setupNamedCalls(GRID_INSTANCE, [=](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+                    batch.setViewTransform(camera);
+                    batch.setPipeline(_pipeline);
+                    geometryCache->renderWireShapeInstances(batch, GeometryCache::Line, data.count(), colorBuffer);
+                });
+            }
         }
 
         {
@@ -314,7 +316,6 @@ public:
                 batch.setPipeline(_pipeline);
                 batch.setInputFormat(getInstancedSolidStreamFormat());
                 batch.setInputBuffer(gpu::Stream::COLOR, colorView);
-                batch.setInputBuffer(gpu::Stream::INSTANCE_XFM, instanceXfmView);
                 batch.setIndirectBuffer(indirectBuffer);
                 shapeData.setupBatch(batch);
                 batch.multiDrawIndexedIndirect(TYPE_COUNT, gpu::TRIANGLES);

--- a/tests/gpu-test/src/main.cpp
+++ b/tests/gpu-test/src/main.cpp
@@ -124,7 +124,6 @@ class QTestWindow : public QWindow {
     glm::mat4 _projectionMatrix;
     RateCounter fps;
     QTime _time;
-    int _instanceLocation{ -1 };
 
 protected:
     void renderText();
@@ -164,7 +163,6 @@ public:
         state->setMultisampleEnable(true);
         state->setDepthTest(gpu::State::DepthTest { true });
         _pipeline = gpu::Pipeline::create(shader, state);
-        _instanceLocation = _pipeline->getProgram()->getUniforms().findLocation("Instanced");
         
         // Clear screen
         gpu::Batch batch;
@@ -245,9 +243,7 @@ public:
                 batch.setViewTransform(camera);
                 batch.setModelTransform(Transform());
                 batch.setPipeline(_pipeline);
-                batch._glUniform1i(_instanceLocation, 1);
                 geometryCache->renderWireShapeInstances(batch, GeometryCache::Line, data.count, transformBuffer, colorBuffer);
-                batch._glUniform1i(_instanceLocation, 0);
             });
         }
 
@@ -316,14 +312,12 @@ public:
                 batch.setViewTransform(camera);
                 batch.setModelTransform(Transform());
                 batch.setPipeline(_pipeline);
-                batch._glUniform1i(_instanceLocation, 1);
                 batch.setInputFormat(getInstancedSolidStreamFormat());
                 batch.setInputBuffer(gpu::Stream::COLOR, colorView);
                 batch.setInputBuffer(gpu::Stream::INSTANCE_XFM, instanceXfmView);
                 batch.setIndirectBuffer(indirectBuffer);
                 shapeData.setupBatch(batch);
                 batch.multiDrawIndexedIndirect(TYPE_COUNT, gpu::TRIANGLES);
-                batch._glUniform1i(_instanceLocation, 0);
             }
 #else
             batch.setViewTransform(camera);

--- a/tests/gpu-test/src/unlit.slv
+++ b/tests/gpu-test/src/unlit.slv
@@ -19,8 +19,6 @@
 <$declareStandardTransform()$>
 
 // the interpolated normal
-uniform bool Instanced = false;
-
 out vec3 _normal;
 out vec3 _color;
 out vec2 _texCoord0;
@@ -32,12 +30,7 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    if (Instanced) {
-        <$transformInstancedModelToClipPos(cam, obj, inPosition, gl_Position)$>
-        <$transformInstancedModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
-    } else {
-        <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
-        <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
-    }
+    <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
+    <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
     _normal = vec3(0.0, 0.0, 1.0);
 }


### PR DESCRIPTION
This PR introduces the notion of draw call infos passed in during a draw call that points to the correct Transform to use.
This allows us to use the same pipeline for normal and named draw calls and the same path to feed the transform.