### PR TITLE
openvr crash on exit fix

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1418,10 +1418,6 @@ void Application::paintGL() {
     // FIXME not needed anymore?
     _offscreenContext->makeCurrent();
 
-    // Tell the plugin what pose we're using to render.  In this case we're just using the
-    // unmodified head pose because the only plugin that cares (the Oculus plugin) uses it
-    // for rotational timewarp.  If we move to support positonal timewarp, we need to
-    // ensure this contains the full pose composed with the eye offsets.
     displayPlugin->updateHeadPose(_frameCount);
 
     // update the avatar with a fresh HMD pose
@@ -1621,6 +1617,10 @@ void Application::paintGL() {
                 mat4 eyeOffsetTransform = glm::translate(mat4(), eyeOffset * -1.0f * IPDScale);
                 eyeOffsets[eye] = eyeOffsetTransform;
 
+                // Tell the plugin what pose we're using to render.  In this case we're just using the
+                // unmodified head pose because the only plugin that cares (the Oculus plugin) uses it
+                // for rotational timewarp.  If we move to support positonal timewarp, we need to
+                // ensure this contains the full pose composed with the eye offsets.
                 displayPlugin->setEyeRenderPose(_frameCount, eye, headPose * glm::inverse(eyeOffsetTransform));
 
                 eyeProjections[eye] = displayPlugin->getEyeProjection(eye, baseProjection);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1418,6 +1418,12 @@ void Application::paintGL() {
     // FIXME not needed anymore?
     _offscreenContext->makeCurrent();
 
+    // Tell the plugin what pose we're using to render.  In this case we're just using the
+    // unmodified head pose because the only plugin that cares (the Oculus plugin) uses it
+    // for rotational timewarp.  If we move to support positonal timewarp, we need to
+    // ensure this contains the full pose composed with the eye offsets.
+    displayPlugin->updateHeadPose(_frameCount);
+
     // update the avatar with a fresh HMD pose
     getMyAvatar()->updateFromHMDSensorMatrix(getHMDSensorPose());
 
@@ -1598,12 +1604,7 @@ void Application::paintGL() {
             auto baseProjection = renderArgs._viewFrustum->getProjection();
             auto hmdInterface = DependencyManager::get<HMDScriptingInterface>();
             float IPDScale = hmdInterface->getIPDScale();
-
-            // Tell the plugin what pose we're using to render.  In this case we're just using the
-            // unmodified head pose because the only plugin that cares (the Oculus plugin) uses it
-            // for rotational timewarp.  If we move to support positonal timewarp, we need to
-            // ensure this contains the full pose composed with the eye offsets.
-            mat4 headPose = displayPlugin->updateHeadPose(_frameCount);
+            mat4 headPose = displayPlugin->getHeadPose();
 
             // FIXME we probably don't need to set the projection matrix every frame,
             // only when the display plugin changes (or in non-HMD modes when the user

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1603,7 +1603,7 @@ void Application::paintGL() {
             // unmodified head pose because the only plugin that cares (the Oculus plugin) uses it
             // for rotational timewarp.  If we move to support positonal timewarp, we need to
             // ensure this contains the full pose composed with the eye offsets.
-            mat4 headPose = displayPlugin->getHeadPose(_frameCount);
+            mat4 headPose = displayPlugin->updateHeadPose(_frameCount);
 
             // FIXME we probably don't need to set the projection matrix every frame,
             // only when the display plugin changes (or in non-HMD modes when the user
@@ -2975,7 +2975,7 @@ void Application::updateMyAvatarLookAtPosition() {
             lookAtPosition.x = -lookAtPosition.x;
         }
         if (isHMD) {
-            glm::mat4 headPose = getActiveDisplayPlugin()->getHeadPose(_frameCount);
+            glm::mat4 headPose = getActiveDisplayPlugin()->getHeadPose();
             glm::quat hmdRotation = glm::quat_cast(headPose);
             lookAtSpot = _myCamera.getPosition() + myAvatar->getOrientation() * (hmdRotation * lookAtPosition);
         } else {
@@ -4927,7 +4927,7 @@ mat4 Application::getEyeOffset(int eye) const {
 
 mat4 Application::getHMDSensorPose() const {
     if (isHMDMode()) {
-        return getActiveDisplayPlugin()->getHeadPose(_frameCount);
+        return getActiveDisplayPlugin()->getHeadPose();
     }
     return mat4();
 }

--- a/interface/src/avatar/AvatarUpdate.cpp
+++ b/interface/src/avatar/AvatarUpdate.cpp
@@ -30,7 +30,6 @@ void AvatarUpdate::synchronousProcess() {
 
     // Keep our own updated value, so that our asynchronous code can consult it.
     _isHMDMode = qApp->isHMDMode();
-    auto frameCount = qApp->getFrameCount();
 
     QSharedPointer<AvatarManager> manager = DependencyManager::get<AvatarManager>();
     MyAvatar* myAvatar = manager->getMyAvatar();

--- a/interface/src/avatar/AvatarUpdate.cpp
+++ b/interface/src/avatar/AvatarUpdate.cpp
@@ -38,7 +38,7 @@ void AvatarUpdate::synchronousProcess() {
 
     // transform the head pose from the displayPlugin into avatar coordinates.
     glm::mat4 invAvatarMat = glm::inverse(createMatFromQuatAndPos(myAvatar->getOrientation(), myAvatar->getPosition()));
-    _headPose = invAvatarMat * (myAvatar->getSensorToWorldMatrix() * qApp->getActiveDisplayPlugin()->getHeadPose(frameCount));
+    _headPose = invAvatarMat * (myAvatar->getSensorToWorldMatrix() * qApp->getActiveDisplayPlugin()->getHeadPose());
 
     if (!isThreaded()) {
         process();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1258,7 +1258,7 @@ void MyAvatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, fl
     if (qApp->isHMDMode()) {
         glm::vec3 cameraPosition = qApp->getCamera()->getPosition();
 
-        glm::mat4 headPose = qApp->getActiveDisplayPlugin()->getHeadPose(qApp->getFrameCount());
+        glm::mat4 headPose = qApp->getActiveDisplayPlugin()->getHeadPose();
         glm::mat4 leftEyePose = qApp->getActiveDisplayPlugin()->getEyeToHeadTransform(Eye::Left);
         leftEyePose = leftEyePose * headPose;
         glm::vec3 leftEyePosition = extractTranslation(leftEyePose);

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -342,7 +342,7 @@ void CompositorHelper::computeHmdPickRay(const glm::vec2& cursorPos, glm::vec3& 
 }
 
 glm::mat4 CompositorHelper::getUiTransform() const {
-    return _currentCamera * glm::inverse(_currentDisplayPlugin->getHeadPose(_currentFrame));
+    return _currentCamera * glm::inverse(_currentDisplayPlugin->getHeadPose());
 }
 
 //Finds the collision point of a world space ray

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -161,3 +161,7 @@ void HmdDisplayPlugin::updateFrameData() {
     Lock lock(_mutex);
     _currentRenderEyePoses = _renderEyePoses[_currentRenderFrameIndex];
 }
+
+glm::mat4 HmdDisplayPlugin::getHeadPose() const {
+    return _headPoseCache.get();
+}

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -7,6 +7,8 @@
 //
 #pragma once
 
+#include <ThreadSafeValueCache.h>
+
 #include <QtGlobal>
 
 #include "../OpenGLDisplayPlugin.h"
@@ -24,7 +26,7 @@ public:
     void setEyeRenderPose(uint32_t frameIndex, Eye eye, const glm::mat4& pose) override final;
     bool isDisplayVisible() const override { return isHmdMounted(); }
 
-
+    virtual glm::mat4 getHeadPose() const override;
 
 protected:
     virtual void hmdPresent() = 0;
@@ -46,6 +48,7 @@ protected:
     using EyePoses = std::array<glm::mat4, 2>;
     QMap<uint32_t, EyePoses> _renderEyePoses;
     EyePoses _currentRenderEyePoses;
+    ThreadSafeValueCache<glm::mat4> _headPoseCache { glm::mat4() };
 
 private:
     bool _enablePreview { false };

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -121,8 +121,14 @@ public:
         static const glm::mat4 transform; return transform;
     }
 
-    virtual glm::mat4 getHeadPose(uint32_t frameIndex) const {
-        static const glm::mat4 pose; return pose;
+    // will query the underlying hmd api to compute the most recent head pose
+    virtual glm::mat4 updateHeadPose(uint32_t frameIndex) {
+        return glm::mat4();
+    }
+
+    // returns a copy of the most recent head pose, computed via updateHeadPose
+    virtual glm::mat4 getHeadPose() const {
+        return glm::mat4();
     }
 
     // Needed for timewarp style features

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -122,9 +122,7 @@ public:
     }
 
     // will query the underlying hmd api to compute the most recent head pose
-    virtual glm::mat4 updateHeadPose(uint32_t frameIndex) {
-        return glm::mat4();
-    }
+    virtual void updateHeadPose(uint32_t frameIndex) {}
 
     // returns a copy of the most recent head pose, computed via updateHeadPose
     virtual glm::mat4 getHeadPose() const {

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -22,10 +22,6 @@ void OculusBaseDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
     _headPoseCache.set(headPose);
 }
 
-glm::mat4 OculusBaseDisplayPlugin::getHeadPose() const {
-    return _headPoseCache.get();
-}
-
 bool OculusBaseDisplayPlugin::isSupported() const {
     return oculusAvailable();
 }

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -15,16 +15,11 @@ void OculusBaseDisplayPlugin::resetSensors() {
     ovr_RecenterPose(_session);
 }
 
-glm::mat4 OculusBaseDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
-    static uint32_t lastFrameSeen = 0;
+void OculusBaseDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
     auto displayTime = ovr_GetPredictedDisplayTime(_session, frameIndex);
-    auto trackingState = ovr_GetTrackingState(_session, displayTime, frameIndex > lastFrameSeen);
-    if (frameIndex > lastFrameSeen) {
-        lastFrameSeen = frameIndex;
-    }
+    auto trackingState = ovr_GetTrackingState(_session, displayTime, true);
     mat4 headPose = toGlm(trackingState.HeadPose.ThePose);
     _headPoseCache.set(headPose);
-    return headPose;
 }
 
 glm::mat4 OculusBaseDisplayPlugin::getHeadPose() const {

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -15,14 +15,20 @@ void OculusBaseDisplayPlugin::resetSensors() {
     ovr_RecenterPose(_session);
 }
 
-glm::mat4 OculusBaseDisplayPlugin::getHeadPose(uint32_t frameIndex) const {
+glm::mat4 OculusBaseDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
     static uint32_t lastFrameSeen = 0;
     auto displayTime = ovr_GetPredictedDisplayTime(_session, frameIndex);
     auto trackingState = ovr_GetTrackingState(_session, displayTime, frameIndex > lastFrameSeen);
     if (frameIndex > lastFrameSeen) {
         lastFrameSeen = frameIndex;
     }
-    return toGlm(trackingState.HeadPose.ThePose);
+    mat4 headPose = toGlm(trackingState.HeadPose.ThePose);
+    _headPoseCache.set(headPose);
+    return headPose;
+}
+
+glm::mat4 OculusBaseDisplayPlugin::getHeadPose() const {
+    return _headPoseCache.get();
 }
 
 bool OculusBaseDisplayPlugin::isSupported() const {

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.h
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.h
@@ -21,7 +21,7 @@ public:
 
     // Stereo specific methods
     virtual void resetSensors() override final;
-    virtual glm::mat4 updateHeadPose(uint32_t frameIndex) override;
+    virtual void updateHeadPose(uint32_t frameIndex) override;
     virtual glm::mat4 getHeadPose() const override;
 
 protected:

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.h
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <display-plugins/hmd/HmdDisplayPlugin.h>
+#include <ThreadSafeValueCache.h>
 
 #include <QTimer>
 
@@ -20,7 +21,8 @@ public:
 
     // Stereo specific methods
     virtual void resetSensors() override final;
-    virtual glm::mat4 getHeadPose(uint32_t frameIndex) const override;
+    virtual glm::mat4 updateHeadPose(uint32_t frameIndex) override;
+    virtual glm::mat4 getHeadPose() const override;
 
 protected:
     void customizeContext() override;
@@ -36,4 +38,5 @@ protected:
     ovrHmdDesc _hmdDesc;
     ovrLayerEyeFov _sceneLayer;
     ovrViewScaleDesc _viewScaleDesc;
+    ThreadSafeValueCache<glm::mat4> _headPoseCache { glm::mat4() };
 };

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.h
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <display-plugins/hmd/HmdDisplayPlugin.h>
-#include <ThreadSafeValueCache.h>
 
 #include <QTimer>
 
@@ -22,7 +21,6 @@ public:
     // Stereo specific methods
     virtual void resetSensors() override final;
     virtual void updateHeadPose(uint32_t frameIndex) override;
-    virtual glm::mat4 getHeadPose() const override;
 
 protected:
     void customizeContext() override;
@@ -38,5 +36,4 @@ protected:
     ovrHmdDesc _hmdDesc;
     ovrLayerEyeFov _sceneLayer;
     ovrViewScaleDesc _viewScaleDesc;
-    ThreadSafeValueCache<glm::mat4> _headPoseCache { glm::mat4() };
 };

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -41,10 +41,6 @@ void OculusLegacyDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
     _headPoseCache.set(toGlm(_trackingState.HeadPose.ThePose));
 }
 
-glm::mat4 OculusLegacyDisplayPlugin::getHeadPose() const {
-    return _headPoseCache.get();
-}
-
 bool OculusLegacyDisplayPlugin::isSupported() const {
     if (!ovr_Initialize(nullptr)) {
         return false;

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -35,14 +35,13 @@ void OculusLegacyDisplayPlugin::resetSensors() {
     ovrHmd_RecenterPose(_hmd);
 }
 
-glm::mat4 OculusLegacyDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
+void OculusLegacyDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
     Lock lock(_mutex);
     _trackingState = ovrHmd_GetTrackingState(_hmd, ovr_GetTimeInSeconds());
-    lastFrameSeen = frameIndex;
     _headPoseCache.set(toGlm(_trackingState.HeadPose.ThePose));
 }
 
-glm::mat4 OculusLegacyDisplayPlugin::getHeadPose(uint32_t frameIndex) const {
+glm::mat4 OculusLegacyDisplayPlugin::getHeadPose() const {
     return _headPoseCache.get();
 }
 

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -35,14 +35,15 @@ void OculusLegacyDisplayPlugin::resetSensors() {
     ovrHmd_RecenterPose(_hmd);
 }
 
+glm::mat4 OculusLegacyDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
+    Lock lock(_mutex);
+    _trackingState = ovrHmd_GetTrackingState(_hmd, ovr_GetTimeInSeconds());
+    lastFrameSeen = frameIndex;
+    _headPoseCache.set(toGlm(_trackingState.HeadPose.ThePose));
+}
+
 glm::mat4 OculusLegacyDisplayPlugin::getHeadPose(uint32_t frameIndex) const {
-    static uint32_t lastFrameSeen = 0;
-    if (frameIndex > lastFrameSeen) {
-        Lock lock(_mutex);
-        _trackingState = ovrHmd_GetTrackingState(_hmd, ovr_GetTimeInSeconds());
-        lastFrameSeen = frameIndex;
-    }
-    return toGlm(_trackingState.HeadPose.ThePose);
+    return _headPoseCache.get();
 }
 
 bool OculusLegacyDisplayPlugin::isSupported() const {

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <display-plugins/hmd/HmdDisplayPlugin.h>
+#include <ThreadSafeValueCache.h>
 
 #include <QTimer>
 
@@ -26,7 +27,8 @@ public:
 
     // Stereo specific methods
     virtual void resetSensors() override;
-    virtual glm::mat4 getHeadPose(uint32_t frameIndex) const override;
+    virtual void updateHeadPose(uint32_t frameIndex) override;
+    virtual glm::mat4 getHeadPose() const override;
 
     virtual float getTargetFrameRate() override;
 
@@ -52,6 +54,7 @@ private:
     //ovrTexture _eyeTextures[2]; // FIXME - not currently in use
     mutable int _hmdScreen { -1 };
     bool _hswDismissed { false };
+    ThreadSafeValueCache _headPoseCache { glm::mat4() };
 };
 
 

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
@@ -54,7 +54,7 @@ private:
     //ovrTexture _eyeTextures[2]; // FIXME - not currently in use
     mutable int _hmdScreen { -1 };
     bool _hswDismissed { false };
-    ThreadSafeValueCache _headPoseCache { glm::mat4() };
+    ThreadSafeValueCache<glm::mat4> _headPoseCache { glm::mat4() };
 };
 
 

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <display-plugins/hmd/HmdDisplayPlugin.h>
-#include <ThreadSafeValueCache.h>
 
 #include <QTimer>
 
@@ -28,7 +27,6 @@ public:
     // Stereo specific methods
     virtual void resetSensors() override;
     virtual void updateHeadPose(uint32_t frameIndex) override;
-    virtual glm::mat4 getHeadPose() const override;
 
     virtual float getTargetFrameRate() override;
 
@@ -54,7 +52,6 @@ private:
     //ovrTexture _eyeTextures[2]; // FIXME - not currently in use
     mutable int _hmdScreen { -1 };
     bool _hswDismissed { false };
-    ThreadSafeValueCache<glm::mat4> _headPoseCache { glm::mat4() };
 };
 
 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -38,7 +38,7 @@ static mat4 _sensorResetMat;
 static std::array<vr::Hmd_Eye, 2> VR_EYES { { vr::Eye_Left, vr::Eye_Right } };
 
 bool OpenVrDisplayPlugin::isSupported() const {
-    return /*!isOculusPresent() &&*/ vr::VR_IsHmdPresent();
+    return !isOculusPresent() && vr::VR_IsHmdPresent();
 }
 
 void OpenVrDisplayPlugin::internalActivate() {

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -112,7 +112,7 @@ void OpenVrDisplayPlugin::resetSensors() {
     _sensorResetMat = glm::inverse(cancelOutRollAndPitch(m));
 }
 
-glm::mat4 OpenVrDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
+void OpenVrDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
 
     float displayFrequency = _system->GetFloatTrackedDeviceProperty(vr::k_unTrackedDeviceIndex_Hmd, vr::Prop_DisplayFrequency_Float);
     float frameDuration = 1.f / displayFrequency;
@@ -141,8 +141,6 @@ glm::mat4 OpenVrDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
     }
 
     _headPoseCache.set(_trackedDevicePoseMat4[0]);
-
-    return _trackedDevicePoseMat4[0];
 }
 
 glm::mat4 OpenVrDisplayPlugin::getHeadPose() const {

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -143,10 +143,6 @@ void OpenVrDisplayPlugin::updateHeadPose(uint32_t frameIndex) {
     _headPoseCache.set(_trackedDevicePoseMat4[0]);
 }
 
-glm::mat4 OpenVrDisplayPlugin::getHeadPose() const {
-    return _headPoseCache.get();
-}
-
 void OpenVrDisplayPlugin::hmdPresent() {
     // Flip y-axis since GL UV coords are backwards.
     static vr::VRTextureBounds_t leftBounds{ 0, 0, 0.5f, 1 };

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -12,7 +12,6 @@
 #include <openvr.h>
 
 #include <display-plugins/hmd/HmdDisplayPlugin.h>
-#include <ThreadSafeValueCache.h>
 
 const float TARGET_RATE_OpenVr = 90.0f;  // FIXME: get from sdk tracked device property? This number is vive-only.
 
@@ -29,7 +28,6 @@ public:
     // Stereo specific methods
     virtual void resetSensors() override;
     virtual void updateHeadPose(uint32_t frameIndex) override;
-    virtual glm::mat4 getHeadPose() const override;
 
 protected:
     void internalActivate() override;
@@ -43,5 +41,4 @@ private:
     std::atomic<vr::EDeviceActivityLevel> _hmdActivityLevel { vr::k_EDeviceActivityLevel_Unknown };
     static const QString NAME;
     mutable Mutex _poseMutex;
-    ThreadSafeValueCache<glm::mat4> _headPoseCache { glm::mat4() };
 };

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -12,6 +12,7 @@
 #include <openvr.h>
 
 #include <display-plugins/hmd/HmdDisplayPlugin.h>
+#include <ThreadSafeValueCache.h>
 
 const float TARGET_RATE_OpenVr = 90.0f;  // FIXME: get from sdk tracked device property? This number is vive-only.
 
@@ -27,7 +28,8 @@ public:
 
     // Stereo specific methods
     virtual void resetSensors() override;
-    virtual glm::mat4 getHeadPose(uint32_t frameIndex) const override;
+    virtual glm::mat4 updateHeadPose(uint32_t frameIndex) override;
+    virtual glm::mat4 getHeadPose() const override;
 
 protected:
     void internalActivate() override;
@@ -41,4 +43,5 @@ private:
     std::atomic<vr::EDeviceActivityLevel> _hmdActivityLevel { vr::k_EDeviceActivityLevel_Unknown };
     static const QString NAME;
     mutable Mutex _poseMutex;
+    ThreadSafeValueCache<glm::mat4> _headPoseCache { glm::mat4() };
 };

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -28,7 +28,7 @@ public:
 
     // Stereo specific methods
     virtual void resetSensors() override;
-    virtual glm::mat4 updateHeadPose(uint32_t frameIndex) override;
+    virtual void updateHeadPose(uint32_t frameIndex) override;
     virtual glm::mat4 getHeadPose() const override;
 
 protected:


### PR DESCRIPTION
Increased thread-safety for display plugin getHeadPose().

Before this fix, a script could call into HMD.getHUDLookAtPosition2D() while the app was shutting down, which in turn would call getHeadPose() on the currently active display plugin.  This call could cause a crash within the openvr plugin, because the SDK was either previously shutdown, or in the process of shutting down on the main thread.

This fixes this by splitting the previous DisplayPlugin::getHeadPose(int) into two parts:

* updateHeadPose(int) which is only called once a frame and only by the main thread.
* getHeadPose() which is thread-safe and will return a cached copy of the hmd pose sampled by the last updateHeadPose.