### PR TITLE
Reset avatar on exit of away-mode.

### DIFF
--- a/examples/away.js
+++ b/examples/away.js
@@ -196,6 +196,7 @@ function goActive() {
     }
     MyAvatar.setEnableMeshVisible(true); // IWBNI we respected Developer->Avatar->Draw Mesh setting.
     stopAwayAnimation();
+    MyAvatar.reset(true);
     hideOverlay();
 
     // restore overlays state to what it was when we went "away"

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -235,7 +235,12 @@ QByteArray MyAvatar::toByteArray(bool cullSmallChanges, bool sendAll) {
     return AvatarData::toByteArray(cullSmallChanges, sendAll);
 }
 
-void MyAvatar::reset(bool andReload) {
+void MyAvatar::reset(bool andRecenter) {
+
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "reset", Q_ARG(bool, andRecenter));
+        return;
+    }
 
     // Reset dynamic state.
     _wasPushing = _isPushing = _isBraking = false;
@@ -245,7 +250,7 @@ void MyAvatar::reset(bool andReload) {
     _targetVelocity = glm::vec3(0.0f);
     setThrust(glm::vec3(0.0f));
 
-    if (andReload) {
+    if (andRecenter) {
         // derive the desired body orientation from the *old* hmd orientation, before the sensor reset.
         auto newBodySensorMatrix = deriveBodyFromHMDSensor(); // Based on current cached HMD position/rotation..
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -93,7 +93,7 @@ public:
     AudioListenerMode getAudioListenerModeCamera() const { return FROM_CAMERA; }
     AudioListenerMode getAudioListenerModeCustom() const { return CUSTOM; }
 
-    void reset(bool andReload = false);
+    Q_INVOKABLE void reset(bool andRecenter = false);
     void update(float deltaTime);
     void preRender(RenderArgs* renderArgs);
 


### PR DESCRIPTION
Exposed MyAvatar.reset(bool) to script.
away.js now calls this on exit of away-mode.

This should help demo situations where the HMD is swapped between individuals with different heights.