### PR TITLE
Vive HMD fixes to prevent user from becoming embedded in the floor.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3404,6 +3404,10 @@ void Application::setOverlaysVisible(bool visible) {
     menu->setIsOptionChecked(MenuOption::Overlays, true);
 }
 
+void Application::centerUI() {
+    _overlayConductor.centerUI();
+}
+
 void Application::cycleCamera() {
     auto menu = Menu::getInstance();
     if (menu->isOptionChecked(MenuOption::FullscreenMirror)) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -298,6 +298,7 @@ public slots:
     void cameraMenuChanged();
     void toggleOverlays();
     void setOverlaysVisible(bool visible);
+    Q_INVOKABLE void centerUI();
 
     void resetPhysicsReadyInformation();
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -96,7 +96,11 @@ public:
     AudioListenerMode getAudioListenerModeCamera() const { return FROM_CAMERA; }
     AudioListenerMode getAudioListenerModeCustom() const { return CUSTOM; }
 
-    Q_INVOKABLE void reset(bool andRecenter = false, bool andReload = true, bool andHead = true);
+    void reset(bool andRecenter = false, bool andReload = true, bool andHead = true);
+
+    Q_INVOKABLE void centerBody(); // thread-safe
+    Q_INVOKABLE void clearIKJointLimitHistory(); // thread-safe
+
     void update(float deltaTime);
     virtual void postUpdate(float deltaTime) override;
     void preDisplaySide(RenderArgs* renderArgs);

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -135,3 +135,7 @@ void HMDScriptingInterface::unsuppressKeyboard() {
 bool HMDScriptingInterface::isKeyboardVisible() {
     return qApp->getActiveDisplayPlugin()->isKeyboardVisible();
 }
+
+void HMDScriptingInterface::centerUI() {
+    QMetaObject::invokeMethod(qApp, "centerUI", Qt::QueuedConnection);
+}

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -55,6 +55,9 @@ public:
     /// Query the display plugin to determine the current VR keyboard visibility
     Q_INVOKABLE bool isKeyboardVisible();
 
+    // rotate the overlay UI sphere so that it is centered about the the current HMD position and orientation
+    Q_INVOKABLE void centerUI();
+
 public:
     HMDScriptingInterface();
     static QScriptValue getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine);

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -488,6 +488,12 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
     return _relativePoses;
 }
 
+void AnimInverseKinematics::clearIKJointLimitHistory() {
+    for (auto& pair : _constraints) {
+        pair.second->clearHistory();
+    }
+}
+
 RotationConstraint* AnimInverseKinematics::getConstraint(int index) {
     RotationConstraint* constraint = nullptr;
     std::map<int, RotationConstraint*>::iterator constraintItr = _constraints.find(index);

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -37,6 +37,8 @@ public:
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, float dt, AnimNode::Triggers& triggersOut) override;
     virtual const AnimPoseVec& overlay(const AnimVariantMap& animVars, float dt, Triggers& triggersOut, const AnimPoseVec& underPoses) override;
 
+    void clearIKJointLimitHistory();
+
 protected:
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets, const AnimPoseVec& underPoses);
     void solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets);

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -295,6 +295,19 @@ void Rig::clearJointAnimationPriority(int index) {
     }
 }
 
+void Rig::clearIKJointLimitHistory() {
+    if (_animNode) {
+        _animNode->traverse([&](AnimNode::Pointer node) {
+            // only report clip nodes as valid roles.
+            auto ikNode = std::dynamic_pointer_cast<AnimInverseKinematics>(node);
+            if (ikNode) {
+                ikNode->clearIKJointLimitHistory();
+            }
+            return true;
+        });
+    }
+}
+
 void Rig::setJointTranslation(int index, bool valid, const glm::vec3& translation, float priority) {
     if (isIndexValid(index)) {
         if (valid) {

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -103,6 +103,8 @@ public:
     void clearJointStates();
     void clearJointAnimationPriority(int index);
 
+    void clearIKJointLimitHistory();
+
     // geometry space
     void setJointState(int index, bool valid, const glm::quat& rotation, const glm::vec3& translation, float priority);
 

--- a/libraries/animation/src/RotationConstraint.h
+++ b/libraries/animation/src/RotationConstraint.h
@@ -35,6 +35,9 @@ public:
     /// \brief clear previous adjustment and adjust constraint limits to allow rotation
     virtual void dynamicallyAdjustLimits(const glm::quat& rotation) {}
 
+    /// \brief reset any remembered joint limit history
+    virtual void clearHistory() {};
+
 protected:
     glm::quat _referenceRotation = glm::quat();
 };

--- a/libraries/animation/src/SwingTwistConstraint.h
+++ b/libraries/animation/src/SwingTwistConstraint.h
@@ -97,8 +97,7 @@ public:
     /// \return reference to SwingLimitFunction instance for unit-testing
     const SwingLimitFunction& getSwingLimitFunction() const { return _swingLimitFunction; }
 
-    /// \brief exposed for unit testing
-    void clearHistory();
+    void clearHistory() override;
 
 private:
     float handleTwistBoundaryConditions(float twistAngle) const;

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -51,4 +51,6 @@ private:
     std::atomic<vr::EDeviceActivityLevel> _hmdActivityLevel { vr::k_EDeviceActivityLevel_Unknown };
     std::atomic<uint32_t> _keyboardSupressionCount{ 0 };
     static const QString NAME;
+
+    vr::HmdMatrix34_t _lastGoodHMDPose;
 };

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -204,7 +204,16 @@ function goActive() {
     }
     MyAvatar.setEnableMeshVisible(true); // IWBNI we respected Developer->Avatar->Draw Mesh setting.
     stopAwayAnimation();
-    MyAvatar.reset(true);
+
+    // update the UI sphere to be centered about the current HMD orientation.
+    HMD.centerUI();
+
+    // forget about any IK joint limits
+    MyAvatar.clearIKJointLimitHistory();
+
+    // update the avatar hips to point in the same direction as the HMD orientation.
+    MyAvatar.centerBody();
+
     hideOverlay();
 
     // restore overlays state to what it was when we went "away"


### PR DESCRIPTION
There are two instances were vive HMD users we're likely to become embedded in the floor or teleported off into space.

* When the HMD was removed the user goes into away mode.  Coming back from away mode could cause avatar to be teleported downward by a meter or so.
* Starting interface without Steam VR running in the background, could cause the avatar to be teleported far from the original spawn location.  