### PR TITLE
Fix the AudioMixer distance attenuation.

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -589,8 +589,8 @@
           "name": "attenuation_per_doubling_in_distance",
           "label": "Default Domain Attenuation",
           "help": "Factor between 0 and 1.0 (0: No attenuation, 1.0: extreme attenuation)",
-          "placeholder": "0.18",
-          "default": "0.18",
+          "placeholder": "0.5",
+          "default": "0.5",
           "advanced": false
         },
         {
@@ -686,7 +686,7 @@
               "name": "coefficient",
               "label": "Attenuation coefficient",
               "can_set": true,
-              "placeholder": "0.18"
+              "placeholder": "0.5"
             }
           ]
         },

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1309,7 +1309,7 @@ float AudioClient::gainForSource(float distance, float volume) {
 
     // attenuate based on distance
     if (distance >= ATTENUATION_BEGINS_AT_DISTANCE) {
-        gain /= distance;   // attenuation = -6dB * log2(distance)
+        gain /= (distance/ATTENUATION_BEGINS_AT_DISTANCE);  // attenuation = -6dB * log2(distance)
     }
 
     return gain;


### PR DESCRIPTION
The zone settings are still used, and still match the documentation where 0 = no attenuation and 1 = max attenuation.  The default is now 0.5 which corresponds to -6dB per doubling of distance. This is the attenuation for a spherical wave in the free field.