### PR TITLE
Ensure we don't get trapped in the QML rendering loop on shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -250,6 +250,9 @@ public:
             _heartbeat = usecTimestampNow();
         });
         heartbeatTimer->start(HEARTBEAT_UPDATE_INTERVAL_SECS * MSECS_PER_SECOND);
+        connect(qApp, &QCoreApplication::aboutToQuit, [this] {
+            _quit = true;
+        });
     }
 
     void deadlockDetectionCrash() {
@@ -258,7 +261,7 @@ public:
     }
 
     void run() override {
-        while (!qApp->isAboutToQuit()) {
+        while (!_quit) {
             QThread::sleep(HEARTBEAT_UPDATE_INTERVAL_SECS);
             auto now = usecTimestampNow();
             auto lastHeartbeatAge = now - _heartbeat;
@@ -269,6 +272,7 @@ public:
     }
 
     static std::atomic<uint64_t> _heartbeat;
+    bool _quit { false };
 };
 
 std::atomic<uint64_t> DeadlockWatchdogThread::_heartbeat;

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -326,6 +326,10 @@ OffscreenQmlSurface::~OffscreenQmlSurface() {
 
 void OffscreenQmlSurface::onAboutToQuit() {
     QObject::disconnect(&_updateTimer);
+    // Disconnecting the update timer is insufficient, since the renderer
+    // may attempting to render already, so we need to explicitly tell the renderer 
+    // to stop
+    _renderer->aboutToQuit(); 
 }
 
 void OffscreenQmlSurface::create(QOpenGLContext* shareContext) {
@@ -486,6 +490,9 @@ void OffscreenQmlSurface::updateQuick() {
         QMutexLocker lock(&(_renderer->_mutex));
         _renderer->post(RENDER);
         while (!_renderer->_cond.wait(&(_renderer->_mutex), 100)) {
+            if (_renderer->_quit) {
+                return;
+            }
             qApp->processEvents();
         }
         _render = false;


### PR DESCRIPTION
The order of shutdown events can sometimes lead to the QML renderer never being able to finish a render, but leaving the main thread always waiting on it.  this change should allow the main thread to recognize that no render is forthcoming and return control back to normal shutdown.