### PR TITLE
DIsable Right Click Marketplace Info for now from edit.js

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -89,6 +89,9 @@ var SETTING_EASE_ON_FOCUS = "cameraEaseOnFocus";
 var SETTING_SHOW_LIGHTS_IN_EDIT_MODE = "showLightsInEditMode";
 var SETTING_SHOW_ZONES_IN_EDIT_MODE = "showZonesInEditMode";
 
+
+// marketplace info, etc.  not quite ready yet.
+var SHOULD_SHOW_PROPERTY_MENU = false;
 var INSUFFICIENT_PERMISSIONS_ERROR_MSG = "You do not have the necessary permissions to edit on this domain."
 var INSUFFICIENT_PERMISSIONS_IMPORT_ERROR_MSG = "You do not have the necessary permissions to place items on this domain."
 
@@ -1022,6 +1025,9 @@ function mouseClickEvent(event) {
     } else if (event.isRightButton) {
         var result = findClickedEntity(event);
         if (result) {
+            if (SHOULD_SHOW_PROPERTY_MENU !== true) {
+                return;
+            }
             var properties = Entities.getEntityProperties(result.entityID);
             if (properties.marketplaceID) {
                 propertyMenu.marketplaceID = properties.marketplaceID;
@@ -1895,9 +1901,11 @@ PopupMenu = function() {
     return this;
 };
 
+
 var propertyMenu = PopupMenu();
 
 propertyMenu.onSelectMenuItem = function(name) {
+
     if (propertyMenu.marketplaceID) {
         showMarketplace(propertyMenu.marketplaceID);
     }


### PR DESCRIPTION
This PR disables this functionality, assuming it will be added back in the future.  Right now it pops up behind other right click menus.

To test:
1.http://rawgit.com/imgntn/hifi/nomarketplaceinfo/examples/edit.js
2. try right clicking on things.  no "no marketplace info" tag appears.
