### PR TITLE
Load plugins in alphabetical order.

### DIFF
--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -86,6 +86,7 @@ const LoaderList& getLoadedPlugins() {
         QString pluginPath = QCoreApplication::applicationDirPath() + "/plugins/";
 #endif
         QDir pluginDir(pluginPath);
+        pluginDir.setSorting(QDir::Name);
         pluginDir.setFilter(QDir::Files);
         if (pluginDir.exists()) {
             qInfo() << "Loading runtime plugins from " << pluginPath;


### PR DESCRIPTION
This will make it easier to reproduce bugs that occur during plugin loading/initialization by making the order deterministic.