### PR TITLE
support for larger than 35 minute clock skew

### DIFF
--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -960,8 +960,7 @@ bool OctreeServer::readOptionInt64(const QString& optionName, const QJsonObject&
         optionAvailable = true;
         result = atoll(argValue);
         qDebug() << "From payload arguments: " << qPrintable(argName) << ":" << result;
-    }
-    else if (settingsSectionObject.contains(optionName)) {
+    } else if (settingsSectionObject.contains(optionName)) {
         optionAvailable = true;
         result = settingsSectionObject[optionName].toString().toLongLong(&optionAvailable);
         if (optionAvailable) {

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -952,6 +952,25 @@ bool OctreeServer::readOptionInt(const QString& optionName, const QJsonObject& s
     return optionAvailable;
 }
 
+bool OctreeServer::readOptionInt64(const QString& optionName, const QJsonObject& settingsSectionObject, qint64& result) {
+    bool optionAvailable = false;
+    QString argName = "--" + optionName;
+    const char* argValue = getCmdOption(_argc, _argv, qPrintable(argName));
+    if (argValue) {
+        optionAvailable = true;
+        result = atoll(argValue);
+        qDebug() << "From payload arguments: " << qPrintable(argName) << ":" << result;
+    }
+    else if (settingsSectionObject.contains(optionName)) {
+        optionAvailable = true;
+        result = settingsSectionObject[optionName].toString().toLongLong(&optionAvailable);
+        if (optionAvailable) {
+            qDebug() << "From domain settings: " << qPrintable(optionName) << ":" << result;
+        }
+    }
+    return optionAvailable;
+}
+
 bool OctreeServer::readOptionString(const QString& optionName, const QJsonObject& settingsSectionObject, QString& result) {
     bool optionAvailable = false;
     QString argName = "--" + optionName;
@@ -1055,10 +1074,10 @@ void OctreeServer::readConfiguration() {
     // Debug option to demonstrate that the server's local time does not
     // need to be in sync with any other network node. This forces clock
     // skew for the individual server node
-    int clockSkew;
-    if (readOptionInt(QString("clockSkew"), settingsSectionObject, clockSkew)) {
+    qint64 clockSkew;
+    if (readOptionInt64(QString("clockSkew"), settingsSectionObject, clockSkew)) {
         usecTimestampNowForceClockSkew(clockSkew);
-        qDebug("clockSkew=%d", clockSkew);
+        qDebug() << "clockSkew=" << clockSkew;
     }
 
     // Check to see if the user passed in a command line option for setting packet send rate

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -145,6 +145,7 @@ protected:
     virtual OctreePointer createTree() = 0;
     bool readOptionBool(const QString& optionName, const QJsonObject& settingsSectionObject, bool& result);
     bool readOptionInt(const QString& optionName, const QJsonObject& settingsSectionObject, int& result);
+    bool readOptionInt64(const QString& optionName, const QJsonObject& settingsSectionObject, qint64& result);
     bool readOptionString(const QString& optionName, const QJsonObject& settingsSectionObject, QString& result);
     void readConfiguration();
     virtual void readAdditionalConfiguration(const QJsonObject& settingsSectionObject) { };

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -127,9 +127,9 @@ int main(int argc, const char* argv[]) {
     const char* CLOCK_SKEW = "--clockSkew";
     const char* clockSkewOption = getCmdOption(argc, argv, CLOCK_SKEW);
     if (clockSkewOption) {
-        int clockSkew = atoi(clockSkewOption);
+        quint64 clockSkew = atoll(clockSkewOption);
         usecTimestampNowForceClockSkew(clockSkew);
-        qCDebug(interfaceapp, "clockSkewOption=%s clockSkew=%d", clockSkewOption, clockSkew);
+        qCDebug(interfaceapp) << "clockSkewOption=" << clockSkewOption << "clockSkew=" << clockSkew;
     }
 
     // Oculus initialization MUST PRECEDE OpenGL context creation.

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, const char* argv[]) {
     const char* CLOCK_SKEW = "--clockSkew";
     const char* clockSkewOption = getCmdOption(argc, argv, CLOCK_SKEW);
     if (clockSkewOption) {
-        quint64 clockSkew = atoll(clockSkewOption);
+        qint64 clockSkew = atoll(clockSkewOption);
         usecTimestampNowForceClockSkew(clockSkew);
         qCDebug(interfaceapp) << "clockSkewOption=" << clockSkewOption << "clockSkew=" << clockSkew;
     }

--- a/interface/src/ui/OctreeStatsDialog.cpp
+++ b/interface/src/ui/OctreeStatsDialog.cpp
@@ -515,7 +515,7 @@ void OctreeStatsDialog::showOctreeServersOfType(int& serverCount, NodeType_t ser
                             QString incomingLikelyLostString = locale.toString((uint)seqStats.getLost());
                             QString incomingRecovered = locale.toString((uint)seqStats.getRecovered());
 
-                            int clockSkewInMS = node->getClockSkewUsec() / (int)USECS_PER_MSEC;
+                            qint64 clockSkewInMS = node->getClockSkewUsec() / USECS_PER_MSEC;
                             QString incomingFlightTimeString = locale.toString((int)stats.getIncomingFlightTimeAverage());
                             QString incomingPingTimeString = locale.toString(node->getPingMs());
                             QString incomingClockSkewString = locale.toString(clockSkewInMS);

--- a/interface/src/ui/OctreeStatsDialog.cpp
+++ b/interface/src/ui/OctreeStatsDialog.cpp
@@ -515,7 +515,9 @@ void OctreeStatsDialog::showOctreeServersOfType(int& serverCount, NodeType_t ser
                             QString incomingLikelyLostString = locale.toString((uint)seqStats.getLost());
                             QString incomingRecovered = locale.toString((uint)seqStats.getRecovered());
 
-                            qint64 clockSkewInMS = node->getClockSkewUsec() / USECS_PER_MSEC;
+                            qint64 clockSkewInUsecs = node->getClockSkewUsec();
+                            QString formattedClockSkewString = formatUsecTime(clockSkewInUsecs);
+                            qint64 clockSkewInMS = clockSkewInUsecs / (qint64)USECS_PER_MSEC;
                             QString incomingFlightTimeString = locale.toString((int)stats.getIncomingFlightTimeAverage());
                             QString incomingPingTimeString = locale.toString(node->getPingMs());
                             QString incomingClockSkewString = locale.toString(clockSkewInMS);
@@ -536,7 +538,9 @@ void OctreeStatsDialog::showOctreeServersOfType(int& serverCount, NodeType_t ser
                                 " Average Ping Time: " << qPrintable(incomingPingTimeString) << " msecs";
 
                             serverDetails << "<br/>" <<
-                                " Average Clock Skew: " << qPrintable(incomingClockSkewString) << " msecs";
+                                " Average Clock Skew: " << qPrintable(incomingClockSkewString) << " msecs" << 
+                                " [" << qPrintable(formattedClockSkewString) << "]";
+
 
                             serverDetails << "<br/>" << "Incoming" <<
                                 " Bytes: " << qPrintable(incomingBytesString) <<

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -29,7 +29,7 @@ void EntityEditPacketSender::processEntityEditNackPacket(QSharedPointer<Received
     }
 }
 
-void EntityEditPacketSender::adjustEditPacketForClockSkew(PacketType type, QByteArray& buffer, int clockSkew) {
+void EntityEditPacketSender::adjustEditPacketForClockSkew(PacketType type, QByteArray& buffer, qint64 clockSkew) {
     if (type == PacketType::EntityAdd || type == PacketType::EntityEdit) {
         EntityItem::adjustEditPacketForClockSkew(buffer, clockSkew);
     }

--- a/libraries/entities/src/EntityEditPacketSender.h
+++ b/libraries/entities/src/EntityEditPacketSender.h
@@ -32,7 +32,7 @@ public:
 
     // My server type is the model server
     virtual char getMyNodeType() const { return NodeType::EntityServer; }
-    virtual void adjustEditPacketForClockSkew(PacketType type, QByteArray& buffer, int clockSkew);
+    virtual void adjustEditPacketForClockSkew(PacketType type, QByteArray& buffer, qint64 clockSkew);
 
 public slots:
     void processEntityEditNackPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -370,7 +370,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         return 0;
     }
 
-    int clockSkew = args.sourceNode ? args.sourceNode->getClockSkewUsec() : 0;
+    qint64 clockSkew = args.sourceNode ? args.sourceNode->getClockSkewUsec() : 0;
 
     BufferParser parser(data, bytesLeftToRead);
 
@@ -485,7 +485,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         qCDebug(entities) << "                                    now:" << now;
         qCDebug(entities) << "                          getLastEdited:" << debugTime(getLastEdited(), now);
         qCDebug(entities) << "                   lastEditedFromBuffer:" << debugTime(lastEditedFromBuffer, now);
-        qCDebug(entities) << "                              clockSkew:" << debugTimeOnly(clockSkew);
+        qCDebug(entities) << "                              clockSkew:" << clockSkew;
         qCDebug(entities) << "           lastEditedFromBufferAdjusted:" << debugTime(lastEditedFromBufferAdjusted, now);
         qCDebug(entities) << "                  _lastEditedFromRemote:" << debugTime(_lastEditedFromRemote, now);
         qCDebug(entities) << "      _lastEditedFromRemoteInRemoteTime:" << debugTime(_lastEditedFromRemoteInRemoteTime, now);
@@ -760,7 +760,7 @@ void EntityItem::debugDump() const {
 }
 
 // adjust any internal timestamps to fix clock skew for this server
-void EntityItem::adjustEditPacketForClockSkew(QByteArray& buffer, int clockSkew) {
+void EntityItem::adjustEditPacketForClockSkew(QByteArray& buffer, qint64 clockSkew) {
     unsigned char* dataAt = reinterpret_cast<unsigned char*>(buffer.data());
     int octets = numberOfThreeBitSectionsInCode(dataAt);
     int lengthOfOctcode = (int)bytesRequiredForCodeLength(octets);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -144,7 +144,7 @@ public:
 
     static int expectedBytes();
 
-    static void adjustEditPacketForClockSkew(QByteArray& buffer, int clockSkew);
+    static void adjustEditPacketForClockSkew(QByteArray& buffer, qint64 clockSkew);
 
     // perform update
     virtual void update(const quint64& now) { _lastUpdated = now; }

--- a/libraries/networking/src/Node.cpp
+++ b/libraries/networking/src/Node.cpp
@@ -73,9 +73,9 @@ void Node::setType(char type) {
     _symmetricSocket.setObjectName(typeString);
 }
 
-void Node::updateClockSkewUsec(int clockSkewSample) {
-    _clockSkewMovingPercentile.updatePercentile((float)clockSkewSample);
-    _clockSkewUsec = (int)_clockSkewMovingPercentile.getValueAtPercentile();
+void Node::updateClockSkewUsec(qint64 clockSkewSample) {
+    _clockSkewMovingPercentile.updatePercentile((double)clockSkewSample);
+    _clockSkewUsec = (quint64)_clockSkewMovingPercentile.getValueAtPercentile();
 }
 
 

--- a/libraries/networking/src/Node.cpp
+++ b/libraries/networking/src/Node.cpp
@@ -74,7 +74,7 @@ void Node::setType(char type) {
 }
 
 void Node::updateClockSkewUsec(qint64 clockSkewSample) {
-    _clockSkewMovingPercentile.updatePercentile((double)clockSkewSample);
+    _clockSkewMovingPercentile.updatePercentile(clockSkewSample);
     _clockSkewUsec = (quint64)_clockSkewMovingPercentile.getValueAtPercentile();
 }
 

--- a/libraries/networking/src/Node.h
+++ b/libraries/networking/src/Node.h
@@ -54,8 +54,8 @@ public:
     int getPingMs() const { return _pingMs; }
     void setPingMs(int pingMs) { _pingMs = pingMs; }
 
-    int getClockSkewUsec() const { return _clockSkewUsec; }
-    void updateClockSkewUsec(int clockSkewSample);
+    qint64 getClockSkewUsec() const { return _clockSkewUsec; }
+    void updateClockSkewUsec(qint64 clockSkewSample);
     QMutex& getMutex() { return _mutex; }
 
     void setIsAllowedEditor(bool isAllowedEditor) { _isAllowedEditor = isAllowedEditor; }
@@ -78,7 +78,7 @@ private:
     std::unique_ptr<NodeData> _linkedData;
     bool _isAlive;
     int _pingMs;
-    int _clockSkewUsec;
+    qint64 _clockSkewUsec;
     QMutex _mutex;
     MovingPercentile _clockSkewMovingPercentile;
     bool _isAllowedEditor;

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -147,13 +147,13 @@ void NodeList::timePingReply(ReceivedMessage& message, const SharedNodePointer& 
     message.readPrimitive(&othersReplyTime);
 
     quint64 now = usecTimestampNow();
-    int pingTime = now - ourOriginalTime;
-    int oneWayFlightTime = pingTime / 2; // half of the ping is our one way flight
+    qint64 pingTime = now - ourOriginalTime;
+    qint64 oneWayFlightTime = pingTime / 2; // half of the ping is our one way flight
 
     // The other node's expected time should be our original time plus the one way flight time
     // anything other than that is clock skew
     quint64 othersExpectedReply = ourOriginalTime + oneWayFlightTime;
-    int clockSkew = othersReplyTime - othersExpectedReply;
+    qint64 clockSkew = othersReplyTime - othersExpectedReply;
 
     sendingNode->setPingMs(pingTime / 1000);
     sendingNode->updateClockSkewUsec(clockSkew);

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -158,9 +158,10 @@ void NodeList::timePingReply(ReceivedMessage& message, const SharedNodePointer& 
     sendingNode->setPingMs(pingTime / 1000);
     sendingNode->updateClockSkewUsec(clockSkew);
 
-    const bool wantDebug = false;
+    const bool wantDebug = true;
 
     if (wantDebug) {
+        auto averageClockSkew = sendingNode->getClockSkewUsec();
         qCDebug(networking) << "PING_REPLY from node " << *sendingNode << "\n" <<
         "                     now: " << now << "\n" <<
         "                 ourTime: " << ourOriginalTime << "\n" <<
@@ -168,8 +169,8 @@ void NodeList::timePingReply(ReceivedMessage& message, const SharedNodePointer& 
         "        oneWayFlightTime: " << oneWayFlightTime << "\n" <<
         "         othersReplyTime: " << othersReplyTime << "\n" <<
         "    othersExprectedReply: " << othersExpectedReply << "\n" <<
-        "               clockSkew: " << clockSkew  << "\n" <<
-        "       average clockSkew: " << sendingNode->getClockSkewUsec();
+        "               clockSkew: " << clockSkew << "[" << formatUsecTime(clockSkew) << "]" << "\n" <<
+        "       average clockSkew: " << averageClockSkew << "[" << formatUsecTime(averageClockSkew) << "]";
     }
 }
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -158,7 +158,7 @@ void NodeList::timePingReply(ReceivedMessage& message, const SharedNodePointer& 
     sendingNode->setPingMs(pingTime / 1000);
     sendingNode->updateClockSkewUsec(clockSkew);
 
-    const bool wantDebug = true;
+    const bool wantDebug = false;
 
     if (wantDebug) {
         auto averageClockSkew = sendingNode->getClockSkewUsec();

--- a/libraries/octree/src/OctreeEditPacketSender.cpp
+++ b/libraries/octree/src/OctreeEditPacketSender.cpp
@@ -315,7 +315,7 @@ void OctreeEditPacketSender::releaseQueuedPacket(const QUuid& nodeID, std::uniqu
     _releaseQueuedPacketMutex.unlock();
 }
 
-std::unique_ptr<NLPacket> OctreeEditPacketSender::initializePacket(PacketType type, int nodeClockSkew) {
+std::unique_ptr<NLPacket> OctreeEditPacketSender::initializePacket(PacketType type, qint64 nodeClockSkew) {
     auto newPacket = NLPacket::create(type);
 
     // skip over sequence number for now; will be packed when packet is ready to be sent out

--- a/libraries/octree/src/OctreeEditPacketSender.h
+++ b/libraries/octree/src/OctreeEditPacketSender.h
@@ -75,7 +75,7 @@ public:
 
     // you must override these...
     virtual char getMyNodeType() const = 0;
-    virtual void adjustEditPacketForClockSkew(PacketType type, QByteArray& buffer, int clockSkew) { }
+    virtual void adjustEditPacketForClockSkew(PacketType type, QByteArray& buffer, qint64 clockSkew) { }
 
     void processNackPacket(ReceivedMessage& message, SharedNodePointer sendingNode);
 
@@ -89,7 +89,7 @@ protected:
     void queuePacketToNode(const QUuid& nodeID, std::unique_ptr<NLPacket> packet);
     void queuePendingPacketToNodes(std::unique_ptr<NLPacket> packet);
     void queuePacketToNodes(std::unique_ptr<NLPacket> packet);
-    std::unique_ptr<NLPacket> initializePacket(PacketType type, int nodeClockSkew);
+    std::unique_ptr<NLPacket> initializePacket(PacketType type, qint64 nodeClockSkew);
     void releaseQueuedPacket(const QUuid& nodeUUID, std::unique_ptr<NLPacket> packetBuffer); // releases specific queued packet
 
     void processPreServerExistsPackets();

--- a/libraries/octree/src/OctreeRenderer.cpp
+++ b/libraries/octree/src/OctreeRenderer.cpp
@@ -74,16 +74,19 @@ void OctreeRenderer::processDatagram(ReceivedMessage& message, SharedNodePointer
         bool packetIsCompressed = oneAtBit(flags, PACKET_IS_COMPRESSED_BIT);
         
         OCTREE_PACKET_SENT_TIME arrivedAt = usecTimestampNow();
-        int clockSkew = sourceNode ? sourceNode->getClockSkewUsec() : 0;
-        int flightTime = arrivedAt - sentAt + clockSkew;
+        qint64 clockSkew = sourceNode ? sourceNode->getClockSkewUsec() : 0;
+        qint64 flightTime = arrivedAt - sentAt + clockSkew;
 
         OCTREE_PACKET_INTERNAL_SECTION_SIZE sectionLength = 0;
 
         if (extraDebugging) {
-            qCDebug(octree, "OctreeRenderer::processDatagram() ... Got Packet Section"
-                   " color:%s compressed:%s sequence: %u flight:%d usec size:%lld data:%lld",
-                   debug::valueOf(packetIsColored), debug::valueOf(packetIsCompressed),
-                   sequence, flightTime, message.getSize(), message.getBytesLeftToRead());
+            qCDebug(octree) << "OctreeRenderer::processDatagram() ... "
+                               "Got Packet Section color:" << packetIsColored <<
+                               "compressed:" << packetIsCompressed <<
+                               "sequence: " <<  sequence << 
+                               "flight: " << flightTime << " usec" <<
+                               "size:" << message.getSize() <<
+                               "data:" << message.getBytesLeftToRead();
         }
         
         _packetsInLastWindow++;
@@ -128,12 +131,16 @@ void OctreeRenderer::processDatagram(ReceivedMessage& message, SharedNodePointer
                     packetData.loadFinalizedContent(reinterpret_cast<const unsigned char*>(message.getRawMessage() + message.getPosition()),
                         sectionLength);
                     if (extraDebugging) {
-                        qCDebug(octree, "OctreeRenderer::processDatagram() ... Got Packet Section"
-                            " color:%s compressed:%s sequence: %u flight:%d usec size:%lld data:%lld"
-                            " subsection:%d sectionLength:%d uncompressed:%d",
-                            debug::valueOf(packetIsColored), debug::valueOf(packetIsCompressed),
-                            sequence, flightTime, message.getSize(), message.getBytesLeftToRead(), subsection, sectionLength,
-                            packetData.getUncompressedSize());
+                        qCDebug(octree) << "OctreeRenderer::processDatagram() ... "
+                            "Got Packet Section color:" << packetIsColored <<
+                            "compressed:" << packetIsCompressed <<
+                            "sequence: " << sequence <<
+                            "flight: " << flightTime << " usec" <<
+                            "size:" << message.getSize() <<
+                            "data:" << message.getBytesLeftToRead() <<
+                            "subsection:" << subsection <<
+                            "sectionLength:" << sectionLength <<
+                            "uncompressed:" << packetData.getUncompressedSize();
                     }
 
                     if (extraDebugging) {

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -747,7 +747,7 @@ const char* OctreeSceneStats::getItemValue(Item item) {
 }
 
 void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool wasStatsPacket, qint64 nodeClockSkewUsec) {
-    const bool wantExtraDebugging = true;
+    const bool wantExtraDebugging = false;
 
     // skip past the flags
     message.seek(sizeof(OCTREE_PACKET_FLAGS));

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -747,7 +747,7 @@ const char* OctreeSceneStats::getItemValue(Item item) {
 }
 
 void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool wasStatsPacket, qint64 nodeClockSkewUsec) {
-    const bool wantExtraDebugging = false;
+    const bool wantExtraDebugging = true;
 
     // skip past the flags
     message.seek(sizeof(OCTREE_PACKET_FLAGS));
@@ -768,6 +768,7 @@ void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool 
         qCDebug(octree) << "sentAt:" << sentAt << " usecs";
         qCDebug(octree) << "arrivedAt:" << arrivedAt << " usecs";
         qCDebug(octree) << "nodeClockSkewUsec:" << nodeClockSkewUsec << " usecs";
+        qCDebug(octree) << "node Clock Skew:" << formatUsecTime(nodeClockSkewUsec);
         qCDebug(octree) << "flightTime:" << flightTime << " usecs";
     }
 

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -773,7 +773,7 @@ void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool 
 
     // Guard against possible corrupted packets... with bad timestamps
     const qint64 MAX_RESONABLE_FLIGHT_TIME = 200 * USECS_PER_SECOND; // 200 seconds is more than enough time for a packet to arrive
-    const qint64 MIN_RESONABLE_FLIGHT_TIME = -1 * USECS_PER_SECOND; // more than 1 second of "reverse flight time" would be unreasonable
+    const qint64 MIN_RESONABLE_FLIGHT_TIME = -1 * (qint64)USECS_PER_SECOND; // more than 1 second of "reverse flight time" would be unreasonable
     if (flightTime > MAX_RESONABLE_FLIGHT_TIME || flightTime < MIN_RESONABLE_FLIGHT_TIME) {
         static QString repeatedMessage
             = LogHandler::getInstance().addRepeatedMessageRegex(

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -746,7 +746,7 @@ const char* OctreeSceneStats::getItemValue(Item item) {
     return _itemValueBuffer;
 }
 
-void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool wasStatsPacket, int nodeClockSkewUsec) {
+void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool wasStatsPacket, qint64 nodeClockSkewUsec) {
     const bool wantExtraDebugging = false;
 
     // skip past the flags
@@ -772,8 +772,8 @@ void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool 
     }
 
     // Guard against possible corrupted packets... with bad timestamps
-    const int MAX_RESONABLE_FLIGHT_TIME = 200 * USECS_PER_SECOND; // 200 seconds is more than enough time for a packet to arrive
-    const int MIN_RESONABLE_FLIGHT_TIME = 0;
+    const qint64 MAX_RESONABLE_FLIGHT_TIME = 200 * USECS_PER_SECOND; // 200 seconds is more than enough time for a packet to arrive
+    const qint64 MIN_RESONABLE_FLIGHT_TIME = -1 * USECS_PER_SECOND; // more than 1 second of "reverse flight time" would be unreasonable
     if (flightTime > MAX_RESONABLE_FLIGHT_TIME || flightTime < MIN_RESONABLE_FLIGHT_TIME) {
         static QString repeatedMessage
             = LogHandler::getInstance().addRepeatedMessageRegex(

--- a/libraries/octree/src/OctreeSceneStats.h
+++ b/libraries/octree/src/OctreeSceneStats.h
@@ -162,7 +162,7 @@ public:
     quint64 getLastFullTotalBytes() const { return _lastFullTotalBytes; }
 
     // Used in client implementations to track individual octree packets
-    void trackIncomingOctreePacket(ReceivedMessage& message, bool wasStatsPacket, int nodeClockSkewUsec);
+    void trackIncomingOctreePacket(ReceivedMessage& message, bool wasStatsPacket, qint64 nodeClockSkewUsec);
 
     quint32 getIncomingPackets() const { return _incomingPacket; }
     quint64 getIncomingBytes() const { return _incomingBytes; }

--- a/libraries/physics/src/ObjectAction.cpp
+++ b/libraries/physics/src/ObjectAction.cpp
@@ -277,7 +277,7 @@ quint64 ObjectAction::localTimeToServerTime(quint64 timeValue) const {
     }
 
     qint64 serverClockSkew = getEntityServerClockSkew();
-    if (serverClockSkew < 0 && timeValue <= -serverClockSkew) {
+    if (serverClockSkew < 0 && timeValue <= (quint64)(-serverClockSkew)) {
         return 1; // non-zero but long-expired value to avoid negative roll-over
     }
 
@@ -291,7 +291,7 @@ quint64 ObjectAction::serverTimeToLocalTime(quint64 timeValue) const {
     }
 
     qint64 serverClockSkew = getEntityServerClockSkew();
-    if (serverClockSkew > 0 && timeValue <= serverClockSkew) {
+    if (serverClockSkew > 0 && timeValue <= (quint64)serverClockSkew) {
         return 1; // non-zero but long-expired value to avoid negative roll-over
     }
 

--- a/libraries/physics/src/ObjectAction.cpp
+++ b/libraries/physics/src/ObjectAction.cpp
@@ -61,7 +61,7 @@ void ObjectAction::updateAction(btCollisionWorld* collisionWorld, btScalar delta
     updateActionWorker(deltaTimeStep);
 }
 
-int ObjectAction::getEntityServerClockSkew() const {
+qint64 ObjectAction::getEntityServerClockSkew() const {
     auto nodeList = DependencyManager::get<NodeList>();
 
     auto ownerEntity = _ownerEntity.lock();
@@ -276,8 +276,8 @@ quint64 ObjectAction::localTimeToServerTime(quint64 timeValue) const {
         return 0;
     }
 
-    int serverClockSkew = getEntityServerClockSkew();
-    if (serverClockSkew < 0 && timeValue <= (quint64)(-serverClockSkew)) {
+    qint64 serverClockSkew = getEntityServerClockSkew();
+    if (serverClockSkew < 0 && timeValue <= -serverClockSkew) {
         return 1; // non-zero but long-expired value to avoid negative roll-over
     }
 
@@ -290,8 +290,8 @@ quint64 ObjectAction::serverTimeToLocalTime(quint64 timeValue) const {
         return 0;
     }
 
-    int serverClockSkew = getEntityServerClockSkew();
-    if (serverClockSkew > 0 && timeValue <= (quint64)serverClockSkew) {
+    qint64 serverClockSkew = getEntityServerClockSkew();
+    if (serverClockSkew > 0 && timeValue <= serverClockSkew) {
         return 1; // non-zero but long-expired value to avoid negative roll-over
     }
 

--- a/libraries/physics/src/ObjectAction.h
+++ b/libraries/physics/src/ObjectAction.h
@@ -70,7 +70,7 @@ protected:
     quint64 _expires { 0 }; // in seconds since epoch
 
 private:
-    int getEntityServerClockSkew() const;
+    qint64 getEntityServerClockSkew() const;
 };
 
 #endif // hifi_ObjectAction_h

--- a/libraries/shared/src/MovingPercentile.cpp
+++ b/libraries/shared/src/MovingPercentile.cpp
@@ -21,7 +21,7 @@ MovingPercentile::MovingPercentile(int numSamples, float percentile)
 {
 }
 
-void MovingPercentile::updatePercentile(quint64 sample) {
+void MovingPercentile::updatePercentile(qint64 sample) {
 
     // insert the new sample into _samplesSorted
     int newSampleIndex;

--- a/libraries/shared/src/MovingPercentile.cpp
+++ b/libraries/shared/src/MovingPercentile.cpp
@@ -17,11 +17,11 @@ MovingPercentile::MovingPercentile(int numSamples, float percentile)
     _sampleIds(),
     _newSampleId(0),
     _indexOfPercentile(0),
-    _valueAtPercentile(0.0f)
+    _valueAtPercentile(0)
 {
 }
 
-void MovingPercentile::updatePercentile(float sample) {
+void MovingPercentile::updatePercentile(quint64 sample) {
 
     // insert the new sample into _samplesSorted
     int newSampleIndex;

--- a/libraries/shared/src/MovingPercentile.h
+++ b/libraries/shared/src/MovingPercentile.h
@@ -18,19 +18,21 @@ class MovingPercentile {
 public:
     MovingPercentile(int numSamples, float percentile = 0.5f);
 
-    void updatePercentile(float sample);
-    float getValueAtPercentile() const { return _valueAtPercentile; }
+    // FIXME - this class is only currently used in calculating the clockSkew, which is a signed 64bit int, not a double
+    // I am somewhat tempted to make this a type sensitive template and/or swith to using qint64's internally
+    void updatePercentile(quint64 sample);
+    quint64 getValueAtPercentile() const { return _valueAtPercentile; }
 
 private:
     const int _numSamples;
     const float _percentile;
 
-    QList<float> _samplesSorted;
+    QList<quint64> _samplesSorted;
     QList<int> _sampleIds;      // incrementally assigned, is cyclic
     int _newSampleId;
 
     int _indexOfPercentile;
-    float _valueAtPercentile;
+    quint64 _valueAtPercentile;
 };
 
 #endif

--- a/libraries/shared/src/MovingPercentile.h
+++ b/libraries/shared/src/MovingPercentile.h
@@ -18,21 +18,19 @@ class MovingPercentile {
 public:
     MovingPercentile(int numSamples, float percentile = 0.5f);
 
-    // FIXME - this class is only currently used in calculating the clockSkew, which is a signed 64bit int, not a double
-    // I am somewhat tempted to make this a type sensitive template and/or swith to using qint64's internally
-    void updatePercentile(quint64 sample);
-    quint64 getValueAtPercentile() const { return _valueAtPercentile; }
+    void updatePercentile(qint64 sample);
+    qint64 getValueAtPercentile() const { return _valueAtPercentile; }
 
 private:
     const int _numSamples;
     const float _percentile;
 
-    QList<quint64> _samplesSorted;
+    QList<qint64> _samplesSorted;
     QList<int> _sampleIds;      // incrementally assigned, is cyclic
     int _newSampleId;
 
     int _indexOfPercentile;
-    quint64 _valueAtPercentile;
+    qint64 _valueAtPercentile;
 };
 
 #endif

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -624,9 +624,10 @@ void debug::checkDeadBeef(void* memoryVoid, int size) {
 QString formatUsecTime(quint64 usecs, int prec) {
     static const quint64 USECS_PER_MINUTE = USECS_PER_SECOND * 60;
     static const quint64 USECS_PER_HOUR = USECS_PER_MINUTE * 60;
+    static const quint64 TWO_HOURS = USECS_PER_HOUR * 2;
 
     QString result;
-    if (usecs > USECS_PER_HOUR) {
+    if (usecs > TWO_HOURS) {
         result = QString::number(usecs / USECS_PER_HOUR) + "hrs";
     } else if (usecs > USECS_PER_MINUTE) {
         result = QString::number(usecs / USECS_PER_MINUTE) + "min";
@@ -645,8 +646,9 @@ QString formatUsecTime(qint64 usecs, int prec) {
     static const qint64 USECS_PER_SECOND = 1000 * USECS_PER_MSEC;
     static const qint64 USECS_PER_MINUTE = USECS_PER_SECOND * 60;
     static const qint64 USECS_PER_HOUR = USECS_PER_MINUTE * 60;
+    static const qint64 TWO_HOURS = USECS_PER_HOUR * 2;
     QString result;
-    if (usecs > USECS_PER_HOUR) {
+    if (usecs > TWO_HOURS || usecs < -TWO_HOURS) {
         result = QString::number(usecs / USECS_PER_HOUR) + "hrs";
     } else if (usecs > USECS_PER_MINUTE || usecs < -USECS_PER_MINUTE) {
         result = QString::number(usecs / USECS_PER_MINUTE) + "min";
@@ -669,8 +671,9 @@ QString formatUsecTime(double usecs, int prec) {
     static const double USECS_PER_SECOND = 1000.0 * USECS_PER_MSEC;
     static const double USECS_PER_MINUTE = USECS_PER_SECOND * 60.0;
     static const double USECS_PER_HOUR = USECS_PER_MINUTE * 60.0;
+    static const double TWO_HOURS = USECS_PER_HOUR * 2;
     QString result;
-    if (usecs > USECS_PER_HOUR || usecs < -USECS_PER_HOUR) {
+    if (usecs > TWO_HOURS || usecs < -TWO_HOURS) {
         result = QString::number(usecs / USECS_PER_HOUR, 'f', prec) + "hrs";
     } else if (usecs > USECS_PER_MINUTE || usecs < -USECS_PER_MINUTE) {
         result = QString::number(usecs / USECS_PER_MINUTE, 'f', prec) + "min";

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -43,8 +43,8 @@
 #include "OctalCode.h"
 #include "SharedLogging.h"
 
-static int usecTimestampNowAdjust = 0; // in usec
-void usecTimestampNowForceClockSkew(int clockSkew) {
+static qint64 usecTimestampNowAdjust = 0; // in usec
+void usecTimestampNowForceClockSkew(qint64 clockSkew) {
     ::usecTimestampNowAdjust = clockSkew;
 }
 

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -621,16 +621,62 @@ void debug::checkDeadBeef(void* memoryVoid, int size) {
     assert(memcmp((unsigned char*)memoryVoid, DEADBEEF, std::min(size, DEADBEEF_SIZE)) != 0);
 }
 
-QString formatUsecTime(float usecs, int prec) {
-    static const quint64 SECONDS_PER_MINUTE = 60;
-    static const quint64 USECS_PER_MINUTE = USECS_PER_SECOND * SECONDS_PER_MINUTE;
+QString formatUsecTime(quint64 usecs, int prec) {
+    static const quint64 USECS_PER_MINUTE = USECS_PER_SECOND * 60;
+    static const quint64 USECS_PER_HOUR = USECS_PER_MINUTE * 60;
 
     QString result;
-    if (usecs > USECS_PER_MINUTE) {
-        result = QString::number(usecs / USECS_PER_MINUTE, 'f', prec) + "min";
+    if (usecs > USECS_PER_HOUR) {
+        result = QString::number(usecs / USECS_PER_HOUR) + "hrs";
+    } else if (usecs > USECS_PER_MINUTE) {
+        result = QString::number(usecs / USECS_PER_MINUTE) + "min";
     } else if (usecs > USECS_PER_SECOND) {
-        result = QString::number(usecs / USECS_PER_SECOND, 'f', prec) + 's';
+        result = QString::number(usecs / USECS_PER_SECOND) + 's';
     } else if (usecs > USECS_PER_MSEC) {
+        result = QString::number(usecs / USECS_PER_MSEC) + "ms";
+    } else {
+        result = QString::number(usecs) + "us";
+    }
+    return result;
+}
+
+QString formatUsecTime(qint64 usecs, int prec) {
+    static const qint64 USECS_PER_MSEC = 1000;
+    static const qint64 USECS_PER_SECOND = 1000 * USECS_PER_MSEC;
+    static const qint64 USECS_PER_MINUTE = USECS_PER_SECOND * 60;
+    static const qint64 USECS_PER_HOUR = USECS_PER_MINUTE * 60;
+    QString result;
+    if (usecs > USECS_PER_HOUR) {
+        result = QString::number(usecs / USECS_PER_HOUR) + "hrs";
+    } else if (usecs > USECS_PER_MINUTE || usecs < -USECS_PER_MINUTE) {
+        result = QString::number(usecs / USECS_PER_MINUTE) + "min";
+    } else if (usecs > USECS_PER_SECOND || usecs < -USECS_PER_SECOND) {
+        result = QString::number(usecs / USECS_PER_SECOND) + 's';
+    } else if (usecs > USECS_PER_MSEC || usecs < -USECS_PER_MSEC) {
+        result = QString::number(usecs / USECS_PER_MSEC) + "ms";
+    } else {
+        result = QString::number(usecs) + "us";
+    }
+    return result;
+}
+
+QString formatUsecTime(float usecs, int prec) {
+    return formatUsecTime((double)usecs, prec);
+}
+
+QString formatUsecTime(double usecs, int prec) {
+    static const double USECS_PER_MSEC = 1000.0;
+    static const double USECS_PER_SECOND = 1000.0 * USECS_PER_MSEC;
+    static const double USECS_PER_MINUTE = USECS_PER_SECOND * 60.0;
+    static const double USECS_PER_HOUR = USECS_PER_MINUTE * 60.0;
+    QString result;
+    if (usecs > USECS_PER_HOUR || usecs < -USECS_PER_HOUR) {
+        result = QString::number(usecs / USECS_PER_HOUR, 'f', prec) + "hrs";
+    } else if (usecs > USECS_PER_MINUTE || usecs < -USECS_PER_MINUTE) {
+        result = QString::number(usecs / USECS_PER_MINUTE, 'f', prec) + "min";
+    } else if (usecs > USECS_PER_SECOND || usecs < -USECS_PER_SECOND) {
+        result = QString::number(usecs / USECS_PER_SECOND, 'f', prec) + 's';
+    } else if (usecs > USECS_PER_MSEC || usecs < -USECS_PER_MSEC) {
         result = QString::number(usecs / USECS_PER_MSEC, 'f', prec) + "ms";
     } else {
         result = QString::number(usecs, 'f', prec) + "us";

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -187,6 +187,10 @@ inline bool isBetween(int64_t value, int64_t max, int64_t min) { return ((value 
 inline bool isNaN(float value) { return value != value; }
 
 QString formatUsecTime(float usecs, int prec = 3);
+QString formatUsecTime(double usecs, int prec = 3);
+QString formatUsecTime(quint64 usecs, int prec = 3);
+QString formatUsecTime(qint64 usecs, int prec = 3);
+
 QString formatSecondsElapsed(float seconds);
 bool similarStrings(const QString& stringA, const QString& stringB);
 

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -121,7 +121,7 @@ const QByteArray HIGH_FIDELITY_USER_AGENT = "Mozilla/5.0 (HighFidelityInterface)
 
 // Equivalent to time_t but in usecs instead of secs
 quint64 usecTimestampNow(bool wantDebug = false);
-void usecTimestampNowForceClockSkew(int clockSkew);
+void usecTimestampNowForceClockSkew(qint64 clockSkew);
 
 // Number of seconds expressed since the first call to this function, expressed as a float
 // Maximum accuracy in msecs

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -186,10 +186,10 @@ inline bool isBetween(int64_t value, int64_t max, int64_t min) { return ((value 
 /// \return bool is the float NaN
 inline bool isNaN(float value) { return value != value; }
 
-QString formatUsecTime(float usecs, int prec = 3);
-QString formatUsecTime(double usecs, int prec = 3);
-QString formatUsecTime(quint64 usecs, int prec = 3);
-QString formatUsecTime(qint64 usecs, int prec = 3);
+QString formatUsecTime(float usecs);
+QString formatUsecTime(double usecs);
+QString formatUsecTime(quint64 usecs);
+QString formatUsecTime(qint64 usecs);
 
 QString formatSecondsElapsed(float seconds);
 bool similarStrings(const QString& stringA, const QString& stringB);


### PR DESCRIPTION
This fixes the various places in the code where we treat clock skew as a 32bit int. The problem with that is that 32bit ints only allow for +/-35 minutes of clock skew. Although it seems unlikely that a clock would be off by more than 35 minutes, it could be possible if someone has for example misconfigured their time zone.