### PR TITLE
fix settings getting reset

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -256,7 +256,7 @@ QVariantList ScriptEngines::getRunning() {
 }
 
 
-static const QString SETTINGS_KEY = "Settings";
+static const QString SETTINGS_KEY = "RunningScripts";
 
 void ScriptEngines::loadDefaultScripts() {
     QUrl defaultScriptsLoc = defaultScriptsLocation();
@@ -281,6 +281,43 @@ void ScriptEngines::loadScripts() {
 
     // loads all saved scripts
     Settings settings;
+
+
+    // START of backward compatibility code
+    // This following if statement is only meant to update the settings file still using the old setting key.
+    // If you read that comment and it has been more than a couple months since it was merged,
+    // then by all means, feel free to remove it.
+    if (!settings.childGroups().contains(SETTINGS_KEY)) {
+        qWarning() << "Detected old script settings config, loading from previous location";
+        const QString oldKey = "Settings";
+
+        // Load old scripts array from settings
+        int size = settings.beginReadArray(oldKey);
+        for (int i = 0; i < size; ++i) {
+            settings.setArrayIndex(i);
+            QString string = settings.value("script").toString();
+            if (!string.isEmpty()) {
+                loadScript(string);
+            }
+        }
+        settings.endArray();
+
+        // Cleanup old scripts array from settings
+        settings.beginWriteArray(oldKey);
+        for (int i = 0; i < size; ++i) {
+            settings.setArrayIndex(i);
+            settings.remove("");
+        }
+        settings.endArray();
+        settings.beginGroup(oldKey);
+        settings.remove("size");
+        settings.endGroup();
+
+        return;
+    }
+    // END of backward compatibility code
+
+
     int size = settings.beginReadArray(SETTINGS_KEY);
     for (int i = 0; i < size; ++i) {
         settings.setArrayIndex(i);

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -97,7 +97,7 @@ namespace Setting {
     }
 
     void Interface::deinit() {
-        if (privateInstance) {
+        if (_isInitialized && privateInstance) {
             // Save value to disk
             save();
 


### PR DESCRIPTION
fixes bugzid:531
When a setting handle was created but never initialized/used, it would override the current value with the default value on destruction.
This issue was affecting "firstRun" which then would affect the running scripts settings causing them to clear they setting array.
That operation would override the "Settings" menu settings since there was a setting key conflict. Both use "Settings" as a setting key.

I changed the running  scripts setting key to something more appropriate and added some code to move the settings to the new location on first run.

Test plan:
- On first run, make sure the scripts are loaded correctly (They should have been loaded from the old settings location and migrated to the new one)
- On second run, make sure the scripts are still loaded correctly (They should have been loaded from the new settings location)
- Make sure settings in general are correctly saved/loaded
- Test fix:

1. Start interface with "Go Home" in the sandbox menu
2. Enable Advanced/Developer menus
3. Close interface
4. Start interface with "Go Home" in the sandbox menu
5. Notice Advanced/Developer menus are still enabled