### PR TITLE
Fix for debugging on windows

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -107,12 +107,15 @@ elseif(WIN32)
   # add an executable that also has the icon itself and the configured rc file as resources
   add_executable(${TARGET_NAME} WIN32 ${INTERFACE_SRCS} ${QM} ${CONFIGURE_ICON_RC_OUTPUT})
 
-  add_custom_command(
-    TARGET ${TARGET_NAME}
-    POST_BUILD
-    COMMAND "mt.exe" -manifest "${CMAKE_CURRENT_SOURCE_DIR}/interface.exe.manifest" -inputresource:"$<TARGET_FILE:${TARGET_NAME}>"\;\#1 -outputresource:"$<TARGET_FILE:${TARGET_NAME}>"\;\#1
-    COMMENT "Adding OS version support manifest to exe"
-  )
+  if ( NOT DEV_BUILD )
+    add_custom_command(
+      TARGET ${TARGET_NAME}
+      POST_BUILD
+      COMMAND "mt.exe" -manifest "${CMAKE_CURRENT_SOURCE_DIR}/interface.exe.manifest" -inputresource:"$<TARGET_FILE:${TARGET_NAME}>"\;\#1 -outputresource:"$<TARGET_FILE:${TARGET_NAME}>"\;\#1
+      COMMENT "Adding OS version support manifest to exe"
+    )
+  endif()
+
 else()
   add_executable(${TARGET_NAME} ${INTERFACE_SRCS} ${QM})
 endif()


### PR DESCRIPTION
Only run mt.exe on the manifest in non development builds.