### PR TITLE
Fix Standard.A/B/X/Y primary thumb JSON mappings

### DIFF
--- a/interface/resources/controllers/oculus_touch.json
+++ b/interface/resources/controllers/oculus_touch.json
@@ -1,8 +1,13 @@
 {
     "name": "Oculus Touch to Standard",
     "channels": [
-        { "from": "OculusTouch.A", "to": "Standard.RightPrimaryThumb" },
-        { "from": "OculusTouch.X", "to": "Standard.LeftPrimaryThumb" },
+        { "from": "OculusTouch.A", "to": "Standard.RightPrimaryThumb", "peek": true },
+        { "from": "OculusTouch.X", "to": "Standard.LeftPrimaryThumb", "peek": true },
+
+        { "from": "OculusTouch.A", "to": "Standard.A" },
+        { "from": "OculusTouch.B", "to": "Standard.B" },
+        { "from": "OculusTouch.X", "to": "Standard.X" },
+        { "from": "OculusTouch.Y", "to": "Standard.Y" },
 
         { "from": "OculusTouch.LY", "to": "Standard.LY",
             "filters": [

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -32,9 +32,6 @@
         { "from": "Standard.Back", "to": "Actions.CycleCamera" },
         { "from": "Standard.Start", "to": "Actions.ContextMenu" },
 
-        { "from": [ "Standard.DU", "Standard.DL", "Standard.DR", "Standard.DD" ], "to": "Standard.LeftPrimaryThumb" },
-        { "from": [ "Standard.A", "Standard.B", "Standard.X", "Standard.Y" ], "to": "Standard.RightPrimaryThumb" },
-
         { "from": "Standard.LT", "to": "Actions.LeftHandClick" }, 
         { "from": "Standard.RT", "to": "Actions.RightHandClick" },
 

--- a/interface/resources/controllers/xbox.json
+++ b/interface/resources/controllers/xbox.json
@@ -15,12 +15,14 @@
 
         { "from": "GamePad.Back", "to": "Standard.Back" }, 
         { "from": "GamePad.Start", "to": "Standard.Start" }, 
-        
+
+        { "from": [ "GamePad.DU", "GamePad.DL", "GamePad.DR", "GamePad.DD" ], "to": "Standard.LeftPrimaryThumb", "peek": true },
         { "from": "GamePad.DU", "to": "Standard.DU" },
         { "from": "GamePad.DD", "to": "Standard.DD" }, 
         { "from": "GamePad.DL", "to": "Standard.DL" },
         { "from": "GamePad.DR", "to": "Standard.DR" }, 
 
+        { "from": [ "GamePad.A", "GamePad.B", "GamePad.X", "GamePad.Y" ], "to": "Standard.RightPrimaryThumb", "peek": true },
         { "from": "GamePad.A", "to": "Standard.A" }, 
         { "from": "GamePad.B", "to": "Standard.B" }, 
         { "from": "GamePad.X", "to": "Standard.X" },


### PR DESCRIPTION
We were mapping from Standard.A/B/X/Y to RightPrimaryThumb and Standard.DU/DL/DR/DD to LeftPrimaryThumb, but that mapping is only really true on the SDL controllers.  This should fix it on the Oculus Touches.