### PR TITLE
Do not warn if no bookmarks file

### DIFF
--- a/interface/src/Bookmarks.cpp
+++ b/interface/src/Bookmarks.cpp
@@ -63,6 +63,11 @@ bool Bookmarks::contains(const QString& name) const {
 void Bookmarks::readFromFile() {
     QFile loadFile(_bookmarksFilename);
 
+    if (!loadFile.exists()) {
+        // User has not yet saved bookmarks
+        return;
+    }
+
     if (!loadFile.open(QIODevice::ReadOnly)) {
         qWarning("Couldn't open bookmarks file for reading");
         return;


### PR DESCRIPTION

- Skips warning on failure to open a bookmarks file if none exists.

#### Testing

Make sure you have no bookmarks file. Then, start up Interface.
In current build, you will get a warning, "Couldn't open bookmarks file for reading".
In this PR build, you will not.