### PR TITLE
Disable OpenVR submit thread when async reprojection is enabled

### DIFF
--- a/cmake/externals/openvr/CMakeLists.txt
+++ b/cmake/externals/openvr/CMakeLists.txt
@@ -7,8 +7,8 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL https://github.com/ValveSoftware/openvr/archive/v1.0.2.zip
-  URL_MD5 0d1cf5f579cf092e33f34759967b7046
+  URL https://github.com/ValveSoftware/openvr/archive/v1.0.3.zip
+  URL_MD5 b484b12901917cc739e40389583c8b0d
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -338,6 +338,9 @@ Menu::Menu() {
     // Developer > Render > Throttle FPS If Not Focus
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::ThrottleFPSIfNotFocus, 0, true);
 
+    // Developer > Render > OpenVR threaded submit
+    addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::OpenVrThreadedSubmit, 0, true);
+
     // Developer > Render > Resolution
     MenuWrapper* resolutionMenu = renderOptionsMenu->addMenu(MenuOption::RenderResolution);
     QActionGroup* resolutionGroup = new QActionGroup(resolutionMenu);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -136,6 +136,7 @@ namespace MenuOption {
     const QString OctreeStats = "Entity Statistics";
     const QString OnePointCalibration = "1 Point Calibration";
     const QString OnlyDisplayTopTen = "Only Display Top Ten";
+    const QString OpenVrThreadedSubmit = "OpenVR Threaded Submit"; 
     const QString OutputMenu = "Display";
     const QString Overlays = "Overlays";
     const QString PackageModel = "Package Model...";

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -35,6 +35,7 @@ Q_DECLARE_LOGGING_CATEGORY(displayplugins)
 
 const QString OpenVrDisplayPlugin::NAME("OpenVR (Vive)");
 const QString StandingHMDSensorMode = "Standing HMD Sensor Mode"; // this probably shouldn't be hardcoded here
+const QString OpenVrThreadedSubmit = "OpenVR Threaded Submit"; // this probably shouldn't be hardcoded here
 
 PoseData _nextRenderPoseData;
 PoseData _nextSimPoseData;
@@ -48,8 +49,6 @@ bool _openVrDisplayActive { false };
 // Flip y-axis since GL UV coords are backwards.
 static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_LEFT{ 0, 0, 0.5f, 1 };
 static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_RIGHT{ 0.5f, 0, 1, 1 };
-
-#if OPENVR_THREADED_SUBMIT
 
 #define REPROJECTION_BINDING 1
 
@@ -351,8 +350,6 @@ public:
     OpenVrDisplayPlugin& _plugin;
 };
 
-#endif
-
 bool OpenVrDisplayPlugin::isSupported() const {
     return openVrSupported();
 }
@@ -394,6 +391,9 @@ bool OpenVrDisplayPlugin::internalActivate() {
         return false;
     }
 
+    _threadedSubmit = _container->isOptionChecked(OpenVrThreadedSubmit);
+    qDebug() << "OpenVR Threaded submit enabled:  " << _threadedSubmit;
+
     _openVrDisplayActive = true;
     _container->setIsOptionChecked(StandingHMDSensorMode, true);
 
@@ -434,16 +434,16 @@ bool OpenVrDisplayPlugin::internalActivate() {
         #endif
     }
 
-#if OPENVR_THREADED_SUBMIT
-    _submitThread = std::make_shared<OpenVrSubmitThread>(*this);
-    if (!_submitCanvas) {
-        withMainThreadContext([&] {
-            _submitCanvas = std::make_shared<gl::OffscreenContext>();
-            _submitCanvas->create();
-            _submitCanvas->doneCurrent();
-        });
+    if (_threadedSubmit) {
+        _submitThread = std::make_shared<OpenVrSubmitThread>(*this);
+        if (!_submitCanvas) {
+            withMainThreadContext([&] {
+                _submitCanvas = std::make_shared<gl::OffscreenContext>();
+                _submitCanvas->create();
+                _submitCanvas->doneCurrent();
+            });
+        }
     }
-#endif
 
     return Parent::internalActivate();
 }
@@ -473,27 +473,27 @@ void OpenVrDisplayPlugin::customizeContext() {
 
     Parent::customizeContext();
 
-#if OPENVR_THREADED_SUBMIT
-    _compositeInfos[0].texture = _compositeFramebuffer->getRenderBuffer(0);
-    for (size_t i = 0; i < COMPOSITING_BUFFER_SIZE; ++i) {
-        if (0 != i) {
-            _compositeInfos[i].texture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, _renderTargetSize.x, _renderTargetSize.y, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT)));
+    if (_threadedSubmit) {
+        _compositeInfos[0].texture = _compositeFramebuffer->getRenderBuffer(0);
+        for (size_t i = 0; i < COMPOSITING_BUFFER_SIZE; ++i) {
+            if (0 != i) {
+                _compositeInfos[i].texture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, _renderTargetSize.x, _renderTargetSize.y, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT)));
+            }
+            _compositeInfos[i].textureID = getGLBackend()->getTextureID(_compositeInfos[i].texture, false);
         }
-        _compositeInfos[i].textureID = getGLBackend()->getTextureID(_compositeInfos[i].texture, false);
+        _submitThread->_canvas = _submitCanvas;
+        _submitThread->start(QThread::HighPriority);
     }
-    _submitThread->_canvas = _submitCanvas;
-    _submitThread->start(QThread::HighPriority);
-#endif
 }
 
 void OpenVrDisplayPlugin::uncustomizeContext() {
     Parent::uncustomizeContext();
 
-#if OPENVR_THREADED_SUBMIT
-    _submitThread->_quit = true;
-    _submitThread->wait();
-    _submitThread.reset();
-#endif
+    if (_threadedSubmit) {
+        _submitThread->_quit = true;
+        _submitThread->wait();
+        _submitThread.reset();
+    }
 }
 
 void OpenVrDisplayPlugin::resetSensors() {
@@ -582,76 +582,77 @@ bool OpenVrDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
 }
 
 void OpenVrDisplayPlugin::compositeLayers() {
-#if OPENVR_THREADED_SUBMIT
-    ++_renderingIndex;
-    _renderingIndex %= COMPOSITING_BUFFER_SIZE;
+    if (_threadedSubmit) {
+        ++_renderingIndex;
+        _renderingIndex %= COMPOSITING_BUFFER_SIZE;
 
-    auto& newComposite = _compositeInfos[_renderingIndex];
-    newComposite.pose = _currentPresentFrameInfo.presentPose;
-    _compositeFramebuffer->setRenderBuffer(0, newComposite.texture);
-#endif
+        auto& newComposite = _compositeInfos[_renderingIndex];
+        newComposite.pose = _currentPresentFrameInfo.presentPose;
+        _compositeFramebuffer->setRenderBuffer(0, newComposite.texture);
+    }
 
     Parent::compositeLayers();
 
-#if OPENVR_THREADED_SUBMIT
-    newComposite.fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-    // https://www.opengl.org/registry/specs/ARB/sync.txt:
-    // > The simple flushing behavior defined by
-    // > SYNC_FLUSH_COMMANDS_BIT will not help when waiting for a fence
-    // > command issued in another context's command stream to complete.
-    // > Applications which block on a fence sync object must take
-    // > additional steps to assure that the context from which the
-    // > corresponding fence command was issued has flushed that command
-    // > to the graphics pipeline.
-    glFlush();
+    if (_threadedSubmit) {
+        auto& newComposite = _compositeInfos[_renderingIndex];
+        newComposite.fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+        // https://www.opengl.org/registry/specs/ARB/sync.txt:
+        // > The simple flushing behavior defined by
+        // > SYNC_FLUSH_COMMANDS_BIT will not help when waiting for a fence
+        // > command issued in another context's command stream to complete.
+        // > Applications which block on a fence sync object must take
+        // > additional steps to assure that the context from which the
+        // > corresponding fence command was issued has flushed that command
+        // > to the graphics pipeline.
+        glFlush();
 
-    if (!newComposite.textureID) {
-        newComposite.textureID = getGLBackend()->getTextureID(newComposite.texture, false);
+        if (!newComposite.textureID) {
+            newComposite.textureID = getGLBackend()->getTextureID(newComposite.texture, false);
+        }
+        withPresentThreadLock([&] {
+            _submitThread->update(newComposite);
+        });
     }
-    withPresentThreadLock([&] {
-        _submitThread->update(newComposite);
-    });
-#endif
 }
 
 void OpenVrDisplayPlugin::hmdPresent() {
     PROFILE_RANGE_EX(__FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
 
-#if OPENVR_THREADED_SUBMIT
-    _submitThread->waitForPresent();
-#else
-    GLuint glTexId = getGLBackend()->getTextureID(_compositeFramebuffer->getRenderBuffer(0), false);
-    vr::Texture_t vrTexture{ (void*)glTexId, vr::API_OpenGL, vr::ColorSpace_Auto };
-    vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
-    vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);
-    vr::VRCompositor()->PostPresentHandoff();
-    _presentRate.increment();
-#endif
+    if (_threadedSubmit) {
+        _submitThread->waitForPresent();
+    } else {
+        GLuint glTexId = getGLBackend()->getTextureID(_compositeFramebuffer->getRenderBuffer(0), false);
+        vr::Texture_t vrTexture { (void*)glTexId, vr::API_OpenGL, vr::ColorSpace_Auto };
+        vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
+        vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);
+        vr::VRCompositor()->PostPresentHandoff();
+        _presentRate.increment();
+    }
 }
 
 void OpenVrDisplayPlugin::postPreview() {
     PROFILE_RANGE_EX(__FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
     PoseData nextRender, nextSim;
     nextRender.frameIndex = presentCount();
-#if !OPENVR_THREADED_SUBMIT
-    vr::VRCompositor()->WaitGetPoses(nextRender.vrPoses, vr::k_unMaxTrackedDeviceCount, nextSim.vrPoses, vr::k_unMaxTrackedDeviceCount);
+    if (_threadedSubmit) {
+        _hmdActivityLevel = _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
+    } else {
+        vr::VRCompositor()->WaitGetPoses(nextRender.vrPoses, vr::k_unMaxTrackedDeviceCount, nextSim.vrPoses, vr::k_unMaxTrackedDeviceCount);
 
-    glm::mat4 resetMat;
-    withPresentThreadLock([&] {
-        resetMat = _sensorResetMat;
-    });
-    nextRender.update(resetMat);
-    nextSim.update(resetMat);
-    withPresentThreadLock([&] {
-        _nextSimPoseData = nextSim;
-    });
-    _nextRenderPoseData = nextRender;
+        glm::mat4 resetMat;
+        withPresentThreadLock([&] {
+            resetMat = _sensorResetMat;
+        });
+        nextRender.update(resetMat);
+        nextSim.update(resetMat);
+        withPresentThreadLock([&] {
+            _nextSimPoseData = nextSim;
+        });
+        _nextRenderPoseData = nextRender;
 
-    // FIXME - this looks wrong!
-    _hmdActivityLevel = vr::k_EDeviceActivityLevel_UserInteraction; // _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
-#else
-    _hmdActivityLevel = _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
-#endif
+        // FIXME - this looks wrong!
+        _hmdActivityLevel = vr::k_EDeviceActivityLevel_UserInteraction; // _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
+    }
 }
 
 bool OpenVrDisplayPlugin::isHmdMounted() const {
@@ -684,4 +685,8 @@ void OpenVrDisplayPlugin::unsuppressKeyboard() {
 
 bool OpenVrDisplayPlugin::isKeyboardVisible() {
     return isOpenVrKeyboardShown(); 
+}
+
+int OpenVrDisplayPlugin::getRequiredThreadCount() const { 
+    return Parent::getRequiredThreadCount() + (_threadedSubmit ? 1 : 0);
 }

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -625,6 +625,7 @@ void OpenVrDisplayPlugin::hmdPresent() {
     vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
     vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);
     vr::VRCompositor()->PostPresentHandoff();
+    _presentRate.increment();
 #endif
 }
 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -643,9 +643,10 @@ void OpenVrDisplayPlugin::postPreview() {
     PROFILE_RANGE_EX(__FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
     PoseData nextRender, nextSim;
     nextRender.frameIndex = presentCount();
-    if (_threadedSubmit) {
-        _hmdActivityLevel = _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
-    } else {
+
+    _hmdActivityLevel = _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
+
+    if (!_threadedSubmit) {
         vr::VRCompositor()->WaitGetPoses(nextRender.vrPoses, vr::k_unMaxTrackedDeviceCount, nextSim.vrPoses, vr::k_unMaxTrackedDeviceCount);
 
         glm::mat4 resetMat;
@@ -659,8 +660,6 @@ void OpenVrDisplayPlugin::postPreview() {
         });
         _nextRenderPoseData = nextRender;
 
-        // FIXME - this looks wrong!
-        _hmdActivityLevel = vr::k_EDeviceActivityLevel_UserInteraction; // _system->GetTrackedDeviceActivityLevel(vr::k_unTrackedDeviceIndex_Hmd);
     }
 }
 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -58,8 +58,10 @@ public:
     void unsuppressKeyboard() override;
     bool isKeyboardVisible() override;
 
+#if OPENVR_THREADED_SUBMIT
     // Needs an additional thread for VR submission
     int getRequiredThreadCount() const override { return Parent::getRequiredThreadCount() + 1; }
+#endif
 
 protected:
     bool internalActivate() override;

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -15,7 +15,7 @@
 
 const float TARGET_RATE_OpenVr = 90.0f;  // FIXME: get from sdk tracked device property? This number is vive-only.
 
-#define OPENVR_THREADED_SUBMIT 1
+#define OPENVR_THREADED_SUBMIT 0
 
 #if OPENVR_THREADED_SUBMIT
 namespace gl {


### PR DESCRIPTION
## Testing

On a machine with an nVidia GPU and the latest drivers, install the SteamVR beta, and run the application with the OpenVR display plugin.  The display should be very smooth.  Additionally, the log should output a line `OpenVR Threaded submit enabled:   false`

On master, with the SteamVR beta, the scene will be full of judder and virtually impossible to deal with.  

If you disable asynchronous reprojection in the SteamVR beta performance settings and restart the application, you should see a log line of `OpenVR Threaded submit enabled:   true` in this PR and the behavior should be similar to master while running the current non-Beta SteamVR version.  

AMD based systems should show `OpenVR Threaded submit enabled:   true` regardless of the SteamVR version used and should behave the same as the current dev build. 