### PR TITLE
Adjust edit handle sizes

### DIFF
--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -894,7 +894,7 @@ SelectionDisplay = (function() {
         alpha: handleAlpha,
         visible: false,
         size: 0.1,
-        scale: 0.025,
+        scale: 0.1,
         isFacingAvatar: false,
         drawInFront: true,
     });

--- a/examples/libraries/entitySelectionTool.js
+++ b/examples/libraries/entitySelectionTool.js
@@ -894,7 +894,7 @@ SelectionDisplay = (function() {
         alpha: handleAlpha,
         visible: false,
         size: 0.1,
-        scale: 0.1,
+        scale: 0.025,
         isFacingAvatar: false,
         drawInFront: true,
     });
@@ -4316,16 +4316,23 @@ SelectionDisplay = (function() {
         return false;
     };
 
+
     that.updateHandleSizes = function() {
         if (selectionManager.hasSelection()) {
             var diff = Vec3.subtract(selectionManager.worldPosition, Camera.getPosition());
             var grabberSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO;
+            var dimensions = SelectionManager.worldDimensions;
+            var avgDimension = (dimensions.x + dimensions.y + dimensions.z) / 3;
+            grabberSize = Math.min(grabberSize, avgDimension / 10);
+
             for (var i = 0; i < stretchHandles.length; i++) {
                 Overlays.editOverlay(stretchHandles[i], {
                     size: grabberSize,
                 });
             }
-            var handleSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 10;
+            var handleSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 7;
+            handleSize = Math.min(handleSize, avgDimension / 3);
+
             Overlays.editOverlay(yawHandle, {
                 scale: handleSize,
             });
@@ -4342,7 +4349,7 @@ SelectionDisplay = (function() {
             });
             Overlays.editOverlay(grabberMoveUp, {
                 position: pos,
-                scale: handleSize / 2,
+                scale: handleSize / 1.25,
             });
         }
     }


### PR DESCRIPTION
When you move a selected object far away, the size and rotate handles will not get bigger than the object (which doesn't work anyway since they overlap).  It is easier therefore to grab for translation a distance object, and it looks better.  

Also reduced the size of the rotate handles somewhat. 

Test plan:  

Create each type of entity within edit.js, test that handles feel like an OK size, and try grabbing handles at different distances from the object.  Should work better than existing. 



