### PR TITLE
fix collisions with non-default registration

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -699,6 +699,8 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         AABox box;
         for (int i = 0; i < _points.size(); i++) {
             for (int j = 0; j < _points[i].size(); j++) {
+                // compensate for registration
+                _points[i][j] += _model->getOffset();
                 // scale so the collision points match the model points
                 _points[i][j] *= scale;
                 box += _points[i][j];
@@ -708,7 +710,6 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         glm::vec3 collisionModelDimensions = box.getDimensions();
         info.setParams(type, collisionModelDimensions, _compoundShapeURL);
         info.setConvexHulls(_points);
-        info.setOffset(_model->getOffset());
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -340,10 +340,6 @@ void RenderableModelEntityItem::updateModelBounds() {
     if (!hasModel() || !_model) {
         return;
     }
-    if (_model->getRegistrationPoint() != getRegistrationPoint()) {
-        qDebug() << "HERE: " << _model->getRegistrationPoint() << getRegistrationPoint();
-    }
-
     bool movingOrAnimating = isMovingRelativeToParent() || isAnimatingSomething();
     if ((movingOrAnimating ||
          _needsInitialSimulation ||

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -598,6 +598,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
     if (type != SHAPE_TYPE_COMPOUND) {
         ModelEntityItem::computeShapeInfo(info);
         info.setParams(type, 0.5f * getDimensions());
+        adjustShapeInfoByRegistration(info);
     } else {
         const QSharedPointer<NetworkGeometry> collisionNetworkGeometry = _model->getCollisionGeometry();
 
@@ -701,6 +702,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         glm::vec3 collisionModelDimensions = box.getDimensions();
         info.setParams(type, collisionModelDimensions, _compoundShapeURL);
         info.setConvexHulls(_points);
+        adjustShapeInfoByRegistration(info);
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -610,7 +610,6 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         ModelEntityItem::computeShapeInfo(info);
         info.setParams(type, 0.5f * getDimensions());
         adjustShapeInfoByRegistration(info);
-        assert(false); // XXX
     } else {
         updateModelBounds();
         const QSharedPointer<NetworkGeometry> collisionNetworkGeometry = _model->getCollisionGeometry();
@@ -704,6 +703,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         AABox box;
         for (int i = 0; i < _points.size(); i++) {
             for (int j = 0; j < _points[i].size(); j++) {
+                // scale so the collision points match the model points
                 _points[i][j] *= scale;
                 box += _points[i][j];
             }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -703,6 +703,9 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
                 _points[i][j] += _model->getOffset();
                 // scale so the collision points match the model points
                 _points[i][j] *= scale;
+                // this next subtraction is done so we can give info the offset, which will cause
+                // the shape-key to change.
+                _points[i][j] -= _model->getOffset();
                 box += _points[i][j];
             }
         }
@@ -710,6 +713,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         glm::vec3 collisionModelDimensions = box.getDimensions();
         info.setParams(type, collisionModelDimensions, _compoundShapeURL);
         info.setConvexHulls(_points);
+        info.setOffset(_model->getOffset());
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -710,12 +710,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         }
 
         glm::vec3 collisionModelDimensions = box.getDimensions();
-        QString shapeKey = _compoundShapeURL + "," +
-            QString::number(_registrationPoint.x) + "," +
-            QString::number(_registrationPoint.y) + "," +
-            QString::number(_registrationPoint.z);
-
-        info.setParams(type, collisionModelDimensions, shapeKey);
+        info.setParams(type, collisionModelDimensions, _compoundShapeURL);
         info.setConvexHulls(_points);
         info.setOffset(_model->getOffset());
     }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -700,7 +700,11 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         }
 
         glm::vec3 collisionModelDimensions = box.getDimensions();
-        info.setParams(type, collisionModelDimensions, _compoundShapeURL);
+        QString shapeKey = _compoundShapeURL + "," +
+            QString::number(_registrationPoint.x) + "," +
+            QString::number(_registrationPoint.y) + "," +
+            QString::number(_registrationPoint.z);
+        info.setParams(type, collisionModelDimensions, shapeKey);
         info.setConvexHulls(_points);
         adjustShapeInfoByRegistration(info);
     }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -704,10 +704,6 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         AABox box;
         for (int i = 0; i < _points.size(); i++) {
             for (int j = 0; j < _points[i].size(); j++) {
-                // compensate for registraion
-                _points[i][j] += _model->getOffset();
-                // _points[i][j] += info.getOffset();
-                // scale so the collision points match the model points
                 _points[i][j] *= scale;
                 box += _points[i][j];
             }
@@ -719,13 +715,9 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
             QString::number(_registrationPoint.y) + "," +
             QString::number(_registrationPoint.z);
 
-        qDebug() << "NEW SHAPE FOR" << getName() << shapeKey;
-        qDebug() << "  model-offset:" << _model->getOffset();
-
         info.setParams(type, collisionModelDimensions, shapeKey);
         info.setConvexHulls(_points);
-        adjustShapeInfoByRegistration(info);
-        qDebug() << "  info-offset:" << info.getOffset();
+        info.setOffset(_model->getOffset());
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -49,6 +49,7 @@ public:
     virtual void removeFromScene(EntityItemPointer self, std::shared_ptr<render::Scene> scene, render::PendingChanges& pendingChanges) override;
 
 
+    void updateModelBounds();
     virtual void render(RenderArgs* args) override;
     virtual bool supportsDetailedRayIntersection() const override { return true; }
     virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -142,7 +142,7 @@ glm::vec3 RenderablePolyVoxEntityItem::getSurfacePositionAdjustment() const {
 glm::mat4 RenderablePolyVoxEntityItem::voxelToLocalMatrix() const {
     glm::vec3 scale = getDimensions() / _voxelVolumeSize; // meters / voxel-units
     bool success; // TODO -- Does this actually have to happen in world space?
-    glm::vec3 center = getCenterPosition(success);
+    glm::vec3 center = getCenterPosition(success); // this handles registrationPoint changes
     glm::vec3 position = getPosition(success);
     glm::vec3 positionToCenter = center - position;
 
@@ -428,6 +428,13 @@ PolyVox::RaycastResult RenderablePolyVoxEntityItem::doRayCast(glm::vec4 originIn
 // virtual
 ShapeType RenderablePolyVoxEntityItem::getShapeType() const {
     return SHAPE_TYPE_COMPOUND;
+}
+
+void RenderablePolyVoxEntityItem::updateRegistrationPoint(const glm::vec3& value) {
+    if (value != _registrationPoint) {
+        _meshDirty = true;
+        EntityItem::updateRegistrationPoint(value);
+    }
 }
 
 bool RenderablePolyVoxEntityItem::isReadyToComputeShape() {
@@ -1231,7 +1238,6 @@ void RenderablePolyVoxEntityItem::computeShapeInfoWorkerAsync() {
     _shapeInfoLock.lockForWrite();
     _shapeInfo.setParams(SHAPE_TYPE_COMPOUND, collisionModelDimensions, shapeKey);
     _shapeInfo.setConvexHulls(points);
-    adjustShapeInfoByRegistration(_shapeInfo);
     _shapeInfoLock.unlock();
 
     _meshLock.lockForWrite();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1224,9 +1224,12 @@ void RenderablePolyVoxEntityItem::computeShapeInfoWorkerAsync() {
     }
 
     glm::vec3 collisionModelDimensions = box.getDimensions();
-    QByteArray b64 = _voxelData.toBase64();
+    QString shapeKey = QString(_voxelData.toBase64()) + "," +
+        QString::number(_registrationPoint.x) + "," +
+        QString::number(_registrationPoint.y) + "," +
+        QString::number(_registrationPoint.z);
     _shapeInfoLock.lockForWrite();
-    _shapeInfo.setParams(SHAPE_TYPE_COMPOUND, collisionModelDimensions, QString(b64));
+    _shapeInfo.setParams(SHAPE_TYPE_COMPOUND, collisionModelDimensions, shapeKey);
     _shapeInfo.setConvexHulls(points);
     adjustShapeInfoByRegistration(_shapeInfo);
     _shapeInfoLock.unlock();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1228,6 +1228,7 @@ void RenderablePolyVoxEntityItem::computeShapeInfoWorkerAsync() {
     _shapeInfoLock.lockForWrite();
     _shapeInfo.setParams(SHAPE_TYPE_COMPOUND, collisionModelDimensions, QString(b64));
     _shapeInfo.setConvexHulls(points);
+    adjustShapeInfoByRegistration(_shapeInfo);
     _shapeInfoLock.unlock();
 
     _meshLock.lockForWrite();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1231,6 +1231,8 @@ void RenderablePolyVoxEntityItem::computeShapeInfoWorkerAsync() {
     }
 
     glm::vec3 collisionModelDimensions = box.getDimensions();
+    // include the registrationPoint in the shape key, because the offset is already
+    // included in the points and the shapeManager wont know that the shape has changed.
     QString shapeKey = QString(_voxelData.toBase64()) + "," +
         QString::number(_registrationPoint.x) + "," +
         QString::number(_registrationPoint.y) + "," +
@@ -1238,6 +1240,7 @@ void RenderablePolyVoxEntityItem::computeShapeInfoWorkerAsync() {
     _shapeInfoLock.lockForWrite();
     _shapeInfo.setParams(SHAPE_TYPE_COMPOUND, collisionModelDimensions, shapeKey);
     _shapeInfo.setConvexHulls(points);
+    // adjustShapeInfoByRegistration(_shapeInfo);
     _shapeInfoLock.unlock();
 
     _meshLock.lockForWrite();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
@@ -116,6 +116,8 @@ public:
 
     virtual void rebakeMesh();
 
+    virtual void updateRegistrationPoint(const glm::vec3& value);
+
 private:
     // The PolyVoxEntityItem class has _voxelData which contains dimensions and compressed voxel data.  The dimensions
     // may not match _voxelVolumeSize.

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -677,7 +677,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
     READ_ENTITY_PROPERTY(PROP_LIFETIME, float, updateLifetime);
     READ_ENTITY_PROPERTY(PROP_SCRIPT, QString, setScript);
     READ_ENTITY_PROPERTY(PROP_SCRIPT_TIMESTAMP, quint64, setScriptTimestamp);
-    READ_ENTITY_PROPERTY(PROP_REGISTRATION_POINT, glm::vec3, setRegistrationPoint);
+    READ_ENTITY_PROPERTY(PROP_REGISTRATION_POINT, glm::vec3, updateRegistrationPoint);
 
     READ_ENTITY_PROPERTY(PROP_ANGULAR_DAMPING, float, updateAngularDamping);
     READ_ENTITY_PROPERTY(PROP_VISIBLE, bool, setVisible);
@@ -1120,7 +1120,7 @@ bool EntityItem::setProperties(const EntityItemProperties& properties) {
 
     // these (along with "position" above) affect tree structure
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(dimensions, updateDimensions);
-    SET_ENTITY_PROPERTY_FROM_PROPERTIES(registrationPoint, setRegistrationPoint);
+    SET_ENTITY_PROPERTY_FROM_PROPERTIES(registrationPoint, updateRegistrationPoint);
 
     // these (along with all properties above) affect the simulation
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(density, updateDensity);
@@ -1340,6 +1340,15 @@ float EntityItem::getRadius() const {
     return 0.5f * glm::length(getDimensions());
 }
 
+void EntityItem::adjustShapeInfoByRegistration(ShapeInfo& info) const {
+    if (_registrationPoint != ENTITY_ITEM_DEFAULT_REGISTRATION_POINT) {
+        glm::mat4 scale = glm::scale(getDimensions());
+        glm::mat4 registration = scale * glm::translate(ENTITY_ITEM_DEFAULT_REGISTRATION_POINT - getRegistrationPoint());
+        glm::vec3 regTransVec = glm::vec3(registration[3]); // extract position component from matrix
+        info.setOffset(regTransVec);
+    }
+}
+
 bool EntityItem::contains(const glm::vec3& point) const {
     if (getShapeType() == SHAPE_TYPE_COMPOUND) {
         bool success;
@@ -1348,12 +1357,21 @@ bool EntityItem::contains(const glm::vec3& point) const {
     } else {
         ShapeInfo info;
         info.setParams(getShapeType(), glm::vec3(0.5f));
+        adjustShapeInfoByRegistration(info);
         return info.contains(worldToEntity(point));
     }
 }
 
 void EntityItem::computeShapeInfo(ShapeInfo& info) {
     info.setParams(getShapeType(), 0.5f * getDimensions());
+    adjustShapeInfoByRegistration(info);
+}
+
+void EntityItem::updateRegistrationPoint(const glm::vec3& value) {
+    if (value != _registrationPoint) {
+        setRegistrationPoint(value);
+        _dirtyFlags |= Simulation::DIRTY_SHAPE;
+    }
 }
 
 void EntityItem::updatePosition(const glm::vec3& value) {

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -320,7 +320,7 @@ public:
     virtual void setRotation(glm::quat orientation) { setOrientation(orientation); }
 
     // updateFoo() methods to be used when changes need to be accumulated in the _dirtyFlags
-    void updateRegistrationPoint(const glm::vec3& value);
+    virtual void updateRegistrationPoint(const glm::vec3& value);
     void updatePosition(const glm::vec3& value);
     void updatePositionFromNetwork(const glm::vec3& value);
     void updateDimensions(const glm::vec3& value);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -305,6 +305,7 @@ public:
     // TODO: get rid of users of getRadius()...
     float getRadius() const;
 
+    virtual void adjustShapeInfoByRegistration(ShapeInfo& info) const;
     virtual bool contains(const glm::vec3& point) const;
 
     virtual bool isReadyToComputeShape() { return !isDead(); }
@@ -319,6 +320,7 @@ public:
     virtual void setRotation(glm::quat orientation) { setOrientation(orientation); }
 
     // updateFoo() methods to be used when changes need to be accumulated in the _dirtyFlags
+    void updateRegistrationPoint(const glm::vec3& value);
     void updatePosition(const glm::vec3& value);
     void updatePositionFromNetwork(const glm::vec3& value);
     void updateDimensions(const glm::vec3& value);

--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -15,7 +15,7 @@
 
 #include "ShapeFactory.h"
 #include "BulletUtil.h"
-
+#include "StreamUtils.h"
 
 
 btConvexHullShape* ShapeFactory::createConvexHull(const QVector<glm::vec3>& points) {
@@ -65,6 +65,11 @@ btConvexHullShape* ShapeFactory::createConvexHull(const QVector<glm::vec3>& poin
         hull->addPoint(btVector3(correctedPoint[0], correctedPoint[1], correctedPoint[2]), false);
     }
     hull->recalcLocalAabb();
+
+    qDebug() << "------- NEW COMPOUND SHAPE ------";
+    qDebug() << "   low = " << minCorner;
+    qDebug() << "   high = " << maxCorner;
+
     return hull;
 }
 
@@ -92,11 +97,13 @@ btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info) {
             const QVector<QVector<glm::vec3>>& points = info.getPoints();
             uint32_t numSubShapes = info.getNumSubShapes();
             if (numSubShapes == 1) {
+                // XXX offset?
                 shape = createConvexHull(info.getPoints()[0]);
             } else {
                 auto compound = new btCompoundShape();
                 btTransform trans;
                 trans.setIdentity();
+                // trans.setOrigin(-glmToBullet(info.getOffset()));
                 foreach (QVector<glm::vec3> hullPoints, points) {
                     btConvexHullShape* hull = createConvexHull(hullPoints);
                     compound->addChildShape (trans, hull);
@@ -110,7 +117,7 @@ btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info) {
         if (glm::length2(info.getOffset()) > MIN_SHAPE_OFFSET * MIN_SHAPE_OFFSET) {
             // this shape has an offset, which we support by wrapping the true shape
             // in a btCompoundShape with a local transform
-            auto compound = new btCompoundShape(); 
+            auto compound = new btCompoundShape();
             btTransform trans;
             trans.setIdentity();
             trans.setOrigin(glmToBullet(info.getOffset()));
@@ -118,5 +125,11 @@ btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info) {
             shape = compound;
         }
     }
+
+    if (type == SHAPE_TYPE_COMPOUND) {
+        qDebug() << "   offset = " << info.getOffset();
+    }
+
+
     return shape;
 }

--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -15,8 +15,6 @@
 
 #include "ShapeFactory.h"
 #include "BulletUtil.h"
-#include "StreamUtils.h"
-
 
 btConvexHullShape* ShapeFactory::createConvexHull(const QVector<glm::vec3>& points) {
     assert(points.size() > 0);
@@ -65,11 +63,6 @@ btConvexHullShape* ShapeFactory::createConvexHull(const QVector<glm::vec3>& poin
         hull->addPoint(btVector3(correctedPoint[0], correctedPoint[1], correctedPoint[2]), false);
     }
     hull->recalcLocalAabb();
-
-    qDebug() << "------- NEW COMPOUND SHAPE ------";
-    qDebug() << "   low = " << minCorner;
-    qDebug() << "   high = " << maxCorner;
-
     return hull;
 }
 
@@ -97,13 +90,11 @@ btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info) {
             const QVector<QVector<glm::vec3>>& points = info.getPoints();
             uint32_t numSubShapes = info.getNumSubShapes();
             if (numSubShapes == 1) {
-                // XXX offset?
                 shape = createConvexHull(info.getPoints()[0]);
             } else {
                 auto compound = new btCompoundShape();
                 btTransform trans;
                 trans.setIdentity();
-                // trans.setOrigin(-glmToBullet(info.getOffset()));
                 foreach (QVector<glm::vec3> hullPoints, points) {
                     btConvexHullShape* hull = createConvexHull(hullPoints);
                     compound->addChildShape (trans, hull);
@@ -113,7 +104,7 @@ btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info) {
         }
         break;
     }
-    if (shape && type != SHAPE_TYPE_COMPOUND) {
+    if (shape) {
         if (glm::length2(info.getOffset()) > MIN_SHAPE_OFFSET * MIN_SHAPE_OFFSET) {
             // this shape has an offset, which we support by wrapping the true shape
             // in a btCompoundShape with a local transform
@@ -125,11 +116,6 @@ btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info) {
             shape = compound;
         }
     }
-
-    if (type == SHAPE_TYPE_COMPOUND) {
-        qDebug() << "   offset = " << info.getOffset();
-    }
-
 
     return shape;
 }

--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -16,6 +16,8 @@
 #include "ShapeFactory.h"
 #include "BulletUtil.h"
 
+
+
 btConvexHullShape* ShapeFactory::createConvexHull(const QVector<glm::vec3>& points) {
     assert(points.size() > 0);
 
@@ -116,6 +118,5 @@ btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info) {
             shape = compound;
         }
     }
-
     return shape;
 }


### PR DESCRIPTION
- if entity registration isn't default, adjust physics shapes to match