### PR TITLE
Migrate stencil and overlay jobs to use plumbers

### DIFF
--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -4,7 +4,7 @@
 //  render-utils/src/
 //
 //  Created by Sam Gateau on 5/29/15.
-//  Copyright 20154 High Fidelity, Inc.
+//  Copyright 2016 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -15,7 +15,6 @@
 #include <RenderArgs.h>
 #include <ViewFrustum.h>
 #include <gpu/Context.h>
-#include <gpu/StandardShaderLib.h>
 
 #include "DebugDeferredBuffer.h"
 #include "DeferredLightingEffect.h"
@@ -31,34 +30,11 @@
 
 #include "RenderDeferredTask.h"
 
-#include "model_vert.h"
-#include "model_shadow_vert.h"
-#include "model_normal_map_vert.h"
-#include "model_lightmap_vert.h"
-#include "model_lightmap_normal_map_vert.h"
-#include "skin_model_vert.h"
-#include "skin_model_shadow_vert.h"
-#include "skin_model_normal_map_vert.h"
-
-#include "model_frag.h"
-#include "model_shadow_frag.h"
-#include "model_normal_map_frag.h"
-#include "model_normal_specular_map_frag.h"
-#include "model_specular_map_frag.h"
-#include "model_lightmap_frag.h"
-#include "model_lightmap_normal_map_frag.h"
-#include "model_lightmap_normal_specular_map_frag.h"
-#include "model_lightmap_specular_map_frag.h"
-#include "model_translucent_frag.h"
-
-#include "overlay3D_vert.h"
-#include "overlay3D_frag.h"
-
-#include "drawOpaqueStencil_frag.h"
-
 using namespace render;
 
-void initDeferredPipelines(render::ShapePlumber& plumber);
+extern void initOverlay3DPipelines(render::ShapePlumber& plumber);
+extern void initStencilPipelines(render::ShapePlumber& plumber);
+extern void initDeferredPipelines(render::ShapePlumber& plumber);
 
 void PrepareDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
     DependencyManager::get<DeferredLightingEffect>()->prepare(renderContext->args);
@@ -181,25 +157,7 @@ void DrawDeferred::run(const SceneContextPointer& sceneContext, const RenderCont
 }
 
 DrawOverlay3D::DrawOverlay3D() : _shapePlumber{ std::make_shared<ShapePlumber>() } {
-    auto vs = gpu::Shader::createVertex(std::string(overlay3D_vert));
-    auto ps = gpu::Shader::createPixel(std::string(overlay3D_frag));
-    auto program = gpu::Shader::createProgram(vs, ps);
-
-    auto opaqueState = std::make_shared<gpu::State>();
-    opaqueState->setDepthTest(false);
-    opaqueState->setBlendFunction(true,
-        // Additive blending
-        gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-
-    auto transparentState = std::make_shared<gpu::State>();
-    transparentState->setDepthTest(false);
-    transparentState->setBlendFunction(true,
-        // For transparency, keep the highlight intensity
-        gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
-        gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-
-    _shapePlumber->addPipeline(ShapeKey::Filter::Builder().withOpaque(), program, opaqueState);
-    _shapePlumber->addPipeline(ShapeKey::Filter::Builder().withTranslucent(), program, transparentState);
+    initOverlay3DPipelines(*_shapePlumber);
 }
 
 void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
@@ -260,18 +218,7 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
 }
 
 DrawStencilDeferred::DrawStencilDeferred() : _shapePlumber{ std::make_shared<ShapePlumber>() } {
-    const gpu::int8 STENCIL_OPAQUE = 1;
-    auto vs = gpu::StandardShaderLib::getDrawUnitQuadTexcoordVS();
-    auto ps = gpu::Shader::createPixel(std::string(drawOpaqueStencil_frag));
-    auto program = gpu::Shader::createProgram(vs, ps);
-    gpu::Shader::makeProgram((*program));
-
-    auto state = std::make_shared<gpu::State>();
-    state->setDepthTest(true, false, gpu::LESS_EQUAL);
-    state->setStencilTest(true, 0xFF, gpu::State::StencilTest(STENCIL_OPAQUE, 0xFF, gpu::ALWAYS, gpu::State::STENCIL_OP_REPLACE, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_REPLACE));
-    state->setColorWriteMask(0);
-
-    _shapePlumber->addPipeline(ShapeKey::Filter::Builder(), program, state);
+    initStencilPipelines(*_shapePlumber);
 }
 
 void DrawStencilDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
@@ -411,166 +358,3 @@ void Blit::run(const SceneContextPointer& sceneContext, const RenderContextPoint
         }
     });
 }
-
-void pipelineBatchSetter(const ShapePipeline& pipeline, gpu::Batch& batch) {
-    if (pipeline.locations->normalFittingMapUnit > -1) {
-        batch.setResourceTexture(pipeline.locations->normalFittingMapUnit,
-            DependencyManager::get<TextureCache>()->getNormalFittingTexture());
-    }
-}
-
-void initDeferredPipelines(render::ShapePlumber& plumber) {
-    using Key = render::ShapeKey;
-    using ShaderPointer = gpu::ShaderPointer;
-
-    auto addPipeline = [&plumber](const Key& key, const ShaderPointer& vertexShader, const ShaderPointer& pixelShader) {
-        auto state = std::make_shared<gpu::State>();
-
-        // Cull backface
-        state->setCullMode(gpu::State::CULL_BACK);
-
-        // Z test depends on transparency
-        state->setDepthTest(true, !key.isTranslucent(), gpu::LESS_EQUAL);
-
-        // Blend if transparent
-        state->setBlendFunction(key.isTranslucent(),
-            // For transparency, keep the highlight intensity
-            gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
-            gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-
-        ShaderPointer program = gpu::Shader::createProgram(vertexShader, pixelShader);
-        plumber.addPipeline(key, program, state, &pipelineBatchSetter);
-
-        // Add a wireframe version
-        if (!key.isWireFrame()) {
-            auto wireFrameKey = Key::Builder(key).withWireframe();
-            auto wireFrameState = std::make_shared<gpu::State>(state->getValues());
-
-            wireFrameState->setFillMode(gpu::State::FILL_LINE);
-
-            plumber.addPipeline(wireFrameKey, program, wireFrameState, &pipelineBatchSetter);
-        }
-    };
-
-    // Vertex shaders
-    auto modelVertex = gpu::Shader::createVertex(std::string(model_vert));
-    auto modelNormalMapVertex = gpu::Shader::createVertex(std::string(model_normal_map_vert));
-    auto modelLightmapVertex = gpu::Shader::createVertex(std::string(model_lightmap_vert));
-    auto modelLightmapNormalMapVertex = gpu::Shader::createVertex(std::string(model_lightmap_normal_map_vert));
-    auto modelShadowVertex = gpu::Shader::createVertex(std::string(model_shadow_vert));
-    auto skinModelVertex = gpu::Shader::createVertex(std::string(skin_model_vert));
-    auto skinModelNormalMapVertex = gpu::Shader::createVertex(std::string(skin_model_normal_map_vert));
-    auto skinModelShadowVertex = gpu::Shader::createVertex(std::string(skin_model_shadow_vert));
-
-    // Pixel shaders
-    auto modelPixel = gpu::Shader::createPixel(std::string(model_frag));
-    auto modelNormalMapPixel = gpu::Shader::createPixel(std::string(model_normal_map_frag));
-    auto modelSpecularMapPixel = gpu::Shader::createPixel(std::string(model_specular_map_frag));
-    auto modelNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(model_normal_specular_map_frag));
-    auto modelTranslucentPixel = gpu::Shader::createPixel(std::string(model_translucent_frag));
-    auto modelShadowPixel = gpu::Shader::createPixel(std::string(model_shadow_frag));
-    auto modelLightmapPixel = gpu::Shader::createPixel(std::string(model_lightmap_frag));
-    auto modelLightmapNormalMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_normal_map_frag));
-    auto modelLightmapSpecularMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_specular_map_frag));
-    auto modelLightmapNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_normal_specular_map_frag));
-
-    // Fill the pipelineLib
-    addPipeline(
-        Key::Builder(),
-        modelVertex, modelPixel);
-
-    addPipeline(
-        Key::Builder().withTangents(),
-        modelNormalMapVertex, modelNormalMapPixel);
-
-    addPipeline(
-        Key::Builder().withSpecular(),
-        modelVertex, modelSpecularMapPixel);
-
-    addPipeline(
-        Key::Builder().withTangents().withSpecular(),
-        modelNormalMapVertex, modelNormalSpecularMapPixel);
-
-
-    addPipeline(
-        Key::Builder().withTranslucent(),
-        modelVertex, modelTranslucentPixel);
-    // FIXME Ignore lightmap for translucents meshpart
-    addPipeline(
-        Key::Builder().withTranslucent().withLightmap(),
-        modelVertex, modelTranslucentPixel);
-
-    addPipeline(
-        Key::Builder().withTangents().withTranslucent(),
-        modelNormalMapVertex, modelTranslucentPixel);
-
-    addPipeline(
-        Key::Builder().withSpecular().withTranslucent(),
-        modelVertex, modelTranslucentPixel);
-
-    addPipeline(
-        Key::Builder().withTangents().withSpecular().withTranslucent(),
-        modelNormalMapVertex, modelTranslucentPixel);
-
-
-    addPipeline(
-        Key::Builder().withLightmap(),
-        modelLightmapVertex, modelLightmapPixel);
-
-    addPipeline(
-        Key::Builder().withLightmap().withTangents(),
-        modelLightmapNormalMapVertex, modelLightmapNormalMapPixel);
-
-    addPipeline(
-        Key::Builder().withLightmap().withSpecular(),
-        modelLightmapVertex, modelLightmapSpecularMapPixel);
-
-    addPipeline(
-        Key::Builder().withLightmap().withTangents().withSpecular(),
-        modelLightmapNormalMapVertex, modelLightmapNormalSpecularMapPixel);
-
-
-    addPipeline(
-        Key::Builder().withSkinned(),
-        skinModelVertex, modelPixel);
-
-    addPipeline(
-        Key::Builder().withSkinned().withTangents(),
-        skinModelNormalMapVertex, modelNormalMapPixel);
-
-    addPipeline(
-        Key::Builder().withSkinned().withSpecular(),
-        skinModelVertex, modelSpecularMapPixel);
-
-    addPipeline(
-        Key::Builder().withSkinned().withTangents().withSpecular(),
-        skinModelNormalMapVertex, modelNormalSpecularMapPixel);
-
-
-    addPipeline(
-        Key::Builder().withSkinned().withTranslucent(),
-        skinModelVertex, modelTranslucentPixel);
-
-    addPipeline(
-        Key::Builder().withSkinned().withTangents().withTranslucent(),
-        skinModelNormalMapVertex, modelTranslucentPixel);
-
-    addPipeline(
-        Key::Builder().withSkinned().withSpecular().withTranslucent(),
-        skinModelVertex, modelTranslucentPixel);
-
-    addPipeline(
-        Key::Builder().withSkinned().withTangents().withSpecular().withTranslucent(),
-        skinModelNormalMapVertex, modelTranslucentPixel);
-
-
-    addPipeline(
-        Key::Builder().withDepthOnly(),
-        modelShadowVertex, modelShadowPixel);
-
-
-    addPipeline(
-        Key::Builder().withSkinned().withDepthOnly(),
-        skinModelShadowVertex, modelShadowPixel);
-}
-

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -106,15 +106,12 @@ public:
     using Config = DrawOverlay3DConfig;
     using JobModel = render::Job::Model<DrawOverlay3D, Config>;
 
-    DrawOverlay3D(render::ShapePlumberPointer shapePlumber) : _shapePlumber{ shapePlumber } {}
+    DrawOverlay3D();
 
     void configure(const Config& config) { _maxDrawn = config.maxDrawn; }
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
 
-    static const gpu::PipelinePointer& getOpaquePipeline();
-
 protected:
-    static gpu::PipelinePointer _opaquePipeline; //lazy evaluation hence mutable
     render::ShapePlumberPointer _shapePlumber;
     int _maxDrawn; // initialized by Config
 };

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -68,14 +68,13 @@ protected:
 
 class DrawStencilDeferred {
 public:
-    DrawStencilDeferred();
-
-    void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
-
     using JobModel = render::Job::Model<DrawStencilDeferred>;
 
+    void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
+    static const gpu::PipelinePointer& getOpaquePipeline();
+
 protected:
-    render::ShapePlumberPointer _shapePlumber;
+    static gpu::PipelinePointer _opaquePipeline; //lazy evaluation hence mutable
 };
 
 class DrawBackgroundDeferred {

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -68,14 +68,14 @@ protected:
 
 class DrawStencilDeferred {
 public:
-    static const gpu::PipelinePointer& getOpaquePipeline();
+    DrawStencilDeferred();
 
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
 
     using JobModel = render::Job::Model<DrawStencilDeferred>;
 
 protected:
-    static gpu::PipelinePointer _opaquePipeline; //lazy evaluation hence mutable
+    render::ShapePlumberPointer _shapePlumber;
 };
 
 class DrawBackgroundDeferred {

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -43,19 +43,7 @@
 
 using namespace render;
 
-void initOverlay3DPipelines(ShapePlumber& plumber) {
-    auto vs = gpu::Shader::createVertex(std::string(overlay3D_vert));
-    auto ps = gpu::Shader::createPixel(std::string(overlay3D_frag));
-    auto program = gpu::Shader::createProgram(vs, ps);
-
-    auto opaqueState = std::make_shared<gpu::State>();
-    opaqueState->setDepthTest(false);
-    opaqueState->setBlendFunction(false);
-
-    plumber.addPipeline(ShapeKey::Filter::Builder().withOpaque(), program, opaqueState);
-}
-
-void initStencilPipelines(ShapePlumber& plumber) {
+void initStencilPipeline(gpu::PipelinePointer& pipeline) {
     const gpu::int8 STENCIL_OPAQUE = 1;
     auto vs = gpu::StandardShaderLib::getDrawUnitQuadTexcoordVS();
     auto ps = gpu::Shader::createPixel(std::string(drawOpaqueStencil_frag));
@@ -67,7 +55,19 @@ void initStencilPipelines(ShapePlumber& plumber) {
     state->setStencilTest(true, 0xFF, gpu::State::StencilTest(STENCIL_OPAQUE, 0xFF, gpu::ALWAYS, gpu::State::STENCIL_OP_REPLACE, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_REPLACE));
     state->setColorWriteMask(0);
 
-    plumber.addPipeline(ShapeKey::Filter::Builder(), program, state);
+    pipeline = gpu::Pipeline::create(program, state);
+}
+
+void initOverlay3DPipelines(ShapePlumber& plumber) {
+    auto vs = gpu::Shader::createVertex(std::string(overlay3D_vert));
+    auto ps = gpu::Shader::createPixel(std::string(overlay3D_frag));
+    auto program = gpu::Shader::createProgram(vs, ps);
+
+    auto opaqueState = std::make_shared<gpu::State>();
+    opaqueState->setDepthTest(false);
+    opaqueState->setBlendFunction(false);
+
+    plumber.addPipeline(ShapeKey::Filter::Builder().withOpaque(), program, opaqueState);
 }
 
 void pipelineBatchSetter(const ShapePipeline& pipeline, gpu::Batch& batch) {

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -1,0 +1,234 @@
+
+//
+//  RenderPipelines.cpp
+//  render-utils/src/
+//
+//  Created by Zach Pomerantz on 1/28/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <gpu/Context.h>
+#include <gpu/StandardShaderLib.h>
+
+#include "TextureCache.h"
+#include "render/DrawTask.h"
+
+#include "model_vert.h"
+#include "model_shadow_vert.h"
+#include "model_normal_map_vert.h"
+#include "model_lightmap_vert.h"
+#include "model_lightmap_normal_map_vert.h"
+#include "skin_model_vert.h"
+#include "skin_model_shadow_vert.h"
+#include "skin_model_normal_map_vert.h"
+
+#include "model_frag.h"
+#include "model_shadow_frag.h"
+#include "model_normal_map_frag.h"
+#include "model_normal_specular_map_frag.h"
+#include "model_specular_map_frag.h"
+#include "model_lightmap_frag.h"
+#include "model_lightmap_normal_map_frag.h"
+#include "model_lightmap_normal_specular_map_frag.h"
+#include "model_lightmap_specular_map_frag.h"
+#include "model_translucent_frag.h"
+
+#include "overlay3D_vert.h"
+#include "overlay3D_frag.h"
+
+#include "drawOpaqueStencil_frag.h"
+
+using namespace render;
+
+void initOverlay3DPipelines(ShapePlumber& plumber) {
+    auto vs = gpu::Shader::createVertex(std::string(overlay3D_vert));
+    auto ps = gpu::Shader::createPixel(std::string(overlay3D_frag));
+    auto program = gpu::Shader::createProgram(vs, ps);
+
+    auto opaqueState = std::make_shared<gpu::State>();
+    opaqueState->setDepthTest(false);
+    opaqueState->setBlendFunction(false);
+
+    plumber.addPipeline(ShapeKey::Filter::Builder().withOpaque(), program, opaqueState);
+}
+
+void initStencilPipelines(ShapePlumber& plumber) {
+    const gpu::int8 STENCIL_OPAQUE = 1;
+    auto vs = gpu::StandardShaderLib::getDrawUnitQuadTexcoordVS();
+    auto ps = gpu::Shader::createPixel(std::string(drawOpaqueStencil_frag));
+    auto program = gpu::Shader::createProgram(vs, ps);
+    gpu::Shader::makeProgram((*program));
+
+    auto state = std::make_shared<gpu::State>();
+    state->setDepthTest(true, false, gpu::LESS_EQUAL);
+    state->setStencilTest(true, 0xFF, gpu::State::StencilTest(STENCIL_OPAQUE, 0xFF, gpu::ALWAYS, gpu::State::STENCIL_OP_REPLACE, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_REPLACE));
+    state->setColorWriteMask(0);
+
+    plumber.addPipeline(ShapeKey::Filter::Builder(), program, state);
+}
+
+void pipelineBatchSetter(const ShapePipeline& pipeline, gpu::Batch& batch) {
+    if (pipeline.locations->normalFittingMapUnit > -1) {
+        batch.setResourceTexture(pipeline.locations->normalFittingMapUnit,
+            DependencyManager::get<TextureCache>()->getNormalFittingTexture());
+    }
+}
+
+void initDeferredPipelines(render::ShapePlumber& plumber) {
+    using Key = render::ShapeKey;
+    using ShaderPointer = gpu::ShaderPointer;
+
+    auto addPipeline = [&plumber](const Key& key, const ShaderPointer& vertexShader, const ShaderPointer& pixelShader) {
+        auto state = std::make_shared<gpu::State>();
+
+        // Cull backface
+        state->setCullMode(gpu::State::CULL_BACK);
+
+        // Z test depends on transparency
+        state->setDepthTest(true, !key.isTranslucent(), gpu::LESS_EQUAL);
+
+        // Blend if transparent
+        state->setBlendFunction(key.isTranslucent(),
+            // For transparency, keep the highlight intensity
+            gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+            gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
+
+        ShaderPointer program = gpu::Shader::createProgram(vertexShader, pixelShader);
+        plumber.addPipeline(key, program, state, &pipelineBatchSetter);
+
+        // Add a wireframe version
+        if (!key.isWireFrame()) {
+            auto wireFrameKey = Key::Builder(key).withWireframe();
+            auto wireFrameState = std::make_shared<gpu::State>(state->getValues());
+
+            wireFrameState->setFillMode(gpu::State::FILL_LINE);
+
+            plumber.addPipeline(wireFrameKey, program, wireFrameState, &pipelineBatchSetter);
+        }
+    };
+
+    // Vertex shaders
+    auto modelVertex = gpu::Shader::createVertex(std::string(model_vert));
+    auto modelNormalMapVertex = gpu::Shader::createVertex(std::string(model_normal_map_vert));
+    auto modelLightmapVertex = gpu::Shader::createVertex(std::string(model_lightmap_vert));
+    auto modelLightmapNormalMapVertex = gpu::Shader::createVertex(std::string(model_lightmap_normal_map_vert));
+    auto modelShadowVertex = gpu::Shader::createVertex(std::string(model_shadow_vert));
+    auto skinModelVertex = gpu::Shader::createVertex(std::string(skin_model_vert));
+    auto skinModelNormalMapVertex = gpu::Shader::createVertex(std::string(skin_model_normal_map_vert));
+    auto skinModelShadowVertex = gpu::Shader::createVertex(std::string(skin_model_shadow_vert));
+
+    // Pixel shaders
+    auto modelPixel = gpu::Shader::createPixel(std::string(model_frag));
+    auto modelNormalMapPixel = gpu::Shader::createPixel(std::string(model_normal_map_frag));
+    auto modelSpecularMapPixel = gpu::Shader::createPixel(std::string(model_specular_map_frag));
+    auto modelNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(model_normal_specular_map_frag));
+    auto modelTranslucentPixel = gpu::Shader::createPixel(std::string(model_translucent_frag));
+    auto modelShadowPixel = gpu::Shader::createPixel(std::string(model_shadow_frag));
+    auto modelLightmapPixel = gpu::Shader::createPixel(std::string(model_lightmap_frag));
+    auto modelLightmapNormalMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_normal_map_frag));
+    auto modelLightmapSpecularMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_specular_map_frag));
+    auto modelLightmapNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(model_lightmap_normal_specular_map_frag));
+
+    // Fill the pipelineLib
+    addPipeline(
+        Key::Builder(),
+        modelVertex, modelPixel);
+
+    addPipeline(
+        Key::Builder().withTangents(),
+        modelNormalMapVertex, modelNormalMapPixel);
+
+    addPipeline(
+        Key::Builder().withSpecular(),
+        modelVertex, modelSpecularMapPixel);
+
+    addPipeline(
+        Key::Builder().withTangents().withSpecular(),
+        modelNormalMapVertex, modelNormalSpecularMapPixel);
+
+
+    addPipeline(
+        Key::Builder().withTranslucent(),
+        modelVertex, modelTranslucentPixel);
+    // FIXME Ignore lightmap for translucents meshpart
+    addPipeline(
+        Key::Builder().withTranslucent().withLightmap(),
+        modelVertex, modelTranslucentPixel);
+
+    addPipeline(
+        Key::Builder().withTangents().withTranslucent(),
+        modelNormalMapVertex, modelTranslucentPixel);
+
+    addPipeline(
+        Key::Builder().withSpecular().withTranslucent(),
+        modelVertex, modelTranslucentPixel);
+
+    addPipeline(
+        Key::Builder().withTangents().withSpecular().withTranslucent(),
+        modelNormalMapVertex, modelTranslucentPixel);
+
+
+    addPipeline(
+        Key::Builder().withLightmap(),
+        modelLightmapVertex, modelLightmapPixel);
+
+    addPipeline(
+        Key::Builder().withLightmap().withTangents(),
+        modelLightmapNormalMapVertex, modelLightmapNormalMapPixel);
+
+    addPipeline(
+        Key::Builder().withLightmap().withSpecular(),
+        modelLightmapVertex, modelLightmapSpecularMapPixel);
+
+    addPipeline(
+        Key::Builder().withLightmap().withTangents().withSpecular(),
+        modelLightmapNormalMapVertex, modelLightmapNormalSpecularMapPixel);
+
+
+    addPipeline(
+        Key::Builder().withSkinned(),
+        skinModelVertex, modelPixel);
+
+    addPipeline(
+        Key::Builder().withSkinned().withTangents(),
+        skinModelNormalMapVertex, modelNormalMapPixel);
+
+    addPipeline(
+        Key::Builder().withSkinned().withSpecular(),
+        skinModelVertex, modelSpecularMapPixel);
+
+    addPipeline(
+        Key::Builder().withSkinned().withTangents().withSpecular(),
+        skinModelNormalMapVertex, modelNormalSpecularMapPixel);
+
+
+    addPipeline(
+        Key::Builder().withSkinned().withTranslucent(),
+        skinModelVertex, modelTranslucentPixel);
+
+    addPipeline(
+        Key::Builder().withSkinned().withTangents().withTranslucent(),
+        skinModelNormalMapVertex, modelTranslucentPixel);
+
+    addPipeline(
+        Key::Builder().withSkinned().withSpecular().withTranslucent(),
+        skinModelVertex, modelTranslucentPixel);
+
+    addPipeline(
+        Key::Builder().withSkinned().withTangents().withSpecular().withTranslucent(),
+        skinModelNormalMapVertex, modelTranslucentPixel);
+
+
+    addPipeline(
+        Key::Builder().withDepthOnly(),
+        modelShadowVertex, modelShadowPixel);
+
+
+    addPipeline(
+        Key::Builder().withSkinned().withDepthOnly(),
+        skinModelShadowVertex, modelShadowPixel);
+}
+


### PR DESCRIPTION
- Replace DrawOverlay3D::getOpaquePipeline with a ShapePlumber.
- Move RenderDeferredTask shader initializations to a separate file for readability.

This refactoring leads up to a fix (not yet in PR) for overlay transparency and layering.