### PR TITLE
Check qml gl context on create

### DIFF
--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -44,13 +44,11 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
         return true;
     }
 
-    std::call_once(_reportOnce, []{
-        qWarning() << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
-        qWarning() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-        qWarning() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
-        qWarning() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
-        qWarning() << "Failed to create OffscreenGLCanvas";
-    });
+    qWarning() << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
+    qWarning() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
+    qWarning() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
+    qWarning() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
+    qWarning() << "Failed to create OffscreenGLCanvas";
 
     return false;
 }

--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -23,7 +23,7 @@ class OffscreenGLCanvas : public QObject {
 public:
     OffscreenGLCanvas();
     ~OffscreenGLCanvas();
-    void create(QOpenGLContext* sharedContext = nullptr);
+    bool create(QOpenGLContext* sharedContext = nullptr);
     bool makeCurrent();
     void doneCurrent();
     QOpenGLContext* getContext() {

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -65,7 +65,11 @@ class OffscreenQmlRenderer : public OffscreenGLCanvas {
 public:
 
     OffscreenQmlRenderer(OffscreenQmlSurface* surface, QOpenGLContext* shareContext) : _surface(surface) {
-        OffscreenGLCanvas::create(shareContext);
+        if (!OffscreenGLCanvas::create(shareContext)) {
+            static const char* error = "Failed to create OffscreenGLCanvas";
+            qWarning() << error;
+            throw error;
+        };
 
         _renderControl = new QMyQuickRenderControl();
 
@@ -153,7 +157,7 @@ private:
             qWarning("Failed to make context current on render thread");
             return;
         }
-        _renderControl->initialize(_context);
+        _renderControl->initialize(getContext());
         setupFbo();
         _escrow.setRecycler([this](GLuint texture){
             _textures.recycleTexture(texture);


### PR DESCRIPTION
Propagates the status of gl context creation through to the creation of the OffscreenQmlSurface, and logs data and crashes Interface if it fails.