### PR TITLE
Fixing the bad color format for skymaps

### DIFF
--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -105,18 +105,18 @@ const QImage& image, bool isLinear, bool doCompress) {
         gpu::Semantic gpuSemantic;
         gpu::Semantic mipSemantic;
         if (isLinear) {
-            mipSemantic = gpu::SBGRA;
-            if (doCompress) {
-                gpuSemantic = gpu::COMPRESSED_SRGBA;
-            } else {
-                gpuSemantic = gpu::SRGBA;
-            }
-        } else {
             mipSemantic = gpu::BGRA;
             if (doCompress) {
                 gpuSemantic = gpu::COMPRESSED_RGBA;
             } else {
                 gpuSemantic = gpu::RGBA;
+            }
+        } else {
+            mipSemantic = gpu::SBGRA;
+            if (doCompress) {
+                gpuSemantic = gpu::COMPRESSED_SRGBA;
+            } else {
+                gpuSemantic = gpu::SRGBA;
             }
         }
         formatGPU = gpu::Element(gpu::VEC4, gpu::NUINT8, gpuSemantic);
@@ -125,18 +125,18 @@ const QImage& image, bool isLinear, bool doCompress) {
         gpu::Semantic gpuSemantic;
         gpu::Semantic mipSemantic;
         if (isLinear) {
-            mipSemantic = gpu::SRGB;
-            if (doCompress) {
-                gpuSemantic = gpu::COMPRESSED_SRGB;
-            } else {
-                gpuSemantic = gpu::SRGB;
-            }
-        } else {
             mipSemantic = gpu::RGB;
             if (doCompress) {
                 gpuSemantic = gpu::COMPRESSED_RGB;
             } else {
                 gpuSemantic = gpu::RGB;
+            }
+        } else {
+            mipSemantic = gpu::SRGB;
+            if (doCompress) {
+                gpuSemantic = gpu::COMPRESSED_SRGB;
+            } else {
+                gpuSemantic = gpu::SRGB;
             }
         }
         formatGPU = gpu::Element(gpu::VEC3, gpu::NUINT8, gpuSemantic);
@@ -186,20 +186,20 @@ gpu::Texture* TextureUsage::process2DTextureColorFromImage(const QImage& srcImag
 }
 
 gpu::Texture* TextureUsage::create2DTextureFromImage(const QImage& srcImage, const std::string& srcImageName) {
-    return process2DTextureColorFromImage(srcImage, true, false, true);
+    return process2DTextureColorFromImage(srcImage, false, false, true);
 }
 
 
 gpu::Texture* TextureUsage::createAlbedoTextureFromImage(const QImage& srcImage, const std::string& srcImageName) {
-    return process2DTextureColorFromImage(srcImage, true, true, true);
+    return process2DTextureColorFromImage(srcImage, false, true, true);
 }
 
 gpu::Texture* TextureUsage::createEmissiveTextureFromImage(const QImage& srcImage, const std::string& srcImageName) {
-    return process2DTextureColorFromImage(srcImage, true, true, true);
+    return process2DTextureColorFromImage(srcImage, false, true, true);
 }
 
 gpu::Texture* TextureUsage::createLightmapTextureFromImage(const QImage& srcImage, const std::string& srcImageName) {
-    return process2DTextureColorFromImage(srcImage, true, true, true);
+    return process2DTextureColorFromImage(srcImage, false, true, true);
 }
 
 


### PR DESCRIPTION
fixing bad color format assignment code and bad color format for the skymaps

THe code in TextureMap.cpp doing the color format assignment was incorrect for the isLinear/not is linear branch
 AND the isLInear flag was set the wrong way for DEFAULT, ALBEDO, EMISSIVE and LIGHTMAP textures (which ended up being the correct result...)

BUt the isLInearFlag was correctly set to fals (meaning sRGB) for cubemaps defining incorrectly the cube textures color format (RGB not sRGB).

THis should all look more correct for the skymaps
THanks Alan for detecting that one.