### PR TITLE
Reset Vive grip buttons to 0 if not pressed

### DIFF
--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -363,6 +363,10 @@ void ViveControllerManager::InputDevice::handleButtonEvent(float deltaTime, uint
         } else if (button == vr::k_EButton_SteamVR_Touchpad) {
             _buttonPressedMap.insert(isLeftHand ? LS : RS);
         }
+    } else {
+        if (button == vr::k_EButton_Grip) {
+            _axisStateMap[isLeftHand ? LEFT_GRIP : RIGHT_GRIP] = 0.0f;
+        }
     }
 
     if (touched) {


### PR DESCRIPTION
Fixes an issue that was caused by a recent PR (https://github.com/highfidelity/hifi/pull/7997) where the Vive grip button would never be recorded as unpressed.

Testing:
- make sure handControllerGrab.js is active
- Equip something by pressing the Vive grip button
- Let go of the button and it should un-equip