### PR TITLE
Move the texture transfer context back to the main thread for shutdown

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
@@ -77,6 +77,12 @@ void GLTextureTransferHelper::setup() {
 #endif
 }
 
+void GLTextureTransferHelper::shutdown() {
+    _canvas->doneCurrent();
+    _canvas->moveToThreadWithContext(qApp->thread());
+}
+
+
 bool GLTextureTransferHelper::processQueueItems(const Queue& messages) {
     for (auto package : messages) {
         glWaitSync(package.fence, 0, GL_TIMEOUT_IGNORED);

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
@@ -28,6 +28,7 @@ public:
 
 protected:
     void setup() override;
+    void shutdown() override;
     bool processQueueItems(const Queue& messages) override;
     void transferTextureSynchronous(const gpu::Texture& texture);
 


### PR DESCRIPTION
Failure to move the texture transfer GL context back to the main thread will cause an assertion error at shutdown.