### PR TITLE
domain-server caches user public keys on disk

### DIFF
--- a/domain-server/src/DomainGatekeeper.h
+++ b/domain-server/src/DomainGatekeeper.h
@@ -101,7 +101,6 @@ private:
     QHash<QUuid, SharedNetworkPeer> _icePeers;
     
     QHash<QString, QUuid> _connectionTokenHash;
-    QHash<QString, QByteArray> _userPublicKeys;
     QSet<QString> _inFlightPublicKeyRequests; // keep track of which we've already asked for
     QSet<QString> _domainOwnerFriends; // keep track of friends of the domain owner
     QSet<QString> _inFlightGroupMembershipsRequests; // keep track of which we've already asked for

--- a/domain-server/src/DomainServerSettingsManager.h
+++ b/domain-server/src/DomainServerSettingsManager.h
@@ -93,6 +93,9 @@ public:
 
     void debugDumpGroupsState();
 
+    void setUserPublicKey(QString lowerUserName, QByteArray publicKey) { _userPublicKeys[lowerUserName] = publicKey; }
+    QByteArray getUserPublicKey(QString lowerUserName) { return _userPublicKeys.value(lowerUserName); }
+
 signals:
     void updateNodePermissions();
 
@@ -157,6 +160,12 @@ private:
 
     // keep track of answers to api queries about which users are in which groups
     QHash<QString, QHash<QUuid, QUuid>> _groupMembership; // QHash<user-name, QHash<group-id, rank-id>>
+
+    // _userPublicKeys is a cached copy of public keys we've successfully retrieved from the metaverse api.
+    // We copy them into and out of the _configMap during saves and loads.
+    void copyPublicKeysToConfigMap();
+    void copyConfigMapToPublicKeys();
+    QHash<QString, QByteArray> _userPublicKeys;
 };
 
 #endif // hifi_DomainServerSettingsManager_h


### PR DESCRIPTION
- domain-server now caches users' public keys to disk, allowing (repeat) authed connections when key-server is unavailable.
