### PR TITLE
entity.js will zero velocities when entities cease to be dynamic

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -1556,6 +1556,11 @@ PropertiesTool = function(opts) {
                     Entities.editEntity(selectionManager.selections[i], properties);
                 }
             } else {
+                if (data.properties.dynamic === false) {
+                    // this object is leaving dynamic, so we zero its velocities
+                    data.properties["velocity"] = {x: 0, y: 0, z: 0};
+                    data.properties["angularVelocity"] = {x: 0, y: 0, z: 0};
+                }
                 if (data.properties.rotation !== undefined) {
                     var rotation = data.properties.rotation;
                     data.properties.rotation = Quat.fromPitchYawRollDegrees(rotation.x, rotation.y, rotation.z);


### PR DESCRIPTION
edit.js provides a UI for manipulating entities so it should stop entities whenever it sets their **dynamic** property to be **false**.

The recipe for the bug is as follows:

(1) Select a static (**dynamic** = false) entity using edit.js
(2) Zero the angular and linear damping
(3) Set the entity **dynamic** but with zero gravity
(4) Give the entity some non-zero angular velocity (unfortunately the angular velocity is in degrees per second so make it something like 60deg/sec about one of the cardinal axes).
(5) Give the entity some slow drift velocity
(6) While it is drifting clear the **dynamic** checkbox  --> we want it to **stop** when set **dynamic**.