### PR TITLE
Default dynamic jitter buffer to true on AM

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -308,7 +308,7 @@
           "type": "checkbox",
           "label": "Dynamic Jitter Buffers",
           "help": "Dynamically buffer client audio based on perceived jitter in packet receipt timing",
-          "default": false,
+          "default": true,
           "advanced": true
         },
         {


### PR DESCRIPTION
Dynamic jitter buffer is now defaulted to true on the audio mixer.