### PR TITLE
Fix primitive shape collisions

### DIFF
--- a/libraries/entities/src/ShapeEntityItem.cpp
+++ b/libraries/entities/src/ShapeEntityItem.cpp
@@ -161,7 +161,7 @@ void ShapeEntityItem::appendSubclassData(OctreePacketData* packetData, EncodeBit
 // This value specifes how the shape should be treated by physics calculations.  
 // For now, all polys will act as spheres
 ShapeType ShapeEntityItem::getShapeType() const {
-    return SHAPE_TYPE_ELLIPSOID;
+    return (_shape == entity::Shape::Cube) ? SHAPE_TYPE_BOX : SHAPE_TYPE_SPHERE;
 }
 
 void ShapeEntityItem::setColor(const rgbColor& value) {


### PR DESCRIPTION
Our physics engine doesn't properly handle ellipsoids.  Additionally, when the shape is a cube, it should report as a box for collisions.