### PR TITLE
Avoid warning for expected unset PresentThread

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -245,8 +245,10 @@ bool OpenGLDisplayPlugin::activate() {
 
 #if THREADED_PRESENT
     // Start the present thread if necessary
-    auto presentThread = DependencyManager::get<PresentThread>();
-    if (!presentThread) {
+    QSharedPointer<PresentThread> presentThread;
+    if (DependencyManager::isSet<PresentThread>()) {
+        presentThread = DependencyManager::get<PresentThread>();
+    } else {
         auto widget = _container->getPrimaryWidget();
         DependencyManager::set<PresentThread>();
         presentThread = DependencyManager::get<PresentThread>();

--- a/libraries/shared/src/DependencyManager.h
+++ b/libraries/shared/src/DependencyManager.h
@@ -49,6 +49,9 @@ public:
     template<typename T>
     static QSharedPointer<T> get();
     
+    template<typename T>
+    static bool isSet();
+    
     template<typename T, typename ...Args>
     static QSharedPointer<T> set(Args&&... args);
 
@@ -87,6 +90,14 @@ QSharedPointer<T> DependencyManager::get() {
     }
     
     return instance.toStrongRef();
+}
+
+template <typename T>
+bool DependencyManager::isSet() {
+    static size_t hashCode = manager().getHashCode<T>();
+
+    QSharedPointer<Dependency>& instance = manager().safeGet(hashCode);
+    return !instance.isNull();
 }
 
 template <typename T, typename ...Args>


### PR DESCRIPTION

- Add an `isSet` method to the `DependencyManager`
- Use `isSet` when initializing the `PresentThread` to avoid unnecessary warning

Adds a method to circumvent a warning where getting the present thread failed, even if you are only getting it to see if it exists. Does so by adding an `isSet` method to see if it exists (so the warning will still trigger if you use `get` and it DNE).

#### Testing

General smoke test on multiple devices (Oculus, Vive, Desktop).
In current PR build, you will *always* get a warning when you start a new device as its present thread is created.
In this PR build, you will only get a warning if something goes wrong.