### PR TITLE
Fix showDesktop SIGNAL

### DIFF
--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -447,7 +447,7 @@ void OffscreenUi::createDesktop(const QUrl& url) {
 
     new KeyboardFocusHack();
 
-    connect(_desktop, SIGNAL(showDesktop()), this, SLOT(showDesktop()));
+    connect(_desktop, SIGNAL(showDesktop()), this, SIGNAL(showDesktop()));
 }
 
 QQuickItem* OffscreenUi::getDesktop() {


### PR DESCRIPTION

- Fixes the connection between `OffscreenUi::_desktop::showDesktop` and `OffscreenUi::showDesktop`.

Qt was not registering this because OffscreenUi::showDesktop is a SIGNAL, not a SLOT.

#### Testing

General smoke test.