### PR TITLE
do not reset hud from button

### DIFF
--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -123,9 +123,7 @@ void OverlayConductor::update(float dt) {
     if (_flags & SuppressedByDrive) {
         if (!isDriving) {
             _flags &= ~SuppressedByDrive;
-            if (_flags & SuppressMask) {
-                shouldRecenter = true;
-            }
+             shouldRecenter = true;
         }
     } else {
         if (myAvatar->getClearOverlayWhenMoving() && drivingChanged && isDriving) {
@@ -136,9 +134,7 @@ void OverlayConductor::update(float dt) {
     if (_flags & SuppressedByHead) {
         if (isAtRest) {
             _flags &= ~SuppressedByHead;
-            if (_flags & SuppressMask) {
-                shouldRecenter = true;
-            }
+            shouldRecenter = true;
         }
     } else {
         if (_hmdMode && headOutsideOverlay()) {
@@ -151,7 +147,7 @@ void OverlayConductor::update(float dt) {
     if (targetVisible != currentVisible) {
         offscreenUi->setPinned(!targetVisible);
     }
-    if (shouldRecenter) {
+    if (shouldRecenter && !_flags) {
         centerUI();
     }
 }

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -118,10 +118,12 @@ void OverlayConductor::update(float dt) {
     bool isDriving = updateAvatarHasDriveInput();
     bool drivingChanged = prevDriving != isDriving;
     bool isAtRest = updateAvatarIsAtRest();
+    bool shouldRecenter = false;
 
     if (_flags & SuppressedByDrive) {
         if (!isDriving) {
             _flags &= ~SuppressedByDrive;
+            shouldRecenter = true;
         }
     } else {
         if (myAvatar->getClearOverlayWhenMoving() && drivingChanged && isDriving) {
@@ -132,6 +134,7 @@ void OverlayConductor::update(float dt) {
     if (_flags & SuppressedByHead) {
         if (isAtRest) {
             _flags &= ~SuppressedByHead;
+            shouldRecenter = true;
         }
     } else {
         if (_hmdMode && headOutsideOverlay()) {
@@ -143,8 +146,8 @@ void OverlayConductor::update(float dt) {
     bool targetVisible = Menu::getInstance()->isOptionChecked(MenuOption::Overlays) && (0 == (_flags & SuppressMask));
     if (targetVisible != currentVisible) {
         offscreenUi->setPinned(!targetVisible);
-        if (targetVisible && _hmdMode) {
-            centerUI();
-        }
+    }
+    if (shouldRecenter) {
+        centerUI();
     }
 }

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -123,7 +123,9 @@ void OverlayConductor::update(float dt) {
     if (_flags & SuppressedByDrive) {
         if (!isDriving) {
             _flags &= ~SuppressedByDrive;
-            shouldRecenter = true;
+            if (_flags & SuppressMask) {
+                shouldRecenter = true;
+            }
         }
     } else {
         if (myAvatar->getClearOverlayWhenMoving() && drivingChanged && isDriving) {
@@ -134,7 +136,9 @@ void OverlayConductor::update(float dt) {
     if (_flags & SuppressedByHead) {
         if (isAtRest) {
             _flags &= ~SuppressedByHead;
-            shouldRecenter = true;
+            if (_flags & SuppressMask) {
+                shouldRecenter = true;
+            }
         }
     } else {
         if (_hmdMode && headOutsideOverlay()) {


### PR DESCRIPTION
HUD should reset position/orientation when coming back after moving, but not when toggling overlays directly (e.g., with the button)