### PR TITLE
verified domain ownership for full automatic networking

### DIFF
--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -236,10 +236,6 @@ OctreeServer::OctreeServer(ReceivedMessage& message) :
 {
     _averageLoopTime.updateAverage(0);
     qDebug() << "Octree server starting... [" << this << "]";
-
-    // make sure the AccountManager has an Auth URL for payment redemptions
-
-    AccountManager::getInstance().setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL);
 }
 
 OctreeServer::~OctreeServer() {

--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -778,7 +778,7 @@ function chooseFromHighFidelityDomains(clickedButton) {
 function createTemporaryDomain() {
   swal({
     title: 'Create temporary place name',
-    text: "This will create a temporary place name and domain ID (valid for 30 days)"
+    text: "This will create a temporary place name and domain ID"
       + " so other users can easily connect to your domain.</br></br>"
       + "In order to make your domain reachable, this will also enable full automatic networking.",
     showCancelButton: true,

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -331,7 +331,6 @@ bool DomainGatekeeper::verifyUserSignature(const QString& username,
                                                                 QCryptographicHash::Sha256);
         
         if (rsaPublicKey) {
-            QByteArray decryptedArray(RSA_size(rsaPublicKey), 0);
             int decryptResult = RSA_verify(NID_sha256,
                                            reinterpret_cast<const unsigned char*>(usernameWithToken.constData()),
                                            usernameWithToken.size(),

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -489,6 +489,10 @@ void DomainServer::setupICEHeartbeatForFullNetworking() {
     limitedNodeList->startSTUNPublicSocketUpdate();
 
     // to send ICE heartbeats we'd better have a private key locally with an uploaded public key
+    auto& accountManager = AccountManager::getInstance();
+    if (!accountManager.getAccountInfo().hasPrivateKey()) {
+        accountManager.generateNewDomainKeypair(limitedNodeList->getSessionUUID());
+    }
 
     if (!_iceHeartbeatTimer) {
         // setup a timer to heartbeat with the ice-server every so often

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -198,7 +198,6 @@ bool DomainServer::optionallySetupOAuth() {
     }
 
     AccountManager& accountManager = AccountManager::getInstance();
-    accountManager.disableSettingsFilePersistence();
     accountManager.setAuthURL(_oauthProviderURL);
 
     _oauthClientID = settingsMap.value(OAUTH_CLIENT_ID_OPTION).toString();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -349,7 +349,8 @@ void DomainServer::setupNodeListAndAssignments(const QUuid& sessionUUID) {
     // nodes will currently use this to add resources to data-web that relate to our domain
     const QVariant* idValueVariant = valueForKeyPath(settingsMap, METAVERSE_DOMAIN_ID_KEY_PATH);
     if (idValueVariant) {
-        nodeList->setSessionUUID(idValueVariant->toString());
+        QUuid domainID { idValueVariant->toString() };
+        nodeList->setSessionUUID(domainID);
     }
 
     connect(nodeList.data(), &LimitedNodeList::nodeAdded, this, &DomainServer::nodeAdded);
@@ -490,7 +491,8 @@ void DomainServer::setupICEHeartbeatForFullNetworking() {
 
     // to send ICE heartbeats we'd better have a private key locally with an uploaded public key
     auto& accountManager = AccountManager::getInstance();
-    if (!accountManager.getAccountInfo().hasPrivateKey()) {
+    auto domainID = accountManager.getAccountInfo().getDomainID();
+    if (!accountManager.getAccountInfo().hasPrivateKey() || domainID != limitedNodeList->getSessionUUID()) {
         accountManager.generateNewDomainKeypair(limitedNodeList->getSessionUUID());
     }
 

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1063,6 +1063,9 @@ void DomainServer::sendHeartbeatToIceServer() {
             qWarning() << "Cannot send an ice-server heartbeat without a private key for signature.";
             qWarning() << "Waiting for keypair generation to complete before sending ICE heartbeat.";
 
+            // hookup this slot to the signal from account manager that tells us when keypair is available
+            connect(&accountManager, &AccountManager::newKeypair, this, &DomainServer::sendHeartbeatToIceServer);
+
             if (!limitedNodeList->getSessionUUID().isNull()) {
                 accountManager.generateNewDomainKeypair(limitedNodeList->getSessionUUID());
             } else {
@@ -1076,7 +1079,7 @@ void DomainServer::sendHeartbeatToIceServer() {
         // QDataStream and the possibility of IPv6 address for the sockets.
         static auto heartbeatPacket = NLPacket::create(PacketType::ICEServerHeartbeat);
 
-        bool shouldRecreatePacket = false
+        bool shouldRecreatePacket = false;
 
         if (heartbeatPacket->getPayloadSize() > 0) {
             // if either of our sockets have changed we need to re-sign the heartbeat

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -110,7 +110,7 @@ DomainServer::DomainServer(int argc, char* argv[]) :
 
         // preload some user public keys so they can connect on first request
         _gatekeeper.preloadAllowedUserPublicKeys();
-        
+
         optionallyGetTemporaryName(args);
     }
 }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1099,7 +1099,7 @@ void DomainServer::sendHeartbeatToIceServer() {
             auto signature = accountManager.getAccountInfo().signPlaintext(plaintext);
 
             // pack the signature with the data
-            heartbeatDataStream << plaintext;
+            heartbeatDataStream << signature;
         }
 
         // send the heartbeat packet to the ice server now

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -492,6 +492,7 @@ void DomainServer::setupICEHeartbeatForFullNetworking() {
     // to send ICE heartbeats we'd better have a private key locally with an uploaded public key
     auto& accountManager = AccountManager::getInstance();
     auto domainID = accountManager.getAccountInfo().getDomainID();
+
     if (!accountManager.getAccountInfo().hasPrivateKey() || domainID != limitedNodeList->getSessionUUID()) {
         accountManager.generateNewDomainKeypair(limitedNodeList->getSessionUUID());
     }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1055,6 +1055,8 @@ void DomainServer::sendHeartbeatToDataServer(const QString& networkAddress) {
 
 void DomainServer::sendHeartbeatToIceServer() {
     if (!_iceServerSocket.getAddress().isNull()) {
+        // NOTE: I'd love to specify the correct size for the packet here, but it's a little trickey with
+        // QDataStream and the possibility of IPv6 address for the sockets.
         static auto heartbeatPacket = NLPacket::create(PacketType::ICEServerHeartbeat);
 
         bool shouldRecreatePacket = false;

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -526,6 +526,8 @@ void DomainServer::setupICEHeartbeatForFullNetworking() {
     // we need this DS to know what our public IP is - start trying to figure that out now
     limitedNodeList->startSTUNPublicSocketUpdate();
 
+    // to send ICE heartbeats we'd better have a private key locally with an uploaded public key
+
     if (!_iceHeartbeatTimer) {
         // setup a timer to heartbeat with the ice-server every so often
         _iceHeartbeatTimer = new QTimer { this };

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -61,6 +61,7 @@ public slots:
     void processNodeJSONStatsPacket(QSharedPointer<ReceivedMessage> packetList, SharedNodePointer sendingNode);
     void processPathQueryPacket(QSharedPointer<ReceivedMessage> packet);
     void processNodeDisconnectRequestPacket(QSharedPointer<ReceivedMessage> message);
+    void processICEServerHeartbeatDenialPacket(QSharedPointer<ReceivedMessage> message);
     
 private slots:
     void aboutToQuit();

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -83,11 +83,9 @@ private:
     void setupNodeListAndAssignments(const QUuid& sessionUUID = QUuid::createUuid());
     bool optionallySetupOAuth();
     bool optionallyReadX509KeyAndCertificate();
-    bool optionallySetupAssignmentPayment();
 
     void optionallyGetTemporaryName(const QStringList& arguments);
 
-    bool didSetupAccountManagerWithAccessToken();
     bool resetAccountManagerAccessToken();
 
     void setupAutomaticNetworking();

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -79,6 +79,8 @@ private slots:
     void handleTempDomainError(QNetworkReply& requestReply);
 
     void queuedQuit(QString quitMessage, int exitCode);
+
+    void handleKeypairChange();
     
 private:
     void setupNodeListAndAssignments(const QUuid& sessionUUID = QUuid::createUuid());
@@ -152,6 +154,7 @@ private:
     DomainServerSettingsManager _settingsManager;
 
     HifiSockAddr _iceServerSocket;
+    std::unique_ptr<NLPacket> _iceServerHeartbeatPacket;
 
     QTimer* _iceHeartbeatTimer { nullptr }; // this looks like it dangles when created but it's parented to the DomainServer
     

--- a/ice-server/CMakeLists.txt
+++ b/ice-server/CMakeLists.txt
@@ -6,3 +6,17 @@ setup_hifi_project(Network)
 # link the shared hifi libraries
 link_hifi_libraries(embedded-webserver networking shared)
 package_libraries_for_deployment()
+
+# find OpenSSL
+find_package(OpenSSL REQUIRED)
+
+if (APPLE AND ${OPENSSL_INCLUDE_DIR} STREQUAL "/usr/include")
+  # this is a user on OS X using system OpenSSL, which is going to throw warnings since they're deprecating for their common crypto
+  message(WARNING "The found version of OpenSSL is the OS X system version. This will produce deprecation warnings."
+    "\nWe recommend you install a newer version (at least 1.0.1h) in a different directory and set OPENSSL_ROOT_DIR in your env so Cmake can find it.")
+endif ()
+
+include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+
+# append OpenSSL to our list of libraries to link
+target_link_libraries(${TARGET_NAME} ${OPENSSL_LIBRARIES})

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -237,8 +237,7 @@ void IceServer::publicKeyReplyFinished(QNetworkReply* reply) {
         if (responseObject[STATUS_KEY].toString() == SUCCESS_VALUE) {
             auto dataObject = responseObject[DATA_KEY].toObject();
             if (dataObject.contains(PUBLIC_KEY_KEY)) {
-                _domainPublicKeys.emplace(domainID,
-                                          QByteArray::fromBase64(dataObject[PUBLIC_KEY_KEY].toString().toUtf8()));
+                _domainPublicKeys[domainID] = QByteArray::fromBase64(dataObject[PUBLIC_KEY_KEY].toString().toUtf8());
             } else {
                 qWarning() << "There was no public key present in response for domain with ID" << domainID;
             }

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -9,13 +9,17 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <QTimer>
+#include "IceServer.h"
+
+#include <QtCore/QJsonDocument>
+#include <QtCore/QTimer>
+#include <QtNetwork/QNetworkReply>
+#include <QtNetwork/QNetworkRequest>
 
 #include <LimitedNodeList.h>
+#include <NetworkingConstants.h>
 #include <udt/PacketHeaders.h>
 #include <SharedUtil.h>
-
-#include "IceServer.h"
 
 const int CLEAR_INACTIVE_PEERS_INTERVAL_MSECS = 1 * 1000;
 const int PEER_SILENCE_THRESHOLD_MSECS = 5 * 1000;
@@ -70,9 +74,10 @@ void IceServer::processPacket(std::unique_ptr<udt::Packet> packet) {
         
         if (nlPacket->getType() == PacketType::ICEServerHeartbeat) {
             SharedNetworkPeer peer = addOrUpdateHeartbeatingPeer(*nlPacket);
-            
-            // so that we can send packets to the heartbeating peer when we need, we need to activate a socket now
-            peer->activateMatchingOrNewSymmetricSocket(nlPacket->getSenderSockAddr());
+            if (peer) {
+                // so that we can send packets to the heartbeating peer when we need, we need to activate a socket now
+                peer->activateMatchingOrNewSymmetricSocket(nlPacket->getSenderSockAddr());
+            }
         } else if (nlPacket->getType() == PacketType::ICEServerQuery) {
             QDataStream heartbeatStream(nlPacket.get());
             
@@ -114,31 +119,107 @@ SharedNetworkPeer IceServer::addOrUpdateHeartbeatingPeer(NLPacket& packet) {
     // pull the UUID, public and private sock addrs for this peer
     QUuid senderUUID;
     HifiSockAddr publicSocket, localSocket;
+    QByteArray signature;
 
     QDataStream heartbeatStream(&packet);
-    
-    heartbeatStream >> senderUUID;
-    heartbeatStream >> publicSocket >> localSocket;
+    heartbeatStream >> senderUUID >> publicSocket >> localSocket;
 
-    // make sure we have this sender in our peer hash
-    SharedNetworkPeer matchingPeer = _activePeers.value(senderUUID);
+    auto signedPlaintext = QByteArray::fromRawData(packet.getPayload(), heartbeatStream.device()->pos());
+    heartbeatStream >> signature;
 
-    if (!matchingPeer) {
-        // if we don't have this sender we need to create them now
-        matchingPeer = QSharedPointer<NetworkPeer>::create(senderUUID, publicSocket, localSocket);
-        _activePeers.insert(senderUUID, matchingPeer);
+    // make sure this is a verified heartbeat before performing any more processing
+    if (isVerifiedHeartbeat(senderUUID, signedPlaintext, signature)) {
+        // make sure we have this sender in our peer hash
+        SharedNetworkPeer matchingPeer = _activePeers.value(senderUUID);
 
-        qDebug() << "Added a new network peer" << *matchingPeer;
+        if (!matchingPeer) {
+            // if we don't have this sender we need to create them now
+            matchingPeer = QSharedPointer<NetworkPeer>::create(senderUUID, publicSocket, localSocket);
+            _activePeers.insert(senderUUID, matchingPeer);
+
+            qDebug() << "Added a new network peer" << *matchingPeer;
+        } else {
+            // we already had the peer so just potentially update their sockets
+            matchingPeer->setPublicSocket(publicSocket);
+            matchingPeer->setLocalSocket(localSocket);
+        }
+
+        // update our last heard microstamp for this network peer to now
+        matchingPeer->setLastHeardMicrostamp(usecTimestampNow());
+        
+        return matchingPeer;
     } else {
-        // we already had the peer so just potentially update their sockets
-        matchingPeer->setPublicSocket(publicSocket);
-        matchingPeer->setLocalSocket(localSocket);
+        // not verified, return the empty peer object
+        return SharedNetworkPeer();
     }
+}
 
-    // update our last heard microstamp for this network peer to now
-    matchingPeer->setLastHeardMicrostamp(usecTimestampNow());
+bool IceServer::isVerifiedHeartbeat(const QUuid& domainID, const QByteArray& plaintext, const QByteArray& signature) {
+    // check if we have a private key for this domain ID - if we do not then fire off the request for it
+    auto it = _domainPublicKeys.find(domainID);
+    if (it != _domainPublicKeys.end()) {
 
-    return matchingPeer;
+        return true;
+    } else {
+        // we don't have a public key for this domain so we can't verify this heartbeat
+        // ask the metaverse API for the right public key and return false to indicate that this is not verified
+        requestDomainPublicKey(domainID);
+
+        return false;
+    }
+}
+
+void IceServer::requestDomainPublicKey(const QUuid& domainID) {
+    // send a request to the metaverse API for the public key for this domain
+    QNetworkAccessManager* manager = new QNetworkAccessManager { this };
+    connect(manager, &QNetworkAccessManager::finished, this, &IceServer::publicKeyReplyFinished);
+
+    QUrl publicKeyURL { NetworkingConstants::METAVERSE_SERVER_URL };
+    QString publicKeyPath = QString("/api/v1/domains/%1/public_key").arg(uuidStringWithoutCurlyBraces(domainID));
+    publicKeyURL.setPath(publicKeyPath);
+
+    QNetworkRequest publicKeyRequest { publicKeyURL };
+    publicKeyRequest.setAttribute(QNetworkRequest::User, domainID);
+
+    qDebug() << "Requesting public key for domain with ID" << domainID;
+
+    manager->get(publicKeyRequest);
+}
+
+void IceServer::publicKeyReplyFinished(QNetworkReply* reply) {
+    // get the domain ID from the QNetworkReply attribute
+    QUuid domainID = reply->request().attribute(QNetworkRequest::User).toUuid();
+
+    if (reply->error() == QNetworkReply::NoError) {
+        // pull out the public key and store it for this domain
+
+        // the response should be JSON
+        QJsonDocument responseDocument = QJsonDocument::fromJson(reply->readAll());
+
+        static const QString DATA_KEY = "data";
+        static const QString PUBLIC_KEY_KEY = "public_key";
+        static const QString STATUS_KEY = "status";
+        static const QString SUCCESS_VALUE = "success";
+
+        auto responseObject = responseDocument.object();
+        if (responseObject[STATUS_KEY].toString() == SUCCESS_VALUE) {
+            auto dataObject = responseObject[DATA_KEY].toObject();
+            if (dataObject.contains(PUBLIC_KEY_KEY)) {
+                _domainPublicKeys.emplace(domainID,
+                                          QByteArray::fromBase64(dataObject[PUBLIC_KEY_KEY].toString().toUtf8()));
+            } else {
+                qWarning() << "There was no public key present in response for domain with ID" << domainID;
+            }
+        } else {
+            qWarning() << "The metaverse API did not return success for public key request for domain with ID" << domainID;
+        }
+
+    } else {
+        // there was a problem getting the public key for the domain
+        // log it since it will be re-requested on the next heartbeat
+
+        qWarning() << "Error retreiving public key for domain with ID" << domainID << "-" <<  reply->errorString();
+    }
 }
 
 void IceServer::sendPeerInformationPacket(const NetworkPeer& peer, const HifiSockAddr* destinationSockAddr) {

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -82,7 +82,7 @@ void IceServer::processPacket(std::unique_ptr<udt::Packet> packet) {
             } else {
                 // we couldn't verify this peer - respond back to them so they know they may need to perform keypair re-generation
                 static auto deniedPacket = NLPacket::create(PacketType::ICEServerHeartbeatDenied);
-                _serverSocket.writePacket(*deniedPacket, packet->getSenderSockAddr());
+                _serverSocket.writePacket(*deniedPacket, nlPacket->getSenderSockAddr());
             }
         } else if (nlPacket->getType() == PacketType::ICEServerQuery) {
             QDataStream heartbeatStream(nlPacket.get());

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -553,7 +553,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     connect(&domainHandler, SIGNAL(connectedToDomain(const QString&)), SLOT(updateWindowTitle()));
     connect(&domainHandler, SIGNAL(disconnectedFromDomain()), SLOT(updateWindowTitle()));
     connect(&domainHandler, SIGNAL(disconnectedFromDomain()), SLOT(clearDomainOctreeDetails()));
-    connect(&domainHandler, &DomainHandler::settingsReceived, this, &Application::domainSettingsReceived);
 
     // update our location every 5 seconds in the metaverse server, assuming that we are authenticated with one
     const qint64 DATA_SERVER_LOCATION_CHANGE_UPDATE_MSECS = 5 * 1000;
@@ -4502,33 +4501,6 @@ void Application::openUrl(const QUrl& url) {
             QDesktopServices::openUrl(url);
         }
     }
-}
-
-void Application::domainSettingsReceived(const QJsonObject& domainSettingsObject) {
-    // from the domain-handler, figure out the satoshi cost per voxel and per meter cubed
-    const QString VOXEL_SETTINGS_KEY = "voxels";
-    const QString PER_VOXEL_COST_KEY = "per-voxel-credits";
-    const QString PER_METER_CUBED_COST_KEY = "per-meter-cubed-credits";
-    const QString VOXEL_WALLET_UUID = "voxel-wallet";
-
-    const QJsonObject& voxelObject = domainSettingsObject[VOXEL_SETTINGS_KEY].toObject();
-
-    qint64 satoshisPerVoxel = 0;
-    qint64 satoshisPerMeterCubed = 0;
-    QUuid voxelWalletUUID;
-
-    if (!domainSettingsObject.isEmpty()) {
-        float perVoxelCredits = (float) voxelObject[PER_VOXEL_COST_KEY].toDouble();
-        float perMeterCubedCredits = (float) voxelObject[PER_METER_CUBED_COST_KEY].toDouble();
-
-        satoshisPerVoxel = (qint64) floorf(perVoxelCredits * SATOSHIS_PER_CREDIT);
-        satoshisPerMeterCubed = (qint64) floorf(perMeterCubedCredits * SATOSHIS_PER_CREDIT);
-
-        voxelWalletUUID = QUuid(voxelObject[VOXEL_WALLET_UUID].toString());
-    }
-
-    qCDebug(interfaceapp) << "Octree edits costs are" << satoshisPerVoxel << "per octree cell and" << satoshisPerMeterCubed << "per meter cubed";
-    qCDebug(interfaceapp) << "Destination wallet UUID for edit payments is" << voxelWalletUUID;
 }
 
 void Application::loadDialog() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -590,6 +590,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     connect(&accountManager, &AccountManager::usernameChanged, this, &Application::updateWindowTitle);
 
     // set the account manager's root URL and trigger a login request if we don't have the access token
+    accountManager.setIsAgent(true);
     accountManager.setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL);
     UserActivityLogger::getInstance().launch(applicationVersion());
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -223,7 +223,6 @@ signals:
     void svoImportRequested(const QString& url);
 
     void checkBackgroundDownloads();
-    void domainConnectionRefused(const QString& reason);
 
     void fullAvatarURLChanged(const QString& newValue, const QString& modelName);
 
@@ -291,8 +290,6 @@ private slots:
     void activeChanged(Qt::ApplicationState state);
 
     void domainSettingsReceived(const QJsonObject& domainSettingsObject);
-    void handleDomainConnectionDeniedPacket(QSharedPointer<ReceivedMessage> message);
-
     void notifyPacketVersionMismatch();
 
     void loadSettings();
@@ -472,7 +469,6 @@ private:
     typedef bool (Application::* AcceptURLMethod)(const QString &);
     static const QHash<QString, AcceptURLMethod> _acceptedExtensions;
 
-    QList<QString> _domainConnectionRefusals;
     glm::uvec2 _renderResolution;
 
     int _maxOctreePPS = DEFAULT_MAX_OCTREE_PPS;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -289,7 +289,6 @@ private slots:
 
     void activeChanged(Qt::ApplicationState state);
 
-    void domainSettingsReceived(const QJsonObject& domainSettingsObject);
     void notifyPacketVersionMismatch();
 
     void loadSettings();

--- a/interface/src/CrashHandler.cpp
+++ b/interface/src/CrashHandler.cpp
@@ -22,10 +22,7 @@
 #include <QStandardPaths>
 #include <QVBoxLayout>
 
-#include "DataServerAccountInfo.h"
 #include "Menu.h"
-
-Q_DECLARE_METATYPE(DataServerAccountInfo)
 
 static const QString RUNNING_MARKER_FILENAME = "Interface.running";
 
@@ -57,7 +54,7 @@ CrashHandler::Action CrashHandler::promptUserForAction() {
     layout->addWidget(label);
 
     QRadioButton* option1 = new QRadioButton("Reset all my settings");
-    QRadioButton* option2 = new QRadioButton("Reset my settings but retain login and avatar info.");
+    QRadioButton* option2 = new QRadioButton("Reset my settings but retain avatar info.");
     QRadioButton* option3 = new QRadioButton("Continue with my current settings");
     option3->setChecked(true);
     layout->addWidget(option1);
@@ -79,7 +76,7 @@ CrashHandler::Action CrashHandler::promptUserForAction() {
             return CrashHandler::DELETE_INTERFACE_INI;
         }
         if (option2->isChecked()) {
-            return CrashHandler::RETAIN_LOGIN_AND_AVATAR_INFO;
+            return CrashHandler::RETAIN_AVATAR_INFO;
         }
     }
 
@@ -88,7 +85,7 @@ CrashHandler::Action CrashHandler::promptUserForAction() {
 }
 
 void CrashHandler::handleCrash(CrashHandler::Action action) {
-    if (action != CrashHandler::DELETE_INTERFACE_INI && action != CrashHandler::RETAIN_LOGIN_AND_AVATAR_INFO) {
+    if (action != CrashHandler::DELETE_INTERFACE_INI && action != CrashHandler::RETAIN_AVATAR_INFO) {
         // CrashHandler::DO_NOTHING or unexpected value
         return;
     }
@@ -101,18 +98,13 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
     const QString DISPLAY_NAME_KEY = "displayName";
     const QString FULL_AVATAR_URL_KEY = "fullAvatarURL";
     const QString FULL_AVATAR_MODEL_NAME_KEY = "fullAvatarModelName";
-    const QString ACCOUNTS_GROUP = "accounts";
     QString displayName;
     QUrl fullAvatarURL;
     QString fullAvatarModelName;
     QUrl address;
-    QMap<QString, DataServerAccountInfo> accounts;
 
-    if (action == CrashHandler::RETAIN_LOGIN_AND_AVATAR_INFO) {
-        // Read login and avatar info
-
-        qRegisterMetaType<DataServerAccountInfo>("DataServerAccountInfo");
-        qRegisterMetaTypeStreamOperators<DataServerAccountInfo>("DataServerAccountInfo");
+    if (action == CrashHandler::RETAIN_AVATAR_INFO) {
+        // Read avatar info
 
         // Location and orientation
         settings.beginGroup(ADDRESS_MANAGER_GROUP);
@@ -125,13 +117,6 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
         fullAvatarURL = settings.value(FULL_AVATAR_URL_KEY).toUrl();
         fullAvatarModelName = settings.value(FULL_AVATAR_MODEL_NAME_KEY).toString();
         settings.endGroup();
-
-        // Accounts
-        settings.beginGroup(ACCOUNTS_GROUP);
-        foreach(const QString& key, settings.allKeys()) {
-            accounts.insert(key, settings.value(key).value<DataServerAccountInfo>());
-        }
-        settings.endGroup();
     }
 
     // Delete Interface.ini
@@ -140,8 +125,8 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
         settingsFile.remove();
     }
 
-    if (action == CrashHandler::RETAIN_LOGIN_AND_AVATAR_INFO) {
-        // Write login and avatar info
+    if (action == CrashHandler::RETAIN_AVATAR_INFO) {
+        // Write avatar info
 
         // Location and orientation
         settings.beginGroup(ADDRESS_MANAGER_GROUP);
@@ -153,13 +138,6 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
         settings.setValue(DISPLAY_NAME_KEY, displayName);
         settings.setValue(FULL_AVATAR_URL_KEY, fullAvatarURL);
         settings.setValue(FULL_AVATAR_MODEL_NAME_KEY, fullAvatarModelName);
-        settings.endGroup();
-
-        // Accounts
-        settings.beginGroup(ACCOUNTS_GROUP);
-        foreach(const QString& key, accounts.keys()) {
-            settings.setValue(key, QVariant::fromValue(accounts.value(key)));
-        }
         settings.endGroup();
     }
 }

--- a/interface/src/CrashHandler.h
+++ b/interface/src/CrashHandler.h
@@ -25,7 +25,7 @@ public:
 private:
     enum Action {
         DELETE_INTERFACE_INI,
-        RETAIN_LOGIN_AND_AVATAR_INFO,
+        RETAIN_AVATAR_INFO,
         DO_NOTHING
     };
 

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -25,7 +25,7 @@
 WindowScriptingInterface::WindowScriptingInterface() {
     const DomainHandler& domainHandler = DependencyManager::get<NodeList>()->getDomainHandler();
     connect(&domainHandler, &DomainHandler::connectedToDomain, this, &WindowScriptingInterface::domainChanged);
-    connect(qApp, &Application::domainConnectionRefused, this, &WindowScriptingInterface::domainConnectionRefused);
+    connect(&domainHandler, &DomainHandler::domainConnectionRefused, this, &WindowScriptingInterface::domainConnectionRefused);
 
     connect(qApp, &Application::svoImportRequested, [this](const QString& urlString) {
         static const QMetaMethod svoImportRequestedSignal =

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -169,14 +169,16 @@ void AccountManager::setAuthURL(const QUrl& authURL) {
         if (loadedFile) {
             // pull out the stored access token and store it in memory
             _accountInfo = accountsMap[_authURL.toString()].value<DataServerAccountInfo>();
-            
+
             qCDebug(networking) << "Found metaverse API account information for" << qPrintable(_authURL.toString());
 
-            // profile info isn't guaranteed to be saved too
-            if (_accountInfo.hasProfile()) {
-                emit profileChanged();
-            } else {
-                requestProfile();
+            if (_isAgent) {
+                // profile info isn't guaranteed to be saved too
+                if (_accountInfo.hasProfile()) {
+                    emit profileChanged();
+                } else {
+                    requestProfile();
+                }
             }
 
         } else {
@@ -327,7 +329,7 @@ void AccountManager::passSuccessToCallback(QNetworkReply* requestReply) {
 
     } else {
         if (VERBOSE_HTTP_REQUEST_DEBUGGING) {
-            qCDebug(networking) << "Received JSON response from data-server that has no matching callback.";
+            qCDebug(networking) << "Received JSON response from metaverse API that has no matching callback.";
             qCDebug(networking) << QJsonDocument::fromJson(requestReply->readAll());
         }
     }
@@ -345,7 +347,7 @@ void AccountManager::passErrorToCallback(QNetworkReply* requestReply) {
         _pendingCallbackMap.remove(requestReply);
     } else {
         if (VERBOSE_HTTP_REQUEST_DEBUGGING) {
-            qCDebug(networking) << "Received error response from data-server that has no matching callback.";
+            qCDebug(networking) << "Received error response from metaverse API that has no matching callback.";
             qCDebug(networking) << "Error" << requestReply->error() << "-" << requestReply->errorString();
             qCDebug(networking) << requestReply->readAll();
         }
@@ -591,7 +593,7 @@ void AccountManager::processGeneratedKeypair(const QByteArray& publicKey, const 
     
     qCDebug(networking) << "Generated 2048-bit RSA key-pair. Storing private key and uploading public key.";
     
-    // set the private key on our data-server account info
+    // set the private key on our metaverse API account info
     _accountInfo.setPrivateKey(privateKey);
     persistAccountToSettings();
     

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -589,6 +589,10 @@ void AccountManager::generateNewKeypair(bool isUserKeypair, const QUuid& domainI
         return;
     }
 
+    // clear the current private key
+    qDebug() << "Clearing current private key in DataServerAccountInfo";
+    _accountInfo.setPrivateKey(QByteArray());
+
     // setup a new QThread to generate the keypair on, in case it takes a while
     QThread* generateThread = new QThread(this);
     generateThread->setObjectName("Account Manager Generator Thread");

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -450,8 +450,12 @@ void AccountManager::setAccessTokenForCurrentAuthURL(const QString& accessToken)
     // replace the account info access token with a new OAuthAccessToken
     OAuthAccessToken newOAuthToken;
     newOAuthToken.token = accessToken;
-    
-    qCDebug(networking) << "Setting new account manager access token. F2C:" << accessToken.left(2) << "L2C:" << accessToken.right(2);
+
+    if (!accessToken.isEmpty()) {
+        qCDebug(networking) << "Setting new AccountManager OAuth token. F2C:" << accessToken.left(2) << "L2C:" << accessToken.right(2);
+    } else if (!_accountInfo.getAccessToken().token.isEmpty()) {
+        qCDebug(networking) << "Clearing AccountManager OAuth token.";
+    }
     
     _accountInfo.setAccessToken(newOAuthToken);
 
@@ -658,7 +662,7 @@ void AccountManager::processGeneratedKeypair() {
         callbackParameters.errorCallbackReceiver = this;
         callbackParameters.errorCallbackMethod = "publicKeyUploadFailed";
 
-        sendRequest(uploadPath, AccountManagerAuth::Required, QNetworkAccessManager::PutOperation,
+        sendRequest(uploadPath, AccountManagerAuth::Optional, QNetworkAccessManager::PutOperation,
                     callbackParameters, QByteArray(), requestMultiPart);
         
         keypairGenerator->deleteLater();

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -83,20 +83,6 @@ AccountManager::AccountManager() :
     connect(&_accountInfo, &DataServerAccountInfo::balanceChanged, this, &AccountManager::accountInfoBalanceChanged);
 }
 
-void AccountManager::setIsAgent(bool isAgent) {
-    if (_isAgent != isAgent) {
-        _isAgent = isAgent;
-
-        if (_isAgent) {
-            // any profile changes in account manager should generate a new keypair
-            connect(this, &AccountManager::profileChanged, this, &AccountManager::generateNewUserKeypair);
-        } else {
-            // disconnect the generation of a new keypair during profile changes
-            disconnect(this, &AccountManager::profileChanged, this, &AccountManager::generateNewUserKeypair);
-        }
-    }
-}
-
 const QString DOUBLE_SLASH_SUBSTITUTE = "slashslash";
 
 void AccountManager::logout() {
@@ -203,13 +189,9 @@ void AccountManager::setAuthURL(const QUrl& authURL) {
             }
         }
 
-        if (_isAgent && !_accountInfo.getAccessToken().token.isEmpty()) {
-            // profile info isn't guaranteed to be saved too
-            if (_accountInfo.hasProfile()) {
-                emit profileChanged();
-            } else {
-                requestProfile();
-            }
+        if (_isAgent && !_accountInfo.getAccessToken().token.isEmpty() && !_accountInfo.hasProfile()) {
+            // we are missing profile information, request it now
+            requestProfile();
         }
 
         // tell listeners that the auth endpoint has changed

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -588,6 +588,12 @@ void AccountManager::requestProfileError(QNetworkReply::NetworkError error) {
 }
 
 void AccountManager::generateNewKeypair(bool isUserKeypair, const QUuid& domainID) {
+
+    if (thread() != QThread::currentThread()) {
+        QMetaObject::invokeMethod(this, "generateNewKeypair", Q_ARG(bool, isUserKeypair), Q_ARG(QUuid, domainID));
+        return;
+    }
+
     if (!isUserKeypair && domainID.isNull()) {
         qCWarning(networking) << "AccountManager::generateNewKeypair called for domain keypair with no domain ID. Will not generate keypair.";
         return;

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -630,7 +630,7 @@ void AccountManager::processGeneratedKeypair() {
     RSAKeypairGenerator* keypairGenerator = qobject_cast<RSAKeypairGenerator*>(sender());
 
     if (keypairGenerator) {
-        // set the private key on our metaverse API account info
+        // hold the private key to later set our metaverse API account info if upload succeeds
         _pendingPrivateKey = keypairGenerator->getPrivateKey();
 
         // upload the public key so data-web has an up-to-date key

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -33,7 +33,7 @@
 #include "AccountManager.h"
 #include "NetworkLogging.h"
 
-const bool VERBOSE_HTTP_REQUEST_DEBUGGING = false;
+const bool VERBOSE_HTTP_REQUEST_DEBUGGING = true;
 
 AccountManager& AccountManager::getInstance(bool forceReset) {
     static std::unique_ptr<AccountManager> sharedInstance(new AccountManager());

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -33,7 +33,7 @@
 #include "AccountManager.h"
 #include "NetworkLogging.h"
 
-const bool VERBOSE_HTTP_REQUEST_DEBUGGING = true;
+const bool VERBOSE_HTTP_REQUEST_DEBUGGING = false;
 
 AccountManager& AccountManager::getInstance(bool forceReset) {
     static std::unique_ptr<AccountManager> sharedInstance(new AccountManager());

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -107,6 +107,7 @@ private slots:
     void processGeneratedKeypair();
     void publicKeyUploadSucceeded(QNetworkReply& reply);
     void publicKeyUploadFailed(QNetworkReply& reply);
+    void generateNewKeypair(bool isUserKeypair = true, const QUuid& domainID = QUuid());
 
 private:
     AccountManager();
@@ -118,8 +119,6 @@ private:
 
     void passSuccessToCallback(QNetworkReply* reply);
     void passErrorToCallback(QNetworkReply* reply);
-
-    void generateNewKeypair(bool isUserKeypair = true, const QUuid& domainID = QUuid());
 
     QUrl _authURL;
     QMap<QNetworkReply*, JSONCallbackParameters> _pendingCallbackMap;

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -62,11 +62,11 @@ public:
                                  QHttpMultiPart* dataMultiPart = NULL,
                                  const QVariantMap& propertyMap = QVariantMap());
 
+    void setIsAgent(bool isAgent);
+
     const QUrl& getAuthURL() const { return _authURL; }
     void setAuthURL(const QUrl& authURL);
     bool hasAuthEndpoint() { return !_authURL.isEmpty(); }
-
-    void disableSettingsFilePersistence() { _shouldPersistToSettingsFile = false; }
 
     bool isLoggedIn() { return !_authURL.isEmpty() && hasValidAccessToken(); }
     bool hasValidAccessToken();
@@ -107,10 +107,11 @@ private slots:
 
 private:
     AccountManager();
-    AccountManager(AccountManager const& other); // not implemented
-    void operator=(AccountManager const& other); // not implemented
+    AccountManager(AccountManager const& other) = delete;
+    void operator=(AccountManager const& other) = delete;
 
     void persistAccountToSettings();
+    void removeAccountFromSettings();
 
     void passSuccessToCallback(QNetworkReply* reply);
     void passErrorToCallback(QNetworkReply* reply);
@@ -121,7 +122,7 @@ private:
     QMap<QNetworkReply*, JSONCallbackParameters> _pendingCallbackMap;
 
     DataServerAccountInfo _accountInfo;
-    bool _shouldPersistToSettingsFile;
+    bool _isAgent { false };
 };
 
 #endif // hifi_AccountManager_h

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -87,7 +87,9 @@ public slots:
     void logout();
     void updateBalance();
     void accountInfoBalanceChanged(qint64 newBalance);
-    void generateNewKeypair();
+    void generateNewUserKeypair() { generateNewKeypair(); }
+    void generateNewDomainKeypair(const QUuid& domainID) { generateNewKeypair(false, domainID); }
+
 signals:
     void authRequired();
     void authEndpointChanged();
@@ -97,10 +99,12 @@ signals:
     void loginFailed();
     void logoutComplete();
     void balanceChanged(qint64 newBalance);
+
 private slots:
     void processReply();
     void handleKeypairGenerationError();
     void processGeneratedKeypair(const QByteArray& publicKey, const QByteArray& privateKey);
+
 private:
     AccountManager();
     AccountManager(AccountManager const& other); // not implemented
@@ -110,6 +114,8 @@ private:
 
     void passSuccessToCallback(QNetworkReply* reply);
     void passErrorToCallback(QNetworkReply* reply);
+
+    void generateNewKeypair(bool isUserKeypair = true, const QUuid& domainID = QUuid());
 
     QUrl _authURL;
     QMap<QNetworkReply*, JSONCallbackParameters> _pendingCallbackMap;

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -105,8 +105,8 @@ private slots:
     void processReply();
     void handleKeypairGenerationError();
     void processGeneratedKeypair();
-    void publicKeyUploadSuceeded();
-    void publicKeyUploadFailed();
+    void publicKeyUploadSucceeded(QNetworkReply& reply);
+    void publicKeyUploadFailed(QNetworkReply& reply);
 
 private:
     AccountManager();

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -103,7 +103,7 @@ signals:
 private slots:
     void processReply();
     void handleKeypairGenerationError();
-    void processGeneratedKeypair(QByteArray publicKey, QByteArray privateKey);
+    void processGeneratedKeypair();
 
 private:
     AccountManager();

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -62,7 +62,7 @@ public:
                                  QHttpMultiPart* dataMultiPart = NULL,
                                  const QVariantMap& propertyMap = QVariantMap());
 
-    void setIsAgent(bool isAgent);
+    void setIsAgent(bool isAgent) { _isAgent = isAgent; }
 
     const QUrl& getAuthURL() const { return _authURL; }
     void setAuthURL(const QUrl& authURL);
@@ -121,6 +121,7 @@ private:
     void passErrorToCallback(QNetworkReply* reply);
 
     QUrl _authURL;
+    
     QMap<QNetworkReply*, JSONCallbackParameters> _pendingCallbackMap;
 
     DataServerAccountInfo _accountInfo;

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -99,19 +99,22 @@ signals:
     void loginFailed();
     void logoutComplete();
     void balanceChanged(qint64 newBalance);
+    void newKeypair();
 
 private slots:
     void processReply();
     void handleKeypairGenerationError();
     void processGeneratedKeypair();
+    void publicKeyUploadSuceeded();
+    void publicKeyUploadFailed();
 
 private:
     AccountManager();
     AccountManager(AccountManager const& other) = delete;
     void operator=(AccountManager const& other) = delete;
 
-    void persistAccountToSettings();
-    void removeAccountFromSettings();
+    void persistAccountToFile();
+    void removeAccountFromFile();
 
     void passSuccessToCallback(QNetworkReply* reply);
     void passErrorToCallback(QNetworkReply* reply);
@@ -123,6 +126,9 @@ private:
 
     DataServerAccountInfo _accountInfo;
     bool _isAgent { false };
+
+    bool _isWaitingForKeypairResponse { false };
+    QByteArray _pendingPrivateKey;
 };
 
 #endif // hifi_AccountManager_h

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -103,7 +103,7 @@ signals:
 private slots:
     void processReply();
     void handleKeypairGenerationError();
-    void processGeneratedKeypair(const QByteArray& publicKey, const QByteArray& privateKey);
+    void processGeneratedKeypair(QByteArray publicKey, QByteArray privateKey);
 
 private:
     AccountManager();

--- a/libraries/networking/src/DataServerAccountInfo.cpp
+++ b/libraries/networking/src/DataServerAccountInfo.cpp
@@ -175,12 +175,12 @@ void DataServerAccountInfo::setPrivateKey(const QByteArray& privateKey) {
 
 QDataStream& operator<<(QDataStream &out, const DataServerAccountInfo& info) {
     out << info._accessToken << info._username << info._xmppPassword << info._discourseApiKey
-        << info._walletID << info._privateKey;
+        << info._walletID << info._privateKey << info._domainID;
     return out;
 }
 
 QDataStream& operator>>(QDataStream &in, DataServerAccountInfo& info) {
     in >> info._accessToken >> info._username >> info._xmppPassword >> info._discourseApiKey
-        >> info._walletID >> info._privateKey;
+        >> info._walletID >> info._privateKey >> info._domainID;
     return in;
 }

--- a/libraries/networking/src/DataServerAccountInfo.h
+++ b/libraries/networking/src/DataServerAccountInfo.h
@@ -23,7 +23,7 @@ const float SATOSHIS_PER_CREDIT = 100000000.0f;
 class DataServerAccountInfo : public QObject {
     Q_OBJECT
 public:
-    DataServerAccountInfo();
+    DataServerAccountInfo() {};
     DataServerAccountInfo(const DataServerAccountInfo& otherInfo);
     DataServerAccountInfo& operator=(const DataServerAccountInfo& otherInfo);
 
@@ -52,7 +52,7 @@ public:
 
     QByteArray getUsernameSignature(const QUuid& connectionToken);
     bool hasPrivateKey() const { return !_privateKey.isEmpty(); }
-    void setPrivateKey(const QByteArray& privateKey);
+    void setPrivateKey(const QByteArray& privateKey) { _privateKey = privateKey; }
 
     void setDomainID(const QUuid& domainID) { _domainID = domainID; }
     const QUuid& getDomainID() const { return _domainID; }
@@ -73,8 +73,8 @@ private:
     QString _xmppPassword;
     QString _discourseApiKey;
     QUuid _walletID;
-    qint64 _balance;
-    bool _hasBalance;
+    qint64 _balance { 0 };
+    bool _hasBalance { false };
     QUuid _domainID; // if this holds account info for a domain, this holds the ID of that domain
     QByteArray _privateKey;
 

--- a/libraries/networking/src/DataServerAccountInfo.h
+++ b/libraries/networking/src/DataServerAccountInfo.h
@@ -42,10 +42,6 @@ public:
     
     const QUuid& getWalletID() const { return _walletID; }
     void setWalletID(const QUuid& walletID);
-    
-    QByteArray getUsernameSignature(const QUuid& connectionToken);
-    bool hasPrivateKey() const { return !_privateKey.isEmpty(); }
-    void setPrivateKey(const QByteArray& privateKey);
 
     qint64 getBalance() const { return _balance; }
     float getBalanceInSatoshis() const { return _balance / SATOSHIS_PER_CREDIT; }
@@ -53,6 +49,13 @@ public:
     bool hasBalance() const { return _hasBalance; }
     void setHasBalance(bool hasBalance) { _hasBalance = hasBalance; }
     Q_INVOKABLE void setBalanceFromJSON(QNetworkReply& requestReply);
+
+    QByteArray getUsernameSignature(const QUuid& connectionToken);
+    bool hasPrivateKey() const { return !_privateKey.isEmpty(); }
+    void setPrivateKey(const QByteArray& privateKey);
+
+    void setDomainID(const QUuid& domainID) { _domainID = domainID; }
+    const QUuid& getDomainID() const { return _domainID; }
 
     bool hasProfile() const;
 
@@ -72,6 +75,7 @@ private:
     QUuid _walletID;
     qint64 _balance;
     bool _hasBalance;
+    QUuid _domainID; // if this holds account info for a domain, this holds the ID of that domain
     QByteArray _privateKey;
 
 };

--- a/libraries/networking/src/DataServerAccountInfo.h
+++ b/libraries/networking/src/DataServerAccountInfo.h
@@ -54,6 +54,8 @@ public:
     bool hasPrivateKey() const { return !_privateKey.isEmpty(); }
     void setPrivateKey(const QByteArray& privateKey) { _privateKey = privateKey; }
 
+    QByteArray signPlaintext(const QByteArray& plaintext);
+
     void setDomainID(const QUuid& domainID) { _domainID = domainID; }
     const QUuid& getDomainID() const { return _domainID; }
 

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -94,7 +94,7 @@ void DomainHandler::softReset() {
     clearSettings();
 
     _connectionDenialsSinceKeypairRegen = 0;
-    
+
     // cancel the failure timeout for any pending requests for settings
     QMetaObject::invokeMethod(&_settingsTimer, "stop");
 }
@@ -107,7 +107,9 @@ void DomainHandler::hardReset() {
     _iceServerSockAddr = HifiSockAddr();
     _hostname = QString();
     _sockAddr.clear();
+
     _hasCheckedForAccessToken = false;
+    _domainConnectionRefusals.clear();
 
     // clear any pending path we may have wanted to ask the previous DS about
     _pendingPath.clear();
@@ -369,7 +371,7 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
 
     auto& accountManager = AccountManager::getInstance();
 
-    if (_hasCheckedForAccessToken) {
+    if (!_hasCheckedForAccessToken) {
         accountManager.checkAndSignalForAccessToken();
         _hasCheckedForAccessToken = true;
     }

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -92,6 +92,8 @@ void DomainHandler::softReset() {
     disconnect();
     
     clearSettings();
+
+    _connectionDenialsSinceKeypairRegen = 0;
     
     // cancel the failure timeout for any pending requests for settings
     QMetaObject::invokeMethod(&_settingsTimer, "stop");
@@ -105,6 +107,7 @@ void DomainHandler::hardReset() {
     _iceServerSockAddr = HifiSockAddr();
     _hostname = QString();
     _sockAddr.clear();
+    _hasCheckedForAccessToken = false;
 
     // clear any pending path we may have wanted to ask the previous DS about
     _pendingPath.clear();
@@ -345,5 +348,37 @@ void DomainHandler::processICEResponsePacket(QSharedPointer<ReceivedMessage> mes
 
         // emit our signal so the NodeList knows to send a ping immediately
         emit icePeerSocketsReceived();
+    }
+}
+
+void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<ReceivedMessage> message) {
+    // Read deny reason from packet
+    quint16 reasonSize;
+    message->readPrimitive(&reasonSize);
+    QString reason = QString::fromUtf8(message->readWithoutCopy(reasonSize));
+
+    // output to the log so the user knows they got a denied connection request
+    // and check and signal for an access token so that we can make sure they are logged in
+    qCWarning(networking) << "The domain-server denied a connection request: " << reason;
+    qCWarning(networking) << "Make sure you are logged in.";
+
+    if (!_domainConnectionRefusals.contains(reason)) {
+        _domainConnectionRefusals.append(reason);
+        emit domainConnectionRefused(reason);
+    }
+
+    auto& accountManager = AccountManager::getInstance();
+
+    if (_hasCheckedForAccessToken) {
+        accountManager.checkAndSignalForAccessToken();
+        _hasCheckedForAccessToken = true;
+    }
+
+    static const int CONNECTION_DENIALS_FOR_KEYPAIR_REGEN = 3;
+
+    // force a re-generation of key-pair after CONNECTION_DENIALS_FOR_KEYPAIR_REGEN failed connection attempts
+    if (++_connectionDenialsSinceKeypairRegen >= CONNECTION_DENIALS_FOR_KEYPAIR_REGEN) {
+        accountManager.generateNewUserKeypair();
+        _connectionDenialsSinceKeypairRegen = 0;
     }
 }

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -92,6 +92,7 @@ public slots:
     void processICEPingReplyPacket(QSharedPointer<ReceivedMessage> message);
     void processDTLSRequirementPacket(QSharedPointer<ReceivedMessage> dtlsRequirementPacket);
     void processICEResponsePacket(QSharedPointer<ReceivedMessage> icePacket);
+    void processDomainServerConnectionDeniedPacket(QSharedPointer<ReceivedMessage> message);
 
 private slots:
     void completedHostnameLookup(const QHostInfo& hostInfo);
@@ -113,6 +114,8 @@ signals:
     void settingsReceived(const QJsonObject& domainSettingsObject);
     void settingsReceiveFail();
 
+    void domainConnectionRefused(QString reason);
+
 private:
     void sendDisconnectPacket();
     void hardReset();
@@ -130,6 +133,10 @@ private:
     QJsonObject _settingsObject;
     QString _pendingPath;
     QTimer _settingsTimer;
+
+    QStringList _domainConnectionRefusals;
+    bool _hasCheckedForAccessToken { false };
+    int _connectionDenialsSinceKeypairRegen { 0 };
 };
 
 #endif // hifi_DomainHandler_h

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -902,10 +902,6 @@ void LimitedNodeList::updateLocalSockAddr() {
     }
 }
 
-void LimitedNodeList::sendHeartbeatToIceServer(const HifiSockAddr& iceServerSockAddr) {
-    sendPacketToIceServer(PacketType::ICEServerHeartbeat, iceServerSockAddr, _sessionUUID);
-}
-
 void LimitedNodeList::sendPeerQueryToIceServer(const HifiSockAddr& iceServerSockAddr, const QUuid& clientID,
                                                const QUuid& peerID) {
     sendPacketToIceServer(PacketType::ICEServerQuery, iceServerSockAddr, clientID, peerID);

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -143,6 +143,7 @@ public:
     bool hasCompletedInitialSTUN() const { return _hasCompletedInitialSTUN; }
 
     const HifiSockAddr& getLocalSockAddr() const { return _localSockAddr; }
+    const HifiSockAddr& getPublicSockAddr() const { return _publicSockAddr; }
     const HifiSockAddr& getSTUNSockAddr() const { return _stunSockAddr; }
 
     void processKillNode(ReceivedMessage& message);
@@ -161,7 +162,6 @@ public:
     std::unique_ptr<NLPacket> constructICEPingPacket(PingType_t pingType, const QUuid& iceID);
     std::unique_ptr<NLPacket> constructICEPingReplyPacket(ReceivedMessage& message, const QUuid& iceID);
 
-    void sendHeartbeatToIceServer(const HifiSockAddr& iceServerSockAddr);
     void sendPeerQueryToIceServer(const HifiSockAddr& iceServerSockAddr, const QUuid& clientID, const QUuid& peerID);
 
     SharedNodePointer findNodeWithAddr(const HifiSockAddr& addr);

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -110,6 +110,7 @@ NodeList::NodeList(char newOwnerType, unsigned short socketListenPort, unsigned 
     packetReceiver.registerListener(PacketType::ICEPing, this, "processICEPingPacket");
     packetReceiver.registerListener(PacketType::DomainServerAddedNode, this, "processDomainServerAddedNode");
     packetReceiver.registerListener(PacketType::DomainServerConnectionToken, this, "processDomainServerConnectionTokenPacket");
+    packetReceiver.registerListener(PacketType::DomainConnectionDenied, &_domainHandler, "processDomainServerConnectionDeniedPacket");
     packetReceiver.registerListener(PacketType::DomainSettings, &_domainHandler, "processSettingsPacketList");
     packetReceiver.registerListener(PacketType::ICEServerPeerInformation, &_domainHandler, "processICEResponsePacket");
     packetReceiver.registerListener(PacketType::DomainServerRequireDTLS, &_domainHandler, "processDTLSRequirementPacket");

--- a/libraries/networking/src/RSAKeypairGenerator.cpp
+++ b/libraries/networking/src/RSAKeypairGenerator.cpp
@@ -85,12 +85,12 @@ void RSAKeypairGenerator::generateKeypair() {
     // we can cleanup the RSA struct before we continue on
     RSA_free(keyPair);
     
-    QByteArray publicKeyArray(reinterpret_cast<char*>(publicKeyDER), publicKeyLength);
-    QByteArray privateKeyArray(reinterpret_cast<char*>(privateKeyDER), privateKeyLength);
+    _publicKey = QByteArray { reinterpret_cast<char*>(publicKeyDER), publicKeyLength };
+    _privateKey = QByteArray { reinterpret_cast<char*>(privateKeyDER), privateKeyLength };
     
     // cleanup the publicKeyDER and publicKeyDER data
     OPENSSL_free(publicKeyDER);
     OPENSSL_free(privateKeyDER);
     
-    emit generatedKeypair(publicKeyArray, privateKeyArray);
+    emit generatedKeypair();
 }

--- a/libraries/networking/src/RSAKeypairGenerator.h
+++ b/libraries/networking/src/RSAKeypairGenerator.h
@@ -22,16 +22,21 @@ public:
 
     void setDomainID(const QUuid& domainID) { _domainID = domainID; }
     const QUuid& getDomainID() const { return _domainID; }
+
+    const QByteArray& getPublicKey() const { return _publicKey; }
+    const QByteArray& getPrivateKey() const { return _privateKey; }
     
 public slots:
     void generateKeypair();
 
 signals:
     void errorGeneratingKeypair();
-    void generatedKeypair(QByteArray publicKey, QByteArray privateKey);
+    void generatedKeypair();
 
 private:
     QUuid _domainID;
+    QByteArray _publicKey;
+    QByteArray _privateKey;
 };
 
 #endif // hifi_RSAKeypairGenerator_h

--- a/libraries/networking/src/RSAKeypairGenerator.h
+++ b/libraries/networking/src/RSAKeypairGenerator.h
@@ -12,17 +12,26 @@
 #ifndef hifi_RSAKeypairGenerator_h
 #define hifi_RSAKeypairGenerator_h
 
-#include <qobject.h>
+#include <QtCore/QObject>
+#include <QtCore/QUuid>
 
 class RSAKeypairGenerator : public QObject {
     Q_OBJECT
 public:
     RSAKeypairGenerator(QObject* parent = 0);
+
+    void setDomainID(const QUuid& domainID) { _domainID = domainID; }
+    const QUuid& getDomainID() const { return _domainID; }
+    
 public slots:
     void generateKeypair();
+
 signals:
     void errorGeneratingKeypair();
     void generatedKeypair(const QByteArray& publicKey, const QByteArray& privateKey);
+
+private:
+    QUuid _domainID;
 };
 
 #endif // hifi_RSAKeypairGenerator_h

--- a/libraries/networking/src/RSAKeypairGenerator.h
+++ b/libraries/networking/src/RSAKeypairGenerator.h
@@ -28,7 +28,7 @@ public slots:
 
 signals:
     void errorGeneratingKeypair();
-    void generatedKeypair(const QByteArray& publicKey, const QByteArray& privateKey);
+    void generatedKeypair(QByteArray publicKey, QByteArray privateKey);
 
 private:
     QUuid _domainID;

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -45,6 +45,8 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AvatarData:
         case PacketType::BulkAvatarData:
             return static_cast<PacketVersion>(AvatarMixerPacketVersion::SoftAttachmentSupport);
+        case PacketType::ICEServerHeartbeat:
+            return 18; // ICE Server Heartbeat signing
         default:
             return 17;
     }

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -30,7 +30,7 @@ const QSet<PacketType> NON_SOURCED_PACKETS = QSet<PacketType>()
     << PacketType::DomainServerAddedNode << PacketType::DomainServerConnectionToken
     << PacketType::DomainSettingsRequest << PacketType::DomainSettings
     << PacketType::ICEServerPeerInformation << PacketType::ICEServerQuery << PacketType::ICEServerHeartbeat
-    << PacketType::ICEPing << PacketType::ICEPingReply
+    << PacketType::ICEPing << PacketType::ICEPingReply << PacketType::ICEServerHeartbeatDenied
     << PacketType::AssignmentClientStatus << PacketType::StopNode
     << PacketType::DomainServerRemovedNode;
 

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -90,7 +90,8 @@ public:
         DomainServerRemovedNode,
         MessagesData,
         MessagesSubscribe,
-        MessagesUnsubscribe
+        MessagesUnsubscribe,
+        ICEServerHeartbeatDenied
     };
 };
 


### PR DESCRIPTION
- fixed a security issue where heartbeats sent to the ice-server from domains were not verified
- added failover for keypair generation from domain-server and Interface so new keypairs are generated if domain-server/ice-server fail to verify signature enough times
- moved account information to a separate file so account information is not stored with other settings