### PR TITLE
Update renderGrid to use a shader, and fix grid edit tools

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -38,6 +38,10 @@ var lightOverlayManager = new LightOverlayManager();
 var cameraManager = new CameraManager();
 
 var grid = Grid();
+gridTool = GridTool({
+    horizontalGrid: grid
+});
+gridTool.setVisible(false);
 
 var entityListTool = EntityListTool();
 
@@ -341,7 +345,7 @@ var toolBar = (function() {
                 isActive = active;
                 if (!isActive) {
                     entityListTool.setVisible(false);
-                    // gridTool.setVisible(false);
+                    gridTool.setVisible(false);
                     grid.setEnabled(false);
                     propertiesTool.setVisible(false);
                     selectionManager.clearSelections();
@@ -349,7 +353,7 @@ var toolBar = (function() {
                 } else {
                     hasShownPropertiesTool = false;
                     entityListTool.setVisible(true);
-                    // gridTool.setVisible(true);
+                    gridTool.setVisible(true);
                     grid.setEnabled(true);
                     propertiesTool.setVisible(true);
                     Window.setFocus();

--- a/examples/html/gridControls.html
+++ b/examples/html/gridControls.html
@@ -146,7 +146,7 @@
         <div class="property-section">
             <label>Major Grid Every</label>
             <span>
-                <input type='number' id="major-spacing" min="2" step="1", ></input>
+                <input type='number' id="major-spacing" min="1" step="1", ></input>
             </span>
         </div>
 

--- a/examples/html/gridControls.html
+++ b/examples/html/gridControls.html
@@ -139,7 +139,7 @@
         <div class="property-section">
             <label>Minor Grid Size</label>
             <span>
-                <input type='number' id="minor-spacing" min="0.2" step="0.2", ></input>
+                <input type='number' id="minor-spacing" min="0.2" step="0.2"></input>
             </span>
         </div>
 

--- a/examples/html/gridControls.html
+++ b/examples/html/gridControls.html
@@ -132,7 +132,7 @@
         <div id="horizontal-position" class="property-section">
             <label>Position (Y Axis)</label>
             <span>
-                <input type='number' id="horiz-y" class="number" value="-1.0" step="0.1"></input>
+                <input type='number' id="horiz-y" class="number" step="0.1"></input>
             </span>
         </div>
 

--- a/examples/html/gridControls.html
+++ b/examples/html/gridControls.html
@@ -33,8 +33,8 @@
                             elPosY.value = origin.y.toFixed(2);
                         }
     
-                        if (data.minorGridWidth !== undefined) {
-                            elMinorSpacing.value = data.minorGridWidth;
+                        if (data.minorGridEvery !== undefined) {
+                            elMinorSpacing.value = data.minorGridEvery;
                         }
     
                         if (data.majorGridEvery !== undefined) {
@@ -60,7 +60,7 @@
                             origin: {
                                 y: elPosY.value,
                             },
-                            minorGridWidth: elMinorSpacing.value,
+                            minorGridEvery: elMinorSpacing.value,
                             majorGridEvery: elMajorSpacing.value,
                             gridColor: gridColor,
                             colorIndex: gridColorIndex,
@@ -132,14 +132,14 @@
         <div id="horizontal-position" class="property-section">
             <label>Position (Y Axis)</label>
             <span>
-                <input type='number' id="horiz-y" class="number" value="0.0" step="0.1"></input>
+                <input type='number' id="horiz-y" class="number" value="-1.0" step="0.1"></input>
             </span>
         </div>
 
         <div class="property-section">
             <label>Minor Grid Size</label>
             <span>
-                <input type='number' id="minor-spacing" min="0" step="0.01", ></input>
+                <input type='number' id="minor-spacing" min="0.2" step="0.2", ></input>
             </span>
         </div>
 

--- a/examples/libraries/gridTool.js
+++ b/examples/libraries/gridTool.js
@@ -25,7 +25,7 @@ Grid = function(opts) {
     var gridOverlay = Overlays.addOverlay("grid", {
         dimensions: { x: scale, y: scale, z: scale },
         visible: false,
-        drawInFront: true,
+        drawInFront: false,
         color: colors[0],
         alpha: gridAlpha,
         rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
@@ -132,9 +132,7 @@ Grid = function(opts) {
 
 
     that.setPosition = function(newPosition, noUpdate) {
-        origin = newPosition;
-        origin.x = 0;
-        origin.z = 0;
+        origin = { x: 0, y: newPosition.y, z: 0 };
         updateGrid();
 
         if (!noUpdate) {

--- a/examples/libraries/gridTool.js
+++ b/examples/libraries/gridTool.js
@@ -12,7 +12,7 @@ Grid = function(opts) {
     ];
     var colorIndex = 0;
     var gridAlpha = 0.6;
-    var origin = { x: 0, y: 0, z: 0 };
+    var origin = { x: 0, y: +MyAvatar.getJointPosition('LeftToeBase').y.toFixed(1) + 0.1, z: 0 };
     var scale = 500;
     var minorGridEvery = 1.0;
     var majorGridEvery = 5;
@@ -23,12 +23,13 @@ Grid = function(opts) {
     var snapToGrid = false;
 
     var gridOverlay = Overlays.addOverlay("grid", {
+        rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         dimensions: { x: scale, y: scale, z: scale },
+        position: origin,
         visible: false,
         drawInFront: false,
         color: colors[0],
         alpha: gridAlpha,
-        rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         minorGridEvery: minorGridEvery,
         majorGridEvery: majorGridEvery,
     });

--- a/examples/libraries/gridTool.js
+++ b/examples/libraries/gridTool.js
@@ -13,23 +13,24 @@ Grid = function(opts) {
     var colorIndex = 0;
     var gridAlpha = 0.6;
     var origin = { x: 0, y: 0, z: 0 };
+    var scale = 500;
+    var minorGridEvery = 1.0;
     var majorGridEvery = 5;
-    var minorGridWidth = 0.2;
     var halfSize = 40;
-    var yOffset = 0.001;
 
     var worldSize = 16384;
 
     var snapToGrid = false;
 
     var gridOverlay = Overlays.addOverlay("grid", {
-        position: { x: 0 , y: 0, z: 0 },
-        visible: true,
+        dimensions: { x: scale, y: scale, z: scale },
+        visible: false,
+        drawInFront: true,
         color: colors[0],
         alpha: gridAlpha,
         rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
-        minorGridWidth: 0.1,
-        majorGridEvery: 2,
+        minorGridEvery: minorGridEvery,
+        majorGridEvery: majorGridEvery,
     });
 
     that.visible = false;
@@ -39,17 +40,13 @@ Grid = function(opts) {
         return origin;
     }
 
-    that.getMinorIncrement = function() { return minorGridWidth; };
-    that.getMajorIncrement = function() { return minorGridWidth * majorGridEvery; };
-
-    that.getMinorGridWidth = function() { return minorGridWidth; };
-    that.setMinorGridWidth = function(value) {
-        minorGridWidth = value;
+    that.getMinorIncrement = function() { return minorGridEvery; };
+    that.setMinorIncrement = function(value) {
+        minorGridEvery = value;
         updateGrid();
-    };
-
-    that.getMajorGridEvery = function() { return majorGridEvery; };
-    that.setMajorGridEvery = function(value) {
+    }
+    that.getMajorIncrement = function() { return majorGridEvery; };
+    that.setMajorIncrement = function(value) {
         majorGridEvery = value;
         updateGrid();
     };
@@ -106,7 +103,7 @@ Grid = function(opts) {
             dimensions = { x: 0, y: 0, z: 0 };
         }
 
-        var spacing = majorOnly ? (minorGridWidth * majorGridEvery) : minorGridWidth;
+        var spacing = majorOnly ? majorGridEvery : minorGridEvery;
 
         position = Vec3.subtract(position, origin);
 
@@ -122,7 +119,7 @@ Grid = function(opts) {
             return delta;
         }
 
-        var spacing = majorOnly ? (minorGridWidth * majorGridEvery) : minorGridWidth;
+        var spacing = majorOnly ? majorGridEvery : minorGridEvery;
 
         var snappedDelta = {
             x: Math.round(delta.x / spacing) * spacing,
@@ -135,7 +132,7 @@ Grid = function(opts) {
 
 
     that.setPosition = function(newPosition, noUpdate) {
-        origin = Vec3.subtract(newPosition, { x: 0, y: yOffset, z: 0 });
+        origin = newPosition;
         origin.x = 0;
         origin.z = 0;
         updateGrid();
@@ -149,7 +146,7 @@ Grid = function(opts) {
         if (that.onUpdate) {
             that.onUpdate({
                 origin: origin,
-                minorGridWidth: minorGridWidth,
+                minorGridEvery: minorGridEvery,
                 majorGridEvery: majorGridEvery,
                 gridSize: halfSize,
                 visible: that.visible,
@@ -171,8 +168,8 @@ Grid = function(opts) {
             that.setPosition(pos, true);
         }
 
-        if (data.minorGridWidth) {
-            minorGridWidth = data.minorGridWidth;
+        if (data.minorGridEvery) {
+            minorGridEvery = data.minorGridEvery;
         }
 
         if (data.majorGridEvery) {
@@ -196,9 +193,9 @@ Grid = function(opts) {
 
     function updateGrid() {
         Overlays.editOverlay(gridOverlay, {
-            position: { x: origin.y, y: origin.y, z: -origin.y },
+            position: { x: 0, y: origin.y, z: 0 },
             visible: that.visible && that.enabled,
-            minorGridWidth: minorGridWidth,
+            minorGridEvery: minorGridEvery,
             majorGridEvery: majorGridEvery,
             color: colors[colorIndex],
             alpha: gridAlpha,

--- a/examples/libraries/gridTool.js
+++ b/examples/libraries/gridTool.js
@@ -187,10 +187,10 @@ Grid = function(opts) {
             that.setVisible(data.visible, true);
         }
 
-        updateGrid();
+        updateGrid(true);
     }
 
-    function updateGrid() {
+    function updateGrid(noUpdate) {
         Overlays.editOverlay(gridOverlay, {
             position: { x: 0, y: origin.y, z: 0 },
             visible: that.visible && that.enabled,
@@ -200,7 +200,9 @@ Grid = function(opts) {
             alpha: gridAlpha,
         });
 
-        that.emitUpdate();
+        if (!noUpdate) {
+            that.emitUpdate();
+        }
     }
 
     function cleanup() {
@@ -243,7 +245,7 @@ GridTool = function(opts) {
         } else if (data.type == "update") {
             horizontalGrid.update(data);
             for (var i = 0; i < listeners.length; i++) {
-                listeners[i](data);
+                listeners[i] && listeners[i](data);
             }
         } else if (data.type == "action") {
             var action = data.action;

--- a/interface/src/audio/AudioScope.cpp
+++ b/interface/src/audio/AudioScope.cpp
@@ -117,8 +117,8 @@ void AudioScope::render(RenderArgs* renderArgs, int width, int height) {
     static const glm::vec4 inputColor = { 0.3f, 1.0f, 0.3f, 1.0f };
     static const glm::vec4 outputLeftColor = { 1.0f, 0.3f, 0.3f, 1.0f };
     static const glm::vec4 outputRightColor = { 0.3f, 0.3f, 1.0f, 1.0f };
-    static const int gridRows = 2;
-    int gridCols = _framesPerScope;
+    static const int gridCols = 2;
+    int gridRows = _framesPerScope;
     
     int x = (width - (int)SCOPE_WIDTH) / 2;
     int y = (height - (int)SCOPE_HEIGHT) / 2;
@@ -128,8 +128,10 @@ void AudioScope::render(RenderArgs* renderArgs, int width, int height) {
     gpu::Batch& batch = *renderArgs->_batch;
     auto geometryCache = DependencyManager::get<GeometryCache>();
 
-    // Grid uses its own pipeline
-    geometryCache->renderGrid(batch, x, y, w, h, gridRows, gridCols, gridColor, 0.005f, _audioScopeGrid);
+    // Grid uses its own pipeline, so draw it before setting another
+    const float GRID_EDGE = 0.005f;
+    geometryCache->renderGrid(batch, glm::vec2(x, y), glm::vec2(x + w, y + h),
+        gridRows, gridCols, GRID_EDGE, gridColor, _audioScopeGrid);
 
     geometryCache->useSimpleDrawPipeline(batch);
     auto textureCache = DependencyManager::get<TextureCache>();

--- a/interface/src/audio/AudioScope.cpp
+++ b/interface/src/audio/AudioScope.cpp
@@ -127,6 +127,10 @@ void AudioScope::render(RenderArgs* renderArgs, int width, int height) {
 
     gpu::Batch& batch = *renderArgs->_batch;
     auto geometryCache = DependencyManager::get<GeometryCache>();
+
+    // Grid uses its own pipeline
+    geometryCache->renderGrid(batch, x, y, w, h, gridRows, gridCols, gridColor, 0.005f, _audioScopeGrid);
+
     geometryCache->useSimpleDrawPipeline(batch);
     auto textureCache = DependencyManager::get<TextureCache>();
     batch.setResourceTexture(0, textureCache->getWhiteTexture());
@@ -139,7 +143,6 @@ void AudioScope::render(RenderArgs* renderArgs, int width, int height) {
     batch.setViewTransform(Transform());
 
     geometryCache->renderQuad(batch, x, y, w, h, backgroundColor, _audioScopeBackground);
-    geometryCache->renderGrid(batch, x, y, w, h, gridRows, gridCols, gridColor, _audioScopeGrid);
     renderLineStrip(batch, _inputID, inputColor, x, y, _samplesPerScope, _scopeInputOffset, _scopeInput);
     renderLineStrip(batch, _outputLeftID, outputLeftColor, x, y, _samplesPerScope, _scopeOutputOffset, _scopeOutputLeft);
     renderLineStrip(batch, _outputRightD, outputRightColor, x, y, _samplesPerScope, _scopeOutputOffset, _scopeOutputRight);

--- a/interface/src/audio/AudioScope.cpp
+++ b/interface/src/audio/AudioScope.cpp
@@ -131,7 +131,7 @@ void AudioScope::render(RenderArgs* renderArgs, int width, int height) {
     // Grid uses its own pipeline, so draw it before setting another
     const float GRID_EDGE = 0.005f;
     geometryCache->renderGrid(batch, glm::vec2(x, y), glm::vec2(x + w, y + h),
-        gridRows, gridCols, GRID_EDGE, gridColor, _audioScopeGrid);
+        gridRows, gridCols, GRID_EDGE, gridColor, true, _audioScopeGrid);
 
     geometryCache->useSimpleDrawPipeline(batch);
     auto textureCache = DependencyManager::get<TextureCache>();

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -76,7 +76,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
         DependencyManager::get<GeometryCache>()->renderGrid(*batch, minCorner, maxCorner,
             _minorGridRowDivisions, _minorGridColDivisions, MINOR_GRID_EDGE,
             _majorGridRowDivisions, _majorGridColDivisions, MAJOR_GRID_EDGE,
-            gridColor);
+            gridColor, _drawInFront);
     }
 }
 

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -81,7 +81,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Grid3DOverlay::getShapeKey() {
-    return render::ShapeKey::Builder().withTranslucent();
+    return render::ShapeKey::Builder().withOwnPipeline();
 }
 
 void Grid3DOverlay::setProperties(const QScriptValue& properties) {

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -75,10 +75,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
             auto cameraPosition =
                 (float)_majorGridEvery * glm::round(args->_viewFrustum->getPosition() / (float)_majorGridEvery);
 
-            // Get the plane of the avatar's feet (or collision ground)
-            auto avatarBaseHeight = avatar->getPosition().y - avatar->getUniformScale();
-
-            position += glm::vec3(cameraPosition.x, avatarBaseHeight, cameraPosition.z);
+            position += glm::vec3(cameraPosition.x, 0.0f, cameraPosition.z);
         }
 
         Transform transform;

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -133,7 +133,7 @@ Grid3DOverlay* Grid3DOverlay::createClone() const {
 }
 
 void Grid3DOverlay::updateGrid() {
-    const int MAJOR_GRID_EVERY_MIN = 5;
+    const int MAJOR_GRID_EVERY_MIN = 1;
     const float MINOR_GRID_EVERY_MIN = 0.2f;
 
     _majorGridEvery = std::max(_majorGridEvery, MAJOR_GRID_EVERY_MIN);

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -129,7 +129,7 @@ Grid3DOverlay* Grid3DOverlay::createClone() const {
 
 void Grid3DOverlay::updateGrid() {
     const int MAJOR_GRID_EVERY_MIN = 1;
-    const float MINOR_GRID_EVERY_MIN = 0.2f;
+    const float MINOR_GRID_EVERY_MIN = 0.01f;
 
     _majorGridEvery = std::max(_majorGridEvery, MAJOR_GRID_EVERY_MIN);
     _minorGridEvery = std::max(_minorGridEvery, MINOR_GRID_EVERY_MIN);

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -13,6 +13,9 @@
 
 #include <QScriptValue>
 
+#include <avatar/AvatarManager.h>
+#include <avatar/MyAvatar.h>
+
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <PathUtils.h>
@@ -20,17 +23,19 @@
 
 
 QString const Grid3DOverlay::TYPE = "grid";
+const float DEFAULT_SCALE = 100.0f;
 
-Grid3DOverlay::Grid3DOverlay() :
-    _minorGridWidth(1.0),
-    _majorGridEvery(5) {
+Grid3DOverlay::Grid3DOverlay() {
+    setDimensions(DEFAULT_SCALE);
+    updateGrid();
 }
 
 Grid3DOverlay::Grid3DOverlay(const Grid3DOverlay* grid3DOverlay) :
     Planar3DOverlay(grid3DOverlay),
-    _minorGridWidth(grid3DOverlay->_minorGridWidth),
-    _majorGridEvery(grid3DOverlay->_majorGridEvery)
+    _majorGridEvery(grid3DOverlay->_majorGridEvery),
+    _minorGridEvery(grid3DOverlay->_minorGridEvery)
 {
+    updateGrid();
 }
 
 void Grid3DOverlay::render(RenderArgs* args) {
@@ -38,14 +43,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
         return; // do nothing if we're not visible
     }
 
-    const int MINOR_GRID_DIVISIONS = 200;
-    const int MAJOR_GRID_DIVISIONS = 100;
     const float MAX_COLOR = 255.0f;
-
-    // center the grid around the camera position on the plane
-    glm::vec3 rotated = glm::inverse(getRotation()) * args->_viewFrustum->getPosition();
-
-    float spacing = _minorGridWidth;
 
     float alpha = getAlpha();
     xColor color = getColor();
@@ -54,71 +52,67 @@ void Grid3DOverlay::render(RenderArgs* args) {
     auto batch = args->_batch;
 
     if (batch) {
+        auto minCorner = glm::vec2(-0.5f, -0.5f);
+        auto maxCorner = glm::vec2(0.5f, 0.5f);
+
+        auto position = getPosition();
+        if (_followCamera) {
+            auto avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+
+            // Add the camera position at the plane of the avatar's base (the floor)
+            auto cameraPosition = args->_viewFrustum->getPosition();
+            auto avatarBaseHeight = avatar->getPosition().y - avatar->getUniformScale();
+            position += glm::vec3(cameraPosition.x, avatarBaseHeight, cameraPosition.z);
+        }
+
         Transform transform;
         transform.setRotation(getRotation());
-
+        transform.setScale(glm::vec3(getDimensions(), 1.0f));
+        transform.setTranslation(position);
+        batch->setModelTransform(transform);
 
         // Minor grid
-        {
-            auto position = glm::vec3(_minorGridWidth * (floorf(rotated.x / spacing) - MINOR_GRID_DIVISIONS / 2),
-                                      spacing * (floorf(rotated.y / spacing) - MINOR_GRID_DIVISIONS / 2),
-                                      getPosition().z);
-            float scale = MINOR_GRID_DIVISIONS * spacing;
-
-            transform.setTranslation(position);
-            transform.setScale(scale);
-
-            batch->setModelTransform(transform);
-
-            DependencyManager::get<GeometryCache>()->renderGrid(*batch, MINOR_GRID_DIVISIONS, MINOR_GRID_DIVISIONS, gridColor);
-        }
+        const float MINOR_GRID_EDGE = 0.0025f;
+        DependencyManager::get<GeometryCache>()->renderGrid(*batch,
+            minCorner, maxCorner, _minorGridRowDivisions, _minorGridColDivisions, gridColor, MINOR_GRID_EDGE);
 
         // Major grid
-        {
-            spacing *= _majorGridEvery;
-            auto position = glm::vec3(spacing * (floorf(rotated.x / spacing) - MAJOR_GRID_DIVISIONS / 2),
-                                      spacing * (floorf(rotated.y / spacing) - MAJOR_GRID_DIVISIONS / 2),
-                                      getPosition().z);
-            float scale = MAJOR_GRID_DIVISIONS * spacing;
-
-            transform.setTranslation(position);
-            transform.setScale(scale);
-
-            // FIXME: THe line width of 4.0f is not supported anymore, we ll need a workaround
-
-            batch->setModelTransform(transform);
-
-            DependencyManager::get<GeometryCache>()->renderGrid(*batch, MAJOR_GRID_DIVISIONS, MAJOR_GRID_DIVISIONS, gridColor);
-        }
+        const float MAJOR_GRID_EDGE = 0.01f;
+        DependencyManager::get<GeometryCache>()->renderGrid(*batch,
+            minCorner, maxCorner, _majorGridRowDivisions, _majorGridColDivisions, gridColor, MAJOR_GRID_EDGE);
     }
 }
 
 const render::ShapeKey Grid3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder();
-    if (getAlpha() != 1.0f) {
-        builder.withTranslucent();
-    }
-    return builder.build();
+    return render::ShapeKey::Builder().withTranslucent();
 }
 
 void Grid3DOverlay::setProperties(const QScriptValue& properties) {
     Planar3DOverlay::setProperties(properties);
-
-    if (properties.property("minorGridWidth").isValid()) {
-        _minorGridWidth = properties.property("minorGridWidth").toVariant().toFloat();
+    if (properties.property("followCamera").isValid()) {
+        _followCamera = properties.property("followCamera").toVariant().toBool();
     }
 
     if (properties.property("majorGridEvery").isValid()) {
         _majorGridEvery = properties.property("majorGridEvery").toVariant().toInt();
     }
+
+    if (properties.property("minorGridEvery").isValid()) {
+        _minorGridEvery = properties.property("minorGridEvery").toVariant().toFloat();
+    }
+
+    updateGrid();
 }
 
 QScriptValue Grid3DOverlay::getProperty(const QString& property) {
-    if (property == "minorGridWidth") {
-        return _minorGridWidth;
+    if (property == "followCamera") {
+        return _followCamera;
     }
     if (property == "majorGridEvery") {
         return _majorGridEvery;
+    }
+    if (property == "minorGridEvery") {
+        return _minorGridEvery;
     }
 
     return Planar3DOverlay::getProperty(property);
@@ -128,3 +122,16 @@ Grid3DOverlay* Grid3DOverlay::createClone() const {
     return new Grid3DOverlay(this);
 }
 
+void Grid3DOverlay::updateGrid() {
+    const int MAJOR_GRID_EVERY_MIN = 5;
+    const float MINOR_GRID_EVERY_MIN = 0.2f;
+
+    _majorGridEvery = std::max(_majorGridEvery, MAJOR_GRID_EVERY_MIN);
+    _minorGridEvery = std::max(_minorGridEvery, MINOR_GRID_EVERY_MIN);
+
+    _majorGridRowDivisions = getDimensions().x / _majorGridEvery;
+    _majorGridColDivisions = getDimensions().y / _majorGridEvery;
+
+    _minorGridRowDivisions = getDimensions().x / _minorGridEvery;
+    _minorGridColDivisions = getDimensions().y / _minorGridEvery;
+}

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -13,6 +13,8 @@
 
 #include <QScriptValue>
 
+#include <OctreeConstants.h>
+
 #include <avatar/AvatarManager.h>
 #include <avatar/MyAvatar.h>
 
@@ -36,6 +38,15 @@ Grid3DOverlay::Grid3DOverlay(const Grid3DOverlay* grid3DOverlay) :
     _minorGridEvery(grid3DOverlay->_minorGridEvery)
 {
     updateGrid();
+}
+
+AABox Grid3DOverlay::getBounds() const {
+    if (_followCamera) {
+        // This is a UI element that should always be in view, lie to the octree to avoid culling
+        const AABox DOMAIN_BOX = AABox(glm::vec3(-TREE_SCALE / 2), TREE_SCALE);
+        return DOMAIN_BOX;
+    }
+    return Planar3DOverlay::getBounds();
 }
 
 void Grid3DOverlay::render(RenderArgs* args) {

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -59,9 +59,14 @@ void Grid3DOverlay::render(RenderArgs* args) {
         if (_followCamera) {
             auto avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
 
-            // Add the camera position at the plane of the avatar's base (the floor)
-            auto cameraPosition = args->_viewFrustum->getPosition();
+            // Get the camera position rounded to the nearest major grid line
+            // This grid is for UI and should lie on worldlines
+            auto cameraPosition =
+                (float)_majorGridEvery * glm::round(args->_viewFrustum->getPosition() / (float)_majorGridEvery);
+
+            // Get the plane of the avatar's feet (or collision ground)
             auto avatarBaseHeight = avatar->getPosition().y - avatar->getUniformScale();
+
             position += glm::vec3(cameraPosition.x, avatarBaseHeight, cameraPosition.z);
         }
 

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -15,9 +15,6 @@
 
 #include <OctreeConstants.h>
 
-#include <avatar/AvatarManager.h>
-#include <avatar/MyAvatar.h>
-
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <PathUtils.h>
@@ -68,8 +65,6 @@ void Grid3DOverlay::render(RenderArgs* args) {
 
         auto position = getPosition();
         if (_followCamera) {
-            auto avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-
             // Get the camera position rounded to the nearest major grid line
             // This grid is for UI and should lie on worldlines
             auto cameraPosition =

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -71,15 +71,12 @@ void Grid3DOverlay::render(RenderArgs* args) {
         transform.setTranslation(position);
         batch->setModelTransform(transform);
 
-        // Minor grid
         const float MINOR_GRID_EDGE = 0.0025f;
-        DependencyManager::get<GeometryCache>()->renderGrid(*batch,
-            minCorner, maxCorner, _minorGridRowDivisions, _minorGridColDivisions, gridColor, MINOR_GRID_EDGE);
-
-        // Major grid
-        const float MAJOR_GRID_EDGE = 0.01f;
-        DependencyManager::get<GeometryCache>()->renderGrid(*batch,
-            minCorner, maxCorner, _majorGridRowDivisions, _majorGridColDivisions, gridColor, MAJOR_GRID_EDGE);
+        const float MAJOR_GRID_EDGE = 0.005f;
+        DependencyManager::get<GeometryCache>()->renderGrid(*batch, minCorner, maxCorner,
+            _minorGridRowDivisions, _minorGridColDivisions, MINOR_GRID_EDGE,
+            _majorGridRowDivisions, _majorGridColDivisions, MAJOR_GRID_EDGE,
+            gridColor);
     }
 }
 

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -32,8 +32,17 @@ public:
     virtual Grid3DOverlay* createClone() const;
 
 private:
-    float _minorGridWidth;
-    int _majorGridEvery;
+    void updateGrid();
+
+    bool _followCamera { true };
+
+    int _majorGridEvery { 5 };
+    float _majorGridRowDivisions;
+    float _majorGridColDivisions;
+
+    float _minorGridEvery { 1.0f };
+    float _minorGridRowDivisions;
+    float _minorGridColDivisions;
 };
 
 #endif // hifi_Grid3DOverlay_h

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -24,6 +24,8 @@ public:
     Grid3DOverlay();
     Grid3DOverlay(const Grid3DOverlay* grid3DOverlay);
 
+    virtual AABox getBounds() const;
+
     virtual void render(RenderArgs* args);
     virtual const render::ShapeKey getShapeKey() override;
     virtual void setProperties(const QScriptValue& properties);

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -31,6 +31,9 @@ public:
 
     virtual Grid3DOverlay* createClone() const;
 
+    // Grids are UI tools, and may not be intersected (pickable)
+    virtual bool findRayIntersection(const glm::vec3&, const glm::vec3&, float&, BoxFace&, glm::vec3&) { return false; }
+
 private:
     void updateGrid();
 

--- a/interface/src/ui/overlays/Planar3DOverlay.h
+++ b/interface/src/ui/overlays/Planar3DOverlay.h
@@ -20,7 +20,7 @@ public:
     Planar3DOverlay();
     Planar3DOverlay(const Planar3DOverlay* planar3DOverlay);
     
-    AABox getBounds() const;
+    virtual AABox getBounds() const;
     
     glm::vec2 getDimensions() const { return _dimensions; }
     void setDimensions(float value) { _dimensions = glm::vec2(value); }

--- a/libraries/gpu/src/gpu/Paint.slh
+++ b/libraries/gpu/src/gpu/Paint.slh
@@ -1,0 +1,47 @@
+<!
+//  Paint.slh
+//  libraries/gpu/src
+//
+//  Created by Zach Pomerantz on 2/19/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Fragment shader utility functions. Will fail compilation in vertex shaders.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+!>
+<@if not GPU_PAINT_SLH@>
+<@def GPU_PAINT_SLH@>
+
+float paintStripe(float value, float offset, float scale, float edge) {
+    float width = fwidth(value);
+    float normalizedWidth = width * scale;
+
+    float x0 = (value + offset) * scale - normalizedWidth / 2;
+    float x1 = x0 + normalizedWidth;
+
+    float balance = 1.0 - edge;
+    float i0 = edge * floor(x0) + max(0.0, fract(x0) - balance);
+    float i1 = edge * floor(x1) + max(0.0, fract(x1) - balance);
+    float strip = (i1 - i0) / normalizedWidth;
+
+    return clamp(strip, 0.0, 1.0);
+}
+
+float paintGrid(vec2 value, vec2 offset, vec2 scale, vec2 edge) {
+    return max(
+        paintStripe(value.x, offset.x, scale.x, edge.x),
+        paintStripe(value.y, offset.y, scale.y, edge.y));
+}
+
+float paintGridMajor(vec2 value, vec2 offset, vec2 scale, vec2 edge) {
+    return paintGrid(value, offset, scale, edge);
+}
+
+float paintGridMajorMinor(vec2 value, vec4 offset, vec4 scale, vec4 edge) {
+    return max(
+        paintGrid(value, offset.xy, scale.xy, edge.xy),
+        paintGrid(value, offset.zw, scale.zw, edge.zw));
+}
+
+<@endif@>

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -600,9 +600,9 @@ void GeometryCache::renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, co
         gridBuffer.edit<GridSchema>().offset.y = -(majorEdge / majorCols) / 2;
         gridBuffer.edit<GridSchema>().offset.z = -(minorEdge / minorRows) / 2;
         gridBuffer.edit<GridSchema>().offset.w = -(minorEdge / minorCols) / 2;
-        gridBuffer.edit<GridSchema>().balance = glm::vec4(glm::vec2(1.0f - majorEdge),
+        gridBuffer.edit<GridSchema>().edge = glm::vec4(glm::vec2(majorEdge),
             // If rows or columns are not set, do not draw minor gridlines
-            glm::vec2((minorRows != 0 && minorCols != 0) ? 1.0f - minorEdge : 0.0f));
+            glm::vec2((minorRows != 0 && minorCols != 0) ? minorEdge : 0.0f));
     }
 
     // Set the grid pipeline

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -22,16 +22,18 @@
 #include "TextureCache.h"
 #include "RenderUtilsLogging.h"
 
-#include "standardTransformPNTC_vert.h"
-#include "standardDrawTexture_frag.h"
-
 #include "gpu/StandardShaderLib.h"
 
 #include "model/TextureMap.h"
 
+#include "standardTransformPNTC_vert.h"
+#include "standardDrawTexture_frag.h"
+
 #include "simple_vert.h"
 #include "simple_textured_frag.h"
 #include "simple_textured_emisive_frag.h"
+
+#include "grid_frag.h"
 
 //#define WANT_DEBUG
 
@@ -564,186 +566,42 @@ void GeometryCache::renderWireSphere(gpu::Batch& batch) {
     renderWireShape(batch, Sphere);
 }
 
+void GeometryCache::renderGrid(gpu::Batch& batch,
+                            const glm::vec2& minCorner, const glm::vec2& maxCorner,
+                            int rows, int cols, const glm::vec4& color, float edge, int id) {
+    static const glm::vec2 minTexCoord(0.0f, 1.0f);
+    static const glm::vec2 maxTexCoord(1.0f, 0.0f);
 
-void GeometryCache::renderGrid(gpu::Batch& batch, int xDivisions, int yDivisions, const glm::vec4& color) {
-    IntPair key(xDivisions, yDivisions);
-    Vec3Pair colorKey(glm::vec3(color.x, color.y, yDivisions), glm::vec3(color.z, color.y, xDivisions));
-
-    int vertices = (xDivisions + 1 + yDivisions + 1) * 2;
-    if (!_gridBuffers.contains(key)) {
-        auto verticesBuffer = std::make_shared<gpu::Buffer>();
-
-        float* vertexData = new float[vertices * 2];
-        float* vertex = vertexData;
-
-        for (int i = 0; i <= xDivisions; i++) {
-            float x = (float)i / xDivisions;
-        
-            *(vertex++) = x;
-            *(vertex++) = 0.0f;
-            
-            *(vertex++) = x;
-            *(vertex++) = 1.0f;
-        }
-        for (int i = 0; i <= yDivisions; i++) {
-            float y = (float)i / yDivisions;
-            
-            *(vertex++) = 0.0f;
-            *(vertex++) = y;
-            
-            *(vertex++) = 1.0f;
-            *(vertex++) = y;
-        }
-
-        verticesBuffer->append(sizeof(float) * vertices * 2, (gpu::Byte*) vertexData);
-        delete[] vertexData;
-        
-        _gridBuffers[key] = verticesBuffer;
-    }
-
-    if (!_gridColors.contains(colorKey)) {
-        auto colorBuffer = std::make_shared<gpu::Buffer>();
-        _gridColors[colorKey] = colorBuffer;
-
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-                            ((int(color.y * 255.0f) & 0xFF) << 8) |
-                            ((int(color.z * 255.0f) & 0xFF) << 16) |
-                            ((int(color.w * 255.0f) & 0xFF) << 24);
-
-        int* colorData = new int[vertices];
-        int* colorDataAt = colorData;
-                            
-        for(int v = 0; v < vertices; v++) {
-            *(colorDataAt++) = compactColor;
-        }
-
-        colorBuffer->append(sizeof(int) * vertices, (gpu::Byte*) colorData);
-        delete[] colorData;
-    }
-    gpu::BufferPointer verticesBuffer = _gridBuffers[key];
-    gpu::BufferPointer colorBuffer = _gridColors[colorKey];
-
-    const int VERTICES_SLOT = 0;
-    const int COLOR_SLOT = 1;
-    auto streamFormat = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
-    
-    streamFormat->setAttribute(gpu::Stream::POSITION, VERTICES_SLOT, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ), 0);
-    streamFormat->setAttribute(gpu::Stream::COLOR, COLOR_SLOT, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
-
-    gpu::BufferView verticesView(verticesBuffer, 0, verticesBuffer->getSize(), streamFormat->getAttributes().at(gpu::Stream::POSITION)._element);
-    gpu::BufferView colorView(colorBuffer, streamFormat->getAttributes().at(gpu::Stream::COLOR)._element);
-    
-    batch.setInputFormat(streamFormat);
-    batch.setInputBuffer(VERTICES_SLOT, verticesView);
-    batch.setInputBuffer(COLOR_SLOT, colorView);
-    batch.draw(gpu::LINES, vertices, 0);
-}
-
-// TODO: why do we seem to create extra BatchItemDetails when we resize the window?? what's that??
-void GeometryCache::renderGrid(gpu::Batch& batch, int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id) {
-    #ifdef WANT_DEBUG
-        qCDebug(renderutils) << "GeometryCache::renderGrid(x["<<x<<"], "
-            "y["<<y<<"],"
-            "w["<<width<<"],"
-            "h["<<height<<"],"
-            "rows["<<rows<<"],"
-            "cols["<<cols<<"],"
-            " id:"<<id<<")...";
-    #endif
-            
     bool registered = (id != UNKNOWN_ID);
-    Vec3Pair key(glm::vec3(x, y, width), glm::vec3(height, rows, cols));
-    Vec3Pair colorKey(glm::vec3(color.x, color.y, rows), glm::vec3(color.z, color.y, cols));
+    Vec2FloatPair key(glm::vec2(rows, cols), edge);
 
-    int vertices = (cols + 1 + rows + 1) * 2;
-    if ((registered && (!_registeredAlternateGridBuffers.contains(id) || _lastRegisteredAlternateGridBuffers[id] != key))
-        || (!registered && !_alternateGridBuffers.contains(key))) {
+    // Make the gridbuffer
+    if ((registered && (!_registeredGridBuffers.contains(id) || _lastRegisteredGridBuffer[id] != key)) ||
+        (!registered && !_gridBuffers.contains(key))) {
+        GridSchema gridSchema;
+        GridBuffer gridBuffer = std::make_shared<gpu::Buffer>(sizeof(GridSchema), (const gpu::Byte*) &gridSchema);
 
-        if (registered && _registeredAlternateGridBuffers.contains(id)) {
-            _registeredAlternateGridBuffers[id].reset();
-            #ifdef WANT_DEBUG
-                qCDebug(renderutils) << "renderGrid()... RELEASING REGISTERED VERTICES BUFFER";
-            #endif
+        if (registered && _registeredGridBuffers.contains(id)) {
+            gridBuffer = _registeredGridBuffers[id];
         }
 
-        auto verticesBuffer = std::make_shared<gpu::Buffer>();
         if (registered) {
-            _registeredAlternateGridBuffers[id] = verticesBuffer;
-            _lastRegisteredAlternateGridBuffers[id] = key;
+            _registeredGridBuffers[id] = gridBuffer;
+            _lastRegisteredGridBuffer[id] = key;
         } else {
-            _alternateGridBuffers[key] = verticesBuffer;
+            _gridBuffers[key] = gridBuffer;
         }
 
-        float* vertexData = new float[vertices * 2];
-        float* vertex = vertexData;
-
-        int dx = width / cols;
-        int dy = height / rows;
-        int tx = x;
-        int ty = y;
-
-        // Draw horizontal grid lines
-        for (int i = rows + 1; --i >= 0; ) {
-            *(vertex++) = x;
-            *(vertex++) = ty;
-
-            *(vertex++) = x + width;
-            *(vertex++) = ty;
-
-            ty += dy;
-        }
-        // Draw vertical grid lines
-        for (int i = cols + 1; --i >= 0; ) {
-            *(vertex++) = tx;
-            *(vertex++) = y;
-
-            *(vertex++) = tx;
-            *(vertex++) = y + height;
-            tx += dx;
-        }
-
-        verticesBuffer->append(sizeof(float) * vertices * 2, (gpu::Byte*) vertexData);
-        delete[] vertexData;
+        gridBuffer.edit<GridSchema>().period = glm::vec2(cols, rows);
+        gridBuffer.edit<GridSchema>().offset.x = -(edge / cols) / 2;
+        gridBuffer.edit<GridSchema>().offset.y = -(edge / rows) / 2;
+        gridBuffer.edit<GridSchema>().balance = glm::vec2(1 - edge);
     }
 
-    if (!_gridColors.contains(colorKey)) {
-        auto colorBuffer = std::make_shared<gpu::Buffer>();
-        _gridColors[colorKey] = colorBuffer;
+    // Set the grid pipeline
+    useGridPipeline(batch, registered ? _registeredGridBuffers[id] : _gridBuffers[key]);
 
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-                            ((int(color.y * 255.0f) & 0xFF) << 8) |
-                            ((int(color.z * 255.0f) & 0xFF) << 16) |
-                            ((int(color.w * 255.0f) & 0xFF) << 24);
-
-        int* colorData = new int[vertices];
-        int* colorDataAt = colorData;
-                            
-                            
-        for(int v = 0; v < vertices; v++) {
-            *(colorDataAt++) = compactColor;
-        }
-
-        colorBuffer->append(sizeof(int) * vertices, (gpu::Byte*) colorData);
-        delete[] colorData;
-    }
-    gpu::BufferPointer verticesBuffer = registered ? _registeredAlternateGridBuffers[id] : _alternateGridBuffers[key];
-    
-    gpu::BufferPointer colorBuffer = _gridColors[colorKey];
-
-    const int VERTICES_SLOT = 0;
-    const int COLOR_SLOT = 1;
-    auto streamFormat = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
-    
-    streamFormat->setAttribute(gpu::Stream::POSITION, VERTICES_SLOT, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ), 0);
-    streamFormat->setAttribute(gpu::Stream::COLOR, COLOR_SLOT, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
-
-    gpu::BufferView verticesView(verticesBuffer, 0, verticesBuffer->getSize(), streamFormat->getAttributes().at(gpu::Stream::POSITION)._element);
-    gpu::BufferView colorView(colorBuffer, streamFormat->getAttributes().at(gpu::Stream::COLOR)._element);
-
-    batch.setInputFormat(streamFormat);
-    batch.setInputBuffer(VERTICES_SLOT, verticesView);
-    batch.setInputBuffer(COLOR_SLOT, colorView);
-    batch.draw(gpu::LINES, vertices, 0);
+    renderQuad(batch, minCorner, maxCorner, minTexCoord, maxTexCoord, color, id);
 }
 
 void GeometryCache::updateVertices(int id, const QVector<glm::vec2>& points, const glm::vec4& color) {
@@ -1772,7 +1630,6 @@ void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
 
         auto state = std::make_shared<gpu::State>();
 
-
         // enable decal blend
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
 
@@ -1790,6 +1647,23 @@ void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
     } else {
         batch.setPipeline(_standardDrawPipeline);
     }
+}
+
+void GeometryCache::useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer) {
+    if (!_gridPipeline) {
+        auto vs = gpu::Shader::createVertex(std::string(standardTransformPNTC_vert));
+        auto ps = gpu::Shader::createPixel(std::string(grid_frag));
+        auto program = gpu::Shader::createProgram(vs, ps);
+        gpu::Shader::makeProgram((*program));
+
+        auto state = std::make_shared<gpu::State>();
+        state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
+
+        _gridPipeline = gpu::Pipeline::create(program, state);
+        _gridSlot = program->getBuffers().findLocation("gridBuffer");
+    }
+    batch.setPipeline(_gridPipeline);
+    batch.setUniformBuffer(_gridSlot, gridBuffer);
 }
 
 

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -207,10 +207,10 @@ public:
     void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
         int majorRows, int majorCols, float majorEdge,
         int minorRows, int minorCols, float minorEdge,
-        const glm::vec4& color, int id = UNKNOWN_ID);
+        const glm::vec4& color, bool isLayered, int id = UNKNOWN_ID);
     void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
-        int rows, int cols, float edge, const glm::vec4& color, int id = UNKNOWN_ID) {
-        renderGrid(batch, minCorner, maxCorner, rows, cols, edge, 0, 0, 0.0f, color, id);
+        int rows, int cols, float edge, const glm::vec4& color, bool isLayered, int id = UNKNOWN_ID) {
+        renderGrid(batch, minCorner, maxCorner, rows, cols, edge, 0, 0, 0.0f, color, isLayered, id);
     }
 
     void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id = UNKNOWN_ID);
@@ -325,8 +325,9 @@ private:
         glm::vec4 edge;
     };
     using GridBuffer = gpu::BufferView;
-    void useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer);
+    void useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer, bool isLayered);
     gpu::PipelinePointer _gridPipeline;
+    gpu::PipelinePointer _gridPipelineLayered;
     int _gridSlot;
 
     class BatchItemDetails {

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -32,7 +32,7 @@
 class SimpleProgramKey;
 
 typedef glm::vec3 Vec3Key;
-
+typedef QPair<glm::vec2, float> Vec2FloatPair;
 typedef QPair<glm::vec2, glm::vec2> Vec2Pair;
 typedef QPair<Vec2Pair, Vec2Pair> Vec2PairPair;
 typedef QPair<glm::vec3, glm::vec3> Vec3Pair;
@@ -203,8 +203,10 @@ public:
     void renderWireSphere(gpu::Batch& batch);
     size_t getSphereTriangleCount();
 
-    void renderGrid(gpu::Batch& batch, int xDivisions, int yDivisions, const glm::vec4& color);
-    void renderGrid(gpu::Batch& batch, int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner, int rows, int cols, const glm::vec4& color, float edge = 0.01f, int id = UNKNOWN_ID);
+    void renderGrid(gpu::Batch& batch, int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, float edge = 0.01f, int id = UNKNOWN_ID) {
+        renderGrid(batch, glm::vec2(x, y), glm::vec2(x + width, y + height), rows, cols, color, edge, id);
+    }
 
     void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id = UNKNOWN_ID);
 
@@ -310,6 +312,18 @@ private:
     gpu::BufferPointer _shapeVertices{ std::make_shared<gpu::Buffer>() };
     gpu::BufferPointer _shapeIndices{ std::make_shared<gpu::Buffer>() };
 
+    class GridSchema {
+    public:
+        glm::vec2 period;
+        glm::vec2 offset;
+        glm::vec2 balance;
+        glm::vec2 _;
+    };
+    using GridBuffer = gpu::BufferView;
+    void useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer);
+    gpu::PipelinePointer _gridPipeline;
+    int _gridSlot;
+
     class BatchItemDetails {
     public:
         static int population;
@@ -366,11 +380,9 @@ private:
     QHash<Vec3PairVec2Pair, BatchItemDetails> _dashedLines;
     QHash<int, BatchItemDetails> _registeredDashedLines;
 
-    QHash<IntPair, gpu::BufferPointer> _gridBuffers;
-    QHash<Vec3Pair, gpu::BufferPointer> _alternateGridBuffers;
-    QHash<int, gpu::BufferPointer> _registeredAlternateGridBuffers;
-    QHash<int, Vec3Pair> _lastRegisteredAlternateGridBuffers;
-    QHash<Vec3Pair, gpu::BufferPointer> _gridColors;
+    QHash<int, Vec2FloatPair> _lastRegisteredGridBuffer;
+    QHash<Vec2FloatPair, GridBuffer> _gridBuffers;
+    QHash<int, GridBuffer> _registeredGridBuffers;
 
     QHash<QUrl, QWeakPointer<NetworkGeometry> > _networkGeometry;
     

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -322,7 +322,7 @@ private:
         // data is arranged as majorRow, majorCol, minorRow, minorCol
         glm::vec4 period;
         glm::vec4 offset;
-        glm::vec4 balance;
+        glm::vec4 edge;
     };
     using GridBuffer = gpu::BufferView;
     void useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -31,7 +31,6 @@
 
 class SimpleProgramKey;
 
-typedef glm::vec3 Vec3Key;
 typedef QPair<glm::vec2, float> Vec2FloatPair;
 typedef QPair<glm::vec2, glm::vec2> Vec2Pair;
 typedef QPair<Vec2Pair, Vec2Pair> Vec2PairPair;
@@ -46,6 +45,11 @@ typedef QPair<Vec4Pair, Vec4Pair> Vec4PairVec4Pair;
 inline uint qHash(const glm::vec2& v, uint seed) {
     // multiply by prime numbers greater than the possible size
     return qHash(v.x + 5009 * v.y, seed);
+}
+
+inline uint qHash(const Vec2FloatPair& v, uint seed) {
+    // multiply by prime numbers greater than the possible size
+    return qHash(v.first.x + 5009 * v.first.y + 5011 * v.second);
 }
 
 inline uint qHash(const Vec2Pair& v, uint seed) {

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -32,6 +32,7 @@
 class SimpleProgramKey;
 
 typedef QPair<glm::vec2, float> Vec2FloatPair;
+typedef QPair<Vec2FloatPair, Vec2FloatPair> Vec2FloatPairPair;
 typedef QPair<glm::vec2, glm::vec2> Vec2Pair;
 typedef QPair<Vec2Pair, Vec2Pair> Vec2PairPair;
 typedef QPair<glm::vec3, glm::vec3> Vec3Pair;
@@ -42,14 +43,10 @@ typedef QPair<Vec3Pair, Vec4Pair> Vec3PairVec4Pair;
 typedef QPair<Vec4Pair, glm::vec4> Vec4PairVec4;
 typedef QPair<Vec4Pair, Vec4Pair> Vec4PairVec4Pair;
 
-inline uint qHash(const glm::vec2& v, uint seed) {
+inline uint qHash(const Vec2FloatPairPair& v, uint seed) {
     // multiply by prime numbers greater than the possible size
-    return qHash(v.x + 5009 * v.y, seed);
-}
-
-inline uint qHash(const Vec2FloatPair& v, uint seed) {
-    // multiply by prime numbers greater than the possible size
-    return qHash(v.first.x + 5009 * v.first.y + 5011 * v.second);
+    return qHash(v.first.first.x + 5009 * v.first.first.y + 5011 * v.first.second +
+        5021 * v.second.first.x + 5023 * v.second.first.y + 5039 * v.second.second);
 }
 
 inline uint qHash(const Vec2Pair& v, uint seed) {
@@ -207,9 +204,13 @@ public:
     void renderWireSphere(gpu::Batch& batch);
     size_t getSphereTriangleCount();
 
-    void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner, int rows, int cols, const glm::vec4& color, float edge = 0.01f, int id = UNKNOWN_ID);
-    void renderGrid(gpu::Batch& batch, int x, int y, int width, int height, int rows, int cols, const glm::vec4& color, float edge = 0.01f, int id = UNKNOWN_ID) {
-        renderGrid(batch, glm::vec2(x, y), glm::vec2(x + width, y + height), rows, cols, color, edge, id);
+    void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
+        int majorRows, int majorCols, float majorEdge,
+        int minorRows, int minorCols, float minorEdge,
+        const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
+        int rows, int cols, float edge, const glm::vec4& color, int id = UNKNOWN_ID) {
+        renderGrid(batch, minCorner, maxCorner, rows, cols, edge, 0, 0, 0.0f, color, id);
     }
 
     void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id = UNKNOWN_ID);
@@ -318,10 +319,10 @@ private:
 
     class GridSchema {
     public:
-        glm::vec2 period;
-        glm::vec2 offset;
-        glm::vec2 balance;
-        glm::vec2 _;
+        // data is arranged as majorRow, majorCol, minorRow, minorCol
+        glm::vec4 period;
+        glm::vec4 offset;
+        glm::vec4 balance;
     };
     using GridBuffer = gpu::BufferView;
     void useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer);
@@ -384,8 +385,8 @@ private:
     QHash<Vec3PairVec2Pair, BatchItemDetails> _dashedLines;
     QHash<int, BatchItemDetails> _registeredDashedLines;
 
-    QHash<int, Vec2FloatPair> _lastRegisteredGridBuffer;
-    QHash<Vec2FloatPair, GridBuffer> _gridBuffers;
+    QHash<int, Vec2FloatPairPair> _lastRegisteredGridBuffer;
+    QHash<Vec2FloatPairPair, GridBuffer> _gridBuffers;
     QHash<int, GridBuffer> _registeredGridBuffers;
 
     QHash<QUrl, QWeakPointer<NetworkGeometry> > _networkGeometry;

--- a/libraries/render-utils/src/grid.slf
+++ b/libraries/render-utils/src/grid.slf
@@ -31,11 +31,16 @@ float paintGrid(vec2 value, vec2 offset, vec2 scale, vec2 balance) {
         paintStripe(value.y, offset.y, scale.y, balance.y));
 }
 
+float paintGridMajorMinor(vec2 value, vec4 offset, vec4 scale, vec4 balance) {
+    return max(
+        paintGrid(value, offset.xy, scale.xy, balance.xy),
+        paintGrid(value, offset.zw, scale.zw, balance.zw));
+}
+
 struct Grid {
-    vec2 period;
-    vec2 offset;
-    vec2 balance;
-    vec2 _;
+    vec4 period;
+    vec4 offset;
+    vec4 balance;
 };
 
 uniform gridBuffer { Grid grid; };
@@ -49,7 +54,12 @@ out vec4 outFragColor;
 void main(void) {
     Grid grid = getGrid();
 
-    float alpha = paintGrid(varTexCoord0, grid.offset, grid.period, grid.balance);
+    float alpha;
+    if (grid.balance.z == 0.0) {
+        alpha = paintGrid(varTexCoord0, grid.offset.xy, grid.period.xy, grid.balance.xy);
+    } else {
+        alpha = paintGridMajorMinor(varTexCoord0, grid.offset, grid.period, grid.balance);
+    }
     if (alpha == 0.0) {
         discard;
     }

--- a/libraries/render-utils/src/grid.slf
+++ b/libraries/render-utils/src/grid.slf
@@ -11,32 +11,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-float paintStripe(float value, float offset, float scale, float edge) {
-    float width = fwidth(value);
-    float normalizedWidth = width * scale;
-
-    float x0 = (value + offset) * scale - normalizedWidth / 2;
-    float x1 = x0 + normalizedWidth;
-
-    float balance = 1.0 - edge;
-    float i0 = edge * floor(x0) + max(0.0, fract(x0) - balance);
-    float i1 = edge * floor(x1) + max(0.0, fract(x1) - balance);
-    float strip = (i1 - i0) / normalizedWidth;
-
-    return clamp(strip, 0.0, 1.0);
-}
-
-float paintGrid(vec2 value, vec2 offset, vec2 scale, vec2 edge) {
-    return max(
-        paintStripe(value.x, offset.x, scale.x, edge.x),
-        paintStripe(value.y, offset.y, scale.y, edge.y));
-}
-
-float paintGridMajorMinor(vec2 value, vec4 offset, vec4 scale, vec4 edge) {
-    return max(
-        paintGrid(value, offset.xy, scale.xy, edge.xy),
-        paintGrid(value, offset.zw, scale.zw, edge.zw));
-}
+<@include gpu/Paint.slh@>
 
 struct Grid {
     vec4 period;

--- a/libraries/render-utils/src/grid.slf
+++ b/libraries/render-utils/src/grid.slf
@@ -1,0 +1,58 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//  grid.slf
+//  fragment shader
+//
+//  Created by Zach Pomerantz on 2/16/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+float paintStripe(float value, float offset, float scale, float balance) {
+    float width = fwidth(value);
+    float normalizedWidth = width * scale;
+
+    float x0 = (value + offset) * scale - normalizedWidth / 2;
+    float x1 = x0 + normalizedWidth;
+
+    float i0 = balance * floor(x0) + max(0.0, fract(x0) - balance);
+    float i1 = balance * floor(x1) + max(0.0, fract(x1) - balance);
+    float strip = (i1 - i0) / normalizedWidth;
+
+    return clamp(strip, 0.0, 1.0);
+}
+
+float paintGrid(vec2 value, vec2 offset, vec2 scale, vec2 balance) {
+    return max(
+        paintStripe(value.x, offset.x, scale.x, balance.x),
+        paintStripe(value.y, offset.y, scale.y, balance.y));
+}
+
+struct Grid {
+    vec2 period;
+    vec2 offset;
+    vec2 balance;
+    vec2 _;
+};
+
+uniform gridBuffer { Grid grid; };
+Grid getGrid() { return grid; };
+
+in vec2 varTexCoord0;
+in vec4 varColor;
+
+out vec4 outFragColor;
+
+void main(void) {
+    Grid grid = getGrid();
+
+    float alpha = paintGrid(varTexCoord0, grid.offset, grid.period, grid.balance);
+    if (alpha == 0.0) {
+        discard;
+    }
+
+    outFragColor = vec4(varColor.xyz, varColor.w * alpha);
+}

--- a/libraries/render-utils/src/grid.slf
+++ b/libraries/render-utils/src/grid.slf
@@ -11,36 +11,37 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-float paintStripe(float value, float offset, float scale, float balance) {
+float paintStripe(float value, float offset, float scale, float edge) {
     float width = fwidth(value);
     float normalizedWidth = width * scale;
 
     float x0 = (value + offset) * scale - normalizedWidth / 2;
     float x1 = x0 + normalizedWidth;
 
-    float i0 = balance * floor(x0) + max(0.0, fract(x0) - balance);
-    float i1 = balance * floor(x1) + max(0.0, fract(x1) - balance);
+    float balance = 1.0 - edge;
+    float i0 = edge * floor(x0) + max(0.0, fract(x0) - balance);
+    float i1 = edge * floor(x1) + max(0.0, fract(x1) - balance);
     float strip = (i1 - i0) / normalizedWidth;
 
     return clamp(strip, 0.0, 1.0);
 }
 
-float paintGrid(vec2 value, vec2 offset, vec2 scale, vec2 balance) {
+float paintGrid(vec2 value, vec2 offset, vec2 scale, vec2 edge) {
     return max(
-        paintStripe(value.x, offset.x, scale.x, balance.x),
-        paintStripe(value.y, offset.y, scale.y, balance.y));
+        paintStripe(value.x, offset.x, scale.x, edge.x),
+        paintStripe(value.y, offset.y, scale.y, edge.y));
 }
 
-float paintGridMajorMinor(vec2 value, vec4 offset, vec4 scale, vec4 balance) {
+float paintGridMajorMinor(vec2 value, vec4 offset, vec4 scale, vec4 edge) {
     return max(
-        paintGrid(value, offset.xy, scale.xy, balance.xy),
-        paintGrid(value, offset.zw, scale.zw, balance.zw));
+        paintGrid(value, offset.xy, scale.xy, edge.xy),
+        paintGrid(value, offset.zw, scale.zw, edge.zw));
 }
 
 struct Grid {
     vec4 period;
     vec4 offset;
-    vec4 balance;
+    vec4 edge;
 };
 
 uniform gridBuffer { Grid grid; };
@@ -55,10 +56,10 @@ void main(void) {
     Grid grid = getGrid();
 
     float alpha;
-    if (grid.balance.z == 0.0) {
-        alpha = paintGrid(varTexCoord0, grid.offset.xy, grid.period.xy, grid.balance.xy);
+    if (grid.edge.z == 0.0) {
+        alpha = paintGrid(varTexCoord0, grid.offset.xy, grid.period.xy, grid.edge.xy);
     } else {
-        alpha = paintGridMajorMinor(varTexCoord0, grid.offset, grid.period, grid.balance);
+        alpha = paintGridMajorMinor(varTexCoord0, grid.offset, grid.period, grid.edge);
     }
     if (alpha == 0.0) {
         discard;


### PR DESCRIPTION
- Reimplements GeometryCache::renderGrid to use a frag shader instead of GL_LINES
- Update properties of grid overlay for consistency
- Add back the grid tool to edit.js