### PR TITLE
Fix native text rendering by forcing positions to integer values

### DIFF
--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -3,9 +3,9 @@ import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2 as OriginalDialogs
 import Qt.labs.settings 1.0
 
-import "../styles" as Hifi
-import "../controls" as HifiControls
-import "../windows"
+import "../../styles" as Hifi
+import "../../controls" as HifiControls
+import "../../windows"
 
 Window {
     id: root
@@ -19,12 +19,6 @@ Window {
     property var scripts: ScriptDiscoveryService;
     property var scriptsModel: scripts.scriptsModelFilter
     property var runningScriptsModel: ListModel { }
-    property var fileFilters: ListModel {
-        id: jsFilters
-        ListElement { text: "Javascript Files (*.js)"; filter: "*.js" }
-        ListElement { text: "All Files (*.*)"; filter: "*.*" }
-    }
-
 
     Settings {
         category: "Overlay.RunningScripts"
@@ -249,7 +243,30 @@ Window {
                     }
                 }
                 model: scriptsModel
-                TableViewColumn { title: "Name"; role: "display"; }
+
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.RightButton
+                    onClicked: treeView.foo();
+                }
+
+                function foo() {
+                    var localRect = Qt.rect(0, 0, width, height);
+                    var rect = desktop.mapFromItem(treeView, 0, 0, width, height)
+                    console.log("Local Rect " + localRect)
+                    console.log("Rect " + rect)
+                    console.log("Desktop size " + Qt.size(desktop.width, desktop.height));
+                }
+
+                TableViewColumn { 
+                    title: "Name";
+                    role: "display";
+//                    delegate: Text {
+//                        text: styleData.value
+//                        renderType: Text.QtRendering
+//                        elite: styleData.elideMode
+//                    }
+                }
             }
 
             HifiControls.TextField {

--- a/interface/resources/qml/windows/Window.qml
+++ b/interface/resources/qml/windows/Window.qml
@@ -45,6 +45,30 @@ Fadable {
     // The content to place inside the window, determined by the client
     default property var content
 
+    property var rectifier: Timer {
+        property bool executing: false;
+        interval: 100
+        repeat: false
+        running: false
+
+        onTriggered: {
+            executing = true;
+            x = Math.floor(x);
+            y = Math.floor(y);
+            executing = false;
+        }
+
+        function begin() {
+            if (!executing) {
+                restart();
+            }
+        }
+    }
+
+
+    onXChanged: rectifier.begin();
+    onYChanged: rectifier.begin();
+
     // This mouse area serves to raise the window. To function, it must live
     // in the window and have a higher Z-order than the content, but follow
     // the position and size of frame decoration

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1260,7 +1260,7 @@ void Application::initializeUi() {
             auto resultVec = _compositor.screenToOverlay(toGlm(pt));
             result = QPointF(resultVec.x, resultVec.y);
         }
-        return result;
+        return result.toPoint();
     });
     offscreenUi->resume();
     connect(_window, &MainWindow::windowGeometryChanged, [this](const QRect& r){
@@ -4418,7 +4418,7 @@ bool Application::displayAvatarAttachmentConfirmationDialog(const QString& name)
 }
 
 void Application::toggleRunningScriptsWidget() {
-    static const QUrl url("dialogs/RunningScripts.qml");
+    static const QUrl url("hifi/dialogs/RunningScripts.qml");
     DependencyManager::get<OffscreenUi>()->show(url, "RunningScripts");
     //if (_runningScriptsWidget->isVisible()) {
     //    if (_runningScriptsWidget->hasFocus()) {

--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -35,7 +35,7 @@ public:
     OffscreenQmlSurface();
     virtual ~OffscreenQmlSurface();
 
-    using MouseTranslator = std::function<QPointF(const QPointF&)>;
+    using MouseTranslator = std::function<QPoint(const QPointF&)>;
 
     virtual void create(QOpenGLContext* context);
     void resize(const QSize& size);
@@ -94,7 +94,7 @@ private:
     bool _polish{ true };
     bool _paused{ true };
     uint8_t _maxFps{ 60 };
-    MouseTranslator _mouseTranslator{ [](const QPointF& p) { return p;  } };
+    MouseTranslator _mouseTranslator{ [](const QPointF& p) { return p.toPoint();  } };
 
 };
 


### PR DESCRIPTION
I identified the issue where some text (typically anything with native text rendering) could look really bad.  It turns out that the current code can allow a window to end up with a size or position that is not an integer.  If the vertical position was at fractional then you ended up seeing letters with varying up and down baselines, while if the horizontal position was non-integer then narrow letters or letter pairs with tight kerning would render illegibly.

May also fix the double-click problem.