### PR TITLE
send session ID in AccountManager without curly braces

### DIFF
--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -222,7 +222,8 @@ void AccountManager::sendRequest(const QString& path,
     auto& activityLogger = UserActivityLogger::getInstance();
     if (activityLogger.isEnabled()) {
         static const QString METAVERSE_SESSION_ID_HEADER = "HFM-SessionID";
-        networkRequest.setRawHeader(METAVERSE_SESSION_ID_HEADER.toLocal8Bit(), _sessionID.toString().toLocal8Bit());
+        networkRequest.setRawHeader(METAVERSE_SESSION_ID_HEADER.toLocal8Bit(),
+                                    uuidStringWithoutCurlyBraces(_sessionID).toLocal8Bit());
     }
 
     QUrl requestURL = _authURL;


### PR DESCRIPTION
- removed the curly braces from AccountManager session ID header