### PR TITLE
fix floating AC Avatar at 0,0,0

### DIFF
--- a/script-archive/audioExamples/acAudioSearching/ACAudioSearchAndInject.js
+++ b/script-archive/audioExamples/acAudioSearching/ACAudioSearchAndInject.js
@@ -40,6 +40,7 @@ var DEFAULT_SOUND_DATA = {
 
 Script.include("../../libraries/utils.js");
 Agent.isAvatar = true; // This puts a robot at 0,0,0, but is currently necessary in order to use AvatarList.
+Avatar.skeletonModelURL = "http://invalid-url";
 function ignore() {}
 function debug() { // Display the arguments not just [Object object].
     //print.apply(null, [].map.call(arguments, JSON.stringify));


### PR DESCRIPTION
This PR hides the scripted avatar at the origin of domains running the ACAudioSearchAndInject.js script