### PR TITLE
Eliminate extraneous writes for unchanged values

### DIFF
--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -28,7 +28,9 @@ Settings::~Settings() {
 }
 
 void Settings::remove(const QString& key) {
-    _manager->remove(key);
+    if (key == "" || _manager->contains(key)) {
+        _manager->remove(key);
+    }
 }
 
 QStringList Settings::childGroups() const {
@@ -72,7 +74,9 @@ void Settings::endGroup() {
 }
 
 void Settings::setValue(const QString& name, const QVariant& value) {
-    _manager->setValue(name, value);
+    if (_manager->value(name) != value) {
+        _manager->setValue(name, value);
+    }
 }
 
 QVariant Settings::value(const QString& name, const QVariant& defaultValue) const {


### PR DESCRIPTION
This commit was supposed to go in my [earlier PR](https://github.com/highfidelity/hifi/pull/8019) for settings from this weekend, but apparently I forgot to `git push`.  This further reduces the number of file writes by causing any client which uses the old style `Settings` interface to set a value to the already extant value, or the remove a value that already doesn't exist, to become a no-op.