### PR TITLE
Fix multiple sessions being created for some users

### DIFF
--- a/interface/src/DiscoverabilityManager.cpp
+++ b/interface/src/DiscoverabilityManager.cpp
@@ -79,9 +79,6 @@ void DiscoverabilityManager::updateLocation() {
         const QString FRIENDS_ONLY_KEY_IN_LOCATION = "friends_only";
         locationObject.insert(FRIENDS_ONLY_KEY_IN_LOCATION, (_mode.get() == Discoverability::Friends));
 
-        // if we have a session ID add it now, otherwise add a null value
-        rootObject[SESSION_ID_KEY] = accountManager->getSessionIDWithoutCurlyBraces();
-
         JSONCallbackParameters callbackParameters;
         callbackParameters.jsonCallbackReceiver = this;
         callbackParameters.jsonCallbackMethod = "handleHeartbeatResponse";
@@ -109,12 +106,8 @@ void DiscoverabilityManager::updateLocation() {
         callbackParameters.jsonCallbackReceiver = this;
         callbackParameters.jsonCallbackMethod = "handleHeartbeatResponse";
 
-        QJsonObject heartbeatObject;
-        heartbeatObject[SESSION_ID_KEY] = accountManager->getSessionIDWithoutCurlyBraces();
-
         accountManager->sendRequest(API_USER_HEARTBEAT_PATH, AccountManagerAuth::Optional,
-                                   QNetworkAccessManager::PutOperation, callbackParameters,
-                                   QJsonDocument(heartbeatObject).toJson());
+                                   QNetworkAccessManager::PutOperation, callbackParameters);
     }
 }
 

--- a/interface/src/DiscoverabilityManager.cpp
+++ b/interface/src/DiscoverabilityManager.cpp
@@ -80,8 +80,7 @@ void DiscoverabilityManager::updateLocation() {
         locationObject.insert(FRIENDS_ONLY_KEY_IN_LOCATION, (_mode.get() == Discoverability::Friends));
 
         // if we have a session ID add it now, otherwise add a null value
-        auto sessionID = accountManager->getSessionID();
-        rootObject[SESSION_ID_KEY] = sessionID.isNull() ? QJsonValue() : sessionID.toString();
+        rootObject[SESSION_ID_KEY] = accountManager->getSessionIDWithoutCurlyBraces();
 
         JSONCallbackParameters callbackParameters;
         callbackParameters.jsonCallbackReceiver = this;
@@ -111,8 +110,7 @@ void DiscoverabilityManager::updateLocation() {
         callbackParameters.jsonCallbackMethod = "handleHeartbeatResponse";
 
         QJsonObject heartbeatObject;
-        auto sessionID = accountManager->getSessionID();
-        heartbeatObject[SESSION_ID_KEY] = sessionID.isNull() ? QJsonValue() : sessionID.toString();
+        heartbeatObject[SESSION_ID_KEY] = accountManager->getSessionIDWithoutCurlyBraces();
 
         accountManager->sendRequest(API_USER_HEARTBEAT_PATH, AccountManagerAuth::Optional,
                                    QNetworkAccessManager::PutOperation, callbackParameters,

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -220,12 +220,8 @@ void AccountManager::sendRequest(const QString& path,
 
     networkRequest.setHeader(QNetworkRequest::UserAgentHeader, _userAgentGetter());
 
-    // if we're allowed to send usage data, include whatever the current session ID is with this request
-    auto& activityLogger = UserActivityLogger::getInstance();
-    if (activityLogger.isEnabled()) {
-        networkRequest.setRawHeader(METAVERSE_SESSION_ID_HEADER,
-                                    uuidStringWithoutCurlyBraces(_sessionID).toLocal8Bit());
-    }
+    networkRequest.setRawHeader(METAVERSE_SESSION_ID_HEADER,
+                                uuidStringWithoutCurlyBraces(_sessionID).toLocal8Bit());
 
     QUrl requestURL = _authURL;
     

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -88,7 +88,6 @@ public:
 
     static QJsonObject dataObjectFromResponse(QNetworkReply& requestReply);
 
-    QString getSessionIDWithoutCurlyBraces() const { return uuidStringWithoutCurlyBraces(_sessionID); }
     QUuid getSessionID() const { return _sessionID; }
     void setSessionID(const QUuid& sessionID) { _sessionID = sessionID; }
 

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -24,6 +24,8 @@
 
 #include <DependencyManager.h>
 
+#include "UUID.h"
+
 class JSONCallbackParameters {
 public:
     JSONCallbackParameters(QObject* jsonCallbackReceiver = nullptr, const QString& jsonCallbackMethod = QString(),
@@ -86,6 +88,7 @@ public:
 
     static QJsonObject dataObjectFromResponse(QNetworkReply& requestReply);
 
+    QString getSessionIDWithoutCurlyBraces() const { return uuidStringWithoutCurlyBraces(_sessionID); }
     QUuid getSessionID() const { return _sessionID; }
     void setSessionID(const QUuid& sessionID) { _sessionID = sessionID; }
 

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -24,8 +24,6 @@
 
 #include <DependencyManager.h>
 
-#include "UUID.h"
-
 class JSONCallbackParameters {
 public:
     JSONCallbackParameters(QObject* jsonCallbackReceiver = nullptr, const QString& jsonCallbackMethod = QString(),


### PR DESCRIPTION
If a user didn't have send-data activated they don't have their session id
sent in the header of requests, but instead send it inside the request
body. The session id being sent in the request included curly braces which
the server considers invalid.