### PR TITLE
Fix tabbing behavior in edit.js

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -546,17 +546,11 @@
 
                                 disableProperties();
                             } else {
-                                var activeElement = document.activeElement;
-    
-                                try {
-                                    var selected = (activeElement
-                                               && activeElement.selectionStart == 0
-                                               && activeElement.selectionEnd == activeElement.value.length);
-                                } catch (e) {
-                                    var  selected = false;
-                                }
+            
     
                                 properties = data.selections[0].properties;
+
+                                //WE SHOULD ONLY UPDATE CHANGED VALUES
                                 elID.innerHTML = properties.id;
     
                                 elType.innerHTML = properties.type;
@@ -572,6 +566,7 @@
                                     enableProperties();
                                 }
 
+                                console.log('updated properties :: ',properties)
     
                                 elName.value = properties.name;
     
@@ -811,11 +806,10 @@
                                     elYTextureURL.value = properties.yTextureURL;
                                     elZTextureURL.value = properties.zTextureURL;
                                 }
-    
-                                if (selected) {
-                                    activeElement.focus();
-                                    activeElement.select();
-                                }
+                                
+                                var activeElement = document.activeElement;
+        
+                                activeElement.select();
                             }
                         }
                     });
@@ -1178,7 +1172,7 @@
                 for (var i = 0; i < els.length; i++) {
                     var clicked = false;
                     var originalText;
-                    els[i].onfocus = function() {
+                    els[i].onfocus = function(e) {
                         originalText = this.value;
                         this.select();
                         clicked = false;

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -550,7 +550,6 @@
     
                                 properties = data.selections[0].properties;
 
-                                //WE SHOULD ONLY UPDATE CHANGED VALUES
                                 elID.innerHTML = properties.id;
     
                                 elType.innerHTML = properties.type;

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -564,8 +564,6 @@
                                 } else {
                                     enableProperties();
                                 }
-
-                                console.log('updated properties :: ',properties)
     
                                 elName.value = properties.name;
     


### PR DESCRIPTION
This PR fixes the behavior when using the tab key to switch between fields in edit.js

Previously, you couldn't go to a field like dimensions in entity properties and change it with the sequence "1 tab 1 tab 1".  Now you can quickly edit properties since the entire field is selected after the change.

To test:

1. Open edit.js
2. Create a cube.
3. Go to its properties page and find the dimensions fields.
4. Click in the x-field and then use this key sequence: 1 tab 1 tab 1
5. You should have a one meter cube.
6.  Test changing some other properties to make sure they still work as expected when using tab.

https://highfidelity.fogbugz.com/f/cases/830/Inconsistent-and-non-standard-behaviour-of-tab-key-in-edit-js