### PR TITLE
Change Font to use shared_ptr instead of freeing on _exit

### DIFF
--- a/libraries/render-utils/src/TextRenderer3D.cpp
+++ b/libraries/render-utils/src/TextRenderer3D.cpp
@@ -54,9 +54,6 @@ TextRenderer3D::TextRenderer3D(const char* family, float pointSize, int weight, 
     }
 }
 
-TextRenderer3D::~TextRenderer3D() {
-}
-
 glm::vec2 TextRenderer3D::computeExtent(const QString& str) const {
     if (_font) {
         return _font->computeExtent(str);

--- a/libraries/render-utils/src/TextRenderer3D.h
+++ b/libraries/render-utils/src/TextRenderer3D.h
@@ -12,10 +12,9 @@
 #ifndef hifi_TextRenderer3D_h
 #define hifi_TextRenderer3D_h
 
+#include <memory>
 #include <glm/glm.hpp>
 #include <QColor>
-
-
 
 namespace gpu {
 class Batch;
@@ -33,8 +32,6 @@ public:
 
     static TextRenderer3D* getInstance(const char* family, float pointSize = DEFAULT_POINT_SIZE, 
             bool bold = false, bool italic = false, EffectType effect = NO_EFFECT, int effectThickness = 1);
-
-    ~TextRenderer3D();
 
     glm::vec2 computeExtent(const QString& str) const;
     float getFontSize() const; // Pixel size
@@ -55,7 +52,7 @@ private:
     // text color
     glm::vec4 _color;
 
-    Font* _font;
+    std::shared_ptr<Font> _font;
 };
 
 

--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -47,15 +47,15 @@ struct QuadBuilder {
 
 
 
-static QHash<QString, Font*> LOADED_FONTS;
+static QHash<QString, Font::Pointer> LOADED_FONTS;
 
-Font* Font::load(QIODevice& fontFile) {
-    Font* result = new Font();
-    result->read(fontFile);
-    return result;
+Font::Pointer Font::load(QIODevice& fontFile) {
+    Pointer font = std::make_shared<Font>();
+    font->read(fontFile);
+    return font;
 }
 
-Font* Font::load(const QString& family) {
+Font::Pointer Font::load(const QString& family) {
     if (!LOADED_FONTS.contains(family)) {
 
         static const QString SDFF_COURIER_PRIME_FILENAME{ ":/CourierPrime.sdff" };

--- a/libraries/render-utils/src/text/Font.h
+++ b/libraries/render-utils/src/text/Font.h
@@ -17,6 +17,8 @@
 
 class Font {
 public:
+    using Pointer = std::shared_ptr<Font>;
+
     Font();
 
     void read(QIODevice& path);
@@ -29,8 +31,8 @@ public:
         const glm::vec4* color, EffectType effectType,
         const glm::vec2& bound, bool layered = false);
 
-    static Font* load(QIODevice& fontFile);
-    static Font* load(const QString& family);
+    static Pointer load(QIODevice& fontFile);
+    static Pointer load(const QString& family);
 
 private:
     QStringList tokenizeForWrapping(const QString& str) const;


### PR DESCRIPTION
`TextRenderer3D` was getting a raw ptr to cached `Font`s. This was fine, because the fonts should have been alive for the duration of the program, but it triggered ASan.

Instead, let the program automatically manage it through smart pointers.