### PR TITLE
treat children of avatars and children of entities differently until velocity handling is fixed

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -888,9 +888,6 @@ void EntityItem::simulateKinematicMotion(float timeElapsed, bool setFlags) {
     if (hasActions()) {
         return;
     }
-    if (!_parentID.isNull()) {
-        return;
-    }
 
     if (hasLocalAngularVelocity()) {
         glm::vec3 localAngularVelocity = getLocalAngularVelocity();


### PR DESCRIPTION
- make spinning things work again while still keeping equipped things from drifting out of the avatar's hand
