### PR TITLE
fix reticle bugs

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -408,6 +408,7 @@ private:
     static void dragEnterEvent(QDragEnterEvent* event);
 
     void maybeToggleMenuVisible(QMouseEvent* event) const;
+    void toggleMenuUnderReticle() const;
 
     MainWindow* _window;
     QElapsedTimer& _sessionRunTimer;

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -492,10 +492,9 @@ void OffscreenUi::unfocusWindows() {
     Q_ASSERT(invokeResult);
 }
 
-void OffscreenUi::toggleMenu(const QPoint& screenPosition) {
+void OffscreenUi::toggleMenu(const QPoint& screenPosition) { // caller should already have mapped using getReticlePosition
     emit showDesktop(); // we really only want to do this if you're showing the menu, but for now this works
-    auto virtualPos = mapToVirtualScreen(screenPosition, nullptr);
-    QMetaObject::invokeMethod(_desktop, "toggleMenu",  Q_ARG(QVariant, virtualPos));
+    QMetaObject::invokeMethod(_desktop, "toggleMenu", Q_ARG(QVariant, screenPosition));
 }
 
 


### PR DESCRIPTION
- Make context menu come up under mouse rather than to the side, so that in HMD you don't go cross-eyed looking past the context menu at the mouse in the distance.
- Stop seeking the mouse to the center of where you are looking when we get close enough. (Was never close enough.)
- Don't require a mouse move for either of the above.