### PR TITLE
MyAvatar: Improved Jump / InAir / Fly behavior 

### DIFF
--- a/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
+++ b/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
@@ -377,6 +377,7 @@
                                                             "interpTarget": 30,
                                                             "interpDuration": 30,
                                                             "transitions": [
+                                                                { "var": "isNotAway", "state": "awayOutro" },
                                                                 { "var": "awayIntroOnDone", "state": "away"}
                                                             ]
                                                         },

--- a/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
+++ b/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
@@ -248,6 +248,7 @@
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -265,6 +266,7 @@
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -281,6 +283,7 @@
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -297,6 +300,7 @@
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -313,6 +317,7 @@
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -329,6 +334,7 @@
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -345,6 +351,7 @@
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -361,6 +368,7 @@
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isTakeoff", "state": "takeoff" },
                                                                 { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
@@ -398,9 +406,18 @@
                                                             ]
                                                         },
                                                         {
+                                                            "id": "takeoff",
+                                                            "interpTarget": 0,
+                                                            "interpDuration": 6,
+                                                            "transitions": [
+                                                                { "var": "isAway", "state": "awayIntro" },
+                                                                { "var": "isNotTakeoff", "state": "inAir" }
+                                                            ]
+                                                        },
+                                                        {
                                                             "id": "inAir",
-                                                            "interpTarget": 3,
-                                                            "interpDuration": 3,
+                                                            "interpTarget": 0,
+                                                            "interpDuration": 6,
                                                             "transitions": [
                                                                 { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isNotInAir", "state": "idle" }
@@ -705,6 +722,18 @@
                                                         "children": []
                                                     },
                                                     {
+                                                        "id": "takeoff",
+                                                        "type": "clip",
+                                                        "data": {
+                                                            "url": "https://hifi-content.s3.amazonaws.com/ozan/dev/anim/standard_anims_160127/jump_takeoff.fbx",
+                                                            "startFrame": 1.0,
+                                                            "endFrame": 2.5,
+                                                            "timeScale": 1.0,
+                                                            "loopFlag": false
+                                                        },
+                                                        "children": []
+                                                    },
+                                                    {
                                                         "id": "inAir",
                                                         "type": "blendLinear",
                                                         "data": {
@@ -720,7 +749,7 @@
                                                                     "startFrame": 0.0,
                                                                     "endFrame": 0.0,
                                                                     "timeScale": 0.0,
-                                                                    "loopFlag": true
+                                                                    "loopFlag": false
                                                                 },
                                                                 "children": []
                                                             },
@@ -732,7 +761,7 @@
                                                                     "startFrame": 6.0,
                                                                     "endFrame": 6.0,
                                                                     "timeScale": 1.0,
-                                                                    "loopFlag": true
+                                                                    "loopFlag": false
                                                                 },
                                                                 "children": []
                                                             },
@@ -744,7 +773,7 @@
                                                                     "startFrame": 11.0,
                                                                     "endFrame": 11.0,
                                                                     "timeScale": 1.0,
-                                                                    "loopFlag": true
+                                                                    "loopFlag": false
                                                                 },
                                                                 "children": []
                                                             }

--- a/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
+++ b/interface/resources/meshes/defaultAvatar_full/avatar-animation.json
@@ -247,7 +247,8 @@
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -263,7 +264,8 @@
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -278,7 +280,8 @@
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -293,7 +296,8 @@
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -308,7 +312,8 @@
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -323,7 +328,8 @@
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -338,7 +344,8 @@
                                                                 { "var": "isMovingLeft", "state": "strafeLeft" },
                                                                 { "var": "isTurningLeft", "state": "turnLeft" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -353,7 +360,8 @@
                                                                 { "var": "isMovingLeft", "state": "strafeLeft" },
                                                                 { "var": "isTurningRight", "state": "turnRight" },
                                                                 { "var": "isAway", "state": "awayIntro" },
-                                                                { "var": "isFlying", "state": "fly" }
+                                                                { "var": "isFlying", "state": "fly" },
+                                                                { "var": "isInAir", "state": "inAir" }
                                                             ]
                                                         },
                                                         {
@@ -385,7 +393,17 @@
                                                             "interpTarget": 6,
                                                             "interpDuration": 6,
                                                             "transitions": [
+                                                                { "var": "isAway", "state": "awayIntro" },
                                                                 { "var": "isNotFlying", "state": "idle" }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "id": "inAir",
+                                                            "interpTarget": 3,
+                                                            "interpDuration": 3,
+                                                            "transitions": [
+                                                                { "var": "isAway", "state": "awayIntro" },
+                                                                { "var": "isNotInAir", "state": "idle" }
                                                             ]
                                                         }
                                                     ]
@@ -685,6 +703,52 @@
                                                             "loopFlag": true
                                                         },
                                                         "children": []
+                                                    },
+                                                    {
+                                                        "id": "inAir",
+                                                        "type": "blendLinear",
+                                                        "data": {
+                                                            "alpha": 0.0,
+                                                            "alphaVar": "inAirAlpha"
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "inAirPreApex",
+                                                                "type": "clip",
+                                                                "data": {
+                                                                    "url": "https://hifi-content.s3.amazonaws.com/ozan/dev/anim/standard_anims_160127/jump_in_air.fbx",
+                                                                    "startFrame": 0.0,
+                                                                    "endFrame": 0.0,
+                                                                    "timeScale": 0.0,
+                                                                    "loopFlag": true
+                                                                },
+                                                                "children": []
+                                                            },
+                                                            {
+                                                                "id": "inAirApex",
+                                                                "type": "clip",
+                                                                "data": {
+                                                                    "url": "https://hifi-content.s3.amazonaws.com/ozan/dev/anim/standard_anims_160127/jump_in_air.fbx",
+                                                                    "startFrame": 6.0,
+                                                                    "endFrame": 6.0,
+                                                                    "timeScale": 1.0,
+                                                                    "loopFlag": true
+                                                                },
+                                                                "children": []
+                                                            },
+                                                            {
+                                                                "id": "inAirPostApex",
+                                                                "type": "clip",
+                                                                "data": {
+                                                                    "url": "https://hifi-content.s3.amazonaws.com/ozan/dev/anim/standard_anims_160127/jump_in_air.fbx",
+                                                                    "startFrame": 11.0,
+                                                                    "endFrame": 11.0,
+                                                                    "timeScale": 1.0,
+                                                                    "loopFlag": true
+                                                                },
+                                                                "children": []
+                                                            }
+                                                        ]
                                                     }
                                                 ]
                                             }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1314,7 +1314,6 @@ void MyAvatar::preRender(RenderArgs* renderArgs) {
 const float RENDER_HEAD_CUTOFF_DISTANCE = 0.5f;
 
 bool MyAvatar::cameraInsideHead() const {
-    const Head* head = getHead();
     const glm::vec3 cameraPosition = qApp->getCamera()->getPosition();
     return glm::length(cameraPosition - getDefaultEyePosition()) < (RENDER_HEAD_CUTOFF_DISTANCE * getUniformScale());
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1311,21 +1311,23 @@ void MyAvatar::preRender(RenderArgs* renderArgs) {
     _prevShouldDrawHead = shouldDrawHead;
 }
 
-const float RENDER_HEAD_CUTOFF_DISTANCE = 0.50f;
+const float RENDER_HEAD_CUTOFF_DISTANCE = 0.5f;
 
 bool MyAvatar::cameraInsideHead() const {
     const Head* head = getHead();
     const glm::vec3 cameraPosition = qApp->getCamera()->getPosition();
-    return glm::length(cameraPosition - head->getEyePosition()) < (RENDER_HEAD_CUTOFF_DISTANCE * getUniformScale());
+    return glm::length(cameraPosition - getDefaultEyePosition()) < (RENDER_HEAD_CUTOFF_DISTANCE * getUniformScale());
 }
 
 bool MyAvatar::shouldRenderHead(const RenderArgs* renderArgs) const {
-    return ((renderArgs->_renderMode != RenderArgs::DEFAULT_RENDER_MODE) ||
-            (qApp->getCamera()->getMode() != CAMERA_MODE_FIRST_PERSON) ||
-            !cameraInsideHead());
+    bool defaultMode = renderArgs->_renderMode == RenderArgs::DEFAULT_RENDER_MODE;
+    bool firstPerson = qApp->getCamera()->getMode() == CAMERA_MODE_FIRST_PERSON;
+    bool insideHead = cameraInsideHead();
+    return !defaultMode || !firstPerson || !insideHead;
 }
 
 void MyAvatar::updateOrientation(float deltaTime) {
+
     //  Smoothly rotate body with arrow keys
     float targetSpeed = _driveKeys[YAW] * _yawSpeed;
     if (targetSpeed != 0.0f) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1510,7 +1510,8 @@ void MyAvatar::updatePosition(float deltaTime) {
     // rotate velocity into camera frame
     glm::quat rotation = getHead()->getCameraOrientation();
     glm::vec3 localVelocity = glm::inverse(rotation) * _targetVelocity;
-    glm::vec3 newLocalVelocity = applyKeyboardMotor(deltaTime, localVelocity, isHovering());
+    bool isHovering = _characterController.getState() == CharacterController::State::Hover;
+    glm::vec3 newLocalVelocity = applyKeyboardMotor(deltaTime, localVelocity, isHovering);
     newLocalVelocity = applyScriptedMotor(deltaTime, newLocalVelocity);
 
     // rotate back into world-frame
@@ -1577,10 +1578,6 @@ bool findAvatarAvatarPenetration(const glm::vec3 positionA, float radiusA, float
         }
     }
     return false;
-}
-
-bool MyAvatar::isHovering() const {
-    return _characterController.isHovering();
 }
 
 void MyAvatar::increaseSize() {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -239,8 +239,6 @@ public:
     glm::quat getCustomListenOrientation() { return _customListenOrientation; }
     void setCustomListenOrientation(glm::quat customListenOrientation) { _customListenOrientation = customListenOrientation; }
 
-    bool isHovering() const;
-
 public slots:
     void increaseSize();
     void decreaseSize();

--- a/interface/src/avatar/MyCharacterController.cpp
+++ b/interface/src/avatar/MyCharacterController.cpp
@@ -67,7 +67,7 @@ void MyCharacterController::updateShapeIfNecessary() {
             _rigidBody->setAngularFactor(0.0f);
             _rigidBody->setWorldTransform(btTransform(glmToBullet(_avatar->getOrientation()),
                                                       glmToBullet(_avatar->getPosition())));
-            if (_isHovering) {
+            if (_state == State::Hover) {
                 _rigidBody->setGravity(btVector3(0.0f, 0.0f, 0.0f));
             } else {
                 _rigidBody->setGravity(DEFAULT_CHARACTER_GRAVITY * _currentUp);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -72,6 +72,18 @@ void SkeletonModel::initJointStates() {
     emit skeletonLoaded();
 }
 
+Rig::CharacterControllerState convertCharacterControllerState(CharacterController::State state) {
+    switch (state) {
+    default:
+    case CharacterController::State::Ground:
+        return Rig::CharacterControllerState::Ground;
+    case CharacterController::State::InAir:
+        return Rig::CharacterControllerState::InAir;
+    case CharacterController::State::Hover:
+        return Rig::CharacterControllerState::Hover;
+    };
+}
+
 // Called within Model::simulate call, below.
 void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     Head* head = _owningAvatar->getHead();
@@ -133,13 +145,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         _rig->updateFromHandParameters(handParams, deltaTime);
 
-        Rig::CharacterControllerState ccState = Rig::CharacterControllerState::Ground;
-        if (myAvatar->getCharacterController()->isHovering()) {
-            ccState = Rig::CharacterControllerState::Hover;
-        } else if (myAvatar->getCharacterController()->isJumping()) {
-            ccState = Rig::CharacterControllerState::Jump;
-        }
-
+        Rig::CharacterControllerState ccState = convertCharacterControllerState(myAvatar->getCharacterController()->getState());
         _rig->computeMotionAnimationState(deltaTime, _owningAvatar->getPosition(), _owningAvatar->getVelocity(), _owningAvatar->getOrientation(), ccState);
 
         // evaluate AnimGraph animation and update jointStates.

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -133,7 +133,14 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         _rig->updateFromHandParameters(handParams, deltaTime);
 
-        _rig->computeMotionAnimationState(deltaTime, _owningAvatar->getPosition(), _owningAvatar->getVelocity(), _owningAvatar->getOrientation(), myAvatar->isHovering());
+        Rig::CharacterControllerState ccState = Rig::CharacterControllerState::Ground;
+        if (myAvatar->getCharacterController()->isHovering()) {
+            ccState = Rig::CharacterControllerState::Hover;
+        } else if (myAvatar->getCharacterController()->isJumping()) {
+            ccState = Rig::CharacterControllerState::Jump;
+        }
+
+        _rig->computeMotionAnimationState(deltaTime, _owningAvatar->getPosition(), _owningAvatar->getVelocity(), _owningAvatar->getOrientation(), ccState);
 
         // evaluate AnimGraph animation and update jointStates.
         Model::updateRig(deltaTime, parentTransform);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -77,6 +77,8 @@ Rig::CharacterControllerState convertCharacterControllerState(CharacterControlle
     default:
     case CharacterController::State::Ground:
         return Rig::CharacterControllerState::Ground;
+    case CharacterController::State::Takeoff:
+        return Rig::CharacterControllerState::Takeoff;
     case CharacterController::State::InAir:
         return Rig::CharacterControllerState::InAir;
     case CharacterController::State::Hover:

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -784,11 +784,14 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
         t += deltaTime;
 
-        if (_enableInverseKinematics) {
-            _animVars.set("ikOverlayAlpha", 1.0f);
-        } else {
-            _animVars.set("ikOverlayAlpha", 0.0f);
+        if (_enableInverseKinematics != _lastEnableInverseKinematics) {
+            if (_enableInverseKinematics) {
+                _animVars.set("ikOverlayAlpha", 1.0f);
+            } else {
+                _animVars.set("ikOverlayAlpha", 0.0f);
+            }
         }
+        _lastEnableInverseKinematics = _enableInverseKinematics;
     }
 
     _lastFront = front;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -624,6 +624,13 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
         const float STATE_CHANGE_HYSTERESIS_TIMER = 0.1f;
 
+        // Skip hystersis timer for jump transitions.
+        if (_desiredState == RigRole::Takeoff) {
+            _desiredStateAge = STATE_CHANGE_HYSTERESIS_TIMER;
+        } else if (_state == RigRole::InAir && _desiredState != RigRole::InAir) {
+            _desiredStateAge = STATE_CHANGE_HYSTERESIS_TIMER;
+        }
+
         if ((_desiredStateAge >= STATE_CHANGE_HYSTERESIS_TIMER) && _desiredState != _state) {
             _state = _desiredState;
             _desiredStateAge = 0.0f;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -582,6 +582,11 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
                 _desiredStateAge = 0.0f;
             }
             _desiredState = RigRole::InAir;
+        } else if (ccState == CharacterControllerState::Takeoff) {
+            if (_desiredState != RigRole::Takeoff) {
+                _desiredStateAge = 0.0f;
+            }
+            _desiredState = RigRole::Takeoff;
         } else {
             float moveThresh;
             if (_state != RigRole::Move) {
@@ -667,6 +672,8 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
                 _animVars.set("isNotTurning", true);
                 _animVars.set("isFlying", false);
                 _animVars.set("isNotFlying", true);
+                _animVars.set("isTakeoff", false);
+                _animVars.set("isNotTakeoff", true);
                 _animVars.set("isInAir", false);
                 _animVars.set("isNotInAir", true);
             }
@@ -689,8 +696,11 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isNotMoving", true);
             _animVars.set("isFlying", false);
             _animVars.set("isNotFlying", true);
+            _animVars.set("isTakeoff", false);
+            _animVars.set("isNotTakeoff", true);
             _animVars.set("isInAir", false);
             _animVars.set("isNotInAir", true);
+
         } else if (_state == RigRole::Idle ) {
             // default anim vars to notMoving and notTurning
             _animVars.set("isMovingForward", false);
@@ -703,8 +713,11 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isNotTurning", true);
             _animVars.set("isFlying", false);
             _animVars.set("isNotFlying", true);
+            _animVars.set("isTakeoff", false);
+            _animVars.set("isNotTakeoff", true);
             _animVars.set("isInAir", false);
             _animVars.set("isNotInAir", true);
+
         } else if (_state == RigRole::Hover) {
             // flying.
             _animVars.set("isMovingForward", false);
@@ -717,8 +730,28 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isNotTurning", true);
             _animVars.set("isFlying", true);
             _animVars.set("isNotFlying", false);
+            _animVars.set("isTakeoff", false);
+            _animVars.set("isNotTakeoff", true);
             _animVars.set("isInAir", false);
             _animVars.set("isNotInAir", true);
+
+        } else if (_state == RigRole::Takeoff) {
+            // jumping in-air
+            _animVars.set("isMovingForward", false);
+            _animVars.set("isMovingBackward", false);
+            _animVars.set("isMovingLeft", false);
+            _animVars.set("isMovingRight", false);
+            _animVars.set("isNotMoving", true);
+            _animVars.set("isTurningLeft", false);
+            _animVars.set("isTurningRight", false);
+            _animVars.set("isNotTurning", true);
+            _animVars.set("isFlying", false);
+            _animVars.set("isNotFlying", true);
+            _animVars.set("isTakeoff", true);
+            _animVars.set("isNotTakeoff", false);
+            _animVars.set("isInAir", true);
+            _animVars.set("isNotInAir", false);
+
         } else if (_state == RigRole::InAir) {
             // jumping in-air
             _animVars.set("isMovingForward", false);
@@ -731,6 +764,8 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isNotTurning", true);
             _animVars.set("isFlying", false);
             _animVars.set("isNotFlying", true);
+            _animVars.set("isTakeoff", false);
+            _animVars.set("isNotTakeoff", true);
             _animVars.set("isInAir", true);
             _animVars.set("isNotInAir", false);
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -577,11 +577,11 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
                 _desiredStateAge = 0.0f;
             }
             _desiredState = RigRole::Hover;
-        } else if (ccState == CharacterControllerState::Jump) {
-            if (_desiredState != RigRole::Jump) {
+        } else if (ccState == CharacterControllerState::InAir) {
+            if (_desiredState != RigRole::InAir) {
                 _desiredStateAge = 0.0f;
             }
-            _desiredState = RigRole::Jump;
+            _desiredState = RigRole::InAir;
         } else {
             float moveThresh;
             if (_state != RigRole::Move) {
@@ -719,7 +719,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isNotFlying", false);
             _animVars.set("isInAir", false);
             _animVars.set("isNotInAir", true);
-        } else if (_state == RigRole::Jump) {
+        } else if (_state == RigRole::InAir) {
             // jumping in-air
             _animVars.set("isMovingForward", false);
             _animVars.set("isMovingBackward", false);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -75,7 +75,7 @@ public:
 
     enum class CharacterControllerState {
         Ground = 0,
-        Jump,
+        InAir,
         Hover
     };
 
@@ -278,7 +278,7 @@ public:
         Turn,
         Move,
         Hover,
-        Jump
+        InAir
     };
     RigRole _state { RigRole::Idle };
     RigRole _desiredState { RigRole::Idle };

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -73,6 +73,12 @@ public:
         glm::quat rightOrientation = glm::quat(); // rig space (z forward)
     };
 
+    enum class CharacterControllerState {
+        Ground = 0,
+        Jump,
+        Hover
+    };
+
     virtual ~Rig() {}
 
     void destroyAnimGraph();
@@ -141,7 +147,7 @@ public:
     glm::mat4 getJointTransform(int jointIndex) const;
 
     // Start or stop animations as needed.
-    void computeMotionAnimationState(float deltaTime, const glm::vec3& worldPosition, const glm::vec3& worldVelocity, const glm::quat& worldRotation, bool isHovering);
+    void computeMotionAnimationState(float deltaTime, const glm::vec3& worldPosition, const glm::vec3& worldVelocity, const glm::quat& worldRotation, CharacterControllerState ccState);
 
     // Regardless of who started the animations or how many, update the joints.
     void updateAnimations(float deltaTime, glm::mat4 rootTransform);
@@ -271,7 +277,8 @@ public:
         Idle = 0,
         Turn,
         Move,
-        Hover
+        Hover,
+        Jump
     };
     RigRole _state { RigRole::Idle };
     RigRole _desiredState { RigRole::Idle };

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -301,6 +301,7 @@ public:
     std::map<QString, AnimNode::Pointer> _origRoleAnimations;
     std::vector<AnimNode::Pointer> _prefetchedAnimations;
 
+    bool _lastEnableInverseKinematics { false };
     bool _enableInverseKinematics { true };
 
 private:

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -75,6 +75,7 @@ public:
 
     enum class CharacterControllerState {
         Ground = 0,
+        Takeoff,
         InAir,
         Hover
     };
@@ -278,6 +279,7 @@ public:
         Turn,
         Move,
         Hover,
+        Takeoff,
         InAir
     };
     RigRole _state { RigRole::Idle };

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -499,8 +499,6 @@ void CharacterController::preSimulation() {
         }
     }
 
-    ///  _walkVelocity.dot(_currentUp) > UPWARD_VELOCITY_THRESHOLD
-
     _previousFlags = _pendingFlags;
     _pendingFlags &= ~PENDING_FLAG_JUMP;
 

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -445,7 +445,6 @@ void CharacterController::preSimulation() {
         const quint64 TAKE_OFF_TO_IN_AIR_PERIOD = 200 * MSECS_PER_SECOND;
         const btScalar MIN_HOVER_HEIGHT = 2.5f;
         const quint64 JUMP_TO_HOVER_PERIOD = 750 * MSECS_PER_SECOND;
-        const btScalar UPWARD_VELOCITY_THRESHOLD = 0.1f;
         const btScalar MAX_WALKING_SPEED = 2.5f;
 
         quint64 now = usecTimestampNow();

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -77,6 +77,7 @@ public:
 
     enum class State {
         Ground = 0,
+        Takeoff,
         InAir,
         Hover
     };
@@ -107,6 +108,7 @@ protected:
 
     glm::vec3 _boxScale; // used to compute capsule shape
 
+    quint64 _takeoffToInAirStart;
     quint64 _jumpToHoverStart;
 
     btScalar _halfHeight;

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -31,6 +31,8 @@ class btRigidBody;
 class btCollisionWorld;
 class btDynamicsWorld;
 
+//#define DEBUG_STATE_CHANGE
+
 class CharacterController : public btCharacterControllerInterface {
 public:
     CharacterController();
@@ -92,7 +94,11 @@ public:
     bool getRigidBodyLocation(glm::vec3& avatarRigidBodyPosition, glm::quat& avatarRigidBodyRotation);
 
 protected:
+#ifdef DEBUG_STATE_CHANGE
+    void setState(State state, const char* reason);
+#else
     void setState(State state);
+#endif
 
     void updateUpAxis(const glm::quat& rotation);
     bool checkForSupport(btCollisionWorld* collisionWorld) const;

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -109,7 +109,9 @@ protected:
     glm::vec3 _boxScale; // used to compute capsule shape
 
     quint64 _takeoffToInAirStart;
-    quint64 _jumpToHoverStart;
+    quint64 _jumpButtonDownStart;
+    quint32 _jumpButtonDownCount;
+    quint32 _takeOffJumpButtonID;
 
     btScalar _halfHeight;
     btScalar _radius;
@@ -131,7 +133,7 @@ protected:
     btDynamicsWorld* _dynamicsWorld { nullptr };
     btRigidBody* _rigidBody { nullptr };
     uint32_t _pendingFlags { 0 };
-
+    uint32_t _previousFlags { 0 };
 };
 
 #endif // hifi_CharacterControllerInterface_h

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -75,9 +75,13 @@ public:
 
     glm::vec3 getLinearVelocity() const;
 
-    bool isJumping() const { return _isJumping; }
-    bool isHovering() const { return _isHovering; }
-    void setHovering(bool enabled);
+    enum class State {
+        Ground = 0,
+        InAir,
+        Hover
+    };
+
+    State getState() const { return _state; }
 
     void setLocalBoundingBox(const glm::vec3& corner, const glm::vec3& scale);
 
@@ -87,6 +91,8 @@ public:
     bool getRigidBodyLocation(glm::vec3& avatarRigidBodyPosition, glm::quat& avatarRigidBodyRotation);
 
 protected:
+    void setState(State state);
+
     void updateUpAxis(const glm::quat& rotation);
     bool checkForSupport(btCollisionWorld* collisionWorld) const;
 
@@ -117,10 +123,7 @@ protected:
     btQuaternion _followAngularDisplacement;
 
     bool _enabled;
-    bool _isOnGround;
-    bool _isJumping;
-    bool _isFalling;
-    bool _isHovering;
+    State _state;
     bool _isPushingUp;
 
     btDynamicsWorld* _dynamicsWorld { nullptr };

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -75,6 +75,7 @@ public:
 
     glm::vec3 getLinearVelocity() const;
 
+    bool isJumping() const { return _isJumping; }
     bool isHovering() const { return _isHovering; }
     void setHovering(bool enabled);
 


### PR DESCRIPTION
There are new animation sets for jump takeoff and in air.

Currently, there is only a single first-pass jump takeoff animation.  There will be a left foot version and a stationary jump version added later.  Also, there is only a single set of 3 first-pass in-air poses, which work well for forward jumps but not so well for stationary jumps, a set of stationary in-air poses will be added later.  At the moment, there is no landing animation support.  This will be added in a future PR.

The physics character controller behavior has been changed:
  * There is a new takeoff state, in between when the jump button has been pressed and the upward jump velocity has been applied.
  * The transition from InAir to Flying has been refined.  It requires a 750 ms jump hold, or a double tap.
  * The transition from Hover to InAir/Ground has been refined.  You won't get pulled into the ground if you are flying fast.

The character controller has been changed to have a single internal state, and preStep and preSimulate has been cleaned up.