### PR TITLE
Fix for reset sensors while in desktop mode.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4745,13 +4745,13 @@ void Application::renderRearViewMirror(RenderArgs* renderArgs, const QRect& regi
     renderArgs->_viewport =  originalViewport;
 }
 
-void Application::resetSensors(bool andReload) {
+void Application::resetSensors(bool andRecenter) {
     DependencyManager::get<Faceshift>()->reset();
     DependencyManager::get<DdeFaceTracker>()->reset();
     DependencyManager::get<EyeTracker>()->reset();
     getActiveDisplayPlugin()->resetSensors();
     _overlayConductor.centerUI();
-    getMyAvatar()->reset(andReload);
+    getMyAvatar()->reset(andRecenter);
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "reset", Qt::QueuedConnection);
 }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -317,7 +317,7 @@ public slots:
 
     void openUrl(const QUrl& url) const;
 
-    void resetSensors(bool andReload = false);
+    void resetSensors(bool andRecenter = false);
     void setActiveFaceTracker() const;
 
 #if (PR_BUILD || DEV_BUILD)

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -254,6 +254,10 @@ void MyAvatar::centerBody() {
         return;
     }
 
+    if (!qApp->isHMDMode()) {
+        return;
+    }
+
     // derive the desired body orientation from the current hmd orientation, before the sensor reset.
     auto newBodySensorMatrix = deriveBodyFromHMDSensor(); // Based on current cached HMD position/rotation..
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -308,7 +308,7 @@ void MyAvatar::reset(bool andRecenter, bool andReload, bool andHead) {
     }
     setThrust(glm::vec3(0.0f));
 
-    if (andRecenter) {
+    if (andRecenter && qApp->isHMDMode()) {
         // derive the desired body orientation from the *old* hmd orientation, before the sensor reset.
         auto newBodySensorMatrix = deriveBodyFromHMDSensor(); // Based on current cached HMD position/rotation..
 


### PR DESCRIPTION
Previously hitting ' a.k.a. reset sensors, would teleport you to the last
position you were in before you switched into desktop mode, or the spawn location.

This fixes that behavior but not re-centering the avatar while in desktop mode.

Similarly, away.js would also teleport the user when in desktop mode
Because, away.js calls MyAvatar.centerBody.  However, centerBody is only meaningful in HMD mode.
To guard against this, MyAvatar::centerBody is now a no-op if the application is not in HMD mode.
