### PR TITLE
Avatar eye gaze fix for HMDs

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3104,10 +3104,8 @@ void Application::updateMyAvatarLookAtPosition() {
         } else {
             //  I am not looking at anyone else, so just look forward
             if (isHMD) {
-                glm::mat4 headPose = myAvatar->getHMDSensorMatrix();
-                glm::quat headRotation = glm::quat_cast(headPose);
-                lookAtSpot = myAvatar->getPosition() +
-                    myAvatar->getOrientation() * (headRotation * glm::vec3(0.0f, 0.0f, -TREE_SCALE));
+                glm::mat4 worldHMDMat = myAvatar->getSensorToWorldMatrix() * myAvatar->getHMDSensorMatrix();
+                lookAtSpot = transformPoint(worldHMDMat, glm::vec3(0.0f, 0.0f, -TREE_SCALE));
             } else {
                 lookAtSpot = myAvatar->getHead()->getEyePosition() +
                     (myAvatar->getHead()->getFinalOrientationInWorldFrame() * glm::vec3(0.0f, 0.0f, -TREE_SCALE));


### PR DESCRIPTION
When no avatars are chosen for more detailed eye gaze tracking the eyes should look straight ahead.
Before this fix, if you were in room scale or not aligned with the camera sensor your gaze could drift to the left or to the right of your head's forward direction.
Now it should follow your head more closely.