### PR TITLE
cleanup ViewFrustum method names

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -425,11 +425,11 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     _maxOctreePPS(maxOctreePacketsPerSecond.get()),
     _lastFaceTrackerUpdate(0)
 {
-    // FIXME this may be excessivly conservative.  On the other hand 
+    // FIXME this may be excessivly conservative.  On the other hand
     // maybe I'm used to having an 8-core machine
-    // Perhaps find the ideal thread count  and subtract 2 or 3 
+    // Perhaps find the ideal thread count  and subtract 2 or 3
     // (main thread, present thread, random OS load)
-    // More threads == faster concurrent loads, but also more concurrent 
+    // More threads == faster concurrent loads, but also more concurrent
     // load on the GPU until we can serialize GPU transfers (off the main thread)
     QThreadPool::globalInstance()->setMaxThreadCount(2);
     thread()->setPriority(QThread::HighPriority);
@@ -560,7 +560,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
 
     auto discoverabilityManager = DependencyManager::get<DiscoverabilityManager>();
     connect(&locationUpdateTimer, &QTimer::timeout, discoverabilityManager.data(), &DiscoverabilityManager::updateLocation);
-    connect(&locationUpdateTimer, &QTimer::timeout, 
+    connect(&locationUpdateTimer, &QTimer::timeout,
         DependencyManager::get<AddressManager>().data(), &AddressManager::storeCurrentAddress);
     locationUpdateTimer.start(DATA_SERVER_LOCATION_CHANGE_UPDATE_MSECS);
 
@@ -604,7 +604,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
 
     connect(addressManager.data(), &AddressManager::hostChanged, this, &Application::updateWindowTitle);
     connect(this, &QCoreApplication::aboutToQuit, addressManager.data(), &AddressManager::storeCurrentAddress);
-    
+
     // Save avatar location immediately after a teleport.
     connect(getMyAvatar(), &MyAvatar::positionGoneTo,
         DependencyManager::get<AddressManager>().data(), &AddressManager::storeCurrentAddress);
@@ -625,7 +625,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
         getEntities()->reloadEntityScripts();
     }, Qt::QueuedConnection);
 
-    connect(scriptEngines, &ScriptEngines::scriptLoadError, 
+    connect(scriptEngines, &ScriptEngines::scriptLoadError,
         scriptEngines, [](const QString& filename, const QString& error){
         OffscreenUi::warning(nullptr, "Error Loading Script", filename + " failed to load.");
     }, Qt::QueuedConnection);
@@ -975,7 +975,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
         disconnect(_idleTimer);
     });
     // Setting the interval to zero forces this to get called whenever there are no messages
-    // in the queue, which can be pretty damn frequent.  Hence the idle function has a bunch 
+    // in the queue, which can be pretty damn frequent.  Hence the idle function has a bunch
     // of logic to abort early if it's being called too often.
     _idleTimer->start(0);
 }
@@ -1023,7 +1023,7 @@ void Application::cleanupBeforeQuit() {
     getEntities()->shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
     DependencyManager::get<ScriptEngines>()->saveScripts();
     DependencyManager::get<ScriptEngines>()->shutdownScripting(); // stop all currently running global scripts
-    DependencyManager::destroy<ScriptEngines>(); 
+    DependencyManager::destroy<ScriptEngines>();
 
     // first stop all timers directly or by invokeMethod
     // depending on what thread they run in
@@ -1212,10 +1212,10 @@ void Application::initializeUi() {
 
     setupPreferences();
 
-    // For some reason there is already an "Application" object in the QML context, 
+    // For some reason there is already an "Application" object in the QML context,
     // though I can't find it. Hence, "ApplicationInterface"
     rootContext->setContextProperty("SnapshotUploader", new SnapshotUploader());
-    rootContext->setContextProperty("ApplicationInterface", this); 
+    rootContext->setContextProperty("ApplicationInterface", this);
     rootContext->setContextProperty("AnimationCache", DependencyManager::get<AnimationCache>().data());
     rootContext->setContextProperty("Audio", &AudioScriptingInterface::getInstance());
     rootContext->setContextProperty("Controller", DependencyManager::get<controller::ScriptingInterface>().data());
@@ -2435,7 +2435,7 @@ void Application::idle(uint64_t now) {
     if (_aboutToQuit) {
         return; // bail early, nothing to do here.
     }
-    
+
     auto displayPlugin = getActiveDisplayPlugin();
     // depending on whether we're throttling or not.
     // Once rendering is off on another thread we should be able to have Application::idle run at start(0) in
@@ -2459,7 +2459,7 @@ void Application::idle(uint64_t now) {
     // Nested ifs are for clarity in the logic.  Don't collapse them into a giant single if.
     // Don't saturate the main thread with rendering, no paint calls until the last one is complete
     if (!_pendingPaint) {
-        // Also no paint calls until the display plugin has increased by at least one frame 
+        // Also no paint calls until the display plugin has increased by at least one frame
         // (don't render at 90fps if the display plugin only goes at 60)
         if (_renderedFrameIndex == INVALID_FRAME || presentCount > _renderedFrameIndex) {
             // Record what present frame we're on
@@ -2469,14 +2469,14 @@ void Application::idle(uint64_t now) {
             // But when we DO request a paint, get to it as soon as possible: high priority
             postEvent(this, new QEvent(static_cast<QEvent::Type>(Paint)), Qt::HighEventPriority);
         }
-    }  
-    
-    // For the rest of idle, we want to cap at the max sim rate, so we might not call 
+    }
+
+    // For the rest of idle, we want to cap at the max sim rate, so we might not call
     // the remaining idle work every paint frame, or vice versa
     // In theory this means we could call idle processing more often than painting,
     // but in practice, when the paintGL calls aren't keeping up, there's no room left
     // in the main thread to call idle more often than paint.
-    // This check is mostly to keep idle from burning up CPU cycles by running at 
+    // This check is mostly to keep idle from burning up CPU cycles by running at
     // hundreds of idles per second when the rendering is that fast
     if ((timeSinceLastUpdateUs / USECS_PER_MSEC) < CAPPED_SIM_FRAME_PERIOD_MS) {
         // No paint this round, but might be time for a new idle, otherwise return
@@ -3423,7 +3423,7 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType, Node
                                                   rootDetails.y * TREE_SCALE,
                                                   rootDetails.z * TREE_SCALE) - glm::vec3(HALF_TREE_SCALE),
                                         rootDetails.s * TREE_SCALE);
-                    ViewFrustum::location serverFrustumLocation = _viewFrustum.cubeInFrustum(serverBounds);
+                    ViewFrustum::location serverFrustumLocation = _viewFrustum.computeCubeViewLocation(serverBounds);
 
                     if (serverFrustumLocation != ViewFrustum::OUTSIDE) {
                         inViewServers++;
@@ -3491,7 +3491,7 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType, Node
                                         rootDetails.s * TREE_SCALE);
 
 
-                    ViewFrustum::location serverFrustumLocation = _viewFrustum.cubeInFrustum(serverBounds);
+                    ViewFrustum::location serverFrustumLocation = _viewFrustum.computeCubeViewLocation(serverBounds);
                     if (serverFrustumLocation != ViewFrustum::OUTSIDE) {
                         inView = true;
                     } else {
@@ -4752,7 +4752,7 @@ static void addDisplayPluginToMenu(DisplayPluginPointer displayPlugin, bool acti
             groupingMenu = "Developer";
             break;
         default:
-            groupingMenu = "Standard"; 
+            groupingMenu = "Standard";
             break;
     }
 

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -136,7 +136,7 @@ glm::quat Avatar::getWorldAlignedOrientation () const {
 
 AABox Avatar::getBounds() const {
     // Our skeleton models are rigged, and this method call safely produces the static bounds of the model.
-    // Except, that getPartBounds produces an infinite, uncentered bounding box when the model is not yet parsed, 
+    // Except, that getPartBounds produces an infinite, uncentered bounding box when the model is not yet parsed,
     // and we want a centered one. NOTE: There is code that may never try to render, and thus never load and get the
     // real model bounds, if this is unrealistically small.
     if (!_skeletonModel.isRenderable()) {
@@ -188,7 +188,7 @@ void Avatar::simulate(float deltaTime) {
 
     // simple frustum check
     float boundingRadius = getBoundingRadius();
-    bool inViewFrustum = qApp->getViewFrustum()->sphereInFrustum(getPosition(), boundingRadius) !=
+    bool inViewFrustum = qApp->getViewFrustum()->computeSphereViewLocation(getPosition(), boundingRadius) !=
         ViewFrustum::OUTSIDE;
 
     {
@@ -401,7 +401,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
         frustum = qApp->getDisplayViewFrustum();
     }
 
-    if (frustum->sphereInFrustum(getPosition(), boundingRadius) == ViewFrustum::OUTSIDE) {
+    if (frustum->computeSphereViewLocation(getPosition(), boundingRadius) == ViewFrustum::OUTSIDE) {
         endRender();
         return;
     }
@@ -516,7 +516,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
         auto& frustum = *renderArgs->_viewFrustum;
         auto textPosition = getDisplayNamePosition();
 
-        if (frustum.pointInFrustum(textPosition, true) == ViewFrustum::INSIDE) {
+        if (frustum.computePointFrustumLocation(textPosition) == ViewFrustum::INSIDE) {
             renderDisplayName(batch, frustum, textPosition);
         }
     }
@@ -670,7 +670,7 @@ glm::vec3 Avatar::getDisplayNamePosition() const {
 }
 
 Transform Avatar::calculateDisplayNameTransform(const ViewFrustum& frustum, const glm::vec3& textPosition) const {
-    Q_ASSERT_X(frustum.pointInFrustum(textPosition, true) == ViewFrustum::INSIDE,
+    Q_ASSERT_X(frustum.computePointFrustumLocation(textPosition) == ViewFrustum::INSIDE,
                "Avatar::calculateDisplayNameTransform", "Text not in viewfrustum.");
     glm::vec3 toFrustum = frustum.getPosition() - textPosition;
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -85,7 +85,7 @@ void EntityTreeElement::initializeExtraEncodeData(EncodeBitstreamParams& params)
         forEachEntity([&](EntityItemPointer entity) {
             entityTreeElementExtraEncodeData->entities.insert(entity->getEntityItemID(), entity->getEntityProperties(params));
         });
-        
+
         // TODO: some of these inserts might be redundant!!!
         extraEncodeData->insert(this, entityTreeElementExtraEncodeData);
     }
@@ -96,39 +96,39 @@ bool EntityTreeElement::shouldIncludeChildData(int childIndex, EncodeBitstreamPa
     assert(extraEncodeData); // EntityTrees always require extra encode data on their encoding passes
 
     if (extraEncodeData->contains(this)) {
-        EntityTreeElementExtraEncodeData* entityTreeElementExtraEncodeData 
+        EntityTreeElementExtraEncodeData* entityTreeElementExtraEncodeData
                         = static_cast<EntityTreeElementExtraEncodeData*>(extraEncodeData->value(this));
-                        
+
         bool childCompleted = entityTreeElementExtraEncodeData->childCompleted[childIndex];
-        
+
         // If we haven't completely sent the child yet, then we should include it
         return !childCompleted;
     }
-    
+
     // I'm not sure this should ever happen, since we should have the extra encode data if we're considering
     // the child data for this element
     assert(false);
     return false;
 }
 
-bool EntityTreeElement::shouldRecurseChildTree(int childIndex, EncodeBitstreamParams& params) const { 
+bool EntityTreeElement::shouldRecurseChildTree(int childIndex, EncodeBitstreamParams& params) const {
     EntityTreeElementPointer childElement = getChildAtIndex(childIndex);
     if (childElement->alreadyFullyEncoded(params)) {
         return false;
     }
-    
+
     return true; // if we don't know otherwise than recurse!
 }
 
-bool EntityTreeElement::alreadyFullyEncoded(EncodeBitstreamParams& params) const { 
+bool EntityTreeElement::alreadyFullyEncoded(EncodeBitstreamParams& params) const {
     OctreeElementExtraEncodeData* extraEncodeData = params.extraEncodeData;
     assert(extraEncodeData); // EntityTrees always require extra encode data on their encoding passes
 
     if (extraEncodeData->contains(this)) {
-        EntityTreeElementExtraEncodeData* entityTreeElementExtraEncodeData 
+        EntityTreeElementExtraEncodeData* entityTreeElementExtraEncodeData
                         = static_cast<EntityTreeElementExtraEncodeData*>(extraEncodeData->value(this));
 
-        // If we know that ALL subtrees below us have already been recursed, then we don't 
+        // If we know that ALL subtrees below us have already been recursed, then we don't
         // need to recurse this child.
         return entityTreeElementExtraEncodeData->subtreeCompleted;
     }
@@ -139,7 +139,7 @@ void EntityTreeElement::updateEncodedData(int childIndex, AppendState childAppen
     OctreeElementExtraEncodeData* extraEncodeData = params.extraEncodeData;
     assert(extraEncodeData); // EntityTrees always require extra encode data on their encoding passes
     if (extraEncodeData->contains(this)) {
-        EntityTreeElementExtraEncodeData* entityTreeElementExtraEncodeData 
+        EntityTreeElementExtraEncodeData* entityTreeElementExtraEncodeData
                         = static_cast<EntityTreeElementExtraEncodeData*>(extraEncodeData->value(this));
 
         if (childAppendState == OctreeElement::COMPLETED) {
@@ -155,7 +155,7 @@ void EntityTreeElement::updateEncodedData(int childIndex, AppendState childAppen
 
 void EntityTreeElement::elementEncodeComplete(EncodeBitstreamParams& params) const {
     const bool wantDebug = false;
-    
+
     if (wantDebug) {
         qCDebug(entities) << "EntityTreeElement::elementEncodeComplete() element:" << _cube;
     }
@@ -188,7 +188,7 @@ void EntityTreeElement::elementEncodeComplete(EncodeBitstreamParams& params) con
             // If we've encoding this element before... but we're coming back a second time in an attempt to
             // encoud our parent... this might happen.
             if (extraEncodeData->contains(childElement.get())) {
-                EntityTreeElementExtraEncodeData* childExtraEncodeData 
+                EntityTreeElementExtraEncodeData* childExtraEncodeData
                     = static_cast<EntityTreeElementExtraEncodeData*>(extraEncodeData->value(childElement.get()));
 
                 if (wantDebug) {
@@ -197,7 +197,7 @@ void EntityTreeElement::elementEncodeComplete(EncodeBitstreamParams& params) con
                     qCDebug(entities) << "    childExtraEncodeData->elementCompleted:" << childExtraEncodeData->elementCompleted;
                     qCDebug(entities) << "    childExtraEncodeData->subtreeCompleted:" << childExtraEncodeData->subtreeCompleted;
                 }
-                
+
                 if (childElement->isLeaf() && childExtraEncodeData->elementCompleted) {
                     if (wantDebug) {
                         qCDebug(entities) << "    CHILD IS LEAF -- AND CHILD ELEMENT DATA COMPLETED!!!";
@@ -217,24 +217,24 @@ void EntityTreeElement::elementEncodeComplete(EncodeBitstreamParams& params) con
         qCDebug(entities) << "    WAS elementCompleted:" << thisExtraEncodeData->elementCompleted;
         qCDebug(entities) << "    WAS subtreeCompleted:" << thisExtraEncodeData->subtreeCompleted;
     }
-    
+
     thisExtraEncodeData->subtreeCompleted = !someChildTreeNotComplete;
 
     if (wantDebug) {
         qCDebug(entities) << "    NOW elementCompleted:" << thisExtraEncodeData->elementCompleted;
         qCDebug(entities) << "    NOW subtreeCompleted:" << thisExtraEncodeData->subtreeCompleted;
-    
+
         if (thisExtraEncodeData->subtreeCompleted) {
             qCDebug(entities) << "    YEAH!!!!! >>>>>>>>>>>>>> NOW subtreeCompleted:" << thisExtraEncodeData->subtreeCompleted;
         }
     }
 }
 
-OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData* packetData, 
+OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData* packetData,
                                                                     EncodeBitstreamParams& params) const {
 
     OctreeElement::AppendState appendElementState = OctreeElement::COMPLETED; // assume the best...
-    
+
     // first, check the params.extraEncodeData to see if there's any partial re-encode data for this element
     OctreeElementExtraEncodeData* extraEncodeData = params.extraEncodeData;
     EntityTreeElementExtraEncodeData* entityTreeElementExtraEncodeData = NULL;
@@ -280,7 +280,7 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
         QVector<uint16_t> indexesOfEntitiesToInclude;
 
         // It's possible that our element has been previous completed. In this case we'll simply not include any of our
-        // entities for encoding. This is needed because we encode the element data at the "parent" level, and so we 
+        // entities for encoding. This is needed because we encode the element data at the "parent" level, and so we
         // need to handle the case where our sibling elements need encoding but we don't.
         if (!entityTreeElementExtraEncodeData->elementCompleted) {
             for (uint16_t i = 0; i < _entityItems.size(); i++) {
@@ -304,7 +304,7 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
                     // frustum culling on rendering.
                     bool success;
                     AACube entityCube = entity->getQueryAACube(success);
-                    if (!success || params.viewFrustum->cubeInFrustum(entityCube) == ViewFrustum::OUTSIDE) {
+                    if (!success || params.viewFrustum->computeCubeViewLocation(entityCube) == ViewFrustum::OUTSIDE) {
                         includeThisEntity = false; // out of view, don't include it
                     }
 
@@ -397,7 +397,7 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
     // this octree element.
     if (extraEncodeData && entityTreeElementExtraEncodeData) {
 
-        // After processing, if we are PARTIAL or COMPLETED then we need to re-include our extra data. 
+        // After processing, if we are PARTIAL or COMPLETED then we need to re-include our extra data.
         // Only our parent can remove our extra data in these cases and only after it knows that all of its
         // children have been encoded.
         // If we weren't able to encode ANY data about ourselves, then we go ahead and remove our element data
@@ -412,7 +412,7 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
                 extraEncodeData->insert(this, entityTreeElementExtraEncodeData);
             }
         } else {
-        
+
             // If we weren't previously completed, check to see if we are
             if (!entityTreeElementExtraEncodeData->elementCompleted) {
                 // If all of our items have been encoded, then we are complete as an element.
@@ -426,9 +426,9 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
         }
     }
 
-    // Determine if no entities at all were able to fit    
+    // Determine if no entities at all were able to fit
     bool noEntitiesFit = (numberOfEntities > 0 && actualNumberOfEntities == 0);
-    
+
     // If we wrote fewer entities than we expected, update the number of entities in our packet
     bool successUpdateEntityCount = true;
     if (numberOfEntities != actualNumberOfEntities) {
@@ -504,7 +504,7 @@ bool EntityTreeElement::bestFitBounds(const glm::vec3& minPoint, const glm::vec3
     glm::vec3 clampedMax = glm::clamp(maxPoint, (float)-HALF_TREE_SCALE, (float)HALF_TREE_SCALE);
 
     if (_cube.contains(clampedMin) && _cube.contains(clampedMax)) {
-        
+
         // If our child would be smaller than our smallest reasonable element, then we are the best fit.
         float childScale = _cube.getScale() / 2.0f;
         if (childScale <= SMALLEST_REASONABLE_OCTREE_ELEMENT_SCALE) {
@@ -524,7 +524,7 @@ bool EntityTreeElement::bestFitBounds(const glm::vec3& minPoint, const glm::vec3
 
 bool EntityTreeElement::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
     bool& keepSearching, OctreeElementPointer& element, float& distance,
-    BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude, 
+    BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
     const QVector<EntityItemID>& entityIdsToDiscard, void** intersectedObject, bool precisionPicking) {
 
     keepSearching = true; // assume that we will continue searching after this.
@@ -607,7 +607,7 @@ bool EntityTreeElement::findDetailedRayIntersection(const glm::vec3& origin, con
 
         // we can use the AABox's ray intersection by mapping our origin and direction into the entity frame
         // and testing intersection there.
-        if (entityFrameBox.findRayIntersection(entityFrameOrigin, entityFrameDirection, localDistance, 
+        if (entityFrameBox.findRayIntersection(entityFrameOrigin, entityFrameDirection, localDistance,
                                                 localFace, localSurfaceNormal)) {
             if (localDistance < distance) {
                 // now ask the entity if we actually intersect
@@ -862,12 +862,12 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
     if (this == _myTree->getRoot().get() && args.bitstreamVersion < VERSION_ROOT_ELEMENT_HAS_DATA) {
         return 0;
     }
-    
+
     const unsigned char* dataAt = data;
     int bytesRead = 0;
     uint16_t numberOfEntities = 0;
     int expectedBytesPerEntity = EntityItem::expectedBytes();
-    
+
     args.elementsPerPacket++;
 
     if (bytesLeftToRead >= (int)sizeof(numberOfEntities)) {
@@ -947,7 +947,7 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
                                 entityItem->recordCreationTime();
                             }
                         } else {
-                            qDebug() << "Recieved packet for previously deleted entity [" << 
+                            qDebug() << "Recieved packet for previously deleted entity [" <<
                                         entityItem->getID() << "] ignoring. (inside " << __FUNCTION__ << ")";
                         }
                     }
@@ -959,7 +959,7 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
             }
         }
     }
-    
+
     return bytesRead;
 }
 
@@ -990,7 +990,7 @@ bool EntityTreeElement::pruneChildren() {
     bool somethingPruned = false;
     for (int childIndex = 0; childIndex < NUMBER_OF_CHILDREN; childIndex++) {
         EntityTreeElementPointer child = getChildAtIndex(childIndex);
-        
+
         // if my child is a leaf, but has no entities, then it's safe to delete my child
         if (child && child->isLeaf() && !child->hasEntities()) {
             deleteChildAtIndex(childIndex);
@@ -1040,4 +1040,4 @@ void EntityTreeElement::debugDump() {
         }
     });
 }
-    
+

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -1034,7 +1034,7 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
         // if we are INSIDE, INTERSECT, or OUTSIDE
         if (parentLocationThisView != ViewFrustum::INSIDE) {
             assert(parentLocationThisView != ViewFrustum::OUTSIDE); // we shouldn't be here if our parent was OUTSIDE!
-            nodeLocationThisView = element->inFrustum(*params.viewFrustum);
+            nodeLocationThisView = element->computeViewLocation(*params.viewFrustum);
         }
 
         // If we're at a element that is out of view, then we can return, because no nodes below us will be in view!
@@ -1053,7 +1053,7 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
         bool wasInView = false;
 
         if (params.deltaViewFrustum && params.lastViewFrustum) {
-            ViewFrustum::location location = element->inFrustum(*params.lastViewFrustum);
+            ViewFrustum::location location = element->computeViewLocation(*params.lastViewFrustum);
 
             // If we're a leaf, then either intersect or inside is considered "formerly in view"
             if (element->isLeaf()) {
@@ -1237,7 +1237,7 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
                     bool childWasInView = false;
 
                     if (childElement && params.deltaViewFrustum && params.lastViewFrustum) {
-                        ViewFrustum::location location = childElement->inFrustum(*params.lastViewFrustum);
+                        ViewFrustum::location location = childElement->computeViewLocation(*params.lastViewFrustum);
 
                         // If we're a leaf, then either intersect or inside is considered "formerly in view"
                         if (childElement->isLeaf()) {

--- a/libraries/octree/src/OctreeElement.cpp
+++ b/libraries/octree/src/OctreeElement.cpp
@@ -458,8 +458,8 @@ float OctreeElement::getEnclosingRadius() const {
     return getScale() * sqrtf(3.0f) / 2.0f;
 }
 
-ViewFrustum::location OctreeElement::inFrustum(const ViewFrustum& viewFrustum) const {
-    return viewFrustum.cubeInFrustum(_cube);
+ViewFrustum::location OctreeElement::computeViewLocation(const ViewFrustum& viewFrustum) const {
+    return viewFrustum.computeCubeViewLocation(_cube);
 }
 
 // There are two types of nodes for which we want to "render"

--- a/libraries/octree/src/OctreeElement.h
+++ b/libraries/octree/src/OctreeElement.h
@@ -49,20 +49,20 @@ protected:
     OctreeElement();
 
     virtual OctreeElementPointer createNewElement(unsigned char * octalCode = NULL) = 0;
-    
+
 public:
     virtual void init(unsigned char * octalCode); /// Your subclass must call init on construction.
     virtual ~OctreeElement();
 
     // methods you can and should override to implement your tree functionality
-    
+
     /// Adds a child to the current element. Override this if there is additional child initialization your class needs.
     virtual OctreeElementPointer addChildAtIndex(int childIndex);
 
-    /// Override this to implement LOD averaging on changes to the tree. 
+    /// Override this to implement LOD averaging on changes to the tree.
     virtual void calculateAverageFromChildren() { }
 
-    /// Override this to implement LOD collapsing and identical child pruning on changes to the tree. 
+    /// Override this to implement LOD collapsing and identical child pruning on changes to the tree.
     virtual bool collapseChildren() { return false; }
 
     /// Should this element be considered to have content in it. This will be used in collision and ray casting methods.
@@ -72,12 +72,12 @@ public:
     /// Should this element be considered to have detailed content in it. Specifically should it be rendered.
     /// By default we assume that only leaves have detailed content, but some octrees may have different semantics.
     virtual bool hasDetailedContent() const { return isLeaf(); }
-    
+
     /// Override this to break up large octree elements when an edit operation is performed on a smaller octree element.
-    /// For example, if the octrees represent solid cubes and a delete of a smaller octree element is done then the 
+    /// For example, if the octrees represent solid cubes and a delete of a smaller octree element is done then the
     /// meaningful split would be to break the larger cube into smaller cubes of the same color/texture.
     virtual void splitChildren() { }
-    
+
     /// Override to indicate that this element requires a split before editing lower elements in the octree
     virtual bool requiresSplit() const { return false; }
 
@@ -88,17 +88,17 @@ public:
     virtual void initializeExtraEncodeData(EncodeBitstreamParams& params) { }
     virtual bool shouldIncludeChildData(int childIndex, EncodeBitstreamParams& params) const { return true; }
     virtual bool shouldRecurseChildTree(int childIndex, EncodeBitstreamParams& params) const { return true; }
-    
+
     virtual void updateEncodedData(int childIndex, AppendState childAppendState, EncodeBitstreamParams& params) const { }
     virtual void elementEncodeComplete(EncodeBitstreamParams& params) const { }
 
     /// Override to serialize the state of this element. This is used for persistance and for transmission across the network.
-    virtual AppendState appendElementData(OctreePacketData* packetData, EncodeBitstreamParams& params) const 
+    virtual AppendState appendElementData(OctreePacketData* packetData, EncodeBitstreamParams& params) const
                                 { return COMPLETED; }
-    
+
     /// Override to deserialize the state of this element. This is used for loading from a persisted file or from reading
     /// from the network.
-    virtual int readElementDataFromBuffer(const unsigned char* data, int bytesLeftToRead, ReadBitstreamToTreeParams& args) 
+    virtual int readElementDataFromBuffer(const unsigned char* data, int bytesLeftToRead, ReadBitstreamToTreeParams& args)
                     { return 0; }
 
     /// Override to indicate that the item is currently rendered in the rendering engine. By default we assume that if
@@ -106,7 +106,7 @@ public:
     /// where an element is not actually rendering all should render elements. If the isRendered() state doesn't match the
     /// shouldRender() state, the tree will remark elements as changed even in cases there the elements have not changed.
     virtual bool isRendered() const { return getShouldRender(); }
-    
+
     virtual bool deleteApproved() const { return true; }
 
     virtual bool canRayIntersect() const { return isLeaf(); }
@@ -114,7 +114,7 @@ public:
     /// \param radius radius of sphere in meters
     /// \param[out] penetration pointing into cube from sphere
     /// \param penetratedObject unused
-    virtual bool findSpherePenetration(const glm::vec3& center, float radius, 
+    virtual bool findSpherePenetration(const glm::vec3& center, float radius,
                         glm::vec3& penetration, void** penetratedObject) const;
 
     // Base class methods you don't need to implement
@@ -125,7 +125,7 @@ public:
     bool isParentOf(OctreeElementPointer possibleChild) const;
 
     /// handles deletion of all descendants, returns false if delete not approved
-    bool safeDeepDeleteChildAtIndex(int childIndex, int recursionCount = 0); 
+    bool safeDeepDeleteChildAtIndex(int childIndex, int recursionCount = 0);
 
 
     const AACube& getAACube() const { return _cube; }
@@ -134,8 +134,8 @@ public:
     int getLevel() const { return numberOfThreeBitSectionsInCode(getOctalCode()) + 1; }
 
     float getEnclosingRadius() const;
-    bool isInView(const ViewFrustum& viewFrustum) const { return inFrustum(viewFrustum) != ViewFrustum::OUTSIDE; }
-    ViewFrustum::location inFrustum(const ViewFrustum& viewFrustum) const;
+    bool isInView(const ViewFrustum& viewFrustum) const { return computeViewLocation(viewFrustum) != ViewFrustum::OUTSIDE; }
+    ViewFrustum::location computeViewLocation(const ViewFrustum& viewFrustum) const;
     float distanceToCamera(const ViewFrustum& viewFrustum) const;
     float furthestDistanceToCamera(const ViewFrustum& viewFrustum) const;
 
@@ -257,7 +257,7 @@ protected:
     static std::map<QString, uint16_t> _mapSourceUUIDsToKeys;
     static std::map<uint16_t, QString> _mapKeysToSourceUUIDs;
 
-    unsigned char _childBitmask;     // 1 byte 
+    unsigned char _childBitmask;     // 1 byte
 
     bool _falseColored : 1, /// Client only, is this voxel false colored, 1 bit
          _isDirty : 1, /// Client only, has this voxel changed since being rendered, 1 bit

--- a/libraries/octree/src/OctreeHeadlessViewer.cpp
+++ b/libraries/octree/src/OctreeHeadlessViewer.cpp
@@ -27,9 +27,9 @@ void OctreeHeadlessViewer::init() {
 void OctreeHeadlessViewer::queryOctree() {
     char serverType = getMyNodeType();
     PacketType packetType = getMyQueryMessageType();
-    
+
     NodeToJurisdictionMap& jurisdictions = *_jurisdictionListener->getJurisdictions();
-    
+
     bool wantExtraDebugging = false;
 
     if (wantExtraDebugging) {
@@ -77,7 +77,7 @@ void OctreeHeadlessViewer::queryOctree() {
                 if (jurisdictions.find(nodeUUID) == jurisdictions.end()) {
                     unknownJurisdictionServers++;
                     return;
-                } 
+                }
                 const JurisdictionMap& map = (jurisdictions)[nodeUUID];
 
                 unsigned char* rootCode = map.getRootOctalCode();
@@ -91,7 +91,7 @@ void OctreeHeadlessViewer::queryOctree() {
 
             if (foundRootDetails) {
                 AACube serverBounds(glm::vec3(rootDetails.x, rootDetails.y, rootDetails.z), rootDetails.s);
-                ViewFrustum::location serverFrustumLocation = _viewFrustum.cubeInFrustum(serverBounds);
+                ViewFrustum::location serverFrustumLocation = _viewFrustum.computeCubeViewLocation(serverBounds);
 
                 if (serverFrustumLocation != ViewFrustum::OUTSIDE) {
                     inViewServers++;
@@ -165,7 +165,7 @@ void OctreeHeadlessViewer::queryOctree() {
             if (foundRootDetails) {
                 AACube serverBounds(glm::vec3(rootDetails.x, rootDetails.y, rootDetails.z), rootDetails.s);
 
-                ViewFrustum::location serverFrustumLocation = _viewFrustum.cubeInFrustum(serverBounds);
+                ViewFrustum::location serverFrustumLocation = _viewFrustum.computeCubeViewLocation(serverBounds);
                 if (serverFrustumLocation != ViewFrustum::OUTSIDE) {
                     inView = true;
                 } else {
@@ -208,7 +208,7 @@ void OctreeHeadlessViewer::queryOctree() {
 
             // setup the query packet
             auto queryPacket = NLPacket::create(packetType);
-            
+
             // read the data to our packet and set the payload size to fit the query
             int querySize = _octreeQuery.getBroadcastData(reinterpret_cast<unsigned char*>(queryPacket->getPayload()));
             queryPacket->setPayloadSize(querySize);

--- a/libraries/octree/src/ViewFrustum.h
+++ b/libraries/octree/src/ViewFrustum.h
@@ -91,10 +91,11 @@ public:
 
     typedef enum {OUTSIDE, INTERSECT, INSIDE} location;
 
-    ViewFrustum::location pointInFrustum(const glm::vec3& point, bool ignoreKeyhole = false) const;
-    ViewFrustum::location sphereInFrustum(const glm::vec3& center, float radius) const;
-    ViewFrustum::location cubeInFrustum(const AACube& cube) const;
-    ViewFrustum::location boxInFrustum(const AABox& box) const;
+    ViewFrustum::location computePointFrustumLocation(const glm::vec3& point) const;
+
+    ViewFrustum::location computeSphereViewLocation(const glm::vec3& center, float radius) const;
+    ViewFrustum::location computeCubeViewLocation(const AACube& cube) const;
+    ViewFrustum::location computeBoxViewLocation(const AABox& box) const;
 
     // some frustum comparisons
     bool matches(const ViewFrustum& compareTo, bool debug = false) const;
@@ -114,15 +115,15 @@ public:
     glm::vec2 projectPoint(glm::vec3 point, bool& pointInView) const;
     OctreeProjectedPolygon getProjectedPolygon(const AACube& box) const;
     void getFurthestPointFromCamera(const AACube& box, glm::vec3& furthestPoint) const;
-    
+
     float distanceToCamera(const glm::vec3& point) const;
-    
+
     void evalProjectionMatrix(glm::mat4& proj) const;
     void evalViewTransform(Transform& view) const;
 
     /// renderAccuracy represents a floating point "visibility" of an object based on it's view from the camera. At a simple
     /// level it returns 0.0f for things that are so small for the current settings that they could not be visible.
-    float calculateRenderAccuracy(const AABox& bounds, float octreeSizeScale = DEFAULT_OCTREE_SIZE_SCALE, 
+    float calculateRenderAccuracy(const AABox& bounds, float octreeSizeScale = DEFAULT_OCTREE_SIZE_SCALE,
                                   int boundaryLevelAdjust = 0) const;
 
     float getAccuracyAngle(float octreeSizeScale = DEFAULT_OCTREE_SIZE_SCALE, int boundaryLevelAdjust = 0) const;

--- a/libraries/render/src/render/CullTask.cpp
+++ b/libraries/render/src/render/CullTask.cpp
@@ -29,7 +29,7 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
     ViewFrustum* frustum = args->_viewFrustum;
 
     details._considered += (int)inItems.size();
-    
+
     // Culling / LOD
     for (auto item : inItems) {
         if (item.bound.isNull()) {
@@ -41,8 +41,8 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
         // when they are outside of the view frustum...
         bool outOfView;
         {
-            PerformanceTimer perfTimer("boxInFrustum");
-            outOfView = frustum->boxInFrustum(item.bound) == ViewFrustum::OUTSIDE;
+            PerformanceTimer perfTimer("computeBoxViewLocation");
+            outOfView = frustum->computeBoxViewLocation(item.bound) == ViewFrustum::OUTSIDE;
         }
         if (!outOfView) {
             bool bigEnoughToRender;
@@ -88,10 +88,10 @@ struct BackToFrontSort {
 void render::depthSortItems(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, bool frontToBack, const ItemBounds& inItems, ItemBounds& outItems) {
     assert(renderContext->args);
     assert(renderContext->args->_viewFrustum);
-    
+
     auto& scene = sceneContext->_scene;
     RenderArgs* args = renderContext->args;
-    
+
 
     // Allocate and simply copy
     outItems.clear();
@@ -237,8 +237,8 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
             */
         }
 
-        bool frustumTest(const AABox& bound) {
-            if (_args->_viewFrustum->boxInFrustum(bound) == ViewFrustum::OUTSIDE) {
+        bool viewTest(const AABox& bound) {
+            if (_args->_viewFrustum->computeBoxViewLocation(bound) == ViewFrustum::OUTSIDE) {
                 _renderDetails._outOfView++;
                 return false;
             }
@@ -302,7 +302,7 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
             auto& item = scene->getItem(id);
             if (_filter.test(item.getKey())) {
                 ItemBound itemBound(id, item.getBound());
-                if (test.frustumTest(itemBound.bound)) {
+                if (test.viewTest(itemBound.bound)) {
                     outItems.emplace_back(itemBound);
                 }
             }
@@ -316,7 +316,7 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
             auto& item = scene->getItem(id);
             if (_filter.test(item.getKey())) {
                 ItemBound itemBound(id, item.getBound());
-                if (test.frustumTest(itemBound.bound)) {
+                if (test.viewTest(itemBound.bound)) {
                     if (test.solidAngleTest(itemBound.bound)) {
                         outItems.emplace_back(itemBound);
                     }


### PR DESCRIPTION
- cleanup some method/variable names in ViewFrustum class to be more correct
- render culling now only checks against the "frustum" part of the "keyhole" view
- add more efficient methods for keyhole culling (not used yet, but will be soon)
- add unit tests for some ViewFrustum methods
- add unit tests (incomplete) for AABox and AACube