### PR TITLE
Preserve and restore the GL context when resizing QML surfaces

### DIFF
--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -69,3 +69,15 @@ QThread* RENDER_THREAD = nullptr;
 bool isRenderThread() {
     return QThread::currentThread() == RENDER_THREAD;
 }
+
+namespace gl {
+    void withSavedContext(const std::function<void()>& f) {
+        // Save the original GL context, because creating a QML surface will create a new context
+        QOpenGLContext * savedContext = QOpenGLContext::currentContext();
+        QSurface * savedSurface = savedContext ? savedContext->surface() : nullptr;
+        f();
+        if (savedContext) {
+            savedContext->makeCurrent(savedSurface);
+        }
+    }
+}

--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -10,6 +10,7 @@
 #ifndef hifi_GLHelpers_h
 #define hifi_GLHelpers_h
 
+#include <functional>
 #include <QJsonObject>
 
 // 16 bits of depth precision
@@ -33,5 +34,9 @@ QJsonObject getGLContextData();
 int glVersionToInteger(QString glVersion);
 
 bool isRenderThread();
+
+namespace gl {
+    void withSavedContext(const std::function<void()>& f);
+}
 
 #endif


### PR DESCRIPTION
If a web entity or overlay renders early in the scene on the first frame and some other component that needs to compile shaders loads later, then the later item will have no GL context and shader compilation will fail.  This should address a large number of strange GL crashes.

## Testing

Unfortunately intentionally reproducing this crash will be exceedingly hard.  Most likely it would involve going into a domain with a web entity and with some other entity (like a polyline or polyvox) that does shader compilation lazily.  This *may* crash in the current build but should be stable in this build. 