### PR TITLE
Show hand controllers when out-of-body for more than 3/4 of a second

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -333,7 +333,7 @@ public slots:
     glm::vec3 getPositionForAudio();
     glm::quat getOrientationForAudio();
 
-    bool isOutOfBody() const { return _follow._isOutOfBody; }
+    bool isOutOfBody() const;
 
 signals:
     void audioListenerModeChanged();
@@ -467,6 +467,7 @@ private:
         };
         uint8_t _activeBits { 0 };
         bool _isOutOfBody { false };
+        float _outOfBodyDistance { 0.0f };
 
         void deactivate();
         void deactivate(FollowType type);
@@ -541,6 +542,9 @@ private:
     };
     DebugDrawVertex _debugLineLoop[DEBUG_LINE_LOOP_SIZE];
     size_t _debugLineLoopIndex { 0 };
+
+    bool _handControllerShow { false };
+    float _handControllerShowTimer { 0.0f };
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -26,6 +26,8 @@
 glm::vec3 TRUNCATE_IK_CAPSULE_POSITION(0.0f, 0.0f, 0.0f);
 float TRUNCATE_IK_CAPSULE_LENGTH = 1000.0f;
 float TRUNCATE_IK_CAPSULE_RADIUS = 0.25f;
+float MIN_OUT_OF_BODY_DISTANCE = TRUNCATE_IK_CAPSULE_RADIUS - 0.1f;
+float MAX_OUT_OF_BODY_DISTANCE = TRUNCATE_IK_CAPSULE_RADIUS + 0.1f;
 
 SkeletonModel::SkeletonModel(Avatar* owningAvatar, QObject* parent, RigPointer rig) :
     Model(rig, parent),
@@ -165,8 +167,6 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
         Rig::HandParameters handParams;
 
         // compute interp factor between in body and out of body hand positions.
-        const float MIN_OUT_OF_BODY_DISTANCE = TRUNCATE_IK_CAPSULE_RADIUS - 0.1f;
-        const float MAX_OUT_OF_BODY_DISTANCE = TRUNCATE_IK_CAPSULE_RADIUS + 0.1f;
         glm::vec3 capsuleStart = Vectors::UNIT_Y * (TRUNCATE_IK_CAPSULE_LENGTH / 2.0f);
         glm::vec3 capsuleEnd = -Vectors::UNIT_Y * (TRUNCATE_IK_CAPSULE_LENGTH / 2.0f);
         float outOfBodyAlpha = distanceFromCapsule(hmdPositionInRigSpace, capsuleStart, capsuleEnd, TRUNCATE_IK_CAPSULE_RADIUS);


### PR DESCRIPTION
Without the timer, the hands can flicker in and out of visibility when lightly brushing against collision.