### PR TITLE
don't send a login-denied packet when we're still waiting for user's public key

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -509,9 +509,7 @@ bool DomainGatekeeper::verifyUserSignature(const QString& username,
         }
     } else {
         if (!senderSockAddr.isNull()) {
-            qDebug() << "Insufficient data to decrypt username signature - denying connection.";
-            sendConnectionDeniedPacket("Insufficient data", senderSockAddr,
-                DomainHandler::ConnectionRefusedReason::LoginError);
+            qDebug() << "Insufficient data to decrypt username signature - delaying connection.";
         }
     }
 


### PR DESCRIPTION
- don't display spurious "insufficient data" message when logging in
