### PR TITLE
move debug for resource retry to when retry occurs

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -519,10 +519,9 @@ const int MAX_ATTEMPTS = 8;
 void Resource::attemptRequest() {
     _startedLoading = true;
 
-    auto timer = qobject_cast<QTimer*>(sender());
-    if (timer) {
-        qCDebug(networking).nospace() << "Server unavailable for" << _url
-            << "- retrying asset load after" << timer->interval() << "ms - attempt" << _attempts << " of " << MAX_ATTEMPTS;
+    if (_attempts > 0) {
+        qCDebug(networking) << "Server unavailable for" << _url
+            << "- retrying asset load - attempt" << _attempts << " of " << MAX_ATTEMPTS;
     }
 
     ResourceCache::attemptRequest(_self);

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -520,7 +520,7 @@ void Resource::attemptRequest() {
     _startedLoading = true;
 
     if (_attempts > 0) {
-        qCDebug(networking) << "Server unavailable for" << _url
+        qCDebug(networking).noquote() << "Server unavailable for" << _url
             << "- retrying asset load - attempt" << _attempts << " of " << MAX_ATTEMPTS;
     }
 
@@ -614,7 +614,7 @@ void Resource::handleReplyFinished() {
                 if (_attempts++ < MAX_ATTEMPTS) {
                     auto waitTime = BASE_DELAY_MS * (int)pow(2.0, _attempts);
 
-                    qCDebug(networking) << "Server unavailable for" << _url << "- may retry in" << waitTime << "ms"
+                    qCDebug(networking).noquote() << "Server unavailable for" << _url << "- may retry in" << waitTime << "ms"
                         << "if resource is still needed";
 
                     QTimer::singleShot(waitTime, this, &Resource::attemptRequest);

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -615,6 +615,9 @@ void Resource::handleReplyFinished() {
                 if (_attempts++ < MAX_ATTEMPTS) {
                     auto waitTime = BASE_DELAY_MS * (int)pow(2.0, _attempts);
 
+                    qCDebug(networking) << "Server unavailable for" << _url << "- may retry in" << waitTime << "ms"
+                        << "if resource is still needed";
+
                     QTimer::singleShot(waitTime, this, &Resource::attemptRequest);
                     break;
                 }


### PR DESCRIPTION
- delay log for resource retry to show only during actual retry 