### PR TITLE
Smooth particle trails

### DIFF
--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -103,6 +103,7 @@ EntityItemPointer ParticleEffectEntityItem::factory(const EntityItemID& entityID
 // our non-pure virtual subclass for now...
 ParticleEffectEntityItem::ParticleEffectEntityItem(const EntityItemID& entityItemID) :
     EntityItem(entityItemID),
+    _previousPosition(getPosition()),
     _lastSimulated(usecTimestampNow())
 {
     _type = EntityTypes::ParticleEffect;
@@ -623,7 +624,8 @@ void ParticleEffectEntityItem::stepSimulation(float deltaTime) {
             }
             
             // emit a new particle at tail index.
-            _particles.push_back(createParticle());
+            _particles.push_back(createParticle(glm::mix(_previousPosition, getPosition(),
+                (deltaTime - timeLeftInFrame) / deltaTime)));
             auto particle = _particles.back();
             particle.lifetime += timeLeftInFrame;
             
@@ -637,15 +639,16 @@ void ParticleEffectEntityItem::stepSimulation(float deltaTime) {
 
         _timeUntilNextEmit -= timeLeftInFrame;
     }
+    _previousPosition = getPosition();
 }
 
-ParticleEffectEntityItem::Particle ParticleEffectEntityItem::createParticle() {
+ParticleEffectEntityItem::Particle ParticleEffectEntityItem::createParticle(const glm::vec3& position) {
     Particle particle;
 
  
     particle.seed = randFloatInRange(-1.0f, 1.0f);
     if (getEmitterShouldTrail()) {
-        particle.position = getPosition();
+        particle.position = position;
     }
     // Position, velocity, and acceleration
     if (_polarStart == 0.0f && _polarFinish == 0.0f && _emitDimensions.z == 0.0f) {

--- a/libraries/entities/src/ParticleEffectEntityItem.h
+++ b/libraries/entities/src/ParticleEffectEntityItem.h
@@ -227,7 +227,7 @@ protected:
 
     bool isAnimatingSomething() const;
     
-    Particle createParticle();
+    Particle createParticle(const glm::vec3& position);
     void stepSimulation(float deltaTime);
     void integrateParticle(Particle& particle, float deltaTime);
     
@@ -275,7 +275,7 @@ protected:
     float _azimuthStart = DEFAULT_AZIMUTH_START;
     float _azimuthFinish = DEFAULT_AZIMUTH_FINISH;
     
-
+    glm::vec3 _previousPosition;
     quint64 _lastSimulated { 0 };
     bool _isEmitting { true };
 


### PR DESCRIPTION
Normally the trail following particles would only update position based on the position the frame was at. This caused for a huge stack of particles. This PR will fix that behavior by filling in the gaps between the previous and current position of the particle emitter.


## Testnotes:


- Run the following script:
  https://gist.githubusercontent.com/thoys/25c0e90dd418202ad83d/raw/9743ac16759ea17de6e57dc5808836f97ba96fc3/fingerFollowingParticles.js
- should create particles emitting from the fingers which will look like lines as they move. (use handcontrollers or walk around)

## Differences:

### Before:
![fd4c4fb518777265055d3198c434b9a3](https://cloud.githubusercontent.com/assets/607735/13199388/b10561a4-d824-11e5-927c-a4841e46cf0b.gif)


### After:
![20863a6c25241cca9e58558fe3d0b700](https://cloud.githubusercontent.com/assets/607735/13199384/7ba7cb28-d824-11e5-9413-bd43a1459bfd.gif)