### PR TITLE
Menu & hand controller polish

### DIFF
--- a/interface/resources/controllers/hydra.json
+++ b/interface/resources/controllers/hydra.json
@@ -3,9 +3,17 @@
     "channels": [
         { "from": "Hydra.LY", "filters": "invert", "to": "Standard.LY" }, 
         { "from": "Hydra.LX", "to": "Standard.LX" },
+        { "from": "Hydra.LT", "to": "Standard.LTClick",  
+            "peek": true,
+            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
+        },
         { "from": "Hydra.LT", "to": "Standard.LT" }, 
         { "from": "Hydra.RY", "filters": "invert", "to": "Standard.RY" }, 
         { "from": "Hydra.RX", "to": "Standard.RX" },
+        { "from": "Hydra.RT", "to": "Standard.RTClick",  
+            "peek": true,
+            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
+        },
         { "from": "Hydra.RT", "to": "Standard.RT" }, 
 
         { "from": "Hydra.LB", "to": "Standard.LB" }, 

--- a/interface/resources/controllers/oculus_touch.json
+++ b/interface/resources/controllers/oculus_touch.json
@@ -8,6 +8,10 @@
 
         { "from": "OculusTouch.LY", "filters": "invert", "to": "Standard.LY" },
         { "from": "OculusTouch.LX", "to": "Standard.LX" },
+        { "from": "OculusTouch.LT", "to": "Standard.LTClick",  
+            "peek": true,
+            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
+        },
         { "from": "OculusTouch.LT", "to": "Standard.LT" },
         { "from": "OculusTouch.LS", "to": "Standard.LS" },
         { "from": "OculusTouch.LeftGrip", "to": "Standard.LeftGrip" },
@@ -15,6 +19,10 @@
 
         { "from": "OculusTouch.RY", "filters": "invert", "to": "Standard.RY" },
         { "from": "OculusTouch.RX", "to": "Standard.RX" },
+        { "from": "OculusTouch.RT", "to": "Standard.RTClick",  
+            "peek": true,
+            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
+        },
         { "from": "OculusTouch.RT", "to": "Standard.RT" },
         { "from": "OculusTouch.RS", "to": "Standard.RS" },
         { "from": "OculusTouch.RightGrip", "to": "Standard.RightGrip" },

--- a/interface/resources/controllers/standard_navigation.json
+++ b/interface/resources/controllers/standard_navigation.json
@@ -10,14 +10,7 @@
         { "from": "Standard.RB", "to": "Actions.UiNavGroup" },
         { "from": [ "Standard.A", "Standard.X" ], "to": "Actions.UiNavSelect" },
         { "from": [ "Standard.B", "Standard.Y" ], "to": "Actions.UiNavBack" },
-        { 
-            "from": [ "Standard.RT", "Standard.LT" ], 
-            "to": "Actions.UiNavSelect", 
-            "filters": [
-                { "type": "deadZone", "min": 0.5 },
-                "constrainToInteger"
-            ]
-        },
+        { "from": [ "Standard.RTClick", "Standard.LTClick" ], "to": "Actions.UiNavSelect" },
         {
             "from": "Standard.LX", "to": "Actions.UiNavLateral",
             "filters": [

--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -9,6 +9,8 @@
                 { "type": "deadZone", "min": 0.05 }
             ]
         },
+        { "from": "Vive.LTClick", "to": "Standard.LTClick" },
+
         { "from": "Vive.LeftGrip", "to": "Standard.LeftGrip" },
         { "from": "Vive.LS", "to": "Standard.LS" },
         { "from": "Vive.LSTouch", "to": "Standard.LSTouch" },
@@ -21,6 +23,8 @@
                 { "type": "deadZone", "min": 0.05 }
             ]
         },
+        { "from": "Vive.RTClick", "to": "Standard.RTClick" },
+
         { "from": "Vive.RightGrip", "to": "Standard.RightGrip" },
         { "from": "Vive.RS", "to": "Standard.RS" },
         { "from": "Vive.RSTouch", "to": "Standard.RSTouch" },

--- a/interface/resources/qml/menus/VrMenuView.qml
+++ b/interface/resources/qml/menus/VrMenuView.qml
@@ -45,6 +45,7 @@ FocusScope {
         onVisibleChanged: recalcSize();
         onCountChanged: recalcSize();
         focus: true
+        highlightMoveDuration: 0
 
         highlight: Rectangle {
             anchors {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4705,6 +4705,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     qScriptRegisterMetaType(scriptEngine, RayToOverlayIntersectionResultToScriptValue,
                             RayToOverlayIntersectionResultFromScriptValue);
 
+    scriptEngine->registerGlobalObject("OffscreenFlags", DependencyManager::get<OffscreenUi>()->getFlags());
     scriptEngine->registerGlobalObject("Desktop", DependencyManager::get<DesktopScriptingInterface>().data());
     scriptEngine->registerGlobalObject("Toolbars", DependencyManager::get<ToolbarScriptingInterface>().data());
 

--- a/libraries/controllers/src/controllers/StandardController.cpp
+++ b/libraries/controllers/src/controllers/StandardController.cpp
@@ -65,6 +65,8 @@ Input::NamedVector StandardController::getAvailableInputs() const {
         // Triggers
         makePair(LT, "LT"),
         makePair(RT, "RT"),
+        makePair(LT_CLICK, "LTClick"),
+        makePair(RT_CLICK, "RTClick"),
 
         // Finger abstractions
         makePair(LEFT_PRIMARY_THUMB, "LeftPrimaryThumb"),

--- a/libraries/controllers/src/controllers/StandardControls.h
+++ b/libraries/controllers/src/controllers/StandardControls.h
@@ -46,6 +46,7 @@ namespace controller {
         LS_CENTER,
         LS_X,
         LS_Y,
+        LT_CLICK,
 
         RIGHT_PRIMARY_THUMB,
         RIGHT_SECONDARY_THUMB,
@@ -56,6 +57,7 @@ namespace controller {
         RS_CENTER,
         RS_X,
         RS_Y,
+        RT_CLICK,
 
         LEFT_PRIMARY_INDEX,
         LEFT_SECONDARY_INDEX,

--- a/libraries/controllers/src/controllers/impl/RouteBuilderProxy.cpp
+++ b/libraries/controllers/src/controllers/impl/RouteBuilderProxy.cpp
@@ -26,6 +26,7 @@
 #include "filters/InvertFilter.h"
 #include "filters/PulseFilter.h"
 #include "filters/ScaleFilter.h"
+#include "conditionals/AndConditional.h"
 
 using namespace controller;
 
@@ -58,12 +59,22 @@ QObject* RouteBuilderProxy::peek(bool enable) {
 }
 
 QObject* RouteBuilderProxy::when(const QScriptValue& expression) {
-    _route->conditional = _parent.conditionalFor(expression);
+    auto newConditional = _parent.conditionalFor(expression);
+    if (_route->conditional) {
+        _route->conditional = ConditionalPointer(new AndConditional(_route->conditional, newConditional));
+    } else {
+        _route->conditional = newConditional;
+    }
     return this;
 }
 
 QObject* RouteBuilderProxy::whenQml(const QJSValue& expression) {
-    _route->conditional = _parent.conditionalFor(expression);
+    auto newConditional = _parent.conditionalFor(expression);
+    if (_route->conditional) {
+        _route->conditional = ConditionalPointer(new AndConditional(_route->conditional, newConditional));
+    } else {
+        _route->conditional = newConditional;
+    }
     return this;
 }
 

--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -55,7 +55,7 @@ public:
 
     bool eventFilter(QObject* originalDestination, QEvent* event) override;
     void addMenuInitializer(std::function<void(VrMenu*)> f);
-
+    QObject* getFlags();
     QQuickItem* getDesktop();
     QQuickItem* getToolWindow();
 

--- a/plugins/oculus/src/OculusControllerManager.cpp
+++ b/plugins/oculus/src/OculusControllerManager.cpp
@@ -199,19 +199,11 @@ void OculusControllerManager::TouchDevice::update(float deltaTime, const control
     _axisStateMap[LX] = inputState.Thumbstick[ovrHand_Left].x;
     _axisStateMap[LY] = inputState.Thumbstick[ovrHand_Left].y;
     _axisStateMap[LT] = inputState.IndexTrigger[ovrHand_Left];
-    // FIXME add hysteresis?  Move to JSON config?
-    if (inputState.IndexTrigger[ovrHand_Left] > 0.9) {
-        _buttonPressedMap.insert(LT_CLICK);
-    }
     _axisStateMap[LEFT_GRIP] = inputState.HandTrigger[ovrHand_Left];
 
     _axisStateMap[RX] = inputState.Thumbstick[ovrHand_Right].x;
     _axisStateMap[RY] = inputState.Thumbstick[ovrHand_Right].y;
     _axisStateMap[RT] = inputState.IndexTrigger[ovrHand_Right];
-    // FIXME add hysteresis?  Move to JSON config?
-    if (inputState.IndexTrigger[ovrHand_Right] > 0.9) {
-        _buttonPressedMap.insert(RT_CLICK);
-    }
     _axisStateMap[RIGHT_GRIP] = inputState.HandTrigger[ovrHand_Right];
 
     // Buttons

--- a/plugins/oculus/src/OculusControllerManager.cpp
+++ b/plugins/oculus/src/OculusControllerManager.cpp
@@ -199,11 +199,19 @@ void OculusControllerManager::TouchDevice::update(float deltaTime, const control
     _axisStateMap[LX] = inputState.Thumbstick[ovrHand_Left].x;
     _axisStateMap[LY] = inputState.Thumbstick[ovrHand_Left].y;
     _axisStateMap[LT] = inputState.IndexTrigger[ovrHand_Left];
+    // FIXME add hysteresis?  Move to JSON config?
+    if (inputState.IndexTrigger[ovrHand_Left] > 0.9) {
+        _buttonPressedMap.insert(LT_CLICK);
+    }
     _axisStateMap[LEFT_GRIP] = inputState.HandTrigger[ovrHand_Left];
 
     _axisStateMap[RX] = inputState.Thumbstick[ovrHand_Right].x;
     _axisStateMap[RY] = inputState.Thumbstick[ovrHand_Right].y;
     _axisStateMap[RT] = inputState.IndexTrigger[ovrHand_Right];
+    // FIXME add hysteresis?  Move to JSON config?
+    if (inputState.IndexTrigger[ovrHand_Right] > 0.9) {
+        _buttonPressedMap.insert(RT_CLICK);
+    }
     _axisStateMap[RIGHT_GRIP] = inputState.HandTrigger[ovrHand_Right];
 
     // Buttons

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -11,9 +11,6 @@
 
 #include "ViveControllerManager.h"
 
-#include <sstream>
-#include <QtCore/QDebug>
-
 #include <PerfStat.h>
 #include <PathUtils.h>
 #include <GeometryCache.h>
@@ -288,9 +285,6 @@ void ViveControllerManager::InputDevice::handleHandController(float deltaTime, u
 
         vr::VRControllerState_t controllerState = vr::VRControllerState_t();
         if (_system->GetControllerState(deviceIndex, &controllerState)) {
-            //std::stringstream stream;
-            //stream << std::hex << controllerState.ulButtonPressed << " " << std::hex << controllerState.ulButtonTouched;
-            //qDebug() << deviceIndex << " " << stream.str().c_str() << controllerState.rAxis[1].x;
             // process each button
             for (uint32_t i = 0; i < vr::k_EButton_Max; ++i) {
                 auto mask = vr::ButtonMaskFromId((vr::EVRButtonId)i);

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -29,9 +29,8 @@ var WANT_DEBUG_SEARCH_NAME = null;
 var SPARK_MODEL_SCALE_FACTOR = 0.75;
 
 var TRIGGER_SMOOTH_RATIO = 0.1; //  Time averaging of trigger - 0.0 disables smoothing
-var TRIGGER_ON_VALUE = 0.4; //  Squeezed just enough to activate search or near grab
-var TRIGGER_GRAB_VALUE = 0.85; //  Squeezed far enough to complete distant grab
-var TRIGGER_OFF_VALUE = 0.15;
+var TRIGGER_OFF_VALUE = 0.1;
+var TRIGGER_ON_VALUE = TRIGGER_OFF_VALUE + 0.05; //  Squeezed just enough to activate search or near grab
 
 var BUMPER_ON_VALUE = 0.5;
 
@@ -376,6 +375,7 @@ function MyController(hand) {
     this.entityActivated = false;
 
     this.triggerValue = 0; // rolling average of trigger value
+    this.triggerClicked = false;
     this.rawTriggerValue = 0;
     this.rawSecondaryValue = 0;
     this.rawThumbValue = 0;
@@ -835,6 +835,10 @@ function MyController(hand) {
         _this.rawTriggerValue = value;
     };
 
+    this.triggerClick = function (value) {
+        _this.triggerClicked = value;
+    };
+
     this.secondaryPress = function (value) {
         _this.rawSecondaryValue = value;
     };
@@ -847,7 +851,7 @@ function MyController(hand) {
     };
 
     this.triggerSmoothedGrab = function () {
-        return this.triggerValue > TRIGGER_GRAB_VALUE;
+        return this.triggerClicked;
     };
 
     this.triggerSmoothedSqueezed = function () {
@@ -2225,7 +2229,10 @@ var MAPPING_NAME = "com.highfidelity.handControllerGrab";
 
 var mapping = Controller.newMapping(MAPPING_NAME);
 mapping.from([Controller.Standard.RT]).peek().to(rightController.triggerPress);
+mapping.from([Controller.Standard.RTClick]).peek().to(rightController.triggerClick);
+
 mapping.from([Controller.Standard.LT]).peek().to(leftController.triggerPress);
+mapping.from([Controller.Standard.LTClick]).peek().to(leftController.triggerClick);
 
 mapping.from([Controller.Standard.RB]).peek().to(rightController.secondaryPress);
 mapping.from([Controller.Standard.LB]).peek().to(leftController.secondaryPress);

--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -49,11 +49,15 @@ function Trigger(label) {
     var that = this;
     that.label = label;
     that.TRIGGER_SMOOTH_RATIO = 0.1; //  Time averaging of trigger - 0.0 disables smoothing
-    that.TRIGGER_ON_VALUE = 0.4;     //  Squeezed just enough to activate search or near grab
-    that.TRIGGER_GRAB_VALUE = 0.85;  //  Squeezed far enough to complete distant grab
-    that.TRIGGER_OFF_VALUE = 0.15;
+    that.TRIGGER_OFF_VALUE = 0.10;
+    that.TRIGGER_ON_VALUE = that.TRIGGER_OFF_VALUE + 0.05;     //  Squeezed just enough to activate search or near grab
     that.rawTriggerValue = 0;
     that.triggerValue = 0;           // rolling average of trigger value
+    that.triggerClicked = false;
+    that.triggerClick = function (value) {
+        print("Trigger clicked is now " + value);
+        that.triggerClicked = value;
+    };
     that.triggerPress = function (value) {
         that.rawTriggerValue = value;
     };
@@ -64,8 +68,8 @@ function Trigger(label) {
             (triggerValue * (1.0 - that.TRIGGER_SMOOTH_RATIO));
     };
     // Current smoothed state, without hysteresis. Answering booleans.
-    that.triggerSmoothedGrab = function () {
-        return that.triggerValue > that.TRIGGER_GRAB_VALUE;
+    that.triggerSmoothedClick = function () {
+        return that.triggerClicked;
     };
     that.triggerSmoothedSqueezed = function () {
         return that.triggerValue > that.TRIGGER_ON_VALUE;
@@ -81,7 +85,7 @@ function Trigger(label) {
         that.updateSmoothedTrigger();
 
         // The first two are independent of previous state:
-        if (that.triggerSmoothedGrab()) {
+        if (that.triggerSmoothedClick()) {
             state = 'full';
         } else if (that.triggerSmoothedReleased()) {
             state = null;
@@ -365,6 +369,8 @@ Script.scriptEnding.connect(clickMapping.disable);
 // Gather the trigger data for smoothing.
 clickMapping.from(Controller.Standard.RT).peek().to(rightTrigger.triggerPress);
 clickMapping.from(Controller.Standard.LT).peek().to(leftTrigger.triggerPress);
+clickMapping.from(Controller.Standard.RTClick).peek().to(rightTrigger.triggerClick);
+clickMapping.from(Controller.Standard.LTClick).peek().to(leftTrigger.triggerClick);
 // Full smoothed trigger is a click.
 function isPointingAtOverlayStartedNonFullTrigger(trigger) {
     // true if isPointingAtOverlay AND we were NOT full triggered when we became so.

--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -54,18 +54,14 @@ function Trigger(label) {
     that.rawTriggerValue = 0;
     that.triggerValue = 0;           // rolling average of trigger value
     that.triggerClicked = false;
-    that.triggerClick = function (value) {
-        print("Trigger clicked is now " + value);
-        that.triggerClicked = value;
-    };
-    that.triggerPress = function (value) {
-        that.rawTriggerValue = value;
-    };
+    that.triggerClick = function (value) { that.triggerClicked = value; };
+    that.triggerPress = function (value) { that.rawTriggerValue = value; };
     that.updateSmoothedTrigger = function () { // e.g., call once/update for effect
         var triggerValue = that.rawTriggerValue;
         // smooth out trigger value
         that.triggerValue = (that.triggerValue * that.TRIGGER_SMOOTH_RATIO) +
             (triggerValue * (1.0 - that.TRIGGER_SMOOTH_RATIO));
+        OffscreenFlags.navigationFocusDisabled = that.triggerValue != 0.0;
     };
     // Current smoothed state, without hysteresis. Answering booleans.
     that.triggerSmoothedClick = function () {
@@ -499,7 +495,10 @@ function checkSettings() {
     updateRecommendedArea();
 }
 checkSettings();
+
 var settingsChecker = Script.setInterval(checkSettings, SETTINGS_CHANGE_RECHECK_INTERVAL);
 Script.scriptEnding.connect(function () {
     Script.clearInterval(settingsChecker);
+    OffscreenFlags.navigationFocusDisabled = false;
 });
+

--- a/scripts/system/libraries/Trigger.js
+++ b/scripts/system/libraries/Trigger.js
@@ -1,0 +1,87 @@
+"use strict";
+
+/*jslint vars: true, plusplus: true*/
+/*globals Script, Overlays, Controller, Reticle, HMD, Camera, Entities, MyAvatar, Settings, Menu, ScriptDiscoveryService, Window, Vec3, Quat, print*/
+
+Trigger = function(properties) {
+    properties = properties || {};
+    var that = this;
+    that.label = properties.label || Math.random();
+    that.SMOOTH_RATIO = properties.smooth || 0.1; //  Time averaging of trigger - 0.0 disables smoothing
+    that.DEADZONE = properties.deadzone || 0.10; // Once pressed, a trigger must fall below the deadzone to be considered un-pressed once pressed.
+    that.HYSTERESIS = properties.hystersis || 0.05; // If not pressed, a trigger must go above DEADZONE + HYSTERSIS to be considered pressed
+
+    that.value = 0;
+    that.pressed = false;
+    that.clicked = false;
+
+    // Handlers
+    that.onPress = properties.onPress || function(){
+        print("Pressed trigger " + that.label)
+    };
+    that.onRelease = properties.onRelease || function(){
+        print("Released trigger " + that.label)
+    };
+    that.onClick = properties.onClick || function(){
+        print("Clicked trigger " + that.label)
+    };
+    that.onUnclick = properties.onUnclick || function(){
+        print("Unclicked trigger " + that.label)
+    };
+    
+    // Getters
+    that.isPressed = function() {
+        return that.pressed;
+    }
+    
+    that.isClicked = function() {
+        return that.clicked;
+    }
+    
+    that.getValue = function() {
+        return that.value;
+    }
+
+    
+    // Private values
+    var controller = properties.controller || Controller.Standard.LT;
+    var controllerClick = properties.controllerClick || Controller.Standard.LTClick;
+    that.mapping =  Controller.newMapping('com.highfidelity.controller.trigger.' + controller + '-' + controllerClick + '.' + that.label + Math.random());
+    Script.scriptEnding.connect(that.mapping.disable);
+
+    // Setup mapping,
+    that.mapping.from(controller).peek().to(function(value) {
+        that.value = (that.value * that.SMOOTH_RATIO) +
+            (value * (1.0 - that.SMOOTH_RATIO)); 
+
+        var oldPressed = that.pressed;
+        if (!that.pressed && that.value >= (that.DEADZONE + that.HYSTERESIS)) {
+            that.pressed = true;
+            that.onPress();
+        }
+
+        if (that.pressed && that.value < that.HYSTERESIS) {
+            that.pressed = false;
+            that.onRelease();
+        }
+    });
+    
+    that.mapping.from(controllerClick).peek().to(function(value){
+        if (!that.clicked && value > 0.0) {
+            that.clicked = true;
+            that.onClick();
+        } 
+        if (that.clicked && value == 0.0) {
+            that.clicked = false;
+            that.onUnclick();
+        }
+    });
+
+    that.enable = function() {
+        that.mapping.enable();
+    }
+
+    that.disable = function() {
+        that.mapping.disable();
+    }
+}


### PR DESCRIPTION
* Make the highlight for QML menus instantly move to the reticle position, rather than lagging behind it and animating.
* Make the trigger 'click' on the Vive be the signal to trigger grab or mouse click behavior from `handControllerGrab.js` and `handControllerPointer.js`.  For Oculus Touch, use a cutoff value of 0.9.

## Testing notes

With the Vive controller, neither the grab or mouse click effect should occur until the trigger is fully depressed to the extent that it 'clicks'.  In the production build, the grab or mouse pointer can occur prior to this point.  

When opening a context menu on the QML 2D layer, the highlight should follow the mouse cursor position precisely, rather than animating over time to the current location.  Note that there may still be a small delay between the laser termination point moving and the pointer position updating due to threading and rendering issues, however the delay should be much shorter than the original animation delay.  