### PR TITLE
repairs to udt SendQueue packet timing

### DIFF
--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -280,11 +280,11 @@ void SendQueue::run() {
         // Once we're here we've either received the handshake ACK or it's going to be time to re-send a handshake.
         // Either way let's continue processing - no packets will be sent if no handshake ACK has been received.
     }
-        
+
+    // Keep an HRC to know when the next packet should have been
+    auto nextPacketTimestamp = p_high_resolution_clock::now();
+
     while (_state == State::Running) {
-        // Record how long the loop takes to execute
-        const auto loopStartTimestamp = p_high_resolution_clock::now();
-        
         bool sentAPacket = maybeResendPacket();
         
         // if we didn't find a packet to re-send AND we think we can fit a new packet on the wire
@@ -304,9 +304,15 @@ void SendQueue::run() {
             return;
         }
         
+        // grab the current HRC timestamp
+        const auto now = p_high_resolution_clock::now();
+
+        // push the next packet timestamp forwards by the current packet send period
+        nextPacketTimestamp += std::chrono::microseconds(_packetSendPeriod);
+
         // sleep as long as we need until next packet send, if we can
-        const auto loopEndTimestamp = p_high_resolution_clock::now();
-        const auto timeToSleep = (loopStartTimestamp + std::chrono::microseconds(_packetSendPeriod)) - loopEndTimestamp;
+        const auto timeToSleep = std::chrono::duration_cast<std::chrono::microseconds>(nextPacketTimestamp - now);
+
         std::this_thread::sleep_for(timeToSleep);
     }
 }

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -29,6 +29,7 @@
 #include "Socket.h"
 
 using namespace udt;
+using namespace std::chrono;
 
 template <typename Mutex1, typename Mutex2>
 class DoubleLock {
@@ -303,15 +304,12 @@ void SendQueue::run() {
         if (_state != State::Running || isInactive(sentAPacket)) {
             return;
         }
-        
-        // grab the current HRC timestamp
-        const auto now = p_high_resolution_clock::now();
 
         // push the next packet timestamp forwards by the current packet send period
         nextPacketTimestamp += std::chrono::microseconds(_packetSendPeriod);
 
         // sleep as long as we need until next packet send, if we can
-        const auto timeToSleep = std::chrono::duration_cast<std::chrono::microseconds>(nextPacketTimestamp - now);
+        const auto timeToSleep = duration_cast<microseconds>(nextPacketTimestamp - p_high_resolution_clock::now());
 
         std::this_thread::sleep_for(timeToSleep);
     }


### PR DESCRIPTION
- fixed a bug in `udt::SendQueue` that would cause the SendQueue to not make its desired timing

This was especially bad on windows where `std::this_thread::sleep_for` frequently cannot sleep for less than a millisecond.