### PR TITLE
re-instate domain API connection info refresh during failure, fix localhost connection after downgrade

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -62,10 +62,7 @@ void DomainGatekeeper::processConnectRequestPacket(QSharedPointer<ReceivedMessag
 
     QByteArray myProtocolVersion = protocolVersionsSignature();
     if (nodeConnection.protocolVersion != myProtocolVersion) {
-        QString protocolVersionError = "Protocol version mismatch - Domain version:" + QCoreApplication::applicationVersion();
-        qDebug() << "Protocol Version mismatch - denying connection.";
-        sendConnectionDeniedPacket(protocolVersionError, message->getSenderSockAddr(), 
-                DomainHandler::ConnectionRefusedReason::ProtocolMismatch);
+        sendProtocolMismatchConnectionDenial(message->getSenderSockAddr());
         return;
     }
     
@@ -121,6 +118,13 @@ void DomainGatekeeper::processConnectRequestPacket(QSharedPointer<ReceivedMessag
     } else {
         qDebug() << "Refusing connection from node at" << message->getSenderSockAddr();
     }
+}
+
+void DomainGatekeeper::sendProtocolMismatchConnectionDenial(const HifiSockAddr& senderSockAddr) {
+    QString protocolVersionError = "Protocol version mismatch - Domain version:" + QCoreApplication::applicationVersion();
+    qDebug() << "Protocol Version mismatch - denying connection.";
+    sendConnectionDeniedPacket(protocolVersionError, senderSockAddr,
+                               DomainHandler::ConnectionRefusedReason::ProtocolMismatch);
 }
 
 SharedNodePointer DomainGatekeeper::processAssignmentConnectRequest(const NodeConnectionData& nodeConnection,
@@ -531,14 +535,14 @@ void DomainGatekeeper::publicKeyJSONCallback(QNetworkReply& requestReply) {
 }
 
 void DomainGatekeeper::sendConnectionDeniedPacket(const QString& reason, const HifiSockAddr& senderSockAddr, 
-            DomainHandler::ConnectionRefusedReason reasonCode) {
+                                                  DomainHandler::ConnectionRefusedReason reasonCode) {
     // this is an agent and we've decided we won't let them connect - send them a packet to deny connection
     QByteArray utfString = reason.toUtf8();
     quint16 payloadSize = utfString.size();
    
     // setup the DomainConnectionDenied packet
     auto connectionDeniedPacket = NLPacket::create(PacketType::DomainConnectionDenied, 
-                                                payloadSize + sizeof(payloadSize) + sizeof(uint8_t));
+                                                   payloadSize + sizeof(payloadSize) + sizeof(uint8_t));
     
     // pack in the reason the connection was denied (the client displays this)
     if (payloadSize > 0) {

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -120,13 +120,6 @@ void DomainGatekeeper::processConnectRequestPacket(QSharedPointer<ReceivedMessag
     }
 }
 
-void DomainGatekeeper::sendProtocolMismatchConnectionDenial(const HifiSockAddr& senderSockAddr) {
-    QString protocolVersionError = "Protocol version mismatch - Domain version:" + QCoreApplication::applicationVersion();
-    qDebug() << "Protocol Version mismatch - denying connection.";
-    sendConnectionDeniedPacket(protocolVersionError, senderSockAddr,
-                               DomainHandler::ConnectionRefusedReason::ProtocolMismatch);
-}
-
 SharedNodePointer DomainGatekeeper::processAssignmentConnectRequest(const NodeConnectionData& nodeConnection,
                                                                     const PendingAssignedNodeData& pendingAssignment) {
     
@@ -532,6 +525,15 @@ void DomainGatekeeper::publicKeyJSONCallback(QNetworkReply& requestReply) {
                 QByteArray::fromBase64(jsonObject[JSON_DATA_KEY].toObject()[JSON_PUBLIC_KEY_KEY].toString().toUtf8());
         }
     }
+}
+
+void DomainGatekeeper::sendProtocolMismatchConnectionDenial(const HifiSockAddr& senderSockAddr) {
+    QString protocolVersionError = "Protocol version mismatch - Domain version: " + QCoreApplication::applicationVersion();
+
+    qDebug() << "Protocol Version mismatch - denying connection.";
+
+    sendConnectionDeniedPacket(protocolVersionError, senderSockAddr,
+                               DomainHandler::ConnectionRefusedReason::ProtocolMismatch);
 }
 
 void DomainGatekeeper::sendConnectionDeniedPacket(const QString& reason, const HifiSockAddr& senderSockAddr, 

--- a/domain-server/src/DomainGatekeeper.h
+++ b/domain-server/src/DomainGatekeeper.h
@@ -42,6 +42,8 @@ public:
     void preloadAllowedUserPublicKeys();
     
     void removeICEPeer(const QUuid& peerUUID) { _icePeers.remove(peerUUID); }
+
+    static void sendProtocolMismatchConnectionDenial(const HifiSockAddr& senderSockAddr);
 public slots:
     void processConnectRequestPacket(QSharedPointer<ReceivedMessage> message);
     void processICEPingPacket(QSharedPointer<ReceivedMessage> message);
@@ -76,8 +78,8 @@ private:
                                        const HifiSockAddr& senderSockAddr);
     
     void sendConnectionTokenPacket(const QString& username, const HifiSockAddr& senderSockAddr);
-    void sendConnectionDeniedPacket(const QString& reason, const HifiSockAddr& senderSockAddr, 
-                    DomainHandler::ConnectionRefusedReason reasonCode = DomainHandler::ConnectionRefusedReason::Unknown);
+    static void sendConnectionDeniedPacket(const QString& reason, const HifiSockAddr& senderSockAddr,
+            DomainHandler::ConnectionRefusedReason reasonCode = DomainHandler::ConnectionRefusedReason::Unknown);
     
     void pingPunchForConnectingPeer(const SharedNetworkPeer& peer);
     

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -324,7 +324,7 @@ bool DomainServer::packetVersionMatch(const udt::Packet& packet) {
     // don't understand, so we can send them an empty EntityData with our latest version and they will
     // warn the user that the protocol is not compatible
     if (headerType == PacketType::DomainConnectRequest &&
-        headerVersion < static_cast<PacketVersion>(DomainConnectRequestVersion::HasProtocolVersions)) {
+        headerVersion <static_cast<PacketVersion>(DomainConnectRequestVersion::HasProtocolVersions)) {
         auto packetWithBadVersion = NLPacket::create(PacketType::EntityData);
         nodeList->sendPacket(std::move(packetWithBadVersion), packet.getSenderSockAddr());
         return false;

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -318,16 +318,11 @@ bool DomainServer::packetVersionMatch(const udt::Packet& packet) {
 
     auto nodeList = DependencyManager::get<LimitedNodeList>();
 
-    // This implements a special case that handles OLD clients which don't know how to negotiate matching
-    // protocol versions. We know these clients will sent DomainConnectRequest with older versions. We also
-    // know these clients will show a warning dialog if they get an EntityData with a protocol version they
-    // don't understand, so we can send them an empty EntityData with our latest version and they will
-    // warn the user that the protocol is not compatible
-    if (headerType == PacketType::DomainConnectRequest &&
-        headerVersion <static_cast<PacketVersion>(DomainConnectRequestVersion::HasProtocolVersions)) {
-        auto packetWithBadVersion = NLPacket::create(PacketType::EntityData);
-        nodeList->sendPacket(std::move(packetWithBadVersion), packet.getSenderSockAddr());
-        return false;
+    // if this is a mismatching connect packet, we can't simply drop it on the floor
+    // send back a packet to the interface that tells them we refuse connection for a mismatch
+    if (headerType == PacketType::DomainConnectRequest
+        && headerVersion != versionForPacketType(PacketType::DomainConnectRequest)) {
+        DomainGatekeeper::sendProtocolMismatchConnectionDenial(packet.getSenderSockAddr());
     }
 
     // let the normal nodeList implementation handle all other packets.

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1072,8 +1072,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
 void Application::domainConnectionRefused(const QString& reasonMessage, int reasonCode) {
     switch (static_cast<DomainHandler::ConnectionRefusedReason>(reasonCode)) {
         case DomainHandler::ConnectionRefusedReason::ProtocolMismatch:
-            notifyPacketVersionMismatch();
-            break;
         case DomainHandler::ConnectionRefusedReason::TooManyUsers:
         case DomainHandler::ConnectionRefusedReason::Unknown: {
             QString message = "Unable to connect to the location you are visiting.\n";

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -655,6 +655,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     connect(nodeList.data(), &NodeList::uuidChanged, this, &Application::setSessionUUID);
     connect(nodeList.data(), &NodeList::packetVersionMismatch, this, &Application::notifyPacketVersionMismatch);
 
+    // you might think we could just do this in NodeList but we only want this connection for Interface
+    connect(nodeList.data(), &NodeList::limitOfSilentDomainCheckInsReached, nodeList.data(), &NodeList::reset);
+
     // connect to appropriate slots on AccountManager
     auto accountManager = DependencyManager::get<AccountManager>();
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -318,7 +318,6 @@ private slots:
     bool displayAvatarAttachmentConfirmationDialog(const QString& name) const;
 
     void setSessionUUID(const QUuid& sessionUUID) const;
-    void limitOfSilentDomainCheckInsReached();
 
     void domainChanged(const QString& domainHostname);
     void updateWindowTitle() const;

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -542,6 +542,9 @@ Menu::Menu() {
     #if (PR_BUILD || DEV_BUILD)
     addCheckableActionToQMenuAndActionHash(networkMenu, MenuOption::SendWrongProtocolVersion, 0, false,
                 qApp, SLOT(sendWrongProtocolVersionsSignature(bool)));
+
+    addCheckableActionToQMenuAndActionHash(networkMenu, MenuOption::SendWrongDSConnectVersion, 0, false,
+                                           nodeList.data(), SLOT(toggleSendNewerDSConnectVersion(bool)));
     #endif
 
     

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -166,6 +166,7 @@ namespace MenuOption {
     const QString RunTimingTests = "Run Timing Tests";
     const QString ScriptEditor = "Script Editor...";
     const QString ScriptedMotorControl = "Enable Scripted Motor Control";
+    const QString SendWrongDSConnectVersion = "Send wrong DS connect version";
     const QString SendWrongProtocolVersion = "Send wrong protocol version";
     const QString SetHomeLocation = "Set Home Location";
     const QString ShowDSConnectTable = "Show Domain Connection Timing";

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -144,12 +144,21 @@ bool AddressManager::handleUrl(const QUrl& lookupUrl, LookupTrigger trigger) {
         // 4. domain network address (IP or dns resolvable hostname)
 
         // use our regex'ed helpers to figure out what we're supposed to do with this
-        if (!handleUsername(lookupUrl.authority())) {
+        if (handleUsername(lookupUrl.authority())) {
+            // handled a username for lookup
+
+            // in case we're failing to connect to where we thought this user was
+            // store their username as previous lookup so we can refresh their location via API
+            _previousLookup = lookupUrl;
+        } else {
             // we're assuming this is either a network address or global place name
             // check if it is a network address first
             bool hostChanged;
             if (handleNetworkAddress(lookupUrl.host()
-                                      + (lookupUrl.port() == -1 ? "" : ":" + QString::number(lookupUrl.port())), trigger, hostChanged)) {
+                                     + (lookupUrl.port() == -1 ? "" : ":" + QString::number(lookupUrl.port())), trigger, hostChanged)) {
+
+                // a network address lookup clears the previous lookup since we don't expect to re-attempt it
+                _previousLookup.clear();
 
                 // If the host changed then we have already saved to history
                 if (hostChanged) {
@@ -165,10 +174,16 @@ bool AddressManager::handleUrl(const QUrl& lookupUrl, LookupTrigger trigger) {
                 // we may have a path that defines a relative viewpoint - if so we should jump to that now
                 handlePath(path, trigger);
             } else if (handleDomainID(lookupUrl.host())){
+                // store this domain ID as the previous lookup in case we're failing to connect and want to refresh API info
+                _previousLookup = lookupUrl;
+
                 // no place name - this is probably a domain ID
                 // try to look up the domain ID on the metaverse API
                 attemptDomainIDLookup(lookupUrl.host(), lookupUrl.path(), trigger);
             } else {
+                // store this place name as the previous lookup in case we fail to connect and want to refresh API info
+                _previousLookup = lookupUrl;
+
                 // wasn't an address - lookup the place name
                 // we may have a path that defines a relative viewpoint - pass that through the lookup so we can go to it after
                 attemptPlaceNameLookup(lookupUrl.host(), lookupUrl.path(), trigger);
@@ -180,9 +195,13 @@ bool AddressManager::handleUrl(const QUrl& lookupUrl, LookupTrigger trigger) {
     } else if (lookupUrl.toString().startsWith('/')) {
         qCDebug(networking) << "Going to relative path" << lookupUrl.path();
 
+        // a path lookup clears the previous lookup since we don't expect to re-attempt it
+        _previousLookup.clear();
+
         // if this is a relative path then handle it as a relative viewpoint
         handlePath(lookupUrl.path(), trigger, true);
         emit lookupResultsFinished();
+
         return true;
     }
 
@@ -276,7 +295,7 @@ void AddressManager::goToAddressFromObject(const QVariantMap& dataObject, const 
 
                     qCDebug(networking) << "Possible domain change required to connect to" << domainHostname
                         << "on" << domainPort;
-                    emit possibleDomainChangeRequired(domainHostname, domainPort);
+                    emit possibleDomainChangeRequired(domainHostname, domainPort, domainID);
                 } else {
                     QString iceServerAddress = domainObject[DOMAIN_ICE_SERVER_ADDRESS_KEY].toString();
 
@@ -315,7 +334,10 @@ void AddressManager::goToAddressFromObject(const QVariantMap& dataObject, const 
                 QString overridePath = reply.property(OVERRIDE_PATH_KEY).toString();
 
                 if (!overridePath.isEmpty()) {
-                    handlePath(overridePath, trigger);
+                    // make sure we don't re-handle an overriden path if this was a refresh of info from API
+                    if (trigger != LookupTrigger::AttemptedRefresh) {
+                        handlePath(overridePath, trigger);
+                    }
                 } else {
                     // take the path that came back
                     const QString PLACE_PATH_KEY = "path";
@@ -598,7 +620,7 @@ bool AddressManager::setDomainInfo(const QString& hostname, quint16 port, Lookup
 
     DependencyManager::get<NodeList>()->flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::HandleAddress);
 
-    emit possibleDomainChangeRequired(hostname, port);
+    emit possibleDomainChangeRequired(hostname, port, QUuid());
 
     return hostChanged;
 }
@@ -618,6 +640,13 @@ void AddressManager::goToUser(const QString& username) {
                                               QByteArray(), nullptr, requestParams);
 }
 
+void AddressManager::refreshPreviousLookup() {
+    // if we have a non-empty previous lookup, fire it again now (but don't re-store it in the history)
+    if (!_previousLookup.isEmpty()) {
+        handleUrl(_previousLookup, LookupTrigger::AttemptedRefresh);
+    }
+}
+
 void AddressManager::copyAddress() {
     QApplication::clipboard()->setText(currentAddress().toString());
 }
@@ -629,7 +658,10 @@ void AddressManager::copyPath() {
 void AddressManager::addCurrentAddressToHistory(LookupTrigger trigger) {
 
     // if we're cold starting and this is called for the first address (from settings) we don't do anything
-    if (trigger != LookupTrigger::StartupFromSettings && trigger != LookupTrigger::DomainPathResponse) {
+    if (trigger != LookupTrigger::StartupFromSettings
+        && trigger != LookupTrigger::DomainPathResponse
+        && trigger != LookupTrigger::AttemptedRefresh) {
+
         if (trigger == LookupTrigger::Back) {
             // we're about to push to the forward stack
             // if it's currently empty emit our signal to say that going forward is now possible

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -384,7 +384,7 @@ void AddressManager::handleAPIError(QNetworkReply& errorReply) {
 
     if (errorReply.error() == QNetworkReply::ContentNotFoundError) {
         // if this is a lookup that has no result, don't keep re-trying it
-        //_previousLookup.clear();
+        _previousLookup.clear();
 
         emit lookupResultIsNotFound();
     }

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -48,7 +48,8 @@ public:
         Forward,
         StartupFromSettings,
         DomainPathResponse,
-        Internal
+        Internal,
+        AttemptedRefresh
     };
 
     bool isConnected();
@@ -89,6 +90,8 @@ public slots:
 
     void goToUser(const QString& username);
 
+    void refreshPreviousLookup();
+
     void storeCurrentAddress();
 
     void copyAddress();
@@ -99,7 +102,7 @@ signals:
     void lookupResultIsOffline();
     void lookupResultIsNotFound();
 
-    void possibleDomainChangeRequired(const QString& newHostname, quint16 newPort);
+    void possibleDomainChangeRequired(const QString& newHostname, quint16 newPort, const QUuid& domainID);
     void possibleDomainChangeRequiredViaICEForID(const QString& iceServerHostname, const QUuid& domainID);
 
     void locationChangeRequired(const glm::vec3& newPosition,
@@ -152,6 +155,8 @@ private:
     quint64 _lastBackPush = 0;
 
     QString _newHostLookupPath;
+    
+    QUrl _previousLookup;
 };
 
 #endif // hifi_AddressManager_h

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -166,7 +166,8 @@ void DomainHandler::setSocketAndID(const QString& hostname, quint16 port, const 
 }
 
 void DomainHandler::setIceServerHostnameAndID(const QString& iceServerHostname, const QUuid& id) {
-    if (_iceServerSockAddr.getAddress().toString() != iceServerHostname && id != _pendingDomainID) {
+
+    if (_iceServerSockAddr.getAddress().toString() != iceServerHostname || id != _pendingDomainID) {
         // re-set the domain info to connect to new domain
         hardReset();
         

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -85,6 +85,7 @@ void DomainHandler::softReset() {
     
     clearSettings();
 
+    _domainConnectionRefusals.clear();
     _connectionDenialsSinceKeypairRegen = 0;
 
     // cancel the failure timeout for any pending requests for settings
@@ -141,9 +142,6 @@ void DomainHandler::setSocketAndID(const QString& hostname, quint16 port, const 
             // set the new hostname
             _hostname = hostname;
 
-            // FIXME - is this the right place???
-            _domainConnectionRefusals.clear();
-
             qCDebug(networking) << "Updated domain hostname to" << _hostname;
 
             // re-set the sock addr to null and fire off a lookup of the IP address for this domain-server's hostname
@@ -168,7 +166,7 @@ void DomainHandler::setSocketAndID(const QString& hostname, quint16 port, const 
 }
 
 void DomainHandler::setIceServerHostnameAndID(const QString& iceServerHostname, const QUuid& id) {
-    if (id != _uuid) {
+    if (_iceServerSockAddr.getAddress().toString() != iceServerHostname && id != _pendingDomainID) {
         // re-set the domain info to connect to new domain
         hardReset();
         

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -28,16 +28,8 @@
 
 DomainHandler::DomainHandler(QObject* parent) :
     QObject(parent),
-    _uuid(),
     _sockAddr(HifiSockAddr(QHostAddress::Null, DEFAULT_DOMAIN_SERVER_PORT)),
-    _assignmentUUID(),
-    _connectionToken(),
-    _iceDomainID(),
-    _iceClientID(),
-    _iceServerSockAddr(),
     _icePeer(this),
-    _isConnected(false),
-    _settingsObject(),
     _settingsTimer(this)
 {
     _sockAddr.setObjectName("DomainServer");
@@ -105,7 +97,7 @@ void DomainHandler::hardReset() {
     softReset();
 
     qCDebug(networking) << "Hard reset in NodeList DomainHandler.";
-    _iceDomainID = QUuid();
+    _pendingDomainID = QUuid();
     _iceServerSockAddr = HifiSockAddr();
     _hostname = QString();
     _sockAddr.clear();
@@ -139,7 +131,7 @@ void DomainHandler::setUUID(const QUuid& uuid) {
     }
 }
 
-void DomainHandler::setHostnameAndPort(const QString& hostname, quint16 port) {
+void DomainHandler::setSocketAndID(const QString& hostname, quint16 port, const QUuid& domainID) {
 
     if (hostname != _hostname || _sockAddr.getPort() != port) {
         // re-set the domain info so that auth information is reloaded
@@ -171,6 +163,8 @@ void DomainHandler::setHostnameAndPort(const QString& hostname, quint16 port) {
         // grab the port by reading the string after the colon
         _sockAddr.setPort(port);
     }
+
+    _pendingDomainID = domainID;
 }
 
 void DomainHandler::setIceServerHostnameAndID(const QString& iceServerHostname, const QUuid& id) {
@@ -181,7 +175,7 @@ void DomainHandler::setIceServerHostnameAndID(const QString& iceServerHostname, 
         // refresh our ICE client UUID to something new
         _iceClientID = QUuid::createUuid();
         
-        _iceDomainID = id;
+        _pendingDomainID = id;
 
         HifiSockAddr* replaceableSockAddr = &_iceServerSockAddr;
         replaceableSockAddr->~HifiSockAddr();
@@ -343,7 +337,7 @@ void DomainHandler::processICEResponsePacket(QSharedPointer<ReceivedMessage> mes
 
     DependencyManager::get<NodeList>()->flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::ReceiveDSPeerInformation);
 
-    if (_icePeer.getUUID() != _iceDomainID) {
+    if (_icePeer.getUUID() != _pendingDomainID) {
         qCDebug(networking) << "Received a network peer with ID that does not match current domain. Will not attempt connection.";
         _icePeer.reset();
     } else {

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -58,8 +58,8 @@ public:
     
     const QUuid& getAssignmentUUID() const { return _assignmentUUID; }
     void setAssignmentUUID(const QUuid& assignmentUUID) { _assignmentUUID = assignmentUUID; }
-    
-    const QUuid& getICEDomainID() const { return _iceDomainID; }
+
+    const QUuid& getPendingDomainID() const { return _pendingDomainID; }
 
     const QUuid& getICEClientID() const { return _iceClientID; }
 
@@ -94,7 +94,7 @@ public:
     };
 
 public slots:
-    void setHostnameAndPort(const QString& hostname, quint16 port = DEFAULT_DOMAIN_SERVER_PORT);
+    void setSocketAndID(const QString& hostname, quint16 port = DEFAULT_DOMAIN_SERVER_PORT, const QUuid& id = QUuid());
     void setIceServerHostnameAndID(const QString& iceServerHostname, const QUuid& id);
 
     void processSettingsPacketList(QSharedPointer<ReceivedMessage> packetList);
@@ -136,11 +136,11 @@ private:
     HifiSockAddr _sockAddr;
     QUuid _assignmentUUID;
     QUuid _connectionToken;
-    QUuid _iceDomainID;
+    QUuid _pendingDomainID; // ID of domain being connected to, via ICE or direct connection
     QUuid _iceClientID;
     HifiSockAddr _iceServerSockAddr;
     NetworkPeer _icePeer;
-    bool _isConnected;
+    bool _isConnected { false };
     QJsonObject _settingsObject;
     QString _pendingPath;
     QTimer _settingsTimer;

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -72,10 +72,11 @@ public:
     bool isConnected() const { return _isConnected; }
     void setIsConnected(bool isConnected);
 
+    bool wasConnectionRefused() const { return !_domainConnectionRefusals.isEmpty(); }
+
     bool hasSettings() const { return !_settingsObject.isEmpty(); }
     void requestDomainSettings();
     const QJsonObject& getSettingsObject() const { return _settingsObject; }
-
    
     void setPendingPath(const QString& pendingPath) { _pendingPath = pendingPath; }
     const QString& getPendingPath() { return _pendingPath; }

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -72,8 +72,6 @@ public:
     bool isConnected() const { return _isConnected; }
     void setIsConnected(bool isConnected);
 
-    bool wasConnectionRefused() const { return !_domainConnectionRefusals.isEmpty(); }
-
     bool hasSettings() const { return !_settingsObject.isEmpty(); }
     void requestDomainSettings();
     const QJsonObject& getSettingsObject() const { return _settingsObject; }
@@ -149,6 +147,8 @@ private:
     QStringList _domainConnectionRefusals;
     bool _hasCheckedForAccessToken { false };
     int _connectionDenialsSinceKeypairRegen { 0 };
+
+    QTimer _apiRefreshTimer;
 };
 
 #endif // hifi_DomainHandler_h

--- a/libraries/networking/src/NLPacket.cpp
+++ b/libraries/networking/src/NLPacket.cpp
@@ -184,6 +184,11 @@ void NLPacket::setType(PacketType type) {
     writeTypeAndVersion();
 }
 
+void NLPacket::setVersion(PacketVersion version) {
+    _version = version;
+    writeTypeAndVersion();
+}
+
 void NLPacket::readType() {
     _type = NLPacket::typeInHeader(*this);
 }

--- a/libraries/networking/src/NLPacket.h
+++ b/libraries/networking/src/NLPacket.h
@@ -65,6 +65,7 @@ public:
     void setType(PacketType type);
     
     PacketVersion getVersion() const { return _version; }
+    void setVersion(PacketVersion version);
 
     const QUuid& getSourceID() const { return _sourceID; }
     

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -356,19 +356,22 @@ void NodeList::sendDomainServerCheckIn() {
         _numNoReplyDomainCheckIns++;
     }
 
-    const int NUM_NO_REPLY_CHECKINS_BEFORE_API_REFRESH = 2;
+    static int numTriggersSinceAPIRefresh = 0;
 
     if (!_publicSockAddr.isNull()
         && !_domainHandler.isConnected()
-        && _numNoReplyDomainCheckIns > NUM_NO_REPLY_CHECKINS_BEFORE_API_REFRESH
         && !_domainHandler.getPendingDomainID().isNull()
-        && !_domainHandler.wasConnectionRefused()) {
+        && !_domainHandler.wasConnectionRefused()
+        && ++numTriggersSinceAPIRefresh > 1) {
 
         // if we aren't connected to the domain-server, and we have an ID
         // (that we presume belongs to a domain in the HF Metaverse)
-        // we request connection information for the domain every so often to make sure what we have is up to date
+        // we re-request connection information from the AdressManager
+        // every 2 failing check in attempts to make sure what we have is up to date
 
         DependencyManager::get<AddressManager>()->refreshPreviousLookup();
+        numTriggersSinceAPIRefresh = 0;
+
     }
 }
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -355,24 +355,6 @@ void NodeList::sendDomainServerCheckIn() {
         // increment the count of un-replied check-ins
         _numNoReplyDomainCheckIns++;
     }
-
-    static int numTriggersSinceAPIRefresh = 0;
-
-    if (!_publicSockAddr.isNull()
-        && !_domainHandler.isConnected()
-        && !_domainHandler.getPendingDomainID().isNull()
-        && !_domainHandler.wasConnectionRefused()
-        && ++numTriggersSinceAPIRefresh > 1) {
-
-        // if we aren't connected to the domain-server, and we have an ID
-        // (that we presume belongs to a domain in the HF Metaverse)
-        // we re-request connection information from the AdressManager
-        // every 2 failing check in attempts to make sure what we have is up to date
-
-        DependencyManager::get<AddressManager>()->refreshPreviousLookup();
-        numTriggersSinceAPIRefresh = 0;
-
-    }
 }
 
 void NodeList::handleDSPathQuery(const QString& newPath) {

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -356,7 +356,14 @@ void NodeList::sendDomainServerCheckIn() {
         _numNoReplyDomainCheckIns++;
     }
 
-    if (!_publicSockAddr.isNull() && !_domainHandler.isConnected() && !_domainHandler.getPendingDomainID().isNull()) {
+    const int NUM_NO_REPLY_CHECKINS_BEFORE_API_REFRESH = 2;
+
+    if (!_publicSockAddr.isNull()
+        && !_domainHandler.isConnected()
+        && _numNoReplyDomainCheckIns > NUM_NO_REPLY_CHECKINS_BEFORE_API_REFRESH
+        && !_domainHandler.getPendingDomainID().isNull()
+        && !_domainHandler.wasConnectionRefused()) {
+
         // if we aren't connected to the domain-server, and we have an ID
         // (that we presume belongs to a domain in the HF Metaverse)
         // we request connection information for the domain every so often to make sure what we have is up to date

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -296,6 +296,13 @@ void NodeList::sendDomainServerCheckIn() {
         QDataStream packetStream(domainPacket.get());
 
         if (domainPacketType == PacketType::DomainConnectRequest) {
+
+#if (PR_BUILD || DEV_BUILD)
+            if (_shouldSendNewerVersion) {
+                domainPacket->setVersion(versionForPacketType(domainPacketType) + 1);
+            }
+#endif
+
             QUuid connectUUID;
 
             if (!_domainHandler.getAssignmentUUID().isNull()) {

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -85,6 +85,10 @@ public slots:
 
     void processICEPingPacket(QSharedPointer<ReceivedMessage> message);
 
+#if (PR_BUILD || DEV_BUILD)
+    void toggleSendNewerDSConnectVersion(bool shouldSendNewerVersion) { _shouldSendNewerVersion = shouldSendNewerVersion; }
+#endif
+
 signals:
     void limitOfSilentDomainCheckInsReached();
     void receivedDomainServerList();
@@ -124,6 +128,10 @@ private:
     HifiSockAddr _assignmentServerSocket;
     bool _isShuttingDown { false };
     QTimer _keepAlivePingTimer;
+
+#if (PR_BUILD || DEV_BUILD)
+    bool _shouldSendNewerVersion { false };
+#endif
 };
 
 #endif // hifi_NodeList_h

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -68,9 +68,6 @@ public:
     
     void setIsShuttingDown(bool isShuttingDown) { _isShuttingDown = isShuttingDown; }
 
-    /// downgrades the DomainConnnectRequest PacketVersion to attempt to probe for older domain servers
-    void downgradeDomainServerCheckInVersion() { _domainConnectRequestVersion--; }
-
 public slots:
     void reset();
     void sendDomainServerCheckIn();
@@ -87,9 +84,6 @@ public slots:
     void processPingReplyPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
 
     void processICEPingPacket(QSharedPointer<ReceivedMessage> message);
-
-    void resetDomainServerCheckInVersion() 
-            { _domainConnectRequestVersion = versionForPacketType(PacketType::DomainConnectRequest); }
 
 signals:
     void limitOfSilentDomainCheckInsReached();
@@ -130,8 +124,6 @@ private:
     HifiSockAddr _assignmentServerSocket;
     bool _isShuttingDown { false };
     QTimer _keepAlivePingTimer;
-
-    PacketVersion _domainConnectRequestVersion = versionForPacketType(PacketType::DomainConnectRequest);
 };
 
 #endif // hifi_NodeList_h

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -105,6 +105,7 @@ private slots:
     void pingPunchForDomainServer();
     
     void sendKeepAlivePings();
+    
 private:
     NodeList() : LimitedNodeList(0, 0) { assert(false); } // Not implemented, needed for DependencyManager templates compile
     NodeList(char ownerType, unsigned short socketListenPort = 0, unsigned short dtlsListenPort = 0);

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -67,7 +67,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
             return static_cast<PacketVersion>(DomainConnectionDeniedVersion::IncludesReasonCode);
 
         case PacketType::DomainConnectRequest:
-            return static_cast<PacketVersion>(DomainConnectRequestVersion::HasHostname);
+            return static_cast<PacketVersion>(DomainConnectRequestVersion::HasProtocolVersions);
 
         default:
             return 17;

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -67,7 +67,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
             return static_cast<PacketVersion>(DomainConnectionDeniedVersion::IncludesReasonCode);
 
         case PacketType::DomainConnectRequest:
-            return static_cast<PacketVersion>(DomainConnectRequestVersion::HasProtocolVersions);
+            return static_cast<PacketVersion>(DomainConnectRequestVersion::HasHostname);
 
         default:
             return 17;


### PR DESCRIPTION
- refresh domain connection information from API when failing to connect
- fix failure to connect to localhost after domain connection version downgrade