### PR TITLE
AnimClip: Animation mirror support

### DIFF
--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -15,12 +15,13 @@
 
 bool AnimClip::usePreAndPostPoseFromAnim = false;
 
-AnimClip::AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag) :
+AnimClip::AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag) :
     AnimNode(AnimNode::Type::Clip, id),
     _startFrame(startFrame),
     _endFrame(endFrame),
     _timeScale(timeScale),
     _loopFlag(loopFlag),
+    _mirrorFlag(mirrorFlag),
     _frame(startFrame)
 {
     loadURL(url);
@@ -49,6 +50,12 @@ const AnimPoseVec& AnimClip::evaluate(const AnimVariantMap& animVars, float dt, 
     }
 
     if (_anim.size()) {
+
+        // lazy creation of mirrored animation frames.
+        if (_mirrorFlag && _anim.size() != _mirrorAnim.size()) {
+            buildMirrorAnim();
+        }
+
         int prevIndex = (int)glm::floor(_frame);
         int nextIndex;
         if (_loopFlag && _frame >= _endFrame) {
@@ -63,8 +70,8 @@ const AnimPoseVec& AnimClip::evaluate(const AnimVariantMap& animVars, float dt, 
         prevIndex = std::min(std::max(0, prevIndex), frameCount - 1);
         nextIndex = std::min(std::max(0, nextIndex), frameCount - 1);
 
-        const AnimPoseVec& prevFrame = _anim[prevIndex];
-        const AnimPoseVec& nextFrame = _anim[nextIndex];
+        const AnimPoseVec& prevFrame = _mirrorFlag ? _mirrorAnim[prevIndex] : _anim[prevIndex];
+        const AnimPoseVec& nextFrame = _mirrorFlag ? _mirrorAnim[nextIndex] : _anim[nextIndex];
         float alpha = glm::fract(_frame);
 
         ::blend(_poses.size(), &prevFrame[0], &nextFrame[0], alpha, &_poses[0]);
@@ -162,9 +169,22 @@ void AnimClip::copyFromNetworkAnim() {
         }
     }
 
+    // mirrorAnim will be re-built on demand, if needed.
+    _mirrorAnim.clear();
+
     _poses.resize(skeletonJointCount);
 }
 
+void AnimClip::buildMirrorAnim() {
+    assert(_skeleton);
+
+    _mirrorAnim.clear();
+    _mirrorAnim.reserve(_anim.size());
+    for (auto& relPoses : _anim) {
+        _mirrorAnim.push_back(relPoses);
+        _skeleton->mirrorRelativePoses(_mirrorAnim.back());
+    }
+}
 
 const AnimPoseVec& AnimClip::getPosesInternal() const {
     return _poses;

--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -38,6 +38,7 @@ const AnimPoseVec& AnimClip::evaluate(const AnimVariantMap& animVars, float dt, 
     _endFrame = animVars.lookup(_endFrameVar, _endFrame);
     _timeScale = animVars.lookup(_timeScaleVar, _timeScale);
     _loopFlag = animVars.lookup(_loopFlagVar, _loopFlag);
+    _mirrorFlag = animVars.lookup(_mirrorFlagVar, _mirrorFlag);
     float frame = animVars.lookup(_frameVar, _frame);
 
     _frame = ::accumulateTime(_startFrame, _endFrame, _timeScale, frame, dt, _loopFlag, _id, triggersOut);

--- a/libraries/animation/src/AnimClip.h
+++ b/libraries/animation/src/AnimClip.h
@@ -27,7 +27,7 @@ public:
 
     static bool usePreAndPostPoseFromAnim;
 
-    AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag);
+    AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag);
     virtual ~AnimClip() override;
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, float dt, Triggers& triggersOut) override;
@@ -49,12 +49,16 @@ public:
     bool getLoopFlag() const { return _loopFlag; }
     void setLoopFlag(bool loopFlag) { _loopFlag = loopFlag; }
 
+    bool getMirrorFlag() const { return _mirrorFlag; }
+    void setMirrorFlag(bool mirrorFlag) { _mirrorFlag = mirrorFlag; }
+
     void loadURL(const QString& url);
 protected:
 
     virtual void setCurrentFrameInternal(float frame) override;
 
     void copyFromNetworkAnim();
+    void buildMirrorAnim();
 
     // for AnimDebugDraw rendering
     virtual const AnimPoseVec& getPosesInternal() const override;
@@ -64,12 +68,14 @@ protected:
 
     // _anim[frame][joint]
     std::vector<AnimPoseVec> _anim;
+    std::vector<AnimPoseVec> _mirrorAnim;
 
     QString _url;
     float _startFrame;
     float _endFrame;
     float _timeScale;
     bool _loopFlag;
+    bool _mirrorFlag;
     float _frame;
 
     QString _startFrameVar;

--- a/libraries/animation/src/AnimClip.h
+++ b/libraries/animation/src/AnimClip.h
@@ -36,6 +36,7 @@ public:
     void setEndFrameVar(const QString& endFrameVar) { _endFrameVar = endFrameVar; }
     void setTimeScaleVar(const QString& timeScaleVar) { _timeScaleVar = timeScaleVar; }
     void setLoopFlagVar(const QString& loopFlagVar) { _loopFlagVar = loopFlagVar; }
+    void setMirrorFlagVar(const QString& mirrorFlagVar) { _mirrorFlagVar = mirrorFlagVar; }
     void setFrameVar(const QString& frameVar) { _frameVar = frameVar; }
 
     float getStartFrame() const { return _startFrame; }
@@ -82,6 +83,7 @@ protected:
     QString _endFrameVar;
     QString _timeScaleVar;
     QString _loopFlagVar;
+    QString _mirrorFlagVar;
     QString _frameVar;
 
     // no copies

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -145,6 +145,14 @@ static NodeProcessFunc animNodeTypeToProcessFunc(AnimNode::Type type) {
     }                                                                   \
     bool NAME = NAME##_VAL.toBool()
 
+#define READ_OPTIONAL_BOOL(NAME, JSON_OBJ, DEFAULT)                     \
+    auto NAME##_VAL = JSON_OBJ.value(#NAME);                            \
+    bool NAME = DEFAULT;                                                \
+    if (NAME##_VAL.isBool()) {                                          \
+        NAME = NAME##_VAL.toBool();                                     \
+    }                                                                   \
+    do {} while (0)
+
 #define READ_FLOAT(NAME, JSON_OBJ, ID, URL, ERROR_RETURN)               \
     auto NAME##_VAL = JSON_OBJ.value(#NAME);                            \
     if (!NAME##_VAL.isDouble()) {                                       \
@@ -222,13 +230,14 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     READ_FLOAT(endFrame, jsonObj, id, jsonUrl, nullptr);
     READ_FLOAT(timeScale, jsonObj, id, jsonUrl, nullptr);
     READ_BOOL(loopFlag, jsonObj, id, jsonUrl, nullptr);
+    READ_OPTIONAL_BOOL(mirrorFlag, jsonObj, false);
 
     READ_OPTIONAL_STRING(startFrameVar, jsonObj);
     READ_OPTIONAL_STRING(endFrameVar, jsonObj);
     READ_OPTIONAL_STRING(timeScaleVar, jsonObj);
     READ_OPTIONAL_STRING(loopFlagVar, jsonObj);
 
-    auto node = std::make_shared<AnimClip>(id, url, startFrame, endFrame, timeScale, loopFlag);
+    auto node = std::make_shared<AnimClip>(id, url, startFrame, endFrame, timeScale, loopFlag, mirrorFlag);
 
     if (!startFrameVar.isEmpty()) {
         node->setStartFrameVar(startFrameVar);

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -236,6 +236,7 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     READ_OPTIONAL_STRING(endFrameVar, jsonObj);
     READ_OPTIONAL_STRING(timeScaleVar, jsonObj);
     READ_OPTIONAL_STRING(loopFlagVar, jsonObj);
+    READ_OPTIONAL_STRING(mirrorFlagVar, jsonObj);
 
     auto node = std::make_shared<AnimClip>(id, url, startFrame, endFrame, timeScale, loopFlag, mirrorFlag);
 
@@ -250,6 +251,9 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     }
     if (!loopFlagVar.isEmpty()) {
         node->setLoopFlagVar(loopFlagVar);
+    }
+    if (!mirrorFlagVar.isEmpty()) {
+        node->setMirrorFlagVar(mirrorFlagVar);
     }
 
     return node;

--- a/libraries/animation/src/AnimPose.cpp
+++ b/libraries/animation/src/AnimPose.cpp
@@ -51,6 +51,11 @@ AnimPose AnimPose::inverse() const {
     return AnimPose(glm::inverse(static_cast<glm::mat4>(*this)));
 }
 
+// mirror about x-axis without applying negative scale.
+AnimPose AnimPose::mirror() const {
+    return AnimPose(scale, glm::quat(rot.w, rot.x, -rot.y, -rot.z), glm::vec3(-trans.x, trans.y, trans.z));
+}
+
 AnimPose::operator glm::mat4() const {
     glm::vec3 xAxis = rot * glm::vec3(scale.x, 0.0f, 0.0f);
     glm::vec3 yAxis = rot * glm::vec3(0.0f, scale.y, 0.0f);

--- a/libraries/animation/src/AnimPose.h
+++ b/libraries/animation/src/AnimPose.h
@@ -30,6 +30,7 @@ struct AnimPose {
     AnimPose operator*(const AnimPose& rhs) const;
 
     AnimPose inverse() const;
+    AnimPose mirror() const;
     operator glm::mat4() const;
 
     glm::vec3 scale;

--- a/libraries/animation/src/AnimSkeleton.h
+++ b/libraries/animation/src/AnimSkeleton.h
@@ -53,6 +53,10 @@ public:
     AnimPose getAbsolutePose(int jointIndex, const AnimPoseVec& poses) const;
 
     void convertRelativePosesToAbsolute(AnimPoseVec& poses) const;
+    void convertAbsolutePosesToRelative(AnimPoseVec& poses) const;
+
+    void mirrorRelativePoses(AnimPoseVec& poses) const;
+    void mirrorAbsolutePoses(AnimPoseVec& poses) const;
 
 #ifndef NDEBUG
     void dump() const;
@@ -69,6 +73,7 @@ protected:
     AnimPoseVec _absoluteDefaultPoses;
     AnimPoseVec _relativePreRotationPoses;
     AnimPoseVec _relativePostRotationPoses;
+    std::vector<int> _mirrorMap;
 
     // no copies
     AnimSkeleton(const AnimSkeleton&) = delete;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -120,7 +120,7 @@ void Rig::overrideRoleAnimation(const QString& role, const QString& url, float f
             _origRoleAnimations[role] = node;
             const float REFERENCE_FRAMES_PER_SECOND = 30.0f;
             float timeScale = fps / REFERENCE_FRAMES_PER_SECOND;
-            auto clipNode = std::make_shared<AnimClip>(role, url, firstFrame, lastFrame, timeScale, loop);
+            auto clipNode = std::make_shared<AnimClip>(role, url, firstFrame, lastFrame, timeScale, loop, false);
             AnimNode::Pointer parent = node->getParent();
             parent->replaceChild(node, clipNode);
         } else {
@@ -152,7 +152,7 @@ void Rig::prefetchAnimation(const QString& url) {
 
     // This will begin loading the NetworkGeometry for the given URL.
     // which should speed us up if we request it later via overrideAnimation.
-    auto clipNode = std::make_shared<AnimClip>("prefetch", url, 0, 0, 1.0, false);
+    auto clipNode = std::make_shared<AnimClip>("prefetch", url, 0, 0, 1.0, false, false);
     _prefetchedAnimations.push_back(clipNode);
 }
 


### PR DESCRIPTION
This allows you to add a mirrorFlag to the animation graph json, or set the mirror flag dynamically at runTime via an animVar.

Test case: 

1) Make a copy of C:\Program Files\High Fidelity\resources\meshes\defaultAvatar_full\avatar-animation.json
2) Open the copy of the avatar-animation.json in a text editor.
3) Replace the following:

<pre>
{
   "id": "idleToWalkFwd",
   "type": "clip",
   "data": {
      "url": "http://hifi-content.s3.amazonaws.com/ozan/dev/anim/standard_anims_160127/idle_to_walk.fbx",
      "startFrame": 1.0,
      "endFrame": 19.0,
      "timeScale": 1.0,
      "loopFlag": false
    },
    "children": []
},
</pre>

with

<pre>
{
   "id": "idleToWalkFwd",
   "type": "clip",
   "data": {
      "url": "http://hifi-content.s3.amazonaws.com/ozan/dev/anim/standard_anims_160127/idle_to_walk.fbx",
      "startFrame": 1.0,
      "endFrame": 19.0,
      "timeScale": 1.0,
      "loopFlag": false,
      "mirrorFlag": true
    },
    "children": []
},
</pre>

4) Open Settings > Avatar... dialog
5) Fill in the Avatar Tuning > Avatar Animation JSON section with a file URL pointing to your copy of animation-json.  For example: `file:///C:/avatar-animation-copy.json`
6) Restart Interface
7) Now when you begin to walk, you should lead with your right foot, instead of your left, because the animation is mirrored. 