### PR TITLE
Fix passing of simple string message types from QML to scripts

### DIFF
--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -130,8 +130,13 @@ void QmlWindowClass::initQml(QVariantMap properties) {
 }
 
 void QmlWindowClass::qmlToScript(const QVariant& message) {
-    QJSValue js = qvariant_cast<QJSValue>(message);
-    emit fromQml(js.toVariant());
+    if (message.canConvert<QJSValue>()) {
+        emit fromQml(qvariant_cast<QJSValue>(message).toVariant());
+    } else if (message.canConvert<QString>()) {
+        emit fromQml(message.toString());
+    } else {
+        qWarning() << "Unsupported message type " << message;
+    }
 }
 
 void QmlWindowClass::sendToQml(const QVariant& message) {


### PR DESCRIPTION
I broke the ability to pass simple strings from QML windows to scripts in this PR:  https://github.com/highfidelity/hifi/pull/7529

This should fix it.