### PR TITLE
Enable script debugging

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -44,7 +44,7 @@ else ()
 endif ()
 
 find_package(Qt5 COMPONENTS
-    Gui Multimedia Network OpenGL Qml Quick Script Svg
+    Gui Multimedia Network OpenGL Qml Quick Script ScriptTools Svg
     WebChannel WebEngine WebEngineWidgets WebKitWidgets WebSockets)
 
 # grab the ui files in resources/ui
@@ -201,7 +201,7 @@ include_directories("${PROJECT_SOURCE_DIR}/src")
 target_link_libraries(
   ${TARGET_NAME}
   Qt5::Gui Qt5::Network Qt5::Multimedia Qt5::OpenGL
-  Qt5::Qml Qt5::Quick Qt5::Script Qt5::Svg
+  Qt5::Qml Qt5::Quick Qt5::Script Qt5::ScriptTools Qt5::Svg
   Qt5::WebChannel Qt5::WebEngine Qt5::WebEngineWidgets Qt5::WebKitWidgets
 )
 

--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -11,8 +11,11 @@
 
 #include "MenuScriptingInterface.h"
 
-#include "Menu.h"
+#include <QtCore/QCoreApplication>
+#include <QtCore/QThread>
+
 #include <MenuItemProperties.h>
+#include "Menu.h"
 
 MenuScriptingInterface* MenuScriptingInterface::getInstance() {
     static MenuScriptingInterface sharedInstance;
@@ -36,6 +39,9 @@ void MenuScriptingInterface::removeMenu(const QString& menu) {
 }
 
 bool MenuScriptingInterface::menuExists(const QString& menu) {
+    if (QThread::currentThread() == qApp->thread()) {
+        return Menu::getInstance()->menuExists(menu);
+    }
     bool result;
     QMetaObject::invokeMethod(Menu::getInstance(), "menuExists", Qt::BlockingQueuedConnection,
                 Q_RETURN_ARG(bool, result), 
@@ -76,11 +82,14 @@ void MenuScriptingInterface::removeMenuItem(const QString& menu, const QString& 
 };
 
 bool MenuScriptingInterface::menuItemExists(const QString& menu, const QString& menuitem) {
+    if (QThread::currentThread() == qApp->thread()) {
+        return Menu::getInstance()->menuItemExists(menu, menuitem);
+    }
     bool result;
     QMetaObject::invokeMethod(Menu::getInstance(), "menuItemExists", Qt::BlockingQueuedConnection,
-                Q_RETURN_ARG(bool, result), 
-                Q_ARG(const QString&, menu),
-                Q_ARG(const QString&, menuitem));
+        Q_RETURN_ARG(bool, result),
+        Q_ARG(const QString&, menu),
+        Q_ARG(const QString&, menuitem));
     return result;
 }
 
@@ -101,6 +110,9 @@ void MenuScriptingInterface::removeActionGroup(const QString& groupName) {
 }
 
 bool MenuScriptingInterface::isOptionChecked(const QString& menuOption) {
+    if (QThread::currentThread() == qApp->thread()) {
+        return Menu::getInstance()->isOptionChecked(menuOption);
+    }
     bool result;
     QMetaObject::invokeMethod(Menu::getInstance(), "isOptionChecked", Qt::BlockingQueuedConnection,
                 Q_RETURN_ARG(bool, result), 
@@ -109,7 +121,7 @@ bool MenuScriptingInterface::isOptionChecked(const QString& menuOption) {
 }
 
 void MenuScriptingInterface::setIsOptionChecked(const QString& menuOption, bool isChecked) {
-    QMetaObject::invokeMethod(Menu::getInstance(), "setIsOptionChecked", Qt::BlockingQueuedConnection,
+    QMetaObject::invokeMethod(Menu::getInstance(), "setIsOptionChecked",
                 Q_ARG(const QString&, menuOption),
                 Q_ARG(bool, isChecked));
 }

--- a/libraries/script-engine/CMakeLists.txt
+++ b/libraries/script-engine/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(TARGET_NAME script-engine)
-setup_hifi_library(Gui Network Script WebSockets Widgets)
+setup_hifi_library(Gui Network Script ScriptTools WebSockets Widgets)
 link_hifi_libraries(shared networking octree gpu ui procedural model model-networking recording avatars fbx entities controllers animation audio physics)

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -18,8 +18,9 @@
 #include <QtCore/QUrl>
 #include <QtCore/QSet>
 #include <QtCore/QWaitCondition>
-#include <QtScript/QScriptEngine>
 #include <QtCore/QStringList>
+
+#include <QtScript/QScriptEngine>
 
 #include <AnimationCache.h>
 #include <AnimVariant.h>
@@ -38,6 +39,8 @@
 #include "ScriptCache.h"
 #include "ScriptUUID.h"
 #include "Vec3.h"
+
+class QScriptEngineDebugger;
 
 static const QString NO_SCRIPT("");
 
@@ -74,6 +77,8 @@ public:
     /// the current script contents and calling run(). Callers will likely want to register the script with external
     /// services before calling this.
     void runInThread();
+
+    void runDebuggable();
 
     /// run the script in the callers thread, exit when stop() is called.
     void run();
@@ -140,6 +145,8 @@ public:
     bool isFinished() const { return _isFinished; } // used by Application and ScriptWidget
     bool isRunning() const { return _isRunning; } // used by ScriptWidget
 
+    bool isDebuggable() const { return _debuggable; }
+
     void disconnectNonEssentialSignals();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -187,6 +194,9 @@ protected:
     bool _wantSignals { true };
     QHash<EntityItemID, EntityScriptDetails> _entityScripts;
     bool _isThreaded { false };
+    QScriptEngineDebugger* _debugger { nullptr };
+    bool _debuggable { false };
+    qint64 _lastUpdate;
 
     void init();
     QString getFilename() const;

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -9,7 +9,8 @@
 #include "ScriptEngines.h"
 
 #include <QtCore/QStandardPaths>
-#include <QtCore/QCoreApplication>
+
+#include <QtWidgets/QApplication>
 
 #include <SettingHandle.h>
 #include <UserActivityLogger.h>
@@ -490,7 +491,12 @@ void ScriptEngines::launchScriptEngine(ScriptEngine* scriptEngine) {
     for (auto initializer : _scriptInitializers) {
         initializer(scriptEngine);
     }
-    scriptEngine->runInThread();
+    
+    if (scriptEngine->isDebuggable() || (qApp->queryKeyboardModifiers() & Qt::ShiftModifier)) {
+        scriptEngine->runDebuggable();
+    } else {
+        scriptEngine->runInThread();
+    }
 }
 
 


### PR DESCRIPTION
First pass at enabling the use of QScriptEngineDebugger in Interface.  

To enable a script for debugging, you may:
* Include a comment with string `#debug` somewhere in the script
* Hold down shift while the script is being loaded or reloaded

Doing either of these will cause the debugger to be attached to the script.  

You can pause force execution to pause by including the keyword `debugger` somewhere in your script.  When not running in debug mode, this keyword will be ignored, but when in debug mode it will act as a breakpoint and pop up the debug window.  Note that if you do this in order to set breakpoints, I recommended you make sure to put the statement after any `Script.include` statements, so that all the scripts will be loaded into the debugger.
