### PR TITLE
Delete parentless entities redux

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -272,6 +272,18 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
     tree->setWantTerseEditLogging(wantTerseEditLogging);
 }
 
+void EntityServer::nodeAdded(SharedNodePointer node) {
+    EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
+    tree->knowAvatarID(node->getUUID());
+    OctreeServer::nodeAdded(node);
+}
+
+void EntityServer::nodeKilled(SharedNodePointer node) {
+    EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
+    tree->deleteDescendantsOfAvatar(node->getUUID());
+    tree->forgetAvatarID(node->getUUID());
+    OctreeServer::nodeKilled(node);
+}
 
 // FIXME - this stats tracking is somewhat temporary to debug the Whiteboard issues. It's not a bad
 // set of stats to have, but we'd probably want a different data structure if we keep it very long.

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -58,6 +58,8 @@ public:
     virtual void trackViewerGone(const QUuid& sessionID) override;
 
 public slots:
+    virtual void nodeAdded(SharedNodePointer node);
+    virtual void nodeKilled(SharedNodePointer node);
     void pruneDeletedEntities();
 
 protected:

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -127,8 +127,8 @@ public:
 public slots:
     /// runs the octree server assignment
     void run();
-    void nodeAdded(SharedNodePointer node);
-    void nodeKilled(SharedNodePointer node);
+    virtual void nodeAdded(SharedNodePointer node);
+    virtual void nodeKilled(SharedNodePointer node);
     void sendStatsPacket();
 
 private slots:

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -457,7 +457,6 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
     foreach(const EntityToDeleteDetails& details, entities) {
         EntityItemPointer theEntity = details.entity;
 
-        qDebug() << "processRemovedEntities on " << theEntity->getID() << theEntity->getName();
         if (getIsServer()) {
             QSet<EntityItemID> childrenIDs;
             theEntity->forEachChild([&](SpatiallyNestablePointer child) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -86,6 +86,11 @@ void EntityTree::postAddEntity(EntityItemPointer entity) {
     if (_simulation) {
         _simulation->addEntity(entity);
     }
+
+    if (!entity->isParentIDValid()) {
+        _missingParent.append(entity);
+    }
+
     _isDirty = true;
     maybeNotifyNewCollisionSoundURL("", entity->getCollisionSoundURL());
     emit addingEntity(entity->getEntityItemID());
@@ -251,6 +256,9 @@ bool EntityTree::updateEntityWithElement(EntityItemPointer entity, const EntityI
             if (!success) {
                 _missingParent.append(childEntity);
                 continue;
+            }
+            if (!childEntity->isParentIDValid()) {
+                _missingParent.append(childEntity);
             }
 
             UpdateEntityOperator theChildOperator(getThisPointer(), containingElement, childEntity, queryCube);
@@ -1004,15 +1012,20 @@ void EntityTree::fixupMissingParents() {
         EntityItemWeakPointer entityWP = iter.next();
         EntityItemPointer entity = entityWP.lock();
         if (entity) {
-            bool success;
-            AACube newCube = entity->getQueryAACube(success);
-            if (success) {
-                // this entity's parent (or ancestry) was previously not fully known, and now is.  Update its
-                // location in the EntityTree.
+            if (entity->isParentIDValid()) {
+                // this entity's parent was previously not known, and now is.  Update its location in the EntityTree...
+                bool success;
+                AACube newCube = entity->getQueryAACube(success);
+                if (!success) {
+                    continue;
+                }
                 moveOperator.addEntityToMoveList(entity, newCube);
                 iter.remove();
                 entity->markAncestorMissing(false);
             } else if (_avatarIDs.contains(entity->getParentID())) {
+                if (!_childrenOfAvatars.contains(entity->getParentID())) {
+                    _childrenOfAvatars[entity->getParentID()] = QSet<EntityItemID>();
+                }
                 _childrenOfAvatars[entity->getParentID()] += entity->getEntityItemID();
                 iter.remove();
                 entity->markAncestorMissing(false);

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -241,6 +241,10 @@ public:
     Q_INVOKABLE int getJointIndex(const QUuid& entityID, const QString& name) const;
     Q_INVOKABLE QStringList getJointNames(const QUuid& entityID) const;
 
+    void knowAvatarID(QUuid avatarID) { _avatarIDs += avatarID; }
+    void forgetAvatarID(QUuid avatarID) { _avatarIDs -= avatarID; }
+    void deleteDescendantsOfAvatar(QUuid avatarID);
+
 public slots:
     void callLoader(EntityItemID entityID);
 
@@ -313,8 +317,11 @@ protected:
     quint64 _maxEditDelta = 0;
     quint64 _treeResetTime = 0;
 
-    void fixupMissingParents();
-    QVector<EntityItemWeakPointer> _missingParent;
+    void fixupMissingParents(); // try to hook members of _missingParent to parent instances
+    QVector<EntityItemWeakPointer> _missingParent; // entites with a parentID but no (yet) known parent instance
+    // we maintain a list of avatarIDs to notice when an entity is a child of one.
+    QSet<QUuid> _avatarIDs; // IDs of avatars connected to entity server
+    QHash<QUuid, QSet<EntityItemID>> _childrenOfAvatars;  // which entities are children of which avatars
 };
 
 #endif // hifi_EntityTree_h


### PR DESCRIPTION
- when a parent of entities (either an avatar or another entity) is deleted, clean up the children
