### PR TITLE
Don't use invalidated iterators

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -64,9 +64,12 @@ void ResourceCache::clearATPAssets() {
     }
     {
         QWriteLocker locker(&_resourcesToBeGottenLock);
-        for (auto& url : _resourcesToBeGotten) {
-            if (url.scheme() == URL_SCHEME_ATP) {
-                _resourcesToBeGotten.removeAll(url);
+        auto it = _resourcesToBeGotten.begin();
+        while (it != _resourcesToBeGotten.end()) {
+            if (it->scheme() == URL_SCHEME_ATP) {
+                it = _resourcesToBeGotten.erase(it);
+            } else {
+                ++it;
             }
         }
     }


### PR DESCRIPTION
Fixes the crash @sethalves found when reloading content.

https://app.asana.com/0/26551373415487/113339865053884