### PR TITLE
Attempt to get better logging from pure virtual call crashes

### DIFF
--- a/interface/src/CrashReporter.cpp
+++ b/interface/src/CrashReporter.cpp
@@ -10,17 +10,16 @@
 //
 
 
+#include "Application.h"
 #include "CrashReporter.h"
 
 #ifdef _WIN32
-#include <WinSock2.h>
 #include <new.h>
 #include <Windows.h>
 #include <DbgHelp.h>
 
 #include <csignal>
 #include <QDebug>
-#include "Application.h"
 
 
 #pragma comment(lib, "Dbghelp.lib")

--- a/interface/src/CrashReporter.cpp
+++ b/interface/src/CrashReporter.cpp
@@ -82,21 +82,15 @@ BOOL redirectLibraryFunctionToFunction(char* library, char* function, void* fn)
 }
 
 void printStackTrace(ULONG framesToSkip = 1) {
-    QString result;
-    unsigned int   i;
-    void         * stack[100];
-    unsigned short frames;
-    SYMBOL_INFO  * symbol;
-    HANDLE         process;
-
-    process = GetCurrentProcess();
+    HANDLE process = GetCurrentProcess();
     SymInitialize(process, NULL, TRUE);
-    frames = CaptureStackBackTrace(framesToSkip, 100, stack, NULL);
-    symbol = (SYMBOL_INFO *)calloc(sizeof(SYMBOL_INFO) + 256 * sizeof(char), 1);
+    void* stack[100];
+    uint16_t frames = CaptureStackBackTrace(framesToSkip, 100, stack, NULL);
+    SYMBOL_INFO* symbol = (SYMBOL_INFO *)calloc(sizeof(SYMBOL_INFO) + 256 * sizeof(char), 1);
     symbol->MaxNameLen = 255;
     symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
 
-    for (i = 0; i < frames; i++) {
+    for (uint16_t i = 0; i < frames; ++i) {
         SymFromAddr(process, (DWORD64)(stack[i]), 0, symbol);
         qWarning() << QString("%1: %2 - 0x%0X").arg(QString::number(frames - i - 1), QString(symbol->Name), QString::number(symbol->Address, 16));
     }

--- a/interface/src/FileLogger.cpp
+++ b/interface/src/FileLogger.cpp
@@ -115,3 +115,7 @@ QString FileLogger::getLogData() {
     }
     return result;
 }
+
+void FileLogger::sync() {
+    _persistThreadInstance->waitIdle();
+}

--- a/interface/src/FileLogger.h
+++ b/interface/src/FileLogger.h
@@ -28,6 +28,7 @@ public:
     virtual void addMessage(const QString&) override;
     virtual QString getLogData() override;
     virtual void locateLog() override;
+    void sync();
 
 signals:
     void rollingLogFile(QString newFilename);


### PR DESCRIPTION
Right now we see a number of pure virtual call crashes on exit, but the stack traces from Bugsplat are difficult to use and interpret.  This code should cause a stack trace to be printed to the log prior to exit, allowing for easier diagnosis.