### PR TITLE
make calculateTextureInfo thread safe

### DIFF
--- a/libraries/model/src/model/Material.h
+++ b/libraries/model/src/model/Material.h
@@ -11,6 +11,8 @@
 #ifndef hifi_model_Material_h
 #define hifi_model_Material_h
 
+#include <QMutex>
+
 #include <bitset>
 #include <map>
 
@@ -324,7 +326,7 @@ public:
 
     // The texture map to channel association
     void setTextureMap(MapChannel channel, const TextureMapPointer& textureMap);
-    const TextureMaps& getTextureMaps() const { return _textureMaps; }
+    const TextureMaps& getTextureMaps() const { return _textureMaps; } // FIXME - not thread safe... 
     const TextureMapPointer getTextureMap(MapChannel channel) const;
 
     // Albedo maps cannot have opacity detected until they are loaded
@@ -344,12 +346,25 @@ public:
     };
 
     const UniformBufferView& getTexMapArrayBuffer() const { return _texMapArrayBuffer; }
+
+    int getTextureCount() const { calculateMaterialInfo(); return _textureCount; }
+    size_t getTextureSize()  const { calculateMaterialInfo(); return _textureSize; }
+    bool hasTextureInfo() const { return _hasCalculatedTextureInfo; }
+
 private:
     mutable MaterialKey _key;
     mutable UniformBufferView _schemaBuffer;
     mutable UniformBufferView _texMapArrayBuffer;
 
     TextureMaps _textureMaps;
+
+    mutable QMutex _textureMapsMutex { QMutex::Recursive };
+    mutable size_t _textureSize { 0 };
+    mutable int _textureCount { 0 };
+    mutable bool _hasCalculatedTextureInfo { false };
+    bool calculateMaterialInfo() const;
+
+
 };
 typedef std::shared_ptr< Material > MaterialPointer;
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -71,38 +71,7 @@ void MeshPartPayload::updateTransform(const Transform& transform, const Transfor
 
 void MeshPartPayload::updateMaterial(model::MaterialPointer drawMaterial) {
     _drawMaterial = drawMaterial;
-    calculateMaterialSize();
 }
-
-bool MeshPartPayload::calculateMaterialSize() {
-    bool allTextures = true; // assume we got this...
-    _materialTextureSize = 0;
-    _materialTextureCount = 0;
-    auto textureMaps = _drawMaterial->getTextureMaps();
-    for (auto const &textureMapItem : textureMaps) {
-        auto textureMap = textureMapItem.second;
-        if (textureMap) {
-            auto textureSoure = textureMap->getTextureSource();
-            if (textureSoure) {
-                auto texture = textureSoure->getGPUTexture();
-                if (texture) {
-                    //auto storedSize = texture->getStoredSize();
-                    auto size = texture->getSize();
-                    _materialTextureSize += size;
-                    _materialTextureCount++;
-                } else {
-                    allTextures = false;
-                }
-            } else {
-                allTextures = false;
-            }
-        } else {
-            allTextures = false;
-        }
-    }
-    return allTextures;
-}
-
 
 ItemKey MeshPartPayload::getKey() const {
     ItemKey::Builder builder;
@@ -378,7 +347,6 @@ void ModelMeshPartPayload::initCache() {
     auto networkMaterial = _model->getGeometry()->getShapeMaterial(_shapeID);
     if (networkMaterial) {
         _drawMaterial = networkMaterial;
-        calculateMaterialSize();
     }
 }
 

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -66,13 +66,9 @@ public:
     bool _hasColorAttrib = false;
 
     size_t getVerticesCount() const { return _drawMesh ? _drawMesh->getNumVertices() : 0; }
-    size_t getMaterialTextureSize() { return _materialTextureSize; }
-    int getMaterialTextureCount() { return _materialTextureCount; }
-    bool calculateMaterialSize();
-
-protected:
-    size_t _materialTextureSize { 0 };
-    int _materialTextureCount { 0 };
+    size_t getMaterialTextureSize() { return _drawMaterial ? _drawMaterial->getTextureSize() : 0; }
+    int getMaterialTextureCount() { return _drawMaterial ? _drawMaterial->getTextureCount() : 0; }
+    bool hasTextureInfo() const { return _drawMaterial ? _drawMaterial->hasTextureInfo() : false; }
 };
 
 namespace render {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -168,10 +168,9 @@ void Model::calculateTextureInfo() {
         bool allTexturesLoaded = true;
         foreach(auto renderItem, _modelMeshRenderItemsSet) {
             auto meshPart = renderItem.get();
-            bool allTexturesForThisMesh = meshPart->calculateMaterialSize();
-            allTexturesLoaded = allTexturesLoaded & allTexturesForThisMesh;
             textureSize += meshPart->getMaterialTextureSize();
             textureCount += meshPart->getMaterialTextureCount();
+            allTexturesLoaded = allTexturesLoaded & meshPart->hasTextureInfo();
         }
         _renderInfoTextureSize = textureSize;
         _renderInfoTextureCount = textureCount;


### PR DESCRIPTION
Fixes crashes in calculateMaterialSize... which could be caused by scripts getting properties, while textures are being loaded or set from other threads.