### PR TITLE
Disable loading client scripts over ATP

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5114,8 +5114,10 @@ void Application::setPreviousScriptLocation(const QString& location) {
 }
 
 void Application::loadScriptURLDialog() const {
-    auto newScript = OffscreenUi::getText(nullptr, "Open and Run Script", "Script URL");
-    if (!newScript.isEmpty()) {
+    auto newScript = OffscreenUi::getText(OffscreenUi::ICON_NONE, "Open and Run Script", "Script URL");
+    if (QUrl(newScript).scheme() == "atp") {
+        OffscreenUi::warning("Error Loading Script", "Cannot load client script over ATP");
+    } else if (!newScript.isEmpty()) {
         DependencyManager::get<ScriptEngines>()->loadScript(newScript);
     }
 }


### PR DESCRIPTION
Client scripts don't make sense when loaded from ATP, and fail to load when interface is restarted or when changing domains.

Fixes [FogBugz 1409](https://highfidelity.fogbugz.com/f/cases/1409/Client-scripts-served-over-ATP-fail-to-load-on-interface-startup).

### Testing
1. Go to Edit>Open and Run Script from URL...
2. Type in a valid ATP URL pointing to a valid script in your ATP server
3. A warning message should show saying ATP client scripts are not allowed
4. Type in a valid ATP URL  to a script that doesn't exist
5. The same error should show
6. A valid HTTP URL to a script that exists should load
7. A valid HTTP URL to a script that doesn't exist should show an error message saying the script failed to load (different error from the ATP message)
8. An invalid URL should show the same error as step 7