### PR TITLE
Add GL checks

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendState.cpp
+++ b/libraries/gpu/src/gpu/GLBackendState.cpp
@@ -609,6 +609,8 @@ void GLBackend::do_setStateDepthBias(Vec2 bias) {
             glDisable(GL_POLYGON_OFFSET_LINE);
             glDisable(GL_POLYGON_OFFSET_POINT);
         }
+        (void) CHECK_GL_ERROR();
+
          _pipeline._stateCache.depthBias = bias.x;
          _pipeline._stateCache.depthBiasSlopeScale = bias.y;
     }
@@ -689,6 +691,7 @@ void GLBackend::do_setStateAlphaToCoverageEnable(bool enable) {
             glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
         }
         (void) CHECK_GL_ERROR();
+
         _pipeline._stateCache.alphaToCoverageEnable = enable;
     }
 }
@@ -702,6 +705,7 @@ void GLBackend::do_setStateSampleMask(uint32 mask) {
             glEnable(GL_SAMPLE_MASK);
             glSampleMaski(0, mask);
         }
+        (void) CHECK_GL_ERROR();
 #endif
         _pipeline._stateCache.sampleMask = mask;
     }
@@ -742,10 +746,10 @@ void GLBackend::do_setStateBlend(State::BlendFunction function) {
 
             glBlendFuncSeparate(BLEND_ARGS[function.getSourceColor()], BLEND_ARGS[function.getDestinationColor()],
                                 BLEND_ARGS[function.getSourceAlpha()], BLEND_ARGS[function.getDestinationAlpha()]);
-            (void) CHECK_GL_ERROR();
         } else {
             glDisable(GL_BLEND);
         }
+        (void) CHECK_GL_ERROR();
 
         _pipeline._stateCache.blendFunction = function;
     }
@@ -757,6 +761,7 @@ void GLBackend::do_setStateColorWriteMask(uint32 mask) {
                 mask & State::ColorMask::WRITE_GREEN,
                 mask & State::ColorMask::WRITE_BLUE,
                 mask & State::ColorMask::WRITE_ALPHA );
+        (void) CHECK_GL_ERROR();
 
         _pipeline._stateCache.colorWriteMask = mask;
     }
@@ -764,7 +769,6 @@ void GLBackend::do_setStateColorWriteMask(uint32 mask) {
 
 
 void GLBackend::do_setStateBlendFactor(Batch& batch, size_t paramOffset) {
-    
     Vec4 factor(batch._params[paramOffset + 0]._float,
                 batch._params[paramOffset + 1]._float,
                 batch._params[paramOffset + 2]._float,


### PR DESCRIPTION
Not all GL commands have associated checks for validity afterwards.
This adds those checks to commands in the GL backend.