### PR TITLE
Turn on forced reprojection on i5 systems

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -39,6 +39,10 @@ const QString StandingHMDSensorMode = "Standing HMD Sensor Mode"; // this probab
 PoseData _nextRenderPoseData;
 PoseData _nextSimPoseData;
 
+#define MIN_CORES_FOR_NORMAL_RENDER 5
+bool forceInterleavedReprojection = (QThread::idealThreadCount() < MIN_CORES_FOR_NORMAL_RENDER);
+
+
 static std::array<vr::Hmd_Eye, 2> VR_EYES { { vr::Eye_Left, vr::Eye_Right } };
 bool _openVrDisplayActive { false };
 // Flip y-axis since GL UV coords are backwards.
@@ -399,7 +403,10 @@ bool OpenVrDisplayPlugin::internalActivate() {
     });
 
     // enable async time warp
-    //vr::VRCompositor()->ForceInterleavedReprojectionOn(true);
+    if (forceInterleavedReprojection) {
+        vr::VRCompositor()->ForceInterleavedReprojectionOn(true);
+    }
+    
 
     // set up default sensor space such that the UI overlay will align with the front of the room.
     auto chaperone = vr::VRChaperone();


### PR DESCRIPTION
on core-constrained systems, use forced reprojection to reduce the GPU/CPU contention

## Testing

Should behave the same as the current production build, however, on i5 systems when running on the Vive, the Framerate should drop to 45 rather than trying to hit 90.   The display should still be at least as smooth as the current production build.