### PR TITLE
Fix alpha cut-outs and incorrect gamma on web overlays and entities

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -101,7 +101,7 @@ void Web3DOverlay::render(RenderArgs* args) {
 
     batch.setModelTransform(transform);
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    geometryCache->bindSimpleProgram(batch, true, false, true, false);
+    geometryCache->bindSimpleSRGBTexturedUnlitNoDstAlphaProgram(batch);
     geometryCache->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color);
     batch.setResourceTexture(0, args->_whiteTexture); // restore default white color after me
 }

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -101,7 +101,7 @@ void Web3DOverlay::render(RenderArgs* args) {
 
     batch.setModelTransform(transform);
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    geometryCache->bindSimpleSRGBTexturedUnlitNoDstAlphaProgram(batch);
+    geometryCache->bindSimpleSRGBTexturedUnlitNoTexAlphaProgram(batch);
     geometryCache->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color);
     batch.setResourceTexture(0, args->_whiteTexture); // restore default white color after me
 }

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -203,10 +203,8 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     if (!success) {
         return;
     }
-    bool textured = false, culled = false, emissive = false;
     if (_texture) {
         batch._glActiveBindTexture(GL_TEXTURE0, GL_TEXTURE_2D, _texture);
-        textured = emissive = true;
     }
 
     DependencyManager::get<GeometryCache>()->bindSimpleSRGBTexturedUnlitNoTexAlphaProgram(batch);

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -208,9 +208,9 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
         batch._glActiveBindTexture(GL_TEXTURE0, GL_TEXTURE_2D, _texture);
         textured = emissive = true;
     }
-    
-    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, textured, culled, emissive);
-    DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f, 1.0f, 1.0f, 0.0f));
+
+    DependencyManager::get<GeometryCache>()->bindSimpleSRGBTexturedUnlitNoTexAlphaProgram(batch);
+    DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
 }
 
 void RenderableWebEntityItem::setSourceUrl(const QString& value) {

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -35,6 +35,7 @@
 #include "simple_vert.h"
 #include "simple_textured_frag.h"
 #include "simple_textured_unlit_frag.h"
+#include "simple_srgb_textured_unlit_no_dst_alpha_frag.h"
 #include "glowLine_vert.h"
 #include "glowLine_geom.h"
 #include "glowLine_frag.h"
@@ -1746,6 +1747,46 @@ inline uint qHash(const SimpleProgramKey& key, uint seed) {
 
 inline bool operator==(const SimpleProgramKey& a, const SimpleProgramKey& b) {
     return a.getRaw() == b.getRaw();
+}
+
+void GeometryCache::bindSimpleSRGBTexturedUnlitNoDstAlphaProgram(gpu::Batch& batch) {
+    batch.setPipeline(getSimpleSRGBTexturedUnlitNoDstAlphaPipeline());
+    // Set a default normal map
+    batch.setResourceTexture(render::ShapePipeline::Slot::MAP::NORMAL_FITTING,
+        DependencyManager::get<TextureCache>()->getNormalFittingTexture());
+}
+
+gpu::PipelinePointer GeometryCache::getSimpleSRGBTexturedUnlitNoDstAlphaPipeline() {
+    // Compile the shaders, once
+    static std::once_flag once;
+    std::call_once(once, [&]() {
+        auto VS = gpu::Shader::createVertex(std::string(simple_vert));
+        auto PS = gpu::Shader::createPixel(std::string(simple_srgb_textured_unlit_no_dst_alpha_frag));
+
+        _simpleSRGBTexturedUnlitNoDstAlphaShader = gpu::Shader::createProgram(VS, PS);
+
+        gpu::Shader::BindingSet slotBindings;
+        slotBindings.insert(gpu::Shader::Binding(std::string("normalFittingMap"), render::ShapePipeline::Slot::MAP::NORMAL_FITTING));
+        gpu::Shader::makeProgram(*_simpleSRGBTexturedUnlitNoDstAlphaShader, slotBindings);
+    });
+
+    if (_simpleSRGBTexturedUnlitNoDstAlphaPipeline) {
+        return _simpleSRGBTexturedUnlitNoDstAlphaPipeline;
+    }
+
+    // If the pipeline did not exist, make it
+    auto state = std::make_shared<gpu::State>();
+    state->setCullMode(gpu::State::CULL_NONE);
+
+    state->setDepthTest(true, true, gpu::LESS_EQUAL);
+    state->setBlendFunction(false,
+        gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+        gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
+
+    gpu::ShaderPointer program = _simpleSRGBTexturedUnlitNoDstAlphaShader;
+    gpu::PipelinePointer pipeline = gpu::Pipeline::create(program, state);
+    _simpleSRGBTexturedUnlitNoDstAlphaPipeline = pipeline;
+    return pipeline;
 }
 
 void GeometryCache::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled, bool unlit, bool depthBiased) {

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -35,7 +35,7 @@
 #include "simple_vert.h"
 #include "simple_textured_frag.h"
 #include "simple_textured_unlit_frag.h"
-#include "simple_srgb_textured_unlit_no_dst_alpha_frag.h"
+#include "simple_srgb_textured_unlit_no_tex_alpha_frag.h"
 #include "glowLine_vert.h"
 #include "glowLine_geom.h"
 #include "glowLine_frag.h"
@@ -1749,25 +1749,25 @@ inline bool operator==(const SimpleProgramKey& a, const SimpleProgramKey& b) {
     return a.getRaw() == b.getRaw();
 }
 
-void GeometryCache::bindSimpleSRGBTexturedUnlitNoDstAlphaProgram(gpu::Batch& batch) {
-    batch.setPipeline(getSimpleSRGBTexturedUnlitNoDstAlphaPipeline());
+void GeometryCache::bindSimpleSRGBTexturedUnlitNoTexAlphaProgram(gpu::Batch& batch) {
+    batch.setPipeline(getSimpleSRGBTexturedUnlitNoTexAlphaPipeline());
     // Set a default normal map
     batch.setResourceTexture(render::ShapePipeline::Slot::MAP::NORMAL_FITTING,
         DependencyManager::get<TextureCache>()->getNormalFittingTexture());
 }
 
-gpu::PipelinePointer GeometryCache::getSimpleSRGBTexturedUnlitNoDstAlphaPipeline() {
+gpu::PipelinePointer GeometryCache::getSimpleSRGBTexturedUnlitNoTexAlphaPipeline() {
     // Compile the shaders, once
     static std::once_flag once;
     std::call_once(once, [&]() {
         auto VS = gpu::Shader::createVertex(std::string(simple_vert));
-        auto PS = gpu::Shader::createPixel(std::string(simple_srgb_textured_unlit_no_dst_alpha_frag));
+        auto PS = gpu::Shader::createPixel(std::string(simple_srgb_textured_unlit_no_tex_alpha_frag));
 
-        _simpleSRGBTexturedUnlitNoDstAlphaShader = gpu::Shader::createProgram(VS, PS);
+        _simpleSRGBTexturedUnlitNoTexAlphaShader = gpu::Shader::createProgram(VS, PS);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("normalFittingMap"), render::ShapePipeline::Slot::MAP::NORMAL_FITTING));
-        gpu::Shader::makeProgram(*_simpleSRGBTexturedUnlitNoDstAlphaShader, slotBindings);
+        gpu::Shader::makeProgram(*_simpleSRGBTexturedUnlitNoTexAlphaShader, slotBindings);
         auto state = std::make_shared<gpu::State>();
         state->setCullMode(gpu::State::CULL_NONE);
         state->setDepthTest(true, true, gpu::LESS_EQUAL);
@@ -1775,10 +1775,10 @@ gpu::PipelinePointer GeometryCache::getSimpleSRGBTexturedUnlitNoDstAlphaPipeline
                                 gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
                                 gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
-        _simpleSRGBTexturedUnlitNoDstAlphaPipeline = gpu::Pipeline::create(_simpleSRGBTexturedUnlitNoDstAlphaShader, state);
+        _simpleSRGBTexturedUnlitNoTexAlphaPipeline = gpu::Pipeline::create(_simpleSRGBTexturedUnlitNoTexAlphaShader, state);
     });
 
-    return _simpleSRGBTexturedUnlitNoDstAlphaPipeline;
+    return _simpleSRGBTexturedUnlitNoTexAlphaPipeline;
 }
 
 void GeometryCache::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled, bool unlit, bool depthBiased) {

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1768,25 +1768,17 @@ gpu::PipelinePointer GeometryCache::getSimpleSRGBTexturedUnlitNoDstAlphaPipeline
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("normalFittingMap"), render::ShapePipeline::Slot::MAP::NORMAL_FITTING));
         gpu::Shader::makeProgram(*_simpleSRGBTexturedUnlitNoDstAlphaShader, slotBindings);
+        auto state = std::make_shared<gpu::State>();
+        state->setCullMode(gpu::State::CULL_NONE);
+        state->setDepthTest(true, true, gpu::LESS_EQUAL);
+        state->setBlendFunction(false,
+                                gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+                                gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
+
+        _simpleSRGBTexturedUnlitNoDstAlphaPipeline = gpu::Pipeline::create(_simpleSRGBTexturedUnlitNoDstAlphaShader, state);
     });
 
-    if (_simpleSRGBTexturedUnlitNoDstAlphaPipeline) {
-        return _simpleSRGBTexturedUnlitNoDstAlphaPipeline;
-    }
-
-    // If the pipeline did not exist, make it
-    auto state = std::make_shared<gpu::State>();
-    state->setCullMode(gpu::State::CULL_NONE);
-
-    state->setDepthTest(true, true, gpu::LESS_EQUAL);
-    state->setBlendFunction(false,
-        gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
-        gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-
-    gpu::ShaderPointer program = _simpleSRGBTexturedUnlitNoDstAlphaShader;
-    gpu::PipelinePointer pipeline = gpu::Pipeline::create(program, state);
-    _simpleSRGBTexturedUnlitNoDstAlphaPipeline = pipeline;
-    return pipeline;
+    return _simpleSRGBTexturedUnlitNoDstAlphaPipeline;
 }
 
 void GeometryCache::bindSimpleProgram(gpu::Batch& batch, bool textured, bool culled, bool unlit, bool depthBiased) {

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -158,9 +158,8 @@ public:
     gpu::PipelinePointer getSimplePipeline(bool textured = false, bool culled = true,
                                           bool unlit = false, bool depthBias = false);
 
-
     void bindSimpleSRGBTexturedUnlitNoDstAlphaProgram(gpu::Batch& batch);
-    gpu::PipelinePointer GeometryCache::getSimpleSRGBTexturedUnlitNoDstAlphaPipeline();
+    gpu::PipelinePointer getSimpleSRGBTexturedUnlitNoDstAlphaPipeline();
 
     render::ShapePipelinePointer getShapePipeline() { return GeometryCache::_simplePipeline; }
     render::ShapePipelinePointer getWireShapePipeline() { return GeometryCache::_simpleWirePipeline; }

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -158,8 +158,8 @@ public:
     gpu::PipelinePointer getSimplePipeline(bool textured = false, bool culled = true,
                                           bool unlit = false, bool depthBias = false);
 
-    void bindSimpleSRGBTexturedUnlitNoDstAlphaProgram(gpu::Batch& batch);
-    gpu::PipelinePointer getSimpleSRGBTexturedUnlitNoDstAlphaPipeline();
+    void bindSimpleSRGBTexturedUnlitNoTexAlphaProgram(gpu::Batch& batch);
+    gpu::PipelinePointer getSimpleSRGBTexturedUnlitNoTexAlphaPipeline();
 
     render::ShapePipelinePointer getShapePipeline() { return GeometryCache::_simplePipeline; }
     render::ShapePipelinePointer getWireShapePipeline() { return GeometryCache::_simpleWirePipeline; }
@@ -421,8 +421,8 @@ private:
     gpu::PipelinePointer _glowLinePipeline;
     QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
 
-    gpu::ShaderPointer _simpleSRGBTexturedUnlitNoDstAlphaShader;
-    gpu::PipelinePointer _simpleSRGBTexturedUnlitNoDstAlphaPipeline;
+    gpu::ShaderPointer _simpleSRGBTexturedUnlitNoTexAlphaShader;
+    gpu::PipelinePointer _simpleSRGBTexturedUnlitNoTexAlphaPipeline;
 
 };
 

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -157,6 +157,11 @@ public:
     // Get the pipeline to render static geometry
     gpu::PipelinePointer getSimplePipeline(bool textured = false, bool culled = true,
                                           bool unlit = false, bool depthBias = false);
+
+
+    void bindSimpleSRGBTexturedUnlitNoDstAlphaProgram(gpu::Batch& batch);
+    gpu::PipelinePointer GeometryCache::getSimpleSRGBTexturedUnlitNoDstAlphaPipeline();
+
     render::ShapePipelinePointer getShapePipeline() { return GeometryCache::_simplePipeline; }
     render::ShapePipelinePointer getWireShapePipeline() { return GeometryCache::_simpleWirePipeline; }
 
@@ -416,6 +421,10 @@ private:
     static render::ShapePipelinePointer _simpleWirePipeline;
     gpu::PipelinePointer _glowLinePipeline;
     QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
+
+    gpu::ShaderPointer _simpleSRGBTexturedUnlitNoDstAlphaShader;
+    gpu::PipelinePointer _simpleSRGBTexturedUnlitNoDstAlphaPipeline;
+
 };
 
 #endif // hifi_GeometryCache_h

--- a/libraries/render-utils/src/simple_srgb_textured_unlit_no_dst_alpha.slf
+++ b/libraries/render-utils/src/simple_srgb_textured_unlit_no_dst_alpha.slf
@@ -1,0 +1,34 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  simple.frag
+//  fragment shader
+//
+//  Created by Anthony Thibault on 7/25/16.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include gpu/Color.slh@>
+<@include DeferredBufferWrite.slh@>
+
+// the albedo texture
+uniform sampler2D originalTexture;
+
+// the interpolated normal
+in vec3 _normal;
+in vec4 _color;
+in vec2 _texCoord0;
+
+void main(void) {
+    vec4 texel = texture(originalTexture, _texCoord0.st);
+    texel = colorToLinearRGBA(texel);
+
+    packDeferredFragmentUnlit(
+         normalize(_normal),
+         1.0,
+         _color.rgb * texel.rgb);
+}

--- a/libraries/render-utils/src/simple_srgb_textured_unlit_no_tex_alpha.slf
+++ b/libraries/render-utils/src/simple_srgb_textured_unlit_no_tex_alpha.slf
@@ -2,7 +2,7 @@
 <$VERSION_HEADER$>
 //  Generated on <$_SCRIBE_DATE$>
 //
-//  simple.frag
+//  simple_srgb_texture_unlit_no_tex_alpha.frag
 //  fragment shader
 //
 //  Created by Anthony Thibault on 7/25/16.


### PR DESCRIPTION
Many websites do not display correctly when used with a Web3DOverlay, or WebEntities.  For example the highfidelity marketplace.  This fixes this by adding a new pixel shader that properly converts from srgb into linear color space and ignores the texel alpha, always writing the overall color alpha value.