### PR TITLE
Log failed MenuUserData::forObject

### DIFF
--- a/libraries/ui/src/VrMenu.cpp
+++ b/libraries/ui/src/VrMenu.cpp
@@ -43,6 +43,11 @@ public:
         auto result = static_cast<MenuUserData*>(object->userData(USER_DATA_ID));
         if (!result) {
             qWarning() << "Unable to find MenuUserData for object " << object;
+            if (auto action = dynamic_cast<QAction*>(object)) {
+                qWarning() << action->text();
+            } else if (auto menu = dynamic_cast<QMenu*>(object)) {
+                qWarning() << menu->title();
+            }
             return nullptr;
         }
         return result;


### PR DESCRIPTION
- Improve logging for failed MenuUserData lookup.

#### Testing

Lots of this fails (with no ill effect, AFAIK), so you can test this by looking at your logs on startup.
In current build, you will see lots of "Unable to find MenuUserData for object <OBJECT_TYPE>", all in a row.
In this PR build, you will see the same, but after every log of this, it will tell you the text or title of the failed action/menu item.