### PR TITLE
Drop resource data after load

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -423,12 +423,12 @@ void Resource::handleReplyFinished() {
     
     auto result = _request->getResult();
     if (result == ResourceRequest::Success) {
-        _data = _request->getData();
         auto extraInfo = _url == _activeUrl ? "" : QString(", %1").arg(_activeUrl.toDisplayString());
         qCDebug(networking).noquote() << QString("Request finished for %1%2").arg(_url.toDisplayString(), extraInfo);
         
-        emit loaded(_data);
-        downloadFinished(_data);
+        auto data = _request->getData();
+        emit loaded(data);
+        downloadFinished(data);
     } else {
         switch (result) {
             case ResourceRequest::Result::Timeout: {

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -194,7 +194,6 @@ public:
     Q_INVOKABLE void allReferencesCleared();
     
     const QUrl& getURL() const { return _url; }
-    const QByteArray& getData() const { return _data; }
 
 signals:
     /// Fired when the resource has been downloaded.
@@ -235,7 +234,6 @@ protected:
     QHash<QPointer<QObject>, float> _loadPriorities;
     QWeakPointer<Resource> _self;
     QPointer<ResourceCache> _cache;
-    QByteArray _data;
     
 private slots:
     void handleDownloadProgress(uint64_t bytesReceived, uint64_t bytesTotal);


### PR DESCRIPTION
Currently, everything using a subclass of `ResourceCache` holds onto the network data with the processed `Resource`.

This removes that `_data` member, which was never used, to reduce memory consumption.