### PR TITLE
Additional work on tracing

### DIFF
--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -38,6 +38,7 @@
 #include "AssignmentClientLogging.h"
 #include "avatars/ScriptableAvatar.h"
 #include <Trace.h>
+#include <StatTracker.h>
 
 const QString ASSIGNMENT_CLIENT_TARGET_NAME = "assignment-client";
 const long long ASSIGNMENT_REQUEST_INTERVAL_MSECS = 1 * 1000;
@@ -50,6 +51,7 @@ AssignmentClient::AssignmentClient(Assignment::Type requestAssignmentType, QStri
     LogUtils::init();
 
     DependencyManager::set<tracing::Tracer>();
+    DependencyManager::set<StatTracker>();
     DependencyManager::set<AccountManager>();
 
     auto scriptableAvatar = DependencyManager::set<ScriptableAvatar>();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -44,6 +44,7 @@
 #include "DomainServerNodeData.h"
 #include "NodeConnectionData.h"
 #include <Trace.h>
+#include <StatTracker.h>
 
 int const DomainServer::EXIT_CODE_REBOOT = 234923;
 
@@ -75,6 +76,7 @@ DomainServer::DomainServer(int argc, char* argv[]) :
     parseCommandLine();
 
     DependencyManager::set<tracing::Tracer>();
+    DependencyManager::set<StatTracker>();
 
     LogUtils::init();
     Setting::init();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3217,7 +3217,6 @@ bool Application::shouldPaint(float nsecsElapsed) {
 }
 
 void Application::idle(float nsecsElapsed) {
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
     PerformanceTimer perfTimer("idle");
 
     // Update the deadlock watchdog
@@ -4538,11 +4537,6 @@ QRect Application::getDesirableApplicationGeometry() const {
 //                 or the "myCamera".
 //
 void Application::loadViewFrustum(Camera& camera, ViewFrustum& viewFrustum) {
-<<<<<<< HEAD
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
-    PerformanceTimer perfTimer("loadViewFrustum");
-=======
->>>>>>> tracing polish
     // We will use these below, from either the camera or head vectors calculated above
     viewFrustum.setProjection(camera.getProjection());
 

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -57,7 +57,7 @@ ApplicationOverlay::~ApplicationOverlay() {
 
 // Renders the overlays either to a texture or to the screen
 void ApplicationOverlay::renderOverlay(RenderArgs* renderArgs) {
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
+    PROFILE_RANGE(render, __FUNCTION__);
     PerformanceWarning warn(Menu::getInstance()->isOptionChecked(MenuOption::PipelineWarnings), "ApplicationOverlay::displayOverlay()");
 
     buildFramebufferObject();
@@ -96,7 +96,7 @@ void ApplicationOverlay::renderOverlay(RenderArgs* renderArgs) {
 }
 
 void ApplicationOverlay::renderQmlUi(RenderArgs* renderArgs) {
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
+    PROFILE_RANGE(app, __FUNCTION__);
 
     if (!_uiTexture) {
         _uiTexture = gpu::TexturePointer(gpu::Texture::createExternal2D(OffscreenQmlSurface::getDiscardLambda()));
@@ -124,7 +124,7 @@ void ApplicationOverlay::renderQmlUi(RenderArgs* renderArgs) {
 }
 
 void ApplicationOverlay::renderAudioScope(RenderArgs* renderArgs) {
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
+    PROFILE_RANGE(app, __FUNCTION__);
 
     gpu::Batch& batch = *renderArgs->_batch;
     auto geometryCache = DependencyManager::get<GeometryCache>();
@@ -143,7 +143,7 @@ void ApplicationOverlay::renderAudioScope(RenderArgs* renderArgs) {
 }
 
 void ApplicationOverlay::renderOverlays(RenderArgs* renderArgs) {
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
+    PROFILE_RANGE(app, __FUNCTION__);
 
     gpu::Batch& batch = *renderArgs->_batch;
     auto geometryCache = DependencyManager::get<GeometryCache>();
@@ -262,7 +262,7 @@ static const auto DEFAULT_SAMPLER = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LI
 static const auto DEPTH_FORMAT = gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::DEPTH);
 
 void ApplicationOverlay::buildFramebufferObject() {
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
+    PROFILE_RANGE(app, __FUNCTION__);
 
     auto uiSize = qApp->getUiSize();
     if (!_overlayFramebuffer || uiSize != _overlayFramebuffer->getSize()) {

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -37,6 +37,7 @@
 #include "Web3DOverlay.h"
 #include <QtQuick/QQuickWindow>
 
+Q_LOGGING_CATEGORY(trace_render_overlays, "trace.render.overlays")
 
 Overlays::Overlays() :
     _nextOverlayID(1) {}
@@ -102,7 +103,7 @@ void Overlays::cleanupOverlaysToDelete() {
 }
 
 void Overlays::renderHUD(RenderArgs* renderArgs) {
-    PROFILE_RANGE(interfaceapp, __FUNCTION__);
+    PROFILE_RANGE(render_overlays, __FUNCTION__);
     QReadLocker lock(&_lock);
     gpu::Batch& batch = *renderArgs->_batch;
 

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -394,7 +394,7 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
         loadPoses(underPoses);
     } else {
 
-        PROFILE_RANGE_EX(animation, "ik/relax", 0xffff00ff, 0);
+        PROFILE_RANGE_EX(simulation_animation, "ik/relax", 0xffff00ff, 0);
 
         // relax toward underPoses
         // HACK: this relaxation needs to be constant per-frame rather than per-realtime
@@ -433,7 +433,7 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
         // build a list of targets from _targetVarVec
         std::vector<IKTarget> targets;
         {
-            PROFILE_RANGE_EX(animation, "ik/computeTargets", 0xffff00ff, 0);
+            PROFILE_RANGE_EX(simulation_animation, "ik/computeTargets", 0xffff00ff, 0);
             computeTargets(animVars, targets, underPoses);
         }
 
@@ -450,7 +450,7 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
         } else {
 
             {
-                PROFILE_RANGE_EX(animation, "ik/shiftHips", 0xffff00ff, 0);
+                PROFILE_RANGE_EX(simulation_animation, "ik/shiftHips", 0xffff00ff, 0);
 
                 // shift hips according to the _hipsOffset from the previous frame
                 float offsetLength = glm::length(_hipsOffset);
@@ -476,12 +476,12 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
             }
 
             {
-                PROFILE_RANGE_EX(animation, "ik/ccd", 0xffff00ff, 0);
+                PROFILE_RANGE_EX(simulation_animation, "ik/ccd", 0xffff00ff, 0);
                 solveWithCyclicCoordinateDescent(targets);
             }
 
             {
-                PROFILE_RANGE_EX(animation, "ik/measureHipsOffset", 0xffff00ff, 0);
+                PROFILE_RANGE_EX(simulation_animation, "ik/measureHipsOffset", 0xffff00ff, 0);
 
                 // measure new _hipsOffset for next frame
                 // by looking for discrepancies between where a targeted endEffector is

--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -55,7 +55,7 @@ void AnimationReader::run() {
     DependencyManager::get<StatTracker>()->decrementStat("PendingProcessing");
     CounterStat counter("Processing");
 
-    PROFILE_RANGE_EX(animation, __FUNCTION__, 0xFF00FF00, 0, { { "url", _url.toString() } });
+    PROFILE_RANGE_EX(resource_parse, __FUNCTION__, 0xFF00FF00, 0, { { "url", _url.toString() } });
     auto originalPriority = QThread::currentThread()->priority();
     if (originalPriority == QThread::InheritPriority) {
         originalPriority = QThread::NormalPriority;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -883,7 +883,7 @@ void Rig::updateAnimationStateHandlers() { // called on avatar update thread (wh
 
 void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
 
-    PROFILE_RANGE_EX(animation, __FUNCTION__, 0xffff00ff, 0);
+    PROFILE_RANGE_EX(simulation_animation, __FUNCTION__, 0xffff00ff, 0);
 
     setModelOffset(rootTransform);
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -129,7 +129,7 @@ public:
         _context->makeCurrent();
         while (!_shutdown) {
             if (_pendingMainThreadOperation) {
-                PROFILE_RANGE(displayPlugins, "MainThreadOp")
+                PROFILE_RANGE(render, "MainThreadOp")
                 {
                     Lock lock(_mutex);
                     _context->doneCurrent();
@@ -203,7 +203,7 @@ public:
             // Execute the frame and present it to the display device.
             _context->makeCurrent();
             {
-                PROFILE_RANGE(displayPlugins, "PluginPresent")
+                PROFILE_RANGE(render, "PluginPresent")
                 currentPlugin->present();
                 CHECK_GL_ERROR();
             }
@@ -560,22 +560,22 @@ void OpenGLDisplayPlugin::compositeLayers() {
     updateCompositeFramebuffer();
 
     {
-        PROFILE_RANGE_EX(displayPlugins, "compositeScene", 0xff0077ff, (uint64_t)presentCount())
+        PROFILE_RANGE_EX(render, "compositeScene", 0xff0077ff, (uint64_t)presentCount())
         compositeScene();
     }
 
     {
-        PROFILE_RANGE_EX(displayPlugins, "compositeOverlay", 0xff0077ff, (uint64_t)presentCount())
+        PROFILE_RANGE_EX(render, "compositeOverlay", 0xff0077ff, (uint64_t)presentCount())
         compositeOverlay();
     }
     auto compositorHelper = DependencyManager::get<CompositorHelper>();
     if (compositorHelper->getReticleVisible()) {
-        PROFILE_RANGE_EX(displayPlugins, "compositePointer", 0xff0077ff, (uint64_t)presentCount())
+        PROFILE_RANGE_EX(render, "compositePointer", 0xff0077ff, (uint64_t)presentCount())
         compositePointer();
     }
 
     {
-        PROFILE_RANGE_EX(displayPlugins, "compositeExtra", 0xff0077ff, (uint64_t)presentCount())
+        PROFILE_RANGE_EX(render, "compositeExtra", 0xff0077ff, (uint64_t)presentCount())
         compositeExtra();
     }
 }
@@ -595,12 +595,12 @@ void OpenGLDisplayPlugin::internalPresent() {
 }
 
 void OpenGLDisplayPlugin::present() {
-    PROFILE_RANGE_EX(displayPlugins, __FUNCTION__, 0xffffff00, (uint64_t)presentCount())
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xffffff00, (uint64_t)presentCount())
     updateFrameData();
     incrementPresentCount();
 
     {
-        PROFILE_RANGE_EX(displayPlugins, "recycle", 0xff00ff00, (uint64_t)presentCount())
+        PROFILE_RANGE_EX(render, "recycle", 0xff00ff00, (uint64_t)presentCount())
         _gpuContext->recycle();
     }
 
@@ -614,19 +614,19 @@ void OpenGLDisplayPlugin::present() {
                 _lastFrame = _currentFrame.get();
             });
             // Execute the frame rendering commands
-            PROFILE_RANGE_EX(displayPlugins, "execute", 0xff00ff00, (uint64_t)presentCount())
+            PROFILE_RANGE_EX(render, "execute", 0xff00ff00, (uint64_t)presentCount())
             _gpuContext->executeFrame(_currentFrame);
         }
 
         // Write all layers to a local framebuffer
         {
-            PROFILE_RANGE_EX(displayPlugins, "composite", 0xff00ffff, (uint64_t)presentCount())
+            PROFILE_RANGE_EX(render, "composite", 0xff00ffff, (uint64_t)presentCount())
             compositeLayers();
         }
 
         // Take the composite framebuffer and send it to the output device
         {
-            PROFILE_RANGE_EX(displayPlugins, "internalPresent", 0xff00ffff, (uint64_t)presentCount())
+            PROFILE_RANGE_EX(render, "internalPresent", 0xff00ffff, (uint64_t)presentCount())
             internalPresent();
         }
 

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -206,7 +206,7 @@ float HmdDisplayPlugin::getLeftCenterPixel() const {
 }
 
 void HmdDisplayPlugin::internalPresent() {
-    PROFILE_RANGE_EX(displayPlugins, __FUNCTION__, 0xff00ff00, (uint64_t)presentCount())
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)presentCount())
 
     // Composite together the scene, overlay and mouse cursor
     hmdPresent();

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -211,7 +211,7 @@ namespace render {
     template <> void payloadRender(const RenderableModelEntityItemMeta::Pointer& payload, RenderArgs* args) {
         if (args) {
             if (payload && payload->entity) {
-                PROFILE_RANGE(renderlogging, "MetaModelRender");
+                PROFILE_RANGE(render, "MetaModelRender");
                 payload->entity->render(args);
             }
         }

--- a/libraries/fbx/src/FBXReader_Node.cpp
+++ b/libraries/fbx/src/FBXReader_Node.cpp
@@ -321,7 +321,7 @@ FBXNode parseTextFBXNode(Tokenizer& tokenizer) {
 }
 
 FBXNode FBXReader::parseFBX(QIODevice* device) {
-    PROFILE_RANGE_EX(modelformat, __FUNCTION__, 0xff0000ff, device);
+    PROFILE_RANGE_EX(resource_parse, __FUNCTION__, 0xff0000ff, device);
     // verify the prolog
     const QByteArray BINARY_PROLOG = "Kaydara FBX Binary  ";
     if (device->peek(BINARY_PROLOG.size()) != BINARY_PROLOG) {

--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -420,7 +420,7 @@ done:
 
 
 FBXGeometry* OBJReader::readOBJ(QByteArray& model, const QVariantHash& mapping, const QUrl& url) {
-    PROFILE_RANGE_EX(modelformat, __FUNCTION__, 0xffff0000, nullptr);
+    PROFILE_RANGE_EX(resource_parse, __FUNCTION__, 0xffff0000, nullptr);
     QBuffer buffer { &model };
     buffer.open(QIODevice::ReadOnly);
 

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -38,6 +38,9 @@
 #include "GLLogging.h"
 #include "Context.h"
 
+Q_LOGGING_CATEGORY(trace_render_qml, "trace.render.qml")
+Q_LOGGING_CATEGORY(trace_render_qml_gl, "trace.render.qml.gl")
+
 struct TextureSet {
     // The number of surfaces with this size
     size_t count { 0 };
@@ -276,6 +279,7 @@ void OffscreenQmlSurface::render() {
         return;
     }
 
+    PROFILE_RANGE(render_qml_gl, __FUNCTION__)
     _canvas->makeCurrent();
 
     _renderControl->sync();
@@ -284,7 +288,6 @@ void OffscreenQmlSurface::render() {
     GLuint texture = offscreenTextures.getNextTexture(_size);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _fbo);
     glFramebufferTexture(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture, 0);
-    PROFILE_RANGE(glLogging, "qml_render->rendercontrol")
     _renderControl->render();
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     glBindTexture(GL_TEXTURE_2D, texture);
@@ -617,12 +620,12 @@ void OffscreenQmlSurface::updateQuick() {
     }
 
     if (_polish) {
+        PROFILE_RANGE(render_qml, "OffscreenQML polish")
         _renderControl->polishItems();
         _polish = false;
     }
 
     if (_render) {
-        PROFILE_RANGE(glLogging, __FUNCTION__);
         render();
         _render = false;
     }

--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
@@ -200,7 +200,7 @@ void GLBackend::renderPassTransfer(const Batch& batch) {
 
     _inRenderTransferPass = true;
     { // Sync all the buffers
-        PROFILE_RANGE(gpugllogging, "syncGPUBuffer");
+        PROFILE_RANGE(render_gpu_gl, "syncGPUBuffer");
 
         for (auto& cached : batch._buffers._items) {
             if (cached._data) {
@@ -210,7 +210,7 @@ void GLBackend::renderPassTransfer(const Batch& batch) {
     }
 
     { // Sync all the buffers
-        PROFILE_RANGE(gpugllogging, "syncCPUTransform");
+        PROFILE_RANGE(render_gpu_gl, "syncCPUTransform");
         _transform._cameras.clear();
         _transform._cameraOffsets.clear();
 
@@ -242,7 +242,7 @@ void GLBackend::renderPassTransfer(const Batch& batch) {
     }
 
     { // Sync the transform buffers
-        PROFILE_RANGE(gpugllogging, "syncGPUTransform");
+        PROFILE_RANGE(render_gpu_gl, "syncGPUTransform");
         transferTransformState(batch);
     }
 
@@ -304,7 +304,7 @@ void GLBackend::render(const Batch& batch) {
     }
     
     {
-        PROFILE_RANGE(gpugllogging, "Transfer");
+        PROFILE_RANGE(render_gpu_gl, "Transfer");
         renderPassTransfer(batch);
     }
 
@@ -314,7 +314,7 @@ void GLBackend::render(const Batch& batch) {
     }
 #endif
     {
-        PROFILE_RANGE(gpugllogging, _stereo._enable ? "Render Stereo" : "Render");
+        PROFILE_RANGE(render_gpu_gl, _stereo._enable ? "Render Stereo" : "Render");
         renderPassDraw(batch);
     }
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendQuery.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendQuery.cpp
@@ -28,7 +28,7 @@ void GLBackend::do_beginQuery(const Batch& batch, size_t paramOffset) {
     auto query = batch._queries.get(batch._params[paramOffset]._uint);
     GLQuery* glquery = syncGPUObject(*query);
     if (glquery) {
-        PROFILE_RANGE_BEGIN(gpugllogging, glquery->_profileRangeId, query->getName().c_str(), 0xFFFF7F00);
+        PROFILE_RANGE_BEGIN(render_gpu_gl, glquery->_profileRangeId, query->getName().c_str(), 0xFFFF7F00);
 
         ++_queryStage._rangeQueryDepth;
         glGetInteger64v(GL_TIMESTAMP, (GLint64*)&glquery->_batchElapsedTime);
@@ -62,7 +62,7 @@ void GLBackend::do_endQuery(const Batch& batch, size_t paramOffset) {
         glGetInteger64v(GL_TIMESTAMP, &now);
         glquery->_batchElapsedTime = now - glquery->_batchElapsedTime;
 
-        PROFILE_RANGE_END(gpugllogging, glquery->_profileRangeId);
+        PROFILE_RANGE_END(render_gpu_gl, glquery->_profileRangeId);
 
         (void)CHECK_GL_ERROR();
     }

--- a/libraries/gpu-gl/src/gpu/gl/GLShared.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLShared.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 
 Q_LOGGING_CATEGORY(gpugllogging, "hifi.gpu.gl")
+Q_LOGGING_CATEGORY(trace_render_gpu_gl, "trace.render.gpu.gl")
 
 namespace gpu { namespace gl {
 

--- a/libraries/gpu-gl/src/gpu/gl/GLShared.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLShared.h
@@ -15,6 +15,7 @@
 #include <QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(gpugllogging)
+Q_DECLARE_LOGGING_CATEGORY(trace_render_gpu_gl)
 
 namespace gpu { namespace gl { 
 

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -122,7 +122,7 @@ void GL41Texture::transferMip(uint16_t mipLevel, uint8_t face) const {
 }
 
 void GL41Texture::startTransfer() {
-    PROFILE_RANGE(gpugllogging, __FUNCTION__);
+    PROFILE_RANGE(render_gpu_gl, __FUNCTION__);
     Parent::startTransfer();
 
     glBindTexture(_target, _id);

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -759,7 +759,7 @@ bool sphericalHarmonicsFromTexture(const gpu::Texture& cubeTexture, std::vector<
         return false;
     }
 
-    PROFILE_RANGE(gpulogging, "sphericalHarmonicsFromTexture");
+    PROFILE_RANGE(render_gpu, "sphericalHarmonicsFromTexture");
 
     const uint sqOrder = order*order;
 
@@ -792,7 +792,7 @@ bool sphericalHarmonicsFromTexture(const gpu::Texture& cubeTexture, std::vector<
 
     // for each face of cube texture
     for(int face=0; face < gpu::Texture::NUM_CUBE_FACES; face++) {
-        PROFILE_RANGE(gpulogging, "ProcessFace");
+        PROFILE_RANGE(render_gpu, "ProcessFace");
 
         auto numComponents = cubeTexture.accessStoredMipFace(0,face)->getFormat().getScalarCount();
         auto data = cubeTexture.accessStoredMipFace(0,face)->readData();

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -24,6 +24,8 @@
 #include <Trace.h>
 #include <StatTracker.h>
 
+Q_LOGGING_CATEGORY(trace_resource_parse_geometry, "trace.resource.parse.geometry")
+
 class GeometryReader;
 
 class GeometryExtra {
@@ -54,7 +56,7 @@ private:
 };
 
 void GeometryMappingResource::downloadFinished(const QByteArray& data) {
-    PROFILE_ASYNC_BEGIN(modelnetworking, "GeometryMappingResource::downloadFinished", _url.toString(),
+    PROFILE_ASYNC_BEGIN(resource_parse_geometry, "GeometryMappingResource::downloadFinished", _url.toString(),
                          { { "url", _url.toString() } });
 
     auto mapping = FSTReader::readMapping(data);
@@ -120,7 +122,7 @@ void GeometryMappingResource::onGeometryMappingLoaded(bool success) {
         disconnect(_connection); // FIXME Should not have to do this
     }
 
-    PROFILE_ASYNC_END(modelnetworking, "GeometryMappingResource::downloadFinished", _url.toString());
+    PROFILE_ASYNC_END(resource_parse_geometry, "GeometryMappingResource::downloadFinished", _url.toString());
     finishedLoading(success);
 }
 
@@ -145,7 +147,7 @@ private:
 void GeometryReader::run() {
     DependencyManager::get<StatTracker>()->decrementStat("PendingProcessing");
     CounterStat counter("Processing");
-    PROFILE_RANGE_EX(modelnetworking, "GeometryReader::run", 0xFF00FF00, 0, { { "url", _url.toString() } });
+    PROFILE_RANGE_EX(resource_parse_geometry, "GeometryReader::run", 0xFF00FF00, 0, { { "url", _url.toString() } });
     auto originalPriority = QThread::currentThread()->priority();
     if (originalPriority == QThread::InheritPriority) {
         originalPriority = QThread::NormalPriority;

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -36,6 +36,8 @@
 #include <Trace.h>
 #include <StatTracker.h>
 
+Q_LOGGING_CATEGORY(trace_resource_parse_image, "trace.resource.parse.image")
+
 TextureCache::TextureCache() {
     setUnusedResourceCacheSize(0);
     setObjectName("TextureCache");
@@ -349,7 +351,7 @@ void ImageReader::run() {
 
     CounterStat counter("Processing");
 
-    PROFILE_RANGE_EX(modelnetworking, __FUNCTION__, 0xffff0000, 0, { { "url", _url.toString() } });
+    PROFILE_RANGE_EX(resource_parse_image, __FUNCTION__, 0xffff0000, 0, { { "url", _url.toString() } });
     auto originalPriority = QThread::currentThread()->priority();
     if (originalPriority == QThread::InheritPriority) {
         originalPriority = QThread::NormalPriority;
@@ -395,7 +397,7 @@ void ImageReader::run() {
 
         auto url = _url.toString().toStdString();
 
-        PROFILE_RANGE_EX(modelnetworking, __FUNCTION__, 0xffffff00, 0);
+        PROFILE_RANGE_EX(resource_parse_image, __FUNCTION__, 0xffffff00, 0);
         texture.reset(resource.dynamicCast<NetworkTexture>()->getTextureLoader()(image, url));
     }
 

--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -746,7 +746,7 @@ const CubeLayout CubeLayout::CUBEMAP_LAYOUTS[] = {
 const int CubeLayout::NUM_CUBEMAP_LAYOUTS = sizeof(CubeLayout::CUBEMAP_LAYOUTS) / sizeof(CubeLayout);
 
 gpu::Texture* TextureUsage::processCubeTextureColorFromImage(const QImage& srcImage, const std::string& srcImageName, bool isLinear, bool doCompress, bool generateMips, bool generateIrradiance) {
-    PROFILE_RANGE(modelLog, "processCubeTextureColorFromImage");
+    PROFILE_RANGE(resource_parse, "processCubeTextureColorFromImage");
 
     gpu::Texture* theTexture = nullptr;
     if ((srcImage.width() > 0) && (srcImage.height() > 0)) {
@@ -805,13 +805,13 @@ gpu::Texture* TextureUsage::processCubeTextureColorFromImage(const QImage& srcIm
             }
 
             if (generateMips) {
-                PROFILE_RANGE(modelLog, "generateMips");
+                PROFILE_RANGE(resource_parse, "generateMips");
                 theTexture->autoGenerateMips(-1);
             }
 
             // Generate irradiance while we are at it
             if (generateIrradiance) {
-                PROFILE_RANGE(modelLog, "generateIrradiance");
+                PROFILE_RANGE(resource_parse, "generateIrradiance");
                 theTexture->generateIrradiance();
             }
         }

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -650,12 +650,12 @@ void Resource::reinsert() {
 
 void Resource::makeRequest() {
     if (_request) {
-        PROFILE_ASYNC_END(resourceLog, "Resource:" + getType(), QString::number(_requestID));
+        PROFILE_ASYNC_END(resource, "Resource:" + getType(), QString::number(_requestID));
         _request->disconnect();
         _request->deleteLater();
     }
 
-    PROFILE_ASYNC_BEGIN(resourceLog, "Resource:" + getType(), QString::number(_requestID), { { "url", _url.toString() }, { "activeURL", _activeUrl.toString() } });
+    PROFILE_ASYNC_BEGIN(resource, "Resource:" + getType(), QString::number(_requestID), { { "url", _url.toString() }, { "activeURL", _activeUrl.toString() } });
 
     _request = ResourceManager::createResourceRequest(this, _activeUrl);
 
@@ -663,7 +663,7 @@ void Resource::makeRequest() {
         qCDebug(networking).noquote() << "Failed to get request for" << _url.toDisplayString();
         ResourceCache::requestCompleted(_self);
         finishedLoading(false);
-        PROFILE_ASYNC_END(resourceLog, "Resource:" + getType(), QString::number(_requestID));
+        PROFILE_ASYNC_END(resource, "Resource:" + getType(), QString::number(_requestID));
         return;
     }
     
@@ -688,7 +688,7 @@ void Resource::handleDownloadProgress(uint64_t bytesReceived, uint64_t bytesTota
 void Resource::handleReplyFinished() {
     Q_ASSERT_X(_request, "Resource::handleReplyFinished", "Request should not be null while in handleReplyFinished");
 
-    PROFILE_ASYNC_END(resourceLog, "Resource:" + getType(), QString::number(_requestID), {
+    PROFILE_ASYNC_END(resource, "Resource:" + getType(), QString::number(_requestID), {
         { "from_cache", _request->loadedFromCache() },
         { "size_mb", _bytesTotal / 1000000.0 }
     });

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -86,7 +86,7 @@ SendQueue::SendQueue(Socket* socket, HifiSockAddr dest) :
     _socket(socket),
     _destination(dest)
 {
-    PROFILE_ASYNC_BEGIN(networking, "SendQueue", _destination.toString());
+    PROFILE_ASYNC_BEGIN(network, "SendQueue", _destination.toString());
 
     // setup psuedo-random number generation for all instances of SendQueue
     static std::random_device rd;
@@ -106,7 +106,7 @@ SendQueue::SendQueue(Socket* socket, HifiSockAddr dest) :
 }
 
 SendQueue::~SendQueue() {
-    PROFILE_ASYNC_END(networking, "SendQueue", _destination.toString());
+    PROFILE_ASYNC_END(network, "SendQueue", _destination.toString());
 }
 
 void SendQueue::queuePacket(std::unique_ptr<Packet> packet) {
@@ -227,7 +227,7 @@ void SendQueue::sendHandshake() {
     if (!_hasReceivedHandshakeACK) {
         // we haven't received a handshake ACK from the client, send another now
         auto handshakePacket = ControlPacket::create(ControlPacket::Handshake, sizeof(SequenceNumber));
-        PROFILE_ASYNC_BEGIN(networking, "SendQueue:Handshake", _destination.toString());
+        PROFILE_ASYNC_BEGIN(network, "SendQueue:Handshake", _destination.toString());
 
         handshakePacket->writePrimitive(_initialSequenceNumber);
         _socket->writeBasePacket(*handshakePacket, _destination);
@@ -244,7 +244,7 @@ void SendQueue::handshakeACK(SequenceNumber initialSequenceNumber) {
             std::lock_guard<std::mutex> locker { _handshakeMutex };
             _hasReceivedHandshakeACK = true;
         }
-        PROFILE_ASYNC_END(networking, "SendQueue:Handshake", _destination.toString());
+        PROFILE_ASYNC_END(network, "SendQueue:Handshake", _destination.toString());
 
         // Notify on the handshake ACK condition
         _handshakeACKCondition.notify_one();

--- a/libraries/octree/src/OctreeElement.cpp
+++ b/libraries/octree/src/OctreeElement.cpp
@@ -392,7 +392,6 @@ OctreeElementPointer OctreeElement::addChildAtIndex(int childIndex) {
 
         _isDirty = true;
         markWithChangedTime();
-        PROFILE_INSTANT(octree, "EntityAdd", "g");
     }
     return childAt;
 }

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -793,7 +793,7 @@ void RenderDeferred::configure(const Config& config) {
 }
 
 void RenderDeferred::run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext, const Inputs& inputs) {
-    PROFILE_RANGE(renderlogging, "DeferredLighting");
+    PROFILE_RANGE(render, "DeferredLighting");
 
     auto deferredTransform = inputs.get0();
     auto deferredFramebuffer = inputs.get1();

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -281,7 +281,7 @@ void Model::reset() {
 }
 
 bool Model::updateGeometry() {
-    PROFILE_RANGE(renderutils, __FUNCTION__);
+    PROFILE_RANGE(render, __FUNCTION__);
     PerformanceTimer perfTimer("Model::updateGeometry");
     bool needFullUpdate = false;
 
@@ -476,7 +476,7 @@ bool Model::convexHullContains(glm::vec3 point) {
 // entity-scripts to call.  I think it would be best to do the picking once-per-frame (in cpu, or gpu if possible)
 // and then the calls use the most recent such result.
 void Model::recalculateMeshBoxes(bool pickAgainstTriangles) {
-    PROFILE_RANGE(renderutils, __FUNCTION__);
+    PROFILE_RANGE(render, __FUNCTION__);
     bool calculatedMeshTrianglesNeeded = pickAgainstTriangles && !_calculatedMeshTrianglesValid;
 
     if (!_calculatedMeshBoxesValid || calculatedMeshTrianglesNeeded || (!_calculatedMeshPartBoxesValid && pickAgainstTriangles) ) {
@@ -969,7 +969,7 @@ Blender::Blender(ModelPointer model, int blendNumber, const Geometry::WeakPointe
 }
 
 void Blender::run() {
-    PROFILE_RANGE_EX(renderutils, __FUNCTION__, 0xFFFF0000, 0, { { "url", _model->getURL().toString() } });
+    PROFILE_RANGE_EX(simulation_animation, __FUNCTION__, 0xFFFF0000, 0, { { "url", _model->getURL().toString() } });
     QVector<glm::vec3> vertices, normals;
     if (_model) {
         int offset = 0;
@@ -1090,7 +1090,7 @@ void Model::snapToRegistrationPoint() {
 }
 
 void Model::simulate(float deltaTime, bool fullUpdate) {
-    PROFILE_RANGE(renderutils, __FUNCTION__);
+    PROFILE_RANGE(simulation, __FUNCTION__);
     PerformanceTimer perfTimer("Model::simulate");
     fullUpdate = updateGeometry() || fullUpdate || (_scaleToFit && !_scaledToFit)
                     || (_snapModelToRegistrationPoint && !_snappedToRegistrationPoint);

--- a/libraries/render/src/render/Task.h
+++ b/libraries/render/src/render/Task.h
@@ -572,7 +572,7 @@ public:
 
     void run(const SceneContextPointer& sceneContext, const RenderContextPointer& renderContext) {
         PerformanceTimer perfTimer(_name.c_str());
-        PROFILE_RANGE(renderlogging, _name.c_str());
+        PROFILE_RANGE(render, _name.c_str());
         auto start = usecTimestampNow();
 
         _concept->run(sceneContext, renderContext);

--- a/libraries/shared/src/Profile.cpp
+++ b/libraries/shared/src/Profile.cpp
@@ -20,10 +20,6 @@ Q_LOGGING_CATEGORY(trace_simulation, "trace.simulation")
 Q_LOGGING_CATEGORY(trace_simulation_animation, "trace.simulation.animation")
 Q_LOGGING_CATEGORY(trace_simulation_physics, "trace.simulation.physics")
 
-void foo() {
-    randFloat();
-}
-
 #if defined(NSIGHT_FOUND)
 #include "nvToolsExt.h"
 #define NSIGHT_TRACING

--- a/libraries/shared/src/Profile.cpp
+++ b/libraries/shared/src/Profile.cpp
@@ -8,6 +8,21 @@
 
 #include "Profile.h"
 
+Q_LOGGING_CATEGORY(trace_app, "trace.app")
+Q_LOGGING_CATEGORY(trace_network, "trace.network")
+Q_LOGGING_CATEGORY(trace_parse, "trace.parse")
+Q_LOGGING_CATEGORY(trace_render, "trace.render")
+Q_LOGGING_CATEGORY(trace_render_gpu, "trace.render.gpu")
+Q_LOGGING_CATEGORY(trace_resource, "trace.resource")
+Q_LOGGING_CATEGORY(trace_resource_network, "trace.resource.network")
+Q_LOGGING_CATEGORY(trace_resource_parse, "trace.resource.parse")
+Q_LOGGING_CATEGORY(trace_simulation, "trace.simulation")
+Q_LOGGING_CATEGORY(trace_simulation_animation, "trace.simulation.animation")
+Q_LOGGING_CATEGORY(trace_simulation_physics, "trace.simulation.physics")
+
+void foo() {
+    randFloat();
+}
 
 #if defined(NSIGHT_FOUND)
 #include "nvToolsExt.h"

--- a/libraries/shared/src/Profile.h
+++ b/libraries/shared/src/Profile.h
@@ -11,6 +11,18 @@
 #define HIFI_PROFILE_
 
 #include "Trace.h"
+#include "SharedUtil.h"
+
+Q_DECLARE_LOGGING_CATEGORY(trace_app)
+Q_DECLARE_LOGGING_CATEGORY(trace_network)
+Q_DECLARE_LOGGING_CATEGORY(trace_render)
+Q_DECLARE_LOGGING_CATEGORY(trace_render_gpu)
+Q_DECLARE_LOGGING_CATEGORY(trace_resource)
+Q_DECLARE_LOGGING_CATEGORY(trace_resource_parse)
+Q_DECLARE_LOGGING_CATEGORY(trace_resource_network)
+Q_DECLARE_LOGGING_CATEGORY(trace_simulation)
+Q_DECLARE_LOGGING_CATEGORY(trace_simulation_animation)
+Q_DECLARE_LOGGING_CATEGORY(trace_simulation_physics)
 
 class Duration {
 public:
@@ -51,13 +63,18 @@ inline void counter(const QLoggingCategory& category, const QString& name, const
     }
 }
 
-#define PROFILE_RANGE(category, name) Duration profileRangeThis(category(), name);
-#define PROFILE_RANGE_EX(category, name, argbColor, payload, ...) Duration profileRangeThis(category(), name, argbColor, (uint64_t)payload, ##__VA_ARGS__);
-#define PROFILE_RANGE_BEGIN(category, rangeId, name, argbColor) rangeId = Duration::beginRange(category(), name, argbColor)
-#define PROFILE_RANGE_END(category, rangeId) Duration::endRange(category(), rangeId)
-#define PROFILE_ASYNC_BEGIN(category, name, id, ...) asyncBegin(category(), name, id, ##__VA_ARGS__);
-#define PROFILE_ASYNC_END(category, name, id, ...) asyncEnd(category(), name, id, ##__VA_ARGS__);
-#define PROFILE_COUNTER(category, name, ...) counter(category(), name, ##__VA_ARGS__);
-#define PROFILE_INSTANT(category, name, ...) instant(category(), name, ##__VA_ARGS__);
+#define PROFILE_RANGE(category, name) Duration profileRangeThis(trace_##category(), name);
+#define PROFILE_RANGE_EX(category, name, argbColor, payload, ...) Duration profileRangeThis(trace_##category(), name, argbColor, (uint64_t)payload, ##__VA_ARGS__);
+#define PROFILE_RANGE_BEGIN(category, rangeId, name, argbColor) rangeId = Duration::beginRange(trace_##category(), name, argbColor)
+#define PROFILE_RANGE_END(category, rangeId) Duration::endRange(trace_##category(), rangeId)
+#define PROFILE_ASYNC_BEGIN(category, name, id, ...) asyncBegin(trace_##category(), name, id, ##__VA_ARGS__);
+#define PROFILE_ASYNC_END(category, name, id, ...) asyncEnd(trace_##category(), name, id, ##__VA_ARGS__);
+#define PROFILE_COUNTER(category, name, ...) counter(trace_##category(), name, ##__VA_ARGS__);
+#define PROFILE_INSTANT(category, name, ...) instant(trace_##category(), name, ##__VA_ARGS__);
+
+#define SAMPLE_PROFILE_RANGE(chance, category, name, ...) if (randFloat() <= chance) { PROFILE_RANGE(category, name); }
+#define SAMPLE_PROFILE_RANGE_EX(chance, category, name, ...) if (randFloat() <= chance) { PROFILE_RANGE_EX(category, name, argbColor, payload, ##__VA_ARGS__); }
+#define SAMPLE_PROFILE_COUNTER(chance, category, name, ...) if (randFloat() <= chance) { PROFILE_COUNTER(category, name, ##__VA_ARGS__); }
+#define SAMPLE_PROFILE_INSTANT(chance, category, name, ...) if (randFloat() <= chance) { PROFILE_INSTANT(category, name, ##__VA_ARGS__); }
 
 #endif

--- a/libraries/shared/src/Trace.h
+++ b/libraries/shared/src/Trace.h
@@ -21,8 +21,6 @@
 
 #include "DependencyManager.h"
 
-#define TRACE_ENABLED
-
 namespace tracing {
 
 bool enabled();

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -110,7 +110,7 @@ void OculusDisplayPlugin::hmdPresent() {
         return;
     }
 
-    PROFILE_RANGE_EX(displayplugins, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
 
     int curIndex;
     ovr_GetTextureSwapChainCurrentIndex(_session, _textureSwapChain, &curIndex);

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -529,7 +529,7 @@ static bool isBadPose(vr::HmdMatrix34_t* mat) {
 }
 
 bool OpenVrDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
-    PROFILE_RANGE_EX(displayplugins, __FUNCTION__, 0xff7fff00, frameIndex)
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xff7fff00, frameIndex)
     handleOpenVrEvents();
     if (openVrQuitRequested()) {
         QMetaObject::invokeMethod(qApp, "quit");
@@ -633,7 +633,7 @@ void OpenVrDisplayPlugin::compositeLayers() {
 }
 
 void OpenVrDisplayPlugin::hmdPresent() {
-    PROFILE_RANGE_EX(displayplugins, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
 
     if (_threadedSubmit) {
         _submitThread->waitForPresent();
@@ -654,7 +654,7 @@ void OpenVrDisplayPlugin::hmdPresent() {
 }
 
 void OpenVrDisplayPlugin::postPreview() {
-    PROFILE_RANGE_EX(displayplugins, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
     PoseData nextRender, nextSim;
     nextRender.frameIndex = presentCount();
 

--- a/tests/render-perf/src/main.cpp
+++ b/tests/render-perf/src/main.cpp
@@ -900,7 +900,7 @@ private:
         gpu::doInBatch(gpuContext, [&](gpu::Batch& batch) {
             batch.resetStages();
         });
-        PROFILE_RANGE(renderperflogging, __FUNCTION__);
+        PROFILE_RANGE(render, __FUNCTION__);
         PerformanceTimer perfTimer("draw");
         // The pending changes collecting the changes here
         render::PendingChanges pendingChanges;


### PR DESCRIPTION
* Fix missing stat tracker for agents
* Migrate tracing categories to a parallel set of QLoggingCategories
* Set up a default set of tracing categories
* When writing a tracing file, if a relative path is provided, put the trace output relative the user's documents directory
* Add SAMPLE_XXX tracing macros to do sampling of values, rather than recording them every time