### PR TITLE
don't cross the eyes

### DIFF
--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -85,11 +85,22 @@ Rig::CharacterControllerState convertCharacterControllerState(CharacterControlle
     };
 }
 
+
 // Called within Model::simulate call, below.
 void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     const FBXGeometry& geometry = getFBXGeometry();
 
     Head* head = _owningAvatar->getHead();
+
+
+    // make sure lookAt is not too close to face (avoid crosseyes)
+    glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
+    glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
+    float focusDistance = glm::length(focusOffset);
+    const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;
+    if (focusDistance < MIN_LOOK_AT_FOCUS_DISTANCE && focusDistance > EPSILON) {
+        lookAt = _owningAvatar->getHead()->getEyePosition() + (MIN_LOOK_AT_FOCUS_DISTANCE / focusDistance) * focusOffset;
+    }
 
     if (_owningAvatar->isMyAvatar()) {
         MyAvatar* myAvatar = static_cast<MyAvatar*>(_owningAvatar);
@@ -164,7 +175,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         Rig::EyeParameters eyeParams;
         eyeParams.worldHeadOrientation = headParams.worldHeadOrientation;
-        eyeParams.eyeLookAt = head->getLookAtPosition();
+        eyeParams.eyeLookAt = lookAt;
         eyeParams.eyeSaccade = head->getSaccade();
         eyeParams.modelRotation = getRotation();
         eyeParams.modelTranslation = getTranslation();
@@ -196,8 +207,8 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         Rig::EyeParameters eyeParams;
         eyeParams.worldHeadOrientation = head->getFinalOrientationInWorldFrame();
-        eyeParams.eyeLookAt = head->getCorrectedLookAtPosition();
-        eyeParams.eyeSaccade = glm::vec3();
+        eyeParams.eyeLookAt = lookAt;
+        eyeParams.eyeSaccade = glm::vec3(0.0f);
         eyeParams.modelRotation = getRotation();
         eyeParams.modelTranslation = getTranslation();
         eyeParams.leftEyeJointIndex = geometry.leftEyeJointIndex;

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -203,8 +203,6 @@ public:
     // rig space
     bool getModelRegistrationPoint(glm::vec3& modelRegistrationPointOut) const;
 
-    const glm::vec3& getEyesInRootFrame() const { return _eyesInRootFrame; }
-
     // rig space
     AnimPose getAbsoluteDefaultPose(int index) const;
 
@@ -275,7 +273,6 @@ protected:
     glm::vec3 _lastFront;
     glm::vec3 _lastPosition;
     glm::vec3 _lastVelocity;
-    glm::vec3 _eyesInRootFrame { Vectors::ZERO };
 
     QUrl _animGraphURL;
     std::shared_ptr<AnimNode> _animNode;


### PR DESCRIPTION
* clamp the minimum distance for "look at" target for eyes to prevent avatars from going cross-eyed