### PR TITLE
Application: change keyboard input focus when using ui overlay.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2564,6 +2564,15 @@ void Application::idle(uint64_t now) {
         _overlayConductor.setEnabled(Menu::getInstance()->isOptionChecked(MenuOption::Overlays));
     }
 
+    // If the offscreen Ui has something active that is NOT the root, then assume it has keyboard focus.
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    if (_keyboardDeviceHasFocus && offscreenUi && offscreenUi->getWindow()->activeFocusItem() != offscreenUi->getRootItem()) {
+        _keyboardMouseDevice->pluginFocusOutEvent();
+        _keyboardDeviceHasFocus = false;
+    } else if (offscreenUi && offscreenUi->getWindow()->activeFocusItem() == offscreenUi->getRootItem()) {
+        _keyboardDeviceHasFocus = true;
+    }
+
     auto displayPlugin = getActiveDisplayPlugin();
     // depending on whether we're throttling or not.
     // Once rendering is off on another thread we should be able to have Application::idle run at start(0) in

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -518,6 +518,8 @@ private:
     std::mutex _preRenderLambdasLock;
 
     std::atomic<uint32_t> _processOctreeStatsCounter { 0 };
+
+    bool _keyboardDeviceHasFocus { true };
 };
 
 #endif // hifi_Application_h


### PR DESCRIPTION
call focusOutEvent on keyboard input plugin when an offscreen ui has activeFocus.