### PR TITLE
Potentially address the crash when no vertex format is specified

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
@@ -81,23 +81,22 @@ void GL45Backend::updateInput() {
                 glVertexBindingDivisor(bufferChannelNum, frequency);
 #endif
             }
-
-
-            // Manage Activation what was and what is expected now
-            // This should only disable VertexAttribs since the one in use have been disabled above
-            for (GLuint i = 0; i < (GLuint)newActivation.size(); i++) {
-                bool newState = newActivation[i];
-                if (newState != _input._attributeActivation[i]) {
-                    if (newState) {
-                        glEnableVertexAttribArray(i);
-                    } else {
-                        glDisableVertexAttribArray(i);
-                    }
-                    _input._attributeActivation.flip(i);
-                }
-            }
-            (void)CHECK_GL_ERROR();
         }
+
+        // Manage Activation what was and what is expected now
+        // This should only disable VertexAttribs since the one needed by the vertex format (if it exists) have been enabled above
+        for (GLuint i = 0; i < (GLuint)newActivation.size(); i++) {
+            bool newState = newActivation[i];
+            if (newState != _input._attributeActivation[i]) {
+                if (newState) {
+                    glEnableVertexAttribArray(i);
+                } else {
+                    glDisableVertexAttribArray(i);
+                }
+                _input._attributeActivation.flip(i);
+            }
+        }
+        (void)CHECK_GL_ERROR();
 
         _input._invalidFormat = false;
         _stats._ISNumFormatChanges++;


### PR DESCRIPTION
IN gl45Backend , if no Input Format is specified, we wouldn't necessarily deactivate all the vertex attributes just like we do in the GL41Backend.
This could  be the reason for the crash with Polyline in the current RC

Test Plan:
There shouldn't be any performance or functional change with this PR.
