### PR TITLE
Remove url change debug info for WebView

### DIFF
--- a/interface/resources/qml/controls-uit/WebView.qml
+++ b/interface/resources/qml/controls-uit/WebView.qml
@@ -35,7 +35,6 @@ WebEngineView {
     }
 
     onUrlChanged: {
-        console.log("Url changed to " + url);
         var originalUrl = url.toString();
         newUrl = urlHandler.fixupUrl(originalUrl).toString();
         if (newUrl !== originalUrl) {

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -26,7 +26,6 @@ WebEngineView {
     }
 
     onUrlChanged: {
-        console.log("Url changed to " + url);
         var originalUrl = url.toString();
         newUrl = urlHandler.fixupUrl(originalUrl).toString();
         if (newUrl !== originalUrl) {


### PR DESCRIPTION
Fixes [FogBugz 1231](https://highfidelity.fogbugz.com/f/cases/1231/Remove-Url-changed-to-from-WebView-logs).

### Testing

1. Open a WebView like the one shown by marketplace.js (click the market icon in the toolbar)
2. Open the logs, reveal log file, and search the file for instances of `Url changed to`
3. There should be none in the most recent log file