### PR TITLE
fix -- make 3d-line overlays work again

### DIFF
--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -23,12 +23,47 @@ Line3DOverlay::Line3DOverlay() :
 
 Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
     Base3DOverlay(line3DOverlay),
+    _start(line3DOverlay->_start),
     _end(line3DOverlay->_end),
     _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
 }
 
 Line3DOverlay::~Line3DOverlay() {
+}
+
+const glm::vec3& Line3DOverlay::getStart() const {
+    bool success;
+    glm::vec3 worldStart = localToWorld(_start, _parentID, _parentJointIndex, success);
+    if (!success) {
+        qDebug() << "Line3DOverlay::getStart failed";
+    }
+    return worldStart;
+}
+
+const glm::vec3& Line3DOverlay::getEnd() const {
+    bool success;
+    glm::vec3 worldEnd = localToWorld(_end, _parentID, _parentJointIndex, success);
+    if (!success) {
+        qDebug() << "Line3DOverlay::getEnd failed";
+    }
+    return worldEnd;
+}
+
+void Line3DOverlay::setStart(const glm::vec3& start) {
+    bool success;
+    _start = worldToLocal(start, _parentID, _parentJointIndex, success);
+    if (!success) {
+        qDebug() << "Line3DOverlay::setStart failed";
+    }
+}
+
+void Line3DOverlay::setEnd(const glm::vec3& end) {
+    bool success;
+    _end = worldToLocal(end, _parentID, _parentJointIndex, success);
+    if (!success) {
+        qDebug() << "Line3DOverlay::setEnd failed";
+    }
 }
 
 AABox Line3DOverlay::getBounds() const {
@@ -76,8 +111,8 @@ const render::ShapeKey Line3DOverlay::getShapeKey() {
     return builder.build();
 }
 
-void Line3DOverlay::setProperties(const QVariantMap& properties) {
-    Base3DOverlay::setProperties(properties);
+void Line3DOverlay::setProperties(const QVariantMap& originalProperties) {
+    QVariantMap properties = originalProperties;
 
     auto start = properties["start"];
     // if "start" property was not there, check to see if they included aliases: startPoint
@@ -87,6 +122,7 @@ void Line3DOverlay::setProperties(const QVariantMap& properties) {
     if (start.isValid()) {
         setStart(vec3FromVariant(start));
     }
+    properties.remove("start"); // so that Base3DOverlay doesn't respond to it
 
     auto end = properties["end"];
     // if "end" property was not there, check to see if they included aliases: endPoint
@@ -109,14 +145,16 @@ void Line3DOverlay::setProperties(const QVariantMap& properties) {
     if (glowWidth.isValid()) {
         setGlow(glowWidth.toFloat());
     }
+
+    Base3DOverlay::setProperties(properties);
 }
 
 QVariant Line3DOverlay::getProperty(const QString& property) {
     if (property == "start" || property == "startPoint" || property == "p1") {
-        return vec3toVariant(_start);
+        return vec3toVariant(getStart());
     }
     if (property == "end" || property == "endPoint" || property == "p2") {
-        return vec3toVariant(_end);
+        return vec3toVariant(getEnd());
     }
 
     return Base3DOverlay::getProperty(property);
@@ -124,4 +162,9 @@ QVariant Line3DOverlay::getProperty(const QString& property) {
 
 Line3DOverlay* Line3DOverlay::createClone() const {
     return new Line3DOverlay(this);
+}
+
+
+void Line3DOverlay::locationChanged(bool tellPhysics) {
+    // do nothing
 }

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -32,7 +32,7 @@ Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
 Line3DOverlay::~Line3DOverlay() {
 }
 
-const glm::vec3& Line3DOverlay::getStart() const {
+glm::vec3 Line3DOverlay::getStart() const {
     bool success;
     glm::vec3 worldStart = localToWorld(_start, _parentID, _parentJointIndex, success);
     if (!success) {
@@ -41,7 +41,7 @@ const glm::vec3& Line3DOverlay::getStart() const {
     return worldStart;
 }
 
-const glm::vec3& Line3DOverlay::getEnd() const {
+glm::vec3 Line3DOverlay::getEnd() const {
     bool success;
     glm::vec3 worldEnd = localToWorld(_end, _parentID, _parentJointIndex, success);
     if (!success) {

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -28,8 +28,8 @@ public:
     virtual AABox getBounds() const override;
 
     // getters
-    const glm::vec3& getStart() const;
-    const glm::vec3& getEnd() const;
+    glm::vec3 getStart() const;
+    glm::vec3 getEnd() const;
     const float& getGlow() const { return _glow; }
     const float& getGlowWidth() const { return _glowWidth; }
 

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -28,14 +28,15 @@ public:
     virtual AABox getBounds() const override;
 
     // getters
-    const glm::vec3& getStart() const { return _start; }
-    const glm::vec3& getEnd() const { return _end; }
+    const glm::vec3& getStart() const;
+    const glm::vec3& getEnd() const;
     const float& getGlow() const { return _glow; }
     const float& getGlowWidth() const { return _glowWidth; }
 
     // setters
-    void setStart(const glm::vec3& start) { _start = start; }
-    void setEnd(const glm::vec3& end) { _end = end; }
+    void setStart(const glm::vec3& start);
+    void setEnd(const glm::vec3& end);
+
     void setGlow(const float& glow) { _glow = glow; }
     void setGlowWidth(const float& glowWidth) { _glowWidth = glowWidth; }
 
@@ -43,6 +44,8 @@ public:
     QVariant getProperty(const QString& property) override;
 
     virtual Line3DOverlay* createClone() const override;
+
+    virtual void locationChanged(bool tellPhysics = true) override;
 
 protected:
     glm::vec3 _start;


### PR DESCRIPTION
- "start" and "end" parameters of a 3d-line overlay are now relative to its "position".
