### PR TITLE
Model: fix for avatars with late loaded transparent textures.

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -571,6 +571,7 @@ void Model::removeFromScene(std::shared_ptr<render::Scene> scene, render::Pendin
     }
     _renderItems.clear();
     _renderItemsSet.clear();
+    _meshGroupsKnown = false;
     _readyWhenAdded = false;
 }
 


### PR DESCRIPTION
This bug was possibly introduced by this commit:

a89a76dc libraries/render-utils/src/Model.cpp (Zach Pomerantz)      2016-03-11 14:25:39

This was causing avatars with transparent textures to not properly get re-added to the scene for Avatars that had the _needsUpdateTransparentTextures flag set to true.