### PR TITLE
Revert step size change in edit.js

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -1201,9 +1201,9 @@
         <div class="property">
             <div class="label">Dimensions</div>
             <div class="value">
-                <div class="input-area">X <input class="coord" type='number' id="property-dim-x"><div class="prop-x"></div></div>
-                <div class="input-area">Y <input class="coord" type='number' id="property-dim-y" ><div class="prop-y"></div></div>
-                <div class="input-area">Z <input class="coord" type='number' id="property-dim-z" ><div class="prop-z"></div></div>
+                <div class="input-area">X <input class="coord" type='number' id="property-dim-x" step="0.1"><div class="prop-x"></div></div>
+                <div class="input-area">Y <input class="coord" type='number' id="property-dim-y" step="0.1"><div class="prop-y"></div></div>
+                <div class="input-area">Z <input class="coord" type='number' id="property-dim-z" step="0.1"><div class="prop-z"></div></div>
                 <div>
                     <input type="button" id="reset-to-natural-dimensions" value="Reset to Natural Dimensions">
                 </div>
@@ -1253,9 +1253,9 @@
         <div class="property">
             <div class="label">Rotation</div>
             <div class="value">
-                <div class="input-area">Pitch <input class="coord" type='number' id="property-rot-x" ></div>
-                <div class="input-area">Yaw <input class="coord" type='number' id="property-rot-y" ></div>
-                <div class="input-area">Roll <input class="coord" type='number' id="property-rot-z"></div>
+                <div class="input-area">Pitch <input class="coord" type='number' id="property-rot-x" step="0.1"></div>
+                <div class="input-area">Yaw <input class="coord" type='number' id="property-rot-y" step="0.1"></div>
+                <div class="input-area">Roll <input class="coord" type='number' id="property-rot-z"step="0.1"></div>
             </div>
         </div>
 

--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -1165,9 +1165,9 @@
         <div class="property">
             <div class="label">Position</div>
             <div class="value">
-                <div class="input-area ">X<input class="coord" type='number' id="property-pos-x" step="0.1"><div class="prop-x"></div></div>
-                <div class="input-area ">Y<input class="coord" type='number' id="property-pos-y" step="0.1"><div class="prop-y"></div></div>
-                <div class="input-area ">Z<input class="coord" type='number' id="property-pos-z" step="0.1"><div class="prop-z"></div></div>
+                <div class="input-area ">X<input class="coord" type='number' id="property-pos-x"><div class="prop-x"></div></div>
+                <div class="input-area ">Y<input class="coord" type='number' id="property-pos-y"><div class="prop-y"></div></div>
+                <div class="input-area ">Z<input class="coord" type='number' id="property-pos-z" ><div class="prop-z"></div></div>
                 <div>
                     <input type="button" id="move-selection-to-grid" value="Selection to Grid">
                     <input type="button" id="move-all-to-grid" value="All to Grid">
@@ -1201,9 +1201,9 @@
         <div class="property">
             <div class="label">Dimensions</div>
             <div class="value">
-                <div class="input-area">X <input class="coord" type='number' id="property-dim-x" step="0.1"><div class="prop-x"></div></div>
-                <div class="input-area">Y <input class="coord" type='number' id="property-dim-y" step="0.1"><div class="prop-y"></div></div>
-                <div class="input-area">Z <input class="coord" type='number' id="property-dim-z" step="0.1"><div class="prop-z"></div></div>
+                <div class="input-area">X <input class="coord" type='number' id="property-dim-x"><div class="prop-x"></div></div>
+                <div class="input-area">Y <input class="coord" type='number' id="property-dim-y" ><div class="prop-y"></div></div>
+                <div class="input-area">Z <input class="coord" type='number' id="property-dim-z" ><div class="prop-z"></div></div>
                 <div>
                     <input type="button" id="reset-to-natural-dimensions" value="Reset to Natural Dimensions">
                 </div>
@@ -1253,9 +1253,9 @@
         <div class="property">
             <div class="label">Rotation</div>
             <div class="value">
-                <div class="input-area">Pitch <input class="coord" type='number' id="property-rot-x" step="0.1"></div>
-                <div class="input-area">Yaw <input class="coord" type='number' id="property-rot-y" step="0.1"></div>
-                <div class="input-area">Roll <input class="coord" type='number' id="property-rot-z"step="0.1"></div>
+                <div class="input-area">Pitch <input class="coord" type='number' id="property-rot-x" ></div>
+                <div class="input-area">Yaw <input class="coord" type='number' id="property-rot-y" ></div>
+                <div class="input-area">Roll <input class="coord" type='number' id="property-rot-z"></div>
             </div>
         </div>
 


### PR DESCRIPTION
This PR reverts a change to the step size for the position input.  Due to floating point drift, a floating point step size (0.1) causes problems at locations more distant from the origin (> 2048).  This would break using the arrow keys to adjust the position.  Now the step size for position is 1 and the arrow keys can be used at large distances.

To test:  

1. Load this script http://rawgit.com/imgntn/hifi/edit-precision-things/examples/edit.js
2. Go to /10000,10000,10000
3. Make a box
4. Use the arrow keys to adjust its position in the entity properties window
5. Observe that you can move the box with your arrow keys in the position inputs