### PR TITLE
Fix assert crash in GPUIdent

### DIFF
--- a/libraries/shared/src/GPUIdent.cpp
+++ b/libraries/shared/src/GPUIdent.cpp
@@ -147,7 +147,7 @@ GPUIdent* GPUIdent::ensureQuery(const QString& vendor, const QString& renderer) 
 
             _isValid = true;
         }
-        hr = spEnumInst->Next(WBEM_INFINITE, 1, &spInstance, &uNumOfInstances);
+        hr = spEnumInst->Next(WBEM_INFINITE, 1, &spInstance.p, &uNumOfInstances);
     }
 #endif
     return this;


### PR DESCRIPTION
In CComPtrBase (atlcomcli.h):

```c++
    //The assert on operator& usually indicates a bug.  If this is really
    //what is needed, however, take the address of the p member explicitly.
    T** operator&() throw()
    {
        ATLASSERT(p==NULL);
        return &p;
    }
```

I replaced our use to get the address directly. @howard-stearns, any issue with this?