### PR TITLE
Fix for spraypaint orientation

### DIFF
--- a/examples/toybox/spray_paint/sprayPaintCan.js
+++ b/examples/toybox/spray_paint/sprayPaintCan.js
@@ -81,7 +81,8 @@
                 green: 20,
                 blue: 150
             },
-            lifetime: 50, //probably wont be holding longer than this straight
+            lifetime: 50, //probably wont be holding longer than this straight,
+            emitterShouldTrail: true
         });
 
         setEntityCustomData(this.resetKey, this.paintStream, {


### PR DESCRIPTION
Spray paint particles that have already been emitted don't change orientation based on can movement or rotation