### PR TITLE
Fix Separation of Bow and Bowstring

### DIFF
--- a/examples/toybox/bow/bow.js
+++ b/examples/toybox/bow/bow.js
@@ -117,9 +117,7 @@
             this.arrowNotchSound = SoundCache.getSound(NOTCH_ARROW_SOUND_URL);
             var userData = Entities.getEntityProperties(this.entityID).userData;
             this.userData = JSON.parse(userData);
-            print('THIS USERDATA::: ' + userData)
             this.preNotchString = this.userData.bowKey.preNotchString;
-            print('PRE NOTCH STRING:::' + this.preNotchString)
         },
 
         unload: function() {

--- a/examples/toybox/bow/bow.js
+++ b/examples/toybox/bow/bow.js
@@ -115,12 +115,15 @@
             this.shootArrowSound = SoundCache.getSound(SHOOT_ARROW_SOUND_URL);
             this.arrowHitSound = SoundCache.getSound(ARROW_HIT_SOUND_URL);
             this.arrowNotchSound = SoundCache.getSound(NOTCH_ARROW_SOUND_URL);
-
+            var userData = Entities.getEntityProperties(this.entityID).userData;
+            this.userData = JSON.parse(userData);
+            print('THIS USERDATA::: ' + userData)
+            this.preNotchString = this.userData.bowKey.preNotchString;
+            print('PRE NOTCH STRING:::' + this.preNotchString)
         },
 
         unload: function() {
             this.deleteStrings();
-            Entities.deleteEntity(this.preNotchString);
             Entities.deleteEntity(this.arrow);
         },
 
@@ -174,18 +177,6 @@
 
             this.bowProperties = Entities.getEntityProperties(this.entityID);
 
-            //create a string across the bow when we pick it up
-            if (this.preNotchString === null) {
-                this.createPreNotchString();
-            }
-
-            if (this.preNotchString !== null && this.aiming === false) {
-                //   print('DRAW PRE NOTCH STRING')
-                this.drawPreNotchStrings();
-            }
-
-            // create the notch detector that arrows will look for
-
             if (this.aiming === true) {
                 Entities.editEntity(this.preNotchString, {
                     visible: false
@@ -213,11 +204,9 @@
                 var data = getEntityCustomData('grabbableKey', this.entityID, {});
                 data.grabbable = true;
                 setEntityCustomData('grabbableKey', this.entityID, data);
-                Entities.deleteEntity(this.preNotchString);
                 Entities.deleteEntity(this.arrow);
                 this.aiming = false;
                 this.hasArrowNotched = false;
-                this.preNotchString = null;
 
             }
         },
@@ -334,10 +323,6 @@
             var bottomStringPosition = Vec3.sum(this.bowProperties.position, downOffset);
             this.bottomStringPosition = Vec3.sum(bottomStringPosition, backOffset);
 
-            Entities.editEntity(this.preNotchString, {
-                position: this.topStringPosition
-            });
-
             Entities.editEntity(this.topString, {
                 position: this.topStringPosition
             });
@@ -379,50 +364,6 @@
             var topVector = Vec3.subtract(this.arrowRearPosition, this.topStringPosition);
             var bottomVector = Vec3.subtract(this.arrowRearPosition, this.bottomStringPosition);
             return [topVector, bottomVector];
-        },
-
-        createPreNotchString: function() {
-            this.bowProperties = Entities.getEntityProperties(_this.entityID, ["position", "rotation", "userData"]);
-
-            var stringProperties = {
-                type: 'Line',
-                position: Vec3.sum(this.bowProperties.position, TOP_NOTCH_OFFSET),
-                dimensions: LINE_DIMENSIONS,
-                visible: true,
-                dynamic: false,
-                collisionless: true,
-                userData: JSON.stringify({
-                    grabbableKey: {
-                        grabbable: false
-                    }
-                })
-            };
-
-            this.preNotchString = Entities.addEntity(stringProperties);
-        },
-
-        drawPreNotchStrings: function() {
-            this.bowProperties = Entities.getEntityProperties(_this.entityID, ["position", "rotation", "userData"]);
-
-            this.updateStringPositions();
-
-            var downVector = Vec3.multiply(-1, Quat.getUp(this.bowProperties.rotation));
-            var downOffset = Vec3.multiply(downVector, BOTTOM_NOTCH_OFFSET * 2);
-
-            Entities.editEntity(this.preNotchString, {
-                name: 'Hifi-Pre-Notch-String',
-                linePoints: [{
-                    x: 0,
-                    y: 0,
-                    z: 0
-                }, Vec3.sum({
-                    x: 0,
-                    y: 0,
-                    z: 0
-                }, downOffset)],
-                lineWidth: 5,
-                color: this.stringData.currentColor,
-            });
         },
 
         checkStringHand: function() {

--- a/examples/toybox/bow/createBow.js
+++ b/examples/toybox/bow/createBow.js
@@ -10,8 +10,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var utilsPath = Script.resolvePath('../../libraries/utils.js')
-Script.include(utilsPath)
+var utilsPath = Script.resolvePath('../../libraries/utils.js');
+Script.include(utilsPath);
 
 var SCRIPT_URL = Script.resolvePath('bow.js');
 
@@ -80,10 +80,12 @@ function makeBow() {
                 }
             }
         })
-    }
+    };
+
     bow = Entities.addEntity(bowProperties);
     createPreNotchString();
 }
+
 var preNotchString;
 
 function createPreNotchString() {

--- a/examples/toybox/bow/createBow.js
+++ b/examples/toybox/bow/createBow.js
@@ -10,6 +10,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+var utilsPath = Script.resolvePath('../../libraries/utils.js')
+Script.include(utilsPath)
 
 var SCRIPT_URL = Script.resolvePath('bow.js');
 
@@ -33,39 +35,114 @@ var center = Vec3.sum(Vec3.sum(MyAvatar.position, {
     z: 0
 }), Vec3.multiply(1, Quat.getFront(Camera.getOrientation())));
 
-var bow = Entities.addEntity({
-    name: 'Hifi-Bow',
-    type: "Model",
-    modelURL: MODEL_URL,
-    position: center,
-    dimensions: BOW_DIMENSIONS,
-    dynamic: true,
-    gravity: BOW_GRAVITY,
-    shapeType: 'compound',
-    compoundShapeURL: COLLISION_HULL_URL,
-    script: SCRIPT_URL,
-    userData: JSON.stringify({
-        grabbableKey: {
-            invertSolidWhileHeld: true,
-            spatialKey: {
-                leftRelativePosition: {
-                    x: -0.02,
-                    y: 0.08,
-                    z: 0.09
-                },
-                relativePosition: {
-                    x: 0.02,
-                    y: 0.08,
-                    z: 0.09
-                },
-                relativeRotation: Quat.fromPitchYawRollDegrees(0, 90, -90)
+
+var TOP_NOTCH_OFFSET = 0.6;
+
+var BOTTOM_NOTCH_OFFSET = 0.6;
+
+var LINE_DIMENSIONS = {
+    x: 5,
+    y: 5,
+    z: 5
+};
+
+var bow;
+
+
+function makeBow() {
+
+    var bowProperties = {
+        name: 'Hifi-Bow',
+        type: "Model",
+        modelURL: MODEL_URL,
+        position: center,
+        dimensions: BOW_DIMENSIONS,
+        dynamic: true,
+        gravity: BOW_GRAVITY,
+        shapeType: 'compound',
+        compoundShapeURL: COLLISION_HULL_URL,
+        script: SCRIPT_URL,
+        userData: JSON.stringify({
+            grabbableKey: {
+                invertSolidWhileHeld: true,
+                spatialKey: {
+                    leftRelativePosition: {
+                        x: -0.02,
+                        y: 0.08,
+                        z: 0.09
+                    },
+                    relativePosition: {
+                        x: 0.02,
+                        y: 0.08,
+                        z: 0.09
+                    },
+                    relativeRotation: Quat.fromPitchYawRollDegrees(0, 90, -90)
+                }
             }
-        }
-    })
-});
+        })
+    }
+    bow = Entities.addEntity(bowProperties);
+    createPreNotchString();
+}
+var preNotchString;
+
+function createPreNotchString() {
+
+    var bowProperties = Entities.getEntityProperties(bow, ["position", "rotation", "userData"]);
+    var downVector = Vec3.multiply(-1, Quat.getUp(bowProperties.rotation));
+    var downOffset = Vec3.multiply(downVector, BOTTOM_NOTCH_OFFSET * 2);
+    var upVector = Quat.getUp(bowProperties.rotation);
+    var upOffset = Vec3.multiply(upVector, TOP_NOTCH_OFFSET);
+
+    var backOffset = Vec3.multiply(-0.1, Quat.getFront(bowProperties.rotation));
+    var topStringPosition = Vec3.sum(bowProperties.position, upOffset);
+    topStringPosition = Vec3.sum(topStringPosition, backOffset);
+
+    var stringProperties = {
+        name: 'Hifi-Bow-Pre-Notch-String',
+        type: 'Line',
+        position: topStringPosition,
+        linePoints: [{
+            x: 0,
+            y: 0,
+            z: 0
+        }, Vec3.sum({
+            x: 0,
+            y: 0,
+            z: 0
+        }, downOffset)],
+        lineWidth: 5,
+        color: {
+            red: 255,
+            green: 255,
+            blue: 255
+        },
+        dimensions: LINE_DIMENSIONS,
+        visible: true,
+        dynamic: false,
+        collisionless: true,
+        parentID: bow,
+        userData: JSON.stringify({
+            grabbableKey: {
+                grabbable: false
+            }
+        })
+    };
+
+    preNotchString = Entities.addEntity(stringProperties);
+
+    var data = {
+        preNotchString: preNotchString
+    };
+
+    setEntityCustomData('bowKey', bow, data);
+}
+
+makeBow();
 
 function cleanup() {
     Entities.deleteEntity(bow);
+    Entities.deleteEntity(preNotchString);
 }
 
 Script.scriptEnding.connect(cleanup);

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -322,39 +322,53 @@
             });
         }
 
-        function createBow() {
+    function createBow() {
 
-            var startPosition = {
-                x: 546.41,
-                y: 495.33,
-                z: 506.46
-            };
+        var startPosition = {
+            x: 546.41,
+            y: 495.33,
+            z: 506.46
+        };
 
-            var BOW_ROTATION = Quat.fromPitchYawRollDegrees(-103.05, -178.60, -87.27);
+        var SCRIPT_URL = Script.resolvePath('bow.js');
+        var BOW_ROTATION = Quat.fromPitchYawRollDegrees(-103.05, -178.60, -87.27);
+        var MODEL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow-deadly.fbx";
+        var COLLISION_HULL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow_collision_hull.obj";
+        var BOW_DIMENSIONS = {
+            x: 0.04,
+            y: 1.3,
+            z: 0.21
+        };
 
-            var MODEL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow-deadly.fbx";
-            var COLLISION_HULL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow_collision_hull.obj";
-            var BOW_DIMENSIONS = {
-                x: 0.04,
-                y: 1.3,
-                z: 0.21
-            };
+        var BOW_GRAVITY = {
+            x: 0,
+            y: -9.8,
+            z: 0
+        };
 
-            var BOW_GRAVITY = {
-                x: 0,
-                y: -9.8,
-                z: 0
-            };
+        var TOP_NOTCH_OFFSET = 0.6;
 
-            var bow = Entities.addEntity({
+        var BOTTOM_NOTCH_OFFSET = 0.6;
+
+        var LINE_DIMENSIONS = {
+            x: 5,
+            y: 5,
+            z: 5
+        };
+
+        var bow;
+
+        function makeBow() {
+
+            var bowProperties = {
                 name: 'Hifi-Bow',
                 type: "Model",
                 modelURL: MODEL_URL,
                 position: startPosition,
-                rotation: BOW_ROTATION,
                 dimensions: BOW_DIMENSIONS,
                 dynamic: true,
                 gravity: BOW_GRAVITY,
+                rotation: BOW_ROTATION,
                 shapeType: 'compound',
                 compoundShapeURL: COLLISION_HULL_URL,
                 script: bowScriptURL,
@@ -379,10 +393,66 @@
                         }
                     }
                 })
-            });
+            }
+            bow = Entities.addEntity(bowProperties);
+            createPreNotchString();
+        }
+        var preNotchString;
 
+        function createPreNotchString() {
+
+            var bowProperties = Entities.getEntityProperties(bow, ["position", "rotation", "userData"]);
+            var downVector = Vec3.multiply(-1, Quat.getUp(bowProperties.rotation));
+            var downOffset = Vec3.multiply(downVector, BOTTOM_NOTCH_OFFSET * 2);
+            var upVector = Quat.getUp(bowProperties.rotation);
+            var upOffset = Vec3.multiply(upVector, TOP_NOTCH_OFFSET);
+
+            var backOffset = Vec3.multiply(-0.1, Quat.getFront(bowProperties.rotation));
+            var topStringPosition = Vec3.sum(bowProperties.position, upOffset);
+            topStringPosition = Vec3.sum(topStringPosition, backOffset);
+
+            var stringProperties = {
+                name: 'Hifi-Bow-Pre-Notch-String',
+                type: 'Line',
+                position: topStringPosition,
+                linePoints: [{
+                    x: 0,
+                    y: 0,
+                    z: 0
+                }, Vec3.sum({
+                    x: 0,
+                    y: 0,
+                    z: 0
+                }, downOffset)],
+                lineWidth: 5,
+                color: {
+                    red: 255,
+                    green: 255,
+                    blue: 255
+                },
+                dimensions: LINE_DIMENSIONS,
+                visible: true,
+                dynamic: false,
+                collisionless: true,
+                parentID: bow,
+                userData: JSON.stringify({
+                    grabbableKey: {
+                        grabbable: false
+                    }
+                })
+            };
+
+            preNotchString = Entities.addEntity(stringProperties);
+
+            var data = {
+                preNotchString: preNotchString
+            };
+
+            setEntityCustomData('bowKey', bow, data);
         }
 
+        makeBow();
+    }
 
         function createFire() {
 

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -415,7 +415,7 @@
                 name: 'Hifi-Bow-Pre-Notch-String',
                 type: 'Line',
                 position: topStringPosition,
-                rotation:BOW_ROTATION,
+                rotation:bowProperties.rotation,
                 linePoints: [{
                     x: 0,
                     y: 0,

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -322,139 +322,138 @@
             });
         }
 
-    function createBow() {
+        function createBow() {
 
-        var startPosition = {
-            x: 546.41,
-            y: 495.33,
-            z: 506.46
-        };
+            var startPosition = {
+                x: 546.41,
+                y: 495.33,
+                z: 506.46
+            };
 
-        var SCRIPT_URL = Script.resolvePath('bow.js');
-        var BOW_ROTATION = Quat.fromPitchYawRollDegrees(-103.05, -178.60, -87.27);
-        var MODEL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow-deadly.fbx";
-        var COLLISION_HULL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow_collision_hull.obj";
-        var BOW_DIMENSIONS = {
-            x: 0.04,
-            y: 1.3,
-            z: 0.21
-        };
+            var SCRIPT_URL = Script.resolvePath('bow.js');
+            var BOW_ROTATION = Quat.fromPitchYawRollDegrees(-103.05, -178.60, -87.27);
+            var MODEL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow-deadly.fbx";
+            var COLLISION_HULL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow_collision_hull.obj";
+            var BOW_DIMENSIONS = {
+                x: 0.04,
+                y: 1.3,
+                z: 0.21
+            };
 
-        var BOW_GRAVITY = {
-            x: 0,
-            y: -9.8,
-            z: 0
-        };
+            var BOW_GRAVITY = {
+                x: 0,
+                y: -9.8,
+                z: 0
+            };
 
-        var TOP_NOTCH_OFFSET = 0.6;
+            var TOP_NOTCH_OFFSET = 0.6;
 
-        var BOTTOM_NOTCH_OFFSET = 0.6;
+            var BOTTOM_NOTCH_OFFSET = 0.6;
 
-        var LINE_DIMENSIONS = {
-            x: 5,
-            y: 5,
-            z: 5
-        };
+            var LINE_DIMENSIONS = {
+                x: 5,
+                y: 5,
+                z: 5
+            };
 
-        var bow;
+            var bow;
 
-        function makeBow() {
+            function makeBow() {
 
-            var bowProperties = {
-                name: 'Hifi-Bow',
-                type: "Model",
-                modelURL: MODEL_URL,
-                position: startPosition,
-                dimensions: BOW_DIMENSIONS,
-                dynamic: true,
-                gravity: BOW_GRAVITY,
-                rotation: BOW_ROTATION,
-                shapeType: 'compound',
-                compoundShapeURL: COLLISION_HULL_URL,
-                script: bowScriptURL,
-                userData: JSON.stringify({
-                    resetMe: {
-                        resetMe: true
-                    },
-                    grabbableKey: {
-                        invertSolidWhileHeld: true,
-                        spatialKey: {
-                            rightRelativePosition: {
-                                x: 0.03,
-                                y: 0.08,
-                                z: 0.11
-                            },
-                            leftRelativePosition: {
-                                x: -0.03,
-                                y: 0.08,
-                                z: 0.11
-                            },
-                            relativeRotation: Quat.fromPitchYawRollDegrees(180, 90, 90)
+                var bowProperties = {
+                    name: 'Hifi-Bow',
+                    type: "Model",
+                    modelURL: MODEL_URL,
+                    position: startPosition,
+                    dimensions: BOW_DIMENSIONS,
+                    dynamic: true,
+                    gravity: BOW_GRAVITY,
+                    rotation: BOW_ROTATION,
+                    shapeType: 'compound',
+                    compoundShapeURL: COLLISION_HULL_URL,
+                    script: bowScriptURL,
+                    userData: JSON.stringify({
+                        resetMe: {
+                            resetMe: true
+                        },
+                        grabbableKey: {
+                            invertSolidWhileHeld: true,
+                            spatialKey: {
+                                rightRelativePosition: {
+                                    x: 0.03,
+                                    y: 0.08,
+                                    z: 0.11
+                                },
+                                leftRelativePosition: {
+                                    x: -0.03,
+                                    y: 0.08,
+                                    z: 0.11
+                                },
+                                relativeRotation: Quat.fromPitchYawRollDegrees(180, 90, 90)
+                            }
                         }
-                    }
-                })
+                    })
+                }
+                bow = Entities.addEntity(bowProperties);
+                createPreNotchString();
             }
-            bow = Entities.addEntity(bowProperties);
-            createPreNotchString();
+            var preNotchString;
+
+            function createPreNotchString() {
+
+                var bowProperties = Entities.getEntityProperties(bow, ["position", "rotation", "userData"]);
+                var downVector = Vec3.multiply(-1, Quat.getUp(bowProperties.rotation));
+                var downOffset = Vec3.multiply(downVector, BOTTOM_NOTCH_OFFSET * 2);
+                var upVector = Quat.getUp(bowProperties.rotation);
+                var upOffset = Vec3.multiply(upVector, TOP_NOTCH_OFFSET);
+
+                var backOffset = Vec3.multiply(-0.1, Quat.getFront(bowProperties.rotation));
+                var topStringPosition = Vec3.sum(bowProperties.position, upOffset);
+                topStringPosition = Vec3.sum(topStringPosition, backOffset);
+
+                var stringProperties = {
+                    name: 'Hifi-Bow-Pre-Notch-String',
+                    type: 'Line',
+                    position: topStringPosition,
+                    rotation: Quat.fromPitchYawRollDegrees(164.6, 164.5, -72),
+                    linePoints: [{
+                        x: 0,
+                        y: 0,
+                        z: 0
+                    }, Vec3.sum({
+                        x: 0,
+                        y: 0,
+                        z: 0
+                    }, downOffset)],
+                    lineWidth: 5,
+                    color: {
+                        red: 255,
+                        green: 255,
+                        blue: 255
+                    },
+                    dimensions: LINE_DIMENSIONS,
+                    visible: true,
+                    dynamic: false,
+                    collisionless: true,
+                    parentID: bow,
+                    userData: JSON.stringify({
+                        grabbableKey: {
+                            grabbable: false
+                        }
+                    })
+                };
+
+                preNotchString = Entities.addEntity(stringProperties);
+
+                var data = {
+                    preNotchString: preNotchString
+                };
+
+                setEntityCustomData('bowKey', bow, data);
+            }
+
+            makeBow();
         }
-        var preNotchString;
-
-        function createPreNotchString() {
-
-            var bowProperties = Entities.getEntityProperties(bow, ["position", "rotation", "userData"]);
-            var downVector = Vec3.multiply(-1, Quat.getUp(bowProperties.rotation));
-            var downOffset = Vec3.multiply(downVector, BOTTOM_NOTCH_OFFSET * 2);
-            var upVector = Quat.getUp(bowProperties.rotation);
-            var upOffset = Vec3.multiply(upVector, TOP_NOTCH_OFFSET);
-
-            var backOffset = Vec3.multiply(-0.1, Quat.getFront(bowProperties.rotation));
-            var topStringPosition = Vec3.sum(bowProperties.position, upOffset);
-            topStringPosition = Vec3.sum(topStringPosition, backOffset);
-
-            var stringProperties = {
-                name: 'Hifi-Bow-Pre-Notch-String',
-                type: 'Line',
-                position: topStringPosition,
-                rotation:bowProperties.rotation,
-                linePoints: [{
-                    x: 0,
-                    y: 0,
-                    z: 0
-                }, Vec3.sum({
-                    x: 0,
-                    y: 0,
-                    z: 0
-                }, downOffset)],
-                lineWidth: 5,
-                color: {
-                    red: 255,
-                    green: 255,
-                    blue: 255
-                },
-                dimensions: LINE_DIMENSIONS,
-                visible: true,
-                dynamic: false,
-                collisionless: true,
-                parentID: bow,
-                userData: JSON.stringify({
-                    grabbableKey: {
-                        grabbable: false
-                    }
-                })
-            };
-
-            preNotchString = Entities.addEntity(stringProperties);
-
-            var data = {
-                preNotchString: preNotchString
-            };
-
-            setEntityCustomData('bowKey', bow, data);
-        }
-
-        makeBow();
-    }
-
         function createFire() {
 
 

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -334,6 +334,7 @@
             var BOW_ROTATION = Quat.fromPitchYawRollDegrees(-103.05, -178.60, -87.27);
             var MODEL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow-deadly.fbx";
             var COLLISION_HULL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow_collision_hull.obj";
+            
             var BOW_DIMENSIONS = {
                 x: 0.04,
                 y: 1.3,

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -415,6 +415,7 @@
                 name: 'Hifi-Bow-Pre-Notch-String',
                 type: 'Line',
                 position: topStringPosition,
+                rotation:BOW_ROTATION,
                 linePoints: [{
                     x: 0,
                     y: 0,

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -314,8 +314,8 @@ MasterReset = function() {
             z: 506.46
         };
 
+        var SCRIPT_URL = Script.resolvePath('bow.js');
         var BOW_ROTATION = Quat.fromPitchYawRollDegrees(-103.05, -178.60, -87.27);
-
         var MODEL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow-deadly.fbx";
         var COLLISION_HULL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow_collision_hull.obj";
         var BOW_DIMENSIONS = {
@@ -330,42 +330,113 @@ MasterReset = function() {
             z: 0
         };
 
-        var bow = Entities.addEntity({
-            name: 'Hifi-Bow',
-            type: "Model",
-            modelURL: MODEL_URL,
-            position: startPosition,
-            rotation: BOW_ROTATION,
-            dimensions: BOW_DIMENSIONS,
-            dynamic: true,
-            gravity: BOW_GRAVITY,
-            shapeType: 'compound',
-            compoundShapeURL: COLLISION_HULL_URL,
-            script: bowScriptURL,
-            userData: JSON.stringify({
-                resetMe: {
-                    resetMe: true
-                },
-                grabbableKey: {
-                    invertSolidWhileHeld: true,
-                    spatialKey: {
-                        rightRelativePosition: {
-                            x: 0.03,
-                            y: 0.08,
-                            z: 0.11
-                        },
-                        leftRelativePosition: {
-                            x: -0.03,
-                            y: 0.08,
-                            z: 0.11
-                        },
-                        relativeRotation: Quat.fromPitchYawRollDegrees(180, 90, 90)
-                    }
-                }
-            })
-        });
-    }
+        var TOP_NOTCH_OFFSET = 0.6;
 
+        var BOTTOM_NOTCH_OFFSET = 0.6;
+
+        var LINE_DIMENSIONS = {
+            x: 5,
+            y: 5,
+            z: 5
+        };
+
+        var bow;
+
+        function makeBow() {
+
+            var bowProperties = {
+                name: 'Hifi-Bow',
+                type: "Model",
+                modelURL: MODEL_URL,
+                position: startPosition,
+                dimensions: BOW_DIMENSIONS,
+                dynamic: true,
+                gravity: BOW_GRAVITY,
+                rotation: BOW_ROTATION,
+                shapeType: 'compound',
+                compoundShapeURL: COLLISION_HULL_URL,
+                script: bowScriptURL,
+                userData: JSON.stringify({
+                    resetMe: {
+                        resetMe: true
+                    },
+                    grabbableKey: {
+                        invertSolidWhileHeld: true,
+                        spatialKey: {
+                            rightRelativePosition: {
+                                x: 0.03,
+                                y: 0.08,
+                                z: 0.11
+                            },
+                            leftRelativePosition: {
+                                x: -0.03,
+                                y: 0.08,
+                                z: 0.11
+                            },
+                            relativeRotation: Quat.fromPitchYawRollDegrees(180, 90, 90)
+                        }
+                    }
+                })
+            }
+            bow = Entities.addEntity(bowProperties);
+            createPreNotchString();
+        }
+        var preNotchString;
+
+        function createPreNotchString() {
+
+            var bowProperties = Entities.getEntityProperties(bow, ["position", "rotation", "userData"]);
+            var downVector = Vec3.multiply(-1, Quat.getUp(bowProperties.rotation));
+            var downOffset = Vec3.multiply(downVector, BOTTOM_NOTCH_OFFSET * 2);
+            var upVector = Quat.getUp(bowProperties.rotation);
+            var upOffset = Vec3.multiply(upVector, TOP_NOTCH_OFFSET);
+
+            var backOffset = Vec3.multiply(-0.1, Quat.getFront(bowProperties.rotation));
+            var topStringPosition = Vec3.sum(bowProperties.position, upOffset);
+            topStringPosition = Vec3.sum(topStringPosition, backOffset);
+
+            var stringProperties = {
+                name: 'Hifi-Bow-Pre-Notch-String',
+                type: 'Line',
+                position: topStringPosition,
+                linePoints: [{
+                    x: 0,
+                    y: 0,
+                    z: 0
+                }, Vec3.sum({
+                    x: 0,
+                    y: 0,
+                    z: 0
+                }, downOffset)],
+                lineWidth: 5,
+                color: {
+                    red: 255,
+                    green: 255,
+                    blue: 255
+                },
+                dimensions: LINE_DIMENSIONS,
+                visible: true,
+                dynamic: false,
+                collisionless: true,
+                parentID: bow,
+                userData: JSON.stringify({
+                    grabbableKey: {
+                        grabbable: false
+                    }
+                })
+            };
+
+            preNotchString = Entities.addEntity(stringProperties);
+
+            var data = {
+                preNotchString: preNotchString
+            };
+
+            setEntityCustomData('bowKey', bow, data);
+        }
+
+        makeBow();
+    }
     function createFire() {
 
 

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -399,7 +399,7 @@ MasterReset = function() {
                 name: 'Hifi-Bow-Pre-Notch-String',
                 type: 'Line',
                 position: topStringPosition,
-                rotation:bowProperties.rotation,
+                rotation: Quat.fromPitchYawRollDegrees(164.6, 164.5, -72),
                 linePoints: [{
                     x: 0,
                     y: 0,
@@ -438,6 +438,7 @@ MasterReset = function() {
 
         makeBow();
     }
+    
     function createFire() {
 
 

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -399,6 +399,7 @@ MasterReset = function() {
                 name: 'Hifi-Bow-Pre-Notch-String',
                 type: 'Line',
                 position: topStringPosition,
+                rotation:BOW_ROTATION,
                 linePoints: [{
                     x: 0,
                     y: 0,

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -318,6 +318,7 @@ MasterReset = function() {
         var BOW_ROTATION = Quat.fromPitchYawRollDegrees(-103.05, -178.60, -87.27);
         var MODEL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow-deadly.fbx";
         var COLLISION_HULL_URL = "https://hifi-public.s3.amazonaws.com/models/bow/new/bow_collision_hull.obj";
+        
         var BOW_DIMENSIONS = {
             x: 0.04,
             y: 1.3,
@@ -438,7 +439,7 @@ MasterReset = function() {
 
         makeBow();
     }
-    
+
     function createFire() {
 
 

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -399,7 +399,7 @@ MasterReset = function() {
                 name: 'Hifi-Bow-Pre-Notch-String',
                 type: 'Line',
                 position: topStringPosition,
-                rotation:BOW_ROTATION,
+                rotation:bowProperties.rotation,
                 linePoints: [{
                     x: 0,
                     y: 0,


### PR DESCRIPTION
Previously, it was possible that the bow and its pre-shot bowstring could become separated, or that bowstring lines could be abandoned.  This PR updates the bow in its single spawner and toybox versions to use parenting for the pre-shot bowstring.  To test, load this script and observe that the bowstring is visible before you equip or grab the bow, invisible while aiming, and never separated from the bow body.

https://rawgit.com/imgntn/hifi/bow-parented-string/examples/toybox/bow/createBow.js

Fix for: https://app.asana.com/0/search/83803812895834/83803812895829