### PR TITLE
Fixed bug where lack of 0 as prefix for numbers would throw an error

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -64,7 +64,7 @@
         function createEmitNumberPropertyUpdateFunction(propertyName) {
             return function() {
                 EventBridge.emitWebEvent(
-                    '{ "type":"update", "properties":{"' + propertyName + '":' + this.value + '}}'
+                    '{ "type":"update", "properties":{"' + propertyName + '":' + parseFloat(this.value).toFixed(2) + '}}'
                 );
             };
         }


### PR DESCRIPTION
Now user can just type .1 instead of 0.1 into a number field in the entity properties panel, and everything will be fine.