### PR TITLE
More precision for edit.js

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -64,7 +64,7 @@
         function createEmitNumberPropertyUpdateFunction(propertyName) {
             return function() {
                 EventBridge.emitWebEvent(
-                    '{ "type":"update", "properties":{"' + propertyName + '":' + parseFloat(this.value).toFixed(2) + '}}'
+                    '{ "type":"update", "properties":{"' + propertyName + '":' + Number(this.value.toFixed(4)) + '}}'
                 );
             };
         }
@@ -438,47 +438,47 @@
     
                                 elVisible.checked = properties.visible;
     
-                                elPositionX.value = properties.position.x.toFixed(2);
-                                elPositionY.value = properties.position.y.toFixed(2);
-                                elPositionZ.value = properties.position.z.toFixed(2);
+                                elPositionX.value = properties.position.x.toFixed(4);
+                                elPositionY.value = properties.position.y.toFixed(4);
+                                elPositionZ.value = properties.position.z.toFixed(4);
     
-                                elDimensionsX.value = properties.dimensions.x.toFixed(2);
-                                elDimensionsY.value = properties.dimensions.y.toFixed(2);
-                                elDimensionsZ.value = properties.dimensions.z.toFixed(2);
+                                elDimensionsX.value = properties.dimensions.x.toFixed(4);
+                                elDimensionsY.value = properties.dimensions.y.toFixed(4);
+                                elDimensionsZ.value = properties.dimensions.z.toFixed(4);
     
                                 elParentID.value = properties.parentID;
                                 elParentJointIndex.value = properties.parentJointIndex;
     
-                                elRegistrationX.value = properties.registrationPoint.x.toFixed(2);
-                                elRegistrationY.value = properties.registrationPoint.y.toFixed(2);
-                                elRegistrationZ.value = properties.registrationPoint.z.toFixed(2);
+                                elRegistrationX.value = properties.registrationPoint.x.toFixed(4);
+                                elRegistrationY.value = properties.registrationPoint.y.toFixed(4);
+                                elRegistrationZ.value = properties.registrationPoint.z.toFixed(4);
     
-                                elRotationX.value = properties.rotation.x.toFixed(2);
-                                elRotationY.value = properties.rotation.y.toFixed(2);
-                                elRotationZ.value = properties.rotation.z.toFixed(2);
+                                elRotationX.value = properties.rotation.x.toFixed(4);
+                                elRotationY.value = properties.rotation.y.toFixed(4);
+                                elRotationZ.value = properties.rotation.z.toFixed(4);
     
-                                elLinearVelocityX.value = properties.velocity.x.toFixed(2);
-                                elLinearVelocityY.value = properties.velocity.y.toFixed(2);
-                                elLinearVelocityZ.value = properties.velocity.z.toFixed(2);
+                                elLinearVelocityX.value = properties.velocity.x.toFixed(4);
+                                elLinearVelocityY.value = properties.velocity.y.toFixed(4);
+                                elLinearVelocityZ.value = properties.velocity.z.toFixed(4);
                                 elLinearDamping.value = properties.damping.toFixed(2);
     
-                                elAngularVelocityX.value = (properties.angularVelocity.x * RADIANS_TO_DEGREES).toFixed(2);
-                                elAngularVelocityY.value = (properties.angularVelocity.y * RADIANS_TO_DEGREES).toFixed(2);
-                                elAngularVelocityZ.value = (properties.angularVelocity.z * RADIANS_TO_DEGREES).toFixed(2);
-                                elAngularDamping.value = properties.angularDamping.toFixed(2);
+                                elAngularVelocityX.value = (properties.angularVelocity.x * RADIANS_TO_DEGREES).toFixed(4);
+                                elAngularVelocityY.value = (properties.angularVelocity.y * RADIANS_TO_DEGREES).toFixed(4);
+                                elAngularVelocityZ.value = (properties.angularVelocity.z * RADIANS_TO_DEGREES).toFixed(4);
+                                elAngularDamping.value = properties.angularDamping.toFixed(4);
     
-                                elRestitution.value = properties.restitution.toFixed(2);
-                                elFriction.value = properties.friction.toFixed(2);
+                                elRestitution.value = properties.restitution.toFixed(4);
+                                elFriction.value = properties.friction.toFixed(4);
     
-                                elGravityX.value = properties.gravity.x.toFixed(2);
-                                elGravityY.value = properties.gravity.y.toFixed(2);
-                                elGravityZ.value = properties.gravity.z.toFixed(2);
+                                elGravityX.value = properties.gravity.x.toFixed(4);
+                                elGravityY.value = properties.gravity.y.toFixed(4);
+                                elGravityZ.value = properties.gravity.z.toFixed(4);
     
-                                elAccelerationX.value = properties.acceleration.x.toFixed(2);
-                                elAccelerationY.value = properties.acceleration.y.toFixed(2);
-                                elAccelerationZ.value = properties.acceleration.z.toFixed(2);
+                                elAccelerationX.value = properties.acceleration.x.toFixed(4);
+                                elAccelerationY.value = properties.acceleration.y.toFixed(4);
+                                elAccelerationZ.value = properties.acceleration.z.toFixed(4);
     
-                                elDensity.value = properties.density.toFixed(2);
+                                elDensity.value = properties.density.toFixed(4);
                                 elCollisionless.checked = properties.collisionless;
                                 elDynamic.checked = properties.dynamic;
                                 elCollisionSoundURL.value = properties.collisionSoundURL;
@@ -1192,9 +1192,9 @@
         <div class="property">
             <div class="label">Position</div>
             <div class="value">
-                <div class="input-area ">X<input class="coord" type='number' id="property-pos-x"><div class="prop-x"></div></div>
-                <div class="input-area ">Y<input class="coord" type='number' id="property-pos-y"><div class="prop-y"></div></div>
-                <div class="input-area ">Z<input class="coord" type='number' id="property-pos-z"><div class="prop-z"></div></div>
+                <div class="input-area ">X<input class="coord" type='number' id="property-pos-x" step="0.1"><div class="prop-x"></div></div>
+                <div class="input-area ">Y<input class="coord" type='number' id="property-pos-y" step="0.1"><div class="prop-y"></div></div>
+                <div class="input-area ">Z<input class="coord" type='number' id="property-pos-z" step="0.1"><div class="prop-z"></div></div>
                 <div>
                     <input type="button" id="move-selection-to-grid" value="Selection to Grid">
                     <input type="button" id="move-all-to-grid" value="All to Grid">
@@ -1228,9 +1228,9 @@
         <div class="property">
             <div class="label">Dimensions</div>
             <div class="value">
-                <div class="input-area">X <input class="coord" type='number' id="property-dim-x"><div class="prop-x"></div></div>
-                <div class="input-area">Y <input class="coord" type='number' id="property-dim-y"><div class="prop-y"></div></div>
-                <div class="input-area">Z <input class="coord" type='number' id="property-dim-z"><div class="prop-z"></div></div>
+                <div class="input-area">X <input class="coord" type='number' id="property-dim-x" step="0.1"><div class="prop-x"></div></div>
+                <div class="input-area">Y <input class="coord" type='number' id="property-dim-y" step="0.1"><div class="prop-y"></div></div>
+                <div class="input-area">Z <input class="coord" type='number' id="property-dim-z" step="0.1"><div class="prop-z"></div></div>
                 <div>
                     <input type="button" id="reset-to-natural-dimensions" value="Reset to Natural Dimensions">
                 </div>
@@ -1280,9 +1280,9 @@
         <div class="property">
             <div class="label">Rotation</div>
             <div class="value">
-                <div class="input-area">Pitch <input class="coord" type='number' id="property-rot-x"></div>
-                <div class="input-area">Yaw <input class="coord" type='number' id="property-rot-y"></div>
-                <div class="input-area">Roll <input class="coord" type='number' id="property-rot-z"></div>
+                <div class="input-area">Pitch <input class="coord" type='number' id="property-rot-x" step="0.1"></div>
+                <div class="input-area">Yaw <input class="coord" type='number' id="property-rot-y" step="0.1"></div>
+                <div class="input-area">Roll <input class="coord" type='number' id="property-rot-z"step="0.1"></div>
             </div>
         </div>
 


### PR DESCRIPTION
Before, most of the values in edit.js were fixed at two decimal places. Now, most are fixed at 4 decimal places. Additionally, I've adjusted the step values of certain inputs to allow for slightly more precision when using the up or down keys to change the value (position, rotation, dimensions have a step of 0.1)

To test:

http://rawgit.com/imgntn/hifi/moreprecision/examples/edit.js