### PR TITLE
Fix orientation being reset to 0,0,0,1

### DIFF
--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -564,10 +564,10 @@ bool AddressManager::handleViewpoint(const QString& viewpointString, bool should
             if (viewpointString[positionRegex.matchedLength() - 1] == QChar('/')
                 && orientationRegex.indexIn(viewpointString, positionRegex.matchedLength() - 1) != -1) {
 
-                glm::quat newOrientation = glm::normalize(glm::quat(orientationRegex.cap(4).toFloat(),
-                                                                    orientationRegex.cap(1).toFloat(),
-                                                                    orientationRegex.cap(2).toFloat(),
-                                                                    orientationRegex.cap(3).toFloat()));
+                newOrientation = glm::normalize(glm::quat(orientationRegex.cap(4).toFloat(),
+                                                          orientationRegex.cap(1).toFloat(),
+                                                          orientationRegex.cap(2).toFloat(),
+                                                          orientationRegex.cap(3).toFloat()));
 
                 if (!isNaN(newOrientation.x) && !isNaN(newOrientation.y) && !isNaN(newOrientation.z)
                     && !isNaN(newOrientation.w)) {


### PR DESCRIPTION
Avatar orientation was being reset to 0,0,0,1 every time you relog or travel to a different place.  Orientation is now once again persisted across relogs, and set to that place's preferred rotation upon traveling.

Resolves [FogBugz case 1152](https://highfidelity.fogbugz.com/f/cases/1152/On-relogging-or-teleporting-to-placename-my-orientation-is-not-correct).

### Testing
1. Startup sandbox
2. Go to localhost
3. Your "yaw" as shown in stats should be ~59 degrees
4. Turn the camera so your yaw is now a different value
5. Restart interface
6. Your yaw should be the same as when you exited, (not 0 or 59)
7. Collect underpants
8. ?
9. Profit