### PR TITLE
Fix GPU buffer leak in geometry cache / overlays

### DIFF
--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -19,6 +19,7 @@ QString const Circle3DOverlay::TYPE = "circle3d";
 Circle3DOverlay::Circle3DOverlay() {
     memset(&_minorTickMarksColor, 0, sizeof(_minorTickMarksColor));
     memset(&_majorTickMarksColor, 0, sizeof(_majorTickMarksColor));
+    qDebug() << "Building circle3d overlay";
 }
 
 Circle3DOverlay::Circle3DOverlay(const Circle3DOverlay* circle3DOverlay) :
@@ -39,8 +40,25 @@ Circle3DOverlay::Circle3DOverlay(const Circle3DOverlay* circle3DOverlay) :
     _majorTicksVerticesID(GeometryCache::UNKNOWN_ID),
     _minorTicksVerticesID(GeometryCache::UNKNOWN_ID)
 {
+    qDebug() << "Building circle3d overlay";
 }
 
+Circle3DOverlay::~Circle3DOverlay() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (_quadVerticesID) {
+        geometryCache->releaseID(_quadVerticesID);
+    }
+    if (_lineVerticesID) {
+        geometryCache->releaseID(_lineVerticesID);
+    }
+    if (_majorTicksVerticesID) {
+        geometryCache->releaseID(_majorTicksVerticesID);
+    }
+    if (_minorTicksVerticesID) {
+        geometryCache->releaseID(_minorTicksVerticesID);
+    }
+    qDebug() << "Destroying circle3d overlay";
+}
 void Circle3DOverlay::render(RenderArgs* args) {
     if (!_visible) {
         return; // do nothing if we're not visible

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -45,17 +45,19 @@ Circle3DOverlay::Circle3DOverlay(const Circle3DOverlay* circle3DOverlay) :
 
 Circle3DOverlay::~Circle3DOverlay() {
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    if (_quadVerticesID) {
-        geometryCache->releaseID(_quadVerticesID);
-    }
-    if (_lineVerticesID) {
-        geometryCache->releaseID(_lineVerticesID);
-    }
-    if (_majorTicksVerticesID) {
-        geometryCache->releaseID(_majorTicksVerticesID);
-    }
-    if (_minorTicksVerticesID) {
-        geometryCache->releaseID(_minorTicksVerticesID);
+    if (geometryCache) {
+        if (_quadVerticesID) {
+            geometryCache->releaseID(_quadVerticesID);
+        }
+        if (_lineVerticesID) {
+            geometryCache->releaseID(_lineVerticesID);
+        }
+        if (_majorTicksVerticesID) {
+            geometryCache->releaseID(_majorTicksVerticesID);
+        }
+        if (_minorTicksVerticesID) {
+            geometryCache->releaseID(_minorTicksVerticesID);
+        }
     }
     qDebug() << "Destroying circle3d overlay";
 }

--- a/interface/src/ui/overlays/Circle3DOverlay.h
+++ b/interface/src/ui/overlays/Circle3DOverlay.h
@@ -23,6 +23,7 @@ public:
 
     Circle3DOverlay();
     Circle3DOverlay(const Circle3DOverlay* circle3DOverlay);
+    ~Circle3DOverlay();
     
     virtual void render(RenderArgs* args) override;
     virtual const render::ShapeKey getShapeKey() override;

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -34,7 +34,7 @@ Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
 Line3DOverlay::~Line3DOverlay() {
     qDebug() << "Destryoing line3D overlay";
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    if (_geometryCacheID) {
+    if (_geometryCacheID && geometryCache) {
         geometryCache->releaseID(_geometryCacheID);
     }
 }

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -19,6 +19,7 @@ QString const Line3DOverlay::TYPE = "line3d";
 Line3DOverlay::Line3DOverlay() :
     _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
+    qDebug() << "Building line3D overlay";
 }
 
 Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
@@ -27,9 +28,15 @@ Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
     _end(line3DOverlay->_end),
     _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
+    qDebug() << "Building line3D overlay";
 }
 
 Line3DOverlay::~Line3DOverlay() {
+    qDebug() << "Destryoing line3D overlay";
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (_geometryCacheID) {
+        geometryCache->releaseID(_geometryCacheID);
+    }
 }
 
 glm::vec3 Line3DOverlay::getStart() const {
@@ -84,7 +91,6 @@ void Line3DOverlay::render(RenderArgs* args) {
     xColor color = getColor();
     const float MAX_COLOR = 255.0f;
     glm::vec4 colorv4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
-
     auto batch = args->_batch;
     if (batch) {
         batch->setModelTransform(getTransform());

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -28,6 +28,10 @@ Rectangle3DOverlay::Rectangle3DOverlay(const Rectangle3DOverlay* rectangle3DOver
 }
 
 Rectangle3DOverlay::~Rectangle3DOverlay() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (_geometryCacheID) {
+        geometryCache->releaseID(_geometryCacheID);
+    }
 }
 
 void Rectangle3DOverlay::render(RenderArgs* args) {

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -19,17 +19,20 @@ QString const Rectangle3DOverlay::TYPE = "rectangle3d";
 Rectangle3DOverlay::Rectangle3DOverlay() :
     _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
+    qDebug() << "Building rect3d overlay";
 }
 
 Rectangle3DOverlay::Rectangle3DOverlay(const Rectangle3DOverlay* rectangle3DOverlay) :
     Planar3DOverlay(rectangle3DOverlay),
     _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
+    qDebug() << "Building rect3d overlay";
 }
 
 Rectangle3DOverlay::~Rectangle3DOverlay() {
+    qDebug() << "Destryoing rect3d overlay";
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    if (_geometryCacheID) {
+    if (_geometryCacheID && geometryCache) {
         geometryCache->releaseID(_geometryCacheID);
     }
 }

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -441,6 +441,34 @@ GeometryCache::~GeometryCache() {
 #endif //def WANT_DEBUG
 }
 
+void GeometryCache::releaseID(int id) {
+    _registeredQuad3DTextures.remove(id);
+    _lastRegisteredQuad2DTexture.remove(id);
+    _registeredQuad2DTextures.remove(id);
+    _lastRegisteredQuad3D.remove(id);
+    _registeredQuad3D.remove(id);
+
+    _lastRegisteredQuad2D.remove(id);
+    _registeredQuad2D.remove(id);
+
+    _lastRegisteredBevelRects.remove(id);
+    _registeredBevelRects.remove(id);
+
+    _lastRegisteredLine3D.remove(id);
+    _registeredLine3DVBOs.remove(id);
+
+    _lastRegisteredLine2D.remove(id);
+    _registeredLine2DVBOs.remove(id);
+
+    _registeredVertices.remove(id);
+
+    _lastRegisteredDashedLines.remove(id);
+    _registeredDashedLines.remove(id);
+
+    _lastRegisteredGridBuffer.remove(id);
+    _registeredGridBuffers.remove(id);
+}
+
 void setupBatchInstance(gpu::Batch& batch, gpu::BufferPointer colorBuffer) {
     gpu::BufferView colorView(colorBuffer, COLOR_ELEMENT);
     batch.setInputBuffer(gpu::Stream::COLOR, colorView);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -148,6 +148,7 @@ public:
     };
 
     int allocateID() { return _nextID++; }
+    void releaseID(int id);
     static const int UNKNOWN_ID;
 
     // Bind the pipeline and get the state to render static geometry


### PR DESCRIPTION
## Testing

Using scripts that create and destroy overlays should no longer cause log lines like `[10/17 12:14:11] [DEBUG] [hifi.gpu] New max GPU buffers  734` every time an overlay is created.  Affected overlays are line3d, circle3d, and rectangle3d.  The easiest way to test this is to use the hand controller triggers on Vive to create pointer lines repeatedly.  In production code this will lead to several log lines about new max GPU buffers corresponding to every time you pull the triggers and the lines become visible.  

Note that you will still see `max GPU buffers` increase as content is loaded for the first time or new content is loaded into an existing scene.  

Any content or script that appears to cause runaway creation of GPU buffers should be reported.