### PR TITLE
smooth out-of-body transition + reduced foot sliding

### DIFF
--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -292,8 +292,8 @@
                                                         },
                                                         {
                                                             "id": "walkBwd",
-                                                            "interpTarget": 6,
-                                                            "interpDuration": 6,
+                                                            "interpTarget": 4,
+                                                            "interpDuration": 4,
                                                             "transitions": [
                                                                 { "var": "isNotMoving", "state": "idle" },
                                                                 { "var": "isMovingForward", "state": "walkFwd" },

--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -255,8 +255,8 @@
                                                         },
                                                         {
                                                             "id": "idleToWalkFwd",
-                                                            "interpTarget": 3,
-                                                            "interpDuration": 3,
+                                                            "interpTarget": 5,
+                                                            "interpDuration": 3.5,
                                                             "transitions": [
                                                                 { "var": "idleToWalkFwdOnDone", "state": "walkFwd" },
                                                                 { "var": "isNotMoving", "state": "idle" },
@@ -523,7 +523,7 @@
                                                         "data": {
                                                             "alpha": 0.0,
                                                             "desiredSpeed": 1.4,
-                                                            "characteristicSpeeds": [0.5, 1.4, 4.5],
+                                                            "characteristicSpeeds": [0.5, 1.3, 4.5],
                                                             "alphaVar": "moveForwardAlpha",
                                                             "desiredSpeedVar": "moveForwardSpeed"
                                                         },
@@ -573,7 +573,7 @@
                                                             "url": "animations/idle_to_walk.fbx",
                                                             "startFrame": 1.0,
                                                             "endFrame": 13.0,
-                                                            "timeScale": 1.0,
+                                                            "timeScale": 0.9,
                                                             "loopFlag": false
                                                         },
                                                         "children": []
@@ -584,7 +584,7 @@
                                                         "data": {
                                                             "alpha": 0.0,
                                                             "desiredSpeed": 1.4,
-                                                            "characteristicSpeeds": [0.6, 1.45],
+                                                            "characteristicSpeeds": [0.6, 1.05],
                                                             "alphaVar": "moveBackwardAlpha",
                                                             "desiredSpeedVar": "moveBackwardSpeed"
                                                         },
@@ -646,7 +646,7 @@
                                                         "data": {
                                                             "alpha": 0.0,
                                                             "desiredSpeed": 1.4,
-                                                            "characteristicSpeeds": [0.2, 0.65],
+                                                            "characteristicSpeeds": [0.2, 0.5],
                                                             "alphaVar": "moveLateralAlpha",
                                                             "desiredSpeedVar": "moveLateralSpeed"
                                                         },
@@ -683,7 +683,7 @@
                                                         "data": {
                                                             "alpha": 0.0,
                                                             "desiredSpeed": 1.4,
-                                                            "characteristicSpeeds": [0.2, 0.65],
+                                                            "characteristicSpeeds": [0.2, 0.5],
                                                             "alphaVar": "moveLateralAlpha",
                                                             "desiredSpeedVar": "moveLateralSpeed"
                                                         },

--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -255,10 +255,10 @@
                                                         },
                                                         {
                                                             "id": "idleToWalkFwd",
-                                                            "interpTarget": 5,
-                                                            "interpDuration": 3.5,
+                                                            "interpTarget": 4,
+                                                            "interpDuration": 3.0,
                                                             "transitions": [
-                                                                { "var": "idleToWalkFwdOnDone", "state": "walkFwd" },
+                                                                { "var": "idleToWalkFwdClipOnDone", "state": "walkFwd" },
                                                                 { "var": "isNotMoving", "state": "idle" },
                                                                 { "var": "isMovingBackward", "state": "walkBwd" },
                                                                 { "var": "isMovingRight", "state": "strafeRight" },
@@ -568,15 +568,28 @@
                                                     },
                                                     {
                                                         "id": "idleToWalkFwd",
-                                                        "type": "clip",
+                                                        "type": "blendLinearMove",
                                                         "data": {
-                                                            "url": "animations/idle_to_walk.fbx",
-                                                            "startFrame": 1.0,
-                                                            "endFrame": 13.0,
-                                                            "timeScale": 0.9,
-                                                            "loopFlag": false
+                                                            "alpha": 0.0,
+                                                            "desiredSpeed": 1.2,
+                                                            "characteristicSpeeds": [1.2],
+                                                            "alphaVar": 0.0,
+                                                            "desiredSpeedVar": "moveForwardSpeed"
                                                         },
-                                                        "children": []
+                                                        "children": [
+                                                            {
+                                                                "id": "idleToWalkFwdClip",
+                                                                "type": "clip",
+                                                                "data": {
+                                                                    "url": "animations/idle_to_walk.fbx",
+                                                                    "startFrame": 1.0,
+                                                                    "endFrame": 13.0,
+                                                                    "timeScale": 0.9,
+                                                                    "loopFlag": false
+                                                                },
+                                                                "children": []
+                                                            }
+                                                        ]
                                                     },
                                                     {
                                                         "id": "walkBwd",

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -485,6 +485,10 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderMyLookAtVectors, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderOtherLookAtVectors, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::FixGaze, 0, false);
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::DisplayLeftFootTrace, 0, false,
+        avatar, SLOT(setEnableDebugDrawLeftFootTrace(bool)));
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::DisplayRightFootTrace, 0, false,
+        avatar, SLOT(setEnableDebugDrawRightFootTrace(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawDefaultPose, 0, false,
         avatar, SLOT(setEnableDebugDrawDefaultPose(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawAnimPose, 0, false,

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -88,6 +88,8 @@ namespace MenuOption {
     const QString DiskCacheEditor = "Disk Cache Editor";
     const QString DisplayCrashOptions = "Display Crash Options";
     const QString DisplayHandTargets = "Show Hand Targets";
+    const QString DisplayLeftFootTrace = "Show Left Foot Trace";
+    const QString DisplayRightFootTrace = "Show Right Foot Trace";
     const QString DisplayModelBounds = "Display Model Bounds";
     const QString DisplayModelTriangles = "Display Model Triangles";
     const QString DisplayModelElementChildProxies = "Display Model Element Children";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1927,6 +1927,10 @@ bool findAvatarAvatarPenetration(const glm::vec3 positionA, float radiusA, float
     return false;
 }
 
+glm::vec3 MyAvatar::getPreActionVelocity() const {
+    return _characterController.getPreActionLinearVelocity();
+}
+
 void MyAvatar::increaseSize() {
     if ((1.0f + SCALING_RATIO) * _targetScale < MAX_AVATAR_SCALE) {
         _targetScale *= (1.0f + SCALING_RATIO);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1378,7 +1378,7 @@ void MyAvatar::harvestResultsFromPhysicsSimulation(float deltaTime) {
         hipsPosition.z *= -1.0f;
         maxHipsOffsetRadius = _characterController.measureMaxHipsOffsetRadius(hipsPosition, maxHipsOffsetRadius);
     }
-    _rig->setMaxHipsOffsetLength(maxHipsOffsetRadius);
+    _rig->updateMaxHipsOffsetLength(maxHipsOffsetRadius, deltaTime);
 
     glm::vec3 position = getPosition();
     glm::quat orientation = getOrientation();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -817,6 +817,14 @@ float loadSetting(Settings& settings, const QString& name, float defaultValue) {
     return value;
 }
 
+void MyAvatar::setEnableDebugDrawLeftFootTrace(bool isEnabled) {
+    _enableDebugDrawLeftFootTrace = isEnabled;
+}
+
+void MyAvatar::setEnableDebugDrawRightFootTrace(bool isEnabled) {
+    _enableDebugDrawRightFootTrace = isEnabled;
+}
+
 void MyAvatar::setEnableDebugDrawDefaultPose(bool isEnabled) {
     _enableDebugDrawDefaultPose = isEnabled;
 
@@ -1619,6 +1627,25 @@ void MyAvatar::postUpdate(float deltaTime) {
 
     DebugDraw::getInstance().updateMyAvatarPos(getPosition());
     DebugDraw::getInstance().updateMyAvatarRot(getOrientation());
+
+    if (_enableDebugDrawLeftFootTrace || _enableDebugDrawRightFootTrace) {
+        int boneIndex = _enableDebugDrawLeftFootTrace ? getJointIndex("LeftFoot") : getJointIndex("RightFoot");
+        const glm::vec4 RED(1.0f, 0.0f, 0.0f, 1.0f);
+        const glm::vec4 WHITE(1.0f, 1.0f, 1.0f, 1.0f);
+        const glm::vec4 TRANS(1.0f, 1.0f, 1.0f, 0.0f);
+        static bool colorBit = true;
+        colorBit = !colorBit;
+        glm::vec4 color = colorBit ? RED : WHITE;
+
+        _debugLineLoop[_debugLineLoopIndex] = DebugDrawVertex(getJointPosition(boneIndex), color);
+        _debugLineLoopIndex = (_debugLineLoopIndex + 1) % DEBUG_LINE_LOOP_SIZE;
+        _debugLineLoop[_debugLineLoopIndex] = DebugDrawVertex(getJointPosition(boneIndex), TRANS);
+        for (size_t prev = DEBUG_LINE_LOOP_SIZE - 1, next = 0; next < DEBUG_LINE_LOOP_SIZE; prev = next, next++) {
+            if (_debugLineLoop[prev].color.w > 0.0f) {
+                DebugDraw::getInstance().drawRay(_debugLineLoop[prev].pos, _debugLineLoop[next].pos, _debugLineLoop[prev].color);
+            }
+        }
+    }
 }
 
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -59,7 +59,7 @@ using namespace std;
 const glm::vec3 DEFAULT_UP_DIRECTION(0.0f, 1.0f, 0.0f);
 const float DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES = 30.0f;
 
-const float MAX_WALKING_SPEED = 2.6f; // human walking speed
+const float MAX_WALKING_SPEED = 2.0f; // human walking speed
 const float MAX_BOOST_SPEED = 0.5f * MAX_WALKING_SPEED; // action motor gets additive boost below this speed
 const float MIN_AVATAR_SPEED = 0.05f;
 const float MIN_AVATAR_SPEED_SQUARED = MIN_AVATAR_SPEED * MIN_AVATAR_SPEED; // speed is set to zero below this

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2300,16 +2300,11 @@ void MyAvatar::FollowHelper::prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat
 }
 
 void MyAvatar::FollowHelper::postPhysicsUpdate(MyAvatar& myAvatar) {
-
-    // get HMD position from sensor space into world space, and back into rig space
     glm::mat4 worldHMDMat = myAvatar.getSensorToWorldMatrix() * myAvatar.getHMDSensorMatrix();
-    glm::mat4 rigToWorld = createMatFromQuatAndPos(myAvatar.getRotation() * Quaternions::Y_180, myAvatar.getPosition());
-    glm::mat4 worldToRig = glm::inverse(rigToWorld);
-    glm::mat4 rigHMDMat = worldToRig * worldHMDMat;
-    glm::vec3 rigHMDPosition = extractTranslation(rigHMDMat);
-
-    // detect if the rig head position is too far from the avatar's position.
-    _isOutOfBody = !pointIsInsideCapsule(rigHMDPosition, TRUNCATE_IK_CAPSULE_POSITION, TRUNCATE_IK_CAPSULE_LENGTH, TRUNCATE_IK_CAPSULE_RADIUS);
+    glm::vec3 worldHMDPosition = extractTranslation(worldHMDMat);
+    glm::vec3 capsuleStart = myAvatar.getPosition() + Vectors::UNIT_Y * (TRUNCATE_IK_CAPSULE_LENGTH / 2.0f);
+    glm::vec3 capsuleEnd = myAvatar.getPosition() - Vectors::UNIT_Y * (TRUNCATE_IK_CAPSULE_LENGTH / 2.0f);
+    _isOutOfBody = !pointIsInsideCapsule(worldHMDPosition, capsuleStart, capsuleEnd, TRUNCATE_IK_CAPSULE_RADIUS);
 }
 
 float MyAvatar::getAccelerationEnergy() {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -284,6 +284,8 @@ public:
     virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
     virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
+    glm::vec3 getPreActionVelocity() const;
+
 public slots:
     void increaseSize();
     void decreaseSize();

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -55,6 +55,8 @@ enum AudioListenerMode {
 };
 Q_DECLARE_METATYPE(AudioListenerMode);
 
+const size_t DEBUG_LINE_LOOP_SIZE = 1000;
+
 class MyAvatar : public Avatar {
     Q_OBJECT
     Q_PROPERTY(bool shouldRenderLocally READ getShouldRenderLocally WRITE setShouldRenderLocally)
@@ -303,6 +305,8 @@ public slots:
 
     Q_INVOKABLE void updateMotionBehaviorFromMenu();
 
+    void setEnableDebugDrawLeftFootTrace(bool isEnabled);
+    void setEnableDebugDrawRightFootTrace(bool isEnabled);
     void setEnableDebugDrawDefaultPose(bool isEnabled);
     void setEnableDebugDrawAnimPose(bool isEnabled);
     void setEnableDebugDrawPosition(bool isEnabled);
@@ -481,6 +485,8 @@ private:
     RigPointer _rig;
     bool _prevShouldDrawHead;
 
+    bool _enableDebugDrawLeftFootTrace { false };
+    bool _enableDebugDrawRightFootTrace { false };
     bool _enableDebugDrawDefaultPose { false };
     bool _enableDebugDrawAnimPose { false };
     bool _enableDebugDrawHandControllers { false };
@@ -517,6 +523,15 @@ private:
     float getEnergy();
     void setEnergy(float value);
     bool didTeleport();
+
+    struct DebugDrawVertex {
+        DebugDrawVertex() : pos(), color() {}
+        DebugDrawVertex(const glm::vec3& posIn, const glm::vec4& colorIn) : pos(posIn), color(colorIn) {}
+        glm::vec3 pos;
+        glm::vec4 color;
+    };
+    DebugDrawVertex _debugLineLoop[DEBUG_LINE_LOOP_SIZE];
+    size_t _debugLineLoopIndex { 0 };
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -55,7 +55,7 @@ enum AudioListenerMode {
 };
 Q_DECLARE_METATYPE(AudioListenerMode);
 
-const size_t DEBUG_LINE_LOOP_SIZE = 1000;
+const size_t DEBUG_LINE_LOOP_SIZE = 500;
 
 class MyAvatar : public Avatar {
     Q_OBJECT

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -149,6 +149,17 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         _rig->updateFromHeadParameters(headParams, deltaTime);
 
+        // OUTOFBODY_HACK: clamp horizontal component of head by maxHipsOffset.
+        // This is to prevent the hands from being incorrect relative to the head because
+        // the hips are being constrained by a small maxHipsOffset due to collision.
+        if (myAvatar->isOutOfBody()) {
+            float headOffsetLength2D = glm::length(glm::vec2(truncatedHMDPositionInRigSpace.x, truncatedHMDPositionInRigSpace.z));
+            if (headOffsetLength2D > _rig->getMaxHipsOffsetLength()) {
+                truncatedHMDPositionInRigSpace.x *= _rig->getMaxHipsOffsetLength() / headOffsetLength2D;
+                truncatedHMDPositionInRigSpace.z *= _rig->getMaxHipsOffsetLength() / headOffsetLength2D;
+            }
+        }
+
         Rig::HandParameters handParams;
 
         auto leftPose = myAvatar->getLeftHandControllerPoseInAvatarFrame();

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -124,10 +124,12 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
             hmdPositionInRigSpace = extractTranslation(rigHMDMat);
 
+            glm::vec3 capsuleStart = Vectors::UNIT_Y * (TRUNCATE_IK_CAPSULE_LENGTH / 2.0f);
+            glm::vec3 capsuleEnd = -Vectors::UNIT_Y * (TRUNCATE_IK_CAPSULE_LENGTH / 2.0f);
+
             // truncate head IK target if it's out of body
             if (myAvatar->isOutOfBody()) {
-                truncatedHMDPositionInRigSpace = projectPointOntoCapsule(hmdPositionInRigSpace, TRUNCATE_IK_CAPSULE_POSITION,
-                                                                         TRUNCATE_IK_CAPSULE_LENGTH, TRUNCATE_IK_CAPSULE_RADIUS);
+                truncatedHMDPositionInRigSpace = projectPointOntoCapsule(hmdPositionInRigSpace, capsuleStart, capsuleEnd, TRUNCATE_IK_CAPSULE_RADIUS);
             } else {
                 truncatedHMDPositionInRigSpace = hmdPositionInRigSpace;
             }

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -200,7 +200,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         Rig::CharacterControllerState ccState = convertCharacterControllerState(myAvatar->getCharacterController()->getState());
 
-        auto velocity = myAvatar->getLocalVelocity();
+        auto velocity = myAvatar->getPreActionVelocity();
         auto position = myAvatar->getLocalPosition();
         auto orientation = myAvatar->getLocalOrientation();
         _rig->computeMotionAnimationState(deltaTime, position, velocity, orientation, ccState);

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -392,10 +392,6 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
         dt = MAX_OVERLAY_DT;
     }
 
-    // OUTOFBODY_HACK: smoothly update update _hipsOffsetLength, otherwise we risk introducing oscillation in the hips offset.
-    float tau = dt / 0.5f;
-    _maxHipsOffsetLength = (1.0f - tau) * _maxHipsOffsetLength + tau * _desiredMaxHipsOffsetLength;
-
     if (_relativePoses.size() != underPoses.size()) {
         loadPoses(underPoses);
     } else {
@@ -585,7 +581,7 @@ void AnimInverseKinematics::clearIKJointLimitHistory() {
 void AnimInverseKinematics::setMaxHipsOffsetLength(float maxLength) {
     // OUTOFBODY_HACK: manually adjust scale here
     const float METERS_TO_CENTIMETERS = 100.0f;
-    _desiredMaxHipsOffsetLength = METERS_TO_CENTIMETERS * maxLength;
+    _maxHipsOffsetLength = METERS_TO_CENTIMETERS * maxLength;
 }
 
 RotationConstraint* AnimInverseKinematics::getConstraint(int index) {

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -85,7 +85,6 @@ protected:
 
     // experimental data for moving hips during IK
     glm::vec3 _hipsOffset { Vectors::ZERO };
-    float _desiredMaxHipsOffsetLength { 1.0f };
     float _maxHipsOffsetLength { 1.0f };
     int _headIndex { -1 };
     int _hipsIndex { -1 };

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -501,9 +501,9 @@ bool Rig::getRelativeDefaultJointTranslation(int index, glm::vec3& translationOu
 }
 
 // animation reference speeds.
-static const std::vector<float> FORWARD_SPEEDS = { 0.4f, 1.4f, 4.5f }; // m/s
-static const std::vector<float> BACKWARD_SPEEDS = { 0.6f, 1.45f }; // m/s
-static const std::vector<float> LATERAL_SPEEDS = { 0.2f, 0.65f }; // m/s
+static const std::vector<float> FORWARD_SPEEDS = { 0.4f, 1.3f, 4.5f }; // m/s
+static const std::vector<float> BACKWARD_SPEEDS = { 0.6f, 1.05f }; // m/s
+static const std::vector<float> LATERAL_SPEEDS = { 0.2f, 0.5f }; // m/s
 
 void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPosition, const glm::vec3& worldVelocity, const glm::quat& worldRotation, CharacterControllerState ccState) {
 
@@ -598,7 +598,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             }
         }
 
-        const float STATE_CHANGE_HYSTERESIS_TIMER = 0.1f;
+        const float STATE_CHANGE_HYSTERESIS_TIMER = 1.0f / 60.0f;
 
         // Skip hystersis timer for jump transitions.
         if (_desiredState == RigRole::Takeoff) {

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -104,7 +104,8 @@ public:
     void clearJointAnimationPriority(int index);
 
     void clearIKJointLimitHistory();
-    void setMaxHipsOffsetLength(float maxLength);
+    void updateMaxHipsOffsetLength(float maxLength, float deltaTime);
+    float getMaxHipsOffsetLength() const;
 
     // geometry space
     void setJointState(int index, bool valid, const glm::quat& rotation, const glm::vec3& translation, float priority);
@@ -318,6 +319,9 @@ protected:
     glm::vec3 _desiredRigHeadPosition;
     bool _truncateIKTargets { false };
     bool _enableDebugDrawIKTargets { false };
+
+    float _maxHipsOffsetLength { 1.0f };
+    float _desiredMaxHipsOffsetLength { 1.0f };
 
 private:
     QMap<int, StateHandler> _stateHandlers;

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -195,6 +195,13 @@ bool CharacterController::checkForSupport(btCollisionWorld* collisionWorld) {
     return hasFloor;
 }
 
+void CharacterController::updateAction(btCollisionWorld* collisionWorld, btScalar deltaTime)
+{
+    _preActionVelocity = getLinearVelocity();
+    preStep(collisionWorld);
+    playerStep(collisionWorld, deltaTime);
+}
+
 void CharacterController::preStep(btCollisionWorld* collisionWorld) {
     // trace a ray straight down to see if we're standing on the ground
     const btTransform& transform = _rigidBody->getWorldTransform();
@@ -455,6 +462,10 @@ glm::vec3 CharacterController::getLinearVelocity() const {
         velocity = bulletToGLM(_rigidBody->getLinearVelocity());
     }
     return velocity;
+}
+
+glm::vec3 CharacterController::getPreActionLinearVelocity() const {
+    return _preActionVelocity;
 }
 
 glm::vec3 CharacterController::getVelocityChange() const {

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -195,8 +195,7 @@ bool CharacterController::checkForSupport(btCollisionWorld* collisionWorld) {
     return hasFloor;
 }
 
-void CharacterController::updateAction(btCollisionWorld* collisionWorld, btScalar deltaTime)
-{
+void CharacterController::updateAction(btCollisionWorld* collisionWorld, btScalar deltaTime) {
     _preActionVelocity = getLinearVelocity();
     preStep(collisionWorld);
     playerStep(collisionWorld, deltaTime);

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -60,10 +60,7 @@ public:
     virtual void warp(const btVector3& origin) override { }
     virtual void debugDraw(btIDebugDraw* debugDrawer) override { }
     virtual void setUpInterpolate(bool value) override { }
-    virtual void updateAction(btCollisionWorld* collisionWorld, btScalar deltaTime) override {
-        preStep(collisionWorld);
-        playerStep(collisionWorld, deltaTime);
-    }
+    virtual void updateAction(btCollisionWorld* collisionWorld, btScalar deltaTime) override;
     virtual void preStep(btCollisionWorld *collisionWorld) override;
     virtual void playerStep(btCollisionWorld *collisionWorld, btScalar dt) override;
     virtual bool canJump() const override { assert(false); return false; } // never call this
@@ -90,6 +87,7 @@ public:
     void disableFollow() { _following = false; }
 
     glm::vec3 getLinearVelocity() const;
+    glm::vec3 getPreActionLinearVelocity() const;
     glm::vec3 getVelocityChange() const;
 
     float getCapsuleRadius() const { return _radius; }
@@ -147,6 +145,7 @@ protected:
     btVector3 _targetVelocity;
     btVector3 _parentVelocity;
     btVector3 _preSimulationVelocity;
+    glm::vec3 _preActionVelocity;
     btVector3 _velocityChange;
     btTransform _followDesiredBodyTransform;
     btVector3 _position;

--- a/libraries/shared/src/GeometryUtil.cpp
+++ b/libraries/shared/src/GeometryUtil.cpp
@@ -579,33 +579,37 @@ float coneSphereAngle(const glm::vec3& coneCenter, const glm::vec3& coneDirectio
     return glm::max(0.0f, theta - phi);
 }
 
-bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius) {
-    glm::vec3 top = capsulePosition.y + glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
-    glm::vec3 bottom = capsulePosition.y - glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
-    if (point.y > top.y + capsuleRadius) {
-        return false;
-    } else if (point.y > top.y) {
-        return glm::length(point - top) < capsuleRadius;
-    } else if (point.y < bottom.y - capsuleRadius) {
-        return false;
-    } else if (point.y < bottom.y) {
-        return glm::length(point - bottom) < capsuleRadius;
+glm::vec3 nearestPointOnLineSegment(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd) {
+    glm::vec3 n = segmentEnd - segmentStart;
+    float len = glm::length(n);
+    if (len < EPSILON) {
+        return segmentStart;
     } else {
-        return glm::length(glm::vec2(point.x, point.z) - glm::vec2(capsulePosition.x, capsulePosition.z)) < capsuleRadius;
+        n /= len;
+        float projection = glm::dot(point - segmentStart, n);
+        projection = glm::clamp(projection, 0.0f, len);
+        return segmentStart + n * projection;
     }
 }
 
-glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius) {
-    glm::vec3 top = capsulePosition.y + glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
-    glm::vec3 bottom = capsulePosition.y - glm::vec3(0.0f, capsuleLength / 2.0f, 0.0f);
-    if (point.y > top.y) {
-        return capsuleRadius * glm::normalize(point - top) + top;
-    } else if (point.y < bottom.y) {
-        return capsuleRadius * glm::normalize(point - bottom) + bottom;
+float distanceFromLineSegment(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd) {
+    return glm::length(point - nearestPointOnLineSegment(point, segmentStart, segmentEnd));
+}
+
+bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsuleStart, const glm::vec3& capsuleEnd, float capsuleRadius) {
+    return distanceFromLineSegment(point, capsuleStart, capsuleEnd) < capsuleRadius;
+}
+
+glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsuleStart, const glm::vec3& capsuleEnd, float capsuleRadius) {
+    glm::vec3 nearestPoint = nearestPointOnLineSegment(point, capsuleStart, capsuleEnd);
+    glm::vec3 d = point - nearestPoint;
+    float dLen = glm::length(d);
+    if (dLen > EPSILON) {
+        return nearestPoint;  // TODO: maybe we should pick a point actually on the surface...
     } else {
-        glm::vec2 capsulePosition2D(capsulePosition.x, capsulePosition.z);
-        glm::vec2 point2D(point.x, point.z);
-        glm::vec2 projectedPoint2D = capsuleRadius * glm::normalize(point2D - capsulePosition2D) + capsulePosition2D;
-        return glm::vec3(projectedPoint2D.x, point.y, projectedPoint2D.y);
+        return nearestPoint + d * (capsuleRadius / dLen);
     }
 }
+
+
+

--- a/libraries/shared/src/GeometryUtil.cpp
+++ b/libraries/shared/src/GeometryUtil.cpp
@@ -596,6 +596,10 @@ float distanceFromLineSegment(const glm::vec3& point, const glm::vec3& segmentSt
     return glm::length(point - nearestPointOnLineSegment(point, segmentStart, segmentEnd));
 }
 
+float distanceFromCapsule(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd, float capsuleRadius) {
+    return distanceFromLineSegment(point, segmentStart, segmentEnd) - capsuleRadius;
+}
+
 bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsuleStart, const glm::vec3& capsuleEnd, float capsuleRadius) {
     return distanceFromLineSegment(point, capsuleStart, capsuleEnd) < capsuleRadius;
 }
@@ -604,7 +608,7 @@ glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsu
     glm::vec3 nearestPoint = nearestPointOnLineSegment(point, capsuleStart, capsuleEnd);
     glm::vec3 d = point - nearestPoint;
     float dLen = glm::length(d);
-    if (dLen > EPSILON) {
+    if (dLen < EPSILON) {
         return nearestPoint;  // TODO: maybe we should pick a point actually on the surface...
     } else {
         return nearestPoint + d * (capsuleRadius / dLen);

--- a/libraries/shared/src/GeometryUtil.h
+++ b/libraries/shared/src/GeometryUtil.h
@@ -162,6 +162,7 @@ private:
 
 glm::vec3 nearestPointOnLineSegment(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd);
 float distanceFromLineSegment(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd);
+float distanceFromCapsule(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd, float capsuleRadius);
 bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsuleStart, const glm::vec3& capsuleEnd, float capsuleRadius);
 glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsuleStart, const glm::vec3& capsuleEnd, float capsuleRadius);
 

--- a/libraries/shared/src/GeometryUtil.h
+++ b/libraries/shared/src/GeometryUtil.h
@@ -160,8 +160,9 @@ private:
     static void copyCleanArray(int& lengthA, glm::vec2* vertexArrayA, int& lengthB, glm::vec2* vertexArrayB);
 };
 
-// vertical capsule
-bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius);
-glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsulePosition, float capsuleLength, float capsuleRadius);
+glm::vec3 nearestPointOnLineSegment(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd);
+float distanceFromLineSegment(const glm::vec3& point, const glm::vec3& segmentStart, const glm::vec3& segmentEnd);
+bool pointIsInsideCapsule(const glm::vec3& point, const glm::vec3& capsuleStart, const glm::vec3& capsuleEnd, float capsuleRadius);
+glm::vec3 projectPointOntoCapsule(const glm::vec3& point, const glm::vec3& capsuleStart, const glm::vec3& capsuleEnd, float capsuleRadius);
 
 #endif // hifi_GeometryUtil_h


### PR DESCRIPTION
Normally, the hand IK targets will follow the hand controllers exactly.  However when your HMD camera gets too far away from your body, we compute the hand IK targets differently, the hands are relative to your avatar's head instead of where your HMD camera is.   This PR attempts to make this transition as smooth as possible by interpolating between the two positions.

Other minor changes:
* The character rig no-longer animates when the body is prevented from moving due to collision.
* There are new developer > avatar debug options which can be used to turn on foot tracing.  This trace can be helpful for detecting foot sliding.
* Tuned interpolation and animation speeds to reduce foot-sliding