### PR TITLE
replace Sandbox default content set with Home

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -195,6 +195,7 @@ void Agent::requestScript() {
         // then wait for the nodeConnected signal to fire off the request
 
         auto assetServer = nodeList->soloNodeOfType(NodeType::AssetServer);
+
         if (!assetServer || !assetServer->getActiveSocket()) {
             qDebug() << "Waiting to connect to Asset Server for ATP script download.";
             _pendingScriptRequest = request;
@@ -209,7 +210,7 @@ void Agent::requestScript() {
 }
 
 void Agent::nodeActivated(SharedNodePointer activatedNode) {
-    if (_pendingScriptRequest) {
+    if (_pendingScriptRequest && activatedNode->getType() == NodeType::AssetServer) {
         qInfo() << "Requesting script at URL" << qPrintable(_pendingScriptRequest->getUrl().toString());
 
         _pendingScriptRequest->send();

--- a/server-console/package.json
+++ b/server-console/package.json
@@ -32,7 +32,7 @@
     "os-homedir": "^1.0.1",
     "request": "2.67.0",
     "request-progress": "1.0.2",
-    "unzip": "0.1.11",
+    "tar-fs": "^1.12.0",
     "yargs": "^3.30.0"
   }
 }

--- a/server-console/package.json
+++ b/server-console/package.json
@@ -9,8 +9,8 @@
   ],
   "devDependencies": {
     "electron-compilers": "^1.0.1",
-    "electron-packager": "^5.2.1",
-    "electron-prebuilt": "0.35.4"
+    "electron-packager": "^6.0.2",
+    "electron-prebuilt": "0.37.5"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "fs-extra": "^0.26.4",
     "node-notifier": "^4.4.0",
     "os-homedir": "^1.0.1",
-    "request": "2.67.0",
+    "request": "^2.67.0",
     "request-progress": "1.0.2",
     "tar-fs": "^1.12.0",
     "yargs": "^3.30.0"

--- a/server-console/packager.js
+++ b/server-console/packager.js
@@ -17,7 +17,7 @@ var iconName = argv.production ? "console" : "console-beta";
 var options = {
     dir: __dirname,
     name: "server-console",
-    version: "0.35.4",
+    version: "0.37.5",
     overwrite: true,
     prune: true,
     arch: "x64",

--- a/server-console/src/downloader.html
+++ b/server-console/src/downloader.html
@@ -16,7 +16,7 @@
         </div>
 
         <div id="state-installing" class="state">
-            <h1>Installing<span class="one">.</span><span class="two">.</span><span class="three">.</span></h1>
+            <h1>Extracting<span class="one">.</span><span class="two">.</span><span class="three">.</span></h1>
             <em>Just a moment</em>
         </div>
 

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -561,14 +561,14 @@ function maybeInstallDefaultContentSet(onComplete) {
                 sendStateUpdate('error', {
                     message: message
                 });
-            } else {
-                sendStateUpdate('installing');
             }
         }), { throttle: 250 }).on('progress', function(state) {
             if (!aborted) {
                 // Update progress popup
                 sendStateUpdate('downloading', state);
             }
+        }).on('end', function(){
+            sendStateUpdate('installing');
         });
 
         function extractError(err) {
@@ -582,13 +582,8 @@ function maybeInstallDefaultContentSet(onComplete) {
             });
         }
 
-        var gunzip = zlib.createGunzip({
-            level: 9
-        });
+        var gunzip = zlib.createGunzip();
         gunzip.on('error', extractError);
-        gunzip.on('finish', function(){
-            console.log("GUNZIP DONE");
-        });
 
         req.pipe(gunzip).pipe(tar.extract(getRootHifiDataDirectory())).on('error', extractError).on('finish', function(){
             // response and decompression complete, return

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -17,7 +17,8 @@ const path = require('path');
 const fs = require('fs-extra');
 const Tail = require('always-tail');
 const http = require('http');
-const unzip = require('unzip');
+const zlib = require('zlib');
+const tar = require('tar-fs');
 
 const request = require('request');
 const progress = require('request-progress');
@@ -88,6 +89,10 @@ function getRootHifiDataDirectory() {
     } else {
         return path.resolve(osHomeDir(), '.local/share/', organization);
     }
+}
+
+function getDomainServerClientResourcesDirectory() {
+    return path.join(getRootHifiDataDirectory(), '/domain-server');
 }
 
 function getAssignmentClientResourcesDirectory() {
@@ -477,18 +482,34 @@ function updateTrayMenu(serverState) {
 const httpStatusPort = 60332;
 
 function maybeInstallDefaultContentSet(onComplete) {
-    // Check for existing AC data
+    // Check for existing data
     const acResourceDirectory = getAssignmentClientResourcesDirectory();
+
     console.log("Checking for existence of " + acResourceDirectory);
-    var userHasExistingServerData = true;
+
+    var userHasExistingACData = true;
     try {
         fs.accessSync(acResourceDirectory);
+        console.log("Found directory " + acResourceDirectory);
     } catch (e) {
         console.log(e);
-        userHasExistingServerData = false;
+        userHasExistingACData = false;
     }
 
-    if (userHasExistingServerData) {
+    const dsResourceDirectory = getDomainServerClientResourcesDirectory();
+
+    console.log("checking for existence of " + dsResourceDirectory);
+
+    var userHasExistingDSData = true;
+    try {
+        fs.accessSync(dsResourceDirectory);
+        console.log("Found directory " + dsResourceDirectory);
+    } catch (e) {
+        console.log(e);
+        userHasExistingDSData = false;
+    }
+
+    if (userHasExistingACData || userHasExistingDSData) {
         console.log("User has existing data, suppressing downloader");
         onComplete();
         return;
@@ -514,16 +535,19 @@ function maybeInstallDefaultContentSet(onComplete) {
 
     electron.ipcMain.on('ready', function() {
         console.log("got ready");
+        var currentState = '';
+
         function sendStateUpdate(state, args) {
             // console.log(state, window, args);
             window.webContents.send('update', { state: state, args: args });
+            currentState = state;
         }
 
         var aborted = false;
 
         // Start downloading content set
         var req = progress(request.get({
-            url: "https://s3.amazonaws.com/hifi-public/homeset/ContentSet-Lounge.zip"
+            url: "http://cachefly.highfidelity.com/home.tgz"
         }, function(error, responseMessage, responseData) {
             if (aborted) {
                 return;
@@ -546,24 +570,21 @@ function maybeInstallDefaultContentSet(onComplete) {
                 sendStateUpdate('downloading', state);
             }
         });
-        var unzipper = unzip.Extract({
-            path: acResourceDirectory,
-            verbose: true
-        });
-        unzipper.on('close', function() {
-            console.log("Done", arguments);
-            sendStateUpdate('complete');
-        });
-        unzipper.on('error', function (err) {
-            console.log("aborting");
+
+        req.pipe(zlib.createGunzip()).pipe(tar.extract(getRootHifiDataDirectory())).on('error', function(){
+            console.log("Aborting request because gunzip/untar failed");
             aborted = true;
             req.abort();
-            console.log("ERROR");
+            console.log("ERROR" +  err);
+
             sendStateUpdate('error', {
                 message: "Error installing resources."
             });
+        }).on('finish', function(){
+            // response and decompression complete, return
+            console.log("Done", arguments);
+            sendStateUpdate('complete');
         });
-        req.pipe(unzipper);
 
         window.on('closed', function() {
             if (currentState == 'downloading') {

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -587,7 +587,7 @@ function maybeInstallDefaultContentSet(onComplete) {
 
         req.pipe(gunzip).pipe(tar.extract(getRootHifiDataDirectory())).on('error', extractError).on('finish', function(){
             // response and decompression complete, return
-            console.log("Done", arguments);
+            console.log("Finished unarchiving home content set");
             sendStateUpdate('complete');
         });
 

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -582,8 +582,13 @@ function maybeInstallDefaultContentSet(onComplete) {
             });
         }
 
-        var gunzip = zlib.createGunzip();
+        var gunzip = zlib.createGunzip({
+            level: 9
+        });
         gunzip.on('error', extractError);
+        gunzip.on('finish', function(){
+            console.log("GUNZIP DONE");
+        });
 
         req.pipe(gunzip).pipe(tar.extract(getRootHifiDataDirectory())).on('error', extractError).on('finish', function(){
             // response and decompression complete, return


### PR DESCRIPTION
- replaces the downloaded content set for sandbox with "home.tgz" from cachefly
- updates electron/electron-prebuilt so we're up to date
- uses gunzip/tar-fs for unarchiving of streamed home.tgz, more reliable than previous unzip
- allows for domain-server settings to be included in content set for custom index path and scripts 