### PR TITLE
ApplicationOverlay: Fix for gray line at top of HMD UI overlay

### DIFF
--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -284,7 +284,8 @@ void ApplicationOverlay::buildFramebufferObject() {
     
     // If the overlay framebuffer still has no color attachment, no textures were available for rendering, so build a new one
     if (!_overlayFramebuffer->getRenderBuffer(0)) {
-        auto colorBuffer = gpu::TexturePointer(gpu::Texture::create2D(COLOR_FORMAT, width, height, DEFAULT_SAMPLER));
+        const gpu::Sampler OVERLAY_SAMPLER(gpu::Sampler::FILTER_MIN_MAG_LINEAR, gpu::Sampler::WRAP_CLAMP);
+        auto colorBuffer = gpu::TexturePointer(gpu::Texture::create2D(COLOR_FORMAT, width, height, OVERLAY_SAMPLER));
         _overlayFramebuffer->setRenderBuffer(0, colorBuffer);
     }
 }


### PR DESCRIPTION
Use GL_CLAMP_TO_EDGE for wrapMode on overlay texture.