### PR TITLE
Fix crash from updating/resetting avatar

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -859,7 +859,11 @@ void Avatar::scaleVectorRelativeToPosition(glm::vec3 &positionToScale) const {
 
 void Avatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
     AvatarData::setSkeletonModelURL(skeletonModelURL);
-    _skeletonModel->setURL(_skeletonModelURL);
+    if (QThread::currentThread() == thread()) {
+        _skeletonModel->setURL(_skeletonModelURL);
+    } else {
+        QMetaObject::invokeMethod(_skeletonModel.get(), "setURL", Qt::QueuedConnection, Q_ARG(QUrl, _skeletonModelURL));
+    }
 }
 
 // create new model, can return an instance of a SoftAttachmentModel rather then Model

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -165,13 +165,15 @@ void Model::enqueueLocationChange() {
         render::PendingChanges pendingChanges;
         foreach (auto itemID, self->_modelMeshRenderItems.keys()) {
             pendingChanges.updateItem<ModelMeshPartPayload>(itemID, [modelTransform, modelMeshOffset](ModelMeshPartPayload& data) {
+                // Ensure the model geometry was not reset between frames
+                if (data._model->isLoaded()) {
+                    // lazy update of cluster matrices used for rendering.  We need to update them here, so we can correctly update the bounding box.
+                    data._model->updateClusterMatrices(modelTransform.getTranslation(), modelTransform.getRotation());
 
-                // lazy update of cluster matrices used for rendering.  We need to update them here, so we can correctly update the bounding box.
-                data._model->updateClusterMatrices(modelTransform.getTranslation(), modelTransform.getRotation());
-
-                // update the model transform and bounding box for this render item.
-                const Model::MeshState& state = data._model->_meshStates.at(data._meshIndex);
-                data.updateTransformForSkinnedMesh(modelTransform, modelMeshOffset, state.clusterMatrices);
+                    // update the model transform and bounding box for this render item.
+                    const Model::MeshState& state = data._model->_meshStates.at(data._meshIndex);
+                    data.updateTransformForSkinnedMesh(modelTransform, modelMeshOffset, state.clusterMatrices);
+                }
             });
         }
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1061,7 +1061,7 @@ void Model::simulateInternal(float deltaTime) {
 void Model::updateClusterMatrices(glm::vec3 modelPosition, glm::quat modelOrientation) {
     PerformanceTimer perfTimer("Model::updateClusterMatrices");
 
-    if (!_needsUpdateClusterMatrices) {
+    if (!_needsUpdateClusterMatrices || !isLoaded()) {
         return;
     }
     _needsUpdateClusterMatrices = false;


### PR DESCRIPTION
In our application event loop:
- Scene updates with pending changes:
  - additions (aka resets)
  - updates
  - removals
- Engine runs (aka render pass)

The model URL, when changed, invalidates its geometry. Its geometry is accessed during updates and engine runs, but updates are queued during engine runs, so only two options are safe:
- Only change model URL during scene removal
- Add a check before performing updates, in the update functor, that the model geometry is still valid

Current code assumed the interlude between the engine run and the scene update was a good place, so it is crashing on update functors. This PR adds a guard in the update functor that was crashing.