### PR TITLE
disable threaded reprojection when running oculus in OpenVR

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -401,9 +401,13 @@ bool OpenVrDisplayPlugin::internalActivate() {
     memset(&timing, 0, sizeof(timing));
     timing.m_nSize = sizeof(vr::Compositor_FrameTiming);
     vr::VRCompositor()->GetFrameTiming(&timing);
-    _asyncReprojectionActive = timing.m_nReprojectionFlags & VRCompositor_ReprojectionAsync;
+    auto usingOpenVRForOculus = oculusViaOpenVR();
+    _asyncReprojectionActive = (timing.m_nReprojectionFlags & VRCompositor_ReprojectionAsync) || usingOpenVRForOculus;
 
     _threadedSubmit = !_asyncReprojectionActive;
+    if (usingOpenVRForOculus) {
+        qDebug() << "Oculus active via OpenVR:  " << usingOpenVRForOculus;
+    }
     qDebug() << "OpenVR Async Reprojection active:  " << _asyncReprojectionActive;
     qDebug() << "OpenVR Threaded submit enabled:  " << _threadedSubmit;
 

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -60,6 +60,12 @@ bool isOculusPresent() {
     return result;
 }
 
+bool oculusViaOpenVR() {
+    static const QString DEBUG_FLAG("HIFI_DEBUG_OPENVR");
+    static bool enableDebugOpenVR = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
+    return enableDebugOpenVR && isOculusPresent() && vr::VR_IsHmdPresent();
+}
+
 bool openVrSupported() {
     static const QString DEBUG_FLAG("HIFI_DEBUG_OPENVR");
     static bool enableDebugOpenVR = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);

--- a/plugins/openvr/src/OpenVrHelpers.h
+++ b/plugins/openvr/src/OpenVrHelpers.h
@@ -15,6 +15,7 @@
 #include <controllers/Forward.h>
 #include <plugins/Forward.h>
 
+bool oculusViaOpenVR(); // is the user using Oculus via OpenVR
 bool openVrSupported();
 
 vr::IVRSystem* acquireOpenVrSystem();


### PR DESCRIPTION
This fixes a judder problem when you're using an oculus from the OpenVR plugin (instead of native Oculus SDK). This will allow people using steam hand controllers like the PSMove to use the OpenVR sdk instead of Oculus SDK which enables hand controllers.