### PR TITLE
Bypass baffling OSX GL error

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -85,8 +85,7 @@ protected:
     virtual void updateFrameData();
 
     ProgramPtr _program;
-    int32_t _modelViewUniform { -1 };
-    int32_t _projectionUniform { -1 };
+    int32_t _mvpUniform { -1 };
     ShapeWrapperPtr _plane;
 
     mutable Mutex _mutex;

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -66,8 +66,8 @@ void HmdDisplayPlugin::compositeOverlay() {
     for_each_eye([&](Eye eye) {
         eyeViewport(eye);
         auto modelView = glm::inverse(_currentRenderEyePoses[eye]); // *glm::translate(mat4(), vec3(0, 0, -1));
-        Uniform<glm::mat4>(*_program, _modelViewUniform).Set(modelView);
-        Uniform<glm::mat4>(*_program, _projectionUniform).Set(_eyeProjections[eye]);
+        auto mvp = _eyeProjections[eye] * modelView;
+        Uniform<glm::mat4>(*_program, _mvpUniform).Set(mvp);
         _sphereSection->Draw();
     });
 }
@@ -82,8 +82,8 @@ void HmdDisplayPlugin::compositePointer() {
         using namespace oglplus;
         eyeViewport(eye);
         auto reticleTransform = compositorHelper->getReticleTransform(_currentRenderEyePoses[eye], headPosition);
-        Uniform<glm::mat4>(*_program, _modelViewUniform).Set(reticleTransform);
-        Uniform<glm::mat4>(*_program, _projectionUniform).Set(_eyeProjections[eye]);
+        auto mvp = _eyeProjections[eye] * reticleTransform;
+        Uniform<glm::mat4>(*_program, _mvpUniform).Set(mvp);
         _plane->Draw();
     });
 }

--- a/libraries/gl/src/gl/OglplusHelpers.cpp
+++ b/libraries/gl/src/gl/OglplusHelpers.cpp
@@ -15,8 +15,7 @@ using namespace oglplus::shapes;
 static const char * SIMPLE_TEXTURED_VS = R"VS(#version 410 core
 #pragma line __LINE__
 
-uniform mat4 Projection = mat4(1);
-uniform mat4 ModelView = mat4(1);
+uniform mat4 mvp = mat4(1);
 
 in vec3 Position;
 in vec2 TexCoord;
@@ -24,7 +23,7 @@ in vec2 TexCoord;
 out vec2 vTexCoord;
 
 void main() {
-  gl_Position = Projection * ModelView * vec4(Position, 1);
+  gl_Position = mvp * vec4(Position, 1);
   vTexCoord = TexCoord ;
 }
 


### PR DESCRIPTION
Testing showed that the code was failing on setting the modelview matrix uniform, even though it had a valid uniform location ID and even though the projection uniform set immediately before it worked fine.  Investigation showed now immediate reason why this would fail, but since our shader doesn't actually need the projection and modelview as separate matrices, it's simple enough to work around by compressing them into a single matrix.  

Needs testing on HMD devices to ensure the combined matrix is correctly compositing the modelview with the projection.