### PR TITLE
Don't truncate time when accumulating, and then divide by non-truncated.

### DIFF
--- a/libraries/shared/src/shared/RateCounter.h
+++ b/libraries/shared/src/shared/RateCounter.h
@@ -22,10 +22,10 @@ class RateCounter {
 public:
     void increment(size_t count = 1) {
         auto now = usecTimestampNow();
-        auto currentIntervalMs = (uint32_t)((now - _start) / USECS_PER_MSEC);
-        if (currentIntervalMs > INTERVAL) {
+        float currentIntervalMs = (now - _start) / (float) USECS_PER_MSEC;
+        if (currentIntervalMs > (float) INTERVAL) {
             float currentCount = _count;
-            float intervalSeconds = (float)currentIntervalMs / (float)MSECS_PER_SECOND;
+            float intervalSeconds = currentIntervalMs / (float) MSECS_PER_SECOND;
             _rate = roundf(currentCount / intervalSeconds * _scale) / _scale;
             _start = now;
             _count = 0;


### PR DESCRIPTION
Trivial adjustment to new RateCounter. e.g., 60fps present rate is 60.00, not 60.04.