### PR TITLE
Machine fingerprint 

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -583,7 +583,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us
     
     // TODO: This is temporary, while developing
-    fingerprint::getMachineFingerprint();
+    FingerprintUtils::getMachineFingerprint();
     // End TODO
     auto nodeList = DependencyManager::get<NodeList>();
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -583,7 +583,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us
     
     // TODO: This is temporary, while developing
-    FingerprintUtils::getMachineFingerprint();
+    fingerprint::getMachineFingerprint();
     // End TODO
     auto nodeList = DependencyManager::get<NodeList>();
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -586,7 +586,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     FingerprintUtils::getMachineFingerprint();
     // End TODO
     auto nodeList = DependencyManager::get<NodeList>();
-    
+
     // Set up a watchdog thread to intentionally crash the application on deadlocks
     _deadlockWatchdogThread = new DeadlockWatchdogThread();
     _deadlockWatchdogThread->start();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -62,6 +62,7 @@
 #include <ErrorDialog.h>
 #include <FileScriptingInterface.h>
 #include <Finally.h>
+#include <FingerprintUtils.h>
 #include <FramebufferCache.h>
 #include <gpu/Batch.h>
 #include <gpu/Context.h>
@@ -580,9 +581,12 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _window->setWindowTitle("Interface");
 
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us
-
+    
+    // TODO: This is temporary, while developing
+    FingerprintUtils::getMachineFingerprint();
+    // End TODO
     auto nodeList = DependencyManager::get<NodeList>();
-
+    
     // Set up a watchdog thread to intentionally crash the application on deadlocks
     _deadlockWatchdogThread = new DeadlockWatchdogThread();
     _deadlockWatchdogThread->start();

--- a/libraries/networking/CMakeLists.txt
+++ b/libraries/networking/CMakeLists.txt
@@ -15,6 +15,10 @@ add_dependency_external_projects(tbb)
 find_package(OpenSSL REQUIRED)
 find_package(TBB REQUIRED)
 
+if (APPLE)
+    find_library(FRAMEWORK_IOKIT IOKit)
+endif ()
+
 if (APPLE AND ${OPENSSL_INCLUDE_DIR} STREQUAL "/usr/include")
   # this is a user on OS X using system OpenSSL, which is going to throw warnings since they're deprecating for their common crypto
   message(WARNING "The found version of OpenSSL is the OS X system version. This will produce deprecation warnings."
@@ -25,6 +29,11 @@ include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
 
 # append OpenSSL to our list of libraries to link
 target_link_libraries(${TARGET_NAME} ${OPENSSL_LIBRARIES} ${TBB_LIBRARIES})
+
+# IOKit is needed for getting machine fingerprint
+if (APPLE)
+    target_link_libraries(${TARGET_NAME} ${FRAMEWORK_IOKIT})
+endif (APPLE)
 
 # libcrypto uses dlopen in libdl
 if (UNIX)

--- a/libraries/networking/src/FingerprintUtils.cpp
+++ b/libraries/networking/src/FingerprintUtils.cpp
@@ -25,7 +25,7 @@
 
 static const QString FALLBACK_FINGERPRINT_KEY = "fallbackFingerprint";
 
-QUuid FingerprintUtils::getMachineFingerprint() {
+QUuid fingerprint::getMachineFingerprint() {
 
     QString uuidString;
 
@@ -56,7 +56,6 @@ QUuid FingerprintUtils::getMachineFingerprint() {
 
     if (FAILED(hres)) {
         qDebug() << "Failed to initialize WbemLocator";
-        return uuidString;
     }
     
     // Connect to WMI through the IWbemLocator::ConnectServer method
@@ -79,7 +78,6 @@ QUuid FingerprintUtils::getMachineFingerprint() {
     if (FAILED(hres)) {
         pLoc->Release();
         qDebug() << "Failed to connect to WMI";
-        return uuidString;
     }
     
     // Set security levels on the proxy
@@ -98,7 +96,6 @@ QUuid FingerprintUtils::getMachineFingerprint() {
         pSvc->Release();
         pLoc->Release();     
         qDebug() << "Failed to set security on proxy blanket";
-        return uuidString;
     }
     
     // Use the IWbemServices pointer to grab the Win32_BIOS stuff
@@ -114,7 +111,6 @@ QUuid FingerprintUtils::getMachineFingerprint() {
         pSvc->Release();
         pLoc->Release();
         qDebug() << "query to get Win32_ComputerSystemProduct info";
-        return uuidString;
     }
     
     // Get the SerialNumber from the Win32_BIOS data 

--- a/libraries/networking/src/FingerprintUtils.cpp
+++ b/libraries/networking/src/FingerprintUtils.cpp
@@ -1,0 +1,140 @@
+//
+//  FingerprintUtils.h
+//  libraries/networking/src
+//
+//  Created by David Kelly on 2016-12-02.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "FingerprintUtils.h"
+#include <QDebug>
+
+QString FingerprintUtils::getMachineFingerprint() {
+    QString retval;
+#ifdef Q_OS_WIN
+    HRESULT hres;
+    IWbemLocator *pLoc = NULL;
+
+    // initialize com
+    hres = CoCreateInstance(
+            CLSID_WbemLocator,             
+            0, 
+            CLSCTX_INPROC_SERVER, 
+            IID_IWbemLocator, (LPVOID *) &pLoc);
+
+    if (FAILED(hres)) {
+        qDebug() << "Failed to initialize WbemLocator";
+        return retval;
+    }
+    
+    // Connect to WMI through the IWbemLocator::ConnectServer method
+    IWbemServices *pSvc = NULL;
+
+    // Connect to the root\cimv2 namespace with
+    // the current user and obtain pointer pSvc
+    // to make IWbemServices calls.
+    hres = pLoc->ConnectServer(
+         _bstr_t(L"ROOT\\CIMV2"), // Object path of WMI namespace
+         NULL,                    // User name. NULL = current user
+         NULL,                    // User password. NULL = current
+         0,                       // Locale. NULL indicates current
+         NULL,                    // Security flags.
+         0,                       // Authority (for example, Kerberos)
+         0,                       // Context object 
+         &pSvc                    // pointer to IWbemServices proxy
+         );
+
+    if (FAILED(hres)) {
+        pLoc->Release();
+        qDebug() << "Failed to connect to WMI";
+        return retval;
+    }
+    
+    // Set security levels on the proxy
+    hres = CoSetProxyBlanket(
+       pSvc,                        // Indicates the proxy to set
+       RPC_C_AUTHN_WINNT,           // RPC_C_AUTHN_xxx
+       RPC_C_AUTHZ_NONE,            // RPC_C_AUTHZ_xxx
+       NULL,                        // Server principal name 
+       RPC_C_AUTHN_LEVEL_CALL,      // RPC_C_AUTHN_LEVEL_xxx 
+       RPC_C_IMP_LEVEL_IMPERSONATE, // RPC_C_IMP_LEVEL_xxx
+       NULL,                        // client identity
+       EOAC_NONE                    // proxy capabilities 
+    );
+
+    if (FAILED(hres)) {
+        pSvc->Release();
+        pLoc->Release();     
+        qDebug() << "Failed to set security on proxy blanket";
+        return retval;
+    }
+    
+    // Use the IWbemServices pointer to grab the Win32_BIOS stuff
+    IEnumWbemClassObject* pEnumerator = NULL;
+    hres = pSvc->ExecQuery(
+        bstr_t("WQL"), 
+        bstr_t("SELECT * FROM Win32_ComputerSystemProduct"),
+        WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, 
+        NULL,
+        &pEnumerator);
+
+    if (FAILED(hres)) {
+        pSvc->Release();
+        pLoc->Release();
+        qDebug() << "query to get Win32_ComputerSystemProduct info";
+        return retval;
+    }
+    
+    // Get the SerialNumber from the Win32_BIOS data 
+    IWbemClassObject *pclsObj;
+    ULONG uReturn = 0;
+
+    SHORT  sRetStatus = -100;
+
+    while (pEnumerator) {
+        HRESULT hr = pEnumerator->Next(WBEM_INFINITE, 1, &pclsObj, &uReturn);
+
+        if(0 == uReturn){
+            break;
+        }
+
+        VARIANT vtProp;
+
+        // Get the value of the Name property
+        hr = pclsObj->Get(L"UUID", 0, &vtProp, 0, 0);
+        if (!FAILED(hres)) {
+            switch (vtProp.vt) {
+                case VT_BSTR:
+                    retval = QString::fromWCharArray(vtProp.bstrVal);
+                    break;
+            }
+        }
+        VariantClear(&vtProp);
+
+        pclsObj->Release();
+    }
+    pEnumerator->Release();
+
+    // Cleanup
+    pSvc->Release();
+    pLoc->Release();
+    
+    qDebug() << "Windows BIOS UUID: " << retval;
+#endif //Q_OS_WIN
+
+#ifdef Q_OS_MAC
+
+    io_registry_entry_t ioRegistryRoot = IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/");
+    CFStringRef uuidCf = (CFStringRef) IORegistryEntryCreateCFProperty(ioRegistryRoot, CFSTR(kIOPlatformUUIDKey), kCFAllocatorDefault, 0);
+    IOObjectRelease(ioRegistryRoot);
+    retval = QString::fromCFString(uuidCf);
+    CFRelease(uuidCf); 
+    qDebug() << "Mac serial number: " << retval;
+#endif //Q_OS_MAC
+
+    return retval;
+}
+

--- a/libraries/networking/src/FingerprintUtils.h
+++ b/libraries/networking/src/FingerprintUtils.h
@@ -1,0 +1,29 @@
+//
+//  FingerprintUtils.h
+//  libraries/networking/src
+//
+//  Created by David Kelly on 2016-12-02.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_FingerprintUtils_h
+#define hifi_FingerprintUtils_h
+
+#include <QString>
+
+#ifdef Q_OS_WIN
+#include <comdef.h>
+#include <Wbemidl.h>
+#endif //Q_OS_WIN
+
+class FingerprintUtils {
+public:
+    static QString getMachineFingerprint();
+
+};
+
+#endif // hifi_FingerprintUtils_h
+

--- a/libraries/networking/src/FingerprintUtils.h
+++ b/libraries/networking/src/FingerprintUtils.h
@@ -13,12 +13,10 @@
 #define hifi_FingerprintUtils_h
 
 #include <QString>
+#include <QUuid>
 
-
-class FingerprintUtils {
-public:
-    static QString getMachineFingerprint();
-
+namespace FingerprintUtils {
+    QUuid getMachineFingerprint();
 };
 
 #endif // hifi_FingerprintUtils_h

--- a/libraries/networking/src/FingerprintUtils.h
+++ b/libraries/networking/src/FingerprintUtils.h
@@ -14,10 +14,6 @@
 
 #include <QString>
 
-#ifdef Q_OS_WIN
-#include <comdef.h>
-#include <Wbemidl.h>
-#endif //Q_OS_WIN
 
 class FingerprintUtils {
 public:

--- a/libraries/networking/src/FingerprintUtils.h
+++ b/libraries/networking/src/FingerprintUtils.h
@@ -15,7 +15,7 @@
 #include <QString>
 #include <QUuid>
 
-namespace FingerprintUtils {
+namespace fingerprint {
     QUuid getMachineFingerprint();
 };
 

--- a/libraries/networking/src/FingerprintUtils.h
+++ b/libraries/networking/src/FingerprintUtils.h
@@ -15,8 +15,12 @@
 #include <QString>
 #include <QUuid>
 
-namespace fingerprint {
-    QUuid getMachineFingerprint();
+class FingerprintUtils {
+public:
+    static QUuid getMachineFingerprint();
+
+private:
+    static QString getMachineFingerprintString();
 };
 
 #endif // hifi_FingerprintUtils_h


### PR DESCRIPTION
Added ability to get the smbios UUID from windows, similar for Mac.  Not using it for anything yet, just grabbing it.  We have ongoing design efforts which will use this, so this is just an effort to grab the data.

If we have ill-behaved bios, where we don't have a good UUID (or we have a bad mac, or we are on linux, etc...) we generate and save a uuid in settings.  Doesn't survive a reinstall, but is something.