### PR TITLE
floating-point versions of the audio resampler and reverb

### DIFF
--- a/libraries/audio/src/AudioReverb.cpp
+++ b/libraries/audio/src/AudioReverb.cpp
@@ -1725,7 +1725,7 @@ void ReverbImpl::reset() {
 // Public API
 //
 
-static const int REVERB_BLOCK = 1024;
+static const int REVERB_BLOCK = 256;
 
 AudioReverb::AudioReverb(float sampleRate) {
 
@@ -1898,6 +1898,44 @@ void AudioReverb::convertOutputToInt16(float** inputs, int16_t* output, int numF
     }
 }
 
+// deinterleave stereo
+void AudioReverb::convertInputFromFloat(const float* input, float** outputs, int numFrames) {
+
+    int i = 0;
+    for (; i < numFrames - 3; i += 4) {
+        __m128 f0 = _mm_loadu_ps(&input[2*i + 0]);
+        __m128 f1 = _mm_loadu_ps(&input[2*i + 4]);
+
+        // deinterleave
+        _mm_storeu_ps(&outputs[0][i], _mm_shuffle_ps(f0, f1, _MM_SHUFFLE(2,0,2,0)));
+        _mm_storeu_ps(&outputs[1][i], _mm_shuffle_ps(f0, f1, _MM_SHUFFLE(3,1,3,1)));
+    }
+    for (; i < numFrames; i++) {
+        // deinterleave
+        outputs[0][i] = input[2*i + 0];
+        outputs[1][i] = input[2*i + 1];
+    }
+}
+
+// interleave stereo
+void AudioReverb::convertOutputToFloat(float** inputs, float* output, int numFrames) {
+
+    int i = 0;
+    for(; i < numFrames - 3; i += 4) {
+        __m128 f0 = _mm_loadu_ps(&inputs[0][i]);
+        __m128 f1 = _mm_loadu_ps(&inputs[1][i]);
+
+        // interleave
+        _mm_storeu_ps(&output[2*i + 0],_mm_unpacklo_ps(f0,f1));
+        _mm_storeu_ps(&output[2*i + 4],_mm_unpackhi_ps(f0,f1));
+    }
+    for(; i < numFrames; i++) {
+        // interleave
+        output[2*i + 0] = inputs[0][i];
+        output[2*i + 1] = inputs[1][i];
+    }
+}
+
 #else
 
 // convert int16_t to float, deinterleave stereo
@@ -1944,6 +1982,26 @@ void AudioReverb::convertOutputToInt16(float** inputs, int16_t* output, int numF
     }
 }
 
+// deinterleave stereo
+void AudioReverb::convertInputFromFloat(const float* input, float** outputs, int numFrames) {
+
+    for (int i = 0; i < numFrames; i++) {
+        // deinterleave
+        outputs[0][i] = input[2*i + 0];
+        outputs[1][i] = input[2*i + 1];
+    }
+}
+
+// interleave stereo
+void AudioReverb::convertOutputToFloat(float** inputs, float* output, int numFrames) {
+
+    for (int i = 0; i < numFrames; i++) {
+        // interleave
+        output[2*i + 0] = inputs[0][i];
+        output[2*i + 1] = inputs[1][i];
+    }
+}
+
 #endif
 
 //
@@ -1960,6 +2018,27 @@ void AudioReverb::render(const int16_t* input, int16_t* output, int numFrames) {
         _impl->process(_inout, _inout, n);
 
         convertOutputToInt16(_inout, output, n);
+
+        input += 2 * n;
+        output += 2 * n;
+        numFrames -= n;
+    }
+}
+
+//
+// This version handles input/output as interleaved float
+//
+void AudioReverb::render(const float* input, float* output, int numFrames) {
+
+    while (numFrames) {
+
+        int n = MIN(numFrames, REVERB_BLOCK);
+
+        convertInputFromFloat(input, _inout, n);
+
+        _impl->process(_inout, _inout, n);
+
+        convertOutputToFloat(_inout, output, n);
 
         input += 2 * n;
         output += 2 * n;

--- a/libraries/audio/src/AudioReverb.cpp
+++ b/libraries/audio/src/AudioReverb.cpp
@@ -13,13 +13,13 @@
 #include "AudioReverb.h"
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4351) // new behavior: elements of array will be default initialized
 
 #include <intrin.h>
 inline static int MULHI(int a, int b) {
     long long c = __emul(a, b);
     return ((int*)&c)[1];
 }
+
 #else
 
 #define MULHI(a,b)  (int)(((long long)(a) * (b)) >> 32)

--- a/libraries/audio/src/AudioReverb.cpp
+++ b/libraries/audio/src/AudioReverb.cpp
@@ -1804,7 +1804,7 @@ void AudioReverb::render(float** inputs, float** outputs, int numFrames) {
 #include <emmintrin.h>
 
 // convert int16_t to float, deinterleave stereo
-void AudioReverb::convertInputFromInt16(const int16_t* input, float** outputs, int numFrames) {
+void AudioReverb::convertInput(const int16_t* input, float** outputs, int numFrames) {
     __m128 scale = _mm_set1_ps(1/32768.0f);
 
     int i = 0;
@@ -1855,8 +1855,8 @@ static inline __m128 dither4() {
     return _mm_mul_ps(d0, _mm_set1_ps(1/65536.0f));
 }
 
-// convert float to int16_t, interleave stereo
-void AudioReverb::convertOutputToInt16(float** inputs, int16_t* output, int numFrames) {
+// convert float to int16_t with dither, interleave stereo
+void AudioReverb::convertOutput(float** inputs, int16_t* output, int numFrames) {
     __m128 scale = _mm_set1_ps(32768.0f);
 
     int i = 0;
@@ -1899,7 +1899,7 @@ void AudioReverb::convertOutputToInt16(float** inputs, int16_t* output, int numF
 }
 
 // deinterleave stereo
-void AudioReverb::convertInputFromFloat(const float* input, float** outputs, int numFrames) {
+void AudioReverb::convertInput(const float* input, float** outputs, int numFrames) {
 
     int i = 0;
     for (; i < numFrames - 3; i += 4) {
@@ -1918,7 +1918,7 @@ void AudioReverb::convertInputFromFloat(const float* input, float** outputs, int
 }
 
 // interleave stereo
-void AudioReverb::convertOutputToFloat(float** inputs, float* output, int numFrames) {
+void AudioReverb::convertOutput(float** inputs, float* output, int numFrames) {
 
     int i = 0;
     for(; i < numFrames - 3; i += 4) {
@@ -1939,7 +1939,7 @@ void AudioReverb::convertOutputToFloat(float** inputs, float* output, int numFra
 #else
 
 // convert int16_t to float, deinterleave stereo
-void AudioReverb::convertInputFromInt16(const int16_t* input, float** outputs, int numFrames) {
+void AudioReverb::convertInput(const int16_t* input, float** outputs, int numFrames) {
     const float scale = 1/32768.0f;
 
     for (int i = 0; i < numFrames; i++) {
@@ -1957,8 +1957,8 @@ static inline float dither() {
     return (int32_t)(r0 - r1) * (1/65536.0f);
 }
 
-// convert float to int16_t, interleave stereo
-void AudioReverb::convertOutputToInt16(float** inputs, int16_t* output, int numFrames) {
+// convert float to int16_t with dither, interleave stereo
+void AudioReverb::convertOutput(float** inputs, int16_t* output, int numFrames) {
     const float scale = 32768.0f;
 
     for (int i = 0; i < numFrames; i++) {
@@ -1983,7 +1983,7 @@ void AudioReverb::convertOutputToInt16(float** inputs, int16_t* output, int numF
 }
 
 // deinterleave stereo
-void AudioReverb::convertInputFromFloat(const float* input, float** outputs, int numFrames) {
+void AudioReverb::convertInput(const float* input, float** outputs, int numFrames) {
 
     for (int i = 0; i < numFrames; i++) {
         // deinterleave
@@ -1993,7 +1993,7 @@ void AudioReverb::convertInputFromFloat(const float* input, float** outputs, int
 }
 
 // interleave stereo
-void AudioReverb::convertOutputToFloat(float** inputs, float* output, int numFrames) {
+void AudioReverb::convertOutput(float** inputs, float* output, int numFrames) {
 
     for (int i = 0; i < numFrames; i++) {
         // interleave
@@ -2013,11 +2013,11 @@ void AudioReverb::render(const int16_t* input, int16_t* output, int numFrames) {
 
         int n = MIN(numFrames, REVERB_BLOCK);
 
-        convertInputFromInt16(input, _inout, n);
+        convertInput(input, _inout, n);
 
         _impl->process(_inout, _inout, n);
 
-        convertOutputToInt16(_inout, output, n);
+        convertOutput(_inout, output, n);
 
         input += 2 * n;
         output += 2 * n;
@@ -2034,11 +2034,11 @@ void AudioReverb::render(const float* input, float* output, int numFrames) {
 
         int n = MIN(numFrames, REVERB_BLOCK);
 
-        convertInputFromFloat(input, _inout, n);
+        convertInput(input, _inout, n);
 
         _impl->process(_inout, _inout, n);
 
-        convertOutputToFloat(_inout, output, n);
+        convertOutput(_inout, output, n);
 
         input += 2 * n;
         output += 2 * n;

--- a/libraries/audio/src/AudioReverb.h
+++ b/libraries/audio/src/AudioReverb.h
@@ -73,11 +73,11 @@ private:
 
     float* _inout[2];
 
-    void convertInputFromInt16(const int16_t* input, float** outputs, int numFrames);
-    void convertOutputToInt16(float** inputs, int16_t* output, int numFrames);
+    void convertInput(const int16_t* input, float** outputs, int numFrames);
+    void convertOutput(float** inputs, int16_t* output, int numFrames);
 
-    void convertInputFromFloat(const float* input, float** outputs, int numFrames);
-    void convertOutputToFloat(float** inputs, float* output, int numFrames);
+    void convertInput(const float* input, float** outputs, int numFrames);
+    void convertOutput(float** inputs, float* output, int numFrames);
 };
 
 #endif // hifi_AudioReverb_h

--- a/libraries/audio/src/AudioReverb.h
+++ b/libraries/audio/src/AudioReverb.h
@@ -64,13 +64,20 @@ public:
     // interleaved int16_t input/output
     void render(const int16_t* input, int16_t* output, int numFrames);
 
+    // interleaved float input/output
+    void render(const float* input, float* output, int numFrames);
+
 private:
     ReverbImpl *_impl;
     ReverbParameters _params;
 
     float* _inout[2];
+
     void convertInputFromInt16(const int16_t* input, float** outputs, int numFrames);
     void convertOutputToInt16(float** inputs, int16_t* output, int numFrames);
+
+    void convertInputFromFloat(const float* input, float** outputs, int numFrames);
+    void convertOutputToFloat(float** inputs, float* output, int numFrames);
 };
 
 #endif // hifi_AudioReverb_h

--- a/libraries/audio/src/AudioSRC.cpp
+++ b/libraries/audio/src/AudioSRC.cpp
@@ -389,7 +389,7 @@ int AudioSRC::multirateFilter2(const float* input0, const float* input1, float* 
 }
 
 // convert int16_t to float, deinterleave stereo
-void AudioSRC::convertInputFromInt16(const int16_t* input, float** outputs, int numFrames) {
+void AudioSRC::convertInput(const int16_t* input, float** outputs, int numFrames) {
     __m128 scale = _mm_set1_ps(1/32768.0f);
 
     if (_numChannels == 1) {
@@ -467,8 +467,8 @@ static inline __m128 dither4() {
     return _mm_mul_ps(d0, _mm_set1_ps(1/65536.0f));
 }
 
-// convert float to int16_t, interleave stereo
-void AudioSRC::convertOutputToInt16(float** inputs, int16_t* output, int numFrames) {
+// convert float to int16_t with dither, interleave stereo
+void AudioSRC::convertOutput(float** inputs, int16_t* output, int numFrames) {
     __m128 scale = _mm_set1_ps(32768.0f);
 
     if (_numChannels == 1) {
@@ -540,7 +540,7 @@ void AudioSRC::convertOutputToInt16(float** inputs, int16_t* output, int numFram
 }
 
 // deinterleave stereo
-void AudioSRC::convertInputFromFloat(const float* input, float** outputs, int numFrames) {
+void AudioSRC::convertInput(const float* input, float** outputs, int numFrames) {
 
     if (_numChannels == 1) {
 
@@ -566,7 +566,7 @@ void AudioSRC::convertInputFromFloat(const float* input, float** outputs, int nu
 }
 
 // interleave stereo
-void AudioSRC::convertOutputToFloat(float** inputs, float* output, int numFrames) {
+void AudioSRC::convertOutput(float** inputs, float* output, int numFrames) {
 
     if (_numChannels == 1) {
 
@@ -726,7 +726,7 @@ int AudioSRC::multirateFilter2(const float* input0, const float* input1, float* 
 }
 
 // convert int16_t to float, deinterleave stereo
-void AudioSRC::convertInputFromInt16(const int16_t* input, float** outputs, int numFrames) {
+void AudioSRC::convertInput(const int16_t* input, float** outputs, int numFrames) {
     const float scale = 1/32768.0f;
 
     if (_numChannels == 1) {
@@ -750,8 +750,8 @@ static inline float dither() {
     return (int32_t)(r0 - r1) * (1/65536.0f);
 }
 
-// convert float to int16_t, interleave stereo
-void AudioSRC::convertOutputToInt16(float** inputs, int16_t* output, int numFrames) {
+// convert float to int16_t with dither, interleave stereo
+void AudioSRC::convertOutput(float** inputs, int16_t* output, int numFrames) {
     const float scale = 32768.0f;
 
     if (_numChannels == 1) {
@@ -791,7 +791,7 @@ void AudioSRC::convertOutputToInt16(float** inputs, int16_t* output, int numFram
 }
 
 // deinterleave stereo
-void AudioSRC::convertInputFromFloat(const float* input, float** outputs, int numFrames) {
+void AudioSRC::convertInput(const float* input, float** outputs, int numFrames) {
 
     if (_numChannels == 1) {
 
@@ -807,7 +807,7 @@ void AudioSRC::convertInputFromFloat(const float* input, float** outputs, int nu
 }
 
 // interleave stereo
-void AudioSRC::convertOutputToFloat(float** inputs, float* output, int numFrames) {
+void AudioSRC::convertOutput(float** inputs, float* output, int numFrames) {
 
     if (_numChannels == 1) {
 
@@ -953,12 +953,12 @@ int AudioSRC::render(const int16_t* input, int16_t* output, int inputFrames) {
 
         int ni = std::min(inputFrames, _inputBlock);
 
-        convertInputFromInt16(input, _inputs, ni);
+        convertInput(input, _inputs, ni);
 
         int no = render(_inputs, _outputs, ni);
         assert(no <= SRC_BLOCK);
 
-        convertOutputToInt16(_outputs, output, no);
+        convertOutput(_outputs, output, no);
 
         input += _numChannels * ni;
         output += _numChannels * no;
@@ -979,12 +979,12 @@ int AudioSRC::render(const float* input, float* output, int inputFrames) {
 
         int ni = std::min(inputFrames, _inputBlock);
 
-        convertInputFromFloat(input, _inputs, ni);
+        convertInput(input, _inputs, ni);
 
         int no = render(_inputs, _outputs, ni);
         assert(no <= SRC_BLOCK);
 
-        convertOutputToFloat(_outputs, output, no);
+        convertOutput(_outputs, output, no);
 
         input += _numChannels * ni;
         output += _numChannels * no;

--- a/libraries/audio/src/AudioSRC.cpp
+++ b/libraries/audio/src/AudioSRC.cpp
@@ -824,7 +824,7 @@ void AudioSRC::convertOutputToFloat(float** inputs, float* output, int numFrames
 
 #endif
 
-int AudioSRC::processFloat(float** inputs, float** outputs, int inputFrames) {
+int AudioSRC::render(float** inputs, float** outputs, int inputFrames) {
     int outputFrames = 0;
 
     int nh = std::min(_numHistory, inputFrames);    // number of frames from history buffer
@@ -955,7 +955,7 @@ int AudioSRC::render(const int16_t* input, int16_t* output, int inputFrames) {
 
         convertInputFromInt16(input, _inputs, ni);
 
-        int no = processFloat(_inputs, _outputs, ni);
+        int no = render(_inputs, _outputs, ni);
         assert(no <= SRC_BLOCK);
 
         convertOutputToInt16(_outputs, output, no);
@@ -981,7 +981,7 @@ int AudioSRC::render(const float* input, float* output, int inputFrames) {
 
         convertInputFromFloat(input, _inputs, ni);
 
-        int no = processFloat(_inputs, _outputs, ni);
+        int no = render(_inputs, _outputs, ni);
         assert(no <= SRC_BLOCK);
 
         convertOutputToFloat(_outputs, output, no);

--- a/libraries/audio/src/AudioSRC.h
+++ b/libraries/audio/src/AudioSRC.h
@@ -34,7 +34,13 @@ public:
     AudioSRC(int inputSampleRate, int outputSampleRate, int numChannels);
     ~AudioSRC();
 
+    // deinterleaved float input/output (native format)
+    int render(float** inputs, float** outputs, int inputFrames);
+
+    // interleaved int16_t input/output
     int render(const int16_t* input, int16_t* output, int inputFrames);
+
+    // interleaved float input/output
     int render(const float* input, float* output, int inputFrames);
 
     int getMinOutput(int inputFrames);
@@ -81,8 +87,6 @@ private:
 
     void convertInputFromFloat(const float* input, float** outputs, int numFrames);
     void convertOutputToFloat(float** inputs, float* output, int numFrames);
-
-    int processFloat(float** inputs, float** outputs, int inputFrames);
 };
 
 #endif // AudioSRC_h

--- a/libraries/audio/src/AudioSRC.h
+++ b/libraries/audio/src/AudioSRC.h
@@ -82,11 +82,11 @@ private:
     int multirateFilter1_AVX2(const float* input0, float* output0, int inputFrames);
     int multirateFilter2_AVX2(const float* input0, const float* input1, float* output0, float* output1, int inputFrames);
 
-    void convertInputFromInt16(const int16_t* input, float** outputs, int numFrames);
-    void convertOutputToInt16(float** inputs, int16_t* output, int numFrames);
+    void convertInput(const int16_t* input, float** outputs, int numFrames);
+    void convertOutput(float** inputs, int16_t* output, int numFrames);
 
-    void convertInputFromFloat(const float* input, float** outputs, int numFrames);
-    void convertOutputToFloat(float** inputs, float* output, int numFrames);
+    void convertInput(const float* input, float** outputs, int numFrames);
+    void convertOutput(float** inputs, float* output, int numFrames);
 };
 
 #endif // AudioSRC_h

--- a/libraries/audio/src/AudioSRC.h
+++ b/libraries/audio/src/AudioSRC.h
@@ -35,6 +35,7 @@ public:
     ~AudioSRC();
 
     int render(const int16_t* input, int16_t* output, int inputFrames);
+    int render(const float* input, float* output, int inputFrames);
 
     int getMinOutput(int inputFrames);
     int getMaxOutput(int inputFrames);
@@ -77,6 +78,9 @@ private:
 
     void convertInputFromInt16(const int16_t* input, float** outputs, int numFrames);
     void convertOutputToInt16(float** inputs, int16_t* output, int numFrames);
+
+    void convertInputFromFloat(const float* input, float** outputs, int numFrames);
+    void convertOutputToFloat(float** inputs, float* output, int numFrames);
 
     int processFloat(float** inputs, float** outputs, int inputFrames);
 };


### PR DESCRIPTION
Enable Interface to migrate to a floating-point audio pipeline with a peak-limiter at the end. This will remove all hard clipping and improve audio quality.