### PR TITLE
Enable forced min spec failure for testing

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -41,7 +41,11 @@
 extern "C" {
     typedef int(__stdcall * CHECKMINSPECPROC) ();
 }
+
+static const QString DEBUG_FAIL_MIN_SPEC_FLAG("HIFI_FAIL_MIN_SPEC");
 #endif
+
+
 
 int main(int argc, const char* argv[]) {
 #if HAS_BUGSPLAT
@@ -161,7 +165,8 @@ int main(int argc, const char* argv[]) {
 
 #ifdef Q_OS_WIN
     // If we're running in steam mode, we need to do an explicit check to ensure we're up to the required min spec
-    if (SteamClient::isRunning()) {
+    if (SteamClient::isRunning() || 
+        QProcessEnvironment::systemEnvironment().contains(DEBUG_FAIL_MIN_SPEC_FLAG)) {
         QString appPath;
         {
             char filename[MAX_PATH];

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -392,8 +392,14 @@ void showMinSpecWarning() {
     miniApp.exec();
 }
 
+static const QString DEBUG_FAIL_MIN_SPEC_FLAG("HIFI_FAIL_MIN_SPEC");
 
 bool checkMinSpecImpl() {
+    if (QProcessEnvironment::systemEnvironment().contains(DEBUG_FAIL_MIN_SPEC_FLAG)) {
+        showMinSpecWarning();
+        return false;
+    }
+
     // If OpenVR isn't supported, we have no min spec, so pass
     if (!openVrSupported()) {
         return true;


### PR DESCRIPTION
## Testing

On a system with SteamVR running, set the environment variable `HIFI_FAIL_MIN_SPEC` to any value and then run interface.  You should see the failure message in the HMD.
