### PR TITLE
Fix incorrect fence delete

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTextureTransfer.cpp
@@ -104,7 +104,7 @@ bool GLTextureTransferHelper::processQueueItems(const Queue& messages) {
                 QThread::usleep(1);
                 result = glClientWaitSync(fence, 0, 0);
             }
-            glDeleteSync(package.fence);
+            glDeleteSync(fence);
         }
 
         object->_contentStamp = texturePointer->getDataStamp();


### PR DESCRIPTION
This corrects a bug in the texture transfer that is leaking OpenGL fence objects.

## Testing

Should have no visible impact on the application.