### PR TITLE
No longer applying volume when reading audio injector buffer

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1132,7 +1132,7 @@ void AudioClient::mixLocalAudioInjectors(float* mixBuffer) {
 
                     // stereo gets directly mixed into mixBuffer
                     for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; i++) {
-                        mixBuffer[i] += (float)_scratchBuffer[i] * (1/32768.0f);
+                        mixBuffer[i] += (float)_scratchBuffer[i] * (1/32768.0f) * injector->getVolume();
                     }
                     
                 } else {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1131,8 +1131,9 @@ void AudioClient::mixLocalAudioInjectors(float* mixBuffer) {
                 } else if (injector->isStereo()) {
 
                     // stereo gets directly mixed into mixBuffer
+                    float gain = injector->getVolume();
                     for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; i++) {
-                        mixBuffer[i] += (float)_scratchBuffer[i] * (1/32768.0f) * injector->getVolume();
+                        mixBuffer[i] += (float)_scratchBuffer[i] * (1/32768.0f) * gain;
                     }
                     
                 } else {

--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -166,7 +166,6 @@ bool AudioInjector::injectLocally() {
 
             _localBuffer->open(QIODevice::ReadOnly);
             _localBuffer->setShouldLoop(_options.loop);
-            _localBuffer->setVolume(_options.volume);
 
             // give our current send position to the local buffer
             _localBuffer->setCurrentOffset(_currentSendOffset);

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -63,7 +63,7 @@ public:
     AudioFOA& getLocalFOA() { return _localFOA; }
 
     bool isLocalOnly() const { return _options.localOnly; }
-    float getVolume() const { return _options.volume; }
+    float getVolume() const { return glm::clamp(_options.volume, 0.0f, 1.0f); }
     glm::vec3 getPosition() const { return _options.position; }
     glm::quat getOrientation() const { return _options.orientation; }
     bool isStereo() const { return _options.stereo; }

--- a/libraries/audio/src/AudioInjectorLocalBuffer.cpp
+++ b/libraries/audio/src/AudioInjectorLocalBuffer.cpp
@@ -17,7 +17,6 @@ AudioInjectorLocalBuffer::AudioInjectorLocalBuffer(const QByteArray& rawAudioArr
     _shouldLoop(false),
     _isStopped(false),
     _currentOffset(0),
-    _volume(1.0f)
 {
     
 }

--- a/libraries/audio/src/AudioInjectorLocalBuffer.cpp
+++ b/libraries/audio/src/AudioInjectorLocalBuffer.cpp
@@ -36,17 +36,6 @@ bool AudioInjectorLocalBuffer::seek(qint64 pos) {
     }
 }
 
-void copy(char* to, char* from, int size, qreal factor) {
-    int16_t* toArray = (int16_t*) to;
-    int16_t* fromArray = (int16_t*) from;
-    int sampleSize = size / sizeof(int16_t);
-    
-    for (int i = 0; i < sampleSize; i++) {
-        *toArray = factor * (*fromArray);
-        toArray++;
-        fromArray++;
-    }
-}
 
 qint64 AudioInjectorLocalBuffer::readData(char* data, qint64 maxSize) {
     if (!_isStopped) {
@@ -60,7 +49,7 @@ qint64 AudioInjectorLocalBuffer::readData(char* data, qint64 maxSize) {
             bytesRead = bytesToEnd;
         }
         
-        copy(data, _rawAudioArray.data() + _currentOffset, bytesRead, _volume);
+        memcpy(data, _rawAudioArray.data() + _currentOffset, bytesRead);
         
         // now check if we are supposed to loop and if we can copy more from the beginning
         if (_shouldLoop && maxSize != bytesRead) {
@@ -88,7 +77,7 @@ qint64 AudioInjectorLocalBuffer::recursiveReadFromFront(char* data, qint64 maxSi
     }
     
     // copy that amount
-    copy(data, _rawAudioArray.data(), bytesRead, _volume);
+    memcpy(data, _rawAudioArray.data(), bytesRead);
     
     // check if we need to call ourselves again and pull from the front again
     if (bytesRead < maxSize) {

--- a/libraries/audio/src/AudioInjectorLocalBuffer.cpp
+++ b/libraries/audio/src/AudioInjectorLocalBuffer.cpp
@@ -16,7 +16,7 @@ AudioInjectorLocalBuffer::AudioInjectorLocalBuffer(const QByteArray& rawAudioArr
     _rawAudioArray(rawAudioArray),
     _shouldLoop(false),
     _isStopped(false),
-    _currentOffset(0),
+    _currentOffset(0)
 {
     
 }

--- a/libraries/audio/src/AudioInjectorLocalBuffer.h
+++ b/libraries/audio/src/AudioInjectorLocalBuffer.h
@@ -30,7 +30,6 @@ public:
 
     void setShouldLoop(bool shouldLoop) { _shouldLoop = shouldLoop; }
     void setCurrentOffset(int currentOffset) { _currentOffset = currentOffset; }
-    void setVolume(float volume) { _volume = glm::clamp(volume, 0.0f, 1.0f); }
 
 private:
     qint64 recursiveReadFromFront(char* data, qint64 maxSize);
@@ -40,7 +39,6 @@ private:
     bool _isStopped;
 
     int _currentOffset;
-    float _volume;
 };
 
 #endif // hifi_AudioInjectorLocalBuffer_h


### PR DESCRIPTION
Since we also apply the gain in HRTF (on both server and client), the mono sources sort of had volume^2 applied to them.  Pulled out the setVolume on the `AudioInjectorLocalBuffer` as well, since it is now unused.  Capped the volume (0-1) in `AudioInjector` now as well - was capped in the local buffer.

Test Plan:

Smoke test audio - a mono, stereo, and ambisonic injector should all probably be tested.  Perhaps Audio.playSound executed locally in the console first.  Then, just to be sure, have an entity or avatar execute them and listen on the other side, too.   
Some test sounds:
mono sin wave: https://s3-us-west-1.amazonaws.com/hifi-content/davidkelly/production/audio/sin220m.wav

stereo sin wave: https://s3-us-west-1.amazonaws.com/hifi-content/davidkelly/production/audio/sin220s.wav

ambisonic: http://hifi-content.s3.amazonaws.com/ken/test/horizontal_test_ambiX.wav

for mono and stereo, be sure to put in your current position so it plays where you are:
`Audio.playSound(ambisonicSound, {position: MyAvatar.position});`
for ambisonic, be sure to put in your orientation so right/left/front/back work as you would expect:
`Audio.playSound(ambisonicSound, {orientation: MyAvatar.orientation});`