### PR TITLE
[Toybox] Fix utils paths

### DIFF
--- a/unpublishedScripts/DomainContent/Toybox/basketball/createRack.js
+++ b/unpublishedScripts/DomainContent/Toybox/basketball/createRack.js
@@ -9,7 +9,7 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
-Script.include("libraries/utils.js");
+Script.include("../libraries/utils.js");
 
 var basketballURL ="http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/basketball/basketball2.fbx";
 var collisionSoundURL = "http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/basketball/basketball.wav";

--- a/unpublishedScripts/DomainContent/Toybox/bow/bow.js
+++ b/unpublishedScripts/DomainContent/Toybox/bow/bow.js
@@ -11,7 +11,7 @@
 
 (function() {
 
-    Script.include("libraries/utils.js");
+    Script.include("../libraries/utils.js");
 
     var NOTCH_ARROW_SOUND_URL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/bow/notch.wav';
     var SHOOT_ARROW_SOUND_URL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/bow/String_release2.L.wav';

--- a/unpublishedScripts/DomainContent/Toybox/bow/createBow.js
+++ b/unpublishedScripts/DomainContent/Toybox/bow/createBow.js
@@ -10,7 +10,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var utilsPath = Script.resolvePath('libraries/utils.js');
+var utilsPath = Script.resolvePath('../libraries/utils.js');
 Script.include(utilsPath);
 
 var SCRIPT_URL = Script.resolvePath('bow.js');

--- a/unpublishedScripts/DomainContent/Toybox/bubblewand/createWand.js
+++ b/unpublishedScripts/DomainContent/Toybox/bubblewand/createWand.js
@@ -10,7 +10,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 
-Script.include("libraries/utils.js");
+Script.include("../libraries/utils.js");
 
 var WAND_MODEL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/bubblewand/wand.fbx';
 var WAND_COLLISION_SHAPE = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/bubblewand/wand_collision_hull.obj';

--- a/unpublishedScripts/DomainContent/Toybox/bubblewand/wand.js
+++ b/unpublishedScripts/DomainContent/Toybox/bubblewand/wand.js
@@ -14,7 +14,7 @@
 
 (function() {
 
-    Script.include("libraries/utils.js");
+    Script.include("../libraries/utils.js");
 
     var BUBBLE_MODEL = "http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/bubblewand/bubble.fbx";
 

--- a/unpublishedScripts/DomainContent/Toybox/doll/doll.js
+++ b/unpublishedScripts/DomainContent/Toybox/doll/doll.js
@@ -13,7 +13,7 @@
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, Audio, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 
 (function() {
-    Script.include("libraries/utils.js");
+    Script.include("../libraries/utils.js");
     var _this;
     // this is the "constructor" for the entity as a JS object we don't do much here
     var Doll = function() {

--- a/unpublishedScripts/DomainContent/Toybox/flashlight/createFlashlight.js
+++ b/unpublishedScripts/DomainContent/Toybox/flashlight/createFlashlight.js
@@ -12,7 +12,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
-Script.include("libraries/utils.js");
+Script.include("../libraries/utils.js");
 
 var scriptURL = Script.resolvePath('flashlight.js');
 

--- a/unpublishedScripts/DomainContent/Toybox/flashlight/flashlight.js
+++ b/unpublishedScripts/DomainContent/Toybox/flashlight/flashlight.js
@@ -17,7 +17,7 @@
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, Audio, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 (function() {
 
-    Script.include("libraries/utils.js");
+    Script.include("../libraries/utils.js");
 
     var ON_SOUND_URL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/flashlight/flashlight_on.wav';
     var OFF_SOUND_URL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/flashlight/flashlight_off.wav';

--- a/unpublishedScripts/DomainContent/Toybox/lights/lightSwitch.js
+++ b/unpublishedScripts/DomainContent/Toybox/lights/lightSwitch.js
@@ -17,7 +17,7 @@
 
 (function() {
     var _this;
-    var utilitiesScript = Script.resolvePath("libraries/utils.js");
+    var utilitiesScript = Script.resolvePath("../libraries/utils.js");
     Script.include(utilitiesScript);
     LightSwitch = function() {
         _this = this;

--- a/unpublishedScripts/DomainContent/Toybox/ping_pong_gun/createPingPongGun.js
+++ b/unpublishedScripts/DomainContent/Toybox/ping_pong_gun/createPingPongGun.js
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
-Script.include("../../libraries/utils.js");
+Script.include("../libraries/utils.js");
 
 var scriptURL = Script.resolvePath('pingPongGun.js');
 

--- a/unpublishedScripts/DomainContent/Toybox/ping_pong_gun/createTargets.js
+++ b/unpublishedScripts/DomainContent/Toybox/ping_pong_gun/createTargets.js
@@ -11,7 +11,7 @@
 //
 /*global MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 
-Script.include("utils.js");
+Script.include("../libraries/utils.js");
 var scriptURL = Script.resolvePath('wallTarget.js');
 
 var MODEL_URL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/ping_pong_gun/target.fbx';

--- a/unpublishedScripts/DomainContent/Toybox/ping_pong_gun/pingPongGun.js
+++ b/unpublishedScripts/DomainContent/Toybox/ping_pong_gun/pingPongGun.js
@@ -11,7 +11,7 @@
 /*global print, MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, Audio, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt */
 (function() {
 
-    Script.include("utils.js");
+    Script.include("../libraries/utils.js");
 
     var SHOOTING_SOUND_URL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/ping_pong_gun/pong_sound.wav';
     var PING_PONG_BALL_URL = 'http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/ping_pong_gun/ping_pong_ball.fbx';

--- a/unpublishedScripts/DomainContent/Toybox/pistol/pistol.js
+++ b/unpublishedScripts/DomainContent/Toybox/pistol/pistol.js
@@ -11,7 +11,7 @@
 
 
 (function() {
-    Script.include("libraries/utils.js");
+    Script.include("../libraries/utils.js");
 
     var _this;
     var DISABLE_LASER_THRESHOLD = 0.2;

--- a/unpublishedScripts/DomainContent/Toybox/spray_paint/sprayPaintCan.js
+++ b/unpublishedScripts/DomainContent/Toybox/spray_paint/sprayPaintCan.js
@@ -10,10 +10,7 @@
 
 
 (function () {
-    // Script.include("../libraries/utils.js");
-    //Need absolute path for now, for testing before PR merge and s3 cloning. Will change post-merge
-
-    Script.include("libraries/utils.js");
+ Script.include("../libraries/utils.js");
 
     this.spraySound = SoundCache.getSound("http://hifi-production.s3.amazonaws.com/DomainContent/Toybox/spray_paint/spray_paint.wav");
 


### PR DESCRIPTION
This PR fixes a previous PR that I did where I didn't get the paths to the utilities library right.  Since other entities would sometimes load utils into the entities namespace, often things worked and also worked on a refresh.  This makes them work the first time and all the time.

To test:
1. Go to your localhost
2. Clear caches
3. Go to "demo"
4. Open Running Scripts and do Reload All for a fresh start
5. Try each of the toys on the table and make sure they work without any reloading of scripts.

(this is deployed on production s3)