### PR TITLE
Fixes for avatar eye tracking.

### DIFF
--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -230,7 +230,7 @@ void Head::simulate(float deltaTime, bool isMine, bool billboard) {
     }
     
     _leftEyePosition = _rightEyePosition = getPosition();
-    _eyePosition = calculateAverageEyePosition();
+    _eyePosition = getPosition();
 
     if (!billboard && _owningAvatar) {
         auto skeletonModel = static_cast<Avatar*>(_owningAvatar)->getSkeletonModel();
@@ -238,6 +238,8 @@ void Head::simulate(float deltaTime, bool isMine, bool billboard) {
             skeletonModel->getEyePositions(_leftEyePosition, _rightEyePosition);
         }
     }
+
+    _eyePosition = calculateAverageEyePosition();
 }
 
 void Head::calculateMouthShapes() {


### PR DESCRIPTION
An incorrect Head::_eyePosition was causing all sorts for problems for eye tracking.  

  * The mouth position was an offset much higher vertically than normal, which caused the eye "saccades" to be incorrect.
  * All of the eye look at fix up code was not being activated, which caused the eyes to not properly look at the camera in desktop mode.
  * The eye lid offset was computed from the top of the head rather than the center of the eyes which caused the eyes to droop more than they should on all our avatars.