### PR TITLE
Add the robustness flag to the GL context in 4.5

### DIFF
--- a/libraries/gl/src/gl/Context.cpp
+++ b/libraries/gl/src/gl/Context.cpp
@@ -274,11 +274,14 @@ void Context::create() {
         contextAttribs.push_back(WGL_CONTEXT_PROFILE_MASK_ARB);
         contextAttribs.push_back(WGL_CONTEXT_CORE_PROFILE_BIT_ARB);
         contextAttribs.push_back(WGL_CONTEXT_FLAGS_ARB);
-        if (enableDebugLogger) {
-            contextAttribs.push_back(WGL_CONTEXT_DEBUG_BIT_ARB);
-        } else {
-            contextAttribs.push_back(0);
+        int flags = 0;
+        if (_version >= 0x0405) {
+            flags |= WGL_CONTEXT_ROBUST_ACCESS_BIT_ARB;
         }
+        if (enableDebugLogger) {
+            flags |= WGL_CONTEXT_DEBUG_BIT_ARB;
+        }
+        contextAttribs.push_back(flags);
         contextAttribs.push_back(0);
         auto shareHglrc = PRIMARY ? PRIMARY->_hglrc : 0;
         _hglrc = wglCreateContextAttribsARB(_hdc, shareHglrc, &contextAttribs[0]);


### PR DESCRIPTION
Add the robustness flag to the OpenGL context when it's a 4.5 context.  This should prevent crashes caused by invalid vertex or index buffer access, instead leaving the results of such invalid draws as undefined.  

## Testing

Testing should focus on the recent crashes in the nVidia drivers, which neither Sam nor I have been able to reproduce.  