### PR TITLE
Application: don't call Model::simulate on network thread.

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -515,6 +515,8 @@ private:
 
     std::map<void*, std::function<void()>> _preRenderLambdas;
     std::mutex _preRenderLambdasLock;
+
+    std::atomic<uint32_t> _processOctreeStatsCounter { 0 };
 };
 
 #endif // hifi_Application_h


### PR DESCRIPTION
This can cause a crash.

On startup the Application::processOctreeStats method on the network thread will call into entities entity->isReadyToComputeShape() (without a tree lock) and trigger Model::simulate.  Model is NOT thread safe.  This was leading to a single model to be initialized on two threads simultaneously.

This might be somewhat rare, I only caught it because I was running a debug build.