### PR TITLE
Adjustment to position and visibility of grab sphere.

### DIFF
--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -375,10 +375,10 @@ void HmdDisplayPlugin::updateFrameData() {
             castDirection = glm::inverse(_presentUiModelTransform.getRotation()) * castDirection;
         }
 
-        // this offset needs to match GRAB_POINT_SPHERE_OFFSET in scripts/system/libraries/controllers.js
-        static const vec3 GRAB_POINT_SPHERE_OFFSET(0.075f, 0.175f, 0.039f);
+        // this offset needs to match GRAB_POINT_SPHERE_OFFSET in scripts/system/libraries/controllers.js:19
+        static const vec3 GRAB_POINT_SPHERE_OFFSET(0.04f, 0.13f, 0.039f);  // x = upward, y = forward, z = lateral
 
-        // swizzle grab point so that (x = upward, y = inward, z = forward)
+        // swizzle grab point so that (x = upward, y = lateral, z = forward)
         vec3 grabPointOffset = glm::vec3(GRAB_POINT_SPHERE_OFFSET.x, GRAB_POINT_SPHERE_OFFSET.z, -GRAB_POINT_SPHERE_OFFSET.y);
         if (i == 0) {
             grabPointOffset.x *= -1.0f; // this changes between left and right hands

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -376,9 +376,10 @@ void HmdDisplayPlugin::updateFrameData() {
         }
 
         // this offset needs to match GRAB_POINT_SPHERE_OFFSET in scripts/system/libraries/controllers.js
-        //static const vec3 GRAB_POINT_SPHERE_OFFSET = vec3(0.1f, 0.04f, -0.32f);
-        static const vec3 GRAB_POINT_SPHERE_OFFSET = vec3(0.0f, 0.0f, -0.175f);
-        vec3 grabPointOffset = GRAB_POINT_SPHERE_OFFSET;
+        static const vec3 GRAB_POINT_SPHERE_OFFSET(0.075f, 0.175f, 0.039f);
+
+        // swizzle grab point so that (x = upward, y = inward, z = forward)
+        vec3 grabPointOffset = glm::vec3(GRAB_POINT_SPHERE_OFFSET.x, GRAB_POINT_SPHERE_OFFSET.z, -GRAB_POINT_SPHERE_OFFSET.y);
         if (i == 0) {
             grabPointOffset.x *= -1.0f; // this changes between left and right hands
         }

--- a/libraries/shared/src/GLMHelpers.cpp
+++ b/libraries/shared/src/GLMHelpers.cpp
@@ -34,7 +34,9 @@ const vec3& Vectors::UP = Vectors::UNIT_Y;
 const vec3& Vectors::FRONT = Vectors::UNIT_NEG_Z;
 
 const quat Quaternions::IDENTITY{ 1.0f, 0.0f, 0.0f, 0.0f };
+const quat Quaternions::X_180{ 0.0f, 1.0f, 0.0f, 0.0f };
 const quat Quaternions::Y_180{ 0.0f, 0.0f, 1.0f, 0.0f };
+const quat Quaternions::Z_180{ 0.0f, 0.0f, 0.0f, 1.0f };
 
 //  Safe version of glm::mix; based on the code in Nick Bobick's article,
 //  http://www.gamasutra.com/features/19980703/quaternions_01.htm (via Clyde,

--- a/libraries/shared/src/GLMHelpers.h
+++ b/libraries/shared/src/GLMHelpers.h
@@ -58,7 +58,9 @@ glm::quat safeMix(const glm::quat& q1, const glm::quat& q2, float alpha);
 class Quaternions {
  public:
     static const quat IDENTITY;
+    static const quat X_180;
     static const quat Y_180;
+    static const quat Z_180;
 };
 
 class Vectors {

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -299,10 +299,11 @@ controller::Pose openVrControllerPoseToHandPose(bool isLeftHand, const mat4& mat
     static const glm::quat leftRotationOffset = glm::inverse(leftQuarterZ * eighthX) * touchToHand;
     static const glm::quat rightRotationOffset = glm::inverse(rightQuarterZ * eighthX) * touchToHand;
 
-    static const float CONTROLLER_X_OFFSET = 0.0381f; // sideways
-    static const float CONTROLLER_Y_OFFSET = 0.0495f; // forwards
-    static const float CONTROLLER_Z_OFFSET = 0.1371f; // upwards
-    static const glm::vec3 CONTROLLER_OFFSET(CONTROLLER_X_OFFSET, CONTROLLER_Y_OFFSET, CONTROLLER_Z_OFFSET);
+    // this needs to match the leftBasePosition in tutorial/viveControllerConfiguration.js:21
+    static const float CONTROLLER_LATERAL_OFFSET = 0.0381f;
+    static const float CONTROLLER_VERTICAL_OFFSET = 0.0495f;
+    static const float CONTROLLER_FORWARD_OFFSET = 0.1371f;
+    static const glm::vec3 CONTROLLER_OFFSET(CONTROLLER_LATERAL_OFFSET, CONTROLLER_VERTICAL_OFFSET, CONTROLLER_FORWARD_OFFSET);
 
     static const glm::vec3 leftTranslationOffset = glm::vec3(-1.0f, 1.0f, 1.0f) * CONTROLLER_OFFSET;
     static const glm::vec3 rightTranslationOffset = CONTROLLER_OFFSET;

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -299,10 +299,11 @@ controller::Pose openVrControllerPoseToHandPose(bool isLeftHand, const mat4& mat
     static const glm::quat leftRotationOffset = glm::inverse(leftQuarterZ * eighthX) * touchToHand;
     static const glm::quat rightRotationOffset = glm::inverse(rightQuarterZ * eighthX) * touchToHand;
 
-    static const float CONTROLLER_LENGTH_OFFSET = 0.0762f;  // three inches
-    static const glm::vec3 CONTROLLER_OFFSET = glm::vec3(CONTROLLER_LENGTH_OFFSET / 2.0f,
-        CONTROLLER_LENGTH_OFFSET / 2.0f,
-        CONTROLLER_LENGTH_OFFSET * 2.0f);
+    static const float CONTROLLER_X_OFFSET = 0.0381f; // sideways
+    static const float CONTROLLER_Y_OFFSET = 0.0495f; // forwards
+    static const float CONTROLLER_Z_OFFSET = 0.1371f; // upwards
+    static const glm::vec3 CONTROLLER_OFFSET(CONTROLLER_X_OFFSET, CONTROLLER_Y_OFFSET, CONTROLLER_Z_OFFSET);
+
     static const glm::vec3 leftTranslationOffset = glm::vec3(-1.0f, 1.0f, 1.0f) * CONTROLLER_OFFSET;
     static const glm::vec3 rightTranslationOffset = CONTROLLER_OFFSET;
 

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -111,7 +111,7 @@ var NEAR_GRABBING_KINEMATIC = true; // force objects to be kinematic when near-g
 var CHECK_TOO_FAR_UNEQUIP_TIME = 0.3; // seconds, duration between checks
 
 
-var GRAB_POINT_SPHERE_RADIUS = NEAR_GRAB_RADIUS;
+var GRAB_POINT_SPHERE_RADIUS = NEAR_GRAB_RADIUS * 1.5;
 var GRAB_POINT_SPHERE_COLOR = { red: 240, green: 240, blue: 240 };
 var GRAB_POINT_SPHERE_ALPHA = 0.85;
 

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -11,7 +11,7 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-/* global setEntityCustomData, getEntityCustomData, flatten, Xform, Script, Quat, Vec3, MyAvatar, Entities, Overlays, Settings, Reticle, Controller, Camera, Messages, Mat4, getControllerWorldLocation, getGrabPointSphereOffset */
+/* global setEntityCustomData, getEntityCustomData, flatten, Xform, Script, Quat, Vec3, MyAvatar, Entities, Overlays, Settings, Reticle, Controller, Camera, Messages, Mat4, getControllerWorldLocation, getGrabPointSphereOffset, setGrabCommunications */
 
 (function() { // BEGIN LOCAL_SCOPE
 
@@ -27,7 +27,7 @@ var WANT_DEBUG_STATE = false;
 var WANT_DEBUG_SEARCH_NAME = null;
 
 var FORCE_IGNORE_IK = false;
-var SHOW_GRAB_POINT_SPHERE = true;
+var SHOW_GRAB_POINT_SPHERE = false;
 
 //
 // these tune time-averaging and "on" value for analog trigger
@@ -101,7 +101,7 @@ var MAX_EQUIP_HOTSPOT_RADIUS = 1.0;
 
 var NEAR_GRABBING_ACTION_TIMEFRAME = 0.05; // how quickly objects move to their new position
 
-var NEAR_GRAB_RADIUS = 0.04; // radius used for palm vs object for near grabbing.
+var NEAR_GRAB_RADIUS = 0.1; // radius used for palm vs object for near grabbing.
 var NEAR_GRAB_MAX_DISTANCE = 1.0; // you cannot grab objects that are this far away from your hand
 
 var NEAR_GRAB_PICK_RADIUS = 0.25; // radius used for search ray vs object for near grabbing.
@@ -111,7 +111,7 @@ var NEAR_GRABBING_KINEMATIC = true; // force objects to be kinematic when near-g
 var CHECK_TOO_FAR_UNEQUIP_TIME = 0.3; // seconds, duration between checks
 
 
-var GRAB_POINT_SPHERE_RADIUS = NEAR_GRAB_RADIUS * 1.5;
+var GRAB_POINT_SPHERE_RADIUS = NEAR_GRAB_RADIUS;
 var GRAB_POINT_SPHERE_COLOR = { red: 240, green: 240, blue: 240 };
 var GRAB_POINT_SPHERE_ALPHA = 0.85;
 
@@ -835,7 +835,7 @@ function MyController(hand) {
             this.grabPointSphere = Overlays.addOverlay("sphere", {
                 localPosition: getGrabPointSphereOffset(this.handToController()),
                 localRotation: { x: 0, y: 0, z: 0, w: 1 },
-                dimensions: GRAB_POINT_SPHERE_RADIUS,
+                dimensions: GRAB_POINT_SPHERE_RADIUS * 2,
                 color: GRAB_POINT_SPHERE_COLOR,
                 alpha: GRAB_POINT_SPHERE_ALPHA,
                 solid: true,
@@ -2661,6 +2661,15 @@ mapping.from([Controller.Standard.RightPrimaryThumb]).peek().to(rightController.
 
 Controller.enableMapping(MAPPING_NAME);
 
+function handleMenuEvent(menuItem) {
+    if (menuItem === "Show Grab Sphere") {
+        SHOW_GRAB_POINT_SPHERE = Menu.isOptionChecked("Show Grab Sphere");
+    }
+}
+
+Menu.addMenuItem({ menuName: "Developer", menuItemName: "Show Grab Sphere", isCheckable: true, isChecked: false });
+Menu.menuItemEvent.connect(handleMenuEvent);
+
 // the section below allows the grab script to listen for messages
 // that disable either one or both hands.  useful for two handed items
 var handToDisable = 'none';
@@ -2776,6 +2785,7 @@ var updateIntervalTimer = Script.setInterval(function(){
 }, BASIC_TIMER_INTERVAL_MS);
 
 function cleanup() {
+    Menu.removeMenuItem("Developer", "Show Grab Sphere");
     Script.clearInterval(updateIntervalTimer);
     rightController.cleanup();
     leftController.cleanup();

--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -21,7 +21,7 @@ getGrabCommunications = function getFarGrabCommunications() {
 // var GRAB_POINT_SPHERE_OFFSET = { x: 0.1, y: 0.32, z: 0.04 };
 
 // this offset needs to match the one in libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
-var GRAB_POINT_SPHERE_OFFSET = { x: 0.0, y: 0.175, z: 0.0 };
+var GRAB_POINT_SPHERE_OFFSET = { x: 0.075, y: 0.175, z: 0.039 };  // x = upward, y = forward, z = inward
 
 getGrabPointSphereOffset = function(handController) {
     if (handController === Controller.Standard.RightHand) {

--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -15,13 +15,8 @@ getGrabCommunications = function getFarGrabCommunications() {
     return !!Settings.getValue(GRAB_COMMUNICATIONS_SETTING, "");
 }
 
-
-// var GRAB_POINT_SPHERE_OFFSET = { x: 0, y: 0.2, z: 0 };
-// var GRAB_POINT_SPHERE_OFFSET = { x: 0.1, y: 0.175, z: 0.04 };
-// var GRAB_POINT_SPHERE_OFFSET = { x: 0.1, y: 0.32, z: 0.04 };
-
-// this offset needs to match the one in libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
-var GRAB_POINT_SPHERE_OFFSET = { x: 0.075, y: 0.175, z: 0.039 };  // x = upward, y = forward, z = inward
+// this offset needs to match the one in libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp:378
+var GRAB_POINT_SPHERE_OFFSET = { x: 0.04, y: 0.13, z: 0.039 };  // x = upward, y = forward, z = lateral
 
 getGrabPointSphereOffset = function(handController) {
     if (handController === Controller.Standard.RightHand) {

--- a/tutorial/viveControllerConfiguration.js
+++ b/tutorial/viveControllerConfiguration.js
@@ -16,16 +16,20 @@ var rightBaseRotation = Quat.multiply(
         Quat.fromPitchYawRollDegrees(0, 0, -90)
     )
 );
-var CONTROLLER_LENGTH_OFFSET = 0.0762; 
+
+// keep these in sync with the values from plugins/openvr/src/OpenVrHelpers.cpp:303
+var CONTROLLER_LATERAL_OFFSET = 0.0381;
+var CONTROLLER_VERTICAL_OFFSET = 0.0495;
+var CONTROLLER_FORWARD_OFFSET = 0.1371;
 var leftBasePosition = {
-    x: CONTROLLER_LENGTH_OFFSET / 2,
-    y: CONTROLLER_LENGTH_OFFSET * 2,
-    z: CONTROLLER_LENGTH_OFFSET / 2
+    x: CONTROLLER_VERTICAL_OFFSET,
+    y: CONTROLLER_FORWARD_OFFSET,
+    z: CONTROLLER_LATERAL_OFFSET
 };
 var rightBasePosition = {
-    x: -CONTROLLER_LENGTH_OFFSET / 2,
-    y: CONTROLLER_LENGTH_OFFSET * 2,
-    z: CONTROLLER_LENGTH_OFFSET / 2
+    x: -CONTROLLER_VERTICAL_OFFSET,
+    y: CONTROLLER_FORWARD_OFFSET,
+    z: CONTROLLER_LATERAL_OFFSET
 };
 
 var viveNaturalDimensions = {


### PR DESCRIPTION
* The grab sphere used to detect objects for near grabbing is now 10 cm in radius instead of 4 cm.
* The grab sphere position and far grab laser origin has been moved to be centered around the vive hand controller.
* The vive hand controller position has been adjusted to better fit in the avatar's hand.
* The visual representation of this grab sphere is always hidden, by default.
* The visual sphere can be re-enabled via the "Developer > Show Grab Sphere" menu item.
