### PR TITLE
fix default skybox behavior

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4326,7 +4326,7 @@ namespace render {
            }
             case model::SunSkyStage::SKY_BOX: {
                 auto skybox = skyStage->getSkybox();
-                if (skybox) {
+                if (!skybox->empty()) {
                     PerformanceTimer perfTimer("skybox");
                     skybox->render(batch, args->getViewFrustum());
                     break;

--- a/libraries/model/src/model/Skybox.h
+++ b/libraries/model/src/model/Skybox.h
@@ -35,6 +35,7 @@ public:
     void setCubemap(const gpu::TexturePointer& cubemap);
     const gpu::TexturePointer& getCubemap() const { return _cubemap; }
 
+    virtual bool empty() { return _schemaBuffer.get<Schema>().color == vec3(0) && !_cubemap; }
     virtual void clear() { setCubemap(nullptr); }
 
     void prepare(gpu::Batch& batch, int textureSlot = SKYBOX_SKYMAP_SLOT, int bufferSlot = SKYBOX_CONSTANTS_SLOT) const;

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -38,6 +38,7 @@ public:
     void parse(const QString& userDataJson);
 
     bool ready();
+    bool enabled() { return _enabled; }
     void prepare(gpu::Batch& batch, const glm::vec3& position, const glm::vec3& size, const glm::quat& orientation);
     const gpu::ShaderPointer& getShader() const { return _shader; }
 

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -26,6 +26,10 @@ ProceduralSkybox::ProceduralSkybox() : model::Skybox() {
     _procedural._opaqueState->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
+bool ProceduralSkybox::empty() {
+    return !_procedural.enabled() && Skybox::empty();
+}
+
 void ProceduralSkybox::clear() {
     // Parse and prepare a procedural with no shaders to release textures
     parse(QString());

--- a/libraries/procedural/src/procedural/ProceduralSkybox.h
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.h
@@ -20,13 +20,14 @@
 class ProceduralSkybox: public model::Skybox {
 public:
     ProceduralSkybox();
-    virtual ~ProceduralSkybox() {};
+    ~ProceduralSkybox() override {};
 
     void parse(const QString& userData) { _procedural.parse(userData); }
 
-    virtual void clear() override;
+    bool empty() override;
+    void clear() override;
 
-    virtual void render(gpu::Batch& batch, const ViewFrustum& frustum) const override;
+    void render(gpu::Batch& batch, const ViewFrustum& frustum) const override;
     static void render(gpu::Batch& batch, const ViewFrustum& frustum, const ProceduralSkybox& skybox);
 
 protected:


### PR DESCRIPTION
- shows default skybox when none is set
- shows color as skybox when a color other than black(0,0,0) is set
- shows texture as skybox when a texture is set
- shows tinted texture as skybox when a color other than black(0,0,0) and a texture are set