### PR TITLE
Ensure newly shown windows are popped to the top of the zorder

### DIFF
--- a/interface/resources/qml/windows/Window.qml
+++ b/interface/resources/qml/windows/Window.qml
@@ -209,6 +209,9 @@ Fadable {
 
             var targetVisibility = getTargetVisibility();
             if (targetVisibility === visible) {
+                if (force) {
+                    window.raise();
+                }
                 return;
             }
 


### PR DESCRIPTION
## Testing

Start the running scripts dialog.  Select 'From URL' or 'From Disk'.  In the production build a new window will appear behind the running scripts dialog.  In this build, newly created windows should always be placed on the top of the z-order.