### PR TITLE
Added Refresh Buttons to entityProperties

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -451,36 +451,36 @@
 
                 var elPreviewCameraButton = document.getElementById("preview-camera-button");
     
-		var urlUpdaters = document.getElementsByClassName("update-url-version");
-		var PARAM_REGEXP = /(?:\?)(\S+)/; // Check if this has any parameters.
-		var TIMESTAMP_REGEXP = /(&?HFTime=\d+)/;
-	
-		var refreshEvent = function(event){
-	  		var urlElement = event.target.parentElement.getElementsByClassName("url")[0];
-  			var content = urlElement.value;
-  			var date = new Date();
-  			var timeStamp = date.getTime();
+                var urlUpdaters = document.getElementsByClassName("update-url-version");
+                var PARAM_REGEXP = /(?:\?)(\S+)/; // Check if this has any parameters.
+                var TIMESTAMP_REGEXP = /(&?HFTime=\d+)/;
 
-  			if(content.length > 0){
-      				if(PARAM_REGEXP.test(content)){
-        			// Has params, so lets remove existing definition and append again.
-        				content = content.replace(TIMESTAMP_REGEXP,"") + "&";		
-      				}else{
-        				content += "?";
-      				}
-				content = content.replace("?&","?");
-				urlElement.value = content + "HFTime=" + timeStamp; 
-    			}
-   			var evt = document.createEvent("HTMLEvents");
-    			evt.initEvent("change", true, true ); 
-    			urlElement.dispatchEvent(evt);
+                var refreshEvent = function(event){
+                    var urlElement = event.target.parentElement.getElementsByClassName("url")[0];
+                    var content = urlElement.value;
+                    var date = new Date();
+                    var timeStamp = date.getTime();
 
-		};
+                    if(content.length > 0){
+                        if(PARAM_REGEXP.test(content)){
+                        // Has params, so lets remove existing definition and append again.
+                            content = content.replace(TIMESTAMP_REGEXP,"") + "&";
+                        }else{
+                            content += "?";
+                        }
+                        content = content.replace("?&","?");
+                        urlElement.value = content + "HFTime=" + timeStamp;
+                    }
 
-		for(var index = 0; index < urlUpdaters.length; index++){
-  			var urlUpdater = urlUpdaters[index];
-  			urlUpdater.addEventListener("click", refreshEvent);
-		}
+                    var evt = document.createEvent("HTMLEvents");
+                    evt.initEvent("change", true, true );
+                    urlElement.dispatchEvent(evt);
+                };
+
+                for(var index = 0; index < urlUpdaters.length; index++){
+                    var urlUpdater = urlUpdaters[index];
+                    urlUpdater.addEventListener("click", refreshEvent);
+                }
 
                 if (window.EventBridge !== undefined) {
                     var properties;
@@ -1216,7 +1216,7 @@
             <div class="label">Ambient URL</div>
             <div class="value">
                 <input type="text" id="property-zone-key-ambient-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1294,7 +1294,7 @@
             <div class="label">Skybox URL</div>
             <div class="value">
                 <input type="text" id="property-zone-skybox-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1306,7 +1306,7 @@
             <div class="label">Source URL</div>
             <div class="value">
                 <input type="text" id="property-web-source-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
 
             </div>
         </div>
@@ -1320,14 +1320,14 @@
             <div class="label">Href - Hifi://address</div>
             <div class="value">
                 <input id="property-hyperlink-href" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
         <div class="hyperlink-section property">
             <div class="label">Description</div>
             <div class="value">
                 <input id="property-hyperlink-description" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1411,19 +1411,19 @@
             <div class="label">X-axis Texture URL</div>
             <div class="value">
               <input type="text" id="property-x-texture-url" class="url">
-		<div class="update-url-version"></div>
+              <div class="update-url-version"></div>
             </div>
 
             <div class="label">Y-axis Texture URL</div>
             <div class="value">
               <input type="text" id="property-y-texture-url" class="url">
-		<div class="update-url-version"></div>
+              <div class="update-url-version"></div>
             </div>
 
             <div class="label">Z-axis Texture URL</div>
             <div class="value">
               <input type="text" id="property-z-texture-url" class="url">
-	      <div class="update-url-version"></div>
+              <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1605,7 +1605,7 @@
             <div class="label">Collision Sound URL</div>
             <div class="value">
                 <input id="property-collision-sound-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1623,7 +1623,7 @@
             </div>
             <div class="value">
                 <input id="property-script-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1636,7 +1636,7 @@
             <div class="label">Model URL</div>
             <div class="value">
                 <input type="text" id="property-model-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1655,14 +1655,14 @@
             <div class="label">Compound Shape URL</div>
             <div class="value">
                 <input type="text" id="property-compound-shape-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
         <div class="model-section property">
             <div class="label">Animation URL</div>
             <div class="value">
                 <input type="text" id="property-model-animation-url" class="url">
-		<div class="update-url-version"></div>
+                <div class="update-url-version"></div>
             </div>
         </div>
         <div class="model-section property">

--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -451,6 +451,37 @@
 
                 var elPreviewCameraButton = document.getElementById("preview-camera-button");
     
+		var urlUpdaters = document.getElementsByClassName("update-url-version");
+		var PARAM_REGEXP = /(?:\?)(\S+)/; // Check if this has any parameters.
+		var TIMESTAMP_REGEXP = /(&?HFTime=\d+)/;
+	
+		var refreshEvent = function(event){
+	  		var urlElement = event.target.parentElement.getElementsByClassName("url")[0];
+  			var content = urlElement.value;
+  			var date = new Date();
+  			var timeStamp = date.getTime();
+
+  			if(content.length > 0){
+      				if(PARAM_REGEXP.test(content)){
+        			// Has params, so lets remove existing definition and append again.
+        				content = content.replace(TIMESTAMP_REGEXP,"") + "&";		
+      				}else{
+        				content += "?";
+      				}
+				content = content.replace("?&","?");
+				urlElement.value = content + "HFTime=" + timeStamp; 
+    			}
+   			var evt = document.createEvent("HTMLEvents");
+    			evt.initEvent("change", true, true ); 
+    			urlElement.dispatchEvent(evt);
+
+		};
+
+		for(var index = 0; index < urlUpdaters.length; index++){
+  			var urlUpdater = urlUpdaters[index];
+  			urlUpdater.addEventListener("click", refreshEvent);
+		}
+
                 if (window.EventBridge !== undefined) {
                     var properties;
                     EventBridge.scriptEventReceived.connect(function(data) {
@@ -1185,6 +1216,7 @@
             <div class="label">Ambient URL</div>
             <div class="value">
                 <input type="text" id="property-zone-key-ambient-url" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1262,6 +1294,7 @@
             <div class="label">Skybox URL</div>
             <div class="value">
                 <input type="text" id="property-zone-skybox-url" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1273,6 +1306,7 @@
             <div class="label">Source URL</div>
             <div class="value">
                 <input type="text" id="property-web-source-url" class="url">
+		<div class="update-url-version"></div>
 
             </div>
         </div>
@@ -1286,12 +1320,14 @@
             <div class="label">Href - Hifi://address</div>
             <div class="value">
                 <input id="property-hyperlink-href" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
         <div class="hyperlink-section property">
             <div class="label">Description</div>
             <div class="value">
                 <input id="property-hyperlink-description" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1375,16 +1411,19 @@
             <div class="label">X-axis Texture URL</div>
             <div class="value">
               <input type="text" id="property-x-texture-url" class="url">
+		<div class="update-url-version"></div>
             </div>
 
             <div class="label">Y-axis Texture URL</div>
             <div class="value">
               <input type="text" id="property-y-texture-url" class="url">
+		<div class="update-url-version"></div>
             </div>
 
             <div class="label">Z-axis Texture URL</div>
             <div class="value">
               <input type="text" id="property-z-texture-url" class="url">
+	      <div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1566,6 +1605,7 @@
             <div class="label">Collision Sound URL</div>
             <div class="value">
                 <input id="property-collision-sound-url" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1583,6 +1623,7 @@
             </div>
             <div class="value">
                 <input id="property-script-url" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1595,6 +1636,7 @@
             <div class="label">Model URL</div>
             <div class="value">
                 <input type="text" id="property-model-url" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
 
@@ -1613,12 +1655,14 @@
             <div class="label">Compound Shape URL</div>
             <div class="value">
                 <input type="text" id="property-compound-shape-url" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
         <div class="model-section property">
             <div class="label">Animation URL</div>
             <div class="value">
                 <input type="text" id="property-model-animation-url" class="url">
+		<div class="update-url-version"></div>
             </div>
         </div>
         <div class="model-section property">

--- a/examples/html/style.css
+++ b/examples/html/style.css
@@ -134,8 +134,18 @@ textarea {
     resize: vertical;
 }
 
+.update-url-version{
+    width:17px;
+    height:17px;
+    float:right;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAQAAACRZI9xAAABAUlEQVQoz33RvyvEARjH8SdlUX6UbhFJfgwmE3aTxWEiitxqN/gH7IxCKTcymLiJFIOJsihiUKcrCYnuXoZv+F45n2d4lvfz6fPpCSFs6BO1JllvLmXk5F37dC0vJ5NGmlBxoFp7Rn6RDpRRtG5KtynrijhLoBBGQcllKkFWAXsyCbKEFxeGqmJmFZFLkE639vX+12hCSVft0nUR8RbLcRN/aSHGIqL2tVYPconL32qLtaiL88Rl0qtXc+pTDv1OPGMlidtgS8Wp2RR05FEFM98/GlRQ9mTHvB7jVt2rKGPAT9xh2z6qfnToHV1SjZpN23Tl051di1oco9W/pdttaBRfEhFXOZV7vEsAAAAASUVORK5CYII=);
+    padding:0 !important;
+    margin:0 2px 0 0 !important;
+}
+
 input.url {
-    width: 100%;
+    width:85%;
+    padding-right: 20px;
 }
 
 input.coord {


### PR DESCRIPTION
This PR adds a simple "reload content" button at the end of each url entityProperty in the Edit windows.

It appends / updates to the url a parameter "HFTime" that is the current timestamp (in milliseconds) to request the latest version of an asset. If there is nothing on the field, pressing the button should do nothing.

-----

### Note this may be difficult to test via rawgit. I suggest downloading the zip and then using the example folder instead as a whole due to so many dependencies in the edit.js script

**Test Expectations:**
- if the url is empty, pressing the button should not do anything
- Pressing the button should always reload the property asset.
- If HFTime already exist, it should be removed, and a new one replacing it should appear.
- Pressing the button should not break the entity url to be invalid URI spec.

**Test cases:**
- Files/Atp? (this is a question mark)
- Plain url
- Url with multiple parameters
- Url parameter with existing HFTime parameter: HFTime Parameter is removed, and updated at the end of the url.

**Testing:**

1. Use edit.js
2. Select an entity with a url property. 
3. Update the url content.
4. Press the refresh button.
5. Updated entity should now load without having to touch the url. This url may now be used on other content using the same asset

