### PR TITLE
Support partial CPU->GPU buffer transfers

### DIFF
--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -267,7 +267,7 @@ void RenderableParticleEffectEntityItem::updateRenderItem() {
         if (numBytes == 0) {
             return;
         }
-        memcpy(particleBuffer->editData(), particlePrimitives->data(), numBytes);
+        particleBuffer->setData(numBytes, (const gpu::Byte*)particlePrimitives->data());
 
         // Update transform and bounds
         payload.setModelTransform(transform);

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -69,10 +69,10 @@ public:
         const GLuint _size;
         const Stamp _stamp;
 
-        GLBuffer(const Buffer& buffer);
+        GLBuffer(const Buffer& buffer, GLBuffer* original = nullptr);
         ~GLBuffer();
 
-        void transfer(bool forceAll = false);
+        void transfer();
 
     private:
         bool getNextTransferBlock(GLintptr& outOffset, GLsizeiptr& outSize, size_t& currentPage) const;

--- a/libraries/gpu/src/gpu/GLBackend.h
+++ b/libraries/gpu/src/gpu/GLBackend.h
@@ -65,15 +65,22 @@ public:
 
     class GLBuffer : public GPUObject {
     public:
-        Stamp _stamp;
-        GLuint _buffer;
-        GLuint _size;
+        const GLuint _buffer;
+        const GLuint _size;
+        const Stamp _stamp;
 
-        GLBuffer();
+        GLBuffer(const Buffer& buffer);
         ~GLBuffer();
 
-        void setSize(GLuint size);
+        void transfer(bool forceAll = false);
+
+    private:
+        bool getNextTransferBlock(GLintptr& outOffset, GLsizeiptr& outSize, size_t& currentPage) const;
+            
+        // The owning texture
+        const Buffer& _gpuBuffer;
     };
+
     static GLBuffer* syncGPUObject(const Buffer& buffer);
     static GLuint getBufferID(const Buffer& buffer);
 

--- a/libraries/gpu/src/gpu/GLBackendBuffer.cpp
+++ b/libraries/gpu/src/gpu/GLBackendBuffer.cpp
@@ -24,7 +24,6 @@ GLBackend::GLBuffer::GLBuffer(const Buffer& buffer, GLBuffer* original) :
     _size((GLuint)buffer._sysmem.getSize()),
     _stamp(buffer._sysmem.getStamp()),
     _gpuBuffer(buffer) {
-
     glBindBuffer(GL_ARRAY_BUFFER, _buffer);
     if (GLEW_VERSION_4_4 || GLEW_ARB_buffer_storage) {
         glBufferStorage(GL_ARRAY_BUFFER, _size, nullptr, GL_DYNAMIC_STORAGE_BIT);
@@ -46,6 +45,7 @@ GLBackend::GLBuffer::GLBuffer(const Buffer& buffer, GLBuffer* original) :
 
     Backend::setGPUObject(buffer, this);
     Backend::incrementBufferGPUCount();
+    Backend::updateBufferGPUMemoryUsage(0, _size);
 }
 
 GLBackend::GLBuffer::~GLBuffer() {

--- a/libraries/gpu/src/gpu/GLBackendBuffer.cpp
+++ b/libraries/gpu/src/gpu/GLBackendBuffer.cpp
@@ -12,14 +12,43 @@
 
 using namespace gpu;
 
-GLBackend::GLBuffer::GLBuffer() :
-    _stamp(0),
-    _buffer(0),
-    _size(0)
-{
-    Backend::incrementBufferGPUCount();
+static std::once_flag check_dsa;
+static bool DSA_SUPPORTED { false };
+
+GLuint allocateSingleBuffer() {
+    std::call_once(check_dsa, [&] {
+        DSA_SUPPORTED = (GLEW_VERSION_4_5 || GLEW_ARB_direct_state_access);
+    });
+    GLuint result;
+    if (DSA_SUPPORTED) {
+        glCreateBuffers(1, &result);
+    } else {
+        glGenBuffers(1, &result);
+    }
+    return result;
 }
 
+GLBackend::GLBuffer::GLBuffer(const Buffer& buffer) : 
+    _buffer(allocateSingleBuffer()), 
+    _size(buffer._sysmem.getSize()), 
+    _stamp(buffer._sysmem.getStamp()), 
+    _gpuBuffer(buffer) {
+    (void)CHECK_GL_ERROR();
+    Backend::setGPUObject(buffer, this);
+    if (DSA_SUPPORTED) {
+        glNamedBufferStorage(_buffer, _size, nullptr, GL_DYNAMIC_STORAGE_BIT);
+    } else {
+        glBindBuffer(GL_ARRAY_BUFFER, _buffer);
+        if (GLEW_VERSION_4_4 || GLEW_ARB_buffer_storage) {
+            glBufferStorage(GL_ARRAY_BUFFER, _size, nullptr, GL_DYNAMIC_STORAGE_BIT);
+        } else {
+            glBufferData(GL_ARRAY_BUFFER, buffer.getSysmem().getSize(), buffer.getSysmem().readData(), GL_DYNAMIC_DRAW);
+        }
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+    Backend::incrementBufferGPUCount();
+}
+    
 GLBackend::GLBuffer::~GLBuffer() {
     if (_buffer != 0) {
         glDeleteBuffers(1, &_buffer);
@@ -28,36 +57,98 @@ GLBackend::GLBuffer::~GLBuffer() {
     Backend::decrementBufferGPUCount();
 }
 
-void GLBackend::GLBuffer::setSize(GLuint size) {
-    Backend::updateBufferGPUMemoryUsage(_size, size);
-    _size = size;
+void GLBackend::GLBuffer::transfer(bool forceAll) {
+    const auto& pageFlags = _gpuBuffer._pages;
+    if (!forceAll) {
+        size_t transitions = 0;
+        if (pageFlags.size()) {
+            bool lastDirty = (0 != (pageFlags[0] & Buffer::DIRTY));
+            for (size_t i = 1; i < pageFlags.size(); ++i) {
+                bool newDirty = (0 != (pageFlags[0] & Buffer::DIRTY));
+                if (newDirty != lastDirty) {
+                    ++transitions;
+                    lastDirty = newDirty;
+                }
+            }
+        }
+
+        // If there are no transitions (implying the whole buffer is dirty) 
+        // or more than 20 transitions, then just transfer the whole buffer
+        if (transitions == 0 || transitions > 20) {
+            forceAll = true;
+        }
+    }
+
+    // Are we transferring the whole buffer?
+    if (forceAll) {
+        if (DSA_SUPPORTED) {
+            glNamedBufferSubData(_buffer, 0, _size, _gpuBuffer.getSysmem().readData());
+        } else {
+            // Now let's update the content of the bo with the sysmem version
+            // TODO: in the future, be smarter about when to actually upload the glBO version based on the data that did change
+            //if () {
+            glBindBuffer(GL_ARRAY_BUFFER, _buffer);
+            glBufferData(GL_ARRAY_BUFFER, _gpuBuffer.getSysmem().getSize(), _gpuBuffer.getSysmem().readData(), GL_DYNAMIC_DRAW);
+            glBindBuffer(GL_ARRAY_BUFFER, 0);
+        }
+    } else {
+        if (!DSA_SUPPORTED) {
+            glBindBuffer(GL_ARRAY_BUFFER, _buffer);
+        }
+        GLintptr offset;
+        GLsizeiptr size;
+        size_t currentPage { 0 };
+        auto data = _gpuBuffer.getSysmem().readData();
+        while (getNextTransferBlock(offset, size, currentPage)) {
+            if (DSA_SUPPORTED) {
+                glNamedBufferSubData(_buffer, offset, size, data + offset);
+            } else {
+                glBufferSubData(GL_ARRAY_BUFFER, offset, size, data + offset);
+            }
+        }
+
+        if (!DSA_SUPPORTED) {
+            glBindBuffer(GL_ARRAY_BUFFER, 0);
+        }
+    }
+    _gpuBuffer._flags &= ~Buffer::DIRTY;
+    (void)CHECK_GL_ERROR();
+}
+
+bool GLBackend::GLBuffer::getNextTransferBlock(GLintptr& outOffset, GLsizeiptr& outSize, size_t& currentPage) const {
+    size_t pageCount = _gpuBuffer._pages.size();
+    // Advance to the first dirty page
+    while (currentPage < pageCount && (0 == (Buffer::DIRTY & _gpuBuffer._pages[currentPage]))) {
+        ++currentPage;
+    }
+
+    // If we got to the end, we're done
+    if (currentPage >= pageCount) {
+        return false;
+    }
+
+    // Advance to the next clean page
+    outOffset = static_cast<GLintptr>(currentPage * _gpuBuffer._pageSize);
+    while (currentPage < pageCount && (0 != (Buffer::DIRTY & _gpuBuffer._pages[currentPage]))) {
+        ++currentPage;
+    }
+    outSize = static_cast<GLsizeiptr>((currentPage * _gpuBuffer._pageSize) - outOffset);
+    return true;
 }
 
 GLBackend::GLBuffer* GLBackend::syncGPUObject(const Buffer& buffer) {
     GLBuffer* object = Backend::getGPUObject<GLBackend::GLBuffer>(buffer);
 
-    if (object && (object->_stamp == buffer.getSysmem().getStamp())) {
-        return object;
+    bool forceTransferAll = false;
+    // Has the storage size changed?
+    if (!object || object->_stamp != buffer.getSysmem().getStamp()) {
+        object = new GLBuffer(buffer);
+        forceTransferAll = true;
     }
 
-    // need to have a gpu object?
-    if (!object) {
-        object = new GLBuffer();
-        glGenBuffers(1, &object->_buffer);
-        (void) CHECK_GL_ERROR();
-        Backend::setGPUObject(buffer, object);
+    if (forceTransferAll || (0 != (buffer._flags & Buffer::DIRTY))) {
+        object->transfer(forceTransferAll);
     }
-
-    // Now let's update the content of the bo with the sysmem version
-    // TODO: in the future, be smarter about when to actually upload the glBO version based on the data that did change
-    //if () {
-    glBindBuffer(GL_ARRAY_BUFFER, object->_buffer);
-    glBufferData(GL_ARRAY_BUFFER, buffer.getSysmem().getSize(), buffer.getSysmem().readData(), GL_DYNAMIC_DRAW);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    object->_stamp = buffer.getSysmem().getStamp();
-    object->setSize((GLuint)buffer.getSysmem().getSize());
-    //}
-    (void) CHECK_GL_ERROR();
 
     return object;
 }

--- a/libraries/gpu/src/gpu/Resource.cpp
+++ b/libraries/gpu/src/gpu/Resource.cpp
@@ -109,40 +109,18 @@ void Resource::Sysmem::deallocateMemory(Byte* dataAllocated, Size size) {
     }
 }
 
-Resource::Sysmem::Sysmem() :
-    _stamp(0),
-    _size(0),
-    _data(NULL)
-{
-}
+Resource::Sysmem::Sysmem() {}
 
-Resource::Sysmem::Sysmem(Size size, const Byte* bytes) :
-    _stamp(0),
-    _size(0),
-    _data(NULL)
-{
-    if (size > 0) {
-        _size = allocateMemory(&_data, size);
-        if (_size >= size) {
-            if (bytes) {
-                memcpy(_data, bytes, size);
-            }
-        }
+Resource::Sysmem::Sysmem(Size size, const Byte* bytes) {
+    if (size > 0 && bytes) {
+        setData(_size, bytes);
     }
 }
 
-Resource::Sysmem::Sysmem(const Sysmem& sysmem) :
-    _stamp(0),
-    _size(0),
-    _data(NULL)
-{
+Resource::Sysmem::Sysmem(const Sysmem& sysmem) {
     if (sysmem.getSize() > 0) {
-        _size = allocateMemory(&_data, sysmem.getSize());
-        if (_size >= sysmem.getSize()) {
-            if (sysmem.readData()) {
-                memcpy(_data, sysmem.readData(), sysmem.getSize());
-            }
-        }
+        allocate(sysmem._size);
+        setData(_size, sysmem._data);
     }
 }
 
@@ -208,7 +186,6 @@ Resource::Size Resource::Sysmem::setData( Size size, const Byte* bytes ) {
     if (allocate(size) == size) {
         if (size && bytes) {
             memcpy( _data, bytes, _size );
-            _stamp++;
         }
     }
     return _size;
@@ -217,7 +194,6 @@ Resource::Size Resource::Sysmem::setData( Size size, const Byte* bytes ) {
 Resource::Size Resource::Sysmem::setSubData( Size offset, Size size, const Byte* bytes) {
     if (size && ((offset + size) <= getSize()) && bytes) {
         memcpy( _data + offset, bytes, size );
-        _stamp++;
         return size;
     }
     return 0;
@@ -264,65 +240,105 @@ Buffer::Size Buffer::getBufferGPUMemoryUsage() {
     return Context::getBufferGPUMemoryUsage();
 }
 
-Buffer::Buffer() :
-    Resource(),
-    _sysmem(new Sysmem()) {
+Buffer::Buffer(Size pageSize) :
+    _pageSize(pageSize) {
     _bufferCPUCount++;
-
 }
 
-Buffer::Buffer(Size size, const Byte* bytes) :
-    Resource(),
-    _sysmem(new Sysmem(size, bytes)) {
-    _bufferCPUCount++;
-    Buffer::updateBufferCPUMemoryUsage(0, _sysmem->getSize());
+Buffer::Buffer(Size size, const Byte* bytes, Size pageSize) : Buffer(pageSize) {
+    setData(size, bytes);
 }
 
-Buffer::Buffer(const Buffer& buf) :
-    Resource(),
-    _sysmem(new Sysmem(buf.getSysmem())) {
-    _bufferCPUCount++;
-    Buffer::updateBufferCPUMemoryUsage(0, _sysmem->getSize());
+Buffer::Buffer(const Buffer& buf) : Buffer(buf._pageSize) {
+    setData(buf.getSize(), buf.getData());
 }
 
 Buffer& Buffer::operator=(const Buffer& buf) {
-    (*_sysmem) = buf.getSysmem();
+    const_cast<Size&>(_pageSize) = buf._pageSize;
+    setData(buf.getSize(), buf.getData());
     return (*this);
 }
 
 Buffer::~Buffer() {
     _bufferCPUCount--;
-
-    if (_sysmem) {
-        Buffer::updateBufferCPUMemoryUsage(_sysmem->getSize(), 0);
-        delete _sysmem;
-        _sysmem = NULL;
-    }
+    Buffer::updateBufferCPUMemoryUsage(_sysmem.getSize(), 0);
 }
 
 Buffer::Size Buffer::resize(Size size) {
+    _end = size;
     auto prevSize = editSysmem().getSize();
-    auto newSize = editSysmem().resize(size);
-    Buffer::updateBufferCPUMemoryUsage(prevSize, newSize);
-    return newSize;
+    if (prevSize < size) {
+        auto newPages = getRequiredPageCount();
+        auto newSize = newPages * _pageSize;
+        editSysmem().resize(size);
+        // All new pages start off as clean, because they haven't been populated by data
+        _pages.resize(newPages, 0);
+        Buffer::updateBufferCPUMemoryUsage(prevSize, newSize);
+    }
+    return _end;
 }
 
+void Buffer::dirtyPages(Size offset, Size bytes) {
+    if (!bytes) {
+        return;
+    }
+    _flags |= DIRTY;
+    // Find the starting page
+    Size startPage = (offset / _pageSize);
+    // Non-zero byte count, so at least one page is dirty
+    Size pageCount = 1;
+    // How much of the page is after the offset?
+    Size remainder = _pageSize - (offset % _pageSize);
+    //  If there are more bytes than page space remaining, we need to increase the page count
+    if (bytes > remainder) {
+        // Get rid of the amount that will fit in the current page
+        bytes -= remainder;
+
+        pageCount += (bytes / _pageSize);
+        if (bytes % _pageSize) {
+            ++pageCount;
+        }
+    }
+
+    // Mark the pages dirty
+    for (Size i = 0; i < pageCount; ++i) {
+        _pages[i + startPage] |= DIRTY;
+    }
+}
+
+
 Buffer::Size Buffer::setData(Size size, const Byte* data) {
-    auto prevSize = editSysmem().getSize();
-    auto newSize = editSysmem().setData(size, data);
-    Buffer::updateBufferCPUMemoryUsage(prevSize, newSize);
-    return newSize;
+    resize(size);
+    setSubData(0, size, data);
+    return _end;
 }
 
 Buffer::Size Buffer::setSubData(Size offset, Size size, const Byte* data) {
-    return editSysmem().setSubData( offset, size, data);
+    auto changedBytes = editSysmem().setSubData(offset, size, data);
+    if (changedBytes) {
+        dirtyPages(offset, changedBytes);
+    }
+    return changedBytes;
 }
 
 Buffer::Size Buffer::append(Size size, const Byte* data) {
-    auto prevSize = editSysmem().getSize();
-    auto newSize = editSysmem().append( size, data);
-    Buffer::updateBufferCPUMemoryUsage(prevSize, newSize);
-    return newSize;
+    auto offset = _end;
+    resize(_end + size);
+    setSubData(offset, size, data);
+    return _end;
+}
+
+Buffer::Size Buffer::getSize() const { 
+    Q_ASSERT(getSysmem().getSize() >= _end);
+    return _end;
+}
+
+Buffer::Size Buffer::getRequiredPageCount() const {
+    Size result = _end / _pageSize;
+    if (_end % _pageSize) {
+        ++result;
+    }
+    return result;
 }
 
 const Element BufferView::DEFAULT_ELEMENT = Element( gpu::SCALAR, gpu::UINT8, gpu::RAW );

--- a/libraries/gpu/src/gpu/Resource.cpp
+++ b/libraries/gpu/src/gpu/Resource.cpp
@@ -270,7 +270,7 @@ Buffer::Size Buffer::resize(Size size) {
     if (prevSize < size) {
         auto newPages = getRequiredPageCount();
         auto newSize = newPages * _pageSize;
-        editSysmem().resize(size);
+        editSysmem().resize(newSize);
         // All new pages start off as clean, because they haven't been populated by data
         _pages.resize(newPages, 0);
         Buffer::updateBufferCPUMemoryUsage(prevSize, newSize);
@@ -278,7 +278,7 @@ Buffer::Size Buffer::resize(Size size) {
     return _end;
 }
 
-void Buffer::dirtyPages(Size offset, Size bytes) {
+void Buffer::markDirty(Size offset, Size bytes) {
     if (!bytes) {
         return;
     }
@@ -316,7 +316,7 @@ Buffer::Size Buffer::setData(Size size, const Byte* data) {
 Buffer::Size Buffer::setSubData(Size offset, Size size, const Byte* data) {
     auto changedBytes = editSysmem().setSubData(offset, size, data);
     if (changedBytes) {
-        dirtyPages(offset, changedBytes);
+        markDirty(offset, changedBytes);
     }
     return changedBytes;
 }

--- a/libraries/render-utils/src/AnimDebugDraw.cpp
+++ b/libraries/render-utils/src/AnimDebugDraw.cpp
@@ -118,29 +118,18 @@ AnimDebugDraw::AnimDebugDraw() :
 
     // HACK: add red, green and blue axis at (1,1,1)
     _animDebugDrawData->_vertexBuffer->resize(sizeof(Vertex) * 6);
-    Vertex* data = (Vertex*)_animDebugDrawData->_vertexBuffer->editData();
-
-    data[0].pos = glm::vec3(1.0, 1.0f, 1.0f);
-    data[0].rgba = toRGBA(255, 0, 0, 255);
-    data[1].pos = glm::vec3(2.0, 1.0f, 1.0f);
-    data[1].rgba = toRGBA(255, 0, 0, 255);
-
-    data[2].pos = glm::vec3(1.0, 1.0f, 1.0f);
-    data[2].rgba = toRGBA(0, 255, 0, 255);
-    data[3].pos = glm::vec3(1.0, 2.0f, 1.0f);
-    data[3].rgba = toRGBA(0, 255, 0, 255);
-
-    data[4].pos = glm::vec3(1.0, 1.0f, 1.0f);
-    data[4].rgba = toRGBA(0, 0, 255, 255);
-    data[5].pos = glm::vec3(1.0, 1.0f, 2.0f);
-    data[5].rgba = toRGBA(0, 0, 255, 255);
-
-    _animDebugDrawData->_indexBuffer->resize(sizeof(uint16_t) * 6);
-    uint16_t* indices = (uint16_t*)_animDebugDrawData->_indexBuffer->editData();
-    for (int i = 0; i < 6; i++) {
-        indices[i] = i;
-    }
-
+    
+    static std::vector<Vertex> vertices({ 
+        Vertex { glm::vec3(1.0, 1.0f, 1.0f), toRGBA(255, 0, 0, 255) },
+        Vertex { glm::vec3(2.0, 1.0f, 1.0f), toRGBA(255, 0, 0, 255) },
+        Vertex { glm::vec3(1.0, 1.0f, 1.0f), toRGBA(0, 255, 0, 255) },
+        Vertex { glm::vec3(1.0, 2.0f, 1.0f), toRGBA(0, 255, 0, 255) },
+        Vertex { glm::vec3(1.0, 1.0f, 1.0f), toRGBA(0, 0, 255, 255) },
+        Vertex { glm::vec3(1.0, 1.0f, 2.0f), toRGBA(0, 0, 255, 255) },
+    });
+    static std::vector<uint16_t> indices({ 0, 1, 2, 3, 4, 5 });
+    _animDebugDrawData->_vertexBuffer->setSubData<Vertex>(0, vertices);
+    _animDebugDrawData->_indexBuffer->setSubData<uint16_t>(0, indices);
 }
 
 AnimDebugDraw::~AnimDebugDraw() {
@@ -356,9 +345,13 @@ void AnimDebugDraw::update() {
         numVerts += (int)DebugDraw::getInstance().getRays().size() * VERTICES_PER_RAY;
 
         // allocate verts!
-        data._vertexBuffer->resize(sizeof(Vertex) * numVerts);
-        Vertex* verts = (Vertex*)data._vertexBuffer->editData();
-        Vertex* v = verts;
+        std::vector<Vertex> vertices;
+        vertices.resize(numVerts);
+        //Vertex* verts = (Vertex*)data._vertexBuffer->editData();
+        Vertex* v = nullptr;
+        if (numVerts) {
+            v = &vertices[0];
+        }
 
         // draw absolute poses
         for (auto& iter : _absolutePoses) {
@@ -381,6 +374,8 @@ void AnimDebugDraw::update() {
                 }
             }
         }
+        data._vertexBuffer->resize(sizeof(Vertex) * numVerts);
+        data._vertexBuffer->setSubData<Vertex>(0, vertices);
 
         // draw markers from shared DebugDraw singleton
         for (auto& iter : markerMap) {
@@ -408,20 +403,19 @@ void AnimDebugDraw::update() {
         }
         DebugDraw::getInstance().clearRays();
 
-        assert(numVerts == (v - verts));
+        assert((!numVerts && !v) || (numVerts == (v - &vertices[0])));
 
         render::Item::Bound theBound;
         for (int i = 0; i < numVerts; i++) {
-            theBound += verts[i].pos;
+            theBound += vertices[i].pos;
         }
         data._bound = theBound;
 
         data._isVisible = (numVerts > 0);
 
         data._indexBuffer->resize(sizeof(uint16_t) * numVerts);
-        uint16_t* indices = (uint16_t*)data._indexBuffer->editData();
         for (int i = 0; i < numVerts; i++) {
-            indices[i] = i;
+            data._indexBuffer->setSubData<uint16_t>(i, (uint16_t)i);;
         }
     });
     scene->enqueuePendingChanges(pendingChanges);

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -116,35 +116,25 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
     // FIrst thing, we collect the bound and the status for all the items we want to render
     int nbItems = 0;
     {
-        if (!_itemBounds) {
-            _itemBounds = std::make_shared<gpu::Buffer>();
-        }
-        if (!_itemStatus) {
-            _itemStatus = std::make_shared<gpu::Buffer>();;
-        }
-        if (!_itemCells) {
-            _itemCells = std::make_shared<gpu::Buffer>();;
-        }
+        _itemBounds.resize(inItems.size());
+        _itemStatus.resize(inItems.size());
+        _itemCells.resize(inItems.size());
 
-        _itemBounds->resize((inItems.size() * sizeof(AABox)));
-        _itemStatus->resize((inItems.size() * NUM_STATUS_VEC4_PER_ITEM * sizeof(glm::vec4)));
-        _itemCells->resize((inItems.size() * sizeof(Octree::Location)));
-
-        AABox* itemAABox = reinterpret_cast<AABox*> (_itemBounds->editData());
-        glm::ivec4* itemStatus = reinterpret_cast<glm::ivec4*> (_itemStatus->editData());
-        Octree::Location* itemCell = reinterpret_cast<Octree::Location*> (_itemCells->editData());
-        for (auto& item : inItems) {
+//        AABox* itemAABox = reinterpret_cast<AABox*> (_itemBounds->editData());
+//        glm::ivec4* itemStatus = reinterpret_cast<glm::ivec4*> (_itemStatus->editData());
+//        Octree::Location* itemCell = reinterpret_cast<Octree::Location*> (_itemCells->editData());
+        for (size_t i = 0; i < inItems.size(); ++i) {
+            const auto& item = inItems[i];
             if (!item.bound.isInvalid()) {
                 if (!item.bound.isNull()) {
-                    (*itemAABox) = item.bound;
+                    _itemBounds[i] = item.bound;
                 } else {
-                    (*itemAABox).setBox(item.bound.getCorner(), 0.1f);
+                    _itemBounds[i].setBox(item.bound.getCorner(), 0.1f);
                 }
                 
 
                 auto& itemScene = scene->getItem(item.id);
-
-                (*itemCell) = scene->getSpatialTree().getCellLocation(itemScene.getCell());
+                _itemCells[i] = scene->getSpatialTree().getCellLocation(itemScene.getCell());
 
                 auto itemStatusPointer = itemScene.getStatus();
                 if (itemStatusPointer) {
@@ -152,25 +142,19 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
                     auto&& currentStatusValues = itemStatusPointer->getCurrentValues();
                     int valueNum = 0;
                     for (int vec4Num = 0; vec4Num < NUM_STATUS_VEC4_PER_ITEM; vec4Num++) {
-                        (*itemStatus) = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
+                        auto& value = (vec4Num ? _itemStatus[i].first : _itemStatus[i].second);
+                        value = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
                         for (int component = 0; component < VEC4_LENGTH; component++) {
                             valueNum = vec4Num * VEC4_LENGTH + component;
                             if (valueNum < (int)currentStatusValues.size()) {
-                                (*itemStatus)[component] = currentStatusValues[valueNum].getPackedData();
+                                value[component] = currentStatusValues[valueNum].getPackedData();
                             }
                         }
-                        itemStatus++;
                     }
                 } else {
-                    (*itemStatus) = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
-                    itemStatus++;
-                    (*itemStatus) = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
-                    itemStatus++;
+                    _itemStatus[i].first = _itemStatus[i].second = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
                 }
-
                 nbItems++;
-                itemAABox++;
-                itemCell++;
             }
         }
     }
@@ -194,25 +178,20 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
         // bind the one gpu::Pipeline we need
         batch.setPipeline(getDrawItemBoundsPipeline());
 
-        AABox* itemAABox = reinterpret_cast<AABox*> (_itemBounds->editData());
-        glm::ivec4* itemStatus = reinterpret_cast<glm::ivec4*> (_itemStatus->editData());
-        Octree::Location* itemCell = reinterpret_cast<Octree::Location*> (_itemCells->editData());
+        //AABox* itemAABox = reinterpret_cast<AABox*> (_itemBounds->editData());
+        //glm::ivec4* itemStatus = reinterpret_cast<glm::ivec4*> (_itemStatus->editData());
+        //Octree::Location* itemCell = reinterpret_cast<Octree::Location*> (_itemCells->editData());
 
         const unsigned int VEC3_ADRESS_OFFSET = 3;
 
         if (_showDisplay) {
             for (int i = 0; i < nbItems; i++) {
-                batch._glUniform3fv(_drawItemBoundPosLoc, 1, (const float*) (itemAABox + i));
-                batch._glUniform3fv(_drawItemBoundDimLoc, 1, ((const float*) (itemAABox + i)) + VEC3_ADRESS_OFFSET);
-               
-   
-                glm::ivec4 cellLocation(itemCell->pos.x, itemCell->pos.y, itemCell->pos.z, itemCell->depth);
+                batch._glUniform3fv(_drawItemBoundPosLoc, 1, (const float*)&(_itemBounds[i]));
+                batch._glUniform3fv(_drawItemBoundDimLoc, 1, ((const float*)&(_itemBounds[i])) + VEC3_ADRESS_OFFSET);
 
+                glm::ivec4 cellLocation(_itemCells[i].pos, _itemCells[i].depth);
                 batch._glUniform4iv(_drawItemCellLocLoc, 1, ((const int*)(&cellLocation)));
-     
-
                 batch.draw(gpu::LINES, 24, 0);
-                itemCell++;
             }
         }
 
@@ -222,10 +201,10 @@ void DrawStatus::run(const SceneContextPointer& sceneContext,
 
         if (_showNetwork) {
             for (int i = 0; i < nbItems; i++) {
-                batch._glUniform3fv(_drawItemStatusPosLoc, 1, (const float*) (itemAABox + i));
-                batch._glUniform3fv(_drawItemStatusDimLoc, 1, ((const float*) (itemAABox + i)) + VEC3_ADRESS_OFFSET);
-                batch._glUniform4iv(_drawItemStatusValue0Loc, 1, (const int*)(itemStatus + NUM_STATUS_VEC4_PER_ITEM * i));
-                batch._glUniform4iv(_drawItemStatusValue1Loc, 1, (const int*)(itemStatus + NUM_STATUS_VEC4_PER_ITEM * i + 1));
+                batch._glUniform3fv(_drawItemStatusPosLoc, 1, (const float*)&(_itemBounds[i]));
+                batch._glUniform3fv(_drawItemStatusDimLoc, 1, ((const float*)&(_itemBounds[i])) + VEC3_ADRESS_OFFSET);
+                batch._glUniform4iv(_drawItemStatusValue0Loc, 1, (const int*)&(_itemStatus[i].first));
+                batch._glUniform4iv(_drawItemStatusValue1Loc, 1, (const int*)&(_itemStatus[i].second));
                 batch.draw(gpu::TRIANGLES, 24 * NUM_STATUS_VEC4_PER_ITEM, 0);
             }
         }

--- a/libraries/render/src/render/DrawStatus.h
+++ b/libraries/render/src/render/DrawStatus.h
@@ -68,9 +68,13 @@ namespace render {
         gpu::Stream::FormatPointer _drawItemFormat;
         gpu::PipelinePointer _drawItemBoundsPipeline;
         gpu::PipelinePointer _drawItemStatusPipeline;
-        gpu::BufferPointer _itemBounds;
-        gpu::BufferPointer _itemCells;
-        gpu::BufferPointer _itemStatus;
+
+        std::vector<AABox> _itemBounds;
+        std::vector<std::pair<glm::ivec4, glm::ivec4>> _itemStatus;
+        std::vector<Octree::Location> _itemCells;
+        //gpu::BufferPointer _itemBounds;
+        //gpu::BufferPointer _itemCells;
+        //gpu::BufferPointer _itemStatus;
         gpu::TexturePointer _statusIconMap;
     };
 }


### PR DESCRIPTION
Currently any change to a `gpu::Buffer` object causes the entire buffer to be transferred when it's next synced with the GL backend.  This change allows `gpu::Buffers` objects to be declared with an optional page size parameter when they're built.  Internally the buffer will track which pages are and are not dirty based on the client calls to `setSubData` (all data setting methods in the class are now ultimately implemented in terms of `setSubData`).  When a buffer is only partially modified, the sync method will transfer only those pages that have changed.  

The default page size is 4k, but can be changed to suit your needs.  One the one hand, if you intend to store a transform buffer of 100k transforms, only a few of which might change per frame, it's not recommended to set the page size to the size of an individual transform, but rather some multiple of the individual element size, to avoid an excessively large page table



