### PR TITLE
Add version number and make adding new menu items to Server Console easier

### DIFF
--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -477,14 +477,14 @@ function performContentMigration() {
 
 var logWindow = null;
 
-
 var labels = {
     serverState: {
         label: 'Server - Stopped',
         enabled: false
     },
     version: {
-         label: 'Version - ' + buildInfo.buildIdentifier,
+        label: 'Version - ' + buildInfo.buildIdentifier,
+        enabled: false
     },
     restart: {
         label: 'Start Server',
@@ -499,7 +499,6 @@ var labels = {
             homeServer.stop();
         }
     },
-
     goHome: {
         label: 'Go Home',
         click: goHomeClicked,
@@ -512,7 +511,6 @@ var labels = {
             shutdown();
         }
     },
-
     settings: {
         label: 'Settings',
         click: function() {
@@ -524,6 +522,12 @@ var labels = {
         label: 'View Logs',
         click: function() {
             logWindow.open();
+        }
+    },
+    share: {
+        label: 'Share',
+        click: function() {
+            shell.openExternal('http://localhost:40100/settings/?action=share')
         }
     },
     migrateContent: {
@@ -552,15 +556,15 @@ function buildMenuArray(serverState) {
     if (isShuttingDown) {
         menuArray.push(labels.shuttingDown);
     } else {
-        menuArray.push(labels.stopped);
-        // menuArray.push(version);
+        menuArray.push(labels.serverState);
+        menuArray.push(labels.version);
         menuArray.push(separator);
         menuArray.push(labels.goHome);
         menuArray.push(separator);
-        menuArray.push(labels.startServer);
+        menuArray.push(labels.restart);
         menuArray.push(labels.stopServer);
         menuArray.push(labels.settings);
-        menuArray.push(labels.logs);
+        menuArray.push(labels.viewLogs);
         menuArray.push(separator);
         menuArray.push(labels.share);
         menuArray.push(separator);
@@ -573,6 +577,7 @@ function buildMenuArray(serverState) {
         }
 
     }
+
 
     return menuArray;
 

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -479,14 +479,14 @@ var logWindow = null;
 
 
 var labels = {
-    serverRunningState: {
+    serverState: {
         label: 'Server - Stopped',
         enabled: false
     },
     version: {
          label: 'Version - ' + buildInfo.buildIdentifier,
     },
-    startServer: {
+    restart: {
         label: 'Start Server',
         click: function() {
             homeServer.restart();
@@ -584,7 +584,7 @@ function updateLabels(serverState) {
     var running = serverState == ProcessGroupStates.STARTED;
 
     labels.goHome.enabled = running;
-    labels.stop.visible = running;
+    labels.stopServer.visible = running;
     labels.settings.enabled = running;
     if (serverState == ProcessGroupStates.STARTED) {
         labels.serverState.label = "Server - Started";

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -477,118 +477,125 @@ function performContentMigration() {
 
 var logWindow = null;
 
+
+var labels = {
+    serverRunningState: {
+        label: 'Server - Stopped',
+        enabled: false
+    },
+    version: {
+         label: 'Version - ' + buildInfo.buildIdentifier,
+    },
+    startServer: {
+        label: 'Start Server',
+        click: function() {
+            homeServer.restart();
+        }
+    },
+    stopServer: {
+        label: 'Stop Server',
+        visible: false,
+        click: function() {
+            homeServer.stop();
+        }
+    },
+
+    goHome: {
+        label: 'Go Home',
+        click: goHomeClicked,
+        enabled: false
+    },
+    quit: {
+        label: 'Quit',
+        accelerator: 'Command+Q',
+        click: function() {
+            shutdown();
+        }
+    },
+
+    settings: {
+        label: 'Settings',
+        click: function() {
+            shell.openExternal('http://localhost:40100/settings');
+        },
+        enabled: false
+    },
+    viewLogs: {
+        label: 'View Logs',
+        click: function() {
+            logWindow.open();
+        }
+    },
+    migrateContent: {
+        label: 'Migrate Stack Manager Content',
+        click: function() {
+            promptToMigrateContent();
+        }
+    },
+    shuttingDown: {
+        label: "Shutting down...",
+        enabled: false
+    },
+}
+
+var separator = {
+    type: 'separator'
+};
+
+
 function buildMenuArray(serverState) {
-    var menuArray = null;
+
+    updateLabels(serverState);
+
+    var menuArray = [];
 
     if (isShuttingDown) {
-        menuArray = [
-            {
-                label: "Shutting down...",
-                enabled: false
-            }
-        ];
+        menuArray.push(labels.shuttingDown);
     } else {
-        menuArray = [
-            {
-                label: 'Server - Stopped',
-                enabled: false
-            },
-            {
-                type: 'separator'
-            },
-            {
-                label: 'Go Home',
-                click: goHomeClicked,
-                enabled: false
-            },
-            {
-                type: 'separator'
-            },
-            {
-                label: 'Start Server',
-                click: function() { homeServer.restart(); }
-            },
-            {
-                label: 'Stop Server',
-                visible: false,
-                click: function() { homeServer.stop(); }
-            },
-            {
-                label: 'Settings',
-                click: function() { shell.openExternal('http://localhost:40100/settings'); },
-                enabled: false
-            },
-            {
-                label: 'View Logs',
-                click: function() { logWindow.open(); }
-            },
-            {
-                type: 'separator'
-            },
-            {
-                label: 'Share',
-                click: function() { shell.openExternal('http://localhost:40100/settings/?action=share') }
-            },
-            {
-                type: 'separator'
-            },
-            {
-                label: 'Quit',
-                accelerator: 'Command+Q',
-                click: function() { shutdown(); }
-            }
-        ];
+        menuArray.push(labels.stopped);
+        // menuArray.push(version);
+        menuArray.push(separator);
+        menuArray.push(labels.goHome);
+        menuArray.push(separator);
+        menuArray.push(labels.startServer);
+        menuArray.push(labels.stopServer);
+        menuArray.push(labels.settings);
+        menuArray.push(labels.logs);
+        menuArray.push(separator);
+        menuArray.push(labels.share);
+        menuArray.push(separator);
+        menuArray.push(labels.quit);
 
         var foundStackManagerContent = isStackManagerContentPresent();
         if (foundStackManagerContent) {
             // add a separator and the stack manager content migration option
-            menuArray.splice(menuArray.length - 1, 0, {
-                label: 'Migrate Stack Manager Content',
-                click: function() { promptToMigrateContent(); }
-            }, {
-                type: 'separator'
-            });
+            menuArray.splice(menuArray.length - 1, 0, labels.migrateContent, separator);
         }
 
-        updateMenuArray(menuArray, serverState);
     }
 
     return menuArray;
+
 }
 
-const GO_HOME_INDEX = 2;
-const SERVER_LABEL_INDEX = 0;
-const RESTART_INDEX = 4;
-const STOP_INDEX = 5;
-const SETTINGS_INDEX = 6;
+function updateLabels(serverState) {
 
-function updateMenuArray(menuArray, serverState) {
     // update the tray menu state
     var running = serverState == ProcessGroupStates.STARTED;
 
-    var serverLabelItem = menuArray[SERVER_LABEL_INDEX];
-    var restartItem = menuArray[RESTART_INDEX];
-
-    // Go Home is only enabled if running
-    menuArray[GO_HOME_INDEX].enabled = running;
-
-    // Stop is only visible if running
-    menuArray[STOP_INDEX].visible = running;
-
-    // Settings is only visible if running
-    menuArray[SETTINGS_INDEX].enabled = running;
-
+    labels.goHome.enabled = running;
+    labels.stop.visible = running;
+    labels.settings.enabled = running;
     if (serverState == ProcessGroupStates.STARTED) {
-        serverLabelItem.label = "Server - Started";
-        restartItem.label = "Restart Server";
+        labels.serverState.label = "Server - Started";
+        labels.restart.label = "Restart Server";
     } else if (serverState == ProcessGroupStates.STOPPED) {
-        serverLabelItem.label = "Server - Stopped";
-        restartItem.label = "Start Server";
+        labels.serverState.label = "Server - Stopped";
+        labels.restart.label = "Start Server";
     } else if (serverState == ProcessGroupStates.STOPPING) {
-        serverLabelItem.label = "Server - Stopping";
-
-        restartItem.label = "Restart Server";
-        restartItem.enabled = false;
+        labels.serverState.label = "Server - Stopping";
+        labels.restart.label = "Restart Server";
+        labels.restart.enabled = false;
     }
 }
 

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -587,8 +587,6 @@ function updateLabels(serverState) {
 
     // update the tray menu state
     var running = serverState == ProcessGroupStates.STARTED;
-    console.log('RUNNING??? ' + running)
-    console.log('SERVERSTATE?'  + serverState)
     labels.goHome.enabled = running;
     labels.stopServer.visible = running;
     labels.settings.enabled = running;

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -587,7 +587,8 @@ function updateLabels(serverState) {
 
     // update the tray menu state
     var running = serverState == ProcessGroupStates.STARTED;
-
+    console.log('RUNNING??? ' + running)
+    console.log('SERVERSTATE?'  + serverState)
     labels.goHome.enabled = running;
     labels.stopServer.visible = running;
     labels.settings.enabled = running;
@@ -597,6 +598,7 @@ function updateLabels(serverState) {
     } else if (serverState == ProcessGroupStates.STOPPED) {
         labels.serverState.label = "Server - Stopped";
         labels.restart.label = "Start Server";
+        labels.restart.enabled = true;
     } else if (serverState == ProcessGroupStates.STOPPING) {
         labels.serverState.label = "Server - Stopping";
         labels.restart.label = "Restart Server";


### PR DESCRIPTION
This PR changes the Menu items functions in the server console to make it easier to add new menu items.  The last PR threw off the menu index; now the updates happen without reference by index.

To test:
1. Download this PR and run server console
2. Click on tray icon and try each menu option, ensuring that they work as expected.