### PR TITLE
Don't crash on OpenVR activation when SteamVR isn't running

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -414,6 +414,7 @@ void OpenGLDisplayPlugin::customizeContext() {
             _cursorPipeline = gpu::Pipeline::create(program, state);
         }
     }
+    updateCompositeFramebuffer();
 }
 
 void OpenGLDisplayPlugin::uncustomizeContext() {
@@ -557,10 +558,7 @@ void OpenGLDisplayPlugin::compositeScene() {
 }
 
 void OpenGLDisplayPlugin::compositeLayers() {
-    auto renderSize = getRecommendedRenderSize();
-    if (!_compositeFramebuffer || _compositeFramebuffer->getSize() != renderSize) {
-        _compositeFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("displayPlugin::composite", gpu::Element::COLOR_RGBA_32, renderSize.x, renderSize.y));
-    }
+    updateCompositeFramebuffer();
 
     {
         PROFILE_RANGE_EX("compositeScene", 0xff0077ff, (uint64_t)presentCount())
@@ -759,4 +757,11 @@ void OpenGLDisplayPlugin::render(std::function<void(gpu::Batch& batch)> f) {
 
 OpenGLDisplayPlugin::~OpenGLDisplayPlugin() {
     qDebug() << "Destroying OpenGLDisplayPlugin";
+}
+
+void OpenGLDisplayPlugin::updateCompositeFramebuffer() {
+    auto renderSize = getRecommendedRenderSize();
+    if (!_compositeFramebuffer || _compositeFramebuffer->getSize() != renderSize) {
+        _compositeFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("OpenGLDisplayPlugin::composite", gpu::Element::COLOR_RGBA_32, renderSize.x, renderSize.y));
+    }
 }

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -78,6 +78,8 @@ protected:
     glm::uvec2 getSurfaceSize() const;
     glm::uvec2 getSurfacePixels() const;
 
+    void updateCompositeFramebuffer();
+
     virtual void compositeLayers();
     virtual void compositeScene();
     virtual void compositeOverlay();

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -377,9 +377,6 @@ void OpenVrDisplayPlugin::init() {
 }
 
 bool OpenVrDisplayPlugin::internalActivate() {
-    _openVrDisplayActive = true;
-    _container->setIsOptionChecked(StandingHMDSensorMode, true);
-
     if (!_system) {
         _system = acquireOpenVrSystem();
     }
@@ -387,6 +384,18 @@ bool OpenVrDisplayPlugin::internalActivate() {
         qWarning() << "Failed to initialize OpenVR";
         return false;
     }
+
+    // If OpenVR isn't running, then the compositor won't be accessible
+    // FIXME find a way to launch the compositor?
+    if (!vr::VRCompositor()) {
+        qWarning() << "Failed to acquire OpenVR compositor";
+        releaseOpenVrSystem();
+        _system = nullptr;
+        return false;
+    }
+
+    _openVrDisplayActive = true;
+    _container->setIsOptionChecked(StandingHMDSensorMode, true);
 
     _system->GetRecommendedRenderTargetSize(&_renderTargetSize.x, &_renderTargetSize.y);
     // Recommended render target size is per-eye, so double the X size for 

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -109,8 +109,12 @@ void releaseOpenVrSystem() {
             vr::Texture_t vrTexture{ (void*)INVALID_GL_TEXTURE_HANDLE, vr::API_OpenGL, vr::ColorSpace_Auto };
             static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_LEFT{ 0, 0, 0.5f, 1 };
             static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_RIGHT{ 0.5f, 0, 1, 1 };
-            vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
-            vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);
+
+            auto compositor = vr::VRCompositor();
+            if (compositor) {
+                compositor->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
+                compositor->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);
+            }
 
             vr::VR_Shutdown();
             _openVrQuitRequested = false;


### PR DESCRIPTION
## Testing 

With a Vive HMD installed, but SteamVR NOT running, switch to the OpenVR display plugin.  In production it will crash (and also crash on startup if OpenVR is the currently active plugin when you last shut down).  In this build it should not crash, but simply continue rendering with the 2D display plugin.