### PR TITLE
do not send stale vive data as valid after deactivating

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -96,6 +96,11 @@ void OpenVrDisplayPlugin::internalDeactivate() {
     Parent::internalDeactivate();
     _container->setIsOptionChecked(StandingHMDSensorMode, false);
     if (_system) {
+        // Invalidate poses. It's fine if someone else sets these shared values, but we're about to stop updating them, and
+        // we don't want ViveControllerManager to consider old values to be valid.
+        for (int i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
+            _trackedDevicePose[i].bPoseIsValid = false;
+        }
         releaseOpenVrSystem();
         _system = nullptr;
     }


### PR DESCRIPTION
Do not send stale vive data as valid.
It had been the case that, after switching into Vive HMD and back to desktop, the hand pose input data was sending unchanging invalid data and reporting it as valid. As a result, the hand positions were bad, and scripts that depended on valid data were bad (including handControllerPointer, which moved the mouse to where it was told).

(cherry picked from commit e6cc1fabe0d97006024e38de4a498b1f364fa860 for vive-ui branch, PR #7999 )