### PR TITLE
MyAvatar: copy body velocity + hmd follow velocity onto avatar

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -136,7 +136,7 @@ Item {
                     Text {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
-                        text: "Velocity: " + root.velocity.toFixed(1)
+                        text: "Speed: " + root.speed.toFixed(1)
                     }
                     Text {
                         color: root.fontColor;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1042,6 +1042,8 @@ void MyAvatar::harvestResultsFromPhysicsSimulation(float deltaTime) {
     nextAttitude(position, orientation);
     _bodySensorMatrix = _follow.postPhysicsUpdate(*this, _bodySensorMatrix);
 
+    setVelocity(_characterController.getLinearVelocity() + _characterController.getFollowVelocity());
+
     // now that physics has adjusted our position, we can update attachements.
     Avatar::simulateAttachments(deltaTime);
 }

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -162,7 +162,7 @@ void Stats::updateStats(bool force) {
     MyAvatar* myAvatar = avatarManager->getMyAvatar();
     glm::vec3 avatarPos = myAvatar->getPosition();
     STAT_UPDATE(position, QVector3D(avatarPos.x, avatarPos.y, avatarPos.z));
-    STAT_UPDATE_FLOAT(velocity, glm::length(myAvatar->getVelocity()), 0.1f);
+    STAT_UPDATE_FLOAT(speed, glm::length(myAvatar->getVelocity()), 0.1f);
     STAT_UPDATE_FLOAT(yaw, myAvatar->getBodyYaw(), 0.1f);
     if (_expanded || force) {
         SharedNodePointer avatarMixer = nodeList->soloNodeOfType(NodeType::AvatarMixer);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -47,7 +47,7 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, entitiesPing, 0)
     STATS_PROPERTY(int, assetPing, 0)
     STATS_PROPERTY(QVector3D, position, QVector3D(0, 0, 0) )
-    STATS_PROPERTY(float, velocity, 0)
+    STATS_PROPERTY(float, speed, 0)
     STATS_PROPERTY(float, yaw, 0)
     STATS_PROPERTY(int, avatarMixerInKbps, 0)
     STATS_PROPERTY(int, avatarMixerInPps, 0)
@@ -138,7 +138,7 @@ signals:
     void entitiesPingChanged();
     void assetPingChanged();
     void positionChanged();
-    void velocityChanged();
+    void speedChanged();
     void yawChanged();
     void avatarMixerInKbpsChanged();
     void avatarMixerInPpsChanged();

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -390,6 +390,14 @@ glm::quat CharacterController::getFollowAngularDisplacement() const {
     return bulletToGLM(_followAngularDisplacement);
 }
 
+glm::vec3 CharacterController::getFollowVelocity() const {
+    if (_followTime > 0.0f) {
+        return bulletToGLM(_followLinearDisplacement) / _followTime;
+    } else {
+        return glm::vec3();
+    }
+}
+
 glm::vec3 CharacterController::getLinearVelocity() const {
     glm::vec3 velocity(0.0f);
     if (_rigidBody) {

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -71,6 +71,7 @@ public:
     float getFollowTime() const { return _followTime; }
     glm::vec3 getFollowLinearDisplacement() const;
     glm::quat getFollowAngularDisplacement() const;
+    glm::vec3 getFollowVelocity() const;
 
     glm::vec3 getLinearVelocity() const;
 


### PR DESCRIPTION
This should fix issue where avatar animations are running in place or moon walking.

This was inadvertently removed in a previous PR.

https://github.com/highfidelity/hifi/pull/6895

Also, renamed Velocity stat to Speed.