### PR TITLE
interface avoids registered exit handlers on Release shutdown

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -163,5 +163,9 @@ int main(int argc, const char* argv[]) {
     Application::shutdownPlugins();
 
     qCDebug(interfaceapp, "Normal exit.");
+#ifndef DEBUG
+    // HACK: exit immediately (don't handle shutdown callbacks) for Release build
+    _exit(exitCode);
+#endif
     return exitCode;
 }


### PR DESCRIPTION
- Release build of interface calls _exit() on shutdown