### PR TITLE
Hand Controller UI Tweaks

### DIFF
--- a/interface/resources/qml/hifi/ToggleHudButton.qml
+++ b/interface/resources/qml/hifi/ToggleHudButton.qml
@@ -16,6 +16,8 @@ Window {
     height: 50
     clip: true
     visible: true
+    // Disable this window from being able to call 'desktop.raise() and desktop.showDesktop'
+    activator: Item {}
 
     Item {
         width: 50
@@ -28,7 +30,7 @@ Window {
         MouseArea {
             readonly property string overlayMenuItem: "Overlays"
             anchors.fill: parent
-            onClicked: MenuInterface.setIsOptionChecked(overlayMenuItem, !MenuInterface.isOptionChecked(overlayMenuItem))
+            onClicked: MenuInterface.setIsOptionChecked(overlayMenuItem, !MenuInterface.isOptionChecked(overlayMenuItem));
         }
     }
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2716,7 +2716,6 @@ void Application::idle(float nsecsElapsed) {
     if (firstIdle) {
         firstIdle = false;
         connect(offscreenUi.data(), &OffscreenUi::showDesktop, this, &Application::showDesktop);
-        _overlayConductor.setEnabled(Menu::getInstance()->isOptionChecked(MenuOption::Overlays));
     }
 
     PROFILE_RANGE(__FUNCTION__);
@@ -3217,13 +3216,13 @@ void Application::updateThreads(float deltaTime) {
 }
 
 void Application::toggleOverlays() {
-    auto newOverlaysVisible = !_overlayConductor.getEnabled();
-    Menu::getInstance()->setIsOptionChecked(MenuOption::Overlays, newOverlaysVisible);
-    _overlayConductor.setEnabled(newOverlaysVisible);
+    auto menu = Menu::getInstance();
+    menu->setIsOptionChecked(MenuOption::Overlays, menu->isOptionChecked(MenuOption::Overlays));
 }
 
 void Application::setOverlaysVisible(bool visible) {
-    _overlayConductor.setEnabled(visible);
+    auto menu = Menu::getInstance();
+    menu->setIsOptionChecked(MenuOption::Overlays, true);
 }
 
 void Application::cycleCamera() {
@@ -5306,9 +5305,7 @@ void Application::readArgumentsFromLocalSocket() const {
 }
 
 void Application::showDesktop() {
-    if (!_overlayConductor.getEnabled()) {
-        _overlayConductor.setEnabled(true);
-    }
+    Menu::getInstance()->setIsOptionChecked(MenuOption::Overlays, true);
 }
 
 CompositorHelper& Application::getApplicationCompositor() const {

--- a/interface/src/scripting/DesktopScriptingInterface.cpp
+++ b/interface/src/scripting/DesktopScriptingInterface.cpp
@@ -16,6 +16,7 @@
 
 #include "Application.h"
 #include "MainWindow.h"
+#include <display-plugins/CompositorHelper.h>
 
 int DesktopScriptingInterface::getWidth() {
     QSize size = qApp->getWindow()->windowHandle()->screen()->virtualSize();
@@ -25,3 +26,8 @@ int DesktopScriptingInterface::getHeight() {
     QSize size = qApp->getWindow()->windowHandle()->screen()->virtualSize();
     return size.height();
 }
+
+void DesktopScriptingInterface::setOverlayAlpha(float alpha) {
+    qApp->getApplicationCompositor().setAlpha(alpha);
+}
+

--- a/interface/src/scripting/DesktopScriptingInterface.h
+++ b/interface/src/scripting/DesktopScriptingInterface.h
@@ -22,6 +22,8 @@ class DesktopScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(int height READ getHeight)  // Physical height of screen(s) including task bars and system menus
 
 public:
+    Q_INVOKABLE void setOverlayAlpha(float alpha);
+
     int getWidth();
     int getHeight();
 };

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -105,9 +105,11 @@ void OverlayConductor::update(float dt) {
 
     MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
     // centerUI when hmd mode is first enabled and mounted
-    if (qApp->isHMDMode() && qApp->getActiveDisplayPlugin()->isDisplayVisible() && !_hmdMode) {
-        _hmdMode = true;
-        centerUI();
+    if (qApp->isHMDMode() && qApp->getActiveDisplayPlugin()->isDisplayVisible()) {
+        if (!_hmdMode) {
+            _hmdMode = true;
+            centerUI();
+        }
     } else {
         _hmdMode = false;
     }

--- a/interface/src/ui/OverlayConductor.h
+++ b/interface/src/ui/OverlayConductor.h
@@ -17,33 +17,20 @@ public:
     ~OverlayConductor();
 
     void update(float dt);
-    void setEnabled(bool enable);
-    bool getEnabled() const;
-
     void centerUI();
 
 private:
     bool headOutsideOverlay() const;
     bool updateAvatarHasDriveInput();
     bool updateAvatarIsAtRest();
-    bool userWishesToHide() const;
-    bool userWishesToShow() const;
 
-    enum State {
-        Enabled = 0,
-        DisabledByDrive,
-        DisabledByHead,
-        DisabledByToggle,
-        NumStates
+    enum SupressionFlags {
+        SuppressedByDrive = 0x01,
+        SuppressedByHead = 0x02,
+        SuppressMask = 0x03,
     };
 
-    void setState(State state);
-    State getState() const;
-
-    State _state { DisabledByDrive };
-
-    bool _prevOverlayMenuChecked { true };
-    bool _enabled { false };
+    uint8_t _flags { SuppressedByDrive };
     bool _hmdMode { false };
 
     // used by updateAvatarHasDriveInput

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.h
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.h
@@ -38,6 +38,7 @@ const float MAGNIFY_MULT = 2.0f;
 class CompositorHelper : public QObject, public Dependency {
     Q_OBJECT
 
+    Q_PROPERTY(float alpha READ getAlpha WRITE setAlpha NOTIFY alphaChanged)
     Q_PROPERTY(bool reticleOverDesktop READ getReticleOverDesktop WRITE setReticleOverDesktop)
 public:
     static const uvec2 VIRTUAL_SCREEN_SIZE;
@@ -74,6 +75,9 @@ public:
     void setModelTransform(const Transform& transform) { _modelTransform = transform; }
     const Transform& getModelTransform() const { return _modelTransform; }
 
+    float getAlpha() const { return _alpha; }
+    void setAlpha(float alpha) { if (alpha != _alpha) { emit alphaChanged();  _alpha = alpha; } }
+
     bool getReticleVisible() const { return _reticleVisible; }
     void setReticleVisible(bool visible) { _reticleVisible = visible; }
 
@@ -109,6 +113,7 @@ public:
 
 signals:
     void allowMouseCaptureChanged();
+    void alphaChanged();
 
 protected slots:
     void sendFakeMouseEvent();
@@ -134,6 +139,7 @@ private:
     float _textureFov { VIRTUAL_UI_TARGET_FOV.y };
     float _textureAspectRatio { VIRTUAL_UI_ASPECT_RATIO };
 
+    float _alpha { 1.0f };
     float _hmdUIRadius { 1.0f };
 
     int _previousBorderWidth { -1 };

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -24,6 +24,9 @@
 #define THREADED_PRESENT 1
 
 class OpenGLDisplayPlugin : public DisplayPlugin {
+    Q_OBJECT
+    Q_PROPERTY(float overlayAlpha MEMBER _overlayAlpha)
+    using Parent = DisplayPlugin;
 protected:
     using Mutex = std::mutex;
     using Lock = std::unique_lock<Mutex>;
@@ -60,6 +63,7 @@ public:
 
     float droppedFrameRate() const override;
 
+    bool beginFrameRender(uint32_t frameIndex) override;
 protected:
 #if THREADED_PRESENT
     friend class PresentThread;
@@ -115,7 +119,8 @@ protected:
     RateCounter<> _presentRate;
     QMap<gpu::TexturePointer, uint32_t> _sceneTextureToFrameIndexMap;
     uint32_t _currentPresentFrameIndex { 0 };
-
+    float _compositeOverlayAlpha{ 1.0f };
+    
     gpu::TexturePointer _currentSceneTexture;
     gpu::TexturePointer _currentOverlayTexture;
 
@@ -157,6 +162,7 @@ private:
     // be serialized through this mutex
     mutable Mutex _presentMutex;
     ProgramPtr _activeProgram;
+    float _overlayAlpha{ 1.0f };
 };
 
 

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -287,6 +287,8 @@ void HmdDisplayPlugin::compositeOverlay() {
     glm::mat4 modelMat = compositorHelper->getModelTransform().getMatrix();
 
     useProgram(_program);
+    // set the alpha
+    Uniform<float>(*_program, _alphaUniform).Set(_compositeOverlayAlpha);
     _sphereSection->Use();
     for_each_eye([&](Eye eye) {
         eyeViewport(eye);
@@ -295,6 +297,8 @@ void HmdDisplayPlugin::compositeOverlay() {
         Uniform<glm::mat4>(*_program, _mvpUniform).Set(mvp);
         _sphereSection->Draw();
     });
+    // restore the alpha
+    Uniform<float>(*_program, _alphaUniform).Set(1.0);
 }
 
 void HmdDisplayPlugin::compositePointer() {
@@ -302,8 +306,9 @@ void HmdDisplayPlugin::compositePointer() {
 
     auto compositorHelper = DependencyManager::get<CompositorHelper>();
 
-    // check the alpha
     useProgram(_program);
+    // set the alpha
+    Uniform<float>(*_program, _alphaUniform).Set(_compositeOverlayAlpha);
 
     // Mouse pointer
     _plane->Use();
@@ -317,6 +322,8 @@ void HmdDisplayPlugin::compositePointer() {
         Uniform<glm::mat4>(*_program, _mvpUniform).Set(mvp);
         _plane->Draw();
     });
+    // restore the alpha
+    Uniform<float>(*_program, _alphaUniform).Set(1.0);
 }
 
 

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -45,7 +45,7 @@ bool OculusBaseDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
         _handPoses = handPoses;
         _frameInfos[frameIndex] = _currentRenderFrameInfo;
     });
-    return true;
+    return Parent::beginFrameRender(frameIndex);
 }
 
 bool OculusBaseDisplayPlugin::isSupported() const {

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -41,6 +41,7 @@ void OculusLegacyDisplayPlugin::resetSensors() {
 }
 
 bool OculusLegacyDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
+
     _currentRenderFrameInfo = FrameInfo();
     _currentRenderFrameInfo.predictedDisplayTime = _currentRenderFrameInfo.sensorSampleTime = ovr_GetTimeInSeconds();
     _trackingState = ovrHmd_GetTrackingState(_hmd, _currentRenderFrameInfo.predictedDisplayTime);
@@ -48,7 +49,7 @@ bool OculusLegacyDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
     withRenderThreadLock([&]{
         _frameInfos[frameIndex] = _currentRenderFrameInfo;
     });
-    return true;
+    return Parent::beginFrameRender(frameIndex);
 }
 
 bool OculusLegacyDisplayPlugin::isSupported() const {

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -204,7 +204,7 @@ bool OpenVrDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
         _handPoses = handPoses;
         _frameInfos[frameIndex] = _currentRenderFrameInfo;
     });
-    return true;
+    return Parent::beginFrameRender(frameIndex);
 }
 
 void OpenVrDisplayPlugin::hmdPresent() {


### PR DESCRIPTION
* Allow scripts that are doing hand controller manipulation of the 3D scene to make the overlays invisible or semi-transparent.  This is orthogonal to UI pinning.  The entire overlay texture will be affected.  
* Fix problems with the OverlayConductor and the Overlays menu option losing sync.

