### PR TITLE
apply "hips offset" to root of state graph

### DIFF
--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -246,7 +246,7 @@ void AnimInverseKinematics::solveWithCyclicCoordinateDescent(const std::vector<I
                     // deltas up the hierarchy.  Its target position is enforced later by shifting the hips.
                     deltaRotation = target.getRotation() * glm::inverse(tipOrientation);
                     float dotSign = copysignf(1.0f, deltaRotation.w);
-                    const float ANGLE_DISTRIBUTION_FACTOR = 0.35f;
+                    const float ANGLE_DISTRIBUTION_FACTOR = 0.45f;
                     deltaRotation = glm::normalize(glm::lerp(glm::quat(), dotSign * deltaRotation, ANGLE_DISTRIBUTION_FACTOR));
                 }
 
@@ -634,7 +634,7 @@ void AnimInverseKinematics::initConstraints() {
         } else if (baseName.startsWith("Spine", Qt::CaseInsensitive)) {
             SwingTwistConstraint* stConstraint = new SwingTwistConstraint();
             stConstraint->setReferenceRotation(_defaultRelativePoses[i].rot);
-            const float MAX_SPINE_TWIST = PI / 8.0f;
+            const float MAX_SPINE_TWIST = PI / 12.0f;
             stConstraint->setTwistLimits(-MAX_SPINE_TWIST, MAX_SPINE_TWIST);
 
             std::vector<float> minDots;
@@ -658,11 +658,11 @@ void AnimInverseKinematics::initConstraints() {
         } else if (0 == baseName.compare("Neck", Qt::CaseInsensitive)) {
             SwingTwistConstraint* stConstraint = new SwingTwistConstraint();
             stConstraint->setReferenceRotation(_defaultRelativePoses[i].rot);
-            const float MAX_NECK_TWIST = PI / 6.0f;
+            const float MAX_NECK_TWIST = PI / 9.0f;
             stConstraint->setTwistLimits(-MAX_NECK_TWIST, MAX_NECK_TWIST);
 
             std::vector<float> minDots;
-            const float MAX_NECK_SWING = PI / 4.0f;
+            const float MAX_NECK_SWING = PI / 8.0f;
             minDots.push_back(cosf(MAX_NECK_SWING));
             stConstraint->setSwingLimits(minDots);
 
@@ -670,11 +670,11 @@ void AnimInverseKinematics::initConstraints() {
         } else if (0 == baseName.compare("Head", Qt::CaseInsensitive)) {
             SwingTwistConstraint* stConstraint = new SwingTwistConstraint();
             stConstraint->setReferenceRotation(_defaultRelativePoses[i].rot);
-            const float MAX_HEAD_TWIST = PI / 8.0f;
+            const float MAX_HEAD_TWIST = PI / 9.0f;
             stConstraint->setTwistLimits(-MAX_HEAD_TWIST, MAX_HEAD_TWIST);
 
             std::vector<float> minDots;
-            const float MAX_HEAD_SWING = PI / 6.0f;
+            const float MAX_HEAD_SWING = PI / 10.0f;
             minDots.push_back(cosf(MAX_HEAD_SWING));
             stConstraint->setSwingLimits(minDots);
 

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -376,13 +376,13 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
                 ++constraintItr;
             }
         } else {
-            // shift the hips according to the offset from the previous frame
+            // shift the everything according to the _hipsOffset from the previous frame
             float offsetLength = glm::length(_hipsOffset);
             const float MIN_HIPS_OFFSET_LENGTH = 0.03f;
             if (offsetLength > MIN_HIPS_OFFSET_LENGTH) {
                 // but only if offset is long enough
                 float scaleFactor = ((offsetLength - MIN_HIPS_OFFSET_LENGTH) / offsetLength);
-                _relativePoses[_hipsIndex].trans = underPoses[_hipsIndex].trans + scaleFactor * _hipsOffset;
+                _relativePoses[_rootIndex].trans = underPoses[_rootIndex].trans + scaleFactor * _hipsOffset;
             }
 
             solveWithCyclicCoordinateDescent(targets);
@@ -775,9 +775,18 @@ void AnimInverseKinematics::setSkeletonInternal(AnimSkeleton::ConstPointer skele
         initConstraints();
         _headIndex = _skeleton->nameToJointIndex("Head");
         _hipsIndex = _skeleton->nameToJointIndex("Hips");
+
+        // walk up the hierarchy until we find the root and cache its index
+        _rootIndex = _hipsIndex;
+        int parentIndex = _skeleton->getParentIndex(_hipsIndex);
+        while (parentIndex != -1) {
+            _rootIndex = parentIndex;
+            parentIndex = _skeleton->getParentIndex(_rootIndex);
+        }
     } else {
         clearConstraints();
         _headIndex = -1;
         _hipsIndex = -1;
+        _rootIndex = -1;
     }
 }

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -79,13 +79,14 @@ protected:
     AnimPoseVec _relativePoses; // current relative poses
 
     // experimental data for moving hips during IK
-    int _headIndex = -1;
-    int _hipsIndex = -1;
-    glm::vec3 _hipsOffset = Vectors::ZERO;
+    glm::vec3 _hipsOffset { Vectors::ZERO };
+    int _headIndex { -1 };
+    int _hipsIndex { -1 };
+    int _rootIndex { -1 };
 
     // _maxTargetIndex is tracked to help optimize the recalculation of absolute poses
     // during the the cyclic coordinate descent algorithm
-    int _maxTargetIndex = 0;
+    int _maxTargetIndex { 0 };
 };
 
 #endif // hifi_AnimInverseKinematics_h

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -82,7 +82,7 @@ protected:
     glm::vec3 _hipsOffset { Vectors::ZERO };
     int _headIndex { -1 };
     int _hipsIndex { -1 };
-    int _rootIndex { -1 };
+    int _hipsParentIndex { -1 };
 
     // _maxTargetIndex is tracked to help optimize the recalculation of absolute poses
     // during the the cyclic coordinate descent algorithm


### PR DESCRIPTION
An alpha user tested #6938 and reported an instability when using a particular avatar.  This PR fixes the problem.

The avatar in question was modified using Blender and had picked up some joints above the "Hips" in the hierarchy and had some non-trivial parent-relative transforms at the root joint and the hips.  This revealed the fact that we were adding the _hipsOffset to the "Hips" joint directly (and hence in the wrong frame) rather than to the root of the entire animation state.