### PR TITLE
fix auto resize of models on import

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -518,6 +518,7 @@ void RenderableModelEntityItem::update(const quint64& now) {
     if (!_dimensionsInitialized && _model && _model->isActive()) {
         if (_model->isLoaded()) {
             EntityItemProperties properties;
+            properties.setLastEdited(usecTimestampNow()); // we must set the edit time since we're editing it
             auto extents = _model->getMeshExtents();
             properties.setDimensions(extents.maximum - extents.minimum);
             qCDebug(entitiesrenderer) << "Autoresizing:" << (!getName().isEmpty() ? getName() : getModelURL());


### PR DESCRIPTION
The auto resize code wasn't properly setting the lastEdit time of the EntityItemProperties it was using to auto-resize the model. This would cause a race condition where the edit would be rejected if the servers scene data arrived before the resize was processed.