### PR TITLE
Restore "Are you sure?" pop-up. Default to "No"

### DIFF
--- a/server-console/src/content-update.css
+++ b/server-console/src/content-update.css
@@ -124,6 +124,7 @@ a:hover {
    overflow: hidden;
    float: left;
    position: relative;
+   word-wrap: break-word;
 
 }
 .col2 {

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -577,12 +577,21 @@ function checkNewContent() {
                   title: 'New home content',
                   message: 'A newer version of the home content set is available.\nDo you wish to update?'
               }, function(idx) {
-                if (idx === 0) {
-                  backupResourceDirectoriesAndRestart();
-                } else {
-                  // They don't want to update, mark content set as current
-                  userConfig.set('homeContentLastModified', new Date());
-                }
+                  if (idx === 0) {
+                      dialog.showMessageBox({
+                          type: 'warning',
+                          buttons: ['Yes', 'No'],
+                          title: 'Are you sure?',
+                          message: 'Updating with the new content will remove all your current content and settings and place them in a backup folder.\nAre you sure?'
+                      }, function(idx) {
+                          if (idx === 0) {
+                              backupResourceDirectoriesAndRestart();
+                          }
+                      });
+                  } else {
+                      // They don't want to update, mark content set as current
+                      userConfig.set('homeContentLastModified', new Date());
+                  }
               });
             }
         }

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -575,16 +575,20 @@ function checkNewContent() {
                   type: 'question',
                   buttons: ['Yes', 'No'],
                   defaultId: 1,
+                  cancelId: 1,
                   title: 'New home content',
-                  message: 'A newer version of the home content set is available.\nDo you wish to update?'
+                  message: 'A newer version of the home content set is available.\nDo you wish to update?',
+                  noLink: true,
               }, function(idx) {
                   if (idx === 0) {
                       dialog.showMessageBox({
                           type: 'warning',
                           buttons: ['Yes', 'No'],
                           defaultId: 1,
+                          cancelId: 1,
                           title: 'Are you sure?',
-                          message: 'Updating with the new content will remove all your current content and settings and place them in a backup folder.\nAre you sure?'
+                          message: 'Updating with the new content will remove all your current content and settings and place them in a backup folder.\nAre you sure?',
+                          noLink: true,
                       }, function(idx) {
                           if (idx === 0) {
                               backupResourceDirectoriesAndRestart();

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -574,6 +574,7 @@ function checkNewContent() {
               dialog.showMessageBox({
                   type: 'question',
                   buttons: ['Yes', 'No'],
+                  defaultId: 1,
                   title: 'New home content',
                   message: 'A newer version of the home content set is available.\nDo you wish to update?'
               }, function(idx) {
@@ -581,6 +582,7 @@ function checkNewContent() {
                       dialog.showMessageBox({
                           type: 'warning',
                           buttons: ['Yes', 'No'],
+                          defaultId: 1,
                           title: 'Are you sure?',
                           message: 'Updating with the new content will remove all your current content and settings and place them in a backup folder.\nAre you sure?'
                       }, function(idx) {


### PR DESCRIPTION
- Restores the "Are you sure?" pop on Sandbox content update with clear explanations of what will happen.
- Default choices to "No" on each pop up to ensure no accidental updates. 