### PR TITLE
Force sandbox config saves

### DIFF
--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -623,6 +623,7 @@ function checkNewContent() {
                   } else {
                       // They don't want to update, mark content set as current
                       userConfig.set('homeContentLastModified', new Date());
+                      userConfig.save(configPath);
                   }
               });
             }
@@ -676,6 +677,7 @@ function maybeInstallDefaultContentSet(onComplete) {
             }
             log.debug('Copied home content over to: ' + getRootHifiDataDirectory());
             userConfig.set('homeContentLastModified', new Date());
+            userConfig.save(configPath);
             onComplete();
         });
         return;
@@ -756,6 +758,7 @@ function maybeInstallDefaultContentSet(onComplete) {
             // response and decompression complete, return
             log.debug("Finished unarchiving home content set");
             userConfig.set('homeContentLastModified', new Date());
+            userConfig.save(configPath);
             sendStateUpdate('complete');
         });
 
@@ -766,6 +769,7 @@ function maybeInstallDefaultContentSet(onComplete) {
         });
 
         userConfig.set('hasRun', true);
+        userConfig.save(configPath);
     });
 }
 


### PR DESCRIPTION
Fixes the Content Update prompt always showing up if the Sandbox was not shutdown correctly.


Test Plan:
- Launch sandbox (content set should get installed).
- Close sandbox.
- Go to C:\Users\Clement\AppData\Roaming\High Fidelity - PR9023\Server Console\config.json.
- Change the homeContentLastModified value to an old date (ie: 2012 should do it).
- Start sandbox.
- You should get prompted for an update.
- Say yes or no, it doesn't matter
- Wait for the download to finish if you said yes
- Do NOT close the sandbox
- Go to C:\Users\Clement\AppData\Roaming\High Fidelity - PR9023\Server Console\config.json.
- Make sure homeContentLastModified was reset to the current date.
- Close sandbox.