### PR TITLE
Expose a property in display plugins to determine if the device is visible to the user

### DIFF
--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -92,3 +92,8 @@ glm::quat HMDScriptingInterface::getOrientation() const {
     }
     return glm::quat();
 }
+
+bool HMDScriptingInterface::isMounted() const{
+    auto displayPlugin = qApp->getActiveDisplayPlugin();
+    return (displayPlugin->isHmd() && displayPlugin->isDisplayVisible());
+}

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -25,6 +25,7 @@ class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Depen
     Q_OBJECT
     Q_PROPERTY(glm::vec3 position READ getPosition)
     Q_PROPERTY(glm::quat orientation READ getOrientation)
+    Q_PROPERTY(bool mounted READ isMounted)
 
 public:
     Q_INVOKABLE glm::vec3 calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const;
@@ -39,6 +40,7 @@ public:
     static QScriptValue getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine);
     static QScriptValue getHUDLookAtPosition3D(QScriptContext* context, QScriptEngine* engine);
 
+    bool isMounted() const;
 
 private:
     // Get the position of the HMD

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -29,24 +29,26 @@ protected:
     using TextureEscrow = GLEscrow<gpu::TexturePointer>;
 public:
     OpenGLDisplayPlugin();
-    virtual void activate() override;
-    virtual void deactivate() override;
-    virtual void stop() override;
-    virtual bool eventFilter(QObject* receiver, QEvent* event) override;
+    void activate() override;
+    void deactivate() override;
+    void stop() override;
+    bool eventFilter(QObject* receiver, QEvent* event) override;
+    bool isDisplayVisible() const override { return true; }
 
-    virtual void submitSceneTexture(uint32_t frameIndex, const gpu::TexturePointer& sceneTexture) override;
-    virtual void submitOverlayTexture(const gpu::TexturePointer& overlayTexture) override;
-    virtual float presentRate() override;
 
-    virtual glm::uvec2 getRecommendedRenderSize() const override {
+    void submitSceneTexture(uint32_t frameIndex, const gpu::TexturePointer& sceneTexture) override;
+    void submitOverlayTexture(const gpu::TexturePointer& overlayTexture) override;
+    float presentRate() override;
+
+    glm::uvec2 getRecommendedRenderSize() const override {
         return getSurfacePixels();
     }
 
-    virtual glm::uvec2 getRecommendedUiSize() const override {
+    glm::uvec2 getRecommendedUiSize() const override {
         return getSurfaceSize();
     }
 
-    virtual QImage getScreenshot() const override;
+    QImage getScreenshot() const override;
 
 protected:
 #if THREADED_PRESENT

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -22,12 +22,16 @@ public:
     glm::uvec2 getRecommendedUiSize() const override final;
     glm::uvec2 getRecommendedRenderSize() const override final { return _renderTargetSize; }
     void setEyeRenderPose(uint32_t frameIndex, Eye eye, const glm::mat4& pose) override final;
+    bool isDisplayVisible() const override { return isHmdMounted(); }
+
 
     void activate() override;
     void deactivate() override;
 
 protected:
     virtual void hmdPresent() = 0;
+    virtual bool isHmdMounted() const = 0;
+
     void compositeOverlay() override;
     void compositePointer() override;
     void internalPresent() override;

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -65,6 +65,12 @@ public:
     virtual bool isThrottled() const { return false; }
     virtual float getTargetFrameRate() { return 0.0f; }
 
+    /// Returns a boolean value indicating whether the display is currently visible 
+    /// to the user.  For monitor displays, false might indicate that a screensaver,
+    /// or power-save mode is active.  For HMDs it may reflect a sensor indicating
+    /// whether the HMD is being worn
+    virtual bool isDisplayVisible() const { return false; }
+
     // Rendering support
 
     // Stop requesting renders, but don't do full deactivation

--- a/plugins/oculus/src/OculusDebugDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDebugDisplayPlugin.h
@@ -17,6 +17,7 @@ public:
 
 protected:
     void hmdPresent() override {}
+    bool isHmdMounted() const override { return true; }
 
 private:
     static const QString NAME;

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -24,6 +24,8 @@ public:
 
 protected:
     void hmdPresent() override;
+    // FIXME update with Oculus API call once it's available in the SDK
+    bool isHmdMounted() const override { return true; }
     void customizeContext() override;
     void uncustomizeContext() override;
     void updateFrameData() override;

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
@@ -35,6 +35,7 @@ public:
 protected:
     virtual void customizeContext() override;
     void hmdPresent() override {}
+    bool isHmdMounted() const override { return true; }
 #if 0
     virtual void uncustomizeContext() override;
     virtual void internalPresent() override;

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -139,4 +139,10 @@ void OpenVrDisplayPlugin::hmdPresent() {
 
     vr::TrackedDevicePose_t currentTrackedDevicePose[vr::k_unMaxTrackedDeviceCount];
     _compositor->WaitGetPoses(currentTrackedDevicePose, vr::k_unMaxTrackedDeviceCount, nullptr, 0);
+    _hmdActivityLevel = _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
 }
+
+bool OpenVrDisplayPlugin::isHmdMounted() const {
+    return _hmdActivityLevel == vr::k_EDeviceActivityLevel_UserInteraction;
+}
+

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -33,9 +33,11 @@ public:
 
 protected:
     void hmdPresent() override;
+    bool isHmdMounted() const override;
 
 private:
     vr::IVRSystem* _system { nullptr };
+    std::atomic<vr::EDeviceActivityLevel> _hmdActivityLevel { vr::k_EDeviceActivityLevel_Unknown };
     static const QString NAME;
     mutable Mutex _poseMutex;
 };


### PR DESCRIPTION
Note this only exposes the property.  It does not act on it.  Possible actions would include 

* Switching to a 2D display driver if the device is an HMD
* Ceasing to increment the present count so that we don't render frames that aren't visible to the user

However each of these has tradeoffs that will require further work and design discussion.  For instance, if we switch to a 2D display when the HMD is removed, do we automatically switch back when the HMD is put back on?  What if Interface is running in the background and someone decides to play something else?  

Not incrementing the present count means we remove the rendering load if the HMD is taken off, but the preview also stops updating.  

In other words, we probably want to act on this information, but we need a plan as to how before I go galloping off implementing something?