### PR TITLE
Allow procedural shaders to be reused, and prevent crashes from rapid updates

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -341,12 +341,7 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
             static QString userData;
             if (userData != zone->getUserData()) {
                 userData = zone->getUserData();
-                auto procedural = std::make_shared<Procedural>(userData);
-                if (procedural->_enabled) {
-                    skybox->setProcedural(procedural);
-                } else {
-                    skybox->setProcedural(ProceduralPointer());
-                }
+                skybox->setProcedural(userData);
             }
             if (zone->getSkyboxProperties().getURL().isEmpty()) {
                 skybox->setCubemap(gpu::TexturePointer());

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -341,7 +341,7 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
             static QString userData;
             if (userData != zone->getUserData()) {
                 userData = zone->getUserData();
-                skybox->setProcedural(userData);
+                skybox->parse(userData);
             }
             if (zone->getSkyboxProperties().getURL().isEmpty()) {
                 skybox->setCubemap(gpu::TexturePointer());

--- a/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableBoxEntityItem.cpp
@@ -31,7 +31,9 @@ EntityItemPointer RenderableBoxEntityItem::factory(const EntityItemID& entityID,
 void RenderableBoxEntityItem::setUserData(const QString& value) {
     if (value != getUserData()) {
         BoxEntityItem::setUserData(value);
-        _procedural.reset();
+        if (_procedural) {
+            _procedural->parse(value);
+        }
     }
 }
 
@@ -39,7 +41,6 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
     PerformanceTimer perfTimer("RenderableBoxEntityItem::render");
     Q_ASSERT(getType() == EntityTypes::Box);
     Q_ASSERT(args->_batch);
-
 
     if (!_procedural) {
         _procedural.reset(new Procedural(this->getUserData()));
@@ -62,7 +63,7 @@ void RenderableBoxEntityItem::render(RenderArgs* args) {
     }
 
     batch.setModelTransform(transToCenter); // we want to include the scale as well
-    if (_procedural && _procedural->ready()) {
+    if (_procedural->ready()) {
         _procedural->prepare(batch, getPosition(), getDimensions());
         auto color = _procedural->getColor(cubeColor);
         batch._glColor4f(color.r, color.g, color.b, color.a);

--- a/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableSphereEntityItem.cpp
@@ -36,7 +36,9 @@ EntityItemPointer RenderableSphereEntityItem::factory(const EntityItemID& entity
 void RenderableSphereEntityItem::setUserData(const QString& value) {
     if (value != getUserData()) {
         SphereEntityItem::setUserData(value);
-        _procedural.reset();
+        if (_procedural) {
+            _procedural->parse(value);
+        }
     }
 }
 

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -155,7 +155,7 @@ void Procedural::parse(QJsonObject proceduralData) {
     auto uniforms = proceduralData[UNIFORMS_KEY].toObject();
     auto channels = proceduralData[CHANNELS_KEY].toArray();
 
-    if (parseVersion(proceduralData[VERSION_KEY]) &&
+    if (parseVersion(version) &&
         parseUrl(shaderUrl) &&
         parseUniforms(uniforms) &&
         parseTextures(channels)) {

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -62,6 +62,9 @@ QJsonValue Procedural::getProceduralData(const QString& proceduralJson) {
     return doc.object()[PROCEDURAL_USER_DATA_KEY];
 }
 
+Procedural::Procedural() {
+    _state = std::make_shared<gpu::State>();
+}
 
 Procedural::Procedural(const QString& userDataJson) {
     parse(userDataJson);

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -75,6 +75,7 @@ void Procedural::parse(const QString& userDataJson) {
     auto proceduralData = getProceduralData(userDataJson);
     // Instead of parsing, prep for a parse on the rendering thread
     // This will be called by Procedural::ready
+    std::lock_guard<std::mutex> lock(_proceduralDataMutex);
     _proceduralData = proceduralData.toObject();
     _proceduralDataDirty = true;
 }
@@ -165,6 +166,7 @@ void Procedural::parse(QJsonObject proceduralData) {
 bool Procedural::ready() {
     // Load any changes to the procedural
     if (_proceduralDataDirty) {
+        std::lock_guard<std::mutex> lock(_proceduralDataMutex);
         parse(_proceduralData);
         _proceduralDataDirty = false;
     }

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -142,7 +142,7 @@ bool Procedural::parseTextures(const QJsonArray& channels) {
     return true;
 }
 
-void Procedural::parse(QJsonObject proceduralData) {
+void Procedural::parse(const QJsonObject& proceduralData) {
     _enabled = false;
 
     if (proceduralData.isEmpty()) {

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -31,6 +31,7 @@ struct Procedural {
 public:
     static QJsonValue getProceduralData(const QString& proceduralJson);
 
+    Procedural();
     Procedural(const QString& userDataJson);
     void parse(const QString& userDataJson);
 
@@ -39,7 +40,6 @@ public:
 
     glm::vec4 getColor(const glm::vec4& entityColor);
 
-    bool _enabled { false };
     uint8_t _version { 1 };
 
     std::string _vertexSource;
@@ -59,8 +59,9 @@ public:
 
 protected:
     // Procedural metadata
-    uint64_t _start{ 0 };
-    int32_t _frameCount{ 0 };
+    bool _enabled { false };
+    uint64_t _start { 0 };
+    int32_t _frameCount { 0 };
 
     // Rendering object descriptions, from userData
     QJsonObject _proceduralData;

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -93,7 +93,7 @@ protected:
 
 private:
     // This should only be called from the render thread, as it shares data with Procedural::prepare
-    void parse(QJsonObject);
+    void parse(const QJsonObject&);
     bool parseVersion(const QJsonValue& version);
     bool parseUrl(const QUrl& url);
     bool parseUniforms(const QJsonObject& uniforms);

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -28,27 +28,24 @@ const size_t MAX_PROCEDURAL_TEXTURE_CHANNELS{ 4 };
 // FIXME better encapsulation
 // FIXME better mechanism for extending to things rendered using shaders other than simple.slv
 struct Procedural {
+public:
     static QJsonValue getProceduralData(const QString& proceduralJson);
 
     Procedural(const QString& userDataJson);
     void parse(const QString& userDataJson);
-    void parse(const QJsonObject&);
+
     bool ready();
     void prepare(gpu::Batch& batch, const glm::vec3& position, const glm::vec3& size);
-    void setupUniforms();
+
     glm::vec4 getColor(const glm::vec4& entityColor);
 
-    bool _enabled{ false };
-    uint8_t _version{ 1 };
+    bool _enabled { false };
+    uint8_t _version { 1 };
 
     std::string _vertexSource;
     std::string _fragmentSource;
 
-    QString _shaderSource;
-    QString _shaderPath;
-    QUrl _shaderUrl;
-    quint64 _shaderModified{ 0 };
-    bool _pipelineDirty{ true };
+    gpu::StatePointer _state;
 
     enum StandardUniforms {
         DATE,
@@ -60,23 +57,48 @@ struct Procedural {
         NUM_STANDARD_UNIFORMS
     };
 
-    int32_t _standardUniformSlots[NUM_STANDARD_UNIFORMS];
-
+protected:
+    // Procedural metadata
     uint64_t _start{ 0 };
     int32_t _frameCount{ 0 };
+
+    // Rendering object descriptions, from userData
+    QJsonObject _proceduralData;
+    QString _shaderSource;
+    QString _shaderPath;
+    QUrl _shaderUrl;
+    quint64 _shaderModified { 0 };
     NetworkShaderPointer _networkShader;
     QJsonObject _parsedUniforms;
     QJsonArray _parsedChannels;
+    bool _proceduralDataDirty { true };
+    bool _shaderDirty { true };
+    bool _uniformsDirty { true };
+    bool _channelsDirty { true };
 
+    // Rendering objects
     UniformLambdas _uniforms;
+    int32_t _standardUniformSlots[NUM_STANDARD_UNIFORMS];
     NetworkTexturePointer _channels[MAX_PROCEDURAL_TEXTURE_CHANNELS];
     gpu::PipelinePointer _pipeline;
     gpu::ShaderPointer _vertexShader;
     gpu::ShaderPointer _fragmentShader;
     gpu::ShaderPointer _shader;
-    gpu::StatePointer _state;
+
+    // Entity metadata
     glm::vec3 _entityDimensions;
     glm::vec3 _entityPosition;
+
+private:
+    // This should only be called from the render thread, as it shares data with Procedural::prepare
+    void parse(QJsonObject);
+    bool parseVersion(const QJsonValue& version);
+    bool parseUrl(const QUrl& url);
+    bool parseUniforms(const QJsonObject& uniforms);
+    bool parseTextures(const QJsonArray& channels);
+
+    void setupUniforms();
+    void setupChannels(bool shouldCreate);
 };
 
 #endif

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -65,6 +65,7 @@ protected:
 
     // Rendering object descriptions, from userData
     QJsonObject _proceduralData;
+    std::mutex _proceduralDataMutex;
     QString _shaderSource;
     QString _shaderPath;
     QUrl _shaderUrl;

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -19,6 +19,10 @@
 #include "ProceduralSkybox_frag.h"
 
 ProceduralSkybox::ProceduralSkybox() : model::Skybox() {
+    _procedural._vertexSource = ProceduralSkybox_vert;
+    _procedural._fragmentSource = ProceduralSkybox_frag;
+    // Adjust the pipeline state for background using the stencil test
+    _procedural._state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
 ProceduralSkybox::ProceduralSkybox(const ProceduralSkybox& skybox) :
@@ -27,14 +31,8 @@ ProceduralSkybox::ProceduralSkybox(const ProceduralSkybox& skybox) :
 
 }
 
-void ProceduralSkybox::setProcedural(const ProceduralPointer& procedural) {
-    _procedural = procedural;
-    if (_procedural) {
-        _procedural->_vertexSource = ProceduralSkybox_vert;
-        _procedural->_fragmentSource = ProceduralSkybox_frag;
-        // Adjust the pipeline state for background using the stencil test
-        _procedural->_state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
-    }
+void ProceduralSkybox::setProcedural(const QString& userData) {
+    _procedural.parse(userData);
 }
 
 void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& frustum) const {
@@ -42,12 +40,10 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& frustum) con
 }
 
 void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const ProceduralSkybox& skybox) {
-    if (!(skybox._procedural)) {
+    if (!(skybox._procedural.ready())) {
         skybox.updateDataBuffer();
         Skybox::render(batch, viewFrustum, skybox);
-    }
-
-    if (skybox._procedural && skybox._procedural->_enabled && skybox._procedural->ready()) {
+    } else {
         gpu::TexturePointer skymap = skybox.getCubemap();
         // FIXME: skymap->isDefined may not be threadsafe
         assert(skymap && skymap->isDefined());
@@ -62,8 +58,7 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
         batch.setModelTransform(Transform()); // only for Mac
         batch.setResourceTexture(0, skybox.getCubemap());
 
-        skybox._procedural->prepare(batch, glm::vec3(0), glm::vec3(1));
+        skybox._procedural.prepare(batch, glm::vec3(0), glm::vec3(1));
         batch.draw(gpu::TRIANGLE_STRIP, 4);
     }
 }
-

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -25,16 +25,6 @@ ProceduralSkybox::ProceduralSkybox() : model::Skybox() {
     _procedural._state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
-ProceduralSkybox::ProceduralSkybox(const ProceduralSkybox& skybox) :
-    model::Skybox(skybox),
-    _procedural(skybox._procedural) {
-
-}
-
-void ProceduralSkybox::setProcedural(const QString& userData) {
-    _procedural.parse(userData);
-}
-
 void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& frustum) const {
     ProceduralSkybox::render(batch, frustum, (*this));
 }

--- a/libraries/procedural/src/procedural/ProceduralSkybox.h
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.h
@@ -17,8 +17,6 @@
 
 #include "Procedural.h"
 
-typedef std::shared_ptr<Procedural> ProceduralPointer;
-
 class ProceduralSkybox: public model::Skybox {
 public:
     ProceduralSkybox();
@@ -26,13 +24,13 @@ public:
     ProceduralSkybox& operator= (const ProceduralSkybox& skybox);
     virtual ~ProceduralSkybox() {};
 
-    void setProcedural(const ProceduralPointer& procedural);
+    void setProcedural(const QString& userData);
 
     virtual void render(gpu::Batch& batch, const ViewFrustum& frustum) const;
     static void render(gpu::Batch& batch, const ViewFrustum& frustum, const ProceduralSkybox& skybox);
 
 protected:
-    ProceduralPointer _procedural;
+    mutable Procedural _procedural;
 };
 typedef std::shared_ptr< ProceduralSkybox > ProceduralSkyboxPointer;
 

--- a/libraries/procedural/src/procedural/ProceduralSkybox.h
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.h
@@ -20,11 +20,9 @@
 class ProceduralSkybox: public model::Skybox {
 public:
     ProceduralSkybox();
-    ProceduralSkybox(const ProceduralSkybox& skybox); 
-    ProceduralSkybox& operator= (const ProceduralSkybox& skybox);
     virtual ~ProceduralSkybox() {};
 
-    void setProcedural(const QString& userData);
+    void parse(const QString& userData) { _procedural.parse(userData); }
 
     virtual void render(gpu::Batch& batch, const ViewFrustum& frustum) const;
     static void render(gpu::Batch& batch, const ViewFrustum& frustum, const ProceduralSkybox& skybox);


### PR DESCRIPTION
- Reimplement procedurals on boxes, spheres, and skybox to reuse a single procedural object per item.
  - Fixes a concurrency issue (crash) where entities would destroy their procedural from the JS thread whilst rendering it from the render thread.
- Allow procedurals to be updated on the fly.

This changes the way that procedurals are updated. Whereas before they were destroyed and remade with new shaders/uniforms, they are now only updated if that part of their userData has changed. Thus, a shader will only be recompiled if its source has changed, and uniforms will only be updated if they are changed. This allows for more robust programmatic shading. It also means that the shader's timer will no longer be reset every time its uniforms are changed - it will only reset when the shader changes!