### PR TITLE
First cut of a snapshot uploader

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5082,6 +5082,11 @@ void Application::takeSnapshot(bool notify) {
     emit DependencyManager::get<WindowScriptingInterface>()->snapshotTaken(path, notify);
 }
 
+void Application::shareSnapshot(const QString& path) {
+    // not much to do here, everything is done in snapshot code...
+    Snapshot::uploadSnapshot(path);
+}
+
 float Application::getRenderResolutionScale() const {
     if (Menu::getInstance()->isOptionChecked(MenuOption::RenderResolutionOne)) {
         return 1.0f;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -249,6 +249,7 @@ public:
     float getAverageSimsPerSecond() const { return _simCounter.rate(); }
     
     void takeSnapshot(bool notify);
+    void shareSnapshot(const QString& filename);
 
 signals:
     void svoImportRequested(const QString& url);

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -202,7 +202,13 @@ void WindowScriptingInterface::copyToClipboard(const QString& text) {
 
 void WindowScriptingInterface::takeSnapshot(bool notify) {
     // only evil-doers call takeSnapshot from a random thread
-    qApp->postLambdaEvent([&] {
+    qApp->postLambdaEvent([notify] {
         qApp->takeSnapshot(notify);
+    });
+}
+
+void WindowScriptingInterface::shareSnapshot(const QString& path) {
+    qApp->postLambdaEvent([path] {
+        qApp->shareSnapshot(path);
     });
 }

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -55,12 +55,14 @@ public slots:
     QScriptValue save(const QString& title = "", const QString& directory = "",  const QString& nameFilter = "");
     void copyToClipboard(const QString& text);
     void takeSnapshot(bool notify);
+    void shareSnapshot(const QString& path);
 
 signals:
     void domainChanged(const QString& domainHostname);
     void svoImportRequested(const QString& url);
     void domainConnectionRefused(const QString& reasonMessage, int reasonCode);
     void snapshotTaken(const QString& path, bool notify);
+    void snapshotShared(bool success);
 
 private slots:
     WebWindowClass* doCreateWebWindow(const QString& title, const QString& url, int width, int height);

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -188,12 +188,17 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
     QJsonParseError jsonError;
     auto doc = QJsonDocument::fromJson(contents, &jsonError);
     if (jsonError.error == QJsonParseError::NoError) {
-        QString thumbnail_url = doc.object().value("thumbnail_url").toString();
+        QString thumbnailUrl = doc.object().value("thumbnail_url").toString();
+        QString placeName = DependencyManager::get<AddressManager>()->getPlaceName();
+        if(placeName.isEmpty()) {
+            placeName = DependencyManager::get<AddressManager>()->getHost();
+        }
 
         // create json post data
         QJsonObject rootObject;
         QJsonObject userStoryObject;
-        userStoryObject.insert("thumbnail_url", thumbnail_url);
+        userStoryObject.insert("thumbnail_url", thumbnailUrl);
+        userStoryObject.insert("place_name", placeName);
         userStoryObject.insert("action", "snapshot");
         rootObject.insert("user_story", userStoryObject);
 

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -189,16 +189,19 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
     auto doc = QJsonDocument::fromJson(contents, &jsonError);
     if (jsonError.error == QJsonParseError::NoError) {
         QString thumbnailUrl = doc.object().value("thumbnail_url").toString();
-        QString placeName = DependencyManager::get<AddressManager>()->getPlaceName();
+        auto addressManager = DependencyManager::get<AddressManager>();
+        QString placeName = addressManager->getPlaceName();
         if(placeName.isEmpty()) {
-            placeName = DependencyManager::get<AddressManager>()->getHost();
+            placeName = addressManager->getHost();
         }
+        QString currentPath = addressManager->currentPath(true);
 
         // create json post data
         QJsonObject rootObject;
         QJsonObject userStoryObject;
         userStoryObject.insert("thumbnail_url", thumbnailUrl);
         userStoryObject.insert("place_name", placeName);
+        userStoryObject.insert("path", currentPath);
         userStoryObject.insert("action", "snapshot");
         rootObject.insert("user_story", userStoryObject);
 

--- a/interface/src/ui/Snapshot.h
+++ b/interface/src/ui/Snapshot.h
@@ -32,6 +32,16 @@ private:
     QUrl _URL;
 };
 
+
+class SnapshotUploader: public QObject {
+    Q_OBJECT
+public slots:
+    void uploadSuccess(QNetworkReply& reply);
+    void uploadFailure(QNetworkReply& reply);
+    void createStorySuccess(QNetworkReply& reply);
+    void createStoryFailure(QNetworkReply& reply);
+};
+
 class Snapshot {
 public:
     static QString saveSnapshot(QImage image);
@@ -40,6 +50,7 @@ public:
 
     static Setting::Handle<QString> snapshotsLocation;
     static Setting::Handle<bool> hasSetSnapshotsLocation;
+    static void uploadSnapshot(const QString& filename);
 private:
     static QFile* savedFileForSnapshot(QImage & image, bool isTemporary);
 };

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -29,7 +29,7 @@ function confirmShare(data) {
 }
 
 function snapshotShared(success) {
-    if(success) {
+    if (success) {
         // for now just print status
         print('snapshot uploaded and shared');
     } else {

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -24,7 +24,18 @@ function confirmShare(data) {
     if (!Window.confirm("Share snapshot " + data.localPath + "?")) { // This dialog will be more elaborate...
         return;
     }
-    Window.alert("Pretending to upload. That code will go here.");
+    Window.snapshotShared.connect(snapshotShared);
+    Window.shareSnapshot(data.localPath); 
+}
+
+function snapshotShared(success) {
+    if(success) {
+        // for now just print status
+        print('snapshot uploaded and shared');
+    } else {
+        // for now just print an error.
+        print('snapshot upload/share failed');
+    } 
 }
 
 function onClicked() {


### PR DESCRIPTION
Changes that allow us to share a snapshot.  Calls into data-web to upload snapshot, then a second call to create the user story.  Note this depends on backend work in https://github.com/highfidelity/data-web/pull/789

Couple things not completely done yet:  
* The share dialog is quite rough, we will want to make that look nice
* Do we want to delete the snap from the hard drive after sharing when successful?  
