### PR TITLE
Fix potential deadlock in QML

### DIFF
--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -23,6 +23,7 @@
 #include <PerfStat.h>
 #include <DependencyManager.h>
 #include <NumericalConstants.h>
+#include <Finally.h>
 
 #include "OffscreenGLCanvas.h"
 #include "GLEscrow.h"
@@ -84,6 +85,7 @@ protected:
     Queue _queue;
     QMutex _mutex;
     QWaitCondition _waitCondition;
+    std::atomic<bool> _rendering { false };
 
 private:
     // Event-driven methods
@@ -271,15 +273,25 @@ void OffscreenQmlRenderThread::resize() {
 }
 
 void OffscreenQmlRenderThread::render() {
-    if (_surface->_paused) {
+    // Ensure we always release the main thread
+    Finally releaseMainThread([this] {
         _waitCondition.wakeOne();
+    });
+
+    if (_surface->_paused) {
         return;
     }
 
-    QMutexLocker locker(&_mutex);
-    _renderControl->sync();
-    _waitCondition.wakeOne();
-    locker.unlock();
+    _rendering = true;
+    Finally unmarkRenderingFlag([this] {
+        _rendering = false;
+    });
+
+    {
+        QMutexLocker locker(&_mutex);
+        _renderControl->sync();
+        releaseMainThread.trigger();
+    }
 
     using namespace oglplus;
 
@@ -292,6 +304,7 @@ void OffscreenQmlRenderThread::render() {
         _fbo->AttachTexture(Framebuffer::Target::Draw, FramebufferAttachment::Color, *texture, 0);
         _fbo->Complete(Framebuffer::Target::Draw);
         {
+            PROFILE_RANGE("qml_render->rendercontrol")
             _renderControl->render();
             // FIXME The web browsers seem to be leaving GL in an error state.
             // Need a debug context with sync logging to figure out why.
@@ -379,8 +392,6 @@ void OffscreenQmlSurface::resize(const QSize& newSize_) {
                 std::max(static_cast<int>(scale * newSize.width()), 10),
                 std::max(static_cast<int>(scale * newSize.height()), 10));
     }
-
-
 
     QSize currentSize = _renderer->_quickWindow->geometry().size();
     if (newSize == currentSize) {
@@ -492,7 +503,12 @@ QObject* OffscreenQmlSurface::finishQmlLoad(std::function<void(QQmlContext*, QOb
 }
 
 void OffscreenQmlSurface::updateQuick() {
-    if (!_renderer || !_renderer->allowNewFrame(_maxFps)) {
+    // If we're 
+    //   a) not set up
+    //   b) already rendering a frame
+    //   c) rendering too fast
+    // then skip this 
+    if (!_renderer || _renderer->_rendering || !_renderer->allowNewFrame(_maxFps)) {
         return;
     }
 
@@ -502,11 +518,11 @@ void OffscreenQmlSurface::updateQuick() {
     }
 
     if (_render) {
+        PROFILE_RANGE(__FUNCTION__);
         // Lock the GUI size while syncing
         QMutexLocker locker(&(_renderer->_mutex));
         _renderer->_queue.add(RENDER);
         _renderer->_waitCondition.wait(&(_renderer->_mutex));
-
         _render = false;
     }
 

--- a/libraries/shared/src/Finally.h
+++ b/libraries/shared/src/Finally.h
@@ -20,6 +20,10 @@ public:
     template <typename F>
     Finally(F f) : _f(f) {}
     ~Finally() { _f(); }
+    void trigger() {
+        _f();
+        _f = [] {};
+    }
 private:
     std::function<void()> _f;
 };


### PR DESCRIPTION
The QML rendering thread is required to *briefly* block the main thread during the call to [`sync`](http://doc.qt.io/qt-5/qquickrendercontrol.html#sync).  However, 

However, a problem arises if the QML rendering thread takes an excessive amount of time in the render call...  For example

* Main thread requests QML render frame 1
* Main thread blocks on waiting for QML to `sync`
* Render thread calls `sync`
* Main thread is released
* Render thread enters `render`
* Main thread requests QML render frame 2
* Main thread blocks on waiting for QML to `sync`
* Render thread is still in previous frame processing and the main thread is never released

Now, the QML thread should never take 10 seconds to render unless something is very wrong, but it would probably be preferable to have the UI freeze than have the application crash.  

This PR addresses the issue by adjusting the code that issues a render event to the rendering thread to only do so if a render event is not already in progress.