### PR TITLE
Various bug fixes in related to HMD overlay support

### DIFF
--- a/examples/controllers/getHUDLookAtPositionTest.js
+++ b/examples/controllers/getHUDLookAtPositionTest.js
@@ -19,18 +19,20 @@ var cubeSize = 0.03;
 var cube = Overlays.addOverlay("cube", {
                     position: cubePosition,
                     size: cubeSize,
-                    color: { red: 255, green: 0, blue: 0},
+                    color: { red: 0, green: 255, blue: 0},
                     alpha: 1,
                     solid: false
                 });
 
-var square = Overlays.addOverlay("text", {
+var SQUARE_SIZE = 20;
+
+var square = Overlays.addOverlay("rectangle", {
                     x: 0,
                     y: 0,
-                    width: 20,
-                    height: 20,
-                    color: { red: 255, green: 255, blue: 0},
-                    backgroundColor: { red: 255, green: 255, blue: 0},
+                    width: SQUARE_SIZE,
+                    height: SQUARE_SIZE,
+                    color: { red: 0, green: 255, blue: 0},
+                    backgroundColor: { red: 0, green: 255, blue: 0},
                     alpha: 1
                 });
 
@@ -43,7 +45,7 @@ Script.update.connect(function(deltaTime) {
     Overlays.editOverlay(cube, { position: lookAt3D });
 
     var lookAt2D = HMD.getHUDLookAtPosition2D();
-    Overlays.editOverlay(square, { x: lookAt2D.x, y: lookAt2D.y });
+    Overlays.editOverlay(square, { x: lookAt2D.x - (SQUARE_SIZE/2), y: lookAt2D.y  - (SQUARE_SIZE/2)});
 });
 
 Script.scriptEnding.connect(function(){

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -1886,7 +1886,7 @@ function cleanup() {
     rightController.cleanup();
     leftController.cleanup();
     Controller.disableMapping(MAPPING_NAME);
-
+    Controller.setReticleVisible(true);
 }
 Script.scriptEnding.connect(cleanup);
 Script.update.connect(update);

--- a/examples/controllers/handControllerGrab.js
+++ b/examples/controllers/handControllerGrab.js
@@ -14,6 +14,7 @@
 
 Script.include("../libraries/utils.js");
 
+
 //
 // add lines where the hand ray picking is happening
 //
@@ -722,6 +723,9 @@ function MyController(hand) {
             this.particleBeamOff();
         }
         this.searchSphereOff();
+
+        Controller.setReticleVisible(true);
+
     };
 
     this.triggerPress = function(value) {
@@ -1018,6 +1022,9 @@ function MyController(hand) {
             this.overlayLineOn(handPosition, searchSphereLocation,
                                (this.triggerSmoothedGrab() || this.bumperSqueezed()) ? INTERSECT_COLOR : NO_INTERSECT_COLOR);
         }
+
+        Controller.setReticleVisible(false);
+
     };
 
     this.distanceGrabTimescale = function(mass, distance) {

--- a/examples/controllers/reticleHandRotationTest.js
+++ b/examples/controllers/reticleHandRotationTest.js
@@ -31,8 +31,8 @@ function moveReticleAbsolute(x, y) {
 
 var MAPPING_NAME = "com.highfidelity.testing.reticleWithHandRotation";
 var mapping = Controller.newMapping(MAPPING_NAME);
-mapping.from(Controller.Standard.LT).peek().constrainToInteger().to(Controller.Actions.ReticleClick);
-mapping.from(Controller.Standard.RT).peek().constrainToInteger().to(Controller.Actions.ReticleClick);
+mapping.from(Controller.Hardware.Hydra.L3).peek().to(Controller.Actions.ReticleClick);
+mapping.from(Controller.Hardware.Hydra.R4).peek().to(Controller.Actions.ReticleClick);
 mapping.enable();
 
 

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -20,15 +20,39 @@
 HMDScriptingInterface::HMDScriptingInterface() {
 }
 
+glm::vec3 HMDScriptingInterface::calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const {
+    glm::vec3 result { position };
+    qApp->getApplicationCompositor().calculateRayUICollisionPoint(position, direction, result);
+    return result;
+}
+
+glm::vec2 HMDScriptingInterface::overlayFromWorldPoint(const glm::vec3& position) const {
+    return qApp->getApplicationCompositor().overlayFromSphereSurface(position);
+}
+
+glm::vec2 HMDScriptingInterface::sphericalToOverlay(const glm::vec2 & position) const {
+    return qApp->getApplicationCompositor().sphericalToOverlay(position);
+}
+
+glm::vec2 HMDScriptingInterface::overlayToSpherical(const glm::vec2 & position) const {
+    return qApp->getApplicationCompositor().overlayToSpherical(position);
+}
+
+glm::vec2 HMDScriptingInterface::screenToOverlay(const glm::vec2 & position) const {
+    return qApp->getApplicationCompositor().screenToOverlay(position);
+}
+
+glm::vec2 HMDScriptingInterface::overlayToScreen(const glm::vec2 & position) const {
+    return qApp->getApplicationCompositor().overlayToScreen(position);
+}
+
+
+
 QScriptValue HMDScriptingInterface::getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine) {
     glm::vec3 hudIntersection;
     auto instance = DependencyManager::get<HMDScriptingInterface>();
     if (instance->getHUDLookAtPosition3D(hudIntersection)) {
-        MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-        glm::vec3 sphereCenter = myAvatar->getDefaultEyePosition();
-        glm::vec3 direction = glm::inverse(myAvatar->getOrientation()) * (hudIntersection - sphereCenter);
-        glm::vec2 polar = glm::vec2(glm::atan(direction.x, -direction.z), glm::asin(direction.y)) * -1.0f;
-        auto overlayPos = qApp->getApplicationCompositor().sphericalToOverlay(polar);
+        glm::vec2 overlayPos = qApp->getApplicationCompositor().overlayFromSphereSurface(hudIntersection);
         return qScriptValueFromValue<glm::vec2>(engine, overlayPos);
     }
     return QScriptValue::NullValue;

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -21,7 +21,7 @@ HMDScriptingInterface::HMDScriptingInterface() {
 }
 
 glm::vec3 HMDScriptingInterface::calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const {
-    glm::vec3 result { position };
+    glm::vec3 result;
     qApp->getApplicationCompositor().calculateRayUICollisionPoint(position, direction, result);
     return result;
 }

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -25,6 +25,16 @@ class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Depen
     Q_OBJECT
     Q_PROPERTY(glm::vec3 position READ getPosition)
     Q_PROPERTY(glm::quat orientation READ getOrientation)
+
+public:
+    Q_INVOKABLE glm::vec3 calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const;
+    Q_INVOKABLE glm::vec2 overlayFromWorldPoint(const glm::vec3& position) const;
+
+    Q_INVOKABLE glm::vec2 sphericalToOverlay(const glm::vec2 & sphericalPos) const;
+    Q_INVOKABLE glm::vec2 overlayToSpherical(const glm::vec2 & overlayPos) const;
+    Q_INVOKABLE glm::vec2 screenToOverlay(const glm::vec2 & screenPos) const;
+    Q_INVOKABLE glm::vec2 overlayToScreen(const glm::vec2 & overlayPos) const;
+
 public:
     HMDScriptingInterface();
     static QScriptValue getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine);

--- a/interface/src/ui/ApplicationCompositor.h
+++ b/interface/src/ui/ApplicationCompositor.h
@@ -62,6 +62,8 @@ public:
     void computeHmdPickRay(glm::vec2 cursorPos, glm::vec3& origin, glm::vec3& direction) const;
     uint32_t getOverlayTexture() const;
 
+    glm::vec2 overlayFromSphereSurface(const glm::vec3& sphereSurfacePoint) const;
+
     void setCameraBaseTransform(const Transform& transform) { _cameraBaseTransform = transform; }
     const Transform& getCameraBaseTransform() const { return _cameraBaseTransform; }
 

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -89,6 +89,12 @@ namespace controller {
         Q_INVOKABLE QObject* parseMapping(const QString& json);
         Q_INVOKABLE QObject* loadMapping(const QString& jsonUrl);
 
+        Q_INVOKABLE bool getReticleVisible() { return _reticleVisible; }
+        Q_INVOKABLE void setReticleVisible(bool visible) { _reticleVisible = visible; }
+
+        Q_INVOKABLE float getReticleDepth() { return _reticleDepth; }
+        Q_INVOKABLE void setReticleDepth(float depth) { _reticleDepth = depth; }
+
         Q_INVOKABLE glm::vec2 getReticlePosition() { 
             return toGlm(QCursor::pos()); 
         }
@@ -159,10 +165,13 @@ namespace controller {
         QVariantMap _actions;
         QVariantMap _standard;
 
-        bool _mouseCaptured{ false };
-        bool _touchCaptured{ false };
-        bool _wheelCaptured{ false };
-        bool _actionsCaptured{ false };
+        bool _mouseCaptured { false };
+        bool _touchCaptured { false };
+        bool _wheelCaptured { false };
+        bool _actionsCaptured { false };
+        bool _reticleVisible { true };
+
+        float _reticleDepth { 1.0f };
     };
 
 

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -13,10 +13,11 @@
 #ifndef hifi_AbstractControllerScriptingInterface_h
 #define hifi_AbstractControllerScriptingInterface_h
 
-#include <unordered_map>
-#include <unordered_set>
+#include <atomic>
 #include <map>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
@@ -165,12 +166,12 @@ namespace controller {
         QVariantMap _actions;
         QVariantMap _standard;
 
-        bool _mouseCaptured { false };
-        bool _touchCaptured { false };
-        bool _wheelCaptured { false };
-        bool _actionsCaptured { false };
-        bool _reticleVisible { true };
+        bool _mouseCaptured{ false };
+        bool _touchCaptured{ false };
+        bool _wheelCaptured{ false };
+        bool _actionsCaptured{ false };
 
+        bool _reticleVisible{ true };
         float _reticleDepth { 1.0f };
     };
 


### PR DESCRIPTION
* Fixes bug where 3D to 2D overlay transforms are wrong if the avatar rotates its body away from the HUD orientation
* Hides/Shows the overlay reticle/cursor when distance grab lasers are showing
* Changes hand controller mouse script to use thumb buttons for mouse clicks instead of triggers
* HUD lookat test script was rendering the 2D cursor in wrong place - now centers it over look at position
