### PR TITLE
Fix some edit.js bugs

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1373,6 +1373,7 @@ var PropertiesTool = function (opts) {
             data = JSON.parse(data);
         }
         catch(e) {
+            print('web event was not valid json.')
             return;
         }
         var i, properties, dY, diff, newPosition;

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1373,7 +1373,7 @@ var PropertiesTool = function (opts) {
             data = JSON.parse(data);
         }
         catch(e) {
-            print('web event was not valid json.')
+            print('Edit.js received web event that was not valid json.')
             return;
         }
         var i, properties, dY, diff, newPosition;

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1369,10 +1369,10 @@ var PropertiesTool = function (opts) {
     });
 
     webView.webEventReceived.connect(function (data) {
-        try{
+        try {
             data = JSON.parse(data);
         }
-        catch(e){
+        catch(e) {
             return;
         }
         var i, properties, dY, diff, newPosition;
@@ -1424,8 +1424,8 @@ var PropertiesTool = function (opts) {
             selectionManager._update();
         } else if(data.type === 'saveUserData'){
             //the event bridge and json parsing handle our avatar id string differently.
-            var actualID = data.id.split('"')[1]
-            var success = Entities.editEntity(actualID, data.properties)
+            var actualID = data.id.split('"')[1];
+            Entities.editEntity(actualID, data.properties);
         } else if (data.type === "showMarketplace") {
             showMarketplace();
         } else if (data.type === "action") {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1369,7 +1369,12 @@ var PropertiesTool = function (opts) {
     });
 
     webView.webEventReceived.connect(function (data) {
-        data = JSON.parse(data);
+        try{
+            data = JSON.parse(data);
+        }
+        catch(e){
+            return;
+        }
         var i, properties, dY, diff, newPosition;
         if (data.type === "print") {
             if (data.message) {
@@ -1418,7 +1423,8 @@ var PropertiesTool = function (opts) {
             pushCommandForSelections();
             selectionManager._update();
         } else if(data.type === 'saveUserData'){
-            Entities.editEntity(data.id, data.properties)
+            var actualID = data.id.split('"')[1]
+            var success = Entities.editEntity(actualID, data.properties)
         } else if (data.type === "showMarketplace") {
             showMarketplace();
         } else if (data.type === "action") {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1423,6 +1423,7 @@ var PropertiesTool = function (opts) {
             pushCommandForSelections();
             selectionManager._update();
         } else if(data.type === 'saveUserData'){
+            //the event bridge and json parsing handle our avatar id string differently.
             var actualID = data.id.split('"')[1]
             var success = Entities.editEntity(actualID, data.properties)
         } else if (data.type === "showMarketplace") {

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -333,7 +333,13 @@ function userDataChanger(groupName, keyName, checkBoxElement, userDataElement, d
     var properties = {};
     var parsedData = {};
     try {
-        parsedData = JSON.parse(userDataElement.value);
+        if ($('#userdata-editor').css('height') !== "0px") {
+            //if there is an expanded, we want to use its json.
+            parsedData = getEditorJSON();
+        } else {
+            parsedData = JSON.parse(userDataElement.value);
+        }
+
     } catch (e) {}
 
     if (!(groupName in parsedData)) {
@@ -441,7 +447,11 @@ function hideUserDataTextArea() {
 function showStaticUserData() {
     $('#static-userdata').show();
     $('#static-userdata').css('height', $('#userdata-editor').height())
-    $('#static-userdata').text(editor.getText());
+    if (editor !== null) {
+        $('#static-userdata').text(editor.getText());
+    }
+
+
 };
 
 function removeStaticUserData() {
@@ -450,7 +460,10 @@ function removeStaticUserData() {
 
 function setEditorJSON(json) {
     editor.set(json)
-    editor.expandAll();
+    if (editor.hasOwnProperty('expandAll')) {
+        editor.expandAll();
+    }
+
 };
 
 function getEditorJSON() {
@@ -745,11 +758,11 @@ function loaded() {
                     } else {
 
                         properties = data.selections[0].properties;
-                        if (lastEntityID !== properties.id && lastEntityID !== null && editor !== null) {
+                        if (lastEntityID !== '"' + properties.id + '"' && lastEntityID !== null && editor !== null) {
                             saveJSONUserData(true);
                         }
 
-                        lastEntityID = properties.id;
+                        lastEntityID = '"' + properties.id + '"';
                         elID.innerHTML = properties.id;
 
                         elType.innerHTML = properties.type;
@@ -840,26 +853,27 @@ function loaded() {
                         FIXME: See FIXME for property-script-url.
                         elScriptTimestamp.value = properties.scriptTimestamp;
                         */
-                        hideUserDataTextArea();
+
                         var json = null;
                         try {
                             json = JSON.parse(properties.userData);
-                  
+                        } catch (e) {
+                            //normal text
+                            deleteJSONEditor();
+                            elUserData.value = properties.userData;
+                            showUserDataTextArea();
+                            showNewJSONEditorButton();
+                            hideSaveUserDataButton();
+                        }
+                        if (json !== null) {
                             if (editor === null) {
                                 createJSONEditor();
                             }
 
                             setEditorJSON(json);
                             showSaveUserDataButton();
+                            hideUserDataTextArea();
                             hideNewJSONEditorButton();
-
-                        } catch (e) {
-                            //normal text
-
-                            elUserData.value = properties.userData;
-                            showUserDataTextArea();
-                            showNewJSONEditorButton();
-                            hideSaveUserDataButton();
                         }
 
                         elHyperlinkHref.value = properties.href;

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -758,9 +758,11 @@ function loaded() {
                     } else {
 
                         properties = data.selections[0].properties;
+
                         if (lastEntityID !== '"' + properties.id + '"' && lastEntityID !== null && editor !== null) {
                             saveJSONUserData(true);
                         }
+                        //the event bridge and json parsing handle our avatar id string differently.  
 
                         lastEntityID = '"' + properties.id + '"';
                         elID.innerHTML = properties.id;


### PR DESCRIPTION
This PR fixes a few bugs and handles more edge cases related to changing userdata.


To test: 

1. Create a cube
2. Toggle its grabbable, triggerable, and ignore inverse kinematics checkboxes and note that the json updates to match.  note: if unchecked, the ignoreIK key will be removed, not set to false.
3. add a new entry to the json at the same level as the grabbable key.  toggle the boxes from step 2 and ensure this key is not written over.
4. normal object property checkboxes like visible, locked, dynamic and collisonless should work as expected