### PR TITLE
Fix for path MTU discovery fail

### DIFF
--- a/libraries/networking/src/udt/Constants.h
+++ b/libraries/networking/src/udt/Constants.h
@@ -18,7 +18,7 @@
 
 namespace udt {
     static const int UDP_IPV4_HEADER_SIZE = 28;
-    static const int MAX_PACKET_SIZE_WITH_UDP_HEADER = 1500;
+    static const int MAX_PACKET_SIZE_WITH_UDP_HEADER = 1492;
     static const int MAX_PACKET_SIZE = MAX_PACKET_SIZE_WITH_UDP_HEADER - UDP_IPV4_HEADER_SIZE;
     static const int MAX_PACKETS_IN_FLIGHT = 25600;
     static const int CONNECTION_RECEIVE_BUFFER_SIZE_PACKETS = 8192;

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -38,6 +38,21 @@ Socket::Socket(QObject* parent) :
     _synTimer->start(_synInterval);
 }
 
+void Socket::bind(const QHostAddress& address, quint16 port) {
+    _udpSocket.bind(address, port);
+    setSystemBufferSizes();
+
+#if defined(Q_OS_LINUX)
+    auto sd = _udpSocket.socketDescriptor();
+    int val = IP_PMTUDISC_DONT;
+    setsockopt(sd, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(val));
+#elif defined(Q_OS_WINDOWS)
+    auto sd = _udpSocket.socketDescriptor();
+    int val = 0; // false
+    setsockopt(sd, IPPROTO_IP, IP_DONTFRAGMENT, &val, sizeof(val));
+#endif
+}
+
 void Socket::rebind() {
     quint16 oldPort = _udpSocket.localPort();
     

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -60,7 +60,7 @@ public:
     qint64 writeDatagram(const char* data, qint64 size, const HifiSockAddr& sockAddr);
     qint64 writeDatagram(const QByteArray& datagram, const HifiSockAddr& sockAddr);
     
-    void bind(const QHostAddress& address, quint16 port = 0) { _udpSocket.bind(address, port); setSystemBufferSizes(); }
+    void bind(const QHostAddress& address, quint16 port = 0);
     void rebind();
     
     void setPacketFilterOperator(PacketFilterOperator filterOperator) { _packetFilterOperator = filterOperator; }

--- a/tools/udt-test/src/UDTTest.cpp
+++ b/tools/udt-test/src/UDTTest.cpp
@@ -25,7 +25,7 @@ const QCommandLineOption TARGET_OPTION {
     "IP:PORT or HOSTNAME:PORT"
 };
 const QCommandLineOption PACKET_SIZE {
-    "packet-size", "size for sent packets in bytes (defaults to 1500)", "bytes",
+    "packet-size", "size for sent packets in bytes (defaults to 1492)", "bytes",
     QString(udt::MAX_PACKET_SIZE_WITH_UDP_HEADER)
 };
 const QCommandLineOption MIN_PACKET_SIZE {
@@ -366,7 +366,7 @@ void UDTTest::sampleStats() {
     static const double USECS_PER_MSEC = 1000.0;
     static const double MEGABITS_PER_BYTE = 8.0 / 1000000.0;
     static const double MS_PER_SECOND = 1000.0;
-    static const double PPS_TO_MBPS = 1500.0 * MEGABITS_PER_BYTE;
+    static const double PPS_TO_MBPS = udt::MAX_PACKET_SIZE_WITH_UDP_HEADER * MEGABITS_PER_BYTE;
 
 
     if (!_target.isNull()) {

--- a/tools/udt-test/src/UDTTest.cpp
+++ b/tools/udt-test/src/UDTTest.cpp
@@ -25,8 +25,8 @@ const QCommandLineOption TARGET_OPTION {
     "IP:PORT or HOSTNAME:PORT"
 };
 const QCommandLineOption PACKET_SIZE {
-    "packet-size", "size for sent packets in bytes (defaults to 1492)", "bytes",
-    QString(udt::MAX_PACKET_SIZE_WITH_UDP_HEADER)
+    "packet-size", "size for sent packets in bytes (defaults to " + QString(MAX_PACKET_SIZE) + ")", "bytes",
+    QString(udt::MAX_PACKET_SIZE)
 };
 const QCommandLineOption MIN_PACKET_SIZE {
     "min-packet-size", "min size for sent packets in bytes", "min bytes"
@@ -366,7 +366,7 @@ void UDTTest::sampleStats() {
     static const double USECS_PER_MSEC = 1000.0;
     static const double MEGABITS_PER_BYTE = 8.0 / 1000000.0;
     static const double MS_PER_SECOND = 1000.0;
-    static const double PPS_TO_MBPS = udt::MAX_PACKET_SIZE_WITH_UDP_HEADER * MEGABITS_PER_BYTE;
+    static const double PPS_TO_MBPS = udt::MAX_PACKET_SIZE * MEGABITS_PER_BYTE;
 
 
     if (!_target.isNull()) {


### PR DESCRIPTION
This patch fixes the case where pmtu_disc fails.

- Make sure the DontFragment flag is not set for the socket.
- Drop the max packet size from 1500 to 1492 with is a fairly common MTU.

https://app.asana.com/0/26551373415487/114763027727130