### PR TITLE
Anti-stutter work

### DIFF
--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -51,6 +51,7 @@ void AnimationReader::run() {
     if (originalPriority == QThread::InheritPriority) {
         originalPriority = QThread::NormalPriority;
     }
+    QThread::currentThread()->setPriority(QThread::LowPriority);
     try {
         if (_data.isEmpty()) {
             throw QString("Reply is NULL ?!");

--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -47,6 +47,10 @@ AnimationReader::AnimationReader(const QUrl& url, const QByteArray& data) :
 }
 
 void AnimationReader::run() {
+    auto originalPriority = QThread::currentThread()->priority();
+    if (originalPriority == QThread::InheritPriority) {
+        originalPriority = QThread::NormalPriority;
+    }
     try {
         if (_data.isEmpty()) {
             throw QString("Reply is NULL ?!");
@@ -73,6 +77,7 @@ void AnimationReader::run() {
     } catch (const QString& error) {
         emit onError(299, error);
     }
+    QThread::currentThread()->setPriority(originalPriority);
 }
 
 bool Animation::isLoaded() const {

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -28,6 +28,11 @@
 #include <GLMHelpers.h>
 
 #if THREADED_PRESENT
+
+// FIXME, for display plugins that don't block on something like vsync, just 
+// cap the present rate at 200
+// const static unsigned int MAX_PRESENT_RATE = 200;
+
 class PresentThread : public QThread, public Dependency {
     using Mutex = std::mutex;
     using Condition = std::condition_variable;
@@ -66,8 +71,10 @@ public:
         _context->moveToThread(this);
     }
 
+
     virtual void run() override {
         OpenGLDisplayPlugin* currentPlugin{ nullptr };
+        thread()->setPriority(QThread::HighestPriority);
         Q_ASSERT(_context);
         while (!_shutdown) {
             if (_pendingMainThreadOperation) {

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -50,6 +50,11 @@ GeometryReader::GeometryReader(const QUrl& url, const QByteArray& data, const QV
 }
 
 void GeometryReader::run() {
+    auto originalPriority = QThread::currentThread()->priority();
+    if (originalPriority == QThread::InheritPriority) {
+        originalPriority = QThread::NormalPriority;
+    }
+    QThread::currentThread()->setPriority(QThread::LowPriority);
     try {
         if (_data.isEmpty()) {
             throw QString("Reply is NULL ?!");
@@ -82,6 +87,8 @@ void GeometryReader::run() {
         qCDebug(modelnetworking) << "Error reading " << _url << ": " << error;
         emit onError(NetworkGeometry::ModelParseError, error);
     }
+
+    QThread::currentThread()->setPriority(originalPriority);
 }
 
 NetworkGeometry::NetworkGeometry(const QUrl& url, bool delayLoad, const QVariantHash& mapping, const QUrl& textureBaseUrl) :

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -268,6 +268,12 @@ void ImageReader::listSupportedImageFormats() {
 }
 
 void ImageReader::run() {
+    auto originalPriority = QThread::currentThread()->priority();
+    if (originalPriority == QThread::InheritPriority) {
+        originalPriority = QThread::NormalPriority;
+    }
+    QThread::currentThread()->setPriority(QThread::LowPriority);
+
     auto texture = _texture.toStrongRef();
     if (!texture) {
         qCWarning(modelnetworking) << "Could not get strong ref";
@@ -306,6 +312,7 @@ void ImageReader::run() {
         Q_ARG(const QImage&, image),
         Q_ARG(void*, theTexture),
         Q_ARG(int, originalWidth), Q_ARG(int, originalHeight));
+    QThread::currentThread()->setPriority(originalPriority);
 }
 
 void NetworkTexture::setImage(const QImage& image, void* voidTexture, int originalWidth,

--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -53,32 +53,26 @@ void TextureMap::setLightmapOffsetScale(float offset, float scale) {
 // FIXME why is this in the model library?  Move to GPU or GPU_GL
 gpu::Texture* TextureUsage::create2DTextureFromImage(const QImage& srcImage, const std::string& srcImageName) {
     QImage image = srcImage;
+    bool validAlpha = false;
     if (image.hasAlphaChannel()) {
         if (image.format() != QImage::Format_ARGB32) {
             image = image.convertToFormat(QImage::Format_ARGB32);
         }
         
         // Actual alpha channel?
-        bool transparent { false };
         for (int y = 0; y < image.height(); ++y) {
             const QRgb* data = reinterpret_cast<const QRgb*>(image.constScanLine(y));
             for (int x = 0; x < image.width(); ++x) {
                 auto alpha = qAlpha(data[x]);
                 if (alpha != 255) {
-                    transparent = true;
+                    validAlpha = true;
                     break;
                 }
             }
         }
-
-        // or bullshit alpha channel?
-        if (!transparent) {
-            qCDebug(modelLog) << "Image with alpha channel is completely opaque:" << QString(srcImageName.c_str());
-            image = image.convertToFormat(QImage::Format_RGB888);
-        }
     } 
     
-    if (!image.hasAlphaChannel() && image.format() != QImage::Format_RGB888) {
+    if (!validAlpha && image.format() != QImage::Format_RGB888) {
         image = image.convertToFormat(QImage::Format_RGB888);
     }
     

--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -50,88 +50,55 @@ void TextureMap::setLightmapOffsetScale(float offset, float scale) {
 }
 
 
-
-
+// FIXME why is this in the model library?  Move to GPU or GPU_GL
 gpu::Texture* TextureUsage::create2DTextureFromImage(const QImage& srcImage, const std::string& srcImageName) {
     QImage image = srcImage;
- 
-    int imageArea = image.width() * image.height();
-    
-    int opaquePixels = 0;
-    int translucentPixels = 0;
-    //bool isTransparent = false;
-    int redTotal = 0, greenTotal = 0, blueTotal = 0, alphaTotal = 0;
-    const int EIGHT_BIT_MAXIMUM = 255;
-    QColor averageColor(EIGHT_BIT_MAXIMUM, EIGHT_BIT_MAXIMUM, EIGHT_BIT_MAXIMUM);
-    
-    if (!image.hasAlphaChannel()) {
-        if (image.format() != QImage::Format_RGB888) {
-            image = image.convertToFormat(QImage::Format_RGB888);
-        }
-        // int redTotal = 0, greenTotal = 0, blueTotal = 0;
-        for (int y = 0; y < image.height(); y++) {
-            for (int x = 0; x < image.width(); x++) {
-                QRgb rgb = image.pixel(x, y);
-                redTotal += qRed(rgb);
-                greenTotal += qGreen(rgb);
-                blueTotal += qBlue(rgb);
-            }
-        }
-        if (imageArea > 0) {
-            averageColor.setRgb(redTotal / imageArea, greenTotal / imageArea, blueTotal / imageArea);
-        }
-    } else {
+    if (image.hasAlphaChannel()) {
         if (image.format() != QImage::Format_ARGB32) {
             image = image.convertToFormat(QImage::Format_ARGB32);
         }
         
-        // check for translucency/false transparency
-        // int opaquePixels = 0;
-        // int translucentPixels = 0;
-        // int redTotal = 0, greenTotal = 0, blueTotal = 0, alphaTotal = 0;
-        for (int y = 0; y < image.height(); y++) {
-            for (int x = 0; x < image.width(); x++) {
-                QRgb rgb = image.pixel(x, y);
-                redTotal += qRed(rgb);
-                greenTotal += qGreen(rgb);
-                blueTotal += qBlue(rgb);
-                int alpha = qAlpha(rgb);
-                alphaTotal += alpha;
-                if (alpha == EIGHT_BIT_MAXIMUM) {
-                    opaquePixels++;
-                } else if (alpha != 0) {
-                    translucentPixels++;
+        // Actual alpha channel?
+        bool transparent { false };
+        for (int y = 0; y < image.height(); ++y) {
+            const QRgb* data = reinterpret_cast<const QRgb*>(image.constScanLine(y));
+            for (int x = 0; x < image.width(); ++x) {
+                auto alpha = qAlpha(data[x]);
+                if (alpha != 255) {
+                    transparent = true;
+                    break;
                 }
             }
         }
-        if (opaquePixels == imageArea) {
+
+        // or bullshit alpha channel?
+        if (!transparent) {
             qCDebug(modelLog) << "Image with alpha channel is completely opaque:" << QString(srcImageName.c_str());
             image = image.convertToFormat(QImage::Format_RGB888);
         }
-        
-        averageColor = QColor(redTotal / imageArea,
-                              greenTotal / imageArea, blueTotal / imageArea, alphaTotal / imageArea);
-        
-        //isTransparent = (translucentPixels >= imageArea / 2);
+    } 
+    
+    if (!image.hasAlphaChannel() && image.format() != QImage::Format_RGB888) {
+        image = image.convertToFormat(QImage::Format_RGB888);
     }
     
     gpu::Texture* theTexture = nullptr;
     if ((image.width() > 0) && (image.height() > 0)) {
-        
         // bool isLinearRGB = true; //(_type == NORMAL_TEXTURE) || (_type == EMISSIVE_TEXTURE);
         bool isLinearRGB = false; //(_type == NORMAL_TEXTURE) || (_type == EMISSIVE_TEXTURE);
-        
+
         gpu::Element formatGPU = gpu::Element(gpu::VEC3, gpu::NUINT8, (isLinearRGB ? gpu::RGB : gpu::SRGB));
         gpu::Element formatMip = gpu::Element(gpu::VEC3, gpu::NUINT8, (isLinearRGB ? gpu::RGB : gpu::SRGB));
         if (image.hasAlphaChannel()) {
             formatGPU = gpu::Element(gpu::VEC4, gpu::NUINT8, (isLinearRGB ? gpu::RGBA : gpu::SRGBA));
             formatMip = gpu::Element(gpu::VEC4, gpu::NUINT8, (isLinearRGB ? gpu::BGRA : gpu::SBGRA));
         }
-        
 
-            theTexture = (gpu::Texture::create2D(formatGPU, image.width(), image.height(), gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR)));
-            theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
-            theTexture->autoGenerateMips(-1);
+        theTexture = (gpu::Texture::create2D(formatGPU, image.width(), image.height(), gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR)));
+        theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
+        theTexture->autoGenerateMips(-1);
+        
+        // FIXME queue for transfer to GPU and block on completion
     }
     
     return theTexture;


### PR DESCRIPTION
This is a first pass at reducing the amount of stutter caused when entering a large scene.  

The stutter appears to be caused by a number of factors.  

- overloading the GPU with an excessive number of simultaneous transfers of large amount of texture / vertex data
- overloading the CPU with an excessive number of parsing threads doing file IO

This PR attempts to address the latter component first, simply because it's easier.  It reduces the size of the global thread pool from the default of `QThread::idealThreadCount()` to `2`.  This means that if you have 16 textures/models to load to render a scene, only 2 of them will be concurrently being loaded from disk to CPU memory at a time.  

Previously it would allow all CPU cores to be consumed performing this task, which could starve the main thread and the present thread, preventing keyboard or mouse input from being handled, and causing the screen to simply freeze (regardless of threaded present).  

Because the number of concurrent file transfers is being limited, the GPU transfers are also partially serialized, reducing their impact as well.

As a result, when teleporting from a nearly empty domain to `hifi://demo/547.046,495.032,509.714/0,-0.29785,0,-0.954613`, the number of missed frames (caused by the main / rendering thread being blocked/starved) is reduced and the amount of complete freezes (caused by the present thread being starved) is almost completely eliminated.

