### PR TITLE
Consolidate stats for opaque/transparent/other

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -186,42 +186,29 @@ Item {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
                         visible: root.expanded;
-                        text: "\tItems Rendered Opaque: " + root.opaqueRendered +
-                            " / Translucent: " + root.translucentRendered +
-                            " / Shadow: " + root.shadowRendered +
-                            " / Other: " + root.otherRendered;
+                        text: "Items rendered / considered: " +
+                            root.itemRendered + " / " + root.itemConsidered;
                     }
                     Text {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
                         visible: root.expanded;
-                        text: "\tOpaque considered: " + root.opaqueConsidered +
-                            " / Out of view: " + root.opaqueOutOfView + 
-                            " / Too small: " + root.opaqueTooSmall;
+                        text: " out of view: " + root.itemOutOfView +
+                            " too small: " + root.itemTooSmall;
                     }
                     Text {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
                         visible: root.expanded;
-                        text: "\tShadow considered: " + root.shadowConsidered +
-                            " / Out of view: " + root.shadowOutOfView +
-                            " / Too small: " + root.shadowTooSmall;
+                        text: "Shadows rendered / considered: " +
+                            root.shadowRendered + " / " + root.shadowConsidered;
                     }
                     Text {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
                         visible: root.expanded;
-                        text: "\tTranslucent considered: " + root.translucentConsidered +
-                            " / Out of view: " + root.translucentOutOfView + 
-                            " / Too small: " + root.translucentTooSmall;
-                    }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
-                        visible: root.expanded;
-                        text: "\tOther considered: " + root.otherConsidered +
-                            " / Out of view: " + root.otherOutOfView + 
-                            " / Too small: " + root.otherTooSmall;
+                        text: " out of view: " + root.shadowOutOfView +
+                            " too small: " + root.shadowTooSmall;
                     }
                     Text {
                         color: root.fontColor;

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -342,22 +342,14 @@ void Stats::setRenderDetails(const RenderDetails& details) {
     STAT_UPDATE(triangles, details._trianglesRendered);
     STAT_UPDATE(materialSwitches, details._materialSwitches);
     if (_expanded) {
-        STAT_UPDATE(opaqueConsidered, (int)details._opaque._considered);
-        STAT_UPDATE(opaqueOutOfView, details._opaque._outOfView);
-        STAT_UPDATE(opaqueTooSmall, details._opaque._tooSmall);
-        STAT_UPDATE(opaqueRendered, (int)details._opaque._rendered);
-        STAT_UPDATE(shadowConsidered, (int)details._shadow._considered);
+        STAT_UPDATE(itemConsidered, details._item._considered);
+        STAT_UPDATE(itemOutOfView, details._item._outOfView);
+        STAT_UPDATE(itemTooSmall, details._item._tooSmall);
+        STAT_UPDATE(itemRendered, details._item._rendered);
+        STAT_UPDATE(shadowConsidered, details._shadow._considered);
         STAT_UPDATE(shadowOutOfView, details._shadow._outOfView);
         STAT_UPDATE(shadowTooSmall, details._shadow._tooSmall);
-        STAT_UPDATE(shadowRendered, (int)details._shadow._rendered);
-        STAT_UPDATE(translucentConsidered, (int)details._translucent._considered);
-        STAT_UPDATE(translucentOutOfView, details._translucent._outOfView);
-        STAT_UPDATE(translucentTooSmall, details._translucent._tooSmall);
-        STAT_UPDATE(translucentRendered, (int)details._translucent._rendered);
-        STAT_UPDATE(otherConsidered, (int)details._other._considered);
-        STAT_UPDATE(otherOutOfView, details._other._outOfView);
-        STAT_UPDATE(otherTooSmall, details._other._tooSmall);
-        STAT_UPDATE(otherRendered, (int)details._other._rendered);
+        STAT_UPDATE(shadowRendered, details._shadow._rendered);
     }
 }
 

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -59,22 +59,14 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, triangles, 0)
     STATS_PROPERTY(int, quads, 0)
     STATS_PROPERTY(int, materialSwitches, 0)
-    STATS_PROPERTY(int, opaqueConsidered, 0)
-    STATS_PROPERTY(int, opaqueOutOfView, 0)
-    STATS_PROPERTY(int, opaqueTooSmall, 0)
-    STATS_PROPERTY(int, opaqueRendered, 0)
+    STATS_PROPERTY(int, itemConsidered, 0)
+    STATS_PROPERTY(int, itemOutOfView, 0)
+    STATS_PROPERTY(int, itemTooSmall, 0)
+    STATS_PROPERTY(int, itemRendered, 0)
     STATS_PROPERTY(int, shadowConsidered, 0)
     STATS_PROPERTY(int, shadowOutOfView, 0)
     STATS_PROPERTY(int, shadowTooSmall, 0)
     STATS_PROPERTY(int, shadowRendered, 0)
-    STATS_PROPERTY(int, translucentConsidered, 0)
-    STATS_PROPERTY(int, translucentOutOfView, 0)
-    STATS_PROPERTY(int, translucentTooSmall, 0)
-    STATS_PROPERTY(int, translucentRendered, 0)
-    STATS_PROPERTY(int, otherConsidered, 0)
-    STATS_PROPERTY(int, otherOutOfView, 0)
-    STATS_PROPERTY(int, otherTooSmall, 0)
-    STATS_PROPERTY(int, otherRendered, 0)
     STATS_PROPERTY(QString, sendingMode, QString())
     STATS_PROPERTY(QString, packetStats, QString())
     STATS_PROPERTY(QString, lodStatus, QString())
@@ -145,22 +137,14 @@ signals:
     void trianglesChanged();
     void quadsChanged();
     void materialSwitchesChanged();
-    void opaqueConsideredChanged();
-    void opaqueOutOfViewChanged();
-    void opaqueTooSmallChanged();
-    void opaqueRenderedChanged();
+    void itemConsideredChanged();
+    void itemOutOfViewChanged();
+    void itemTooSmallChanged();
+    void itemRenderedChanged();
     void shadowConsideredChanged();
     void shadowOutOfViewChanged();
     void shadowTooSmallChanged();
     void shadowRenderedChanged();
-    void translucentConsideredChanged();
-    void translucentOutOfViewChanged();
-    void translucentTooSmallChanged();
-    void translucentRenderedChanged();
-    void otherConsideredChanged();
-    void otherOutOfViewChanged();
-    void otherTooSmallChanged();
-    void otherRenderedChanged();
     void sendingModeChanged();
     void packetStatsChanged();
     void lodStatusChanged();

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -56,7 +56,7 @@ RenderDeferredTask::RenderDeferredTask(CullFunctor cullFunctor) {
     // Fetch and cull the items from the scene
     auto sceneFilter = ItemFilter::Builder::visibleWorldItems().withoutLayered();
     const auto sceneSelection = addJob<FetchSpatialTree>("FetchSceneSelection", sceneFilter);
-    const auto culledSceneSelection = addJob<CullSpatialSelection>("CullSceneSelection", sceneSelection, cullFunctor, RenderDetails::OPAQUE_ITEM, sceneFilter);
+    const auto culledSceneSelection = addJob<CullSpatialSelection>("CullSceneSelection", sceneSelection, cullFunctor, RenderDetails::ITEM, sceneFilter);
 
     // Multi filter visible items into different buckets
     const int NUM_FILTERS = 3;

--- a/libraries/render-utils/src/RenderShadowTask.cpp
+++ b/libraries/render-utils/src/RenderShadowTask.cpp
@@ -108,7 +108,7 @@ RenderShadowTask::RenderShadowTask(CullFunctor cullFunctor) : Task(std::make_sha
     const auto fetchedItems = addJob<FetchItems>("FetchShadowMap");
 
     // CPU: Cull against KeyLight frustum (nearby viewing camera)
-    const auto culledItems = addJob<CullItems<RenderDetails::SHADOW_ITEM>>("CullShadowMap", fetchedItems, cullFunctor);
+    const auto culledItems = addJob<CullItems<RenderDetails::SHADOW>>("CullShadowMap", fetchedItems, cullFunctor);
 
     // CPU: Sort by pipeline
     const auto sortedShapes = addJob<PipelineSortShapes>("PipelineSortShadowSort", culledItems);

--- a/libraries/render/src/render/CullTask.cpp
+++ b/libraries/render/src/render/CullTask.cpp
@@ -28,7 +28,7 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
     RenderArgs* args = renderContext->args;
     ViewFrustum* frustum = args->_viewFrustum;
 
-    details._considered += inItems.size();
+    details._considered += (int)inItems.size();
     
     // Culling / LOD
     for (auto item : inItems) {
@@ -59,7 +59,7 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
             details._outOfView++;
         }
     }
-    details._rendered += outItems.size();
+    details._rendered += (int)outItems.size();
 }
 
 struct ItemBoundSort {
@@ -202,7 +202,7 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
     auto& scene = sceneContext->_scene;
 
     auto& details = args->_details.edit(_detailType);
-    details._considered += inSelection.numItems();
+    details._considered += (int)inSelection.numItems();
 
     // Eventually use a frozen frustum
     auto argFrustum = args->_viewFrustum;
@@ -325,7 +325,7 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
         }
     }
 
-    details._rendered += outItems.size();
+    details._rendered += (int)outItems.size();
 
 
     // Restore frustum if using the frozen one:

--- a/libraries/render/src/render/CullTask.h
+++ b/libraries/render/src/render/CullTask.h
@@ -138,7 +138,7 @@ namespace render {
             _cullFunctor{ cullFunctor } {}
 
         CullFunctor _cullFunctor;
-        RenderDetails::Type _detailType{ RenderDetails::OPAQUE_ITEM };
+        RenderDetails::Type _detailType{ RenderDetails::OTHER };
         ItemFilter _filter{ ItemFilter::Builder::opaqueShape().withoutLayered() };
 
         void configure(const Config& config);

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -35,36 +35,31 @@ class ShapePipeline;
 class RenderDetails {
 public:
     enum Type {
-        OPAQUE_ITEM,
-        SHADOW_ITEM,
-        TRANSLUCENT_ITEM,
-        OTHER_ITEM
+        ITEM,
+        SHADOW,
+        OTHER
     };
     
     struct Item {
-        size_t _considered = 0;
-        size_t _rendered = 0;
+        int _considered = 0;
         int _outOfView = 0;
         int _tooSmall = 0;
+        int _rendered = 0;
     };
     
     int _materialSwitches = 0;
     int _trianglesRendered = 0;
     
-    Item _opaque;
+    Item _item;
     Item _shadow;
-    Item _translucent;
     Item _other;
     
     Item& edit(Type type) {
         switch (type) {
-            case OPAQUE_ITEM:
-                return _opaque;
-            case SHADOW_ITEM:
+            case SHADOW:
                 return _shadow;
-            case TRANSLUCENT_ITEM:
-                return _translucent;
-            case OTHER_ITEM:
+            case ITEM:
+                return _item;
             default:
                 return _other;
         }


### PR DESCRIPTION
Fixes the Developer > Stats menu details.
The menu can be clicked on for more details on rendering. This consolidates opaque/transparent/other counters, to match the consolidation done by the octree in code.