### PR TITLE
Add virtual keyboard for steam username collision

### DIFF
--- a/interface/resources/qml/LoginDialog/CompleteProfileBody.qml
+++ b/interface/resources/qml/LoginDialog/CompleteProfileBody.qml
@@ -29,8 +29,9 @@ Item {
         readonly property int maxHeight: 720
 
         function resize() {
-            var targetWidth = Math.max(titleWidth, additionalTextContainer.contentWidth)
-            var targetHeight = 4 * hifi.dimensions.contentSpacing.y + buttons.height + additionalTextContainer.height
+            var targetWidth = Math.max(titleWidth, Math.max(additionalTextContainer.contentWidth,
+                                                            termsContainer.contentWidth))
+            var targetHeight = 5 * hifi.dimensions.contentSpacing.y + buttons.height + additionalTextContainer.height + termsContainer.height
 
             root.width = Math.max(d.minWidth, Math.min(d.maxWidth, targetWidth))
             root.height = Math.max(d.minHeight, Math.min(d.maxHeight, targetHeight))
@@ -43,7 +44,7 @@ Item {
             top: parent.top
             horizontalCenter: parent.horizontalCenter
             margins: 0
-            topMargin: 3 * hifi.dimensions.contentSpacing.y
+            topMargin: 2 * hifi.dimensions.contentSpacing.y
         }
         spacing: hifi.dimensions.contentSpacing.x
         onHeightChanged: d.resize(); onWidthChanged: d.resize();
@@ -89,6 +90,25 @@ Item {
             bodyLoader.item.width = root.pane.width
             bodyLoader.item.height = root.pane.height
         }
+    }
+
+    InfoItem {
+        id: termsContainer
+        anchors {
+            top: additionalTextContainer.bottom
+            left: parent.left
+            margins: 0
+            topMargin: 2 * hifi.dimensions.contentSpacing.y
+        }
+
+        text: qsTr("By creating this user profile, you agree to <a href='https://highfidelity.com/terms'>High Fidelity's Terms of Service</a>")
+        wrapMode: Text.WordWrap
+        color: hifi.colors.baseGrayHighlight
+        lineHeight: 1
+        lineHeightMode: Text.ProportionalHeight
+        horizontalAlignment: Text.AlignHCenter
+
+        onLinkActivated: loginDialog.openUrl(link)
     }
 
     Component.onCompleted: {

--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -42,8 +42,14 @@ Item {
 
         function resize() {
             var targetWidth = Math.max(titleWidth, form.contentWidth);
-            var targetHeight =  hifi.dimensions.contentSpacing.y + mainTextContainer.height
-                    + 4 * hifi.dimensions.contentSpacing.y + form.height + hifi.dimensions.contentSpacing.y + buttons.height;
+            var targetHeight =  hifi.dimensions.contentSpacing.y + mainTextContainer.height +
+                            4 * hifi.dimensions.contentSpacing.y + form.height +
+                                hifi.dimensions.contentSpacing.y + buttons.height;
+
+            if (additionalInformation.visible) {
+                targetWidth = Math.max(targetWidth, additionalInformation.width);
+                targetHeight += hifi.dimensions.contentSpacing.y + additionalInformation.height
+            }
 
             root.width = Math.max(d.minWidth, Math.min(d.maxWidth, targetWidth));
             root.height = Math.max(d.minHeight, Math.min(d.maxHeight, targetHeight))
@@ -134,6 +140,25 @@ Item {
             }
         }
 
+    }
+
+    InfoItem {
+        id: additionalInformation
+        anchors {
+            top: form.bottom
+            left: parent.left
+            margins: 0
+            topMargin: hifi.dimensions.contentSpacing.y
+        }
+
+        visible: loginDialog.isSteamRunning()
+
+        text: qsTr("Your steam account informations will not be exposed to other users.")
+        wrapMode: Text.WordWrap
+        color: hifi.colors.baseGrayHighlight
+        lineHeight: 1
+        lineHeightMode: Text.ProportionalHeight
+        horizontalAlignment: Text.AlignHCenter
     }
 
     // Override ScrollingWindow's keyboard that would be at very bottom of dialog.


### PR DESCRIPTION
- Adds support for the virtual keyboard to the window for username collision during a Steam login.
- Inform user their Steam informations will not be shared

https://highfidelity.fogbugz.com/f/cases/1964/Virtual-keyboard-covers-textfield-in-Steam-username-taken-popup
https://highfidelity.fogbugz.com/f/cases/1863/Add-language-to-Steam-login-page-that-your-username-will-not-be-exposed