### PR TITLE
Fix crashes in OpenGLVersionChecker 

### DIFF
--- a/libraries/gl/src/gl/Context.cpp
+++ b/libraries/gl/src/gl/Context.cpp
@@ -215,10 +215,10 @@ void Context::create() {
         }
         glewExperimental = true;
         glewInit();
-        if (glewIsSupported("GL_VERSION_4_5")) {
-            _version = 0x0405;
+       // if (glewIsSupported("GL_VERSION_4_5")) {
+       //     _version = 0x0405;
       //  } else if (glewIsSupported("GL_VERSION_4_3")) {
-        } else if (glewIsSupported("GL_VERSION_4_4")) {
+       /* } else*/ if (glewIsSupported("GL_VERSION_4_8")) {
 ///_version = 0x0403;
             _version = 0x0404;
         }

--- a/libraries/gl/src/gl/Context.cpp
+++ b/libraries/gl/src/gl/Context.cpp
@@ -217,8 +217,10 @@ void Context::create() {
         glewInit();
         if (glewIsSupported("GL_VERSION_4_5")) {
             _version = 0x0405;
-        } else if (glewIsSupported("GL_VERSION_4_3")) {
-            _version = 0x0403;
+      //  } else if (glewIsSupported("GL_VERSION_4_3")) {
+        } else if (glewIsSupported("GL_VERSION_4_4")) {
+///_version = 0x0403;
+            _version = 0x0404;
         }
         glGetError();
         wglMakeCurrent(0, 0);

--- a/libraries/gl/src/gl/Context.cpp
+++ b/libraries/gl/src/gl/Context.cpp
@@ -215,12 +215,10 @@ void Context::create() {
         }
         glewExperimental = true;
         glewInit();
-       // if (glewIsSupported("GL_VERSION_4_5")) {
-       //     _version = 0x0405;
-      //  } else if (glewIsSupported("GL_VERSION_4_3")) {
-       /* } else*/ if (glewIsSupported("GL_VERSION_4_8")) {
-///_version = 0x0403;
-            _version = 0x0404;
+        if (glewIsSupported("GL_VERSION_4_5")) {
+            _version = 0x0405;
+        } else if (glewIsSupported("GL_VERSION_4_3")) {
+            _version = 0x0403;
         }
         glGetError();
         wglMakeCurrent(0, 0);

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -21,6 +21,7 @@
 
 #include "GLHelpers.h"
 
+// Minimum gl version required is 4.1
 #define MINIMUM_GL_VERSION 0x0401
 
 OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
@@ -76,7 +77,7 @@ QJsonObject OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
     // - major_number.minor_number.release_number
     // Reference: https://www.opengl.org/sdk/docs/man/docbook4/xhtml/glGetString.xml
 
-    int minimumMajorNumber = (MINIMUM_GL_VERSION >> 16);
+    int minimumMajorNumber = (MINIMUM_GL_VERSION >> 8) & 0xFF;
     int minimumMinorNumber = (MINIMUM_GL_VERSION & 0xFF);
     int majorNumber = 0;
     int minorNumber = 0;

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -75,15 +75,26 @@ QJsonObject OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
     // - major_number.minor_number 
     // - major_number.minor_number.release_number
     // Reference: https://www.opengl.org/sdk/docs/man/docbook4/xhtml/glGetString.xml
-    const QString version { "version" };
-    QString glVersion = glData[version].toString();
-    QStringList versionParts = glVersion.split(QRegularExpression("[\\.\\s]"));
-    int majorNumber = versionParts[0].toInt();
-    int minorNumber = versionParts[1].toInt();
+
     int minimumMajorNumber = (MINIMUM_GL_VERSION >> 16);
     int minimumMinorNumber = (MINIMUM_GL_VERSION & 0xFF);
-    valid = (majorNumber > minimumMajorNumber
-        || (majorNumber == minimumMajorNumber && minorNumber >= minimumMinorNumber));
+    int majorNumber = 0;
+    int minorNumber = 0;
+    const QString version { "version" };
+    if (version.contains(version)) {
+        QString glVersion = glData[version].toString();
+        QStringList versionParts = glVersion.split(QRegularExpression("[\\.\\s]"));
+        if (versionParts.size() >= 2) {
+            majorNumber = versionParts[0].toInt();
+            minorNumber = versionParts[1].toInt();
+            valid = (majorNumber > minimumMajorNumber
+                || (majorNumber == minimumMajorNumber && minorNumber >= minimumMinorNumber));
+        } else {
+            valid = false;
+        }
+    } else {
+        valid = false;
+    }
 
     // Prompt user if below minimum
     if (!valid) {

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -22,7 +22,8 @@
 #include "GLHelpers.h"
 
 // Minimum gl version required is 4.1
-#define MINIMUM_GL_VERSION 0x0401
+//#define MINIMUM_GL_VERSION 0x0401
+#define MINIMUM_GL_VERSION 0x0404
 
 OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
     QApplication(argc, argv)

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -23,7 +23,7 @@
 
 // Minimum gl version required is 4.1
 //#define MINIMUM_GL_VERSION 0x0401
-#define MINIMUM_GL_VERSION 0x0404
+#define MINIMUM_GL_VERSION 0x0408
 
 OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
     QApplication(argc, argv)

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -22,8 +22,7 @@
 #include "GLHelpers.h"
 
 // Minimum gl version required is 4.1
-//#define MINIMUM_GL_VERSION 0x0401
-#define MINIMUM_GL_VERSION 0x0408
+#define MINIMUM_GL_VERSION 0x0401
 
 OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
     QApplication(argc, argv)

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -81,7 +81,7 @@ QJsonObject OpenGLVersionChecker::checkVersion(bool& valid, bool& override) {
     int majorNumber = 0;
     int minorNumber = 0;
     const QString version { "version" };
-    if (version.contains(version)) {
+    if (glData.contains(version)) {
         QString glVersion = glData[version].toString();
         QStringList versionParts = glVersion.split(QRegularExpression("[\\.\\s]"));
         if (versionParts.size() >= 2) {


### PR DESCRIPTION
Add more safe checks on the values returned from the opengl context creation to avoid crashing on non capable hardwares

THanks to @davidkelly for pointing out the issue