### PR TITLE
Prevent overlay cleanup from crashing the app

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -37,9 +37,16 @@
 
 
 Overlays::Overlays() : _nextOverlayID(1) {
+    connect(qApp, &Application::beforeAboutToQuit, [=] {
+        cleanupAllOverlays();
+    });
 }
 
 Overlays::~Overlays() {
+}
+
+
+void Overlays::cleanupAllOverlays() {
     {
         QWriteLocker lock(&_lock);
         QWriteLocker deleteLock(&_deleteLock);
@@ -53,7 +60,6 @@ Overlays::~Overlays() {
         _overlaysWorld.clear();
         _panels.clear();
     }
-    
     cleanupOverlaysToDelete();
 }
 

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -145,6 +145,7 @@ signals:
 
 private:
     void cleanupOverlaysToDelete();
+    void cleanupAllOverlays();
 
     QMap<unsigned int, Overlay::Pointer> _overlaysHUD;
     QMap<unsigned int, Overlay::Pointer> _overlaysWorld;


### PR DESCRIPTION
Overlays using QML need to be destroyed before the QML context is destroyed.  