### PR TITLE
Remove unused static method gpu::Texture

### DIFF
--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -221,13 +221,6 @@ Texture* Texture::create(Type type, const Element& texelFormat, uint16 width, ui
     return tex;
 }
 
-Texture* Texture::createFromStorage(Storage* storage) {
-   Texture* tex = new Texture();
-   tex->_storage.reset(storage);
-   storage->assignTexture(tex);
-   return tex;
-}
-
 Texture::Texture():
     Resource()
 {

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -260,7 +260,7 @@ public:
         Stamp bumpStamp() { return ++_stamp; }
     protected:
         Stamp _stamp = 0;
-        Texture* _texture = nullptr;
+        Texture* _texture = nullptr; // Points to the parent texture (not owned)
         Texture::Type _type = Texture::TEX_2D; // The type of texture is needed to know the number of faces to expect
         std::vector<std::vector<PixelsPointer>> _mips; // an array of mips, each mip is an array of faces
 

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -280,8 +280,6 @@ public:
     static Texture* create3D(const Element& texelFormat, uint16 width, uint16 height, uint16 depth, const Sampler& sampler = Sampler());
     static Texture* createCube(const Element& texelFormat, uint16 width, const Sampler& sampler = Sampler());
 
-    static Texture* createFromStorage(Storage* storage);
-
     Texture();
     Texture(const Texture& buf); // deep copy of the sysmem texture
     Texture& operator=(const Texture& buf); // deep copy of the sysmem texture


### PR DESCRIPTION
Removes `Texture::createFromStorage`, which depended on a raw pointer for an object protected by a smart pointer.

Also adds a comment on Texture::Pixels::Storage::_texture noting that the pointer is unowned - it is a reference to the parent Texture.