### PR TITLE
Suppress key release events for presses that were absorbed by QML

### DIFF
--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -569,7 +569,7 @@ QPointF OffscreenQmlSurface::mapToVirtualScreen(const QPointF& originalPoint, QO
 // Event handling customization
 //
 
-bool OffscreenQmlSurface::eventFilter(QObject* originalDestination, QEvent* event) {
+bool OffscreenQmlSurface::filterEnabled(QObject* originalDestination, QEvent* event) const {
     if (_renderer->_quickWindow == originalDestination) {
         return false;
     }
@@ -577,7 +577,13 @@ bool OffscreenQmlSurface::eventFilter(QObject* originalDestination, QEvent* even
     if (_paused) {
         return false;
     }
+    return true;
+}
 
+bool OffscreenQmlSurface::eventFilter(QObject* originalDestination, QEvent* event) {
+    if (!filterEnabled(originalDestination, event)) {
+        return false;
+    }
 #ifdef DEBUG
     // Don't intercept our own events, or we enter an infinite recursion
     QObject* recurseTest = originalDestination;

--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -66,7 +66,7 @@ public:
     QQmlContext* getRootContext();
 
     QPointF mapToVirtualScreen(const QPointF& originalPoint, QObject* originalWidget);
-    virtual bool eventFilter(QObject* originalDestination, QEvent* event);
+    bool eventFilter(QObject* originalDestination, QEvent* event) override;
 
 signals:
     void textureUpdated(unsigned int texture);
@@ -75,6 +75,9 @@ public slots:
     void requestUpdate();
     void requestRender();
     void onAboutToQuit();
+
+protected:
+    bool filterEnabled(QObject* originalDestination, QEvent* event) const;
 
 private:
     QObject* finishQmlLoad(std::function<void(QQmlContext*, QObject*)> f);

--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -12,6 +12,7 @@
 #ifndef hifi_OffscreenUi_h
 #define hifi_OffscreenUi_h
 
+#include <unordered_map>
 #include <QtCore/QVariant>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMessageBox>
@@ -37,6 +38,7 @@ public:
     void setNavigationFocused(bool focused);
     void unfocusWindows();
     void toggleMenu(const QPoint& screenCoordinates);
+    bool eventFilter(QObject* originalDestination, QEvent* event) override;
 
     QQuickItem* getDesktop();
     QQuickItem* getToolWindow();
@@ -131,6 +133,7 @@ private:
 
     QQuickItem* _desktop { nullptr };
     QQuickItem* _toolWindow { nullptr };
+    std::unordered_map<int, bool> _pressedKeys;
 };
 
 #endif


### PR DESCRIPTION
Testing

If you run the following script in production Hifi:

```
Controller.keyReleaseEvent.connect(function(event) {
    print("keyReleaseEvent() -- event.text:" + event.text);
});

Controller.keyPressEvent.connect(function(event) {
    print("keyPressEvent() -- event.text:" + event.text);
});
```

You will see logging of all key press and release events.  If you open up a QML window ( like the address bar) and start typing you'll no longer see key presses, but you will see key releases.

With this build, you should no longer see key release events while a QML window is up. 