### PR TITLE
Memory leak on exit for CharacterController

### DIFF
--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -72,6 +72,17 @@ CharacterController::CharacterController() {
     _pendingFlags = PENDING_FLAG_UPDATE_SHAPE;
 }
 
+CharacterController::~CharacterController() {
+    if (_rigidBody) {
+        btCollisionShape* shape = _rigidBody->getCollisionShape();
+        if (shape) {
+            delete shape;
+        }
+        delete _rigidBody;
+        _rigidBody = nullptr;
+    }
+}
+
 bool CharacterController::needsRemoval() const {
     return ((_pendingFlags & PENDING_FLAG_REMOVE_FROM_SIMULATION) == PENDING_FLAG_REMOVE_FROM_SIMULATION);
 }

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -36,7 +36,7 @@ class btDynamicsWorld;
 class CharacterController : public btCharacterControllerInterface {
 public:
     CharacterController();
-    virtual ~CharacterController() {}
+    virtual ~CharacterController();
 
     bool needsRemoval() const;
     bool needsAddition() const;


### PR DESCRIPTION
Delete the btRigidBody and it's collision shape in the CharacterController destructor.

Note: there is only one instance of this class and it's lifetime is the same as the MyAvatar instance.
