### PR TITLE
Remove refresh feature from edit.js for now

### DIFF
--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -468,36 +468,9 @@
 
                 var elPreviewCameraButton = document.getElementById("preview-camera-button");
     
-                var urlUpdaters = document.getElementsByClassName("update-url-version");
                 var PARAM_REGEXP = /(?:\?)(\S+)/; // Check if this has any parameters.
                 var TIMESTAMP_REGEXP = /(&?HFTime=\d+)/;
 
-                var refreshEvent = function (event) {
-                    var urlElement = event.target.parentElement.getElementsByTagName("INPUT")[0];
-                    var content = urlElement.value;
-                    var date = new Date();
-                    var timeStamp = date.getTime();
-
-                    if(content.length > 0){
-                        if(PARAM_REGEXP.test(content)){
-                        // Has params, so lets remove existing definition and append again.
-                            content = content.replace(TIMESTAMP_REGEXP,"") + "&";
-                        }else{
-                            content += "?";
-                        }
-                        content = content.replace("?&","?");
-                        urlElement.value = content + "HFTime=" + timeStamp;
-                    }
-
-                    var evt = document.createEvent("HTMLEvents");
-                    evt.initEvent("change", true, true );
-                    urlElement.dispatchEvent(evt);
-                };
-
-                for(var index = 0; index < urlUpdaters.length; index++){
-                    var urlUpdater = urlUpdaters[index];
-                    urlUpdater.addEventListener("click", refreshEvent, true);
-                }
 
                 if (window.EventBridge !== undefined) {
                     var properties;
@@ -1397,20 +1370,17 @@
                 <option value="3">Edged marching cubes</option>
             </select>
         </div>
-        <div class="spatial-group poly-vox-section property url refresh">
+        <div class="spatial-group poly-vox-section property url ">
             <label for="property-x-texture-url">X-axis texture URL</label>
             <input type="text" id="property-x-texture-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
-        <div class="spatial-group poly-vox-section property url refresh">
+        <div class="spatial-group poly-vox-section property url ">
             <label for="property-y-texture-url">Y-axis texture URL</label>
             <input type="text" id="property-y-texture-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
-        <div class="spatial-group poly-vox-section property url refresh">
+        <div class="spatial-group poly-vox-section property url ">
             <label for="property-z-texture-url">Z-axis texture URL</label>
             <input type="text" id="property-z-texture-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
         <div class="spatial-group property pyr">
             <label>Rotation</label>
@@ -1545,16 +1515,15 @@
             </div>
         </div>
 
-        <div class="behavior-group property url refresh">
+        <div class="behavior-group property url ">
             <label for="property-collision-sound-url">Collision sound URL</label>
             <input type="text" id="property-collision-sound-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
         <div class="behavior-group property number">
             <label>Lifetime</label>
             <input type="number" id="property-lifetime">
         </div>
-        <div class="behavior-group property url refresh">
+        <div class="behavior-group property url ">
             <!--
             FIXME: If reload buttons at the end of each URL continue to work OK during beta, this reload button and associated
             code should be removed.
@@ -1563,17 +1532,15 @@
             -->
             <label for="property-script-url">Script URL</label>
             <input type="text" id="property-script-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
 
 
         <div class="section-header model-group model-section zone-section">
             <label>Model</label><span>M</span>
         </div>
-        <div class="model-group model-section property url refresh">
+        <div class="model-group model-section property url ">
             <label for="property-model-url">Model URL</label>
             <input type="text" id="property-model-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
         <div class="model-group model-section zone-section property dropdown">
             <label>Collision shape type</label>
@@ -1584,15 +1551,13 @@
                 <option value="compound">Compound</option>
             </select>
         </div>
-        <div class="model-group model-section zone-section property url refresh">
+        <div class="model-group model-section zone-section property url ">
             <label for="property-compound-shape-url">Compound shape URL</label>
             <input type="text" id="property-compound-shape-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
-        <div class="model-group model-section property url refresh">
+        <div class="model-group model-section property url ">
             <label for="property-model-animation-url">Animation URL</label>
             <input type="text" id="property-model-animation-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
         <div class="model-group model-section property checkbox">
             <input type="checkbox" id="property-model-animation-playing">
@@ -1693,10 +1658,9 @@
             <label>Ambient intensity</label>
             <input type="number" id="property-zone-key-ambient-intensity" min="0" max="10" step="0.1">
         </div>
-        <div class="zone-group zone-section keylight-section property url refresh">
+        <div class="zone-group zone-section keylight-section property url ">
             <label for="property-zone-key-ambient-url">Ambient URL</label>
             <input type="text" id="property-zone-key-ambient-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
 
         <div class="sub-section-header zone-group zone-section stage-section">
@@ -1745,20 +1709,18 @@
                 <div><input type="number" class="blue" id="property-zone-skybox-color-blue"><label for="property-zone-skybox-color-blue">Blue:</label></div>
             </div>
         </div>
-        <div class="zone-group zone-section skybox-section property url refresh">
+        <div class="zone-group zone-section skybox-section property url ">
             <label for="property-zone-skybox-url">Skybox URL</label>
             <input type="text" id="property-zone-skybox-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
 
 
         <div class="section-header web-group web-section">
             <label>Web</label><span>M</span>
         </div>
-        <div class="web-group web-section property url refresh">
+        <div class="web-group web-section property url ">
             <label for="property-web-source-url">Source URL</label>
             <input type="text" id="property-web-source-url">
-            <input type="button" class="update-url-version glyph" value="F" />
         </div>
 
 

--- a/examples/html/entityProperties.html
+++ b/examples/html/entityProperties.html
@@ -467,10 +467,6 @@
                 var elZTextureURL = document.getElementById("property-z-texture-url");
 
                 var elPreviewCameraButton = document.getElementById("preview-camera-button");
-    
-                var PARAM_REGEXP = /(?:\?)(\S+)/; // Check if this has any parameters.
-                var TIMESTAMP_REGEXP = /(&?HFTime=\d+)/;
-
 
                 if (window.EventBridge !== undefined) {
                     var properties;


### PR DESCRIPTION
This PR removes the 'refresh' feature for assets through edit.js -- it conflicts with atp:/ which does not at the moment support query strings.  Manual 'cache-busting' can still be accomplished by simply adding any various query string for non-atp assets.  

to test:
1. open edit.js
2. create something
3. look at its properties
4. observe that there is not a way to add the 'hftime' string to an asset by reloading it (models, animations, collision sounds, textures, etc)
5. check editing properties generally works as expected