### PR TITLE
Vec3 and shader helpers

### DIFF
--- a/libraries/procedural/src/procedural/ProceduralCommon.slf
+++ b/libraries/procedural/src/procedural/ProceduralCommon.slf
@@ -264,6 +264,37 @@ float snoise(vec2 v) {
     return 130.0 * dot(m, g);
 }
 
+// https://www.shadertoy.com/view/lsfGRr
+float hash( float n )
+{
+    return fract(sin(n)*43758.5453);
+}
+
+float noise( in vec2 x )
+{
+    vec2 p = floor(x);
+    vec2 f = fract(x);
+
+    f = f*f*(3.0-2.0*f);
+
+    float n = p.x + p.y*57.0;
+
+    return mix(mix( hash(n+  0.0), hash(n+  1.0),f.x),
+               mix( hash(n+ 57.0), hash(n+ 58.0),f.x),f.y);
+}
+
+// https://www.shadertoy.com/view/MdX3Rr
+// https://en.wikipedia.org/wiki/Fractional_Brownian_motion
+float fbm(in vec2 p) {
+	const mat2 m2 = mat2(0.8, -0.6, 0.6, 0.8);
+	float f = 0.0;
+	f += 0.5000 * noise(p); p = m2 * p * 2.02;
+	f += 0.2500 * noise(p); p = m2 * p * 2.03;
+	f += 0.1250 * noise(p); p = m2 * p * 2.01;
+	f += 0.0625 * noise(p);
+
+	return f / 0.9375;
+}
 
 #define PROCEDURAL 1
 

--- a/libraries/procedural/src/procedural/ProceduralCommon.slf
+++ b/libraries/procedural/src/procedural/ProceduralCommon.slf
@@ -265,33 +265,31 @@ float snoise(vec2 v) {
 }
 
 // https://www.shadertoy.com/view/lsfGRr
-float hash( float n )
-{
-    return fract(sin(n)*43758.5453);
+float hifi_hash(float n) {
+    return fract(sin(n) * 43758.5453);
 }
 
-float noise( in vec2 x )
-{
+float hifi_noise(in vec2 x) {
     vec2 p = floor(x);
     vec2 f = fract(x);
 
-    f = f*f*(3.0-2.0*f);
+    f = f * f * (3.0 - 2.0 * f);
 
-    float n = p.x + p.y*57.0;
+    float n = p.x + p.y * 57.0;
 
-    return mix(mix( hash(n+  0.0), hash(n+  1.0),f.x),
-               mix( hash(n+ 57.0), hash(n+ 58.0),f.x),f.y);
+    return mix(mix(hifi_hash(n +  0.0), hifi_hash(n +  1.0), f.x),
+               mix(hifi_hash(n + 57.0), hifi_hash(n + 58.0), f.x), f.y);
 }
 
 // https://www.shadertoy.com/view/MdX3Rr
 // https://en.wikipedia.org/wiki/Fractional_Brownian_motion
-float fbm(in vec2 p) {
+float hifi_fbm(in vec2 p) {
 	const mat2 m2 = mat2(0.8, -0.6, 0.6, 0.8);
 	float f = 0.0;
-	f += 0.5000 * noise(p); p = m2 * p * 2.02;
-	f += 0.2500 * noise(p); p = m2 * p * 2.03;
-	f += 0.1250 * noise(p); p = m2 * p * 2.01;
-	f += 0.0625 * noise(p);
+	f += 0.5000 * hifi_noise(p); p = m2 * p * 2.02;
+	f += 0.2500 * hifi_noise(p); p = m2 * p * 2.03;
+	f += 0.1250 * hifi_noise(p); p = m2 * p * 2.01;
+	f += 0.0625 * hifi_noise(p);
 
 	return f / 0.9375;
 }

--- a/libraries/script-engine/src/Vec3.cpp
+++ b/libraries/script-engine/src/Vec3.cpp
@@ -83,15 +83,7 @@ glm::vec3 Vec3::fromPolar(float elevation, float azimuth) {
     return fromPolar(v);
 }
 
-float Vec3::angle(const glm::vec3& fromV, const glm::vec3& toV) {
-	glm::vec3 fromVNormalized = glm::normalize(fromV);
-	glm::vec3 toVNormalized = glm::normalize(toV);
-
-	float radians = glm::acos(glm::dot(fromVNormalized, toVNormalized));
-
-	return radians * 180.0f / PI;
+float Vec3::getAngle(const glm::vec3& v1, const glm::vec3& v2) {
+	return glm::acos(glm::dot(glm::normalize(v1), glm::normalize(v2)));
 }
 
-glm::vec3 Vec3::lerp(const glm::vec3& v1, const glm::vec3& v2, float t) {
-	return v1 * (1.0f - t) + v2 * t;
-}

--- a/libraries/script-engine/src/Vec3.cpp
+++ b/libraries/script-engine/src/Vec3.cpp
@@ -82,3 +82,16 @@ glm::vec3 Vec3::fromPolar(float elevation, float azimuth) {
     glm::vec3 v = glm::vec3(elevation, azimuth, 1.0f);
     return fromPolar(v);
 }
+
+float Vec3::angle(const glm::vec3& fromV, const glm::vec3& toV) {
+	glm::vec3 fromVNormalized = glm::normalize(fromV);
+	glm::vec3 toVNormalized = glm::normalize(toV);
+
+	float radians = glm::acos(glm::dot(fromVNormalized, toVNormalized));
+
+	return radians * 180.0f / PI;
+}
+
+glm::vec3 Vec3::lerp(const glm::vec3& v1, const glm::vec3& v2, float t) {
+	return v1 * (1.0f - t) + v2 * t;
+}

--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -83,6 +83,8 @@ public slots:
     glm::vec3 toPolar(const glm::vec3& v);
     glm::vec3 fromPolar(const glm::vec3& polar);
     glm::vec3 fromPolar(float elevation, float azimuth);
+	float angle(const glm::vec3& fromV, const glm::vec3& toV);
+	glm::vec3 lerp(const glm::vec3& v1, const glm::vec3& v2, float t);
 
 private:
     const glm::vec3& UNIT_X() { return Vectors::UNIT_X; }

--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -83,8 +83,7 @@ public slots:
     glm::vec3 toPolar(const glm::vec3& v);
     glm::vec3 fromPolar(const glm::vec3& polar);
     glm::vec3 fromPolar(float elevation, float azimuth);
-    float angle(const glm::vec3& fromV, const glm::vec3& toV);
-    glm::vec3 lerp(const glm::vec3& v1, const glm::vec3& v2, float t);
+    float getAngle(const glm::vec3& v1, const glm::vec3& v2);
 
 private:
     const glm::vec3& UNIT_X() { return Vectors::UNIT_X; }

--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -83,8 +83,8 @@ public slots:
     glm::vec3 toPolar(const glm::vec3& v);
     glm::vec3 fromPolar(const glm::vec3& polar);
     glm::vec3 fromPolar(float elevation, float azimuth);
-	float angle(const glm::vec3& fromV, const glm::vec3& toV);
-	glm::vec3 lerp(const glm::vec3& v1, const glm::vec3& v2, float t);
+    float angle(const glm::vec3& fromV, const glm::vec3& toV);
+    glm::vec3 lerp(const glm::vec3& v1, const glm::vec3& v2, float t);
 
 private:
     const glm::vec3& UNIT_X() { return Vectors::UNIT_X; }


### PR DESCRIPTION
**Vec3.getAngle** (in radians) - handy for telling if an entity is facing within EPSILON radians of a given direction

**fbm** - classic noise algo for shaders that produces awesome cloud-like effects. Will probably be very popular for hifi modders for messing with skyboxes. 

**QA**:
Add a sphere entity with the following `userData`:

```
{
  "ProceduralEntity": {
    "version": 2,
    "shaderUrl": "https://raw.githubusercontent.com/Polyrhythm/hifi-scripts/master/clouds.fs"
  }
}
```

You should get a sphere that looks like this:

![fbm-noise](https://cloud.githubusercontent.com/assets/1242927/20734104/2c995004-b64c-11e6-82f4-19ebd8a4fe09.gif)

This tests the shader helpers I added.

