### PR TITLE
filenames on Linux are case-sensitive

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -43,6 +43,7 @@ ScriptEngines::ScriptEngines()
 
 QString normalizeScriptUrl(const QString& rawScriptUrl) {
     auto lower = rawScriptUrl.toLower();
+#ifndef Q_OS_LINUX
     if (!rawScriptUrl.startsWith("http:") && !rawScriptUrl.startsWith("https:") &&  !rawScriptUrl.startsWith("atp:")) {
         if (rawScriptUrl.startsWith("file:")) {
             return rawScriptUrl.toLower();
@@ -50,6 +51,7 @@ QString normalizeScriptUrl(const QString& rawScriptUrl) {
         // Force lowercase on file scripts because of drive letter weirdness.
         return QUrl::fromLocalFile(rawScriptUrl).toString().toLower();
     }
+#endif
     return QUrl(rawScriptUrl).toString();
 }
 

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -42,16 +42,21 @@ ScriptEngines::ScriptEngines()
 }
 
 QString normalizeScriptUrl(const QString& rawScriptUrl) {
-    auto lower = rawScriptUrl.toLower();
-#ifndef Q_OS_LINUX
     if (!rawScriptUrl.startsWith("http:") && !rawScriptUrl.startsWith("https:") &&  !rawScriptUrl.startsWith("atp:")) {
+#ifdef Q_OS_LINUX
+        if (rawScriptUrl.startsWith("file:")) {
+            return rawScriptUrl;
+        }
+        return QUrl::fromLocalFile(rawScriptUrl).toString();
+#else
         if (rawScriptUrl.startsWith("file:")) {
             return rawScriptUrl.toLower();
         }
         // Force lowercase on file scripts because of drive letter weirdness.
         return QUrl::fromLocalFile(rawScriptUrl).toString().toLower();
-    }
 #endif
+
+    }
     return QUrl(rawScriptUrl).toString();
 }
 


### PR DESCRIPTION
- on Linux, fix bug which cause scripts run from local disk to not load upon interface restart
