### PR TITLE
Fix race condition in BatchLoader

### DIFF
--- a/libraries/script-engine/src/BatchLoader.cpp
+++ b/libraries/script-engine/src/BatchLoader.cpp
@@ -50,18 +50,18 @@ void BatchLoader::start() {
 
         qCDebug(scriptengine) << "Loading script at " << url;
 
-		auto scriptCache = DependencyManager::get<ScriptCache>();
+        auto scriptCache = DependencyManager::get<ScriptCache>();
 
-		// Use a proxy callback to handle the call and emit the signal in a thread-safe way.
-		// If BatchLoader is deleted before the callback is called, the subsequent "emit" call will not do
-		// anything.
-		ScriptCacheSignalProxy* proxy = new ScriptCacheSignalProxy(scriptCache.data());
-		scriptCache->getScriptContents(url.toString(), [proxy](const QString& url, const QString& contents, bool isURL, bool success) {
-			proxy->receivedContent(url, contents, isURL, success);
-			proxy->deleteLater();
-		}, false);
+        // Use a proxy callback to handle the call and emit the signal in a thread-safe way.
+        // If BatchLoader is deleted before the callback is called, the subsequent "emit" call will not do
+        // anything.
+        ScriptCacheSignalProxy* proxy = new ScriptCacheSignalProxy(scriptCache.data());
+        scriptCache->getScriptContents(url.toString(), [proxy](const QString& url, const QString& contents, bool isURL, bool success) {
+            proxy->receivedContent(url, contents, isURL, success);
+            proxy->deleteLater();
+        }, false);
 
-		connect(proxy, &ScriptCacheSignalProxy::contentAvailable, this, [this](const QString& url, const QString& contents, bool isURL, bool success) {
+        connect(proxy, &ScriptCacheSignalProxy::contentAvailable, this, [this](const QString& url, const QString& contents, bool isURL, bool success) {
             if (isURL && success) {
                 _data.insert(url, contents);
                 qCDebug(scriptengine) << "Loaded: " << url;
@@ -74,10 +74,10 @@ void BatchLoader::start() {
                 _finished = true;
                 emit finished(_data);
             }
-		});
+        });
     }
 }
 
 void ScriptCacheSignalProxy::receivedContent(const QString& url, const QString& contents, bool isURL, bool success) {
-	emit contentAvailable(url, contents, isURL, success);
+    emit contentAvailable(url, contents, isURL, success);
 }

--- a/libraries/script-engine/src/BatchLoader.cpp
+++ b/libraries/script-engine/src/BatchLoader.cpp
@@ -44,33 +44,40 @@ void BatchLoader::start() {
         return;
     }
 
+
     for (const auto& rawURL : _urls) {
         QUrl url = expandScriptUrl(normalizeScriptURL(rawURL));
 
         qCDebug(scriptengine) << "Loading script at " << url;
 
-        QPointer<BatchLoader> self = this;
-        DependencyManager::get<ScriptCache>()->getScriptContents(url.toString(), [this, self](const QString& url, const QString& contents, bool isURL, bool success) {
-            if (!self) {
-                return;
-            }
+		auto scriptCache = DependencyManager::get<ScriptCache>();
 
-            // Because the ScriptCache may call this callback from differents threads,
-            // we need to make sure this is thread-safe.
-            std::lock_guard<std::mutex> lock(_dataLock);
+		// Use a proxy callback to handle the call and emit the signal in a thread-safe way.
+		// If BatchLoader is deleted before the callback is called, the subsequent "emit" call will not do
+		// anything.
+		ScriptCacheSignalProxy* proxy = new ScriptCacheSignalProxy(scriptCache.data());
+		scriptCache->getScriptContents(url.toString(), [proxy](const QString& url, const QString& contents, bool isURL, bool success) {
+			proxy->receivedContent(url, contents, isURL, success);
+			proxy->deleteLater();
+		}, false);
 
+		connect(proxy, &ScriptCacheSignalProxy::contentAvailable, this, [this](const QString& url, const QString& contents, bool isURL, bool success) {
             if (isURL && success) {
                 _data.insert(url, contents);
                 qCDebug(scriptengine) << "Loaded: " << url;
             } else {
                 _data.insert(url, QString());
-                qCDebug(scriptengine) << "Could not load" << url;
+                qCDebug(scriptengine) << "Could not load: " << url;
             }
 
             if (!_finished && _urls.size() == _data.size()) {
                 _finished = true;
                 emit finished(_data);
             }
-        }, false);
+		});
     }
+}
+
+void ScriptCacheSignalProxy::receivedContent(const QString& url, const QString& contents, bool isURL, bool success) {
+	emit contentAvailable(url, contents, isURL, success);
 }

--- a/libraries/script-engine/src/BatchLoader.h
+++ b/libraries/script-engine/src/BatchLoader.h
@@ -21,6 +21,16 @@
 
 #include <mutex>
 
+class ScriptCacheSignalProxy : public QObject {
+	Q_OBJECT
+public:
+	ScriptCacheSignalProxy(QObject* parent) : QObject(parent) { }
+   void receivedContent(const QString& url, const QString& contents, bool isURL, bool success);
+
+signals:
+   void contentAvailable(const QString& url, const QString& contents, bool isURL, bool success);
+};
+
 class BatchLoader : public QObject {
     Q_OBJECT
 public:
@@ -39,7 +49,6 @@ private:
     bool _finished;
     QSet<QUrl> _urls;
     QMap<QUrl, QString> _data;
-    std::mutex _dataLock;
 };
 
 #endif // hifi_BatchLoader_h

--- a/libraries/script-engine/src/BatchLoader.h
+++ b/libraries/script-engine/src/BatchLoader.h
@@ -22,19 +22,19 @@
 #include <mutex>
 
 class ScriptCacheSignalProxy : public QObject {
-	Q_OBJECT
+    Q_OBJECT
 public:
-	ScriptCacheSignalProxy(QObject* parent) : QObject(parent) { }
-   void receivedContent(const QString& url, const QString& contents, bool isURL, bool success);
+    ScriptCacheSignalProxy(QObject* parent) : QObject(parent) { }
+    void receivedContent(const QString& url, const QString& contents, bool isURL, bool success);
 
 signals:
-   void contentAvailable(const QString& url, const QString& contents, bool isURL, bool success);
+    void contentAvailable(const QString& url, const QString& contents, bool isURL, bool success);
 };
 
 class BatchLoader : public QObject {
     Q_OBJECT
 public:
-    BatchLoader(const QList<QUrl>& urls) ;
+    BatchLoader(const QList<QUrl>& urls);
 
     void start();
     bool isFinished() const { return _finished; };


### PR DESCRIPTION
Previously a thread could be inside BatchLoader's callback while it gets deleted. This attempts to fix that particular issue.