### PR TITLE
Only send machine fingerprint when not logged in

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -66,7 +66,6 @@
 #include <ErrorDialog.h>
 #include <FileScriptingInterface.h>
 #include <Finally.h>
-#include <FingerprintUtils.h>
 #include <FramebufferCache.h>
 #include <gpu/Batch.h>
 #include <gpu/Context.h>
@@ -614,9 +613,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us
     
-    // TODO: This is temporary, while developing
-    FingerprintUtils::getMachineFingerprint();
-    // End TODO
     auto nodeList = DependencyManager::get<NodeList>();
 
     // Set up a watchdog thread to intentionally crash the application on deadlocks

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -373,9 +373,8 @@ void NodeList::sendDomainServerCheckIn() {
 
             packetStream << hardwareAddress;
 
-            // add in machine fingerprint
-            QUuid machineFingerprint = FingerprintUtils::getMachineFingerprint();
-            packetStream << machineFingerprint;
+            auto accountManager = DependencyManager::get<AccountManager>();
+            packetStream << (accountManager->isLoggedIn() ? QUuid() : FingerprintUtils::getMachineFingerprint());
         }
 
         // pack our data to send to the domain-server including

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -373,6 +373,7 @@ void NodeList::sendDomainServerCheckIn() {
 
             packetStream << hardwareAddress;
 
+            // now add the machine fingerprint - a null UUID if logged in, real one if not logged in
             auto accountManager = DependencyManager::get<AccountManager>();
             packetStream << (accountManager->isLoggedIn() ? QUuid() : FingerprintUtils::getMachineFingerprint());
         }


### PR DESCRIPTION
While at it, no longer grabbing it at all when starting up, as that was just a dev thing.  Should consider not sending MAC address too, but we may revisit that later.

Test Plan:

You need 2 clients.  On localhost, you are automatically an admin, so one client on localhost, the other client on a different machine.  When they pop in, look in PAL.  If they are logged in, the PAL will display the machine fingerprint as {000.,}.  When not logged in, the actual fingerprint.  Login and logout during a session, the machine fingerprint should come/go as expected (only when _not_ logged in).  

While at it, look at the PAL on the other client, and verify you don't see the user name or machine fingerprint when you don't have kick rights.  