### PR TITLE
Grab.js: Update Position on Mouse Grab Start

### DIFF
--- a/examples/grab.js
+++ b/examples/grab.js
@@ -373,6 +373,10 @@ Grabber.prototype.pressEvent = function(event) {
 
     beacon.updatePosition(this.startPosition);
 
+    if(!entityIsGrabbedByOther(this.entityID)){
+      this.moveEvent(event);
+    }
+     
     // TODO: play sounds again when we aren't leaking AudioInjector threads
     //Audio.playSound(grabSound, { position: entityProperties.position, volume: VOLUME });
 }


### PR DESCRIPTION
Makes sure that the moment the user starts dragging on a
object (that isn't grabbed by another), the position is immediately updated
instead of waiting for the user to move their mouse.

If this isn't done, the entity would fling it self back to the position grabbed position the moment the mouse if dragged: if the entity one with a lot of mass, this bug can cause unintentional flinging of entities that it collides with when coming back.

Can be tested by making a ball roll down a plane onto a flat horizontal plane and then trying to stop the ball with the grab script.