### PR TITLE
Clean up resource cache's encapsulation of asynchronous loading

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -584,12 +584,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     // put the NodeList and datagram processing on the node thread
     nodeList->moveToThread(nodeThread);
 
-    // Model background downloads need to happen on the Datagram Processor Thread.  The idle loop will
-    // emit checkBackgroundDownloads to cause the ModelCache to check it's queue for requested background
-    // downloads.
-    auto modelCache = DependencyManager::get<ModelCache>();
-    connect(this, &Application::checkBackgroundDownloads, modelCache.data(), &ModelCache::checkAsynchronousGets);
-
     // put the audio processing on a separate thread
     QThread* audioThread = new QThread();
     audioThread->setObjectName("Audio Thread");
@@ -2746,9 +2740,6 @@ void Application::idle(uint64_t now) {
     }
 
     _overlayConductor.update(secondsSinceLastUpdate);
-
-    // check for any requested background downloads.
-    emit checkBackgroundDownloads();
 }
 
 void Application::setLowVelocityFilter(bool lowVelocityFilter) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -224,8 +224,6 @@ public:
 signals:
     void svoImportRequested(const QString& url);
 
-    void checkBackgroundDownloads();
-
     void fullAvatarURLChanged(const QString& newValue, const QString& modelName);
 
     void beforeAboutToQuit();

--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -36,7 +36,7 @@ AnimationPointer AnimationCache::getAnimation(const QUrl& url) {
 }
 
 QSharedPointer<Resource> AnimationCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
-        bool delayLoad, const void* extra) {
+    const void* extra) {
     return QSharedPointer<Resource>(new Animation(url), &Resource::deleter);
 }
 

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -35,8 +35,8 @@ public:
 
 protected:
     
-    virtual QSharedPointer<Resource> createResource(const QUrl& url,
-                const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra);
+    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+        const void* extra);
 private:
     explicit AnimationCache(QObject* parent = NULL);
     virtual ~AnimationCache() { }

--- a/libraries/audio/src/SoundCache.cpp
+++ b/libraries/audio/src/SoundCache.cpp
@@ -35,7 +35,7 @@ SharedSoundPointer SoundCache::getSound(const QUrl& url) {
 }
 
 QSharedPointer<Resource> SoundCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
-                                                    bool delayLoad, const void* extra) {
+    const void* extra) {
     qCDebug(audio) << "Requesting sound at" << url.toString();
     return QSharedPointer<Resource>(new Sound(url), &Resource::deleter);
 }

--- a/libraries/audio/src/SoundCache.h
+++ b/libraries/audio/src/SoundCache.h
@@ -25,8 +25,8 @@ public:
     Q_INVOKABLE SharedSoundPointer getSound(const QUrl& url);
     
 protected:
-    virtual QSharedPointer<Resource> createResource(const QUrl& url,
-                                                    const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra);
+    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+        const void* extra);
 private:
     SoundCache(QObject* parent = NULL);
 };

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -71,7 +71,7 @@ void GeometryMappingResource::downloadFinished(const QByteArray& data) {
         GeometryExtra extra{ mapping, _textureBaseUrl };
 
         // Get the raw GeometryResource, not the wrapped NetworkGeometry
-        _geometryResource = modelCache->getResource(url, QUrl(), false, &extra).staticCast<GeometryResource>();
+        _geometryResource = modelCache->getResource(url, QUrl(), &extra).staticCast<GeometryResource>();
         // Avoid caching nested resources - their references will be held by the parent
         _geometryResource->_isCacheable = false;
 
@@ -236,7 +236,7 @@ ModelCache::ModelCache() {
 }
 
 QSharedPointer<Resource> ModelCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
-                                                    bool delayLoad, const void* extra) {
+    const void* extra) {
     Resource* resource = nullptr;
     if (url.path().toLower().endsWith(".fst")) {
         resource = new GeometryMappingResource(url);
@@ -252,7 +252,7 @@ QSharedPointer<Resource> ModelCache::createResource(const QUrl& url, const QShar
 
 std::shared_ptr<NetworkGeometry> ModelCache::getGeometry(const QUrl& url, const QVariantHash& mapping, const QUrl& textureBaseUrl) {
     GeometryExtra geometryExtra = { mapping, textureBaseUrl };
-    GeometryResource::Pointer resource = getResource(url, QUrl(), true, &geometryExtra).staticCast<GeometryResource>();
+    GeometryResource::Pointer resource = getResource(url, QUrl(), &geometryExtra).staticCast<GeometryResource>();
     if (resource) {
         if (resource->isLoaded() && resource->shouldSetTextures()) {
             resource->setTextures();

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -44,8 +44,8 @@ public:
 protected:
     friend class GeometryMappingResource;
 
-    virtual QSharedPointer<Resource> createResource(const QUrl& url,
-        const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra);
+    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+        const void* extra);
 
 private:
     ModelCache();

--- a/libraries/model-networking/src/model-networking/ShaderCache.cpp
+++ b/libraries/model-networking/src/model-networking/ShaderCache.cpp
@@ -7,11 +7,8 @@
 //
 #include "ShaderCache.h"
 
-NetworkShader::NetworkShader(const QUrl& url, bool delayLoad)
-    : Resource(url, delayLoad)
-{
-    
-}
+NetworkShader::NetworkShader(const QUrl& url) :
+    Resource(url) {}
 
 void NetworkShader::downloadFinished(const QByteArray& data) {
     _source = QString::fromUtf8(data);
@@ -24,10 +21,11 @@ ShaderCache& ShaderCache::instance() {
 }
 
 NetworkShaderPointer ShaderCache::getShader(const QUrl& url) {
-    return ResourceCache::getResource(url, QUrl(), false, nullptr).staticCast<NetworkShader>();
+    return ResourceCache::getResource(url, QUrl(), nullptr).staticCast<NetworkShader>();
 }
 
-QSharedPointer<Resource> ShaderCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra) {
-    return QSharedPointer<Resource>(new NetworkShader(url, delayLoad), &Resource::deleter);
+QSharedPointer<Resource> ShaderCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+    const void* extra) {
+    return QSharedPointer<Resource>(new NetworkShader(url), &Resource::deleter);
 }
 

--- a/libraries/model-networking/src/model-networking/ShaderCache.h
+++ b/libraries/model-networking/src/model-networking/ShaderCache.h
@@ -13,7 +13,7 @@
 
 class NetworkShader : public Resource {
 public:
-    NetworkShader(const QUrl& url, bool delayLoad);
+    NetworkShader(const QUrl& url);
     virtual void downloadFinished(const QByteArray& data) override;
 
     QString _source;
@@ -28,7 +28,8 @@ public:
     NetworkShaderPointer getShader(const QUrl& url);
 
 protected:
-    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra) override;
+    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+        const void* extra) override;
 };
 
 #endif

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -167,7 +167,7 @@ ScriptableResource* TextureCache::prefetch(const QUrl& url, int type) {
 
 NetworkTexturePointer TextureCache::getTexture(const QUrl& url, Type type, const QByteArray& content) {
     TextureExtra extra = { type, content };
-    return ResourceCache::getResource(url, QUrl(), content.isEmpty(), &extra).staticCast<NetworkTexture>();
+    return ResourceCache::getResource(url, QUrl(), &extra).staticCast<NetworkTexture>();
 }
 
 
@@ -231,8 +231,8 @@ gpu::TexturePointer TextureCache::getImageTexture(const QString& path, Type type
     return gpu::TexturePointer(loader(image, QUrl::fromLocalFile(path).fileName().toStdString()));
 }
 
-QSharedPointer<Resource> TextureCache::createResource(const QUrl& url,
-        const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra) {
+QSharedPointer<Resource> TextureCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+    const void* extra) {
     const TextureExtra* textureExtra = static_cast<const TextureExtra*>(extra);
     auto type = textureExtra ? textureExtra->type : Type::DEFAULT_TEXTURE;
     auto content = textureExtra ? textureExtra->content : QByteArray();
@@ -241,7 +241,7 @@ QSharedPointer<Resource> TextureCache::createResource(const QUrl& url,
 }
 
 NetworkTexture::NetworkTexture(const QUrl& url, Type type, const QByteArray& content) :
-    Resource(url, !content.isEmpty()),
+    Resource(url),
     _type(type)
 {
     _textureSource = std::make_shared<gpu::TextureSource>();

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -131,8 +131,8 @@ protected:
     // Overload ResourceCache::prefetch to allow specifying texture type for loads
     Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type);
 
-    virtual QSharedPointer<Resource> createResource(const QUrl& url,
-        const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra);
+    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+        const void* extra);
         
 private:
     TextureCache();

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -187,12 +187,13 @@ protected slots:
     // and delegate to it (see TextureCache::prefetch(const QUrl&, int).
     ScriptableResource* prefetch(const QUrl& url, void* extra);
 
-    /// Loads a resource from the specified URL.
+    /// Loads a resource from the specified URL and returns it.
+    /// If the caller is on a different thread than the ResourceCache,
+    /// returns an empty smart pointer and loads its asynchronously.
     /// \param fallback a fallback URL to load if the desired one is unavailable
-    /// \param delayLoad if true, don't load the resource immediately; wait until load is first requested
     /// \param extra extra data to pass to the creator, if appropriate
     QSharedPointer<Resource> getResource(const QUrl& url, const QUrl& fallback = QUrl(),
-                                         bool delayLoad = false, void* extra = NULL);
+        void* extra = NULL);
 
 private slots:
     void clearATPAssets();
@@ -205,8 +206,8 @@ protected:
     Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url) { return prefetch(url, nullptr); }
 
     /// Creates a new resource.
-    virtual QSharedPointer<Resource> createResource(const QUrl& url,
-        const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra) = 0;
+    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
+        const void* extra) = 0;
     
     void addUnusedResource(const QSharedPointer<Resource>& resource);
     void removeUnusedResource(const QSharedPointer<Resource>& resource);
@@ -257,7 +258,7 @@ class Resource : public QObject {
 
 public:
     
-    Resource(const QUrl& url, bool delayLoad = false);
+    Resource(const QUrl& url);
     ~Resource();
     
     /// Returns the key last used to identify this resource in the unused map.

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -179,9 +179,6 @@ public:
 signals:
     void dirty();
 
-public slots:
-    void checkAsynchronousGets();
-
 protected slots:
     void updateTotalSize(const qint64& deltaSize);
 
@@ -189,6 +186,13 @@ protected slots:
     // Left as a protected member so subclasses can overload prefetch
     // and delegate to it (see TextureCache::prefetch(const QUrl&, int).
     ScriptableResource* prefetch(const QUrl& url, void* extra);
+
+    /// Loads a resource from the specified URL.
+    /// \param fallback a fallback URL to load if the desired one is unavailable
+    /// \param delayLoad if true, don't load the resource immediately; wait until load is first requested
+    /// \param extra extra data to pass to the creator, if appropriate
+    QSharedPointer<Resource> getResource(const QUrl& url, const QUrl& fallback = QUrl(),
+                                         bool delayLoad = false, void* extra = NULL);
 
 private slots:
     void clearATPAssets();
@@ -199,13 +203,6 @@ protected:
     // which should be a QScriptEngine with ScriptableResource registered, so that
     // the QScriptEngine will delete the pointer when it is garbage collected.
     Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url) { return prefetch(url, nullptr); }
-
-    /// Loads a resource from the specified URL.
-    /// \param fallback a fallback URL to load if the desired one is unavailable
-    /// \param delayLoad if true, don't load the resource immediately; wait until load is first requested
-    /// \param extra extra data to pass to the creator, if appropriate
-    QSharedPointer<Resource> getResource(const QUrl& url, const QUrl& fallback = QUrl(),
-                                                     bool delayLoad = false, void* extra = NULL);
 
     /// Creates a new resource.
     virtual QSharedPointer<Resource> createResource(const QUrl& url,

--- a/libraries/recording/src/recording/ClipCache.cpp
+++ b/libraries/recording/src/recording/ClipCache.cpp
@@ -9,12 +9,9 @@
 #include "impl/PointerClip.h"
 
 using namespace recording;
-NetworkClipLoader::NetworkClipLoader(const QUrl& url, bool delayLoad)
-    : Resource(url, delayLoad), _clip(std::make_shared<NetworkClip>(url))
-{
-    
-}
-
+NetworkClipLoader::NetworkClipLoader(const QUrl& url) :
+    Resource(url),
+    _clip(std::make_shared<NetworkClip>(url)) {}
 
 void NetworkClip::init(const QByteArray& clipData) {
     _clipData = clipData;
@@ -32,10 +29,10 @@ ClipCache& ClipCache::instance() {
 }
 
 NetworkClipLoaderPointer ClipCache::getClipLoader(const QUrl& url) {
-    return ResourceCache::getResource(url, QUrl(), false, nullptr).staticCast<NetworkClipLoader>();
+    return ResourceCache::getResource(url, QUrl(), nullptr).staticCast<NetworkClipLoader>();
 }
 
-QSharedPointer<Resource> ClipCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra) {
-    return QSharedPointer<Resource>(new NetworkClipLoader(url, delayLoad), &Resource::deleter);
+QSharedPointer<Resource> ClipCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback, const void* extra) {
+    return QSharedPointer<Resource>(new NetworkClipLoader(url), &Resource::deleter);
 }
 

--- a/libraries/recording/src/recording/ClipCache.h
+++ b/libraries/recording/src/recording/ClipCache.h
@@ -31,7 +31,7 @@ private:
 
 class NetworkClipLoader : public Resource {
 public:
-    NetworkClipLoader(const QUrl& url, bool delayLoad);
+    NetworkClipLoader(const QUrl& url);
     virtual void downloadFinished(const QByteArray& data) override;
     ClipPointer getClip() { return _clip; }
     bool completed() { return _failedToLoad || isLoaded(); }
@@ -49,7 +49,7 @@ public:
     NetworkClipLoaderPointer getClipLoader(const QUrl& url);
 
 protected:
-    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback, bool delayLoad, const void* extra) override;
+    virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback, const void* extra) override;
 };
 
 }


### PR DESCRIPTION
`delayLoad` did not do what it advertised, so this revises the logic of asynchronous loads to be self-contained within ResourceCache - instead of requiring polling from Application - and removes the `delayLoad` parameter from caches and resources.