### PR TITLE
Expose triggerOption to scripts, plus _physicsEnabled

### DIFF
--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -125,3 +125,8 @@ void MenuScriptingInterface::setIsOptionChecked(const QString& menuOption, bool 
                 Q_ARG(const QString&, menuOption),
                 Q_ARG(bool, isChecked));
 }
+
+void MenuScriptingInterface::triggerOption(const QString& menuOption) {
+    QMetaObject::invokeMethod(Menu::getInstance(), "triggerOption", Q_ARG(const QString&, menuOption));    
+}
+

--- a/interface/src/scripting/MenuScriptingInterface.h
+++ b/interface/src/scripting/MenuScriptingInterface.h
@@ -48,6 +48,8 @@ public slots:
     
     bool isOptionChecked(const QString& menuOption);
     void setIsOptionChecked(const QString& menuOption, bool isChecked);
+
+    void triggerOption(const QString& menuOption);
     
 signals:
     void menuItemEvent(const QString& menuItem);

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -206,3 +206,7 @@ void WindowScriptingInterface::takeSnapshot(bool notify, float aspectRatio) {
 void WindowScriptingInterface::shareSnapshot(const QString& path) {
     qApp->shareSnapshot(path);
 }
+
+bool WindowScriptingInterface::isPhysicsEnabled() {
+    return qApp->isPhysicsEnabled();
+}

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -54,6 +54,7 @@ public slots:
     void copyToClipboard(const QString& text);
     void takeSnapshot(bool notify = true, float aspectRatio = 0.0f);
     void shareSnapshot(const QString& path);
+    bool isPhysicsEnabled();
 
 signals:
     void domainChanged(const QString& domainHostname);

--- a/libraries/ui/src/ui/Menu.h
+++ b/libraries/ui/src/ui/Menu.h
@@ -62,7 +62,6 @@ public:
     MenuWrapper* getMenu(const QString& menuName);
     MenuWrapper* getSubMenuFromName(const QString& menuName, MenuWrapper* menu);
 
-    void triggerOption(const QString& menuOption);
     QAction* getActionForOption(const QString& menuOption);
 
     QAction* addActionToQMenuAndActionHash(MenuWrapper* destinationMenu,
@@ -112,6 +111,8 @@ public slots:
 
     void toggleDeveloperMenus();
     void toggleAdvancedMenus();
+    
+    void triggerOption(const QString& menuOption);
 
     static bool isSomeSubmenuShown() { return _isSomeSubmenuShown; }
 


### PR DESCRIPTION
Now any menu item can be triggered, so you can do `Menu.triggerOption("Reload content (Clears all caches))"` or `Window.isPhysicsEnabled()`.  Allows our domain load test scripts to clear caches, detect when things have loaded.  