### PR TITLE
Remove QML threaded rendering

### DIFF
--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -116,21 +116,6 @@ QNetworkAccessManager* QmlNetworkAccessManagerFactory::create(QObject* parent) {
 Q_DECLARE_LOGGING_CATEGORY(offscreenFocus)
 Q_LOGGING_CATEGORY(offscreenFocus, "hifi.offscreen.focus")
 
-#if 0
-QJsonObject getGLContextData();
-QJsonObject _glData;
-
-QJsonObject OffscreenQmlSurface::getGLContextData() {
-    _glMutex.lock();
-    if (_glData.isEmpty()) {
-        _glWait.wait(&_glMutex);
-    }
-    _glMutex.unlock();
-    return _glData;
-}
-#endif
-
-
 void OffscreenQmlSurface::setupFbo() {
     _canvas->makeCurrent();
     _textures.setSize(_size);
@@ -324,7 +309,7 @@ void OffscreenQmlSurface::create(QOpenGLContext* shareContext) {
     }
 
     // FIXME 
-//    _qmlEngine->rootContext()->setContextProperty("GL", _renderer->getGLContextData());
+    _qmlEngine->rootContext()->setContextProperty("GL", _glData);
     _qmlEngine->rootContext()->setContextProperty("offscreenWindow", QVariant::fromValue(getWindow()));
     _qmlComponent = new QQmlComponent(_qmlEngine);
 
@@ -336,6 +321,7 @@ void OffscreenQmlSurface::create(QOpenGLContext* shareContext) {
         qWarning("Failed to make context current for QML Renderer");
         return;
     }
+    _glData = ::getGLContextData();
     _renderControl->initialize(_canvas->getContext());
     setupFbo();
 

--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -98,8 +98,8 @@ private:
     void setupFbo();
     bool allowNewFrame(uint8_t fps);
     void render();
-    void resize();
     void cleanup();
+    QJsonObject getGLContextData();
 
 private slots:
     void updateQuick();
@@ -112,6 +112,8 @@ private:
     QQmlComponent* _qmlComponent { nullptr };
     QQuickItem* _rootItem { nullptr };
     OffscreenGLCanvas* _canvas { nullptr };
+    QJsonObject _glData;
+
     QTimer _updateTimer;
     uint32_t _fbo { 0 };
     uint32_t _depthStencil { 0 };

--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -9,10 +9,13 @@
 #ifndef hifi_OffscreenQmlSurface_h
 #define hifi_OffscreenQmlSurface_h
 
-#include <QTimer>
-#include <QUrl>
 #include <atomic>
 #include <functional>
+
+#include <QtCore/QJsonObject>
+#include <QTimer>
+#include <QUrl>
+
 
 #include <GLMHelpers.h>
 #include <ThreadHelpers.h>

--- a/libraries/gl/src/gl/TextureRecycler.cpp
+++ b/libraries/gl/src/gl/TextureRecycler.cpp
@@ -1,0 +1,83 @@
+//
+//  Created by Bradley Austin Davis on 2016-10-05
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#include "TextureRecycler.h"
+#include "Config.h"
+
+#include <set>
+
+
+void TextureRecycler::setSize(const uvec2& size) {
+    if (size == _size) {
+        return;
+    }
+    _size = size;
+    while (!_readyTextures.empty()) {
+        _readyTextures.pop();
+    }
+    std::set<Map::key_type> toDelete;
+    std::for_each(_allTextures.begin(), _allTextures.end(), [&](Map::const_reference item) {
+        if (!item.second._active && item.second._size != _size) {
+            toDelete.insert(item.first);
+        }
+    });
+    std::for_each(toDelete.begin(), toDelete.end(), [&](Map::key_type key) {
+        _allTextures.erase(key);
+    });
+}
+
+void TextureRecycler::clear() {
+    while (!_readyTextures.empty()) {
+        _readyTextures.pop();
+    }
+    _allTextures.clear();
+}
+
+uint32_t TextureRecycler::getNextTexture() {
+    if (_readyTextures.empty()) {
+        uint32_t newTexture;
+        glGenTextures(1, &newTexture);
+        glBindTexture(GL_TEXTURE_2D, newTexture);
+        if (_useMipmaps) {
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+        } else {
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        }
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 8.0f);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.2f);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 8.0f); 
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, _size.x, _size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+        _allTextures.emplace(std::piecewise_construct, std::forward_as_tuple(newTexture), std::forward_as_tuple(newTexture, _size));
+        _readyTextures.push(newTexture);
+    }
+
+    uint32_t result = _readyTextures.front();
+    _readyTextures.pop();
+    auto& item = _allTextures[result];
+    item._active = true;
+    return result;
+}
+
+void TextureRecycler::recycleTexture(GLuint texture) {
+    Q_ASSERT(_allTextures.count(texture));
+    auto& item = _allTextures[texture];
+    Q_ASSERT(item._active);
+    item._active = false;
+    if (item._size != _size) {
+        // Buh-bye
+        _allTextures.erase(texture);
+        return;
+    }
+
+    _readyTextures.push(item._tex);
+}
+

--- a/libraries/gl/src/gl/TextureRecycler.h
+++ b/libraries/gl/src/gl/TextureRecycler.h
@@ -1,0 +1,47 @@
+//
+//  Created by Bradley Austin Davis on 2015-04-04
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#pragma once
+#ifndef hifi_TextureRecycler_h
+#define hifi_TextureRecycler_h
+
+#include <atomic>
+#include <queue>
+#include <map>
+
+#include <GLMHelpers.h>
+
+class TextureRecycler {
+public:
+    TextureRecycler(bool useMipmaps) : _useMipmaps(useMipmaps) {}
+    void setSize(const uvec2& size);
+    void clear();
+    uint32_t getNextTexture();
+    void recycleTexture(uint32_t texture);
+
+private:
+
+    struct TexInfo {
+        const uint32_t _tex{ 0 };
+        const uvec2 _size;
+        bool _active { false };
+
+        TexInfo() {}
+        TexInfo(uint32_t tex, const uvec2& size) : _tex(tex), _size(size) {}
+        TexInfo(const TexInfo& other) : _tex(other._tex), _size(other._size) {}
+    };
+
+    using Map = std::map<uint32_t, TexInfo>;
+    using Queue = std::queue<uint32_t>;
+
+    Map _allTextures;
+    Queue _readyTextures;
+    uvec2 _size{ 1920, 1080 };
+    bool _useMipmaps;
+};
+
+#endif


### PR DESCRIPTION
Now that primary rendering is no longer on the main thread, the driving force behind moving QML rendering off the main thread is gone.  By moving QML rendering back to the main thread, we should reduce the total number of threads executing content as well as potential concurrent OpenGL context work.  This should have a positive impact on systems that are thread constrained, like i5 based computers.

## Testing

Application behavior should be unchanged.  There may be a slight performance improvement / less stuttering on core-constrained systems.