### PR TITLE
Correctly represent lighting framebuffer

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -225,6 +225,12 @@ public:
                     }
                     break;
 
+                case gpu::R11G11B10:
+                    texel.format = GL_RGB;
+                    // the type should be float
+                    texel.internalFormat = GL_R11F_G11F_B10F;
+                    break;
+
                 case gpu::DEPTH:
                     texel.format = GL_DEPTH_COMPONENT; // It's depth component to load it
                     texel.internalFormat = GL_DEPTH_COMPONENT;
@@ -302,11 +308,6 @@ public:
                 case gpu::SRGBA:
                     texel.internalFormat = GL_SRGB; // standard 2.2 gamma correction color
                     break;
-                case gpu::R11G11B10: {
-                    // the type should be float
-                    texel.internalFormat = GL_R11F_G11F_B10F;
-                    break;
-                }
                 default:
                     qCDebug(gpulogging) << "Unknown combination of texel format";
                 }

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -285,7 +285,7 @@ Texture::Size Texture::resize(Type type, const Element& texelFormat, uint16 widt
         }
 
         // Here the Texture has been fully defined from the gpu point of view (size and format)
-         _defined = true;
+        _defined = true;
     } else {
          _stamp++;
     }

--- a/libraries/render-utils/src/FramebufferCache.cpp
+++ b/libraries/render-utils/src/FramebufferCache.cpp
@@ -97,7 +97,7 @@ void FramebufferCache::createPrimaryFramebuffer() {
 
     // FIXME: Decide on the proper one, let s stick to R11G11B10 for now
     //_lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, width, height, defaultSampler));
-    _lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC3, gpu::NUINT8, gpu::R11G11B10), width, height, defaultSampler));
+    _lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::R11G11B10), width, height, defaultSampler));
     //_lightingTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element(gpu::VEC4, gpu::HALF, gpu::RGBA), width, height, defaultSampler));
     _lightingFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create());
     _lightingFramebuffer->setRenderBuffer(0, _lightingTexture);


### PR DESCRIPTION
The lighting framebuffer's size is calculated internally by GL, but our external assumptions (used for tracking memory consumption) currently assume 24 bits, when it should be 32.
This fixes that representation.