### PR TITLE
add bind polyfill and basic .editorconfig for indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+# 4-space indentation
+[*]
+indent_style = space
+indent_size = 4

--- a/scripts/developer/libraries/utils.js
+++ b/scripts/developer/libraries/utils.js
@@ -6,6 +6,34 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+if (!Function.prototype.bind) {
+    Function.prototype.bind = function(oThis) {
+        if (typeof this !== 'function') {
+            // closest thing possible to the ECMAScript 5
+            // internal IsCallable function
+            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+        }
+
+        var aArgs   = Array.prototype.slice.call(arguments, 1),
+            fToBind = this,
+            fNOP    = function() {},
+            fBound  = function() {
+                return fToBind.apply(this instanceof fNOP
+                        ? this
+                        : oThis,
+                        aArgs.concat(Array.prototype.slice.call(arguments)));
+            };
+
+        if (this.prototype) {
+            // Function.prototype doesn't have a prototype property
+            fNOP.prototype = this.prototype; 
+        }
+        fBound.prototype = new fNOP();
+
+        return fBound;
+    };
+}
+
 vec3toStr = function(v, digits) {
     if (!digits) { digits = 3; }
     return "{ " + v.x.toFixed(digits) + ", " + v.y.toFixed(digits) + ", " + v.z.toFixed(digits)+ " }";

--- a/scripts/developer/libraries/utils.js
+++ b/scripts/developer/libraries/utils.js
@@ -6,34 +6,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-if (!Function.prototype.bind) {
-    Function.prototype.bind = function(oThis) {
-        if (typeof this !== 'function') {
-            // closest thing possible to the ECMAScript 5
-            // internal IsCallable function
-            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-        }
-
-        var aArgs   = Array.prototype.slice.call(arguments, 1),
-            fToBind = this,
-            fNOP    = function() {},
-            fBound  = function() {
-                return fToBind.apply(this instanceof fNOP
-                        ? this
-                        : oThis,
-                        aArgs.concat(Array.prototype.slice.call(arguments)));
-            };
-
-        if (this.prototype) {
-            // Function.prototype doesn't have a prototype property
-            fNOP.prototype = this.prototype; 
-        }
-        fBound.prototype = new fNOP();
-
-        return fBound;
-    };
-}
-
 vec3toStr = function(v, digits) {
     if (!digits) { digits = 3; }
     return "{ " + v.x.toFixed(digits) + ", " + v.y.toFixed(digits) + ", " + v.z.toFixed(digits)+ " }";

--- a/scripts/developer/tests/bindUnitTest.js
+++ b/scripts/developer/tests/bindUnitTest.js
@@ -1,0 +1,31 @@
+Script.include('../libraries/jasmine/jasmine.js');
+Script.include('../libraries/jasmine/hifi-boot.js');
+Script.include('../../system/libraries/utils.js');
+
+describe('Bind', function() {
+    it('functions should have bind available', function() {
+        var foo = 'bar';
+
+        function callAnotherFn(anotherFn) {
+            return anotherFn();
+        }
+
+        function TestConstructor() {
+            this.foo = foo;
+        }
+
+        TestConstructor.prototype.doSomething = function() {
+            return callAnotherFn(function() {
+                return this.foo;
+            }.bind(this));
+        }
+
+        var instance = new TestConstructor();
+        
+        expect(typeof(instance.doSomething.bind) !== 'undefined');
+        expect(instance.doSomething()).toEqual(foo);
+    });
+});
+
+jasmine.getEnv().execute();
+Script.stop();

--- a/scripts/developer/tests/bindUnitTest.js
+++ b/scripts/developer/tests/bindUnitTest.js
@@ -18,7 +18,7 @@ describe('Bind', function() {
             return callAnotherFn(function() {
                 return this.foo;
             }.bind(this));
-        }
+        };
 
         var instance = new TestConstructor();
         

--- a/scripts/system/libraries/utils.js
+++ b/scripts/system/libraries/utils.js
@@ -7,31 +7,31 @@
 //
 
 if (!Function.prototype.bind) {
-  Function.prototype.bind = function(oThis) {
+Function.prototype.bind = function(oThis) {
     if (typeof this !== 'function') {
-      // closest thing possible to the ECMAScript 5
-      // internal IsCallable function
-      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+        // closest thing possible to the ECMAScript 5
+        // internal IsCallable function
+        throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
     }
 
     var aArgs   = Array.prototype.slice.call(arguments, 1),
         fToBind = this,
         fNOP    = function() {},
         fBound  = function() {
-          return fToBind.apply(this instanceof fNOP
-                 ? this
-                 : oThis,
-                 aArgs.concat(Array.prototype.slice.call(arguments)));
+            return fToBind.apply(this instanceof fNOP
+                    ? this
+                    : oThis,
+                    aArgs.concat(Array.prototype.slice.call(arguments)));
         };
 
     if (this.prototype) {
-      // Function.prototype doesn't have a prototype property
-      fNOP.prototype = this.prototype; 
+        // Function.prototype doesn't have a prototype property
+        fNOP.prototype = this.prototype; 
     }
     fBound.prototype = new fNOP();
 
     return fBound;
-  };
+    };
 }
 
 vec3toStr = function(v, digits) {

--- a/scripts/system/libraries/utils.js
+++ b/scripts/system/libraries/utils.js
@@ -6,6 +6,34 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
+
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    if (this.prototype) {
+      // Function.prototype doesn't have a prototype property
+      fNOP.prototype = this.prototype; 
+    }
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}
+
 vec3toStr = function(v, digits) {
     if (!digits) { digits = 3; }
     return "{ " + v.x.toFixed(digits) + ", " + v.y.toFixed(digits) + ", " + v.z.toFixed(digits)+ " }";

--- a/scripts/system/libraries/utils.js
+++ b/scripts/system/libraries/utils.js
@@ -7,30 +7,30 @@
 //
 
 if (!Function.prototype.bind) {
-Function.prototype.bind = function(oThis) {
-    if (typeof this !== 'function') {
-        // closest thing possible to the ECMAScript 5
-        // internal IsCallable function
-        throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-    }
+    Function.prototype.bind = function(oThis) {
+        if (typeof this !== 'function') {
+            // closest thing possible to the ECMAScript 5
+            // internal IsCallable function
+            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+        }
 
-    var aArgs   = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP    = function() {},
-        fBound  = function() {
-            return fToBind.apply(this instanceof fNOP
-                    ? this
-                    : oThis,
-                    aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
+        var aArgs   = Array.prototype.slice.call(arguments, 1),
+            fToBind = this,
+            fNOP    = function() {},
+            fBound  = function() {
+                return fToBind.apply(this instanceof fNOP
+                        ? this
+                        : oThis,
+                        aArgs.concat(Array.prototype.slice.call(arguments)));
+            };
 
-    if (this.prototype) {
-        // Function.prototype doesn't have a prototype property
-        fNOP.prototype = this.prototype; 
-    }
-    fBound.prototype = new fNOP();
+        if (this.prototype) {
+            // Function.prototype doesn't have a prototype property
+            fNOP.prototype = this.prototype; 
+        }
+        fBound.prototype = new fNOP();
 
-    return fBound;
+        return fBound;
     };
 }
 


### PR DESCRIPTION
`bind` is a must for modern Javascript development. Having it available to scripts including `utils.js` seems like a reasonable thing. It avoids having to include the polyfill in every script that may need it, like [here](https://github.com/highfidelity/hifi/blob/030f0d71036e0c6e3940b3c2d899727e3bda10f6/tutorial/tutorial.js#L15-L41). It's a best practice to use this over the clunky `that`/`this` thing that was a precursor to binding the context.

My implementation is a straight copy from the [MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).

I've also included an [editorconfig](https://github.com/Polyrhythm/hifi/blob/68e86da023fbc48880e123c930874c253bbb8abf/.editorconfig) file which can go some length towards normalizing indentation settings for the repo. It works in many IDEs seamlessly.

**QA**:
1. Open `scripts/developer/tests/bindUnitTest.js` in the Script Editor within Interface.
1. Toggle run the script and observe in the debug log that the test passes.