### PR TITLE
fix to default avatar model

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -968,9 +968,10 @@ bool AvatarData::hasIdentityChangedAfterParsing(const QByteArray& data) {
 
     bool hasIdentityChanged = false;
 
-    if (skeletonModelURL != _skeletonModelURL) {
+    if (_firstSkeletonCheck || (skeletonModelURL != _skeletonModelURL)) {
         setSkeletonModelURL(skeletonModelURL);
         hasIdentityChanged = true;
+        _firstSkeletonCheck = false;
     }
 
     if (displayName != _displayName) {

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -368,7 +368,8 @@ protected:
 
     HeadData* _headData;
 
-    QUrl _skeletonModelURL; // These need to be empty so that on first time setting them they will not short circuit
+    QUrl _skeletonModelURL;
+    bool _firstSkeletonCheck { true };
     QUrl _skeletonFBXURL;
     QVector<AttachmentData> _attachmentData;
     QString _displayName;


### PR DESCRIPTION
If an avatar was using the default avatar (empty string), the avatar mixer wasn't considering the identity packet as changed, and was never sending out the packet so people wouldn't see the avatar.