### PR TITLE
Don't show address bar when starting up in a connected state

### DIFF
--- a/interface/src/ConnectionMonitor.cpp
+++ b/interface/src/ConnectionMonitor.cpp
@@ -29,7 +29,9 @@ void ConnectionMonitor::init() {
 
     _timer.setSingleShot(true);
     _timer.setInterval(DISPLAY_AFTER_DISCONNECTED_FOR_X_MS);
-    _timer.start();
+    if (!domainHandler.isConnected()) {
+        _timer.start();
+    }
 
     auto dialogsManager = DependencyManager::get<DialogsManager>();
     connect(&_timer, &QTimer::timeout, dialogsManager.data(), &DialogsManager::showAddressBar);


### PR DESCRIPTION
The use of `QCoreApplication::processEvents()` in the app constructor can sometimes lead to the connection to a given server to complete before `ConnectionManager::init`.  Init assumes that no connection exists and that it will receive an event when one does occur.  In this case if you're already connected, then you never get the connection event to stop the timer, and the address bar pops up even though you're already connected.  

The fix is to check the existing connection state in `ConnectionManager::init` and only start the timer if you're not currently connected.


## Testing

* Start interface connected to local domain
* Address bar should not pop up (in production it may)
* Start interface connected to no domain (`hifi://127.0.0.0`)
* Address bar should pop up shortly after start
