### PR TITLE
Improved HRTF

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -240,7 +240,7 @@ void AudioMixer::addStreamToMixForListeningNodeWithStream(AudioMixerClientData& 
 
                 // this is not done for stereo streams since they do not go through the HRTF
                 static int16_t silentMonoBlock[AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL] = {};
-                hrtf.renderSilent(silentMonoBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, gain,
+                hrtf.renderSilent(silentMonoBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, 0.0f, gain,
                                   AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
 
                 ++_hrtfSilentRenders;;
@@ -287,7 +287,7 @@ void AudioMixer::addStreamToMixForListeningNodeWithStream(AudioMixerClientData& 
         // silent frame from source
 
         // we still need to call renderSilent via the HRTF for mono source
-        hrtf.renderSilent(streamBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, gain,
+        hrtf.renderSilent(streamBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, 0.0f, gain,
                           AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
 
         ++_hrtfSilentRenders;
@@ -300,7 +300,7 @@ void AudioMixer::addStreamToMixForListeningNodeWithStream(AudioMixerClientData& 
         // the mixer is struggling so we're going to drop off some streams
 
         // we call renderSilent via the HRTF with the actual frame data and a gain of 0.0
-        hrtf.renderSilent(streamBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, 0.0f,
+        hrtf.renderSilent(streamBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, 0.0f, 0.0f,
                           AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
 
         ++_hrtfStruggleRenders;
@@ -311,7 +311,7 @@ void AudioMixer::addStreamToMixForListeningNodeWithStream(AudioMixerClientData& 
     ++_hrtfRenders;
 
     // mono stream, call the HRTF with our block and calculated azimuth and gain
-    hrtf.render(streamBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, gain,
+    hrtf.render(streamBlock, _mixedSamples, HRTF_DATASET_INDEX, azimuth, 0.0f, gain,
                 AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
 }
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -888,7 +888,7 @@ void AudioClient::mixLocalAudioInjectors(int16_t* inputBuffer) {
                     float azimuth = azimuthForSource(relativePosition); 
                 
                 
-                    injector->getLocalHRTF().render(_scratchBuffer, _hrtfBuffer, 1, azimuth, gain, AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
+                    injector->getLocalHRTF().render(_scratchBuffer, _hrtfBuffer, 1, azimuth, 0.0f, gain, AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
                 }
             
             } else {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -882,13 +882,13 @@ void AudioClient::mixLocalAudioInjectors(int16_t* inputBuffer) {
                     
                 } else {
 
-                    // calculate gain and azimuth for hrtf
+                    // calculate distance, gain and azimuth for hrtf
                     glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
+                    float distance = glm::max(glm::length(relativePosition), EPSILON);
                     float gain = gainForSource(relativePosition, injector->getVolume()); 
-                    float azimuth = azimuthForSource(relativePosition); 
+                    float azimuth = azimuthForSource(relativePosition);         
                 
-                
-                    injector->getLocalHRTF().render(_scratchBuffer, _hrtfBuffer, 1, azimuth, 0.0f, gain, AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
+                    injector->getLocalHRTF().render(_scratchBuffer, _hrtfBuffer, 1, azimuth, distance, gain, AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
                 }
             
             } else {

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -217,7 +217,7 @@ private:
     void outputFormatChanged();
     void mixLocalAudioInjectors(int16_t* inputBuffer);
     float azimuthForSource(const glm::vec3& relativePosition);
-    float gainForSource(const glm::vec3& relativePosition, float volume);
+    float gainForSource(float distance, float volume);
 
     QByteArray firstInputFrame;
     QAudioInput* _audioInput;

--- a/libraries/audio/src/AudioHRTF.cpp
+++ b/libraries/audio/src/AudioHRTF.cpp
@@ -753,7 +753,7 @@ static void setFilters(float firCoef[4][HRTF_TAPS], float bqCoef[5][8], int dela
     distance = (distance < 1.0f) ? 1.0f : distance;
     double freq = exp2(-0.666 * log2(distance) + 15.75);
     double coef[5];
-    LowpassBiquad(coef, TWOPI * freq / 24000);
+    LowpassBiquad(coef, (double)TWOPI * freq / 24000);
 
     // TESTING: compute attn at w=pi
     //double num = coef[0] - coef[1] + coef[2];

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -21,7 +21,7 @@ static const int HRTF_TABLES = 25;      // number of HRTF subjects
 static const int HRTF_DELAY = 24;       // max ITD in samples (1.0ms at 24KHz)
 static const int HRTF_BLOCK = 256;      // block processing size
 
-static const float HRTF_GAIN = 0.5f;    // HRTF global gain adjustment
+static const float HRTF_GAIN = 1.0f;    // HRTF global gain adjustment
 
 class AudioHRTF {
 

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -33,15 +33,16 @@ public:
     // output: interleaved stereo mix buffer (accumulates into existing output)
     // index: HRTF subject index
     // azimuth: clockwise panning angle in radians
+    // distance: source distance in meters
     // gain: gain factor for distance attenuation
     // numFrames: must be HRTF_BLOCK in this version
     //
-    void render(int16_t* input, float* output, int index, float azimuth, float gain, int numFrames);
+    void render(int16_t* input, float* output, int index, float azimuth, float distance, float gain, int numFrames);
 
     //
     // Fast path when input is known to be silent
     //
-    void renderSilent(int16_t* input, float* output, int index, float azimuth, float gain, int numFrames);
+    void renderSilent(int16_t* input, float* output, int index, float azimuth, float distance, float gain, int numFrames);
 
 private:
     AudioHRTF(const AudioHRTF&) = delete;
@@ -49,10 +50,10 @@ private:
 
     // SIMD channel assignmentS
     enum Channel {
-        L0,
-        R0,
-        L1,
-        R1
+        L0, R0,
+        L1, R1,
+        L2, R2,
+        L3, R3
     };
 
     // For best cache utilization when processing thousands of instances, only
@@ -64,11 +65,12 @@ private:
     // integer delay history
     float _delayState[4][HRTF_DELAY] = {};
 
-    // fractional delay history
-    float _bqState[2][4] = {};
+    // biquad history
+    float _bqState[3][8] = {};
 
     // parameter history
     float _azimuthState = 0.0f;
+    float _distanceState = 0.0f;
     float _gainState = 0.0f;
 
     bool _silentState = false;


### PR DESCRIPTION
Adds a distance filter to model the frequency-dependent attenuation of sound propagation in open air.
Optimized using SIMD and computing all biquads in parallel. Performance impact is almost zero.
Filter updates are continuously interpolated and clean to -90dB.

Enabled by default in Interface and AudioMixer.