### PR TITLE
Update the build docs for a better OpenSSL security posture.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,8 +2,8 @@
 
 * [cmake](http://www.cmake.org/cmake/resources/software.html) ~> 3.3.2
 * [Qt](http://www.qt.io/download-open-source) ~> 5.5.1
-* [OpenSSL](https://www.openssl.org/community/binaries.html) ~> 1.0.1m
-  * IMPORTANT: Using the recommended version of OpenSSL is critical to avoid security vulnerabilities.
+* [OpenSSL](https://www.openssl.org/community/binaries.html) ~> 1.0.1 (highest letter)
+  * IMPORTANT: Using the recommended version of OpenSSL is critical to avoid security vulnerabilities. Make sure to check regularly to see if there is a new version.
 * [VHACD](https://github.com/virneo/v-hacd)(clone this repository)(Optional)
 
 ####CMake External Project Dependencies

--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -73,8 +73,8 @@ Your system may already have several versions of the OpenSSL DLL's (ssleay32.dll
     QSslSocket: cannot resolve SSL_get0_next_proto_negotiated
 
 To prevent these problems, install OpenSSL yourself. Download one of the following binary packages [from this website](http://slproweb.com/products/Win32OpenSSL.html):
-* Win32 OpenSSL v1.0.1q
-* Win64 OpenSSL v1.0.1q
+* Win32 OpenSSL v1.0.1 (highest letter)
+* Win64 OpenSSL v1.0.1 (highest letter)
 
 Install OpenSSL into the Windows system directory, to make sure that Qt uses the version that you've just installed, and not some other version.
 


### PR DESCRIPTION
There are around 19 CVEs in the current recommended OpenSSL. This should help make it clearer to use the latest and keep up to date.