### PR TITLE
Immediate visual ignore

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -558,6 +558,10 @@ void AvatarMixer::handleKillAvatarPacket(QSharedPointer<ReceivedMessage> message
 }
 
 void AvatarMixer::handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
+    auto killPacket = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID + sizeof(KillAvatarReason));
+    killPacket->write(message->peek(NUM_BYTES_RFC4122_UUID));
+    killPacket->writePrimitive(KillAvatarReason::AvatarIgnored);
+    DependencyManager::get<NodeList>()->sendUnreliablePacket(*killPacket, *senderNode);
     senderNode->parseIgnoreRequestMessage(message);
 }
 


### PR DESCRIPTION
Currently, clicking "Ignore" for an avatar results in a ~5 second delay before the other avatar actually disappears. However, the audio for the ignored avatar cuts out immediately.

This PR causes the ignored avatar to disappear immediately, removing the delay and enabling behavior parity between the audio and visuals.