### PR TITLE
Exposing GPU & Batch running time to Engine gpu jobs

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLBackendQuery.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendQuery.cpp
@@ -25,6 +25,7 @@ void GLBackend::do_beginQuery(const Batch& batch, size_t paramOffset) {
     auto query = batch._queries.get(batch._params[paramOffset]._uint);
     GLQuery* glquery = syncGPUObject(*query);
     if (glquery) {
+        glGetInteger64v(GL_TIMESTAMP, (GLint64*)&glquery->_batchElapsedTime);
         if (timeElapsed) {
             glBeginQuery(GL_TIME_ELAPSED, glquery->_endqo);
         } else {
@@ -43,6 +44,10 @@ void GLBackend::do_endQuery(const Batch& batch, size_t paramOffset) {
         } else {
             glQueryCounter(glquery->_endqo, GL_TIMESTAMP);
         }
+        GLint64 now;
+        glGetInteger64v(GL_TIMESTAMP, &now);
+        glquery->_batchElapsedTime = now - glquery->_batchElapsedTime;
+
         (void)CHECK_GL_ERROR();
     }
 }
@@ -61,7 +66,7 @@ void GLBackend::do_getQuery(const Batch& batch, size_t paramOffset) {
                 glGetQueryObjectui64v(glquery->_endqo, GL_QUERY_RESULT, &end);
                 glquery->_result = end - start;
             }
-            query->triggerReturnHandler(glquery->_result);
+            query->triggerReturnHandler(glquery->_result, glquery->_batchElapsedTime);
         }
         (void)CHECK_GL_ERROR();
     }

--- a/libraries/gpu-gl/src/gpu/gl/GLQuery.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLQuery.h
@@ -48,6 +48,7 @@ public:
     const GLuint& _endqo = { _id };
     const GLuint _beginqo = { 0 };
     GLuint64 _result { (GLuint64)-1 };
+    GLuint64 _batchElapsedTime { (GLuint64) 0 };
 
 protected:
     GLQuery(const std::weak_ptr<GLBackend>& backend, const Query& query, GLuint endId, GLuint beginId) : Parent(backend, query, endId), _beginqo(beginId) {}

--- a/libraries/gpu/src/gpu/Query.h
+++ b/libraries/gpu/src/gpu/Query.h
@@ -30,14 +30,17 @@ namespace gpu {
         Query(const Handler& returnHandler);
         ~Query();
 
-        double getElapsedTime() const;
+        double getGPUElapsedTime() const;
+        double getBatchElapsedTime() const;
 
+        // Only for gpu::Context
         const GPUObjectPointer gpuObject {};
-        void triggerReturnHandler(uint64_t queryResult);
+        void triggerReturnHandler(uint64_t queryResult, uint64_t batchElapsedTime);
     protected:
         Handler _returnHandler;
 
-        uint64_t _queryResult = 0;
+        uint64_t _queryResult { 0 };
+        uint64_t _usecBatchElapsedTime { 0 };
     };
     
     typedef std::shared_ptr<Query> QueryPointer;
@@ -53,7 +56,8 @@ namespace gpu {
         void begin(gpu::Batch& batch);
         void end(gpu::Batch& batch);
         
-        double getAverage() const;
+        double getGPUAverage() const;
+        double getBatchAverage() const;
 
     protected:
         
@@ -62,7 +66,8 @@ namespace gpu {
         gpu::Queries _timerQueries;
         int _headIndex = -1;
         int _tailIndex = -1;
-        MovingAverage<double, QUERY_QUEUE_SIZE * 2> _movingAverage;
+        MovingAverage<double, QUERY_QUEUE_SIZE * 2> _movingAverageGPU;
+        MovingAverage<double, QUERY_QUEUE_SIZE * 2> _movingAverageBatch;
         
         int rangeIndex(int index) const { return (index % QUERY_QUEUE_SIZE); }
     };

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -432,7 +432,8 @@ void AmbientOcclusionEffect::run(const render::SceneContextPointer& sceneContext
     });
 
     // Update the timer
-    std::static_pointer_cast<Config>(renderContext->jobConfig)->gpuTime = _gpuTimer.getAverage();
+    auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
+    config->setGPUBatchRunTime(_gpuTimer.getGPUAverage(), _gpuTimer.getBatchAverage());
 }
 
 

--- a/libraries/render-utils/src/AmbientOcclusionEffect.h
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.h
@@ -53,7 +53,7 @@ protected:
 
 using AmbientOcclusionFramebufferPointer = std::shared_ptr<AmbientOcclusionFramebuffer>;
 
-class AmbientOcclusionEffectConfig : public render::Job::Config::Persistent {
+class AmbientOcclusionEffectConfig : public render::GPUJobConfig::Persistent {
     Q_OBJECT
     Q_PROPERTY(bool enabled MEMBER enabled NOTIFY dirty)
     Q_PROPERTY(bool ditheringEnabled MEMBER ditheringEnabled NOTIFY dirty)
@@ -68,9 +68,9 @@ class AmbientOcclusionEffectConfig : public render::Job::Config::Persistent {
     Q_PROPERTY(int numSamples MEMBER numSamples WRITE setNumSamples)
     Q_PROPERTY(int resolutionLevel MEMBER resolutionLevel WRITE setResolutionLevel)
     Q_PROPERTY(int blurRadius MEMBER blurRadius WRITE setBlurRadius)
-    Q_PROPERTY(double gpuTime READ getGpuTime)
+
 public:
-    AmbientOcclusionEffectConfig() : render::Job::Config::Persistent("Ambient Occlusion", false) {}
+    AmbientOcclusionEffectConfig() : render::GPUJobConfig::Persistent("Ambient Occlusion", false) {}
 
     const int MAX_RESOLUTION_LEVEL = 4;
     const int MAX_BLUR_RADIUS = 6;
@@ -84,7 +84,6 @@ public:
     void setNumSamples(int samples) { numSamples = std::max(1.0f, (float)samples); emit dirty(); }
     void setResolutionLevel(int level) { resolutionLevel = std::max(0, std::min(level, MAX_RESOLUTION_LEVEL)); emit dirty(); }
     void setBlurRadius(int radius) { blurRadius = std::max(0, std::min(MAX_BLUR_RADIUS, radius)); emit dirty(); }
-    double getGpuTime() { return gpuTime; }
 
     float radius{ 0.5f };
     float perspectiveScale{ 1.0f };
@@ -99,7 +98,6 @@ public:
     bool ditheringEnabled{ true }; // randomize the distribution of taps per pixel, should always be true
     bool borderingEnabled{ true }; // avoid evaluating information from non existing pixels out of the frame, should always be true
     bool fetchMipsEnabled{ true }; // fetch taps in sub mips to otpimize cache, should always be true
-    double gpuTime{ 0.0 };
 
 signals:
     void dirty();

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -714,5 +714,5 @@ void RenderDeferred::run(const SceneContextPointer& sceneContext, const RenderCo
     });
     
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
-    config->gpuTime = _gpuTimer.getAverage();
+    config->setGPUBatchRunTime(_gpuTimer.getGPUAverage(), _gpuTimer.getBatchAverage());
 }

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -161,21 +161,7 @@ public:
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
 };
 
-
-class RenderDeferredConfig : public render::Job::Config {
-    Q_OBJECT
-    Q_PROPERTY(double gpuTime READ getGpuTime)
-public:
-    RenderDeferredConfig() : render::Job::Config(true) {}
-
-    double getGpuTime() { return gpuTime; }
-    
-    double gpuTime{ 0.0 };
-
-signals:
-    void dirty();
-};
-
+using RenderDeferredConfig = render::GPUJobConfig;
 
 class RenderDeferred {
 public:

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -245,7 +245,7 @@ void EndGPURangeTimer::run(const render::SceneContextPointer& sceneContext, cons
     });
     
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
-    config->gpuTime = timer->getAverage();
+    config->setGPUBatchRunTime(timer->getGPUAverage(), timer->getBatchAverage());
 }
 
 

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -193,17 +193,6 @@ public:
 };
 
 using RenderDeferredTaskConfig = render::GPUTaskConfig;
-/**
-class RenderDeferredTaskConfig : public render::Task::Config {
-    Q_OBJECT
-    Q_PROPERTY(double gpuTime READ getGpuTime)
-public:
-    double getGpuTime() { return gpuTime; }
-
-protected:
-    friend class RenderDeferredTask;
-    double gpuTime;
-};*/
 
 class RenderDeferredTask : public render::Task {
 public:

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -29,18 +29,8 @@ protected:
     gpu::RangeTimerPointer _gpuTimer;
 };
 
+using GPURangeTimerConfig = render::GPUJobConfig;
 
-class GPURangeTimerConfig : public render::Job::Config {
-    Q_OBJECT
-    Q_PROPERTY(double gpuTime READ getGpuTime)
-public:
-    double getGpuTime() { return gpuTime; }
-    
-protected:
-    friend class EndGPURangeTimer;
-    double gpuTime;
-};
-  
 class EndGPURangeTimer {
 public:
     using Config = GPURangeTimerConfig;
@@ -143,16 +133,7 @@ protected:
     gpu::PipelinePointer getOpaquePipeline();
 };
 
-class DrawBackgroundDeferredConfig : public render::Job::Config {
-    Q_OBJECT
-    Q_PROPERTY(double gpuTime READ getGpuTime)
-public:
-    double getGpuTime() { return gpuTime; }
-
-protected:
-    friend class DrawBackgroundDeferred;
-    double gpuTime;
-};
+using DrawBackgroundDeferredConfig = render::GPUJobConfig;
 
 class DrawBackgroundDeferred {
 public:
@@ -211,6 +192,8 @@ public:
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext, const gpu::FramebufferPointer& srcFramebuffer);
 };
 
+using RenderDeferredTaskConfig = render::GPUTaskConfig;
+/**
 class RenderDeferredTaskConfig : public render::Task::Config {
     Q_OBJECT
     Q_PROPERTY(double gpuTime READ getGpuTime)
@@ -220,7 +203,7 @@ public:
 protected:
     friend class RenderDeferredTask;
     double gpuTime;
-};
+};*/
 
 class RenderDeferredTask : public render::Task {
 public:

--- a/libraries/render-utils/src/SurfaceGeometryPass.cpp
+++ b/libraries/render-utils/src/SurfaceGeometryPass.cpp
@@ -201,7 +201,7 @@ void LinearDepthPass::run(const render::SceneContextPointer& sceneContext, const
     });
 
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
-    config->gpuTime = _gpuTimer.getAverage();
+    config->setGPUBatchRunTime(_gpuTimer.getGPUAverage(), _gpuTimer.getBatchAverage());
 }
 
 
@@ -524,7 +524,7 @@ void SurfaceGeometryPass::run(const render::SceneContextPointer& sceneContext, c
        
  
     auto config = std::static_pointer_cast<Config>(renderContext->jobConfig);
-    config->gpuTime = _gpuTimer.getAverage();
+    config->setGPUBatchRunTime(_gpuTimer.getGPUAverage(), _gpuTimer.getBatchAverage());
 }
 
 

--- a/libraries/render-utils/src/SurfaceGeometryPass.h
+++ b/libraries/render-utils/src/SurfaceGeometryPass.h
@@ -63,14 +63,6 @@ protected:
 using LinearDepthFramebufferPointer = std::shared_ptr<LinearDepthFramebuffer>;
 
 using LinearDepthPassConfig = render::GPUJobConfig;
-/*
-class LinearDepthPassConfig : public render::GPUJobConfig {
-    Q_OBJECT
-public:
-    LinearDepthPassConfig() : render::GPUJobConfig(true) {}
-signals:
-    void dirty();
-};*/
 
 class LinearDepthPass {
 public:

--- a/libraries/render-utils/src/SurfaceGeometryPass.h
+++ b/libraries/render-utils/src/SurfaceGeometryPass.h
@@ -62,20 +62,15 @@ protected:
 
 using LinearDepthFramebufferPointer = std::shared_ptr<LinearDepthFramebuffer>;
 
-
-class LinearDepthPassConfig : public render::Job::Config {
+using LinearDepthPassConfig = render::GPUJobConfig;
+/*
+class LinearDepthPassConfig : public render::GPUJobConfig {
     Q_OBJECT
-    Q_PROPERTY(double gpuTime READ getGpuTime)
 public:
-    LinearDepthPassConfig() : render::Job::Config(true) {}
-
-    double getGpuTime() { return gpuTime; }
-
-    double gpuTime{ 0.0 };
-
+    LinearDepthPassConfig() : render::GPUJobConfig(true) {}
 signals:
     void dirty();
-};
+};*/
 
 class LinearDepthPass {
 public:
@@ -148,7 +143,7 @@ protected:
 
 using SurfaceGeometryFramebufferPointer = std::shared_ptr<SurfaceGeometryFramebuffer>;
 
-class SurfaceGeometryPassConfig : public render::Job::Config {
+class SurfaceGeometryPassConfig : public render::GPUJobConfig {
     Q_OBJECT
     Q_PROPERTY(float depthThreshold MEMBER depthThreshold NOTIFY dirty)
     Q_PROPERTY(float basisScale MEMBER basisScale NOTIFY dirty)
@@ -158,9 +153,8 @@ class SurfaceGeometryPassConfig : public render::Job::Config {
     Q_PROPERTY(float diffuseFilterScale MEMBER diffuseFilterScale NOTIFY dirty)
     Q_PROPERTY(float diffuseDepthThreshold MEMBER diffuseDepthThreshold NOTIFY dirty)
 
-    Q_PROPERTY(double gpuTime READ getGpuTime)
 public:
-    SurfaceGeometryPassConfig() : render::Job::Config(true) {}
+    SurfaceGeometryPassConfig() : render::GPUJobConfig(true) {}
 
     float depthThreshold{ 5.0f }; // centimeters
     float basisScale{ 1.0f };
@@ -168,10 +162,6 @@ public:
     int resolutionLevel{ 1 };
     float diffuseFilterScale{ 0.2f };
     float diffuseDepthThreshold{ 1.0f };
-
-    double getGpuTime() { return gpuTime; }
-
-    double gpuTime{ 0.0 };
 
 signals:
     void dirty();

--- a/libraries/render/src/render/Task.h
+++ b/libraries/render/src/render/Task.h
@@ -542,7 +542,7 @@ public:
 
         _concept->run(sceneContext, renderContext);
 
-        _concept->setCPURunTime((double)(usecTimestampNow() - start) / 1000000.0);
+        _concept->setCPURunTime((double)(usecTimestampNow() - start) / 1000.0);
     }
 
     protected:

--- a/libraries/render/src/render/Task.h
+++ b/libraries/render/src/render/Task.h
@@ -334,9 +334,9 @@ protected:
 // A default Config is always on; to create an enableable Config, use the ctor JobConfig(bool enabled)
 class JobConfig : public QObject {
     Q_OBJECT
-    Q_PROPERTY(quint64 cpuRunTime READ getCPUTRunTime NOTIFY newStats())
+    Q_PROPERTY(double cpuRunTime READ getCPURunTime NOTIFY newStats()) //ms
 
-    quint64 _CPURunTime{ 0 };
+    double _msCPURunTime{ 0.0 };
 public:
     using Persistent = PersistentConfig<JobConfig>;
 
@@ -364,8 +364,8 @@ public:
 
     // Running Time measurement
     // The new stats signal is emitted once per run time of a job when stats  (cpu runtime) are updated
-    void setCPURunTime(quint64 ustime) { _CPURunTime = ustime; emit newStats(); }
-    quint64 getCPUTRunTime() const { return _CPURunTime; }
+    void setCPURunTime(double mstime) { _msCPURunTime = mstime; emit newStats(); }
+    double getCPURunTime() const { return _msCPURunTime; }
 
 public slots:
     void load(const QJsonObject& val) { qObjectFromJsonValue(val, *this); emit loaded(); }
@@ -418,6 +418,46 @@ template <class T, class I, class O> void jobRun(T& data, const SceneContextPoin
     data.run(sceneContext, renderContext, input, output);
 }
 
+class GPUJobConfig : public JobConfig {
+    Q_OBJECT
+    Q_PROPERTY(double gpuRunTime READ getGPURunTime)
+    Q_PROPERTY(double batchRunTime READ getBatchRunTime)
+
+    double _msGPURunTime { 0.0 };
+    double _msBatchRunTime { 0.0 };
+public:
+    using Persistent = PersistentConfig<GPUJobConfig>;
+
+    GPUJobConfig() = default;
+    GPUJobConfig(bool enabled) : JobConfig(enabled) {}
+
+    // Running Time measurement on GPU and for Batch execution
+    void setGPUBatchRunTime(double msGpuTime, double msBatchTime) { _msGPURunTime = msGpuTime; _msBatchRunTime = msBatchTime; }
+    double getGPURunTime() const { return _msGPURunTime; }
+    double getBatchRunTime() const { return _msBatchRunTime; }
+};
+
+class GPUTaskConfig : public TaskConfig {
+    Q_OBJECT
+    Q_PROPERTY(double gpuRunTime READ getGPURunTime)
+    Q_PROPERTY(double batchRunTime READ getBatchRunTime)
+
+    double _msGPURunTime { 0.0 };
+    double _msBatchRunTime { 0.0 };
+public:
+
+    using Persistent = PersistentConfig<GPUTaskConfig>;
+
+
+    GPUTaskConfig() = default;
+    GPUTaskConfig(bool enabled) : TaskConfig(enabled) {}
+
+    // Running Time measurement on GPU and for Batch execution
+    void setGPUBatchRunTime(double msGpuTime, double msBatchTime) { _msGPURunTime = msGpuTime; _msBatchRunTime = msBatchTime; }
+    double getGPURunTime() const { return _msGPURunTime; }
+    double getBatchRunTime() const { return _msBatchRunTime; }
+};
+
 class Job {
 public:
     using Config = JobConfig;
@@ -439,7 +479,7 @@ public:
         virtual void run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) = 0;
 
     protected:
-        void setCPURunTime(quint64 ustime) { std::static_pointer_cast<Config>(_config)->setCPURunTime(ustime); }
+        void setCPURunTime(double mstime) { std::static_pointer_cast<Config>(_config)->setCPURunTime(mstime); }
 
         QConfigPointer _config;
 
@@ -502,7 +542,7 @@ public:
 
         _concept->run(sceneContext, renderContext);
 
-        _concept->setCPURunTime(usecTimestampNow() - start);
+        _concept->setCPURunTime((double)(usecTimestampNow() - start) / 1000000.0);
     }
 
     protected:

--- a/scripts/developer/utilities/render/ambientOcclusionPass.qml
+++ b/scripts/developer/utilities/render/ambientOcclusionPass.qml
@@ -75,7 +75,7 @@ Column {
             object: Render.getConfig("AmbientOcclusion")
             valueUnit: "ms"
             valueScale: 1
-            valueNumDigits: "4"
+            valueNumDigits: "3"
             plots: [
             {
                    prop: "gpuRunTime",

--- a/scripts/developer/utilities/render/ambientOcclusionPass.qml
+++ b/scripts/developer/utilities/render/ambientOcclusionPass.qml
@@ -78,7 +78,7 @@ Column {
             valueNumDigits: "4"
             plots: [
             {
-                   prop: "gpuTime",
+                   prop: "gpuRunTime",
                    label: "gpu",
                    color: "#FFFFFF"
                }

--- a/scripts/developer/utilities/render/stats.qml
+++ b/scripts/developer/utilities/render/stats.qml
@@ -214,7 +214,7 @@ Item {
            object: parent.drawOpaqueConfig
            valueUnit: "ms"
            valueScale: 1
-           valueNumDigits: "1"
+           valueNumDigits: "2"
            plots: [
                {
                    object: Render.getConfig("DrawOpaqueDeferred"),

--- a/scripts/developer/utilities/render/stats.qml
+++ b/scripts/developer/utilities/render/stats.qml
@@ -213,7 +213,7 @@ Item {
            height: parent.evalEvenHeight()
            object: parent.drawOpaqueConfig
            valueUnit: "ms"
-           valueScale: 1000
+           valueScale: 1
            valueNumDigits: "1"
            plots: [
                {

--- a/scripts/developer/utilities/render/statsGPU.qml
+++ b/scripts/developer/utilities/render/statsGPU.qml
@@ -39,31 +39,71 @@ Item {
            plots: [
             {
                    object: Render.getConfig("OpaqueRangeTimer"),
-                   prop: "gpuTime",
+                   prop: "gpuRunTime",
                    label: "Opaque",
                    color: "#FFFFFF"
                }, 
                {
                    object: Render.getConfig("LinearDepth"),
-                   prop: "gpuTime",
+                   prop: "gpuRunTime",
                    label: "LinearDepth",
                    color: "#00FF00"
                },{
                    object: Render.getConfig("SurfaceGeometry"),
-                   prop: "gpuTime",
+                   prop: "gpuRunTime",
                    label: "SurfaceGeometry",
                    color: "#00FFFF"
                },
                {
                    object: Render.getConfig("RenderDeferred"),
-                   prop: "gpuTime",
+                   prop: "gpuRunTime",
                    label: "DeferredLighting",
                    color: "#FF00FF"
                }
                ,
                {
                    object: Render.getConfig("ToneAndPostRangeTimer"),
-                   prop: "gpuTime",
+                   prop: "gpuRunTime",
+                   label: "tone and post",
+                   color: "#FF0000"
+               }
+           ]
+        }
+        PlotPerf {
+           title: "Timing"
+           height: parent.evalEvenHeight()
+           object: parent.drawOpaqueConfig
+           valueUnit: "ms"
+           valueScale: 1
+           valueNumDigits: "4"
+           plots: [
+            {
+                   object: Render.getConfig("OpaqueRangeTimer"),
+                   prop: "batchRunTime",
+                   label: "Opaque",
+                   color: "#FFFFFF"
+               }, 
+               {
+                   object: Render.getConfig("LinearDepth"),
+                   prop: "batchRunTime",
+                   label: "LinearDepth",
+                   color: "#00FF00"
+               },{
+                   object: Render.getConfig("SurfaceGeometry"),
+                   prop: "batchRunTime",
+                   label: "SurfaceGeometry",
+                   color: "#00FFFF"
+               },
+               {
+                   object: Render.getConfig("RenderDeferred"),
+                   prop: "batchRunTime",
+                   label: "DeferredLighting",
+                   color: "#FF00FF"
+               }
+               ,
+               {
+                   object: Render.getConfig("ToneAndPostRangeTimer"),
+                   prop: "batchRunTime",
                    label: "tone and post",
                    color: "#FF0000"
                }

--- a/scripts/developer/utilities/render/statsGPU.qml
+++ b/scripts/developer/utilities/render/statsGPU.qml
@@ -75,7 +75,7 @@ Item {
            object: parent.drawOpaqueConfig
            valueUnit: "ms"
            valueScale: 1
-           valueNumDigits: "4"
+           valueNumDigits: "3"
            plots: [
             {
                    object: Render.getConfig("OpaqueRangeTimer"),

--- a/scripts/developer/utilities/render/statsGPU.qml
+++ b/scripts/developer/utilities/render/statsGPU.qml
@@ -30,7 +30,7 @@ Item {
 
       
         PlotPerf {
-           title: "Timing"
+           title: "GPU Timing"
            height: parent.evalEvenHeight()
            object: parent.drawOpaqueConfig
            valueUnit: "ms"
@@ -70,7 +70,7 @@ Item {
            ]
         }
         PlotPerf {
-           title: "Timing"
+           title: "Batch Timing"
            height: parent.evalEvenHeight()
            object: parent.drawOpaqueConfig
            valueUnit: "ms"


### PR DESCRIPTION
- Adding the cpu elapsed time in the gpu::Query & gpu::RangeTImer . THis is the cpu time measured to perform the Batch commands from the gpu::Batch::beginQuery to the gpu::Batch::endQuery.
This timing is measured from within the specific Backend (gl).
The Batch run time is the actual time measured in the Render Thread.

- Introduce a systematic render::Job::Config exposing the needed gpuRunTime and batchRunTime. these properties are now visible from the Job relying on a GPUJobConfig.

- changed the type for the cpuRunTIme exposed from render::Job::Config in order to be more coherent with all these timing variables. They are now all double expressed in milliseconds

- Updated the renderStats..qml , GPUStats.qml and ambientOcclusionPass.qml to expose this new information

Testing plan:
Smoke test, nothing should behave or perform differently
Using the script "Developer/Utilities/Render/renderGPUStats.js" should show 2 Plots, one for gpu timing, the 2nd for Batch timing


