### PR TITLE
Fix entity lifetime guards (re: canRez/canRezTmp)

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -150,8 +150,10 @@ bool EntityTree::updateEntityWithElement(EntityItemPointer entity, const EntityI
 
     if (!canRezPermanentEntities && (entity->getLifetime() != properties.getLifetime())) {
         // we don't allow a Node that can't create permanent entities to adjust lifetimes on existing ones
-        qCDebug(entities) << "Refusing disallowed entity lifetime adjustment.";
-        return false;
+        if (properties.lifetimeChanged()) {
+            qCDebug(entities) << "Refusing disallowed entity lifetime adjustment.";
+            return false;
+        }
     }
 
     // enforce support for locked entities. If an entity is currently locked, then the only
@@ -322,8 +324,8 @@ bool EntityTree::updateEntityWithElement(EntityItemPointer entity, const EntityI
 bool EntityTree::permissionsAllowRez(const EntityItemProperties& properties, bool canRez, bool canRezTmp) {
     float lifeTime = properties.getLifetime();
 
-    if (lifeTime == 0.0f || lifeTime > _maxTmpEntityLifetime) {
-        // this is an attempt to rez a permanent entity.
+    if (lifeTime == ENTITY_ITEM_IMMORTAL_LIFETIME || lifeTime > _maxTmpEntityLifetime) {
+        // this is an attempt to rez a permanent or non-temporary entity.
         if (!canRez) {
             return false;
         }


### PR DESCRIPTION
This patch fixes two issues related to local Entity tree updates and the `canRezTmp` scenario.

The code changes seem pretty trivial, but for completeness here are some additional details:

1) A code guard intending to prevent immortal Entities from being added wasn't actually catching them -- it's been updated to do so.
2) A code guard intending (I think) to block `lifetime` adjustments only was also being triggered in the default case -- it's been updated to apply only when `lifetimeChanged()` is true.

To test from a domain where `Entities.canRezTmp() === true && Entities.canRez() === false`:

```javascript
// (1) Previously this call would succeed (locally), but should now correctly fail to add the Entity at all:
Entities.addEntity({ type: 'Sphere', position: MyAvatar.position });

// (2) Previously the edit call below would fail, but should now succeed:
var id = Entities.addEntity({ type: 'Sphere', position: MyAvatar.position, lifetime: 600 });
Entities.editEntity(id, { velocity: Vec3.UP })
```
