### PR TITLE
Handle window.open/close in Web content.

### DIFF
--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.5
 import QtQuick.Controls 1.2
-import QtWebEngine 1.1
+import QtWebEngine 1.2
 
 import "controls-uit"
 import "styles" as HifiStyles
@@ -222,6 +222,9 @@ ScrollingWindow {
                 var component = Qt.createComponent("Browser.qml");
                 var newWindow = component.createObject(desktop);
                 request.openIn(newWindow.webView)
+            }
+            onWindowCloseRequested: {
+                root.destroy();
             }
 
             Component.onCompleted: {

--- a/interface/resources/qml/controls-uit/BaseWebView.qml
+++ b/interface/resources/qml/controls-uit/BaseWebView.qml
@@ -15,7 +15,7 @@ WebEngineView {
     id: root
     property var newUrl;
 
-    profile.httpUserAgent: "Mozilla/5.0 Chrome/38.0 (HighFidelityInterface)"
+    profile: desktop.browserProfile
 
     Component.onCompleted: {
         console.log("Connecting JS messaging to Hifi Logging")
@@ -60,9 +60,4 @@ WebEngineView {
             }
         }
     }
-
-
-    // This breaks the webchannel used for passing messages.  Fixed in Qt 5.6
-    // See https://bugreports.qt.io/browse/QTBUG-49521
-    //profile: desktop.browserProfile
 }


### PR DESCRIPTION
Handle window.open requests from web pages in controls-uit/WebView following QT upgrade.
Handle window.close requests in the browser.