### PR TITLE
Add more GPU stats, make stats easier to read

### DIFF
--- a/interface/resources/qml/StatText.qml
+++ b/interface/resources/qml/StatText.qml
@@ -1,0 +1,9 @@
+import QtQuick 2.3
+import QtQuick.Controls 1.2
+
+Text {
+    color: "white"; 
+    style: Text.Outline;
+    styleColor: "black";
+    font.pixelSize: 12;
+}

--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -1,6 +1,7 @@
 import Hifi 1.0 as Hifi
 import QtQuick 2.3
 import QtQuick.Controls 1.2
+import '.'
 
 Item {
     id: stats
@@ -28,9 +29,7 @@ Item {
         implicitWidth: row.width
 
         anchors.horizontalCenter: parent.horizontalCenter
-        readonly property int fontSize: 12
-        readonly property string fontColor: "white"
-        readonly property string bgColor: "#99333333"
+        readonly property string bgColor: "#AA111111"
 
         Row {
             id: row
@@ -49,64 +48,40 @@ Item {
                 Column {
                     id: generalCol
                     spacing: 4; x: 4; y: 4;
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Servers: " + root.serverCount
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Avatars: " + root.avatarCount
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Frame Rate: " + root.framerate.toFixed(2);
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Render Rate: " + root.renderrate.toFixed(2);
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Present Rate: " + root.presentrate.toFixed(2);
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Present New Rate: " + root.presentnewrate.toFixed(2);
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Present Drop Rate: " + root.presentdroprate.toFixed(2);
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Simrate: " + root.simrate
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Avatar Simrate: " + root.avatarSimrate
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Packets In/Out: " + root.packetInCount + "/" + root.packetOutCount
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Mbps In/Out: " + root.mbpsIn.toFixed(2) + "/" + root.mbpsOut.toFixed(2)
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded
                         text: "Asset Mbps In/Out: " + root.assetMbpsIn.toFixed(2) + "/" + root.assetMbpsOut.toFixed(2)
                     }
@@ -126,29 +101,19 @@ Item {
                 Column {
                     id: pingCol
                     spacing: 4; x: 4; y: 4;
-                    Text {
-                        color: root.fontColor
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Audio ping: " + root.audioPing
                     }
-                    Text {
-                        color: root.fontColor
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Avatar ping: " + root.avatarPing
                     }
-                    Text {
-                        color: root.fontColor
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Entities avg ping: " + root.entitiesPing
                     }
-                    Text {
-                        color: root.fontColor
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Asset ping: " + root.assetPing
                     }
-                    Text {
-                        color: root.fontColor
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: "Messages max ping: " + root.messagePing
                     }
@@ -167,46 +132,32 @@ Item {
                 Column {
                     id: geoCol
                     spacing: 4; x: 4; y: 4;
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Position: " + root.position.x.toFixed(1) + ", " +
                             root.position.y.toFixed(1) + ", " + root.position.z.toFixed(1)
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Speed: " + root.speed.toFixed(1)
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Yaw: " + root.yaw.toFixed(1)
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: "Avatar Mixer In: " + root.avatarMixerInKbps + " kbps, " +
                             root.avatarMixerInPps + "pps";
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: "Avatar Mixer Out: " + root.avatarMixerOutKbps + " kbps, " +
                             root.avatarMixerOutPps + "pps";
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: "Downloads: " + root.downloads + "/" + root.downloadLimit +
                               ", Pending: " + root.downloadsPending;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded && root.downloadUrls.length > 0;
                         text: "Download URLs:"
                     }
@@ -217,9 +168,7 @@ Item {
                         visible: root.expanded && root.downloadUrls.length > 0;
 
                         model: root.downloadUrls
-                        delegate: Text {
-                            color: root.fontColor;
-                            font.pixelSize: root.fontSize
+                        delegate: StatText {
                             visible: root.expanded;
                             text: modelData.length > 30
                                 ?  modelData.substring(0, 5) + "..." + modelData.substring(modelData.length - 22)
@@ -240,99 +189,92 @@ Item {
                 Column {
                     id: octreeCol
                     spacing: 4; x: 4; y: 4;
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         text: "Triangles: " + root.triangles +
                             " / Material Switches: " + root.materialSwitches
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
-                        text: "GPU Textures: " + root.gpuTextures;
+                    StatText {
+                        text: "GPU Textures: ";
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
-                        text: "GPU Buffers: " + root.gpuBuffers;
+                    StatText {
+                        text: "  Sparse Enabled: " + (0 == root.gpuSparseTextureEnabled ? "false" : "true");
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
+                        text: "  Count: " + root.gpuTextures;
+                    }
+                    StatText {
+                        text: "  Sparse Count: " + root.gpuTexturesSparse;
+                        visible: 0 != root.gpuSparseTextureEnabled;
+                    }
+                    StatText {
+                        text: "  Virtual Memory: " + root.gpuTextureVirtualMemory + " MB";
+                    }
+                    StatText {
+                        text: "  Commited Memory: " + root.gpuTextureMemory + " MB";
+                    }
+                    StatText {
+                        text: "  Sparse Memory: " + root.gpuTextureSparseMemory + " MB";
+                        visible: 0 != root.gpuSparseTextureEnabled;
+                    }
+                    StatText {
+                        text: "GPU Buffers: "
+                    }
+                    StatText {
+                        text: "  Count: " + root.gpuTextures;
+                    }
+                    StatText {
                         text: "QML Texture Memory: " + root.qmlTextureMemory + " MB";
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: "Items rendered / considered: " +
                             root.itemRendered + " / " + root.itemConsidered;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: " out of view: " + root.itemOutOfView +
                             " too small: " + root.itemTooSmall;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: "Shadows rendered / considered: " +
                             root.shadowRendered + " / " + root.shadowConsidered;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded;
                         text: " out of view: " + root.shadowOutOfView +
                             " too small: " + root.shadowTooSmall;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: !root.expanded
                         text: "Octree Elements Server: " + root.serverElements +
                             " Local: " + root.localElements;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded
                         text: "Octree Sending Mode: " + root.sendingMode;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded
                         text: "Octree Packets to Process: " + root.packetStats;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded
                         text: "Octree Elements - ";
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded
                         text: "\tServer: " + root.serverElements +
                             " Internal: " + root.serverInternal +
                             " Leaves: " + root.serverLeaves;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded
                         text: "\tLocal: " + root.localElements +
                             " Internal: " + root.localInternal +
                             " Leaves: " + root.localLeaves;
                     }
-                    Text {
-                        color: root.fontColor;
-                        font.pixelSize: root.fontSize
+                    StatText {
                         visible: root.expanded
                         text: "LOD: " + root.lodStatus;
                     }
@@ -346,12 +288,10 @@ Item {
             width: perfText.width + 8
             height: perfText.height + 8
             color: root.bgColor;
-            Text {
+            StatText {
                 x: 4; y: 4
                 id: perfText
-                color: root.fontColor
                 font.family: root.monospaceFont
-                font.pixelSize: 12
                 text: "------------------------------------------ Function " +
                     "--------------------------------------- --msecs- -calls--\n" +
                     root.timingStats;

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -287,7 +287,13 @@ void Stats::updateStats(bool force) {
 
     STAT_UPDATE(gpuBuffers, (int)gpu::Context::getBufferGPUCount());
     STAT_UPDATE(gpuTextures, (int)gpu::Context::getTextureGPUCount());
+    STAT_UPDATE(gpuTexturesSparse, (int)gpu::Context::getTextureGPUSparseCount());
     STAT_UPDATE(qmlTextureMemory, (int)BYTES_TO_MB(OffscreenQmlSurface::getUsedTextureMemory()));
+    STAT_UPDATE(gpuTextureMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUMemoryUsage()));
+    STAT_UPDATE(gpuTextureVirtualMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUVirtualMemoryUsage()));
+    STAT_UPDATE(gpuTextureSparseMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUSparseMemoryUsage()));
+    STAT_UPDATE(gpuSparseTextureEnabled, gpu::Texture::getEnableSparseTextures() ? 1 : 0);
+
 
     // Incoming packets
     QLocale locale(QLocale::English);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -89,7 +89,12 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, localLeaves, 0)
     STATS_PROPERTY(int, gpuBuffers, 0)
     STATS_PROPERTY(int, gpuTextures, 0)
+    STATS_PROPERTY(int, gpuTexturesSparse, 0)
     STATS_PROPERTY(int, qmlTextureMemory, 0)
+    STATS_PROPERTY(int, gpuTextureMemory, 0)
+    STATS_PROPERTY(int, gpuTextureVirtualMemory, 0)
+    STATS_PROPERTY(int, gpuTextureSparseMemory, 0)
+    STATS_PROPERTY(int, gpuSparseTextureEnabled, 0)
 
 public:
     static Stats* getInstance();
@@ -175,9 +180,14 @@ signals:
     void localInternalChanged();
     void localLeavesChanged();
     void timingStatsChanged();
+    void qmlTextureMemoryChanged();
     void gpuBuffersChanged();
     void gpuTexturesChanged();
-    void qmlTextureMemoryChanged();
+    void gpuTexturesSparseChanged();
+    void gpuTextureMemoryChanged();
+    void gpuTextureVirtualMemoryChanged();
+    void gpuTextureSparseMemoryChanged();
+    void gpuSparseTextureEnabledChanged();
 
 private:
     int _recentMaxPackets{ 0 } ; // recent max incoming voxel packets to process

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -205,6 +205,8 @@ GLTexture::~GLTexture() {
                 qWarning() << "No recycler available for texture " << _id << " possible leak";
             }
         } else if (_id) {
+            // WARNING!  Sparse textures do not use this code path.  See GL45BackendTexture for 
+            // the GL45Texture destructor for doing any required work tracking GPU stats
             backend->releaseTexture(_id, _size);
         }
     }
@@ -275,7 +277,7 @@ void GLTexture::postTransfer() {
     setSyncState(GLSyncState::Idle);
     ++_transferCount;
 
-    // At this point the mip pixels have been loaded, we can notify the gpu texture to abandon it's memory
+    // At this point the mip pixels have been loaded, we can notify the g   pu texture to abandon it's memory
     switch (_gpuObject.getType()) {
         case Texture::TEX_2D:
             for (uint16_t i = 0; i < Sampler::MAX_MIP_LEVEL; ++i) {

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -277,7 +277,7 @@ void GLTexture::postTransfer() {
     setSyncState(GLSyncState::Idle);
     ++_transferCount;
 
-    // At this point the mip pixels have been loaded, we can notify the g   pu texture to abandon it's memory
+    // At this point the mip pixels have been loaded, we can notify the gpu texture to abandon it's memory
     switch (_gpuObject.getType()) {
         case Texture::TEX_2D:
             for (uint16_t i = 0; i < Sampler::MAX_MIP_LEVEL; ++i) {

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -139,7 +139,7 @@ float GLTexture::getMemoryPressure() {
     }
 
     // Return the consumed texture memory divided by the available texture memory.
-    auto consumedGpuMemory = Context::getTextureGPUMemoryUsage();
+    auto consumedGpuMemory = Context::getTextureGPUSparseMemoryUsage();
     float memoryPressure = (float)consumedGpuMemory / (float)availableTextureMemory;
     static Context::Size lastConsumedGpuMemory = 0;
     if (memoryPressure > 1.0f && lastConsumedGpuMemory != consumedGpuMemory) {

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.h
@@ -30,7 +30,7 @@ public:
     static std::shared_ptr<GLTextureTransferHelper> _textureTransferHelper;
 
     template <typename GLTextureType>
-    static GLTextureType* sync(GLBackend& backend, const TexturePointer& texturePointer, bool needTransfer) {
+    static GLTexture* sync(GLBackend& backend, const TexturePointer& texturePointer, bool needTransfer) {
         const Texture& texture = *texturePointer;
 
         // Special case external textures
@@ -74,7 +74,7 @@ public:
         }
 
         // If the object hasn't been created, or the object definition is out of date, drop and re-create
-        GLTextureType* object = Backend::getGPUObject<GLTextureType>(texture);
+        GLTexture* object = Backend::getGPUObject<GLTextureType>(texture);
 
         // Create the texture if need be (force re-creation if the storage stamp changes
         // for easier use of immutable storage)
@@ -84,6 +84,7 @@ public:
             if (!object->_transferrable) {
                 object->createTexture();
                 object->_contentStamp = texture.getDataStamp();
+                object->updateSize();
                 object->postTransfer();
             }
         }
@@ -119,7 +120,7 @@ public:
         if (!texture) {
             return 0;
         }
-        GLTextureType* object { nullptr };
+        GLTexture* object { nullptr };
         if (shouldSync) {
             object = sync<GLTextureType>(backend, texture, shouldSync);
         } else {

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -252,6 +252,9 @@ GL45Texture::GL45Texture(const std::weak_ptr<GLBackend>& backend, const Texture&
 
     if (_transferrable && Texture::getEnableSparseTextures()) {
         _sparseInfo.maybeMakeSparse();
+        if (_sparseInfo.sparse) {
+            Backend::incrementTextureGPUSparseCount();
+        }
     }
 }
 
@@ -261,6 +264,7 @@ GL45Texture::~GL45Texture() {
         qCDebug(gpugl45logging) << "Destroying texture " << _id << " from source " << _source.c_str();
     }
     if (_sparseInfo.sparse) {
+        Backend::decrementTextureGPUSparseCount();
         // Remove this texture from the candidate list of derezzable textures
         {
             auto mipLevels = usedMipLevels();
@@ -300,6 +304,7 @@ GL45Texture::~GL45Texture() {
         }
 
         auto size = _size;
+        const_cast<GLuint&>(_size) = 0;
         _textureTransferHelper->queueExecution([id, size, destructionFunctions] {
             for (auto function : destructionFunctions) {
                 function();
@@ -307,6 +312,7 @@ GL45Texture::~GL45Texture() {
             glDeleteTextures(1, &id);
             Backend::decrementTextureGPUCount();
             Backend::updateTextureGPUMemoryUsage(size, 0);
+            Backend::updateTextureGPUSparseMemoryUsage(size, 0);
         });
     }
 }
@@ -338,7 +344,9 @@ void GL45Texture::updateSize() const {
         qFatal("Compressed textures not yet supported");
     }
 
-    if (_transferrable) {
+    if (_transferrable && _sparseInfo.sparse) {
+        auto size = _allocatedPages * _sparseInfo.pageBytes;
+        Backend::updateTextureGPUSparseMemoryUsage(_size, size);
         setSize(_allocatedPages * _sparseInfo.pageBytes);
     } else {
         setSize(_virtualSize);

--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -167,9 +167,11 @@ std::atomic<uint32_t> Context::_bufferGPUCount { 0 };
 std::atomic<Buffer::Size> Context::_bufferGPUMemoryUsage { 0 };
 
 std::atomic<uint32_t> Context::_textureGPUCount{ 0 };
-std::atomic<Texture::Size> Context::_textureGPUMemoryUsage{ 0 };
+std::atomic<uint32_t> Context::_textureGPUSparseCount { 0 };
+std::atomic<Texture::Size> Context::_textureGPUMemoryUsage { 0 };
 std::atomic<Texture::Size> Context::_textureGPUVirtualMemoryUsage{ 0 };
-std::atomic<uint32_t> Context::_textureGPUTransferCount{ 0 };
+std::atomic<Texture::Size> Context::_textureGPUSparseMemoryUsage { 0 };
+std::atomic<uint32_t> Context::_textureGPUTransferCount { 0 };
 
 void Context::incrementBufferGPUCount() {
     static std::atomic<uint32_t> max { 0 };
@@ -217,6 +219,18 @@ void Context::decrementTextureGPUCount() {
     --_textureGPUCount;
 }
 
+void Context::incrementTextureGPUSparseCount() {
+    static std::atomic<uint32_t> max { 0 };
+    auto total = ++_textureGPUSparseCount;
+    if (total > max.load()) {
+        max = total;
+        qCDebug(gpulogging) << "New max GPU textures " << total;
+    }
+}
+void Context::decrementTextureGPUSparseCount() {
+    --_textureGPUSparseCount;
+}
+
 void Context::updateTextureGPUMemoryUsage(Size prevObjectSize, Size newObjectSize) {
     if (prevObjectSize == newObjectSize) {
         return;
@@ -236,6 +250,17 @@ void Context::updateTextureGPUVirtualMemoryUsage(Size prevObjectSize, Size newOb
         _textureGPUVirtualMemoryUsage.fetch_add(newObjectSize - prevObjectSize);
     } else {
         _textureGPUVirtualMemoryUsage.fetch_sub(prevObjectSize - newObjectSize);
+    }
+}
+
+void Context::updateTextureGPUSparseMemoryUsage(Size prevObjectSize, Size newObjectSize) {
+    if (prevObjectSize == newObjectSize) {
+        return;
+    }
+    if (newObjectSize > prevObjectSize) {
+        _textureGPUSparseMemoryUsage.fetch_add(newObjectSize - prevObjectSize);
+    } else {
+        _textureGPUSparseMemoryUsage.fetch_sub(prevObjectSize - newObjectSize);
     }
 }
 
@@ -263,12 +288,20 @@ uint32_t Context::getTextureGPUCount() {
     return _textureGPUCount.load();
 }
 
+uint32_t Context::getTextureGPUSparseCount() {
+    return _textureGPUSparseCount.load();
+}
+
 Context::Size Context::getTextureGPUMemoryUsage() {
     return _textureGPUMemoryUsage.load();
 }
 
 Context::Size Context::getTextureGPUVirtualMemoryUsage() {
     return _textureGPUVirtualMemoryUsage.load();
+}
+
+Context::Size Context::getTextureGPUSparseMemoryUsage() {
+    return _textureGPUSparseMemoryUsage.load();
 }
 
 uint32_t Context::getTextureGPUTransferCount() {
@@ -280,7 +313,10 @@ void Backend::decrementBufferGPUCount() { Context::decrementBufferGPUCount(); }
 void Backend::updateBufferGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateBufferGPUMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::incrementTextureGPUCount() { Context::incrementTextureGPUCount(); }
 void Backend::decrementTextureGPUCount() { Context::decrementTextureGPUCount(); }
+void Backend::incrementTextureGPUSparseCount() { Context::incrementTextureGPUSparseCount(); }
+void Backend::decrementTextureGPUSparseCount() { Context::decrementTextureGPUSparseCount(); }
 void Backend::updateTextureGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::updateTextureGPUVirtualMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUVirtualMemoryUsage(prevObjectSize, newObjectSize); }
+void Backend::updateTextureGPUSparseMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUSparseMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::incrementTextureGPUTransferCount() { Context::incrementTextureGPUTransferCount(); }
 void Backend::decrementTextureGPUTransferCount() { Context::decrementTextureGPUTransferCount(); }

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -94,7 +94,10 @@ public:
     static void updateBufferGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void incrementTextureGPUCount();
     static void decrementTextureGPUCount();
+    static void incrementTextureGPUSparseCount();
+    static void decrementTextureGPUSparseCount();
     static void updateTextureGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
+    static void updateTextureGPUSparseMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void updateTextureGPUVirtualMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void incrementTextureGPUTransferCount();
     static void decrementTextureGPUTransferCount();
@@ -201,8 +204,10 @@ public:
     static Size getBufferGPUMemoryUsage();
 
     static uint32_t getTextureGPUCount();
+    static uint32_t getTextureGPUSparseCount();
     static Size getTextureGPUMemoryUsage();
     static Size getTextureGPUVirtualMemoryUsage();
+    static Size getTextureGPUSparseMemoryUsage();
     static uint32_t getTextureGPUTransferCount();
 
 protected:
@@ -235,7 +240,10 @@ protected:
 
     static void incrementTextureGPUCount();
     static void decrementTextureGPUCount();
+    static void incrementTextureGPUSparseCount();
+    static void decrementTextureGPUSparseCount();
     static void updateTextureGPUMemoryUsage(Size prevObjectSize, Size newObjectSize);
+    static void updateTextureGPUSparseMemoryUsage(Size prevObjectSize, Size newObjectSize);
     static void updateTextureGPUVirtualMemoryUsage(Size prevObjectSize, Size newObjectSize);
     static void incrementTextureGPUTransferCount();
     static void decrementTextureGPUTransferCount();
@@ -247,7 +255,9 @@ protected:
     static std::atomic<Size> _bufferGPUMemoryUsage;
 
     static std::atomic<uint32_t> _textureGPUCount;
+    static std::atomic<uint32_t> _textureGPUSparseCount;
     static std::atomic<Size> _textureGPUMemoryUsage;
+    static std::atomic<Size> _textureGPUSparseMemoryUsage;
     static std::atomic<Size> _textureGPUVirtualMemoryUsage;
     static std::atomic<uint32_t> _textureGPUTransferCount;
 

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -70,6 +70,14 @@ void Texture::updateTextureCPUMemoryUsage(Size prevObjectSize, Size newObjectSiz
     }
 }
 
+bool Texture::getEnableSparseTextures() { 
+    return _enableSparseTextures.load(); 
+}
+
+bool Texture::getEnableIncrementalTextureTransfers() { 
+    return _enableIncrementalTextureTransfers.load(); 
+}
+
 uint32_t Texture::getTextureCPUCount() {
     return _textureCPUCount.load();
 }
@@ -82,12 +90,20 @@ uint32_t Texture::getTextureGPUCount() {
     return Context::getTextureGPUCount();
 }
 
+uint32_t Texture::getTextureGPUSparseCount() {
+    return Context::getTextureGPUSparseCount();
+}
+
 Texture::Size Texture::getTextureGPUMemoryUsage() {
     return Context::getTextureGPUMemoryUsage();
 }
 
 Texture::Size Texture::getTextureGPUVirtualMemoryUsage() {
     return Context::getTextureGPUVirtualMemoryUsage();
+}
+
+Texture::Size Texture::getTextureGPUSparseMemoryUsage() {
+    return Context::getTextureGPUSparseMemoryUsage();
 }
 
 uint32_t Texture::getTextureGPUTransferCount() {

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -151,14 +151,16 @@ public:
     static uint32_t getTextureCPUCount();
     static Size getTextureCPUMemoryUsage();
     static uint32_t getTextureGPUCount();
+    static uint32_t getTextureGPUSparseCount();
     static Size getTextureGPUMemoryUsage();
     static Size getTextureGPUVirtualMemoryUsage();
+    static Size getTextureGPUSparseMemoryUsage();
     static uint32_t getTextureGPUTransferCount();
     static Size getAllowedGPUMemoryUsage();
     static void setAllowedGPUMemoryUsage(Size size);
 
-    static bool getEnableSparseTextures() { return _enableSparseTextures.load(); }
-    static bool getEnableIncrementalTextureTransfers() { return _enableIncrementalTextureTransfers.load(); }
+    static bool getEnableSparseTextures();
+    static bool getEnableIncrementalTextureTransfers();
 
     static void setEnableSparseTextures(bool enabled);
     static void setEnableIncrementalTextureTransfers(bool enabled);


### PR DESCRIPTION
* Fixes the GPU texture memory calculation, which was not including non-sparse textures.
* Adds new stats for
 * sparse texture count
 * sparse texture memory as a subset of total GPU texture memory
 * whether sparse textures are enabled (the above two stats only display if they are)
* Make the stats easier to read by darkening the background, decreasing the background alpha, and giving the text an outline color.  

## Testing 

Application behavior should be unchanged.  This PR only modifies the code renders the debug stats.

If you enable stats (`/`) you should see the new values in the rightmost column.  If sparse textures is enabled, you should see the sparse texture count and the sparse texture memory consumed.

If you go to a dev-playa and use the developer / render / texture memory menu to set the texture memory to a very small value (like 64 MB) you should see the sparse texture memory fall to under that value.  The total texture memory may remain above that value due to other content, like framebuffers and the like.  