### PR TITLE
repairs to index path behaviour

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -65,7 +65,7 @@
             {
               "name": "viewpoint",
               "label": "Viewpoint",
-              "placeholder": "/512,512,512"
+              "placeholder": "/0,0,0"
             }
           ]
         }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1872,16 +1872,27 @@ void DomainServer::processPathQueryPacket(QSharedPointer<ReceivedMessage> messag
 
         const QString PATHS_SETTINGS_KEYPATH_FORMAT = "%1.%2";
         const QString PATH_VIEWPOINT_KEY = "viewpoint";
+        const QString INDEX_PATH = "/";
 
         // check out paths in the _configMap to see if we have a match
-        const QVariant* pathMatch = valueForKeyPath(_settingsManager.getSettingsMap(),
-                                                    QString(PATHS_SETTINGS_KEYPATH_FORMAT).arg(SETTINGS_PATHS_KEY)
-                                                                                          .arg(pathQuery));
-        if (pathMatch) {
+        auto keypath = QString(PATHS_SETTINGS_KEYPATH_FORMAT).arg(SETTINGS_PATHS_KEY).arg(pathQuery);
+        const QVariant* pathMatch = valueForKeyPath(_settingsManager.getSettingsMap(), keypath);
+
+        // if we didn't match the path BUT this is for the index path then send back our default
+
+
+        if (pathMatch || pathQuery == INDEX_PATH) {
             // we got a match, respond with the resulting viewpoint
             auto nodeList = DependencyManager::get<LimitedNodeList>();
 
-            QString responseViewpoint = pathMatch->toMap()[PATH_VIEWPOINT_KEY].toString();
+            QString responseViewpoint;
+
+            if (pathMatch) {
+                responseViewpoint = pathMatch->toMap()[PATH_VIEWPOINT_KEY].toString();
+            } else {
+                const QString DEFAULT_INDEX_PATH = "/0,0,0/0,0,0,1";
+                responseViewpoint = DEFAULT_INDEX_PATH;
+            }
 
             if (!responseViewpoint.isEmpty()) {
                 QByteArray viewpointUTF8 = responseViewpoint.toUtf8();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1878,15 +1878,13 @@ void DomainServer::processPathQueryPacket(QSharedPointer<ReceivedMessage> messag
         auto keypath = QString(PATHS_SETTINGS_KEYPATH_FORMAT).arg(SETTINGS_PATHS_KEY).arg(pathQuery);
         const QVariant* pathMatch = valueForKeyPath(_settingsManager.getSettingsMap(), keypath);
 
-        // if we didn't match the path BUT this is for the index path then send back our default
-
-
         if (pathMatch || pathQuery == INDEX_PATH) {
             // we got a match, respond with the resulting viewpoint
             auto nodeList = DependencyManager::get<LimitedNodeList>();
 
             QString responseViewpoint;
 
+            // if we didn't match the path BUT this is for the index path then send back our default
             if (pathMatch) {
                 responseViewpoint = pathMatch->toMap()[PATH_VIEWPOINT_KEY].toString();
             } else {

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -149,8 +149,15 @@ bool AddressManager::handleUrl(const QUrl& lookupUrl, LookupTrigger trigger) {
             // check if it is a network address first
             if (handleNetworkAddress(lookupUrl.host()
                                       + (lookupUrl.port() == -1 ? "" : ":" + QString::number(lookupUrl.port())), trigger)) {
+
+                // if we were not passed a path, use the index path
+                auto path = lookupUrl.path();
+                if (path.isEmpty()) {
+                    path = INDEX_PATH;
+                }
+
                 // we may have a path that defines a relative viewpoint - if so we should jump to that now
-                handlePath(lookupUrl.path(), trigger);
+                handlePath(path, trigger);
             } else if (handleDomainID(lookupUrl.host())){
                 // no place name - this is probably a domain ID
                 // try to look up the domain ID on the metaverse API

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -60,7 +60,7 @@ NodeList::NodeList(char newOwnerType, unsigned short socketListenPort, unsigned 
 
     // in case we don't know how to talk to DS when a path change is requested
     // fire off any pending DS path query when we get socket information
-    connect(&_domainHandler, &DomainHandler::completedSocketDiscovery, this, &NodeList::sendPendingDSPathQuery);
+    connect(&_domainHandler, &DomainHandler::connectedToDomain, this, &NodeList::sendPendingDSPathQuery);
 
     // send a domain server check in immediately once the DS socket is known
     connect(&_domainHandler, &DomainHandler::completedSocketDiscovery, this, &NodeList::sendDomainServerCheckIn);

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -336,7 +336,7 @@ LogWindow.prototype = {
 
 function goHomeClicked() {
     if (interfacePath) {
-        startInterface('hifi://localhost/7.91966,23.2104,20.7416/0,-0.476144,0,0.879367');
+        startInterface('hifi://localhost');
     } else {
         // show an error to say that we can't go home without an interface instance
         dialog.showErrorBox("Client Not Found", binaryMissingMessage("High Fidelity client", "Interface", false));


### PR DESCRIPTION
This makes "Go Home" from the Server Console go to the index path. 
To handle this change for new users with the default content set, the domain-server now returns a default index path of "/0,0,0/0,0,0,1". 
The Interface client was not previously going to the index path if it went to a network address and not a place name - that is now fixed.