### PR TITLE
Beta Release 24 - Includes up to Developer Release 5572

### DIFF
--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -16,6 +16,7 @@
 #include <QRegExp>
 #include <QStringList>
 
+#include <BuildInfo.h>
 #include <GLMHelpers.h>
 #include <NumericalConstants.h>
 #include <SettingHandle.h>
@@ -27,6 +28,11 @@
 #include "UserActivityLogger.h"
 #include "udt/PacketHeaders.h"
 
+#if USE_STABLE_GLOBAL_SERVICES
+const QString DEFAULT_HIFI_ADDRESS = "hifi://welcome";
+#else
+const QString DEFAULT_HIFI_ADDRESS = "hifi://dev-welcome";
+#endif
 
 const QString ADDRESS_MANAGER_SETTINGS_GROUP = "AddressManager";
 const QString SETTINGS_CURRENT_ADDRESS_KEY = "address";

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -24,11 +24,7 @@
 
 const QString HIFI_URL_SCHEME = "hifi";
 
-#if USE_STABLE_GLOBAL_SERVICES
-const QString DEFAULT_HIFI_ADDRESS = "hifi://welcome";
-#else
-const QString DEFAULT_HIFI_ADDRESS = "hifi://dev-welcome";
-#endif
+extern const QString DEFAULT_HIFI_ADDRESS;
 
 const QString SANDBOX_HIFI_ADDRESS = "hifi://localhost";
 const QString INDEX_PATH = "/";


### PR DESCRIPTION
* display location and connection status in address bar when it doesn't have focus 
* Support external GL textures with proper fencing
* Initial work towards making performance testing reproducible
* Remove all usage of oglplus
* Fix model overlay visibility and texture properties
* Add ability to parent overlays to MyAvatar for use across servers
* Add category to log lines
* Fix intermittent channel swapping
* Fix CMAKE warning about un-unit-testable CPP file in physics unit tests
* Add flag to interface to have it start the sandbox server
* Fix 16khz support and hot-unplugging audio devices
This PR fixes two unrelated audio issues on Windows, by updating qtaudio_wasapi.dll. 
* Fix ScriptEngine not properly resolving paths
* Trigger unequip at a more lenient angle and with the secondary trigger
* Add setMapping to ATP scripting interface and fix threading bug
* added a command-line tool for checking on health of a domain-server and ACs 
* Add retrying of script requests
* Remove QML threaded rendering
* Fix script paths not resolving correctly
* HMD Keyboard
* Kill agents in avatar mixer when they stop being avatars
* Update teleport.js to ignore invisible or collisionless objects and disallow teleporting to certain surfaces
* init the accumulator for script elapsed time
* Updated Tutorial content
* Fix page size usage in gpu buffers
* Fix away HMD unmouted logic
* Fix GPU texture counter, better logging for memory pressure
* Send High Fidelity user's visibility when users.js starts up
* Adjustments to grab indicators
* Adapt shader for GL ES support
* Allow equipped object to follow hand and not controller
* Fix Asset Browser add-to-world
* Prevent crashes in openvr on shutdown
* Have avatar sounds negotiate codecs
* Update ds path queries to be reliable
* Update window size automaticatlly
* Bug fixes in oculus_touch default mapping
* Fix edit.js not allowing imports when you only have temp rez permissions
* Prevent crash on exit
* Additional plugin debugging, better plugin resource cleanup
* Make agent avatar animations work again, and use them in crowds 
* Update ScriptCache to clear ATP assets when disconnected from a domain
* Don't crash on OpenVR activation when SteamVR isn't running
* Better handling of the teleport target overlays to prevent flashing
* Fix entity-import with only tmp-rez rights
* Make laser pointers work even while content is loading
* Make marketplace tablet be clientOnly fixes 
* Close button and frame on goto address bar. 
* Fix cellscience ac script load
* Fixes for various networking/ATP stuck download failure cases
* Fix AMD crash caused by missing glFlush
* Never interact with hud elements while holding something
* HMD keyboard polishing
* Avoid uninitialized oculus gl calls
* Update gamepad help image
* Switchable placeholder for domain-connection failure, currently a modal
* Directory picker works when choosing the initial value
* Don't override place name path with index path
* Add GPU buffer and texture current counts to the main stats display
* Fix play button in cellscience
* Speculative fix for crash in FBXReader.cpp
* Fix deadlock when removing tablet
* Fix bug in Script.include when urls is empty
* Fix suggestion card appearing behind keyboard
* Replaces UDT default congestion control with TCP (Vegas)
* Move HF access token to authorization header
* Add virtual keyboard for steam username collision
* Move HFWebEngineProfile to interface/networking
* Fixed HandcontrollerGrab distance unequip
* Ensure model attachment lifetimes
* Rate limit QML web surfaces
* Unit scaled address bar
* Force valid file path for asset file mapping operations
* Update users.js to be minimizable when logged out, and by default
* Fix invalid ShapeKey ref
* Adjustment to position and visibility of grab sphere.
* Fix intermittent crash on teleport from contextless Qt connection
* Remove the use of implicit ids in geometry cache
* Fix sequence number race condition
* Fix some audio mixer data races
* Added attachment support to crowd-agent
* Fix crash on startup
* Remove showing of overlays in away.js
* Fix flicker in system (inside the hud) hand-lasers.
* Fix offscreen QML texture leak, improve texture sharing for same size surfaces
* Always go to dev-welcome when not using stable services
* Fix for sandbox startup issue
* Undo bad script-engine AC change
* Fix some data-races in logging system
* Heartbeats need to happen while waiting for sandbox
* Show hand controllers in away.js
* Report offscreen texture memory usage in stats
* Add more GPU stats, make stats easier to read
* Add free GPU memory to the displayed stats
* New texture memory scheme
* Add Bullet profile info to PerformanceTimer stats