### PR TITLE
actually make the RunningMarker run on a different thread

### DIFF
--- a/libraries/shared/src/RunningMarker.cpp
+++ b/libraries/shared/src/RunningMarker.cpp
@@ -23,7 +23,6 @@ RunningMarker::RunningMarker(QObject* parent, QString name) :
     _parent(parent),
     _name(name)
 {
-    qDebug() << __FUNCTION__ << "parent:" << parent << "name:" << name;
 }
 
 void RunningMarker::startRunningMarker() {
@@ -40,7 +39,6 @@ void RunningMarker::startRunningMarker() {
     QObject::connect(_runningMarkerTimer, &QTimer::timeout, [=](){
         writeRunningMarkerFiler();
     });
-    //QObject::connect(_runningMarkerThread, &QThread::finished, _runningMarkerTimer, &QObject::deleteLater);
     _runningMarkerTimer->start(RUNNING_STATE_CHECK_IN_MSECS);
 
     // put the time on the thread

--- a/libraries/shared/src/RunningMarker.cpp
+++ b/libraries/shared/src/RunningMarker.cpp
@@ -19,35 +19,40 @@
 #include "NumericalConstants.h"
 #include "PathUtils.h"
 
-
 RunningMarker::RunningMarker(QObject* parent, QString name) :
     _parent(parent),
     _name(name)
 {
+    qDebug() << __FUNCTION__ << "parent:" << parent << "name:" << name;
 }
 
 void RunningMarker::startRunningMarker() {
     static const int RUNNING_STATE_CHECK_IN_MSECS = MSECS_PER_SECOND;
 
     // start the nodeThread so its event loop is running
-    QThread* runningMarkerThread = new QThread(_parent);
-    runningMarkerThread->setObjectName("Running Marker Thread");
-    runningMarkerThread->start();
+    _runningMarkerThread = new QThread(_parent);
+    _runningMarkerThread->setObjectName("Running Marker Thread");
+    _runningMarkerThread->start();
 
     writeRunningMarkerFiler(); // write the first file, even before timer
 
-    QTimer* runningMarkerTimer = new QTimer(_parent);
-    QObject::connect(runningMarkerTimer, &QTimer::timeout, [=](){
+    _runningMarkerTimer = new QTimer();
+    QObject::connect(_runningMarkerTimer, &QTimer::timeout, [=](){
         writeRunningMarkerFiler();
     });
-    runningMarkerTimer->start(RUNNING_STATE_CHECK_IN_MSECS);
+    //QObject::connect(_runningMarkerThread, &QThread::finished, _runningMarkerTimer, &QObject::deleteLater);
+    _runningMarkerTimer->start(RUNNING_STATE_CHECK_IN_MSECS);
 
     // put the time on the thread
-    runningMarkerTimer->moveToThread(runningMarkerThread);
+    _runningMarkerTimer->moveToThread(_runningMarkerThread);
 }
 
 RunningMarker::~RunningMarker() {
     deleteRunningMarkerFile();
+    _runningMarkerTimer->stop();
+    _runningMarkerThread->quit();
+    _runningMarkerTimer->deleteLater();
+    _runningMarkerThread->deleteLater();
 }
 
 void RunningMarker::writeRunningMarkerFiler() {

--- a/libraries/shared/src/RunningMarker.h
+++ b/libraries/shared/src/RunningMarker.h
@@ -14,6 +14,8 @@
 
 #include <QObject>
 #include <QString>
+#include <QThread>
+#include <QTimer>
 
 class RunningMarker {
 public:
@@ -30,6 +32,8 @@ protected:
 
     QObject* _parent { nullptr };
     QString _name;
+    QThread* _runningMarkerThread { nullptr };
+    QTimer* _runningMarkerTimer { nullptr };
 };
 
 #endif // hifi_RunningMarker_h

--- a/libraries/shared/src/RunningMarker.h
+++ b/libraries/shared/src/RunningMarker.h
@@ -14,8 +14,9 @@
 
 #include <QObject>
 #include <QString>
-#include <QThread>
-#include <QTimer>
+
+class QThread;
+class QTimer;
 
 class RunningMarker {
 public:


### PR DESCRIPTION
this should properly move the RunningMarker timer callbacks to the dedicated thread. This should fix the fact that if the interface Main Thread blocks for more than 5 seconds the sandbox would shut down.