### PR TITLE
Ensure the QML content gets destroyed on deletion of a QML surface

### DIFF
--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -313,7 +313,7 @@ OffscreenQmlSurface::OffscreenQmlSurface() {
 
 OffscreenQmlSurface::~OffscreenQmlSurface() {
     _renderer->stop();
-
+    delete _rootItem;
     delete _renderer;
     delete _qmlComponent;
     delete _qmlEngine;


### PR DESCRIPTION
Right now we destroy the context and engine, but this apparently isn't sufficient to destroy all the content.  This change should fix the issue with web entity audio continuing to play after you've left the domain or deleted the entity.

An easy way to test this is to create a web entity that points to something that has audio, like a youtube video, and then move to another domain and verify that the audio stops.