### PR TITLE
Fix deadlock on shutdown from blocking texture/model loads

### DIFF
--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -64,9 +64,9 @@ void AnimationReader::run() {
 
         if (urlValid) {
             // Parse the FBX directly from the QNetworkReply
-            FBXGeometry* fbxgeo = nullptr;
+            FBXGeometry::Pointer fbxgeo;
             if (_url.path().toLower().endsWith(".fbx")) {
-                fbxgeo = readFBX(_data, QVariantHash(), _url.path());
+                fbxgeo.reset(readFBX(_data, QVariantHash(), _url.path()));
             } else {
                 QString errorStr("usupported format");
                 emit onError(299, errorStr);
@@ -117,16 +117,16 @@ const QVector<FBXAnimationFrame>& Animation::getFramesReference() const {
 void Animation::downloadFinished(const QByteArray& data) {
     // parse the animation/fbx file on a background thread.
     AnimationReader* animationReader = new AnimationReader(_url, data);
-    connect(animationReader, SIGNAL(onSuccess(FBXGeometry*)), SLOT(animationParseSuccess(FBXGeometry*)));
+    connect(animationReader, SIGNAL(onSuccess(FBXGeometry::Pointer)), SLOT(animationParseSuccess(FBXGeometry::Pointer)));
     connect(animationReader, SIGNAL(onError(int, QString)), SLOT(animationParseError(int, QString)));
     QThreadPool::globalInstance()->start(animationReader);
 }
 
-void Animation::animationParseSuccess(FBXGeometry* geometry) {
+void Animation::animationParseSuccess(FBXGeometry::Pointer geometry) {
 
     qCDebug(animation) << "Animation parse success" << _url.toDisplayString();
 
-    _geometry.reset(geometry);
+    _geometry = geometry;
     finishedLoading(true);
 }
 

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -68,12 +68,12 @@ protected:
     virtual void downloadFinished(const QByteArray& data) override;
 
 protected slots:
-    void animationParseSuccess(FBXGeometry* geometry);
+    void animationParseSuccess(FBXGeometry::Pointer geometry);
     void animationParseError(int error, QString str);
 
 private:
     
-    std::unique_ptr<FBXGeometry> _geometry;
+    FBXGeometry::Pointer _geometry;
 };
 
 /// Reads geometry in a worker thread.
@@ -85,7 +85,7 @@ public:
     virtual void run();
 
 signals:
-    void onSuccess(FBXGeometry* geometry);
+    void onSuccess(FBXGeometry::Pointer geometry);
     void onError(int error, QString str);
 
 private:

--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -39,6 +39,8 @@
 
 using namespace std;
 
+static int FBXGeometryPointerMetaTypeId = qRegisterMetaType<FBXGeometry::Pointer>();
+
 QStringList FBXGeometry::getJointNames() const {
     QStringList names;
     foreach (const FBXJoint& joint, joints) {

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -270,6 +270,7 @@ inline bool operator!=(const SittingPoint& lhs, const SittingPoint& rhs)
 /// A set of meshes extracted from an FBX document.
 class FBXGeometry {
 public:
+    using Pointer = std::shared_ptr<FBXGeometry>;
 
     QString author;
     QString applicationName; ///< the name of the application that generated the model
@@ -330,6 +331,7 @@ public:
 };
 
 Q_DECLARE_METATYPE(FBXGeometry)
+Q_DECLARE_METATYPE(FBXGeometry::Pointer)
 
 /// Reads FBX geometry from the supplied model and mapping data.
 /// \exception QString if an error occurs in parsing

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -17,6 +17,7 @@
 
 using namespace gpu;
 
+static int TexturePointerMetaTypeId = qRegisterMetaType<TexturePointer>();
 
 std::atomic<uint32_t> Texture::_textureCPUCount{ 0 };
 std::atomic<Texture::Size> Texture::_textureCPUMemoryUsage{ 0 };
@@ -857,8 +858,8 @@ void TextureSource::reset(const QUrl& url) {
     _imageUrl = url;
 }
 
-void TextureSource::resetTexture(gpu::Texture* texture) {
-    _gpuTexture.reset(texture);
+void TextureSource::resetTexture(gpu::TexturePointer texture) {
+    _gpuTexture = texture;
 }
 
 bool TextureSource::isDefined() const {

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -16,6 +16,7 @@
 #include <algorithm> //min max and more
 #include <bitset>
 
+#include <QMetaType>
 #include <QUrl>
 
 namespace gpu {
@@ -469,7 +470,6 @@ protected:
 typedef std::shared_ptr<Texture> TexturePointer;
 typedef std::vector< TexturePointer > Textures;
 
-
  // TODO: For now TextureView works with Texture as a place holder for the Texture.
  // The overall logic should be about the same except that the Texture will be a real GL Texture under the hood
 class TextureView {
@@ -526,7 +526,7 @@ public:
 
     void reset(const QUrl& url);
 
-    void resetTexture(gpu::Texture* texture);
+    void resetTexture(gpu::TexturePointer texture);
 
     bool isDefined() const;
 
@@ -538,5 +538,6 @@ typedef std::shared_ptr< TextureSource > TextureSourcePointer;
 
 };
 
+Q_DECLARE_METATYPE(gpu::TexturePointer)
 
 #endif

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -128,7 +128,6 @@ public:
 signals:
     void networkTextureCreated(const QWeakPointer<NetworkTexture>& self);
 
-
 protected:
 
     virtual bool isCacheable() const override { return _loaded; }
@@ -136,9 +135,7 @@ protected:
     virtual void downloadFinished(const QByteArray& data) override;
           
     Q_INVOKABLE void loadContent(const QByteArray& content);
-    // FIXME: This void* should be a gpu::Texture* but i cannot get it to work for now, moving on...
-    Q_INVOKABLE void setImage(void* texture, int originalWidth, int originalHeight);
-
+    Q_INVOKABLE void setImage(gpu::TexturePointer texture, int originalWidth, int originalHeight);
 
 private:
     TextureType _type;


### PR DESCRIPTION
- Register gpu::TexturePointer with Qt
- Alias FBXGeometry::Pointer and register with Qt
- Change threaded resource readers to use smart pointers