### PR TITLE
Add rolled log files to BugSplat

### DIFF
--- a/interface/src/FileLogger.cpp
+++ b/interface/src/FileLogger.cpp
@@ -24,8 +24,9 @@
 static const QString FILENAME_FORMAT = "hifi-log_%1_%2.txt";
 static const QString DATETIME_FORMAT = "yyyy-MM-dd_hh.mm.ss";
 static const QString LOGS_DIRECTORY = "Logs";
-// Max log size is 1 MB
-static const qint64 MAX_LOG_SIZE = 1024 * 1024;
+// Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
+// small so it doesn't go over the 2MB zipped limit for all of the files we send.
+static const qint64 MAX_LOG_SIZE = 512 * 1024;
 // Max log age is 1 hour
 static const uint64_t MAX_LOG_AGE_USECS = USECS_PER_SECOND * 3600;
 

--- a/interface/src/FileLogger.h
+++ b/interface/src/FileLogger.h
@@ -15,6 +15,8 @@
 #include "AbstractLoggerInterface.h"
 #include <GenericQueueThread.h>
 
+#include <QtCore/QFile>
+
 class FileLogger : public AbstractLoggerInterface {
     Q_OBJECT
 
@@ -27,10 +29,31 @@ public:
     virtual QString getLogData() override;
     virtual void locateLog() override;
 
+signals:
+    void rollingLogFile(QString newFilename);
+
 private:
     const QString _fileName;
     friend class FilePersistThread;
 };
+
+class FilePersistThread : public GenericQueueThread < QString > {
+    Q_OBJECT
+public:
+    FilePersistThread(const FileLogger& logger);
+
+signals:
+    void rollingLogFile(QString newFilename);
+
+protected:
+    void rollFileIfNecessary(QFile& file, bool notifyListenersIfRolled = true);
+    virtual bool processQueueItems(const Queue& messages);
+
+private:
+    const FileLogger& _logger;
+    uint64_t _lastRollTime;
+};
+
 
 
 

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -177,8 +177,14 @@ int main(int argc, const char* argv[]) {
         });
 
         // BugSplat WILL NOT work with file paths that do not use OS native separators.
-        auto logPath = QDir::toNativeSeparators(app.getLogger()->getFilename());
+        auto logger = app.getLogger();
+        auto logPath = QDir::toNativeSeparators(logger->getFilename());
         mpSender.sendAdditionalFile(qPrintable(logPath));
+
+        QObject::connect(logger, &FileLogger::rollingLogFile, &app, [&mpSender](QString newFilename) {
+            auto rolledLogPath = QDir::toNativeSeparators(newFilename);
+            mpSender.sendAdditionalFile(qPrintable(rolledLogPath));
+        });
 #endif
 
         printSystemInformation();

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -181,7 +181,11 @@ int main(int argc, const char* argv[]) {
         auto logPath = QDir::toNativeSeparators(logger->getFilename());
         mpSender.sendAdditionalFile(qPrintable(logPath));
 
-        QObject::connect(logger, &FileLogger::rollingLogFile, &app, [&mpSender](QString newFilename) {
+        QMetaObject::Connection connection;
+        connection = QObject::connect(logger, &FileLogger::rollingLogFile, &app, [&mpSender, &connection](QString newFilename) {
+            // We only want to add the first rolled log file (the "beginning" of the log) to BugSplat to ensure we don't exceed the 2MB
+            // zipped limit, so we disconnect here.
+            QObject::disconnect(connection);
             auto rolledLogPath = QDir::toNativeSeparators(newFilename);
             mpSender.sendAdditionalFile(qPrintable(rolledLogPath));
         });


### PR DESCRIPTION
Changes to logfile rolling to allow the first log file of a session to be included in the bugsplat in the event of a crash.