### PR TITLE
"Collision Shape Type" in edit.js instead of "Shape Type"

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -1516,7 +1516,7 @@
         </div>
 
         <div class="model-section zone-section property">
-            <div class="label">Shape Type</div>
+            <div class="label">Collision Shape Type</div>
             <div class="value">
                 <select name="SelectShapeType" id="property-shape-type">
                     <option value='none'>none</option>


### PR DESCRIPTION
This PR makes the name of this field clearer.  There are no functional changes.

To test:
1. Run this script http://rawgit.com/imgntn/hifi/shapetype/examples/edit.js
2. Upload a model
3. Go to its properties and observe that the field name makes sense in context