### PR TITLE
fix recursive mutex in Entites.callEntityMethod()

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -415,12 +415,12 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
 }
 
 void EntityScriptingInterface::setEntitiesScriptEngine(EntitiesScriptEngineProvider* engine) {
-    std::lock_guard<std::mutex> lock(_entitiesScriptEngineLock);
+    std::lock_guard<std::recursive_mutex> lock(_entitiesScriptEngineLock);
     _entitiesScriptEngine = engine;
 }
 
 void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method, const QStringList& params) {
-    std::lock_guard<std::mutex> lock(_entitiesScriptEngineLock);
+    std::lock_guard<std::recursive_mutex> lock(_entitiesScriptEngineLock);
     if (_entitiesScriptEngine) {
         EntityItemID entityID{ id };
         _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params);

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -215,7 +215,7 @@ private:
 
     EntityTreePointer _entityTree;
 
-    std::mutex _entitiesScriptEngineLock;
+    std::recursive_mutex _entitiesScriptEngineLock;
     EntitiesScriptEngineProvider* _entitiesScriptEngine { nullptr };
     
     bool _bidOnSimulationOwnership { false };


### PR DESCRIPTION
This fixes an exception when calling `Entities.callEntityMethod()` from inside of a method that was reached by calling `Entities.callEntityMethod()`