### PR TITLE
Reduce GLShader::compileShader log spam

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLPipeline.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLPipeline.cpp
@@ -24,8 +24,15 @@ GLPipeline* GLPipeline::sync(const Pipeline& pipeline) {
 
     // No object allocated yet, let's see if it's worth it...
     ShaderPointer shader = pipeline.getProgram();
+
+    // If this pipeline's shader has already failed to compile, don't try again
+    if (shader->compilationHasFailed()) {
+        return nullptr;
+    }
+
     GLShader* programObject = GLShader::sync(*shader);
     if (programObject == nullptr) {
+        shader->setCompilationHasFailed(true);
         return nullptr;
     }
 

--- a/libraries/gpu/src/gpu/Shader.h
+++ b/libraries/gpu/src/gpu/Shader.h
@@ -120,6 +120,9 @@ public:
     bool isProgram() const { return getType() > NUM_DOMAINS; }
     bool isDomain() const { return getType() < NUM_DOMAINS; }
 
+    void setCompilationHasFailed(bool compilationHasFailed) { _compilationHasFailed = compilationHasFailed; }
+    bool compilationHasFailed() const { return _compilationHasFailed; }
+
     const Source& getSource() const { return _source; }
 
     const Shaders& getShaders() const { return _shaders; }
@@ -180,6 +183,9 @@ protected:
 
     // The type of the shader, the master key
     Type _type;
+
+    // Whether or not the shader compilation failed
+    mutable bool _compilationHasFailed { false };
 };
 
 typedef Shader::Pointer ShaderPointer;

--- a/libraries/gpu/src/gpu/Shader.h
+++ b/libraries/gpu/src/gpu/Shader.h
@@ -185,7 +185,7 @@ protected:
     Type _type;
 
     // Whether or not the shader compilation failed
-    mutable bool _compilationHasFailed { false };
+    bool _compilationHasFailed { false };
 };
 
 typedef Shader::Pointer ShaderPointer;


### PR DESCRIPTION
Previously, if an entity had a shader attached to it with an error in it, the entire shader would constantly get printed in the log.  This should prevent the error from getting logged constantly (technically it's still printed twice but it was decided that this is ok).

Also, there were outdated GLSL calls in one of our skybox shaders, causing lots of errors to be logged on Macs.  This should now be fixed.