### PR TITLE
Adding more detailed counters for texture memory consumption

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -229,6 +229,9 @@ Item {
                         text: "  Count: " + root.gpuTextures;
                     }
                     StatText {
+                        text: "GL Context FBO Memory: " + root.glContextFBOMemory + " MB";
+                    }
+                    StatText {
                         text: "QML Texture Memory: " + root.qmlTextureMemory + " MB";
                     }
                     StatText {

--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -216,6 +216,9 @@ Item {
                         text: "  Commited Memory: " + root.gpuTextureMemory + " MB";
                     }
                     StatText {
+                        text: "  Framebuffer Memory: " + root.gpuTextureFramebufferMemory + " MB";
+                    }
+                    StatText {
                         text: "  Sparse Memory: " + root.gpuTextureSparseMemory + " MB";
                         visible: 0 != root.gpuSparseTextureEnabled;
                     }

--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -229,7 +229,7 @@ Item {
                         text: "  Count: " + root.gpuTextures;
                     }
                     StatText {
-                        text: "GL Context FBO Memory: " + root.glContextFBOMemory + " MB";
+                        text: "GL Swapchain Memory: " + root.glContextSwapchainMemory + " MB";
                     }
                     StatText {
                         text: "QML Texture Memory: " + root.qmlTextureMemory + " MB";

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -25,6 +25,8 @@
 #include <PerfStat.h>
 #include <plugins/DisplayPlugin.h>
 
+#include <gl/Context.h>
+
 #include "BandwidthRecorder.h"
 #include "Menu.h"
 #include "Util.h"
@@ -287,6 +289,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(gpuBuffers, (int)gpu::Context::getBufferGPUCount());
     STAT_UPDATE(gpuTextures, (int)gpu::Context::getTextureGPUCount());
     STAT_UPDATE(gpuTexturesSparse, (int)gpu::Context::getTextureGPUSparseCount());
+    STAT_UPDATE(glContextFBOMemory, (int)BYTES_TO_MB(gl::Context::getDefaultFBOMemoryUsage()));
     STAT_UPDATE(qmlTextureMemory, (int)BYTES_TO_MB(OffscreenQmlSurface::getUsedTextureMemory()));
     STAT_UPDATE(gpuTextureMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUMemoryUsage()));
     STAT_UPDATE(gpuTextureVirtualMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUVirtualMemoryUsage()));

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -289,7 +289,9 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(gpuBuffers, (int)gpu::Context::getBufferGPUCount());
     STAT_UPDATE(gpuTextures, (int)gpu::Context::getTextureGPUCount());
     STAT_UPDATE(gpuTexturesSparse, (int)gpu::Context::getTextureGPUSparseCount());
-    STAT_UPDATE(glContextFBOMemory, (int)BYTES_TO_MB(gl::Context::getDefaultFBOMemoryUsage()));
+
+    STAT_UPDATE(glContextSwapchainMemory, (int)BYTES_TO_MB(gl::Context::getSwapchainMemoryUsage()));
+
     STAT_UPDATE(qmlTextureMemory, (int)BYTES_TO_MB(OffscreenQmlSurface::getUsedTextureMemory()));
     STAT_UPDATE(gpuTextureMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUMemoryUsage()));
     STAT_UPDATE(gpuTextureVirtualMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUVirtualMemoryUsage()));

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -290,6 +290,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(qmlTextureMemory, (int)BYTES_TO_MB(OffscreenQmlSurface::getUsedTextureMemory()));
     STAT_UPDATE(gpuTextureMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUMemoryUsage()));
     STAT_UPDATE(gpuTextureVirtualMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUVirtualMemoryUsage()));
+    STAT_UPDATE(gpuTextureFramebufferMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUFramebufferMemoryUsage()));
     STAT_UPDATE(gpuTextureSparseMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUSparseMemoryUsage()));
     STAT_UPDATE(gpuSparseTextureEnabled, gpu::Texture::getEnableSparseTextures() ? 1 : 0);
     STAT_UPDATE(gpuFreeMemory, (int)BYTES_TO_MB(gpu::Context::getFreeGPUMemory()));

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -93,6 +93,7 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, qmlTextureMemory, 0)
     STATS_PROPERTY(int, gpuTextureMemory, 0)
     STATS_PROPERTY(int, gpuTextureVirtualMemory, 0)
+    STATS_PROPERTY(int, gpuTextureFramebufferMemory, 0)
     STATS_PROPERTY(int, gpuTextureSparseMemory, 0)
     STATS_PROPERTY(int, gpuSparseTextureEnabled, 0)
     STATS_PROPERTY(int, gpuFreeMemory, 0)
@@ -187,6 +188,7 @@ signals:
     void gpuTexturesSparseChanged();
     void gpuTextureMemoryChanged();
     void gpuTextureVirtualMemoryChanged();
+    void gpuTextureFramebufferMemoryChanged();
     void gpuTextureSparseMemoryChanged();
     void gpuSparseTextureEnabledChanged();
     void gpuFreeMemoryChanged();

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -90,7 +90,7 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, gpuBuffers, 0)
     STATS_PROPERTY(int, gpuTextures, 0)
     STATS_PROPERTY(int, gpuTexturesSparse, 0)
-    STATS_PROPERTY(int, glContextFBOMemory, 0)
+    STATS_PROPERTY(int, glContextSwapchainMemory, 0)
     STATS_PROPERTY(int, qmlTextureMemory, 0)
     STATS_PROPERTY(int, gpuTextureMemory, 0)
     STATS_PROPERTY(int, gpuTextureVirtualMemory, 0)
@@ -183,7 +183,7 @@ signals:
     void localInternalChanged();
     void localLeavesChanged();
     void timingStatsChanged();
-    void glContextFBOMemoryChanged();
+    void glContextSwapchainMemoryChanged();
     void qmlTextureMemoryChanged();
     void gpuBuffersChanged();
     void gpuTexturesChanged();

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -90,6 +90,7 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, gpuBuffers, 0)
     STATS_PROPERTY(int, gpuTextures, 0)
     STATS_PROPERTY(int, gpuTexturesSparse, 0)
+    STATS_PROPERTY(int, glContextFBOMemory, 0)
     STATS_PROPERTY(int, qmlTextureMemory, 0)
     STATS_PROPERTY(int, gpuTextureMemory, 0)
     STATS_PROPERTY(int, gpuTextureVirtualMemory, 0)
@@ -182,6 +183,7 @@ signals:
     void localInternalChanged();
     void localLeavesChanged();
     void timingStatsChanged();
+    void glContextFBOMemoryChanged();
     void qmlTextureMemoryChanged();
     void gpuBuffersChanged();
     void gpuTexturesChanged();

--- a/libraries/gl/src/gl/Context.cpp
+++ b/libraries/gl/src/gl/Context.cpp
@@ -109,7 +109,7 @@ Context::~Context() {
 void Context::updateSwapchainMemoryCounter() {
     if (_window) {
         auto newSize = _window->size();
-        auto newMemSize = gl::Context::evalSurfaceMemoryUsage(newSize.width(), newSize.height(), _swapchainPixelSize);
+        auto newMemSize = gl::Context::evalSurfaceMemoryUsage(newSize.width(), newSize.height(), (uint32_t) _swapchainPixelSize);
         gl::Context::updateSwapchainMemoryUsage(_swapchainMemoryUsage, newMemSize);
         _swapchainMemoryUsage = newMemSize;
     } else {
@@ -257,8 +257,9 @@ void Context::create() {
         wglChoosePixelFormatARB(_hdc, &formatAttribs[0], NULL, 1, &pixelFormat, &numFormats);
         DescribePixelFormat(_hdc, pixelFormat, sizeof(pfd), &pfd);
     }
-    // The swap chain  pixel size for swap chains is : rgba32 * double buffer + depth24stencil8
-    _swapchainPixelSize = 32 * 2 + 32;
+    // The swap chain  pixel size for swap chains is : rgba32 + depth24stencil8
+    // We don't apply the length of the swap chain into this pixelSize since it is not vsible for the Process (on windows).
+    _swapchainPixelSize = 32 + 32;
     updateSwapchainMemoryCounter();
 
     SetPixelFormat(_hdc, pixelFormat, &pfd);

--- a/libraries/gl/src/gl/Context.h
+++ b/libraries/gl/src/gl/Context.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include <QtGlobal>
+#include <atomic>
 
 #if defined(Q_OS_WIN)
 #include <Windows.h>
@@ -23,7 +24,7 @@ class QThread;
 
 namespace gl {
 
-class Context {
+    class Context {
     protected:
         QWindow* _window { nullptr };
         static Context* PRIMARY;
@@ -57,6 +58,13 @@ class Context {
         virtual void create();
         QOpenGLContext* qglContext();
         void moveToThread(QThread* thread);
+
+        static size_t getDefaultFBOMemoryUsage();
+        static size_t evalMemoryUsage(uint32_t width, uint32_t height);
+        static void updateDefaultFBOMemoryUsage(size_t prevFBOSize, size_t newFBOSize);
+
+     private:
+        static std::atomic<size_t> _defaultFBOMemoryUsage;
     };
 
     class OffscreenContext : public Context {
@@ -67,6 +75,7 @@ class Context {
         virtual ~OffscreenContext();
         void create() override;
     };
+
 }
 
 #endif // hifi_gpu_GPUConfig_h

--- a/libraries/gl/src/gl/Context.h
+++ b/libraries/gl/src/gl/Context.h
@@ -59,12 +59,16 @@ namespace gl {
         QOpenGLContext* qglContext();
         void moveToThread(QThread* thread);
 
-        static size_t getDefaultFBOMemoryUsage();
-        static size_t evalMemoryUsage(uint32_t width, uint32_t height);
-        static void updateDefaultFBOMemoryUsage(size_t prevFBOSize, size_t newFBOSize);
+        static size_t evalSurfaceMemoryUsage(uint32_t width, uint32_t height, uint32_t pixelSize);
+        static size_t getSwapchainMemoryUsage();
+        static void updateSwapchainMemoryUsage(size_t prevSize, size_t newSize);
 
      private:
-        static std::atomic<size_t> _defaultFBOMemoryUsage;
+        static std::atomic<size_t> _totalSwapchainMemoryUsage;
+
+        size_t _swapchainMemoryUsage { 0 };
+        size_t _swapchainPixelSize { 0 };
+        void updateSwapchainMemoryCounter();
     };
 
     class OffscreenContext : public Context {

--- a/libraries/gl/src/gl/ContextQt.cpp
+++ b/libraries/gl/src/gl/ContextQt.cpp
@@ -45,6 +45,7 @@ void Context::moveToThread(QThread* thread) {
 
 #ifndef Q_OS_WIN
 bool Context::makeCurrent() {
+    updateSwapchainMemoryCounter();
     return _context->makeCurrent(_window);
 }
 
@@ -70,6 +71,9 @@ void Context::create() {
     }
     _context->setFormat(getDefaultOpenGLSurfaceFormat());
     _context->create();
+
+    _swapchainPixelSize = evalGLFormatSwapchainPixelSize(_context->format());
+    updateSwapchainMemoryCounter();
 }
 
 #endif

--- a/libraries/gl/src/gl/ContextQt.cpp
+++ b/libraries/gl/src/gl/ContextQt.cpp
@@ -15,6 +15,8 @@
 #include <QtPlatformHeaders/QWGLNativeContext>
 #endif
 
+#include "GLHelpers.h"
+
 using namespace gl;
 
 void Context::destroyContext(QOpenGLContext* context) {

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -13,6 +13,15 @@
 
 #include <QtOpenGL/QGL>
 
+size_t evalGLFormatSwapchainPixelSize(const QSurfaceFormat& format) {
+    size_t pixelSize = format.redBufferSize() + format.greenBufferSize() + format.blueBufferSize() + format.alphaBufferSize();
+    if (format.swapBehavior() > 0) {
+        pixelSize *= format.swapBehavior(); // multiply the color buffer pixel size by the actual swapchain depth
+    }
+    pixelSize += format.stencilBufferSize() + format.depthBufferSize();
+    return pixelSize;
+}
+
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat() {
     static QSurfaceFormat format;
     static std::once_flag once;

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -15,9 +15,11 @@
 
 size_t evalGLFormatSwapchainPixelSize(const QSurfaceFormat& format) {
     size_t pixelSize = format.redBufferSize() + format.greenBufferSize() + format.blueBufferSize() + format.alphaBufferSize();
-    if (format.swapBehavior() > 0) {
-        pixelSize *= format.swapBehavior(); // multiply the color buffer pixel size by the actual swapchain depth
-    }
+    // We don't apply the length of the swap chain into this pixelSize since it is not vsible for the Process (on windows).
+    // Let s keep this here remember that:
+    // if (format.swapBehavior() > 0) {
+    //     pixelSize *= format.swapBehavior(); // multiply the color buffer pixel size by the actual swapchain depth
+    // }
     pixelSize += format.stencilBufferSize() + format.depthBufferSize();
     return pixelSize;
 }

--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -26,6 +26,8 @@ class QGLFormat;
 template<class F>
 void setGLFormatVersion(F& format, int major = 4, int minor = 5) { format.setVersion(major, minor); }
 
+size_t evalGLFormatSwapchainPixelSize(const QSurfaceFormat& format);
+
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat();
 QJsonObject getGLContextData();
 int glVersionToInteger(QString glVersion);

--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -24,8 +24,7 @@
 
 OffscreenGLCanvas::OffscreenGLCanvas() :
     _context(new QOpenGLContext),
-    _offscreenSurface(new QOffscreenSurface),
-    _offscreenSurfaceCurrentMemoryUsage(0)
+    _offscreenSurface(new QOffscreenSurface)
 {
 }
 
@@ -34,8 +33,6 @@ OffscreenGLCanvas::~OffscreenGLCanvas() {
     _context->makeCurrent(_offscreenSurface);
     delete _context;
     _context = nullptr;
-
-    gl::Context::updateDefaultFBOMemoryUsage(_offscreenSurfaceCurrentMemoryUsage, 0);
 
     _offscreenSurface->destroy();
     delete _offscreenSurface;
@@ -60,15 +57,6 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
     return false;
 }
 
-void OffscreenGLCanvas::updateMemoryCounter() {
-    if (_offscreenSurface) {
-        auto newSize =_offscreenSurface->size();
-        auto newMemSize =  gl::Context::evalMemoryUsage(newSize.width(), newSize.height());
-        gl::Context::updateDefaultFBOMemoryUsage(_offscreenSurfaceCurrentMemoryUsage, newMemSize);
-        _offscreenSurfaceCurrentMemoryUsage = newMemSize;
-    }
-}
-
 bool OffscreenGLCanvas::makeCurrent() {
     bool result = _context->makeCurrent(_offscreenSurface);
     Q_ASSERT(result);
@@ -78,8 +66,6 @@ bool OffscreenGLCanvas::makeCurrent() {
         qCDebug(glLogging) << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
         qCDebug(glLogging) << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
     });
-
-    updateMemoryCounter();
 
     return result;
 }

--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -36,8 +36,6 @@ protected:
     std::once_flag _reportOnce;
     QOpenGLContext* _context{ nullptr };
     QOffscreenSurface* _offscreenSurface{ nullptr };
-    size_t _offscreenSurfaceCurrentMemoryUsage { 0 };
-    void updateMemoryCounter();
 };
 
 #endif // hifi_OffscreenGLCanvas_h

--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -36,6 +36,8 @@ protected:
     std::once_flag _reportOnce;
     QOpenGLContext* _context{ nullptr };
     QOffscreenSurface* _offscreenSurface{ nullptr };
+    size_t _offscreenSurfaceCurrentMemoryUsage { 0 };
+    void updateMemoryCounter();
 };
 
 #endif // hifi_OffscreenGLCanvas_h

--- a/libraries/gpu-gl/src/gpu/gl/GLFramebuffer.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLFramebuffer.cpp
@@ -13,7 +13,7 @@ using namespace gpu;
 using namespace gpu::gl;
 
 GLFramebuffer::~GLFramebuffer() { 
-    if (_id) { 
+    if (_id) {
         auto backend = _backend.lock();
         if (backend) {
             backend->releaseFramebuffer(_id);

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -181,8 +181,11 @@ GLTexture::~GLTexture() {
             // the GL45Texture destructor for doing any required work tracking GPU stats
             backend->releaseTexture(_id, _size);
         }
+
+        if (!_external && !_transferrable) {
+            Backend::updateTextureGPUFramebufferMemoryUsage(_size, 0);
+        }
     }
-    Backend::updateTextureGPUVirtualMemoryUsage(_virtualSize, 0);
 }
 
 void GLTexture::createTexture() {
@@ -217,6 +220,9 @@ void GLTexture::withPreservedTexture(std::function<void()> f) const {
 }
 
 void GLTexture::setSize(GLuint size) const {
+    if (!_external && !_transferrable) {
+        Backend::updateTextureGPUFramebufferMemoryUsage(_size, size);
+    }
     Backend::updateTextureGPUMemoryUsage(_size, size);
     const_cast<GLuint&>(_size) = size;
 }

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -186,6 +186,7 @@ GLTexture::~GLTexture() {
             Backend::updateTextureGPUFramebufferMemoryUsage(_size, 0);
         }
     }
+    Backend::updateTextureGPUVirtualMemoryUsage(_virtualSize, 0);
 }
 
 void GLTexture::createTexture() {

--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -170,7 +170,8 @@ std::atomic<Buffer::Size> Context::_bufferGPUMemoryUsage { 0 };
 std::atomic<uint32_t> Context::_textureGPUCount{ 0 };
 std::atomic<uint32_t> Context::_textureGPUSparseCount { 0 };
 std::atomic<Texture::Size> Context::_textureGPUMemoryUsage { 0 };
-std::atomic<Texture::Size> Context::_textureGPUVirtualMemoryUsage{ 0 };
+std::atomic<Texture::Size> Context::_textureGPUVirtualMemoryUsage { 0 };
+std::atomic<Texture::Size> Context::_textureGPUFramebufferMemoryUsage { 0 };
 std::atomic<Texture::Size> Context::_textureGPUSparseMemoryUsage { 0 };
 std::atomic<uint32_t> Context::_textureGPUTransferCount { 0 };
 
@@ -262,6 +263,17 @@ void Context::updateTextureGPUVirtualMemoryUsage(Size prevObjectSize, Size newOb
     }
 }
 
+void Context::updateTextureGPUFramebufferMemoryUsage(Size prevObjectSize, Size newObjectSize) {
+    if (prevObjectSize == newObjectSize) {
+        return;
+    }
+    if (newObjectSize > prevObjectSize) {
+        _textureGPUFramebufferMemoryUsage.fetch_add(newObjectSize - prevObjectSize);
+    } else {
+        _textureGPUFramebufferMemoryUsage.fetch_sub(prevObjectSize - newObjectSize);
+    }
+}
+
 void Context::updateTextureGPUSparseMemoryUsage(Size prevObjectSize, Size newObjectSize) {
     if (prevObjectSize == newObjectSize) {
         return;
@@ -310,6 +322,10 @@ Context::Size Context::getTextureGPUVirtualMemoryUsage() {
     return _textureGPUVirtualMemoryUsage.load();
 }
 
+Context::Size Context::getTextureGPUFramebufferMemoryUsage() {
+    return _textureGPUFramebufferMemoryUsage.load();
+}
+
 Context::Size Context::getTextureGPUSparseMemoryUsage() {
     return _textureGPUSparseMemoryUsage.load();
 }
@@ -329,6 +345,7 @@ void Backend::incrementTextureGPUSparseCount() { Context::incrementTextureGPUSpa
 void Backend::decrementTextureGPUSparseCount() { Context::decrementTextureGPUSparseCount(); }
 void Backend::updateTextureGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::updateTextureGPUVirtualMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUVirtualMemoryUsage(prevObjectSize, newObjectSize); }
+void Backend::updateTextureGPUFramebufferMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUFramebufferMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::updateTextureGPUSparseMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUSparseMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::incrementTextureGPUTransferCount() { Context::incrementTextureGPUTransferCount(); }
 void Backend::decrementTextureGPUTransferCount() { Context::decrementTextureGPUTransferCount(); }

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -101,6 +101,7 @@ public:
     static void updateTextureGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void updateTextureGPUSparseMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void updateTextureGPUVirtualMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
+    static void updateTextureGPUFramebufferMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void incrementTextureGPUTransferCount();
     static void decrementTextureGPUTransferCount();
 
@@ -210,6 +211,7 @@ public:
     static Size getFreeGPUMemory();
     static Size getTextureGPUMemoryUsage();
     static Size getTextureGPUVirtualMemoryUsage();
+    static Size getTextureGPUFramebufferMemoryUsage();
     static Size getTextureGPUSparseMemoryUsage();
     static uint32_t getTextureGPUTransferCount();
 
@@ -249,6 +251,7 @@ protected:
     static void updateTextureGPUMemoryUsage(Size prevObjectSize, Size newObjectSize);
     static void updateTextureGPUSparseMemoryUsage(Size prevObjectSize, Size newObjectSize);
     static void updateTextureGPUVirtualMemoryUsage(Size prevObjectSize, Size newObjectSize);
+    static void updateTextureGPUFramebufferMemoryUsage(Size prevObjectSize, Size newObjectSize);
     static void incrementTextureGPUTransferCount();
     static void decrementTextureGPUTransferCount();
 
@@ -264,6 +267,7 @@ protected:
     static std::atomic<Size> _textureGPUMemoryUsage;
     static std::atomic<Size> _textureGPUSparseMemoryUsage;
     static std::atomic<Size> _textureGPUVirtualMemoryUsage;
+    static std::atomic<Size> _textureGPUFramebufferMemoryUsage;
     static std::atomic<uint32_t> _textureGPUTransferCount;
 
 

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -102,6 +102,11 @@ Texture::Size Texture::getTextureGPUVirtualMemoryUsage() {
     return Context::getTextureGPUVirtualMemoryUsage();
 }
 
+
+Texture::Size Texture::getTextureGPUFramebufferMemoryUsage() {
+    return Context::getTextureGPUFramebufferMemoryUsage();
+}
+
 Texture::Size Texture::getTextureGPUSparseMemoryUsage() {
     return Context::getTextureGPUSparseMemoryUsage();
 }

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -154,6 +154,7 @@ public:
     static uint32_t getTextureGPUSparseCount();
     static Size getTextureGPUMemoryUsage();
     static Size getTextureGPUVirtualMemoryUsage();
+    static Size getTextureGPUFramebufferMemoryUsage();
     static Size getTextureGPUSparseMemoryUsage();
     static uint32_t getTextureGPUTransferCount();
     static Size getAllowedGPUMemoryUsage();


### PR DESCRIPTION
Introducing 2 new counters visible on the stats ui:
- in the gpu texture list the Framebuffer which should account fo r the amount of memory allocated on gpu for textures which are used in Framebuffers.

- added a counter for measuring the estimated cost of all the swapchains coming from the window providing the rendering surface to a gl::Context. The cost of the swapchain depends on its pixel format and the size of the window.

I choose to NOT take into account the swapchain length (double buffered vs single bufferd) to evaluete the pixel cost of the swapchain since in practice the double buffer becomes really something managed by the OS and we can't really know if its really allocated for sure.
Our experimentation and comaprison with the metric comming from Process Explorer seems to validate that...

