### PR TITLE
Remove the use of implicit ids in geometry cache

### DIFF
--- a/interface/src/Util.cpp
+++ b/interface/src/Util.cpp
@@ -50,50 +50,69 @@ void renderWorldBox(gpu::Batch& batch) {
     static const float DASH_LENGTH = 1.0f;
     static const float GAP_LENGTH = 1.0f;
     auto transform = Transform{};
+    static std::array<int, 18> geometryIds;
+    static std::once_flag initGeometryIds;
+    std::call_once(initGeometryIds, [&] {
+        for (size_t i = 0; i < geometryIds.size(); ++i) {
+            geometryIds[i] = geometryCache->allocateID();
+        }
+    });
 
     batch.setModelTransform(transform);
 
-    geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(HALF_TREE_SCALE, 0.0f, 0.0f), RED);
+    geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(HALF_TREE_SCALE, 0.0f, 0.0f), RED, geometryIds[0]);
     geometryCache->renderDashedLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(-HALF_TREE_SCALE, 0.0f, 0.0f), DASHED_RED,
-                                    DASH_LENGTH, GAP_LENGTH);
+                                    DASH_LENGTH, GAP_LENGTH, geometryIds[1]);
 
-    geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, HALF_TREE_SCALE, 0.0f), GREEN);
+    geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, HALF_TREE_SCALE, 0.0f), GREEN, geometryIds[2]);
     geometryCache->renderDashedLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, -HALF_TREE_SCALE, 0.0f), DASHED_GREEN,
-                                    DASH_LENGTH, GAP_LENGTH);
+                                    DASH_LENGTH, GAP_LENGTH, geometryIds[3]);
 
-    geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, HALF_TREE_SCALE), BLUE);
+    geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, HALF_TREE_SCALE), BLUE, geometryIds[4]);
     geometryCache->renderDashedLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, -HALF_TREE_SCALE), DASHED_BLUE,
-                                    DASH_LENGTH, GAP_LENGTH);
+                                    DASH_LENGTH, GAP_LENGTH, geometryIds[5]);
 
     // X center boundaries
     geometryCache->renderLine(batch, glm::vec3(-HALF_TREE_SCALE, -HALF_TREE_SCALE, 0.0f),
-                              glm::vec3(HALF_TREE_SCALE, -HALF_TREE_SCALE, 0.0f), GREY);
+                              glm::vec3(HALF_TREE_SCALE, -HALF_TREE_SCALE, 0.0f), GREY,
+                              geometryIds[6]);
     geometryCache->renderLine(batch, glm::vec3(-HALF_TREE_SCALE, -HALF_TREE_SCALE, 0.0f),
-                              glm::vec3(-HALF_TREE_SCALE, HALF_TREE_SCALE, 0.0f), GREY);
+                              glm::vec3(-HALF_TREE_SCALE, HALF_TREE_SCALE, 0.0f), GREY,
+                              geometryIds[7]);
     geometryCache->renderLine(batch, glm::vec3(-HALF_TREE_SCALE, HALF_TREE_SCALE, 0.0f),
-                              glm::vec3(HALF_TREE_SCALE, HALF_TREE_SCALE, 0.0f), GREY);
+                              glm::vec3(HALF_TREE_SCALE, HALF_TREE_SCALE, 0.0f), GREY,
+                              geometryIds[8]);
     geometryCache->renderLine(batch, glm::vec3(HALF_TREE_SCALE, -HALF_TREE_SCALE, 0.0f),
-                              glm::vec3(HALF_TREE_SCALE, HALF_TREE_SCALE, 0.0f), GREY);
+                              glm::vec3(HALF_TREE_SCALE, HALF_TREE_SCALE, 0.0f), GREY,
+                              geometryIds[9]);
 
     // Z center boundaries
     geometryCache->renderLine(batch, glm::vec3(0.0f, -HALF_TREE_SCALE, -HALF_TREE_SCALE),
-                              glm::vec3(0.0f, -HALF_TREE_SCALE, HALF_TREE_SCALE), GREY);
+                              glm::vec3(0.0f, -HALF_TREE_SCALE, HALF_TREE_SCALE), GREY,
+                              geometryIds[10]);
     geometryCache->renderLine(batch, glm::vec3(0.0f, -HALF_TREE_SCALE, -HALF_TREE_SCALE),
-                              glm::vec3(0.0f, HALF_TREE_SCALE, -HALF_TREE_SCALE), GREY);
+                              glm::vec3(0.0f, HALF_TREE_SCALE, -HALF_TREE_SCALE), GREY,
+                              geometryIds[11]);
     geometryCache->renderLine(batch, glm::vec3(0.0f, HALF_TREE_SCALE, -HALF_TREE_SCALE),
-                              glm::vec3(0.0f, HALF_TREE_SCALE, HALF_TREE_SCALE), GREY);
+                              glm::vec3(0.0f, HALF_TREE_SCALE, HALF_TREE_SCALE), GREY,
+                              geometryIds[12]);
     geometryCache->renderLine(batch, glm::vec3(0.0f, -HALF_TREE_SCALE, HALF_TREE_SCALE),
-                              glm::vec3(0.0f, HALF_TREE_SCALE, HALF_TREE_SCALE), GREY);
+                              glm::vec3(0.0f, HALF_TREE_SCALE, HALF_TREE_SCALE), GREY,
+                              geometryIds[13]);
 
     // Center boundaries
     geometryCache->renderLine(batch, glm::vec3(-HALF_TREE_SCALE, 0.0f, -HALF_TREE_SCALE),
-                              glm::vec3(-HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY);
+                              glm::vec3(-HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY,
+                              geometryIds[14]);
     geometryCache->renderLine(batch, glm::vec3(-HALF_TREE_SCALE, 0.0f, -HALF_TREE_SCALE),
-                              glm::vec3(HALF_TREE_SCALE, 0.0f, -HALF_TREE_SCALE), GREY);
+                              glm::vec3(HALF_TREE_SCALE, 0.0f, -HALF_TREE_SCALE), GREY,
+                              geometryIds[15]);
     geometryCache->renderLine(batch, glm::vec3(HALF_TREE_SCALE, 0.0f, -HALF_TREE_SCALE),
-                              glm::vec3(HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY);
+                              glm::vec3(HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY,
+                              geometryIds[16]);
     geometryCache->renderLine(batch, glm::vec3(-HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE),
-                              glm::vec3(HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY);
+                              glm::vec3(HALF_TREE_SCALE, 0.0f, HALF_TREE_SCALE), GREY,
+                              geometryIds[17]);
 
     
     geometryCache->renderWireCubeInstance(batch, GREY4);

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -99,6 +99,11 @@ Avatar::Avatar(RigPointer rig) :
 
     _skeletonModel = std::make_shared<SkeletonModel>(this, nullptr, rig);
     connect(_skeletonModel.get(), &Model::setURLFinished, this, &Avatar::setModelURLFinished);
+
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    _nameRectGeometryID = geometryCache->allocateID();
+    _leftPointerGeometryID = geometryCache->allocateID();
+    _rightPointerGeometryID = geometryCache->allocateID();
 }
 
 Avatar::~Avatar() {
@@ -118,6 +123,13 @@ Avatar::~Avatar() {
     if (_motionState) {
         delete _motionState;
         _motionState = nullptr;
+    }
+
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_nameRectGeometryID);
+        geometryCache->releaseID(_leftPointerGeometryID);
+        geometryCache->releaseID(_rightPointerGeometryID);
     }
 }
 
@@ -492,7 +504,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                 pointerTransform.setRotation(rotation);
                 batch.setModelTransform(pointerTransform);
                 geometryCache->bindSimpleProgram(batch);
-                geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor);
+                geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor, _leftPointerGeometryID);
             }
         }
 
@@ -516,7 +528,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                 pointerTransform.setRotation(rotation);
                 batch.setModelTransform(pointerTransform);
                 geometryCache->bindSimpleProgram(batch);
-                geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor);
+                geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor, _rightPointerGeometryID);
             }
         }
     }
@@ -782,7 +794,7 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& view, const
             PROFILE_RANGE_BATCH(batch, __FUNCTION__":renderBevelCornersRect");
             DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, true, true);
             DependencyManager::get<GeometryCache>()->renderBevelCornersRect(batch, left, bottom, width, height,
-                bevelDistance, backgroundColor);
+                bevelDistance, backgroundColor, _nameRectGeometryID);
         }
 
         // Render actual name

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -248,6 +248,9 @@ protected:
     ThreadSafeValueCache<glm::quat> _rightPalmRotationCache { glm::quat() };
 
 private:
+    int _leftPointerGeometryID { 0 };
+    int _rightPointerGeometryID { 0 };
+    int _nameRectGeometryID { 0 };
     bool _initialized;
     bool _shouldAnimate { true };
     bool _shouldSkipRender { false };

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -40,9 +40,18 @@ ApplicationOverlay::ApplicationOverlay()
     auto geometryCache = DependencyManager::get<GeometryCache>();
     _domainStatusBorder = geometryCache->allocateID();
     _magnifierBorder = geometryCache->allocateID();
+    _qmlGeometryId = geometryCache->allocateID();
+    _rearViewGeometryId = geometryCache->allocateID();
 }
 
 ApplicationOverlay::~ApplicationOverlay() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_domainStatusBorder);
+        geometryCache->releaseID(_magnifierBorder);
+        geometryCache->releaseID(_qmlGeometryId);
+        geometryCache->releaseID(_rearViewGeometryId);
+    }
 }
 
 // Renders the overlays either to a texture or to the screen
@@ -112,7 +121,7 @@ void ApplicationOverlay::renderQmlUi(RenderArgs* renderArgs) {
     batch.setModelTransform(Transform());
     batch.resetViewTransform();
     batch.setResourceTexture(0, _uiTexture);
-    geometryCache->renderUnitQuad(batch, glm::vec4(1));
+    geometryCache->renderUnitQuad(batch, glm::vec4(1), _qmlGeometryId);
 }
 
 void ApplicationOverlay::renderAudioScope(RenderArgs* renderArgs) {
@@ -188,7 +197,7 @@ void ApplicationOverlay::renderRearView(RenderArgs* renderArgs) {
 
         batch.setResourceTexture(0, selfieTexture);
         float alpha = DependencyManager::get<OffscreenUi>()->getDesktop()->property("unpinnedAlpha").toFloat();
-        geometryCache->renderQuad(batch, bottomLeft, topRight, texCoordMinCorner, texCoordMaxCorner, glm::vec4(1.0f, 1.0f, 1.0f, alpha));
+        geometryCache->renderQuad(batch, bottomLeft, topRight, texCoordMinCorner, texCoordMaxCorner, glm::vec4(1.0f, 1.0f, 1.0f, alpha), _rearViewGeometryId);
 
         batch.setResourceTexture(0, renderArgs->_whiteTexture);
     }

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -50,6 +50,8 @@ private:
     gpu::TexturePointer _overlayDepthTexture;
     gpu::TexturePointer _overlayColorTexture;
     gpu::FramebufferPointer _overlayFramebuffer;
+    int _qmlGeometryId { 0 };
+    int _rearViewGeometryId { 0 };
 };
 
 #endif // hifi_ApplicationOverlay_h

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -18,9 +18,29 @@
 
 QString const Cube3DOverlay::TYPE = "cube";
 
+Cube3DOverlay::Cube3DOverlay() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    for (size_t i = 0; i < _geometryIds.size(); ++i) {
+        _geometryIds[i] = geometryCache->allocateID();
+    }
+}
+
 Cube3DOverlay::Cube3DOverlay(const Cube3DOverlay* cube3DOverlay) :
     Volume3DOverlay(cube3DOverlay)
 {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    for (size_t i = 0; i < _geometryIds.size(); ++i) {
+        _geometryIds[i] = geometryCache->allocateID();
+    }
+}
+
+Cube3DOverlay::~Cube3DOverlay() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        for (size_t i = 0; i < _geometryIds.size(); ++i) {
+            geometryCache->releaseID(_geometryIds[i]);
+        }
+    }
 }
 
 void Cube3DOverlay::render(RenderArgs* args) {
@@ -71,20 +91,20 @@ void Cube3DOverlay::render(RenderArgs* args) {
                 glm::vec3 topLeftFar(-halfDimensions.x, halfDimensions.y, halfDimensions.z);
                 glm::vec3 topRightFar(halfDimensions.x, halfDimensions.y, halfDimensions.z);
 
-                geometryCache->renderDashedLine(*batch, bottomLeftNear, bottomRightNear, cubeColor);
-                geometryCache->renderDashedLine(*batch, bottomRightNear, bottomRightFar, cubeColor);
-                geometryCache->renderDashedLine(*batch, bottomRightFar, bottomLeftFar, cubeColor);
-                geometryCache->renderDashedLine(*batch, bottomLeftFar, bottomLeftNear, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomLeftNear, bottomRightNear, cubeColor, _geometryIds[0]);
+                geometryCache->renderDashedLine(*batch, bottomRightNear, bottomRightFar, cubeColor, _geometryIds[1]);
+                geometryCache->renderDashedLine(*batch, bottomRightFar, bottomLeftFar, cubeColor, _geometryIds[2]);
+                geometryCache->renderDashedLine(*batch, bottomLeftFar, bottomLeftNear, cubeColor, _geometryIds[3]);
 
-                geometryCache->renderDashedLine(*batch, topLeftNear, topRightNear, cubeColor);
-                geometryCache->renderDashedLine(*batch, topRightNear, topRightFar, cubeColor);
-                geometryCache->renderDashedLine(*batch, topRightFar, topLeftFar, cubeColor);
-                geometryCache->renderDashedLine(*batch, topLeftFar, topLeftNear, cubeColor);
+                geometryCache->renderDashedLine(*batch, topLeftNear, topRightNear, cubeColor, _geometryIds[4]);
+                geometryCache->renderDashedLine(*batch, topRightNear, topRightFar, cubeColor, _geometryIds[5]);
+                geometryCache->renderDashedLine(*batch, topRightFar, topLeftFar, cubeColor, _geometryIds[6]);
+                geometryCache->renderDashedLine(*batch, topLeftFar, topLeftNear, cubeColor, _geometryIds[7]);
 
-                geometryCache->renderDashedLine(*batch, bottomLeftNear, topLeftNear, cubeColor);
-                geometryCache->renderDashedLine(*batch, bottomRightNear, topRightNear, cubeColor);
-                geometryCache->renderDashedLine(*batch, bottomLeftFar, topLeftFar, cubeColor);
-                geometryCache->renderDashedLine(*batch, bottomRightFar, topRightFar, cubeColor);
+                geometryCache->renderDashedLine(*batch, bottomLeftNear, topLeftNear, cubeColor, _geometryIds[8]);
+                geometryCache->renderDashedLine(*batch, bottomRightNear, topRightNear, cubeColor, _geometryIds[9]);
+                geometryCache->renderDashedLine(*batch, bottomLeftFar, topLeftFar, cubeColor, _geometryIds[10]);
+                geometryCache->renderDashedLine(*batch, bottomRightFar, topRightFar, cubeColor, _geometryIds[11]);
 
             } else {
                 transform.setScale(dimensions);

--- a/interface/src/ui/overlays/Cube3DOverlay.h
+++ b/interface/src/ui/overlays/Cube3DOverlay.h
@@ -20,9 +20,10 @@ public:
     static QString const TYPE;
     virtual QString getType() const override { return TYPE; }
 
-    Cube3DOverlay() {}
+    Cube3DOverlay();
     Cube3DOverlay(const Cube3DOverlay* cube3DOverlay);
-    
+    ~Cube3DOverlay();
+
     virtual void render(RenderArgs* args) override;
     virtual const render::ShapeKey getShapeKey() override;
 
@@ -37,6 +38,8 @@ public:
 
 private:
     float _borderSize;
+    // edges on a cube
+    std::array<int, 12> _geometryIds;
 };
 
  

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -24,6 +24,7 @@ const float DEFAULT_SCALE = 100.0f;
 Grid3DOverlay::Grid3DOverlay() {
     setDimensions(DEFAULT_SCALE);
     updateGrid();
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }
 
 Grid3DOverlay::Grid3DOverlay(const Grid3DOverlay* grid3DOverlay) :
@@ -32,6 +33,14 @@ Grid3DOverlay::Grid3DOverlay(const Grid3DOverlay* grid3DOverlay) :
     _minorGridEvery(grid3DOverlay->_minorGridEvery)
 {
     updateGrid();
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
+}
+
+Grid3DOverlay::~Grid3DOverlay() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_geometryId);
+    }
 }
 
 AABox Grid3DOverlay::getBounds() const {
@@ -80,7 +89,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
         DependencyManager::get<GeometryCache>()->renderGrid(*batch, minCorner, maxCorner,
             _minorGridRowDivisions, _minorGridColDivisions, MINOR_GRID_EDGE,
             _majorGridRowDivisions, _majorGridColDivisions, MAJOR_GRID_EDGE,
-            gridColor, _drawInFront);
+            gridColor, _drawInFront, _geometryId);
     }
 }
 

--- a/interface/src/ui/overlays/Grid3DOverlay.h
+++ b/interface/src/ui/overlays/Grid3DOverlay.h
@@ -23,6 +23,7 @@ public:
 
     Grid3DOverlay();
     Grid3DOverlay(const Grid3DOverlay* grid3DOverlay);
+    ~Grid3DOverlay();
 
     virtual AABox getBounds() const override;
 
@@ -48,6 +49,7 @@ private:
     float _minorGridEvery { 1.0f };
     float _minorGridRowDivisions;
     float _minorGridColDivisions;
+    int _geometryId { 0 };
 };
 
 #endif // hifi_Grid3DOverlay_h

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -24,7 +24,7 @@ QString const Image3DOverlay::TYPE = "image3d";
 
 Image3DOverlay::Image3DOverlay() {
     _isLoaded = false;
-    _emissive = false;
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }
 
 Image3DOverlay::Image3DOverlay(const Image3DOverlay* image3DOverlay) :
@@ -34,6 +34,14 @@ Image3DOverlay::Image3DOverlay(const Image3DOverlay* image3DOverlay) :
     _emissive(image3DOverlay->_emissive),
     _fromImage(image3DOverlay->_fromImage)
 {
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
+}
+
+Image3DOverlay::~Image3DOverlay() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_geometryId);
+    }
 }
 
 void Image3DOverlay::update(float deltatime) {
@@ -100,7 +108,8 @@ void Image3DOverlay::render(RenderArgs* args) {
 
     DependencyManager::get<GeometryCache>()->renderQuad(
         *batch, topLeft, bottomRight, texCoordTopLeft, texCoordBottomRight,
-        glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha)
+        glm::vec4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha),
+        _geometryId
     );
 
     batch->setResourceTexture(0, args->_whiteTexture); // restore default white color after me

--- a/interface/src/ui/overlays/Image3DOverlay.h
+++ b/interface/src/ui/overlays/Image3DOverlay.h
@@ -26,7 +26,7 @@ public:
 
     Image3DOverlay();
     Image3DOverlay(const Image3DOverlay* image3DOverlay);
-
+    ~Image3DOverlay();
     virtual void render(RenderArgs* args) override;
 
     virtual void update(float deltatime) override;
@@ -48,9 +48,10 @@ public:
 private:
     QString _url;
     NetworkTexturePointer _texture;
-    bool _emissive;
+    bool _emissive { false };
 
     QRect _fromImage; // where from in the image to sample
+    int _geometryId { 0 };
 };
 
 #endif // hifi_Image3DOverlay_h

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -19,6 +19,10 @@ QString const Rectangle3DOverlay::TYPE = "rectangle3d";
 Rectangle3DOverlay::Rectangle3DOverlay() :
     _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    for (size_t i = 0; i < _rectGeometryIds.size(); ++i) {
+        _rectGeometryIds[i] = geometryCache->allocateID();
+    }
     qDebug() << "Building rect3d overlay";
 }
 
@@ -26,14 +30,21 @@ Rectangle3DOverlay::Rectangle3DOverlay(const Rectangle3DOverlay* rectangle3DOver
     Planar3DOverlay(rectangle3DOverlay),
     _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    for (size_t i = 0; i < _rectGeometryIds.size(); ++i) {
+        _rectGeometryIds[i] = geometryCache->allocateID();
+    }
     qDebug() << "Building rect3d overlay";
 }
 
 Rectangle3DOverlay::~Rectangle3DOverlay() {
     qDebug() << "Destryoing rect3d overlay";
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    if (_geometryCacheID && geometryCache) {
+    if (geometryCache) {
         geometryCache->releaseID(_geometryCacheID);
+        for (size_t i = 0; i < _rectGeometryIds.size(); ++i) {
+            geometryCache->releaseID(_rectGeometryIds[i]);
+        }
     }
 }
 
@@ -66,7 +77,7 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
             glm::vec3 topLeft(-halfDimensions.x, -halfDimensions.y, 0.0f);
             glm::vec3 bottomRight(halfDimensions.x, halfDimensions.y, 0.0f);
             geometryCache->bindSimpleProgram(*batch);
-            geometryCache->renderQuad(*batch, topLeft, bottomRight, rectangleColor);
+            geometryCache->renderQuad(*batch, topLeft, bottomRight, rectangleColor, _geometryCacheID);
         } else {
             geometryCache->bindSimpleProgram(*batch, false, false, false, true, true);
             if (getIsDashedLine()) {
@@ -75,10 +86,10 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
                 glm::vec3 point3(halfDimensions.x, halfDimensions.y, 0.0f);
                 glm::vec3 point4(-halfDimensions.x, halfDimensions.y, 0.0f);
 
-                geometryCache->renderDashedLine(*batch, point1, point2, rectangleColor);
-                geometryCache->renderDashedLine(*batch, point2, point3, rectangleColor);
-                geometryCache->renderDashedLine(*batch, point3, point4, rectangleColor);
-                geometryCache->renderDashedLine(*batch, point4, point1, rectangleColor);
+                geometryCache->renderDashedLine(*batch, point1, point2, rectangleColor, _rectGeometryIds[0]);
+                geometryCache->renderDashedLine(*batch, point2, point3, rectangleColor, _rectGeometryIds[1]);
+                geometryCache->renderDashedLine(*batch, point3, point4, rectangleColor, _rectGeometryIds[2]);
+                geometryCache->renderDashedLine(*batch, point4, point1, rectangleColor, _rectGeometryIds[3]);
             } else {
                 if (halfDimensions != _previousHalfDimensions) {
                     QVector<glm::vec3> border;

--- a/interface/src/ui/overlays/Rectangle3DOverlay.h
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.h
@@ -30,6 +30,7 @@ public:
     virtual Rectangle3DOverlay* createClone() const override;
 private:
     int _geometryCacheID;
+    std::array<int, 4> _rectGeometryIds;
     glm::vec2 _previousHalfDimensions;
 };
 

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -25,6 +25,7 @@ QString const Text3DOverlay::TYPE = "text3d";
 
 Text3DOverlay::Text3DOverlay() {
     _textRenderer = TextRenderer3D::getInstance(SANS_FONT_FAMILY, FIXED_FONT_POINT_SIZE);
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }
 
 Text3DOverlay::Text3DOverlay(const Text3DOverlay* text3DOverlay) :
@@ -39,10 +40,15 @@ Text3DOverlay::Text3DOverlay(const Text3DOverlay* text3DOverlay) :
     _bottomMargin(text3DOverlay->_bottomMargin)
 {
     _textRenderer = TextRenderer3D::getInstance(SANS_FONT_FAMILY, FIXED_FONT_POINT_SIZE);
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }
 
 Text3DOverlay::~Text3DOverlay() {
     delete _textRenderer;
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_geometryId);
+    }
 }
 
 xColor Text3DOverlay::getBackgroundColor() {
@@ -97,7 +103,7 @@ void Text3DOverlay::render(RenderArgs* args) {
 
     glm::vec3 topLeft(-halfDimensions.x, -halfDimensions.y, SLIGHTLY_BEHIND);
     glm::vec3 bottomRight(halfDimensions.x, halfDimensions.y, SLIGHTLY_BEHIND);
-    DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, quadColor);
+    DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, quadColor, _geometryId);
 
     // Same font properties as textSize()
     float maxHeight = (float)_textRenderer->computeExtent("Xy").y * LINE_SCALE_RATIO;

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -74,6 +74,7 @@ private:
     float _topMargin { 0.1f };
     float _rightMargin { 0.1f };
     float _bottomMargin { 0.1f };
+    int _geometryId { 0 };
 };
 
 #endif // hifi_Text3DOverlay_h

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -32,7 +32,9 @@ static float OPAQUE_ALPHA_THRESHOLD = 0.99f;
 
 QString const Web3DOverlay::TYPE = "web3d";
 
-Web3DOverlay::Web3DOverlay() : _dpi(DPI) { }
+Web3DOverlay::Web3DOverlay() : _dpi(DPI) { 
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
+}
 
 Web3DOverlay::Web3DOverlay(const Web3DOverlay* Web3DOverlay) :
     Billboard3DOverlay(Web3DOverlay),
@@ -40,6 +42,7 @@ Web3DOverlay::Web3DOverlay(const Web3DOverlay* Web3DOverlay) :
     _dpi(Web3DOverlay->_dpi),
     _resolution(Web3DOverlay->_resolution)
 {
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }
 
 Web3DOverlay::~Web3DOverlay() {
@@ -54,6 +57,10 @@ Web3DOverlay::~Web3DOverlay() {
         AbstractViewStateInterface::instance()->postLambdaEvent([webSurface] {
             webSurface->deleteLater();
         });
+    }
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_geometryId);
     }
 }
 
@@ -122,7 +129,7 @@ void Web3DOverlay::render(RenderArgs* args) {
     } else {
         geometryCache->bindOpaqueWebBrowserProgram(batch);
     }
-    geometryCache->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color);
+    geometryCache->renderQuad(batch, halfSize * -1.0f, halfSize, vec2(0), vec2(1), color, _geometryId);
     batch.setResourceTexture(0, args->_whiteTexture); // restore default white color after me
 }
 

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -47,6 +47,7 @@ private:
     QString _url;
     float _dpi;
     vec2 _resolution{ 640, 480 };
+    int _geometryId { 0 };
 };
 
 #endif // hifi_Web3DOverlay_h

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -112,6 +112,10 @@ void HmdDisplayPlugin::internalDeactivate() {
 void HmdDisplayPlugin::customizeContext() {
     Parent::customizeContext();
     _overlayRenderer.build();
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    for (size_t i = 0; i < _geometryIds.size(); ++i) {
+        _geometryIds[i] = geometryCache->allocateID();
+    }
 }
 
 void HmdDisplayPlugin::uncustomizeContext() {
@@ -126,6 +130,11 @@ void HmdDisplayPlugin::uncustomizeContext() {
     });
     _overlayRenderer = OverlayRenderer();
     _previewTexture.reset();
+
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    for (size_t i = 0; i < _geometryIds.size(); ++i) {
+        geometryCache->releaseID(_geometryIds[i]);
+    }
     Parent::uncustomizeContext();
 }
 
@@ -630,7 +639,7 @@ void HmdDisplayPlugin::compositeExtra() {
             const auto& laser = _presentHandLasers[index];
             if (laser.valid()) {
                 const auto& points = _presentHandLaserPoints[index];
-                geometryCache->renderGlowLine(batch, points.first, points.second, laser.color);
+                geometryCache->renderGlowLine(batch, points.first, points.second, laser.color, _geometryIds[index]);
             }
         });
     });

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -77,9 +77,9 @@ protected:
 
     Transform _presentUiModelTransform;
     std::array<HandLaserInfo, 2> _presentHandLasers;
+    std::array<int, 2> _geometryIds;
     std::array<mat4, 2> _presentHandPoses;
     std::array<std::pair<vec3, vec3>, 2> _presentHandLaserPoints;
-
     std::array<mat4, 2> _eyeOffsets;
     std::array<mat4, 2> _eyeProjections;
     std::array<mat4, 2> _eyeInverseProjections;

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.h
@@ -23,13 +23,14 @@ class RenderableTextEntityItem : public TextEntityItem  {
 public:
     static EntityItemPointer factory(const EntityItemID& entityID, const EntityItemProperties& properties);
     RenderableTextEntityItem(const EntityItemID& entityItemID) : TextEntityItem(entityItemID) { }
-    ~RenderableTextEntityItem() { delete _textRenderer; }
+    ~RenderableTextEntityItem();
 
     virtual void render(RenderArgs* args) override;
 
     SIMPLE_RENDERABLE();
     
 private:
+    int _geometryID { 0 };
     TextRenderer3D* _textRenderer = TextRenderer3D::getInstance(SANS_FONT_FAMILY, FIXED_FONT_POINT_SIZE / 2.0f);
 };
 

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -52,11 +52,16 @@ RenderableWebEntityItem::RenderableWebEntityItem(const EntityItemID& entityItemI
     _touchDevice.setType(QTouchDevice::TouchScreen);
     _touchDevice.setName("RenderableWebEntityItemTouchDevice");
     _touchDevice.setMaximumTouchPoints(4);
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }
 
 RenderableWebEntityItem::~RenderableWebEntityItem() {
     destroyWebSurface();
     qDebug() << "Destroyed web entity " << getID();
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_geometryId);
+    }
 }
 
 bool RenderableWebEntityItem::buildWebSurface(EntityTreeRenderer* renderer) {
@@ -228,7 +233,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     } else {
         DependencyManager::get<GeometryCache>()->bindOpaqueWebBrowserProgram(batch);
     }
-    DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f, 1.0f, 1.0f, fadeRatio));
+    DependencyManager::get<GeometryCache>()->renderQuad(batch, topLeft, bottomRight, texMin, texMax, glm::vec4(1.0f, 1.0f, 1.0f, fadeRatio), _geometryId);
 }
 
 void RenderableWebEntityItem::setSourceUrl(const QString& value) {

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -69,6 +69,7 @@ private:
     QMetaObject::Connection _mouseReleaseConnection;
     QMetaObject::Connection _mouseMoveConnection;
     QMetaObject::Connection _hoverLeaveConnection;
+    int _geometryId { 0 };
 };
 
 #endif // hifi_RenderableWebEntityItem_h

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -29,6 +29,14 @@
 
 
 Antialiasing::Antialiasing() {
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
+}
+
+Antialiasing::~Antialiasing() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_geometryId);
+    }
 }
 
 const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
@@ -150,7 +158,7 @@ void Antialiasing::run(const render::SceneContextPointer& sceneContext, const re
         glm::vec2 topRight(1.0f, 1.0f);
         glm::vec2 texCoordTopLeft(0.0f, 0.0f);
         glm::vec2 texCoordBottomRight(1.0f, 1.0f);
-        DependencyManager::get<GeometryCache>()->renderQuad(batch, bottomLeft, topRight, texCoordTopLeft, texCoordBottomRight, color);
+        DependencyManager::get<GeometryCache>()->renderQuad(batch, bottomLeft, topRight, texCoordTopLeft, texCoordBottomRight, color, _geometryId);
 
 
         // Blend step
@@ -159,6 +167,6 @@ void Antialiasing::run(const render::SceneContextPointer& sceneContext, const re
         batch.setFramebuffer(sourceBuffer);
         batch.setPipeline(getBlendPipeline());
 
-        DependencyManager::get<GeometryCache>()->renderQuad(batch, bottomLeft, topRight, texCoordTopLeft, texCoordBottomRight, color);
+        DependencyManager::get<GeometryCache>()->renderQuad(batch, bottomLeft, topRight, texCoordTopLeft, texCoordBottomRight, color, _geometryId);
     });
 }

--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -29,6 +29,7 @@ public:
     using JobModel = render::Job::ModelI<Antialiasing, gpu::FramebufferPointer, Config>;
 
     Antialiasing();
+    ~Antialiasing();
     void configure(const Config& config) {}
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext, const gpu::FramebufferPointer& sourceBuffer);
 
@@ -46,7 +47,7 @@ private:
 
     gpu::PipelinePointer _antialiasingPipeline;
     gpu::PipelinePointer _blendPipeline;
-
+    int _geometryId { 0 };
 };
 
 #endif // hifi_AntialiasingEffect_h

--- a/libraries/render-utils/src/DebugDeferredBuffer.h
+++ b/libraries/render-utils/src/DebugDeferredBuffer.h
@@ -42,6 +42,7 @@ public:
     using JobModel = render::Job::ModelI<DebugDeferredBuffer, Inputs, Config>;
     
     DebugDeferredBuffer();
+    ~DebugDeferredBuffer();
 
     void configure(const Config& config);
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext, const Inputs& inputs);
@@ -96,6 +97,7 @@ private:
     
     StandardPipelines _pipelines;
     CustomPipelines _customPipelines;
+    int _geometryId { 0 };
 };
 
 #endif // hifi_DebugDeferredBuffer_h

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -230,73 +230,79 @@ public:
     void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
         int majorRows, int majorCols, float majorEdge,
         int minorRows, int minorCols, float minorEdge,
-        const glm::vec4& color, bool isLayered, int id = UNKNOWN_ID);
+        const glm::vec4& color, bool isLayered, int id);
     void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
-        int rows, int cols, float edge, const glm::vec4& color, bool isLayered, int id = UNKNOWN_ID) {
+        int rows, int cols, float edge, const glm::vec4& color, bool isLayered, int id) {
         renderGrid(batch, minCorner, maxCorner, rows, cols, edge, 0, 0, 0.0f, color, isLayered, id);
     }
 
-    void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id);
 
-    void renderUnitQuad(gpu::Batch& batch, const glm::vec4& color = glm::vec4(1), int id = UNKNOWN_ID);
+    void renderUnitQuad(gpu::Batch& batch, const glm::vec4& color, int id);
 
-    void renderQuad(gpu::Batch& batch, int x, int y, int width, int height, const glm::vec4& color, int id = UNKNOWN_ID)
+    void renderUnitQuad(gpu::Batch& batch, int id) {
+        renderUnitQuad(batch, glm::vec4(1), id);
+    }
+
+    void renderQuad(gpu::Batch& batch, int x, int y, int width, int height, const glm::vec4& color, int id)
             { renderQuad(batch, glm::vec2(x,y), glm::vec2(x + width, y + height), color, id); }
             
     // TODO: I think there's a bug in this version of the renderQuad() that's not correctly rebuilding the vbos
     // if the color changes by the corners are the same, as evidenced by the audio meter which should turn white
     // when it's clipping
-    void renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner, const glm::vec4& color, int id);
 
     void renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
                     const glm::vec2& texCoordMinCorner, const glm::vec2& texCoordMaxCorner, 
-                    const glm::vec4& color, int id = UNKNOWN_ID);
+                    const glm::vec4& color, int id);
 
-    void renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id = UNKNOWN_ID);
+    void renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, const glm::vec3& maxCorner, const glm::vec4& color, int id);
 
     void renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, const glm::vec3& bottomLeft, 
                     const glm::vec3& bottomRight, const glm::vec3& topRight,
                     const glm::vec2& texCoordTopLeft, const glm::vec2& texCoordBottomLeft,
                     const glm::vec2& texCoordBottomRight, const glm::vec2& texCoordTopRight, 
-                    const glm::vec4& color, int id = UNKNOWN_ID);
+                    const glm::vec4& color, int id);
 
 
-    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, const glm::vec3& color, int id = UNKNOWN_ID) 
+    void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, const glm::vec3& color, int id)
                     { renderLine(batch, p1, p2, color, color, id); }
     
     void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
-                    const glm::vec3& color1, const glm::vec3& color2, int id = UNKNOWN_ID)
+                    const glm::vec3& color1, const glm::vec3& color2, int id)
                     { renderLine(batch, p1, p2, glm::vec4(color1, 1.0f), glm::vec4(color2, 1.0f), id); }
 
     void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
-                    const glm::vec4& color, int id = UNKNOWN_ID)
+                    const glm::vec4& color, int id)
                     { renderLine(batch, p1, p2, color, color, id); }
 
     void renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, 
-                    const glm::vec4& color1, const glm::vec4& color2, int id = UNKNOWN_ID);
+                    const glm::vec4& color1, const glm::vec4& color2, int id);
 
     void renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
-                    const glm::vec4& color, float glowIntensity = 1.0f, float glowWidth = 0.05f, int id = UNKNOWN_ID);
+                    const glm::vec4& color, float glowIntensity, float glowWidth, int id);
 
-    void renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color,
-                          int id = UNKNOWN_ID)
+    void renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, const glm::vec4& color, int id) 
+                       { renderGlowLine(batch, p1, p2, color, 1.0f, 0.05f, id); }
+
+    void renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id)
                           { renderDashedLine(batch, start, end, color, 0.05f, 0.025f, id); }
 
     void renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color,
-                          const float dash_length, const float gap_length, int id = UNKNOWN_ID);
+                          const float dash_length, const float gap_length, int id);
 
-    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec3& color, int id = UNKNOWN_ID)
+    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec3& color, int id)
                     { renderLine(batch, p1, p2, glm::vec4(color, 1.0f), id); }
 
-    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec4& color, int id = UNKNOWN_ID)
+    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec4& color, int id)
                     { renderLine(batch, p1, p2, color, color, id); }
 
     void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,
-                    const glm::vec3& color1, const glm::vec3& color2, int id = UNKNOWN_ID)
+                    const glm::vec3& color1, const glm::vec3& color2, int id)
                     { renderLine(batch, p1, p2, glm::vec4(color1, 1.0f), glm::vec4(color2, 1.0f), id); }
 
     void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,
-                                    const glm::vec4& color1, const glm::vec4& color2, int id = UNKNOWN_ID);
+                                    const glm::vec4& color1, const glm::vec4& color2, int id);
 
     void updateVertices(int id, const QVector<glm::vec2>& points, const glm::vec4& color);
     void updateVertices(int id, const QVector<glm::vec2>& points, const QVector<glm::vec4>& colors);
@@ -381,41 +387,32 @@ private:
     int _nextID{ 1 };
 
     QHash<int, Vec3PairVec4Pair> _lastRegisteredQuad3DTexture;
-    QHash<Vec3PairVec4Pair, BatchItemDetails> _quad3DTextures;
     QHash<int, BatchItemDetails> _registeredQuad3DTextures;
 
     QHash<int, Vec4PairVec4> _lastRegisteredQuad2DTexture;
-    QHash<Vec4PairVec4, BatchItemDetails> _quad2DTextures;
     QHash<int, BatchItemDetails> _registeredQuad2DTextures;
 
     QHash<int, Vec3PairVec4> _lastRegisteredQuad3D;
-    QHash<Vec3PairVec4, BatchItemDetails> _quad3D;
     QHash<int, BatchItemDetails> _registeredQuad3D;
 
     QHash<int, Vec4Pair> _lastRegisteredQuad2D;
-    QHash<Vec4Pair, BatchItemDetails> _quad2D;
     QHash<int, BatchItemDetails> _registeredQuad2D;
 
     QHash<int, Vec3Pair> _lastRegisteredBevelRects;
-    QHash<Vec3Pair, BatchItemDetails> _bevelRects;
     QHash<int, BatchItemDetails> _registeredBevelRects;
 
     QHash<int, Vec3Pair> _lastRegisteredLine3D;
-    QHash<Vec3Pair, BatchItemDetails> _line3DVBOs;
     QHash<int, BatchItemDetails> _registeredLine3DVBOs;
 
     QHash<int, Vec2Pair> _lastRegisteredLine2D;
-    QHash<Vec2Pair, BatchItemDetails> _line2DVBOs;
     QHash<int, BatchItemDetails> _registeredLine2DVBOs;
     
     QHash<int, BatchItemDetails> _registeredVertices;
 
     QHash<int, Vec3PairVec2Pair> _lastRegisteredDashedLines;
-    QHash<Vec3PairVec2Pair, BatchItemDetails> _dashedLines;
     QHash<int, BatchItemDetails> _registeredDashedLines;
 
     QHash<int, Vec2FloatPairPair> _lastRegisteredGridBuffer;
-    QHash<Vec2FloatPairPair, GridBuffer> _gridBuffers;
     QHash<int, GridBuffer> _registeredGridBuffers;
 
     gpu::ShaderPointer _simpleShader;

--- a/libraries/render-utils/src/HitEffect.cpp
+++ b/libraries/render-utils/src/HitEffect.cpp
@@ -33,6 +33,14 @@
 
 
 HitEffect::HitEffect() {
+    _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
+}
+
+HitEffect::~HitEffect() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (_geometryId && geometryCache) {
+        geometryCache->releaseID(_geometryId);
+    }
 }
 
 const gpu::PipelinePointer& HitEffect::getHitEffectPipeline() {
@@ -77,10 +85,10 @@ void HitEffect::run(const render::SceneContextPointer& sceneContext, const rende
 
         batch.setPipeline(getHitEffectPipeline());
 
-        glm::vec4 color(0.0f, 0.0f, 0.0f, 1.0f);
-        glm::vec2 bottomLeft(-1.0f, -1.0f);
-        glm::vec2 topRight(1.0f, 1.0f);
-        DependencyManager::get<GeometryCache>()->renderQuad(batch, bottomLeft, topRight, color);
+        static const glm::vec4 color(0.0f, 0.0f, 0.0f, 1.0f);
+        static const glm::vec2 bottomLeft(-1.0f, -1.0f);
+        static const glm::vec2 topRight(1.0f, 1.0f);
+        DependencyManager::get<GeometryCache>()->renderQuad(batch, bottomLeft, topRight, color, _geometryId);
     });
 }
 

--- a/libraries/render-utils/src/HitEffect.h
+++ b/libraries/render-utils/src/HitEffect.h
@@ -24,12 +24,14 @@ public:
     using JobModel = render::Job::Model<HitEffect, Config>;
     
     HitEffect();
+    ~HitEffect();
     void configure(const Config& config) {}
     void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext);
     
     const gpu::PipelinePointer& getHitEffectPipeline();
     
 private:
+    int _geometryId { 0 };
     gpu::PipelinePointer _hitEffectPipeline;
 };
 


### PR DESCRIPTION
The use of implicit endpoints as keys can lead to leakage of GPU resources.  This changes the GeometryCache API to _require_ the use of a geometry ID for every simple draw, ensuring that a given item will re-use the same GPU buffers over and over, rather than potentially creating new ones.

## Testing

When using the hand lasers to hover over UI elements, the current production build will show a constantly increasing number of GPU buffers on the stats display (enabled with `/`).  With this build the stats should not keep climbing as you move the lasers around over the UI.

Application behavior should be otherwise unchanged.
