### PR TITLE
Fix intermittent crash on exit

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -71,8 +71,8 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
 }
 
 EntityTreeRenderer::~EntityTreeRenderer() {
-    // NOTE: we don't need to delete _entitiesScriptEngine because it is registered with the application and has a
-    // signal tied to call it's deleteLater on doneRunning
+    // NOTE: We don't need to delete _entitiesScriptEngine because
+    //       it is registered with ScriptEngines, which will call deleteLater for us.
 }
 
 void EntityTreeRenderer::clear() {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -154,8 +154,10 @@ ScriptEngine::~ScriptEngine() {
 
 void ScriptEngine::disconnectNonEssentialSignals() {
     disconnect();
-    if (_isRunning && _isThreaded) { // ensure the thread is running
-        connect(this, &ScriptEngine::doneRunning, thread(), &QThread::quit);
+    QThread* receiver;
+    // Ensure the thread should be running, and does exist
+    if (_isRunning && _isThreaded && (receiver = thread())) {
+        connect(this, &ScriptEngine::doneRunning, receiver, &QThread::quit);
     }
 }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -154,7 +154,9 @@ ScriptEngine::~ScriptEngine() {
 
 void ScriptEngine::disconnectNonEssentialSignals() {
     disconnect();
-    connect(this, &ScriptEngine::doneRunning, thread(), &QThread::quit);
+    if (_isRunning && _isThreaded) { // ensure the thread is running
+        connect(this, &ScriptEngine::doneRunning, thread(), &QThread::quit);
+    }
 }
 
 void ScriptEngine::runInThread() {


### PR DESCRIPTION
- Guard against a deleted entity scripting thread

---

#### Intent
Fixes an edge-case where the entity scripting engine has no thread affinity at cleanup, resulting in a crash during shutdown from trying to connect to a null thread.
(See: https://app.asana.com/0/74051501495175/106100688584166.)

#### Testing

I cannot reproduce this. It happens every few days, on random machines.
General smoke test. Quit and restart a lot (the crash is on exit).