### PR TITLE
Move oglplus dependency from sourceforge to s3

### DIFF
--- a/cmake/externals/oglplus/CMakeLists.txt
+++ b/cmake/externals/oglplus/CMakeLists.txt
@@ -4,7 +4,7 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 include(ExternalProject)
 ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://iweb.dl.sourceforge.net/project/oglplus/oglplus-0.63.x/oglplus-0.63.0.zip
+    URL http://hifi-public.s3.amazonaws.com/dependencies/oglplus-0.63.0.zip
     URL_MD5 de984ab245b185b45c87415c0e052135
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
I'm seeing build failures on fetching the oglplus library.  We're currently fetching from sourceforge, so I'm trying moving the dependency to our S3 repository.