### PR TITLE
Refactor Camera scripting interface a little

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1717,22 +1717,22 @@ void Application::paintGL() {
             if (isHMDMode()) {
                 mat4 camMat = myAvatar->getSensorToWorldMatrix() * myAvatar->getHMDSensorMatrix();
                 _myCamera.setPosition(extractTranslation(camMat));
-                _myCamera.setRotation(glm::quat_cast(camMat));
+                _myCamera.setOrientation(glm::quat_cast(camMat));
             } else {
                 _myCamera.setPosition(myAvatar->getDefaultEyePosition());
-                _myCamera.setRotation(myAvatar->getHead()->getCameraOrientation());
+                _myCamera.setOrientation(myAvatar->getHead()->getCameraOrientation());
             }
         } else if (_myCamera.getMode() == CAMERA_MODE_THIRD_PERSON) {
             if (isHMDMode()) {
                 auto hmdWorldMat = myAvatar->getSensorToWorldMatrix() * myAvatar->getHMDSensorMatrix();
-                _myCamera.setRotation(glm::normalize(glm::quat_cast(hmdWorldMat)));
+                _myCamera.setOrientation(glm::normalize(glm::quat_cast(hmdWorldMat)));
                 _myCamera.setPosition(extractTranslation(hmdWorldMat) +
                     myAvatar->getOrientation() * boomOffset);
             } else {
-                _myCamera.setRotation(myAvatar->getHead()->getOrientation());
+                _myCamera.setOrientation(myAvatar->getHead()->getOrientation());
                 if (Menu::getInstance()->isOptionChecked(MenuOption::CenterPlayerInView)) {
                     _myCamera.setPosition(myAvatar->getDefaultEyePosition()
-                        + _myCamera.getRotation() * boomOffset);
+                        + _myCamera.getOrientation() * boomOffset);
                 } else {
                     _myCamera.setPosition(myAvatar->getDefaultEyePosition()
                         + myAvatar->getOrientation() * boomOffset);
@@ -1751,7 +1751,7 @@ void Application::paintGL() {
 
                 glm::quat worldMirrorRotation = mirrorBodyOrientation * mirrorHmdRotation;
 
-                _myCamera.setRotation(worldMirrorRotation);
+                _myCamera.setOrientation(worldMirrorRotation);
 
                 glm::vec3 hmdOffset = extractTranslation(myAvatar->getHMDSensorMatrix());
                 // Mirror HMD lateral offsets
@@ -1762,7 +1762,7 @@ void Application::paintGL() {
                    + mirrorBodyOrientation * glm::vec3(0.0f, 0.0f, 1.0f) * MIRROR_FULLSCREEN_DISTANCE * _scaleMirror
                    + mirrorBodyOrientation * hmdOffset);
             } else {
-                _myCamera.setRotation(myAvatar->getWorldAlignedOrientation()
+                _myCamera.setOrientation(myAvatar->getWorldAlignedOrientation()
                     * glm::quat(glm::vec3(0.0f, PI + _rotateMirror, 0.0f)));
                 _myCamera.setPosition(myAvatar->getDefaultEyePosition()
                     + glm::vec3(0, _raiseMirror * myAvatar->getUniformScale(), 0)
@@ -1775,11 +1775,11 @@ void Application::paintGL() {
             if (cameraEntity != nullptr) {
                 if (isHMDMode()) {
                     glm::quat hmdRotation = extractRotation(myAvatar->getHMDSensorMatrix());
-                    _myCamera.setRotation(cameraEntity->getRotation() * hmdRotation);
+                    _myCamera.setOrientation(cameraEntity->getRotation() * hmdRotation);
                     glm::vec3 hmdOffset = extractTranslation(myAvatar->getHMDSensorMatrix());
                     _myCamera.setPosition(cameraEntity->getPosition() + (hmdRotation * hmdOffset));
                 } else {
-                    _myCamera.setRotation(cameraEntity->getRotation());
+                    _myCamera.setOrientation(cameraEntity->getRotation());
                     _myCamera.setPosition(cameraEntity->getPosition());
                 }
             }
@@ -3314,9 +3314,9 @@ void Application::updateMyAvatarLookAtPosition() {
             if (isLookingAtSomeone) {
                 deflection *= GAZE_DEFLECTION_REDUCTION_DURING_EYE_CONTACT;
             }
-            lookAtSpot = origin + _myCamera.getRotation() * glm::quat(glm::radians(glm::vec3(
+            lookAtSpot = origin + _myCamera.getOrientation() * glm::quat(glm::radians(glm::vec3(
                 eyePitch * deflection, eyeYaw * deflection, 0.0f))) *
-                glm::inverse(_myCamera.getRotation()) * (lookAtSpot - origin);
+                glm::inverse(_myCamera.getOrientation()) * (lookAtSpot - origin);
         }
     }
 
@@ -4032,7 +4032,7 @@ void Application::loadViewFrustum(Camera& camera, ViewFrustum& viewFrustum) {
 
     // Set the viewFrustum up with the correct position and orientation of the camera
     viewFrustum.setPosition(camera.getPosition());
-    viewFrustum.setOrientation(camera.getRotation());
+    viewFrustum.setOrientation(camera.getOrientation());
 
     // Ask the ViewFrustum class to calculate our corners
     viewFrustum.calculate();
@@ -4305,7 +4305,7 @@ void Application::renderRearViewMirror(RenderArgs* renderArgs, const QRect& regi
                                     myAvatar->getOrientation() * glm::vec3(0.0f, 0.0f, -1.0f) * MIRROR_REARVIEW_DISTANCE * myAvatar->getScale());
     }
     _mirrorCamera.setProjection(glm::perspective(glm::radians(fov), aspect, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP));
-    _mirrorCamera.setRotation(myAvatar->getWorldAlignedOrientation() * glm::quat(glm::vec3(0.0f, PI, 0.0f)));
+    _mirrorCamera.setOrientation(myAvatar->getWorldAlignedOrientation() * glm::quat(glm::vec3(0.0f, PI, 0.0f)));
 
 
     // set the bounds of rear mirror view

--- a/interface/src/Camera.cpp
+++ b/interface/src/Camera.cpp
@@ -62,14 +62,14 @@ void Camera::update(float deltaTime) {
 }
 
 void Camera::recompose() {
-    mat4 orientation = glm::mat4_cast(_rotation);
+    mat4 orientation = glm::mat4_cast(_orientation);
     mat4 translation = glm::translate(mat4(), _position);
     _transform = translation * orientation;
 }
 
 void Camera::decompose() {
     _position = vec3(_transform[3]);
-    _rotation = glm::quat_cast(_transform);
+    _orientation = glm::quat_cast(_transform);
 }
 
 void Camera::setTransform(const glm::mat4& transform) {
@@ -85,8 +85,8 @@ void Camera::setPosition(const glm::vec3& position) {
     }
 }
 
-void Camera::setRotation(const glm::quat& rotation) {
-    _rotation = rotation; 
+void Camera::setOrientation(const glm::quat& orientation) {
+    _orientation = orientation;
     recompose();
     if (_isKeepLookingAt) {
         lookAt(_lookingAt);
@@ -154,9 +154,9 @@ QString Camera::getModeString() const {
 void Camera::lookAt(const glm::vec3& lookAt) {
     glm::vec3 up = IDENTITY_UP;
     glm::mat4 lookAtMatrix = glm::lookAt(_position, lookAt, up);
-    glm::quat rotation = glm::quat_cast(lookAtMatrix);
-    rotation.w = -rotation.w; // Rosedale approved
-    _rotation = rotation;
+    glm::quat orientation = glm::quat_cast(lookAtMatrix);
+    orientation.w = -orientation.w; // Rosedale approved
+    _orientation = orientation;
 }
 
 void Camera::keepLookingAt(const glm::vec3& point) {
@@ -171,7 +171,7 @@ void Camera::loadViewFrustum(ViewFrustum& frustum) const {
 
     // Set the viewFrustum up with the correct position and orientation of the camera
     frustum.setPosition(getPosition());
-    frustum.setOrientation(getRotation());
+    frustum.setOrientation(getOrientation());
 
     // Ask the ViewFrustum class to calculate our corners
     frustum.calculate();

--- a/interface/src/Camera.h
+++ b/interface/src/Camera.h
@@ -45,7 +45,7 @@ class Camera : public QObject {
 public:
     Camera();
 
-    void initialize(); // instantly put the camera at the ideal position and rotation. 
+    void initialize(); // instantly put the camera at the ideal position and orientation. 
 
     void update( float deltaTime );
 
@@ -57,24 +57,21 @@ public:
 
     EntityItemPointer getCameraEntityPointer() const { return _cameraEntity; }
 
-public slots:
-    QString getModeString() const;
-    void setModeString(const QString& mode);
-
-    glm::quat getRotation() const { return _rotation; }
-    void setRotation(const glm::quat& rotation);
-
-    glm::vec3 getPosition() const { return _position; }
-    void setPosition(const glm::vec3& position);
-
-    glm::quat getOrientation() const { return getRotation(); }
-    void setOrientation(const glm::quat& orientation) { setRotation(orientation); }
-
     const glm::mat4& getTransform() const { return _transform; }
     void setTransform(const glm::mat4& transform);
 
     const glm::mat4& getProjection() const { return _projection; }
     void setProjection(const glm::mat4& projection);
+
+public slots:
+    QString getModeString() const;
+    void setModeString(const QString& mode);
+
+    glm::vec3 getPosition() const { return _position; }
+    void setPosition(const glm::vec3& position);
+
+    glm::quat getOrientation() const { return _orientation; }
+    void setOrientation(const glm::quat& orientation);
 
     QUuid getCameraEntity() const;
     void setCameraEntity(QUuid entityID);
@@ -105,7 +102,7 @@ private:
 
     // derived
     glm::vec3 _position;
-    glm::quat _rotation;
+    glm::quat _orientation;
     bool _isKeepLookingAt{ false };
     glm::vec3 _lookingAt;
     EntityItemPointer _cameraEntity;


### PR DESCRIPTION
Changes
* get/setRotation has been removed, as it was a duplicate of get/setOrientation, but undocumented and barely used.
* get/setTransform and get/setPerspective have been changed to methods from slots, since glm::mat4 is not exposed to the scriping interface so they didn't work in scripting.

Testing
1. Startup interface and open the JS console (CTRL-ALT-J)
2. Enter in `Camera.getRotation`, `Camera.setRotation`, `Camera.getTransform`, `Camera.setTransform`, `Camera.getPerspective`, `Camera.setPerspective`
3. All should come back as `undefined`.