### PR TITLE
Animate iff visible

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -121,7 +121,6 @@ void Avatar::init() {
     getHead()->init();
     _skeletonModel.init();
     _initialized = true;
-    _shouldRenderBillboard = false;
 }
 
 glm::vec3 Avatar::getChestPosition() const {

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -255,7 +255,7 @@ protected:
 private:
     bool _initialized;
     NetworkTexturePointer _billboardTexture;
-    bool _shouldRenderBillboard;
+    bool _shouldRenderBillboard { true };
     bool _shouldSkipRender { false };
     bool _isLookAtTarget;
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1113,7 +1113,7 @@ void Model::deleteGeometry() {
     _blendedBlendshapeCoefficients.clear();
 }
 
-AABox Model::getPartBounds(int meshIndex, int partIndex, glm::vec3 modelPosition, glm::quat modelOrientation) {
+AABox Model::getPartBounds(int meshIndex, int partIndex, glm::vec3 modelPosition, glm::quat modelOrientation) const {
 
     if (!_geometry || !_geometry->isLoaded()) {
         return AABox();

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -89,7 +89,7 @@ public:
     bool isVisible() const { return _isVisible; }
 
     void updateRenderItems();
-    AABox getPartBounds(int meshIndex, int partIndex, glm::vec3 modelPosition, glm::quat modelOrientation);
+    AABox getPartBounds(int meshIndex, int partIndex, glm::vec3 modelPosition, glm::quat modelOrientation) const;
 
     bool maybeStartBlender();
 


### PR DESCRIPTION
Don't stop animating while an avatar is still visible.
https://app.asana.com/0/32622044445063/75547783717817

We now animate using the same test as for rendering LOD visibility.