### PR TITLE
Expose Machine Fingerprint in PAL

### DIFF
--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -800,7 +800,12 @@ void DomainServerSettingsManager::processUsernameFromIDRequestPacket(QSharedPoin
                 usernameFromIDReplyPacket->write(nodeUUID.toRfc4122());
                 usernameFromIDReplyPacket->writeString(verifiedUsername);
 
-                qDebug() << "Sending username" << verifiedUsername << "associated with node" << nodeUUID;
+                // now put in the machine fingerprint
+                DomainServerNodeData* nodeData = reinterpret_cast<DomainServerNodeData*>(matchingNode->getLinkedData());
+                QUuid machineFingerprint = nodeData ? nodeData->getMachineFingerprint() : QUuid();
+                usernameFromIDReplyPacket->write(machineFingerprint.toRfc4122());
+                
+                qDebug() << "Sending username" << verifiedUsername << "and machine fingerprint" << machineFingerprint << "associated with node" << nodeUUID;
 
                 // Ship it!
                 limitedNodeList->sendPacket(std::move(usernameFromIDReplyPacket), *sendingNode);

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -923,8 +923,10 @@ void NodeList::processUsernameFromIDReply(QSharedPointer<ReceivedMessage> messag
     QString nodeUUIDString = (QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID))).toString();
     // read the username from the packet
     QString username = message->readString();
+    // read the machine fingerprint from the packet
+    QString machineFingerprintString = (QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID))).toString();
 
-    qDebug() << "Got username" << username << "for node" << nodeUUIDString;
+    qDebug() << "Got username" << username << "and machine fingerprint" << machineFingerprintString << "for node" << nodeUUIDString;
 
-    emit usernameFromIDReply(nodeUUIDString, username);
+    emit usernameFromIDReply(nodeUUIDString, username, machineFingerprintString);
 }

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -111,7 +111,7 @@ signals:
     void receivedDomainServerList();
     void ignoredNode(const QUuid& nodeID);
     void ignoreRadiusEnabledChanged(bool isIgnored);
-    void usernameFromIDReply(const QString& nodeID, const QString& username);
+    void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint);
 
 private slots:
     void stopKeepalivePingTimer();

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -80,6 +80,9 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AudioStreamStats:
             return static_cast<PacketVersion>(AudioVersion::SpaceBubbleChanges);
 
+        case PacketType::UsernameFromIDReply:
+            return static_cast<PacketVersion>(UsernameFromIDReplyVersion::HasMachineFingerprint);
+
         default:
             return 17;
     }

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -44,7 +44,7 @@ const QSet<PacketType> NON_SOURCED_PACKETS = QSet<PacketType>()
 PacketVersion versionForPacketType(PacketType packetType) {
     switch (packetType) {
         case PacketType::DomainList:
-            return static_cast<PacketVersion>(DomainListVersion::GetUsernameFromUUIDSupport);
+            return static_cast<PacketVersion>(DomainListVersion::GetMachineFingerprintFromUUIDSupport);
         case PacketType::EntityAdd:
         case PacketType::EntityEdit:
         case PacketType::EntityData:
@@ -79,9 +79,6 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::MicrophoneAudioWithEcho:
         case PacketType::AudioStreamStats:
             return static_cast<PacketVersion>(AudioVersion::SpaceBubbleChanges);
-
-        case PacketType::UsernameFromIDReply:
-            return static_cast<PacketVersion>(UsernameFromIDReplyVersion::HasMachineFingerprint);
 
         default:
             return 17;

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -230,7 +230,8 @@ enum class DomainServerAddedNodeVersion : PacketVersion {
 enum class DomainListVersion : PacketVersion {
     PrePermissionsGrid = 18,
     PermissionsGrid,
-    GetUsernameFromUUIDSupport
+    GetUsernameFromUUIDSupport,
+    GetMachineFingerprintFromUUIDSupport
 };
 
 enum class AudioVersion : PacketVersion {
@@ -239,10 +240,6 @@ enum class AudioVersion : PacketVersion {
     Exactly10msAudioPackets,
     TerminatingStreamStats,
     SpaceBubbleChanges,
-};
-
-enum class UsernameFromIDReplyVersion : PacketVersion {
-    HasMachineFingerprint = 18
 };
 
 #endif // hifi_PacketHeaders_h

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -241,4 +241,8 @@ enum class AudioVersion : PacketVersion {
     SpaceBubbleChanges,
 };
 
+enum class UsernameFromIDReplyVersion : PacketVersion {
+    HasMachineFingerprint = 18
+};
+
 #endif // hifi_PacketHeaders_h

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -101,10 +101,10 @@ signals:
     void enteredIgnoreRadius();
 
     /**jsdoc
-    * Notifies scripts of the username associated with a UUID.
-    * @function Users.enteredIgnoreRadius
+    * Notifies scripts of the username and machine fingerprint associated with a UUID.
+    * @function Users.usernameFromIDReply
     */
-    void usernameFromIDReply(const QString& nodeID, const QString& username);
+    void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint);
 };
 
 

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -137,7 +137,7 @@ function populateUserList() {
 }
 
 // The function that handles the reply from the server
-function usernameFromIDReply(id, username) {
+function usernameFromIDReply(id, username, machineFingerprint) {
     var data;
     // If the ID we've received is our ID...
     if (AvatarList.getAvatar('').sessionUUID === id) {
@@ -145,7 +145,7 @@ function usernameFromIDReply(id, username) {
         data = ['', username + ' (hidden)']
     } else {
         // Set the data to contain the ID and the username+ID concat string.
-        data = [id, username + '/' + id];
+        data = [id, username + '/' + machineFingerprint];
     }
     print('Username Data:', JSON.stringify(data));
     // Ship the data off to QML


### PR DESCRIPTION
For now, just putting the machine fingerprint UUID in the PAL where the domain-server's uuid was shown before. 

Test Plan:
Open up PAL with another person (running this PR) in the domain.  You will see the uuid below their name be their machine fingerprint, when they are anonymous (since only anonymous users send machine fingerprint).   That fingerprint is easy to see in the interface log -- right at the top maybe 2nd line down.