### PR TITLE
NotFinished never should have had its own bit

### DIFF
--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -165,14 +165,10 @@ void AudioInjector::restart() {
             if (!_options.localOnly) {
 
                 if (!injectorManager->restartFinishedInjector(this)) {
-                    // TODO: this logic seems to remove the pending delete,
-                    // which makes me wonder about the deleteLater calls
                     _state = AudioInjectorState::Finished; // we're not playing, so reset the state used by isPlaying.
                 }
             }
         } else {
-            // TODO: this logic seems to remove the pending delete,
-            // which makes me wonder about the deleteLater calls
             _state = AudioInjectorState::Finished; // we failed to play, so we are finished again
         }
     }

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -34,11 +34,11 @@ class AudioInjectorManager;
 
 
 enum class AudioInjectorState : uint8_t {
-    NotFinished = 1,
-    Finished = 2,
-    PendingDelete = 4,
-    LocalInjectionFinished = 8,
-    NetworkInjectionFinished = 16
+    NotFinished = 0,
+    Finished = 1,
+    PendingDelete = 2,
+    LocalInjectionFinished = 4,
+    NetworkInjectionFinished = 8
 };
 
 AudioInjectorState operator& (AudioInjectorState lhs, AudioInjectorState rhs);
@@ -50,12 +50,6 @@ class AudioInjector : public QObject {
     Q_OBJECT
     
 public:
-    static const uint8_t NotFinished = 1;
-    static const uint8_t Finished = 2;
-    static const uint8_t PendingDelete = 4;
-    static const uint8_t LocalInjectionFinished = 8;
-    static const uint8_t NetworkInjectionFinished = 16;
-
     AudioInjector(QObject* parent);
     AudioInjector(const Sound& sound, const AudioInjectorOptions& injectorOptions);
     AudioInjector(const QByteArray& audioData, const AudioInjectorOptions& injectorOptions);
@@ -90,7 +84,7 @@ public slots:
     void setOptions(const AudioInjectorOptions& options);
     
     float getLoudness() const { return _loudness; }
-    bool isPlaying() const { return stateHas(AudioInjectorState::NotFinished); }
+    bool isPlaying() const { return !stateHas(AudioInjectorState::Finished); }
     void finish();
     void finishLocalInjection();
     void finishNetworkInjection();


### PR DESCRIPTION
Since there is a Finished flag too.  So now, it is just 0, used as
a starting point, and we check for !hasState(Finished).  So we can 
now expect the isPlaying to be correct.  Ugh, lame error on my part.