### PR TITLE
check for empty snapshot dir, and default to temp

### DIFF
--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -106,7 +106,7 @@ QFile* Snapshot::savedFileForSnapshot(QImage & shot, bool isTemporary) {
         QString snapshotFullPath = snapshotsLocation.get();
 
         if (snapshotFullPath.isEmpty()) {
-            snapshotFullPath = QFileDialog::getExistingDirectory(nullptr, "Choose Snapshots Directory", snapshotsLocation.get());
+            snapshotFullPath = OffscreenUi::getExistingDirectory(nullptr, "Choose Snapshots Directory", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
             snapshotsLocation.set(snapshotFullPath);
         }
 

--- a/interface/src/ui/Snapshot.h
+++ b/interface/src/ui/Snapshot.h
@@ -39,7 +39,6 @@ public:
     static SnapshotMetaData* parseSnapshotData(QString snapshotPath);
 
     static Setting::Handle<QString> snapshotsLocation;
-    static Setting::Handle<bool> hasSetSnapshotsLocation;
     static void uploadSnapshot(const QString& filename);
 private:
     static QFile* savedFileForSnapshot(QImage & image, bool isTemporary);

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -616,12 +616,38 @@ QString OffscreenUi::fileSaveDialog(const QString& caption, const QString& dir, 
     return fileDialog(map);
 }
 
+QString OffscreenUi::existingDirectoryDialog(const QString& caption, const QString& dir, const QString& filter, QString* selectedFilter, QFileDialog::Options options) {
+    if (QThread::currentThread() != thread()) {
+        QString result;
+        QMetaObject::invokeMethod(this, "existingDirectoryDialog", Qt::BlockingQueuedConnection,
+                                  Q_RETURN_ARG(QString, result),
+                                  Q_ARG(QString, caption),
+                                  Q_ARG(QString, dir),
+                                  Q_ARG(QString, filter),
+                                  Q_ARG(QString*, selectedFilter),
+                                  Q_ARG(QFileDialog::Options, options));
+        return result;
+    }
+
+    QVariantMap map;
+    map.insert("caption", caption);
+    map.insert("dir", QUrl::fromLocalFile(dir));
+    map.insert("filter", filter);
+    map.insert("options", static_cast<int>(options));
+    map.insert("selectDirectory", true);
+    return fileDialog(map);
+}
+
 QString OffscreenUi::getOpenFileName(void* ignored, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options) {
     return DependencyManager::get<OffscreenUi>()->fileOpenDialog(caption, dir, filter, selectedFilter, options);
 }
 
 QString OffscreenUi::getSaveFileName(void* ignored, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options) {
     return DependencyManager::get<OffscreenUi>()->fileSaveDialog(caption, dir, filter, selectedFilter, options);
+}
+
+QString OffscreenUi::getExistingDirectory(void* ignored, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options) {
+    return DependencyManager::get<OffscreenUi>()->existingDirectoryDialog(caption, dir, filter, selectedFilter, options);
 }
 
 bool OffscreenUi::eventFilter(QObject* originalDestination, QEvent* event) {

--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -115,11 +115,14 @@ public:
 
     Q_INVOKABLE QString fileOpenDialog(const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
     Q_INVOKABLE QString fileSaveDialog(const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
+    Q_INVOKABLE QString existingDirectoryDialog(const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
 
     // Compatibility with QFileDialog::getOpenFileName
     static QString getOpenFileName(void* ignored, const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
     // Compatibility with QFileDialog::getSaveFileName
     static QString getSaveFileName(void* ignored, const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
+    // Compatibility with QFileDialog::getExistingDirectory
+    static QString getExistingDirectory(void* ignored, const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = 0, QFileDialog::Options options = 0);
 
     Q_INVOKABLE QVariant inputDialog(const Icon icon, const QString& title, const QString& label = QString(), const QVariant& current = QVariant());
     Q_INVOKABLE QVariant customInputDialog(const Icon icon, const QString& title, const QVariantMap& config);


### PR DESCRIPTION
fixes https://highfidelity.fogbugz.com/f/cases/1815

To test:
- start with a delete Interface.ini, or remove any line that starts with 'snapshotsLocation=' in it.
- snapshot button and ctrl-s should prompt for directory to save in.
- cancelling the snapshot directory prompt should still save to to a temp directory (with both snapshot both and ctrl-s), but should not result in creating the snapshotsLocation= setting in the .ini. A subsequent snapshot should again prompt for a directory.
- Snapshots should NOT ask for a directory after EITHER picking a directory when prompted, or after saving a snapshot directory in general settings.
- Changing the value in general setting should work.