### PR TITLE
Fix "Running Scripts" window being inaccessible

### DIFF
--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -22,7 +22,7 @@ ScrollingWindow {
     objectName: "RunningScripts"
     title: "Running Scripts"
     resizable: true
-    destroyOnHidden: true
+    destroyOnHidden: false
     implicitWidth: 424
     implicitHeight: isHMD ? 695 : 728
     minSize: Qt.vector2d(424, 300)


### PR DESCRIPTION
I have reason to believe that our proprietary "destroyOnHidden" property of our Window.qml object is causing problems. Or, perhaps it is our code that hides QML windows...in either case, this one-line change fixes an annoying issue I've been having for a long time. It doesn't fix any underlying bugs, but I propose that's OK for now...

To test that "destroyOnHidden: true" causes problems:
1. Using any HiFi build except this one, enter any domain.
2. Move your avatar a few steps. Notice that the HUD collapses and all non-pinned windows fade out. This is intended behavior.
3. *While the HUD is collapsed*, press Ctrl+J to invoke the "Running Scripts" window.
4. Notice that the window doesn't appear...Also notice that your mouse is "on top" of the invisible window, and thus you can't, for example, hold right click to turn. Additionally, notice that you will never be able to get the "Running Scripts" window to appear again without restarting Interface. Infuriating!

If you run Interface using this build, you'll notice that the "Running Scripts" window is invoked properly and behaves as expected.

This bug _definitely_ applies to other windows with the "destroyOnHidden: true" property, and I'm concerned that this particular bug has affected people more than they realize. This quick change doesn't fix windows such as the Browser, where this buggy behavior remains present.

Anyway, since I use the Ctrl+J shortcut so often and have run into this bug more times than I can count, I'd like to merge this quick "fix" into Master.