### PR TITLE
Remove frame lag and jitter from near grabbed physical objects.

### DIFF
--- a/interface/src/avatar/AvatarActionHold.h
+++ b/interface/src/avatar/AvatarActionHold.h
@@ -15,6 +15,7 @@
 #include <QUuid>
 
 #include <EntityItem.h>
+#include <AnimPose.h>
 #include <ObjectActionSpring.h>
 
 #include "avatar/MyAvatar.h"
@@ -40,6 +41,8 @@ public:
                            glm::vec3& linearVelocity, glm::vec3& angularVelocity) override;
 
     virtual void prepareForPhysicsSimulation() override;
+
+    void lateAvatarUpdate(const AnimPose& prePhysicsRoomPose, const AnimPose& postAvatarUpdateRoomPose);
 
 private:
     void doKinematicUpdate(float deltaTimeStep);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -26,6 +26,7 @@
 #include "MyCharacterController.h"
 #include <ThreadSafeValueCache.h>
 
+class AvatarActionHold;
 class ModelItemID;
 
 enum DriveKeys {
@@ -277,6 +278,10 @@ public:
     virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
     virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
+    void addHoldAction(AvatarActionHold* holdAction);  // thread-safe
+    void removeHoldAction(AvatarActionHold* holdAction);  // thread-safe
+    void updateHoldActions(const AnimPose& prePhysicsPose, const AnimPose& postUpdatePose);
+
 public slots:
     void increaseSize();
     void decreaseSize();
@@ -487,6 +492,10 @@ private:
     ThreadSafeValueCache<controller::Pose> _rightHandControllerPoseInSensorFrameCache { controller::Pose() };
 
     bool _hmdLeanRecenterEnabled = true;
+
+    AnimPose _prePhysicsRoomPose;
+    std::mutex _holdActionsMutex;
+    std::vector<AvatarActionHold*> _holdActions;
 
     float AVATAR_MOVEMENT_ENERGY_CONSTANT { 0.001f };
     float AUDIO_ENERGY_CONSTANT { 0.000001f };


### PR DESCRIPTION
In the game loop, physics occurs before avatar update.  Before this PR, when the avatar is moved during avatar update, near grabbed objects will not pick up this move until one frame later, when the physics is run on the next update.

After this PR, near grabbed objects are adjusted to reflect any position or rotation change that occurred during the avatar update.  This removes lag and jitter in the motion of held objects during driving and re-centering.