### PR TITLE
Prevent crashes in openvr on shutdown

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -445,8 +445,9 @@ void OpenVrDisplayPlugin::internalDeactivate() {
     _openVrDisplayActive = false;
     _container->setIsOptionChecked(StandingHMDSensorMode, false);
     if (_system) {
-        // Invalidate poses. It's fine if someone else sets these shared values, but we're about to stop updating them, and
+        // TODO: Invalidate poses. It's fine if someone else sets these shared values, but we're about to stop updating them, and
         // we don't want ViveControllerManager to consider old values to be valid.
+        _container->makeRenderingContextCurrent();
         releaseOpenVrSystem();
         _system = nullptr;
     }

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -132,6 +132,7 @@ void ViveControllerManager::deactivate() {
     _container->removeMenu(MENU_PATH);
 
     if (_system) {
+        _container->makeRenderingContextCurrent();
         releaseOpenVrSystem();
         _system = nullptr;
     }


### PR DESCRIPTION
By ensuring that there is an opengl context bound before calling VR_Shutdown()