### PR TITLE
Respond to error from free in texture parsing

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -124,7 +124,9 @@ QVariantMap RenderableModelEntityItem::parseTexturesToMap(QString textures) {
         qCWarning(entitiesrenderer) << "Could not evaluate textures property value:" << _textures;
         return _originalTextures;
     }
-    return texturesJson.object().toVariantMap();
+
+    auto parsed = texturesJson.toVariant();
+    return parsed.toMap();
 }
 
 void RenderableModelEntityItem::remapTextures() {

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -109,7 +109,7 @@ int RenderableModelEntityItem::readEntitySubclassDataFromBuffer(const unsigned c
 
 QVariantMap RenderableModelEntityItem::parseTexturesToMap(QString textures) {
     // If textures are unset, revert to original textures
-    if (textures == "") {
+    if (textures.isEmpty()) {
         return _originalTextures;
     }
 


### PR DESCRIPTION
This PR is in response to a crash that has not been recorded, but only observed in Debug mode in VS13.

It holds Utf8 on the stack as a QByteArray to avoid the free that would come with its going out of scope, as parsing textures was observed to crash on a call to free around that call. The assumption behind this PR is that converting the QJsonDocument to a QJsonObject to a QVariantMap results in heap use-after-free. Instead, this converts the QJsonDocument to a QVariant, and then returns that QVariant as a QVariantMap.

It also correctly tests the textures for emptiness.