### PR TITLE
only signal once on a protocol mismatch with DS

### DIFF
--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -118,6 +118,8 @@ void DomainHandler::hardReset() {
     _hostname = QString();
     _sockAddr.clear();
 
+    _hasSignalledProtocolMismatch = false;
+
     _hasCheckedForAccessToken = false;
 
     // clear any pending path we may have wanted to ask the previous DS about
@@ -405,9 +407,24 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
     // and check and signal for an access token so that we can make sure they are logged in
     qCWarning(networking) << "The domain-server denied a connection request: " << reasonMessage;
 
-    if (!_domainConnectionRefusals.contains(reasonMessage)) {
-        _domainConnectionRefusals.append(reasonMessage);
-        emit domainConnectionRefused(reasonMessage, (int)reasonCode);
+    if (!_domainConnectionRefusals.contains(reasonCode)) {
+        _domainConnectionRefusals.append(reasonCode);
+
+        bool shouldSignal = true;
+
+        // only signal once for a protocol mismatch, even between soft resets that will reset the _domainConnectionRefusals
+        if (reasonCode == ConnectionRefusedReason::ProtocolMismatch) {
+            if (_hasSignalledProtocolMismatch) {
+                shouldSignal = false;
+            } else {
+                _hasSignalledProtocolMismatch = true;
+            }
+        }
+
+        if (shouldSignal) {
+            emit domainConnectionRefused(reasonMessage, (int)reasonCode);
+        }
+
     }
 
     auto accountManager = DependencyManager::get<AccountManager>();

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -144,7 +144,8 @@ private:
     QString _pendingPath;
     QTimer _settingsTimer;
 
-    QStringList _domainConnectionRefusals;
+    QList<ConnectionRefusedReason> _domainConnectionRefusals;
+    bool _hasSignalledProtocolMismatch { false };
     bool _hasCheckedForAccessToken { false };
     int _connectionDenialsSinceKeypairRegen { 0 };
 


### PR DESCRIPTION
- fix an infinite popup of protocol mismatch when connecting to an older domain-server