### PR TITLE
No more delete with backspace in edit.js

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -803,7 +803,7 @@ function setupModelMenus() {
             menuName: "Edit",
             menuItemName: "Delete",
             shortcutKeyEvent: {
-                text: "backspace"
+                text: "delete"
             },
             afterItem: "Entities",
             grouping: "Advanced"
@@ -1215,7 +1215,7 @@ Controller.keyReleaseEvent.connect(function (event) {
         cameraManager.keyReleaseEvent(event);
     }
     // since sometimes our menu shortcut keys don't work, trap our menu items here also and fire the appropriate menu items
-    if (event.text === "BACKSPACE" || event.text === "DELETE") {
+    if (event.text === "DELETE") {
         deleteSelectedEntities();
     } else if (event.text === "ESC") {
         selectionManager.clearSelections();


### PR DESCRIPTION
This PR makes it so that you cannot delete objects in edit.js with the backspace key.  It was too easy to accidentally delete things.

To test.
1: Open edit.js and create a cube
2. Select it and hit backspace
3. it should not delete
4. now hit delete key and it should delete