### PR TITLE
group snapshots by place

### DIFF
--- a/interface/resources/qml/hifi/Card.qml
+++ b/interface/resources/qml/hifi/Card.qml
@@ -27,6 +27,7 @@ Rectangle {
     property var goFunction: null;
     property string storyId: "";
 
+    property bool drillDownToPlace: false;
     property string timePhrase: pastTime(timestamp);
     property int onlineUsers: 0;
 
@@ -113,7 +114,7 @@ Rectangle {
     }
     FiraSansRegular {
         id: users;
-        text: (action === 'concurrency') ? onlineUsers : 'snapshot';
+        text: (action === 'concurrency') ? onlineUsers : ('snapshot' + (drillDownToPlace ? 's' : ''));
         size: (action === 'concurrency') ? textSize : textSizeSmall;
         color: hifi.colors.white;
         anchors {
@@ -140,7 +141,7 @@ Rectangle {
         id: usersImage;
         imageURL: "../../images/" + action + ".svg";
         size: 32;
-        onClicked: goFunction("/user_stories/" + storyId);
+        onClicked: goFunction(drillDownToPlace ? ("/places/" + placeName) : ("/user_stories/" + storyId));
         buttonState: 0;
         defaultState: 0;
         hoverState: 1;


### PR DESCRIPTION
Prototype of grouping snapshots by place in feed.

The difference from current behavior is subtle:
- When there are multiple snapshots among the (filtered) feed results that were taken in the same place, only the top-scoring card is shown in the feed, and the word "snapshot" is instead changed to "snapshots". 
- When you click on the camera icon on a card that shows plural snapshots, it goes to the place page (with all the top snapshots listed) rather than to the snapshot card. (There is a server PR https://github.com/highfidelity/data-web/pull/868 will allow you to page through ALL the snapshots for a given place, instead of just the top five.)

 Note that concurrency cards still appear separately, even for the same place. Otherwise, "grouping" would effectively just be showing concurrency cards only. The separate https://github.com/highfidelity/hifi/pull/9061 allows showing only concurrency, only snapshots, or both.

There are some other possibilities that I haven't yet explored:
- A more distinctive visual difference when multiple snapshots are grouped together.
- A fancy multi-snapshot action when you click on the card (instead of just the icon). For example, maybe it could animate some display of all the cards so that you could get the broader idea of what goes on in this place, and then pick the one you want to go to (which can be at different locations after the same user entry point). Instead, this PR currently just takes you to the in-world location of the top snapshot.