### PR TITLE
Prevent avatar's wrists from entering torso

### DIFF
--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -144,6 +144,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
         } else {
             handParams.isRightEnabled = false;
         }
+        handParams.bodyCapsuleRadius = myAvatar->getCharacterController()->getCapsuleRadius();
 
         _rig->updateFromHandParameters(handParams, deltaTime);
 

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -670,7 +670,7 @@ void AnimInverseKinematics::initConstraints() {
             stConstraint->setTwistLimits(-MAX_SHOULDER_TWIST, MAX_SHOULDER_TWIST);
 
             std::vector<float> minDots;
-            const float MAX_SHOULDER_SWING = PI / 20.0f;
+            const float MAX_SHOULDER_SWING = PI / 6.0f;
             minDots.push_back(cosf(MAX_SHOULDER_SWING));
             stConstraint->setSwingLimits(minDots);
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1083,6 +1083,7 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
 
         const float HAND_RADIUS = 0.05f;
         const float BODY_RADIUS = params.bodyCapsuleRadius;
+        const float MIN_LENGTH = 1.0e-4f;
 
         // project the hips onto the xz plane.
         auto hipsTrans = _internalPoseSet._absolutePoses[_animSkeleton->nameToJointIndex("Hips")].trans;
@@ -1092,13 +1093,14 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
 
             // project the hand position onto the xz plane.
             glm::vec2 handCircleCenter(params.leftPosition.x, params.leftPosition.z);
-            auto d = handCircleCenter - bodyCircleCenter;
 
             // check for 2d overlap of the hand and body circles.
-            float penetrationDistance = HAND_RADIUS + BODY_RADIUS - glm::length(d);
-            if (penetrationDistance > 0) {
+            auto circleToCircle = handCircleCenter - bodyCircleCenter;
+            const float circleToCircleLength = glm::length(circleToCircle);
+            const float penetrationDistance = HAND_RADIUS + BODY_RADIUS - circleToCircleLength;
+            if (penetrationDistance > 0.0f && circleToCircleLength > MIN_LENGTH) {
                 // push the hands out of the body
-                handCircleCenter += penetrationDistance * glm::normalize(d);
+                handCircleCenter += penetrationDistance * glm::normalize(circleToCircle);
             }
 
             glm::vec3 handPosition(handCircleCenter.x, params.leftPosition.y, handCircleCenter.y);
@@ -1115,13 +1117,14 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
 
             // project the hand position onto the xz plane.
             glm::vec2 handCircleCenter(params.rightPosition.x, params.rightPosition.z);
-            auto d = handCircleCenter - bodyCircleCenter;
 
             // check for 2d overlap of the hand and body circles.
-            float penetrationDistance = HAND_RADIUS + BODY_RADIUS - glm::length(d);
-            if (penetrationDistance > 0) {
+            auto circleToCircle = handCircleCenter - bodyCircleCenter;
+            const float circleToCircleLength = glm::length(circleToCircle);
+            const float penetrationDistance = HAND_RADIUS + BODY_RADIUS - circleToCircleLength;
+            if (penetrationDistance > 0.0f && circleToCircleLength > MIN_LENGTH) {
                 // push the hands out of the body
-                handCircleCenter += penetrationDistance * glm::normalize(d);
+                handCircleCenter += penetrationDistance * glm::normalize(circleToCircle);
             }
 
             glm::vec3 handPosition(handCircleCenter.x, params.rightPosition.y, handCircleCenter.y);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -67,6 +67,7 @@ public:
     struct HandParameters {
         bool isLeftEnabled;
         bool isRightEnabled;
+        float bodyCapsuleRadius;
         glm::vec3 leftPosition = glm::vec3();     // rig space
         glm::quat leftOrientation = glm::quat();  // rig space (z forward)
         glm::vec3 rightPosition = glm::vec3();    // rig space

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -78,6 +78,8 @@ public:
 
     glm::vec3 getLinearVelocity() const;
 
+    float getCapsuleRadius() const { return _radius; }
+
     enum class State {
         Ground = 0,
         Takeoff,


### PR DESCRIPTION
* Use a 2d circle/circle intersection test to keep the wrists outside of the body, but only when hand controllers are enabled.
* Open up the shoulder constraints to improve arm swinging during walk cycle.

There will be a separate PR, later, for the IK system to prevent the elbows from entering the torso.