### PR TITLE
improve hand-controller edit

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -720,7 +720,7 @@ var mouseCapturedByTool = false;
 var lastMousePosition = null;
 var idleMouseTimerId = null;
 var CLICK_TIME_THRESHOLD = 500 * 1000; // 500 ms
-var CLICK_MOVE_DISTANCE_THRESHOLD = 8;
+var CLICK_MOVE_DISTANCE_THRESHOLD = 20;
 var IDLE_MOUSE_TIMEOUT = 200;
 var DEFAULT_ENTITY_DRAG_DROP_DISTANCE = 2.0;
 

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -304,7 +304,7 @@ SelectionDisplay = (function() {
     var previousHandleColor;
     var previousHandleAlpha;
 
-    var grabberSizeCorner = 0.025;
+    var grabberSizeCorner = 0.025; // These get resized by updateHandleSizes().
     var grabberSizeEdge = 0.015;
     var grabberSizeFace = 0.025;
     var grabberAlpha = 1;
@@ -4320,7 +4320,7 @@ SelectionDisplay = (function() {
     that.updateHandleSizes = function() {
         if (selectionManager.hasSelection()) {
             var diff = Vec3.subtract(selectionManager.worldPosition, Camera.getPosition());
-            var grabberSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO;
+            var grabberSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 2;
             var dimensions = SelectionManager.worldDimensions;
             var avgDimension = (dimensions.x + dimensions.y + dimensions.z) / 3;
             grabberSize = Math.min(grabberSize, avgDimension / 10);


### PR DESCRIPTION
Makes edit.js more usable with hand controllers:
  The box edit-handles are larger.
  The distinction between a click (selection) and a drag, leans slightly more towards click than had been the case. This makes is slightly easier to select (a quick click-release with a steady hand) than before. (This is not a general redesign.  Selecting through the the Entity List on the edit panel is still the primary  recommended means of selection when using hand controllers.)