### PR TITLE
Make whiteboard marker spawning work with 'far trigger'

### DIFF
--- a/unpublishedScripts/DomainContent/Home/whiteboard/swiper.js
+++ b/unpublishedScripts/DomainContent/Home/whiteboard/swiper.js
@@ -18,9 +18,20 @@
         busy: false,
         preload: function(entityID) {
             this.entityID = entityID;
+            Entities.editEntity(entityID, {
+                userData: JSON.stringify({
+                    grabbableKey: {
+                        grabbable: false,
+                        wantsTrigger: true
+                    }
+                })
+            });
             Script.update.connect(this.update);
         },
         clickReleaseOnEntity: function() {
+            this.createSupplies();
+        },
+        startFarTrigger: function() {
             this.createSupplies();
         },
         update: function() {
@@ -45,7 +56,6 @@
                 }, 2000)
             }
         },
-
         createSupplies: function() {
             var myProperties = Entities.getEntityProperties(this.entityID);
 


### PR DESCRIPTION
This PR changes the whiteboard swiper so that it works when you trigger it from afar with your laser beam -- based on user testing.

To test.
1. Visit forum
2. Reload All Scripts from running scripts.
3. Run your hand beam through the 'swiper' on the left of the whiteboard
4. Markers and an eraser should spawn.