### PR TITLE
include default scripts instead of loading them

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -8,25 +8,75 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+var DEFAULT_SCRIPTS = [
+    "system/progress.js",
+    "system/away.js",
+    "system/users.js",
+    "system/mute.js",
+    "system/goto.js",
+    "system/hmd.js",
+    "system/marketplaces/marketplace.js",
+    "system/edit.js",
+    "system/mod.js",
+    "system/selectAudioDevice.js",
+    "system/notifications.js",
+    "system/controllers/handControllerGrab.js",
+    "system/controllers/handControllerPointer.js",
+    "system/controllers/squeezeHands.js",
+    "system/controllers/grab.js",
+    "system/controllers/teleport.js",
+    "system/controllers/toggleAdvancedMovementForHandControllers.js,
+    "system/dialTone.js",
+    "system/firstPersonHMD.js",
+    "system/snapshot.js"
+];
 
-Script.load("system/progress.js");
-Script.load("system/away.js");
-Script.load("system/users.js");
-Script.load("system/mute.js");
-Script.load("system/goto.js");
-Script.load("system/hmd.js");
-Script.load("system/marketplaces/marketplace.js");
-Script.load("system/edit.js");
-Script.load("system/mod.js");
-Script.load("system/selectAudioDevice.js");
-Script.load("system/notifications.js");
-Script.load("system/controllers/handControllerGrab.js");
-Script.load("system/controllers/handControllerPointer.js");
-Script.load("system/controllers/squeezeHands.js");
-Script.load("system/controllers/grab.js");
-Script.load("system/controllers/teleport.js");
-Script.load("system/controllers/toggleAdvancedMovementForHandControllers.js")
-Script.load("system/dialTone.js");
-Script.load("system/firstPersonHMD.js");
-Script.load("system/snapshot.js");
+// add a menu item for debugging
+var MENU_CATEGORY = "Developer"
+var MENU_ITEM = "Debug defaultScripts.js";
+var debuggingDefaultScripts = false;
 
+if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_ITEM)) {
+    Menu.addMenuItem({
+        menuName: MENU_CATEGORY,
+        menuItemName: MENU_ITEM,
+        isCheckable: true,
+        isChecked: false,
+        grouping: "Advanced"
+    });
+}
+
+// start all scripts
+if (Menu.isOptionChecked(MENU_ITEM)) {
+    // we're debugging individual default scripts
+    // so we load each into its own ScriptEngine instance
+    debuggingDefaultScripts = true;
+    for (var i in DEFAULT_SCRIPTS) {
+        Script.load(DEFAULT_SCRIPTS[i]);
+    }
+} else {
+    // include all default scripts into this ScriptEngine
+    for (var i in DEFAULT_SCRIPTS) {
+        Script.include(DEFAULT_SCRIPTS[i]);
+    }
+}
+
+function stopLoadedScripts() {
+    if (debuggingDefaultScripts) {
+        // remove debug script loads
+        var runningScripts = ScriptDiscoveryService.getRunning();
+        for (var i in runningScripts) {
+            var scriptName = runningScripts[i].name;
+            for (var j in DEFAULT_SCRIPTS) {
+                if (DEFAULT_SCRIPTS[j].slice(-scriptName.length) == scriptName) {
+                    ScriptDiscoveryService.stopScript(runningScripts[i].url);
+                }
+            }
+        }
+        if (!Menu.isOptionChecked(MENU_ITEM)) {
+            Menu.removeMenuItem(MENU_CATEGORY, MENU_ITEM);
+        }
+    }
+}
+
+Script.scriptEnding.connect(stopLoadedScripts);

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -1,3 +1,6 @@
+"use strict";
+/* jslint vars: true, plusplus: true */
+
 //
 //  defaultScripts.js
 //  examples

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -32,7 +32,7 @@ var DEFAULT_SCRIPTS = [
 ];
 
 // add a menu item for debugging
-var MENU_CATEGORY = "Developer"
+var MENU_CATEGORY = "Developer";
 var MENU_ITEM = "Debug defaultScripts.js";
 var debuggingDefaultScripts = false;
 
@@ -56,8 +56,8 @@ if (Menu.isOptionChecked(MENU_ITEM)) {
     }
 } else {
     // include all default scripts into this ScriptEngine
-    for (var i in DEFAULT_SCRIPTS) {
-        Script.include(DEFAULT_SCRIPTS[i]);
+    for (var j in DEFAULT_SCRIPTS) {
+        Script.include(DEFAULT_SCRIPTS[j]);
     }
 }
 
@@ -68,7 +68,7 @@ function stopLoadedScripts() {
         for (var i in runningScripts) {
             var scriptName = runningScripts[i].name;
             for (var j in DEFAULT_SCRIPTS) {
-                if (DEFAULT_SCRIPTS[j].slice(-scriptName.length) == scriptName) {
+                if (DEFAULT_SCRIPTS[j].slice(-scriptName.length) === scriptName) {
                     ScriptDiscoveryService.stopScript(runningScripts[i].url);
                 }
             }

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -1,8 +1,8 @@
 "use strict";
-/*jslint vars: true, plusplus: true*/
-/*global HMD, AudioDevice, MyAvatar, Controller, Script, Overlays, print*/
+
 //
 //  away.js
+//
 //  examples
 //
 //  Created by Howard Stearns 11/3/15
@@ -13,9 +13,11 @@
 //
 // Goes into "paused" when the '.' key (and automatically when started in HMD), and normal when pressing any key.
 // See MAIN CONTROL, below, for what "paused" actually does.
+
+(function() { // BEGIN LOCAL_SCOPE
+
 var OVERLAY_WIDTH = 1920;
 var OVERLAY_HEIGHT = 1080;
-var OVERLAY_RATIO = OVERLAY_WIDTH / OVERLAY_HEIGHT;
 var OVERLAY_DATA = {
     width: OVERLAY_WIDTH,
     height: OVERLAY_HEIGHT,
@@ -51,7 +53,11 @@ var AWAY_INTRO = {
 var _animation = AnimationCache.prefetch(AWAY_INTRO.url);
 
 function playAwayAnimation() {
-    MyAvatar.overrideAnimation(AWAY_INTRO.url, AWAY_INTRO.playbackRate, AWAY_INTRO.loopFlag, AWAY_INTRO.startFrame, AWAY_INTRO.endFrame);
+    MyAvatar.overrideAnimation(AWAY_INTRO.url,
+            AWAY_INTRO.playbackRate,
+            AWAY_INTRO.loopFlag,
+            AWAY_INTRO.startFrame,
+            AWAY_INTRO.endFrame);
 }
 
 function stopAwayAnimation() {
@@ -74,8 +80,6 @@ function moveCloserToCamera(positionAtHUD) {
 }
 
 function showOverlay() {
-    var properties = {visible: true};
-
     if (HMD.active) {
         // make sure desktop version is hidden
         Overlays.editOverlay(overlay, { visible: false });
@@ -252,8 +256,9 @@ function maybeGoAway() {
         }
     }
 
-    // If the mouse has gone from captured, to non-captured state, then it likely means the person is still in the HMD, but
-    // tabbed away from the application (meaning they don't have mouse control) and they likely want to go into an away state
+    // If the mouse has gone from captured, to non-captured state, then it likely means the person is still in the HMD,
+    // but tabbed away from the application (meaning they don't have mouse control) and they likely want to go into
+    // an away state
     if (Reticle.mouseCaptured !== wasMouseCaptured) {
         wasMouseCaptured = !wasMouseCaptured;
         if (!wasMouseCaptured) {
@@ -298,3 +303,5 @@ Script.scriptEnding.connect(function () {
     Controller.mousePressEvent.disconnect(goActive);
     Controller.keyPressEvent.disconnect(maybeGoActive);
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/controllers/grab.js
+++ b/scripts/system/controllers/grab.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //  grab.js
 //  examples
 //
@@ -9,7 +11,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/*global print, Mouse, MyAvatar, Entities, AnimationCache, SoundCache, Scene, Camera, Overlays, Audio, HMD, AvatarList, AvatarManager, Controller, UndoStack, Window, Account, GlobalServices, Script, ScriptDiscoveryService, LODManager, Menu, Vec3, Quat, AudioDevice, Paths, Clipboard, Settings, XMLHttpRequest, randFloat, randInt, pointInExtents, vec3equal, setEntityCustomData, getEntityCustomData */
+
+(function() { // BEGIN LOCAL_SCOPE
 
 Script.include("../libraries/utils.js");
 // objects that appear smaller than this can't be grabbed
@@ -344,7 +347,6 @@ Grabber.prototype.pressEvent = function(event) {
 
     mouse.startDrag(event);
 
-    var now = Date.now();
     this.lastHeartBeat = 0;
 
     var clickedEntity = pickResults.entityID;
@@ -385,7 +387,7 @@ Grabber.prototype.pressEvent = function(event) {
 
     beacon.updatePosition(this.startPosition);
 
-    if(!entityIsGrabbedByOther(this.entityID)){
+    if (!entityIsGrabbedByOther(this.entityID)) {
       this.moveEvent(event);
     }
 
@@ -452,7 +454,7 @@ Grabber.prototype.moveEvent = function(event) {
 
     // see if something added/restored gravity
     var entityProperties = Entities.getEntityProperties(this.entityID);
-    if (Vec3.length(entityProperties.gravity) != 0) {
+    if (Vec3.length(entityProperties.gravity) !== 0.0) {
         this.originalGravity = entityProperties.gravity;
     }
     this.currentPosition = entityProperties.position;
@@ -500,7 +502,8 @@ Grabber.prototype.moveEvent = function(event) {
             };
         } else {
             var cameraPosition = Camera.getPosition();
-            newPointOnPlane = mouseIntersectionWithPlane(this.pointOnPlane, this.planeNormal, mouse.current, this.maxDistance);
+            newPointOnPlane = mouseIntersectionWithPlane(
+                    this.pointOnPlane, this.planeNormal, mouse.current, this.maxDistance);
             var relativePosition = Vec3.subtract(newPointOnPlane, cameraPosition);
             var distance = Vec3.length(relativePosition);
             if (distance > this.maxDistance) {
@@ -625,7 +628,7 @@ function editEvent(channel, message, sender, localOnly) {
         return;
     }
     try {
-        data = JSON.parse(message);
+        var data = JSON.parse(message);
         if ("enabled" in data) {
             enabled = !data["enabled"];
         }
@@ -640,3 +643,5 @@ Controller.keyPressEvent.connect(keyPressEvent);
 Controller.keyReleaseEvent.connect(keyReleaseEvent);
 Messages.subscribe("edit-events");
 Messages.messageReceived.connect(editEvent);
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/controllers/grab.js
+++ b/scripts/system/controllers/grab.js
@@ -15,8 +15,7 @@
 (function() { // BEGIN LOCAL_SCOPE
 
 Script.include("../libraries/utils.js");
-// objects that appear smaller than this can't be grabbed
-var MAX_SOLID_ANGLE = 0.01;
+var MAX_SOLID_ANGLE = 0.01; // objects that appear smaller than this can't be grabbed
 
 var ZERO_VEC3 = {
     x: 0,
@@ -42,18 +41,6 @@ var DEFAULT_GRABBABLE_DATA = {
 };
 
 
-var MAX_SOLID_ANGLE = 0.01; // objects that appear smaller than this can't be grabbed
-var ZERO_VEC3 = {
-    x: 0,
-    y: 0,
-    z: 0
-};
-var IDENTITY_QUAT = {
-    x: 0,
-    y: 0,
-    z: 0,
-    w: 0
-};
 var ACTION_TTL = 10; // seconds
 
 var enabled = true;
@@ -124,7 +111,7 @@ function mouseIntersectionWithPlane(pointOnPlane, planeNormal, event, maxDistanc
 }
 
 // Mouse class stores mouse click and drag info
-Mouse = function() {
+function Mouse() {
     this.current = {
         x: 0,
         y: 0
@@ -194,7 +181,7 @@ var mouse = new Mouse();
 
 
 // Beacon class stores info for drawing a line at object's target position
-Beacon = function() {
+function Beacon() {
     this.height = 0.10;
     this.overlayID = Overlays.addOverlay("line3d", {
         color: {
@@ -246,7 +233,7 @@ var beacon = new Beacon();
 
 
 // Grabber class stores and computes info for grab behavior
-Grabber = function() {
+function Grabber() {
     this.isGrabbing = false;
     this.entityID = null;
     this.actionID = null;

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1,4 +1,5 @@
 "use strict";
+
 //  handControllerGrab.js
 //
 //  Created by Eric Levin on  9/2/15
@@ -10,7 +11,8 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-/* global setEntityCustomData, getEntityCustomData, vec3toStr, flatten, Xform */
+
+(function() { // BEGIN LOCAL_SCOPE
 
 Script.include("/~/system/libraries/utils.js");
 Script.include("/~/system/libraries/Xform.js");
@@ -25,8 +27,6 @@ var WANT_DEBUG_SEARCH_NAME = null;
 //
 // these tune time-averaging and "on" value for analog trigger
 //
-
-var SPARK_MODEL_SCALE_FACTOR = 0.75;
 
 var TRIGGER_SMOOTH_RATIO = 0.1; //  Time averaging of trigger - 0.0 disables smoothing
 var TRIGGER_OFF_VALUE = 0.1;
@@ -88,7 +88,6 @@ var COLORS_GRAB_DISTANCE_HOLD = {
 };
 
 
-var LINE_LENGTH = 500;
 var PICK_MAX_DISTANCE = 500; // max length of pick-ray
 
 //
@@ -129,7 +128,6 @@ var ZERO_VEC = {
 var NULL_UUID = "{00000000-0000-0000-0000-000000000000}";
 
 // these control how long an abandoned pointer line or action will hang around
-var LIFETIME = 10;
 var ACTION_TTL = 15; // seconds
 var ACTION_TTL_REFRESH = 5;
 var PICKS_PER_SECOND_PER_HAND = 60;
@@ -2643,3 +2641,5 @@ function cleanup() {
 
 Script.scriptEnding.connect(cleanup);
 Script.update.connect(update);
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -1,6 +1,4 @@
 "use strict";
-/*jslint vars: true, plusplus: true*/
-/*globals Script, Overlays, Controller, Reticle, HMD, Camera, Entities, MyAvatar, Settings, Menu, ScriptDiscoveryService, Window, Vec3, Quat, print*/
 
 //
 //  handControllerPointer.js
@@ -12,6 +10,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 // Control the "mouse" using hand controller. (HMD and desktop.)
 // First-person only.
@@ -440,7 +440,7 @@ function clearSystemLaser() {
     HMD.disableHandLasers(BOTH_HUD_LASERS);
     systemLaserOn = false;
     weMovedReticle = true;
-    Reticle.position = { x: -1, y: -1 }; 
+    Reticle.position = { x: -1, y: -1 };
 }
 function setColoredLaser() { // answer trigger state if lasers supported, else falsey.
     var color = (activeTrigger.state === 'full') ? LASER_TRIGGER_COLOR_XYZW : LASER_SEARCH_COLOR_XYZW;
@@ -508,3 +508,5 @@ Script.scriptEnding.connect(function () {
     Script.clearInterval(settingsChecker);
     OffscreenFlags.navigationFocusDisabled = false;
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/controllers/squeezeHands.js
+++ b/scripts/system/controllers/squeezeHands.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  controllers/squeezeHands.js
 //
@@ -9,6 +11,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 var lastLeftTrigger = 0;
 var lastRightTrigger = 0;
@@ -82,3 +86,5 @@ function shutdown() {
 Script.scriptEnding.connect(shutdown);
 
 init();
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Created by james b. pollack @imgntn on 7/2/2016
 // Copyright 2016 High Fidelity, Inc.
 //
@@ -5,6 +7,8 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+(function() { // BEGIN LOCAL_SCOPE
 
 var inTeleportMode = false;
 
@@ -594,7 +598,6 @@ function getAvatarFootOffset() {
         }
     })
 
-    var myPosition = MyAvatar.position;
     var offset = upperLeg + lowerLeg + foot + toe + toeTop;
     offset = offset / 100;
     return offset;
@@ -738,3 +741,5 @@ var handleHandMessages = function(channel, message, sender) {
 
 Messages.subscribe('Hifi-Teleport-Disabler');
 Messages.messageReceived.connect(handleHandMessages);
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -1,13 +1,17 @@
+"use strict";
+
 // Created by james b. pollack @imgntn on 8/18/2016
 // Copyright 2016 High Fidelity, Inc.
 //
-//advanced movements settings are in individual controller json files
-//what we do is check the status of the 'advance movement' checkbox when you enter HMD mode
-//if 'advanced movement' is checked...we give you the defaults that are in the json.
-//if 'advanced movement' is not checked... we override the advanced controls with basic ones.
+// advanced movements settings are in individual controller json files
+// what we do is check the status of the 'advance movement' checkbox when you enter HMD mode
+// if 'advanced movement' is checked...we give you the defaults that are in the json.
+// if 'advanced movement' is not checked... we override the advanced controls with basic ones.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+(function() { // BEGIN LOCAL_SCOPE
 
 var mappingName, basicMapping, isChecked;
 
@@ -139,3 +143,5 @@ HMD.displayModeChanged.connect(function(isHMDMode) {
         }
     }
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/dialTone.js
+++ b/scripts/system/dialTone.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  dialTone.js
 //  examples
@@ -10,9 +12,9 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+(function() { // BEGIN LOCAL_SCOPE
+
 // setup the local sound we're going to use
-
-
 var connectSound = SoundCache.getSound(Script.resolvePath("assets/sounds/hello.wav"));
 var disconnectSound = SoundCache.getSound(Script.resolvePath("assets/sounds/goodbye.wav"));
 var micMutedSound = SoundCache.getSound(Script.resolvePath("assets/sounds/goodbye.wav"));
@@ -36,3 +38,5 @@ AudioDevice.muteToggled.connect(function () {
         Audio.playSound(micMutedSound, soundOptions);
     }
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //  newEditEntities.js
 //  examples
 //
@@ -11,13 +13,13 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+(function() { // BEGIN LOCAL_SCOPE
+
 var HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
 var EDIT_TOGGLE_BUTTON = "com.highfidelity.interface.system.editButton";
 var SYSTEM_TOOLBAR = "com.highfidelity.interface.toolbar.system";
 var EDIT_TOOLBAR = "com.highfidelity.interface.toolbar.edit";
 
-/* globals SelectionDisplay, SelectionManager, LightOverlayManager, CameraManager, Grid, GridTool, EntityListTool, Toolbars,
-           progressDialog, tooltip, ParticleExplorerTool */
 Script.include([
     "libraries/stringHelpers.js",
     "libraries/dataViewHelpers.js",
@@ -94,7 +96,6 @@ var SHOULD_SHOW_PROPERTY_MENU = false;
 var INSUFFICIENT_PERMISSIONS_ERROR_MSG = "You do not have the necessary permissions to edit on this domain.";
 var INSUFFICIENT_PERMISSIONS_IMPORT_ERROR_MSG = "You do not have the necessary permissions to place items on this domain.";
 
-var mode = 0;
 var isActive = false;
 
 var IMPORTING_SVO_OVERLAY_WIDTH = 144;
@@ -501,8 +502,6 @@ var selectedEntityID;
 var orientation;
 var intersection;
 
-
-var SCALE_FACTOR = 200.0;
 
 function rayPlaneIntersection(pickRay, point, normal) { //
     //
@@ -1726,3 +1725,5 @@ entityListTool.webView.webEventReceived.connect(function (data) {
         }
     }
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/firstPersonHMD.js
+++ b/scripts/system/firstPersonHMD.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  firstPersonHMD.js
 //  system
@@ -9,9 +11,13 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+(function() { // BEGIN LOCAL_SCOPE
+
 // Automatically enter first person mode when entering HMD mode
 HMD.displayModeChanged.connect(function(isHMDMode) {
     if (isHMDMode) {
         Camera.setModeString("first person");
     }
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/goto.js
+++ b/scripts/system/goto.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  goto.js
 //  scripts/system/
@@ -8,6 +10,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 var toolBar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
 
@@ -38,3 +42,5 @@ Script.scriptEnding.connect(function () {
     button.clicked.disconnect(onClicked);
     DialogsManager.addressBarShown.disconnect(onAddressBarShown);
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/hmd.js
+++ b/scripts/system/hmd.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  hmd.js
 //  scripts/system/
@@ -8,6 +10,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 var headset; // The preferred headset. Default to the first one found in the following list.
 var displayMenuName = "Display";
@@ -36,13 +40,13 @@ if (headset) {
         visible: true,
         hoverState: 2,
         defaultState: 0,
-        alpha: 0.9,
+        alpha: 0.9
     });
     onHmdChanged(HMD.active);
-    
+
     button.clicked.connect(onClicked);
     HMD.displayModeChanged.connect(onHmdChanged);
-    
+
     Script.scriptEnding.connect(function () {
         toolBar.removeButton("hmdToggle");
         button.clicked.disconnect(onClicked);
@@ -50,3 +54,4 @@ if (headset) {
     });
 }
 
+}()); // END LOCAL_SCOPE

--- a/scripts/system/marketplaces/clara.js
+++ b/scripts/system/marketplaces/clara.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  clara.js
 //
@@ -8,6 +10,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 var toolIconUrl = Script.resolvePath("../assets/images/tools/");
 var qml = Script.resolvePath("../../../resources/qml/MarketplaceComboBox.qml")
@@ -77,3 +81,5 @@ Script.scriptEnding.connect(function () {
     browseExamplesButton.clicked.disconnect(onClick);
     marketplaceWindow.visibleChanged.disconnect(onExamplesWindowVisibilityChanged);
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/marketplaces/marketplace.js
+++ b/scripts/system/marketplaces/marketplace.js
@@ -8,6 +8,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+(function() { // BEGIN LOCAL_SCOPE
+
 /* global WebTablet */
 Script.include("../libraries/WebTablet.js");
 
@@ -100,3 +102,5 @@ Script.scriptEnding.connect(function () {
     browseExamplesButton.clicked.disconnect(onClick);
     marketplaceWindow.visibleChanged.disconnect(onMarketplaceWindowVisibilityChanged);
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/mod.js
+++ b/scripts/system/mod.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  mod.js
 //  scripts/system/
@@ -8,6 +10,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 // grab the toolbar
 var toolbar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
@@ -39,7 +43,7 @@ function removeOverlays() {
     // enumerate the overlays and remove them
     var modOverlayKeys = Object.keys(modOverlays);
 
-    for (i = 0; i < modOverlayKeys.length; ++i) {
+    for (var i = 0; i < modOverlayKeys.length; ++i) {
         var avatarID = modOverlayKeys[i];
         Overlays.deleteOverlay(modOverlays[avatarID]);
     }
@@ -72,7 +76,7 @@ function updateOverlays() {
 
         var identifiers = AvatarList.getAvatarIdentifiers();
 
-        for (i = 0; i < identifiers.length; ++i) {
+        for (var i = 0; i < identifiers.length; ++i) {
             var avatarID = identifiers[i];
 
             if (avatarID === null) {
@@ -138,7 +142,7 @@ function handleSelectedOverlay(clickedOverlay) {
     // see this is one of our mod overlays
 
     var modOverlayKeys = Object.keys(modOverlays)
-    for (i = 0; i < modOverlayKeys.length; ++i) {
+    for (var i = 0; i < modOverlayKeys.length; ++i) {
         var avatarID = modOverlayKeys[i];
         var modOverlay = modOverlays[avatarID];
 
@@ -214,3 +218,5 @@ Script.scriptEnding.connect(function() {
     removeOverlays();
     triggerMapping.disable();
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/mute.js
+++ b/scripts/system/mute.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  goto.js
 //  scripts/system/
@@ -9,8 +11,9 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var toolBar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
+(function() { // BEGIN LOCAL_SCOPE
 
+var toolBar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
 
 var button = toolBar.addButton({
     objectName: "mute",
@@ -33,7 +36,7 @@ function onMuteToggled() {
 }
 onMuteToggled();
 function onClicked(){
-    var menuItem = "Mute Microphone"; 
+    var menuItem = "Mute Microphone";
     Menu.setIsOptionChecked(menuItem, !Menu.isOptionChecked(menuItem));
 }
 button.clicked.connect(onClicked);
@@ -44,3 +47,5 @@ Script.scriptEnding.connect(function () {
     button.clicked.disconnect(onClicked);
     AudioDevice.muteToggled.disconnect(onMuteToggled);
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  notifications.js
 //  Version 0.801
@@ -56,6 +58,8 @@
 //      }
 //  }
 
+(function() { // BEGIN LOCAL_SCOPE
+
 Script.include("./libraries/soundArray.js");
 
 var width = 340.0; //width of notification overlay
@@ -105,7 +109,7 @@ var NotificationType = {
             return NotificationType.UNKNOWN;
         }
         var preMenuItemName = menuItemName.substr(0, menuItemName.length - NOTIFICATION_MENU_ITEM_POST.length);
-        for (type in this.properties) {
+        for (var type in this.properties) {
             if (this.properties[type].text === preMenuItemName) {
                 return parseInt(type) + 1;
             }
@@ -120,7 +124,7 @@ var NotificationType = {
 var randomSounds = new SoundArray({ localOnly: true }, true);
 var numberOfSounds = 2;
 for (var i = 1; i <= numberOfSounds; i++) {
-    
+
     randomSounds.addSound(Script.resolvePath("assets/sounds/notification-general"+ i + ".raw"));
 }
 
@@ -230,9 +234,9 @@ function calculate3DOverlayPositions(noticeWidth, noticeHeight, y) {
     };
 }
 
-//  Pushes data to each array and sets up data for 2nd dimension array 
+//  Pushes data to each array and sets up data for 2nd dimension array
 //  to handle auxiliary data not carried by the overlay class
-//  specifically notification "heights", "times" of creation, and . 
+//  specifically notification "heights", "times" of creation, and .
 function notify(notice, button, height, imageProperties, image) {
     var notificationText,
         noticeWidth,
@@ -584,7 +588,7 @@ function setup() {
         isChecked: Settings.getValue(PLAY_NOTIFICATION_SOUNDS_SETTING)
     });
     Menu.addSeparator(MENU_NAME, "Play sounds for:");
-    for (type in NotificationType.properties) {
+    for (var type in NotificationType.properties) {
         checked = Settings.getValue(PLAY_NOTIFICATION_SOUNDS_TYPE_SETTING_PRE + (parseInt(type) + 1));
         checked = checked === '' ? true : checked;
         Menu.addMenuItem({
@@ -620,7 +624,7 @@ LODManager.LODDecreased.connect(function() {
     var warningText = "\n"
             + "Due to the complexity of the content, the \n"
             + "level of detail has been decreased. "
-            + "You can now see: \n" 
+            + "You can now see: \n"
             + LODManager.getLODFeedbackText();
 
     if (lodTextID == false) {
@@ -641,3 +645,5 @@ Window.domainConnectionRefused.connect(onDomainConnectionRefused);
 Window.snapshotTaken.connect(onSnapshotTaken);
 
 setup();
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/progress.js
+++ b/scripts/system/progress.js
@@ -245,7 +245,7 @@
     }
 
     function updateProgressBarLocation() {
-        viewport = Controller.getViewportDimensions();
+        var viewport = Controller.getViewportDimensions();
         windowWidth = viewport.x;
         windowHeight = viewport.y;
 

--- a/scripts/system/progress.js
+++ b/scripts/system/progress.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  progress.js
 //  examples
@@ -11,7 +13,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-(function() {
+(function() { // BEGIN LOCAL_SCOPE
 
     function debug() {
         return;
@@ -283,4 +285,5 @@
     GlobalServices.updateDownloadInfo();
     Script.setInterval(update, 1000/60);
     Script.scriptEnding.connect(tearDown);
-}());
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/selectAudioDevice.js
+++ b/scripts/system/selectAudioDevice.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  audioDeviceExample.js
 //  examples
@@ -10,6 +12,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 if (typeof String.prototype.startsWith != 'function') {
     String.prototype.startsWith = function (str){
@@ -62,11 +66,11 @@ function setupAudioMenus() {
     for(var i = 0; i < outputDevices.length; i++) {
         var thisDeviceSelected = (outputDevices[i] == selectedOutputDevice);
         var menuItem = "Use " + outputDevices[i] + " for Output";
-        Menu.addMenuItem({ 
-                            menuName: "Audio > Devices", 
-                            menuItemName: menuItem, 
-                            isCheckable: true, 
-                            isChecked: thisDeviceSelected 
+        Menu.addMenuItem({
+                            menuName: "Audio > Devices",
+                            menuItemName: menuItem,
+                            isCheckable: true,
+                            isChecked: thisDeviceSelected
                         });
         if (thisDeviceSelected) {
             selectedOutputMenu = menuItem;
@@ -86,11 +90,11 @@ function setupAudioMenus() {
     for(var i = 0; i < inputDevices.length; i++) {
         var thisDeviceSelected = (inputDevices[i] == selectedInputDevice);
         var menuItem = "Use " + inputDevices[i] + " for Input";
-        Menu.addMenuItem({ 
-                            menuName: "Audio > Devices", 
-                            menuItemName: menuItem, 
-                            isCheckable: true, 
-                            isChecked: thisDeviceSelected 
+        Menu.addMenuItem({
+                            menuName: "Audio > Devices",
+                            menuItemName: menuItem,
+                            isCheckable: true,
+                            isChecked: thisDeviceSelected
                         });
         if (thisDeviceSelected) {
             selectedInputMenu = menuItem;
@@ -212,3 +216,5 @@ Script.scriptEnding.connect(function () {
     Menu.menuItemEvent.disconnect(menuItemEvent);
     Script.update.disconnect(checkHMDAudio);
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -7,6 +7,9 @@
 // Distributed under the Apache License, Version 2.0
 // See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
+
 var SNAPSHOT_DELAY = 500; // 500ms
 var toolBar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
 var resetOverlays;
@@ -152,3 +155,5 @@ Script.scriptEnding.connect(function () {
     button.clicked.disconnect(onClicked);
     Window.snapshotShared.disconnect(snapshotShared);
 });
+
+}()); // END LOCAL_SCOPE

--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //
 //  users.js
 //  examples
@@ -8,6 +10,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+
+(function() { // BEGIN LOCAL_SCOPE
 
 var PopUpMenu = function (properties) {
     var value = properties.value,
@@ -1189,3 +1193,5 @@ var usersWindow = (function () {
     setUp();
     Script.scriptEnding.connect(tearDown);
 }());
+
+}()); // END LOCAL_SCOPE


### PR DESCRIPTION
* use Script.include() inside defaultScripts.js instead of Script.load() for performance improvements
* all default script variables are evaluated in local scope to prevent namespace collisions
* localize scope of accidental global variables in default scripts