### PR TITLE
Introducing a fix for the overlayered model drawn in front

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -81,6 +81,7 @@ void ModelOverlay::render(RenderArgs* args) {
     }
 
     _model->setVisibleInScene(_visible, scene);
+    _model->setLayeredInFront(getDrawInFront(), scene);
 
     scene->enqueuePendingChanges(pendingChanges);
 }

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -304,6 +304,12 @@ template <> const Item::Bound payloadGetBound(const ModelMeshPartPayload::Pointe
     }
     return Item::Bound();
 }
+template <> int payloadGetLayer(const ModelMeshPartPayload::Pointer& payload) {
+    if (payload) {
+        return payload->getLayer();
+    }
+    return 0;
+}
 
 template <> const ShapeKey shapeGetShapeKey(const ModelMeshPartPayload::Pointer& payload) {
     if (payload) {
@@ -378,6 +384,10 @@ ItemKey ModelMeshPartPayload::getKey() const {
         builder.withInvisible();
     }
 
+    if (_model->isLayeredInFront()) {
+        builder.withLayered();
+    }
+
     if (_isBlendShaped || _isSkinned) {
         builder.withDeformed();
     }
@@ -394,6 +404,17 @@ ItemKey ModelMeshPartPayload::getKey() const {
     }
 
     return builder.build();
+}
+
+int ModelMeshPartPayload::getLayer() const {
+    // MAgic number while we are defining the layering mechanism:
+    const int LAYER_3D_FRONT = 1;
+    const int LAYER_3D = 0;
+    if (_model->isLayeredInFront()) {
+        return LAYER_3D_FRONT;
+    } else {
+        return LAYER_3D;
+    }
 }
 
 ShapeKey ModelMeshPartPayload::getShapeKey() const {

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -95,6 +95,7 @@ public:
 
     // Render Item interface
     render::ItemKey getKey() const override;
+    int getLayer() const;
     render::ShapeKey getShapeKey() const override; // shape interface
     void render(RenderArgs* args) const override;
 
@@ -122,6 +123,7 @@ private:
 namespace render {
     template <> const ItemKey payloadGetKey(const ModelMeshPartPayload::Pointer& payload);
     template <> const Item::Bound payloadGetBound(const ModelMeshPartPayload::Pointer& payload);
+    template <> int payloadGetLayer(const ModelMeshPartPayload::Pointer& payload);
     template <> const ShapeKey shapeGetShapeKey(const ModelMeshPartPayload::Pointer& payload);
     template <> void payloadRender(const ModelMeshPartPayload::Pointer& payload, RenderArgs* args);
 }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -620,6 +620,22 @@ void Model::setVisibleInScene(bool newValue, std::shared_ptr<render::Scene> scen
     }
 }
 
+
+void Model::setLayeredInFront(bool layered, std::shared_ptr<render::Scene> scene) {
+    if (_isLayeredInFront != layered) {
+        _isLayeredInFront = layered;
+
+        render::PendingChanges pendingChanges;
+        foreach(auto item, _modelMeshRenderItems.keys()) {
+            pendingChanges.resetItem(item, _modelMeshRenderItems[item]);
+        }
+        foreach(auto item, _collisionRenderItems.keys()) {
+            pendingChanges.resetItem(item, _collisionRenderItems[item]);
+        }
+        scene->enqueuePendingChanges(pendingChanges);
+    }
+}
+
 bool Model::addToScene(std::shared_ptr<render::Scene> scene,
                        render::PendingChanges& pendingChanges,
                        render::Item::Status::Getters& statusGetters) {

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -80,6 +80,7 @@ public:
 
     // new Scene/Engine rendering support
     void setVisibleInScene(bool newValue, std::shared_ptr<render::Scene> scene);
+    void setLayeredInFront(bool layered, std::shared_ptr<render::Scene> scene);
     bool needsFixupInScene() const;
 
     bool needsReload() const { return _needsReload; }
@@ -97,6 +98,8 @@ public:
     bool isRenderable() const;
 
     bool isVisible() const { return _isVisible; }
+
+    bool isLayeredInFront() const { return _isLayeredInFront; }
 
     void updateRenderItems();
     void setRenderItemsNeedUpdate() { _renderItemsNeedUpdate = true; }
@@ -412,6 +415,8 @@ protected:
     bool _hasCalculatedTextureInfo { false };
     int _renderInfoDrawCalls { 0 };
     int _renderInfoHasTransparent { false };
+
+    bool _isLayeredInFront { false };
 
 private:
     float _loadingPriority { 0.0f };


### PR DESCRIPTION
This PR allows Overlay Models to apply correctly the "DrawInFront" flag.

We simply now communicate a "DrawInFront" flag from the Model to its Reneder Items and apply that to the Item::getKey and the Item::getLayer() function.

##Test Plan
RUn this script: [http://howard-stearns.github.io/models/scripts/draw-in-front-bug.js](url)
IN current master, the wireframe of the avatar is rendered in the 3D scene, not respecting the the "DrawInFornt" property.
In This PR, this should be fixed.

