### PR TITLE
Fix AMD crash caused by missing glFlush

### DIFF
--- a/libraries/gl/src/gl/TextureRecycler.cpp
+++ b/libraries/gl/src/gl/TextureRecycler.cpp
@@ -37,27 +37,35 @@ void TextureRecycler::clear() {
     _allTextures.clear();
 }
 
+void TextureRecycler::addTexture() {
+    uint32_t newTexture;
+    glGenTextures(1, &newTexture);
+    glBindTexture(GL_TEXTURE_2D, newTexture);
+    if (_useMipmaps) {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    } else {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    }
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 8.0f);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.2f);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 8.0f);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, _size.x, _size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+    _allTextures.emplace(std::piecewise_construct, std::forward_as_tuple(newTexture), std::forward_as_tuple(newTexture, _size));
+    _readyTextures.push(newTexture);
+}
+
 uint32_t TextureRecycler::getNextTexture() {
+    while (_allTextures.size() < _textureCount) {
+        addTexture();
+    }
+
     if (_readyTextures.empty()) {
-        uint32_t newTexture;
-        glGenTextures(1, &newTexture);
-        glBindTexture(GL_TEXTURE_2D, newTexture);
-        if (_useMipmaps) {
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-        } else {
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        }
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 8.0f);
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.2f);
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 8.0f); 
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, _size.x, _size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
-        _allTextures.emplace(std::piecewise_construct, std::forward_as_tuple(newTexture), std::forward_as_tuple(newTexture, _size));
-        _readyTextures.push(newTexture);
+        addTexture();
     }
 
     uint32_t result = _readyTextures.front();

--- a/libraries/gl/src/gl/TextureRecycler.h
+++ b/libraries/gl/src/gl/TextureRecycler.h
@@ -19,11 +19,13 @@ class TextureRecycler {
 public:
     TextureRecycler(bool useMipmaps) : _useMipmaps(useMipmaps) {}
     void setSize(const uvec2& size);
+    void setTextureCount(uint8_t textureCount);
     void clear();
     uint32_t getNextTexture();
     void recycleTexture(uint32_t texture);
 
 private:
+    void addTexture();
 
     struct TexInfo {
         const uint32_t _tex{ 0 };
@@ -42,6 +44,7 @@ private:
     Queue _readyTextures;
     uvec2 _size{ 1920, 1080 };
     bool _useMipmaps;
+    uint8_t _textureCount { 3 };
 };
 
 #endif

--- a/libraries/gl/src/gl/TextureRecycler.h
+++ b/libraries/gl/src/gl/TextureRecycler.h
@@ -15,6 +15,10 @@
 
 #include <GLMHelpers.h>
 
+// GPU resources are typically buffered for one copy being used by the renderer, 
+// one copy in flight, and one copy being used by the receiver
+#define GPU_RESOURCE_BUFFER_SIZE 3
+
 class TextureRecycler {
 public:
     TextureRecycler(bool useMipmaps) : _useMipmaps(useMipmaps) {}
@@ -44,7 +48,7 @@ private:
     Queue _readyTextures;
     uvec2 _size{ 1920, 1080 };
     bool _useMipmaps;
-    uint8_t _textureCount { 3 };
+    uint8_t _textureCount { GPU_RESOURCE_BUFFER_SIZE };
 };
 
 #endif


### PR DESCRIPTION
AMD cards are much more demanding of proper OpenGL fence handling.  Creating a fence in one context for use in another *requires* a flush on the creating context before the fence is used on the receiving context.  In the case of this bug, it was possible for a texture to be released by the scene render thread and passed back to the QML rendering, which would attempt to wait and destroy a fence, prior to that fence being flushed through the command queue on the scene render thread.  

This change modifies the code so that we always do a flush between creating any such fences and handing them back to their respective source contexts.

Additionally, the texture recycler now maintains a minimum of 3 textures in it's cycle buffer for use, to avoid congestion.

## Testing

Interface should no longer crash immediately on startup with AMD GPUs.