### PR TITLE
send lookup hostname to DS for split counts, correct number of DS connected users

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -55,9 +55,9 @@ void DomainGatekeeper::processConnectRequestPacket(QSharedPointer<ReceivedMessag
     if (message->getSize() == 0) {
         return;
     }
-    
+
     QDataStream packetStream(message->getMessage());
-    
+
     // read a NodeConnectionData object from the packet so we can pass around this data while we're inspecting it
     NodeConnectionData nodeConnection = NodeConnectionData::fromDataStream(packetStream, message->getSenderSockAddr());
     

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -105,6 +105,7 @@ void DomainGatekeeper::processConnectRequestPacket(QSharedPointer<ReceivedMessag
         DomainServerNodeData* nodeData = reinterpret_cast<DomainServerNodeData*>(node->getLinkedData());
         nodeData->setSendingSockAddr(message->getSenderSockAddr());
         nodeData->setNodeInterestSet(nodeConnection.interestList.toSet());
+        nodeData->setPlaceName(nodeConnection.placeName);
         
         // signal that we just connected a node so the DomainServer can get it a list
         // and broadcast its presence right away

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -151,6 +151,7 @@ SharedNodePointer DomainGatekeeper::processAssignmentConnectRequest(const NodeCo
     nodeData->setAssignmentUUID(matchingQueuedAssignment->getUUID());
     nodeData->setWalletUUID(it->second.getWalletUUID());
     nodeData->setNodeVersion(it->second.getNodeVersion());
+    nodeData->setWasAssigned(true);
     
     // cleanup the PendingAssignedNodeData for this assignment now that it's connecting
     _pendingAssignedNodes.erase(it);
@@ -283,7 +284,7 @@ SharedNodePointer DomainGatekeeper::processAgentConnectRequest(const NodeConnect
     // set the edit rights for this user
     newNode->setIsAllowedEditor(isAllowedEditor);
     newNode->setCanRez(canRez);
-    
+
     // grab the linked data for our new node so we can set the username
     DomainServerNodeData* nodeData = reinterpret_cast<DomainServerNodeData*>(newNode->getLinkedData());
     

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -462,7 +462,7 @@ void DomainServer::setupAutomaticNetworking() {
                 nodeList->startSTUNPublicSocketUpdate();
             } else {
                 // send our heartbeat to data server so it knows what our network settings are
-                sendHeartbeatToDataServer();
+                sendHeartbeatToMetaverse();
             }
         } else {
             qDebug() << "Cannot enable domain-server automatic networking without a domain ID."
@@ -471,7 +471,7 @@ void DomainServer::setupAutomaticNetworking() {
             return;
         }
     } else {
-        sendHeartbeatToDataServer();
+        sendHeartbeatToMetaverse();
     }
 
     qDebug() << "Updating automatic networking setting in domain-server to" << _automaticNetworkingSetting;
@@ -480,7 +480,7 @@ void DomainServer::setupAutomaticNetworking() {
     const int DOMAIN_SERVER_DATA_WEB_HEARTBEAT_MSECS = 15 * 1000;
 
     QTimer* dataHeartbeatTimer = new QTimer(this);
-    connect(dataHeartbeatTimer, SIGNAL(timeout()), this, SLOT(sendHeartbeatToDataServer()));
+    connect(dataHeartbeatTimer, SIGNAL(timeout()), this, SLOT(sendHeartbeatToMetaverse()));
     dataHeartbeatTimer->start(DOMAIN_SERVER_DATA_WEB_HEARTBEAT_MSECS);
 }
 
@@ -1029,11 +1029,11 @@ QJsonObject jsonForDomainSocketUpdate(const HifiSockAddr& socket) {
 const QString DOMAIN_UPDATE_AUTOMATIC_NETWORKING_KEY = "automatic_networking";
 
 void DomainServer::performIPAddressUpdate(const HifiSockAddr& newPublicSockAddr) {
-    sendHeartbeatToDataServer(newPublicSockAddr.getAddress().toString());
+    sendHeartbeatToMetaverse(newPublicSockAddr.getAddress().toString());
 }
 
 
-void DomainServer::sendHeartbeatToDataServer(const QString& networkAddress) {
+void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress) {
     const QString DOMAIN_UPDATE = "/api/v1/domains/%1";
 
     auto nodeList = DependencyManager::get<LimitedNodeList>();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -678,6 +678,9 @@ void DomainServer::processListRequestPacket(QSharedPointer<ReceivedMessage> mess
     DomainServerNodeData* nodeData = reinterpret_cast<DomainServerNodeData*>(sendingNode->getLinkedData());
     nodeData->setNodeInterestSet(nodeRequestData.interestList.toSet());
 
+    // update the connecting hostname in case it has changed
+    nodeData->setPlaceName(nodeRequestData.placeName);
+
     sendDomainListToNode(sendingNode, message->getSenderSockAddr());
 }
 

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -71,7 +71,7 @@ private slots:
     void sendPendingTransactionsToServer();
 
     void performIPAddressUpdate(const HifiSockAddr& newPublicSockAddr);
-    void sendHeartbeatToDataServer() { sendHeartbeatToDataServer(QString()); }
+    void sendHeartbeatToMetaverse() { sendHeartbeatToMetaverse(QString()); }
     void sendHeartbeatToIceServer();
     
     void handleConnectedNode(SharedNodePointer newNode);
@@ -103,7 +103,7 @@ private:
 
     void setupAutomaticNetworking();
     void setupICEHeartbeatForFullNetworking();
-    void sendHeartbeatToDataServer(const QString& networkAddress);
+    void sendHeartbeatToMetaverse(const QString& networkAddress);
 
     void randomizeICEServerAddress(bool shouldTriggerHostLookup);
 

--- a/domain-server/src/DomainServerNodeData.h
+++ b/domain-server/src/DomainServerNodeData.h
@@ -58,7 +58,7 @@ public:
     void removeOverrideForKey(const QString& key, const QString& value);
 
     const QString& getPlaceName() { return _placeName; }
-    void setPlaceName(const QString& placeName) { _placeName; }
+    void setPlaceName(const QString& placeName) { _placeName = placeName; }
     
 private:
     QJsonObject overrideValuesIfNeeded(const QJsonObject& newStats);

--- a/domain-server/src/DomainServerNodeData.h
+++ b/domain-server/src/DomainServerNodeData.h
@@ -59,6 +59,9 @@ public:
 
     const QString& getPlaceName() { return _placeName; }
     void setPlaceName(const QString& placeName) { _placeName = placeName; }
+
+    bool wasAssigned() const { return _wasAssigned; };
+    void setWasAssigned(bool wasAssigned) { _wasAssigned = wasAssigned; }
     
 private:
     QJsonObject overrideValuesIfNeeded(const QJsonObject& newStats);
@@ -80,6 +83,8 @@ private:
     QString _nodeVersion;
 
     QString _placeName;
+
+    bool _wasAssigned { false };
 };
 
 #endif // hifi_DomainServerNodeData_h

--- a/domain-server/src/DomainServerNodeData.h
+++ b/domain-server/src/DomainServerNodeData.h
@@ -56,6 +56,9 @@ public:
     
     void addOverrideForKey(const QString& key, const QString& value, const QString& overrideValue);
     void removeOverrideForKey(const QString& key, const QString& value);
+
+    const QString& getPlaceName() { return _placeName; }
+    void setPlaceName(const QString& placeName) { _placeName; }
     
 private:
     QJsonObject overrideValuesIfNeeded(const QJsonObject& newStats);
@@ -75,6 +78,8 @@ private:
     bool _isAuthenticated = true;
     NodeSet _nodeInterestSet;
     QString _nodeVersion;
+
+    QString _placeName;
 };
 
 #endif // hifi_DomainServerNodeData_h

--- a/domain-server/src/NodeConnectionData.cpp
+++ b/domain-server/src/NodeConnectionData.cpp
@@ -19,6 +19,7 @@ NodeConnectionData NodeConnectionData::fromDataStream(QDataStream& dataStream, c
     
     if (isConnectRequest) {
         dataStream >> newHeader.connectUUID;
+        dataStream >> newHeader.placeName;
     }
     
     dataStream >> newHeader.nodeType

--- a/domain-server/src/NodeConnectionData.cpp
+++ b/domain-server/src/NodeConnectionData.cpp
@@ -19,12 +19,11 @@ NodeConnectionData NodeConnectionData::fromDataStream(QDataStream& dataStream, c
     
     if (isConnectRequest) {
         dataStream >> newHeader.connectUUID;
-        dataStream >> newHeader.placeName;
     }
     
     dataStream >> newHeader.nodeType
         >> newHeader.publicSockAddr >> newHeader.localSockAddr
-        >> newHeader.interestList;
+        >> newHeader.interestList >> newHeader.placeName;
 
     newHeader.senderSockAddr = senderSockAddr;
     

--- a/domain-server/src/NodeConnectionData.h
+++ b/domain-server/src/NodeConnectionData.h
@@ -27,6 +27,7 @@ public:
     HifiSockAddr localSockAddr;
     HifiSockAddr senderSockAddr;
     QList<NodeType_t> interestList;
+    QString placeName;
 };
 
 

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -295,10 +295,13 @@ void AddressManager::goToAddressFromObject(const QVariantMap& dataObject, const 
                 // set our current root place name to the name that came back
                 const QString PLACE_NAME_KEY = "name";
                 QString placeName = rootMap[PLACE_NAME_KEY].toString();
+
                 if (!placeName.isEmpty()) {
                     if (setHost(placeName, trigger)) {
                         trigger = LookupTrigger::Internal;
                     }
+
+                    _placeName = placeName;
                 } else {
                     if (setHost(domainIDString, trigger)) {
                         trigger = LookupTrigger::Internal;
@@ -580,7 +583,9 @@ bool AddressManager::setHost(const QString& host, LookupTrigger trigger, quint16
 bool AddressManager::setDomainInfo(const QString& hostname, quint16 port, LookupTrigger trigger) {
     bool hostChanged = setHost(hostname, trigger, port);
 
+    // clear any current place information
     _rootPlaceID = QUuid();
+    _placeName.clear();
 
     qCDebug(networking) << "Possible domain change required to connect to domain at" << hostname << "on" << port;
 

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -306,6 +306,9 @@ void AddressManager::goToAddressFromObject(const QVariantMap& dataObject, const 
                     if (setHost(domainIDString, trigger)) {
                         trigger = LookupTrigger::Internal;
                     }
+                    
+                    // this isn't a place, so clear the place name
+                    _placeName.clear();
                 }
 
                 // check if we had a path to override the path returned

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -58,6 +58,7 @@ public:
     const QString currentPath(bool withOrientation = true) const;
 
     const QUuid& getRootPlaceID() const { return _rootPlaceID; }
+    const QString& getPlaceName() const { return _placeName; }
 
     const QString& getHost() const { return _host; }
 
@@ -141,6 +142,7 @@ private:
 
     QString _host;
     quint16 _port;
+    QString _placeName;
     QUuid _rootPlaceID;
     PositionGetter _positionGetter;
     OrientationGetter _orientationGetter;

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -312,6 +312,9 @@ void NodeList::sendDomainServerCheckIn() {
 
             // pack the connect UUID for this connect request
             packetStream << connectUUID;
+
+            // pack the hostname information (so the domain-server can see which place name we came in on)
+            packetStream << DependencyManager::get<AddressManager>()->getPlaceName();
         }
 
         // pack our data to send to the domain-server

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -312,13 +312,12 @@ void NodeList::sendDomainServerCheckIn() {
 
             // pack the connect UUID for this connect request
             packetStream << connectUUID;
-
-            // pack the hostname information (so the domain-server can see which place name we came in on)
-            packetStream << DependencyManager::get<AddressManager>()->getPlaceName();
         }
 
-        // pack our data to send to the domain-server
-        packetStream << _ownerType << _publicSockAddr << _localSockAddr << _nodeTypesOfInterest.toList();
+        // pack our data to send to the domain-server including
+        // the hostname information (so the domain-server can see which place name we came in on)
+        packetStream << _ownerType << _publicSockAddr << _localSockAddr << _nodeTypesOfInterest.toList()
+            << DependencyManager::get<AddressManager>()->getPlaceName();
 
         if (!_domainHandler.isConnected()) {
             DataServerAccountInfo& accountInfo = accountManager->getAccountInfo();

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -58,6 +58,9 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AssetUpload:
             // Removal of extension from Asset requests
             return 18;
+        case PacketType::DomainConnectRequest:
+            // addition of referring hostname information
+            return 18;
         default:
             return 17;
     }


### PR DESCRIPTION
- Interface sends the place name it used to get to the domain-server
- domain-server separates the number of connected users by place name they used to connect
- domain-server reports unauthenticated users in the count of connected users