### PR TITLE
Add dead zone to yaw controls

### DIFF
--- a/interface/resources/controllers/xbox.json
+++ b/interface/resources/controllers/xbox.json
@@ -25,7 +25,7 @@
             ]
         },
 
-        { "from": "GamePad.RX", "to": "Actions.Yaw" },
+        { "from": "GamePad.RX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Actions.Yaw" },
 
         { "from": "GamePad.RY",
           "to": "Actions.VERTICAL_UP",


### PR DESCRIPTION
The translate X and translate Z controls have deadzones, but the yaw control doesn't.  This should add a deadzone to the yaw control, hopefully preventing noise or non-calibrated hardware from causing continuous drift.  

@OmegaHeron can you try testing this out with your xbox controller attached?  You should no longer drift left or right when walking.  There may be other issues that cause drift when flying that are unrelated to whether you have a joystick connected.
