### PR TITLE
avatar snaps to HMD position when possible after large displacement

### DIFF
--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -209,7 +209,6 @@ bool CharacterController::checkForSupport(btCollisionWorld* collisionWorld, btSc
             if (stepContactIndex > -1 && highestStep > stepHeight) {
                 // remember step info for later
                 btManifoldPoint& contact = contactManifold->getContactPoint(stepContactIndex);
-                btVector3 pointOnCharacter = characterIsFirst ? contact.m_localPointA : contact.m_localPointB; // object-local-frame
                 btVector3 normal = characterIsFirst ? contact.m_normalWorldOnB : -contact.m_normalWorldOnB; // points toward character
                 stepHeight = highestStep;
                 stepNormal = normal;

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -870,9 +870,10 @@ void CharacterController::setMoveKinematically(bool kinematic) {
 bool CharacterController::queryPenetration(const btTransform& transform) {
     btVector3 minBox;
     btVector3 maxBox;
-    _ghost.queryPenetration(transform, minBox, maxBox);
-    btVector3 penetration = maxBox;
-    penetration.setMax(minBox.absolute());
+    _ghost.setWorldTransform(transform);
+    _ghost.measurePenetration(minBox, maxBox);
+    btVector3 penetration = minBox;
+    penetration.setMax(maxBox.absolute());
     const btScalar MIN_PENETRATION_SQUARED = 0.0016f; // 0.04^2
     return penetration.length2() < MIN_PENETRATION_SQUARED;
 }

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -857,3 +857,13 @@ void CharacterController::setMoveKinematically(bool kinematic) {
         _ghost.setMotorOnly(!_moveKinematically);
     }
 }
+
+bool CharacterController::queryPenetration(const btTransform& transform) {
+    btVector3 minBox;
+    btVector3 maxBox;
+    _ghost.queryPenetration(transform, minBox, maxBox);
+    btVector3 penetration = maxBox;
+    penetration.setMax(minBox.absolute());
+    const btScalar MIN_PENETRATION_SQUARED = 0.0016f; // 0.04^2
+    return penetration.length2() > MIN_PENETRATION_SQUARED;
+}

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -119,6 +119,8 @@ public:
     float measureMaxHipsOffsetRadius(const glm::vec3& currentHipsOffset, float maxSweepDistance);
     void setMoveKinematically(bool kinematic); // KINEMATIC_CONTROLLER_HACK
 
+    bool queryPenetration(const btTransform& transform);
+
 protected:
 #ifdef DEBUG_STATE_CHANGE
     void setState(State state, const char* reason);

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -165,13 +165,6 @@ protected:
     quint32 _jumpButtonDownCount;
     quint32 _takeoffJumpButtonID;
 
-    // data for walking up steps
-    btVector3 _stepPoint;
-    btVector3 _stepNormal;
-    btScalar _stepHeight { 0.0f };
-    btScalar _minStepHeight { 0.0f };
-    btScalar _maxStepHeight { 0.0f };
-
     btScalar _halfHeight { 0.0f };
     btScalar _radius { 0.0f };
 

--- a/libraries/physics/src/CharacterGhostObject.cpp
+++ b/libraries/physics/src/CharacterGhostObject.cpp
@@ -242,17 +242,11 @@ bool CharacterGhostObject::sweepTest(
     return false;
 }
 
-void CharacterGhostObject::queryPenetration(const btTransform& transform, btVector3& minBoxOut, btVector3& maxBoxOut) {
-    // place in world and refresh overlapping pairs
-    setWorldTransform(transform);
-    measurePenetration(minBoxOut, maxBoxOut);
-}
-
 void CharacterGhostObject::measurePenetration(btVector3& minBoxOut, btVector3& maxBoxOut) {
     // minBoxOut and maxBoxOut will be updated with penetration envelope.
-    // If one of the points is at <0,0,0> then the penetration may be resolvable in a single step,
-    // but if the space spanned by those two corners extends in both directions along at least one
-    // component then this object is sandwiched between two opposing objects.
+    // If one of the corner points is <0,0,0> then the penetration is resolvable in a single step,
+    // but if the space spanned by the two corners extends in both directions along at least one
+    // component then we the object is sandwiched between two opposing objects.
 
     // We assume this object has just been moved to its current location, or else objects have been
     // moved around it since the last step so we must update the overlapping pairs.

--- a/libraries/physics/src/CharacterGhostObject.h
+++ b/libraries/physics/src/CharacterGhostObject.h
@@ -59,6 +59,9 @@ public:
     bool isSteppingUp() const { return _steppingUp; }
     const btVector3& getFloorNormal() const { return _floorNormal; }
 
+    void queryPenetration(const btTransform& transform, btVector3& minBoxOut, btVector3& maxBoxOut);
+    void measurePenetration(btVector3& minBoxOut, btVector3& maxBoxOut);
+
 protected:
     void removeFromWorld();
     void addToWorld();

--- a/libraries/physics/src/CharacterGhostObject.h
+++ b/libraries/physics/src/CharacterGhostObject.h
@@ -59,7 +59,6 @@ public:
     bool isSteppingUp() const { return _steppingUp; }
     const btVector3& getFloorNormal() const { return _floorNormal; }
 
-    void queryPenetration(const btTransform& transform, btVector3& minBoxOut, btVector3& maxBoxOut);
     void measurePenetration(btVector3& minBoxOut, btVector3& maxBoxOut);
 
 protected:


### PR DESCRIPTION
* after large displacement between Avatar and its target position according to HMD check if teleport would not introduce significant penetration and if so do it
* also: prevent high vertical velocity when walking up steps and ledges