### PR TITLE
fix queryAACube lastEdited bug

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -397,6 +397,9 @@ void MyAvatar::simulate(float deltaTime) {
                 if (packetSender) {
                     EntityItemProperties properties = entity->getProperties();
                     properties.setQueryAACubeDirty();
+                    auto now = usecTimestampNow();
+                    entity->setLastEdited(now);
+                    properties.setLastEdited(now);
                     packetSender->queueEditEntityMessage(PacketType::EntityEdit, entity->getID(), properties);
                     entity->setLastBroadcast(usecTimestampNow());
                 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -383,6 +383,7 @@ void MyAvatar::simulate(float deltaTime) {
     EntityTreeRenderer* entityTreeRenderer = qApp->getEntities();
     EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
     if (entityTree) {
+        auto now = usecTimestampNow();
         EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
         MovingEntitiesOperator moveOperator(entityTree);
         forEachDescendant([&](SpatiallyNestablePointer object) {
@@ -397,7 +398,6 @@ void MyAvatar::simulate(float deltaTime) {
                 if (packetSender) {
                     EntityItemProperties properties = entity->getProperties();
                     properties.setQueryAACubeDirty();
-                    auto now = usecTimestampNow();
                     properties.setLastEdited(now);
                     packetSender->queueEditEntityMessage(PacketType::EntityEdit, entity->getID(), properties);
                     entity->setLastBroadcast(usecTimestampNow());

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -398,7 +398,6 @@ void MyAvatar::simulate(float deltaTime) {
                     EntityItemProperties properties = entity->getProperties();
                     properties.setQueryAACubeDirty();
                     auto now = usecTimestampNow();
-                    entity->setLastEdited(now);
                     properties.setLastEdited(now);
                     packetSender->queueEditEntityMessage(PacketType::EntityEdit, entity->getID(), properties);
                     entity->setLastBroadcast(usecTimestampNow());

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -41,6 +41,8 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type, EntityItemI
         return; // bail early
     }
 
+    assert(properties.getLastEdited() > 0);
+
     QByteArray bufferOut(NLPacket::maxPayloadSize(type), 0);
 
     if (EntityItemProperties::encodeEntityEditPacket(type, modelID, properties, bufferOut)) {

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -470,7 +470,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         Q_ASSERT(parser.offset() == (unsigned int) bytesRead);
     }
 #endif
-    quint64 lastEditedFromBufferAdjusted = lastEditedFromBuffer - clockSkew;
+    quint64 lastEditedFromBufferAdjusted = lastEditedFromBuffer == 0 ? 0 : lastEditedFromBuffer - clockSkew;
     if (lastEditedFromBufferAdjusted > now) {
         lastEditedFromBufferAdjusted = now;
     }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -345,6 +345,9 @@ QUuid EntityScriptingInterface::editEntity(QUuid id, const EntityItemProperties&
                         EntityItemPointer entityDescendant = std::static_pointer_cast<EntityItem>(descendant);
                         EntityItemProperties newQueryCubeProperties;
                         newQueryCubeProperties.setQueryAACube(descendant->getQueryAACube());
+                        auto now = usecTimestampNow();
+                        entity->setLastEdited(now);
+                        newQueryCubeProperties.setLastEdited(now);
                         queueEntityMessage(PacketType::EntityEdit, descendant->getID(), newQueryCubeProperties);
                         entityDescendant->setLastBroadcast(usecTimestampNow());
                     }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -346,7 +346,6 @@ QUuid EntityScriptingInterface::editEntity(QUuid id, const EntityItemProperties&
                         EntityItemProperties newQueryCubeProperties;
                         newQueryCubeProperties.setQueryAACube(descendant->getQueryAACube());
                         auto now = usecTimestampNow();
-                        entity->setLastEdited(now);
                         newQueryCubeProperties.setLastEdited(now);
                         queueEntityMessage(PacketType::EntityEdit, descendant->getID(), newQueryCubeProperties);
                         entityDescendant->setLastBroadcast(usecTimestampNow());

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -345,8 +345,7 @@ QUuid EntityScriptingInterface::editEntity(QUuid id, const EntityItemProperties&
                         EntityItemPointer entityDescendant = std::static_pointer_cast<EntityItem>(descendant);
                         EntityItemProperties newQueryCubeProperties;
                         newQueryCubeProperties.setQueryAACube(descendant->getQueryAACube());
-                        auto now = usecTimestampNow();
-                        newQueryCubeProperties.setLastEdited(now);
+                        newQueryCubeProperties.setLastEdited(properties.getLastEdited());
                         queueEntityMessage(PacketType::EntityEdit, descendant->getID(), newQueryCubeProperties);
                         entityDescendant->setLastBroadcast(usecTimestampNow());
                     }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -815,6 +815,14 @@ void EntityTree::fixupTerseEditLogging(EntityItemProperties& properties, QList<Q
             changedProperties[index] = QString("jointTranslations:") + QString::number((int)value);
         }
     }
+    if (properties.queryAACubeChanged()) {
+        int index = changedProperties.indexOf("queryAACube");
+        glm::vec3 center = properties.getQueryAACube().calcCenter();
+        changedProperties[index] = QString("queryAACube:") +
+            QString::number((int)center.x) + "," +
+            QString::number((int)center.y) + "," +
+            QString::number((int)center.z);
+    }
 }
 
 int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned char* editData, int maxLength,

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -459,6 +459,7 @@ bool EntityTreeElement::bestFitEntityBounds(EntityItemPointer entity) const {
     bool success;
     auto queryCube = entity->getQueryAACube(success);
     if (!success) {
+        qDebug() << "EntityTreeElement::bestFitEntityBounds couldn't get queryCube for" << entity->getName() << entity->getID();
         return false;
     }
     return bestFitBounds(queryCube);
@@ -904,6 +905,8 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
                         _myTree->entityChanged(entityItem);
                     }
                     bool bestFitAfter = bestFitEntityBounds(entityItem);
+                    qDebug() << "got update for" << entityItem->getName() << bestFitBefore << bestFitAfter <<
+                        entityItem->getQueryAACube();
 
                     if (bestFitBefore != bestFitAfter) {
                         // This is the case where the entity existed, and is in some element in our tree...

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -905,8 +905,6 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
                         _myTree->entityChanged(entityItem);
                     }
                     bool bestFitAfter = bestFitEntityBounds(entityItem);
-                    qDebug() << "got update for" << entityItem->getName() << bestFitBefore << bestFitAfter <<
-                        entityItem->getQueryAACube();
 
                     if (bestFitBefore != bestFitAfter) {
                         // This is the case where the entity existed, and is in some element in our tree...

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -527,6 +527,9 @@ void EntityMotionState::sendUpdate(OctreeEditPacketSender* packetSender, const Q
             if (descendant->computePuffedQueryAACube()) {
                 EntityItemProperties newQueryCubeProperties;
                 newQueryCubeProperties.setQueryAACube(descendant->getQueryAACube());
+                auto now = usecTimestampNow();
+                entityDescendant->setLastEdited(now);
+                newQueryCubeProperties.setLastEdited(now);
                 entityPacketSender->queueEditEntityMessage(PacketType::EntityEdit, descendant->getID(), newQueryCubeProperties);
                 entityDescendant->setLastBroadcast(usecTimestampNow());
             }

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -528,7 +528,6 @@ void EntityMotionState::sendUpdate(OctreeEditPacketSender* packetSender, const Q
                 EntityItemProperties newQueryCubeProperties;
                 newQueryCubeProperties.setQueryAACube(descendant->getQueryAACube());
                 auto now = usecTimestampNow();
-                entityDescendant->setLastEdited(now);
                 newQueryCubeProperties.setLastEdited(now);
                 entityPacketSender->queueEditEntityMessage(PacketType::EntityEdit, descendant->getID(), newQueryCubeProperties);
                 entityDescendant->setLastBroadcast(usecTimestampNow());

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -527,8 +527,7 @@ void EntityMotionState::sendUpdate(OctreeEditPacketSender* packetSender, const Q
             if (descendant->computePuffedQueryAACube()) {
                 EntityItemProperties newQueryCubeProperties;
                 newQueryCubeProperties.setQueryAACube(descendant->getQueryAACube());
-                auto now = usecTimestampNow();
-                newQueryCubeProperties.setLastEdited(now);
+                newQueryCubeProperties.setLastEdited(properties.getLastEdited());
                 entityPacketSender->queueEditEntityMessage(PacketType::EntityEdit, descendant->getID(), newQueryCubeProperties);
                 entityDescendant->setLastBroadcast(usecTimestampNow());
             }


### PR DESCRIPTION
- fix a bug that caused clients to send queryAACube udpates with a lastEdited of 0, causing updates to be ignored.
