### PR TITLE
Log snapshot upload and user story creation errors

### DIFF
--- a/interface/src/ui/SnapshotUploader.cpp
+++ b/interface/src/ui/SnapshotUploader.cpp
@@ -65,12 +65,11 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
 
 void SnapshotUploader::uploadFailure(QNetworkReply& reply) {
     QString replyString = reply.readAll();
-    qDebug() << "Error uploading snapshot: " << reply.errorString();
+    qDebug() << "Error " << reply.errorString() << " uploading snapshot " << _pathname << " from " << _inWorldLocation;
     if (replyString.size() == 0) {
         replyString = reply.errorString();
     }
     emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(replyString); // maybe someday include _inWorldLocation, _filename?
-
     delete this;
 }
 
@@ -81,7 +80,7 @@ void SnapshotUploader::createStorySuccess(QNetworkReply& reply) {
 
 void SnapshotUploader::createStoryFailure(QNetworkReply& reply) {
     QString replyString = reply.readAll();
-    qDebug() << "Error creating user story: " << reply.errorString(); 
+    qDebug() << "Error " << reply.errorString() << " uploading snapshot " << _pathname << " from " << _inWorldLocation;
     if (replyString.size() == 0) {
         replyString = reply.errorString();
     }

--- a/interface/src/ui/SnapshotUploader.cpp
+++ b/interface/src/ui/SnapshotUploader.cpp
@@ -64,7 +64,13 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
 }
 
 void SnapshotUploader::uploadFailure(QNetworkReply& reply) {
-    emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(reply.readAll()); // maybe someday include _inWorldLocation, _filename?
+    QString replyString = reply.readAll();
+    qDebug() << "Error uploading snapshot: " << reply.errorString();
+    if (replyString.size() == 0) {
+        replyString = reply.errorString();
+    }
+    emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(replyString); // maybe someday include _inWorldLocation, _filename?
+
     delete this;
 }
 
@@ -74,6 +80,12 @@ void SnapshotUploader::createStorySuccess(QNetworkReply& reply) {
 }
 
 void SnapshotUploader::createStoryFailure(QNetworkReply& reply) {
-     emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(reply.readAll());
-     delete this;
+    QString replyString = reply.readAll();
+    qDebug() << "Error creating user story: " << reply.errorString(); 
+    if (replyString.size() == 0) {
+        replyString = reply.errorString();
+    }
+    emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(replyString);
+    delete this;
 }
+


### PR DESCRIPTION
Plus, if the body of the error is empty, put something in there so the script will not think it was successful.