### PR TITLE
Don't always mark procedural shaders dirty

### DIFF
--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -115,6 +115,11 @@ bool Procedural::parseUrl(const QUrl& shaderUrl) {
         return false;
     }
 
+    // If the URL hasn't changed, don't mark the shader as dirty
+    if (_shaderUrl == shaderUrl) {
+        return true;
+    }
+
     _shaderUrl = shaderUrl;
     _shaderDirty = true;
 


### PR DESCRIPTION
Previously, anytime you modified any part of a procedural shape entities user data, it would get marked as _shaderDirty.  As a result, repeatedly modifying the uniforms would also reset the shaders, and, in turn, would continually reset iGlobalTime to 0.  No more!