### PR TITLE
Dk/agent avatar audio artifacts

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -349,7 +349,7 @@ void Agent::executeScript() {
         audioTransform.setRotation(scriptedAvatar->getOrientation());
         AbstractAudioInterface::emitAudioPacket(audio.data(), audio.size(), audioSequenceNumber, audioTransform, PacketType::MicrophoneAudioNoEcho);
     });
-    
+
     auto avatarHashMap = DependencyManager::set<AvatarHashMap>();
     _scriptEngine->registerGlobalObject("AvatarList", avatarHashMap.data());
 

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -81,7 +81,8 @@ signals:
 private:
     void negotiateAudioFormat();
     void selectAudioFormat(const QString& selectedCodecName);
-    
+    void flushEncoder();
+
     std::unique_ptr<ScriptEngine> _scriptEngine;
     EntityEditPacketSender _entityEditSender;
     EntityTreeHeadlessViewer _entityViewer;
@@ -107,6 +108,7 @@ private:
     QString _selectedCodecName;
     Encoder* _encoder { nullptr }; 
     QThread _avatarAudioTimerThread;
+    bool _flushEncoder { false };
 };
 
 #endif // hifi_Agent_h


### PR DESCRIPTION
This fixes both the screaming when`summon.js` is stopped, and the click at the beginning of the audio when using `Avatar.playAvatarSound`.  Also fixed some weird whitespace issue and removed some commented out code.