### PR TITLE
only do depth reticle depth check when the reticle is visible

### DIFF
--- a/examples/depthReticle.js
+++ b/examples/depthReticle.js
@@ -112,7 +112,7 @@ function autoHideReticle() {
 function checkReticleDepth() {
     var now = Date.now();
     var timeSinceLastDepthCheck = now - lastDepthCheckTime;
-    if (timeSinceLastDepthCheck > TIME_BETWEEN_DEPTH_CHECKS) {
+    if (timeSinceLastDepthCheck > TIME_BETWEEN_DEPTH_CHECKS && Reticle.visible) {
         var newDesiredDepth = desiredDepth;
         lastDepthCheckTime = now;
         var reticlePosition = Reticle.position;
@@ -160,7 +160,6 @@ function moveToDesiredDepth() {
         } else {
             newDepth = Reticle.depth + distanceToAdjustThisCycle;
         }
-
         Reticle.setDepth(newDepth);
     }
 }


### PR DESCRIPTION
this simple optimization will save us from doing intermittent depth checks when the mouse isn't even visible... which helps for content like demo where there are lots of triangles.