### PR TITLE
CharacterController: Improve ground support detection

### DIFF
--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -86,6 +86,7 @@ public:
 
 protected:
     void updateUpAxis(const glm::quat& rotation);
+    bool checkForSupport(btCollisionWorld* collisionWorld) const;
 
 protected:
     btVector3 _currentUp;
@@ -104,6 +105,7 @@ protected:
     btScalar _radius;
 
     btScalar _floorDistance;
+    bool _hasSupport;
 
     btScalar _gravity;
 


### PR DESCRIPTION
In addition to the existing line probe ground check, also check if the bottom sphere of the capsule is contact with any geometry before going into hover mode.  This should prevent going into the fly animation when standing or walking on collision shapes with small gaps between elements.