### PR TITLE
Drop network data after processing

### DIFF
--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -611,7 +611,7 @@ AnimNode::Pointer AnimNodeLoader::load(const QByteArray& contents, const QUrl& j
     return loadNode(rootVal.toObject(), jsonUrl);
 }
 
-void AnimNodeLoader::onRequestDone(const QByteArray& data) {
+void AnimNodeLoader::onRequestDone(const QByteArray data) {
     auto node = load(data, _url);
     if (node) {
         emit success(node);

--- a/libraries/animation/src/AnimNodeLoader.h
+++ b/libraries/animation/src/AnimNodeLoader.h
@@ -36,7 +36,7 @@ protected:
     static AnimNode::Pointer load(const QByteArray& contents, const QUrl& jsonUrl);
 
 protected slots:
-    void onRequestDone(const QByteArray& data);
+    void onRequestDone(const QByteArray data);
     void onRequestError(QNetworkReply::NetworkError error);
 
 protected:

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -293,7 +293,7 @@ void NetworkGeometry::requestModel(const QUrl& url) {
     connect(_resource, &Resource::failed, this, &NetworkGeometry::modelRequestError);
 }
 
-void NetworkGeometry::mappingRequestDone(const QByteArray& data) {
+void NetworkGeometry::mappingRequestDone(const QByteArray data) {
     assert(_state == RequestMappingState);
 
     // parse the mapping file
@@ -325,7 +325,7 @@ void NetworkGeometry::mappingRequestError(QNetworkReply::NetworkError error) {
     emit onFailure(*this, MappingRequestError);
 }
 
-void NetworkGeometry::modelRequestDone(const QByteArray& data) {
+void NetworkGeometry::modelRequestDone(const QByteArray data) {
     assert(_state == RequestModelState);
 
     _state = ParsingModelState;

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -113,10 +113,10 @@ public slots:
     void textureLoaded(const QWeakPointer<NetworkTexture>& networkTexture);
 
 protected slots:
-    void mappingRequestDone(const QByteArray& data);
+    void mappingRequestDone(const QByteArray data);
     void mappingRequestError(QNetworkReply::NetworkError error);
 
-    void modelRequestDone(const QByteArray& data);
+    void modelRequestDone(const QByteArray data);
     void modelRequestError(QNetworkReply::NetworkError error);
 
     void modelParseSuccess(FBXGeometry* geometry);

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -423,12 +423,12 @@ void Resource::handleReplyFinished() {
     
     auto result = _request->getResult();
     if (result == ResourceRequest::Success) {
-        _data = _request->getData();
         auto extraInfo = _url == _activeUrl ? "" : QString(", %1").arg(_activeUrl.toDisplayString());
         qCDebug(networking).noquote() << QString("Request finished for %1%2").arg(_url.toDisplayString(), extraInfo);
         
-        emit loaded(_data);
-        downloadFinished(_data);
+        auto data = _request->getData();
+        emit loaded(data);
+        downloadFinished(data);
     } else {
         switch (result) {
             case ResourceRequest::Result::Timeout: {

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -194,12 +194,11 @@ public:
     Q_INVOKABLE void allReferencesCleared();
     
     const QUrl& getURL() const { return _url; }
-    const QByteArray& getData() const { return _data; }
 
 signals:
     /// Fired when the resource has been downloaded.
     /// This can be used instead of downloadFinished to access data before it is processed.
-    void loaded(const QByteArray& request);
+    void loaded(const QByteArray request);
 
     /// Fired when the resource has finished loading.
     void finished(bool success);
@@ -235,7 +234,6 @@ protected:
     QHash<QPointer<QObject>, float> _loadPriorities;
     QWeakPointer<Resource> _self;
     QPointer<ResourceCache> _cache;
-    QByteArray _data;
     
 private slots:
     void handleDownloadProgress(uint64_t bytesReceived, uint64_t bytesTotal);


### PR DESCRIPTION
See #7467. It was reverted, as it passed a const-ref in a signal which then went out of scope.
This passes a const in the signal instead, so it is copied into the Qt signal/slot framework.