### PR TITLE
Fix initial visibility of QML windows from scripts

### DIFF
--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -118,7 +118,7 @@ void QmlWindowClass::initQml(QVariantMap properties) {
             }
 
             bool visible = !properties.contains(VISIBILE_PROPERTY) || properties[VISIBILE_PROPERTY].toBool();
-            object->setProperty(VISIBILE_PROPERTY, visible);
+            object->setProperty(OFFSCREEN_VISIBILITY_PROPERTY, visible);
             object->setProperty(SOURCE_PROPERTY, _source);
 
             // Forward messages received from QML on to the script


### PR DESCRIPTION
A recent refactor of the window and frame definitions broke the initial visibility of windows created by scripts.  QML windows that would previously have appeared based on the properties passed by the script now appear invisible unless you explicitly set their visibility post-creation.  This PR fixes that issue. 