### PR TITLE
Use proper getter for model overlay scaling

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -45,7 +45,7 @@ void ModelOverlay::update(float deltatime) {
         _updateModel = false;
         
         _model.setSnapModelToCenter(true);
-        _model.setScale(getScale());
+        _model.setScale(getDimensions());
         _model.setRotation(getRotation());
         _model.setTranslation(getPosition());
         _model.setURL(_url);
@@ -82,22 +82,6 @@ void ModelOverlay::render(RenderArgs* args) {
     if (!_visible) {
         return;
     }
-
-    /*    
-    if (_model.isActive()) {
-        if (_model.isRenderable()) {
-            float glowLevel = getGlowLevel();
-            Glower* glower = NULL;
-            if (glowLevel > 0.0f) {
-                glower = new Glower(glowLevel);
-            }
-            _model.render(args, getAlpha());
-            if (glower) {
-                delete glower;
-            }
-        }
-    }
-    */
 }
 
 void ModelOverlay::setProperties(const QScriptValue &properties) {
@@ -107,9 +91,18 @@ void ModelOverlay::setProperties(const QScriptValue &properties) {
     
     Volume3DOverlay::setProperties(properties);
     
-    if (position != getPosition() || rotation != getRotation() || scale != getDimensions()) {
-        _model.setScaleToFit(true, getScale());
+    if (position != getPosition() || rotation != getRotation()) {
         _updateModel = true;
+    }
+
+    if (scale != getDimensions()) {
+        auto newScale = getDimensions();
+        if (newScale.x <= 0 || newScale.y <= 0 || newScale.z <= 0) {
+            setDimensions(scale);
+        } else {
+            _model.setScaleToFit(true, getDimensions());
+            _updateModel = true;
+        }
     }
     
     QScriptValue urlValue = properties.property("url");
@@ -140,7 +133,7 @@ QScriptValue ModelOverlay::getProperty(const QString& property) {
     if (property == "url") {
         return _url.toString();
     }
-    if (property == "dimensions") {
+    if (property == "dimensions" || property == "scale" || property == "size") {
         return vec3toScriptValue(_scriptEngine, _model.getScaleToFitDimensions());
     }
     if (property == "textures") {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -43,7 +43,7 @@ Model::Model(RigPointer rig, QObject* parent) :
     _rotation(),
     _scale(1.0f, 1.0f, 1.0f),
     _scaleToFit(false),
-    _scaleToFitDimensions(0.0f),
+    _scaleToFitDimensions(1.0f),
     _scaledToFit(false),
     _snapModelToRegistrationPoint(false),
     _snappedToRegistrationPoint(false),
@@ -907,6 +907,14 @@ void Model::setScaleToFit(bool scaleToFit, float largestDimension, bool forceRes
             _scaledToFit = false; // force rescaling
         }
     }
+}
+
+glm::vec3 Model::getScaleToFitDimensions() const {
+    if (_scaleToFitDimensions.y == FAKE_DIMENSION_PLACEHOLDER &&
+        _scaleToFitDimensions.z == FAKE_DIMENSION_PLACEHOLDER) {
+        return glm::vec3(_scaleToFitDimensions.x);
+    }
+    return _scaleToFitDimensions;
 }
 
 void Model::scaleToFit() {

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -197,7 +197,7 @@ public:
 
     /// enables/disables scale to fit behavior, the model will be automatically scaled to the specified largest dimension
     bool getIsScaledToFit() const { return _scaledToFit; } /// is model scaled to fit
-    const glm::vec3& getScaleToFitDimensions() const { return _scaleToFitDimensions; } /// the dimensions model is scaled to
+    glm::vec3 getScaleToFitDimensions() const; /// the dimensions model is scaled to, including inferred y/z
 
     void setCauterizeBones(bool flag) { _cauterizeBones = flag; }
     bool getCauterizeBones() const { return _cauterizeBones; }


### PR DESCRIPTION
- Adds getters for `scale`, `size` to the model overlay
- Use appropriate setter internally for model overlay (`getDimensions` instead of `getScale`)
- Initialize Model::_scaleToFitDimensions to a sane value (`1.0f`)