### PR TITLE
Use matching hash keys for input/output when batch-loading scripts.

### DIFF
--- a/libraries/script-engine/src/BatchLoader.cpp
+++ b/libraries/script-engine/src/BatchLoader.cpp
@@ -44,6 +44,7 @@ void BatchLoader::start() {
         return;
     }
 
+
     for (const auto& rawURL : _urls) {
         QUrl url = expandScriptUrl(normalizeScriptURL(rawURL));
 
@@ -56,12 +57,12 @@ void BatchLoader::start() {
         // anything.
         ScriptCacheSignalProxy* proxy = new ScriptCacheSignalProxy(scriptCache.data());
 
-        connect(proxy, &ScriptCacheSignalProxy::contentAvailable, this, [this, rawURL](const QString& url, const QString& contents, bool isURL, bool success) {
+        connect(proxy, &ScriptCacheSignalProxy::contentAvailable, this, [this](const QString& url, const QString& contents, bool isURL, bool success) {
             if (isURL && success) {
-                _data.insert(rawURL, contents);
+                _data.insert(url, contents);
                 qCDebug(scriptengine) << "Loaded: " << url;
             } else {
-                _data.insert(rawURL, QString());
+                _data.insert(url, QString());
                 qCDebug(scriptengine) << "Could not load: " << url;
             }
 

--- a/libraries/script-engine/src/BatchLoader.cpp
+++ b/libraries/script-engine/src/BatchLoader.cpp
@@ -44,7 +44,6 @@ void BatchLoader::start() {
         return;
     }
 
-
     for (const auto& rawURL : _urls) {
         QUrl url = expandScriptUrl(normalizeScriptURL(rawURL));
 
@@ -57,12 +56,12 @@ void BatchLoader::start() {
         // anything.
         ScriptCacheSignalProxy* proxy = new ScriptCacheSignalProxy(scriptCache.data());
 
-        connect(proxy, &ScriptCacheSignalProxy::contentAvailable, this, [this](const QString& url, const QString& contents, bool isURL, bool success) {
+        connect(proxy, &ScriptCacheSignalProxy::contentAvailable, this, [this, rawURL](const QString& url, const QString& contents, bool isURL, bool success) {
             if (isURL && success) {
-                _data.insert(url, contents);
+                _data.insert(rawURL, contents);
                 qCDebug(scriptengine) << "Loaded: " << url;
             } else {
-                _data.insert(url, QString());
+                _data.insert(rawURL, QString());
                 qCDebug(scriptengine) << "Could not load: " << url;
             }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1187,6 +1187,8 @@ void ScriptEngine::include(const QStringList& includeFiles, QScriptValue callbac
             thisURL = resolvePath(file);
         }
 
+        thisURL = expandScriptUrl(normalizeScriptURL(ResourceManager::normalizeURL(thisURL)));
+
         if (!_includedURLs.contains(thisURL)) {
             if (!isStandardLibrary && !currentSandboxURL.isEmpty() && (thisURL.scheme() == "file") &&
                 (currentSandboxURL.scheme() != "file" ||

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1172,7 +1172,8 @@ void ScriptEngine::include(const QStringList& includeFiles, QScriptValue callbac
     // Guard against meaningless query and fragment parts.
     // Do NOT use PreferLocalFile as its behavior is unpredictable (e.g., on defaultScriptsLocation())
     const auto strippingFlags = QUrl::RemoveFilename | QUrl::RemoveQuery | QUrl::RemoveFragment;
-    for (QString file : includeFiles) {
+    for (QString includeFile : includeFiles) {
+        QString file = ResourceManager::normalizeURL(includeFile);
         QUrl thisURL;
         bool isStandardLibrary = false;
         if (file.startsWith("/~/")) {
@@ -1186,8 +1187,6 @@ void ScriptEngine::include(const QStringList& includeFiles, QScriptValue callbac
         } else {
             thisURL = resolvePath(file);
         }
-
-        thisURL = expandScriptUrl(normalizeScriptURL(ResourceManager::normalizeURL(thisURL)));
 
         if (!_includedURLs.contains(thisURL)) {
             if (!isStandardLibrary && !currentSandboxURL.isEmpty() && (thisURL.scheme() == "file") &&


### PR DESCRIPTION
This PR fixes a small issue with BatchLoader where false-negatives can happen when the input URL differs from the output URL; eg:

```javascript
// override local tutorial URLs to pull from an arbitrary github branch
Resources.overrideUrlPrefix(
    '/~/tutorials/',
    'https://rawgit.com/humbletim/hifi/pull-8973-test/scripts/tutorials/'
);
Script.include('/~/tutorials/createPingPongGun.js');
```

#### To test:

1. Perform smoke test of defaultScripts, checking to make sure the usual startup scripts all seem to load OK.
2. Run https://raw.githubusercontent.com/humbletim/hifi-aux/master/tests/script-cache/test-overrideUrlPrefix.js
3. Observe that the logs show `script:print()<< -=-=-=- pull-8973-test -=-=-=-`
