### PR TITLE
fix crash with multiple solo nodes in closeCurrentPacket

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -34,7 +34,7 @@
 #include "NetworkLogging.h"
 #include "udt/Packet.h"
 
-const char SOLO_NODE_TYPES[2] = {
+const std::set<NodeType_t> SOLO_NODE_TYPES = {
     NodeType::AvatarMixer,
     NodeType::AudioMixer
 };
@@ -534,7 +534,7 @@ SharedNodePointer LimitedNodeList::addOrUpdateNode(const QUuid& uuid, NodeType_t
 
     if (it != _nodeHash.end()) {
         SharedNodePointer& matchingNode = it->second;
-
+        
         matchingNode->setPublicSocket(publicSocket);
         matchingNode->setLocalSocket(localSocket);
         matchingNode->setPermissions(permissions);
@@ -551,7 +551,33 @@ SharedNodePointer LimitedNodeList::addOrUpdateNode(const QUuid& uuid, NodeType_t
 
         SharedNodePointer newNodePointer(newNode, &QObject::deleteLater);
 
+        // if this is a solo node type, we assume that the DS has replaced its assignment and we should kill the previous node
+        if (SOLO_NODE_TYPES.count(newNode->getType())) {
+            // while we still have the read lock, see if there is a previous solo node we'll need to remove
+            auto previousSoloIt = std::find_if(_nodeHash.cbegin(), _nodeHash.cend(), [newNode](const UUIDNodePair& nodePair){
+                return nodePair.second->getType() == newNode->getType();
+            });
+
+            if (previousSoloIt != _nodeHash.cend()) {
+                // we have a previous solo node, switch to a write lock so we can remove it
+                readLocker.unlock();
+
+                QWriteLocker writeLocker(&_nodeMutex);
+
+                auto oldSoloNode = previousSoloIt->second;
+
+                _nodeHash.unsafe_erase(previousSoloIt);
+                handleNodeKill(oldSoloNode);
+
+                // convert the current lock back to a read lock for insertion of new node
+                writeLocker.unlock();
+                readLocker.relock();
+            }
+        }
+
+        // insert the new node and release our read lock
         _nodeHash.insert(UUIDNodePair(newNode->getUUID(), newNodePointer));
+        readLocker.unlock();
 
         qCDebug(networking) << "Added" << *newNode;
 

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <iterator>
 #include <memory>
+#include <set>
 #include <unordered_map>
 
 #ifndef _WIN32
@@ -46,7 +47,7 @@
 
 const quint64 NODE_SILENCE_THRESHOLD_MSECS = 5 * 1000;
 
-extern const char SOLO_NODE_TYPES[2];
+extern const std::set<NodeType_t> SOLO_NODE_TYPES;
 
 const char DEFAULT_ASSIGNMENT_SERVER_HOSTNAME[] = "localhost";
 


### PR DESCRIPTION
- fixed a crash in `closeCurrentPacket` due to multiple solo nodes