### PR TITLE
Remove model url placeholder text from edit.js import

### DIFF
--- a/examples/edit.js
+++ b/examples/edit.js
@@ -95,10 +95,6 @@ var SHOULD_SHOW_PROPERTY_MENU = false;
 var INSUFFICIENT_PERMISSIONS_ERROR_MSG = "You do not have the necessary permissions to edit on this domain."
 var INSUFFICIENT_PERMISSIONS_IMPORT_ERROR_MSG = "You do not have the necessary permissions to place items on this domain."
 
-var modelURLs = [
-    "Insert the URL to your FBX"
-];
-
 var mode = 0;
 var isActive = false;
 
@@ -432,7 +428,7 @@ var toolBar = (function() {
         }
 
         if (newModelButton === toolBar.clicked(clickedOverlay)) {
-            url = Window.prompt("Model URL", modelURLs[Math.floor(Math.random() * modelURLs.length)]);
+            url = Window.prompt("Model URL");
             if (url !== null && url !== "") {
                 addModel(url);
             }


### PR DESCRIPTION
This PR removes the placeholder text from the import prompt in edit.js  It was inaccurate and needed to be cleared before using.

To test:
1. Run edit.js
2. Click the edit icon
3. click the import icon
4. observe that there is no text in the model url field
5. test that uploading a model works as expected
