### PR TITLE
switch OctreeSendThread and OctreePersistThread to use std::this_thread::sleep_for() instead of usleep()

### DIFF
--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -9,6 +9,9 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <chrono>
+#include <thread>
+
 #include <NodeList.h>
 #include <NumericalConstants.h>
 #include <udt/PacketHeaders.h>
@@ -101,13 +104,16 @@ bool OctreeSendThread::process() {
         int elapsed = (usecTimestampNow() - start);
         int usecToSleep =  OCTREE_SEND_INTERVAL_USECS - elapsed;
 
-        if (usecToSleep > 0) {
-            PerformanceWarning warn(false,"OctreeSendThread... usleep()",false,&_usleepTime,&_usleepCalls);
-            usleep(usecToSleep);
-        } else {
+        if (usecToSleep <= 0) {
             const int MIN_USEC_TO_SLEEP = 1;
-            usleep(MIN_USEC_TO_SLEEP);
+            usecToSleep = MIN_USEC_TO_SLEEP;
         }
+
+        {
+            PerformanceWarning warn(false,"OctreeSendThread... usleep()",false,&_usleepTime,&_usleepCalls);
+            std::this_thread::sleep_for(std::chrono::microseconds(usecToSleep));
+        }
+
     }
 
     return isStillRunning();  // keep running till they terminate us

--- a/libraries/octree/src/OctreePersistThread.cpp
+++ b/libraries/octree/src/OctreePersistThread.cpp
@@ -9,6 +9,9 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <chrono>
+#include <thread>
+
 #include <cstdio>
 #include <fstream>
 #include <time.h>
@@ -201,7 +204,7 @@ bool OctreePersistThread::process() {
     if (isStillRunning()) {
         quint64 MSECS_TO_USECS = 1000;
         quint64 USECS_TO_SLEEP = 10 * MSECS_TO_USECS; // every 10ms
-        usleep(USECS_TO_SLEEP);
+        std::this_thread::sleep_for(std::chrono::microseconds(USECS_TO_SLEEP));
 
         // do our updates then check to save...
         _tree->update();


### PR DESCRIPTION
`usleep()` on windows has the side effect that it does a busy wait if the request sleep time is under 1ms, since the `OctreeSendThread` and `OctreePersistThread` don't actually care about that level of precision, we can use the less accurate by more CPU friendly `std::this_thread::sleep_for()` to sleep our threads.