### PR TITLE
Fix a number of crashes / hangs on exit

### DIFF
--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -74,6 +74,7 @@ signals:
 public slots:
     void requestUpdate();
     void requestRender();
+    void onAboutToQuit();
 
 private:
     QObject* finishQmlLoad(std::function<void(QQmlContext*, QObject*)> f);

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -144,7 +144,12 @@ ScriptEngine::ScriptEngine(const QString& scriptContents, const QString& fileNam
 ScriptEngine::~ScriptEngine() {
     qCDebug(scriptengine) << "Script Engine shutting down (destructor) for script:" << getFilename();
 
-    DependencyManager::get<ScriptEngines>()->removeScriptEngine(this);
+    auto scriptEngines = DependencyManager::get<ScriptEngines>();
+    if (scriptEngines) {
+        scriptEngines->removeScriptEngine(this);
+    } else {
+        qCWarning(scriptengine) << "Script destroyed after ScriptEngines!";
+    }
 }
 
 void ScriptEngine::disconnectNonEssentialSignals() {


### PR DESCRIPTION
* ScriptEngine crash

I crashed inside the `ScriptEngine` destructor on shutdown and traced it back to the fact that the `ScriptEngines` instance (which manages each individual `ScriptEngine`) had already been destroyed.  I'm not sure how this engine managed to miss being destroyed by the shutdown process, but it apparently did.  I'm not sure if this is an order of processing `deleteLater()` messages issue or if the script was started late.

The issue is very hard to reproduce at will.  

The code change should at least prevent the null pointer exception on shutdown when this occurs.

* OBJReader deadlock

I found that i could sometimes deadlock the application on shutdown inside the OBJReader code, which was waiting on network signal that would never come, sometimes after the application instance was gone.

* QML surface shutdown crash

Depending on the order of events, the QML surface can attempt to call back an invalid slot after destruction.