### PR TITLE
Don't use GL functions before making the context current

### DIFF
--- a/libraries/gl/src/gl/GLWidget.cpp
+++ b/libraries/gl/src/gl/GLWidget.cpp
@@ -67,8 +67,8 @@ void GLWidget::createContext() {
     _context = new gl::Context();
     _context->setWindow(windowHandle());
     _context->create();
-    _context->clear();
     _context->makeCurrent();
+    _context->clear();
 }
 
 bool GLWidget::makeCurrent() {


### PR DESCRIPTION
We're calling a bunch of GL functions and a buffer swap without an active context.  This may be corrupting memory, depending on the GL driver in use.  

