### PR TITLE
Even lower audio latency

### DIFF
--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -87,7 +87,7 @@ public:
         AudioOutputIODevice(MixedProcessedAudioStream& receivedAudioStream, AudioClient* audio) :
             _receivedAudioStream(receivedAudioStream), _audio(audio), _unfulfilledReads(0) {};
 
-        void start() { open(QIODevice::ReadOnly); }
+        void start() { open(QIODevice::ReadOnly | QIODevice::Unbuffered); }
         void stop() { close(); }
         qint64 readData(char * data, qint64 maxSize) override;
         qint64 writeData(const char * data, qint64 maxSize) override { return 0; }


### PR DESCRIPTION
In Qt5.6, manually opening a QIODevice will default to new buffered-mode access. For audio output, this inserts a 16KB buffer between the low-level audio callback and refills requested by QIODevice. resulting in added latency. It is now forced to unbuffered mode. Input and loopback audio were unaffected.