### PR TITLE
Fixed constant turn of 22.5 degrees in comfort mode

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -9,6 +9,8 @@
           "to": "Actions.StepYaw",
           "filters":
             [
+                { "type": "deadZone", "min": 0.15 },
+                "constrainToInteger",
                 { "type": "pulse", "interval": 0.5 },
                 { "type": "scale", "scale": 22.5 }
             ]


### PR DESCRIPTION
Testing:

- In comfort mode, snap turn should always be 22.5 degrees, regardless of controller