### PR TITLE
Add users.js to default, start visible to friends only

### DIFF
--- a/interface/src/DiscoverabilityManager.cpp
+++ b/interface/src/DiscoverabilityManager.cpp
@@ -20,7 +20,7 @@
 #include "DiscoverabilityManager.h"
 #include "Menu.h"
 
-const Discoverability::Mode DEFAULT_DISCOVERABILITY_MODE = Discoverability::All;
+const Discoverability::Mode DEFAULT_DISCOVERABILITY_MODE = Discoverability::Friends;
 
 DiscoverabilityManager::DiscoverabilityManager() :
     _mode("discoverabilityMode", DEFAULT_DISCOVERABILITY_MODE)

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -8,11 +8,12 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-Script.load("system/edit.js");
+
 Script.load("system/progress.js");
 Script.load("system/away.js");
 Script.load("system/users.js");
 Script.load("system/examples.js");
+Script.load("system/edit.js");
 Script.load("system/selectAudioDevice.js");
 Script.load("system/notifications.js");
 Script.load("system/controllers/handControllerGrab.js");

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -8,9 +8,10 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-Script.load("system/away.js");
-Script.load("system/progress.js");
 Script.load("system/edit.js");
+Script.load("system/progress.js");
+Script.load("system/away.js");
+Script.load("system/users.js");
 Script.load("system/examples.js");
 Script.load("system/selectAudioDevice.js");
 Script.load("system/notifications.js");

--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -222,7 +222,7 @@ var usersWindow = (function() {
 
     var baseURL = Script.resolvePath("assets/images/tools/");
 
-    var WINDOW_WIDTH = 160,
+    var WINDOW_WIDTH = 260,
         WINDOW_MARGIN = 12,
         WINDOW_BASE_MARGIN = 6, // A little less is needed in order look correct
         WINDOW_FONT = {


### PR DESCRIPTION
This PR returns users.js to the default scripts, but changes its starting setting to be 'friends only'. It also makes the window a bit wider so you can see where people are before teleporting.

To test:
1. Dont copy settings from production.
2. users.js should start as part of default scripts
3. it should start with 'friends' selected as visibility level
4. you should not appear on https://metaverse.highfidelity.com/api/v1/users?status=online
5. switch to visiblity 'everyone' 
6. you should appear on https://metaverse.highfidelity.com/api/v1/users?status=online
7. switch back to 'friends' and make sure you are visible to a friend who is also online