### PR TITLE
Fix marketplace title

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
         "SoundCache": false,
         "Stats": false,
         "TextureCache": false,
+        "Toolbars": false,
         "Uuid": false,
         "UndoStack": false,
         "Vec3": false,

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -15,7 +15,7 @@ Script.load("system/users.js");
 Script.load("system/mute.js");
 Script.load("system/goto.js");
 Script.load("system/hmd.js");
-Script.load("system/examples.js");
+Script.load("system/marketplace.js");
 Script.load("system/edit.js");
 Script.load("system/ignore.js");
 Script.load("system/selectAudioDevice.js");

--- a/scripts/system/marketplace.js
+++ b/scripts/system/marketplace.js
@@ -29,7 +29,6 @@ function showMarketplace(marketplaceID) {
     if (marketplaceID) {
         url = url + "/items/" + marketplaceID;
     }
-    print("setting marketplace URL to " + url);
     marketplaceWindow.setURL(url);
     marketplaceWindow.setVisible(true);
 

--- a/scripts/system/marketplace.js
+++ b/scripts/system/marketplace.js
@@ -1,6 +1,5 @@
 //
-//  examples.js
-//  examples
+//  marketplace.js
 //
 //  Created by Eric Levin on 8 Jan 2016
 //  Copyright 2016 High Fidelity, Inc.
@@ -11,9 +10,9 @@
 
 var toolIconUrl = Script.resolvePath("assets/images/tools/");
 
-var EXAMPLES_URL = "https://metaverse.highfidelity.com/examples";
-var examplesWindow = new OverlayWebWindow({
-    title: 'Examples',
+var MARKETPLACE_URL = "https://metaverse.highfidelity.com/marketplace";
+var marketplaceWindow = new OverlayWebWindow({
+    title: "Marketplace",
     source: "about:blank",
     width: 900,
     height: 700,
@@ -26,24 +25,24 @@ var TOOLBAR_MARGIN_Y = 0;
 
 
 function showExamples(marketplaceID) {
-    var url = EXAMPLES_URL;
+    var url = MARKETPLACE_URL;
     if (marketplaceID) {
         url = url + "/items/" + marketplaceID;
     }
-    print("setting examples URL to " + url);
-    examplesWindow.setURL(url);
-    examplesWindow.setVisible(true);
+    print("setting marketplace URL to " + url);
+    marketplaceWindow.setURL(url);
+    marketplaceWindow.setVisible(true);
 
     UserActivityLogger.openedMarketplace();
 }
 
 function hideExamples() {
-    examplesWindow.setVisible(false);
-    examplesWindow.setURL("about:blank");
+    marketplaceWindow.setVisible(false);
+    marketplaceWindow.setURL("about:blank");
 }
 
 function toggleExamples() {
-    if (examplesWindow.visible) {
+    if (marketplaceWindow.visible) {
         hideExamples();
     } else {
         showExamples();
@@ -54,7 +53,7 @@ var toolBar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
 
 var browseExamplesButton = toolBar.addButton({
     imageURL: toolIconUrl + "market.svg",
-    objectName: "examples",
+    objectName: "marketplace",
     buttonState: 1,
     defaultState: 1,
     hoverState: 3,
@@ -62,18 +61,18 @@ var browseExamplesButton = toolBar.addButton({
 });
 
 function onExamplesWindowVisibilityChanged() {
-    browseExamplesButton.writeProperty('buttonState', examplesWindow.visible ? 0 : 1);
-    browseExamplesButton.writeProperty('defaultState', examplesWindow.visible ? 0 : 1);
-    browseExamplesButton.writeProperty('hoverState', examplesWindow.visible ? 2 : 3);
+    browseExamplesButton.writeProperty('buttonState', marketplaceWindow.visible ? 0 : 1);
+    browseExamplesButton.writeProperty('defaultState', marketplaceWindow.visible ? 0 : 1);
+    browseExamplesButton.writeProperty('hoverState', marketplaceWindow.visible ? 2 : 3);
 }
 function onClick() {
     toggleExamples();
 }
 browseExamplesButton.clicked.connect(onClick);
-examplesWindow.visibleChanged.connect(onExamplesWindowVisibilityChanged);
+marketplaceWindow.visibleChanged.connect(onExamplesWindowVisibilityChanged);
 
 Script.scriptEnding.connect(function () {
-    toolBar.removeButton("examples");
+    toolBar.removeButton("marketplace");
     browseExamplesButton.clicked.disconnect(onClick);
-    examplesWindow.visibleChanged.disconnect(onExamplesWindowVisibilityChanged);
+    marketplaceWindow.visibleChanged.disconnect(onExamplesWindowVisibilityChanged);
 });

--- a/scripts/system/marketplace.js
+++ b/scripts/system/marketplace.js
@@ -24,7 +24,7 @@ var toolWidth = 50;
 var TOOLBAR_MARGIN_Y = 0;
 
 
-function showExamples(marketplaceID) {
+function showMarketplace(marketplaceID) {
     var url = MARKETPLACE_URL;
     if (marketplaceID) {
         url = url + "/items/" + marketplaceID;
@@ -36,16 +36,16 @@ function showExamples(marketplaceID) {
     UserActivityLogger.openedMarketplace();
 }
 
-function hideExamples() {
+function hideMarketplace() {
     marketplaceWindow.setVisible(false);
     marketplaceWindow.setURL("about:blank");
 }
 
-function toggleExamples() {
+function toggleMarketplace() {
     if (marketplaceWindow.visible) {
-        hideExamples();
+        hideMarketplace();
     } else {
-        showExamples();
+        showMarketplace();
     }
 }
 
@@ -66,7 +66,7 @@ function onExamplesWindowVisibilityChanged() {
     browseExamplesButton.writeProperty('hoverState', marketplaceWindow.visible ? 2 : 3);
 }
 function onClick() {
-    toggleExamples();
+    toggleMarketplace();
 }
 browseExamplesButton.clicked.connect(onClick);
 marketplaceWindow.visibleChanged.connect(onExamplesWindowVisibilityChanged);


### PR DESCRIPTION
Renamed examples.js to marketplace.js, and updated the title of the window it creates.

Resolves [FogBugz 1260](https://highfidelity.fogbugz.com/f/cases/1260/Market-Window-still-references-Examples).

### Testing
1. Close all scripts and run the defaultScripts.js from this PR
2. The marketplace icon should show in the toolbar
3. On clicking the icon, a web window should appear with "Marketplace" in its title bar
4. It should show the HiFi marketplace and be just as interactive as before