### PR TITLE
Fix procedural rendering on primitives

### DIFF
--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -18,7 +18,7 @@
 // the interpolated normal
 in vec3 _normal;
 in vec3 _modelNormal;
-in vec3 _color;
+in vec4 _color;
 in vec2 _texCoord0;
 in vec4 _position;
 


### PR DESCRIPTION
PR https://github.com/highfidelity/hifi/pull/7859 broke rendering of procedural primitives because the _color attribute for the simple pipeline changed to a `vec4` from a `vec3`, but the `simple.slf` fragment shader was not updated.