### PR TITLE
Postpone logging of the shutdown reason

### DIFF
--- a/libraries/embedded-webserver/src/HTTPManager.cpp
+++ b/libraries/embedded-webserver/src/HTTPManager.cpp
@@ -184,13 +184,15 @@ bool HTTPManager::bindSocket() {
         
         return true;
     } else {
-        qCritical() << "Failed to open HTTP server socket:" << errorString() << " can't continue";
-        QMetaObject::invokeMethod(this, "queuedExit", Qt::QueuedConnection);
-        
+        QString errorMessage = "Failed to open HTTP server socket: " + errorString() + ", can't continue";
+        QMetaObject::invokeMethod(this, "queuedExit", Qt::QueuedConnection, Q_ARG(QString, errorMessage));
         return false;
     }
 }
 
-void HTTPManager::queuedExit() {
+void HTTPManager::queuedExit(QString errorMessage) {
+    if (!errorMessage.isEmpty()) {
+        qCCritical(embeddedwebserver) << qPrintable(errorMessage);
+    }
     QCoreApplication::exit(SOCKET_ERROR_EXIT_CODE);
 }

--- a/libraries/embedded-webserver/src/HTTPManager.h
+++ b/libraries/embedded-webserver/src/HTTPManager.h
@@ -39,7 +39,7 @@ public:
 
 private slots:
     void isTcpServerListening();
-    void queuedExit();
+    void queuedExit(QString errorMessage);
     
 private:
     bool bindSocket();


### PR DESCRIPTION
This makes it more obvious to the log reader why the DS went
down.