### PR TITLE
Prevent crash on exit.

### DIFF
--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -37,9 +37,13 @@ AvatarActionHold::AvatarActionHold(const QUuid& id, EntityItemPointer ownerEntit
 }
 
 AvatarActionHold::~AvatarActionHold() {
-    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-    if (myAvatar) {
-        myAvatar->removeHoldAction(this);
+    // Sometimes actions are destroyed after the AvatarManager is destroyed by the Application.
+    auto avatarManager = DependencyManager::get<AvatarManager>();
+    if (avatarManager) {
+        auto myAvatar = avatarManager->getMyAvatar();
+        if (myAvatar) {
+            myAvatar->removeHoldAction(this);
+        }
     }
 
 #if WANT_DEBUG


### PR DESCRIPTION
If you or another user begins to near-grab an object while you exit the application, you might run into this crash. The PhysicalEntitySimulation has a list of AvatarHoldActions shared_ptr's. When it is destroyed, via the Application destructor, it will release these pointers. This in turn will invoke a AvatarHoldAction destructor, which attempts to reference the AvatarManager via the DependencyManager. However at this point the AvatarManager has already been destroyed, leading to a null dereference.

The fix is to check the AvatarManager pointer first.