### PR TITLE
Honor reorient and quit request from OVR

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4750,7 +4750,7 @@ void Application::resetSensors(bool andReload) {
     DependencyManager::get<EyeTracker>()->reset();
     getActiveDisplayPlugin()->resetSensors();
     _overlayConductor.centerUI();
-    getMyAvatar()->reset(andReload);
+    getMyAvatar()->reset(true, andReload);
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "reset", Qt::QueuedConnection);
 }
 
@@ -5735,6 +5735,7 @@ void Application::updateDisplayMode() {
             QObject::connect(displayPlugin.get(), &DisplayPlugin::recommendedFramebufferSizeChanged, [this](const QSize & size) {
                 resizeGL();
             });
+            QObject::connect(displayPlugin.get(), &DisplayPlugin::resetSensorsRequested, this, &Application::requestReset);
             first = false;
         }
 

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -205,7 +205,8 @@ public:
 
 
 signals:
-    void recommendedFramebufferSizeChanged(const QSize & size);
+    void recommendedFramebufferSizeChanged(const QSize& size);
+    void resetSensorsRequested();
 
 protected:
     void incrementPresentCount();

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -21,6 +21,15 @@ void OculusBaseDisplayPlugin::resetSensors() {
 }
 
 bool OculusBaseDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
+    handleOVREvents();
+    if (quitRequested()) {
+        QMetaObject::invokeMethod(qApp, "quit");
+        return false;
+    }
+    if (reorientRequested()) {
+        emit resetSensorsRequested();
+    }
+
     _currentRenderFrameInfo = FrameInfo();
     _currentRenderFrameInfo.sensorSampleTime = ovr_GetTimeInSeconds();
     _currentRenderFrameInfo.predictedDisplayTime = ovr_GetPredictedDisplayTime(_session, frameIndex);

--- a/plugins/oculus/src/OculusHelpers.h
+++ b/plugins/oculus/src/OculusHelpers.h
@@ -20,6 +20,10 @@ bool oculusAvailable();
 ovrSession acquireOculusSession();
 void releaseOculusSession();
 
+void handleOVREvents();
+bool quitRequested();
+bool reorientRequested();
+
 // Convenience method for looping over each eye with a lambda
 template <typename Function>
 inline void ovr_for_each_eye(Function function) {


### PR DESCRIPTION
Respond the reset orientation and quit calls from Oculus

Test Plan:
While in the Oculus:
- Turn around (Away from the UI)
- Open the Oculus menu (Power button on Xbox controller)
- Choose to reorient
- Make sure UI is back in front of you.
- Open the Oculus menu
- Exit to Oculus home
- Make sure Interface shuts down.