### PR TITLE
Save the set of running scripts when they change, as well as at shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -731,18 +731,11 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
         registerScriptEngineWithApplicationServices(engine);
     });
 
-    static const int SCRIPT_SAVE_COUNTDOWN_INTERVAL_MS = 5000;
-    QTimer* scriptSaveTimer = new QTimer(this);
-    connect(scriptSaveTimer, &QTimer::timeout, [] {
-        DependencyManager::get<ScriptEngines>()->saveScripts();
-    });
-    scriptSaveTimer->setSingleShot(true);
-    connect(scriptEngines, &ScriptEngines::scriptCountChanged, scriptEngines, [this, scriptSaveTimer] {
+    connect(scriptEngines, &ScriptEngines::scriptCountChanged, scriptEngines, [this] {
         auto scriptEngines = DependencyManager::get<ScriptEngines>();
         if (scriptEngines->getRunningScripts().isEmpty()) {
             getMyAvatar()->clearScriptableSettings();
         }
-        scriptSaveTimer->start(SCRIPT_SAVE_COUNTDOWN_INTERVAL_MS);
     }, Qt::QueuedConnection);
 
     connect(scriptEngines, &ScriptEngines::scriptsReloading, scriptEngines, [this] {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -731,11 +731,18 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
         registerScriptEngineWithApplicationServices(engine);
     });
 
-    connect(scriptEngines, &ScriptEngines::scriptCountChanged, scriptEngines, [this] {
+    static const int SCRIPT_SAVE_COUNTDOWN_INTERVAL_MS = 5000;
+    QTimer* scriptSaveTimer = new QTimer(this);
+    connect(scriptSaveTimer, &QTimer::timeout, [] {
+        DependencyManager::get<ScriptEngines>()->saveScripts();
+    });
+    scriptSaveTimer->setSingleShot(true);
+    connect(scriptEngines, &ScriptEngines::scriptCountChanged, scriptEngines, [this, scriptSaveTimer] {
         auto scriptEngines = DependencyManager::get<ScriptEngines>();
         if (scriptEngines->getRunningScripts().isEmpty()) {
             getMyAvatar()->clearScriptableSettings();
         }
+        scriptSaveTimer->start(SCRIPT_SAVE_COUNTDOWN_INTERVAL_MS);
     }, Qt::QueuedConnection);
 
     connect(scriptEngines, &ScriptEngines::scriptsReloading, scriptEngines, [this] {


### PR DESCRIPTION
## Testing

* Start, stop and restart the application while running some set of scripts, verify scripts are preserved over the restart.
* Add a new script through the Running Scripts dialog.  Wait 10 second and then crash the application through the developer menu.  Restart the application and verify the newly added script is still loaded.
