### PR TITLE
QML Fixes

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1362,6 +1362,9 @@ void Application::paintGL() {
         renderArgs._renderMode = RenderArgs::MIRROR_RENDER_MODE;
         renderArgs._blitFramebuffer = DependencyManager::get<FramebufferCache>()->getSelfieFramebuffer();
 
+        auto inputs = AvatarInputs::getInstance();
+        _mirrorViewRect.moveTo(inputs->x(), inputs->y());
+
         renderRearViewMirror(&renderArgs, _mirrorViewRect);
 
         renderArgs._blitFramebuffer.reset();

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -220,18 +220,7 @@ QmlWindowClass::QmlWindowClass(QObject* qmlWindow)
 }
 
 QmlWindowClass::~QmlWindowClass() {
-    if (_qmlWindow) {
-        if (_toolWindow) {
-            auto offscreenUi = DependencyManager::get<OffscreenUi>();
-            auto toolWindow = offscreenUi->getToolWindow();
-            auto invokeResult = QMetaObject::invokeMethod(toolWindow, "removeTabForUrl", Qt::QueuedConnection, 
-                Q_ARG(QVariant, _source));
-            Q_ASSERT(invokeResult);
-        } else {
-            _qmlWindow->deleteLater();
-        }
-        _qmlWindow = nullptr;
-    }
+    close();
 }
 
 void QmlWindowClass::registerObject(const QString& name, QObject* object) {
@@ -331,14 +320,18 @@ void QmlWindowClass::setTitle(const QString& title) {
 }
 
 void QmlWindowClass::close() {
-    DependencyManager::get<OffscreenUi>()->executeOnUiThread([this] {
-        if (_qmlWindow) {
-            _qmlWindow->setProperty("destroyOnInvisible", true);
-            _qmlWindow->setProperty("visible", false);
+    if (_qmlWindow) {
+        if (_toolWindow) {
+            auto offscreenUi = DependencyManager::get<OffscreenUi>();
+            auto toolWindow = offscreenUi->getToolWindow();
+            auto invokeResult = QMetaObject::invokeMethod(toolWindow, "removeTabForUrl", Qt::QueuedConnection,
+                Q_ARG(QVariant, _source));
+            Q_ASSERT(invokeResult);
+        } else {
             _qmlWindow->deleteLater();
-            _qmlWindow = nullptr;
         }
-    });
+        _qmlWindow = nullptr;
+    }
 }
 
 void QmlWindowClass::hasClosed() {


### PR DESCRIPTION
* Tool window tabs should be explicitly closable by scripts
* Mini-mirror should move with the mirror controls
