### PR TITLE
fix crash in scripted timer on shutdown

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1017,9 +1017,12 @@ void ScriptEngine::updateMemoryCost(const qint64& deltaSize) {
 }
 
 void ScriptEngine::timerFired() {
-    if (DependencyManager::get<ScriptEngines>()->isStopped()) {
-        qCDebug(scriptengine) << "Script.timerFired() while shutting down is ignored... parent script:" << getFilename();
-        return; // bail early
+    {
+        auto engine = DependencyManager::get<ScriptEngines>();
+        if (!engine || engine->isStopped()) {
+            qCDebug(scriptengine) << "Script.timerFired() while shutting down is ignored... parent script:" << getFilename();
+            return; // bail early
+        }
     }
 
     QTimer* callingTimer = reinterpret_cast<QTimer*>(sender());


### PR DESCRIPTION
ScriptEngines is destroyed immediately after shutdownScripting, so there is a window in which a scripted timer can fire in which the ScriptEngine::isStopped() test is tried on a null pointer, causing a crash. This fixes it.