### PR TITLE
better allocation of CPU time while loading scenes and when slow scripts are running

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4679,7 +4679,7 @@ void Application::packetSent(quint64 length) {
 
 void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scriptEngine) {
 
-    scriptEngine->setPhysicsEnabledFunction([this]() { 
+    scriptEngine->setEmitScriptUpdatesFunction([this]() {
         return isPhysicsEnabled();
     });
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4678,6 +4678,11 @@ void Application::packetSent(quint64 length) {
 }
 
 void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scriptEngine) {
+
+    scriptEngine->setPhysicsEnabledFunction([this]() { 
+        return isPhysicsEnabled();
+    });
+
     // setup the packet senders and jurisdiction listeners of the script engine's scripting interfaces so
     // we can use the same ones from the application.
     auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -215,6 +215,7 @@ public:
     qint64 getCurrentSessionRuntime() const { return _sessionRunTimer.elapsed(); }
 
     bool isAboutToQuit() const { return _aboutToQuit; }
+    bool isPhysicsEnabled() const { return _physicsEnabled; }
 
     // the isHMDMode is true whenever we use the interface from an HMD and not a standard flat display
     // rendering of several elements depend on that

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -894,7 +894,7 @@ void ScriptEngine::run() {
         qint64 now = usecTimestampNow();
 
         // we check for 'now' in the past in case people set their clock back
-        if (_isPhysicsEnabledFunc() && _lastUpdate < now) {
+        if (_emitScriptUpdates() && _lastUpdate < now) {
             float deltaTime = (float) (now - _lastUpdate) / (float) USECS_PER_SECOND;
             if (!_isFinished) {
                 auto preUpdate = clock::now();

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -168,7 +168,7 @@ public:
     // NOTE - this is used by the TypedArray implemetation. we need to review this for thread safety
     ArrayBufferClass* getArrayBufferClass() { return _arrayBufferClass; }
 
-    void setPhysicsEnabledFunction(std::function<bool()> func) { _isPhysicsEnabledFunc = func; }
+    void setEmitScriptUpdatesFunction(std::function<bool()> func) { _emitScriptUpdates = func; }
 
 public slots:
     void callAnimationStateHandler(QScriptValue callback, AnimVariantMap parameters, QStringList names, bool useNames, AnimVariantResultHandler resultHandler);
@@ -239,7 +239,7 @@ protected:
     void doWithEnvironment(const EntityItemID& entityID, const QUrl& sandboxURL, std::function<void()> operation);
     void callWithEnvironment(const EntityItemID& entityID, const QUrl& sandboxURL, QScriptValue function, QScriptValue thisObject, QScriptValueList args);
 
-    std::function<bool()> _isPhysicsEnabledFunc{ [](){ return true; }  };
+    std::function<bool()> _emitScriptUpdates{ [](){ return true; }  };
 
 };
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -168,6 +168,8 @@ public:
     // NOTE - this is used by the TypedArray implemetation. we need to review this for thread safety
     ArrayBufferClass* getArrayBufferClass() { return _arrayBufferClass; }
 
+    void setPhysicsEnabledFunction(std::function<bool()> func) { _isPhysicsEnabledFunc = func; }
+
 public slots:
     void callAnimationStateHandler(QScriptValue callback, AnimVariantMap parameters, QStringList names, bool useNames, AnimVariantResultHandler resultHandler);
     void updateMemoryCost(const qint64&);
@@ -236,6 +238,9 @@ protected:
     QUrl currentSandboxURL {}; // The toplevel url string for the entity script that loaded the code being executed, else empty.
     void doWithEnvironment(const EntityItemID& entityID, const QUrl& sandboxURL, std::function<void()> operation);
     void callWithEnvironment(const EntityItemID& entityID, const QUrl& sandboxURL, QScriptValue function, QScriptValue thisObject, QScriptValueList args);
+
+    std::function<bool()> _isPhysicsEnabledFunc{ [](){ return true; }  };
+
 };
 
 #endif // hifi_ScriptEngine_h


### PR DESCRIPTION
This PR makes two changes to improve the CPU load and loading performance of scenes, as well as better handle scenes with complex scripts.

1) Scripts won't get "update" signals while the scene is still loading. Specifically during the time that physics is disabled during the scene load time. This allows the other CPU related tasks (like mesh parsing, or texture conversion) to get more access to the CPU. Scripts will still run, they just won't get updates sent to them.

2) Scripts that are taking a very long time in their update methods will get punished by being forced to sleep longer. This basically prevents poorly behaving scripts from hogging too much CPU time.