### PR TITLE
Show sysem laser when we have the opportunity for in-world pointer

### DIFF
--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -420,6 +420,10 @@ function updateVisualization(controllerPosition, controllerDirection, hudPositio
     var falseProjection = intersection3d(eye, Vec3.subtract(hudPosition3d, eye));
     Overlays.editOverlay(fakeProjectionBall, {visible: true, position: falseProjection});
     */
+    if (!systemLaserOn) { // In case the laser is passing in front of a window.
+        // Maybe we should make the color match the grab pointer? But how would we do far grab particles?
+        systemLaserOn = HMD.setHandLasers(activeHudLaser, true, LASER_COLOR_XYZW, SYSTEM_LASER_DIRECTION);
+    }
     Reticle.visible = false;
 
     return visualizationIsShowing; // In case we change caller to act conditionally.


### PR DESCRIPTION
When a hand controller trigger is partially or full squeezed, draw the inside-the-hud system laser.
Without this, HUD elements always draw over the top of the search lasers.