### PR TITLE
fixed context menu showing up in the correct location with oculus touch

### DIFF
--- a/interface/resources/controllers/oculus_touch.json
+++ b/interface/resources/controllers/oculus_touch.json
@@ -3,6 +3,8 @@
     "channels": [
         { "from": "OculusTouch.A", "to": "Standard.RightPrimaryThumb", "peek": true },
         { "from": "OculusTouch.X", "to": "Standard.LeftPrimaryThumb", "peek": true },
+        { "from": "OculusTouch.B", "to": "Standard.RightSecondaryThumb", "peek": true},
+        { "from": "OculusTouch.Y", "to": "Standard.LeftSecondaryThumb", "peek": true},
 
         { "from": "OculusTouch.A", "to": "Standard.A" },
         { "from": "OculusTouch.B", "to": "Standard.B" },


### PR DESCRIPTION
Making the context menu show up where the oculus controller is pointing towards.

To Test

1. using oculus touch controller and in HMD mode.
2, when pressing B or Y on the touch controller the context menu should appear in the direction you are pointing in.  