### PR TITLE
Application: disable deadlock watchdog for debug builds

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -272,11 +272,13 @@ public:
     void run() override {
         while (!_quit) {
             QThread::sleep(HEARTBEAT_UPDATE_INTERVAL_SECS);
+#ifdef NDEBUG
             auto now = usecTimestampNow();
             auto lastHeartbeatAge = now - _heartbeat;
             if (lastHeartbeatAge > MAX_HEARTBEAT_AGE_USECS) {
                 deadlockDetectionCrash();
             }
+#endif
         }
     }
 


### PR DESCRIPTION
Cause it will cause a crash if you sit on a breakpoint for too long.