### PR TITLE
Fix Oculus hand controllers to only work in HMD

### DIFF
--- a/interface/resources/controllers/oculus_touch.json
+++ b/interface/resources/controllers/oculus_touch.json
@@ -23,7 +23,7 @@
         { "from": "OculusTouch.LT", "to": "Standard.LT" },
         { "from": "OculusTouch.LS", "to": "Standard.LS" },
         { "from": "OculusTouch.LeftGrip", "filters": { "type": "deadZone", "min": 0.5 }, "to": "Standard.LeftGrip" },
-        { "from": "OculusTouch.LeftHand", "to": "Standard.LeftHand" },
+        { "from": "OculusTouch.LeftHand", "to": "Standard.LeftHand", "when": [ "Application.InHMD" ] },
 
         { "from": "OculusTouch.RY", "to": "Standard.RY",
             "filters": [
@@ -39,7 +39,7 @@
         { "from": "OculusTouch.RT", "to": "Standard.RT" },
         { "from": "OculusTouch.RS", "to": "Standard.RS" },
         { "from": "OculusTouch.RightGrip", "filters": { "type": "deadZone", "min": 0.5 }, "to": "Standard.RightGrip" },
-        { "from": "OculusTouch.RightHand", "to": "Standard.RightHand" },
+        { "from": "OculusTouch.RightHand", "to": "Standard.RightHand", "when": [ "Application.InHMD" ] },
 
         { "from": "OculusTouch.LeftApplicationMenu", "to": "Standard.Back" },
         { "from": "OculusTouch.RightApplicationMenu", "to": "Standard.Start" },
@@ -58,4 +58,3 @@
         { "from": "OculusTouch.RightIndexPoint", "to": "Standard.RightIndexPoint" }
     ]
 }
-


### PR DESCRIPTION
QuickFix for weird avatar Switch `Oculus Rift` -> Desktop mode.   This is untested by me as I do not own the Oculus touch controllers.
## test plan
- For this test the Oculus Rift CV1  and Oculus Touch are required
1. Use `Oculus Rift` as display mode
2. Switch back to Desktop mode
3. Notice that the avatar doesn't stand in a weird pose, but normal as it would in Desktop mode.
