### PR TITLE
don't require authentication to send usage data

### DIFF
--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -63,7 +63,7 @@ void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCall
     }
     
     accountManager.sendRequest(USER_ACTIVITY_URL,
-                               AccountManagerAuth::Required,
+                               AccountManagerAuth::Optional,
                                QNetworkAccessManager::PostOperation,
                                params, NULL, multipart);
 }


### PR DESCRIPTION
- enables usage data collection for anonymous users if they are not opted out (Settings -> General -> Privacy)