### PR TITLE
Add stutter tracking

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -70,6 +70,10 @@ Item {
                         text: "Present Drop Rate: " + root.presentdroprate.toFixed(2);
                     }
                     StatText {
+                        text: "Stutter Rate: " + root.stutterrate.toFixed(3);
+                        visible: root.stutterrate != -1;
+                    }
+                    StatText {
                         text: "Simrate: " + root.simrate
                     }
                     StatText {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1197,6 +1197,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         properties["present_rate"] = displayPlugin->presentRate();
         properties["new_frame_present_rate"] = displayPlugin->newFramePresentRate();
         properties["dropped_frame_rate"] = displayPlugin->droppedFrameRate();
+        properties["stutter_rate"] = displayPlugin->stutterRate();
         properties["sim_rate"] = getAverageSimsPerSecond();
         properties["avatar_sim_rate"] = getAvatarSimrate();
         properties["has_async_reprojection"] = displayPlugin->hasAsyncReprojection();

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -128,7 +128,8 @@ void Stats::updateStats(bool force) {
         STAT_UPDATE(renderrate, displayPlugin->renderRate());
         STAT_UPDATE(presentrate, displayPlugin->presentRate());
         STAT_UPDATE(presentnewrate, displayPlugin->newFramePresentRate());
-        STAT_UPDATE(presentdroprate, qApp->getActiveDisplayPlugin()->droppedFrameRate());
+        STAT_UPDATE(presentdroprate, displayPlugin->droppedFrameRate());
+        STAT_UPDATE(stutterrate, displayPlugin->stutterRate());
     } else {
         STAT_UPDATE(presentrate, -1);
         STAT_UPDATE(presentnewrate, -1);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -36,7 +36,9 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(float, renderrate, 0)
     // How often the display plugin is presenting to the device
     STATS_PROPERTY(float, presentrate, 0)
-    
+    // How often the display device reprojecting old frames
+    STATS_PROPERTY(float, stutterrate, 0)
+
     STATS_PROPERTY(float, presentnewrate, 0)
     STATS_PROPERTY(float, presentdroprate, 0)
     STATS_PROPERTY(int, simrate, 0)
@@ -140,6 +142,7 @@ signals:
     void presentrateChanged();
     void presentnewrateChanged();
     void presentdroprateChanged();
+    void stutterrateChanged();
     void simrateChanged();
     void avatarSimrateChanged();
     void avatarCountChanged();

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -710,3 +710,7 @@ void HmdDisplayPlugin::compositeExtra() {
 HmdDisplayPlugin::~HmdDisplayPlugin() {
     qDebug() << "Destroying HmdDisplayPlugin";
 }
+
+float HmdDisplayPlugin::stutterRate() const {
+    return _stutterRate.rate();
+}

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -44,6 +44,8 @@ public:
         return false;
     }
 
+    float stutterRate() const override;
+
 protected:
     virtual void hmdPresent() = 0;
     virtual bool isHmdMounted() const = 0;
@@ -108,8 +110,9 @@ protected:
     QMap<uint32_t, FrameInfo> _frameInfos;
     FrameInfo _currentPresentFrameInfo;
     FrameInfo _currentRenderFrameInfo;
+    RateCounter<> _stutterRate;
 
-    bool _disablePreview{ true };
+    bool _disablePreview { true };
 private:
     ivec4 getViewportForSourceSize(const uvec2& size) const;
     float getLeftCenterPixel() const;

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -188,6 +188,8 @@ public:
     virtual float renderRate() const { return -1.0f; }
     // Rate at which we present to the display device
     virtual float presentRate() const { return -1.0f; }
+    // Rate at which old frames are presented to the device display
+    virtual float stutterRate() const { return -1.0f; }
     // Rate at which new frames are being presented to the display device
     virtual float newFramePresentRate() const { return -1.0f; }
     // Rate at which rendered frames are being skipped

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -146,6 +146,16 @@ void OculusDisplayPlugin::hmdPresent() {
         if (!OVR_SUCCESS(result)) {
             logWarning("Failed to present");
         }
+
+        static int droppedFrames = 0;
+        ovrPerfStats perfStats;
+        ovr_GetPerfStats(_session, &perfStats);
+        for (int i = 0; i < perfStats.FrameStatsCount; ++i) {
+            const auto& frameStats = perfStats.FrameStats[i];
+            int delta = frameStats.CompositorDroppedFrameCount - droppedFrames;
+            _stutterRate.increment(delta);
+            droppedFrames = frameStats.CompositorDroppedFrameCount;
+        }
     }
     _presentRate.increment();
 }

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -641,6 +641,12 @@ void OpenVrDisplayPlugin::hmdPresent() {
         vr::VRCompositor()->PostPresentHandoff();
         _presentRate.increment();
     }
+
+    vr::Compositor_FrameTiming frameTiming;
+    memset(&frameTiming, 0, sizeof(vr::Compositor_FrameTiming));
+    frameTiming.m_nSize = sizeof(vr::Compositor_FrameTiming);
+    vr::VRCompositor()->GetFrameTiming(&frameTiming);
+    _stutterRate.increment(frameTiming.m_nNumDroppedFrames);
 }
 
 void OpenVrDisplayPlugin::postPreview() {
@@ -701,4 +707,8 @@ bool OpenVrDisplayPlugin::isKeyboardVisible() {
 
 int OpenVrDisplayPlugin::getRequiredThreadCount() const { 
     return Parent::getRequiredThreadCount() + (_threadedSubmit ? 1 : 0);
+}
+
+float OpenVrDisplayPlugin::stutterRate() const {
+    return _stutterRate.rate();
 }

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -708,7 +708,3 @@ bool OpenVrDisplayPlugin::isKeyboardVisible() {
 int OpenVrDisplayPlugin::getRequiredThreadCount() const { 
     return Parent::getRequiredThreadCount() + (_threadedSubmit ? 1 : 0);
 }
-
-float OpenVrDisplayPlugin::stutterRate() const {
-    return _stutterRate.rate();
-}

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -58,8 +58,6 @@ public:
     // Possibly needs an additional thread for VR submission
     int getRequiredThreadCount() const override; 
 
-    float stutterRate() const override;
-
 protected:
     bool internalActivate() override;
     void internalDeactivate() override;
@@ -79,7 +77,6 @@ private:
     vr::HmdMatrix34_t _lastGoodHMDPose;
     mat4 _sensorResetMat;
     bool _threadedSubmit { true };
-    RateCounter<> _stutterRate;
 
     CompositeInfo::Array _compositeInfos;
     size_t _renderingIndex { 0 };

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -58,6 +58,8 @@ public:
     // Possibly needs an additional thread for VR submission
     int getRequiredThreadCount() const override; 
 
+    float stutterRate() const override;
+
 protected:
     bool internalActivate() override;
     void internalDeactivate() override;
@@ -77,6 +79,7 @@ private:
     vr::HmdMatrix34_t _lastGoodHMDPose;
     mat4 _sensorResetMat;
     bool _threadedSubmit { true };
+    RateCounter<> _stutterRate;
 
     CompositeInfo::Array _compositeInfos;
     size_t _renderingIndex { 0 };


### PR DESCRIPTION
Add a stat for stutters per second (the number of additional times a frame was scanned out to the display without reprojection)

## Testing

On an AMD system, or on an nVidia system running release Steam, or running Steam Beta with asyncronous reprojection turned off, load up a scene.  The stutter rate should occasionally rise above 0 indicating the number of stutters per second that you're encountering.  

You can also test by going to `hifi://dreaming` and moving your head so close to the procedural balls that they fill your field of view.  The shaders will consume so much GPU that it will trigger stutter on any hardware.
