### PR TITLE
Allow atomic editing of multiple overlays from scripts

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -234,6 +234,29 @@ bool Overlays::editOverlay(unsigned int id, const QVariant& properties) {
     return false;
 }
 
+bool Overlays::editOverlays(const QVariant& propertiesById) {
+    QVariantMap map = propertiesById.toMap();
+    bool success = true;
+    QWriteLocker lock(&_lock);
+    for (const auto& key : map.keys()) {
+        bool convertSuccess;
+        unsigned int id = key.toUInt(&convertSuccess);
+        if (!convertSuccess) {
+            success = false;
+            continue;
+        }
+
+        Overlay::Pointer thisOverlay = getOverlay(id);
+        if (!thisOverlay) {
+            success = false;
+            continue;
+        }
+        QVariant properties = map[key];
+        thisOverlay->setProperties(properties.toMap());
+    }
+    return success;
+}
+
 void Overlays::deleteOverlay(unsigned int id) {
     Overlay::Pointer overlayToDelete;
 

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -89,6 +89,10 @@ public slots:
     /// successful edit, if the input id is for an unknown overlay this function will have no effect
     bool editOverlay(unsigned int id, const QVariant& properties);
 
+    /// edits an overlay updating only the included properties, will return the identified OverlayID in case of
+    /// successful edit, if the input id is for an unknown overlay this function will have no effect
+    bool editOverlays(const QVariant& propertiesById);
+
     /// deletes a particle
     void deleteOverlay(unsigned int id);
 


### PR DESCRIPTION
## Testing notes

Run the script at http://s3.amazonaws.com/DreamingContent/scripts/tests/overlayAnimation.js

It will create somewhere near your avatar a several thousand spinning hexagons overlayed on same spot.  In the current production build you will usually notice a ghosting effect as hexagons are in different states for a given frame.  In this build you should notice no (or at least less) ghosting.

