### PR TITLE
don't show help or login on first run

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1091,6 +1091,11 @@ void Application::checkChangeCursor() {
 
         _cursorNeedsChanging = false;
     }
+
+
+    // After all of the constructor is completed, then set firstRun to false.
+    Setting::Handle<bool> firstRun{ Settings::firstRun, true };
+    firstRun.set(false);
 }
 
 void Application::showCursor(const QCursor& cursor) {
@@ -2950,7 +2955,7 @@ void Application::init() {
         addressLookupString = arguments().value(urlIndex + 1);
     }
 
-    Setting::Handle<bool> firstRun { "firstRun", true };
+    Setting::Handle<bool> firstRun { Settings::firstRun, true };
     if (addressLookupString.isEmpty() && firstRun.get()) {
         qDebug() << "First run and no URL passed... attempting to Go Home...";
         DependencyManager::get<AddressManager>()->goHomeOrElsewhere();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -702,9 +702,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     // The value will be 0 if the user blew away settings this session, which is both a feature and a bug.
     UserActivityLogger::getInstance().launch(applicationVersion(), _previousSessionCrashed, sessionRunTime.get());
 
-    // once the event loop has started, check and signal for an access token
-    QMetaObject::invokeMethod(&accountManager, "checkAndSignalForAccessToken", Qt::QueuedConnection);
-
     auto addressManager = DependencyManager::get<AddressManager>();
 
     // use our MyAvatar position and quat for address manager path
@@ -1327,8 +1324,6 @@ void Application::initializeGL() {
 
     // update before the first render
     update(0);
-
-    InfoView::show(INFO_HELP_PATH, true);
 }
 
 FrameTimingsScriptingInterface _frameTimingsScriptingInterface;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2957,8 +2957,15 @@ void Application::init() {
 
     Setting::Handle<bool> firstRun { Settings::firstRun, true };
     if (addressLookupString.isEmpty() && firstRun.get()) {
-        qDebug() << "First run and no URL passed... attempting to Go Home...";
-        DependencyManager::get<AddressManager>()->goHomeOrElsewhere();
+        qDebug() << "First run and no URL passed... attempting to go to Home or Entry...";
+        DependencyManager::get<AddressManager>()->ifLocalSandboxRunningElse([](){
+            qDebug() << "Home sandbox appears to be running, going to Home.";
+            DependencyManager::get<AddressManager>()->goToLocalSandbox();
+        }, 
+        [](){
+            qDebug() << "Home sandbox does not appear to be running, going to Entry.";
+            DependencyManager::get<AddressManager>()->goToEntry();
+        });
     } else {
         qDebug() << "Not first run... going to" << qPrintable(addressLookupString.isEmpty() ? QString("previous location") : addressLookupString);
         DependencyManager::get<AddressManager>()->loadSettings(addressLookupString);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2950,7 +2950,14 @@ void Application::init() {
         addressLookupString = arguments().value(urlIndex + 1);
     }
 
-    DependencyManager::get<AddressManager>()->loadSettings(addressLookupString);
+    Setting::Handle<bool> firstRun { "firstRun", true };
+    if (addressLookupString.isEmpty() && firstRun.get()) {
+        qDebug() << "First run and no URL passed... attempting to Go Home...";
+        DependencyManager::get<AddressManager>()->goHomeOrElsewhere();
+    } else {
+        qDebug() << "Not first run... going to" << qPrintable(addressLookupString.isEmpty() ? QString("previous location") : addressLookupString);
+        DependencyManager::get<AddressManager>()->loadSettings(addressLookupString);
+    }
 
     qCDebug(interfaceapp) << "Loaded settings";
 

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -646,7 +646,7 @@ void AddressManager::goHomeOrElsewhere(QString elsewhere, LookupTrigger trigger)
             if (!serversValue.isUndefined() && serversValue.isObject()) {
                 auto serversObject = serversValue.toObject();
                 auto serversCount = serversObject.size();
-                const int MINIMUM_EXPECTED_SERVER_COUNT = 6;
+                const int MINIMUM_EXPECTED_SERVER_COUNT = 5;
                 if (serversCount >= MINIMUM_EXPECTED_SERVER_COUNT) {
                     qDebug() << "Home sandbox is running, going to " << SANDBOX_HIFI_ADDRESS;
                     handleUrl(SANDBOX_HIFI_ADDRESS, trigger);

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -636,9 +636,8 @@ void AddressManager::goHomeOrElsewhere(QString elsewhere, LookupTrigger trigger)
     sandboxStatus.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
     QNetworkReply* reply = networkAccessManager.get(sandboxStatus);
 
-    connect(reply, &QNetworkReply::finished, this, [this, elsewhere, trigger]() {
-        QNetworkReply* sender = qobject_cast<QNetworkReply*>(QObject::sender());
-        auto statusData = sender->readAll();
+    connect(reply, &QNetworkReply::finished, this, [this, elsewhere, reply, trigger]() {
+        auto statusData = reply->readAll();
         auto statusJson = QJsonDocument::fromJson(statusData);
         if (!statusJson.isEmpty()) {
             auto statusObject = statusJson.object();

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -25,6 +25,7 @@
 const QString HIFI_URL_SCHEME = "hifi";
 const QString DEFAULT_HIFI_ADDRESS = "hifi://entry";
 const QString SANDBOX_HIFI_ADDRESS = "hifi://localhost";
+const QString SANDBOX_STATUS_URL = "http://localhost:60332/status";
 const QString INDEX_PATH = "/";
 
 const QString GET_PLACE = "/api/v1/places/%1";
@@ -66,8 +67,10 @@ public:
     const QStack<QUrl>& getBackStack() const { return _backStack; }
     const QStack<QUrl>& getForwardStack() const { return _forwardStack; }
 
-    void goHomeOrElsewhere(QString elsewhere = DEFAULT_HIFI_ADDRESS, 
-                           LookupTrigger trigger = LookupTrigger::StartupFromSettings);
+    /// determines if the local sandbox is likely running. It does not account for custom setups but is only 
+    /// intended to detect the standard sandbox install.
+    void ifLocalSandboxRunningElse(std::function<void()> localSandboxRunningDoThis,
+                                   std::function<void()> localSandboxNotRunningDoThat);
 
 public slots:
     void handleLookupString(const QString& lookupString);
@@ -78,6 +81,8 @@ public slots:
 
     void goBack();
     void goForward();
+    void goToLocalSandbox(LookupTrigger trigger = LookupTrigger::StartupFromSettings) { handleUrl(SANDBOX_HIFI_ADDRESS, trigger); }
+    void goToEntry(LookupTrigger trigger = LookupTrigger::StartupFromSettings) { handleUrl(DEFAULT_HIFI_ADDRESS, trigger); }
 
     void goToUser(const QString& username);
 

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -24,6 +24,7 @@
 
 const QString HIFI_URL_SCHEME = "hifi";
 const QString DEFAULT_HIFI_ADDRESS = "hifi://entry";
+const QString SANDBOX_HIFI_ADDRESS = "hifi://localhost";
 const QString INDEX_PATH = "/";
 
 const QString GET_PLACE = "/api/v1/places/%1";
@@ -64,6 +65,9 @@ public:
 
     const QStack<QUrl>& getBackStack() const { return _backStack; }
     const QStack<QUrl>& getForwardStack() const { return _forwardStack; }
+
+    void goHomeOrElsewhere(QString elsewhere = DEFAULT_HIFI_ADDRESS, 
+                           LookupTrigger trigger = LookupTrigger::StartupFromSettings);
 
 public slots:
     void handleLookupString(const QString& lookupString);

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -67,8 +67,8 @@ public:
     const QStack<QUrl>& getBackStack() const { return _backStack; }
     const QStack<QUrl>& getForwardStack() const { return _forwardStack; }
 
-    /// determines if the local sandbox is likely running. It does not account for custom setups but is only 
-    /// intended to detect the standard sandbox install.
+    /// determines if the local sandbox is likely running. It does not account for custom setups, and is only 
+    /// intended to detect the standard local sandbox install.
     void ifLocalSandboxRunningElse(std::function<void()> localSandboxRunningDoThis,
                                    std::function<void()> localSandboxNotRunningDoThat);
 

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -270,12 +270,12 @@ void ScriptEngines::loadOneScript(const QString& scriptFilename) {
 
 void ScriptEngines::loadScripts() {
     // check first run...
-    if (_firstRun.get()) {
+    Setting::Handle<bool> firstRun { Settings::firstRun, true };
+    if (firstRun.get()) {
         qCDebug(scriptengine) << "This is a first run...";
         // clear the scripts, and set out script to our default scripts
         clearScripts();
         loadDefaultScripts();
-        _firstRun.set(false);
         return;
     }
 

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -87,8 +87,6 @@ protected:
     void onScriptEngineError(const QString& scriptFilename);
     void launchScriptEngine(ScriptEngine* engine);
 
-
-    Setting::Handle<bool> _firstRun { "firstRun", true };
     QReadWriteLock _scriptEnginesHashLock;
     QHash<QUrl, ScriptEngine*> _scriptEnginesHash;
     QSet<ScriptEngine*> _allKnownScriptEngines;

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -13,6 +13,7 @@
 
 #include <math.h>
 
+const QString Settings::firstRun { "firstRun" };
 
 void Settings::getFloatValueIfValid(const QString& name, float& floatValue) {
     const QVariant badDefaultValue = NAN;

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -26,6 +26,8 @@
 // TODO: remove
 class Settings : public QSettings {
 public:
+    static const QString firstRun;
+
     void getFloatValueIfValid(const QString& name, float& floatValue);
     void getBoolValue(const QString& name, bool& boolValue);
 

--- a/libraries/shared/src/SettingInterface.h
+++ b/libraries/shared/src/SettingInterface.h
@@ -16,7 +16,6 @@
 #include <QVariant>
 
 namespace Setting {
-
     void preInit();
     void init();
     void cleanupSettings();

--- a/libraries/shared/src/SettingInterface.h
+++ b/libraries/shared/src/SettingInterface.h
@@ -16,6 +16,7 @@
 #include <QVariant>
 
 namespace Setting {
+
     void preInit();
     void init();
     void cleanupSettings();


### PR DESCRIPTION
At Ryan's request we're changing the first run experience slightly... 

----------------
- Make sure that no matter which path the first time user takes to launch Interface, the first place they go is Home. If The Sandbox is not running we take them to Playa/Entry. 

- Don't show login screen on startup. We don't require people to create an account when they download the client so chances are we will have just taken them inworld and then ask them to go out again. We also make it really hard for people who go straight to HMD mode as you can't close the window unless you have your mouse. Eventually we will have good enough controls that non-logged in users will have neutered experiences and want to level up. 

- Remove the welcome screen. If you are in the HMD it's hard to close and the info isn't all that useful. We could add some of this info to the Hello World popup. 

