### PR TITLE
Avoid messaging for render targets generating mip maps

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -322,7 +322,9 @@ void GL45Texture::withPreservedTexture(std::function<void()> f) const {
 }
 
 void GL45Texture::generateMips() const {
-    qCDebug(gpugl45logging) << "Generating mipmaps for " << _source.c_str();
+    if (_transferrable) {
+        qCDebug(gpugl45logging) << "Generating mipmaps for " << _source.c_str();
+    }
     glGenerateTextureMipmap(_id);
     (void)CHECK_GL_ERROR();
 }


### PR DESCRIPTION
Simply avoid messaging the console when a texture is generating MipMap with the GPU command and it is a render targets.
potentially Render targets actually generate their mips every frame and that fills the log for something that useful.

**To test:**
THis PR should have no performance impact and no feature impact.
It s only affecting the way we log that particular message "Generating mipmaps for..."
Note that this is only on platform supporting GL45 (nvidia or amd, not intel or Mac)

Enable Ambient Occlusion (turn the developper menu on and graphics... then enable the Ambient OCclusion)

Show the log console (Menu Developer/Log) 
With Master, you should see the log filling with the message  "[hifi.gpu.gl45] Generating mipmaps for  halfLinearDepth::color::0"
This message stops logging  if you disable Ambient Occlusion.

With this PR this should NOT happen at all when AO is on.
