### PR TITLE
Improve Avatar Mixer Joint Compression

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -515,13 +515,13 @@ void AvatarMixer::domainSettingsRequestComplete() {
 void AvatarMixer::handlePacketVersionMismatch(PacketType type, const HifiSockAddr& senderSockAddr, const QUuid& senderUUID) {
     // if this client is using packet versions we don't expect.
     if ((type == PacketTypeEnum::Value::AvatarIdentity || type == PacketTypeEnum::Value::AvatarData) && !senderUUID.isNull()) {
-        // Echo an empty AvatarIdentity packet back to that client.
+        // Echo an empty AvatarData packet back to that client.
         // This should trigger a version mismatch dialog on their side.
         auto nodeList = DependencyManager::get<NodeList>();
         auto node = nodeList->nodeWithUUID(senderUUID);
         if (node) {
-            auto poisonPacket = NLPacket::create(PacketType::AvatarIdentity, 0);
-            nodeList->sendPacket(std::move(poisonPacket), *node);
+            auto emptyPacket = NLPacket::create(PacketType::AvatarData, 0);
+            nodeList->sendPacket(std::move(emptyPacket), *node);
         }
     }
 }

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -38,7 +38,8 @@ private slots:
     void handleAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleKillAvatarPacket(QSharedPointer<ReceivedMessage> message);
     void domainSettingsRequestComplete();
-    
+    void handlePacketVersionMismatch(PacketType type, const HifiSockAddr& senderSockAddr, const QUuid& senderUUID);
+
 private:
     void broadcastAvatarData();
     void parseDomainServerSettings(const QJsonObject& domainSettings);

--- a/libraries/animation/src/AnimSkeleton.cpp
+++ b/libraries/animation/src/AnimSkeleton.cpp
@@ -107,6 +107,18 @@ void AnimSkeleton::convertAbsolutePosesToRelative(AnimPoseVec& poses) const {
     }
 }
 
+void AnimSkeleton::convertAbsoluteRotationsToRelative(std::vector<glm::quat>& rotations) const {
+    // poses start off absolute and leave in relative frame
+    int lastIndex = std::min((int)rotations.size(), (int)_joints.size());
+    for (int i = lastIndex - 1; i >= 0; --i) {
+        int parentIndex = _joints[i].parentIndex;
+        if (parentIndex != -1) {
+            rotations[i] = glm::inverse(rotations[parentIndex]) * rotations[i];
+        }
+    }
+}
+
+
 void AnimSkeleton::mirrorRelativePoses(AnimPoseVec& poses) const {
     convertRelativePosesToAbsolute(poses);
     mirrorAbsolutePoses(poses);

--- a/libraries/animation/src/AnimSkeleton.h
+++ b/libraries/animation/src/AnimSkeleton.h
@@ -55,6 +55,8 @@ public:
     void convertRelativePosesToAbsolute(AnimPoseVec& poses) const;
     void convertAbsolutePosesToRelative(AnimPoseVec& poses) const;
 
+    void convertAbsoluteRotationsToRelative(std::vector<glm::quat>& rotations) const;
+
     void mirrorRelativePoses(AnimPoseVec& poses) const;
     void mirrorAbsolutePoses(AnimPoseVec& poses) const;
 

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -229,9 +229,6 @@ protected:
     void updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::quat& worldHeadOrientation, const glm::vec3& lookAt, const glm::vec3& saccade);
     void calcAnimAlpha(float speed, const std::vector<float>& referenceSpeeds, float* alphaOut) const;
 
-    // geometry space
-    bool getJointData(int index, JointData& jointDataOut) const;
-
     AnimPose _modelOffset;  // model to rig space
     AnimPose _geometryOffset; // geometry to model space (includes unit offset & fst offsets)
     AnimPose _invGeometryOffset;

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -104,12 +104,6 @@ public:
 
     void setModelOffset(const glm::mat4& modelOffsetMat);
 
-    // geometry space
-    bool getJointStateRotation(int index, glm::quat& rotation) const;
-
-    // geometry space
-    bool getJointStateTranslation(int index, glm::vec3& translation) const;
-
     void clearJointState(int index);
     void clearJointStates();
     void clearJointAnimationPriority(int index);
@@ -119,8 +113,6 @@ public:
 
     // geometry space
     void setJointTranslation(int index, bool valid, const glm::vec3& translation, float priority);
-
-    // geometry space
     void setJointRotation(int index, bool valid, const glm::quat& rotation, float priority);
 
     // legacy
@@ -237,8 +229,12 @@ protected:
     void updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::quat& worldHeadOrientation, const glm::vec3& lookAt, const glm::vec3& saccade);
     void calcAnimAlpha(float speed, const std::vector<float>& referenceSpeeds, float* alphaOut) const;
 
+    // geometry space
+    bool getJointData(int index, JointData& jointDataOut) const;
+
     AnimPose _modelOffset;  // model to rig space
     AnimPose _geometryOffset; // geometry to model space (includes unit offset & fst offsets)
+    AnimPose _invGeometryOffset;
 
     struct PoseSet {
         AnimPoseVec _relativePoses; // geometry space relative to parent.

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -263,7 +263,7 @@ QByteArray AvatarData::toByteArray(bool cullSmallChanges, bool sendAll) {
     for (int i = 0; i < _jointData.size(); i ++) {
         const JointData& data = _jointData[ i ];
         if (validity & (1 << validityBit)) {
-            destinationBuffer += packOrientationQuatToBytes(destinationBuffer, data.rotation);
+            destinationBuffer += packOrientationQuatToSixBytes(destinationBuffer, data.rotation);
         }
         if (++validityBit == BITS_IN_BYTE) {
             validityBit = 0;
@@ -650,10 +650,10 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
             if (validRotations[i]) {
                 _hasNewJointRotations = true;
                 data.rotationSet = true;
-                sourceBuffer += unpackOrientationQuatFromBytes(sourceBuffer, data.rotation);
+                sourceBuffer += unpackOrientationQuatFromSixBytes(sourceBuffer, data.rotation);
             }
         }
-    } // numJoints * 8 bytes
+    } // numJoints * 6 bytes
 
     // joint translations
     // get translation validity bits -- these indicate which translations were packed

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -121,6 +121,8 @@ void AvatarData::setHandPosition(const glm::vec3& handPosition) {
     _handPosition = glm::inverse(getOrientation()) * (handPosition - getPosition());
 }
 
+#define WANT_DEBUG
+
 QByteArray AvatarData::toByteArray(bool cullSmallChanges, bool sendAll) {
     // TODO: DRY this up to a shared method
     // that can pack any type given the number of bytes
@@ -329,7 +331,7 @@ QByteArray AvatarData::toByteArray(bool cullSmallChanges, bool sendAll) {
     }
 
     #ifdef WANT_DEBUG
-    if (sendAll) {
+    //if (sendAll) {
         qDebug() << "AvatarData::toByteArray" << cullSmallChanges << sendAll
                  << "rotations:" << rotationSentCount << "translations:" << translationSentCount
                  << "largest:" << maxTranslationDimension
@@ -339,7 +341,7 @@ QByteArray AvatarData::toByteArray(bool cullSmallChanges, bool sendAll) {
                  << (beforeTranslations - beforeRotations) << "+"
                  << (destinationBuffer - beforeTranslations) << "="
                  << (destinationBuffer - startPosition);
-    }
+    //}
     #endif
 
     return avatarDataByteArray.left(destinationBuffer - startPosition);

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -176,9 +176,10 @@ bool LimitedNodeList::packetVersionMatch(const udt::Packet& packet) {
 
         bool hasBeenOutput = false;
         QString senderString;
+        const HifiSockAddr& senderSockAddr = packet.getSenderSockAddr();
+        QUuid sourceID;
 
         if (NON_SOURCED_PACKETS.contains(headerType)) {
-            const HifiSockAddr& senderSockAddr = packet.getSenderSockAddr();
             hasBeenOutput = versionDebugSuppressMap.contains(senderSockAddr, headerType);
 
             if (!hasBeenOutput) {
@@ -186,7 +187,7 @@ bool LimitedNodeList::packetVersionMatch(const udt::Packet& packet) {
                 senderString = QString("%1:%2").arg(senderSockAddr.getAddress().toString()).arg(senderSockAddr.getPort());
             }
         } else {
-            QUuid sourceID = NLPacket::sourceIDInHeader(packet);
+            sourceID = NLPacket::sourceIDInHeader(packet);
 
             hasBeenOutput = sourcedVersionDebugSuppressMap.contains(sourceID, headerType);
 
@@ -201,7 +202,7 @@ bool LimitedNodeList::packetVersionMatch(const udt::Packet& packet) {
                 << senderString << "sent" << qPrintable(QString::number(headerVersion)) << "but"
                 << qPrintable(QString::number(versionForPacketType(headerType))) << "expected.";
 
-            emit packetVersionMismatch(headerType);
+            emit packetVersionMismatch(headerType, senderSockAddr, sourceID);
         }
 
         return false;

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -236,7 +236,9 @@ public slots:
 
 signals:
     void dataSent(quint8 channelType, int bytes);
-    void packetVersionMismatch(PacketType type);
+
+    // QUuid might be zero for non-sourced packet types.
+    void packetVersionMismatch(PacketType type, const HifiSockAddr& senderSockAddr, const QUuid& senderUUID);
 
     void uuidChanged(const QUuid& ownerUUID, const QUuid& oldUUID);
     void nodeAdded(SharedNodePointer);

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -48,9 +48,11 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::EntityEdit:
         case PacketType::EntityData:
             return VERSION_LIGHT_HAS_FALLOFF_RADIUS;
+        case PacketType::AvatarIdentity:
         case PacketType::AvatarData:
         case PacketType::BulkAvatarData:
-            return static_cast<PacketVersion>(AvatarMixerPacketVersion::SoftAttachmentSupport);
+        case PacketType::KillAvatar:
+            return static_cast<PacketVersion>(AvatarMixerPacketVersion::AbsoluteSixByteRotations);
         case PacketType::ICEServerHeartbeat:
             return 18; // ICE Server Heartbeat signing
         case PacketType::AssetGetInfo:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -174,7 +174,8 @@ const PacketVersion VERSION_LIGHT_HAS_FALLOFF_RADIUS = 57;
 
 enum class AvatarMixerPacketVersion : PacketVersion {
     TranslationSupport = 17,
-    SoftAttachmentSupport
+    SoftAttachmentSupport,
+    AbsoluteFortyEightBitRotations
 };
 
 #endif // hifi_PacketHeaders_h

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -175,7 +175,7 @@ const PacketVersion VERSION_LIGHT_HAS_FALLOFF_RADIUS = 57;
 enum class AvatarMixerPacketVersion : PacketVersion {
     TranslationSupport = 17,
     SoftAttachmentSupport,
-    AbsoluteFortyEightBitRotations
+    AbsoluteSixByteRotations
 };
 
 #endif // hifi_PacketHeaders_h

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -726,10 +726,6 @@ glm::vec3 Model::calculateScaledOffsetPoint(const glm::vec3& point) const {
     return translatedPoint;
 }
 
-bool Model::getJointState(int index, glm::quat& rotation) const {
-    return _rig->getJointStateRotation(index, rotation);
-}
-
 void Model::clearJointState(int index) {
     _rig->clearJointState(index);
 }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -252,10 +252,6 @@ protected:
     /// Returns the scaled equivalent of a point in model space.
     glm::vec3 calculateScaledOffsetPoint(const glm::vec3& point) const;
 
-    /// Fetches the joint state at the specified index.
-    /// \return whether or not the joint state is "valid" (that is, non-default)
-    bool getJointState(int index, glm::quat& rotation) const;
-
     /// Clear the joint states
     void clearJointState(int index);
 

--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -151,7 +151,7 @@ int packOrientationQuatToSixBytes(unsigned char* buffer, const glm::quat& quatIn
     // ensure that the sign of the dropped component is always negative.
     glm::quat q = quatInput[largestComponent] > 0 ? -quatInput : quatInput;
 
-    const float MAGNITUDE = 1.0f / sqrt(2.0f);
+    const float MAGNITUDE = 1.0f / sqrtf(2.0f);
     const uint32_t NUM_BITS_PER_COMPONENT = 15;
     const uint32_t RANGE = (1 << NUM_BITS_PER_COMPONENT) - 1;
 

--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -135,6 +135,87 @@ int unpackOrientationQuatFromBytes(const unsigned char* buffer, glm::quat& quatO
     return sizeof(quatParts);
 }
 
+#define HI_BYTE(x) (uint8_t)(x >> 8)
+#define LO_BYTE(x) (uint8_t)(0xff & x)
+
+int packOrientationQuatToSixBytes(unsigned char* buffer, const glm::quat& quatInput) {
+
+    // find largest component
+    uint8_t largestComponent = 0;
+    for (int i = 1; i < 4; i++) {
+        if (fabs(quatInput[i]) > fabs(quatInput[largestComponent])) {
+            largestComponent = i;
+        }
+    }
+
+    // ensure that the sign of the dropped component is always negative.
+    glm::quat q = quatInput[largestComponent] > 0 ? -quatInput : quatInput;
+
+    const float MAGNITUDE = 1.0f / sqrt(2.0f);
+    const uint32_t NUM_BITS_PER_COMPONENT = 15;
+    const uint32_t RANGE = (1 << NUM_BITS_PER_COMPONENT) - 1;
+
+    // quantize the smallest three components into integers
+    uint16_t components[3];
+    for (int i = 0, j = 0; i < 4; i++) {
+        if (i != largestComponent) {
+            // transform component into 0..1 range.
+            float value = (q[i] + MAGNITUDE) / (2.0f * MAGNITUDE);
+
+            // quantize 0..1 into 0..range
+            components[j] = (uint16_t)(value * RANGE);
+            j++;
+        }
+    }
+
+    // encode the largestComponent into the high bits of the first two components
+    components[0] = (0x7fff & components[0]) | ((0x01 & largestComponent) << 15);
+    components[1] = (0x7fff & components[1]) | ((0x02 & largestComponent) << 14);
+
+    buffer[0] = HI_BYTE(components[0]);
+    buffer[1] = LO_BYTE(components[0]);
+    buffer[2] = HI_BYTE(components[1]);
+    buffer[3] = LO_BYTE(components[1]);
+    buffer[4] = HI_BYTE(components[2]);
+    buffer[5] = LO_BYTE(components[2]);
+
+    return 6;
+}
+
+int unpackOrientationQuatFromSixBytes(const unsigned char* buffer, glm::quat& quatOutput) {
+
+    uint16_t components[3];
+    components[0] = ((uint16_t)(0x7f & buffer[0]) << 8) | buffer[1];
+    components[1] = ((uint16_t)(0x7f & buffer[2]) << 8) | buffer[3];
+    components[2] = ((uint16_t)(0x7f & buffer[4]) << 8) | buffer[5];
+
+    // largestComponent is encoded into the highest bits of the first 2 components
+    uint8_t largestComponent = ((0x80 & buffer[2]) >> 6) | ((0x80 & buffer[0]) >> 7);
+
+    const uint32_t NUM_BITS_PER_COMPONENT = 15;
+    const float RANGE = (float)((1 << NUM_BITS_PER_COMPONENT) - 1);
+    const float MAGNITUDE = 1.0f / sqrtf(2.0f);
+    float floatComponents[3];
+    for (int i = 0; i < 3; i++) {
+        floatComponents[i] = ((float)components[i] / RANGE) * (2.0f * MAGNITUDE) - MAGNITUDE;
+    }
+
+    // missingComponent is always negative.
+    float missingComponent = -sqrtf(1.0f - floatComponents[0] * floatComponents[0] - floatComponents[1] * floatComponents[1] - floatComponents[2] * floatComponents[2]);
+
+    for (int i = 0, j = 0; i < 4; i++) {
+        if (i != largestComponent) {
+            quatOutput[i] = floatComponents[j];
+            j++;
+        } else {
+            quatOutput[i] = missingComponent;
+        }
+    }
+
+    return 6;
+}
+
+
 //  Safe version of glm::eulerAngles; uses the factorization method described in David Eberly's
 //  http://www.geometrictools.com/Documentation/EulerAngles.pdf (via Clyde,
 // https://github.com/threerings/clyde/blob/master/src/main/java/com/threerings/math/Quaternion.java)

--- a/libraries/shared/src/GLMHelpers.h
+++ b/libraries/shared/src/GLMHelpers.h
@@ -97,6 +97,14 @@ int unpackFloatAngleFromTwoByte(const uint16_t* byteAnglePointer, float* destina
 int packOrientationQuatToBytes(unsigned char* buffer, const glm::quat& quatInput);
 int unpackOrientationQuatFromBytes(const unsigned char* buffer, glm::quat& quatOutput);
 
+// alternate compression method that picks the smallest three quaternion components.
+// and packs them into 15 bits each. An additional 2 bits are used to encode which component
+// was omitted.  Also because the components are encoded from the -1/sqrt(2) to 1/sqrt(2) which
+// gives us some extra precision over the -1 to 1 range.  The final result will have a maximum
+// error of +- 4.3e-5 error per compoenent.
+int packOrientationQuatToSixBytes(unsigned char* buffer, const glm::quat& quatInput);
+int unpackOrientationQuatFromSixBytes(const unsigned char* buffer, glm::quat& quatOutput);
+
 // Ratios need the be highly accurate when less than 10, but not very accurate above 10, and they
 // are never greater than 1000 to 1, this allows us to encode each component in 16bits
 int packFloatRatioToTwoByte(unsigned char* buffer, float ratio);

--- a/tests/shared/src/GLMHelpersTests.cpp
+++ b/tests/shared/src/GLMHelpersTests.cpp
@@ -54,4 +54,51 @@ void GLMHelpersTests::testEulerDecomposition() {
     }
 }
 
+static void testQuatCompression(glm::quat testQuat) {
 
+    float MAX_COMPONENT_ERROR = 4.3e-5f;
+
+    glm::quat q;
+    uint8_t bytes[6];
+    packOrientationQuatToSixBytes(bytes, testQuat);
+    unpackOrientationQuatFromSixBytes(bytes, q);
+    if (glm::dot(q, testQuat) < 0.0f) {
+        q = -q;
+    }
+    QCOMPARE_WITH_ABS_ERROR(q.x, testQuat.x, MAX_COMPONENT_ERROR);
+    QCOMPARE_WITH_ABS_ERROR(q.y, testQuat.y, MAX_COMPONENT_ERROR);
+    QCOMPARE_WITH_ABS_ERROR(q.z, testQuat.z, MAX_COMPONENT_ERROR);
+    QCOMPARE_WITH_ABS_ERROR(q.w, testQuat.w, MAX_COMPONENT_ERROR);
+}
+
+void GLMHelpersTests::testSixByteOrientationCompression() {
+    const glm::quat ROT_X_90 = glm::angleAxis(PI / 2.0f, glm::vec3(1.0f, 0.0f, 0.0f));
+    const glm::quat ROT_Y_180 = glm::angleAxis(PI, glm::vec3(0.0f, 1.0, 0.0f));
+    const glm::quat ROT_Z_30 = glm::angleAxis(PI / 6.0f, glm::vec3(1.0f, 0.0f, 0.0f));
+
+    testQuatCompression(ROT_X_90);
+    testQuatCompression(ROT_Y_180);
+    testQuatCompression(ROT_Z_30);
+    testQuatCompression(ROT_X_90 * ROT_Y_180);
+    testQuatCompression(ROT_Y_180 * ROT_X_90);
+    testQuatCompression(ROT_Z_30 * ROT_X_90);
+    testQuatCompression(ROT_X_90 * ROT_Z_30);
+    testQuatCompression(ROT_Z_30 * ROT_Y_180);
+    testQuatCompression(ROT_Y_180 * ROT_Z_30);
+    testQuatCompression(ROT_X_90 * ROT_Y_180 * ROT_Z_30);
+    testQuatCompression(ROT_Y_180 * ROT_Z_30 * ROT_X_90);
+    testQuatCompression(ROT_Z_30 * ROT_X_90 * ROT_Y_180);
+
+    testQuatCompression(-ROT_X_90);
+    testQuatCompression(-ROT_Y_180);
+    testQuatCompression(-ROT_Z_30);
+    testQuatCompression(-(ROT_X_90 * ROT_Y_180));
+    testQuatCompression(-(ROT_Y_180 * ROT_X_90));
+    testQuatCompression(-(ROT_Z_30 * ROT_X_90));
+    testQuatCompression(-(ROT_X_90 * ROT_Z_30));
+    testQuatCompression(-(ROT_Z_30 * ROT_Y_180));
+    testQuatCompression(-(ROT_Y_180 * ROT_Z_30));
+    testQuatCompression(-(ROT_X_90 * ROT_Y_180 * ROT_Z_30));
+    testQuatCompression(-(ROT_Y_180 * ROT_Z_30 * ROT_X_90));
+    testQuatCompression(-(ROT_Z_30 * ROT_X_90 * ROT_Y_180));
+}

--- a/tests/shared/src/GLMHelpersTests.h
+++ b/tests/shared/src/GLMHelpersTests.h
@@ -19,6 +19,7 @@ class GLMHelpersTests : public QObject {
     Q_OBJECT
 private slots:
     void testEulerDecomposition();
+    void testSixByteOrientationCompression();
 };
 
 float getErrorDifference(const float& a, const float& b);


### PR DESCRIPTION
* AvatarData rotations are now sent in absolute frame instead of relative frame.  This will increase the precision of extremity joints such as the head and hands, because the compression error does not compound up the joint hierarchy.
* AvatarData rotations are now compressed into 6 bytes instead of 8.  We only send the smallest 3 quaternion components at 15 bits of precision per component.  The extra bits determine which component we dropped.  See `packOrientationQuatToSixBytes` in GLMHelpers.cpp for implementation.
* Added unit tests for new compression algorithm.
* Avatar-Mixer will now respond with an empty AvatarData packet to clients with unexpected packet versions.  This will trigger the "incompatible version" dialog on the client.

THIS PR IS FOR INTERNAL TESTING ONLY, once it is ready to go the DO NOT MERGE flag will be removed.