### PR TITLE
fix crash when deleting entities quickly

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3089,13 +3089,14 @@ void Application::update(float deltaTime) {
             static VectorOfMotionStates motionStates;
             _entitySimulation.getObjectsToRemoveFromPhysics(motionStates);
             _physicsEngine->removeObjects(motionStates);
+            _entitySimulation.deleteObjectsRemovedFromPhysics();
 
-            getEntities()->getTree()->withWriteLock([&] {
+            getEntities()->getTree()->withReadLock([&] {
                 _entitySimulation.getObjectsToAddToPhysics(motionStates);
                 _physicsEngine->addObjects(motionStates);
 
             });
-            getEntities()->getTree()->withWriteLock([&] {
+            getEntities()->getTree()->withReadLock([&] {
                 _entitySimulation.getObjectsToChange(motionStates);
                 VectorOfMotionStates stillNeedChange = _physicsEngine->changeObjects(motionStates);
                 _entitySimulation.setObjectsToChange(stillNeedChange);

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -48,6 +48,7 @@ void EntitySimulation::takeEntitiesToDelete(VectorOfEntities& entitiesToDelete) 
 }
 
 void EntitySimulation::removeEntityInternal(EntityItemPointer entity) {
+    QMutexLocker lock(&_mutex);
     // remove from all internal lists except _entitiesToDelete
     _mortalEntities.remove(entity);
     _entitiesToUpdate.remove(entity);
@@ -61,6 +62,7 @@ void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     assert(entity);
     assert(entity->isDead());
     if (entity->isSimulated()) {
+        QMutexLocker lock(&_mutex);
         entity->clearActions(this);
         removeEntityInternal(entity);
         _entitiesToDelete.insert(entity);
@@ -69,11 +71,13 @@ void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
 
 void EntitySimulation::addEntityInternal(EntityItemPointer entity) {
     if (entity->isMoving() && !entity->getPhysicsInfo()) {
+        QMutexLocker lock(&_mutex);
         _simpleKinematicEntities.insert(entity);
     }
 }
 
 void EntitySimulation::changeEntityInternal(EntityItemPointer entity) {
+    QMutexLocker lock(&_mutex);
     if (entity->isMoving() && !entity->getPhysicsInfo()) {
         _simpleKinematicEntities.insert(entity);
     } else {
@@ -86,6 +90,7 @@ void EntitySimulation::expireMortalEntities(const quint64& now) {
     if (now > _nextExpiry) {
         // only search for expired entities if we expect to find one
         _nextExpiry = quint64(-1);
+        QMutexLocker lock(&_mutex);
         SetOfEntities::iterator itemItr = _mortalEntities.begin();
         while (itemItr != _mortalEntities.end()) {
             EntityItemPointer entity = *itemItr;
@@ -108,6 +113,7 @@ void EntitySimulation::expireMortalEntities(const quint64& now) {
 // protected
 void EntitySimulation::callUpdateOnEntitiesThatNeedIt(const quint64& now) {
     PerformanceTimer perfTimer("updatingEntities");
+    QMutexLocker lock(&_mutex);
     SetOfEntities::iterator itemItr = _entitiesToUpdate.begin();
     while (itemItr != _entitiesToUpdate.end()) {
         EntityItemPointer entity = *itemItr;
@@ -124,6 +130,7 @@ void EntitySimulation::callUpdateOnEntitiesThatNeedIt(const quint64& now) {
 
 // protected
 void EntitySimulation::sortEntitiesThatMoved() {
+    QMutexLocker lock(&_mutex);
     // NOTE: this is only for entities that have been moved by THIS EntitySimulation.
     // External changes to entity position/shape are expected to be sorted outside of the EntitySimulation.
     PerformanceTimer perfTimer("sortingEntities");

--- a/libraries/entities/src/SimpleEntitySimulation.cpp
+++ b/libraries/entities/src/SimpleEntitySimulation.cpp
@@ -23,6 +23,7 @@ void SimpleEntitySimulation::updateEntitiesInternal(const quint64& now) {
     // has finished simulating it.
     auto nodeList = DependencyManager::get<LimitedNodeList>();
 
+    QMutexLocker lock(&_mutex);
     SetOfEntities::iterator itemItr = _entitiesWithSimulator.begin();
     while (itemItr != _entitiesWithSimulator.end()) {
         EntityItemPointer entity = *itemItr;
@@ -48,18 +49,21 @@ void SimpleEntitySimulation::updateEntitiesInternal(const quint64& now) {
 void SimpleEntitySimulation::addEntityInternal(EntityItemPointer entity) {
     EntitySimulation::addEntityInternal(entity);
     if (!entity->getSimulatorID().isNull()) {
+        QMutexLocker lock(&_mutex);
         _entitiesWithSimulator.insert(entity);
     }
 }
 
 void SimpleEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
     EntitySimulation::removeEntityInternal(entity);
+    QMutexLocker lock(&_mutex);
     _entitiesWithSimulator.remove(entity);
 }
 
 void SimpleEntitySimulation::changeEntityInternal(EntityItemPointer entity) {
     EntitySimulation::changeEntityInternal(entity);
     if (!entity->getSimulatorID().isNull()) {
+        QMutexLocker lock(&_mutex);
         _entitiesWithSimulator.insert(entity);
     }
     entity->clearDirtyFlags();

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -49,6 +49,7 @@ public:
     virtual void prepareEntityForDelete(EntityItemPointer entity) override;
 
     void getObjectsToRemoveFromPhysics(VectorOfMotionStates& result);
+    void deleteObjectsRemovedFromPhysics();
     void getObjectsToAddToPhysics(VectorOfMotionStates& result);
     void setObjectsToChange(const VectorOfMotionStates& objectsToChange);
     void getObjectsToChange(VectorOfMotionStates& result);


### PR DESCRIPTION
This is the real fix for the crash when deleting lots of entities very quickly.

Here is the script that used to crash:

    // deleteQuickly.js -- create a bunch of entities and then delete them very quickly
    //
    var LIFETIME = 120;
    var SIZE = 10.0;
    var SEPARATION = 20.0;
    var ROWS_X = 30;
    var ROWS_Z = 30;
    var RATE_PER_SECOND = 1000; // The entity server will drop data if we create things too fast.
    var SCRIPT_INTERVAL = 100;
    var DELETE_DELAY = 5;
    var x = 0;
    var y = 0;
    var z = 0;
    var totalCreated = 0;
    var entityIds = [];
    var stop = false;
    Script.setInterval(function () {
        if (stop || !Entities.serversExist() || !Entities.canRez()) {
            return;
        }
        var numToCreate = RATE_PER_SECOND * (SCRIPT_INTERVAL / 1000.0);
        for (var i = 0; i < numToCreate; i++) {
            var position = { x: SIZE + (x * SEPARATION), y: SIZE, z: SIZE + (z * SEPARATION) };
            entityIds.push(Entities.addEntity({
                type: "Sphere",
                name: "gridTest",
                position: position,
                dimensions: { x: SIZE, y: SIZE, z: SIZE },
                color: { red: x / ROWS_X * 255, green: 50, blue: z / ROWS_Z * 255 },
                ignoreCollisions: true,
                dynamic: false,
                lifetime: LIFETIME
            }));
            totalCreated++;
            x++;
            if (x == ROWS_X) {
                x = 0;
                z++;
            }
            if (z == ROWS_Z) {
                stop = true;
                Script.setTimeout(function () { // wait DELETE_DELAY seconds and the delete
                    entityIds.forEach(function (id) {
                        Entities.deleteEntity(id);
                    });
                    Script.stop();
                }, DELETE_DELAY * 1000);
            }
        }
    }, SCRIPT_INTERVAL);




