### PR TITLE
Allow message passing from a script to a QML window

### DIFF
--- a/interface/resources/qml/QmlWindow.qml
+++ b/interface/resources/qml/QmlWindow.qml
@@ -50,7 +50,23 @@ Windows.Window {
             }
         }
     }
+
+    // Handle message traffic from the script that launched us to the loaded QML
+    function fromScript(message) {
+        if (root.dynamicContent && root.dynamicContent.fromScript) {
+            root.dynamicContent.fromScript(message);
+        }
+    }
     
+    // Handle message traffic from our loaded QML to the script that launched us
+    signal sendToScript(var message);
+    onDynamicContentChanged: {
+        if (dynamicContent && dynamicContent.sendToScript) {
+            dynamicContent.sendToScript.connect(sendToScript);
+        }
+    }
+
+
     Item {
         id: contentHolder
         anchors.fill: parent

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -217,6 +217,13 @@ QmlWindowClass::QmlWindowClass(QObject* qmlWindow)
     qDebug() << "Created window with ID " << _windowId;
     Q_ASSERT(_qmlWindow);
     Q_ASSERT(dynamic_cast<const QQuickItem*>(_qmlWindow));
+    // Forward messages received from QML on to the script
+    connect(_qmlWindow, SIGNAL(sendToScript(QVariant)), this, SIGNAL(fromQml(const QVariant&)), Qt::QueuedConnection);
+}
+
+void QmlWindowClass::sendToQml(const QVariant& message) {
+    // Forward messages received from the script on to QML
+    QMetaObject::invokeMethod(asQuickItem(), "fromScript", Qt::QueuedConnection, Q_ARG(QVariant, message));
 }
 
 QmlWindowClass::~QmlWindowClass() {

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -67,17 +67,23 @@ public slots:
 
     void setTitle(const QString& title);
 
+
     // Ugh.... do not want to do
     Q_INVOKABLE void raise();
     Q_INVOKABLE void close();
     Q_INVOKABLE int getWindowId() const { return _windowId; };
     Q_INVOKABLE QmlScriptEventBridge* getEventBridge() const { return _eventBridge; };
 
+    // Scripts can use this to send a message to the QML object
+    void sendToQml(const QVariant& message);
+
 signals:
     void visibilityChanged(bool visible);  // Tool window
     void moved(glm::vec2 position);
     void resized(QSizeF size);
     void closed();
+    // Scripts can connect to this signal to receive messages from the QML object
+    void fromQml(const QVariant& message);
 
 protected slots:
     void hasClosed();


### PR DESCRIPTION
Similar to the *eventBridge* functionality that lets a script communicate with a launched web window, this allows a script to send messages to and receive messages from a launched QML window.

From the script side you might do the following:

```
var QML_URL = "https://s3.amazonaws.com/DreamingContent/qml/TardisBuild.qml";
var qmlWindow = new OverlayWindow({
    source: QML_URL, 
    width: 128, height: 128,
    visible: false
});
qmlWindow.setPosition(30, 30);
qmlWindow.setVisible(true);

// Handling an incoming message from the QML window
qmlWindow.fromQml.connect(function(message){
    print("Got message from QML in script");
    print(message)
})

// Note, QML loading is not instantaneous, so you want to give a delay before attempting to send
// to the QML content.  You may wish to wait for a response to a given command before starting 
// other operations.
Script.setTimeout(function() {
    // Sending a message to the QML window
    qmlWindow.sendToQml(["foo", "bar", {x: 1}]);
}, 1000);
```


From the QML side, you simply need to implement a signal and a handler *at the root level of your QML*.  So for instance in the above referenced file https://s3.amazonaws.com/DreamingContent/qml/TardisBuild.qml we see the following:

```
    function fromScript(message) {
        console.log("Got script message in QML window: " + message);
        console.log("Echoing");
        sendToScript(message);
    }

    signal sendToScript(string message);
```

This setup should produce the following log:

[03/04 11:26:05] [DEBUG] Got script message in tardis window: foo,bar,[object Object]
[03/04 11:26:05] [DEBUG] Echoing
[03/04 11:26:05] [DEBUG] script:print()<< Got message from QML in script
[03/04 11:26:05] [DEBUG] script:print()<< foo,bar,[object Object]

Note that this mechanism is more versatile than the corresponding web system in that the messages  are passed as variants, rather than as strings.  This means that you do not need to `JSON.stringify` complex objects before sending them.  As long as the type of data is serializable (i.e. doesn't include functions or other callables), then the message should arrive as it was sent.  