### PR TITLE
Avoid triggering deadlock on long local qml component instantion

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -271,6 +271,8 @@ public slots:
 
     void reloadResourceCaches();
 
+    void updateHeartbeat();
+
     void crashApplication();
     void deadlockApplication();
 
@@ -505,6 +507,8 @@ private:
     mutable QMutex _changeCursorLock { QMutex::Recursive };
     QCursor _desiredCursor{ Qt::BlankCursor };
     bool _cursorNeedsChanging { false };
+
+    QThread* _deadlockWatchdogThread;
 };
 
 #endif // hifi_Application_h

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -426,7 +426,11 @@ void OffscreenQmlSurface::setBaseUrl(const QUrl& baseUrl) {
 }
 
 QObject* OffscreenQmlSurface::load(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f) {
-    _qmlComponent->loadUrl(qmlSource);
+    // Synchronous loading may take a while; restart the deadlock timer
+    QMetaObject::invokeMethod(qApp, "updateHeartbeat", Qt::DirectConnection);
+
+    _qmlComponent->loadUrl(qmlSource, QQmlComponent::PreferSynchronous);
+
     if (_qmlComponent->isLoading()) {
         connect(_qmlComponent, &QQmlComponent::statusChanged, this, 
             [this, f](QQmlComponent::Status){


### PR DESCRIPTION
- Expose DeadlockWatchdogThread::updateHeartbeat as a public slot on qApp.
- Make qml component instantiation `PreferSynchronous` explicitly.
- Update deadlock heartbeat before qml component instantiation to avoid "deadlock" trigger on long load times.