### PR TITLE
Fix for frozen ghost avatars

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -187,9 +187,10 @@ void Avatar::simulate(float deltaTime) {
 
     // simple frustum check
     float boundingRadius = getBoundingRadius();
-    bool inView = qApp->getDisplayViewFrustum()->sphereIntersectsFrustum(getPosition(), boundingRadius);
+    bool avatarPositionInView = qApp->getDisplayViewFrustum()->sphereIntersectsFrustum(getPosition(), boundingRadius);
+    bool avatarMeshInView = qApp->getDisplayViewFrustum()->boxIntersectsFrustum(_skeletonModel->getRenderableMeshBound());
 
-    if (_shouldAnimate && !_shouldSkipRender && inView) {
+    if (_shouldAnimate && !_shouldSkipRender && (avatarPositionInView || avatarMeshInView)) {
         {
             PerformanceTimer perfTimer("skeleton");
             _skeletonModel->getRig()->copyJointsFromJointData(_jointData);


### PR DESCRIPTION
Previously, when renderItems were visible they were not updated with the latest avatar mixer rotations and positions.  This could result in a frozen non-animating avatar visible even after the avatar has moved far away.  Now the renderItems are updated if they are visible or the bounding sphere around the avatar position is visible.