### PR TITLE
Avoid setting textures on empty models

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -232,7 +232,7 @@ std::shared_ptr<NetworkGeometry> ModelCache::getGeometry(const QUrl& url, const 
     GeometryExtra geometryExtra = { mapping, textureBaseUrl };
     GeometryResource::Pointer resource = getResource(url, QUrl(), true, &geometryExtra).staticCast<GeometryResource>();
     if (resource) {
-        if (resource->isLoaded() && !resource->hasTextures()) {
+        if (resource->isLoaded() && resource->shouldSetTextures()) {
             resource->setTextures();
         }
         return std::make_shared<NetworkGeometry>(resource);

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -107,7 +107,8 @@ protected:
     friend class GeometryMappingResource;
 
     // Geometries may not hold onto textures while cached - that is for the texture cache
-    bool hasTextures() const { return !_materials.empty(); }
+    // Instead, these methods clear and reset textures from the geometry when caching/loading
+    bool shouldSetTextures() const { return _geometry && _materials.empty(); }
     void setTextures();
     void resetTextures();
 


### PR DESCRIPTION
- Check that textures exist to be set before setting them when taking models out of cache

---

#### Intent
Fixes a crash where the empty model (`QUrl()`) tried to set its textures when uncached (access violation).
(See: https://www.bugsplatsoftware.com/keycrash/?stackKeyId=394&database=interface_alpha.)

#### Testing

##### Repro
1. Upload a model with a collision hull.
2. Clear the collision hull through edit.js.
3. Add it back.
- This will not work if any other models are still using a null model (including set and unset collision hulls). Do this on a blank domain.

##### Expectations
In current build, you will crash. The callstack will show a crash in `GeometryResource::setTextures()`.
In this PR build, it should work fine.