### PR TITLE
Update the scene on overlay3d updates

### DIFF
--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -229,5 +229,6 @@ bool Overlay::addToScene(Overlay::Pointer overlay, std::shared_ptr<render::Scene
 
 void Overlay::removeFromScene(Overlay::Pointer overlay, std::shared_ptr<render::Scene> scene, render::PendingChanges& pendingChanges) {
     pendingChanges.removeItem(_renderItemID);
+    _renderItemID = render::Item::INVALID_ITEM_ID;
 }
 

--- a/interface/src/ui/overlays/OverlaysPayload.cpp
+++ b/interface/src/ui/overlays/OverlaysPayload.cpp
@@ -40,7 +40,7 @@ namespace render {
             if (std::dynamic_pointer_cast<Base3DOverlay>(overlay)->getDrawInFront()) {
                 builder.withLayered();
             }
-            if (overlay->getAlpha() != 1.0f) {
+            if (overlay->getAlphaPulse() != 0.0f || overlay->getAlpha() != 1.0f) {
                 builder.withTransparent();
             }
         } else {

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -41,10 +41,12 @@ public:
     float getRightMargin() const { return _rightMargin; }
     float getBottomMargin() const { return _bottomMargin; }
     xColor getBackgroundColor();
-    float getBackgroundAlpha() const { return _backgroundAlpha; }
+    float getTextAlpha() { return _textAlpha; }
+    float getBackgroundAlpha() { return getAlpha(); }
 
     // setters
     void setText(const QString& text) { _text = text; }
+    void setTextAlpha(float alpha) { _textAlpha = alpha; }
     void setLineHeight(float value) { _lineHeight = value; }
     void setLeftMargin(float margin) { _leftMargin = margin; }
     void setTopMargin(float margin) { _topMargin = margin; }
@@ -65,13 +67,13 @@ private:
     TextRenderer3D* _textRenderer = nullptr;
     
     QString _text;
-    xColor _backgroundColor;
-    float _backgroundAlpha;
-    float _lineHeight;
-    float _leftMargin;
-    float _topMargin;
-    float _rightMargin;
-    float _bottomMargin;
+    xColor _backgroundColor = xColor{ 0, 0, 0 };
+    float _textAlpha{ 1.0f };
+    float _lineHeight{ 1.0f };
+    float _leftMargin{ 0.1f };
+    float _topMargin{ 0.1f };
+    float _rightMargin{ 0.1f };
+    float _bottomMargin{ 0.1f };
 };
 
 #endif // hifi_Text3DOverlay_h

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -67,13 +67,13 @@ private:
     TextRenderer3D* _textRenderer = nullptr;
     
     QString _text;
-    xColor _backgroundColor = xColor{ 0, 0, 0 };
-    float _textAlpha{ 1.0f };
-    float _lineHeight{ 1.0f };
-    float _leftMargin{ 0.1f };
-    float _topMargin{ 0.1f };
-    float _rightMargin{ 0.1f };
-    float _bottomMargin{ 0.1f };
+    xColor _backgroundColor = xColor { 0, 0, 0 };
+    float _textAlpha { 1.0f };
+    float _lineHeight { 1.0f };
+    float _leftMargin { 0.1f };
+    float _topMargin { 0.1f };
+    float _rightMargin { 0.1f };
+    float _bottomMargin { 0.1f };
 };
 
 #endif // hifi_Text3DOverlay_h

--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -117,7 +117,10 @@ public:
     bool isSmall() const { return _flags[SMALLER]; }
     void setSmaller(bool smaller) { (smaller ? _flags.set(SMALLER) : _flags.reset(SMALLER)); }
 
+    bool operator==(const ItemKey& key) { return (_flags == key._flags); }
+    bool operator!=(const ItemKey& key) { return (_flags != key._flags); }
 };
+using ItemKeys = std::vector<ItemKey>;
 
 inline QDebug operator<<(QDebug debug, const ItemKey& itemKey) {
     debug << "[ItemKey: isOpaque:" << itemKey.isOpaque()

--- a/libraries/render/src/render/Scene.h
+++ b/libraries/render/src/render/Scene.h
@@ -40,6 +40,7 @@ public:
     ~PendingChanges() {}
 
     void resetItem(ItemID id, const PayloadPointer& payload);
+    void resortItem(ItemID id, ItemKey oldKey, ItemKey newKey);
     void removeItem(ItemID id);
 
     template <class T> void updateItem(ItemID id, std::function<void(T&)> func) {
@@ -50,8 +51,11 @@ public:
 
     void merge(PendingChanges& changes);
 
-    Payloads _resetPayloads;
     ItemIDs _resetItems; 
+    Payloads _resetPayloads;
+    ItemIDs _resortItems;
+    ItemKeys _resortOldKeys;
+    ItemKeys _resortNewKeys;
     ItemIDs _removedItems;
     ItemIDs _updatedItems;
     UpdateFunctors _updateFunctors;
@@ -107,6 +111,7 @@ protected:
 
 
     void resetItems(const ItemIDs& ids, Payloads& payloads);
+    void resortItems(const ItemIDs& ids, ItemKeys& oldKeys, ItemKeys& newKeys);
     void removeItems(const ItemIDs& ids);
     void updateItems(const ItemIDs& ids, UpdateFunctors& functors);
 


### PR DESCRIPTION
- Add/remove an item from the scene when it's drawOnHUD property is changed.
- Update ItemKey when an overlay edit changes the ItemKey.

Updating the ItemKey without creating a new shared ptr necessitated a new method for the scene, resort (to resort the item based on a new key).