### PR TITLE
SteamVR keyboard functionality

### DIFF
--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -751,30 +751,9 @@ void OffscreenQmlSurface::onFocusObjectChanged(QObject* object) {
         return;
     }
 
-    QVariant result;
-#if 1
-    auto invokeResult = QMetaObject::invokeMethod(object, "inputMethodQuery", Q_RETURN_ARG(QVariant, result),
-        Q_ARG(Qt::InputMethodQuery, Qt::ImEnabled),
-        Q_ARG(QVariant, QVariant()));
-#else
-
-    //static const char* INPUT_METHOD_QUERY_METHOD_NAME = "inputMethodQuery(Qt::InputMethodQuery, QVariant)";
-    static const char* INPUT_METHOD_QUERY_METHOD_NAME = "inputMethodQuery";
-    auto meta = object->metaObject();
-    qDebug() << "new focus " << object;
-    auto index = meta->indexOfMethod(INPUT_METHOD_QUERY_METHOD_NAME);
-    if (index < 0 || index >= meta->methodCount()) {
-        setFocusText(false);
-        return;
-    }
-
-    auto method = meta->method(index);
-    auto invokeResult = method.invoke(object,
-        Q_RETURN_ARG(QVariant, result),
-        Q_ARG(Qt::InputMethodQuery, Qt::ImEnabled),
-        Q_ARG(QVariant, QVariant()));
-#endif
-    setFocusText(invokeResult && result.toBool());
+    QInputMethodQueryEvent query(Qt::ImEnabled);
+    qApp->sendEvent(object, &query);
+    setFocusText(query.value(Qt::ImEnabled).toBool());
 }
 
 void OffscreenQmlSurface::setFocusText(bool newFocusText) {

--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -30,7 +30,7 @@ class OffscreenQmlRenderThread;
 
 class OffscreenQmlSurface : public QObject {
     Q_OBJECT
-
+    Q_PROPERTY(bool focusText READ isFocusText NOTIFY focusTextChanged)
 public:
     OffscreenQmlSurface();
     virtual ~OffscreenQmlSurface();
@@ -55,6 +55,7 @@ public:
         _mouseTranslator = mouseTranslator;
     }
 
+    bool isFocusText() const { return _focusText; }
     void pause();
     void resume();
     bool isPaused() const;
@@ -70,6 +71,8 @@ public:
 
 signals:
     void textureUpdated(unsigned int texture);
+    void focusObjectChanged(QObject* newFocus);
+    void focusTextChanged(bool focusText);
 
 public slots:
     void requestUpdate();
@@ -78,6 +81,7 @@ public slots:
 
 protected:
     bool filterEnabled(QObject* originalDestination, QEvent* event) const;
+    void setFocusText(bool newFocusText);
 
 private:
     QObject* finishQmlLoad(std::function<void(QQmlContext*, QObject*)> f);
@@ -85,6 +89,7 @@ private:
 
 private slots:
     void updateQuick();
+    void onFocusObjectChanged(QObject* newFocus);
 
 private:
     friend class OffscreenQmlRenderThread;
@@ -97,6 +102,7 @@ private:
     bool _render{ false };
     bool _polish{ true };
     bool _paused{ true };
+    bool _focusText { false };
     uint8_t _maxFps{ 60 };
     MouseTranslator _mouseTranslator{ [](const QPointF& p) { return p.toPoint();  } };
     QWindow* _proxyWindow { nullptr };

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -36,12 +36,14 @@ vec3 _trackedDeviceLinearVelocities[vr::k_unMaxTrackedDeviceCount];
 vec3 _trackedDeviceAngularVelocities[vr::k_unMaxTrackedDeviceCount];
 static mat4 _sensorResetMat;
 static std::array<vr::Hmd_Eye, 2> VR_EYES { { vr::Eye_Left, vr::Eye_Right } };
+bool _openVrDisplayActive { false };
 
 bool OpenVrDisplayPlugin::isSupported() const {
     return openVrSupported();
 }
 
 bool OpenVrDisplayPlugin::internalActivate() {
+    _openVrDisplayActive = true;
     _container->setIsOptionChecked(StandingHMDSensorMode, true);
 
     if (!_system) {
@@ -94,6 +96,7 @@ bool OpenVrDisplayPlugin::internalActivate() {
 
 void OpenVrDisplayPlugin::internalDeactivate() {
     Parent::internalDeactivate();
+    _openVrDisplayActive = false;
     _container->setIsOptionChecked(StandingHMDSensorMode, false);
     if (_system) {
         // Invalidate poses. It's fine if someone else sets these shared values, but we're about to stop updating them, and

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -99,19 +99,33 @@ static char textArray[8192];
 static QMetaObject::Connection _focusConnection, _focusTextConnection;
 extern bool _openVrDisplayActive;
 static vr::IVROverlay* _overlay { nullptr };
-static QObject* _focusObject { nullptr };
+static QObject* _keyboardFocusObject { nullptr };
 static QString _existingText;
 static Qt::InputMethodHints _currentHints;
 extern vr::TrackedDevicePose_t _trackedDevicePose[vr::k_unMaxTrackedDeviceCount];
+static bool _keyboardShown { false };
+static const uint32_t SHOW_KEYBOARD_DELAY_MS = 100;
 
 void showOpenVrKeyboard(bool show = true) {
-    if (_overlay) {
-        if (show) {
-            auto offscreenUi = DependencyManager::get<OffscreenUi>();
-            _focusObject = offscreenUi->getWindow()->focusObject();
+    if (!_overlay) {
+        return;
+    }
 
-            QInputMethodQueryEvent query(Qt::ImQueryInput | Qt::ImHints);
-            qApp->sendEvent(_focusObject, &query);
+    if (show) {
+        // To avoid flickering the keyboard when a text element is only briefly selected, 
+        // show the keyboard asynchrnously after a very short delay, but only after we check 
+        // that the current focus object is still one that is text enabled
+        QTimer::singleShot(SHOW_KEYBOARD_DELAY_MS, [] {
+            auto offscreenUi = DependencyManager::get<OffscreenUi>();
+            auto currentFocus = offscreenUi->getWindow()->focusObject();
+            QInputMethodQueryEvent query(Qt::ImEnabled | Qt::ImQueryInput | Qt::ImHints);
+            qApp->sendEvent(currentFocus, &query);
+            // Current focus isn't text enabled, bail early.
+            if (!query.value(Qt::ImEnabled).toBool()) {
+                return;
+            }
+            // We're going to show the keyboard now...
+            _keyboardFocusObject = currentFocus;
             _currentHints = Qt::InputMethodHints(query.value(Qt::ImHints).toUInt());
             vr::EGamepadTextInputMode inputMode = vr::k_EGamepadTextInputModeNormal;
             if (_currentHints & Qt::ImhHiddenText) {
@@ -123,17 +137,24 @@ void showOpenVrKeyboard(bool show = true) {
             }
             _existingText = query.value(Qt::ImSurroundingText).toString();
 
-            auto showKeyboardResult = _overlay->ShowKeyboard(inputMode, lineMode, "Keyboard", 1024, 
+            auto showKeyboardResult = _overlay->ShowKeyboard(inputMode, lineMode, "Keyboard", 1024,
                 _existingText.toLocal8Bit().toStdString().c_str(), false, 0);
 
-            mat4 headPose = toGlm(_trackedDevicePose[0].mDeviceToAbsoluteTracking);
-            mat4 keyboardTransform = glm::translate(headPose, vec3(0, -0.5, -1));
-            keyboardTransform = keyboardTransform * glm::rotate(mat4(), 3.14159f / 4.0f, vec3(-1, 0, 0));
-            auto keyboardTransformVr = toOpenVr(keyboardTransform);
-            _overlay->SetKeyboardTransformAbsolute(vr::ETrackingUniverseOrigin::TrackingUniverseStanding, &keyboardTransformVr);
-        } else {
-            _focusObject = nullptr;
+            if (vr::VROverlayError_None == showKeyboardResult) {
+                _keyboardShown = true;
+                // Try to position the keyboard slightly below where the user is looking.
+                mat4 headPose = toGlm(_trackedDevicePose[0].mDeviceToAbsoluteTracking);
+                mat4 keyboardTransform = glm::translate(headPose, vec3(0, -0.5, -1));
+                keyboardTransform = keyboardTransform * glm::rotate(mat4(), 3.14159f / 4.0f, vec3(-1, 0, 0));
+                auto keyboardTransformVr = toOpenVr(keyboardTransform);
+                _overlay->SetKeyboardTransformAbsolute(vr::ETrackingUniverseOrigin::TrackingUniverseStanding, &keyboardTransformVr);
+            }
+        });
+    } else {
+        _keyboardFocusObject = nullptr;
+        if (_keyboardShown) {
             _overlay->HideKeyboard();
+            _keyboardShown = false;
         }
     }
 }
@@ -147,7 +168,7 @@ void finishOpenVrKeyboardInput() {
     // ImhDialableCharactersOnly ImhEmailCharactersOnly  ImhUrlCharactersOnly  ImhLatinOnly
     QInputMethodEvent event(_existingText, QList<QInputMethodEvent::Attribute>());
     event.setCommitString(newText, 0, _existingText.size());
-    qApp->sendEvent(_focusObject, &event);
+    qApp->sendEvent(_keyboardFocusObject, &event);
     // Simulate an enter press on the top level window to trigger the action
     if (0 == (_currentHints & Qt::ImhMultiLine)) {
         qApp->sendEvent(offscreenUi->getWindow(), &QKeyEvent(QEvent::KeyPress, Qt::Key_Return, Qt::KeyboardModifiers(), QString("\n")));
@@ -155,12 +176,18 @@ void finishOpenVrKeyboardInput() {
     }
 }
 
+static const QString DEBUG_FLAG("HIFI_DISABLE_STEAM_VR_KEYBOARD");
+bool disableSteamVrKeyboard = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
+
 void enableOpenVrKeyboard() {
+    if (disableSteamVrKeyboard) {
+        return;
+    }
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     _overlay = vr::VROverlay();
 
     _focusConnection = QObject::connect(offscreenUi->getWindow(), &QQuickWindow::focusObjectChanged, [](QObject* object) {
-        if (object != _focusObject && _overlay) {
+        if (object != _keyboardFocusObject) {
             showOpenVrKeyboard(false);
         }
     });
@@ -174,6 +201,9 @@ void enableOpenVrKeyboard() {
 
 
 void disableOpenVrKeyboard() {
+    if (disableSteamVrKeyboard) {
+        return;
+    }
     QObject::disconnect(_focusTextConnection);
     QObject::disconnect(_focusConnection);
 }

--- a/plugins/openvr/src/OpenVrHelpers.h
+++ b/plugins/openvr/src/OpenVrHelpers.h
@@ -44,3 +44,13 @@ inline mat4 toGlm(const vr::HmdMatrix34_t& m) {
         m.m[0][3], m.m[1][3], m.m[2][3], 1.0f);
     return result;
 }
+
+inline vr::HmdMatrix34_t toOpenVr(const mat4& m) {
+    vr::HmdMatrix34_t result;
+    for (uint8_t i = 0; i < 3; ++i) {
+        for (uint8_t j = 0; j < 4; ++j) {
+            result.m[i][j] = m[j][i];
+        }
+    }
+    return result;
+}

--- a/plugins/openvr/src/OpenVrHelpers.h
+++ b/plugins/openvr/src/OpenVrHelpers.h
@@ -18,6 +18,9 @@ vr::IVRSystem* acquireOpenVrSystem();
 void releaseOpenVrSystem();
 void handleOpenVrEvents();
 bool openVrQuitRequested();
+void enableOpenVrKeyboard();
+void disableOpenVrKeyboard();
+
 
 template<typename F>
 void openvr_for_each_eye(F f) {

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -12,6 +12,7 @@
 #include "ViveControllerManager.h"
 
 #include <QtCore/QProcessEnvironment>
+#include <QtQuick/QQuickWindow>
 
 #include <PerfStat.h>
 #include <PathUtils.h>
@@ -22,6 +23,7 @@
 #include <NumericalConstants.h>
 #include <plugins/PluginContainer.h>
 #include <UserActivityLogger.h>
+#include <OffscreenUi.h>
 
 #include <controllers/UserInputMapper.h>
 
@@ -55,6 +57,9 @@ bool ViveControllerManager::isSupported() const {
     return openVrSupported();
 }
 
+QMetaObject::Connection _focusConnection;
+extern bool _openVrDisplayActive;
+
 bool ViveControllerManager::activate() {
     InputPlugin::activate();
 
@@ -67,7 +72,20 @@ bool ViveControllerManager::activate() {
         _system = acquireOpenVrSystem();
     }
     Q_ASSERT(_system);
-
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    _focusConnection = connect(offscreenUi.data(), &OffscreenUi::focusTextChanged, [this](bool focusText) {
+        if (_openVrDisplayActive) {
+            auto overlay = vr::VROverlay();
+            if (overlay) {
+                if (focusText) {
+                    //virtual EVROverlayError ShowKeyboard( eInputMode, EGamepadTextInputLineMode eLineInputMode, const char *pchDescription, uint32_t unCharMax, const char *pchExistingText, bool bUseMinimalMode, uint64_t uUserValue) = 0;
+                    overlay->ShowKeyboard(vr::EGamepadTextInputMode::k_EGamepadTextInputModeNormal, vr::k_EGamepadTextInputLineModeSingleLine, "Test", 1024, "", false, 0);
+                } else {
+                    overlay->HideKeyboard();
+                }
+            }
+        }
+    });
     // OpenVR provides 3d mesh representations of the controllers
     // Disabled controller rendering code
     /*
@@ -131,6 +149,8 @@ bool ViveControllerManager::activate() {
 
 void ViveControllerManager::deactivate() {
     InputPlugin::deactivate();
+
+    disconnect(_focusConnection);
 
     _container->removeMenuItem(MENU_NAME, RENDER_CONTROLLERS);
     _container->removeMenu(MENU_PATH);
@@ -218,6 +238,18 @@ void ViveControllerManager::pluginUpdate(float deltaTime, const controller::Inpu
     if (openVrQuitRequested()) {
         deactivate();
         return;
+    }
+
+    vr::VREvent_t vrEvent;
+    static char textArray[8192];
+    while (vr::VRSystem()->PollNextEvent(&vrEvent, sizeof(vrEvent))) {
+        if (vrEvent.eventType == vr::VREvent_KeyboardDone) {
+            auto chars = vr::VROverlay()->GetKeyboardText(textArray, 8192);
+            QInputMethodEvent* event = new QInputMethodEvent();
+            event->setCommitString(QString(QByteArray(textArray, chars)), 0, 0);
+            auto focusObject = DependencyManager::get<OffscreenUi>()->getWindow()->focusObject();
+            qApp->postEvent(focusObject, event);
+        }
     }
 
     // because update mutates the internal state we need to lock


### PR DESCRIPTION
This update to the earlier SteamVR keyboard PR moves most of the code from the ViveControllerManager.cpp file to OpenVrHelpers.cpp.  Both the display plugin and the input plugin now handle OpenVR events due to an unrelated PR, but the event handling itself is done in the common code in OpenVrHelpers, so it made sense to put the bulk of the code there.  The only thing ViveControllerManager.cpp is still responsible for is enabling the keyboard functionality when it activates and disabling it when it deactivates.

The keyboard itself should now simulate a 'return' keypress to the top level offscreen QML window, so when you enter an address in the address bar and press done, you should actually get taken to your destination.  However I'm uncertain of the implications of sending a return key to every possible text input field, as the effect might be undesirable on some of them.  

Additionally, the current overlay show / hide functionality is annoying in combination with the keyboard.  If the target of the keyboard is hidden when the desktop goes into pinned mode, the steam keyboard goes away along with it, because the item no longer has text focus.  In the case of the address bar, when the bar becomes visible again it immediately grabs focus and so the steam vr keyboard overlay reappears, but both the address bar and the keyboard overlay have been reset.  

Unfortunately this sequence can be triggered just be leaning too far in a direction, because this is considered to be driving your avatar and thus makes the overlays hidden.  