### PR TITLE
Fix users.js display

### DIFF
--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -661,15 +661,12 @@ var usersWindow = (function() {
         });
 
         if (loggedIn === true) {
-            print('logged in')
             Overlays.editOverlay(friendsButton, {
                 visible: isVisible && !isMinimized
             });
             displayControl.setVisible(isVisible && !isMinimized);
             visibilityControl.setVisible(isVisible && !isMinimized);
         }
-
-        print('update overlay vis')
 
     }
 

--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -570,15 +570,18 @@ var usersWindow = (function() {
             visibilityControl.setVisible(false);
             displayControl.setVisible(false);
         } else {
-            if (isMinimized === true) {
+            if (isMinimized === 'true' || isMinimized === true) {
                 return;
+            } else {
+                Overlays.editOverlay(friendsButton, {
+                    visible: true
+                });
+                visibilityControl.setVisible(true);
+                displayControl.setVisible(true);
             }
-            Overlays.editOverlay(friendsButton, {
-                visible: true
-            });
-            visibilityControl.setVisible(true);
-            displayControl.setVisible(true);
+
         }
+
     }
 
 
@@ -660,19 +663,15 @@ var usersWindow = (function() {
             visible: isVisible && isUsingScrollbars && !isMinimized
         });
 
-        if (loggedIn === true) {
-            Overlays.editOverlay(friendsButton, {
-                visible: isVisible && !isMinimized
-            });
-            displayControl.setVisible(isVisible && !isMinimized);
-            visibilityControl.setVisible(isVisible && !isMinimized);
-        }
-
+        Overlays.editOverlay(friendsButton, {
+            visible: isVisible && !isMinimized
+        });
+        displayControl.setVisible(isVisible && !isMinimized);
+        visibilityControl.setVisible(isVisible && !isMinimized);
     }
 
     function setVisible(visible) {
         isVisible = visible;
-
         if (isVisible) {
             if (usersTimer === null) {
                 pollUsers();
@@ -681,9 +680,7 @@ var usersWindow = (function() {
             Script.clearTimeout(usersTimer);
             usersTimer = null;
         }
-
         updateOverlayVisibility();
-
     }
 
     function setMinimized(minimized) {

--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -369,8 +369,8 @@ var usersWindow = (function() {
         MENU_ITEM = "Users Online",
         MENU_ITEM_AFTER = "Chat...",
 
-        SETTING_USERS_WINDOW_MINIMIZED = "UsersWindow.Minimized",
-        SETINGS_USERS_WINDOW_OFFSET = "UsersWindow.Offset",
+        SETTING_USERS_WINDOW_MINIMIZED = "UsersWindow.Minimized.Rev.1",
+        SETINGS_USERS_WINDOW_OFFSET = "UsersWindow.Offset.Rev.1",
         // +ve x, y values are offset from left, top of screen; -ve from right, bottom.
 
         isVisible = true,
@@ -571,16 +571,13 @@ var usersWindow = (function() {
             displayControl.setVisible(false);
         } else {
             if (isMinimized === true) {
-                loggedIn = true;
-                return
+                return;
             }
             Overlays.editOverlay(friendsButton, {
                 visible: true
             });
             visibilityControl.setVisible(true);
             displayControl.setVisible(true);
-            loggedIn = true;
-
         }
     }
 
@@ -664,12 +661,15 @@ var usersWindow = (function() {
         });
 
         if (loggedIn === true) {
+            print('logged in')
             Overlays.editOverlay(friendsButton, {
                 visible: isVisible && !isMinimized
             });
             displayControl.setVisible(isVisible && !isMinimized);
             visibilityControl.setVisible(isVisible && !isMinimized);
         }
+
+        print('update overlay vis')
 
     }
 

--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -663,11 +663,14 @@ var usersWindow = (function() {
             visible: isVisible && isUsingScrollbars && !isMinimized
         });
 
-        Overlays.editOverlay(friendsButton, {
-            visible: isVisible && !isMinimized
-        });
-        displayControl.setVisible(isVisible && !isMinimized);
-        visibilityControl.setVisible(isVisible && !isMinimized);
+        if (loggedIn === true) {
+            Overlays.editOverlay(friendsButton, {
+                visible: isVisible && !isMinimized
+            });
+            displayControl.setVisible(isVisible && !isMinimized);
+            visibilityControl.setVisible(isVisible && !isMinimized);
+        }
+
     }
 
     function setVisible(visible) {
@@ -1142,7 +1145,8 @@ var usersWindow = (function() {
         pollUsers();
 
         // Set minimized at end - setup code does not handle `minimized == false` correctly
-        setMinimized(Settings.getValue(SETTING_USERS_WINDOW_MINIMIZED, false));
+        var wasMinimized = Settings.getValue(SETTING_USERS_WINDOW_MINIMIZED, false);
+        setMinimized(wasMinimized);
     }
 
     function tearDown() {


### PR DESCRIPTION
This PR fixes a bug where the old settings for whether the users.js window was minimized or not would cause the display to function incorrectly.  Now, the display should appear as expected when you run this users.js script.

To test:
1. Run users.js 
2. Logout 
3. Observe buttons disappear
4. Login 
5. Observe buttons reappear.
6. Start and stop the script in both states and see that buttons appear as expected. 