### PR TITLE
make the deadlock watchdog more generous

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -248,13 +248,8 @@ public:
     // Set the heartbeat on launch
     DeadlockWatchdogThread() {
         setObjectName("Deadlock Watchdog");
-        QTimer* heartbeatTimer = new QTimer();
         // Give the heartbeat an initial value
         _heartbeat = usecTimestampNow();
-        connect(heartbeatTimer, &QTimer::timeout, [this] {
-            updateHeartbeat();
-        });
-        heartbeatTimer->start(HEARTBEAT_UPDATE_INTERVAL_SECS * MSECS_PER_SECOND);
         connect(qApp, &QCoreApplication::aboutToQuit, [this] {
             _quit = true;
         });
@@ -278,7 +273,7 @@ public:
             auto now = usecTimestampNow();
             auto lastHeartbeatAge = now - _heartbeat;
             auto sinceLastReport = now - _lastReport;
-            int elapsedMovingAverage = _movingAverage.average;
+            auto elapsedMovingAverage = _movingAverage.getAverage();
 
             if (elapsedMovingAverage > _maxElapsedAverage) {
                 qDebug() << "DEADLOCK WATCHDOG NEW maxElapsedAverage:"
@@ -287,7 +282,7 @@ public:
                     << "maxElapsed:" << _maxElapsed
                     << "PREVIOUS maxElapsedAverage:" << _maxElapsedAverage
                     << "NEW maxElapsedAverage:" << elapsedMovingAverage
-                    << "numSamples:" << _movingAverage.numSamples;
+                    << "numSamples:" << _movingAverage.getNumSamples();
                 _maxElapsedAverage = elapsedMovingAverage;
             }
             if (lastHeartbeatAge > _maxElapsed) {
@@ -297,7 +292,7 @@ public:
                     << "PREVIOUS maxElapsed:" << _maxElapsed
                     << "NEW maxElapsed:" << lastHeartbeatAge
                     << "maxElapsedAverage:" << _maxElapsedAverage
-                    << "numSamples:" << _movingAverage.numSamples;
+                    << "numSamples:" << _movingAverage.getNumSamples();
                 _maxElapsed = lastHeartbeatAge;
             }
             if ((sinceLastReport > HEARTBEAT_REPORT_INTERVAL_USECS) || (elapsedMovingAverage > WARNING_ELAPSED_HEARTBEAT)) {
@@ -305,7 +300,7 @@ public:
                          << "elapsedMovingAverage:" << elapsedMovingAverage
                          << "maxElapsed:" << _maxElapsed
                          << "maxElapsedAverage:" << _maxElapsedAverage
-                         << "numSamples:" << _movingAverage.numSamples;
+                         << "numSamples:" << _movingAverage.getNumSamples();
                 _lastReport = now;
             }
 
@@ -315,7 +310,7 @@ public:
                          << "elapsedMovingAverage:" << elapsedMovingAverage
                          << "maxElapsed:" << _maxElapsed
                          << "maxElapsedAverage:" << _maxElapsedAverage
-                         << "numSamples:" << _movingAverage.numSamples;
+                         << "numSamples:" << _movingAverage.getNumSamples();
                 deadlockDetectionCrash();
             }
 #endif

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -271,8 +271,10 @@ public:
         while (!_quit) {
             QThread::sleep(HEARTBEAT_UPDATE_INTERVAL_SECS);
             auto now = usecTimestampNow();
-            auto lastHeartbeatAge = now - _heartbeat;
-            auto sinceLastReport = now - _lastReport;
+
+            // in the unlikely event that now is less than _heartbeat, don't rollover and confuse ourselves
+            auto lastHeartbeatAge = (now > _heartbeat) ? now - _heartbeat : 0; 
+            auto sinceLastReport = (now > _lastReport) ? now - _lastReport : 0;
             auto elapsedMovingAverage = _movingAverage.getAverage();
 
             if (elapsedMovingAverage > _maxElapsedAverage) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -321,8 +321,9 @@ public:
     static std::atomic<uint64_t> _lastReport;
     static std::atomic<uint64_t> _maxElapsed;
     static std::atomic<int> _maxElapsedAverage;
-    bool _quit { false };
     static ThreadSafeMovingAverage<int, HEARTBEAT_SAMPLES> _movingAverage;
+
+    bool _quit { false };
 };
 
 std::atomic<uint64_t> DeadlockWatchdogThread::_heartbeat;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -322,7 +322,7 @@ public:
     static std::atomic<int> _maxElapsed;
     static std::atomic<int> _maxElapsedAverage;
     bool _quit { false };
-    MovingAverage<int, HEARTBEAT_SAMPLES> _movingAverage;
+    ThreadSafeMovingAverage<int, HEARTBEAT_SAMPLES> _movingAverage;
 };
 
 std::atomic<uint64_t> DeadlockWatchdogThread::_heartbeat;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -242,7 +242,7 @@ public:
     static const unsigned long HEARTBEAT_UPDATE_INTERVAL_SECS = 1;
     static const unsigned long HEARTBEAT_REPORT_INTERVAL_USECS = 5 * USECS_PER_SECOND;
     static const unsigned long MAX_HEARTBEAT_AGE_USECS = 30 * USECS_PER_SECOND;
-    static const uint64_t WARNING_ELAPSED_HEARTBEAT = 500 * USECS_PER_MSEC; // warn if elapsed heartbeat average is large
+    static const int WARNING_ELAPSED_HEARTBEAT = 500 * USECS_PER_MSEC; // warn if elapsed heartbeat average is large
     static const int HEARTBEAT_SAMPLES = 100000; // ~5 seconds worth of samples
     
     // Set the heartbeat on launch
@@ -319,7 +319,7 @@ public:
 
     static std::atomic<uint64_t> _heartbeat;
     static std::atomic<uint64_t> _lastReport;
-    static std::atomic<int> _maxElapsed;
+    static std::atomic<uint64_t> _maxElapsed;
     static std::atomic<int> _maxElapsedAverage;
     bool _quit { false };
     ThreadSafeMovingAverage<int, HEARTBEAT_SAMPLES> _movingAverage;
@@ -327,7 +327,7 @@ public:
 
 std::atomic<uint64_t> DeadlockWatchdogThread::_heartbeat;
 std::atomic<uint64_t> DeadlockWatchdogThread::_lastReport;
-std::atomic<int> DeadlockWatchdogThread::_maxElapsed;
+std::atomic<uint64_t> DeadlockWatchdogThread::_maxElapsed;
 std::atomic<int> DeadlockWatchdogThread::_maxElapsedAverage;
 
 #ifdef Q_OS_WIN

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -306,7 +306,10 @@ public:
 
 #ifdef NDEBUG
             if (lastHeartbeatAge > MAX_HEARTBEAT_AGE_USECS) {
-                qDebug() << "DEADLOCK DETECTED -- lastHeartbeatAge:" << lastHeartbeatAge 
+                qDebug() << "DEADLOCK DETECTED -- "
+                         << "lastHeartbeatAge:" << lastHeartbeatAge
+                         << "[ _heartbeat:" << _heartbeat
+                         << "now:" << now << " ]"
                          << "elapsedMovingAverage:" << elapsedMovingAverage
                          << "maxElapsed:" << _maxElapsed
                          << "maxElapsedAverage:" << _maxElapsedAverage

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -322,13 +322,14 @@ public:
     static std::atomic<uint64_t> _maxElapsed;
     static std::atomic<int> _maxElapsedAverage;
     bool _quit { false };
-    ThreadSafeMovingAverage<int, HEARTBEAT_SAMPLES> _movingAverage;
+    static ThreadSafeMovingAverage<int, HEARTBEAT_SAMPLES> _movingAverage;
 };
 
 std::atomic<uint64_t> DeadlockWatchdogThread::_heartbeat;
 std::atomic<uint64_t> DeadlockWatchdogThread::_lastReport;
 std::atomic<uint64_t> DeadlockWatchdogThread::_maxElapsed;
 std::atomic<int> DeadlockWatchdogThread::_maxElapsedAverage;
+ThreadSafeMovingAverage<int, DeadlockWatchdogThread::HEARTBEAT_SAMPLES> DeadlockWatchdogThread::_movingAverage;
 
 #ifdef Q_OS_WIN
 class MyNativeEventFilter : public QAbstractNativeEventFilter {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -282,7 +282,7 @@ public:
                     << "maxElapsed:" << _maxElapsed
                     << "PREVIOUS maxElapsedAverage:" << _maxElapsedAverage
                     << "NEW maxElapsedAverage:" << elapsedMovingAverage
-                    << "numSamples:" << _movingAverage.getNumSamples();
+                    << "samples:" << _movingAverage.getSamples();
                 _maxElapsedAverage = elapsedMovingAverage;
             }
             if (lastHeartbeatAge > _maxElapsed) {
@@ -292,7 +292,7 @@ public:
                     << "PREVIOUS maxElapsed:" << _maxElapsed
                     << "NEW maxElapsed:" << lastHeartbeatAge
                     << "maxElapsedAverage:" << _maxElapsedAverage
-                    << "numSamples:" << _movingAverage.getNumSamples();
+                    << "samples:" << _movingAverage.getSamples();
                 _maxElapsed = lastHeartbeatAge;
             }
             if ((sinceLastReport > HEARTBEAT_REPORT_INTERVAL_USECS) || (elapsedMovingAverage > WARNING_ELAPSED_HEARTBEAT)) {
@@ -300,7 +300,7 @@ public:
                          << "elapsedMovingAverage:" << elapsedMovingAverage
                          << "maxElapsed:" << _maxElapsed
                          << "maxElapsedAverage:" << _maxElapsedAverage
-                         << "numSamples:" << _movingAverage.getNumSamples();
+                         << "samples:" << _movingAverage.getSamples();
                 _lastReport = now;
             }
 
@@ -310,7 +310,7 @@ public:
                          << "elapsedMovingAverage:" << elapsedMovingAverage
                          << "maxElapsed:" << _maxElapsed
                          << "maxElapsedAverage:" << _maxElapsedAverage
-                         << "numSamples:" << _movingAverage.getNumSamples();
+                         << "samples:" << _movingAverage.getSamples();
                 deadlockDetectionCrash();
             }
 #endif

--- a/libraries/gpu/src/gpu/Query.cpp
+++ b/libraries/gpu/src/gpu/Query.cpp
@@ -67,5 +67,5 @@ void RangeTimer::end(gpu::Batch& batch) {
 }
 
 double RangeTimer::getAverage() const {
-    return _movingAverage.getAverage();
+    return _movingAverage.average;
 }

--- a/libraries/gpu/src/gpu/Query.cpp
+++ b/libraries/gpu/src/gpu/Query.cpp
@@ -67,5 +67,5 @@ void RangeTimer::end(gpu::Batch& batch) {
 }
 
 double RangeTimer::getAverage() const {
-    return _movingAverage.average;
+    return _movingAverage.getAverage();
 }

--- a/libraries/shared/src/SimpleMovingAverage.h
+++ b/libraries/shared/src/SimpleMovingAverage.h
@@ -57,16 +57,12 @@ public:
 
     void addSample(T sample) {
         if (numSamples > 0) {
-            T lastAverage = average;
-            average = (sample * WEIGHTING) + (lastAverage * ONE_MINUS_WEIGHTING);
+            average = (sample * WEIGHTING) + (average * ONE_MINUS_WEIGHTING);
         } else {
             average = sample;
         }
         numSamples++;
     }
-
-    T getAverage() const { return average; }
-    T getNumSamples() const { return numSamples; }
 };
 
 template <class T, int MAX_NUM_SAMPLES> class ThreadSafeMovingAverage {

--- a/libraries/shared/src/SimpleMovingAverage.h
+++ b/libraries/shared/src/SimpleMovingAverage.h
@@ -57,7 +57,8 @@ public:
 
     void addSample(T sample) {
         if (numSamples > 0) {
-            average = (sample * WEIGHTING) + (average * ONE_MINUS_WEIGHTING);
+            T lastAverage = average;
+            average = (sample * WEIGHTING) + (lastAverage * ONE_MINUS_WEIGHTING);
         } else {
             average = sample;
         }

--- a/libraries/shared/src/SimpleMovingAverage.h
+++ b/libraries/shared/src/SimpleMovingAverage.h
@@ -44,11 +44,6 @@ private:
 
 template <class T, int MAX_NUM_SAMPLES> class MovingAverage {
 public:
-    const float WEIGHTING = 1.0f / (float)MAX_NUM_SAMPLES;
-    const float ONE_MINUS_WEIGHTING = 1.0f - WEIGHTING;
-    std::atomic<int> numSamples { 0 };
-    std::atomic<T> average;
-
     void clear() {
         numSamples = 0;
     }
@@ -64,6 +59,15 @@ public:
         }
         numSamples++;
     }
+
+    T getAverage() const { return average; }
+    T getNumSamples() const { return numSamples; }
+
+private:
+    const float WEIGHTING = 1.0f / (float)MAX_NUM_SAMPLES;
+    const float ONE_MINUS_WEIGHTING = 1.0f - WEIGHTING;
+    std::atomic<int> numSamples{ 0 };
+    std::atomic<T> average;
 };
 
 #endif // hifi_SimpleMovingAverage_h

--- a/libraries/shared/src/SimpleMovingAverage.h
+++ b/libraries/shared/src/SimpleMovingAverage.h
@@ -44,6 +44,11 @@ private:
 
 template <class T, int MAX_NUM_SAMPLES> class MovingAverage {
 public:
+    const float WEIGHTING = 1.0f / (float)MAX_NUM_SAMPLES;
+    const float ONE_MINUS_WEIGHTING = 1.0f - WEIGHTING;
+    int numSamples{ 0 };
+    T average;
+
     void clear() {
         numSamples = 0;
     }
@@ -62,6 +67,29 @@ public:
 
     T getAverage() const { return average; }
     T getNumSamples() const { return numSamples; }
+};
+
+template <class T, int MAX_NUM_SAMPLES> class ThreadSafeMovingAverage {
+public:
+    void clear() {
+        numSamples = 0;
+    }
+
+    bool isAverageValid() const { return (numSamples > 0); }
+
+    void addSample(T sample) {
+        if (numSamples > 0) {
+            T lastAverage = average;
+            average = (sample * WEIGHTING) + (lastAverage * ONE_MINUS_WEIGHTING);
+        }
+        else {
+            average = sample;
+        }
+        numSamples++;
+    }
+
+    T getAverage() const { return average; }
+    T getNumSamples() const { return numSamples; }
 
 private:
     const float WEIGHTING = 1.0f / (float)MAX_NUM_SAMPLES;
@@ -69,5 +97,6 @@ private:
     std::atomic<int> numSamples{ 0 };
     std::atomic<T> average;
 };
+
 
 #endif // hifi_SimpleMovingAverage_h

--- a/libraries/shared/src/SimpleMovingAverage.h
+++ b/libraries/shared/src/SimpleMovingAverage.h
@@ -14,6 +14,7 @@
 #ifndef hifi_SimpleMovingAverage_h
 #define hifi_SimpleMovingAverage_h
 
+#include <atomic>
 #include <stdint.h>
 
 class SimpleMovingAverage {
@@ -45,8 +46,8 @@ template <class T, int MAX_NUM_SAMPLES> class MovingAverage {
 public:
     const float WEIGHTING = 1.0f / (float)MAX_NUM_SAMPLES;
     const float ONE_MINUS_WEIGHTING = 1.0f - WEIGHTING;
-    int numSamples{ 0 };
-    T average;
+    std::atomic<int> numSamples { 0 };
+    std::atomic<T> average;
 
     void clear() {
         numSamples = 0;

--- a/libraries/shared/src/SimpleMovingAverage.h
+++ b/libraries/shared/src/SimpleMovingAverage.h
@@ -69,41 +69,39 @@ template <class T, int MAX_NUM_SAMPLES> class ThreadSafeMovingAverage {
 public:
     void clear() {
         std::unique_lock<std::mutex> lock(_lock);
-        numSamples = 0;
+        _samples = 0;
     }
 
     bool isAverageValid() const { 
         std::unique_lock<std::mutex> lock(_lock);
-        return (numSamples > 0);
+        return (_samples > 0);
     }
 
     void addSample(T sample) {
         std::unique_lock<std::mutex> lock(_lock);
-        if (numSamples > 0) {
-            T lastAverage = average;
-            average = (sample * WEIGHTING) + (lastAverage * ONE_MINUS_WEIGHTING);
+        if (_samples > 0) {
+            _average = (sample * WEIGHTING) + (_average * ONE_MINUS_WEIGHTING);
+        } else {
+            _average = sample;
         }
-        else {
-            average = sample;
-        }
-        numSamples++;
+        _samples++;
     }
 
     T getAverage() const { 
         std::unique_lock<std::mutex> lock(_lock);
-        return average;
+        return _average;
     }
 
-    T getNumSamples() const { 
+    size_t getSamples() const {
         std::unique_lock<std::mutex> lock(_lock);
-        return numSamples;
+        return _samples;
     }
 
 private:
     const float WEIGHTING = 1.0f / (float)MAX_NUM_SAMPLES;
     const float ONE_MINUS_WEIGHTING = 1.0f - WEIGHTING;
-    int numSamples { 0 };
-    T average;
+    size_t _samples { 0 };
+    T _average;
     mutable std::mutex _lock;
 };
 


### PR DESCRIPTION
- fixes a rollover bug in deadlock detection, which was causing false positives
- bump the deadlock to 30 seconds
- update the heartbeat in paintGL() and idle() as well as on the timer
- add some logging so we can see how often heatbeats happen on slow machines
- removed the heartbeat timer, and instead sets the heartbeat from Application::idle() and Application::paintGL()
- also make a new version of `MovingAverage` template that is thread safe.