### PR TITLE
Fix script end errors

### DIFF
--- a/scripts/system/controllers/squeezeHands.js
+++ b/scripts/system/controllers/squeezeHands.js
@@ -19,6 +19,8 @@ var CONTROLLER_DEAD_SPOT = 0.25;
 var TRIGGER_SMOOTH_TIMESCALE = 0.1;
 var OVERLAY_RAMP_RATE = 8.0;
 
+var animStateHandlerID;
+
 function clamp(val, min, max) {
     return Math.min(Math.max(val, min), max);
 }
@@ -33,8 +35,10 @@ function lerp(a, b, alpha) {
 
 function init() {
     Script.update.connect(update);
-    MyAvatar.addAnimationStateHandler(animStateHandler, ["leftHandOverlayAlpha", "rightHandOverlayAlpha",
-                                                         "leftHandGraspAlpha", "rightHandGraspAlpha"]);
+    animStateHandlerID = MyAvatar.addAnimationStateHandler(
+        animStateHandler,
+        ["leftHandOverlayAlpha", "rightHandOverlayAlpha", "leftHandGraspAlpha", "rightHandGraspAlpha"]
+    );
 }
 
 function animStateHandler(props) {
@@ -72,7 +76,7 @@ function update(dt) {
 
 function shutdown() {
     Script.update.disconnect(update);
-    MyAvatar.removeAnimationStateHandler(animStateHandler);
+    MyAvatar.removeAnimationStateHandler(animStateHandlerID);
 }
 
 Script.scriptEnding.connect(shutdown);


### PR DESCRIPTION
Fix an error on script end for squeezeHands.js.

Fixes [FogBugz 1271](https://highfidelity.fogbugz.com/f/cases/1271/stopping-default-script-squeezeHands-gives-error-Rig-removeAnimationStateHandler-invalid-argument-expected-a-number).

### Testing

1. Run squeezeHands.js, then close it
2. No error saying "Rig::removeAnimationStateHandler invalid argument, expected a number" should show up in the logs when it exits