### PR TITLE
elevate permissions required for mute environment to kick

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -489,7 +489,7 @@ void AudioMixer::handleNodeAudioPacket(QSharedPointer<ReceivedMessage> message, 
 void AudioMixer::handleMuteEnvironmentPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) {
     auto nodeList = DependencyManager::get<NodeList>();
 
-    if (sendingNode->isAllowedEditor()) {
+    if (sendingNode->getCanKick()) {
         glm::vec3 position;
         float radius;
 


### PR DESCRIPTION
- allow only those who have kick permissions in a domain to request an environment mute