### PR TITLE
add warnings for socket error and unexpected state change

### DIFF
--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -413,11 +413,11 @@ std::vector<HifiSockAddr> Socket::getConnectionSockAddrs() {
 }
 
 void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
-    qWarning() << "udt::Socket error -" << socketError;
+    qCWarning(networking) << "udt::Socket error -" << socketError;
 }
 
 void Socket::handleStateChanged(QAbstractSocket::SocketState socketState) {
     if (socketState != QAbstractSocket::BoundState) {
-        qWarning() << "udt::Socket state changed - state is now" << socketState;
+        qCWarning(networking) << "udt::Socket state changed - state is now" << socketState;
     }
 }

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -37,7 +37,7 @@ Socket::Socket(QObject* parent) :
     // start our timer for the synchronization time interval
     _synTimer->start(_synInterval);
 
-    // make sure we hear about errors and state chagnes from the underlying socket
+    // make sure we hear about errors and state changes from the underlying socket
     connect(&_udpSocket, SIGNAL(error(QAbstractSocket::SocketError)),
             this, SLOT(handleSocketError(QAbstractSocket::SocketError)));
     connect(&_udpSocket, &QAbstractSocket::stateChanged, this, &Socket::handleStateChanged);

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -36,6 +36,11 @@ Socket::Socket(QObject* parent) :
     
     // start our timer for the synchronization time interval
     _synTimer->start(_synInterval);
+
+    // make sure we hear about errors and state chagnes from the underlying socket
+    connect(&_udpSocket, SIGNAL(error(QAbstractSocket::SocketError)),
+            this, SLOT(handleSocketError(QAbstractSocket::SocketError)));
+    connect(&_udpSocket, &QAbstractSocket::stateChanged, this, &Socket::handleStateChanged);
 }
 
 void Socket::bind(const QHostAddress& address, quint16 port) {
@@ -405,4 +410,14 @@ std::vector<HifiSockAddr> Socket::getConnectionSockAddrs() {
         addr.push_back(connectionPair.first);
     }
     return addr;
+}
+
+void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
+    qWarning() << "udt::Socket error -" << socketError;
+}
+
+void Socket::handleStateChanged(QAbstractSocket::SocketState socketState) {
+    if (socketState != QAbstractSocket::BoundState) {
+        qWarning() << "udt::Socket state changed - state is now" << socketState;
+    }
 }

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -86,7 +86,10 @@ public slots:
 private slots:
     void readPendingDatagrams();
     void rateControlSync();
-    
+
+    void handleSocketError(QAbstractSocket::SocketError socketError);
+    void handleStateChanged(QAbstractSocket::SocketState socketState);
+
 private:
     void setSystemBufferSizes();
     Connection& findOrCreateConnection(const HifiSockAddr& sockAddr);


### PR DESCRIPTION
- add `qWarning` calls to `udt::Socket` to capture socket state changes and errors