### PR TITLE
Restores "Select Audio DLL at runtime"

### DIFF
--- a/cmake/externals/wasapi/CMakeLists.txt
+++ b/cmake/externals/wasapi/CMakeLists.txt
@@ -6,8 +6,8 @@ if (WIN32)
   include(ExternalProject)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi4.zip
-    URL_MD5 2abde5340a64d387848f12b9536a7e85
+    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi5.zip
+    URL_MD5 0530753e855ffc00232cc969bf1c84a8
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/cmake/macros/PackageLibrariesForDeployment.cmake
+++ b/cmake/macros/PackageLibrariesForDeployment.cmake
@@ -43,26 +43,24 @@ macro(PACKAGE_LIBRARIES_FOR_DEPLOYMENT)
     )
 
     set(QTAUDIO_PATH $<TARGET_FILE_DIR:${TARGET_NAME}>/audio)
+    set(QTAUDIO_WIN7_PATH $<TARGET_FILE_DIR:${TARGET_NAME}>/audioWin7/audio)
+    set(QTAUDIO_WIN8_PATH $<TARGET_FILE_DIR:${TARGET_NAME}>/audioWin8/audio)
 
-    if (DEPLOY_PACKAGE)
-      # copy qtaudio_wasapi.dll alongside qtaudio_windows.dll, and let the installer resolve
-      add_custom_command(
-        TARGET ${TARGET_NAME}
-        POST_BUILD
-        COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windows.dll ( ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapi.dll ${QTAUDIO_PATH} && ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapi.pdb ${QTAUDIO_PATH} )
-        COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windowsd.dll ( ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapid.dll ${QTAUDIO_PATH} && ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapid.pdb ${QTAUDIO_PATH} )
-      )
-    elseif (${CMAKE_SYSTEM_VERSION} VERSION_LESS 6.2)
-      # continue using qtaudio_windows.dll on Windows 7
-    else ()
-      # replace qtaudio_windows.dll with qtaudio_wasapi.dll on Windows 8/8.1/10
-      add_custom_command(
-        TARGET ${TARGET_NAME}
-        POST_BUILD
-        COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windows.dll ( ${CMAKE_COMMAND} -E remove ${QTAUDIO_PATH}/qtaudio_windows.dll && ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapi.dll ${QTAUDIO_PATH} && ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapi.pdb ${QTAUDIO_PATH} )
-        COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windowsd.dll ( ${CMAKE_COMMAND} -E remove ${QTAUDIO_PATH}/qtaudio_windowsd.dll && ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapid.dll ${QTAUDIO_PATH} && ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapid.pdb ${QTAUDIO_PATH} )
-      )
-    endif ()   
+    # copy qtaudio_wasapi.dll and qtaudio_windows.dll in the correct directories for runtime selection
+    add_custom_command(
+      TARGET ${TARGET_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${QTAUDIO_WIN7_PATH}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${QTAUDIO_WIN8_PATH}
+      # copy release DLLs
+      COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windows.dll ( ${CMAKE_COMMAND} -E copy ${QTAUDIO_PATH}/qtaudio_windows.dll ${QTAUDIO_WIN7_PATH} )
+      COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windows.dll ( ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapi.dll ${QTAUDIO_WIN8_PATH} )
+      # copy debug DLLs
+      COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windowsd.dll ( ${CMAKE_COMMAND} -E copy ${QTAUDIO_PATH}/qtaudio_windowsd.dll ${QTAUDIO_WIN7_PATH} )
+      COMMAND if exist ${QTAUDIO_PATH}/qtaudio_windowsd.dll ( ${CMAKE_COMMAND} -E copy ${WASAPI_DLL_PATH}/qtaudio_wasapid.dll ${QTAUDIO_WIN8_PATH} )
+      # remove directory
+      COMMAND  ${CMAKE_COMMAND} -E remove_directory ${QTAUDIO_PATH}  
+    )
 
   endif ()
 endmacro()

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -630,17 +630,6 @@ Section "-Core installation"
   Delete "$INSTDIR\version"
   Delete "$INSTDIR\xinput1_3.dll"
 
-  ; The installer includes two different Qt audio plugins.
-  ; On Windows 8 and above, only qtaudio_wasapi.dll should be installed.
-  ; On Windows 7 and below, only qtaudio_windows.dll should be installed.
-  ${If} ${AtLeastWin8}
-    Delete "$INSTDIR\audio\qtaudio_windows.dll"
-    Delete "$INSTDIR\audio\qtaudio_windows.pdb"
-  ${Else}
-    Delete "$INSTDIR\audio\qtaudio_wasapi.dll"
-    Delete "$INSTDIR\audio\qtaudio_wasapi.pdb"
-  ${EndIf}
-
   ; Delete old desktop shortcuts before they were renamed during Sandbox rename
   Delete "$DESKTOP\@PRE_SANDBOX_INTERFACE_SHORTCUT_NAME@.lnk"
   Delete "$DESKTOP\@PRE_SANDBOX_CONSOLE_SHORTCUT_NAME@.lnk"

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -168,6 +168,8 @@
 // On Windows PC, NVidia Optimus laptop, we want to enable NVIDIA GPU
 // FIXME seems to be broken.
 #if defined(Q_OS_WIN)
+#include <VersionHelpers.h>
+
 extern "C" {
  _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
 }
@@ -418,6 +420,16 @@ bool setupEssentials(int& argc, char** argv) {
 
     Setting::preInit();
 
+#if defined(Q_OS_WIN)
+    // Select appropriate audio DLL
+    QString audioDLLPath = QCoreApplication::applicationDirPath();
+    if (IsWindows8OrGreater()) {
+        audioDLLPath += "/audioWin8";
+    } else {
+        audioDLLPath += "/audioWin7";
+    }
+    QCoreApplication::addLibraryPath(audioDLLPath);
+#endif
 
     static const auto SUPPRESS_SETTINGS_RESET = "--suppress-settings-reset";
     bool suppressPrompt = cmdOptionExists(argc, const_cast<const char**>(argv), SUPPRESS_SETTINGS_RESET);


### PR DESCRIPTION
Reverts highfidelity/hifi#9144
Restores highfidelity/hifi#9129


Test Plan:
- Make sure C:\Program Files\High Fidelity - PR9129\audio does not exist.
- Make sure audio works correctly
- Make sure Audio > Devices only lists devices once
- Must be tested on Windows 7 and on Windows 8+