### PR TITLE
Teleport works with xbox controllers

### DIFF
--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -234,17 +234,12 @@ function Teleporter() {
     this.rightRay = function() {
         var pose = Controller.getPoseValue(Controller.Standard.RightHand);
         var rightPosition = pose.valid ? Vec3.sum(Vec3.multiplyQbyV(MyAvatar.orientation, pose.translation), MyAvatar.position) : MyAvatar.getHeadPosition();
-        var rightRotation = pose.valid ? Quat.multiply(MyAvatar.orientation, pose.rotation) : MyAvatar.headOrientation;
-
-        var rightFinal = Quat.multiply(rightRotation, Quat.angleAxis(-90, {
-            x: 1,
-            y: 0,
-            z: 0
-        }));
+        var rightRotation = pose.valid ? Quat.multiply(MyAvatar.orientation, pose.rotation) :
+                                         Quat.multiply(MyAvatar.headOrientation, Quat.angleAxis(-90, {x: 1, y: 0, z: 0}));
 
         var rightPickRay = {
             origin: rightPosition,
-            direction: Quat.getUp(pose.valid ? rightRotation : rightFinal),
+            direction: Quat.getUp(rightRotation),
         };
 
         this.rightPickRay = rightPickRay;
@@ -287,17 +282,12 @@ function Teleporter() {
     this.leftRay = function() {
         var pose = Controller.getPoseValue(Controller.Standard.LeftHand);
         var leftPosition = pose.valid ? Vec3.sum(Vec3.multiplyQbyV(MyAvatar.orientation, pose.translation), MyAvatar.position) : MyAvatar.getHeadPosition();
-        var leftRotation = pose.valid ? Quat.multiply(MyAvatar.orientation, pose.rotation) : MyAvatar.headOrientation;
-
-        var leftFinal = Quat.multiply(leftRotation, Quat.angleAxis(-90, {
-            x: 1,
-            y: 0,
-            z: 0
-        }));
+        var leftRotation = pose.valid ? Quat.multiply(MyAvatar.orientation, pose.rotation) :
+                                        Quat.multiply(MyAvatar.headOrientation, Quat.angleAxis(-90, {x: 1, y: 0, z: 0}));
 
         var leftPickRay = {
             origin: leftPosition,
-            direction: Quat.getUp(pose.valid ? leftRotation : leftFinal),
+            direction: Quat.getUp(leftRotation),
         };
 
         this.leftPickRay = leftPickRay;

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -232,14 +232,11 @@ function Teleporter() {
     };
 
     this.rightRay = function() {
+        var pose = Controller.getPoseValue(Controller.Standard.RightHand);
+        var rightPosition = pose.valid ? Vec3.sum(Vec3.multiplyQbyV(MyAvatar.orientation, pose.translation), MyAvatar.position) : MyAvatar.getHeadPosition();
+        var rightRotation = pose.valid ? Quat.multiply(MyAvatar.orientation, pose.rotation) : MyAvatar.headOrientation;
 
-        var rightPosition = Vec3.sum(Vec3.multiplyQbyV(MyAvatar.orientation, Controller.getPoseValue(Controller.Standard.RightHand).translation), MyAvatar.position);
-
-        var rightControllerRotation = Controller.getPoseValue(Controller.Standard.RightHand).rotation;
-
-        var rightRotation = Quat.multiply(MyAvatar.orientation, rightControllerRotation);
-
-        var rightFinal = Quat.multiply(rightRotation, Quat.angleAxis(90, {
+        var rightFinal = Quat.multiply(rightRotation, Quat.angleAxis(-90, {
             x: 1,
             y: 0,
             z: 0
@@ -247,7 +244,7 @@ function Teleporter() {
 
         var rightPickRay = {
             origin: rightPosition,
-            direction: Quat.getUp(rightRotation),
+            direction: Quat.getUp(pose.valid ? rightRotation : rightFinal),
         };
 
         this.rightPickRay = rightPickRay;
@@ -288,11 +285,11 @@ function Teleporter() {
 
 
     this.leftRay = function() {
-        var leftPosition = Vec3.sum(Vec3.multiplyQbyV(MyAvatar.orientation, Controller.getPoseValue(Controller.Standard.LeftHand).translation), MyAvatar.position);
+        var pose = Controller.getPoseValue(Controller.Standard.LeftHand);
+        var leftPosition = pose.valid ? Vec3.sum(Vec3.multiplyQbyV(MyAvatar.orientation, pose.translation), MyAvatar.position) : MyAvatar.getHeadPosition();
+        var leftRotation = pose.valid ? Quat.multiply(MyAvatar.orientation, pose.rotation) : MyAvatar.headOrientation;
 
-        var leftRotation = Quat.multiply(MyAvatar.orientation, Controller.getPoseValue(Controller.Standard.LeftHand).rotation)
-
-        var leftFinal = Quat.multiply(leftRotation, Quat.angleAxis(90, {
+        var leftFinal = Quat.multiply(leftRotation, Quat.angleAxis(-90, {
             x: 1,
             y: 0,
             z: 0
@@ -300,7 +297,7 @@ function Teleporter() {
 
         var leftPickRay = {
             origin: leftPosition,
-            direction: Quat.getUp(leftRotation),
+            direction: Quat.getUp(pose.valid ? leftRotation : leftFinal),
         };
 
         this.leftPickRay = leftPickRay;


### PR DESCRIPTION
If a controller doesn't provide a valid hand pose (like with xbox controllers), use the avatar's head position and orientation instead.

This allows you to teleport with xbox controllers by controlling the teleporter with your head.