### PR TITLE
Model: Toggling Physics > Draw Collision Hulls works again

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -434,6 +434,8 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
                 _showCollisionHull = shouldShowCollisionHull;
                 render::PendingChanges pendingChanges;
 
+                _model->removeFromScene(scene, pendingChanges);
+
                 render::Item::Status::Getters statusGetters;
                 makeEntityItemStatusGetters(getThisPointer(), statusGetters);
                 _model->addToScene(scene, pendingChanges, statusGetters, _showCollisionHull);


### PR DESCRIPTION
Collision renderItems were never getting removed when shouldShowCollisionHull became false.