### PR TITLE
Disable gradient QML items on AMD

### DIFF
--- a/interface/resources/qml/controls-uit/ContentSection.qml
+++ b/interface/resources/qml/controls-uit/ContentSection.qml
@@ -116,7 +116,7 @@ Column {
 
         LinearGradient {
             id: bottomBar
-            visible: isCollapsible
+            visible: desktop.gradientsSupported && isCollapsible
             width: frame.width
             height: visible ? 4 : 0
             x: -hifi.dimensions.contentMargin.x

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -34,6 +34,10 @@ FocusScope {
     // The VR version of the primary menu
     property var rootMenu: Menu { objectName: "rootMenu" }
 
+    // FIXME: Alpha gradients display as fuschia under QtQuick 2.5 on OSX/AMD
+    //        because shaders are 4.2, and do not include #version declarations.
+    property bool gradientsSupported: Qt.platform.os != "osx" && !~GL.vendor.indexOf("ATI")
+
     readonly property alias zLevels: zLevels
     QtObject {
         id: zLevels;

--- a/interface/resources/qml/windows-uit/Frame.qml
+++ b/interface/resources/qml/windows-uit/Frame.qml
@@ -59,9 +59,9 @@ Item {
         height: 1.66 * window.height
         x: (window.width - width) / 2
         y: window.height / 2 - 0.375 * height
-        // FIXME: Alpha gradients display as fuschia under QtQuick 2.5 on OSX.
-        // Check again when have a later version of QtQuick.
-        visible: window && window.focus && pane.visible && Qt.platform.os != "osx"
+        // FIXME: Alpha gradients display as fuschia under QtQuick 2.5 on OSX/AMD
+        //        because shaders are 4.2, and do not include #version declaration.
+        visible: window && window.focus && pane.visible && Qt.platform.os != "osx" && !~GL.vendor.indexOf("ATI")
         gradient: Gradient {
             // GradientStop position 0.5 is at full circumference of circle that fits inside the square.
             GradientStop { position: 0.0; color: "#ff000000" }    // black, 100% opacity

--- a/interface/resources/qml/windows-uit/Frame.qml
+++ b/interface/resources/qml/windows-uit/Frame.qml
@@ -20,6 +20,8 @@ Item {
 
     default property var decoration
 
+    property bool gradientsSupported: desktop.gradientsSupported
+
     readonly property int iconSize: 22
     readonly property int frameMargin: 9
     readonly property int frameMarginLeft: frameMargin
@@ -59,9 +61,7 @@ Item {
         height: 1.66 * window.height
         x: (window.width - width) / 2
         y: window.height / 2 - 0.375 * height
-        // FIXME: Alpha gradients display as fuschia under QtQuick 2.5 on OSX/AMD
-        //        because shaders are 4.2, and do not include #version declaration.
-        visible: window && window.focus && pane.visible && Qt.platform.os != "osx" && !~GL.vendor.indexOf("ATI")
+        visible: gradientsSupported && window && window.focus && pane.visible
         gradient: Gradient {
             // GradientStop position 0.5 is at full circumference of circle that fits inside the square.
             GradientStop { position: 0.0; color: "#ff000000" }    // black, 100% opacity

--- a/interface/resources/qml/windows-uit/Window.qml
+++ b/interface/resources/qml/windows-uit/Window.qml
@@ -51,6 +51,7 @@ Fadable {
     // property bool pinnable: false
     // property bool pinned: false
     property bool resizable: false
+    property bool gradientsSupported: desktop.gradientsSupported
 
     property vector2d minSize: Qt.vector2d(100, 100)
     property vector2d maxSize: Qt.vector2d(1280, 800)
@@ -142,9 +143,7 @@ Fadable {
         }
 
         LinearGradient {
-            // FIXME: Alpha gradients display as fuschia under QtQuick 2.5 on OSX/AMD
-            //        because shaders are 4.2, and do not include #version declaration.
-            visible: modality != Qt.ApplicationModal && Qt.platform.os != "osx" && !~GL.vendor.indexOf("ATI")
+            visible: gradientsSupported && modality != Qt.ApplicationModal
             anchors.top: contentBackground.bottom
             anchors.left: contentBackground.left
             width: contentBackground.width - 1

--- a/interface/resources/qml/windows-uit/Window.qml
+++ b/interface/resources/qml/windows-uit/Window.qml
@@ -142,9 +142,9 @@ Fadable {
         }
 
         LinearGradient {
-            // FIXME: Alpha gradients display as fuschia under QtQuick 2.5 on OSX.
-            // Check again when have a later version of QtQuick.
-            visible: modality != Qt.ApplicationModal && Qt.platform.os != "osx"
+            // FIXME: Alpha gradients display as fuschia under QtQuick 2.5 on OSX/AMD
+            //        because shaders are 4.2, and do not include #version declaration.
+            visible: modality != Qt.ApplicationModal && Qt.platform.os != "osx" && !~GL.vendor.indexOf("ATI")
             anchors.top: contentBackground.bottom
             anchors.left: contentBackground.left
             width: contentBackground.width - 1

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -199,8 +199,6 @@ static const QString DESKTOP_LOCATION = QStandardPaths::writableLocation(QStanda
 static const QString DESKTOP_LOCATION = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation).append("/script.js");
 #endif
 
-QJsonObject Application::_glData {};
-
 Setting::Handle<int> maxOctreePacketsPerSecond("maxOctreePPS", DEFAULT_MAX_OCTREE_PPS);
 
 const QHash<QString, Application::AcceptURLMethod> Application::_acceptedExtensions {
@@ -1321,9 +1319,6 @@ void Application::initializeUi() {
     offscreenUi->create(_offscreenContext->getContext());
 
     auto rootContext = offscreenUi->getRootContext();
-
-    // First set the GL property, so the desktop can use it for graphics workarounds
-    rootContext->setContextProperty("GL", _glData);
 
     offscreenUi->setProxyWindow(_window->windowHandle());
     offscreenUi->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "/qml/"));

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -96,6 +96,9 @@ public:
     static void initPlugins();
     static void shutdownPlugins();
 
+    // Expose the gl metadata to QML
+    static void setGL(const QJsonObject& glData) { _glData = glData; }
+
     Application(int& argc, char** argv, QElapsedTimer& startup_time);
     ~Application();
 
@@ -378,6 +381,8 @@ private:
     static void dragEnterEvent(QDragEnterEvent* event);
 
     void maybeToggleMenuVisible(QMouseEvent* event) const;
+
+    static QJsonObject _glData;
 
     MainWindow* _window;
     QElapsedTimer& _sessionRunTimer;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -96,9 +96,6 @@ public:
     static void initPlugins();
     static void shutdownPlugins();
 
-    // Expose the gl metadata to QML
-    static void setGL(const QJsonObject& glData) { _glData = glData; }
-
     Application(int& argc, char** argv, QElapsedTimer& startup_time);
     ~Application();
 
@@ -381,8 +378,6 @@ private:
     static void dragEnterEvent(QDragEnterEvent* event);
 
     void maybeToggleMenuVisible(QMouseEvent* event) const;
-
-    static QJsonObject _glData;
 
     MainWindow* _window;
     QElapsedTimer& _sessionRunTimer;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, const char* argv[]) {
     MiniDmpSender mpSender { BUG_SPLAT_DATABASE, BUG_SPLAT_APPLICATION_NAME, qPrintable(BuildInfo::VERSION),
                              nullptr, BUG_SPLAT_FLAGS };
 #endif
-    
+
     QString applicationName = "High Fidelity Interface - " + qgetenv("USERNAME");
 
     bool instanceMightBeRunning = true;
@@ -105,13 +105,14 @@ int main(int argc, const char* argv[]) {
     // This is done separately from the main Application so that start-up and shut-down logic within the main Application is
     // not made more complicated than it already is.
     bool override = false;
-    QString glVersion;
+    QJsonObject glData;
     {
         OpenGLVersionChecker openGLVersionChecker(argc, const_cast<char**>(argv));
         bool valid = true;
-        glVersion = openGLVersionChecker.checkVersion(valid, override);
+        glData = openGLVersionChecker.checkVersion(valid, override);
         if (!valid) {
             if (override) {
+                auto glVersion = glData["version"].toString();
                 qCDebug(interfaceapp, "Running on insufficient OpenGL version: %s.", glVersion.toStdString().c_str());
             } else {
                 qCDebug(interfaceapp, "Early exit due to OpenGL version.");
@@ -139,21 +140,23 @@ int main(int argc, const char* argv[]) {
     // or in the main window ctor, before GL startup.
     Application::initPlugins();
 
+    // GL must be available to the root QML context on startup.
+    Application::setGL(glData);
+
     int exitCode;
     {
         QSettings::setDefaultFormat(QSettings::IniFormat);
         Application app(argc, const_cast<char**>(argv), startupTime);
-
         // If we failed the OpenGLVersion check, log it.
         if (override) {
             auto& accountManager = AccountManager::getInstance();
             if (accountManager.isLoggedIn()) {
-                UserActivityLogger::getInstance().insufficientGLVersion(glVersion);
+                UserActivityLogger::getInstance().insufficientGLVersion(glData);
             } else {
-                QObject::connect(&AccountManager::getInstance(), &AccountManager::loginComplete, [glVersion](){
+                QObject::connect(&AccountManager::getInstance(), &AccountManager::loginComplete, [glData](){
                     static bool loggedInsufficientGL = false;
                     if (!loggedInsufficientGL) {
-                        UserActivityLogger::getInstance().insufficientGLVersion(glVersion);
+                        UserActivityLogger::getInstance().insufficientGLVersion(glData);
                         loggedInsufficientGL = true;
                     }
                 });

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -140,13 +140,11 @@ int main(int argc, const char* argv[]) {
     // or in the main window ctor, before GL startup.
     Application::initPlugins();
 
-    // GL must be available to the root QML context on startup.
-    Application::setGL(glData);
-
     int exitCode;
     {
         QSettings::setDefaultFormat(QSettings::IniFormat);
         Application app(argc, const_cast<char**>(argv), startupTime);
+
         // If we failed the OpenGLVersion check, log it.
         if (override) {
             auto& accountManager = AccountManager::getInstance();

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -4,6 +4,7 @@
 
 #include <QtGui/QSurfaceFormat>
 #include <QtOpenGL/QGL>
+#include <QOpenGLContext>
 
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat() {
     static QSurfaceFormat format;
@@ -34,4 +35,22 @@ const QGLFormat& getDefaultGLFormat() {
         glFormat.setStencil(false);
     });
     return glFormat;
+}
+
+QJsonObject getGLContextData() {
+    if (!QOpenGLContext::currentContext()) {
+        return QJsonObject();
+    }
+
+    QString glVersion = QString((const char*)glGetString(GL_VERSION));
+    QString glslVersion = QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
+    QString glVendor = QString((const char*) glGetString(GL_VENDOR));
+    QString glRenderer = QString((const char*)glGetString(GL_RENDERER));
+
+    return QJsonObject {
+        { "version", glVersion },
+        { "slVersion", glslVersion },
+        { "vendor", glVendor },
+        { "renderer", glRenderer },
+    };
 }

--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -10,6 +10,8 @@
 #ifndef hifi_GLHelpers_h
 #define hifi_GLHelpers_h
 
+#include <QJsonObject>
+
 // 16 bits of depth precision
 #define DEFAULT_GL_DEPTH_BUFFER_BITS 16
 // 8 bits of stencil buffer (typically you really only need 1 bit for functionality
@@ -21,4 +23,6 @@ class QGLFormat;
 
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat();
 const QGLFormat& getDefaultGLFormat();
+QJsonObject getGLContextData();
+
 #endif

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -27,6 +27,7 @@
 
 #include "OffscreenGLCanvas.h"
 #include "GLEscrow.h"
+#include "GLHelpers.h"
 
 
 // Time between receiving a request to render the offscreen UI actually triggering
@@ -221,6 +222,11 @@ void OffscreenQmlRenderThread::init() {
         _quit = true;
         return;
     }
+
+    // Expose GL data to QML
+    auto glData = getGLContextData();
+    auto setGL = [=]{ _surface->getRootContext()->setContextProperty("GL", glData); };
+    _surface->executeOnUiThread(setGL);
 
     _renderControl->initialize(_canvas.getContext());
     setupFbo();

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -17,6 +17,7 @@
 
 #include "Config.h"
 #include "GLWidget.h"
+#include "GLHelpers.h"
 
 OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
     QApplication(argc, argv)
@@ -44,10 +45,7 @@ QJsonObject OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
     
     // Retrieve OpenGL version
     glWidget->initializeGL();
-    QString glVersion = QString((const char*)glGetString(GL_VERSION));
-    QString glslVersion = QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-    QString glVendor = QString((const char*) glGetString(GL_VENDOR));
-    QString glRenderer = QString((const char*)glGetString(GL_RENDERER));
+    QJsonObject glData = getGLContextData();
     delete glWidget;
 
     // Compare against minimum
@@ -55,6 +53,8 @@ QJsonObject OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
     // - major_number.minor_number 
     // - major_number.minor_number.release_number
     // Reference: https://www.opengl.org/sdk/docs/man/docbook4/xhtml/glGetString.xml
+    const QString version { "version" };
+    QString glVersion = glData[version].toString();
     QStringList versionParts = glVersion.split(QRegularExpression("[\\.\\s]"));
     int majorNumber = versionParts[0].toInt();
     int minorNumber = versionParts[1].toInt();
@@ -76,10 +76,5 @@ QJsonObject OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
         override = messageBox.exec() == QMessageBox::Ignore;
     }
 
-    return QJsonObject{
-        { "version", glVersion },
-        { "slVersion", glslVersion },
-        { "vendor", glVendor },
-        { "renderer", glRenderer },
-    };
+    return glData;
 }

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -13,6 +13,7 @@
 
 #include <QMessageBox>
 #include <QRegularExpression>
+#include <QJsonObject>
 
 #include "Config.h"
 #include "GLWidget.h"
@@ -22,7 +23,7 @@ OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
 {
 }
 
-QString OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
+QJsonObject OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
     valid = true;
     override = false;
 
@@ -38,12 +39,15 @@ QString OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
         messageBox.setStandardButtons(QMessageBox::Ok);
         messageBox.setDefaultButton(QMessageBox::Ok);
         messageBox.exec();
-        return QString();
+        return QJsonObject();
     }
     
     // Retrieve OpenGL version
     glWidget->initializeGL();
     QString glVersion = QString((const char*)glGetString(GL_VERSION));
+    QString glslVersion = QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
+    QString glVendor = QString((const char*) glGetString(GL_VENDOR));
+    QString glRenderer = QString((const char*)glGetString(GL_RENDERER));
     delete glWidget;
 
     // Compare against minimum
@@ -72,5 +76,10 @@ QString OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
         override = messageBox.exec() == QMessageBox::Ignore;
     }
 
-    return glVersion;
+    return QJsonObject{
+        { "version", glVersion },
+        { "slVersion", glslVersion },
+        { "vendor", glVendor },
+        { "renderer", glRenderer },
+    };
 }

--- a/libraries/gl/src/gl/OpenGLVersionChecker.h
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.h
@@ -19,7 +19,7 @@ class OpenGLVersionChecker : public QApplication {
 public:
     OpenGLVersionChecker(int& argc, char** argv);
 
-    static QString checkVersion(bool& valid, bool& override);
+    static QJsonObject checkVersion(bool& valid, bool& override);
 };
 
 #endif // hifi_OpenGLVersionChecker_h

--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -85,11 +85,11 @@ void UserActivityLogger::launch(QString applicationVersion, bool previousSession
     logAction(ACTION_NAME, actionDetails);
 }
 
-void UserActivityLogger::insufficientGLVersion(QString glVersion) {
+void UserActivityLogger::insufficientGLVersion(const QJsonObject& glData) {
     const QString ACTION_NAME = "insufficient_gl";
     QJsonObject actionDetails;
-    QString GL_VERSION = "glVersion";
-    actionDetails.insert(GL_VERSION, glVersion);
+    QString GL_DATA = "glData";
+    actionDetails.insert(GL_DATA, glData);
 
     logAction(ACTION_NAME, actionDetails);
 }

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -31,7 +31,7 @@ public slots:
     
     void launch(QString applicationVersion, bool previousSessionCrashed, int previousSessionRuntime);
 
-    void insufficientGLVersion(QString glVersion);
+    void insufficientGLVersion(const QJsonObject& glData);
     
     void changedDisplayName(QString displayName);
     void changedModel(QString typeOfModel, QString modelURL);

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -15,6 +15,8 @@
 #include <QtQuick/QQuickWindow>
 #include <QtQml/QtQml>
 
+#include <gl/GLHelpers.h>
+
 #include <AbstractUriHandler.h>
 #include <AccountManager.h>
 


### PR DESCRIPTION
- Expose GL information to QML (version, slVersion, vendor, renderer)
- Send all GL information to metaverse on GL version incompatibility override
- Key gradient visibility on GL vendor (card manufacturer)

Fixes the large fuchsia boxes that appeared for QML focus windows on AMD cards. Only fixes the boxes *behind* dialogues, not within them.