### PR TITLE
Reading animation properties without an entityTree lock is considered harmful

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -271,10 +271,10 @@ bool RenderableModelEntityItem::getAnimationFrame() {
         return false;
     }
 
-    if (!hasAnimation() || !_jointMappingCompleted) {
+    if (!hasRenderAnimation() || !_jointMappingCompleted) {
         return false;
     }
-    AnimationPointer myAnimation = getAnimation(_animationProperties.getURL()); // FIXME: this could be optimized
+    AnimationPointer myAnimation = getAnimation(getRenderAnimationURL()); // FIXME: this could be optimized
     if (myAnimation && myAnimation->isLoaded()) {
 
         const QVector<FBXAnimationFrame>&  frames = myAnimation->getFramesReference(); // NOTE: getFrames() is too heavy
@@ -384,7 +384,7 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
             }
 
             if (_model) {
-                if (hasAnimation()) {
+                if (hasRenderAnimation()) {
                     if (!jointsMapped()) {
                         QStringList modelJointNames = _model->getJointNames();
                         mapJoints(modelJointNames);
@@ -527,6 +527,9 @@ void RenderableModelEntityItem::update(const quint64& now) {
                                       Q_ARG(EntityItemProperties, properties));
         }
     }
+
+    // make a copy of the animation properites
+    _renderAnimationProperties = _animationProperties;
 
     ModelEntityItem::update(now);
 }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -82,6 +82,11 @@ public:
     virtual int getJointIndex(const QString& name) const override;
     virtual QStringList getJointNames() const override;
 
+    // These operate on a copy of the renderAnimationProperties, so they can be accessed
+    // without having the entityTree lock.
+    bool hasRenderAnimation() const { return !_renderAnimationProperties.getURL().isEmpty(); }
+    const QString& getRenderAnimationURL() const { return _renderAnimationProperties.getURL(); }
+
 private:
     QVariantMap parseTexturesToMap(QString textures);
     void remapTextures();
@@ -96,6 +101,8 @@ private:
     bool _originalTexturesRead = false;
     QVector<QVector<glm::vec3>> _points;
     bool _dimensionsInitialized = true;
+
+    AnimationPropertyGroup _renderAnimationProperties;
 
     render::ItemID _myMetaItem{ render::Item::INVALID_ITEM_ID };
 


### PR DESCRIPTION
In RenderableModelEntityItem::update() make a copy of the _animationProperties, while the entityTree is locked.  In RenderableModelEntityItem::render() read from the copy of _animationProperties when not under the entityTree lock.