### PR TITLE
Tuned haptic pulses for grab, release, equip, de-quip

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1965,6 +1965,9 @@ function MyController(hand) {
         var noVelocity = false;
         if (this.grabbedEntity !== null) {
 
+            //  Make a small release haptic pulse if we really were holding something
+            Controller.triggerHapticPulse(HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, this.hand);
+
             // If this looks like the release after adjusting something still held in the other hand, print the position
             // and rotation of the held thing to help content creators set the userData.
             var grabData = getEntityCustomData(GRAB_USER_DATA_KEY, this.grabbedEntity, {});
@@ -2001,8 +2004,6 @@ function MyController(hand) {
             grabbedEntity: this.grabbedEntity,
             joint: this.hand === RIGHT_HAND ? "RightHand" : "LeftHand"
         }));
-
-        Controller.triggerHapticPulse(HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, this.hand);
 
         this.grabbedEntity = null;
         this.grabbedHotspot = null;

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1443,7 +1443,8 @@ function MyController(hand) {
     };
 
     this.distanceHolding = function(deltaTime, timestamp) {
-        if (this.triggerSmoothedReleased()) {
+        
+        if (!this.triggerClicked) {    
             this.callEntityMethodOnGrabbed("releaseGrab");
             this.setState(STATE_OFF, "trigger released");
             return;
@@ -1761,7 +1762,7 @@ function MyController(hand) {
 
     this.nearGrabbing = function(deltaTime, timestamp) {
 
-        if (this.state == STATE_NEAR_GRABBING && this.triggerSmoothedReleased()) {
+        if (this.state == STATE_NEAR_GRABBING && !this.triggerClicked) {
             this.callEntityMethodOnGrabbed("releaseGrab");
             this.setState(STATE_OFF, "trigger released");
             return;


### PR DESCRIPTION
For Vive, tuned haptic pulses for grab script: 

Near and Far grab/release now make a very slight pulse.
When the hand is in an equip sphere, there will be a textured feeling - very small vibrates as you move.
When turning upside down to release, you will feel a smaller pulse than before. 

TEST PLAN: 

Near and Far grab and equip/drop multiple things with both hands.  You should feel haptics as described above.   When showing and releasing search beam when nothing is grabbed, you should NOT feel anything.