### PR TITLE
reduce log spam for the deadlock watchdog

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -252,7 +252,6 @@ public:
             auto lastHeartbeatAge = (now > lastHeartbeat) ? now - lastHeartbeat : 0;
             auto sinceLastReport = (now > _lastReport) ? now - _lastReport : 0;
             auto elapsedMovingAverage = _movingAverage.getAverage();
-            auto menu = Menu::getInstance();
 
             if (elapsedMovingAverage > _maxElapsedAverage) {
                 qDebug() << "DEADLOCK WATCHDOG WARNING:"

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -255,6 +255,7 @@ public slots:
 
     void resetSensors(bool andReload = false);
     void setActiveFaceTracker() const;
+    void toggleSuppressDeadlockWatchdogStatus(bool checked);
 
 #ifdef HAVE_IVIEWHMD
     void setActiveEyeTracker();

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -530,6 +530,7 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::PipelineWarnings);
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::LogExtraTimings);
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::SuppressShortTimings);
+    addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::SupressDeadlockWatchdogStatus, 0, false);
 
     // Developer > Audio >>>
     MenuWrapper* audioDebugMenu = developerMenu->addMenu("Audio");

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -530,7 +530,9 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::PipelineWarnings);
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::LogExtraTimings);
     addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::SuppressShortTimings);
-    addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::SupressDeadlockWatchdogStatus, 0, false);
+    addCheckableActionToQMenuAndActionHash(timingMenu, MenuOption::SupressDeadlockWatchdogStatus, 0, false,
+        qApp, SLOT(toggleSuppressDeadlockWatchdogStatus(bool)));
+
 
     // Developer > Audio >>>
     MenuWrapper* audioDebugMenu = developerMenu->addMenu("Audio");

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -162,6 +162,7 @@ namespace MenuOption {
     const QString Stats = "Stats";
     const QString StopAllScripts = "Stop All Scripts";
     const QString SuppressShortTimings = "Suppress Timings Less than 10ms";
+    const QString SupressDeadlockWatchdogStatus = "Supress Deadlock Watchdog Status";
     const QString ThirdPerson = "Third Person";
     const QString ThreePointCalibration = "3 Point Calibration";
     const QString ThrottleFPSIfNotFocus = "Throttle FPS If Not Focus"; // FIXME - this value duplicated in Basic2DWindowOpenGLDisplayPlugin.cpp


### PR DESCRIPTION
Cleans up the deadlock watchdog messages a little bit. Adds a developer menu to suppress some of these messages.