### PR TITLE
When trigger is pulled, snap search beam to correct length instead of animating

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1319,6 +1319,11 @@ function MyController(hand) {
 
     this.searchEnter = function() {
         mostRecentSearchingHand = this.hand;
+        var rayPickInfo = this.calcRayPickInfo(this.hand);
+        if (rayPickInfo.entityID || rayPickInfo.overlayID) {
+            this.intersectionDistance = rayPickInfo.distance;
+            this.searchSphereDistance = this.intersectionDistance;
+        }
     };
 
     this.search = function(deltaTime, timestamp) {


### PR DESCRIPTION
This improves interaction on web browser tablets. Instead of the beam shooting
through the tablet and animating back to the surface, it starts at the correct length.