### PR TITLE
fix domain-server command-line arguments

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -174,6 +174,13 @@ void DomainServer::parseCommandLine() {
     const QCommandLineOption domainIDOption("d", "domain-server uuid");
     parser.addOption(domainIDOption);
 
+    const QCommandLineOption getTempNameOption("get-temp-name", "Request a temporary domain-name");
+    parser.addOption(getTempNameOption);
+
+    const QCommandLineOption masterConfigOption("master-config", "Deprecated config-file option");
+    parser.addOption(masterConfigOption);
+
+
     if (!parser.parse(QCoreApplication::arguments())) {
         qWarning() << parser.errorText() << endl;
         parser.showHelp();


### PR DESCRIPTION
- repair doman-server's ability to parse command-line arguments

