### PR TITLE
fix mouse-grab moving both an overlay and an entity at the same time

### DIFF
--- a/scripts/system/controllers/grab.js
+++ b/scripts/system/controllers/grab.js
@@ -316,7 +316,12 @@ Grabber.prototype.pressEvent = function(event) {
         return;
     }
 
-    if (event.isLeftButton!==true ||event.isRightButton===true || event.isMiddleButton===true) {
+    if (event.isLeftButton !== true || event.isRightButton === true || event.isMiddleButton === true) {
+        return;
+    }
+
+    if (Overlays.getOverlayAtPoint(Reticle.position) > 0) {
+        // the mouse is pointing at an overlay; don't look for entities underneath the overlay.
         return;
     }
 


### PR DESCRIPTION
- don't mouse-grab things through an overlay
