### PR TITLE
Delete used QNetworkReply

### DIFF
--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -271,6 +271,7 @@ QNetworkReply* OBJReader::request(QUrl& url, bool isTest) {
     QNetworkRequest netRequest(url);
     QNetworkReply* netReply = isTest ? networkAccessManager.head(netRequest) : networkAccessManager.get(netRequest);
     if (!qApp || aboutToQuit) {
+        netReply->deleteLater();
         return nullptr;
     }
     QEventLoop loop; // Create an event loop that will quit when we get the finished signal

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -1700,6 +1700,7 @@ bool Octree::readFromURL(const QString& urlString) {
             QDataStream inputStream(reply);
             readOk = readFromStream(resourceSize, inputStream);
         }
+        delete reply;
     }
     return readOk;
 }


### PR DESCRIPTION
Fixes memory leaks by deleting QNetworkReply instances after they are used.