### PR TITLE
Add transparency and layering for overlays

### DIFF
--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -278,7 +278,7 @@ void Circle3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Circle3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withNoCull();
+    auto builder = render::ShapeKey::Builder().withoutCullFace();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -105,7 +105,6 @@ void Circle3DOverlay::render(RenderArgs* args) {
     auto transform = _transform;
     transform.postScale(glm::vec3(getDimensions(), 1.0f));
     batch.setModelTransform(transform);
-    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false);
     
     // for our overlay, is solid means we draw a ring between the inner and outer radius of the circle, otherwise
     // we just draw a line...
@@ -276,6 +275,14 @@ void Circle3DOverlay::render(RenderArgs* args) {
         _lastInnerRadius = innerRadius;
         _lastOuterRadius = outerRadius;
     }
+}
+
+const render::ShapeKey Circle3DOverlay::getShapeKey() {
+    auto builder = render::ShapeKey::Builder().withNoCull();
+    if (getAlpha() != 1.0f) {
+        builder.withTranslucent();
+    }
+    return builder.build();
 }
 
 void Circle3DOverlay::setProperties(const QScriptValue &properties) {

--- a/interface/src/ui/overlays/Circle3DOverlay.h
+++ b/interface/src/ui/overlays/Circle3DOverlay.h
@@ -25,7 +25,7 @@ public:
     Circle3DOverlay(const Circle3DOverlay* circle3DOverlay);
     
     virtual void render(RenderArgs* args);
-    virtual const render::ShapeKey Circle3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
     virtual void setProperties(const QScriptValue& properties);
     virtual QScriptValue getProperty(const QString& property);
 

--- a/interface/src/ui/overlays/Circle3DOverlay.h
+++ b/interface/src/ui/overlays/Circle3DOverlay.h
@@ -25,6 +25,7 @@ public:
     Circle3DOverlay(const Circle3DOverlay* circle3DOverlay);
     
     virtual void render(RenderArgs* args);
+    virtual const render::ShapeKey Circle3DOverlay::getShapeKey() override;
     virtual void setProperties(const QScriptValue& properties);
     virtual QScriptValue getProperty(const QString& property);
 

--- a/interface/src/ui/overlays/Cube3DOverlay.h
+++ b/interface/src/ui/overlays/Cube3DOverlay.h
@@ -24,7 +24,7 @@ public:
     Cube3DOverlay(const Cube3DOverlay* cube3DOverlay);
     
     virtual void render(RenderArgs* args);
-    virtual const render::ShapeKey Cube3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
 
     virtual Cube3DOverlay* createClone() const;
 

--- a/interface/src/ui/overlays/Cube3DOverlay.h
+++ b/interface/src/ui/overlays/Cube3DOverlay.h
@@ -24,6 +24,7 @@ public:
     Cube3DOverlay(const Cube3DOverlay* cube3DOverlay);
     
     virtual void render(RenderArgs* args);
+    virtual const render::ShapeKey Cube3DOverlay::getShapeKey() override;
 
     virtual Cube3DOverlay* createClone() const;
 

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -93,6 +93,14 @@ void Grid3DOverlay::render(RenderArgs* args) {
     }
 }
 
+const render::ShapeKey Grid3DOverlay::getShapeKey() {
+    auto builder = render::ShapeKey::Builder();
+    if (getAlpha() != 1.0f) {
+        builder.withTranslucent();
+    }
+    return builder.build();
+}
+
 void Grid3DOverlay::setProperties(const QScriptValue& properties) {
     Planar3DOverlay::setProperties(properties);
 

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -25,6 +25,7 @@ public:
     Grid3DOverlay(const Grid3DOverlay* grid3DOverlay);
 
     virtual void render(RenderArgs* args);
+    virtual const render::ShapeKey Grid3DOverlay::getShapeKey() override;
     virtual void setProperties(const QScriptValue& properties);
     virtual QScriptValue getProperty(const QString& property);
 

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -25,7 +25,7 @@ public:
     Grid3DOverlay(const Grid3DOverlay* grid3DOverlay);
 
     virtual void render(RenderArgs* args);
-    virtual const render::ShapeKey Grid3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
     virtual void setProperties(const QScriptValue& properties);
     virtual QScriptValue getProperty(const QString& property);
 

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -104,7 +104,7 @@ void Image3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Image3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withNoCull().withDepthBias();
+    auto builder = render::ShapeKey::Builder().withoutCullFace().withDepthBias();
     if (_emissive) {
         builder.withEmissive();
     }

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -95,13 +95,23 @@ void Image3DOverlay::render(RenderArgs* args) {
     batch->setModelTransform(transform);
     batch->setResourceTexture(0, _texture->getGPUTexture());
 
-    DependencyManager::get<GeometryCache>()->bindSimpleProgram(*batch, true, false, _emissive, true);
     DependencyManager::get<GeometryCache>()->renderQuad(
         *batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
         glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha)
     );
 
     batch->setResourceTexture(0, args->_whiteTexture); // restore default white color after me
+}
+
+const render::ShapeKey Image3DOverlay::getShapeKey() {
+    auto builder = render::ShapeKey::Builder().withNoCull().withDepthBias();
+    if (_emissive) {
+        builder.withEmissive();
+    }
+    if (getAlpha() != 1.0f) {
+        builder.withTranslucent();
+    }
+    return builder.build();
 }
 
 void Image3DOverlay::setProperties(const QScriptValue &properties) {

--- a/interface/src/ui/overlays/Image3DOverlay.h
+++ b/interface/src/ui/overlays/Image3DOverlay.h
@@ -31,7 +31,7 @@ public:
 
     virtual void update(float deltatime);
 
-    virtual const render::ShapeKey Image3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
 
     // setters
     void setURL(const QString& url);

--- a/interface/src/ui/overlays/Image3DOverlay.h
+++ b/interface/src/ui/overlays/Image3DOverlay.h
@@ -31,6 +31,8 @@ public:
 
     virtual void update(float deltatime);
 
+    virtual const render::ShapeKey Image3DOverlay::getShapeKey() override;
+
     // setters
     void setURL(const QString& url);
     void setClipFromSource(const QRect& bounds) { _fromImage = bounds; }

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -53,7 +53,6 @@ void Line3DOverlay::render(RenderArgs* args) {
     auto batch = args->_batch;
     if (batch) {
         batch->setModelTransform(_transform);
-        DependencyManager::get<GeometryCache>()->bindSimpleProgram(*batch);
 
         if (getIsDashedLine()) {
             // TODO: add support for color to renderDashedLine()
@@ -62,6 +61,14 @@ void Line3DOverlay::render(RenderArgs* args) {
             DependencyManager::get<GeometryCache>()->renderLine(*batch, _start, _end, colorv4, _geometryCacheID);
         }
     }
+}
+
+const render::ShapeKey Line3DOverlay::getShapeKey() {
+    auto builder = render::ShapeKey::Builder();
+    if (getAlpha() != 1.0f) {
+        builder.withTranslucent();
+    }
+    return builder.build();
 }
 
 void Line3DOverlay::setProperties(const QScriptValue& properties) {

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -24,6 +24,7 @@ public:
     Line3DOverlay(const Line3DOverlay* line3DOverlay);
     ~Line3DOverlay();
     virtual void render(RenderArgs* args);
+    virtual const render::ShapeKey Line3DOverlay::getShapeKey() override;
     virtual AABox getBounds() const;
 
     // getters

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -24,7 +24,7 @@ public:
     Line3DOverlay(const Line3DOverlay* line3DOverlay);
     ~Line3DOverlay();
     virtual void render(RenderArgs* args);
-    virtual const render::ShapeKey Line3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
     virtual AABox getBounds() const;
 
     // getters

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -44,6 +44,8 @@ public:
     virtual bool addToScene(Overlay::Pointer overlay, std::shared_ptr<render::Scene> scene, render::PendingChanges& pendingChanges);
     virtual void removeFromScene(Overlay::Pointer overlay, std::shared_ptr<render::Scene> scene, render::PendingChanges& pendingChanges);
 
+    virtual const render::ShapeKey getShapeKey() { return render::ShapeKey::Builder::ownPipeline(); }
+
     // getters
     virtual QString getType() const = 0;
     virtual bool is3D() const = 0;
@@ -119,6 +121,7 @@ namespace render {
    template <> const Item::Bound payloadGetBound(const Overlay::Pointer& overlay);
    template <> int payloadGetLayer(const Overlay::Pointer& overlay);
    template <> void payloadRender(const Overlay::Pointer& overlay, RenderArgs* args);
+   template <> const ShapeKey shapeGetShapeKey(const Overlay::Pointer& overlay);
 }
 
  

--- a/interface/src/ui/overlays/OverlaysPayload.cpp
+++ b/interface/src/ui/overlays/OverlaysPayload.cpp
@@ -35,15 +35,18 @@
 
 namespace render {
     template <> const ItemKey payloadGetKey(const Overlay::Pointer& overlay) {
+        auto builder = ItemKey::Builder().withTypeShape();
         if (overlay->is3D() && !std::dynamic_pointer_cast<Base3DOverlay>(overlay)->getDrawOnHUD()) {
             if (std::dynamic_pointer_cast<Base3DOverlay>(overlay)->getDrawInFront()) {
-                return ItemKey::Builder().withTypeShape().withLayered().build();
-            } else {
-                return ItemKey::Builder::opaqueShape();
+                builder.withLayered();
+            }
+            if (overlay->getAlpha() != 1.0f) {
+                builder.withTransparent();
             }
         } else {
-            return ItemKey::Builder().withTypeShape().withViewSpace().build();
+            builder.withViewSpace();
         }
+        return builder.build();
     }
     template <> const Item::Bound payloadGetBound(const Overlay::Pointer& overlay) {
         return overlay->getBounds();

--- a/interface/src/ui/overlays/OverlaysPayload.cpp
+++ b/interface/src/ui/overlays/OverlaysPayload.cpp
@@ -83,4 +83,7 @@ namespace render {
             }
         }
     }
+    template <> const ShapeKey shapeGetShapeKey(const Overlay::Pointer& overlay) {
+        return overlay->getShapeKey();
+    }
 }

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -88,6 +88,14 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
     }
 }
 
+const render::ShapeKey Rectangle3DOverlay::getShapeKey() {
+    auto builder = render::ShapeKey::Builder();
+    if (getAlpha() != 1.0f) {
+        builder.withTranslucent();
+    }
+    return builder.build();
+}
+
 void Rectangle3DOverlay::setProperties(const QScriptValue &properties) {
     Planar3DOverlay::setProperties(properties);
 }

--- a/interface/src/ui/overlays/Rectangle3DOverlay.h
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.h
@@ -24,6 +24,7 @@ public:
     Rectangle3DOverlay(const Rectangle3DOverlay* rectangle3DOverlay);
     ~Rectangle3DOverlay();
     virtual void render(RenderArgs* args);
+    virtual const render::ShapeKey Rectangle3DOverlay::getShapeKey() override;
     virtual void setProperties(const QScriptValue& properties);
 
     virtual Rectangle3DOverlay* createClone() const;

--- a/interface/src/ui/overlays/Rectangle3DOverlay.h
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.h
@@ -24,7 +24,7 @@ public:
     Rectangle3DOverlay(const Rectangle3DOverlay* rectangle3DOverlay);
     ~Rectangle3DOverlay();
     virtual void render(RenderArgs* args);
-    virtual const render::ShapeKey Rectangle3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
     virtual void setProperties(const QScriptValue& properties);
 
     virtual Rectangle3DOverlay* createClone() const;

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -42,12 +42,27 @@ void Sphere3DOverlay::render(RenderArgs* args) {
         Transform transform = _transform;
         transform.postScale(getDimensions() * SPHERE_OVERLAY_SCALE);
         batch->setModelTransform(transform);
+
+        auto geometryCache = DependencyManager::get<GeometryCache>();
+        auto pipeline = args->_pipeline;
+        if (!pipeline) {
+            pipeline = geometryCache->getShapePipeline();
+        }
+
         if (_isSolid) {
-            DependencyManager::get<GeometryCache>()->renderSolidSphereInstance(*batch, sphereColor);
+            geometryCache->renderSolidSphereInstance(*batch, sphereColor, pipeline);
         } else {
-            DependencyManager::get<GeometryCache>()->renderWireSphereInstance(*batch, sphereColor);
+            geometryCache->renderWireSphereInstance(*batch, sphereColor, pipeline);
         }
     }
+}
+
+const render::ShapeKey Sphere3DOverlay::getShapeKey() {
+    auto builder = render::ShapeKey::Builder();
+    if (getAlpha() != 1.0f) {
+        builder.withTranslucent();
+    }
+    return builder.build();
 }
 
 Sphere3DOverlay* Sphere3DOverlay::createClone() const {

--- a/interface/src/ui/overlays/Sphere3DOverlay.h
+++ b/interface/src/ui/overlays/Sphere3DOverlay.h
@@ -24,7 +24,7 @@ public:
     Sphere3DOverlay(const Sphere3DOverlay* Sphere3DOverlay);
     
     virtual void render(RenderArgs* args);
-    virtual const render::ShapeKey Sphere3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
 
     virtual Sphere3DOverlay* createClone() const;
 };

--- a/interface/src/ui/overlays/Sphere3DOverlay.h
+++ b/interface/src/ui/overlays/Sphere3DOverlay.h
@@ -24,6 +24,7 @@ public:
     Sphere3DOverlay(const Sphere3DOverlay* Sphere3DOverlay);
     
     virtual void render(RenderArgs* args);
+    virtual const render::ShapeKey Sphere3DOverlay::getShapeKey() override;
 
     virtual Sphere3DOverlay* createClone() const;
 };

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -31,6 +31,8 @@ public:
 
     virtual void update(float deltatime);
 
+    virtual const render::ShapeKey getShapeKey() override;
+
     // getters
     const QString& getText() const { return _text; }
     float getLineHeight() const { return _lineHeight; }
@@ -72,5 +74,4 @@ private:
     float _bottomMargin;
 };
 
- 
 #endif // hifi_Text3DOverlay_h

--- a/interface/src/ui/overlays/Volume3DOverlay.h
+++ b/interface/src/ui/overlays/Volume3DOverlay.h
@@ -34,7 +34,7 @@ public:
     
 protected:
     // Centered local bounding box
-    AABox _localBoundingBox;
+    AABox _localBoundingBox{ vec3(0.0f), 1.0f };
 };
 
  

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -106,7 +106,7 @@ void Web3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Web3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withNoCull().withDepthBias();
+    auto builder = render::ShapeKey::Builder().withoutCullFace().withDepthBias();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -101,9 +101,16 @@ void Web3DOverlay::render(RenderArgs* args) {
     }
 
     batch.setModelTransform(transform);
-    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, true, false, false, true);
     DependencyManager::get<GeometryCache>()->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color);
     batch.setResourceTexture(0, args->_whiteTexture); // restore default white color after me
+}
+
+const render::ShapeKey Web3DOverlay::getShapeKey() {
+    auto builder = render::ShapeKey::Builder().withNoCull().withDepthBias();
+    if (getAlpha() != 1.0f) {
+        builder.withTranslucent();
+    }
+    return builder.build();
 }
 
 void Web3DOverlay::setProperties(const QScriptValue &properties) {

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -25,7 +25,7 @@ public:
     virtual ~Web3DOverlay();
 
     virtual void render(RenderArgs* args);
-    virtual const render::ShapeKey Web3DOverlay::getShapeKey() override;
+    virtual const render::ShapeKey getShapeKey() override;
 
     virtual void update(float deltatime);
 

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -25,6 +25,7 @@ public:
     virtual ~Web3DOverlay();
 
     virtual void render(RenderArgs* args);
+    virtual const render::ShapeKey Web3DOverlay::getShapeKey() override;
 
     virtual void update(float deltatime);
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -73,10 +73,12 @@ public:
         BufferPointers buffers;
         Function function;
         DrawCallInfoBuffer drawCallInfos;
+        Pipeline::Pointer pipeline;
 
         size_t count() const { return drawCallInfos.size();  }
 
         void process(Batch& batch) {
+            batch.setPipeline(pipeline);
             if (function) {
                 function(batch, *this);
             }

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -73,12 +73,10 @@ public:
         BufferPointers buffers;
         Function function;
         DrawCallInfoBuffer drawCallInfos;
-        Pipeline::Pointer pipeline;
 
         size_t count() const { return drawCallInfos.size();  }
 
         void process(Batch& batch) {
-            batch.setPipeline(pipeline);
             if (function) {
                 function(batch, *this);
             }

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -511,8 +511,8 @@ void DeferredLightingEffect::render(const render::RenderContextPointer& renderCo
     }
 }
 
-void DeferredLightingEffect::setupTransparent(gpu::Batch& batch, int lightBufferUnit) {
-    PerformanceTimer perfTimer("DLE->setupTransparent()");
+void DeferredLightingEffect::setupBatch(gpu::Batch& batch, int lightBufferUnit) {
+    PerformanceTimer perfTimer("DLE->setupBatch()");
     auto globalLight = _allocatedLights[_globalLights.front()];
     batch.setUniformBuffer(lightBufferUnit, globalLight->getSchemaBuffer());
 }

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -511,9 +511,10 @@ void DeferredLightingEffect::render(const render::RenderContextPointer& renderCo
     }
 }
 
-void DeferredLightingEffect::setupTransparent(RenderArgs* args, int lightBufferUnit) {
+void DeferredLightingEffect::setupTransparent(gpu::Batch& batch, int lightBufferUnit) {
+    PerformanceTimer perfTimer("DLE->setupTransparent()");
     auto globalLight = _allocatedLights[_globalLights.front()];
-    args->_batch->setUniformBuffer(lightBufferUnit, globalLight->getSchemaBuffer());
+    batch.setUniformBuffer(lightBufferUnit, globalLight->getSchemaBuffer());
 }
 
 static void loadLightProgram(const char* vertSource, const char* fragSource, bool lightVolume, gpu::PipelinePointer& pipeline, LightLocationsPtr& locations) {

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -46,7 +46,7 @@ public:
     void prepare(RenderArgs* args);
     void render(const render::RenderContextPointer& renderContext);
 
-    void setupTransparent(gpu::Batch& batch, int lightBufferUnit);
+    void setupBatch(gpu::Batch& batch, int lightBufferUnit);
 
     // update global lighting
     void setAmbientLightMode(int preset);

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -46,7 +46,7 @@ public:
     void prepare(RenderArgs* args);
     void render(const render::RenderContextPointer& renderContext);
 
-    void setupTransparent(RenderArgs* args, int lightBufferUnit);
+    void setupTransparent(gpu::Batch& batch, int lightBufferUnit);
 
     // update global lighting
     void setAmbientLightMode(int preset);

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1925,16 +1925,19 @@ uint32_t toCompactColor(const glm::vec4& color) {
 
 static const size_t INSTANCE_COLOR_BUFFER = 0;
 
-template <typename F>
-void renderInstances(const std::string& name, gpu::Batch& batch, const glm::vec4& color, const render::ShapePipelinePointer& pipeline, F f) {
+void renderInstances(const std::string& name, gpu::Batch& batch, const glm::vec4& color,
+                    const render::ShapePipelinePointer& pipeline, gpu::Batch::NamedBatchData::Function f) {
+    // Add color to named buffer
     {
         gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(name, INSTANCE_COLOR_BUFFER);
         auto compactColor = toCompactColor(color);
         instanceColorBuffer->append(compactColor);
     }
-    
+
+    // Add call to named buffer
     batch.setupNamedCalls(name, [f, pipeline](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        batch.setPipeline(pipeline->get(batch));
+        batch.setPipeline(pipeline->pipeline);
+        pipeline->prepare(batch);
         f(batch, data);
     });
 }

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -477,7 +477,6 @@ void GeometryCache::buildShapes() {
 
 gpu::Stream::FormatPointer& getSolidStreamFormat() {
     if (!SOLID_STREAM_FORMAT) {
-        const int VERTEX_NORMAL_OFFSET = POSITION_ELEMENT.getSize();
         SOLID_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
         SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, POSITION_ELEMENT);
         SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);
@@ -487,7 +486,6 @@ gpu::Stream::FormatPointer& getSolidStreamFormat() {
 
 gpu::Stream::FormatPointer& getInstancedSolidStreamFormat() {
     if (!INSTANCED_SOLID_STREAM_FORMAT) {
-        const int VERTEX_NORMAL_OFFSET = POSITION_ELEMENT.getSize();
         INSTANCED_SOLID_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
         INSTANCED_SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, POSITION_ELEMENT);
         INSTANCED_SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1927,15 +1927,18 @@ static const size_t INSTANCE_COLOR_BUFFER = 0;
 
 void renderInstances(const std::string& name, gpu::Batch& batch, const glm::vec4& color,
                     const render::ShapePipelinePointer& pipeline, gpu::Batch::NamedBatchData::Function f) {
+    // Add pipeline to name
+    std::string instanceName = name + std::to_string(std::hash<render::ShapePipelinePointer>()(pipeline));
+
     // Add color to named buffer
     {
-        gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(name, INSTANCE_COLOR_BUFFER);
+        gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(instanceName, INSTANCE_COLOR_BUFFER);
         auto compactColor = toCompactColor(color);
         instanceColorBuffer->append(compactColor);
     }
 
     // Add call to named buffer
-    batch.setupNamedCalls(name, [f, pipeline](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
+    batch.setupNamedCalls(instanceName, [f, pipeline](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
         batch.setPipeline(pipeline->pipeline);
         pipeline->prepare(batch);
         f(batch, data);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -158,7 +158,10 @@ public:
                                           bool emissive = false, bool depthBias = false);
     render::ShapePipelinePointer getShapePipeline() { return GeometryCache::_simplePipeline; }
     
-    // Static geometry
+    // Static (instanced) geometry
+    void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
+    void renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
+
     void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec4& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline);
     void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec3& color,
@@ -188,20 +191,14 @@ public:
     }
     
     // Dynamic geometry
-    void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
-    void renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
     void renderShape(gpu::Batch& batch, Shape shape);
     void renderWireShape(gpu::Batch& batch, Shape shape);
     size_t getShapeTriangleCount(Shape shape);
 
-    void renderCubeInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
-    void renderWireCubeInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
     void renderCube(gpu::Batch& batch);
     void renderWireCube(gpu::Batch& batch);
     size_t getCubeTriangleCount();
 
-    void renderSphereInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
-    void renderWireSphereInstances(gpu::Batch& batch, size_t count, gpu::BufferPointer colorBuffer);
     void renderSphere(gpu::Batch& batch);
     void renderWireSphere(gpu::Batch& batch);
     size_t getSphereTriangleCount();

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -166,28 +166,28 @@ public:
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline);
     void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec3& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline) {
-        renderSolidSphereInstance(batch, glm::vec4(color, 1.0), pipeline);
+        renderSolidSphereInstance(batch, glm::vec4(color, 1.0f), pipeline);
     }
     
     void renderWireSphereInstance(gpu::Batch& batch, const glm::vec4& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline);
     void renderWireSphereInstance(gpu::Batch& batch, const glm::vec3& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline) {
-        renderWireSphereInstance(batch, glm::vec4(color, 1.0), pipeline);
+        renderWireSphereInstance(batch, glm::vec4(color, 1.0f), pipeline);
     }
     
     void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec4& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline);
     void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec3& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline) {
-        renderSolidCubeInstance(batch, glm::vec4(color, 1.0), pipeline);
+        renderSolidCubeInstance(batch, glm::vec4(color, 1.0f), pipeline);
     }
     
     void renderWireCubeInstance(gpu::Batch& batch, const glm::vec4& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline);
     void renderWireCubeInstance(gpu::Batch& batch, const glm::vec3& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline) {
-        renderWireCubeInstance(batch, glm::vec4(color, 1.0), pipeline);
+        renderWireCubeInstance(batch, glm::vec4(color, 1.0f), pipeline);
     }
     
     // Dynamic geometry

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -150,31 +150,44 @@ public:
     static const int UNKNOWN_ID;
     
     
-    /// Sets up the state necessary to render static untextured geometry with the simple program.
-    gpu::PipelinePointer bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
-                                           bool emissive = false, bool depthBias = false);
+    // Bind the pipeline and get the state to render static geometry
+    void bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool culled = true,
+                                          bool emissive = false, bool depthBias = false);
+    // Get the pipeline to render static geometry
+    gpu::PipelinePointer getSimplePipeline(bool textured = false, bool culled = true,
+                                          bool emissive = false, bool depthBias = false);
+    render::ShapePipelinePointer getShapePipeline() { return GeometryCache::_simplePipeline; }
     
-    void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec4& color);
-    void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec3& color) {
-        renderSolidSphereInstance(batch, glm::vec4(color, 1.0));
+    // Static geometry
+    void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec4& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline);
+    void renderSolidSphereInstance(gpu::Batch& batch, const glm::vec3& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline) {
+        renderSolidSphereInstance(batch, glm::vec4(color, 1.0), pipeline);
     }
     
-    void renderWireSphereInstance(gpu::Batch& batch, const glm::vec4& color);
-    void renderWireSphereInstance(gpu::Batch& batch, const glm::vec3& color) {
-        renderWireSphereInstance(batch, glm::vec4(color, 1.0));
+    void renderWireSphereInstance(gpu::Batch& batch, const glm::vec4& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline);
+    void renderWireSphereInstance(gpu::Batch& batch, const glm::vec3& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline) {
+        renderWireSphereInstance(batch, glm::vec4(color, 1.0), pipeline);
     }
     
-    void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec4& color);
-    void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec3& color) {
-        renderSolidCubeInstance(batch, glm::vec4(color, 1.0));
+    void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec4& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline);
+    void renderSolidCubeInstance(gpu::Batch& batch, const glm::vec3& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline) {
+        renderSolidCubeInstance(batch, glm::vec4(color, 1.0), pipeline);
     }
     
-    void renderWireCubeInstance(gpu::Batch& batch, const glm::vec4& color);
-    void renderWireCubeInstance(gpu::Batch& batch, const glm::vec3& color) {
-        renderWireCubeInstance(batch, glm::vec4(color, 1.0));
+    void renderWireCubeInstance(gpu::Batch& batch, const glm::vec4& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline);
+    void renderWireCubeInstance(gpu::Batch& batch, const glm::vec3& color,
+                                    const render::ShapePipelinePointer& pipeline = _simplePipeline) {
+        renderWireCubeInstance(batch, glm::vec4(color, 1.0), pipeline);
     }
     
-
+    // Dynamic geometry
     void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
     void renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
     void renderShape(gpu::Batch& batch, Shape shape);
@@ -364,11 +377,9 @@ private:
 
     QHash<QUrl, QWeakPointer<NetworkGeometry> > _networkGeometry;
     
-
-    gpu::PipelinePointer getPipeline(SimpleProgramKey config);
-    
     gpu::ShaderPointer _simpleShader;
     gpu::ShaderPointer _emissiveShader;
+    static render::ShapePipelinePointer _simplePipeline;
     QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
 };
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -239,13 +239,6 @@ void MeshPartPayload::render(RenderArgs* args) const {
     // apply material properties
     bindMaterial(batch, locations);
 
-
-    // TODO: We should be able to do that just in the renderTransparentJob
-    if (key.isTranslucent() && locations->lightBufferUnit >= 0) {
-        PerformanceTimer perfTimer("DLE->setupTransparent()");
-
-        DependencyManager::get<DeferredLightingEffect>()->setupTransparent(args, locations->lightBufferUnit);
-    }
     if (args) {
         args->_details._materialSwitches++;
     }
@@ -517,13 +510,6 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     // apply material properties
     bindMaterial(batch, locations);
         
-        
-    // TODO: We should be able to do that just in the renderTransparentJob
-    if (key.isTranslucent() && locations->lightBufferUnit >= 0) {
-        PerformanceTimer perfTimer("DLE->setupTransparent()");
-            
-        DependencyManager::get<DeferredLightingEffect>()->setupTransparent(args, locations->lightBufferUnit);
-    }
     if (args) {
         args->_details._materialSwitches++;
     }

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -225,8 +225,6 @@ void MeshPartPayload::render(RenderArgs* args) const {
 
     gpu::Batch& batch = *(args->_batch);
 
-    ShapeKey key = getShapeKey();
-
     auto locations = args->_pipeline->locations;
     assert(locations);
 
@@ -468,8 +466,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
 
     gpu::Batch& batch = *(args->_batch);
 
-    ShapeKey key = getShapeKey();
-    if (!key.isValid()) {
+    if (!getShapeKey().isValid()) {
         return;
     }
 

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -104,7 +104,8 @@ RenderDeferredTask::RenderDeferredTask(CullFunctor cullFunctor) {
         addJob<DrawStatus>("DrawStatus", opaques, DrawStatus(statusIconMap));
     }
 
-    addJob<DrawOverlay3D>("DrawOverlay3D");
+    addJob<DrawOverlay3D>("DrawOverlay3DOpaque", ItemFilter::Builder::opaqueShape().withLayered());
+    addJob<DrawOverlay3D>("DrawOverlay3DTransparent", ItemFilter::Builder::transparentShape().withLayered());
 
     addJob<HitEffect>("HitEffect");
 
@@ -156,7 +157,7 @@ void DrawDeferred::run(const SceneContextPointer& sceneContext, const RenderCont
     });
 }
 
-DrawOverlay3D::DrawOverlay3D() : _shapePlumber{ std::make_shared<ShapePlumber>() } {
+DrawOverlay3D::DrawOverlay3D(ItemFilter filter) : _filter{ filter }, _shapePlumber{ std::make_shared<ShapePlumber>() } {
     initOverlay3DPipelines(*_shapePlumber);
 }
 
@@ -166,7 +167,7 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
 
     // render backgrounds
     auto& scene = sceneContext->_scene;
-    auto& items = scene->getMasterBucket().at(ItemFilter::Builder::opaqueShape().withLayered());
+    auto& items = scene->getMasterBucket().at(_filter);
 
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
 
@@ -179,7 +180,6 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
         }
     }
     config->numItems = (int)inItems.size();
-    config->numDrawn = (int)inItems.size();
 
     if (!inItems.empty()) {
         RenderArgs* args = renderContext->args;

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -87,14 +87,11 @@ public:
 class DrawOverlay3DConfig : public render::Job::Config {
     Q_OBJECT
     Q_PROPERTY(int numItems READ getNumItems)
-    Q_PROPERTY(int numDrawn READ getNumDrawn)
     Q_PROPERTY(int maxDrawn MEMBER maxDrawn NOTIFY dirty)
 public:
     int getNumItems() { return numItems; }
-    int getNumDrawn() { return numDrawn; }
 
     int numItems{ 0 };
-    int numDrawn{ 0 };
     int maxDrawn{ -1 };
 signals:
     void dirty();
@@ -105,13 +102,14 @@ public:
     using Config = DrawOverlay3DConfig;
     using JobModel = render::Job::Model<DrawOverlay3D, Config>;
 
-    DrawOverlay3D();
+    DrawOverlay3D(render::ItemFilter filter);
 
     void configure(const Config& config) { _maxDrawn = config.maxDrawn; }
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
 
 protected:
     render::ShapePlumberPointer _shapePlumber;
+    render::ItemFilter _filter;
     int _maxDrawn; // initialized by Config
 };
 

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -108,8 +108,8 @@ public:
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
 
 protected:
-    render::ShapePlumberPointer _shapePlumber;
     render::ItemFilter _filter;
+    render::ShapePlumberPointer _shapePlumber;
     int _maxDrawn; // initialized by Config
 };
 

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -96,7 +96,7 @@ void lightBatchSetter(const ShapePipeline& pipeline, gpu::Batch& batch) {
     batchSetter(pipeline, batch);
     // Set the light
     if (pipeline.locations->lightBufferUnit >= 0) {
-        DependencyManager::get<DeferredLightingEffect>()->setupTransparent(batch, pipeline.locations->lightBufferUnit);
+        DependencyManager::get<DeferredLightingEffect>()->setupBatch(batch, pipeline.locations->lightBufferUnit);
     }
 }
 

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -76,7 +76,15 @@ void initOverlay3DPipelines(ShapePlumber& plumber) {
     opaqueState->setDepthTest(false);
     opaqueState->setBlendFunction(false);
 
+    auto transparentState = std::make_shared<gpu::State>();
+    transparentState->setDepthTest(false);
+    transparentState->setBlendFunction(true,
+        gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+        gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
+
+
     plumber.addPipeline(ShapeKey::Filter::Builder().withOpaque(), program, opaqueState, &batchSetter);
+    plumber.addPipeline(ShapeKey::Filter::Builder().withTranslucent(), program, transparentState, &batchSetter);
 }
 
 void initDeferredPipelines(render::ShapePlumber& plumber) {

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -135,7 +135,7 @@ void initOverlay3DPipelines(ShapePlumber& plumber) {
         }
 
         ShapeKey::Filter::Builder builder;
-        isCulled ? builder.withCull() : builder.withoutCull();
+        isCulled ? builder.withCullFace() : builder.withoutCullFace();
         isBiased ? builder.withDepthBias() : builder.withoutDepthBias();
         isOpaque ? builder.withOpaque() : builder.withTranslucent();
 
@@ -154,7 +154,7 @@ void initDeferredPipelines(render::ShapePlumber& plumber) {
         // These keyvalues' pipelines will be added by this lamdba in addition to the key passed
         assert(!key.isWireFrame());
         assert(!key.isDepthBiased());
-        assert(key.isCulled());
+        assert(key.isCullFace());
 
         ShaderPointer program = gpu::Shader::createProgram(vertexShader, pixelShader);
 
@@ -173,7 +173,7 @@ void initDeferredPipelines(render::ShapePlumber& plumber) {
                 gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
             if (!isCulled) {
-                builder.withNoCull();
+                builder.withoutCullFace();
             }
             state->setCullMode(isCulled ? gpu::State::CULL_BACK : gpu::State::CULL_NONE);
             if (isWireframed) {

--- a/libraries/render-utils/src/TextRenderer3D.cpp
+++ b/libraries/render-utils/src/TextRenderer3D.cpp
@@ -72,12 +72,12 @@ float TextRenderer3D::getFontSize() const {
 }
 
 void TextRenderer3D::draw(gpu::Batch& batch, float x, float y, const QString& str, const glm::vec4& color,
-                         const glm::vec2& bounds) {
+                         const glm::vec2& bounds, bool layered) {
     // The font does all the OpenGL work
     if (_font) {
         // Cache color so that the pointer stays valid.
         _color = color;
-        _font->drawString(batch, x, y, str, &_color, _effectType, bounds);
+        _font->drawString(batch, x, y, str, &_color, _effectType, bounds, layered);
     }
 }
 

--- a/libraries/render-utils/src/TextRenderer3D.h
+++ b/libraries/render-utils/src/TextRenderer3D.h
@@ -40,7 +40,7 @@ public:
     float getFontSize() const; // Pixel size
     
     void draw(gpu::Batch& batch, float x, float y, const QString& str, const glm::vec4& color = glm::vec4(1.0f),
-              const glm::vec2& bounds = glm::vec2(-1.0f));
+              const glm::vec2& bounds = glm::vec2(-1.0f), bool layered = false);
 
 private:
     TextRenderer3D(const char* family, float pointSize, int weight = -1, bool italic = false,

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -1,7 +1,7 @@
 <@include gpu/Config.slh@>
 <$VERSION_HEADER$>
 //  Generated on <$_SCRIBE_DATE$>
-//  model.vert
+//  model.slv
 //  vertex shader
 //
 //  Created by Andrzej Kapolka on 10/14/13.
@@ -17,21 +17,18 @@
 <$declareStandardTransform()$>
 
 const int MAX_TEXCOORDS = 2;
-
 uniform mat4 texcoordMatrices[MAX_TEXCOORDS];
 
-out vec4 _position;
-out vec3 _normal;
 out vec3 _color;
 out float _alpha;
 out vec2 _texCoord0;
+out vec4 _position;
+out vec3 _normal;
 
 void main(void) {
-    // pass along the diffuse color in linear space
     _color = colorToLinearRGB(inColor.xyz);
     _alpha = inColor.w;
 
-    // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.st, 0.0, 1.0)).st;
 
     // standard transform

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -23,11 +23,13 @@ uniform mat4 texcoordMatrices[MAX_TEXCOORDS];
 out vec4 _position;
 out vec3 _normal;
 out vec3 _color;
+out float _alpha;
 out vec2 _texCoord0;
 
 void main(void) {
     // pass along the diffuse color in linear space
     _color = colorToLinearRGB(inColor.xyz);
+    _alpha = inColor.w;
 
     // and the texture coordinates
     _texCoord0 = (texcoordMatrices[0] * vec4(inTexCoord0.st, 0.0, 1.0)).st;

--- a/libraries/render-utils/src/model_emissive.slf
+++ b/libraries/render-utils/src/model_emissive.slf
@@ -1,0 +1,38 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  model_emissive.frag
+//  fragment shader
+//
+//  Created by Zach Pomerantz on 2/3/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+<@include model/Material.slh@>
+
+uniform sampler2D diffuseMap;
+
+in vec2 _texCoord0;
+in vec3 _normal;
+in vec3 _color;
+in float _alpha;
+
+void main(void) {
+    vec4 texel = texture(diffuseMap, _texCoord0);
+
+    Material mat = getMaterial();
+    vec3 fragColor = getMaterialDiffuse(mat) * texel.rgb * _color;
+
+    packDeferredFragmentLightmap(
+        normalize(_normal), 
+        texel.a,
+        vec3(1.0),
+        getMaterialSpecular(mat),
+        getMaterialShininess(mat),
+        fragColor);
+}

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -11,16 +11,14 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
 <@include model/Material.slh@>
 
-// Everything about global lighting
-
 <@include DeferredLighting.slh@>
+<@include model/Light.slh@>
+
 <@include gpu/Transform.slh@>
 <$declareStandardCameraTransform()$>
-
-// Everything about light
-<@include model/Light.slh@>
 
 vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 diffuse, vec3 specular, float gloss, float opacity) {
 
@@ -42,11 +40,10 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 d
     return vec4(color, opacity);
 }
 
-// the diffuse texture
 uniform sampler2D diffuseMap;
 
-in vec4 _position;
 in vec2 _texCoord0;
+in vec4 _position;
 in vec3 _normal;
 in vec3 _color;
 in float _alpha;
@@ -54,17 +51,15 @@ in float _alpha;
 out vec4 _fragColor;
 
 void main(void) {
-    vec3 fragPosition = _position.xyz;
-
-    // Fetch diffuse map
     vec4 diffuse = texture(diffuseMap, _texCoord0);
 
     Material mat = getMaterial();
+    vec3 fragPosition = _position.xyz;
     vec3 fragNormal = normalize(_normal);
-    float fragOpacity = getMaterialOpacity(mat) * diffuse.a * _alpha;
     vec3 fragDiffuse = getMaterialDiffuse(mat) * diffuse.rgb * _color;
     vec3 fragSpecular = getMaterialSpecular(mat);
     float fragGloss = getMaterialShininess(mat);
+    float fragOpacity = getMaterialOpacity(mat) * diffuse.a * _alpha;
 
     _fragColor =  evalGlobalColor(1.0,
         fragPosition,

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -35,7 +35,7 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 d
 
     vec4 shading = evalFragShading(fragNormal, -getLightDirection(light), fragEyeDir, specular, gloss);
 
-    color += vec3(opacity * diffuse + shading.rgb) * shading.w * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
+    color += vec3(diffuse * shading.w * opacity + shading.rgb) * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
 
     return vec4(color, opacity);
 }
@@ -58,7 +58,7 @@ void main(void) {
     vec3 fragNormal = normalize(_normal);
     vec3 fragDiffuse = getMaterialDiffuse(mat) * diffuse.rgb * _color;
     vec3 fragSpecular = getMaterialSpecular(mat);
-    float fragGloss = getMaterialShininess(mat);
+    float fragGloss = getMaterialShininess(mat) / 128;
     float fragOpacity = getMaterialOpacity(mat) * diffuse.a * _alpha;
 
     _fragColor =  evalGlobalColor(1.0,

--- a/libraries/render-utils/src/model_translucent_emissive.slf
+++ b/libraries/render-utils/src/model_translucent_emissive.slf
@@ -1,0 +1,33 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  model_translucent_emissive.frag
+//  fragment shader
+//
+//  Created by Zach Pomerantz on 2/3/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include model/Material.slh@>
+
+uniform sampler2D diffuseMap;
+
+in vec2 _texCoord0;
+in vec3 _color;
+in float _alpha;
+
+out vec4 _fragColor;
+
+void main(void) {
+    vec4 diffuse = texture(diffuseMap, _texCoord0);
+
+    Material mat = getMaterial();
+    vec3 fragColor = getMaterialDiffuse(mat) * diffuse.rgb * _color;
+    float fragOpacity = getMaterialOpacity(mat) * diffuse.a * _alpha;
+
+    _fragColor = vec4(fragColor, fragOpacity);
+}

--- a/libraries/render-utils/src/overlay3D.slf
+++ b/libraries/render-utils/src/overlay3D.slf
@@ -1,7 +1,7 @@
 <@include gpu/Config.slh@>
 <$VERSION_HEADER$>
 //  Generated on <$_SCRIBE_DATE$>
-//  model.frag
+//  overlay3D.slf
 //  fragment shader
 //
 //  Created by Sam Gateau on 6/16/15.
@@ -11,20 +11,60 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-uniform sampler2D diffuseMap;
+<@include DeferredLighting.slh@>
+<@include model/Light.slh@>
 
-in vec2 varTexcoord;
+<@include gpu/Transform.slh@>
+<$declareStandardCameraTransform()$>
 
-in vec3 varEyeNormal;
+vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 diffuse, vec3 specular, float gloss, float opacity) {
 
-in vec4 varColor;
-out vec4 outFragColor;
+    // Need the light now
+    Light light = getLight();
+    TransformCamera cam = getTransformCamera();
+    vec3 fragNormal;
+    <$transformEyeToWorldDir(cam, normal, fragNormal)$>
+    vec3 fragEyeVectorView = normalize(-position);
+    vec3 fragEyeDir;
+    <$transformEyeToWorldDir(cam, fragEyeVectorView, fragEyeDir)$>
 
+    vec3 color = opacity * diffuse.rgb * getLightColor(light) * getLightAmbientIntensity(light);
+
+    vec4 shading = evalFragShading(fragNormal, -getLightDirection(light), fragEyeDir, specular, gloss);
+    color += vec3(opacity * diffuse + shading.rgb) * shading.w * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
+
+    return vec4(color, opacity);
+}
+
+uniform sampler2D originalTexture;
+
+in vec2 _texCoord0;
+in vec4 _position;
+in vec3 _normal;
+in vec3 _color;
+in float _alpha;
+
+out vec4 _fragColor;
 
 void main(void) {
-    vec4 diffuse = texture(diffuseMap, varTexcoord.st);
-    if (diffuse.a < 0.5) {
+    vec4 diffuse = texture(originalTexture, _texCoord0);
+
+    vec3 fragPosition = _position.xyz;
+    vec3 fragNormal = normalize(_normal);
+    vec3 fragDiffuse = diffuse.rgb * _color;
+    vec3 fragSpecular = vec3(0.1);
+    float fragGloss = 10;
+    float fragOpacity = diffuse.a;
+
+    if (fragOpacity <= 0.1) {
         discard;
     }
-    outFragColor = vec4(varColor * diffuse);
+
+    _fragColor =  evalGlobalColor(1.0,
+        fragPosition,
+        fragNormal,
+        fragDiffuse,
+        fragSpecular,
+        fragGloss,
+        fragOpacity);
 }

--- a/libraries/render-utils/src/overlay3D.slf
+++ b/libraries/render-utils/src/overlay3D.slf
@@ -31,7 +31,8 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 d
     vec3 color = opacity * diffuse.rgb * getLightColor(light) * getLightAmbientIntensity(light);
 
     vec4 shading = evalFragShading(fragNormal, -getLightDirection(light), fragEyeDir, specular, gloss);
-    color += vec3(opacity * diffuse + shading.rgb) * shading.w * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
+
+    color += vec3(diffuse * shading.w * opacity + shading.rgb) * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
 
     return vec4(color, opacity);
 }
@@ -53,7 +54,7 @@ void main(void) {
     vec3 fragNormal = normalize(_normal);
     vec3 fragDiffuse = diffuse.rgb * _color;
     vec3 fragSpecular = vec3(0.1);
-    float fragGloss = 10;
+    float fragGloss = 10.0 / 128.0;
     float fragOpacity = diffuse.a;
 
     if (fragOpacity <= 0.1) {

--- a/libraries/render-utils/src/overlay3D.slf
+++ b/libraries/render-utils/src/overlay3D.slf
@@ -61,11 +61,14 @@ void main(void) {
         discard;
     }
 
-    _fragColor =  evalGlobalColor(1.0,
+    vec4 color =  evalGlobalColor(1.0,
         fragPosition,
         fragNormal,
         fragDiffuse,
         fragSpecular,
         fragGloss,
         fragOpacity);
+
+    // Apply standard tone mapping
+    _fragColor = vec4(pow(color.xyz, vec3(1.0 / 2.2)), color.w);
 }

--- a/libraries/render-utils/src/overlay3D.slv
+++ b/libraries/render-utils/src/overlay3D.slv
@@ -2,6 +2,7 @@
 <$VERSION_HEADER$>
 //  Generated on <$_SCRIBE_DATE$>
 //  overlay3D.slv
+//  vertex shader
 //
 //  Created by Sam Gateau on 6/16/15.
 //  Copyright 2015 High Fidelity, Inc.
@@ -15,22 +16,21 @@
 <@include gpu/Transform.slh@>
 <$declareStandardTransform()$>
 
+out vec3 _color;
+out float _alpha;
 out vec2 _texCoord0;
-
 out vec4 _position;
 out vec3 _normal;
 
-out vec3 _color;
-out float _alpha;
-
 void main(void) {
-    _texCoord0 = inTexCoord0.xy;
     _color = colorToLinearRGB(inColor.xyz);
     _alpha = inColor.w;
+
+    _texCoord0 = inTexCoord0.st;
 
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
-    <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal.xyz)$>
+    <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal)$>
 }

--- a/libraries/render-utils/src/overlay3D.slv
+++ b/libraries/render-utils/src/overlay3D.slv
@@ -15,25 +15,22 @@
 <@include gpu/Transform.slh@>
 <$declareStandardTransform()$>
 
-out vec2 varTexcoord;
+out vec2 _texCoord0;
 
-// interpolated eye position
-out vec4 varEyePosition;
+out vec4 _position;
+out vec3 _normal;
 
-// the interpolated normal
-out vec3 varEyeNormal;
-
-out vec4 varColor;
+out vec3 _color;
+out float _alpha;
 
 void main(void) {
-    varTexcoord = inTexCoord0.xy;
-
-    // pass along the color
-    varColor = colorToLinearRGBA(inColor);
+    _texCoord0 = inTexCoord0.xy;
+    _color = colorToLinearRGB(inColor.xyz);
+    _alpha = inColor.w;
 
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, varEyePosition, gl_Position)$>
-    <$transformModelToEyeDir(cam, obj, inNormal.xyz, varEyeNormal.xyz)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
+    <$transformModelToEyeDir(cam, obj, inNormal.xyz, _normal.xyz)$>
 }

--- a/libraries/render-utils/src/overlay3D_emissive.slf
+++ b/libraries/render-utils/src/overlay3D_emissive.slf
@@ -25,5 +25,8 @@ void main(void) {
     if (diffuse.a <= 0.1) {
         discard;
     }
-    _fragColor = vec4(diffuse.rgb * _color, diffuse.a);
+    vec4 color = vec4(diffuse.rgb * _color, diffuse.a);
+
+    // Apply standard tone mapping
+    _fragColor = vec4(pow(color.xyz, vec3(1.0 / 2.2)), color.w);
 }

--- a/libraries/render-utils/src/overlay3D_emissive.slf
+++ b/libraries/render-utils/src/overlay3D_emissive.slf
@@ -1,0 +1,29 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  overlay3D_emissive.frag
+//  fragment shader
+//
+//  Created by Zach Pomerantz on 2/2/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+uniform sampler2D originalTexture;
+
+in vec2 _texCoord0;
+in vec3 _color;
+
+out vec4 _fragColor;
+
+void main(void) {
+    vec4 diffuse = texture(originalTexture, _texCoord0);
+
+    if (diffuse.a <= 0.1) {
+        discard;
+    }
+    _fragColor = vec4(diffuse.rgb * _color, diffuse.a);
+}

--- a/libraries/render-utils/src/overlay3D_translucent.slf
+++ b/libraries/render-utils/src/overlay3D_translucent.slf
@@ -1,26 +1,21 @@
 <@include gpu/Config.slh@>
 <$VERSION_HEADER$>
 //  Generated on <$_SCRIBE_DATE$>
-//
-//  model_translucent.frag
+//  overlay3D_translucent.slf
 //  fragment shader
 //
-//  Created by Andrzej Kapolka on 9/19/14.
-//  Copyright 2014 High Fidelity, Inc.
+//  Created by Sam Gateau on 6/16/15.
+//  Copyright 2015 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-<@include model/Material.slh@>
-
-// Everything about global lighting
 
 <@include DeferredLighting.slh@>
+<@include model/Light.slh@>
+
 <@include gpu/Transform.slh@>
 <$declareStandardCameraTransform()$>
-
-// Everything about light
-<@include model/Light.slh@>
 
 vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 diffuse, vec3 specular, float gloss, float opacity) {
 
@@ -36,17 +31,15 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 d
     vec3 color = opacity * diffuse.rgb * getLightColor(light) * getLightAmbientIntensity(light);
 
     vec4 shading = evalFragShading(fragNormal, -getLightDirection(light), fragEyeDir, specular, gloss);
-
     color += vec3(opacity * diffuse + shading.rgb) * shading.w * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
 
     return vec4(color, opacity);
 }
 
-// the diffuse texture
-uniform sampler2D diffuseMap;
+uniform sampler2D originalTexture;
 
-in vec4 _position;
 in vec2 _texCoord0;
+in vec4 _position;
 in vec3 _normal;
 in vec3 _color;
 in float _alpha;
@@ -54,17 +47,14 @@ in float _alpha;
 out vec4 _fragColor;
 
 void main(void) {
+    vec4 diffuse = texture(originalTexture, _texCoord0);
+
     vec3 fragPosition = _position.xyz;
-
-    // Fetch diffuse map
-    vec4 diffuse = texture(diffuseMap, _texCoord0);
-
-    Material mat = getMaterial();
     vec3 fragNormal = normalize(_normal);
-    float fragOpacity = getMaterialOpacity(mat) * diffuse.a * _alpha;
-    vec3 fragDiffuse = getMaterialDiffuse(mat) * diffuse.rgb * _color;
-    vec3 fragSpecular = getMaterialSpecular(mat);
-    float fragGloss = getMaterialShininess(mat);
+    vec3 fragDiffuse = diffuse.rgb * _color;
+    vec3 fragSpecular = vec3(0.1);
+    float fragGloss = 10;
+    float fragOpacity = diffuse.a * _alpha;
 
     _fragColor =  evalGlobalColor(1.0,
         fragPosition,

--- a/libraries/render-utils/src/overlay3D_translucent.slf
+++ b/libraries/render-utils/src/overlay3D_translucent.slf
@@ -58,11 +58,14 @@ void main(void) {
     float fragGloss = 10.0 / 128.0;
     float fragOpacity = diffuse.a * _alpha;
 
-    _fragColor =  evalGlobalColor(1.0,
+    vec4 color =  evalGlobalColor(1.0,
         fragPosition,
         fragNormal,
         fragDiffuse,
         fragSpecular,
         fragGloss,
         fragOpacity);
+
+    // Apply standard tone mapping
+    _fragColor = vec4(pow(color.xyz, vec3(1.0 / 2.2)), color.w);
 }

--- a/libraries/render-utils/src/overlay3D_translucent.slf
+++ b/libraries/render-utils/src/overlay3D_translucent.slf
@@ -1,6 +1,7 @@
 <@include gpu/Config.slh@>
 <$VERSION_HEADER$>
 //  Generated on <$_SCRIBE_DATE$>
+//
 //  overlay3D_translucent.slf
 //  fragment shader
 //
@@ -31,7 +32,8 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 d
     vec3 color = opacity * diffuse.rgb * getLightColor(light) * getLightAmbientIntensity(light);
 
     vec4 shading = evalFragShading(fragNormal, -getLightDirection(light), fragEyeDir, specular, gloss);
-    color += vec3(opacity * diffuse + shading.rgb) * shading.w * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
+
+    color += vec3(diffuse * shading.w * opacity + shading.rgb) * shadowAttenuation * getLightColor(light) * getLightIntensity(light);
 
     return vec4(color, opacity);
 }
@@ -53,7 +55,7 @@ void main(void) {
     vec3 fragNormal = normalize(_normal);
     vec3 fragDiffuse = diffuse.rgb * _color;
     vec3 fragSpecular = vec3(0.1);
-    float fragGloss = 10;
+    float fragGloss = 10.0 / 128.0;
     float fragOpacity = diffuse.a * _alpha;
 
     _fragColor =  evalGlobalColor(1.0,

--- a/libraries/render-utils/src/overlay3D_translucent_emissive.slf
+++ b/libraries/render-utils/src/overlay3D_translucent_emissive.slf
@@ -1,0 +1,27 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  overlay3D_translucent_emissive.frag
+//  fragment shader
+//
+//  Created by Zach Pomerantz on 2/2/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+uniform sampler2D originalTexture;
+
+in vec2 _texCoord0;
+in vec3 _color;
+in float _alpha;
+
+out vec4 _fragColor;
+
+void main(void) {
+    vec4 diffuse = texture(originalTexture, _texCoord0);
+
+    _fragColor = vec4(diffuse.rgb * _color, diffuse.a * _alpha);
+}

--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -234,6 +234,10 @@ void Font::setupGPU() {
                 gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
                 gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
             _pipeline = gpu::Pipeline::create(program, state);
+
+            auto layeredState = std::make_shared<gpu::State>(state->getValues());
+            layeredState->setDepthTest(false);
+            _layeredPipeline = gpu::Pipeline::create(program, layeredState);
         }
 
         // Sanity checks
@@ -336,7 +340,7 @@ void Font::rebuildVertices(float x, float y, const QString& str, const glm::vec2
 }
 
 void Font::drawString(gpu::Batch& batch, float x, float y, const QString& str, const glm::vec4* color,
-                      EffectType effectType, const glm::vec2& bounds) {
+                      EffectType effectType, const glm::vec2& bounds, bool layered) {
     if (str == "") {
         return;
     }
@@ -347,7 +351,7 @@ void Font::drawString(gpu::Batch& batch, float x, float y, const QString& str, c
 
     setupGPU();
 
-    batch.setPipeline(_pipeline);
+    batch.setPipeline(layered ? _layeredPipeline : _pipeline);
     batch.setResourceTexture(_fontLoc, _texture);
     batch._glUniform1i(_outlineLoc, (effectType == OUTLINE_EFFECT));
     batch._glUniform4fv(_colorLoc, 1, (const float*)color);

--- a/libraries/render-utils/src/text/Font.h
+++ b/libraries/render-utils/src/text/Font.h
@@ -27,7 +27,7 @@ public:
     // Render string to batch
     void drawString(gpu::Batch& batch, float x, float y, const QString& str,
         const glm::vec4* color, EffectType effectType,
-        const glm::vec2& bound);
+        const glm::vec2& bound, bool layered = false);
 
     static Font* load(QIODevice& fontFile);
     static Font* load(const QString& family);
@@ -61,6 +61,7 @@ private:
 
     // gpu structures
     gpu::PipelinePointer _pipeline;
+    gpu::PipelinePointer _layeredPipeline;
     gpu::TexturePointer _texture;
     gpu::Stream::FormatPointer _format;
     gpu::BufferPointer _verticesBuffer;

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -143,6 +143,7 @@ void renderShape(RenderArgs* args, const ShapePlumberPointer& shapeContext, cons
         if (args->_pipeline) {
             item.render(args);
         }
+        args->_pipeline = nullptr;
     } else if (key.hasOwnPipeline()) {
         item.render(args);
     } else {

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -22,11 +22,6 @@ ShapeKey::Filter::Builder::Builder() {
     _mask.set(INVALID);
 }
 
-gpu::PipelinePointer ShapePipeline::get(gpu::Batch& batch) {
-    batchSetter(*this, batch);
-    return this->pipeline;
-}
-
 void ShapePlumber::addPipelineHelper(const Filter& filter, ShapeKey key, int bit, const PipelinePointer& pipeline) {
     // Iterate over all keys
     if (bit < (int)ShapeKey::FlagBit::NUM_FLAGS) {

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -95,13 +95,13 @@ const ShapePipelinePointer ShapePlumber::pickPipeline(RenderArgs* args, const Ke
     PipelinePointer shapePipeline(pipelineIterator->second);
     auto& batch = args->_batch;
 
+    // Setup the one pipeline (to rule them all)
+    batch->setPipeline(shapePipeline->pipeline);
+
     // Run the pipeline's BatchSetter on the passed in batch
     if (shapePipeline->batchSetter) {
         shapePipeline->batchSetter(*shapePipeline, *batch);
     }
-
-    // Setup the one pipeline (to rule them all)
-    batch->setPipeline(shapePipeline->pipeline);
 
     return shapePipeline;
 }

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -22,6 +22,11 @@ ShapeKey::Filter::Builder::Builder() {
     _mask.set(INVALID);
 }
 
+gpu::PipelinePointer ShapePipeline::get(gpu::Batch& batch) {
+    batchSetter(*this, batch);
+    return this->pipeline;
+}
+
 void ShapePlumber::addPipelineHelper(const Filter& filter, ShapeKey key, int bit, const PipelinePointer& pipeline) {
     // Iterate over all keys
     if (bit < (int)ShapeKey::FlagBit::NUM_FLAGS) {

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -17,6 +17,12 @@
 
 using namespace render;
 
+void ShapePipeline::prepare(gpu::Batch& batch) {
+    if (batchSetter) {
+        batchSetter(*this, batch);
+    }
+}
+
 ShapeKey::Filter::Builder::Builder() {
     _mask.set(OWN_PIPELINE);
     _mask.set(INVALID);

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -223,9 +223,9 @@ public:
     ShapePipeline(gpu::PipelinePointer pipeline, LocationsPointer locations, BatchSetter batchSetter) :
         pipeline(pipeline), locations(locations), batchSetter(batchSetter) {}
 
-    // Normally, a pipeline is accessed thorugh pickPipeline. If it needs to be accessed manually,
-    // this method preps the pipeline with defaults set by its batchSetter and returns only the gpu::Pipeline.
-    gpu::PipelinePointer get(gpu::Batch& batch);
+    // Normally, a pipeline is accessed thorugh pickPipeline. If it needs to be set manually,
+    // after calling setPipeline this method should be called to prepare the pipeline with default buffers.
+    void prepare(gpu::Batch& batch) { batchSetter(*this, batch); }
 
     gpu::PipelinePointer pipeline;
     std::shared_ptr<Locations> locations;

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -30,7 +30,7 @@ public:
         DEPTH_ONLY,
         DEPTH_BIAS,
         WIREFRAME,
-        CULL,
+        NO_CULL_FACE,
 
         OWN_PIPELINE,
         INVALID,
@@ -41,12 +41,12 @@ public:
 
     Flags _flags;
 
-    ShapeKey() : _flags{0} { _flags.set(CULL); }
+    ShapeKey() : _flags{ 0 } {}
     ShapeKey(const Flags& flags) : _flags{flags} {}
 
     class Builder {
     public:
-        Builder() { _flags.set(CULL); }
+        Builder() {}
         Builder(ShapeKey key) : _flags{key._flags} {}
 
         ShapeKey build() const { return ShapeKey{_flags}; }
@@ -61,7 +61,7 @@ public:
         Builder& withDepthOnly() { _flags.set(DEPTH_ONLY); return (*this); }
         Builder& withDepthBias() { _flags.set(DEPTH_BIAS); return (*this); }
         Builder& withWireframe() { _flags.set(WIREFRAME); return (*this); }
-        Builder& withNoCull() { _flags.reset(CULL); return (*this); }
+        Builder& withoutCullFace() { _flags.reset(NO_CULL_FACE); return (*this); }
 
         Builder& withOwnPipeline() { _flags.set(OWN_PIPELINE); return (*this); }
         Builder& invalidate() { _flags.set(INVALID); return (*this); }
@@ -117,8 +117,8 @@ public:
             Builder& withWireframe() { _flags.set(WIREFRAME); _mask.set(WIREFRAME); return (*this); }
             Builder& withoutWireframe() { _flags.reset(WIREFRAME); _mask.set(WIREFRAME); return (*this); }
 
-            Builder& withCull() { _flags.set(CULL); _mask.set(CULL); return (*this); }
-            Builder& withoutCull() { _flags.reset(CULL); _mask.set(CULL); return (*this); }
+            Builder& withCullFace() { _flags.reset(NO_CULL_FACE); _mask.set(NO_CULL_FACE); return (*this); }
+            Builder& withoutCullFace() { _flags.set(NO_CULL_FACE); _mask.set(NO_CULL_FACE); return (*this); }
 
         protected:
             friend class Filter;
@@ -142,7 +142,7 @@ public:
     bool isDepthOnly() const { return _flags[DEPTH_ONLY]; }
     bool isDepthBiased() const { return _flags[DEPTH_BIAS]; }
     bool isWireFrame() const { return _flags[WIREFRAME]; }
-    bool isCulled() const { return _flags[CULL]; }
+    bool isCullFace() const { return !_flags[NO_CULL_FACE]; }
 
     bool hasOwnPipeline() const { return _flags[OWN_PIPELINE]; }
     bool isValid() const { return !_flags[INVALID]; }
@@ -178,7 +178,7 @@ inline QDebug operator<<(QDebug debug, const ShapeKey& key) {
                 << "isDepthOnly:" << key.isDepthOnly()
                 << "isDepthBiased:" << key.isDepthBiased()
                 << "isWireFrame:" << key.isWireFrame()
-                << "isCulled:" << key.isCulled()
+                << "isCullFace:" << key.isCullFace()
                 << "]";
         }
     } else {

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -209,6 +209,10 @@ public:
     ShapePipeline(gpu::PipelinePointer pipeline, LocationsPointer locations, BatchSetter batchSetter) :
         pipeline(pipeline), locations(locations), batchSetter(batchSetter) {}
 
+    // Normally, a pipeline is accessed thorugh pickPipeline. If it needs to be accessed manually,
+    // this method preps the pipeline with defaults set by its batchSetter and returns only the gpu::Pipeline.
+    gpu::PipelinePointer get(gpu::Batch& batch);
+
     gpu::PipelinePointer pipeline;
     std::shared_ptr<Locations> locations;
 

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -225,7 +225,7 @@ public:
 
     // Normally, a pipeline is accessed thorugh pickPipeline. If it needs to be set manually,
     // after calling setPipeline this method should be called to prepare the pipeline with default buffers.
-    void prepare(gpu::Batch& batch) { batchSetter(*this, batch); }
+    void prepare(gpu::Batch& batch);
 
     gpu::PipelinePointer pipeline;
     std::shared_ptr<Locations> locations;

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -61,7 +61,7 @@ public:
         Builder& withDepthOnly() { _flags.set(DEPTH_ONLY); return (*this); }
         Builder& withDepthBias() { _flags.set(DEPTH_BIAS); return (*this); }
         Builder& withWireframe() { _flags.set(WIREFRAME); return (*this); }
-        Builder& withoutCullFace() { _flags.reset(NO_CULL_FACE); return (*this); }
+        Builder& withoutCullFace() { _flags.set(NO_CULL_FACE); return (*this); }
 
         Builder& withOwnPipeline() { _flags.set(OWN_PIPELINE); return (*this); }
         Builder& invalidate() { _flags.set(INVALID); return (*this); }

--- a/tests/gpu-test/src/main.cpp
+++ b/tests/gpu-test/src/main.cpp
@@ -239,6 +239,7 @@ public:
                 }
             }
 
+            auto pipeline = geometryCache->getSimplePipeline();
             for (auto& transform : transforms) {
                 batch.setModelTransform(transform);
                 batch.setupNamedCalls(GRID_INSTANCE, [=](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {


### PR DESCRIPTION
Commits d14ce8a..a790b09 update the geometry cache to:
- Allow passing of an explicit ShapePipeline into instanced draw calls, in order to add buffers.
- Supply a normal buffer to draw calls, and fix those for instanced shapes.

Commits 127f969..60f3ee5 implement various fixes necessary for overlays to work.

Commits 399fe95..53bd595 update the overlay and emissive shaders and pipelines (through their plumbers) and update all appropriate overlays to render through them.

The effect of all of this is to allow overlays to be layered (if `drawInFront` is set) and transparent (if `alpha != 0.1`).