### PR TITLE
fix resize on plugin switch

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5681,6 +5681,9 @@ void Application::updateDisplayMode() {
     // Make the switch atomic from the perspective of other threads
     {
         std::unique_lock<std::mutex> lock(_displayPluginLock);
+        // Tell the desktop to no reposition (which requires plugin info), until we have set the new plugin, below.
+        bool wasRepositionLocked = offscreenUi->getDesktop()->property("repositionLocked").toBool();
+        offscreenUi->getDesktop()->setProperty("repositionLocked", true);
 
         auto oldDisplayPlugin = _displayPlugin;
         if (_displayPlugin) {
@@ -5717,6 +5720,7 @@ void Application::updateDisplayMode() {
         _offscreenContext->makeCurrent();
         getApplicationCompositor().setDisplayPlugin(newDisplayPlugin);
         _displayPlugin = newDisplayPlugin;
+        offscreenUi->getDesktop()->setProperty("repositionLocked", wasRepositionLocked);
     }
 
     emit activeDisplayPluginChanged();


### PR DESCRIPTION
fixes https://highfidelity.fogbugz.com/f/cases/1992/wacky-hud-element-placement-when-switching-between-desktop-and-hmd-loses-overlays

test plan:
- Start with an empty Interface.ini in desktop. Observe the location of overlays. Maybe open a few more, scattered around.
- Switch to HMD. All overlays should be within the "recommended area" which extends a bit to the sides, but NOT way behind you.
- Switch back to Desktop.  Overlays should be same as original.
- Repeat, but this time in HMD, move some of the overlays further around to both sides (and up and down) so that they start to get clipped (almost behind you).  Now when you go back to desktop, the ones that were clipped outside the recommended area (from the first HMD step) will be clipped, but still visible.
- Repeat with manual resizing of desktop Interface window.