### PR TITLE
Allow display plugins to expose a preferred audio device

### DIFF
--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -97,3 +97,11 @@ bool HMDScriptingInterface::isMounted() const{
     auto displayPlugin = qApp->getActiveDisplayPlugin();
     return (displayPlugin->isHmd() && displayPlugin->isDisplayVisible());
 }
+
+QString HMDScriptingInterface::preferredAudioInput() const {
+    return qApp->getActiveDisplayPlugin()->getPreferredAudioInDevice();
+}
+
+QString HMDScriptingInterface::preferredAudioOutput() const {
+    return qApp->getActiveDisplayPlugin()->getPreferredAudioOutDevice();
+}

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -34,6 +34,8 @@ public:
 
     Q_INVOKABLE glm::vec2 sphericalToOverlay(const glm::vec2 & sphericalPos) const;
     Q_INVOKABLE glm::vec2 overlayToSpherical(const glm::vec2 & overlayPos) const;
+    Q_INVOKABLE QString preferredAudioInput() const;
+    Q_INVOKABLE QString preferredAudioOutput() const;
 
 public:
     HMDScriptingInterface();

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <vector>
 
+#include <QtCore/qsystemdetection.h>
 #include <QtCore/QByteArray>
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QObject>
@@ -125,6 +126,10 @@ public:
     void setOrientationGetter(AudioOrientationGetter orientationGetter) { _orientationGetter = orientationGetter; }
 
     static const float CALLBACK_ACCELERATOR_RATIO;
+
+#ifdef Q_OS_WIN
+    static QString friendlyNameForAudioDevice(wchar_t* guid);
+#endif
 
 public slots:
     void start();

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -74,6 +74,9 @@ public:
     /// whether the HMD is being worn
     virtual bool isDisplayVisible() const { return false; }
 
+    virtual QString getPreferredAudioInDevice() const { return QString(); }
+    virtual QString getPreferredAudioOutDevice() const { return QString(); }
+
     // Rendering support
 
     /**

--- a/plugins/oculus/CMakeLists.txt
+++ b/plugins/oculus/CMakeLists.txt
@@ -12,8 +12,8 @@ if (WIN32)
     add_definitions(-DGLEW_STATIC)
 
     set(TARGET_NAME oculus)
-    setup_hifi_plugin()
-    link_hifi_libraries(shared gl gpu controllers ui plugins display-plugins input-plugins)
+    setup_hifi_plugin(Multimedia)
+    link_hifi_libraries(shared gl gpu controllers ui plugins display-plugins input-plugins audio-client networking)
     
     include_hifi_library_headers(octree)
     
@@ -21,5 +21,6 @@ if (WIN32)
     find_package(LibOVR REQUIRED)
     target_include_directories(${TARGET_NAME} PRIVATE ${LIBOVR_INCLUDE_DIRS})
     target_link_libraries(${TARGET_NAME} ${LIBOVR_LIBRARIES})
+    target_link_libraries(${TARGET_NAME} Winmm.lib)
 
 endif()

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.h
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.h
@@ -21,6 +21,7 @@ public:
     // Stereo specific methods
     virtual void resetSensors() override final;
     virtual void beginFrameRender(uint32_t frameIndex) override;
+    float getTargetFrameRate() override { return _hmdDesc.DisplayRefreshRate; }
     
 
 protected:

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -7,21 +7,13 @@
 //
 #include "OculusDisplayPlugin.h"
 
-#ifdef WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <Mmsystem.h>
-#include <mmdeviceapi.h>
-#include <devicetopology.h>
-#include <Functiondiscoverykeys_devpkey.h>
-#include <VersionHelpers.h>
-#endif
+// Odd ordering of header is required to avoid 'macro redinition warnings'
+#include <AudioClient.h>
 
 #include <OVR_CAPI_Audio.h>
-#include <QtCore/QThread>
 
 #include <shared/NsightHelpers.h>
-#include <AudioClient.h>
+
 #include "OculusHelpers.h"
 
 const QString OculusDisplayPlugin::NAME("Oculus Rift");
@@ -33,36 +25,7 @@ bool OculusDisplayPlugin::internalActivate() {
     if (result && _session) {
         ovr_SetInt(_session, OVR_PERF_HUD_MODE, currentDebugMode);
     }
-
-    auto audioClient = DependencyManager::get<AudioClient>();
-    QString riftAudioIn = getPreferredAudioInDevice();
-    if (riftAudioIn != QString()) {
-        _savedAudioIn = audioClient->getDeviceName(QAudio::Mode::AudioInput);
-        QMetaObject::invokeMethod(audioClient.data(), "switchInputToAudioDevice", Q_ARG(const QString&, riftAudioIn));
-    } else {
-        _savedAudioIn.clear();
-    }
-
-    QString riftAudioOut = getPreferredAudioOutDevice();
-    if (riftAudioOut != QString()) {
-        _savedAudioOut = audioClient->getDeviceName(QAudio::Mode::AudioOutput);
-        QMetaObject::invokeMethod(audioClient.data(), "switchOutputToAudioDevice", Q_ARG(const QString&, riftAudioOut));
-    } else {
-        _savedAudioOut.clear();
-    }
-
     return result;
-}
-
-void OculusDisplayPlugin::internalDeactivate() {
-    auto audioClient = DependencyManager::get<AudioClient>();
-    if (_savedAudioIn != QString()) {
-        QMetaObject::invokeMethod(audioClient.data(), "switchInputToAudioDevice", Q_ARG(const QString&, _savedAudioIn));
-    }
-    if (_savedAudioOut != QString()) {
-        QMetaObject::invokeMethod(audioClient.data(), "switchOutputToAudioDevice", Q_ARG(const QString&, _savedAudioOut));
-    }
-    Parent::internalDeactivate();
 }
 
 void OculusDisplayPlugin::cycleDebugOutput() {
@@ -137,50 +100,12 @@ bool OculusDisplayPlugin::isHmdMounted() const {
         (ovrFalse != status.HmdMounted));
 }
 
-static QString audioDeviceFriendlyName(LPCWSTR device) {
-    QString deviceName;
-
-    HRESULT hr = S_OK;
-    CoInitialize(NULL);
-    IMMDeviceEnumerator* pMMDeviceEnumerator = NULL;
-    CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&pMMDeviceEnumerator);
-    IMMDevice* pEndpoint;
-    hr = pMMDeviceEnumerator->GetDevice(device, &pEndpoint);
-    if (hr == E_NOTFOUND) {
-        printf("Audio Error: device not found\n");
-        deviceName = QString("NONE");
-    } else {
-        IPropertyStore* pPropertyStore;
-        pEndpoint->OpenPropertyStore(STGM_READ, &pPropertyStore);
-        pEndpoint->Release();
-        pEndpoint = NULL;
-        PROPVARIANT pv;
-        PropVariantInit(&pv);
-        hr = pPropertyStore->GetValue(PKEY_Device_FriendlyName, &pv);
-        pPropertyStore->Release();
-        pPropertyStore = NULL;
-        deviceName = QString::fromWCharArray((wchar_t*)pv.pwszVal);
-        if (!IsWindows8OrGreater()) {
-            // Windows 7 provides only the 31 first characters of the device name.
-            const DWORD QT_WIN7_MAX_AUDIO_DEVICENAME_LEN = 31;
-            deviceName = deviceName.left(QT_WIN7_MAX_AUDIO_DEVICENAME_LEN);
-        }
-        qDebug() << " device:" << deviceName;
-        PropVariantClear(&pv);
-    }
-    pMMDeviceEnumerator->Release();
-    pMMDeviceEnumerator = NULL;
-    CoUninitialize();
-    return deviceName;
-}
-
-
 QString OculusDisplayPlugin::getPreferredAudioInDevice() const { 
     WCHAR buffer[OVR_AUDIO_MAX_DEVICE_STR_SIZE];
     if (!OVR_SUCCESS(ovr_GetAudioDeviceInGuidStr(buffer))) {
         return QString();
     }
-    return audioDeviceFriendlyName(buffer);
+    return AudioClient::friendlyNameForAudioDevice(buffer);
 }
 
 QString OculusDisplayPlugin::getPreferredAudioOutDevice() const { 
@@ -188,6 +113,6 @@ QString OculusDisplayPlugin::getPreferredAudioOutDevice() const {
     if (!OVR_SUCCESS(ovr_GetAudioDeviceOutGuidStr(buffer))) {
         return QString();
     }
-    return audioDeviceFriendlyName(buffer);
+    return AudioClient::friendlyNameForAudioDevice(buffer);
 }
 

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -22,7 +22,6 @@ public:
 
 protected:
     bool internalActivate() override;
-    void internalDeactivate() override;
     void hmdPresent() override;
     bool isHmdMounted() const override;
     void customizeContext() override;
@@ -33,8 +32,6 @@ private:
     static const QString NAME;
     bool _enablePreview { false };
     bool _monoPreview { true };
-    QString _savedAudioIn;
-    QString _savedAudioOut;
 
     SwapFboPtr       _sceneFbo;
 };

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -12,20 +12,19 @@
 struct SwapFramebufferWrapper;
 using SwapFboPtr = QSharedPointer<SwapFramebufferWrapper>;
 
-const float TARGET_RATE_Oculus = 75.0f;
-
 class OculusDisplayPlugin : public OculusBaseDisplayPlugin {
     using Parent = OculusBaseDisplayPlugin;
 public:
     const QString& getName() const override { return NAME; }
 
-    float getTargetFrameRate() override { return TARGET_RATE_Oculus; }
+    QString getPreferredAudioInDevice() const override;
+    QString getPreferredAudioOutDevice() const override;
 
 protected:
     bool internalActivate() override;
+    void internalDeactivate() override;
     void hmdPresent() override;
-    // FIXME update with Oculus API call once it's available in the SDK
-    bool isHmdMounted() const override { return true; }
+    bool isHmdMounted() const override;
     void customizeContext() override;
     void uncustomizeContext() override;
     void cycleDebugOutput() override;
@@ -34,6 +33,8 @@ private:
     static const QString NAME;
     bool _enablePreview { false };
     bool _monoPreview { true };
+    QString _savedAudioIn;
+    QString _savedAudioOut;
 
     SwapFboPtr       _sceneFbo;
 };


### PR DESCRIPTION
This adds functionality to the display plugins to expose a preferred audio device, such as the Oculus headphones and mic.  This information is also exposed in the HMD scripting interface so that a script could automatically switch audio devices when the HMD is activated.

Note that apparently our QML layer doesn't use the same audio device as the AudioClient, so audio from QML surface and web entities will not respect this change (but neither will they respect a change to the audio device performed using the normal method in the menus.  It's a separate bug).