### PR TITLE
fix for HRTF map crash

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -484,7 +484,9 @@ void AudioMixer::removeHRTFsForFinishedInjector(const QUuid& streamID) {
 
         nodeList->eachNode([injectorClientData, &streamID](const SharedNodePointer& node){
             auto listenerClientData = dynamic_cast<AudioMixerClientData*>(node->getLinkedData());
-            listenerClientData->removeHRTFForStream(injectorClientData->getNodeID(), streamID);
+            if (listenerClientData) {
+                listenerClientData->removeHRTFForStream(injectorClientData->getNodeID(), streamID);
+            }
         });
     }
 }


### PR DESCRIPTION
- fixes a crash in audio-mixer while removing the HRTF objects for a stream or Node