### PR TITLE
fix crash for empty modelUrl in ModelEntityItem

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -480,12 +480,17 @@ Model* RenderableModelEntityItem::getModel(EntityTreeRenderer* renderer) {
         } else { // we already have the model we want...
             result = _model;
         }
-    } else { // if our desired URL is empty, we may need to delete our existing model
-        if (_model) {
-            _myRenderer->releaseModel(_model);
-            result = _model = NULL;
-            _needsInitialSimulation = true;
-        }
+    } else if (_model) {
+        // remove from scene
+        render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
+        render::PendingChanges pendingChanges;
+        _model->removeFromScene(scene, pendingChanges);
+        scene->enqueuePendingChanges(pendingChanges);
+
+        // release interest
+        _myRenderer->releaseModel(_model);
+        result = _model = NULL;
+        _needsInitialSimulation = true;
     }
 
     return result;


### PR DESCRIPTION
There was a recipe for crashing the interface:

(1) Create a model entity.  For example you can use this FBX file: http://s3.amazonaws.com/hifi-public/models/props/Dice/goldDie.fbx
(2) Select new entity with edit.js
(3) Set the "Model URL" to empty string
(4) Deselect the model (click on the window somewhere)
(5) Exit edit mode (toggle entity.js off)
(6) Re-enter edit mode (toggle entity.js on)
(7) Click on entity again --> crash

The problem was that the model was being deleted out from under the scene and when it was selected again the model was assumed to be complete with valid geometry.