### PR TITLE
Launch Interface after Sandbox content loaded

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -571,7 +571,9 @@ Function HandlePostInstallOptions
     ; both launches use the explorer trick in case the user has elevated permissions for the installer
     ; it won't be possible to use this approach if either application should be launched with a command line param
     ${If} ${SectionIsSelected} ${@SERVER_COMPONENT_NAME@}
-      Exec '"$WINDIR\explorer.exe" "$INSTDIR\@CONSOLE_INSTALL_SUBDIR@\@CONSOLE_WIN_EXEC_NAME@"'
+      ; create shortcut with ARGUMENTS
+      CreateShortCut "$TEMP\SandboxShortcut.lnk" "$INSTDIR\@CONSOLE_INSTALL_SUBDIR@\@CONSOLE_WIN_EXEC_NAME@" "-- --launchInterface"
+      Exec '"$WINDIR\explorer.exe" "$TEMP\SandboxShortcut.lnk"'
     ${Else}
       Exec '"$WINDIR\explorer.exe" "$INSTDIR\@INTERFACE_WIN_EXEC_NAME@"'
     ${EndIf}

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -868,6 +868,12 @@ function onContentLoaded() {
         homeServer.start();
     }
 
+    // If we were launched with the launchInterface option, then we need to launch interface now
+    if (argv.launchInterface) {
+        log.debug("Interface launch requested... argv.launchInterface:", argv.launchInterface);
+        startInterface();
+    }
+
     // If we were launched with the shutdownWatcher option, then we need to watch for the interface app
     // shutting down. The interface app will regularly update a running state file which we will check.
     // If the file doesn't exist or stops updating for a significant amount of time, we will shut down.


### PR DESCRIPTION
[BugID: 2117](https://highfidelity.fogbugz.com/f/cases/2117/web-site-download-installer-should-launch-interface-after-install)
Launches the interface on installation after the content is loaded.

Test Plan:
- Install PR build
- Select "Launch sandbox after install"
- Interface should launch once the content downloading is over
- Shut down Interface and the Sandbox
- Launch Sandbox
- Interface should not start.