### PR TITLE
fix silence on no codec after previous codec has been set

### DIFF
--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -542,4 +542,5 @@ void InboundAudioStream::cleanupCodec() {
             _decoder = nullptr;
         }
     }
+    _selectedCodecName = "";
 }


### PR DESCRIPTION
Test Plan:
1) run local sandbox... in the domain settings change the **Audio Codec Preference Order** to "x" - this will essentially disable all codecs
2) run with server echo enabled so you can hear yourself
3) Connect to a "properly configured domain" (dev-playa) - talk - you should hear yourself
4) Connect to your local sandbox  - talk - you should hear yourself

In the current production interface at step 4 you will hear silence, this PR fixes that bug.
