### PR TITLE
Remove oglplus usage in Offscreen QML rendering

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "DisplayPlugin.h"
+#include <gl/Config.h>
 
 #include <condition_variable>
 #include <memory>
@@ -18,7 +19,6 @@
 
 #include <GLMHelpers.h>
 #include <SimpleMovingAverage.h>
-#include <gl/GLEscrow.h>
 #include <shared/RateCounter.h>
 
 namespace gpu {
@@ -35,7 +35,6 @@ protected:
     using Mutex = std::mutex;
     using Lock = std::unique_lock<Mutex>;
     using Condition = std::condition_variable;
-    using TextureEscrow = GLEscrow<gpu::TexturePointer>;
 public:
     // These must be final to ensure proper ordering of operations 
     // between the main thread and the presentation thread


### PR DESCRIPTION
The OGLPlus functionality of calling `glGetError()` after every function is impacting performance.

## Testing

This should not impact application functionality at all.  It may have a minor performance improvment on i5 systems