### PR TITLE
Turn and drive the HMD with linear velocity

### DIFF
--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -222,9 +222,10 @@ void CharacterController::playerStep(btCollisionWorld* dynaWorld, btScalar dt) {
         _rigidBody->setLinearVelocity(velocity + _parentVelocity);
         if (_following) {
             // OUTOFBODY_HACK -- these consts were copied from elsewhere, and then tuned
-            const float NORMAL_WALKING_SPEED = 0.5f;
+            const float NORMAL_WALKING_SPEED = 1.5f; // actual walk speed is 2.5 m/sec
             const float FOLLOW_TIME = 0.8f;
             const float FOLLOW_ROTATION_THRESHOLD = cosf(PI / 6.0f);
+            const float FOLLOW_FACTOR = 0.5f;
 
             const float MAX_ANGULAR_SPEED = FOLLOW_ROTATION_THRESHOLD / FOLLOW_TIME;
 
@@ -232,7 +233,7 @@ void CharacterController::playerStep(btCollisionWorld* dynaWorld, btScalar dt) {
 
             btVector3 startPos = bodyTransform.getOrigin();
             btVector3 deltaPos = _followDesiredBodyTransform.getOrigin() - startPos;
-            btVector3 vel = deltaPos * (0.5f / dt);
+            btVector3 vel = deltaPos * (FOLLOW_FACTOR / dt);
             btScalar speed = vel.length();
             if (speed > NORMAL_WALKING_SPEED) {
                 vel *= NORMAL_WALKING_SPEED / speed;


### PR DESCRIPTION
Turning action rotates the sensor to world matrix about the HMD, not the avatar.
Driving actions are converted to a single velocity relative to the HMD orientation.  This velocity is applied to the sensor to world matrix with NO acceleration, (other than the change acceleration introduced from to turning your HMD).
