### PR TITLE
Fix for driving/turning while flying in HMD mode

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -467,6 +467,8 @@ void MyAvatar::simulate(float deltaTime) {
 
     if (_characterController.getState() != CharacterController::State::Hover) {
         updateSensorToWorldMatrix(_enableVerticalComfortMode ? SensorToWorldUpdateMode::VerticalComfort : SensorToWorldUpdateMode::Vertical);
+    } else {
+        updateSensorToWorldMatrix(SensorToWorldUpdateMode::None);
     }
 
     {
@@ -616,6 +618,8 @@ void MyAvatar::updateSensorToWorldMatrix(SensorToWorldUpdateMode mode) {
         } else if (mode == SensorToWorldUpdateMode::Vertical) {
             setSensorToWorldMatrix(sensorToWorldMat);
         }
+    } else if (mode == SensorToWorldUpdateMode::None) {
+        setSensorToWorldMatrix(_sensorToWorldMatrix);
     }
 }
 
@@ -1897,7 +1901,7 @@ void MyAvatar::applyVelocityToSensorToWorldMatrix(const glm::vec3& velocity, flo
         // update the position column of matrix
         glm::mat4 newSensorToWorldMatrix = _sensorToWorldMatrix;
         newSensorToWorldMatrix[3] = glm::vec4(position, 1.0f);
-        setSensorToWorldMatrix(newSensorToWorldMatrix);
+        _sensorToWorldMatrix = newSensorToWorldMatrix;
     }
 }
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -192,7 +192,8 @@ public:
     enum class SensorToWorldUpdateMode {
         Full = 0,
         Vertical,
-        VerticalComfort
+        VerticalComfort,
+        None
     };
     void updateSensorToWorldMatrix(SensorToWorldUpdateMode mode = SensorToWorldUpdateMode::Full);
 


### PR DESCRIPTION
The internal MyAvatar:_sensorToWorldMatrix was being updated properly, however
the MyAvatar::_sensorToWorldMatrixCache was not. To fix this I've introduced
a new "mode" to updateSensorToWorldMatrix that does not change the sensorToWorldMatrix at all,
but properly copies the value to the cache and also updates hand controller poses etc.