### PR TITLE
Heartbeats need to happen while waiting for sandbox

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -585,6 +585,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     static bool determinedSandboxState = false;
     static bool sandboxIsRunning = false;
     SandboxUtils sandboxUtils;
+    // updateHeartbeat() because we are going to poll shortly...
+    updateHeartbeat();
     sandboxUtils.ifLocalSandboxRunningElse([&]() {
         qCDebug(interfaceapp) << "Home sandbox appears to be running.....";
         determinedSandboxState = true;
@@ -605,6 +607,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     auto startWaiting = usecTimestampNow();
     while (!determinedSandboxState && (usecTimestampNow() - startWaiting <= MAX_WAIT_TIME)) {
         QCoreApplication::processEvents();
+        // updateHeartbeat() while polling so we don't scare the deadlock watchdog
+        updateHeartbeat();
         usleep(USECS_PER_MSEC * 50); // 20hz
     }
 


### PR DESCRIPTION
We can only know if sandbox is up by waiting for the http request to
succeed or fail.  In the common case (fail since it isn't up yet), we
have to wait until a connect timeout in http.  Seems that is a couple
seconds, and in that time we really upset the deadlock watchdog thread
since it keeps a moving average of heartbeat times.

Simple solution, updateHeartbeat while waiting, and right before we
start.


# Test Plan
(1) start interface.  Just interface.  You should not see a constant stream of deadlock warnings in the logs of the form:
`[10/21 09:50:33] [DEBUG] [hifi.interface.deadlock] DEADLOCK WATCHDOG WARNING: lastHeartbeatAge: 4001673 elapsedMovingAverage: 0 PREVIOUS maxElapsed: 3001433 NEW maxElapsed: 4001673 ** NEW MAX ELAPSED ** maxElapsedAverage: 0 samples: 0
...`
(2) do the same, but have interface start sandbox (perhaps run from steam by copying interface.exe over there).  You should observe happy logs as above.
(3) 🍻 