### PR TITLE
Bug fixes in oculus_touch default mapping

### DIFF
--- a/interface/resources/controllers/oculus_touch.json
+++ b/interface/resources/controllers/oculus_touch.json
@@ -11,42 +11,34 @@
 
         { "from": "OculusTouch.LY", "to": "Standard.LY",
             "filters": [
-                { "type": "deadZone", "min": 0.05 },
+                { "type": "deadZone", "min": 0.3 },
                 "invert"
             ]
         },
-        { "from": "OculusTouch.LX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.LX" },
-        { "from": "OculusTouch.LT", "to": "Standard.LTClick",  
+        { "from": "OculusTouch.LX", "filters": { "type": "deadZone", "min": 0.3 }, "to": "Standard.LX" },
+        { "from": "OculusTouch.LT", "to": "Standard.LTClick",
             "peek": true,
             "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
         },
         { "from": "OculusTouch.LT", "to": "Standard.LT" },
         { "from": "OculusTouch.LS", "to": "Standard.LS" },
-        { "from": "OculusTouch.LeftGrip", "to": "Standard.LTClick",  
-            "peek": true,
-            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
-        },
-        { "from": "OculusTouch.LeftGrip", "to": "Standard.LT" },
+        { "from": "OculusTouch.LeftGrip", "filters": { "type": "deadZone", "min": 0.3 }, "to": "Standard.LeftGrip" },
         { "from": "OculusTouch.LeftHand", "to": "Standard.LeftHand" },
 
         { "from": "OculusTouch.RY", "to": "Standard.RY",
             "filters": [
-                { "type": "deadZone", "min": 0.05 },
+                { "type": "deadZone", "min": 0.3 },
                 "invert"
             ]
         },
-        { "from": "OculusTouch.RX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.RX" },
-        { "from": "OculusTouch.RT", "to": "Standard.RTClick",  
+        { "from": "OculusTouch.RX", "filters": { "type": "deadZone", "min": 0.3 }, "to": "Standard.RX" },
+        { "from": "OculusTouch.RT", "to": "Standard.RTClick",
             "peek": true,
             "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
         },
         { "from": "OculusTouch.RT", "to": "Standard.RT" },
         { "from": "OculusTouch.RS", "to": "Standard.RS" },
-        { "from": "OculusTouch.RightGrip", "to": "Standard.LTClick",  
-            "peek": true,
-            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
-        },
-        { "from": "OculusTouch.RightGrip", "to": "Standard.RT" },
+        { "from": "OculusTouch.RightGrip", "filters": { "type": "deadZone", "min": 0.3 }, "to": "Standard.RightGrip" },
         { "from": "OculusTouch.RightHand", "to": "Standard.RightHand" },
 
         { "from": "OculusTouch.LeftApplicationMenu", "to": "Standard.Back" },

--- a/interface/resources/controllers/oculus_touch.json
+++ b/interface/resources/controllers/oculus_touch.json
@@ -22,7 +22,7 @@
         },
         { "from": "OculusTouch.LT", "to": "Standard.LT" },
         { "from": "OculusTouch.LS", "to": "Standard.LS" },
-        { "from": "OculusTouch.LeftGrip", "filters": { "type": "deadZone", "min": 0.3 }, "to": "Standard.LeftGrip" },
+        { "from": "OculusTouch.LeftGrip", "filters": { "type": "deadZone", "min": 0.5 }, "to": "Standard.LeftGrip" },
         { "from": "OculusTouch.LeftHand", "to": "Standard.LeftHand" },
 
         { "from": "OculusTouch.RY", "to": "Standard.RY",
@@ -38,7 +38,7 @@
         },
         { "from": "OculusTouch.RT", "to": "Standard.RT" },
         { "from": "OculusTouch.RS", "to": "Standard.RS" },
-        { "from": "OculusTouch.RightGrip", "filters": { "type": "deadZone", "min": 0.3 }, "to": "Standard.RightGrip" },
+        { "from": "OculusTouch.RightGrip", "filters": { "type": "deadZone", "min": 0.5 }, "to": "Standard.RightGrip" },
         { "from": "OculusTouch.RightHand", "to": "Standard.RightHand" },
 
         { "from": "OculusTouch.LeftApplicationMenu", "to": "Standard.Back" },


### PR DESCRIPTION
* Made sticks less sensitive. Raised deadSpot min from 0.05 to 0.3.
* Fixed problem were grip and trigger was mapped to Standard triggers. This was causing all sorts of problems
  with the handControllerGrab script.  Including double lasers and a stuck right hand laser.
* mapped grip to standard grip. So now you can use the grip button to drop equipped objects.
* increased deadZone on grip to make inadvertent drops less likely to happen.