### PR TITLE
Support for animGraphUrl override in FST file.

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -288,8 +288,6 @@ public slots:
 
     Q_INVOKABLE void updateMotionBehaviorFromMenu();
 
-    Q_INVOKABLE QUrl getAnimGraphUrl() const { return _animGraphUrl; }
-
     void setEnableDebugDrawDefaultPose(bool isEnabled);
     void setEnableDebugDrawAnimPose(bool isEnabled);
     void setEnableDebugDrawPosition(bool isEnabled);
@@ -299,7 +297,11 @@ public slots:
     void setEnableMeshVisible(bool isEnabled);
     void setUseAnimPreAndPostRotations(bool isEnabled);
     void setEnableInverseKinematics(bool isEnabled);
-    Q_INVOKABLE void setAnimGraphUrl(const QUrl& url);
+
+    QUrl getAnimGraphOverrideUrl() const;  // thread-safe
+    void setAnimGraphOverrideUrl(QUrl value);  // thread-safe
+    QUrl getAnimGraphUrl() const;  // thread-safe
+    void setAnimGraphUrl(const QUrl& url);  // thread-safe
 
     glm::vec3 getPositionForAudio();
     glm::quat getOrientationForAudio();
@@ -403,7 +405,9 @@ private:
     // Avatar Preferences
     QUrl _fullAvatarURLFromPreferences;
     QString _fullAvatarModelName;
-    QUrl _animGraphUrl {""};
+    ThreadSafeValueCache<QUrl> _currentAnimGraphUrl;
+    ThreadSafeValueCache<QUrl> _prefOverrideAnimGraphUrl;
+    QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
     bool _clearOverlayWhenMoving { true };
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -161,8 +161,8 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
-        auto getter = [=]()->QString { return myAvatar->getAnimGraphUrl().toString(); };
-        auto setter = [=](const QString& value) { myAvatar->setAnimGraphUrl(value); };
+        auto getter = [=]()->QString { return myAvatar->getAnimGraphOverrideUrl().toString(); };
+        auto setter = [=](const QString& value) { myAvatar->setAnimGraphOverrideUrl(QUrl(value)); };
         auto preference = new EditPreference(AVATAR_TUNING, "Avatar animation JSON", getter, setter);
         preference->setPlaceholderText("default");
         preferences->addPreference(preference);

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -67,6 +67,18 @@ void GeometryMappingResource::downloadFinished(const QByteArray& data) {
             _textureBaseUrl = resolveTextureBaseUrl(url, _url.resolved(texdir));
         }
 
+        auto animGraphVariant = mapping.value("animGraphUrl");
+        if (animGraphVariant.isValid()) {
+            QUrl fstUrl(animGraphVariant.toString());
+            if (fstUrl.isValid()) {
+                _animGraphOverrideUrl = _url.resolved(fstUrl);
+            } else {
+                _animGraphOverrideUrl = QUrl();
+            }
+        } else {
+            _animGraphOverrideUrl = QUrl();
+        }
+
         auto modelCache = DependencyManager::get<ModelCache>();
         GeometryExtra extra{ mapping, _textureBaseUrl };
 
@@ -284,6 +296,8 @@ Geometry::Geometry(const Geometry& geometry) {
     for (const auto& material : geometry._materials) {
         _materials.push_back(std::make_shared<NetworkMaterial>(*material));
     }
+
+    _animGraphOverrideUrl = geometry._animGraphOverrideUrl;
 }
 
 void Geometry::setTextures(const QVariantMap& textureMap) {

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -52,6 +52,7 @@ public:
     void setTextures(const QVariantMap& textureMap);
 
     virtual bool areTexturesLoaded() const;
+    const QUrl& getAnimGraphOverrideUrl() const { return _animGraphOverrideUrl; }
 
 protected:
     friend class GeometryMappingResource;
@@ -63,6 +64,8 @@ protected:
 
     // Copied to each geometry, mutable throughout lifetime via setTextures
     NetworkMaterials _materials;
+
+    QUrl _animGraphOverrideUrl;
 
 private:
     mutable bool _areTexturesLoaded { false };


### PR DESCRIPTION
You can now override the animGraph json used on a per-avatar basis by adding a line in the avatar fst file.  This gives the ability to override animations without running a special script.  For example:

    animGraphUrl = steel-debug-dude-anim.json

This is url can be absolute or relative to the url of the fst file itself.  For example:

    animGraphUrl = https://s3.amazonaws.com/hifi-public/tony/steel-debug-dude/steel-debug-dude-anim.json

An example fst demonstrating this functionality is [here](https://s3.amazonaws.com/hifi-public/tony/steel-debug-dude/steel-debug-dude.fst) it replaces the standard anim graph with one that only supports two animations, idle and walkFwd.