### PR TITLE
Don't reposition windows prior to selecting the initial display plugin

### DIFF
--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -24,6 +24,13 @@ FocusScope {
     readonly property int invalid_position: -9999;
     property rect recommendedRect: Qt.rect(0,0,0,0);
     property var expectedChildren;
+    property bool repositionLocked: true
+
+    onRepositionLockedChanged: {
+        if (!repositionLocked) {
+            d.handleSizeChanged();
+        }
+    }
 
     onHeightChanged: d.handleSizeChanged();
     
@@ -52,11 +59,14 @@ FocusScope {
         readonly property real menu: 8000
     }
 
-
     QtObject {
         id: d
 
         function handleSizeChanged() {
+            if (desktop.repositionLocked) {
+                return;
+            }
+
             var oldRecommendedRect = recommendedRect;
             var newRecommendedRectJS = (typeof Controller === "undefined") ? Qt.rect(0,0,0,0) : Controller.getRecommendedOverlayRect();
             var newRecommendedRect = Qt.rect(newRecommendedRectJS.x, newRecommendedRectJS.y, 
@@ -235,6 +245,10 @@ FocusScope {
         }
 
         function repositionAll() {
+            if (desktop.repositionLocked) {
+                return;
+            }
+
             var oldRecommendedRect = recommendedRect;
             var oldRecommendedDimmensions = { x: oldRecommendedRect.width, y: oldRecommendedRect.height };
             var newRecommendedRect = Controller.getRecommendedOverlayRect();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -963,6 +963,13 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
     updateHeartbeat();
 
     loadSettings();
+
+    // Now that we've loaded the menu and thus switched to the previous display plugin
+    // we can unlock the desktop repositioning code, since all the positions will be 
+    // relative to the desktop size for this plugin
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    offscreenUi->getDesktop()->setProperty("repositionLocked", false);
+
     // Make sure we don't time out during slow operations at startup
     updateHeartbeat();
 
@@ -5347,7 +5354,6 @@ void Application::updateDisplayMode() {
         getApplicationCompositor().setDisplayPlugin(newDisplayPlugin);
         _displayPlugin = newDisplayPlugin;
     }
-
 
     emit activeDisplayPluginChanged();
 


### PR DESCRIPTION
The code that re-positions windows doesn't properly deal with the case where the user exited in HMD mode.  If the user exits in HMD mode all the window positions are relative to the HMD-sized overlay, and will have large X values because of the extremely wide overlay size.  

This change inhibits any desktop automatic re-positioning of windows at the construction time of the desktop until such time as we enable it.  In the code, I've added a line to enable automatic re-positioning after we've loaded the settings for the first time, since this will update the menu and thus the previous window positions should now all be valid against the current plugin (the assumed plugin at the time of shutting down previously).  

