### PR TITLE
Add GPU buffer and texture current counts to the main stats display

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -249,6 +249,16 @@ Item {
                     Text {
                         color: root.fontColor;
                         font.pixelSize: root.fontSize
+                        text: "GPU Textures: " + root.gpuTextures;
+                    }
+                    Text {
+                        color: root.fontColor;
+                        font.pixelSize: root.fontSize
+                        text: "GPU Buffers: " + root.gpuBuffers;
+                    }
+                    Text {
+                        color: root.fontColor;
+                        font.pixelSize: root.fontSize
                         visible: root.expanded;
                         text: "Items rendered / considered: " +
                             root.itemRendered + " / " + root.itemConsidered;

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -285,6 +285,9 @@ void Stats::updateStats(bool force) {
         STAT_UPDATE(sendingMode, sendingModeResult);
     }
 
+    STAT_UPDATE(gpuBuffers, (int)gpu::Context::getBufferGPUCount());
+    STAT_UPDATE(gpuTextures, (int)gpu::Context::getTextureGPUCount());
+
     // Incoming packets
     QLocale locale(QLocale::English);
     auto voxelPacketsToProcess = qApp->getOctreePacketProcessor().packetsToProcessCount();

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -89,6 +89,8 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, localElements, 0)
     STATS_PROPERTY(int, localInternal, 0)
     STATS_PROPERTY(int, localLeaves, 0)
+    STATS_PROPERTY(int, gpuBuffers, 0)
+    STATS_PROPERTY(int, gpuTextures, 0)
 
 public:
     static Stats* getInstance();
@@ -177,6 +179,8 @@ signals:
     void localInternalChanged();
     void localLeavesChanged();
     void timingStatsChanged();
+    void gpuBuffersChanged();
+    void gpuTexturesChanged();
 
 private:
     int _recentMaxPackets{ 0 } ; // recent max incoming voxel packets to process


### PR DESCRIPTION
## Testing

The overlay (enabled with the `/` key) should now show the current number of GPU textures and buffers in the 4th column.