### PR TITLE
Fix the Vive controllers to support menus

### DIFF
--- a/interface/resources/controllers/hydra.json
+++ b/interface/resources/controllers/hydra.json
@@ -13,11 +13,11 @@
         { "from": "Hydra.RB", "to": "Standard.RB" }, 
         { "from": "Hydra.RS", "to": "Standard.RS" },
 
-        { "from": [ "Hydra.L1", "Hydra.L2", "Hydra.L3", "Hydra.L4" ], "to": "Standard.LeftPrimaryThumb" },
-        { "from": [ "Hydra.L0" ], "to": "Standard.LeftSecondaryThumb" },
+        { "from": "Hydra.L0", "to": "Standard.Back" },
+        { "from": "Hydra.R0", "to": "Standard.Start" },
 
+        { "from": [ "Hydra.L1", "Hydra.L2", "Hydra.L3", "Hydra.L4" ], "to": "Standard.LeftPrimaryThumb" },
         { "from": [ "Hydra.R1", "Hydra.R2", "Hydra.R3", "Hydra.R4" ], "to": "Standard.RightPrimaryThumb" },
-        { "from": [ "Hydra.R0" ], "to": "Standard.RightSecondaryThumb" },
 
         { "from": "Hydra.LeftHand", "to": "Standard.LeftHand" }, 
         { "from": "Hydra.RightHand", "to": "Standard.RightHand" }

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -33,7 +33,9 @@
         { "from": [ "Standard.A", "Standard.B", "Standard.X", "Standard.Y" ], "to": "Standard.RightPrimaryThumb" },
         { "from": "Standard.Start", "to": "Standard.RightSecondaryThumb" },
 
+        { "from": "Standard.LeftPrimaryThumb", "to": "Actions.CycleCamera" }, 
         { "from": "Standard.LeftSecondaryThumb", "to": "Actions.CycleCamera" }, 
+        { "from": "Standard.RightPrimaryThumb", "to": "Actions.ContextMenu" },
         { "from": "Standard.RightSecondaryThumb", "to": "Actions.ContextMenu" },
 
         { "from": "Standard.LT", "to": "Actions.LeftHandClick" }, 

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -27,16 +27,11 @@
 
         { "from": "Standard.RY", "to": "Actions.Up", "filters": "invert"}, 
 
+        { "from": "Standard.Back", "to": "Actions.CycleCamera" },
+        { "from": "Standard.Start", "to": "Actions.ContextMenu" },
+
         { "from": [ "Standard.DU", "Standard.DL", "Standard.DR", "Standard.DD" ], "to": "Standard.LeftPrimaryThumb" },
-        { "from": "Standard.Back", "to": "Standard.LeftSecondaryThumb" },
-
         { "from": [ "Standard.A", "Standard.B", "Standard.X", "Standard.Y" ], "to": "Standard.RightPrimaryThumb" },
-        { "from": "Standard.Start", "to": "Standard.RightSecondaryThumb" },
-
-        { "from": "Standard.LeftPrimaryThumb", "to": "Actions.CycleCamera" }, 
-        { "from": "Standard.LeftSecondaryThumb", "to": "Actions.CycleCamera" }, 
-        { "from": "Standard.RightPrimaryThumb", "to": "Actions.ContextMenu" },
-        { "from": "Standard.RightSecondaryThumb", "to": "Actions.ContextMenu" },
 
         { "from": "Standard.LT", "to": "Actions.LeftHandClick" }, 
         { "from": "Standard.RT", "to": "Actions.RightHandClick" },

--- a/interface/resources/controllers/standard_navigation.json
+++ b/interface/resources/controllers/standard_navigation.json
@@ -12,7 +12,7 @@
         { "from": "Standard.LB", "to": "Actions.UiNavGroup","filters": "invert" },
         { "from": "Standard.RB", "to": "Actions.UiNavGroup" },
         { "from": [ "Standard.A", "Standard.X" ], "to": "Actions.UiNavSelect" },
-        { "from": [ "Standard.B", "Standard.Y", "Standard.RightPrimaryThumb", "Standard.LeftPrimaryThumb" ], "to": "Actions.UiNavBack" },
+        { "from": [ "Standard.B", "Standard.Y" ], "to": "Actions.UiNavBack" },
         { 
             "from": [ "Standard.RT", "Standard.LT" ], 
             "to": "Actions.UiNavSelect", 

--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -15,10 +15,8 @@
         { "from": "Vive.RB", "to": "Standard.RB" },
         { "from": "Vive.RS", "to": "Standard.RS" },
 
-        { "from": "Vive.LeftPrimaryThumb", "to": "Standard.LeftPrimaryThumb" },
-        { "from": "Vive.RightPrimaryThumb", "to": "Standard.RightPrimaryThumb" },
-        { "from": "Vive.LeftSecondaryThumb", "to": "Standard.LeftSecondaryThumb" },
-        { "from": "Vive.RightSecondaryThumb", "to": "Standard.RightSecondaryThumb" },
+        { "from": "Vive.Back", "to": "Standard.Back" },
+        { "from": "Vive.Start", "to": "Standard.Start" },
 
         { "from": "Vive.LeftHand", "to": "Standard.LeftHand" },
         { "from": "Vive.RightHand", "to": "Standard.RightHand" }

--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -15,8 +15,8 @@
         { "from": "Vive.RB", "to": "Standard.RB" },
         { "from": "Vive.RS", "to": "Standard.RS" },
 
-        { "from": "Vive.Back", "to": "Standard.Back" },
-        { "from": "Vive.Start", "to": "Standard.Start" },
+        { "from": "Vive.LeftApplicationMenu", "to": "Standard.Back" },
+        { "from": "Vive.RightApplicationMenu", "to": "Standard.Start" },
 
         { "from": "Vive.LeftHand", "to": "Standard.LeftHand" },
         { "from": "Vive.RightHand", "to": "Standard.RightHand" }

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -311,7 +311,7 @@ void ViveControllerManager::InputDevice::handleButtonEvent(float deltaTime, uint
 
     using namespace controller;
     if (button == vr::k_EButton_ApplicationMenu) {
-        _buttonPressedMap.insert(isLeftHand ? LEFT_PRIMARY_THUMB : RIGHT_PRIMARY_THUMB);
+        _buttonPressedMap.insert(isLeftHand ? BACK : START);
     } else if (button == vr::k_EButton_Grip) {
         _buttonPressedMap.insert(isLeftHand ? LB : RB);
     } else if (button == vr::k_EButton_SteamVR_Trigger) {
@@ -426,10 +426,8 @@ controller::Input::NamedVector ViveControllerManager::InputDevice::getAvailableI
         makePair(LEFT_HAND, "LeftHand"),
         makePair(RIGHT_HAND, "RightHand"),
 
-        makePair(LEFT_PRIMARY_THUMB, "LeftPrimaryThumb"),
-        makePair(LEFT_SECONDARY_THUMB, "LeftSecondaryThumb"),
-        makePair(RIGHT_PRIMARY_THUMB, "RightPrimaryThumb"),
-        makePair(RIGHT_SECONDARY_THUMB, "RightSecondaryThumb"),
+        makePair(BACK, "Back"),
+        makePair(START, "Start"),
     };
 
     //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 0), "Left Button A"));

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -426,8 +426,8 @@ controller::Input::NamedVector ViveControllerManager::InputDevice::getAvailableI
         makePair(LEFT_HAND, "LeftHand"),
         makePair(RIGHT_HAND, "RightHand"),
 
-        makePair(BACK, "Back"),
-        makePair(START, "Start"),
+        makePair(BACK, "LeftApplicationMenu"),
+        makePair(START, "RightApplicationMenu"),
     };
 
     //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 0), "Left Button A"));

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -303,6 +303,13 @@ void ViveControllerManager::InputDevice::handleAxisEvent(float deltaTime, uint32
     }
 }
 
+// An enum for buttons which do not exist in the StandardControls enum
+enum ViveButtonChannel {
+    LEFT_APP_MENU = controller::StandardButtonChannel::NUM_STANDARD_BUTTONS,
+    RIGHT_APP_MENU
+};
+
+
 // These functions do translation from the Steam IDs to the standard controller IDs
 void ViveControllerManager::InputDevice::handleButtonEvent(float deltaTime, uint32_t button, bool pressed, bool isLeftHand) {
     if (!pressed) {
@@ -311,7 +318,7 @@ void ViveControllerManager::InputDevice::handleButtonEvent(float deltaTime, uint
 
     using namespace controller;
     if (button == vr::k_EButton_ApplicationMenu) {
-        _buttonPressedMap.insert(isLeftHand ? BACK : START);
+        _buttonPressedMap.insert(isLeftHand ? LEFT_APP_MENU : RIGHT_APP_MENU);
     } else if (button == vr::k_EButton_Grip) {
         _buttonPressedMap.insert(isLeftHand ? LB : RB);
     } else if (button == vr::k_EButton_SteamVR_Trigger) {
@@ -426,21 +433,9 @@ controller::Input::NamedVector ViveControllerManager::InputDevice::getAvailableI
         makePair(LEFT_HAND, "LeftHand"),
         makePair(RIGHT_HAND, "RightHand"),
 
-        makePair(BACK, "LeftApplicationMenu"),
-        makePair(START, "RightApplicationMenu"),
+        Input::NamedPair(Input(_deviceID, LEFT_APP_MENU, ChannelType::BUTTON), "LeftApplicationMenu"),
+        Input::NamedPair(Input(_deviceID, RIGHT_APP_MENU, ChannelType::BUTTON), "RightApplicationMenu"),
     };
-
-    //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 0), "Left Button A"));
-    //availableInputs.append(Input::NamedPair(makeInput(GRIP_BUTTON, 0), "Left Grip Button"));
-    //availableInputs.append(Input::NamedPair(makeInput(TRACKPAD_BUTTON, 0), "Left Trackpad Button"));
-    //availableInputs.append(Input::NamedPair(makeInput(TRIGGER_BUTTON, 0), "Left Trigger Button"));
-    //availableInputs.append(Input::NamedPair(makeInput(BACK_TRIGGER, 0), "Left Back Trigger"));
-    //availableInputs.append(Input::NamedPair(makeInput(RIGHT_HAND), "Right Hand"));
-    //availableInputs.append(Input::NamedPair(makeInput(BUTTON_A, 1), "Right Button A"));
-    //availableInputs.append(Input::NamedPair(makeInput(GRIP_BUTTON, 1), "Right Grip Button"));
-    //availableInputs.append(Input::NamedPair(makeInput(TRACKPAD_BUTTON, 1), "Right Trackpad Button"));
-    //availableInputs.append(Input::NamedPair(makeInput(TRIGGER_BUTTON, 1), "Right Trigger Button"));
-    //availableInputs.append(Input::NamedPair(makeInput(BACK_TRIGGER, 1), "Right Back Trigger"));
 
     return availableInputs;
 }
@@ -449,31 +444,3 @@ QString ViveControllerManager::InputDevice::getDefaultMappingConfig() const {
     static const QString MAPPING_JSON = PathUtils::resourcesPath() + "/controllers/vive.json";
     return MAPPING_JSON;
 }
-
-//void ViveControllerManager::assignDefaultInputMapping(UserInputMapper& mapper) {
-//    const float JOYSTICK_MOVE_SPEED = 1.0f;
-//
-//    // Left Trackpad: Movement, strafing
-//    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_FORWARD, makeInput(AXIS_Y_POS, 0), makeInput(TRACKPAD_BUTTON, 0), JOYSTICK_MOVE_SPEED);
-//    mapper.addInputChannel(UserInputMapper::LONGITUDINAL_BACKWARD, makeInput(AXIS_Y_NEG, 0), makeInput(TRACKPAD_BUTTON, 0), JOYSTICK_MOVE_SPEED);
-//    mapper.addInputChannel(UserInputMapper::LATERAL_RIGHT, makeInput(AXIS_X_POS, 0), makeInput(TRACKPAD_BUTTON, 0), JOYSTICK_MOVE_SPEED);
-//    mapper.addInputChannel(UserInputMapper::LATERAL_LEFT, makeInput(AXIS_X_NEG, 0), makeInput(TRACKPAD_BUTTON, 0), JOYSTICK_MOVE_SPEED);
-//
-//    // Right Trackpad: Vertical movement, zooming
-//    mapper.addInputChannel(UserInputMapper::VERTICAL_UP, makeInput(AXIS_Y_POS, 1), makeInput(TRACKPAD_BUTTON, 1), JOYSTICK_MOVE_SPEED);
-//    mapper.addInputChannel(UserInputMapper::VERTICAL_DOWN, makeInput(AXIS_Y_NEG, 1), makeInput(TRACKPAD_BUTTON, 1), JOYSTICK_MOVE_SPEED);
-//
-//    // Buttons
-//    mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(BUTTON_A, 0));
-//    mapper.addInputChannel(UserInputMapper::SHIFT, makeInput(BUTTON_A, 1));
-//
-//    mapper.addInputChannel(UserInputMapper::ACTION1, makeInput(GRIP_BUTTON, 0));
-//    mapper.addInputChannel(UserInputMapper::ACTION2, makeInput(GRIP_BUTTON, 1));
-//
-//    mapper.addInputChannel(UserInputMapper::LEFT_HAND_CLICK, makeInput(BACK_TRIGGER, 0));
-//    mapper.addInputChannel(UserInputMapper::RIGHT_HAND_CLICK, makeInput(BACK_TRIGGER, 1));
-//
-//    // Hands
-//    mapper.addInputChannel(UserInputMapper::LEFT_HAND, makeInput(LEFT_HAND));
-//    mapper.addInputChannel(UserInputMapper::RIGHT_HAND, makeInput(RIGHT_HAND));
-//}


### PR DESCRIPTION
We map the secondary thumbs to 'cycle camera' and 'context menu', but the vive has no mapping to the secondary thumb.  on the other hand we appear to not map the primary thumb to anything by default, so I'm adding a mapping to the same 'cycle camera' and 'context menu' actions, which should allow them to be triggered from the menu / application button on the Vive hand controllers.