### PR TITLE
Render bounds in Forward Render Task

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1740,7 +1740,7 @@ void Application::initializeGL() {
     // Set up the render engine
     render::CullFunctor cullFunctor = LODManager::shouldRender;
     _renderEngine->addJob<RenderShadowTask>("RenderShadowTask", cullFunctor);
-    static const QString RENDER_FORWARD = "RENDER_FORWARD";
+    static const QString RENDER_FORWARD = "HIFI_RENDER_FORWARD";
     if (QProcessEnvironment::systemEnvironment().contains(RENDER_FORWARD)) {
         _renderEngine->addJob<RenderForwardTask>("RenderForwardTask", cullFunctor);
     } else {

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -171,7 +171,6 @@ const gpu::PipelinePointer DrawBounds::getPipeline() {
 
 void DrawBounds::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const Inputs& items) {
     RenderArgs* args = renderContext->args;
-    auto& scene = sceneContext->_scene;
 
     gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
         // Setup projection

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -151,9 +151,6 @@ void PrepareFramebuffer::run(const SceneContextPointer& sceneContext, const Rend
         batch.setFramebuffer(_framebuffer);
         batch.clearFramebuffer(
             gpu::Framebuffer::BUFFER_COLOR0 |
-            gpu::Framebuffer::BUFFER_COLOR1 |
-            gpu::Framebuffer::BUFFER_COLOR2 |
-            gpu::Framebuffer::BUFFER_COLOR3 |
             gpu::Framebuffer::BUFFER_DEPTH |
             gpu::Framebuffer::BUFFER_STENCIL,
             vec4(vec3(0), 0), 1.0, 0.0, true);

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -21,29 +21,14 @@
 
 #include <render/CullTask.h>
 #include <render/SortTask.h>
-#include <render/DrawTask.h>
-#include <render/DrawStatus.h>
-#include <render/DrawSceneOctree.h>
-#include <render/BlurTask.h>
 
-#include "LightingModel.h"
-#include "DebugDeferredBuffer.h"
-#include "DeferredFramebuffer.h"
-#include "DeferredLightingEffect.h"
-#include "SurfaceGeometryPass.h"
 #include "FramebufferCache.h"
-#include "HitEffect.h"
 #include "TextureCache.h"
-
-#include "AmbientOcclusionEffect.h"
-#include "AntialiasingEffect.h"
-#include "ToneMappingEffect.h"
-#include "SubsurfaceScattering.h"
 
 #include <gpu/StandardShaderLib.h>
 
-#include "drawOpaqueStencil_frag.h"
-
+#include <render/drawItemBounds_vert.h>
+#include <render/drawItemBounds_frag.h>
 
 using namespace render;
 extern void initOverlay3DPipelines(render::ShapePlumber& plumber);
@@ -94,6 +79,8 @@ RenderForwardTask::RenderForwardTask(CullFunctor cullFunctor) {
     const auto background = filteredNonspatialBuckets[BACKGROUND_BUCKET];
 
     const auto framebuffer = addJob<PrepareFramebuffer>("PrepareFramebuffer");
+
+    addJob<DrawBounds>("DrawBounds", opaques);
 
     // Blit!
     addJob<Blit>("Blit", framebuffer);
@@ -153,8 +140,61 @@ void PrepareFramebuffer::run(const SceneContextPointer& sceneContext, const Rend
             gpu::Framebuffer::BUFFER_COLOR0 |
             gpu::Framebuffer::BUFFER_DEPTH |
             gpu::Framebuffer::BUFFER_STENCIL,
-            vec4(vec3(0), 0), 1.0, 0.0, true);
+            vec4(vec3(0), 1), 1.0, 0.0, true);
     });
 
     framebuffer = _framebuffer;
+}
+
+const gpu::PipelinePointer DrawBounds::getPipeline() {
+    if (!_boundsPipeline) {
+        auto vs = gpu::Shader::createVertex(std::string(drawItemBounds_vert));
+        auto ps = gpu::Shader::createPixel(std::string(drawItemBounds_frag));
+        gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
+
+        gpu::Shader::BindingSet slotBindings;
+        gpu::Shader::makeProgram(*program, slotBindings);
+
+        _cornerLocation = program->getUniforms().findLocation("inBoundPos");
+        _scaleLocation = program->getUniforms().findLocation("inBoundDim");
+
+        auto state = std::make_shared<gpu::State>();
+        state->setDepthTest(true, false, gpu::LESS_EQUAL);
+        state->setBlendFunction(true,
+            gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+            gpu::State::DEST_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ZERO);
+
+        _boundsPipeline = gpu::Pipeline::create(program, state);
+    }
+    return _boundsPipeline;
+}
+
+void DrawBounds::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const Inputs& items) {
+    RenderArgs* args = renderContext->args;
+    auto& scene = sceneContext->_scene;
+
+    gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
+        // Setup projection
+        glm::mat4 projMat;
+        Transform viewMat;
+        args->getViewFrustum().evalProjectionMatrix(projMat);
+        args->getViewFrustum().evalViewTransform(viewMat);
+        batch.setProjectionTransform(projMat);
+        batch.setViewTransform(viewMat);
+        batch.setModelTransform(Transform());
+
+        // Bind program
+        batch.setPipeline(getPipeline());
+        assert(_cornerLocation >= 0);
+        assert(_scaleLocation >= 0);
+
+        // Render bounds
+        for (const auto& item : items) {
+            batch._glUniform3fv(_cornerLocation, 1, (const float*)(&item.bound.getCorner()));
+            batch._glUniform3fv(_scaleLocation, 1, (const float*)(&item.bound.getScale()));
+
+            static const int NUM_VERTICES_PER_CUBE = 24;
+            batch.draw(gpu::LINES, NUM_VERTICES_PER_CUBE, 0);
+        }
+    });
 }

--- a/libraries/render-utils/src/RenderForwardTask.h
+++ b/libraries/render-utils/src/RenderForwardTask.h
@@ -39,4 +39,18 @@ private:
     gpu::FramebufferPointer _framebuffer;
 };
 
+class DrawBounds {
+public:
+    using Inputs = render::ItemBounds;
+    using JobModel = render::Job::ModelI<DrawBounds, Inputs>;
+
+    void run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext, const Inputs& items);
+
+private:
+    const gpu::PipelinePointer getPipeline();
+    gpu::PipelinePointer _boundsPipeline;
+    int _cornerLocation { -1 };
+    int _scaleLocation { -1 };
+};
+
 #endif // hifi_RenderForwardTask_h


### PR DESCRIPTION
- Changes flag from RENDER_FORWARD to HIFI_RENDER_FORWARD
- Removes extra buffer clears
- Renders object bounds (as cuboids)