### PR TITLE
Fix users.js maximize button unclickable with hand controllers

### DIFF
--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -253,6 +253,11 @@ var usersWindow = (function () {
         windowPane,
         windowHeading,
 
+        // Margin on the left and right side of the window to keep
+        // it from getting too close to the edge of the screen which
+        // is unclickable.
+        WINDOW_MARGIN_X = 20,
+
         // Window border is similar to that of edit.js.
         WINDOW_MARGIN_HALF = WINDOW_MARGIN / 2,
         WINDOW_BORDER_WIDTH = WINDOW_WIDTH + 2 * WINDOW_MARGIN_HALF,
@@ -446,7 +451,7 @@ var usersWindow = (function () {
     }
 
     function saturateWindowPosition() {
-        windowPosition.x = Math.max(0, Math.min(viewport.x - WINDOW_WIDTH, windowPosition.x));
+        windowPosition.x = Math.max(WINDOW_MARGIN_X, Math.min(viewport.x - WINDOW_WIDTH - WINDOW_MARGIN_X, windowPosition.x));
         windowPosition.y = Math.max(windowMinimumHeight, Math.min(viewport.y, windowPosition.y));
     }
 

--- a/scripts/system/users.js
+++ b/scripts/system/users.js
@@ -228,7 +228,7 @@ var usersWindow = (function () {
 
     var WINDOW_WIDTH = 260,
         WINDOW_MARGIN = 12,
-        WINDOW_BASE_MARGIN = 6, // A little less is needed in order look correct
+        WINDOW_BASE_MARGIN = 24, // A little less is needed in order look correct
         WINDOW_FONT = {
             size: 12
         },
@@ -254,10 +254,11 @@ var usersWindow = (function () {
         windowHeading,
 
         // Window border is similar to that of edit.js.
-        WINDOW_BORDER_WIDTH = WINDOW_WIDTH + 2 * WINDOW_BASE_MARGIN,
-        WINDOW_BORDER_TOP_MARGIN = 2 * WINDOW_BASE_MARGIN,
-        WINDOW_BORDER_BOTTOM_MARGIN = WINDOW_BASE_MARGIN,
-        WINDOW_BORDER_LEFT_MARGIN = WINDOW_BASE_MARGIN,
+        WINDOW_MARGIN_HALF = WINDOW_MARGIN / 2,
+        WINDOW_BORDER_WIDTH = WINDOW_WIDTH + 2 * WINDOW_MARGIN_HALF,
+        WINDOW_BORDER_TOP_MARGIN = 2 * WINDOW_MARGIN_HALF,
+        WINDOW_BORDER_BOTTOM_MARGIN = WINDOW_MARGIN_HALF,
+        WINDOW_BORDER_LEFT_MARGIN = WINDOW_MARGIN_HALF,
         WINDOW_BORDER_RADIUS = 4,
         WINDOW_BORDER_COLOR = { red: 255, green: 255, blue: 255 },
         WINDOW_BORDER_ALPHA = 0.5,


### PR DESCRIPTION
Using hand controllers, you cannot click closer than 25px to the edge of HUD/Overlay region. This becomes a problem with users.js because the maximize button is within this region. To fix this, I've added padding on all sides of the users window so that you cannot move the window itself too close to the edge of the screen, making the maximize button unclickable.

To test:

 1. Move the users.js window as far to the bottom left of the overlay area as possible.
 1. Make sure you can maximize and minimize the users.js window
 1. Move the users.js window as far to the bottom right of the overlay area as possible.
 1. Make sure you can maximize and minimize the users.js window
