### PR TITLE
Guard against lack of GL support to avoid crash

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -144,9 +144,19 @@ int main(int argc, const char* argv[]) {
         Application app(argc, const_cast<char**>(argv), startupTime);
 
         // If we failed the OpenGLVersion check, log it.
-        // This needed to wait until the Application ctor for credentials.
         if (override) {
-            UserActivityLogger::getInstance().insufficientGLVersion(glVersion);
+            auto& accountManager = AccountManager::getInstance();
+            if (accountManager.isLoggedIn()) {
+                UserActivityLogger::getInstance().insufficientGLVersion(glVersion);
+            } else {
+                QObject::connect(&AccountManager::getInstance(), &AccountManager::loginComplete, [glVersion](){
+                    static bool loggedInsufficientGL = false;
+                    if (!loggedInsufficientGL) {
+                        UserActivityLogger::getInstance().insufficientGLVersion(glVersion);
+                        loggedInsufficientGL = true;
+                    }
+                });
+            }
         }
 
         // Setup local server

--- a/libraries/gl/src/gl/GLWidget.cpp
+++ b/libraries/gl/src/gl/GLWidget.cpp
@@ -50,7 +50,9 @@ void GLWidget::initializeGL() {
     // TODO: write the proper code for linux
     makeCurrent();
 #if defined(Q_OS_WIN)
-    _vsyncSupported = context()->contextHandle()->hasExtension("WGL_EXT_swap_control");;
+    if (isValid() && context() && context()->contextHandle()) {
+        _vsyncSupported = context()->contextHandle()->hasExtension("WGL_EXT_swap_control");;
+    }
 #endif
 }
 

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -22,8 +22,9 @@ OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
 {
 }
 
-bool OpenGLVersionChecker::isValidVersion() {
-    bool valid = true;
+QString OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
+    valid = true;
+    override = false;
 
     GLWidget* glWidget = new GLWidget();
     valid = glWidget->isValid();
@@ -37,7 +38,7 @@ bool OpenGLVersionChecker::isValidVersion() {
         messageBox.setStandardButtons(QMessageBox::Ok);
         messageBox.setDefaultButton(QMessageBox::Ok);
         messageBox.exec();
-        return false;
+        return QString();
     }
     
     // Retrieve OpenGL version
@@ -68,8 +69,8 @@ bool OpenGLVersionChecker::isValidVersion() {
         messageBox.setInformativeText("Press OK to exit; Ignore to continue.");
         messageBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Ignore);
         messageBox.setDefaultButton(QMessageBox::Ok);
-        valid = messageBox.exec() == QMessageBox::Ignore;
+        override = messageBox.exec() == QMessageBox::Ignore;
     }
 
-    return valid;
+    return glVersion;
 }

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -25,8 +25,22 @@ OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
 bool OpenGLVersionChecker::isValidVersion() {
     bool valid = true;
 
-    // Retrieve OpenGL version
     GLWidget* glWidget = new GLWidget();
+    valid = glWidget->isValid();
+    // Inform user if no OpenGL support
+    if (!valid) {
+        QMessageBox messageBox;
+        messageBox.setWindowTitle("Missing OpenGL Support");
+        messageBox.setIcon(QMessageBox::Warning);
+        messageBox.setText(QString().sprintf("Your system does not support OpenGL, Interface cannot run."));
+        messageBox.setInformativeText("Press OK to exit.");
+        messageBox.setStandardButtons(QMessageBox::Ok);
+        messageBox.setDefaultButton(QMessageBox::Ok);
+        messageBox.exec();
+        return false;
+    }
+    
+    // Retrieve OpenGL version
     glWidget->initializeGL();
     QString glVersion = QString((const char*)glGetString(GL_VERSION));
     delete glWidget;

--- a/libraries/gl/src/gl/OpenGLVersionChecker.h
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.h
@@ -19,7 +19,7 @@ class OpenGLVersionChecker : public QApplication {
 public:
     OpenGLVersionChecker(int& argc, char** argv);
 
-    static bool isValidVersion();
+    static QString checkVersion(bool& valid, bool& override);
 };
 
 #endif // hifi_OpenGLVersionChecker_h

--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -91,6 +91,15 @@ void UserActivityLogger::launch(QString applicationVersion, bool previousSession
     logAction(ACTION_NAME, actionDetails);
 }
 
+void UserActivityLogger::insufficientGLVersion(QString glVersion) {
+    const QString ACTION_NAME = "insufficient_gl";
+    QJsonObject actionDetails;
+    QString GL_VERSION = "glVersion";
+    actionDetails.insert(GL_VERSION, glVersion);
+
+    logAction(ACTION_NAME, actionDetails);
+}
+
 void UserActivityLogger::changedDisplayName(QString displayName) {
     const QString ACTION_NAME = "changed_display_name";
     QJsonObject actionDetails;

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -30,6 +30,8 @@ public slots:
     void logAction(QString action, QJsonObject details = QJsonObject(), JSONCallbackParameters params = JSONCallbackParameters());
     
     void launch(QString applicationVersion, bool previousSessionCrashed, int previousSessionRuntime);
+
+    void insufficientGLVersion(QString glVersion);
     
     void changedDisplayName(QString displayName);
     void changedModel(QString typeOfModel, QString modelURL);


### PR DESCRIPTION
- Inform user if there is no GL support, and quit.
- Triple-check context before checking for vsync.

Removes `makeCurrent()` from `initializeGL()`, [as it is done by Qt before calling the virtual method](http://doc.qt.io/qt-5/qglwidget.html#initializeGL).