### PR TITLE
Fixing texture storage allocation on OSX/GL 4.1

### DIFF
--- a/libraries/gpu/src/gpu/GLBackendTexture.cpp
+++ b/libraries/gpu/src/gpu/GLBackendTexture.cpp
@@ -243,7 +243,7 @@ void GLBackend::GLTexture::allocateStorage() {
         glTexStorage2D(_target, usedMipLevels(), texelFormat.internalFormat, dimensions.x, dimensions.y);
         (void)CHECK_GL_ERROR();
     } else {
-        for (uint16_t l = _minMip; l < _maxMip; l++) {
+        for (uint16_t l = _minMip; l <= _maxMip; l++) {
             // Get the mip level dimensions, accounting for the downgrade level
             Vec3u dimensions = _gpuTexture.evalMipDimensions(l);
             for (GLenum target : getFaceTargets()) {

--- a/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
+++ b/libraries/gpu/src/gpu/GLBackendTextureTransfer.h
@@ -6,11 +6,14 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QtGlobal>
 #include <QSharedPointer>
 #include <GenericQueueThread.h>
 #include "GLBackendShared.h"
 
+#ifdef Q_OS_WIN
 #define THREADED_TEXTURE_TRANSFER
+#endif
 
 class OffscreenGLCanvas;
 

--- a/libraries/shared/src/GPUIdent.cpp
+++ b/libraries/shared/src/GPUIdent.cpp
@@ -45,6 +45,7 @@ GPUIdent* GPUIdent::ensureQuery(const QString& vendor, const QString& renderer) 
             CGLDescribeRenderer(rendererInfo, j, kCGLRPVideoMemoryMegabytes, &deviceVRAM);
             if (deviceVRAM > bestVRAM) {
                 bestVRAM = deviceVRAM;
+                _isValid = true;
             }
         }
     }


### PR DESCRIPTION
This fixes the black screen on macs in caused by the recent changes to GLBackendTexture.cpp
