### PR TITLE
Keyboard focus polish for Vive UI

### DIFF
--- a/interface/resources/qml/controls-uit/SpinBox.qml
+++ b/interface/resources/qml/controls-uit/SpinBox.qml
@@ -36,15 +36,15 @@ SpinBox {
         id: spinStyle
         background: Rectangle {
             color: isLightColorScheme
-                   ? (spinBox.focus ? hifi.colors.white : hifi.colors.lightGray)
-                   : (spinBox.focus ? hifi.colors.black : hifi.colors.baseGrayShadow)
+                   ? (spinBox.activeFocus ? hifi.colors.white : hifi.colors.lightGray)
+                   : (spinBox.activeFocus ? hifi.colors.black : hifi.colors.baseGrayShadow)
             border.color: spinBoxLabelInside.visible ? spinBoxLabelInside.color : hifi.colors.primaryHighlight
-            border.width: spinBox.focus ? spinBoxLabelInside.visible ? 2 : 1 : 0
+            border.width: spinBox.activeFocus ? spinBoxLabelInside.visible ? 2 : 1 : 0
         }
 
         textColor: isLightColorScheme
-                   ? (spinBox.focus ? hifi.colors.black : hifi.colors.lightGray)
-                   : (spinBox.focus ? hifi.colors.white : hifi.colors.lightGrayText)
+                   ? (spinBox.activeFocus ? hifi.colors.black : hifi.colors.lightGray)
+                   : (spinBox.activeFocus ? hifi.colors.white : hifi.colors.lightGrayText)
         selectedTextColor: hifi.colors.black
         selectionColor: hifi.colors.primaryHighlight
 
@@ -96,7 +96,7 @@ SpinBox {
         anchors.fill: parent
         propagateComposedEvents: true
         onWheel: {
-            if(spinBox.focus)
+            if(spinBox.activeFocus)
                 wheel.accepted = false
             else
                 wheel.accepted = true

--- a/interface/resources/qml/controls-uit/TextField.qml
+++ b/interface/resources/qml/controls-uit/TextField.qml
@@ -36,14 +36,14 @@ TextField {
 
     style: TextFieldStyle {
         textColor: isLightColorScheme
-                   ? (textField.focus ? hifi.colors.black : hifi.colors.lightGray)
-                   : (textField.focus ? hifi.colors.white : hifi.colors.lightGrayText)
+                   ? (textField.activeFocus ? hifi.colors.black : hifi.colors.lightGray)
+                   : (textField.activeFocus ? hifi.colors.white : hifi.colors.lightGrayText)
         background: Rectangle {
             color: isLightColorScheme
-                   ? (textField.focus ? hifi.colors.white : hifi.colors.textFieldLightBackground)
-                   : (textField.focus ? hifi.colors.black : hifi.colors.baseGrayShadow)
+                   ? (textField.activeFocus ? hifi.colors.white : hifi.colors.textFieldLightBackground)
+                   : (textField.activeFocus ? hifi.colors.black : hifi.colors.baseGrayShadow)
             border.color: hifi.colors.primaryHighlight
-            border.width: textField.focus ? 1 : 0
+            border.width: textField.activeFocus ? 1 : 0
             radius: isSearchField ? textField.height / 2 : 0
 
             HiFiGlyphs {

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -30,6 +30,7 @@ FocusScope {
         if (!repositionLocked) {
             d.handleSizeChanged();
         }
+
     }
 
     onHeightChanged: d.handleSizeChanged();
@@ -66,7 +67,6 @@ FocusScope {
             if (desktop.repositionLocked) {
                 return;
             }
-
             var oldRecommendedRect = recommendedRect;
             var newRecommendedRectJS = (typeof Controller === "undefined") ? Qt.rect(0,0,0,0) : Controller.getRecommendedOverlayRect();
             var newRecommendedRect = Qt.rect(newRecommendedRectJS.x, newRecommendedRectJS.y, 
@@ -311,8 +311,8 @@ FocusScope {
 
     onPinnedChanged: {
         if (pinned) {
-            nullFocus.focus = true;
-            nullFocus.forceActiveFocus();
+            desktop.focus = true;
+            desktop.forceActiveFocus();
 
             // recalculate our non-pinned children
             hiddenChildren = d.findMatchingChildren(desktop, function(child){
@@ -486,16 +486,30 @@ FocusScope {
     }
 
     function unfocusWindows() {
+        // First find the active focus item, and unfocus it, all the way 
+        // up the parent chain to the window
+        var currentFocus = offscreenWindow.activeFocusItem;
+        var targetWindow = d.getDesktopWindow(currentFocus);
+        while (currentFocus) {
+            if (currentFocus === targetWindow) {
+                break;
+            }
+            currentFocus.focus = false;
+            currentFocus = currentFocus.parent;
+        }
+
+        // Unfocus all windows
         var windows = d.getTopLevelWindows();
         for (var i = 0; i < windows.length; ++i) {
             windows[i].focus = false;
         }
+
+        // For the desktop to have active focus
         desktop.focus = true;
+        desktop.forceActiveFocus();
     }
 
     FocusHack { id: focusHack; }
-
-    FocusScope { id: nullFocus; }
 
     Rectangle {
         id: focusDebugger;
@@ -510,5 +524,5 @@ FocusScope {
         enabled: DebugQML
         onTriggered: focusDebugger.visible = !focusDebugger.visible
     }
-    
+
 }

--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -53,11 +53,6 @@ ScrollingWindow {
         updateRunningScripts();
     }
 
-    function setDefaultFocus() {
-        // Work around FocusScope of scrollable window.
-        filterEdit.forceActiveFocus();
-    }
-
     function updateRunningScripts() {
         var runningScripts = ScriptDiscoveryService.getRunning();
         runningScriptsModel.clear()
@@ -276,7 +271,6 @@ ScrollingWindow {
                 isSearchField: true
                 anchors.left: parent.left
                 anchors.right: parent.right
-                focus: true
                 colorScheme: hifi.colorSchemes.dark
                 placeholderText: "Filter"
                 onTextChanged: scriptsModel.filterRegExp =  new RegExp("^.*" + text + ".*$", "i")

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -268,6 +268,7 @@ void handleOpenVrEvents() {
             case vr::VREvent_KeyboardClosed:
                 _keyboardFocusObject = nullptr;
                 _keyboardShown = false;
+                DependencyManager::get<OffscreenUi>()->unfocusWindows();
                 break;
 
             default:

--- a/scripts/developer/tests/playaPerformanceTest.qml
+++ b/scripts/developer/tests/playaPerformanceTest.qml
@@ -125,7 +125,6 @@ Rectangle {
 
     TextField {
         id: addressLine
-        focus: true
         anchors { 
             left: parent.left; right: parent.right;
             top: row.bottom; margins: 16; 


### PR DESCRIPTION
* When the keyboard is dismissed, unfocus the text field in a window
* Don't auto-focus text fields when opening most dialogs
* Properly render UI coloring based on `activeFocus`, not `focus`