### PR TITLE
Fixing the resize of gpu::framebuffer to avoid unecessary re validation every frame

### DIFF
--- a/libraries/gpu/src/gpu/Framebuffer.cpp
+++ b/libraries/gpu/src/gpu/Framebuffer.cpp
@@ -118,12 +118,14 @@ void Framebuffer::resize(uint16 width, uint16 height, uint16 numSamples) {
                 if (_renderBuffers[i]) {
                     _renderBuffers[i]._texture->resize2D(width, height, numSamples);
                     _numSamples = _renderBuffers[i]._texture->getNumSamples();
+                    ++_colorStamps[i];
                 }
             }
 
             if (_depthStencilBuffer) {
                 _depthStencilBuffer._texture->resize2D(width, height, numSamples);
                 _numSamples = _depthStencilBuffer._texture->getNumSamples();
+                ++_depthStamp; 
             }
 
             _width = width;

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -56,6 +56,7 @@ const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
         auto height = _antialiasingBuffer->getHeight();
         auto defaultSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT);
         _antialiasingTexture = gpu::TexturePointer(gpu::Texture::create2D(format, width, height, defaultSampler));
+        _antialiasingBuffer->setRenderBuffer(0, _antialiasingTexture);
 
         // Good to go add the brand new pipeline
         _antialiasingPipeline = gpu::Pipeline::create(program, state);
@@ -126,7 +127,6 @@ void Antialiasing::run(const render::SceneContextPointer& sceneContext, const re
         // FXAA step
         getAntialiasingPipeline();
         batch.setResourceTexture(0, framebufferCache->getLightingTexture());
-        _antialiasingBuffer->setRenderBuffer(0, _antialiasingTexture);
         batch.setFramebuffer(_antialiasingBuffer);
         batch.setPipeline(getAntialiasingPipeline());
 


### PR DESCRIPTION
This PR  simply fixes the lack of dirty flag notification on the Framebuffer when it gets resized.
FIxing it now avoid to call setREnderBuffer every frame in the Antialiasing effect which was causing extra gl calls that could show up in profiling.
I could see as much as 1ms saved there.
It s a simple fix, not risky.