### PR TITLE
Move directory, examples, and edit toolbar buttons down a bit

### DIFF
--- a/scripts/system/directory.js
+++ b/scripts/system/directory.js
@@ -26,7 +26,7 @@ var directoryWindow = new OverlayWebWindow({
 
 var toolHeight = 50;
 var toolWidth = 50;
-var TOOLBAR_MARGIN_Y = 25;
+var TOOLBAR_MARGIN_Y = 0;
 
 
 function showDirectory() {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -53,7 +53,7 @@ selectionManager.addEventListener(function() {
 var toolIconUrl = Script.resolvePath("assets/images/tools/");
 var toolHeight = 50;
 var toolWidth = 50;
-var TOOLBAR_MARGIN_Y = 25;
+var TOOLBAR_MARGIN_Y = 0;
 
 var DEGREES_TO_RADIANS = Math.PI / 180.0;
 var RADIANS_TO_DEGREES = 180.0 / Math.PI;

--- a/scripts/system/examples.js
+++ b/scripts/system/examples.js
@@ -58,7 +58,7 @@ var toolBar = (function() {
         browseExamplesButton;
 
     function initialize() {
-        toolBar = new ToolBar(0, 0, ToolBar.HORIXONTAL, "highfidelity.examples.toolbar", function(windowDimensions, toolbar) {
+        toolBar = new ToolBar(0, 0, ToolBar.HORIZONTAL, "highfidelity.examples.toolbar", function(windowDimensions, toolbar) {
             return {
                 x: windowDimensions.x / 2,
                 y: windowDimensions.y

--- a/scripts/system/examples.js
+++ b/scripts/system/examples.js
@@ -26,7 +26,7 @@ var examplesWindow = new OverlayWebWindow({
 
 var toolHeight = 50;
 var toolWidth = 50;
-var TOOLBAR_MARGIN_Y = 25;
+var TOOLBAR_MARGIN_Y = 0;
 
 
 function showExamples(marketplaceID) {


### PR DESCRIPTION
They are now lower again, with a 50px margin to the bottom of the screen instead of 75px. Previously they had a 25px to the bottom of the screen, but the recommended overlay rectangle now says to have a 50px margin.