### PR TITLE
Tilt Maze Should Delete Stray Balls

### DIFF
--- a/unpublishedScripts/DomainContent/Home/tiltMaze/maze.js
+++ b/unpublishedScripts/DomainContent/Home/tiltMaze/maze.js
@@ -96,6 +96,9 @@
             if (this.ballLocked === true) {
                 return;
             }
+            if(this.ball!==null){
+                Entities.deleteEntity(this.ball);
+            }
 
             var properties = {
                 name: 'Hifi Tilt Maze Ball',


### PR DESCRIPTION
It's possible to shake a ball out of the tilt maze because of physics tunneling.  This PR adds a feature to the tilt maze that deletes the stray balls when a new ball is created.

To test:
1. Run this script. https://rawgit.com/imgntn/hifi/tiltmaze/unpublishedScripts/DomainContent/Home/tiltMaze/createTiltMaze.js
2. Grab the tilt maze with your hand controller and shake it hard
3. Observe that balls escape the maze but are not left around the environment.