### PR TITLE
remove AssetResourceRequest timeout, output occasional progress to log

### DIFF
--- a/libraries/networking/src/AssetResourceRequest.cpp
+++ b/libraries/networking/src/AssetResourceRequest.cpp
@@ -164,7 +164,7 @@ void AssetResourceRequest::onDownloadProgress(qint64 bytesReceived, qint64 bytes
         int percentage =  roundf((float) bytesReceived / (float) bytesTotal * 100.0f);
 
         qCDebug(networking).nospace() << "Progress for " << _url.path() << " - "
-            << bytesReceived << " bytes of " << bytesTotal << " - " << percentage << "%";
+            << bytesReceived << " of " << bytesTotal << " bytes - " << percentage << "%";
 
         _lastProgressDebug = now;
     }

--- a/libraries/networking/src/AssetResourceRequest.cpp
+++ b/libraries/networking/src/AssetResourceRequest.cpp
@@ -39,7 +39,7 @@ bool AssetResourceRequest::urlIsAssetHash() const {
 
 void AssetResourceRequest::setupTimer() {
     Q_ASSERT(!_sendTimer);
-    static const int TIMEOUT_MS = 2000;
+    static const int TIMEOUT_MS = 15000;
 
     _sendTimer = new QTimer(this);
     connect(_sendTimer, &QTimer::timeout, this, &AssetResourceRequest::onTimeout);

--- a/libraries/networking/src/AssetResourceRequest.cpp
+++ b/libraries/networking/src/AssetResourceRequest.cpp
@@ -18,6 +18,14 @@
 #include "MappingRequest.h"
 #include "NetworkLogging.h"
 
+static const int DOWNLOAD_PROGRESS_LOG_INTERVAL_SECONDS = 5;
+
+AssetResourceRequest::AssetResourceRequest(const QUrl& url) :
+    ResourceRequest(url)
+{
+    _lastProgressDebug = p_high_resolution_clock::now() - std::chrono::seconds(DOWNLOAD_PROGRESS_LOG_INTERVAL_SECONDS);
+}
+
 AssetResourceRequest::~AssetResourceRequest() {
     if (_assetMappingRequest) {
         _assetMappingRequest->deleteLater();
@@ -145,7 +153,6 @@ void AssetResourceRequest::onDownloadProgress(qint64 bytesReceived, qint64 bytes
 
     emit progress(bytesReceived, bytesTotal);
 
-    static const int DOWNLOAD_PROGRESS_LOG_INTERVAL_SECONDS = 5;
     auto now = p_high_resolution_clock::now();
 
     // if we haven't received the full asset check if it is time to output progress to log

--- a/libraries/networking/src/AssetResourceRequest.cpp
+++ b/libraries/networking/src/AssetResourceRequest.cpp
@@ -11,7 +11,7 @@
 
 #include "AssetResourceRequest.h"
 
-#include <QtCore/qloggingcategory.h>
+#include <QtCore/QLoggingCategory>
 
 #include "AssetClient.h"
 #include "AssetUtils.h"

--- a/libraries/networking/src/AssetResourceRequest.cpp
+++ b/libraries/networking/src/AssetResourceRequest.cpp
@@ -11,10 +11,12 @@
 
 #include "AssetResourceRequest.h"
 
+#include <QtCore/qloggingcategory.h>
+
 #include "AssetClient.h"
 #include "AssetUtils.h"
 #include "MappingRequest.h"
-#include <QtCore/qloggingcategory.h>
+#include "NetworkLogging.h"
 
 AssetResourceRequest::~AssetResourceRequest() {
     if (_assetMappingRequest) {
@@ -24,10 +26,6 @@ AssetResourceRequest::~AssetResourceRequest() {
     if (_assetRequest) {
         _assetRequest->deleteLater();
     }
-
-    if (_sendTimer) {
-        cleanupTimer();
-    }
 }
 
 bool AssetResourceRequest::urlIsAssetHash() const {
@@ -35,24 +33,6 @@ bool AssetResourceRequest::urlIsAssetHash() const {
 
     QRegExp hashRegex { ATP_HASH_REGEX_STRING };
     return hashRegex.exactMatch(_url.toString());
-}
-
-void AssetResourceRequest::setupTimer() {
-    Q_ASSERT(!_sendTimer);
-    static const int TIMEOUT_MS = 15000;
-
-    _sendTimer = new QTimer(this);
-    connect(_sendTimer, &QTimer::timeout, this, &AssetResourceRequest::onTimeout);
-
-    _sendTimer->setSingleShot(true);
-    _sendTimer->start(TIMEOUT_MS);
-}
-
-void AssetResourceRequest::cleanupTimer() {
-    Q_ASSERT(_sendTimer);
-    disconnect(_sendTimer, 0, this, 0);
-    _sendTimer->deleteLater();
-    _sendTimer = nullptr;
 }
 
 void AssetResourceRequest::doSend() {
@@ -80,8 +60,6 @@ void AssetResourceRequest::requestMappingForPath(const AssetPath& path) {
     connect(_assetMappingRequest, &GetMappingRequest::finished, this, [this, path](GetMappingRequest* request){
         Q_ASSERT(_state == InProgress);
         Q_ASSERT(request == _assetMappingRequest);
-
-        cleanupTimer();
 
         switch (request->getError()) {
             case MappingRequest::NoError:
@@ -118,7 +96,6 @@ void AssetResourceRequest::requestMappingForPath(const AssetPath& path) {
         _assetMappingRequest = nullptr;
     });
 
-    setupTimer();
     _assetMappingRequest->start();
 }
 
@@ -133,8 +110,6 @@ void AssetResourceRequest::requestHash(const AssetHash& hash) {
         Q_ASSERT(_state == InProgress);
         Q_ASSERT(req == _assetRequest);
         Q_ASSERT(req->getState() == AssetRequest::Finished);
-
-        cleanupTimer();
         
         switch (req->getError()) {
             case AssetRequest::Error::NoError:
@@ -162,35 +137,30 @@ void AssetResourceRequest::requestHash(const AssetHash& hash) {
         _assetRequest = nullptr;
     });
 
-    setupTimer();
     _assetRequest->start();
 }
 
 void AssetResourceRequest::onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal) {
     Q_ASSERT(_state == InProgress);
 
-    // We've received data, so reset the timer
-    _sendTimer->start();
-
     emit progress(bytesReceived, bytesTotal);
+
+    static const int DOWNLOAD_PROGRESS_LOG_INTERVAL_SECONDS = 5;
+    auto now = p_high_resolution_clock::now();
+
+    // if we haven't received the full asset check if it is time to output progress to log
+    // we do so every X seconds to assist with ATP download tracking
+
+    if (bytesReceived != bytesTotal
+        && now - _lastProgressDebug > std::chrono::seconds(DOWNLOAD_PROGRESS_LOG_INTERVAL_SECONDS)) {
+
+        int percentage =  roundf((float) bytesReceived / (float) bytesTotal * 100.0f);
+
+        qCDebug(networking).nospace() << "Progress for " << _url.path() << " - "
+            << bytesReceived << " bytes of " << bytesTotal << " - " << percentage << "%";
+
+        _lastProgressDebug = now;
+    }
+
 }
 
-void AssetResourceRequest::onTimeout() {
-    if (_state == InProgress) {
-        qWarning() << "Asset request timed out: " << _url;
-        if (_assetRequest) {
-            disconnect(_assetRequest, 0, this, 0);
-            _assetRequest->deleteLater();
-            _assetRequest = nullptr;
-        }
-        if (_assetMappingRequest) {
-            disconnect(_assetMappingRequest, 0, this, 0);
-            _assetMappingRequest->deleteLater();
-            _assetMappingRequest = nullptr;
-        }
-        _result = Timeout;
-        _state = Finished;
-        emit finished();
-    }
-    cleanupTimer();
-}

--- a/libraries/networking/src/AssetResourceRequest.h
+++ b/libraries/networking/src/AssetResourceRequest.h
@@ -22,7 +22,7 @@
 class AssetResourceRequest : public ResourceRequest {
     Q_OBJECT
 public:
-    AssetResourceRequest(const QUrl& url) : ResourceRequest(url) { }
+    AssetResourceRequest(const QUrl& url);
     virtual ~AssetResourceRequest() override;
 
 protected:

--- a/libraries/networking/src/AssetResourceRequest.h
+++ b/libraries/networking/src/AssetResourceRequest.h
@@ -14,6 +14,8 @@
 
 #include <QUrl>
 
+#include <PortableHighResolutionClock.h>
+
 #include "AssetRequest.h"
 #include "ResourceRequest.h"
 
@@ -28,21 +30,17 @@ protected:
 
 private slots:
     void onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal);
-    void onTimeout();
 
 private:
-    void setupTimer();
-    void cleanupTimer();
-
     bool urlIsAssetHash() const;
 
     void requestMappingForPath(const AssetPath& path);
     void requestHash(const AssetHash& hash);
 
-    QTimer* _sendTimer { nullptr };
-
     GetMappingRequest* _assetMappingRequest { nullptr };
     AssetRequest* _assetRequest { nullptr };
+
+    p_high_resolution_clock::time_point _lastProgressDebug;
 };
 
 #endif

--- a/libraries/networking/src/ReceivedMessage.cpp
+++ b/libraries/networking/src/ReceivedMessage.cpp
@@ -54,7 +54,7 @@ void ReceivedMessage::appendPacket(NLPacket& packet) {
                "We should not be appending to a complete message");
 
     // Limit progress signal to every X packets
-    const int EMIT_PROGRESS_EVERY_X_PACKETS = 100;
+    const int EMIT_PROGRESS_EVERY_X_PACKETS = 5;
 
     ++_numPackets;
 

--- a/libraries/networking/src/ReceivedMessage.cpp
+++ b/libraries/networking/src/ReceivedMessage.cpp
@@ -54,7 +54,7 @@ void ReceivedMessage::appendPacket(NLPacket& packet) {
                "We should not be appending to a complete message");
 
     // Limit progress signal to every X packets
-    const int EMIT_PROGRESS_EVERY_X_PACKETS = 5;
+    const int EMIT_PROGRESS_EVERY_X_PACKETS = 50;
 
     ++_numPackets;
 


### PR DESCRIPTION
- fixes a bug introduced in #8730 which caused ATP downloads to timeout frequently with multiple concurrent ATP downloads