### PR TITLE
Fix for Bow and Arrow Not Re-enabling Hands At Unequip

### DIFF
--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -816,7 +816,21 @@ function MyController(hand) {
                 direction: pickRay.direction
             };
 
-            Messages.sendMessage('Hifi-Light-Overlay-Ray-Check', JSON.stringify(pickRayBacked));
+            //we need to trim the size of this message a bit right now.
+            var modifiedPickRayBacked = {
+                origin:{
+                    x:  parseFloat(pickRayBacked.origin.x.toFixed(2)),
+                    y:  parseFloat(pickRayBacked.origin.y.toFixed(2)),
+                    z:  parseFloat(pickRayBacked.origin.z.toFixed(2))
+                },
+                 direction:{
+                    x:  parseFloat(pickRayBacked.direction.x.toFixed(2)),
+                    y:  parseFloat(pickRayBacked.direction.y.toFixed(2)),
+                    z:  parseFloat(pickRayBacked.direction.z.toFixed(2))
+                }
+            }
+
+            Messages.sendMessage('Hifi-Light-Overlay-Ray-Check', JSON.stringify(modifiedPickRayBacked));
 
             var intersection;
 


### PR DESCRIPTION
Previously, equipping the bow and arrow would result in one of your hands becoming permanently disabled.  Now, you can use the bow and arrow and have your hands function normally.

To test:
1. Make a bow with /toybox/createBow.js
2. Equip it
3. Unequip
4. Try to grab other things

With the master handControllerGrab.js, one of your hands will quit working.  You will not see a grab beam for this hand.

With this script, your hands will continue to function as normal.  
https://rawgit.com/imgntn/hifi/bowandarrowfixjan29/examples/controllers/handControllerGrab.js

https://app.asana.com/0/46580934041217/82053018733923