### PR TITLE
Name exposed cache objects

### DIFF
--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -22,6 +22,7 @@ AnimationCache::AnimationCache(QObject* parent) :
 {
     const qint64 ANIMATION_DEFAULT_UNUSED_MAX_SIZE = 50 * BYTES_PER_MEGABYTES;
     setUnusedResourceCacheSize(ANIMATION_DEFAULT_UNUSED_MAX_SIZE);
+    setObjectName("AnimationCache");
 }
 
 AnimationPointer AnimationCache::getAnimation(const QUrl& url) {

--- a/libraries/audio/src/SoundCache.cpp
+++ b/libraries/audio/src/SoundCache.cpp
@@ -21,6 +21,7 @@ SoundCache::SoundCache(QObject* parent) :
 {
     const qint64 SOUND_DEFAULT_UNUSED_MAX_SIZE = 50 * BYTES_PER_MEGABYTES;
     setUnusedResourceCacheSize(SOUND_DEFAULT_UNUSED_MAX_SIZE);
+    setObjectName("SoundCache");
 }
 
 SharedSoundPointer SoundCache::getSound(const QUrl& url) {

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -226,6 +226,7 @@ void GeometryDefinitionResource::setGeometryDefinition(void* fbxGeometry) {
 ModelCache::ModelCache() {
     const qint64 GEOMETRY_DEFAULT_UNUSED_MAX_SIZE = DEFAULT_UNUSED_MAX_SIZE;
     setUnusedResourceCacheSize(GEOMETRY_DEFAULT_UNUSED_MAX_SIZE);
+    setObjectName("ModelCache");
 }
 
 QSharedPointer<Resource> ModelCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -34,6 +34,7 @@
 TextureCache::TextureCache() {
     const qint64 TEXTURE_DEFAULT_UNUSED_MAX_SIZE = DEFAULT_UNUSED_MAX_SIZE;
     setUnusedResourceCacheSize(TEXTURE_DEFAULT_UNUSED_MAX_SIZE);
+    setObjectName("TextureCache");
 }
 
 TextureCache::~TextureCache() {


### PR DESCRIPTION
This makes the `QObject` names clear to JS looking at it, and let's debugging query the cache type from the `ResourceCache` base class using `objectName()`