### PR TITLE
Add ability to parent overlays to MyAvatar for use across servers

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -401,7 +401,7 @@ private:
 
     int sendNackPackets();
 
-    MyAvatar* getMyAvatar() const;
+    std::shared_ptr<MyAvatar> getMyAvatar() const;
 
     void checkSkeleton() const;
 

--- a/interface/src/InterfaceParentFinder.cpp
+++ b/interface/src/InterfaceParentFinder.cpp
@@ -13,8 +13,11 @@
 #include <EntityTree.h>
 #include <EntityTreeRenderer.h>
 #include <avatar/AvatarManager.h>
+#include <AvatarData.h>
 
 #include "InterfaceParentFinder.h"
+
+
 
 SpatiallyNestableWeakPointer InterfaceParentFinder::find(QUuid parentID, bool& success, SpatialParentTree* entityTree) const {
     SpatiallyNestableWeakPointer parent;
@@ -43,6 +46,11 @@ SpatiallyNestableWeakPointer InterfaceParentFinder::find(QUuid parentID, bool& s
     if (!parent.expired()) {
         success = true;
         return parent;
+    }
+
+    if (parentID == AVATAR_SELF_ID) {
+        success = true;
+        return avatarManager->getMyAvatar();
     }
 
     success = false;

--- a/interface/src/InterfaceParentFinder.cpp
+++ b/interface/src/InterfaceParentFinder.cpp
@@ -17,8 +17,6 @@
 
 #include "InterfaceParentFinder.h"
 
-
-
 SpatiallyNestableWeakPointer InterfaceParentFinder::find(QUuid parentID, bool& success, SpatialParentTree* entityTree) const {
     SpatiallyNestableWeakPointer parent;
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -166,7 +166,7 @@ Menu::Menu() {
     // Avatar menu ----------------------------------
     MenuWrapper* avatarMenu = addMenu("Avatar");
     auto avatarManager = DependencyManager::get<AvatarManager>();
-    QObject* avatar = avatarManager->getMyAvatar();
+    auto avatar = avatarManager->getMyAvatar();
 
     // Avatar > Attachments...
     auto action = addActionToQMenuAndActionHash(avatarMenu, MenuOption::Attachments);
@@ -182,19 +182,19 @@ Menu::Menu() {
     addActionToQMenuAndActionHash(avatarSizeMenu,
         MenuOption::IncreaseAvatarSize,
         0, // QML Qt::Key_Plus,
-        avatar, SLOT(increaseSize()));
+        avatar.get(), SLOT(increaseSize()));
 
     // Avatar > Size > Decrease
     addActionToQMenuAndActionHash(avatarSizeMenu,
         MenuOption::DecreaseAvatarSize,
         0, // QML Qt::Key_Minus,
-        avatar, SLOT(decreaseSize()));
+        avatar.get(), SLOT(decreaseSize()));
 
     // Avatar > Size > Reset
     addActionToQMenuAndActionHash(avatarSizeMenu,
         MenuOption::ResetAvatarSize,
         0, // QML Qt::Key_Equal,
-        avatar, SLOT(resetSize()));
+        avatar.get(), SLOT(resetSize()));
 
     // Avatar > Reset Sensors
     addActionToQMenuAndActionHash(avatarMenu,
@@ -486,38 +486,38 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderOtherLookAtVectors, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::FixGaze, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawDefaultPose, 0, false,
-        avatar, SLOT(setEnableDebugDrawDefaultPose(bool)));
+        avatar.get(), SLOT(setEnableDebugDrawDefaultPose(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawAnimPose, 0, false,
-        avatar, SLOT(setEnableDebugDrawAnimPose(bool)));
+        avatar.get(), SLOT(setEnableDebugDrawAnimPose(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawPosition, 0, false,
-        avatar, SLOT(setEnableDebugDrawPosition(bool)));
+        avatar.get(), SLOT(setEnableDebugDrawPosition(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::MeshVisible, 0, true,
-        avatar, SLOT(setEnableMeshVisible(bool)));
+        avatar.get(), SLOT(setEnableMeshVisible(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::DisableEyelidAdjustment, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::TurnWithHead, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::UseAnimPreAndPostRotations, 0, true,
-        avatar, SLOT(setUseAnimPreAndPostRotations(bool)));
+        avatar.get(), SLOT(setUseAnimPreAndPostRotations(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::EnableInverseKinematics, 0, true,
-        avatar, SLOT(setEnableInverseKinematics(bool)));
+        avatar.get(), SLOT(setEnableInverseKinematics(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderSensorToWorldMatrix, 0, false,
-        avatar, SLOT(setEnableDebugDrawSensorToWorldMatrix(bool)));
+        avatar.get(), SLOT(setEnableDebugDrawSensorToWorldMatrix(bool)));
 
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ActionMotorControl,
-        Qt::CTRL | Qt::SHIFT | Qt::Key_K, true, avatar, SLOT(updateMotionBehaviorFromMenu()),
+        Qt::CTRL | Qt::SHIFT | Qt::Key_K, true, avatar.get(), SLOT(updateMotionBehaviorFromMenu()),
         UNSPECIFIED_POSITION, "Developer");
 
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ScriptedMotorControl, 0, true,
-        avatar, SLOT(updateMotionBehaviorFromMenu()),
+        avatar.get(), SLOT(updateMotionBehaviorFromMenu()),
         UNSPECIFIED_POSITION, "Developer");
 
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::EnableCharacterController, 0, true,
-        avatar, SLOT(updateMotionBehaviorFromMenu()),
+        avatar.get(), SLOT(updateMotionBehaviorFromMenu()),
         UNSPECIFIED_POSITION, "Developer");
 
     // Developer > Hands >>>
     MenuWrapper* handOptionsMenu = developerMenu->addMenu("Hands");
     addCheckableActionToQMenuAndActionHash(handOptionsMenu, MenuOption::DisplayHandTargets, 0, false,
-        avatar, SLOT(setEnableDebugDrawHandControllers(bool)));
+        avatar.get(), SLOT(setEnableDebugDrawHandControllers(bool)));
     addCheckableActionToQMenuAndActionHash(handOptionsMenu, MenuOption::LowVelocityFilter, 0, true,
         qApp, SLOT(setLowVelocityFilter(bool)));
 

--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -37,7 +37,7 @@ AvatarActionHold::~AvatarActionHold() {
 }
 
 bool AvatarActionHold::getAvatarRigidBodyLocation(glm::vec3& avatarRigidBodyPosition, glm::quat& avatarRigidBodyRotation) {
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
     MyCharacterController* controller = myAvatar ? myAvatar->getCharacterController() : nullptr;
     if (!controller) {
         qDebug() << "AvatarActionHold::getAvatarRigidBodyLocation failed to get character controller";

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -31,6 +31,7 @@
 #include <SettingHandle.h>
 #include <UsersScriptingInterface.h>
 #include <UUID.h>
+#include <AvatarData.h>
 
 #include "Application.h"
 #include "Avatar.h"
@@ -323,7 +324,7 @@ void AvatarManager::handleCollisionEvents(const CollisionEvents& collisionEvents
         // an id of null. Thus this code handles any collision in which one of the participating objects is
         // my avatar. (Other user machines will make a similar analysis and inject sound for their collisions.)
         if (collision.idA.isNull() || collision.idB.isNull()) {
-            MyAvatar* myAvatar = getMyAvatar();
+            auto myAvatar = getMyAvatar();
             auto collisionSound = myAvatar->getCollisionSound();
             if (collisionSound) {
                 const auto characterController = myAvatar->getCharacterController();
@@ -399,7 +400,7 @@ void AvatarManager::updateAvatarRenderStatus(bool shouldRenderAvatars) {
 
 
 AvatarSharedPointer AvatarManager::getAvatarBySessionID(const QUuid& sessionID) {
-    if (sessionID == _myAvatar->getSessionUUID()) {
+    if (sessionID == AVATAR_SELF_ID || sessionID == _myAvatar->getSessionUUID()) {
         return _myAvatar;
     }
 

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -39,7 +39,7 @@ public:
 
     void init();
 
-    MyAvatar* getMyAvatar() { return _myAvatar.get(); }
+    std::shared_ptr<MyAvatar> getMyAvatar() { return _myAvatar; }
     AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID) override;
 
     void updateMyAvatar(float deltaTime);

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -79,7 +79,7 @@ bool HMDScriptingInterface::getHUDLookAtPosition3D(glm::vec3& result) const {
 }
 
 glm::mat4 HMDScriptingInterface::getWorldHMDMatrix() const {
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
     return myAvatar->getSensorToWorldMatrix() * myAvatar->getHMDSensorMatrix();
 }
 

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -43,7 +43,7 @@ bool OverlayConductor::headOutsideOverlay() const {
 
 bool OverlayConductor::updateAvatarIsAtRest() {
 
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
 
     const quint64 REST_ENABLE_TIME_USECS = 1000 * 1000; // 1 s
     const quint64 REST_DISABLE_TIME_USECS = 200 * 1000;  // 200 ms
@@ -69,7 +69,7 @@ bool OverlayConductor::updateAvatarIsAtRest() {
 }
 
 bool OverlayConductor::updateAvatarHasDriveInput() {
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
 
     const quint64 DRIVE_ENABLE_TIME_USECS = 200 * 1000;  // 200 ms
     const quint64 DRIVE_DISABLE_TIME_USECS = 1000 * 1000; // 1 s
@@ -103,7 +103,7 @@ void OverlayConductor::update(float dt) {
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     bool currentVisible = !offscreenUi->getDesktop()->property("pinned").toBool();
 
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
     // centerUI when hmd mode is first enabled and mounted
     if (qApp->isHMDMode() && qApp->getActiveDisplayPlugin()->isDisplayVisible()) {
         if (!_hmdMode) {

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -32,7 +32,7 @@
 void setupPreferences() {
     auto preferences = DependencyManager::get<Preferences>();
 
-    MyAvatar* myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
     static const QString AVATAR_BASICS { "Avatar Basics" };
     {
         auto getter = [=]()->QString { return myAvatar->getDisplayName(); };

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -170,7 +170,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(entitiesPing, octreeServerCount ? totalPingOctree / octreeServerCount : -1);
 
     // Third column, avatar stats
-    MyAvatar* myAvatar = avatarManager->getMyAvatar();
+    auto myAvatar = avatarManager->getMyAvatar();
     glm::vec3 avatarPos = myAvatar->getPosition();
     STAT_UPDATE(position, QVector3D(avatarPos.x, avatarPos.y, avatarPos.z));
     STAT_UPDATE_FLOAT(speed, glm::length(myAvatar->getVelocity()), 0.01f);

--- a/interface/src/ui/overlays/OverlaysPayload.cpp
+++ b/interface/src/ui/overlays/OverlaysPayload.cpp
@@ -64,7 +64,7 @@ namespace render {
         if (args) {
             if (overlay->getAnchor() == Overlay::MY_AVATAR) {
                 auto batch = args->_batch;
-                MyAvatar* avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+                auto avatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
                 glm::quat myAvatarRotation = avatar->getOrientation();
                 glm::vec3 myAvatarPosition = avatar->getPosition();
                 float angle = glm::degrees(glm::angle(myAvatarRotation));

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -55,6 +55,7 @@ typedef unsigned long long quint64;
 #include <NumericalConstants.h>
 #include <Packed.h>
 #include <ThreadSafeValueCache.h>
+#include <SharedUtil.h>
 
 #include "AABox.h"
 #include "HeadData.h"
@@ -137,10 +138,6 @@ class QDataStream;
 class AttachmentData;
 class Transform;
 using TransformPointer = std::shared_ptr<Transform>;
-
-// When writing out avatarEntities to a QByteArray, if the parentID is the ID of MyAvatar, use this ID instead.  This allows
-// the value to be reset when the sessionID changes.
-const QUuid AVATAR_SELF_ID = QUuid("{00000000-0000-0000-0000-000000000001}");
 
 class AvatarData : public QObject, public SpatiallyNestable {
     Q_OBJECT

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -12,6 +12,7 @@
 
 #include "EntityItemID.h"
 #include <VariantMapToScriptValue.h>
+#include <SharedUtil.h>
 #include <SpatialParentFinder.h>
 
 #include "EntitiesLogging.h"
@@ -179,6 +180,11 @@ QUuid EntityScriptingInterface::addEntity(const EntityItemProperties& properties
         const QUuid myNodeID = nodeList->getSessionUUID();
         propertiesWithSimID.setClientOnly(clientOnly);
         propertiesWithSimID.setOwningAvatarID(myNodeID);
+    }
+
+    if (propertiesWithSimID.getParentID() == AVATAR_SELF_ID) {
+        qDebug() << "ERROR: Cannot set entity parent ID to the local-only MyAvatar ID";
+        propertiesWithSimID.setParentID(QUuid());
     }
 
     auto dimensions = propertiesWithSimID.getDimensions();
@@ -357,6 +363,9 @@ QUuid EntityScriptingInterface::editEntity(QUuid id, const EntityItemProperties&
 
             if (!scriptSideProperties.parentIDChanged()) {
                 properties.setParentID(entity->getParentID());
+            } else if (scriptSideProperties.getParentID() == AVATAR_SELF_ID) {
+                qDebug() << "ERROR: Cannot set entity parent ID to the local-only MyAvatar ID";
+                properties.setParentID(QUuid());
             }
             if (!scriptSideProperties.parentJointIndexChanged()) {
                 properties.setParentJointIndex(entity->getParentJointIndex());

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -23,6 +23,12 @@
 
 #include <QtCore/QDebug>
 #include <QtCore/QCoreApplication>
+#include <QUuid>
+
+
+// When writing out avatarEntities to a QByteArray, if the parentID is the ID of MyAvatar, use this ID instead.  This allows
+// the value to be reset when the sessionID changes.
+const QUuid AVATAR_SELF_ID = QUuid("{00000000-0000-0000-0000-000000000001}");
 
 // Access to the global instance pointer to enable setting / unsetting
 template <typename T>

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -856,7 +856,7 @@ QList<SpatiallyNestablePointer> SpatiallyNestable::getChildren() const {
     _childrenLock.withReadLock([&] {
         foreach(SpatiallyNestableWeakPointer childWP, _children.values()) {
             SpatiallyNestablePointer child = childWP.lock();
-            if (child && child->_parentKnowsMe && child->getParentID() == getID()) {
+            if (child && child->_parentKnowsMe && (child->getParentID() == getID() || child->getParentID() == QUuid("{00000000-0000-0000-0000-000000000001}"))) {
                 children << child;
             }
         }


### PR DESCRIPTION
Right now you can only parent to your avatar's sessionID, which changes when switching domains. This PR let's you use the special AVATAR_SELF_ID as a unique identifier for your own avatar.