### PR TITLE
Model: fix for crash when displaying collision mesh

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -536,7 +536,7 @@ void Model::setVisibleInScene(bool newValue, std::shared_ptr<render::Scene> scen
             pendingChanges.resetItem(item, _modelMeshRenderItems[item]);
         }
         foreach (auto item, _collisionRenderItems.keys()) {
-            pendingChanges.resetItem(item, _modelMeshRenderItems[item]);
+            pendingChanges.resetItem(item, _collisionRenderItems[item]);
         }
         scene->enqueuePendingChanges(pendingChanges);
     }

--- a/libraries/render/src/render/Scene.cpp
+++ b/libraries/render/src/render/Scene.cpp
@@ -16,8 +16,13 @@
 using namespace render;
 
 void PendingChanges::resetItem(ItemID id, const PayloadPointer& payload) {
-    _resetItems.push_back(id);
-    _resetPayloads.push_back(payload);
+    if (payload) {
+        _resetItems.push_back(id);
+        _resetPayloads.push_back(payload);
+    } else {
+        qDebug() << "WARNING: PendingChanges::resetItem with a null payload!";
+        removeItem(id);
+    }
 }
 
 void PendingChanges::removeItem(ItemID id) {


### PR DESCRIPTION
This was due to a default constructed PayloadPointer being sent to the scene via resetItem.

The fix is to A) not do that anymore, B) make resetItem more robust and not crash if this happens.