### PR TITLE
Small QML fixes

### DIFF
--- a/interface/resources/qml/QmlWindow.qml
+++ b/interface/resources/qml/QmlWindow.qml
@@ -19,12 +19,40 @@ Windows.Window {
     property var channel;
     // Don't destroy on close... otherwise the JS/C++ will have a dangling pointer
     destroyOnCloseButton: false
-    property alias source: pageLoader.source 
-    
-    Loader { 
-        id: pageLoader
-        objectName: "Loader"
-        focus: true
-        property var dialog: root
+    property var source;
+    property var component;
+    property var dynamicContent;
+    onSourceChanged: {
+        if (dynamicContent) {
+            dynamicContent.destroy();
+            dynamicContent = null; 
+        }
+        component = Qt.createComponent(source);
+        console.log("Created component " + component + " from source " + source);
     }
-} // dialog
+
+    onComponentChanged: {
+        console.log("Component changed to " + component)
+        populate();
+    }
+        
+    function populate() {
+        console.log("Populate called: dynamicContent " + dynamicContent + " component " + component);
+        if (!dynamicContent && component) {
+            if (component.status == Component.Error) {
+                console.log("Error loading component:", component.errorString());
+            } else if (component.status == Component.Ready) {
+                console.log("Building dynamic content");
+                dynamicContent = component.createObject(contentHolder);
+            } else {
+                console.log("Component not yet ready, connecting to status change");
+                component.statusChanged.connect(populate);
+            }
+        }
+    }
+    
+    Item {
+        id: contentHolder
+        anchors.fill: parent
+    }
+}

--- a/interface/resources/qml/windows/Window.qml
+++ b/interface/resources/qml/windows/Window.qml
@@ -17,8 +17,8 @@ Fadable {
     HifiConstants { id: hifi }
     // The Window size is the size of the content, while the frame
     // decorations can extend outside it.
-    implicitHeight: content.height
-    implicitWidth: content.width
+    implicitHeight: content ? content.height : 0
+    implicitWidth: content ? content.width : 0
     x: -1; y: -1
     enabled: visible
 


### PR DESCRIPTION
* Fix some issues with OverlayWindow creation in scripts.

As an example, load the script https://s3.amazonaws.com/DreamingContent/scripts/flockOfFish.js  This should create a toolbar that lets you create a small QML window.  However, with the production build the content of the window will either not load or will render incorrectly.  With this PR build the content should always load the first time and should be properly laid out.
