### PR TITLE
Use snapshot data from file

### DIFF
--- a/interface/src/ui/SnapshotUploader.cpp
+++ b/interface/src/ui/SnapshotUploader.cpp
@@ -57,9 +57,9 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
             callbackParams,
             QJsonDocument(rootObject).toJson());
 
-    }
-    else {
+    } else {
         emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(contents);
+        delete this;
     }
 }
 

--- a/interface/src/ui/SnapshotUploader.h
+++ b/interface/src/ui/SnapshotUploader.h
@@ -14,13 +14,19 @@
 
 #include <QObject>
 #include <QtNetwork/QNetworkReply>
+#include <QtCore/QUrl>
 
 class SnapshotUploader : public QObject {
     Q_OBJECT
-        public slots:
+public:
+    SnapshotUploader(QUrl inWorldLocation, QString pathname);
+public slots:
     void uploadSuccess(QNetworkReply& reply);
     void uploadFailure(QNetworkReply& reply);
     void createStorySuccess(QNetworkReply& reply);
     void createStoryFailure(QNetworkReply& reply);
+private:
+    QUrl _inWorldLocation;
+    QString _pathname;
 };
 #endif // hifi_SnapshotUploader_h


### PR DESCRIPTION
Allow movement (or domain change) between taking a snapshot and uploading it.
Fixes https://highfidelity.fogbugz.com/f/cases/2161/snapshots-recorded-for-wrong-place