### PR TITLE
Default background behavior to stars

### DIFF
--- a/libraries/model/src/model/Stage.h
+++ b/libraries/model/src/model/Stage.h
@@ -173,7 +173,7 @@ public:
     const SkyboxPointer& getSkybox() const { valid(); return _skybox; }
 
 protected:
-    BackgroundMode _backgroundMode = SKY_BOX;
+    BackgroundMode _backgroundMode = SKY_DOME;
 
     LightPointer _sunLight;
     mutable SkyboxPointer _skybox;


### PR DESCRIPTION
The codepath to propagate zone settings to the stage (actually rendered zone) only runs if the zone changes. If there is no zone to begin with, then the default is shown.

This changes the default behavior to SKY_DOME, instead of SKY_BOX, so that it will show stars instead of whatever is in the stage's memory. This was manifesting as a white background with (for me) a thin red border.