### PR TITLE
Fix async issues related to JS <-> App <-> QML <-> HTML communication

### DIFF
--- a/examples/html/eventBridgeLoader.js
+++ b/examples/html/eventBridgeLoader.js
@@ -10,50 +10,11 @@
 
 var EventBridge;
 
-EventBridgeConnectionProxy = function(parent) {
-    this.parent = parent;
-    this.realSignal = this.parent.realBridge.scriptEventReceived
-    this.webWindowId = this.parent.webWindow.windowId;
-}
-
-EventBridgeConnectionProxy.prototype.connect = function(callback) {
-    var that = this;
-    this.realSignal.connect(function(id, message) {
-        if (id === that.webWindowId) { callback(message); }
-    });
-}
-
-EventBridgeProxy = function(webWindow) {
-    this.webWindow = webWindow;
-    this.realBridge = this.webWindow.eventBridge;  
-    this.scriptEventReceived = new EventBridgeConnectionProxy(this);
-}
-
-EventBridgeProxy.prototype.emitWebEvent = function(data) {
-    this.realBridge.emitWebEvent(data);
-}
-
 openEventBridge = function(callback) {
-    EVENT_BRIDGE_URI = "ws://localhost:51016";
-    socket = new WebSocket(this.EVENT_BRIDGE_URI);
-    
-    socket.onclose = function() { 
-        console.error("web channel closed"); 
-    };
-
-    socket.onerror = function(error) { 
-        console.error("web channel error: " + error); 
-    };
-
-    socket.onopen = function() {
-        channel = new QWebChannel(socket, function(channel) {
-            console.log("Document url is " + document.URL);
-            var webWindow = channel.objects[document.URL.toLowerCase()];
-            console.log("WebWindow is " + webWindow)
-            eventBridgeProxy = new EventBridgeProxy(webWindow);
-            EventBridge = eventBridgeProxy; 
-            if (callback) {  callback(eventBridgeProxy); }
-        });
-    }
+    new QWebChannel(qt.webChannelTransport, function(channel) {
+        console.log("uid " + EventBridgeUid);
+        EventBridge = channel.objects[EventBridgeUid];
+        callback(EventBridge);
+    });
 }
 

--- a/examples/html/qmlWebTest.html
+++ b/examples/html/qmlWebTest.html
@@ -4,21 +4,17 @@
 <script type="text/javascript" src="jquery-2.1.4.min.js"></script>
 <script type="text/javascript" src="qrc:///qtwebchannel/qwebchannel.js"></script>
 <script type="text/javascript" src="eventBridgeLoader.js"></script>
-
 <script>
-    var myBridge;
-
     window.onload = function() { 
-        openEventBridge(function(eventBridge) {
-            myBridge = eventBridge;
-            myBridge.scriptEventReceived.connect(function(message) {
+        openEventBridge(function() {
+            EventBridge.scriptEventReceived.connect(function(message) {
                 console.log("HTML side received message: " + message); 
             });
         });
     }
 
     testClick = function() {
-        myBridge.emitWebEvent("HTML side sending message - button click");
+        EventBridge.emitWebEvent(["Foo", "Bar", { "baz": 1} ]);
     }
 </script>
 </head>

--- a/examples/tests/qmlWebTest.js
+++ b/examples/tests/qmlWebTest.js
@@ -8,26 +8,14 @@ webWindow.eventBridge.webEventReceived.connect(function(data) {
     print("JS Side event received: " + data);
 });
 
-var titles = ["A", "B", "C"];
-var titleIndex = 0;
-
 Script.setInterval(function() {
-    webWindow.eventBridge.emitScriptEvent("JS Event sent");
-    var size = webWindow.size;
-    var position = webWindow.position;
-    print("Window url: " + webWindow.url)
-    print("Window visible: " + webWindow.visible)
-    print("Window size:  " + size.x + "x" + size.y)
-    print("Window pos:   " + position.x + "x" + position.y)
-    webWindow.setVisible(!webWindow.visible);
-    webWindow.setTitle(titles[titleIndex]);
-    webWindow.setSize(320 + Math.random() * 100, 240 + Math.random() * 100);
-    titleIndex += 1;
-    titleIndex %= titles.length;
-}, 2 * 1000);
+    var message = [ Math.random(), Math.random() ];
+    print("JS Side sending: " + message); 
+    webWindow.emitScriptEvent(message);
+}, 5 * 1000);
 
-Script.setTimeout(function() {
-    print("Closing script");
+Script.scriptEnding.connect(function(){
     webWindow.close();
-    Script.stop();
-}, 15 * 1000)
+    webWindow.deleteLater();
+});
+

--- a/interface/resources/qml/QmlWebWindow.qml
+++ b/interface/resources/qml/QmlWebWindow.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.3
 import QtQuick.Controls 1.2
 import QtWebEngine 1.1
+import QtWebChannel 1.0
 
 import "windows" as Windows
 import "controls" as Controls
@@ -15,11 +16,22 @@ Windows.Window {
     // Don't destroy on close... otherwise the JS/C++ will have a dangling pointer
     destroyOnCloseButton: false
     property alias source: webview.url
+    property alias webChannel: webview.webChannel
+    // A unique identifier to let the HTML JS find the event bridge 
+    // object (our C++ wrapper)
+    property string uid;
+
+    // This is for JS/QML communication, which is unused in a WebWindow,
+    // but not having this here results in spurious warnings about a 
+    // missing signal
+    signal sendToScript(var message);
 
     Controls.WebView {
         id: webview
         url: "about:blank"
         anchors.fill: parent
         focus: true
+        onUrlChanged: webview.runJavaScript("EventBridgeUid = \"" + uid + "\";");
+        Component.onCompleted: webview.runJavaScript("EventBridgeUid = \"" + uid + "\";");
     }
 } // dialog

--- a/interface/resources/qml/ToolWindow.qml
+++ b/interface/resources/qml/ToolWindow.qml
@@ -37,14 +37,33 @@ Windows.Window {
         Repeater {
             model: 4
             Tab {
+                // Force loading of the content even if the tab is not visible
+                // (required for letting the C++ code access the webview)
                 active: true
-                enabled: false;
-                // we need to store the original url here for future identification
+                enabled: false
                 property string originalUrl: "";
-                onEnabledChanged: toolWindow.updateVisiblity();
+
                 Controls.WebView {
                     id: webView;
+                    // we need to store the original url here for future identification
+                    // A unique identifier to let the HTML JS find the event bridge 
+                    // object (our C++ wrapper)
+                    property string uid;
                     anchors.fill: parent
+                    enabled: false
+
+                    // This is for JS/QML communication, which is unused in a WebWindow,
+                    // but not having this here results in spurious warnings about a 
+                    // missing signal
+                    signal sendToScript(var message);
+                    
+                    onUrlChanged: webView.runJavaScript("EventBridgeUid = \"" + uid + "\";");
+                    onEnabledChanged: toolWindow.updateVisiblity();
+                    onLoadingChanged: {
+                        if (loadRequest.status == WebEngineView.LoadSucceededStatus) {
+                            webView.runJavaScript("EventBridgeUid = \"" + uid + "\";");
+                        }
+                    }
                 }
             }
         }
@@ -113,20 +132,23 @@ Windows.Window {
 
         var tab = tabView.getTab(index);
         tab.title = "";
-        tab.originalUrl = "";
         tab.enabled = false;
+        tab.originalUrl = "";
+        tab.item.url = "about:blank";
+        tab.item.enabled = false;
     }
 
     function addWebTab(properties) {
         if (!properties.source) {
-            console.warn("Attempted to open Web Tool Pane without URL")
+            console.warn("Attempted to open Web Tool Pane without URL");
             return;
         }
 
         var existingTabIndex = findIndexForUrl(properties.source);
         if (existingTabIndex >= 0) {
-            console.log("Existing tab " + existingTabIndex + " found with URL " + properties.source)
-            return tabView.getTab(existingTabIndex);
+            console.log("Existing tab " + existingTabIndex + " found with URL " + properties.source);
+            var tab = tabView.getTab(existingTabIndex);
+            return tab.item;
         }
 
         var freeTabIndex = findFreeTab();
@@ -135,25 +157,22 @@ Windows.Window {
             return;
         }
 
-        var newTab = tabView.getTab(freeTabIndex);
-        newTab.title = properties.title || "Unknown";
-        newTab.originalUrl = properties.source;
-        newTab.item.url = properties.source;
-        newTab.active = true;
-
         if (properties.width) {
-            tabView.width = Math.min(Math.max(tabView.width, properties.width),
-                                        toolWindow.maxSize.x);
+            tabView.width = Math.min(Math.max(tabView.width, properties.width), toolWindow.maxSize.x);
         }
 
         if (properties.height) {
-            tabView.height = Math.min(Math.max(tabView.height, properties.height),
-                                        toolWindow.maxSize.y);
+            tabView.height = Math.min(Math.max(tabView.height, properties.height), toolWindow.maxSize.y);
         }
 
-        console.log("Updating visibility based on child tab added");
-        newTab.enabledChanged.connect(updateVisiblity)
-        updateVisiblity();
-        return newTab
+        var tab = tabView.getTab(freeTabIndex);
+        tab.title = properties.title || "Unknown";
+        tab.enabled = true;
+        tab.originalUrl = properties.source;
+
+        var result = tab.item;
+        result.enabled = true;
+        result.url = properties.source;
+        return result;
     }
 }

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -59,6 +59,7 @@ WebEngineView {
             request.openIn(newWindow.webView)
     }
 
-
-    profile: desktop.browserProfile
+    // This breaks the webchannel used for passing messages.  Fixed in Qt 5.6
+    // See https://bugreports.qt.io/browse/QTBUG-49521
+    //profile: desktop.browserProfile
 }

--- a/libraries/ui/src/QmlWebWindowClass.cpp
+++ b/libraries/ui/src/QmlWebWindowClass.cpp
@@ -31,19 +31,18 @@ static const char* const URL_PROPERTY = "source";
 // Method called by Qt scripts to create a new web window in the overlay
 QScriptValue QmlWebWindowClass::constructor(QScriptContext* context, QScriptEngine* engine) {
     return QmlWindowClass::internalConstructor("QmlWebWindow.qml", context, engine,
-        [&](QObject* object) { return new QmlWebWindowClass(object); });
+        [&](QObject* object) {  return new QmlWebWindowClass(object);  });
 }
 
 QmlWebWindowClass::QmlWebWindowClass(QObject* qmlWindow) : QmlWindowClass(qmlWindow) {
 }
 
 
-// FIXME remove.
-void QmlWebWindowClass::handleNavigation(const QString& url) {
-}
-
 QString QmlWebWindowClass::getURL() const {
     QVariant result = DependencyManager::get<OffscreenUi>()->returnFromUiThread([&]()->QVariant {
+        if (_qmlWindow.isNull()) {
+            return QVariant();
+        }
         return _qmlWindow->property(URL_PROPERTY);
     });
     return result.toString();
@@ -54,6 +53,8 @@ extern QString fixupHifiUrl(const QString& urlString);
 
 void QmlWebWindowClass::setURL(const QString& urlString) {
     DependencyManager::get<OffscreenUi>()->executeOnUiThread([=] {
-        _qmlWindow->setProperty(URL_PROPERTY, fixupHifiUrl(urlString));
+        if (!_qmlWindow.isNull()) {
+            _qmlWindow->setProperty(URL_PROPERTY, fixupHifiUrl(urlString));
+        }
     });
 }

--- a/libraries/ui/src/QmlWebWindowClass.h
+++ b/libraries/ui/src/QmlWebWindowClass.h
@@ -26,9 +26,6 @@ public slots:
 
 signals:
     void urlChanged();
-
-private slots:
-    void handleNavigation(const QString& url);
 };
 
 #endif

--- a/libraries/ui/src/QmlWebWindowClass.h
+++ b/libraries/ui/src/QmlWebWindowClass.h
@@ -11,10 +11,13 @@
 
 #include "QmlWindowClass.h"
 
+class QWebChannel;
+
 // FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping 
 class QmlWebWindowClass : public QmlWindowClass {
     Q_OBJECT
     Q_PROPERTY(QString url READ getURL CONSTANT)
+    Q_PROPERTY(QString uid READ getUid CONSTANT)
 
 public:
     static QScriptValue constructor(QScriptContext* context, QScriptEngine* engine);
@@ -23,9 +26,18 @@ public:
 public slots:
     QString getURL() const;
     void setURL(const QString& url);
+    const QString& getUid() const { return _uid; }
+    void emitScriptEvent(const QVariant& scriptMessage);
+    void emitWebEvent(const QVariant& webMessage);
 
 signals:
     void urlChanged();
+    void scriptEventReceived(const QVariant& message);
+    void webEventReceived(const QVariant& message);
+
+private:
+    QString _uid;
+    QWebChannel* _webchannel { nullptr };
 };
 
 #endif

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -10,10 +10,12 @@
 #define hifi_ui_QmlWindowClass_h
 
 #include <QtCore/QObject>
-#include <GLMHelpers.h>
+#include <QtCore/QPointer>
 #include <QtScript/QScriptValue>
 #include <QtQuick/QQuickItem>
 #include <QtWebChannel/QWebChannelAbstractTransport>
+
+#include <GLMHelpers.h>
 
 class QScriptEngine;
 class QScriptContext;
@@ -38,14 +40,13 @@ private:
     const QmlWindowClass* _webWindow { nullptr };
     QWebSocket *_socket { nullptr };
 };
-
 // FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping 
 class QmlWindowClass : public QObject {
     Q_OBJECT
     Q_PROPERTY(QObject* eventBridge READ getEventBridge CONSTANT)
     Q_PROPERTY(int windowId READ getWindowId CONSTANT)
-    Q_PROPERTY(glm::vec2 position READ getPosition WRITE setPosition)
-    Q_PROPERTY(glm::vec2 size READ getSize WRITE setSize)
+    Q_PROPERTY(glm::vec2 position READ getPosition WRITE setPosition NOTIFY positionChanged)
+    Q_PROPERTY(glm::vec2 size READ getSize WRITE setSize NOTIFY sizeChanged)
     Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibilityChanged)
 
 public:
@@ -64,11 +65,8 @@ public slots:
     glm::vec2 getSize() const;
     void setSize(const glm::vec2& size);
     void setSize(int width, int height);
-
     void setTitle(const QString& title);
 
-
-    // Ugh.... do not want to do
     Q_INVOKABLE void raise();
     Q_INVOKABLE void close();
     Q_INVOKABLE int getWindowId() const { return _windowId; };
@@ -79,6 +77,8 @@ public slots:
 
 signals:
     void visibilityChanged(bool visible);  // Tool window
+    void positionChanged();
+    void sizeChanged();
     void moved(glm::vec2 position);
     void resized(QSizeF size);
     void closed();
@@ -104,7 +104,7 @@ protected:
     // for tool window panes in QML
     bool _toolWindow { false };
     const int _windowId;
-    QObject* _qmlWindow;
+    QPointer<QObject> _qmlWindow;
     QString _source;
 };
 

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -13,38 +13,16 @@
 #include <QtCore/QPointer>
 #include <QtScript/QScriptValue>
 #include <QtQuick/QQuickItem>
-#include <QtWebChannel/QWebChannelAbstractTransport>
 
 #include <GLMHelpers.h>
 
 class QScriptEngine;
 class QScriptContext;
-class QmlWindowClass;
-class QWebSocketServer;
-class QWebSocket;
 
-class QmlScriptEventBridge : public QObject {
-    Q_OBJECT
-public:
-    QmlScriptEventBridge(const QmlWindowClass* webWindow) : _webWindow(webWindow) {}
-
-public slots :
-    void emitWebEvent(const QString& data);
-    void emitScriptEvent(const QString& data);
-
-signals:
-    void webEventReceived(const QString& data);
-    void scriptEventReceived(int windowId, const QString& data);
-
-private:
-    const QmlWindowClass* _webWindow { nullptr };
-    QWebSocket *_socket { nullptr };
-};
 // FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping 
 class QmlWindowClass : public QObject {
     Q_OBJECT
     Q_PROPERTY(QObject* eventBridge READ getEventBridge CONSTANT)
-    Q_PROPERTY(int windowId READ getWindowId CONSTANT)
     Q_PROPERTY(glm::vec2 position READ getPosition WRITE setPosition NOTIFY positionChanged)
     Q_PROPERTY(glm::vec2 size READ getSize WRITE setSize NOTIFY sizeChanged)
     Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibilityChanged)
@@ -69,8 +47,7 @@ public slots:
 
     Q_INVOKABLE void raise();
     Q_INVOKABLE void close();
-    Q_INVOKABLE int getWindowId() const { return _windowId; };
-    Q_INVOKABLE QmlScriptEventBridge* getEventBridge() const { return _eventBridge; };
+    Q_INVOKABLE QObject* getEventBridge() { return this; };
 
     // Scripts can use this to send a message to the QML object
     void sendToQml(const QVariant& message);
@@ -92,18 +69,12 @@ protected:
     static QScriptValue internalConstructor(const QString& qmlSource, 
         QScriptContext* context, QScriptEngine* engine, 
         std::function<QmlWindowClass*(QObject*)> function);
-    static void setupServer();
-    static void registerObject(const QString& name, QObject* object);
-    static void deregisterObject(QObject* object);
-    static QWebSocketServer* _webChannelServer;
 
     QQuickItem* asQuickItem() const;
-    QmlScriptEventBridge* const _eventBridge { new QmlScriptEventBridge(this) };
 
     // FIXME needs to be initialized in the ctor once we have support
     // for tool window panes in QML
     bool _toolWindow { false };
-    const int _windowId;
     QPointer<QObject> _qmlWindow;
     QString _source;
 };


### PR DESCRIPTION
Addresses a potential sources of crashing due to the asynchronous passing of requests between JS scripts and the QML objects.

Also re-implements the mechanism used to communicate between Interface JS and HTML JS

To test this you need to load scripts from `http://rawgit.com/jherico/hifi/qml_crashes/examples/defaultScripts.js`

One issue I saw in production was that repeatedly reloading all scripts would eventually crash.  With this build I'm unable to reproduce this.  Note that you should wait for the reload to finish before reloading again.  Simply spamming the reload button seems to have some issues.