### PR TITLE
Migrate edit.js toolbar to the new toolbar API

### DIFF
--- a/interface/resources/qml/hifi/toolbars/Toolbar.qml
+++ b/interface/resources/qml/hifi/toolbars/Toolbar.qml
@@ -20,19 +20,7 @@ Window {
     width: content.width
     height: content.height
     // Disable this window from being able to call 'desktop.raise() and desktop.showDesktop'
-    activator: MouseArea {
-        width: frame.decoration ? frame.decoration.width : window.width
-        height: frame.decoration ? frame.decoration.height : window.height
-        x: frame.decoration ? frame.decoration.anchors.leftMargin : 0
-        y: frame.decoration ? frame.decoration.anchors.topMargin : 0
-        propagateComposedEvents: true
-        acceptedButtons: Qt.AllButtons
-        enabled: window.visible
-        hoverEnabled: true
-        onPressed: mouse.accepted = false;
-        onEntered: window.mouseEntered();
-        onExited: window.mouseExited();
-    }
+    activator: Item {}
     property bool horizontal: true
     property real buttonSize: 50;
     property var buttons: []

--- a/interface/resources/qml/hifi/toolbars/Toolbar.qml
+++ b/interface/resources/qml/hifi/toolbars/Toolbar.qml
@@ -19,7 +19,6 @@ Window {
     shown: true
     width: content.width
     height: content.height
-    visible: true
     // Disable this window from being able to call 'desktop.raise() and desktop.showDesktop'
     activator: MouseArea {
         width: frame.decoration ? frame.decoration.width : window.width
@@ -38,7 +37,7 @@ Window {
     property real buttonSize: 50;
     property var buttons: []
     property var container: horizontal ? row : column
-
+            
     Settings {
         category: "toolbar/" + window.objectName
         property alias x: window.x

--- a/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
+++ b/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
@@ -8,23 +8,16 @@ Item {
     property var subImage;
     property int yOffset: 0
     property int buttonState: 0
-    property int hoverOffset: 0
+    property int hoverState: -1
+    property int defaultState: -1
     property var toolbar;
     property real size: 50 // toolbar ? toolbar.buttonSize : 50
     width: size; height: size
     property bool pinned: false
     clip: true
-    
-    function updateOffset() {
-        yOffset = size * (buttonState + hoverOffset);
-    }
-    
+
     onButtonStateChanged: {
-        hoverOffset = 0; // subtle: show the new state without hover. don't wait for mouse to be moved away
-        // The above is per UX design, but ALSO avoid a subtle issue that would be a problem because
-        // the hand controllers don't move the mouse when not triggered, so releasing the trigger would
-        // never show unhovered.
-        updateOffset();
+        yOffset = size * buttonState;
     }
 
     Component.onCompleted: {
@@ -57,12 +50,14 @@ Item {
         anchors.fill: parent
         onClicked: asyncClickSender.start();
         onEntered: {
-            hoverOffset = 2;
-            updateOffset();
+            if (hoverState > 0) {
+                buttonState = hoverState;
+            }
         }
         onExited: {
-            hoverOffset = 0;
-            updateOffset();
+            if (defaultState > 0) {
+                buttonState = defaultState;
+            }
         }
     }
 }

--- a/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
+++ b/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 1.4
 Item {
     id: button
     property alias imageURL: image.source
-    property alias alpha: button.opacity
+    property alias alpha: image.opacity
     property var subImage;
     property int yOffset: 0
     property int buttonState: 0
@@ -14,32 +14,11 @@ Item {
     width: size; height: size
     property bool pinned: false
     clip: true
-
-    Behavior on opacity {
-        NumberAnimation {
-            duration: 150
-            easing.type: Easing.InOutCubic
-        }
-    }
-
-    property alias fadeTargetProperty: button.opacity
-
-    onFadeTargetPropertyChanged: {
-        visible = (fadeTargetProperty !== 0.0);
-    }
-
-    onVisibleChanged: {
-        if ((!visible && fadeTargetProperty != 0.0) || (visible && fadeTargetProperty == 0.0)) {
-            var target = visible;
-            visible = !visible;
-            fadeTargetProperty = target ? 1.0 : 0.0;
-            return;
-        }
-    }
-
+    
     function updateOffset() {
         yOffset = size * (buttonState + hoverOffset);
     }
+    
     onButtonStateChanged: {
         hoverOffset = 0; // subtle: show the new state without hover. don't wait for mouse to be moved away
         // The above is per UX design, but ALSO avoid a subtle issue that would be a problem because
@@ -64,11 +43,19 @@ Item {
         width: parent.width
     }
 
+    Timer {
+        id: asyncClickSender
+        interval: 10
+        repeat: false
+        running: false
+        onTriggered: button.clicked();
+    }
+    
     MouseArea {
         id: mouseArea
         hoverEnabled: true
         anchors.fill: parent
-        onClicked: button.clicked();
+        onClicked: asyncClickSender.start();
         onEntered: {
             hoverOffset = 2;
             updateOffset();

--- a/interface/resources/qml/windows/Decoration.qml
+++ b/interface/resources/qml/windows/Decoration.qml
@@ -43,15 +43,19 @@ Rectangle {
     // Enable dragging of the window,
     // detect mouseover of the window (including decoration)
     MouseArea {
+        id: decorationMouseArea
         anchors.fill: parent
         drag.target: window
+        hoverEnabled: true
+        onEntered: window.mouseEntered();
+        onExited: window.mouseExited();
     }
     Connections {
         target: window
         onMouseEntered: {
             if (desktop.hmdHandMouseActive) {
                 root.inflateDecorations()
-           }
+            }
         }
         onMouseExited: root.deflateDecorations();
     }
@@ -59,7 +63,7 @@ Rectangle {
         target: desktop
         onHmdHandMouseActiveChanged: {
             if (desktop.hmdHandMouseActive) {
-                if (window.activator.containsMouse) {
+                if (decorationMouseArea.containsMouse) {
                     root.inflateDecorations();
                 }
             } else {

--- a/interface/resources/qml/windows/Window.qml
+++ b/interface/resources/qml/windows/Window.qml
@@ -115,14 +115,10 @@ Fadable {
         propagateComposedEvents: true
         acceptedButtons: Qt.AllButtons
         enabled: window.visible
-        hoverEnabled: true
         onPressed: {
-            //console.log("Pressed on activator area");
             window.raise();
             mouse.accepted = false;
         }
-        onEntered:  window.mouseEntered();
-        onExited: window.mouseExited();
     }
 
     // This mouse area serves to swallow mouse events while the mouse is over the window

--- a/interface/src/scripting/ToolbarScriptingInterface.cpp
+++ b/interface/src/scripting/ToolbarScriptingInterface.cpp
@@ -8,6 +8,8 @@
 
 #include "ToolbarScriptingInterface.h"
 
+#include <QtCore/QThread>
+
 #include <OffscreenUi.h>
 
 class QmlWrapper : public QObject {
@@ -79,7 +81,11 @@ public:
 
     Q_INVOKABLE QObject* addButton(const QVariant& properties) {
         QVariant resultVar;
-        bool invokeResult = QMetaObject::invokeMethod(_qmlObject, "addButton", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QVariant, resultVar), Q_ARG(QVariant, properties));
+        Qt::ConnectionType connectionType = Qt::AutoConnection;
+        if (QThread::currentThread() != _qmlObject->thread()) {
+            connectionType = Qt::BlockingQueuedConnection;
+        }
+        bool invokeResult = QMetaObject::invokeMethod(_qmlObject, "addButton", connectionType, Q_RETURN_ARG(QVariant, resultVar), Q_ARG(QVariant, properties));
         if (!invokeResult) {
             return nullptr;
         }
@@ -101,8 +107,12 @@ public:
 QObject* ToolbarScriptingInterface::getToolbar(const QString& toolbarId) {
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     auto desktop = offscreenUi->getDesktop();
+    Qt::ConnectionType connectionType = Qt::AutoConnection;
+    if (QThread::currentThread() != desktop->thread()) {
+        connectionType = Qt::BlockingQueuedConnection;
+    }
     QVariant resultVar;
-    bool invokeResult = QMetaObject::invokeMethod(desktop, "getToolbar", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QVariant, resultVar), Q_ARG(QVariant, toolbarId));
+    bool invokeResult = QMetaObject::invokeMethod(desktop, "getToolbar", connectionType, Q_RETURN_ARG(QVariant, resultVar), Q_ARG(QVariant, toolbarId));
     if (!invokeResult) {
         return nullptr;
     }

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -201,6 +201,7 @@ var toolBar = (function() {
 
     function cleanup() {
         that.setActive(false);
+        systemToolbar.removeButton("com.highfidelity.interface.system.editButton");
     }
     
     function addButton(name, image, handler) {
@@ -237,11 +238,10 @@ var toolBar = (function() {
 
         systemToolbar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
         activeButton = systemToolbar.addButton({
-            objectName: "activeButton",
+            objectName: "com.highfidelity.interface.system.editButton",
             imageURL: TOOL_ICON_URL + "edit.svg",
             visible: true,
             buttonState: 1,
-            alpha: 0.9,
         });
         activeButton.clicked.connect(function(){
             that.setActive(!isActive);
@@ -418,9 +418,7 @@ var toolBar = (function() {
         toolBar.writeProperty("shown", active);
         var visible = toolBar.readProperty("visible");
         if (active && !visible) { 
-            toolBar.writeProperty("visible", false);
             toolBar.writeProperty("shown", false);
-            toolBar.writeProperty("visible", true);
             toolBar.writeProperty("shown", true);
         }
         //toolBar.selectTool(activeButton, isActive);

--- a/scripts/system/examples.js
+++ b/scripts/system/examples.js
@@ -69,6 +69,7 @@ browseExamplesButton.clicked.connect(onClick);
 examplesWindow.visibleChanged.connect(onExamplesWindowVisibilityChanged);
 
 Script.scriptEnding.connect(function () {
+    toolBar.removeButton("examples");
     browseExamplesButton.clicked.disconnect(onClick);
     examplesWindow.visibleChanged.disconnect(onExamplesWindowVisibilityChanged);
 });

--- a/scripts/system/goto.js
+++ b/scripts/system/goto.js
@@ -30,6 +30,7 @@ button.clicked.connect(onClicked);
 DialogsManager.addressBarShown.connect(onAddressBarShown);
 
 Script.scriptEnding.connect(function () {
+    toolBar.removeButton("goto");
     button.clicked.disconnect(onClicked);
     DialogsManager.addressBarShown.disconnect(onAddressBarShown);
 });

--- a/scripts/system/hmd.js
+++ b/scripts/system/hmd.js
@@ -40,6 +40,7 @@ if (headset) {
     HMD.displayModeChanged.connect(onHmdChanged);
     
     Script.scriptEnding.connect(function () {
+        toolBar.removeButton("hmdToggle");
         button.clicked.disconnect(onClicked);
         HMD.displayModeChanged.disconnect(onHmdChanged);
     });

--- a/scripts/system/mute.js
+++ b/scripts/system/mute.js
@@ -34,6 +34,7 @@ button.clicked.connect(onClicked);
 AudioDevice.muteToggled.connect(onMuteToggled);
 
 Script.scriptEnding.connect(function () {
+    toolBar.removeButton("mute");
     button.clicked.disconnect(onClicked);
     AudioDevice.muteToggled.disconnect(onMuteToggled);
 });


### PR DESCRIPTION
## Testing

With this build, the `edit` button should appear in the main system toolbar while running the edit.js script.  When clicking on the edit button it will change state and a new bar will appear, showing all the buttons that used to appear next to edit in the old edit.js toolbar.  

The new toolbar should have exactly the same functionality, but should appear with our standard toolbar handles and be easier to move in the HMD.  