### PR TITLE
Defer mipmap gen to gpu

### DIFF
--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -171,14 +171,6 @@ gpu::Texture* TextureUsage::process2DTextureColorFromImage(const QImage& srcImag
 
         if (generateMips) {
             theTexture->autoGenerateMips(-1);
-            auto levels = theTexture->maxMip();
-            uvec2 size(image.width(), image.height());
-            for (uint8_t i = 1; i <= levels; ++i) {
-                size >>= 1;
-                size = glm::max(size, uvec2(1));
-                image = image.scaled(size.x, size.y, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-                theTexture->assignStoredMip(i, formatMip, image.byteCount(), image.constBits());
-            }
         }
     }
 


### PR DESCRIPTION
Removes code that attempted to generate mipmaps after setting them to autogenerate.

This was generating (expensive) QImage mipmaps and doing nothing with them, as setting autogeneration makes assignStoredMip a nop.

This code should speed up scene loading, as it reduces the CPU load for generating textures. In performance tests loading 1580 standard textures (scenes from Big Buck Bunny), current build takes 105.7% of the time to load a QImage to process it into a gpu::Texture (calls within ImageReader::run to TextureUsage::process2DTextureColorFromImage over QImage::fromData). In this build, it takes only 68.8% of the time.