### PR TITLE
use ConvexHull shape for irregular "spheres"

### DIFF
--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -256,8 +256,18 @@ const btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info)
         }
         break;
         case SHAPE_TYPE_SPHERE: {
-            float radius = info.getHalfExtents().x;
-            shape = new btSphereShape(radius);
+            glm::vec3 halfExtents = info.getHalfExtents();
+            float radius = halfExtents.x;
+            if (radius == halfExtents.y && radius == halfExtents.z) {
+                shape = new btSphereShape(radius);
+            } else {
+                ShapeInfo::PointList points;
+                points.reserve(NUM_UNIT_SPHERE_DIRECTIONS);
+                for (uint32_t i = 0; i < NUM_UNIT_SPHERE_DIRECTIONS; ++i) {
+                    points.push_back(bulletToGLM(_unitSphereDirections[i]) * halfExtents);
+                }
+                shape = createConvexHull(points);
+            }
         }
         break;
         case SHAPE_TYPE_CAPSULE_Y: {

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -114,8 +114,7 @@ float ShapeInfo::computeVolume() const {
             break;
         }
         case SHAPE_TYPE_SPHERE: {
-            float radius = _halfExtents.x;
-            volume = 4.0f * PI * radius * radius * radius / 3.0f;
+            volume = 4.0f * PI * _halfExtents.x * _halfExtents.y * _halfExtents.z / 3.0f;
             break;
         }
         case SHAPE_TYPE_CYLINDER_Y: {

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -33,13 +33,8 @@ void ShapeInfo::setParams(ShapeType type, const glm::vec3& halfExtents, QString 
             _halfExtents = glm::vec3(0.0f);
             break;
         case SHAPE_TYPE_BOX:
+        case SHAPE_TYPE_SPHERE:
             break;
-        case SHAPE_TYPE_SPHERE: {
-            // sphere radius is max of halfExtents
-            float radius = glm::max(glm::max(halfExtents.x, halfExtents.y), halfExtents.z);
-            _halfExtents = glm::vec3(radius);
-            break;
-        }
         case SHAPE_TYPE_COMPOUND:
         case SHAPE_TYPE_STATIC_MESH:
             _url = QUrl(url);


### PR DESCRIPTION
* entities that collide like "spheres" actually use ellipsoidal convexHull if they don't have a cubic bounding box