### PR TITLE
Add "Snapshot" text to snapshot cards in Address Bar Dialog

### DIFF
--- a/interface/resources/qml/hifi/Card.qml
+++ b/interface/resources/qml/hifi/Card.qml
@@ -113,8 +113,8 @@ Rectangle {
     }
     FiraSansRegular {
         id: users;
-        visible: action === 'concurrency';
-        text: onlineUsers;
+        visible: true;
+        text: ((action === 'concurrency') ? (onlineUsers) : ('Snapshot'));
         size: textSize;
         color: hifi.colors.white;
         anchors {

--- a/interface/resources/qml/hifi/Card.qml
+++ b/interface/resources/qml/hifi/Card.qml
@@ -113,9 +113,8 @@ Rectangle {
     }
     FiraSansRegular {
         id: users;
-        visible: true;
-        text: ((action === 'concurrency') ? (onlineUsers) : ('Snapshot'));
-        size: textSize;
+        text: (action === 'concurrency') ? onlineUsers : 'snapshot';
+        size: (action === 'concurrency') ? textSize : textSizeSmall;
         color: hifi.colors.white;
         anchors {
             verticalCenter: usersImage.verticalCenter;


### PR DESCRIPTION
This text makes it easier for users to discern snapshot cards from concurrency cards.