### PR TITLE
Movement changes for Hand Controllers

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -11,7 +11,7 @@
             [
                 { "type": "deadZone", "min": 0.15 },
                 "constrainToInteger",
-                { "type": "pulse", "interval": 0.5 },
+                { "type": "pulse", "interval": 0.25 },
                 { "type": "scale", "scale": 22.5 }
             ]
         },

--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -13,7 +13,6 @@
         { "from": "Vive.LS", "to": "Standard.LS" },
         { "from": "Vive.LSTouch", "to": "Standard.LSTouch" },
 
-        { "from": "Vive.RY", "when": "Vive.RSY", "filters": ["invert"], "to": "Standard.RY" },
         { "from": "Vive.RX", "when": "Vive.RSX", "to": "Standard.RX" },
         { 
         	"from": "Vive.RT", "to": "Standard.RT",

--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -1,8 +1,6 @@
 {
     "name": "Vive to Standard",
     "channels": [
-        { "from": "Vive.LY", "when": "Vive.LSY", "filters": ["invert"], "to": "Standard.LY" },
-        { "from": "Vive.LX", "when": "Vive.LSX", "to": "Standard.LX" },
         { 
         	"from": "Vive.LT", "to": "Standard.LT",
         	"filters": [

--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -1,9 +1,11 @@
 {
     "name": "Vive to Standard",
     "channels": [
+        { "from": "Vive.LY", "when": "Vive.LSY", "filters": ["invert"], "to": "Standard.LY" },
+        { "from": "Vive.LX", "when": "Vive.LSX", "to": "Standard.LX" },
         { 
-        	"from": "Vive.LT", "to": "Standard.LT",
-        	"filters": [
+            "from": "Vive.LT", "to": "Standard.LT",
+            "filters": [
                 { "type": "deadZone", "min": 0.05 }
             ]
         },
@@ -13,10 +15,11 @@
         { "from": "Vive.LS", "to": "Standard.LS" },
         { "from": "Vive.LSTouch", "to": "Standard.LSTouch" },
 
+        { "from": "Vive.RY", "when": "Vive.RSY", "filters": ["invert"], "to": "Standard.RY" },
         { "from": "Vive.RX", "when": "Vive.RSX", "to": "Standard.RX" },
         { 
-        	"from": "Vive.RT", "to": "Standard.RT",
-        	"filters": [
+            "from": "Vive.RT", "to": "Standard.RT",
+            "filters": [
                 { "type": "deadZone", "min": 0.05 }
             ]
         },

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -26,5 +26,6 @@ Script.load("system/controllers/handControllerPointer.js");
 Script.load("system/controllers/squeezeHands.js");
 Script.load("system/controllers/grab.js");
 Script.load("system/controllers/teleport.js");
+Script.load("system/controllers/advancedMovement.js")
 Script.load("system/dialTone.js");
 Script.load("system/firstPersonHMD.js");

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -21,11 +21,11 @@ Script.load("system/edit.js");
 Script.load("system/mod.js");
 Script.load("system/selectAudioDevice.js");
 Script.load("system/notifications.js");
-Script.load("system/controllers/toggleAdvancedMovementForHandControllers.js")
 Script.load("system/controllers/handControllerGrab.js");
 Script.load("system/controllers/handControllerPointer.js");
 Script.load("system/controllers/squeezeHands.js");
 Script.load("system/controllers/grab.js");
 Script.load("system/controllers/teleport.js");
+Script.load("system/controllers/toggleAdvancedMovementForHandControllers.js")
 Script.load("system/dialTone.js");
 Script.load("system/firstPersonHMD.js");

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -21,11 +21,11 @@ Script.load("system/edit.js");
 Script.load("system/mod.js");
 Script.load("system/selectAudioDevice.js");
 Script.load("system/notifications.js");
+Script.load("system/controllers/toggleAdvancedMovementForHandControllers.js")
 Script.load("system/controllers/handControllerGrab.js");
 Script.load("system/controllers/handControllerPointer.js");
 Script.load("system/controllers/squeezeHands.js");
 Script.load("system/controllers/grab.js");
 Script.load("system/controllers/teleport.js");
-Script.load("system/controllers/advancedMovement.js")
 Script.load("system/dialTone.js");
 Script.load("system/firstPersonHMD.js");

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -26,8 +26,6 @@ Script.load("system/controllers/handControllerPointer.js");
 Script.load("system/controllers/squeezeHands.js");
 Script.load("system/controllers/grab.js");
 Script.load("system/controllers/teleport.js");
-if (Controller.Hardware.Vive !== undefined) {
-    Script.load("system/controllers/advancedMovement.js")
-}
+Script.load("system/controllers/advancedMovement.js")
 Script.load("system/dialTone.js");
 Script.load("system/firstPersonHMD.js");

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -26,6 +26,8 @@ Script.load("system/controllers/handControllerPointer.js");
 Script.load("system/controllers/squeezeHands.js");
 Script.load("system/controllers/grab.js");
 Script.load("system/controllers/teleport.js");
-Script.load("system/controllers/advancedMovement.js")
+if (Controller.Hardware.Vive !== undefined) {
+    Script.load("system/controllers/advancedMovement.js")
+}
 Script.load("system/dialTone.js");
 Script.load("system/firstPersonHMD.js");

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -18,9 +18,9 @@ function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
     var VIVE = Controller.Hardware.Vive;
-    advancedMapping.from(VIVE.LY).when(Controller.Vive.LSY).invert().to(Controller.Standard.LY);
-    advancedMapping.from(VIVE.LX).when(Controller.Vive.LSX).to(Controller.Standard.LX);
-    advancedMapping.from(VIVE.RY).when(Controller.Vive.RSY).invert().to(Controller.Standard.RY);
+    advancedMapping.from(VIVE.LY).when(VIVE.LSY).invert().to(Controller.Standard.LY);
+    advancedMapping.from(VIVE.LX).when(VIVE.LSX).to(Controller.Standard.LX);
+    advancedMapping.from(VIVE.RY).when(VIVE.RSY).invert().to(Controller.Standard.RY);
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -17,22 +17,13 @@ function addTranslationToLeftStick() {
 function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
-    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY)).invert().to(
-        function(val) {
-            testPrint('LY:' + val);
-        });
-    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX)).to(
-        function(val) {
-            testPrint('LX' + val)
-        });
-    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY)).invert().to(
-        function(val) {
-            testPrint('RY' + val)
-        });
+    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY)===1).invert().to(Controller.Standard.LY);
+    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX)===1).to(Controller.Standard.LX);
+    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY)===1).invert().to(Controller.Standard.RY);
 }
 
-function testPrint(what) {
-    print(what)
+function testPrint(what){
+    print('it was controller: ' + what)
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -18,9 +18,12 @@ function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
     var VIVE = Controller.Hardware.Vive;
-    advancedMapping.from(VIVE.LY).when(VIVE.LSY).invert().to(Controller.Standard.LY);
-    advancedMapping.from(VIVE.LX).when(VIVE.LSX).to(Controller.Standard.LX);
-    advancedMapping.from(VIVE.RY).when(VIVE.RSY).invert().to(Controller.Standard.RY);
+    var LSY = Controller.getValue(VIVE.LSY);
+    var LSX = Controller.getValue(VIVE.LSX);
+    var RSY = Controller.getValue(VIVE.RSY);
+    advancedMapping.from(VIVE.LY).when(LSY).invert().to(Controller.Standard.LY);
+    advancedMapping.from(VIVE.LX).when(LSX).to(Controller.Standard.LX);
+    advancedMapping.from(VIVE.RY).when(RSY).invert().to(Controller.Standard.RY);
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -17,12 +17,18 @@ function addTranslationToLeftStick() {
 function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
-    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY)===1).invert().to(Controller.Standard.LY);
-    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX)===1).to(Controller.Standard.LX);
-    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY)===1).invert().to(Controller.Standard.RY);
+    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY) === 1).invert().to(function(val) {
+        testPrint('ly:' + val)
+    });
+    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX) === 1).to(function(val) {
+        testPrint('lx:' + val)
+    });
+    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY) === 1).invert().to(function(val) {
+        testPrint('ry:' + val)
+    });
 }
 
-function testPrint(what){
+function testPrint(what) {
     print('it was controller: ' + what)
 }
 

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -1,54 +1,78 @@
-var mappingName, advancedMapping;
+//advanced movements settings are in individual controller json files
+//what we do is check the status of the 'advance movement' checkbox when you enter HMD mode
+//if 'advanced movement' is checked...we give you the defaults that are in the json.
+//if 'advanced movement' is not checked... we override the advanced controls with basic ones.
+//when the script stops, 
+
+//todo: store in prefs
+//
+
+
+var mappingName, basicMapping;
 
 function addAdvancedMovementItemToSettingsMenu() {
     Menu.addMenuItem({
         menuName: "Settings",
-        menuItemName: "Advanced Movement (Vive)",
+        menuItemName: "Advanced Movement For Hand Controllers",
         isCheckable: true,
         isChecked: false
     });
 
 }
 
-function addTranslationToLeftStick() {
-    Controller.enableMapping(mappingName);
+function rotate180() {
+    MyAvatar.orientation = Quat.inverse(MyAvatar.orientation);
 }
 
-function registerMappings() {
+function registerBasicMapping() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
-    advancedMapping = Controller.newMapping(mappingName);
-    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY) === 1).invert().to(function(val) {
-        testPrint('ly:' + val)
+    basicMapping = Controller.newMapping(mappingName);
+    basicMapping.from(Controller.Standard.LY).to(function(value) {
+        var stick = Controller.getValue(Controller.Standard.LS);
+        if (value === 1) {
+            rotate180();
+        }
+        print('should do LY stuff' + value + ":stick:" + stick);
+        return;
     });
-    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX) === 1).to(function(val) {
-        testPrint('lx:' + val)
-    });
-    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY) === 1).invert().to(function(val) {
-        testPrint('ry:' + val)
-    });
+    basicMapping.from(Controller.Standard.LX).to(Controller.Standard.RX);
+    basicMapping.from(Controller.Standard.RY).to(function(value) {
+        var stick = Controller.getValue(Controller.Standard.RS);
+        if (value === 1) {
+            rotate180();
+        }
+        print('should do RY stuff' + value + ":stick:" + stick);
+        return;
+    })
 }
 
 function testPrint(what) {
     print('it was controller: ' + what)
 }
 
-function removeTranslationFromLeftStick() {
+function enableMappings() {
+    Controller.enableMapping(mappingName);
+}
+
+function disableMappings() {
     Controller.disableMapping(mappingName);
 }
 
 function scriptEnding() {
-    Menu.removeMenuItem("Settings", "Advanced Movement (Vive)");
-    removeTranslationFromLeftStick();
+    Menu.removeMenuItem("Settings", "Advanced Movement For Hand Controllers");
+    disableMappings();
 }
 
+var isChecked = false;
+
 function menuItemEvent(menuItem) {
-    if (menuItem == "Advanced Movement (Vive)") {
-        print("  checked=" + Menu.isOptionChecked("Advanced Movement (Vive)"));
-        var isChecked = Menu.isOptionChecked("Advanced Movement (Vive)");
+    if (menuItem == "Advanced Movement For Hand Controllers") {
+        print("  checked=" + Menu.isOptionChecked("Advanced Movement For Hand Controllers"));
+        isChecked = Menu.isOptionChecked("Advanced Movement For Hand Controllers");
         if (isChecked === true) {
-            addTranslationToLeftStick();
+            disableMappings();
         } else if (isChecked === false) {
-            removeTranslationFromLeftStick();
+            enableMappings();
         }
     }
 
@@ -56,9 +80,22 @@ function menuItemEvent(menuItem) {
 
 addAdvancedMovementItemToSettingsMenu();
 
-// register our scriptEnding callback
 Script.scriptEnding.connect(scriptEnding);
 
 Menu.menuItemEvent.connect(menuItemEvent);
 
-registerMappings();
+registerBasicMapping();
+enableMappings();
+
+HMD.displayModeChanged.connect(function(isHMDMode) {
+    if (isHMDMode) {
+        if (Controller.Hardware.Vive !== undefined || Controller.Hardware.OculusTouch !== undefined) {
+            if (isChecked === true) {
+                disableMappings();
+            } else if (isChecked === false) {
+                enableMappings();
+            }
+
+        }
+    }
+});

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -17,13 +17,22 @@ function addTranslationToLeftStick() {
 function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
-    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY)).invert().to(Controller.Standard.LY);
-    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX)).to(Controller.Standard.LX);
-    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY)).invert().to(Controller.Standard.RY);
+    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY)).invert().to(
+        function(val) {
+            testPrint('LY:' + val);
+        });
+    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX)).to(
+        function(val) {
+            testPrint('LX' + val)
+        });
+    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY)).invert().to(
+        function(val) {
+            testPrint('RY' + val)
+        });
 }
 
-function testPrint(what){
-    print('it was controller: ' + what)
+function testPrint(what) {
+    print(what)
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -1,0 +1,53 @@
+var mappingName, advancedMapping;
+
+function addAdvancedMovementItemToSettingsMenu() {
+    Menu.addMenuItem({
+        menuName: "Settings",
+        menuItemName: "Advanced Movement",
+        isCheckable: true,
+        isChecked: false
+    });
+
+}
+
+function addTranslationToLeftStick() {
+    Controller.enableMapping(mappingName);
+}
+
+function registerMappings() {
+    mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
+    advancedMapping = Controller.newMapping(mappingName);
+    advancedMapping.from(Controller.Vive.LY).invert().to(Controller.Standard.LY);
+    advancedMapping.from(Controller.Vive.LX).to(Controller.Standard.LX);
+}
+
+function removeTranslationFromLeftStick() {
+    Controller.disableMapping(mappingName);
+}
+
+function scriptEnding() {
+    Menu.removeMenuItem("Settings", "Advanced Movement");
+    removeTranslationFromLeftStick();
+}
+
+function menuItemEvent(menuItem) {
+    if (menuItem == "Advanced Movement") {
+        print("  checked=" + Menu.isOptionChecked("Advanced Movement"));
+        var isChecked = Menu.isOptionChecked("Advanced Movement");
+        if (isChecked === true) {
+            addTranslationToLeftStick();
+        } else if (isChecked === false) {
+            removeTranslationFromLeftStick();
+        }
+    }
+
+}
+
+addAdvancedMovementItemToSettingsMenu();
+
+// register our scriptEnding callback
+Script.scriptEnding.connect(scriptEnding);
+
+Menu.menuItemEvent.connect(menuItemEvent);
+
+registerMappings();

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -17,10 +17,13 @@ function addTranslationToLeftStick() {
 function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
-    var VIVE = Controller.Hardware.Vive;
-    advancedMapping.from(VIVE.LY).when(Controller.getValue(VIVE.LS)).invert().to(Controller.Standard.LY);
-    advancedMapping.from(VIVE.LX).when(Controller.getValue(VIVE.LS)).to(Controller.Standard.LX);
-    advancedMapping.from(VIVE.RY).when(Controller.getValue(VIVE.RS)).invert().to(Controller.Standard.RY);
+    advancedMapping.from(Controller.Hardware.Vive.LY).when(Controller.getValue(Controller.Hardware.Vive.LSY)).invert().to(Controller.Standard.LY);
+    advancedMapping.from(Controller.Hardware.Vive.LX).when(Controller.getValue(Controller.Hardware.Vive.LSX)).to(Controller.Standard.LX);
+    advancedMapping.from(Controller.Hardware.Vive.RY).when(Controller.getValue(Controller.Hardware.Vive.RSY)).invert().to(Controller.Standard.RY);
+}
+
+function testPrint(what){
+    print('it was controller: ' + what)
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -17,9 +17,9 @@ function addTranslationToLeftStick() {
 function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
-    advancedMapping.from(Controller.Vive.LY).invert().to(Controller.Standard.LY);
-    advancedMapping.from(Controller.Vive.LX).to(Controller.Standard.LX);
-    advancedMapping.from(Controller.Vive.RY).invert().to(Standard.RY);
+    advancedMapping.from(Controller.Vive.LY).when(Controller.Vive.LSY).invert().to(Controller.Standard.LY);
+    advancedMapping.from(Controller.Vive.LX).when(Controller.Vive.LSX).to(Controller.Standard.LX);
+    advancedMapping.from(Controller.Vive.RY).when(Controller.Vive.RSY).invert().to(Controller.Standard.RY);
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -17,9 +17,10 @@ function addTranslationToLeftStick() {
 function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
-    advancedMapping.from(Controller.Vive.LY).when(Controller.Vive.LSY).invert().to(Controller.Standard.LY);
-    advancedMapping.from(Controller.Vive.LX).when(Controller.Vive.LSX).to(Controller.Standard.LX);
-    advancedMapping.from(Controller.Vive.RY).when(Controller.Vive.RSY).invert().to(Controller.Standard.RY);
+    var VIVE = Controller.Hardware.Vive;
+    advancedMapping.from(VIVE.LY).when(Controller.Vive.LSY).invert().to(Controller.Standard.LY);
+    advancedMapping.from(VIVE.LX).when(Controller.Vive.LSX).to(Controller.Standard.LX);
+    advancedMapping.from(VIVE.RY).when(Controller.Vive.RSY).invert().to(Controller.Standard.RY);
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -8,14 +8,27 @@
 //
 
 
-var mappingName, basicMapping;
+var mappingName, basicMapping,isChecked;
+
+var previousSetting = Settings.getValue('advancedMovementForHandControllersIsChecked');
+if (previousSetting === '') {
+    previousSetting = false;
+    isChecked=false;
+}
+
+if(previousSetting===true){
+    isChecked=true;
+}
+if(previousSetting===false){
+    isChecked=false;
+}
 
 function addAdvancedMovementItemToSettingsMenu() {
     Menu.addMenuItem({
         menuName: "Settings",
         menuItemName: "Advanced Movement For Hand Controllers",
         isCheckable: true,
-        isChecked: false
+        isChecked: previousSetting
     });
 
 }
@@ -63,15 +76,16 @@ function scriptEnding() {
     disableMappings();
 }
 
-var isChecked = false;
 
 function menuItemEvent(menuItem) {
     if (menuItem == "Advanced Movement For Hand Controllers") {
         print("  checked=" + Menu.isOptionChecked("Advanced Movement For Hand Controllers"));
         isChecked = Menu.isOptionChecked("Advanced Movement For Hand Controllers");
         if (isChecked === true) {
+            Settings.setValue('advancedMovementForHandControllersIsChecked', true);
             disableMappings();
         } else if (isChecked === false) {
+            Settings.setValue('advancedMovementForHandControllersIsChecked', false);
             enableMappings();
         }
     }
@@ -85,7 +99,14 @@ Script.scriptEnding.connect(scriptEnding);
 Menu.menuItemEvent.connect(menuItemEvent);
 
 registerBasicMapping();
-enableMappings();
+if (previousSetting === true) {
+    print('JBP WAS SET TO TRUE')
+    disableMappings();
+} else if (previousSetting === false) {
+    print('JBP WAS SET TO FALSE')
+    enableMappings();
+}
+
 
 HMD.displayModeChanged.connect(function(isHMDMode) {
     if (isHMDMode) {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -18,9 +18,9 @@ function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
     var VIVE = Controller.Hardware.Vive;
-    advancedMapping.from(VIVE.LY).when(Controller.getValue(VIVE.LSY)).invert().to(Controller.Standard.LY);
-    advancedMapping.from(VIVE.LX).when(Controller.getValue(VIVE.LSX)).to(Controller.Standard.LX);
-    advancedMapping.from(VIVE.RY).when(Controller.getValue(VIVE.RSY)).invert().to(Controller.Standard.RY);
+    advancedMapping.from(VIVE.LY).when(Controller.getValue(VIVE.LS)).invert().to(Controller.Standard.LY);
+    advancedMapping.from(VIVE.LX).when(Controller.getValue(VIVE.LS)).to(Controller.Standard.LX);
+    advancedMapping.from(VIVE.RY).when(Controller.getValue(VIVE.RS)).invert().to(Controller.Standard.RY);
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -3,7 +3,7 @@ var mappingName, advancedMapping;
 function addAdvancedMovementItemToSettingsMenu() {
     Menu.addMenuItem({
         menuName: "Settings",
-        menuItemName: "Advanced Movement",
+        menuItemName: "Advanced Movement (Vive)",
         isCheckable: true,
         isChecked: false
     });
@@ -31,14 +31,14 @@ function removeTranslationFromLeftStick() {
 }
 
 function scriptEnding() {
-    Menu.removeMenuItem("Settings", "Advanced Movement");
+    Menu.removeMenuItem("Settings", "Advanced Movement (Vive)");
     removeTranslationFromLeftStick();
 }
 
 function menuItemEvent(menuItem) {
-    if (menuItem == "Advanced Movement") {
-        print("  checked=" + Menu.isOptionChecked("Advanced Movement"));
-        var isChecked = Menu.isOptionChecked("Advanced Movement");
+    if (menuItem == "Advanced Movement (Vive)") {
+        print("  checked=" + Menu.isOptionChecked("Advanced Movement (Vive)"));
+        var isChecked = Menu.isOptionChecked("Advanced Movement (Vive)");
         if (isChecked === true) {
             addTranslationToLeftStick();
         } else if (isChecked === false) {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -19,6 +19,7 @@ function registerMappings() {
     advancedMapping = Controller.newMapping(mappingName);
     advancedMapping.from(Controller.Vive.LY).invert().to(Controller.Standard.LY);
     advancedMapping.from(Controller.Vive.LX).to(Controller.Standard.LX);
+    advancedMapping.from(Controller.Vive.RY).invert().to(Standard.RY);
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/advancedMovement.js
+++ b/scripts/system/controllers/advancedMovement.js
@@ -18,12 +18,9 @@ function registerMappings() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     advancedMapping = Controller.newMapping(mappingName);
     var VIVE = Controller.Hardware.Vive;
-    var LSY = Controller.getValue(VIVE.LSY);
-    var LSX = Controller.getValue(VIVE.LSX);
-    var RSY = Controller.getValue(VIVE.RSY);
-    advancedMapping.from(VIVE.LY).when(LSY).invert().to(Controller.Standard.LY);
-    advancedMapping.from(VIVE.LX).when(LSX).to(Controller.Standard.LX);
-    advancedMapping.from(VIVE.RY).when(RSY).invert().to(Controller.Standard.RY);
+    advancedMapping.from(VIVE.LY).when(Controller.getValue(VIVE.LSY)).invert().to(Controller.Standard.LY);
+    advancedMapping.from(VIVE.LX).when(Controller.getValue(VIVE.LSX)).to(Controller.Standard.LX);
+    advancedMapping.from(VIVE.RY).when(Controller.getValue(VIVE.RSY)).invert().to(Controller.Standard.RY);
 }
 
 function removeTranslationFromLeftStick() {

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -37,7 +37,7 @@ var COLORS_TELEPORT_TOO_CLOSE = {
     blue: 73
 };
 
-var TELEPORT_CANCEL_RANGE = 1.5;
+var TELEPORT_CANCEL_RANGE = 1;
 var USE_COOL_IN = true;
 var COOL_IN_DURATION = 500;
 

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -115,13 +115,11 @@ function Teleporter() {
 
         inTeleportMode = true;
         this.inCoolIn = true;
-        print('setting cool in timeout')
         if (coolInTimeout !== null) {
             Script.clearTimeout(coolInTimeout);
 
         }
         coolInTimeout = Script.setTimeout(function() {
-            print('should exit cool in mode now' + COOL_IN_DURATION)
             _this.inCoolIn = false;
         }, COOL_IN_DURATION)
 
@@ -234,15 +232,12 @@ function Teleporter() {
             teleporter.leftRay();
             if ((leftPad.buttonValue === 0) && inTeleportMode === true) {
                 if (_this.inCoolIn === true) {
-                    print('released during cool in period.  exit.')
                     _this.exitTeleportMode();
                     _this.deleteTargetOverlay();
                     _this.deleteCancelOverlay();
                 } else {
-                    print('release while not in cool in and in teleport mode. should teleport')
                     _this.teleport();
                 }
-                print('some other state::' + leftPad.buttonValue + "///" + inTeleportMode)
                 return;
             }
 
@@ -253,15 +248,12 @@ function Teleporter() {
             teleporter.rightRay();
             if ((rightPad.buttonValue === 0) && inTeleportMode === true) {
                 if (_this.inCoolIn === true) {
-                    print('released during cool in period.  exit.')
                     _this.exitTeleportMode();
                     _this.deleteTargetOverlay();
                     _this.deleteCancelOverlay();
                 } else {
-                    print('release while not in cool in and in teleport mode. should teleport')
                     _this.teleport();
                 }
-                print('some other state::' + rightPad.buttonValue + "///" + inTeleportMode)
                 return;
             }
         }

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -294,14 +294,25 @@ function Teleporter() {
                     this.createCancelOverlay();
                 }
             } else {
-                this.deleteCancelOverlay();
-
-                this.rightLineOn(rightPickRay.origin, rightIntersection.intersection, COLORS_TELEPORT_CAN_TELEPORT);
-                if (this.targetOverlay !== null) {
-                    this.updateTargetOverlay(rightIntersection);
+                if (this.inCoolIn === true) {
+                    this.deleteTargetOverlay();
+                    this.rightLineOn(rightPickRay.origin, rightIntersection.intersection, COLORS_TELEPORT_TOO_CLOSE);
+                    if (this.cancelOverlay !== null) {
+                        this.updateCancelOverlay(rightIntersection);
+                    } else {
+                        this.createCancelOverlay();
+                    }
                 } else {
-                    this.createTargetOverlay();
+                    this.deleteCancelOverlay();
+
+                    this.rightLineOn(rightPickRay.origin, rightIntersection.intersection, COLORS_TELEPORT_CAN_TELEPORT);
+                    if (this.targetOverlay !== null) {
+                        this.updateTargetOverlay(rightIntersection);
+                    } else {
+                        this.createTargetOverlay();
+                    }
                 }
+
 
             }
 
@@ -346,14 +357,25 @@ function Teleporter() {
                     this.createCancelOverlay();
                 }
             } else {
-                this.deleteCancelOverlay();
-                this.leftLineOn(leftPickRay.origin, leftIntersection.intersection, COLORS_TELEPORT_CAN_TELEPORT);
-
-                if (this.targetOverlay !== null) {
-                    this.updateTargetOverlay(leftIntersection);
+                if (this.inCoolIn === true) {
+                    this.deleteTargetOverlay();
+                    this.leftLineOn(leftPickRay.origin, leftIntersection.intersection, COLORS_TELEPORT_TOO_CLOSE);
+                    if (this.cancelOverlay !== null) {
+                        this.updateCancelOverlay(leftIntersection);
+                    } else {
+                        this.createCancelOverlay();
+                    }
                 } else {
-                    this.createTargetOverlay();
+                    this.deleteCancelOverlay();
+                    this.leftLineOn(leftPickRay.origin, leftIntersection.intersection, COLORS_TELEPORT_CAN_TELEPORT);
+
+                    if (this.targetOverlay !== null) {
+                        this.updateTargetOverlay(leftIntersection);
+                    } else {
+                        this.createTargetOverlay();
+                    }
                 }
+
 
             }
 

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -39,7 +39,7 @@ var COLORS_TELEPORT_TOO_CLOSE = {
 
 var TELEPORT_CANCEL_RANGE = 1.5;
 var USE_COOL_IN = true;
-var COOL_IN_DURATION = 1750;
+var COOL_IN_DURATION = 500;
 
 function ThumbPad(hand) {
     this.hand = hand;
@@ -111,6 +111,12 @@ function Teleporter() {
         }
 
         inTeleportMode = true;
+        this.inCoolIn = true;
+        print('setting cool in timeout')
+        this.coolInTimeout = Script.setTimeout(function() {
+            print('should exit cool in mode now' + COOL_IN_DURATION)
+            _this.inCoolIn = false;
+        }, COOL_IN_DURATION)
 
         if (this.smoothArrivalInterval !== null) {
             Script.clearInterval(this.smoothArrivalInterval);
@@ -123,10 +129,9 @@ function Teleporter() {
         this.initialize();
         Script.update.connect(this.update);
         this.updateConnected = true;
-        this.inCoolIn = true;
-        Script.setTimeout(function() {
-            _this.inCoolIn = false;
-        }, COOL_IN_DURATION)
+
+
+
     };
 
     this.createTargetOverlay = function() {
@@ -202,7 +207,7 @@ function Teleporter() {
         this.turnOffOverlayBeams();
 
         this.updateConnected = null;
-        _this.inCoolIn = false;
+        this.inCoolIn = false;
 
         Script.setTimeout(function() {
             inTeleportMode = false;

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -202,14 +202,13 @@ function Teleporter() {
         this.turnOffOverlayBeams();
 
         this.updateConnected = null;
+        _this.inCoolIn = false;
 
         Script.setTimeout(function() {
             inTeleportMode = false;
             _this.enableGrab();
         }, 200);
     };
-
-
 
     this.update = function() {
         if (isDisabled === 'both') {
@@ -223,12 +222,15 @@ function Teleporter() {
             teleporter.leftRay();
             if ((leftPad.buttonValue === 0) && inTeleportMode === true) {
                 if (_this.inCoolIn === true) {
+                    print('released during cool in period.  exit.')
                     _this.exitTeleportMode();
                     _this.deleteTargetOverlay();
                     _this.deleteCancelOverlay();
                 } else {
+                    print('release while not in cool in and in teleport mode. should teleport')
                     _this.teleport();
                 }
+                print('some other state::' + leftPad.buttonValue + "///" + inTeleportMode)
                 return;
             }
 
@@ -239,12 +241,15 @@ function Teleporter() {
             teleporter.rightRay();
             if ((rightPad.buttonValue === 0) && inTeleportMode === true) {
                 if (_this.inCoolIn === true) {
+                    print('released during cool in period.  exit.')
                     _this.exitTeleportMode();
                     _this.deleteTargetOverlay();
                     _this.deleteCancelOverlay();
                 } else {
+                    print('release while not in cool in and in teleport mode. should teleport')
                     _this.teleport();
                 }
+                print('some other state::' + rightPad.buttonValue + "///" + inTeleportMode)
                 return;
             }
         }

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -72,6 +72,8 @@ function Trigger(hand) {
     };
 }
 
+var coolInTimeout = null;
+
 function Teleporter() {
     var _this = this;
     this.intersection = null;
@@ -84,6 +86,7 @@ function Teleporter() {
     this.teleportHand = null;
     this.tooClose = false;
     this.inCoolIn = false;
+
 
     this.initialize = function() {
         this.createMappings();
@@ -113,7 +116,11 @@ function Teleporter() {
         inTeleportMode = true;
         this.inCoolIn = true;
         print('setting cool in timeout')
-        this.coolInTimeout = Script.setTimeout(function() {
+        if (coolInTimeout !== null) {
+            Script.clearTimeout(coolInTimeout);
+
+        }
+        coolInTimeout = Script.setTimeout(function() {
             print('should exit cool in mode now' + COOL_IN_DURATION)
             _this.inCoolIn = false;
         }, COOL_IN_DURATION)
@@ -208,9 +215,9 @@ function Teleporter() {
 
         this.updateConnected = null;
         this.inCoolIn = false;
+        inTeleportMode = false;
 
         Script.setTimeout(function() {
-            inTeleportMode = false;
             _this.enableGrab();
         }, 200);
     };

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -15,16 +15,13 @@ var TURN_RATE = 1000;
 var MENU_ITEM_NAME = "Advanced Movement For Hand Controllers";
 var SETTINGS_KEY = 'advancedMovementForHandControllersIsChecked';
 var previousSetting = Settings.getValue(SETTINGS_KEY);
-if (previousSetting === '') {
+if (previousSetting === '' || previousSetting === false) {
     previousSetting = false;
     isChecked = false;
 }
 
 if (previousSetting === true) {
     isChecked = true;
-}
-if (previousSetting === false) {
-    isChecked = false;
 }
 
 function addAdvancedMovementItemToSettingsMenu() {

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -35,7 +35,12 @@ function addAdvancedMovementItemToSettingsMenu() {
 }
 
 function rotate180() {
-    MyAvatar.orientation = Quat.inverse(MyAvatar.orientation);
+    var newOrientation = Quat.multiply(MyAvatar.orientation, Quat.angleAxis(180, {
+        x: 0,
+        y: 1,
+        z: 0
+    }))
+    MyAvatar.orientation = newOrientation
 }
 
 var inFlipTurn = false;

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -11,6 +11,8 @@
 
 var mappingName, basicMapping, isChecked;
 
+var TURN_RATE = 1000;
+
 var previousSetting = Settings.getValue('advancedMovementForHandControllersIsChecked');
 if (previousSetting === '') {
     previousSetting = false;
@@ -59,7 +61,7 @@ function registerBasicMapping() {
                 rotate180();
                 Script.setTimeout(function() {
                     inFlipTurn = false;
-                }, 250)
+                }, TURN_RATE)
             } else {
 
             }
@@ -122,11 +124,15 @@ Script.scriptEnding.connect(scriptEnding);
 Menu.menuItemEvent.connect(menuItemEvent);
 
 registerBasicMapping();
-if (previousSetting === true) {
-    disableMappings();
-} else if (previousSetting === false) {
-    enableMappings();
-}
+
+Script.setTimeout(function() {
+    if (previousSetting === true) {
+        disableMappings();
+    } else(previousSetting === false) {
+        enableMappings();
+    }
+
+}, 0)
 
 
 HMD.displayModeChanged.connect(function(isHMDMode) {

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -15,12 +15,13 @@ var TURN_RATE = 1000;
 var MENU_ITEM_NAME = "Advanced Movement For Hand Controllers";
 var SETTINGS_KEY = 'advancedMovementForHandControllersIsChecked';
 var previousSetting = Settings.getValue(SETTINGS_KEY);
-if (previousSetting === '' || previousSetting === false) {
+if (previousSetting === '' || previousSetting === false || previousSetting === 'false') {
     previousSetting = false;
     isChecked = false;
 }
 
-if (previousSetting === true) {
+if (previousSetting === true || previousSetting === 'true') {
+    previousSetting = true;
     isChecked = true;
 }
 

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -1,5 +1,6 @@
-// Created by james b. pollack @imgntn on 7/2/2016
+// Created by james b. pollack @imgntn on 8/18/2016
 // Copyright 2016 High Fidelity, Inc.
+//
 //advanced movements settings are in individual controller json files
 //what we do is check the status of the 'advance movement' checkbox when you enter HMD mode
 //if 'advanced movement' is checked...we give you the defaults that are in the json.
@@ -49,15 +50,12 @@ function registerBasicMapping() {
         }
         if (Controller.Hardware.Vive !== undefined) {
             if (value > 0.75 && inFlipTurn === false) {
-                print('vive should flip turn')
                 inFlipTurn = true;
                 rotate180();
                 Script.setTimeout(function() {
-                    print('vive should be able to flip turn again')
                     inFlipTurn = false;
                 }, 250)
             } else {
-                print('vive should not flip turn')
 
             }
         }
@@ -71,19 +69,15 @@ function registerBasicMapping() {
         }
         if (Controller.Hardware.Vive !== undefined) {
             if (value > 0.75 && inFlipTurn === false) {
-                print('vive should flip turn')
                 inFlipTurn = true;
                 rotate180();
                 Script.setTimeout(function() {
-                    print('vive should be able to flip turn again')
                     inFlipTurn = false;
                 }, 250)
             } else {
-                print('vive should not flip turn')
 
             }
         }
-        print('should do RY stuff' + value + ":stick:" + stick);
         return;
     })
 }
@@ -114,7 +108,6 @@ function menuItemEvent(menuItem) {
             enableMappings();
         }
     }
-
 }
 
 addAdvancedMovementItemToSettingsMenu();

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -23,6 +23,7 @@ if (previousSetting === true) {
     isChecked = true;
 }
 if (previousSetting === false) {
+    previousSetting = false;
     isChecked = false;
 }
 
@@ -132,7 +133,7 @@ Script.setTimeout(function() {
         enableMappings();
     }
 
-}, 0)
+}, 100)
 
 
 HMD.displayModeChanged.connect(function(isHMDMode) {

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -1,26 +1,26 @@
+// Created by james b. pollack @imgntn on 7/2/2016
+// Copyright 2016 High Fidelity, Inc.
 //advanced movements settings are in individual controller json files
 //what we do is check the status of the 'advance movement' checkbox when you enter HMD mode
 //if 'advanced movement' is checked...we give you the defaults that are in the json.
 //if 'advanced movement' is not checked... we override the advanced controls with basic ones.
-//when the script stops, 
-
-//todo: store in prefs
 //
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
-
-var mappingName, basicMapping,isChecked;
+var mappingName, basicMapping, isChecked;
 
 var previousSetting = Settings.getValue('advancedMovementForHandControllersIsChecked');
 if (previousSetting === '') {
     previousSetting = false;
-    isChecked=false;
+    isChecked = false;
 }
 
-if(previousSetting===true){
-    isChecked=true;
+if (previousSetting === true) {
+    isChecked = true;
 }
-if(previousSetting===false){
-    isChecked=false;
+if (previousSetting === false) {
+    isChecked = false;
 }
 
 function addAdvancedMovementItemToSettingsMenu() {
@@ -37,31 +37,57 @@ function rotate180() {
     MyAvatar.orientation = Quat.inverse(MyAvatar.orientation);
 }
 
+var inFlipTurn = false;
+
 function registerBasicMapping() {
     mappingName = 'Hifi-AdvancedMovement-Dev-' + Math.random();
     basicMapping = Controller.newMapping(mappingName);
     basicMapping.from(Controller.Standard.LY).to(function(value) {
         var stick = Controller.getValue(Controller.Standard.LS);
-        if (value === 1) {
+        if (value === 1 && Controller.Hardware.OculusTouch !== undefined) {
             rotate180();
         }
-        print('should do LY stuff' + value + ":stick:" + stick);
+        if (Controller.Hardware.Vive !== undefined) {
+            if (value > 0.75 && inFlipTurn === false) {
+                print('vive should flip turn')
+                inFlipTurn = true;
+                rotate180();
+                Script.setTimeout(function() {
+                    print('vive should be able to flip turn again')
+                    inFlipTurn = false;
+                }, 250)
+            } else {
+                print('vive should not flip turn')
+
+            }
+        }
         return;
     });
     basicMapping.from(Controller.Standard.LX).to(Controller.Standard.RX);
     basicMapping.from(Controller.Standard.RY).to(function(value) {
         var stick = Controller.getValue(Controller.Standard.RS);
-        if (value === 1) {
+        if (value === 1 && Controller.Hardware.OculusTouch !== undefined) {
             rotate180();
+        }
+        if (Controller.Hardware.Vive !== undefined) {
+            if (value > 0.75 && inFlipTurn === false) {
+                print('vive should flip turn')
+                inFlipTurn = true;
+                rotate180();
+                Script.setTimeout(function() {
+                    print('vive should be able to flip turn again')
+                    inFlipTurn = false;
+                }, 250)
+            } else {
+                print('vive should not flip turn')
+
+            }
         }
         print('should do RY stuff' + value + ":stick:" + stick);
         return;
     })
 }
 
-function testPrint(what) {
-    print('it was controller: ' + what)
-}
 
 function enableMappings() {
     Controller.enableMapping(mappingName);
@@ -79,7 +105,6 @@ function scriptEnding() {
 
 function menuItemEvent(menuItem) {
     if (menuItem == "Advanced Movement For Hand Controllers") {
-        print("  checked=" + Menu.isOptionChecked("Advanced Movement For Hand Controllers"));
         isChecked = Menu.isOptionChecked("Advanced Movement For Hand Controllers");
         if (isChecked === true) {
             Settings.setValue('advancedMovementForHandControllersIsChecked', true);
@@ -100,10 +125,8 @@ Menu.menuItemEvent.connect(menuItemEvent);
 
 registerBasicMapping();
 if (previousSetting === true) {
-    print('JBP WAS SET TO TRUE')
     disableMappings();
 } else if (previousSetting === false) {
-    print('JBP WAS SET TO FALSE')
     enableMappings();
 }
 

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -12,8 +12,9 @@
 var mappingName, basicMapping, isChecked;
 
 var TURN_RATE = 1000;
-
-var previousSetting = Settings.getValue('advancedMovementForHandControllersIsChecked');
+var MENU_ITEM_NAME = "Advanced Movement For Hand Controllers";
+var SETTINGS_KEY = 'advancedMovementForHandControllersIsChecked';
+var previousSetting = Settings.getValue(SETTINGS_KEY);
 if (previousSetting === '') {
     previousSetting = false;
     isChecked = false;
@@ -29,7 +30,7 @@ if (previousSetting === false) {
 function addAdvancedMovementItemToSettingsMenu() {
     Menu.addMenuItem({
         menuName: "Settings",
-        menuItemName: "Advanced Movement For Hand Controllers",
+        menuItemName: MENU_ITEM_NAME,
         isCheckable: true,
         isChecked: previousSetting
     });
@@ -54,16 +55,13 @@ function registerBasicMapping() {
         var stick = Controller.getValue(Controller.Standard.LS);
         if (value === 1 && Controller.Hardware.OculusTouch !== undefined) {
             rotate180();
-        }
-        if (Controller.Hardware.Vive !== undefined) {
+        } else if (Controller.Hardware.Vive !== undefined) {
             if (value > 0.75 && inFlipTurn === false) {
                 inFlipTurn = true;
                 rotate180();
                 Script.setTimeout(function() {
                     inFlipTurn = false;
                 }, TURN_RATE)
-            } else {
-
             }
         }
         return;
@@ -73,16 +71,13 @@ function registerBasicMapping() {
         var stick = Controller.getValue(Controller.Standard.RS);
         if (value === 1 && Controller.Hardware.OculusTouch !== undefined) {
             rotate180();
-        }
-        if (Controller.Hardware.Vive !== undefined) {
+        } else if (Controller.Hardware.Vive !== undefined) {
             if (value > 0.75 && inFlipTurn === false) {
                 inFlipTurn = true;
                 rotate180();
                 Script.setTimeout(function() {
                     inFlipTurn = false;
                 }, TURN_RATE)
-            } else {
-
             }
         }
         return;
@@ -99,19 +94,19 @@ function disableMappings() {
 }
 
 function scriptEnding() {
-    Menu.removeMenuItem("Settings", "Advanced Movement For Hand Controllers");
+    Menu.removeMenuItem("Settings", MENU_ITEM_NAME);
     disableMappings();
 }
 
 
 function menuItemEvent(menuItem) {
-    if (menuItem == "Advanced Movement For Hand Controllers") {
-        isChecked = Menu.isOptionChecked("Advanced Movement For Hand Controllers");
+    if (menuItem == MENU_ITEM_NAME) {
+        isChecked = Menu.isOptionChecked(MENU_ITEM_NAME);
         if (isChecked === true) {
-            Settings.setValue('advancedMovementForHandControllersIsChecked', true);
+            Settings.setValue(SETTINGS_KEY, true);
             disableMappings();
         } else if (isChecked === false) {
-            Settings.setValue('advancedMovementForHandControllersIsChecked', false);
+            Settings.setValue(SETTINGS_KEY, false);
             enableMappings();
         }
     }
@@ -131,7 +126,6 @@ Script.setTimeout(function() {
     } else {
         enableMappings();
     }
-
 }, 100)
 
 

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -23,7 +23,6 @@ if (previousSetting === true) {
     isChecked = true;
 }
 if (previousSetting === false) {
-    previousSetting = false;
     isChecked = false;
 }
 
@@ -81,7 +80,7 @@ function registerBasicMapping() {
                 rotate180();
                 Script.setTimeout(function() {
                     inFlipTurn = false;
-                }, 250)
+                }, TURN_RATE)
             } else {
 
             }

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -128,7 +128,7 @@ registerBasicMapping();
 Script.setTimeout(function() {
     if (previousSetting === true) {
         disableMappings();
-    } else(previousSetting === false) {
+    } else {
         enableMappings();
     }
 


### PR DESCRIPTION
This PR changes some default locomotion settings when using Hand Controllers.
- By default, users cannot translate with left pad / stick.
- By default, users cannot jump with right pad / stick.
- Be default, the horizontal axis of the left and right sticks turns your avatar.
- By default, pressing the down direction of either stick / pad will rotate your avatar 180 degrees.

To enable locomotion by translation and jumping (previous behavior), users can select "Advanced Movement For Hand Controllers" from the Settings Menu.

To test:
1. Load this PR and its default scripts.
2. You should not be able to walk or jump with the hand controllers. 
3. Check "Advanced Movement For Hand Controllers" in the Settings Menu.
4. You should be able to walk and jump with the controllers.
