### PR TITLE
force AC assignment stop during DOS, process events for rapid injectors

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -680,11 +680,11 @@ void AudioMixer::domainSettingsRequestComplete() {
 void AudioMixer::broadcastMixes() {
     auto nodeList = DependencyManager::get<NodeList>(); 
     
-    int nextFrame = 0;
+    int64_t nextFrame = 0;
     QElapsedTimer timer;
     timer.start();
     
-    int usecToSleep = AudioConstants::NETWORK_FRAME_USECS;
+    int64_t usecToSleep = AudioConstants::NETWORK_FRAME_USECS;
     
     const int TRAILING_AVERAGE_FRAMES = 100;
     int framesSinceCutoffEvent = TRAILING_AVERAGE_FRAMES;
@@ -826,12 +826,7 @@ void AudioMixer::broadcastMixes() {
             break;
         }
         
-        usecToSleep = (++nextFrame * AudioConstants::NETWORK_FRAME_USECS) - timer.nsecsElapsed() / 1000; // ns to us
-
-        if (usecToSleep > int(USECS_PER_SECOND)) {
-            qDebug() << "DANGER: amount to sleep is" << usecToSleep;
-            qDebug() << "NextFrame is" << nextFrame << "and timer nsecs elapsed is" << timer.nsecsElapsed();
-        }
+        usecToSleep = (++nextFrame * AudioConstants::NETWORK_FRAME_USECS) - (timer.nsecsElapsed() / 1000);
 
         if (usecToSleep > 0) {
             usleep(usecToSleep);

--- a/libraries/audio/src/AudioInjectorManager.cpp
+++ b/libraries/audio/src/AudioInjectorManager.cpp
@@ -79,6 +79,11 @@ void AudioInjectorManager::run() {
             if (_injectors.size() > 0) {
                 // loop through the injectors in the map and send whatever frames need to go out
                 auto front = _injectors.top();
+
+                // create an InjectorQueue to hold injectors to be queued
+                // this allows us to call processEvents even if a single injector wants to be re-queued immediately
+                InjectorQueue holdingQueue;
+
                 while (_injectors.size() > 0 && front.first <= usecTimestampNow()) {
                     // either way we're popping this injector off - get a copy first
                     auto injector = front.second;
@@ -89,8 +94,8 @@ void AudioInjectorManager::run() {
                         auto nextCallDelta = injector->injectNextFrame();
 
                         if (nextCallDelta >= 0 && !injector->isFinished()) {
-                            // re-enqueue the injector with the correct timing
-                            _injectors.emplace(usecTimestampNow() + nextCallDelta, injector);
+                            // enqueue the injector with the correct timing in our holding queue
+                            holdingQueue.emplace(usecTimestampNow() + nextCallDelta, injector);
                         }
                     }
                     
@@ -100,6 +105,12 @@ void AudioInjectorManager::run() {
                         // no more injectors to look at, break
                         break;
                     }
+                }
+
+                // if there are injectors in the holding queue, push them to our persistent queue now
+                while (!holdingQueue.empty()) {
+                    _injectors.push(holdingQueue.top());
+                    holdingQueue.pop();
                 }
             }
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -490,6 +490,9 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
     // this is a packet from the domain server, reset the count of un-replied check-ins
     _numNoReplyDomainCheckIns = 0;
 
+    // emit our signal so listeners know we just heard from the DS
+    emit receivedDomainServerList();
+
     DependencyManager::get<NodeList>()->flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::ReceiveDSList);
 
     QDataStream packetStream(message->getMessage());

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -87,6 +87,7 @@ public slots:
 
 signals:
     void limitOfSilentDomainCheckInsReached();
+    void receivedDomainServerList();
 private slots:
     void stopKeepalivePingTimer();
     void sendPendingDSPathQuery();

--- a/libraries/networking/src/ThreadedAssignment.cpp
+++ b/libraries/networking/src/ThreadedAssignment.cpp
@@ -30,6 +30,10 @@ ThreadedAssignment::ThreadedAssignment(ReceivedMessage& message) :
 
     connect(&_domainServerTimer, &QTimer::timeout, this, &ThreadedAssignment::checkInWithDomainServerOrExit);
     _domainServerTimer.setInterval(DOMAIN_SERVER_CHECK_IN_MSECS);
+
+    // if the NL tells us we got a DS response, clear our member variable of queued check-ins
+    auto nodeList = DependencyManager::get<NodeList>();
+    connect(nodeList.data(), &NodeList::receivedDomainServerList, this, &ThreadedAssignment::clearQueuedCheckIns);
 }
 
 void ThreadedAssignment::setFinished(bool isFinished) {
@@ -103,11 +107,18 @@ void ThreadedAssignment::sendStatsPacket() {
 }
 
 void ThreadedAssignment::checkInWithDomainServerOrExit() {
-    if (DependencyManager::get<NodeList>()->getNumNoReplyDomainCheckIns() == MAX_SILENT_DOMAIN_SERVER_CHECK_INS) {
+    qDebug() << "WE ARE AT" << _numQueuedCheckIns << "queued check-ins";
+    
+    // verify that the number of queued check-ins is not >= our max
+    // the number of queued check-ins is cleared anytime we get a response from the domain-server
+    if (_numQueuedCheckIns >= MAX_SILENT_DOMAIN_SERVER_CHECK_INS) {
         setFinished(true);
     } else {
         auto nodeList = DependencyManager::get<NodeList>();
         QMetaObject::invokeMethod(nodeList.data(), "sendDomainServerCheckIn");
+
+        // increase the number of queued check ins
+        _numQueuedCheckIns++;
     }
 }
 

--- a/libraries/networking/src/ThreadedAssignment.cpp
+++ b/libraries/networking/src/ThreadedAssignment.cpp
@@ -107,8 +107,6 @@ void ThreadedAssignment::sendStatsPacket() {
 }
 
 void ThreadedAssignment::checkInWithDomainServerOrExit() {
-    qDebug() << "WE ARE AT" << _numQueuedCheckIns << "queued check-ins";
-    
     // verify that the number of queued check-ins is not >= our max
     // the number of queued check-ins is cleared anytime we get a response from the domain-server
     if (_numQueuedCheckIns >= MAX_SILENT_DOMAIN_SERVER_CHECK_INS) {

--- a/libraries/networking/src/ThreadedAssignment.cpp
+++ b/libraries/networking/src/ThreadedAssignment.cpp
@@ -110,6 +110,8 @@ void ThreadedAssignment::checkInWithDomainServerOrExit() {
     // verify that the number of queued check-ins is not >= our max
     // the number of queued check-ins is cleared anytime we get a response from the domain-server
     if (_numQueuedCheckIns >= MAX_SILENT_DOMAIN_SERVER_CHECK_INS) {
+        qDebug() << "At least" << MAX_SILENT_DOMAIN_SERVER_CHECK_INS << "have been queued without a response from domain-server"
+            << "Stopping the current assignment";
         setFinished(true);
     } else {
         auto nodeList = DependencyManager::get<NodeList>();

--- a/libraries/networking/src/ThreadedAssignment.h
+++ b/libraries/networking/src/ThreadedAssignment.h
@@ -33,6 +33,7 @@ public slots:
     virtual void run() = 0;
     Q_INVOKABLE virtual void stop() { setFinished(true); }
     virtual void sendStatsPacket();
+    void clearQueuedCheckIns() { _numQueuedCheckIns = 0; }
 
 signals:
     void finished();
@@ -42,6 +43,7 @@ protected:
     bool _isFinished;
     QTimer _domainServerTimer;
     QTimer _statsTimer;
+    int _numQueuedCheckIns { 0 };
     
 protected slots:
     void domainSettingsRequestFailed();


### PR DESCRIPTION
- fixed an issue where assignment-clients would not notice they had lost connection to domain-server if they were inundated with packets
- fixed an issue with AudioInjectorManager not processing events if an individual injector continuously asked to be immediately queued 