### PR TITLE
don't adjust a time of '0 usecs since epoch' with clock skew in edit packets

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -763,7 +763,7 @@ void EntityItem::adjustEditPacketForClockSkew(QByteArray& buffer, int clockSkew)
     // lastEdited
     quint64 lastEditedInLocalTime;
     memcpy(&lastEditedInLocalTime, dataAt, sizeof(lastEditedInLocalTime));
-    quint64 lastEditedInServerTime = lastEditedInLocalTime + clockSkew;
+    quint64 lastEditedInServerTime = lastEditedInLocalTime > 0 ? lastEditedInLocalTime + clockSkew : 0;
     memcpy(dataAt, &lastEditedInServerTime, sizeof(lastEditedInServerTime));
     #ifdef WANT_DEBUG
         qCDebug(entities, "EntityItem::adjustEditPacketForClockSkew()...");


### PR DESCRIPTION
- fix a bug that was causing some entity edit packets to be ignored by server
