### PR TITLE
fix remote triggering handControllerGrab 

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1267,7 +1267,7 @@ function MyController(hand) {
             if (this.triggerSmoothedGrab()) {
                 this.grabbedHotspot = potentialEquipHotspot;
                 this.grabbedEntity = potentialEquipHotspot.entityID;
-                this.setState(STATE_HOLD, "eqipping '" + entityPropertiesCache.getProps(this.grabbedEntity).name + "'");
+                this.setState(STATE_HOLD, "equipping '" + entityPropertiesCache.getProps(this.grabbedEntity).name + "'");
                 return;
             }
         }
@@ -2354,9 +2354,20 @@ var handleHandMessages = function(channel, message, sender) {
             try {
                 data = JSON.parse(message);
                 var selectedController = (data.hand === 'left') ? leftController : rightController;
+                var hotspotIndex = data.hotspotIndex !== undefined ? parseInt(data.hotspotIndex) : 0;
                 selectedController.release();
+                var wearableEntity = data.entityID;
+                entityPropertiesCache.addEntity(wearableEntity);
+                selectedController.grabbedEntity = wearableEntity;
+                var hotspots = selectedController.collectEquipHotspots(selectedController.grabbedEntity);
+                if (hotspots.length > 0) {
+                    if (hotspotIndex >= hotspots.length) {
+                        hotspotIndex = 0;
+                    }
+                    selectedController.grabbedHotspot = hotspots[hotspotIndex];
+                }
                 selectedController.setState(STATE_HOLD, "Hifi-Hand-Grab msg received");
-                selectedController.grabbedEntity = data.entityID;
+                selectedController.nearGrabbingEnter();
 
             } catch (e) {
                 print("WARNING: error parsing Hifi-Hand-Grab message");


### PR DESCRIPTION
Fixes the handControllerGrab `Hifi-Hand-Grab` message. Was broken since the hotspot changes to handControllerGrab.js.


## Testplan

1. copy the ID of a grab-able entity like the pingpong gun. (in the edit.js script's properties window it should be displayed on top)
2. open ` tools -> console` and enter the following command
    - `Messages.sendLocalMessage('Hifi-Hand-Grab', JSON.stringify({hand: 'right', entityID: '{12345678-1111-2222-3333-123456789012}'}));` 
    - (replace `{12345678-1111-2222-3333-123456789012}` with your entity ID)
3. The entity should be attached to your right hand.