### PR TITLE
Prevent Script retries when HTTP errors are irrecoverable

### DIFF
--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -14,6 +14,7 @@
 #include <QFile>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QMetaEnum>
 
 #include <SharedUtil.h>
 
@@ -78,10 +79,36 @@ void HTTPResourceRequest::onRequestFinished() {
             _loadedFromCache = _reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute).toBool();
             _result = Success;
             break;
+
         case QNetworkReply::TimeoutError:
             _result = Timeout;
             break;
+
+        case QNetworkReply::ContentNotFoundError: // Script.include('https://httpbin.org/status/404')
+            _result = NotFound;
+            break;
+
+        case QNetworkReply::ProtocolInvalidOperationError: // Script.include('https://httpbin.org/status/400')
+            _result = InvalidURL;
+            break;
+
+        case QNetworkReply::UnknownContentError: // Script.include('QUrl("https://httpbin.org/status/402")')
+        case QNetworkReply::ContentOperationNotPermittedError: //Script.include('https://httpbin.org/status/403')
+        case QNetworkReply::AuthenticationRequiredError: // Script.include('https://httpbin.org/basic-auth/user/passwd')
+            _result = AccessDenied;
+            break;
+
+        case QNetworkReply::RemoteHostClosedError:  // Script.include('http://127.0.0.1:22')
+        case QNetworkReply::ConnectionRefusedError: // Script.include(http://127.0.0.1:1')
+        case QNetworkReply::HostNotFoundError:      // Script.include('http://foo.bar.highfidelity.io')
+        case QNetworkReply::ServiceUnavailableError: // Script.include('QUrl("https://httpbin.org/status/503")')
+            _result = ServerUnavailable;
+            break;
+
+        case QNetworkReply::UnknownServerError: // Script.include('QUrl("https://httpbin.org/status/504")')
+        case QNetworkReply::InternalServerError: // Script.include('QUrl("https://httpbin.org/status/500")')
         default:
+            qDebug() << "HTTPResourceRequest error:" << QMetaEnum::fromType<QNetworkReply::NetworkError>().valueToKey(_reply->error());
             _result = Error;
             break;
     }

--- a/libraries/script-engine/src/ScriptCache.cpp
+++ b/libraries/script-engine/src/ScriptCache.cpp
@@ -202,7 +202,14 @@ void ScriptCache::scriptContentAvailable() {
                 finished = true;
                 qCDebug(scriptengine) << "Done downloading script at:" << url.toString();
             } else {
-                if (scriptRequest.numRetries < MAX_RETRIES) {
+                auto result = req->getResult();
+                bool irrecoverable =
+                    result == ResourceRequest::AccessDenied ||
+                    result == ResourceRequest::InvalidURL ||
+                    result == ResourceRequest::NotFound ||
+                    scriptRequest.numRetries >= MAX_RETRIES;
+
+                if (!irrecoverable) {
                     ++scriptRequest.numRetries;
 
                     qDebug() << "Script request failed: " << url;


### PR DESCRIPTION
This PR increases the resolution of errors reported by `HTTPResourceRequest` and then uses it in `ScriptCache` to bail early when automatic retry would be futile (such as in the case of HTTP 404 Not Found errors).

[edit: links to client scripts moved to test plan comment below]

_I also had a change available that adds debug stream support to ResourceRequest -- which then allows ScriptCache to quickly log a more specific reason as to why the request failed -- but wasn't sure about including as part of this PR._ https://github.com/highfidelity/hifi/compare/master...humbletim:add-resource-request-dbgstreams
