### PR TITLE
Make entity properties be undefined after entity is unloaded

### DIFF
--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -1515,7 +1515,6 @@ SelectionDisplay = (function() {
         }
 
         that.updateRotationHandles();
-        that.highlightSelectable();
 
         var rotation, dimensions, position, registrationPoint;
 

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -47,7 +47,9 @@ _localRenderAlphaChanged(false),
 _defaultSettings(true),
 _naturalDimensions(1.0f, 1.0f, 1.0f),
 _naturalPosition(0.0f, 0.0f, 0.0f),
-_desiredProperties(desiredProperties)
+_desiredProperties(desiredProperties),
+
+_entityFound(false)
 {
 }
 
@@ -320,6 +322,11 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
 QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool skipDefaults) const {
     QScriptValue properties = engine->newObject();
     EntityItemProperties defaultEntityProperties;
+
+    if (!_entityFound) {
+        // Return without setting any default property values so that properties are reported in JavaScript as undefined.
+        return properties;
+    }
 
     if (_idSet) {
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER_ALWAYS(id, _id.toString());

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -32,24 +32,7 @@ KeyLightPropertyGroup EntityItemProperties::_staticKeyLight;
 EntityPropertyList PROP_LAST_ITEM = (EntityPropertyList)(PROP_AFTER_LAST_ITEM - 1);
 
 EntityItemProperties::EntityItemProperties(EntityPropertyFlags desiredProperties) :
-
-_id(UNKNOWN_ENTITY_ID),
-_idSet(false),
-_lastEdited(0),
-_type(EntityTypes::Unknown),
-
-_glowLevel(0.0f),
-_localRenderAlpha(1.0f),
-
-_glowLevelChanged(false),
-_localRenderAlphaChanged(false),
-
-_defaultSettings(true),
-_naturalDimensions(1.0f, 1.0f, 1.0f),
-_naturalPosition(0.0f, 0.0f, 0.0f),
-_desiredProperties(desiredProperties),
-
-_entityFound(false)
+    _desiredProperties(desiredProperties) //,
 {
 }
 

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -285,14 +285,12 @@ private:
     EntityTypes::EntityType _type;
     void setType(const QString& typeName) { _type = EntityTypes::getEntityTypeFromName(typeName); }
 
-    bool _entityFound;
-
     float _glowLevel;
     float _localRenderAlpha;
     bool _glowLevelChanged;
     bool _localRenderAlphaChanged;
     bool _defaultSettings;
-    bool _dimensionsInitialized = true; // Only false if creating an entity localy with no dimensions properties
+    bool _dimensionsInitialized = true; // Only false if creating an entity locally with no dimensions properties
 
     // NOTE: The following are pseudo client only properties. They are only used in clients which can access
     // properties of model geometry. But these properties are not serialized like other properties.
@@ -302,6 +300,8 @@ private:
     glm::vec3 _naturalPosition;
 
     EntityPropertyFlags _desiredProperties; // if set will narrow scopes of copy/to/from to just these properties
+
+    bool _entityFound;
 };
 
 Q_DECLARE_METATYPE(EntityItemProperties);

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -279,29 +279,29 @@ protected:
     void setCollisionMaskFromString(const QString& maskString);
 
 private:
-    QUuid _id;
-    bool _idSet;
-    quint64 _lastEdited;
-    EntityTypes::EntityType _type;
+    QUuid _id { UNKNOWN_ENTITY_ID };
+    bool _idSet { false };
+    quint64 _lastEdited { 0 };
+    EntityTypes::EntityType _type { EntityTypes::Unknown };
     void setType(const QString& typeName) { _type = EntityTypes::getEntityTypeFromName(typeName); }
 
-    float _glowLevel;
-    float _localRenderAlpha;
-    bool _glowLevelChanged;
-    bool _localRenderAlphaChanged;
-    bool _defaultSettings;
-    bool _dimensionsInitialized = true; // Only false if creating an entity locally with no dimensions properties
+    float _glowLevel { 0.0f };
+    float _localRenderAlpha { 1.0f };
+    bool _glowLevelChanged { false };
+    bool _localRenderAlphaChanged { false };
+    bool _defaultSettings { true };
+    bool _dimensionsInitialized { true }; // Only false if creating an entity locally with no dimensions properties
 
     // NOTE: The following are pseudo client only properties. They are only used in clients which can access
     // properties of model geometry. But these properties are not serialized like other properties.
     QVector<SittingPoint> _sittingPoints;
     QStringList _textureNames;
-    glm::vec3 _naturalDimensions;
-    glm::vec3 _naturalPosition;
+    glm::vec3 _naturalDimensions { 1.0f, 1.0f, 1.0f };
+    glm::vec3 _naturalPosition { 0.0f, 0.0f, 0.0f };
 
     EntityPropertyFlags _desiredProperties; // if set will narrow scopes of copy/to/from to just these properties
 
-    bool _entityFound;
+    bool _entityFound { false };
 };
 
 Q_DECLARE_METATYPE(EntityItemProperties);

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -272,6 +272,8 @@ public:
     void setJointRotationsDirty() { _jointRotationsSetChanged = true; _jointRotationsChanged = true; }
     void setJointTranslationsDirty() { _jointTranslationsSetChanged = true; _jointTranslationsChanged = true; }
 
+    void setEntityFound() { _entityFound = true; }
+
 protected:
     QString getCollisionMaskAsString() const;
     void setCollisionMaskFromString(const QString& maskString);
@@ -282,6 +284,8 @@ private:
     quint64 _lastEdited;
     EntityTypes::EntityType _type;
     void setType(const QString& typeName) { _type = EntityTypes::getEntityTypeFromName(typeName); }
+
+    bool _entityFound;
 
     float _glowLevel;
     float _localRenderAlpha;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -202,11 +202,13 @@ EntityItemProperties EntityScriptingInterface::getEntityProperties(QUuid identit
                     }
                 }
 
+                results = convertLocationToScriptSemantics(results);
+                results.setEntityFound();
             }
         });
     }
 
-    return convertLocationToScriptSemantics(results);
+    return results;
 }
 
 QUuid EntityScriptingInterface::editEntity(QUuid id, const EntityItemProperties& scriptSideProperties) {


### PR DESCRIPTION
Instead of having default "zero" values.