### PR TITLE
Remove high frequency messages from grab script

### DIFF
--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -817,8 +817,6 @@ function MyController(hand) {
                 direction: pickRay.direction
             };
 
-            Messages.sendMessage('Hifi-Light-Overlay-Ray-Check', JSON.stringify(pickRayBacked));
-
             var intersection;
 
             if (USE_BLACKLIST === true && blacklist.length !== 0) {
@@ -1341,12 +1339,6 @@ function MyController(hand) {
             Entities.callEntityMethod(this.grabbedEntity, "continueEquip");
         }
 
-        //// jbp::: SEND UPDATE MESSAGE TO WEARABLES MANAGER
-        Messages.sendMessage('Hifi-Wearables-Manager', JSON.stringify({
-            action: 'update',
-            grabbedEntity: this.grabbedEntity
-        }))
-
         if (this.actionID && this.actionTimeout - now < ACTION_TTL_REFRESH * MSEC_PER_SEC) {
             // if less than a 5 seconds left, refresh the actions ttl
             var success = Entities.updateAction(this.grabbedEntity, this.actionID, {
@@ -1614,8 +1606,6 @@ function MyController(hand) {
 
         this.actionID = null;
         this.setState(STATE_OFF);
-
-        //// jbp::: SEND RELEASE MESSAGE TO WEARABLES MANAGER
 
         Messages.sendMessage('Hifi-Wearables-Manager', JSON.stringify({
             action: 'checkIfWearable',

--- a/examples/light_modifier/README.md
+++ b/examples/light_modifier/README.md
@@ -1,3 +1,5 @@
+*Temporarily Deprecated - needs a better way to know when 'grab beams' intersect with 'light overlays'.  Sending messages containing the ray from the hand grab script to the overlay intersection test doesn't seem to be sustainable. *
+
 This PR demonstrates one way in-world editing of objects might work. 
 
 Running this script will show light overlay icons in-world.  Enter edit mode by running your distance beam through a light overlay.  Exit using the red X.


### PR DESCRIPTION
This PR removes high frequency messages from the grab script, pending a design meeting.   This returns the bow to functionality but will deprecate the light modifier script for now, which is noted in an update to its readme.

To test:  https://rawgit.com/imgntn/hifi/removeHighFreqMsg/examples/controllers/handControllerGrab.js

1. Run /toybox/createBow.js
2. Equip and unequip the bow.
3. Note that your hands and their grab beams remain functional.