### PR TITLE
fix entity-import with only tmp-rez rights

### DIFF
--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -365,6 +365,7 @@ inline QDebug operator<<(QDebug debug, const EntityItemProperties& properties) {
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, Damping, damping, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, Restitution, restitution, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, Friction, friction, "");
+    DEBUG_PROPERTY_IF_CHANGED(debug, properties, Created, created, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, Lifetime, lifetime, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, Script, script, "");
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, ScriptTimestamp, scriptTimestamp, "");

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -945,7 +945,9 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                     properties.setLifetime(_maxTmpEntityLifetime);
                     // also bump up the lastEdited time of the properties so that the interface that created this edit
                     // will accept our adjustment to lifetime back into its own entity-tree.
-                    properties.setLastEdited(properties.getLastEdited() + LAST_EDITED_SERVERSIDE_BUMP);
+                    if (properties.getLastEdited() != UNKNOWN_CREATED_TIME) {
+                        properties.setLastEdited(properties.getLastEdited() + LAST_EDITED_SERVERSIDE_BUMP);
+                    }
                 }
             }
 

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -945,9 +945,10 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                     properties.setLifetime(_maxTmpEntityLifetime);
                     // also bump up the lastEdited time of the properties so that the interface that created this edit
                     // will accept our adjustment to lifetime back into its own entity-tree.
-                    if (properties.getLastEdited() != UNKNOWN_CREATED_TIME) {
-                        properties.setLastEdited(properties.getLastEdited() + LAST_EDITED_SERVERSIDE_BUMP);
+                    if (properties.getLastEdited() == UNKNOWN_CREATED_TIME) {
+                        properties.setLastEdited(usecTimestampNow());
                     }
+                    properties.setLastEdited(properties.getLastEdited() + LAST_EDITED_SERVERSIDE_BUMP);
                 }
             }
 


### PR DESCRIPTION
- it's now possible to import (with menu or market) entities in places where you have only tmp-rez rights
