### PR TITLE
Asset browser ui

### DIFF
--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -213,7 +213,7 @@ ScrollingWindow {
                         // different scripting engine from QTScript.
                         gravity = Vec3.multiply(Vec3.fromPolar(Math.PI / 2, 0), 10);
                     } else {
-                        gravity = { x: 0, y: 0, z: 0 };
+                        gravity = Vec3.multiply(Vec3.fromPolar(Math.PI / 2, 0), 0);
                     }
 
                     print("Asset browser - adding asset " + url + " (" + name + ") to world.");

--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -207,7 +207,14 @@ ScrollingWindow {
                 } else if (url) {
                     var name = assetProxyModel.data(treeView.selection.currentIndex);
                     var addPosition = Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getFront(MyAvatar.orientation)));
-                    var gravity = dynamic ? { x: 0, y: -10, z: 0 } : { x: 0, y: 0, z: 0 };
+                    var gravity;
+                    if (dynamic) {
+                        // Create a vector <0, -10, 0>.  { x: 0, y: -10, z: 0 } won't work because Qt is dumb and this is a
+                        // different scripting engine from QTScript.
+                        gravity = Vec3.multiply(Vec3.fromPolar(Math.PI / 2, 0), 10);
+                    } else {
+                        gravity = { x: 0, y: 0, z: 0 };
+                    }
 
                     print("Asset browser - adding asset " + url + " (" + name + ") to world.");
 

--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -141,18 +141,81 @@ ScrollingWindow {
     }
 
     function addToWorld() {
-        var url = assetProxyModel.data(treeView.selection.currentIndex, 0x103);
+        var defaultURL = assetProxyModel.data(treeView.selection.currentIndex, 0x103);
 
-        if (!url || !canAddToWorld(url)) {
+        if (!defaultURL || !canAddToWorld(defaultURL)) {
             return;
         }
 
-        var name = assetProxyModel.data(treeView.selection.currentIndex);
+        var SHAPE_TYPE_NONE = 0;
+        var SHAPE_TYPE_SIMPLE_HULL = 1;
+        var SHAPE_TYPE_SIMPLE_COMPOUND = 2;
+        var SHAPE_TYPE_STATIC_MESH = 3;
 
-        console.log("Asset browser - adding asset " + url + " (" + name + ") to world.");
+        var SHAPE_TYPES = [];
+        SHAPE_TYPES[SHAPE_TYPE_NONE] = "No Collision";
+        SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
+        SHAPE_TYPES[SHAPE_TYPE_SIMPLE_COMPOUND] = "Good - Sub-meshes";
+        SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
 
-        var addPosition = Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getFront(MyAvatar.orientation)));
-        Entities.addModelEntity(name, url, addPosition);
+        var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
+        var DYNAMIC_DEFAULT = false;
+        var prompt = desktop.customInputDialog({
+            textInput: {
+                label: "Model URL",
+                text: defaultURL
+            },
+            comboBox: {
+                label: "Automatic Collisions",
+                index: SHAPE_TYPE_DEFAULT,
+                items: SHAPE_TYPES
+            },
+            checkBox: {
+                label: "Dynamic",
+                checked: DYNAMIC_DEFAULT,
+                disableForItems: [
+                    SHAPE_TYPE_STATIC_MESH
+                ],
+                checkStateOnDisable: false,
+                warningOnDisable: "Models with automatic collisions set to 'Exact' cannot be dynamic"
+            }
+        });
+
+        prompt.selected.connect(function (jsonResult) {
+            if (jsonResult) {
+                var result = JSON.parse(jsonResult);
+                var url = result.textInput;
+                var shapeType;
+                switch (result.comboBox) {
+                    case SHAPE_TYPE_SIMPLE_HULL:
+                        shapeType = "simple-hull";
+                        break;
+                    case SHAPE_TYPE_SIMPLE_COMPOUND:
+                        shapeType = "simple-compound";
+                        break;
+                    case SHAPE_TYPE_STATIC_MESH:
+                        shapeType = "static-mesh";
+                        break;
+                    default:
+                        shapeType = "none";
+                }
+
+                var dynamic = result.checkBox !== null ? result.checkBox : DYNAMIC_DEFAULT;
+                if (shapeType === "static-mesh" && dynamic) {
+                    // The prompt should prevent this case
+                    print("Error: model cannot be both static mesh and dynamic.  This should never happen.");
+                } else if (url) {
+                    var name = assetProxyModel.data(treeView.selection.currentIndex);
+                    var addPosition = Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getFront(MyAvatar.orientation)));
+                    var gravity = dynamic ? { x: 0, y: -10, z: 0 } : { x: 0, y: 0, z: 0 };
+
+                    print("Asset browser - adding asset " + url + " (" + name + ") to world.");
+
+                    // Entities.addEntity doesn't work from QML, so we use this.
+                    Entities.addModelEntity(name, url, shapeType, dynamic, addPosition, gravity);
+                }
+            }
+        });
     }
 
     function copyURLToClipboard(index) {

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -198,12 +198,16 @@ QUuid EntityScriptingInterface::addEntity(const EntityItemProperties& properties
     }
 }
 
-QUuid EntityScriptingInterface::addModelEntity(const QString& name, const QString& modelUrl, const glm::vec3& position) {
+QUuid EntityScriptingInterface::addModelEntity(const QString& name, const QString& modelUrl, const QString& shapeType,
+                                               bool dynamic, const glm::vec3& position, const glm::vec3& gravity) {
     EntityItemProperties properties;
     properties.setType(EntityTypes::Model);
     properties.setName(name);
     properties.setModelURL(modelUrl);
+    properties.setShapeTypeFromString(shapeType);
+    properties.setDynamic(dynamic);
     properties.setPosition(position);
+    properties.setGravity(gravity);
     return addEntity(properties);
 }
 

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -86,7 +86,8 @@ public slots:
     Q_INVOKABLE QUuid addEntity(const EntityItemProperties& properties, bool clientOnly = false);
 
     /// temporary method until addEntity can be used from QJSEngine
-    Q_INVOKABLE QUuid addModelEntity(const QString& name, const QString& modelUrl, const glm::vec3& position);
+    Q_INVOKABLE QUuid addModelEntity(const QString& name, const QString& modelUrl, const QString& shapeType, bool dynamic,
+                                     const glm::vec3& position, const glm::vec3& gravity);
 
     /// gets the current model properties for a specific model
     /// this function will not find return results in script engine contexts which don't have access to models

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -349,12 +349,8 @@ QVariant OffscreenUi::getCustomInfo(const Icon icon, const QString& title, const
     }
 
     QVariant result = DependencyManager::get<OffscreenUi>()->customInputDialog(icon, title, config);
-    if (result.isValid()) {
-        // We get a JSON encoded result, so we unpack it into a QVariant wrapping a QVariantMap
-        result = QVariant(QJsonDocument::fromJson(result.toString().toUtf8()).object().toVariantMap());
-        if (ok) {
-            *ok = true;
-        }
+    if (ok && result.isValid()) {
+        *ok = true;
     }
 
     return result;
@@ -386,7 +382,13 @@ QVariant OffscreenUi::customInputDialog(const Icon icon, const QString& title, c
         return result;
     }
 
-    return waitForInputDialogResult(createCustomInputDialog(icon, title, config));
+    QVariant result = waitForInputDialogResult(createCustomInputDialog(icon, title, config));
+    if (result.isValid()) {
+        // We get a JSON encoded result, so we unpack it into a QVariant wrapping a QVariantMap
+        result = QVariant(QJsonDocument::fromJson(result.toString().toUtf8()).object().toVariantMap());
+    }
+
+    return result;
 }
 
 void OffscreenUi::togglePinned() {


### PR DESCRIPTION
Add dynamic and collision shape selection to add to world flow from asset browser.

### Testing
1. Open asset browser
2. Select an fbx file and click add to world
3. A dialog identical to the add model dialog should appear
4. Try different configurations and different models
5. Shape type, dynamic state, and model URL should all be reflected in the created entities
6. When you add to world an object that has dynamic true, the object should have a gravity of -10. 