### PR TITLE
Disable glow line temporarily while fixing implementation

### DIFF
--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1593,7 +1593,10 @@ void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const
     glowIntensity = 0.0f;
 #endif
 
+    glowIntensity = 0.0f;
+
     if (glowIntensity <= 0) {
+        bindSimpleProgram(batch, false, false, false, true, false);
         renderLine(batch, p1, p2, color, id);
         return;
     }


### PR DESCRIPTION
The new stereo implementation breaks the glow effect on lines (which is implemented using a Geometry shader that probably needs to be updated in the face of the change to stereo rendering).  Additionally, the glow line effect has poor rendering when the line is excessively long, since the fade out effect at the ends is scaled relative to the line length, meaning a line pointing to an infinite or very large distance will fade to invisibility long before it reaches a point in space near the hands.  

Fixing both these issues will take some time, so this PR disables the glow effect entirely, causing all requests to render glow lines to render simple lines instead.

## Testing 

The hand lasers when interacting with the scene or with the UI should appear as simple aliased lines, rather than diffuse glow lines that appear in the current beta build.  