### PR TITLE
Static cast avatar network reply

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1162,7 +1162,7 @@ void AvatarData::setBillboardFromURL(const QString &billboardURL) {
 }
 
 void AvatarData::setBillboardFromNetworkReply() {
-    QNetworkReply* networkReply = reinterpret_cast<QNetworkReply*>(sender());
+    QNetworkReply* networkReply = static_cast<QNetworkReply*>(sender());
     setBillboard(networkReply->readAll());
     networkReply->deleteLater();
 }


### PR DESCRIPTION
Instead of `reinterpret_cast`. I think this is dead code.