### PR TITLE
various HMD fixes and improvements

### DIFF
--- a/examples/away.js
+++ b/examples/away.js
@@ -132,10 +132,22 @@ function maybeGoActive(event) {
     }
 }
 var wasHmdActive = false;
+var wasMouseCaptured = false;
 function maybeGoAway() {
     if (HMD.active !== wasHmdActive) {
         wasHmdActive = !wasHmdActive;
         if (wasHmdActive) {
+            goAway();
+        }
+    }
+
+    // If the mouse has gone from captured, to non-captured state,
+    // then it likely means the person is still in the HMD, but has
+    // tabbed away from the application (meaning they don't have mouse 
+    // control) and they likely want to go into an away state
+    if (Reticle.mouseCaptured !== wasMouseCaptured) {
+        wasMouseCaptured = !wasMouseCaptured;
+        if (!wasMouseCaptured) {
             goAway();
         }
     }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3906,16 +3906,8 @@ void Application::resetSensors(bool andReload) {
     DependencyManager::get<Faceshift>()->reset();
     DependencyManager::get<DdeFaceTracker>()->reset();
     DependencyManager::get<EyeTracker>()->reset();
-
     getActiveDisplayPlugin()->resetSensors();
-
-    QScreen* currentScreen = _window->windowHandle()->screen();
-    QWindow* mainWindow = _window->windowHandle();
-    QPoint windowCenter = mainWindow->geometry().center();
-    _glWidget->cursor().setPos(currentScreen, windowCenter);
-
     getMyAvatar()->reset(andReload);
-
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "reset", Qt::QueuedConnection);
 }
 

--- a/interface/src/ui/ApplicationCompositor.h
+++ b/interface/src/ui/ApplicationCompositor.h
@@ -101,9 +101,9 @@ public:
     void handleLeaveEvent();
     QPointF getMouseEventPosition(QMouseEvent* event);
 
+    bool shouldCaptureMouse() const;
 
 private:
-    bool shouldCaptureMouse() const;
 
     void displayOverlayTextureStereo(RenderArgs* renderArgs, float aspectRatio, float fov);
     void bindCursorTexture(gpu::Batch& batch, uint8_t cursorId = 0);
@@ -162,9 +162,12 @@ class ReticleInterface : public QObject {
     Q_PROPERTY(bool visible READ getVisible WRITE setVisible)
     Q_PROPERTY(float depth READ getDepth WRITE setDepth)
     Q_PROPERTY(glm::vec2 maximumPosition READ getMaximumPosition)
+    Q_PROPERTY(bool mouseCaptured READ isMouseCaptured)
 
 public:
     ReticleInterface(ApplicationCompositor* outer) : QObject(outer), _compositor(outer) {}
+
+    Q_INVOKABLE bool isMouseCaptured() { return _compositor->shouldCaptureMouse(); }
 
     Q_INVOKABLE bool getVisible() { return _compositor->getReticleVisible(); }
     Q_INVOKABLE void setVisible(bool visible) { _compositor->setReticleVisible(visible); }


### PR DESCRIPTION
Fixes included:
- don't move mouse to center of screen on reset sensors
- if in the HMD and you lose mouse capture, go into away mode