### PR TITLE
Addressing stuttering in the frame while loading content - Part 2

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1255,6 +1255,9 @@ void Application::initializeGL() {
     // Where the gpuContext is initialized and where the TRUE Backend is created and assigned
     gpu::Context::init<gpu::GLBackend>();
     _gpuContext = std::make_shared<gpu::Context>();
+    // The gpu context can make child contexts for transfers, so 
+    // we need to restore primary rendering context
+    _offscreenContext->makeCurrent();
 
     initDisplay();
     qCDebug(interfaceapp, "Initialized Display.");

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -12,7 +12,7 @@ const QSurfaceFormat& getDefaultOpenGLSurfaceFormat() {
         // Qt Quick may need a depth and stencil buffer. Always make sure these are available.
         format.setDepthBufferSize(DEFAULT_GL_DEPTH_BUFFER_BITS);
         format.setStencilBufferSize(DEFAULT_GL_STENCIL_BUFFER_BITS);
-        format.setVersion(4, 1);
+        format.setVersion(4, 5);
 #ifdef DEBUG
         format.setOption(QSurfaceFormat::DebugContext);
 #endif
@@ -27,7 +27,7 @@ const QGLFormat& getDefaultGLFormat() {
     static QGLFormat glFormat;
     static std::once_flag once;
     std::call_once(once, [] {
-        glFormat.setVersion(4, 1);
+        glFormat.setVersion(4, 5);
         glFormat.setProfile(QGLFormat::CoreProfile); // Requires >=Qt-4.8.0
         glFormat.setSampleBuffers(false);
         glFormat.setDepth(false);

--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -83,3 +83,8 @@ void OffscreenGLCanvas::doneCurrent() {
 QObject* OffscreenGLCanvas::getContextObject() {
     return _context;
 }
+
+void OffscreenGLCanvas::moveToThreadWithContext(QThread* thread) {
+    moveToThread(thread);
+    _context->moveToThread(thread);
+}

--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -26,6 +26,7 @@ public:
     bool create(QOpenGLContext* sharedContext = nullptr);
     bool makeCurrent();
     void doneCurrent();
+    void moveToThreadWithContext(QThread* thread);
     QOpenGLContext* getContext() {
         return _context;
     }

--- a/libraries/gl/src/gl/OglplusHelpers.h
+++ b/libraries/gl/src/gl/OglplusHelpers.h
@@ -37,7 +37,6 @@
 #include <oglplus/bound/framebuffer.hpp>
 #include <oglplus/bound/renderbuffer.hpp>
 #include <oglplus/shapes/wrapper.hpp>
-#include <oglplus/shapes/plane.hpp>
 
 #ifdef _WIN32
 #pragma warning(pop)
@@ -55,7 +54,9 @@ using ProgramPtr = std::shared_ptr<oglplus::Program>;
 using Mat4Uniform = oglplus::Uniform<mat4>;
 
 ProgramPtr loadDefaultShader();
+ProgramPtr loadCubemapShader();
 void compileProgram(ProgramPtr & result, const std::string& vs, const std::string& fs);
+ShapeWrapperPtr loadSkybox(ProgramPtr program);
 ShapeWrapperPtr loadPlane(ProgramPtr program, float aspect = 1.0f);
 ShapeWrapperPtr loadSphereSection(ProgramPtr program, float fov = PI / 3.0f * 2.0f, float aspect = 16.0f / 9.0f, int slices = 32, int stacks = 32);
     

--- a/libraries/gl/src/gl/QOpenGLContextWrapper.cpp
+++ b/libraries/gl/src/gl/QOpenGLContextWrapper.cpp
@@ -13,6 +13,9 @@
 
 #include <QOpenGLContext>
 
+QOpenGLContext* QOpenGLContextWrapper::currentContext() {
+    return QOpenGLContext::currentContext();
+}
 
 QOpenGLContextWrapper::QOpenGLContextWrapper() :
     _context(new QOpenGLContext)

--- a/libraries/gl/src/gl/QOpenGLContextWrapper.h
+++ b/libraries/gl/src/gl/QOpenGLContextWrapper.h
@@ -19,13 +19,14 @@ class QSurfaceFormat;
 class QOpenGLContextWrapper {
 public:
     QOpenGLContextWrapper();
-    
     void setFormat(const QSurfaceFormat& format);
     bool create();
     void swapBuffers(QSurface* surface);
     bool makeCurrent(QSurface* surface);
     void doneCurrent();
     void setShareContext(QOpenGLContext* otherContext);
+
+    static QOpenGLContext* currentContext();
 
     QOpenGLContext* getContext() {
         return _context;

--- a/libraries/gpu/src/gpu/GLBackend.cpp
+++ b/libraries/gpu/src/gpu/GLBackend.cpp
@@ -125,6 +125,7 @@ GLBackend::GLBackend() {
     glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &_uboAlignment);
     initInput();
     initTransform();
+    initTextureTransferHelper();
 }
 
 GLBackend::~GLBackend() {

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -24,6 +24,8 @@
 
 namespace gpu {
 
+class GLTextureTransferHelper;
+
 class GLBackend : public Backend {
 
     // Context Backend static interface required
@@ -35,7 +37,6 @@ class GLBackend : public Backend {
     explicit GLBackend(bool syncCache);
     GLBackend();
 public:
-
     virtual ~GLBackend();
 
     virtual void render(Batch& batch);
@@ -75,25 +76,63 @@ public:
 
     class GLTexture : public GPUObject {
     public:
-        Stamp _storageStamp;
-        Stamp _contentStamp;
-        GLuint _texture;
-        GLenum _target;
+        const Stamp _storageStamp;
+        Stamp _contentStamp { 0 };
+        const GLuint _texture;
+        const GLenum _target;
 
-        GLTexture();
+        GLTexture(const gpu::Texture& gpuTexture);
         ~GLTexture();
 
-        void setSize(GLuint size);
         GLuint size() const { return _size; }
 
+        enum SyncState {
+            // The texture is currently undergoing no processing, although it's content
+            // may be out of date, or it's storage may be invalid relative to the 
+            // owning GPU texture
+            Idle,
+            // The texture has been queued for transfer to the GPU
+            Pending,
+            // The texture has been transferred to the GPU, but is awaiting
+            // any post transfer operations that may need to occur on the 
+            // primary rendering thread
+            Transferred,
+        };
+
+        void setSyncState(SyncState syncState) { _syncState = syncState; }
+        SyncState getSyncState() const { return _syncState; }
+
+        // Is the storage out of date relative to the gpu texture?
+        bool invalid() const;
+
+        // Is the content out of date relative to the gpu texture?
+        bool outdated() const;
+
+        // Is the texture in a state where it can be rendered with no work?
+        bool ready() const;
+
+        // Move the image bits from the CPU to the GPU
+        void transfer() const;
+
+        // Execute any post-move operations that must occur only on the main thread
+        void postTransfer();
+
+        static const size_t CUBE_NUM_FACES = 6;
+        static const GLenum CUBE_FACE_LAYOUT[6];
+
     private:
-        GLuint _size;
+        void transferMip(GLenum target, const Texture::PixelsPointer& mip) const;
+
+        const GLuint _size;
+        // The owning texture
+        const Texture& _gpuTexture;
+        std::atomic<SyncState> _syncState { SyncState::Idle };
     };
-    static GLTexture* syncGPUObject(const Texture& texture);
+    static GLTexture* syncGPUObject(const TexturePointer& texture);
     static GLuint getTextureID(const TexturePointer& texture, bool sync = true);
 
     // very specific for now
-    static void syncSampler(const Sampler& sampler, Texture::Type type, GLTexture* object);
+    static void syncSampler(const Sampler& sampler, Texture::Type type, const GLTexture* object);
 
     class GLShader : public GPUObject {
     public:
@@ -240,6 +279,11 @@ public:
 protected:
     void renderPassTransfer(Batch& batch);
     void renderPassDraw(Batch& batch);
+
+    void initTextureTransferHelper();
+    static void transferGPUObject(const TexturePointer& texture);
+
+    static std::shared_ptr<GLTextureTransferHelper> _textureTransferHelper;
 
     // Draw Stage
     void do_draw(Batch& batch, size_t paramOffset);
@@ -484,6 +528,7 @@ protected:
 
     typedef void (GLBackend::*CommandCall)(Batch&, size_t);
     static CommandCall _commandCalls[Batch::NUM_COMMANDS];
+
 };
 
 };

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -103,13 +103,13 @@ public:
         SyncState getSyncState() const { return _syncState; }
 
         // Is the storage out of date relative to the gpu texture?
-        bool invalid() const;
+        bool isInvalid() const;
 
         // Is the content out of date relative to the gpu texture?
-        bool outdated() const;
+        bool isOutdated() const;
 
         // Is the texture in a state where it can be rendered with no work?
-        bool ready() const;
+        bool isReady() const;
 
         // Move the image bits from the CPU to the GPU
         void transfer() const;

--- a/libraries/gpu/src/gpu/GLBackendOutput.cpp
+++ b/libraries/gpu/src/gpu/GLBackendOutput.cpp
@@ -83,7 +83,7 @@ GLBackend::GLFramebuffer* GLBackend::syncGPUObject(const Framebuffer& framebuffe
                 for (auto& b : framebuffer.getRenderBuffers()) {
                     surface = b._texture;
                     if (surface) {
-                        gltexture = GLBackend::syncGPUObject(*surface);
+                        gltexture = GLBackend::syncGPUObject(surface);
                     } else {
                         gltexture = nullptr;
                     }
@@ -123,7 +123,7 @@ GLBackend::GLFramebuffer* GLBackend::syncGPUObject(const Framebuffer& framebuffe
         if (framebuffer.getDepthStamp() != object->_depthStamp) {
             auto surface = framebuffer.getDepthStencilBuffer();
             if (framebuffer.hasDepthStencil() && surface) {
-                gltexture = GLBackend::syncGPUObject(*surface);
+                gltexture = GLBackend::syncGPUObject(surface);
             }
     
             if (gltexture) {

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -255,7 +255,7 @@ void GLBackend::do_setResourceTexture(Batch& batch, size_t paramOffset) {
     _stats._RSNumTextureBounded++;
 
     // Always make sure the GLObject is in sync
-    GLTexture* object = GLBackend::syncGPUObject(*resourceTexture);
+    GLTexture* object = GLBackend::syncGPUObject(resourceTexture);
     if (object) {
         GLuint to = object->_texture;
         GLuint target = object->_target;

--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -9,19 +9,81 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 #include "GPULogging.h"
+
+#include <QtCore/QThread>
+
 #include "GLBackendShared.h"
 #include "GLTexelFormat.h"
+#include "GLBackendTextureTransfer.h"
 
 using namespace gpu;
 
-GLBackend::GLTexture::GLTexture() :
-    _storageStamp(0),
-    _contentStamp(0),
-    _texture(0),
-    _target(GL_TEXTURE_2D),
-    _size(0)
+GLenum gpuToGLTextureType(const Texture& texture) {
+    // If we get here, we need to allocate and or update the content of the texture
+    // or it's already being transferred
+    switch (texture.getType()) {
+    case Texture::TEX_2D:
+        return GL_TEXTURE_2D;
+        break;
+
+    case Texture::TEX_CUBE:
+        return GL_TEXTURE_CUBE_MAP;
+        break;
+
+    default:
+        qFatal("Unsupported texture type");
+    }
+    Q_UNREACHABLE();
+    return GL_TEXTURE_2D;
+}
+
+GLuint allocateSingleTexture() {
+    GLuint result;
+    glGenTextures(1, &result);
+    return result;
+}
+
+const GLenum GLBackend::GLTexture::CUBE_FACE_LAYOUT[6] = {
+    GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
+    GL_TEXTURE_CUBE_MAP_POSITIVE_Y, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
+    GL_TEXTURE_CUBE_MAP_POSITIVE_Z, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
+};
+
+// Create the texture and allocate storage
+GLBackend::GLTexture::GLTexture(const Texture& texture) : 
+    _storageStamp(texture.getStamp()), _texture(allocateSingleTexture()), 
+    _target(gpuToGLTextureType(texture)), _size((GLuint)texture.getSize()), _gpuTexture(texture) 
 {
     Backend::incrementTextureGPUCount();
+    Backend::updateTextureGPUMemoryUsage(0, _size);
+    Backend::setGPUObject(texture, this);
+
+    GLsizei width = texture.getWidth();
+    GLsizei height = texture.getHeight();
+    GLsizei levels = 1;
+    if (texture.maxMip() > 0) {
+        if (texture.isAutogenerateMips()) {
+            while ((width | height) >> levels) {
+                ++levels;
+            }
+        }
+        levels = std::max(1, std::min(texture.maxMip() + 1, levels));
+    }
+
+    GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat());
+    withPreservedTexture(_target, [&] {
+        glBindTexture(_target, _texture);
+        (void)CHECK_GL_ERROR();
+        // GO through the process of allocating the correct storage 
+        if (GLEW_VERSION_4_2) {
+            glTexStorage2D(_target, levels, texelFormat.internalFormat, width, height);
+        } else {
+            glTexImage2D(_target, 0, texelFormat.internalFormat, width, height, 0, texelFormat.format, texelFormat.type, 0);
+        }
+        (void)CHECK_GL_ERROR();
+        syncSampler(texture.getSampler(), texture.getType(), this);
+        (void)CHECK_GL_ERROR();
+    });
 }
 
 GLBackend::GLTexture::~GLTexture() {
@@ -32,199 +94,164 @@ GLBackend::GLTexture::~GLTexture() {
     Backend::decrementTextureGPUCount();
 }
 
-void GLBackend::GLTexture::setSize(GLuint size) {
-    Backend::updateTextureGPUMemoryUsage(_size, size);
-    _size = size;
+bool GLBackend::GLTexture::invalid() const {
+    return _storageStamp < _gpuTexture.getStamp();
 }
 
-GLBackend::GLTexture* GLBackend::syncGPUObject(const Texture& texture) {
-    GLTexture* object = Backend::getGPUObject<GLBackend::GLTexture>(texture);
+bool GLBackend::GLTexture::outdated() const {
+    return _contentStamp < _gpuTexture.getDataStamp();
+}
 
-    // If GPU object already created and in sync
-    bool needUpdate = false;
-    if (object && (object->_storageStamp == texture.getStamp())) {
-        // If gpu object info is in sync with sysmem version
-        if (object->_contentStamp >= texture.getDataStamp()) {
-            // Then all good, GPU object is ready to be used
-            return object;
-        } else {
-            // Need to update the content of the GPU object from the source sysmem of the texture
-            needUpdate = true;
-        }
-    } else if (!texture.isDefined()) {
+bool GLBackend::GLTexture::ready() const {
+    // If we have an invalid texture, we're never ready
+    if (invalid()) {
+        return false;
+    }
+
+    // If we're out of date, but the transfer is in progress, report ready
+    // as a special case
+    auto syncState = _syncState.load();
+
+    if (outdated()) {
+        return Pending == syncState;
+    }
+
+    return Idle == syncState;
+}
+
+//#define USE_PBO
+
+// Move content bits from the CPU to the GPU for a given mip / face
+void GLBackend::GLTexture::transferMip(GLenum target, const Texture::PixelsPointer& mip) const {
+    GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_gpuTexture.getTexelFormat(), mip->getFormat());
+#ifdef USE_PBO
+    GLuint pixelBufferID;
+    glGenBuffers(1, &pixelBufferID);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pixelBufferID);
+    //if (GLEW_VERSION_4_4) {
+    //    glBufferStorage(GL_PIXEL_UNPACK_BUFFER, mip->getSize(), nullptr, GL_STREAM_DRAW);
+    //} else {
+        glBufferData(GL_PIXEL_UNPACK_BUFFER, mip->getSize(), nullptr, GL_STREAM_DRAW);
+    //}
+    void* mappedBuffer = glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
+    memcpy(mappedBuffer, mip->readData(), mip->getSize());
+    //// use while PBO is still bound, assumes GL_TEXTURE_2D and offset 0
+    glTexSubImage2D(target, 0, 0, 0, _gpuTexture.getWidth(), _gpuTexture.getHeight(), texelFormat.format, texelFormat.type, 0);
+    glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    glDeleteBuffers(1, &pixelBufferID);
+#else
+    //glTexImage2D(target, 0, internalFormat, texture.getWidth(), texture.getHeight(), 0, texelFormat.format, texelFormat.type, bytes);
+    glTexSubImage2D(target, 0, 0, 0, _gpuTexture.getWidth(), _gpuTexture.getHeight(), texelFormat.format, texelFormat.type, mip->readData());
+    (void)CHECK_GL_ERROR();
+#endif
+}
+
+// Move content bits from the CPU to the GPU
+void GLBackend::GLTexture::transfer() const {
+    PROFILE_RANGE(__FUNCTION__);
+    qDebug() << "Transferring texture: " << _texture;
+    // Need to update the content of the GPU object from the source sysmem of the texture
+    if (_contentStamp >= _gpuTexture.getDataStamp()) {
+        return;
+    }
+
+    glBindTexture(_target, _texture);
+    // GO through the process of allocating the correct storage and/or update the content
+    switch (_gpuTexture.getType()) {
+        case Texture::TEX_2D:
+            if (_gpuTexture.isStoredMipFaceAvailable(0)) {
+                transferMip(GL_TEXTURE_2D, _gpuTexture.accessStoredMipFace(0));
+            }
+            break;
+
+        case Texture::TEX_CUBE:
+            // transfer pixels from each faces
+            for (int f = 0; f < CUBE_NUM_FACES; f++) {
+                if (_gpuTexture.isStoredMipFaceAvailable(0, f)) {
+                    transferMip(CUBE_FACE_LAYOUT[f], _gpuTexture.accessStoredMipFace(0, f));
+                }
+            }
+            break;
+
+        default:
+            qCWarning(gpulogging) << __FUNCTION__ << " case for Texture Type " << _gpuTexture.getType() << " not supported";
+            break;
+    }
+
+    if (_gpuTexture.isAutogenerateMips()) {
+        glGenerateMipmap(_target);
+        (void)CHECK_GL_ERROR();
+    }
+}
+
+// Do any post-transfer operations that might be required on the main context / rendering thread
+void GLBackend::GLTexture::postTransfer() {
+    setSyncState(GLTexture::Idle);
+    switch (_gpuTexture.getType()) {
+        case Texture::TEX_2D:
+            // At this point the mip piels have been loaded, we can notify
+            _gpuTexture.notifyMipFaceGPULoaded(0, 0);
+            break;
+
+        case Texture::TEX_CUBE:
+            for (uint8_t f = 0; f < CUBE_NUM_FACES; ++f) {
+                // At this point the mip piels have been loaded, we can notify
+                _gpuTexture.notifyMipFaceGPULoaded(0, f);
+            }
+            break;
+
+        default:
+            qCWarning(gpulogging) << __FUNCTION__ << " case for Texture Type " << _gpuTexture.getType() << " not supported";
+            break;
+    }
+}
+
+GLBackend::GLTexture* GLBackend::syncGPUObject(const TexturePointer& texturePointer) {
+    const Texture& texture = *texturePointer;
+    if (!texture.isDefined()) {
         // NO texture definition yet so let's avoid thinking
         return nullptr;
     }
 
+    // If the object hasn't been created, or the object definition is out of date, drop and re-create
+    GLTexture* object = Backend::getGPUObject<GLBackend::GLTexture>(texture);
+    if (object && object->ready()) {
+        return object;
+    }
+
+    // Object isn't ready, check what we need to do...
+    
+    // Create the texture if need be (force re-creation if the storage stamp changes
+    // for easier use of immutable storage)
+    if (!object || object->invalid()) {
+        // This automatically destroys the old texture
+        object = new GLTexture(texture);
+    }
+
     // need to have a gpu object?
-    if (!object) {
-        object = new GLTexture();
-        glGenTextures(1, &object->_texture);
-        (void) CHECK_GL_ERROR();
-        Backend::setGPUObject(texture, object);
+    if (texture.getNumSlices() != 1) {
+        return object;
     }
 
-    // GO through the process of allocating the correct storage and/or update the content
-    switch (texture.getType()) {
-    case Texture::TEX_2D: {
-        if (texture.getNumSlices() == 1) {
-            GLint boundTex = -1;
-            glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTex);
-            glBindTexture(GL_TEXTURE_2D, object->_texture);
-
-            if (needUpdate) {
-                if (texture.isStoredMipFaceAvailable(0)) {
-                    Texture::PixelsPointer mip = texture.accessStoredMipFace(0);
-                    const GLvoid* bytes = mip->readData();
-                    Element srcFormat = mip->getFormat();
-                
-                    GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
-
-                    glBindTexture(GL_TEXTURE_2D, object->_texture);
-                    glTexSubImage2D(GL_TEXTURE_2D, 0,
-                        texelFormat.internalFormat, texture.getWidth(), texture.getHeight(), 0,
-                        texelFormat.format, texelFormat.type, bytes);
-
-                    if (texture.isAutogenerateMips()) {
-                        glGenerateMipmap(GL_TEXTURE_2D);
-                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-                    }
-
-                object->_target = GL_TEXTURE_2D;
-
-                syncSampler(texture.getSampler(), texture.getType(), object);
-
-
-                    // At this point the mip piels have been loaded, we can notify
-                    texture.notifyMipFaceGPULoaded(0, 0);
-
-                    object->_contentStamp = texture.getDataStamp();
-                }
-            } else {
-                const GLvoid* bytes = 0;
-                Element srcFormat = texture.getTexelFormat();
-                if (texture.isStoredMipFaceAvailable(0)) {
-                    Texture::PixelsPointer mip = texture.accessStoredMipFace(0);
-                
-                    bytes = mip->readData();
-                    srcFormat = mip->getFormat();
-
-                    object->_contentStamp = texture.getDataStamp();
-                }
-
-                GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
-
-                glTexImage2D(GL_TEXTURE_2D, 0,
-                    texelFormat.internalFormat, texture.getWidth(), texture.getHeight(), 0,
-                    texelFormat.format, texelFormat.type, bytes);
-
-                if (bytes && texture.isAutogenerateMips()) {
-                    glGenerateMipmap(GL_TEXTURE_2D);
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-                }
-                object->_target = GL_TEXTURE_2D;
-
-                syncSampler(texture.getSampler(), texture.getType(), object);
-                
-                // At this point the mip pixels have been loaded, we can notify
-                texture.notifyMipFaceGPULoaded(0, 0);
-
-                object->_storageStamp = texture.getStamp();
-                object->_contentStamp = texture.getDataStamp();
-                object->setSize((GLuint)texture.getSize());
-            }
-
-            glBindTexture(GL_TEXTURE_2D, boundTex);
-        }
-        break;
+    // Object might be outdated, if so, start the transfer
+    // (outdated objects that are already in transfer will have reported 'true' for ready()
+    if (object->outdated()) {
+        _textureTransferHelper->transferTexture(texturePointer);
     }
-    case Texture::TEX_CUBE: {
-        if (texture.getNumSlices() == 1) {
-            GLint boundTex = -1;
-            glGetIntegerv(GL_TEXTURE_BINDING_CUBE_MAP, &boundTex);
-            glBindTexture(GL_TEXTURE_CUBE_MAP, object->_texture);
-            const int NUM_FACES = 6;
-            const GLenum FACE_LAYOUT[] = {
-                 GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
-                 GL_TEXTURE_CUBE_MAP_POSITIVE_Y, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                 GL_TEXTURE_CUBE_MAP_POSITIVE_Z, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z };
-            if (needUpdate) {
-                glBindTexture(GL_TEXTURE_CUBE_MAP, object->_texture);
 
-                // transfer pixels from each faces
-                for (int f = 0; f < NUM_FACES; f++) {
-                    if (texture.isStoredMipFaceAvailable(0, f)) {
-                        Texture::PixelsPointer mipFace = texture.accessStoredMipFace(0, f);
-                        Element srcFormat = mipFace->getFormat();
-                        GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
-
-                        glTexSubImage2D(FACE_LAYOUT[f], 0, texelFormat.internalFormat, texture.getWidth(), texture.getWidth(), 0,
-                                texelFormat.format, texelFormat.type, (GLvoid*) (mipFace->readData()));
-
-                        // At this point the mip pixels have been loaded, we can notify
-                        texture.notifyMipFaceGPULoaded(0, f);
-                    }
-                }
-
-                if (texture.isAutogenerateMips()) {
-                    glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
-                    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-                }
-
-                object->_target = GL_TEXTURE_CUBE_MAP;
-
-                syncSampler(texture.getSampler(), texture.getType(), object);
-
-                object->_contentStamp = texture.getDataStamp();
-
-            } else {
-                glBindTexture(GL_TEXTURE_CUBE_MAP, object->_texture);
-
-                // transfer pixels from each faces
-                for (int f = 0; f < NUM_FACES; f++) {
-                    if (texture.isStoredMipFaceAvailable(0, f)) {
-                        Texture::PixelsPointer mipFace = texture.accessStoredMipFace(0, f);
-                        Element srcFormat = mipFace->getFormat();
-                        GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(texture.getTexelFormat(), srcFormat);
-
-                        glTexImage2D(FACE_LAYOUT[f], 0, texelFormat.internalFormat, texture.getWidth(), texture.getWidth(), 0,
-                                texelFormat.format, texelFormat.type, (GLvoid*) (mipFace->readData()));
-
-                        // At this point the mip pixels have been loaded, we can notify
-                        texture.notifyMipFaceGPULoaded(0, f);
-                    }
-                }
-
-                if (texture.isAutogenerateMips()) {
-                    glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
-                    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-                } else {
-                    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-                    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-                }
-                
-                object->_target = GL_TEXTURE_CUBE_MAP;
-
-                syncSampler(texture.getSampler(), texture.getType(), object);
-
-                object->_storageStamp = texture.getStamp();
-                object->_contentStamp = texture.getDataStamp();
-                object->setSize((GLuint)texture.getSize());
-            }
-
-            glBindTexture(GL_TEXTURE_CUBE_MAP, boundTex);
-        }
-        break;
+    if (GLTexture::Transferred == object->getSyncState()) {
+        object->postTransfer();
     }
-    default:
-        qCDebug(gpulogging) << "GLBackend::syncGPUObject(const Texture&) case for Texture Type " << texture.getType() << " not supported";    
-    }
-    (void) CHECK_GL_ERROR();
 
     return object;
 }
 
+std::shared_ptr<GLTextureTransferHelper> GLBackend::_textureTransferHelper;
 
+void GLBackend::initTextureTransferHelper() {
+    _textureTransferHelper = std::make_shared<GLTextureTransferHelper>();
+}
 
 GLuint GLBackend::getTextureID(const TexturePointer& texture, bool sync) {
     if (!texture) {
@@ -232,7 +259,7 @@ GLuint GLBackend::getTextureID(const TexturePointer& texture, bool sync) {
     }
     GLTexture* object { nullptr };
     if (sync) {
-        object = GLBackend::syncGPUObject(*texture);
+        object = GLBackend::syncGPUObject(texture);
     } else {
         object = Backend::getGPUObject<GLBackend::GLTexture>(*texture);
     }
@@ -243,38 +270,37 @@ GLuint GLBackend::getTextureID(const TexturePointer& texture, bool sync) {
     }
 }
 
-void GLBackend::syncSampler(const Sampler& sampler, Texture::Type type, GLTexture* object) {
+void GLBackend::syncSampler(const Sampler& sampler, Texture::Type type, const GLTexture* object) {
     if (!object) return;
-    if (!object->_texture) return;
 
     class GLFilterMode {
     public:
         GLint minFilter;
         GLint magFilter;
     };
-    static const GLFilterMode filterModes[] = {   
-        {GL_NEAREST,      GL_NEAREST},  //FILTER_MIN_MAG_POINT,
-        {GL_NEAREST,       GL_LINEAR},  //FILTER_MIN_POINT_MAG_LINEAR,
-        {GL_LINEAR,      GL_NEAREST},  //FILTER_MIN_LINEAR_MAG_POINT,
-        {GL_LINEAR,       GL_LINEAR},  //FILTER_MIN_MAG_LINEAR,
- 
-        {GL_NEAREST_MIPMAP_NEAREST,      GL_NEAREST},  //FILTER_MIN_MAG_MIP_POINT,
-        {GL_NEAREST_MIPMAP_NEAREST,      GL_NEAREST},  //FILTER_MIN_MAG_MIP_POINT,
-        {GL_NEAREST_MIPMAP_LINEAR,       GL_NEAREST},  //FILTER_MIN_MAG_POINT_MIP_LINEAR,
-        {GL_NEAREST_MIPMAP_NEAREST,      GL_LINEAR},  //FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,
-        {GL_NEAREST_MIPMAP_LINEAR,       GL_LINEAR},  //FILTER_MIN_POINT_MAG_MIP_LINEAR,
-        {GL_LINEAR_MIPMAP_NEAREST,       GL_NEAREST},  //FILTER_MIN_LINEAR_MAG_MIP_POINT,
-        {GL_LINEAR_MIPMAP_LINEAR,        GL_NEAREST},  //FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,
-        {GL_LINEAR_MIPMAP_NEAREST,       GL_LINEAR},  //FILTER_MIN_MAG_LINEAR_MIP_POINT,
-        {GL_LINEAR_MIPMAP_LINEAR,        GL_LINEAR},  //FILTER_MIN_MAG_MIP_LINEAR,
-        {GL_LINEAR_MIPMAP_LINEAR,        GL_LINEAR}  //FILTER_ANISOTROPIC,
+    static const GLFilterMode filterModes[] = {
+        { GL_NEAREST, GL_NEAREST },  //FILTER_MIN_MAG_POINT,
+        { GL_NEAREST, GL_LINEAR },  //FILTER_MIN_POINT_MAG_LINEAR,
+        { GL_LINEAR, GL_NEAREST },  //FILTER_MIN_LINEAR_MAG_POINT,
+        { GL_LINEAR, GL_LINEAR },  //FILTER_MIN_MAG_LINEAR,
+
+        { GL_NEAREST_MIPMAP_NEAREST, GL_NEAREST },  //FILTER_MIN_MAG_MIP_POINT,
+        { GL_NEAREST_MIPMAP_NEAREST, GL_NEAREST },  //FILTER_MIN_MAG_MIP_POINT,
+        { GL_NEAREST_MIPMAP_LINEAR, GL_NEAREST },  //FILTER_MIN_MAG_POINT_MIP_LINEAR,
+        { GL_NEAREST_MIPMAP_NEAREST, GL_LINEAR },  //FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,
+        { GL_NEAREST_MIPMAP_LINEAR, GL_LINEAR },  //FILTER_MIN_POINT_MAG_MIP_LINEAR,
+        { GL_LINEAR_MIPMAP_NEAREST, GL_NEAREST },  //FILTER_MIN_LINEAR_MAG_MIP_POINT,
+        { GL_LINEAR_MIPMAP_LINEAR, GL_NEAREST },  //FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,
+        { GL_LINEAR_MIPMAP_NEAREST, GL_LINEAR },  //FILTER_MIN_MAG_LINEAR_MIP_POINT,
+        { GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR },  //FILTER_MIN_MAG_MIP_LINEAR,
+        { GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR }  //FILTER_ANISOTROPIC,
     };
 
     auto fm = filterModes[sampler.getFilter()];
     glTexParameteri(object->_target, GL_TEXTURE_MIN_FILTER, fm.minFilter);
     glTexParameteri(object->_target, GL_TEXTURE_MAG_FILTER, fm.magFilter);
 
-    static const GLenum comparisonFuncs[] = { 
+    static const GLenum comparisonFuncs[] = {
         GL_NEVER,
         GL_LESS,
         GL_EQUAL,
@@ -291,7 +317,7 @@ void GLBackend::syncSampler(const Sampler& sampler, Texture::Type type, GLTextur
         glTexParameteri(object->_target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
     }
 
-    static const GLenum wrapModes[] = {   
+    static const GLenum wrapModes[] = {
         GL_REPEAT,                         // WRAP_REPEAT,
         GL_MIRRORED_REPEAT,                // WRAP_MIRROR,
         GL_CLAMP_TO_EDGE,                  // WRAP_CLAMP,
@@ -302,15 +328,12 @@ void GLBackend::syncSampler(const Sampler& sampler, Texture::Type type, GLTextur
     glTexParameteri(object->_target, GL_TEXTURE_WRAP_T, wrapModes[sampler.getWrapModeV()]);
     glTexParameteri(object->_target, GL_TEXTURE_WRAP_R, wrapModes[sampler.getWrapModeW()]);
 
-    glTexParameterfv(object->_target, GL_TEXTURE_BORDER_COLOR, (const float*) &sampler.getBorderColor());
+    glTexParameterfv(object->_target, GL_TEXTURE_BORDER_COLOR, (const float*)&sampler.getBorderColor());
     glTexParameteri(object->_target, GL_TEXTURE_BASE_LEVEL, sampler.getMipOffset());
-    glTexParameterf(object->_target, GL_TEXTURE_MIN_LOD, (float) sampler.getMinMip());
+    glTexParameterf(object->_target, GL_TEXTURE_MIN_LOD, (float)sampler.getMinMip());
     glTexParameterf(object->_target, GL_TEXTURE_MAX_LOD, (sampler.getMaxMip() == Sampler::MAX_MIP_LEVEL ? 1000.f : sampler.getMaxMip()));
     glTexParameterf(object->_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, sampler.getMaxAnisotropy());
-
 }
-
-
 
 void GLBackend::do_generateTextureMips(Batch& batch, size_t paramOffset) {
     TexturePointer resourceTexture = batch._textures.get(batch._params[paramOffset + 0]._uint);
@@ -318,7 +341,7 @@ void GLBackend::do_generateTextureMips(Batch& batch, size_t paramOffset) {
         return;
     }
 
-    GLTexture* object = GLBackend::syncGPUObject(*resourceTexture);
+    GLTexture* object = GLBackend::syncGPUObject(resourceTexture);
     if (!object) {
         return;
     }
@@ -333,7 +356,7 @@ void GLBackend::do_generateTextureMips(Batch& batch, size_t paramOffset) {
 
     if (freeSlot < 0) {
         // If had to use slot 0 then restore state
-        GLTexture* boundObject = GLBackend::syncGPUObject(*_resource._textures[0]);
+        GLTexture* boundObject = GLBackend::syncGPUObject(_resource._textures[0]);
         if (boundObject) {
             glBindTexture(boundObject->_target, boundObject->_texture);
         }

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
@@ -1,0 +1,109 @@
+//
+//  Created by Bradley Austin Davis on 2016/04/03
+//  Copyright 2013-2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "GLBackendTextureTransfer.h"
+
+#include "GLBackendShared.h"
+#include "GLTexelFormat.h"
+
+#ifdef THREADED_TEXTURE_TRANSFER
+#include <gl/OffscreenGLCanvas.h>
+#include <gl/OglplusHelpers.h>
+#include <gl/QOpenGLContextWrapper.h>
+#endif
+
+using namespace gpu;
+
+static ProgramPtr _program;
+static ProgramPtr _cubeProgram;
+static ShapeWrapperPtr _plane;
+static ShapeWrapperPtr _skybox;
+static BasicFramebufferWrapperPtr _framebuffer;
+
+GLTextureTransferHelper::GLTextureTransferHelper() {
+#ifdef THREADED_TEXTURE_TRANSFER
+    _canvas = std::make_shared<OffscreenGLCanvas>();
+    _canvas->create(QOpenGLContextWrapper::currentContext());
+    if (!_canvas->makeCurrent()) {
+        qFatal("Unable to create texture transfer context");
+    }
+    _canvas->doneCurrent();
+    initialize(true, QThread::LowPriority);
+    _canvas->moveToThreadWithContext(_thread);
+#endif
+}
+
+void GLTextureTransferHelper::transferTexture(const gpu::TexturePointer& texturePointer) {
+    GLBackend::GLTexture* object = Backend::getGPUObject<GLBackend::GLTexture>(*texturePointer);
+#ifdef THREADED_TEXTURE_TRANSFER
+    TextureTransferPackage package { texturePointer, glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0) };
+    glFlush();
+    object->setSyncState(GLBackend::GLTexture::Pending);
+    queueItem(package);
+#else
+    object->transfer();
+    object->postTransfer();
+#endif
+}
+
+void GLTextureTransferHelper::setup() {
+#ifdef THREADED_TEXTURE_TRANSFER
+    _canvas->makeCurrent();
+    _program = loadDefaultShader();
+    _plane = loadPlane(_program);
+    _cubeProgram = loadCubemapShader();
+    _skybox = loadSkybox(_cubeProgram);
+    _framebuffer = std::make_shared<BasicFramebufferWrapper>();
+    _framebuffer->Init({ 100, 100 });
+    _framebuffer->fbo.Bind(oglplus::FramebufferTarget::Draw);
+#endif
+}
+
+bool GLTextureTransferHelper::processQueueItems(const Queue& messages) {
+    for (auto package : messages) {
+        glWaitSync(package.fence, 0, GL_TIMEOUT_IGNORED);
+        glDeleteSync(package.fence);
+        TexturePointer texturePointer = package.texture.lock();
+        // Texture no longer exists, move on to the next
+        if (!texturePointer) {
+            continue;
+        }
+
+        GLBackend::GLTexture* object = Backend::getGPUObject<GLBackend::GLTexture>(*texturePointer);
+        object->transfer();
+
+        // Now force a draw using the texture
+        try {
+            switch (texturePointer->getType()) {
+                case Texture::TEX_2D:
+                    _program->Use();
+                    _plane->Use();
+                    _plane->Draw();
+                    break;
+
+                case Texture::TEX_CUBE:
+                    _cubeProgram->Use();
+                    _skybox->Use();
+                    _skybox->Draw();
+                    break;
+
+                default:
+                    qCWarning(gpulogging) << __FUNCTION__ << " case for Texture Type " << texturePointer->getType() << " not supported";
+                    break;
+            }
+        } catch (const std::runtime_error& error) {
+            qWarning() << "Failed to render texture on background thread: " << error.what();
+        }
+
+        glBindTexture(object->_target, 0);
+        glFinish();
+        object->_contentStamp = texturePointer->getDataStamp();
+        object->setSyncState(GLBackend::GLTexture::Transferred);
+    }
+    return true;
+}

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
@@ -1,0 +1,61 @@
+//
+//  Created by Bradley Austin Davis on 2016/04/03
+//  Copyright 2013-2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <GenericQueueThread.h>
+#include "GLBackendShared.h"
+
+#define THREADED_TEXTURE_TRANSFER
+
+class OffscreenGLCanvas;
+
+namespace gpu {
+
+struct TextureTransferPackage {
+    std::weak_ptr<Texture> texture;
+    GLsync fence;
+};
+
+class GLTextureTransferHelper : public GenericQueueThread<TextureTransferPackage> {
+public:
+    GLTextureTransferHelper();
+    void transferTexture(const gpu::TexturePointer& texturePointer);
+    void postTransfer(const gpu::TexturePointer& texturePointer);
+
+protected:
+    void setup() override;
+    bool processQueueItems(const Queue& messages) override;
+    void transferTextureSynchronous(const gpu::Texture& texture);
+
+private:
+    std::shared_ptr<OffscreenGLCanvas> _canvas;
+};
+
+template <typename F>
+void withPreservedTexture(GLenum target, F f) {
+    GLint boundTex = -1;
+    switch (target) {
+    case GL_TEXTURE_2D:
+        glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTex);
+        break;
+
+    case GL_TEXTURE_CUBE_MAP:
+        glGetIntegerv(GL_TEXTURE_BINDING_CUBE_MAP, &boundTex);
+        break;
+
+    default:
+        qFatal("Unsupported texture type");
+    }
+    (void)CHECK_GL_ERROR();
+
+    f();
+
+    glBindTexture(target, boundTex);
+    (void)CHECK_GL_ERROR();
+}
+
+}

--- a/libraries/gpu/src/gpu/GLTexelFormat.h
+++ b/libraries/gpu/src/gpu/GLTexelFormat.h
@@ -14,6 +14,9 @@ public:
     GLenum format;
     GLenum type;
 
+    static GLTexelFormat evalGLTexelFormat(const gpu::Element& dstFormat) {
+        return evalGLTexelFormat(dstFormat, dstFormat);
+    }
     static GLTexelFormat evalGLTexelFormat(const gpu::Element& dstFormat, const gpu::Element& srcFormat) {
         using namespace gpu;
         if (dstFormat != srcFormat) {

--- a/libraries/shared/src/GenericThread.cpp
+++ b/libraries/shared/src/GenericThread.cpp
@@ -46,6 +46,8 @@ void GenericThread::initialize(bool isThreaded, QThread::Priority priority) {
         _thread->start();
         
         _thread->setPriority(priority);
+    } else {
+        setup();
     }
 }
 
@@ -60,10 +62,16 @@ void GenericThread::terminate() {
             _thread->deleteLater();
             _thread = NULL;
         }
+    } else {
+        shutdown();
     }
 }
 
 void GenericThread::threadRoutine() {
+    if (_isThreaded) {
+        setup();
+    }
+
     while (!_stopThread) {
 
         // override this function to do whatever your class actually does, return false to exit thread early
@@ -78,8 +86,13 @@ void GenericThread::threadRoutine() {
         }
     }
 
-    // If we were on a thread, then quit our thread
-    if (_isThreaded && _thread) {
-        _thread->quit();
+    if (_isThreaded) {
+        shutdown();
+
+        // If we were on a thread, then quit our thread
+        if (_thread) {
+            _thread->quit();
+        }
     }
+    
 }

--- a/libraries/shared/src/GenericThread.h
+++ b/libraries/shared/src/GenericThread.h
@@ -33,9 +33,6 @@ public:
     /// Call to stop the thread
     void terminate();
 
-    /// Override this function to do whatever your class actually does, return false to exit thread early.
-    virtual bool process() = 0;
-
     virtual void terminating() { }; // lets your subclass know we're terminating, and it should respond appropriately
 
     bool isThreaded() const { return _isThreaded; }
@@ -48,6 +45,10 @@ signals:
     void finished();
 
 protected:
+    /// Override this function to do whatever your class actually does, return false to exit thread early.
+    virtual bool process() = 0;
+    virtual void setup() {};
+    virtual void shutdown() {};
 
     /// Locks all the resources of the thread.
     void lock() { _mutex.lock(); }


### PR DESCRIPTION
This moves the job of transferring of image data across the CPU/GPU boundary to a background thread / rendering context.

- MUST test on OSX to verify the legacy code path
