### PR TITLE
Less nauseating third person HMD camera

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -519,6 +519,11 @@ private:
 
     std::atomic<uint32_t> _processOctreeStatsCounter { 0 };
 
+    glm::mat4 _thirdPersonCameraHMDInverse;
+    glm::quat _thirdPersonCameraOrientationReference;
+    glm::vec3 _thirdPersonCameraPosition;
+    bool _thirdPersonHMDCameraEnabled { false };
+
     bool _keyboardDeviceHasFocus { true };
 };
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1449,7 +1449,8 @@ void MyAvatar::updateOrientation(float deltaTime) {
     }
 
     // use head/HMD orientation to turn while flying
-    if (getCharacterController()->getState() == CharacterController::State::Hover) {
+    if (getCharacterController()->getState() == CharacterController::State::Hover &&
+        qApp->getCamera()->getMode() != CAMERA_MODE_THIRD_PERSON && !getSnapTurn()) {
 
         // This is the direction the user desires to fly in.
         glm::vec3 desiredFacing = getHead()->getCameraOrientation() * Vectors::UNIT_Z;
@@ -1627,7 +1628,11 @@ glm::vec3 MyAvatar::applyScriptedMotor(float deltaTime, const glm::vec3& localVe
 
 void MyAvatar::updatePosition(float deltaTime) {
     // rotate velocity into camera frame
+
     glm::quat rotation = getHead()->getCameraOrientation();
+    if (qApp->getCamera()->getMode() == CAMERA_MODE_THIRD_PERSON && qApp->isHMDMode()) {
+        rotation = qApp->getCamera()->getRotation();
+    }
     glm::vec3 localVelocity = glm::inverse(rotation) * _targetVelocity;
     bool isHovering = _characterController.getState() == CharacterController::State::Hover;
     glm::vec3 newLocalVelocity = applyKeyboardMotor(deltaTime, localVelocity, isHovering);


### PR DESCRIPTION
The idea is to never rotate the HMD camera while in third person, only translate it.
Also, it's important that any HMD translation/rotation from the head occurs in world space properly.

There are some drawbacks, though, it's very easy to move the avatar in a direction that is different than your current third person camera facing.  And it's easy to move the avatar out of your field of vision.

Feedback is welcome