### PR TITLE
Delay congestion epochs first decrease

### DIFF
--- a/assignment-client/src/assets/AssetServer.cpp
+++ b/assignment-client/src/assets/AssetServer.cpp
@@ -82,11 +82,11 @@ void AssetServer::completeSetup() {
     auto maxBandwidthFloat = maxBandwidthValue.toDouble(-1);
 
     if (maxBandwidthFloat > 0.0) {
-        const int BYTES_PER_MEGABITS = (1024 * 1024) / 8;
-        int maxBandwidth = maxBandwidthFloat * BYTES_PER_MEGABITS;
+        const int BITS_PER_MEGABITS = 1000 * 1000;
+        int maxBandwidth = maxBandwidthFloat * BITS_PER_MEGABITS;
         nodeList->setConnectionMaxBandwidth(maxBandwidth);
         qInfo() << "Set maximum bandwith per connection to" << maxBandwidthFloat << "Mb/s."
-                    " (" << maxBandwidth << "bytes/sec)";
+                    " (" << maxBandwidth << "bits/s)";
     }
 
     // get the path to the asset folder from the domain server settings

--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -163,6 +163,8 @@ void DefaultCC::onLoss(SequenceNumber rangeStart, SequenceNumber rangeEnd) {
 
         if (!_delayedDecrease) {
             setPacketSendPeriod(ceil(_packetSendPeriod * INTER_PACKET_ARRIVAL_INCREASE));
+        } else {
+            _loss = false;
         }
 
         // update the count of NAKs and count of decreases in this interval

--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -19,7 +19,7 @@ using namespace std::chrono;
 static const double USECS_PER_SECOND = 1000000.0;
 
 void CongestionControl::setMaxBandwidth(int maxBandwidth) {
-    _maxBandwidth = maxBandwidth;
+    _maxBandwidth = maxBandwidth / 8;
     setPacketSendPeriod(_packetSendPeriod);
 }
 

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -15,7 +15,6 @@
 #include <atomic>
 #include <memory>
 #include <vector>
-#include <random>
 
 #include <PortableHighResolutionClock.h>
 
@@ -61,7 +60,7 @@ protected:
     double _congestionWindowSize { 16.0 }; // Congestion window size, in packets
     
     int _bandwidth { 0 }; // estimated bandwidth, packets per second
-    std::atomic<int> _maxBandwidth { -1 }; // Maximum desired bandwidth, bytes per second
+    std::atomic<int> _maxBandwidth { -1 }; // Maximum desired bandwidth, bits per second
     double _maxCongestionWindowSize { 0.0 }; // maximum cwnd size, in packets
     
     int _mss { 0 }; // Maximum Packet Size, including all packet headers
@@ -81,8 +80,8 @@ private:
     bool _userDefinedRTO { false }; // if the RTO value is defined by users
     int _rto { -1 }; // RTO value, microseconds
 };
-
-
+    
+    
 class CongestionControlVirtualFactory {
 public:
     virtual ~CongestionControlVirtualFactory() {}
@@ -124,12 +123,7 @@ private:
     int _randomDecreaseThreshold { 1 }; // random threshold on decrease by number of loss events
     int _avgNAKNum { 0 }; // average number of NAKs per congestion
     int _decreaseCount { 0 }; // number of decreases in a congestion epoch
-
-
-    bool _delayedDecrease  { false };
-    std::random_device _rd;
-    std::mt19937 _generator;
-    std::uniform_int_distribution<> _distribution;
+    bool _delayedDecrease { false };
 };
     
 }

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -15,7 +15,7 @@
 #include <atomic>
 #include <memory>
 #include <vector>
-#include <memory>
+#include <random>
 
 #include <PortableHighResolutionClock.h>
 
@@ -81,8 +81,8 @@ private:
     bool _userDefinedRTO { false }; // if the RTO value is defined by users
     int _rto { -1 }; // RTO value, microseconds
 };
-    
-    
+
+
 class CongestionControlVirtualFactory {
 public:
     virtual ~CongestionControlVirtualFactory() {}
@@ -124,6 +124,12 @@ private:
     int _randomDecreaseThreshold { 1 }; // random threshold on decrease by number of loss events
     int _avgNAKNum { 0 }; // average number of NAKs per congestion
     int _decreaseCount { 0 }; // number of decreases in a congestion epoch
+
+
+    bool _delayedDecrease  { false };
+    std::random_device _rd;
+    std::mt19937 _generator;
+    std::uniform_int_distribution<> _distribution;
 };
     
 }

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -354,7 +354,7 @@ void Socket::setCongestionControlFactory(std::unique_ptr<CongestionControlVirtua
 
 
 void Socket::setConnectionMaxBandwidth(int maxBandwidth) {
-    qInfo() << "Setting socket's maximum bandwith to" << maxBandwidth << ". ("
+    qInfo() << "Setting socket's maximum bandwith to" << maxBandwidth << "bps. ("
             << _connectionsHash.size() << "live connections)";
     _maxBandwidth = maxBandwidth;
     for (auto& pair : _connectionsHash) {

--- a/tools/udt-test/src/UDTTest.cpp
+++ b/tools/udt-test/src/UDTTest.cpp
@@ -57,13 +57,13 @@ const QCommandLineOption STATS_INTERVAL {
 };
 
 const QStringList CLIENT_STATS_TABLE_HEADERS {
-    "Send (P/s)", "Est. Max (P/s)", "RTT (ms)", "CW (P)", "Period (us)",
+    "Send (Mb/s)", "Est. Max (Mb/s)", "RTT (ms)", "CW (P)", "Period (us)",
     "Recv ACK", "Procd ACK", "Recv LACK", "Recv NAK", "Recv TNAK",
     "Sent ACK2", "Sent Packets", "Re-sent Packets"
 };
 
 const QStringList SERVER_STATS_TABLE_HEADERS {
-    "  Mb/s  ", "Recv P/s", "Est. Max (P/s)", "RTT (ms)", "CW (P)",
+    "  Mb/s  ", "Recv Mb/s", "Est. Max (Mb/s)", "RTT (ms)", "CW (P)",
     "Sent ACK", "Sent LACK", "Sent NAK", "Sent TNAK",
     "Recv ACK2", "Duplicates (P)"
 };
@@ -364,7 +364,11 @@ void UDTTest::handleMessage(std::unique_ptr<Message> message) {
 void UDTTest::sampleStats() {
     static bool first = true;
     static const double USECS_PER_MSEC = 1000.0;
-    
+    static const double MEGABITS_PER_BYTE = 8.0 / 1000000.0;
+    static const double MS_PER_SECOND = 1000.0;
+    static const double PPS_TO_MBPS = 1500.0 * 8.0 / 1000000.0;
+
+
     if (!_target.isNull()) {
         if (first) {
             // output the headers for stats for our table
@@ -378,8 +382,8 @@ void UDTTest::sampleStats() {
         
         // setup a list of left justified values
         QStringList values {
-            QString::number(stats.sendRate).rightJustified(CLIENT_STATS_TABLE_HEADERS[++headerIndex].size()),
-            QString::number(stats.estimatedBandwith).rightJustified(CLIENT_STATS_TABLE_HEADERS[++headerIndex].size()),
+            QString::number(stats.sendRate * PPS_TO_MBPS).rightJustified(CLIENT_STATS_TABLE_HEADERS[++headerIndex].size()),
+            QString::number(stats.estimatedBandwith * PPS_TO_MBPS).rightJustified(CLIENT_STATS_TABLE_HEADERS[++headerIndex].size()),
             QString::number(stats.rtt / USECS_PER_MSEC, 'f', 2).rightJustified(CLIENT_STATS_TABLE_HEADERS[++headerIndex].size()),
             QString::number(stats.congestionWindowSize).rightJustified(CLIENT_STATS_TABLE_HEADERS[++headerIndex].size()),
             QString::number(stats.packetSendPeriod).rightJustified(CLIENT_STATS_TABLE_HEADERS[++headerIndex].size()),
@@ -408,16 +412,13 @@ void UDTTest::sampleStats() {
             
             int headerIndex = -1;
             
-            static const double MEGABITS_PER_BYTE = 8.0 / 1000000.0;
-            static const double MS_PER_SECOND = 1000.0;
-            
             double megabitsPerSecond = (stats.receivedBytes * MEGABITS_PER_BYTE * MS_PER_SECOND) / _statsInterval;
             
             // setup a list of left justified values
             QStringList values {
                 QString::number(megabitsPerSecond, 'f', 2).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),
-                QString::number(stats.receiveRate).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),
-                QString::number(stats.estimatedBandwith).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),
+                QString::number(stats.receiveRate * PPS_TO_MBPS).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),
+                QString::number(stats.estimatedBandwith * PPS_TO_MBPS).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),
                 QString::number(stats.rtt / USECS_PER_MSEC, 'f', 2).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),
                 QString::number(stats.congestionWindowSize).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),
                 QString::number(stats.events[udt::ConnectionStats::Stats::SentACK]).rightJustified(SERVER_STATS_TABLE_HEADERS[++headerIndex].size()),

--- a/tools/udt-test/src/UDTTest.cpp
+++ b/tools/udt-test/src/UDTTest.cpp
@@ -366,7 +366,7 @@ void UDTTest::sampleStats() {
     static const double USECS_PER_MSEC = 1000.0;
     static const double MEGABITS_PER_BYTE = 8.0 / 1000000.0;
     static const double MS_PER_SECOND = 1000.0;
-    static const double PPS_TO_MBPS = 1500.0 * 8.0 / 1000000.0;
+    static const double PPS_TO_MBPS = 1500.0 * MEGABITS_PER_BYTE;
 
 
     if (!_target.isNull()) {


### PR DESCRIPTION
- Delay the first decrease of each congestion epoch to the 2nd NAK if the first NAK is for a single packet.
      This makes the protocol more resilient on networks with small but constant loss,
      and especially networks subjected to a high number of out of orde packets.
- Make sure all stats are in Mb/s, this makes it easier to read and understand the data