### PR TITLE
Update Scene on ZoneEntity update

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -853,3 +853,19 @@ void EntityTreeRenderer::updateEntityRenderStatus(bool shouldRenderEntities) {
         }
     }
 }
+
+void EntityTreeRenderer::updateZone(const EntityItemID& id) {
+    if (!_bestZone) {
+        // Get in the zone!
+        auto zone = getTree()->findEntityByEntityItemID(id);
+        if (zone && zone->contains(_lastAvatarPosition)) {
+            _currentEntitiesInside << id;
+            emit enterEntity(id);
+            _entitiesScriptEngine->callEntityScriptMethod(id, "enterEntity");
+            _bestZone = std::dynamic_pointer_cast<ZoneEntityItem>(zone);
+        }
+    }
+    if (_bestZone && _bestZone->getID() == id) {
+        applyZonePropertiesToScene(_bestZone);
+    }
+}

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -136,11 +136,11 @@ private:
     EntityItemID _currentClickingOnEntityID;
 
     QScriptValueList createEntityArgs(const EntityItemID& entityID);
-    void checkEnterLeaveEntities();
+    bool checkEnterLeaveEntities();
     void leaveAllEntities();
     void forceRecheckEntities();
 
-    glm::vec3 _lastAvatarPosition;
+    glm::vec3 _lastAvatarPosition { 0.0f };
     QVector<EntityItemID> _currentEntitiesInside;
 
     bool _pendingSkyboxTexture { false };

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -109,6 +109,7 @@ public slots:
     void entitySciptChanging(const EntityItemID& entityID, const bool reload);
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
     void updateEntityRenderStatus(bool shouldRenderEntities);
+    void updateZone(const EntityItemID& id);
 
     // optional slots that can be wired to menu items
     void setDisplayModelBounds(bool value) { _displayModelBounds = value; }

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -18,6 +18,7 @@
 #include <GeometryCache.h>
 #include <PerfStat.h>
 
+#include "EntityTreeRenderer.h"
 #include "RenderableEntityItem.h"
 
 // Sphere entities should fit inside a cube entity of the same size, so a sphere that has dimensions 1x1x1
@@ -60,6 +61,10 @@ bool RenderableZoneEntityItem::setProperties(const EntityItemProperties& propert
         somethingChanged = this->ZoneEntityItem::setProperties(properties);
     });
     return somethingChanged;
+}
+
+void RenderableZoneEntityItem::somethingChangedNotification() {
+    DependencyManager::get<EntityTreeRenderer>()->updateZone(_id);
 }
 
 int RenderableZoneEntityItem::readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.h
@@ -28,6 +28,8 @@ public:
     { }
     
     virtual bool setProperties(const EntityItemProperties& properties);
+    virtual void somethingChangedNotification() override;
+
     virtual int readEntitySubclassDataFromBuffer(const unsigned char* data, int bytesLeftToRead,
                                                  ReadBitstreamToTreeParams& args,
                                                  EntityPropertyFlags& propertyFlags, bool overwriteLocalData,


### PR DESCRIPTION
ZoneEntity is unique in that it is not updated
every frame that it is rendered, but only
when the avatar moves.

This introduces custom code so that the
RenderableZoneEntity initiates an update
in the EntityTreeRenderer on update,
to improve usability of zone editing.