### PR TITLE
size activity card up

### DIFF
--- a/interface/resources/qml/AddressBarDialog.qml
+++ b/interface/resources/qml/AddressBarDialog.qml
@@ -217,8 +217,8 @@ Window {
         }
 
         Window {
-            width: 750;
-            height: 500;
+            width: 938;
+            height: 625;
             scale: 0.8  // Reset scale of Window to 1.0 (counteract address bar's scale value of 1.25)
             HifiControls.WebView {
                 anchors.fill: parent;


### PR DESCRIPTION
Scale the activity card back up to match the window being scaled down, so that it covers the address bar.