### PR TITLE
Rate limit QML web surfaces

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -79,6 +79,9 @@ void Web3DOverlay::render(RenderArgs* args) {
             });
         };
         _webSurface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface(), deleter);
+        // FIXME, the max FPS could be better managed by being dynamic (based on the number of current surfaces
+        // and the current rendering load)
+        _webSurface->setMaxFps(10);
         _webSurface->create(currentContext);
         _webSurface->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "/qml/controls/"));
         _webSurface->load("WebView.qml");

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -95,11 +95,14 @@ bool RenderableWebEntityItem::buildWebSurface(EntityTreeRenderer* renderer) {
     };
     _webSurface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface(), deleter);
 
+    // FIXME, the max FPS could be better managed by being dynamic (based on the number of current surfaces
+    // and the current rendering load)
+    _webSurface->setMaxFps(10);
+
     // The lifetime of the QML surface MUST be managed by the main thread
     // Additionally, we MUST use local variables copied by value, rather than
     // member variables, since they would implicitly refer to a this that 
     // is no longer valid
-
     _webSurface->create(currentContext);
     _webSurface->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "/qml/controls/"));
     _webSurface->load("WebView.qml", [&](QQmlContext* context, QObject* obj) {


### PR DESCRIPTION
Numerous QML web entities and overlays (such as the marketplace tablet and in-world web entities for locations in ova-welcome) may be contributing to the rendering slowdowns people are seeing.  This attempts to mitigate the issue by rate-limiting the surfaces to 10 frames per second.  This will be detrimental to video content rendered through a web entity, but c'est la vie.

## Testing

Application behavior should be unchanged.  Web pages may be less smooth in scrolling.  Video content on web pages will likely be 'jerky'