### PR TITLE
Differentiate global sun and skyStage sun

### DIFF
--- a/libraries/model/src/model/Stage.cpp
+++ b/libraries/model/src/model/Stage.cpp
@@ -142,6 +142,8 @@ SunSkyStage::SunSkyStage() :
     _skybox(std::make_shared<Skybox>())
 {
     _sunLight->setType(Light::SUN);
+    // Default ambient sphere (for lack of skybox)
+    _sunLight->setAmbientSpherePreset(gpu::SphericalHarmonics::Preset::OLD_TOWN_SQUARE);
  
     setSunIntensity(1.0f);
     setSunAmbientIntensity(0.5f);

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -87,14 +87,11 @@ void DeferredLightingEffect::init() {
     _allocatedLights.push_back(std::make_shared<model::Light>());
 
     model::LightPointer lp = _allocatedLights[0];
+    lp->setType(model::Light::SUN);
+
     // Add the global light to the light stage (for later shadow rendering)
     _lightStage.addLight(lp);
 
-    lp->setDirection(-glm::vec3(1.0f, 1.0f, 1.0f));
-    lp->setColor(glm::vec3(1.0f));
-    lp->setIntensity(1.0f);
-    lp->setType(model::Light::SUN);
-    lp->setAmbientSpherePreset(gpu::SphericalHarmonics::Preset(_ambientLightMode % gpu::SphericalHarmonics::NUM_PRESET));
 }
 
 void DeferredLightingEffect::addPointLight(const glm::vec3& position, float radius, const glm::vec3& color,
@@ -560,7 +557,13 @@ static void loadLightProgram(const char* vertSource, const char* fragSource, boo
 }
 
 void DeferredLightingEffect::setGlobalLight(const model::LightPointer& light, const gpu::TexturePointer& skyboxTexture) {
-    _allocatedLights.front() = light;
+    auto globalLight = _allocatedLights.front();
+    globalLight->setDirection(light->getDirection());
+    globalLight->setColor(light->getColor());
+    globalLight->setIntensity(light->getIntensity());
+    globalLight->setAmbientIntensity(light->getAmbientIntensity());
+    globalLight->setAmbientSphere(light->getAmbientSphere());
+
     _skyboxTexture = skyboxTexture;
 }
 


### PR DESCRIPTION
#7186 broke the default ambientSphere, because it was never set in the skyStage, and the allocated global light was replaced by the skyStage sun every frame.

This fixes that by setting a default in the skystage, and only copying necessary values from the skyStage sun to the global sun. They represent the same thing, but right now there are other dependents on the global light and it is easier to keep them split.