### PR TITLE
Fix for sandbox startup issue

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1328,10 +1328,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     const QString TUTORIAL_PATH = "/tutorial_begin";
 
     if (shouldGoToTutorial) {
-        sandboxUtils.ifLocalSandboxRunningElse([=]() {
+        if(determinedSandboxState) {
             qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
             DependencyManager::get<AddressManager>()->goToLocalSandbox(TUTORIAL_PATH);
-        }, [=]() {
+        } else {
             qCDebug(interfaceapp) << "Home sandbox does not appear to be running, going to Entry.";
             if (firstRun.get()) {
                 showHelp();
@@ -1341,7 +1341,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
             } else {
                 DependencyManager::get<AddressManager>()->loadSettings(addressLookupString);
             }
-        });
+        }
     } else {
 
         bool isFirstRun = firstRun.get();
@@ -1353,13 +1353,13 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         // If this is a first run we short-circuit the address passed in
         if (isFirstRun) {
             if (hasHMDAndHandControllers) {
-                sandboxUtils.ifLocalSandboxRunningElse([=]() {
+                if(determinedSandboxState) {
                     qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
                     DependencyManager::get<AddressManager>()->goToLocalSandbox();
-                }, [=]() {
+                } else {
                     qCDebug(interfaceapp) << "Home sandbox does not appear to be running, going to Entry.";
                     DependencyManager::get<AddressManager>()->goToEntry();
-                });
+                }
             } else {
                 DependencyManager::get<AddressManager>()->goToEntry();
             }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -583,15 +583,18 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     
     bool wantsSandboxRunning = shouldRunServer();
     static bool determinedSandboxState = false;
+    static bool sandboxIsRunning = false;
     SandboxUtils sandboxUtils;
     sandboxUtils.ifLocalSandboxRunningElse([&]() {
         qCDebug(interfaceapp) << "Home sandbox appears to be running.....";
         determinedSandboxState = true;
+        sandboxIsRunning = true;
     }, [&, wantsSandboxRunning]() {
         qCDebug(interfaceapp) << "Home sandbox does not appear to be running....";
         if (wantsSandboxRunning) {
             QString contentPath = getRunServerPath();
             SandboxUtils::runLocalSandbox(contentPath, true, RUNNING_MARKER_FILENAME);
+            sandboxIsRunning = true;
         }
         determinedSandboxState = true;
     });
@@ -1328,7 +1331,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     const QString TUTORIAL_PATH = "/tutorial_begin";
 
     if (shouldGoToTutorial) {
-        if(determinedSandboxState) {
+        if(sandboxIsRunning) {
             qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
             DependencyManager::get<AddressManager>()->goToLocalSandbox(TUTORIAL_PATH);
         } else {
@@ -1353,7 +1356,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         // If this is a first run we short-circuit the address passed in
         if (isFirstRun) {
             if (hasHMDAndHandControllers) {
-                if(determinedSandboxState) {
+                if(sandboxIsRunning) {
                     qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
                     DependencyManager::get<AddressManager>()->goToLocalSandbox();
                 } else {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -589,13 +589,15 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         determinedSandboxState = true;
     }, [&, wantsSandboxRunning]() {
         qCDebug(interfaceapp) << "Home sandbox does not appear to be running....";
-        determinedSandboxState = true;
         if (wantsSandboxRunning) {
             QString contentPath = getRunServerPath();
             SandboxUtils::runLocalSandbox(contentPath, true, RUNNING_MARKER_FILENAME);
         }
+        determinedSandboxState = true;
     });
 
+    // SandboxUtils::runLocalSandbox currently has 2 sec delay after spawning sandbox, so 4
+    // sec here is ok I guess.  TODO: ping sandbox so we know it is up, perhaps?
     quint64 MAX_WAIT_TIME = USECS_PER_SECOND * 4;
     auto startWaiting = usecTimestampNow();
     while (!determinedSandboxState && (usecTimestampNow() - startWaiting <= MAX_WAIT_TIME)) {


### PR DESCRIPTION
Move `determinedSandboxState=true` until after we spawn it.   