### PR TITLE
Remove directory.js from default scripts

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -17,7 +17,5 @@ Script.load("system/notifications.js");
 Script.load("system/controllers/handControllerGrab.js");
 Script.load("system/controllers/squeezeHands.js");
 Script.load("system/controllers/grab.js");
-Script.load("system/directory.js");
 Script.load("system/dialTone.js");
-// Script.load("attachedEntitiesManager.js");
 Script.load("system/depthReticle.js");


### PR DESCRIPTION
This PR removes the directory for now (and also a commented out attachments manager).  