### PR TITLE
check values in location updates for NaN before using them

### DIFF
--- a/libraries/shared/src/AACube.cpp
+++ b/libraries/shared/src/AACube.cpp
@@ -480,7 +480,7 @@ AACube& AACube::operator += (const glm::vec3& point) {
 }
 
 bool AACube::containsNaN() const {
-    if (isNaN(_corner.x) || isNaN(_corner.y) || isNaN(_corner.z)) {
+    if (isVec3NaN(_corner)) {
         return true;
     }
     if (isNaN(_scale)) {

--- a/libraries/shared/src/AACube.cpp
+++ b/libraries/shared/src/AACube.cpp
@@ -480,7 +480,7 @@ AACube& AACube::operator += (const glm::vec3& point) {
 }
 
 bool AACube::containsNaN() const {
-    if ( _corner.x != _corner.x ||  _corner.y != _corner.y ||  _corner.z != _corner.z) {
+    if (isNaN(_corner.x) || isNaN(_corner.y) || isNaN(_corner.z)) {
         return true;
     }
     if (_scale != _scale) {

--- a/libraries/shared/src/AACube.cpp
+++ b/libraries/shared/src/AACube.cpp
@@ -478,3 +478,13 @@ AACube& AACube::operator += (const glm::vec3& point) {
 
     return (*this);
 }
+
+bool AACube::containsNaN() const {
+    if ( _corner.x != _corner.x ||  _corner.y != _corner.y ||  _corner.z != _corner.z) {
+        return true;
+    }
+    if (_scale != _scale) {
+        return true;
+    }
+    return false;
+}

--- a/libraries/shared/src/AACube.cpp
+++ b/libraries/shared/src/AACube.cpp
@@ -483,7 +483,7 @@ bool AACube::containsNaN() const {
     if (isNaN(_corner.x) || isNaN(_corner.y) || isNaN(_corner.z)) {
         return true;
     }
-    if (_scale != _scale) {
+    if (isNaN(_scale)) {
         return true;
     }
     return false;

--- a/libraries/shared/src/AACube.cpp
+++ b/libraries/shared/src/AACube.cpp
@@ -480,11 +480,5 @@ AACube& AACube::operator += (const glm::vec3& point) {
 }
 
 bool AACube::containsNaN() const {
-    if (isVec3NaN(_corner)) {
-        return true;
-    }
-    if (isNaN(_scale)) {
-        return true;
-    }
-    return false;
+    return isNaN(_corner) || isNaN(_scale);
 }

--- a/libraries/shared/src/AACube.h
+++ b/libraries/shared/src/AACube.h
@@ -66,6 +66,8 @@ public:
 
     AACube& operator += (const glm::vec3& point);
 
+    bool containsNaN() const;
+
 private:
     glm::vec3 getClosestPointOnFace(const glm::vec3& point, BoxFace face) const;
     glm::vec3 getClosestPointOnFace(const glm::vec4& origin, const glm::vec4& direction, BoxFace face) const;

--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -425,10 +425,10 @@ void generateBasisVectors(const glm::vec3& primaryAxis, const glm::vec3& seconda
     vAxisOut = glm::cross(wAxisOut, uAxisOut);
 }
 
-bool isVec3NaN(glm::vec3 value) {
+bool isNaN(glm::vec3 value) {
     return isNaN(value.x) || isNaN(value.y) || isNaN(value.z);
 }
 
-bool isQuatNaN(glm::quat value) {
+bool isNaN(glm::quat value) {
     return isNaN(value.w) || isNaN(value.x) || isNaN(value.y) || isNaN(value.z);
 }

--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -425,3 +425,10 @@ void generateBasisVectors(const glm::vec3& primaryAxis, const glm::vec3& seconda
     vAxisOut = glm::cross(wAxisOut, uAxisOut);
 }
 
+bool isVec3NaN(glm::vec3 value) {
+    return isNaN(value.x) || isNaN(value.y) || isNaN(value.z);
+}
+
+bool isQuatNaN(glm::quat value) {
+    return isNaN(value.w) || isNaN(value.x) || isNaN(value.y) || isNaN(value.z);
+}

--- a/libraries/shared/src/GLMHelpers.h
+++ b/libraries/shared/src/GLMHelpers.h
@@ -224,4 +224,8 @@ glm::vec3 transformVector(const glm::mat4& m, const glm::vec3& v);
 void generateBasisVectors(const glm::vec3& primaryAxis, const glm::vec3& secondaryAxis,
                           glm::vec3& uAxisOut, glm::vec3& vAxisOut, glm::vec3& wAxisOut);
 
+
+bool isVec3NaN(glm::vec3 value);
+bool isQuatNaN(glm::quat value);
+
 #endif // hifi_GLMHelpers_h

--- a/libraries/shared/src/GLMHelpers.h
+++ b/libraries/shared/src/GLMHelpers.h
@@ -225,7 +225,7 @@ void generateBasisVectors(const glm::vec3& primaryAxis, const glm::vec3& seconda
                           glm::vec3& uAxisOut, glm::vec3& vAxisOut, glm::vec3& wAxisOut);
 
 
-bool isVec3NaN(glm::vec3 value);
-bool isQuatNaN(glm::quat value);
+bool isNaN(glm::vec3 value);
+bool isNaN(glm::quat value);
 
 #endif // hifi_GLMHelpers_h

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -624,8 +624,8 @@ void debug::checkDeadBeef(void* memoryVoid, int size) {
     assert(memcmp((unsigned char*)memoryVoid, DEADBEEF, std::min(size, DEADBEEF_SIZE)) != 0);
 }
 
-bool isNaN(float value) { 
-    return value != value; 
+bool isNaN(float value) {
+    return value != value;
 }
 
 QString formatUsecTime(float usecs, int prec) {

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -162,7 +162,6 @@ bool isBetween(int64_t value, int64_t max, int64_t min);
 /// \return bool is the float NaN
 bool isNaN(float value);
 
-
 QString formatUsecTime(float usecs, int prec = 3);
 QString formatSecondsElapsed(float seconds);
 bool similarStrings(const QString& stringA, const QString& stringB);

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -162,6 +162,7 @@ bool isBetween(int64_t value, int64_t max, int64_t min);
 /// \return bool is the float NaN
 bool isNaN(float value);
 
+
 QString formatUsecTime(float usecs, int prec = 3);
 QString formatSecondsElapsed(float seconds);
 bool similarStrings(const QString& stringA, const QString& stringB);

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -315,7 +315,7 @@ glm::vec3 SpatiallyNestable::getPosition(int jointIndex, bool& success) const {
 
 void SpatiallyNestable::setPosition(const glm::vec3& position, bool& success) {
     // guard against introducing NaN into the transform
-    if (position.x != position.x || position.y != position.y || position.z != position.z) {
+    if (isNaN(position.x) || isNaN(position.y) || isNaN(position.z)) {
         success = false;
         return;
     }
@@ -364,10 +364,7 @@ glm::quat SpatiallyNestable::getOrientation(int jointIndex, bool& success) const
 
 void SpatiallyNestable::setOrientation(const glm::quat& orientation, bool& success) {
     // guard against introducing NaN into the transform
-    if (orientation.x != orientation.x ||
-        orientation.y != orientation.y ||
-        orientation.z != orientation.z ||
-        orientation.w != orientation.w) {
+    if (isNaN(orientation.x) || isNaN(orientation.y) || isNaN(orientation.z) || isNaN(orientation.w)) {
         success = false;
         return;
     }
@@ -451,7 +448,7 @@ glm::vec3 SpatiallyNestable::getScale(int jointIndex) const {
 
 void SpatiallyNestable::setScale(const glm::vec3& scale) {
     // guard against introducing NaN into the transform
-    if (scale.x != scale.x || scale.y != scale.y || scale.z != scale.z) {
+    if (isNaN(scale.x) || isNaN(scale.y) || isNaN(scale.z)) {
         qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
         return;
     }
@@ -492,7 +489,7 @@ glm::vec3 SpatiallyNestable::getLocalPosition() const {
 
 void SpatiallyNestable::setLocalPosition(const glm::vec3& position) {
     // guard against introducing NaN into the transform
-    if (position.x != position.x || position.y != position.y || position.z != position.z) {
+    if (isNaN(position.x) || isNaN(position.y) || isNaN(position.z)) {
         qDebug() << "SpatiallyNestable::setLocalPosition -- position contains NaN";
         return;
     }
@@ -512,10 +509,7 @@ glm::quat SpatiallyNestable::getLocalOrientation() const {
 
 void SpatiallyNestable::setLocalOrientation(const glm::quat& orientation) {
     // guard against introducing NaN into the transform
-    if (orientation.x != orientation.x ||
-        orientation.y != orientation.y ||
-        orientation.z != orientation.z ||
-        orientation.w != orientation.w) {
+    if (isNaN(orientation.x) || isNaN(orientation.y) || isNaN(orientation.z) || isNaN(orientation.w)) {
         qDebug() << "SpatiallyNestable::setLocalOrientation -- orientation contains NaN";
         return;
     }
@@ -536,7 +530,7 @@ glm::vec3 SpatiallyNestable::getLocalScale() const {
 
 void SpatiallyNestable::setLocalScale(const glm::vec3& scale) {
     // guard against introducing NaN into the transform
-    if (scale.x != scale.x || scale.y != scale.y || scale.z != scale.z) {
+    if (isNaN(scale.x) || isNaN(scale.y) || isNaN(scale.z)) {
         qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
         return;
     }

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -315,7 +315,7 @@ glm::vec3 SpatiallyNestable::getPosition(int jointIndex, bool& success) const {
 
 void SpatiallyNestable::setPosition(const glm::vec3& position, bool& success) {
     // guard against introducing NaN into the transform
-    if (isVec3NaN(position)) {
+    if (isNaN(position)) {
         success = false;
         return;
     }
@@ -364,7 +364,7 @@ glm::quat SpatiallyNestable::getOrientation(int jointIndex, bool& success) const
 
 void SpatiallyNestable::setOrientation(const glm::quat& orientation, bool& success) {
     // guard against introducing NaN into the transform
-    if (isQuatNaN(orientation)) {
+    if (isNaN(orientation)) {
         success = false;
         return;
     }
@@ -448,7 +448,7 @@ glm::vec3 SpatiallyNestable::getScale(int jointIndex) const {
 
 void SpatiallyNestable::setScale(const glm::vec3& scale) {
     // guard against introducing NaN into the transform
-    if (isVec3NaN(scale)) {
+    if (isNaN(scale)) {
         qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
         return;
     }
@@ -489,7 +489,7 @@ glm::vec3 SpatiallyNestable::getLocalPosition() const {
 
 void SpatiallyNestable::setLocalPosition(const glm::vec3& position) {
     // guard against introducing NaN into the transform
-    if (isVec3NaN(position)) {
+    if (isNaN(position)) {
         qDebug() << "SpatiallyNestable::setLocalPosition -- position contains NaN";
         return;
     }
@@ -509,7 +509,7 @@ glm::quat SpatiallyNestable::getLocalOrientation() const {
 
 void SpatiallyNestable::setLocalOrientation(const glm::quat& orientation) {
     // guard against introducing NaN into the transform
-    if (isQuatNaN(orientation)) {
+    if (isNaN(orientation)) {
         qDebug() << "SpatiallyNestable::setLocalOrientation -- orientation contains NaN";
         return;
     }
@@ -530,7 +530,7 @@ glm::vec3 SpatiallyNestable::getLocalScale() const {
 
 void SpatiallyNestable::setLocalScale(const glm::vec3& scale) {
     // guard against introducing NaN into the transform
-    if (isVec3NaN(scale)) {
+    if (isNaN(scale)) {
         qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
         return;
     }

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -314,6 +314,11 @@ glm::vec3 SpatiallyNestable::getPosition(int jointIndex, bool& success) const {
 }
 
 void SpatiallyNestable::setPosition(const glm::vec3& position, bool& success) {
+    // guard against introducing NaN into the transform
+    if (position.x != position.x || position.y != position.y || position.z != position.z) {
+        success = false;
+        return;
+    }
     Transform parentTransform = getParentTransform(success);
     Transform myWorldTransform;
     _transformLock.withWriteLock([&] {
@@ -358,6 +363,15 @@ glm::quat SpatiallyNestable::getOrientation(int jointIndex, bool& success) const
 }
 
 void SpatiallyNestable::setOrientation(const glm::quat& orientation, bool& success) {
+    // guard against introducing NaN into the transform
+    if (orientation.x != orientation.x ||
+        orientation.y != orientation.y ||
+        orientation.z != orientation.z ||
+        orientation.w != orientation.w) {
+        success = false;
+        return;
+    }
+
     Transform parentTransform = getParentTransform(success);
     Transform myWorldTransform;
     _transformLock.withWriteLock([&] {
@@ -408,6 +422,10 @@ const Transform SpatiallyNestable::getTransform(int jointIndex, bool& success) c
 }
 
 void SpatiallyNestable::setTransform(const Transform& transform, bool& success) {
+    if (transform.containsNaN()) {
+        success = false;
+        return;
+    }
     Transform parentTransform = getParentTransform(success);
     _transformLock.withWriteLock([&] {
         Transform::inverseMult(_transform, parentTransform, transform);
@@ -432,6 +450,11 @@ glm::vec3 SpatiallyNestable::getScale(int jointIndex) const {
 }
 
 void SpatiallyNestable::setScale(const glm::vec3& scale) {
+    // guard against introducing NaN into the transform
+    if (scale.x != scale.x || scale.y != scale.y || scale.z != scale.z) {
+        qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
+        return;
+    }
     // TODO: scale
     _transformLock.withWriteLock([&] {
         _transform.setScale(scale);
@@ -448,6 +471,11 @@ const Transform SpatiallyNestable::getLocalTransform() const {
 }
 
 void SpatiallyNestable::setLocalTransform(const Transform& transform) {
+    // guard against introducing NaN into the transform
+    if (transform.containsNaN()) {
+        qDebug() << "SpatiallyNestable::setLocalTransform -- transform contains NaN";
+        return;
+    }
     _transformLock.withWriteLock([&] {
         _transform = transform;
     });
@@ -463,6 +491,11 @@ glm::vec3 SpatiallyNestable::getLocalPosition() const {
 }
 
 void SpatiallyNestable::setLocalPosition(const glm::vec3& position) {
+    // guard against introducing NaN into the transform
+    if (position.x != position.x || position.y != position.y || position.z != position.z) {
+        qDebug() << "SpatiallyNestable::setLocalPosition -- position contains NaN";
+        return;
+    }
     _transformLock.withWriteLock([&] {
         _transform.setTranslation(position);
     });
@@ -478,6 +511,14 @@ glm::quat SpatiallyNestable::getLocalOrientation() const {
 }
 
 void SpatiallyNestable::setLocalOrientation(const glm::quat& orientation) {
+    // guard against introducing NaN into the transform
+    if (orientation.x != orientation.x ||
+        orientation.y != orientation.y ||
+        orientation.z != orientation.z ||
+        orientation.w != orientation.w) {
+        qDebug() << "SpatiallyNestable::setLocalOrientation -- orientation contains NaN";
+        return;
+    }
     _transformLock.withWriteLock([&] {
         _transform.setRotation(orientation);
     });
@@ -494,6 +535,11 @@ glm::vec3 SpatiallyNestable::getLocalScale() const {
 }
 
 void SpatiallyNestable::setLocalScale(const glm::vec3& scale) {
+    // guard against introducing NaN into the transform
+    if (scale.x != scale.x || scale.y != scale.y || scale.z != scale.z) {
+        qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
+        return;
+    }
     // TODO: scale
     _transformLock.withWriteLock([&] {
         _transform.setScale(scale);
@@ -561,6 +607,10 @@ AACube SpatiallyNestable::getMaximumAACube(bool& success) const {
 }
 
 void SpatiallyNestable::setQueryAACube(const AACube& queryAACube) {
+    if (queryAACube.containsNaN()) {
+        qDebug() << "SpatiallyNestable::setQueryAACube -- cube contains NaN";
+        return;
+    }
     _queryAACube = queryAACube;
     if (queryAACube.getScale() > 0.0f) {
         _queryAACubeSet = true;

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -315,7 +315,7 @@ glm::vec3 SpatiallyNestable::getPosition(int jointIndex, bool& success) const {
 
 void SpatiallyNestable::setPosition(const glm::vec3& position, bool& success) {
     // guard against introducing NaN into the transform
-    if (isNaN(position.x) || isNaN(position.y) || isNaN(position.z)) {
+    if (isVec3NaN(position)) {
         success = false;
         return;
     }
@@ -364,7 +364,7 @@ glm::quat SpatiallyNestable::getOrientation(int jointIndex, bool& success) const
 
 void SpatiallyNestable::setOrientation(const glm::quat& orientation, bool& success) {
     // guard against introducing NaN into the transform
-    if (isNaN(orientation.x) || isNaN(orientation.y) || isNaN(orientation.z) || isNaN(orientation.w)) {
+    if (isQuatNaN(orientation)) {
         success = false;
         return;
     }
@@ -448,7 +448,7 @@ glm::vec3 SpatiallyNestable::getScale(int jointIndex) const {
 
 void SpatiallyNestable::setScale(const glm::vec3& scale) {
     // guard against introducing NaN into the transform
-    if (isNaN(scale.x) || isNaN(scale.y) || isNaN(scale.z)) {
+    if (isVec3NaN(scale)) {
         qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
         return;
     }
@@ -489,7 +489,7 @@ glm::vec3 SpatiallyNestable::getLocalPosition() const {
 
 void SpatiallyNestable::setLocalPosition(const glm::vec3& position) {
     // guard against introducing NaN into the transform
-    if (isNaN(position.x) || isNaN(position.y) || isNaN(position.z)) {
+    if (isVec3NaN(position)) {
         qDebug() << "SpatiallyNestable::setLocalPosition -- position contains NaN";
         return;
     }
@@ -509,7 +509,7 @@ glm::quat SpatiallyNestable::getLocalOrientation() const {
 
 void SpatiallyNestable::setLocalOrientation(const glm::quat& orientation) {
     // guard against introducing NaN into the transform
-    if (isNaN(orientation.x) || isNaN(orientation.y) || isNaN(orientation.z) || isNaN(orientation.w)) {
+    if (isQuatNaN(orientation)) {
         qDebug() << "SpatiallyNestable::setLocalOrientation -- orientation contains NaN";
         return;
     }
@@ -530,7 +530,7 @@ glm::vec3 SpatiallyNestable::getLocalScale() const {
 
 void SpatiallyNestable::setLocalScale(const glm::vec3& scale) {
     // guard against introducing NaN into the transform
-    if (isNaN(scale.x) || isNaN(scale.y) || isNaN(scale.z)) {
+    if (isVec3NaN(scale)) {
         qDebug() << "SpatiallyNestable::setLocalScale -- scale contains NaN";
         return;
     }

--- a/libraries/shared/src/Transform.cpp
+++ b/libraries/shared/src/Transform.cpp
@@ -152,14 +152,5 @@ QJsonObject Transform::toJson(const Transform& transform) {
 }
 
 bool Transform::containsNaN() const {
-    if (isQuatNaN(_rotation)) {
-        return true;
-    }
-    if (isVec3NaN(_scale)) {
-        return true;
-    }
-    if (isVec3NaN(_translation)) {
-        return true;
-    }
-    return false;
+    return isNaN(_rotation) || isNaN(_scale) || isNaN(_translation);
 }

--- a/libraries/shared/src/Transform.cpp
+++ b/libraries/shared/src/Transform.cpp
@@ -152,13 +152,13 @@ QJsonObject Transform::toJson(const Transform& transform) {
 }
 
 bool Transform::containsNaN() const {
-    if (isNaN(_rotation.x) || isNaN(_rotation.y) || isNaN(_rotation.z) || isNaN(_rotation.w)) {
+    if (isQuatNaN(_rotation)) {
         return true;
     }
-    if (isNaN(_scale.x) || isNaN(_scale.y) || isNaN(_scale.z)) {
+    if (isVec3NaN(_scale)) {
         return true;
     }
-    if (isNaN(_translation.x) || isNaN(_translation.y) || isNaN(_translation.z)) {
+    if (isVec3NaN(_translation)) {
         return true;
     }
     return false;

--- a/libraries/shared/src/Transform.cpp
+++ b/libraries/shared/src/Transform.cpp
@@ -152,20 +152,13 @@ QJsonObject Transform::toJson(const Transform& transform) {
 }
 
 bool Transform::containsNaN() const {
-    if (_rotation.x != _rotation.x ||
-        _rotation.y != _rotation.y ||
-        _rotation.z != _rotation.z ||
-        _rotation.w != _rotation.w) {
+    if (isNaN(_rotation.x) || isNaN(_rotation.y) || isNaN(_rotation.z) || isNaN(_rotation.w)) {
         return true;
     }
-    if (_scale.x != _scale.x ||
-        _scale.y != _scale.y ||
-        _scale.z != _scale.z) {
+    if (isNaN(_scale.x) || isNaN(_scale.y) || isNaN(_scale.z)) {
         return true;
     }
-    if (_translation.x != _translation.x ||
-        _translation.y != _translation.y ||
-        _translation.z != _translation.z) {
+    if (isNaN(_translation.x) || isNaN(_translation.y) || isNaN(_translation.z)) {
         return true;
     }
     return false;

--- a/libraries/shared/src/Transform.cpp
+++ b/libraries/shared/src/Transform.cpp
@@ -150,3 +150,23 @@ QJsonObject Transform::toJson(const Transform& transform) {
     }
     return result;
 }
+
+bool Transform::containsNaN() const {
+    if (_rotation.x != _rotation.x ||
+        _rotation.y != _rotation.y ||
+        _rotation.z != _rotation.z ||
+        _rotation.w != _rotation.w) {
+        return true;
+    }
+    if (_scale.x != _scale.x ||
+        _scale.y != _scale.y ||
+        _scale.z != _scale.z) {
+        return true;
+    }
+    if (_translation.x != _translation.x ||
+        _translation.y != _translation.y ||
+        _translation.z != _translation.z) {
+        return true;
+    }
+    return false;
+}

--- a/libraries/shared/src/Transform.h
+++ b/libraries/shared/src/Transform.h
@@ -145,6 +145,8 @@ public:
     Vec4 transform(const Vec4& pos) const;
     Vec3 transform(const Vec3& pos) const;
 
+    bool containsNaN() const;
+
 protected:
 
     enum Flag {


### PR DESCRIPTION
- guard against NaN getting into the transform for entities and avatars
