### PR TITLE
clean audio mixer

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -753,7 +753,6 @@ void AudioMixer::broadcastMixes() {
                 // ratio of frame spent sleeping / total frame time
                 ((CURRENT_FRAME_RATIO * timeToSleep.count()) / (float) AudioConstants::NETWORK_FRAME_USECS);
 
-            float lastCutoffRatio = _performanceThrottlingRatio;
             bool hasRatioChanged = false;
 
             if (framesSinceCutoffEvent >= TRAILING_AVERAGE_FRAMES) {

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -52,6 +52,7 @@ private slots:
     void removeHRTFsForFinishedInjector(const QUuid& streamID);
 
 private:
+    AudioMixerClientData* getOrCreateClientData(Node* node);
     void domainSettingsRequestComplete();
     
     /// adds one stream to the mix for a listening node

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -355,7 +355,10 @@ QJsonObject AudioMixerClientData::getAudioStreamStats() {
 }
 
 void AudioMixerClientData::handleMismatchAudioFormat(SharedNodePointer node, const QString& currentCodec, const QString& recievedCodec) {
-    qDebug() << __FUNCTION__ << "sendingNode:" << *node << "currentCodec:" << currentCodec << "recievedCodec:" << recievedCodec;
+    qDebug() << __FUNCTION__ <<
+        "sendingNode:" << *node <<
+        "currentCodec:" << currentCodec <<
+        "receivedCodec:" << recievedCodec;
     sendSelectAudioFormat(node, currentCodec);
 }
 

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -344,7 +344,6 @@ bool OffscreenQmlSurface::allowNewFrame(uint8_t fps) {
 OffscreenQmlSurface::OffscreenQmlSurface() {
 }
 
-static const uint64_t MAX_SHUTDOWN_WAIT_SECS = 2;
 OffscreenQmlSurface::~OffscreenQmlSurface() {
     QObject::disconnect(&_updateTimer);
     QObject::disconnect(qApp);


### PR DESCRIPTION
- groups sections of the audio mixer broadcast (mixing) code
- allows the audio mixer to recover from large pauses by not counting frames from start (see 3e16dab)