### PR TITLE
Remember setting for 'debug defaultScripts.js'

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -51,7 +51,6 @@ if (previousSetting === true || previousSetting === 'true') {
 
 
 
-var debuggingDefaultScripts = previousSetting;
 
 if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_ITEM)) {
     Menu.addMenuItem({
@@ -87,19 +86,16 @@ if (Menu.isOptionChecked(MENU_ITEM)) {
 
 function menuItemEvent(menuItem) {
     if (menuItem == MENU_ITEM) {
+
         isChecked = Menu.isOptionChecked(MENU_ITEM);
         if (isChecked === true) {
             Settings.setValue(SETTINGS_KEY, true);
-            debuggingDefaultScripts = true;
-            stopLoadedScripts();
-            runDefaultsSeparately();
         } else if (isChecked === false) {
             Settings.setValue(SETTINGS_KEY, false);
-            debuggingDefaultScripts = false;
-            stopLoadedScripts();
-            runDefaultsTogether();
         }
     }
+        Window.alert('You must reload all scripts for this to take effect.')
+
 }
 
 

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -93,8 +93,9 @@ function menuItemEvent(menuItem) {
         } else if (isChecked === false) {
             Settings.setValue(SETTINGS_KEY, false);
         }
+         Window.alert('You must reload all scripts for this to take effect.')
     }
-        Window.alert('You must reload all scripts for this to take effect.')
+
 
 }
 

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -65,8 +65,7 @@ if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_I
 
 function runDefaultsTogether() {
     for (var j in DEFAULT_SCRIPTS) {
-       print('trying to include:'+DEFAULT_SCRIPTS[j])
-        Script.include(DEFAULT_SCRIPTS[j]+"?"+Math.random());
+        Script.include(DEFAULT_SCRIPTS[j] + "?" + Math.random());
     }
 }
 
@@ -106,18 +105,16 @@ function menuItemEvent(menuItem) {
 
 
 function stopLoadedScripts() {
-   
         // remove debug script loads
-        var runningScripts = ScriptDiscoveryService.getRunning();
-        for (var i in runningScripts) {
-            var scriptName = runningScripts[i].name;
-            for (var j in DEFAULT_SCRIPTS) {
-                if (DEFAULT_SCRIPTS[j].slice(-scriptName.length) === scriptName) {
-                    ScriptDiscoveryService.stopScript(runningScripts[i].url);
-                }
+    var runningScripts = ScriptDiscoveryService.getRunning();
+    for (var i in runningScripts) {
+        var scriptName = runningScripts[i].name;
+        for (var j in DEFAULT_SCRIPTS) {
+            if (DEFAULT_SCRIPTS[j].slice(-scriptName.length) === scriptName) {
+                ScriptDiscoveryService.stopScript(runningScripts[i].url);
             }
         }
-
+    }
 }
 
 function removeMenuItem() {

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -64,7 +64,7 @@ if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_I
 
 function runDefaultsTogether() {
     for (var j in DEFAULT_SCRIPTS) {
-        Script.include(DEFAULT_SCRIPTS[j] + "?" + Math.random());
+        Script.include(DEFAULT_SCRIPTS[j]);
     }
 }
 


### PR DESCRIPTION
This PR makes it so that your setting for whether to 'debug' default scripts is remembered. It also adds an alert when you toggle the menu item to remind you to reload all scripts for your change to take effect.

To test:
1. It should start with combined defaultScripts.js
2. check settings -> debug defaultScripts.js'  an alert should show up. 
3. reload all scripts
5. should be separate
6. uncheck 'settings -> debug defaultScripts.js'
7. reload all scripts
8. a single defaultscripts.js should be running
9. you should be able to leave the app and come back and it should be in the appropriate state.
10. at no time should you have multiple copies of any script running, or multiples of any menu items