### PR TITLE
Fix for laggy avatar attachments

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -340,6 +340,10 @@ void MyAvatar::simulate(float deltaTime) {
         _skeletonModel->simulate(deltaTime);
     }
 
+    // we've achived our final adjusted our position & rotation for the avatar
+    // and all joints, we can now update our attachements.
+    Avatar::simulateAttachments(deltaTime);
+
     if (!_skeletonModel->hasSkeleton()) {
         // All the simulation that can be done has been done
         return;
@@ -1160,9 +1164,6 @@ void MyAvatar::harvestResultsFromPhysicsSimulation(float deltaTime) {
     _bodySensorMatrix = _follow.postPhysicsUpdate(*this, _bodySensorMatrix);
 
     setVelocity(_characterController.getLinearVelocity() + _characterController.getFollowVelocity());
-
-    // now that physics has adjusted our position, we can update attachements.
-    Avatar::simulateAttachments(deltaTime);
 }
 
 QString MyAvatar::getScriptedMotorFrame() const {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -340,8 +340,8 @@ void MyAvatar::simulate(float deltaTime) {
         _skeletonModel->simulate(deltaTime);
     }
 
-    // we've achived our final adjusted our position & rotation for the avatar
-    // and all joints, we can now update our attachements.
+    // we've achived our final adjusted position and rotation for the avatar
+    // and all of its joints, now update our attachements.
     Avatar::simulateAttachments(deltaTime);
 
     if (!_skeletonModel->hasSkeleton()) {


### PR DESCRIPTION
This was difficult to notice, as it only affected movement that occurred after physics.  But it is very noticeable if you disable avatar physics.

There was a one frame lag in rotation only if avatar collisions are enabled.  If avatar collisions are disabled, the lag affects both rotation and position.  This PR fixes both issues.