### PR TITLE
change path for defaultscripts.js in scriptengine

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -253,7 +253,7 @@ static const QString SETTINGS_KEY = "Settings";
 
 void ScriptEngines::loadDefaultScripts() {
     QUrl defaultScriptsLoc = defaultScriptsLocation();
-    defaultScriptsLoc.setPath(defaultScriptsLoc.path() + "/system/defaultScripts.js");
+    defaultScriptsLoc.setPath(defaultScriptsLoc.path() + "/defaultScripts.js");
     loadScript(defaultScriptsLoc.toString());
 }
 


### PR DESCRIPTION
We moved defaultScripts.js up a level last night to avoid an error when upgrading due to the previous defaultScripts.js being in a specific location.  That error would prevent defaultScripts from loading.  When I made that change I forgot to revert the change to the scriptengine path.  This PR points interface at /scripts/defaultScripts.js