### PR TITLE
Entities editor fixes

### DIFF
--- a/examples/html/edit-style.css
+++ b/examples/html/edit-style.css
@@ -252,6 +252,7 @@ input[type=number]::-webkit-inner-spin-button {
     display: block;
     position: relative;
     width: 10px;
+    height: 100%;
     overflow: hidden;
     font-family: hifi-glyphs;
     font-size: 50px;

--- a/examples/html/edit-style.css
+++ b/examples/html/edit-style.css
@@ -76,8 +76,10 @@ body {
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-}
 
+    overflow-x: hidden;
+    overflow-y: auto;
+}
 
 table {
     font-family: FiraSans-SemiBold;

--- a/examples/html/edit-style.css
+++ b/examples/html/edit-style.css
@@ -789,6 +789,7 @@ textarea:enabled[scrolling="true"]::-webkit-resizer {
     width: 100%;
     overflow-x: hidden;
     overflow-y: auto;
+    box-sizing: border-box;
     padding-top: 28px; /* Space for header and footer outside of scroll region. */
     margin-top: 28px;
     border-left: 2px solid #575757;
@@ -807,6 +808,7 @@ textarea:enabled[scrolling="true"]::-webkit-resizer {
 }
 
 #entity-table thead {
+    box-sizing: border-box;
     border: 2px solid #575757;
     border-top-left-radius: 7px;
     border-top-right-radius: 7px;
@@ -814,6 +816,7 @@ textarea:enabled[scrolling="true"]::-webkit-resizer {
 }
 
 #entity-table tfoot {
+    box-sizing: border-box;
     border: 2px solid #575757;
     border-bottom-left-radius: 7px;
     border-bottom-right-radius: 7px;

--- a/examples/html/edit-style.css
+++ b/examples/html/edit-style.css
@@ -231,11 +231,11 @@ input[type="text"] {
 input[type="number"] {
     position: relative;
     height: 28px;
-    width: 120px;
+    width: 124px;
 }
 
 input[type=number] {
-    padding-right: 6px;
+    padding-right: 3px;
 }
 input[type=number]::-webkit-inner-spin-button {
     -webkit-appearance: none;
@@ -657,7 +657,7 @@ div.refresh input[type="button"] {
     padding-left: 25px;
 }
 .pyr .tuple input {
-    padding-left: 45px;
+    padding-left: 40px;
 }
 
 .tuple div > label:first-child {

--- a/examples/html/edit-style.css
+++ b/examples/html/edit-style.css
@@ -12,7 +12,7 @@
     font-family: Raleway-Regular;
     src: url(../../resources/fonts/Raleway-Regular.ttf),  /* Windows production */
          url(../../fonts/Raleway-Regular.ttf),  /* OSX production */
-         url(../../interface/resources/fonts/Raleway-Regular.ttf);  /* Development */
+         url(../../interface/resources/fonts/Raleway-Regular.ttf);  /* Development, running script in /HiFi/examples */
 }
 
 @font-face {

--- a/examples/html/edit-style.css
+++ b/examples/html/edit-style.css
@@ -10,43 +10,50 @@
 
 @font-face {
     font-family: Raleway-Regular;
-    src: url(../../resources/fonts/Raleway-Regular.ttf),  /* Production */
+    src: url(../../resources/fonts/Raleway-Regular.ttf),  /* Windows production */
+         url(../../fonts/Raleway-Regular.ttf),  /* OSX production */
          url(../../interface/resources/fonts/Raleway-Regular.ttf);  /* Development */
 }
 
 @font-face {
     font-family: Raleway-Light;
     src: url(../../resources/fonts/Raleway-Light.ttf),
+         url(../../fonts/Raleway-Light.ttf),
          url(../../interface/resources/fonts/Raleway-Light.ttf);
 }
 
 @font-face {
     font-family: Raleway-Bold;
     src: url(../../resources/fonts/Raleway-Bold.ttf),
+         url(../../fonts/Raleway-Bold.ttf),
          url(../../interface/resources/fonts/Raleway-Bold.ttf);
 }
 
 @font-face {
     font-family: Raleway-SemiBold;
     src: url(../../resources/fonts/Raleway-SemiBold.ttf),
+         url(../../fonts/Raleway-SemiBold.ttf),
          url(../../interface/resources/fonts/Raleway-SemiBold.ttf);
 }
 
 @font-face {
     font-family: FiraSans-SemiBold;
     src: url(../../resources/fonts/FiraSans-SemiBold.ttf),
+         url(../../fonts/FiraSans-SemiBold.ttf),
          url(../../interface/resources/fonts/FiraSans-SemiBold.ttf);
 }
 
 @font-face {
     font-family: AnonymousPro-Regular;
-    src: url(../../resources/fonts/AnonymousPro-Regular.ttf), 
+    src: url(../../resources/fonts/AnonymousPro-Regular.ttf),
+         url(../../fonts/AnonymousPro-Regular.ttf),
          url(../../interface/resources/fonts/AnonymousPro-Regular.ttf);
 }
 
 @font-face {
     font-family: HiFi-Glyphs;
-    src: url(../../resources/fonts/hifi-glyphs.ttf), 
+    src: url(../../resources/fonts/hifi-glyphs.ttf),
+         url(../../fonts/hifi-glyphs.ttf),
          url(../../interface/resources/fonts/hifi-glyphs.ttf);
 }
 

--- a/examples/html/entityList.html
+++ b/examples/html/entityList.html
@@ -254,7 +254,7 @@
 
               function resize() {
                   // Take up available window space
-                  elEntityTableScroll.style.height = window.innerHeight - 232;
+                  elEntityTableScroll.style.height = window.innerHeight - 200;
 
                   // Update the widths of the header cells to match the body
                   var tds = document.querySelectorAll("#entity-table-body tr:first-child td");

--- a/interface/resources/qml/ToolWindow.qml
+++ b/interface/resources/qml/ToolWindow.qml
@@ -30,7 +30,7 @@ Window {
     title: "Edit"
     property alias tabView: tabView
     implicitWidth: 520; implicitHeight: 695
-    minSize: Qt.vector2d(400, 500)
+    minSize: Qt.vector2d(412, 500)
 
     HifiConstants { id: hifi }
 


### PR DESCRIPTION
- Fix display of large negative coordinates and angles (numbers were being obscured by spin buttons)
- Fix fonts on OSX (text was serif, letters were displaying instead of glyphs)
- Fix horizontal scrollbar appearing in entity properties tab on OSX (it shouldn't)
- Fix spin box buttons not appearing on OSX
- Fix right margin of entities list
