### PR TITLE
Fix - When avatar's parent is deleted, avatar does not move

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -438,7 +438,7 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
         return;
     }
 
-    checkEntity(entityID);
+    IsAvatarParentOfEntity(entityID);
     emit deletingEntity(entityID);
 
     // NOTE: callers must lock the tree before using this method
@@ -448,7 +448,7 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
     _isDirty = true;
 }
 
-void EntityTree::checkEntity(const EntityItemID entityID) {
+void EntityTree::IsAvatarParentOfEntity(const EntityItemID entityID) {
 
     EntityItemPointer entity = findEntityByEntityItemID(entityID);
 
@@ -488,7 +488,7 @@ void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool i
         }
 
         // tell our delete operator about this entityID
-        checkEntity(entityID);
+        IsAvatarParentOfEntity(entityID);
         theOperator.addEntityIDToDeleteList(entityID);
         emit deletingEntity(entityID);
     }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -438,7 +438,7 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
         return;
     }
 
-    IsAvatarParentOfEntity(entityID);
+    unhookChildAvatar(entityID);
     emit deletingEntity(entityID);
 
     // NOTE: callers must lock the tree before using this method
@@ -448,11 +448,11 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
     _isDirty = true;
 }
 
-void EntityTree::IsAvatarParentOfEntity(const EntityItemID entityID) {
+void EntityTree::unhookChildAvatar(const EntityItemID entityID) {
 
     EntityItemPointer entity = findEntityByEntityItemID(entityID);
 
-    entity->forEachChild([&](SpatiallyNestablePointer child) {
+    entity->forEachDescendant([&](SpatiallyNestablePointer child) {
         if (child->getNestableType() == NestableType::Avatar) {
             child->setParentID(nullptr);
         }
@@ -488,7 +488,7 @@ void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool i
         }
 
         // tell our delete operator about this entityID
-        IsAvatarParentOfEntity(entityID);
+        unhookChildAvatar(entityID);
         theOperator.addEntityIDToDeleteList(entityID);
         emit deletingEntity(entityID);
     }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -438,6 +438,7 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
         return;
     }
 
+    checkEntity(entityID);
     emit deletingEntity(entityID);
 
     // NOTE: callers must lock the tree before using this method
@@ -445,6 +446,17 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
     recurseTreeWithOperator(&theOperator);
     processRemovedEntities(theOperator);
     _isDirty = true;
+}
+
+void EntityTree::checkEntity(const EntityItemID entityID) {
+
+    EntityItemPointer entity = findEntityByEntityItemID(entityID);
+
+    entity->forEachChild([&](SpatiallyNestablePointer child) {
+        if (child->getNestableType() == NestableType::Avatar) {
+            child->setParentID(nullptr);
+        }
+    });
 }
 
 void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool ignoreWarnings) {
@@ -476,6 +488,7 @@ void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool i
         }
 
         // tell our delete operator about this entityID
+        checkEntity(entityID);
         theOperator.addEntityIDToDeleteList(entityID);
         emit deletingEntity(entityID);
     }

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -122,7 +122,7 @@ public:
     bool updateEntity(EntityItemPointer entity, const EntityItemProperties& properties, const SharedNodePointer& senderNode = SharedNodePointer(nullptr));
 
     // check if the avatar is a child of this entity, If so set the avatar parentID to null
-    void checkEntity(const EntityItemID entityID);
+    void IsAvatarParentOfEntity(const EntityItemID entityID);
     void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = true);
     void deleteEntities(QSet<EntityItemID> entityIDs, bool force = false, bool ignoreWarnings = true);
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -121,6 +121,8 @@ public:
     // use this method if you have a pointer to the entity (avoid an extra entity lookup)
     bool updateEntity(EntityItemPointer entity, const EntityItemProperties& properties, const SharedNodePointer& senderNode = SharedNodePointer(nullptr));
 
+    // check if the avatar is a child of this entity, If so set the avatar parentID to null
+    void checkEntity(const EntityItemID entityID);
     void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = true);
     void deleteEntities(QSet<EntityItemID> entityIDs, bool force = false, bool ignoreWarnings = true);
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -122,7 +122,7 @@ public:
     bool updateEntity(EntityItemPointer entity, const EntityItemProperties& properties, const SharedNodePointer& senderNode = SharedNodePointer(nullptr));
 
     // check if the avatar is a child of this entity, If so set the avatar parentID to null
-    void IsAvatarParentOfEntity(const EntityItemID entityID);
+    void unhookChildAvatar(const EntityItemID entityID);
     void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = true);
     void deleteEntities(QSet<EntityItemID> entityIDs, bool force = false, bool ignoreWarnings = true);
 


### PR DESCRIPTION
Fixed the issue of the when an avatar's parent is deleted the avatar is not able to move.

Link to issue - https://github.com/highfidelity/hifi/issues/9058

Test plan:
1. Enter in edit mode and create an object.
2. Run this script https://people.ucsc.edu/~druiz4/scripts/AvataeBug.js on the created entity, which makes the avatar the parent of the entity. 
3. One script is enabled move the entity around and your avatar will move with the entity.
4. Delete the entity,  your avatar should stay in pace and be able to move around.

QA Failed - If when performing step four, if the avatar ends up  suspended in the air or is unable to move.