### PR TITLE
Oculus updates for upcoming runtime changes

### DIFF
--- a/plugins/oculus/CMakeLists.txt
+++ b/plugins/oculus/CMakeLists.txt
@@ -13,7 +13,7 @@ if (WIN32)
 
     set(TARGET_NAME oculus)
     setup_hifi_plugin()
-    link_hifi_libraries(shared gl plugins gpu display-plugins input-plugins)
+    link_hifi_libraries(shared gl gpu controllers plugins display-plugins input-plugins)
     
     include_hifi_library_headers(octree)
     

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -26,31 +26,7 @@ glm::mat4 OculusBaseDisplayPlugin::getHeadPose(uint32_t frameIndex) const {
 }
 
 bool OculusBaseDisplayPlugin::isSupported() const {
-    if (!OVR_SUCCESS(ovr_Initialize(nullptr))) {
-        qDebug() << "OculusBaseDisplayPlugin : ovr_Initialize() failed";
-        return false;
-    }
-
-    ovrSession session { nullptr };
-    ovrGraphicsLuid luid;
-    auto result = ovr_Create(&session, &luid);
-    if (!OVR_SUCCESS(result)) {
-        ovrErrorInfo error;
-        ovr_GetLastErrorInfo(&error);
-        qDebug() << "OculusBaseDisplayPlugin : ovr_Create() failed" << result << error.Result << error.ErrorString;
-        ovr_Shutdown();
-        return false;
-    }
-
-    auto hmdDesc = ovr_GetHmdDesc(session);
-    if (hmdDesc.Type == ovrHmd_None) {
-        ovr_Destroy(session);
-        ovr_Shutdown();
-        return false;
-    }
-
-    ovr_Shutdown();
-    return true;
+    return oculusAvailable();
 }
 
 // DLL based display plugins MUST initialize GLEW inside the DLL code.
@@ -68,13 +44,7 @@ void OculusBaseDisplayPlugin::deinit() {
 }
 
 void OculusBaseDisplayPlugin::activate() {
-    if (!OVR_SUCCESS(ovr_Initialize(nullptr))) {
-        qFatal("Could not init OVR");
-    }
-
-    if (!OVR_SUCCESS(ovr_Create(&_session, &_luid))) {
-        qFatal("Failed to acquire HMD");
-    }
+    _session = acquireOculusSession();
 
     _hmdDesc = ovr_GetHmdDesc(_session);
 
@@ -130,7 +100,6 @@ void OculusBaseDisplayPlugin::activate() {
 
 void OculusBaseDisplayPlugin::deactivate() {
     HmdDisplayPlugin::deactivate();
-    ovr_Destroy(_session);
+    releaseOculusSession();
     _session = nullptr;
-    ovr_Shutdown();
 }

--- a/plugins/oculus/src/OculusHelpers.h
+++ b/plugins/oculus/src/OculusHelpers.h
@@ -14,6 +14,10 @@
 
 #include <gl/OglplusHelpers.h>
 
+bool oculusAvailable();
+ovrSession acquireOculusSession();
+void releaseOculusSession();
+
 // Convenience method for looping over each eye with a lambda
 template <typename Function>
 inline void ovr_for_each_eye(Function function) {
@@ -23,6 +27,19 @@ inline void ovr_for_each_eye(Function function) {
         function(eye);
     }
 }
+
+template <typename Function>
+inline void ovr_for_each_hand(Function function) {
+    for (ovrHandType hand = ovrHandType::ovrHand_Left;
+        hand <= ovrHandType::ovrHand_Right;
+        hand = static_cast<ovrHandType>(hand + 1)) {
+        function(hand);
+    }
+}
+
+
+
+
 
 inline glm::mat4 toGlm(const ovrMatrix4f & om) {
     return glm::transpose(glm::make_mat4(&om.M[0][0]));
@@ -85,6 +102,7 @@ inline ovrPosef ovrPoseFromGlm(const glm::mat4 & m) {
     result.Position = ovrFromGlm(translation);
     return result; 
 }
+
 
 // A wrapper for constructing and using a swap texture set,
 // where each frame you draw to a texture via the FBO,

--- a/plugins/oculus/src/OculusProvider.cpp
+++ b/plugins/oculus/src/OculusProvider.cpp
@@ -14,15 +14,18 @@
 
 #include <plugins/RuntimePlugin.h>
 #include <plugins/DisplayPlugin.h>
+#include <plugins/InputPlugin.h>
 
 #include "OculusDisplayPlugin.h"
 #include "OculusDebugDisplayPlugin.h"
 
-class OculusProvider : public QObject, public DisplayProvider
+class OculusProvider : public QObject, public DisplayProvider, InputProvider
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID DisplayProvider_iid FILE "oculus.json")
     Q_INTERFACES(DisplayProvider)
+    Q_PLUGIN_METADATA(IID InputProvider_iid FILE "oculus.json")
+    Q_INTERFACES(InputProvider)
 
 public:
     OculusProvider(QObject* parent = nullptr) : QObject(parent) {}
@@ -47,8 +50,23 @@ public:
         return _displayPlugins;
     }
 
+    virtual InputPluginList getInputPlugins() override {
+        // FIXME pending full oculus input API and hardware
+#if 0
+        static std::once_flag once;
+        std::call_once(once, [&] {
+            InputPluginPointer plugin(new OculusControllerManager());
+            if (plugin->isSupported()) {
+                _inputPlugins.push_back(plugin);
+            }
+        });
+#endif
+        return _inputPlugins;
+    }
+
 private:
     DisplayPluginList _displayPlugins;
+    InputPluginList _inputPlugins;
 };
 
 #include "OculusProvider.moc"


### PR DESCRIPTION
The Oculus release runtime will launch the Oculus home desktop window whenever any application created an Oculus session.  We do this at application startup to determine if the Oculus SDK is available or not, which causes a problem, because this means when you launch Interface, the Oculus home window appears on top of it, whether you're running in VR mode or not.

This PR changes the `isSupported` check for the plugin to use an alternative function `ovr_Detect`, which does not trigger the Oculus home window. 

Additionally it adds some framework preperation for supporting input plugins for the Oculus once the Remote and Touch APIs are aready.

Testing:

This PR should behave exactly the same on systems with the 0.8 runtime.  on systems with the release runtime it should now behave the same as 0.8, instead of popping up the Oculus Home window on launch.