### PR TITLE
Fixes for building on MSVC 2015 / Qt 5.8

### DIFF
--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -147,15 +147,15 @@ QString getCollisionGroupAsString(uint8_t group) {
 }
 
 uint8_t getCollisionGroupAsBitMask(const QStringRef& name) {
-    if (0 == name.compare("dynamic")) {
+    if (0 == name.compare(QString("dynamic"))) {
         return USER_COLLISION_GROUP_DYNAMIC;
-    } else if (0 == name.compare("static")) {
+    } else if (0 == name.compare(QString("static"))) {
         return USER_COLLISION_GROUP_STATIC;
-    } else if (0 == name.compare("kinematic")) {
+    } else if (0 == name.compare(QString("kinematic"))) {
         return USER_COLLISION_GROUP_KINEMATIC;
-    } else if (0 == name.compare("myAvatar")) {
+    } else if (0 == name.compare(QString("myAvatar"))) {
         return USER_COLLISION_GROUP_MY_AVATAR;
-    } else if (0 == name.compare("otherAvatar")) {
+    } else if (0 == name.compare(QString("otherAvatar"))) {
         return USER_COLLISION_GROUP_OTHER_AVATAR;
     }
     return 0;

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -26,6 +26,15 @@
 #include <windows.h>
 #include "CPUIdent.h"
 #include <Psapi.h>
+
+#if _MSC_VER >= 1900
+#pragma comment(lib, "legacy_stdio_definitions.lib")
+FILE _iob[] = {*stdin, *stdout, *stderr};
+extern "C" FILE * __cdecl __iob_func(void) {
+    return _iob;
+}
+#endif
+
 #endif
 
 

--- a/tests/render-perf/src/main.cpp
+++ b/tests/render-perf/src/main.cpp
@@ -1086,7 +1086,7 @@ private:
     QSize _size;
     QSettings _settings;
 
-    std::atomic<size_t> _renderCount;
+    std::atomic<size_t> _renderCount{ 0 };
     gl::OffscreenContext _initContext;
     RenderThread _renderThread;
     QWindowCamera _camera;
@@ -1152,3 +1152,4 @@ int main(int argc, char** argv) {
 }
 
 #include "main.moc"
+


### PR DESCRIPTION
These are the required changes for enabling builds on Qt 5.8 and Visual Studio 2015.

The `#pragma comment(lib, "legacy_stdio_definitions.lib")` line ensures that functions which used to be exported from previous versions of the C stdio library, but are now inline still exist as linkable.  This is required because the OpenSSL binaries we rely on link against these functions.  

The remaining changes resolve compile errors or fix uninitialized variables.

## Testing

Smoke test only.  These changes should have no impact on application behavior or performance.