### PR TITLE
Auto-unhide the desktop when showing or raising a window

### DIFF
--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -10,11 +10,18 @@ import "../js/Utils.js" as Utils
 // windows will be childed.
 FocusScope {
     id: desktop
-    anchors.fill: parent;
     objectName: "desktop"
+
+    // Allow the scale of the desktop to be changed without screwing up the size relative to the parent.
+    height: parent.height / scale
+    width: parent.width / scale
 
     onHeightChanged: d.repositionAll();
     onWidthChanged: d.repositionAll();
+
+    // Controls and windows can trigger this signal to ensure the desktop becomes visible
+    // when they're opened.
+    signal showDesktop();
 
     // Allows QML/JS to find the desktop through the parent chain
     property bool desktopRoot: true
@@ -217,6 +224,8 @@ FocusScope {
         }
 
         reposition(targetWindow);
+
+        showDesktop();
     }
 
     function reposition(item) {
@@ -314,7 +323,7 @@ FocusScope {
         enabled: DebugQML
         onTriggered: focusDebugger.visible = !focusDebugger.visible
     }
-
+    
 }
 
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1198,7 +1198,8 @@ void Application::initializeUi() {
     // OffscreenUi is a subclass of OffscreenQmlSurface specifically designed to
     // support the window management and scripting proxies for VR use
     offscreenUi->createDesktop(QString("hifi/Desktop.qml"));
-    
+    connect(offscreenUi.data(), &OffscreenUi::showDesktop, this, &Application::showDesktop);
+
     // FIXME either expose so that dialogs can set this themselves or
     // do better detection in the offscreen UI of what has focus
     offscreenUi->setNavigationFocused(false);
@@ -5126,5 +5127,11 @@ void Application::readArgumentsFromLocalSocket() {
     // If we received a message, try to open it as a URL
     if (message.length() > 0) {
         qApp->openUrl(QString::fromUtf8(message));
+    }
+}
+
+void Application::showDesktop() {
+    if (!_overlayConductor.getEnabled()) {
+        _overlayConductor.setEnabled(true);
     }
 }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -280,6 +280,7 @@ public slots:
     void runTests();
 
 private slots:
+    void showDesktop();
     void clearDomainOctreeDetails();
     void idle(uint64_t now);
     void aboutToQuit();

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -112,6 +112,7 @@ void OffscreenUi::create(QOpenGLContext* context) {
 }
 
 void OffscreenUi::show(const QUrl& url, const QString& name, std::function<void(QQmlContext*, QObject*)> f) {
+    emit showDesktop();
     QQuickItem* item = getRootItem()->findChild<QQuickItem*>(name);
     // First load?
     if (!item) {
@@ -127,6 +128,7 @@ void OffscreenUi::toggle(const QUrl& url, const QString& name, std::function<voi
     QQuickItem* item = getRootItem()->findChild<QQuickItem*>(name);
     // Already loaded?  
     if (item) {
+        emit showDesktop();
         item->setVisible(!item->isVisible());
         return;
     }
@@ -134,6 +136,7 @@ void OffscreenUi::toggle(const QUrl& url, const QString& name, std::function<voi
     load(url, f);
     item = getRootItem()->findChild<QQuickItem*>(name);
     if (item && !item->isVisible()) {
+        emit showDesktop();
         item->setVisible(true);
     }
 }
@@ -439,6 +442,8 @@ void OffscreenUi::createDesktop(const QUrl& url) {
     new VrMenu(this);
 
     new KeyboardFocusHack();
+
+    connect(_desktop, SIGNAL(showDesktop()), this, SLOT(showDesktop()));
 }
 
 QQuickItem* OffscreenUi::getDesktop() {

--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -106,6 +106,9 @@ public:
     // Compatibility with QInputDialog::getItem
     static QString getItem(void *ignored, const QString & title, const QString & label, const QStringList & items, int current = 0, bool editable = true, bool * ok = 0, Qt::WindowFlags flags = 0, Qt::InputMethodHints inputMethodHints = Qt::ImhNone);
 
+signals:
+    void showDesktop();
+
 private:
     QString fileDialog(const QVariantMap& properties);
 


### PR DESCRIPTION
When the overlay is hidden with the O key, using keyboard shortcuts to show the address bar or other dialogs currently fails to show the desktop.  This PR should allow users to bring the overlay desktop back with any keyboard shortcut intended to show a window.  