### PR TITLE
add protocol to metaverse heartbeat

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1086,8 +1086,8 @@ void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress) {
     // add the versions
     static const QString VERSION_KEY = "version";
     domainObject[VERSION_KEY] = BuildInfo::VERSION;
-    static const QString PROTOCOL_KEY = "protocol";
-    domainObject[PROTOCOL_KEY] = protocolVersionsSignatureBase64();
+    static const QString PROTOCOL_VERSION_KEY = "protocol";
+    domainObject[PROTOCOL_VERSION_KEY] = protocolVersionsSignatureBase64();
 
     // add networking
     if (!networkAddress.isEmpty()) {
@@ -1121,12 +1121,7 @@ void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress) {
     QString domainUpdateJSON = QString("{\"domain\":%1}").arg(QString(QJsonDocument(domainObject).toJson(QJsonDocument::Compact)));
 
     static const QString DOMAIN_UPDATE = "/api/v1/domains/%1";
-    QString path = DOMAIN_UPDATE.arg(uuidStringWithoutCurlyBraces(getID()));
-#if DEV_BUILD || PR_BUILD
-    qDebug() << "Domain metadata sent to" << path;
-    qDebug() << "Domain metadata update:" << domainUpdateJSON;
-#endif
-    DependencyManager::get<AccountManager>()->sendRequest(path,
+    DependencyManager::get<AccountManager>()->sendRequest(DOMAIN_UPDATE.arg(uuidStringWithoutCurlyBraces(getID())),
                                               AccountManagerAuth::Optional,
                                               QNetworkAccessManager::PutOperation,
                                               JSONCallbackParameters(nullptr, QString(), this, "handleMetaverseHeartbeatError"),

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1121,7 +1121,12 @@ void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress) {
     QString domainUpdateJSON = QString("{\"domain\":%1}").arg(QString(QJsonDocument(domainObject).toJson(QJsonDocument::Compact)));
 
     static const QString DOMAIN_UPDATE = "/api/v1/domains/%1";
-    DependencyManager::get<AccountManager>()->sendRequest(DOMAIN_UPDATE.arg(uuidStringWithoutCurlyBraces(getID())),
+    QString path = DOMAIN_UPDATE.arg(uuidStringWithoutCurlyBraces(getID()));
+#if DEV_BUILD || PR_BUILD
+    qDebug() << "Domain metadata sent to" << path;
+    qDebug() << "Domain metadata update:" << domainUpdateJSON;
+#endif
+    DependencyManager::get<AccountManager>()->sendRequest(path,
                                               AccountManagerAuth::Optional,
                                               QNetworkAccessManager::PutOperation,
                                               JSONCallbackParameters(nullptr, QString(), this, "handleMetaverseHeartbeatError"),

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1083,9 +1083,11 @@ void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress) {
     // Setup the domain object to send to the data server
     QJsonObject domainObject;
 
-    // add the version
+    // add the versions
     static const QString VERSION_KEY = "version";
     domainObject[VERSION_KEY] = BuildInfo::VERSION;
+    static const QString PROTOCOL_KEY = "protocol";
+    domainObject[PROTOCOL_KEY] = protocolVersionsSignatureBase64();
 
     // add networking
     if (!networkAddress.isEmpty()) {

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -99,8 +99,9 @@ void sendWrongProtocolVersionsSignature(bool sendWrongVersion) {
 }
 #endif
 
-QByteArray protocolVersionsSignature() {
-    static QByteArray protocolVersionSignature;
+static QByteArray protocolVersionSignature;
+static QString protocolVersionSignatureBase64;
+static void ensureProtocolVersionsSignature() {
     static std::once_flag once;
     std::call_once(once, [&] {
         QByteArray buffer;
@@ -114,8 +115,11 @@ QByteArray protocolVersionsSignature() {
         QCryptographicHash hash(QCryptographicHash::Md5);
         hash.addData(buffer);
         protocolVersionSignature = hash.result();
+        protocolVersionSignatureBase64 = protocolVersionSignature.toBase64();
     });
-
+}
+QByteArray protocolVersionsSignature() {
+    ensureProtocolVersionsSignature();
     #if (PR_BUILD || DEV_BUILD)
     if (sendWrongProtocolVersion) {
         return QByteArray("INCORRECTVERSION"); // only for debugging version checking
@@ -123,4 +127,8 @@ QByteArray protocolVersionsSignature() {
     #endif
 
     return protocolVersionSignature;
+}
+QString protocolVersionsSignatureBase64() {
+    ensureProtocolVersionsSignature();
+    return protocolVersionSignatureBase64;
 }

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -113,6 +113,7 @@ extern const QSet<PacketType> NON_SOURCED_PACKETS;
 
 PacketVersion versionForPacketType(PacketType packetType);
 QByteArray protocolVersionsSignature(); /// returns a unqiue signature for all the current protocols
+QString protocolVersionsSignatureBase64();
 
 #if (PR_BUILD || DEV_BUILD)
 void sendWrongProtocolVersionsSignature(bool sendWrongVersion); /// for debugging version negotiation


### PR DESCRIPTION
Adds a base64 accessor for protocol version signature, and uses it in DomainServer::sendHeartbeatToMetaverse.
