### PR TITLE
Test support for limiting texture quality

### DIFF
--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -52,8 +52,18 @@ void TextureMap::setLightmapOffsetScale(float offset, float scale) {
     _lightmapOffsetScale.y = scale;
 }
 
+TextureQuality TextureUsage::_quality = TextureQuality::LOW;
+
 const QImage TextureUsage::process2DImageColor(const QImage& srcImage, bool& validAlpha, bool& alphaAsMask) {
     QImage image = srcImage;
+    if (_quality != TextureQuality::NATIVE) {
+        auto maxDimension = static_cast<int>(_quality);
+        auto size = image.size();
+        if (size.width() > maxDimension || size.height() > maxDimension) {
+            auto newSize = QSize(std::min(size.width(), maxDimension), std::min(size.height(), maxDimension));
+            image = image.scaled(newSize);
+        }
+    }
     validAlpha = false;
     alphaAsMask = true;
     const uint8 OPAQUE_ALPHA = 255;
@@ -202,6 +212,16 @@ gpu::Texture* TextureUsage::createNormalTextureFromNormalImage(const QImage& src
         image = image.convertToFormat(QImage::Format_RGB888);
     }
 
+    // FIXME we probably need special scaling functionality for normal maps.
+    if (_quality != TextureQuality::NATIVE) {
+        auto maxDimension = static_cast<int>(_quality);
+        auto size = image.size();
+        if (size.width() > maxDimension || size.height() > maxDimension) {
+            auto newSize = QSize(std::min(size.width(), maxDimension), std::min(size.height(), maxDimension));
+            image = image.scaled(newSize);
+        }
+    }
+
     gpu::Texture* theTexture = nullptr;
     if ((image.width() > 0) && (image.height() > 0)) {
         
@@ -233,6 +253,16 @@ gpu::Texture* TextureUsage::createNormalTextureFromBumpImage(const QImage& srcIm
     
     if (image.format() != QImage::Format_RGB888) {
         image = image.convertToFormat(QImage::Format_RGB888);
+    }
+
+    // FIXME we probably need special scaling functionality for normal maps.
+    if (_quality != TextureQuality::NATIVE) {
+        auto maxDimension = static_cast<int>(_quality);
+        auto size = image.size();
+        if (size.width() > maxDimension || size.height() > maxDimension) {
+            auto newSize = QSize(std::min(size.width(), maxDimension), std::min(size.height(), maxDimension));
+            image = image.scaled(newSize);
+        }
     }
 
     // PR 5540 by AlessandroSigna integrated here as a specialized TextureLoader for bumpmaps
@@ -311,6 +341,16 @@ gpu::Texture* TextureUsage::createRoughnessTextureFromImage(const QImage& srcIma
         }
     }
 
+    // FIXME we probably need special scaling functionality for normal maps.
+    if (_quality != TextureQuality::NATIVE) {
+        auto maxDimension = static_cast<int>(_quality);
+        auto size = image.size();
+        if (size.width() > maxDimension || size.height() > maxDimension) {
+            auto newSize = QSize(std::min(size.width(), maxDimension), std::min(size.height(), maxDimension));
+            image = image.scaled(newSize);
+        }
+    }
+
     image = image.convertToFormat(QImage::Format_Grayscale8);
 
     gpu::Texture* theTexture = nullptr;
@@ -341,6 +381,16 @@ gpu::Texture* TextureUsage::createRoughnessTextureFromGlossImage(const QImage& s
     } else {
         if (image.format() != QImage::Format_ARGB32) {
             image = image.convertToFormat(QImage::Format_ARGB32);
+        }
+    }
+
+    // FIXME we probably need special scaling functionality for normal maps.
+    if (_quality != TextureQuality::NATIVE) {
+        auto maxDimension = static_cast<int>(_quality);
+        auto size = image.size();
+        if (size.width() > maxDimension || size.height() > maxDimension) {
+            auto newSize = QSize(std::min(size.width(), maxDimension), std::min(size.height(), maxDimension));
+            image = image.scaled(newSize);
         }
     }
 
@@ -378,6 +428,16 @@ gpu::Texture* TextureUsage::createMetallicTextureFromImage(const QImage& srcImag
     } else {
         if (image.format() != QImage::Format_ARGB32) {
             image = image.convertToFormat(QImage::Format_ARGB32);
+        }
+    }
+
+    // FIXME we probably need special scaling functionality for normal maps.
+    if (_quality != TextureQuality::NATIVE) {
+        auto maxDimension = static_cast<int>(_quality);
+        auto size = image.size();
+        if (size.width() > maxDimension || size.height() > maxDimension) {
+            auto newSize = QSize(std::min(size.width(), maxDimension), std::min(size.height(), maxDimension));
+            image = image.scaled(newSize);
         }
     }
 

--- a/libraries/model/src/model/TextureMap.h
+++ b/libraries/model/src/model/TextureMap.h
@@ -24,13 +24,23 @@ namespace model {
 
 typedef glm::vec3 Color;
 
+enum class TextureQuality {
+    LOWEST = 256,
+    LOW = 512,
+    MEDIUM = 1024,
+    HIGH = 2048, 
+    HIGHER = 4096,
+    ULTRA = 8192,
+    NATIVE = ~0,
+};
+
 class TextureUsage {
 public:
     gpu::Texture::Type _type{ gpu::Texture::TEX_2D };
     Material::MapFlags _materialUsage{ MaterialKey::ALBEDO_MAP };
 
     int _environmentUsage = 0;
-
+    static TextureQuality _quality;
     static gpu::Texture* create2DTextureFromImage(const QImage& image, const std::string& srcImageName);
     static gpu::Texture* createAlbedoTextureFromImage(const QImage& image, const std::string& srcImageName);
     static gpu::Texture* createEmissiveTextureFromImage(const QImage& image, const std::string& srcImageName);


### PR DESCRIPTION
Test limiting the texture quality to determine how much of an impact it has on lower end machines.  This PR limits textures to 512x512 at the file loading level.  