### PR TITLE
Center HMD Hud after teleport

### DIFF
--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -553,6 +553,7 @@ function Teleporter() {
         _this.smoothArrivalInterval = Script.setInterval(function() {
             if (_this.arrivalPoints.length === 0) {
                 Script.clearInterval(_this.smoothArrivalInterval);
+                HMD.centerUI();
                 return;
             }
             var landingPoint = _this.arrivalPoints.shift();
@@ -564,8 +565,8 @@ function Teleporter() {
             }
 
         }, SMOOTH_ARRIVAL_SPACING);
-        
-        HMD.centerUI();
+
+
     }
 }
 

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -564,6 +564,8 @@ function Teleporter() {
             }
 
         }, SMOOTH_ARRIVAL_SPACING);
+        
+        HMD.centerUI();
     }
 }
 


### PR DESCRIPTION
This PR centers the HMD hud in Vive after you teleport, so that it doesn't get abandoned!

To test:
1. In Vive, make sure that the HUD is always near you after you teleport.  In previous builds it was possible to leave it behind in space.