### PR TITLE
Add support for pop-up windows to Qt WebEngineView

### DIFF
--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -14,7 +14,8 @@ Window {
     destroyOnInvisible: true
     width: 800
     height: 600
-
+    property alias webView: webview
+    
     Component.onCompleted: {
         visible = true
         addressBar.text = webview.url
@@ -28,6 +29,7 @@ Window {
     }
 
     Item {
+        id:item
         anchors.fill: parent
         Rectangle {
             anchors.left: parent.left
@@ -125,12 +127,10 @@ Window {
                 console.log("New icon: " + icon)
             }
             
-            profile: WebEngineProfile {
-                id: webviewProfile
-                storageName: "qmlUserBrowser"
-            }
-
+            profile: desktop.browserProfile
+    
         }
+
     } // item
     
     Keys.onPressed: {

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -37,11 +37,6 @@ WebEngineView {
         }
     }
 
-    onFeaturePermissionRequested: {
-        console.log('permission requested',securityOrigin, feature)
-        grantFeaturePermission(securityOrigin, feature, true);
-    }
-
     onLoadingChanged: {
         // Required to support clicking on "hifi://" links
         if (WebEngineView.LoadStartedStatus == loadRequest.status) {

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -11,6 +11,7 @@ WebEngineView {
         root.javaScriptConsoleMessage.connect(function(level, message, lineNumber, sourceID) {
             console.log("Web Window JS message: " + sourceID + " " + lineNumber + " " +  message);
         });
+
     }
 
     // FIXME hack to get the URL with the auth token included.  Remove when we move to Qt 5.6
@@ -36,6 +37,11 @@ WebEngineView {
         }
     }
 
+    onFeaturePermissionRequested: {
+        console.log('permission requested',securityOrigin, feature)
+        grantFeaturePermission(securityOrigin, feature, true);
+    }
+
     onLoadingChanged: {
         // Required to support clicking on "hifi://" links
         if (WebEngineView.LoadStartedStatus == loadRequest.status) {
@@ -48,9 +54,12 @@ WebEngineView {
         }
     }
 
-    profile: WebEngineProfile {
-        id: webviewProfile
-        httpUserAgent: "Mozilla/5.0 (HighFidelityInterface)"
-        storageName: "qmlWebEngine"
+    onNewViewRequested:{
+            var component = Qt.createComponent("../Browser.qml");
+            var newWindow = component.createObject(desktop);
+            request.openIn(newWindow.webView)
     }
+
+
+    profile: desktop.browserProfile
 }

--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -10,7 +10,7 @@ Desktop {
 
     Component.onCompleted: {
         WebEngine.settings.javascriptCanOpenWindows = true;
-        WebEngine.settings.javascriptCanAccessClipboard = true;
+        WebEngine.settings.javascriptCanAccessClipboard = false;
         WebEngine.settings.spatialNavigationEnabled = true;
         WebEngine.settings.localContentCanAccessRemoteUrls = true;
     }
@@ -18,7 +18,7 @@ Desktop {
     // The tool window, one instance
     property alias toolWindow: toolWindow
     ToolWindow { id: toolWindow }
-    
+
     property var browserProfile: WebEngineProfile {
         id: webviewProfile
         httpUserAgent: "Chrome/48.0 (HighFidelityInterface)"

--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -9,8 +9,8 @@ Desktop {
     id: desktop
 
     Component.onCompleted: {
-        WebEngine.settings.javascriptCanOpenWindows = false;
-        WebEngine.settings.javascriptCanAccessClipboard = false;
+        WebEngine.settings.javascriptCanOpenWindows = true;
+        WebEngine.settings.javascriptCanAccessClipboard = true;
         WebEngine.settings.spatialNavigationEnabled = true;
         WebEngine.settings.localContentCanAccessRemoteUrls = true;
     }
@@ -18,6 +18,12 @@ Desktop {
     // The tool window, one instance
     property alias toolWindow: toolWindow
     ToolWindow { id: toolWindow }
+    
+    property var browserProfile: WebEngineProfile {
+        id: webviewProfile
+        httpUserAgent: "Chrome/48.0 (HighFidelityInterface)"
+        storageName: "qmlWebEngine"
+    }
 
     Action {
         text: "Open Browser"


### PR DESCRIPTION
Previously, we didn't handle requests by web sites to open new windows, which could prevent a site like www.asana.com from loading since its login requires a new window.  This PR adds support for popups, so now these types of sites work.

To test:

1. Open a browser with Ctrl-B
2. Type in a site that requires a pop up for its login, like www.asana.com
3. Click log-in and observe that a new window pops up that allows you to log in (this step fails in master)