### PR TITLE
Avatar: fix for Avatar animation updates while wearing HMD

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -187,7 +187,7 @@ void Avatar::simulate(float deltaTime) {
 
     // simple frustum check
     float boundingRadius = getBoundingRadius();
-    bool inView = qApp->getViewFrustum()->sphereIntersectsFrustum(getPosition(), boundingRadius);
+    bool inView = qApp->getDisplayViewFrustum()->sphereIntersectsFrustum(getPosition(), boundingRadius);
 
     if (_shouldAnimate && !_shouldSkipRender && inView) {
         {


### PR DESCRIPTION
The boundingSphere vs frustum check now uses the displayViewFrustum, which
more accurately reflects the actual projection matrix used for rendering.