### PR TITLE
Bugfix for avatar LOD

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -303,6 +303,9 @@ void Avatar::simulate(float deltaTime) {
             head->setScale(getUniformScale());
             head->simulate(deltaTime, false, !_shouldAnimate);
         }
+    } else {
+        // a non-full update is still required so that the position, rotation, scale and bounds of the skeletonModel are updated.
+        _skeletonModel->simulate(deltaTime, false);
     }
 
     // update animation for display name fade in/out


### PR DESCRIPTION
If an avatar was LOD'ed out, it would never become visible again, because the bounds of the skeleton model were never updated again.  This PR ensures that the model bound is updated, even when the avatar is LOD'ed away.