### PR TITLE
Reset entities script engine on domain change

### DIFF
--- a/examples/entityScripts/exampleSelfCallingTimeoutNoCleanup.js
+++ b/examples/entityScripts/exampleSelfCallingTimeoutNoCleanup.js
@@ -1,0 +1,56 @@
+//
+//  exampleSelfCallingTimeoutNoCleanup.js
+//  examples/entityScripts
+//
+//  Created by Brad Hefta-Gaub on 4/18/16.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  This is an example of an entity script which hooks the update signal
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+(function() {
+    var _this;
+
+    // this is the "constructor" for the entity as a JS object we don't do much here, but we do want to remember
+    // our this object, so we can access it in cases where we're called without a this (like in the case of various global signals)
+    ExampleUpdate = function() { 
+         _this = this;
+    };
+
+    ExampleUpdate.prototype = {
+
+        timeOutFunction: function() {
+            var entityID = _this.entityID;
+            print("timeOutFunction in entityID:" + entityID);
+            Script.setTimeout(function() {
+                _this.timeOutFunction();
+            }, 3000);
+        },
+
+        // preload() will be called when the entity has become visible (or known) to the interface
+        // it gives us a chance to set our local JavaScript object up. In this case it means:
+        //   * remembering our entityID, so we can access it in cases where we're called without an entityID
+        //   * connecting to the update signal so we can check our grabbed state
+        preload: function(entityID) {
+            print("preload - entityID:" + entityID);
+            this.entityID = entityID;
+
+            print("preload - entityID:" + entityID + "-- calling timeOutFunction()....");
+            _this.timeOutFunction();
+        },
+
+        // unload() will be called when our entity is no longer available. It may be because we were deleted,
+        // or because we've left the domain or quit the application. In all cases we want to unhook our connection
+        // to the update signal
+        unload: function(entityID) {
+            print("unload - entityID:" + entityID);
+            print("NOTE --- WE DID NOT CALL clear our timeout");
+        },
+    };
+
+    // entity scripts always need to return a newly constructed object of our type
+    return new ExampleUpdate();
+})

--- a/examples/entityScripts/exampleTimeoutNoCleanup.js
+++ b/examples/entityScripts/exampleTimeoutNoCleanup.js
@@ -1,0 +1,50 @@
+//
+//  exampleTimeoutNoCleanup.js
+//  examples/entityScripts
+//
+//  Created by Brad Hefta-Gaub on 4/18/16.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  This is an example of an entity script which hooks the update signal
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+(function() {
+    var _this;
+
+    // this is the "constructor" for the entity as a JS object we don't do much here, but we do want to remember
+    // our this object, so we can access it in cases where we're called without a this (like in the case of various global signals)
+    ExampleUpdate = function() { 
+         _this = this;
+    };
+
+    ExampleUpdate.prototype = {
+
+        // preload() will be called when the entity has become visible (or known) to the interface
+        // it gives us a chance to set our local JavaScript object up. In this case it means:
+        //   * remembering our entityID, so we can access it in cases where we're called without an entityID
+        //   * connecting to the update signal so we can check our grabbed state
+        preload: function(entityID) {
+            print("preload - entityID:" + entityID);
+            this.entityID = entityID;
+
+            Script.setTimeout(function() {
+                    var entityID = _this.entityID;
+                    print("timer timeout in entityID:" + entityID);
+                }, 3000);
+        },
+
+        // unload() will be called when our entity is no longer available. It may be because we were deleted,
+        // or because we've left the domain or quit the application. In all cases we want to unhook our connection
+        // to the update signal
+        unload: function(entityID) {
+            print("unload - entityID:" + entityID);
+            print("NOTE --- WE DID NOT CALL clear our timeout");
+        },
+    };
+
+    // entity scripts always need to return a newly constructed object of our type
+    return new ExampleUpdate();
+})

--- a/examples/entityScripts/exampleTimeoutNoCleanup.js
+++ b/examples/entityScripts/exampleTimeoutNoCleanup.js
@@ -30,9 +30,9 @@
             print("preload - entityID:" + entityID);
             this.entityID = entityID;
 
-            Script.setTimeout(function() {
+            Script.setInterval(function() {
                     var entityID = _this.entityID;
-                    print("timer timeout in entityID:" + entityID);
+                    print("timer interval in entityID:" + entityID);
                 }, 3000);
         },
 

--- a/examples/entityScripts/exampleUpdate.js
+++ b/examples/entityScripts/exampleUpdate.js
@@ -1,0 +1,54 @@
+//
+//  exampleUpdate.js
+//  examples/entityScripts
+//
+//  Created by Brad Hefta-Gaub on 4/18/16.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  This is an example of an entity script which hooks the update signal
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+(function() {
+    var _this;
+
+    // this is the "constructor" for the entity as a JS object we don't do much here, but we do want to remember
+    // our this object, so we can access it in cases where we're called without a this (like in the case of various global signals)
+    ExampleUpdate = function() { 
+         _this = this;
+    };
+
+    ExampleUpdate.prototype = {
+
+        // update() will be called regulary, because we've hooked the update signal in our preload() function.
+        // we will check the avatars hand positions and if either hand is in our bounding box, we will notice that
+        update: function() {
+            // because the update() signal doesn't have a valid this, we need to use our memorized _this to access our entityID
+            var entityID = _this.entityID;
+            print("update in entityID:" + entityID);
+        },
+
+        // preload() will be called when the entity has become visible (or known) to the interface
+        // it gives us a chance to set our local JavaScript object up. In this case it means:
+        //   * remembering our entityID, so we can access it in cases where we're called without an entityID
+        //   * connecting to the update signal so we can check our grabbed state
+        preload: function(entityID) {
+            print("preload - entityID:" + entityID);
+            this.entityID = entityID;
+            Script.update.connect(this.update);
+        },
+
+        // unload() will be called when our entity is no longer available. It may be because we were deleted,
+        // or because we've left the domain or quit the application. In all cases we want to unhook our connection
+        // to the update signal
+        unload: function(entityID) {
+            print("unload - entityID:" + entityID);
+            Script.update.disconnect(this.update);
+        },
+    };
+
+    // entity scripts always need to return a newly constructed object of our type
+    return new ExampleUpdate();
+})

--- a/examples/entityScripts/exampleUpdateNoDisconnect.js
+++ b/examples/entityScripts/exampleUpdateNoDisconnect.js
@@ -1,0 +1,54 @@
+//
+//  exampleUpdateNoDisconnect.js
+//  examples/entityScripts
+//
+//  Created by Brad Hefta-Gaub on 4/18/16.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  This is an example of an entity script which hooks the update signal
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+(function() {
+    var _this;
+
+    // this is the "constructor" for the entity as a JS object we don't do much here, but we do want to remember
+    // our this object, so we can access it in cases where we're called without a this (like in the case of various global signals)
+    ExampleUpdate = function() { 
+         _this = this;
+    };
+
+    ExampleUpdate.prototype = {
+
+        // update() will be called regulary, because we've hooked the update signal in our preload() function.
+        // we will check the avatars hand positions and if either hand is in our bounding box, we will notice that
+        update: function() {
+            // because the update() signal doesn't have a valid this, we need to use our memorized _this to access our entityID
+            var entityID = _this.entityID;
+            print("update in entityID:" + entityID);
+        },
+
+        // preload() will be called when the entity has become visible (or known) to the interface
+        // it gives us a chance to set our local JavaScript object up. In this case it means:
+        //   * remembering our entityID, so we can access it in cases where we're called without an entityID
+        //   * connecting to the update signal so we can check our grabbed state
+        preload: function(entityID) {
+            print("preload - entityID:" + entityID);
+            this.entityID = entityID;
+            Script.update.connect(this.update);
+        },
+
+        // unload() will be called when our entity is no longer available. It may be because we were deleted,
+        // or because we've left the domain or quit the application. In all cases we want to unhook our connection
+        // to the update signal
+        unload: function(entityID) {
+            print("unload - entityID:" + entityID);
+            print("NOTE --- WE DID NOT CALL Script.update.disconnect()");
+        },
+    };
+
+    // entity scripts always need to return a newly constructed object of our type
+    return new ExampleUpdate();
+})

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4177,14 +4177,12 @@ void Application::clearDomainOctreeDetails() {
 
     // if we're about to quit, we really don't need to do any of these things...
     if (_aboutToQuit) {
-        qCDebug(interfaceapp) << "No need to clear domain octree details we are shutting down...";
         return;
     }
 
-
     qCDebug(interfaceapp) << "Clearing domain octree details...";
-    // reset the environment so that we don't erroneously end up with multiple
 
+    // reset the environment so that we don't erroneously end up with multiple
     resetPhysicsReadyInformation();
 
     // reset our node to stats and node to jurisdiction maps... since these must be changing...

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1188,7 +1188,6 @@ void Application::cleanupBeforeQuit() {
     nodeList->getPacketReceiver().setShouldDropPackets(true);
 
     getEntities()->shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
-    getEntities()->clear(); // this will allow entity scripts to properly shutdown
 
     DependencyManager::get<ScriptEngines>()->saveScripts();
     DependencyManager::get<ScriptEngines>()->shutdownScripting(); // stop all currently running global scripts

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1156,9 +1156,6 @@ void Application::aboutToQuit() {
 }
 
 void Application::cleanupBeforeQuit() {
-    qDebug() << __FUNCTION__ << "----- START -----";
-
-
     // add a logline indicating if QTWEBENGINE_REMOTE_DEBUGGING is set or not
     QString webengineRemoteDebugging = QProcessEnvironment::systemEnvironment().value("QTWEBENGINE_REMOTE_DEBUGGING", "false");
     qCDebug(interfaceapp) << "QTWEBENGINE_REMOTE_DEBUGGING =" << webengineRemoteDebugging;
@@ -1190,18 +1187,12 @@ void Application::cleanupBeforeQuit() {
     // tell the packet receiver we're shutting down, so it can drop packets
     nodeList->getPacketReceiver().setShouldDropPackets(true);
 
-    qDebug() << __FUNCTION__ << "about to call getEntities()->shutdown();";
     getEntities()->shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
-
     getEntities()->clear(); // this will allow entity scripts to properly shutdown
-    //DependencyManager::destroy<EntityTreeRenderer>();
-    qDebug() << __FUNCTION__ << "AFTER call to getEntities()->shutdown();";
 
-    qDebug() << __FUNCTION__ << "about to shutdown ScriptEngines...";
     DependencyManager::get<ScriptEngines>()->saveScripts();
     DependencyManager::get<ScriptEngines>()->shutdownScripting(); // stop all currently running global scripts
     DependencyManager::destroy<ScriptEngines>();
-    qDebug() << __FUNCTION__ << "AFTER shutdown ScriptEngines...";
 
     // first stop all timers directly or by invokeMethod
     // depending on what thread they run in
@@ -1211,14 +1202,10 @@ void Application::cleanupBeforeQuit() {
     pingTimer.stop();
     QMetaObject::invokeMethod(&_settingsTimer, "stop", Qt::BlockingQueuedConnection);
 
-    qDebug() << __FUNCTION__ << " line:" << __LINE__;
-
     // save state
     _settingsThread.quit();
     saveSettings();
     _window->saveGeometry();
-
-    qDebug() << __FUNCTION__ << " line:" << __LINE__;
 
     // stop the AudioClient
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(),
@@ -1227,13 +1214,9 @@ void Application::cleanupBeforeQuit() {
     // destroy the AudioClient so it and its thread have a chance to go down safely
     DependencyManager::destroy<AudioClient>();
 
-    qDebug() << __FUNCTION__ << " line:" << __LINE__;
-
     // destroy the AudioInjectorManager so it and its thread have a chance to go down safely
     // this will also stop any ongoing network injectors
     DependencyManager::destroy<AudioInjectorManager>();
-
-    qDebug() << __FUNCTION__ << " line:" << __LINE__;
 
     // Destroy third party processes after scripts have finished using them.
 #ifdef HAVE_DDE
@@ -1243,11 +1226,7 @@ void Application::cleanupBeforeQuit() {
     DependencyManager::destroy<EyeTracker>();
 #endif
 
-    qDebug() << __FUNCTION__ << " line:" << __LINE__;
-
     DependencyManager::destroy<OffscreenUi>();
-
-    qDebug() << __FUNCTION__ << " ----- END -----";
 }
 
 Application::~Application() {
@@ -4218,9 +4197,7 @@ void Application::clearDomainOctreeDetails() {
     });
 
     // reset the model renderer
-    qCDebug(interfaceapp) << __FUNCTION__ << " --- BEFORE getEntities()->clear() --- _aboutToQuit:" << _aboutToQuit;
     getEntities()->clear();
-    qCDebug(interfaceapp) << __FUNCTION__ << " --- AFTER getEntities()->clear() ---";
 
     auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
     skyStage->setBackgroundMode(model::SunSkyStage::SKY_DOME);
@@ -4229,13 +4206,9 @@ void Application::clearDomainOctreeDetails() {
 }
 
 void Application::domainChanged(const QString& domainHostname) {
-    qCDebug(interfaceapp) << __FUNCTION__ << " --- BEGIN --- domainHostname:" << domainHostname;
-
     updateWindowTitle();
-    //clearDomainOctreeDetails();
     // disable physics until we have enough information about our new location to not cause craziness.
     resetPhysicsReadyInformation();
-    qCDebug(interfaceapp) << __FUNCTION__ << " --- END ---";
 }
 
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4182,7 +4182,6 @@ void Application::clearDomainOctreeDetails() {
 
     qCDebug(interfaceapp) << "Clearing domain octree details...";
 
-    // reset the environment so that we don't erroneously end up with multiple
     resetPhysicsReadyInformation();
 
     // reset our node to stats and node to jurisdiction maps... since these must be changing...

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -140,6 +140,8 @@ void EntityTreeRenderer::init() {
 void EntityTreeRenderer::shutdown() {
     _entitiesScriptEngine->disconnectNonEssentialSignals(); // disconnect all slots/signals from the script engine, except essential
     _shuttingDown = true;
+
+    clear(); // always clear() on shutdown
 }
 
 void EntityTreeRenderer::setTree(OctreePointer newTree) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -78,6 +78,7 @@ EntityTreeRenderer::~EntityTreeRenderer() {
 int EntityTreeRenderer::_entititesScriptEngineCount = 0;
 
 void EntityTreeRenderer::setupEntitiesScriptEngine() {
+    QSharedPointer<ScriptEngine> oldEngine = _entitiesScriptEngine; // save the old engine through this function, so the EntityScriptingInterface doesn't have problems with it.
     _entitiesScriptEngine = QSharedPointer<ScriptEngine>(new ScriptEngine(NO_SCRIPT, QString("Entities %1").arg(++_entititesScriptEngineCount)), ScriptEngine::doDeleteLater);
     _scriptingServices->registerScriptEngineWithApplicationServices(_entitiesScriptEngine.data());
     _entitiesScriptEngine->runInThread();

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -92,7 +92,6 @@ void EntityTreeRenderer::clear() {
         _entitiesScriptEngine->stop();
     }
 
-    // this would be a good place to actuall delete and recreate the _entitiesScriptEngine
     if (_wantScripts && !_shuttingDown) {
         // NOTE: you can't actually need to delete it here because when we call setupEntitiesScriptEngine it will
         //       assign a new instance to our shared pointer, which will deref the old instance and ultimately call

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -88,12 +88,11 @@ void EntityTreeRenderer::clear() {
     leaveAllEntities();
     if (_entitiesScriptEngine) {
         _entitiesScriptEngine->unloadAllEntityScripts();
+        _entitiesScriptEngine->stop();
     }
 
     // this would be a good place to actuall delete and recreate the _entitiesScriptEngine
     if (_wantScripts && !_shuttingDown) {
-        _entitiesScriptEngine->stop();
-
         // NOTE: you can't actually need to delete it here because when we call setupEntitiesScriptEngine it will
         //       assign a new instance to our shared pointer, which will deref the old instance and ultimately call
         //       the custom deleter which calls deleteLater

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -75,11 +75,11 @@ EntityTreeRenderer::~EntityTreeRenderer() {
     //       it is registered with ScriptEngines, which will call deleteLater for us.
 }
 
-int EntityTreeRenderer::_entititesScriptEngineCount = 0;
+int EntityTreeRenderer::_entitiesScriptEngineCount = 0;
 
 void EntityTreeRenderer::setupEntitiesScriptEngine() {
     QSharedPointer<ScriptEngine> oldEngine = _entitiesScriptEngine; // save the old engine through this function, so the EntityScriptingInterface doesn't have problems with it.
-    _entitiesScriptEngine = QSharedPointer<ScriptEngine>(new ScriptEngine(NO_SCRIPT, QString("Entities %1").arg(++_entititesScriptEngineCount)), ScriptEngine::doDeleteLater);
+    _entitiesScriptEngine = QSharedPointer<ScriptEngine>(new ScriptEngine(NO_SCRIPT, QString("Entities %1").arg(++_entitiesScriptEngineCount)), &QObject::deleteLater);
     _scriptingServices->registerScriptEngineWithApplicationServices(_entitiesScriptEngine.data());
     _entitiesScriptEngine->runInThread();
     DependencyManager::get<EntityScriptingInterface>()->setEntitiesScriptEngine(_entitiesScriptEngine.data());

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -71,7 +71,6 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
 }
 
 EntityTreeRenderer::~EntityTreeRenderer() {
-    qDebug() << __FUNCTION__;
     // NOTE: We don't need to delete _entitiesScriptEngine because
     //       it is registered with ScriptEngines, which will call deleteLater for us.
 }
@@ -79,27 +78,21 @@ EntityTreeRenderer::~EntityTreeRenderer() {
 int EntityTreeRenderer::_entititesScriptEngineCount = 0;
 
 void EntityTreeRenderer::setupEntitiesScriptEngine() {
-    qDebug() << __FUNCTION__ << "---- BEGIN ----";
     _entitiesScriptEngine = QSharedPointer<ScriptEngine>(new ScriptEngine(NO_SCRIPT, QString("Entities %1").arg(++_entititesScriptEngineCount)), ScriptEngine::doDeleteLater);
     _scriptingServices->registerScriptEngineWithApplicationServices(_entitiesScriptEngine.data());
     _entitiesScriptEngine->runInThread();
     DependencyManager::get<EntityScriptingInterface>()->setEntitiesScriptEngine(_entitiesScriptEngine.data());
-    qDebug() << __FUNCTION__ << "---- END ----";
 }
 
 void EntityTreeRenderer::clear() {
-    qDebug() << __FUNCTION__ << "---- BEGIN ----";
     leaveAllEntities();
     if (_entitiesScriptEngine) {
         _entitiesScriptEngine->unloadAllEntityScripts();
     }
 
     // this would be a good place to actuall delete and recreate the _entitiesScriptEngine
-    qDebug() << __FUNCTION__ << "_shuttingDown:" << _shuttingDown;
     if (_wantScripts && !_shuttingDown) {
-        qDebug() << __FUNCTION__ << " about to _entitiesScriptEngine->stop()";
         _entitiesScriptEngine->stop();
-        qDebug() << __FUNCTION__ << " AFTER _entitiesScriptEngine->stop()";
 
         // NOTE: you can't actually need to delete it here because when we call setupEntitiesScriptEngine it will
         //       assign a new instance to our shared pointer, which will deref the old instance and ultimately call
@@ -116,7 +109,6 @@ void EntityTreeRenderer::clear() {
     _entitiesInScene.clear();
 
     OctreeRenderer::clear();
-    qDebug() << __FUNCTION__ << "---- END ----";
 }
 
 void EntityTreeRenderer::reloadEntityScripts() {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -126,6 +126,8 @@ protected:
     }
 
 private:
+    void setupEntitiesScriptEngine();
+
     void addEntityToScene(EntityItemPointer entity);
     bool findBestZoneAndMaybeContainingEntities(const glm::vec3& avatarPosition, QVector<EntityItemID>* entitiesContainingAvatar);
 
@@ -196,6 +198,8 @@ private:
     QHash<EntityItemID, EntityItemPointer> _entitiesInScene;
     // For Scene.shouldRenderEntities
     QList<EntityItemID> _entityIDsLastInScene;
+
+    static int _entititesScriptEngineCount;
 };
 
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -199,7 +199,7 @@ private:
     // For Scene.shouldRenderEntities
     QList<EntityItemID> _entityIDsLastInScene;
 
-    static int _entititesScriptEngineCount;
+    static int _entitiesScriptEngineCount;
 };
 
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -155,7 +155,7 @@ private:
     NetworkTexturePointer _ambientTexture;
 
     bool _wantScripts;
-    ScriptEngine* _entitiesScriptEngine;
+    QSharedPointer<ScriptEngine> _entitiesScriptEngine;
 
     bool isCollisionOwner(const QUuid& myNodeID, EntityTreePointer entityTree,
                           const EntityItemID& id, const Collision& collision);

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -414,7 +414,13 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
     }
 }
 
+void EntityScriptingInterface::setEntitiesScriptEngine(EntitiesScriptEngineProvider* engine) {
+    std::unique_lock<std::mutex> lock(_entitiesScriptEngineLock);
+    _entitiesScriptEngine = engine;
+}
+
 void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method, const QStringList& params) {
+    std::unique_lock<std::mutex> lock(_entitiesScriptEngineLock);
     if (_entitiesScriptEngine) {
         EntityItemID entityID{ id };
         _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params);

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -415,12 +415,12 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
 }
 
 void EntityScriptingInterface::setEntitiesScriptEngine(EntitiesScriptEngineProvider* engine) {
-    std::unique_lock<std::mutex> lock(_entitiesScriptEngineLock);
+    std::lock_guard<std::mutex> lock(_entitiesScriptEngineLock);
     _entitiesScriptEngine = engine;
 }
 
 void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method, const QStringList& params) {
-    std::unique_lock<std::mutex> lock(_entitiesScriptEngineLock);
+    std::lock_guard<std::mutex> lock(_entitiesScriptEngineLock);
     if (_entitiesScriptEngine) {
         EntityItemID entityID{ id };
         _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params);

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -71,7 +71,7 @@ public:
 
     void setEntityTree(EntityTreePointer modelTree);
     EntityTreePointer getEntityTree() { return _entityTree; }
-    void setEntitiesScriptEngine(EntitiesScriptEngineProvider* engine) { _entitiesScriptEngine = engine; }
+    void setEntitiesScriptEngine(EntitiesScriptEngineProvider* engine);
     float calculateCost(float mass, float oldVelocity, float newVelocity);
 public slots:
 
@@ -214,6 +214,8 @@ private:
         bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude, const QVector<EntityItemID>& entityIdsToDiscard);
 
     EntityTreePointer _entityTree;
+
+    std::mutex _entitiesScriptEngineLock;
     EntitiesScriptEngineProvider* _entitiesScriptEngine { nullptr };
     
     bool _bidOnSimulationOwnership { false };

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -758,7 +758,6 @@ void ScriptEngine::stop() {
             QMetaObject::invokeMethod(this, "stop");
             return;
         }
-        abortEvaluation(); // abort any script evaluation that may be active
         _isFinished = true;
         if (_wantSignals) {
             emit runningStateChanged();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1049,8 +1049,8 @@ void ScriptEngine::forwardHandlerCall(const EntityItemID& entityID, const QStrin
 // since all of these operations can be asynch we will always do the actual work in the response handler
 // for the download
 void ScriptEngine::loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const EntityItemID& entityID, const QString& entityScript, bool forceRedownload) {
-    // NOTE: If the script content is not currently in the caceh, The LAMBDA here, will be called on the Main Thread
-    //       which means we're guarenteed that it's not the correct thread for the ScriptEngine. This means
+    // NOTE: If the script content is not currently in the cache, the LAMBDA here will be called on the Main Thread
+    //       which means we're guaranteed that it's not the correct thread for the ScriptEngine. This means
     //       when we get into entityScriptContentAvailable() we will likely invokeMethod() to get it over
     //       to the "Entities" ScriptEngine thread.
     DependencyManager::get<ScriptCache>()->getScriptContents(entityScript, [theEngine, entityID](const QString& scriptOrURL, const QString& contents, bool isURL, bool success) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1065,7 +1065,7 @@ void ScriptEngine::loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const 
             // FIXME - I'm leaving this in for testing, so that QA can confirm that sometimes the script contents
             //         returns after the ScriptEngine has been deleted, we can remove this after QA verifies the
             //         repro case.
-            qDebug() << "ScriptCache::getScriptContents() returned after our ScriptEngine was deleted...";
+            qDebug() << "ScriptCache::getScriptContents() returned after our ScriptEngine was deleted... script:" << scriptOrURL;
         }
     }, forceRedownload);
 }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -18,6 +18,7 @@
 #include <QtNetwork/QNetworkReply>
 #include <QtScript/QScriptEngine>
 #include <QtScript/QScriptValue>
+#include <QtScript/QScriptValueIterator>
 #include <QtCore/QStringList>
 
 #include <AudioConstants.h>
@@ -1072,7 +1073,6 @@ void ScriptEngine::loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const 
 // since all of these operations can be asynch we will always do the actual work in the response handler
 // for the download
 void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, const QString& scriptOrURL, const QString& contents, bool isURL, bool success) {
-
     if (QThread::currentThread() != thread()) {
 #ifdef THREAD_DEBUGGING
         qDebug() << "*** WARNING *** ScriptEngine::entityScriptContentAvailable() called on wrong thread ["
@@ -1183,8 +1183,6 @@ void ScriptEngine::unloadEntityScript(const EntityItemID& entityID) {
         stopAllTimersForEntityScript(entityID);
     }
 }
-
-#include <QScriptValueIterator>
 
 void ScriptEngine::unloadAllEntityScripts() {
     if (QThread::currentThread() != thread()) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -142,14 +142,18 @@ ScriptEngine::ScriptEngine(const QString& scriptContents, const QString& fileNam
 }
 
 ScriptEngine::~ScriptEngine() {
+    qCDebug(scriptengine) << __FUNCTION__ << "--- BEGIN --- script:" << getFilename();
     qCDebug(scriptengine) << "Script Engine shutting down (destructor) for script:" << getFilename();
 
     auto scriptEngines = DependencyManager::get<ScriptEngines>();
     if (scriptEngines) {
+        qCDebug(scriptengine) << "About to remove ScriptEngine [" << getFilename() << "] from ScriptEngines!";
         scriptEngines->removeScriptEngine(this);
+        qCDebug(scriptengine) << "AFTER remove ScriptEngine [" << getFilename() << "] from ScriptEngines!";
     } else {
         qCWarning(scriptengine) << "Script destroyed after ScriptEngines!";
     }
+    qCDebug(scriptengine) << __FUNCTION__ << "--- END --- script:" << getFilename();
 }
 
 void ScriptEngine::disconnectNonEssentialSignals() {
@@ -1197,6 +1201,8 @@ void ScriptEngine::unloadEntityScript(const EntityItemID& entityID) {
     }
 }
 
+#include <QScriptValueIterator>
+
 void ScriptEngine::unloadAllEntityScripts() {
     if (QThread::currentThread() != thread()) {
 #ifdef THREAD_DEBUGGING
@@ -1213,6 +1219,16 @@ void ScriptEngine::unloadAllEntityScripts() {
         callEntityScriptMethod(entityID, "unload");
     }
     _entityScripts.clear();
+
+#ifdef DEBUG_ENGINE_STATE
+    qDebug() << "---- CURRENT STATE OF ENGINE: --------------------------";
+    QScriptValueIterator it(globalObject());
+    while (it.hasNext()) {
+        it.next();
+        qDebug() << it.name() << ":" << it.value().toString();
+    }
+    qDebug() << "--------------------------------------------------------";
+#endif // DEBUG_ENGINE_STATE
 }
 
 void ScriptEngine::refreshFileScript(const EntityItemID& entityID) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -145,9 +145,7 @@ ScriptEngine::~ScriptEngine() {
     qCDebug(scriptengine) << "Script Engine shutting down (destructor) for script:" << getFilename();
     auto scriptEngines = DependencyManager::get<ScriptEngines>();
     if (scriptEngines) {
-        qCDebug(scriptengine) << "About to remove ScriptEngine [" << getFilename() << "] from ScriptEngines!";
         scriptEngines->removeScriptEngine(this);
-        qCDebug(scriptengine) << "AFTER remove ScriptEngine [" << getFilename() << "] from ScriptEngines!";
     } else {
         qCWarning(scriptengine) << "Script destroyed after ScriptEngines!";
     }
@@ -759,6 +757,7 @@ void ScriptEngine::stop() {
             QMetaObject::invokeMethod(this, "stop");
             return;
         }
+        abortEvaluation(); // abort any script evaluation that may be active
         _isFinished = true;
         if (_wantSignals) {
             emit runningStateChanged();

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -71,7 +71,7 @@ public:
     ~ScriptEngine();
 
     // Useful for QSharePointer<ScriptEngine>
-    static void doDeleteLater(ScriptEngine* obj) { obj->deleteLater(); }
+    static void doDeleteLater(ScriptEngine* engine) { engine->deleteLater(); }
 
     /// run the script in a dedicated thread. This will have the side effect of evalulating
     /// the current script contents and calling run(). Callers will likely want to register the script with external

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -70,9 +70,6 @@ public:
 
     ~ScriptEngine();
 
-    // Useful for QSharePointer<ScriptEngine>
-    static void doDeleteLater(ScriptEngine* engine) { engine->deleteLater(); }
-
     /// run the script in a dedicated thread. This will have the side effect of evalulating
     /// the current script contents and calling run(). Callers will likely want to register the script with external
     /// services before calling this.

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -70,6 +70,9 @@ public:
 
     ~ScriptEngine();
 
+    // Useful for QSharePointer<ScriptEngine>
+    static void doDeleteLater(ScriptEngine* obj) { obj->deleteLater(); }
+
     /// run the script in a dedicated thread. This will have the side effect of evalulating
     /// the current script contents and calling run(). Callers will likely want to register the script with external
     /// services before calling this.
@@ -124,7 +127,10 @@ public:
     Q_INVOKABLE QUrl resolvePath(const QString& path) const;
 
     // Entity Script Related methods
-    Q_INVOKABLE void loadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload = false); // will call the preload method once loaded
+    //Q_INVOKABLE void loadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload = false); // will call the preload method once loaded
+
+    static void loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
+
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params = QStringList());
@@ -223,5 +229,12 @@ protected:
     friend class ScriptEngines;
     static std::atomic<bool> _stoppingAllScripts;
 };
+
+/*
+class ScriptEngine : public QObject {
+    Q_OBJECT
+};
+*/
+
 
 #endif // hifi_ScriptEngine_h

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -127,10 +127,7 @@ public:
     Q_INVOKABLE QUrl resolvePath(const QString& path) const;
 
     // Entity Script Related methods
-    //Q_INVOKABLE void loadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload = false); // will call the preload method once loaded
-
     static void loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
-
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params = QStringList());
@@ -229,12 +226,5 @@ protected:
     friend class ScriptEngines;
     static std::atomic<bool> _stoppingAllScripts;
 };
-
-/*
-class ScriptEngine : public QObject {
-    Q_OBJECT
-};
-*/
-
 
 #endif // hifi_ScriptEngine_h


### PR DESCRIPTION
This fixes memory "holds" and security issues with entity scripts. Now, when you change domains, the script engine state for the entities scripts will be completely reset. This reduces the memory footprint for scripts as well as fixes potential security back doors.