### PR TITLE
Fix eslint descrepencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,13 +52,14 @@ module.exports = {
     },
     "rules": {
         "brace-style": ["error", "1tbs", { "allowSingleLine": false }],
-        "comma-dangle": ["error", "only-multiline"],
+        "comma-dangle": ["error", "never"],
         "camelcase": ["error"],
         "curly": ["error", "all"],
         "indent": ["error", 4, { "SwitchCase": 1 }],
         "keyword-spacing": ["error", { "before": true, "after": true }],
         "max-len": ["error", 128, 4],
         "new-cap": ["error"],
+        "no-floating-decimal": ["error"],
         //"no-magic-numbers": ["error", { "ignore": [0, 1], "ignoreArrayIndexes": true }],
         "no-multiple-empty-lines": ["error"],
         "no-multi-spaces": ["error"],
@@ -67,6 +68,6 @@ module.exports = {
         "spaced-comment": ["error", "always", {
             "line": { "markers": ["/"] }
         }],
-        "space-before-function-paren": ["error", "never"]
+        "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}]
     }
 };


### PR DESCRIPTION
Prohibit trailing commas, and fix function spacing rule to be more in
line with the coding standard.  Also prohibit leading decimal points,
also specified in coding standard.

Testing:
1. Make sure eslint is installed: `npm i -g eslint`, you need node for this: <https://nodejs.org/en/>
2. Create a file called `foo.js`
3. Copy-paste in the script below
4. Run `eslint -c path/to/hifi/.eslintrc.js --color foo.js` from the same directory as `foo.js`, replacing `path/to/hifi/` with the relevant path
5. It should throw errors for `space-before-function-paren`, `no-floating-decimal`, and `comma-dangle`