### PR TITLE
resurrection of threadsafe ViewFrustum

### DIFF
--- a/assignment-client/src/octree/OctreeQueryNode.cpp
+++ b/assignment-client/src/octree/OctreeQueryNode.cpp
@@ -141,6 +141,16 @@ void OctreeQueryNode::writeToPacket(const unsigned char* buffer, unsigned int by
     }
 }
 
+void OctreeQueryNode::copyCurrentViewFrustum(ViewFrustum& viewOut) const {
+    QMutexLocker viewLocker(&_viewMutex);
+    viewOut = _currentViewFrustum;
+}
+
+void OctreeQueryNode::copyLastKnownViewFrustum(ViewFrustum& viewOut) const {
+    QMutexLocker viewLocker(&_viewMutex);
+    viewOut = _lastKnownViewFrustum;
+}
+
 bool OctreeQueryNode::updateCurrentViewFrustum() {
     // if shutting down, return immediately
     if (_isShuttingDown) {
@@ -171,11 +181,13 @@ bool OctreeQueryNode::updateCurrentViewFrustum() {
     }
 
 
-    // if there has been a change, then recalculate
-    if (!newestViewFrustum.isVerySimilar(_currentViewFrustum)) {
-        _currentViewFrustum = newestViewFrustum;
-        _currentViewFrustum.calculate();
-        currentViewFrustumChanged = true;
+    { // if there has been a change, then recalculate
+        QMutexLocker viewLocker(&_viewMutex);
+        if (!newestViewFrustum.isVerySimilar(_currentViewFrustum)) {
+            _currentViewFrustum = newestViewFrustum;
+            _currentViewFrustum.calculate();
+            currentViewFrustumChanged = true;
+        }
     }
 
     // Also check for LOD changes from the client
@@ -219,11 +231,14 @@ void OctreeQueryNode::updateLastKnownViewFrustum() {
         return;
     }
 
-    bool frustumChanges = !_lastKnownViewFrustum.isVerySimilar(_currentViewFrustum);
+    {
+        QMutexLocker viewLocker(&_viewMutex);
+        bool frustumChanges = !_lastKnownViewFrustum.isVerySimilar(_currentViewFrustum);
 
-    if (frustumChanges) {
-        // save our currentViewFrustum into our lastKnownViewFrustum
-        _lastKnownViewFrustum = _currentViewFrustum;
+        if (frustumChanges) {
+            // save our currentViewFrustum into our lastKnownViewFrustum
+            _lastKnownViewFrustum = _currentViewFrustum;
+        }
     }
 
     // save that we know the view has been sent.
@@ -237,15 +252,13 @@ bool OctreeQueryNode::moveShouldDump() const {
         return false;
     }
 
+    QMutexLocker viewLocker(&_viewMutex);
     glm::vec3 oldPosition = _lastKnownViewFrustum.getPosition();
     glm::vec3 newPosition = _currentViewFrustum.getPosition();
 
     // theoretically we could make this slightly larger but relative to avatar scale.
     const float MAXIMUM_MOVE_WITHOUT_DUMP = 0.0f;
-    if (glm::distance(newPosition, oldPosition) > MAXIMUM_MOVE_WITHOUT_DUMP) {
-        return true;
-    }
-    return false;
+    return glm::distance(newPosition, oldPosition) > MAXIMUM_MOVE_WITHOUT_DUMP;
 }
 
 void OctreeQueryNode::dumpOutOfView() {
@@ -257,8 +270,13 @@ void OctreeQueryNode::dumpOutOfView() {
     int stillInView = 0;
     int outOfView = 0;
     OctreeElementBag tempBag;
+    ViewFrustum viewCopy;
+    {
+        QMutexLocker viewLocker(&_viewMutex);
+        viewCopy = _currentViewFrustum;
+    }
     while (OctreeElementPointer elementToCheck = elementBag.extract()) {
-        if (elementToCheck->isInView(_currentViewFrustum)) {
+        if (elementToCheck->isInView(viewCopy)) {
             tempBag.insert(elementToCheck);
             stillInView++;
         } else {
@@ -267,7 +285,7 @@ void OctreeQueryNode::dumpOutOfView() {
     }
     if (stillInView > 0) {
         while (OctreeElementPointer elementToKeepInBag = tempBag.extract()) {
-            if (elementToKeepInBag->isInView(_currentViewFrustum)) {
+            if (elementToKeepInBag->isInView(viewCopy)) {
                 elementBag.insert(elementToKeepInBag);
             }
         }

--- a/assignment-client/src/octree/OctreeQueryNode.cpp
+++ b/assignment-client/src/octree/OctreeQueryNode.cpp
@@ -271,10 +271,7 @@ void OctreeQueryNode::dumpOutOfView() {
     int outOfView = 0;
     OctreeElementBag tempBag;
     ViewFrustum viewCopy;
-    {
-        QMutexLocker viewLocker(&_viewMutex);
-        viewCopy = _currentViewFrustum;
-    }
+    copyCurrentViewFrustum(viewCopy);
     while (OctreeElementPointer elementToCheck = elementBag.extract()) {
         if (elementToCheck->isInView(viewCopy)) {
             tempBag.insert(elementToCheck);

--- a/assignment-client/src/octree/OctreeQueryNode.h
+++ b/assignment-client/src/octree/OctreeQueryNode.h
@@ -56,8 +56,8 @@ public:
     OctreeElementBag elementBag;
     OctreeElementExtraEncodeData extraEncodeData;
 
-    const ViewFrustum& getCurrentViewFrustum() const { return _currentViewFrustum; }
-    const ViewFrustum& getLastKnownViewFrustum() const { return _lastKnownViewFrustum; }
+    void copyCurrentViewFrustum(ViewFrustum& viewOut) const;
+    void copyLastKnownViewFrustum(ViewFrustum& viewOut) const;
 
     // These are not classic setters because they are calculating and maintaining state
     // which is set asynchronously through the network receive
@@ -114,6 +114,8 @@ private:
 
     int _maxSearchLevel { 1 };
     int _maxLevelReachedInLastSearch { 1 };
+
+    mutable QMutex _viewMutex { QMutex::Recursive };
     ViewFrustum _currentViewFrustum;
     ViewFrustum _lastKnownViewFrustum;
     quint64 _lastTimeBagEmpty { 0 };
@@ -139,7 +141,7 @@ private:
     QQueue<OCTREE_PACKET_SEQUENCE> _nackedSequenceNumbers;
 
     quint64 _sceneSendStartTime = 0;
-    
+
     std::array<char, udt::MAX_PACKET_SIZE> _lastOctreePayload;
 };
 

--- a/assignment-client/src/octree/OctreeQueryNode.h
+++ b/assignment-client/src/octree/OctreeQueryNode.h
@@ -44,7 +44,7 @@ public:
 
     bool packetIsDuplicate() const;
     bool shouldSuppressDuplicatePacket();
-    
+
     unsigned int getAvailable() const { return _octreePacket->bytesAvailableForWrite(); }
     int getMaxSearchLevel() const { return _maxSearchLevel; }
     void resetMaxSearchLevel() { _maxSearchLevel = 1; }
@@ -56,8 +56,8 @@ public:
     OctreeElementBag elementBag;
     OctreeElementExtraEncodeData extraEncodeData;
 
-    ViewFrustum& getCurrentViewFrustum() { return _currentViewFrustum; }
-    ViewFrustum& getLastKnownViewFrustum() { return _lastKnownViewFrustum; }
+    const ViewFrustum& getCurrentViewFrustum() const { return _currentViewFrustum; }
+    const ViewFrustum& getLastKnownViewFrustum() const { return _lastKnownViewFrustum; }
 
     // These are not classic setters because they are calculating and maintaining state
     // which is set asynchronously through the network receive

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -332,8 +332,6 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
 
     _packetData.changeSettings(true, targetSize); // FIXME - eventually support only compressed packets
 
-    const ViewFrustum* lastViewFrustum = viewFrustumChanged ? &nodeData->getLastKnownViewFrustum() : NULL;
-
     // If the current view frustum has changed OR we have nothing to send, then search against
     // the current view frustum for things to send.
     if (viewFrustumChanged || nodeData->elementBag.isEmpty()) {
@@ -411,7 +409,7 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
                     quint64 lockWaitEnd = usecTimestampNow();
                     lockWaitElapsedUsec = (float)(lockWaitEnd - lockWaitStart);
                     quint64 encodeStart = usecTimestampNow();
-                    
+
                     OctreeElementPointer subTree = nodeData->elementBag.extract();
                     if (!subTree) {
                         return;
@@ -420,18 +418,22 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
                     float octreeSizeScale = nodeData->getOctreeSizeScale();
                     int boundaryLevelAdjustClient = nodeData->getBoundaryLevelAdjust();
 
-                    int boundaryLevelAdjust = boundaryLevelAdjustClient + 
+                    int boundaryLevelAdjust = boundaryLevelAdjustClient +
                                               (viewFrustumChanged ? LOW_RES_MOVING_ADJUST : NO_BOUNDARY_ADJUST);
 
-                    EncodeBitstreamParams params(INT_MAX, &nodeData->getCurrentViewFrustum(), 
-                                                 WANT_EXISTS_BITS, DONT_CHOP, viewFrustumChanged, lastViewFrustum,
+                    EncodeBitstreamParams params(INT_MAX, WANT_EXISTS_BITS, DONT_CHOP,
+                                                 viewFrustumChanged,
                                                  boundaryLevelAdjust, octreeSizeScale,
                                                  nodeData->getLastTimeBagEmpty(),
                                                  isFullScene, &nodeData->stats, _myServer->getJurisdiction(),
                                                  &nodeData->extraEncodeData);
+                    params.viewFrustum = nodeData->getCurrentViewFrustum();
+                    if (viewFrustumChanged) {
+                        params.lastViewFrustum = nodeData->getLastKnownViewFrustum();
+                    }
 
                     // Our trackSend() function is implemented by the server subclass, and will be called back
-                    // during the encodeTreeBitstream() as new entities/data elements are sent 
+                    // during the encodeTreeBitstream() as new entities/data elements are sent
                     params.trackSend = [this, node](const QUuid& dataID, quint64 dataEdited) {
                         _myServer->trackSend(dataID, dataEdited, node->getUUID());
                     };

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -427,9 +427,9 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
                                                  nodeData->getLastTimeBagEmpty(),
                                                  isFullScene, &nodeData->stats, _myServer->getJurisdiction(),
                                                  &nodeData->extraEncodeData);
-                    params.viewFrustum = nodeData->getCurrentViewFrustum();
+                    nodeData->copyCurrentViewFrustum(params.viewFrustum);
                     if (viewFrustumChanged) {
-                        params.lastViewFrustum = nodeData->getLastKnownViewFrustum();
+                        nodeData->copyLastKnownViewFrustum(params.lastViewFrustum);
                     }
 
                     // Our trackSend() function is implemented by the server subclass, and will be called back

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4519,11 +4519,6 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     scriptEngine->registerGlobalObject("Reticle", getApplicationCompositor().getReticleInterface());
 }
 
-void Application::copyCurrentViewFrustum(ViewFrustum& viewOut) const {
-    QMutexLocker viewLocker(&_viewMutex);
-    viewOut = _displayViewFrustum;
-}
-
 bool Application::canAcceptURL(const QString& urlString) const {
     QUrl url(urlString);
     if (urlString.startsWith(HIFI_URL_SCHEME)) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1512,6 +1512,7 @@ void Application::paintGL() {
     auto lodManager = DependencyManager::get<LODManager>();
 
 
+    _viewFrustum.calculate();
     RenderArgs renderArgs(_gpuContext, getEntities(), getViewFrustum(), lodManager->getOctreeSizeScale(),
                           lodManager->getBoundaryLevelAdjust(), RenderArgs::DEFAULT_RENDER_MODE,
                           RenderArgs::MONO, RenderArgs::RENDER_DEBUG_NONE);
@@ -3872,16 +3873,6 @@ MyAvatar* Application::getMyAvatar() const {
 
 glm::vec3 Application::getAvatarPosition() const {
     return getMyAvatar()->getPosition();
-}
-
-ViewFrustum* Application::getViewFrustum() {
-#ifdef DEBUG
-    if (QThread::currentThread() == activeRenderingThread) {
-        // FIXME, figure out a better way to do this
-        //qWarning() << "Calling Application::getViewFrustum() from the active rendering thread, did you mean Application::getDisplayViewFrustum()?";
-    }
-#endif
-    return &_viewFrustum;
 }
 
 const ViewFrustum* Application::getViewFrustum() const {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3651,19 +3651,16 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType, Node
     //qCDebug(interfaceapp) << ">>> inside... queryOctree()... _viewFrustum.getFieldOfView()=" << _viewFrustum.getFieldOfView();
     bool wantExtraDebugging = getLogger()->extraDebugging();
 
-    ViewFrustum viewFrustumCopy;
-    {
-        QMutexLocker viewLocker(&_viewMutex);
-        viewFrustumCopy = _viewFrustum;
-    }
-    _octreeQuery.setCameraPosition(viewFrustumCopy.getPosition());
-    _octreeQuery.setCameraOrientation(viewFrustumCopy.getOrientation());
-    _octreeQuery.setCameraFov(viewFrustumCopy.getFieldOfView());
-    _octreeQuery.setCameraAspectRatio(viewFrustumCopy.getAspectRatio());
-    _octreeQuery.setCameraNearClip(viewFrustumCopy.getNearClip());
-    _octreeQuery.setCameraFarClip(viewFrustumCopy.getFarClip());
+    ViewFrustum viewFrustum;
+    copyViewFrustum(viewFrustum);
+    _octreeQuery.setCameraPosition(viewFrustum.getPosition());
+    _octreeQuery.setCameraOrientation(viewFrustum.getOrientation());
+    _octreeQuery.setCameraFov(viewFrustum.getFieldOfView());
+    _octreeQuery.setCameraAspectRatio(viewFrustum.getAspectRatio());
+    _octreeQuery.setCameraNearClip(viewFrustum.getNearClip());
+    _octreeQuery.setCameraFarClip(viewFrustum.getFarClip());
     _octreeQuery.setCameraEyeOffsetPosition(glm::vec3());
-    _octreeQuery.setCameraCenterRadius(viewFrustumCopy.getCenterRadius());
+    _octreeQuery.setCameraCenterRadius(viewFrustum.getCenterRadius());
     auto lodManager = DependencyManager::get<LODManager>();
     _octreeQuery.setOctreeSizeScale(lodManager->getOctreeSizeScale());
     _octreeQuery.setBoundaryLevelAdjust(lodManager->getBoundaryLevelAdjust());
@@ -3699,7 +3696,7 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType, Node
                                                   rootDetails.y * TREE_SCALE,
                                                   rootDetails.z * TREE_SCALE) - glm::vec3(HALF_TREE_SCALE),
                                         rootDetails.s * TREE_SCALE);
-                    if (viewFrustumCopy.cubeIntersectsKeyhole(serverBounds)) {
+                    if (viewFrustum.cubeIntersectsKeyhole(serverBounds)) {
                         inViewServers++;
                     }
                 }
@@ -3765,11 +3762,9 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType, Node
                                         rootDetails.s * TREE_SCALE);
 
 
-                    inView = viewFrustumCopy.cubeIntersectsKeyhole(serverBounds);
-                } else {
-                    if (wantExtraDebugging) {
-                        qCDebug(interfaceapp) << "Jurisdiction without RootCode for node " << *node << ". That's unusual!";
-                    }
+                    inView = viewFrustum.cubeIntersectsKeyhole(serverBounds);
+                } else if (wantExtraDebugging) {
+                    qCDebug(interfaceapp) << "Jurisdiction without RootCode for node " << *node << ". That's unusual!";
                 }
             }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -128,13 +128,12 @@ public:
     Camera* getCamera() { return &_myCamera; }
     const Camera* getCamera() const { return &_myCamera; }
     // Represents the current view frustum of the avatar.
-    const ViewFrustum* getViewFrustum() const;
+    const ViewFrustum& getViewFrustum() const;
     // Represents the view frustum of the current rendering pass,
     // which might be different from the viewFrustum, i.e. shadowmap
     // passes, mirror window passes, etc
-    ViewFrustum* getDisplayViewFrustum();
-    const ViewFrustum* getDisplayViewFrustum() const;
-    ViewFrustum* getShadowViewFrustum() override { return &_shadowViewFrustum; }
+    const ViewFrustum& getDisplayViewFrustum() const;
+    const ViewFrustum& getShadowViewFrustum() override { return _shadowViewFrustum; }
     const OctreePacketProcessor& getOctreePacketProcessor() const { return _octreeProcessor; }
     EntityTreeRenderer* getEntities() const { return DependencyManager::get<EntityTreeRenderer>().data(); }
     QUndoStack* getUndoStack() { return &_undoStack; }
@@ -168,7 +167,7 @@ public:
     virtual controller::ScriptingInterface* getControllerScriptingInterface() { return _controllerScriptingInterface; }
     virtual void registerScriptEngineWithApplicationServices(ScriptEngine* scriptEngine) override;
 
-    virtual ViewFrustum* getCurrentViewFrustum() override { return getDisplayViewFrustum(); }
+    virtual const ViewFrustum& getCurrentViewFrustum() override { return getDisplayViewFrustum(); }
     virtual QThread* getMainThread() override { return thread(); }
     virtual PickRay computePickRay(float x, float y) const override;
     virtual glm::vec3 getAvatarPosition() const override;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -167,7 +167,7 @@ public:
     virtual controller::ScriptingInterface* getControllerScriptingInterface() { return _controllerScriptingInterface; }
     virtual void registerScriptEngineWithApplicationServices(ScriptEngine* scriptEngine) override;
 
-    virtual void copyCurrentViewFrustum(ViewFrustum& viewOut) const override;
+    virtual ViewFrustum* getCurrentViewFrustum() override { return getDisplayViewFrustum(); }
     virtual QThread* getMainThread() override { return thread(); }
     virtual PickRay computePickRay(float x, float y) const override;
     virtual glm::vec3 getAvatarPosition() const override;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -128,7 +128,6 @@ public:
     Camera* getCamera() { return &_myCamera; }
     const Camera* getCamera() const { return &_myCamera; }
     // Represents the current view frustum of the avatar.
-    ViewFrustum* getViewFrustum();
     const ViewFrustum* getViewFrustum() const;
     // Represents the view frustum of the current rendering pass,
     // which might be different from the viewFrustum, i.e. shadowmap

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -167,7 +167,7 @@ public:
     virtual controller::ScriptingInterface* getControllerScriptingInterface() { return _controllerScriptingInterface; }
     virtual void registerScriptEngineWithApplicationServices(ScriptEngine* scriptEngine) override;
 
-    virtual ViewFrustum* getCurrentViewFrustum() override { return getDisplayViewFrustum(); }
+    virtual void copyCurrentViewFrustum(ViewFrustum& viewOut) const override { copyDisplayViewFrustum(viewOut); }
     virtual QThread* getMainThread() override { return thread(); }
     virtual PickRay computePickRay(float x, float y) const override;
     virtual glm::vec3 getAvatarPosition() const override;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -128,12 +128,12 @@ public:
     Camera* getCamera() { return &_myCamera; }
     const Camera* getCamera() const { return &_myCamera; }
     // Represents the current view frustum of the avatar.
-    const ViewFrustum& getViewFrustum() const;
+    void copyViewFrustum(ViewFrustum& viewOut) const;
     // Represents the view frustum of the current rendering pass,
     // which might be different from the viewFrustum, i.e. shadowmap
     // passes, mirror window passes, etc
-    const ViewFrustum& getDisplayViewFrustum() const;
-    const ViewFrustum& getShadowViewFrustum() override { return _shadowViewFrustum; }
+    void copyDisplayViewFrustum(ViewFrustum& viewOut) const;
+    void copyShadowViewFrustum(ViewFrustum& viewOut) const override;
     const OctreePacketProcessor& getOctreePacketProcessor() const { return _octreeProcessor; }
     EntityTreeRenderer* getEntities() const { return DependencyManager::get<EntityTreeRenderer>().data(); }
     QUndoStack* getUndoStack() { return &_undoStack; }
@@ -167,7 +167,7 @@ public:
     virtual controller::ScriptingInterface* getControllerScriptingInterface() { return _controllerScriptingInterface; }
     virtual void registerScriptEngineWithApplicationServices(ScriptEngine* scriptEngine) override;
 
-    virtual const ViewFrustum& getCurrentViewFrustum() override { return getDisplayViewFrustum(); }
+    virtual void copyCurrentViewFrustum(ViewFrustum& viewOut) const override;
     virtual QThread* getMainThread() override { return thread(); }
     virtual PickRay computePickRay(float x, float y) const override;
     virtual glm::vec3 getAvatarPosition() const override;
@@ -412,6 +412,7 @@ private:
     EntityTreeRenderer _entityClipboardRenderer;
     EntityTreePointer _entityClipboard;
 
+    mutable QMutex _viewMutex { QMutex::Recursive };
     ViewFrustum _viewFrustum; // current state of view frustum, perspective, orientation, etc.
     ViewFrustum _lastQueriedViewFrustum; /// last view frustum used to query octree servers (voxels)
     ViewFrustum _displayViewFrustum;

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -10,6 +10,7 @@
 //
 
 #include <SettingHandle.h>
+#include <OctreeUtils.h>
 #include <Util.h>
 
 #include "Application.h"
@@ -216,7 +217,7 @@ QString LODManager::getLODFeedbackText() {
 bool LODManager::shouldRender(const RenderArgs* args, const AABox& bounds) {
     // FIXME - eventually we want to use the render accuracy as an indicator for the level of detail
     // to use in rendering.
-    float renderAccuracy = args->_viewFrustum->calculateRenderAccuracy(bounds, args->_sizeScale, args->_boundaryLevelAdjust);
+    float renderAccuracy = calculateRenderAccuracy(args->getViewFrustum().getPosition(), bounds, args->_sizeScale, args->_boundaryLevelAdjust);
     return (renderAccuracy > 0.0f);
 };
 
@@ -228,7 +229,6 @@ void LODManager::setBoundaryLevelAdjust(int boundaryLevelAdjust) {
     _boundaryLevelAdjust = boundaryLevelAdjust;
 }
 
-
 void LODManager::loadSettings() {
     setDesktopLODDecreaseFPS(desktopLODDecreaseFPS.get());
     setHMDLODDecreaseFPS(hmdLODDecreaseFPS.get());
@@ -238,5 +238,4 @@ void LODManager::saveSettings() {
     desktopLODDecreaseFPS.set(getDesktopLODDecreaseFPS());
     hmdLODDecreaseFPS.set(getHMDLODDecreaseFPS());
 }
-
 

--- a/interface/src/Stars.cpp
+++ b/interface/src/Stars.cpp
@@ -194,8 +194,8 @@ void Stars::render(RenderArgs* renderArgs, float alpha) {
 
     gpu::Batch& batch = *renderArgs->_batch;
     batch.setViewTransform(Transform());
-    batch.setProjectionTransform(renderArgs->_viewFrustum->getProjection());
-    batch.setModelTransform(Transform().setRotation(glm::inverse(renderArgs->_viewFrustum->getOrientation()) *
+    batch.setProjectionTransform(renderArgs->getViewFrustum().getProjection());
+    batch.setModelTransform(Transform().setRotation(glm::inverse(renderArgs->getViewFrustum().getOrientation()) *
         quat(vec3(TILT, 0, 0))));
     batch.setResourceTexture(0, textureCache->getWhiteTexture());
 

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -25,6 +25,7 @@
 #include <LODManager.h>
 #include <NodeList.h>
 #include <NumericalConstants.h>
+#include <OctreeUtils.h>
 #include <udt/PacketHeaders.h>
 #include <PerfStat.h>
 #include <SharedUtil.h>
@@ -171,7 +172,8 @@ void Avatar::simulate(float deltaTime) {
     // update the shouldAnimate flag to match whether or not we will render the avatar.
     const float MINIMUM_VISIBILITY_FOR_ON = 0.4f;
     const float MAXIMUM_VISIBILITY_FOR_OFF = 0.6f;
-    float visibility = qApp->getViewFrustum()->calculateRenderAccuracy(getBounds(), DependencyManager::get<LODManager>()->getOctreeSizeScale());
+    float visibility = calculateRenderAccuracy(qApp->getViewFrustum().getPosition(),
+            getBounds(), DependencyManager::get<LODManager>()->getOctreeSizeScale());
     if (!_shouldAnimate) {
         if (visibility > MINIMUM_VISIBILITY_FOR_ON) {
             _shouldAnimate = true;
@@ -381,17 +383,13 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
         }
     }
 
-    // simple frustum check
-    float boundingRadius = getBoundingRadius();
-    ViewFrustum* frustum = nullptr;
-    if (renderArgs->_renderMode == RenderArgs::SHADOW_RENDER_MODE) {
-        frustum = qApp->getShadowViewFrustum();
-    } else {
-        frustum = qApp->getDisplayViewFrustum();
-    }
-
-    if (!frustum->sphereIntersectsFrustum(getPosition(), boundingRadius)) {
-        return;
+    { // simple frustum check
+        const ViewFrustum& frustum = renderArgs->_renderMode == RenderArgs::SHADOW_RENDER_MODE ?
+            qApp->getShadowViewFrustum() :
+            qApp->getDisplayViewFrustum();
+        if (!frustum.sphereIntersectsFrustum(getPosition(), getBoundingRadius())) {
+            return;
+        }
     }
 
     glm::vec3 toTarget = cameraPosition - getPosition();
@@ -413,7 +411,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                       : GLOW_FROM_AVERAGE_LOUDNESS;
 
         // render body
-        renderBody(renderArgs, frustum, glowLevel);
+        renderBody(renderArgs, glowLevel);
 
         if (renderArgs->_renderMode != RenderArgs::SHADOW_RENDER_MODE) {
             // add local lights
@@ -502,9 +500,8 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
 
     auto cameraMode = qApp->getCamera()->getMode();
     if (!isMyAvatar() || cameraMode != CAMERA_MODE_FIRST_PERSON) {
-        auto& frustum = *renderArgs->_viewFrustum;
+        auto frustum = renderArgs->getViewFrustum();
         auto textPosition = getDisplayNamePosition();
-
         if (frustum.pointIntersectsFrustum(textPosition)) {
             renderDisplayName(batch, frustum, textPosition);
         }

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -506,7 +506,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
 
     auto cameraMode = qApp->getCamera()->getMode();
     if (!isMyAvatar() || cameraMode != CAMERA_MODE_FIRST_PERSON) {
-        ViewFrustum frustum = renderArgs->getViewFrustum();
+        auto& frustum = renderArgs->getViewFrustum();
         auto textPosition = getDisplayNamePosition();
         if (frustum.pointIntersectsFrustum(textPosition)) {
             renderDisplayName(batch, frustum, textPosition);

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -232,7 +232,7 @@ protected:
 
     Transform calculateDisplayNameTransform(const ViewFrustum& view, const glm::vec3& textPosition) const;
     void renderDisplayName(gpu::Batch& batch, const ViewFrustum& view, const glm::vec3& textPosition) const;
-    virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, float glowLevel = 0.0f);
+    virtual void renderBody(RenderArgs* renderArgs, float glowLevel = 0.0f);
     virtual bool shouldRenderHead(const RenderArgs* renderArgs) const;
     virtual void fixupModelsInScene();
 

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -316,7 +316,7 @@ void Head::relaxLean(float deltaTime) {
     _deltaLeanForward *= relaxationFactor;
 }
 
-void Head::render(RenderArgs* renderArgs, float alpha, ViewFrustum* renderFrustum) {
+void Head::render(RenderArgs* renderArgs, float alpha) {
 }
 
 void Head::renderLookAts(RenderArgs* renderArgs) {

--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -316,9 +316,6 @@ void Head::relaxLean(float deltaTime) {
     _deltaLeanForward *= relaxationFactor;
 }
 
-void Head::render(RenderArgs* renderArgs, float alpha) {
-}
-
 void Head::renderLookAts(RenderArgs* renderArgs) {
     renderLookAts(renderArgs, _leftEyePosition, _rightEyePosition);
 }

--- a/interface/src/avatar/Head.h
+++ b/interface/src/avatar/Head.h
@@ -29,8 +29,6 @@ class Head : public HeadData {
 public:
     explicit Head(Avatar* owningAvatar);
 
-    Head(Avatar* owningAvatar);
-
     void init();
     void reset();
     void simulate(float deltaTime, bool isMine, bool billboard = false);

--- a/interface/src/avatar/Head.h
+++ b/interface/src/avatar/Head.h
@@ -28,11 +28,13 @@ class Avatar;
 class Head : public HeadData {
 public:
     explicit Head(Avatar* owningAvatar);
-    
+
+    Head(Avatar* owningAvatar);
+
     void init();
     void reset();
     void simulate(float deltaTime, bool isMine, bool billboard = false);
-    void render(RenderArgs* renderArgs, float alpha, ViewFrustum* renderFrustum);
+    void render(RenderArgs* renderArgs, float alpha);
     void setScale(float scale);
     void setPosition(glm::vec3 position) { _position = position; }
     void setAverageLoudness(float averageLoudness) { _averageLoudness = averageLoudness; }
@@ -44,7 +46,7 @@ public:
 
     /// \return orientationBase+Delta
     glm::quat getFinalOrientationInLocalFrame() const;
-    
+
     /// \return orientationBody * (orientationBase+Delta)
     glm::quat getFinalOrientationInWorldFrame() const;
 

--- a/interface/src/avatar/Head.h
+++ b/interface/src/avatar/Head.h
@@ -32,7 +32,6 @@ public:
     void init();
     void reset();
     void simulate(float deltaTime, bool isMine, bool billboard = false);
-    void render(RenderArgs* renderArgs, float alpha);
     void setScale(float scale);
     void setPosition(glm::vec3 position) { _position = position; }
     void setAverageLoudness(float averageLoudness) { _averageLoudness = averageLoudness; }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -546,7 +546,7 @@ void MyAvatar::updateFromTrackers(float deltaTime) {
         head->setDeltaYaw(estimatedRotation.y);
         head->setDeltaRoll(estimatedRotation.z);
     } else {
-        float magnifyFieldOfView = qApp->getViewFrustum()->getFieldOfView() / _realWorldFieldOfView.get();
+        float magnifyFieldOfView = qApp->getViewFrustum().getFieldOfView() / _realWorldFieldOfView.get();
         head->setDeltaPitch(estimatedRotation.x * magnifyFieldOfView);
         head->setDeltaYaw(estimatedRotation.y * magnifyFieldOfView);
         head->setDeltaRoll(estimatedRotation.z);
@@ -936,8 +936,8 @@ void MyAvatar::updateLookAtTargetAvatar() {
                     glm::vec3 leftEyeHeadLocal = glm::vec3(leftEye[3]);
                     glm::vec3 rightEyeHeadLocal = glm::vec3(rightEye[3]);
                     auto humanSystem = qApp->getViewFrustum();
-                    glm::vec3 humanLeftEye = humanSystem->getPosition() + (humanSystem->getOrientation() * leftEyeHeadLocal);
-                    glm::vec3 humanRightEye = humanSystem->getPosition() + (humanSystem->getOrientation() * rightEyeHeadLocal);
+                    glm::vec3 humanLeftEye = humanSystem.getPosition() + (humanSystem.getOrientation() * leftEyeHeadLocal);
+                    glm::vec3 humanRightEye = humanSystem.getPosition() + (humanSystem.getOrientation() * rightEyeHeadLocal);
 
                     auto hmdInterface = DependencyManager::get<HMDScriptingInterface>();
                     float ipdScale = hmdInterface->getIPDScale();
@@ -951,7 +951,7 @@ void MyAvatar::updateLookAtTargetAvatar() {
                 }
 
                 // And now we can finally add that offset to the camera.
-                glm::vec3 corrected = qApp->getViewFrustum()->getPosition() + gazeOffset;
+                glm::vec3 corrected = qApp->getViewFrustum().getPosition() + gazeOffset;
 
                 avatar->getHead()->setCorrectedLookAtPosition(corrected);
 
@@ -1259,7 +1259,7 @@ void MyAvatar::attach(const QString& modelURL, const QString& jointName,
     Avatar::attach(modelURL, jointName, translation, rotation, scale, isSoft, allowDuplicates, useSaved);
 }
 
-void MyAvatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, float glowLevel) {
+void MyAvatar::renderBody(RenderArgs* renderArgs, float glowLevel) {
 
     if (!_skeletonModel->isRenderable()) {
         return; // wait until all models are loaded
@@ -1269,7 +1269,7 @@ void MyAvatar::renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, fl
 
     //  Render head so long as the camera isn't inside it
     if (shouldRenderHead(renderArgs)) {
-        getHead()->render(renderArgs, 1.0f, renderFrustum);
+        getHead()->render(renderArgs, 1.0f);
     }
 
     // This is drawing the lookat vectors from our avatar to wherever we're looking.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -546,7 +546,9 @@ void MyAvatar::updateFromTrackers(float deltaTime) {
         head->setDeltaYaw(estimatedRotation.y);
         head->setDeltaRoll(estimatedRotation.z);
     } else {
-        float magnifyFieldOfView = qApp->getViewFrustum().getFieldOfView() / _realWorldFieldOfView.get();
+        ViewFrustum viewFrustum;
+        qApp->copyViewFrustum(viewFrustum);
+        float magnifyFieldOfView = viewFrustum.getFieldOfView() / _realWorldFieldOfView.get();
         head->setDeltaPitch(estimatedRotation.x * magnifyFieldOfView);
         head->setDeltaYaw(estimatedRotation.y * magnifyFieldOfView);
         head->setDeltaRoll(estimatedRotation.z);
@@ -929,15 +931,17 @@ void MyAvatar::updateLookAtTargetAvatar() {
                 // (We will be adding that offset to the camera position, after making some other adjustments.)
                 glm::vec3 gazeOffset = lookAtPosition - getHead()->getEyePosition();
 
+                 ViewFrustum viewFrustum;
+                 qApp->copyViewFrustum(viewFrustum);
+
                 // scale gazeOffset by IPD, if wearing an HMD.
                 if (qApp->isHMDMode()) {
                     glm::mat4 leftEye = qApp->getEyeOffset(Eye::Left);
                     glm::mat4 rightEye = qApp->getEyeOffset(Eye::Right);
                     glm::vec3 leftEyeHeadLocal = glm::vec3(leftEye[3]);
                     glm::vec3 rightEyeHeadLocal = glm::vec3(rightEye[3]);
-                    auto humanSystem = qApp->getViewFrustum();
-                    glm::vec3 humanLeftEye = humanSystem.getPosition() + (humanSystem.getOrientation() * leftEyeHeadLocal);
-                    glm::vec3 humanRightEye = humanSystem.getPosition() + (humanSystem.getOrientation() * rightEyeHeadLocal);
+                    glm::vec3 humanLeftEye = viewFrustum.getPosition() + (viewFrustum.getOrientation() * leftEyeHeadLocal);
+                    glm::vec3 humanRightEye = viewFrustum.getPosition() + (viewFrustum.getOrientation() * rightEyeHeadLocal);
 
                     auto hmdInterface = DependencyManager::get<HMDScriptingInterface>();
                     float ipdScale = hmdInterface->getIPDScale();
@@ -951,7 +955,7 @@ void MyAvatar::updateLookAtTargetAvatar() {
                 }
 
                 // And now we can finally add that offset to the camera.
-                glm::vec3 corrected = qApp->getViewFrustum().getPosition() + gazeOffset;
+                glm::vec3 corrected = viewFrustum.getPosition() + gazeOffset;
 
                 avatar->getHead()->setCorrectedLookAtPosition(corrected);
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1271,11 +1271,6 @@ void MyAvatar::renderBody(RenderArgs* renderArgs, float glowLevel) {
 
     fixupModelsInScene();
 
-    //  Render head so long as the camera isn't inside it
-    if (shouldRenderHead(renderArgs)) {
-        getHead()->render(renderArgs, 1.0f);
-    }
-
     // This is drawing the lookat vectors from our avatar to wherever we're looking.
     if (qApp->isHMDMode()) {
         glm::vec3 cameraPosition = qApp->getCamera()->getPosition();
@@ -1356,7 +1351,6 @@ void MyAvatar::destroyAnimGraph() {
 void MyAvatar::preRender(RenderArgs* renderArgs) {
 
     render::ScenePointer scene = qApp->getMain3DScene();
-    const bool shouldDrawHead = shouldRenderHead(renderArgs);
 
     if (_skeletonModel->initWhenReady(scene)) {
         initHeadBones();
@@ -1408,6 +1402,7 @@ void MyAvatar::preRender(RenderArgs* renderArgs) {
     DebugDraw::getInstance().updateMyAvatarPos(getPosition());
     DebugDraw::getInstance().updateMyAvatarRot(getOrientation());
 
+    const bool shouldDrawHead = shouldRenderHead(renderArgs);
     if (shouldDrawHead != _prevShouldDrawHead) {
         _skeletonModel->setCauterizeBones(!shouldDrawHead);
     }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -306,7 +306,7 @@ private:
     void simulate(float deltaTime);
     void updateFromTrackers(float deltaTime);
     virtual void render(RenderArgs* renderArgs, const glm::vec3& cameraPositio) override;
-    virtual void renderBody(RenderArgs* renderArgs, ViewFrustum* renderFrustum, float glowLevel = 0.0f) override;
+    virtual void renderBody(RenderArgs* renderArgs, float glowLevel = 0.0f) override;
     virtual bool shouldRenderHead(const RenderArgs* renderArgs) const override;
     void setShouldRenderLocally(bool shouldRender) { _shouldRender = shouldRender; setEnableMeshVisible(shouldRender); }
     bool getShouldRenderLocally() const { return _shouldRender; }

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -65,7 +65,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
             // Get the camera position rounded to the nearest major grid line
             // This grid is for UI and should lie on worldlines
             auto cameraPosition =
-                (float)_majorGridEvery * glm::round(args->_viewFrustum->getPosition() / (float)_majorGridEvery);
+                (float)_majorGridEvery * glm::round(args->getViewFrustum().getPosition() / (float)_majorGridEvery);
 
             position += glm::vec3(cameraPosition.x, 0.0f, cameraPosition.z);
         }

--- a/interface/src/ui/overlays/LocalModelsOverlay.cpp
+++ b/interface/src/ui/overlays/LocalModelsOverlay.cpp
@@ -37,10 +37,10 @@ void LocalModelsOverlay::render(RenderArgs* args) {
         auto batch = args ->_batch;
 
         Transform transform = Transform();
-        transform.setTranslation(args->_viewFrustum->getPosition() + getPosition());
+        transform.setTranslation(args->getViewFrustum().getPosition() + getPosition());
         batch->setViewTransform(transform);
         _entityTreeRenderer->render(args);
-        transform.setTranslation(args->_viewFrustum->getPosition());
+        transform.setTranslation(args->getViewFrustum().getPosition());
         batch->setViewTransform(transform);
     }
 }

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -51,7 +51,7 @@ void RenderableTextEntityItem::render(RenderArgs* args) {
     }
     if (getFaceCamera()) {
         //rotate about vertical to face the camera
-        glm::vec3 dPosition = args->_viewFrustum->getPosition() - getPosition();
+        glm::vec3 dPosition = args->getViewFrustum().getPosition() - getPosition();
         // If x and z are 0, atan(x, z) is undefined, so default to 0 degrees
         float yawRotation = dPosition.x == 0.0f && dPosition.z == 0.0f ? 0.0f : glm::atan(dPosition.x, dPosition.z);
         glm::quat orientation = glm::quat(glm::vec3(0.0f, yawRotation, 0.0f));

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -298,7 +298,7 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
                         entityTreeElementExtraEncodeData->entities.contains(entity->getEntityItemID());
                 }
 
-                if (includeThisEntity) {
+                if (includeThisEntity || params.recurseEverything) {
 
                     // we want to use the maximum possible box for this, so that we don't have to worry about the nuance of
                     // simulation changing what's visible. consider the case where the entity contains an angular velocity

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -13,6 +13,7 @@
 
 #include <FBXReader.h>
 #include <GeometryUtil.h>
+#include <OctreeUtils.h>
 
 #include "EntitiesLogging.h"
 #include "EntityItemProperties.h"
@@ -297,7 +298,7 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
                         entityTreeElementExtraEncodeData->entities.contains(entity->getEntityItemID());
                 }
 
-                if (includeThisEntity && params.viewFrustum) {
+                if (includeThisEntity) {
 
                     // we want to use the maximum possible box for this, so that we don't have to worry about the nuance of
                     // simulation changing what's visible. consider the case where the entity contains an angular velocity
@@ -305,7 +306,7 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
                     // frustum culling on rendering.
                     bool success;
                     AACube entityCube = entity->getQueryAACube(success);
-                    if (!success || !params.viewFrustum->cubeIntersectsKeyhole(entityCube)) {
+                    if (!success || !params.viewFrustum.cubeIntersectsKeyhole(entityCube)) {
                         includeThisEntity = false; // out of view, don't include it
                     } else {
                         // Check the size of the entity, it's possible that a "too small to see" entity is included in a
@@ -322,9 +323,10 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
                             // AABox.  If this happens, fall back to the queryAACube.
                             entityBounds = AABox(entityCube);
                         }
-                        auto renderAccuracy = params.viewFrustum->calculateRenderAccuracy(entityBounds,
-                                                                                          params.octreeElementSizeScale,
-                                                                                          params.boundaryLevelAdjust);
+                        auto renderAccuracy = calculateRenderAccuracy(params.viewFrustum.getPosition(),
+                                                                      entityBounds,
+                                                                      params.octreeElementSizeScale,
+                                                                      params.boundaryLevelAdjust);
                         if (renderAccuracy <= 0.0f) {
                             includeThisEntity = false; // too small, don't include it
 

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -33,6 +33,7 @@
 #include <QString>
 
 #include <GeometryUtil.h>
+#include <Gzip.h>
 #include <LogHandler.h>
 #include <NetworkAccessManager.h>
 #include <OctalCode.h>
@@ -40,12 +41,12 @@
 #include <ResourceManager.h>
 #include <SharedUtil.h>
 #include <PathUtils.h>
-#include <Gzip.h>
+#include <ViewFrustum.h>
 
 #include "OctreeConstants.h"
 #include "OctreeElementBag.h"
 #include "Octree.h"
-#include "ViewFrustum.h"
+#include "OctreeUtils.h"
 #include "OctreeLogging.h"
 
 
@@ -898,7 +899,7 @@ int Octree::encodeTreeBitstream(OctreeElementPointer element,
     }
 
     // If we're at a element that is out of view, then we can return, because no nodes below us will be in view!
-    if (params.viewFrustum && !element->isInView(*params.viewFrustum)) {
+    if (!params.recurseEverything && !element->isInView(params.viewFrustum)) {
         params.stopReason = EncodeBitstreamParams::OUT_OF_VIEW;
         return bytesWritten;
     }
@@ -1014,15 +1015,12 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
     }
 
     ViewFrustum::intersection nodeLocationThisView = ViewFrustum::INSIDE; // assume we're inside
-
-    // caller can pass NULL as viewFrustum if they want everything
-    if (params.viewFrustum) {
-        float distance = element->distanceToCamera(*params.viewFrustum);
+    if (!params.recurseEverything) {
         float boundaryDistance = boundaryDistanceForRenderLevel(element->getLevel() + params.boundaryLevelAdjust,
                                         params.octreeElementSizeScale);
 
         // If we're too far away for our render level, then just return
-        if (distance >= boundaryDistance) {
+        if (element->distanceToCamera(params.viewFrustum) >= boundaryDistance) {
             if (params.stats) {
                 params.stats->skippedDistance(element);
             }
@@ -1034,7 +1032,7 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
         // if we are INSIDE, INTERSECT, or OUTSIDE
         if (parentLocationThisView != ViewFrustum::INSIDE) {
             assert(parentLocationThisView != ViewFrustum::OUTSIDE); // we shouldn't be here if our parent was OUTSIDE!
-            nodeLocationThisView = element->computeViewIntersection(*params.viewFrustum);
+            nodeLocationThisView = element->computeViewIntersection(params.viewFrustum);
         }
 
         // If we're at a element that is out of view, then we can return, because no nodes below us will be in view!
@@ -1052,8 +1050,8 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
         // because we don't send nodes from the previously know in view frustum.
         bool wasInView = false;
 
-        if (params.deltaViewFrustum && params.lastViewFrustum) {
-            ViewFrustum::intersection location = element->computeViewIntersection(*params.lastViewFrustum);
+        if (params.deltaView) {
+            ViewFrustum::intersection location = element->computeViewIntersection(params.lastViewFrustum);
 
             // If we're a leaf, then either intersect or inside is considered "formerly in view"
             if (element->isLeaf()) {
@@ -1067,10 +1065,9 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
             // to it, and so therefore it may now be visible from an LOD perspective, in which case we don't consider it
             // as "was in view"...
             if (wasInView) {
-                float distance = element->distanceToCamera(*params.lastViewFrustum);
                 float boundaryDistance = boundaryDistanceForRenderLevel(element->getLevel() + params.boundaryLevelAdjust,
                                                                             params.octreeElementSizeScale);
-                if (distance >= boundaryDistance) {
+                if (element->distanceToCamera(params.lastViewFrustum) >= boundaryDistance) {
                     // This would have been invisible... but now should be visible (we wouldn't be here otherwise)...
                     wasInView = false;
                 }
@@ -1078,9 +1075,9 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
         }
 
         // If we were previously in the view, then we normally will return out of here and stop recursing. But
-        // if we're in deltaViewFrustum mode, and this element has changed since it was last sent, then we do
+        // if we're in deltaView mode, and this element has changed since it was last sent, then we do
         // need to send it.
-        if (wasInView && !(params.deltaViewFrustum && element->hasChangedSince(params.lastViewFrustumSent - CHANGE_FUDGE))) {
+        if (wasInView && !(params.deltaView && element->hasChangedSince(params.lastViewFrustumSent - CHANGE_FUDGE))) {
             if (params.stats) {
                 params.stats->skippedWasInView(element);
             }
@@ -1090,7 +1087,7 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
 
         // If we're not in delta sending mode, and we weren't asked to do a force send, and the voxel hasn't changed,
         // then we can also bail early and save bits
-        if (!params.forceSendScene && !params.deltaViewFrustum &&
+        if (!params.forceSendScene && !params.deltaView &&
             !element->hasChangedSince(params.lastViewFrustumSent - CHANGE_FUDGE)) {
             if (params.stats) {
                 params.stats->skippedNoChange(element);
@@ -1179,10 +1176,10 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
         int originalIndex = indexOfChildren[i];
 
         bool childIsInView  = (childElement &&
-                ( !params.viewFrustum || // no view frustum was given, everything is assumed in view
-                  (nodeLocationThisView == ViewFrustum::INSIDE) || // parent was fully in view, we can assume ALL children are
+                (params.recurseEverything ||
+                 (nodeLocationThisView == ViewFrustum::INSIDE) || // parent was fully in view, we can assume ALL children are
                   (nodeLocationThisView == ViewFrustum::INTERSECT &&
-                        childElement->isInView(*params.viewFrustum)) // the parent intersects and the child is in view
+                        childElement->isInView(params.viewFrustum)) // the parent intersects and the child is in view
                 ));
 
         if (!childIsInView) {
@@ -1192,12 +1189,11 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
             }
         } else {
             // Before we consider this further, let's see if it's in our LOD scope...
-            float distance = distancesToChildren[i];
-            float boundaryDistance = !params.viewFrustum ? 1 :
-                                     boundaryDistanceForRenderLevel(childElement->getLevel() + params.boundaryLevelAdjust,
+            float boundaryDistance = params.recurseEverything ? 1 :
+                                    boundaryDistanceForRenderLevel(childElement->getLevel() + params.boundaryLevelAdjust,
                                             params.octreeElementSizeScale);
 
-            if (!(distance < boundaryDistance)) {
+            if (!(distancesToChildren[i] < boundaryDistance)) {
                 // don't need to check childElement here, because we can't get here with no childElement
                 if (params.stats) {
                     params.stats->skippedDistance(childElement);
@@ -1215,10 +1211,9 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
 
                 bool childIsOccluded = false; // assume it's not occluded
 
-                bool shouldRender = !params.viewFrustum
-                                    ? true
-                                    : childElement->calculateShouldRender(params.viewFrustum,
-                                                    params.octreeElementSizeScale, params.boundaryLevelAdjust);
+                bool shouldRender = params.recurseEverything ||
+                        childElement->calculateShouldRender(params.viewFrustum,
+                                params.octreeElementSizeScale, params.boundaryLevelAdjust);
 
                 // track some stats
                 if (params.stats) {
@@ -1236,8 +1231,8 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
                 if (shouldRender && !childIsOccluded) {
                     bool childWasInView = false;
 
-                    if (childElement && params.deltaViewFrustum && params.lastViewFrustum) {
-                        ViewFrustum::intersection location = childElement->computeViewIntersection(*params.lastViewFrustum);
+                    if (childElement && params.deltaView) {
+                        ViewFrustum::intersection location = childElement->computeViewIntersection(params.lastViewFrustum);
 
                         // If we're a leaf, then either intersect or inside is considered "formerly in view"
                         if (childElement->isLeaf()) {
@@ -1251,7 +1246,7 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
                     // Or if we were previously in the view, but this element has changed since it was last sent, then we do
                     // need to send it.
                     if (!childWasInView ||
-                        (params.deltaViewFrustum &&
+                        (params.deltaView &&
                          childElement->hasChangedSince(params.lastViewFrustumSent - CHANGE_FUDGE))){
 
                         childrenDataBits += (1 << (7 - originalIndex));
@@ -1456,7 +1451,7 @@ int Octree::encodeTreeBitstreamRecursion(OctreeElementPointer element,
                 // called databits), then we wouldn't send the children. So those types of Octree's should tell us to keep
                 // recursing, by returning TRUE in recurseChildrenWithData().
 
-                if (recurseChildrenWithData() || !params.viewFrustum || !oneAtBit(childrenDataBits, originalIndex)) {
+                if (params.recurseEverything || recurseChildrenWithData() || !oneAtBit(childrenDataBits, originalIndex)) {
 
                     // Allow the datatype a chance to determine if it really wants to recurse this tree. Usually this
                     // will be true. But if the tree has already been encoded, we will skip this.
@@ -1978,7 +1973,8 @@ void Octree::writeToSVOFile(const char* fileName, OctreeElementPointer element) 
         bool lastPacketWritten = false;
 
         while (OctreeElementPointer subTree = elementBag.extract()) {
-            EncodeBitstreamParams params(INT_MAX, IGNORE_VIEW_FRUSTUM, NO_EXISTS_BITS);
+            EncodeBitstreamParams params(INT_MAX, NO_EXISTS_BITS);
+            params.recurseEverything = true;
             withReadLock([&] {
                 params.extraEncodeData = &extraEncodeData;
                 bytesWritten = encodeTreeBitstream(subTree, &packetData, elementBag, params);

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -20,9 +20,9 @@
 
 #include <shared/ReadWriteLockable.h>
 #include <SimpleMovingAverage.h>
+#include <ViewFrustum.h>
 
 #include "JurisdictionMap.h"
-#include "ViewFrustum.h"
 #include "OctreeElement.h"
 #include "OctreeElementBag.h"
 #include "OctreePacketData.h"
@@ -61,22 +61,22 @@ const int LOW_RES_MOVING_ADJUST  = 1;
 const quint64 IGNORE_LAST_SENT  = 0;
 
 #define IGNORE_SCENE_STATS       NULL
-#define IGNORE_VIEW_FRUSTUM      NULL
 #define IGNORE_COVERAGE_MAP      NULL
 #define IGNORE_JURISDICTION_MAP  NULL
 
 class EncodeBitstreamParams {
 public:
+    ViewFrustum viewFrustum;
+    ViewFrustum lastViewFrustum;
+    quint64 lastViewFrustumSent;
     int maxEncodeLevel;
     int maxLevelReached;
-    const ViewFrustum* viewFrustum;
     bool includeExistsBits;
     int chopLevels;
-    bool deltaViewFrustum;
-    const ViewFrustum* lastViewFrustum;
+    bool deltaView;
+    bool recurseEverything { false };
     int boundaryLevelAdjust;
     float octreeElementSizeScale;
-    quint64 lastViewFrustumSent;
     bool forceSendScene;
     OctreeSceneStats* stats;
     JurisdictionMap* jurisdictionMap;
@@ -99,11 +99,9 @@ public:
 
     EncodeBitstreamParams(
         int maxEncodeLevel = INT_MAX,
-        const ViewFrustum* viewFrustum = IGNORE_VIEW_FRUSTUM,
         bool includeExistsBits = WANT_EXISTS_BITS,
         int  chopLevels = 0,
-        bool deltaViewFrustum = false,
-        const ViewFrustum* lastViewFrustum = IGNORE_VIEW_FRUSTUM,
+        bool useDeltaView = false,
         int boundaryLevelAdjust = NO_BOUNDARY_ADJUST,
         float octreeElementSizeScale = DEFAULT_OCTREE_SIZE_SCALE,
         quint64 lastViewFrustumSent = IGNORE_LAST_SENT,
@@ -111,22 +109,24 @@ public:
         OctreeSceneStats* stats = IGNORE_SCENE_STATS,
         JurisdictionMap* jurisdictionMap = IGNORE_JURISDICTION_MAP,
         OctreeElementExtraEncodeData* extraEncodeData = NULL) :
+            viewFrustum(),
+            lastViewFrustum(),
+            lastViewFrustumSent(lastViewFrustumSent),
             maxEncodeLevel(maxEncodeLevel),
             maxLevelReached(0),
-            viewFrustum(viewFrustum),
             includeExistsBits(includeExistsBits),
             chopLevels(chopLevels),
-            deltaViewFrustum(deltaViewFrustum),
-            lastViewFrustum(lastViewFrustum),
+            deltaView(useDeltaView),
             boundaryLevelAdjust(boundaryLevelAdjust),
             octreeElementSizeScale(octreeElementSizeScale),
-            lastViewFrustumSent(lastViewFrustumSent),
             forceSendScene(forceSendScene),
             stats(stats),
             jurisdictionMap(jurisdictionMap),
             extraEncodeData(extraEncodeData),
             stopReason(UNKNOWN)
-    {}
+    {
+        lastViewFrustum.invalidate();
+    }
 
     void displayStopReason() {
         printf("StopReason: ");
@@ -341,7 +341,7 @@ public:
 
     bool getIsClient() const { return !_isServer; } /// Is this a client based tree. Allows guards for certain operations
     void setIsClient(bool isClient) { _isServer = !isClient; }
-    
+
     virtual void dumpTree() { }
     virtual void pruneTree() { }
 
@@ -351,7 +351,6 @@ public:
     virtual quint64 getAverageUpdateTime() const { return 0;  }
     virtual quint64 getAverageCreateTime() const { return 0;  }
     virtual quint64 getAverageLoggingTime() const { return 0;  }
-
 
 signals:
     void importSize(float x, float y, float z);

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -109,8 +109,6 @@ public:
         OctreeSceneStats* stats = IGNORE_SCENE_STATS,
         JurisdictionMap* jurisdictionMap = IGNORE_JURISDICTION_MAP,
         OctreeElementExtraEncodeData* extraEncodeData = NULL) :
-            viewFrustum(),
-            lastViewFrustum(),
             lastViewFrustumSent(lastViewFrustumSent),
             maxEncodeLevel(maxEncodeLevel),
             maxLevelReached(0),

--- a/libraries/octree/src/OctreeElement.cpp
+++ b/libraries/octree/src/OctreeElement.cpp
@@ -22,10 +22,11 @@
 
 #include "AACube.h"
 #include "OctalCode.h"
+#include "Octree.h"
 #include "OctreeConstants.h"
 #include "OctreeElement.h"
-#include "Octree.h"
 #include "OctreeLogging.h"
+#include "OctreeUtils.h"
 #include "SharedUtil.h"
 
 AtomicUIntStat OctreeElement::_octreeMemoryUsage { 0 };
@@ -471,11 +472,11 @@ ViewFrustum::intersection OctreeElement::computeViewIntersection(const ViewFrust
 //    Since, if we know the camera position and orientation, we can know which of the corners is the "furthest"
 //    corner. We can use we can use this corner as our "voxel position" to do our distance calculations off of.
 //    By doing this, we don't need to test each child voxel's position vs the LOD boundary
-bool OctreeElement::calculateShouldRender(const ViewFrustum* viewFrustum, float voxelScaleSize, int boundaryLevelAdjust) const {
+bool OctreeElement::calculateShouldRender(const ViewFrustum& viewFrustum, float voxelScaleSize, int boundaryLevelAdjust) const {
     bool shouldRender = false;
 
     if (hasContent()) {
-        float furthestDistance = furthestDistanceToCamera(*viewFrustum);
+        float furthestDistance = furthestDistanceToCamera(viewFrustum);
         float childBoundary = boundaryDistanceForRenderLevel(getLevel() + 1 + boundaryLevelAdjust, voxelScaleSize);
         bool inChildBoundary = (furthestDistance <= childBoundary);
         if (hasDetailedContent() && inChildBoundary) {

--- a/libraries/octree/src/OctreeElement.h
+++ b/libraries/octree/src/OctreeElement.h
@@ -21,9 +21,9 @@
 
 #include <OctalCode.h>
 #include <SharedUtil.h>
+#include <ViewFrustum.h>
 
 #include "AACube.h"
-#include "ViewFrustum.h"
 #include "OctreeConstants.h"
 
 using AtomicUIntStat = std::atomic<uintmax_t>;
@@ -139,7 +139,7 @@ public:
     float distanceToCamera(const ViewFrustum& viewFrustum) const;
     float furthestDistanceToCamera(const ViewFrustum& viewFrustum) const;
 
-    bool calculateShouldRender(const ViewFrustum* viewFrustum,
+    bool calculateShouldRender(const ViewFrustum& viewFrustum,
                 float voxelSizeScale = DEFAULT_OCTREE_SIZE_SCALE, int boundaryLevelAdjust = 0) const;
 
     // points are assumed to be in Voxel Coordinates (not TREE_SCALE'd)

--- a/libraries/octree/src/OctreeHeadlessViewer.cpp
+++ b/libraries/octree/src/OctreeHeadlessViewer.cpp
@@ -14,14 +14,12 @@
 #include "OctreeLogging.h"
 #include "OctreeHeadlessViewer.h"
 
-OctreeHeadlessViewer::OctreeHeadlessViewer() : OctreeRenderer()
-{
+OctreeHeadlessViewer::OctreeHeadlessViewer() : OctreeRenderer() {
     _viewFrustum.setProjection(glm::perspective(glm::radians(DEFAULT_FIELD_OF_VIEW_DEGREES), DEFAULT_ASPECT_RATIO, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP));
 }
 
 void OctreeHeadlessViewer::init() {
     OctreeRenderer::init();
-    setViewFrustum(&_viewFrustum);
 }
 
 void OctreeHeadlessViewer::queryOctree() {

--- a/libraries/octree/src/OctreeHeadlessViewer.h
+++ b/libraries/octree/src/OctreeHeadlessViewer.h
@@ -14,6 +14,7 @@
 
 #include <udt/PacketHeaders.h>
 #include <SharedUtil.h>
+#include <ViewFrustum.h>
 
 #include "JurisdictionListener.h"
 #include "Octree.h"
@@ -22,7 +23,6 @@
 #include "OctreeRenderer.h"
 #include "OctreeSceneStats.h"
 #include "Octree.h"
-#include "ViewFrustum.h"
 
 // Generic client side Octree renderer class.
 class OctreeHeadlessViewer : public OctreeRenderer {
@@ -66,7 +66,6 @@ public slots:
     unsigned getOctreeElementsCount() const { return _tree->getOctreeElementsCount(); }
 
 private:
-    ViewFrustum _viewFrustum;
     JurisdictionListener* _jurisdictionListener = nullptr;
     OctreeQuery _octreeQuery;
 

--- a/libraries/octree/src/OctreeQuery.cpp
+++ b/libraries/octree/src/OctreeQuery.cpp
@@ -120,4 +120,3 @@ glm::vec3 OctreeQuery::calculateCameraDirection() const {
     glm::vec3 direction = glm::vec3(_cameraOrientation * glm::vec4(IDENTITY_FRONT, 0.0f));
     return direction;
 }
-

--- a/libraries/octree/src/OctreeRenderer.cpp
+++ b/libraries/octree/src/OctreeRenderer.cpp
@@ -23,7 +23,7 @@
 OctreeRenderer::OctreeRenderer() :
     _tree(NULL),
     _managedTree(false),
-    _viewFrustum(NULL)
+    _viewFrustum()
 {
 }
 
@@ -201,9 +201,9 @@ void OctreeRenderer::processDatagram(ReceivedMessage& message, SharedNodePointer
 
 bool OctreeRenderer::renderOperation(OctreeElementPointer element, void* extraData) {
     RenderArgs* args = static_cast<RenderArgs*>(extraData);
-    if (element->isInView(*args->_viewFrustum)) {
+    if (element->isInView(args->getViewFrustum())) {
         if (element->hasContent()) {
-            if (element->calculateShouldRender(args->_viewFrustum, args->_sizeScale, args->_boundaryLevelAdjust)) {
+            if (element->calculateShouldRender(args->getViewFrustum(), args->_sizeScale, args->_boundaryLevelAdjust)) {
                 args->_renderer->renderElement(element, args);
             } else {
                 return false; // if we shouldn't render, then we also should stop recursing.

--- a/libraries/octree/src/OctreeRenderer.cpp
+++ b/libraries/octree/src/OctreeRenderer.cpp
@@ -22,8 +22,7 @@
 
 OctreeRenderer::OctreeRenderer() :
     _tree(NULL),
-    _managedTree(false),
-    _viewFrustum()
+    _managedTree(false)
 {
 }
 

--- a/libraries/octree/src/OctreeRenderer.h
+++ b/libraries/octree/src/OctreeRenderer.h
@@ -51,8 +51,8 @@ public:
     /// render the content of the octree
     virtual void render(RenderArgs* renderArgs);
 
-    ViewFrustum* getViewFrustum() const { return _viewFrustum; }
-    void setViewFrustum(ViewFrustum* viewFrustum) { _viewFrustum = viewFrustum; }
+    const ViewFrustum* getViewFrustum() const { return _viewFrustum; }
+    void setViewFrustum(const ViewFrustum* viewFrustum) { _viewFrustum = viewFrustum; }
 
     static bool renderOperation(OctreeElementPointer element, void* extraData);
 
@@ -75,7 +75,7 @@ protected:
 
     OctreePointer _tree;
     bool _managedTree;
-    ViewFrustum* _viewFrustum;
+    const ViewFrustum* _viewFrustum;
 
     SimpleMovingAverage _elementsPerPacket;
     SimpleMovingAverage _entitiesPerPacket;

--- a/libraries/octree/src/OctreeRenderer.h
+++ b/libraries/octree/src/OctreeRenderer.h
@@ -20,10 +20,10 @@
 #include <udt/PacketHeaders.h>
 #include <RenderArgs.h>
 #include <SharedUtil.h>
+#include <ViewFrustum.h>
 
 #include "Octree.h"
 #include "OctreePacketData.h"
-#include "ViewFrustum.h"
 
 class OctreeRenderer;
 
@@ -51,8 +51,8 @@ public:
     /// render the content of the octree
     virtual void render(RenderArgs* renderArgs);
 
-    const ViewFrustum* getViewFrustum() const { return _viewFrustum; }
-    void setViewFrustum(const ViewFrustum* viewFrustum) { _viewFrustum = viewFrustum; }
+    const ViewFrustum& getViewFrustum() const { return _viewFrustum; }
+    void setViewFrustum(const ViewFrustum& viewFrustum) { _viewFrustum = viewFrustum; }
 
     static bool renderOperation(OctreeElementPointer element, void* extraData);
 
@@ -75,7 +75,7 @@ protected:
 
     OctreePointer _tree;
     bool _managedTree;
-    const ViewFrustum* _viewFrustum;
+    ViewFrustum _viewFrustum;
 
     SimpleMovingAverage _elementsPerPacket;
     SimpleMovingAverage _entitiesPerPacket;

--- a/libraries/octree/src/OctreeUtils.cpp
+++ b/libraries/octree/src/OctreeUtils.cpp
@@ -1,0 +1,71 @@
+//
+//  OctreeUtils.cpp
+//  libraries/octree/src
+//
+//  Created by Andrew Meadows 2016.03.04
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "OctreeUtils.h"
+
+#include <mutex>
+
+#include <glm/glm.hpp>
+
+#include <AABox.h>
+
+
+float calculateRenderAccuracy(const glm::vec3& position,
+        const AABox& bounds,
+        float octreeSizeScale,
+        int boundaryLevelAdjust) {
+    float largestDimension = bounds.getLargestDimension();
+
+    const float maxScale = (float)TREE_SCALE;
+    float visibleDistanceAtMaxScale = boundaryDistanceForRenderLevel(boundaryLevelAdjust, octreeSizeScale) / OCTREE_TO_MESH_RATIO;
+
+    static std::once_flag once;
+    static QMap<float, float> shouldRenderTable;
+    std::call_once(once, [&] {
+        float SMALLEST_SCALE_IN_TABLE = 0.001f; // 1mm is plenty small
+        float scale = maxScale;
+        float factor = 1.0f;
+
+        while (scale > SMALLEST_SCALE_IN_TABLE) {
+            scale /= 2.0f;
+            factor /= 2.0f;
+            shouldRenderTable[scale] = factor;
+        }
+    });
+
+    float closestScale = maxScale;
+    float visibleDistanceAtClosestScale = visibleDistanceAtMaxScale;
+    QMap<float, float>::const_iterator lowerBound = shouldRenderTable.lowerBound(largestDimension);
+    if (lowerBound != shouldRenderTable.constEnd()) {
+        closestScale = lowerBound.key();
+        visibleDistanceAtClosestScale = visibleDistanceAtMaxScale * lowerBound.value();
+    }
+
+    if (closestScale < largestDimension) {
+        visibleDistanceAtClosestScale *= 2.0f;
+    }
+
+    // FIXME - for now, it's either visible or not visible. We want to adjust this to eventually return
+    // a floating point for objects that have small angular size to indicate that they may be rendered
+    // with lower preciscion
+    float distanceToCamera = glm::length(bounds.calcCenter() - position);
+    return (distanceToCamera <= visibleDistanceAtClosestScale) ? 1.0f : 0.0f;
+}
+
+float boundaryDistanceForRenderLevel(unsigned int renderLevel, float voxelSizeScale) {
+    return voxelSizeScale / powf(2.0f, renderLevel);
+}
+
+float getAccuracyAngle(float octreeSizeScale, int boundaryLevelAdjust) {
+    const float maxScale = (float)TREE_SCALE;
+    float visibleDistanceAtMaxScale = boundaryDistanceForRenderLevel(boundaryLevelAdjust, octreeSizeScale) / OCTREE_TO_MESH_RATIO;
+    return atan(maxScale / visibleDistanceAtMaxScale);
+}

--- a/libraries/octree/src/OctreeUtils.h
+++ b/libraries/octree/src/OctreeUtils.h
@@ -1,0 +1,30 @@
+//
+//  OctreeUtils.h
+//  libraries/octree/src
+//
+//  Created by Andrew Meadows 2016.03.04
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_OctreeUtils_h
+#define hifi_OctreeUtils_h
+
+#include "OctreeConstants.h"
+
+class AABox;
+
+/// renderAccuracy represents a floating point "visibility" of an object based on it's view from the camera. At a simple
+/// level it returns 0.0f for things that are so small for the current settings that they could not be visible.
+float calculateRenderAccuracy(const glm::vec3& position,
+        const AABox& bounds,
+        float octreeSizeScale = DEFAULT_OCTREE_SIZE_SCALE,
+        int boundaryLevelAdjust = 0);
+
+float boundaryDistanceForRenderLevel(unsigned int renderLevel, float voxelSizeScale);
+
+float getAccuracyAngle(float octreeSizeScale, int boundaryLevelAdjust);
+
+#endif // hifi_OctreeUtils_h

--- a/libraries/octree/src/ViewFrustum.cpp
+++ b/libraries/octree/src/ViewFrustum.cpp
@@ -268,55 +268,6 @@ bool testMatches(float lhs, float rhs, float epsilon = EPSILON) {
     return (fabs(lhs - rhs) <= epsilon);
 }
 
-bool ViewFrustum::matches(const ViewFrustum& compareTo, bool debug) const {
-    bool result =
-           testMatches(compareTo._position, _position) &&
-           testMatches(compareTo._direction, _direction) &&
-           testMatches(compareTo._up, _up) &&
-           testMatches(compareTo._right, _right) &&
-           testMatches(compareTo._fieldOfView, _fieldOfView) &&
-           testMatches(compareTo._aspectRatio, _aspectRatio) &&
-           testMatches(compareTo._nearClip, _nearClip) &&
-           testMatches(compareTo._farClip, _farClip) &&
-           testMatches(compareTo._focalLength, _focalLength);
-
-    if (!result && debug) {
-        qCDebug(octree, "ViewFrustum::matches()... result=%s", debug::valueOf(result));
-        qCDebug(octree, "%s -- compareTo._position=%f,%f,%f _position=%f,%f,%f",
-                (testMatches(compareTo._position,_position) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._position.x, (double)compareTo._position.y, (double)compareTo._position.z,
-                (double)_position.x, (double)_position.y, (double)_position.z);
-        qCDebug(octree, "%s -- compareTo._direction=%f,%f,%f _direction=%f,%f,%f",
-                (testMatches(compareTo._direction, _direction) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._direction.x, (double)compareTo._direction.y, (double)compareTo._direction.z,
-                (double)_direction.x, (double)_direction.y, (double)_direction.z );
-        qCDebug(octree, "%s -- compareTo._up=%f,%f,%f _up=%f,%f,%f",
-                (testMatches(compareTo._up, _up) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._up.x, (double)compareTo._up.y, (double)compareTo._up.z,
-                (double)_up.x, (double)_up.y, (double)_up.z );
-        qCDebug(octree, "%s -- compareTo._right=%f,%f,%f _right=%f,%f,%f",
-                (testMatches(compareTo._right, _right) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._right.x, (double)compareTo._right.y, (double)compareTo._right.z,
-                (double)_right.x, (double)_right.y, (double)_right.z );
-        qCDebug(octree, "%s -- compareTo._fieldOfView=%f _fieldOfView=%f",
-                (testMatches(compareTo._fieldOfView, _fieldOfView) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._fieldOfView, (double)_fieldOfView);
-        qCDebug(octree, "%s -- compareTo._aspectRatio=%f _aspectRatio=%f",
-                (testMatches(compareTo._aspectRatio, _aspectRatio) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._aspectRatio, (double)_aspectRatio);
-        qCDebug(octree, "%s -- compareTo._nearClip=%f _nearClip=%f",
-                (testMatches(compareTo._nearClip, _nearClip) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._nearClip, (double)_nearClip);
-        qCDebug(octree, "%s -- compareTo._farClip=%f _farClip=%f",
-                (testMatches(compareTo._farClip, _farClip) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._farClip, (double)_farClip);
-        qCDebug(octree, "%s -- compareTo._focalLength=%f _focalLength=%f",
-                (testMatches(compareTo._focalLength, _focalLength) ? "MATCHES " : "NO MATCH"),
-                (double)compareTo._focalLength, (double)_focalLength);
-    }
-    return result;
-}
-
 bool ViewFrustum::isVerySimilar(const ViewFrustum& compareTo, bool debug) const {
 
     //  Compute distance between the two positions

--- a/libraries/octree/src/ViewFrustum.cpp
+++ b/libraries/octree/src/ViewFrustum.cpp
@@ -630,7 +630,7 @@ void ViewFrustum::getFurthestPointFromCamera(const AACube& box, glm::vec3& furth
     }
 }
 
-const ViewFrustum::Corners ViewFrustum::getCorners(const float& depth) {
+const ViewFrustum::Corners ViewFrustum::getCorners(const float& depth) const {
     glm::vec3 normal = glm::normalize(_direction);
 
     auto getCorner = [&](enum::BoxVertex nearCorner, enum::BoxVertex farCorner) {

--- a/libraries/octree/src/ViewFrustum.h
+++ b/libraries/octree/src/ViewFrustum.h
@@ -74,7 +74,7 @@ public:
         glm::vec3 bottomRight;
     // Get the corners depth units from frustum position, along frustum orientation
     };
-    const Corners getCorners(const float& depth);
+    const Corners getCorners(const float& depth) const;
 
     // getters for corners
     const glm::vec3& getFarTopLeft() const { return _cornersWorld[TOP_LEFT_FAR]; }

--- a/libraries/octree/src/ViewFrustum.h
+++ b/libraries/octree/src/ViewFrustum.h
@@ -107,10 +107,6 @@ public:
     bool cubeIntersectsKeyhole(const AACube& cube) const;
     bool boxIntersectsKeyhole(const AABox& box) const;
 
-    // some frustum comparisons
-    bool matches(const ViewFrustum& compareTo, bool debug = false) const;
-    bool matches(const ViewFrustum* compareTo, bool debug = false) const { return matches(*compareTo, debug); }
-
     bool isVerySimilar(const ViewFrustum& compareTo, bool debug = false) const;
     bool isVerySimilar(const ViewFrustum* compareTo, bool debug = false) const { return isVerySimilar(*compareTo, debug); }
 

--- a/libraries/octree/src/ViewFrustum.h
+++ b/libraries/octree/src/ViewFrustum.h
@@ -122,8 +122,6 @@ public:
 
     void printDebugDetails() const;
 
-    glm::vec2 projectPoint(glm::vec3 point, bool& pointInView) const;
-    OctreeProjectedPolygon getProjectedPolygon(const AACube& box) const;
     void getFurthestPointFromCamera(const AACube& box, glm::vec3& furthestPoint) const;
 
     float distanceToCamera(const glm::vec3& point) const;

--- a/libraries/render-utils/src/AbstractViewStateInterface.h
+++ b/libraries/render-utils/src/AbstractViewStateInterface.h
@@ -28,11 +28,11 @@ class PickRay;
 /// Interface provided by Application to other objects that need access to the current view state details
 class AbstractViewStateInterface {
 public:
-    /// gets the current view frustum for rendering the view state
-    virtual const ViewFrustum& getCurrentViewFrustum() = 0;
+    /// copies the current view frustum for rendering the view state
+    virtual void copyCurrentViewFrustum(ViewFrustum& viewOut) const = 0;
 
-    /// gets the shadow view frustum for rendering the view state
-    virtual const ViewFrustum& getShadowViewFrustum() = 0;
+    /// copies the shadow view frustum for rendering the view state
+    virtual void copyShadowViewFrustum(ViewFrustum& viewOut) const = 0;
 
     virtual QThread* getMainThread() = 0;
 

--- a/libraries/render-utils/src/AbstractViewStateInterface.h
+++ b/libraries/render-utils/src/AbstractViewStateInterface.h
@@ -29,13 +29,13 @@ class PickRay;
 class AbstractViewStateInterface {
 public:
     /// gets the current view frustum for rendering the view state
-    virtual ViewFrustum* getCurrentViewFrustum() = 0;
+    virtual const ViewFrustum& getCurrentViewFrustum() = 0;
 
     /// gets the shadow view frustum for rendering the view state
-    virtual ViewFrustum* getShadowViewFrustum() = 0;
+    virtual const ViewFrustum& getShadowViewFrustum() = 0;
 
     virtual QThread* getMainThread() = 0;
-    
+
     virtual PickRay computePickRay(float x, float y) const = 0;
 
     virtual glm::vec3 getAvatarPosition() const = 0;

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -284,7 +284,7 @@ void AmbientOcclusionEffect::updateGaussianDistribution() {
 
 void AmbientOcclusionEffect::run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     RenderArgs* args = renderContext->args;
 
@@ -309,7 +309,7 @@ void AmbientOcclusionEffect::run(const render::SceneContextPointer& sceneContext
     auto resolutionLevel = getResolutionLevel();
 
     // Update the depth info with near and far (same for stereo)
-    setDepthInfo(args->_viewFrustum->getNearClip(), args->_viewFrustum->getFarClip());
+    setDepthInfo(args->getViewFrustum().getNearClip(), args->getViewFrustum().getFarClip());
 
     _frameTransformBuffer.edit<FrameTransform>().pixelInfo = args->_viewport;
     //_parametersBuffer.edit<Parameters>()._ditheringInfo.y += 0.25f;
@@ -319,7 +319,7 @@ void AmbientOcclusionEffect::run(const render::SceneContextPointer& sceneContext
     if (!isStereo) {
         // Eval the mono projection
         mat4 monoProjMat;
-        args->_viewFrustum->evalProjectionMatrix(monoProjMat);
+        args->getViewFrustum().evalProjectionMatrix(monoProjMat);
         _frameTransformBuffer.edit<FrameTransform>().projection[0] = monoProjMat;
         _frameTransformBuffer.edit<FrameTransform>().stereoInfo = glm::vec4(0.0f, (float)args->_viewport.z, 0.0f, 0.0f);
 
@@ -365,7 +365,7 @@ void AmbientOcclusionEffect::run(const render::SceneContextPointer& sceneContext
 
         // Pyramid pass
         batch.setFramebuffer(pyramidFBO);
-        batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, glm::vec4(args->_viewFrustum->getFarClip(), 0.0f, 0.0f, 0.0f));
+        batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, glm::vec4(args->getViewFrustum().getFarClip(), 0.0f, 0.0f, 0.0f));
         batch.setPipeline(pyramidPipeline);
         batch.setResourceTexture(AmbientOcclusionEffect_DepthMapSlot, depthBuffer);
         batch.draw(gpu::TRIANGLE_STRIP, 4);

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -94,7 +94,7 @@ const gpu::PipelinePointer& Antialiasing::getBlendPipeline() {
 
 void Antialiasing::run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     RenderArgs* args = renderContext->args;
 
@@ -118,8 +118,8 @@ void Antialiasing::run(const render::SceneContextPointer& sceneContext, const re
 
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);
         batch.setModelTransform(Transform());
@@ -134,7 +134,7 @@ void Antialiasing::run(const render::SceneContextPointer& sceneContext, const re
         float left, right, bottom, top, nearVal, farVal;
         glm::vec4 nearClipPlane, farClipPlane;
 
-        args->_viewFrustum->computeOffAxisFrustum(left, right, bottom, top, nearVal, farVal, nearClipPlane, farClipPlane);
+        args->getViewFrustum().computeOffAxisFrustum(left, right, bottom, top, nearVal, farVal, nearClipPlane, farClipPlane);
 
         // float depthScale = (farVal - nearVal) / farVal;
         // float nearScale = -1.0f / nearVal;

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -275,7 +275,7 @@ void DebugDeferredBuffer::configure(const Config& config) {
 
 void DebugDeferredBuffer::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
 
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
@@ -283,20 +283,20 @@ void DebugDeferredBuffer::run(const SceneContextPointer& sceneContext, const Ren
         const auto framebufferCache = DependencyManager::get<FramebufferCache>();
         const auto textureCache = DependencyManager::get<TextureCache>();
         const auto& lightStage = DependencyManager::get<DeferredLightingEffect>()->getLightStage();
-        
+
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);
         batch.setModelTransform(Transform());
 
         // TODO REMOVE: Temporary until UI
         auto first = _customPipelines.begin()->first;
-        
+
         batch.setPipeline(getPipeline(_mode, first));
-        
+
         batch.setResourceTexture(Albedo, framebufferCache->getDeferredColorTexture());
         batch.setResourceTexture(Normal, framebufferCache->getDeferredNormalTexture());
         batch.setResourceTexture(Specular, framebufferCache->getDeferredSpecularTexture());

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -218,15 +218,15 @@ void DeferredLightingEffect::render(const render::RenderContextPointer& renderCo
         float tHeight = args->_viewport.w / (float)framebufferSize.height();
 
         // The view frustum is the mono frustum base
-        auto viewFrustum = args->_viewFrustum;
+        auto viewFrustum = args->getViewFrustum();
 
         // Eval the mono projection
         mat4 monoProjMat;
-        viewFrustum->evalProjectionMatrix(monoProjMat);
+        viewFrustum.evalProjectionMatrix(monoProjMat);
 
         // The mono view transform
         Transform monoViewTransform;
-        viewFrustum->evalViewTransform(monoViewTransform);
+        viewFrustum.evalViewTransform(monoViewTransform);
 
         // THe mono view matrix coming from the mono view transform
         glm::mat4 monoViewMat;
@@ -296,8 +296,8 @@ void DeferredLightingEffect::render(const render::RenderContextPointer& renderCo
             fetchTexcoordRects[0] = glm::vec4(sMin, tMin, sWidth, tHeight);
         }
 
-        auto eyePoint = viewFrustum->getPosition();
-        float nearRadius = glm::distance(eyePoint, viewFrustum->getNearTopLeft());
+        auto eyePoint = viewFrustum.getPosition();
+        float nearRadius = glm::distance(eyePoint, viewFrustum.getNearTopLeft());
 
 
         for (int side = 0; side < numPasses; side++) {

--- a/libraries/render-utils/src/HitEffect.cpp
+++ b/libraries/render-utils/src/HitEffect.cpp
@@ -62,19 +62,19 @@ const gpu::PipelinePointer& HitEffect::getHitEffectPipeline() {
 
 void HitEffect::run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
 
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
-    
+
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);
         batch.setModelTransform(Transform());
-    
+
         batch.setPipeline(getHitEffectPipeline());
 
         glm::vec4 color(0.0f, 0.0f, 0.0f, 1.0f);

--- a/libraries/render-utils/src/LightStage.cpp
+++ b/libraries/render-utils/src/LightStage.cpp
@@ -20,7 +20,7 @@ LightStage::Shadow::Shadow(model::LightPointer light) : _light{ light}, _frustum
     _schemaBuffer = std::make_shared<gpu::Buffer>(sizeof(Schema), (const gpu::Byte*) &schema);
 }
 
-void LightStage::Shadow::setKeylightFrustum(ViewFrustum* viewFrustum, float nearDepth, float farDepth) {
+void LightStage::Shadow::setKeylightFrustum(const ViewFrustum* viewFrustum, float nearDepth, float farDepth) {
     assert(nearDepth < farDepth);
 
     // Orient the keylight frustum
@@ -43,7 +43,6 @@ void LightStage::Shadow::setKeylightFrustum(ViewFrustum* viewFrustum, float near
     const Transform view{ _frustum->getView()};
     const Transform viewInverse{ view.getInverseMatrix() };
 
-    viewFrustum->calculate();
     auto nearCorners = viewFrustum->getCorners(nearDepth);
     auto farCorners = viewFrustum->getCorners(farDepth);
 

--- a/libraries/render-utils/src/LightStage.cpp
+++ b/libraries/render-utils/src/LightStage.cpp
@@ -20,7 +20,7 @@ LightStage::Shadow::Shadow(model::LightPointer light) : _light{ light}, _frustum
     _schemaBuffer = std::make_shared<gpu::Buffer>(sizeof(Schema), (const gpu::Byte*) &schema);
 }
 
-void LightStage::Shadow::setKeylightFrustum(const ViewFrustum* viewFrustum, float nearDepth, float farDepth) {
+void LightStage::Shadow::setKeylightFrustum(const ViewFrustum& viewFrustum, float nearDepth, float farDepth) {
     assert(nearDepth < farDepth);
 
     // Orient the keylight frustum
@@ -38,13 +38,13 @@ void LightStage::Shadow::setKeylightFrustum(const ViewFrustum* viewFrustum, floa
     _frustum->setOrientation(orientation);
 
     // Position the keylight frustum
-    _frustum->setPosition(viewFrustum->getPosition() - (nearDepth + farDepth)*direction);
+    _frustum->setPosition(viewFrustum.getPosition() - (nearDepth + farDepth)*direction);
 
     const Transform view{ _frustum->getView()};
     const Transform viewInverse{ view.getInverseMatrix() };
 
-    auto nearCorners = viewFrustum->getCorners(nearDepth);
-    auto farCorners = viewFrustum->getCorners(farDepth);
+    auto nearCorners = viewFrustum.getCorners(nearDepth);
+    auto farCorners = viewFrustum.getCorners(farDepth);
 
     vec3 min{ viewInverse.transform(nearCorners.bottomLeft) };
     vec3 max{ min };

--- a/libraries/render-utils/src/LightStage.h
+++ b/libraries/render-utils/src/LightStage.h
@@ -28,7 +28,7 @@ public:
 
         Shadow(model::LightPointer light);
 
-        void setKeylightFrustum(const ViewFrustum* viewFrustum, float nearDepth, float farDepth);
+        void setKeylightFrustum(const ViewFrustum& viewFrustum, float nearDepth, float farDepth);
 
         const std::shared_ptr<ViewFrustum> getFrustum() const { return _frustum; }
 

--- a/libraries/render-utils/src/LightStage.h
+++ b/libraries/render-utils/src/LightStage.h
@@ -28,7 +28,7 @@ public:
 
         Shadow(model::LightPointer light);
 
-        void setKeylightFrustum(ViewFrustum* viewFrustum, float nearDepth, float farDepth);
+        void setKeylightFrustum(const ViewFrustum* viewFrustum, float nearDepth, float farDepth);
 
         const std::shared_ptr<ViewFrustum> getFrustum() const { return _frustum; }
 

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -202,7 +202,7 @@ void DrawDeferred::run(const SceneContextPointer& sceneContext, const RenderCont
 
 void DrawStateSortDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemBounds& inItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
 
@@ -215,8 +215,8 @@ void DrawStateSortDeferred::run(const SceneContextPointer& sceneContext, const R
 
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
 
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -163,7 +163,7 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
 
 
     // Is it possible that we render without a viewFrustum ?
-    if (!(renderContext->args && renderContext->args->_viewFrustum)) {
+    if (!(renderContext->args && renderContext->args->hasViewFrustum())) {
         return;
     }
 
@@ -174,7 +174,7 @@ void RenderDeferredTask::run(const SceneContextPointer& sceneContext, const Rend
 
 void DrawDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemBounds& inItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
 
@@ -187,8 +187,8 @@ void DrawDeferred::run(const SceneContextPointer& sceneContext, const RenderCont
 
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
 
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);
@@ -240,7 +240,7 @@ DrawOverlay3D::DrawOverlay3D(bool opaque) :
 
 void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const render::ItemBounds& inItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
 
@@ -268,8 +268,8 @@ void DrawOverlay3D::run(const SceneContextPointer& sceneContext, const RenderCon
 
             glm::mat4 projMat;
             Transform viewMat;
-            args->_viewFrustum->evalProjectionMatrix(projMat);
-            args->_viewFrustum->evalViewTransform(viewMat);
+            args->getViewFrustum().evalProjectionMatrix(projMat);
+            args->getViewFrustum().evalViewTransform(viewMat);
 
             batch.setProjectionTransform(projMat);
             batch.setViewTransform(viewMat);
@@ -290,7 +290,7 @@ const gpu::PipelinePointer& DrawStencilDeferred::getOpaquePipeline() {
 
 void DrawStencilDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     // from the touched pixel generate the stencil buffer 
     RenderArgs* args = renderContext->args;
@@ -316,7 +316,7 @@ void DrawStencilDeferred::run(const SceneContextPointer& sceneContext, const Ren
 
 void DrawBackgroundDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemBounds& inItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     RenderArgs* args = renderContext->args;
     doInBatch(args->_context, [&](gpu::Batch& batch) {
@@ -334,8 +334,8 @@ void DrawBackgroundDeferred::run(const SceneContextPointer& sceneContext, const 
 
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
 
         batch.setProjectionTransform(projMat);
         batch.setViewTransform(viewMat);

--- a/libraries/render-utils/src/RenderShadowTask.cpp
+++ b/libraries/render-utils/src/RenderShadowTask.cpp
@@ -146,7 +146,7 @@ void RenderShadowTask::run(const SceneContextPointer& sceneContext, const render
     }
 
     // Cache old render args
-    ViewFrustum* viewFrustum = args->_viewFrustum;
+    const ViewFrustum* viewFrustum = args->_viewFrustum;
     RenderArgs::RenderMode mode = args->_renderMode;
 
     auto nearClip = viewFrustum->getNearClip();

--- a/libraries/render/src/render/CullTask.cpp
+++ b/libraries/render/src/render/CullTask.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <assert.h>
 
+#include <OctreeUtils.h>
 #include <PerfStat.h>
 #include <ViewFrustum.h>
 #include <gpu/Context.h>
@@ -23,10 +24,10 @@ using namespace render;
 void render::cullItems(const RenderContextPointer& renderContext, const CullFunctor& cullFunctor, RenderDetails::Item& details,
                        const ItemBounds& inItems, ItemBounds& outItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     RenderArgs* args = renderContext->args;
-    const ViewFrustum* frustum = args->_viewFrustum;
+    const ViewFrustum& frustum = args->getViewFrustum();
 
     details._considered += (int)inItems.size();
 
@@ -42,7 +43,7 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
         bool inView;
         {
             PerformanceTimer perfTimer("boxIntersectsFrustum");
-            inView = frustum->boxIntersectsFrustum(item.bound);
+            inView = frustum.boxIntersectsFrustum(item.bound);
         }
         if (inView) {
             bool bigEnoughToRender;
@@ -64,7 +65,7 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
 
 void FetchNonspatialItems::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, ItemBounds& outItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     auto& scene = sceneContext->_scene;
 
     outItems.clear();
@@ -85,7 +86,7 @@ void FetchSpatialTree::configure(const Config& config) {
 
 void FetchSpatialTree::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, ItemSpatialTree::ItemSelection& outSelection) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
     auto& scene = sceneContext->_scene;
 
@@ -93,22 +94,18 @@ void FetchSpatialTree::run(const SceneContextPointer& sceneContext, const Render
     outSelection.clear();
 
     // Eventually use a frozen frustum
-    auto queryFrustum = *args->_viewFrustum;
+    auto queryFrustum = args->getViewFrustum();
     if (_freezeFrustum) {
         if (_justFrozeFrustum) {
             _justFrozeFrustum = false;
-            _frozenFrutstum = *args->_viewFrustum;
+            _frozenFrutstum = args->getViewFrustum();
         }
         queryFrustum = _frozenFrutstum;
     }
 
     // Octree selection!
-
-    float angle = glm::degrees(queryFrustum.getAccuracyAngle(args->_sizeScale, args->_boundaryLevelAdjust));
-
-
+    float angle = glm::degrees(getAccuracyAngle(args->_sizeScale, args->_boundaryLevelAdjust));
     scene->getSpatialTree().selectCellItems(outSelection, _filter, queryFrustum, angle);
-
 }
 
 void CullSpatialSelection::configure(const Config& config) {
@@ -120,7 +117,7 @@ void CullSpatialSelection::configure(const Config& config) {
 void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext,
     const ItemSpatialTree::ItemSelection& inSelection, ItemBounds& outItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
     auto& scene = sceneContext->_scene;
 
@@ -128,13 +125,12 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
     details._considered += (int)inSelection.numItems();
 
     // Eventually use a frozen frustum
-    auto argFrustum = args->_viewFrustum;
     if (_freezeFrustum) {
         if (_justFrozeFrustum) {
             _justFrozeFrustum = false;
-            _frozenFrutstum = *args->_viewFrustum;
+            _frozenFrutstum = args->getViewFrustum();
         }
-        args->_viewFrustum = &_frozenFrutstum; // replace the true view frustum by the frozen one
+        args->pushViewFrustum(_frozenFrutstum); // replace the true view frustum by the frozen one
     }
 
     // Culling Frustum / solidAngle test helper class
@@ -151,8 +147,8 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
             _renderDetails(renderDetails)
         {
             // FIXME: Keep this code here even though we don't use it yet
-            /*_eyePos = _args->_viewFrustum->getPosition();
-            float a = glm::degrees(_args->_viewFrustum->getAccuracyAngle(_args->_sizeScale, _args->_boundaryLevelAdjust));
+            /*_eyePos = _args->getViewFrustum().getPosition();
+            float a = glm::degrees(Octree::getAccuracyAngle(_args->_sizeScale, _args->_boundaryLevelAdjust));
             auto angle = std::min(glm::radians(45.0f), a); // no worse than 45 degrees
             angle = std::max(glm::radians(1.0f / 60.0f), a); // no better than 1 minute of degree
             auto tanAlpha = tan(angle);
@@ -161,7 +157,7 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
         }
 
         bool frustumTest(const AABox& bound) {
-            if (!_args->_viewFrustum->boxIntersectsFrustum(bound)) {
+            if (!_args->getViewFrustum().boxIntersectsFrustum(bound)) {
                 _renderDetails._outOfView++;
                 return false;
             }
@@ -305,7 +301,7 @@ void CullSpatialSelection::run(const SceneContextPointer& sceneContext, const Re
 
     // Restore frustum if using the frozen one:
     if (_freezeFrustum) {
-        args->_viewFrustum = argFrustum;
+        args->popViewFrustum();
     }
 
     std::static_pointer_cast<Config>(renderContext->jobConfig)->numItems = (int)outItems.size();

--- a/libraries/render/src/render/CullTask.cpp
+++ b/libraries/render/src/render/CullTask.cpp
@@ -26,7 +26,7 @@ void render::cullItems(const RenderContextPointer& renderContext, const CullFunc
     assert(renderContext->args->_viewFrustum);
 
     RenderArgs* args = renderContext->args;
-    ViewFrustum* frustum = args->_viewFrustum;
+    const ViewFrustum* frustum = args->_viewFrustum;
 
     details._considered += (int)inItems.size();
 

--- a/libraries/render/src/render/DrawSceneOctree.cpp
+++ b/libraries/render/src/render/DrawSceneOctree.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <assert.h>
 
+#include <OctreeUtils.h>
 #include <PerfStat.h>
 #include <RenderArgs.h>
 
@@ -86,7 +87,7 @@ void DrawSceneOctree::configure(const Config& config) {
 void DrawSceneOctree::run(const SceneContextPointer& sceneContext,
                           const RenderContextPointer& renderContext, const ItemSpatialTree::ItemSelection& inSelection) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
     auto& scene = sceneContext->_scene;
 
@@ -97,8 +98,8 @@ void DrawSceneOctree::run(const SceneContextPointer& sceneContext,
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
         batch.setViewportTransform(args->_viewport);
 
         batch.setProjectionTransform(projMat);
@@ -148,7 +149,7 @@ void DrawSceneOctree::run(const SceneContextPointer& sceneContext,
         }
         // Draw the LOD Reticle
         {
-            float angle = glm::degrees(args->_viewFrustum->getAccuracyAngle(args->_sizeScale, args->_boundaryLevelAdjust));
+            float angle = glm::degrees(getAccuracyAngle(args->_sizeScale, args->_boundaryLevelAdjust));
             Transform crosshairModel;
             crosshairModel.setTranslation(glm::vec3(0.0, 0.0, -1000.0));
             crosshairModel.setScale(1000.0 * tan(glm::radians(angle))); // Scaling at the actual tan of the lod angle => Multiplied by TWO
@@ -198,15 +199,15 @@ void DrawItemSelection::configure(const Config& config) {
 void DrawItemSelection::run(const SceneContextPointer& sceneContext,
     const RenderContextPointer& renderContext, const ItemSpatialTree::ItemSelection& inSelection) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
     auto& scene = sceneContext->_scene;
 
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
         batch.setViewportTransform(args->_viewport);
 
         batch.setProjectionTransform(projMat);

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -107,7 +107,7 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
                      const RenderContextPointer& renderContext,
                      const ItemBounds& inItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
     auto& scene = sceneContext->_scene;
     const int NUM_STATUS_VEC4_PER_ITEM = 2;
@@ -183,8 +183,8 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         glm::mat4 projMat;
         Transform viewMat;
-        args->_viewFrustum->evalProjectionMatrix(projMat);
-        args->_viewFrustum->evalViewTransform(viewMat);
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
         batch.setViewportTransform(args->_viewport);
 
         batch.setProjectionTransform(projMat);

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -120,7 +120,7 @@ void render::renderStateSortShapes(const SceneContextPointer& sceneContext, cons
 
 void DrawLight::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const ItemBounds& inLights) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
 
     // render lights

--- a/libraries/render/src/render/SortTask.cpp
+++ b/libraries/render/src/render/SortTask.cpp
@@ -1,5 +1,5 @@
 //
-//  CullTask.cpp
+//  SortTask.cpp
 //  render/src/render
 //
 //  Created by Sam Gateau on 2/2/16.

--- a/libraries/render/src/render/SortTask.cpp
+++ b/libraries/render/src/render/SortTask.cpp
@@ -42,7 +42,7 @@ struct BackToFrontSort {
 
 void render::depthSortItems(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, bool frontToBack, const ItemBounds& inItems, ItemBounds& outItems) {
     assert(renderContext->args);
-    assert(renderContext->args->_viewFrustum);
+    assert(renderContext->args->hasViewFrustum());
 
     auto& scene = sceneContext->_scene;
     RenderArgs* args = renderContext->args;
@@ -60,7 +60,7 @@ void render::depthSortItems(const SceneContextPointer& sceneContext, const Rende
     for (auto itemDetails : inItems) {
         auto item = scene->getItem(itemDetails.id);
         auto bound = itemDetails.bound; // item.getBound();
-        float distance = args->_viewFrustum->distanceToCamera(bound.calcCenter());
+        float distance = args->getViewFrustum().distanceToCamera(bound.calcCenter());
 
         itemBoundSorts.emplace_back(ItemBoundSort(distance, distance, distance, itemDetails.id, bound));
     }

--- a/libraries/shared/src/CubeProjectedPolygon.h
+++ b/libraries/shared/src/CubeProjectedPolygon.h
@@ -1,55 +1,55 @@
 //
-//  OctreeProjectedPolygon.h
-//  libraries/octree/src
+//  CubeProjectedPolygon.h
+//  libraries/shared/src
 //
 //  Created by Brad Hefta-Gaub on 06/11/13.
 //  Copyright 2013 High Fidelity, Inc.
 //
-//  The projected shadow (on the 2D view plane) for a voxel
+//  The projected shadow (on the 2D view plane) for a cube
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#ifndef hifi_OctreeProjectedPolygon_h
-#define hifi_OctreeProjectedPolygon_h
+#ifndef hifi_CubeProjectedPolygon_h
+#define hifi_CubeProjectedPolygon_h
 
 #include <glm/glm.hpp>
 
 // there's a max of 6 vertices of a project polygon, and a max of twice that when clipped to the screen
-const int MAX_PROJECTED_POLYGON_VERTEX_COUNT = 6; 
-const int MAX_CLIPPED_PROJECTED_POLYGON_VERTEX_COUNT = MAX_PROJECTED_POLYGON_VERTEX_COUNT * 2; 
+const int MAX_PROJECTED_POLYGON_VERTEX_COUNT = 6;
+const int MAX_CLIPPED_PROJECTED_POLYGON_VERTEX_COUNT = MAX_PROJECTED_POLYGON_VERTEX_COUNT * 2;
 typedef glm::vec2 ProjectedVertices[MAX_CLIPPED_PROJECTED_POLYGON_VERTEX_COUNT];
 
-class BoundingBox {
+class BoundingRectangle {
 public:
     enum { BOTTOM_LEFT, BOTTOM_RIGHT, TOP_RIGHT, TOP_LEFT, VERTEX_COUNT };
 
-    BoundingBox(const glm::vec2 corner, const glm::vec2 size) : corner(corner), size(size), _set(true) {}
-    BoundingBox() : _set(false) {}
+    BoundingRectangle(const glm::vec2 corner, const glm::vec2 size) : corner(corner), size(size), _set(true) {}
+    BoundingRectangle() : _set(false) {}
     glm::vec2 corner;
     glm::vec2 size;
-    bool contains(const BoundingBox& box) const;
+    bool contains(const BoundingRectangle& box) const;
     bool contains(const glm::vec2& point) const;
     bool pointInside(const glm::vec2& point) const { return contains(point); }
 
-    void explandToInclude(const BoundingBox& box);
+    void explandToInclude(const BoundingRectangle& box);
 
     float area() const { return size.x * size.y; }
 
     int getVertexCount() const { return VERTEX_COUNT; }
     glm::vec2 getVertex(int vertexNumber) const;
 
-    BoundingBox topHalf() const;
-    BoundingBox bottomHalf() const;
-    BoundingBox leftHalf() const;
-    BoundingBox rightHalf() const;
+    BoundingRectangle topHalf() const;
+    BoundingRectangle bottomHalf() const;
+    BoundingRectangle leftHalf() const;
+    BoundingRectangle rightHalf() const;
 
     float getMaxX() const { return corner.x + size.x; }
     float getMaxY() const { return corner.y + size.y; }
     float getMinX() const { return corner.x; }
     float getMinY() const { return corner.y; }
-    
+
     void printDebugDetails(const char* label=NULL) const;
 private:
     bool _set;
@@ -63,18 +63,18 @@ const int PROJECTION_NEAR    = 16;
 const int PROJECTION_FAR     = 32;
 const int PROJECTION_CLIPPED = 64;
 
-class OctreeProjectedPolygon {
+class CubeProjectedPolygon {
 
 public:
-    OctreeProjectedPolygon(const BoundingBox& box);
+    CubeProjectedPolygon(const BoundingRectangle& box);
 
-    OctreeProjectedPolygon(int vertexCount = 0) : 
-        _vertexCount(vertexCount), 
+    CubeProjectedPolygon(int vertexCount = 0) :
+        _vertexCount(vertexCount),
         _maxX(-FLT_MAX), _maxY(-FLT_MAX), _minX(FLT_MAX), _minY(FLT_MAX),
         _distance(0)
         { }
-        
-    ~OctreeProjectedPolygon() { }
+
+    ~CubeProjectedPolygon() { }
     const ProjectedVertices& getVertices() const { return _vertices; }
     const glm::vec2& getVertex(int i) const { return _vertices[i]; }
     void setVertex(int vertex, const glm::vec2& point);
@@ -92,28 +92,28 @@ public:
 
 
     bool pointInside(const glm::vec2& point, bool* matchesVertex = NULL) const;
-    bool occludes(const OctreeProjectedPolygon& occludee, bool checkAllInView = false) const;
-    bool occludes(const BoundingBox& occludee) const;
-    bool intersects(const OctreeProjectedPolygon& testee) const;
-    bool intersects(const BoundingBox& box) const;
-    bool matches(const OctreeProjectedPolygon& testee) const;
-    bool matches(const BoundingBox& testee) const;
-    bool intersectsOnAxes(const OctreeProjectedPolygon& testee) const;
+    bool occludes(const CubeProjectedPolygon& occludee, bool checkAllInView = false) const;
+    bool occludes(const BoundingRectangle& occludee) const;
+    bool intersects(const CubeProjectedPolygon& testee) const;
+    bool intersects(const BoundingRectangle& box) const;
+    bool matches(const CubeProjectedPolygon& testee) const;
+    bool matches(const BoundingRectangle& testee) const;
+    bool intersectsOnAxes(const CubeProjectedPolygon& testee) const;
 
-    bool canMerge(const OctreeProjectedPolygon& that) const;
-    void merge(const OctreeProjectedPolygon& that); // replaces vertices of this with new merged version
-    
+    bool canMerge(const CubeProjectedPolygon& that) const;
+    void merge(const CubeProjectedPolygon& that); // replaces vertices of this with new merged version
+
     float getMaxX() const { return _maxX; }
     float getMaxY() const { return _maxY; }
     float getMinX() const { return _minX; }
     float getMinY() const { return _minY; }
-    
-    BoundingBox getBoundingBox() const { 
-        return BoundingBox(glm::vec2(_minX,_minY), glm::vec2(_maxX - _minX, _maxY - _minY)); 
+
+    BoundingRectangle getBoundingBox() const {
+        return BoundingRectangle(glm::vec2(_minX,_minY), glm::vec2(_maxX - _minX, _maxY - _minY));
     }
 
     void printDebugDetails() const;
-    
+
     static long pointInside_calls;
     static long occludes_calls;
     static long intersects_calls;
@@ -132,4 +132,4 @@ private:
 };
 
 
-#endif // hifi_OctreeProjectedPolygon_h
+#endif // hifi_CubeProjectedPolygon_h

--- a/libraries/shared/src/PIDController.cpp
+++ b/libraries/shared/src/PIDController.cpp
@@ -35,7 +35,7 @@ float PIDController::update(float measuredValue, float dt, bool resetAccumulator
         updateHistory(measuredValue, dt, error, accumulatedError, changeInError, p, i, d, computedValue);
     }
     Q_ASSERT(!glm::isnan(computedValue));
-    
+
     // update state for next time
     _lastError = error;
     _lastAccumulation = accumulatedError;

--- a/libraries/shared/src/Plane.cpp
+++ b/libraries/shared/src/Plane.cpp
@@ -1,6 +1,6 @@
 //
 //  Plane.cpp
-//  libraries/octree/src/
+//  libraries/shared/src/
 //
 //  Created by Brad Hefta-Gaub on 04/11/13.
 //  Copyright 2013 High Fidelity, Inc.
@@ -13,12 +13,12 @@
 //
 
 #include "Plane.h"
-#include "OctreeLogging.h"
-
-
-#include <QtCore/QDebug>
 
 #include <stdio.h>
+#include <QtCore/QDebug>
+
+#include "SharedLogging.h"
+
 
 void Plane::set3Points(const glm::vec3 &v1, const glm::vec3 &v2, const glm::vec3 &v3) {
     glm::vec3 linev1v2, linev1v3;
@@ -65,7 +65,7 @@ float Plane::distance(const glm::vec3 &point) const {
 }
 
 void Plane::print() const {
-    qCDebug(octree, "Plane - point (x=%f y=%f z=%f) normal (x=%f y=%f z=%f) d=%f",
+    qCDebug(shared, "Plane - point (x=%f y=%f z=%f) normal (x=%f y=%f z=%f) d=%f",
             (double)_point.x, (double)_point.y, (double)_point.z,
             (double)_normal.x, (double)_normal.y, (double)_normal.z, (double)_dCoefficient);
 }

--- a/libraries/shared/src/Plane.h
+++ b/libraries/shared/src/Plane.h
@@ -1,6 +1,6 @@
 //
 //  Plane.h
-//  libraries/octree/src/
+//  libraries/shared/src/
 //
 //  Created by Brad Hefta-Gaub on 04/11/13.
 //  Copyright 2013 High Fidelity, Inc.
@@ -20,7 +20,7 @@
 class Plane {
 public:
     Plane(const glm::vec3 &v1, const glm::vec3 &v2, const glm::vec3 &v3) { set3Points(v1,v2,v3); }
-    Plane() : _normal(0,0,0), _point(0,0,0), _dCoefficient(0) {};
+    Plane() : _normal(0.0f), _point(0.0f), _dCoefficient(0.0f) {};
     ~Plane() {} ;
 
     // methods for defining the plane
@@ -28,12 +28,13 @@ public:
     void setNormalAndPoint(const glm::vec3 &normal, const glm::vec3 &point);
     void setCoefficients(float a, float b, float c, float d);
 
-    // getters    
+    // getters
     const glm::vec3& getNormal() const { return _normal; };
     const glm::vec3& getPoint() const { return _point; };
     float getDCoefficient() const { return _dCoefficient; };
 
     // utilities
+    void invalidate() { _normal = glm::vec3(0.0f), _dCoefficient = 1.0e6f; } // distance() never less than 10^6
     float distance(const glm::vec3 &point) const;
     void print() const;
 

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -88,7 +88,6 @@ public:
                gpu::Batch* batch = nullptr) :
     _context(context),
     _renderer(renderer),
-    _viewFrustums(),
     _sizeScale(sizeScale),
     _boundaryLevelAdjust(boundaryLevelAdjust),
     _renderMode(renderMode),

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -14,12 +14,15 @@
 
 #include <functional>
 #include <memory>
-#include "GLMHelpers.h"
+#include <stack>
+
+#include <GLMHelpers.h>
+#include <ViewFrustum.h>
+
 
 
 class AABox;
 class OctreeRenderer;
-class ViewFrustum;
 
 namespace gpu {
 class Batch;
@@ -39,21 +42,21 @@ public:
         SHADOW,
         OTHER
     };
-    
+
     struct Item {
         int _considered = 0;
         int _outOfView = 0;
         int _tooSmall = 0;
         int _rendered = 0;
     };
-    
+
     int _materialSwitches = 0;
     int _trianglesRendered = 0;
-    
+
     Item _item;
     Item _shadow;
     Item _other;
-    
+
     Item& edit(Type type) {
         switch (type) {
             case SHADOW:
@@ -77,7 +80,6 @@ public:
 
     RenderArgs(std::shared_ptr<gpu::Context> context = nullptr,
                OctreeRenderer* renderer = nullptr,
-               const ViewFrustum* viewFrustum = nullptr,
                float sizeScale = 1.0f,
                int boundaryLevelAdjust = 0,
                RenderMode renderMode = DEFAULT_RENDER_MODE,
@@ -86,7 +88,7 @@ public:
                gpu::Batch* batch = nullptr) :
     _context(context),
     _renderer(renderer),
-    _viewFrustum(viewFrustum),
+    _viewFrustums(),
     _sizeScale(sizeScale),
     _boundaryLevelAdjust(boundaryLevelAdjust),
     _renderMode(renderMode),
@@ -95,11 +97,22 @@ public:
     _batch(batch) {
     }
 
+    bool hasViewFrustum() const { return _viewFrustums.size() > 0; }
+    void setViewFrustum(const ViewFrustum& viewFrustum) {
+        while (_viewFrustums.size() > 0) {
+            _viewFrustums.pop();
+        }
+        _viewFrustums.push(viewFrustum);
+    }
+    const ViewFrustum& getViewFrustum() const { assert(_viewFrustums.size() > 0); return _viewFrustums.top(); }
+    void pushViewFrustum(const ViewFrustum& viewFrustum) { _viewFrustums.push(viewFrustum); }
+    void popViewFrustum() { _viewFrustums.pop(); }
+
     std::shared_ptr<gpu::Context> _context = nullptr;
     std::shared_ptr<gpu::Framebuffer> _blitFramebuffer = nullptr;
     std::shared_ptr<render::ShapePipeline> _pipeline = nullptr;
     OctreeRenderer* _renderer = nullptr;
-    const ViewFrustum* _viewFrustum = nullptr;
+    std::stack<ViewFrustum> _viewFrustums;
     glm::ivec4 _viewport{ 0.0f, 0.0f, 1.0f, 1.0f };
     glm::vec3 _boomOffset{ 0.0f, 0.0f, 1.0f };
     float _sizeScale = 1.0f;
@@ -108,7 +121,7 @@ public:
     RenderSide _renderSide = MONO;
     DebugFlags _debugFlags = RENDER_DEBUG_NONE;
     gpu::Batch* _batch = nullptr;
-    
+
     std::shared_ptr<gpu::Texture> _whiteTexture;
 
     RenderDetails _details;

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -77,7 +77,7 @@ public:
 
     RenderArgs(std::shared_ptr<gpu::Context> context = nullptr,
                OctreeRenderer* renderer = nullptr,
-               ViewFrustum* viewFrustum = nullptr,
+               const ViewFrustum* viewFrustum = nullptr,
                float sizeScale = 1.0f,
                int boundaryLevelAdjust = 0,
                RenderMode renderMode = DEFAULT_RENDER_MODE,
@@ -99,7 +99,7 @@ public:
     std::shared_ptr<gpu::Framebuffer> _blitFramebuffer = nullptr;
     std::shared_ptr<render::ShapePipeline> _pipeline = nullptr;
     OctreeRenderer* _renderer = nullptr;
-    ViewFrustum* _viewFrustum = nullptr;
+    const ViewFrustum* _viewFrustum = nullptr;
     glm::ivec4 _viewport{ 0.0f, 0.0f, 1.0f, 1.0f };
     glm::vec3 _boomOffset{ 0.0f, 0.0f, 1.0f };
     float _sizeScale = 1.0f;

--- a/libraries/shared/src/ViewFrustum.cpp
+++ b/libraries/shared/src/ViewFrustum.cpp
@@ -107,11 +107,6 @@ void ViewFrustum::calculate() {
     _planes[RIGHT_PLANE].set3Points(_cornersWorld[BOTTOM_RIGHT_FAR], _cornersWorld[BOTTOM_RIGHT_NEAR], _cornersWorld[TOP_RIGHT_FAR]);
     _planes[NEAR_PLANE].set3Points(_cornersWorld[BOTTOM_RIGHT_NEAR], _cornersWorld[BOTTOM_LEFT_NEAR], _cornersWorld[TOP_LEFT_NEAR]);
     _planes[FAR_PLANE].set3Points(_cornersWorld[BOTTOM_LEFT_FAR], _cornersWorld[BOTTOM_RIGHT_FAR], _cornersWorld[TOP_RIGHT_FAR]);
-
-    // Also calculate our projection matrix in case people want to project points...
-    // Projection matrix : Field of View, ratio, display range : near to far
-    glm::vec3 lookAt = _position + _direction;
-    glm::mat4 view = glm::lookAt(_position, lookAt, _up);
 }
 
 //enum { TOP_PLANE = 0, BOTTOM_PLANE, LEFT_PLANE, RIGHT_PLANE, NEAR_PLANE, FAR_PLANE };

--- a/libraries/shared/src/ViewFrustum.h
+++ b/libraries/shared/src/ViewFrustum.h
@@ -132,38 +132,33 @@ public:
 
     void invalidate(); // causes all reasonable intersection tests to fail
 private:
-    // camera location/orientation attributes
-    glm::vec3 _position; // the position in world-frame
-    glm::quat _orientation;
     glm::mat4 _view;
-
-    // Lens attributes
     glm::mat4 _projection;
 
-    // calculated for orientation
+    ::Plane _planes[NUM_FRUSTUM_PLANES]; // plane normals point inside frustum
+
+    glm::vec3 _position; // position in world-frame
+    glm::quat _orientation; // orientation in world-frame
+
+    // calculated from orientation
     glm::vec3 _direction = IDENTITY_FRONT;
     glm::vec3 _up = IDENTITY_UP;
     glm::vec3 _right = IDENTITY_RIGHT;
 
+    // calculated from projection
+    glm::vec4 _corners[NUM_FRUSTUM_CORNERS];
+    glm::vec3 _cornersWorld[NUM_FRUSTUM_CORNERS];
     float _centerSphereRadius = DEFAULT_CENTER_SPHERE_RADIUS;
-
-    // Calculated values
-    glm::mat4 _inverseProjection;
     float _width { 1.0f };
     float _height { 1.0f };
     float _aspectRatio { 1.0f };
-    float _nearClip { DEFAULT_NEAR_CLIP };
-    float _farClip { DEFAULT_FAR_CLIP };
     float _focalLength { 0.25f };
     float _fieldOfView { DEFAULT_FIELD_OF_VIEW_DEGREES };
-    glm::vec4 _corners[NUM_FRUSTUM_CORNERS];
-    glm::vec3 _cornersWorld[NUM_FRUSTUM_CORNERS];
-    ::Plane _planes[NUM_FRUSTUM_PLANES]; // plane normals point inside frustum
+
+    float _nearClip { DEFAULT_NEAR_CLIP };
+    float _farClip { DEFAULT_FAR_CLIP };
 
     const char* debugPlaneName (int plane) const;
-
-    // Used to project points
-    glm::mat4 _ourModelViewProjectionMatrix;
 };
 using ViewFrustumPointer = std::shared_ptr<ViewFrustum>;
 

--- a/libraries/shared/src/ViewFrustum.h
+++ b/libraries/shared/src/ViewFrustum.h
@@ -17,8 +17,6 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 
-//#include <GLMHelpers.h>
-
 #include "AABox.h"
 #include "AACube.h"
 #include "CubeProjectedPolygon.h"

--- a/libraries/shared/src/ViewFrustum.h
+++ b/libraries/shared/src/ViewFrustum.h
@@ -21,6 +21,7 @@
 
 #include "AABox.h"
 #include "AACube.h"
+#include "CubeProjectedPolygon.h"
 #include "Plane.h"
 #include "RegisteredMetaTypes.h"
 #include "Transform.h"
@@ -108,6 +109,10 @@ public:
     bool cubeIntersectsKeyhole(const AACube& cube) const;
     bool boxIntersectsKeyhole(const AABox& box) const;
 
+    // some frustum comparisons
+    bool matches(const ViewFrustum& compareTo, bool debug = false) const;
+    bool matches(const ViewFrustum* compareTo, bool debug = false) const { return matches(*compareTo, debug); }
+
     bool isVerySimilar(const ViewFrustum& compareTo, bool debug = false) const;
     bool isVerySimilar(const ViewFrustum* compareTo, bool debug = false) const { return isVerySimilar(*compareTo, debug); }
 
@@ -119,6 +124,8 @@ public:
 
     void printDebugDetails() const;
 
+    glm::vec2 projectPoint(glm::vec3 point, bool& pointInView) const;
+    CubeProjectedPolygon getProjectedPolygon(const AACube& box) const;
     void getFurthestPointFromCamera(const AACube& box, glm::vec3& furthestPoint) const;
 
     float distanceToCamera(const glm::vec3& point) const;
@@ -159,6 +166,9 @@ private:
     float _farClip { DEFAULT_FAR_CLIP };
 
     const char* debugPlaneName (int plane) const;
+
+    // Used to project points
+    glm::mat4 _ourModelViewProjectionMatrix;
 };
 using ViewFrustumPointer = std::shared_ptr<ViewFrustum>;
 


### PR DESCRIPTION
* move ViewFrustum class to shared lib
* remove cruft (such as calls to Head::render() which has empty implementation)
* use ViewFrustum reference rather than copies
* use mutex locks around changes/accesses of OctreeViewerNode's various ViewFrustum data members
* RenderArgs uses a stack of ViewFrustums rather than just one pointer
* re-order ViewFrustum data members for more compact storage in memory