### PR TITLE
Wire up zone ambientURL

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3818,8 +3818,8 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
 
     // Setup the current Zone Entity lighting
     {
-        auto sun = DependencyManager::get<SceneScriptingInterface>()->getSkyStage()->getSunLight();
-        DependencyManager::get<DeferredLightingEffect>()->setGlobalLight(sun);
+        auto stage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
+        DependencyManager::get<DeferredLightingEffect>()->setGlobalLight(stage->getSunLight(), stage->getSkybox()->getCubemap());
     }
 
     {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3816,18 +3816,10 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
         });
     }
 
-    // Setup the current Zone Entity lighting and skybox
+    // Setup the current Zone Entity lighting
     {
-        // FIXME: Use a zone setting to determine the ambient light mode
-        DependencyManager::get<DeferredLightingEffect>()->setAmbientLightMode(-1);
-        auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
-        DependencyManager::get<DeferredLightingEffect>()->setGlobalLight(skyStage->getSunLight()->getDirection(), skyStage->getSunLight()->getColor(), skyStage->getSunLight()->getIntensity(), skyStage->getSunLight()->getAmbientIntensity());
-
-        auto skybox = model::SkyboxPointer();
-        if (skyStage->getBackgroundMode() == model::SunSkyStage::SKY_BOX) {
-            skybox = skyStage->getSkybox();
-        }
-        DependencyManager::get<DeferredLightingEffect>()->setGlobalSkybox(skybox);
+        auto sun = DependencyManager::get<SceneScriptingInterface>()->getSkyStage()->getSunLight();
+        DependencyManager::get<DeferredLightingEffect>()->setGlobalLight(sun);
     }
 
     {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -146,6 +146,9 @@ private:
     bool _pendingSkyboxTexture { false };
     NetworkTexturePointer _skyboxTexture;
 
+    bool _pendingAmbientTexture { false };
+    NetworkTexturePointer _ambientTexture;
+
     bool _wantScripts;
     ScriptEngine* _entitiesScriptEngine;
 

--- a/libraries/entities/src/KeyLightPropertyGroup.cpp
+++ b/libraries/entities/src/KeyLightPropertyGroup.cpp
@@ -30,7 +30,7 @@ void KeyLightPropertyGroup::copyToScriptValue(const EntityPropertyFlags& desired
     COPY_GROUP_PROPERTY_TO_QSCRIPTVALUE(PROP_KEYLIGHT_INTENSITY, KeyLight, keyLight, Intensity, intensity);
     COPY_GROUP_PROPERTY_TO_QSCRIPTVALUE(PROP_KEYLIGHT_AMBIENT_INTENSITY, KeyLight, keyLight, AmbientIntensity, ambientIntensity);
     COPY_GROUP_PROPERTY_TO_QSCRIPTVALUE(PROP_KEYLIGHT_DIRECTION, KeyLight, keyLight, Direction, direction);
-    COPY_GROUP_PROPERTY_TO_QSCRIPTVALUE(PROP_KEYLIGHT_AMBIENT_URL, KeyLight, keyLight, AmbientURL, ambientUrl);
+    COPY_GROUP_PROPERTY_TO_QSCRIPTVALUE(PROP_KEYLIGHT_AMBIENT_URL, KeyLight, keyLight, AmbientURL, ambientURL);
 
 }
 

--- a/libraries/model/src/model/Stage.cpp
+++ b/libraries/model/src/model/Stage.cpp
@@ -202,14 +202,13 @@ void SunSkyStage::setSunModelEnable(bool isEnabled) {
     invalidate();
 }
 
-void SunSkyStage::setSunColor(const Vec3& color) {
-    _sunLight->setColor(color);
-}
-void SunSkyStage::setSunIntensity(float intensity) {
-    _sunLight->setIntensity(intensity);
-}
-void SunSkyStage::setSunAmbientIntensity(float intensity) {
-    _sunLight->setAmbientIntensity(intensity);
+void SunSkyStage::setSunAmbientSphere(const gpu::SHPointer& sphere) {
+    if (sphere) {
+        _sunLight->setAmbientSphere(*sphere);
+    } else {
+        const gpu::SphericalHarmonics::Preset DEFAULT_AMBIENT_SPHERE = gpu::SphericalHarmonics::OLD_TOWN_SQUARE;
+        _sunLight->setAmbientSpherePreset(DEFAULT_AMBIENT_SPHERE);
+    }
 }
 
 void SunSkyStage::setSunDirection(const Vec3& direction) {

--- a/libraries/model/src/model/Stage.h
+++ b/libraries/model/src/model/Stage.h
@@ -11,7 +11,7 @@
 #ifndef hifi_model_Stage_h
 #define hifi_model_Stage_h
 
-#include "gpu/Pipeline.h"
+#include <gpu/Pipeline.h>
 
 #include "Light.h"
 #include "Skybox.h"
@@ -143,12 +143,13 @@ public:
     bool isSunModelEnabled() const { return _sunModelEnable; }
 
     // Sun properties
-    void setSunColor(const Vec3& color);
+    void setSunColor(const Vec3& color) { _sunLight->setColor(color); }
     const Vec3& getSunColor() const { return getSunLight()->getColor(); }
-    void setSunIntensity(float intensity);
+    void setSunIntensity(float intensity) { _sunLight->setIntensity(intensity); }
     float getSunIntensity() const { return getSunLight()->getIntensity(); }
-    void setSunAmbientIntensity(float intensity);
+    void setSunAmbientIntensity(float intensity) { _sunLight->setAmbientIntensity(intensity); }
     float getSunAmbientIntensity() const { return getSunLight()->getAmbientIntensity(); }
+    void setSunAmbientSphere(const gpu::SHPointer& sphere);
 
     // The sun direction is expressed in the world space
     void setSunDirection(const Vec3& direction);

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -560,13 +560,7 @@ static void loadLightProgram(const char* vertSource, const char* fragSource, boo
 }
 
 void DeferredLightingEffect::setGlobalLight(const model::LightPointer& light, const gpu::TexturePointer& skyboxTexture) {
-    auto globalLight = _allocatedLights.front();
-    globalLight->setDirection(light->getDirection());
-    globalLight->setColor(light->getColor());
-    globalLight->setIntensity(light->getIntensity());
-    globalLight->setAmbientIntensity(light->getAmbientIntensity());
-    globalLight->setAmbientSphere(light->getAmbientSphere());
-
+    _allocatedLights.front() = light;
     _skyboxTexture = skyboxTexture;
 }
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -562,32 +562,13 @@ static void loadLightProgram(const char* vertSource, const char* fragSource, boo
 
 }
 
-void DeferredLightingEffect::setAmbientLightMode(int preset) {
-    if ((preset >= 0) && (preset < gpu::SphericalHarmonics::NUM_PRESET)) {
-        _ambientLightMode = preset;
-        auto light = _allocatedLights.front();
-        light->setAmbientSpherePreset(gpu::SphericalHarmonics::Preset(preset % gpu::SphericalHarmonics::NUM_PRESET));
-    } else {
-        // force to preset 0
-        setAmbientLightMode(0);
-    }
-}
-
-void DeferredLightingEffect::setGlobalLight(const glm::vec3& direction, const glm::vec3& diffuse, float intensity, float ambientIntensity) {
-    auto light = _allocatedLights.front();
-    light->setDirection(direction);
-    light->setColor(diffuse);
-    light->setIntensity(intensity);
-    light->setAmbientIntensity(ambientIntensity);
-}
-
-void DeferredLightingEffect::setGlobalSkybox(const model::SkyboxPointer& skybox) {
-    _skybox = skybox;
-    auto light = _allocatedLights.front();
-
-    if (_skybox && _skybox->getCubemap() && _skybox->getCubemap()->isDefined() && _skybox->getCubemap()->getIrradiance()) {
-        light->setAmbientSphere( (*_skybox->getCubemap()->getIrradiance()) );
-    }
+void DeferredLightingEffect::setGlobalLight(const model::LightPointer& light) {
+    auto globalLight = _allocatedLights.front();
+    globalLight->setDirection(light->getDirection());
+    globalLight->setColor(light->getColor());
+    globalLight->setIntensity(light->getIntensity());
+    globalLight->setAmbientIntensity(light->getAmbientIntensity());
+    globalLight->setAmbientSphere(light->getAmbientSphere());
 }
 
 model::MeshPointer DeferredLightingEffect::getSpotLightMesh() {

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -49,9 +49,7 @@ public:
     void setupKeyLightBatch(gpu::Batch& batch, int lightBufferUnit, int skyboxCubemapUnit);
 
     // update global lighting
-    void setAmbientLightMode(int preset);
-    void setGlobalLight(const glm::vec3& direction, const glm::vec3& diffuse, float intensity, float ambientIntensity);
-    void setGlobalSkybox(const model::SkyboxPointer& skybox);
+    void setGlobalLight(const model::LightPointer& light);
 
     const LightStage& getLightStage() { return _lightStage; }
     void setShadowMapEnabled(bool enable) { _shadowMapEnabled = enable; };

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -18,7 +18,6 @@
 #include <NumericalConstants.h>
 
 #include "model/Light.h"
-#include "model/Stage.h"
 #include "model/Geometry.h"
 
 #include "render/Context.h"
@@ -49,7 +48,7 @@ public:
     void setupKeyLightBatch(gpu::Batch& batch, int lightBufferUnit, int skyboxCubemapUnit);
 
     // update global lighting
-    void setGlobalLight(const model::LightPointer& light);
+    void setGlobalLight(const model::LightPointer& light, const gpu::TexturePointer& skyboxTexture);
 
     const LightStage& getLightStage() { return _lightStage; }
     void setShadowMapEnabled(bool enable) { _shadowMapEnabled = enable; };
@@ -96,7 +95,7 @@ private:
     std::vector<int> _spotLights;
 
     int _ambientLightMode = 0;
-    model::SkyboxPointer _skybox;
+    gpu::TexturePointer _skyboxTexture;
 
     // Class describing the uniform buffer with all the parameters common to the deferred shaders
     class DeferredTransform {

--- a/libraries/script-engine/src/SceneScriptingInterface.cpp
+++ b/libraries/script-engine/src/SceneScriptingInterface.cpp
@@ -77,6 +77,10 @@ void SceneScripting::KeyLight::setAmbientIntensity(float intensity) {
     _skyStage->setSunAmbientIntensity(intensity);
 }
 
+void SceneScripting::KeyLight::setAmbientSphere(const gpu::SHPointer& sphere) {
+    _skyStage->setSunAmbientSphere(sphere);
+}
+
 glm::vec3 SceneScripting::KeyLight::getDirection() const {
     return _skyStage->getSunDirection();
 }

--- a/libraries/script-engine/src/SceneScriptingInterface.h
+++ b/libraries/script-engine/src/SceneScriptingInterface.h
@@ -81,6 +81,10 @@ namespace SceneScripting {
         // setDirection is only effective if stage Sun model is disabled
         void setDirection(const glm::vec3& direction);
 
+        // AmbientTexture is unscriptable - it must be set through the zone entity
+        void setAmbientSphere(const gpu::SHPointer& sphere);
+        void resetAmbientSphere() { setAmbientSphere(nullptr); }
+
     protected:
         model::SunSkyStagePointer _skyStage;
     };


### PR DESCRIPTION
Zone entities have a property, `ambientURL`, which now sets the ambient texture for the zone. It can be scripted through the zone, but not through the scene.

If `ambientURL` is set, it will be used. If `ambientURL` is unset, but the background is showing a skybox, the skybox is used. Otherwise, OLD_TOWN_SQUARE is used as a default. There is no longer access to the ambient light presets, although they are left in the code.