### PR TITLE
refresh/close the asset browser dialog on domain switch

### DIFF
--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -21,7 +21,7 @@ import "dialogs"
 Window {
     id: root
     objectName: "AssetServer"
-    title: "My Asset Server"
+    title: "Asset Browser"
     resizable: true
     destroyOnInvisible: true
     x: 40; y: 40
@@ -123,6 +123,10 @@ Window {
         return supportedExtensions.reduce(function(total, current) {
             return total | new RegExp(current).test(path);
         }, false);
+    }
+
+    function clear() {
+        Assets.mappingModel.clear();
     }
 
     function reload() {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -312,6 +312,7 @@ private slots:
     void domainChanged(const QString& domainHostname);
     void updateWindowTitle();
     void nodeAdded(SharedNodePointer node);
+    void nodeActivated(SharedNodePointer node);
     void nodeKilled(SharedNodePointer node);
     void packetSent(quint64 length);
     void updateDisplayMode();

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -137,15 +137,14 @@ Menu::Menu() {
     QObject::connect(nodeList.data(), &NodeList::canRezChanged, assetServerAction, &QAction::setEnabled);
     assetServerAction->setEnabled(nodeList->getThisNodeCanRez());
 
-    // Edit > Reload All Content [advanced]
-    addActionToQMenuAndActionHash(editMenu, MenuOption::ReloadContent, 0, qApp, SLOT(reloadResourceCaches()),
-        QAction::NoRole, UNSPECIFIED_POSITION, "Advanced");
-
-
     // Edit > Package Model... [advanced]
     addActionToQMenuAndActionHash(editMenu, MenuOption::PackageModel, 0,
         qApp, SLOT(packageModel()),
         QAction::NoRole, UNSPECIFIED_POSITION, "Advanced");
+
+    // Edit > Reload All Content [advanced]
+    addActionToQMenuAndActionHash(editMenu, MenuOption::ReloadContent, 0, qApp, SLOT(reloadResourceCaches()),
+                                  QAction::NoRole, UNSPECIFIED_POSITION, "Advanced");
 
 
     // Audio menu ----------------------------------

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -34,7 +34,7 @@ namespace MenuOption {
     const QString AnimDebugDrawDefaultPose = "Debug Draw Default Pose";
     const QString AnimDebugDrawPosition= "Debug Draw Position";
     const QString AssetMigration = "ATP Asset Migration";
-    const QString AssetServer = "My Asset Server";
+    const QString AssetServer = "Asset Browser";
     const QString Attachments = "Attachments...";
     const QString AudioNetworkStats = "Audio Network Stats";
     const QString AudioNoiseReduction = "Audio Noise Reduction";

--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -13,12 +13,26 @@
 
 #include <QtScript/QScriptEngine>
 #include <QtCore/QFile>
+#include <QtCore/QThread>
 
 #include <AssetRequest.h>
 #include <AssetUpload.h>
 #include <MappingRequest.h>
 #include <NetworkLogging.h>
 #include <OffscreenUi.h>
+
+void AssetMappingModel::clear() {
+    // make sure we are on the same thread before we touch the hash
+    if (thread() != QThread::currentThread()) {
+        QMetaObject::invokeMethod(this, "clear");
+        return;
+    }
+
+    qDebug() << "Clearing loaded asset mappings for Asset Browser";
+
+    _pathToItemMap.clear();
+    QStandardItemModel::clear();
+}
 
 AssetMappingsScriptingInterface::AssetMappingsScriptingInterface() {
     _proxyModel.setSourceModel(&_assetMappingModel);

--- a/interface/src/scripting/AssetMappingsScriptingInterface.h
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.h
@@ -21,7 +21,6 @@
 #include <QSortFilterProxyModel>
 
 
-
 class AssetMappingModel : public QStandardItemModel {
     Q_OBJECT
 public:
@@ -29,6 +28,9 @@ public:
 
     bool isKnownMapping(QString path) const { return _pathToItemMap.contains(path); }
     bool isKnownFolder(QString path) const;
+
+public slots:
+    void clear();
 
 signals:
     void errorGettingMappings(QString errorString);


### PR DESCRIPTION
- renamed "My Asset Server" dialog to "Asset Browser"
- fixed an issue where the dialog would show the previous Asset Server contents on a domain switch