### PR TITLE
Small QML Fixes

### DIFF
--- a/interface/resources/qml/controls/ComboBox.qml
+++ b/interface/resources/qml/controls/ComboBox.qml
@@ -91,8 +91,10 @@ FocusScope {
         id: popup
         parent: desktop
         anchors.fill: parent
+        z: desktop.zLevels.menu
         visible: false
         focus: true
+
         MouseArea {
             anchors.fill: parent
             onClicked: hideList();
@@ -116,7 +118,7 @@ FocusScope {
 
             ListView {
                 id: listView
-                height: textView.height * count
+                height: textField.height * count * 1.4
                 model: root.model
                 highlight: Rectangle{
                     width: listView.currentItem ? listView.currentItem.width : 0

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -252,9 +252,9 @@ FocusScope {
         return messageDialogBuilder.createObject(desktop, properties);
     }
 
-    Component { id: queryDialogBuilder; QueryDialog { } }
-    function queryBox(properties) {
-        return queryDialogBuilder.createObject(desktop, properties);
+    Component { id: inputDialogBuilder; QueryDialog { } }
+    function inputDialog(properties) {
+        return inputDialogBuilder.createObject(desktop, properties);
     }
 
     Component { id: fileDialogBuilder; FileDialog { } }

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -257,6 +257,12 @@ FocusScope {
         return queryDialogBuilder.createObject(desktop, properties);
     }
 
+    Component { id: fileDialogBuilder; FileDialog { } }
+    function fileOpenDialog(properties) {
+        return fileDialogBuilder.createObject(desktop, properties);
+    }
+
+
     MenuMouseHandler { id: menuPopperUpper }
     function popupMenu(point) {
         menuPopperUpper.popup(desktop, rootMenu.items, point);

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -12,6 +12,27 @@ import "fileDialog"
 //FIXME implement shortcuts for favorite location
 ModalWindow {
     id: root
+    resizable: true
+    width: 640
+    height: 480
+
+    Settings {
+        category: "FileDialog"
+        property alias width: root.width
+        property alias height: root.height
+        property alias x: root.x
+        property alias y: root.y
+    }
+
+
+    // Set from OffscreenUi::getOpenFile()
+    property alias caption: root.title;
+    // Set from OffscreenUi::getOpenFile()
+    property alias dir: model.folder;
+    // Set from OffscreenUi::getOpenFile()
+    property alias filter: selectionType.filtersString;
+    // Set from OffscreenUi::getOpenFile()
+    property int options; // <-- FIXME unused
 
     property bool selectDirectory: false;
     property bool showHidden: false;
@@ -19,17 +40,11 @@ ModalWindow {
     property bool multiSelect: false;
     // FIXME implement
     property bool saveDialog: false;
+    property var helper: fileDialogHelper
+    property alias model: fileTableView.model
 
     signal selectedFile(var file);
     signal canceled();
-    resizable: true
-    width: 640
-    height: 480
-
-    property var helper: fileDialogHelper
-    property alias model: fileTableView.model
-    property alias filterModel: selectionType.model
-    property alias folder: model.folder
 
     Rectangle {
         anchors.fill: parent
@@ -120,6 +135,7 @@ ModalWindow {
             onDoubleClicked: navigateToRow(row);
             model: FolderListModel {
                 id: model
+                nameFilters: selectionType.currentFilter
                 showDirsFirst: true
                 showDotAndDotDot: false
                 showFiles: !root.selectDirectory
@@ -157,12 +173,10 @@ ModalWindow {
             readOnly: true
         }
 
-        ComboBox {
+        FileTypeSelection {
             id: selectionType
             anchors { bottom: buttonRow.top; bottomMargin: 8; right: parent.right; rightMargin: 8; left: buttonRow.left }
             visible: !selectDirectory
-            model: ListModel { ListElement { text: "All Files (*.*)"; filter: "*.*" } }
-//            onCurrentIndexChanged: model.nameFilters = [ filterModel.get(currentIndex).filter ]
             KeyNavigation.left: fileTableView
             KeyNavigation.right: openButton
         }

--- a/interface/resources/qml/dialogs/MessageDialog.qml
+++ b/interface/resources/qml/dialogs/MessageDialog.qml
@@ -5,6 +5,7 @@ import QtQuick.Dialogs 1.2 as OriginalDialogs
 import "../controls"
 import "../styles"
 import "../windows"
+import "messageDialog"
 
 // FIXME respect default button functionality
 ModalWindow {
@@ -126,126 +127,23 @@ ModalWindow {
             onHeightChanged: d.resize(); onWidthChanged: d.resize();
             layoutDirection: Qt.RightToLeft
             anchors { bottom: details.top; right: parent.right; margins: d.spacing * 2; bottomMargin: 0 }
-            Button {
-                id: okButton
-                text: qsTr("OK")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Ok
-                onClicked: root.click(OriginalDialogs.StandardButton.Ok)
-                visible: root.buttons & OriginalDialogs.StandardButton.Ok
-
-            }
-            Button {
-                id: openButton
-                text: qsTr("Open")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Open
-                onClicked: root.click(OriginalDialogs.StandardButton.Open)
-                visible: root.buttons & OriginalDialogs.StandardButton.Open
-            }
-            Button {
-                id: saveButton
-                text: qsTr("Save")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Save
-                onClicked: root.click(OriginalDialogs.StandardButton.Save)
-                visible: root.buttons & OriginalDialogs.StandardButton.Save
-            }
-            Button {
-                id: saveAllButton
-                text: qsTr("Save All")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.SaveAll
-                onClicked: root.click(OriginalDialogs.StandardButton.SaveAll)
-                visible: root.buttons & OriginalDialogs.StandardButton.SaveAll
-            }
-            Button {
-                id: retryButton
-                text: qsTr("Retry")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Retry
-                onClicked: root.click(OriginalDialogs.StandardButton.Retry)
-                visible: root.buttons & OriginalDialogs.StandardButton.Retry
-            }
-            Button {
-                id: ignoreButton
-                text: qsTr("Ignore")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Ignore
-                onClicked: root.click(OriginalDialogs.StandardButton.Ignore)
-                visible: root.buttons & OriginalDialogs.StandardButton.Ignore
-            }
-            Button {
-                id: applyButton
-                text: qsTr("Apply")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Apply
-                onClicked: root.click(OriginalDialogs.StandardButton.Apply)
-                visible: root.buttons & OriginalDialogs.StandardButton.Apply
-            }
-            Button {
-                id: yesButton
-                text: qsTr("Yes")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Yes
-                onClicked: root.click(OriginalDialogs.StandardButton.Yes)
-                visible: root.buttons & OriginalDialogs.StandardButton.Yes
-            }
-            Button {
-                id: yesAllButton
-                text: qsTr("Yes to All")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.YesToAll
-                onClicked: root.click(OriginalDialogs.StandardButton.YesToAll)
-                visible: root.buttons & OriginalDialogs.StandardButton.YesToAll
-            }
-            Button {
-                id: noButton
-                text: qsTr("No")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.No
-                onClicked: root.click(OriginalDialogs.StandardButton.No)
-                visible: root.buttons & OriginalDialogs.StandardButton.No
-            }
-            Button {
-                id: noAllButton
-                text: qsTr("No to All")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.NoToAll
-                onClicked: root.click(OriginalDialogs.StandardButton.NoToAll)
-                visible: root.buttons & OriginalDialogs.StandardButton.NoToAll
-            }
-            Button {
-                id: discardButton
-                text: qsTr("Discard")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Discard
-                onClicked: root.click(OriginalDialogs.StandardButton.Discard)
-                visible: root.buttons & OriginalDialogs.StandardButton.Discard
-            }
-            Button {
-                id: resetButton
-                text: qsTr("Reset")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Reset
-                onClicked: root.click(OriginalDialogs.StandardButton.Reset)
-                visible: root.buttons & OriginalDialogs.StandardButton.Reset
-            }
-            Button {
-                id: restoreDefaultsButton
-                text: qsTr("Restore Defaults")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.RestoreDefaults
-                onClicked: root.click(OriginalDialogs.StandardButton.RestoreDefaults)
-                visible: root.buttons & OriginalDialogs.StandardButton.RestoreDefaults
-            }
-            Button {
-                id: cancelButton
-                text: qsTr("Cancel")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Cancel
-                onClicked: root.click(OriginalDialogs.StandardButton.Cancel)
-                visible: root.buttons & OriginalDialogs.StandardButton.Cancel
-            }
-            Button {
-                id: abortButton
-                text: qsTr("Abort")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Abort
-                onClicked: root.click(OriginalDialogs.StandardButton.Abort)
-                visible: root.buttons & OriginalDialogs.StandardButton.Abort
-            }
-            Button {
-                id: closeButton
-                text: qsTr("Close")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Close
-                onClicked: root.click(OriginalDialogs.StandardButton.Close)
-                visible: root.buttons & OriginalDialogs.StandardButton.Close
-            }
+            MessageDialogButton { dialog: root; text: qsTr("OK"); button: OriginalDialogs.StandardButton.Ok; }
+            MessageDialogButton { dialog: root; text: qsTr("Open"); button: OriginalDialogs.StandardButton.Open; }
+            MessageDialogButton { dialog: root; text: qsTr("Save"); button: OriginalDialogs.StandardButton.Save; }
+            MessageDialogButton { dialog: root; text: qsTr("Save All"); button: OriginalDialogs.StandardButton.SaveAll; }
+            MessageDialogButton { dialog: root; text: qsTr("Retry"); button: OriginalDialogs.StandardButton.Retry; }
+            MessageDialogButton { dialog: root; text: qsTr("Ignore"); button: OriginalDialogs.StandardButton.Ignore; }
+            MessageDialogButton { dialog: root; text: qsTr("Apply"); button: OriginalDialogs.StandardButton.Apply; }
+            MessageDialogButton { dialog: root; text: qsTr("Yes"); button: OriginalDialogs.StandardButton.Yes; }
+            MessageDialogButton { dialog: root; text: qsTr("Yes to All"); button: OriginalDialogs.StandardButton.YesToAll; }
+            MessageDialogButton { dialog: root; text: qsTr("No"); button: OriginalDialogs.StandardButton.No; }
+            MessageDialogButton { dialog: root; text: qsTr("No to All"); button: OriginalDialogs.StandardButton.NoToAll; }
+            MessageDialogButton { dialog: root; text: qsTr("Discard"); button: OriginalDialogs.StandardButton.Discard; }
+            MessageDialogButton { dialog: root; text: qsTr("Reset"); button: OriginalDialogs.StandardButton.Reset; }
+            MessageDialogButton { dialog: root; text: qsTr("Restore Defaults"); button: OriginalDialogs.StandardButton.RestoreDefaults; }
+            MessageDialogButton { dialog: root; text: qsTr("Cancel"); button: OriginalDialogs.StandardButton.Cancel; }
+            MessageDialogButton { dialog: root; text: qsTr("Abort"); button: OriginalDialogs.StandardButton.Abort; }
+            MessageDialogButton { dialog: root; text: qsTr("Close"); button: OriginalDialogs.StandardButton.Close; }
             Button {
                 id: moreButton
                 text: qsTr("Show Details...")
@@ -253,13 +151,7 @@ ModalWindow {
                 }
                 visible: detailedText && detailedText.length > 0
             }
-            Button {
-                id: helpButton
-                text: qsTr("Help")
-                focus: root.defaultButton === OriginalDialogs.StandardButton.Help
-                onClicked: root.click(OriginalDialogs.StandardButton.Help)
-                visible: root.buttons & OriginalDialogs.StandardButton.Help
-            }
+            MessageDialogButton { dialog: root; text: qsTr("Help"); button: OriginalDialogs.StandardButton.Help; }
         }
 
         Item {
@@ -328,7 +220,7 @@ ModalWindow {
             case Qt.Key_Enter:
             case Qt.Key_Return:
                 event.accepted = true
-                root.click(OriginalDialogs.StandardButton.Ok)
+                root.click(root.defaultButton)
                 break
         }
     }

--- a/interface/resources/qml/dialogs/QueryDialog.qml
+++ b/interface/resources/qml/dialogs/QueryDialog.qml
@@ -16,9 +16,17 @@ ModalWindow {
     signal selected(var result);
     signal canceled();
 
-    property alias result: textResult.text
+    property var items;
+    property alias label: mainTextContainer.text
+    property var result;
+    // FIXME not current honored
+    property var current;
+
+    // For text boxes
     property alias placeholderText: textResult.placeholderText
-    property alias text: mainTextContainer.text
+
+    // For combo boxes
+    property bool editable: true;
 
     Rectangle {
         clip: true
@@ -55,10 +63,20 @@ ModalWindow {
             anchors { top: mainTextContainer.bottom; bottom: buttons.top; left: parent.left; right: parent.right; margins: d.spacing }
             // FIXME make a text field type that can be bound to a history for autocompletion
             TextField {
-                focus: true
                 id: textResult
+                focus: items ? false : true
+                visible: items ? false : true
                 anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter }
             }
+
+            VrControls.ComboBox {
+                id: comboBox
+                focus: items ? true : false
+                visible: items ? true : false
+                anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter }
+                model: items ? items : []
+            }
+
         }
 
         Flow {
@@ -86,6 +104,7 @@ ModalWindow {
             text: qsTr("OK")
             shortcut: Qt.Key_Return
             onTriggered: {
+                root.result = items ? comboBox.currentText : textResult.text
                 root.selected(root.result);
                 root.destroy();
             }

--- a/interface/resources/qml/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/dialogs/RunningScripts.qml
@@ -123,26 +123,42 @@ Window {
                 }
 
                 ListView {
+                    id: listView
                     clip: true
                     anchors { fill: parent; margins: 0 }
 
                     model: runningScriptsModel
 
                     delegate: Rectangle {
+                        id: rectangle
+                        clip: true
                         radius: 3
                         anchors { left: parent.left; right: parent.right }
 
-                        height: scriptName.height + 12
-                        color: index % 2 ? "#ddd" : "#eee"
+                        height: scriptName.height + 12 + (ListView.isCurrentItem ? scriptName.height + 6 : 0)
+                        color: ListView.isCurrentItem ? "#39f" :
+                                   index % 2 ? "#ddd" : "#eee"
 
                         Text {
-                            anchors { left: parent.left; leftMargin: 4; verticalCenter: parent.verticalCenter }
                             id: scriptName
+                            anchors { left: parent.left; leftMargin: 4; top: parent.top; topMargin:6 }
                             text: name
                         }
 
+                        Text {
+                            id: scriptUrl
+                            anchors { left: scriptName.left; right: parent.right; rightMargin: 4; top: scriptName.bottom; topMargin: 6 }
+                            text: url
+                            elide: Text.ElideMiddle
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: listView.currentIndex = index
+                        }
+
                         Row {
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.verticalCenter: scriptName.verticalCenter
                             anchors.right: parent.right
                             anchors.rightMargin: 4
                             spacing: 4

--- a/interface/resources/qml/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/dialogs/RunningScripts.qml
@@ -72,23 +72,6 @@ Window {
         scripts.stopAllScripts();
     }
 
-    Component {
-        id: fileDialogBuilder
-        FileDialog { }
-    }
-
-    function loadFromFile() {
-        var fileDialog = fileDialogBuilder.createObject(desktop, { filterModel: fileFilters });
-        fileDialog.canceled.connect(function(){
-            console.debug("Cancelled file open")
-        })
-
-        fileDialog.selectedFile.connect(function(file){
-            console.debug("Selected " + file)
-            scripts.loadOneScript(file);
-        })
-    }
-
     Rectangle {
         color: "white"
         anchors.fill: parent
@@ -201,31 +184,38 @@ Window {
                 anchors.bottomMargin: 8
                 anchors.right: parent.right
 
-                // For some reason trigginer an API that enters
-                // an internal event loop directly from the button clicked
-                // trigger below causes the appliction to behave oddly.
-                // Most likely because the button onClicked handling is never
-                // completed until the function returns.
-                // FIXME find a better way of handling the input dialogs that
-                // doesn't trigger this.
-                Timer {
-                    id: asyncAction
-                    interval: 50
-                    repeat: false
-                    running: false
-                    onTriggered: ApplicationInterface.loadScriptURLDialog();
-                }
 
                 Button {
                     text: "from URL";
-                    onClicked: {
-                        focus = false;
-                        asyncAction.running = true;
+                    onClicked: fromUrlTimer.running = true;
+
+                    // For some reason trigginer an API that enters
+                    // an internal event loop directly from the button clicked
+                    // trigger below causes the appliction to behave oddly.
+                    // Most likely because the button onClicked handling is never
+                    // completed until the function returns.
+                    // FIXME find a better way of handling the input dialogs that
+                    // doesn't trigger this.
+                    Timer {
+                        id: fromUrlTimer
+                        interval: 5
+                        repeat: false
+                        running: false
+                        onTriggered: ApplicationInterface.loadScriptURLDialog();
                     }
                 }
+
                 Button {
                     text: "from Disk"
-                    onClicked: loadFromFile();
+                    onClicked: fromDiskTimer.running = true;
+
+                    Timer {
+                        id: fromDiskTimer
+                        interval: 5
+                        repeat: false
+                        running: false
+                        onTriggered: ApplicationInterface.loadDialog();
+                    }
                 }
             }
 

--- a/interface/resources/qml/dialogs/fileDialog/FileTypeSelection.qml
+++ b/interface/resources/qml/dialogs/fileDialog/FileTypeSelection.qml
@@ -1,0 +1,27 @@
+import QtQuick 2.5
+
+import "../../controls" as VrControls
+
+VrControls.ComboBox {
+    id: root
+    property string filtersString:  "All Files (*.*)";
+    property var currentFilter: [ "*.*" ];
+
+    // Per http://doc.qt.io/qt-5/qfiledialog.html#getOpenFileName the string can contain
+    // multiple filters separated by semicolons
+    // ex:  "Images (*.png *.xpm *.jpg);;Text files (*.txt);;XML files (*.xml)"
+    model: filtersString.split(';;');
+
+    enabled: model.length > 1
+
+    onCurrentTextChanged: {
+        var globRegex = /\((.*)\)$/
+        var globs = globRegex.exec(currentText);
+        if (!globs[1]) {
+            console.warn("Unable to parse filter " + currentText);
+            return;
+        }
+        currentFilter = globs[1].split(" ");
+    }
+}
+

--- a/interface/resources/qml/dialogs/messageDialog/MessageDialogButton.qml
+++ b/interface/resources/qml/dialogs/messageDialog/MessageDialogButton.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.5
+import QtQuick.Controls 1.2
+import QtQuick.Dialogs 1.2
+
+Button {
+    property var dialog;
+    property int button: StandardButton.NoButton;
+
+    focus: dialog.defaultButton === button
+    onClicked: dialog.click(button)
+    visible: dialog.buttons & button
+}

--- a/interface/resources/qml/windows/DefaultFrame.qml
+++ b/interface/resources/qml/windows/DefaultFrame.qml
@@ -20,12 +20,8 @@ Frame {
 
         Row {
             id: controlsRow
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.rightMargin: iconSize
-            anchors.topMargin: iconSize / 2
+            anchors { right: parent.right; top: parent.top; rightMargin: iconSize; topMargin: iconSize / 2; }
             spacing: iconSize / 4
-
             FontAwesome {
                 visible: false
                 text: "\uf08d"
@@ -54,6 +50,18 @@ Frame {
                 }
             }
         }
+
+        Text {
+            id: titleText
+            anchors { left: parent.left; leftMargin: iconSize; right: controlsRow.left;  rightMargin: iconSize; top: parent.top; topMargin: iconSize / 2; }
+            text: window.title
+            elide: Text.ElideRight
+            font.bold: true
+            color: window.focus ? "white" : "gray"
+            style: Text.Outline;
+            styleColor: "black"
+        }
     }
+
 }
 

--- a/interface/resources/qml/windows/Frame.qml
+++ b/interface/resources/qml/windows/Frame.qml
@@ -25,7 +25,7 @@ Item {
         id: debugZ
         visible: DebugQML
         text: window ? "Z: " + window.z : ""
-        y: -height
+        y: window.height + 4
     }
 
     function deltaSize(dx, dy) {

--- a/interface/resources/qml/windows/ModalFrame.qml
+++ b/interface/resources/qml/windows/ModalFrame.qml
@@ -13,5 +13,16 @@ Frame {
         color: "#7f7f7f7f";
         radius: 3;
     }
+
+    Text {
+        y: -implicitHeight - iconSize / 2
+        text: window.title
+        elide: Text.ElideRight
+        font.bold: true
+        color: window.focus ? "white" : "gray"
+        style: Text.Outline;
+        styleColor: "black"
+    }
+
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -406,6 +406,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     _entityClipboard(new EntityTree()),
     _lastQueriedTime(usecTimestampNow()),
     _mirrorViewRect(QRect(MIRROR_VIEW_LEFT_PADDING, MIRROR_VIEW_TOP_PADDING, MIRROR_VIEW_WIDTH, MIRROR_VIEW_HEIGHT)),
+    _previousScriptLocation("LastScriptLocation", DESKTOP_LOCATION),
     _fieldOfView("fieldOfView", DEFAULT_FIELD_OF_VIEW_DEGREES),
     _scaleMirror(1.0f),
     _rotateMirror(0.0f),
@@ -416,8 +417,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     _aboutToQuit(false),
     _notifiedPacketVersionMismatchThisDomain(false),
     _maxOctreePPS(maxOctreePacketsPerSecond.get()),
-    _lastFaceTrackerUpdate(0),
-    _previousScriptLocation("LastScriptLocation", DESKTOP_LOCATION)
+    _lastFaceTrackerUpdate(0)
 {
     thread()->setObjectName("Main Thread");
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -103,6 +103,9 @@ public:
 
     void postLambdaEvent(std::function<void()> f) override;
 
+    QString getPreviousScriptLocation();
+    void setPreviousScriptLocation(const QString& previousScriptLocation);
+
     void initializeGL();
     void initializeUi();
     void paintGL();
@@ -431,6 +434,7 @@ private:
     Camera _mirrorCamera;                        // Cammera for mirror view
     QRect _mirrorViewRect;
 
+    Setting::Handle<QString> _previousScriptLocation;
     Setting::Handle<float> _fieldOfView;
 
     float _scaleMirror;

--- a/interface/src/Bookmarks.cpp
+++ b/interface/src/Bookmarks.cpp
@@ -20,12 +20,14 @@
 
 #include <AddressManager.h>
 #include <Application.h>
+#include <OffscreenUi.h>
 
 #include "MainWindow.h"
 #include "Menu.h"
 #include "InterfaceLogging.h"
 
 #include "Bookmarks.h"
+#include <QtQuick/QQuickWindow>
 
 Bookmarks::Bookmarks() {
     _bookmarksFilename = QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/" + BOOKMARKS_FILENAME;
@@ -104,18 +106,13 @@ void Bookmarks::setupMenus(Menu* menubar, MenuWrapper* menu) {
 }
 
 void Bookmarks::bookmarkLocation() {
-    QInputDialog bookmarkLocationDialog(qApp->getWindow());
-    bookmarkLocationDialog.setWindowTitle("Bookmark Location");
-    bookmarkLocationDialog.setLabelText("Name:");
-    bookmarkLocationDialog.setInputMode(QInputDialog::TextInput);
-    bookmarkLocationDialog.resize(400, 200);
-    
-    if (bookmarkLocationDialog.exec() == QDialog::Rejected) {
+    bool ok = false;
+    auto bookmarkName = OffscreenUi::getText(nullptr, "Bookmark Location", "Name:", QLineEdit::Normal, QString(), &ok);
+    if (!ok) {
         return;
     }
     
-    QString bookmarkName = bookmarkLocationDialog.textValue().trimmed();
-    bookmarkName = bookmarkName.replace(QRegExp("(\r\n|[\r\n\t\v ])+"), " ");
+    bookmarkName = bookmarkName.trimmed().replace(QRegExp("(\r\n|[\r\n\t\v ])+"), " ");
     if (bookmarkName.length() == 0) {
         return;
     }
@@ -125,13 +122,14 @@ void Bookmarks::bookmarkLocation() {
     
     Menu* menubar = Menu::getInstance();
     if (contains(bookmarkName)) {
-        QMessageBox duplicateBookmarkMessage;
-        duplicateBookmarkMessage.setIcon(QMessageBox::Warning);
-        duplicateBookmarkMessage.setText("The bookmark name you entered already exists in your list.");
-        duplicateBookmarkMessage.setInformativeText("Would you like to overwrite it?");
-        duplicateBookmarkMessage.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        duplicateBookmarkMessage.setDefaultButton(QMessageBox::Yes);
-        if (duplicateBookmarkMessage.exec() == QMessageBox::No) {
+        auto offscreenUi = DependencyManager::get<OffscreenUi>();
+        auto duplicateBookmarkMessage = offscreenUi->createMessageBox(QMessageBox::Warning, "Duplicate Bookmark",
+            "The bookmark name you entered already exists in your list.",
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        duplicateBookmarkMessage->setProperty("informativeText", "Would you like to overwrite it?");
+
+        auto result = offscreenUi->waitForMessageBoxResult(duplicateBookmarkMessage);
+        if (result != QMessageBox::Yes) {
             return;
         }
         removeLocationFromMenu(menubar, bookmarkName);
@@ -157,19 +155,13 @@ void Bookmarks::deleteBookmark() {
         bookmarkList.append(menuItems[i]->text());
     }
     
-    QInputDialog deleteBookmarkDialog(qApp->getWindow());
-    deleteBookmarkDialog.setWindowTitle("Delete Bookmark");
-    deleteBookmarkDialog.setLabelText("Select the bookmark to delete");
-    deleteBookmarkDialog.resize(400, 400);
-    deleteBookmarkDialog.setOption(QInputDialog::UseListViewForComboBoxItems);
-    deleteBookmarkDialog.setComboBoxItems(bookmarkList);
-    deleteBookmarkDialog.setOkButtonText("Delete");
-    
-    if (deleteBookmarkDialog.exec() == QDialog::Rejected) {
+    bool ok = false;
+    auto bookmarkName = OffscreenUi::getItem(nullptr, "Delete Bookmark", "Select the bookmark to delete", bookmarkList, 0, false, &ok);
+    if (!ok) {
         return;
     }
     
-    QString bookmarkName = deleteBookmarkDialog.textValue().trimmed();
+    bookmarkName = bookmarkName.trimmed();
     if (bookmarkName.length() == 0) {
         return;
     }

--- a/interface/src/ui/ScriptEditorWidget.cpp
+++ b/interface/src/ui/ScriptEditorWidget.cpp
@@ -191,10 +191,10 @@ bool ScriptEditorWidget::save() {
 bool ScriptEditorWidget::saveAs() {
     auto scriptEngines = DependencyManager::get<ScriptEngines>();
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save script"),
-                                                    scriptEngines->getPreviousScriptLocation(),
+                                                    qApp->getPreviousScriptLocation(),
                                                     tr("JavaScript Files (*.js)"));
     if (!fileName.isEmpty()) {
-        scriptEngines->setPreviousScriptLocation(fileName);
+        qApp->setPreviousScriptLocation(fileName);
         return saveFile(fileName);
     } else {
         return false;

--- a/interface/src/ui/ScriptEditorWindow.cpp
+++ b/interface/src/ui/ScriptEditorWindow.cpp
@@ -87,12 +87,11 @@ void ScriptEditorWindow::loadScriptMenu(const QString& scriptName) {
 }
 
 void ScriptEditorWindow::loadScriptClicked() {
-    auto scriptEngines = DependencyManager::get<ScriptEngines>();
     QString scriptName = QFileDialog::getOpenFileName(this, tr("Interface"),
-                                                      scriptEngines->getPreviousScriptLocation(),
+                                                      qApp->getPreviousScriptLocation(),
                                                       tr("JavaScript Files (*.js)"));
     if (!scriptName.isEmpty()) {
-        scriptEngines->setPreviousScriptLocation(scriptName);
+        qApp->setPreviousScriptLocation(scriptName);
         addScriptEditorWidget("loading...")->loadFile(scriptName);
         updateButtons();
     }
@@ -100,7 +99,7 @@ void ScriptEditorWindow::loadScriptClicked() {
 
 void ScriptEditorWindow::loadMenuAboutToShow() {
     _loadMenu->clear();
-    QStringList runningScripts = DependencyManager::get<ScriptEngines>()->getRunningScripts();;
+    QStringList runningScripts = DependencyManager::get<ScriptEngines>()->getRunningScripts();
     if (runningScripts.count() > 0) {
         QSignalMapper* signalMapper = new QSignalMapper(this);
         foreach (const QString& runningScript, runningScripts) {

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -34,8 +34,7 @@ ScriptsModel& getScriptsModel() {
 }
 
 ScriptEngines::ScriptEngines()
-    : _scriptsLocationHandle("scriptsLocation", DESKTOP_LOCATION),
-      _previousScriptLocation("LastScriptLocation", DESKTOP_LOCATION)
+    : _scriptsLocationHandle("scriptsLocation", DESKTOP_LOCATION)
 {
     _scriptsModelFilter.setSourceModel(&_scriptsModel);
     _scriptsModelFilter.sort(0, Qt::AscendingOrder);
@@ -444,15 +443,4 @@ void ScriptEngines::onScriptFinished(const QString& rawScriptUrl, ScriptEngine* 
 void ScriptEngines::onScriptEngineError(const QString& scriptFilename) {
     qCDebug(scriptengine) << "Application::loadScript(), script failed to load...";
     emit scriptLoadError(scriptFilename, "");
-}
-
-QString ScriptEngines::getPreviousScriptLocation() const {
-    return _previousScriptLocation.get();
-}
-
-void ScriptEngines::setPreviousScriptLocation(const QString& previousScriptLocation) {
-    if (_previousScriptLocation.get() != previousScriptLocation) {
-        _previousScriptLocation.set(previousScriptLocation);
-        emit previousScriptLocationChanged();
-    }
 }

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -30,7 +30,6 @@ class ScriptEngines : public QObject, public Dependency {
 
     Q_PROPERTY(ScriptsModel* scriptsModel READ scriptsModel CONSTANT)
     Q_PROPERTY(ScriptsModelFilter* scriptsModelFilter READ scriptsModelFilter CONSTANT)
-    Q_PROPERTY(QString previousScriptLocation READ getPreviousScriptLocation WRITE setPreviousScriptLocation NOTIFY previousScriptLocationChanged)
 
 public:
     using ScriptInitializer = std::function<void(ScriptEngine*)>;
@@ -47,9 +46,6 @@ public:
     void setScriptsLocation(const QString& scriptsLocation);
     QStringList getRunningScripts();
     ScriptEngine* getScriptEngine(const QString& scriptHash);
-
-    QString getPreviousScriptLocation() const;
-    void setPreviousScriptLocation(const QString& previousScriptLocation);
 
     ScriptsModel* scriptsModel() { return &_scriptsModel; };
     ScriptsModelFilter* scriptsModelFilter() { return &_scriptsModelFilter; };
@@ -73,7 +69,6 @@ signals:
     void scriptCountChanged();
     void scriptsReloading();
     void scriptLoadError(const QString& filename, const QString& error);
-    void previousScriptLocationChanged();
 
 protected slots: 
     void onScriptFinished(const QString& fileNameString, ScriptEngine* engine);
@@ -97,7 +92,6 @@ protected:
     std::atomic<bool> _stoppingAllScripts { false };
     std::list<ScriptInitializer> _scriptInitializers;
     mutable Setting::Handle<QString> _scriptsLocationHandle;
-    mutable Setting::Handle<QString> _previousScriptLocation;
     ScriptsModel _scriptsModel;
     ScriptsModelFilter _scriptsModelFilter;
 };

--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -42,6 +42,13 @@ public:
     QQuickItem* getToolWindow();
 
 
+    // Message box compatibility
+    Q_INVOKABLE QMessageBox::StandardButton messageBox(QMessageBox::Icon icon, const QString& title, const QString& text, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton);
+    // Must be called from the main thread
+    QQuickItem* createMessageBox(QMessageBox::Icon icon, const QString& title, const QString& text, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton);
+    // Must be called from the main thread
+    QMessageBox::StandardButton waitForMessageBoxResult(QQuickItem* messageBox);
+
     /// Same design as QMessageBox::critical(), will block, returns result
     static QMessageBox::StandardButton critical(void* ignored, const QString& title, const QString& text,
         QMessageBox::StandardButtons buttons = QMessageBox::Ok,
@@ -80,18 +87,21 @@ public:
         QMessageBox::StandardButtons buttons = QMessageBox::Ok,
         QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
 
-    Q_INVOKABLE QMessageBox::StandardButton messageBox(QMessageBox::Icon icon, const QString& title, const QString& text, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton);
-    Q_INVOKABLE QVariant inputDialog(const QString& query, const QString& placeholderText = QString(), const QString& currentValue = QString());
+    // file dialog compatibility
     Q_INVOKABLE QString fileOpenDialog(const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
-
-    // FIXME implement
-    static QVariant query(const QString& query, const QString& placeholderText = QString(), const QString& currentValue = QString());
-
     // Compatibility with QFileDialog::getOpenFileName
     static QString getOpenFileName(void* ignored, const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
 
+
+    // input dialog compatibility
+    Q_INVOKABLE QVariant inputDialog(const QString& title, const QString& label = QString(), const QVariant& current = QVariant());
+    QQuickItem* createInputDialog(const QString& title, const QString& label, const QVariant& current);
+    QVariant waitForInputDialogResult(QQuickItem* inputDialog);
+
     // Compatibility with QInputDialog::getText
     static QString getText(void* ignored, const QString & title, const QString & label, QLineEdit::EchoMode mode = QLineEdit::Normal, const QString & text = QString(), bool * ok = 0, Qt::WindowFlags flags = 0, Qt::InputMethodHints inputMethodHints = Qt::ImhNone);
+    // Compatibility with QInputDialog::getItem
+    static QString getItem(void *ignored, const QString & title, const QString & label, const QStringList & items, int current = 0, bool editable = true, bool * ok = 0, Qt::WindowFlags flags = 0, Qt::InputMethodHints inputMethodHints = Qt::ImhNone);
 
 private:
     QQuickItem* _desktop { nullptr };

--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -82,11 +82,11 @@ public:
 
     Q_INVOKABLE QMessageBox::StandardButton messageBox(QMessageBox::Icon icon, const QString& title, const QString& text, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton);
     Q_INVOKABLE QVariant inputDialog(const QString& query, const QString& placeholderText = QString(), const QString& currentValue = QString());
+    Q_INVOKABLE QString fileOpenDialog(const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
 
     // FIXME implement
     static QVariant query(const QString& query, const QString& placeholderText = QString(), const QString& currentValue = QString());
 
-    // FIXME implement
     // Compatibility with QFileDialog::getOpenFileName
     static QString getOpenFileName(void* ignored, const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
 

--- a/tests/ui/qmlscratch.pro
+++ b/tests/ui/qmlscratch.pro
@@ -21,6 +21,7 @@ DISTFILES += \
     ../../interface/resources/qml/dialogs/*.qml \
     ../../interface/resources/qml/dialogs/fileDialog/*.qml \
     ../../interface/resources/qml/dialogs/preferences/*.qml \
+    ../../interface/resources/qml/dialogs/messageDialog/*.qml \
     ../../interface/resources/qml/desktop/*.qml \
     ../../interface/resources/qml/menus/*.qml \
     ../../interface/resources/qml/styles/*.qml \


### PR DESCRIPTION
* [Running scripts now show the script URL when selected](https://app.asana.com/0/search/84807451681006/80772566277353)
* [persist the directory used when loading a script with a file dialog](https://app.asana.com/0/27650181942747/85195408116250)
* [Support an API compatible with `QFileDialog::getOpenFile` that functions in the HMD](https://app.asana.com/0/27650181942747/85269468410420)
* [Make HMD compatible combo boxes work in modal dialogs](https://app.asana.com/0/27650181942747/85269468410418)
* [Make the Ctrl-O load script dialog HMD compatible](https://app.asana.com/0/27650181942747/84807451681012)
* [Add title text to windows](https://app.asana.com/0/26225263936266/85074795603221)
* [Move bookmark popup dialogs to QML](https://app.asana.com/0/27650181942747/85281972770184)