### PR TITLE
Actually delete textures we're not using

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -187,7 +187,11 @@ GLTexture::~GLTexture() {
         }
     }
 
-    Backend::decrementTextureGPUCount();
+    if (_id) {
+        glDeleteTextures(1, &_id);
+        const_cast<GLuint&>(_id) = 0;
+        Backend::decrementTextureGPUCount();
+    }
     Backend::updateTextureGPUMemoryUsage(_size, 0);
     Backend::updateTextureGPUVirtualMemoryUsage(_virtualSize, 0);
 }


### PR DESCRIPTION
Looks like we missed the actual GL deletion call in the destructor for textures... we only ever deleted textures that got used as a downsample source.  This should fix it.

