### PR TITLE
Make sure we start fade in once an item becomes ready

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -330,9 +330,22 @@ bool Geometry::areTexturesLoaded() const {
     if (!_areTexturesLoaded) {
         for (auto& material : _materials) {
             // Check if material textures are loaded
-            if (std::any_of(material->_textures.cbegin(), material->_textures.cend(),
-                [](const NetworkMaterial::Textures::value_type& it) { return it.texture && !it.texture->isLoaded(); })) {
+            bool materialMissingTexture = std::any_of(material->_textures.cbegin(), material->_textures.cend(),
+                [](const NetworkMaterial::Textures::value_type& it) { 
+                auto texture = it.texture;
+                if (!texture) {
+                    return false;
+                }
+                // Failed texture downloads need to be considered as 'loaded' 
+                // or the object will never fade in
+                bool finished = texture->isLoaded() || texture->isFailed();
+                if (!finished) {
+                    return true;
+                }
+                return false;
+            });
 
+            if (materialMissingTexture) {
                 return false;
             }
 

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -282,6 +282,9 @@ public:
     /// Checks whether the resource has loaded.
     virtual bool isLoaded() const { return _loaded; }
 
+    /// Checks whether the resource has failed to download.
+    virtual bool isFailed() const { return _failedToLoad; }
+
     /// For loading resources, returns the number of bytes received.
     qint64 getBytesReceived() const { return _bytesReceived; }
     

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -533,9 +533,20 @@ void ModelMeshPartPayload::startFade() {
 void ModelMeshPartPayload::render(RenderArgs* args) const {
     PerformanceTimer perfTimer("ModelMeshPartPayload::render");
 
-    if (!_model->_readyWhenAdded || !_model->_isVisible || !_hasStartedFade) {
+    if (!_model->_readyWhenAdded || !_model->_isVisible) {
         return; // bail asap
     }
+
+    // If we didn't start the fade in, check if we are ready to now....
+    if (!_hasStartedFade && _model->isLoaded() && _model->getGeometry()->areTexturesLoaded()) {
+        const_cast<ModelMeshPartPayload&>(*this).startFade();
+    }
+
+    // If we still didn't start the fade in, bail
+    if (!_hasStartedFade) {
+        return;
+    }
+
 
     // When an individual mesh parts like this finishes its fade, we will mark the Model as 
     // having render items that need updating


### PR DESCRIPTION
Some items appear invisible because they become stuck in a state where they never fade in.  This ensures that once the fade in conditions are satisfied we start the fade logic.