### PR TITLE
Fix for crash in openvr on startup

### DIFF
--- a/cmake/macros/SetupHifiPlugin.cmake
+++ b/cmake/macros/SetupHifiPlugin.cmake
@@ -17,6 +17,12 @@ macro(SETUP_HIFI_PLUGIN)
         set(PLUGIN_PATH "plugins")
     endif()
 
+    if (WIN32)
+        # produce PDB files for plugins as well
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
+    endif()
+
     if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_GENERATOR STREQUAL "Unix Makefiles")
         set(PLUGIN_FULL_PATH "${CMAKE_BINARY_DIR}/interface/${PLUGIN_PATH}/")
     else()

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -210,6 +210,11 @@ void ViveControllerManager::renderHand(const controller::Pose& pose, gpu::Batch&
 
 
 void ViveControllerManager::pluginUpdate(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) {
+
+    if (!_system) {
+        return;
+    }
+
     auto userInputMapper = DependencyManager::get<controller::UserInputMapper>();
     handleOpenVrEvents();
     if (openVrQuitRequested()) {


### PR DESCRIPTION
pluginActivate can fail and return false, when steamvr is in a "Not Ready" state. In practice this can occur on a botched steamvr install, or when the vr compositor process is unable to start.

When pluginActivate returns false, there's some sort of race condition where pluginUpdate will still be called. But it's only reproducible in release builds, without the debugger attached.

This commit prevents pluginUpdate from crashing by making sure that the openvr _system ptr is valid first.

Additionally, this PR will generate PDB files for release plugins.