### PR TITLE
Remove image color in edit.js

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -109,11 +109,6 @@ var importingSVOImageOverlay = Overlays.addOverlay("image", {
     width: 20,
     height: 20,
     alpha: 1.0,
-    color: {
-        red: 255,
-        green: 255,
-        blue: 255
-    },
     x: Window.innerWidth - IMPORTING_SVO_OVERLAY_WIDTH,
     y: Window.innerHeight - IMPORTING_SVO_OVERLAY_HEIGHT,
     visible: false,


### PR DESCRIPTION
This removes the warning generated by ImageOverlay.qml
for the unhandled property, color.

To test:http://rawgit.com/zzmp/hifi/fix/edit-image-color/examples/edit.js