### PR TITLE
Fix audio injectors not working

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -397,7 +397,7 @@ void Agent::processAgentAvatarAndAudio(float deltaTime) {
                 if (_numAvatarSoundSentBytes == soundByteArray.size()) {
                     // we're done with this sound object - so set our pointer back to NULL
                     // and our sent bytes back to zero
-                    _avatarSound = NULL;
+                    _avatarSound.clear();
                     _numAvatarSoundSentBytes = 0;
                 }
             }

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -56,7 +56,7 @@ public:
 
 public slots:
     void run();
-    void playAvatarSound(Sound* avatarSound) { setAvatarSound(avatarSound); }
+    void playAvatarSound(SharedSoundPointer avatarSound) { setAvatarSound(avatarSound); }
 
 private slots:
     void requestScript();
@@ -77,7 +77,7 @@ private:
     MixedAudioStream _receivedAudioStream;
     float _lastReceivedAudioLoudness;
 
-    void setAvatarSound(Sound* avatarSound) { _avatarSound = avatarSound; }
+    void setAvatarSound(SharedSoundPointer avatarSound) { _avatarSound = avatarSound; }
 
     void sendAvatarIdentityPacket();
     void sendAvatarBillboardPacket();
@@ -85,7 +85,7 @@ private:
     QString _scriptContents;
     QTimer* _scriptRequestTimeout { nullptr };
     bool _isListeningToAudioStream = false;
-    Sound* _avatarSound = nullptr;
+    SharedSoundPointer _avatarSound;
     int _numAvatarSoundSentBytes = 0;
     bool _isAvatar = false;
     QTimer* _avatarIdentityTimer = nullptr;

--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -32,8 +32,8 @@ AudioInjector::AudioInjector(QObject* parent) :
 
 }
 
-AudioInjector::AudioInjector(Sound* sound, const AudioInjectorOptions& injectorOptions) :
-    _audioData(sound->getByteArray()),
+AudioInjector::AudioInjector(const Sound& sound, const AudioInjectorOptions& injectorOptions) :
+    _audioData(sound.getByteArray()),
     _options(injectorOptions)
 {
 

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -45,7 +45,7 @@ public:
     };
     
     AudioInjector(QObject* parent);
-    AudioInjector(Sound* sound, const AudioInjectorOptions& injectorOptions);
+    AudioInjector(const Sound& sound, const AudioInjectorOptions& injectorOptions);
     AudioInjector(const QByteArray& audioData, const AudioInjectorOptions& injectorOptions);
     
     bool isFinished() const { return _state == State::Finished; }

--- a/libraries/audio/src/Sound.h
+++ b/libraries/audio/src/Sound.h
@@ -20,18 +20,16 @@
 
 class Sound : public Resource {
     Q_OBJECT
-    
-    Q_PROPERTY(bool downloaded READ isReady)
-    Q_PROPERTY(float duration READ getDuration)
+
 public:
     Sound(const QUrl& url, bool isStereo = false);
     
     bool isStereo() const { return _isStereo; }    
     bool isReady() const { return _isReady; }
-    float getDuration() { return _duration; }
+    float getDuration() const { return _duration; }
 
  
-    const QByteArray& getByteArray() { return _byteArray; }
+    const QByteArray& getByteArray() const { return _byteArray; }
 
 signals:
     void ready();
@@ -50,13 +48,28 @@ private:
 
 typedef QSharedPointer<Sound> SharedSoundPointer;
 
+class SoundScriptingInterface : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(bool downloaded READ isReady)
+    Q_PROPERTY(float duration READ getDuration)
+
+public:
+    SoundScriptingInterface(SharedSoundPointer sound);
+    SharedSoundPointer getSound() { return _sound; }
+
+    bool isReady() const { return _sound->isReady(); }
+    float getDuration() { return _sound->getDuration(); }
+
+signals:
+    void ready();
+
+private:
+    SharedSoundPointer _sound;
+};
+
 Q_DECLARE_METATYPE(SharedSoundPointer)
-QScriptValue soundSharedPointerToScriptValue(QScriptEngine* engine, SharedSoundPointer const& in);
-void soundSharedPointerFromScriptValue(const QScriptValue& object, SharedSoundPointer &out);
-
-Q_DECLARE_METATYPE(Sound*)
-QScriptValue soundPointerToScriptValue(QScriptEngine* engine, Sound* const& in);
-void soundPointerFromScriptValue(const QScriptValue& object, Sound* &out);
-
+QScriptValue soundSharedPointerToScriptValue(QScriptEngine* engine, const SharedSoundPointer& in);
+void soundSharedPointerFromScriptValue(const QScriptValue& object, SharedSoundPointer& out);
 
 #endif // hifi_Sound_h

--- a/libraries/script-engine/src/AudioScriptingInterface.cpp
+++ b/libraries/script-engine/src/AudioScriptingInterface.cpp
@@ -17,7 +17,6 @@
 void registerAudioMetaTypes(QScriptEngine* engine) {
     qScriptRegisterMetaType(engine, injectorOptionsToScriptValue, injectorOptionsFromScriptValue);
     qScriptRegisterMetaType(engine, soundSharedPointerToScriptValue, soundSharedPointerFromScriptValue);
-    qScriptRegisterMetaType(engine, soundPointerToScriptValue, soundPointerFromScriptValue);
 }
 
 AudioScriptingInterface& AudioScriptingInterface::getInstance() {
@@ -31,13 +30,14 @@ AudioScriptingInterface::AudioScriptingInterface() :
 
 }
 
-ScriptAudioInjector* AudioScriptingInterface::playSound(Sound* sound, const AudioInjectorOptions& injectorOptions) {
+ScriptAudioInjector* AudioScriptingInterface::playSound(SharedSoundPointer sound, const AudioInjectorOptions& injectorOptions) {
     if (QThread::currentThread() != thread()) {
         ScriptAudioInjector* injector = NULL;
 
         QMetaObject::invokeMethod(this, "playSound", Qt::BlockingQueuedConnection,
                                   Q_RETURN_ARG(ScriptAudioInjector*, injector),
-                                  Q_ARG(Sound*, sound), Q_ARG(const AudioInjectorOptions&, injectorOptions));
+                                  Q_ARG(SharedSoundPointer, sound),
+                                  Q_ARG(const AudioInjectorOptions&, injectorOptions));
         return injector;
     }
 

--- a/libraries/script-engine/src/AudioScriptingInterface.h
+++ b/libraries/script-engine/src/AudioScriptingInterface.h
@@ -27,7 +27,7 @@ public:
 
 protected:
     // this method is protected to stop C++ callers from calling, but invokable from script
-    Q_INVOKABLE ScriptAudioInjector* playSound(Sound* sound, const AudioInjectorOptions& injectorOptions = AudioInjectorOptions());
+    Q_INVOKABLE ScriptAudioInjector* playSound(SharedSoundPointer sound, const AudioInjectorOptions& injectorOptions = AudioInjectorOptions());
 
     Q_INVOKABLE void setStereoInput(bool stereo);
 


### PR DESCRIPTION
Made a SoundScriptingInterface object that wraps the sound shared pointer.
This has 2 benefits:
- Script object holds a strong reference to the sound.
- the Sound interface is fully detached from the sound object. 