### PR TITLE
demo: decoupled HMD from physical body

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3667,13 +3667,6 @@ void Application::update(float deltaTime) {
             if (nearbyEntitiesAreReadyForPhysics()) {
                 _physicsEnabled = true;
                 getMyAvatar()->updateMotionBehaviorFromMenu();
-            } else {
-                auto characterController = getMyAvatar()->getCharacterController();
-                if (characterController) {
-                    // if we have a character controller, disable it here so the avatar doesn't get stuck due to
-                    // a non-loading collision hull.
-                    characterController->setEnabled(false);
-                }
             }
         }
     }

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -491,6 +491,8 @@ Menu::Menu() {
         avatar, SLOT(setEnableInverseKinematics(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderSensorToWorldMatrix, 0, false,
         avatar, SLOT(setEnableDebugDrawSensorToWorldMatrix(bool)));
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderIKTargets, 0, false,
+        avatar, SLOT(setEnableDebugDrawIKTargets(bool)));
 
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ActionMotorControl,
         Qt::CTRL | Qt::SHIFT | Qt::Key_K, true, avatar, SLOT(updateMotionBehaviorFromMenu()),

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -502,7 +502,7 @@ Menu::Menu() {
         avatar, SLOT(updateMotionBehaviorFromMenu()),
         UNSPECIFIED_POSITION, "Developer");
 
-    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::EnableCharacterController, 0, true,
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::EnableAvatarCollisions, 0, true,
         avatar, SLOT(updateMotionBehaviorFromMenu()),
         UNSPECIFIED_POSITION, "Developer");
 

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -161,6 +161,7 @@ namespace MenuOption {
     const QString RenderResolutionThird = "1/3";
     const QString RenderResolutionQuarter = "1/4";
     const QString RenderSensorToWorldMatrix = "Show SensorToWorld Matrix";
+    const QString RenderIKTargets = "Show IK Targets";
     const QString ResetAvatarSize = "Reset Avatar Size";
     const QString ResetSensors = "Reset Sensors";
     const QString RunningScripts = "Running Scripts...";

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -97,7 +97,7 @@ namespace MenuOption {
     const QString DontRenderEntitiesAsScene = "Don't Render Entities as Scene";
     const QString EchoLocalAudio = "Echo Local Audio";
     const QString EchoServerAudio = "Echo Server Audio";
-    const QString EnableCharacterController = "Enable avatar collisions";
+    const QString EnableAvatarCollisions = "Enable Avatar Collisions";
     const QString EnableInverseKinematics = "Enable Inverse Kinematics";
     const QString ExpandMyAvatarSimulateTiming = "Expand /myAvatar/simulation";
     const QString ExpandMyAvatarTiming = "Expand /myAvatar";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -82,7 +82,7 @@ const float MyAvatar::ZOOM_MIN = 0.5f;
 const float MyAvatar::ZOOM_MAX = 25.0f;
 const float MyAvatar::ZOOM_DEFAULT = 1.5f;
 
-extern bool HACKY_GLOBAL_ENABLE_DEBUG_DRAW_IK_TARGETS;
+extern bool OUTOFBODY_HACK_ENABLE_DEBUG_DRAW_IK_TARGETS;
 
 MyAvatar::MyAvatar(RigPointer rig) :
     Avatar(rig),
@@ -839,7 +839,7 @@ void MyAvatar::setEnableDebugDrawSensorToWorldMatrix(bool isEnabled) {
 void MyAvatar::setEnableDebugDrawIKTargets(bool isEnabled) {
     _enableDebugDrawIKTargets = isEnabled;
 
-    HACKY_GLOBAL_ENABLE_DEBUG_DRAW_IK_TARGETS = isEnabled;
+    OUTOFBODY_HACK_ENABLE_DEBUG_DRAW_IK_TARGETS = isEnabled;
 }
 
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -547,8 +547,12 @@ void MyAvatar::updateJointFromController(controller::Action poseKey, ThreadSafeV
 void MyAvatar::updateSensorToWorldMatrix() {
     // update the sensor mat so that the body position will end up in the desired
     // position when driven from the head.
-    glm::mat4 desiredMat = createMatFromQuatAndPos(getOrientation(), getPosition());
-    _sensorToWorldMatrix = desiredMat * glm::inverse(_bodySensorMatrix);
+    glm::mat4 bodyToWorld = createMatFromQuatAndPos(getOrientation(), getPosition());
+    setSensorToWorldMatrix(bodyToWorld * glm::inverse(_bodySensorMatrix));
+}
+
+void MyAvatar::setSensorToWorldMatrix(const glm::mat4& sensorToWorld) {
+    _sensorToWorldMatrix = sensorToWorld;
 
     lateUpdatePalms();
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -82,6 +82,8 @@ const float MyAvatar::ZOOM_MIN = 0.5f;
 const float MyAvatar::ZOOM_MAX = 25.0f;
 const float MyAvatar::ZOOM_DEFAULT = 1.5f;
 
+extern bool HACKY_GLOBAL_ENABLE_DEBUG_DRAW_IK_TARGETS;
+
 MyAvatar::MyAvatar(RigPointer rig) :
     Avatar(rig),
     _wasPushing(false),
@@ -829,6 +831,13 @@ void MyAvatar::setEnableDebugDrawSensorToWorldMatrix(bool isEnabled) {
         DebugDraw::getInstance().removeMarker("sensorToWorldMatrix");
     }
 }
+
+void MyAvatar::setEnableDebugDrawIKTargets(bool isEnabled) {
+    _enableDebugDrawIKTargets = isEnabled;
+
+    HACKY_GLOBAL_ENABLE_DEBUG_DRAW_IK_TARGETS = isEnabled;
+}
+
 
 void MyAvatar::setEnableMeshVisible(bool isEnabled) {
     render::ScenePointer scene = qApp->getMain3DScene();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -86,9 +86,9 @@ const float MyAvatar::ZOOM_DEFAULT = 1.5f;
 extern bool OUTOFBODY_HACK_ENABLE_DEBUG_DRAW_IK_TARGETS;
 
 // OUTOFBODY_HACK defined in SkeletonModel.cpp
-extern const glm::vec3 TRUNCATE_IK_CAPSULE_POSITION;
-extern const float TRUNCATE_IK_CAPSULE_LENGTH;
-extern const float TRUNCATE_IK_CAPSULE_RADIUS;
+extern glm::vec3 TRUNCATE_IK_CAPSULE_POSITION;
+extern float TRUNCATE_IK_CAPSULE_LENGTH;
+extern float TRUNCATE_IK_CAPSULE_RADIUS;
 
 MyAvatar::MyAvatar(RigPointer rig) :
     Avatar(rig),
@@ -2159,31 +2159,65 @@ void MyAvatar::FollowHelper::prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat
     _desiredBodyMatrix = desiredBodyMatrix;
 
     if (myAvatar.getHMDLeanRecenterEnabled()) {
-        updateRotationActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
-        updateHorizontalActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
-        updateVerticalActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
 
-        glm::mat4 desiredWorldMatrix = myAvatar.getSensorToWorldMatrix() * _desiredBodyMatrix;
-        glm::mat4 currentWorldMatrix = createMatFromQuatAndPos(myAvatar.getOrientation(), myAvatar.getPosition());
+        if (_isOutOfBody) {
 
-        AnimPose followWorldPose(currentWorldMatrix);
-        if (isActive(Rotation)) {
-            followWorldPose.rot = glmExtractRotation(desiredWorldMatrix);
-        }
-        if (isActive(Horizontal)) {
+            glm::mat4 desiredWorldMatrix = myAvatar.getSensorToWorldMatrix() * _desiredBodyMatrix;
+            glm::mat4 currentWorldMatrix = createMatFromQuatAndPos(myAvatar.getOrientation(), myAvatar.getPosition());
+            AnimPose followWorldPose(currentWorldMatrix);
+
+            // OUTOFBODY_HACK, only takes horizontal movement into account.
+
+            // horizontal follow
             glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
             followWorldPose.trans.x = desiredTranslation.x;
             followWorldPose.trans.z = desiredTranslation.z;
-        }
-        if (isActive(Vertical)) {
-            glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
-            followWorldPose.trans.y = desiredTranslation.y;
-        }
 
-        if (isActive()) {
+            // rotation follow
+            // face the HMD
+            glm::vec3 hmdWorldPosition = extractTranslation(myAvatar.getSensorToWorldMatrix() * myAvatar.getHMDSensorMatrix());
+            glm::vec3 facing = myAvatar.getPosition() - hmdWorldPosition;
+            facing.y = 0.0f;
+            if (glm::length(facing) > EPSILON) {
+                // turn to face the hmd
+                followWorldPose.rot = glm::angleAxis(atan2(facing.x, facing.z), Vectors::UNIT_Y);
+            } else {
+                followWorldPose.rot = glmExtractRotation(desiredWorldMatrix);
+            }
+
             myAvatar.getCharacterController()->setFollowParameters(followWorldPose);
+
         } else {
-            myAvatar.getCharacterController()->disableFollow();
+            updateRotationActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
+            updateHorizontalActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
+            updateVerticalActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
+
+            glm::mat4 desiredWorldMatrix = myAvatar.getSensorToWorldMatrix() * _desiredBodyMatrix;
+            glm::mat4 currentWorldMatrix = createMatFromQuatAndPos(myAvatar.getOrientation(), myAvatar.getPosition());
+
+            AnimPose followWorldPose(currentWorldMatrix);
+            if (isActive(Rotation)) {
+                followWorldPose.rot = glmExtractRotation(desiredWorldMatrix);
+            }
+            if (isActive(Horizontal)) {
+                glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
+                followWorldPose.trans.x = desiredTranslation.x;
+                followWorldPose.trans.z = desiredTranslation.z;
+            }
+            if (isActive(Vertical)) {
+                glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
+                followWorldPose.trans.y = desiredTranslation.y;
+            }
+
+            if (isActive()) {
+                myAvatar.getCharacterController()->setFollowParameters(followWorldPose);
+            } else {
+                myAvatar.getCharacterController()->disableFollow();
+            }
+
+            glm::mat4 currentWorldMatrixY180 = createMatFromQuatAndPos(myAvatar.getOrientation() * Quaternions::Y_180, myAvatar.getPosition());
+            _prevInBodyHMDMatInAvatarSpace = _inBodyHMDMatInAvatarSpace;
+            _inBodyHMDMatInAvatarSpace = glm::inverse(currentWorldMatrixY180) * myAvatar.getSensorToWorldMatrix() * myAvatar.getHMDSensorMatrix();
         }
     } else {
         deactivate();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -86,9 +86,9 @@ const float MyAvatar::ZOOM_DEFAULT = 1.5f;
 extern bool OUTOFBODY_HACK_ENABLE_DEBUG_DRAW_IK_TARGETS;
 
 // OUTOFBODY_HACK defined in SkeletonModel.cpp
-extern const glm::vec3 TRUNCATE_IK_CAPSULE_POSITION;
-extern const float TRUNCATE_IK_CAPSULE_LENGTH;
-extern const float TRUNCATE_IK_CAPSULE_RADIUS;
+extern glm::vec3 TRUNCATE_IK_CAPSULE_POSITION;
+extern float TRUNCATE_IK_CAPSULE_LENGTH;
+extern float TRUNCATE_IK_CAPSULE_RADIUS;
 
 MyAvatar::MyAvatar(RigPointer rig) :
     Avatar(rig),

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -315,6 +315,8 @@ public slots:
     glm::vec3 getPositionForAudio();
     glm::quat getOrientationForAudio();
 
+    bool isOutOfBody() const { return _follow._isOutOfBody; }
+
 signals:
     void audioListenerModeChanged();
     void transformChanged();
@@ -445,7 +447,8 @@ private:
             NumFollowTypes
         };
         glm::mat4 _desiredBodyMatrix;
-        uint8_t _activeBits;
+        uint8_t _activeBits { 0 };
+        bool _isOutOfBody { false };
 
         void deactivate();
         void deactivate(FollowType type);
@@ -457,6 +460,7 @@ private:
         void updateHorizontalActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
         void updateVerticalActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
         void prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat4& bodySensorMatrix, const glm::mat4& currentBodyMatrix);
+        void postPhysicsUpdate(MyAvatar& myAvatar);
     };
     FollowHelper _follow;
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -279,6 +279,9 @@ public:
     virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
     virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
+    bool isOutOfBody() const { return _follow._isOutOfBody; }
+    glm::mat4 getInBodyHMDMatInAvatarSpace() const { return _follow._prevInBodyHMDMatInAvatarSpace; }
+
 public slots:
     void increaseSize();
     void decreaseSize();
@@ -314,8 +317,6 @@ public slots:
 
     glm::vec3 getPositionForAudio();
     glm::quat getOrientationForAudio();
-
-    bool isOutOfBody() const { return _follow._isOutOfBody; }
 
 signals:
     void audioListenerModeChanged();
@@ -449,6 +450,8 @@ private:
         glm::mat4 _desiredBodyMatrix;
         uint8_t _activeBits { 0 };
         bool _isOutOfBody { false };
+        glm::mat4 _prevInBodyHMDMatInAvatarSpace;
+        glm::mat4 _inBodyHMDMatInAvatarSpace;
 
         void deactivate();
         void deactivate(FollowType type);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -83,7 +83,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(float energy READ getEnergy WRITE setEnergy)
 
     Q_PROPERTY(bool hmdLeanRecenterEnabled READ getHMDLeanRecenterEnabled WRITE setHMDLeanRecenterEnabled)
-    Q_PROPERTY(bool characterControllerEnabled READ getCharacterControllerEnabled WRITE setCharacterControllerEnabled)
+    Q_PROPERTY(bool avatarCollisionsEnabled READ getAvatarCollisionsEnabled WRITE setAvatarCollisionsEnabled)
 
 public:
     explicit MyAvatar(RigPointer rig);
@@ -273,8 +273,8 @@ public:
 
     bool hasDriveInput() const;
 
-    Q_INVOKABLE void setCharacterControllerEnabled(bool enabled);
-    Q_INVOKABLE bool getCharacterControllerEnabled();
+    Q_INVOKABLE void setAvatarCollisionsEnabled(bool enabled);
+    Q_INVOKABLE bool getAvatarCollisionsEnabled();
 
     virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
     virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -299,6 +299,7 @@ public slots:
     void setEnableDebugDrawPosition(bool isEnabled);
     void setEnableDebugDrawHandControllers(bool isEnabled);
     void setEnableDebugDrawSensorToWorldMatrix(bool isEnabled);
+    void setEnableDebugDrawIKTargets(bool isEnabled);
     bool getEnableMeshVisible() const { return _skeletonModel->isVisible(); }
     void setEnableMeshVisible(bool isEnabled);
     void setUseAnimPreAndPostRotations(bool isEnabled);
@@ -469,6 +470,7 @@ private:
     bool _enableDebugDrawAnimPose { false };
     bool _enableDebugDrawHandControllers { false };
     bool _enableDebugDrawSensorToWorldMatrix { false };
+    bool _enableDebugDrawIKTargets { false };
 
     AudioListenerMode _audioListenerMode;
     glm::vec3 _customListenPosition;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -126,6 +126,8 @@ public:
     // This is so the correct camera can be used for rendering.
     void updateSensorToWorldMatrix();
 
+    void setSensorToWorldMatrix(const glm::mat4& sensorToWorld);
+
     void setRealWorldFieldOfView(float realWorldFov) { _realWorldFieldOfView.set(realWorldFov); }
 
     Q_INVOKABLE glm::vec3 getDefaultEyePosition() const;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -442,7 +442,7 @@ private:
             NumFollowTypes
         };
         glm::mat4 _desiredBodyMatrix;
-        float _timeRemaining[NumFollowTypes];
+        uint8_t _activeBits;
 
         void deactivate();
         void deactivate(FollowType type);
@@ -450,13 +450,10 @@ private:
         void activate(FollowType type);
         bool isActive() const;
         bool isActive(FollowType followType) const;
-        float getMaxTimeRemaining() const;
-        void decrementTimeRemaining(float dt);
-        bool shouldActivateRotation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix) const;
-        bool shouldActivateVertical(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix) const;
-        bool shouldActivateHorizontal(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix) const;
-        void prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat4& bodySensorMatrix, const glm::mat4& currentBodyMatrix, bool hasDriveInput);
-        glm::mat4 postPhysicsUpdate(const MyAvatar& myAvatar, const glm::mat4& currentBodyMatrix);
+        void updateRotationActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
+        void updateHorizontalActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
+        void updateVerticalActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
+        void prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat4& bodySensorMatrix, const glm::mat4& currentBodyMatrix);
     };
     FollowHelper _follow;
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -279,9 +279,6 @@ public:
     virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
     virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
-    bool isOutOfBody() const { return _follow._isOutOfBody; }
-    glm::mat4 getInBodyHMDMatInAvatarSpace() const { return _follow._prevInBodyHMDMatInAvatarSpace; }
-
 public slots:
     void increaseSize();
     void decreaseSize();
@@ -317,6 +314,8 @@ public slots:
 
     glm::vec3 getPositionForAudio();
     glm::quat getOrientationForAudio();
+
+    bool isOutOfBody() const { return _follow._isOutOfBody; }
 
 signals:
     void audioListenerModeChanged();
@@ -450,8 +449,6 @@ private:
         glm::mat4 _desiredBodyMatrix;
         uint8_t _activeBits { 0 };
         bool _isOutOfBody { false };
-        glm::mat4 _prevInBodyHMDMatInAvatarSpace;
-        glm::mat4 _inBodyHMDMatInAvatarSpace;
 
         void deactivate();
         void deactivate(FollowType type);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -23,9 +23,9 @@
 #include "InterfaceLogging.h"
 #include "AnimDebugDraw.h"
 
-const glm::vec3 TRUNCATE_IK_CAPSULE_POSITION(0.0f, 0.0f, 0.0f);
-const float TRUNCATE_IK_CAPSULE_LENGTH = 1000.0f;
-const float TRUNCATE_IK_CAPSULE_RADIUS = 0.5f;
+glm::vec3 TRUNCATE_IK_CAPSULE_POSITION(0.0f, 0.0f, 0.0f);
+float TRUNCATE_IK_CAPSULE_LENGTH = 1000.0f;
+float TRUNCATE_IK_CAPSULE_RADIUS = 0.5f;
 
 SkeletonModel::SkeletonModel(Avatar* owningAvatar, QObject* parent, RigPointer rig) :
     Model(rig, parent),

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -91,13 +91,18 @@ glm::vec3 HMDScriptingInterface::getPosition() const {
 }
 
 void HMDScriptingInterface::setPosition(const glm::vec3& position) {
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-    glm::mat4 hmdToSensor = myAvatar->getHMDSensorMatrix();
-    glm::mat4 sensorToWorld = myAvatar->getSensorToWorldMatrix();
-    glm::mat4 hmdToWorld = sensorToWorld * hmdToSensor;
-    setTranslation(hmdToWorld, position);
-    sensorToWorld = hmdToWorld * glm::inverse(hmdToSensor);
-    myAvatar->setSensorToWorldMatrix(sensorToWorld);
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setPosition", Qt::QueuedConnection, Q_ARG(const glm::vec3&, position));
+        return;
+    } else {
+        MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+        glm::mat4 hmdToSensor = myAvatar->getHMDSensorMatrix();
+        glm::mat4 sensorToWorld = myAvatar->getSensorToWorldMatrix();
+        glm::mat4 hmdToWorld = sensorToWorld * hmdToSensor;
+        setTranslation(hmdToWorld, position);
+        sensorToWorld = hmdToWorld * glm::inverse(hmdToSensor);
+        myAvatar->setSensorToWorldMatrix(sensorToWorld);
+    }
 }
 
 glm::quat HMDScriptingInterface::getOrientation() const {

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -90,6 +90,16 @@ glm::vec3 HMDScriptingInterface::getPosition() const {
     return glm::vec3();
 }
 
+void HMDScriptingInterface::setPosition(const glm::vec3& position) {
+    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    glm::mat4 hmdToSensor = myAvatar->getHMDSensorMatrix();
+    glm::mat4 sensorToWorld = myAvatar->getSensorToWorldMatrix();
+    glm::mat4 hmdToWorld = sensorToWorld * hmdToSensor;
+    setTranslation(hmdToWorld, position);
+    sensorToWorld = hmdToWorld * glm::inverse(hmdToSensor);
+    myAvatar->setSensorToWorldMatrix(sensorToWorld);
+}
+
 glm::quat HMDScriptingInterface::getOrientation() const {
     if (qApp->getActiveDisplayPlugin()->isHmd()) {
         return glm::normalize(glm::quat_cast(getWorldHMDMatrix()));
@@ -138,4 +148,9 @@ bool HMDScriptingInterface::isKeyboardVisible() {
 
 void HMDScriptingInterface::centerUI() {
     QMetaObject::invokeMethod(qApp, "centerUI", Qt::QueuedConnection);
+}
+
+void HMDScriptingInterface::snapToAvatar() {
+    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    myAvatar->updateSensorToWorldMatrix();
 }

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -72,7 +72,7 @@ private:
     glm::vec3 getPosition() const;
 
     // Set the position of the HMD
-    void setPosition(const glm::vec3& position);
+    Q_INVOKABLE void setPosition(const glm::vec3& position);
 
     // Get the orientation of the HMD
     glm::quat getOrientation() const;

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -25,7 +25,7 @@ class QScriptEngine;
 
 class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Dependency {
     Q_OBJECT
-    Q_PROPERTY(glm::vec3 position READ getPosition)
+    Q_PROPERTY(glm::vec3 position READ getPosition WRITE setPosition)
     Q_PROPERTY(glm::quat orientation READ getOrientation)
     Q_PROPERTY(bool mounted READ isMounted)
 
@@ -58,6 +58,8 @@ public:
     // rotate the overlay UI sphere so that it is centered about the the current HMD position and orientation
     Q_INVOKABLE void centerUI();
 
+    // snap HMD to align with Avatar's current position in world-frame
+    Q_INVOKABLE void snapToAvatar();
 public:
     HMDScriptingInterface();
     static QScriptValue getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine);
@@ -68,7 +70,10 @@ public:
 private:
     // Get the position of the HMD
     glm::vec3 getPosition() const;
-    
+
+    // Set the position of the HMD
+    void setPosition(const glm::vec3& position);
+
     // Get the orientation of the HMD
     glm::quat getOrientation() const;
 

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -444,7 +444,6 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
 
         // AJT: HACK
         if (HACKY_GLOBAL_ENABLE_DEBUG_DRAW_IK_TARGETS && HACKY_GLOBAL_RIG_POINTER) {
-            const float CM_TO_M = 0.01f;
             const vec4 WHITE(1.0f);
             glm::mat4 geomToRigMat = HACKY_GLOBAL_RIG_POINTER->getGeometryToRigTransform();
             glm::mat4 rigToAvatarMat = createMatFromQuatAndPos(Quaternions::Y_180, glm::vec3());

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -21,8 +21,8 @@
 #include "SwingTwistConstraint.h"
 #include "AnimationLogging.h"
 
-bool HACKY_GLOBAL_ENABLE_DEBUG_DRAW_IK_TARGETS = false;
-Rig* HACKY_GLOBAL_RIG_POINTER = nullptr;
+bool OUTOFBODY_HACK_ENABLE_DEBUG_DRAW_IK_TARGETS = false;
+Rig* OUTOFBODY_HACK_RIG_POINTER = nullptr;
 
 AnimInverseKinematics::AnimInverseKinematics(const QString& id) : AnimNode(AnimNode::Type::InverseKinematics, id) {
 }
@@ -442,10 +442,9 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
             computeTargets(animVars, targets, underPoses);
         }
 
-        // AJT: HACK
-        if (HACKY_GLOBAL_ENABLE_DEBUG_DRAW_IK_TARGETS && HACKY_GLOBAL_RIG_POINTER) {
+        if (OUTOFBODY_HACK_ENABLE_DEBUG_DRAW_IK_TARGETS && OUTOFBODY_HACK_RIG_POINTER) {
             const vec4 WHITE(1.0f);
-            glm::mat4 geomToRigMat = HACKY_GLOBAL_RIG_POINTER->getGeometryToRigTransform();
+            glm::mat4 geomToRigMat = OUTOFBODY_HACK_RIG_POINTER->getGeometryToRigTransform();
             glm::mat4 rigToAvatarMat = createMatFromQuatAndPos(Quaternions::Y_180, glm::vec3());
 
             for (auto& target : targets) {

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -47,6 +47,8 @@ const glm::vec3 DEFAULT_LEFT_EYE_POS(0.3f, 0.9f, 0.0f);
 const glm::vec3 DEFAULT_HEAD_POS(0.0f, 0.75f, 0.0f);
 const glm::vec3 DEFAULT_NECK_POS(0.0f, 0.70f, 0.0f);
 
+extern Rig* HACKY_GLOBAL_RIG_POINTER;
+
 void Rig::overrideAnimation(const QString& url, float fps, bool loop, float firstFrame, float lastFrame) {
 
     UserAnimState::ClipNodeEnum clipNodeEnum;
@@ -875,6 +877,7 @@ void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
         _animVars.setRigToGeometryTransform(_rigToGeometryTransform);
 
         // evaluate the animation
+        HACKY_GLOBAL_RIG_POINTER = this;
         AnimNode::Triggers triggersOut;
         _internalPoseSet._relativePoses = _animNode->evaluate(_animVars, deltaTime, triggersOut);
         if ((int)_internalPoseSet._relativePoses.size() != _animSkeleton->getNumJoints()) {
@@ -885,6 +888,7 @@ void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
         for (auto& trigger : triggersOut) {
             _animVars.setTrigger(trigger);
         }
+        HACKY_GLOBAL_RIG_POINTER = nullptr;
     }
 
     applyOverridePoses();

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -47,6 +47,10 @@ const glm::vec3 DEFAULT_LEFT_EYE_POS(0.3f, 0.9f, 0.0f);
 const glm::vec3 DEFAULT_HEAD_POS(0.0f, 0.75f, 0.0f);
 const glm::vec3 DEFAULT_NECK_POS(0.0f, 0.70f, 0.0f);
 
+const glm::vec3 TRUNCATE_IK_CAPSULE_POSITION(0.0f, 0.0f, 0.0f);
+float TRUNCATE_IK_CAPSULE_LENGTH = 1000.0;
+float TRUNCATE_IK_CAPSULE_RADIUS = 0.5;
+
 extern Rig* HACKY_GLOBAL_RIG_POINTER;
 
 void Rig::overrideAnimation(const QString& url, float fps, bool loop, float firstFrame, float lastFrame) {
@@ -999,6 +1003,37 @@ void Rig::computeHeadNeckAnimVars(const AnimPose& hmdPose, glm::vec3& headPositi
     neckOrientationOut = safeMix(hmdOrientation, _animSkeleton->getRelativeDefaultPose(neckIndex).rot, 0.5f);
 }
 
+static bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius) {
+    glm::vec3 top = capsulePosition.y + glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    glm::vec3 bottom = capsulePosition.y - glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    if (point.y > top.y + capsuleRadius) {
+        return false;
+    } else if (point.y > top.y) {
+        return glm::length(point - top) < capsuleRadius;
+    } else if (point.y < bottom.y - capsuleRadius) {
+        return false;
+    } else if (point.y < bottom.y) {
+        return glm::length(point - bottom) < capsuleRadius;
+    } else {
+        return glm::length(glm::vec2(point.x, point.z) - glm::vec2(capsulePosition.x, capsulePosition.z)) < capsuleRadius;
+    }
+}
+
+static glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius) {
+    glm::vec3 top = capsulePosition.y + glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    glm::vec3 bottom = capsulePosition.y - glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    if (point.y > top.y) {
+        return capsuleRadius * glm::normalize(point - top) + top;
+    } else if (point.y < bottom.y) {
+        return capsuleRadius * glm::normalize(point - bottom) + bottom;
+    } else {
+        glm::vec2 capsulePosition2D(capsulePosition.x, capsulePosition.z);
+        glm::vec2 point2D(point.x, point.z);
+        glm::vec2 projectedPoint2D = capsuleRadius * glm::normalize(point2D - capsulePosition2D) + capsulePosition2D;
+        return glm::vec3(projectedPoint2D.x, point.y, projectedPoint2D.y);
+    }
+}
+
 void Rig::updateNeckJoint(int index, const HeadParameters& params) {
     if (_animSkeleton && index >= 0 && index < _animSkeleton->getNumJoints()) {
         glm::quat yFlip180 = glm::angleAxis(PI, glm::vec3(0.0f, 1.0f, 0.0f));
@@ -1009,19 +1044,19 @@ void Rig::updateNeckJoint(int index, const HeadParameters& params) {
             AnimPose hmdPose(glm::vec3(1.0f), params.rigHeadOrientation * yFlip180, params.rigHeadPosition);
             computeHeadNeckAnimVars(hmdPose, headPos, headRot, neckPos, neckRot);
 
-            // debug rendering
-#ifdef DEBUG_RENDERING
-            const glm::vec4 red(1.0f, 0.0f, 0.0f, 1.0f);
-            const glm::vec4 green(0.0f, 1.0f, 0.0f, 1.0f);
+            // decide if we SHOULD truncate IK targets
+            if (!pointIsInsideCapsule(params.rigHeadPosition, TRUNCATE_IK_CAPSULE_POSITION, TRUNCATE_IK_CAPSULE_LENGTH, TRUNCATE_IK_CAPSULE_RADIUS)) {
+                _desiredRigHeadPosition = headPos;
+                _truncateIKTargets = true;
+            } else {
+                _truncateIKTargets = false;
+            }
 
-            // transform from bone into avatar space
-            AnimPose headPose(glm::vec3(1), headRot, headPos);
-            DebugDraw::getInstance().addMyAvatarMarker("headTarget", headPose.rot, headPose.trans, red);
-
-            // transform from bone into avatar space
-            AnimPose neckPose(glm::vec3(1), neckRot, neckPos);
-            DebugDraw::getInstance().addMyAvatarMarker("neckTarget", neckPose.rot, neckPose.trans, green);
-#endif
+            // truncate head IK target.
+            if (_truncateIKTargets) {
+                headPos = projectPointOntoCapsule(_desiredRigHeadPosition, TRUNCATE_IK_CAPSULE_POSITION, TRUNCATE_IK_CAPSULE_LENGTH, TRUNCATE_IK_CAPSULE_RADIUS);
+                neckPos = (neckPos - _desiredRigHeadPosition) + headPos;
+            }
 
             _animVars.set("headPosition", headPos);
             _animVars.set("headRotation", headRot);
@@ -1095,8 +1130,16 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
 
         if (params.isLeftEnabled) {
 
-            // prevent the hand IK targets from intersecting the body capsule
             glm::vec3 handPosition = params.leftPosition;
+
+            // truncate hand IK target
+            if (_truncateIKTargets) {
+                glm::vec3 offset = handPosition - _desiredRigHeadPosition;
+                glm::vec3 headPos = projectPointOntoCapsule(_desiredRigHeadPosition, TRUNCATE_IK_CAPSULE_POSITION, TRUNCATE_IK_CAPSULE_LENGTH, TRUNCATE_IK_CAPSULE_RADIUS);
+                handPosition = headPos + offset;
+            }
+
+            // prevent the hand IK targets from intersecting the body capsule
             glm::vec3 displacement(glm::vec3::_null);
             if (findSphereCapsulePenetration(handPosition, HAND_RADIUS, bodyCapsuleStart, bodyCapsuleEnd, bodyCapsuleRadius, displacement)) {
                 handPosition -= displacement;
@@ -1113,8 +1156,16 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
 
         if (params.isRightEnabled) {
 
-            // prevent the hand IK targets from intersecting the body capsule
             glm::vec3 handPosition = params.rightPosition;
+
+            // truncate hand IK target
+            if (_truncateIKTargets) {
+                glm::vec3 offset = handPosition - _desiredRigHeadPosition;
+                glm::vec3 headPos = projectPointOntoCapsule(_desiredRigHeadPosition, TRUNCATE_IK_CAPSULE_POSITION, TRUNCATE_IK_CAPSULE_LENGTH, TRUNCATE_IK_CAPSULE_RADIUS);
+                handPosition = headPos + offset;
+            }
+
+            // prevent the hand IK targets from intersecting the body capsule
             glm::vec3 displacement(glm::vec3::_null);
             if (findSphereCapsulePenetration(handPosition, HAND_RADIUS, bodyCapsuleStart, bodyCapsuleEnd, bodyCapsuleRadius, displacement)) {
                 handPosition -= displacement;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -51,7 +51,7 @@ const glm::vec3 TRUNCATE_IK_CAPSULE_POSITION(0.0f, 0.0f, 0.0f);
 float TRUNCATE_IK_CAPSULE_LENGTH = 1000.0;
 float TRUNCATE_IK_CAPSULE_RADIUS = 0.5;
 
-extern Rig* HACKY_GLOBAL_RIG_POINTER;
+extern Rig* OUTOFBODY_HACK_RIG_POINTER;
 
 void Rig::overrideAnimation(const QString& url, float fps, bool loop, float firstFrame, float lastFrame) {
 
@@ -881,7 +881,7 @@ void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
         _animVars.setRigToGeometryTransform(_rigToGeometryTransform);
 
         // evaluate the animation
-        HACKY_GLOBAL_RIG_POINTER = this;
+        OUTOFBODY_HACK_RIG_POINTER = this;
         AnimNode::Triggers triggersOut;
         _internalPoseSet._relativePoses = _animNode->evaluate(_animVars, deltaTime, triggersOut);
         if ((int)_internalPoseSet._relativePoses.size() != _animSkeleton->getNumJoints()) {
@@ -892,7 +892,7 @@ void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
         for (auto& trigger : triggersOut) {
             _animVars.setTrigger(trigger);
         }
-        HACKY_GLOBAL_RIG_POINTER = nullptr;
+        OUTOFBODY_HACK_RIG_POINTER = nullptr;
     }
 
     applyOverridePoses();

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -312,6 +312,8 @@ protected:
     bool _enableInverseKinematics { true };
 
     mutable uint32_t _jointNameWarningCount { 0 };
+    glm::vec3 _desiredRigHeadPosition;
+    bool _truncateIKTargets { false };
 
 private:
     QMap<int, StateHandler> _stateHandlers;

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -19,12 +19,15 @@
 #include <BulletDynamics/Character/btCharacterControllerInterface.h>
 
 #include <GLMHelpers.h>
+#include <PhysicsCollisionGroups.h>
+
 #include "BulletUtil.h"
 
 const uint32_t PENDING_FLAG_ADD_TO_SIMULATION = 1U << 0;
 const uint32_t PENDING_FLAG_REMOVE_FROM_SIMULATION = 1U << 1;
 const uint32_t PENDING_FLAG_UPDATE_SHAPE = 1U << 2;
 const uint32_t PENDING_FLAG_JUMP = 1U << 3;
+const uint32_t PENDING_FLAG_UPDATE_COLLISION_GROUP = 1U << 4;
 
 const float DEFAULT_CHARACTER_GRAVITY = -5.0f;
 
@@ -107,9 +110,15 @@ public:
 
     void setLocalBoundingBox(const glm::vec3& corner, const glm::vec3& scale);
 
+    /*
     bool isEnabled() const { return _enabled; }  // thread-safe
     void setEnabled(bool enabled);
-    bool isEnabledAndReady() const { return _enabled && _dynamicsWorld; }
+    */
+    bool isEnabledAndReady() const { return _dynamicsWorld; }
+
+    void setCollisionGroup(int16_t group);
+    int16_t getCollisionGroup() const { return _collisionGroup; }
+    void handleChangedCollisionGroup();
 
     bool getRigidBodyLocation(glm::vec3& avatarRigidBodyPosition, glm::quat& avatarRigidBodyRotation);
 
@@ -170,7 +179,6 @@ protected:
     btVector3 _linearAcceleration;
     bool _following { false };
 
-    std::atomic_bool _enabled;
     State _state;
     bool _isPushingUp;
 
@@ -180,6 +188,7 @@ protected:
     uint32_t _previousFlags { 0 };
 
     bool _flyingAllowed { true };
+    int16_t _collisionGroup { BULLET_COLLISION_GROUP_MY_AVATAR };
 };
 
 #endif // hifi_CharacterControllerInterface_h

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -82,7 +82,8 @@ public:
     void getPositionAndOrientation(glm::vec3& position, glm::quat& rotation) const;
 
     void setParentVelocity(const glm::vec3& parentVelocity);
-    void setFollowParameters(const glm::mat4& desiredWorldMatrix, float timeRemaining);
+    void setFollowParameters(const glm::mat4& desiredWorldBodyMatrix);
+    void disableFollow() { _following = false; }
     float getFollowTime() const { return _followTime; }
     glm::vec3 getFollowLinearDisplacement() const;
     glm::quat getFollowAngularDisplacement() const;
@@ -142,7 +143,6 @@ protected:
     btVector3 _preSimulationVelocity;
     btVector3 _velocityChange;
     btTransform _followDesiredBodyTransform;
-    btScalar _followTimeRemaining;
     btTransform _characterBodyTransform;
 
     glm::vec3 _shapeLocalOffset;
@@ -168,6 +168,7 @@ protected:
     btVector3 _followLinearDisplacement;
     btQuaternion _followAngularDisplacement;
     btVector3 _linearAcceleration;
+    bool _following { false };
 
     std::atomic_bool _enabled;
     State _state;

--- a/libraries/shared/src/GeometryUtil.cpp
+++ b/libraries/shared/src/GeometryUtil.cpp
@@ -578,3 +578,34 @@ float coneSphereAngle(const glm::vec3& coneCenter, const glm::vec3& coneDirectio
 
     return glm::max(0.0f, theta - phi);
 }
+
+bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius) {
+    glm::vec3 top = capsulePosition.y + glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    glm::vec3 bottom = capsulePosition.y - glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    if (point.y > top.y + capsuleRadius) {
+        return false;
+    } else if (point.y > top.y) {
+        return glm::length(point - top) < capsuleRadius;
+    } else if (point.y < bottom.y - capsuleRadius) {
+        return false;
+    } else if (point.y < bottom.y) {
+        return glm::length(point - bottom) < capsuleRadius;
+    } else {
+        return glm::length(glm::vec2(point.x, point.z) - glm::vec2(capsulePosition.x, capsulePosition.z)) < capsuleRadius;
+    }
+}
+
+glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius) {
+    glm::vec3 top = capsulePosition.y + glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    glm::vec3 bottom = capsulePosition.y - glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
+    if (point.y > top.y) {
+        return capsuleRadius * glm::normalize(point - top) + top;
+    } else if (point.y < bottom.y) {
+        return capsuleRadius * glm::normalize(point - bottom) + bottom;
+    } else {
+        glm::vec2 capsulePosition2D(capsulePosition.x, capsulePosition.z);
+        glm::vec2 point2D(point.x, point.z);
+        glm::vec2 projectedPoint2D = capsuleRadius * glm::normalize(point2D - capsulePosition2D) + capsulePosition2D;
+        return glm::vec3(projectedPoint2D.x, point.y, projectedPoint2D.y);
+    }
+}

--- a/libraries/shared/src/GeometryUtil.h
+++ b/libraries/shared/src/GeometryUtil.h
@@ -160,5 +160,8 @@ private:
     static void copyCleanArray(int& lengthA, glm::vec2* vertexArrayA, int& lengthB, glm::vec2* vertexArrayB);
 };
 
+// vertical capsule
+bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius);
+glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius);
 
 #endif // hifi_GeometryUtil_h

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -44,7 +44,7 @@ var COLORS_TELEPORT_TOO_CLOSE = {
 var TELEPORT_CANCEL_RANGE = 1;
 var USE_COOL_IN = true;
 var COOL_IN_DURATION = 500;
-var MAX_HMD_AVATAR_SEPARATION = 10.0f;
+var MAX_HMD_AVATAR_SEPARATION = 10.0;
 
 function ThumbPad(hand) {
     this.hand = hand;

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -540,16 +540,16 @@ function Teleporter() {
     };
 
     this.getWayPoints = function(startPoint, endPoint, numberOfSteps) {
-        var travel = Vec3.subtract(endPoint - startPoint);
+        var travel = Vec3.subtract(endPoint, startPoint);
         var distance = Vec3.length(travel);
         if (distance > 1.0) {
-            var base = Math.exp(log(distance + 1.0) / numberOfSteps);
+            var base = Math.exp(Math.log(distance + 1.0) / numberOfSteps);
             var wayPoints = [];
             var i;
 
             for (i = 0; i < numberOfSteps - 1; i++) {
                 var backFraction = (1.0 - Math.exp((numberOfSteps - 1 - i) * Math.log(base))) / distance;
-                wayPoints.push(Vec3.sum(endPoint, Vec3.multiply(backFraction, travel));
+                wayPoints.push(Vec3.sum(endPoint, Vec3.multiply(backFraction, travel)));
             }
         }
         wayPoints.push(endPoint);

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -542,9 +542,9 @@ function Teleporter() {
     this.getWayPoints = function(startPoint, endPoint, numberOfSteps) {
         var travel = Vec3.subtract(endPoint, startPoint);
         var distance = Vec3.length(travel);
+        var wayPoints = [];
         if (distance > 1.0) {
             var base = Math.exp(Math.log(distance + 1.0) / numberOfSteps);
-            var wayPoints = [];
             var i;
 
             for (i = 0; i < numberOfSteps - 1; i++) {

--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -564,7 +564,7 @@ function Teleporter() {
         } else if (this.teleportMode === "HMDFirstAvatarWillFollow") {
             var eyeOffset = Vec3.subtract(MyAvatar.getEyePosition(), MyAvatar.position);
             landingPoint = Vec3.sum(landingPoint, eyeOffset);
-            HMD.setPosition(landingPoint);
+            HMD.position = landingPoint;
         }
     }
 


### PR DESCRIPTION
PR for demo purposes: HMD position is no longer slaved to physical avatar body.  Instead the avatar body tries to get to its "ideal" position relative to the HMD's world-frame position.  Some known problems:

(1) Still using teleportation for transform reconciliation, but the effective velocities are capped so it is less jittery than it would be without capping (using velocity for this reconciliation would get rid of jitter).

(2) IK targets still follow the HMD and are unbounded, so the animation state can get quite wacky.  In particular this is causing the animated rig to lift up off of (or sink into) the ground.  The collision capsule is not necessarily floating off the floor... but it might be if it is trying hard to eliminate the vertical offset.