### PR TITLE
Cleanup resources used by offscreen GL surfaces 

### DIFF
--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -36,7 +36,15 @@ OffscreenGLCanvas::~OffscreenGLCanvas() {
         delete _logger;
         _logger = nullptr;
     }
+    
     _context->doneCurrent();
+    delete _context;
+    _context = nullptr;
+
+    _offscreenSurface->destroy();
+    delete _offscreenSurface;
+    _offscreenSurface = nullptr;
+
 }
 
 bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {

--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -34,8 +34,8 @@ public:
     
 protected:
     std::once_flag _reportOnce;
-    QOpenGLContext* _context;
-    QOffscreenSurface* _offscreenSurface;
+    QOpenGLContext* _context{ nullptr };
+    QOffscreenSurface* _offscreenSurface{ nullptr };
     QOpenGLDebugLogger* _logger{ nullptr };
 };
 

--- a/libraries/gl/src/gl/QOpenGLContextWrapper.cpp
+++ b/libraries/gl/src/gl/QOpenGLContextWrapper.cpp
@@ -28,16 +28,17 @@ QOpenGLContext* QOpenGLContextWrapper::currentContext() {
     return QOpenGLContext::currentContext();
 }
 
-
 QOpenGLContextWrapper::QOpenGLContextWrapper() :
-_context(new QOpenGLContext)
-{
-}
-
+    _ownContext(true), _context(new QOpenGLContext) { }
 
 QOpenGLContextWrapper::QOpenGLContextWrapper(QOpenGLContext* context) :
-    _context(context)
-{
+    _context(context) { }
+
+QOpenGLContextWrapper::~QOpenGLContextWrapper() {
+    if (_ownContext) {
+        delete _context;
+        _context = nullptr;
+    }
 }
 
 void QOpenGLContextWrapper::setFormat(const QSurfaceFormat& format) {

--- a/libraries/gl/src/gl/QOpenGLContextWrapper.h
+++ b/libraries/gl/src/gl/QOpenGLContextWrapper.h
@@ -23,6 +23,7 @@ class QOpenGLContextWrapper {
 public:
     QOpenGLContextWrapper();
     QOpenGLContextWrapper(QOpenGLContext* context);
+    virtual ~QOpenGLContextWrapper();
     void setFormat(const QSurfaceFormat& format);
     bool create();
     void swapBuffers(QSurface* surface);
@@ -40,6 +41,7 @@ public:
 
     
 private:
+    bool _ownContext { false };
     QOpenGLContext* _context { nullptr };
 };
 


### PR DESCRIPTION
Web entities use offscreen QML surfaces to render, but the offscreen GL canvas class used to hold the rendering context wasn't properly cleaning up in its destructor.  This should reduce or eliminate the memory being leaked by web entities.