### PR TITLE
null audio injector

### DIFF
--- a/libraries/script-engine/src/AudioScriptingInterface.cpp
+++ b/libraries/script-engine/src/AudioScriptingInterface.cpp
@@ -45,8 +45,11 @@ ScriptAudioInjector* AudioScriptingInterface::playSound(Sound* sound, const Audi
         // stereo option isn't set from script, this comes from sound metadata or filename
         AudioInjectorOptions optionsCopy = injectorOptions;
         optionsCopy.stereo = sound->isStereo();
-
-        return new ScriptAudioInjector(AudioInjector::playSound(sound->getByteArray(), optionsCopy, _localAudioInterface));
+        auto injector = AudioInjector::playSound(sound->getByteArray(), optionsCopy, _localAudioInterface);
+        if (!injector) {
+            return NULL;
+        }
+        return new ScriptAudioInjector(injector);
 
     } else {
         qCDebug(scriptengine) << "AudioScriptingInterface::playSound called with null Sound object.";


### PR DESCRIPTION
When we don't make an audo injector (because we're at a limit), make sure the value returned to scripts is null.