### PR TITLE
Fixed unable to remove menus from VrMenu context

### DIFF
--- a/libraries/ui/src/VrMenu.cpp
+++ b/libraries/ui/src/VrMenu.cpp
@@ -59,6 +59,18 @@ public:
         _qml->setProperty("visible", _action->isVisible());
     }
 
+    void clear() {
+        _qml->setProperty("checkable", 0);
+        _qml->setProperty("enabled", 0);
+        _qml->setProperty("text", 0);
+        _qml->setProperty("shortcut", 0);
+        _qml->setProperty("checked", 0);
+        _qml->setProperty("visible", 0);
+
+        _action->setUserData(USER_DATA_ID, nullptr);
+        _qml->setUserData(USER_DATA_ID, nullptr);
+    }
+
 
     const QUuid uuid{ QUuid::createUuid() };
 
@@ -231,32 +243,6 @@ void VrMenu::removeAction(QAction* action) {
         return;
     }
 
-    QObject* parent = action->menu();
-    QObject* qmlParent = nullptr;
-
-    QMenu* parentMenu = dynamic_cast<QMenu*>(parent);
-    if (parentMenu) {
-        MenuUserData* MenuUserData = MenuUserData::forObject(parentMenu->menuAction());
-        if (!MenuUserData) {
-            return;
-        }
-        qmlParent = findMenuObject(MenuUserData->uuid.toString());
-    } else if (dynamic_cast<QMenuBar*>(parent)) {
-        qmlParent = _rootMenu;
-    } else {
-        Q_ASSERT(false);
-    }
-
-    QObject* item = findMenuObject(userData->uuid.toString());
-
-    QQuickMenu1* menu = nullptr;
-    QMetaObject::invokeMethod(item, "parentMenu", Qt::DirectConnection, Q_RETURN_ARG(QQuickMenu1*, menu));
-
-    if (!menu) {
-        return;
-    }
-    QQuickMenuBase* menuItem = reinterpret_cast<QQuickMenuBase*>(item);
-    QObject* baseMenu = reinterpret_cast<QObject*>(menu);
-
-    QMetaObject::invokeMethod(baseMenu, "removeItem", Qt::DirectConnection, Q_ARG(QQuickMenuBase*, menuItem));
+    userData->clear();
+    delete userData;
 }

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -84,7 +84,7 @@ void Menu::scanMenu(QMenu& menu, settingsAction modifySetting, Settings& setting
     groups.pop_back();
 }
 
-void Menu::addDisabledActionAndSeparator(MenuWrapper* destinationMenu, const QString& actionName, 
+void Menu::addDisabledActionAndSeparator(MenuWrapper* destinationMenu, const QString& actionName,
                                             int menuItemLocation, const QString& grouping) {
     QAction* actionBefore = NULL;
     QAction* separator;
@@ -123,7 +123,7 @@ QAction* Menu::addActionToQMenuAndActionHash(MenuWrapper* destinationMenu,
                                              const QObject* receiver,
                                              const char* member,
                                              QAction::MenuRole role,
-                                             int menuItemLocation, 
+                                             int menuItemLocation,
                                              const QString& grouping) {
     QAction* action = NULL;
     QAction* actionBefore = NULL;
@@ -165,7 +165,7 @@ QAction* Menu::addActionToQMenuAndActionHash(MenuWrapper* destinationMenu,
                                              const QString& actionName,
                                              const QKeySequence& shortcut,
                                              QAction::MenuRole role,
-                                             int menuItemLocation, 
+                                             int menuItemLocation,
                                              const QString& grouping) {
     QAction* actionBefore = NULL;
 
@@ -207,7 +207,7 @@ QAction* Menu::addCheckableActionToQMenuAndActionHash(MenuWrapper* destinationMe
                                                       const bool checked,
                                                       const QObject* receiver,
                                                       const char* member,
-                                                      int menuItemLocation, 
+                                                      int menuItemLocation,
                                                       const QString& grouping) {
 
     QAction* action = addActionToQMenuAndActionHash(destinationMenu, actionName, shortcut, receiver, member,
@@ -408,6 +408,10 @@ void Menu::removeMenu(const QString& menuName) {
             parent->removeAction(action);
         } else {
             QMenuBar::removeAction(action);
+            auto offscreenUi = DependencyManager::get<OffscreenUi>();
+            offscreenUi->addMenuInitializer([=](VrMenu* vrMenu) {
+                vrMenu->removeAction(action);
+            });
         }
 
         QMenuBar::repaint();
@@ -496,15 +500,15 @@ void Menu::setGroupingIsVisible(const QString& grouping, bool isVisible) {
 
 void Menu::addActionGroup(const QString& groupName, const QStringList& actionList, const QString& selected, QObject* receiver, const char* slot) {
     auto menu = addMenu(groupName);
-    
+
     QActionGroup* actionGroup = new QActionGroup(menu);
     actionGroup->setExclusive(true);
-    
+
     for (auto action : actionList) {
         auto item = addCheckableActionToQMenuAndActionHash(menu, action, 0, action == selected, receiver, slot);
         actionGroup->addAction(item);
     }
-    
+
     QMenuBar::repaint();
 }
 
@@ -582,4 +586,3 @@ void MenuWrapper::insertAction(QAction* before, QAction* action) {
         vrMenu->insertAction(before, action);
     });
 }
-


### PR DESCRIPTION
Fixed the issue of menus not being removed from VrMenu after they have been added.

Issue link - https://github.com/highfidelity/hifi/issues/8814