### PR TITLE
Fix confirm dialog

### DIFF
--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -107,7 +107,7 @@ public:
         QMessageBox::StandardButtons buttons = QMessageBox::Ok,
         QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
     static QMessageBox::StandardButton question(const QString& title, const QString& text,
-        QMessageBox::StandardButtons buttons = QMessageBox::Ok,
+        QMessageBox::StandardButtons buttons = QMessageBox::Yes | QMessageBox::No,
         QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
     static QMessageBox::StandardButton warning(const QString& title, const QString& text,
         QMessageBox::StandardButtons buttons = QMessageBox::Ok,


### PR DESCRIPTION
Fixes [FogBugz 1334](https://highfidelity.fogbugz.com/f/cases/1334/Js-confirm-popup-returns-false-when-ok-clicked).

### Testing
1. Open up the JS console and run `Window.confirm("Confirming");`
2. A dialog box should appear with yes and no buttons
3. The function should return true on yes, false on no