### PR TITLE
Check for valid qml gl context creation

### DIFF
--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -38,11 +38,13 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
         _context->setShareContext(sharedContext);
     }
     _context->setFormat(getDefaultOpenGLSurfaceFormat());
+
     if (_context->create()) {
         _offscreenSurface->setFormat(_context->format());
         _offscreenSurface->create();
-        return true;
+        return _offscreenSurface->isValid();
     }
+    qWarning("Failed to create OffscreenGLCanvas context");
 
     return false;
 }


### PR DESCRIPTION
This checks that a QML Renderer thread has successfully created a GL context.
If not, it will just quit the renderer thread, which may manifest as a (non-crashing) bug.