### PR TITLE
Introduce a simple state sort for drawing opaque items

### DIFF
--- a/examples/utilities/render/stats.qml
+++ b/examples/utilities/render/stats.qml
@@ -81,11 +81,6 @@ Item {
                     color: "#1AC567"
                 },
                 {
-                    prop: "frameTextureCount",
-                    label: "Frame",
-                    color: "#E2334D"
-                },
-                {
                     prop: "textureGPUTransferCount",
                     label: "Transfer",
                     color: "#9495FF"
@@ -114,13 +109,7 @@ Item {
                     prop: "textureGPUVirtualMemoryUsage",
                     label: "GPU Virtual",
                     color: "#9495FF"
-                },
-                {
-                    prop: "frameTextureMemoryUsage",
-                    label: "Frame",
-                    color: "#E2334D"
                 }
-
             ]
         }
 
@@ -170,6 +159,24 @@ Item {
             ]
         }
  
+        PlotPerf {
+            title: "State Changes"
+            height: parent.evalEvenHeight()
+            object: stats.config
+            plots: [
+                {
+                    prop: "frameTextureCount",
+                    label: "Textures",
+                    color: "#00B4EF"
+                },
+                {
+                    prop: "frameSetPipelineCount",
+                    label: "Pipelines",
+                    color: "#E2334D"
+                }
+            ]
+        }  
+
         property var drawOpaqueConfig: Render.getConfig("DrawOpaqueDeferred")
         property var drawTransparentConfig: Render.getConfig("DrawTransparentDeferred")
         property var drawLightConfig: Render.getConfig("DrawLight")

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -39,6 +39,8 @@ public:
     int _DSNumAPIDrawcalls = 0;
     int _DSNumDrawcalls = 0;
     int _DSNumTriangles = 0;
+
+    int _PSNumSetPipelines = 0;
  
     ContextStats() {}
     ContextStats(const ContextStats& stats) = default;

--- a/libraries/gpu/src/gpu/GLBackendPipeline.cpp
+++ b/libraries/gpu/src/gpu/GLBackendPipeline.cpp
@@ -64,6 +64,9 @@ void GLBackend::do_setPipeline(Batch& batch, size_t paramOffset) {
         return;
     }
 
+    // A true new Pipeline
+    _stats._PSNumSetPipelines++;
+
     // null pipeline == reset
     if (!pipeline) {
         _pipeline._pipeline.reset();

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -96,7 +96,7 @@ RenderDeferredTask::RenderDeferredTask(CullFunctor cullFunctor) {
     addJob<PrepareDeferred>("PrepareDeferred");
 
     // Render opaque objects in DeferredBuffer
-    addJob<DrawDeferred>("DrawOpaqueDeferred", opaques, shapePlumber);
+    addJob<DrawStateSortDeferred>("DrawOpaqueDeferred", opaques, shapePlumber);
 
     // Once opaque is all rendered create stencil background
     addJob<DrawStencilDeferred>("DrawOpaqueStencil");
@@ -199,6 +199,38 @@ void DrawDeferred::run(const SceneContextPointer& sceneContext, const RenderCont
         renderShapes(sceneContext, renderContext, _shapePlumber, inItems, _maxDrawn);
         args->_batch = nullptr;
     });
+}
+
+void DrawStateSortDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemBounds& inItems) {
+    assert(renderContext->args);
+    assert(renderContext->args->_viewFrustum);
+
+    auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
+
+    RenderArgs* args = renderContext->args;
+
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
+        args->_batch = &batch;
+        batch.setViewportTransform(args->_viewport);
+        batch.setStateScissorRect(args->_viewport);
+
+        glm::mat4 projMat;
+        Transform viewMat;
+        args->_viewFrustum->evalProjectionMatrix(projMat);
+        args->_viewFrustum->evalViewTransform(viewMat);
+
+        batch.setProjectionTransform(projMat);
+        batch.setViewTransform(viewMat);
+
+        if (_stateSort) {
+            renderStateSortShapes(sceneContext, renderContext, _shapePlumber, inItems, _maxDrawn);
+        } else {
+            renderShapes(sceneContext, renderContext, _shapePlumber, inItems, _maxDrawn);
+        }
+        args->_batch = nullptr;
+    });
+
+    config->setNumDrawn((int)inItems.size());
 }
 
 DrawOverlay3D::DrawOverlay3D(bool opaque) :

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -72,6 +72,44 @@ protected:
     int _maxDrawn; // initialized by Config
 };
 
+class DrawStateSortConfig : public render::Job::Config {
+    Q_OBJECT
+        Q_PROPERTY(int numDrawn READ getNumDrawn NOTIFY numDrawnChanged)
+        Q_PROPERTY(int maxDrawn MEMBER maxDrawn NOTIFY dirty)
+        Q_PROPERTY(bool stateSort MEMBER stateSort NOTIFY dirty)
+public:
+
+    int getNumDrawn() { return numDrawn; }
+    void setNumDrawn(int num) { numDrawn = num; emit numDrawnChanged(); }
+
+    int maxDrawn{ -1 };
+    bool stateSort{ true };
+
+signals:
+    void numDrawnChanged();
+    void dirty();
+
+protected:
+    int numDrawn{ 0 };
+};
+
+class DrawStateSortDeferred {
+public:
+    using Config = DrawStateSortConfig;
+    using JobModel = render::Job::ModelI<DrawStateSortDeferred, render::ItemBounds, Config>;
+
+    DrawStateSortDeferred(render::ShapePlumberPointer shapePlumber) : _shapePlumber{ shapePlumber } {}
+
+    void configure(const Config& config) { _maxDrawn = config.maxDrawn; _stateSort = config.stateSort; }
+    void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext, const render::ItemBounds& inItems);
+
+protected:
+    render::ShapePlumberPointer _shapePlumber;
+    int _maxDrawn; // initialized by Config
+    bool _stateSort;
+};
+
+
 class DrawStencilDeferred {
 public:
     using JobModel = render::Job::Model<DrawStencilDeferred>;

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -75,11 +75,11 @@ void render::renderStateSortShapes(const SceneContextPointer& sceneContext, cons
         numItemsToDraw = glm::min(numItemsToDraw, maxDrawnItems);
     }
 
-    using SortedPipelines = std::vector< render::ShapeKey >;
-    using SortedShapes = std::unordered_map< render::ShapeKey, std::vector< Item >, render::ShapeKey::Hash, render::ShapeKey::KeyEqual >;
+    using SortedPipelines = std::vector<render::ShapeKey>;
+    using SortedShapes = std::unordered_map<render::ShapeKey, std::vector<Item>, render::ShapeKey::Hash, render::ShapeKey::KeyEqual>;
     SortedPipelines sortedPipelines;
     SortedShapes sortedShapes;
-    std::vector< Item > ownPipelineBucket;
+    std::vector<Item> ownPipelineBucket;
 
 
     for (auto i = 0; i < numItemsToDraw; ++i) {

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -65,6 +65,57 @@ void render::renderShapes(const SceneContextPointer& sceneContext, const RenderC
     }
 }
 
+void render::renderStateSortShapes(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext,
+    const ShapePlumberPointer& shapeContext, const ItemBounds& inItems, int maxDrawnItems) {
+    auto& scene = sceneContext->_scene;
+    RenderArgs* args = renderContext->args;
+
+    int numItemsToDraw = (int)inItems.size();
+    if (maxDrawnItems != -1) {
+        numItemsToDraw = glm::min(numItemsToDraw, maxDrawnItems);
+    }
+
+    using SortedPipelines = std::vector< render::ShapeKey >;
+    using SortedShapes = std::unordered_map< render::ShapeKey, std::vector< Item >, render::ShapeKey::Hash, render::ShapeKey::KeyEqual >;
+    SortedPipelines sortedPipelines;
+    SortedShapes sortedShapes;
+    std::vector< Item > ownPipelineBucket;
+
+
+    for (auto i = 0; i < numItemsToDraw; ++i) {
+        auto item = scene->getItem(inItems[i].id);
+
+        {
+            assert(item.getKey().isShape());
+            const auto& key = item.getShapeKey();
+            if (key.isValid() && !key.hasOwnPipeline()) {
+                auto& bucket = sortedShapes[key];
+                if (bucket.empty()) {
+                    sortedPipelines.push_back(key);
+                }
+                bucket.push_back(item);
+            } else if (key.hasOwnPipeline()) {
+                ownPipelineBucket.push_back(item);
+            } else {
+                qDebug() << "Item could not be rendered: invalid key ?" << key;
+            }
+        }
+    }
+
+    // THen render
+    for (auto& pipelineKey : sortedPipelines) {
+        auto& bucket = sortedShapes[pipelineKey];
+        args->_pipeline = shapeContext->pickPipeline(args, pipelineKey);
+        for (auto& item : bucket) {
+            item.render(args);
+        }
+    }
+    args->_pipeline = nullptr;
+    for (auto& item : ownPipelineBucket) {
+        item.render(args);
+    }
+}
+
 void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemBounds& inLights) {
     assert(renderContext->args);
     assert(renderContext->args->_viewFrustum);

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -102,7 +102,7 @@ void render::renderStateSortShapes(const SceneContextPointer& sceneContext, cons
         }
     }
 
-    // THen render
+    // Then render
     for (auto& pipelineKey : sortedPipelines) {
         auto& bucket = sortedShapes[pipelineKey];
         args->_pipeline = shapeContext->pickPipeline(args, pipelineKey);

--- a/libraries/render/src/render/DrawTask.h
+++ b/libraries/render/src/render/DrawTask.h
@@ -18,6 +18,7 @@ namespace render {
 
 void renderItems(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemBounds& inItems, int maxDrawnItems = -1);
 void renderShapes(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ShapePlumberPointer& shapeContext, const ItemBounds& inItems, int maxDrawnItems = -1);
+void renderStateSortShapes(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ShapePlumberPointer& shapeContext, const ItemBounds& inItems, int maxDrawnItems = -1);
 
 
 

--- a/libraries/render/src/render/EngineStats.cpp
+++ b/libraries/render/src/render/EngineStats.cpp
@@ -49,5 +49,7 @@ void EngineStats::run(const SceneContextPointer& sceneContext, const RenderConte
     config->frameTextureRate = config->frameTextureCount * frequency;
     config->frameTextureMemoryUsage = _gpuStats._RSAmountTextureMemoryBounded - gpuStats._RSAmountTextureMemoryBounded;
 
+    config->frameSetPipelineCount = _gpuStats._PSNumSetPipelines - gpuStats._PSNumSetPipelines;
+
     config->emitDirty();
 }

--- a/libraries/render/src/render/EngineStats.h
+++ b/libraries/render/src/render/EngineStats.h
@@ -47,6 +47,9 @@ namespace render {
         Q_PROPERTY(quint32 frameTextureRate MEMBER frameTextureRate NOTIFY dirty)
         Q_PROPERTY(quint32 frameTextureMemoryUsage MEMBER frameTextureMemoryUsage NOTIFY dirty)
 
+        Q_PROPERTY(quint32 frameSetPipelineCount MEMBER frameSetPipelineCount NOTIFY dirty)
+
+
     public:
         EngineStatsConfig() : Job::Config(true) {}
 
@@ -72,6 +75,10 @@ namespace render {
         quint32 frameTextureCount{ 0 };
         quint32 frameTextureRate{ 0 };
         qint64 frameTextureMemoryUsage{ 0 };
+
+        quint32 frameSetPipelineCount{ 0 };
+
+
 
         void emitDirty() { emit dirty(); }
 


### PR DESCRIPTION
a Simple state sort applied to the Opaque Items in the new DrawStateSortDeferred Job used in place of the DrawDeferred job.

THis is sorting the items based on the ShapeKey which allow the code to factorise the setPipeline and greatly reduce the number of state changes.
THis also as a nice impact on performance on the batch rendering as the glUseProgram is used much more efficiently.
This is a very simple first step toward better state sort but this already gives use nice performance improvment.

in the DrawOpaqueDeferred job I measure ~1ms over 10ms in Playa in stereo.
The state Sort can be turned off so we can compare in real time the differrences of performance.

Added the counter "frameSetPipelineCounter" in Render.Stats that represent the number of time the SetPipeline is actually performed in the GLBackend layers with true glUseProgram beeing called.

Cleaned up the renderStats.js qml to introduce a new plot "State Changes" which shows this new SetPipeline counter and migrated the Frame Texture Counter  there.
Removed the per Frame Texture Memory since it was a bit confusing.