### PR TITLE
Track resources as they fall out of cache

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -137,9 +137,14 @@ void ResourceCache::setUnusedResourceCacheSize(qint64 unusedResourcesMaxSize) {
 }
 
 void ResourceCache::addUnusedResource(const QSharedPointer<Resource>& resource) {
-    // If it doesn't fit or its size is unknown, leave the cache alone.
+    // If it doesn't fit or its size is unknown, remove it from the cache.
     if (resource->getBytes() == 0 || resource->getBytes() > _unusedResourcesMaxSize) {
         resource->setCache(nullptr);
+
+        _totalResourcesSize -= resource->getBytes();
+        _resources.remove(resource->getURL());
+        resetResourceCounters();
+
         return;
     }
     reserveUnusedResource(resource->getBytes());


### PR DESCRIPTION
Fixes the counters in cacheStats.js, so that they decrease when resources go out of scope. Without this change, the counters for totals will keep on increasing.