### PR TITLE
Possible polyline crash fix

### DIFF
--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -161,8 +161,14 @@ void RenderablePolyLineEntityItem::update(const quint64& now) {
     uniforms.color = toGlm(getXColor());
     memcpy(&_uniformBuffer.edit<PolyLineUniforms>(), &uniforms, sizeof(PolyLineUniforms));
     if (_pointsChanged || _strokeWidthsChanged || _normalsChanged) {
-        updateVertices();
-        updateGeometry();
+        QWriteLocker lock(&_quadReadWriteLock);
+        if (_points.size() < 2 || _normals.size() < 2 || _strokeWidths.size() < 2) {
+            _empty = true;
+        }
+        if (!_empty) {
+            updateVertices();
+            updateGeometry();
+        }
     }
 
 }
@@ -170,8 +176,7 @@ void RenderablePolyLineEntityItem::update(const quint64& now) {
 void RenderablePolyLineEntityItem::render(RenderArgs* args) {
     checkFading();
 
-    QWriteLocker lock(&_quadReadWriteLock);
-    if (_points.size() < 2 || _normals.size () < 2 || _strokeWidths.size() < 2) {
+    if (_empty) {
         return;
     }
 

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -162,9 +162,7 @@ void RenderablePolyLineEntityItem::update(const quint64& now) {
     memcpy(&_uniformBuffer.edit<PolyLineUniforms>(), &uniforms, sizeof(PolyLineUniforms));
     if (_pointsChanged || _strokeWidthsChanged || _normalsChanged) {
         QWriteLocker lock(&_quadReadWriteLock);
-        if (_points.size() < 2 || _normals.size() < 2 || _strokeWidths.size() < 2) {
-            _empty = true;
-        }
+        _empty = (_points.size() < 2 || _normals.size() < 2 || _strokeWidths.size() < 2);
         if (!_empty) {
             updateVertices();
             updateGeometry();

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
@@ -50,6 +50,7 @@ protected:
     gpu::BufferPointer _verticesBuffer;
     gpu::BufferView _uniformBuffer;
     unsigned int _numVertices;
+    bool _empty { true };
     QVector<glm::vec3> _vertices;
 };
 


### PR DESCRIPTION
The current code uses a `QReadWriteLock` to protect access to the Polyline points, normals and widths...  however, this lock isn't used around the code that reads these members and uses them to update the vertex buffer.  If there's a race condition and one of the points, normals or widths are being modified while the renderable geometry is being updated then pretty much anything could happen.  