### PR TITLE
Fix userData in edit.js sometimes showing wrong value when locked

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -445,13 +445,11 @@ function hideUserDataTextArea() {
 };
 
 function showStaticUserData() {
-    $('#static-userdata').show();
-    $('#static-userdata').css('height', $('#userdata-editor').height())
     if (editor !== null) {
+        $('#static-userdata').show();
+        $('#static-userdata').css('height', $('#userdata-editor').height())
         $('#static-userdata').text(editor.getText());
     }
-
-
 };
 
 function removeStaticUserData() {


### PR DESCRIPTION
To test:

 1. Create an entity 1 with no userData on it
 2. Create another entity 2 with JSON userData
 3. Select entity 2
 4. Select entity 1, look at the user properties, then lock it
 5. The userData should still be blank and should not show entity 2's userData
 6. Unlock entity 1
 7. Set the userData to a non-JSON value, like "asdf"
 8. Select entity 2
 9. Select entity 1, look at the user properties, then lock it
 10. The userData should still be the non-JSON value you set it to
 11. Lastly, please do general smoke testing to make sure userData is showing the correct value for a few different entities