### PR TITLE
Add lock on model texs

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -143,11 +143,17 @@ void RenderableModelEntityItem::remapTextures() {
         _currentTextures = _originalTextures;
     }
 
-    auto textures = parseTexturesToMap(getTextures());
+    auto textures = getTextures();
+    if (textures == _lastTextures) {
+        return;
+    }
 
-    if (textures != _currentTextures) {
-        geometry->setTextures(textures);
-        _currentTextures = textures;
+    _lastTextures = textures;
+    auto newTextures = parseTexturesToMap(textures);
+
+    if (newTextures != _currentTextures) {
+        geometry->setTextures(newTextures);
+        _currentTextures = newTextures;
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -117,12 +117,11 @@ QVariantMap RenderableModelEntityItem::parseTexturesToMap(QString textures) {
     QJsonParseError error;
     QJsonDocument texturesJson = QJsonDocument::fromJson(textures.toUtf8(), &error);
     if (error.error != QJsonParseError::NoError) {
-        qCWarning(entitiesrenderer) << "Could not evaluate textures property value:" << _textures;
+        qCWarning(entitiesrenderer) << "Could not evaluate textures property value:" << textures;
         return _originalTextures;
     }
 
-    auto parsed = texturesJson.toVariant();
-    return parsed.toMap();
+    return texturesJson.toVariant().toMap();
 }
 
 void RenderableModelEntityItem::remapTextures() {
@@ -144,7 +143,7 @@ void RenderableModelEntityItem::remapTextures() {
         _currentTextures = _originalTextures;
     }
 
-    auto textures = parseTexturesToMap(_textures);
+    auto textures = parseTexturesToMap(getTextures());
 
     if (textures != _currentTextures) {
         geometry->setTextures(textures);

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -90,6 +90,7 @@ private:
     bool _needsInitialSimulation = true;
     bool _needsModelReload = true;
     EntityTreeRenderer* _myRenderer = nullptr;
+    QString _lastTextures;
     QVariantMap _currentTextures;
     QVariantMap _originalTextures;
     bool _originalTexturesRead = false;

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -42,6 +42,17 @@ ModelEntityItem::ModelEntityItem(const EntityItemID& entityItemID) : EntityItem(
     _color[0] = _color[1] = _color[2] = 0;
 }
 
+const QString ModelEntityItem::getTextures() const {
+    QReadLocker locker(&_texturesLock);
+    auto textures = _textures;
+    return textures;
+}
+
+void ModelEntityItem::setTextures(const QString& textures) {
+    QWriteLocker locker(&_texturesLock);
+    _textures = textures;
+}
+
 EntityItemProperties ModelEntityItem::getProperties(EntityPropertyFlags desiredProperties) const {
     EntityItemProperties properties = EntityItem::getProperties(desiredProperties); // get the properties from our base class
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(color, getXColor);

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -110,8 +110,8 @@ public:
     float getAnimationFPS() const { return _animationLoop.getFPS(); }
 
     static const QString DEFAULT_TEXTURES;
-    const QString& getTextures() const { return _textures; }
-    void setTextures(const QString& textures) { _textures = textures; }
+    const QString getTextures() const;
+    void setTextures(const QString& textures);
 
     virtual bool shouldBePhysical() const;
 
@@ -159,7 +159,9 @@ protected:
     AnimationPropertyGroup _animationProperties;
     AnimationLoop _animationLoop;
 
+    mutable QReadWriteLock _texturesLock;
     QString _textures;
+
     ShapeType _shapeType = SHAPE_TYPE_NONE;
 
     // used on client side


### PR DESCRIPTION
In response to consistent crashes on parseTexturesToMap.