### PR TITLE
Delete Old Interface Logs If the Sum Size of Those Logs Exceeds Reasonable Size

### DIFF
--- a/interface/src/FileLogger.cpp
+++ b/interface/src/FileLogger.cpp
@@ -62,37 +62,37 @@ FilePersistThread::FilePersistThread(const FileLogger& logger) : _logger(logger)
 }
 
 void FilePersistThread::rollFileIfNecessary(QFile& file, bool notifyListenersIfRolled) {
-	uint64_t now = usecTimestampNow();
-	if ((file.size() > MAX_LOG_SIZE) || (now - _lastRollTime) > MAX_LOG_AGE_USECS) {
-		QString newFileName = getLogRollerFilename();
-		if (file.copy(newFileName)) {
-			file.open(QIODevice::WriteOnly | QIODevice::Truncate);
-			file.close();
-			qDebug() << "Rolled log file:" << newFileName;
+    uint64_t now = usecTimestampNow();
+    if ((file.size() > MAX_LOG_SIZE) || (now - _lastRollTime) > MAX_LOG_AGE_USECS) {
+        QString newFileName = getLogRollerFilename();
+        if (file.copy(newFileName)) {
+            file.open(QIODevice::WriteOnly | QIODevice::Truncate);
+            file.close();
+            qDebug() << "Rolled log file:" << newFileName;
 
-			if (notifyListenersIfRolled) {
-				emit rollingLogFile(newFileName);
-			}
+            if (notifyListenersIfRolled) {
+                emit rollingLogFile(newFileName);
+            }
 
-			_lastRollTime = now;
-		}
-		QStringList nameFilters;
-		nameFilters << FILENAME_WILDCARD;
+            _lastRollTime = now;
+        }
+        QStringList nameFilters;
+        nameFilters << FILENAME_WILDCARD;
 
-		QDir logQDir(FileUtils::standardPath(LOGS_DIRECTORY));
-		logQDir.setNameFilters(nameFilters);
-		logQDir.setSorting(QDir::Time);
-		QFileInfoList filesInDir = logQDir.entryInfoList();
-		qint64 totalSizeOfDir = 0;
-		foreach(QFileInfo dirItm, filesInDir){
-			if (totalSizeOfDir < MAX_LOG_DIR_SIZE){
-				totalSizeOfDir += dirItm.size();
-			} else {
-				QFile file(dirItm.filePath());
-				file.remove();
-			}
-		}
-	}
+        QDir logQDir(FileUtils::standardPath(LOGS_DIRECTORY));
+        logQDir.setNameFilters(nameFilters);
+        logQDir.setSorting(QDir::Time);
+        QFileInfoList filesInDir = logQDir.entryInfoList();
+        qint64 totalSizeOfDir = 0;
+        foreach(QFileInfo dirItm, filesInDir){
+            if (totalSizeOfDir < MAX_LOG_DIR_SIZE){
+                totalSizeOfDir += dirItm.size();
+            } else {
+                QFile file(dirItm.filePath());
+                file.remove();
+            }
+        }
+    }
 }
 bool FilePersistThread::processQueueItems(const Queue& messages) {
     QFile file(_logger._fileName);

--- a/interface/src/FileLogger.cpp
+++ b/interface/src/FileLogger.cpp
@@ -94,6 +94,7 @@ void FilePersistThread::rollFileIfNecessary(QFile& file, bool notifyListenersIfR
         }
     }
 }
+
 bool FilePersistThread::processQueueItems(const Queue& messages) {
     QFile file(_logger._fileName);
     rollFileIfNecessary(file);

--- a/interface/src/FileLogger.cpp
+++ b/interface/src/FileLogger.cpp
@@ -62,20 +62,20 @@ FilePersistThread::FilePersistThread(const FileLogger& logger) : _logger(logger)
 }
 
 void FilePersistThread::rollFileIfNecessary(QFile& file, bool notifyListenersIfRolled) {
-    uint64_t now = usecTimestampNow();
-    if ((file.size() > MAX_LOG_SIZE) || (now - _lastRollTime) > MAX_LOG_AGE_USECS) {
-        QString newFileName = getLogRollerFilename();
-        if (file.copy(newFileName)) {
-            file.open(QIODevice::WriteOnly | QIODevice::Truncate);
-            file.close();
-            qDebug() << "Rolled log file:" << newFileName;
+	uint64_t now = usecTimestampNow();
+	if ((file.size() > MAX_LOG_SIZE) || (now - _lastRollTime) > MAX_LOG_AGE_USECS) {
+		QString newFileName = getLogRollerFilename();
+		if (file.copy(newFileName)) {
+			file.open(QIODevice::WriteOnly | QIODevice::Truncate);
+			file.close();
+			qDebug() << "Rolled log file:" << newFileName;
 
-            if (notifyListenersIfRolled) {
-                emit rollingLogFile(newFileName);
-            }
+			if (notifyListenersIfRolled) {
+				emit rollingLogFile(newFileName);
+			}
 
-            _lastRollTime = now;
-        }
+			_lastRollTime = now;
+		}
 		QStringList nameFilters;
 		nameFilters << FILENAME_WILDCARD;
 
@@ -84,18 +84,16 @@ void FilePersistThread::rollFileIfNecessary(QFile& file, bool notifyListenersIfR
 		logQDir.setSorting(QDir::Time);
 		QFileInfoList filesInDir = logQDir.entryInfoList();
 		qint64 totalSizeOfDir = 0;
-		foreach (QFileInfo dirItm, filesInDir){
+		foreach(QFileInfo dirItm, filesInDir){
 			if (totalSizeOfDir < MAX_LOG_DIR_SIZE){
 				totalSizeOfDir += dirItm.size();
-			}
-			else {
+			} else {
 				QFile file(dirItm.filePath());
 				file.remove();
 			}
 		}
-    }
+	}
 }
-
 bool FilePersistThread::processQueueItems(const Queue& messages) {
     QFile file(_logger._fileName);
     rollFileIfNecessary(file);


### PR DESCRIPTION
Right now the logs roll at 512 kb, and this will delete the oldest if there are more than 100 of them. Prevents Interface log dir from getting as enormous as mine did.

**QA TEST**

Note: Must be willing to temporarily sacrifice 51 Mb of Hard Drive space. 

- Navigate to your log directory, APPDATA/LOCAL/High Fidelity/Interface/Logs on Windows. 

- Run this script (https://gist.githubusercontent.com/BingShearer/1ea56ab5ccddc4f6be9389d29fda3ee3/raw/51f91c4a7455e2b1e60771787c150122623ca24a/logFlood.js) to fill your logs.

- Watch as the oldest one gets picked off as the total size exceeds 51 Mb.
