### PR TITLE
Enable sparse textures and incremental transfer on i5

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -388,7 +388,7 @@ Menu::Menu() {
 
 #ifdef Q_OS_WIN
     #define MIN_CORES_FOR_INCREMENTAL_TEXTURES 5
-    bool recommendedIncrementalTransfers = (QThread::idealThreadCount() >= MIN_CORES_FOR_INCREMENTAL_TEXTURES);
+    bool recommendedIncrementalTransfers = true;
     bool recommendedSparseTextures = recommendedIncrementalTransfers;
 
     qDebug() << "[TEXTURE TRANSFER SUPPORT]"

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -111,7 +111,7 @@ float GLTexture::getMemoryPressure() {
         }
 #else 
         // Hardcode texture limit for sparse textures at 1 GB for now
-        availableTextureMemory = GPU_MEMORY_RESERVE_BYTES;
+        availableTextureMemory = TEXTURE_MEMORY_MIN_BYTES;
 #endif
     }
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -366,10 +366,14 @@ bool GL45Texture::continueTransfer() {
         size_t maxFace = GL_TEXTURE_CUBE_MAP == _target ? CUBE_NUM_FACES : 1;
         for (uint8_t face = 0; face < maxFace; ++face) {
             for (uint16_t mipLevel = _minMip; mipLevel <= _maxMip; ++mipLevel) {
+                auto size = _gpuObject.evalMipDimensions(mipLevel);
+                if (_sparseInfo.sparse && mipLevel <= _sparseInfo.maxSparseLevel) {
+                    glTexturePageCommitmentEXT(_id, mipLevel, 0, 0, face, size.x, size.y, 1, GL_TRUE);
+                    _allocatedPages += _sparseInfo.getPageCount(size);
+                }
                 if (_gpuObject.isStoredMipFaceAvailable(mipLevel, face)) {
                     auto mip = _gpuObject.accessStoredMipFace(mipLevel, face);
                     GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat(), mip->getFormat());
-                    auto size = _gpuObject.evalMipDimensions(mipLevel);
                     if (GL_TEXTURE_2D == _target) {
                         glTextureSubImage2D(_id, mipLevel, 0, 0, size.x, size.y, texelFormat.format, texelFormat.type, mip->readData());
                     } else if (GL_TEXTURE_CUBE_MAP == _target) {


### PR DESCRIPTION
## Testing

On an i5 system, clear out the `Interface.ini` file and then start this build.  Both the 'Enable Dynamic Texture Management' and 'Enable Incremental Texture Transfer' should be checked. 

Following the same procedure on the current production build will see those items unchecked.

_Bear in mind_, any value set in the INI file will supersede the defaults. 
