### PR TITLE
fix flashing in default skybox, and allow skybox lighting without textures

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4253,6 +4253,21 @@ namespace render {
         auto backgroundMode = skyStage->getBackgroundMode();
 
         switch (backgroundMode) {
+            case model::SunSkyStage::SKY_DEFAULT: {
+                static const glm::vec3 DEFAULT_SKYBOX_COLOR{ 255.0f / 255.0f, 220.0f / 255.0f, 194.0f / 255.0f };
+                static const float DEFAULT_SKYBOX_INTENSITY{ 0.2f };
+                static const float DEFAULT_SKYBOX_AMBIENT_INTENSITY{ 2.0f };
+                static const glm::vec3 DEFAULT_SKYBOX_DIRECTION{ 0.0f, 0.0f, -1.0f };
+
+                auto scene = DependencyManager::get<SceneScriptingInterface>()->getStage();
+                auto sceneKeyLight = scene->getKeyLight();
+                scene->setSunModelEnable(false);
+                sceneKeyLight->setColor(DEFAULT_SKYBOX_COLOR);
+                sceneKeyLight->setIntensity(DEFAULT_SKYBOX_INTENSITY);
+                sceneKeyLight->setAmbientIntensity(DEFAULT_SKYBOX_AMBIENT_INTENSITY);
+                sceneKeyLight->setDirection(DEFAULT_SKYBOX_DIRECTION);
+                // fall through: render a skybox, if available
+           }
             case model::SunSkyStage::SKY_BOX: {
                 auto skybox = skyStage->getSkybox();
                 if (skybox) {
@@ -4260,33 +4275,22 @@ namespace render {
                     skybox->render(batch, args->getViewFrustum());
                     break;
                 }
+                // fall through: render defaults, if available
             }
-
-            // Fall through: if no skybox is available, render the SKY_DOME
-            case model::SunSkyStage::SKY_DOME:  {
-               if (Menu::getInstance()->isOptionChecked(MenuOption::DefaultSkybox)) {
-                   static const glm::vec3 DEFAULT_SKYBOX_COLOR { 255.0f / 255.0f, 220.0f / 255.0f, 194.0f / 255.0f };
-                   static const float DEFAULT_SKYBOX_INTENSITY { 0.2f };
-                   static const float DEFAULT_SKYBOX_AMBIENT_INTENSITY { 2.0f };
-                   static const glm::vec3 DEFAULT_SKYBOX_DIRECTION { 0.0f, 0.0f, -1.0f };
-
-                   auto scene = DependencyManager::get<SceneScriptingInterface>()->getStage();
-                   auto sceneKeyLight = scene->getKeyLight();
-                   scene->setSunModelEnable(false);
-                   sceneKeyLight->setColor(DEFAULT_SKYBOX_COLOR);
-                   sceneKeyLight->setIntensity(DEFAULT_SKYBOX_INTENSITY);
-                   sceneKeyLight->setAmbientIntensity(DEFAULT_SKYBOX_AMBIENT_INTENSITY);
-                   sceneKeyLight->setDirection(DEFAULT_SKYBOX_DIRECTION);
-
-                   auto defaultSkyboxAmbientTexture = qApp->getDefaultSkyboxAmbientTexture();
-                   // do not set the ambient sphere - it peaks too high, and causes flashing when turning
-                   sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
-
-                   qApp->getDefaultSkybox()->render(batch, args->getViewFrustum());
-               }
+            case model::SunSkyStage::SKY_DEFAULT_AMBIENT_TEXTURE: {
+                if (Menu::getInstance()->isOptionChecked(MenuOption::DefaultSkybox)) {
+                    auto scene = DependencyManager::get<SceneScriptingInterface>()->getStage();
+                    auto sceneKeyLight = scene->getKeyLight();
+                    auto defaultSkyboxAmbientTexture = qApp->getDefaultSkyboxAmbientTexture();
+                    // do not set the ambient sphere - it peaks too high, and causes flashing when turning
+                    sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
+                }
+                // fall through: render defaults, if available
             }
-                break;
-
+            case model::SunSkyStage::SKY_DEFAULT_TEXTURE:
+                if (Menu::getInstance()->isOptionChecked(MenuOption::DefaultSkybox)) {
+                    qApp->getDefaultSkybox()->render(batch, args->getViewFrustum());
+                }
             case model::SunSkyStage::NO_BACKGROUND:
             default:
                 // this line intentionally left blank
@@ -4503,7 +4507,7 @@ void Application::clearDomainOctreeDetails() {
 
     auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
 
-    skyStage->setBackgroundMode(model::SunSkyStage::SKY_DOME);
+    skyStage->setBackgroundMode(model::SunSkyStage::SKY_DEFAULT);
 
     _recentlyClearedDomain = true;
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4279,7 +4279,7 @@ namespace render {
                    sceneKeyLight->setDirection(DEFAULT_SKYBOX_DIRECTION);
 
                    auto defaultSkyboxAmbientTexture = qApp->getDefaultSkyboxAmbientTexture();
-                   sceneKeyLight->setAmbientSphere(defaultSkyboxAmbientTexture->getIrradiance());
+                   // do not set the ambient sphere - it peaks too high, and causes flashing when turning
                    sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
 
                    qApp->getDefaultSkybox()->render(batch, args->getViewFrustum());

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -346,8 +346,6 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
     auto sceneStage = scene->getStage();
     auto skyStage = scene->getSkyStage();
     auto sceneKeyLight = sceneStage->getKeyLight();
-    auto sceneLocation = sceneStage->getLocation();
-    auto sceneTime = sceneStage->getTime();
     
     // Skybox and procedural skybox data
     auto skybox = std::dynamic_pointer_cast<ProceduralSkybox>(skyStage->getSkybox());
@@ -383,6 +381,8 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
         sceneStage->setLocation(zone->getStageProperties().getLongitude(),
             zone->getStageProperties().getLatitude(),
             zone->getStageProperties().getAltitude());
+
+        auto sceneTime = sceneStage->getTime();
         sceneTime->setHour(zone->getStageProperties().calculateHour());
         sceneTime->setDay(zone->getStageProperties().calculateDay());
     }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -185,25 +185,15 @@ private:
 
     QMultiMap<QUrl, EntityItemID> _waitingOnPreload;
 
-    bool _hasPreviousZone { false };
     std::shared_ptr<ZoneEntityItem> _bestZone;
     float _bestZoneVolume;
+
+    QString _zoneUserData;
 
     quint64 _lastZoneCheck { 0 };
     const quint64 ZONE_CHECK_INTERVAL = USECS_PER_MSEC * 100; // ~10hz
     const float ZONE_CHECK_DISTANCE = 0.001f;
 
-    glm::vec3 _previousKeyLightColor;
-    float _previousKeyLightIntensity;
-    float _previousKeyLightAmbientIntensity;
-    glm::vec3 _previousKeyLightDirection;
-    bool _previousStageSunModelEnabled;
-    float _previousStageLongitude;
-    float _previousStageLatitude;
-    float _previousStageAltitude;
-    float _previousStageHour;
-    int _previousStageDay;
-    
     QHash<EntityItemID, EntityItemPointer> _entitiesInScene;
     // For Scene.shouldRenderEntities
     QList<EntityItemID> _entityIDsLastInScene;

--- a/libraries/model/src/model/Stage.cpp
+++ b/libraries/model/src/model/Stage.cpp
@@ -244,21 +244,6 @@ void SunSkyStage::updateGraphicsObject() const {
         double originAlt = _earthSunModel.getAltitude();
         _sunLight->setPosition(Vec3(0.0f, originAlt, 0.0f));
     }
-
-    // Background
-    switch (getBackgroundMode()) {
-        case NO_BACKGROUND: {
-            break;
-        }
-        case SKY_DOME: {
-            break;
-        }
-        case SKY_BOX: {
-            break;
-        }
-        case NUM_BACKGROUND_MODES:
-            Q_UNREACHABLE();
-    };
 }
 
 void SunSkyStage::setBackgroundMode(BackgroundMode mode) {

--- a/libraries/model/src/model/Stage.h
+++ b/libraries/model/src/model/Stage.h
@@ -160,8 +160,10 @@ public:
  
     enum BackgroundMode {
         NO_BACKGROUND = 0,
-        SKY_DOME,
+        SKY_DEFAULT,
         SKY_BOX,
+        SKY_DEFAULT_AMBIENT_TEXTURE,
+        SKY_DEFAULT_TEXTURE,
 
         NUM_BACKGROUND_MODES,
     };
@@ -173,7 +175,7 @@ public:
     const SkyboxPointer& getSkybox() const { valid(); return _skybox; }
 
 protected:
-    BackgroundMode _backgroundMode = SKY_DOME;
+    BackgroundMode _backgroundMode = SKY_DEFAULT;
 
     LightPointer _sunLight;
     mutable SkyboxPointer _skybox;

--- a/tests/render-perf/src/main.cpp
+++ b/tests/render-perf/src/main.cpp
@@ -345,10 +345,6 @@ namespace render {
                 break;
             }
         }
-
-                                          // Fall through: if no skybox is available, render the SKY_DOME
-        case model::SunSkyStage::SKY_DOME:  
-        case model::SunSkyStage::NO_BACKGROUND:
         default:
             // this line intentionally left blank
             break;


### PR DESCRIPTION
- Fixes flashing on a default skybox
- Fixes skybox behavior to allow keylights without a skybox texture
- Removes skybox functionality to revert to previous skybox, as it may no longer exist