### PR TITLE
fix interface crash when deleting lots of objects at once

### DIFF
--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -142,6 +142,7 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
     // finally clear all lists maintained by this class
     _physicalObjects.clear();
     _entitiesToRemoveFromPhysics.clear();
+    _entitiesToRelease.clear();
     _entitiesToAddToPhysics.clear();
     _pendingChanges.clear();
     _outgoingChanges.clear();
@@ -157,6 +158,7 @@ void PhysicalEntitySimulation::prepareEntityForDelete(EntityItemPointer entity) 
 // end EntitySimulation overrides
 
 void PhysicalEntitySimulation::getObjectsToRemoveFromPhysics(VectorOfMotionStates& result) {
+    _entitiesToRelease.clear();
     result.clear();
     QMutexLocker lock(&_mutex);
     for (auto entity: _entitiesToRemoveFromPhysics) {
@@ -171,7 +173,7 @@ void PhysicalEntitySimulation::getObjectsToRemoveFromPhysics(VectorOfMotionState
             _entitiesToDelete.insert(entity);
         }
     }
-    _entitiesToRemoveFromPhysics.clear();
+    _entitiesToRemoveFromPhysics.swap(_entitiesToRelease);
 }
 
 void PhysicalEntitySimulation::getObjectsToAddToPhysics(VectorOfMotionStates& result) {

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -60,6 +60,7 @@ public:
 
 private:
     SetOfEntities _entitiesToRemoveFromPhysics;
+    SetOfEntities _entitiesToRelease;
     SetOfEntities _entitiesToAddToPhysics;
 
     SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed
@@ -70,7 +71,7 @@ private:
     PhysicsEnginePointer _physicsEngine = nullptr;
     EntityEditPacketSender* _entityPacketSender = nullptr;
 
-    uint32_t _lastStepSendPackets = 0;
+    uint32_t _lastStepSendPackets { 0 };
 };
 
 


### PR DESCRIPTION
There was a crash mode where deleting lots of objects at once (using edit.js) it was possible to crash a debug interface client on an assert (and would probably sometimes crash a release client too).

After looking at it I decided that there is a race condition where the **PhysicalEntitySimulation** briefly holds no references to an **EntityItem** while it disassembles the backpointers between it and its **EntityMotionState**.  If the last reference happens to be deleted inside this short window (via the render thread, for example) then  the  backpointers may not quite be cleaned up yet and an assert will be hit.

The solution is to keep a reference until we're sure the backpointers are properly disassembled.