### PR TITLE
Release skybox textures when rendering stars

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -297,7 +297,14 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
     auto sceneLocation = sceneStage->getLocation();
     auto sceneTime = sceneStage->getTime();
     
+    // Skybox and procedural skybox data
+    auto skybox = std::dynamic_pointer_cast<ProceduralSkybox>(skyStage->getSkybox());
+    static QString userData;
+
     if (!zone) {
+        userData = QString();
+        skybox->clear();
+
         _pendingSkyboxTexture = false;
         _skyboxTexture.clear();
 
@@ -373,9 +380,7 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
 
     switch (zone->getBackgroundMode()) {
         case BACKGROUND_MODE_SKYBOX: {
-            auto skybox = std::dynamic_pointer_cast<ProceduralSkybox>(skyStage->getSkybox());
             skybox->setColor(zone->getSkyboxProperties().getColorVec3());
-            static QString userData;
             if (userData != zone->getUserData()) {
                 userData = zone->getUserData();
                 skybox->parse(userData);
@@ -414,9 +419,15 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
 
         case BACKGROUND_MODE_INHERIT:
         default:
-            skyStage->setBackgroundMode(model::SunSkyStage::SKY_DOME); // let the application background through
-            _pendingSkyboxTexture = false;
+            // Clear the skybox to release its textures
+            userData = QString();
+            skybox->clear();
+
             _skyboxTexture.clear();
+            _pendingSkyboxTexture = false;
+
+            // Let the application background through
+            skyStage->setBackgroundMode(model::SunSkyStage::SKY_DOME);
             break;
     }
 

--- a/libraries/model/src/model/Skybox.h
+++ b/libraries/model/src/model/Skybox.h
@@ -35,6 +35,8 @@ public:
     void setCubemap(const gpu::TexturePointer& cubemap);
     const gpu::TexturePointer& getCubemap() const { return _cubemap; }
 
+    virtual void clear() { setCubemap(nullptr); }
+
     void prepare(gpu::Batch& batch, int textureSlot = SKYBOX_SKYMAP_SLOT, int bufferSlot = SKYBOX_CONSTANTS_SLOT) const;
     virtual void render(gpu::Batch& batch, const ViewFrustum& frustum) const;
 

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -25,6 +25,14 @@ ProceduralSkybox::ProceduralSkybox() : model::Skybox() {
     _procedural._state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
+void ProceduralSkybox::clear() {
+    // Parse and prepare a procedural with no shaders to release textures
+    parse(QString());
+    _procedural.ready();
+
+    Skybox::clear();
+}
+
 void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& frustum) const {
     if (_procedural.ready()) {
         ProceduralSkybox::render(batch, frustum, (*this));

--- a/libraries/procedural/src/procedural/ProceduralSkybox.h
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.h
@@ -24,6 +24,8 @@ public:
 
     void parse(const QString& userData) { _procedural.parse(userData); }
 
+    virtual void clear() override;
+
     virtual void render(gpu::Batch& batch, const ViewFrustum& frustum) const;
     static void render(gpu::Batch& batch, const ViewFrustum& frustum, const ProceduralSkybox& skybox);
 


### PR DESCRIPTION
- Adds a virtual method `Skybox::clear` to release textures
- Calls clear when not rendering a skybox
- Amends procedural shader parsing to release unused resources (shader/textures)

---

#### Intent
Frees GPU texture memory when switching domains, or switching to a zone with no skybox.
(See: https://app.asana.com/0/74051501495175/107448718339742.)

#### Testing

##### Repro
1. Test twice; on one test, set your texture cache size to 0 (`Developer > Network > RAM Caches Size`).
2. Open `renderStats.js` and go to an area with no zone.
3. Load fully, and note the GPU gpu::Texture memory usage.
4. Go to `hifi://playa`, and wait for the skybox (celestial map) to load fully.
5. Go back to the area with no zone.

##### Expectations
In current build, the skybox textures will stick around. Your memory usage will be appreciably larger than it was before.
In this PR build, the skybox textures will go away. Your memory usage will be less than in current build.

This changes the procedural shaders implementation, so that should be given a smoke test as well.