### PR TITLE
Remove showing of overlays in away.js

### DIFF
--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -54,7 +54,6 @@ var AWAY_INTRO = {
 var isEnabled = true;
 var wasMuted; // unknonwn?
 var isAway = false; // we start in the un-away state
-var wasOverlaysVisible = Menu.isOptionChecked("Overlays");
 var eventMappingName = "io.highfidelity.away"; // goActive on hand controller button events, too.
 var eventMapping = Controller.newMapping(eventMappingName);
 var avatarPosition = MyAvatar.position;
@@ -178,12 +177,6 @@ function goAway(fromStartup) {
     playAwayAnimation(); // animation is still seen by others
     showOverlay();
 
-    // remember the View > Overlays state...
-    wasOverlaysVisible = Menu.isOptionChecked("Overlays");
-
-    // show overlays so that people can see the "Away" message
-    Menu.setIsOptionChecked("Overlays", true);
-
     // tell the Reticle, we want to stop capturing the mouse until we come back
     Reticle.allowMouseCapture = false;
     // Allow users to find their way to other applications, our menus, etc.
@@ -232,9 +225,6 @@ function goActive() {
     MyAvatar.centerBody();
 
     hideOverlay();
-
-    // restore overlays state to what it was when we went "away"
-    Menu.setIsOptionChecked("Overlays", wasOverlaysVisible);
 
     // tell the Reticle, we are ready to capture the mouse again and it should be visible
     Reticle.allowMouseCapture = true;


### PR DESCRIPTION
This change makes changes to away.js so that overlays are not automatically displayed when going into away mode.

To test:

 1. Confirm that you can see the away message in both HMD and Desktop while away
 1. Confirm that if you have overlays hidden (`View > Overlays` unchecked) while you are not in away mode that they are not shown when you go into away mode, but that **you can still see the away message**.
 1. Confirm that away.js works as expected