### PR TITLE
Fix crash when switching to desktop mode from oculus HMD mode

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -867,6 +867,10 @@ void AudioClient::handleLocalEchoAndReverb(QByteArray& inputByteArray) {
 
 void AudioClient::handleAudioInput() {
 
+    if (!_inputDevice) {
+        return;
+    }
+
     // input samples required to produce exactly NETWORK_FRAME_SAMPLES of output
     const int inputSamplesRequired = (_inputToNetworkResampler ? 
                                       _inputToNetworkResampler->getMinInput(AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL) : 

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -63,7 +63,6 @@ void OculusBaseDisplayPlugin::customizeContext() {
 
 void OculusBaseDisplayPlugin::uncustomizeContext() {
     Parent::uncustomizeContext();
-    internalPresent();
 }
 
 bool OculusBaseDisplayPlugin::internalActivate() {


### PR DESCRIPTION
Removed internalPresent in oculus uncustomizeContext.  It had no ill effects.