### PR TITLE
init the accumulator for script elapsed time

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -849,7 +849,7 @@ void ScriptEngine::run() {
 
     _lastUpdate = usecTimestampNow();
 
-    std::chrono::microseconds totalUpdates;
+    std::chrono::microseconds totalUpdates(0);
 
     // TODO: Integrate this with signals/slots instead of reimplementing throttling for ScriptEngine
     while (!_isFinished) {


### PR DESCRIPTION
On Mac and Windows (and maybe even Linux Interface) this doesn't matter.
But on Linux/ubuntu/assignment-client, it initialized with a large value causing the bad-script-punisher to sleep forever on ac agents rather than issuing ScriptEngine::update and all the agent processing that is dependent on it.