### PR TITLE
lock entity-tree before moving entity-children of avatars

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -373,32 +373,34 @@ void MyAvatar::simulate(float deltaTime) {
     EntityTreeRenderer* entityTreeRenderer = qApp->getEntities();
     EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
     if (entityTree) {
-        auto now = usecTimestampNow();
-        EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
-        MovingEntitiesOperator moveOperator(entityTree);
-        forEachDescendant([&](SpatiallyNestablePointer object) {
-            // if the queryBox has changed, tell the entity-server
-            if (object->computePuffedQueryAACube() && object->getNestableType() == NestableType::Entity) {
-                EntityItemPointer entity = std::static_pointer_cast<EntityItem>(object);
-                bool success;
-                AACube newCube = entity->getQueryAACube(success);
-                if (success) {
-                    moveOperator.addEntityToMoveList(entity, newCube);
-                }
-                if (packetSender) {
-                    EntityItemProperties properties = entity->getProperties();
-                    properties.setQueryAACubeDirty();
-                    properties.setLastEdited(now);
-                    packetSender->queueEditEntityMessage(PacketType::EntityEdit, entity->getID(), properties);
-                    entity->setLastBroadcast(usecTimestampNow());
-                }
+        entityTree->withWriteLock([&] {
+            auto now = usecTimestampNow();
+            EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
+            MovingEntitiesOperator moveOperator(entityTree);
+            forEachDescendant([&](SpatiallyNestablePointer object) {
+                    // if the queryBox has changed, tell the entity-server
+                    if (object->computePuffedQueryAACube() && object->getNestableType() == NestableType::Entity) {
+                        EntityItemPointer entity = std::static_pointer_cast<EntityItem>(object);
+                        bool success;
+                        AACube newCube = entity->getQueryAACube(success);
+                        if (success) {
+                            moveOperator.addEntityToMoveList(entity, newCube);
+                        }
+                        if (packetSender) {
+                            EntityItemProperties properties = entity->getProperties();
+                            properties.setQueryAACubeDirty();
+                            properties.setLastEdited(now);
+                            packetSender->queueEditEntityMessage(PacketType::EntityEdit, entity->getID(), properties);
+                            entity->setLastBroadcast(usecTimestampNow());
+                        }
+                    }
+                });
+            // also update the position of children in our local octree
+            if (moveOperator.hasMovingEntities()) {
+                PerformanceTimer perfTimer("recurseTreeWithOperator");
+                entityTree->recurseTreeWithOperator(&moveOperator);
             }
         });
-        // also update the position of children in our local octree
-        if (moveOperator.hasMovingEntities()) {
-            PerformanceTimer perfTimer("recurseTreeWithOperator");
-            entityTree->recurseTreeWithOperator(&moveOperator);
-        }
     }
 }
 


### PR DESCRIPTION
- possible fix for a crash while holding a non-physical entity
