### PR TITLE
Suppress repeated ice server connection messages

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1233,7 +1233,10 @@ void DomainServer::sendICEServerAddressToMetaverseAPI() {
         callbackParameters.errorCallbackReceiver = this;
         callbackParameters.errorCallbackMethod = "handleFailedICEServerAddressUpdate";
 
-        qDebug() << "Updating ice-server address in High Fidelity Metaverse API to" << _iceServerSocket.getAddress().toString();
+        static QString repeatedMessage = LogHandler::getInstance().addOnlyOnceMessageRegex
+                   ("Updating ice-server address in High Fidelity Metaverse API to [^ \n]+");
+        qDebug() << "Updating ice-server address in High Fidelity Metaverse API to"
+                 << _iceServerSocket.getAddress().toString();
 
         static const QString DOMAIN_ICE_ADDRESS_UPDATE = "/api/v1/domains/%1/ice_server_address";
 


### PR DESCRIPTION
Fixes [FogBugz 1102](https://highfidelity.fogbugz.com/f/cases/1102/Loss-of-internet-connection-results-in-massive-log-spam-with-Domain-Server).

### Testing
1. You must have domain running fully automatic networking
2. It must have either a temporary or permanent place name
3. It must have previously connected to an ICE server and began heartbeats
4. It must fully lose its internet connection as in you've unplugged ethernet cable class of lost
5. It should not spam "[07/01 11:21:13] [DEBUG] Updating ice-server address in High Fidelity Metaverse API to"
6. Make sure you can repro the bug on a production version to be sure it's actually fixed