### PR TITLE
Fix a crash if current shader is null

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
@@ -406,7 +406,7 @@ void GLBackend::do_popProfileRange(const Batch& batch, size_t paramOffset) {
 
 // As long as we don;t use several versions of shaders we can avoid this more complex code path
 #ifdef GPU_STEREO_CAMERA_BUFFER
-#define GET_UNIFORM_LOCATION(shaderUniformLoc) _pipeline._programShader->getUniformLocation(shaderUniformLoc, (GLShader::Version) isStereo())
+#define GET_UNIFORM_LOCATION(shaderUniformLoc) ((_pipeline._programShader) ? _pipeline._programShader->getUniformLocation(shaderUniformLoc, (GLShader::Version) isStereo()) : -1)
 #else
 #define GET_UNIFORM_LOCATION(shaderUniformLoc) shaderUniformLoc
 #endif


### PR DESCRIPTION
This PR fixes a potential crash happening when a non compiled shader is used (and failed to compile) and a "_glUniform" is assigned on it.
This could be the case with procedural shaders failing to compile and beeing rendered. Their rendering sequence will potentially assign uniform values. THat s where we would get a crash.

Test Plan:
In current RC, some user experience a crash going to eschatology or looking at an entity with a failing procedural shader.
With this PR, this should be solved

THis should happen regardless of beeing desktop / HMD ( need to check both).

Smoke test otherwise, performances and quality should be the same

