### PR TITLE
4k display & QML Offscreen rendering fixes

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2165,13 +2165,10 @@ void Application::resizeGL() {
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     auto uiSize = displayPlugin->getRecommendedUiSize();
     // Bit of a hack since there's no device pixel ratio change event I can find.
-    static qreal lastDevicePixelRatio = 0;
-    qreal devicePixelRatio = _window->devicePixelRatio();
-    if (offscreenUi->size() != fromGlm(uiSize) || devicePixelRatio != lastDevicePixelRatio) {
+    if (offscreenUi->size() != fromGlm(uiSize)) {
         qCDebug(interfaceapp) << "Device pixel ratio changed, triggering resize to " << uiSize;
         offscreenUi->resize(fromGlm(uiSize), true);
         _offscreenContext->makeCurrent();
-        lastDevicePixelRatio = devicePixelRatio;
     }
 }
 


### PR DESCRIPTION
* Remove the workaround for a bug in offscreen rendering of QML on systems with HDPI displays
* Fix logic to clamp maximum dimensions of any offscreen QML surface at 4k

## Testing

This PR must be tested on a system with an HDPI (4k or better) display before it is merged.  Application behavior should be unchanged, but this may resolve issues with massive GPU memory consumption on HDPI systems.  

Steps:
- On a "high DPI display" - run interface in full screen
- Using process explorer, check the "GPU Commited Bytes"
- Compare this build to master -- should should see master consuming more memory.

