### PR TITLE
CellScience play button doesn't play anything

### DIFF
--- a/unpublishedScripts/DomainContent/CellScience/Scripts/showButtonToPlaySound.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/showButtonToPlaySound.js
@@ -6,7 +6,7 @@
 //
 
 (function() {
-    var baseURL = "https://hifi-production.s3.amazonaws.com/hifi-production/DomainContent/CellScience/";
+    var baseURL = "https://hifi-production.s3.amazonaws.com/DomainContent/CellScience/";
     var self = this;
     this.buttonImageURL = baseURL + "GUI/play_audio.svg?2";
 

--- a/unpublishedScripts/DomainContent/CellScience/Scripts/showIdentification.js
+++ b/unpublishedScripts/DomainContent/CellScience/Scripts/showIdentification.js
@@ -47,8 +47,7 @@
                 stereo: true,
                 loop: false,
                 localOnly: true,
-                volume: 0.035,
-                position: properties.position
+                volume: 0.45,
             };
             self.sound = SoundCache.getSound(self.soundURL);
             self.buttonImageURL = baseURL + "GUI/GUI_audio.png?" + version;
@@ -142,6 +141,7 @@
                 Overlays.editOverlay(self.button, {
                     visible: false
                 });
+                self.soundOptions.position = MyAvatar.position;
                 this.soundPlaying = Audio.playSound(self.sound, self.soundOptions);
             } else {
                 // print("not downloaded");


### PR DESCRIPTION
Turns out an entity script is calling Audio.playSound(...), which is localOnly and stereo, but the position is far away from where you are.  Used to be that was fine -- localOnly just played into your ears.   Now we adjust the volume based on distance, and if mono we HRTF it too.  So, that sound just is too faint to hear.

Simple solution is use your avatar's position.  Also bumped the volume a bit since it was really low.

I've now uploaded this to the _correct_ spot in S3.

*Note that the old version of the script will be cached unless you wipe your cache - reload content should do the trick*