### PR TITLE
Bug fix for avatar debug marker rendering.

### DIFF
--- a/libraries/render-utils/src/AnimDebugDraw.cpp
+++ b/libraries/render-utils/src/AnimDebugDraw.cpp
@@ -374,8 +374,6 @@ void AnimDebugDraw::update() {
                 }
             }
         }
-        data._vertexBuffer->resize(sizeof(Vertex) * numVerts);
-        data._vertexBuffer->setSubData<Vertex>(0, vertices);
 
         // draw markers from shared DebugDraw singleton
         for (auto& iter : markerMap) {
@@ -402,6 +400,9 @@ void AnimDebugDraw::update() {
             addLine(std::get<0>(iter), std::get<1>(iter), std::get<2>(iter), v);
         }
         DebugDraw::getInstance().clearRays();
+
+        data._vertexBuffer->resize(sizeof(Vertex) * numVerts);
+        data._vertexBuffer->setSubData<Vertex>(0, vertices);
 
         assert((!numVerts && !v) || (numVerts == (v - &vertices[0])));
 


### PR DESCRIPTION
"Developer > Hands > Show Hand Targets" works again
"Developer > Avatar > Draw Position" works again