### PR TITLE
Add face camera option to edit.js text entity properties

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -452,6 +452,7 @@
                 var elTextText = document.getElementById("property-text-text");
                 var elTextLineHeight = document.getElementById("property-text-line-height");
                 var elTextTextColor = document.getElementById("property-text-text-color");
+                var elTextFaceCamera = document.getElementById("property-text-face-camera");
                 var elTextTextColorRed = document.getElementById("property-text-text-color-red");
                 var elTextTextColorGreen = document.getElementById("property-text-text-color-green");
                 var elTextTextColorBlue = document.getElementById("property-text-text-color-blue");
@@ -735,6 +736,7 @@
     
                                     elTextText.value = properties.text;
                                     elTextLineHeight.value = properties.lineHeight.toFixed(4);
+                                    elTextFaceCamera = properties.faceCamera;
                                     elTextTextColor.style.backgroundColor = "rgb(" + properties.textColor.red  + "," + properties.textColor.green + "," + properties.textColor.blue + ")";
                                     elTextTextColorRed.value = properties.textColor.red;
                                     elTextTextColorGreen.value = properties.textColor.green;
@@ -996,8 +998,8 @@
                 elModelTextures.addEventListener('change', createEmitTextPropertyUpdateFunction('textures'));
     
                 elTextText.addEventListener('change', createEmitTextPropertyUpdateFunction('text'));
+                elTextFaceCamera.addEventListener('change', createEmitCheckedPropertyUpdateFunction('faceCamera'));
                 elTextLineHeight.addEventListener('change', createEmitNumberPropertyUpdateFunction('lineHeight'));
-    
                 var textTextColorChangeFunction = createEmitColorPropertyUpdateFunction(
                     'textColor', elTextTextColorRed, elTextTextColorGreen, elTextTextColorBlue);
                 elTextTextColorRed.addEventListener('change', textTextColorChangeFunction);
@@ -1714,6 +1716,10 @@
         <div class="text-group text-section property text">
             <label for="property-text-text">Text content</label>
             <input type="text" id="property-text-text">
+        </div>
+        <div class="text-group text-section property checkbox">
+            <input type="checkbox" id="property-text-face-camera">
+            <label for="property-text-face-camera">&nbsp;Face Camera</label>
         </div>
         <div class="text-group text-section property number">
             <label>Line height <span class="unit">m</span></label>


### PR DESCRIPTION
This PR exposes the faceCamera property of text entities as a checkbox in edit.js

To test:

1. run edit.js
2. create a text entity 
3. go to its properties
4. toggle face camera and observe that the text should billboard toward you

https://highfidelity.fogbugz.com/f/cases/455/faceCamera-property-of-text-entities-not-exposed-in-edit-js