### PR TITLE
Remove Search Sphere After Far Equip

### DIFF
--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -932,6 +932,7 @@ function MyController(hand) {
                                                                  FAR_TO_NEAR_GRAB_PADDING_FACTOR);
                 }
                 this.setState(this.state == STATE_SEARCHING ? STATE_DISTANCE_HOLDING : STATE_EQUIP);
+                this.searchSphereOff();
                 return;
             }
 


### PR DESCRIPTION
Previously, if you far-equipped an object, the search sphere would remain on the surface where the object was grabbed.  Now, the search sphere is cleared when you far equip.  To test, load this script and observe that no search sphere remains after you have far-equipped an object.

https://rawgit.com/imgntn/hifi/removesearchsphereonequip/examples/controllers/handControllerGrab.js