### PR TITLE
raise desktop when showing it

### DIFF
--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -312,6 +312,7 @@ FocusScope {
 
     onPinnedChanged: {
         if (pinned) {
+            d.raiseWindow(desktop);
             desktop.focus = true;
             desktop.forceActiveFocus();
 


### PR DESCRIPTION
fixes https://highfidelity.fogbugz.com/f/cases/edit/2197/modal-dialogs-not-on-top-if-created-when-overlays-are-off