### PR TITLE
adjust grab indicators

### DIFF
--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -374,7 +374,8 @@ void HmdDisplayPlugin::updateFrameData() {
         }
 
         // this offset needs to match GRAB_POINT_SPHERE_OFFSET in scripts/system/libraries/controllers.js
-        static const vec3 GRAB_POINT_SPHERE_OFFSET = vec3(0.1f, 0.04f, -0.32f);
+        //static const vec3 GRAB_POINT_SPHERE_OFFSET = vec3(0.1f, 0.04f, -0.32f);
+        static const vec3 GRAB_POINT_SPHERE_OFFSET = vec3(0.0f, 0.0f, -0.175f);
         vec3 grabPointOffset = GRAB_POINT_SPHERE_OFFSET;
         if (i == 0) {
             grabPointOffset.x *= -1.0f; // this changes between left and right hands

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1075,12 +1075,6 @@ function MyController(hand) {
         var controllerLocation = getControllerWorldLocation(this.handToController(), true);
         var worldHandPosition = controllerLocation.position;
 
-        if (controllerLocation.valid) {
-            this.grabPointSphereOn();
-        } else {
-            this.grabPointSphereOff();
-        }
-
         var candidateEntities = Entities.findEntities(worldHandPosition, MAX_EQUIP_HOTSPOT_RADIUS);
         entityPropertiesCache.addEntities(candidateEntities);
         var potentialEquipHotspot = this.chooseBestEquipHotspot(candidateEntities);
@@ -1103,9 +1097,11 @@ function MyController(hand) {
             if (!this.grabPointIntersectsEntity) {
                 Controller.triggerHapticPulse(1, 20, this.hand);
                 this.grabPointIntersectsEntity = true;
+                this.grabPointSphereOn();
             }
         } else {
             this.grabPointIntersectsEntity = false;
+            this.grabPointSphereOff();
         }
     };
 
@@ -1426,12 +1422,6 @@ function MyController(hand) {
 
         var controllerLocation = getControllerWorldLocation(this.handToController(), true);
         var handPosition = controllerLocation.position;
-
-        if (controllerLocation.valid) {
-            this.grabPointSphereOn();
-        } else {
-            this.grabPointSphereOff();
-        }
 
         var rayPickInfo = this.calcRayPickInfo(this.hand);
 

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -112,7 +112,7 @@ var CHECK_TOO_FAR_UNEQUIP_TIME = 0.3; // seconds, duration between checks
 
 
 var GRAB_POINT_SPHERE_RADIUS = NEAR_GRAB_RADIUS;
-var GRAB_POINT_SPHERE_COLOR = { red: 20, green: 90, blue: 238 };
+var GRAB_POINT_SPHERE_COLOR = { red: 240, green: 240, blue: 240 };
 var GRAB_POINT_SPHERE_ALPHA = 0.85;
 
 

--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -10,9 +10,10 @@
 
 // var GRAB_POINT_SPHERE_OFFSET = { x: 0, y: 0.2, z: 0 };
 // var GRAB_POINT_SPHERE_OFFSET = { x: 0.1, y: 0.175, z: 0.04 };
+// var GRAB_POINT_SPHERE_OFFSET = { x: 0.1, y: 0.32, z: 0.04 };
 
 // this offset needs to match the one in libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
-var GRAB_POINT_SPHERE_OFFSET = { x: 0.1, y: 0.32, z: 0.04 };
+var GRAB_POINT_SPHERE_OFFSET = { x: 0.0, y: 0.175, z: 0.0 };
 
 getGrabPointSphereOffset = function(handController) {
     if (handController === Controller.Standard.RightHand) {


### PR DESCRIPTION
- make the grab indicators silver instead of blue
- move them to a better location relative to hand controller and avatar hands
- only show the grab indicator when you're touching a grabbable object