### PR TITLE
avatar preferences chooser modal web

### DIFF
--- a/interface/resources/qml/dialogs/preferences/AvatarBrowser.qml
+++ b/interface/resources/qml/dialogs/preferences/AvatarBrowser.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.3
-import QtQuick.Controls 1.2
+import QtQuick 2.5
+import QtQuick.Controls 1.4
 import QtWebEngine 1.1
 
 import "../../windows" as Windows
@@ -11,9 +11,7 @@ Windows.Window {
     HifiConstants { id: hifi }
     width: 900; height: 700
     resizable: true
-    anchors.centerIn: parent
     modality: Qt.ApplicationModal
-    frame: Windows.ModalFrame {}
 
     Item {
         anchors.fill: parent


### PR DESCRIPTION
When the avatar marketplace is chosen from avatar preferences, let it be moveable so that the user can move it aside to see their avatar.

https://app.asana.com/0/32622044445063/83808273856060