### PR TITLE
Removed button color declarations on createDice.js to make icons visible

### DIFF
--- a/scripts/tutorials/createDice.js
+++ b/scripts/tutorials/createDice.js
@@ -46,11 +46,6 @@ var offButton = toolBar.addOverlay("image", {
   width: BUTTON_SIZE,
   height: BUTTON_SIZE,
   imageURL: "http://hifi-production.s3.amazonaws.com/tutorials/dice/close.png",
-  color: {
-    red: 255,
-    green: 255,
-    blue: 255
-  },
   alpha: 1
 });
 
@@ -60,11 +55,6 @@ var deleteButton = toolBar.addOverlay("image", {
   width: BUTTON_SIZE,
   height: BUTTON_SIZE,
   imageURL: "http://hifi-production.s3.amazonaws.com/tutorials/dice/delete.png",
-  color: {
-    red: 255,
-    green: 255,
-    blue: 255
-  },
   alpha: 1
 });
 
@@ -75,11 +65,6 @@ var diceButton = toolBar.addOverlay("image", {
   width: BUTTON_SIZE,
   height: BUTTON_SIZE,
   imageURL: diceIconURL,
-  color: {
-    red: 255,
-    green: 255,
-    blue: 255
-  },
   alpha: 1
 });
 


### PR DESCRIPTION
Don't know why the color seemed to mess up icon visibility, but this fixes it. 
fix for this:
https://highfidelity.fogbugz.com/f/cases/assign/1163/createDice-js-icons-are-blank?ixPersonAssignedTo=57

QA:

- Run createDice.js FROM DISK
- Observe beautiful icons
