### PR TITLE
Log about webengine remote debugging

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -38,6 +38,8 @@
 
 #include <QtMultimedia/QMediaPlayer>
 
+#include <QProcessEnvironment>
+
 #include <gl/QOpenGLContextWrapper.h>
 
 #include <ResourceScriptingInterface.h>
@@ -1120,6 +1122,11 @@ void Application::aboutToQuit() {
 }
 
 void Application::cleanupBeforeQuit() {
+    // add a logline indicating if QTWEBENGINE_REMOTE_DEBUGGING is set or not
+    QProcessEnvironment env;
+    bool webengineRemoteDebuggingSet = env.keys().contains("QTWEBENGINE_REMOTE_DEBUGGING");
+    qCDebug(interfaceapp) << "QTWEBENGINE_REMOTE_DEBUGGING =" << webengineRemoteDebuggingSet;
+
     // Stop third party processes so that they're not left running in the event of a subsequent shutdown crash.
 #ifdef HAVE_DDE
     DependencyManager::get<DdeFaceTracker>()->setEnabled(false);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1122,10 +1122,9 @@ void Application::aboutToQuit() {
 }
 
 void Application::cleanupBeforeQuit() {
-    // add a logline indicating if QTWEBENGINE_REMOTE_DEBUGGING is set or not.
-    QProcessEnvironment env;
-    bool webengineRemoteDebuggingSet = env.keys().contains("QTWEBENGINE_REMOTE_DEBUGGING");
-    qCDebug(interfaceapp) << "QTWEBENGINE_REMOTE_DEBUGGING =" << webengineRemoteDebuggingSet;
+    // add a logline indicating if QTWEBENGINE_REMOTE_DEBUGGING is set or not
+    QString webengineRemoteDebugging = QProcessEnvironment::systemEnvironment().value("QTWEBENGINE_REMOTE_DEBUGGING", "false");
+    qCDebug(interfaceapp) << "QTWEBENGINE_REMOTE_DEBUGGING =" << webengineRemoteDebugging;
 
     // Stop third party processes so that they're not left running in the event of a subsequent shutdown crash.
 #ifdef HAVE_DDE

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1122,7 +1122,7 @@ void Application::aboutToQuit() {
 }
 
 void Application::cleanupBeforeQuit() {
-    // add a logline indicating if QTWEBENGINE_REMOTE_DEBUGGING is set or not
+    // add a logline indicating if QTWEBENGINE_REMOTE_DEBUGGING is set or not.
     QProcessEnvironment env;
     bool webengineRemoteDebuggingSet = env.keys().contains("QTWEBENGINE_REMOTE_DEBUGGING");
     qCDebug(interfaceapp) << "QTWEBENGINE_REMOTE_DEBUGGING =" << webengineRemoteDebuggingSet;


### PR DESCRIPTION
- log a line about the contents of QTWEBENGINE_REMOTE_DEBUGGING before exiting
