### PR TITLE
lock around audio-client quit flag to avoid shutdown race

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -85,18 +85,26 @@ public:
     }
 
     void beforeAboutToQuit() {
+        Lock lock(_checkDevicesMutex);
         _quit = true;
     }
 
     void run() override {
-        while (!_quit) {
+        for (;;) {
+            {
+                Lock lock(_checkDevicesMutex);
+                if (_quit) {
+                    break;
+                }
+                _audioClient->checkDevices();
+            }
             QThread::msleep(DEVICE_CHECK_INTERVAL_MSECS);
-            _audioClient->checkDevices();
         }
     }
 
 private:
     AudioClient* _audioClient { nullptr };
+    Mutex _checkDevicesMutex;
     bool _quit { false };
 };
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -90,7 +90,7 @@ public:
     }
 
     void run() override {
-        for (;;) {
+        while (true) {
             {
                 Lock lock(_checkDevicesMutex);
                 if (_quit) {


### PR DESCRIPTION
- possible fix for crash-on-shutdown 2159
