### PR TITLE
Fixing the key light pass with ambient map

### DIFF
--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -478,6 +478,8 @@ void RenderDeferredSetup::run(const render::SceneContextPointer& sceneContext, c
         // Setup the global directional pass pipeline
         {
             if (deferredLightingEffect->_shadowMapEnabled) {
+                // If the keylight has an ambient Map then use the Skybox version of the pass
+                // otherwise use the ambient sphere version
                 if (keyLight->getAmbientMap()) {
                     program = deferredLightingEffect->_directionalSkyboxLightShadow;
                     locations = deferredLightingEffect->_directionalSkyboxLightShadowLocations;
@@ -486,6 +488,8 @@ void RenderDeferredSetup::run(const render::SceneContextPointer& sceneContext, c
                     locations = deferredLightingEffect->_directionalAmbientSphereLightShadowLocations;
                 }
             } else {
+                // If the keylight has an ambient Map then use the Skybox version of the pass
+                // otherwise use the ambient sphere version
                 if (keyLight->getAmbientMap()) {
                     program = deferredLightingEffect->_directionalSkyboxLight;
                     locations = deferredLightingEffect->_directionalSkyboxLightLocations;

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -487,10 +487,8 @@ void RenderDeferredSetup::run(const render::SceneContextPointer& sceneContext, c
                 }
             } else {
                 if (keyLight->getAmbientMap()) {
-                    program = deferredLightingEffect->_directionalAmbientSphereLight;
-                    locations = deferredLightingEffect->_directionalAmbientSphereLightLocations;
-                    //program = deferredLightingEffect->_directionalSkyboxLight;
-                    //locations = deferredLightingEffect->_directionalSkyboxLightLocations;
+                    program = deferredLightingEffect->_directionalSkyboxLight;
+                    locations = deferredLightingEffect->_directionalSkyboxLightLocations;
                 } else {
                     program = deferredLightingEffect->_directionalAmbientSphereLight;
                     locations = deferredLightingEffect->_directionalAmbientSphereLightLocations;


### PR DESCRIPTION
the key light pass was using the wrong program.
this is now fixed
THere is still a problem with the sampler filter used that seems to be nearest (visible when looking at a rough surface), i will fix it in a future PR