### PR TITLE
manually install OpenSSL DLLs for Qt

### DIFF
--- a/cmake/macros/InstallBesideConsole.cmake
+++ b/cmake/macros/InstallBesideConsole.cmake
@@ -64,5 +64,10 @@ macro(install_beside_console)
       )
     endif()
 
+    # set variables used by manual ssleay library copy
+    set(TARGET_INSTALL_DIR ${COMPONENT_INSTALL_DIR})
+    set(TARGET_INSTALL_COMPONENT ${SERVER_COMPONENT})
+    manually_install_openssl_for_qt()
+
   endif ()
 endmacro()

--- a/cmake/macros/ManuallyInstallOpenSSLForQt.cmake
+++ b/cmake/macros/ManuallyInstallOpenSSLForQt.cmake
@@ -1,0 +1,34 @@
+#
+#  ManuallyInstallOpenSSLforQt.cmake
+#
+#  Created by Stephen Birarda on 1/15/16.
+#  Copyright 2014 High Fidelity, Inc.
+#
+#  Distributed under the Apache License, Version 2.0.
+#  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+#
+
+macro(manually_install_openssl_for_qt)
+
+  # Qt dynamically links OpenSSL if it can find it on the user's machine
+  # We want to avoid it being found somewhere random and have it not being a compatible version
+  # So even though we don't need the dynamic version of OpenSSL for our direct-use purposes
+  # we use this macro to include the two SSL DLLs with the targets using QtNetwork
+  if (WIN32)
+    # we have to call find_package(OpenSSL) here even though this target may not directly need it
+    find_package(OpenSSL REQUIRED)
+
+    install(
+      FILES "${OPENSSL_DLL_PATH}/ssleay32.dll"
+      DESTINATION ${TARGET_INSTALL_DIR}
+      COMPONENT ${TARGET_INSTALL_COMPONENT}
+    )
+
+    install(
+      FILES "${OPENSSL_DLL_PATH}/libeay32.dll"
+      DESTINATION ${TARGET_INSTALL_DIR}
+      COMPONENT ${TARGET_INSTALL_COMPONENT}
+    )
+  endif()
+
+endmacro()

--- a/cmake/modules/FindOpenSSL.cmake
+++ b/cmake/modules/FindOpenSSL.cmake
@@ -107,6 +107,8 @@ if (WIN32 AND NOT CYGWIN)
     select_library_configurations(SSL_EAY)
 
     set(OPENSSL_LIBRARIES ${SSL_EAY_LIBRARY} ${LIB_EAY_LIBRARY})
+
+    find_path(OPENSSL_DLL_PATH NAMES ssleay32.dll PATH_SUFFIXES "bin" ${_OPENSSL_ROOT_HINTS_AND_PATHS})
   endif()
 else()
 
@@ -198,6 +200,9 @@ endif ()
 include(FindPackageHandleStandardArgs)
 
 set(OPENSSL_REQUIREMENTS OPENSSL_LIBRARIES OPENSSL_INCLUDE_DIR)
+if (WIN32)
+  list(APPEND OPENSSL_REQUIREMENTS OPENSSL_DLL_PATH)
+endif ()
 
 if (OPENSSL_VERSION)
   find_package_handle_standard_args(OpenSSL

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -266,5 +266,9 @@ add_bugsplat()
 if (WIN32)
     set(EXTRA_DEPLOY_OPTIONS "--qmldir  ${PROJECT_SOURCE_DIR}/resources/qml")
 
+    set(TARGET_INSTALL_DIR ${INTERFACE_INSTALL_DIR})
+    set(TARGET_INSTALL_COMPONENT ${CLIENT_COMPONENT})
+    manually_install_openssl_for_qt()
+
     package_libraries_for_deployment()
 endif()


### PR DESCRIPTION
- fixes a bug for fresh installs on machines with incompatible OpenSSL DLLs present elsewhere on the machine