### PR TITLE
Automatically enter first person when in HMD mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5350,13 +5350,7 @@ void Application::updateDisplayMode() {
     // reset the avatar, to set head and hand palms back to a reasonable default pose.
     getMyAvatar()->reset(false);
 
-	// go into first person when they are in HMD mode, since 3rd person HMD is dumb
-	if (isHMDMode() && !menu->isOptionChecked(MenuOption::FirstPerson)) {
-		menu->setIsOptionChecked(MenuOption::FirstPerson, true);
-		cameraMenuChanged();
-	}
-
-	Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
+    Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
 }
 
 mat4 Application::getEyeProjection(int eye) const {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5349,14 +5349,14 @@ void Application::updateDisplayMode() {
 
     // reset the avatar, to set head and hand palms back to a reasonable default pose.
     getMyAvatar()->reset(false);
-
-	// go into first person when they are in HMD mode, since 3rd person HMD is dumb
-	if (isHMDMode() && !menu->isOptionChecked(MenuOption::FirstPerson)) {
-		menu->setIsOptionChecked(MenuOption::FirstPerson, true);
-		cameraMenuChanged();
-	}
-
-	Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
+    
+    // go into first person when they are in HMD mode, since 3rd person HMD is dumb
+    if (isHMDMode() && !menu->isOptionChecked(MenuOption::FirstPerson)) {
+        menu->setIsOptionChecked(MenuOption::FirstPerson, true);
+        cameraMenuChanged();
+    }
+    
+    Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
 }
 
 mat4 Application::getEyeProjection(int eye) const {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5350,7 +5350,13 @@ void Application::updateDisplayMode() {
     // reset the avatar, to set head and hand palms back to a reasonable default pose.
     getMyAvatar()->reset(false);
 
-    Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
+	// go into first person when they are in HMD mode, since 3rd person HMD is dumb
+	if (isHMDMode() && !menu->isOptionChecked(MenuOption::FirstPerson)) {
+		menu->setIsOptionChecked(MenuOption::FirstPerson, true);
+		cameraMenuChanged();
+	}
+
+	Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
 }
 
 mat4 Application::getEyeProjection(int eye) const {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5349,14 +5349,14 @@ void Application::updateDisplayMode() {
 
     // reset the avatar, to set head and hand palms back to a reasonable default pose.
     getMyAvatar()->reset(false);
-    
-    // go into first person when they are in HMD mode, since 3rd person HMD is dumb
-    if (isHMDMode() && !menu->isOptionChecked(MenuOption::FirstPerson)) {
-        menu->setIsOptionChecked(MenuOption::FirstPerson, true);
-        cameraMenuChanged();
-    }
-    
-    Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
+
+	// go into first person when they are in HMD mode, since 3rd person HMD is dumb
+	if (isHMDMode() && !menu->isOptionChecked(MenuOption::FirstPerson)) {
+		menu->setIsOptionChecked(MenuOption::FirstPerson, true);
+		cameraMenuChanged();
+	}
+
+	Q_ASSERT_X(_displayPlugin, "Application::updateDisplayMode", "could not find an activated display plugin");
 }
 
 mat4 Application::getEyeProjection(int eye) const {

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -19,6 +19,9 @@
 #include "Application.h"
 
 HMDScriptingInterface::HMDScriptingInterface() {
+	connect(qApp, &Application::activeDisplayPluginChanged, [this]{
+		emit displayModeChanged(isHMDMode());
+	});
 }
 
 glm::vec3 HMDScriptingInterface::calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const {

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -19,9 +19,9 @@
 #include "Application.h"
 
 HMDScriptingInterface::HMDScriptingInterface() {
-	connect(qApp, &Application::activeDisplayPluginChanged, [this]{
-		emit displayModeChanged(isHMDMode());
-	});
+    connect(qApp, &Application::activeDisplayPluginChanged, [this]{
+        emit displayModeChanged(isHMDMode());
+    });
 }
 
 glm::vec3 HMDScriptingInterface::calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const {

--- a/libraries/display-plugins/src/display-plugins/AbstractHMDScriptingInterface.h
+++ b/libraries/display-plugins/src/display-plugins/AbstractHMDScriptingInterface.h
@@ -31,6 +31,7 @@ public:
 
 signals:
     void IPDScaleChanged();
+    void displayModeChanged(bool isHMDMode);
 
 private:
     float _IPDScale{ 1.0 };

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -21,3 +21,4 @@ Script.load("system/controllers/handControllerPointer.js");
 Script.load("system/controllers/squeezeHands.js");
 Script.load("system/controllers/grab.js");
 Script.load("system/dialTone.js");
+Script.load("system/firstPersonHMD.js");

--- a/scripts/system/firstPersonHMD.js
+++ b/scripts/system/firstPersonHMD.js
@@ -1,0 +1,17 @@
+//
+//  firstPersonHMD.js
+//  system
+//
+//  Created by Zander Otavka on 6/24/16
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+// Automatically enter first person mode when entering HMD mode
+HMD.displayModeChanged.connect(function(isHMDMode) {
+    if (isHMDMode) {
+        Camera.setModeString("first person");
+    }
+});


### PR DESCRIPTION
In response to [this](https://highfidelity.fogbugz.com/f/cases/959/Switching-to-HMD-should-switch-to-first-person-camera) bug, entering HMD mode automatically enables first person camera view.