### PR TITLE
switchable placeholder for domain-connection failure, currently a modal

### DIFF
--- a/interface/src/ConnectionMonitor.cpp
+++ b/interface/src/ConnectionMonitor.cpp
@@ -34,7 +34,7 @@ void ConnectionMonitor::init() {
     }
 
     auto dialogsManager = DependencyManager::get<DialogsManager>();
-    connect(&_timer, &QTimer::timeout, dialogsManager.data(), &DialogsManager::showAddressBar);
+    connect(&_timer, &QTimer::timeout, dialogsManager.data(), &DialogsManager::indicateDomainConnectionFailure);
 }
 
 void ConnectionMonitor::disconnectedFromDomain() {

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -59,6 +59,10 @@ void DialogsManager::showFeed() {
     emit setUseFeed(true);
 }
 
+void DialogsManager::indicateDomainConnectionFailure() {
+    OffscreenUi::information("No Connection", "Unable to connect to this domain. Click the 'GO TO' button on the toolbar to visit another domain.");
+}
+
 void DialogsManager::toggleDiskCacheEditor() {
     maybeCreateDialog(_diskCacheEditor);
     _diskCacheEditor->toggle();

--- a/interface/src/ui/DialogsManager.h
+++ b/interface/src/ui/DialogsManager.h
@@ -46,6 +46,7 @@ public slots:
     void toggleAddressBar();
     void showAddressBar();
     void showFeed();
+    void indicateDomainConnectionFailure();
     void toggleDiskCacheEditor();
     void toggleLoginDialog();
     void showLoginDialog();


### PR DESCRIPTION
fixes https://highfidelity.fogbugz.com/f/cases/1978/Do-not-show-GoTo-dialog-automatically-when-not-connected-to-a-domain per discussion with Ryan/Alan.