### PR TITLE
optionally include the metaverse session ID as HTTP header when sending usage data

### DIFF
--- a/interface/src/DiscoverabilityManager.cpp
+++ b/interface/src/DiscoverabilityManager.cpp
@@ -127,6 +127,10 @@ void DiscoverabilityManager::handleHeartbeatResponse(QNetworkReply& requestReply
 
     if (!dataObject.isEmpty()) {
         _sessionID = dataObject[SESSION_ID_KEY].toString();
+
+        // give that session ID to the account manager
+        auto accountManager = DependencyManager::get<AccountManager>();
+        accountManager->setSessionID(_sessionID);
     }
 }
 

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AccountManager.h"
+
 #include <memory>
 
 #include <QtCore/QDataStream>
@@ -26,13 +28,13 @@
 
 #include <SettingHandle.h>
 
+#include "NetworkLogging.h"
 #include "NodeList.h"
 #include "udt/PacketHeaders.h"
 #include "RSAKeypairGenerator.h"
 #include "SharedUtil.h"
+#include "UserActivityLogger.h"
 
-#include "AccountManager.h"
-#include "NetworkLogging.h"
 
 const bool VERBOSE_HTTP_REQUEST_DEBUGGING = false;
 
@@ -215,6 +217,13 @@ void AccountManager::sendRequest(const QString& path,
     QNetworkRequest networkRequest;
 
     networkRequest.setHeader(QNetworkRequest::UserAgentHeader, _userAgentGetter());
+
+    // if we're allowed to send usage data, include whatever the current session ID is with this request
+    auto& activityLogger = UserActivityLogger::getInstance();
+    if (activityLogger.isEnabled()) {
+        static const QString METAVERSE_SESSION_ID_HEADER = "HFM-SessionID";
+        networkRequest.setRawHeader(METAVERSE_SESSION_ID_HEADER.toLocal8Bit(), _sessionID.toString().toLocal8Bit());
+    }
 
     QUrl requestURL = _authURL;
     

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -86,6 +86,8 @@ public:
 
     static QJsonObject dataObjectFromResponse(QNetworkReply& requestReply);
 
+    void setSessionID(const QUuid& sessionID) { _sessionID = sessionID; }
+
 public slots:
     void requestAccessToken(const QString& login, const QString& password);
 
@@ -136,6 +138,8 @@ private:
 
     bool _isWaitingForKeypairResponse { false };
     QByteArray _pendingPrivateKey;
+
+    QUuid _sessionID;
 };
 
 #endif // hifi_AccountManager_h


### PR DESCRIPTION
- send the metaverse session ID with all HF HTTP requests when sending usage data