### PR TITLE
Add free GPU memory to the displayed stats

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -194,6 +194,9 @@ Item {
                             " / Material Switches: " + root.materialSwitches
                     }
                     StatText {
+                        text: "GPU Free Memory: " + root.gpuFreeMemory + " MB";
+                    }
+                    StatText {
                         text: "GPU Textures: ";
                     }
                     StatText {

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -111,7 +111,6 @@ void Stats::updateStats(bool force) {
         PerformanceTimer::setActive(shouldDisplayTimingDetail);
     }
 
-
     auto nodeList = DependencyManager::get<NodeList>();
     auto avatarManager = DependencyManager::get<AvatarManager>();
     // we need to take one avatar out so we don't include ourselves
@@ -293,7 +292,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(gpuTextureVirtualMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUVirtualMemoryUsage()));
     STAT_UPDATE(gpuTextureSparseMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUSparseMemoryUsage()));
     STAT_UPDATE(gpuSparseTextureEnabled, gpu::Texture::getEnableSparseTextures() ? 1 : 0);
-
+    STAT_UPDATE(gpuFreeMemory, (int)BYTES_TO_MB(gpu::Context::getFreeGPUMemory()));
 
     // Incoming packets
     QLocale locale(QLocale::English);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -95,6 +95,7 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, gpuTextureVirtualMemory, 0)
     STATS_PROPERTY(int, gpuTextureSparseMemory, 0)
     STATS_PROPERTY(int, gpuSparseTextureEnabled, 0)
+    STATS_PROPERTY(int, gpuFreeMemory, 0)
 
 public:
     static Stats* getInstance();
@@ -188,6 +189,7 @@ signals:
     void gpuTextureVirtualMemoryChanged();
     void gpuTextureSparseMemoryChanged();
     void gpuSparseTextureEnabledChanged();
+    void gpuFreeMemoryChanged();
 
 private:
     int _recentMaxPackets{ 0 } ; // recent max incoming voxel packets to process

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -630,6 +630,8 @@ void OpenGLDisplayPlugin::present() {
             PROFILE_RANGE_EX("internalPresent", 0xff00ffff, (uint64_t)presentCount())
             internalPresent();
         }
+
+        gpu::Backend::setFreeGPUMemory(gpu::gl::getFreeDedicatedMemory());
     }
 }
 

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -123,7 +123,7 @@ private:
     void destroyTexture(GLuint texture) {
         --_allTextureCount;
         auto size = _textureSizes[texture];
-        assert(getMemoryForSize(size) < _totalTextureUsage);
+        assert(getMemoryForSize(size) <= _totalTextureUsage);
         _totalTextureUsage -= getMemoryForSize(size);
         _textureSizes.erase(texture);
         glDeleteTextures(1, &texture);

--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -162,6 +162,7 @@ Backend::TransformCamera Backend::TransformCamera::getEyeCamera(int eye, const S
 }
 
 // Counters for Buffer and Texture usage in GPU/Context
+std::atomic<Size> Context::_freeGPUMemory { 0 };
 std::atomic<uint32_t> Context::_fenceCount { 0 };
 std::atomic<uint32_t> Context::_bufferGPUCount { 0 };
 std::atomic<Buffer::Size> Context::_bufferGPUMemoryUsage { 0 };
@@ -172,6 +173,14 @@ std::atomic<Texture::Size> Context::_textureGPUMemoryUsage { 0 };
 std::atomic<Texture::Size> Context::_textureGPUVirtualMemoryUsage{ 0 };
 std::atomic<Texture::Size> Context::_textureGPUSparseMemoryUsage { 0 };
 std::atomic<uint32_t> Context::_textureGPUTransferCount { 0 };
+
+void Context::setFreeGPUMemory(Size size) {
+    _freeGPUMemory.store(size);
+}
+
+Size Context::getFreeGPUMemory() {
+    return _freeGPUMemory.load();
+}
 
 void Context::incrementBufferGPUCount() {
     static std::atomic<uint32_t> max { 0 };
@@ -272,6 +281,7 @@ void Context::incrementTextureGPUTransferCount() {
         qCDebug(gpulogging) << "New max GPU textures transfers" << total;
     }
 }
+
 void Context::decrementTextureGPUTransferCount() {
     --_textureGPUTransferCount;
 }
@@ -308,6 +318,8 @@ uint32_t Context::getTextureGPUTransferCount() {
     return _textureGPUTransferCount.load();
 }
 
+void Backend::setFreeGPUMemory(Size size) { Context::setFreeGPUMemory(size); }
+Resource::Size Backend::getFreeGPUMemory() { return Context::getFreeGPUMemory(); }
 void Backend::incrementBufferGPUCount() { Context::incrementBufferGPUCount(); }
 void Backend::decrementBufferGPUCount() { Context::decrementBufferGPUCount(); }
 void Backend::updateBufferGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateBufferGPUMemoryUsage(prevObjectSize, newObjectSize); }

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -89,6 +89,8 @@ public:
 
     // These should only be accessed by Backend implementation to repport the buffer and texture allocations,
     // they are NOT public calls
+    static Resource::Size getFreeGPUMemory();
+    static void setFreeGPUMemory(Resource::Size prevObjectSize);
     static void incrementBufferGPUCount();
     static void decrementBufferGPUCount();
     static void updateBufferGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
@@ -205,6 +207,7 @@ public:
 
     static uint32_t getTextureGPUCount();
     static uint32_t getTextureGPUSparseCount();
+    static Size getFreeGPUMemory();
     static Size getTextureGPUMemoryUsage();
     static Size getTextureGPUVirtualMemoryUsage();
     static Size getTextureGPUSparseMemoryUsage();
@@ -238,6 +241,7 @@ protected:
     static void incrementFenceCount();
     static void decrementFenceCount();
 
+    static void setFreeGPUMemory(Size size);
     static void incrementTextureGPUCount();
     static void decrementTextureGPUCount();
     static void incrementTextureGPUSparseCount();
@@ -249,6 +253,7 @@ protected:
     static void decrementTextureGPUTransferCount();
 
     // Buffer, Texture and Fence Counters
+    static std::atomic<Size> _freeGPUMemory;
     static std::atomic<uint32_t> _fenceCount;
 
     static std::atomic<uint32_t> _bufferGPUCount;


### PR DESCRIPTION
## Testing

Available GPU memory as reported by the GL extension should be visible in the stats display (`/`).  It should drop when loading domain content.  It _may_ rise again when disconnecting from any domain or when going to a domain with less content than the current one, but due to the complexities of GL drivers and virtual memory, drops may not be immediate, or occur at all.  