### PR TITLE
Assignment Client fixes

### DIFF
--- a/assignment-client/src/AssignmentClientLogging.cpp
+++ b/assignment-client/src/AssignmentClientLogging.cpp
@@ -11,4 +11,4 @@
 
 #include "AssignmentClientLogging.h"
 
-Q_LOGGING_CATEGORY(assigmnentclient, "hifi.assignment-client")
+Q_LOGGING_CATEGORY(assignment_client, "hifi.assignment-client")

--- a/assignment-client/src/AssignmentClientLogging.h
+++ b/assignment-client/src/AssignmentClientLogging.h
@@ -14,6 +14,6 @@
 
 #include <QLoggingCategory>
 
-Q_DECLARE_LOGGING_CATEGORY(assigmnentclient)
+Q_DECLARE_LOGGING_CATEGORY(assignment_client)
 
 #endif // hifi_AssignmentClientLogging_h

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1749,7 +1749,7 @@ bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
 
                 _ephemeralACScripts[scriptAssignment->getUUID()] = formData[0].second;
 
-                // add the script assigment to the assignment queue
+                // add the script assignment to the assignment queue
                 SharedAssignmentPointer sharedScriptedAssignment(scriptAssignment);
                 _unfulfilledAssignments.enqueue(sharedScriptedAssignment);
                 _allAssignments.insert(sharedScriptedAssignment->getUUID(), sharedScriptedAssignment);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -68,6 +68,7 @@
 #include <InfoView.h>
 #include <input-plugins/InputPlugin.h>
 #include <controllers/UserInputMapper.h>
+#include <controllers/ScriptingInterface.h>
 #include <controllers/StateController.h>
 #include <UserActivityLoggerScriptingInterface.h>
 #include <LogHandler.h>
@@ -4918,6 +4919,10 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     scriptEngine->registerGlobalObject("Users", DependencyManager::get<UsersScriptingInterface>().data());
 
     scriptEngine->registerGlobalObject("Steam", new SteamScriptingInterface(scriptEngine));
+
+    auto scriptingInterface = DependencyManager::get<controller::ScriptingInterface>();
+    scriptEngine->registerGlobalObject("Controller", scriptingInterface.data());
+    UserInputMapper::registerControllerTypes(scriptEngine);
 }
 
 bool Application::canAcceptURL(const QString& urlString) const {

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -536,8 +536,13 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
     QUuid domainUUID;
     packetStream >> domainUUID;
 
+    // pull our owner UUID from the packet, it's always the first thing
+    QUuid newUUID;
+    packetStream >> newUUID;
+
     // if this was the first domain-server list from this domain, we've now connected
     if (!_domainHandler.isConnected()) {
+        setSessionUUID(newUUID);
         _domainHandler.setUUID(domainUUID);
         _domainHandler.setIsConnected(true);
 
@@ -548,12 +553,9 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
         // Recieved packet from different domain.
         qWarning() << "IGNORING DomainList packet from" << domainUUID << "while connected to" << _domainHandler.getUUID();
         return;
+    } else {
+        setSessionUUID(newUUID);
     }
-
-    // pull our owner UUID from the packet, it's always the first thing
-    QUuid newUUID;
-    packetStream >> newUUID;
-    setSessionUUID(newUUID);
 
     // pull the permissions/right/privileges for this node out of the stream
     NodePermissions newPermissions;

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -517,10 +517,6 @@ void ScriptEngine::init() {
     // constants
     globalObject().setProperty("TREE_SCALE", newVariant(QVariant(TREE_SCALE)));
 
-    auto scriptingInterface = DependencyManager::get<controller::ScriptingInterface>();
-    registerGlobalObject("Controller", scriptingInterface.data());
-    UserInputMapper::registerControllerTypes(this);
-
     auto recordingInterface = DependencyManager::get<RecordingScriptingInterface>();
     registerGlobalObject("Recording", recordingInterface.data());
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -166,7 +166,7 @@ public:
     void setUserLoaded(bool isUserLoaded) { _isUserLoaded = isUserLoaded; }
     bool isUserLoaded() const { return _isUserLoaded; }
 
-    // NOTE - this is used by the TypedArray implemetation. we need to review this for thread safety
+    // NOTE - this is used by the TypedArray implementation. we need to review this for thread safety
     ArrayBufferClass* getArrayBufferClass() { return _arrayBufferClass; }
 
     void setEmitScriptUpdatesFunction(std::function<bool()> func) { _emitScriptUpdates = func; }


### PR DESCRIPTION
- Sets the SessionUUID before emitting the connectedToDomain signal
     - Could potentially fix multiple issues, but confirmed to fix https://highfidelity.fogbugz.com/f/cases/1768/Agent-AC-fails-to-grab-script-added-from-DS-assignment-run-page
- Fix warning message in assignment clients: `DependencyManager::get(): No instance available for class controller::ScriptingInterface`
- Spelling fixes

## Testing plan:
- Smoke test (make sure to test on your own Sandbox or Standalone Server)
- Test run an assignment script (One comes by default with a clean Sandbox install (ACAudioSearchAndInject.js comes by default, it should make the looping sounds in your Sandbox play, like the fire-crackling)
- Test if the most common defaultScripts still work as expected.