### PR TITLE
CAS-style entity edits

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -143,6 +143,7 @@ EntityPropertyFlags EntityItem::getEntityProperties(EncodeBitstreamParams& param
     requestedProperties += PROP_OWNING_AVATAR_ID;
 
     requestedProperties += PROP_LAST_EDITED_BY;
+    requestedProperties += PROP_CAS_UNIQUE;
 
     return requestedProperties;
 }
@@ -283,6 +284,7 @@ OctreeElement::AppendState EntityItem::appendEntityData(OctreePacketData* packet
         APPEND_ENTITY_PROPERTY(PROP_PARENT_JOINT_INDEX, getParentJointIndex());
         APPEND_ENTITY_PROPERTY(PROP_QUERY_AA_CUBE, getQueryAACube());
         APPEND_ENTITY_PROPERTY(PROP_LAST_EDITED_BY, getLastEditedBy());
+        APPEND_ENTITY_PROPERTY(PROP_CAS_UNIQUE, getCasUnique());
 
         appendSubclassData(packetData, params, entityTreeElementExtraEncodeData,
                                 requestedProperties,
@@ -808,6 +810,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
 
     READ_ENTITY_PROPERTY(PROP_QUERY_AA_CUBE, AACube, setQueryAACube);
     READ_ENTITY_PROPERTY(PROP_LAST_EDITED_BY, QUuid, setLastEditedBy);
+    READ_ENTITY_PROPERTY(PROP_CAS_UNIQUE, quint64, setCasUnique);
 
     bytesRead += readEntitySubclassDataFromBuffer(dataAt, (bytesLeftToRead - bytesRead), args,
                                                   propertyFlags, overwriteLocalData, somethingChanged);
@@ -1211,6 +1214,7 @@ EntityItemProperties EntityItem::getProperties(EntityPropertyFlags desiredProper
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(owningAvatarID, getOwningAvatarID);
 
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(lastEditedBy, getLastEditedBy);
+    COPY_ENTITY_PROPERTY_TO_PROPERTIES(casUnique, getCasUnique);
 
     properties._defaultSettings = false;
 
@@ -1315,6 +1319,7 @@ bool EntityItem::setProperties(const EntityItemProperties& properties) {
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(owningAvatarID, setOwningAvatarID);
 
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(lastEditedBy, setLastEditedBy);
+    SET_ENTITY_PROPERTY_FROM_PROPERTIES(casUnique, setCasUnique);
 
     AACube saveQueryAACube = _queryAACube;
     checkAndAdjustQueryAACube();

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -452,6 +452,10 @@ public:
     QUuid getLastEditedBy() const { return _lastEditedBy; }
     void setLastEditedBy(QUuid value) { _lastEditedBy = value; }
 
+    quint64 getCasUnique() const { return _casUnique; }
+    void setCasUnique(quint64 value) { _casUnique = value; }
+    void changeCasUnique() { _casUnique++; }
+
 protected:
 
     void setSimulated(bool simulated) { _simulated = simulated; }
@@ -474,6 +478,7 @@ protected:
     quint64 _lastEditedFromRemoteInRemoteTime; // last time we received an edit from the server (in server-time-frame)
     quint64 _created;
     quint64 _changedOnServer;
+    quint64 _casUnique { 0 };
 
     mutable AABox _cachedAABox;
     mutable AACube _maxAACube;

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -221,6 +221,8 @@ public:
 
     DEFINE_PROPERTY_REF(PROP_LAST_EDITED_BY, LastEditedBy, lastEditedBy, QUuid, ENTITY_ITEM_DEFAULT_LAST_EDITED_BY);
 
+    DEFINE_PROPERTY_REF(PROP_CAS_UNIQUE, CasUnique, casUnique, quint64, 0);
+
     static QString getBackgroundModeString(BackgroundMode mode);
 
 
@@ -272,6 +274,7 @@ public:
     void setCreated(QDateTime& v);
 
     bool hasTerseUpdateChanges() const;
+    bool hasNonTerseUpdateChanges() const;
     bool hasMiscPhysicsChanges() const;
 
     void clearSimulationOwner();
@@ -459,6 +462,8 @@ inline QDebug operator<<(QDebug debug, const EntityItemProperties& properties) {
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, OwningAvatarID, owningAvatarID, "");
 
     DEBUG_PROPERTY_IF_CHANGED(debug, properties, LastEditedBy, lastEditedBy, "");
+
+    DEBUG_PROPERTY_IF_CHANGED(debug, properties, CasUnique, casUnique, "");
 
     properties.getAnimation().debugDump();
     properties.getSkybox().debugDump();

--- a/libraries/entities/src/EntityPropertyFlags.h
+++ b/libraries/entities/src/EntityPropertyFlags.h
@@ -183,6 +183,9 @@ enum EntityPropertyList {
 
     PROP_LAST_EDITED_BY,
 
+    PROP_CAS_UNIQUE, // compare-and-swap / check-and-set ID
+
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // ATTENTION: add new properties to end of list just ABOVE this line
     PROP_AFTER_LAST_ITEM,

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -141,6 +141,7 @@ public slots:
     /**jsdoc
      * Updates an entity with the specified properties.
      *
+     * @param {EntityItemProperties} properties Properties of the entity to change.
      * @function Entities.editEntity
      * @return {EntityID} The EntityID of the entity if the edit was successful, otherwise the null {EntityID}.
      */

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -48,7 +48,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::EntityAdd:
         case PacketType::EntityEdit:
         case PacketType::EntityData:
-            return VERSION_ENTITIES_LAST_EDITED_BY;
+            return VERSION_ENTITIES_CAS;
         case PacketType::AvatarIdentity:
         case PacketType::AvatarData:
         case PacketType::BulkAvatarData:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -191,6 +191,7 @@ const PacketVersion VERSION_MODEL_ENTITIES_SUPPORT_SIMPLE_HULLS = 62;
 const PacketVersion VERSION_WEB_ENTITIES_SUPPORT_DPI = 63;
 const PacketVersion VERSION_ENTITIES_ARROW_ACTION = 64;
 const PacketVersion VERSION_ENTITIES_LAST_EDITED_BY = 65;
+const PacketVersion VERSION_ENTITIES_CAS = 66;
 
 enum class AssetServerPacketVersion: PacketVersion {
     VegasCongestionControl = 19


### PR DESCRIPTION
- enable compare-and-swap edits of entities so that certain changes can be made more reliable
