### PR TITLE
Expose haptics to JS

### DIFF
--- a/libraries/controllers/src/controllers/InputDevice.h
+++ b/libraries/controllers/src/controllers/InputDevice.h
@@ -31,6 +31,12 @@ namespace controller {
 class Endpoint;
 using EndpointPointer = std::shared_ptr<Endpoint>;
 
+enum Hand {
+    LEFT = 0,
+    RIGHT,
+    BOTH
+};
+
 // NOTE: If something inherits from both InputDevice and InputPlugin, InputPlugin must go first.
 // e.g. class Example : public InputPlugin, public InputDevice
 // instead of class Example : public InputDevice, public InputPlugin
@@ -56,7 +62,7 @@ public:
     const QString& getName() const { return _name; }
 
     // By default, Input Devices do not support haptics
-    virtual bool triggerHapticPulse(float strength, float duration, bool leftHand) { return false; }
+    virtual bool triggerHapticPulse(float strength, float duration, controller::Hand hand) { return false; }
 
     // Update call MUST be called once per simulation loop
     // It takes care of updating the action states and deltas

--- a/libraries/controllers/src/controllers/InputDevice.h
+++ b/libraries/controllers/src/controllers/InputDevice.h
@@ -51,12 +51,12 @@ public:
 
     float getValue(const Input& input) const;
     float getValue(ChannelType channelType, uint16_t channel) const;
-	Pose getPoseValue(uint16_t channel) const;
+    Pose getPoseValue(uint16_t channel) const;
 
     const QString& getName() const { return _name; }
 
-	// By default, Input Devices do not support haptics
-	virtual bool triggerHapticPulse(float strength, float duration, bool leftHand) { return false; }
+    // By default, Input Devices do not support haptics
+    virtual bool triggerHapticPulse(float strength, float duration, bool leftHand) { return false; }
 
     // Update call MUST be called once per simulation loop
     // It takes care of updating the action states and deltas

--- a/libraries/controllers/src/controllers/InputDevice.h
+++ b/libraries/controllers/src/controllers/InputDevice.h
@@ -51,9 +51,12 @@ public:
 
     float getValue(const Input& input) const;
     float getValue(ChannelType channelType, uint16_t channel) const;
-    Pose getPoseValue(uint16_t channel) const;
+	Pose getPoseValue(uint16_t channel) const;
 
     const QString& getName() const { return _name; }
+
+	// By default, Input Devices do not support haptics
+	virtual bool triggerHapticPulse(float strength, float duration, bool leftHand) { return false; }
 
     // Update call MUST be called once per simulation loop
     // It takes care of updating the action states and deltas

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -140,8 +140,22 @@ namespace controller {
         return DependencyManager::get<UserInputMapper>()->getActionNames();
     }
 
-    bool ScriptingInterface::triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand) const {
-        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(device, strength, duration, leftHand);
+    bool ScriptingInterface::triggerHapticPulse(float strength, float duration, controller::Hand hand) const {
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(strength, duration, hand);
+    }
+
+    bool ScriptingInterface::triggerShortHapticPulse(float strength, controller::Hand hand) const {
+        const float SHORT_HAPTIC_DURATION_MS = 250.0f;
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(strength, SHORT_HAPTIC_DURATION_MS, hand);
+    }
+
+    bool ScriptingInterface::triggerHapticPulseOnDevice(unsigned int device, float strength, float duration, controller::Hand hand) const {
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulseOnDevice(device, strength, duration, hand);
+    }
+
+    bool ScriptingInterface::triggerShortHapticPulseOnDevice(unsigned int device, float strength, controller::Hand hand) const {
+        const float SHORT_HAPTIC_DURATION_MS = 250.0f;
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulseOnDevice(device, strength, SHORT_HAPTIC_DURATION_MS, hand);
     }
 
     void ScriptingInterface::updateMaps() {

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -76,69 +76,73 @@ controller::ScriptingInterface::ScriptingInterface() {
 
 namespace controller {
 
-    QObject* ScriptingInterface::newMapping(const QString& mappingName) {
-        auto userInputMapper = DependencyManager::get<UserInputMapper>();
-        return new MappingBuilderProxy(*userInputMapper, userInputMapper->newMapping(mappingName));
-    }
+	QObject* ScriptingInterface::newMapping(const QString& mappingName) {
+		auto userInputMapper = DependencyManager::get<UserInputMapper>();
+		return new MappingBuilderProxy(*userInputMapper, userInputMapper->newMapping(mappingName));
+	}
 
-    void ScriptingInterface::enableMapping(const QString& mappingName, bool enable) {
-        auto userInputMapper = DependencyManager::get<UserInputMapper>();
-        userInputMapper->enableMapping(mappingName, enable);
-    }
+	void ScriptingInterface::enableMapping(const QString& mappingName, bool enable) {
+		auto userInputMapper = DependencyManager::get<UserInputMapper>();
+		userInputMapper->enableMapping(mappingName, enable);
+	}
 
-    float ScriptingInterface::getValue(const int& source) const {
-        auto userInputMapper = DependencyManager::get<UserInputMapper>();
-        return userInputMapper->getValue(Input((uint32_t)source));
-    }
+	float ScriptingInterface::getValue(const int& source) const {
+		auto userInputMapper = DependencyManager::get<UserInputMapper>();
+		return userInputMapper->getValue(Input((uint32_t)source));
+	}
 
-    float ScriptingInterface::getButtonValue(StandardButtonChannel source, uint16_t device) const {
-        return getValue(Input(device, source, ChannelType::BUTTON).getID());
-    }
+	float ScriptingInterface::getButtonValue(StandardButtonChannel source, uint16_t device) const {
+		return getValue(Input(device, source, ChannelType::BUTTON).getID());
+	}
 
-    float ScriptingInterface::getAxisValue(StandardAxisChannel source, uint16_t device) const {
-        return getValue(Input(device, source, ChannelType::AXIS).getID());
-    }
+	float ScriptingInterface::getAxisValue(StandardAxisChannel source, uint16_t device) const {
+		return getValue(Input(device, source, ChannelType::AXIS).getID());
+	}
 
-    Pose ScriptingInterface::getPoseValue(const int& source) const {
-        auto userInputMapper = DependencyManager::get<UserInputMapper>();
-        return userInputMapper->getPose(Input((uint32_t)source)); 
-    }
-    
-    Pose ScriptingInterface::getPoseValue(StandardPoseChannel source, uint16_t device) const {
-        return getPoseValue(Input(device, source, ChannelType::POSE).getID());
-    }
+	Pose ScriptingInterface::getPoseValue(const int& source) const {
+		auto userInputMapper = DependencyManager::get<UserInputMapper>();
+		return userInputMapper->getPose(Input((uint32_t)source));
+	}
 
-    QVector<Action> ScriptingInterface::getAllActions() {
-        return DependencyManager::get<UserInputMapper>()->getAllActions();
-    }
+	Pose ScriptingInterface::getPoseValue(StandardPoseChannel source, uint16_t device) const {
+		return getPoseValue(Input(device, source, ChannelType::POSE).getID());
+	}
 
-    QString ScriptingInterface::getDeviceName(unsigned int device) {
-        return DependencyManager::get<UserInputMapper>()->getDeviceName((unsigned short)device);
-    }
+	QVector<Action> ScriptingInterface::getAllActions() {
+		return DependencyManager::get<UserInputMapper>()->getAllActions();
+	}
 
-    QVector<Input::NamedPair> ScriptingInterface::getAvailableInputs(unsigned int device) {
-        return DependencyManager::get<UserInputMapper>()->getAvailableInputs((unsigned short)device);
-    }
+	QString ScriptingInterface::getDeviceName(unsigned int device) {
+		return DependencyManager::get<UserInputMapper>()->getDeviceName((unsigned short)device);
+	}
 
-    int ScriptingInterface::findDevice(QString name) {
-        return DependencyManager::get<UserInputMapper>()->findDevice(name);
-    }
+	QVector<Input::NamedPair> ScriptingInterface::getAvailableInputs(unsigned int device) {
+		return DependencyManager::get<UserInputMapper>()->getAvailableInputs((unsigned short)device);
+	}
 
-    QVector<QString> ScriptingInterface::getDeviceNames() {
-        return DependencyManager::get<UserInputMapper>()->getDeviceNames();
-    }
+	int ScriptingInterface::findDevice(QString name) {
+		return DependencyManager::get<UserInputMapper>()->findDevice(name);
+	}
 
-    float ScriptingInterface::getActionValue(int action) {
-        return DependencyManager::get<UserInputMapper>()->getActionState(Action(action));
-    }
+	QVector<QString> ScriptingInterface::getDeviceNames() {
+		return DependencyManager::get<UserInputMapper>()->getDeviceNames();
+	}
 
-    int ScriptingInterface::findAction(QString actionName) {
-        return DependencyManager::get<UserInputMapper>()->findAction(actionName);
-    }
+	float ScriptingInterface::getActionValue(int action) {
+		return DependencyManager::get<UserInputMapper>()->getActionState(Action(action));
+	}
 
-    QVector<QString> ScriptingInterface::getActionNames() const {
-        return DependencyManager::get<UserInputMapper>()->getActionNames();
-    }
+	int ScriptingInterface::findAction(QString actionName) {
+		return DependencyManager::get<UserInputMapper>()->findAction(actionName);
+	}
+
+	QVector<QString> ScriptingInterface::getActionNames() const {
+		return DependencyManager::get<UserInputMapper>()->getActionNames();
+	}
+
+	bool ScriptingInterface::triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand) const {
+		return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(device, strength, duration, leftHand);
+	}
 
     void ScriptingInterface::updateMaps() {
         QVariantMap newHardware;

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -76,73 +76,73 @@ controller::ScriptingInterface::ScriptingInterface() {
 
 namespace controller {
 
-	QObject* ScriptingInterface::newMapping(const QString& mappingName) {
-		auto userInputMapper = DependencyManager::get<UserInputMapper>();
-		return new MappingBuilderProxy(*userInputMapper, userInputMapper->newMapping(mappingName));
-	}
+    QObject* ScriptingInterface::newMapping(const QString& mappingName) {
+        auto userInputMapper = DependencyManager::get<UserInputMapper>();
+        return new MappingBuilderProxy(*userInputMapper, userInputMapper->newMapping(mappingName));
+    }
 
-	void ScriptingInterface::enableMapping(const QString& mappingName, bool enable) {
-		auto userInputMapper = DependencyManager::get<UserInputMapper>();
-		userInputMapper->enableMapping(mappingName, enable);
-	}
+    void ScriptingInterface::enableMapping(const QString& mappingName, bool enable) {
+        auto userInputMapper = DependencyManager::get<UserInputMapper>();
+        userInputMapper->enableMapping(mappingName, enable);
+    }
 
-	float ScriptingInterface::getValue(const int& source) const {
-		auto userInputMapper = DependencyManager::get<UserInputMapper>();
-		return userInputMapper->getValue(Input((uint32_t)source));
-	}
+    float ScriptingInterface::getValue(const int& source) const {
+        auto userInputMapper = DependencyManager::get<UserInputMapper>();
+        return userInputMapper->getValue(Input((uint32_t)source));
+    }
 
-	float ScriptingInterface::getButtonValue(StandardButtonChannel source, uint16_t device) const {
-		return getValue(Input(device, source, ChannelType::BUTTON).getID());
-	}
+    float ScriptingInterface::getButtonValue(StandardButtonChannel source, uint16_t device) const {
+        return getValue(Input(device, source, ChannelType::BUTTON).getID());
+    }
 
-	float ScriptingInterface::getAxisValue(StandardAxisChannel source, uint16_t device) const {
-		return getValue(Input(device, source, ChannelType::AXIS).getID());
-	}
+    float ScriptingInterface::getAxisValue(StandardAxisChannel source, uint16_t device) const {
+        return getValue(Input(device, source, ChannelType::AXIS).getID());
+    }
 
-	Pose ScriptingInterface::getPoseValue(const int& source) const {
-		auto userInputMapper = DependencyManager::get<UserInputMapper>();
-		return userInputMapper->getPose(Input((uint32_t)source));
-	}
+    Pose ScriptingInterface::getPoseValue(const int& source) const {
+        auto userInputMapper = DependencyManager::get<UserInputMapper>();
+        return userInputMapper->getPose(Input((uint32_t)source)); 
+    }
+    
+    Pose ScriptingInterface::getPoseValue(StandardPoseChannel source, uint16_t device) const {
+        return getPoseValue(Input(device, source, ChannelType::POSE).getID());
+    }
 
-	Pose ScriptingInterface::getPoseValue(StandardPoseChannel source, uint16_t device) const {
-		return getPoseValue(Input(device, source, ChannelType::POSE).getID());
-	}
+    QVector<Action> ScriptingInterface::getAllActions() {
+        return DependencyManager::get<UserInputMapper>()->getAllActions();
+    }
 
-	QVector<Action> ScriptingInterface::getAllActions() {
-		return DependencyManager::get<UserInputMapper>()->getAllActions();
-	}
+    QString ScriptingInterface::getDeviceName(unsigned int device) {
+        return DependencyManager::get<UserInputMapper>()->getDeviceName((unsigned short)device);
+    }
 
-	QString ScriptingInterface::getDeviceName(unsigned int device) {
-		return DependencyManager::get<UserInputMapper>()->getDeviceName((unsigned short)device);
-	}
+    QVector<Input::NamedPair> ScriptingInterface::getAvailableInputs(unsigned int device) {
+        return DependencyManager::get<UserInputMapper>()->getAvailableInputs((unsigned short)device);
+    }
 
-	QVector<Input::NamedPair> ScriptingInterface::getAvailableInputs(unsigned int device) {
-		return DependencyManager::get<UserInputMapper>()->getAvailableInputs((unsigned short)device);
-	}
+    int ScriptingInterface::findDevice(QString name) {
+        return DependencyManager::get<UserInputMapper>()->findDevice(name);
+    }
 
-	int ScriptingInterface::findDevice(QString name) {
-		return DependencyManager::get<UserInputMapper>()->findDevice(name);
-	}
+    QVector<QString> ScriptingInterface::getDeviceNames() {
+        return DependencyManager::get<UserInputMapper>()->getDeviceNames();
+    }
 
-	QVector<QString> ScriptingInterface::getDeviceNames() {
-		return DependencyManager::get<UserInputMapper>()->getDeviceNames();
-	}
+    float ScriptingInterface::getActionValue(int action) {
+        return DependencyManager::get<UserInputMapper>()->getActionState(Action(action));
+    }
 
-	float ScriptingInterface::getActionValue(int action) {
-		return DependencyManager::get<UserInputMapper>()->getActionState(Action(action));
-	}
+    int ScriptingInterface::findAction(QString actionName) {
+        return DependencyManager::get<UserInputMapper>()->findAction(actionName);
+    }
 
-	int ScriptingInterface::findAction(QString actionName) {
-		return DependencyManager::get<UserInputMapper>()->findAction(actionName);
-	}
+    QVector<QString> ScriptingInterface::getActionNames() const {
+        return DependencyManager::get<UserInputMapper>()->getActionNames();
+    }
 
-	QVector<QString> ScriptingInterface::getActionNames() const {
-		return DependencyManager::get<UserInputMapper>()->getActionNames();
-	}
-
-	bool ScriptingInterface::triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand) const {
-		return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(device, strength, duration, leftHand);
-	}
+    bool ScriptingInterface::triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand) const {
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(device, strength, duration, leftHand);
+    }
 
     void ScriptingInterface::updateMaps() {
         QVariantMap newHardware;

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -77,7 +77,7 @@ namespace controller {
         Q_INVOKABLE QVector<QString> getDeviceNames();
         Q_INVOKABLE int findAction(QString actionName);
         Q_INVOKABLE QVector<QString> getActionNames() const;
-        
+
         Q_INVOKABLE float getValue(const int& source) const;
         Q_INVOKABLE float getButtonValue(StandardButtonChannel source, uint16_t device = 0) const;
         Q_INVOKABLE float getAxisValue(StandardAxisChannel source, uint16_t device = 0) const;

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -77,12 +77,14 @@ namespace controller {
         Q_INVOKABLE QVector<QString> getDeviceNames();
         Q_INVOKABLE int findAction(QString actionName);
         Q_INVOKABLE QVector<QString> getActionNames() const;
-
+		
         Q_INVOKABLE float getValue(const int& source) const;
         Q_INVOKABLE float getButtonValue(StandardButtonChannel source, uint16_t device = 0) const;
         Q_INVOKABLE float getAxisValue(StandardAxisChannel source, uint16_t device = 0) const;
         Q_INVOKABLE Pose getPoseValue(const int& source) const;
-        Q_INVOKABLE Pose getPoseValue(StandardPoseChannel source, uint16_t device = 0) const;
+		Q_INVOKABLE Pose getPoseValue(StandardPoseChannel source, uint16_t device = 0) const;
+
+		Q_INVOKABLE bool triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand = true) const;
 
         Q_INVOKABLE QObject* newMapping(const QString& mappingName = QUuid::createUuid().toString());
         Q_INVOKABLE void enableMapping(const QString& mappingName, bool enable = true);

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -84,7 +84,10 @@ namespace controller {
         Q_INVOKABLE Pose getPoseValue(const int& source) const;
         Q_INVOKABLE Pose getPoseValue(StandardPoseChannel source, uint16_t device = 0) const;
 
-        Q_INVOKABLE bool triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand = true) const;
+        Q_INVOKABLE bool triggerHapticPulse(float strength, float duration, controller::Hand hand = BOTH) const;
+        Q_INVOKABLE bool triggerShortHapticPulse(float strength, controller::Hand hand = BOTH) const;
+        Q_INVOKABLE bool triggerHapticPulseOnDevice(unsigned int device, float strength, float duration, controller::Hand hand = BOTH) const;
+        Q_INVOKABLE bool triggerShortHapticPulseOnDevice(unsigned int device, float strength, controller::Hand hand = BOTH) const;
 
         Q_INVOKABLE QObject* newMapping(const QString& mappingName = QUuid::createUuid().toString());
         Q_INVOKABLE void enableMapping(const QString& mappingName, bool enable = true);

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -77,14 +77,14 @@ namespace controller {
         Q_INVOKABLE QVector<QString> getDeviceNames();
         Q_INVOKABLE int findAction(QString actionName);
         Q_INVOKABLE QVector<QString> getActionNames() const;
-		
+        
         Q_INVOKABLE float getValue(const int& source) const;
         Q_INVOKABLE float getButtonValue(StandardButtonChannel source, uint16_t device = 0) const;
         Q_INVOKABLE float getAxisValue(StandardAxisChannel source, uint16_t device = 0) const;
         Q_INVOKABLE Pose getPoseValue(const int& source) const;
-		Q_INVOKABLE Pose getPoseValue(StandardPoseChannel source, uint16_t device = 0) const;
+        Q_INVOKABLE Pose getPoseValue(StandardPoseChannel source, uint16_t device = 0) const;
 
-		Q_INVOKABLE bool triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand = true) const;
+        Q_INVOKABLE bool triggerHapticPulse(unsigned int device, float strength, float duration, bool leftHand = true) const;
 
         Q_INVOKABLE QObject* newMapping(const QString& mappingName = QUuid::createUuid().toString());
         Q_INVOKABLE void enableMapping(const QString& mappingName, bool enable = true);

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -337,11 +337,11 @@ QVector<QString> UserInputMapper::getActionNames() const {
 }
 
 bool UserInputMapper::triggerHapticPulse(uint16 deviceID, float strength, float duration, bool leftHand) {
-	Locker locker(_lock);
-	if (_registeredDevices.find(deviceID) != _registeredDevices.end()) {
-		return _registeredDevices[deviceID]->triggerHapticPulse(strength, duration, leftHand);
-	}
-	return false;
+    Locker locker(_lock);
+    if (_registeredDevices.find(deviceID) != _registeredDevices.end()) {
+        return _registeredDevices[deviceID]->triggerHapticPulse(strength, duration, leftHand);
+    }
+    return false;
 }
 
 int actionMetaTypeId = qRegisterMetaType<Action>();

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -336,6 +336,14 @@ QVector<QString> UserInputMapper::getActionNames() const {
     return result;
 }
 
+bool UserInputMapper::triggerHapticPulse(uint16 deviceID, float strength, float duration, bool leftHand) {
+	Locker locker(_lock);
+	if (_registeredDevices.find(deviceID) != _registeredDevices.end()) {
+		return _registeredDevices[deviceID]->triggerHapticPulse(strength, duration, leftHand);
+	}
+	return false;
+}
+
 int actionMetaTypeId = qRegisterMetaType<Action>();
 int inputMetaTypeId = qRegisterMetaType<Input>();
 int inputPairMetaTypeId = qRegisterMetaType<Input::NamedPair>();

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -89,7 +89,7 @@ namespace controller {
         void setActionState(Action action, float value) { _actionStates[toInt(action)] = value; }
         void deltaActionState(Action action, float delta) { _actionStates[toInt(action)] += delta; }
         void setActionState(Action action, const Pose& value) { _poseStates[toInt(action)] = value; }
-		bool triggerHapticPulse(uint16 deviceID, float strength, float duration, bool leftHand);
+        bool triggerHapticPulse(uint16 deviceID, float strength, float duration, bool leftHand);
 
         static Input makeStandardInput(controller::StandardButtonChannel button);
         static Input makeStandardInput(controller::StandardAxisChannel axis);

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -89,7 +89,8 @@ namespace controller {
         void setActionState(Action action, float value) { _actionStates[toInt(action)] = value; }
         void deltaActionState(Action action, float delta) { _actionStates[toInt(action)] += delta; }
         void setActionState(Action action, const Pose& value) { _poseStates[toInt(action)] = value; }
-        bool triggerHapticPulse(uint16 deviceID, float strength, float duration, bool leftHand);
+        bool triggerHapticPulse(float strength, float duration, controller::Hand hand);
+        bool triggerHapticPulseOnDevice(uint16 deviceID, float strength, float duration, controller::Hand hand);
 
         static Input makeStandardInput(controller::StandardButtonChannel button);
         static Input makeStandardInput(controller::StandardAxisChannel axis);
@@ -200,6 +201,7 @@ Q_DECLARE_METATYPE(QVector<controller::Input::NamedPair>)
 Q_DECLARE_METATYPE(controller::Input)
 Q_DECLARE_METATYPE(controller::Action)
 Q_DECLARE_METATYPE(QVector<controller::Action>)
+Q_DECLARE_METATYPE(controller::Hand)
 
 // Cheating.
 using UserInputMapper = controller::UserInputMapper;

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -89,6 +89,7 @@ namespace controller {
         void setActionState(Action action, float value) { _actionStates[toInt(action)] = value; }
         void deltaActionState(Action action, float delta) { _actionStates[toInt(action)] += delta; }
         void setActionState(Action action, const Pose& value) { _poseStates[toInt(action)] = value; }
+		bool triggerHapticPulse(uint16 deviceID, float strength, float duration, bool leftHand);
 
         static Input makeStandardInput(controller::StandardButtonChannel button);
         static Input makeStandardInput(controller::StandardAxisChannel axis);

--- a/plugins/hifiSdl2/src/Joystick.cpp
+++ b/plugins/hifiSdl2/src/Joystick.cpp
@@ -25,7 +25,7 @@ Joystick::Joystick(SDL_JoystickID instanceId, SDL_GameController* sdlGameControl
     _instanceId(instanceId)
 {
     if (!_sdlHaptic) {
-        qDebug() << SDL_GetError();
+        qDebug() << QString(SDL_GetError());
     }
     SDL_HapticRumbleInit(_sdlHaptic);
 }

--- a/plugins/hifiSdl2/src/Joystick.cpp
+++ b/plugins/hifiSdl2/src/Joystick.cpp
@@ -21,9 +21,10 @@ Joystick::Joystick(SDL_JoystickID instanceId, SDL_GameController* sdlGameControl
         InputDevice("GamePad"),
     _sdlGameController(sdlGameController),
     _sdlJoystick(SDL_GameControllerGetJoystick(_sdlGameController)),
+    _sdlHaptic(SDL_HapticOpenFromJoystick(_sdlJoystick)),
     _instanceId(instanceId)
 {
-    
+    SDL_HapticRumbleInit(_sdlHaptic);
 }
 
 Joystick::~Joystick() {
@@ -31,6 +32,7 @@ Joystick::~Joystick() {
 }
 
 void Joystick::closeJoystick() {
+    SDL_HapticClose(_sdlHaptic);
     SDL_GameControllerClose(_sdlGameController);
 }
 
@@ -60,6 +62,13 @@ void Joystick::handleButtonEvent(const SDL_ControllerButtonEvent& event) {
     } else {
         _buttonPressedMap.erase(input.getChannel());
     }
+}
+
+bool Joystick::triggerHapticPulse(float strength, float duration, bool leftHand) {
+    if (SDL_HapticRumblePlay(_sdlHaptic, strength, duration) != 0) {
+        return false;
+    }
+    return true;
 }
 
 controller::Input::NamedVector Joystick::getAvailableInputs() const {

--- a/plugins/hifiSdl2/src/Joystick.cpp
+++ b/plugins/hifiSdl2/src/Joystick.cpp
@@ -25,9 +25,12 @@ Joystick::Joystick(SDL_JoystickID instanceId, SDL_GameController* sdlGameControl
     _instanceId(instanceId)
 {
     if (!_sdlHaptic) {
-        qDebug() << QString(SDL_GetError());
+        qDebug() << "SDL Haptic Open Failure: " << QString(SDL_GetError());
+    } else {
+        if (SDL_HapticRumbleInit(_sdlHaptic) != 0) {
+            qDebug() << "SDL Haptic Rumble Init Failure: " << QString(SDL_GetError());
+        }
     }
-    SDL_HapticRumbleInit(_sdlHaptic);
 }
 
 Joystick::~Joystick() {
@@ -35,7 +38,9 @@ Joystick::~Joystick() {
 }
 
 void Joystick::closeJoystick() {
-    SDL_HapticClose(_sdlHaptic);
+    if (_sdlHaptic) {
+        SDL_HapticClose(_sdlHaptic);
+    }
     SDL_GameControllerClose(_sdlGameController);
 }
 

--- a/plugins/hifiSdl2/src/Joystick.cpp
+++ b/plugins/hifiSdl2/src/Joystick.cpp
@@ -25,7 +25,7 @@ Joystick::Joystick(SDL_JoystickID instanceId, SDL_GameController* sdlGameControl
     _instanceId(instanceId)
 {
     if (!_sdlHaptic) {
-        qDebug(SDL_GetError());
+        qDebug() << SDL_GetError();
     }
     SDL_HapticRumbleInit(_sdlHaptic);
 }

--- a/plugins/hifiSdl2/src/Joystick.cpp
+++ b/plugins/hifiSdl2/src/Joystick.cpp
@@ -67,7 +67,7 @@ void Joystick::handleButtonEvent(const SDL_ControllerButtonEvent& event) {
     }
 }
 
-bool Joystick::triggerHapticPulse(float strength, float duration, bool leftHand) {
+bool Joystick::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
     if (SDL_HapticRumblePlay(_sdlHaptic, strength, duration) != 0) {
         return false;
     }

--- a/plugins/hifiSdl2/src/Joystick.h
+++ b/plugins/hifiSdl2/src/Joystick.h
@@ -37,7 +37,7 @@ public:
     virtual void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
     virtual void focusOutEvent() override;
 
-    bool triggerHapticPulse(float strength, float duration, bool leftHand) override;
+    bool triggerHapticPulse(float strength, float duration, controller::Hand hand) override;
     
     Joystick() : InputDevice("GamePad") {}
     ~Joystick();

--- a/plugins/hifiSdl2/src/Joystick.h
+++ b/plugins/hifiSdl2/src/Joystick.h
@@ -36,6 +36,8 @@ public:
     virtual QString getDefaultMappingConfig() const override;
     virtual void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
     virtual void focusOutEvent() override;
+
+    bool triggerHapticPulse(float strength, float duration, bool leftHand) override;
     
     Joystick() : InputDevice("GamePad") {}
     ~Joystick();
@@ -52,6 +54,7 @@ public:
 private:
     SDL_GameController* _sdlGameController;
     SDL_Joystick* _sdlJoystick;
+    SDL_Haptic* _sdlHaptic;
     SDL_JoystickID _instanceId;
 };
 

--- a/plugins/hifiSdl2/src/SDL2Manager.cpp
+++ b/plugins/hifiSdl2/src/SDL2Manager.cpp
@@ -49,7 +49,7 @@ SDL_JoystickID SDL2Manager::getInstanceId(SDL_GameController* controller) {
 }
 
 void SDL2Manager::init() {
-    bool initSuccess = (SDL_Init(SDL_INIT_GAMECONTROLLER) == 0);
+    bool initSuccess = (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) == 0);
 
     if (initSuccess) {
         int joystickCount = SDL_NumJoysticks();

--- a/plugins/oculus/src/OculusControllerManager.cpp
+++ b/plugins/oculus/src/OculusControllerManager.cpp
@@ -253,18 +253,28 @@ bool OculusControllerManager::TouchDevice::triggerHapticPulse(float strength, fl
     Locker locker(_lock);
     bool toReturn = true;
     if (hand == controller::BOTH || hand == controller::LEFT) {
-        _leftHapticStrength = (duration > _leftHapticDuration) ? strength : _leftHapticStrength;
-        if (ovr_SetControllerVibration(_parent._session, ovrControllerType_LTouch, 1.0f, _leftHapticStrength) != ovrSuccess) {
-            toReturn = false;
+        if (strength == 0.0f) {
+            _leftHapticStrength = 0.0f;
+            _leftHapticDuration = 0.0f;
+        } else {
+            _leftHapticStrength = (duration > _leftHapticDuration) ? strength : _leftHapticStrength;
+            if (ovr_SetControllerVibration(_parent._session, ovrControllerType_LTouch, 1.0f, _leftHapticStrength) != ovrSuccess) {
+                toReturn = false;
+            }
+            _leftHapticDuration = std::max(duration, _leftHapticDuration);
         }
-        _leftHapticDuration = std::max(duration, _leftHapticDuration);
     }
     if (hand == controller::BOTH || hand == controller::RIGHT) {
-        _rightHapticStrength = (duration > _rightHapticDuration) ? strength : _rightHapticStrength;
-        if (ovr_SetControllerVibration(_parent._session, ovrControllerType_RTouch, 1.0f, _rightHapticStrength) != ovrSuccess) {
-            toReturn = false;
+        if (strength == 0.0f) {
+            _rightHapticStrength = 0.0f;
+            _rightHapticDuration = 0.0f;
+        } else {
+            _rightHapticStrength = (duration > _rightHapticDuration) ? strength : _rightHapticStrength;
+            if (ovr_SetControllerVibration(_parent._session, ovrControllerType_RTouch, 1.0f, _rightHapticStrength) != ovrSuccess) {
+                toReturn = false;
+            }
+            _rightHapticDuration = std::max(duration, _rightHapticDuration);
         }
-        _rightHapticDuration = std::max(duration, _rightHapticDuration);
     }
     return toReturn;
 }

--- a/plugins/oculus/src/OculusControllerManager.cpp
+++ b/plugins/oculus/src/OculusControllerManager.cpp
@@ -253,16 +253,18 @@ bool OculusControllerManager::TouchDevice::triggerHapticPulse(float strength, fl
     Locker locker(_lock);
     bool toReturn = true;
     if (hand == controller::BOTH || hand == controller::LEFT) {
-        if (ovr_SetControllerVibration(_parent._session, ovrControllerType_LTouch, 1.0f, strength) != ovrSuccess) {
+        _leftHapticStrength = (duration > _leftHapticDuration) ? strength : _leftHapticStrength;
+        if (ovr_SetControllerVibration(_parent._session, ovrControllerType_LTouch, 1.0f, _leftHapticStrength) != ovrSuccess) {
             toReturn = false;
         }
-        _leftHapticDuration = duration;
+        _leftHapticDuration = std::max(duration, _leftHapticDuration);
     }
     if (hand == controller::BOTH || hand == controller::RIGHT) {
-        if (ovr_SetControllerVibration(_parent._session, ovrControllerType_RTouch, 1.0f, strength) != ovrSuccess) {
+        _rightHapticStrength = (duration > _rightHapticDuration) ? strength : _rightHapticStrength;
+        if (ovr_SetControllerVibration(_parent._session, ovrControllerType_RTouch, 1.0f, _rightHapticStrength) != ovrSuccess) {
             toReturn = false;
         }
-        _rightHapticDuration = duration;
+        _rightHapticDuration = std::max(duration, _rightHapticDuration);
     }
     return toReturn;
 }

--- a/plugins/oculus/src/OculusControllerManager.cpp
+++ b/plugins/oculus/src/OculusControllerManager.cpp
@@ -221,12 +221,12 @@ void OculusControllerManager::TouchDevice::update(float deltaTime, const control
     {
         Locker locker(_lock);
         if (_leftHapticDuration > 0.0f) {
-            _leftHapticDuration -= deltaTime;
+            _leftHapticDuration -= deltaTime * 1000.0f; // milliseconds
         } else {
             stopHapticPulse(true);
         }
         if (_rightHapticDuration > 0.0f) {
-            _rightHapticDuration -= deltaTime;
+            _rightHapticDuration -= deltaTime * 1000.0f; // milliseconds
         } else {
             stopHapticPulse(false);
         }

--- a/plugins/oculus/src/OculusControllerManager.h
+++ b/plugins/oculus/src/OculusControllerManager.h
@@ -80,7 +80,9 @@ private:
         void withLock(F&& f) { Locker locker(_lock); f(); }
 
         float _leftHapticDuration { 0.0f };
+        float _leftHapticStrength { 0.0f };
         float _rightHapticDuration { 0.0f };
+        float _rightHapticStrength { 0.0f };
         mutable std::recursive_mutex _lock;
 
         friend class OculusControllerManager;

--- a/plugins/oculus/src/OculusControllerManager.h
+++ b/plugins/oculus/src/OculusControllerManager.h
@@ -72,8 +72,6 @@ private:
 
     private:
         void stopHapticPulse(bool leftHand);
-
-    private:
         void handlePose(float deltaTime, const controller::InputCalibrationData& inputCalibrationData, ovrHandType hand, const ovrPoseStatef& handPose);
         int _trackedControllers { 0 };
         friend class OculusControllerManager;

--- a/plugins/oculus/src/OculusControllerManager.h
+++ b/plugins/oculus/src/OculusControllerManager.h
@@ -10,6 +10,7 @@
 #define hifi__OculusControllerManager
 
 #include <QObject>
+#include <QTimer>
 #include <unordered_set>
 
 #include <GLMHelpers.h>
@@ -31,6 +32,9 @@ public:
 
     void pluginFocusOutEvent() override;
     void pluginUpdate(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
+
+private slots:
+    void stopHapticPulse(bool leftHand);
 
 private:
     class OculusInputDevice : public controller::InputDevice {
@@ -64,6 +68,11 @@ private:
         void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
         void focusOutEvent() override;
 
+        bool triggerHapticPulse(float strength, float duration, bool leftHand) override;
+
+    private:
+        void stopHapticPulse(bool leftHand);
+
     private:
         void handlePose(float deltaTime, const controller::InputCalibrationData& inputCalibrationData, ovrHandType hand, const ovrPoseStatef& handPose);
         int _trackedControllers { 0 };
@@ -73,6 +82,8 @@ private:
     ovrSession _session { nullptr };
     ovrInputState _inputState {};
     RemoteDevice::Pointer _remote;
+    QTimer _leftHapticTimer;
+    QTimer _rightHapticTimer;
     TouchDevice::Pointer _touch;
     static const QString NAME;
 };

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -477,8 +477,8 @@ void ViveControllerManager::InputDevice::hapticsHelper(float deltaTime, bool lef
 
         // Vive Controllers only support duration up to 4 ms, which is short enough that any variation feels more like strength
         const float MAX_HAPTIC_TIME = 3999.0f; // in microseconds
-        float hapticTime = strength*MAX_HAPTIC_TIME;
-        if (hapticTime < duration*1000.0f) {
+        float hapticTime = strength * MAX_HAPTIC_TIME;
+        if (hapticTime < duration * 1000.0f) {
             _system->TriggerHapticPulse(deviceIndex, 0, hapticTime);
         }
 

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -455,12 +455,12 @@ void ViveControllerManager::InputDevice::handlePoseEvent(float deltaTime, const 
 bool ViveControllerManager::InputDevice::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
     Locker locker(_lock);
     if (hand == controller::BOTH || hand == controller::LEFT) {
-        _leftHapticStrength = strength;
-        _leftHapticDuration = duration;
+        _leftHapticStrength = (duration > _leftHapticDuration) ? strength : _leftHapticStrength;
+        _leftHapticDuration = std::max(duration, _leftHapticDuration);
     }
     if (hand == controller::BOTH || hand == controller::RIGHT) {
-        _rightHapticStrength = strength;
-        _rightHapticDuration = duration;
+        _rightHapticStrength = (duration > _rightHapticDuration) ? strength : _rightHapticStrength;
+        _rightHapticDuration = std::max(duration, _rightHapticDuration);
     }
     return true;
 }

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -452,12 +452,13 @@ void ViveControllerManager::InputDevice::handlePoseEvent(float deltaTime, const 
     _poseStateMap[isLeftHand ? controller::LEFT_HAND : controller::RIGHT_HAND] = avatarPose.transform(controllerToAvatar);
 }
 
-bool ViveControllerManager::InputDevice::triggerHapticPulse(float strength, float duration, bool leftHand) {
+bool ViveControllerManager::InputDevice::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
     Locker locker(_lock);
-    if (leftHand) {
+    if (hand == controller::BOTH || hand == controller::LEFT) {
         _leftHapticStrength = strength;
         _leftHapticDuration = duration;
-    } else {
+    }
+    if (hand == controller::BOTH || hand == controller::RIGHT) {
         _rightHapticStrength = strength;
         _rightHapticDuration = duration;
     }
@@ -481,9 +482,6 @@ void ViveControllerManager::InputDevice::hapticsHelper(float deltaTime, bool lef
             _system->TriggerHapticPulse(deviceIndex, 0, hapticTime);
         }
 
-        // Must wait 5 ms before triggering another pulse on this controller
-        // https://github.com/ValveSoftware/openvr/wiki/IVRSystem::TriggerHapticPulse
-        const float HAPTIC_RESET_TIME = 5.0f;
         float remainingHapticTime = duration - (hapticTime / 1000.0f + deltaTime * 1000.0f); // in milliseconds
         if (leftHand) {
             _leftHapticDuration = remainingHapticTime;

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -455,12 +455,22 @@ void ViveControllerManager::InputDevice::handlePoseEvent(float deltaTime, const 
 bool ViveControllerManager::InputDevice::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
     Locker locker(_lock);
     if (hand == controller::BOTH || hand == controller::LEFT) {
-        _leftHapticStrength = (duration > _leftHapticDuration) ? strength : _leftHapticStrength;
-        _leftHapticDuration = std::max(duration, _leftHapticDuration);
+        if (strength == 0.0f) {
+            _leftHapticStrength = 0.0f;
+            _leftHapticDuration = 0.0f;
+        } else {
+            _leftHapticStrength = (duration > _leftHapticDuration) ? strength : _leftHapticStrength;
+            _leftHapticDuration = std::max(duration, _leftHapticDuration);
+        }
     }
     if (hand == controller::BOTH || hand == controller::RIGHT) {
-        _rightHapticStrength = (duration > _rightHapticDuration) ? strength : _rightHapticStrength;
-        _rightHapticDuration = std::max(duration, _rightHapticDuration);
+        if (strength == 0.0f) {
+            _rightHapticStrength = 0.0f;
+            _rightHapticDuration = 0.0f;
+        } else {
+            _rightHapticStrength = (duration > _rightHapticDuration) ? strength : _rightHapticStrength;
+            _rightHapticDuration = std::max(duration, _rightHapticDuration);
+        }
     }
     return true;
 }

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -56,6 +56,8 @@ private:
         void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
         void focusOutEvent() override;
 
+        bool triggerHapticPulse(float strength, float duration, bool leftHand) override;
+
         void handleHandController(float deltaTime, uint32_t deviceIndex, const controller::InputCalibrationData& inputCalibrationData, bool isLeftHand);
         void handleButtonEvent(float deltaTime, uint32_t button, bool pressed, bool touched, bool isLeftHand);
         void handleAxisEvent(float deltaTime, uint32_t axis, float x, float y, bool isLeftHand);

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -48,7 +48,7 @@ public:
 private:
     class InputDevice : public controller::InputDevice {
     public:
-        InputDevice(vr::IVRSystem*& system) : controller::InputDevice("Vive"), _system(system), _leftHapticDuration(0.0f), _rightHapticDuration(0.0f) {}
+        InputDevice(vr::IVRSystem*& system) : controller::InputDevice("Vive"), _system(system) {}
     private:
         // Device functions
         controller::Input::NamedVector getAvailableInputs() const override;
@@ -56,7 +56,7 @@ private:
         void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
         void focusOutEvent() override;
 
-        bool triggerHapticPulse(float strength, float duration, bool leftHand) override;
+        bool triggerHapticPulse(float strength, float duration, controller::Hand hand) override;
         void hapticsHelper(float deltaTime, bool leftHand);
 
         void handleHandController(float deltaTime, uint32_t deviceIndex, const controller::InputCalibrationData& inputCalibrationData, bool isLeftHand);
@@ -100,10 +100,10 @@ private:
 
         int _trackedControllers { 0 };
         vr::IVRSystem*& _system;
-        float _leftHapticStrength;
-        float _leftHapticDuration;
-        float _rightHapticStrength;
-        float _rightHapticDuration;
+        float _leftHapticStrength { 0.0f };
+        float _leftHapticDuration { 0.0f };
+        float _rightHapticStrength { 0.0f };
+        float _rightHapticDuration { 0.0f };
         mutable std::recursive_mutex _lock;
 
         friend class ViveControllerManager;


### PR DESCRIPTION
Addresses: https://github.com/highfidelity/hifi/issues/7844

Added some JavaScript functions that allow you to trigger controller vibrations.  Added support for Vive controllers, Oculus Touch, and SDL game controllers, but only the Vive API seems to be working right now.

There are two main methods:
- Controller.triggerHapticPulse(float strength, float duration, Hand hand = 2)
- Controller.triggerHapticPulseOnDevice(uint deviceID, float strength, float duration, Hand hand = 2)

And there are also "short" versions of both of those that don't take in a duration and automatically trigger pulses of 250 ms:
- Controller.triggerShortHapticPulse(float strength, Hand hand = 2)
- Controller.triggerShortHapticPulseOnDevice(uint deviceID, float strength, Hand hand = 2)

Strengths should range from 0-1.  Durations are in milliseconds.

The last arguments are optional and default to 2, which means both hands.  0 means just the left hand, and 1 means just the right hand.

If you trigger a pulse while another one is already in progress, the strength and duration of the one that would finish last are honored.