### PR TITLE
Fix messed up LogDialog multi-lines

### DIFF
--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -127,7 +127,7 @@ void LogDialog::resizeEvent(QResizeEvent*) {
 void LogDialog::appendLogLine(QString logLine) {
     if (isVisible()) {
         if (logLine.contains(_searchTerm, Qt::CaseInsensitive)) {
-            _logTextBox->appendPlainText(logLine.simplified());
+            _logTextBox->appendPlainText(logLine.trimmed());
         }
     }
 }


### PR DESCRIPTION
Log dialog now correctly prints multi-lines debug messages.