### PR TITLE
fixes for various networking/ATP stuck download failure cases

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -519,7 +519,7 @@ void DomainServer::setupNodeListAndAssignments() {
     // add whatever static assignments that have been parsed to the queue
     addStaticAssignmentsToQueue();
 
-    // set a custum packetVersionMatch as the verify packet operator for the udt::Socket
+    // set a custom packetVersionMatch as the verify packet operator for the udt::Socket
     nodeList->setPacketFilterOperator(&DomainServer::packetVersionMatch);
 }
 

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -453,7 +453,7 @@ MessageID AssetClient::getAssetMapping(const AssetPath& path, MappingOperationCa
 
         packetList->writeString(path);
 
-        if (nodeList->sendPacketList(std::move(packetList), *assetServer)) {
+        if (nodeList->sendPacketList(std::move(packetList), *assetServer) != -1) {
             _pendingMappingRequests[assetServer][messageID] = callback;
 
             return messageID;

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -19,6 +19,8 @@
 #include <QtScript/QScriptEngine>
 #include <QtNetwork/QNetworkDiskCache>
 
+#include "udt/ControlPacket.h"
+
 #include "AssetRequest.h"
 #include "AssetUpload.h"
 #include "AssetUtils.h"

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -46,7 +46,7 @@ AssetClient::AssetClient() {
 
     connect(nodeList.data(), &LimitedNodeList::nodeKilled, this, &AssetClient::handleNodeKilled);
     connect(nodeList.data(), &LimitedNodeList::clientConnectionToNodeReset,
-            this, &::AssetClient::handleNodeClientConnectionReset);
+            this, &AssetClient::handleNodeClientConnectionReset);
 }
 
 void AssetClient::init() {

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -453,15 +453,17 @@ MessageID AssetClient::getAssetMapping(const AssetPath& path, MappingOperationCa
 
         packetList->writeString(path);
 
-        nodeList->sendPacketList(std::move(packetList), *assetServer);
+        if (nodeList->sendPacketList(std::move(packetList), *assetServer)) {
+            _pendingMappingRequests[assetServer][messageID] = callback;
 
-        _pendingMappingRequests[assetServer][messageID] = callback;
-
-        return messageID;
-    } else {
-        callback(false, AssetServerError::NoError, QSharedPointer<ReceivedMessage>());
-        return INVALID_MESSAGE_ID;
+            return messageID;
+        } else {
+            qDebug() << "getAssetMapping would have been sent but no active socket - send back no response received";
+        }
     }
+
+    callback(false, AssetServerError::NoError, QSharedPointer<ReceivedMessage>());
+    return INVALID_MESSAGE_ID;
 }
 
 MessageID AssetClient::getAllAssetMappings(MappingOperationCallback callback) {

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -19,8 +19,6 @@
 #include <QtScript/QScriptEngine>
 #include <QtNetwork/QNetworkDiskCache>
 
-#include "udt/ControlPacket.h"
-
 #include "AssetRequest.h"
 #include "AssetUpload.h"
 #include "AssetUtils.h"

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -727,7 +727,7 @@ void AssetClient::handleNodeClientConnectionReset(SharedNodePointer node) {
         return;
     }
 
-    qCDebug(asset_client) << "AssetClient detected completed client handshake with Asset Server - failing any pending requests";
+    qCDebug(asset_client) << "AssetClient detected client connection reset handshake with Asset Server - failing any pending requests";
 
     forceFailureOfPendingRequests(node);
 }

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -75,6 +75,7 @@ private slots:
     void handleAssetUploadReply(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
 
     void handleNodeKilled(SharedNodePointer node);
+    void handleNodeClientConnectionReset(SharedNodePointer node);
 
 private:
     MessageID getAssetMapping(const AssetHash& hash, MappingOperationCallback callback);
@@ -95,6 +96,8 @@ private:
 
     void handleProgressCallback(const QWeakPointer<Node>& node, MessageID messageID, qint64 size, DataOffset length);
     void handleCompleteCallback(const QWeakPointer<Node>& node, MessageID messageID);
+
+    void forceFailureOfPendingRequests(SharedNodePointer node);
 
     struct GetAssetRequestData {
         QSharedPointer<ReceivedMessage> message;

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -119,7 +119,7 @@ LimitedNodeList::LimitedNodeList(int socketListenPort, int dtlsListenPort) :
     _nodeSocket.setConnectionCreationFilterOperator(std::bind(&LimitedNodeList::sockAddrBelongsToNode, this, _1));
 
     // handle when a socket connection has its receiver side reset - might need to emit clientConnectionToNodeReset
-    connect(&_nodeSocket, &udt::Socket::clientHandshakeComplete, this, &LimitedNodeList::clientConnectionToSockAddrReset);
+    connect(&_nodeSocket, &udt::Socket::clientHandshakeRequestComplete, this, &LimitedNodeList::clientConnectionToSockAddrReset);
 
     _packetStatTimer.start();
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -113,6 +113,10 @@ LimitedNodeList::LimitedNodeList(int socketListenPort, int dtlsListenPort) :
     using std::placeholders::_1;
     _nodeSocket.setPacketFilterOperator(std::bind(&LimitedNodeList::isPacketVerified, this, _1));
 
+    // set our socketBelongsToNode method as the connection creation filter operator for the udt::Socket
+    using std::placeholders::_1;
+    _nodeSocket.setConnectionCreationFilterOperator(std::bind(&LimitedNodeList::sockAddrBelongsToNode, this, _1));
+
     _packetStatTimer.start();
 
     if (_stunSockAddr.getAddress().isNull()) {

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -325,6 +325,8 @@ void LimitedNodeList::fillPacketHeader(const NLPacket& packet, const QUuid& conn
     }
 }
 
+static const qint64 ERROR_SENDING_PACKET_BYTES = -1;
+
 qint64 LimitedNodeList::sendUnreliablePacket(const NLPacket& packet, const Node& destinationNode) {
     Q_ASSERT(!packet.isPartOfMessage());
 
@@ -361,7 +363,7 @@ qint64 LimitedNodeList::sendPacket(std::unique_ptr<NLPacket> packet, const Node&
         return sendPacket(std::move(packet), *activeSocket, destinationNode.getConnectionSecret());
     } else {
         qCDebug(networking) << "LimitedNodeList::sendPacket called without active socket for node" << destinationNode << "- not sending";
-        return -1;
+        return ERROR_SENDING_PACKET_BYTES;
     }
 }
 
@@ -400,7 +402,7 @@ qint64 LimitedNodeList::sendPacketList(NLPacketList& packetList, const Node& des
     } else {
         qCDebug(networking) << "LimitedNodeList::sendPacketList called without active socket for node" << destinationNode
             << " - not sending.";
-        return -1;
+        return ERROR_SENDING_PACKET_BYTES;
     }
 }
 
@@ -446,7 +448,7 @@ qint64 LimitedNodeList::sendPacketList(std::unique_ptr<NLPacketList> packetList,
         return _nodeSocket.writePacketList(std::move(packetList), *activeSocket);
     } else {
         qCDebug(networking) << "LimitedNodeList::sendPacketList called without active socket for node. Not sending.";
-        return -1;
+        return ERROR_SENDING_PACKET_BYTES;
     }
 }
 
@@ -454,7 +456,7 @@ qint64 LimitedNodeList::sendPacket(std::unique_ptr<NLPacket> packet, const Node&
                                    const HifiSockAddr& overridenSockAddr) {
     if (overridenSockAddr.isNull() && !destinationNode.getActiveSocket()) {
         qCDebug(networking) << "LimitedNodeList::sendPacket called without active socket for node. Not sending.";
-        return -1;
+        return ERROR_SENDING_PACKET_BYTES;
     }
 
     // use the node's active socket as the destination socket if there is no overriden socket address
@@ -1154,6 +1156,8 @@ void LimitedNodeList::clientConnectionToSockAddrReset(const HifiSockAddr& sockAd
     }
 }
 
+#if (PR_BUILD || DEV_BUILD)
+
 void LimitedNodeList::sendFakedHandshakeRequestToNode(SharedNodePointer node) {
 
     if (node && node->getActiveSocket()) {
@@ -1162,3 +1166,5 @@ void LimitedNodeList::sendFakedHandshakeRequestToNode(SharedNodePointer node) {
         _nodeSocket.writeBasePacket(*handshakeRequestPacket, *node->getActiveSocket());
     }
 }
+
+#endif

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -116,7 +116,6 @@ LimitedNodeList::LimitedNodeList(int socketListenPort, int dtlsListenPort) :
     _nodeSocket.setPacketFilterOperator(std::bind(&LimitedNodeList::isPacketVerified, this, _1));
 
     // set our socketBelongsToNode method as the connection creation filter operator for the udt::Socket
-    using std::placeholders::_1;
     _nodeSocket.setConnectionCreationFilterOperator(std::bind(&LimitedNodeList::sockAddrBelongsToNode, this, _1));
 
     // handle when a socket connection has its receiver side reset - might need to emit clientConnectionToNodeReset

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -1161,9 +1161,7 @@ void LimitedNodeList::clientConnectionToSockAddrReset(const HifiSockAddr& sockAd
 void LimitedNodeList::sendFakedHandshakeRequestToNode(SharedNodePointer node) {
 
     if (node && node->getActiveSocket()) {
-        // randomly send a handshake request packet to get assets we previously asked for into a stuck state
-        auto handshakeRequestPacket = udt::ControlPacket::create(udt::ControlPacket::HandshakeRequest, 0);
-        _nodeSocket.writeBasePacket(*handshakeRequestPacket, *node->getActiveSocket());
+        _nodeSocket.sendFakedHandshakeRequest(*node->getActiveSocket());
     }
 }
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -1154,3 +1154,12 @@ void LimitedNodeList::clientConnectionToSockAddrReset(const HifiSockAddr& sockAd
         emit clientConnectionToNodeReset(matchingNode);
     }
 }
+
+void LimitedNodeList::sendFakedHandshakeRequestToNode(SharedNodePointer node) {
+
+    if (node && node->getActiveSocket()) {
+        // randomly send a handshake request packet to get assets we previously asked for into a stuck state
+        auto handshakeRequestPacket = udt::ControlPacket::create(udt::ControlPacket::HandshakeRequest, 0);
+        _nodeSocket.writeBasePacket(*handshakeRequestPacket, *node->getActiveSocket());
+    }
+}

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -32,6 +32,7 @@
 #include <UUID.h>
 
 #include "AccountManager.h"
+#include "AssetClient.h"
 #include "Assignment.h"
 #include "HifiSockAddr.h"
 #include "NetworkLogging.h"

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -357,7 +357,7 @@ qint64 LimitedNodeList::sendPacket(std::unique_ptr<NLPacket> packet, const Node&
         return sendPacket(std::move(packet), *activeSocket, destinationNode.getConnectionSecret());
     } else {
         qCDebug(networking) << "LimitedNodeList::sendPacket called without active socket for node" << destinationNode << "- not sending";
-        return 0;
+        return -1;
     }
 }
 
@@ -396,7 +396,7 @@ qint64 LimitedNodeList::sendPacketList(NLPacketList& packetList, const Node& des
     } else {
         qCDebug(networking) << "LimitedNodeList::sendPacketList called without active socket for node" << destinationNode
             << " - not sending.";
-        return 0;
+        return -1;
     }
 }
 
@@ -442,7 +442,7 @@ qint64 LimitedNodeList::sendPacketList(std::unique_ptr<NLPacketList> packetList,
         return _nodeSocket.writePacketList(std::move(packetList), *activeSocket);
     } else {
         qCDebug(networking) << "LimitedNodeList::sendPacketList called without active socket for node. Not sending.";
-        return 0;
+        return -1;
     }
 }
 
@@ -450,7 +450,7 @@ qint64 LimitedNodeList::sendPacket(std::unique_ptr<NLPacket> packet, const Node&
                                    const HifiSockAddr& overridenSockAddr) {
     if (overridenSockAddr.isNull() && !destinationNode.getActiveSocket()) {
         qCDebug(networking) << "LimitedNodeList::sendPacket called without active socket for node. Not sending.";
-        return 0;
+        return -1;
     }
 
     // use the node's active socket as the destination socket if there is no overriden socket address

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -41,7 +41,8 @@ static Setting::Handle<quint16> LIMITED_NODELIST_LOCAL_PORT("LimitedNodeList.Loc
 
 const std::set<NodeType_t> SOLO_NODE_TYPES = {
     NodeType::AvatarMixer,
-    NodeType::AudioMixer
+    NodeType::AudioMixer,
+    NodeType::AssetServer
 };
 
 LimitedNodeList::LimitedNodeList(int socketListenPort, int dtlsListenPort) :

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -41,6 +41,7 @@
 #include "NLPacketList.h"
 #include "PacketReceiver.h"
 #include "ReceivedMessage.h"
+#include "udt/ControlPacket.h"
 #include "udt/PacketHeaders.h"
 #include "udt/Socket.h"
 #include "UUIDHasher.h"
@@ -235,6 +236,7 @@ public:
 
     static void makeSTUNRequestPacket(char* stunRequestPacket);
 
+    void sendFakedHandshakeRequestToNode(SharedNodePointer node);
 
 public slots:
     void reset();

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -236,7 +236,9 @@ public:
 
     static void makeSTUNRequestPacket(char* stunRequestPacket);
 
+#if (PR_BUILD || DEV_BUILD)
     void sendFakedHandshakeRequestToNode(SharedNodePointer node);
+#endif
 
 public slots:
     void reset();

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -299,6 +299,8 @@ protected:
     void sendPacketToIceServer(PacketType packetType, const HifiSockAddr& iceServerSockAddr, const QUuid& clientID,
                                const QUuid& peerRequestID = QUuid());
 
+    bool sockAddrBelongsToNode(const HifiSockAddr& sockAddr) { return findNodeWithAddr(sockAddr) != SharedNodePointer(); }
+
     QUuid _sessionUUID;
     NodeHash _nodeHash;
     mutable QReadWriteLock _nodeMutex;

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -262,6 +262,8 @@ signals:
     void nodeKilled(SharedNodePointer);
     void nodeActivated(SharedNodePointer);
 
+    void clientConnectionToNodeReset(SharedNodePointer);
+
     void localSockAddrChanged(const HifiSockAddr& localSockAddr);
     void publicSockAddrChanged(const HifiSockAddr& publicSockAddr);
 
@@ -274,6 +276,8 @@ signals:
 protected slots:
     void connectedForLocalSocketTest();
     void errorTestingLocalSocket();
+    
+    void clientConnectionToSockAddrReset(const HifiSockAddr& sockAddr);
 
 protected:
     LimitedNodeList(int socketListenPort = INVALID_PORT, int dtlsListenPort = INVALID_PORT);

--- a/libraries/networking/src/MappingRequest.cpp
+++ b/libraries/networking/src/MappingRequest.cpp
@@ -65,8 +65,6 @@ void GetMappingRequest::doStart() {
 
     auto assetClient = DependencyManager::get<AssetClient>();
 
-    qDebug() << "Asking asset client to get mapping for" << _path;
-
     _mappingRequestID = assetClient->getAssetMapping(_path,
             [this, assetClient](bool responseReceived, AssetServerError error, QSharedPointer<ReceivedMessage> message) {
 

--- a/libraries/networking/src/MappingRequest.cpp
+++ b/libraries/networking/src/MappingRequest.cpp
@@ -65,6 +65,8 @@ void GetMappingRequest::doStart() {
 
     auto assetClient = DependencyManager::get<AssetClient>();
 
+    qDebug() << "Asking asset client to get mapping for" << _path;
+
     _mappingRequestID = assetClient->getAssetMapping(_path,
             [this, assetClient](bool responseReceived, AssetServerError error, QSharedPointer<ReceivedMessage> message) {
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -28,6 +28,7 @@
 #include "HifiSockAddr.h"
 
 #include "NetworkLogging.h"
+#include "udt/ControlPacket.h"
 #include "udt/PacketHeaders.h"
 #include "SharedUtil.h"
 
@@ -125,6 +126,21 @@ NodeList::NodeList(char newOwnerType, int socketListenPort, int dtlsListenPort) 
     packetReceiver.registerListener(PacketType::ICEPingReply, &_domainHandler, "processICEPingReplyPacket");
     packetReceiver.registerListener(PacketType::DomainServerPathResponse, this, "processDomainServerPathResponse");
     packetReceiver.registerListener(PacketType::DomainServerRemovedNode, this, "processDomainServerRemovedNode");
+
+    // setup a timer to occasionally delete the AssetServer node - hopefully to help repro a specific stuck asset case
+    auto killASTimer = new QTimer(this);
+    connect(killASTimer, &QTimer::timeout, this, &NodeList::fakeHandshakeReq);
+    killASTimer->start(10000);
+}
+
+void NodeList::fakeHandshakeReq() {
+    SharedNodePointer assetServer = soloNodeOfType(NodeType::AssetServer);
+
+    if (assetServer && assetServer->getActiveSocket()) {
+        // randomly send a handshake request packet to get assets we previously asked for into a stuck state
+        auto handshakeRequestPacket = udt::ControlPacket::create(udt::ControlPacket::HandshakeRequest, 0);
+        _nodeSocket.writeBasePacket(*handshakeRequestPacket, *assetServer->getActiveSocket());
+    }
 }
 
 qint64 NodeList::sendStats(const QJsonObject& statsObject, const HifiSockAddr& destination) {

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -132,6 +132,8 @@ private:
 
     void pingPunchForInactiveNode(const SharedNodePointer& node);
 
+    bool sockAddrBelongsToDomainOrNode(const HifiSockAddr& sockAddr);
+
     NodeType_t _ownerType;
     NodeSet _nodeTypesOfInterest;
     DomainHandler _domainHandler;

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -114,6 +114,8 @@ private slots:
     void sendKeepAlivePings();
 
     void maybeSendIgnoreSetToNode(SharedNodePointer node);
+
+    void fakeHandshakeReq();
     
 private:
     NodeList() : LimitedNodeList(INVALID_PORT, INVALID_PORT) { assert(false); } // Not implemented, needed for DependencyManager templates compile

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -114,8 +114,6 @@ private slots:
     void sendKeepAlivePings();
 
     void maybeSendIgnoreSetToNode(SharedNodePointer node);
-
-    void fakeHandshakeReq();
     
 private:
     NodeList() : LimitedNodeList(INVALID_PORT, INVALID_PORT) { assert(false); } // Not implemented, needed for DependencyManager templates compile

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -426,19 +426,24 @@ SequenceNumber Connection::nextACK() const {
     }
 }
 
+void Connection::sendHandshakeRequest() {
+    auto handshakeRequestPacket = ControlPacket::create(ControlPacket::HandshakeRequest, 0);
+    _parentSocket->writeBasePacket(*handshakeRequestPacket, _destination);
+
+    _didRequestHandshake = true;
+}
+
 bool Connection::processReceivedSequenceNumber(SequenceNumber sequenceNumber, int packetSize, int payloadSize) {
     
     if (!_hasReceivedHandshake) {
         // Refuse to process any packets until we've received the handshake
         // Send handshake request to re-request a handshake
-        auto handshakeRequestPacket = ControlPacket::create(ControlPacket::HandshakeRequest, 0);
-        _parentSocket->writeBasePacket(*handshakeRequestPacket, _destination);
-
-        _didRequestHandshake = true;
 
 #ifdef UDT_CONNECTION_DEBUG
         qCDebug(networking) << "Received packet before receiving handshake, sending HandshakeRequest";
 #endif
+
+        sendHandshakeRequest();
 
         return false;
     }

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -789,6 +789,8 @@ void Connection::processHandshake(ControlPacketPointer controlPacket) {
     
     // indicate that handshake has been received
     _hasReceivedHandshake = true;
+
+    emit receiverHandshakeComplete(_destination);
 }
 
 void Connection::processHandshakeACK(ControlPacketPointer controlPacket) {

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -434,6 +434,8 @@ bool Connection::processReceivedSequenceNumber(SequenceNumber sequenceNumber, in
         auto handshakeRequestPacket = ControlPacket::create(ControlPacket::HandshakeRequest, 0);
         _parentSocket->writeBasePacket(*handshakeRequestPacket, _destination);
 
+        _didRequestHandshake = true;
+
 #ifdef UDT_CONNECTION_DEBUG
         qCDebug(networking) << "Received packet before receiving handshake, sending HandshakeRequest";
 #endif
@@ -790,7 +792,10 @@ void Connection::processHandshake(ControlPacketPointer controlPacket) {
     // indicate that handshake has been received
     _hasReceivedHandshake = true;
 
-    emit receiverHandshakeComplete(_destination);
+    if (_didRequestHandshake) {
+        emit receiverHandshakeRequestComplete(_destination);
+        _didRequestHandshake = false;
+    }
 }
 
 void Connection::processHandshakeACK(ControlPacketPointer controlPacket) {

--- a/libraries/networking/src/udt/Connection.h
+++ b/libraries/networking/src/udt/Connection.h
@@ -79,6 +79,8 @@ public:
 
     void setMaxBandwidth(int maxBandwidth);
 
+    void sendHandshakeRequest();
+
 signals:
     void packetSent();
     void connectionInactive(const HifiSockAddr& sockAddr);

--- a/libraries/networking/src/udt/Connection.h
+++ b/libraries/networking/src/udt/Connection.h
@@ -82,7 +82,7 @@ public:
 signals:
     void packetSent();
     void connectionInactive(const HifiSockAddr& sockAddr);
-    void receiverHandshakeComplete(const HifiSockAddr& sockAddr);
+    void receiverHandshakeRequestComplete(const HifiSockAddr& sockAddr);
 
 private slots:
     void recordSentPackets(int payload, int total);
@@ -130,6 +130,7 @@ private:
     
     bool _hasReceivedHandshake { false }; // flag for receipt of handshake from server
     bool _hasReceivedHandshakeACK { false }; // flag for receipt of handshake ACK from client
+    bool _didRequestHandshake { false }; // flag for request of handshake from server
    
     p_high_resolution_clock::time_point _connectionStart = p_high_resolution_clock::now(); // holds the time_point for creation of this connection
     p_high_resolution_clock::time_point _lastReceiveTime; // holds the last time we received anything from sender

--- a/libraries/networking/src/udt/Connection.h
+++ b/libraries/networking/src/udt/Connection.h
@@ -82,7 +82,8 @@ public:
 signals:
     void packetSent();
     void connectionInactive(const HifiSockAddr& sockAddr);
-    
+    void receiverHandshakeComplete(const HifiSockAddr& sockAddr);
+
 private slots:
     void recordSentPackets(int payload, int total);
     void recordRetransmission();

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -237,7 +237,8 @@ Connection* Socket::findOrCreateConnection(const HifiSockAddr& sockAddr) {
             QObject::connect(connection.get(), &Connection::connectionInactive, this, &Socket::cleanupConnection);
 
             // allow higher-level classes to find out when connections have completed a handshake
-            QObject::connect(connection.get(), &Connection::receiverHandshakeComplete, this, &Socket::clientHandshakeComplete);
+            QObject::connect(connection.get(), &Connection::receiverHandshakeRequestComplete,
+                             this, &Socket::clientHandshakeRequestComplete);
 
 #ifdef UDT_CONNECTION_DEBUG
             qCDebug(networking) << "Creating new connection to" << sockAddr;

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -464,3 +464,14 @@ void Socket::handleStateChanged(QAbstractSocket::SocketState socketState) {
         qCWarning(networking) << "udt::Socket state changed - state is now" << socketState;
     }
 }
+
+#if (PR_BUILD || DEV_BUILD)
+
+void Socket::sendFakedHandshakeRequest(const HifiSockAddr& sockAddr) {
+    auto connection = findOrCreateConnection(sockAddr);
+    if (connection) {
+        connection->sendHandshakeRequest();
+    }
+}
+
+#endif

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -236,6 +236,9 @@ Connection* Socket::findOrCreateConnection(const HifiSockAddr& sockAddr) {
             // we queue the connection to cleanup connection in case it asks for it during its own rate control sync
             QObject::connect(connection.get(), &Connection::connectionInactive, this, &Socket::cleanupConnection);
 
+            // allow higher-level classes to find out when connections have completed a handshake
+            QObject::connect(connection.get(), &Connection::receiverHandshakeComplete, this, &Socket::clientHandshakeComplete);
+
 #ifdef UDT_CONNECTION_DEBUG
             qCDebug(networking) << "Creating new connection to" << sockAddr;
 #endif

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -171,11 +171,28 @@ qint64 Socket::writePacketList(std::unique_ptr<PacketList> packetList, const Hif
 }
 
 void Socket::writeReliablePacket(Packet* packet, const HifiSockAddr& sockAddr) {
-    findOrCreateConnection(sockAddr, true)->sendReliablePacket(std::unique_ptr<Packet>(packet));
+    auto connection = findOrCreateConnection(sockAddr);
+    if (connection) {
+        connection->sendReliablePacket(std::unique_ptr<Packet>(packet));
+    }
+#ifdef UDT_CONNECTION_DEBUG
+    else {
+        qCDebug(networking) << "Socket::writeReliablePacket refusing to send packet - no connection was created";
+    }
+#endif
+
 }
 
 void Socket::writeReliablePacketList(PacketList* packetList, const HifiSockAddr& sockAddr) {
-    findOrCreateConnection(sockAddr, true)->sendReliablePacketList(std::unique_ptr<PacketList>(packetList));
+    auto connection = findOrCreateConnection(sockAddr);
+    if (connection) {
+        connection->sendReliablePacketList(std::unique_ptr<PacketList>(packetList));
+    }
+#ifdef UDT_CONNECTION_DEBUG
+    else {
+        qCDebug(networking) << "Socket::writeReliablePacketList refusing to send packet list - no connection was created";
+    }
+#endif
 }
 
 qint64 Socket::writeDatagram(const char* data, qint64 size, const HifiSockAddr& sockAddr) {
@@ -198,34 +215,33 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const HifiSockAddr& soc
     return bytesWritten;
 }
 
-Connection* Socket::findOrCreateConnection(const HifiSockAddr& sockAddr, bool forceCreation) {
+Connection* Socket::findOrCreateConnection(const HifiSockAddr& sockAddr) {
     auto it = _connectionsHash.find(sockAddr);
 
     if (it == _connectionsHash.end()) {
         // we did not have a matching connection, time to see if we should make one
 
-        if (!forceCreation && _connectionCreationFilterOperator && !_connectionCreationFilterOperator(sockAddr)) {
-            // we weren't asked to force the creation of a connection
-            // and the connection creation filter did not tell us to create one
+        if (_connectionCreationFilterOperator && !_connectionCreationFilterOperator(sockAddr)) {
+            // the connection creation filter did not allow us to create a new connection
 #ifdef UDT_CONNECTION_DEBUG
             qCDebug(networking) << "Socket::findOrCreateConnection refusing to create connection for" << sockAddr
                 << "due to connection creation filter";
 #endif
             return nullptr;
-        }
+        } else {
+            auto congestionControl = _ccFactory->create();
+            congestionControl->setMaxBandwidth(_maxBandwidth);
+            auto connection = std::unique_ptr<Connection>(new Connection(this, sockAddr, std::move(congestionControl)));
 
-        auto congestionControl = _ccFactory->create();
-        congestionControl->setMaxBandwidth(_maxBandwidth);
-        auto connection = std::unique_ptr<Connection>(new Connection(this, sockAddr, std::move(congestionControl)));
-
-        // we queue the connection to cleanup connection in case it asks for it during its own rate control sync
-        QObject::connect(connection.get(), &Connection::connectionInactive, this, &Socket::cleanupConnection);
+            // we queue the connection to cleanup connection in case it asks for it during its own rate control sync
+            QObject::connect(connection.get(), &Connection::connectionInactive, this, &Socket::cleanupConnection);
 
 #ifdef UDT_CONNECTION_DEBUG
-        qCDebug(networking) << "Creating new connection to" << sockAddr;
+            qCDebug(networking) << "Creating new connection to" << sockAddr;
 #endif
 
-        it = _connectionsHash.insert(it, std::make_pair(sockAddr, std::move(connection)));
+            it = _connectionsHash.insert(it, std::make_pair(sockAddr, std::move(connection)));
+        }
     }
 
     return it->second.get();

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -83,6 +83,10 @@ public:
     
     StatsVector sampleStatsForAllConnections();
 
+#if (PR_BUILD || DEV_BUILD)
+    void sendFakedHandshakeRequest(const HifiSockAddr& sockAddr);
+#endif
+
 signals:
     void clientHandshakeRequestComplete(const HifiSockAddr& sockAddr);
 

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -25,7 +25,7 @@
 #include "CongestionControl.h"
 #include "Connection.h"
 
-//#define UDT_CONNECTION_DEBUG
+#define UDT_CONNECTION_DEBUG
 
 class UDTTest;
 
@@ -96,7 +96,7 @@ private slots:
 
 private:
     void setSystemBufferSizes();
-    Connection* findOrCreateConnection(const HifiSockAddr& sockAddr, bool forceCreation = false);
+    Connection* findOrCreateConnection(const HifiSockAddr& sockAddr);
     bool socketMatchesNodeOrDomain(const HifiSockAddr& sockAddr);
    
     // privatized methods used by UDTTest - they are private since they must be called on the Socket thread

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -84,7 +84,7 @@ public:
     StatsVector sampleStatsForAllConnections();
 
 signals:
-    void clientHandshakeComplete(const HifiSockAddr& sockAddr);
+    void clientHandshakeRequestComplete(const HifiSockAddr& sockAddr);
 
 public slots:
     void cleanupConnection(HifiSockAddr sockAddr);

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -83,6 +83,9 @@ public:
     
     StatsVector sampleStatsForAllConnections();
 
+signals:
+    void clientHandshakeComplete(const HifiSockAddr& sockAddr);
+
 public slots:
     void cleanupConnection(HifiSockAddr sockAddr);
     void clearConnections();

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -25,7 +25,7 @@
 #include "CongestionControl.h"
 #include "Connection.h"
 
-#define UDT_CONNECTION_DEBUG
+//#define UDT_CONNECTION_DEBUG
 
 class UDTTest;
 

--- a/libraries/script-engine/src/AssetScriptingInterface.cpp
+++ b/libraries/script-engine/src/AssetScriptingInterface.cpp
@@ -17,6 +17,7 @@
 #include <AssetUpload.h>
 #include <MappingRequest.h>
 #include <NetworkLogging.h>
+#include <NodeList.h>
 
 AssetScriptingInterface::AssetScriptingInterface(QScriptEngine* engine) :
     _engine(engine)
@@ -86,3 +87,13 @@ void AssetScriptingInterface::downloadData(QString urlString, QScriptValue callb
 
     assetRequest->start();
 }
+
+#if (PR_BUILD || DEV_BUILD)
+void AssetScriptingInterface::sendFakedHandshake() {
+    auto nodeList = DependencyManager::get<NodeList>();
+    SharedNodePointer assetServer = nodeList->soloNodeOfType(NodeType::AssetServer);
+
+    nodeList->sendFakedHandshakeRequestToNode(assetServer);
+}
+
+#endif

--- a/libraries/script-engine/src/AssetScriptingInterface.h
+++ b/libraries/script-engine/src/AssetScriptingInterface.h
@@ -28,6 +28,10 @@ public:
     Q_INVOKABLE void downloadData(QString url, QScriptValue downloadComplete);
     Q_INVOKABLE void setMapping(QString path, QString hash, QScriptValue callback);
 
+#if (PR_BUILD || DEV_BUILD)
+    Q_INVOKABLE void sendFakedHandshake();
+#endif
+
 protected:
     QSet<AssetRequest*> _pendingRequests;
     QScriptEngine* _engine;


### PR DESCRIPTION
- fixed an issue with stuck AssetClient requests made after adding Asset Server but before activating Asset Server socket
- fixed an issue with multiple Asset Servers being added to Interface NodeList (Asset Server should have been a solo node like Audio Mixer and Avatar Mixer)
- fixed an issue with lost/stuck asset requests on Asset Server quick disconnect/reconnect
- added faked handshake function to AssetScriptingInterface in PR_BUILD and DEV_BUILD
- fixed an issue with udt::Connections created for nodes no longer present in NodeList
- fixed an issue with udt::SendQueue timeout when no response had ever been received