### PR TITLE
Fix the dice in /tutorials

### DIFF
--- a/scripts/tutorials/createDice.js
+++ b/scripts/tutorials/createDice.js
@@ -31,7 +31,8 @@ var BUTTON_SIZE = 32;
 var PADDING = 3;
 
 //a helper library for creating toolbars
-Script.include(["../system/libraries/toolBars.js"]);
+Script.include("http://hifi-production.s3.amazonaws.com/tutorials/dice/toolBars.js");
+
 var toolBar = new ToolBar(0, 0, ToolBar.HORIZONTAL, "highfidelity.dice.toolbar", function(screenSize) {
   return {
     x: (screenSize.x / 2 - BUTTON_SIZE * 2 + PADDING),

--- a/scripts/tutorials/createDice.js
+++ b/scripts/tutorials/createDice.js
@@ -31,7 +31,7 @@ var BUTTON_SIZE = 32;
 var PADDING = 3;
 
 //a helper library for creating toolbars
-Script.include(["../default/libraries/toolBars.js"]);
+Script.include(["../system/libraries/toolBars.js"]);
 var toolBar = new ToolBar(0, 0, ToolBar.HORIZONTAL, "highfidelity.dice.toolbar", function(screenSize) {
   return {
     x: (screenSize.x / 2 - BUTTON_SIZE * 2 + PADDING),


### PR DESCRIPTION
This PR fixes an error in the dice script related to the toolbars library: it changes the toolbar reference to a production url.