### PR TITLE
Improve comfort of third-person HMD camera.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3490,9 +3490,6 @@ void Application::update(float deltaTime) {
             avatarManager->updateOtherAvatars(deltaTime);
         }
 
-        // update sensorToWorldMatrix for camera and hand controllers
-        getMyAvatar()->updateSensorToWorldMatrix();
-
         qApp->updateMyAvatarLookAtPosition();
 
         {


### PR DESCRIPTION
By preventing avatar rotation due to HMD head turning.

Also, fix one frame glitch during snap turning, by updating the sensorToWorld matrix
after the MyAvatar::updateOrientation rotates the avatar, but before we perform IK.