### PR TITLE
fix bug which caused getValue for a non-existent key to return the integer 2

### DIFF
--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -91,7 +91,7 @@ void Settings::setValue(const QString& name, const QVariant& value) {
 QVariant Settings::value(const QString& name, const QVariant& defaultValue) const {
     QVariant result = _manager->value(name, defaultValue);
     if (result == _manager->unsetValue()) {
-        return QVariant(QString());
+        return defaultValue;
     }
     return result;
 }

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -89,11 +89,7 @@ void Settings::setValue(const QString& name, const QVariant& value) {
 }
 
 QVariant Settings::value(const QString& name, const QVariant& defaultValue) const {
-    QVariant result = _manager->value(name, defaultValue);
-    if (result == _manager->unsetValue()) {
-        return defaultValue;
-    }
-    return result;
+    return _manager->value(name, defaultValue);
 }
 
 

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -89,7 +89,11 @@ void Settings::setValue(const QString& name, const QVariant& value) {
 }
 
 QVariant Settings::value(const QString& name, const QVariant& defaultValue) const {
-    return _manager->value(name, defaultValue);
+    QVariant result = _manager->value(name, defaultValue);
+    if (result == _manager->unsetValue()) {
+        return QVariant(QString());
+    }
+    return result;
 }
 
 

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -53,7 +53,7 @@ namespace Setting {
         const auto& key = handle->getKey();
         withWriteLock([&] {
             QVariant loadedValue;
-            if (_pendingChanges.contains(key)) {
+            if (_pendingChanges.contains(key) && _pendingChanges[key] != UNSET_VALUE) {
                 loadedValue = _pendingChanges[key];
             } else {
                 loadedValue = value(key);
@@ -70,10 +70,11 @@ namespace Setting {
         QVariant handleValue = UNSET_VALUE;
         if (handle->isSet()) {
             handleValue = handle->getVariant();
-            withWriteLock([&] {
-                _pendingChanges[key] = handleValue;
-            });
         }
+
+        withWriteLock([&] {
+            _pendingChanges[key] = handleValue;
+        });
     }
 
     static const int SAVE_INTERVAL_MSEC = 5 * 1000; // 5 sec

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -70,11 +70,10 @@ namespace Setting {
         QVariant handleValue = UNSET_VALUE;
         if (handle->isSet()) {
             handleValue = handle->getVariant();
+            withWriteLock([&] {
+                _pendingChanges[key] = handleValue;
+            });
         }
-
-        withWriteLock([&] {
-            _pendingChanges[key] = handleValue;
-        });
     }
 
     static const int SAVE_INTERVAL_MSEC = 5 * 1000; // 5 sec

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -46,7 +46,7 @@ namespace Setting {
     private:
         QHash<QString, Interface*> _handles;
         QPointer<QTimer> _saveTimer = nullptr;
-        const QVariant UNSET_VALUE { QUuid::createUuid().variant() };
+        const QVariant UNSET_VALUE { QUuid::createUuid() };
         QHash<QString, QVariant> _pendingChanges;
 
         friend class Interface;

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -28,7 +28,6 @@ namespace Setting {
 
     public:
         void customDeleter() override;
-        const QVariant& unsetValue() { return UNSET_VALUE; }
 
     protected:
         ~Manager();

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -28,7 +28,7 @@ namespace Setting {
 
     public:
         void customDeleter() override;
-        QVariant unsetValue() { return UNSET_VALUE; }
+        const QVariant& unsetValue() { return UNSET_VALUE; }
 
     protected:
         ~Manager();

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -28,6 +28,7 @@ namespace Setting {
 
     public:
         void customDeleter() override;
+        QVariant unsetValue() { return UNSET_VALUE; }
 
     protected:
         ~Manager();


### PR DESCRIPTION
- fix bug which caused getValue for a non-existent Settings key to return the integer 2
