### PR TITLE
Disable glow lines on Mac

### DIFF
--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -113,10 +113,12 @@ void HmdDisplayPlugin::customizeContext() {
 
     updateReprojectionProgram();
     updateOverlayProgram();
+#ifdef HMD_HAND_LASER_SUPPORT
     updateLaserProgram();
-
     _laserGeometry = loadLaser(_laserProgram);
+#endif
 }
+
 //#define LIVE_SHADER_RELOAD 1
 
 static QString readFile(const QString& filename) {
@@ -162,6 +164,7 @@ void HmdDisplayPlugin::updateReprojectionProgram() {
 
 }
 
+#ifdef HMD_HAND_LASER_SUPPORT
 void HmdDisplayPlugin::updateLaserProgram() {
     static const QString vsFile = PathUtils::resourcesPath() + "/shaders/hmd_hand_lasers.vert";
     static const QString gsFile = PathUtils::resourcesPath() + "/shaders/hmd_hand_lasers.geom";
@@ -202,6 +205,7 @@ void HmdDisplayPlugin::updateLaserProgram() {
         }
     }
 }
+#endif
 
 void HmdDisplayPlugin::updateOverlayProgram() {
     static const QString vsFile = PathUtils::resourcesPath() + "/shaders/hmd_ui_glow.vert";
@@ -249,8 +253,10 @@ void HmdDisplayPlugin::uncustomizeContext() {
     _compositeFramebuffer.reset();
     _previewProgram.reset();
     _reprojectionProgram.reset();
+#ifdef HMD_HAND_LASER_SUPPORT
     _laserProgram.reset();
     _laserGeometry.reset();
+#endif
     Parent::uncustomizeContext();
 }
 
@@ -516,6 +522,7 @@ bool HmdDisplayPlugin::setHandLaser(uint32_t hands, HandLaserMode mode, const ve
 }
 
 void HmdDisplayPlugin::compositeExtra() {
+#ifdef HMD_HAND_LASER_SUPPORT
     // If neither hand laser is activated, exit
     if (!_presentHandLasers[0].valid() && !_presentHandLasers[1].valid()) {
         return;
@@ -584,4 +591,5 @@ void HmdDisplayPlugin::compositeExtra() {
         }
     });
     glDisable(GL_BLEND);
+#endif
 }

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -14,6 +14,10 @@
 
 #include "../OpenGLDisplayPlugin.h"
 
+#ifdef Q_OS_WIN
+#define HMD_HAND_LASER_SUPPORT
+#endif
+
 class HmdDisplayPlugin : public OpenGLDisplayPlugin {
     using Parent = OpenGLDisplayPlugin;
 public:
@@ -93,7 +97,9 @@ protected:
 
 private:
     void updateOverlayProgram();
+#ifdef HMD_HAND_LASER_SUPPORT
     void updateLaserProgram();
+#endif
     void updateReprojectionProgram();
 
     bool _enablePreview { false };
@@ -130,11 +136,13 @@ private:
 
     ShapeWrapperPtr _sphereSection;
 
+#ifdef HMD_HAND_LASER_SUPPORT
     ProgramPtr _laserProgram;
     struct LaserUniforms {
         int32_t mvp { -1 };
         int32_t color { -1 };
     } _laserUniforms;
     ShapeWrapperPtr _laserGeometry;
+#endif
 };
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1552,6 +1552,12 @@ void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm
 
 void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
     const glm::vec4& color, float glowIntensity, float glowWidth, int id) {
+
+    // Disable glow lines on OSX
+#ifndef Q_OS_WIN
+    glowIntensity = 0.0f;
+#endif
+
     if (glowIntensity <= 0) {
         renderLine(batch, p1, p2, color, id);
         return;


### PR DESCRIPTION
Our geometry shader use is apparently incompatible with OSX, so until we find a better solution for rendering glow lines, we should disable them.