### PR TITLE
Fix for Planky Settings window

### DIFF
--- a/examples/html/plankySettings.html
+++ b/examples/html/plankySettings.html
@@ -3,11 +3,15 @@
 <head>
 <link rel="stylesheet" type="text/css" href="style.css">
 <script type="text/javascript" src="jquery-2.1.4.min.js"></script>
+<script type="text/javascript" src="qrc:///qtwebchannel/qwebchannel.js"></script>
+<script type="text/javascript" src="eventBridgeLoader.js"></script>
 <script type="text/javascript">
 var properties = [];
-function sendWebEvent(data) {
-    EventBridge.emitWebEvent(JSON.stringify(data));
+
+var sendWebEvent = function(data) {
+    console.log('sendWebEvent not initialized.');
 }
+
 PropertyInput = function(key, label, value, attributes) {
     this.key = key;
     this.label = label;
@@ -93,7 +97,7 @@ function addHeader(label) {
     $('#properties-list').append($('<div>').addClass('section-header').append($('<label>').text(label)));
 }
 
-$(function() {  
+$(function() {
     addHeader('Stack Settings');
     properties['numLayers'] = new NumberInput('numLayers', 'Layers', 17, {'min': 0, 'max': 300, 'step': 1});
     properties['blocksPerLayer'] = new NumberInput('blocksPerLayer', 'Blocks per layer', 4, {'min': 1, 'max': 100, 'step': 1});
@@ -120,7 +124,8 @@ $(function() {
         .append($('<input>').val('factory reset').attr('type', 'button').on('click', function() { sendWebEvent({action: 'factory-reset'}); }))
         .append($('<input>').val('save as default').attr('type', 'button').on('click', function() { sendWebEvent({action: 'save-default'}); }))
         .append($('<input>').val('cleanup planky').attr('type', 'button').on('click', function() { sendWebEvent({action: 'cleanup'}); }));
-    if (window.EventBridge !== undefined) {
+
+    openEventBridge(function() {
         EventBridge.scriptEventReceived.connect(function(data) {
             data = JSON.parse(data);
             if (data.action == 'load') {
@@ -129,8 +134,11 @@ $(function() {
                 });
             }
         });
-    }
-    sendWebEvent({action: 'loaded'});
+        sendWebEvent = function(data) {
+            EventBridge.emitWebEvent(JSON.stringify(data));
+        };
+        sendWebEvent({action: 'loaded'});
+    });
 });
 </script>
 </head>


### PR DESCRIPTION
- fixes the settings window of Planky
- sets lifetime of Planky blocks 60 minutes (per request of Ryan)

## Test notes
1. You do not have to install the client that comes with this build, use the latest release or dev build.
2. Run the planky.js script : `Edit -> Run script form URL` -> http://rawgit.com/thoys/hifi/1066efc73754e074b7e850fb6cfbe272cc2d0d2d/examples/example/games/planky.js

3. Click the Planky button &nbsp;&nbsp;&nbsp; <img src="http://s3.amazonaws.com/hifi-public/marketplace/hificontent/Games/blocks/planky_button.svg" width="50px" alt="Planky Button"/>

4. Planky should be created in front of you now.

5. Click the Cog button &nbsp;&nbsp;&nbsp; <img src="http://s3.amazonaws.com/hifi-public/marketplace/hificontent/Games/blocks/cog.svg" width="50px" alt="Planky Button"/>

6. A settings window should appear. Try changing properties such as the stack height. The planky stack should not be physical during the period that the Cog button is enabled.

7. Click the Cog again, and try moving the planky blocks arround using either the regular `grab.js` script or the `handcontrollerGrab.js` script.

8. Have fun with it in case it all works out. :+1: 
