### PR TITLE
Fixing the warning issue and tweaking the ao blur constants

### DIFF
--- a/libraries/render-utils/src/AmbientOcclusionEffect.h
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.h
@@ -106,7 +106,7 @@ private:
         // Dithering info 
         glm::vec4 ditheringInfo { 0.0f, 0.0f, 0.01f, 1.0f };
         // Sampling info
-        glm::vec4 sampleInfo { 11.0f, 1.0/11.0f, 7.0f, 1.0f };
+        glm::vec4 sampleInfo { 11.0f, 1.0f/11.0f, 7.0f, 1.0f };
         // Blurring info
         glm::vec4 blurInfo { 1.0f, 3.0f, 2.0f, 0.0f };
          // gaussian distribution coefficients first is the sampling radius (max is 6)

--- a/libraries/render-utils/src/ssao.slh
+++ b/libraries/render-utils/src/ssao.slh
@@ -134,6 +134,7 @@ float getBlurEdgeSharpness() {
     return params._blurInfo.x;
 }
 
+#define CONSTANT_GAUSSIAN
 #ifdef CONSTANT_GAUSSIAN
 const int BLUR_RADIUS = 4;
 const float gaussian[BLUR_RADIUS + 1] =
@@ -146,12 +147,10 @@ float[](0.153170, 0.144893, 0.122649, 0.092902, 0.062970);  // stddev = 2.0
 
 int getBlurRadius() {
     return BLUR_RADIUS;
-    return int(params._blurInfo.y);
 }
 
 float getBlurCoef(int c) {
     return gaussian[c];
-    return params._gaussianCoefs[c];
 }
 #else
 int getBlurRadius() {

--- a/libraries/render-utils/src/ssao.slh
+++ b/libraries/render-utils/src/ssao.slh
@@ -182,8 +182,8 @@ vec2 fetchOcclusionDepth(ivec2 coords) {
     return unpackOcclusionDepth(texelFetch(occlusionMap, coords, 0).xyz);
 }
 
-const int RADIUS_SCALE = 2;
-const float BLUR_WEIGHT_OFFSET = 0.3;
+const int RADIUS_SCALE = 1;
+const float BLUR_WEIGHT_OFFSET = 0.0;
 const float BLUR_EDGE_SCALE = 2000.0;
 
 vec2 evalTapWeightedValue(ivec3 side, int r, ivec2 ssC, float key) {

--- a/libraries/render-utils/src/ssao.slh
+++ b/libraries/render-utils/src/ssao.slh
@@ -134,7 +134,6 @@ float getBlurEdgeSharpness() {
     return params._blurInfo.x;
 }
 
-#define CONSTANT_GAUSSIAN
 #ifdef CONSTANT_GAUSSIAN
 const int BLUR_RADIUS = 4;
 const float gaussian[BLUR_RADIUS + 1] =
@@ -182,7 +181,7 @@ vec2 fetchOcclusionDepth(ivec2 coords) {
 }
 
 const int RADIUS_SCALE = 1;
-const float BLUR_WEIGHT_OFFSET = 0.0;
+const float BLUR_WEIGHT_OFFSET = 0.05;
 const float BLUR_EDGE_SCALE = 2000.0;
 
 vec2 evalTapWeightedValue(ivec3 side, int r, ivec2 ssC, float key) {

--- a/libraries/render-utils/src/ssao_makeHorizontalBlur.slf
+++ b/libraries/render-utils/src/ssao_makeHorizontalBlur.slf
@@ -15,7 +15,6 @@ const ivec2 horizontal = ivec2(1,0);
 <$declareBlurPass(horizontal)$>
 
 
-in vec2 varTexCoord0;
 out vec4 outFragColor;
 
 void main(void) {

--- a/libraries/render-utils/src/ssao_makeVerticalBlur.slf
+++ b/libraries/render-utils/src/ssao_makeVerticalBlur.slf
@@ -13,7 +13,6 @@
 const ivec2 vertical = ivec2(0,1);
 <$declareBlurPass(vertical)$>
 
-in vec2 varTexCoord0;
 out vec4 outFragColor;
 
 void main(void) {


### PR DESCRIPTION
- address the nasty double to float cast warning

- tweek the blur stride constant used in the AO blur effect

- removing unused attributes and lines from the shader