### PR TITLE
Fix inlined fbx content for identically named texs with different paths

### DIFF
--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -411,7 +411,11 @@ public:
     FBXTexture getTexture(const QString& textureID);
 
     QHash<QString, QString> _textureNames;
+    // Hashes the original RelativeFilename of textures
+    QHash<QString, QByteArray> _textureFilepaths;
+    // Hashes the place to look for textures, in case they are not inlined
     QHash<QString, QByteArray> _textureFilenames;
+    // Hashes texture content by filepath, in case they are inlined
     QHash<QByteArray, QByteArray> _textureContent;
     QHash<QString, TextureParam> _textureParams;
 

--- a/libraries/fbx/src/FBXReader_Material.cpp
+++ b/libraries/fbx/src/FBXReader_Material.cpp
@@ -28,9 +28,16 @@ bool FBXMaterial::needTangentSpace() const {
 
 FBXTexture FBXReader::getTexture(const QString& textureID) {
     FBXTexture texture;
-    texture.filename = _textureFilenames.value(textureID);
+    const QByteArray& filepath = _textureFilepaths.value(textureID);
+    texture.content = _textureContent.value(filepath);
+
+    if (texture.content.isEmpty()) { // the content is not inlined
+        texture.filename = _textureFilenames.value(textureID);
+    } else { // use supplied filepath for inlined content
+        texture.filename = filepath;
+    }
+
     texture.name = _textureNames.value(textureID);
-    texture.content = _textureContent.value(texture.filename);
     texture.transform.setIdentity();
     texture.texcoordSet = 0;
     if (_textureParams.contains(textureID)) {


### PR DESCRIPTION
Disambiguates identially named but differently pathed texture files in the fbx texture cache.