### PR TITLE
Improved body follow behavior

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3811,7 +3811,7 @@ void Application::update(float deltaTime) {
             avatarManager->getObjectsToChange(motionStates);
             _physicsEngine->changeObjects(motionStates);
 
-            myAvatar->prepareForPhysicsSimulation();
+            myAvatar->prepareForPhysicsSimulation(deltaTime);
             _physicsEngine->forEachAction([&](EntityActionPointer action) {
                 action->prepareForPhysicsSimulation();
             });

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -36,6 +36,7 @@
 #include <UserActivityLogger.h>
 #include <AnimDebugDraw.h>
 #include <AnimClip.h>
+#include <AnimUtil.h>
 #include <recording/Deck.h>
 #include <recording/Recorder.h>
 #include <recording/Clip.h>
@@ -1347,7 +1348,7 @@ void MyAvatar::updateMotors() {
     _characterController.setLinearAcceleration(glm::vec3(0.0f, _thrust.y, 0.0f));
 }
 
-void MyAvatar::prepareForPhysicsSimulation() {
+void MyAvatar::prepareForPhysicsSimulation(float deltaTime) {
     relayDriveKeysToCharacterController();
     updateMotors();
 
@@ -1365,9 +1366,14 @@ void MyAvatar::prepareForPhysicsSimulation() {
 
     _characterController.setPositionAndOrientation(position, orientation);
     if (qApp->isHMDMode()) {
-        glm::mat4 bodyToWorldMatrix = createMatFromQuatAndPos(orientation, position);
-        glm::mat4 currentBodySensorMatrix = glm::inverse(_sensorToWorldMatrix) * bodyToWorldMatrix;
-        _follow.prePhysicsUpdate(*this, deriveBodyFromHMDSensor(), currentBodySensorMatrix);
+        // update the _bodySensorMatrix based on leaning behavior of the avatar.
+        _bodySensorMatrix = _follow.prePhysicsUpdate(*this, deriveBodyFromHMDSensor(), _bodySensorMatrix, hasDriveInput(), deltaTime);
+
+        // The avatar physics body always follows the _bodySensorMatrix.
+        glm::mat4 worldBodyMatrix = _sensorToWorldMatrix * _bodySensorMatrix;
+        getCharacterController()->setFollowParameters(worldBodyMatrix);
+
+        DebugDraw::getInstance().addMarker("bodySensorMatrix", glmExtractRotation(worldBodyMatrix), extractTranslation(worldBodyMatrix), glm::vec4(1.0f));
     } else {
         _follow.deactivate();
         getCharacterController()->disableFollow();
@@ -2230,10 +2236,10 @@ void MyAvatar::FollowHelper::updateRotationActivation(const MyAvatar& myAvatar, 
         deactivate(Rotation);
     } else {
         const float FOLLOW_ROTATION_THRESHOLD = cosf(PI / 6.0f); // 30 degrees
-        const float STOP_FOLLOW_ROTATION_THRESHOLD = 0.99f;
+        const float STOP_FOLLOW_ROTATION_THRESHOLD = cosf(PI / 180.0f);  // 1 degree
         glm::vec2 bodyFacing = getFacingDir2D(currentBodyMatrix);
         if (isActive(Rotation)) {
-            if (glm::dot(myAvatar.getHMDSensorFacingMovingAverage(), bodyFacing) > STOP_FOLLOW_ROTATION_THRESHOLD) {
+            if (glm::dot(myAvatar.getHMDSensorFacing(), bodyFacing) > STOP_FOLLOW_ROTATION_THRESHOLD) {
                 deactivate(Rotation);
             }
         } else if (glm::dot(myAvatar.getHMDSensorFacingMovingAverage(), bodyFacing) < FOLLOW_ROTATION_THRESHOLD) {
@@ -2272,9 +2278,6 @@ void MyAvatar::FollowHelper::updateHorizontalActivation(const MyAvatar& myAvatar
 }
 
 void MyAvatar::FollowHelper::updateVerticalActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix) {
-
-    // OUTOFBODY_HACK: disable vertical follow behavior
-    /*
     const float CYLINDER_TOP = 0.1f;
     const float CYLINDER_BOTTOM = -1.5f;
     const float MIN_VERTICAL_OFFSET = 0.02f;
@@ -2287,42 +2290,41 @@ void MyAvatar::FollowHelper::updateVerticalActivation(const MyAvatar& myAvatar, 
     } else if (offset.y > CYLINDER_TOP || offset.y < CYLINDER_BOTTOM) {
         activate(Vertical);
     }
-    */
 }
 
-void MyAvatar::FollowHelper::prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix) {
-    _desiredBodyMatrix = desiredBodyMatrix;
-
+glm::mat4 MyAvatar::FollowHelper::prePhysicsUpdate(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix, bool hasDriveInput, float deltaTime) {
     if (myAvatar.getHMDLeanRecenterEnabled()) {
         updateRotationActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
         updateHorizontalActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
         updateVerticalActivation(myAvatar, desiredBodyMatrix, currentBodyMatrix);
 
-        glm::mat4 desiredWorldMatrix = myAvatar.getSensorToWorldMatrix() * _desiredBodyMatrix;
-        glm::mat4 currentWorldMatrix = createMatFromQuatAndPos(myAvatar.getOrientation(), myAvatar.getPosition());
+        AnimPose currentBodyPose(currentBodyMatrix);
+        AnimPose desiredBodyPose(desiredBodyMatrix);
+        AnimPose followBodyPose(currentBodyMatrix);
 
-        AnimPose followWorldPose(currentWorldMatrix);
-        if (isActive(Rotation)) {
-            followWorldPose.rot = glmExtractRotation(desiredWorldMatrix);
+        if (isActive(Rotation) || hasDriveInput) {
+            followBodyPose.rot = desiredBodyPose.rot;
         }
-        if (isActive(Horizontal)) {
-            glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
-            followWorldPose.trans.x = desiredTranslation.x;
-            followWorldPose.trans.z = desiredTranslation.z;
+        if (isActive(Horizontal) || hasDriveInput) {
+            followBodyPose.trans.x = desiredBodyPose.trans.x;
+            followBodyPose.trans.z = desiredBodyPose.trans.z;
         }
-        if (isActive(Vertical)) {
-            glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
-            followWorldPose.trans.y = desiredTranslation.y;
+        if (isActive(Vertical) || hasDriveInput) {
+            followBodyPose.trans.y = desiredBodyPose.trans.y;
         }
 
-        if (isActive()) {
-            myAvatar.getCharacterController()->setFollowParameters(followWorldPose);
+        if (isActive() || hasDriveInput) {
+            const float TIMESCALE = 0.2f;
+            const float tau = deltaTime / TIMESCALE;
+            AnimPose newBodyPose;
+            blend(1, &currentBodyPose, &followBodyPose, tau, &newBodyPose);
+            return (glm::mat4)newBodyPose;
         } else {
-            myAvatar.getCharacterController()->disableFollow();
+            return currentBodyMatrix;
         }
     } else {
         deactivate();
-        myAvatar.getCharacterController()->disableFollow();
+        return currentBodyMatrix;
     }
 }
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1372,8 +1372,6 @@ void MyAvatar::prepareForPhysicsSimulation(float deltaTime) {
         // The avatar physics body always follows the _bodySensorMatrix.
         glm::mat4 worldBodyMatrix = _sensorToWorldMatrix * _bodySensorMatrix;
         getCharacterController()->setFollowParameters(worldBodyMatrix);
-
-        DebugDraw::getInstance().addMarker("bodySensorMatrix", glmExtractRotation(worldBodyMatrix), extractTranslation(worldBodyMatrix), glm::vec4(1.0f));
     } else {
         _follow.deactivate();
         getCharacterController()->disableFollow();

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -109,6 +109,7 @@ public:
     const glm::mat4& getHMDSensorMatrix() const { return _hmdSensorMatrix; }
     const glm::vec3& getHMDSensorPosition() const { return _hmdSensorPosition; }
     const glm::quat& getHMDSensorOrientation() const { return _hmdSensorOrientation; }
+    const glm::vec2& getHMDSensorFacing() const { return _hmdSensorFacing; }
     const glm::vec2& getHMDSensorFacingMovingAverage() const { return _hmdSensorFacingMovingAverage; }
 
     Q_INVOKABLE void setOrientationVar(const QVariant& newOrientationVar);
@@ -235,7 +236,7 @@ public:
     const MyCharacterController* getCharacterController() const { return &_characterController; }
 
     void updateMotors();
-    void prepareForPhysicsSimulation();
+    void prepareForPhysicsSimulation(float deltaTime);
     void harvestResultsFromPhysicsSimulation(float deltaTime);
 
     const QString& getCollisionSoundURL() { return _collisionSoundURL; }
@@ -459,7 +460,6 @@ private:
             Vertical,
             NumFollowTypes
         };
-        glm::mat4 _desiredBodyMatrix;
         uint8_t _activeBits { 0 };
         bool _isOutOfBody { false };
 
@@ -472,7 +472,7 @@ private:
         void updateRotationActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
         void updateHorizontalActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
         void updateVerticalActivation(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix);
-        void prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat4& bodySensorMatrix, const glm::mat4& currentBodyMatrix);
+        glm::mat4 prePhysicsUpdate(const MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix, const glm::mat4& currentBodyMatrix, bool hasDriveInput, float deltaTime);
         void postPhysicsUpdate(MyAvatar& myAvatar);
     };
     FollowHelper _follow;

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -261,6 +261,7 @@ void CharacterController::playerStep(btCollisionWorld* dynaWorld, btScalar dt) {
             const float HORIZONTAL_FOLLOW_TIMESCALE = 0.1f;
             const float VERTICAL_FOLLOW_TIMESCALE = (_state == State::Hover) ? HORIZONTAL_FOLLOW_TIMESCALE : 20.0f;
             glm::quat worldFrameRotation; // identity
+            vel.setY(0.0f);  // don't allow any vertical component of the follow velocity to enter the _targetVelocity.
             addMotor(bulletToGLM(vel), worldFrameRotation, HORIZONTAL_FOLLOW_TIMESCALE, VERTICAL_FOLLOW_TIMESCALE);
         }
 

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -231,7 +231,7 @@ void CharacterController::playerStep(btCollisionWorld* dynaWorld, btScalar dt) {
     btVector3 velocity = _rigidBody->getLinearVelocity() - _parentVelocity;
     if (_following) {
         // linear part uses a motor
-        const float MAX_WALKING_SPEED = 2.5f; // TODO: scale this stuff with avatar size
+        const float MAX_WALKING_SPEED = 30.5f; // TODO: scale this stuff with avatar size
         const float MAX_WALKING_SPEED_DISTANCE = 1.0f;
         const float NORMAL_WALKING_SPEED = 0.5f * MAX_WALKING_SPEED;
         const float NORMAL_WALKING_SPEED_DISTANCE = 0.5f * MAX_WALKING_SPEED_DISTANCE;


### PR DESCRIPTION
* follow helper lean re-centering / reconciliation now modifies bodySensorMatrix, NOT the character controller.
* The character controller now always follows the bodySensorMatrix (in world space).

This decouples the lean re-centering velocity from the velocity used to move the character controller.
We can now independently tune these things separately.

Also, the max character controller follow velocity has been increased to 30.5 from 2.5, this helps the body keep up with the sensor to world matrix, even while flying.