### PR TITLE
Bug fix for click events received by entity scripts

### DIFF
--- a/libraries/shared/src/PointerEvent.cpp
+++ b/libraries/shared/src/PointerEvent.cpp
@@ -81,28 +81,43 @@ QScriptValue PointerEvent::toScriptValue(QScriptEngine* engine, const PointerEve
     direction.setProperty("z", event._direction.z);
     obj.setProperty("pos3D", direction);
 
+    bool isPrimaryButton = false;
+    bool isSecondaryButton = false;
+    bool isTertiaryButton = false;
     switch (event._button) {
     case NoButtons:
         obj.setProperty("button", "None");
         break;
     case PrimaryButton:
         obj.setProperty("button", "Primary");
+        isPrimaryButton = true;
         break;
     case SecondaryButton:
         obj.setProperty("button", "Secondary");
+        isSecondaryButton = true;
         break;
     case TertiaryButton:
         obj.setProperty("button", "Tertiary");
+        isTertiaryButton = true;
         break;
     }
 
-    obj.setProperty("isLeftButton", areFlagsSet(event._buttons, PrimaryButton));
-    obj.setProperty("isRightButton", areFlagsSet(event._buttons, SecondaryButton));
-    obj.setProperty("isMiddleButton", areFlagsSet(event._buttons, TertiaryButton));
+    if (isPrimaryButton) {
+        obj.setProperty("isPrimaryButton", isPrimaryButton);
+        obj.setProperty("isLeftButton", isPrimaryButton);
+    }
+    if (isSecondaryButton) {
+        obj.setProperty("isSecondaryButton", isSecondaryButton);
+        obj.setProperty("isRightButton", isSecondaryButton);
+    }
+    if (isTertiaryButton) {
+        obj.setProperty("isTertiaryButton", isTertiaryButton);
+        obj.setProperty("isMiddleButton", isTertiaryButton);
+    }
 
-    obj.setProperty("isPrimaryButton", areFlagsSet(event._buttons, PrimaryButton));
-    obj.setProperty("isSecondaryButton", areFlagsSet(event._buttons, SecondaryButton));
-    obj.setProperty("isTertiaryButton", areFlagsSet(event._buttons, TertiaryButton));
+    obj.setProperty("isPrimaryHeld", areFlagsSet(event._buttons, PrimaryButton));
+    obj.setProperty("isSecondaryHeld", areFlagsSet(event._buttons, SecondaryButton));
+    obj.setProperty("isTertiaryHeld", areFlagsSet(event._buttons, TertiaryButton));
 
     return obj;
 }
@@ -146,9 +161,9 @@ void PointerEvent::fromScriptValue(const QScriptValue& object, PointerEvent& eve
             event._button = NoButtons;
         }
 
-        bool primary = object.property("isPrimary").toBool() || object.property("isLeftButton").toBool();
-        bool secondary = object.property("isSecondary").toBool() || object.property("isRightButton").toBool();
-        bool tertiary = object.property("isTertiary").toBool() || object.property("isMiddleButton").toBool();
+        bool primary = object.property("isPrimaryHeld").toBool();
+        bool secondary = object.property("isSecondaryHeld").toBool();
+        bool tertiary = object.property("isTertiaryHeld").toBool();
         event._buttons = 0;
         if (primary) {
             event._buttons |= PrimaryButton;

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1426,10 +1426,7 @@ function MyController(hand) {
                     pos3D: rayPickInfo.intersection,
                     normal: rayPickInfo.normal,
                     direction: rayPickInfo.searchRay.direction,
-                    button: "None",
-                    isPrimaryButton: false,
-                    isSecondaryButton: false,
-                    isTertiaryButton: false
+                    button: "None"
                 };
 
                 this.hoverEntity = entity;
@@ -1449,10 +1446,7 @@ function MyController(hand) {
                     pos3D: rayPickInfo.intersection,
                     normal: rayPickInfo.normal,
                     direction: rayPickInfo.searchRay.direction,
-                    button: "None",
-                    isPrimaryButton: false,
-                    isSecondaryButton: false,
-                    isTertiaryButton: false
+                    button: "None"
                 };
 
                 Entities.sendMouseMoveOnEntity(entity, pointerEvent);
@@ -2124,9 +2118,7 @@ function MyController(hand) {
                 normal: intersectInfo.normal,
                 direction: intersectInfo.searchRay.direction,
                 button: "Primary",
-                isPrimaryButton: true,
-                isSecondaryButton: false,
-                isTertiaryButton: false
+                isPrimaryHeld: true
             };
 
             Entities.sendMousePressOnEntity(this.grabbedEntity, pointerEvent);
@@ -2152,15 +2144,12 @@ function MyController(hand) {
                     pos3D: intersectInfo.point,
                     normal: intersectInfo.normal,
                     direction: intersectInfo.searchRay.direction,
-                    button: "Primary",
-                    isPrimaryButton: false,
-                    isSecondaryButton: false,
-                    isTertiaryButton: false
+                    button: "Primary"
                 };
             } else {
                 pointerEvent = this.touchingEnterPointerEvent;
                 pointerEvent.button = "Primary";
-                pointerEvent.isPrimaryButton = false;
+                pointerEvent.isPrimaryHeld = false;
             }
 
             Entities.sendMouseReleaseOnEntity(this.grabbedEntity, pointerEvent);
@@ -2197,9 +2186,7 @@ function MyController(hand) {
                 normal: intersectInfo.normal,
                 direction: intersectInfo.searchRay.direction,
                 button: "NoButtons",
-                isPrimaryButton: true,
-                isSecondaryButton: false,
-                isTertiaryButton: false
+                isPrimaryHeld: true
             };
 
             var POINTER_PRESS_TO_MOVE_DELAY = 0.15; // seconds


### PR DESCRIPTION
PointerEvent.isLeftButton should be true even on left button release events.
in a previous PR this behavior was changed. isLeftButton was used as a flag indicating the button state, which would be false on left button release events.
Because we have scripts that rely on the old behavior, I've changed it back to the original and introduced isPrimaryHeld properties instead.