### PR TITLE
fix flicker in system (inside the hud) hand-lasers.

### DIFF
--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -379,10 +379,6 @@ void HmdDisplayPlugin::updateFrameData() {
         mat4 model = _presentHandPoses[i];
         vec3 castStart = vec3(model[3]);
         vec3 castDirection = glm::quat_cast(model) * laserDirection;
-        if (glm::abs(glm::length2(castDirection) - 1.0f) > EPSILON) {
-            castDirection = glm::normalize(castDirection);
-            castDirection = glm::inverse(_presentUiModelTransform.getRotation()) * castDirection;
-        }
 
         // this offset needs to match GRAB_POINT_SPHERE_OFFSET in scripts/system/libraries/controllers.js:19
         static const vec3 GRAB_POINT_SPHERE_OFFSET(0.04f, 0.13f, 0.039f);  // x = upward, y = forward, z = lateral


### PR DESCRIPTION
fix https://highfidelity.fogbugz.com/f/cases/1849/Double-lasers-when-over-HUD

Test plan, in HMD:
Use blue and red search lasers over various objects and hud elements. Observe the lasers that appear between your hand and the hud when pointing at overlays, and make sure there are no bad visuals . 
In particular, there had been flickering when aiming across your own body to a hud element far to the other side (e.g., far to the left if you're right-handed).