### PR TITLE
Mini mirror/multi-monitor bug fixes

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1459,13 +1459,7 @@ void Application::initializeUi() {
     });
     offscreenUi->resume();
     connect(_window, &MainWindow::windowGeometryChanged, [this](const QRect& r){
-        static qreal oldDevicePixelRatio = 0;
-        qreal devicePixelRatio = getActiveDisplayPlugin()->devicePixelRatio();
-        if (devicePixelRatio != oldDevicePixelRatio) {
-            oldDevicePixelRatio = devicePixelRatio;
-            qDebug() << "Device pixel ratio changed, triggering GL resize";
-            resizeGL();
-        }
+        resizeGL();
     });
 
     // This will set up the input plugins UI
@@ -1840,7 +1834,8 @@ void Application::resizeGL() {
     static qreal lastDevicePixelRatio = 0;
     qreal devicePixelRatio = _window->devicePixelRatio();
     if (offscreenUi->size() != fromGlm(uiSize) || devicePixelRatio != lastDevicePixelRatio) {
-        offscreenUi->resize(fromGlm(uiSize));
+        qDebug() << "Device pixel ratio changed, triggering resize";
+        offscreenUi->resize(fromGlm(uiSize), true);
         _offscreenContext->makeCurrent();
         lastDevicePixelRatio = devicePixelRatio;
     }

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -150,7 +150,8 @@ void ApplicationOverlay::renderRearViewToFbo(RenderArgs* renderArgs) {
 }
 
 void ApplicationOverlay::renderRearView(RenderArgs* renderArgs) {
-    if (!qApp->isHMDMode() && Menu::getInstance()->isOptionChecked(MenuOption::MiniMirror)) {
+    if (!qApp->isHMDMode() && Menu::getInstance()->isOptionChecked(MenuOption::MiniMirror) &&
+        !Menu::getInstance()->isOptionChecked(MenuOption::FullscreenMirror)) {
         gpu::Batch& batch = *renderArgs->_batch;
 
         auto geometryCache = DependencyManager::get<GeometryCache>();

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -166,13 +166,11 @@ void ApplicationOverlay::renderRearView(RenderArgs* renderArgs) {
         batch.setViewTransform(Transform());
         
         float screenRatio = ((float)qApp->getDevicePixelRatio());
-        float renderRatio = ((float)screenRatio * qApp->getRenderResolutionScale());
+        float renderRatio = ((float)qApp->getRenderResolutionScale());
         
         auto viewport = qApp->getMirrorViewRect();
-        glm::vec2 bottomLeft(viewport.left(), viewport.top() + viewport.height());
-        glm::vec2 topRight(viewport.left() + viewport.width(), viewport.top());
-        bottomLeft *= screenRatio;
-        topRight *= screenRatio;
+        glm::vec2 bottomLeft(viewport.left(), viewport.top() + screenRatio * viewport.height());
+        glm::vec2 topRight(viewport.left() + screenRatio * viewport.width(), viewport.top());
         glm::vec2 texCoordMinCorner(0.0f, 0.0f);
         glm::vec2 texCoordMaxCorner(viewport.width() * renderRatio / float(selfieTexture->getWidth()), viewport.height() * renderRatio / float(selfieTexture->getHeight()));
 

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -169,8 +169,10 @@ void ApplicationOverlay::renderRearView(RenderArgs* renderArgs) {
         float renderRatio = ((float)qApp->getRenderResolutionScale());
         
         auto viewport = qApp->getMirrorViewRect();
-        glm::vec2 bottomLeft(viewport.left(), viewport.top() + screenRatio * viewport.height());
-        glm::vec2 topRight(viewport.left() + screenRatio * viewport.width(), viewport.top());
+        glm::vec2 bottomLeft(viewport.left(), viewport.top() + viewport.height());
+        glm::vec2 topRight(viewport.left() + viewport.width(), viewport.top());
+        bottomLeft *= screenRatio;
+        topRight *= screenRatio;
         glm::vec2 texCoordMinCorner(0.0f, 0.0f);
         glm::vec2 texCoordMaxCorner(viewport.width() * renderRatio / float(selfieTexture->getWidth()), viewport.height() * renderRatio / float(selfieTexture->getHeight()));
 

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -414,7 +414,7 @@ void OffscreenQmlSurface::create(QOpenGLContext* shareContext) {
     _updateTimer.start();
 }
 
-void OffscreenQmlSurface::resize(const QSize& newSize_) {
+void OffscreenQmlSurface::resize(const QSize& newSize_, bool forceResize) {
 
     if (!_renderer || !_renderer->_quickWindow) {
         return;
@@ -433,7 +433,7 @@ void OffscreenQmlSurface::resize(const QSize& newSize_) {
     }
 
     QSize currentSize = _renderer->_quickWindow->geometry().size();
-    if (newSize == currentSize) {
+    if (newSize == currentSize && !forceResize) {
         return;
     }
 

--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -38,7 +38,7 @@ public:
     using MouseTranslator = std::function<QPoint(const QPointF&)>;
 
     virtual void create(QOpenGLContext* context);
-    void resize(const QSize& size);
+    void resize(const QSize& size, bool forceResize = false);
     QSize size() const;
     Q_INVOKABLE QObject* load(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
     Q_INVOKABLE QObject* load(const QString& qmlSourceFile, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {}) {


### PR DESCRIPTION
Fixes several issues relating to the Mini Mirror and multi-monitor displays with different device pixel ratios:
- Mini mirror either rendering at half or twice the correct size on multi monitor setups with different device pixel ratios (fogbugz case 892)
- QML overlays getting messed up when moving between monitors with different device pixel ratios
- In Fullscreen Mirror Mode, mini mirror would show garbage (instead: don't show it)