### PR TITLE
Clear GL error before initializing qml to avoid mystery crash

### DIFF
--- a/libraries/gl/src/gl/GLWindow.cpp
+++ b/libraries/gl/src/gl/GLWindow.cpp
@@ -39,6 +39,14 @@ GLWindow::~GLWindow() {
 bool GLWindow::makeCurrent() {
     bool makeCurrentResult = _context->makeCurrent(this);
     Q_ASSERT(makeCurrentResult);
+    
+    std::call_once(_reportOnce, []{
+        qDebug() << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
+        qDebug() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
+        qDebug() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
+        qDebug() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
+    });
+    
     Q_ASSERT(_context == QOpenGLContext::currentContext());
     
     return makeCurrentResult;

--- a/libraries/gl/src/gl/GLWindow.cpp
+++ b/libraries/gl/src/gl/GLWindow.cpp
@@ -39,14 +39,6 @@ GLWindow::~GLWindow() {
 bool GLWindow::makeCurrent() {
     bool makeCurrentResult = _context->makeCurrent(this);
     Q_ASSERT(makeCurrentResult);
-    
-    std::call_once(_reportOnce, []{
-        qDebug() << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
-        qDebug() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-        qDebug() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
-        qDebug() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
-    });
-    
     Q_ASSERT(_context == QOpenGLContext::currentContext());
     
     return makeCurrentResult;

--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -44,10 +44,6 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
         return true;
     }
 
-    qWarning() << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
-    qWarning() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-    qWarning() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
-    qWarning() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
     qWarning() << "Failed to create OffscreenGLCanvas";
 
     return false;
@@ -57,13 +53,6 @@ bool OffscreenGLCanvas::makeCurrent() {
     bool result = _context->makeCurrent(_offscreenSurface);
     Q_ASSERT(result);
     
-    std::call_once(_reportOnce, []{
-        qDebug() << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
-        qDebug() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-        qDebug() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
-        qDebug() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
-    });
-
 #ifdef DEBUG
     if (result && !_logger) {
         _logger = new QOpenGLDebugLogger(this);

--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -44,8 +44,6 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
         return true;
     }
 
-    qWarning() << "Failed to create OffscreenGLCanvas";
-
     return false;
 }
 
@@ -53,6 +51,13 @@ bool OffscreenGLCanvas::makeCurrent() {
     bool result = _context->makeCurrent(_offscreenSurface);
     Q_ASSERT(result);
     
+    std::call_once(_reportOnce, []{
+        qDebug() << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
+        qDebug() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
+        qDebug() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
+        qDebug() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
+    });
+
 #ifdef DEBUG
     if (result && !_logger) {
         _logger = new QOpenGLDebugLogger(this);

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -192,7 +192,7 @@ void OffscreenQmlRenderThread::setupFbo() {
     // FIXME: Something upstream is polluting the context with a GL_INVALID_ENUM,
     //        likely from glewExperimental = true
     GLenum err = glGetError();
-    if (err != GLEW_OK) {
+    if (err != GL_NO_ERROR) {
         qDebug() << "Clearing outstanding GL error to set up QML FBO:" << glewGetErrorString(err);
     }
 

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -187,6 +187,15 @@ bool OffscreenQmlRenderThread::event(QEvent *e) {
 void OffscreenQmlRenderThread::setupFbo() {
     using namespace oglplus;
     _textures.setSize(_size);
+
+    // Before making any ogl calls, clear any outstanding errors
+    // FIXME: Something upstream is polluting the context with a GL_INVALID_ENUM,
+    //        likely from glewExperimental = true
+    GLenum err = glGetError();
+    if (err != GLEW_OK) {
+        qDebug() << "Clearing outstanding GL error to set up QML FBO:" << glewGetErrorString(err);
+    }
+
     _depthStencil.reset(new Renderbuffer());
     Context::Bound(Renderbuffer::Target::Renderbuffer, *_depthStencil)
         .Storage(

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -87,18 +87,15 @@ void GLBackend::init() {
     static std::once_flag once;
     std::call_once(once, [] {
         qCDebug(gpulogging) << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
-
         qCDebug(gpulogging) << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-
         qCDebug(gpulogging) << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
-
         qCDebug(gpulogging) << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
 
         glewExperimental = true;
         GLenum err = glewInit();
-        glGetError();
+        glGetError(); // clear the potential error from glewExperimental
         if (GLEW_OK != err) {
-            /* Problem: glewInit failed, something is seriously wrong. */
+            // glewInit failed, something is seriously wrong.
             qCDebug(gpulogging, "Error: %s\n", glewGetErrorString(err));
         }
         qCDebug(gpulogging, "Status: Using GLEW %s\n", glewGetString(GLEW_VERSION));

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -30,7 +30,7 @@ bool OculusBaseDisplayPlugin::isSupported() const {
 void OculusBaseDisplayPlugin::customizeContext() {
     glewExperimental = true;
     GLenum err = glewInit();
-    glGetError();
+    glGetError(); // clear the potential error from glewExperimental
     Parent::customizeContext();
 }
 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -101,7 +101,7 @@ void OpenVrDisplayPlugin::customizeContext() {
     std::call_once(once, []{
         glewExperimental = true;
         GLenum err = glewInit();
-        glGetError();
+        glGetError(); // clear the potential error from glewExperimental
     });
     Parent::customizeContext();
 }


### PR DESCRIPTION
Adds a check before calling oglplus operations in the OffscreenQmlRenderThread to see if there are any outstanding gl errors. If there is one, it will be cleared and logged as:
```
Clearing outstanding GL error to set up QML FBO: ERROR_TYPE
```

This should remove setupFbo crashes, but continue to log when the errors occur.