### PR TITLE
Validate href entity property (hifi:// only)

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -982,7 +982,7 @@
         </div>
 
         <div class="property">
-            <div class="label">Href</div>
+            <div class="label">Href - Hifi://address</div>
             <div class="value">
                 <input id="property-hyperlink-href" class="url">
             </div>

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -812,6 +812,14 @@ void EntityItem::setMass(float mass) {
     }
 }
 
+void EntityItem::setHref(QString value) {
+    auto href = value.toLower();
+    if (! (value.toLower().startsWith("hifi://")) ) {
+        return;
+    }
+    _href = value;
+}
+
 void EntityItem::simulate(const quint64& now) {
     if (_lastSimulated == 0) {
         _lastSimulated = now;

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -172,7 +172,7 @@ public:
 
     // Hyperlink related getters and setters
     QString getHref() const { return _href; }
-    void setHref(QString value) { _href = value; }
+    void setHref(QString value);
 
     QString getDescription() const { return _description; }
     void setDescription(QString value) { _description = value; }


### PR DESCRIPTION
Previously it was possible to put a non-hifi address in for the href property of an entity.  With this PR, only hifi:// protocol is allowed.

To test:
1.Create a box using edit.js
2. View its properties
3. In href, enter "http://www.google.com"
4. Observe the change doesn't stick
5. In href, enter "hifi://sandbox"
6. click the entity and observe being teleported to sandbox

Fixes bug: https://app.asana.com/0/31759584831097/80715240133036