### PR TITLE
guard long sleeps in udt::SendQueue

### DIFF
--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -81,6 +81,8 @@ AccountManager::AccountManager() :
     
     qRegisterMetaType<QHttpMultiPart*>("QHttpMultiPart*");
 
+    qRegisterMetaType<AccountManagerAuth::Type>();
+
     connect(&_accountInfo, &DataServerAccountInfo::balanceChanged, this, &AccountManager::accountInfoBalanceChanged);
 }
 
@@ -215,7 +217,7 @@ void AccountManager::sendRequest(const QString& path,
     if (thread() != QThread::currentThread()) {
         QMetaObject::invokeMethod(this, "sendRequest",
                                   Q_ARG(const QString&, path),
-                                  Q_ARG(AccountManagerAuth::Type, AccountManagerAuth::Required),
+                                  Q_ARG(AccountManagerAuth::Type, authType),
                                   Q_ARG(QNetworkAccessManager::Operation, operation),
                                   Q_ARG(const JSONCallbackParameters&, callbackParams),
                                   Q_ARG(const QByteArray&, dataByteArray),

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -223,6 +223,7 @@ void AccountManager::sendRequest(const QString& path,
                                   Q_ARG(const QByteArray&, dataByteArray),
                                   Q_ARG(QHttpMultiPart*, dataMultiPart),
                                   Q_ARG(QVariantMap, propertyMap));
+        return;
     }
     
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();

--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -58,8 +58,6 @@ void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCall
     
     // if no callbacks specified, call our owns
     if (params.isEmpty()) {
-        params.jsonCallbackReceiver = this;
-        params.jsonCallbackMethod = "requestFinished";
         params.errorCallbackReceiver = this;
         params.errorCallbackMethod = "requestError";
     }
@@ -68,10 +66,6 @@ void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCall
                                AccountManagerAuth::Required,
                                QNetworkAccessManager::PostOperation,
                                params, NULL, multipart);
-}
-
-void UserActivityLogger::requestFinished(QNetworkReply& requestReply) {
-    // qCDebug(networking) << object;
 }
 
 void UserActivityLogger::requestError(QNetworkReply& errorReply) {

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -39,7 +39,6 @@ public slots:
     void wentTo(QString destinationType, QString destinationName);
     
 private slots:
-    void requestFinished(QNetworkReply& requestReply);
     void requestError(QNetworkReply& errorReply);
     
 private:

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -17,6 +17,7 @@
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDateTime>
+#include <QtCore/QJsonObject>
 #include <QtCore/QThread>
 
 #include <LogHandler.h>
@@ -27,6 +28,7 @@
 #include "ControlPacket.h"
 #include "Packet.h"
 #include "PacketList.h"
+#include "../UserActivityLogger.h"
 #include "Socket.h"
 
 using namespace udt;
@@ -328,7 +330,33 @@ void SendQueue::run() {
         nextPacketTimestamp += std::chrono::microseconds(nextPacketDelta);
 
         // sleep as long as we need until next packet send, if we can
-        const auto timeToSleep = duration_cast<microseconds>(nextPacketTimestamp - p_high_resolution_clock::now());
+        auto now = p_high_resolution_clock::now();
+        auto timeToSleep = duration_cast<microseconds>(nextPacketTimestamp - now);
+
+        // we're seeing SendQueues sleep for a long period of time here,
+        // which can lock the NodeList if it's attempting to clear connections
+        // for now we guard this by capping the time this thread and sleep for
+
+        const int MAX_SEND_QUEUE_SLEEP_USECS = 5000000;
+        if (timeToSleep.count() > MAX_SEND_QUEUE_SLEEP_USECS) {
+            // alright, we're in a weird state
+            // we want to know why this is happening so we can implement a better fix than this guard
+            // send some details up to the API (if the user allows us) that indicate how we could such a large timeToSleep
+            static const QString SEND_QUEUE_LONG_SLEEP_ACTION = "sendqueue-sleep";
+
+            // setup a json object with the details we want
+            QJsonObject longSleepObject;
+            longSleepObject["timeToSleep"] = timeToSleep.count();
+            longSleepObject["packetSendPeriod"] = _packetSendPeriod.load();
+            longSleepObject["nextPacketDelta"] = nextPacketDelta;
+            longSleepObject["nextPacketTimestamp"] = nextPacketTimestamp.time_since_epoch().count();
+            longSleepObject["then"] = now.time_since_epoch().count();
+
+            // hopefully send this event using the user activity logger
+            UserActivityLogger::getInstance().logAction(SEND_QUEUE_LONG_SLEEP_ACTION, longSleepObject);
+
+            timeToSleep = std::chrono::microseconds(MAX_SEND_QUEUE_SLEEP_USECS);
+        }
 
         std::this_thread::sleep_for(timeToSleep);
     }

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -337,8 +337,14 @@ void SendQueue::run() {
         // which can lock the NodeList if it's attempting to clear connections
         // for now we guard this by capping the time this thread and sleep for
 
-        const microseconds MAX_SEND_QUEUE_SLEEP_USECS { 5000000 };
+        const microseconds MAX_SEND_QUEUE_SLEEP_USECS { 2000000 };
         if (timeToSleep > MAX_SEND_QUEUE_SLEEP_USECS) {
+            qWarning() << "udt::SendQueue wanted to sleep for" << timeToSleep.count() << "microseconds";
+            qWarning() << "Capping sleep to" << MAX_SEND_QUEUE_SLEEP_USECS.count();
+            qWarning() << "PSP:" << _packetSendPeriod << "NPD:" << nextPacketDelta
+                << "NPT:" << nextPacketTimestamp.time_since_epoch().count()
+                << "NOW:" << now.time_since_epoch().count();
+
             // alright, we're in a weird state
             // we want to know why this is happening so we can implement a better fix than this guard
             // send some details up to the API (if the user allows us) that indicate how we could such a large timeToSleep

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -352,11 +352,11 @@ void SendQueue::run() {
 
             // setup a json object with the details we want
             QJsonObject longSleepObject;
-            longSleepObject["timeToSleep"] = int64_t(timeToSleep.count());
+            longSleepObject["timeToSleep"] = qint64(timeToSleep.count());
             longSleepObject["packetSendPeriod"] = _packetSendPeriod.load();
             longSleepObject["nextPacketDelta"] = nextPacketDelta;
-            longSleepObject["nextPacketTimestamp"] = int64_t(nextPacketTimestamp.time_since_epoch().count());
-            longSleepObject["then"] = int64_t(now.time_since_epoch().count());
+            longSleepObject["nextPacketTimestamp"] = qint64(nextPacketTimestamp.time_since_epoch().count());
+            longSleepObject["then"] = qint64(now.time_since_epoch().count());
 
             // hopefully send this event using the user activity logger
             UserActivityLogger::getInstance().logAction(SEND_QUEUE_LONG_SLEEP_ACTION, longSleepObject);

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -337,8 +337,8 @@ void SendQueue::run() {
         // which can lock the NodeList if it's attempting to clear connections
         // for now we guard this by capping the time this thread and sleep for
 
-        const int MAX_SEND_QUEUE_SLEEP_USECS = 5000000;
-        if (timeToSleep.count() > MAX_SEND_QUEUE_SLEEP_USECS) {
+        const microseconds MAX_SEND_QUEUE_SLEEP_USECS { 5000000 };
+        if (timeToSleep > MAX_SEND_QUEUE_SLEEP_USECS) {
             // alright, we're in a weird state
             // we want to know why this is happening so we can implement a better fix than this guard
             // send some details up to the API (if the user allows us) that indicate how we could such a large timeToSleep
@@ -355,7 +355,7 @@ void SendQueue::run() {
             // hopefully send this event using the user activity logger
             UserActivityLogger::getInstance().logAction(SEND_QUEUE_LONG_SLEEP_ACTION, longSleepObject);
 
-            timeToSleep = std::chrono::microseconds(MAX_SEND_QUEUE_SLEEP_USECS);
+            timeToSleep = MAX_SEND_QUEUE_SLEEP_USECS;
         }
 
         std::this_thread::sleep_for(timeToSleep);

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -346,11 +346,11 @@ void SendQueue::run() {
 
             // setup a json object with the details we want
             QJsonObject longSleepObject;
-            longSleepObject["timeToSleep"] = timeToSleep.count();
+            longSleepObject["timeToSleep"] = int64_t(timeToSleep.count());
             longSleepObject["packetSendPeriod"] = _packetSendPeriod.load();
             longSleepObject["nextPacketDelta"] = nextPacketDelta;
-            longSleepObject["nextPacketTimestamp"] = nextPacketTimestamp.time_since_epoch().count();
-            longSleepObject["then"] = now.time_since_epoch().count();
+            longSleepObject["nextPacketTimestamp"] = int64_t(nextPacketTimestamp.time_since_epoch().count());
+            longSleepObject["then"] = int64_t(now.time_since_epoch().count());
 
             // hopefully send this event using the user activity logger
             UserActivityLogger::getInstance().logAction(SEND_QUEUE_LONG_SLEEP_ACTION, longSleepObject);


### PR DESCRIPTION
- fixes an issue where the `udt::SendQueue` could be stuck sleeping for a long time, potentially deadlocking the NodeList when it was clearing connections
- fixes an unregistered datatype `AccountManagerAuth::Type`