### PR TITLE
Remove Particle Search Beams from Grab Script and Create / Destroy Systems on Demand

### DIFF
--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -1663,12 +1663,6 @@ function MyController(hand) {
 var rightController = new MyController(RIGHT_HAND);
 var leftController = new MyController(LEFT_HAND);
 
-//preload the particle beams so that they are full length when you start searching
-// if (USE_PARTICLE_BEAM_FOR_MOVING === true) {
-//     rightController.createParticleBeam();
-//     leftController.createParticleBeam();
-// }
-
 var MAPPING_NAME = "com.highfidelity.handControllerGrab";
 
 var mapping = Controller.newMapping(MAPPING_NAME);


### PR DESCRIPTION
Previously, each avatar had two hidden  particle systems that were used for search and move beams.  Now, since we're only using particle beams for moving, we create and destroy those beams on grab / release of an object instead of having them stick around.  When you test this script, you should only see a particle system in your entities list while you're actively far grabbing something.

https://rawgit.com/imgntn/hifi/fixgrabparticlesystems/examples/controllers/handControllerGrab.js