### PR TITLE
More verbose messaging about incorrect case in entity types

### DIFF
--- a/libraries/entities/src/EntityTypes.cpp
+++ b/libraries/entities/src/EntityTypes.cpp
@@ -17,6 +17,7 @@
 #include "EntityItem.h"
 #include "EntityItemProperties.h"
 #include "EntityTypes.h"
+#include "EntitiesLogging.h"
 
 #include "LightEntityItem.h"
 #include "ModelEntityItem.h"
@@ -62,6 +63,9 @@ EntityTypes::EntityType EntityTypes::getEntityTypeFromName(const QString& name) 
     QMap<QString, EntityTypes::EntityType>::iterator matchedTypeName = _nameToTypeMap.find(name);
     if (matchedTypeName != _nameToTypeMap.end()) {
         return matchedTypeName.value();
+    }
+    if (name.size() > 0 && name[0].isLower()) {
+        qCDebug(entities) << "Entity types must start with an uppercase letter. Please change the type" << name;
     }
     return Unknown;
 }


### PR DESCRIPTION
This PR is more verbose about why an addEntity call might be failing, if a user tries to add an entity with a lowercase type. 

Previously, the log would just say

```script failed to add new Entity to local Octree```

With this PR, it will also say:

```Entity types must start with an uppercase letter. Please change the type  "box"```

To test, open the console and run this code:

```
Entities.addEntity({
position: MyAvatar.position,
dimensions: {
x: 0.5,
y: 0.5,
z: 0.5
},
color: {
red: 255,
green: 0,
blue: 255
},
type: 'box'
})
```

https://highfidelity.fogbugz.com/f/cases/390/entity-type-is-case-sensitive