### PR TITLE
fix Assets.getMapping(path, callback) to return a value

### DIFF
--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -62,8 +62,10 @@ void AssetMappingsScriptingInterface::getMapping(QString path, QJSValue callback
     auto request = assetClient->createGetMappingRequest(path);
 
     connect(request, &GetMappingRequest::finished, this, [this, callback](GetMappingRequest* request) mutable {
+        auto hash = request->getHash();
+
         if (callback.isCallable()) {
-            QJSValueList args { request->getErrorString() };
+            QJSValueList args { request->getErrorString(), hash };
             callback.call(args);
         }
 


### PR DESCRIPTION
This PR fixes a bug in `Assets.getMapping` where it wasn't providing the hash value back to the QML callback.

To test, here is a [client script and QML dialog](https://gist.githubusercontent.com/humbletim/45ed6da94dc0b38ebebe32476b2532de).  It can also be loaded directly into Interface using <kbd>Ctrl-Shift-O</kbd> and the URL:

`https://gist.githubusercontent.com/humbletim/45ed6da94dc0b38ebebe32476b2532de/raw/89aaf92cad5df7ff487b8db07e310f975979a9e0/test.js`

A successful result should look similar to the following (ie: with no [ERRORS] and a final [OK] displayed):

![image](https://cloud.githubusercontent.com/assets/94753/17267961/fcb1f348-55e6-11e6-83ee-095b8fac7166.png)
