### PR TITLE
animate suggestions when available

### DIFF
--- a/interface/resources/qml/AddressBarDialog.qml
+++ b/interface/resources/qml/AddressBarDialog.qml
@@ -112,6 +112,7 @@ Window {
                 placeName: model.place_name;
                 hifiUrl: model.place_name + model.path;
                 thumbnail: model.thumbnail_url;
+                imageUrl: model.image_url;
                 action: model.action;
                 timestamp: model.created_at;
                 onlineUsers: model.online_users;
@@ -395,6 +396,7 @@ Window {
             created_at: data.created_at || "",
             action: data.action || "",
             thumbnail_url: resolveUrl(thumbnail_url),
+            image_url: resolveUrl(data.details.image_url),
 
             metaverseId: (data.id || "").toString(), // Some are strings from server while others are numbers. Model objects require uniformity.
 

--- a/interface/resources/qml/hifi/Card.qml
+++ b/interface/resources/qml/hifi/Card.qml
@@ -25,6 +25,7 @@ Rectangle {
     property string timestamp: "";
     property string hifiUrl: "";
     property string thumbnail: defaultThumbnail;
+    property string imageUrl: "";
     property var goFunction: null;
     property string storyId: "";
 
@@ -67,13 +68,21 @@ Rectangle {
         return 'about a minute ago';
     }
 
+    property bool hasGif: imageUrl.indexOf('.gif') === (imageUrl.length - 4);
+    AnimatedImage {
+        id: animation;
+        // Always visible, to drive loading, but initially covered up by lobby during load.
+        source: hasGif ? imageUrl : "";
+        fillMode: lobby.fillMode;
+        anchors.fill: lobby;
+    }
     Image {
         id: lobby;
+        visible: !hasGif || (animation.status !== Image.Ready);
         width: parent.width - (isConcurrency ? 0 : (2 * smallMargin));
         height: parent.height - messageHeight - (isConcurrency ? 0 : smallMargin);
         source: thumbnail || defaultThumbnail;
         fillMode: Image.PreserveAspectCrop;
-        // source gets filled in later
         anchors {
             horizontalCenter: parent.horizontalCenter;
             top: parent.top;


### PR DESCRIPTION
shows animated .gifs in suggestions once they are loaded (using thumbnail before that).
(Animated .gif is still available when you click on info, but here we're showing it without having to drill down.)