### PR TITLE
Send KillAvatar message to AudioMixer

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -424,7 +424,7 @@ void Agent::setIsListeningToAudioStream(bool isListeningToAudioStream) {
         },
             [&](const SharedNodePointer& node) {
             qDebug() << "sending KillAvatar message to Audio Mixers";
-            auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID);
+            auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID, true);
             packet->write(getSessionUUID().toRfc4122());
             nodeList->sendPacket(std::move(packet), *node);
         });
@@ -475,7 +475,7 @@ void Agent::setIsAvatar(bool isAvatar) {
             },
                 [&](const SharedNodePointer& node) {
                 qDebug() << "sending KillAvatar message to Avatar and Audio Mixers";
-                auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID);
+                auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID, true);
                 packet->write(getSessionUUID().toRfc4122());
                 nodeList->sendPacket(std::move(packet), *node);
             });

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -88,6 +88,7 @@ void Agent::playAvatarSound(SharedSoundPointer sound) {
         QMetaObject::invokeMethod(this, "playAvatarSound", Q_ARG(SharedSoundPointer, sound));
         return;
     } else {
+        _numAvatarSoundSentBytes = 0;
         setAvatarSound(sound);
     }
 }

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -424,9 +424,9 @@ void Agent::setIsListeningToAudioStream(bool isListeningToAudioStream) {
         },
             [&](const SharedNodePointer& node) {
             qDebug() << "sending KillAvatar message to Audio Mixers";
-            auto packetList = NLPacketList::create(PacketType::KillAvatar, QByteArray(), true, true);
-            packetList->write(getSessionUUID().toRfc4122());
-            nodeList->sendPacketList(std::move(packetList), *node);
+            auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID);
+            packet->write(getSessionUUID().toRfc4122());
+            nodeList->sendPacket(std::move(packet), *node);
         });
 
     }
@@ -475,9 +475,9 @@ void Agent::setIsAvatar(bool isAvatar) {
             },
                 [&](const SharedNodePointer& node) {
                 qDebug() << "sending KillAvatar message to Avatar and Audio Mixers";
-                auto packetList = NLPacketList::create(PacketType::KillAvatar, QByteArray(), true, true);
-                packetList->write(getSessionUUID().toRfc4122());
-                nodeList->sendPacketList(std::move(packetList), *node);
+                auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID);
+                packet->write(getSessionUUID().toRfc4122());
+                nodeList->sendPacket(std::move(packet), *node);
             });
         }
         emit stopAvatarAudioTimer();

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -439,7 +439,8 @@ void Agent::setIsAvatar(bool isAvatar) {
             packetList->write(getSessionUUID().toRfc4122());
             nodeList->eachMatchingNode(
                 [&](const SharedNodePointer& node)->bool {
-                return node->getType() == NodeType::AvatarMixer && node->getActiveSocket();
+                return (node->getType() == NodeType::AvatarMixer || node->getType() == NodeType::AudioMixer)
+                        && node->getActiveSocket();
             },
                 [&](const SharedNodePointer& node) {
                 nodeList->sendPacketList(std::move(packetList), *node);

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -404,8 +404,38 @@ QUuid Agent::getSessionUUID() const {
     return DependencyManager::get<NodeList>()->getSessionUUID();
 }
 
+void Agent::setIsListeningToAudioStream(bool isListeningToAudioStream) { 
+    // this must happen on Agent's main thread
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setIsListeningToAudioStream", Q_ARG(bool, isListeningToAudioStream));
+        return;
+    }
+    if (_isListeningToAudioStream) {
+        // have to tell just the audio mixer to KillAvatar. 
+
+        auto nodeList = DependencyManager::get<NodeList>();
+        nodeList->eachMatchingNode(
+            [&](const SharedNodePointer& node)->bool {
+            return (node->getType() == NodeType::AudioMixer)
+            && node->getActiveSocket();
+        },
+            [&](const SharedNodePointer& node) {
+            qDebug() << "sending KillAvatar message to Avatar and Audio Mixers";
+            auto packetList = NLPacketList::create(PacketType::KillAvatar, QByteArray(), true, true);
+            packetList->write(getSessionUUID().toRfc4122());
+            nodeList->sendPacketList(std::move(packetList), *node);
+        });
+
+    }
+    _isListeningToAudioStream = isListeningToAudioStream; 
+}
 
 void Agent::setIsAvatar(bool isAvatar) {
+    // this must happen on Agent's main thread
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setIsAvatar", Q_ARG(bool, isAvatar));
+        return;
+    }
     _isAvatar = isAvatar;
 
     if (_isAvatar && !_avatarIdentityTimer) {
@@ -435,14 +465,15 @@ void Agent::setIsAvatar(bool isAvatar) {
             // when we stop sending identity, but then get woken up again by the mixer itself, which sends
             // identity packets to everyone. Here we explicitly tell the mixer to kill the entry for us.
             auto nodeList = DependencyManager::get<NodeList>();
-            auto packetList = NLPacketList::create(PacketType::KillAvatar, QByteArray(), true, true);
-            packetList->write(getSessionUUID().toRfc4122());
             nodeList->eachMatchingNode(
                 [&](const SharedNodePointer& node)->bool {
                 return (node->getType() == NodeType::AvatarMixer || node->getType() == NodeType::AudioMixer)
                         && node->getActiveSocket();
             },
                 [&](const SharedNodePointer& node) {
+                qDebug() << "sending KillAvatar message to Avatar and Audio Mixers";
+                auto packetList = NLPacketList::create(PacketType::KillAvatar, QByteArray(), true, true);
+                packetList->write(getSessionUUID().toRfc4122());
                 nodeList->sendPacketList(std::move(packetList), *node);
             });
         }

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -88,7 +88,10 @@ void Agent::playAvatarSound(SharedSoundPointer sound) {
         QMetaObject::invokeMethod(this, "playAvatarSound", Q_ARG(SharedSoundPointer, sound));
         return;
     } else {
-        _numAvatarSoundSentBytes = 0;
+        // TODO: seems to add occasional artifact in tests.  I believe it is 
+        // correct to do this, but need to figure out for sure, so commenting this
+        // out until I verify.  
+        // _numAvatarSoundSentBytes = 0;
         setAvatarSound(sound);
     }
 }

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -420,11 +420,10 @@ void Agent::setIsListeningToAudioStream(bool isListeningToAudioStream) {
         auto nodeList = DependencyManager::get<NodeList>();
         nodeList->eachMatchingNode(
             [&](const SharedNodePointer& node)->bool {
-            return (node->getType() == NodeType::AudioMixer)
-            && node->getActiveSocket();
+            return (node->getType() == NodeType::AudioMixer) && node->getActiveSocket();
         },
             [&](const SharedNodePointer& node) {
-            qDebug() << "sending KillAvatar message to Avatar and Audio Mixers";
+            qDebug() << "sending KillAvatar message to Audio Mixers";
             auto packetList = NLPacketList::create(PacketType::KillAvatar, QByteArray(), true, true);
             packetList->write(getSessionUUID().toRfc4122());
             nodeList->sendPacketList(std::move(packetList), *node);

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -49,7 +49,7 @@ public:
     bool isPlayingAvatarSound() const { return _avatarSound != NULL; }
 
     bool isListeningToAudioStream() const { return _isListeningToAudioStream; }
-    void setIsListeningToAudioStream(bool isListeningToAudioStream) { _isListeningToAudioStream = isListeningToAudioStream; }
+    void setIsListeningToAudioStream(bool isListeningToAudioStream);
 
     float getLastReceivedAudioLoudness() const { return _lastReceivedAudioLoudness; }
     QUuid getSessionUUID() const;

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -93,6 +93,7 @@ AudioMixer::AudioMixer(ReceivedMessage& message) :
     packetReceiver.registerListener(PacketType::NegotiateAudioFormat, this, "handleNegotiateAudioFormat");
     packetReceiver.registerListener(PacketType::MuteEnvironment, this, "handleMuteEnvironmentPacket");
     packetReceiver.registerListener(PacketType::NodeIgnoreRequest, this, "handleNodeIgnoreRequestPacket");
+    packetReceiver.registerListener(PacketType::KillAvatar, this, "handleKillAvatarPacket");
 
     connect(nodeList.data(), &NodeList::nodeKilled, this, &AudioMixer::handleNodeKilled);
 }
@@ -597,6 +598,14 @@ void AudioMixer::handleNodeKilled(SharedNodePointer killedNode) {
         }
     });
 }
+
+void AudioMixer::handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {
+    auto clientData = dynamic_cast<AudioMixerClientData*>(sendingNode->getLinkedData());
+    if (clientData) {
+        clientData->removeAgentAvatarAudioStream();
+    }
+}
+
 
 void AudioMixer::handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {
     sendingNode->parseIgnoreRequestMessage(packet);

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -607,7 +607,7 @@ void AudioMixer::handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, 
         nodeList->eachNode([sendingNode](const SharedNodePointer& node){
             auto listenerClientData = dynamic_cast<AudioMixerClientData*>(node->getLinkedData());
             if (listenerClientData) {
-                listenerClientData->removeHRTFForStream(sendingNode->getUUID(), QUuid());
+                listenerClientData->removeHRTFForStream(sendingNode->getUUID());
             }
         });
     }

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -602,16 +602,14 @@ void AudioMixer::handleNodeKilled(SharedNodePointer killedNode) {
 void AudioMixer::handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {
     auto clientData = dynamic_cast<AudioMixerClientData*>(sendingNode->getLinkedData());
     if (clientData) {
-        QUuid streamID = clientData->removeAgentAvatarAudioStream();
-        if (streamID != QUuid()) {
-            auto nodeList = DependencyManager::get<NodeList>();
-            nodeList->eachNode([sendingNode, &streamID](const SharedNodePointer& node){
-                auto listenerClientData = dynamic_cast<AudioMixerClientData*>(node->getLinkedData());
-                if (listenerClientData) {
-                    listenerClientData->removeHRTFForStream(sendingNode->getUUID(), streamID);
-                }
-            });
-        }
+        clientData->removeAgentAvatarAudioStream();
+        auto nodeList = DependencyManager::get<NodeList>();
+        nodeList->eachNode([sendingNode](const SharedNodePointer& node){
+            auto listenerClientData = dynamic_cast<AudioMixerClientData*>(node->getLinkedData());
+            if (listenerClientData) {
+                listenerClientData->removeHRTFForStream(sendingNode->getUUID(), QUuid());
+            }
+        });
     }
 }
 

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -603,6 +603,9 @@ void AudioMixer::handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, 
     auto clientData = dynamic_cast<AudioMixerClientData*>(sendingNode->getLinkedData());
     if (clientData) {
         clientData->removeAgentAvatarAudioStream();
+        // when you don't specify a stream, this removes just the QUuid() 
+        // stream (which is the avatar's mic stream)
+        clientData->removeHRTFForStream(sendingNode->getUUID());
     }
 }
 

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -48,6 +48,7 @@ private slots:
     void handleNegotiateAudioFormat(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void handleNodeKilled(SharedNodePointer killedNode);
     void handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
+    void handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
 
     void removeHRTFsForFinishedInjector(const QUuid& streamID);
 

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -73,20 +73,26 @@ void AudioMixerClientData::removeHRTFForStream(const QUuid& nodeID, const QUuid&
     }
 }
 
-void AudioMixerClientData::removeAgentAvatarAudioStream() {
+QUuid AudioMixerClientData::removeAgentAvatarAudioStream() {
     QWriteLocker writeLocker { &_streamsLock };
+    QUuid streamId;
     auto it = _audioStreams.find(QUuid());
     if (it != _audioStreams.end()) {
+        AvatarAudioStream* stream = dynamic_cast<AvatarAudioStream*>(it->second.get());
+        if (stream) {
+            streamId = stream->getStreamIdentifier();
+        }
         _audioStreams.erase(it);
     }
     writeLocker.unlock();
+
+    return streamId;
 }
 
 int AudioMixerClientData::parseData(ReceivedMessage& message) {
     PacketType packetType = message.getType();
 
     if (packetType == PacketType::AudioStreamStats) {
-
         // skip over header, appendFlag, and num stats packed
         message.seek(sizeof(quint8) + sizeof(quint16));
 

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -73,6 +73,15 @@ void AudioMixerClientData::removeHRTFForStream(const QUuid& nodeID, const QUuid&
     }
 }
 
+void AudioMixerClientData::removeAgentAvatarAudioStream() {
+    QWriteLocker writeLocker { &_streamsLock };
+    auto it = _audioStreams.find(QUuid());
+    if (it != _audioStreams.end()) {
+        _audioStreams.erase(it);
+    }
+    writeLocker.unlock();
+}
+
 int AudioMixerClientData::parseData(ReceivedMessage& message) {
     PacketType packetType = message.getType();
 

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -73,20 +73,13 @@ void AudioMixerClientData::removeHRTFForStream(const QUuid& nodeID, const QUuid&
     }
 }
 
-QUuid AudioMixerClientData::removeAgentAvatarAudioStream() {
+void AudioMixerClientData::removeAgentAvatarAudioStream() {
     QWriteLocker writeLocker { &_streamsLock };
-    QUuid streamId;
     auto it = _audioStreams.find(QUuid());
     if (it != _audioStreams.end()) {
-        AvatarAudioStream* stream = dynamic_cast<AvatarAudioStream*>(it->second.get());
-        if (stream) {
-            streamId = stream->getStreamIdentifier();
-        }
         _audioStreams.erase(it);
     }
     writeLocker.unlock();
-
-    return streamId;
 }
 
 int AudioMixerClientData::parseData(ReceivedMessage& message) {

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -50,7 +50,7 @@ public:
     // removes an AudioHRTF object for a given stream
     void removeHRTFForStream(const QUuid& nodeID, const QUuid& streamID = QUuid());
 
-    void removeAgentAvatarAudioStream();
+    QUuid removeAgentAvatarAudioStream();
 
     int parseData(ReceivedMessage& message) override;
 

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -50,7 +50,7 @@ public:
     // removes an AudioHRTF object for a given stream
     void removeHRTFForStream(const QUuid& nodeID, const QUuid& streamID = QUuid());
 
-    QUuid removeAgentAvatarAudioStream();
+    void removeAgentAvatarAudioStream();
 
     int parseData(ReceivedMessage& message) override;
 

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -50,6 +50,8 @@ public:
     // removes an AudioHRTF object for a given stream
     void removeHRTFForStream(const QUuid& nodeID, const QUuid& streamID = QUuid());
 
+    void removeAgentAvatarAudioStream();
+
     int parseData(ReceivedMessage& message) override;
 
     // attempt to pop a frame from each audio stream, and return the number of streams from this client


### PR DESCRIPTION
Similar to sending it to the `AvatarMixer`.  In this case, it is so it can remove the listening agent avatar audio streams.  Otherwise they stick around forever, and eventually swamp the audio mixer.
