### PR TITLE
fixes for udt timeout behaviour

### DIFF
--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -180,7 +180,6 @@ void DefaultCC::onLoss(SequenceNumber rangeStart, SequenceNumber rangeEnd) {
     }
 }
 
-// Note: This isn't currently being called by anything since we, unlike UDT, don't have TTL on our packets
 void DefaultCC::onTimeout() {
     if (_slowStart) {
         stopSlowStart();

--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -62,10 +62,10 @@ void DefaultCC::onACK(SequenceNumber ackNum) {
 
     if (_slowStart) {
         // we are in slow start phase - increase the congestion window size by the number of packets just ACKed
-        _congestionWindowSize += seqlen(_slowStartLastACK, ackNum);
+        _congestionWindowSize += seqlen(_lastACK, ackNum);
         
         // update the last ACK
-        _slowStartLastACK = ackNum;
+        _lastACK = ackNum;
 
         // check if we can get out of slow start (is our new congestion window size bigger than the max)
         if (_congestionWindowSize > _maxCongestionWindowSize) {
@@ -186,11 +186,11 @@ void DefaultCC::onTimeout() {
         stopSlowStart();
     } else {
         // UDT used to do the following on timeout if not in slow start - we should check if it could be helpful
-        // _lastDecreasePeriod = _packetSendPeriod;
-        // _packetSendPeriod = ceil(_packetSendPeriod * 2);
-        
+         _lastDecreasePeriod = _packetSendPeriod;
+         _packetSendPeriod = ceil(_packetSendPeriod * 2);
+
         // this seems odd - the last ack they were setting _lastDecreaseMaxSeq to only applies to slow start
-        // _lastDecreaseMaxSeq = _slowStartLastAck;
+         _lastDecreaseMaxSeq = _lastACK;
     }
 }
 
@@ -209,6 +209,5 @@ void DefaultCC::stopSlowStart() {
 }
 
 void DefaultCC::setInitialSendSequenceNumber(udt::SequenceNumber seqNum) {
-    _slowStartLastACK = seqNum;
-    _lastDecreaseMaxSeq = seqNum - 1;
+    _lastACK = _lastDecreaseMaxSeq = seqNum - 1;
 }

--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -137,6 +137,8 @@ void DefaultCC::onLoss(SequenceNumber rangeStart, SequenceNumber rangeEnd) {
             return;
         }
     }
+
+    _loss = true;
     
     static const double INTER_PACKET_ARRIVAL_INCREASE = 1.125;
     static const int MAX_DECREASES_PER_CONGESTION_EPOCH = 5;
@@ -144,13 +146,6 @@ void DefaultCC::onLoss(SequenceNumber rangeStart, SequenceNumber rangeEnd) {
     // check if this NAK starts a new congestion period - this will be the case if the
     // NAK received occured for a packet sent after the last decrease
     if (rangeStart > _lastDecreaseMaxSeq) {
-
-        // check if we should skip handling of this loss event
-        // we do this if this congestion event represents only a single packet loss
-        if (rangeStart == rangeEnd) {
-            qDebug() << "Skipping a first loss event";
-            return;
-        }
 
         _lastDecreasePeriod = _packetSendPeriod;
 
@@ -183,8 +178,6 @@ void DefaultCC::onLoss(SequenceNumber rangeStart, SequenceNumber rangeEnd) {
         _packetSendPeriod = ceil(_packetSendPeriod * INTER_PACKET_ARRIVAL_INCREASE);
         _lastDecreaseMaxSeq = _sendCurrSeqNum;
     }
-
-    _loss = true;
 }
 
 // Note: This isn't currently being called by anything since we, unlike UDT, don't have TTL on our packets

--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -148,6 +148,7 @@ void DefaultCC::onLoss(SequenceNumber rangeStart, SequenceNumber rangeEnd) {
         // check if we should skip handling of this loss event
         // we do this if this congestion event represents only a single packet loss
         if (rangeStart == rangeEnd) {
+            qDebug() << "Skipping a first loss event";
             return;
         }
 
@@ -212,4 +213,9 @@ void DefaultCC::stopSlowStart() {
         // using the method below.
         _packetSendPeriod = _congestionWindowSize / (_rtt + synInterval());
     }
+}
+
+void DefaultCC::setInitialSendSequenceNumber(udt::SequenceNumber seqNum) {
+    _slowStartLastACK = seqNum;
+    _lastDecreaseMaxSeq = seqNum - 1;
 }

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -41,7 +41,7 @@ public:
     virtual void init() {}
     virtual void onACK(SequenceNumber ackNum) {}
     virtual void onLoss(SequenceNumber rangeStart, SequenceNumber rangeEnd) {}
-    
+    virtual void onTimeout() {}
 protected:
     void setAckInterval(int ackInterval) { _ackInterval = ackInterval; }
     void setRTO(int rto) { _userDefinedRTO = true; _rto = rto; }
@@ -115,7 +115,7 @@ private:
     p_high_resolution_clock::time_point _lastRCTime = p_high_resolution_clock::now(); // last rate increase time
     
     bool _slowStart { true };	// if in slow start phase
-    SequenceNumber _slowStartLastACK; // last ACKed seq num from previous slow start check
+    SequenceNumber _lastACK; // last ACKed sequence number from previous
     bool _loss { false };	// if loss happened since last rate increase
     SequenceNumber _lastDecreaseMaxSeq; // max pkt seq num sent out when last decrease happened
     double _lastDecreasePeriod { 1 }; // value of _packetSendPeriod when last decrease happened

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -107,7 +107,7 @@ public:
     virtual void onTimeout();
 
 protected:
-    virtual void setInitialSendSequenceNumber(SequenceNumber seqNum) { _slowStartLastACK = seqNum; }
+    virtual void setInitialSendSequenceNumber(SequenceNumber seqNum);
 
 private:
     void stopSlowStart(); // stops the slow start on loss or timeout

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -118,6 +118,7 @@ private:
     SequenceNumber _slowStartLastACK; // last ACKed seq num from previous slow start check
     bool _loss { false };	// if loss happened since last rate increase
     SequenceNumber _lastDecreaseMaxSeq; // max pkt seq num sent out when last decrease happened
+    SequenceNumber _firstLossFromEvent;  // sequence number of first packet ignored for last congestion event
     double _lastDecreasePeriod { 1 }; // value of _packetSendPeriod when last decrease happened
     int _nakCount { 0 }; // number of NAKs in congestion epoch
     int _randomDecreaseThreshold { 1 }; // random threshold on decrease by number of loss events

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -118,7 +118,6 @@ private:
     SequenceNumber _slowStartLastACK; // last ACKed seq num from previous slow start check
     bool _loss { false };	// if loss happened since last rate increase
     SequenceNumber _lastDecreaseMaxSeq; // max pkt seq num sent out when last decrease happened
-    SequenceNumber _firstLossFromEvent;  // sequence number of first packet ignored for last congestion event
     double _lastDecreasePeriod { 1 }; // value of _packetSendPeriod when last decrease happened
     int _nakCount { 0 }; // number of NAKs in congestion epoch
     int _randomDecreaseThreshold { 1 }; // random threshold on decrease by number of loss events

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -98,6 +98,7 @@ SendQueue& Connection::getSendQueue() {
         QObject::connect(_sendQueue.get(), &SendQueue::packetSent, this, &Connection::recordSentPackets);
         QObject::connect(_sendQueue.get(), &SendQueue::packetRetransmitted, this, &Connection::recordRetransmission);
         QObject::connect(_sendQueue.get(), &SendQueue::queueInactive, this, &Connection::queueInactive);
+        QObject::connect(_sendQueue.get(), &SendQueue::timeout, this, &Connection::queueTimeout);
         
         // set defaults on the send queue from our congestion control object and estimatedTimeout()
         _sendQueue->setPacketSendPeriod(_congestionControl->_packetSendPeriod);
@@ -127,6 +128,12 @@ void Connection::queueInactive() {
         
         deactivate();
     }
+}
+
+void Connection::queueTimeout() {
+    updateCongestionControlAndSendQueue([this]{
+        _congestionControl->onTimeout();
+    });
 }
 
 void Connection::sendReliablePacket(std::unique_ptr<Packet> packet) {

--- a/libraries/networking/src/udt/Connection.h
+++ b/libraries/networking/src/udt/Connection.h
@@ -84,6 +84,7 @@ private slots:
     void recordSentPackets(int payload, int total);
     void recordRetransmission();
     void queueInactive();
+    void queueTimeout();
     
 private:
     void sendACK(bool wasCausedBySyncTimeout = true);

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -512,7 +512,7 @@ bool SendQueue::isInactive(bool sentAPacket) {
                         // add them to the loss list
                         
                         // Note that thanks to the DoubleLock we have the _naksLock right now
-                        _naks.append(SequenceNumber(_lastACKSequenceNumber) + 1, _currentSequenceNumber);
+                        _naks.insert(SequenceNumber(_lastACKSequenceNumber) + 1, _currentSequenceNumber);
                     }
                 }
             }

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -157,6 +157,9 @@ void SendQueue::ack(SequenceNumber ack) {
     }
     
     _lastACKSequenceNumber = (uint32_t) ack;
+
+    // call notify_one on the condition_variable_any in case the send thread is sleeping with a full congestion window
+    _emptyCondition.notify_one();
 }
 
 void SendQueue::nak(SequenceNumber start, SequenceNumber end) {

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -510,12 +510,12 @@ bool SendQueue::isInactive(bool sentAPacket) {
                 auto cvStatus = _emptyCondition.wait_for(locker, waitDuration);
                 
                 if (cvStatus == std::cv_status::timeout) {
-                    if (SequenceNumber(_lastACKSequenceNumber) < _currentSequenceNumber) {
+                    if (_naks.isEmpty() && SequenceNumber(_lastACKSequenceNumber) < _currentSequenceNumber) {
                         // after a timeout if we still have sent packets that the client hasn't ACKed we
                         // add them to the loss list
                         
                         // Note that thanks to the DoubleLock we have the _naksLock right now
-                        _naks.insert(SequenceNumber(_lastACKSequenceNumber) + 1, _currentSequenceNumber);
+                        _naks.append(SequenceNumber(_lastACKSequenceNumber) + 1, _currentSequenceNumber);
                     }
                 }
             }

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -514,6 +514,11 @@ bool SendQueue::isInactive(bool sentAPacket) {
                     
                     // Note that thanks to the DoubleLock we have the _naksLock right now
                     _naks.append(SequenceNumber(_lastACKSequenceNumber) + 1, _currentSequenceNumber);
+
+                    // we have the lock again - time to unlock it
+                    locker.unlock();
+                    
+                    emit timeout();
                 }
             }
         }

--- a/libraries/networking/src/udt/SendQueue.h
+++ b/libraries/networking/src/udt/SendQueue.h
@@ -118,7 +118,6 @@ private:
     
     std::atomic<int> _estimatedTimeout { 0 }; // Estimated timeout, set from CC
     std::atomic<int> _syncInterval { udt::DEFAULT_SYN_INTERVAL_USECS }; // Sync interval, set from CC
-    std::atomic<int> _timeoutExpiryCount { 0 }; // The number of times the timeout has expired without response from client
     std::atomic<uint64_t> _lastReceiverResponse { 0 }; // Timestamp for the last time we got new data from the receiver (ACK/NAK)
     
     std::atomic<int> _flowWindowSize { 0 }; // Flow control window size (number of packets that can be on wire) - set from CC

--- a/libraries/networking/src/udt/SendQueue.h
+++ b/libraries/networking/src/udt/SendQueue.h
@@ -78,6 +78,8 @@ signals:
     void packetRetransmitted();
     
     void queueInactive();
+
+    void timeout();
     
 private slots:
     void run();

--- a/libraries/networking/src/udt/SendQueue.h
+++ b/libraries/networking/src/udt/SendQueue.h
@@ -97,6 +97,8 @@ private:
     
     bool isInactive(bool sentAPacket);
     void deactivate(); // makes the queue inactive and cleans it up
+
+    bool isFlowWindowFull() const;
     
     // Increments current sequence number and return it
     SequenceNumber getNextSequenceNumber();


### PR DESCRIPTION
- fixes an issue where the udt::SendQueue would not reset its state if it is still sending packets but not hearing from receiver
- fixes an issue where the udt::SendQueue would not re-send packets if the receiver goes away for a short period of time and it thinks the flow window is full
- fixes an assert due to race conditions in udt::SendQueue timeout
- adds decrease of packet send period if udt::SendQueue hits a timeout