### PR TITLE
Fix GPU texture counter, better logging for memory pressure

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
@@ -666,7 +666,6 @@ void GLBackend::recycle() const {
         for (auto pair : externalTexturesTrash) {
             auto fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
             pair.second(pair.first, fence);
-            decrementTextureGPUCount();
         }
     }
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -115,7 +115,7 @@ float GLTexture::getMemoryPressure() {
                 if (freeGpuMemory != lastFreeGpuMemory) {
                     lastFreeGpuMemory = freeGpuMemory;
                     if (freePercentage < MIN_FREE_GPU_MEMORY_PERCENTAGE) {
-                        qDebug() << "Exceeded max GPU memory";
+                        qCDebug(gpugllogging) << "Exceeded min free GPU memory " << freePercentage;
                         return OVER_MEMORY_PRESSURE;
                     }
                 }
@@ -129,7 +129,13 @@ float GLTexture::getMemoryPressure() {
 
     // Return the consumed texture memory divided by the available texture memory.
     auto consumedGpuMemory = Context::getTextureGPUMemoryUsage();
-    return (float)consumedGpuMemory / (float)availableTextureMemory;
+    float memoryPressure = (float)consumedGpuMemory / (float)availableTextureMemory;
+    static Context::Size lastConsumedGpuMemory = 0;
+    if (memoryPressure > 1.0f && lastConsumedGpuMemory != consumedGpuMemory) {
+        lastConsumedGpuMemory = consumedGpuMemory;
+        qCDebug(gpugllogging) << "Exceeded max allowed texture memory: " << consumedGpuMemory << " / " << availableTextureMemory;
+    }
+    return memoryPressure;
 }
 
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -20,8 +20,19 @@ std::shared_ptr<GLTextureTransferHelper> GLTexture::_textureTransferHelper;
 
 // FIXME placeholder for texture memory over-use
 #define DEFAULT_MAX_MEMORY_MB 256
-#define MIN_FREE_GPU_MEMORY_PERCENTAGE 0.25f
 #define OVER_MEMORY_PRESSURE 2.0f
+
+// FIXME other apps show things like Oculus home consuming large amounts of GPU memory
+// which causes us to blur textures needlessly (since other app GPU memory usage will likely 
+// be swapped out and not cause any actual impact
+//#define CHECK_MIN_FREE_GPU_MEMORY
+#ifdef CHECK_MIN_FREE_GPU_MEMORY
+#define MIN_FREE_GPU_MEMORY_PERCENTAGE 0.25f
+#endif
+
+// Allow 65% of all available GPU memory to be consumed by textures
+// FIXME overly conservative?
+#define MAX_CONSUMED_TEXTURE_MEMORY_PERCENTAGE 0.65f
 
 const GLenum GLTexture::CUBE_FACE_LAYOUT[6] = {
     GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
@@ -107,6 +118,7 @@ float GLTexture::getMemoryPressure() {
             // If we can't query the dedicated memory just use a fallback fixed value of 256 MB
             totalGpuMemory = MB_TO_BYTES(DEFAULT_MAX_MEMORY_MB);
         } else {
+#ifdef CHECK_MIN_FREE_GPU_MEMORY
             // Check the global free GPU memory
             auto freeGpuMemory = getFreeDedicatedMemory();
             if (freeGpuMemory) {
@@ -120,11 +132,10 @@ float GLTexture::getMemoryPressure() {
                     }
                 }
             }
+#endif
         }
 
-        // Allow 50% of all available GPU memory to be consumed by textures
-        // FIXME overly conservative?
-        availableTextureMemory = (totalGpuMemory >> 1);
+        availableTextureMemory = static_cast<gpu::Size>(totalGpuMemory * MAX_CONSUMED_TEXTURE_MEMORY_PERCENTAGE);
     }
 
     // Return the consumed texture memory divided by the available texture memory.


### PR DESCRIPTION
## Testing

If using the `renderStats.js` script to monitor the rendering data, the number of GPU textures should now reflect reality, rather than immedately wrapping to 4 billion and constantly decrementing

When exceeding texture memory, the system should now report different output in the log depending on whether it was because the minimum GPU free memory was breached, or the consumed GPU texture memory was too high.