### PR TITLE
Hold onto octree child after creation

### DIFF
--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -384,9 +384,10 @@ int Octree::readElementData(OctreeElementPointer destinationElement, const unsig
         // check the exists mask to see if we have a child to traverse into
 
         if (oneAtBit(childInBufferMask, childIndex)) {
-            if (!destinationElement->getChildAtIndex(childIndex)) {
+            auto childAt = destinationElement->getChildAtIndex(childIndex);
+            if (!childAt) {
                 // add a child at that index, if it doesn't exist
-                destinationElement->addChildAtIndex(childIndex);
+                childAt = destinationElement->addChildAtIndex(childIndex);
                 bool nodeIsDirty = destinationElement->isDirty();
                 if (nodeIsDirty) {
                     _isDirty = true;
@@ -394,8 +395,7 @@ int Octree::readElementData(OctreeElementPointer destinationElement, const unsig
             }
 
             // tell the child to read the subsequent data
-            int lowerLevelBytes = readElementData(destinationElement->getChildAtIndex(childIndex),
-                                      nodeData + bytesRead, bytesLeftToRead, args);
+            int lowerLevelBytes = readElementData(childAt, nodeData + bytesRead, bytesLeftToRead, args);
 
             bytesRead += lowerLevelBytes;
             bytesLeftToRead -= lowerLevelBytes;


### PR DESCRIPTION
- Hold onto octree element after creation so nothing can delete it before use.

---

#### Intent
Prevent a documented crash from trying to recurse into an empty element.
(See: https://app.asana.com/0/26225263936266/105096043004292.)

#### Testing

General smoke test. The original crash could not be reproduced, so just make sure things still work.