### PR TITLE
Make Overlay API usable from QML

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -11,8 +11,6 @@
 
 #include "Base3DOverlay.h"
 
-#include <QScriptValue>
-
 #include <RegisteredMetaTypes.h>
 #include <SharedUtil.h>
 
@@ -41,103 +39,78 @@ Base3DOverlay::Base3DOverlay(const Base3DOverlay* base3DOverlay) :
 {
 }
 
-void Base3DOverlay::setProperties(const QScriptValue& properties) {
+void Base3DOverlay::setProperties(const QVariantMap& properties) {
     Overlay::setProperties(properties);
 
-    QScriptValue drawInFront = properties.property("drawInFront");
+    auto drawInFront = properties["drawInFront"];
 
     if (drawInFront.isValid()) {
-        bool value = drawInFront.toVariant().toBool();
+        bool value = drawInFront.toBool();
         setDrawInFront(value);
     }
 
-    QScriptValue position = properties.property("position");
+    auto position = properties["position"];
 
     // if "position" property was not there, check to see if they included aliases: point, p1
     if (!position.isValid()) {
-        position = properties.property("p1");
+        position = properties["p1"];
         if (!position.isValid()) {
-            position = properties.property("point");
+            position = properties["point"];
         }
     }
-
     if (position.isValid()) {
-        QScriptValue x = position.property("x");
-        QScriptValue y = position.property("y");
-        QScriptValue z = position.property("z");
-        if (x.isValid() && y.isValid() && z.isValid()) {
-            glm::vec3 newPosition;
-            newPosition.x = x.toVariant().toFloat();
-            newPosition.y = y.toVariant().toFloat();
-            newPosition.z = z.toVariant().toFloat();
-            setPosition(newPosition);
-        }
+        setPosition(vec3FromVariant(position));
     }
 
-    if (properties.property("lineWidth").isValid()) {
-        setLineWidth(properties.property("lineWidth").toVariant().toFloat());
+    if (properties["lineWidth"].isValid()) {
+        setLineWidth(properties["lineWidth"].toFloat());
     }
 
-    QScriptValue rotation = properties.property("rotation");
+    auto rotation = properties["rotation"];
 
     if (rotation.isValid()) {
-        glm::quat newRotation;
-
-        // size, scale, dimensions is special, it might just be a single scalar, or it might be a vector, check that here
-        QScriptValue x = rotation.property("x");
-        QScriptValue y = rotation.property("y");
-        QScriptValue z = rotation.property("z");
-        QScriptValue w = rotation.property("w");
-
-
-        if (x.isValid() && y.isValid() && z.isValid() && w.isValid()) {
-            newRotation.x = x.toVariant().toFloat();
-            newRotation.y = y.toVariant().toFloat();
-            newRotation.z = z.toVariant().toFloat();
-            newRotation.w = w.toVariant().toFloat();
-            setRotation(newRotation);
-        }
+        setRotation(quatFromVariant(rotation));
     }
 
-    if (properties.property("isSolid").isValid()) {
-        setIsSolid(properties.property("isSolid").toVariant().toBool());
+    if (properties["isSolid"].isValid()) {
+        setIsSolid(properties["isSolid"].toBool());
     }
-    if (properties.property("isFilled").isValid()) {
-        setIsSolid(properties.property("isSolid").toVariant().toBool());
+    if (properties["isFilled"].isValid()) {
+        setIsSolid(properties["isSolid"].toBool());
     }
-    if (properties.property("isWire").isValid()) {
-        setIsSolid(!properties.property("isWire").toVariant().toBool());
+    if (properties["isWire"].isValid()) {
+        setIsSolid(!properties["isWire"].toBool());
     }
-    if (properties.property("solid").isValid()) {
-        setIsSolid(properties.property("solid").toVariant().toBool());
+    if (properties["solid"].isValid()) {
+        setIsSolid(properties["solid"].toBool());
     }
-    if (properties.property("filled").isValid()) {
-        setIsSolid(properties.property("filled").toVariant().toBool());
+    if (properties["filled"].isValid()) {
+        setIsSolid(properties["filled"].toBool());
     }
-    if (properties.property("wire").isValid()) {
-        setIsSolid(!properties.property("wire").toVariant().toBool());
+    if (properties["wire"].isValid()) {
+        setIsSolid(!properties["wire"].toBool());
     }
 
-    if (properties.property("isDashedLine").isValid()) {
-        setIsDashedLine(properties.property("isDashedLine").toVariant().toBool());
+    if (properties["isDashedLine"].isValid()) {
+        setIsDashedLine(properties["isDashedLine"].toBool());
     }
-    if (properties.property("dashed").isValid()) {
-        setIsDashedLine(properties.property("dashed").toVariant().toBool());
+    if (properties["dashed"].isValid()) {
+        setIsDashedLine(properties["dashed"].toBool());
     }
-    if (properties.property("ignoreRayIntersection").isValid()) {
-        setIgnoreRayIntersection(properties.property("ignoreRayIntersection").toVariant().toBool());
+    if (properties["ignoreRayIntersection"].isValid()) {
+        setIgnoreRayIntersection(properties["ignoreRayIntersection"].toBool());
     }
 }
 
-QScriptValue Base3DOverlay::getProperty(const QString& property) {
+QVariant Base3DOverlay::getProperty(const QString& property) {
     if (property == "position" || property == "start" || property == "p1" || property == "point") {
-        return vec3toScriptValue(_scriptEngine, getPosition());
+        return vec3toVariant(getPosition());
     }
     if (property == "lineWidth") {
         return _lineWidth;
     }
     if (property == "rotation") {
-        return quatToScriptValue(_scriptEngine, getRotation());
+        return quatToVariant(getRotation());
     }
     if (property == "isSolid" || property == "isFilled" || property == "solid" || property == "filed") {
         return _isSolid;

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -52,8 +52,8 @@ public:
 
     virtual AABox getBounds() const = 0;
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                         BoxFace& face, glm::vec3& surfaceNormal);

--- a/interface/src/ui/overlays/Billboard3DOverlay.cpp
+++ b/interface/src/ui/overlays/Billboard3DOverlay.cpp
@@ -18,19 +18,19 @@ Billboard3DOverlay::Billboard3DOverlay(const Billboard3DOverlay* billboard3DOver
 {
 }
 
-void Billboard3DOverlay::setProperties(const QScriptValue &properties) {
+void Billboard3DOverlay::setProperties(const QVariantMap& properties) {
     Planar3DOverlay::setProperties(properties);
     PanelAttachable::setProperties(properties);
     Billboardable::setProperties(properties);
 }
 
-QScriptValue Billboard3DOverlay::getProperty(const QString &property) {
-    QScriptValue value;
-    value = Billboardable::getProperty(_scriptEngine, property);
+QVariant Billboard3DOverlay::getProperty(const QString &property) {
+    QVariant value;
+    value = Billboardable::getProperty(property);
     if (value.isValid()) {
         return value;
     }
-    value = PanelAttachable::getProperty(_scriptEngine, property);
+    value = PanelAttachable::getProperty(property);
     if (value.isValid()) {
         return value;
     }

--- a/interface/src/ui/overlays/Billboard3DOverlay.h
+++ b/interface/src/ui/overlays/Billboard3DOverlay.h
@@ -23,8 +23,8 @@ public:
     Billboard3DOverlay() {}
     Billboard3DOverlay(const Billboard3DOverlay* billboard3DOverlay);
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
 protected:
     virtual void applyTransformTo(Transform& transform, bool force = false);

--- a/interface/src/ui/overlays/Billboardable.cpp
+++ b/interface/src/ui/overlays/Billboardable.cpp
@@ -14,18 +14,18 @@
 #include <Application.h>
 #include <Transform.h>
 
-void Billboardable::setProperties(const QScriptValue &properties) {
-    QScriptValue isFacingAvatar = properties.property("isFacingAvatar");
+void Billboardable::setProperties(const QVariantMap& properties) {
+    auto isFacingAvatar = properties["isFacingAvatar"];
     if (isFacingAvatar.isValid()) {
-        setIsFacingAvatar(isFacingAvatar.toVariant().toBool());
+        setIsFacingAvatar(isFacingAvatar.toBool());
     }
 }
 
-QScriptValue Billboardable::getProperty(QScriptEngine* scriptEngine, const QString &property) {
+QVariant Billboardable::getProperty(const QString &property) {
     if (property == "isFacingAvatar") {
         return isFacingAvatar();
     }
-    return QScriptValue();
+    return QVariant();
 }
 
 void Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offsetRotation) {

--- a/interface/src/ui/overlays/Billboardable.h
+++ b/interface/src/ui/overlays/Billboardable.h
@@ -12,11 +12,9 @@
 #ifndef hifi_Billboardable_h
 #define hifi_Billboardable_h
 
-#include <QScriptValue>
-
 #include <glm/gtc/quaternion.hpp>
+#include <QVariant>
 
-class QScriptEngine;
 class QString;
 class Transform;
 
@@ -26,8 +24,8 @@ public:
     void setIsFacingAvatar(bool isFacingAvatar) { _isFacingAvatar = isFacingAvatar; }
 
 protected:
-    void setProperties(const QScriptValue& properties);
-    QScriptValue getProperty(QScriptEngine* scriptEngine, const QString& property);
+    void setProperties(const QVariantMap& properties);
+    QVariant getProperty(const QString& property);
 
     void pointTransformAtCamera(Transform& transform, glm::quat offsetRotation = {1, 0, 0, 0});
 

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -286,83 +286,76 @@ const render::ShapeKey Circle3DOverlay::getShapeKey() {
     return builder.build();
 }
 
-void Circle3DOverlay::setProperties(const QScriptValue &properties) {
+void Circle3DOverlay::setProperties(const QVariantMap& properties) {
     Planar3DOverlay::setProperties(properties);
 
-    QScriptValue startAt = properties.property("startAt");
+    QVariant startAt = properties["startAt"];
     if (startAt.isValid()) {
-        setStartAt(startAt.toVariant().toFloat());
+        setStartAt(startAt.toFloat());
     }
 
-    QScriptValue endAt = properties.property("endAt");
+    QVariant endAt = properties["endAt"];
     if (endAt.isValid()) {
-        setEndAt(endAt.toVariant().toFloat());
+        setEndAt(endAt.toFloat());
     }
 
-    QScriptValue outerRadius = properties.property("radius");
+    QVariant outerRadius = properties["radius"];
     if (!outerRadius.isValid()) {
-        outerRadius = properties.property("outerRadius");
+        outerRadius = properties["outerRadius"];
     }
     if (outerRadius.isValid()) {
-        setOuterRadius(outerRadius.toVariant().toFloat());
+        setOuterRadius(outerRadius.toFloat());
     }
 
-    QScriptValue innerRadius = properties.property("innerRadius");
+    QVariant innerRadius = properties["innerRadius"];
     if (innerRadius.isValid()) {
-        setInnerRadius(innerRadius.toVariant().toFloat());
+        setInnerRadius(innerRadius.toFloat());
     }
 
-    QScriptValue hasTickMarks = properties.property("hasTickMarks");
+    QVariant hasTickMarks = properties["hasTickMarks"];
     if (hasTickMarks.isValid()) {
-        setHasTickMarks(hasTickMarks.toVariant().toBool());
+        setHasTickMarks(hasTickMarks.toBool());
     }
 
-    QScriptValue majorTickMarksAngle = properties.property("majorTickMarksAngle");
+    QVariant majorTickMarksAngle = properties["majorTickMarksAngle"];
     if (majorTickMarksAngle.isValid()) {
-        setMajorTickMarksAngle(majorTickMarksAngle.toVariant().toFloat());
+        setMajorTickMarksAngle(majorTickMarksAngle.toFloat());
     }
 
-    QScriptValue minorTickMarksAngle = properties.property("minorTickMarksAngle");
+    QVariant minorTickMarksAngle = properties["minorTickMarksAngle"];
     if (minorTickMarksAngle.isValid()) {
-        setMinorTickMarksAngle(minorTickMarksAngle.toVariant().toFloat());
+        setMinorTickMarksAngle(minorTickMarksAngle.toFloat());
     }
 
-    QScriptValue majorTickMarksLength = properties.property("majorTickMarksLength");
+    QVariant majorTickMarksLength = properties["majorTickMarksLength"];
     if (majorTickMarksLength.isValid()) {
-        setMajorTickMarksLength(majorTickMarksLength.toVariant().toFloat());
+        setMajorTickMarksLength(majorTickMarksLength.toFloat());
     }
 
-    QScriptValue minorTickMarksLength = properties.property("minorTickMarksLength");
+    QVariant minorTickMarksLength = properties["minorTickMarksLength"];
     if (minorTickMarksLength.isValid()) {
-        setMinorTickMarksLength(minorTickMarksLength.toVariant().toFloat());
+        setMinorTickMarksLength(minorTickMarksLength.toFloat());
     }
 
-    QScriptValue majorTickMarksColor = properties.property("majorTickMarksColor");
+    bool valid;
+    auto majorTickMarksColor = properties["majorTickMarksColor"];
     if (majorTickMarksColor.isValid()) {
-        QScriptValue red = majorTickMarksColor.property("red");
-        QScriptValue green = majorTickMarksColor.property("green");
-        QScriptValue blue = majorTickMarksColor.property("blue");
-        if (red.isValid() && green.isValid() && blue.isValid()) {
-            _majorTickMarksColor.red = red.toVariant().toInt();
-            _majorTickMarksColor.green = green.toVariant().toInt();
-            _majorTickMarksColor.blue = blue.toVariant().toInt();
+        auto color = xColorFromVariant(majorTickMarksColor, valid);
+        if (valid) {
+            _majorTickMarksColor = color;
         }
     }
 
-    QScriptValue minorTickMarksColor = properties.property("minorTickMarksColor");
+    auto minorTickMarksColor = properties["minorTickMarksColor"];
     if (minorTickMarksColor.isValid()) {
-        QScriptValue red = minorTickMarksColor.property("red");
-        QScriptValue green = minorTickMarksColor.property("green");
-        QScriptValue blue = minorTickMarksColor.property("blue");
-        if (red.isValid() && green.isValid() && blue.isValid()) {
-            _minorTickMarksColor.red = red.toVariant().toInt();
-            _minorTickMarksColor.green = green.toVariant().toInt();
-            _minorTickMarksColor.blue = blue.toVariant().toInt();
+        auto color = xColorFromVariant(majorTickMarksColor, valid);
+        if (valid) {
+            _minorTickMarksColor = color;
         }
     }
 }
 
-QScriptValue Circle3DOverlay::getProperty(const QString& property) {
+QVariant Circle3DOverlay::getProperty(const QString& property) {
     if (property == "startAt") {
         return _startAt;
     }
@@ -394,10 +387,10 @@ QScriptValue Circle3DOverlay::getProperty(const QString& property) {
         return _minorTickMarksLength;
     }
     if (property == "majorTickMarksColor") {
-        return xColorToScriptValue(_scriptEngine, _majorTickMarksColor);
+        return xColorToVariant(_majorTickMarksColor);
     }
     if (property == "minorTickMarksColor") {
-        return xColorToScriptValue(_scriptEngine, _minorTickMarksColor);
+        return xColorToVariant(_minorTickMarksColor);
     }
 
     return Planar3DOverlay::getProperty(property);

--- a/interface/src/ui/overlays/Circle3DOverlay.h
+++ b/interface/src/ui/overlays/Circle3DOverlay.h
@@ -26,8 +26,8 @@ public:
     
     virtual void render(RenderArgs* args);
     virtual const render::ShapeKey getShapeKey() override;
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     float getStartAt() const { return _startAt; }
     float getEndAt() const { return _endAt; }

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -11,8 +11,6 @@
 // include this before QGLWidget, which includes an earlier version of OpenGL
 #include "Cube3DOverlay.h"
 
-#include <QScriptValue>
-
 #include <SharedUtil.h>
 #include <StreamUtils.h>
 #include <GeometryCache.h>
@@ -110,18 +108,18 @@ Cube3DOverlay* Cube3DOverlay::createClone() const {
     return new Cube3DOverlay(this);
 }
 
-void Cube3DOverlay::setProperties(const QScriptValue& properties) {
+void Cube3DOverlay::setProperties(const QVariantMap& properties) {
     Volume3DOverlay::setProperties(properties);
 
-    QScriptValue borderSize = properties.property("borderSize");
+    auto borderSize = properties["borderSize"];
 
     if (borderSize.isValid()) {
-        float value = borderSize.toVariant().toFloat();
+        float value = borderSize.toFloat();
         setBorderSize(value);
     }
 }
 
-QScriptValue Cube3DOverlay::getProperty(const QString& property) {
+QVariant Cube3DOverlay::getProperty(const QString& property) {
     if (property == "borderSize") {
         return _borderSize;
     }

--- a/interface/src/ui/overlays/Cube3DOverlay.h
+++ b/interface/src/ui/overlays/Cube3DOverlay.h
@@ -32,8 +32,8 @@ public:
 
     void setBorderSize(float value) { _borderSize = value; }
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
 private:
     float _borderSize;

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -11,10 +11,7 @@
 
 #include "Grid3DOverlay.h"
 
-#include <QScriptValue>
-
 #include <OctreeConstants.h>
-
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <PathUtils.h>
@@ -92,24 +89,24 @@ const render::ShapeKey Grid3DOverlay::getShapeKey() {
     return render::ShapeKey::Builder().withOwnPipeline();
 }
 
-void Grid3DOverlay::setProperties(const QScriptValue& properties) {
+void Grid3DOverlay::setProperties(const QVariantMap& properties) {
     Planar3DOverlay::setProperties(properties);
-    if (properties.property("followCamera").isValid()) {
-        _followCamera = properties.property("followCamera").toVariant().toBool();
+    if (properties["followCamera"].isValid()) {
+        _followCamera = properties["followCamera"].toBool();
     }
 
-    if (properties.property("majorGridEvery").isValid()) {
-        _majorGridEvery = properties.property("majorGridEvery").toVariant().toInt();
+    if (properties["majorGridEvery"].isValid()) {
+        _majorGridEvery = properties["majorGridEvery"].toInt();
     }
 
-    if (properties.property("minorGridEvery").isValid()) {
-        _minorGridEvery = properties.property("minorGridEvery").toVariant().toFloat();
+    if (properties["minorGridEvery"].isValid()) {
+        _minorGridEvery = properties["minorGridEvery"].toFloat();
     }
 
     updateGrid();
 }
 
-QScriptValue Grid3DOverlay::getProperty(const QString& property) {
+QVariant Grid3DOverlay::getProperty(const QString& property) {
     if (property == "followCamera") {
         return _followCamera;
     }

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -28,8 +28,8 @@ public:
 
     virtual void render(RenderArgs* args);
     virtual const render::ShapeKey getShapeKey() override;
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     virtual Grid3DOverlay* createClone() const;
 

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -12,8 +12,6 @@
 
 #include "Image3DOverlay.h"
 
-#include <QScriptValue>
-
 #include <DependencyManager.h>
 #include <GeometryCache.h>
 #include <gpu/Batch.h>
@@ -114,41 +112,42 @@ const render::ShapeKey Image3DOverlay::getShapeKey() {
     return builder.build();
 }
 
-void Image3DOverlay::setProperties(const QScriptValue &properties) {
+void Image3DOverlay::setProperties(const QVariantMap& properties) {
     Billboard3DOverlay::setProperties(properties);
 
-    QScriptValue urlValue = properties.property("url");
+    auto urlValue = properties["url"];
     if (urlValue.isValid()) {
-        QString newURL = urlValue.toVariant().toString();
+        QString newURL = urlValue.toString();
         if (newURL != _url) {
             setURL(newURL);
         }
     }
 
-    QScriptValue subImageBounds = properties.property("subImage");
-    if (subImageBounds.isValid()) {
-        if (subImageBounds.isNull()) {
+    auto subImageBoundsVar = properties["subImage"];
+    if (subImageBoundsVar.isValid()) {
+        if (subImageBoundsVar.isNull()) {
             _fromImage = QRect();
         } else {
             QRect oldSubImageRect = _fromImage;
             QRect subImageRect = _fromImage;
-            if (subImageBounds.property("x").isValid()) {
-                subImageRect.setX(subImageBounds.property("x").toVariant().toInt());
+            auto subImageBounds = subImageBoundsVar.toMap();
+            if (subImageBounds["x"].isValid()) {
+                subImageRect.setX(subImageBounds["x"].toInt());
             } else {
                 subImageRect.setX(oldSubImageRect.x());
             }
-            if (subImageBounds.property("y").isValid()) {
-                subImageRect.setY(subImageBounds.property("y").toVariant().toInt());
+            if (subImageBounds["y"].isValid()) {
+                subImageRect.setY(subImageBounds["y"].toInt());
             } else {
                 subImageRect.setY(oldSubImageRect.y());
             }
-            if (subImageBounds.property("width").isValid()) {
-                subImageRect.setWidth(subImageBounds.property("width").toVariant().toInt());
+            if (subImageBounds["width"].isValid()) {
+                subImageRect.setWidth(subImageBounds["width"].toInt());
             } else {
                 subImageRect.setWidth(oldSubImageRect.width());
             }
-            if (subImageBounds.property("height").isValid()) {
-                subImageRect.setHeight(subImageBounds.property("height").toVariant().toInt());
+            if (subImageBounds["height"].isValid()) {
+                subImageRect.setHeight(subImageBounds["height"].toInt());
             } else {
                 subImageRect.setHeight(oldSubImageRect.height());
             }
@@ -156,21 +155,21 @@ void Image3DOverlay::setProperties(const QScriptValue &properties) {
         }
     }
 
-    QScriptValue emissiveValue = properties.property("emissive");
+    auto emissiveValue = properties["emissive"];
     if (emissiveValue.isValid()) {
         _emissive = emissiveValue.toBool();
     }
 }
 
-QScriptValue Image3DOverlay::getProperty(const QString& property) {
+QVariant Image3DOverlay::getProperty(const QString& property) {
     if (property == "url") {
         return _url;
     }
     if (property == "subImage") {
-        return qRectToScriptValue(_scriptEngine, _fromImage);
+        return _fromImage;
     }
     if (property == "offsetPosition") {
-        return vec3toScriptValue(_scriptEngine, getOffsetPosition());
+        return vec3toVariant(getOffsetPosition());
     }
     if (property == "emissive") {
         return _emissive;

--- a/interface/src/ui/overlays/Image3DOverlay.h
+++ b/interface/src/ui/overlays/Image3DOverlay.h
@@ -37,8 +37,8 @@ public:
     void setURL(const QString& url);
     void setClipFromSource(const QRect& bounds) { _fromImage = bounds; }
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                         BoxFace& face, glm::vec3& surfaceNormal);

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -71,49 +71,34 @@ const render::ShapeKey Line3DOverlay::getShapeKey() {
     return builder.build();
 }
 
-void Line3DOverlay::setProperties(const QScriptValue& properties) {
+void Line3DOverlay::setProperties(const QVariantMap& properties) {
     Base3DOverlay::setProperties(properties);
 
-    QScriptValue start = properties.property("start");
+    auto start = properties["start"];
     // if "start" property was not there, check to see if they included aliases: startPoint
     if (!start.isValid()) {
-        start = properties.property("startPoint");
+        start = properties["startPoint"];
     }
     if (start.isValid()) {
-        QScriptValue x = start.property("x");
-        QScriptValue y = start.property("y");
-        QScriptValue z = start.property("z");
-        if (x.isValid() && y.isValid() && z.isValid()) {
-            glm::vec3 newStart;
-            newStart.x = x.toVariant().toFloat();
-            newStart.y = y.toVariant().toFloat();
-            newStart.z = z.toVariant().toFloat();
-            setStart(newStart);
-        }
+        setStart(vec3FromVariant(start));
     }
 
-    QScriptValue end = properties.property("end");
+    auto end = properties["end"];
     // if "end" property was not there, check to see if they included aliases: endPoint
     if (!end.isValid()) {
-        end = properties.property("endPoint");
+        end = properties["endPoint"];
     }
     if (end.isValid()) {
-        QScriptValue x = end.property("x");
-        QScriptValue y = end.property("y");
-        QScriptValue z = end.property("z");
-        if (x.isValid() && y.isValid() && z.isValid()) {
-            glm::vec3 newEnd;
-            newEnd.x = x.toVariant().toFloat();
-            newEnd.y = y.toVariant().toFloat();
-            newEnd.z = z.toVariant().toFloat();
-            setEnd(newEnd);
-        }
+        setEnd(vec3FromVariant(end));
     }
 }
 
-QScriptValue Line3DOverlay::getProperty(const QString& property) {
+QVariant Line3DOverlay::getProperty(const QString& property) {
+    if (property == "start" || property == "startPoint" || property == "p1") {
+        return vec3toVariant(_start);
+    }
     if (property == "end" || property == "endPoint" || property == "p2") {
-        return vec3toScriptValue(_scriptEngine, _end);
+        return vec3toVariant(_end);
     }
 
     return Base3DOverlay::getProperty(property);

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -35,8 +35,8 @@ public:
     void setStart(const glm::vec3& start) { _start = start; }
     void setEnd(const glm::vec3& end) { _end = end; }
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     virtual Line3DOverlay* createClone() const;
 

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -84,7 +84,7 @@ void ModelOverlay::render(RenderArgs* args) {
     }
 }
 
-void ModelOverlay::setProperties(const QScriptValue &properties) {
+void ModelOverlay::setProperties(const QVariantMap& properties) {
     auto position = getPosition();
     auto rotation = getRotation();
     auto scale = getDimensions();
@@ -105,16 +105,16 @@ void ModelOverlay::setProperties(const QScriptValue &properties) {
         }
     }
     
-    QScriptValue urlValue = properties.property("url");
-    if (urlValue.isValid() && urlValue.isString()) {
+    auto urlValue = properties["url"];
+    if (urlValue.isValid() && urlValue.canConvert<QString>()) {
         _url = urlValue.toString();
         _updateModel = true;
         _isLoaded = false;
     }
     
-    QScriptValue texturesValue = properties.property("textures");
-    if (texturesValue.isValid() && texturesValue.toVariant().canConvert(QVariant::Map)) {
-        QVariantMap textureMap = texturesValue.toVariant().toMap();
+    auto texturesValue = properties["textures"];
+    if (texturesValue.isValid() && texturesValue.canConvert(QVariant::Map)) {
+        QVariantMap textureMap = texturesValue.toMap();
         foreach(const QString& key, textureMap.keys()) {
             
             QUrl newTextureURL = textureMap[key].toUrl();
@@ -129,22 +129,22 @@ void ModelOverlay::setProperties(const QScriptValue &properties) {
     }
 }
 
-QScriptValue ModelOverlay::getProperty(const QString& property) {
+QVariant ModelOverlay::getProperty(const QString& property) {
     if (property == "url") {
         return _url.toString();
     }
     if (property == "dimensions" || property == "scale" || property == "size") {
-        return vec3toScriptValue(_scriptEngine, _model.getScaleToFitDimensions());
+        return vec3toVariant(_model.getScaleToFitDimensions());
     }
     if (property == "textures") {
         if (_modelTextures.size() > 0) {
-            QScriptValue textures = _scriptEngine->newObject();
+            QVariantMap textures;
             foreach(const QString& key, _modelTextures.keys()) {
-                textures.setProperty(key, _modelTextures[key].toString());
+                textures[key] = _modelTextures[key].toString();
             }
             return textures;
         } else {
-            return QScriptValue();
+            return QVariant();
         }
     }
 

--- a/interface/src/ui/overlays/ModelOverlay.h
+++ b/interface/src/ui/overlays/ModelOverlay.h
@@ -27,9 +27,9 @@ public:
 
     virtual void update(float deltatime);
     virtual void render(RenderArgs* args);
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
-    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
+    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
                                         BoxFace& face, glm::vec3& surfaceNormal);
     virtual bool findRayIntersectionExtraInfo(const glm::vec3& origin, const glm::vec3& direction, 
                                         float& distance, BoxFace& face, glm::vec3& surfaceNormal, QString& extraInfo);

--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -52,70 +52,68 @@ Overlay::Overlay(const Overlay* overlay) :
     _colorPulse(overlay->_colorPulse),
     _color(overlay->_color),
     _visible(overlay->_visible),
-    _anchor(overlay->_anchor),
-    _scriptEngine(NULL)
+    _anchor(overlay->_anchor)
 {
-}
-
-void Overlay::init(QScriptEngine* scriptEngine) {
-    _scriptEngine = scriptEngine;
 }
 
 Overlay::~Overlay() {
 }
 
-void Overlay::setProperties(const QScriptValue& properties) {
-    QScriptValue color = properties.property("color");
-    xColorFromScriptValue(properties.property("color"), _color);
+void Overlay::setProperties(const QVariantMap& properties) {
+    bool valid;
+    auto color = xColorFromVariant(properties["color"], valid);
+    if (valid) {
+        _color = color;
+    }
 
-    if (properties.property("alpha").isValid()) {
-        setAlpha(properties.property("alpha").toVariant().toFloat());
+    if (properties["alpha"].isValid()) {
+        setAlpha(properties["alpha"].toFloat());
     }
     
-    if (properties.property("glowLevel").isValid()) {
-        setGlowLevel(properties.property("glowLevel").toVariant().toFloat());
+    if (properties["glowLevel"].isValid()) {
+        setGlowLevel(properties["glowLevel"].toFloat());
     }
 
-    if (properties.property("pulseMax").isValid()) {
-        setPulseMax(properties.property("pulseMax").toVariant().toFloat());
+    if (properties["pulseMax"].isValid()) {
+        setPulseMax(properties["pulseMax"].toFloat());
     }
 
-    if (properties.property("pulseMin").isValid()) {
-        setPulseMin(properties.property("pulseMin").toVariant().toFloat());
+    if (properties["pulseMin"].isValid()) {
+        setPulseMin(properties["pulseMin"].toFloat());
     }
 
-    if (properties.property("pulsePeriod").isValid()) {
-        setPulsePeriod(properties.property("pulsePeriod").toVariant().toFloat());
+    if (properties["pulsePeriod"].isValid()) {
+        setPulsePeriod(properties["pulsePeriod"].toFloat());
     }
     
-    if (properties.property("glowLevelPulse").isValid()) {
-        setGlowLevelPulse(properties.property("glowLevelPulse").toVariant().toFloat());
+    if (properties["glowLevelPulse"].isValid()) {
+        setGlowLevelPulse(properties["glowLevelPulse"].toFloat());
     }
     
-    if (properties.property("alphaPulse").isValid()) {
-        setAlphaPulse(properties.property("alphaPulse").toVariant().toFloat());
+    if (properties["alphaPulse"].isValid()) {
+        setAlphaPulse(properties["alphaPulse"].toFloat());
     }
 
-    if (properties.property("colorPulse").isValid()) {
-        setColorPulse(properties.property("colorPulse").toVariant().toFloat());
+    if (properties["colorPulse"].isValid()) {
+        setColorPulse(properties["colorPulse"].toFloat());
     }
 
-    if (properties.property("visible").isValid()) {
-        bool visible = properties.property("visible").toVariant().toBool();
+    if (properties["visible"].isValid()) {
+        bool visible = properties["visible"].toBool();
         setVisible(visible);
     }
     
-    if (properties.property("anchor").isValid()) {
-        QString property = properties.property("anchor").toVariant().toString();
+    if (properties["anchor"].isValid()) {
+        QString property = properties["anchor"].toString();
         if (property == "MyAvatar") {
             setAnchor(MY_AVATAR);
         }
     }
 }
 
-QScriptValue Overlay::getProperty(const QString& property) {
+QVariant Overlay::getProperty(const QString& property) {
     if (property == "color") {
-        return xColorToScriptValue(_scriptEngine, _color);
+        return xColorToVariant(_color);
     }
     if (property == "alpha") {
         return _alpha;
@@ -148,7 +146,7 @@ QScriptValue Overlay::getProperty(const QString& property) {
         return _anchor == MY_AVATAR ? "MyAvatar" : "";
     }
 
-    return QScriptValue();
+    return QVariant();
 }
 
 xColor Overlay::getColor() { 

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -15,9 +15,6 @@
 #include <SharedUtil.h> // for xColor
 #include <render/Scene.h>
 
-class QScriptEngine;
-class QScriptValue;
-
 class Overlay : public QObject {
     Q_OBJECT
     
@@ -34,7 +31,6 @@ public:
     Overlay();
     Overlay(const Overlay* overlay);
     ~Overlay();
-    void init(QScriptEngine* scriptEngine);
     virtual void update(float deltatime) {}
     virtual void render(RenderArgs* args) = 0;
     
@@ -82,9 +78,9 @@ public:
     void setColorPulse(float value) { _colorPulse = value; }
     void setAlphaPulse(float value) { _alphaPulse = value; }
 
-    virtual void setProperties(const QScriptValue& properties);
+    virtual void setProperties(const QVariantMap& properties);
     virtual Overlay* createClone() const = 0;
-    virtual QScriptValue getProperty(const QString& property);
+    virtual QVariant getProperty(const QString& property);
 
     render::ItemID getRenderItemID() const { return _renderItemID; }
     void setRenderItemID(render::ItemID renderItemID) { _renderItemID = renderItemID; }
@@ -112,8 +108,6 @@ protected:
     xColor _color;
     bool _visible; // should the overlay be drawn at all
     Anchor _anchor;
-
-    QScriptEngine* _scriptEngine;
 };
 
 namespace render {

--- a/interface/src/ui/overlays/Overlay2D.cpp
+++ b/interface/src/ui/overlays/Overlay2D.cpp
@@ -23,49 +23,44 @@ AABox Overlay2D::getBounds() const {
                  glm::vec3(_bounds.width(), _bounds.height(), 0.01f));
 }
 
-void Overlay2D::setProperties(const QScriptValue& properties) {
+void Overlay2D::setProperties(const QVariantMap& properties) {
     Overlay::setProperties(properties);
     
-    QScriptValue bounds = properties.property("bounds");
+    auto bounds = properties["bounds"];
     if (bounds.isValid()) {
-        QRect boundsRect;
-        boundsRect.setX(bounds.property("x").toVariant().toInt());
-        boundsRect.setY(bounds.property("y").toVariant().toInt());
-        boundsRect.setWidth(bounds.property("width").toVariant().toInt());
-        boundsRect.setHeight(bounds.property("height").toVariant().toInt());
-        setBounds(boundsRect);
+        bool valid;
+        auto rect = qRectFromVariant(bounds, valid);
+        setBounds(rect);
     } else {
         QRect oldBounds = _bounds;
         QRect newBounds = oldBounds;
-        
-        if (properties.property("x").isValid()) {
-            newBounds.setX(properties.property("x").toVariant().toInt());
+        if (properties["x"].isValid()) {
+            newBounds.setX(properties["x"].toInt());
         } else {
             newBounds.setX(oldBounds.x());
         }
-        if (properties.property("y").isValid()) {
-            newBounds.setY(properties.property("y").toVariant().toInt());
+        if (properties["y"].isValid()) {
+            newBounds.setY(properties["y"].toInt());
         } else {
             newBounds.setY(oldBounds.y());
         }
-        if (properties.property("width").isValid()) {
-            newBounds.setWidth(properties.property("width").toVariant().toInt());
+        if (properties["width"].isValid()) {
+            newBounds.setWidth(properties["width"].toInt());
         } else {
             newBounds.setWidth(oldBounds.width());
         }
-        if (properties.property("height").isValid()) {
-            newBounds.setHeight(properties.property("height").toVariant().toInt());
+        if (properties["height"].isValid()) {
+            newBounds.setHeight(properties["height"].toInt());
         } else {
             newBounds.setHeight(oldBounds.height());
         }
         setBounds(newBounds);
-        //qDebug() << "set bounds to " << getBounds();
     }
 }
 
-QScriptValue Overlay2D::getProperty(const QString& property) {
+QVariant Overlay2D::getProperty(const QString& property) {
     if (property == "bounds") {
-        return qRectToScriptValue(_scriptEngine, _bounds);
+        return qRectToVariant(_bounds);
     }
     if (property == "x") {
         return _bounds.x();

--- a/interface/src/ui/overlays/Overlay2D.h
+++ b/interface/src/ui/overlays/Overlay2D.h
@@ -40,8 +40,8 @@ public:
     void setHeight(int height) { _bounds.setHeight(height); }
     void setBounds(const QRect& bounds) { _bounds = bounds; }
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
 protected:
     QRect _bounds; // where on the screen to draw

--- a/interface/src/ui/overlays/OverlayPanel.cpp
+++ b/interface/src/ui/overlays/OverlayPanel.cpp
@@ -26,26 +26,27 @@ PropertyBinding::PropertyBinding(QString avatar, QUuid entity) :
 {
 }
 
-QScriptValue propertyBindingToScriptValue(QScriptEngine* engine, const PropertyBinding& value) {
-    QScriptValue obj = engine->newObject();
+QVariant propertyBindingToVariant(const PropertyBinding& value) {
+    QVariantMap obj;
 
     if (value.avatar == "MyAvatar") {
-        obj.setProperty("avatar", "MyAvatar");
+        obj["avatar"] = "MyAvatar";
     } else if (!value.entity.isNull()) {
-        obj.setProperty("entity", engine->newVariant(value.entity));
+        obj["entity"] = value.entity;
     }
 
     return obj;
 }
 
-void propertyBindingFromScriptValue(const QScriptValue& object, PropertyBinding& value) {
-    QScriptValue avatar = object.property("avatar");
-    QScriptValue entity = object.property("entity");
+void propertyBindingFromVariant(const QVariant& objectVar, PropertyBinding& value) {
+    auto object = objectVar.toMap();
+    auto avatar = object["avatar"];
+    auto entity = object["entity"];
 
     if (avatar.isValid() && !avatar.isNull()) {
-        value.avatar = avatar.toVariant().toString();
+        value.avatar = avatar.toString();
     } else if (entity.isValid() && !entity.isNull()) {
-        value.entity = entity.toVariant().toUuid();
+        value.entity = entity.toUuid();
     }
 }
 
@@ -62,103 +63,82 @@ void OverlayPanel::removeChild(unsigned int childId) {
     }
 }
 
-QScriptValue OverlayPanel::getProperty(const QString &property) {
+QVariant OverlayPanel::getProperty(const QString &property) {
     if (property == "anchorPosition") {
-        return vec3toScriptValue(_scriptEngine, getAnchorPosition());
+        return vec3toVariant(getAnchorPosition());
     }
     if (property == "anchorPositionBinding") {
-        return propertyBindingToScriptValue(_scriptEngine,
-                                            PropertyBinding(_anchorPositionBindMyAvatar ?
+        return propertyBindingToVariant(PropertyBinding(_anchorPositionBindMyAvatar ?
                                                             "MyAvatar" : "",
                                                             _anchorPositionBindEntity));
     }
     if (property == "anchorRotation") {
-        return quatToScriptValue(_scriptEngine, getAnchorRotation());
+        return quatToVariant(getAnchorRotation());
     }
     if (property == "anchorRotationBinding") {
-        return propertyBindingToScriptValue(_scriptEngine,
-                                            PropertyBinding(_anchorRotationBindMyAvatar ?
+        return propertyBindingToVariant(PropertyBinding(_anchorRotationBindMyAvatar ?
                                                             "MyAvatar" : "",
                                                             _anchorRotationBindEntity));
     }
     if (property == "anchorScale") {
-        return vec3toScriptValue(_scriptEngine, getAnchorScale());
+        return vec3toVariant(getAnchorScale());
     }
     if (property == "visible") {
         return getVisible();
     }
     if (property == "children") {
-        QScriptValue array = _scriptEngine->newArray(_children.length());
+        QVariantList array;
         for (int i = 0; i < _children.length(); i++) {
-            array.setProperty(i, _children[i]);
+            array.append(_children[i]);
         }
         return array;
     }
 
-    QScriptValue value = Billboardable::getProperty(_scriptEngine, property);
+    auto value = Billboardable::getProperty(property);
     if (value.isValid()) {
         return value;
     }
-    return PanelAttachable::getProperty(_scriptEngine, property);
+    return PanelAttachable::getProperty(property);
 }
 
-void OverlayPanel::setProperties(const QScriptValue &properties) {
+void OverlayPanel::setProperties(const QVariantMap& properties) {
     PanelAttachable::setProperties(properties);
     Billboardable::setProperties(properties);
 
-    QScriptValue anchorPosition = properties.property("anchorPosition");
-    if (anchorPosition.isValid() &&
-        anchorPosition.property("x").isValid() &&
-        anchorPosition.property("y").isValid() &&
-        anchorPosition.property("z").isValid()) {
-        glm::vec3 newPosition;
-        vec3FromScriptValue(anchorPosition, newPosition);
-        setAnchorPosition(newPosition);
+    auto anchorPosition = properties["anchorPosition"];
+    if (anchorPosition.isValid()) {
+        setAnchorPosition(vec3FromVariant(anchorPosition));
     }
 
-    QScriptValue anchorPositionBinding = properties.property("anchorPositionBinding");
+    auto anchorPositionBinding = properties["anchorPositionBinding"];
     if (anchorPositionBinding.isValid()) {
         PropertyBinding binding = {};
-        propertyBindingFromScriptValue(anchorPositionBinding, binding);
+        propertyBindingFromVariant(anchorPositionBinding, binding);
         _anchorPositionBindMyAvatar = binding.avatar == "MyAvatar";
         _anchorPositionBindEntity = binding.entity;
     }
 
-    QScriptValue anchorRotation = properties.property("anchorRotation");
-    if (anchorRotation.isValid() &&
-        anchorRotation.property("x").isValid() &&
-        anchorRotation.property("y").isValid() &&
-        anchorRotation.property("z").isValid() &&
-        anchorRotation.property("w").isValid()) {
-        glm::quat newRotation;
-        quatFromScriptValue(anchorRotation, newRotation);
-        setAnchorRotation(newRotation);
+    auto anchorRotation = properties["anchorRotation"];
+    if (anchorRotation.isValid()) {
+        setAnchorRotation(quatFromVariant(anchorRotation));
     }
 
-    QScriptValue anchorRotationBinding = properties.property("anchorRotationBinding");
+    auto anchorRotationBinding = properties["anchorRotationBinding"];
     if (anchorRotationBinding.isValid()) {
         PropertyBinding binding = {};
-        propertyBindingFromScriptValue(anchorPositionBinding, binding);
+        propertyBindingFromVariant(anchorPositionBinding, binding);
         _anchorRotationBindMyAvatar = binding.avatar == "MyAvatar";
         _anchorRotationBindEntity = binding.entity;
     }
 
-    QScriptValue anchorScale = properties.property("anchorScale");
+    auto anchorScale = properties["anchorScale"];
     if (anchorScale.isValid()) {
-        if (anchorScale.property("x").isValid() &&
-            anchorScale.property("y").isValid() &&
-            anchorScale.property("z").isValid()) {
-            glm::vec3 newScale;
-            vec3FromScriptValue(anchorScale, newScale);
-            setAnchorScale(newScale);
-        } else {
-            setAnchorScale(anchorScale.toVariant().toFloat());
-        }
+        setAnchorScale(vec3FromVariant(anchorScale));
     }
 
-    QScriptValue visible = properties.property("visible");
+    auto visible = properties["visible"];
     if (visible.isValid()) {
-        setVisible(visible.toVariant().toBool());
+        setVisible(visible.toBool());
     }
 }
 

--- a/interface/src/ui/overlays/OverlayPanel.h
+++ b/interface/src/ui/overlays/OverlayPanel.h
@@ -16,7 +16,6 @@
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
-#include <QScriptValue>
 #include <QUuid>
 
 #include "PanelAttachable.h"
@@ -30,8 +29,8 @@ public:
     QUuid entity;
 };
 
-QScriptValue propertyBindingToScriptValue(QScriptEngine* engine, const PropertyBinding& value);
-void propertyBindingFromScriptValue(const QScriptValue& object, PropertyBinding& value);
+QVariant propertyBindingToVariant(const PropertyBinding& value);
+void propertyBindingFromVariant(const QVariant& object, PropertyBinding& value);
 
 
 class OverlayPanel : public QObject, public PanelAttachable, public Billboardable {
@@ -60,8 +59,8 @@ public:
     void removeChild(unsigned int childId);
     unsigned int popLastChild() { return _children.takeLast(); }
 
-    QScriptValue getProperty(const QString& property);
-    void setProperties(const QScriptValue& properties);
+    void setProperties(const QVariantMap& properties);
+    QVariant getProperty(const QString& property);
 
     virtual void applyTransformTo(Transform& transform, bool force = false);
 

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -31,7 +31,7 @@ class PickRay;
 class OverlayPropertyResult {
 public:
     OverlayPropertyResult();
-    QScriptValue value;
+    QVariant value;
 };
 
 Q_DECLARE_METATYPE(OverlayPropertyResult);
@@ -75,7 +75,7 @@ public:
 
 public slots:
     /// adds an overlay with the specific properties
-    unsigned int addOverlay(const QString& type, const QScriptValue& properties);
+    unsigned int addOverlay(const QString& type, const QVariant& properties);
 
     /// adds an overlay that's already been created
     unsigned int addOverlay(Overlay* overlay) { return addOverlay(Overlay::Pointer(overlay)); }
@@ -86,7 +86,7 @@ public slots:
 
     /// edits an overlay updating only the included properties, will return the identified OverlayID in case of
     /// successful edit, if the input id is for an unknown overlay this function will have no effect
-    bool editOverlay(unsigned int id, const QScriptValue& properties);
+    bool editOverlay(unsigned int id, const QVariant& properties);
 
     /// deletes a particle
     void deleteOverlay(unsigned int id);
@@ -122,10 +122,10 @@ public slots:
     unsigned int addPanel(OverlayPanel::Pointer panel);
 
     /// creates and adds a panel based on a set of properties
-    unsigned int addPanel(const QScriptValue& properties);
+    unsigned int addPanel(const QVariant& properties);
 
     /// edit the properties of a panel
-    void editPanel(unsigned int panelId, const QScriptValue& properties);
+    void editPanel(unsigned int panelId, const QVariant& properties);
 
     /// get a property of a panel
     OverlayPropertyResult getPanelProperty(unsigned int panelId, const QString& property);

--- a/interface/src/ui/overlays/OverlaysPayload.cpp
+++ b/interface/src/ui/overlays/OverlaysPayload.cpp
@@ -8,8 +8,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <QScriptValueIterator>
-
 #include <limits>
 #include <typeinfo>
 

--- a/interface/src/ui/overlays/PanelAttachable.cpp
+++ b/interface/src/ui/overlays/PanelAttachable.cpp
@@ -23,52 +23,37 @@ bool PanelAttachable::getParentVisible() const {
     }
 }
 
-QScriptValue PanelAttachable::getProperty(QScriptEngine* scriptEngine, const QString &property) {
+QVariant PanelAttachable::getProperty(const QString& property) {
     if (property == "offsetPosition") {
-        return vec3toScriptValue(scriptEngine, getOffsetPosition());
+        return vec3toVariant(getOffsetPosition());
     }
     if (property == "offsetRotation") {
-        return quatToScriptValue(scriptEngine, getOffsetRotation());
+        return quatToVariant(getOffsetRotation());
     }
     if (property == "offsetScale") {
-        return vec3toScriptValue(scriptEngine, getOffsetScale());
+        return vec3toVariant(getOffsetScale());
     }
-    return QScriptValue();
+    return QVariant();
 }
 
-void PanelAttachable::setProperties(const QScriptValue &properties) {
-    QScriptValue offsetPosition = properties.property("offsetPosition");
-    if (offsetPosition.isValid() &&
-        offsetPosition.property("x").isValid() &&
-        offsetPosition.property("y").isValid() &&
-        offsetPosition.property("z").isValid()) {
-        glm::vec3 newPosition;
-        vec3FromScriptValue(offsetPosition, newPosition);
-        setOffsetPosition(newPosition);
-    }
-
-    QScriptValue offsetRotation = properties.property("offsetRotation");
-    if (offsetRotation.isValid() &&
-        offsetRotation.property("x").isValid() &&
-        offsetRotation.property("y").isValid() &&
-        offsetRotation.property("z").isValid() &&
-        offsetRotation.property("w").isValid()) {
-        glm::quat newRotation;
-        quatFromScriptValue(offsetRotation, newRotation);
-        setOffsetRotation(newRotation);
-    }
-
-    QScriptValue offsetScale = properties.property("offsetScale");
-    if (offsetScale.isValid()) {
-        if (offsetScale.property("x").isValid() &&
-            offsetScale.property("y").isValid() &&
-            offsetScale.property("z").isValid()) {
-            glm::vec3 newScale;
-            vec3FromScriptValue(offsetScale, newScale);
-            setOffsetScale(newScale);
-        } else {
-            setOffsetScale(offsetScale.toVariant().toFloat());
+void PanelAttachable::setProperties(const QVariantMap& properties) {
+    auto offsetPosition = properties["offsetPosition"];
+    bool valid;
+    if (offsetPosition.isValid()) {
+        glm::vec3 newPosition = vec3FromVariant(offsetPosition, valid);
+        if (valid) {
+            setOffsetPosition(newPosition);
         }
+    }
+
+    auto offsetRotation = properties["offsetRotation"];
+    if (offsetRotation.isValid()) {
+        setOffsetRotation(quatFromVariant(offsetRotation));
+    }
+
+    auto offsetScale = properties["offsetScale"];
+    if (offsetScale.isValid()) {
+        setOffsetScale(vec3FromVariant(offsetScale));
     }
 }
 

--- a/interface/src/ui/overlays/PanelAttachable.h
+++ b/interface/src/ui/overlays/PanelAttachable.h
@@ -57,8 +57,8 @@ public:
     void setOffsetScale(const glm::vec3& scale) { _offset.setScale(scale); }
 
 protected:
-    QScriptValue getProperty(QScriptEngine* scriptEngine, const QString& property);
-    void setProperties(const QScriptValue& properties);
+    void setProperties(const QVariantMap& properties);
+    QVariant getProperty(const QString& property);
 
     /// set position, rotation and scale on transform based on offsets, and parent panel offsets
     /// if force is false, only apply transform if it hasn't been applied in the last .1 seconds

--- a/interface/src/ui/overlays/Planar3DOverlay.cpp
+++ b/interface/src/ui/overlays/Planar3DOverlay.cpp
@@ -35,57 +35,27 @@ AABox Planar3DOverlay::getBounds() const {
     return AABox(extents);
 }
 
-void Planar3DOverlay::setProperties(const QScriptValue& properties) {
+void Planar3DOverlay::setProperties(const QVariantMap& properties) {
     Base3DOverlay::setProperties(properties);
 
-    QScriptValue dimensions = properties.property("dimensions");
+    auto dimensions = properties["dimensions"];
 
     // if "dimensions" property was not there, check to see if they included aliases: scale
     if (!dimensions.isValid()) {
-        dimensions = properties.property("scale");
+        dimensions = properties["scale"];
         if (!dimensions.isValid()) {
-            dimensions = properties.property("size");
+            dimensions = properties["size"];
         }
     }
 
     if (dimensions.isValid()) {
-        bool validDimensions = false;
-        glm::vec2 newDimensions;
-
-        QScriptValue x = dimensions.property("x");
-        QScriptValue y = dimensions.property("y");
-
-        if (x.isValid() && y.isValid()) {
-            newDimensions.x = x.toVariant().toFloat();
-            newDimensions.y = y.toVariant().toFloat();
-            validDimensions = true;
-        } else {
-            QScriptValue width = dimensions.property("width");
-            QScriptValue height = dimensions.property("height");
-            if (width.isValid() && height.isValid()) {
-                newDimensions.x = width.toVariant().toFloat();
-                newDimensions.y = height.toVariant().toFloat();
-                validDimensions = true;
-            }
-        }
-
-        // size, scale, dimensions is special, it might just be a single scalar, check that here
-        if (!validDimensions && dimensions.isNumber()) {
-            float size = dimensions.toVariant().toFloat();
-            newDimensions.x = size;
-            newDimensions.y = size;
-            validDimensions = true;
-        }
-
-        if (validDimensions) {
-            setDimensions(newDimensions);
-        }
+        setDimensions(vec2FromVariant(dimensions));
     }
 }
 
-QScriptValue Planar3DOverlay::getProperty(const QString& property) {
+QVariant Planar3DOverlay::getProperty(const QString& property) {
     if (property == "dimensions" || property == "scale" || property == "size") {
-        return vec2toScriptValue(_scriptEngine, getDimensions());
+        return vec2toVariant(getDimensions());
     }
 
     return Base3DOverlay::getProperty(property);

--- a/interface/src/ui/overlays/Planar3DOverlay.h
+++ b/interface/src/ui/overlays/Planar3DOverlay.h
@@ -26,8 +26,8 @@ public:
     void setDimensions(float value) { _dimensions = glm::vec2(value); }
     void setDimensions(const glm::vec2& value) { _dimensions = value; }
     
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                         BoxFace& face, glm::vec3& surfaceNormal);

--- a/interface/src/ui/overlays/QmlOverlay.cpp
+++ b/interface/src/ui/overlays/QmlOverlay.cpp
@@ -57,7 +57,7 @@ QmlOverlay::~QmlOverlay() {
     }
 }
 
-void QmlOverlay::setProperties(const QScriptValue& properties) {
+void QmlOverlay::setProperties(const QVariantMap& properties) {
     Overlay2D::setProperties(properties);
     auto bounds = _bounds;
     std::weak_ptr<QQuickItem> weakQmlElement;
@@ -71,7 +71,7 @@ void QmlOverlay::setProperties(const QScriptValue& properties) {
             _qmlElement->setHeight(bounds.height());
         }
     });
-    QMetaObject::invokeMethod(_qmlElement.get(), "updatePropertiesFromScript", Q_ARG(QVariant, properties.toVariant()));
+    QMetaObject::invokeMethod(_qmlElement.get(), "updatePropertiesFromScript", Q_ARG(QVariant, properties));
 }
 
 void QmlOverlay::render(RenderArgs* args) {

--- a/interface/src/ui/overlays/QmlOverlay.h
+++ b/interface/src/ui/overlays/QmlOverlay.h
@@ -28,7 +28,7 @@ public:
     // Cannot fetch properties from QML based overlays due to race conditions
     bool supportsGetProperty() const override { return false; }
 
-    void setProperties(const QScriptValue& properties) override;
+    void setProperties(const QVariantMap& properties) override;
     void render(RenderArgs* args) override;
 
 private:

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -96,7 +96,7 @@ const render::ShapeKey Rectangle3DOverlay::getShapeKey() {
     return builder.build();
 }
 
-void Rectangle3DOverlay::setProperties(const QScriptValue &properties) {
+void Rectangle3DOverlay::setProperties(const QVariantMap& properties) {
     Planar3DOverlay::setProperties(properties);
 }
 

--- a/interface/src/ui/overlays/Rectangle3DOverlay.h
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.h
@@ -25,7 +25,7 @@ public:
     ~Rectangle3DOverlay();
     virtual void render(RenderArgs* args);
     virtual const render::ShapeKey getShapeKey() override;
-    virtual void setProperties(const QScriptValue& properties);
+    void setProperties(const QVariantMap& properties) override;
 
     virtual Rectangle3DOverlay* createClone() const;
 private:

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -121,57 +121,54 @@ const render::ShapeKey Text3DOverlay::getShapeKey() {
     return builder.build();
 }
 
-void Text3DOverlay::setProperties(const QScriptValue& properties) {
+void Text3DOverlay::setProperties(const QVariantMap& properties) {
     Billboard3DOverlay::setProperties(properties);
 
-    QScriptValue text = properties.property("text");
+    auto text = properties["text"];
     if (text.isValid()) {
-        setText(text.toVariant().toString());
+        setText(text.toString());
     }
 
-    QScriptValue textAlpha = properties.property("textAlpha");
+    auto textAlpha = properties["textAlpha"];
     if (textAlpha.isValid()) {
-        setTextAlpha(textAlpha.toVariant().toFloat());
+        setTextAlpha(textAlpha.toFloat());
     }
 
-    QScriptValue backgroundColor = properties.property("backgroundColor");
+    bool valid;
+    auto backgroundColor = properties["backgroundColor"];
     if (backgroundColor.isValid()) {
-        QScriptValue red = backgroundColor.property("red");
-        QScriptValue green = backgroundColor.property("green");
-        QScriptValue blue = backgroundColor.property("blue");
-        if (red.isValid() && green.isValid() && blue.isValid()) {
-            _backgroundColor.red = red.toVariant().toInt();
-            _backgroundColor.green = green.toVariant().toInt();
-            _backgroundColor.blue = blue.toVariant().toInt();
+        auto color = xColorFromVariant(backgroundColor, valid);
+        if (valid) {
+            _backgroundColor = color;
         }
     }
 
-    if (properties.property("backgroundAlpha").isValid()) {
-        setAlpha(properties.property("backgroundAlpha").toVariant().toFloat());
+    if (properties["backgroundAlpha"].isValid()) {
+        setAlpha(properties["backgroundAlpha"].toFloat());
     }
 
-    if (properties.property("lineHeight").isValid()) {
-        setLineHeight(properties.property("lineHeight").toVariant().toFloat());
+    if (properties["lineHeight"].isValid()) {
+        setLineHeight(properties["lineHeight"].toFloat());
     }
 
-    if (properties.property("leftMargin").isValid()) {
-        setLeftMargin(properties.property("leftMargin").toVariant().toFloat());
+    if (properties["leftMargin"].isValid()) {
+        setLeftMargin(properties["leftMargin"].toFloat());
     }
 
-    if (properties.property("topMargin").isValid()) {
-        setTopMargin(properties.property("topMargin").toVariant().toFloat());
+    if (properties["topMargin"].isValid()) {
+        setTopMargin(properties["topMargin"].toFloat());
     }
 
-    if (properties.property("rightMargin").isValid()) {
-        setRightMargin(properties.property("rightMargin").toVariant().toFloat());
+    if (properties["rightMargin"].isValid()) {
+        setRightMargin(properties["rightMargin"].toFloat());
     }
 
-    if (properties.property("bottomMargin").isValid()) {
-        setBottomMargin(properties.property("bottomMargin").toVariant().toFloat());
+    if (properties["bottomMargin"].isValid()) {
+        setBottomMargin(properties["bottomMargin"].toFloat());
     }
 }
 
-QScriptValue Text3DOverlay::getProperty(const QString& property) {
+QVariant Text3DOverlay::getProperty(const QString& property) {
     if (property == "text") {
         return _text;
     }
@@ -179,7 +176,7 @@ QScriptValue Text3DOverlay::getProperty(const QString& property) {
         return _textAlpha;
     }
     if (property == "backgroundColor") {
-        return xColorToScriptValue(_scriptEngine, _backgroundColor);
+        return xColorToVariant(_backgroundColor);
     }
     if (property == "backgroundAlpha") {
         return Billboard3DOverlay::getProperty("alpha");

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -53,8 +53,8 @@ public:
     void setRightMargin(float margin) { _rightMargin = margin; }
     void setBottomMargin(float margin) { _bottomMargin = margin; }
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     QSizeF textSize(const QString& test) const;  // Meters
 

--- a/interface/src/ui/overlays/Volume3DOverlay.cpp
+++ b/interface/src/ui/overlays/Volume3DOverlay.cpp
@@ -26,67 +26,27 @@ AABox Volume3DOverlay::getBounds() const {
     return AABox(extents);
 }
 
-void Volume3DOverlay::setProperties(const QScriptValue& properties) {
+void Volume3DOverlay::setProperties(const QVariantMap& properties) {
     Base3DOverlay::setProperties(properties);
 
-    QScriptValue dimensions = properties.property("dimensions");
+    auto dimensions = properties["dimensions"];
 
     // if "dimensions" property was not there, check to see if they included aliases: scale
     if (!dimensions.isValid()) {
-        dimensions = properties.property("scale");
+        dimensions = properties["scale"];
         if (!dimensions.isValid()) {
-            dimensions = properties.property("size");
+            dimensions = properties["size"];
         }
     }
 
     if (dimensions.isValid()) {
-        bool validDimensions = false;
-        glm::vec3 newDimensions;
-
-        QScriptValue x = dimensions.property("x");
-        QScriptValue y = dimensions.property("y");
-        QScriptValue z = dimensions.property("z");
-
-
-        if (x.isValid() && x.isNumber() &&
-            y.isValid() && y.isNumber() &&
-            z.isValid() && z.isNumber()) {
-            newDimensions.x = x.toNumber();
-            newDimensions.y = y.toNumber();
-            newDimensions.z = z.toNumber();
-            validDimensions = true;
-        } else {
-            QScriptValue width = dimensions.property("width");
-            QScriptValue height = dimensions.property("height");
-            QScriptValue depth = dimensions.property("depth");
-            if (width.isValid() && width.isNumber() &&
-                height.isValid() && height.isNumber() &&
-                depth.isValid() && depth.isNumber()) {
-                newDimensions.x = width.toNumber();
-                newDimensions.y = height.toNumber();
-                newDimensions.z = depth.toNumber();
-                validDimensions = true;
-            }
-        }
-
-        // size, scale, dimensions is special, it might just be a single scalar, check that here
-        if (!validDimensions && dimensions.isNumber()) {
-            float size = dimensions.toNumber();
-            newDimensions.x = size;
-            newDimensions.y = size;
-            newDimensions.z = size;
-            validDimensions = true;
-        }
-
-        if (validDimensions) {
-            setDimensions(newDimensions);
-        }
+        setDimensions(vec3FromVariant(dimensions));
     }
 }
 
-QScriptValue Volume3DOverlay::getProperty(const QString& property) {
+QVariant Volume3DOverlay::getProperty(const QString& property) {
     if (property == "dimensions" || property == "scale" || property == "size") {
-        return vec3toScriptValue(_scriptEngine, getDimensions());
+        return vec3toVariant(getDimensions());
     }
 
     return Base3DOverlay::getProperty(property);

--- a/interface/src/ui/overlays/Volume3DOverlay.h
+++ b/interface/src/ui/overlays/Volume3DOverlay.h
@@ -26,8 +26,8 @@ public:
     void setDimensions(float value) { _localBoundingBox.setBox(glm::vec3(-value / 2.0f), value); }
     void setDimensions(const glm::vec3& value) { _localBoundingBox.setBox(-value / 2.0f, value); }
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                         BoxFace& face, glm::vec3& surfaceNormal);

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -12,7 +12,6 @@
 
 #include "Web3DOverlay.h"
 
-#include <QtScript/QScriptValue>
 #include <QtGui/QOpenGLContext>
 #include <QtQuick/QQuickItem>
 
@@ -113,30 +112,34 @@ const render::ShapeKey Web3DOverlay::getShapeKey() {
     return builder.build();
 }
 
-void Web3DOverlay::setProperties(const QScriptValue &properties) {
+void Web3DOverlay::setProperties(const QVariantMap& properties) {
     Billboard3DOverlay::setProperties(properties);
 
-    QScriptValue urlValue = properties.property("url");
+    auto urlValue = properties["url"];
     if (urlValue.isValid()) {
-        QString newURL = urlValue.toVariant().toString();
+        QString newURL = urlValue.toString();
         if (newURL != _url) {
             setURL(newURL);
         }
     }
 
-    QScriptValue resolution = properties.property("resolution");
+    auto resolution = properties["resolution"];
     if (resolution.isValid()) {
-        vec2FromScriptValue(resolution, _resolution);
+        bool valid;
+        auto res = vec2FromVariant(resolution, valid);
+        if (valid) {
+            _resolution = res;
+        }
     }
 
 
-    QScriptValue dpi = properties.property("dpi");
+    auto dpi = properties["dpi"];
     if (dpi.isValid()) {
-        _dpi = dpi.toVariant().toFloat();
+        _dpi = dpi.toFloat();
     }
 }
 
-QScriptValue Web3DOverlay::getProperty(const QString& property) {
+QVariant Web3DOverlay::getProperty(const QString& property) {
     if (property == "url") {
         return _url;
     }

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -32,8 +32,8 @@ public:
     // setters
     void setURL(const QString& url);
 
-    virtual void setProperties(const QScriptValue& properties);
-    virtual QScriptValue getProperty(const QString& property);
+    void setProperties(const QVariantMap& properties) override;
+    QVariant getProperty(const QString& property) override;
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                         BoxFace& face, glm::vec3& surfaceNormal);

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -35,48 +35,71 @@ Q_DECLARE_METATYPE(AACube)
 
 void registerMetaTypes(QScriptEngine* engine);
 
+// Vec4
 QScriptValue vec4toScriptValue(QScriptEngine* engine, const glm::vec4& vec4);
 void vec4FromScriptValue(const QScriptValue& object, glm::vec4& vec4);
 
+// Vec3
 QScriptValue vec3toScriptValue(QScriptEngine* engine, const glm::vec3 &vec3);
 void vec3FromScriptValue(const QScriptValue &object, glm::vec3 &vec3);
 
+QVariant vec3toVariant(const glm::vec3 &vec3);
 glm::vec3 vec3FromVariant(const QVariant &object, bool& valid);
 glm::vec3 vec3FromVariant(const QVariant &object);
 
+// Vec2
 QScriptValue vec2toScriptValue(QScriptEngine* engine, const glm::vec2 &vec2);
 void vec2FromScriptValue(const QScriptValue &object, glm::vec2 &vec2);
 
+QVariant vec2toVariant(const glm::vec2 &vec2);
+glm::vec2 vec2FromVariant(const QVariant &object, bool& valid);
+glm::vec2 vec2FromVariant(const QVariant &object);
+
+// Quaternions
 QScriptValue quatToScriptValue(QScriptEngine* engine, const glm::quat& quat);
 void quatFromScriptValue(const QScriptValue &object, glm::quat& quat);
 
+QVariant quatToVariant(const glm::quat& quat);
 glm::quat quatFromVariant(const QVariant &object, bool& isValid);
 glm::quat quatFromVariant(const QVariant &object);
 
+// Rect
 QScriptValue qRectToScriptValue(QScriptEngine* engine, const QRect& rect);
 void qRectFromScriptValue(const QScriptValue& object, QRect& rect);
 
+QVariant qRectToVariant(const QRect& rect);
+QRect qRectFromVariant(const QVariant& object, bool& isValid);
+
+// xColor
 QScriptValue xColorToScriptValue(QScriptEngine* engine, const xColor& color);
 void xColorFromScriptValue(const QScriptValue &object, xColor& color);
 
+QVariant xColorToVariant(const xColor& color);
+xColor xColorFromVariant(const QVariant &object, bool& isValid);
+
+// QColor
 QScriptValue qColorToScriptValue(QScriptEngine* engine, const QColor& color);
 void qColorFromScriptValue(const QScriptValue& object, QColor& color);
 
 QScriptValue qURLToScriptValue(QScriptEngine* engine, const QUrl& url);
 void qURLFromScriptValue(const QScriptValue& object, QUrl& url);
 
+// vector<vec3>
 QScriptValue qVectorVec3ToScriptValue(QScriptEngine* engine, const QVector<glm::vec3>& vector);
 void qVectorVec3FromScriptValue(const QScriptValue& array, QVector<glm::vec3>& vector);
 QVector<glm::vec3> qVectorVec3FromScriptValue(const QScriptValue& array);
 
+// vector<quat>
 QScriptValue qVectorQuatToScriptValue(QScriptEngine* engine, const QVector<glm::quat>& vector);
 void qVectorQuatFromScriptValue(const QScriptValue& array, QVector<glm::quat>& vector);
 QVector<glm::quat> qVectorQuatFromScriptValue(const QScriptValue& array);
 
+// vector<bool>
 QScriptValue qVectorBoolToScriptValue(QScriptEngine* engine, const QVector<bool>& vector);
 void qVectorBoolFromScriptValue(const QScriptValue& array, QVector<bool>& vector);
 QVector<bool> qVectorBoolFromScriptValue(const QScriptValue& array);
 
+// vector<float>
 QScriptValue qVectorFloatToScriptValue(QScriptEngine* engine, const QVector<float>& vector);
 void qVectorFloatFromScriptValue(const QScriptValue& array, QVector<float>& vector);
 QVector<float> qVectorFloatFromScriptValue(const QScriptValue& array);


### PR DESCRIPTION
Right now many of our scripting interfaces are usable only from JS, even though there's little reason they shouldn't also be accessible from QML.  The primary blocker is that QML uses QJSEngine, not QScriptEngine, and therefore can't call any scripting function that is decorated with a type that can't be converted to or from a QJSValue or QVariant.  This means any function that takes arbitrary properties as a QScriptValue, or any function that includes a GLM type in the signature.

This PR modifies the Overlays scripting interface to use QVariant everywhere it was previously using QScriptValue.  This should enable overlays to be created by QML as well as JS.

This PR isn't critical for MVP nor associated with any Asana task, but is a stepping stone towards some overlay animation functionality I want to create in my personal domain.