### PR TITLE
fix-mouth-movement

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -214,7 +214,7 @@ void Avatar::simulate(float deltaTime) {
             Head* head = getHead();
             head->setPosition(headPosition);
             head->setScale(getUniformScale());
-            head->simulate(deltaTime, false, _shouldAnimate);
+            head->simulate(deltaTime, false, !_shouldAnimate);
         }
     }
 


### PR DESCRIPTION
Fix inverted boolean that was preventing other people's avatars from mouth-moving