### PR TITLE
Fix the crash on start up if default ambient map fails to load

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4361,8 +4361,12 @@ namespace render {
                     auto scene = DependencyManager::get<SceneScriptingInterface>()->getStage();
                     auto sceneKeyLight = scene->getKeyLight();
                     auto defaultSkyboxAmbientTexture = qApp->getDefaultSkyboxAmbientTexture();
-                    sceneKeyLight->setAmbientSphere(defaultSkyboxAmbientTexture->getIrradiance());
-                    sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
+                    if (defaultSkyboxAmbientTexture) {
+                        sceneKeyLight->setAmbientSphere(defaultSkyboxAmbientTexture->getIrradiance());
+                        sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
+                    } else {
+                        qWarning() << "Failed to get a valid Default SKybox Ambient Texture ? probably because it couldn't be find during initialization step";
+                    }
                     // fall through: render defaults skybox
                 } else {
                     break;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4365,7 +4365,9 @@ namespace render {
                         sceneKeyLight->setAmbientSphere(defaultSkyboxAmbientTexture->getIrradiance());
                         sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
                     } else {
-                        qWarning() << "Failed to get a valid Default SKybox Ambient Texture ? probably because it couldn't be find during initialization step";
+                        static QString repeatedMessage
+                            = LogHandler::getInstance().addRepeatedMessageRegex(
+                            "Failed to get a valid Default Skybox Ambient Texture ? probably because it couldn't be find during initialization step");
                     }
                     // fall through: render defaults skybox
                 } else {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2170,7 +2170,7 @@ bool Application::event(QEvent* event) {
     // handle custom URL
     if (event->type() == QEvent::FileOpen) {
 
-		QFileOpenEvent* fileEvent = static_cast<QFileOpenEvent*>(event);
+        QFileOpenEvent* fileEvent = static_cast<QFileOpenEvent*>(event);
 
         QUrl url = fileEvent->url();
 
@@ -4365,8 +4365,7 @@ namespace render {
                         sceneKeyLight->setAmbientSphere(defaultSkyboxAmbientTexture->getIrradiance());
                         sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
                     } else {
-                        static QString repeatedMessage
-                            = LogHandler::getInstance().addRepeatedMessageRegex(
+                        static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex(
                             "Failed to get a valid Default Skybox Ambient Texture ? probably because it couldn't be find during initialization step");
                     }
                     // fall through: render defaults skybox

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -511,9 +511,7 @@ void GL45Texture::stripToMip(uint16_t newMinMip) {
     _minMip = newMinMip;
     // Re-sync the sampler to force access to the new mip level
     syncSampler();
-    size_t oldSize = _size;
     updateSize();
-    Q_ASSERT(_size > oldSize);
 
 
     // Re-insert into the texture-by-mips map if appropriate


### PR DESCRIPTION
THis is fogbuz #1776
https://highfidelity.fogbugz.com/f/cases/1776/Crash-in-interface-model-SunSkyStage-setSunAmbientSphere

In case the default ambient map is not loaded properly, then itdoesn;t exist.
THe crashing call was using the defaultAMbienMap pointer assuming it was existing.
I added a check for it.

Removed an assert in GL45BackendTexture that was triggering for the wrong reason in debug