### PR TITLE
fix crash on click on non-visible web-entity

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -994,7 +994,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
         if (_keyboardFocusedItem != entityItemID) {
             _keyboardFocusedItem = UNKNOWN_ENTITY_ID;
             auto properties = entityScriptingInterface->getEntityProperties(entityItemID);
-            if (EntityTypes::Web == properties.getType() && !properties.getLocked()) {
+            if (EntityTypes::Web == properties.getType() && !properties.getLocked() && properties.getVisible()) {
                 auto entity = entityScriptingInterface->getEntityTree()->findEntityByID(entityItemID);
                 RenderableWebEntityItem* webEntity = dynamic_cast<RenderableWebEntityItem*>(entity.get());
                 if (webEntity) {
@@ -1043,6 +1043,13 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     // If the user clicks somewhere where there is NO entity at all, we will release focus
     connect(getEntities(), &EntityTreeRenderer::mousePressOffEntity,
         [=](const RayToEntityIntersectionResult& entityItemID, const QMouseEvent* event) {
+        _keyboardFocusedItem = UNKNOWN_ENTITY_ID;
+        if (_keyboardFocusHighlight) {
+            _keyboardFocusHighlight->setVisible(false);
+        }
+    });
+
+    connect(this, &Application::aboutToQuit, [=]() {
         _keyboardFocusedItem = UNKNOWN_ENTITY_ID;
         if (_keyboardFocusHighlight) {
             _keyboardFocusHighlight->setVisible(false);

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -226,10 +226,15 @@ void RenderableWebEntityItem::setSourceUrl(const QString& value) {
 }
 
 void RenderableWebEntityItem::setProxyWindow(QWindow* proxyWindow) {
-    _webSurface->setProxyWindow(proxyWindow);
+    if (_webSurface) {
+        _webSurface->setProxyWindow(proxyWindow);
+    }
 }
 
 QObject* RenderableWebEntityItem::getEventHandler() {
+    if (!_webSurface) {
+        return nullptr;
+    }
     return _webSurface->getEventHandler();
 }
 


### PR DESCRIPTION
Fixes

* Crash when clicking an invisible web entity (that has never been visible to you)
* Crash when exiting the application with an invisible web entity selected in edit mode
* Invisible web entities should not gain keyboard focus

