### PR TITLE
Fixing issues with unclosed groups in settings persistence

### DIFF
--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -173,6 +173,7 @@ void AccountManager::setAuthURL(const QUrl& authURL) {
                         <<  "from previous settings file";
                 }
             }
+            settings.endGroup();
 
             if (_accountInfo.getAccessToken().token.isEmpty()) {
                 qCWarning(networking) << "Unable to load account file. No existing account settings will be loaded.";

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -334,6 +334,7 @@ void ScriptEngines::clearScripts() {
     Settings settings;
     settings.beginWriteArray(SETTINGS_KEY);
     settings.remove("");
+    settings.endArray();
 }
 
 void ScriptEngines::saveScripts() {

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -18,6 +18,7 @@
 
 const QString Settings::firstRun { "firstRun" };
 
+
 Settings::Settings() : 
     _manager(DependencyManager::get<Setting::Manager>()), 
     _locker(&(_manager->getLock())) 
@@ -25,6 +26,9 @@ Settings::Settings() :
 }
 
 Settings::~Settings() {
+    if (_prefixes.size() != 0) {
+        qFatal("Unstable Settings Prefixes:  You must call endGroup for every beginGroup and endArray for every begin*Array call");
+    }
 }
 
 void Settings::remove(const QString& key) {
@@ -50,14 +54,17 @@ bool Settings::contains(const QString& key) const {
 }
 
 int Settings::beginReadArray(const QString & prefix) {
+    _prefixes.push(prefix);
     return _manager->beginReadArray(prefix);
 }
 
 void Settings::beginWriteArray(const QString& prefix, int size) {
+    _prefixes.push(prefix);
     _manager->beginWriteArray(prefix, size);
 }
 
 void Settings::endArray() {
+    _prefixes.pop();
     _manager->endArray();
 }
 
@@ -66,10 +73,12 @@ void Settings::setArrayIndex(int i) {
 }
 
 void Settings::beginGroup(const QString& prefix) {
+    _prefixes.push(prefix);
     _manager->beginGroup(prefix);
 }
 
 void Settings::endGroup() {
+    _prefixes.pop();
     _manager->endGroup();
 }
 

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -77,15 +77,40 @@ namespace Setting {
         virtual ~Handle() { deinit(); }
         
         // Returns setting value, returns its default value if not found
-        T get() { return get(_defaultValue); }
+        T get() const { 
+            return get(_defaultValue); 
+        }
+
         // Returns setting value, returns other if not found
-        T get(const T& other) { maybeInit(); return (_isSet) ? _value : other; }
-        T getDefault() const { return _defaultValue; }
+        T get(const T& other) const { 
+            maybeInit(); 
+            return (_isSet) ? _value : other; 
+        }
+
+        const T& getDefault() const { 
+            return _defaultValue; 
+        }
         
-        void set(const T& value) { maybeInit(); _value = value; _isSet = true; }
-        void reset() { set(_defaultValue); }
-        
-        void remove() { maybeInit(); _isSet = false; }
+        void reset() { 
+            set(_defaultValue); 
+        }
+
+        void set(const T& value) { 
+            maybeInit(); 
+            if (_value != value) { 
+                _value = value; 
+                _isSet = true; 
+                save(); 
+            } 
+        }
+
+        void remove() { 
+            maybeInit(); 
+            if (_isSet) { 
+                _isSet = false; 
+                save(); 
+            }  
+        }
         
     protected:
         virtual void setVariant(const QVariant& variant);

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -97,7 +97,7 @@ namespace Setting {
 
         void set(const T& value) { 
             maybeInit(); 
-            if (_value != value) { 
+            if ((!_isSet && (value != _defaultValue)) || _value != value) {
                 _value = value; 
                 _isSet = true; 
                 save(); 

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -58,8 +58,10 @@ public:
     void setQuatValue(const QString& name, const glm::quat& quatValue);
     void getQuatValueIfValid(const QString& name, glm::quat& quatValue);
 
+private:
     QSharedPointer<Setting::Manager> _manager;
     QWriteLocker _locker;
+    QStack<QString> _prefixes;
 };
 
 namespace Setting {

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -119,9 +119,9 @@ namespace Setting {
     }
 
     
-    void Interface::maybeInit() {
+    void Interface::maybeInit() const {
         if (!_isInitialized) {
-            init();
+            const_cast<Interface*>(this)->init();
         }
     }
     

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -98,6 +98,8 @@ namespace Setting {
                 // Register Handle
                 manager->registerHandle(this);
                 _isInitialized = true;
+            } else {
+                qWarning() << "Settings interface used after manager destroyed";
             }
         
             // Load value from disk

--- a/libraries/shared/src/SettingInterface.h
+++ b/libraries/shared/src/SettingInterface.h
@@ -39,19 +39,20 @@ namespace Setting {
         virtual ~Interface() = default;
 
         void init();
-        void maybeInit();
+        void maybeInit() const;
         void deinit();
         
         void save();
         void load();
-        
-        bool _isInitialized = false;
+
         bool _isSet = false;
         const QString _key;
+
+    private:
+        mutable bool _isInitialized = false;
         
         friend class Manager;
-
-        QWeakPointer<Manager> _manager;
+        mutable QWeakPointer<Manager> _manager;
     };
 }
 

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -33,8 +33,8 @@ namespace Setting {
     void Manager::customDeleter() { }
 
 
-    void Manager::registerHandle(Setting::Interface* handle) {
-        QString key = handle->getKey();
+    void Manager::registerHandle(Interface* handle) {
+        const QString& key = handle->getKey();
         withWriteLock([&] {
             if (_handles.contains(key)) {
                 qWarning() << "Setting::Manager::registerHandle(): Key registered more than once, overriding: " << key;
@@ -58,7 +58,9 @@ namespace Setting {
             } else {
                 loadedValue = value(key);
             }
-            handle->setVariant(loadedValue);
+            if (loadedValue.isValid()) {
+                handle->setVariant(loadedValue);
+            }
         });
     }
 
@@ -101,7 +103,7 @@ namespace Setting {
                 if (newValue == savedValue) {
                     continue;
                 }
-                if (newValue == UNSET_VALUE) {
+                if (newValue == UNSET_VALUE || !newValue.isValid()) {
                     remove(key);
                 } else {
                     setValue(key, newValue);

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -96,6 +96,7 @@ namespace Setting {
     }
 
     void Manager::saveAll() {
+        bool forceSync = false;
         withWriteLock([&] {
             for (auto key : _pendingChanges.keys()) {
                 auto newValue = _pendingChanges[key];
@@ -104,13 +105,19 @@ namespace Setting {
                     continue;
                 }
                 if (newValue == UNSET_VALUE || !newValue.isValid()) {
+                    forceSync = true;
                     remove(key);
                 } else {
+                    forceSync = true;
                     setValue(key, newValue);
                 }
             }
             _pendingChanges.clear();
         });
+
+        if (forceSync) {
+            sync();
+        }
 
         // Restart timer
         if (_saveTimer) {


### PR DESCRIPTION
My recent changes to settings broke persistence of some (possibly all?) settings changes.  There were a bunch of places in the code that were doing something like this:

    {
      Settings settings;
      settings.beginWriteArray(SETTINGS_KEY);
      settings.remove("");
    }

This was fine when the `Settings` object synchronously wrote to the INI file, because the 'prefix state' of the Settings object lived and died with it's scope.  

However, because the `Settings` object now forwards to the settings manager, by beginning an array and not making a corresponding `settings.endArray()` call, they've changed the state of the actual QSettings derived singleton we use to persist settings.  All subsequent settings get written underneath the new key, so if you examine your INI file now, you'll see things like

```
[accounts]
RunningScripts\fieldOfView=@Invalid()
```

Where the field of view has been placed underneath `accounts/RunningScripts` even though it belongs under `general`.  

This fix modifies the two existing locations where a `begin` is performed without a corresponding `end`, and additionally adds a `qFatal` call to the `Settings` destructor if someone tries to use a settings object without balancing the begin and end calls.

This probably passed QA because whether or not a value is properly read depends on when it's read from the INI file.  Screwing up the prefixes works fine if it's symmetrical, but if something is written under one prefix and then read under another, then changes to it cease to work across sessions.

