### PR TITLE
fix export of animation properties

### DIFF
--- a/libraries/entities/src/AnimationPropertyGroup.cpp
+++ b/libraries/entities/src/AnimationPropertyGroup.cpp
@@ -244,6 +244,10 @@ void AnimationPropertyGroup::markAllChanged() {
     _fpsChanged = true;
     _currentFrameChanged = true;
     _runningChanged = true;
+    _loopChanged = true;
+    _firstFrameChanged = true;
+    _lastFrameChanged = true;
+    _holdChanged = true;
 }
 
 EntityPropertyFlags AnimationPropertyGroup::getChangedProperties() const {


### PR DESCRIPTION
the firstFrame, lastFrame, loop, and hold properties were not being properly exported - this will fix that