### PR TITLE
Add a tracker and logging of memory allocated by the GPU library

### DIFF
--- a/cmake/externals/oglplus/CMakeLists.txt
+++ b/cmake/externals/oglplus/CMakeLists.txt
@@ -4,7 +4,7 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 include(ExternalProject)
 ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://iweb.dl.sourceforge.net/project/oglplus/oglplus-0.63.x/oglplus-0.63.0.zip
+    URL http://hifi-public.s3.amazonaws.com/dependencies/oglplus-0.63.0.zip
     URL_MD5 de984ab245b185b45c87415c0e052135
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/libraries/gpu/src/gpu/Resource.cpp
+++ b/libraries/gpu/src/gpu/Resource.cpp
@@ -10,11 +10,74 @@
 //
 #include "Resource.h"
 
+#include <atomic>
+
+#include <SharedUtil.h>
+#include <NumericalConstants.h>
 #include <QDebug>
 
 using namespace gpu;
 
+class AllocationDebugger {
+public:
+    void operator+=(size_t size) {
+        _allocatedMemory += size;
+        maybeReport();
+    }
+
+    void operator-=(size_t size) {
+        _allocatedMemory -= size;
+        maybeReport();
+    }
+
+private:
+    QString formatSize(size_t size) {
+        float num = size;
+        QStringList list;
+        list << "KB" << "MB" << "GB" << "TB";
+
+        QStringListIterator i(list);
+        QString unit("bytes");
+
+        while (num >= K && i.hasNext()) {
+            unit = i.next();
+            num /= K;
+        }
+        return QString().setNum(num, 'f', 2) + " " + unit;
+    }
+
+    void maybeReport() {
+        auto now = usecTimestampNow();
+        if (now - _lastReportTime < MAX_REPORT_FREQUENCY) {
+            return;
+        }
+        size_t current = _allocatedMemory;
+        size_t last = _lastReportedMemory;
+        size_t delta = (current > last) ? (current - last) : (last - current);
+        if (delta > MIN_REPORT_DELTA) {
+            _lastReportTime = now;
+            _lastReportedMemory = current;
+            qDebug() << "Total allocation " << formatSize(current);
+        }
+    }
+
+    std::atomic<size_t> _allocatedMemory;
+    std::atomic<size_t> _lastReportedMemory;
+    std::atomic<uint64_t> _lastReportTime;
+
+    static const float K;
+    // Report changes of 5 megabytes
+    static const size_t MIN_REPORT_DELTA = 1024 * 1024 * 5;
+    // Report changes no more frequently than every 15 seconds
+    static const uint64_t MAX_REPORT_FREQUENCY = USECS_PER_SECOND * 15;
+};
+
+const float AllocationDebugger::K = 1024.0f;
+
+static AllocationDebugger allocationDebugger;
+
 Resource::Size Resource::Sysmem::allocateMemory(Byte** dataAllocated, Size size) {
+    allocationDebugger += size;
     if ( !dataAllocated ) { 
         qWarning() << "Buffer::Sysmem::allocateMemory() : Must have a valid dataAllocated pointer.";
         return NOT_ALLOCATED;
@@ -38,6 +101,7 @@ Resource::Size Resource::Sysmem::allocateMemory(Byte** dataAllocated, Size size)
 }
 
 void Resource::Sysmem::deallocateMemory(Byte* dataAllocated, Size size) {
+    allocationDebugger -= size;
     if (dataAllocated) {
         delete[] dataAllocated;
     }


### PR DESCRIPTION
This add some logging specifically of the system (CPU) memory allocated by the gpu library.  

Testing this in my domain `hifi://dreaming/508.962,512.78,509.212/0,-0.937658,0,0.347564` shows the memory jump to 1.2 GB within 1 minute of entering the domain.  A significant amount of this seems to be from entities that are currently set not visible.  I'm surprised we load this geometry / these textures.  Also, if we're loading the textures but never rendering them, I suspect that we're retaining a lot of system memory for the loaded texture file, since the criteria for dropping the system memory is that we've synced it to the GPU. 

