### PR TITLE
fix broken procedural skybox when leaving and re-entering

### DIFF
--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -100,10 +100,6 @@ bool Procedural::parseUrl(const QUrl& shaderUrl) {
         return false;
     }
 
-    if (_shaderUrl == shaderUrl) {
-        return true;
-    }
-
     _shaderUrl = shaderUrl;
     _shaderDirty = true;
 


### PR DESCRIPTION
If you leave and then re-enter a zone with a procedural skybox, when you re-enter you only see the cubemap, not the procedural content, which never loads.  This PR fixes this issue.  