### PR TITLE
Crash on exit fix for render items

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1576,6 +1576,12 @@ void Application::cleanupBeforeQuit() {
 #endif
 
     DependencyManager::destroy<OffscreenUi>();
+
+    // shutdown render engine
+    _main3DScene = nullptr;
+    _renderEngine = nullptr;
+
+    qCDebug(interfaceapp) << "Application::cleanupBeforeQuit() complete";
 }
 
 Application::~Application() {

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -36,6 +36,7 @@
 #include "Application.h"
 #include "Avatar.h"
 #include "AvatarManager.h"
+#include "InterfaceLogging.h"
 #include "Menu.h"
 #include "MyAvatar.h"
 #include "SceneScriptingInterface.h"
@@ -208,11 +209,15 @@ AvatarSharedPointer AvatarManager::addAvatar(const QUuid& sessionUUID, const QWe
     auto rawRenderableAvatar = std::static_pointer_cast<Avatar>(newAvatar);
 
     render::ScenePointer scene = qApp->getMain3DScene();
-    render::PendingChanges pendingChanges;
-    if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()) {
-        rawRenderableAvatar->addToScene(rawRenderableAvatar, scene, pendingChanges);
+    if (scene) {
+        render::PendingChanges pendingChanges;
+        if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()) {
+            rawRenderableAvatar->addToScene(rawRenderableAvatar, scene, pendingChanges);
+        }
+        scene->enqueuePendingChanges(pendingChanges);
+    } else {
+        qCWarning(interfaceapp) << "AvatarManager::addAvatar() : Unexpected null scene, possibly during application shutdown";
     }
-    scene->enqueuePendingChanges(pendingChanges);
 
     return newAvatar;
 }

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -15,6 +15,7 @@
 #include <render/Scene.h>
 #include <EntityItem.h>
 #include "AbstractViewStateInterface.h"
+#include "EntitiesRendererLogging.h"
 
 
 // These or the icon "name" used by the render item status value, they correspond to the atlas texture used by the DrawItemStatus
@@ -79,10 +80,14 @@ public:
         render::PendingChanges pendingChanges;
         render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
 
-        pendingChanges.updateItem<RenderableEntityItemProxy>(_myItem, [](RenderableEntityItemProxy& data) {
-        });
+        if (scene) {
+            pendingChanges.updateItem<RenderableEntityItemProxy>(_myItem, [](RenderableEntityItemProxy& data) {
+            });
 
-        scene->enqueuePendingChanges(pendingChanges);
+            scene->enqueuePendingChanges(pendingChanges);
+        } else {
+            qCWarning(entitiesrenderer) << "SimpleRenderableEntityItem::notifyChanged(), Unexpected null scene, possibly during application shutdown";
+        }
     }
 
 private:

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -248,9 +248,12 @@ void RenderableZoneEntityItem::notifyBoundChanged() {
     }
     render::PendingChanges pendingChanges;
     render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
+    if (scene) {
+        pendingChanges.updateItem<RenderableZoneEntityItemMeta>(_myMetaItem, [](RenderableZoneEntityItemMeta& data) {
+        });
 
-    pendingChanges.updateItem<RenderableZoneEntityItemMeta>(_myMetaItem, [](RenderableZoneEntityItemMeta& data) {
-    });
-
-    scene->enqueuePendingChanges(pendingChanges);
+        scene->enqueuePendingChanges(pendingChanges);
+    } else {
+        qCWarning(entitiesrenderer) << "RenderableZoneEntityItem::notifyBoundChanged(), Unexpected null scene, possibly during application shutdown";
+    }
 }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -862,8 +862,12 @@ void Model::setURL(const QUrl& url) {
     {
         render::PendingChanges pendingChanges;
         render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
-        removeFromScene(scene, pendingChanges);
-        scene->enqueuePendingChanges(pendingChanges);
+        if (scene) {
+            removeFromScene(scene, pendingChanges);
+            scene->enqueuePendingChanges(pendingChanges);
+        } else {
+            qCWarning(renderutils) << "Model::setURL(), Unexpected null scene, possibly during application shutdown";
+        }
     }
 
     _needsReload = true;

--- a/libraries/render/src/render/Scene.cpp
+++ b/libraries/render/src/render/Scene.cpp
@@ -48,6 +48,10 @@ Scene::Scene(glm::vec3 origin, float size) :
     _items.push_back(Item()); // add the itemID #0 to nothing
 }
 
+Scene::~Scene() {
+    qDebug() << "Scene::~Scene()";
+}
+
 ItemID Scene::allocateID() {
     // Just increment and return the proevious value initialized at 0
     return _IDAllocator.fetch_add(1);

--- a/libraries/render/src/render/Scene.h
+++ b/libraries/render/src/render/Scene.h
@@ -55,7 +55,7 @@ typedef std::queue<PendingChanges> PendingChangesQueue;
 class Scene {
 public:
     Scene(glm::vec3 origin, float size);
-    ~Scene() {}
+    ~Scene();
 
     // This call is thread safe, can be called from anywhere to allocate a new ID
     ItemID allocateID();


### PR DESCRIPTION
Destroy the render scene & engine before the Application is destroyed.

Many render items/payloads contain smart pointers back to the objects that added them to the scene, including entity and avatar objects. Currently, those render items are destroyed when the scene is destroyed very late in the application life-cycle.

There are rare crashes that can occur when these render items are destroyed. Possibly, due to them referencing objects that have already been destroyed via raw pointers. In an effort to eliminate these crashes, we now destroy the scene earlier, within Application::aboutToQuit() which is connected to the QCoreApplication::aboutToQuit signal.  Also, we guard against null scene pointer dereferences.  Any location that accesses the scene off the main thread, now checks the validity of the scene pointer.