### PR TITLE
Fix overlays when scaling resolution

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -512,7 +512,7 @@ void OpenGLDisplayPlugin::compositeOverlay() {
                 batch.draw(gpu::TRIANGLE_STRIP, 4);
             });
         } else {
-            batch.setViewportTransform(ivec4(uvec2(0), _currentFrame->framebuffer->getSize()));
+            batch.setViewportTransform(ivec4(uvec2(0), _compositeFramebuffer->getSize()));
             batch.draw(gpu::TRIANGLE_STRIP, 4);
         }
     });
@@ -536,7 +536,7 @@ void OpenGLDisplayPlugin::compositePointer() {
                 batch.draw(gpu::TRIANGLE_STRIP, 4);
             });
         } else {
-            batch.setViewportTransform(ivec4(uvec2(0), _currentFrame->framebuffer->getSize()));
+            batch.setViewportTransform(ivec4(uvec2(0), _compositeFramebuffer->getSize()));
             batch.draw(gpu::TRIANGLE_STRIP, 4);
         }
     });
@@ -726,7 +726,7 @@ bool OpenGLDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
 }
 
 ivec4 OpenGLDisplayPlugin::eyeViewport(Eye eye) const {
-    uvec2 vpSize = _currentFrame->framebuffer->getSize();
+    uvec2 vpSize = _compositeFramebuffer->getSize();
     vpSize.x /= 2;
     uvec2 vpPos;
     if (eye == Eye::Right) {


### PR DESCRIPTION
## Testing

in the `Developer / Render / Scale Resolution` menu, select a value other than 1.  In the production build, the UI will take up a fraction of the screen, rather than being overlaid on the entire screen.  In this build the overlay should be displayed properly.