### PR TITLE
fix ATP SendQueue failure to receive after re-activity

### DIFF
--- a/libraries/networking/src/udt/Connection.h
+++ b/libraries/networking/src/udt/Connection.h
@@ -139,6 +139,8 @@ private:
     
     SequenceNumber _lastSentACK; // The last sent ACK
     SequenceNumber _lastSentACK2; // The last sent ACK sub-sequence number in an ACK2
+
+    SequenceNumber _inactiveSendQueueSequenceNumber { 0 };
    
     int _acksDuringSYN { 1 }; // The number of non-SYN ACKs sent during SYN
     int _lightACKsDuringSYN { 1 }; // The number of lite ACKs sent during SYN interval

--- a/libraries/networking/src/udt/SendQueue.h
+++ b/libraries/networking/src/udt/SendQueue.h
@@ -50,7 +50,8 @@ public:
         Stopped
     };
     
-    static std::unique_ptr<SendQueue> create(Socket* socket, HifiSockAddr destination);
+    static std::unique_ptr<SendQueue> create(Socket* socket, HifiSockAddr destination,
+                                             SequenceNumber currentSequenceNumber = SequenceNumber());
     
     void queuePacket(std::unique_ptr<Packet> packet);
     void queuePacketList(std::unique_ptr<PacketList> packetList);
@@ -83,7 +84,7 @@ private slots:
     void run();
     
 private:
-    SendQueue(Socket* socket, HifiSockAddr dest);
+    SendQueue(Socket* socket, HifiSockAddr dest, SequenceNumber currentSequenceNumber);
     SendQueue(SendQueue& other) = delete;
     SendQueue(SendQueue&& other) = delete;
     
@@ -108,7 +109,7 @@ private:
     
     std::atomic<uint32_t> _lastACKSequenceNumber { 0 }; // Last ACKed sequence number
     
-    SequenceNumber _currentSequenceNumber; // Last sequence number sent out
+    SequenceNumber _currentSequenceNumber { 0 }; // Last sequence number sent out
     std::atomic<uint32_t> _atomicCurrentSequenceNumber { 0 }; // Atomic for last sequence number sent out
     
     std::atomic<int> _packetSendPeriod { 0 }; // Interval between two packet send event in microseconds, set from CC


### PR DESCRIPTION
- fixes a bug where a re-activated SendQueue would start over with a new SequenceNumber that a still connected receiver would not recognize