### PR TITLE
Sandbox logs to file

### DIFF
--- a/server-console/package.json
+++ b/server-console/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "hf-console",
-  "description": "High Fidelity Console",
+  "name": "HighFidelitySandbox",
+  "description": "High Fidelity Sandbox",
   "author": "High Fidelity",
   "license": "Apache-2.0",
   "version": "1.0.0",
@@ -33,6 +33,7 @@
     "request": "^2.67.0",
     "request-progress": "1.0.2",
     "tar-fs": "^1.12.0",
-    "yargs": "^3.30.0"
+    "yargs": "^3.30.0",
+    "electron-log": "1.1.1"
   }
 }

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -1,11 +1,11 @@
 'use strict';
 
+global.log = require('electron-log');
+
 const electron = require('electron');
 const app = electron.app;  // Module to control application life.
 const BrowserWindow = electron.BrowserWindow;
 const nativeImage = electron.nativeImage;
-
-const log = require('electron-log');
 
 const notifier = require('node-notifier');
 const util = require('util');

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -64,7 +64,6 @@ function getBuildInfo() {
     var buildInfo = DEFAULT_BUILD_INFO;
 
     if (buildInfoPath) {
-        log.debug('Build info path:', buildInfoPath);
         try {
             buildInfo = JSON.parse(fs.readFileSync(buildInfoPath));
         } catch (e) {
@@ -75,15 +74,6 @@ function getBuildInfo() {
     return buildInfo;
 }
 const buildInfo = getBuildInfo();
-
-const logFile = getApplicationDataDirectory() + '/log.txt';
-fs.ensureFileSync(logFile); // Ensure file exists
-
-global.log = require('electron-log');
-log.transports.file.maxSize = 5 * 1024 * 1024;
-log.transports.file.file = logFile;
-
-log.debug("build info", buildInfo);
 
 function getRootHifiDataDirectory() {
     var organization = "High Fidelity";
@@ -111,6 +101,14 @@ function getApplicationDataDirectory() {
     return path.join(getRootHifiDataDirectory(), '/Server Console');
 }
 
+// Configure log
+global.log = require('electron-log');
+const logFile = getApplicationDataDirectory() + '/log.txt';
+fs.ensureFileSync(logFile); // Ensure file exists
+log.transports.file.maxSize = 5 * 1024 * 1024;
+log.transports.file.file = logFile;
+
+log.debug("build info", buildInfo);
 log.debug("Root hifi directory is: ", getRootHifiDataDirectory());
 
 const ipcMain = electron.ipcMain;

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -1,7 +1,5 @@
 'use strict';
 
-global.log = require('electron-log');
-
 const electron = require('electron');
 const app = electron.app;  // Module to control application life.
 const BrowserWindow = electron.BrowserWindow;
@@ -76,8 +74,14 @@ function getBuildInfo() {
 
     return buildInfo;
 }
-
 const buildInfo = getBuildInfo();
+
+const logFile = getApplicationDataDirectory() + '/log.txt';
+fs.ensureFileSync(logFile); // Ensure file exists
+
+global.log = require('electron-log');
+log.transports.file.maxSize = 5 * 1024 * 1024;
+log.transports.file.file = logFile;
 
 log.debug("build info", buildInfo);
 

--- a/server-console/src/modules/config.js
+++ b/server-console/src/modules/config.js
@@ -1,6 +1,5 @@
 var fs = require('fs');
 var extend = require('extend');
-var log = require('electron-log');
 
 function Config() {
     this.data = {};

--- a/server-console/src/modules/config.js
+++ b/server-console/src/modules/config.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var extend = require('extend');
+var log = require('electron-log');
 
 function Config() {
     this.data = {};
@@ -10,7 +11,7 @@ Config.prototype = {
         try {
             rawData = fs.readFileSync(filePath);
         } catch(e) {
-            console.log("Config file not found");
+            log.debug("Config file not found");
         }
         var configData = {};
 
@@ -21,7 +22,7 @@ Config.prototype = {
                 configData = {};
             }
         } catch(e) {
-            console.error("Error parsing config file", filePath)
+            log.error("Error parsing config file", filePath)
         }
 
         this.data = {};
@@ -37,7 +38,7 @@ Config.prototype = {
         return defaultValue;
     },
     set: function(key, value) {
-        console.log("Setting", key, "to", value);
+        log.debug("Setting", key, "to", value);
         this.data[key] = value;
     }
 };

--- a/server-console/src/modules/hf-process.js
+++ b/server-console/src/modules/hf-process.js
@@ -8,7 +8,6 @@ const childProcess = require('child_process');
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
-const log = require('electron-log');
 
 const ProcessGroupStates = {
     STOPPED: 'stopped',

--- a/server-console/src/modules/hf-updater.js
+++ b/server-console/src/modules/hf-updater.js
@@ -4,6 +4,7 @@ const util = require('util');
 const events = require('events');
 const cheerio = require('cheerio');
 const os = require('os');
+const log = require('electron-log');
 
 const platform = os.type() == 'Windows_NT' ? 'windows' : 'mac';
 
@@ -11,7 +12,7 @@ const BUILDS_URL = 'https://highfidelity.com/builds.xml';
 
 function UpdateChecker(currentVersion, checkForUpdatesEveryXSeconds) {
     this.currentVersion = currentVersion;
-    console.log('cur', currentVersion);
+    log.debug('cur', currentVersion);
 
     setInterval(this.checkForUpdates.bind(this), checkForUpdatesEveryXSeconds * 1000);
     this.checkForUpdates();
@@ -19,10 +20,10 @@ function UpdateChecker(currentVersion, checkForUpdatesEveryXSeconds) {
 util.inherits(UpdateChecker, events.EventEmitter);
 UpdateChecker.prototype = extend(UpdateChecker.prototype, {
     checkForUpdates: function() {
-        console.log("Checking for updates");
+        log.debug("Checking for updates");
         request(BUILDS_URL, (error, response, body) => {
             if (error) {
-                console.log("Error", error);
+                log.debug("Error", error);
                 return;
             }
             if (response.statusCode == 200) {
@@ -30,13 +31,13 @@ UpdateChecker.prototype = extend(UpdateChecker.prototype, {
                     var $ = cheerio.load(body, { xmlMode: true });
                     const latestBuild = $('project[name="interface"] platform[name="' + platform + '"]').children().first();
                     const latestVersion = parseInt(latestBuild.find('version').text());
-                    console.log("Latest version is:", latestVersion, this.currentVersion);
+                    log.debug("Latest version is:", latestVersion, this.currentVersion);
                     if (latestVersion > this.currentVersion) {
                         const url = latestBuild.find('url').text();
                         this.emit('update-available', latestVersion, url);
                     }
                 } catch (e) {
-                    console.warn("Error when checking for updates", e);
+                    log.warn("Error when checking for updates", e);
                 }
             }
         });

--- a/server-console/src/modules/hf-updater.js
+++ b/server-console/src/modules/hf-updater.js
@@ -4,7 +4,6 @@ const util = require('util');
 const events = require('events');
 const cheerio = require('cheerio');
 const os = require('os');
-const log = require('electron-log');
 
 const platform = os.type() == 'Windows_NT' ? 'windows' : 'mac';
 

--- a/server-console/src/modules/path-finder.js
+++ b/server-console/src/modules/path-finder.js
@@ -1,6 +1,5 @@
 var fs = require('fs');
 var path = require('path');
-var log = require('electron-log');
 
 function platformExtension(name) {
     if (name == "Interface") {

--- a/server-console/src/modules/path-finder.js
+++ b/server-console/src/modules/path-finder.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var log = require('electron-log');
 
 function platformExtension(name) {
     if (name == "Interface") {
@@ -72,11 +73,11 @@ exports.discoveredPath = function (name, binaryType, releaseType) {
                 var extension = platformExtension(name);
 
                 if (stats.isFile() || (stats.isDirectory() && extension == ".app")) {
-                    console.log("Found " + name + " at " + testPath);
+                    log.debug("Found " + name + " at " + testPath);
                     return testPath;
                 }
             } catch (e) {
-                console.log("Executable with name " + name + " not found at path " + testPath);
+                log.debug("Executable with name " + name + " not found at path " + testPath);
             }
         }
 


### PR DESCRIPTION
Included a new package so we can save the logs to a file.
- on Linux: `~/.local/share/High Fidelity/Server Console/log.txt`
- on OS X: `~/Library/Application Support/High Fidelity/Server Console/log.txt`
- on Windows: `%USERPROFILE%/AppData/Roaming/High Fidelity/Server Console/log.txt`

Added debug to shutdown process.


Test Plan:
- Run the Sandbox for a little bit, close it.
- Check that the log file was correctly saved.