### PR TITLE
Fix decoration inflation

### DIFF
--- a/interface/resources/qml/windows/Decoration.qml
+++ b/interface/resources/qml/windows/Decoration.qml
@@ -48,7 +48,23 @@ Rectangle {
         drag.target: window
         hoverEnabled: true
         onEntered: window.mouseEntered();
-        onExited: window.mouseExited();
+        onExited: {
+            if (!containsMouseGlobal()) {
+                window.mouseExited();
+            }
+        }
+        
+        function containsMouseGlobal() {
+            var reticlePos = Reticle.position;
+            var globalPosition = decorationMouseArea.mapToItem(desktop, 0, 0);
+            var localPosition = {
+                x: reticlePos.x - globalPosition.x,
+                y: reticlePos.y - globalPosition.y,
+            };
+            return localPosition.x >= 0 && localPosition.x <= width &&
+                   localPosition.y >= 0 && localPosition.y <= height;
+        }
+        
     }
     Connections {
         target: window
@@ -57,7 +73,9 @@ Rectangle {
                 root.inflateDecorations()
             }
         }
-        onMouseExited: root.deflateDecorations();
+        onMouseExited: {
+            root.deflateDecorations();
+        }
     }
     Connections {
         target: desktop

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -442,3 +442,12 @@ glm::mat4 CompositorHelper::getReticleTransform(const glm::mat4& eyePose, const 
     }
     return result;
 }
+
+
+QVariant ReticleInterface::getPosition() const {
+    return vec2toVariant(_compositor->getReticlePosition());
+}
+
+void ReticleInterface::setPosition(QVariant position) {
+    _compositor->setReticlePosition(vec2FromVariant(position));
+}

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.h
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.h
@@ -174,7 +174,7 @@ private:
 // Scripting interface available to control the Reticle
 class ReticleInterface : public QObject {
     Q_OBJECT
-    Q_PROPERTY(glm::vec2 position READ getPosition WRITE setPosition)
+    Q_PROPERTY(QVariant position READ getPosition WRITE setPosition)
     Q_PROPERTY(bool visible READ getVisible WRITE setVisible)
     Q_PROPERTY(float depth READ getDepth WRITE setDepth)
     Q_PROPERTY(glm::vec2 maximumPosition READ getMaximumPosition)
@@ -198,8 +198,8 @@ public:
     Q_INVOKABLE float getDepth() { return _compositor->getReticleDepth(); }
     Q_INVOKABLE void setDepth(float depth) { _compositor->setReticleDepth(depth); }
 
-    Q_INVOKABLE glm::vec2 getPosition() { return _compositor->getReticlePosition(); }
-    Q_INVOKABLE void setPosition(glm::vec2 position) { _compositor->setReticlePosition(position); }
+    Q_INVOKABLE QVariant getPosition() const;
+    Q_INVOKABLE void setPosition(QVariant position);
 
     Q_INVOKABLE glm::vec2 getMaximumPosition() { return _compositor->getReticleMaximumPosition(); }
 

--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -32,6 +32,7 @@ function setupHandler(event, handler) {
         event.disconnect(handler);
     });
 }
+
 // If some capability is not available until expiration milliseconds after the last update.
 function TimeLock(expiration) {
     var last = 0;
@@ -42,6 +43,7 @@ function TimeLock(expiration) {
         return ((optionalNow || Date.now()) - last) > expiration;
     };
 }
+
 var handControllerLockOut = new TimeLock(2000);
 
 function Trigger(label) {
@@ -116,6 +118,10 @@ var weMovedReticle = false;
 function ignoreMouseActivity() {
     // If we're paused, or if change in cursor position is from this script, not the hardware mouse.
     if (!Reticle.allowMouseCapture) {
+        return true;
+    }
+    var pos = Reticle.position;
+    if (pos.x == -1 && pos.y == -1) {
         return true;
     }
     // Only we know if we moved it, which is why this script has to replace depthReticle.js
@@ -433,11 +439,12 @@ function clearSystemLaser() {
     }
     HMD.disableHandLasers(BOTH_HUD_LASERS);
     systemLaserOn = false;
+    weMovedReticle = true;
+    Reticle.position = { x: -1, y: -1 }; 
 }
 function setColoredLaser() { // answer trigger state if lasers supported, else falsey.
     var color = (activeTrigger.state === 'full') ? LASER_TRIGGER_COLOR_XYZW : LASER_SEARCH_COLOR_XYZW;
     return HMD.setHandLasers(activeHudLaser, true, color, SYSTEM_LASER_DIRECTION) && activeTrigger.state;
-
 }
 
 // MAIN OPERATIONS -----------


### PR DESCRIPTION
So, we can't use a mousearea for the whole window that uses hover events, or nothing _in_ the window can receive hover events.  However, we want the decorations to be inflated as long as the mouse is inside the outermost window.  

This PR changes the behavior on the exit detection to check if the global cursor is still inside the bounds of the decorations rectangle, and only deflates the window if it is not.  

In theory, we should always get an exit notification of the mouse leaving the window because it will have to cross the decorations again... however, I'm concerned that because windows can overlap and obfuscate one another, a window could get expanded and be left in that state if you moved onto another window that overlapped it before moving out of the first window's rectangle.

## Testing

When mousing over a window in the HMD using hand controllers, the decorations should stay large as long as you are anywhere within the bounds of the decorations, including over the pin and close controls.

