### PR TITLE
Fix address bar becoming unusable after going backwards or forwards

### DIFF
--- a/interface/src/ui/AddressBarDialog.cpp
+++ b/interface/src/ui/AddressBarDialog.cpp
@@ -23,7 +23,6 @@ AddressBarDialog::AddressBarDialog(QQuickItem* parent) : OffscreenQmlDialog(pare
     auto addressManager = DependencyManager::get<AddressManager>();
     connect(addressManager.data(), &AddressManager::lookupResultIsOffline, this, &AddressBarDialog::displayAddressOfflineMessage);
     connect(addressManager.data(), &AddressManager::lookupResultIsNotFound, this, &AddressBarDialog::displayAddressNotFoundMessage);
-    connect(addressManager.data(), &AddressManager::lookupResultsFinished, this, &AddressBarDialog::hide);
     connect(addressManager.data(), &AddressManager::goBackPossible, this, [this] (bool isPossible) {
         if (isPossible != _backEnabled) {
             _backEnabled = isPossible;
@@ -38,10 +37,6 @@ AddressBarDialog::AddressBarDialog(QQuickItem* parent) : OffscreenQmlDialog(pare
     });
     _backEnabled = !(DependencyManager::get<AddressManager>()->getBackStack().isEmpty());
     _forwardEnabled = !(DependencyManager::get<AddressManager>()->getForwardStack().isEmpty());
-}
-
-void AddressBarDialog::hide() {
-    ((QQuickItem*)parent())->setEnabled(false);
 }
 
 void AddressBarDialog::loadAddress(const QString& address) {

--- a/interface/src/ui/AddressBarDialog.h
+++ b/interface/src/ui/AddressBarDialog.h
@@ -33,7 +33,6 @@ signals:
 protected:
     void displayAddressOfflineMessage();
     void displayAddressNotFoundMessage();
-    void hide();
 
     Q_INVOKABLE void loadAddress(const QString& address);
     Q_INVOKABLE void loadHome();

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -501,6 +501,8 @@ bool AddressManager::handleViewpoint(const QString& viewpointString, bool should
 
             QRegExp orientationRegex(QUAT_REGEX_STRING);
 
+            bool orientationChanged = false;
+
             // we may also have an orientation
             if (viewpointString[positionRegex.matchedLength() - 1] == QChar('/')
                 && orientationRegex.indexIn(viewpointString, positionRegex.matchedLength() - 1) != -1) {
@@ -512,14 +514,13 @@ bool AddressManager::handleViewpoint(const QString& viewpointString, bool should
 
                 if (!isNaN(newOrientation.x) && !isNaN(newOrientation.y) && !isNaN(newOrientation.z)
                     && !isNaN(newOrientation.w)) {
-                    emit locationChangeRequired(newPosition, true, newOrientation, shouldFace);
-                    return true;
+                    orientationChanged = true;
                 } else {
                     qCDebug(networking) << "Orientation parsed from lookup string is invalid. Will not use for location change.";
                 }
             }
 
-            emit locationChangeRequired(newPosition, false, newOrientation, shouldFace);
+            emit locationChangeRequired(newPosition, orientationChanged, newOrientation, shouldFace);
 
         } else {
             qCDebug(networking) << "Could not jump to position from lookup string because it has an invalid value.";

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -292,8 +292,6 @@ void AddressManager::goToAddressFromObject(const QVariantMap& dataObject, const 
                 const QString PLACE_ID_KEY = "id";
                 _rootPlaceID = rootMap[PLACE_ID_KEY].toUuid();
 
-                bool addressChanged = false;
-
                 // set our current root place name to the name that came back
                 const QString PLACE_NAME_KEY = "name";
                 QString placeName = rootMap[PLACE_NAME_KEY].toString();

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -600,13 +600,6 @@ void AddressManager::addCurrentAddressToHistory(LookupTrigger trigger) {
 
     // if we're cold starting and this is called for the first address (from settings) we don't do anything
     if (trigger != LookupTrigger::StartupFromSettings) {
-        if (trigger == LookupTrigger::UserInput) {
-            // anyime the user has manually looked up an address we know we should clear the forward stack
-            _forwardStack.clear();
-
-            emit goForwardPossible(false);
-        }
-
         if (trigger == LookupTrigger::Back) {
             // we're about to push to the forward stack
             // if it's currently empty emit our signal to say that going forward is now possible
@@ -618,9 +611,16 @@ void AddressManager::addCurrentAddressToHistory(LookupTrigger trigger) {
             // and do not but it into the back stack
             _forwardStack.push(currentAddress());
         } else {
+            if (trigger == LookupTrigger::UserInput) {
+                // anyime the user has manually looked up an address we know we should clear the forward stack
+                _forwardStack.clear();
+
+                emit goForwardPossible(false);
+            }
+
             // we're about to push to the back stack
-            // if it's currently empty emit our signal to say that going forward is now possible
-            if (_forwardStack.size() == 0) {
+            // if it's currently empty emit our signal to say that going backward is now possible
+            if (_backStack.size() == 0) {
                 emit goBackPossible(true);
             }
 

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -47,7 +47,8 @@ public:
         Back,
         Forward,
         StartupFromSettings,
-        DomainPathResponse
+        DomainPathResponse,
+        Internal
     };
 
     bool isConnected();
@@ -118,14 +119,15 @@ private slots:
 private:
     void goToAddressFromObject(const QVariantMap& addressMap, const QNetworkReply& reply);
 
-    void setHost(const QString& host, LookupTrigger trigger, quint16 port = 0);
-    void setDomainInfo(const QString& hostname, quint16 port, LookupTrigger trigger);
+    // Set host and port, and return `true` if it was changed.
+    bool setHost(const QString& host, LookupTrigger trigger, quint16 port = 0);
+    bool setDomainInfo(const QString& hostname, quint16 port, LookupTrigger trigger);
 
     const JSONCallbackParameters& apiCallbackParameters();
 
     bool handleUrl(const QUrl& lookupUrl, LookupTrigger trigger = UserInput);
 
-    bool handleNetworkAddress(const QString& lookupString, LookupTrigger trigger);
+    bool handleNetworkAddress(const QString& lookupString, LookupTrigger trigger, bool& hostChanged);
     void handlePath(const QString& path, LookupTrigger trigger, bool wasPathOnly = false);
     bool handleViewpoint(const QString& viewpointString, bool shouldFace, LookupTrigger trigger,
                          bool definitelyPathOnly = false, const QString& pathString = QString());

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -46,7 +46,8 @@ public:
         UserInput,
         Back,
         Forward,
-        StartupFromSettings
+        StartupFromSettings,
+        DomainPathResponse
     };
 
     bool isConnected();
@@ -77,7 +78,7 @@ public slots:
 
     // we currently expect this to be called from NodeList once handleLookupString has been called with a path
     bool goToViewpointForPath(const QString& viewpointString, const QString& pathString)
-        { return handleViewpoint(viewpointString, false, false, pathString); }
+        { return handleViewpoint(viewpointString, false, DomainPathResponse, false, pathString); }
 
     void goBack();
     void goForward();
@@ -125,7 +126,7 @@ private:
 
     bool handleNetworkAddress(const QString& lookupString, LookupTrigger trigger);
     void handlePath(const QString& path, LookupTrigger trigger, bool wasPathOnly = false);
-    bool handleViewpoint(const QString& viewpointString, bool shouldFace = false,
+    bool handleViewpoint(const QString& viewpointString, bool shouldFace, LookupTrigger trigger,
                          bool definitelyPathOnly = false, const QString& pathString = QString());
     bool handleUsername(const QString& lookupString);
     bool handleDomainID(const QString& host);

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -115,8 +115,9 @@ private slots:
     void handleAPIResponse(QNetworkReply& requestReply);
     void handleAPIError(QNetworkReply& errorReply);
 
-    void goToAddressFromObject(const QVariantMap& addressMap, const QNetworkReply& reply);
 private:
+    void goToAddressFromObject(const QVariantMap& addressMap, const QNetworkReply& reply);
+
     void setHost(const QString& host, LookupTrigger trigger, quint16 port = 0);
     void setDomainInfo(const QString& hostname, quint16 port, LookupTrigger trigger);
 


### PR DESCRIPTION
Problems:

 * Address bar was disabled but not hidden after receiving a requestFinished signal from the AddressManager
 * Hiding on requestFinished is probably not desired behavior because it means pressing back will cause the window to be closed when the request finishes.

With those problems in mind, I disabled the hide-on-requestFinished behavior altogether. When navigating by entering an address, the address bar is already hidden after pressing enter.