### PR TITLE
Fix ordering of GL backend state reset commands to Field key

### DIFF
--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -158,7 +158,6 @@ public:
         ~GLState();
 
         // The state commands to reset to default,
-        // WARNING depending on the order of the State::Field enum
         static const Commands _resetStateCommands;
 
         friend class GLBackend;

--- a/libraries/gpu/src/gpu/GLBackendState.cpp
+++ b/libraries/gpu/src/gpu/GLBackendState.cpp
@@ -35,6 +35,7 @@ const GLBackend::GLState::Commands makeResetStateCommands();
 const GLBackend::GLState::Commands GLBackend::GLState::_resetStateCommands = makeResetStateCommands();
 
 
+// NOTE: This must stay in sync with the ordering of the State::Field enum
 const GLBackend::GLState::Commands makeResetStateCommands() {
     // Since State::DEFAULT is a static defined in another .cpp the initialisation order is random
     // and we have a 50/50 chance that State::DEFAULT is not yet initialized.
@@ -69,9 +70,9 @@ const GLBackend::GLState::Commands makeResetStateCommands() {
         CommandPointer(stencilCommand),
         CommandPointer(stencilCommand),
         
-        std::make_shared<Command1B>(&GLBackend::do_setStateAlphaToCoverageEnable, DEFAULT.alphaToCoverageEnable),
-        
         std::make_shared<Command1U>(&GLBackend::do_setStateSampleMask, DEFAULT.sampleMask),
+
+        std::make_shared<Command1B>(&GLBackend::do_setStateAlphaToCoverageEnable, DEFAULT.alphaToCoverageEnable),
         
         std::make_shared<CommandBlend>(&GLBackend::do_setStateBlend, DEFAULT.blendFunction),
         

--- a/libraries/gpu/src/gpu/State.h
+++ b/libraries/gpu/src/gpu/State.h
@@ -345,6 +345,7 @@ public:
     uint8 getColorWriteMask() const { return _values.colorWriteMask; }
 
     // All the possible fields
+    // NOTE: If you change this, you must update GLBackend::GLState::_resetStateCommands
     enum Field {
         FILL_MODE,
         CULL_MODE,
@@ -364,6 +365,7 @@ public:
         STENCIL_TEST_BACK,
 
         SAMPLE_MASK,
+
         ALPHA_TO_COVERAGE_ENABLE,
 
         BLEND_FUNCTION,


### PR DESCRIPTION
Discovered while investigating crashes for GLBackend::resetPipelineState, although I do not think it is related.
This fixes the backends pipeline reset functors to be in sync with the fields that they reset.