### PR TITLE
Update vive controller display to not hide on equip

### DIFF
--- a/scripts/system/controllers/controllerDisplayManager.js
+++ b/scripts/system/controllers/controllerDisplayManager.js
@@ -16,6 +16,8 @@
 Script.include("controllerDisplay.js");
 Script.include("viveControllerConfiguration.js");
 
+var HIDE_CONTROLLERS_ON_EQUIP = false;
+
 //
 // Management of controller display
 //
@@ -116,12 +118,14 @@ ControllerDisplayManager = function() {
                     }
                 }
             } else if (channel === 'Hifi-Object-Manipulation') {
-                data = JSON.parse(message);
-                visible = data.action !== 'equip';
-                if (data.joint === "LeftHand") {
-                    self.setLeftVisible(visible);
-                } else if (data.joint === "RightHand") {
-                    self.setRightVisible(visible);
+                if (HIDE_CONTROLLERS_ON_EQUIP) {
+                    data = JSON.parse(message);
+                    visible = data.action !== 'equip';
+                    if (data.joint === "LeftHand") {
+                        self.setLeftVisible(visible);
+                    } else if (data.joint === "RightHand") {
+                        self.setRightVisible(visible);
+                    }
                 }
             }
         }


### PR DESCRIPTION
We ended up disabling this functionality in the tutorial because the controller visual shows the user what to press to unequip. I've left the code because I think this could be something useful to continue playing with in the future, and might actually be the right choice outside of the tutorial.