### PR TITLE
FB 2591: Taking simultaneous GIF snapshots crashes Interface

### DIFF
--- a/interface/src/ui/SnapshotAnimated.cpp
+++ b/interface/src/ui/SnapshotAnimated.cpp
@@ -55,10 +55,6 @@ void SnapshotAnimated::saveSnapshotAnimated(QString pathStill, float aspectRatio
         // Start the snapshotAnimatedTimer QTimer - argument for this is in milliseconds
         SnapshotAnimated::snapshotAnimatedTimerRunning = true;
         SnapshotAnimated::snapshotAnimatedTimer->start(SNAPSNOT_ANIMATED_FRAME_DELAY_MSEC);
-    // If we're already in the middle of capturing an animated snapshot...
-    } else {
-        // Just tell the dependency manager that the capture of the still snapshot has taken place.
-        emit dm->snapshotTaken(pathStill, "", false);
     }
 }
 
@@ -88,9 +84,6 @@ void SnapshotAnimated::captureFrames() {
             // If that was the last frame...
             if ((SnapshotAnimated::snapshotAnimatedTimestamp - SnapshotAnimated::snapshotAnimatedFirstFrameTimestamp) >= (SnapshotAnimated::snapshotAnimatedDuration.get() * MSECS_PER_SECOND)) {
                 SnapshotAnimated::snapshotAnimatedTimerRunning = false;
-                // Reset the current frame timestamp
-                SnapshotAnimated::snapshotAnimatedTimestamp = 0;
-                SnapshotAnimated::snapshotAnimatedFirstFrameTimestamp = 0;
 
                 // Notify the user that we're processing the snapshot
                 emit SnapshotAnimated::snapshotAnimatedDM->processingGif();
@@ -136,7 +129,10 @@ void SnapshotAnimated::processFrames() {
     SnapshotAnimated::snapshotAnimatedFrameVector.squeeze();
     SnapshotAnimated::snapshotAnimatedFrameDelayVector.clear();
     SnapshotAnimated::snapshotAnimatedFrameDelayVector.squeeze();
+    // Reset the current frame timestamp
+    SnapshotAnimated::snapshotAnimatedTimestamp = 0;
+    SnapshotAnimated::snapshotAnimatedFirstFrameTimestamp = 0;
 
-    // Let the dependency manager know that the snapshots have been taken.
+    // Let the window scripting interface know that the snapshots have been taken.
     emit SnapshotAnimated::snapshotAnimatedDM->snapshotTaken(SnapshotAnimated::snapshotStillPath, SnapshotAnimated::snapshotAnimatedPath, false);
 }

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -166,6 +166,9 @@ function resetButtons(pathStillSnapshot, pathAnimatedSnapshot, notify) {
         if (resetOverlays) {
             Menu.setIsOptionChecked("Overlays", true);
         }
+    } else {
+        // Allow the user to click the snapshot HUD button again
+        button.clicked.connect(onClicked);
     }
     // update button states
     button.writeProperty("buttonState", 1);
@@ -177,14 +180,16 @@ function resetButtons(pathStillSnapshot, pathAnimatedSnapshot, notify) {
     // during which time the user may have moved. So stash that info in the dialog so that
     // it records the correct href. (We can also stash in .jpegs, but not .gifs.)
     // last element in data array tells dialog whether we can share or not
-    confirmShare([ 
-        { localPath: pathAnimatedSnapshot, href: href },
+    var confirmShareContents = [
         { localPath: pathStillSnapshot, href: href },
         {
             canShare: !!isDomainOpen(domainId),
             openFeedAfterShare: shouldOpenFeedAfterShare()
-        }
-    ]);
+        }];
+    if (pathAnimatedSnapshot !== "") {
+        confirmShareContents.unshift({ localPath: pathAnimatedSnapshot, href: href });
+    }
+    confirmShare(confirmShareContents);
     if (clearOverlayWhenMoving) {
         MyAvatar.setClearOverlayWhenMoving(true); // not until after the share dialog
     }
@@ -196,9 +201,11 @@ function processingGif() {
     Reticle.visible = reticleVisible;
 
     // update button states
-    button.writeProperty("buttonState", 1);
-    button.writeProperty("defaultState", 1);
-    button.writeProperty("hoverState", 3);
+    button.writeProperty("buttonState", 0);
+    button.writeProperty("defaultState", 0);
+    button.writeProperty("hoverState", 2);
+    // Don't allow the user to click the snapshot button yet
+    button.clicked.disconnect(onClicked);
     // show overlays if they were on
     if (resetOverlays) {
         Menu.setIsOptionChecked("Overlays", true);


### PR DESCRIPTION
Also, don't let users take new GIF snapshots while one is already processing.

https://highfidelity.fogbugz.com/f/cases/2591/Taking-simultaneous-GIF-snapshots-crashes-Interface