### PR TITLE
avatarFinderBeacon.js -- Find other avatars more easily

### DIFF
--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -20,7 +20,8 @@ var beacons = {};
 
 // List of .fst files used by AC scripts, that should be ignored in the script in case TRY_TO_IGNORE_AC_AGENTS is enabled
 var POSSIBLE_AC_AVATARS = [
-    'http://hifi-content.s3.amazonaws.com/ozan/dev/avatars/invisible_avatar/invisible_avatar.fst'
+    'http://hifi-content.s3.amazonaws.com/ozan/dev/avatars/invisible_avatar/invisible_avatar.fst',
+    'http://hifi-content.s3.amazonaws.com/ozan/dev/avatars/camera_man/pod/_latest/camera_man_pod.fst'
 ];
 
 AvatarFinderBeacon = function(avatar) {

--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -26,6 +26,7 @@ var POSSIBLE_AC_AVATARS = [
 
 AvatarFinderBeacon = function(avatar) {
     var visible = false;
+    var avatarSessionUUID = avatar.sessionUUID;
     this.overlay = Overlays.addOverlay('line3d', {
         color: BEAM_COLOR,
         dashed: false,
@@ -35,7 +36,7 @@ AvatarFinderBeacon = function(avatar) {
         visible: visible,
         drawInFront: SHOW_THROUGH_WALLS,
         ignoreRayIntersection: true,
-        parentID: avatar.sessionUUID,
+        parentID: avatarSessionUUID,
         parentJointIndex: -2
     });
     this.cleanup = function() {
@@ -45,7 +46,7 @@ AvatarFinderBeacon = function(avatar) {
         return (Vec3.distance(MyAvatar.position, avatar.position) >= MIN_DISPLAY_DISTANCE);
     };
     this.update = function() {
-        avatar = AvatarList.getAvatar(avatar.sessionUUID);
+        avatar = AvatarList.getAvatar(avatarSessionUUID);
         Overlays.editOverlay(this.overlay, {
             visible: this.shouldShow()
         });

--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -1,0 +1,87 @@
+//  avatarFinderBeacon.js
+//
+//  Created by Thijs Wenker on 12/7/16
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Shows 2km long red beams for each avatar outside of the 10 meter radius of your avatar, tries to ignore AC Agents.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+var MIN_DISPLAY_DISTANCE = 10.0; // meters
+var BEAM_COLOR = {red: 255, green: 0, blue: 0};
+var SHOW_THROUGH_WALLS = false;
+var BEACON_LENGTH = 2000.0; // meters
+var TRY_TO_IGNORE_AC_AGENTS = true;
+
+var HALF_BEACON_LENGTH = BEACON_LENGTH / 2.0;
+
+var beacons = {};
+
+// List of .fst files used by AC scripts, that should be ignored in the script in case TRY_TO_IGNORE_AC_AGENTS is enabled
+var POSSIBLE_AC_AVATARS = [
+    'http://hifi-content.s3.amazonaws.com/ozan/dev/avatars/invisible_avatar/invisible_avatar.fst'
+];
+
+AvatarFinderBeacon = function(avatar) {
+    var visible = false;
+    this.overlay = Overlays.addOverlay('line3d', {
+        color: BEAM_COLOR,
+        dashed: false,
+        start: Vec3.sum(avatar.position, {x: 0, y: -HALF_BEACON_LENGTH, z: 0}),
+        end: Vec3.sum(avatar.position, {x: 0, y: HALF_BEACON_LENGTH, z: 0}),
+        rotation: {x: 0, y: 0, z: 0, w: 1},
+        visible: visible,
+        drawInFront: SHOW_THROUGH_WALLS,
+        ignoreRayIntersection: true,
+        parentID: avatar.sessionUUID,
+        parentJointIndex: -2
+    });
+    this.cleanup = function() {
+        Overlays.deleteOverlay(this.overlay);
+    };
+    this.shouldShow = function() {
+        return (Vec3.distance(MyAvatar.position, avatar.position) >= MIN_DISPLAY_DISTANCE);
+    };
+    this.update = function() {
+        avatar = AvatarList.getAvatar(avatar.sessionUUID);
+        Overlays.editOverlay(this.overlay, {
+            visible: this.shouldShow()
+        });
+    };
+};
+
+function updateBeacon(avatarSessionUUID) {
+    if (!(avatarSessionUUID in beacons)) {
+        var avatar = AvatarList.getAvatar(avatarSessionUUID);
+        if (TRY_TO_IGNORE_AC_AGENTS && (POSSIBLE_AC_AVATARS.indexOf(avatar.skeletonModelURL) !== -1 ||
+                                        Vec3.length(avatar.position) === 0.0)) {
+            return;
+        }
+        beacons[avatarSessionUUID] = new AvatarFinderBeacon(avatar);
+        return;
+    }
+    beacons[avatarSessionUUID].update();
+}
+
+Script.update.connect(function() {
+    AvatarList.getAvatarIdentifiers().forEach(function(avatarSessionUUID) {
+        updateBeacon(avatarSessionUUID);
+    });
+});
+
+AvatarList.avatarRemovedEvent.connect(function(avatarSessionUUID) {
+    if (avatarSessionUUID in beacons) {
+        beacons[avatarSessionUUID].clear();
+        delete beacons[avatarSessionUUID];
+    }
+});
+
+Script.scriptEnding.connect(function() {
+    for (var sessionUUID in beacons) {
+        if (!beacons.hasOwnProperty(sessionUUID)) {
+            return;
+        }
+        beacons[sessionUUID].cleanup();
+    }
+});

--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -3,12 +3,12 @@
 //  Created by Thijs Wenker on 12/7/16
 //  Copyright 2016 High Fidelity, Inc.
 //
-//  Shows 2km long red beams for each avatar outside of the 10 meter radius of your avatar, tries to ignore AC Agents.
+//  Shows 2km long red beams for each avatar outside of the 20 meter radius of your avatar, tries to ignore AC Agents.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
-var MIN_DISPLAY_DISTANCE = 10.0; // meters
+var MIN_DISPLAY_DISTANCE = 20.0; // meters
 var BEAM_COLOR = {red: 255, green: 0, blue: 0};
 var SHOW_THROUGH_WALLS = false;
 var BEACON_LENGTH = 2000.0; // meters

--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -56,8 +56,8 @@ AvatarFinderBeacon = function(avatar) {
 function updateBeacon(avatarSessionUUID) {
     if (!(avatarSessionUUID in beacons)) {
         var avatar = AvatarList.getAvatar(avatarSessionUUID);
-        if (TRY_TO_IGNORE_AC_AGENTS && (POSSIBLE_AC_AVATARS.indexOf(avatar.skeletonModelURL) !== -1 ||
-                                        Vec3.length(avatar.position) === 0.0)) {
+        if (TRY_TO_IGNORE_AC_AGENTS
+            && (POSSIBLE_AC_AVATARS.indexOf(avatar.skeletonModelURL) !== -1 || Vec3.length(avatar.position) === 0.0)) {
             return;
         }
         beacons[avatarSessionUUID] = new AvatarFinderBeacon(avatar);

--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -78,7 +78,7 @@ Script.update.connect(function() {
 
 AvatarList.avatarRemovedEvent.connect(function(avatarSessionUUID) {
     if (avatarSessionUUID in beacons) {
-        beacons[avatarSessionUUID].clear();
+        beacons[avatarSessionUUID].cleanup();
         delete beacons[avatarSessionUUID];
     }
 });

--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -64,6 +64,10 @@ function updateBeacon(avatarSessionUUID) {
     beacons[avatarSessionUUID].update();
 }
 
+Window.domainChanged.connect(function () {
+    beacons = {};
+});
+
 Script.update.connect(function() {
     AvatarList.getAvatarIdentifiers().forEach(function(avatarSessionUUID) {
         updateBeacon(avatarSessionUUID);

--- a/scripts/system/avatarFinderBeacon.js
+++ b/scripts/system/avatarFinderBeacon.js
@@ -43,7 +43,7 @@ AvatarFinderBeacon = function(avatar) {
         Overlays.deleteOverlay(this.overlay);
     };
     this.shouldShow = function() {
-        return (Vec3.distance(MyAvatar.position, avatar.position) >= MIN_DISPLAY_DISTANCE);
+        return Vec3.distance(MyAvatar.position, avatar.position) >= MIN_DISPLAY_DISTANCE;
     };
     this.update = function() {
         avatar = AvatarList.getAvatar(avatarSessionUUID);


### PR DESCRIPTION
This is a script that will add a red line from 1km above till 1km below the avatars out side of a 20 meter radius.

## Test Plan
- Run script: `https://rawgit.com/thoys/hifi/3ec06b1a6e03889788c8dd8f761304ef18ddf39b/scripts/system/avatarFinderBeacon.js` in Edit->Running Script -> From URL.
- Test this in an area with multiple avatars that are spread apart over the domain.
- A 2 km red line should be visible starting above and finishing below each avatar outside a 20 meter radius from your avatar.

 