### PR TITLE
Fix MyAvatar name and url accessors.

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -212,8 +212,8 @@ public:
     virtual void clearJointsData() override;
 
     Q_INVOKABLE void useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelName = QString());
-    Q_INVOKABLE const QUrl& getFullAvatarURLFromPreferences() const { return _fullAvatarURLFromPreferences; }
-    Q_INVOKABLE const QString& getFullAvatarModelName() const { return _fullAvatarModelName; }
+    Q_INVOKABLE QUrl getFullAvatarURLFromPreferences() const { return _fullAvatarURLFromPreferences; }
+    Q_INVOKABLE QString getFullAvatarModelName() const { return _fullAvatarModelName; }
     void resetFullAvatarURL();
 
 


### PR DESCRIPTION
Q_INVOKABLE does not support returning references.
MyAvatar.getFullAvatarURLFromPreferences() now returns a QUrl instead of a reference.
MyAvatar.getFullAvatarModelName() now returns a QString instead of reference.

This should fix the JS API for these methods, they will now receive a JS string instead of undefined.