### PR TITLE
Fixed pressing the grip button causes a near grabbed object to drop

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1012,7 +1012,7 @@ function MyController(hand) {
 
         // The value to check if we will allow the release function to be called
         var allowReleaseValue = 0.1;
-        if (value > 0 && _this.rawTriggerValue <= allowReleaseValue) {
+        if (value > 0 && _this.state == STATE_HOLD) {
             _this.release();
         }
     };

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1009,7 +1009,10 @@ function MyController(hand) {
 
     this.secondaryPress = function(value) {
         _this.rawSecondaryValue = value;
-        if (value > 0) {
+
+        // The value to check if we will allow the release function to be called
+        var allowReleaseValue = 0.1;
+        if (value > 0 && _this.rawTriggerValue <= allowReleaseValue) {
             _this.release();
         }
     };

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2346,6 +2346,7 @@ function MyController(hand) {
                 this.callEntityMethodOnGrabbed("releaseEquip");
             }
 
+
             //  Make a small release haptic pulse if we really were holding something
             Controller.triggerHapticPulse(HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, this.hand);
 

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2349,7 +2349,6 @@ function MyController(hand) {
                 this.callEntityMethodOnGrabbed("releaseEquip");
             }
 
-
             //  Make a small release haptic pulse if we really were holding something
             Controller.triggerHapticPulse(HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, this.hand);
 


### PR DESCRIPTION
To Test
1. near or far grab an object...when pressing the grip button...the grabbed object should not be dropped
2. equip an object and pressing the grip button should drop the object.

fogbugz - https://highfidelity.fogbugz.com/f/cases/2368/Grip-button-causes-you-to-drop-a-near-grabbed-object