### PR TITLE
Avoid caching textures before they load

### DIFF
--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -344,6 +344,7 @@ void NetworkTexture::setImage(const QImage& image, void* voidTexture, int origin
         _width = _height = 0;
     }
     
+    _isCacheable = true;
     finishedLoading(true);
 
     emit networkTextureCreated(qWeakPointerCast<NetworkTexture, Resource> (_self));

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -132,6 +132,8 @@ signals:
 
 protected:
 
+    virtual bool isCacheable() const override { return _isCacheable; }
+
     virtual void downloadFinished(const QByteArray& data) override;
           
     Q_INVOKABLE void loadContent(const QByteArray& content);
@@ -146,6 +148,7 @@ private:
     int _originalHeight { 0 };
     int _width { 0 };
     int _height { 0 };
+    bool _isCacheable { false };
 };
 
 #endif // hifi_TextureCache_h

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -278,20 +278,20 @@ void Resource::refresh() {
 }
 
 void Resource::allReferencesCleared() {
-    if (_cache) {
+    if (_cache && isCacheable()) {
         if (QThread::currentThread() != thread()) {
             QMetaObject::invokeMethod(this, "allReferencesCleared");
             return;
         }
-        
+
         // create and reinsert new shared pointer 
         QSharedPointer<Resource> self(this, &Resource::allReferencesCleared);
         setSelf(self);
         reinsert();
-        
+
         // add to the unused list
         _cache->addUnusedResource(self);
-        
+
     } else {
         delete this;
     }

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -192,6 +192,9 @@ protected slots:
 protected:
     virtual void init();
 
+    /// Checks whether the resource is cacheable.
+    virtual bool isCacheable() const { return true; }
+
     /// Called when the download has finished
     virtual void downloadFinished(const QByteArray& data);
 


### PR DESCRIPTION
- Adds a method to resources denoting whether they should be cached: `Resource::isCacheable`.
- Only sets textures as cacheable once they have both downloaded and processed their image.

Textures had an edge case where they could download binary data, begin processing, go out of scope, and thus never finish processing the data, though it would be cached and so never retried. This fixes that.

Textures now only cache if they have both downloaded *and* processed their data. If they have downloaded but *not processed* their data, they will not be cached. They downloaded binary will be cached according to that file's conventions (asset, file, or HTTP).