### PR TITLE
Various Overlay, Menu, and Away Mode bug fixes

### DIFF
--- a/examples/away.js
+++ b/examples/away.js
@@ -152,6 +152,7 @@ function maybeMoveOverlay() {
 
 // MAIN CONTROL
 var wasMuted, isAway;
+var wasOverlaysVisible = Menu.isOptionChecked("Overlays");
 var eventMappingName = "io.highfidelity.away"; // goActive on hand controller button events, too.
 var eventMapping = Controller.newMapping(eventMappingName);
 
@@ -168,6 +169,13 @@ function goAway() {
     MyAvatar.setEnableMeshVisible(false);  // just for our own display, without changing point of view
     playAwayAnimation(); // animation is still seen by others
     showOverlay();
+
+    // remember the View > Overlays state...
+    wasOverlaysVisible = Menu.isOptionChecked("Overlays");
+    print("wasOverlaysVisible:" + wasOverlaysVisible);
+
+    // show overlays so that people can see the "Away" message
+    Menu.setIsOptionChecked("Overlays", true);
 
     // tell the Reticle, we want to stop capturing the mouse until we come back
     Reticle.allowMouseCapture = false;
@@ -187,6 +195,9 @@ function goActive() {
     MyAvatar.setEnableMeshVisible(true); // IWBNI we respected Developer->Avatar->Draw Mesh setting.
     stopAwayAnimation();
     hideOverlay();
+
+    // restore overlays state to what it was when we went "away"
+    Menu.setIsOptionChecked("Overlays", wasOverlaysVisible);
 
     // tell the Reticle, we are ready to capture the mouse again and it should be visible
     Reticle.allowMouseCapture = true;

--- a/examples/away.js
+++ b/examples/away.js
@@ -181,7 +181,6 @@ function goAway() {
 
     // remember the View > Overlays state...
     wasOverlaysVisible = Menu.isOptionChecked("Overlays");
-    print("wasOverlaysVisible:" + wasOverlaysVisible);
 
     // show overlays so that people can see the "Away" message
     Menu.setIsOptionChecked("Overlays", true);

--- a/examples/away.js
+++ b/examples/away.js
@@ -156,6 +156,15 @@ var wasOverlaysVisible = Menu.isOptionChecked("Overlays");
 var eventMappingName = "io.highfidelity.away"; // goActive on hand controller button events, too.
 var eventMapping = Controller.newMapping(eventMappingName);
 
+// backward compatible version of getting HMD.mounted, so it works in old clients
+function safeGetHMDMounted() {
+    if (HMD.mounted === undefined) {
+        return true;
+    }
+    return HMD.mounted;
+}
+var wasHmdMounted = safeGetHMDMounted();
+
 function goAway() {
     if (isAway) {
         return;
@@ -182,7 +191,9 @@ function goAway() {
     if (HMD.active) {
         Reticle.visible = false;
     }
+    wasHmdMounted = safeGetHMDMounted(); // always remember the correct state
 }
+
 function goActive() {
     if (!isAway) {
         return;
@@ -205,6 +216,7 @@ function goActive() {
     if (HMD.active) {
         Reticle.position = HMD.getHUDLookAtPosition2D();
     }
+    wasHmdMounted = safeGetHMDMounted(); // always remember the correct state
 }
 
 function maybeGoActive(event) {
@@ -217,6 +229,7 @@ function maybeGoActive(event) {
         goActive();
     }
 }
+
 var wasHmdActive = HMD.active;
 var wasMouseCaptured = Reticle.mouseCaptured;
 
@@ -235,6 +248,13 @@ function maybeGoAway() {
         if (!wasMouseCaptured) {
             goAway();
         }
+    }
+
+    // If you've removed your HMD from your head, and we can detect it, we will also go away...
+    var hmdMounted = safeGetHMDMounted();
+    if (HMD.active && !hmdMounted && wasHmdMounted) {
+        wasHmdMounted = hmdMounted;
+        goAway();
     }
 }
 

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -222,8 +222,11 @@ void Menu::setIsOptionChecked(const QString& menuOption, bool isChecked) {
         return;
     }
     QAction* menu = _actionHash.value(menuOption);
-    if (menu) {
-        menu->setChecked(isChecked);
+    if (menu && menu->isCheckable()) {
+        auto wasChecked = menu->isChecked();
+        if (wasChecked != isChecked) {
+            menu->trigger();
+        }
     }
 }
 


### PR DESCRIPTION
- Fix several checkable menu items that would not properly trigger when checked via the Scripting API
- make the overlays toggle visible automatically when entering away mode
- enter away mode on the Vive if you remove the HMD