### PR TITLE
Fix snapshot dialog rendering

### DIFF
--- a/interface/resources/qml/hifi/dialogs/SnapshotShareDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/SnapshotShareDialog.qml
@@ -7,7 +7,7 @@ import "../../windows"
 import "../../js/Utils.js" as Utils
 import "../models"
 
-ScrollingWindow {
+Window {
     id: root
     resizable: true
     width: 516

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4998,7 +4998,6 @@ void Application::takeSnapshot() {
 
     DependencyManager::get<OffscreenUi>()->load("hifi/dialogs/SnapshotShareDialog.qml", [=](QQmlContext*, QObject* dialog) {
         dialog->setProperty("source", QUrl::fromLocalFile(fileName));
-        connect(dialog, SIGNAL(uploadSnapshot(const QString& snapshot)), this, SLOT(uploadSnapshot(const QString& snapshot)));
     });
 }
 


### PR DESCRIPTION
Fixes the snapshot dialog just rendering as a grey window.

Note:  The "Share" button is broken so this is pretty much useless, but there are separate plans to address that.