### PR TITLE
Protect against deleted AssetRequest access

### DIFF
--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -202,6 +202,7 @@ AssetUpload* AssetClient::createUpload(const QByteArray& data) {
 
 bool AssetClient::getAsset(const QString& hash, DataOffset start, DataOffset end,
                            ReceivedAssetCallback callback, ProgressCallback progressCallback) {
+    Q_ASSERT(thread() == QThread::currentThread());
     if (hash.length() != SHA256_HASH_HEX_LENGTH) {
         qCWarning(asset_client) << "Invalid hash size";
         return false;
@@ -240,6 +241,7 @@ bool AssetClient::getAsset(const QString& hash, DataOffset start, DataOffset end
 }
 
 bool AssetClient::getAssetInfo(const QString& hash, GetInfoCallback callback) {
+    Q_ASSERT(thread() == QThread::currentThread());
     auto nodeList = DependencyManager::get<NodeList>();
     SharedNodePointer assetServer = nodeList->soloNodeOfType(NodeType::AssetServer);
 


### PR DESCRIPTION
A bugsplat dump showed a clear null pointer access in one of the AssetRequest callback methods.  it looks like progress message can sometimes be handled after a finished signal destroys the object.

This PR may be overzealous in terms of protection, as I'm not sure which callbacks can potentially be triggered after object deletion, but better to err on the side of caution, IMO.