### PR TITLE
tweaks to LOD behavior

### DIFF
--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -40,11 +40,10 @@ const int UP_SHIFT_SAMPLES_OF_FRAMES = ASSUMED_FPS * UP_SHIFT_WINDOW_IN_SECS;
 const float ADJUST_LOD_DOWN_BY = 0.9f;
 const float ADJUST_LOD_UP_BY = 1.1f;
 
-// This controls how low the auto-adjust LOD will go a value of 1 means it will adjust to a point where you must be 0.25
-// meters away from an object of TREE_SCALE before you can see it (which is effectively completely blind). The default value
-// DEFAULT_OCTREE_SIZE_SCALE means you can be 400 meters away from a 1 meter object in order to see it (which is ~20:20 vision).
-const float ADJUST_LOD_MIN_SIZE_SCALE = 1.0f;
+// The default value DEFAULT_OCTREE_SIZE_SCALE means you can be 400 meters away from a 1 meter object in order to see it (which is ~20:20 vision).
 const float ADJUST_LOD_MAX_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE;
+// This controls how low the auto-adjust LOD will go. We want a minimum vision of ~20:500 or 0.04 of default
+const float ADJUST_LOD_MIN_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE * 0.04f;
 
 class RenderArgs;
 class AABox;

--- a/interface/src/ui/LodToolsDialog.cpp
+++ b/interface/src/ui/LodToolsDialog.cpp
@@ -51,8 +51,8 @@ LodToolsDialog::LodToolsDialog(QWidget* parent) :
     connect(_manualLODAdjust, SIGNAL(toggled(bool)), SLOT(updateAutomaticLODAdjust()));
     
     _lodSize = new QSlider(Qt::Horizontal, this);
-    const int MAX_LOD_SIZE = MAX_LOD_SIZE_MULTIPLIER;
-    const int MIN_LOD_SIZE = ADJUST_LOD_MIN_SIZE_SCALE;
+    const int MAX_LOD_SIZE = 2000; // ~20:4 vision -- really good.
+    const int MIN_LOD_SIZE = 5; // ~20:1600 vision -- really bad!
     const int STEP_LOD_SIZE = 1;
     const int PAGE_STEP_LOD_SIZE = 100;
     const int SLIDER_WIDTH = 300;


### PR DESCRIPTION
- minimum automatic LOD will now adjust to vision of ~20:500 or 0.04 of default
- changed the Dev > Render > LOD Tools slider to go from ~20:1600 to ~20:4 instead of wider range