### PR TITLE
Fixing a bug when albedo map transparent is not quite loaded yet

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -147,7 +147,7 @@ bool NetworkGeometry::isLoadedWithTextures() const {
                 (material->lightmapTexture && !material->lightmapTexture->isLoaded())) {
                 return false;
             }
-            if (material->albedoTexture) {
+            if (material->albedoTexture && material->albedoTexture->getGPUTexture()) {
                 // Reset the materialKey transparentTexture key only, as it is albedoTexture-dependent
                 const auto& usage = material->albedoTexture->getGPUTexture()->getUsage();
                 bool isTransparentTexture = usage.isAlpha() && !usage.isAlphaMask();

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -20,7 +20,8 @@
 <@include gpu/Transform.slh@>
 <$declareStandardCameraTransform()$>
 
-uniform sampler2D albedoMap;
+<@include MaterialTextures.slh@>
+<$declareMaterialTextures(ALBEDO, ROUGHNESS, _SCRIBE_NULL, _SCRIBE_NULL, EMISSIVE, OCCLUSION)$>
 
 in vec2 _texCoord0;
 in vec4 _position;
@@ -31,16 +32,27 @@ in float _alpha;
 out vec4 _fragColor;
 
 void main(void) {
-    vec4 albedo = texture(albedoMap, _texCoord0);
-
     Material mat = getMaterial();
+    int matKey = getMaterialKey(mat);
+    <$fetchMaterialTextures(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, _SCRIBE_NULL, emissiveTex, occlusionTex)$>
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color;
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+
+    float metallic = getMaterialMetallic(mat);
+
+    vec3 emissive = getMaterialEmissive(mat);
+    <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
+
+
     vec3 fragPosition = _position.xyz;
     vec3 fragNormal = normalize(_normal);
-    vec3 fragAlbedo = getMaterialAlbedo(mat) * albedo.rgb * _color;
-    float fragMetallic = getMaterialMetallic(mat);
-    vec3 fragEmissive = getMaterialEmissive(mat);
-    float fragRoughness = getMaterialRoughness(mat);
-    float fragOpacity = getMaterialOpacity(mat) * albedo.a * _alpha;
+
+    float fragOpacity = getMaterialOpacity(mat) * albedoTex.a * _alpha;
 
     TransformCamera cam = getTransformCamera();
 
@@ -50,9 +62,9 @@ void main(void) {
         1.0,
         fragPosition,
         fragNormal,
-        fragAlbedo,
-        fragMetallic,
-        fragEmissive,
-        fragRoughness),
+        albedo,
+        metallic,
+        emissive,
+        roughness),
         fragOpacity);
 }


### PR DESCRIPTION
Added a missing test to access the albedo texture gpu version

- simple clean on the transparent shader