### PR TITLE
Render alpha textures immediately

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -434,8 +434,6 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
                 _showCollisionHull = shouldShowCollisionHull;
                 render::PendingChanges pendingChanges;
 
-                _model->removeFromScene(scene, pendingChanges);
-
                 render::Item::Status::Getters statusGetters;
                 makeEntityItemStatusGetters(getThisPointer(), statusGetters);
                 _model->addToScene(scene, pendingChanges, statusGetters, _showCollisionHull);

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -133,10 +133,8 @@ void RenderableModelEntityItem::remapTextures() {
         return; // nothing to do if the model has not yet loaded
     }
 
-    auto& geometry = _model->getGeometry()->getGeometry();
-
     if (!_originalTexturesRead) {
-        _originalTextures = geometry->getTextures();
+        _originalTextures = _model->getTextures();
         _originalTexturesRead = true;
 
         // Default to _originalTextures to avoid remapping immediately and lagging on load
@@ -152,7 +150,7 @@ void RenderableModelEntityItem::remapTextures() {
     auto newTextures = parseTexturesToMap(textures);
 
     if (newTextures != _currentTextures) {
-        geometry->setTextures(newTextures);
+        _model->setTextures(newTextures);
         _currentTextures = newTextures;
     }
 }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -116,8 +116,15 @@ QVariantMap RenderableModelEntityItem::parseTexturesToMap(QString textures) {
 
     QJsonParseError error;
     QJsonDocument texturesJson = QJsonDocument::fromJson(textures.toUtf8(), &error);
+    // If textures are invalid, revert to original textures
     if (error.error != QJsonParseError::NoError) {
         qCWarning(entitiesrenderer) << "Could not evaluate textures property value:" << textures;
+        return _originalTextures;
+    }
+
+    QVariantMap texturesMap = texturesJson.toVariant().toMap();
+    // If textures are unset, revert to original textures
+    if (texturesMap.isEmpty()) {
         return _originalTextures;
     }
 

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -270,6 +270,9 @@ void Geometry::setTextures(const QVariantMap& textureMap) {
 
                 material->setTextures(textureMap);
                 _areTexturesLoaded = false;
+
+                // If we only use cached textures, they should all be loaded
+                areTexturesLoaded();
             }
         }
     } else {
@@ -279,8 +282,6 @@ void Geometry::setTextures(const QVariantMap& textureMap) {
 
 bool Geometry::areTexturesLoaded() const {
     if (!_areTexturesLoaded) {
-        _hasTransparentTextures = false;
-
         for (auto& material : _materials) {
             // Check if material textures are loaded
             if (std::any_of(material->_textures.cbegin(), material->_textures.cend(),
@@ -293,8 +294,6 @@ bool Geometry::areTexturesLoaded() const {
             const auto albedoTexture = material->_textures[NetworkMaterial::MapChannel::ALBEDO_MAP];
             if (albedoTexture.texture && albedoTexture.texture->getGPUTexture()) {
                 material->resetOpacityMap();
-
-                _hasTransparentTextures |= material->getKey().isTranslucent();
             }
         }
 

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -74,9 +74,6 @@ public:
     void setTextures(const QVariantMap& textureMap);
 
     virtual bool areTexturesLoaded() const;
-    // Returns true if any albedo texture has a non-masking alpha channel.
-    // This can only be known after areTexturesLoaded().
-    bool hasTransparentTextures() const { return _hasTransparentTextures; }
 
 protected:
     friend class GeometryMappingResource;
@@ -91,7 +88,6 @@ protected:
 
 private:
     mutable bool _areTexturesLoaded { false };
-    mutable bool _hasTransparentTextures { false };
 };
 
 /// A geometry loaded from the network.

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -76,14 +76,9 @@ AbstractViewStateInterface* Model::_viewState = NULL;
 
 bool Model::needsFixupInScene() const {
     if (readyToAddToScene()) {
-        // Once textures are loaded, fixup if they are now transparent
-        if (_needsUpdateTransparentTextures && _geometry->getGeometry()->areTexturesLoaded()) {
-            _needsUpdateTransparentTextures = false;
-            bool hasTransparentTextures = _geometry->getGeometry()->hasTransparentTextures();
-            if (_hasTransparentTextures != hasTransparentTextures) {
-                _hasTransparentTextures = hasTransparentTextures;
-                return true;
-            }
+        if (_needsUpdateTextures && _geometry->getGeometry()->areTexturesLoaded()) {
+            _needsUpdateTextures = false;
+            return true;
         }
         if (!_readyWhenAdded) {
             return true;
@@ -791,6 +786,13 @@ int Model::getLastFreeJointIndex(int jointIndex) const {
     return (isActive() && jointIndex != -1) ? getFBXGeometry().joints.at(jointIndex).freeLineage.last() : -1;
 }
 
+void Model::setTextures(const QVariantMap& textures) {
+    if (isLoaded()) {
+        _needsUpdateTextures = true;
+        _geometry->getGeometry()->setTextures(textures);
+    }
+}
+
 void Model::setURL(const QUrl& url) {
     // don't recreate the geometry if it's the same URL
     if (_url == url && _geometry && _geometry->getURL() == url) {
@@ -807,8 +809,7 @@ void Model::setURL(const QUrl& url) {
     }
 
     _needsReload = true;
-    _needsUpdateTransparentTextures = true;
-    _hasTransparentTextures = false;
+    _needsUpdateTextures = true;
     _meshGroupsKnown = false;
     invalidCalculatedMeshBoxes();
     deleteGeometry();

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -87,7 +87,10 @@ public:
     bool initWhenReady(render::ScenePointer scene);
     bool addToScene(std::shared_ptr<render::Scene> scene,
                     render::PendingChanges& pendingChanges,
-                    bool showCollisionHull = false);
+                    bool showCollisionHull = false) {
+        auto getters = render::Item::Status::Getters(0);
+        return addToScene(scene, pendingChanges, getters, showCollisionHull);
+    }
     bool addToScene(std::shared_ptr<render::Scene> scene,
                     render::PendingChanges& pendingChanges,
                     render::Item::Status::Getters& statusGetters,

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -129,6 +129,9 @@ public:
     /// Returns a reference to the shared collision geometry.
     const NetworkGeometry::Pointer& getCollisionGeometry() const { return _collisionGeometry; }
 
+    const QVariantMap getTextures() const { assert(isLoaded()); return _geometry->getGeometry()->getTextures(); }
+    void setTextures(const QVariantMap& textures);
+
     /// Provided as a convenience, will crash if !isLoaded()
     // And so that getGeometry() isn't chained everywhere
     const FBXGeometry& getFBXGeometry() const { assert(isLoaded()); return getGeometry()->getGeometry()->getGeometry(); }
@@ -385,9 +388,8 @@ protected:
     bool _readyWhenAdded { false };
     bool _needsReload { true };
     bool _needsUpdateClusterMatrices { true };
-    mutable bool _needsUpdateTransparentTextures { true };
-    mutable bool _hasTransparentTextures { false };
     bool _showCollisionHull { false };
+    mutable bool _needsUpdateTextures { true };
 
     friend class ModelMeshPartPayload;
     RigPointer _rig;


### PR DESCRIPTION
Fixes up the model every time all textures are loaded, instead of waiting for alpha to change.
Fixes an issue where the alpha was not applied until the entity was moved.

- Adds texture getter/setter to the Model.
- Amends Model to need fixup when new textures are all loaded.
- Reorders RenderableModelEntityItem::render to reduce flicker when changing textures.
- Amends Model::addToScene to avoid recreating items (needed to remove flicker).
- Defaults to _originalTextures when `{}` is specified in the textures property.