### PR TITLE
add support to abort evaluation of long running scripts on shutdown

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -222,14 +222,14 @@ void ScriptEngine::waitTillDoneRunning() {
             
             // if we've been waiting a second or more, then tell the script engine to stop evaluating
             if (elapsed > USECS_PER_SECOND) {
-                qDebug() << "giving up on evaluation elapsed:" << elapsed << "calling abortEvaluation() script:" << scriptName;
+                qCDebug(scriptengine) << "Script " << scriptName << " has been running too long [" << elapsed << "] aborting evaluation.";
                 threadSafeAbortEvaluation();
             }
 
             // if we've been waiting for more than 5 seconds then we should be more aggessive about stopping
             static const auto WAITING_TOO_LONG = USECS_PER_SECOND * 5;
             if (elapsed > WAITING_TOO_LONG) {
-                qDebug() << "giving up on thread elapsed:" << elapsed << "calling thread->quit() script:" << scriptName;
+                qCDebug(scriptengine) << "Script " << scriptName << " has been running too long [" << elapsed << "] quitting.";
                 thread()->quit();
                 break;
             }
@@ -396,7 +396,6 @@ void ScriptEngine::registerValue(const QString& valueName, QScriptValue value) {
             if (partsToGo > 0) {
                 //QObject *object = new QObject;
                 QScriptValue partValue = newArray(); //newQObject(object, QScriptEngine::ScriptOwnership);
-                qDebug() << "partValue[" << pathPart<<"].isArray() :" << partValue.isArray();
                 partObject.setProperty(pathPart, partValue);
             } else {
                 partObject.setProperty(pathPart, value);
@@ -1089,11 +1088,6 @@ void ScriptEngine::loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const 
                 << QThread::currentThread() << "] expected thread [" << strongEngine->thread() << "]";
 #endif
             strongEngine->entityScriptContentAvailable(entityID, scriptOrURL, contents, isURL, success);
-        } else {
-            // FIXME - I'm leaving this in for testing, so that QA can confirm that sometimes the script contents
-            //         returns after the ScriptEngine has been deleted, we can remove this after QA verifies the
-            //         repro case.
-            qDebug() << "ScriptCache::getScriptContents() returned after our ScriptEngine was deleted... script:" << scriptOrURL;
         }
     }, forceRedownload);
 }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -201,6 +201,8 @@ void ScriptEngine::waitTillDoneRunning() {
         // we want the application thread to continue to process events, because the scripts will likely need to
         // marshall messages across to the main thread. For example if they access Settings or Menu in any of their
         // shutdown code.
+        QString scriptName = getFilename();
+
         auto startedWaiting = usecTimestampNow();
         while (thread()->isRunning()) {
             // process events for the main application thread, allowing invokeMethod calls to pass between threads
@@ -210,14 +212,14 @@ void ScriptEngine::waitTillDoneRunning() {
             
             // if we've been waiting a second or more, then tell the script engine to stop evaluating
             if (elapsed > USECS_PER_SECOND) {
-                qDebug() << __FUNCTION__ << "...giving up on evaluation elapsed:" << elapsed << "calling abortEvaluation()";
+                qDebug() << "giving up on evaluation elapsed:" << elapsed << "calling abortEvaluation() script:" << scriptName;
                 abortEvaluation();
             }
 
             // if we've been waiting for more than 5 seconds then we should be more aggessive about stopping
             static const auto WAITING_TOO_LONG = USECS_PER_SECOND * 5;
             if (elapsed > WAITING_TOO_LONG) {
-                qDebug() << __FUNCTION__ << "...giving up on thread elapsed:" << elapsed << "calling thread->quit()";
+                qDebug() << "giving up on thread elapsed:" << elapsed << "calling thread->quit() script:" << scriptName;
                 thread()->quit();
                 break;
             }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -221,7 +221,8 @@ void ScriptEngine::waitTillDoneRunning() {
             auto elapsed = stillWaiting - startedWaiting;
             
             // if we've been waiting a second or more, then tell the script engine to stop evaluating
-            if (elapsed > USECS_PER_SECOND) {
+            static const auto MAX_SCRIPT_EVALUATION_TIME =  USECS_PER_SECOND;
+            if (elapsed > MAX_SCRIPT_EVALUATION_TIME) {
                 qCDebug(scriptengine) << "Script " << scriptName << " has been running too long [" << elapsed << "] aborting evaluation.";
                 threadSafeAbortEvaluation();
             }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -218,11 +218,11 @@ void ScriptEngine::waitTillDoneRunning() {
 
             // if we've been waiting for more than 5 seconds then we should be more aggessive about stopping
             if (elapsedUsecs > WAITING_TOO_LONG) {
-                qCDebug(scriptengine) << "Script " << scriptName << " has been running too long [" << elapsedUsecs << "] quitting.";
+                qCDebug(scriptengine) << "Script " << scriptName << " has been running too long [" << elapsedUsecs << " usecs] quitting.";
                 thread()->quit();
                 break;
             } else if (elapsedUsecs > MAX_SCRIPT_EVALUATION_TIME) {
-                qCDebug(scriptengine) << "Script " << scriptName << " has been running too long [" << elapsedUsecs << "] aborting evaluation.";
+                qCDebug(scriptengine) << "Script " << scriptName << " has been running too long [" << elapsedUsecs << " usecs] aborting evaluation.";
                 QMetaObject::invokeMethod(this, "abortEvaluation");
             }
         }

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -134,6 +134,7 @@ public:
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // NOTE - this is intended to be a public interface for Agent scripts, and local scripts, but not for EntityScripts
     Q_INVOKABLE void stop();
+    Q_INVOKABLE void threadSafeAbortEvaluation();
 
     bool isFinished() const { return _isFinished; } // used by Application and ScriptWidget
     bool isRunning() const { return _isRunning; } // used by ScriptWidget

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -134,7 +134,6 @@ public:
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // NOTE - this is intended to be a public interface for Agent scripts, and local scripts, but not for EntityScripts
     Q_INVOKABLE void stop();
-    Q_INVOKABLE void threadSafeAbortEvaluation();
 
     bool isFinished() const { return _isFinished; } // used by Application and ScriptWidget
     bool isRunning() const { return _isRunning; } // used by ScriptWidget


### PR DESCRIPTION
This fixes problems on shutdown with scripts that might have infinite loops and/or are running extra slow for some unknown reason... and/or that might possibly be deadlocked on a script call