### PR TITLE
openvr deadlock and crash on exit fixes

### DIFF
--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -124,7 +124,6 @@ void HmdDisplayPlugin::uncustomizeContext() {
         batch.setFramebuffer(_compositeFramebuffer);
         batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, vec4(0));
     });
-    internalPresent();
     _overlayRenderer = OverlayRenderer();
     Parent::uncustomizeContext();
 }

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -127,7 +127,7 @@ const gpu::TexturePointer& TextureCache::getGrayTexture() {
     if (!_grayTexture) {
         _grayTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, 1, 1));
         _grayTexture->setSource("TextureCache::_grayTexture");
-        _grayTexture->assignStoredMip(0, _whiteTexture->getTexelFormat(), sizeof(OPAQUE_WHITE), OPAQUE_GRAY);
+        _grayTexture->assignStoredMip(0, _grayTexture->getTexelFormat(), sizeof(OPAQUE_GRAY), OPAQUE_GRAY);
     }
     return _grayTexture;
 }
@@ -145,7 +145,7 @@ const gpu::TexturePointer& TextureCache::getBlackTexture() {
     if (!_blackTexture) {
         _blackTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, 1, 1));
         _blackTexture->setSource("TextureCache::_blackTexture");
-        _blackTexture->assignStoredMip(0, _whiteTexture->getTexelFormat(), sizeof(OPAQUE_BLACK), OPAQUE_BLACK);
+        _blackTexture->assignStoredMip(0, _blackTexture->getTexelFormat(), sizeof(OPAQUE_BLACK), OPAQUE_BLACK);
     }
     return _blackTexture;
 }

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -59,7 +59,7 @@ private:
 
     QString _targetName;
     bool _shouldOutputProcessID { false };
-    bool _shouldOutputThreadID { false };
+    bool _shouldOutputThreadID { true };
     bool _shouldDisplayMilliseconds { false };
     QSet<QString> _repeatedMessageRegexes;
     QHash<QString, int> _repeatMessageCountHash;

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -59,7 +59,7 @@ private:
 
     QString _targetName;
     bool _shouldOutputProcessID { false };
-    bool _shouldOutputThreadID { true };
+    bool _shouldOutputThreadID { false };
     bool _shouldDisplayMilliseconds { false };
     QSet<QString> _repeatedMessageRegexes;
     QHash<QString, int> _repeatMessageCountHash;

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -61,6 +61,11 @@ void OculusBaseDisplayPlugin::customizeContext() {
     Parent::customizeContext();
 }
 
+void OculusBaseDisplayPlugin::uncustomizeContext() {
+    Parent::uncustomizeContext();
+    internalPresent();
+}
+
 bool OculusBaseDisplayPlugin::internalActivate() {
     _session = acquireOculusSession();
     if (!_session) {

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.h
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.h
@@ -26,6 +26,7 @@ public:
 
 protected:
     void customizeContext() override;
+    void uncustomizeContext() override;
     bool internalActivate() override;
     void internalDeactivate() override;
     void updatePresentPose() override;

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -103,6 +103,15 @@ void releaseOpenVrSystem() {
             #if DEV_BUILD
                 qCDebug(displayplugins) << "OpenVR: zero refcount, deallocate VR system";
             #endif
+
+            // HACK: workaround openvr crash, call submit right before VR_Shutdown.
+            const GLuint NON_ZERO_GL_TEXTURE_HANDLE = 1;
+            vr::Texture_t vrTexture{ (void*)NON_ZERO_GL_TEXTURE_HANDLE, vr::API_OpenGL, vr::ColorSpace_Auto };
+            static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_LEFT{ 0, 0, 0.5f, 1 };
+            static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_RIGHT{ 0.5f, 0, 1, 1 };
+            vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
+            vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);
+
             vr::VR_Shutdown();
             _openVrQuitRequested = false;
             activeHmd = nullptr;

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -104,9 +104,9 @@ void releaseOpenVrSystem() {
                 qCDebug(displayplugins) << "OpenVR: zero refcount, deallocate VR system";
             #endif
 
-            // HACK: workaround openvr crash, call submit right before VR_Shutdown.
-            const GLuint NON_ZERO_GL_TEXTURE_HANDLE = 1;
-            vr::Texture_t vrTexture{ (void*)NON_ZERO_GL_TEXTURE_HANDLE, vr::API_OpenGL, vr::ColorSpace_Auto };
+            // HACK: workaround openvr crash, call submit with an invalid texture, right before VR_Shutdown.
+            const GLuint INVALID_GL_TEXTURE_HANDLE = -1;
+            vr::Texture_t vrTexture{ (void*)INVALID_GL_TEXTURE_HANDLE, vr::API_OpenGL, vr::ColorSpace_Auto };
             static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_LEFT{ 0, 0, 0.5f, 1 };
             static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_RIGHT{ 0.5f, 0, 1, 1 };
             vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);


### PR DESCRIPTION
* fixes for deadlock when switching rapidly between desktop and openvr.
* workaround openvr crash on exit by calling submit before calling VR_Shutdown