### PR TITLE
use a steady clock for mixer timings

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -585,6 +585,7 @@ void AudioMixer::broadcastMixes() {
     int framesSinceCutoffEvent = TRAILING_AVERAGE_FRAMES;
 
     int currentFrame { 1 };
+    int numFramesPerSecond { (int) ceil(AudioConstants::NETWORK_FRAMES_PER_SEC) };
 
     while (!_isFinished) {
         const float STRUGGLE_TRIGGER_SLEEP_PERCENTAGE_THRESHOLD = 0.10f;
@@ -695,7 +696,10 @@ void AudioMixer::broadcastMixes() {
                     nodeData->incrementOutgoingMixedAudioSequenceNumber();
 
                     // send an audio stream stats packet to the client approximately every second
-                    if (nodeData->shouldSendStats(currentFrame++)) {
+                    ++currentFrame;
+                    currentFrame %= numFramesPerSecond;
+
+                    if (nodeData->shouldSendStats(currentFrame)) {
                         nodeData->sendAudioStreamStatsPackets(node);
                     }
 

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -694,10 +694,8 @@ void AudioMixer::broadcastMixes() {
                     nodeList->sendPacket(std::move(mixPacket), *node);
                     nodeData->incrementOutgoingMixedAudioSequenceNumber();
 
-                    static const int FRAMES_PER_SECOND = int(ceilf(1.0f / AudioConstants::NETWORK_FRAME_SECS));
-
                     // send an audio stream stats packet to the client approximately every second
-                    if (nextFrame % FRAMES_PER_SECOND == 0) {
+                    if (nodeData->shouldSendStats(currentFrame++)) {
                         nodeData->sendAudioStreamStatsPackets(node);
                     }
 

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -189,6 +189,10 @@ void AudioMixerClientData::checkBuffersBeforeFrameSend() {
     }
 }
 
+bool AudioMixerClientData::shouldSendStats(int frameNumber) {
+    return (frameNumber % (int) ceil(1.0f / AudioConstants::NETWORK_FRAME_SECS)) == _frameToSendStats;
+}
+
 void AudioMixerClientData::sendAudioStreamStatsPackets(const SharedNodePointer& destinationNode) {
 
     auto nodeList = DependencyManager::get<NodeList>();

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -190,7 +190,7 @@ void AudioMixerClientData::checkBuffersBeforeFrameSend() {
 }
 
 bool AudioMixerClientData::shouldSendStats(int frameNumber) {
-    return (frameNumber % (int) ceil(1.0f / AudioConstants::NETWORK_FRAME_SECS)) == _frameToSendStats;
+    return frameNumber == _frameToSendStats;
 }
 
 void AudioMixerClientData::sendAudioStreamStatsPackets(const SharedNodePointer& destinationNode) {

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <random>
+
 #include <QtCore/QDebug>
 #include <QtCore/QJsonArray>
 
@@ -26,7 +28,14 @@ AudioMixerClientData::AudioMixerClientData(const QUuid& nodeID) :
     _outgoingMixedAudioSequenceNumber(0),
     _downstreamAudioStreamStats()
 {
+    // of the ~94 blocks in a second of audio sent from the AudioMixer, pick a random one to send out a stats packet on
+    // this ensures we send out stats to this client around every second
+    // but do not send all of the stats packets out at the same time
+    std::random_device randomDevice;
+    std::mt19937 numberGenerator { randomDevice() };
+    std::uniform_int_distribution<> distribution { 1, (int) ceil(1.0f / AudioConstants::NETWORK_FRAME_SECS) };
 
+    _frameToSendStats = distribution(numberGenerator);
 }
 
 AvatarAudioStream* AudioMixerClientData::getAvatarAudioStream() {

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -59,7 +59,7 @@ public:
     quint16 getOutgoingSequenceNumber() const { return _outgoingMixedAudioSequenceNumber; }
 
     // uses randomization to have the AudioMixer send a stats packet to this node around every second
-    bool shouldSendStats(int frameNumber) { return frameNumber % _frameToSendStats == 0; }
+    bool shouldSendStats(int frameNumber);
 
 signals:
     void injectorStreamFinished(const QUuid& streamIdentifier);

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -58,6 +58,9 @@ public:
     void incrementOutgoingMixedAudioSequenceNumber() { _outgoingMixedAudioSequenceNumber++; }
     quint16 getOutgoingSequenceNumber() const { return _outgoingMixedAudioSequenceNumber; }
 
+    // uses randomization to have the AudioMixer send a stats packet to this node around every second
+    bool shouldSendStats(int frameNumber) { return frameNumber % _frameToSendStats == 0; }
+
 signals:
     void injectorStreamFinished(const QUuid& streamIdentifier);
 
@@ -72,6 +75,8 @@ private:
     quint16 _outgoingMixedAudioSequenceNumber;
 
     AudioStreamStats _downstreamAudioStreamStats;
+
+    int _frameToSendStats { 0 };
 };
 
 #endif // hifi_AudioMixerClientData_h

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -36,7 +36,6 @@ public slots:
 private slots:
     void handleAvatarDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
-    void handleAvatarBillboardPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleKillAvatarPacket(QSharedPointer<ReceivedMessage> message);
     void domainSettingsRequestComplete();
     
@@ -53,7 +52,6 @@ private:
     
     int _sumListeners { 0 };
     int _numStatFrames { 0 };
-    int _sumBillboardPackets { 0 };
     int _sumIdentityPackets { 0 };
 
     float _maxKbpsPerNode = 0.0f;

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -15,6 +15,8 @@
 #ifndef hifi_AvatarMixer_h
 #define hifi_AvatarMixer_h
 
+#include <PortableHighResolutionClock.h>
+
 #include <ThreadedAssignment.h>
 
 /// Handles assignments of type AvatarMixer - distribution of avatar data to various clients
@@ -44,15 +46,15 @@ private:
     
     QThread _broadcastThread;
     
-    quint64 _lastFrameTimestamp;
+    p_high_resolution_clock::time_point _lastFrameTimestamp;
     
-    float _trailingSleepRatio;
-    float _performanceThrottlingRatio;
+    float _trailingSleepRatio { 1.0f };
+    float _performanceThrottlingRatio { 0.0f };
     
-    int _sumListeners;
-    int _numStatFrames;
-    int _sumBillboardPackets;
-    int _sumIdentityPackets;
+    int _sumListeners { 0 };
+    int _numStatFrames { 0 };
+    int _sumBillboardPackets { 0 };
+    int _sumIdentityPackets { 0 };
 
     float _maxKbpsPerNode = 0.0f;
 

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -48,9 +48,6 @@ public:
 
     uint16_t getLastReceivedSequenceNumber() const { return _lastReceivedSequenceNumber; }
 
-    HRCTime getBillboardChangeTimestamp() const { return _billboardChangeTimestamp; }
-    void flagBillboardChange() { _billboardChangeTimestamp = p_high_resolution_clock::now(); }
-
     HRCTime getIdentityChangeTimestamp() const { return _identityChangeTimestamp; }
     void flagIdentityChange() { _identityChangeTimestamp = p_high_resolution_clock::now(); }
 
@@ -89,7 +86,6 @@ private:
     std::unordered_map<QUuid, uint16_t> _lastBroadcastSequenceNumbers;
     std::unordered_set<QUuid> _hasReceivedFirstPacketsFrom;
 
-    p_high_resolution_clock::time_point _billboardChangeTimestamp;
     p_high_resolution_clock::time_point _identityChangeTimestamp;
 
     float _fullRateDistance = FLT_MAX;

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -86,7 +86,7 @@ private:
     std::unordered_map<QUuid, uint16_t> _lastBroadcastSequenceNumbers;
     std::unordered_set<QUuid> _hasReceivedFirstPacketsFrom;
 
-    p_high_resolution_clock::time_point _identityChangeTimestamp;
+    HRCTime _identityChangeTimestamp;
 
     float _fullRateDistance = FLT_MAX;
     float _maxAvatarDistance = FLT_MAX;

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -24,6 +24,7 @@
 #include <NodeData.h>
 #include <NumericalConstants.h>
 #include <udt/PacketHeaders.h>
+#include <PortableHighResolutionClock.h>
 #include <SimpleMovingAverage.h>
 #include <UUIDHasher.h>
 
@@ -33,6 +34,8 @@ const QString INBOUND_AVATAR_DATA_STATS_KEY = "inbound_av_data_kbps";
 class AvatarMixerClientData : public NodeData {
     Q_OBJECT
 public:
+    using HRCTime = p_high_resolution_clock::time_point;
+
     int parseData(ReceivedMessage& message) override;
     AvatarData& getAvatar() { return *_avatar; }
 
@@ -45,11 +48,11 @@ public:
 
     uint16_t getLastReceivedSequenceNumber() const { return _lastReceivedSequenceNumber; }
 
-    quint64 getBillboardChangeTimestamp() const { return _billboardChangeTimestamp; }
-    void setBillboardChangeTimestamp(quint64 billboardChangeTimestamp) { _billboardChangeTimestamp = billboardChangeTimestamp; }
+    HRCTime getBillboardChangeTimestamp() const { return _billboardChangeTimestamp; }
+    void flagBillboardChange() { _billboardChangeTimestamp = p_high_resolution_clock::now(); }
 
-    quint64 getIdentityChangeTimestamp() const { return _identityChangeTimestamp; }
-    void setIdentityChangeTimestamp(quint64 identityChangeTimestamp) { _identityChangeTimestamp = identityChangeTimestamp; }
+    HRCTime getIdentityChangeTimestamp() const { return _identityChangeTimestamp; }
+    void flagIdentityChange() { _identityChangeTimestamp = p_high_resolution_clock::now(); }
 
     void setFullRateDistance(float fullRateDistance) { _fullRateDistance = fullRateDistance; }
     float getFullRateDistance() const { return _fullRateDistance; }
@@ -86,8 +89,8 @@ private:
     std::unordered_map<QUuid, uint16_t> _lastBroadcastSequenceNumbers;
     std::unordered_set<QUuid> _hasReceivedFirstPacketsFrom;
 
-    quint64 _billboardChangeTimestamp = 0;
-    quint64 _identityChangeTimestamp = 0;
+    p_high_resolution_clock::time_point _billboardChangeTimestamp;
+    p_high_resolution_clock::time_point _identityChangeTimestamp;
 
     float _fullRateDistance = FLT_MAX;
     float _maxAvatarDistance = FLT_MAX;

--- a/libraries/audio/src/AudioConstants.h
+++ b/libraries/audio/src/AudioConstants.h
@@ -29,6 +29,7 @@ namespace AudioConstants {
     const int NETWORK_FRAME_SAMPLES_PER_CHANNEL = NETWORK_FRAME_BYTES_PER_CHANNEL / sizeof(AudioSample);
     const float NETWORK_FRAME_SECS = (AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL / float(AudioConstants::SAMPLE_RATE));
     const float NETWORK_FRAME_MSECS = NETWORK_FRAME_SECS * 1000.0f;
+    const float NETWORK_FRAMES_PER_SEC =  1.0f / NETWORK_FRAME_SECS;
 
     // be careful with overflows when using this constant
     const int NETWORK_FRAME_USECS = static_cast<int>(NETWORK_FRAME_MSECS * 1000.0f);


### PR DESCRIPTION
- use the assumed steady p_high_resolution_clock for mixer block timings
- improve audio stats sending by spreading out stats packets to clients