### PR TITLE
[CellScience] Move buttons; update ribosome location

### DIFF
--- a/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_cells.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_cells.js
@@ -7,7 +7,7 @@
 
 (function() {
 
-    var version = 12;
+    var version = 13;
 
     var baseURL = "https://hifi-production.s3.amazonaws.com/DomainContent/CellScience/";
     var button;
@@ -47,7 +47,7 @@
                 var buttonPadding = 10;
                 var offset = 0;
                 var buttonPositionX = (offset + 1) * (buttonWidth + buttonPadding) + (windowDimensions.x / 2) - (buttonWidth * 3 + buttonPadding * 2.5);
-                var buttonPositionY = (windowDimensions.y - buttonHeight) - 50;
+                var buttonPositionY = (windowDimensions.y - buttonHeight) - 150;
                 button = Overlays.addOverlay("image", {
                     x: buttonPositionX,
                     y: buttonPositionY,

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_hexokinase.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_hexokinase.js
@@ -13,7 +13,7 @@
 
 (function() {
 
-    var version = 12;
+    var version = 13;
 
     var baseURL = "https://hifi-production.s3.amazonaws.com/DomainContent/CellScience/";
     var button;
@@ -53,7 +53,7 @@
                 var buttonPadding = 10;
                 var offset = 3;
                 var buttonPositionX = (offset + 1) * (buttonWidth + buttonPadding) + (windowDimensions.x / 2) - (buttonWidth * 3 + buttonPadding * 2.5);
-                var buttonPositionY = (windowDimensions.y - buttonHeight) - 50;
+                var buttonPositionY = (windowDimensions.y - buttonHeight) - 150;
                 button = Overlays.addOverlay("image", {
                     x: buttonPositionX,
                     y: buttonPositionY,

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_inside_the_cell.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_inside_the_cell.js
@@ -7,7 +7,7 @@
 
 (function() {
 
-    var version = 12;
+    var version = 13;
 
     var baseURL = "https://hifi-production.s3.amazonaws.com/DomainContent/CellScience/";
     var button;
@@ -47,7 +47,7 @@
                 var buttonPadding = 10;
                 var offset = 1;
                 var buttonPositionX = (offset + 1) * (buttonWidth + buttonPadding) + (windowDimensions.x / 2) - (buttonWidth * 3 + buttonPadding * 2.5);
-                var buttonPositionY = (windowDimensions.y - buttonHeight) - 50;
+                var buttonPositionY = (windowDimensions.y - buttonHeight) - 150;
                 button = Overlays.addOverlay("image", {
                     x: buttonPositionX,
                     y: buttonPositionY,

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_ribosome.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_ribosome.js
@@ -26,9 +26,9 @@
             z: 3000
         },
         target: {
-            x: 3276.6,
-            y: 13703.3,
-            z: 4405.6
+            x: 13500,
+            y: 3000,
+            z: 3000
         },
         preload: function(entityId) {
             print('CELL PRELOAD RIBOSOME 1')

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_ribosome.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/nav_button_ribosome.js
@@ -6,7 +6,7 @@
 //
 (function() {
 
-    var version = 12;
+    var version = 13;
 
     var baseURL = "https://hifi-production.s3.amazonaws.com/DomainContent/CellScience/";
     var button;
@@ -46,7 +46,7 @@
                 var buttonPadding = 10;
                 var offset = 2;
                 var buttonPositionX = (offset + 1) * (buttonWidth + buttonPadding) + (windowDimensions.x / 2) - (buttonWidth * 3 + buttonPadding * 2.5);
-                var buttonPositionY = (windowDimensions.y - buttonHeight) - 50;
+                var buttonPositionY = (windowDimensions.y - buttonHeight) - 150;
                 button = Overlays.addOverlay("image", {
                     x: buttonPositionX,
                     y: buttonPositionY,

--- a/unpublishedScripts/DomainContent/CellScience/importNow.js
+++ b/unpublishedScripts/DomainContent/CellScience/importNow.js
@@ -5,7 +5,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var version = 1218;
+var version = 1219;
 
 var WORLD_OFFSET = {
     x: 0,

--- a/unpublishedScripts/DomainContent/CellScience/importNow.js
+++ b/unpublishedScripts/DomainContent/CellScience/importNow.js
@@ -5,7 +5,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var version = 1217;
+var version = 1218;
 
 var WORLD_OFFSET = {
     x: 0,


### PR DESCRIPTION
This PR moves the GUI buttons for cell since up so that they don't overlap the edit and example buttons.  It additionally changes the location for the ribosome button to be correct.

To test:
1. Visit cellscience
2. Observe that the buttons are higher up
3. Click the ribosome button and observe that you end in in the ribosome land

This code is already deployed to production s3.