### PR TITLE
legacy support for EntityViewer.setKeyholeRadius()

### DIFF
--- a/examples/acScripts/entitySpawnerAC.js
+++ b/examples/acScripts/entitySpawnerAC.js
@@ -95,7 +95,7 @@ EntityViewer.setPosition({
     y: 0,
     z: 0
 });
-EntityViewer.setKeyholeRadius(60000);
+EntityViewer.setCenterRadius(60000);
 var octreeQueryInterval = Script.setInterval(function() {
     EntityViewer.queryOctree();
 }, 1000);

--- a/examples/audioExamples/acAudioSearching/ACAudioSearchAndInject.js
+++ b/examples/audioExamples/acAudioSearching/ACAudioSearchAndInject.js
@@ -45,7 +45,7 @@ function debug() { // Display the arguments not just [Object object].
     //print.apply(null, [].map.call(arguments, JSON.stringify));
 }
 
-EntityViewer.setKeyholeRadius(QUERY_RADIUS);
+EntityViewer.setCenterRadius(QUERY_RADIUS);
 
 // ENTITY DATA CACHE
 // 

--- a/libraries/octree/src/OctreeHeadlessViewer.h
+++ b/libraries/octree/src/OctreeHeadlessViewer.h
@@ -47,6 +47,7 @@ public slots:
     void setPosition(const glm::vec3& position) { _viewFrustum.setPosition(position); }
     void setOrientation(const glm::quat& orientation) { _viewFrustum.setOrientation(orientation); }
     void setCenterRadius(float radius) { _viewFrustum.setCenterRadius(radius); }
+    void setKeyholeRadius(float radius) { _viewFrustum.setCenterRadius(radius); } // TODO: remove this legacy support
 
     // setters for LOD and PPS
     void setVoxelSizeScale(float sizeScale) { _voxelSizeScale = sizeScale; }


### PR DESCRIPTION
It seems I accidentally removed **EntityViewer.setKeyholeRadius()**.  I didn't notice that it was exposed to JS when I replaced it with **EntityViewer.setCenterRadius()**.  This PR adds back the old method for legacy support, although we should update the JS docs and remove it eventually.