### PR TITLE
Fix crash in JurisdictionMap

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3656,11 +3656,11 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType, Node
             } else {
                 const JurisdictionMap& map = (jurisdictions)[nodeUUID];
 
-                unsigned char* rootCode = map.getRootOctalCode();
+                auto rootCode = map.getRootOctalCode();
 
                 if (rootCode) {
                     VoxelPositionSize rootDetails;
-                    voxelDetailsForCode(rootCode, rootDetails);
+                    voxelDetailsForCode(rootCode.get(), rootDetails);
                     AACube serverBounds(glm::vec3(rootDetails.x * TREE_SCALE,
                                                   rootDetails.y * TREE_SCALE,
                                                   rootDetails.z * TREE_SCALE) - glm::vec3(HALF_TREE_SCALE),
@@ -3720,11 +3720,11 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType, Node
             } else {
                 const JurisdictionMap& map = (jurisdictions)[nodeUUID];
 
-                unsigned char* rootCode = map.getRootOctalCode();
+                auto rootCode = map.getRootOctalCode();
 
                 if (rootCode) {
                     VoxelPositionSize rootDetails;
-                    voxelDetailsForCode(rootCode, rootDetails);
+                    voxelDetailsForCode(rootCode.get(), rootDetails);
                     AACube serverBounds(glm::vec3(rootDetails.x * TREE_SCALE,
                                                   rootDetails.y * TREE_SCALE,
                                                   rootDetails.z * TREE_SCALE) - glm::vec3(HALF_TREE_SCALE),
@@ -4251,9 +4251,9 @@ void Application::nodeKilled(SharedNodePointer node) {
                 return;
             }
 
-            unsigned char* rootCode = _entityServerJurisdictions[nodeUUID].getRootOctalCode();
+            auto rootCode = _entityServerJurisdictions[nodeUUID].getRootOctalCode();
             VoxelPositionSize rootDetails;
-            voxelDetailsForCode(rootCode, rootDetails);
+            voxelDetailsForCode(rootCode.get(), rootDetails);
 
             qCDebug(interfaceapp, "model server going away...... v[%f, %f, %f, %f]",
                 (double)rootDetails.x, (double)rootDetails.y, (double)rootDetails.z, (double)rootDetails.s);
@@ -4378,7 +4378,7 @@ int Application::processOctreeStats(ReceivedMessage& message, SharedNodePointer 
             }
 
             VoxelPositionSize rootDetails;
-            voxelDetailsForCode(octreeStats.getJurisdictionRoot(), rootDetails);
+            voxelDetailsForCode(octreeStats.getJurisdictionRoot().get(), rootDetails);
 
             qCDebug(interfaceapp, "stats from new %s server... [%f, %f, %f, %f]",
                 qPrintable(serverType),

--- a/interface/src/ui/OctreeStatsDialog.cpp
+++ b/interface/src/ui/OctreeStatsDialog.cpp
@@ -433,13 +433,13 @@ void OctreeStatsDialog::showOctreeServersOfType(int& serverCount, NodeType_t ser
                 } 
                 const JurisdictionMap& map = serverJurisdictions[nodeUUID];
 
-                unsigned char* rootCode = map.getRootOctalCode();
+                auto rootCode = map.getRootOctalCode();
 
                 if (rootCode) {
-                    QString rootCodeHex = octalCodeToHexString(rootCode);
+                    QString rootCodeHex = octalCodeToHexString(rootCode.get());
 
                     VoxelPositionSize rootDetails;
-                    voxelDetailsForCode(rootCode, rootDetails);
+                    voxelDetailsForCode(rootCode.get(), rootDetails);
                     AACube serverBounds(glm::vec3(rootDetails.x, rootDetails.y, rootDetails.z), rootDetails.s);
                     serverDetails << " jurisdiction: "
                         << qPrintable(rootCodeHex)

--- a/libraries/octree/src/JurisdictionMap.cpp
+++ b/libraries/octree/src/JurisdictionMap.cpp
@@ -64,7 +64,14 @@ JurisdictionMap::JurisdictionMap(const JurisdictionMap& other) : _rootOctalCode(
 }
 
 void JurisdictionMap::copyContents(const OctalCodePtr& rootCodeIn, const OctalCodePtrList& endNodesIn) {
-    init(rootCodeIn, endNodesIn);
+    OctalCodePtr rootCode = rootCodeIn;
+    if (!rootCode) {
+        rootCode = createOctalCodePtr(1);
+        *rootCode = 0;
+    }
+
+    OctalCodePtrList emptyEndNodes;
+    init(rootCode, endNodesIn);
 }
 
 void JurisdictionMap::copyContents(const JurisdictionMap& other) {

--- a/libraries/octree/src/JurisdictionMap.cpp
+++ b/libraries/octree/src/JurisdictionMap.cpp
@@ -73,7 +73,7 @@ void JurisdictionMap::copyContents(const JurisdictionMap& other) {
     OctalCodePtr rootOctalCode;
     OctalCodePtrList endNodes;
 
-    std::tie(rootOctalCode, endNodes) = other.getRootOctalCodeAndEndNodes();
+    std::tie(rootOctalCode, endNodes) = other.getRootAndEndNodeOctalCodes();
 
     init(rootOctalCode, endNodes);
 }
@@ -83,7 +83,7 @@ JurisdictionMap::~JurisdictionMap() {
 
 JurisdictionMap::JurisdictionMap(NodeType_t type) : _rootOctalCode(nullptr) {
     _nodeType = type;
-    OctalCodePtr rootCode = allocateOctalCodePtr(1);
+    OctalCodePtr rootCode = createOctalCodePtr(1);
     *rootCode = 0;
 
     OctalCodePtrList emptyEndNodes;
@@ -125,7 +125,7 @@ JurisdictionMap::JurisdictionMap(const char* rootHexCode, const char* endNodesHe
     }
 }
 
-std::tuple<OctalCodePtr, OctalCodePtrList> JurisdictionMap::getRootOctalCodeAndEndNodes() const {
+std::tuple<OctalCodePtr, OctalCodePtrList> JurisdictionMap::getRootAndEndNodeOctalCodes() const {
     std::lock_guard<std::mutex> lock(_octalCodeMutex);
     return std::tuple<OctalCodePtr, OctalCodePtrList>(_rootOctalCode, _endNodes);
 }
@@ -291,7 +291,7 @@ int JurisdictionMap::unpackFromPacket(ReceivedMessage& message) {
     _endNodes.clear();
 
     if (bytes > 0 && bytes <= message.getBytesLeftToRead()) {
-        _rootOctalCode = allocateOctalCodePtr(bytes);
+        _rootOctalCode = createOctalCodePtr(bytes);
         message.read(reinterpret_cast<char*>(_rootOctalCode.get()), bytes);
 
         // if and only if there's a root jurisdiction, also include the end nodes
@@ -303,7 +303,7 @@ int JurisdictionMap::unpackFromPacket(ReceivedMessage& message) {
             message.readPrimitive(&bytes);
 
             if (bytes <= message.getBytesLeftToRead()) {
-                auto endNodeCode = allocateOctalCodePtr(bytes);
+                auto endNodeCode = createOctalCodePtr(bytes);
                 message.read(reinterpret_cast<char*>(endNodeCode.get()), bytes);
 
                 // if the endNodeCode was 0 length then don't add it

--- a/libraries/octree/src/JurisdictionMap.cpp
+++ b/libraries/octree/src/JurisdictionMap.cpp
@@ -99,7 +99,7 @@ JurisdictionMap::JurisdictionMap(const char* rootHexCode, const char* endNodesHe
     qCDebug(octree, "JurisdictionMap::JurisdictionMap(const char* rootHexCode=[%p] %s, const char* endNodesHexCodes=[%p] %s)",
         rootHexCode, rootHexCode, endNodesHexCodes, endNodesHexCodes);
 
-    _rootOctalCode = std::shared_ptr<unsigned char>(hexStringToOctalCode(QString(rootHexCode)));
+    _rootOctalCode = hexStringToOctalCode(QString(rootHexCode));
 
     qCDebug(octree, "JurisdictionMap::JurisdictionMap() _rootOctalCode=%p octalCode=", _rootOctalCode.get());
     myDebugPrintOctalCode(_rootOctalCode.get(), true);

--- a/libraries/octree/src/JurisdictionMap.cpp
+++ b/libraries/octree/src/JurisdictionMap.cpp
@@ -119,7 +119,7 @@ JurisdictionMap::JurisdictionMap(const char* rootHexCode, const char* endNodesHe
         //printOctalCode(endNodeOctcode);
         _endNodes.push_back(endNodeOctcode);
 
-        qCDebug(octree, "JurisdictionMap::JurisdictionMap() endNodeOctcode=%p octalCode=", endNodeOctcode);
+        qCDebug(octree, "JurisdictionMap::JurisdictionMap() endNodeOctcode=%p octalCode=", endNodeOctcode.get());
         myDebugPrintOctalCode(endNodeOctcode.get(), true);
 
     }

--- a/libraries/octree/src/JurisdictionMap.h
+++ b/libraries/octree/src/JurisdictionMap.h
@@ -51,7 +51,8 @@ public:
     bool writeToFile(const char* filename);
     bool readFromFile(const char* filename);
 
-    std::tuple<OctalCodePtr, OctalCodePtrList> JurisdictionMap::getRootOctalCodeAndEndNodes() const;
+    // Provide an atomic way to get both the rootOctalCode and endNodeOctalCodes.
+    std::tuple<OctalCodePtr, OctalCodePtrList> JurisdictionMap::getRootAndEndNodeOctalCodes() const;
     OctalCodePtr getRootOctalCode() const;
     OctalCodePtrList getEndNodeOctalCodes() const;
 

--- a/libraries/octree/src/JurisdictionMap.h
+++ b/libraries/octree/src/JurisdictionMap.h
@@ -52,7 +52,7 @@ public:
     bool readFromFile(const char* filename);
 
     // Provide an atomic way to get both the rootOctalCode and endNodeOctalCodes.
-    std::tuple<OctalCodePtr, OctalCodePtrList> JurisdictionMap::getRootAndEndNodeOctalCodes() const;
+    std::tuple<OctalCodePtr, OctalCodePtrList> getRootAndEndNodeOctalCodes() const;
     OctalCodePtr getRootOctalCode() const;
     OctalCodePtrList getEndNodeOctalCodes() const;
 

--- a/libraries/octree/src/JurisdictionMap.h
+++ b/libraries/octree/src/JurisdictionMap.h
@@ -23,6 +23,7 @@
 
 #include <NLPacket.h>
 #include <Node.h>
+#include <OctalCode.h>
 
 class JurisdictionMap {
 public:
@@ -41,7 +42,7 @@ public:
 
     // application constructors
     JurisdictionMap(const char* filename);
-    JurisdictionMap(unsigned char* rootOctalCode, const std::vector<unsigned char*>& endNodes);
+//    JurisdictionMap(unsigned char* rootOctalCode, const std::vector<unsigned char*>& endNodes);
     JurisdictionMap(const char* rootHextString, const char* endNodesHextString);
     ~JurisdictionMap();
 
@@ -50,11 +51,10 @@ public:
     bool writeToFile(const char* filename);
     bool readFromFile(const char* filename);
 
-    unsigned char* getRootOctalCode() const { return _rootOctalCode; }
-    unsigned char* getEndNodeOctalCode(int index) const { return _endNodes[index]; }
-    int getEndNodeCount() const { return (int)_endNodes.size(); }
+    OctalCodePtr getRootOctalCode() const { return _rootOctalCode; }
+    std::vector<OctalCodePtr> getEndNodeOctalCodes() const { return _endNodes; }
 
-    void copyContents(unsigned char* rootCodeIn, const std::vector<unsigned char*>& endNodesIn);
+    void copyContents(const OctalCodePtr& rootCodeIn, const std::vector<OctalCodePtr>& endNodesIn);
 
     int unpackFromPacket(ReceivedMessage& message);
     std::unique_ptr<NLPacket> packIntoPacket();
@@ -69,11 +69,11 @@ public:
 
 private:
     void copyContents(const JurisdictionMap& other); // use assignment instead
-    void clear();
-    void init(unsigned char* rootOctalCode, const std::vector<unsigned char*>& endNodes);
+    void init(OctalCodePtr rootOctalCode, const std::vector<OctalCodePtr>& endNodes);
 
-    unsigned char* _rootOctalCode;
-    std::vector<unsigned char*> _endNodes;
+    mutable std::mutex _octalCodeMutex;
+    OctalCodePtr _rootOctalCode { nullptr };
+    std::vector<OctalCodePtr> _endNodes;
     NodeType_t _nodeType;
 };
 

--- a/libraries/octree/src/JurisdictionMap.h
+++ b/libraries/octree/src/JurisdictionMap.h
@@ -42,8 +42,8 @@ public:
 
     // application constructors
     JurisdictionMap(const char* filename);
-//    JurisdictionMap(unsigned char* rootOctalCode, const std::vector<unsigned char*>& endNodes);
     JurisdictionMap(const char* rootHextString, const char* endNodesHextString);
+
     ~JurisdictionMap();
 
     Area isMyJurisdiction(const unsigned char* nodeOctalCode, int childIndex) const;
@@ -70,7 +70,7 @@ public:
 
 private:
     void copyContents(const JurisdictionMap& other); // use assignment instead
-    void init(OctalCodePtr rootOctalCode, const std::vector<OctalCodePtr>& endNodes);
+    void init(OctalCodePtr rootOctalCode, const OctalCodePtrList& endNodes);
 
     mutable std::mutex _octalCodeMutex;
     OctalCodePtr _rootOctalCode { nullptr };

--- a/libraries/octree/src/JurisdictionMap.h
+++ b/libraries/octree/src/JurisdictionMap.h
@@ -51,10 +51,11 @@ public:
     bool writeToFile(const char* filename);
     bool readFromFile(const char* filename);
 
-    OctalCodePtr getRootOctalCode() const { return _rootOctalCode; }
-    std::vector<OctalCodePtr> getEndNodeOctalCodes() const { return _endNodes; }
+    std::tuple<OctalCodePtr, OctalCodePtrList> JurisdictionMap::getRootOctalCodeAndEndNodes() const;
+    OctalCodePtr getRootOctalCode() const;
+    OctalCodePtrList getEndNodeOctalCodes() const;
 
-    void copyContents(const OctalCodePtr& rootCodeIn, const std::vector<OctalCodePtr>& endNodesIn);
+    void copyContents(const OctalCodePtr& rootCodeIn, const OctalCodePtrList& endNodesIn);
 
     int unpackFromPacket(ReceivedMessage& message);
     std::unique_ptr<NLPacket> packIntoPacket();
@@ -73,7 +74,7 @@ private:
 
     mutable std::mutex _octalCodeMutex;
     OctalCodePtr _rootOctalCode { nullptr };
-    std::vector<OctalCodePtr> _endNodes;
+    OctalCodePtrList _endNodes;
     NodeType_t _nodeType;
 };
 

--- a/libraries/octree/src/OctreeHeadlessViewer.cpp
+++ b/libraries/octree/src/OctreeHeadlessViewer.cpp
@@ -78,12 +78,12 @@ void OctreeHeadlessViewer::queryOctree() {
                 }
                 const JurisdictionMap& map = (jurisdictions)[nodeUUID];
 
-                unsigned char* rootCode = map.getRootOctalCode();
+                auto rootCode = map.getRootOctalCode();
                 if (!rootCode) {
                     return;
                 }
 
-                voxelDetailsForCode(rootCode, rootDetails);
+                voxelDetailsForCode(rootCode.get(), rootDetails);
                 foundRootDetails = true;
             });
 
@@ -146,7 +146,7 @@ void OctreeHeadlessViewer::queryOctree() {
                 }
 
                 const JurisdictionMap& map = (jurisdictions)[nodeUUID];
-                unsigned char* rootCode = map.getRootOctalCode();
+                auto rootCode = map.getRootOctalCode();
 
                 if (!rootCode) {
                     if (wantExtraDebugging) {
@@ -154,7 +154,7 @@ void OctreeHeadlessViewer::queryOctree() {
                     }
                     return;
                 }
-                voxelDetailsForCode(rootCode, rootDetails);
+                voxelDetailsForCode(rootCode.get(), rootDetails);
                 foundRootDetails = true;
             });
 

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -110,29 +110,21 @@ void OctreeSceneStats::copyFromOther(const OctreeSceneStats& other) {
     _treesRemoved = other._treesRemoved;
 
     // before copying the jurisdictions, delete any current values...
-    if (_jurisdictionRoot) {
-        delete[] _jurisdictionRoot;
-        _jurisdictionRoot = NULL;
-    }
-    for (size_t i = 0; i < _jurisdictionEndNodes.size(); i++) {
-        if (_jurisdictionEndNodes[i]) {
-            delete[] _jurisdictionEndNodes[i];
-        }
-    }
+    _jurisdictionRoot = nullptr;
     _jurisdictionEndNodes.clear();
 
     // Now copy the values from the other
     if (other._jurisdictionRoot) {
-        auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(other._jurisdictionRoot));
-        _jurisdictionRoot = new unsigned char[bytes];
-        memcpy(_jurisdictionRoot, other._jurisdictionRoot, bytes);
+        auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(other._jurisdictionRoot.get()));
+        _jurisdictionRoot = OctalCodePtr(new unsigned char[bytes]);
+        memcpy(_jurisdictionRoot.get(), other._jurisdictionRoot.get(), bytes);
     }
     for (size_t i = 0; i < other._jurisdictionEndNodes.size(); i++) {
-        unsigned char* endNodeCode = other._jurisdictionEndNodes[i];
+        auto& endNodeCode = other._jurisdictionEndNodes[i];
         if (endNodeCode) {
-            auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(endNodeCode));
-            unsigned char* endNodeCodeCopy = new unsigned char[bytes];
-            memcpy(endNodeCodeCopy, endNodeCode, bytes);
+            auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(endNodeCode.get()));
+            auto endNodeCodeCopy = OctalCodePtr(new unsigned char[bytes]);
+            memcpy(endNodeCodeCopy.get(), endNodeCode.get(), bytes);
             _jurisdictionEndNodes.push_back(endNodeCodeCopy);
         }
     }
@@ -162,37 +154,15 @@ void OctreeSceneStats::sceneStarted(bool isFullScene, bool isMoving, OctreeEleme
     _isFullScene = isFullScene;
     _isMoving = isMoving;
 
-    if (_jurisdictionRoot) {
-        delete[] _jurisdictionRoot;
-        _jurisdictionRoot = NULL;
-    }
+    _jurisdictionRoot = nullptr;
+
     // clear existing endNodes before copying new ones...
-    for (size_t i=0; i < _jurisdictionEndNodes.size(); i++) {
-        if (_jurisdictionEndNodes[i]) {
-            delete[] _jurisdictionEndNodes[i];
-        }
-    }
     _jurisdictionEndNodes.clear();
 
     // setup jurisdictions
     if (jurisdictionMap) {
-        unsigned char* jurisdictionRoot = jurisdictionMap->getRootOctalCode();
-        if (jurisdictionRoot) {
-            auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(jurisdictionRoot));
-            _jurisdictionRoot = new unsigned char[bytes];
-            memcpy(_jurisdictionRoot, jurisdictionRoot, bytes);
-        }
-
-        // copy new endNodes...
-        for (int i = 0; i < jurisdictionMap->getEndNodeCount(); i++) {
-            unsigned char* endNodeCode = jurisdictionMap->getEndNodeOctalCode(i);
-            if (endNodeCode) {
-                auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(endNodeCode));
-                unsigned char* endNodeCodeCopy = new unsigned char[bytes];
-                memcpy(endNodeCodeCopy, endNodeCode, bytes);
-                _jurisdictionEndNodes.push_back(endNodeCodeCopy);
-            }
-        }
+        _jurisdictionRoot = jurisdictionMap->getRootOctalCode();
+        _jurisdictionEndNodes = jurisdictionMap->getEndNodeOctalCodes();
     }
 }
 
@@ -270,15 +240,7 @@ void OctreeSceneStats::reset() {
     _existsInPacketBitsWritten = 0;
     _treesRemoved = 0;
 
-    if (_jurisdictionRoot) {
-        delete[] _jurisdictionRoot;
-        _jurisdictionRoot = NULL;
-    }
-    for (size_t i = 0; i < _jurisdictionEndNodes.size(); i++) {
-        if (_jurisdictionEndNodes[i]) {
-            delete[] _jurisdictionEndNodes[i];
-        }
-    }
+    _jurisdictionRoot = nullptr;
     _jurisdictionEndNodes.clear();
 }
 
@@ -418,9 +380,9 @@ int OctreeSceneStats::packIntoPacket() {
     // add the root jurisdiction
     if (_jurisdictionRoot) {
         // copy the
-        int bytes = (int)bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(_jurisdictionRoot));
+        int bytes = (int)bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(_jurisdictionRoot.get()));
         _statsPacket->writePrimitive(bytes);
-        _statsPacket->write(reinterpret_cast<char*>(_jurisdictionRoot), bytes);
+        _statsPacket->write(reinterpret_cast<char*>(_jurisdictionRoot.get()), bytes);
 
         // if and only if there's a root jurisdiction, also include the end elements
         int endNodeCount = (int)_jurisdictionEndNodes.size();
@@ -428,10 +390,10 @@ int OctreeSceneStats::packIntoPacket() {
         _statsPacket->writePrimitive(endNodeCount);
 
         for (int i=0; i < endNodeCount; i++) {
-            unsigned char* endNodeCode = _jurisdictionEndNodes[i];
-            auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(endNodeCode));
+            auto& endNodeCode = _jurisdictionEndNodes[i];
+            auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(endNodeCode.get()));
             _statsPacket->writePrimitive(bytes);
-            _statsPacket->write(reinterpret_cast<char*>(endNodeCode), bytes);
+            _statsPacket->write(reinterpret_cast<char*>(endNodeCode.get()), bytes);
         }
     } else {
         int bytes = 0;
@@ -500,17 +462,7 @@ int OctreeSceneStats::unpackFromPacket(ReceivedMessage& packet) {
     packet.readPrimitive(&_existsInPacketBitsWritten);
     packet.readPrimitive(&_treesRemoved);
     // before allocating new juridiction, clean up existing ones
-    if (_jurisdictionRoot) {
-        delete[] _jurisdictionRoot;
-        _jurisdictionRoot = NULL;
-    }
-    
-    // clear existing endNodes before copying new ones...
-    for (size_t i = 0; i < _jurisdictionEndNodes.size(); i++) {
-        if (_jurisdictionEndNodes[i]) {
-            delete[] _jurisdictionEndNodes[i];
-        }
-    }
+    _jurisdictionRoot = nullptr;
     _jurisdictionEndNodes.clear();
 
     // read the root jurisdiction
@@ -518,11 +470,11 @@ int OctreeSceneStats::unpackFromPacket(ReceivedMessage& packet) {
     packet.readPrimitive(&bytes);
 
     if (bytes == 0) {
-        _jurisdictionRoot = NULL;
+        _jurisdictionRoot = nullptr;
         _jurisdictionEndNodes.clear();
     } else {
-        _jurisdictionRoot = new unsigned char[bytes];
-        packet.read(reinterpret_cast<char*>(_jurisdictionRoot), bytes);
+        _jurisdictionRoot = OctalCodePtr(new unsigned char[bytes]);
+        packet.read(reinterpret_cast<char*>(_jurisdictionRoot.get()), bytes);
 
         // if and only if there's a root jurisdiction, also include the end elements
         _jurisdictionEndNodes.clear();
@@ -535,8 +487,8 @@ int OctreeSceneStats::unpackFromPacket(ReceivedMessage& packet) {
             
             packet.readPrimitive(&bytes);
             
-            unsigned char* endNodeCode = new unsigned char[bytes];
-            packet.read(reinterpret_cast<char*>(endNodeCode), bytes);
+            auto endNodeCode = OctalCodePtr(new unsigned char[bytes]);
+            packet.read(reinterpret_cast<char*>(endNodeCode.get()), bytes);
             
             _jurisdictionEndNodes.push_back(endNodeCode);
         }

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -116,14 +116,14 @@ void OctreeSceneStats::copyFromOther(const OctreeSceneStats& other) {
     // Now copy the values from the other
     if (other._jurisdictionRoot) {
         auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(other._jurisdictionRoot.get()));
-        _jurisdictionRoot = allocateOctalCodePtr(bytes);
+        _jurisdictionRoot = createOctalCodePtr(bytes);
         memcpy(_jurisdictionRoot.get(), other._jurisdictionRoot.get(), bytes);
     }
     for (size_t i = 0; i < other._jurisdictionEndNodes.size(); i++) {
         auto& endNodeCode = other._jurisdictionEndNodes[i];
         if (endNodeCode) {
             auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(endNodeCode.get()));
-            auto endNodeCodeCopy = allocateOctalCodePtr(bytes);
+            auto endNodeCodeCopy = createOctalCodePtr(bytes);
             memcpy(endNodeCodeCopy.get(), endNodeCode.get(), bytes);
             _jurisdictionEndNodes.push_back(endNodeCodeCopy);
         }
@@ -156,7 +156,7 @@ void OctreeSceneStats::sceneStarted(bool isFullScene, bool isMoving, OctreeEleme
 
     // setup jurisdictions
     if (jurisdictionMap) {
-        std::tie(_jurisdictionRoot, _jurisdictionEndNodes) = jurisdictionMap->getRootOctalCodeAndEndNodes();
+        std::tie(_jurisdictionRoot, _jurisdictionEndNodes) = jurisdictionMap->getRootAndEndNodeOctalCodes();
     } else {
         _jurisdictionRoot = nullptr;
         _jurisdictionEndNodes.clear();
@@ -470,7 +470,7 @@ int OctreeSceneStats::unpackFromPacket(ReceivedMessage& packet) {
         _jurisdictionRoot = nullptr;
         _jurisdictionEndNodes.clear();
     } else {
-        _jurisdictionRoot = allocateOctalCodePtr(bytes);
+        _jurisdictionRoot = createOctalCodePtr(bytes);
         packet.read(reinterpret_cast<char*>(_jurisdictionRoot.get()), bytes);
 
         // if and only if there's a root jurisdiction, also include the end elements
@@ -484,7 +484,7 @@ int OctreeSceneStats::unpackFromPacket(ReceivedMessage& packet) {
             
             packet.readPrimitive(&bytes);
             
-            auto endNodeCode = allocateOctalCodePtr(bytes);
+            auto endNodeCode = createOctalCodePtr(bytes);
             packet.read(reinterpret_cast<char*>(endNodeCode.get()), bytes);
             
             _jurisdictionEndNodes.push_back(endNodeCode);

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -116,14 +116,14 @@ void OctreeSceneStats::copyFromOther(const OctreeSceneStats& other) {
     // Now copy the values from the other
     if (other._jurisdictionRoot) {
         auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(other._jurisdictionRoot.get()));
-        _jurisdictionRoot = OctalCodePtr(new unsigned char[bytes]);
+        _jurisdictionRoot = allocateOctalCodePtr(bytes);
         memcpy(_jurisdictionRoot.get(), other._jurisdictionRoot.get(), bytes);
     }
     for (size_t i = 0; i < other._jurisdictionEndNodes.size(); i++) {
         auto& endNodeCode = other._jurisdictionEndNodes[i];
         if (endNodeCode) {
             auto bytes = bytesRequiredForCodeLength(numberOfThreeBitSectionsInCode(endNodeCode.get()));
-            auto endNodeCodeCopy = OctalCodePtr(new unsigned char[bytes]);
+            auto endNodeCodeCopy = allocateOctalCodePtr(bytes);
             memcpy(endNodeCodeCopy.get(), endNodeCode.get(), bytes);
             _jurisdictionEndNodes.push_back(endNodeCodeCopy);
         }
@@ -470,7 +470,7 @@ int OctreeSceneStats::unpackFromPacket(ReceivedMessage& packet) {
         _jurisdictionRoot = nullptr;
         _jurisdictionEndNodes.clear();
     } else {
-        _jurisdictionRoot = OctalCodePtr(new unsigned char[bytes]);
+        _jurisdictionRoot = allocateOctalCodePtr(bytes);
         packet.read(reinterpret_cast<char*>(_jurisdictionRoot.get()), bytes);
 
         // if and only if there's a root jurisdiction, also include the end elements
@@ -484,7 +484,7 @@ int OctreeSceneStats::unpackFromPacket(ReceivedMessage& packet) {
             
             packet.readPrimitive(&bytes);
             
-            auto endNodeCode = OctalCodePtr(new unsigned char[bytes]);
+            auto endNodeCode = allocateOctalCodePtr(bytes);
             packet.read(reinterpret_cast<char*>(endNodeCode.get()), bytes);
             
             _jurisdictionEndNodes.push_back(endNodeCode);

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -154,15 +154,12 @@ void OctreeSceneStats::sceneStarted(bool isFullScene, bool isMoving, OctreeEleme
     _isFullScene = isFullScene;
     _isMoving = isMoving;
 
-    _jurisdictionRoot = nullptr;
-
-    // clear existing endNodes before copying new ones...
-    _jurisdictionEndNodes.clear();
-
     // setup jurisdictions
     if (jurisdictionMap) {
-        _jurisdictionRoot = jurisdictionMap->getRootOctalCode();
-        _jurisdictionEndNodes = jurisdictionMap->getEndNodeOctalCodes();
+        std::tie(_jurisdictionRoot, _jurisdictionEndNodes) = jurisdictionMap->getRootOctalCodeAndEndNodes();
+    } else {
+        _jurisdictionRoot = nullptr;
+        _jurisdictionEndNodes.clear();
     }
 }
 

--- a/libraries/octree/src/OctreeSceneStats.h
+++ b/libraries/octree/src/OctreeSceneStats.h
@@ -147,7 +147,7 @@ public:
     OctalCodePtr getJurisdictionRoot() const { return _jurisdictionRoot; }
 
     /// Returns list of OctCodes for end elements of the jurisdiction of this particular octree server
-    const std::vector<OctalCodePtr>& getJurisdictionEndNodes() const { return _jurisdictionEndNodes; }
+    const OctalCodePtrList& getJurisdictionEndNodes() const { return _jurisdictionEndNodes; }
 
     bool isMoving() const { return _isMoving; }
     bool isFullScene() const { return _isFullScene; }

--- a/libraries/octree/src/OctreeSceneStats.h
+++ b/libraries/octree/src/OctreeSceneStats.h
@@ -20,6 +20,7 @@
 #include "JurisdictionMap.h"
 #include "OctreePacketData.h"
 #include "SequenceNumberStats.h"
+#include "OctalCode.h"
 
 #define GREENISH  0x40ff40d0
 #define YELLOWISH 0xffef40c0
@@ -143,10 +144,10 @@ public:
     const char* getItemValue(Item item);
 
     /// Returns OctCode for root element of the jurisdiction of this particular octree server
-    unsigned char* getJurisdictionRoot() const { return _jurisdictionRoot; }
+    OctalCodePtr getJurisdictionRoot() const { return _jurisdictionRoot; }
 
     /// Returns list of OctCodes for end elements of the jurisdiction of this particular octree server
-    const std::vector<unsigned char*>& getJurisdictionEndNodes() const { return _jurisdictionEndNodes; }
+    const std::vector<OctalCodePtr>& getJurisdictionEndNodes() const { return _jurisdictionEndNodes; }
 
     bool isMoving() const { return _isMoving; }
     bool isFullScene() const { return _isFullScene; }
@@ -277,8 +278,8 @@ private:
     static const int MAX_ITEM_VALUE_LENGTH = 128;
     char _itemValueBuffer[MAX_ITEM_VALUE_LENGTH];
 
-    unsigned char* _jurisdictionRoot;
-    std::vector<unsigned char*> _jurisdictionEndNodes;
+    OctalCodePtr _jurisdictionRoot;
+    std::vector<OctalCodePtr> _jurisdictionEndNodes;
 };
 
 /// Map between element IDs and their reported OctreeSceneStats. Typically used by classes that need to know which elements sent

--- a/libraries/shared/src/OctalCode.cpp
+++ b/libraries/shared/src/OctalCode.cpp
@@ -304,7 +304,7 @@ bool isAncestorOf(const unsigned char* possibleAncestor, const unsigned char* po
     return true;
 }
 
-OctalCodePtr allocateOctalCodePtr(size_t size) {
+OctalCodePtr createOctalCodePtr(size_t size) {
     return OctalCodePtr(new unsigned char[size], std::default_delete<unsigned char[]>());
 }
 
@@ -315,7 +315,7 @@ OctalCodePtr hexStringToOctalCode(const QString& input) {
     int byteArrayIndex = 0;
 
     // allocate byte array based on half of string length
-    auto bytes = allocateOctalCodePtr(input.length() / HEX_BYTE_SIZE);
+    auto bytes = createOctalCodePtr(input.length() / HEX_BYTE_SIZE);
 
     // loop through the string - 2 bytes at a time converting
     //  it to decimal equivalent and store in byte array

--- a/libraries/shared/src/OctalCode.cpp
+++ b/libraries/shared/src/OctalCode.cpp
@@ -304,14 +304,14 @@ bool isAncestorOf(const unsigned char* possibleAncestor, const unsigned char* po
     return true;
 }
 
-unsigned char* hexStringToOctalCode(const QString& input) {
+std::shared_ptr<unsigned char> hexStringToOctalCode(const QString& input) {
     const int HEX_NUMBER_BASE = 16;
     const int HEX_BYTE_SIZE = 2;
     int stringIndex = 0;
     int byteArrayIndex = 0;
 
     // allocate byte array based on half of string length
-    unsigned char* bytes = new unsigned char[(input.length()) / HEX_BYTE_SIZE];
+    auto bytes = std::shared_ptr<unsigned char>(new unsigned char[(input.length()) / HEX_BYTE_SIZE]);
 
     // loop through the string - 2 bytes at a time converting
     //  it to decimal equivalent and store in byte array
@@ -321,15 +321,14 @@ unsigned char* hexStringToOctalCode(const QString& input) {
         if (!ok) {
             break;
         }
-        bytes[byteArrayIndex] = (unsigned char)value;
+        bytes.get()[byteArrayIndex] = (unsigned char)value;
         stringIndex += HEX_BYTE_SIZE;
         byteArrayIndex++;
     }
 
     // something went wrong
     if (!ok) {
-        delete[] bytes;
-        return NULL;
+        return nullptr;
     }
     return bytes;
 }

--- a/libraries/shared/src/OctalCode.cpp
+++ b/libraries/shared/src/OctalCode.cpp
@@ -304,7 +304,7 @@ bool isAncestorOf(const unsigned char* possibleAncestor, const unsigned char* po
     return true;
 }
 
-std::shared_ptr<unsigned char> hexStringToOctalCode(const QString& input) {
+OctalCodePtr hexStringToOctalCode(const QString& input) {
     const int HEX_NUMBER_BASE = 16;
     const int HEX_BYTE_SIZE = 2;
     int stringIndex = 0;

--- a/libraries/shared/src/OctalCode.cpp
+++ b/libraries/shared/src/OctalCode.cpp
@@ -304,6 +304,10 @@ bool isAncestorOf(const unsigned char* possibleAncestor, const unsigned char* po
     return true;
 }
 
+OctalCodePtr allocateOctalCodePtr(size_t size) {
+    return OctalCodePtr(new unsigned char[size], std::default_delete<unsigned char[]>());
+}
+
 OctalCodePtr hexStringToOctalCode(const QString& input) {
     const int HEX_NUMBER_BASE = 16;
     const int HEX_BYTE_SIZE = 2;
@@ -311,7 +315,7 @@ OctalCodePtr hexStringToOctalCode(const QString& input) {
     int byteArrayIndex = 0;
 
     // allocate byte array based on half of string length
-    auto bytes = std::shared_ptr<unsigned char>(new unsigned char[(input.length()) / HEX_BYTE_SIZE]);
+    auto bytes = allocateOctalCodePtr(input.length() / HEX_BYTE_SIZE);
 
     // loop through the string - 2 bytes at a time converting
     //  it to decimal equivalent and store in byte array

--- a/libraries/shared/src/OctalCode.h
+++ b/libraries/shared/src/OctalCode.h
@@ -61,7 +61,7 @@ typedef enum {
 
 OctalCodeComparison compareOctalCodes(const unsigned char* code1, const unsigned char* code2);
 
-OctalCodePtr allocateOctalCodePtr(size_t size);
+OctalCodePtr createOctalCodePtr(size_t size);
 QString octalCodeToHexString(const unsigned char* octalCode);
 OctalCodePtr hexStringToOctalCode(const QString& input);
 

--- a/libraries/shared/src/OctalCode.h
+++ b/libraries/shared/src/OctalCode.h
@@ -12,8 +12,9 @@
 #ifndef hifi_OctalCode_h
 #define hifi_OctalCode_h
 
-#include <string.h>
 #include <QString>
+
+#include <memory>
 
 const int BITS_IN_OCTAL = 3;
 const int NUMBER_OF_COLORS = 3; // RGB!
@@ -21,6 +22,8 @@ const int SIZE_OF_COLOR_DATA = NUMBER_OF_COLORS * sizeof(unsigned char); // size
 const int RED_INDEX   = 0;
 const int GREEN_INDEX = 1;
 const int BLUE_INDEX  = 2;
+
+using OctalCodePtr = std::shared_ptr<unsigned char>;
 
 void printOctalCode(const unsigned char* octalCode);
 size_t bytesRequiredForCodeLength(unsigned char threeBitCodes);
@@ -58,6 +61,6 @@ typedef enum {
 OctalCodeComparison compareOctalCodes(const unsigned char* code1, const unsigned char* code2);
 
 QString octalCodeToHexString(const unsigned char* octalCode);
-unsigned char* hexStringToOctalCode(const QString& input);
+std::shared_ptr<unsigned char> hexStringToOctalCode(const QString& input);
 
 #endif // hifi_OctalCode_h

--- a/libraries/shared/src/OctalCode.h
+++ b/libraries/shared/src/OctalCode.h
@@ -61,6 +61,7 @@ typedef enum {
 
 OctalCodeComparison compareOctalCodes(const unsigned char* code1, const unsigned char* code2);
 
+OctalCodePtr allocateOctalCodePtr(size_t size);
 QString octalCodeToHexString(const unsigned char* octalCode);
 OctalCodePtr hexStringToOctalCode(const QString& input);
 

--- a/libraries/shared/src/OctalCode.h
+++ b/libraries/shared/src/OctalCode.h
@@ -24,6 +24,7 @@ const int GREEN_INDEX = 1;
 const int BLUE_INDEX  = 2;
 
 using OctalCodePtr = std::shared_ptr<unsigned char>;
+using OctalCodePtrList = std::vector<OctalCodePtr>;
 
 void printOctalCode(const unsigned char* octalCode);
 size_t bytesRequiredForCodeLength(unsigned char threeBitCodes);
@@ -61,6 +62,6 @@ typedef enum {
 OctalCodeComparison compareOctalCodes(const unsigned char* code1, const unsigned char* code2);
 
 QString octalCodeToHexString(const unsigned char* octalCode);
-std::shared_ptr<unsigned char> hexStringToOctalCode(const QString& input);
+OctalCodePtr hexStringToOctalCode(const QString& input);
 
 #endif // hifi_OctalCode_h

--- a/libraries/shared/src/OctalCode.h
+++ b/libraries/shared/src/OctalCode.h
@@ -12,6 +12,7 @@
 #ifndef hifi_OctalCode_h
 #define hifi_OctalCode_h
 
+#include <vector>
 #include <QString>
 
 #include <memory>


### PR DESCRIPTION
This is an attempt to fix a crash in JurisdictionMap. The _rootOctalCode used a bare pointer, allowing access across multiple threads in an unsafe way. Changes:

 * Make _rootOctalCode and _endNodes use std::shared_ptr so that their lifetime can be properly extended when they are being accessed externally.
  * Add guards around access to _rootOctalCode and _endNodes
  * Add atomic `getRootAndEndNodeOctalCodes` to avoid race conditions when getting both values.