### PR TITLE
Fixing logging errors on initial load of controller routes

### DIFF
--- a/interface/resources/controllers/standard_navigation.json
+++ b/interface/resources/controllers/standard_navigation.json
@@ -2,9 +2,6 @@
     "name": "Standard to Action",
     "when": "Application.NavigationFocused",
     "channels": [
-        { "disabled_from": { "makeAxis" : [ "Standard.DD", "Standard.DU" ] }, "to": "Actions.UiNavVertical" },
-        { "disabled_from": { "makeAxis" : [ "Standard.DL", "Standard.DR" ] }, "to": "Actions.UiNavLateral" },
-        { "disabled_from": { "makeAxis" : [ "Standard.LB", "Standard.RB" ] }, "to": "Actions.UiNavGroup" },
         { "from": "Standard.DU", "to": "Actions.UiNavVertical" },
         { "from": "Standard.DD", "to": "Actions.UiNavVertical", "filters": "invert" },
         { "from": "Standard.DL", "to": "Actions.UiNavLateral", "filters": "invert" },

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -33,8 +33,10 @@ static QVariantMap createDeviceMap(const controller::InputDevice::Pointer device
     for (const auto& inputMapping : userInputMapper->getAvailableInputs(device->getDeviceID())) {
         const auto& input = inputMapping.first;
         const auto inputName = QString(inputMapping.second).remove(SANITIZE_NAME_EXPRESSION);
+#ifdef DEBUG
         qCDebug(controllers) << "\tInput " << input.getChannel() << (int)input.getType()
             << QString::number(input.getID(), 16) << ": " << inputName;
+#endif
         deviceMap.insert(inputName, input.getID());
     }
     return deviceMap;

--- a/libraries/controllers/src/controllers/StateController.cpp
+++ b/libraries/controllers/src/controllers/StateController.cpp
@@ -28,7 +28,7 @@ void StateController::setStateVariables(const QStringList& newStateVariables) {
 StateController::StateController() : InputDevice("Application") {
     _deviceID = UserInputMapper::STANDARD_DEVICE;
     for (const auto& variable : stateVariables) {
-        _namedReadLambdas[variable] = [] { return 0; };
+        _namedReadLambdas[variable] = []()->float{ return 0; };
     }
 }
 

--- a/libraries/controllers/src/controllers/StateController.cpp
+++ b/libraries/controllers/src/controllers/StateController.cpp
@@ -26,7 +26,7 @@ void StateController::setStateVariables(const QStringList& newStateVariables) {
 }
 
 StateController::StateController() : InputDevice("Application") {
-    _deviceID = UserInputMapper::STANDARD_DEVICE;
+    _deviceID = UserInputMapper::STATE_DEVICE;
     for (const auto& variable : stateVariables) {
         _namedReadLambdas[variable] = []()->float{ return 0; };
     }
@@ -49,7 +49,9 @@ Input::NamedVector StateController::getAvailableInputs() const {
 }
 
 EndpointPointer StateController::createEndpoint(const Input& input) const {
-    return std::make_shared<LambdaEndpoint>(_namedReadLambdas[stateVariables[input.getChannel()]]);
+    auto name = stateVariables[input.getChannel()];
+    ReadLambda& readLambda = const_cast<QHash<QString, ReadLambda>&>(_namedReadLambdas)[name];
+    return std::make_shared<LambdaRefEndpoint>(readLambda);
 }
 
 }

--- a/libraries/controllers/src/controllers/StateController.h
+++ b/libraries/controllers/src/controllers/StateController.h
@@ -24,26 +24,28 @@ class StateController : public QObject, public InputDevice {
     Q_PROPERTY(QString name READ getName)
 
 public:
+    using Pointer = std::shared_ptr<StateController>;
+    using ReadLambda = std::function<float()>;
+    using NamedReadLambda = QPair<QString, ReadLambda>;
+
+    static void setStateVariables(const QStringList& stateVariables);
+
+    StateController();
+
     const QString& getName() const { return _name; }
 
     // Device functions
     virtual Input::NamedVector getAvailableInputs() const override;
-    virtual void update(float deltaTime, const InputCalibrationData& inputCalibrationData, bool jointsCaptured) override;
-    virtual void focusOutEvent() override;
 
-    StateController();
-    virtual ~StateController();
+    void update(float deltaTime, const InputCalibrationData& inputCalibrationData, bool jointsCaptured) override {}
+    void focusOutEvent() override {}
 
-    using ReadLambda = std::function<float()>;
-    using NamedReadLambda = QPair<QString, ReadLambda>;
+    void setInputVariant(const QString& name, ReadLambda lambda);
 
-    void addInputVariant(QString name, ReadLambda lambda);
-
-    virtual EndpointPointer createEndpoint(const Input& input) const override;
-
+    EndpointPointer createEndpoint(const Input& input) const override;
 
 protected:
-    QVector<NamedReadLambda> _namedReadLambdas;
+    QHash<QString, ReadLambda> _namedReadLambdas;
 };
 
 }

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -140,7 +140,6 @@ void UserInputMapper::loadDefaultMapping(uint16 deviceID) {
         return;
     }
 
-
     auto mapping = loadMappings(proxyEntry->second->getDefaultMappingConfigs());
     if (mapping) {
         auto prevMapping = _mappingsByDevice[deviceID];
@@ -705,6 +704,12 @@ Mapping::Pointer UserInputMapper::loadMapping(const QString& jsonFile, bool enab
     if (jsonFile.isEmpty()) {
         return Mapping::Pointer();
     }
+    // Each mapping only needs to be loaded once
+    static QSet<QString> loaded;
+    if (loaded.contains(jsonFile)) {
+        return Mapping::Pointer();
+    }
+    loaded.insert(jsonFile);
     QString json;
     {
         QFile file(jsonFile);
@@ -971,7 +976,7 @@ Route::Pointer UserInputMapper::parseRoute(const QJsonValue& value) {
     result->json = QString(QJsonDocument(obj).toJson());
     result->source = parseSource(obj[JSON_CHANNEL_FROM]);
     result->debug = obj[JSON_CHANNEL_DEBUG].toBool();
-    result->debug = obj[JSON_CHANNEL_PEEK].toBool();
+    result->peek = obj[JSON_CHANNEL_PEEK].toBool();
     if (!result->source) {
         qWarning() << "Invalid route source " << obj[JSON_CHANNEL_FROM];
         return Route::Pointer();

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -30,6 +30,7 @@
 #include "DeviceProxy.h"
 #include "StandardControls.h"
 #include "Actions.h"
+#include "StateController.h"
 
 namespace controller {
 
@@ -55,8 +56,9 @@ namespace controller {
         using uint16 = uint16_t;
         using uint32 = uint32_t;
 
-        static const uint16_t ACTIONS_DEVICE;
         static const uint16_t STANDARD_DEVICE;
+        static const uint16_t ACTIONS_DEVICE;
+        static const uint16_t STATE_DEVICE;
 
         UserInputMapper();
         virtual ~UserInputMapper();
@@ -100,10 +102,11 @@ namespace controller {
         const DevicesMap& getDevices() { return _registeredDevices; }
         uint16 getStandardDeviceID() const { return STANDARD_DEVICE; }
         InputDevice::Pointer getStandardDevice() { return _registeredDevices[getStandardDeviceID()]; }
+        StateController::Pointer getStateDevice() { return _stateDevice; }
 
         MappingPointer newMapping(const QString& mappingName);
         MappingPointer parseMapping(const QString& json);
-        MappingPointer loadMapping(const QString& jsonFile);
+        MappingPointer loadMapping(const QString& jsonFile, bool enable = false);
         MappingPointer loadMappings(const QStringList& jsonFiles);
 
         void loadDefaultMapping(uint16 deviceID);
@@ -120,6 +123,7 @@ namespace controller {
         // GetFreeDeviceID should be called before registering a device to use an ID not used by a different device.
         uint16 getFreeDeviceID() { return _nextFreeDeviceID++; }
         DevicesMap _registeredDevices;
+        StateController::Pointer _stateDevice;
         uint16 _nextFreeDeviceID = STANDARD_DEVICE + 1;
 
         std::vector<float> _actionStates = std::vector<float>(toInt(Action::NUM_ACTIONS), 0.0f);

--- a/libraries/controllers/src/controllers/impl/Endpoint.cpp
+++ b/libraries/controllers/src/controllers/impl/Endpoint.cpp
@@ -12,5 +12,8 @@
 //           warning LNK4221: This object file does not define any previously undefined public symbols, 
 //           so it will not be used by any link operation that consumes this library
 //
-//#include "Endpoint.h"
+#include "Endpoint.h"
 
+namespace controller {
+    Endpoint::WriteLambda DEFAULT_WRITE_LAMBDA = [](float) {};
+}

--- a/libraries/controllers/src/controllers/impl/Endpoint.h
+++ b/libraries/controllers/src/controllers/impl/Endpoint.h
@@ -67,6 +67,23 @@ namespace controller {
         WriteLambda _writeLambda;
     };
 
+    extern Endpoint::WriteLambda DEFAULT_WRITE_LAMBDA;
+
+    class LambdaRefEndpoint : public Endpoint {
+    public:
+        using Endpoint::apply;
+        LambdaRefEndpoint(const ReadLambda& readLambda, const WriteLambda& writeLambda = DEFAULT_WRITE_LAMBDA)
+            : Endpoint(Input::INVALID_INPUT), _readLambda(readLambda), _writeLambda(writeLambda) {
+        }
+
+        virtual float peek() const override { return _readLambda(); }
+        virtual void apply(float value, const Pointer& source) override { _writeLambda(value); }
+
+    private:
+        const ReadLambda& _readLambda;
+        const WriteLambda& _writeLambda;
+    };
+
 
     class VirtualEndpoint : public Endpoint {
     public:


### PR DESCRIPTION
The errors are caused because the route endpoints in the standard control routes don't exist when the routes are parsed.  This PR adds a mechanism to define the state route endpoint names before the routes are parsed, even if you can't define the lambdas that return proper values yet.