### PR TITLE
Disable viewpoint menus in hmd

### DIFF
--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -126,6 +126,23 @@ void MenuScriptingInterface::setIsOptionChecked(const QString& menuOption, bool 
                 Q_ARG(bool, isChecked));
 }
 
+bool MenuScriptingInterface::isMenuEnabled(const QString& menuOption) {
+    if (QThread::currentThread() == qApp->thread()) {
+        return Menu::getInstance()->isOptionChecked(menuOption);
+    }
+    bool result;
+    QMetaObject::invokeMethod(Menu::getInstance(), "isMenuEnabled", Qt::BlockingQueuedConnection,
+        Q_RETURN_ARG(bool, result),
+        Q_ARG(const QString&, menuOption));
+    return result;
+}
+
+void MenuScriptingInterface::setMenuEnabled(const QString& menuOption, bool isChecked) {
+    QMetaObject::invokeMethod(Menu::getInstance(), "setMenuEnabled",
+        Q_ARG(const QString&, menuOption),
+        Q_ARG(bool, isChecked));
+}
+
 void MenuScriptingInterface::triggerOption(const QString& menuOption) {
     QMetaObject::invokeMethod(Menu::getInstance(), "triggerOption", Q_ARG(const QString&, menuOption));    
 }

--- a/interface/src/scripting/MenuScriptingInterface.h
+++ b/interface/src/scripting/MenuScriptingInterface.h
@@ -50,6 +50,9 @@ public slots:
     void setIsOptionChecked(const QString& menuOption, bool isChecked);
 
     void triggerOption(const QString& menuOption);
+
+    bool isMenuEnabled(const QString& menuName);
+    void setMenuEnabled(const QString& menuName, bool isEnabled);
     
 signals:
     void menuItemEvent(const QString& menuItem);

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -428,6 +428,25 @@ bool Menu::menuExists(const QString& menuName) {
     return false;
 }
 
+bool Menu::isMenuEnabled(const QString& menuName) {
+    QAction* action = getMenuAction(menuName);
+
+    // only proceed if the menu actually exists
+    if (action) {
+        return action->isEnabled();
+    }
+    return false;
+}
+
+void Menu::setMenuEnabled(const QString& menuName, bool isEnabled) {
+    QAction* action = getMenuAction(menuName);
+
+    // only proceed if the menu actually exists
+    if (action) {
+        action->setEnabled(isEnabled);
+    }
+}
+
 void Menu::addSeparator(const QString& menuName, const QString& separatorName, const QString& grouping) {
     MenuWrapper* menuObj = getMenu(menuName);
     if (menuObj) {

--- a/libraries/ui/src/ui/Menu.h
+++ b/libraries/ui/src/ui/Menu.h
@@ -106,6 +106,9 @@ public slots:
     bool isOptionChecked(const QString& menuOption) const;
     void setIsOptionChecked(const QString& menuOption, bool isChecked);
 
+    bool isMenuEnabled(const QString& menuName);
+    void setMenuEnabled(const QString& menuName, bool isEnabled);
+
     bool getGroupingIsVisible(const QString& grouping);
     void setGroupingIsVisible(const QString& grouping, bool isVisible); /// NOTE: the "" grouping is always visible
 

--- a/scripts/system/hmd.js
+++ b/scripts/system/hmd.js
@@ -24,10 +24,16 @@ var desktopMenuItemName = "Desktop";
 
 var toolBar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
 var button;
+// Independent and Entity mode make people sick. Third Person and Mirror have traps that we need to work through.
+// Disable them in hmd.
+var desktopOnlyViews = ['Third Person', 'Mirror', 'Independent Mode', 'Entity Mode'];
 function onHmdChanged(isHmd) {
     button.writeProperty('buttonState', isHmd ? 0 : 1);
     button.writeProperty('defaultState', isHmd ? 0 : 1);
     button.writeProperty('hoverState', isHmd ? 2 : 3);
+    desktopOnlyViews.forEach(function (view) {
+        Menu.setMenuEnabled("View>" + view, !isHmd);
+    });
 }
 function onClicked(){
     var isDesktop = Menu.isOptionChecked(desktopMenuItemName);


### PR DESCRIPTION
When in HMD, the menu items for views other than first-person are disabled. You can still use the keyboard toggles ('h', and 'p') to go in and out of different points of view.

Also exposes menu enable/disable to scripts.