### PR TITLE
never interact with hud elements while holding something

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -15,9 +15,9 @@
 
 (function() { // BEGIN LOCAL_SCOPE
 
-Script.include("/~/system/libraries/utils.js");
-Script.include("/~/system/libraries/Xform.js");
-Script.include("/~/system/libraries/controllers.js");
+Script.include("../libraries/utils.js");
+Script.include("../libraries/Xform.js");
+Script.include("../libraries/controllers.js");
 
 //
 // add lines where the hand ray picking is happening
@@ -792,7 +792,7 @@ function MyController(hand) {
     };
 
     this.setState = function(newState, reason) {
-
+        setGrabCommunications((newState === STATE_DISTANCE_HOLDING) || (newState === STATE_NEAR_GRABBING));
         if (WANT_DEBUG || WANT_DEBUG_STATE) {
             var oldStateName = stateToName(this.state);
             var newStateName = stateToName(newState);

--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -20,7 +20,7 @@
 // When partially squeezing over a HUD element, a laser or the reticle is shown where the active hand
 // controller beam intersects the HUD.
 
-Script.include("/~/system/libraries/controllers.js");
+Script.include("../libraries/controllers.js");
 
 // UTILITIES -------------
 //
@@ -483,6 +483,9 @@ function update() {
     rightTrigger.update();
     if (!activeTrigger.state) {
         return off(); // No trigger
+    }
+    if (getGrabCommunications()) {
+        return off();
     }
     var hudPoint2d = activeHudPoint2d(activeHand);
     if (!hudPoint2d) {

--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -7,6 +7,14 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 /* global MyAvatar, Vec3, Controller, Quat */
 
+var GRAB_COMMUNICATIONS_SETTING = "io.highfidelity.isFarGrabbing";
+setGrabCommunications = function setFarGrabCommunications(on) {
+    Settings.setValue(GRAB_COMMUNICATIONS_SETTING, on ? "on" : "");
+}
+getGrabCommunications = function getFarGrabCommunications() {
+    return !!Settings.getValue(GRAB_COMMUNICATIONS_SETTING, "");
+}
+
 
 // var GRAB_POINT_SPHERE_OFFSET = { x: 0, y: 0.2, z: 0 };
 // var GRAB_POINT_SPHERE_OFFSET = { x: 0.1, y: 0.175, z: 0.04 };


### PR DESCRIPTION
If you have near grabbed or far grabbed something, don't interact with hud elements.
Fixes at least the frist case of https://highfidelity.fogbugz.com/f/cases/1849/Double-lasers-when-over-HUD, and possibly the second.

Test plan:
- Far grab something and wave it behind or "in front" of a hud element. The hand-to-hud laser should not show up while you're holding it, and hud buttons should not highlight or interact.
- Repeat for near grabbing something.
Note that the hud elements are always drawn "on top", even when an object (grabbed or otherwise) is "closer". That does not change with this PR.

Also makes scripts use relative references, so you don't waste time debugging an included script that hasn't changed though you think you've edited it.