### PR TITLE
Initial Steamworks integration

### DIFF
--- a/cmake/externals/steamworks/CMakeLists.txt
+++ b/cmake/externals/steamworks/CMakeLists.txt
@@ -1,0 +1,62 @@
+include(ExternalProject)
+
+set(EXTERNAL_NAME steamworks)
+
+string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
+
+set(STEAMWORKS_URL "https://s3-us-west-1.amazonaws.com/hifi-content/clement/production/Steamworks.zip")
+set(STEAMWORKS_URL_MD5 "95ba9d0e3ddc04f8a8be17d2da806cbb")
+
+ExternalProject_Add(
+  ${EXTERNAL_NAME}
+  URL ${STEAMWORKS_URL}
+  URL_MD5 ${STEAMWORKS_URL_MD5}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  LOG_DOWNLOAD 1
+)
+
+set_target_properties(${EXTERNAL_NAME} PROPERTIES FOLDER "hidden/externals")
+
+ExternalProject_Get_Property(${EXTERNAL_NAME} SOURCE_DIR)
+
+set(${EXTERNAL_NAME_UPPER}_INCLUDE_DIRS ${SOURCE_DIR}/public CACHE TYPE INTERNAL)
+
+if (WIN32)
+
+    if ("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+        set(ARCH_DIR ${SOURCE_DIR}/redistributable_bin/win64)
+        set(ARCH_SUFFIX "64")
+    else()
+        set(ARCH_DIR ${SOURCE_DIR}/redistributable_bin)
+        set(ARCH_SUFFIX "")
+    endif()
+
+    set(${EXTERNAL_NAME_UPPER}_DLL_PATH ${ARCH_DIR})
+    set(${EXTERNAL_NAME_UPPER}_LIB_PATH ${ARCH_DIR})
+
+    set(${EXTERNAL_NAME_UPPER}_LIBRARY_RELEASE "${${EXTERNAL_NAME_UPPER}_LIB_PATH}/steam_api${ARCH_SUFFIX}.lib" CACHE TYPE INTERNAL)
+    add_paths_to_fixup_libs("${${EXTERNAL_NAME_UPPER}_DLL_PATH}")
+
+elseif(APPLE)
+
+    set(${EXTERNAL_NAME_UPPER}_LIBRARY_RELEASE ${SOURCE_DIR}/redistributable_bin/osx32/libsteam_api.dylib CACHE TYPE INTERNAL)
+
+    set(_STEAMWORKS_LIB_DIR "${SOURCE_DIR}/redistributable_bin/osx32")
+    ExternalProject_Add_Step(
+      ${EXTERNAL_NAME}
+      change-install-name
+      COMMENT "Calling install_name_tool on libraries to fix install name for dylib linking"
+      COMMAND ${CMAKE_COMMAND} -DINSTALL_NAME_LIBRARY_DIR=${_STEAMWORKS_LIB_DIR} -P ${EXTERNAL_PROJECT_DIR}/OSXInstallNameChange.cmake
+      DEPENDEES install
+      WORKING_DIRECTORY <SOURCE_DIR>
+      LOG 1
+    )
+
+elseif(NOT ANDROID)
+
+    # FIXME need to account for different architectures
+    set(${EXTERNAL_NAME_UPPER}_LIBRARY_RELEASE ${SOURCE_DIR}/redistributable_bin/linux64/libsteam_api.so CACHE TYPE INTERNAL)
+
+endif()

--- a/cmake/externals/steamworks/CMakeLists.txt
+++ b/cmake/externals/steamworks/CMakeLists.txt
@@ -4,7 +4,7 @@ set(EXTERNAL_NAME steamworks)
 
 string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 
-set(STEAMWORKS_URL "https://s3-us-west-1.amazonaws.com/hifi-content/clement/production/Steamworks.zip")
+set(STEAMWORKS_URL "https://s3.amazonaws.com/hifi-public/dependencies/steamworks_sdk_137.zip")
 set(STEAMWORKS_URL_MD5 "95ba9d0e3ddc04f8a8be17d2da806cbb")
 
 ExternalProject_Add(

--- a/cmake/macros/TargetSteamworks.cmake
+++ b/cmake/macros/TargetSteamworks.cmake
@@ -6,6 +6,7 @@
 #  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 #
 macro(TARGET_STEAMWORKS)
+    add_dependency_external_projects(steamworks)
     find_package(Steamworks REQUIRED)
     target_include_directories(${TARGET_NAME} PRIVATE ${STEAMWORKS_INCLUDE_DIRS})
     target_link_libraries(${TARGET_NAME} ${STEAMWORKS_LIBRARIES})

--- a/cmake/macros/TargetSteamworks.cmake
+++ b/cmake/macros/TargetSteamworks.cmake
@@ -1,0 +1,12 @@
+#
+#  Copyright 2015 High Fidelity, Inc.
+#  Created by Clement Brisset on 6/8/2016
+#
+#  Distributed under the Apache License, Version 2.0.
+#  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+#
+macro(TARGET_STEAMWORKS)
+    find_package(Steamworks REQUIRED)
+    target_include_directories(${TARGET_NAME} PRIVATE ${STEAMWORKS_INCLUDE_DIRS})
+    target_link_libraries(${TARGET_NAME} ${STEAMWORKS_LIBRARIES})
+endmacro()

--- a/cmake/modules/FindSteamworks.cmake
+++ b/cmake/modules/FindSteamworks.cmake
@@ -1,6 +1,6 @@
-# 
+#
 #  FindSteamworks.cmake
-# 
+#
 #  Try to find the Steamworks controller library
 #
 #  This module defines the following variables
@@ -20,26 +20,10 @@
 #  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 #
 
-set(STEAMWORKS_POSSIBLE_PATHS "/Users/clement/Downloads/steamworks_sdk_137/")
+include(SelectLibraryConfigurations)
+select_library_configurations(STEAMWORKS)
 
-find_path(STEAMWORKS_INCLUDE_DIRS
-    NAMES steam_api.h
-    PATH_SUFFIXES "public/steam"
-    PATHS ${STEAMWORKS_POSSIBLE_PATHS}
-)
-
-get_filename_component(STEAMWORKS_INCLUDE_DIR_NAME ${STEAMWORKS_INCLUDE_DIRS} NAME)
-if (STEAMWORKS_INCLUDE_DIR_NAME STREQUAL "steam")
-    get_filename_component(STEAMWORKS_INCLUDE_DIRS ${STEAMWORKS_INCLUDE_DIRS} PATH)
-else()
-    message(STATUS "Include directory not named steam, this will cause issues with include statements")
-endif()
-
-find_library(STEAMWORKS_LIBRARIES
-    NAMES libsteam_api.dylib
-    PATH_SUFFIXES "redistributable_bin/osx32"
-    PATHS ${STEAMWORKS_POSSIBLE_PATHS}
-)
-
-
-find_package_handle_standard_args(Steamworks DEFAULT_MSG STEAMWORKS_LIBRARIES STEAMWORKS_INCLUDE_DIRS)
+set(STEAMWORKS_REQUIREMENTS STEAMWORKS_INCLUDE_DIRS STEAMWORKS_LIBRARIES)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Steamworks DEFAULT_MSG STEAMWORKS_INCLUDE_DIRS STEAMWORKS_LIBRARIES)
+mark_as_advanced(STEAMWORKS_LIBRARIES STEAMWORKS_INCLUDE_DIRS STEAMWORKS_SEARCH_DIRS)

--- a/cmake/modules/FindSteamworks.cmake
+++ b/cmake/modules/FindSteamworks.cmake
@@ -1,0 +1,45 @@
+# 
+#  FindSteamworks.cmake
+# 
+#  Try to find the Steamworks controller library
+#
+#  This module defines the following variables
+#
+#  STEAMWORKS_FOUND - Was Steamworks found
+#  STEAMWORKS_INCLUDE_DIRS - the Steamworks include directory
+#  STEAMWORKS_LIBRARIES - Link this to use Steamworks
+#
+#  This module accepts the following variables
+#
+#  STEAMWORKS_ROOT - Can be set to steamworks install path or Windows build path
+#
+#  Created on 6/8/2016 by Clement Brisset
+#  Copyright 2016 High Fidelity, Inc.
+#
+#  Distributed under the Apache License, Version 2.0.
+#  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+#
+
+set(STEAMWORKS_POSSIBLE_PATHS "/Users/clement/Downloads/steamworks_sdk_137/")
+
+find_path(STEAMWORKS_INCLUDE_DIRS
+    NAMES steam_api.h
+    PATH_SUFFIXES "public/steam"
+    PATHS ${STEAMWORKS_POSSIBLE_PATHS}
+)
+
+get_filename_component(STEAMWORKS_INCLUDE_DIR_NAME ${STEAMWORKS_INCLUDE_DIRS} NAME)
+if (STEAMWORKS_INCLUDE_DIR_NAME STREQUAL "steam")
+    get_filename_component(STEAMWORKS_INCLUDE_DIRS ${STEAMWORKS_INCLUDE_DIRS} PATH)
+else()
+    message(STATUS "Include directory not named steam, this will cause issues with include statements")
+endif()
+
+find_library(STEAMWORKS_LIBRARIES
+    NAMES libsteam_api.dylib
+    PATH_SUFFIXES "redistributable_bin/osx32"
+    PATHS ${STEAMWORKS_POSSIBLE_PATHS}
+)
+
+
+find_package_handle_standard_args(Steamworks DEFAULT_MSG STEAMWORKS_LIBRARIES STEAMWORKS_INCLUDE_DIRS)

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -139,7 +139,7 @@ link_hifi_libraries(shared octree gpu gl gpu-gl procedural model render
                     recording fbx networking model-networking entities avatars
                     audio audio-client animation script-engine physics
                     render-utils entities-renderer ui auto-updater
-                    controllers plugins display-plugins input-plugins)
+                    controllers plugins display-plugins input-plugins steamworks-wrapper)
 
 # include the binary directory of render-utils for shader includes
 target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_BINARY_DIR}/libraries/render-utils")

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5144,13 +5144,6 @@ void Application::updateDisplayMode() {
             QObject::connect(displayPlugin.get(), &DisplayPlugin::recommendedFramebufferSizeChanged, [this](const QSize & size) {
                 resizeGL();
             });
-            QObject::connect(displayPlugin.get(), &DisplayPlugin::outputDeviceLost, [this, displayPluginName] {
-                PluginManager::getInstance()->disableDisplayPlugin(displayPluginName);
-                auto menu = Menu::getInstance();
-                if (menu->menuItemExists(MenuOption::OutputMenu, displayPluginName)) {
-                    menu->removeMenuItem(MenuOption::OutputMenu, displayPluginName);
-                }
-            });
             first = false;
         }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -389,7 +389,10 @@ bool setupEssentials(int& argc, char** argv) {
 
     Setting::preInit();
 
-    bool previousSessionCrashed = CrashHandler::checkForResetSettings();
+
+    static const auto SUPPRESS_SETTINGS_RESET = "--suppress-settings-reset";
+    bool suppressPrompt = cmdOptionExists(argc, const_cast<const char**>(argv), SUPPRESS_SETTINGS_RESET);
+    bool previousSessionCrashed = CrashHandler::checkForResetSettings(suppressPrompt);
     CrashHandler::writeRunningMarkerFiler();
     qAddPostRoutine(CrashHandler::deleteRunningMarkerFile);
 

--- a/interface/src/CrashHandler.cpp
+++ b/interface/src/CrashHandler.cpp
@@ -27,7 +27,7 @@
 
 static const QString RUNNING_MARKER_FILENAME = "Interface.running";
 
-bool CrashHandler::checkForResetSettings() {
+bool CrashHandler::checkForResetSettings(bool suppressPrompt) {
     QSettings::setDefaultFormat(QSettings::IniFormat);
     QSettings settings;
     settings.beginGroup("Developer");
@@ -41,6 +41,10 @@ bool CrashHandler::checkForResetSettings() {
 
     QFile runningMarkerFile(runningMarkerFilePath());
     bool wasLikelyCrash = runningMarkerFile.exists();
+
+    if (suppressPrompt) {
+        return wasLikelyCrash;
+    }
 
     if (wasLikelyCrash || askToResetSettings) {
         if (displaySettingsResetOnCrash || askToResetSettings) {

--- a/interface/src/CrashHandler.h
+++ b/interface/src/CrashHandler.h
@@ -17,7 +17,7 @@
 class CrashHandler {
 
 public:
-    static bool checkForResetSettings();
+    static bool checkForResetSettings(bool suppressPrompt = false);
 
     static void writeRunningMarkerFiler();
     static void deleteRunningMarkerFile();

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -189,7 +189,7 @@ void EntityTreeElement::elementEncodeComplete(EncodeBitstreamParams& params) con
             // encoud our parent... this might happen.
             if (extraEncodeData->contains(childElement.get())) {
                 EntityTreeElementExtraEncodeData* childExtraEncodeData
-                    = static_cast<EntityTreeElementExtraEncodeData*>(extraEncodeData->value(childElement.get()));
+                    = static_cast<EntityTreeElementExtraEncodeData*>((*extraEncodeData)[childElement.get()]);
 
                 if (wantDebug) {
                     qCDebug(entities) << "checking child: " << childElement->_cube;

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -170,10 +170,6 @@ public:
 
 signals:
     void recommendedFramebufferSizeChanged(const QSize & size);
-    // Indicates that this display plugin is no longer valid for use.
-    // For instance if a user exits Oculus Home or Steam VR while 
-    // using the corresponding plugin, that plugin should be disabled.
-    void outputDeviceLost();
 
 protected:
     void incrementPresentCount();

--- a/libraries/steamworks-wrapper/CMakeLists.txt
+++ b/libraries/steamworks-wrapper/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TARGET_NAME steamworks-wrapper)
+setup_hifi_library()
+link_hifi_libraries()
+
+target_steamworks()

--- a/libraries/steamworks-wrapper/src/steamworks-wrapper/SteamClient.cpp
+++ b/libraries/steamworks-wrapper/src/steamworks-wrapper/SteamClient.cpp
@@ -1,0 +1,19 @@
+//
+//  SteamClient.cpp
+//  steamworks-wrapper/src/steamworks-wrapper
+//
+//  Created by Clement Brisset on 6/8/16.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "SteamClient.h"
+
+#include <steam/steam_api.h>
+
+
+
+
+

--- a/libraries/steamworks-wrapper/src/steamworks-wrapper/SteamClient.h
+++ b/libraries/steamworks-wrapper/src/steamworks-wrapper/SteamClient.h
@@ -1,0 +1,21 @@
+//
+//  SteamClient.h
+//  steamworks-wrapper/src/steamworks-wrapper
+//
+//  Created by Clement Brisset on 6/8/16.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+
+#ifndef hifi_SteamClient_h
+#define hifi_SteamClient_h
+
+class SteamClient {
+
+
+};
+
+#endif // hifi_SteamClient_h

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -128,10 +128,7 @@ void OpenVrDisplayPlugin::resetSensors() {
 
 bool OpenVrDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
     handleOpenVrEvents();
-    if (openVrQuitRequested()) {
-        emit outputDeviceLost();
-        return false;
-    }
+
     double displayFrequency = _system->GetFloatTrackedDeviceProperty(vr::k_unTrackedDeviceIndex_Hmd, vr::Prop_DisplayFrequency_Float);
     double frameDuration = 1.f / displayFrequency;
     double vsyncToPhotons = _system->GetFloatTrackedDeviceProperty(vr::k_unTrackedDeviceIndex_Hmd, vr::Prop_SecondsFromVsyncToPhotons_Float);

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -26,11 +26,6 @@ using Lock = std::unique_lock<Mutex>;
 static int refCount { 0 };
 static Mutex mutex;
 static vr::IVRSystem* activeHmd { nullptr };
-static bool _openVrQuitRequested { false };
-
-bool openVrQuitRequested() {
-    return _openVrQuitRequested;
-}
 
 static const uint32_t RELEASE_OPENVR_HMD_DELAY_MS = 5000;
 
@@ -84,7 +79,6 @@ void releaseOpenVrSystem() {
         if (0 == refCount) {
             qCDebug(displayplugins) << "OpenVR: zero refcount, deallocate VR system";
             vr::VR_Shutdown();
-            _openVrQuitRequested = false;
             activeHmd = nullptr;
         }
     }
@@ -103,14 +97,14 @@ void handleOpenVrEvents() {
     while (activeHmd->PollNextEvent(&event, sizeof(event))) {
         switch (event.eventType) {
             case vr::VREvent_Quit:
-                _openVrQuitRequested = true;
                 activeHmd->AcknowledgeQuit_Exiting();
+                QMetaObject::invokeMethod(qApp, "quit");
                 break;
 
             default:
                 break;
         }
-        qDebug() << "OpenVR: Event " << event.eventType;
+        qDebug() << "OpenVR: Event " << activeHmd->GetEventTypeNameFromEnum((vr::EVREventType)event.eventType) << "(" << event.eventType << ")";
     }
 
 }

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -214,10 +214,6 @@ void ViveControllerManager::renderHand(const controller::Pose& pose, gpu::Batch&
 void ViveControllerManager::pluginUpdate(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) {
     auto userInputMapper = DependencyManager::get<controller::UserInputMapper>();
     handleOpenVrEvents();
-    if (openVrQuitRequested()) {
-        deactivate();
-        return;
-    }
 
     // because update mutates the internal state we need to lock
     userInputMapper->withLock([&, this]() {

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -515,6 +515,20 @@ function maybeInstallDefaultContentSet(onComplete) {
         return;
     }
 
+    console.log("Found contentPath:" + argv.contentPath);
+    if (argv.contentPath) {
+        fs.copy(argv.contentPath, getRootHifiDataDirectory(), function (err) {
+            if (err) {
+                console.log('Could not copy home content: ' + err);
+                return console.error(err)
+            }
+            console.log('Copied home content over to: ' + getRootHifiDataDirectory());
+            onComplete();
+        });
+        return;
+    }
+
+
     // Show popup
     var window = new BrowserWindow({
         icon: appIcon,


### PR DESCRIPTION
- Steamworks added as an external dependency
- SteamVR can ask Interface to quit
- Added sandbox cmd line opt `--contentPath` to load home content from a local directory.
- Added interface cmd line opt `--suppress-settings-reset` that will prevent the settings reset popup from appearing