### PR TITLE
Application: fix for jittery hands when moving.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1470,10 +1470,6 @@ void Application::paintGL() {
     // update the avatar with a fresh HMD pose
     getMyAvatar()->updateFromHMDSensorMatrix(getHMDSensorPose());
 
-    // update sensorToWorldMatrix for camera and hand controllers
-    getMyAvatar()->updateSensorToWorldMatrix();
-
-
     auto lodManager = DependencyManager::get<LODManager>();
 
 
@@ -3405,6 +3401,9 @@ void Application::update(float deltaTime) {
             PROFILE_RANGE_EX("OtherAvatars", 0xffff00ff, (uint64_t)getActiveDisplayPlugin()->presentCount());
             avatarManager->updateOtherAvatars(deltaTime);
         }
+
+        // update sensorToWorldMatrix for camera and hand controllers
+        getMyAvatar()->updateSensorToWorldMatrix();
 
         qApp->updateMyAvatarLookAtPosition();
 


### PR DESCRIPTION
The issue was that the hands are sampled in sensor coordinates.
But when the avatar is moved via physics, the sensor to world matrix
must be updated to move the hands in the world by the correct amount.
These new hand positions are then computed before IK is performed.