### PR TITLE
Better threaded handling of QML overlays

### DIFF
--- a/interface/src/ui/overlays/QmlOverlay.cpp
+++ b/interface/src/ui/overlays/QmlOverlay.cpp
@@ -51,27 +51,24 @@ void QmlOverlay::buildQmlElement(const QUrl& url) {
 }
 
 QmlOverlay::~QmlOverlay() {
-    if (_qmlElement) {
-        _qmlElement->deleteLater();
-        _qmlElement = nullptr;
-    }
+    _qmlElement.reset();
 }
 
 void QmlOverlay::setProperties(const QVariantMap& properties) {
     Overlay2D::setProperties(properties);
     auto bounds = _bounds;
-    std::weak_ptr<QQuickItem> weakQmlElement;
-    DependencyManager::get<OffscreenUi>()->executeOnUiThread([=] {
+    std::weak_ptr<QQuickItem> weakQmlElement = _qmlElement;
+    DependencyManager::get<OffscreenUi>()->executeOnUiThread([weakQmlElement, bounds, properties] {
         // check to see if qmlElement still exists
         auto qmlElement = weakQmlElement.lock();
         if (qmlElement) {
-            _qmlElement->setX(bounds.left());
-            _qmlElement->setY(bounds.top());
-            _qmlElement->setWidth(bounds.width());
-            _qmlElement->setHeight(bounds.height());
+            qmlElement->setX(bounds.left());
+            qmlElement->setY(bounds.top());
+            qmlElement->setWidth(bounds.width());
+            qmlElement->setHeight(bounds.height());
+            QMetaObject::invokeMethod(qmlElement.get(), "updatePropertiesFromScript", Qt::DirectConnection, Q_ARG(QVariant, properties));
         }
     });
-    QMetaObject::invokeMethod(_qmlElement.get(), "updatePropertiesFromScript", Q_ARG(QVariant, properties));
 }
 
 void QmlOverlay::render(RenderArgs* args) {


### PR DESCRIPTION
QML Overlays have a few issues.  They will call `deleteLater()` multiple times for a single object, and the code to detect if a QML element has been deleted doesn't function properly because a weak pointer isn't initialized, and because an invokation of a QML function is not inside the protected section.  