### PR TITLE
move two AvatarList invokable methods from AvatarManager to AvatarHashMap

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -268,17 +268,6 @@ QVector<AvatarManager::LocalLight> AvatarManager::getLocalLights() const {
     return _localLights;
 }
 
-QVector<QUuid> AvatarManager::getAvatarIdentifiers() {
-    QReadLocker locker(&_hashLock);
-    return _avatarHash.keys().toVector();
-}
-
-AvatarData* AvatarManager::getAvatar(QUuid avatarID) {
-    // Null/Default-constructed QUuids will return MyAvatar
-    return getAvatarBySessionID(avatarID).get();
-}
-
-
 void AvatarManager::getObjectsToRemoveFromPhysics(VectorOfMotionStates& result) {
     result.clear();
     result.swap(_motionStatesToRemoveFromPhysics);

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -39,7 +39,7 @@ public:
     void init();
 
     MyAvatar* getMyAvatar() { return _myAvatar.get(); }
-    AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID);
+    AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID) override;
 
     void updateMyAvatar(float deltaTime);
     void updateOtherAvatars(float deltaTime);
@@ -56,9 +56,6 @@ public:
 
     Q_INVOKABLE void setLocalLights(const QVector<AvatarManager::LocalLight>& localLights);
     Q_INVOKABLE QVector<AvatarManager::LocalLight> getLocalLights() const;
-    // Currently, your own avatar will be included as the null avatar id.
-    Q_INVOKABLE QVector<QUuid> getAvatarIdentifiers();
-    Q_INVOKABLE AvatarData* getAvatar(QUuid avatarID);
 
 
     void getObjectsToRemoveFromPhysics(VectorOfMotionStates& motionStates);

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -22,6 +22,16 @@ AvatarHashMap::AvatarHashMap() {
     connect(DependencyManager::get<NodeList>().data(), &NodeList::uuidChanged, this, &AvatarHashMap::sessionUUIDChanged);
 }
 
+QVector<QUuid> AvatarHashMap::getAvatarIdentifiers() {
+    QReadLocker locker(&_hashLock);
+    return _avatarHash.keys().toVector();
+}
+
+AvatarData* AvatarHashMap::getAvatar(QUuid avatarID) {
+    // Null/Default-constructed QUuids will return MyAvatar
+    return getAvatarBySessionID(avatarID).get();
+}
+
 bool AvatarHashMap::isAvatarInRange(const glm::vec3& position, const float range) {
     auto hashCopy = getHashCopy();
     foreach(const AvatarSharedPointer& sharedAvatar, hashCopy) {

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -38,7 +38,7 @@ public:
     Q_INVOKABLE QVector<QUuid> getAvatarIdentifiers();
     Q_INVOKABLE AvatarData* getAvatar(QUuid avatarID);
 
-    AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID) { return findAvatar(sessionID); }
+    virtual AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID) { return findAvatar(sessionID); }
 
 signals:
     void avatarAddedEvent(const QUuid& sessionUUID);

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -34,6 +34,12 @@ public:
     AvatarHash getHashCopy() { QReadLocker lock(&_hashLock); return _avatarHash; }
     int size() { return _avatarHash.size(); }
 
+    // Currently, your own avatar will be included as the null avatar id.
+    Q_INVOKABLE QVector<QUuid> getAvatarIdentifiers();
+    Q_INVOKABLE AvatarData* getAvatar(QUuid avatarID);
+
+    AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID) { return findAvatar(sessionID); }
+
 signals:
     void avatarAddedEvent(const QUuid& sessionUUID);
     void avatarRemovedEvent(const QUuid& sessionUUID);


### PR DESCRIPTION
- exposed `getAvatarIdentifiers` and `getAvatar` to the assignment-client Agent