### PR TITLE
Vive timewarp

### DIFF
--- a/interface/resources/shaders/reproject.frag
+++ b/interface/resources/shaders/reproject.frag
@@ -1,0 +1,71 @@
+#version 450 core
+
+uniform sampler2D sampler;
+layout (location = 0) uniform mat3 reprojection = mat3(1);
+layout (location = 4) uniform mat4 inverseProjections[2];
+layout (location = 12) uniform mat4 projections[2];
+
+in vec2 vTexCoord;
+in vec3 vPosition;
+
+out vec4 FragColor;
+
+void main() {
+    vec2 uv = vTexCoord;
+
+    mat4 eyeInverseProjection;
+    mat4 eyeProjection;
+    
+    float xoffset = 1.0;
+    vec2 uvmin = vec2(0.0);
+    vec2 uvmax = vec2(1.0);
+    // determine the correct projection and inverse projection to use.
+    if (vTexCoord.x < 0.5) {
+        uvmax.x = 0.5;
+        eyeInverseProjection = inverseProjections[0];
+        eyeProjection = projections[0];
+    } else {
+        xoffset = -1.0;
+        uvmin.x = 0.5;
+        uvmax.x = 1.0;
+        eyeInverseProjection = inverseProjections[1];
+        eyeProjection = projections[1];
+    }
+
+    // Account for stereo in calculating the per-eye NDC coordinates
+    vec4 ndcSpace = vec4(vPosition, 1.0);
+    ndcSpace.x *= 2.0;
+    ndcSpace.x += xoffset;
+    
+    // Convert from NDC to eyespace
+    vec4 eyeSpace = eyeInverseProjection * ndcSpace;
+    eyeSpace /= eyeSpace.w;
+
+    // Convert to a noramlized ray 
+    vec3 ray = eyeSpace.xyz;
+    ray = normalize(ray);
+
+    // Adjust the ray by the rotation
+    ray = reprojection * ray;
+
+    // Project back on to the texture plane
+    ray /= ray.z;
+    ray *= eyeSpace.z;
+
+    // Update the eyespace vector
+    eyeSpace.xyz = ray;
+
+    // Reproject back into NDC
+    ndcSpace = eyeProjection * eyeSpace;
+    ndcSpace /= ndcSpace.w;
+    ndcSpace.x -= xoffset;
+    ndcSpace.x /= 2.0;
+    
+    // Calculate the new UV coordinates
+    uv = (ndcSpace.xy / 2.0) + 0.5;
+    if (any(greaterThan(uv, uvmax)) || any(lessThan(uv, uvmin))) {
+        FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    } else {
+        FragColor = texture(sampler, uv);
+    }
+}

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -71,6 +71,7 @@ protected:
     glm::uvec2 getSurfacePixels() const;
 
     void compositeLayers();
+    virtual void compositeScene();
     virtual void compositeOverlay();
     virtual void compositePointer();
 
@@ -93,6 +94,7 @@ protected:
 
     void withMainThreadContext(std::function<void()> f) const;
 
+    void useProgram(const ProgramPtr& program);
     void present();
     void updateTextures();
     void drawUnitQuad();
@@ -111,7 +113,7 @@ protected:
     RateCounter<> _newFrameRate;
     RateCounter<> _presentRate;
     QMap<gpu::TexturePointer, uint32_t> _sceneTextureToFrameIndexMap;
-    uint32_t _currentRenderFrameIndex { 0 };
+    uint32_t _currentPresentFrameIndex { 0 };
 
     gpu::TexturePointer _currentSceneTexture;
     gpu::TexturePointer _currentOverlayTexture;
@@ -130,6 +132,10 @@ protected:
 
     std::map<uint16_t, CursorData> _cursorsData;
     BasicFramebufferWrapperPtr _compositeFramebuffer;
+    bool _lockCurrentTexture { false };
+
+private:
+    ProgramPtr _activeProgram;
 };
 
 

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -28,13 +28,6 @@ public:
 
     virtual glm::mat4 getHeadPose() const override;
 
-    struct FrameInfo {
-        glm::mat4 renderPose;
-        glm::mat4 presentPose;
-        double sensorSampleTime { 0 };
-        double predictedDisplayTime { 0 };
-        glm::mat3 presentRotation() const;
-    };
 
 
 protected:
@@ -60,6 +53,16 @@ protected:
     glm::uvec2 _renderTargetSize;
     float _ipd { 0.064f };
 
+    struct FrameInfo {
+        glm::mat4 rawRenderPose;
+        glm::mat4 renderPose;
+        glm::mat4 rawPresentPose;
+        glm::mat4 presentPose;
+        double sensorSampleTime { 0 };
+        double predictedDisplayTime { 0 };
+        glm::mat3 presentReprojection;
+    };
+
     QMap<uint32_t, FrameInfo> _frameInfos;
     FrameInfo _currentPresentFrameInfo;
     FrameInfo _currentRenderFrameInfo;
@@ -67,6 +70,7 @@ protected:
 private:
     bool _enablePreview { false };
     bool _monoPreview { true };
+    bool _enableReprojection { true };
     ShapeWrapperPtr _sphereSection;
     ProgramPtr _reprojectionProgram;
 };

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -28,13 +28,12 @@ public:
 
     virtual glm::mat4 getHeadPose() const override;
 
-    using EyePoses = std::array<glm::mat4, 2>;
-
     struct FrameInfo {
-        EyePoses eyePoses;
-        glm::mat4 headPose;
+        glm::mat4 renderPose;
+        glm::mat4 presentPose;
         double sensorSampleTime { 0 };
         double predictedDisplayTime { 0 };
+        glm::mat3 presentRotation() const;
     };
 
 
@@ -42,8 +41,10 @@ protected:
     virtual void hmdPresent() = 0;
     virtual bool isHmdMounted() const = 0;
     virtual void postPreview() {};
+    virtual void updatePresentPose();
 
     bool internalActivate() override;
+    void compositeScene() override;
     void compositeOverlay() override;
     void compositePointer() override;
     void internalPresent() override;
@@ -53,17 +54,20 @@ protected:
 
     std::array<glm::mat4, 2> _eyeOffsets;
     std::array<glm::mat4, 2> _eyeProjections;
+    std::array<glm::mat4, 2> _eyeInverseProjections;
+
     glm::mat4 _cullingProjection;
     glm::uvec2 _renderTargetSize;
     float _ipd { 0.064f };
 
     QMap<uint32_t, FrameInfo> _frameInfos;
     FrameInfo _currentPresentFrameInfo;
-    ThreadSafeValueCache<FrameInfo> _currentRenderFrameInfo;
+    FrameInfo _currentRenderFrameInfo;
 
 private:
     bool _enablePreview { false };
     bool _monoPreview { true };
     ShapeWrapperPtr _sphereSection;
+    ProgramPtr _reprojectionProgram;
 };
 

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -16,15 +16,14 @@ void OculusBaseDisplayPlugin::resetSensors() {
 }
 
 void OculusBaseDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
-    FrameInfo frame;
-    frame.sensorSampleTime = ovr_GetTimeInSeconds();;
-    frame.predictedDisplayTime = ovr_GetPredictedDisplayTime(_session, frameIndex);
-    auto trackingState = ovr_GetTrackingState(_session, frame.predictedDisplayTime, ovrTrue);
-    frame.headPose = toGlm(trackingState.HeadPose.ThePose);
-
-    _currentRenderFrameInfo.set(frame);
+    _currentRenderFrameInfo = FrameInfo();
+    _currentRenderFrameInfo.sensorSampleTime = ovr_GetTimeInSeconds();;
+    _currentRenderFrameInfo.predictedDisplayTime = ovr_GetPredictedDisplayTime(_session, frameIndex);
+    auto trackingState = ovr_GetTrackingState(_session, _currentRenderFrameInfo.predictedDisplayTime, ovrTrue);
+    _currentRenderFrameInfo.renderPose = toGlm(trackingState.HeadPose.ThePose);
+    _currentRenderFrameInfo.presentPose = _currentRenderFrameInfo.renderPose;
     Lock lock(_mutex);
-    _frameInfos[frameIndex] = frame;
+    _frameInfos[frameIndex] = _currentRenderFrameInfo;
 }
 
 bool OculusBaseDisplayPlugin::isSupported() const {

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -84,7 +84,7 @@ void blit(const SrcFbo& srcFbo, const DstFbo& dstFbo) {
 
 void OculusDisplayPlugin::hmdPresent() {
 
-    PROFILE_RANGE_EX(__FUNCTION__, 0xff00ff00, (uint64_t)_currentRenderFrameIndex)
+    PROFILE_RANGE_EX(__FUNCTION__, 0xff00ff00, (uint64_t)_currentPresentFrameIndex)
 
     if (!_currentSceneTexture) {
         return;
@@ -94,10 +94,10 @@ void OculusDisplayPlugin::hmdPresent() {
     _sceneFbo->Commit();
     {
         _sceneLayer.SensorSampleTime = _currentPresentFrameInfo.sensorSampleTime;
-        _sceneLayer.RenderPose[ovrEyeType::ovrEye_Left] = ovrPoseFromGlm(_currentPresentFrameInfo.headPose);
-        _sceneLayer.RenderPose[ovrEyeType::ovrEye_Right] = ovrPoseFromGlm(_currentPresentFrameInfo.headPose);
+        _sceneLayer.RenderPose[ovrEyeType::ovrEye_Left] = ovrPoseFromGlm(_currentPresentFrameInfo.renderPose);
+        _sceneLayer.RenderPose[ovrEyeType::ovrEye_Right] = ovrPoseFromGlm(_currentPresentFrameInfo.renderPose);
         ovrLayerHeader* layers = &_sceneLayer.Header;
-        ovrResult result = ovr_SubmitFrame(_session, _currentRenderFrameIndex, &_viewScaleDesc, &layers, 1);
+        ovrResult result = ovr_SubmitFrame(_session, _currentPresentFrameIndex, &_viewScaleDesc, &layers, 1);
         if (!OVR_SUCCESS(result)) {
             logWarning("Failed to present");
         }

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -38,7 +38,7 @@ void OculusLegacyDisplayPlugin::resetSensors() {
 void OculusLegacyDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
     _currentRenderFrameInfo = FrameInfo();
     _currentRenderFrameInfo.predictedDisplayTime = _currentRenderFrameInfo.sensorSampleTime = ovr_GetTimeInSeconds();
-    _trackingState = ovrHmd_GetTrackingState(_hmd, _currentRenderFrameInfo..predictedDisplayTime);
+    _trackingState = ovrHmd_GetTrackingState(_hmd, _currentRenderFrameInfo.predictedDisplayTime);
     _currentRenderFrameInfo.renderPose = toGlm(_trackingState.HeadPose.ThePose);
     Lock lock(_mutex);
     _frameInfos[frameIndex] = _currentRenderFrameInfo;

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -36,13 +36,12 @@ void OculusLegacyDisplayPlugin::resetSensors() {
 }
 
 void OculusLegacyDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
-    FrameInfo frame;
-    frame.predictedDisplayTime = frame.sensorSampleTime = ovr_GetTimeInSeconds();
-    _trackingState = ovrHmd_GetTrackingState(_hmd, frame.predictedDisplayTime);
-    frame.headPose = toGlm(_trackingState.HeadPose.ThePose);
-    _currentRenderFrameInfo.set(frame);
+    _currentRenderFrameInfo = FrameInfo();
+    _currentRenderFrameInfo.predictedDisplayTime = _currentRenderFrameInfo.sensorSampleTime = ovr_GetTimeInSeconds();
+    _trackingState = ovrHmd_GetTrackingState(_hmd, _currentRenderFrameInfo..predictedDisplayTime);
+    _currentRenderFrameInfo.renderPose = toGlm(_trackingState.HeadPose.ThePose);
     Lock lock(_mutex);
-    _frameInfos[frameIndex] = frame;
+    _frameInfos[frameIndex] = _currentRenderFrameInfo;
 }
 
 bool OculusLegacyDisplayPlugin::isSupported() const {

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include <QtCore/QProcessEnvironment>
 #include <QMainWindow>
 #include <QLoggingCategory>
 #include <QGLWidget>
@@ -29,6 +30,10 @@ Q_DECLARE_LOGGING_CATEGORY(displayplugins)
 const QString OpenVrDisplayPlugin::NAME("OpenVR (Vive)");
 const QString StandingHMDSensorMode = "Standing HMD Sensor Mode"; // this probably shouldn't be hardcoded here
 
+static const QString DEBUG_FLAG("HIFI_DEBUG_OPENVR");
+static bool enableDebugOpenVR = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
+
+
 static vr::IVRCompositor* _compositor{ nullptr };
 vr::TrackedDevicePose_t _trackedDevicePose[vr::k_unMaxTrackedDeviceCount];
 mat4 _trackedDevicePoseMat4[vr::k_unMaxTrackedDeviceCount];
@@ -38,7 +43,7 @@ static mat4 _sensorResetMat;
 static std::array<vr::Hmd_Eye, 2> VR_EYES { { vr::Eye_Left, vr::Eye_Right } };
 
 bool OpenVrDisplayPlugin::isSupported() const {
-    return !isOculusPresent() && vr::VR_IsHmdPresent();
+    return (enableDebugOpenVR || !isOculusPresent()) && vr::VR_IsHmdPresent();
 }
 
 bool OpenVrDisplayPlugin::internalActivate() {

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -140,18 +140,16 @@ void OpenVrDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
     _currentRenderFrameInfo.predictedDisplayTime = frameDuration + vsyncToPhotons;
 #endif
 
-    vr::TrackedDevicePose_t predictedTrackedDevicePose[vr::k_unMaxTrackedDeviceCount];
-    _system->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, _currentRenderFrameInfo.predictedDisplayTime, predictedTrackedDevicePose, vr::k_unMaxTrackedDeviceCount);
+    _system->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, _currentRenderFrameInfo.predictedDisplayTime, _trackedDevicePose, vr::k_unMaxTrackedDeviceCount);
 
     // copy and process predictedTrackedDevicePoses
     for (int i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
-        _trackedDevicePose[i] = predictedTrackedDevicePose[i];
-        _trackedDevicePoseMat4[i] = toGlm(_trackedDevicePose[i].mDeviceToAbsoluteTracking);
+        _trackedDevicePoseMat4[i] = _sensorResetMat * toGlm(_trackedDevicePose[i].mDeviceToAbsoluteTracking);
         _trackedDeviceLinearVelocities[i] = transformVectorFast(_sensorResetMat, toGlm(_trackedDevicePose[i].vVelocity));
         _trackedDeviceAngularVelocities[i] = transformVectorFast(_sensorResetMat, toGlm(_trackedDevicePose[i].vAngularVelocity));
     }
-    _currentRenderFrameInfo.rawRenderPose = _trackedDevicePoseMat4[vr::k_unTrackedDeviceIndex_Hmd];
-    _currentRenderFrameInfo.renderPose = _sensorResetMat * _currentRenderFrameInfo.rawRenderPose;
+    _currentRenderFrameInfo.rawRenderPose = toGlm(_trackedDevicePose[vr::k_unTrackedDeviceIndex_Hmd].mDeviceToAbsoluteTracking);
+    _currentRenderFrameInfo.renderPose = _trackedDevicePoseMat4[vr::k_unTrackedDeviceIndex_Hmd];
 
     Lock lock(_mutex);
     _frameInfos[frameIndex] = _currentRenderFrameInfo;

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -28,10 +28,12 @@ public:
     // Stereo specific methods
     virtual void resetSensors() override;
     virtual void beginFrameRender(uint32_t frameIndex) override;
+    void cycleDebugOutput() override { _lockCurrentTexture = !_lockCurrentTexture; }
 
 protected:
     bool internalActivate() override;
     void internalDeactivate() override;
+    void updatePresentPose() override;
 
     void hmdPresent() override;
     bool isHmdMounted() const override;


### PR DESCRIPTION
Because of our relatively long rendering pipeline and the variability of rendering rates depending on domain content, in HMDs we rely on reprojection of the scene based on the difference between the render pose and the actual present pose.  Unfortunately, the Vive doesn't support reprojection natively like Oculus.  As such we need a mechanism to do the reprojection ourselves when we composite the scene texture for submission to the OpenVR API.

This is an implementation of reprojection (timewarp) for OpenVR.
