### PR TITLE
Fix iDate uniform in procedurals to be continuous

### DIFF
--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -374,7 +374,8 @@ void Procedural::setupUniforms() {
             v.y = date.month() - 1;
             // But not the day... go figure
             v.z = date.day();
-            v.w = (time.hour() * 3600) + (time.minute() * 60) + time.second();
+            float fractSeconds = (time.msec() / 1000.0f);
+            v.w = (time.hour() * 3600) + (time.minute() * 60) + time.second() + fractSeconds;
             batch._glUniform(_standardUniformSlots[DATE], v);
         });
     }


### PR DESCRIPTION
Currently the vec4 iDate uniform in procedural entities is supposed to provide the current year, month, day and second.  However, the second value doesn't change smoothly.  Instead it jumps from whole second to whole second.  This PR will allow it to have fractional values allowing for smoothly animated shaders that are based on the shared time for all viewers, rather than the local time since the shader started executing.  