### PR TITLE
Decrease Cell Science Volume

### DIFF
--- a/unpublishedScripts/DomainContent/CellScience/Scripts/playBackgroundAudio.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/playBackgroundAudio.js
@@ -20,7 +20,7 @@
             stereo: true,
             loop: true,
             localOnly: true,
-            volume: 0.5
+            volume: 0.2
         };
 
         this.sound = SoundCache.getSound(self.soundURL);

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/playBackgroundAudio.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/playBackgroundAudio.js
@@ -20,7 +20,7 @@
             stereo: true,
             loop: true,
             localOnly: true,
-            volume: 0.2
+            volume: 0.035
         };
 
         this.sound = SoundCache.getSound(self.soundURL);
@@ -36,7 +36,6 @@
         }
     }
 
-
     this.enterEntity = function(entityID) {
         print("entering audio zone");
         if (self.sound.downloaded) {
@@ -47,7 +46,6 @@
             print("sound is not downloaded");
         }
     }
-
 
 
     this.leaveEntity = function(entityID) {

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/playBackgroundAudio.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/playBackgroundAudio.js
@@ -8,7 +8,7 @@
 (function() {
     var self = this;
     var baseURL = "https://hifi-content.s3.amazonaws.com/DomainContent/CellScience/";
-    var version = 8;
+    var version = 9;
     this.preload = function(entityId) {
         self.soundPlaying = false;
         self.entityId = entityId;

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/showButtonToPlaySound.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/showButtonToPlaySound.js
@@ -24,7 +24,7 @@
             stereo: true,
             loop: false,
             localOnly: true,
-            volume: 0.2
+            volume: 0.035
         };
         this.sound = SoundCache.getSound(this.soundURL);
     }

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/showButtonToPlaySound.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/showButtonToPlaySound.js
@@ -24,7 +24,7 @@
             stereo: true,
             loop: false,
             localOnly: true,
-            volume: 0.5
+            volume: 0.2
         };
         this.sound = SoundCache.getSound(this.soundURL);
     }

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/showIdentification.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/showIdentification.js
@@ -22,7 +22,7 @@
             stereo: true,
             loop: false,
             localOnly: true,
-            volume: 0.2,
+            volume: 0.035,
             position: this.position
         };
         this.sound = SoundCache.getSound(this.soundURL);

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/showIdentification.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/showIdentification.js
@@ -22,7 +22,7 @@
             stereo: true,
             loop: false,
             localOnly: true,
-            volume: 0.5,
+            volume: 0.2,
             position: this.position
         };
         this.sound = SoundCache.getSound(this.soundURL);

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/zoom.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/zoom.js
@@ -25,8 +25,9 @@
             loop: false,
             localOnly: false,
             position: this.position,
-            volume: 0.2
+            volume: 0.035
         };
+        
         this.teleportSound = SoundCache.getSound("https://hifi-content.s3.amazonaws.com/DomainContent/CellScience/Audio/whoosh.wav");
         //print('Script.clearTimeout PRELOADING A ZOOM ENTITY')
         print(" portal destination is " + portalDestination);

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/zoom.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/zoom.js
@@ -25,7 +25,7 @@
             loop: false,
             localOnly: false,
             position: this.position,
-            volume: 0.5
+            volume: 0.2
         };
         this.teleportSound = SoundCache.getSound("https://hifi-content.s3.amazonaws.com/DomainContent/CellScience/Audio/whoosh.wav");
         //print('Script.clearTimeout PRELOADING A ZOOM ENTITY')

--- a/unpublishedScripts/DomainContent/CellScience/importCellScience.js
+++ b/unpublishedScripts/DomainContent/CellScience/importCellScience.js
@@ -5,7 +5,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var version = 1003;
+var version = 1004;
 var cellLayout;
 var baseLocation = "https://hifi-content.s3.amazonaws.com/DomainContent/CellScience/";
 


### PR DESCRIPTION
This PR reduces the volume of the music playing in cell science.

**NOTE: This script will clear content where you run it**

To test: 

1. In an empty domain, go to running scripts and import this script from url: http://hifi-content.s3.amazonaws.com/DomainContent/CellScience/importCellScience.js
2. Stop the importCellScience.js script.
3. Observe that the volume is at a reasonable level.
