### PR TITLE
Fix bad roughness value read from the deferred buffer

### DIFF
--- a/libraries/render-utils/src/DeferredBufferRead.slh
+++ b/libraries/render-utils/src/DeferredBufferRead.slh
@@ -101,7 +101,7 @@ DeferredFragment unpackDeferredFragmentNoPosition(vec2 texcoord) {
 
     // Unpack the normal from the map
     frag.normal = normalize(frag.normalVal.xyz * 2.0 - vec3(1.0));
-    frag.roughness = 2.0 * frag.normalVal.a;
+    frag.roughness = frag.normalVal.a;
 
     // Diffuse color and unpack the mode and the metallicness
     frag.diffuse = frag.diffuseVal.xyz;


### PR DESCRIPTION
FIxing bug introduced in PR #7859 build master  http://builds.highfidelity.com/HighFidelity-Beta-4884.exe
The roughness value stored in the g-Buffer was scaled by 2 ( it used to be needed...) and generated a bad value.