### PR TITLE
Don't display "Reveal Scripts Folder" control in HMD mode

### DIFF
--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -24,7 +24,8 @@ Window {
     resizable: true
     destroyOnInvisible: true
     x: 40; y: 40
-    implicitWidth: 400; implicitHeight: 728
+    implicitWidth: 400
+    implicitHeight: isHMD ? 695 : 728
     minSize: Qt.vector2d(200, 300)
 
     HifiConstants { id: hifi }
@@ -32,6 +33,7 @@ Window {
     property var scripts: ScriptDiscoveryService;
     property var scriptsModel: scripts.scriptsModelFilter
     property var runningScriptsModel: ListModel { }
+    property bool isHMD: false
 
     Settings {
         category: "Overlay.RunningScripts"
@@ -44,7 +46,10 @@ Window {
         onScriptCountChanged: updateRunningScripts();
     }
 
-    Component.onCompleted: updateRunningScripts()
+    Component.onCompleted: {
+        isHMD = HMD.active;
+        updateRunningScripts();
+    }
 
     function setDefaultFocus() {
         // Work around FocusScope of scrollable window.
@@ -237,7 +242,7 @@ Window {
             }
 
             HifiControls.VerticalSpacer {
-                height: hifi.dimensions.controlInterlineHeight - 3
+                height: hifi.dimensions.controlInterlineHeight - (!isHMD ? 3 : 0)
             }
 
             HifiControls.TextAction {
@@ -248,10 +253,12 @@ Window {
                 onClicked: fileDialogHelper.openScriptsDirectory()
                 colorScheme: hifi.colorSchemes.dark
                 anchors.left: parent.left
+                visible: !isHMD
             }
 
             HifiControls.VerticalSpacer {
                 height: hifi.dimensions.controlInterlineHeight - 3
+                visible: !isHMD
             }
         }
     }

--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -250,7 +250,7 @@ Window {
                 icon: hifi.glyphs.script
                 iconSize: 24
                 text: "Reveal Scripts Folder"
-                onClicked: fileDialogHelper.openScriptsDirectory()
+                onClicked: fileDialogHelper.openDirectory(scripts.defaultScriptsPath)
                 colorScheme: hifi.colorSchemes.dark
                 anchors.left: parent.left
                 visible: !isHMD

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -511,3 +511,7 @@ void ScriptEngines::onScriptEngineError(const QString& scriptFilename) {
     qCDebug(scriptengine) << "Application::loadScript(), script failed to load...";
     emit scriptLoadError(scriptFilename, "");
 }
+
+QString ScriptEngines::getDefaultScriptsLocation() const {
+    return defaultScriptsLocation().toString();
+}

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -50,6 +50,8 @@ public:
     ScriptsModel* scriptsModel() { return &_scriptsModel; };
     ScriptsModelFilter* scriptsModelFilter() { return &_scriptsModelFilter; };
 
+    QString getDefaultScriptsLocation() const;
+
     Q_INVOKABLE void loadOneScript(const QString& scriptFilename);
     Q_INVOKABLE ScriptEngine* loadScript(const QUrl& scriptFilename = QString(),
         bool isUserLoaded = true, bool loadScriptFromEditor = false, bool activateMainWindow = false, bool reload = false);
@@ -61,6 +63,8 @@ public:
     Q_INVOKABLE QVariantList getRunning();
     Q_INVOKABLE QVariantList getPublic();
     Q_INVOKABLE QVariantList getLocal();
+
+    Q_PROPERTY(QString defaultScriptsPath READ getDefaultScriptsLocation)
 
     // Called at shutdown time
     void shutdownScripting();

--- a/libraries/ui/src/FileDialogHelper.cpp
+++ b/libraries/ui/src/FileDialogHelper.cpp
@@ -16,8 +16,6 @@
 #include <QtCore/QRegularExpression>
 #include <QDesktopServices>
 
-#include "PathUtils.h"
-
 
 QUrl FileDialogHelper::home() {
     return pathToUrl(QStandardPaths::standardLocations(QStandardPaths::HomeLocation)[0]);
@@ -107,6 +105,6 @@ QStringList FileDialogHelper::drives() {
     return result;
 }
 
-void FileDialogHelper::openScriptsDirectory() {
-    QDesktopServices::openUrl(defaultScriptsLocation());
+void FileDialogHelper::openDirectory(const QString& path) {
+    QDesktopServices::openUrl(path);
 }

--- a/libraries/ui/src/FileDialogHelper.h
+++ b/libraries/ui/src/FileDialogHelper.h
@@ -59,7 +59,7 @@ public:
     Q_INVOKABLE QUrl pathToUrl(const QString& path);
     Q_INVOKABLE QUrl saveHelper(const QString& saveText, const QUrl& currentFolder, const QStringList& selectionFilters);
 
-    Q_INVOKABLE void openScriptsDirectory();
+    Q_INVOKABLE void openDirectory(const QString& path);
 };
 
 

--- a/tests/ui/qml/Stubs.qml
+++ b/tests/ui/qml/Stubs.qml
@@ -51,7 +51,11 @@ Item {
         function getRunning() {
             return _runningScripts;
         }
+    }
 
+    Item {
+        objectName: "HMD"
+        property bool active: false
     }
 
     Item {

--- a/tests/ui/src/main.cpp
+++ b/tests/ui/src/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char *argv[]) {
     setChild(engine, "ApplicationCompositor");
     setChild(engine, "Desktop");
     setChild(engine, "ScriptDiscoveryService");
+    setChild(engine, "HMD");
     setChild(engine, "MenuHelper");
     setChild(engine, "Preferences");
     setChild(engine, "urlHandler");


### PR DESCRIPTION
And decouple UI and shared libraries.