### PR TITLE
Fix parsing of embedded entity scripts

### DIFF
--- a/libraries/script-engine/src/ScriptCache.cpp
+++ b/libraries/script-engine/src/ScriptCache.cpp
@@ -110,9 +110,16 @@ void ScriptCache::getScriptContents(const QString& scriptOrURL, contentAvailable
     QUrl url = ResourceManager::normalizeURL(unnormalizedURL);
 
     // attempt to determine if this is a URL to a script, or if this is actually a script itself (which is valid in the entityScript use case)
-    if (url.scheme().isEmpty() && scriptOrURL.simplified().replace(" ", "").contains("(function(){")) {
+    if (unnormalizedURL.scheme().isEmpty() && scriptOrURL.simplified().replace(" ", "").contains("(function(){")) {
         contentAvailable(scriptOrURL, scriptOrURL, false, true);
         return;
+    }
+
+    // give a similar treatment to javacript: urls
+    if (unnormalizedURL.scheme() == "javascript") {
+        QString contents{ scriptOrURL };
+        contents.replace(QRegExp("^javascript:"), "");
+        contentAvailable(scriptOrURL, contents, false, true);
     }
 
     Lock lock(_containerLock);


### PR DESCRIPTION
Now correctly identifies when scripts are not URLs as well as `javascript:` urls.

Fixes [FogBugz 179](https://highfidelity.fogbugz.com/f/cases/179/simple-inline-direct-code-injection-entity-scripts-fail-to-load)

### Testing
1. Pick an entity without a script, and paste `(function(){ print("FOOOOOOO"); });` into the script url field.
2. The console should print `FOOOOOOO`, there should be no complaints about `file:///(function(){ print("FOOOOOOO"); });`
3. Pick another entity without a script (or use the same one) and paste `javascript:(function(){ print("BAAAAAAAAAR"); });` into the url field
4. Likewise, the console should print `BAAAAAAAAR` with no related errors or warnings
5. Maybe try some more complicated scripts too, and some valid urls that might look like javascript - it's looking for `(function(){`