### PR TITLE
Fix checkbox being clickable outside of checkbox and label extents

### DIFF
--- a/examples/html/edit-style.css
+++ b/examples/html/edit-style.css
@@ -452,6 +452,10 @@ input[type=checkbox]:checked + label:hover {
     min-height: 29px;
 }
 
+.property.checkbox {
+    width: auto;
+}
+
 .property label {
     display: table-cell;
     vertical-align: middle;


### PR DESCRIPTION
Currently, if you click anywhere on the same line as a checkbox in edit.js the checkbox is clicked. This fix restricts the clickable area to the checkbox plus its associated label text.