### PR TITLE
Fix crash in AssetClient handleProgressCallback

### DIFF
--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -93,7 +93,7 @@ private:
     bool cancelGetAssetRequest(MessageID id);
     bool cancelUploadAssetRequest(MessageID id);
 
-    void handleProgressCallback(const QWeakPointer<Node>& node, MessageID messageID, DataOffset length);
+    void handleProgressCallback(const QWeakPointer<Node>& node, MessageID messageID, qint64 size, DataOffset length);
     void handleCompleteCallback(const QWeakPointer<Node>& node, MessageID messageID);
 
     struct GetAssetRequestData {

--- a/libraries/networking/src/ReceivedMessage.cpp
+++ b/libraries/networking/src/ReceivedMessage.cpp
@@ -61,7 +61,7 @@ void ReceivedMessage::appendPacket(NLPacket& packet) {
     _data.append(packet.getPayload(), packet.getPayloadSize());
 
     if (_numPackets % EMIT_PROGRESS_EVERY_X_PACKETS == 0) {
-        emit progress();
+        emit progress(getSize());
     }
 
     if (packet.getPacketPosition() == NLPacket::PacketPosition::LAST) {

--- a/libraries/networking/src/ReceivedMessage.h
+++ b/libraries/networking/src/ReceivedMessage.h
@@ -78,7 +78,7 @@ public:
     template<typename T> qint64 readHeadPrimitive(T* data);
 
 signals:
-    void progress();
+    void progress(qint64 size);
     void completed();
 
 private slots:


### PR DESCRIPTION
This PR fixes the AssetClient crash by removing a race condition.

The `_data` member of ReceivedMessage was accessed while the network thread was still appending data as it came in with possible reallocation of the byte array.

Test Plan:
- Run the script `domain-check.js` several time to make sure the crash does not happen anymore.