### PR TITLE
Fix for crash in QtWebEngineCore when rapidly switching domains

### DIFF
--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -27,6 +27,7 @@ Item {
 
     WebEngineView {
         id: root
+        objectName: "webEngineView"
         x: 0
         y: 0
         width: parent.width

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -326,7 +326,17 @@ void RenderableWebEntityItem::handlePointerEvent(const PointerEvent& event) {
 void RenderableWebEntityItem::destroyWebSurface() {
     if (_webSurface) {
         --_currentWebCount;
+
+        QQuickItem* rootItem = _webSurface->getRootItem();
+        if (rootItem) {
+            QObject* obj = rootItem->findChild<QObject*>("webEngineView");
+            if (obj) {
+                QMetaObject::invokeMethod(obj, "stop");
+            }
+        }
+
         _webSurface->pause();
+
         _webSurface->disconnect(_connection);
         QObject::disconnect(_mousePressConnection);
         _mousePressConnection = QMetaObject::Connection();


### PR DESCRIPTION
Call stop on the QWebEngineView before destroying OffscreenQMLSurface.