### PR TITLE
Fix bugs with Entities.addEntity

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -191,9 +191,11 @@ QUuid EntityScriptingInterface::addEntity(const EntityItemProperties& properties
     if (success) {
         emit debitEnergySource(cost);
         queueEntityMessage(PacketType::EntityAdd, id, propertiesWithSimID);
-    }
 
-    return id;
+        return id;
+    } else {
+        return QUuid();
+    }
 }
 
 QUuid EntityScriptingInterface::addModelEntity(const QString& name, const QString& modelUrl, const glm::vec3& position) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -320,6 +320,11 @@ EntityItemPointer EntityTree::addEntity(const EntityItemID& entityID, const Enti
         return nullptr;
     }
 
+    if (!properties.getClientOnly() && getIsClient() &&
+        !nodeList->getThisNodeCanRez() && !nodeList->getThisNodeCanRezTmp()) {
+        return nullptr;
+    }
+
     bool recordCreationTime = false;
     if (props.getCreated() == UNKNOWN_CREATED_TIME) {
         // the entity's creation time was not specified in properties, which means this is a NEW entity


### PR DESCRIPTION
Bug Fixes:
1. Entities cannot be added locally if they don't have permission from the domain server.
2. If an entity fails to be added, Entites.addEntity will return null. (Fixes [FogBugz case 365][fogbugz]).

Testing:
1. Start up sandbox
2. Navigate to <http://localhost:40100/settings/#security> in a browser
3. Disable entity rez and temp rez
4. Go to localhost in interface
5. Run the below script (don't try to use edit.js, it does it's own permission checks)
6. No entity should be created. If a box shows up in front of the avatar, it fails the test.
6. Check the console (CTRL-SHIFT-L), make sure it printed "NEW ENTITY ID = null" somewhere

```js
// Create the box properties
var pos = Vec3.sum(MyAvatar.position, Quat.getFront(MyAvatar.orientation));  
var properties = {
  type: "Box",
  position: pos
};

// Add the box
var id = Entities.addEntity(properties);
print("NEW ENTITY ID = " + id);

// Kill script after entity is created (or not created)
Script.stop();
```

[fogbugz]: https://highfidelity.fogbugz.com/f/cases/356/Entities-addEntity-can-return-a-UUID-even-when-unsuccessful