### PR TITLE
Fix export entities by region

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3049,17 +3049,20 @@ bool Application::exportEntities(const QString& filename, const QVector<EntityIt
 }
 
 bool Application::exportEntities(const QString& filename, float x, float y, float z, float scale) {
-    glm::vec3 offset(x, y, z);
+    glm::vec3 center(x, y, z);
+    glm::vec3 minCorner = center - vec3(scale);
+    float cubeSize = scale * 2;
+    AACube boundingCube(minCorner, cubeSize);
     QVector<EntityItemPointer> entities;
     QVector<EntityItemID> ids;
     auto entityTree = getEntities()->getTree();
     entityTree->withReadLock([&] {
-        entityTree->findEntities(AACube(offset, scale), entities);
+        entityTree->findEntities(boundingCube, entities);
         foreach(EntityItemPointer entity, entities) {
             ids << entity->getEntityItemID();
         }
     });
-    return exportEntities(filename, ids, &offset);
+    return exportEntities(filename, ids, &center);
 }
 
 void Application::loadSettings() {


### PR DESCRIPTION
The existing code to export entities takes a point in space and a point called 'scale'.  However, it's behavior is non-intuitive, as the exported region treats the x,y,z value as a minimum corner and the 'scale' is the value added to each to get the upper corner.  This is apparently a holdover from the days of not supporting negative coordinates.  

This PR modifies the export function to treat the x,y,z as a center point and the scale as a distance in each dimension to the corners of the bounding box.  