### PR TITLE
Fix procedural entity transparency

### DIFF
--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -91,11 +91,6 @@ void RenderableShapeEntityItem::render(RenderArgs* args) {
         _procedural.reset(new Procedural(getUserData()));
         _procedural->_vertexSource = simple_vert;
         _procedural->_fragmentSource = simple_frag;
-        _procedural->_state->setCullMode(gpu::State::CULL_NONE);
-        _procedural->_state->setDepthTest(true, true, gpu::LESS_EQUAL);
-        _procedural->_state->setBlendFunction(true,
-            gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
-            gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
     }
 
     gpu::Batch& batch = *args->_batch;

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -43,15 +43,17 @@ public:
 
     glm::vec4 getColor(const glm::vec4& entityColor);
     quint64 getFadeStartTime() { return _fadeStartTime; }
-    bool isFading() { return _isFading; }
+    bool isFading() { return _doesFade && _isFading; }
     void setIsFading(bool isFading) { _isFading = isFading; }
+    void setDoesFade(bool doesFade) { _doesFade = doesFade; }
 
     uint8_t _version { 1 };
 
     std::string _vertexSource;
     std::string _fragmentSource;
 
-    gpu::StatePointer _state;
+    gpu::StatePointer _opaqueState { std::make_shared<gpu::State>() };
+    gpu::StatePointer _transparentState { std::make_shared<gpu::State>() };
 
     enum StandardUniforms {
         DATE,
@@ -89,7 +91,8 @@ protected:
     UniformLambdas _uniforms;
     int32_t _standardUniformSlots[NUM_STANDARD_UNIFORMS];
     NetworkTexturePointer _channels[MAX_PROCEDURAL_TEXTURE_CHANNELS];
-    gpu::PipelinePointer _pipeline;
+    gpu::PipelinePointer _opaquePipeline;
+    gpu::PipelinePointer _transparentPipeline;
     gpu::ShaderPointer _vertexShader;
     gpu::ShaderPointer _fragmentShader;
     gpu::ShaderPointer _shader;
@@ -113,6 +116,7 @@ private:
     quint64 _fadeStartTime;
     bool _hasStartedFade { false };
     bool _isFading { false };
+    bool _doesFade { true };
 };
 
 #endif

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -22,7 +22,8 @@ ProceduralSkybox::ProceduralSkybox() : model::Skybox() {
     _procedural._vertexSource = skybox_vert;
     _procedural._fragmentSource = skybox_frag;
     // Adjust the pipeline state for background using the stencil test
-    _procedural._state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
+    _procedural.setDoesFade(false);
+    _procedural._opaqueState->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
 void ProceduralSkybox::clear() {


### PR DESCRIPTION
Addresses fogbugz case [1428](https://highfidelity.fogbugz.com/f/cases/1428/Procedural-shader-bugs)

Fixes a bug with transparency on procedural entities that was introduced with the fade effect.  Also disables fading on procedural skyboxes until zone fading can be properly added.