### PR TITLE
Avatar: Eye-tracking works again

### DIFF
--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -231,6 +231,13 @@ void Head::simulate(float deltaTime, bool isMine, bool billboard) {
     
     _leftEyePosition = _rightEyePosition = getPosition();
     _eyePosition = calculateAverageEyePosition();
+
+    if (!billboard && _owningAvatar) {
+        auto skeletonModel = static_cast<Avatar*>(_owningAvatar)->getSkeletonModel();
+        if (skeletonModel) {
+            skeletonModel->getEyePositions(_leftEyePosition, _rightEyePosition);
+        }
+    }
 }
 
 void Head::calculateMouthShapes() {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -897,7 +897,9 @@ void MyAvatar::updateLookAtTargetAvatar() {
                     // Scale by proportional differences between avatar and human.
                     float humanEyeSeparationInModelSpace = glm::length(humanLeftEye - humanRightEye) * ipdScale;
                     float avatarEyeSeparation = glm::length(avatarLeftEye - avatarRightEye);
-                    gazeOffset = gazeOffset * humanEyeSeparationInModelSpace / avatarEyeSeparation;
+                    if (avatarEyeSeparation > 0.0f) {
+                        gazeOffset = gazeOffset * humanEyeSeparationInModelSpace / avatarEyeSeparation;
+                    }
                 }
 
                 // And now we can finally add that offset to the camera.


### PR DESCRIPTION
This replaces the calculation of the Head left and right eye positions used for eye tracking.
Which was inadvertently removed in this commit 7483b8546b8e5003f87ea814a90fce144edafad9

Also, prevent division by zero, which can cause the gazeOffset to be Inf.