### PR TITLE
Add a DrawBackgroundDeferred gpu timer

### DIFF
--- a/examples/utilities/tools/render/BG.qml
+++ b/examples/utilities/tools/render/BG.qml
@@ -1,0 +1,22 @@
+//
+//  BG.qml
+//  examples/utilities/tools/render
+//
+//  Created by Zach Pomerantz on 2/8/2016
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or https://www.apache.org/licenses/LICENSE-2.0.html
+//
+import QtQuick 2.5
+import QtQuick.Controls 1.4
+
+Item {
+    Timer {
+        running: true; repeat: true
+        onTriggered: time.text = Render.getConfig("DrawBackgroundDeferred").gpuTime
+    }
+
+    Text { id: time; font.pointSize: 20 }
+}
+

--- a/examples/utilities/tools/render/debugBG.js
+++ b/examples/utilities/tools/render/debugBG.js
@@ -1,0 +1,21 @@
+//
+//  debugBG.js
+//  examples/utilities/tools/render
+//
+//  Zach Pomerantz, created on 1/27/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+// Set up the qml ui
+var qml = Script.resolvePath('BG.qml');
+var window = new OverlayWindow({
+    title: 'Background Timer',
+    source: qml,
+    width: 300
+});
+window.setPosition(25, 50);
+window.closed.connect(function() { Script.stop(); });
+

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -291,6 +291,7 @@ void DrawBackgroundDeferred::run(const SceneContextPointer& sceneContext, const 
     RenderArgs* args = renderContext->args;
     doInBatch(args->_context, [&](gpu::Batch& batch) {
         args->_batch = &batch;
+        _gpuTimer.begin(batch);
 
         auto lightingFBO = DependencyManager::get<FramebufferCache>()->getLightingFramebuffer();
 
@@ -310,8 +311,11 @@ void DrawBackgroundDeferred::run(const SceneContextPointer& sceneContext, const 
         batch.setViewTransform(viewMat);
 
         renderItems(sceneContext, renderContext, inItems);
+        _gpuTimer.end(batch);
     });
     args->_batch = nullptr;
+
+    std::static_pointer_cast<Config>(renderContext->jobConfig)->gpuTime = _gpuTimer.getAverage();
 }
 
 void Blit::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -82,11 +82,27 @@ protected:
     static gpu::PipelinePointer _opaquePipeline; //lazy evaluation hence mutable
 };
 
+class DrawBackgroundDeferredConfig : public render::Job::Config {
+    Q_OBJECT
+    Q_PROPERTY(double gpuTime READ getGpuTime)
+public:
+    double getGpuTime() { return gpuTime; }
+
+protected:
+    friend class DrawBackgroundDeferred;
+    double gpuTime;
+};
+
 class DrawBackgroundDeferred {
 public:
+    using Config = DrawBackgroundDeferredConfig;
+    using JobModel = render::Job::ModelI<DrawBackgroundDeferred, render::ItemBounds, Config>;
+
+    void configure(const Config& config) {}
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext, const render::ItemBounds& inItems);
 
-    using JobModel = render::Job::ModelI<DrawBackgroundDeferred, render::ItemBounds>;
+protected:
+    gpu::RangeTimer _gpuTimer;
 };
 
 class DrawOverlay3DConfig : public render::Job::Config {


### PR DESCRIPTION
Adds a timer to the gpu for the rendering of the skybox.
It can be viewed either through `Render.RenderDeferredTask.DrawBackgroundDeferred.gpuTimer` or by using the new script, `examples/utilities/tools/render/debugBG.js`.