### PR TITLE
grab script improvements

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -277,7 +277,6 @@ var ATTACH_POINT_SETTINGS = "io.highfidelity.attachPoints";
 function getAttachPointSettings() {
     try {
         var str = Settings.getValue(ATTACH_POINT_SETTINGS);
-        print("getAttachPointSettings = " + str);
         if (str === "false") {
             return {};
         } else {
@@ -290,7 +289,6 @@ function getAttachPointSettings() {
 }
 function setAttachPointSettings(attachPointSettings) {
     var str = JSON.stringify(attachPointSettings);
-    print("setAttachPointSettings = " + str);
     Settings.setValue(ATTACH_POINT_SETTINGS, str);
 }
 function getAttachPointForHotspotFromSettings(hotspot, hand) {

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -202,8 +202,7 @@ CONTROLLER_STATE_MACHINE[STATE_NEAR_GRABBING] = {
 CONTROLLER_STATE_MACHINE[STATE_HOLD] = {
     name: "hold",
     enterMethod: "nearGrabbingEnter",
-    updateMethod: "nearGrabbing",
-    exitMethod: "holdExit"
+    updateMethod: "nearGrabbing"
 };
 CONTROLLER_STATE_MACHINE[STATE_NEAR_TRIGGER] = {
     name: "trigger",
@@ -1990,6 +1989,15 @@ function MyController(hand) {
 
             if (dropDetected && !this.waitForTriggerRelease && this.triggerSmoothedGrab()) {
                 this.callEntityMethodOnGrabbed("releaseEquip");
+
+                // store the offset attach points into preferences.
+                if (USE_ATTACH_POINT_SETTINGS && this.grabbedHotspot && this.grabbedEntity) {
+                    var props = Entities.getEntityProperties(this.grabbedEntity, ["localPosition", "localRotation"]);
+                    if (props && props.localPosition && props.localRotation) {
+                        storeAttachPointForHotspotInSettings(this.grabbedHotspot, this.hand, props.localPosition, props.localRotation);
+                    }
+                }
+
                 var grabbedEntity = this.grabbedEntity;
                 this.release();
                 this.grabbedEntity = grabbedEntity;
@@ -2088,16 +2096,6 @@ function MyController(hand) {
                 print("continueNearGrabbing -- updateAction failed");
                 Entities.deleteAction(this.grabbedEntity, this.actionID);
                 this.setupHoldAction();
-            }
-        }
-    };
-
-    this.holdExit = function () {
-        // store the offset attach points into preferences.
-        if (USE_ATTACH_POINT_SETTINGS && this.grabbedHotspot && this.grabbedEntity) {
-            var props = Entities.getEntityProperties(this.grabbedEntity, ["localPosition", "localRotation"]);
-            if (props && props.localPosition && props.localRotation) {
-                storeAttachPointForHotspotInSettings(this.grabbedHotspot, this.hand, props.localPosition, props.localRotation);
             }
         }
     };

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -271,8 +271,7 @@ function propsArePhysical(props) {
     return isPhysical;
 }
 
-// currently disabled.
-var USE_ATTACH_POINT_SETTINGS = false;
+var USE_ATTACH_POINT_SETTINGS = true;
 
 var ATTACH_POINT_SETTINGS = "io.highfidelity.attachPoints";
 function getAttachPointSettings() {
@@ -2091,16 +2090,10 @@ function MyController(hand) {
     this.holdExit = function () {
         // store the offset attach points into preferences.
         if (USE_ATTACH_POINT_SETTINGS && this.grabbedHotspot && this.grabbedEntity) {
-            entityPropertiesCache.addEntity(this.grabbedEntity);
-            var props = entityPropertiesCache.getProps(this.grabbedEntity);
-            var entityXform = new Xform(props.rotation, props.position);
-            var avatarXform = new Xform(MyAvatar.orientation, MyAvatar.position);
-            var handRot = (this.hand === RIGHT_HAND) ? MyAvatar.getRightPalmRotation() : MyAvatar.getLeftPalmRotation();
-            var avatarHandPos = (this.hand === RIGHT_HAND) ? MyAvatar.rightHandPosition : MyAvatar.leftHandPosition;
-            var palmXform = new Xform(handRot, avatarXform.xformPoint(avatarHandPos));
-            var offsetXform = Xform.mul(palmXform.inv(), entityXform);
-
-            storeAttachPointForHotspotInSettings(this.grabbedHotspot, this.hand, offsetXform.pos, offsetXform.rot);
+            var props = Entities.getEntityProperties(this.grabbedEntity, ["localPosition", "localRotation"]);
+            if (props && props.localPosition && props.localRotation) {
+                storeAttachPointForHotspotInSettings(this.grabbedHotspot, this.hand, props.localPosition, props.localRotation);
+            }
         }
     };
 


### PR DESCRIPTION
* after equipping an object attach points are saved in the user settings.  This allows the user to re-adjust the equipped item and have the system remember that adjustment.
* dropping an object is slightly different, instead of falling directly out of your hand, it will instead transition to a near-grabbed state.  The near grab state will release the grab when you release the trigger. This allows you to de-equip an object and set it upright on a table one handed.
* you can no longer drop an object by clicking the trackpad.