### PR TITLE
fix razor blades in your ears when switching between domains with no codecs installed

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -534,14 +534,18 @@ void AudioClient::handleSelectedAudioFormat(QSharedPointer<ReceivedMessage> mess
     _selectedCodecName = message->readString();
 
     qDebug() << "Selected Codec:" << _selectedCodecName;
+
+    // release any old codec encoder/decoder first...
+    if (_codec && _encoder) {
+        _codec->releaseEncoder(_encoder);
+        _encoder = nullptr;
+        _codec = nullptr;
+    }
+    _receivedAudioStream.cleanupCodec();
+
     auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
     for (auto& plugin : codecPlugins) {
         if (_selectedCodecName == plugin->getName()) {
-            // release any old codec encoder/decoder first...
-            if (_codec && _encoder) {
-                _codec->releaseEncoder(_encoder);
-                _encoder = nullptr;
-            }
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO); 
             _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);
@@ -821,7 +825,6 @@ void AudioClient::handleAudioInput() {
         audioTransform.setRotation(_orientationGetter());
         // FIXME find a way to properly handle both playback audio and user audio concurrently
 
-        // TODO - codec encode goes here
         QByteArray decocedBuffer(reinterpret_cast<char*>(networkAudioSamples), numNetworkBytes);
         QByteArray encodedBuffer;
         if (_encoder) {
@@ -840,7 +843,6 @@ void AudioClient::handleRecordedAudioInput(const QByteArray& audio) {
     audioTransform.setTranslation(_positionGetter());
     audioTransform.setRotation(_orientationGetter());
 
-    // TODO - codec encode goes here
     QByteArray encodedBuffer;
     if (_encoder) {
         _encoder->encode(audio, encodedBuffer);


### PR DESCRIPTION
Test plan:
- running this build on windows
- go "home" - notice audio is OK
- go to "dev-demo" -- notice audio is still OK
- go "home" - audio still OK

on the current dev-download - you will get razor blades in your ears when you go to dev-demo... this fixes that bug.