### PR TITLE
Make shared lists thread safe

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -159,44 +159,45 @@ void ResourceCache::clearUnusedResource() {
     }
 }
 
-bool ResourceCache::attemptRequest(Resource* resource) {
-    auto sharedItems = DependencyManager::get<ResourceCacheSharedItems>();
-
-    // Disable request limiting for ATP
-    if (resource->getURL().scheme() != URL_SCHEME_ATP) {
-        if (_requestsActive >= _requestLimit) {
-            // wait until a slot becomes available
-            sharedItems->_pendingRequests.append(resource);
-            return false;
-        }
-
-        ++_requestsActive;
-    }	
-
-    sharedItems->_loadingRequests.append(resource);
-    resource->makeRequest();
-    return true;
+void ResourceCacheSharedItems::appendActiveRequest(Resource* resource) {
+    Lock lock(_mutex);
+    _loadingRequests.append(resource);
 }
 
-void ResourceCache::requestCompleted(Resource* resource) {
-    auto sharedItems = DependencyManager::get<ResourceCacheSharedItems>();
-    sharedItems->_loadingRequests.removeOne(resource);
-    if (resource->getURL().scheme() != URL_SCHEME_ATP) {
-        --_requestsActive;
-    }
-
-    attemptHighestPriorityRequest();
+void ResourceCacheSharedItems::appendPendingRequest(Resource* resource) {
+    Lock lock(_mutex);
+    _pendingRequests.append(resource);
 }
 
-bool ResourceCache::attemptHighestPriorityRequest() {
-    auto sharedItems = DependencyManager::get<ResourceCacheSharedItems>();
+QList<QPointer<Resource>> ResourceCacheSharedItems::getPendingRequests() const {
+    Lock lock(_mutex);
+    return _pendingRequests;
+}
+
+uint32_t ResourceCacheSharedItems::getPendingRequestsCount() const {
+    Lock lock(_mutex);
+    return _pendingRequests.size();
+}
+
+QList<Resource*> ResourceCacheSharedItems::getLoadingRequests() const {
+    Lock lock(_mutex);
+    return _loadingRequests;
+}
+
+void ResourceCacheSharedItems::removeRequest(Resource* resource) {
+    Lock lock(_mutex);
+    _loadingRequests.removeOne(resource);
+}
+
+Resource* ResourceCacheSharedItems::getHighestPendingRequest() {
+    Lock lock(_mutex);
     // look for the highest priority pending request
     int highestIndex = -1;
     float highestPriority = -FLT_MAX;
-    for (int i = 0; i < sharedItems->_pendingRequests.size(); ) {
-        Resource* resource = sharedItems->_pendingRequests.at(i).data();
+    for (int i = 0; i < _pendingRequests.size();) {
+        Resource* resource = _pendingRequests.at(i).data();
         if (!resource) {
-            sharedItems->_pendingRequests.removeAt(i);
+            _pendingRequests.removeAt(i);
             continue;
         }
         float priority = resource->getLoadPriority();
@@ -206,7 +207,45 @@ bool ResourceCache::attemptHighestPriorityRequest() {
         }
         i++;
     }
-    return (highestIndex >= 0) && attemptRequest(sharedItems->_pendingRequests.takeAt(highestIndex));
+    if (highestIndex >= 0) {
+        return _pendingRequests.takeAt(highestIndex);
+    }
+    return nullptr;
+}
+
+bool ResourceCache::attemptRequest(Resource* resource) {
+    auto sharedItems = DependencyManager::get<ResourceCacheSharedItems>();
+
+    // Disable request limiting for ATP
+    if (resource->getURL().scheme() != URL_SCHEME_ATP) {
+        if (_requestsActive >= _requestLimit) {
+            // wait until a slot becomes available
+            sharedItems->appendPendingRequest(resource);
+            return false;
+        }
+
+        ++_requestsActive;
+    }
+
+    sharedItems->appendActiveRequest(resource);
+    resource->makeRequest();
+    return true;
+}
+
+void ResourceCache::requestCompleted(Resource* resource) {
+    auto sharedItems = DependencyManager::get<ResourceCacheSharedItems>();
+    sharedItems->removeRequest(resource);
+    if (resource->getURL().scheme() != URL_SCHEME_ATP) {
+        --_requestsActive;
+    }
+
+    attemptHighestPriorityRequest();
+}
+
+bool ResourceCache::attemptHighestPriorityRequest() {
+    auto sharedItems = DependencyManager::get<ResourceCacheSharedItems>();
+    auto resource = sharedItems->getHighestPendingRequest();
+    return (resource && attemptRequest(resource));
 }
 
 const int DEFAULT_REQUEST_LIMIT = 10;


### PR DESCRIPTION
the lists in `ResourceCacheSharedItems` can be accessed from multiple threads and must be protected with locking.  