### PR TITLE
Disable console splash screen

### DIFF
--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -812,7 +812,8 @@ for (var key in trayIcons) {
 const notificationIcon = path.join(__dirname, '../resources/console-notification.png');
 
 function onContentLoaded() {
-    maybeShowSplash();
+    // Disable splash window for now.
+    // maybeShowSplash();
 
     if (buildInfo.releaseType == 'PRODUCTION') {
         var currentVersion = null;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/1869/Don-t-show-the-Sandbox-dialog-on-install-and-launch

Test plan:
- Make sure splash screen does not appear on launch of the Sandbox