### PR TITLE
Adjust ping pong gun dimensions

### DIFF
--- a/examples/toybox/ping_pong_gun/createPingPongGun.js
+++ b/examples/toybox/ping_pong_gun/createPingPongGun.js
@@ -30,9 +30,9 @@ var pingPongGun = Entities.addEntity({
   script: scriptURL,
   position: center,
   dimensions: {
-    x: 0.08,
-    y: 0.21,
-    z: 0.47
+    x: 0.125,
+    y: 0.3875,
+    z: 0.9931
   },
   dynamic: true,
   collisionSoundURL: COLLISION_SOUND_URL,

--- a/examples/toybox/ping_pong_gun/pingPongGun.js
+++ b/examples/toybox/ping_pong_gun/pingPongGun.js
@@ -23,7 +23,7 @@
     //if the trigger value goes below this value, reload the gun.
     var RELOAD_THRESHOLD = 0.95;
     var GUN_TIP_FWD_OFFSET = -0.35;
-    var GUN_TIP_UP_OFFSET = 0.040;
+    var GUN_TIP_UP_OFFSET = 0.12;
     var GUN_FORCE = 9;
     var BALL_RESTITUTION = 0.6;
     var BALL_LINEAR_DAMPING = 0.4;

--- a/unpublishedScripts/hiddenEntityReset.js
+++ b/unpublishedScripts/hiddenEntityReset.js
@@ -1278,9 +1278,9 @@
                 },
                 restitution: 0,
                 dimensions: {
-                    x: 0.08,
-                    y: 0.21,
-                    z: 0.47
+                    x: 0.125,
+                    y: 0.3875,
+                    z: 0.9931
                 },
                 dynamic: true,
                 collisionSoundURL: COLLISION_SOUND_URL,

--- a/unpublishedScripts/masterReset.js
+++ b/unpublishedScripts/masterReset.js
@@ -1266,9 +1266,9 @@ MasterReset = function() {
             },
             restitution: 0,
             dimensions: {
-                x: 0.08,
-                y: 0.21,
-                z: 0.47
+                x: 0.125,
+                y: 0.3875,
+                z: 0.9931
             },
             dynamic: true,
             collisionSoundURL: COLLISION_SOUND_URL,


### PR DESCRIPTION
The natural dimensions of the new ping pong gun were different than the old one, so slight updates needed all around.

To test:
1. Load this script https://rawgit.com/imgntn/hifi/pingponggunfix/examples/toybox/ping_pong_gun/createPingPongGun.js
2. Note that the ping pong balls shoot out of the end of an un-squished gun