### PR TITLE
Fixed HandcontrollerGrab distance unequip

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2103,7 +2103,7 @@ function MyController(hand) {
                     this.autoUnequipCounter = 0;
                 }
 
-                if (this.autoUnequipCounter > 1) {
+                if (this.autoUnequipCounter > 0.25) {
                         // for whatever reason, the held/equipped entity has been pulled away.  ungrab or unequip.
                     print("handControllerGrab -- autoreleasing held or equipped item because it is far from hand." +
                         props.parentID + ", dist = " + dist);

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2098,7 +2098,7 @@ function MyController(hand) {
                 var TEAR_AWAY_DISTANCE = 0.1;
                 var dist = distanceBetweenPointAndEntityBoundingBox(handPosition, props);
                 if (dist > TEAR_AWAY_DISTANCE) {
-                    this.autoUnequipCounter += 1;
+                    this.autoUnequipCounter += deltaTime;
                 } else {
                     this.autoUnequipCounter = 0;
                 }


### PR DESCRIPTION
Will now use deltaTime and a second instead of instantly disconnecting on
if more than 0.1 off. This is to avoid accidental disconnection due to
acceleration and latency

Additionally, one could maybe adjust the time it takes to a half second, but this seemed enough to fix the issues with moving at high velocities with an equipped item. 

