### PR TITLE
Re-enable OpenVR support

### DIFF
--- a/cmake/externals/openvr/CMakeLists.txt
+++ b/cmake/externals/openvr/CMakeLists.txt
@@ -7,8 +7,8 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL https://github.com/ValveSoftware/openvr/archive/v0.9.12.zip
-  URL_MD5 c08dced68ce4e341e1467e6814ae419d
+  URL https://github.com/ValveSoftware/openvr/archive/v0.9.15.zip
+  URL_MD5 0ff8560b49b6da1150fcc47360e8ceca
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -39,6 +39,7 @@ glm::mat4 OculusBaseDisplayPlugin::getHeadPose(uint32_t frameIndex) const {
 
 bool OculusBaseDisplayPlugin::isSupported() const {
     if (!OVR_SUCCESS(ovr_Initialize(nullptr))) {
+        qDebug() << "OculusBaseDisplayPlugin : ovr_Initialize() failed";
         return false;
     }
 
@@ -48,6 +49,7 @@ bool OculusBaseDisplayPlugin::isSupported() const {
     if (!OVR_SUCCESS(result)) {
         ovrErrorInfo error;
         ovr_GetLastErrorInfo(&error);
+        qDebug() << "OculusBaseDisplayPlugin : ovr_Create() failed" << result << error.Result << error.ErrorString;
         ovr_Shutdown();
         return false;
     }

--- a/plugins/openvr/CMakeLists.txt
+++ b/plugins/openvr/CMakeLists.txt
@@ -6,20 +6,17 @@
 #  See the accompanying file LICENSE or http:#www.apache.org/licenses/LICENSE-2.0.html
 #
 
-# OpenVR is disabled until a) it works with threaded present and 
-# b) it doesn't interfere with Oculus SDK 0.8 
-if (FALSE)
-#if (WIN32)
+if (WIN32)
     # we're using static GLEW, so define GLEW_STATIC
     add_definitions(-DGLEW_STATIC)
     set(TARGET_NAME openvr)
     setup_hifi_plugin(OpenGL Script Qml Widgets)
-    link_hifi_libraries(shared gl networking controllers 
-        plugins display-plugins input-plugins script-engine 
+    link_hifi_libraries(shared gl networking controllers
+        plugins display-plugins input-plugins script-engine
         render-utils model gpu render model-networking fbx)
 
     include_hifi_library_headers(octree)
-    
+
     add_dependency_external_projects(OpenVR)
     find_package(OpenVR REQUIRED)
     target_include_directories(${TARGET_NAME} PRIVATE ${OPENVR_INCLUDE_DIRS})

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -72,10 +72,7 @@ mat4 toGlm(const vr::HmdMatrix34_t& m) {
 }
 
 bool OpenVrDisplayPlugin::isSupported() const {
-    auto hmd = acquireOpenVrSystem();
-    bool success = nullptr != hmd;
-    releaseOpenVrSystem();
-    return success;
+    return vr::VR_IsHmdPresent();
 }
 
 void OpenVrDisplayPlugin::activate() {

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -32,11 +32,14 @@ const QString OpenVrDisplayPlugin::NAME("OpenVR (Vive)");
 const QString StandingHMDSensorMode = "Standing HMD Sensor Mode"; // this probably shouldn't be hardcoded here
 
 static vr::IVRCompositor* _compositor{ nullptr };
+static vr::TrackedDevicePose_t _presentThreadTrackedDevicePose[vr::k_unMaxTrackedDeviceCount];
 vr::TrackedDevicePose_t _trackedDevicePose[vr::k_unMaxTrackedDeviceCount];
 mat4 _trackedDevicePoseMat4[vr::k_unMaxTrackedDeviceCount];
 static mat4 _sensorResetMat;
 static uvec2 _windowSize;
 static uvec2 _renderTargetSize;
+
+
 
 struct PerEyeData {
     //uvec2 _viewportOrigin;
@@ -87,11 +90,16 @@ void OpenVrDisplayPlugin::activate() {
     // Recommended render target size is per-eye, so double the X size for 
     // left + right eyes
     _renderTargetSize.x *= 2;
-    openvr_for_each_eye([&](vr::Hmd_Eye eye) {
-        PerEyeData& eyeData = _eyesData[eye];
-        eyeData._projectionMatrix = toGlm(_hmd->GetProjectionMatrix(eye, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP, vr::API_OpenGL));
-        eyeData._eyeOffset = toGlm(_hmd->GetEyeToHeadTransform(eye));
-    });
+
+    {
+        Lock lock(_poseMutex);
+        openvr_for_each_eye([&](vr::Hmd_Eye eye) {
+            PerEyeData& eyeData = _eyesData[eye];
+            eyeData._projectionMatrix = toGlm(_hmd->GetProjectionMatrix(eye, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP, vr::API_OpenGL));
+            eyeData._eyeOffset = toGlm(_hmd->GetEyeToHeadTransform(eye));
+        });
+    }
+
     _compositor = vr::VRCompositor();
     Q_ASSERT(_compositor);
     WindowOpenGLDisplayPlugin::activate();
@@ -130,25 +138,24 @@ mat4 OpenVrDisplayPlugin::getProjection(Eye eye, const mat4& baseProjection) con
     if (eye == Mono) {
         eye = Left;
     }
+    Lock lock(_poseMutex);
     return _eyesData[eye]._projectionMatrix;
 }
 
 void OpenVrDisplayPlugin::resetSensors() {
-    _sensorResetMat = glm::inverse(cancelOutRollAndPitch(_trackedDevicePoseMat4[0]));
+    Lock lock(_poseMutex);
+    glm::mat4 m = toGlm(_trackedDevicePose[0].mDeviceToAbsoluteTracking);
+    _sensorResetMat = glm::inverse(cancelOutRollAndPitch(m));
 }
 
 glm::mat4 OpenVrDisplayPlugin::getEyeToHeadTransform(Eye eye) const {
+    Lock lock(_poseMutex);
     return _eyesData[eye]._eyeOffset;
 }
 
 glm::mat4 OpenVrDisplayPlugin::getHeadPose(uint32_t frameIndex) const {
-    glm::mat4 result;
-    {
-        Lock lock(_mutex);
-        result = _trackedDevicePoseMat4[0];
-
-    }
-    return result;
+    Lock lock(_poseMutex);
+    return _trackedDevicePoseMat4[0];
 }
 
 
@@ -177,25 +184,28 @@ void OpenVrDisplayPlugin::internalPresent() {
     }
 
     vr::Texture_t texture{ (void*)_currentSceneTexture, vr::API_OpenGL, vr::ColorSpace_Auto };
-    {
-        Lock lock(_mutex);
-        _compositor->Submit(vr::Eye_Left, &texture, &leftBounds);
-        _compositor->Submit(vr::Eye_Right, &texture, &rightBounds);
-    }
+
+    _compositor->Submit(vr::Eye_Left, &texture, &leftBounds);
+    _compositor->Submit(vr::Eye_Right, &texture, &rightBounds);
+
     glFinish();
+
+    if (_enablePreview) {
+        swapBuffers();
+    }
+
+    _compositor->WaitGetPoses(_presentThreadTrackedDevicePose, vr::k_unMaxTrackedDeviceCount, nullptr, 0);
+
     {
-        Lock lock(_mutex);
-        _compositor->WaitGetPoses(_trackedDevicePose, vr::k_unMaxTrackedDeviceCount, nullptr, 0);
+        // copy and process _presentThreadTrackedDevicePoses
+        Lock lock(_poseMutex);
         for (int i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
+            _trackedDevicePose[i] = _presentThreadTrackedDevicePose[i];
             _trackedDevicePoseMat4[i] = _sensorResetMat * toGlm(_trackedDevicePose[i].mDeviceToAbsoluteTracking);
         }
         openvr_for_each_eye([&](vr::Hmd_Eye eye) {
             _eyesData[eye]._pose = _trackedDevicePoseMat4[0];
         });
-    }
-
-    if (_enablePreview) {
-        swapBuffers();
     }
 
     //WindowOpenGLDisplayPlugin::internalPresent();

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -47,5 +47,6 @@ private:
     static const QString NAME;
     bool _enablePreview { false };
     bool _monoPreview { true };
+    mutable Mutex _poseMutex;
 };
 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -45,5 +45,7 @@ protected:
 private:
     vr::IVRSystem* _hmd { nullptr };
     static const QString NAME;
+    bool _enablePreview { false };
+    bool _monoPreview { true };
 };
 

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -40,6 +40,8 @@ vr::IVRSystem* acquireOpenVrSystem() {
             qCDebug(displayplugins) << "openvr: incrementing refcount";
             ++refCount;
         }
+    } else {
+        qCDebug(displayplugins) << "openvr: no hmd present";
     }
     return activeHmd;
 }

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -23,11 +23,11 @@ using Lock = std::unique_lock<Mutex>;
 static int refCount { 0 };
 static Mutex mutex;
 static vr::IVRSystem* activeHmd { nullptr };
-static bool hmdPresent = vr::VR_IsHmdPresent();
 
 static const uint32_t RELEASE_OPENVR_HMD_DELAY_MS = 5000;
 
 vr::IVRSystem* acquireOpenVrSystem() {
+    bool hmdPresent = vr::VR_IsHmdPresent();
     if (hmdPresent) {
         Lock lock(mutex);
         if (!activeHmd) {
@@ -53,24 +53,7 @@ void releaseOpenVrSystem() {
         --refCount;
         if (0 == refCount) {
             qCDebug(displayplugins) << "openvr: zero refcount, deallocate VR system";
-            // Avoid spamming the VR system with activate/deactivate calls at system startup by
-            // putting in a delay before we destory the shutdown the VR subsystem
-
-            // FIXME releasing the VR system at all seems to trigger an exception deep inside the Oculus DLL.  
-            // disabling for now.
-            //QTimer* releaseTimer = new QTimer();
-            //releaseTimer->singleShot(RELEASE_OPENVR_HMD_DELAY_MS, [releaseTimer] {
-            //    Lock lock(mutex);
-            //    qDebug() << "Delayed openvr destroy activated";
-            //    if (0 == refCount && nullptr != activeHmd) {
-            //        qDebug() << "Delayed openvr destroy: releasing resources";
-            //        activeHmd = nullptr;
-            //        vr::VR_Shutdown();
-            //    } else {
-            //        qDebug() << "Delayed openvr destroy: HMD still in use";
-            //    }
-            //    releaseTimer->deleteLater();
-            //});
+            vr::VR_Shutdown();
         }
     }
 }

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -66,10 +66,12 @@ void ViveControllerManager::activate() {
     }
     Q_ASSERT(_hmd);
 
+    // OpenVR provides 3d mesh representations of the controllers
+    // Disabled controller rendering code
+    /*
     auto renderModels = vr::VRRenderModels();
 
     vr::RenderModel_t model;
-    /*
     if (!_hmd->LoadRenderModel(CONTROLLER_MODEL_STRING, &model)) {
         qDebug() << QString("Unable to load render model %1\n").arg(CONTROLLER_MODEL_STRING);
     } else {
@@ -145,6 +147,7 @@ void ViveControllerManager::deactivate() {
 void ViveControllerManager::updateRendering(RenderArgs* args, render::ScenePointer scene, render::PendingChanges pendingChanges) {
     PerformanceTimer perfTimer("ViveControllerManager::updateRendering");
 
+    /*
     if (_modelLoaded) {
         //auto controllerPayload = new render::Payload<ViveControllerManager>(this);
         //auto controllerPayloadPointer = ViveControllerManager::PayloadPointer(controllerPayload);
@@ -175,9 +178,11 @@ void ViveControllerManager::updateRendering(RenderArgs* args, render::ScenePoint
             }
         });
     }
+    */
 }
 
 void ViveControllerManager::renderHand(const controller::Pose& pose, gpu::Batch& batch, int sign) {
+    /*
     auto userInputMapper = DependencyManager::get<controller::UserInputMapper>();
     Transform transform(userInputMapper->getSensorToWorldMat());
     transform.postTranslate(pose.getTranslation() + pose.getRotation() * glm::vec3(0, 0, CONTROLLER_LENGTH_OFFSET));
@@ -199,6 +204,7 @@ void ViveControllerManager::renderHand(const controller::Pose& pose, gpu::Batch&
     //    mesh->getVertexBuffer()._stride);
     batch.setIndexBuffer(gpu::UINT16, mesh->getIndexBuffer()._buffer, 0);
     batch.drawIndexed(gpu::TRIANGLES, mesh->getNumIndices(), 0);
+    */
 }
 
 

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -48,10 +48,7 @@ static const QString RENDER_CONTROLLERS = "Render Hand Controllers";
 const QString ViveControllerManager::NAME = "OpenVR";
 
 bool ViveControllerManager::isSupported() const {
-    auto hmd = acquireOpenVrSystem();
-    bool success = hmd != nullptr;
-    releaseOpenVrSystem();
-    return success;
+    return vr::VR_IsHmdPresent();
 }
 
 void ViveControllerManager::activate() {


### PR DESCRIPTION
* Re-added OpenVR plugin to Windows build.
* Updated OpenVR plugin to work under threaded present.
* Bug fix for sensor reset in Vive
* Added preview rendering in main window.

Oculus Rift DK2 works in OpenVR but only in mono mode for some reason, I don't think it's due to anything on our side, because the same code path works in the Vive Developer Edition.
