### PR TITLE
Fix crash in Audio Client

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -598,8 +598,18 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     audioThread->setObjectName("Audio Thread");
 
     auto audioIO = DependencyManager::get<AudioClient>();
-    audioIO->setPositionGetter([this]{ return getMyAvatar()->getPositionForAudio(); });
-    audioIO->setOrientationGetter([this]{ return getMyAvatar()->getOrientationForAudio(); });
+    audioIO->setPositionGetter([]{
+        auto audioIO = DependencyManager::get<AvatarManager>();
+        auto myAvatar = audioIO ? audioIO->getMyAvatar() : nullptr;
+        
+        return myAvatar ? myAvatar->getPositionForAudio() : Vectors::ZERO;
+    });
+    audioIO->setOrientationGetter([]{
+        auto audioIO = DependencyManager::get<AvatarManager>();
+        auto myAvatar = audioIO ? audioIO->getMyAvatar() : nullptr;
+
+        return myAvatar ? myAvatar->getOrientationForAudio() : Quaternions::IDENTITY;
+    });
 
     audioIO->moveToThread(audioThread);
     recording::Frame::registerFrameHandler(AudioConstants::getAudioFrameName(), [=](recording::Frame::ConstPointer frame) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -599,14 +599,14 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
 
     auto audioIO = DependencyManager::get<AudioClient>();
     audioIO->setPositionGetter([]{
-        auto audioIO = DependencyManager::get<AvatarManager>();
-        auto myAvatar = audioIO ? audioIO->getMyAvatar() : nullptr;
+        auto avatarManager = DependencyManager::get<AvatarManager>();
+        auto myAvatar = avatarManager ? avatarManager->getMyAvatar() : nullptr;
         
         return myAvatar ? myAvatar->getPositionForAudio() : Vectors::ZERO;
     });
     audioIO->setOrientationGetter([]{
-        auto audioIO = DependencyManager::get<AvatarManager>();
-        auto myAvatar = audioIO ? audioIO->getMyAvatar() : nullptr;
+        auto avatarManager = DependencyManager::get<AvatarManager>();
+        auto myAvatar = avatarManager ? avatarManager->getMyAvatar() : nullptr;
 
         return myAvatar ? myAvatar->getOrientationForAudio() : Quaternions::IDENTITY;
     });

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -50,6 +50,9 @@
 
 static const int RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES = 100;
 
+static const auto DEFAULT_POSITION_GETTER = []{ return Vectors::ZERO; };
+static const auto DEFAULT_ORIENTATION_GETTER = [] { return Quaternions::IDENTITY; };
+
 Setting::Handle<bool> dynamicJitterBuffers("dynamicJitterBuffers", DEFAULT_DYNAMIC_JITTER_BUFFERS);
 Setting::Handle<int> maxFramesOverDesired("maxFramesOverDesired", DEFAULT_MAX_FRAMES_OVER_DESIRED);
 Setting::Handle<int> staticDesiredJitterBufferFrames("staticDesiredJitterBufferFrames",
@@ -103,7 +106,9 @@ AudioClient::AudioClient() :
     _outgoingAvatarAudioSequenceNumber(0),
     _audioOutputIODevice(_receivedAudioStream, this),
     _stats(&_receivedAudioStream),
-    _inputGate()
+    _inputGate(),
+    _positionGetter(DEFAULT_POSITION_GETTER),
+    _orientationGetter(DEFAULT_ORIENTATION_GETTER)
 {
     // clear the array of locally injected samples
     memset(_localProceduralSamples, 0, AudioConstants::NETWORK_FRAME_BYTES_PER_CHANNEL);


### PR DESCRIPTION
Make sure the position and orientation getter lambdas are initialized and won't try to access a null pointer