### PR TITLE
Fix AssignmentClient unpacking an assignment when it already has one

### DIFF
--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -235,6 +235,11 @@ void AssignmentClient::sendAssignmentRequest() {
 void AssignmentClient::handleCreateAssignmentPacket(QSharedPointer<ReceivedMessage> message) {
     qCDebug(assigmnentclient) << "Received a PacketType::CreateAssignment - attempting to unpack.";
 
+    if (_currentAssignment) {
+        qCWarning(assigmnentclient) << "Received a PacketType::CreateAssignment while still running an active assignment. Ignoring.";
+        return;
+    }
+
     // construct the deployed assignment from the packet data
     _currentAssignment = AssignmentFactory::unpackAssignment(*message);
 


### PR DESCRIPTION
There was an issue where multiple AssignmentClient objects could be created on a single AC.