### PR TITLE
keep track of actions we are editing and ignore updates from server for these actions

### DIFF
--- a/libraries/entities/src/EntityActionInterface.h
+++ b/libraries/entities/src/EntityActionInterface.h
@@ -54,6 +54,9 @@ public:
     virtual bool lifetimeIsOver() { return false; }
     virtual quint64 getExpires() { return 0; }
 
+    virtual bool isMine() { return _isMine; }
+    virtual void setIsMine(bool value) { _isMine = value; }
+
     bool locallyAddedButNotYetReceived = false;
 
     virtual bool shouldSuppressLocationEdits() { return false; }
@@ -89,6 +92,7 @@ protected:
     QUuid _id;
     EntityActionType _type;
     bool _active { false };
+    bool _isMine { false }; // did this interface create / edit this action?
 };
 
 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -658,6 +658,9 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         if (_simulationOwner.set(newSimOwner)) {
             _dirtyFlags |= Simulation::DIRTY_SIMULATOR_ID;
             somethingChanged = true;
+            // recompute weOwnSimulation so that if this is the packet that tells use we are the owner,
+            // we ignore the physics changes from this packet.
+            weOwnSimulation = _simulationOwner.matchesValidID(myNodeID);
         }
     }
     {   // When we own the simulation we don't accept updates to the entity's transform/velocities

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1702,6 +1702,7 @@ bool EntityItem::updateAction(EntitySimulation* simulation, const QUuid& actionI
 
         success = action->updateArguments(arguments);
         if (success) {
+            action->setIsMine(true);
             serializeActions(success, _allActionsDataCache);
             _dirtyFlags |= Simulation::DIRTY_PHYSICS_ACTIVATION;
         } else {
@@ -1808,7 +1809,9 @@ void EntityItem::deserializeActionsInternal() {
             EntityActionPointer action = _objectActions[actionID];
             // TODO: make sure types match?  there isn't currently a way to
             // change the type of an existing action.
-            action->deserialize(serializedAction);
+            if (!action->isMine()) {
+                action->deserialize(serializedAction);
+            }
             action->locallyAddedButNotYetReceived = false;
             updated << actionID;
         } else {

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -830,6 +830,7 @@ QUuid EntityScriptingInterface::addAction(const QString& actionTypeString,
             if (!action) {
                 return false;
             }
+            action->setIsMine(true);
             success = entity->addAction(simulation, action);
             entity->grabSimulationOwnership();
             return false; // Physics will cause a packet to be sent, so don't send from here.


### PR DESCRIPTION
- ignore changes to actions that are echoed back to us by the entity server.
