### PR TITLE
disable AC child file logging by default

### DIFF
--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -96,9 +96,6 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     const QCommandLineOption logDirectoryOption(ASSIGNMENT_LOG_DIRECTORY, "directory to store logs", "log-directory");
     parser.addOption(logDirectoryOption);
 
-    const QCommandLineOption noLogFileOption(ASSIGNMENT_NO_CHILD_LOG_FILE_OPTION, "disable writing of child assignment-client output to file");
-    parser.addOption(noLogFileOption);
-
     if (!parser.parse(QCoreApplication::arguments())) {
         qCritical() << parser.errorText() << endl;
         parser.showHelp();
@@ -142,17 +139,10 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
         httpStatusPort = parser.value(httpStatusPortOption).toUShort();
     }
 
-    bool wantsChildFileLogging = false;
-    QDir logDirectory { "." };
+    QString logDirectory;
 
-    if (!parser.isSet(noLogFileOption)) {
-        wantsChildFileLogging = true;
-
-        if (parser.isSet(logDirectoryOption)) {
-            logDirectory = parser.value(logDirectoryOption);
-        } else {
-            logDirectory = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-        }
+    if (parser.isSet(logDirectoryOption)) {
+        logDirectory = parser.value(logDirectoryOption);
     }
 
 
@@ -226,8 +216,7 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
         AssignmentClientMonitor* monitor =  new AssignmentClientMonitor(numForks, minForks, maxForks,
                                                                         requestAssignmentType, assignmentPool,
                                                                         listenPort, walletUUID, assignmentServerHostname,
-                                                                        assignmentServerPort, httpStatusPort, logDirectory,
-                                                                        wantsChildFileLogging);
+                                                                        assignmentServerPort, httpStatusPort, logDirectory);
         monitor->setParent(this);
         connect(this, &QCoreApplication::aboutToQuit, monitor, &AssignmentClientMonitor::aboutToQuit);
     } else {

--- a/assignment-client/src/AssignmentClientApp.h
+++ b/assignment-client/src/AssignmentClientApp.h
@@ -27,6 +27,7 @@ const QString ASSIGNMENT_MAX_FORKS_OPTION = "max";
 const QString ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION = "monitor-port";
 const QString ASSIGNMENT_HTTP_STATUS_PORT = "http-status-port";
 const QString ASSIGNMENT_LOG_DIRECTORY = "log-directory";
+const QString ASSIGNMENT_NO_CHILD_LOG_FILE_OPTION = "no-child-log-files";
 
 class AssignmentClientApp : public QCoreApplication {
     Q_OBJECT

--- a/assignment-client/src/AssignmentClientApp.h
+++ b/assignment-client/src/AssignmentClientApp.h
@@ -27,7 +27,6 @@ const QString ASSIGNMENT_MAX_FORKS_OPTION = "max";
 const QString ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION = "monitor-port";
 const QString ASSIGNMENT_HTTP_STATUS_PORT = "http-status-port";
 const QString ASSIGNMENT_LOG_DIRECTORY = "log-directory";
-const QString ASSIGNMENT_NO_CHILD_LOG_FILE_OPTION = "no-child-log-files";
 
 class AssignmentClientApp : public QCoreApplication {
     Q_OBJECT

--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -33,7 +33,8 @@ AssignmentClientMonitor::AssignmentClientMonitor(const unsigned int numAssignmen
                                                  const unsigned int maxAssignmentClientForks,
                                                  Assignment::Type requestAssignmentType, QString assignmentPool,
                                                  quint16 listenPort, QUuid walletUUID, QString assignmentServerHostname,
-                                                 quint16 assignmentServerPort, quint16 httpStatusServerPort, QDir logDirectory) :
+                                                 quint16 assignmentServerPort, quint16 httpStatusServerPort, QDir logDirectory,
+                                                 bool wantsChildFileLogging) :
     _logDirectory(logDirectory),
     _httpManager(QHostAddress::LocalHost, httpStatusServerPort, "", this),
     _numAssignmentClientForks(numAssignmentClientForks),
@@ -43,7 +44,8 @@ AssignmentClientMonitor::AssignmentClientMonitor(const unsigned int numAssignmen
     _assignmentPool(assignmentPool),
     _walletUUID(walletUUID),
     _assignmentServerHostname(assignmentServerHostname),
-    _assignmentServerPort(assignmentServerPort)
+    _assignmentServerPort(assignmentServerPort),
+    _wantsChildFileLogging(wantsChildFileLogging)
 
 {
     qDebug() << "_requestAssignmentType =" << _requestAssignmentType;
@@ -159,51 +161,60 @@ void AssignmentClientMonitor::spawnChildClient() {
     _childArguments.append("--" + ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION);
     _childArguments.append(QString::number(DependencyManager::get<NodeList>()->getLocalSockAddr().getPort()));
 
-    // Setup log files
-    const QString DATETIME_FORMAT = "yyyyMMdd.hh.mm.ss.zzz";
+    QString nowString, stdoutFilenameTemp, stderrFilenameTemp, stdoutPathTemp, stderrPathTemp;
 
-    if (!_logDirectory.exists()) {
-        qDebug() << "Log directory (" << _logDirectory.absolutePath() << ") does not exist, creating.";
-        _logDirectory.mkpath(_logDirectory.absolutePath());
+
+    if (_wantsChildFileLogging) {
+        // Setup log files
+        const QString DATETIME_FORMAT = "yyyyMMdd.hh.mm.ss.zzz";
+
+        if (!_logDirectory.exists()) {
+            qDebug() << "Log directory (" << _logDirectory.absolutePath() << ") does not exist, creating.";
+            _logDirectory.mkpath(_logDirectory.absolutePath());
+        }
+
+        nowString = QDateTime::currentDateTime().toString(DATETIME_FORMAT);
+        stdoutFilenameTemp = QString("ac-%1-stdout.txt").arg(nowString);
+        stderrFilenameTemp = QString("ac-%1-stderr.txt").arg(nowString);
+        stdoutPathTemp = _logDirectory.absoluteFilePath(stdoutFilenameTemp);
+        stderrPathTemp = _logDirectory.absoluteFilePath(stderrFilenameTemp);
+
+        // reset our output and error files
+        assignmentClient->setStandardOutputFile(stdoutPathTemp);
+        assignmentClient->setStandardErrorFile(stderrPathTemp);
     }
-
-    auto nowString = QDateTime::currentDateTime().toString(DATETIME_FORMAT);
-    auto stdoutFilenameTemp = QString("ac-%1-stdout.txt").arg(nowString);
-    auto stderrFilenameTemp = QString("ac-%1-stderr.txt").arg(nowString);
-    QString stdoutPathTemp = _logDirectory.absoluteFilePath(stdoutFilenameTemp);
-    QString stderrPathTemp = _logDirectory.absoluteFilePath(stderrFilenameTemp);
-
-    // reset our output and error files
-    assignmentClient->setStandardOutputFile(stdoutPathTemp);
-    assignmentClient->setStandardErrorFile(stderrPathTemp);
 
     // make sure that the output from the child process appears in our output
     assignmentClient->setProcessChannelMode(QProcess::ForwardedChannels);
-
     assignmentClient->start(QCoreApplication::applicationFilePath(), _childArguments);
 
-    // Update log path to use PID in filename
-    auto stdoutFilename = QString("ac-%1_%2-stdout.txt").arg(nowString).arg(assignmentClient->processId());
-    auto stderrFilename = QString("ac-%1_%2-stderr.txt").arg(nowString).arg(assignmentClient->processId());
-    QString stdoutPath = _logDirectory.absoluteFilePath(stdoutFilename);
-    QString stderrPath = _logDirectory.absoluteFilePath(stderrFilename);
+    QString stdoutPath, stderrPath;
 
-    qDebug() << "Renaming " << stdoutPathTemp << " to " << stdoutPath;
-    if (!_logDirectory.rename(stdoutFilenameTemp, stdoutFilename)) {
-        qDebug() << "Failed to rename " << stdoutFilenameTemp;
-        stdoutPath = stdoutPathTemp;
-        stdoutFilename = stdoutFilenameTemp;
+    if (_wantsChildFileLogging) {
+
+        // Update log path to use PID in filename
+        auto stdoutFilename = QString("ac-%1_%2-stdout.txt").arg(nowString).arg(assignmentClient->processId());
+        auto stderrFilename = QString("ac-%1_%2-stderr.txt").arg(nowString).arg(assignmentClient->processId());
+        stdoutPath = _logDirectory.absoluteFilePath(stdoutFilename);
+        stderrPath = _logDirectory.absoluteFilePath(stderrFilename);
+
+        qDebug() << "Renaming " << stdoutPathTemp << " to " << stdoutPath;
+        if (!_logDirectory.rename(stdoutFilenameTemp, stdoutFilename)) {
+            qDebug() << "Failed to rename " << stdoutFilenameTemp;
+            stdoutPath = stdoutPathTemp;
+            stdoutFilename = stdoutFilenameTemp;
+        }
+
+        qDebug() << "Renaming " << stderrPathTemp << " to " << stderrPath;
+        if (!QFile::rename(stderrPathTemp, stderrPath)) {
+            qDebug() << "Failed to rename " << stderrFilenameTemp;
+            stderrPath = stderrPathTemp;
+            stderrFilename = stderrFilenameTemp;
+        }
+        
+        qDebug() << "Child stdout being written to: " << stdoutFilename;
+        qDebug() << "Child stderr being written to: " << stderrFilename;
     }
-
-    qDebug() << "Renaming " << stderrPathTemp << " to " << stderrPath;
-    if (!QFile::rename(stderrPathTemp, stderrPath)) {
-        qDebug() << "Failed to rename " << stderrFilenameTemp;
-        stderrPath = stderrPathTemp;
-        stderrFilename = stderrFilenameTemp;
-    }
-
-    qDebug() << "Child stdout being written to: " << stdoutFilename;
-    qDebug() << "Child stderr being written to: " << stderrFilename;
 
     if (assignmentClient->processId() > 0) {
         auto pid = assignmentClient->processId();
@@ -212,6 +223,7 @@ void AssignmentClientMonitor::spawnChildClient() {
                 this, [this, pid]() { childProcessFinished(pid); });
 
         qDebug() << "Spawned a child client with PID" << assignmentClient->processId();
+
         _childProcesses.insert(assignmentClient->processId(), { assignmentClient, stdoutPath, stderrPath });
     }
 }

--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -33,9 +33,7 @@ AssignmentClientMonitor::AssignmentClientMonitor(const unsigned int numAssignmen
                                                  const unsigned int maxAssignmentClientForks,
                                                  Assignment::Type requestAssignmentType, QString assignmentPool,
                                                  quint16 listenPort, QUuid walletUUID, QString assignmentServerHostname,
-                                                 quint16 assignmentServerPort, quint16 httpStatusServerPort, QDir logDirectory,
-                                                 bool wantsChildFileLogging) :
-    _logDirectory(logDirectory),
+                                                 quint16 assignmentServerPort, quint16 httpStatusServerPort, QString logDirectory) :
     _httpManager(QHostAddress::LocalHost, httpStatusServerPort, "", this),
     _numAssignmentClientForks(numAssignmentClientForks),
     _minAssignmentClientForks(minAssignmentClientForks),
@@ -44,11 +42,15 @@ AssignmentClientMonitor::AssignmentClientMonitor(const unsigned int numAssignmen
     _assignmentPool(assignmentPool),
     _walletUUID(walletUUID),
     _assignmentServerHostname(assignmentServerHostname),
-    _assignmentServerPort(assignmentServerPort),
-    _wantsChildFileLogging(wantsChildFileLogging)
+    _assignmentServerPort(assignmentServerPort)
 
 {
     qDebug() << "_requestAssignmentType =" << _requestAssignmentType;
+
+    if (!logDirectory.isEmpty()) {
+        _wantsChildFileLogging = true;
+        _logDirectory = QDir(logDirectory);
+    }
 
     // start the Logging class with the parent's target name
     LogHandler::getInstance().setTargetName(ASSIGNMENT_CLIENT_MONITOR_TARGET_NAME);

--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -38,7 +38,8 @@ public:
     AssignmentClientMonitor(const unsigned int numAssignmentClientForks, const unsigned int minAssignmentClientForks,
                             const unsigned int maxAssignmentClientForks, Assignment::Type requestAssignmentType,
                             QString assignmentPool, quint16 listenPort, QUuid walletUUID, QString assignmentServerHostname,
-                            quint16 assignmentServerPort, quint16 httpStatusServerPort, QDir logDirectory);
+                            quint16 assignmentServerPort, quint16 httpStatusServerPort, QDir logDirectory,
+                            bool wantsChildFileLogging);
     ~AssignmentClientMonitor();
 
     void stopChildProcesses();
@@ -73,6 +74,8 @@ private:
     quint16 _assignmentServerPort;
 
     QMap<qint64, ACProcess> _childProcesses;
+
+    bool _wantsChildFileLogging;
 };
 
 #endif // hifi_AssignmentClientMonitor_h

--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -38,8 +38,7 @@ public:
     AssignmentClientMonitor(const unsigned int numAssignmentClientForks, const unsigned int minAssignmentClientForks,
                             const unsigned int maxAssignmentClientForks, Assignment::Type requestAssignmentType,
                             QString assignmentPool, quint16 listenPort, QUuid walletUUID, QString assignmentServerHostname,
-                            quint16 assignmentServerPort, quint16 httpStatusServerPort, QDir logDirectory,
-                            bool wantsChildFileLogging);
+                            quint16 assignmentServerPort, quint16 httpStatusServerPort, QString logDirectory);
     ~AssignmentClientMonitor();
 
     void stopChildProcesses();
@@ -75,7 +74,7 @@ private:
 
     QMap<qint64, ACProcess> _childProcesses;
 
-    bool _wantsChildFileLogging;
+    bool _wantsChildFileLogging { false };
 };
 
 #endif // hifi_AssignmentClientMonitor_h


### PR DESCRIPTION
- disabled writing of AC child output to log file unless `--log-directory` is passed 