### PR TITLE
fix "deadlock" when setting clock backwards

### DIFF
--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -561,6 +561,12 @@ bool ParticleEffectEntityItem::needsToCallUpdate() const {
 
 void ParticleEffectEntityItem::update(const quint64& now) {
 
+    // we check for 'now' in the past in case users set their clock backward
+    if (now < _lastSimulated) {
+        _lastSimulated = now;
+        return;
+    }
+
     float deltaTime = (float)(now - _lastSimulated) / (float)USECS_PER_SECOND;
     _lastSimulated = now;
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -673,11 +673,14 @@ void ScriptEngine::run() {
         }
 
         qint64 now = usecTimestampNow();
-        float deltaTime = (float) (now - lastUpdate) / (float) USECS_PER_SECOND;
 
-        if (!_isFinished) {
-            if (_wantSignals) {
-                emit update(deltaTime);
+        // we check for 'now' in the past in case people set their clock back
+        if (lastUpdate < now) {
+            float deltaTime = (float) (now - lastUpdate) / (float) USECS_PER_SECOND;
+            if (!_isFinished) {
+                if (_wantSignals) {
+                    emit update(deltaTime);
+                }
             }
         }
         lastUpdate = now;


### PR DESCRIPTION
- fixed a bug whereby setting the system clock backwards would lock up the interface