### PR TITLE
one more crack at fixing the blender

### DIFF
--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -402,11 +402,15 @@ public slots:
         const QVector<glm::vec3>& vertices, const QVector<glm::vec3>& normals);
 
 private:
+    using Mutex = std::mutex;
+    using Lock = std::unique_lock<Mutex>;
+
     ModelBlender();
     virtual ~ModelBlender();
 
     std::set<ModelWeakPointer, std::owner_less<ModelWeakPointer>> _modelsRequiringBlends;
     int _pendingBlenders;
+    Mutex _mutex;
 };
 
 


### PR DESCRIPTION
Makes the `_modelsRequiringBlends` thread safe, in case multiple threads attempt to call `noteRequiresBlend()` while blenders are running. Also implements the proper version of iterating and removing items from `std::set<>` 