### PR TITLE
use a setting handle for UAL disabled to fix startup race

### DIFF
--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -25,15 +25,12 @@ UserActivityLogger& UserActivityLogger::getInstance() {
     return sharedInstance;
 }
 
-UserActivityLogger::UserActivityLogger() : _disabled(false) {
-}
-
 void UserActivityLogger::disable(bool disable) {
-    _disabled = disable;
+    _disabled.set(disable);
 }
 
 void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCallbackParameters params) {
-    if (_disabled) {
+    if (_disabled.get()) {
         return;
     }
     

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -19,6 +19,8 @@
 #include <QJsonObject>
 #include <QNetworkReply>
 
+#include <SettingHandle.h>
+
 class UserActivityLogger : public QObject {
     Q_OBJECT
     
@@ -44,8 +46,8 @@ private slots:
     void requestError(QNetworkReply& errorReply);
     
 private:
-    UserActivityLogger();
-    bool _disabled;
+    UserActivityLogger() {};
+    Setting::Handle<bool> _disabled { "UserActivityLoggerDisabled", false };
 };
 
 #endif // hifi_UserActivityLogger_h


### PR DESCRIPTION
- fixes an issue where two events would go out for users not wanting to send usage data due to Menu load race