### PR TITLE
Support for scale property on model overlays

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -17,7 +17,7 @@
 
 class Base3DOverlay : public Overlay {
     Q_OBJECT
-    
+
 public:
     Base3DOverlay();
     Base3DOverlay(const Base3DOverlay* base3DOverlay);
@@ -27,10 +27,10 @@ public:
     const glm::vec3& getPosition() const { return _transform.getTranslation(); }
     const glm::quat& getRotation() const { return _transform.getRotation(); }
     const glm::vec3& getScale() const { return _transform.getScale(); }
-   
+
     // TODO: consider implementing registration points in this class
     const glm::vec3& getCenter() const { return getPosition(); }
-    
+
     float getLineWidth() const { return _lineWidth; }
     bool getIsSolid() const { return _isSolid; }
     bool getIsDashedLine() const { return _isDashedLine; }
@@ -43,7 +43,7 @@ public:
     void setRotation(const glm::quat& value) { _transform.setRotation(value); }
     void setScale(float value) { _transform.setScale(value); }
     void setScale(const glm::vec3& value) { _transform.setScale(value); }
-    
+
     void setLineWidth(float lineWidth) { _lineWidth = lineWidth; }
     void setIsSolid(bool isSolid) { _isSolid = isSolid; }
     void setIsDashedLine(bool isDashedLine) { _isDashedLine = isDashedLine; }
@@ -55,22 +55,22 @@ public:
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
 
-    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
+    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
                                         BoxFace& face, glm::vec3& surfaceNormal);
 
-    virtual bool findRayIntersectionExtraInfo(const glm::vec3& origin, const glm::vec3& direction, 
+    virtual bool findRayIntersectionExtraInfo(const glm::vec3& origin, const glm::vec3& direction,
                                         float& distance, BoxFace& face, glm::vec3& surfaceNormal, QString& extraInfo) {
         return findRayIntersection(origin, direction, distance, face, surfaceNormal);
     }
 
 protected:
     Transform _transform;
-    
+
     float _lineWidth;
     bool _isSolid;
     bool _isDashedLine;
     bool _ignoreRayIntersection;
     bool _drawInFront;
 };
- 
+
 #endif // hifi_Base3DOverlay_h

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -106,9 +106,7 @@ void ModelOverlay::setProperties(const QVariantMap& properties) {
     } else if (scale.isValid()) {
         // if "scale" property is set but "dimentions" is not.
         // do NOT scale to fit.
-        if (scale.isValid()) {
-            _scaleToFit = false;
-        }
+        _scaleToFit = false;
     }
 
     if (origPosition != getPosition() || origRotation != getRotation() || origDimensions != getDimensions() || origScale != getScale()) {

--- a/interface/src/ui/overlays/ModelOverlay.h
+++ b/interface/src/ui/overlays/ModelOverlay.h
@@ -43,9 +43,10 @@ private:
 
     ModelPointer _model;
     QVariantMap _modelTextures;
-    
+
     QUrl _url;
-    bool _updateModel;
+    bool _updateModel = { false };
+    bool _scaleToFit = { false };
 };
 
 #endif // hifi_ModelOverlay_h

--- a/interface/src/ui/overlays/Volume3DOverlay.cpp
+++ b/interface/src/ui/overlays/Volume3DOverlay.cpp
@@ -22,7 +22,7 @@ AABox Volume3DOverlay::getBounds() const {
     auto extents = Extents{_localBoundingBox};
     extents.rotate(getRotation());
     extents.shiftBy(getPosition());
-    
+
     return AABox(extents);
 }
 
@@ -31,7 +31,7 @@ void Volume3DOverlay::setProperties(const QVariantMap& properties) {
 
     auto dimensions = properties["dimensions"];
 
-    // if "dimensions" property was not there, check to see if they included aliases: scale
+    // if "dimensions" property was not there, check to see if they included aliases: scale, size
     if (!dimensions.isValid()) {
         dimensions = properties["scale"];
         if (!dimensions.isValid()) {
@@ -57,7 +57,7 @@ bool Volume3DOverlay::findRayIntersection(const glm::vec3& origin, const glm::ve
     // extents is the entity relative, scaled, centered extents of the entity
     glm::mat4 worldToEntityMatrix;
     _transform.getInverseMatrix(worldToEntityMatrix);
-    
+
     glm::vec3 overlayFrameOrigin = glm::vec3(worldToEntityMatrix * glm::vec4(origin, 1.0f));
     glm::vec3 overlayFrameDirection = glm::vec3(worldToEntityMatrix * glm::vec4(direction, 0.0f));
 

--- a/interface/src/ui/overlays/Volume3DOverlay.h
+++ b/interface/src/ui/overlays/Volume3DOverlay.h
@@ -15,13 +15,13 @@
 
 class Volume3DOverlay : public Base3DOverlay {
     Q_OBJECT
-    
+
 public:
     Volume3DOverlay() {}
     Volume3DOverlay(const Volume3DOverlay* volume3DOverlay);
-    
+
     virtual AABox getBounds() const override;
-    
+
     const glm::vec3& getDimensions() const { return _localBoundingBox.getDimensions(); }
     void setDimensions(float value) { _localBoundingBox.setBox(glm::vec3(-value / 2.0f), value); }
     void setDimensions(const glm::vec3& value) { _localBoundingBox.setBox(-value / 2.0f, value); }
@@ -29,13 +29,13 @@ public:
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
 
-    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
-                                        BoxFace& face, glm::vec3& surfaceNormal) override;
-    
+    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
+                                     BoxFace& face, glm::vec3& surfaceNormal) override;
+
 protected:
     // Centered local bounding box
     AABox _localBoundingBox{ vec3(0.0f), 1.0f };
 };
 
- 
+
 #endif // hifi_Volume3DOverlay_h


### PR DESCRIPTION
If "scale" property is present but "dimensions" are not, the model's natural dimensions will be scaled by the scale property.

If only the "dimensions" property is present, the model will be automatically scaled to fit the dimensions specified.

If both properties are present, the model will still be "scale to fit" but the dimension will be scaled by the scale factor.

For example:

If a model is loaded that is 2cm tall, is loaded with no "dimensions" or "scale" properties.
It will be displayed as 2cm tall.

    {"scale": 2}

The above properties will result in a model that is 4cm tall.

    {"dimensions": 1}

This will result in a model that is 1cm tall.

    {"scale": 2, "dimensions": 2}

Will result in a model that is 2cm tall.