### PR TITLE
allow scripts to launch qml windows

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -28,6 +28,12 @@
 static const QString DESKTOP_LOCATION = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
 static const QString LAST_BROWSE_LOCATION_SETTING = "LastBrowseLocation";
 
+void WindowScriptingInterface::show(const QString& url, const QString& title) {
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    offscreenUi->executeOnUiThread([=] {
+        offscreenUi->show(url, title);
+    });
+}
 
 QScriptValue CustomPromptResultToScriptValue(QScriptEngine* engine, const CustomPromptResult& result) {
     if (!result.value.isValid()) {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -42,6 +42,7 @@ public:
     int getInnerHeight();
     int getX();
     int getY();
+    Q_INVOKABLE void show(const QString& url, const QString& title);
 
 public slots:
     QScriptValue hasFocus();


### PR DESCRIPTION
test notes:
Open javascript console, and enter Window.show("hifi/dialogs/RunningScripts.qml", "Test")