### PR TITLE
Avatar & Animation cppcheck static analysis fixes

### DIFF
--- a/examples/utilities/tools/developerMenuItems.js
+++ b/examples/utilities/tools/developerMenuItems.js
@@ -36,11 +36,11 @@ var AUDIO_LISTENER_MODE_CUSTOM = "Audio from custom position";
 
 // be sure that the audio listener options are in the right order (same as the enumerator)
 var AUDIO_LISTENER_OPTIONS = [
-    // MyAvatar.FROM_HEAD (0)
+    // MyAvatar.audioListenerModeHead (0)
     AUDIO_LISTENER_MODE_FROM_HEAD,
-    // MyAvatar.FROM_CAMERA (1)
+    // MyAvatar.audioListenerModeCamera (1)
     AUDIO_LISTENER_MODE_FROM_CAMERA,
-    // MyAvatar.CUSTOM (2)
+    // MyAvatar.audioListenerCustom (2)
     AUDIO_LISTENER_MODE_CUSTOM
 ];
 var AUDIO_STEREO_INPUT = "Stereo Input";

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -972,7 +972,6 @@ void Avatar::renderJointConnectingCone(gpu::Batch& batch, glm::vec3 position1, g
         glm::vec3 perpCos = glm::normalize(glm::cross(axis, perpSin));
         perpSin = glm::cross(perpCos, axis);
 
-        float anglea = 0.0f;
         float angleb = 0.0f;
         QVector<glm::vec3> points;
 
@@ -980,7 +979,7 @@ void Avatar::renderJointConnectingCone(gpu::Batch& batch, glm::vec3 position1, g
 
             // the rectangles that comprise the sides of the cone section are
             // referenced by "a" and "b" in one dimension, and "1", and "2" in the other dimension.
-            anglea = angleb;
+            int anglea = angleb;
             angleb = ((float)(i+1) / (float)NUM_BODY_CONE_SIDES) * TWO_PI;
 
             float sa = sinf(anglea);

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -57,7 +57,7 @@ class Avatar : public AvatarData {
     Q_PROPERTY(glm::vec3 skeletonOffset READ getSkeletonOffset WRITE setSkeletonOffset)
 
 public:
-    Avatar(RigPointer rig = nullptr);
+    explicit Avatar(RigPointer rig = nullptr);
     ~Avatar();
 
     typedef render::Payload<AvatarData> Payload;

--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -308,7 +308,6 @@ bool AvatarActionHold::updateArguments(QVariantMap arguments) {
             hand = _hand;
         }
 
-        ok = true;
         auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
         holderID = myAvatar->getSessionUUID();
 

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -63,11 +63,11 @@ void AvatarManager::registerMetaTypes(QScriptEngine* engine) {
 }
 
 AvatarManager::AvatarManager(QObject* parent) :
-    _avatarFades()
+    _avatarFades(),
+    _myAvatar(std::make_shared<MyAvatar>(std::make_shared<Rig>()))
 {
     // register a meta type for the weak pointer we'll use for the owning avatar mixer for each avatar
     qRegisterMetaType<QWeakPointer<Node> >("NodeWeakPointer");
-    _myAvatar = std::make_shared<MyAvatar>(std::make_shared<Rig>());
 
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
     packetReceiver.registerListener(PacketType::BulkAvatarData, this, "processAvatarDataPacket");

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -71,8 +71,8 @@ public slots:
     void updateAvatarRenderStatus(bool shouldRenderAvatars);
 
 private:
-    AvatarManager(QObject* parent = 0);
-    AvatarManager(const AvatarManager& other);
+    explicit AvatarManager(QObject* parent = 0);
+    explicit AvatarManager(const AvatarManager& other);
 
     void simulateAvatarFades(float deltaTime);
 

--- a/interface/src/avatar/AvatarUpdate.cpp
+++ b/interface/src/avatar/AvatarUpdate.cpp
@@ -16,7 +16,7 @@
 #include <display-plugins/DisplayPlugin.h>
 #include "InterfaceLogging.h"
 
-AvatarUpdate::AvatarUpdate() : GenericThread(),  _lastAvatarUpdate(0) {
+AvatarUpdate::AvatarUpdate() : GenericThread(),  _lastAvatarUpdate(0), _isHMDMode(false) {
     setObjectName("Avatar Update"); // GenericThread::initialize uses this to set the thread name.
     Settings settings;
     const int DEFAULT_TARGET_AVATAR_SIMRATE = 60;

--- a/interface/src/avatar/Head.h
+++ b/interface/src/avatar/Head.h
@@ -28,7 +28,7 @@ class Avatar;
 
 class Head : public HeadData {
 public:
-    Head(Avatar* owningAvatar);
+    explicit Head(Avatar* owningAvatar);
     
     void init();
     void reset();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1522,9 +1522,9 @@ glm::vec3 MyAvatar::applyKeyboardMotor(float deltaTime, const glm::vec3& localVe
     // (1) braking --> short timescale (aggressive motor assertion)
     // (2) pushing --> medium timescale (mild motor assertion)
     // (3) inactive --> long timescale (gentle friction for low speeds)
-    float MIN_KEYBOARD_MOTOR_TIMESCALE = 0.125f;
-    float MAX_KEYBOARD_MOTOR_TIMESCALE = 0.4f;
-    float MIN_KEYBOARD_BRAKE_SPEED = 0.3f;
+    const float MIN_KEYBOARD_MOTOR_TIMESCALE = 0.125f;
+    const float MAX_KEYBOARD_MOTOR_TIMESCALE = 0.4f;
+    const float MIN_KEYBOARD_BRAKE_SPEED = 0.3f;
     float timescale = MAX_KEYBOARD_MOTOR_TIMESCALE;
     bool isThrust = (glm::length2(_thrust) > EPSILON);
     if (_isPushing || isThrust ||

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -63,9 +63,9 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(AudioListenerMode audioListenerMode READ getAudioListenerMode WRITE setAudioListenerMode)
     Q_PROPERTY(glm::vec3 customListenPosition READ getCustomListenPosition WRITE setCustomListenPosition)
     Q_PROPERTY(glm::quat customListenOrientation READ getCustomListenOrientation WRITE setCustomListenOrientation)
-    Q_PROPERTY(AudioListenerMode FROM_HEAD READ getAudioListenerModeHead)
-    Q_PROPERTY(AudioListenerMode FROM_CAMERA READ getAudioListenerModeCamera)
-    Q_PROPERTY(AudioListenerMode CUSTOM READ getAudioListenerModeCustom)
+    Q_PROPERTY(AudioListenerMode audioListenerModeHead READ getAudioListenerModeHead)
+    Q_PROPERTY(AudioListenerMode audioListenerModeCamera READ getAudioListenerModeCamera)
+    Q_PROPERTY(AudioListenerMode audioListenerModeCustom READ getAudioListenerModeCustom)
     //TODO: make gravity feature work Q_PROPERTY(glm::vec3 gravity READ getGravity WRITE setGravity)
 
 
@@ -84,7 +84,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(float energy READ getEnergy WRITE setEnergy)
 
 public:
-    MyAvatar(RigPointer rig);
+    explicit MyAvatar(RigPointer rig);
     ~MyAvatar();
 
     virtual void simulateAttachments(float deltaTime) override;

--- a/interface/src/avatar/MyCharacterController.cpp
+++ b/interface/src/avatar/MyCharacterController.cpp
@@ -46,14 +46,15 @@ void MyCharacterController::updateShapeIfNecessary() {
         // NOTE: _shapeLocalOffset is already computed
 
         if (_radius > 0.0f) {
-            // HACK: use some simple mass property defaults for now
-            float mass = 100.0f;
-            btVector3 inertia(30.0f, 8.0f, 30.0f);
-
             // create RigidBody if it doesn't exist
             if (!_rigidBody) {
+
+                // HACK: use some simple mass property defaults for now
+                const float DEFAULT_AVATAR_MASS = 100.0f;
+                const btVector3 DEFAULT_AVATAR_INERTIA_TENSOR(30.0f, 8.0f, 30.0f);
+
                 btCollisionShape* shape = new btCapsuleShape(_radius, 2.0f * _halfHeight);
-                _rigidBody = new btRigidBody(mass, nullptr, shape, inertia);
+                _rigidBody = new btRigidBody(DEFAULT_AVATAR_MASS, nullptr, shape, DEFAULT_AVATAR_INERTIA_TENSOR);
             } else {
                 btCollisionShape* shape = _rigidBody->getCollisionShape();
                 if (shape) {

--- a/interface/src/avatar/MyCharacterController.h
+++ b/interface/src/avatar/MyCharacterController.h
@@ -21,7 +21,7 @@ class MyAvatar;
 
 class MyCharacterController : public CharacterController {
 public:
-    MyCharacterController(MyAvatar* avatar);
+    explicit MyCharacterController(MyAvatar* avatar);
     ~MyCharacterController ();
 
     virtual void updateShapeIfNecessary() override;

--- a/libraries/animation/src/AnimExpression.h
+++ b/libraries/animation/src/AnimExpression.h
@@ -21,7 +21,7 @@
 class AnimExpression {
 public:
     friend class AnimTests;
-    AnimExpression(const QString& str);
+    explicit AnimExpression(const QString& str);
 protected:
     struct Token {
         enum Type {
@@ -49,8 +49,8 @@ protected:
             Comma,
             Error
         };
-        Token(Type type) : type {type} {}
-        Token(const QStringRef& strRef) : type {Type::Identifier}, strVal {strRef.toString()} {}
+        explicit Token(Type type) : type {type} {}
+        explicit Token(const QStringRef& strRef) : type {Type::Identifier}, strVal {strRef.toString()} {}
         explicit Token(int val) : type {Type::Int}, intVal {val} {}
         explicit Token(bool val) : type {Type::Bool}, intVal {val} {}
         explicit Token(float val) : type {Type::Float}, floatVal {val} {}
@@ -82,7 +82,7 @@ protected:
             Modulus,
             UnaryMinus
         };
-        OpCode(Type type) : type {type} {}
+        explicit OpCode(Type type) : type {type} {}
         explicit OpCode(const QStringRef& strRef) : type {Type::Identifier}, strVal {strRef.toString()} {}
         explicit OpCode(const QString& str) : type {Type::Identifier}, strVal {str} {}
         explicit OpCode(int val) : type {Type::Int}, intVal {val} {}

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -25,7 +25,7 @@ class RotationConstraint;
 class AnimInverseKinematics : public AnimNode {
 public:
 
-    AnimInverseKinematics(const QString& id);
+    explicit AnimInverseKinematics(const QString& id);
     virtual ~AnimInverseKinematics() override;
 
     void loadDefaultPoses(const AnimPoseVec& poses);

--- a/libraries/animation/src/AnimNodeLoader.h
+++ b/libraries/animation/src/AnimNodeLoader.h
@@ -25,7 +25,7 @@ class AnimNodeLoader : public QObject {
     Q_OBJECT
 
 public:
-    AnimNodeLoader(const QUrl& url);
+    explicit AnimNodeLoader(const QUrl& url);
 
 signals:
     void success(AnimNode::Pointer node);

--- a/libraries/animation/src/AnimSkeleton.h
+++ b/libraries/animation/src/AnimSkeleton.h
@@ -23,8 +23,8 @@ public:
     using Pointer = std::shared_ptr<AnimSkeleton>;
     using ConstPointer = std::shared_ptr<const AnimSkeleton>;
 
-    AnimSkeleton(const FBXGeometry& fbxGeometry);
-    AnimSkeleton(const std::vector<FBXJoint>& joints);
+    explicit AnimSkeleton(const FBXGeometry& fbxGeometry);
+    explicit AnimSkeleton(const std::vector<FBXJoint>& joints);
     int nameToJointIndex(const QString& jointName) const;
     const QString& getJointName(int jointIndex) const;
     int getNumJoints() const;

--- a/libraries/animation/src/AnimStateMachine.h
+++ b/libraries/animation/src/AnimStateMachine.h
@@ -110,7 +110,7 @@ protected:
 
 public:
 
-    AnimStateMachine(const QString& id);
+    explicit AnimStateMachine(const QString& id);
     virtual ~AnimStateMachine() override;
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, float dt, Triggers& triggersOut) override;

--- a/libraries/animation/src/AnimVariant.h
+++ b/libraries/animation/src/AnimVariant.h
@@ -37,12 +37,12 @@ public:
     static const AnimVariant False;
 
     AnimVariant() : _type(Type::Bool) { memset(&_val, 0, sizeof(_val)); }
-    AnimVariant(bool value) : _type(Type::Bool) { _val.boolVal = value; }
-    AnimVariant(int value) : _type(Type::Int) { _val.intVal = value; }
-    AnimVariant(float value) : _type(Type::Float) { _val.floats[0] = value; }
-    AnimVariant(const glm::vec3& value) : _type(Type::Vec3) { *reinterpret_cast<glm::vec3*>(&_val) = value; }
-    AnimVariant(const glm::quat& value) : _type(Type::Quat) { *reinterpret_cast<glm::quat*>(&_val) = value; }
-    AnimVariant(const QString& value) : _type(Type::String) { _stringVal = value; }
+    explicit AnimVariant(bool value) : _type(Type::Bool) { _val.boolVal = value; }
+    explicit AnimVariant(int value) : _type(Type::Int) { _val.intVal = value; }
+    explicit AnimVariant(float value) : _type(Type::Float) { _val.floats[0] = value; }
+    explicit AnimVariant(const glm::vec3& value) : _type(Type::Vec3) { *reinterpret_cast<glm::vec3*>(&_val) = value; }
+    explicit AnimVariant(const glm::quat& value) : _type(Type::Quat) { *reinterpret_cast<glm::quat*>(&_val) = value; }
+    explicit AnimVariant(const QString& value) : _type(Type::String) { _stringVal = value; }
 
     bool isBool() const { return _type == Type::Bool; }
     bool isInt() const { return _type == Type::Int; }
@@ -250,7 +250,7 @@ public:
                 qCDebug(animation) << "    " << pair.first << "=" << pair.second.getString();
                 break;
             default:
-                assert("AnimVariant::Type" == "valid");
+                assert(("invalid AnimVariant::Type", false));
             }
         }
     }

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -38,7 +38,7 @@ protected:
     virtual QSharedPointer<Resource> createResource(const QUrl& url,
                 const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra);
 private:
-    AnimationCache(QObject* parent = NULL);
+    explicit AnimationCache(QObject* parent = NULL);
     virtual ~AnimationCache() { }
 
 };
@@ -51,7 +51,7 @@ class Animation : public Resource {
 
 public:
 
-    Animation(const QUrl& url);
+    explicit Animation(const QUrl& url);
 
     const FBXGeometry& getGeometry() const { return *_geometry; }
 

--- a/libraries/animation/src/AnimationLoop.cpp
+++ b/libraries/animation/src/AnimationLoop.cpp
@@ -40,6 +40,7 @@ AnimationLoop::AnimationLoop(const AnimationDetails& animationDetails) :
     _lastFrame(animationDetails.lastFrame),
     _running(animationDetails.running),
     _currentFrame(animationDetails.currentFrame),
+    _maxFrameIndexHint(MAXIMUM_POSSIBLE_FRAME),
     _resetOnRunning(true),
     _lastSimulated(usecTimestampNow())
 {
@@ -55,6 +56,7 @@ AnimationLoop::AnimationLoop(float fps, bool loop, bool hold, bool startAutomati
     _lastFrame(lastFrame),
     _running(running),
     _currentFrame(currentFrame),
+    _maxFrameIndexHint(MAXIMUM_POSSIBLE_FRAME),
     _resetOnRunning(true),
     _lastSimulated(usecTimestampNow())
 {

--- a/libraries/animation/src/AnimationLoop.h
+++ b/libraries/animation/src/AnimationLoop.h
@@ -19,7 +19,7 @@ public:
     static const float MAXIMUM_POSSIBLE_FRAME;
 
     AnimationLoop();
-    AnimationLoop(const AnimationDetails& animationDetails);
+    explicit AnimationLoop(const AnimationDetails& animationDetails);
     AnimationLoop(float fps, bool loop, bool hold, bool startAutomatically, float firstFrame, 
                   float lastFrame, bool running, float currentFrame);
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -37,17 +37,7 @@ static bool isEqual(const glm::quat& p, const glm::quat& q) {
     return 1.0f - fabsf(glm::dot(p, q)) <= EPSILON;
 }
 
-#ifdef NDEBUG
-#define ASSERT(cond)
-#else
-#define ASSERT(cond)                            \
-    do {                                        \
-        if (!(cond)) {                          \
-            int* ptr = nullptr;                 \
-            *ptr = 10;                          \
-        }                                       \
-    } while (0)
-#endif
+#define ASSERT(cond) assert(cond)
 
 // 2 meter tall dude
 const glm::vec3 DEFAULT_RIGHT_EYE_POS(-0.3f, 0.9f, 0.0f);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -83,6 +83,7 @@ public:
         Hover
     };
 
+    Rig() {}
     virtual ~Rig() {}
 
     void destroyAnimGraph();

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1115,7 +1115,7 @@ void AvatarData::detachOne(const QString& modelURL, const QString& jointName) {
         return;
     }
     QVector<AttachmentData> attachmentData = getAttachmentData();
-    for (QVector<AttachmentData>::iterator it = attachmentData.begin(); it != attachmentData.end(); it++) {
+    for (QVector<AttachmentData>::iterator it = attachmentData.begin(); it != attachmentData.end(); ++it) {
         if (it->modelURL == modelURL && (jointName.isEmpty() || it->jointName == jointName)) {
             attachmentData.erase(it);
             setAttachmentData(attachmentData);
@@ -1134,7 +1134,7 @@ void AvatarData::detachAll(const QString& modelURL, const QString& jointName) {
         if (it->modelURL == modelURL && (jointName.isEmpty() || it->jointName == jointName)) {
             it = attachmentData.erase(it);
         } else {
-            it++;
+            ++it;
         }
     }
     setAttachmentData(attachmentData);

--- a/libraries/avatars/src/HeadData.cpp
+++ b/libraries/avatars/src/HeadData.cpp
@@ -42,6 +42,8 @@ HeadData::HeadData(AvatarData* owningAvatar) :
     _rightEyeBlink(0.0f),
     _averageLoudness(0.0f),
     _browAudioLift(0.0f),
+    _audioAverageLoudness(0.0f),
+    _pupilDilation(0.0f),
     _owningAvatar(owningAvatar)
 {
     

--- a/libraries/avatars/src/HeadData.h
+++ b/libraries/avatars/src/HeadData.h
@@ -32,7 +32,7 @@ class QJsonObject;
 
 class HeadData {
 public:
-    HeadData(AvatarData* owningAvatar);
+    explicit HeadData(AvatarData* owningAvatar);
     virtual ~HeadData() { };
     
     // degrees


### PR DESCRIPTION
Mostly stylistic, but It did detect several cases were we could have used uninitialized values.

Also, renamed JS properties, MyAvatar.FROM_HEAD, FROM_CAMERA & CUSTOM enumeration to MyAvatar.audioListenerModeHead, MyAvatar.audioListenerModeCamera & MyAvatar.audioListenerModeCustom