### PR TITLE
Fix resource caches overlap

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -55,6 +55,8 @@ Agent::Agent(ReceivedMessage& message) :
 {
     DependencyManager::get<EntityScriptingInterface>()->setPacketSender(&_entityEditSender);
 
+    ResourceManager::init();
+
     DependencyManager::registerInheritance<SpatialParentFinder, AssignmentParentFinder>();
 
     DependencyManager::set<ResourceCacheSharedItems>();
@@ -73,8 +75,6 @@ Agent::Agent(ReceivedMessage& message) :
         { PacketType::OctreeStats, PacketType::EntityData, PacketType::EntityErase },
         this, "handleOctreePacket");
     packetReceiver.registerListener(PacketType::Jurisdiction, this, "handleJurisdictionPacket");
-
-    ResourceManager::init();
 }
 
 void Agent::handleOctreePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
@@ -464,9 +464,9 @@ void Agent::aboutToFinish() {
 
     // our entity tree is going to go away so tell that to the EntityScriptingInterface
     DependencyManager::get<EntityScriptingInterface>()->setEntityTree(nullptr);
+
+    ResourceManager::cleanup();
     
     // cleanup the AudioInjectorManager (and any still running injectors)
     DependencyManager::destroy<AudioInjectorManager>();
-
-    ResourceManager::cleanup();
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1072,10 +1072,8 @@ void Application::cleanupBeforeQuit() {
 }
 
 void Application::emptyLocalCache() {
-    if (auto cache = NetworkAccessManager::getInstance().cache()) {
-        qDebug() << "DiskCacheEditor::clear(): Clearing disk cache.";
-        cache->clear();
-    }
+    auto assetClient = DependencyManager::get<AssetClient>();
+    QMetaObject::invokeMethod(assetClient.data(), "clearCache", Qt::QueuedConnection);
 }
 
 Application::~Application() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1071,11 +1071,6 @@ void Application::cleanupBeforeQuit() {
     DependencyManager::destroy<OffscreenUi>();
 }
 
-void Application::emptyLocalCache() {
-    auto assetClient = DependencyManager::get<AssetClient>();
-    QMetaObject::invokeMethod(assetClient.data(), "clearCache", Qt::QueuedConnection);
-}
-
 Application::~Application() {
     EntityTreePointer tree = getEntities()->getTree();
     tree->setSimulation(NULL);
@@ -3061,7 +3056,7 @@ void Application::reloadResourceCaches() {
     _viewFrustum.setOrientation(glm::quat());
     queryOctree(NodeType::EntityServer, PacketType::EntityQuery, _entityServerJurisdictions);
 
-    emptyLocalCache();
+    DependencyManager::get<AssetClient>()->clearCache();
 
     DependencyManager::get<AnimationCache>()->refreshAll();
     DependencyManager::get<ModelCache>()->refreshAll();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1113,6 +1113,8 @@ Application::~Application() {
     DependencyManager::destroy<ScriptCache>();
     DependencyManager::destroy<SoundCache>();
 
+    ResourceManager::cleanup();
+
     QThread* nodeThread = DependencyManager::get<NodeList>()->thread();
 
     // remove the NodeList from the DependencyManager
@@ -1127,8 +1129,6 @@ Application::~Application() {
 #if 0
     ConnexionClient::getInstance().destroy();
 #endif
-
-    ResourceManager::cleanup();
 
     qInstallMessageHandler(NULL); // NOTE: Do this as late as possible so we continue to get our log messages
 }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -330,8 +330,6 @@ private:
 
     void cleanupBeforeQuit();
 
-    void emptyLocalCache();
-
     void update(float deltaTime);
 
     void setPalmData(Hand* hand, const controller::Pose& pose, float deltaTime, HandData::Hand whichHand, float triggerValue);

--- a/interface/src/ui/DiskCacheEditor.cpp
+++ b/interface/src/ui/DiskCacheEditor.cpp
@@ -103,12 +103,10 @@ void DiskCacheEditor::makeDialog() {
 }
 
 void DiskCacheEditor::refresh() {
-    auto assetClient = DependencyManager::get<AssetClient>();
-    QMetaObject::invokeMethod(assetClient.data() , "cacheInfoRequest", Qt::QueuedConnection,
-                              Q_ARG(QObject*, this), Q_ARG(QString, "update"));
+    DependencyManager::get<AssetClient>()->cacheInfoRequest(this, "cacheInfoCallback");
 }
 
-void DiskCacheEditor::update(QString cacheDirectory, qint64 cacheSize, qint64 maximumCacheSize) {
+void DiskCacheEditor::cacheInfoCallback(QString cacheDirectory, qint64 cacheSize, qint64 maximumCacheSize) {
     static const auto stringify = [](qint64 number) {
         static const QStringList UNITS = QStringList() << "B" << "KB" << "MB" << "GB";
         static const qint64 CHUNK = 1024;
@@ -141,7 +139,6 @@ void DiskCacheEditor::clear() {
                                                "are you sure you want to do that?",
                                                QMessageBox::Ok | QMessageBox::Cancel);
     if (buttonClicked == QMessageBox::Ok) {
-        auto assetClient = DependencyManager::get<AssetClient>();
-        QMetaObject::invokeMethod(assetClient.data() , "clearCache", Qt::QueuedConnection);
+        DependencyManager::get<AssetClient>()->clearCache();
     }
 }

--- a/interface/src/ui/DiskCacheEditor.cpp
+++ b/interface/src/ui/DiskCacheEditor.cpp
@@ -91,7 +91,7 @@ void DiskCacheEditor::makeDialog() {
     _refreshTimer = new QTimer(_dialog);
     _refreshTimer->setInterval(100);
     _refreshTimer->setSingleShot(false);
-    QObject::connect(_refreshTimer, &QTimer::timeout, this, &DiskCacheEditor::refresh);
+    QObject::connect(_refreshTimer.data(), &QTimer::timeout, this, &DiskCacheEditor::refresh);
     _refreshTimer->start();
 
     QPushButton* clearCacheButton = new QPushButton(_dialog);

--- a/interface/src/ui/DiskCacheEditor.cpp
+++ b/interface/src/ui/DiskCacheEditor.cpp
@@ -122,6 +122,7 @@ void DiskCacheEditor::refresh() {
         }
         return QString("%0 %1").arg(number).arg(UNITS[i]);
     };
+    return;
     QNetworkDiskCache* cache = qobject_cast<QNetworkDiskCache*>(NetworkAccessManager::getInstance().cache());
     
     if (_path) {
@@ -135,6 +136,7 @@ void DiskCacheEditor::refresh() {
     }
 }
 
+#include <AssetClient.h>
 void DiskCacheEditor::clear() {
     QMessageBox::StandardButton buttonClicked =
                                     OffscreenUi::question(_dialog, "Clearing disk cache",
@@ -142,10 +144,8 @@ void DiskCacheEditor::clear() {
                                               "are you sure you want to do that?",
                                               QMessageBox::Ok | QMessageBox::Cancel);
     if (buttonClicked == QMessageBox::Ok) {
-        if (auto cache = NetworkAccessManager::getInstance().cache()) {
-            qDebug() << "DiskCacheEditor::clear(): Clearing disk cache.";
-            cache->clear();
-        }
+        auto assetClient = DependencyManager::get<AssetClient>();
+        QMetaObject::invokeMethod(assetClient.data() , "clearCache", Qt::QueuedConnection);
     }
     refresh();
 }

--- a/interface/src/ui/DiskCacheEditor.cpp
+++ b/interface/src/ui/DiskCacheEditor.cpp
@@ -88,8 +88,10 @@ void DiskCacheEditor::makeDialog() {
 
     refresh();
 
+
+    static const int REFRESH_INTERVAL = 100; // msec
     _refreshTimer = new QTimer(_dialog);
-    _refreshTimer->setInterval(100);
+    _refreshTimer->setInterval(REFRESH_INTERVAL);
     _refreshTimer->setSingleShot(false);
     QObject::connect(_refreshTimer.data(), &QTimer::timeout, this, &DiskCacheEditor::refresh);
     _refreshTimer->start();

--- a/interface/src/ui/DiskCacheEditor.h
+++ b/interface/src/ui/DiskCacheEditor.h
@@ -33,9 +33,9 @@ public slots:
     
 private slots:
     void refresh();
-    void update(QString cacheDirectory, qint64 cacheSize, qint64 maximumCacheSize);
+    void cacheInfoCallback(QString cacheDirectory, qint64 cacheSize, qint64 maximumCacheSize);
     void clear();
-    
+
 private:
     void makeDialog();
     

--- a/interface/src/ui/DiskCacheEditor.h
+++ b/interface/src/ui/DiskCacheEditor.h
@@ -18,6 +18,7 @@
 class QDialog;
 class QLabel;
 class QWindow;
+class QTimer;
 
 class DiskCacheEditor : public QObject {
     Q_OBJECT
@@ -32,6 +33,7 @@ public slots:
     
 private slots:
     void refresh();
+    void update(QString cacheDirectory, qint64 cacheSize, qint64 maximumCacheSize);
     void clear();
     
 private:
@@ -41,6 +43,7 @@ private:
     QPointer<QLabel> _path;
     QPointer<QLabel> _size;
     QPointer<QLabel> _maxSize;
+    QPointer<QTimer> _refreshTimer;
 };
 
 #endif // hifi_DiskCacheEditor_h

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -47,22 +47,20 @@ AssetClient::AssetClient() {
 }
 
 void AssetClient::init() {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "init", Qt::BlockingQueuedConnection);
-    }
-    
+    Q_ASSERT(QThread::currentThread() == thread());
+
     // Setup disk cache if not already
-    QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
+    auto& networkAccessManager = NetworkAccessManager::getInstance();
     if (!networkAccessManager.cache()) {
         QString cachePath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
         cachePath = !cachePath.isEmpty() ? cachePath : "interfaceCache";
-        
+
         QNetworkDiskCache* cache = new QNetworkDiskCache();
         cache->setMaximumCacheSize(MAXIMUM_CACHE_SIZE);
         cache->setCacheDirectory(cachePath);
         networkAccessManager.setCache(cache);
-        qCDebug(asset_client) << "AssetClient disk cache setup at" << cachePath
-                                << "(size:" << MAXIMUM_CACHE_SIZE / BYTES_PER_GIGABYTES << "GB)";
+        qDebug() << "ResourceManager disk cache setup at" << cachePath
+        << "(size:" << MAXIMUM_CACHE_SIZE / BYTES_PER_GIGABYTES << "GB)";
     }
 }
 

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -66,7 +66,12 @@ void AssetClient::init() {
 
 
 void AssetClient::cacheInfoRequest(QObject* reciever, QString slot) {
-    Q_ASSERT(QThread::currentThread() == thread());
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "cacheInfoRequest", Qt::QueuedConnection,
+                                  Q_ARG(QObject*, reciever), Q_ARG(QString, slot));
+        return;
+    }
+
 
     if (auto* cache = qobject_cast<QNetworkDiskCache*>(NetworkAccessManager::getInstance().cache())) {
         QMetaObject::invokeMethod(reciever, slot.toStdString().data(), Qt::QueuedConnection,
@@ -79,7 +84,10 @@ void AssetClient::cacheInfoRequest(QObject* reciever, QString slot) {
 }
 
 void AssetClient::clearCache() {
-    Q_ASSERT(QThread::currentThread() == thread());
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "clearCache", Qt::QueuedConnection);
+        return;
+    }
 
     if (auto cache = NetworkAccessManager::getInstance().cache()) {
         qDebug() << "AssetClient::clearCache(): Clearing disk cache.";

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -60,7 +60,7 @@ void AssetClient::init() {
         cache->setCacheDirectory(cachePath);
         networkAccessManager.setCache(cache);
         qDebug() << "ResourceManager disk cache setup at" << cachePath
-        << "(size:" << MAXIMUM_CACHE_SIZE / BYTES_PER_GIGABYTES << "GB)";
+                 << "(size:" << MAXIMUM_CACHE_SIZE / BYTES_PER_GIGABYTES << "GB)";
     }
 }
 

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -64,6 +64,15 @@ void AssetClient::init() {
     }
 }
 
+void AssetClient::clearCache() {
+    Q_ASSERT(QThread::currentThread() == thread());
+
+    if (auto cache = NetworkAccessManager::getInstance().cache()) {
+        qDebug() << "AssetClient::clearCache(): Clearing disk cache.";
+        cache->clear();
+    }
+}
+
 bool haveAssetServer() {
     auto nodeList = DependencyManager::get<NodeList>();
     SharedNodePointer assetServer = nodeList->soloNodeOfType(NodeType::AssetServer);

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -64,12 +64,28 @@ void AssetClient::init() {
     }
 }
 
+
+void AssetClient::cacheInfoRequest(QObject* reciever, QString slot) {
+    Q_ASSERT(QThread::currentThread() == thread());
+
+    if (auto* cache = qobject_cast<QNetworkDiskCache*>(NetworkAccessManager::getInstance().cache())) {
+        QMetaObject::invokeMethod(reciever, slot.toStdString().data(), Qt::QueuedConnection,
+                                  Q_ARG(QString, cache->cacheDirectory()),
+                                  Q_ARG(qint64, cache->cacheSize()),
+                                  Q_ARG(qint64, cache->maximumCacheSize()));
+    } else {
+        qCWarning(asset_client) << "No disk cache to get info from.";
+    }
+}
+
 void AssetClient::clearCache() {
     Q_ASSERT(QThread::currentThread() == thread());
 
     if (auto cache = NetworkAccessManager::getInstance().cache()) {
         qDebug() << "AssetClient::clearCache(): Clearing disk cache.";
         cache->clear();
+    } else {
+        qCWarning(asset_client) << "No disk cache to clear.";
     }
 }
 

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -50,6 +50,7 @@ public:
 
 public slots:
     void init();
+    void clearCache();
 
 private slots:
     void handleAssetGetInfoReply(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -50,6 +50,8 @@ public:
 
 public slots:
     void init();
+
+    void cacheInfoRequest(QObject* reciever, QString slot);
     void clearCache();
 
 private slots:

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -43,12 +43,13 @@ class AssetClient : public QObject, public Dependency {
     Q_OBJECT
 public:
     AssetClient();
-    
-    Q_INVOKABLE void init();
 
     Q_INVOKABLE AssetRequest* createRequest(const QString& hash, const QString& extension);
     Q_INVOKABLE AssetUpload* createUpload(const QString& filename);
     Q_INVOKABLE AssetUpload* createUpload(const QByteArray& data, const QString& extension);
+
+public slots:
+    void init();
 
 private slots:
     void handleAssetGetInfoReply(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);

--- a/libraries/networking/src/AssetResourceRequest.h
+++ b/libraries/networking/src/AssetResourceRequest.h
@@ -20,7 +20,7 @@
 class AssetResourceRequest : public ResourceRequest {
     Q_OBJECT
 public:
-    AssetResourceRequest(QObject* parent, const QUrl& url) : ResourceRequest(parent, url) { }
+    AssetResourceRequest(const QUrl& url) : ResourceRequest(url) { }
     ~AssetResourceRequest();
 
 protected:

--- a/libraries/networking/src/FileResourceRequest.h
+++ b/libraries/networking/src/FileResourceRequest.h
@@ -19,7 +19,7 @@
 class FileResourceRequest : public ResourceRequest {
     Q_OBJECT
 public:
-    FileResourceRequest(QObject* parent, const QUrl& url) : ResourceRequest(parent, url) { }
+    FileResourceRequest(const QUrl& url) : ResourceRequest(url) { }
 
 protected:
     virtual void doSend() override;

--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -28,6 +28,25 @@ HTTPResourceRequest::~HTTPResourceRequest() {
     }
 }
 
+void HTTPResourceRequest::setupTimer() {
+    Q_ASSERT(!_sendTimer);
+    static const int TIMEOUT_MS = 10000;
+
+    _sendTimer = new QTimer();
+    connect(this, &QObject::destroyed, _sendTimer, &QTimer::deleteLater);
+    connect(_sendTimer, &QTimer::timeout, this, &HTTPResourceRequest::onTimeout);
+
+    _sendTimer->setSingleShot(true);
+    _sendTimer->start(TIMEOUT_MS);
+}
+
+void HTTPResourceRequest::cleanupTimer() {
+    Q_ASSERT(_sendTimer);
+    _sendTimer->disconnect(this);
+    _sendTimer->deleteLater();
+    _sendTimer = nullptr;
+}
+
 void HTTPResourceRequest::doSend() {
     QNetworkRequest networkRequest(_url);
     networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
@@ -42,18 +61,15 @@ void HTTPResourceRequest::doSend() {
     
     connect(_reply, &QNetworkReply::finished, this, &HTTPResourceRequest::onRequestFinished);
     connect(_reply, &QNetworkReply::downloadProgress, this, &HTTPResourceRequest::onDownloadProgress);
-    connect(&_sendTimer, &QTimer::timeout, this, &HTTPResourceRequest::onTimeout);
 
-    static const int TIMEOUT_MS = 10000;
-    _sendTimer.setSingleShot(true);
-    _sendTimer.start(TIMEOUT_MS);
+    setupTimer();
 }
 
 void HTTPResourceRequest::onRequestFinished() {
     Q_ASSERT(_state == InProgress);
     Q_ASSERT(_reply);
 
-    _sendTimer.stop();
+    cleanupTimer();
     
     switch(_reply->error()) {
         case QNetworkReply::NoError:
@@ -80,7 +96,7 @@ void HTTPResourceRequest::onDownloadProgress(qint64 bytesReceived, qint64 bytesT
     Q_ASSERT(_state == InProgress);
     
     // We've received data, so reset the timer
-    _sendTimer.start();
+    _sendTimer->start();
 
     emit progress(bytesReceived, bytesTotal);
 }
@@ -91,6 +107,8 @@ void HTTPResourceRequest::onTimeout() {
     _reply->abort();
     _reply->deleteLater();
     _reply = nullptr;
+
+    cleanupTimer();
     
     _result = Timeout;
     _state = Finished;

--- a/libraries/networking/src/HTTPResourceRequest.h
+++ b/libraries/networking/src/HTTPResourceRequest.h
@@ -21,7 +21,7 @@
 class HTTPResourceRequest : public ResourceRequest {
     Q_OBJECT
 public:
-    HTTPResourceRequest(QObject* parent, const QUrl& url) : ResourceRequest(parent, url) { }
+    HTTPResourceRequest(const QUrl& url) : ResourceRequest(url) { }
     ~HTTPResourceRequest();
 
 protected:
@@ -33,7 +33,10 @@ private slots:
     void onRequestFinished();
 
 private:
-    QTimer _sendTimer;
+    void setupTimer();
+    void cleanupTimer();
+
+    QTimer* _sendTimer { nullptr };
     QNetworkReply* _reply { nullptr };
 };
 

--- a/libraries/networking/src/ResourceManager.cpp
+++ b/libraries/networking/src/ResourceManager.cpp
@@ -11,12 +11,20 @@
 
 #include "ResourceManager.h"
 
-#include "AssetResourceRequest.h"
-#include "FileResourceRequest.h"
-#include "HTTPResourceRequest.h"
+#include <QNetworkDiskCache>
+#include <QStandardPaths>
+#include <QThread>
 
 #include <SharedUtil.h>
 
+
+#include "AssetResourceRequest.h"
+#include "FileResourceRequest.h"
+#include "HTTPResourceRequest.h"
+#include "NetworkAccessManager.h"
+
+
+QThread ResourceManager::_thread;
 ResourceManager::PrefixMap ResourceManager::_prefixMap;
 QMutex ResourceManager::_prefixMapLock;
 
@@ -67,18 +75,41 @@ QUrl ResourceManager::normalizeURL(const QUrl& originalUrl) {
     return url;
 }
 
+void ResourceManager::init() {
+    _thread.setObjectName("Ressource Manager Thread");
+
+    auto assetClient = DependencyManager::set<AssetClient>();
+    assetClient->moveToThread(&_thread);
+    QObject::connect(&_thread, &QThread::started, assetClient.data(), &AssetClient::init);
+
+    _thread.start();
+}
+
+void ResourceManager::cleanup() {
+    // cleanup the AssetClient thread
+    DependencyManager::destroy<AssetClient>();
+    _thread.quit();
+    _thread.wait();
+}
+
 ResourceRequest* ResourceManager::createResourceRequest(QObject* parent, const QUrl& url) {
     auto normalizedURL = normalizeURL(url);
     auto scheme = normalizedURL.scheme();
+
+    ResourceRequest* request = nullptr;
+
     if (scheme == URL_SCHEME_FILE) {
-        return new FileResourceRequest(parent, normalizedURL);
+        request = new FileResourceRequest(normalizedURL);
     } else if (scheme == URL_SCHEME_HTTP || scheme == URL_SCHEME_HTTPS || scheme == URL_SCHEME_FTP) {
-        return new HTTPResourceRequest(parent, normalizedURL);
+        request = new HTTPResourceRequest(normalizedURL);
     } else if (scheme == URL_SCHEME_ATP) {
-        return new AssetResourceRequest(parent, normalizedURL);
+        request = new AssetResourceRequest(normalizedURL);
+    } else {
+        qDebug() << "Unknown scheme (" << scheme << ") for URL: " << url.url();
+        return nullptr;
     }
+    Q_ASSERT(request);
 
-    qDebug() << "Unknown scheme (" << scheme << ") for URL: " << url.url();
-
-    return nullptr;
+    request->moveToThread(&_thread);
+    return request;
 }

--- a/libraries/networking/src/ResourceManager.h
+++ b/libraries/networking/src/ResourceManager.h
@@ -29,8 +29,15 @@ public:
     static void setUrlPrefixOverride(const QString& prefix, const QString& replacement);
     static QString normalizeURL(const QString& urlString);
     static QUrl normalizeURL(const QUrl& url);
+
     static ResourceRequest* createResourceRequest(QObject* parent, const QUrl& url);
+
+    static void init();
+    static void cleanup();
+
 private:
+    static QThread _thread;
+
     using PrefixMap = std::map<QString, QString>;
 
     static PrefixMap _prefixMap;

--- a/libraries/networking/src/ResourceRequest.cpp
+++ b/libraries/networking/src/ResourceRequest.cpp
@@ -11,12 +11,15 @@
 
 #include "ResourceRequest.h"
 
-ResourceRequest::ResourceRequest(QObject* parent, const QUrl& url) :
-    QObject(parent),
-    _url(url) {
-}
+#include <QtCore/QThread>
+
+ResourceRequest::ResourceRequest(const QUrl& url) : _url(url) { }
 
 void ResourceRequest::send() {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "send", Qt::QueuedConnection);
+        return;
+    }
     Q_ASSERT(_state == NotStarted);
 
     _state = InProgress;

--- a/libraries/networking/src/ResourceRequest.h
+++ b/libraries/networking/src/ResourceRequest.h
@@ -20,7 +20,7 @@
 class ResourceRequest : public QObject {
     Q_OBJECT
 public:
-    ResourceRequest(QObject* parent, const QUrl& url);
+    ResourceRequest(const QUrl& url);
 
     enum State {
         NotStarted = 0,
@@ -38,7 +38,6 @@ public:
         NotFound
     };
 
-    void send();
     QByteArray getData() { return _data; }
     State getState() const { return _state; }
     Result getResult() const { return _result; }
@@ -47,8 +46,11 @@ public:
 
     void setCacheEnabled(bool value) { _cacheEnabled = value; }
 
+public slots:
+    void send();
+
 signals:
-    void progress(uint64_t bytesReceived, uint64_t bytesTotal);
+    void progress(qint64 bytesReceived, qint64 bytesTotal);
     void finished();
 
 protected:


### PR DESCRIPTION
- Put all resource request on the same thread (Formerly only the AssetClient's thread)
- Made sure all resource request have the disk cache accessible.
- Made sure we don't have several disk cache instances sharing a same directory.