### PR TITLE
Cleanly shutdown the texture transfer thread on quit

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
@@ -44,6 +44,17 @@ GLTextureTransferHelper::GLTextureTransferHelper() {
     _canvas->doneCurrent();
     initialize(true, QThread::LowPriority);
     _canvas->moveToThreadWithContext(_thread);
+
+    // Clean shutdown on UNIX, otherwise _canvas is freed early
+    connect(qApp, &QCoreApplication::aboutToQuit, [&] { terminate(); });
+#endif
+}
+
+GLTextureTransferHelper::~GLTextureTransferHelper() {
+#ifdef THREADED_TEXTURE_TRANSFER
+    if (isStillRunning()) {
+        terminate();
+    }
 #endif
 }
 

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
@@ -91,6 +91,7 @@ void GLTextureTransferHelper::setup() {
 void GLTextureTransferHelper::shutdown() {
     _canvas->doneCurrent();
     _canvas->moveToThreadWithContext(qApp->thread());
+    _canvas.reset();
 }
 
 

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.cpp
@@ -36,7 +36,7 @@ using namespace gpu;
 
 GLTextureTransferHelper::GLTextureTransferHelper() {
 #ifdef THREADED_TEXTURE_TRANSFER
-    _canvas = std::make_shared<OffscreenGLCanvas>();
+    _canvas = QSharedPointer<OffscreenGLCanvas>(new OffscreenGLCanvas(), &QObject::deleteLater);
     _canvas->create(QOpenGLContextWrapper::currentContext());
     if (!_canvas->makeCurrent()) {
         qFatal("Unable to create texture transfer context");
@@ -89,9 +89,11 @@ void GLTextureTransferHelper::setup() {
 }
 
 void GLTextureTransferHelper::shutdown() {
+#ifdef THREADED_TEXTURE_TRANSFER
     _canvas->doneCurrent();
     _canvas->moveToThreadWithContext(qApp->thread());
     _canvas.reset();
+#endif
 }
 
 

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
@@ -6,6 +6,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QSharedPointer>
 #include <GenericQueueThread.h>
 #include "GLBackendShared.h"
 
@@ -34,7 +35,7 @@ protected:
     void transferTextureSynchronous(const gpu::Texture& texture);
 
 private:
-    std::shared_ptr<OffscreenGLCanvas> _canvas;
+    QSharedPointer<OffscreenGLCanvas> _canvas;
 };
 
 template <typename F>

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
@@ -23,6 +23,7 @@ struct TextureTransferPackage {
 class GLTextureTransferHelper : public GenericQueueThread<TextureTransferPackage> {
 public:
     GLTextureTransferHelper();
+    ~GLTextureTransferHelper();
     void transferTexture(const gpu::TexturePointer& texturePointer);
     void postTransfer(const gpu::TexturePointer& texturePointer);
 


### PR DESCRIPTION
Prevents a crash on clean exit from the texture transfer thread, from (either) calling the virtual `shutdown` method from the base dtor, or from accessing the `_canvas` member after it had been freed, or from deleting the `_canvas` QObject in the wrong thread.

This is only evident in "clean" exits. Current release builds call `_exit`, so this will make no difference there.