### PR TITLE
Custom OpenGL context creation

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -778,8 +778,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
 
     // enable mouse tracking; otherwise, we only get drag events
     _glWidget->setMouseTracking(true);
+    // Make sure the window is set to the correct size by processing the pending events
+    QCoreApplication::processEvents();
+    _glWidget->createContext();
     _glWidget->makeCurrent();
-    _glWidget->initializeGL();
 
     initializeGL();
     // Make sure we don't time out during slow operations at startup
@@ -1484,7 +1486,7 @@ void Application::initializeGL() {
     _glWidget->makeCurrent();
     _chromiumShareContext = new OffscreenGLCanvas();
     _chromiumShareContext->setObjectName("ChromiumShareContext");
-    _chromiumShareContext->create(_glWidget->context()->contextHandle());
+    _chromiumShareContext->create(_glWidget->qglContext());
     _chromiumShareContext->makeCurrent();
     qt_gl_set_global_share_context(_chromiumShareContext->getContext());
 
@@ -1531,7 +1533,7 @@ void Application::initializeGL() {
 
     _offscreenContext = new OffscreenGLCanvas();
     _offscreenContext->setObjectName("MainThreadContext");
-    _offscreenContext->create(_glWidget->context()->contextHandle());
+    _offscreenContext->create(_glWidget->qglContext());
     _offscreenContext->makeCurrent();
 
     // update before the first render
@@ -1553,7 +1555,7 @@ void Application::initializeUi() {
 
 
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->create(_glWidget->context()->contextHandle());
+    offscreenUi->create(_glWidget->qglContext());
 
     auto rootContext = offscreenUi->getRootContext();
 
@@ -5675,7 +5677,7 @@ MainWindow* Application::getPrimaryWindow() {
 }
 
 QOpenGLContext* Application::getPrimaryContext() {
-    return _glWidget->context()->contextHandle();
+    return _glWidget->qglContext();
 }
 
 bool Application::makeRenderingContextCurrent() {

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -29,6 +29,7 @@
 #include <gl/GLWidget.h>
 #include <gl/Config.h>
 #include <gl/GLEscrow.h>
+#include <gl/Context.h>
 
 #include <gpu/Texture.h>
 #include <gpu/StandardShaderLib.h>
@@ -108,7 +109,7 @@ public:
         }
     }
 
-    void setContext(QGLContext * context) {
+    void setContext(gl::Context* context) {
         // Move the OpenGL context to the present thread
         // Extra code because of the widget 'wrapper' context
         _context = context;
@@ -126,7 +127,6 @@ public:
         OpenGLDisplayPlugin* currentPlugin{ nullptr };
         Q_ASSERT(_context);
         _context->makeCurrent();
-        Q_ASSERT(isCurrentContext(_context->contextHandle()));
         while (!_shutdown) {
             if (_pendingMainThreadOperation) {
                 PROFILE_RANGE("MainThreadOp") 
@@ -250,7 +250,7 @@ private:
     bool _finishedMainThreadOperation { false };
     QThread* _mainThread { nullptr };
     std::queue<OpenGLDisplayPlugin*> _newPluginQueue;
-    QGLContext* _context { nullptr };
+    gl::Context* _context { nullptr };
 };
 
 bool OpenGLDisplayPlugin::activate() {
@@ -649,8 +649,8 @@ float OpenGLDisplayPlugin::presentRate() const {
 }
 
 void OpenGLDisplayPlugin::swapBuffers() {
-    static auto widget = _container->getPrimaryWidget();
-    widget->swapBuffers();
+    static auto context = _container->getPrimaryWidget()->context();
+    context->swapBuffers();
 }
 
 void OpenGLDisplayPlugin::withMainThreadContext(std::function<void()> f) const {

--- a/libraries/gl/src/gl/Context.cpp
+++ b/libraries/gl/src/gl/Context.cpp
@@ -1,0 +1,279 @@
+//
+//  Created by Bradley Austin Davis on 2016/08/21
+//  Copyright 2013-2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "Context.h"
+
+#include <assert.h>
+
+#include <mutex>
+
+#include <QtCore/QDebug>
+#include <QtCore/QProcessEnvironment>
+#include <QtCore/QThread>
+
+#include <QtGui/QWindow>
+#include <QtGui/QGuiApplication>
+
+#include <GLMHelpers.h>
+
+#ifdef Q_OS_WIN
+
+#ifdef DEBUG
+static bool enableDebugLogger = true;
+#else
+static const QString DEBUG_FLAG("HIFI_DEBUG_OPENGL");
+static bool enableDebugLogger = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
+#endif
+
+#endif
+
+#include "Config.h"
+#include "GLHelpers.h"
+
+
+using namespace gl;
+
+Context* Context::PRIMARY = nullptr;
+
+Context::Context() {}
+
+Context::Context(QWindow* window) {
+    setWindow(window);
+}
+
+#ifdef Q_OS_WIN
+void Context::destroyWin32Context(HGLRC hglrc) {
+    wglDeleteContext(hglrc);
+}
+#endif
+
+void Context::release() {
+    doneCurrent();
+#ifdef Q_OS_WIN
+    if (_wrappedContext) {
+        destroyContext(_wrappedContext);
+        _wrappedContext = nullptr;
+    }
+    if (_hglrc) {
+        destroyWin32Context(_hglrc);
+        _hglrc = 0;
+    }
+    if (_hdc) {
+        ReleaseDC(_hwnd, _hdc);
+        _hdc = 0;
+    }
+    _hwnd = 0;
+#else
+    destroyContext(_context);
+    _context = nullptr;
+#endif
+    _window = nullptr;
+    if (PRIMARY == this) {
+        PRIMARY = nullptr;
+    }
+    }
+
+Context::~Context() {
+    release();
+}
+
+void Context::setWindow(QWindow* window) {
+    release();
+    _window = window;
+#ifdef Q_OS_WIN
+    _hwnd = (HWND)window->winId();
+#endif
+}
+
+#ifdef Q_OS_WIN
+static const char* PRIMARY_CONTEXT_PROPERTY_NAME = "com.highfidelity.gl.primaryContext";
+
+bool Context::makeCurrent() {
+    BOOL result = wglMakeCurrent(_hdc, _hglrc);
+    assert(result);
+    return result;
+}
+
+void Context::swapBuffers() {
+    SwapBuffers(_hdc);
+}
+
+void Context::doneCurrent() {
+    wglMakeCurrent(0, 0);
+}
+
+void GLAPIENTRY debugMessageCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
+    if (GL_DEBUG_SEVERITY_NOTIFICATION == severity) {
+        return;
+    }
+    qDebug() << "QQQ " << message;
+}
+
+// FIXME build the PFD based on the 
+static const PIXELFORMATDESCRIPTOR pfd =    // pfd Tells Windows How We Want Things To Be
+{
+    sizeof(PIXELFORMATDESCRIPTOR),         // Size Of This Pixel Format Descriptor
+    1,                                      // Version Number
+    PFD_DRAW_TO_WINDOW |                    // Format Must Support Window
+    PFD_SUPPORT_OPENGL |                    // Format Must Support OpenGL
+    PFD_DOUBLEBUFFER,                       // Must Support Double Buffering
+    PFD_TYPE_RGBA,                          // Request An RGBA Format
+    24,                                     // Select Our Color Depth
+    0, 0, 0, 0, 0, 0,                       // Color Bits Ignored
+    1,                                      // Alpha Buffer
+    0,                                      // Shift Bit Ignored
+    0,                                      // No Accumulation Buffer
+    0, 0, 0, 0,                             // Accumulation Bits Ignored
+    24,                                     // 24 Bit Z-Buffer (Depth Buffer)  
+    8,                                      // 8 Bit Stencil Buffer
+    0,                                      // No Auxiliary Buffer
+    PFD_MAIN_PLANE,                         // Main Drawing Layer
+    0,                                      // Reserved
+    0, 0, 0                                 // Layer Masks Ignored
+};
+
+void setupPixelFormatSimple(HDC hdc) {
+    auto pixelFormat = ChoosePixelFormat(hdc, &pfd);
+    if (pixelFormat == 0) {
+        throw std::runtime_error("Unable to create initial context");
+    }
+
+    if (SetPixelFormat(hdc, pixelFormat, &pfd) == FALSE) {
+        throw std::runtime_error("Unable to create initial context");
+    }
+}
+
+void Context::create() {
+    if (!PRIMARY) {
+        PRIMARY = static_cast<Context*>(qApp->property(PRIMARY_CONTEXT_PROPERTY_NAME).value<void*>());
+    }
+
+    if (PRIMARY) {
+        _version = PRIMARY->_version;
+    }
+
+    assert(0 != _hwnd);
+    assert(0 == _hdc);
+    auto hwnd = _hwnd;
+    // Create a temporary context to initialize glew
+    static std::once_flag once;
+    std::call_once(once, [&] {
+        auto hdc = GetDC(hwnd);
+        setupPixelFormatSimple(hdc);
+        auto glrc = wglCreateContext(hdc);
+        BOOL makeCurrentResult;
+        makeCurrentResult = wglMakeCurrent(hdc, glrc);
+        if (!makeCurrentResult) {
+            throw std::runtime_error("Unable to create initial context");
+        }
+        glewExperimental = true;
+        glewInit();
+        if (glewIsSupported("GL_VERSION_4_5")) {
+            _version = 0x0405;
+        } else if (glewIsSupported("GL_VERSION_4_3")) {
+            _version = 0x0403;
+        }
+        glGetError();
+        wglMakeCurrent(0, 0);
+        wglDeleteContext(glrc);
+        ReleaseDC(hwnd, hdc);
+    });
+
+    _hdc = GetDC(_hwnd);
+    static int pixelFormat = 0;
+    static PIXELFORMATDESCRIPTOR pfd;
+    if (!pixelFormat) {
+        memset(&pfd, 0, sizeof(pfd));
+        pfd.nSize = sizeof(pfd);
+        std::vector<int> formatAttribs;
+        formatAttribs.push_back(WGL_DRAW_TO_WINDOW_ARB);
+        formatAttribs.push_back(GL_TRUE);
+        formatAttribs.push_back(WGL_SUPPORT_OPENGL_ARB);
+        formatAttribs.push_back(GL_TRUE);
+        formatAttribs.push_back(WGL_DOUBLE_BUFFER_ARB);
+        formatAttribs.push_back(GL_TRUE);
+        formatAttribs.push_back(WGL_PIXEL_TYPE_ARB);
+        formatAttribs.push_back(WGL_TYPE_RGBA_ARB);
+        formatAttribs.push_back(WGL_COLOR_BITS_ARB);
+        formatAttribs.push_back(32);
+        formatAttribs.push_back(WGL_DEPTH_BITS_ARB);
+        formatAttribs.push_back(24);
+        formatAttribs.push_back(WGL_STENCIL_BITS_ARB);
+        formatAttribs.push_back(8);
+        formatAttribs.push_back(WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB);
+        formatAttribs.push_back(GL_TRUE);
+        // terminate the list
+        formatAttribs.push_back(0);
+        UINT numFormats;
+        wglChoosePixelFormatARB(_hdc, &formatAttribs[0], NULL, 1, &pixelFormat, &numFormats);
+        DescribePixelFormat(_hdc, pixelFormat, sizeof(pfd), &pfd);
+    }
+    SetPixelFormat(_hdc, pixelFormat, &pfd);
+    {
+        std::vector<int> contextAttribs;
+        uint32_t majorVersion = _version >> 8;
+        uint32_t minorVersion = _version & 0xFF;
+        contextAttribs.push_back(WGL_CONTEXT_MAJOR_VERSION_ARB);
+        contextAttribs.push_back(majorVersion);
+        contextAttribs.push_back(WGL_CONTEXT_MINOR_VERSION_ARB);
+        contextAttribs.push_back(minorVersion);
+        contextAttribs.push_back(WGL_CONTEXT_PROFILE_MASK_ARB);
+        contextAttribs.push_back(WGL_CONTEXT_CORE_PROFILE_BIT_ARB);
+        contextAttribs.push_back(WGL_CONTEXT_FLAGS_ARB);
+        if (enableDebugLogger) {
+            contextAttribs.push_back(WGL_CONTEXT_DEBUG_BIT_ARB);
+        } else {
+            contextAttribs.push_back(0);
+        }
+        contextAttribs.push_back(0);
+        auto shareHglrc = PRIMARY ? PRIMARY->_hglrc : 0;
+        _hglrc = wglCreateContextAttribsARB(_hdc, shareHglrc, &contextAttribs[0]);
+    }
+
+    if (_hglrc == 0) {
+        throw std::runtime_error("Could not create GL context");
+    }
+
+    if (!PRIMARY) {
+        PRIMARY = this;
+        qApp->setProperty(PRIMARY_CONTEXT_PROPERTY_NAME, QVariant::fromValue((void*)PRIMARY));
+    }
+
+    if (enableDebugLogger) {
+        makeCurrent();
+        glDebugMessageCallback(debugMessageCallback, NULL);
+        glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+        doneCurrent();
+    }
+}
+#endif
+
+void Context::clear() {
+    glClearColor(0, 0, 0, 1);
+    QSize windowSize = _window->size() * _window->devicePixelRatio();
+    glViewport(0, 0, windowSize.width(), windowSize.height());
+    glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    swapBuffers();
+}
+
+
+OffscreenContext::~OffscreenContext() {
+    _window->deleteLater();
+}
+
+void OffscreenContext::create() {
+    if (!_window) {
+        _window = new QWindow();
+        _window->setFlags(Qt::MSWindowsOwnDC);
+        _window->setSurfaceType(QSurface::OpenGLSurface);
+        _window->create();
+        setWindow(_window);
+        QGuiApplication::processEvents();
+    }
+    Parent::create();
+}

--- a/libraries/gl/src/gl/Context.h
+++ b/libraries/gl/src/gl/Context.h
@@ -1,0 +1,72 @@
+//
+//  Created by Bradley Austin Davis on 2016/08/21
+//  Copyright 2013-2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_gl_context_h
+#define hifi_gl_context_h
+
+#include <stdint.h>
+#include <QtGlobal>
+
+#if defined(Q_OS_WIN)
+#include <Windows.h>
+#endif
+
+class QSurface;
+class QWindow;
+class QOpenGLContext;
+class QThread;
+
+namespace gl {
+
+class Context {
+    protected:
+        QWindow* _window { nullptr };
+        static Context* PRIMARY;
+        static void destroyContext(QOpenGLContext* context);
+#if defined(Q_OS_WIN)
+        uint32_t _version { 0x0401 };
+        HWND _hwnd { 0 };
+        HDC _hdc { 0 };
+        HGLRC _hglrc { 0 };
+        static void destroyWin32Context(HGLRC hglrc);
+        QOpenGLContext* _wrappedContext { nullptr };
+#else
+        QOpenGLContext* _context { nullptr };
+#endif
+   
+    private:
+        Context(const Context& other);
+
+    public:
+        Context();
+        Context(QWindow* window);
+        void release();
+        virtual ~Context();
+
+        void clear();
+        void setWindow(QWindow* window);
+        bool makeCurrent();
+        static void makeCurrent(QOpenGLContext* context, QSurface* surface);
+        void swapBuffers();
+        void doneCurrent();
+        virtual void create();
+        QOpenGLContext* qglContext();
+        void moveToThread(QThread* thread);
+    };
+
+    class OffscreenContext : public Context {
+        using Parent = Context;
+    protected:
+        QWindow* _window { nullptr };
+    public:
+        virtual ~OffscreenContext();
+        virtual void create();
+    };
+}
+
+#endif // hifi_gpu_GPUConfig_h

--- a/libraries/gl/src/gl/ContextQt.cpp
+++ b/libraries/gl/src/gl/ContextQt.cpp
@@ -1,0 +1,75 @@
+//
+//  Created by Bradley Austin Davis on 2016/08/21
+//  Copyright 2013-2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "Context.h"
+
+#include <QtGui/QOpenGLContext>
+#include <QtGui/QWindow>
+
+#ifdef Q_OS_WIN
+#include <QtPlatformHeaders/QWGLNativeContext>
+#endif
+
+using namespace gl;
+
+void Context::destroyContext(QOpenGLContext* context) {
+    delete context;
+}
+
+void Context::makeCurrent(QOpenGLContext* context, QSurface* surface) {
+    context->makeCurrent(surface);
+}
+
+QOpenGLContext* Context::qglContext() {
+#ifdef Q_OS_WIN
+    if (!_wrappedContext) {
+        _wrappedContext = new QOpenGLContext();
+        _wrappedContext->setNativeHandle(QVariant::fromValue(QWGLNativeContext(_hglrc, _hwnd)));
+        _wrappedContext->create();
+    }
+    return _wrappedContext;
+#else
+    
+    return _context;
+#endif
+}
+
+void Context::moveToThread(QThread* thread) {
+    qglContext()->moveToThread(thread);
+}
+
+#ifndef Q_OS_WIN
+bool Context::makeCurrent() {
+    return _context->makeCurrent(_window);
+}
+
+void Context::swapBuffers() {
+    _context->swapBuffers(_window);
+}
+
+void Context::doneCurrent() {
+    if (_context) {
+        _context->doneCurrent();
+    }
+}
+
+const QSurfaceFormat& getDefaultOpenGLSurfaceFormat();
+
+
+void Context::create() {
+    _context = new QOpenGLContext();
+    if (PRIMARY) {
+        _context->setShareContext(PRIMARY->qglContext());
+    } else {
+        PRIMARY = this;
+    }
+    _context->setFormat(getDefaultOpenGLSurfaceFormat());
+    _context->create();
+}
+
+#endif

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -21,44 +21,20 @@ const QSurfaceFormat& getDefaultOpenGLSurfaceFormat() {
         format.setDepthBufferSize(DEFAULT_GL_DEPTH_BUFFER_BITS);
         format.setStencilBufferSize(DEFAULT_GL_STENCIL_BUFFER_BITS);
         setGLFormatVersion(format);
-        if (GLDebug::enabled()) {
-            qDebug() << "Enabling debug context";
-            format.setOption(QSurfaceFormat::DebugContext);
-        }
         format.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
         QSurfaceFormat::setDefaultFormat(format);
     });
     return format;
 }
 
-const QGLFormat& getDefaultGLFormat() {
-    // Specify an OpenGL 3.3 format using the Core profile.
-    // That is, no old-school fixed pipeline functionality
-    static QGLFormat glFormat;
-    static std::once_flag once;
-    std::call_once(once, [] {
-        setGLFormatVersion(glFormat);
-        glFormat.setProfile(QGLFormat::CoreProfile); // Requires >=Qt-4.8.0
-        glFormat.setSampleBuffers(false);
-        glFormat.setDepth(false);
-        glFormat.setStencil(false);
-        QGLFormat::setDefaultFormat(glFormat);
-    });
-    return glFormat;
-}
-
 int glVersionToInteger(QString glVersion) {
     QStringList versionParts = glVersion.split(QRegularExpression("[\\.\\s]"));
     int majorNumber = versionParts[0].toInt();
     int minorNumber = versionParts[1].toInt();
-    return majorNumber * 100 + minorNumber * 10;
+    return (majorNumber << 16) | minorNumber;
 }
 
 QJsonObject getGLContextData() {
-    if (!QOpenGLContext::currentContext()) {
-        return QJsonObject();
-    }
-
     QString glVersion = QString((const char*)glGetString(GL_VERSION));
     QString glslVersion = QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
     QString glVendor = QString((const char*) glGetString(GL_VENDOR));
@@ -76,32 +52,4 @@ QThread* RENDER_THREAD = nullptr;
 
 bool isRenderThread() {
     return QThread::currentThread() == RENDER_THREAD;
-}
-
-
-#ifdef DEBUG
-static bool enableDebugLogger = true;
-#else
-static const QString DEBUG_FLAG("HIFI_DEBUG_OPENGL");
-static bool enableDebugLogger = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
-#endif
-
-bool GLDebug::enabled() {
-    return enableDebugLogger;
-}
-
-void GLDebug::log(const QOpenGLDebugMessage & debugMessage) {
-    qDebug() << debugMessage;
-}
-
-void GLDebug::setupLogger(QObject* window) {
-    if (enabled()) {
-        QOpenGLDebugLogger* logger = new QOpenGLDebugLogger(window);
-        logger->initialize(); // initializes in the current context, i.e. ctx
-        logger->enableMessages();
-        QObject::connect(logger, &QOpenGLDebugLogger::messageLogged, window, [&](const QOpenGLDebugMessage & debugMessage) {
-            GLDebug::log(debugMessage);
-        });
-        logger->startLogging(QOpenGLDebugLogger::SynchronousLogging);
-    }
 }

--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -27,19 +27,9 @@ template<class F>
 void setGLFormatVersion(F& format, int major = 4, int minor = 5) { format.setVersion(major, minor); }
 
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat();
-const QGLFormat& getDefaultGLFormat();
 QJsonObject getGLContextData();
 int glVersionToInteger(QString glVersion);
 
 bool isRenderThread();
-
-
-class GLDebug {
-public:
-    static bool enabled();
-    static void log(const QOpenGLDebugMessage& debugMessage);
-    static void setupLogger(QObject* window = nullptr);
-};
-
 
 #endif

--- a/libraries/gl/src/gl/GLWidget.h
+++ b/libraries/gl/src/gl/GLWidget.h
@@ -10,31 +10,43 @@
 #ifndef hifi_GLWidget_h
 #define hifi_GLWidget_h
 
-#include <QGLWidget>
+#include <QtWidgets/QWidget>
+
+namespace gl {
+    class Context;
+}
+
+class QOpenGLContext;
 
 /// customized canvas that simply forwards requests/events to the singleton application
-class GLWidget : public QGLWidget {
+class GLWidget : public QWidget {
     Q_OBJECT
     
 public:
     GLWidget();
+    ~GLWidget();
     int getDeviceWidth() const;
     int getDeviceHeight() const;
     QSize getDeviceSize() const { return QSize(getDeviceWidth(), getDeviceHeight()); }
-    bool isVsyncSupported() const;
-    virtual void initializeGL() override;
+    QPaintEngine* paintEngine() const override;
+    void createContext();
+    bool makeCurrent();
+    void doneCurrent();
+    gl::Context* context() { return _context; }
+    QOpenGLContext* qglContext();
+
 
 protected:
+    virtual bool nativeEvent(const QByteArray &eventType, void *message, long *result) override;
     virtual bool event(QEvent* event) override;
-    virtual void paintEvent(QPaintEvent* event) override;
-    virtual void resizeEvent(QResizeEvent* event) override;
+    gl::Context* _context { nullptr };
 
 private slots:
     virtual bool eventFilter(QObject*, QEvent* event) override;
 
 private:
+    QPaintEngine* _paintEngine { nullptr };
     bool _vsyncSupported { false };
 };
-
 
 #endif // hifi_GLCanvas_h

--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -60,7 +60,6 @@ bool OffscreenGLCanvas::makeCurrent() {
         qDebug() << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
         qDebug() << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
         qDebug() << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
-        GLDebug::setupLogger(this);
     });
 
     return result;

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -100,7 +100,7 @@ float GLTexture::getMemoryPressure() {
 
     // If no memory limit has been set, use a percentage of the total dedicated memory
     if (!availableTextureMemory) {
-        auto totalGpuMemory = gpu::gl::getDedicatedMemory();
+        auto totalGpuMemory = getDedicatedMemory();
 
         // If no limit has been explicitly set, and the dedicated memory can't be determined, 
         // just use a fallback fixed value of 256 MB
@@ -118,7 +118,7 @@ float GLTexture::getMemoryPressure() {
     return (float)consumedGpuMemory / (float)availableTextureMemory;
 }
 
-GLTexture::DownsampleSource::DownsampleSource(const std::weak_ptr<gl::GLBackend>& backend, GLTexture* oldTexture) :
+GLTexture::DownsampleSource::DownsampleSource(const std::weak_ptr<GLBackend>& backend, GLTexture* oldTexture) :
     _backend(backend),
     _size(oldTexture ? oldTexture->_size : 0),
     _texture(oldTexture ? oldTexture->takeOwnership() : 0),
@@ -161,7 +161,7 @@ GLTexture::GLTexture(const std::weak_ptr<GLBackend>& backend, const gpu::Texture
 
 
 // Create the texture and allocate storage
-GLTexture::GLTexture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& texture, GLuint id, bool transferrable) :
+GLTexture::GLTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture, GLuint id, bool transferrable) :
     GLTexture(backend, texture, id, nullptr, transferrable)
 {
     // FIXME, do during allocation
@@ -170,7 +170,7 @@ GLTexture::GLTexture(const std::weak_ptr<gl::GLBackend>& backend, const Texture&
 }
 
 // Create the texture and copy from the original higher resolution version
-GLTexture::GLTexture(const std::weak_ptr<gl::GLBackend>& backend, const gpu::Texture& texture, GLuint id, GLTexture* originalTexture) :
+GLTexture::GLTexture(const std::weak_ptr<GLBackend>& backend, const gpu::Texture& texture, GLuint id, GLTexture* originalTexture) :
     GLTexture(backend, texture, id, originalTexture, originalTexture->_transferrable)
 {
     Q_ASSERT(_minMip >= originalTexture->_minMip);

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.h
@@ -58,7 +58,6 @@ public:
         // If we just did a transfer, return the object after doing post-transfer work
         if (GLSyncState::Transferred == object->getSyncState()) {
             object->postTransfer();
-            return object;
         }
 
         if (object->isOutdated()) {

--- a/libraries/gpu-gl/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTextureTransfer.cpp
@@ -7,10 +7,8 @@
 //
 #include "GLTextureTransfer.h"
 
-#ifdef THREADED_TEXTURE_TRANSFER
-#include <gl/OffscreenGLCanvas.h>
-#include <gl/QOpenGLContextWrapper.h>
-#endif
+#include <gl/GLHelpers.h>
+#include <gl/Context.h>
 
 #include "GLShared.h"
 #include "GLTexture.h"
@@ -20,16 +18,9 @@ using namespace gpu::gl;
 
 GLTextureTransferHelper::GLTextureTransferHelper() {
 #ifdef THREADED_TEXTURE_TRANSFER
-    _canvas = QSharedPointer<OffscreenGLCanvas>(new OffscreenGLCanvas(), &QObject::deleteLater);
-    _canvas->setObjectName("TextureTransferCanvas");
-    _canvas->create(QOpenGLContextWrapper::currentContext());
-    if (!_canvas->makeCurrent()) {
-        qFatal("Unable to create texture transfer context");
-    }
-    _canvas->doneCurrent();
+    setObjectName("TextureTransferThread");
+    _context.create();
     initialize(true, QThread::LowPriority);
-    _canvas->moveToThreadWithContext(_thread);
-
     // Clean shutdown on UNIX, otherwise _canvas is freed early
     connect(qApp, &QCoreApplication::aboutToQuit, [&] { terminate(); });
 #endif
@@ -64,17 +55,9 @@ void GLTextureTransferHelper::transferTexture(const gpu::TexturePointer& texture
 }
 
 void GLTextureTransferHelper::setup() {
-#ifdef THREADED_TEXTURE_TRANSFER
-    _canvas->makeCurrent();
-#endif
 }
 
 void GLTextureTransferHelper::shutdown() {
-#ifdef THREADED_TEXTURE_TRANSFER
-    _canvas->doneCurrent();
-    _canvas->moveToThreadWithContext(qApp->thread());
-    _canvas.reset();
-#endif
 }
 
 void GLTextureTransferHelper::do_transfer(GLTexture& texture) {
@@ -85,6 +68,9 @@ void GLTextureTransferHelper::do_transfer(GLTexture& texture) {
 }
 
 bool GLTextureTransferHelper::processQueueItems(const Queue& messages) {
+#ifdef THREADED_TEXTURE_TRANSFER
+    _context.makeCurrent();
+#endif
     for (auto package : messages) {
         TexturePointer texturePointer = package.texture.lock();
         // Texture no longer exists, move on to the next
@@ -93,21 +79,39 @@ bool GLTextureTransferHelper::processQueueItems(const Queue& messages) {
         }
 
         if (package.fence) {
-            glClientWaitSync(package.fence, GL_SYNC_FLUSH_COMMANDS_BIT, GL_TIMEOUT_IGNORED);
+            auto result = glClientWaitSync(package.fence, 0, 0);
+            while (GL_TIMEOUT_EXPIRED == result || GL_WAIT_FAILED == result) {
+                // Minimum sleep
+                QThread::usleep(1);
+                result = glClientWaitSync(package.fence, 0, 0);
+            }
+            assert(GL_CONDITION_SATISFIED == result || GL_ALREADY_SIGNALED == result);
             glDeleteSync(package.fence);
             package.fence = 0;
         }
 
         GLTexture* object = Backend::getGPUObject<GLTexture>(*texturePointer);
+
         do_transfer(*object);
         glBindTexture(object->_target, 0);
 
-        auto writeSync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-        glClientWaitSync(writeSync, GL_SYNC_FLUSH_COMMANDS_BIT, GL_TIMEOUT_IGNORED);
-        glDeleteSync(writeSync);
+        {
+            auto fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+            assert(fence);
+            auto result = glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+            while (GL_TIMEOUT_EXPIRED == result || GL_WAIT_FAILED == result) {
+                // Minimum sleep
+                QThread::usleep(1);
+                result = glClientWaitSync(fence, 0, 0);
+            }
+            glDeleteSync(package.fence);
+        }
 
         object->_contentStamp = texturePointer->getDataStamp();
         object->setSyncState(GLSyncState::Transferred);
     }
+#ifdef THREADED_TEXTURE_TRANSFER
+    _context.doneCurrent();
+#endif
     return true;
 }

--- a/libraries/gpu-gl/src/gpu/gl/GLTextureTransfer.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLTextureTransfer.h
@@ -13,13 +13,13 @@
 
 #include <GenericQueueThread.h>
 
+#include <gl/Context.h>
+
 #include "GLShared.h"
 
 #ifdef Q_OS_WIN
 #define THREADED_TEXTURE_TRANSFER
 #endif
-
-class OffscreenGLCanvas;
 
 namespace gpu { namespace gl {
 
@@ -43,7 +43,7 @@ protected:
     void do_transfer(GLTexture& texturePointer);
 
 private:
-    QSharedPointer<OffscreenGLCanvas> _canvas;
+    ::gl::OffscreenContext _context;
 };
 
 } }

--- a/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
@@ -27,8 +27,10 @@
 
 namespace gpu { namespace gl41 {
 
-class GL41Backend : public gl::GLBackend {
-    using Parent = gl::GLBackend;
+using namespace gpu::gl;
+
+class GL41Backend : public GLBackend {
+    using Parent = GLBackend;
     // Context Backend static interface required
     friend class Context;
 
@@ -36,12 +38,12 @@ public:
     explicit GL41Backend(bool syncCache) : Parent(syncCache) {}
     GL41Backend() : Parent() {}
 
-    class GL41Texture : public gpu::gl::GLTexture {
-        using Parent = gpu::gl::GLTexture;
+    class GL41Texture : public GLTexture {
+        using Parent = GLTexture;
         GLuint allocate();
     public:
-        GL41Texture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& buffer, bool transferrable);
-        GL41Texture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& buffer, GL41Texture* original);
+        GL41Texture(const std::weak_ptr<GLBackend>& backend, const Texture& buffer, bool transferrable);
+        GL41Texture(const std::weak_ptr<GLBackend>& backend, const Texture& buffer, GL41Texture* original);
 
     protected:
         void transferMip(uint16_t mipLevel, uint8_t face = 0) const;
@@ -56,16 +58,16 @@ public:
 
 protected:
     GLuint getFramebufferID(const FramebufferPointer& framebuffer) override;
-    gl::GLFramebuffer* syncGPUObject(const Framebuffer& framebuffer) override;
+    GLFramebuffer* syncGPUObject(const Framebuffer& framebuffer) override;
 
     GLuint getBufferID(const Buffer& buffer) override;
-    gl::GLBuffer* syncGPUObject(const Buffer& buffer) override;
+    GLBuffer* syncGPUObject(const Buffer& buffer) override;
 
     GLuint getTextureID(const TexturePointer& texture, bool needTransfer = true) override;
-    gl::GLTexture* syncGPUObject(const TexturePointer& texture, bool sync = true) override;
+    GLTexture* syncGPUObject(const TexturePointer& texture, bool sync = true) override;
 
     GLuint getQueryID(const QueryPointer& query) override;
-    gl::GLQuery* syncGPUObject(const Query& query) override;
+    GLQuery* syncGPUObject(const Query& query) override;
 
     // Draw Stage
     void do_draw(const Batch& batch, size_t paramOffset) override;

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendBuffer.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendBuffer.cpp
@@ -10,7 +10,7 @@
 
 namespace gpu {
     namespace gl41 {
-        class GL41Buffer : public gl::GLBuffer {
+        class GL41Buffer : public gpu::gl::GLBuffer {
             using Parent = gpu::gl::GLBuffer;
             static GLuint allocate() {
                 GLuint result;
@@ -55,6 +55,7 @@ namespace gpu {
 }
 
 using namespace gpu;
+using namespace gpu::gl;
 using namespace gpu::gl41;
 
 
@@ -62,6 +63,6 @@ GLuint GL41Backend::getBufferID(const Buffer& buffer) {
     return GL41Buffer::getId<GL41Buffer>(*this, buffer);
 }
 
-gl::GLBuffer* GL41Backend::syncGPUObject(const Buffer& buffer) {
+GLBuffer* GL41Backend::syncGPUObject(const Buffer& buffer) {
     return GL41Buffer::sync<GL41Buffer>(*this, buffer);
 }

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendQuery.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendQuery.cpp
@@ -13,10 +13,11 @@
 #include "../gl/GLQuery.h"
 
 using namespace gpu;
+using namespace gpu::gl;
 using namespace gpu::gl41; 
 
-class GL41Query : public gpu::gl::GLQuery {
-    using Parent = gpu::gl::GLQuery;
+class GL41Query : public GLQuery {
+    using Parent = GLQuery;
 public:
     static GLuint allocateQuery() {
         GLuint result;
@@ -24,11 +25,11 @@ public:
         return result;
     }
 
-    GL41Query(const std::weak_ptr<gl::GLBackend>& backend, const Query& query)
+    GL41Query(const std::weak_ptr<GLBackend>& backend, const Query& query)
         : Parent(backend, query, allocateQuery(), allocateQuery()) { }
 };
 
-gl::GLQuery* GL41Backend::syncGPUObject(const Query& query) {
+GLQuery* GL41Backend::syncGPUObject(const Query& query) {
     return GL41Query::sync<GL41Query>(*this, query);
 }
 

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -17,9 +17,10 @@
 #include "../gl/GLTexelFormat.h"
 
 using namespace gpu;
+using namespace gpu::gl;
 using namespace gpu::gl41;
 
-using GL41TexelFormat = gl::GLTexelFormat;
+using GL41TexelFormat = GLTexelFormat;
 using GL41Texture = GL41Backend::GL41Texture;
 
 GLuint GL41Texture::allocate() {
@@ -33,13 +34,13 @@ GLuint GL41Backend::getTextureID(const TexturePointer& texture, bool transfer) {
     return GL41Texture::getId<GL41Texture>(*this, texture, transfer);
 }
 
-gl::GLTexture* GL41Backend::syncGPUObject(const TexturePointer& texture, bool transfer) {
+GLTexture* GL41Backend::syncGPUObject(const TexturePointer& texture, bool transfer) {
     return GL41Texture::sync<GL41Texture>(*this, texture, transfer);
 }
 
-GL41Texture::GL41Texture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& texture, bool transferrable) : gl::GLTexture(backend, texture, allocate(), transferrable) {}
+GL41Texture::GL41Texture(const std::weak_ptr<GLBackend>& backend, const Texture& texture, bool transferrable) : GLTexture(backend, texture, allocate(), transferrable) {}
 
-GL41Texture::GL41Texture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& texture, GL41Texture* original) : gl::GLTexture(backend, texture, allocate(), original) {}
+GL41Texture::GL41Texture(const std::weak_ptr<GLBackend>& backend, const Texture& texture, GL41Texture* original) : GLTexture(backend, texture, allocate(), original) {}
 
 void GL41Backend::GL41Texture::withPreservedTexture(std::function<void()> f) const  {
     GLint boundTex = -1;
@@ -71,7 +72,7 @@ void GL41Backend::GL41Texture::generateMips() const {
 }
 
 void GL41Backend::GL41Texture::allocateStorage() const {
-    gl::GLTexelFormat texelFormat = gl::GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat());
+    GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat());
     glTexParameteri(_target, GL_TEXTURE_BASE_LEVEL, 0);
     (void)CHECK_GL_ERROR();
     glTexParameteri(_target, GL_TEXTURE_MAX_LEVEL, _maxMip - _minMip);
@@ -131,7 +132,7 @@ void GL41Backend::GL41Texture::updateSize() const {
 // Move content bits from the CPU to the GPU for a given mip / face
 void GL41Backend::GL41Texture::transferMip(uint16_t mipLevel, uint8_t face) const {
     auto mip = _gpuObject.accessStoredMipFace(mipLevel, face);
-    gl::GLTexelFormat texelFormat = gl::GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat(), mip->getFormat());
+    GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat(), mip->getFormat());
     //GLenum target = getFaceTargets()[face];
     GLenum target = _target == GL_TEXTURE_2D ? GL_TEXTURE_2D : CUBE_FACE_LAYOUT[face];
     auto size = _gpuObject.evalMipDimensions(mipLevel);
@@ -216,7 +217,7 @@ void GL41Backend::GL41Texture::syncSampler() const {
 
     if (sampler.doComparison()) {
         glTexParameteri(_target, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_R_TO_TEXTURE);
-        glTexParameteri(_target, GL_TEXTURE_COMPARE_FUNC, gl::COMPARISON_TO_GL[sampler.getComparisonFunction()]);
+        glTexParameteri(_target, GL_TEXTURE_COMPARE_FUNC, COMPARISON_TO_GL[sampler.getComparisonFunction()]);
     } else {
         glTexParameteri(_target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
     }

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTransform.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTransform.cpp
@@ -69,7 +69,9 @@ void GL41Backend::transferTransformState(const Batch& batch) const {
 #else
     glActiveTexture(GL_TEXTURE0 + TRANSFORM_OBJECT_SLOT);
     glBindTexture(GL_TEXTURE_BUFFER, _transform._objectBufferTexture);
-    glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA32F, _transform._objectBuffer);
+    if (!batch._objects.empty()) {
+        glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA32F, _transform._objectBuffer);
+    }
 #endif
 
     CHECK_GL_ERROR();

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -15,9 +15,11 @@
 #include "../gl/GLTexture.h"
 
 namespace gpu { namespace gl45 {
+    
+using namespace gpu::gl;
 
-class GL45Backend : public gl::GLBackend {
-    using Parent = gl::GLBackend;
+class GL45Backend : public GLBackend {
+    using Parent = GLBackend;
     // Context Backend static interface required
     friend class Context;
 
@@ -25,12 +27,12 @@ public:
     explicit GL45Backend(bool syncCache) : Parent(syncCache) {}
     GL45Backend() : Parent() {}
 
-    class GL45Texture : public gpu::gl::GLTexture {
-        using Parent = gpu::gl::GLTexture;
+    class GL45Texture : public GLTexture {
+        using Parent = GLTexture;
         GLuint allocate(const Texture& texture);
     public:
-        GL45Texture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& texture, bool transferrable);
-        GL45Texture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& texture, GLTexture* original);
+        GL45Texture(const std::weak_ptr<GLBackend>& backend, const Texture& texture, bool transferrable);
+        GL45Texture(const std::weak_ptr<GLBackend>& backend, const Texture& texture, GLTexture* original);
 
     protected:
         void transferMip(uint16_t mipLevel, uint8_t face = 0) const;
@@ -45,16 +47,16 @@ public:
 
 protected:
     GLuint getFramebufferID(const FramebufferPointer& framebuffer) override;
-    gl::GLFramebuffer* syncGPUObject(const Framebuffer& framebuffer) override;
+    GLFramebuffer* syncGPUObject(const Framebuffer& framebuffer) override;
 
     GLuint getBufferID(const Buffer& buffer) override;
-    gl::GLBuffer* syncGPUObject(const Buffer& buffer) override;
+    GLBuffer* syncGPUObject(const Buffer& buffer) override;
 
     GLuint getTextureID(const TexturePointer& texture, bool needTransfer = true) override;
-    gl::GLTexture* syncGPUObject(const TexturePointer& texture, bool sync = true) override;
+    GLTexture* syncGPUObject(const TexturePointer& texture, bool sync = true) override;
 
     GLuint getQueryID(const QueryPointer& query) override;
-    gl::GLQuery* syncGPUObject(const Query& query) override;
+    GLQuery* syncGPUObject(const Query& query) override;
 
     // Draw Stage
     void do_draw(const Batch& batch, size_t paramOffset) override;

--- a/libraries/ui/src/MainWindow.cpp
+++ b/libraries/ui/src/MainWindow.cpp
@@ -30,6 +30,7 @@ MainWindow::MainWindow(QWidget* parent) :
     _windowGeometry("WindowGeometry"),
     _windowState("WindowState", 0)
 {
+    setAttribute(Qt::WA_NoSystemBackground);
     setAcceptDrops(true);
 }
 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -12,8 +12,11 @@
 
 #include <GLMHelpers.h>
 
+#include <gl/Context.h>
+
 #include <gpu/Frame.h>
 #include <gpu/gl/GLBackend.h>
+
 
 #include <ViewFrustum.h>
 #include <PathUtils.h>
@@ -56,7 +59,7 @@ public:
     using Condition = std::condition_variable;
     using Lock = std::unique_lock<Mutex>;
     friend class OpenVrDisplayPlugin;
-    std::shared_ptr<OffscreenGLCanvas> _canvas;
+    std::shared_ptr<gl::OffscreenContext> _canvas;
     BasicFramebufferWrapperPtr _framebuffer;
     ProgramPtr _program;
     ShapeWrapperPtr _plane;
@@ -129,7 +132,6 @@ public:
 
     void run() override {
         QThread::currentThread()->setPriority(QThread::Priority::TimeCriticalPriority);
-        assert(_canvas->thread() == QThread::currentThread());
         _canvas->makeCurrent();
         glDisable(GL_DEPTH_TEST);
         glViewport(0, 0, _plugin._renderTargetSize.x, _plugin._renderTargetSize.y);
@@ -206,7 +208,6 @@ public:
         _program.reset();
         _framebuffer.reset();
         _canvas->doneCurrent();
-        _canvas->moveToThreadWithContext(qApp->thread());
     }
 
     void update(const CompositeInfo& newCompositeInfo) {
@@ -309,14 +310,11 @@ bool OpenVrDisplayPlugin::internalActivate() {
     _submitThread = std::make_shared<OpenVrSubmitThread>(*this);
     if (!_submitCanvas) {
         withMainThreadContext([&] {
-            _submitCanvas = std::make_shared<OffscreenGLCanvas>();
-            _submitCanvas->setObjectName("OpenVRSubmitContext");
-            _submitCanvas->create(_container->getPrimaryContext());
+            _submitCanvas = std::make_shared<gl::OffscreenContext>();
+            _submitCanvas->create();
             _submitCanvas->doneCurrent();
         });
     }
-    _submitCanvas->moveToThreadWithContext(_submitThread.get());
-    assert(_submitCanvas->thread() == _submitThread.get());
 #endif
 
     return Parent::internalActivate();
@@ -354,7 +352,6 @@ void OpenVrDisplayPlugin::customizeContext() {
         }
         _compositeInfos[i].textureID = getGLBackend()->getTextureID(_compositeInfos[i].texture, false);
     }
-    assert(_submitCanvas->thread() == _submitThread.get());
     _submitThread->_canvas = _submitCanvas;
     _submitThread->start(QThread::HighPriority);
 #endif
@@ -367,7 +364,6 @@ void OpenVrDisplayPlugin::uncustomizeContext() {
     _submitThread->_quit = true;
     _submitThread->wait();
     _submitThread.reset();
-    assert(_submitCanvas->thread() == qApp->thread());
 #endif
 }
 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -18,6 +18,9 @@ const float TARGET_RATE_OpenVr = 90.0f;  // FIXME: get from sdk tracked device p
 #define OPENVR_THREADED_SUBMIT 1
 
 #if OPENVR_THREADED_SUBMIT
+namespace gl {
+    class OffscreenContext;
+}
 class OpenVrSubmitThread;
 class OffscreenGLCanvas;
 static const size_t COMPOSITING_BUFFER_SIZE = 3;
@@ -79,7 +82,7 @@ private:
     CompositeInfo::Array _compositeInfos;
     size_t _renderingIndex { 0 };
     std::shared_ptr<OpenVrSubmitThread> _submitThread;
-    std::shared_ptr<OffscreenGLCanvas> _submitCanvas;
+    std::shared_ptr<gl::OffscreenContext> _submitCanvas;
     friend class OpenVrSubmitThread;
 #endif
 };

--- a/tests/gpu-test/src/TestWindow.cpp
+++ b/tests/gpu-test/src/TestWindow.cpp
@@ -73,7 +73,6 @@ void TestWindow::initGl() {
     DependencyManager::set<DeferredLightingEffect>();
     resize(QSize(800, 600));
 
-    GLDebug::setupLogger(this);
 #ifdef DEFERRED_LIGHTING
     auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
     deferredLightingEffect->init();

--- a/tests/render-perf/src/Camera.hpp
+++ b/tests/render-perf/src/Camera.hpp
@@ -32,6 +32,9 @@ public:
         DOWN,
         BACK,
         FORWARD,
+        MLEFT,
+        MMIDDLE,
+        MRIGHT,
         KEYS_SIZE,
         INVALID = -1,
     };

--- a/tests/render-utils/src/main.cpp
+++ b/tests/render-utils/src/main.cpp
@@ -112,8 +112,6 @@ public:
 
         gpu::Context::init<gpu::gl::GLBackend>();
 
-
-        GLDebug::setupLogger(this);
         qDebug() << (const char*)glGetString(GL_VERSION);
 
         //_textRenderer[0] = TextRenderer::getInstance(SANS_FONT_FAMILY, 12, false);

--- a/tests/shaders/src/main.cpp
+++ b/tests/shaders/src/main.cpp
@@ -108,9 +108,7 @@ public:
 
         show();
         makeCurrent();
-
         gpu::Context::init<gpu::gl::GLBackend>();
-        GLDebug::setupLogger(this);
         makeCurrent();
         resize(QSize(800, 600));
     }


### PR DESCRIPTION
This customizes the OpenGL context creation on windows, and falls back to the standard Qt context creation on other platforms.

## Testing

Smoke test for functionality.  However, the build should be tested on both Windows and OSX and on windows platforms should be tested on both AMD, nVidia, and Intel hardware, and tested on both older (non OpenGL 4.5 supporting) systems as well as recent cards, and should be tested in both Oculus and Vive on supported hardware. 

If you test and pass or fail this PR please note your hardware and GL version (should be visible in the logs)

## Tested

* nVidia - OpenGL 4.5 - Pass

## Untested

* Win32/AMD - OpenGL 4.5
* OSX - OpenGL 4.1
* Linux - OpenGL ???
* Win32/Intel - OpenGL 4.1 ? (needs somewhat old Intel GPU)
* Win32/AMD OpenGL 4.1 ? (needs very old AMD card)
* Win32/nVidia OpenGL 4.1 ? (needs very old nVidia card)