### PR TITLE
Vive: smoother updates for IK driven by vive controllers

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -210,7 +210,7 @@ static const QString INFO_EDIT_ENTITIES_PATH = "html/edit-commands.html";
 
 static const unsigned int THROTTLED_SIM_FRAMERATE = 15;
 static const int THROTTLED_SIM_FRAME_PERIOD_MS = MSECS_PER_SECOND / THROTTLED_SIM_FRAMERATE;
-static const unsigned int CAPPED_SIM_FRAMERATE = 60;
+static const unsigned int CAPPED_SIM_FRAMERATE = 120;
 static const int CAPPED_SIM_FRAME_PERIOD_MS = MSECS_PER_SECOND / CAPPED_SIM_FRAMERATE;
 
 static const uint32_t INVALID_FRAME = UINT32_MAX;
@@ -1733,6 +1733,7 @@ bool Application::event(QEvent* event) {
 
     if ((int)event->type() == (int)Paint) {
         paintGL();
+        return true;
     }
 
     if (!_keyboardFocusedItem.isInvalidID()) {


### PR DESCRIPTION
Before this PR the simulation rate was clamped to never exceed 60htz.
This had problems when waving the vive hand controllers in the world,
they would jitter.  The simulation rate is now clamped to never exceed
120 htz.  This has the effect of synchronizing the display and the
update rates to 90htz.

Also there are improvements to vive support if threaded present is
disabled.