### PR TITLE
Added preferences for the Perception Neuron plugin.

### DIFF
--- a/interface/resources/qml/dialogs/PreferencesDialog.qml
+++ b/interface/resources/qml/dialogs/PreferencesDialog.qml
@@ -55,22 +55,20 @@ ScrollingWindow {
 
         Component.onCompleted: {
             var categories = Preferences.categories;
-            var categoryMap;
             var i;
-            if (showCategories && showCategories.length) {
-                categoryMap = {};
-                for (i = 0; i < showCategories.length; ++i) {
-                    categoryMap[showCategories[i]] = true;
-                }
+
+            // build a map of valid categories.
+            var categoryMap = {};
+            for (i = 0; i < categories.length; i++) {
+                categoryMap[categories[i]] = true;
             }
 
-            for (i = 0; i < categories.length; ++i) {
-                var category = categories[i];
-                if (categoryMap && !categoryMap[category]) {
-                    continue;
+            // create a section for each valid category in showCategories
+            // NOTE: the sort order of items in the showCategories array is the same order in the dialog.
+            for (i = 0; i < showCategories.length; i++) {
+                if (categoryMap[showCategories[i]]) {
+                    sections.push(sectionBuilder.createObject(prefControls, {name: showCategories[i]}));
                 }
-
-                sections.push(sectionBuilder.createObject(prefControls, { name: category }));
             }
 
             if (sections.length) {

--- a/interface/resources/qml/hifi/dialogs/GeneralPreferencesDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/GeneralPreferencesDialog.qml
@@ -17,7 +17,7 @@ PreferencesDialog {
     id: root
     objectName: "GeneralPreferencesDialog"
     title: "General Settings"
-    showCategories: ["UI", "Snapshots", "Scripts", "Privacy", "Octree", "HMD", "Sixense Controllers"]
+    showCategories: ["UI", "Snapshots", "Scripts", "Privacy", "Octree", "HMD", "Sixense Controllers", "Perception Neuron"]
     property var settings: Settings {
         category: root.objectName
         property alias x: root.x

--- a/plugins/hifiNeuron/src/NeuronPlugin.h
+++ b/plugins/hifiNeuron/src/NeuronPlugin.h
@@ -28,6 +28,7 @@ public:
     bool isHandController() const override { return false; }
 
     // Plugin functions
+    virtual void init() override;
     virtual bool isSupported() const override;
     virtual const QString getName() const override { return NAME; }
     const QString getID() const override { return NEURON_ID_STRING; }
@@ -68,7 +69,8 @@ protected:
     static const char* NAME;
     static const char* NEURON_ID_STRING;
 
-    std::string _serverAddress;
+    bool _enabled;
+    QString _serverAddress;
     int _serverPort;
     void* _socketRef;
 


### PR DESCRIPTION
This PR disables this plugin by default because it is infrequently used and sometimes crashes on initialization if there is a TCP service already running on port 7001.

The plugin can be enabled via the General Preferences dialog.  The preferences also include fields for the server address and port.  NOTE: changes to these settings won't take effect until the next launch of interface.

To prevent the Neuron Plugin section showing up as the top section of the General Preferences dialog, a change was made to qml/dialogs/PreferencesDialog.qml which preserves the sort order of the showCategories array.
