### PR TITLE
Keep textureBaseUrl for fst models

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -95,7 +95,8 @@ class GeometryResource : public Resource, public Geometry {
 public:
     using Pointer = QSharedPointer<GeometryResource>;
 
-    GeometryResource(const QUrl& url, const QUrl& textureBaseUrl = QUrl()) : Resource(url) {}
+    GeometryResource(const QUrl& url, const QUrl& textureBaseUrl = QUrl()) :
+        Resource(url), _textureBaseUrl(textureBaseUrl) {}
 
     virtual bool areTexturesLoaded() const { return isLoaded() && Geometry::areTexturesLoaded(); }
 


### PR DESCRIPTION
With #7533, fst models no longer load textures, as the textures are reloaded from a bare filepath. The base URL (the fst) is not persisted between the geometry definition and the mapping.

This fixes that by resolving the _textureBaseUrl in the GeometryMappingResource so that reloaded textures are loaded from the correct, qualified filepath.