### PR TITLE
fix crowd animation again

### DIFF
--- a/scripts/developer/tests/performance/summon.js
+++ b/scripts/developer/tests/performance/summon.js
@@ -80,6 +80,7 @@ function messageHandler(channel, messageString, senderID) {
                 position: Vec3.sum(MyAvatar.position, {x: coord(), y: 0, z: coord()}),
                 orientation: Quat.fromPitchYawRollDegrees(0, Quat.safeEulerAngles(MyAvatar.orientation).y + (turnSpread * (Math.random() - 0.5)), 0),
                 soundData: chatter && SOUND_DATA,
+                skeletonModelURL: "http://howard-stearns.github.io/models/resources/meshes/defaultAvatar_full.fst",
                 animationData: ANIMATION_DATA
             });
         }


### PR DESCRIPTION
fixes https://highfidelity.fogbugz.com/f/cases/1995/no-agent-animation-on-linux

On Linux, there are no /~/... resources. That doesn't matter if you just want to show the avatar, because the default url gets translated to each client and the client fetches and draws it. But to do the animation, the ac needs the skeleton.  So... we now have the interface script specify a valid .fst (which points to a valid .fbx).