### PR TITLE
Fix for grab script search ray length

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1173,10 +1173,12 @@ function MyController(hand) {
         }
 
         var rayPickInfo = this.calcRayPickInfo(this.hand);
-        this.intersectionDistance = rayPickInfo.distance;
         if (rayPickInfo.entityID) {
             candidateEntities.push(rayPickInfo.entityID);
             this.entityPropertyCache.addEntity(rayPickInfo.entityID);
+            this.intersectionDistance = rayPickInfo.distance;
+        } else {
+            this.intersectionDistance = 0;
         }
 
         var grabbableEntities = candidateEntities.filter(function (entity) {


### PR DESCRIPTION
Test case:
   * in the home content squeeze the trigger to make the grab-script search beams visible.
   * if you sweep the search beams around the room they should change their length dynamically to not pass thru the walls and floor.