### PR TITLE
Better create locations for Entities

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1129,36 +1129,37 @@ function handeMenuEvent(menuItem) {
     tooltip.show(false);
 }
 
-// This function tries to find a reasonable position to place a new entity based on the camera
-// position. If a reasonable position within the world bounds can't be found, `null` will
-// be returned. The returned position will also take into account grid snapping settings.
 function getPositionToCreateEntity() {
-    var distance = cameraManager.enabled ? cameraManager.zoomDistance : DEFAULT_ENTITY_DRAG_DROP_DISTANCE;
-    var direction = Quat.getFront(Camera.orientation);
-    var offset = Vec3.multiply(distance, direction);
-    var placementPosition = Vec3.sum(Camera.position, offset);
-
-    var cameraPosition = Camera.position;
-
     var HALF_TREE_SCALE = 16384;
-
-    var cameraOutOfBounds = Math.abs(cameraPosition.x) > HALF_TREE_SCALE || Math.abs(cameraPosition.y) > HALF_TREE_SCALE ||
-                            Math.abs(cameraPosition.z) > HALF_TREE_SCALE;
-    var placementOutOfBounds = Math.abs(placementPosition.x) > HALF_TREE_SCALE ||
-                               Math.abs(placementPosition.y) > HALF_TREE_SCALE ||
-                               Math.abs(placementPosition.z) > HALF_TREE_SCALE;
-
-    if (cameraOutOfBounds && placementOutOfBounds) {
-        return null;
+    var direction = Quat.getFront(MyAvatar.orientation);
+    var distance = 1;
+    var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, distance));
+    position.y +=0.5;
+    if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
+        return null
     }
-
-    placementPosition.x = Math.min(HALF_TREE_SCALE, Math.max(-HALF_TREE_SCALE, placementPosition.x));
-    placementPosition.y = Math.min(HALF_TREE_SCALE, Math.max(-HALF_TREE_SCALE, placementPosition.y));
-    placementPosition.z = Math.min(HALF_TREE_SCALE, Math.max(-HALF_TREE_SCALE, placementPosition.z));
-
-    return placementPosition;
+    return position;
 }
 
+function getPositionToImportEntity() {
+    var dimensions = Clipboard.getContentsDimensions();
+    var HALF_TREE_SCALE = 16384;
+    var direction = Quat.getFront(MyAvatar.orientation);
+    var distance = 1;
+    if (dimensions.x > distance) {
+        distance = dimensions.x
+    }
+    if (dimensions.z > distance) {
+        distance = dimensions.z
+    }
+    var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, distance));
+
+    if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
+        return null
+    }
+
+    return position;
+}
 function importSVO(importURL) {
     print("Import URL requested: " + importURL);
     if (!Entities.canAdjustLocks()) {
@@ -1183,7 +1184,7 @@ function importSVO(importURL) {
             z: 0
         };
         if (Clipboard.getClipboardContentsLargestDimension() < VERY_LARGE) {
-            position = getPositionToCreateEntity();
+            position = getPositionToImportEntity();
         }
         if (position !== null && position !== undefined) {
             var pastedEntityIDs = Clipboard.pasteEntities(position);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1148,17 +1148,12 @@ function getPositionToImportEntity() {
     var dimensions = Clipboard.getContentsDimensions();
     var HALF_TREE_SCALE = 16384;
     var direction = Quat.getFront(MyAvatar.orientation);
-    var distance = 1.5;
-    if (dimensions.x > distance) {
-        distance = dimensions.x / 2
-    }
-    if (dimensions.z > distance) {
-        distance = dimensions.z / 2
-    }
-    var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, distance));
+    var longest = 1;
+    longest = Math.sqrt(Math.pow(dimensions.x, 2) + Math.pow(dimensions.z, 2));
+    var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, longest));
 
     if (Camera.mode === "entity" || Camera.mode === "independent") {
-        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getFront(Camera.orientation), distance))
+        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getFront(Camera.orientation), longest))
     }
 
     if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1157,8 +1157,6 @@ function getPositionToImportEntity() {
     }
     var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, distance));
 
-    print('distance is:: ' + distance);
-
     if (Camera.mode === "entity" || Camera.mode === "independent") {
         position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getFront(Camera.orientation), distance))
     }

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1128,13 +1128,16 @@ function handeMenuEvent(menuItem) {
     }
     tooltip.show(false);
 }
-
 function getPositionToCreateEntity() {
     var HALF_TREE_SCALE = 16384;
     var direction = Quat.getFront(MyAvatar.orientation);
     var distance = 1;
     var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, distance));
-    position.y +=0.5;
+
+    if (Camera.mode === "entity" || Camera.mode === "independent") {
+        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getFront(Camera.orientation), distance))
+    }
+    position.y += 0.5;
     if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
         return null
     }
@@ -1145,14 +1148,20 @@ function getPositionToImportEntity() {
     var dimensions = Clipboard.getContentsDimensions();
     var HALF_TREE_SCALE = 16384;
     var direction = Quat.getFront(MyAvatar.orientation);
-    var distance = 1;
+    var distance = 1.5;
     if (dimensions.x > distance) {
-        distance = dimensions.x
+        distance = dimensions.x / 2
     }
     if (dimensions.z > distance) {
-        distance = dimensions.z
+        distance = dimensions.z / 2
     }
     var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, distance));
+
+    print('distance is:: ' + distance);
+
+    if (Camera.mode === "entity" || Camera.mode === "independent") {
+        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getFront(Camera.orientation), distance))
+    }
 
     if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
         return null


### PR DESCRIPTION
This PR makes it so that entities created using edit.js or imported from marketplace have better positions.

Previously, when you would import some objects from the marketplace they would end up in unpredictable locations or you would end up inside of them.  Now, you should never end up inside of an entity that you import.  Primitives should be created in predictable locations irrespective of the camera orientation.

To test:
1. Open edit.js
2. Import a cube.  Observe that it is about 1 meter in front of your avatar position about about a half meter above.
3.  Point your camera at the sky and repeat #2, cube should end up in the same place
4. Open up the marketplace and import "Dungeon Floor 6m x 6m"
5. Note that you are not inside of the floor.  In the release build, you end up inside of this and it jitters.
6. Test with some other marketplace items.