### PR TITLE
fix cellscience ac script load

### DIFF
--- a/unpublishedScripts/DomainContent/CellScience/moveCellsAC.js
+++ b/unpublishedScripts/DomainContent/CellScience/moveCellsAC.js
@@ -39,11 +39,13 @@ var THROTTLE = true;
 var THROTTLE_RATE = 5000;
 
 var sinceLastUpdate = 0;
+var entitiesToMove = [];
 
 //print('cells script')
 
 function findCells() {
     var results = Entities.findEntities(basePosition, 60000);
+    Script.clearInterval(octreeQueryInterval); // we don't need it any more
 
     if (results.length === 0) {
         //    print('no entities found')
@@ -55,9 +57,7 @@ function findCells() {
         //  print('name is:: ' + name)
         if (name === 'Cell') {
             //   print('found a cell!!' + v)
-            Script.setTimeout(function() {
-                moveCell(v);
-            }, Math.random() * THROTTLE_RATE);
+            entitiesToMove.push(v);
         }
     });
 }
@@ -93,6 +93,7 @@ function update(deltaTime) {
             Entities.setPacketsPerSecond(6000);
             print("PPS:" + Entities.getPacketsPerSecond());
             initialized = true;
+            Script.setTimeout(findCells, 20 * 1000); // After 20 seconds of getting entities, look for cells.
         }
         return;
     }
@@ -102,7 +103,11 @@ function update(deltaTime) {
         if (sinceLastUpdate > THROTTLE_RATE) {
             //     print('SHOULD FIND CELLS!!!')
             sinceLastUpdate = 0;
-            findCells();
+            entitiesToMove.forEach(function (v) {
+                Script.setTimeout(function() {
+                    moveCell(v);
+                }, Math.random() * THROTTLE_RATE); // don't move all of them every five seconds, but at random times over interval
+            });
         } else {
             // print('returning in update ' + sinceLastUpdate)
             return;

--- a/unpublishedScripts/DomainContent/CellScience/moveVesiclesAC.js
+++ b/unpublishedScripts/DomainContent/CellScience/moveVesiclesAC.js
@@ -39,11 +39,13 @@ var THROTTLE = true;
 var THROTTLE_RATE = 5000;
 
 var sinceLastUpdate = 0;
+var entitiesToMove = [];
 
 //print('vesicle script')
 
 function findVesicles() {
     var results = Entities.findEntities(basePosition, 60000);
+    Script.clearInterval(octreeQueryInterval); // we don't need it any more
 
     if (results.length === 0) {
         // print('no entities found');
@@ -54,9 +56,7 @@ function findVesicles() {
         var name = Entities.getEntityProperties(v, 'name').name;
         if (name === 'vesicle') {
             //print('found a vesicle!!' + v)
-            Script.setTimeout(function() {
-                moveVesicle(v);
-            }, Math.random() * THROTTLE_RATE);
+            entitiesToMove.push(v);
         }
     });
 }
@@ -100,6 +100,7 @@ function update(deltaTime) {
             Entities.setPacketsPerSecond(6000);
             print("PPS:" + Entities.getPacketsPerSecond());
             initialized = true;
+            Script.setTimeout(findVesicles, 20 * 1000); // After 20 seconds of getting entities, look for cells.
         }
         return;
     }
@@ -108,7 +109,11 @@ function update(deltaTime) {
         sinceLastUpdate = sinceLastUpdate + deltaTime * 1000;
         if (sinceLastUpdate > THROTTLE_RATE) {
             sinceLastUpdate = 0;
-            findVesicles();
+            entitiesToMove.forEach(function (v) {
+                Script.setTimeout(function() {
+                    moveVesicle(v);
+                }, Math.random() * THROTTLE_RATE); // don't move all of them every five seconds, but at random times over interval
+            });
         } else {
             return;
         }


### PR DESCRIPTION
Get Cells and vesicles just once, 20 seconds after we start querying (and shut down queries).

Fixes https://highfidelity.fogbugz.com/f/cases/1960/cell-science-AC-scripts-cause-entity-server-to-spike-CPU