### PR TITLE
Remove myAvatar motion states on shutdown

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -254,10 +254,7 @@ void AvatarManager::clearAllAvatars() {
 
     QWriteLocker locker(&_hashLock);
 
-    _myAvatar->die();
-    _myAvatar.reset();
-
-    _avatarHash.clear();
+    handleRemovedAvatar(_myAvatar);
 }
 
 void AvatarManager::setLocalLights(const QVector<AvatarManager::LocalLight>& localLights) {


### PR DESCRIPTION
A previous fix (#7702) had incorrectly left myAvatar's motion states in the physics engine. This fixes that.