### PR TITLE
Fix buffer leak in line entity

### DIFF
--- a/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
@@ -24,6 +24,13 @@ EntityItemPointer RenderableLineEntityItem::factory(const EntityItemID& entityID
     return entity;
 }
 
+RenderableLineEntityItem::~RenderableLineEntityItem() {
+    auto geometryCache = DependencyManager::get<GeometryCache>();
+    if (geometryCache) {
+        geometryCache->releaseID(_lineVerticesID);
+    }
+}
+
 void RenderableLineEntityItem::updateGeometry() {
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (_lineVerticesID == GeometryCache::UNKNOWN_ID) {

--- a/libraries/entities-renderer/src/RenderableLineEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableLineEntityItem.h
@@ -23,6 +23,7 @@ public:
         LineEntityItem(entityItemID),
        _lineVerticesID(GeometryCache::UNKNOWN_ID)
     { }
+    ~RenderableLineEntityItem();
 
     virtual void render(RenderArgs* args) override;
 


### PR DESCRIPTION
Line entities need to release their GeometryCache IDs.

## Testing

Functionality should remain unchanged.  You can test this by creating a domain containing a line entity.  If you repeatedly disconnect (by connecting to some invalid location like "127.0.0.0") and reconnect, you will see the buffer count remain steady.  In the production build the buffer count will rise over time.
