### PR TITLE
Don't trigger modal dialog from menu handler

### DIFF
--- a/interface/src/Bookmarks.cpp
+++ b/interface/src/Bookmarks.cpp
@@ -88,11 +88,11 @@ void Bookmarks::persistToFile() {
 
 void Bookmarks::setupMenus(Menu* menubar, MenuWrapper* menu) {
     // Add menus/actions
-    menubar->addActionToQMenuAndActionHash(menu, MenuOption::BookmarkLocation, 0,
-                                           this, SLOT(bookmarkLocation()));
+    auto bookmarkAction = menubar->addActionToQMenuAndActionHash(menu, MenuOption::BookmarkLocation);
+    QObject::connect(bookmarkAction, SIGNAL(triggered()), this, SLOT(bookmarkLocation()), Qt::QueuedConnection);
     _bookmarksMenu = menu->addMenu(MenuOption::Bookmarks);
-    _deleteBookmarksAction = menubar->addActionToQMenuAndActionHash(menu, MenuOption::DeleteBookmark, 0,
-                                                                    this, SLOT(deleteBookmark()));
+    _deleteBookmarksAction = menubar->addActionToQMenuAndActionHash(menu, MenuOption::DeleteBookmark);
+    QObject::connect(_deleteBookmarksAction, SIGNAL(triggered()), this, SLOT(deleteBookmark()), Qt::QueuedConnection);
     
     // Enable/Disable menus as needed
     enableMenuItems(_bookmarks.count() > 0);


### PR DESCRIPTION
triggering a modal dialog from within a menu handler causes the menu handler not to return until the modal dialog is closed, leaving both the dialog and the menu visible on the screen.  Modal dialogs launched from menu handlers should use a queued connection to allow the menu to close before the dialog opens.
