### PR TITLE
No laser without trigger

### DIFF
--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -377,7 +377,7 @@ function turnOffVisualization(optionalEnableClicks) { // because we're showing c
     if (!optionalEnableClicks) {
         expireMouseCursor();
         clearSystemLaser();
-    } else if (!systemLaserOn) {
+    } else if (!systemLaserOn && activeTrigger.state) {
         // If the active plugin doesn't implement hand lasers, show the mouse reticle instead.
         systemLaserOn = HMD.setHandLasers(activeHudLaser, true, LASER_COLOR_XYZW, SYSTEM_LASER_DIRECTION);
         Reticle.visible = !systemLaserOn;


### PR DESCRIPTION
"Partial trigger should be the way I search for a click/interaction. It should not be on by default when I am over an overlay."

Back when we used mouse cursors, the rule was "always show a mouse cursor when I'm pointing at an overlay". This PR changes the laser to only be displayed when triggering.
