### PR TITLE
Don't trigger keyboard on revealing the overlay layer

### DIFF
--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -297,6 +297,9 @@ FocusScope {
 
     onPinnedChanged: {
         if (pinned) {
+            nullFocus.focus = true;
+            nullFocus.forceActiveFocus();
+
             // recalculate our non-pinned children
             hiddenChildren = d.findMatchingChildren(desktop, function(child){
                 return !d.isTopLevelWindow(child) && child.visible && !child.pinned;
@@ -477,6 +480,8 @@ FocusScope {
     }
 
     FocusHack { id: focusHack; }
+
+    FocusScope { id: nullFocus; }
 
     Rectangle {
         id: focusDebugger;

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -267,7 +267,7 @@ void OpenVrDisplayPlugin::unsuppressKeyboard() {
         return;
     }
     if (1 == _keyboardSupressionCount.fetch_sub(1)) {
-        enableOpenVrKeyboard();
+        enableOpenVrKeyboard(_container);
     }
 }
 

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -21,6 +21,9 @@
 #include <OffscreenUi.h>
 #include <controllers/Pose.h>
 #include <NumericalConstants.h>
+#include <plugins/PluginContainer.h>
+#include <ui/Menu.h>
+#include "../../interface/src/Menu.h"
 
 Q_DECLARE_LOGGING_CATEGORY(displayplugins)
 Q_LOGGING_CATEGORY(displayplugins, "hifi.plugins.display")
@@ -91,7 +94,7 @@ void releaseOpenVrSystem() {
 
 static char textArray[8192];
 
-static QMetaObject::Connection _focusConnection, _focusTextConnection;
+static QMetaObject::Connection _focusConnection, _focusTextConnection, _overlayMenuConnection;
 extern bool _openVrDisplayActive;
 static vr::IVROverlay* _overlay { nullptr };
 static QObject* _keyboardFocusObject { nullptr };
@@ -99,7 +102,8 @@ static QString _existingText;
 static Qt::InputMethodHints _currentHints;
 extern vr::TrackedDevicePose_t _trackedDevicePose[vr::k_unMaxTrackedDeviceCount];
 static bool _keyboardShown { false };
-static const uint32_t SHOW_KEYBOARD_DELAY_MS = 100;
+static bool _overlayRevealed { false };
+static const uint32_t SHOW_KEYBOARD_DELAY_MS = 400;
 
 void showOpenVrKeyboard(bool show = true) {
     if (!_overlay) {
@@ -175,12 +179,24 @@ void finishOpenVrKeyboardInput() {
 static const QString DEBUG_FLAG("HIFI_DISABLE_STEAM_VR_KEYBOARD");
 bool disableSteamVrKeyboard = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
 
-void enableOpenVrKeyboard() {
+void enableOpenVrKeyboard(PluginContainer* container) {
     if (disableSteamVrKeyboard) {
         return;
     }
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     _overlay = vr::VROverlay();
+
+    
+    auto menu = container->getPrimaryMenu();
+    auto action = menu->getActionForOption(MenuOption::Overlays);
+
+    // When the overlays are revealed, suppress the keyboard from appearing on text focus for a tenth of a second. 
+    _overlayMenuConnection = QObject::connect(action, &QAction::triggered, [action] {
+        if (action->isChecked()) {
+            _overlayRevealed = true;
+            QTimer::singleShot(100, [&] { _overlayRevealed = false; });
+        }
+    });
 
     _focusConnection = QObject::connect(offscreenUi->getWindow(), &QQuickWindow::focusObjectChanged, [](QObject* object) {
         if (object != _keyboardFocusObject) {
@@ -190,6 +206,11 @@ void enableOpenVrKeyboard() {
 
     _focusTextConnection = QObject::connect(offscreenUi.data(), &OffscreenUi::focusTextChanged, [](bool focusText) {
         if (_openVrDisplayActive) {
+            if (_overlayRevealed) {
+                // suppress at most one text focus event
+                _overlayRevealed = false;
+                return;
+            }
             showOpenVrKeyboard(focusText);
         }
     });
@@ -200,6 +221,7 @@ void disableOpenVrKeyboard() {
     if (disableSteamVrKeyboard) {
         return;
     }
+    QObject::disconnect(_overlayMenuConnection);
     QObject::disconnect(_focusTextConnection);
     QObject::disconnect(_focusConnection);
 }

--- a/plugins/openvr/src/OpenVrHelpers.h
+++ b/plugins/openvr/src/OpenVrHelpers.h
@@ -13,6 +13,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 
 #include <controllers/Forward.h>
+#include <plugins/Forward.h>
 
 bool openVrSupported();
 
@@ -20,7 +21,7 @@ vr::IVRSystem* acquireOpenVrSystem();
 void releaseOpenVrSystem();
 void handleOpenVrEvents();
 bool openVrQuitRequested();
-void enableOpenVrKeyboard();
+void enableOpenVrKeyboard(PluginContainer* container);
 void disableOpenVrKeyboard();
 bool isOpenVrKeyboardShown();
 

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -63,7 +63,7 @@ bool ViveControllerManager::activate() {
     }
     Q_ASSERT(_system);
 
-    enableOpenVrKeyboard();
+    enableOpenVrKeyboard(_container);
 
     // OpenVR provides 3d mesh representations of the controllers
     // Disabled controller rendering code


### PR DESCRIPTION
This causes anything that triggers the overlay layer to be revealed to suppress any field that gains text focus from triggering the keyboard, to avoid focused text fields.  

It has two independent mechanisms.  The first is that the Desktop will explicitly change focus to an empty placeholder when the pinned state is being enabled, so that on being restored, no text field will have focus.  The second is code in the helper plugin that will detect the re-enabling of overlays and suppress any text field being focused from triggering the keyboard for a tenth of a second.

Additionally, this slightly increases the amount of time before a text field being focused causes the keyboard to appear, to 400 microseconds.  This prevents the effect of clicking the close button on a window that has a text field focused from causing the keyboard to appear and then vanish.
