### PR TITLE
Fix ResourceCacheSharedItems::_loadingRequests removals

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -28,6 +28,80 @@
                            (((x) > (max)) ? (max) :\
                                             (x)))
 
+void ResourceCacheSharedItems::appendActiveRequest(QWeakPointer<Resource> resource) {
+    Lock lock(_mutex);
+    _loadingRequests.append(resource);
+}
+
+void ResourceCacheSharedItems::appendPendingRequest(QWeakPointer<Resource> resource) {
+    Lock lock(_mutex);
+    _pendingRequests.append(resource);
+}
+
+QList<QSharedPointer<Resource>> ResourceCacheSharedItems::getPendingRequests() {
+    QList<QSharedPointer<Resource>> result;
+
+    {
+        Lock lock(_mutex);
+        foreach(QSharedPointer<Resource> resource, _pendingRequests) {
+            if (resource) {
+                result.append(resource);
+            }
+        }
+    }
+    return result;
+}
+
+uint32_t ResourceCacheSharedItems::getPendingRequestsCount() const {
+    Lock lock(_mutex);
+    return _pendingRequests.size();
+}
+
+QList<QSharedPointer<Resource>> ResourceCacheSharedItems::getLoadingRequests() {
+    QList<QSharedPointer<Resource>> result;
+
+    {
+        Lock lock(_mutex);
+        foreach(QSharedPointer<Resource> resource, _loadingRequests) {
+            if (resource) {
+                result.append(resource);
+            }
+        }
+    }
+    return result;
+}
+
+void ResourceCacheSharedItems::removeRequest(QWeakPointer<Resource> resource) {
+    Lock lock(_mutex);
+    _loadingRequests.removeAll(resource);
+}
+
+QSharedPointer<Resource> ResourceCacheSharedItems::getHighestPendingRequest() {
+    Lock lock(_mutex);
+    // look for the highest priority pending request
+    int highestIndex = -1;
+    float highestPriority = -FLT_MAX;
+    QSharedPointer<Resource> highestResource;
+    for (int i = 0; i < _pendingRequests.size();) {
+        auto resource = _pendingRequests.at(i).lock();
+        if (!resource) {
+            _pendingRequests.removeAt(i);
+            continue;
+        }
+        float priority = resource->getLoadPriority();
+        if (priority >= highestPriority) {
+            highestPriority = priority;
+            highestIndex = i;
+            highestResource = resource;
+        }
+        i++;
+    }
+    if (highestIndex >= 0) {
+        _pendingRequests.takeAt(highestIndex);
+    }
+    return highestResource;
+}
+
 ResourceCache::ResourceCache(QObject* parent) : QObject(parent) {
     auto& domainHandler = DependencyManager::get<NodeList>()->getDomainHandler();
     connect(&domainHandler, &DomainHandler::disconnectedFromDomain,
@@ -264,81 +338,7 @@ void ResourceCache::updateTotalSize(const qint64& oldSize, const qint64& newSize
     _totalResourcesSize += (newSize - oldSize);
     emit dirty();
 }
-
-void ResourceCacheSharedItems::appendActiveRequest(QWeakPointer<Resource> resource) {
-    Lock lock(_mutex);
-    _loadingRequests.append(resource);
-}
-
-void ResourceCacheSharedItems::appendPendingRequest(QWeakPointer<Resource> resource) {
-    Lock lock(_mutex);
-    _pendingRequests.append(resource);
-}
-
-QList<QSharedPointer<Resource>> ResourceCacheSharedItems::getPendingRequests() {
-    QList<QSharedPointer<Resource>> result;
-
-    {
-        Lock lock(_mutex);
-        foreach(QSharedPointer<Resource> resource, _pendingRequests) {
-            if (resource) {
-                result.append(resource);
-            }
-        }
-    }
-    return result;
-}
-
-uint32_t ResourceCacheSharedItems::getPendingRequestsCount() const {
-    Lock lock(_mutex);
-    return _pendingRequests.size();
-}
-
-QList<QSharedPointer<Resource>> ResourceCacheSharedItems::getLoadingRequests() {
-    QList<QSharedPointer<Resource>> result;
-
-    {
-        Lock lock(_mutex);
-        foreach(QSharedPointer<Resource> resource, _loadingRequests) {
-            if (resource) {
-                result.append(resource);
-            }
-        }
-    }
-    return result;
-}
-
-void ResourceCacheSharedItems::removeRequest(QWeakPointer<Resource> resource) {
-    Lock lock(_mutex);
-    _loadingRequests.removeAll(resource);
-}
-
-QSharedPointer<Resource> ResourceCacheSharedItems::getHighestPendingRequest() {
-    Lock lock(_mutex);
-    // look for the highest priority pending request
-    int highestIndex = -1;
-    float highestPriority = -FLT_MAX;
-    QSharedPointer<Resource> highestResource;
-    for (int i = 0; i < _pendingRequests.size();) {
-        auto resource = _pendingRequests.at(i).lock();
-        if (!resource) {
-            _pendingRequests.removeAt(i);
-            continue;
-        }
-        float priority = resource->getLoadPriority();
-        if (priority >= highestPriority) {
-            highestPriority = priority;
-            highestIndex = i;
-            highestResource = resource;
-        }
-        i++;
-    }
-    if (highestIndex >= 0) {
-        _pendingRequests.takeAt(highestIndex);
-    }
-    return highestResource;
-}
-
+ 
 QList<QSharedPointer<Resource>> ResourceCache::getLoadingRequests() {
     return DependencyManager::get<ResourceCacheSharedItems>()->getLoadingRequests();
 }


### PR DESCRIPTION
- Moves ResourceCacheSharedItems implementation to top of impl file to match the header file.
- Fixes removal from _loadingRequests for the case when it requests are freed (freed weak pointers cannot be used as a key for removal).