### PR TITLE
Make clear popup is from the Sandbox

### DIFF
--- a/server-console/src/content-update.html
+++ b/server-console/src/content-update.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Server Backup</title>
+    <title>High Fidelity Sandbox</title>
     <script src="content-update.js"></script>
     <link rel="stylesheet" type="text/css" href="content-update.css"></link>
 </head>

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -606,7 +606,7 @@ function checkNewContent() {
                   buttons: ['Yes', 'No'],
                   defaultId: 1,
                   cancelId: 1,
-                  title: 'New home content',
+                  title: 'High Fidelity Sandbox',
                   message: 'A newer version of the home content set is available.\nDo you wish to update?',
                   noLink: true,
               }, function(idx) {


### PR DESCRIPTION
Clarify popup titles.

Test plan:
- Make sure the Content update and the Backup popup have a title indicating they are from the Sandbox.

https://highfidelity.fogbugz.com/f/cases/2306/Sandbox-s-New-Content-Update-alert-doesn-t-identify-itself-as-High-Fidelity-on-auto-load