### PR TITLE
Fix race condition in BatchLoader

### DIFF
--- a/libraries/script-engine/src/BatchLoader.cpp
+++ b/libraries/script-engine/src/BatchLoader.cpp
@@ -48,6 +48,11 @@ void BatchLoader::start() {
             if (!self) {
                 return;
             }
+
+            // Because the ScriptCache may call this callback from differents threads,
+            // we need to make sure this is thread-safe.
+            std::lock_guard<std::mutex> lock(_dataLock);
+
             if (isURL && success) {
                 _data.insert(url, contents);
                 qCDebug(scriptengine) << "Loaded: " << url;
@@ -55,16 +60,11 @@ void BatchLoader::start() {
                 _data.insert(url, QString());
                 qCDebug(scriptengine) << "Could not load" << url;
             }
-            checkFinished();
+
+            if (!_finished && _urls.size() == _data.size()) {
+                _finished = true;
+                emit finished(_data);
+            }
         }, false);
-    }
-
-    checkFinished();
-}
-
-void BatchLoader::checkFinished() {
-    if (!_finished && _urls.size() == _data.size()) {
-        _finished = true;
-        emit finished(_data);
     }
 }

--- a/libraries/script-engine/src/BatchLoader.h
+++ b/libraries/script-engine/src/BatchLoader.h
@@ -19,6 +19,8 @@
 #include <QString>
 #include <QUrl>
 
+#include <mutex>
+
 class BatchLoader : public QObject {
     Q_OBJECT
 public:
@@ -37,6 +39,7 @@ private:
     bool _finished;
     QSet<QUrl> _urls;
     QMap<QUrl, QString> _data;
+    std::mutex _dataLock;
 };
 
 #endif // hifi_BatchLoader_h


### PR DESCRIPTION
There were 2 potential issues here:
 1. `checkFinished` was getting called at the end of `start`, which created a possible crash if the ScriptCache callback was called quickly after the request was made (say, if the script was in the disk cache).
 2. `ScriptCache` doesn't guarantee that the callbacks will be called on the same thread. In particular, if the script is in the cache, the callback will be called on the thread that `getScriptContents` was called on, but if it's not it will be called from the thread that `ScriptCache` lives on.