### PR TITLE
Enable HTML5 userMedia APIs in QTWebengine view

### DIFF
--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -129,6 +129,10 @@ Window {
                 id: webviewProfile
                 storageName: "qmlUserBrowser"
             }
+                
+            onFeaturePermissionRequested: {
+                grantFeaturePermission(securityOrigin, feature, true);
+            }
 
         }
     } // item

--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -129,10 +129,6 @@ Window {
                 id: webviewProfile
                 storageName: "qmlUserBrowser"
             }
-                
-            onFeaturePermissionRequested: {
-                grantFeaturePermission(securityOrigin, feature, true);
-            }
 
         }
     } // item

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -11,6 +11,7 @@ WebEngineView {
         root.javaScriptConsoleMessage.connect(function(level, message, lineNumber, sourceID) {
             console.log("Web Window JS message: " + sourceID + " " + lineNumber + " " +  message);
         });
+
     }
 
     // FIXME hack to get the URL with the auth token included.  Remove when we move to Qt 5.6
@@ -34,6 +35,10 @@ WebEngineView {
             }
             urlReplacementTimer.start();
         }
+    }
+
+    onFeaturePermissionRequested: {
+        grantFeaturePermission(securityOrigin, feature, true);
     }
 
     onLoadingChanged: {


### PR DESCRIPTION
This PR enables the use of certain HTML5 audio/video APIs that allow capture from a user's microphone and video camera.    This applies to both web overlays and the web browser (although not web entities at the moment).

1. Ctrl-B to open a browser.
2. Visit https://dev.windows.com/en-us/microsoft-edge/testdrive/demos/microphone/ and click start demo
3. Make sure your mic etc isn't muted and observe that the HTML5 webpage gets your voice input!

This automatically approves feature requests... We could do a feature permission bar.  But some feedback would be great!

*I don't have a webcam so if someone could please test a site that uses HTML5 video capture?