### PR TITLE
Don't release the Oculus plugin when disabling the plugin

### DIFF
--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -52,6 +52,16 @@ void OculusDisplayPlugin::customizeContext() {
 }
 
 void OculusDisplayPlugin::uncustomizeContext() {
+    using namespace oglplus;
+    
+    // Present a final black frame to the HMD
+    _compositeFramebuffer->Bound(FramebufferTarget::Draw, [] {
+        Context::ClearColor(0, 0, 0, 1);
+        Context::Clear().ColorBuffer();
+    });
+
+    hmdPresent();
+    
 #if (OVR_MAJOR_VERSION >= 6)
     _sceneFbo.reset();
 #endif

--- a/plugins/oculus/src/OculusHelpers.cpp
+++ b/plugins/oculus/src/OculusHelpers.cpp
@@ -90,12 +90,14 @@ ovrSession acquireOculusSession() {
 
 void releaseOculusSession() {
     Q_ASSERT(refCount > 0 && session);
+#if 0
     if (!--refCount) {
         qCDebug(oculus) << "oculus: zero refcount, shutdown SDK and session";
         ovr_Destroy(session);
         ovr_Shutdown();
         session = nullptr;
     }
+#endif
 }
 
 

--- a/plugins/oculus/src/OculusHelpers.cpp
+++ b/plugins/oculus/src/OculusHelpers.cpp
@@ -90,6 +90,8 @@ ovrSession acquireOculusSession() {
 
 void releaseOculusSession() {
     Q_ASSERT(refCount > 0 && session);
+    // HACK the Oculus runtime doesn't seem to play well with repeated shutdown / restart.
+    // So for now we'll just hold on to the session
 #if 0
     if (!--refCount) {
         qCDebug(oculus) << "oculus: zero refcount, shutdown SDK and session";


### PR DESCRIPTION
Currently we attempt to shut down the connection to the Oculus SDK when disabling the Oculus display plugin.  However, for whatever reason, this does not seem to work correctly.  The HMD never returns to Oculus home.  Further, subsequently re-enabling the SDK almost inevitably results in a crash.

This is an ugly interim solution to avoid this crash by simply not releasing the Oculus SDK connection and re-using the same 'session' from activation to activation.  It resolves the crash, but in the long run it's the wrong thing to do IMO.  However, since Oculus isn't very focused on multi-mode apps right now, I'm not sure there core support for turning the SDK off and on repeatedly is really there.  