### PR TITLE
Fix ToolWindow's initial position (e.g., as used by edit.js).

### DIFF
--- a/interface/resources/qml/ToolWindow.qml
+++ b/interface/resources/qml/ToolWindow.qml
@@ -20,8 +20,8 @@ Windows.Window {
     property string newTabSource
     property alias tabView: tabView
     onParentChanged: {
-        x = desktop.width / 2 - width / 2;
-        y = desktop.height / 2 - height / 2;
+        x = 120;
+        y = 120;
     }
 
     Settings {


### PR DESCRIPTION
Applies when there is no ToolWindow.position in Interface.ini