### PR TITLE
Fix model overlays not correctly scaling

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -45,7 +45,7 @@ void ModelOverlay::update(float deltatime) {
         _updateModel = false;
         
         _model->setSnapModelToCenter(true);
-        _model->setScale(getDimensions());
+        _model->setScaleToFit(true, getDimensions());
         _model->setRotation(getRotation());
         _model->setTranslation(getPosition());
         _model->setURL(_url);
@@ -100,7 +100,6 @@ void ModelOverlay::setProperties(const QVariantMap& properties) {
         if (newScale.x <= 0 || newScale.y <= 0 || newScale.z <= 0) {
             setDimensions(scale);
         } else {
-            _model->setScaleToFit(true, getDimensions());
             _updateModel = true;
         }
     }


### PR DESCRIPTION
James had me look at an issue he was having with Model Overlays and I noticed that models were not being scaled to fit correctly. It looks the intent was to scale the model extents to fit the dimensions, but the effect was being reset later.