### PR TITLE
Client script test runner

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -589,7 +589,9 @@ Menu::Menu() {
     #endif
 
     
-
+	// Developer >> Tests >>>
+	MenuWrapper* testMenu = developerMenu->addMenu("Tests");
+	addActionToQMenuAndActionHash(testMenu, MenuOption::RunClientScriptTests, 0, dialogsManager.data(), SLOT(showTestingResults()));
 
     // Developer > Timing >>>
     MenuWrapper* timingMenu = developerMenu->addMenu("Timing");

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -589,9 +589,9 @@ Menu::Menu() {
     #endif
 
     
-	// Developer >> Tests >>>
-	MenuWrapper* testMenu = developerMenu->addMenu("Tests");
-	addActionToQMenuAndActionHash(testMenu, MenuOption::RunClientScriptTests, 0, dialogsManager.data(), SLOT(showTestingResults()));
+    // Developer >> Tests >>>
+    MenuWrapper* testMenu = developerMenu->addMenu("Tests");
+    addActionToQMenuAndActionHash(testMenu, MenuOption::RunClientScriptTests, 0, dialogsManager.data(), SLOT(showTestingResults()));
 
     // Developer > Timing >>>
     MenuWrapper* timingMenu = developerMenu->addMenu("Timing");

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -172,6 +172,7 @@ namespace MenuOption {
     const QString ResetAvatarSize = "Reset Avatar Size";
     const QString ResetSensors = "Reset Sensors";
     const QString RunningScripts = "Running Scripts...";
+	const QString RunClientScriptTests = "Run Client Script Tests";
     const QString RunTimingTests = "Run Timing Tests";
     const QString ScriptEditor = "Script Editor...";
     const QString ScriptedMotorControl = "Enable Scripted Motor Control";

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -172,7 +172,7 @@ namespace MenuOption {
     const QString ResetAvatarSize = "Reset Avatar Size";
     const QString ResetSensors = "Reset Sensors";
     const QString RunningScripts = "Running Scripts...";
-	const QString RunClientScriptTests = "Run Client Script Tests";
+    const QString RunClientScriptTests = "Run Client Script Tests";
     const QString RunTimingTests = "Run Timing Tests";
     const QString ScriptEditor = "Script Editor...";
     const QString ScriptedMotorControl = "Enable Scripted Motor Control";

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -158,6 +158,15 @@ void DialogsManager::showScriptEditor() {
     _scriptEditor->raise();
 }
 
+void DialogsManager::showTestingResults() {
+	if (!_testingDialog) {
+		_testingDialog = new TestingDialog(qApp->getWindow());
+		connect(_testingDialog, SIGNAL(closed()), _testingDialog, SLOT(deleteLater()));
+	}
+	_testingDialog->show();
+	_testingDialog->raise();
+}
+
 void DialogsManager::showDomainConnectionDialog() {
     // if the dialog already exists we delete it so the connection data is refreshed
     if (_domainConnectionDialog) {

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -159,12 +159,12 @@ void DialogsManager::showScriptEditor() {
 }
 
 void DialogsManager::showTestingResults() {
-	if (!_testingDialog) {
-		_testingDialog = new TestingDialog(qApp->getWindow());
-		connect(_testingDialog, SIGNAL(closed()), _testingDialog, SLOT(deleteLater()));
-	}
-	_testingDialog->show();
-	_testingDialog->raise();
+    if (!_testingDialog) {
+        _testingDialog = new TestingDialog(qApp->getWindow());
+        connect(_testingDialog, SIGNAL(closed()), _testingDialog, SLOT(deleteLater()));
+    }
+    _testingDialog->show();
+    _testingDialog->raise();
 }
 
 void DialogsManager::showDomainConnectionDialog() {

--- a/interface/src/ui/DialogsManager.h
+++ b/interface/src/ui/DialogsManager.h
@@ -40,7 +40,7 @@ public:
     QPointer<HMDToolsDialog> getHMDToolsDialog() const { return _hmdToolsDialog; }
     QPointer<LodToolsDialog> getLodToolsDialog() const { return _lodToolsDialog; }
     QPointer<OctreeStatsDialog> getOctreeStatsDialog() const { return _octreeStatsDialog; }
-	QPointer<TestingDialog> getTestingDialog() const { return _testingDialog; }
+    QPointer<TestingDialog> getTestingDialog() const { return _testingDialog; }
     void emitAddressBarShown(bool visible) { emit addressBarShown(visible); }
 
 public slots:
@@ -58,7 +58,7 @@ public slots:
     void hmdTools(bool showTools);
     void showScriptEditor();
     void showDomainConnectionDialog();
-	void showTestingResults();
+    void showTestingResults();
     
     // Application Update
     void showUpdateDialog();
@@ -87,7 +87,7 @@ private:
     QPointer<LodToolsDialog> _lodToolsDialog;
     QPointer<OctreeStatsDialog> _octreeStatsDialog;
     QPointer<ScriptEditorWindow> _scriptEditor;
-	QPointer<TestingDialog> _testingDialog;
+    QPointer<TestingDialog> _testingDialog;
     QPointer<DomainConnectionDialog> _domainConnectionDialog;
 };
 

--- a/interface/src/ui/DialogsManager.h
+++ b/interface/src/ui/DialogsManager.h
@@ -17,6 +17,7 @@
 #include <DependencyManager.h>
 
 #include "HMDToolsDialog.h"
+#include "TestingDialog.h"
 
 class AnimationsDialog;
 class AttachmentsDialog;
@@ -26,6 +27,7 @@ class DiskCacheEditor;
 class LodToolsDialog;
 class OctreeStatsDialog;
 class ScriptEditorWindow;
+class TestingDialog;
 class QMessageBox;
 class DomainConnectionDialog;
 
@@ -38,6 +40,7 @@ public:
     QPointer<HMDToolsDialog> getHMDToolsDialog() const { return _hmdToolsDialog; }
     QPointer<LodToolsDialog> getLodToolsDialog() const { return _lodToolsDialog; }
     QPointer<OctreeStatsDialog> getOctreeStatsDialog() const { return _octreeStatsDialog; }
+	QPointer<TestingDialog> getTestingDialog() const { return _testingDialog; }
     void emitAddressBarShown(bool visible) { emit addressBarShown(visible); }
 
 public slots:
@@ -55,6 +58,7 @@ public slots:
     void hmdTools(bool showTools);
     void showScriptEditor();
     void showDomainConnectionDialog();
+	void showTestingResults();
     
     // Application Update
     void showUpdateDialog();
@@ -83,6 +87,7 @@ private:
     QPointer<LodToolsDialog> _lodToolsDialog;
     QPointer<OctreeStatsDialog> _octreeStatsDialog;
     QPointer<ScriptEditorWindow> _scriptEditor;
+	QPointer<TestingDialog> _testingDialog;
     QPointer<DomainConnectionDialog> _domainConnectionDialog;
 };
 

--- a/interface/src/ui/TestingDialog.cpp
+++ b/interface/src/ui/TestingDialog.cpp
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <ScriptEngines.h>
+#include "ScriptEngines.h"
 
 #include "ui/TestingDialog.h"
 #include "Application.h"
@@ -17,19 +17,23 @@
 TestingDialog::TestingDialog(QWidget* parent) :
 	QDialog(parent, Qt::Window | Qt::WindowCloseButtonHint | Qt::WindowStaysOnTopHint)
 {
-	DependencyManager::get<ScriptEngines>()->loadOneScript(qApp->applicationDirPath() + testRunnerRelativePath);
-	this->setWindowTitle(windowLabel);
+	setAttribute(Qt::WA_DeleteOnClose);
+	setWindowTitle(windowLabel);
+
+	_console = new JSConsole(this);
+	_console->setFixedHeight(TESTING_CONSOLE_HEIGHT);
+
+	auto _engines = DependencyManager::get<ScriptEngines>();
+	_engine = _engines->loadScript(qApp->applicationDirPath() + testRunnerRelativePath);
+	_console->setScriptEngine(_engine);
+	connect(_engine, &ScriptEngine::finished, this, &TestingDialog::onTestingFinished);
 }
 
 TestingDialog::~TestingDialog() {
-	// TODO: Clean up here?
+	delete _console;
 }
 
-void TestingDialog::reject() {
-	this->QDialog::close();
-}
-
-void TestingDialog::closeEvent(QCloseEvent* event) {
-	this->QDialog::closeEvent(event);
-	emit closed();
+void TestingDialog::onTestingFinished(const QString& scriptPath) {
+	_engine = NULL;
+	_console->setScriptEngine(NULL);
 }

--- a/interface/src/ui/TestingDialog.cpp
+++ b/interface/src/ui/TestingDialog.cpp
@@ -1,0 +1,35 @@
+//
+//  TestingDialog.cpp
+//  interface/src/ui
+//
+//  Created by Ryan Jones on 12/3/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <ScriptEngines.h>
+
+#include "ui/TestingDialog.h"
+#include "Application.h"
+
+TestingDialog::TestingDialog(QWidget* parent) :
+	QDialog(parent, Qt::Window | Qt::WindowCloseButtonHint | Qt::WindowStaysOnTopHint)
+{
+	DependencyManager::get<ScriptEngines>()->loadOneScript(qApp->applicationDirPath() + testRunnerRelativePath);
+	this->setWindowTitle(windowLabel);
+}
+
+TestingDialog::~TestingDialog() {
+	// TODO: Clean up here?
+}
+
+void TestingDialog::reject() {
+	this->QDialog::close();
+}
+
+void TestingDialog::closeEvent(QCloseEvent* event) {
+	this->QDialog::closeEvent(event);
+	emit closed();
+}

--- a/interface/src/ui/TestingDialog.cpp
+++ b/interface/src/ui/TestingDialog.cpp
@@ -15,25 +15,21 @@
 #include "Application.h"
 
 TestingDialog::TestingDialog(QWidget* parent) :
-	QDialog(parent, Qt::Window | Qt::WindowCloseButtonHint | Qt::WindowStaysOnTopHint)
+    QDialog(parent, Qt::Window | Qt::WindowCloseButtonHint | Qt::WindowStaysOnTopHint),
+    _console(new JSConsole(this))
 {
-	setAttribute(Qt::WA_DeleteOnClose);
-	setWindowTitle(windowLabel);
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle(windowLabel);
 
-	_console = new JSConsole(this);
-	_console->setFixedHeight(TESTING_CONSOLE_HEIGHT);
+    _console->setFixedHeight(TESTING_CONSOLE_HEIGHT);
 
-	auto _engines = DependencyManager::get<ScriptEngines>();
-	_engine = _engines->loadScript(qApp->applicationDirPath() + testRunnerRelativePath);
-	_console->setScriptEngine(_engine);
-	connect(_engine, &ScriptEngine::finished, this, &TestingDialog::onTestingFinished);
-}
-
-TestingDialog::~TestingDialog() {
-	delete _console;
+    auto _engines = DependencyManager::get<ScriptEngines>();
+    _engine = _engines->loadScript(qApp->applicationDirPath() + testRunnerRelativePath);
+    _console->setScriptEngine(_engine);
+    connect(_engine, &ScriptEngine::finished, this, &TestingDialog::onTestingFinished);
 }
 
 void TestingDialog::onTestingFinished(const QString& scriptPath) {
-	_engine = NULL;
-	_console->setScriptEngine(NULL);
+    _engine = nullptr;
+    _console->setScriptEngine(nullptr);
 }

--- a/interface/src/ui/TestingDialog.h
+++ b/interface/src/ui/TestingDialog.h
@@ -1,10 +1,24 @@
+//
+//  TestingDialog.h
+//  interface/src/ui
+//
+//  Created by Ryan Jones on 12/3/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
 #ifndef hifi_TestingDialog_h
 #define hifi_TestingDialog_h
 
 #include <QDialog>
+#include "ScriptEngine.h"
+#include "JSConsole.h"
 
-const QString windowLabel = "Testing Dialog";
-const QString testRunnerRelativePath = "/scripts/developer/tests/bindUnitTest.js";
+const QString windowLabel = "Client Script Tests";
+const QString testRunnerRelativePath = "/scripts/developer/tests/unit_tests/testRunner.js";
+const unsigned int TESTING_CONSOLE_HEIGHT = 400;
 
 class TestingDialog : public QDialog {
 	Q_OBJECT
@@ -12,14 +26,11 @@ public:
 	TestingDialog(QWidget* parent);
 	~TestingDialog();
 
-signals:
-	void closed();
+	void onTestingFinished(const QString& scriptPath);
 
-public slots:
-	void reject() override;
-
-protected:
-	void closeEvent(QCloseEvent*) override;
+private:
+	JSConsole* _console;
+	ScriptEngine* _engine;
 };
 
 #endif

--- a/interface/src/ui/TestingDialog.h
+++ b/interface/src/ui/TestingDialog.h
@@ -21,16 +21,15 @@ const QString testRunnerRelativePath = "/scripts/developer/tests/unit_tests/test
 const unsigned int TESTING_CONSOLE_HEIGHT = 400;
 
 class TestingDialog : public QDialog {
-	Q_OBJECT
+    Q_OBJECT
 public:
-	TestingDialog(QWidget* parent);
-	~TestingDialog();
+    TestingDialog(QWidget* parent);
 
-	void onTestingFinished(const QString& scriptPath);
+    void onTestingFinished(const QString& scriptPath);
 
 private:
-	JSConsole* _console;
-	ScriptEngine* _engine;
+    std::unique_ptr<JSConsole> _console;
+    ScriptEngine* _engine;
 };
 
 #endif

--- a/interface/src/ui/TestingDialog.h
+++ b/interface/src/ui/TestingDialog.h
@@ -1,0 +1,25 @@
+#ifndef hifi_TestingDialog_h
+#define hifi_TestingDialog_h
+
+#include <QDialog>
+
+const QString windowLabel = "Testing Dialog";
+const QString testRunnerRelativePath = "/scripts/developer/tests/bindUnitTest.js";
+
+class TestingDialog : public QDialog {
+	Q_OBJECT
+public:
+	TestingDialog(QWidget* parent);
+	~TestingDialog();
+
+signals:
+	void closed();
+
+public slots:
+	void reject() override;
+
+protected:
+	void closeEvent(QCloseEvent*) override;
+};
+
+#endif

--- a/scripts/developer/libraries/jasmine/hifi-boot.js
+++ b/scripts/developer/libraries/jasmine/hifi-boot.js
@@ -1,27 +1,50 @@
-
 (function() {
+    var BALLOT_X = '&#10007;';
+    var CHECKMARK = '&#10003;';
+    var DOWN_RIGHT_ARROW = '&#8627;';
+    var PASSED = 'passed';
+    var lastSpecStartTime;
     function ConsoleReporter(options) {
+        var startTime = new Date().getTime();
+        var errorCount = 0;
         this.jasmineStarted = function (obj) {
-            print("jasmineStarted: numSpecs = " + obj.totalSpecsDefined);
+            print('Jasmine started with ' + obj.totalSpecsDefined + ' tests.');
         };
         this.jasmineDone = function (obj) {
-            print("jasmineDone");
+            var ERROR = errorCount === 1 ? 'error' : 'errors';
+            var endTime = new Date().getTime();
+            print('<hr />');
+            if (errorCount === 0) {
+                print ('<span style="color:green">All tests passed!</span>');
+            } else {
+                print('<span style="color:red">Tests completed with ' +
+                    errorCount + ' ' + ERROR + '.<span>');
+            }
+            print('Tests completed in ' + (endTime - startTime) + 'ms.');
         };
         this.suiteStarted = function(obj) {
-            print("suiteStarted: \"" + obj.fullName + "\"");
+            print(obj.fullName);
         };
         this.suiteDone = function(obj) {
-            print("suiteDone: \"" + obj.fullName + "\" " + obj.status);
+            print('');
         };
         this.specStarted = function(obj) {
-            print("specStarted: \"" + obj.fullName + "\"");
+            lastSpecStartTime = new Date().getTime();
         };
         this.specDone = function(obj) {
-            print("specDone: \"" + obj.fullName + "\" " + obj.status);
+            var specEndTime = new Date().getTime();
+            var symbol = obj.status === PASSED ?
+                '<span style="color:green">' + CHECKMARK + '</span>' :
+                '<span style="color:red">' + BALLOT_X + '</span>';
+            print('... ' + obj.fullName + ' ' + symbol + ' ' + '<span style="color:orange">[' +
+                (specEndTime - lastSpecStartTime) + 'ms]</span>');
 
-            var i, l = obj.failedExpectations.length;
-            for (i = 0; i < l; i++) {
-                print("  " + obj.failedExpectations[i].message);
+            var specErrors = obj.failedExpectations.length;
+            errorCount += specErrors;
+            for (var i = 0; i < specErrors; i++) {
+                print('<span style="margin-right:0.5em"></span>' + DOWN_RIGHT_ARROW +
+                    '<span style="color:red">  ' +
+                    obj.failedExpectations[i].message + '</span>');
             }
         };
         return this;
@@ -44,10 +67,11 @@
 
     function extend(destination, source) {
         for (var property in source) {
-            destination[property] = source[property];
+            if (source.hasOwnProperty(property)) {
+                destination[property] = source[property];
+            }
         }
         return destination;
     }
-
 }());
 

--- a/scripts/developer/tests/unit_tests/avatarUnitTests.js
+++ b/scripts/developer/tests/unit_tests/avatarUnitTests.js
@@ -1,7 +1,4 @@
 
-Script.include("../libraries/jasmine/jasmine.js");
-Script.include("../libraries/jasmine/hifi-boot.js");
-
 // Art3mis
 var DEFAULT_AVATAR_URL = "https://hifi-metaverse.s3-us-west-1.amazonaws.com/marketplace/contents/e76946cc-c272-4adf-9bb6-02cde0a4b57d/8fd984ea6fe1495147a3303f87fa6e23.fst?1460131758";
 
@@ -17,6 +14,7 @@ describe("MyAvatar", function () {
 
         // wait until we are finished loading
         var id = Script.setInterval(function () {
+            print(MyAvatar.jointNames.length);
             if (MyAvatar.jointNames.length == 72) {
                 // assume we are finished loading.
                 Script.clearInterval(id);
@@ -54,6 +52,4 @@ describe("MyAvatar", function () {
     });
 
 });
-
-jasmine.getEnv().execute();
 

--- a/scripts/developer/tests/unit_tests/avatarUnitTests.js
+++ b/scripts/developer/tests/unit_tests/avatarUnitTests.js
@@ -14,7 +14,6 @@ describe("MyAvatar", function () {
 
         // wait until we are finished loading
         var id = Script.setInterval(function () {
-            print(MyAvatar.jointNames.length);
             if (MyAvatar.jointNames.length == 72) {
                 // assume we are finished loading.
                 Script.clearInterval(id);

--- a/scripts/developer/tests/unit_tests/bindUnitTest.js
+++ b/scripts/developer/tests/unit_tests/bindUnitTest.js
@@ -1,9 +1,12 @@
-Script.include('../libraries/jasmine/jasmine.js');
-Script.include('../libraries/jasmine/hifi-boot.js');
-Script.include('../../system/libraries/utils.js');
+Script.include('../../../system/libraries/utils.js');
 
 describe('Bind', function() {
-    it('functions should have bind available', function() {
+    it('exists for functions', function() {
+        var FUNC = 'function';
+        expect(typeof(function() {}.bind)).toEqual(FUNC);
+    });
+
+    it('should allow for setting context of this', function() {
         var foo = 'bar';
 
         function callAnotherFn(anotherFn) {
@@ -22,10 +25,6 @@ describe('Bind', function() {
 
         var instance = new TestConstructor();
         
-        expect(typeof(instance.doSomething.bind) !== 'undefined');
         expect(instance.doSomething()).toEqual(foo);
     });
 });
-
-jasmine.getEnv().execute();
-Script.stop();

--- a/scripts/developer/tests/unit_tests/entityUnitTests.js
+++ b/scripts/developer/tests/unit_tests/entityUnitTests.js
@@ -1,0 +1,53 @@
+describe('Entity', function() {
+    var center = Vec3.sum(
+        MyAvatar.position,
+        Vec3.multiply(3, Quat.getFront(Camera.getOrientation()))
+    );
+    var boxEntity;
+    var boxProps = {
+        type: 'Box',
+        color: {
+            red: 255,
+            green: 255,
+            blue: 255,
+        },
+        position: center,
+        dimensions: {
+            x: 1,
+            y: 1,
+            z: 1,
+        },
+    };
+
+    beforeEach(function() {
+        boxEntity = Entities.addEntity(boxProps);
+    });
+
+    afterEach(function() {
+        Entities.deleteEntity(boxEntity);
+        boxEntity = null;
+    });
+
+    it('can be added programmatically', function() {
+        expect(typeof(boxEntity)).toEqual('string');
+    });
+
+    it('instantiates itself correctly', function() {
+        var props = Entities.getEntityProperties(boxEntity);
+        expect(props.type).toEqual(boxProps.type);
+    });
+
+    it('can be modified after creation', function() {
+        var newPos = {
+            x: boxProps.position.x,
+            y: boxProps.position.y,
+            z: boxProps.position.z + 1.0,
+        };
+        Entities.editEntity(boxEntity, {
+            position: newPos,
+        });
+
+        var props = Entities.getEntityProperties(boxEntity);
+        expect(Math.round(props.position.z)).toEqual(Math.round(newPos.z));
+    });
+});

--- a/scripts/developer/tests/unit_tests/testRunner.js
+++ b/scripts/developer/tests/unit_tests/testRunner.js
@@ -1,0 +1,13 @@
+// Include testing library
+Script.include('../../libraries/jasmine/jasmine.js');
+Script.include('../../libraries/jasmine/hifi-boot.js')
+
+// Include unit tests
+// FIXME: Figure out why jasmine done() is not working.
+// Script.include('avatarUnitTests.js');
+Script.include('bindUnitTest.js');
+Script.include('entityUnitTests.js');
+
+// Run the tests
+jasmine.getEnv().execute();
+Script.stop();


### PR DESCRIPTION
**Impetus**:
Current client-side script testing is basically non-existant. There are a handful of test scripts in `scripts/developer/tests` that don't really conform to any given methodology and are not being run as part of a regular QA testing regimen. Ensuring that these script tests don't break is just as important as *.cpp tests and should therefore be part of the QA process for every PR.

**Solution**:
Rely on Jasmine to run all scripting tests. For convenience, I have built a developer menu item that kicks off a `JSConsole` which runs an included test runner that, in turn, includes all unit tests and runs them.

**Features**:
- [x] [Custom console output](https://github.com/highfidelity/hifi/compare/master...Polyrhythm:ryan/client-side-tests?expand=1#diff-aa4bdc06d9d7e49754a280641554803d) clearly showing what passes, what fails (with complete stack trace), how long each individual spec takes, and how long all specs take in aggregate
- [x] Menu item for running and viewing test results for QA convenience - one click process - very clear if any tests fail
- [x] [Consolidated test runner](https://github.com/highfidelity/hifi/compare/master...Polyrhythm:ryan/client-side-tests?expand=1#diff-d406174eb48a210897d225c829bed016) where all unit tests should be added
- [x] [Improved bind unit test](https://github.com/highfidelity/hifi/compare/master...Polyrhythm:ryan/client-side-tests?expand=1#diff-59adb16052dd9c1be6fee63be11c5204) and example Entity unit test for showing the general use case

**Known issues**:
Asynchronous testing is broken right now - Jasmine supplies a `done()` callback for making this work which is not being called in unit tests right now. I found this out while attempting to run an existing unit test in the repo which was broken at some point between when it was first introduced and now - a good case for having regular client-side testing as part of QA.

**QA**:
1. Connect to a domain with edit privileges (tests will involve the editing tools)
1. Developer -> Tests -> Run Client Script Tests`

Passing specs:
![pass](https://cloud.githubusercontent.com/assets/1242927/20874282/377249d2-ba65-11e6-9f88-b04fa44add7f.png)

Failing spec with error output:
![fail](https://cloud.githubusercontent.com/assets/1242927/20874283/3a71cf54-ba65-11e6-8426-517cd4458e67.png)

**Devs**:
If you want to mess around with this and try to introduce test breakage on purpose, you can either edit the test scripts yourself in the main repo and then build to propagate changes to the build-exported scripts, or you can just go ahead and manually edit the scripts that are pulled in to whichever build dir you happen to be using for interface.