### PR TITLE
Remove incremental texture transfers

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -396,15 +396,6 @@ Menu::Menu() {
         });
     }
 
-    // Developer > Render > Enable Incremental Texture Transfer
-    {
-        auto action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::IncrementalTextureTransfer, 0, gpu::Texture::getEnableIncrementalTextureTransfers());
-        connect(action, &QAction::triggered, [&](bool checked) {
-            qDebug() << "[TEXTURE TRANSFER SUPPORT] --- Enable Incremental Texture Transfer menu option:" << checked;
-            gpu::Texture::setEnableIncrementalTextureTransfers(checked);
-        });
-    }
-
 #else
     qDebug() << "[TEXTURE TRANSFER SUPPORT] Incremental Texture Transfer and Dynamic Texture Management not supported on this platform.";
 #endif

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -112,7 +112,6 @@ namespace MenuOption {
     const QString FrameTimer = "Show Timer";
     const QString FullscreenMirror = "Mirror";
     const QString Help = "Help...";
-    const QString IncrementalTextureTransfer = "Enable Incremental Texture Transfer";
     const QString IncreaseAvatarSize = "Increase Avatar Size";
     const QString IndependentMode = "Independent Mode";
     const QString ActionMotorControl = "Enable Default Motor Control";

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -14,6 +14,8 @@
 #include "../gl/GLBackend.h"
 #include "../gl/GLTexture.h"
 
+#define INCREMENTAL_TRANSFER 0
+
 namespace gpu { namespace gl45 {
     
 using namespace gpu::gl;
@@ -56,6 +58,7 @@ public:
             GLint pageDimensionsIndex { 0 };
         };
 
+#if INCREMENTAL_TRANSFER
         struct TransferState {
             TransferState(GL45Texture& texture);
             uvec3 currentPageSize() const;
@@ -75,6 +78,10 @@ public:
             const uint8_t* srcPointer { nullptr };
         };
     protected:
+        TransferState _transferState;
+#endif
+
+    protected:
         void updateMips() override;
         void stripToMip(uint16_t newMinMip);
         void startTransfer() override;
@@ -91,7 +98,6 @@ public:
         void derez();
 
         SparseInfo _sparseInfo;
-        TransferState _transferState;
         uint32_t _allocatedPages { 0 };
         uint32_t _lastMipAllocatedPages { 0 };
         uint16_t _mipOffset { 0 };

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -35,18 +35,15 @@ std::atomic<Texture::Size> Texture::_allowedCPUMemoryUsage { 0 };
 
 
 #define MIN_CORES_FOR_INCREMENTAL_TEXTURES 5
-bool recommendedIncrementalTransfers = (QThread::idealThreadCount() >= MIN_CORES_FOR_INCREMENTAL_TEXTURES);
-bool recommendedSparseTextures = recommendedIncrementalTransfers;
+bool recommendedSparseTextures = (QThread::idealThreadCount() >= MIN_CORES_FOR_INCREMENTAL_TEXTURES);
 
-std::atomic<bool> Texture::_enableSparseTextures { recommendedIncrementalTransfers };
-std::atomic<bool> Texture::_enableIncrementalTextureTransfers { recommendedSparseTextures };
+std::atomic<bool> Texture::_enableSparseTextures { recommendedSparseTextures };
 
 struct ReportTextureState {
     ReportTextureState() {
         qDebug() << "[TEXTURE TRANSFER SUPPORT]"
             << "\n\tidealThreadCount:" << QThread::idealThreadCount()
-            << "\n\tRECOMMENDED enableSparseTextures:" << recommendedSparseTextures
-            << "\n\tRECOMMENDED enableIncrementalTextures:" << recommendedIncrementalTransfers;
+            << "\n\tRECOMMENDED enableSparseTextures:" << recommendedSparseTextures;
     }
 } report;
 
@@ -58,16 +55,6 @@ void Texture::setEnableSparseTextures(bool enabled) {
     qDebug() << "[TEXTURE TRANSFER SUPPORT] Sparse Textures and Dynamic Texture Management not supported on this platform.";
 #endif
 }
-
-void Texture::setEnableIncrementalTextureTransfers(bool enabled) {
-#ifdef Q_OS_WIN
-    qDebug() << "[TEXTURE TRANSFER SUPPORT] SETTING - Enable Incremental Texture Transfer:" << enabled;
-    _enableIncrementalTextureTransfers = enabled;
-#else
-    qDebug() << "[TEXTURE TRANSFER SUPPORT] Incremental Texture Transfer not supported on this platform.";
-#endif
-}
-
 
 void Texture::updateTextureCPUMemoryUsage(Size prevObjectSize, Size newObjectSize) {
     if (prevObjectSize == newObjectSize) {
@@ -82,10 +69,6 @@ void Texture::updateTextureCPUMemoryUsage(Size prevObjectSize, Size newObjectSiz
 
 bool Texture::getEnableSparseTextures() { 
     return _enableSparseTextures.load(); 
-}
-
-bool Texture::getEnableIncrementalTextureTransfers() { 
-    return _enableIncrementalTextureTransfers.load(); 
 }
 
 uint32_t Texture::getTextureCPUCount() {

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -143,10 +143,8 @@ class Texture : public Resource {
     static std::atomic<uint32_t> _textureCPUCount;
     static std::atomic<Size> _textureCPUMemoryUsage;
     static std::atomic<Size> _allowedCPUMemoryUsage;
-    static void updateTextureCPUMemoryUsage(Size prevObjectSize, Size newObjectSize);
-
     static std::atomic<bool> _enableSparseTextures;
-    static std::atomic<bool> _enableIncrementalTextureTransfers;
+    static void updateTextureCPUMemoryUsage(Size prevObjectSize, Size newObjectSize);
 
 public:
     static uint32_t getTextureCPUCount();
@@ -162,10 +160,7 @@ public:
     static void setAllowedGPUMemoryUsage(Size size);
 
     static bool getEnableSparseTextures();
-    static bool getEnableIncrementalTextureTransfers();
-
     static void setEnableSparseTextures(bool enabled);
-    static void setEnableIncrementalTextureTransfers(bool enabled);
 
     using ExternalRecycler = std::function<void(uint32, void*)>;
     using ExternalIdAndFence = std::pair<uint32, void*>;


### PR DESCRIPTION
While testing shows that incremental transfers can potentially smooth out some stutters, the downside is that transfers tend to take much longer, leading to scenes with avatars wandering around with no surface texture, and frequently missing skybox textures for up to a minute after you've connected.  

This PR removes the (developer) menu items and removes all code that supported incremental transfers.  

## Testing

Smoke test.  Behavior should be unchanged, although if you were using an i7 based system you may see faster texture loads.  The 'Enable Incremental Texture Transfer' menu item should be gone from the Developer / Render menu. 