### PR TITLE
Fix hover states for toolbar buttons

### DIFF
--- a/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
+++ b/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
@@ -50,12 +50,12 @@ Item {
         anchors.fill: parent
         onClicked: asyncClickSender.start();
         onEntered: {
-            if (hoverState > 0) {
+            if (hoverState >= 0) {
                 buttonState = hoverState;
             }
         }
         onExited: {
-            if (defaultState > 0) {
+            if (defaultState >= 0) {
                 buttonState = defaultState;
             }
         }

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -234,11 +234,16 @@ var toolBar = (function() {
             objectName: EDIT_TOGGLE_BUTTON,
             imageURL: TOOL_ICON_URL + "edit.svg",
             visible: true,
+            alpha: 0.9,
             buttonState: 1,
+            hoverState: 3,
+            defaultState: 1,
         });
         activeButton.clicked.connect(function() {
             that.setActive(!isActive);
             activeButton.writeProperty("buttonState", isActive ? 0 : 1);
+            activeButton.writeProperty("defaultState", isActive ? 0 : 1);
+            activeButton.writeProperty("hoverState", isActive ? 2 : 3);
         });
 
         toolBar = Toolbars.getToolbar(EDIT_TOOLBAR);

--- a/scripts/system/examples.js
+++ b/scripts/system/examples.js
@@ -56,11 +56,15 @@ var browseExamplesButton = toolBar.addButton({
     imageURL: toolIconUrl + "market.svg",
     objectName: "examples",
     buttonState: 1,
+    defaultState: 1,
+    hoverState: 3,
     alpha: 0.9
 });
 
 function onExamplesWindowVisibilityChanged() {
     browseExamplesButton.writeProperty('buttonState', examplesWindow.visible ? 0 : 1);
+    browseExamplesButton.writeProperty('defaultState', examplesWindow.visible ? 0 : 1);
+    browseExamplesButton.writeProperty('hoverState', examplesWindow.visible ? 2 : 3);
 }
 function onClick() {
     toggleExamples();

--- a/scripts/system/goto.js
+++ b/scripts/system/goto.js
@@ -17,11 +17,15 @@ var button = toolBar.addButton({
     imageURL: Script.resolvePath("assets/images/tools/directory.svg"),
     visible: true,
     buttonState: 1,
+    defaultState: 1,
+    hoverState: 3,
     alpha: 0.9,
 });
 
 function onAddressBarShown(visible) {
     button.writeProperty('buttonState', visible ? 0 : 1);
+    button.writeProperty('defaultState', visible ? 0 : 1);
+    button.writeProperty('hoverState', visible ? 2 : 3);
 }
 function onClicked(){
     DialogsManager.toggleAddressBar();

--- a/scripts/system/hmd.js
+++ b/scripts/system/hmd.js
@@ -22,6 +22,8 @@ var toolBar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
 var button;
 function onHmdChanged(isHmd) {
     button.writeProperty('buttonState', isHmd ? 0 : 1);
+    button.writeProperty('defaultState', isHmd ? 0 : 1);
+    button.writeProperty('hoverState', isHmd ? 2 : 3);
 }
 function onClicked(){
     var isDesktop = Menu.isOptionChecked(desktopMenuItemName);
@@ -32,6 +34,8 @@ if (headset) {
         objectName: "hmdToggle",
         imageURL: Script.resolvePath("assets/images/tools/switch.svg"),
         visible: true,
+        hoverState: 2,
+        defaultState: 0,
         alpha: 0.9,
     });
     onHmdChanged(HMD.active);

--- a/scripts/system/ignore.js
+++ b/scripts/system/ignore.js
@@ -18,6 +18,8 @@ var button = toolbar.addButton({
     imageURL: Script.resolvePath("assets/images/tools/ignore.svg"),
     visible: true,
     buttonState: 1,
+    defaultState: 2,
+    hoverState: 3,
     alpha: 0.9
 });
 
@@ -46,6 +48,8 @@ function buttonClicked(){
     }
 
     button.writeProperty('buttonState', isShowingOverlays ? 0 : 1);
+    button.writeProperty('defaultState', isShowingOverlays ? 0 : 1);
+    button.writeProperty('hoverState', isShowingOverlays ? 2 : 3);
 }
 
 button.clicked.connect(buttonClicked);

--- a/scripts/system/mute.js
+++ b/scripts/system/mute.js
@@ -17,13 +17,19 @@ var button = toolBar.addButton({
     imageURL: Script.resolvePath("assets/images/tools/mic.svg"),
     visible: true,
     buttonState: 1,
+    defaultState: 1,
+    hoverState: 3,
     alpha: 0.9
 });
 
 function onMuteToggled() {
     // We could just toggle state, but we're less likely to get out of wack if we read the AudioDevice.
     // muted => button "on" state => 1. go figure.
-    button.writeProperty('buttonState', AudioDevice.getMuted() ? 0 : 1);
+    var state = AudioDevice.getMuted() ? 0 : 1;
+    var hoverState = AudioDevice.getMuted() ? 2 : 3;
+    button.writeProperty('buttonState', state);
+    button.writeProperty('defaultState', state);
+    button.writeProperty('hoverState', hoverState);
 }
 onMuteToggled();
 function onClicked(){


### PR DESCRIPTION
The recent modifications to the edit toolbar required a change to the core toolbar API so that hovering logic is done by the caller rather than baked into the toolbar QML.

This PR updates all the existing system toolbar buttons to use the new mechanism to set hover and unhover states.

## Testing

With this build, if you mouse over one of the system toolbar buttons it should highlight in response to your mouse and return to it's original state when you move the mouse away.  In the current dev-master build, the buttons will not respond visually to mouse-over.
