### PR TITLE
reduce activity logging spam

### DIFF
--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -53,7 +53,6 @@ void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCall
         detailsPart.setBody(QJsonDocument(details).toJson(QJsonDocument::Compact));
         multipart->append(detailsPart);
     }
-    qCDebug(networking) << "Logging activity" << action;
     
     // if no callbacks specified, call our owns
     if (params.isEmpty()) {


### PR DESCRIPTION
Test plan:
- Run the client
- check the logs
- you will no longer see log messages like: `[07/24 10:33:07] [DEBUG] Logging activity "stats`