### PR TITLE
eslintrc: accept spaces after function keyword in anonymous functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,6 @@ module.exports = {
         "spaced-comment": ["error", "always", {
             "line": { "markers": ["/"] }
         }],
-        "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}]
+        "space-before-function-paren": ["error", {"anonymous": "ignore", "named": "never"}]
     }
 };


### PR DESCRIPTION
Anonymous functions `function () {}` and `function() {}` will both be accepted by eslint.