### PR TITLE
Fix buffer count in stats display

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -241,7 +241,7 @@ Item {
                         text: "GPU Buffers: "
                     }
                     StatText {
-                        text: "  Count: " + root.gpuTextures;
+                        text: "  Count: " + root.gpuBuffers;
                     }
                     StatText {
                         text: "  Memory: " + root.gpuBufferMemory;


### PR DESCRIPTION
## Testing

The GPU buffers count display on the stats should no longer always be the same number as the texture count.