### PR TITLE
GIFs: Quality improvements; duration tweaks; processing notif

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -62,6 +62,7 @@ signals:
     void domainConnectionRefused(const QString& reasonMessage, int reasonCode, const QString& extraInfo);
     void snapshotTaken(const QString& pathStillSnapshot, const QString& pathAnimatedSnapshot, bool notify);
     void snapshotShared(const QString& error);
+    void processingGif();
 
 private:
     QString getPreviousBrowseLocation() const;

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -105,8 +105,8 @@ void setupPreferences() {
         auto getter = []()->float { return SnapshotAnimated::snapshotAnimatedDuration.get(); };
         auto setter = [](float value) { SnapshotAnimated::snapshotAnimatedDuration.set(value); };
         auto preference = new SpinnerPreference(SNAPSHOTS, "Animated Snapshot Duration", getter, setter);
-        preference->setMin(3);
-        preference->setMax(10);
+        preference->setMin(1);
+        preference->setMax(5);
         preference->setStep(1);
         preferences->addPreference(preference);
     }

--- a/interface/src/ui/SnapshotAnimated.cpp
+++ b/interface/src/ui/SnapshotAnimated.cpp
@@ -92,6 +92,9 @@ void SnapshotAnimated::captureFrames() {
                 SnapshotAnimated::snapshotAnimatedTimestamp = 0;
                 SnapshotAnimated::snapshotAnimatedFirstFrameTimestamp = 0;
 
+                // Notify the user that we're processing the snapshot
+                emit SnapshotAnimated::snapshotAnimatedDM->processingGif();
+
                 // Kick off the thread that'll pack the frames into the GIF
                 QtConcurrent::run(processFrames);
                 // Stop the snapshot QTimer. This action by itself DOES NOT GUARANTEE

--- a/interface/src/ui/SnapshotAnimated.h
+++ b/interface/src/ui/SnapshotAnimated.h
@@ -21,8 +21,8 @@
 #include "scripting/WindowScriptingInterface.h"
 
 // If the snapshot width or the framerate are too high for the
-// application to handle, the framerate of the output GIF will drop.
-#define SNAPSNOT_ANIMATED_WIDTH (480)
+// computer to handle, the framerate of the output GIF will drop.
+#define SNAPSNOT_ANIMATED_WIDTH (720)
 // This value should divide evenly into 100. Snapshot framerate is NOT guaranteed.
 #define SNAPSNOT_ANIMATED_TARGET_FRAMERATE (25)
 #define SNAPSNOT_ANIMATED_DURATION_SECS (3)

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -532,6 +532,10 @@ function onSnapshotTaken(pathStillSnapshot, pathAnimatedSnapshot, notify) {
     }
 }
 
+function processingGif() {
+    createNotification("Processing GIF snapshot...", NotificationType.SNAPSHOT);
+}
+
 //  handles mouse clicks on buttons
 function mousePressEvent(event) {
     var pickRay,
@@ -631,6 +635,7 @@ Script.scriptEnding.connect(scriptEnding);
 Menu.menuItemEvent.connect(menuItemEvent);
 Window.domainConnectionRefused.connect(onDomainConnectionRefused);
 Window.snapshotTaken.connect(onSnapshotTaken);
+Window.processingGif.connect(processingGif);
 Window.notifyEditError = onEditError;
 
 setup();

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -156,19 +156,22 @@ function isDomainOpen(id) {
 }
 
 function resetButtons(pathStillSnapshot, pathAnimatedSnapshot, notify) {
-    // show hud
-    toolBar.writeProperty("visible", true);
-    Reticle.visible = reticleVisible;
-    
+    // If we're not taking an animated snapshot, we have to show the HUD.
+    // If we ARE taking an animated snapshot, we've already re-enabled the HUD by this point.
+    if (pathAnimatedSnapshot === "") {
+        // show hud
+        toolBar.writeProperty("visible", true);
+        Reticle.visible = reticleVisible;
+        // show overlays if they were on
+        if (resetOverlays) {
+            Menu.setIsOptionChecked("Overlays", true);
+        }
+    }
     // update button states
     button.writeProperty("buttonState", 1);
     button.writeProperty("defaultState", 1);
     button.writeProperty("hoverState", 3);
     Window.snapshotTaken.disconnect(resetButtons);
-    // show overlays if they were on
-    if (resetOverlays) {
-        Menu.setIsOptionChecked("Overlays", true);
-    }
 
     // A Snapshot Review dialog might be left open indefinitely after taking the picture,
     // during which time the user may have moved. So stash that info in the dialog so that
@@ -187,13 +190,30 @@ function resetButtons(pathStillSnapshot, pathAnimatedSnapshot, notify) {
     }
 }
 
+function processingGif() {
+    // show hud
+    toolBar.writeProperty("visible", true);
+    Reticle.visible = reticleVisible;
+
+    // update button states
+    button.writeProperty("buttonState", 1);
+    button.writeProperty("defaultState", 1);
+    button.writeProperty("hoverState", 3);
+    // show overlays if they were on
+    if (resetOverlays) {
+        Menu.setIsOptionChecked("Overlays", true);
+    }
+}
+
 button.clicked.connect(onClicked);
 Window.snapshotShared.connect(snapshotShared);
+Window.processingGif.connect(processingGif);
 
 Script.scriptEnding.connect(function () {
     toolBar.removeButton("snapshot");
     button.clicked.disconnect(onClicked);
     Window.snapshotShared.disconnect(snapshotShared);
+    Window.processingGif.disconnect(processingGif);
 });
 
 }()); // END LOCAL_SCOPE


### PR DESCRIPTION
A quick PR to help improve the Animated Snapshot feature.

What this does:
- Improve the quality of the GIFs by increasing their width to 720px (up from 480px)
- Allow users to select the duration of the GIFs from 1 second to 5 seconds (change from 3 seconds to 10 seconds)
- Re-enable the HUD after the frames have captured, then show a "GIF Processing..." notification, then display the Share menu once the GIF has actually been created. This prevents some potential confusion due to the waiting period between pressing the "Snapshot" button and actually seeing your snapshot (which is now a tiny bit longer because the frames are bigger).

What this PR doesn't do:
- Improve the Share dialog (@AlanZimmerman is working on a concept for that)

I'm fairly certain QA beyond what I've done is largely unnecessary, but, as a quick smoke test: Try capturing an animated snapshot in an HMD, then sharing it to the Metaverse feed. Note the new "Processing" notification.