### PR TITLE
fix domain-server permissions-grid usernames to be case insensitive

### DIFF
--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -241,7 +241,7 @@ void DomainServerSettingsManager::setupConfigMap(const QStringList& argumentList
             }
 
             QList<QHash<QString, NodePermissionsPointer>> permissionsSets;
-            permissionsSets << _standardAgentPermissions << _agentPermissions;
+            permissionsSets << _standardAgentPermissions.get() << _agentPermissions.get();
             foreach (auto permissionsSet, permissionsSets) {
                 foreach (QString userName, permissionsSet.keys()) {
                     if (onlyEditorsAreRezzers) {
@@ -267,7 +267,7 @@ void DomainServerSettingsManager::setupConfigMap(const QStringList& argumentList
 }
 
 void DomainServerSettingsManager::packPermissionsForMap(QString mapName,
-                                                        QHash<QString, NodePermissionsPointer> agentPermissions,
+                                                        NodePermissionsMap& agentPermissions,
                                                         QString keyPath) {
     QVariant* security = valueForKeyPath(_configMap.getUserConfig(), "security");
     if (!security || !security->canConvert(QMetaType::QVariantMap)) {
@@ -378,7 +378,7 @@ void DomainServerSettingsManager::unpackPermissions() {
     #ifdef WANT_DEBUG
     qDebug() << "--------------- permissions ---------------------";
     QList<QHash<QString, NodePermissionsPointer>> permissionsSets;
-    permissionsSets << _standardAgentPermissions << _agentPermissions;
+    permissionsSets << _standardAgentPermissions.get() << _agentPermissions.get();
     foreach (auto permissionSet, permissionsSets) {
         QHashIterator<QString, NodePermissionsPointer> i(permissionSet);
         while (i.hasNext()) {

--- a/domain-server/src/DomainServerSettingsManager.h
+++ b/domain-server/src/DomainServerSettingsManager.h
@@ -72,11 +72,11 @@ private:
 
     friend class DomainServer;
 
-    void packPermissionsForMap(QString mapName, QHash<QString, NodePermissionsPointer> agentPermissions, QString keyPath);
+    void packPermissionsForMap(QString mapName, NodePermissionsMap& agentPermissions, QString keyPath);
     void packPermissions();
     void unpackPermissions();
-    QHash<QString, NodePermissionsPointer> _standardAgentPermissions; // anonymous, logged-in, localhost
-    QHash<QString, NodePermissionsPointer> _agentPermissions; // specific account-names
+    NodePermissionsMap _standardAgentPermissions; // anonymous, logged-in, localhost
+    NodePermissionsMap _agentPermissions; // specific account-names
 };
 
 #endif // hifi_DomainServerSettingsManager_h

--- a/libraries/networking/src/NodePermissions.h
+++ b/libraries/networking/src/NodePermissions.h
@@ -24,9 +24,9 @@ using NodePermissionsPointer = std::shared_ptr<NodePermissions>;
 class NodePermissions {
 public:
     NodePermissions() { _id = QUuid::createUuid().toString(); }
-    NodePermissions(const QString& name) { _id = name; }
+    NodePermissions(const QString& name) { _id = name.toLower(); }
     NodePermissions(QMap<QString, QVariant> perms) {
-        _id = perms["permissions_id"].toString();
+        _id = perms["permissions_id"].toString().toLower();
         canConnectToDomain = perms["id_can_connect"].toBool();
         canAdjustLocks = perms["id_can_adjust_locks"].toBool();
         canRezPermanentEntities = perms["id_can_rez"].toBool();
@@ -38,7 +38,7 @@ public:
     QString getID() const { return _id; }
 
     // the _id member isn't authenticated and _username is.
-    void setUserName(QString userName) { _userName = userName; }
+    void setUserName(QString userName) { _userName = userName.toLower(); }
     QString getUserName() { return _userName; }
 
     bool isAssignment { false };
@@ -87,6 +87,23 @@ protected:
     QString _id;
     QString _userName;
 };
+
+
+// wrap QHash in a class that forces all keys to be lowercase
+class NodePermissionsMap {
+public:
+    NodePermissionsMap() { }
+    NodePermissionsPointer& operator[](const QString& key) { return _data[key.toLower()]; }
+    NodePermissionsPointer operator[](const QString& key) const { return _data.value(key.toLower()); }
+    bool contains(const QString& key) const { return _data.contains(key.toLower()); }
+    QList<QString> keys() const { return _data.keys(); }
+    QHash<QString, NodePermissionsPointer> get() { return _data; }
+    void clear() { _data.clear(); }
+
+private:
+    QHash<QString, NodePermissionsPointer> _data;
+};
+
 
 const NodePermissions DEFAULT_AGENT_PERMISSIONS;
 


### PR DESCRIPTION
- usernames in domain-server permissions-grid are now case insensitive
