### PR TITLE
Multichannel audio support

### DIFF
--- a/cmake/externals/wasapi/CMakeLists.txt
+++ b/cmake/externals/wasapi/CMakeLists.txt
@@ -6,8 +6,8 @@ if (WIN32)
   include(ExternalProject)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi3.zip
-    URL_MD5 1a2433f80a788a54c70f505ff4f43ac1
+    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi4.zip
+    URL_MD5 2abde5340a64d387848f12b9536a7e85
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -395,10 +395,16 @@ bool adjustedFormatForAudioDevice(const QAudioDeviceInfo& audioDevice,
     adjustedAudioFormat.setSampleType(QAudioFormat::SignedInt);
     adjustedAudioFormat.setByteOrder(QAudioFormat::LittleEndian);
 
-    assert(audioDevice.isFormatSupported(adjustedAudioFormat));
-
+    if (!audioDevice.isFormatSupported(adjustedAudioFormat)) {
+        qCDebug(audioclient) << "WARNING: The mix format is" << adjustedAudioFormat << "but isFormatSupported() failed.";
+        return false;
+    }
     // converting to/from this rate must produce an integral number of samples
-    return (adjustedAudioFormat.sampleRate() * AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL % AudioConstants::SAMPLE_RATE == 0);
+    if (adjustedAudioFormat.sampleRate() * AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL % AudioConstants::SAMPLE_RATE != 0) {
+        qCDebug(audioclient) << "WARNING: The current sample rate [" << adjustedAudioFormat.sampleRate() << "] is not supported.";
+        return false;
+    }
+    return true;
 
 #elif defined(Q_OS_ANDROID)
     // FIXME: query the native sample rate of the device?

--- a/libraries/audio/src/AudioRingBuffer.h
+++ b/libraries/audio/src/AudioRingBuffer.h
@@ -105,6 +105,8 @@ public:
 
         void readSamples(int16_t* dest, int numSamples);
         void readSamplesWithFade(int16_t* dest, int numSamples, float fade);
+        void readSamplesWithUpmix(int16_t* dest, int numSamples, int numExtraChannels);
+        void readSamplesWithDownmix(int16_t* dest, int numSamples);
 
     private:
         int16_t* atShiftedBy(int i);
@@ -222,6 +224,40 @@ inline void AudioRingBuffer::ConstIterator::readSamplesWithFade(int16_t* dest, i
         *dest = (float)*at * fade;
         ++dest;
         at = (at == _bufferLast) ? _bufferFirst : at + 1;
+    }
+}
+
+inline void AudioRingBuffer::ConstIterator::readSamplesWithUpmix(int16_t* dest, int numSamples, int numExtraChannels) {
+    int16_t* at = _at;
+    for (int i = 0; i < numSamples/2; i++) {
+
+        // read 2 samples
+        int16_t left = *at;
+        at = (at == _bufferLast) ? _bufferFirst : at + 1;
+        int16_t right = *at;
+        at = (at == _bufferLast) ? _bufferFirst : at + 1;
+
+        // write 2 + N samples
+        *dest++ = left;
+        *dest++ = right;
+        for (int n = 0; n < numExtraChannels; n++) {
+            *dest++ = 0;
+        }
+    }
+}
+
+inline void AudioRingBuffer::ConstIterator::readSamplesWithDownmix(int16_t* dest, int numSamples) {
+    int16_t* at = _at;
+    for (int i = 0; i < numSamples/2; i++) {
+
+        // read 2 samples
+        int16_t left = *at;
+        at = (at == _bufferLast) ? _bufferFirst : at + 1;
+        int16_t right = *at;
+        at = (at == _bufferLast) ? _bufferFirst : at + 1;
+
+        // write 1 sample
+        *dest++ = (int16_t)((left + right) / 2);
     }
 }
 


### PR DESCRIPTION
Add support for mono or multichannel audio output devices. Due to HRTF and reverb, the audio pipeline will always produce stereo output. The backend will now upmix/downmix to the device format, if needed. 

This PR includes updated WASAPI Qt plugins that implement multichannel support.