### PR TITLE
init debug octree rendering to be false

### DIFF
--- a/libraries/render/src/render/DrawStatus.h
+++ b/libraries/render/src/render/DrawStatus.h
@@ -25,7 +25,7 @@ namespace render {
 
         void dirtyHelper();
 
-        bool showDisplay{ true }; // FIXME FOR debug
+        bool showDisplay{ false };
         bool showNetwork{ false };
 
     public slots:


### PR DESCRIPTION
- prevent the render octree visualization display by default