### PR TITLE
allow domain-server to cycle through ice-servers when failing

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1120,6 +1120,9 @@ void DomainServer::sendHeartbeatToIceServer() {
             // reset the number of no reply ICE hearbeats
             _noReplyICEHeartbeats = 0;
 
+            // reset the connection flag for ICE server
+            _connectedToICEServer = false;
+
             randomizeICEServerAddress();
         }
 
@@ -2073,6 +2076,11 @@ void DomainServer::processICEServerHeartbeatDenialPacket(QSharedPointer<Received
 void DomainServer::processICEServerHeartbeatACK(QSharedPointer<ReceivedMessage> message) {
     // we don't do anything with this ACK other than use it to tell us to keep talking to the same ice-server
     _noReplyICEHeartbeats = 0;
+
+    if (!_connectedToICEServer) {
+        _connectedToICEServer = true;
+        qInfo() << "Connected to ice-server at" << _iceServerSocket;
+    }
 }
 
 void DomainServer::handleKeypairChange() {

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -2110,13 +2110,16 @@ void DomainServer::randomizeICEServerAddress() {
     }
 
     // of the list of available addresses that we haven't tried, pick a random one
-    int maxIndex = candidateICEAddresses.size();
+    int maxIndex = candidateICEAddresses.size() - 1;
+    int indexToTry = 0;
 
-    static std::random_device randomDevice;
-    static std::mt19937 generator(randomDevice());
-    std::uniform_int_distribution<> distribution(0, maxIndex);
+    if (maxIndex > 0) {
+        static std::random_device randomDevice;
+        static std::mt19937 generator(randomDevice());
+        std::uniform_int_distribution<> distribution(0, maxIndex);
 
-    auto indexToTry = distribution(generator);
+        indexToTry = distribution(generator);
+    }
 
     _iceServerSocket = HifiSockAddr { candidateICEAddresses[indexToTry], ICE_SERVER_DEFAULT_PORT };
     qInfo() << "Set candidate ice-server socket to" << _iceServerSocket;

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -2113,7 +2113,7 @@ void DomainServer::randomizeICEServerAddress() {
     int maxIndex = candidateICEAddresses.size();
 
     static std::random_device randomDevice;
-    static std::mt19937 generator;
+    static std::mt19937 generator(randomDevice());
     std::uniform_int_distribution<> distribution(0, maxIndex);
 
     auto indexToTry = distribution(generator);

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -172,6 +172,7 @@ private:
     QTimer* _iceAddressLookupTimer { nullptr }; // this looks like a dangling pointer but is parented to the DomainServer
     int _iceAddressLookupID { -1 };
     int _noReplyICEHeartbeats { 0 };
+    bool _connectedToICEServer { false };
 
     friend class DomainGatekeeper;
 };

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -81,6 +81,12 @@ private slots:
     void queuedQuit(QString quitMessage, int exitCode);
 
     void handleKeypairChange();
+
+    void updateICEServerAddresses();
+    void handleICEHostInfo(const QHostInfo& hostInfo);
+
+signals:
+    void iceServerChanged();
     
 private:
     void setupNodeListAndAssignments(const QUuid& sessionUUID = QUuid::createUuid());
@@ -94,6 +100,8 @@ private:
     void setupAutomaticNetworking();
     void setupICEHeartbeatForFullNetworking();
     void sendHeartbeatToDataServer(const QString& networkAddress);
+
+    void randomizeICEServerAddress();
 
     unsigned int countConnectedUsers();
 
@@ -157,7 +165,12 @@ private:
     std::unique_ptr<NLPacket> _iceServerHeartbeatPacket;
 
     QTimer* _iceHeartbeatTimer { nullptr }; // this looks like it dangles when created but it's parented to the DomainServer
-    
+
+    QList<QHostAddress> _iceServerAddresses;
+    QSet<QHostAddress> _failedIceServerAddresses;
+    QTimer* _iceAddressLookupTimer { nullptr }; // this looks like a dangling pointer but is parented to the DomainServer
+    int _iceAddressLookupID { -1 };
+
     friend class DomainGatekeeper;
 };
 

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -62,6 +62,7 @@ public slots:
     void processPathQueryPacket(QSharedPointer<ReceivedMessage> packet);
     void processNodeDisconnectRequestPacket(QSharedPointer<ReceivedMessage> message);
     void processICEServerHeartbeatDenialPacket(QSharedPointer<ReceivedMessage> message);
+    void processICEServerHeartbeatACK(QSharedPointer<ReceivedMessage> message);
     
 private slots:
     void aboutToQuit();
@@ -170,6 +171,7 @@ private:
     QSet<QHostAddress> _failedIceServerAddresses;
     QTimer* _iceAddressLookupTimer { nullptr }; // this looks like a dangling pointer but is parented to the DomainServer
     int _iceAddressLookupID { -1 };
+    int _noReplyICEHeartbeats { 0 };
 
     friend class DomainGatekeeper;
 };

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -86,6 +86,9 @@ private slots:
     void updateICEServerAddresses();
     void handleICEHostInfo(const QHostInfo& hostInfo);
 
+    void sendICEServerAddressToMetaverseAPI();
+    void handleFailedICEServerAddressUpdate(QNetworkReply& requestReply);
+
 signals:
     void iceServerChanged();
     
@@ -172,7 +175,10 @@ private:
     QTimer* _iceAddressLookupTimer { nullptr }; // this looks like a dangling pointer but is parented to the DomainServer
     int _iceAddressLookupID { -1 };
     int _noReplyICEHeartbeats { 0 };
+    int _numHeartbeatDenials { 0 };
     bool _connectedToICEServer { false };
+
+    bool _hasAccessToken { false };
 
     friend class DomainGatekeeper;
 };

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -27,8 +27,6 @@
 const int CLEAR_INACTIVE_PEERS_INTERVAL_MSECS = 1 * 1000;
 const int PEER_SILENCE_THRESHOLD_MSECS = 5 * 1000;
 
-const quint16 ICE_SERVER_MONITORING_PORT = 40110;
-
 IceServer::IceServer(int argc, char* argv[]) :
     QCoreApplication(argc, argv),
     _id(QUuid::createUuid()),
@@ -37,7 +35,6 @@ IceServer::IceServer(int argc, char* argv[]) :
 {
     // start the ice-server socket
     qDebug() << "ice-server socket is listening on" << ICE_SERVER_DEFAULT_PORT;
-    qDebug() << "monitoring http endpoint is listening on " << ICE_SERVER_MONITORING_PORT;
     _serverSocket.bind(QHostAddress::AnyIPv4, ICE_SERVER_DEFAULT_PORT);
 
     // set processPacket as the verified packet callback for the udt::Socket

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -82,6 +82,11 @@ void IceServer::processPacket(std::unique_ptr<udt::Packet> packet) {
             if (peer) {
                 // so that we can send packets to the heartbeating peer when we need, we need to activate a socket now
                 peer->activateMatchingOrNewSymmetricSocket(nlPacket->getSenderSockAddr());
+
+                // we have an active and verified heartbeating peer
+                // send them an ACK packet so they know that they are being heard and ready for ICE
+                static auto ackPacket = NLPacket::create(PacketType::ICEServerHeartbeatACK);
+                _serverSocket.writePacket(*ackPacket, nlPacket->getSenderSockAddr());
             } else {
                 // we couldn't verify this peer - respond back to them so they know they may need to perform keypair re-generation
                 static auto deniedPacket = NLPacket::create(PacketType::ICEServerHeartbeatDenied);

--- a/ice-server/src/IceServer.h
+++ b/ice-server/src/IceServer.h
@@ -28,11 +28,10 @@
 
 class QNetworkReply;
 
-class IceServer : public QCoreApplication, public HTTPRequestHandler {
+class IceServer : public QCoreApplication {
     Q_OBJECT
 public:
     IceServer(int argc, char* argv[]);
-    bool handleHTTPRequest(HTTPConnection* connection, const QUrl& url, bool skipSubHandler = false);
 private slots:
     void clearInactivePeers();
     void publicKeyReplyFinished(QNetworkReply* reply);
@@ -52,13 +51,9 @@ private:
     using NetworkPeerHash = QHash<QUuid, SharedNetworkPeer>;
     NetworkPeerHash _activePeers;
 
-    HTTPManager _httpManager;
-
     using RSAUniquePtr = std::unique_ptr<RSA, std::function<void(RSA*)>>;
     using DomainPublicKeyHash = std::unordered_map<QUuid, RSAUniquePtr>;
     DomainPublicKeyHash _domainPublicKeys;
-
-    quint64 _lastInactiveCheckTimestamp;
 };
 
 #endif // hifi_IceServer_h

--- a/ice-server/src/IceServer.h
+++ b/ice-server/src/IceServer.h
@@ -54,6 +54,8 @@ private:
     using RSAUniquePtr = std::unique_ptr<RSA, std::function<void(RSA*)>>;
     using DomainPublicKeyHash = std::unordered_map<QUuid, RSAUniquePtr>;
     DomainPublicKeyHash _domainPublicKeys;
+
+    QSet<QUuid> _pendingPublicKeyRequests;
 };
 
 #endif // hifi_IceServer_h

--- a/libraries/networking/src/NetworkPeer.h
+++ b/libraries/networking/src/NetworkPeer.h
@@ -21,7 +21,7 @@
 #include "HifiSockAddr.h"
 
 const QString ICE_SERVER_HOSTNAME = "localhost";
-const int ICE_SERVER_DEFAULT_PORT = 7337;
+const quint16 ICE_SERVER_DEFAULT_PORT = 7337;
 const int ICE_HEARBEAT_INTERVAL_MSECS = 2 * 1000;
 const int MAX_ICE_CONNECTION_ATTEMPTS = 5;
 

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -34,8 +34,8 @@ const QSet<PacketType> NON_SOURCED_PACKETS = QSet<PacketType>()
     << PacketType::DomainServerAddedNode << PacketType::DomainServerConnectionToken
     << PacketType::DomainSettingsRequest << PacketType::DomainSettings
     << PacketType::ICEServerPeerInformation << PacketType::ICEServerQuery << PacketType::ICEServerHeartbeat
-    << PacketType::ICEPing << PacketType::ICEPingReply << PacketType::ICEServerHeartbeatDenied
-    << PacketType::AssignmentClientStatus << PacketType::StopNode
+    << PacketType::ICEServerHeartbeatACK << PacketType::ICEPing << PacketType::ICEPingReply
+    << PacketType::ICEServerHeartbeatDenied << PacketType::AssignmentClientStatus << PacketType::StopNode
     << PacketType::DomainServerRemovedNode;
 
 const QSet<PacketType> RELIABLE_PACKETS = QSet<PacketType>();

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -93,7 +93,8 @@ public:
         MessagesUnsubscribe,
         ICEServerHeartbeatDenied,
         AssetMappingOperation,
-        AssetMappingOperationReply
+        AssetMappingOperationReply,
+        ICEServerHeartbeatACK
     };
 };
 


### PR DESCRIPTION
- domain-server uses a new endpoint ice.highfidelity.com to get list of available ice-server addresses
- domain-server fails over to different ice-server address when the currently selected ice-server stops responding
- domain-server updates current ice-server address with metaverse API (including temporary domains)
- ice-server sends ACK packets to domain-server on receipt of a verified heartbeat