### PR TITLE
QuickFix for weird avatar when switch Vive -> Desktop mode

### DIFF
--- a/interface/resources/controllers/vive.json
+++ b/interface/resources/controllers/vive.json
@@ -34,7 +34,7 @@
         { "from": "Vive.RSCenter", "to": "Standard.RightPrimaryThumb" },
         { "from": "Vive.RightApplicationMenu", "to": "Standard.RightSecondaryThumb" },
 
-        { "from": "Vive.LeftHand", "to": "Standard.LeftHand" },
-        { "from": "Vive.RightHand", "to": "Standard.RightHand" }
+        { "from": "Vive.LeftHand", "to": "Standard.LeftHand", "when": [ "Application.InHMD" ]  },
+        { "from": "Vive.RightHand", "to": "Standard.RightHand", "when": [ "Application.InHMD" ]  }
     ]
 }


### PR DESCRIPTION
QuickFix for weird avatar Switch Vive -> Desktop mode. There is probably a more elegant solution, as this still lets you walk with the Vive controllers, which possibly shouldn't be possible by design (default).

## test plan

- For this test a HTC Vive is required

1. Use OpenVR as display mode
2. Switch back to Desktop mode
3. Notice that the avatar doesn't stand in a weird pose, but normal as it would in Desktop mode.
4. Make sure that trigger/grab -able object do not make the Vive controllers vibrate while in Desktop mode