### PR TITLE
Fix rendering of overlay spheres with alpha

### DIFF
--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -58,7 +58,7 @@ void Sphere3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Sphere3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withOwnPipeline();
+    auto builder = render::ShapeKey::Builder();
     if (getAlpha() != 1.0f) {
         builder.withTranslucent();
     }


### PR DESCRIPTION
3D overlay spheres were always rendering with full alpha, regardless of how they were created.  This PR should fix.  

## Testing

When running [this script](http://s3.amazonaws.com/DreamingContent/scripts/tests/overlays.js) the top blue sphere should be transparent.  In production it is not, but in this build it is.