### PR TITLE
directory picker works when choosing the initial value

### DIFF
--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -87,6 +87,8 @@ ModalWindow {
 
         if (selectDirectory) {
             currentSelection.text = d.capitalizeDrive(helper.urlToPath(initialFolder));
+            d.currentSelectionIsFolder = true;
+            d.currentSelectionUrl = initialFolder;
         }
 
         helper.contentsChanged.connect(function() {


### PR DESCRIPTION
test plan:

1. Open Settings->General, and clear the display of one of the directory settings, such as snapshots or scripts directory. Then click "Browse" and accept the default. The displayed answer should get filled in again. (It was not doing so in master.)

2. Remove Interface.ini OR remove the line in it that begins with snapshotsLocation=. 
  - Take a snasphot, and choose 'Cancel' when prompted for a directory. It should NOT set snapshotsLocation in .ini. (It should still save the picture, using a temp directory.)
  - Repeat. (It should prompt for a snapshot directory again.) This time chose the default. It SHOULD now set snapshotsLocation  in .ini, and it should NOT prompt again for a directory when you take a third snapshot.

3 and 4.  Repeat (1) and (2) with non-defaults choices.