### PR TITLE
only export joint values if they've been explicitly set by scripts

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -748,6 +748,7 @@ glm::vec3 RenderableModelEntityItem::getAbsoluteJointTranslationInObjectFrame(in
 bool RenderableModelEntityItem::setAbsoluteJointRotationInObjectFrame(int index, const glm::quat& rotation) {
     bool result = false;
     _jointDataLock.withWriteLock([&] {
+        _jointRotationsExplicitlySet = true;
         resizeJointArrays();
         if (index >= 0 && index < _absoluteJointRotationsInObjectFrame.size() &&
             _absoluteJointRotationsInObjectFrame[index] != rotation) {
@@ -764,6 +765,7 @@ bool RenderableModelEntityItem::setAbsoluteJointRotationInObjectFrame(int index,
 bool RenderableModelEntityItem::setAbsoluteJointTranslationInObjectFrame(int index, const glm::vec3& translation) {
     bool result = false;
     _jointDataLock.withWriteLock([&] {
+        _jointTranslationsExplicitlySet = true;
         resizeJointArrays();
         if (index >= 0 && index < _absoluteJointTranslationsInObjectFrame.size() &&
             _absoluteJointTranslationsInObjectFrame[index] != translation) {

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -541,13 +541,6 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_LOCAL_POSITION, localPosition);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_LOCAL_ROTATION, localRotation);
 
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_JOINT_ROTATIONS_SET, jointRotationsSet);
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_JOINT_ROTATIONS, jointRotations);
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_JOINT_TRANSLATIONS_SET, jointTranslationsSet);
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_JOINT_TRANSLATIONS, jointTranslations);
-
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_QUERY_AA_CUBE, queryAACube);
-
     // FIXME - I don't think these properties are supported any more
     //COPY_PROPERTY_TO_QSCRIPTVALUE(glowLevel);
     //COPY_PROPERTY_TO_QSCRIPTVALUE(localRenderAlpha);

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -404,6 +404,7 @@ void ModelEntityItem::resizeJointArrays(int newSize) {
 
 void ModelEntityItem::setJointRotations(const QVector<glm::quat>& rotations) {
     _jointDataLock.withWriteLock([&] {
+        _jointRotationsExplicitlySet = rotations.size() > 0;
         resizeJointArrays(rotations.size());
         for (int index = 0; index < rotations.size(); index++) {
             if (_absoluteJointRotationsInObjectFrameSet[index]) {
@@ -416,6 +417,7 @@ void ModelEntityItem::setJointRotations(const QVector<glm::quat>& rotations) {
 
 void ModelEntityItem::setJointRotationsSet(const QVector<bool>& rotationsSet) {
     _jointDataLock.withWriteLock([&] {
+        _jointRotationsExplicitlySet = rotationsSet.size() > 0;
         resizeJointArrays(rotationsSet.size());
         for (int index = 0; index < rotationsSet.size(); index++) {
             _absoluteJointRotationsInObjectFrameSet[index] = rotationsSet[index];
@@ -425,6 +427,7 @@ void ModelEntityItem::setJointRotationsSet(const QVector<bool>& rotationsSet) {
 
 void ModelEntityItem::setJointTranslations(const QVector<glm::vec3>& translations) {
     _jointDataLock.withWriteLock([&] {
+        _jointTranslationsExplicitlySet = translations.size() > 0;
         resizeJointArrays(translations.size());
         for (int index = 0; index < translations.size(); index++) {
             if (_absoluteJointTranslationsInObjectFrameSet[index]) {
@@ -437,6 +440,7 @@ void ModelEntityItem::setJointTranslations(const QVector<glm::vec3>& translation
 
 void ModelEntityItem::setJointTranslationsSet(const QVector<bool>& translationsSet) {
     _jointDataLock.withWriteLock([&] {
+        _jointTranslationsExplicitlySet = translationsSet.size() > 0;
         resizeJointArrays(translationsSet.size());
         for (int index = 0; index < translationsSet.size(); index++) {
             _absoluteJointTranslationsInObjectFrameSet[index] = translationsSet[index];
@@ -447,7 +451,9 @@ void ModelEntityItem::setJointTranslationsSet(const QVector<bool>& translationsS
 QVector<glm::quat> ModelEntityItem::getJointRotations() const {
     QVector<glm::quat> result;
     _jointDataLock.withReadLock([&] {
-        result = _absoluteJointRotationsInObjectFrame;
+        if (_jointRotationsExplicitlySet) {
+            result = _absoluteJointRotationsInObjectFrame;
+        }
     });
     return result;
 }
@@ -455,15 +461,20 @@ QVector<glm::quat> ModelEntityItem::getJointRotations() const {
 QVector<bool> ModelEntityItem::getJointRotationsSet() const {
     QVector<bool> result;
     _jointDataLock.withReadLock([&] {
-        result = _absoluteJointRotationsInObjectFrameSet;
+        if (_jointRotationsExplicitlySet) {
+            result = _absoluteJointRotationsInObjectFrameSet;
+        }
     });
+
     return result;
 }
 
 QVector<glm::vec3> ModelEntityItem::getJointTranslations() const {
     QVector<glm::vec3> result;
     _jointDataLock.withReadLock([&] {
-        result = _absoluteJointTranslationsInObjectFrame;
+        if (_jointTranslationsExplicitlySet) {
+            result = _absoluteJointTranslationsInObjectFrame;
+        }
     });
     return result;
 }
@@ -471,7 +482,9 @@ QVector<glm::vec3> ModelEntityItem::getJointTranslations() const {
 QVector<bool> ModelEntityItem::getJointTranslationsSet() const {
     QVector<bool> result;
     _jointDataLock.withReadLock([&] {
-        result = _absoluteJointTranslationsInObjectFrameSet;
+        if (_jointTranslationsExplicitlySet) {
+            result = _absoluteJointTranslationsInObjectFrameSet;
+        }
     });
     return result;
 }

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -140,9 +140,13 @@ protected:
     // they aren't currently updated from data in the model/rig, and they don't have a direct effect
     // on what's rendered.
     ReadWriteLockable _jointDataLock;
+
+    bool _jointRotationsExplicitlySet { false }; // were the joints set as a property or just side effect of animations
     QVector<glm::quat> _absoluteJointRotationsInObjectFrame;
     QVector<bool> _absoluteJointRotationsInObjectFrameSet; // ever set?
     QVector<bool> _absoluteJointRotationsInObjectFrameDirty; // needs a relay to model/rig?
+    
+    bool _jointTranslationsExplicitlySet { false }; // were the joints set as a property or just side effect of animations
     QVector<glm::vec3> _absoluteJointTranslationsInObjectFrame;
     QVector<bool> _absoluteJointTranslationsInObjectFrameSet; // ever set?
     QVector<bool> _absoluteJointTranslationsInObjectFrameDirty; // needs a relay to model/rig?


### PR DESCRIPTION
This partially fixes the problem with exporting/importing and duplicating models that are being animated. Basically, if a model was animated, the client thought that the joint rotations and translations had been set and was including those in the properties, that was wasteful and caused the exported JSONs and property sets to be larger than they need to be. That would ultimately cause the "addEntity" to fail if it's properties couldn't fit in a single packet.

This fixes the erroneous inclusion of all the extra joint data.