### PR TITLE
Fix drop in text rendering quality when texture memory is low

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -363,6 +363,7 @@ Menu::Menu() {
     QActionGroup* textureGroup = new QActionGroup(textureMenu);
     textureGroup->setExclusive(true);
     textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTextureAutomatic, 0, true));
+    textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture4MB, 0, false));
     textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture64MB, 0, false));
     textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture256MB, 0, false));
     textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture512MB, 0, false));
@@ -372,7 +373,9 @@ Menu::Menu() {
         auto checked = textureGroup->checkedAction();
         auto text = checked->text();
         gpu::Context::Size newMaxTextureMemory { 0 };
-        if (MenuOption::RenderMaxTexture64MB == text) {
+        if (MenuOption::RenderMaxTexture4MB == text) {
+            newMaxTextureMemory = MB_TO_BYTES(4);
+        } else if (MenuOption::RenderMaxTexture64MB == text) {
             newMaxTextureMemory = MB_TO_BYTES(64);
         } else if (MenuOption::RenderMaxTexture256MB == text) {
             newMaxTextureMemory = MB_TO_BYTES(256);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -156,6 +156,7 @@ namespace MenuOption {
     const QString RenderOtherLookAtVectors = "Show Other Eye Vectors";
     const QString RenderMaxTextureMemory = "Maximum Texture Memory";
     const QString RenderMaxTextureAutomatic = "Automatic Texture Memory";
+    const QString RenderMaxTexture4MB = "4 MB";
     const QString RenderMaxTexture64MB = "64 MB";
     const QString RenderMaxTexture256MB = "256 MB";
     const QString RenderMaxTexture512MB = "512 MB";

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -360,7 +360,6 @@ void OpenGLDisplayPlugin::customizeContext() {
                 auto usage = gpu::Texture::Usage::Builder().withColor().withAlpha();
                 cursorData.texture->setUsage(usage.build());
                 cursorData.texture->assignStoredMip(0, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), image.byteCount(), image.constBits());
-                cursorData.texture->autoGenerateMips(-1);
             }
         }
     }

--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -210,7 +210,6 @@ void Font::read(QIODevice& in) {
     _texture = gpu::TexturePointer(gpu::Texture::create2D(formatGPU, image.width(), image.height(),
                                    gpu::Sampler(gpu::Sampler::FILTER_MIN_POINT_MAG_LINEAR)));
     _texture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
-    _texture->autoGenerateMips(-1);
 }
 
 void Font::setupGPU() {


### PR DESCRIPTION
Texture downsampling is used in our application to ensure that we don't start dying when too much content is loaded, by reducing the memory consumed by textures.  However, there are some instances where we absolutely should not be downsampling a texture.  Two cases are the cursor textures used in UI compositing and the distance fields we use for text rendering.  In both these we can easily avoid downsampling by disabling mip generation for them. 

## Testing

On an AMD system launch the application and create a text entity in a scene with some textured content.  Then set the max texture memory to 4 MB in the Developer / Render / Max Texture Memory menu.  On production builds this will cause the text to become unreadable or disappear entirely.  On this build it should not affect text (entity) rendering at all.