### PR TITLE
More accurate X/Z movement with edit.js

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -728,9 +728,10 @@ function rayPlaneIntersection2(pickRay, point, normal) {
     //  This version of the test returns false if the ray is directed away from the plane
     //
     var collides = Vec3.dot(pickRay.direction, normal);
-    if (collides > 0.0) return false;
-
     var d = -Vec3.dot(point, normal);
+    if (((collides > 0.0) && (d > 0.0)) || ((collides < 0.0) && (d < 0.0))) {
+        return false;
+    }
     var t = -(Vec3.dot(pickRay.origin, normal) + d) / collides;
 
     return Vec3.sum(pickRay.origin, Vec3.multiply(pickRay.direction, t));

--- a/examples/edit.js
+++ b/examples/edit.js
@@ -945,6 +945,7 @@ function mouseReleaseEvent(event) {
 }
 
 function mouseClickEvent(event) {
+    var wantDebug = false;
     if (isActive && event.isLeftButton) {
         var result = findClickedEntity(event);
         if (result === null) {
@@ -959,11 +960,15 @@ function mouseClickEvent(event) {
 
         var properties = Entities.getEntityProperties(foundEntity);
         if (isLocked(properties)) {
-            print("Model locked " + properties.id);
+            if (wantDebug) {
+                print("Model locked " + properties.id);
+            }
         } else {
             var halfDiagonal = Vec3.length(properties.dimensions) / 2.0;
 
-            print("Checking properties: " + properties.id + " " + " - Half Diagonal:" + halfDiagonal);
+            if (wantDebug) {
+                print("Checking properties: " + properties.id + " " + " - Half Diagonal:" + halfDiagonal);
+            }
             //                P         P - Model
             //               /|         A - Palm
             //              / | d       B - unit vector toward tip
@@ -1000,8 +1005,9 @@ function mouseClickEvent(event) {
                 } else {
                     selectionManager.addEntity(foundEntity, true);
                 }
-
-                print("Model selected: " + foundEntity);
+                if (wantDebug) {
+                    print("Model selected: " + foundEntity);
+                }
                 selectionDisplay.select(selectedEntityID, event);
 
                 if (Menu.isOptionChecked(MENU_AUTO_FOCUS_ON_SELECT)) {

--- a/examples/edit.js
+++ b/examples/edit.js
@@ -729,12 +729,12 @@ function rayPlaneIntersection2(pickRay, point, normal) {
     //
     var collides = Vec3.dot(pickRay.direction, normal);
     var d = -Vec3.dot(point, normal);
-    if (((collides > 0.0) && (d > 0.0)) || ((collides < 0.0) && (d < 0.0))) {
-        return false;
-    }
     var t = -(Vec3.dot(pickRay.origin, normal) + d) / collides;
-
-    return Vec3.sum(pickRay.origin, Vec3.multiply(pickRay.direction, t));
+    if (t < 0.0) {
+        return false;
+    } else {
+        return Vec3.sum(pickRay.origin, Vec3.multiply(pickRay.direction, t));
+    }
 }
 
 function findClickedEntity(event) {

--- a/examples/edit.js
+++ b/examples/edit.js
@@ -711,9 +711,27 @@ var intersection;
 
 var SCALE_FACTOR = 200.0;
 
-function rayPlaneIntersection(pickRay, point, normal) {
+function rayPlaneIntersection(pickRay, point, normal) {    //
+    //
+    //  This version of the test returns the intersection of a line with a plane
+    //
+    var collides = Vec3.dot(pickRay.direction, normal);
+
     var d = -Vec3.dot(point, normal);
-    var t = -(Vec3.dot(pickRay.origin, normal) + d) / Vec3.dot(pickRay.direction, normal);
+    var t = -(Vec3.dot(pickRay.origin, normal) + d) / collides;
+
+    return Vec3.sum(pickRay.origin, Vec3.multiply(pickRay.direction, t));
+}
+
+function rayPlaneIntersection2(pickRay, point, normal) {
+    //
+    //  This version of the test returns false if the ray is directed away from the plane
+    //
+    var collides = Vec3.dot(pickRay.direction, normal);
+    if (collides > 0.0) return false;
+
+    var d = -Vec3.dot(point, normal);
+    var t = -(Vec3.dot(pickRay.origin, normal) + d) / collides;
 
     return Vec3.sum(pickRay.origin, Vec3.multiply(pickRay.direction, t));
 }

--- a/examples/edit.js
+++ b/examples/edit.js
@@ -758,7 +758,8 @@ function findClickedEntity(event) {
     var foundEntity = result.entityID;
     return {
         pickRay: pickRay,
-        entityID: foundEntity
+        entityID: foundEntity,
+        intersection: result.intersection
     };
 }
 
@@ -978,6 +979,8 @@ function mouseClickEvent(event) {
 
                 if (!event.isShifted) {
                     selectionManager.setSelections([foundEntity]);
+                    Vec3.print("found object, intersection = ", result.intersection);
+                    selectionManager.setPickPlanePosition(result.intersection);
                 } else {
                     selectionManager.addEntity(foundEntity, true);
                 }

--- a/examples/edit.js
+++ b/examples/edit.js
@@ -979,8 +979,6 @@ function mouseClickEvent(event) {
 
                 if (!event.isShifted) {
                     selectionManager.setSelections([foundEntity]);
-                    Vec3.print("found object, intersection = ", result.intersection);
-                    selectionManager.setPickPlanePosition(result.intersection);
                 } else {
                     selectionManager.addEntity(foundEntity, true);
                 }

--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -2264,7 +2264,6 @@ SelectionDisplay = (function() {
         greatestDimension: 0.0,
         startingDistance: 0.0,
         startingAzimuth: 0.0,
-        lastVector: { x: 0, y: 0, z: 0 },
         onBegin: function(event) {
             SelectionManager.saveProperties();
             startPosition = SelectionManager.worldPosition;
@@ -2337,7 +2336,6 @@ SelectionDisplay = (function() {
             var azimuth = translateXZTool.azimuth(pickRay.origin, pick);
             if ((translateXZTool.startingAzimuth > 0.0 && azimuth < MIN_AZIMUTH) || 
                 (translateXZTool.startingAzimuth < 0.0 && azimuth > MIN_AZIMUTH)) {
-                //vector = translateXZTool.lastVector;
                 if (wantDebug) {
                     print("Azimuth = " + azimuth);
                 }
@@ -2355,8 +2353,6 @@ SelectionDisplay = (function() {
                     return;
                 }
             }
-
-            translateXZTool.lastVector = vector; 
 
             // If shifted, constrain to one axis
             if (event.isShifted) {
@@ -3797,7 +3793,7 @@ SelectionDisplay = (function() {
     };
 
     that.mousePressEvent = function(event) {
-         
+        var wantDebug = false; 
         if (!event.isLeftButton) {
             // if another mouse button than left is pressed ignore it
             return false;
@@ -3823,7 +3819,7 @@ SelectionDisplay = (function() {
 
         if (result.intersects) {
 
-            var wantDebug = false;
+            
             if (wantDebug) {
                 print("something intersects... ");
                 print("   result.overlayID:" + result.overlayID + "[" + overlayNames[result.overlayID] + "]");
@@ -3920,7 +3916,10 @@ SelectionDisplay = (function() {
 
         if (!somethingClicked) {
 
-            print("rotate handle case...");
+            if (wantDebug) {
+                print("rotate handle case...");
+            }
+            
 
             // After testing our stretch handles, then check out rotate handles
             Overlays.editOverlay(yawHandle, {
@@ -3988,15 +3987,17 @@ SelectionDisplay = (function() {
                         break;
 
                     default:
-                        print("mousePressEvent()...... " + overlayNames[result.overlayID]);
+                        if (wantDebug) {
+                            print("mousePressEvent()...... " + overlayNames[result.overlayID]);
+                        }
                         mode = "UNKNOWN";
                         break;
                 }
             }
-
-            print("    somethingClicked:" + somethingClicked);
-            print("                mode:" + mode);
-
+            if (wantDebug) {
+                print("    somethingClicked:" + somethingClicked);
+                print("                mode:" + mode);
+            }
 
             if (somethingClicked) {
 
@@ -4142,17 +4143,22 @@ SelectionDisplay = (function() {
                         translateXZTool.pickPlanePosition = result.intersection;
                         translateXZTool.greatestDimension = Math.max(Math.max(SelectionManager.worldDimensions.x, SelectionManager.worldDimensions.y), 
                             SelectionManager.worldDimensions.z);
-                        print("longest dimension" + translateXZTool.greatestDimension);
-                        translateXZTool.startingDistance = Vec3.distance(pickRay.origin, SelectionManager.position);
-                        print("starting distance" + translateXZTool.startingDistance);
-                        translateXZTool.startingAzimuth = translateXZTool.azimuth(pickRay.origin, translateXZTool.pickPlanePosition);
-                        print("starting azimuth" + translateXZTool.startingAzimuth);
+                        if (wantDebug) {
+                            print("longest dimension: " + translateXZTool.greatestDimension);
+                            translateXZTool.startingDistance = Vec3.distance(pickRay.origin, SelectionManager.position);
+                            print("starting distance: " + translateXZTool.startingDistance);
+                            translateXZTool.startingAzimuth = translateXZTool.azimuth(pickRay.origin, translateXZTool.pickPlanePosition);
+                            print(" starting azimuth: " + translateXZTool.startingAzimuth);
+                        }
+                        
                         mode = translateXZTool.mode;
                         activeTool.onBegin(event);
                         somethingClicked = true;
                         break;
                     default:
-                        print("mousePressEvent()...... " + overlayNames[result.overlayID]);
+                        if (wantDebug) {
+                            print("mousePressEvent()...... " + overlayNames[result.overlayID]);
+                        }
                         mode = "UNKNOWN";
                         break;
                 }

--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -2334,10 +2334,13 @@ SelectionDisplay = (function() {
             // If the mouse is too close to the horizon of the pick plane, stop moving
             var MIN_AZIMUTH = 0.02;   //  Radians 
             var azimuth = translateXZTool.azimuth(pickRay.origin, pick);
+            if (wantDebug) {
+                    print("Start Azimuth: " + translateXZTool.startingAzimuth + ", Azimuth: " + azimuth);
+            }
             if ((translateXZTool.startingAzimuth > 0.0 && azimuth < MIN_AZIMUTH) || 
-                (translateXZTool.startingAzimuth < 0.0 && azimuth > MIN_AZIMUTH)) {
+                (translateXZTool.startingAzimuth < 0.0 && azimuth > -MIN_AZIMUTH)) {
                 if (wantDebug) {
-                    print("Azimuth = " + azimuth);
+                    print("too close to horizon!");
                 }
                 return;
             }

--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -2332,7 +2332,7 @@ SelectionDisplay = (function() {
             var vector = Vec3.subtract(pick, initialXZPick);
 
             // If the mouse is too close to the horizon of the pick plane, stop moving
-            var MIN_AZIMUTH = 0.02;   //  Radians 
+            var MIN_AZIMUTH = 0.02;   //  largest dimension of object divided by distance to it
             var azimuth = translateXZTool.azimuth(pickRay.origin, pick);
             if (wantDebug) {
                     print("Start Azimuth: " + translateXZTool.startingAzimuth + ", Azimuth: " + azimuth);

--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -87,11 +87,6 @@ SelectionManager = (function() {
         y: 0,
         z: 0
     };
-    that.pickPlanePosition = {
-        x: 0,
-        y: 0,
-        z: 0
-    };
 
     that.saveProperties = function() {
         that.savedProperties = {};
@@ -117,13 +112,6 @@ SelectionManager = (function() {
         }
 
         that._update();
-    };
-
-    that.setPickPlanePosition = function(position) {
-        that.pickPlanePosition.x = position.x;
-        that.pickPlanePosition.y = position.y;
-        that.pickPlanePosition.z = position.z;
-        Vec3.print("that.pickPlanePosition = ", that.pickPlanePosition);
     };
 
     that.addEntity = function(entityID, toggleSelection) {
@@ -2326,15 +2314,6 @@ SelectionDisplay = (function() {
             });
 
             var vector = Vec3.subtract(pick, initialXZPick);
-
-            Vec3.print("Pick Plane Position", translateXZTool.pickPlanePosition);
-            
-            /*
-            if (pickRay.origin.y < this.pickPlanePosition.y) {
-                vector.x *= -1.0;
-                vector.z *= -1.0;
-            } */
-            
 
             // If shifted, constrain to one axis
             if (event.isShifted) {

--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -2263,7 +2263,7 @@ SelectionDisplay = (function() {
         pickPlanePosition: { x: 0, y: 0, z: 0 },
         greatestDimension: 0.0,
         startingDistance: 0.0,
-        startingAzimuth: 0.0,
+        startingElevation: 0.0,
         onBegin: function(event) {
             SelectionManager.saveProperties();
             startPosition = SelectionManager.worldPosition;
@@ -2307,7 +2307,7 @@ SelectionDisplay = (function() {
                 visible: false
             });
         },
-        azimuth: function(origin, intersection) {
+        elevation: function(origin, intersection) {
             return (origin.y - intersection.y) / Vec3.distance(origin, intersection);
         },
         onMove: function(event) {
@@ -2332,13 +2332,13 @@ SelectionDisplay = (function() {
             var vector = Vec3.subtract(pick, initialXZPick);
 
             // If the mouse is too close to the horizon of the pick plane, stop moving
-            var MIN_AZIMUTH = 0.02;   //  largest dimension of object divided by distance to it
-            var azimuth = translateXZTool.azimuth(pickRay.origin, pick);
+            var MIN_ELEVATION = 0.02;   //  largest dimension of object divided by distance to it
+            var elevation = translateXZTool.elevation(pickRay.origin, pick);
             if (wantDebug) {
-                    print("Start Azimuth: " + translateXZTool.startingAzimuth + ", Azimuth: " + azimuth);
+                    print("Start Elevation: " + translateXZTool.startingElevation + ", elevation: " + elevation);
             }
-            if ((translateXZTool.startingAzimuth > 0.0 && azimuth < MIN_AZIMUTH) || 
-                (translateXZTool.startingAzimuth < 0.0 && azimuth > -MIN_AZIMUTH)) {
+            if ((translateXZTool.startingElevation > 0.0 && elevation < MIN_ELEVATION) || 
+                (translateXZTool.startingElevation < 0.0 && elevation > -MIN_ELEVATION)) {
                 if (wantDebug) {
                     print("too close to horizon!");
                 }
@@ -4150,8 +4150,8 @@ SelectionDisplay = (function() {
                             print("longest dimension: " + translateXZTool.greatestDimension);
                             translateXZTool.startingDistance = Vec3.distance(pickRay.origin, SelectionManager.position);
                             print("starting distance: " + translateXZTool.startingDistance);
-                            translateXZTool.startingAzimuth = translateXZTool.azimuth(pickRay.origin, translateXZTool.pickPlanePosition);
-                            print(" starting azimuth: " + translateXZTool.startingAzimuth);
+                            translateXZTool.startingElevation = translateXZTool.elevation(pickRay.origin, translateXZTool.pickPlanePosition);
+                            print(" starting elevation: " + translateXZTool.startingElevation);
                         }
                         
                         mode = translateXZTool.mode;


### PR DESCRIPTION
Plane for colliding pointer was center of object, which could be very different from where the pointer actually was over, meaning that it was easy for object to move wrong relative to pointer. 

Now the point of collision with the selection box is used, meaning objects stay under the cursor.  

Next:   1.  Use actual collision point with the entity itself rather than selection box. 
            2.  Don't allow object to move too far away if the plane passes too close to the pick ray origin.

