### PR TITLE
Disable arrow keys being able to move between HTML form fields

### DIFF
--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -21,7 +21,7 @@ Desktop {
     Component.onCompleted: {
         WebEngine.settings.javascriptCanOpenWindows = true;
         WebEngine.settings.javascriptCanAccessClipboard = false;
-        WebEngine.settings.spatialNavigationEnabled = true;
+        WebEngine.settings.spatialNavigationEnabled = false;
         WebEngine.settings.localContentCanAccessRemoteUrls = true;
     }
 


### PR DESCRIPTION
Moving between form fields with arrow keys makes it to easy to make
unintended changes to adjacent fields.