### PR TITLE
Seems we were not deleting the right hrtfs when a node is killed

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -591,10 +591,10 @@ void AudioMixer::handleNodeKilled(SharedNodePointer killedNode) {
     // enumerate the connected listeners to remove HRTF objects for the disconnected node
     auto nodeList = DependencyManager::get<NodeList>();
 
-    nodeList->eachNode([](const SharedNodePointer& node) {
+    nodeList->eachNode([&killedNode](const SharedNodePointer& node) {
         auto clientData = dynamic_cast<AudioMixerClientData*>(node->getLinkedData());
         if (clientData) {
-            clientData->removeHRTFsForNode(node->getUUID());
+            clientData->removeHRTFsForNode(killedNode->getUUID());
         }
     });
 }


### PR DESCRIPTION
Simple fix, just make sure we delete the hrtfs associated with the
killedNode.  The test is to delete some nodes (agents) and make sure
nothing bad happens to audio mixer, or the audio itself.