### PR TITLE
Removed innocuous "AvatarData packet size mismatch" warning

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -632,13 +632,6 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
     #endif
 
     int numBytesRead = sourceBuffer - startPosition;
-
-    if (numBytesRead != buffer.size()) {
-        if (shouldLogError(now)) {
-            qCWarning(avatars) << "AvatarData packet size mismatch: expected " << numBytesRead << " received " << buffer.size();
-        }
-    }
-
     _averageBytesReceived.updateAverage(numBytesRead);
     return numBytesRead;
 }


### PR DESCRIPTION
This should not have been a warning, it is expected behavior when a BulkAvatarData packet is filled
with data from more then one avatar.