### PR TITLE
Optimize updateModelBounds

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -342,16 +342,23 @@ void RenderableModelEntityItem::updateModelBounds() {
     if (!hasModel() || !_model) {
         return;
     }
+    if (!_dimensionsInitialized || !_model->isActive()) {
+        return;
+    }
+
+        
     bool movingOrAnimating = isMovingRelativeToParent() || isAnimatingSomething();
     glm::vec3 dimensions = getDimensions();
-    if ((movingOrAnimating ||
+    bool success;
+    auto transform = getTransform(success);
+
+    if (movingOrAnimating ||
          _needsInitialSimulation ||
          _needsJointSimulation ||
-         _model->getTranslation() != getPosition() ||
+         _model->getTranslation() != transform.getTranslation() ||
          _model->getScaleToFitDimensions() != dimensions ||
-         _model->getRotation() != getRotation() ||
-         _model->getRegistrationPoint() != getRegistrationPoint())
-        && _model->isActive() && _dimensionsInitialized) {
+         _model->getRotation() != transform.getRotation() ||
+         _model->getRegistrationPoint() != getRegistrationPoint()) {
         doInitialModelSimulation();
         _needsJointSimulation = false;
     }


### PR DESCRIPTION
Profiling the Playa scene in my new performance tool, I find that up to 15% of our time is spent inside `RenderableModelEntityItem::updateModelBounds`.  This function, and the functions it relies on could use some examination to see if they can be optimized, and also to determine if it's really necessary to call it every single frame.  

However, this PR makes some minor tweaks to the code to add some early return conditions that should avoid some of the expensive calls if possible and to optimize the checking of the transform to ensure that we don't needlessly call `getTransform()` multiple times (through individual calls to `getRotation` and `getPosition`.

My local testing with playa content shows a 5-10 FPS improvment with these changes.  

Additional examination should be done to this function and it's called functions to see if there are other easy optimizations as well.