### PR TITLE
Partition vive trackpad by center, x, and y (not just center v outer).

### DIFF
--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -1,16 +1,16 @@
 {
     "name": "Vive to Standard",
     "channels": [
-        { "from": "Vive.LY", "when": "Vive.LSOuter", "filters": ["invert"], "to": "Standard.LY" },
-        { "from": "Vive.LX", "when": "Vive.LSOuter", "to": "Standard.LX" },
+        { "from": "Vive.LY", "when": "Vive.LSY", "filters": ["invert"], "to": "Standard.LY" },
+        { "from": "Vive.LX", "when": "Vive.LSX", "to": "Standard.LX" },
 
         { "from": "Vive.LT", "to": "Standard.LT" },
         { "from": "Vive.LeftGrip", "to": "Standard.LB" },
         { "from": "Vive.LS", "to": "Standard.LS" },
         { "from": "Vive.LSTouch", "to": "Standard.LSTouch" },
 
-        { "from": "Vive.RY", "when": "Vive.RSOuter", "filters": ["invert"], "to": "Standard.RY" },
-        { "from": "Vive.RX", "when": "Vive.RSOuter", "to": "Standard.RX" },
+        { "from": "Vive.RY", "when": "Vive.RSY", "filters": ["invert"], "to": "Standard.RY" },
+        { "from": "Vive.RX", "when": "Vive.RSX", "to": "Standard.RX" },
 
         { "from": "Vive.RT", "to": "Standard.RT" },
         { "from": "Vive.RightGrip", "to": "Standard.RB" },

--- a/libraries/controllers/src/controllers/StandardControls.h
+++ b/libraries/controllers/src/controllers/StandardControls.h
@@ -44,7 +44,8 @@ namespace controller {
         LS_TOUCH,
         LEFT_THUMB_UP,
         LS_CENTER,
-        LS_OUTER,
+        LS_X,
+        LS_Y,
 
         RIGHT_PRIMARY_THUMB,
         RIGHT_SECONDARY_THUMB,
@@ -53,7 +54,8 @@ namespace controller {
         RS_TOUCH,
         RIGHT_THUMB_UP,
         RS_CENTER,
-        RS_OUTER,
+        RS_X,
+        RS_Y,
 
         LEFT_PRIMARY_INDEX,
         LEFT_SECONDARY_INDEX,

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -290,7 +290,7 @@ void ViveControllerManager::InputDevice::handleHandController(float deltaTime, u
     }
 }
 
-void ViveControllerManager::InputDevice::partitionTouchpad(int sButton, int xAxis, int yAxis, int centerPseudoButton, int xPseudoButton, int yPesudoButton) {
+void ViveControllerManager::InputDevice::partitionTouchpad(int sButton, int xAxis, int yAxis, int centerPseudoButton, int xPseudoButton, int yPseudoButton) {
     // Populate the L/RS_CENTER/OUTER pseudo buttons, corresponding to a partition of the L/RS space based on the X/Y values.
     const float CENTER_DEADBAND = 0.6f;
     const float DIAGONAL_DIVIDE_IN_RADIANS = PI / 4.0f;
@@ -301,7 +301,7 @@ void ViveControllerManager::InputDevice::partitionTouchpad(int sButton, int xAxi
         float angle = glm::atan(cartesianQuadrantI.y / cartesianQuadrantI.x);
         float radius = glm::length(cartesianQuadrantI);
         bool isCenter = radius < CENTER_DEADBAND;
-        _buttonPressedMap.insert(isCenter ? centerPseudoButton : ((angle < DIAGONAL_DIVIDE_IN_RADIANS) ? xPseudoButton :yPesudoButton));
+        _buttonPressedMap.insert(isCenter ? centerPseudoButton : ((angle < DIAGONAL_DIVIDE_IN_RADIANS) ? xPseudoButton :yPseudoButton));
     }
 }
 

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -61,7 +61,7 @@ private:
         void handleAxisEvent(float deltaTime, uint32_t axis, float x, float y, bool isLeftHand);
         void handlePoseEvent(float deltaTime, const controller::InputCalibrationData& inputCalibrationData, const mat4& mat,
                              const vec3& linearVelocity, const vec3& angularVelocity, bool isLeftHand);
-        void ViveControllerManager::InputDevice::partitionTouchpad(int sButton, int xAxis, int yAxis, int centerPsuedoButton, int xPseudoButton, int yPseudoButton);
+        void partitionTouchpad(int sButton, int xAxis, int yAxis, int centerPsuedoButton, int xPseudoButton, int yPseudoButton);
 
         class FilteredStick {
         public:

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -61,7 +61,7 @@ private:
         void handleAxisEvent(float deltaTime, uint32_t axis, float x, float y, bool isLeftHand);
         void handlePoseEvent(float deltaTime, const controller::InputCalibrationData& inputCalibrationData, const mat4& mat,
                              const vec3& linearVelocity, const vec3& angularVelocity, bool isLeftHand);
-        void ViveControllerManager::InputDevice::partitionTouchpad(int sButton, int xAxis, int yAxis, int centerPsuedoButton, int outerPseudoButton);
+        void ViveControllerManager::InputDevice::partitionTouchpad(int sButton, int xAxis, int yAxis, int centerPsuedoButton, int xPseudoButton, int yPseudoButton);
 
         class FilteredStick {
         public:


### PR DESCRIPTION
Instead Hardware.Vive L/RSCenter and L/RSOuter, the latter is now split into L/RSX and L/RSY.
Results to Standard mapping remain unchanged.