### PR TITLE
Fix the lighting problem at the outline of the shapes

### DIFF
--- a/libraries/render-utils/src/local_lights_shading.slf
+++ b/libraries/render-utils/src/local_lights_shading.slf
@@ -30,7 +30,6 @@
 
 <@include LightClusterGrid.slh@>
 
-
 in vec2 _texCoord0;
 out vec4 _fragColor;
 
@@ -39,15 +38,13 @@ void main(void) {
     // Grab the fragment data from the uv
     vec2 texCoord = _texCoord0.st;
 
-    vec4 fragPosition = unpackDeferredPositionFromZeye(texCoord);
-    DeferredFragment frag = unpackDeferredFragmentNoPosition(texCoord);
+    DeferredFrameTransform deferredTransform = getDeferredFrameTransform();
+    DeferredFragment frag = unpackDeferredFragment(deferredTransform, texCoord);
+    vec4 fragPosition = frag.position;
 
     if (frag.mode == FRAG_MODE_UNLIT) {
         discard;
     }
-
-    frag.position = fragPosition;
-
 
     // Frag pos in world
     mat4 invViewMat = getViewInverse();
@@ -56,7 +53,6 @@ void main(void) {
     // From frag world pos find the cluster
     vec4 clusterEyePos = frustumGrid_worldToEye(fragPos);
     ivec3 clusterPos = frustumGrid_eyeToClusterPos(clusterEyePos.xyz);
-
 
     ivec3 cluster = clusterGrid_getCluster(frustumGrid_clusterToIndex(clusterPos));
     int numLights = cluster.x + cluster.y;


### PR DESCRIPTION
use the depth buffer instead of the Linear depth buffer to evaluate the fragment position from the deferred buffer.

Test Plan:
Compare the rendering of a shape lit by light entities (spot or point) in this PR vs the RC29 pr (https://github.com/highfidelity/hifi/pull/9145)

The problem identified by PIper should not show anymore:
Look at the edges of the avatars in the images. Top image has strange edge artifacts compared to current release.

![9145_edgeissue](https://cloud.githubusercontent.com/assets/7314019/20861017/5afbbcdc-b97d-11e6-8ed4-82d99ed10a30.png)


![current_release](https://cloud.githubusercontent.com/assets/7314019/20861020/61c5fa28-b97d-11e6-89a9-cd2f6c441502.png)

And now with this PR (Matthew's avatar):
![hifi-snap-by-sam-on-2016-12-05_00-58-44](https://cloud.githubusercontent.com/assets/2230265/20878973/633e5dfa-ba86-11e6-875e-520b4574817d.jpg)


