### PR TITLE
add support for avatar licenses in FST files

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -96,6 +96,7 @@
 #include <UserActivityLogger.h>
 #include <recording/Deck.h>
 #include <recording/Recorder.h>
+#include <shared/StringHelpers.h>
 #include <QmlWebWindowClass.h>
 #include <Preferences.h>
 #include <display-plugins/CompositorHelper.h>
@@ -4517,18 +4518,36 @@ bool Application::askToSetAvatarUrl(const QString& url) {
     FSTReader::ModelType modelType = FSTReader::predictModelType(fstMapping);
 
     QString modelName = fstMapping["name"].toString();
+    QString modelLicense = fstMapping["license"].toString();
+
+    bool agreeToLicence = true; // assume true
+    if (!modelLicense.isEmpty()) {
+        // word wrap the licence text to fit in a reasonable shaped message box.
+        const int MAX_CHARACTERS_PER_LINE = 90;
+        modelLicense = simpleWordWrap(modelLicense, MAX_CHARACTERS_PER_LINE);
+
+        agreeToLicence = QMessageBox::Yes == OffscreenUi::question("Avatar Usage License",
+            modelLicense + "\nDo you argee to these terms?",
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+    }
+
     bool ok = false;
-    switch (modelType) {
 
-        case FSTReader::HEAD_AND_BODY_MODEL:
-             ok = QMessageBox::Ok == OffscreenUi::question("Set Avatar",
-                               "Would you like to use '" + modelName + "' for your avatar?",
-                               QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
-        break;
+    if (!agreeToLicence) {
+        qCDebug(interfaceapp) << "Declined to agree to avatar license: " << url;
+    } else {
+        switch (modelType) {
 
-        default:
-            OffscreenUi::warning("", modelName + "Does not support a head and body as required.");
-        break;
+            case FSTReader::HEAD_AND_BODY_MODEL:
+                 ok = QMessageBox::Ok == OffscreenUi::question("Set Avatar",
+                                   "Would you like to use '" + modelName + "' for your avatar?",
+                                   QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
+            break;
+
+            default:
+                OffscreenUi::warning("", modelName + "Does not support a head and body as required.");
+            break;
+        }
     }
 
     if (ok) {

--- a/libraries/shared/src/shared/StringHelpers.cpp
+++ b/libraries/shared/src/shared/StringHelpers.cpp
@@ -1,0 +1,41 @@
+//
+//  Created by Brad Hefta-Gaub on 2016/04/13
+//  Copyright 2013-2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <QStringList>
+
+#include "StringHelpers.h"
+
+/// Note: this will not preserve line breaks in the original input.
+QString simpleWordWrap(const QString& input, int maxCharactersPerLine) {
+    QStringList words = input.split(QRegExp("\\s+"));
+    QString output;
+    QString currentLine;
+    foreach(const auto& word, words) {
+        auto newLength = currentLine.length() + word.length() + 1;
+
+        // if this next word would fit, include it
+        if (newLength <= maxCharactersPerLine) {
+            currentLine += " " + word;
+        } else {
+            if (!output.isEmpty()) {
+                output += "\n";
+            }
+            output += currentLine;
+            currentLine = word;
+        }
+    }
+
+    // if there is remaining text in the current line, append it to the end
+    if (!currentLine.isEmpty()) {
+        if (!output.isEmpty()) {
+            output += "\n";
+        }
+        output += currentLine;
+    }
+    return output;
+}

--- a/libraries/shared/src/shared/StringHelpers.h
+++ b/libraries/shared/src/shared/StringHelpers.h
@@ -1,0 +1,17 @@
+//
+//  Created by Brad Hefta-Gaub on 2016/04/13
+//  Copyright 2013-2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+#ifndef hifi_Shared_StringHelpers_h
+#define hifi_Shared_StringHelpers_h
+
+#include <QString>
+
+QString simpleWordWrap(const QString& input, int maxCharactersPerLine);
+
+#endif


### PR DESCRIPTION
Some avatar FST files might contain special licenses, if so, when you attempt to wear them, we will display the license and ask you to agree to the license.