### PR TITLE
use NetworkAccessManager in IceServer for single QNAM instance

### DIFF
--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -19,6 +19,7 @@
 #include <QtNetwork/QNetworkRequest>
 
 #include <LimitedNodeList.h>
+#include <NetworkAccessManager.h>
 #include <NetworkingConstants.h>
 #include <udt/PacketHeaders.h>
 #include <SharedUtil.h>
@@ -33,8 +34,7 @@ IceServer::IceServer(int argc, char* argv[]) :
     _id(QUuid::createUuid()),
     _serverSocket(),
     _activePeers(),
-    _httpManager(QHostAddress::AnyIPv4, ICE_SERVER_MONITORING_PORT, QString("%1/web/").arg(QCoreApplication::applicationDirPath()), this),
-    _networkAccessManager(this)
+    _httpManager(QHostAddress::AnyIPv4, ICE_SERVER_MONITORING_PORT, QString("%1/web/").arg(QCoreApplication::applicationDirPath()), this)
 {
     // start the ice-server socket
     qDebug() << "ice-server socket is listening on" << ICE_SERVER_DEFAULT_PORT;
@@ -202,8 +202,8 @@ bool IceServer::isVerifiedHeartbeat(const QUuid& domainID, const QByteArray& pla
 
 void IceServer::requestDomainPublicKey(const QUuid& domainID) {
     // send a request to the metaverse API for the public key for this domain
-    
-    connect(&_networkAccessManager, &QNetworkAccessManager::finished, this, &IceServer::publicKeyReplyFinished);
+    auto& networkAccessManager = NetworkAccessManager::getInstance();
+    connect(&networkAccessManager, &QNetworkAccessManager::finished, this, &IceServer::publicKeyReplyFinished);
 
     QUrl publicKeyURL { NetworkingConstants::METAVERSE_SERVER_URL };
     QString publicKeyPath = QString("/api/v1/domains/%1/public_key").arg(uuidStringWithoutCurlyBraces(domainID));
@@ -214,7 +214,7 @@ void IceServer::requestDomainPublicKey(const QUuid& domainID) {
 
     qDebug() << "Requesting public key for domain with ID" << domainID;
 
-    _networkAccessManager.get(publicKeyRequest);
+    networkAccessManager.get(publicKeyRequest);
 }
 
 void IceServer::publicKeyReplyFinished(QNetworkReply* reply) {

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -313,7 +313,10 @@ bool IceServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url, b
                                 ? 1 : 0;
 
             connection->respond(HTTPConnection::StatusCode200, QByteArray::number(statusNumber));
+
+            return true;
         }
     }
-    return true;
+
+    return false;
 }

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -33,7 +33,8 @@ IceServer::IceServer(int argc, char* argv[]) :
     _id(QUuid::createUuid()),
     _serverSocket(),
     _activePeers(),
-    _httpManager(QHostAddress::AnyIPv4, ICE_SERVER_MONITORING_PORT, QString("%1/web/").arg(QCoreApplication::applicationDirPath()), this)
+    _httpManager(QHostAddress::AnyIPv4, ICE_SERVER_MONITORING_PORT, QString("%1/web/").arg(QCoreApplication::applicationDirPath()), this),
+    _networkAccessManager(this)
 {
     // start the ice-server socket
     qDebug() << "ice-server socket is listening on" << ICE_SERVER_DEFAULT_PORT;
@@ -201,8 +202,8 @@ bool IceServer::isVerifiedHeartbeat(const QUuid& domainID, const QByteArray& pla
 
 void IceServer::requestDomainPublicKey(const QUuid& domainID) {
     // send a request to the metaverse API for the public key for this domain
-    QNetworkAccessManager* manager = new QNetworkAccessManager { this };
-    connect(manager, &QNetworkAccessManager::finished, this, &IceServer::publicKeyReplyFinished);
+    
+    connect(&_networkAccessManager, &QNetworkAccessManager::finished, this, &IceServer::publicKeyReplyFinished);
 
     QUrl publicKeyURL { NetworkingConstants::METAVERSE_SERVER_URL };
     QString publicKeyPath = QString("/api/v1/domains/%1/public_key").arg(uuidStringWithoutCurlyBraces(domainID));
@@ -213,7 +214,7 @@ void IceServer::requestDomainPublicKey(const QUuid& domainID) {
 
     qDebug() << "Requesting public key for domain with ID" << domainID;
 
-    manager->get(publicKeyRequest);
+    _networkAccessManager.get(publicKeyRequest);
 }
 
 void IceServer::publicKeyReplyFinished(QNetworkReply* reply) {

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -35,7 +35,7 @@ IceServer::IceServer(int argc, char* argv[]) :
     _serverSocket(),
     _activePeers(),
     _httpManager(QHostAddress::AnyIPv4, ICE_SERVER_MONITORING_PORT, QString("%1/web/").arg(QCoreApplication::applicationDirPath()), this),
-	_lastInactiveCheckTimestamp(QDateTime::currentMSecsSinceEpoch())
+    _lastInactiveCheckTimestamp(QDateTime::currentMSecsSinceEpoch())
 {
     // start the ice-server socket
     qDebug() << "ice-server socket is listening on" << ICE_SERVER_DEFAULT_PORT;

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -34,7 +34,8 @@ IceServer::IceServer(int argc, char* argv[]) :
     _id(QUuid::createUuid()),
     _serverSocket(),
     _activePeers(),
-    _httpManager(QHostAddress::AnyIPv4, ICE_SERVER_MONITORING_PORT, QString("%1/web/").arg(QCoreApplication::applicationDirPath()), this)
+    _httpManager(QHostAddress::AnyIPv4, ICE_SERVER_MONITORING_PORT, QString("%1/web/").arg(QCoreApplication::applicationDirPath()), this),
+	_lastInactiveCheckTimestamp(QDateTime::currentMSecsSinceEpoch())
 {
     // start the ice-server socket
     qDebug() << "ice-server socket is listening on" << ICE_SERVER_DEFAULT_PORT;

--- a/ice-server/src/IceServer.h
+++ b/ice-server/src/IceServer.h
@@ -58,7 +58,7 @@ private:
     using DomainPublicKeyHash = std::unordered_map<QUuid, RSAUniquePtr>;
     DomainPublicKeyHash _domainPublicKeys;
 
-    quint64 _lastPacketTimestamp;
+    quint64 _lastInactiveCheckTimestamp;
 };
 
 #endif // hifi_IceServer_h

--- a/ice-server/src/IceServer.h
+++ b/ice-server/src/IceServer.h
@@ -54,6 +54,8 @@ private:
 
     HTTPManager _httpManager;
 
+    QNetworkAccessManager _networkAccessManager;
+
     using RSAUniquePtr = std::unique_ptr<RSA, std::function<void(RSA*)>>;
     using DomainPublicKeyHash = std::unordered_map<QUuid, RSAUniquePtr>;
     DomainPublicKeyHash _domainPublicKeys;

--- a/ice-server/src/IceServer.h
+++ b/ice-server/src/IceServer.h
@@ -54,8 +54,6 @@ private:
 
     HTTPManager _httpManager;
 
-    QNetworkAccessManager _networkAccessManager;
-
     using RSAUniquePtr = std::unique_ptr<RSA, std::function<void(RSA*)>>;
     using DomainPublicKeyHash = std::unordered_map<QUuid, RSAUniquePtr>;
     DomainPublicKeyHash _domainPublicKeys;


### PR DESCRIPTION
- fixes an issue with IceServer open file handles due to many QNetworkAccessManager instances