### PR TITLE
Potential cause of that buzzsaw when resetting

### DIFF
--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -59,7 +59,9 @@ void InboundAudioStream::reset() {
     _isStarved = true;
     _hasStarted = false;
     resetStats();
-    cleanupCodec();
+    // FIXME: calling cleanupCodec() seems to be the cause of the buzzsaw -- we get an assert
+    // after this is called in AudioClient.  Ponder and fix...
+    // cleanupCodec();
 }
 
 void InboundAudioStream::resetStats() {


### PR DESCRIPTION
I saw an assert, @ZappoMan suggested we comment out `cleanupCodec()` in `InboundAudioStream::reset()`, and no more assert.  Seems like it is the issue.