### PR TITLE
MyAvatar: use a box instead of a sphere for horizontal re-centering

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1945,7 +1945,7 @@ bool MyAvatar::FollowHelper::shouldActivateRotation(const MyAvatar& myAvatar, co
 bool MyAvatar::FollowHelper::shouldActivateHorizontal(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix) const {
 
     // -z axis of currentBodyMatrix in world space.
-    glm::vec3 forward = glm::normalize(glm::vec3(-currentBodyMatrix[0][3], -currentBodyMatrix[1][3], -currentBodyMatrix[2][3]));
+    glm::vec3 forward = glm::normalize(glm::vec3(-currentBodyMatrix[0][2], -currentBodyMatrix[1][2], -currentBodyMatrix[2][2]));
     // x axis of currentBodyMatrix in world space.
     glm::vec3 right = glm::normalize(glm::vec3(currentBodyMatrix[0][0], currentBodyMatrix[1][0], currentBodyMatrix[2][0]));
     glm::vec3 offset = extractTranslation(desiredBodyMatrix) - extractTranslation(currentBodyMatrix);


### PR DESCRIPTION
This should prevent the avatar from looking out of balance when the user moves the HMD forward/backward.