### PR TITLE
AnimInverseKinematics: fix for extra twist in lowerSpine joints.

### DIFF
--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -278,8 +278,8 @@ int AnimInverseKinematics::solveTargetWithCCD(const IKTarget& target, AnimPoseVe
             if (axisLength > MIN_AXIS_LENGTH) {
                 // compute angle of rotation that brings tip closer to target
                 axis /= axisLength;
-                float cos_angle = std::min(std::max(glm::dot(leverArm, targetLine) / (glm::length(leverArm) * glm::length(targetLine)), -1.0f), 1.0f);
-                float angle = acosf(cos_angle);
+                float cosAngle = std::min(std::max(glm::dot(leverArm, targetLine) / (glm::length(leverArm) * glm::length(targetLine)), -1.0f), 1.0f);
+                float angle = acosf(cosAngle);
                 const float MIN_ADJUSTMENT_ANGLE = 1.0e-4f;
                 if (angle > MIN_ADJUSTMENT_ANGLE) {
                     // reduce angle by a fraction (for stability)

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -278,7 +278,7 @@ int AnimInverseKinematics::solveTargetWithCCD(const IKTarget& target, AnimPoseVe
             if (axisLength > MIN_AXIS_LENGTH) {
                 // compute angle of rotation that brings tip closer to target
                 axis /= axisLength;
-                float cosAngle = std::min(std::max(glm::dot(leverArm, targetLine) / (glm::length(leverArm) * glm::length(targetLine)), -1.0f), 1.0f);
+                float cosAngle = glm::clamp(glm::dot(leverArm, targetLine) / (glm::length(leverArm) * glm::length(targetLine)), -1.0f, 1.0f);
                 float angle = acosf(cosAngle);
                 const float MIN_ADJUSTMENT_ANGLE = 1.0e-4f;
                 if (angle > MIN_ADJUSTMENT_ANGLE) {

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -278,8 +278,8 @@ int AnimInverseKinematics::solveTargetWithCCD(const IKTarget& target, AnimPoseVe
             if (axisLength > MIN_AXIS_LENGTH) {
                 // compute angle of rotation that brings tip closer to target
                 axis /= axisLength;
-                float angle = acosf(glm::dot(leverArm, targetLine) / (glm::length(leverArm) * glm::length(targetLine)));
-
+                float cos_angle = std::min(std::max(glm::dot(leverArm, targetLine) / (glm::length(leverArm) * glm::length(targetLine)), -1.0f), 1.0f);
+                float angle = acosf(cos_angle);
                 const float MIN_ADJUSTMENT_ANGLE = 1.0e-4f;
                 if (angle > MIN_ADJUSTMENT_ANGLE) {
                     // reduce angle by a fraction (for stability)
@@ -348,7 +348,7 @@ int AnimInverseKinematics::solveTargetWithCCD(const IKTarget& target, AnimPoseVe
         }
 
         // keep track of tip's new transform as we descend towards root
-        tipPosition = jointPosition + deltaRotation * leverArm;
+        tipPosition = jointPosition + deltaRotation * (tipPosition - jointPosition);
         tipOrientation = glm::normalize(deltaRotation * tipOrientation);
         tipParentOrientation = glm::normalize(deltaRotation * tipParentOrientation);
 


### PR DESCRIPTION
* When computing tipPosition, for the next iteration of the CCD,
  use the leverArm before it's projected onto the lowerSpine twist axis.
* fix for acos() that was going outside of valid domain. (-1.0, 1.0)

This is a subtle thing to test for, but one good example would be to compare the avatar walking animation on master vs the walk animation in this PR.  The one on master will have exaggerated chest and shoulder rotation, which is not present in the original animation.  The version in this PR will match the original animation more closely.