### PR TITLE
Fix injector looping issues when using audio that isn't a multiple of the sample size

### DIFF
--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -181,6 +181,15 @@ int64_t AudioInjector::injectNextFrame() {
         // make sure we actually have samples downloaded to inject
         if (_audioData.size()) {
 
+            auto sampleSize = (_options.stereo ? 2 : 1) * sizeof(AudioConstants::AudioSample);
+            auto numSamples = static_cast<int>(_audioData.size() / sampleSize);
+            auto targetSize = numSamples * sampleSize;
+            if (targetSize != _audioData.size()) {
+                qDebug() << "Resizing audio that doesn't end at multiple of sample size, resizing from "
+                    << _audioData.size() << " to " << targetSize;
+                _audioData.resize(targetSize);
+            }
+
             _outgoingSequenceNumber = 0;
             _nextFrame = 0;
 

--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -281,7 +281,7 @@ int64_t AudioInjector::injectNextFrame() {
         _currentPacket->write(_audioData.data() + _currentSendOffset, bytesToCopy);
         _currentSendOffset += bytesToCopy;
         totalBytesLeftToCopy -= bytesToCopy;
-        if (_currentSendOffset >= _audioData.size()) {
+        if (_options.loop && _currentSendOffset >= _audioData.size()) {
             _currentSendOffset = 0;
         }
     }

--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -181,7 +181,7 @@ int64_t AudioInjector::injectNextFrame() {
         // make sure we actually have samples downloaded to inject
         if (_audioData.size()) {
 
-            auto sampleSize = (_options.stereo ? 2 : 1) * sizeof(AudioConstants::AudioSample);
+            int sampleSize = (_options.stereo ? 2 : 1) * sizeof(AudioConstants::AudioSample);
             auto numSamples = static_cast<int>(_audioData.size() / sampleSize);
             auto targetSize = numSamples * sampleSize;
             if (targetSize != _audioData.size()) {


### PR DESCRIPTION
This fixes an issue on hq where looped audio would go static-y when looping when the audio data size was not a multiple of its sample size.