### PR TITLE
Capture original location in snapshots

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5450,10 +5450,10 @@ void Application::takeSnapshot(bool notify, bool includeAnimated, float aspectRa
         }
     });
 }
-void Application::shareSnapshot(const QString& path) {
-    postLambdaEvent([path] {
+void Application::shareSnapshot(const QString& path, const QUrl& href) {
+    postLambdaEvent([path, href] {
         // not much to do here, everything is done in snapshot code...
-        Snapshot::uploadSnapshot(path);
+        Snapshot::uploadSnapshot(path, href);
     });
 }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -267,7 +267,7 @@ public:
     float getAverageSimsPerSecond() const { return _simCounter.rate(); }
     
     void takeSnapshot(bool notify, bool includeAnimated = false, float aspectRatio = 0.0f);
-    void shareSnapshot(const QString& filename);
+    void shareSnapshot(const QString& filename, const QUrl& href = QUrl(""));
 
     model::SkyboxPointer getDefaultSkybox() const { return _defaultSkybox; }
     gpu::TexturePointer getDefaultSkyboxTexture() const { return _defaultSkyboxTexture;  }

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -203,8 +203,8 @@ void WindowScriptingInterface::takeSnapshot(bool notify, bool includeAnimated, f
     qApp->takeSnapshot(notify, includeAnimated, aspectRatio);
 }
 
-void WindowScriptingInterface::shareSnapshot(const QString& path) {
-    qApp->shareSnapshot(path);
+void WindowScriptingInterface::shareSnapshot(const QString& path, const QUrl& href) {
+    qApp->shareSnapshot(path, href);
 }
 
 bool WindowScriptingInterface::isPhysicsEnabled() {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -53,7 +53,7 @@ public slots:
     void showAssetServer(const QString& upload = "");
     void copyToClipboard(const QString& text);
     void takeSnapshot(bool notify = true, bool includeAnimated = false, float aspectRatio = 0.0f);
-    void shareSnapshot(const QString& path);
+    void shareSnapshot(const QString& path, const QUrl& href = QUrl(""));
     bool isPhysicsEnabled();
 
 signals:

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -151,13 +151,17 @@ QFile* Snapshot::savedFileForSnapshot(QImage & shot, bool isTemporary) {
     return imageTempFile;
 }
 
-void Snapshot::uploadSnapshot(const QString& filename) {
+void Snapshot::uploadSnapshot(const QString& filename, const QUrl& href) {
 
     const QString SNAPSHOT_UPLOAD_URL = "/api/v1/snapshots";
-    // Alternatively to parseSnapshotData, we could pass the inWorldLocation through the call chain. This way is less disruptive to existing code.
-    SnapshotMetaData* snapshotData = Snapshot::parseSnapshotData(filename);
-    SnapshotUploader* uploader = new SnapshotUploader(snapshotData->getURL(), filename);
-    delete snapshotData;
+    SnapshotUploader* uploader;
+    if (href.isEmpty()) {
+        SnapshotMetaData* snapshotData = Snapshot::parseSnapshotData(filename);
+        uploader = new SnapshotUploader(snapshotData->getURL(), filename);
+        delete snapshotData;
+    } else {
+        uploader = new SnapshotUploader(href, filename);
+    }
     
     QFile* file = new QFile(filename);
     Q_ASSERT(file->exists());

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -63,8 +63,6 @@ SnapshotMetaData* Snapshot::parseSnapshotData(QString snapshotPath) {
 
         // parsing URL
         url = QUrl(shot.text(URL), QUrl::ParsingMode::StrictMode);
-    } else if (snapshotPath.right(3) == "gif") {
-        url = QUrl(DependencyManager::get<AddressManager>()->currentShareableAddress());
     } else {
         return NULL;
     }
@@ -154,14 +152,16 @@ QFile* Snapshot::savedFileForSnapshot(QImage & shot, bool isTemporary) {
 void Snapshot::uploadSnapshot(const QString& filename, const QUrl& href) {
 
     const QString SNAPSHOT_UPLOAD_URL = "/api/v1/snapshots";
-    SnapshotUploader* uploader;
-    if (href.isEmpty()) {
+    QUrl url = href;
+    if (url.isEmpty()) {
         SnapshotMetaData* snapshotData = Snapshot::parseSnapshotData(filename);
-        uploader = new SnapshotUploader(snapshotData->getURL(), filename);
+        url = snapshotData->getURL();
         delete snapshotData;
-    } else {
-        uploader = new SnapshotUploader(href, filename);
     }
+    if (url.isEmpty()) {
+        url = QUrl(DependencyManager::get<AddressManager>()->currentShareableAddress());
+    }
+    SnapshotUploader* uploader = new SnapshotUploader(url, filename);
     
     QFile* file = new QFile(filename);
     Q_ASSERT(file->exists());

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -155,7 +155,9 @@ void Snapshot::uploadSnapshot(const QString& filename, const QUrl& href) {
     QUrl url = href;
     if (url.isEmpty()) {
         SnapshotMetaData* snapshotData = Snapshot::parseSnapshotData(filename);
-        url = snapshotData->getURL();
+        if (snapshotData) {
+            url = snapshotData->getURL();
+        }
         delete snapshotData;
     }
     if (url.isEmpty()) {

--- a/interface/src/ui/Snapshot.h
+++ b/interface/src/ui/Snapshot.h
@@ -39,7 +39,7 @@ public:
     static SnapshotMetaData* parseSnapshotData(QString snapshotPath);
 
     static Setting::Handle<QString> snapshotsLocation;
-    static void uploadSnapshot(const QString& filename);
+    static void uploadSnapshot(const QString& filename, const QUrl& href = QUrl(""));
 private:
     static QFile* savedFileForSnapshot(QImage & image, bool isTemporary);
 };

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -99,12 +99,17 @@ function snapshotShared(errorMessage) {
         showFeedWindow();
     }
 }
-
+var href, domainId;
 function onClicked() {
     // Raising the desktop for the share dialog at end will interact badly with clearOverlayWhenMoving.
     // Turn it off now, before we start futzing with things (and possibly moving).
     clearOverlayWhenMoving = MyAvatar.getClearOverlayWhenMoving(); // Do not use Settings. MyAvatar keeps a separate copy.
     MyAvatar.setClearOverlayWhenMoving(false);
+
+    // We will record snapshots based on the starting location. That could change, e.g., when recording a .gif.
+    // Even the domainId could change (e.g., if the user falls into a teleporter while recording).
+    href = location.href;
+    domainId = location.domainId;
 
     // update button states
     resetOverlays = Menu.isOptionChecked("Overlays"); // For completness. Certainly true if the button is visible to be clicke.
@@ -168,13 +173,12 @@ function resetButtons(pathStillSnapshot, pathAnimatedSnapshot, notify) {
     // A Snapshot Review dialog might be left open indefinitely after taking the picture,
     // during which time the user may have moved. So stash that info in the dialog so that
     // it records the correct href. (We can also stash in .jpegs, but not .gifs.)
-    var href = location.href;
     // last element in data array tells dialog whether we can share or not
     confirmShare([ 
         { localPath: pathAnimatedSnapshot, href: href },
         { localPath: pathStillSnapshot, href: href },
         {
-            canShare: !!isDomainOpen(location.domainId),
+            canShare: !!isDomainOpen(domainId),
             openFeedAfterShare: shouldOpenFeedAfterShare()
         }
     ]);

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -71,7 +71,7 @@ function confirmShare(data) {
                     if (submessage.share) {
                         print('sharing', submessage.localPath);
                         outstanding++;
-                        Window.shareSnapshot(submessage.localPath);
+                        Window.shareSnapshot(submessage.localPath, submessage.href);
                     } else {
                         print('not sharing', submessage.localPath);
                     }
@@ -159,10 +159,14 @@ function resetButtons(pathStillSnapshot, pathAnimatedSnapshot, notify) {
     button.writeProperty("hoverState", 3);
     Window.snapshotTaken.disconnect(resetButtons);
 
+    // A Snapshot Review dialog might be left open indefinitely after taking the picture,
+    // during which time the user may have moved. So stash that info in the dialog so that
+    // it records the correct href. (We can also stash in .jpegs, but not .gifs.)
+    var href = location.href;
     // last element in data array tells dialog whether we can share or not
     confirmShare([ 
-        { localPath: pathAnimatedSnapshot },
-        { localPath: pathStillSnapshot },
+        { localPath: pathAnimatedSnapshot, href: href },
+        { localPath: pathStillSnapshot, href: href },
         {
             canShare: !!isDomainOpen(location.domainId),
             openFeedAfterShare: shouldOpenFeedAfterShare()


### PR DESCRIPTION
Capture correct href and domain at start of snapshot, not the end, because it matters for time recordings such as animated .gif.
Also allow movement during recording.

(re-) fixes https://highfidelity.fogbugz.com/f/cases/2161/snapshots-recorded-for-wrong-place