### PR TITLE
Ensure the pause overlay is unlit (emissive)

### DIFF
--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -34,6 +34,7 @@ var OVERLAY_DATA_HMD = {
     color: {red: 255, green: 255, blue: 255},
     alpha: 1,
     scale: 2,
+    emissive: true,
     isFacingAvatar: true,
     drawInFront: true
 };


### PR DESCRIPTION
## Testing

While in the HMD and running the `away.js` script, press escape or alt-tab from Interface in order to trigger the paused image.  Note that the image is fully lit (bright white text) and is unaffected by scene lighting.  In production builds it will be affected by scene lighting. 