### PR TITLE
Fix a bug when using the gpu::Batch::_glUniform*() calls  with a bad location

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLShader.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLShader.h
@@ -41,7 +41,7 @@ public:
     }
 
     GLint getUniformLocation(GLint srcLoc, Version version = Mono) const {
-        // THIS will be used in the future PR as we grow the number of versions
+        // This check protect against potential invalid src location for this shader, if unknown then return -1.
         const auto& mapping = _uniformMappings[version];
         auto found = mapping.find(srcLoc);
         if (found == mapping.end()) {

--- a/libraries/gpu-gl/src/gpu/gl/GLShader.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLShader.h
@@ -40,10 +40,14 @@ public:
         return _shaderObjects[version].glprogram;
     }
 
-    GLint getUniformLocation(GLint srcLoc, Version version = Mono) {
+    GLint getUniformLocation(GLint srcLoc, Version version = Mono) const {
         // THIS will be used in the future PR as we grow the number of versions
-        return _uniformMappings[version][srcLoc];
-       // return srcLoc;
+        const auto& mapping = _uniformMappings[version];
+        auto found = mapping.find(srcLoc);
+        if (found == mapping.end()) {
+            return -1;
+        }
+        return found->second;
     }
 
     const std::weak_ptr<GLBackend> _backend;


### PR DESCRIPTION
When using the _glUnfirm calls on the gpu::Batch with a bad location (unknown from the shader uniforms) then in the corresponding glBackend::do_glUniform*() we are going through the uniform bindding mapping table in the GLShader looking for the invalid location. this would return 0 by default which could cause bad effects,
Did a more conservative test instead to avoid the behavior.

Test Plan:
Smoke test in desktop and hmd should be good.

Potentially this is the root cause for some of the recent bugs happening in the current RC.
SInce i don;t have a definitive repro for it (try going to eschatology...?) i wasn;'t able to confirm that theory.