### PR TITLE
Model: fixed two crash issues when changing avatars

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -144,10 +144,11 @@ void GeometryReader::run() {
                 throw QString("unsupported format");
             }
 
-            // Ensure the resource has not been deleted, and won't be while invoke method is in flight.
+            // Ensure the resource has not been deleted, and won't be while invokeMethod is in flight.
             auto resource = _resource.toStrongRef();
             if (!resource) {
                 qCWarning(modelnetworking) << "Abandoning load of" << _url << "; could not get strong ref";
+                delete fbxGeometry;
             } else {
                 QMetaObject::invokeMethod(resource.data(), "setGeometryDefinition", Qt::BlockingQueuedConnection, Q_ARG(void*, fbxGeometry));
             }
@@ -159,7 +160,7 @@ void GeometryReader::run() {
         qCDebug(modelnetworking) << "Error reading " << _url << ": " << error;
 
         auto resource = _resource.toStrongRef();
-        // Ensure the resoruce has not been deleted, and won't be while invoke method is in flight.
+        // Ensure the resoruce has not been deleted, and won't be while invokeMethod is in flight.
         if (!resource) {
             qCWarning(modelnetworking) << "Abandoning load of" << _url << "; could not get strong ref";
         } else {

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -118,10 +118,8 @@ void GeometryReader::run() {
     }
     QThread::currentThread()->setPriority(QThread::LowPriority);
 
-    // Ensure the resource is still being requested
-    auto resource = _resource.toStrongRef();
-    if (!resource) {
-        qCWarning(modelnetworking) << "Abandoning load of" << _url << "; could not get strong ref";
+    if (!_resource.data()) {
+        qCWarning(modelnetworking) << "Abandoning load of" << _url << "; resource was deleted";
         return;
     }
 
@@ -146,14 +144,27 @@ void GeometryReader::run() {
                 throw QString("unsupported format");
             }
 
-            QMetaObject::invokeMethod(resource.data(), "setGeometryDefinition",
-                Q_ARG(void*, fbxGeometry));
+            // Ensure the resource has not been deleted, and won't be while invoke method is in flight.
+            auto resource = _resource.toStrongRef();
+            if (!resource) {
+                qCWarning(modelnetworking) << "Abandoning load of" << _url << "; could not get strong ref";
+            } else {
+                QMetaObject::invokeMethod(resource.data(), "setGeometryDefinition", Qt::BlockingQueuedConnection, Q_ARG(void*, fbxGeometry));
+            }
         } else {
             throw QString("url is invalid");
         }
     } catch (const QString& error) {
+
         qCDebug(modelnetworking) << "Error reading " << _url << ": " << error;
-        QMetaObject::invokeMethod(resource.data(), "finishedLoading", Q_ARG(bool, false));
+
+        auto resource = _resource.toStrongRef();
+        // Ensure the resoruce has not been deleted, and won't be while invoke method is in flight.
+        if (!resource) {
+            qCWarning(modelnetworking) << "Abandoning load of" << _url << "; could not get strong ref";
+        } else {
+            QMetaObject::invokeMethod(resource.data(), "finishedLoading", Qt::BlockingQueuedConnection, Q_ARG(bool, false));
+        }
     }
 
     QThread::currentThread()->setPriority(originalPriority);

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -394,6 +394,8 @@ protected:
 
     friend class ModelMeshPartPayload;
     RigPointer _rig;
+
+    uint32_t _deleteGeometryCounter { 0 };
 };
 
 Q_DECLARE_METATYPE(ModelPointer)


### PR DESCRIPTION
* When the GeometryReader has the last ref to the GeometryResource ptr
  It needs to hold on to the reference until invokeMethod is completed.
  Otherwise, invokeMethod will call a method on a deleted object, leading
  to memory corruption or crashes.

* When the Model URL is changed, the clusterMatrices are invalided and the
  RenderItemsSets are cleared.  However, there still might be renderItems in
  the scene pending changes list that might refer to those RenderItems and their
  clusterMatrices.  We need to guard against this access to prevent reading from
  memory that was previously freed.

Both of these issues were uncovered using the [avatar-thrasher](https://gist.github.com/hyperlogic/d82a61d141df43d576428501a82c5ee6) test script.