### PR TITLE
fix entity dissapears when switching between models in asset-server

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -48,13 +48,6 @@ RenderableModelEntityItem::~RenderableModelEntityItem() {
 
 void RenderableModelEntityItem::setModelURL(const QString& url) {
     auto& currentURL = getParsedModelURL();
-    if (_model && (currentURL != url)) {
-        // The machinery for updateModelBounds will give existing models the opportunity to fix their translation/rotation/scale/registration.
-        // The first two are straightforward, but the latter two have guards to make sure they don't happen after they've already been set.
-        // Here we reset those guards. This doesn't cause the entity values to change -- it just allows the model to match once it comes in.
-        _model->setScaleToFit(false, getDimensions());
-        _model->setSnapModelToRegistrationPoint(false, getRegistrationPoint());
-    }
     ModelEntityItem::setModelURL(url);
 
     if (currentURL != getParsedModelURL() || !_model) {
@@ -163,6 +156,14 @@ void RenderableModelEntityItem::remapTextures() {
 }
 
 void RenderableModelEntityItem::doInitialModelSimulation() {
+    // The machinery for updateModelBounds will give existing models the opportunity to fix their
+    // translation/rotation/scale/registration.  The first two are straightforward, but the latter two have guards to
+    // make sure they don't happen after they've already been set.  Here we reset those guards. This doesn't cause the
+    // entity values to change -- it just allows the model to match once it comes in.
+    _model->setScaleToFit(false, getDimensions());
+    _model->setSnapModelToRegistrationPoint(false, getRegistrationPoint());
+
+    // now recalculate the bounds and registration
     _model->setScaleToFit(true, getDimensions());
     _model->setSnapModelToRegistrationPoint(true, getRegistrationPoint());
     _model->setRotation(getRotation());


### PR DESCRIPTION
- when changing the url of an ModelEntity's model, recalculate bounds and registration after model is finished loading