### PR TITLE
tidy zone flying and ghosting entities editor options

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -1717,6 +1717,14 @@
             <input type="checkbox" id="property-zone-stage-sun-model-enabled">
             <label for="property-zone-stage-sun-model-enabled">Enable stage sun model</label>
         </div>
+        <div class="zone-group zone-section property checkbox">
+            <input type="checkbox" id="property-zone-flying-allowed">
+            <label for="property-zone-flying-allowed">Flying allowed</label>
+        </div>
+        <div class="zone-group zone-section property checkbox">
+            <input type="checkbox" id="property-zone-ghosting-allowed">
+            <label for="property-zone-ghosting-allowed">Ghosting allowed</label>
+        </div>
 
         <div class="sub-section-header zone-group zone-section keylight-section">
             <label>Key Light</label>
@@ -1799,15 +1807,6 @@
         <div class="zone-group zone-section skybox-section property url ">
             <label for="property-zone-skybox-url">Skybox URL</label>
             <input type="text" id="property-zone-skybox-url">
-        </div>
-
-        <div class="zone-group zone-section property checkbox">
-          <input type="checkbox" id="property-zone-flying-allowed">
-          <label for="property-zone-flying-allowed">&nbsp;Flying Allowed</label>
-        </div>
-        <div class="zone-group zone-section property checkbox">
-          <input type="checkbox" id="property-zone-ghosting-allowed">
-          <label for="property-zone-ghosting-allowed">&nbsp;Ghosting Allowed</label>
         </div>
 
 


### PR DESCRIPTION
Move options to top of section from under "skybox" subsection
Fix capitalization of labels