### PR TITLE
Logging improvements

### DIFF
--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -175,9 +175,6 @@ AssignmentClient::~AssignmentClient() {
 
 void AssignmentClient::aboutToQuit() {
     stopAssignmentClient();
-
-    // clear the log handler so that Qt doesn't call the destructor on LogHandler
-    qInstallMessageHandler(0);
 }
 
 void AssignmentClient::setUpStatusToMonitor() {

--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -45,9 +45,6 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     setApplicationName("assignment-client");
     setApplicationVersion(BuildInfo::VERSION);
 
-    // use the verbose message handler in Logging
-    qInstallMessageHandler(LogHandler::verboseMessageHandler);
-
     // parse command-line
     QCommandLineParser parser;
     parser.setApplicationDescription("High Fidelity Assignment Client");

--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -126,9 +126,6 @@ void AssignmentClientMonitor::stopChildProcesses() {
 
 void AssignmentClientMonitor::aboutToQuit() {
     stopChildProcesses();
-
-    // clear the log handler so that Qt doesn't call the destructor on LogHandler
-    qInstallMessageHandler(0);
 }
 
 void AssignmentClientMonitor::spawnChildClient() {

--- a/assignment-client/src/main.cpp
+++ b/assignment-client/src/main.cpp
@@ -9,8 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <QtCore/QDebug>
-
+#include <LogHandler.h>
 #include <SharedUtil.h>
 
 #include "AssignmentClientApp.h"
@@ -18,10 +17,14 @@
 int main(int argc, char* argv[]) {
     disableQtBearerPoll(); // Fixes wifi ping spikes
 
+    qInstallMessageHandler(LogHandler::verboseMessageHandler);
+    qInfo() << "Starting.";
+
     AssignmentClientApp app(argc, argv);
     
     int acReturn = app.exec();
     qDebug() << "assignment-client process" <<  app.applicationPid() << "exiting with status code" << acReturn;
-    
+
+    qInfo() << "Quitting.";
     return acReturn;
 }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -72,12 +72,9 @@ DomainServer::DomainServer(int argc, char* argv[]) :
     _iceServerPort(ICE_SERVER_DEFAULT_PORT)
 {
     parseCommandLine();
-    qInstallMessageHandler(LogHandler::verboseMessageHandler);
 
     LogUtils::init();
     Setting::init();
-
-    connect(this, &QCoreApplication::aboutToQuit, this, &DomainServer::aboutToQuit);
 
     setOrganizationName(BuildInfo::MODIFIED_ORGANIZATION);
     setOrganizationDomain("highfidelity.io");
@@ -211,6 +208,7 @@ void DomainServer::parseCommandLine() {
 }
 
 DomainServer::~DomainServer() {
+    qInfo() << "Domain Server is shutting down.";
     // destroy the LimitedNodeList before the DomainServer QCoreApplication is down
     DependencyManager::destroy<LimitedNodeList>();
 }
@@ -221,12 +219,6 @@ void DomainServer::queuedQuit(QString quitMessage, int exitCode) {
     }
 
     QCoreApplication::exit(exitCode);
-}
-
-void DomainServer::aboutToQuit() {
-
-    // clear the log handler so that Qt doesn't call the destructor on LogHandler
-    qInstallMessageHandler(0);
 }
 
 void DomainServer::restart() {

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -72,8 +72,6 @@ public slots:
     void processICEServerHeartbeatACK(QSharedPointer<ReceivedMessage> message);
 
 private slots:
-    void aboutToQuit();
-
     void setupPendingAssignmentCredits();
     void sendPendingTransactionsToServer();
 
@@ -150,12 +148,8 @@ private:
 
     bool isAuthenticatedRequest(HTTPConnection* connection, const QUrl& url);
 
-    void handleTokenRequestFinished();
     QNetworkReply* profileRequestGivenTokenReply(QNetworkReply* tokenReply);
-    void handleProfileRequestFinished();
     Headers setupCookieHeadersFromProfileReply(QNetworkReply* profileReply);
-
-    void loadExistingSessionsFromSettings();
 
     QJsonObject jsonForSocket(const HifiSockAddr& socket);
     QJsonObject jsonObjectForNode(const SharedNodePointer& node);

--- a/domain-server/src/main.cpp
+++ b/domain-server/src/main.cpp
@@ -15,8 +15,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <QtCore/QCoreApplication>
-
 #include <LogHandler.h>
 #include <SharedUtil.h>
 
@@ -29,6 +27,9 @@ int main(int argc, char* argv[]) {
     setvbuf(stdout, NULL, _IOLBF, 0);
 #endif
 
+    qInstallMessageHandler(LogHandler::verboseMessageHandler);
+    qInfo() << "Starting.";
+
     int currentExitCode = 0;
 
     // use a do-while to handle domain-server restart
@@ -37,7 +38,7 @@ int main(int argc, char* argv[]) {
         currentExitCode = domainServer.exec();
     } while (currentExitCode == DomainServer::EXIT_CODE_REBOOT);
 
-
+    qInfo() << "Quitting.";
     return currentExitCode;
 }
 

--- a/ice-server/src/main.cpp
+++ b/ice-server/src/main.cpp
@@ -19,8 +19,9 @@ int main(int argc, char* argv[]) {
 #ifndef WIN32
     setvbuf(stdout, NULL, _IOLBF, 0);
 #endif
-    
+
     qInstallMessageHandler(LogHandler::verboseMessageHandler);
+    qInfo() << "Starting.";
     
     IceServer iceServer(argc, argv);
     return iceServer.exec();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1654,7 +1654,8 @@ Application::~Application() {
     
     _window->deleteLater();
 
-    qInstallMessageHandler(nullptr); // NOTE: Do this as late as possible so we continue to get our log messages
+    // Can't log to file passed this point, FileLogger about to be deleted
+    qInstallMessageHandler(LogHandler::verboseMessageHandler);
 }
 
 void Application::initializeGL() {

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -52,8 +52,10 @@ public:
 
     const QString& addRepeatedMessageRegex(const QString& regexString);
     const QString& addOnlyOnceMessageRegex(const QString& regexString);
+
 private:
     LogHandler();
+    ~LogHandler();
 
     void flushRepeatedMessages();
 

--- a/libraries/shared/src/ShutdownEventListener.cpp
+++ b/libraries/shared/src/ShutdownEventListener.cpp
@@ -9,8 +9,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <QCoreApplication>
-
 #include "ShutdownEventListener.h"
 
 #ifdef Q_OS_WIN
@@ -18,6 +16,9 @@
 #else
 #include <csignal>
 #endif
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDebug>
 
 ShutdownEventListener& ShutdownEventListener::getInstance() {
     static ShutdownEventListener staticInstance;
@@ -29,9 +30,7 @@ void signalHandler(int param) {
     QMetaObject::invokeMethod(qApp, "quit");
 }
 
-ShutdownEventListener::ShutdownEventListener(QObject* parent) :
-    QObject(parent)
-{
+ShutdownEventListener::ShutdownEventListener(QObject* parent) : QObject(parent) {
 #ifndef Q_OS_WIN
     // be a signal handler for SIGTERM so we can stop our children when we get it
     signal(SIGTERM, signalHandler);

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -109,7 +109,8 @@ bool FilePersistThread::processQueueItems(const Queue& messages) {
 }
 
 FileLogger::FileLogger(QObject* parent) :
-    AbstractLoggerInterface(parent), _fileName(getLogFilename())
+    AbstractLoggerInterface(parent),
+    _fileName(getLogFilename())
 {
     _persistThreadInstance = new FilePersistThread(*this);
     _persistThreadInstance->initialize(true, QThread::LowestPriority);

--- a/libraries/shared/src/shared/FileLogger.h
+++ b/libraries/shared/src/shared/FileLogger.h
@@ -24,7 +24,7 @@ public:
     FileLogger(QObject* parent = NULL);
     virtual ~FileLogger();
 
-    QString getFilename() { return _fileName; }
+    QString getFilename() const { return _fileName; }
     virtual void addMessage(const QString&) override;
     virtual QString getLogData() override;
     virtual void locateLog() override;


### PR DESCRIPTION
Few logging improvements I've made while working on the Sandbox stalling bug.

Now the server log files will contain 100% of the log given a proper shutdown.
Not missing the startup and shutdown logging anymore.

Wouldn've done it for interface too, but I need my Settings PR #8789 to get in first.


Test plan:
- Standard smoke test
- Run Sandbox and quit it
- Check logs the ACs, they should start with `Starting.` and end with `Quitting.`*
- Unfortunately the Sandbox always force kills the DS on windows, so you won't be able to observe this on the DS. We have a bug file for that.
 
* We statically flush some cached messages so there might be a couple lines after `Quitting.`