### PR TITLE
Don't render wire geometry with lighting effects

### DIFF
--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -97,7 +97,7 @@ void Circle3DOverlay::render(RenderArgs* args) {
     _lastColor = colorX;
 
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    
+
     Q_ASSERT(args->_batch);
     auto& batch = *args->_batch;
 
@@ -149,6 +149,7 @@ void Circle3DOverlay::render(RenderArgs* args) {
             geometryCache->updateVertices(_quadVerticesID, points, color);
         }
         
+        geometryCache->bindSimpleProgram(batch);
         geometryCache->renderVertices(batch, gpu::TRIANGLES, _quadVerticesID);
         
     } else {
@@ -187,6 +188,8 @@ void Circle3DOverlay::render(RenderArgs* args) {
             geometryCache->updateVertices(_lineVerticesID, points, color);
         }
         
+        // Render unlit
+        geometryCache->bindSimpleProgram(batch, false, false, true);
         if (getIsDashedLine()) {
             geometryCache->renderVertices(batch, gpu::LINES, _lineVerticesID);
         } else {
@@ -279,7 +282,7 @@ void Circle3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Circle3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withoutCullFace();
+    auto builder = render::ShapeKey::Builder().withOwnPipeline();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -149,7 +149,6 @@ void Circle3DOverlay::render(RenderArgs* args) {
             geometryCache->updateVertices(_quadVerticesID, points, color);
         }
         
-        geometryCache->bindSimpleProgram(batch);
         geometryCache->renderVertices(batch, gpu::TRIANGLES, _quadVerticesID);
         
     } else {
@@ -188,8 +187,6 @@ void Circle3DOverlay::render(RenderArgs* args) {
             geometryCache->updateVertices(_lineVerticesID, points, color);
         }
         
-        // Render unlit
-        geometryCache->bindSimpleProgram(batch, false, false, true);
         if (getIsDashedLine()) {
             geometryCache->renderVertices(batch, gpu::LINES, _lineVerticesID);
         } else {
@@ -282,9 +279,12 @@ void Circle3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Circle3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withOwnPipeline();
+    auto builder = render::ShapeKey::Builder().withoutCullFace();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
+    }
+    if (!getIsSolid()) {
+        builder.withUnlit().withDepthBias();
     }
     return builder.build();
 }

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -48,7 +48,7 @@ void Cube3DOverlay::render(RenderArgs* args) {
         auto geometryCache = DependencyManager::get<GeometryCache>();
         auto pipeline = args->_pipeline;
         if (!pipeline) {
-            pipeline = geometryCache->getShapePipeline();
+            pipeline = _isSolid ? geometryCache->getShapePipeline() : geometryCache->getWireShapePipeline();
         }
 
         if (_isSolid) {
@@ -56,7 +56,7 @@ void Cube3DOverlay::render(RenderArgs* args) {
             batch->setModelTransform(transform);
             geometryCache->renderSolidCubeInstance(*batch, cubeColor, pipeline);
         } else {
-
+            geometryCache->bindSimpleProgram(*batch, false, false, true, true);
             if (getIsDashedLine()) {
                 transform.setScale(1.0f);
                 batch->setModelTransform(transform);
@@ -97,7 +97,7 @@ void Cube3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Cube3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder();
+    auto builder = render::ShapeKey::Builder().withOwnPipeline();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -44,7 +44,6 @@ void Cube3DOverlay::render(RenderArgs* args) {
         Transform transform;
         transform.setTranslation(position);
         transform.setRotation(rotation);
-
         auto geometryCache = DependencyManager::get<GeometryCache>();
         auto pipeline = args->_pipeline;
         if (!pipeline) {
@@ -97,9 +96,12 @@ void Cube3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Cube3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withOwnPipeline();
+    auto builder = render::ShapeKey::Builder();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
+    }
+    if (!getIsSolid()) {
+        builder.withUnlit().withDepthBias();
     }
     return builder.build();
 }

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -75,11 +75,9 @@ void Grid3DOverlay::render(RenderArgs* args) {
         transform.setScale(glm::vec3(getDimensions(), 1.0f));
         transform.setTranslation(position);
         batch->setModelTransform(transform);
-        auto geometryCache = DependencyManager::get<GeometryCache>();
-        geometryCache->bindSimpleProgram(*batch, false, false, true, true);
         const float MINOR_GRID_EDGE = 0.0025f;
         const float MAJOR_GRID_EDGE = 0.005f;
-        geometryCache->renderGrid(*batch, minCorner, maxCorner,
+        DependencyManager::get<GeometryCache>()->renderGrid(*batch, minCorner, maxCorner,
             _minorGridRowDivisions, _minorGridColDivisions, MINOR_GRID_EDGE,
             _majorGridRowDivisions, _majorGridColDivisions, MAJOR_GRID_EDGE,
             gridColor, _drawInFront);
@@ -87,7 +85,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Grid3DOverlay::getShapeKey() {
-    return render::ShapeKey::Builder().withOwnPipeline();
+    return render::ShapeKey::Builder().withOwnPipeline().withUnlit().withDepthBias();
 }
 
 void Grid3DOverlay::setProperties(const QVariantMap& properties) {

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -75,10 +75,11 @@ void Grid3DOverlay::render(RenderArgs* args) {
         transform.setScale(glm::vec3(getDimensions(), 1.0f));
         transform.setTranslation(position);
         batch->setModelTransform(transform);
-
+        auto geometryCache = DependencyManager::get<GeometryCache>();
+        geometryCache->bindSimpleProgram(*batch, false, false, true, true);
         const float MINOR_GRID_EDGE = 0.0025f;
         const float MAJOR_GRID_EDGE = 0.005f;
-        DependencyManager::get<GeometryCache>()->renderGrid(*batch, minCorner, maxCorner,
+        geometryCache->renderGrid(*batch, minCorner, maxCorner,
             _minorGridRowDivisions, _minorGridColDivisions, MINOR_GRID_EDGE,
             _majorGridRowDivisions, _majorGridColDivisions, MAJOR_GRID_EDGE,
             gridColor, _drawInFront);

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -92,8 +92,10 @@ void Image3DOverlay::render(RenderArgs* args) {
 
     batch->setModelTransform(transform);
     batch->setResourceTexture(0, _texture->getGPUTexture());
-
-    DependencyManager::get<GeometryCache>()->renderQuad(
+    
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    geometryCache->bindSimpleProgram(*batch, true, false);
+    geometryCache->renderQuad(
         *batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
         glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha)
     );
@@ -102,7 +104,7 @@ void Image3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Image3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withoutCullFace().withDepthBias();
+    auto builder = render::ShapeKey::Builder().withOwnPipeline();
     if (_emissive) {
         builder.withUnlit();
     }

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -93,9 +93,7 @@ void Image3DOverlay::render(RenderArgs* args) {
     batch->setModelTransform(transform);
     batch->setResourceTexture(0, _texture->getGPUTexture());
     
-    auto geometryCache = DependencyManager::get<GeometryCache>();
-    geometryCache->bindSimpleProgram(*batch, true, false);
-    geometryCache->renderQuad(
+    DependencyManager::get<GeometryCache>()->renderQuad(
         *batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
         glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha)
     );
@@ -104,7 +102,7 @@ void Image3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Image3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withOwnPipeline();
+    auto builder = render::ShapeKey::Builder().withoutCullFace().withDepthBias();
     if (_emissive) {
         builder.withUnlit();
     }

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -54,17 +54,20 @@ void Line3DOverlay::render(RenderArgs* args) {
     if (batch) {
         batch->setModelTransform(_transform);
 
+        auto geometryCache = DependencyManager::get<GeometryCache>();
+        geometryCache->bindSimpleProgram(*batch, false, false, true, true);
         if (getIsDashedLine()) {
             // TODO: add support for color to renderDashedLine()
-            DependencyManager::get<GeometryCache>()->renderDashedLine(*batch, _start, _end, colorv4, _geometryCacheID);
+            geometryCache->renderDashedLine(*batch, _start, _end, colorv4, _geometryCacheID);
         } else {
-            DependencyManager::get<GeometryCache>()->renderLine(*batch, _start, _end, colorv4, _geometryCacheID);
+
+            geometryCache->renderLine(*batch, _start, _end, colorv4, _geometryCacheID);
         }
     }
 }
 
 const render::ShapeKey Line3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withoutCullFace();
+    auto builder = render::ShapeKey::Builder().withOwnPipeline();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -53,13 +53,15 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
         transform.setRotation(rotation);
 
         batch->setModelTransform(transform);
+        auto geometryCache = DependencyManager::get<GeometryCache>();
 
         if (getIsSolid()) {
             glm::vec3 topLeft(-halfDimensions.x, -halfDimensions.y, 0.0f);
             glm::vec3 bottomRight(halfDimensions.x, halfDimensions.y, 0.0f);
-            DependencyManager::get<GeometryCache>()->renderQuad(*batch, topLeft, bottomRight, rectangleColor);
+            geometryCache->bindSimpleProgram(*batch);
+            geometryCache->renderQuad(*batch, topLeft, bottomRight, rectangleColor);
         } else {
-            auto geometryCache = DependencyManager::get<GeometryCache>();
+            geometryCache->bindSimpleProgram(*batch, false, false, true, true);
             if (getIsDashedLine()) {
                 glm::vec3 point1(-halfDimensions.x, -halfDimensions.y, 0.0f);
                 glm::vec3 point2(halfDimensions.x, -halfDimensions.y, 0.0f);
@@ -89,7 +91,7 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Rectangle3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder();
+    auto builder = render::ShapeKey::Builder().withOwnPipeline();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -46,7 +46,7 @@ void Sphere3DOverlay::render(RenderArgs* args) {
         auto geometryCache = DependencyManager::get<GeometryCache>();
         auto pipeline = args->_pipeline;
         if (!pipeline) {
-            pipeline = geometryCache->getShapePipeline();
+            pipeline = _isSolid ? geometryCache->getShapePipeline() : geometryCache->getWireShapePipeline();
         }
 
         if (_isSolid) {
@@ -58,7 +58,7 @@ void Sphere3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Sphere3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder();
+    auto builder = render::ShapeKey::Builder().withOwnPipeline();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -62,6 +62,9 @@ const render::ShapeKey Sphere3DOverlay::getShapeKey() {
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }
+    if (!getIsSolid()) {
+        builder.withUnlit().withDepthBias();
+    }
     return builder.build();
 }
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -100,7 +100,9 @@ void Web3DOverlay::render(RenderArgs* args) {
     }
 
     batch.setModelTransform(transform);
-    DependencyManager::get<GeometryCache>()->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color);
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    geometryCache->bindSimpleProgram(batch, true, false, true, false);
+    geometryCache->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color);
     batch.setResourceTexture(0, args->_whiteTexture); // restore default white color after me
 }
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -309,6 +309,7 @@ gpu::Stream::FormatPointer& getInstancedSolidStreamFormat() {
 }
 
 render::ShapePipelinePointer GeometryCache::_simplePipeline;
+render::ShapePipelinePointer GeometryCache::_simpleWirePipeline;
 
 GeometryCache::GeometryCache() :
     _nextID(0)
@@ -323,6 +324,10 @@ GeometryCache::GeometryCache() :
                 batch.setResourceTexture(render::ShapePipeline::Slot::MAP::NORMAL_FITTING,
                     DependencyManager::get<TextureCache>()->getNormalFittingTexture());
             }
+        );
+    GeometryCache::_simpleWirePipeline =
+        std::make_shared<render::ShapePipeline>(getSimplePipeline(false, false, true, true), nullptr,
+            [](const render::ShapePipeline&, gpu::Batch& batch) { }
         );
 }
 

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -157,7 +157,8 @@ public:
     gpu::PipelinePointer getSimplePipeline(bool textured = false, bool culled = true,
                                           bool unlit = false, bool depthBias = false);
     render::ShapePipelinePointer getShapePipeline() { return GeometryCache::_simplePipeline; }
-    
+    render::ShapePipelinePointer getWireShapePipeline() { return GeometryCache::_simpleWirePipeline; }
+
     // Static (instanced) geometry
     void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
     void renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
@@ -179,7 +180,7 @@ public:
     void renderWireSphereInstance(gpu::Batch& batch, const glm::vec4& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline);
     void renderWireSphereInstance(gpu::Batch& batch, const glm::vec3& color,
-                                    const render::ShapePipelinePointer& pipeline = _simplePipeline) {
+                                    const render::ShapePipelinePointer& pipeline = _simpleWirePipeline) {
         renderWireSphereInstance(batch, glm::vec4(color, 1.0f), pipeline);
     }
     
@@ -193,7 +194,7 @@ public:
     void renderWireCubeInstance(gpu::Batch& batch, const glm::vec4& color,
                                     const render::ShapePipelinePointer& pipeline = _simplePipeline);
     void renderWireCubeInstance(gpu::Batch& batch, const glm::vec3& color,
-                                    const render::ShapePipelinePointer& pipeline = _simplePipeline) {
+                                    const render::ShapePipelinePointer& pipeline = _simpleWirePipeline) {
         renderWireCubeInstance(batch, glm::vec4(color, 1.0f), pipeline);
     }
     
@@ -401,6 +402,7 @@ private:
     gpu::ShaderPointer _simpleShader;
     gpu::ShaderPointer _unlitShader;
     static render::ShapePipelinePointer _simplePipeline;
+    static render::ShapePipelinePointer _simpleWirePipeline;
     QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
 };
 


### PR DESCRIPTION
Wireframes should be unaffected by lighting.  Currently hand lasers in the Vive UI are very hard to see in playa because of the lighting.  