### PR TITLE
First attempt at PAL operations with ignore

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -65,6 +65,7 @@ AudioMixer::AudioMixer(ReceivedMessage& message) :
     packetReceiver.registerListener(PacketType::NegotiateAudioFormat, this, "handleNegotiateAudioFormat");
     packetReceiver.registerListener(PacketType::MuteEnvironment, this, "handleMuteEnvironmentPacket");
     packetReceiver.registerListener(PacketType::NodeIgnoreRequest, this, "handleNodeIgnoreRequestPacket");
+    packetReceiver.registerListener(PacketType::NodeUnignoreRequest, this, "handleNodeUnignoreRequestPacket");
     packetReceiver.registerListener(PacketType::KillAvatar, this, "handleKillAvatarPacket");
     packetReceiver.registerListener(PacketType::NodeMuteRequest, this, "handleNodeMuteRequestPacket");
     packetReceiver.registerListener(PacketType::RadiusIgnoreRequest, this, "handleRadiusIgnoreRequestPacket");
@@ -223,6 +224,10 @@ void AudioMixer::handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, 
 
 void AudioMixer::handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {
     sendingNode->parseIgnoreRequestMessage(packet);
+}
+
+void AudioMixer::handleNodeUnignoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {
+    sendingNode->parseUnignoreRequestMessage(packet);
 }
 
 void AudioMixer::handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -62,6 +62,7 @@ private slots:
     void handleNegotiateAudioFormat(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void handleNodeKilled(SharedNodePointer killedNode);
     void handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
+    void handleNodeUnignoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleNodeMuteRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -347,7 +347,6 @@ void AvatarMixer::broadcastAvatarData() {
                         && (forceSend
                             || otherNodeData->getIdentityChangeTimestamp() > _lastFrameTimestamp
                             || distribution(generator) < IDENTITY_SEND_PROBABILITY)) {
-                        qDebug() << "FIXME HRS sending identity to" << node->getUUID() << "from" << otherNode->getUUID() << "gets mine/all/view:" << getsIgnoredByMe << getsAnyIgnored << getsOutOfView ;
                         sendIdentityPacket(otherNodeData, node);
                     }
 
@@ -417,7 +416,6 @@ void AvatarMixer::broadcastAvatarData() {
                                         ? AvatarData::SendAllData : AvatarData::IncludeSmallData;
                         nodeData->incrementAvatarInView();
                     }
-                    //qDebug() << "FIXME HRS sending" << detail << "to" << node->getUUID() << "from" << otherNode->getUUID();
 
                     numAvatarDataBytes += avatarPacketList->write(otherNode->getUUID().toRfc4122());
                     numAvatarDataBytes += avatarPacketList->write(otherAvatar.toByteArray(detail));
@@ -552,14 +550,12 @@ void AvatarMixer::handleViewFrustumPacket(QSharedPointer<ReceivedMessage> messag
 void AvatarMixer::handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
     auto nodeList = DependencyManager::get<NodeList>();
     nodeList->getOrCreateLinkedData(senderNode);
-    qDebug() << "HRS FIXME received RequestsDomainListData packet from" << senderNode->getUUID();
 
     if (senderNode->getLinkedData()) {
         AvatarMixerClientData* nodeData = dynamic_cast<AvatarMixerClientData*>(senderNode->getLinkedData());
         if (nodeData != nullptr) {
             bool isRequesting;
             message->readPrimitive(&isRequesting);
-            qDebug() << "HRS FIXME handling RequestsDomainListData packet" << isRequesting << "from" << nodeData->getNodeID();
             nodeData->setRequestsDomainListData(isRequesting);
         }
     }

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -51,7 +51,7 @@ AvatarMixer::AvatarMixer(ReceivedMessage& message) :
     packetReceiver.registerListener(PacketType::NodeIgnoreRequest, this, "handleNodeIgnoreRequestPacket");
     packetReceiver.registerListener(PacketType::NodeUnignoreRequest, this, "handleNodeUnignoreRequestPacket");
     packetReceiver.registerListener(PacketType::RadiusIgnoreRequest, this, "handleRadiusIgnoreRequestPacket");
-    packetReceiver.registerListener(PacketType::RequestDomainListData, this, "handleRequestDomainListDataPacket");
+    packetReceiver.registerListener(PacketType::RequestsDomainListData, this, "handleRequestsDomainListDataPacket");
 
     auto nodeList = DependencyManager::get<NodeList>();
     connect(nodeList.data(), &NodeList::packetVersionMismatch, this, &AvatarMixer::handlePacketVersionMismatch);
@@ -536,18 +536,18 @@ void AvatarMixer::handleViewFrustumPacket(QSharedPointer<ReceivedMessage> messag
     }
 }
 
-void AvatarMixer::handleRequestDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
+void AvatarMixer::handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
     auto nodeList = DependencyManager::get<NodeList>();
     nodeList->getOrCreateLinkedData(senderNode);
-    qDebug() << "HRS FIXME received requestDomainListData packet from" << senderNode->getUUID();
+    qDebug() << "HRS FIXME received RequestsDomainListData packet from" << senderNode->getUUID();
 
     if (senderNode->getLinkedData()) {
         AvatarMixerClientData* nodeData = dynamic_cast<AvatarMixerClientData*>(senderNode->getLinkedData());
         if (nodeData != nullptr) {
             bool isRequesting;
             message->readPrimitive(&isRequesting);
-            qDebug() << "HRS FIXME handling requestDomainListData packet" << isRequesting << "from" << nodeData->getNodeID();
-            nodeData->setRequestDomainListData(isRequesting);
+            qDebug() << "HRS FIXME handling RequestsDomainListData packet" << isRequesting << "from" << nodeData->getNodeID();
+            nodeData->setRequestsDomainListData(isRequesting);
         }
     }
 }

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -585,6 +585,9 @@ void AvatarMixer::handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> 
     senderNode->parseIgnoreRequestMessage(message);
 }
 
+void AvatarMixer::handleNodeUnignoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {
+    sendingNode->parseUnignoreRequestMessage(packet);
+}
 void AvatarMixer::handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode) {
     sendingNode->parseIgnoreRadiusRequestMessage(packet);
 }

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -49,6 +49,7 @@ AvatarMixer::AvatarMixer(ReceivedMessage& message) :
     packetReceiver.registerListener(PacketType::AvatarIdentity, this, "handleAvatarIdentityPacket");
     packetReceiver.registerListener(PacketType::KillAvatar, this, "handleKillAvatarPacket");
     packetReceiver.registerListener(PacketType::NodeIgnoreRequest, this, "handleNodeIgnoreRequestPacket");
+    packetReceiver.registerListener(PacketType::NodeUnignoreRequest, this, "handleNodeUnignoreRequestPacket");
     packetReceiver.registerListener(PacketType::RadiusIgnoreRequest, this, "handleRadiusIgnoreRequestPacket");
     packetReceiver.registerListener(PacketType::RequestDomainListData, this, "handleRequestDomainListDataPacket");
 
@@ -208,8 +209,8 @@ void AvatarMixer::broadcastAvatarData() {
 
             // send extra data that is otherwise surpressed
             bool getsOutOfView = nodeData->getRequestsDomainListData();
-            bool getsAnyIgnored = node->getCanKick();
-            bool getsIgnoredByMe = getsAnyIgnored || nodeData->getRequestsDomainListData();
+            bool getsIgnoredByMe = nodeData->getRequestsDomainListData();
+            bool getsAnyIgnored = getsIgnoredByMe && node->getCanKick();
 
             // Check if it is time to adjust what we send this client based on the observed
             // bandwidth to this node. We do this once a second, which is also the window for
@@ -339,7 +340,7 @@ void AvatarMixer::broadcastAvatarData() {
                         && (forceSend
                             || otherNodeData->getIdentityChangeTimestamp() > _lastFrameTimestamp
                             || distribution(generator) < IDENTITY_SEND_PROBABILITY)) {
-                        qDebug() << "FIXME HRS sending identity to" << node->getUUID() << "from" << otherNode->getUUID();
+                        qDebug() << "FIXME HRS sending identity to" << node->getUUID() << "from" << otherNode->getUUID() << "gets mine/all/view:" << getsIgnoredByMe << getsAnyIgnored << getsOutOfView ;
                         sendIdentityPacket(otherNodeData, node);
                     }
 

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -207,9 +207,13 @@ void AvatarMixer::broadcastAvatarData() {
             // use the data rate specifically for avatar data for FRD adjustment checks
             float avatarDataRateLastSecond = nodeData->getOutboundAvatarDataKbps();
 
-            // send extra data that is otherwise surpressed
+            // When this is true, the AvatarMixer will send Avatar data to a client about avatars that are not in the view frustrum
             bool getsOutOfView = nodeData->getRequestsDomainListData();
-            bool getsIgnoredByMe = nodeData->getRequestsDomainListData();
+
+            // When this is true, the AvatarMixer will send Avatar data to a client about avatars that they've ignored
+            bool getsIgnoredByMe = getsOutOfView;
+            
+            // When this is true, the AvatarMixer will send Avatar data to a client about avatars that have ignored them
             bool getsAnyIgnored = getsIgnoredByMe && node->getCanKick();
 
             // Check if it is time to adjust what we send this client based on the observed

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -42,6 +42,7 @@ private slots:
     void handleKillAvatarPacket(QSharedPointer<ReceivedMessage> message);
     void handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
+    void handleRequestDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void domainSettingsRequestComplete();
     void handlePacketVersionMismatch(PacketType type, const HifiSockAddr& senderSockAddr, const QUuid& senderUUID);
 

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -41,6 +41,7 @@ private slots:
     void handleAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleKillAvatarPacket(QSharedPointer<ReceivedMessage> message);
     void handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
+    void handleNodeUnignoreRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleRequestDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void domainSettingsRequestComplete();

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -43,7 +43,7 @@ private slots:
     void handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleNodeUnignoreRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
-    void handleRequestDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
+    void handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void domainSettingsRequestComplete();
     void handlePacketVersionMismatch(PacketType type, const HifiSockAddr& senderSockAddr, const QUuid& senderUUID);
 

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -102,7 +102,7 @@ public:
     const QString& getBaseDisplayName() { return _baseDisplayName; }
     void setBaseDisplayName(const QString& baseDisplayName) { _baseDisplayName = baseDisplayName; }
     bool getRequestsDomainListData() { return _requestsDomainListData; }
-    void setRequestDomainListData(bool requesting) { _requestsDomainListData = requesting; }
+    void setRequestsDomainListData(bool requesting) { _requestsDomainListData = requesting; }
 
 private:
     AvatarSharedPointer _avatar { new AvatarData() };

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -101,6 +101,8 @@ public:
     void incrementAvatarOutOfView() { _recentOtherAvatarsOutOfView++; }
     const QString& getBaseDisplayName() { return _baseDisplayName; }
     void setBaseDisplayName(const QString& baseDisplayName) { _baseDisplayName = baseDisplayName; }
+    bool getRequestsDomainListData() { return _requestsDomainListData; }
+    void setRequestDomainListData(bool requesting) { _requestsDomainListData = requesting; }
 
 private:
     AvatarSharedPointer _avatar { new AvatarData() };
@@ -129,6 +131,7 @@ private:
     int _recentOtherAvatarsInView { 0 };
     int _recentOtherAvatarsOutOfView { 0 };
     QString _baseDisplayName{}; // The santized key used in determinging unique sessionDisplayName, so that we can remove from dictionary.
+    bool _requestsDomainListData { false };
 };
 
 #endif // hifi_AvatarMixerClientData_h

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -44,6 +44,7 @@
 #include "Util.h"
 #include "world.h"
 #include "InterfaceLogging.h"
+#include "SceneScriptingInterface.h"
 #include "SoftAttachmentModel.h"
 #include <Rig.h>
 
@@ -467,6 +468,7 @@ bool Avatar::addToScene(AvatarSharedPointer self, std::shared_ptr<render::Scene>
         attachmentModel->addToScene(scene, pendingChanges);
     }
 
+    _inScene = true;
     return true;
 }
 
@@ -477,6 +479,7 @@ void Avatar::removeFromScene(AvatarSharedPointer self, std::shared_ptr<render::S
     for (auto& attachmentModel : _attachmentModels) {
         attachmentModel->removeFromScene(scene, pendingChanges);
     }
+    _inScene = false;
 }
 
 void Avatar::updateRenderItem(render::PendingChanges& pendingChanges) {
@@ -1334,5 +1337,23 @@ void Avatar::setParentJointIndex(quint16 parentJointIndex) {
         if (!success) {
             qCDebug(interfaceapp) << "Avatar::setParentJointIndex failed to reset avatar's location.";
         }
+    }
+}
+
+void Avatar::addToScene(AvatarSharedPointer myHandle) {
+    render::ScenePointer scene = qApp->getMain3DScene();
+    if (scene) {
+        render::PendingChanges pendingChanges;
+        if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars() && !DependencyManager::get<NodeList>()->isIgnoringNode(getSessionUUID())) {
+            addToScene(myHandle, scene, pendingChanges);
+        }
+        scene->enqueuePendingChanges(pendingChanges);
+    } else {
+        qCWarning(interfaceapp) << "AvatarManager::addAvatar() : Unexpected null scene, possibly during application shutdown";
+    }
+}
+void Avatar::ensureInScene(AvatarSharedPointer self) {
+    if (!_inScene) {
+        addToScene(self);
     }
 }

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -292,7 +292,15 @@ void Avatar::updateAvatarEntities() {
     }
 }
 
+void Avatar::setShouldDie() {
+    // This will cause the avatar to be shrunk away and removed (the actual Avatar gets removed), but then it comes back.
+    _owningAvatarMixer.clear();
 
+    // This removes the avatar from physics and makes it shrink away, but does not actualy remvoe Avatar from Avatar Manager.
+    // FIXME hrs remove, unless it can be made to work cleanly.
+    // (In which case, this could be on AvatarList/AvatarManager instead, and consider moving pal.js usage to Pal.qml, and removing (un)ignoredNode signalling.)
+    //DependencyManager::get<AvatarManager>()->handleRemovedAvatar(AvatarSharedPointer(this), AvatarIgnored);
+}
 
 void Avatar::simulate(float deltaTime) {
     PerformanceTimer perfTimer("simulate");

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -296,11 +296,6 @@ void Avatar::updateAvatarEntities() {
 void Avatar::setShouldDie() {
     // This will cause the avatar to be shrunk away and removed (the actual Avatar gets removed), but then it comes back.
     _owningAvatarMixer.clear();
-
-    // This removes the avatar from physics and makes it shrink away, but does not actualy remvoe Avatar from Avatar Manager.
-    // FIXME hrs remove, unless it can be made to work cleanly.
-    // (In which case, this could be on AvatarList/AvatarManager instead, and consider moving pal.js usage to Pal.qml, and removing (un)ignoredNode signalling.)
-    //DependencyManager::get<AvatarManager>()->handleRemovedAvatar(AvatarSharedPointer(this), AvatarIgnored);
 }
 
 void Avatar::simulate(float deltaTime) {

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -178,6 +178,8 @@ public:
     glm::vec3 getUncachedRightPalmPosition() const;
     glm::quat getUncachedRightPalmRotation() const;
 
+    Q_INVOKABLE void setShouldDie();
+
 public slots:
 
     // FIXME - these should be migrated to use Pose data instead

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -256,6 +256,9 @@ protected:
     ThreadSafeValueCache<glm::vec3> _rightPalmPositionCache { glm::vec3() };
     ThreadSafeValueCache<glm::quat> _rightPalmRotationCache { glm::quat() };
 
+    void addToScene(AvatarSharedPointer self);
+    void ensureInScene(AvatarSharedPointer self);
+
 private:
     int _leftPointerGeometryID { 0 };
     int _rightPointerGeometryID { 0 };
@@ -264,6 +267,7 @@ private:
     bool _shouldAnimate { true };
     bool _shouldSkipRender { false };
     bool _isLookAtTarget { false };
+    bool _inScene { false };
 
     float getBoundingRadius() const;
 

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -198,6 +198,7 @@ void AvatarManager::simulateAvatarFades(float deltaTime) {
         if (avatar->getTargetScale() <= MIN_FADE_SCALE) {
             avatar->removeFromScene(*fadingIterator, scene, pendingChanges);
             // only remove from _avatarFades if we're sure its motionState has been removed from PhysicsEngine
+            qDebug() << "fixme hrs at minimum fade scale" << _motionStatesToRemoveFromPhysics.empty();
             if (_motionStatesToRemoveFromPhysics.empty()) {
                 fadingIterator = _avatarFades.erase(fadingIterator);
             } else {

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -159,6 +159,7 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
             removeAvatar(avatarIterator.key());
             ++avatarIterator;
         } else {
+            avatar->ensureInScene(avatar);
             avatar->simulate(deltaTime);
             ++avatarIterator;
 
@@ -198,7 +199,6 @@ void AvatarManager::simulateAvatarFades(float deltaTime) {
         if (avatar->getTargetScale() <= MIN_FADE_SCALE) {
             avatar->removeFromScene(*fadingIterator, scene, pendingChanges);
             // only remove from _avatarFades if we're sure its motionState has been removed from PhysicsEngine
-            qDebug() << "fixme hrs at minimum fade scale" << _motionStatesToRemoveFromPhysics.empty();
             if (_motionStatesToRemoveFromPhysics.empty()) {
                 fadingIterator = _avatarFades.erase(fadingIterator);
             } else {
@@ -220,16 +220,7 @@ AvatarSharedPointer AvatarManager::addAvatar(const QUuid& sessionUUID, const QWe
     auto newAvatar = AvatarHashMap::addAvatar(sessionUUID, mixerWeakPointer);
     auto rawRenderableAvatar = std::static_pointer_cast<Avatar>(newAvatar);
 
-    render::ScenePointer scene = qApp->getMain3DScene();
-    if (scene) {
-        render::PendingChanges pendingChanges;
-        if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()) {
-            rawRenderableAvatar->addToScene(rawRenderableAvatar, scene, pendingChanges);
-        }
-        scene->enqueuePendingChanges(pendingChanges);
-    } else {
-        qCWarning(interfaceapp) << "AvatarManager::addAvatar() : Unexpected null scene, possibly during application shutdown";
-    }
+    rawRenderableAvatar->addToScene(rawRenderableAvatar);
 
     return newAvatar;
 }

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -93,7 +93,6 @@ private:
     // virtual overrides
     virtual AvatarSharedPointer newSharedAvatar() override;
     virtual AvatarSharedPointer addAvatar(const QUuid& sessionUUID, const QWeakPointer<Node>& mixerWeakPointer) override;
-
     virtual void handleRemovedAvatar(const AvatarSharedPointer& removedAvatar, KillAvatarReason removalReason = KillAvatarReason::NoReason) override;
 
     QVector<AvatarSharedPointer> _avatarFades;

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -112,7 +112,7 @@ void AvatarHashMap::processAvatarDataPacket(QSharedPointer<ReceivedMessage> mess
         // make sure this isn't our own avatar data or for a previously ignored node
         auto nodeList = DependencyManager::get<NodeList>();
 
-        if (sessionUUID != _lastOwnerSessionUUID && !nodeList->isIgnoringNode(sessionUUID)) {
+        if (sessionUUID != _lastOwnerSessionUUID && (!nodeList->isIgnoringNode(sessionUUID) || nodeList->getRequestsDomainListData())) {
             auto avatar = newOrExistingAvatar(sessionUUID, sendingNode);
 
             // have the matching (or new) avatar parse the data from the packet
@@ -145,7 +145,8 @@ void AvatarHashMap::processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> 
             identity.uuid = EMPTY;
         }
     }
-    if (!nodeList->isIgnoringNode(identity.uuid)) {
+    qDebug() << "FIXME HRS processing identity packet regarding" << identity.uuid << "ignoring:" << nodeList->isIgnoringNode(identity.uuid) << "reqestsDomainList:" << nodeList->getRequestsDomainListData();
+    if (!nodeList->isIgnoringNode(identity.uuid) || nodeList->getRequestsDomainListData()) {
         // mesh URL for a UUID, find avatar in our list
         auto avatar = newOrExistingAvatar(identity.uuid, sendingNode);
         avatar->processAvatarIdentity(identity);

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -145,7 +145,6 @@ void AvatarHashMap::processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> 
             identity.uuid = EMPTY;
         }
     }
-    qDebug() << "FIXME HRS processing identity packet regarding" << identity.uuid << "ignoring:" << nodeList->isIgnoringNode(identity.uuid) << "reqestsDomainList:" << nodeList->getRequestsDomainListData();
     if (!nodeList->isIgnoringNode(identity.uuid) || nodeList->getRequestsDomainListData()) {
         // mesh URL for a UUID, find avatar in our list
         auto avatar = newOrExistingAvatar(identity.uuid, sendingNode);

--- a/libraries/networking/src/Node.cpp
+++ b/libraries/networking/src/Node.cpp
@@ -118,7 +118,7 @@ void Node::removeIgnoredNode(const QUuid& otherNodeID) {
         // remove the session UUID from the set of ignored ones for this listening node
         _ignoredNodeIDSet.unsafe_erase(otherNodeID);
     } else {
-        qCWarning(networking) << "Node::addIgnoredNode called with null ID or ID of ignoring node.";
+        qCWarning(networking) << "Node::removeIgnoredNode called with null ID or ID of ignoring node.";
     }
 }
 

--- a/libraries/networking/src/Node.h
+++ b/libraries/networking/src/Node.h
@@ -21,6 +21,7 @@
 #include <QtCore/QSharedPointer>
 #include <QtCore/QUuid>
 
+#include <QReadLocker>
 #include <UUIDHasher.h>
 
 #include <tbb/concurrent_unordered_set.h>
@@ -72,8 +73,10 @@ public:
     bool getCanKick() const { return _permissions.can(NodePermissions::Permission::canKick); }
 
     void parseIgnoreRequestMessage(QSharedPointer<ReceivedMessage> message);
+    void parseUnignoreRequestMessage(QSharedPointer<ReceivedMessage> message);
     void addIgnoredNode(const QUuid& otherNodeID);
-    bool isIgnoringNodeWithID(const QUuid& nodeID) const { return _ignoredNodeIDSet.find(nodeID) != _ignoredNodeIDSet.cend(); }
+    void removeIgnoredNode(const QUuid& otherNodeID);
+    bool isIgnoringNodeWithID(const QUuid& nodeID) const { QReadLocker lock { &_ignoredNodeIDSetLock }; return _ignoredNodeIDSet.find(nodeID) != _ignoredNodeIDSet.cend(); }
     void parseIgnoreRadiusRequestMessage(QSharedPointer<ReceivedMessage> message);
 
     friend QDataStream& operator<<(QDataStream& out, const Node& node);
@@ -97,6 +100,7 @@ private:
     MovingPercentile _clockSkewMovingPercentile;
     NodePermissions _permissions;
     tbb::concurrent_unordered_set<QUuid, UUIDHasher> _ignoredNodeIDSet;
+    mutable QReadWriteLock _ignoredNodeIDSetLock;
 
     std::atomic_bool _ignoreRadiusEnabled;
 };

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -812,7 +812,7 @@ void NodeList::ignoreNodeBySessionID(const QUuid& nodeID) {
 }
 
 void NodeList::unignoreNodeBySessionID(const QUuid& nodeID) {
-    // enumerate the nodes to send a reliable ignore packet to each that can leverage it
+    // enumerate the nodes to send a reliable unignore packet to each that can leverage it
     if (!nodeID.isNull() && _sessionUUID != nodeID) {
         eachMatchingNode([&nodeID](const SharedNodePointer& node)->bool {
             if (node->getType() == NodeType::AudioMixer || node->getType() == NodeType::AvatarMixer) {
@@ -821,7 +821,7 @@ void NodeList::unignoreNodeBySessionID(const QUuid& nodeID) {
                 return false;
             }
         }, [&nodeID, this](const SharedNodePointer& destinationNode) {
-            // create a reliable NLPacket with space for the ignore UUID
+            // create a reliable NLPacket with space for the unignore UUID
             auto ignorePacket = NLPacket::create(PacketType::NodeUnignoreRequest, NUM_BYTES_RFC4122_UUID, true);
 
             // write the node ID to the packet
@@ -829,7 +829,7 @@ void NodeList::unignoreNodeBySessionID(const QUuid& nodeID) {
 
             qCDebug(networking) << "Sending packet to unignore node" << uuidStringWithoutCurlyBraces(nodeID);
 
-            // send off this ignore packet reliably to the matching node
+            // send off this unignore packet reliably to the matching node
             sendPacket(std::move(ignorePacket), *destinationNode);
         });
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -974,7 +974,6 @@ void NodeList::setRequestsDomainListData(bool isRequesting) {
         auto packet = NLPacket::create(PacketType::RequestsDomainListData, sizeof(bool), true); // reliable
         packet->writePrimitive(isRequesting);
         sendPacket(std::move(packet), *destinationNode);
-        qDebug() << "HRS FIXME sending RequestsDomainListData packet" << isRequesting;
     });
     _requestsDomainListData = isRequesting;
 }

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -930,3 +930,19 @@ void NodeList::processUsernameFromIDReply(QSharedPointer<ReceivedMessage> messag
 
     emit usernameFromIDReply(nodeUUIDString, username, machineFingerprintString);
 }
+
+void NodeList::setRequestsDomainListData(bool isRequesting) {
+    // Tell the avatar mixer whether I want to receive any additional data to which I might be entitiled .
+    if (_requestsDomainListData == isRequesting) {
+        return;
+    }
+    eachMatchingNode([](const SharedNodePointer& node)->bool {
+        return node->getType() == NodeType::AvatarMixer;
+    }, [this, isRequesting](const SharedNodePointer& destinationNode) {
+        auto packet = NLPacket::create(PacketType::RequestDomainListData, sizeof(bool), true); // reliable
+        packet->writePrimitive(isRequesting);
+        sendPacket(std::move(packet), *destinationNode);
+        qDebug() << "HRS FIXME sending requestDomainListData packet" << isRequesting;
+    });
+    _requestsDomainListData = isRequesting;
+}

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -971,10 +971,10 @@ void NodeList::setRequestsDomainListData(bool isRequesting) {
     eachMatchingNode([](const SharedNodePointer& node)->bool {
         return node->getType() == NodeType::AvatarMixer;
     }, [this, isRequesting](const SharedNodePointer& destinationNode) {
-        auto packet = NLPacket::create(PacketType::RequestDomainListData, sizeof(bool), true); // reliable
+        auto packet = NLPacket::create(PacketType::RequestsDomainListData, sizeof(bool), true); // reliable
         packet->writePrimitive(isRequesting);
         sendPacket(std::move(packet), *destinationNode);
-        qDebug() << "HRS FIXME sending requestDomainListData packet" << isRequesting;
+        qDebug() << "HRS FIXME sending RequestsDomainListData packet" << isRequesting;
     });
     _requestsDomainListData = isRequesting;
 }

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -82,6 +82,8 @@ public:
     void kickNodeBySessionID(const QUuid& nodeID);
     void muteNodeBySessionID(const QUuid& nodeID);
     void requestUsernameFromSessionID(const QUuid& nodeID);
+    bool getRequestsDomainListData() { return _requestsDomainListData; }
+    void setRequestsDomainListData(bool isRequesting);
 
 public slots:
     void reset();
@@ -153,6 +155,7 @@ private:
     HifiSockAddr _assignmentServerSocket;
     bool _isShuttingDown { false };
     QTimer _keepAlivePingTimer;
+    bool _requestsDomainListData;
 
     mutable QReadWriteLock _ignoredSetLock;
     tbb::concurrent_unordered_set<QUuid, UUIDHasher> _ignoredNodeIDs;

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -77,6 +77,7 @@ public:
     void enableIgnoreRadius() { ignoreNodesInRadius(true); }
     void disableIgnoreRadius() { ignoreNodesInRadius(false); }
     void ignoreNodeBySessionID(const QUuid& nodeID);
+    void unignoreNodeBySessionID(const QUuid& nodeID);
     bool isIgnoringNode(const QUuid& nodeID) const;
 
     void kickNodeBySessionID(const QUuid& nodeID);
@@ -112,6 +113,7 @@ signals:
     void limitOfSilentDomainCheckInsReached();
     void receivedDomainServerList();
     void ignoredNode(const QUuid& nodeID);
+    void unignoredNode(const QUuid& nodeID);
     void ignoreRadiusEnabledChanged(bool isIgnored);
     void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint);
 

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -53,7 +53,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AvatarData:
         case PacketType::BulkAvatarData:
         case PacketType::KillAvatar:
-            return static_cast<PacketVersion>(AvatarMixerPacketVersion::SessionDisplayName);
+            return static_cast<PacketVersion>(AvatarMixerPacketVersion::Unignore);
         case PacketType::ICEServerHeartbeat:
             return 18; // ICE Server Heartbeat signing
         case PacketType::AssetGetInfo:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -104,7 +104,7 @@ public:
         UsernameFromIDRequest,
         UsernameFromIDReply,
         ViewFrustum,
-        RequestDomainListData,
+        RequestsDomainListData,
         NodeUnignoreRequest,
         LAST_PACKET_TYPE = NodeUnignoreRequest
     };

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -106,7 +106,7 @@ public:
         ViewFrustum,
         RequestDomainListData,
         NodeUnignoreRequest,
-        LAST_PACKET_TYPE = ViewFrustum // FIXME! NodeUnignoreRequest
+        LAST_PACKET_TYPE = NodeUnignoreRequest
     };
 };
 
@@ -209,7 +209,8 @@ enum class AvatarMixerPacketVersion : PacketVersion {
     SensorToWorldMat,
     HandControllerJoints,
     HasKillAvatarReason,
-    SessionDisplayName
+    SessionDisplayName,
+    Unignore
 };
 
 enum class DomainConnectRequestVersion : PacketVersion {

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -105,7 +105,8 @@ public:
         UsernameFromIDReply,
         ViewFrustum,
         RequestDomainListData,
-        LAST_PACKET_TYPE = ViewFrustum // FIXME! RequestDomainListData
+        NodeUnignoreRequest,
+        LAST_PACKET_TYPE = ViewFrustum // FIXME! NodeUnignoreRequest
     };
 };
 

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -104,7 +104,8 @@ public:
         UsernameFromIDRequest,
         UsernameFromIDReply,
         ViewFrustum,
-        LAST_PACKET_TYPE = ViewFrustum
+        RequestDomainListData,
+        LAST_PACKET_TYPE = ViewFrustum // FIXME! RequestDomainListData
     };
 };
 

--- a/libraries/script-engine/src/UsersScriptingInterface.cpp
+++ b/libraries/script-engine/src/UsersScriptingInterface.cpp
@@ -26,6 +26,12 @@ void UsersScriptingInterface::ignore(const QUuid& nodeID) {
     DependencyManager::get<NodeList>()->ignoreNodeBySessionID(nodeID);
 }
 
+void UsersScriptingInterface::unignore(const QUuid& nodeID) {
+    // ask the NodeList to ignore this user (based on the session ID of their node)
+    DependencyManager::get<NodeList>()->unignoreNodeBySessionID(nodeID);
+}
+
+
 void UsersScriptingInterface::kick(const QUuid& nodeID) {
     // ask the NodeList to kick the user with the given session ID
     DependencyManager::get<NodeList>()->kickNodeBySessionID(nodeID);

--- a/libraries/script-engine/src/UsersScriptingInterface.cpp
+++ b/libraries/script-engine/src/UsersScriptingInterface.cpp
@@ -19,6 +19,8 @@ UsersScriptingInterface::UsersScriptingInterface() {
     connect(nodeList.data(), &LimitedNodeList::canKickChanged, this, &UsersScriptingInterface::canKickChanged);
     connect(nodeList.data(), &NodeList::ignoreRadiusEnabledChanged, this, &UsersScriptingInterface::ignoreRadiusEnabledChanged);
     connect(nodeList.data(), &NodeList::usernameFromIDReply, this, &UsersScriptingInterface::usernameFromIDReply);
+    connect(nodeList.data(), &NodeList::ignoredNode, this, &UsersScriptingInterface::ignoredNode);
+    connect(nodeList.data(), &NodeList::unignoredNode, this, &UsersScriptingInterface::unignoredNode);
 }
 
 void UsersScriptingInterface::ignore(const QUuid& nodeID) {

--- a/libraries/script-engine/src/UsersScriptingInterface.cpp
+++ b/libraries/script-engine/src/UsersScriptingInterface.cpp
@@ -61,3 +61,10 @@ void UsersScriptingInterface::disableIgnoreRadius() {
 bool UsersScriptingInterface::getIgnoreRadiusEnabled() {
     return DependencyManager::get<NodeList>()->getIgnoreRadiusEnabled();
 }
+
+bool UsersScriptingInterface::getRequestsDomainListData() {
+    return DependencyManager::get<NodeList>()->getRequestsDomainListData();
+}
+void UsersScriptingInterface::setRequestsDomainListData(bool isRequesting) {
+    DependencyManager::get<NodeList>()->setRequestsDomainListData(isRequesting);
+}

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -37,6 +37,7 @@ public slots:
     * @param {nodeID} nodeID The node or session ID of the user you want to ignore.
     */
     void ignore(const QUuid& nodeID);
+    void unignore(const QUuid& nodeID);
 
     /**jsdoc
     * Kick another user.

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -24,6 +24,7 @@ class UsersScriptingInterface : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
 
     Q_PROPERTY(bool canKick READ getCanKick)
+    Q_PROPERTY(bool requestsDomainListData READ getRequestsDomainListData WRITE setRequestsDomainListData)
 
 public:
     UsersScriptingInterface();
@@ -105,6 +106,11 @@ signals:
     * @function Users.usernameFromIDReply
     */
     void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint);
+
+private:
+    bool getRequestsDomainListData();
+    void setRequestsDomainListData(bool requests);
+    bool _requestsDomainListData;
 };
 
 

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -95,6 +95,8 @@ public slots:
 signals:
     void canKickChanged(bool canKick);
     void ignoreRadiusEnabledChanged(bool isEnabled);
+    void ignoredNode(const QUuid& nodeID);
+    void unignoredNode(const QUuid& nodeID);
 
     /**jsdoc
     * Notifies scripts that another user has entered the ignore radius

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -329,6 +329,12 @@ pal.visibleChanged.connect(onVisibleChanged);
 pal.closed.connect(off);
 Users.usernameFromIDReply.connect(usernameFromIDReply);
 
+function onIgnore(sessionId) { // make it go away in the usual way, since we'll still get data keeping it live
+    // Why doesn't this work from .qml? (crashes)
+    AvatarList.getAvatar(sessionId).setShouldDie();
+}
+Users.ignoredNode.connect(onIgnore);
+
 //
 // Cleanup.
 //
@@ -338,6 +344,7 @@ Script.scriptEnding.connect(function () {
     pal.visibleChanged.disconnect(onVisibleChanged);
     pal.closed.disconnect(off);
     Users.usernameFromIDReply.disconnect(usernameFromIDReply);
+    Users.ignoredNode.disconnect(onIgnore);
     off();
 });
 

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -252,9 +252,11 @@ function off() {
     }
     triggerMapping.disable(); // It's ok if we disable twice.
     removeOverlays();
+    Users.requestsDomainListData = false;
 }
 function onClicked() {
     if (!pal.visible) {
+        Users.requestsDomainListData = true;
         populateUserList();
         pal.raise();
         isWired = true;


### PR DESCRIPTION
This DNM PR is up so that we can look at the functionality of the PAL with respect to the ignore/unignore lifecycle, and following avatar-mixer optimizations.

Things to try, with two or more interfaces running this PR against the sandbox in this PR:
- Ignore the other avatar using the PAL:
 - The other avatar should see you disappear after a moment, as though you had left.
 - You will see the PAL ignore box checked for this user.
 - You should loose audio from that user.
 - You should see the other avatar disappear, but the clickable avatar node overlay should remain.
 - As the other avatar moves, the overlay should follow.
 - When you close the PAL, the overlay should disappear.
 - When you open the PAL again, the ignored user should be listed and marked as ignored, and the overlay should be visible at the right position. The overlay should indicate when the user is selected or unselected via the overlay or the list.
 - You should be able to click the activated ignore button to unignore. At that point, you and the other user should see and hear each other normally. (N.B.: 9253 addresses the PAL styling, including the checkboxes.)
- For an ordinary user, the above ignore/unignore behavior should ONLY work for those that you ignore. I.e., if A ignores B, and B (who does not have kick rights) opens the PAL, B must NOT be able to see A in the list nor have any overlay.
- For a user with kick permissions, the inclusion of an avatar in the list and overlay should include those that have ignored you. (The ignore button and state still refers to you ignoring them, not vice versa). I.e., if griefer ignores admin, both dissapear from each other. But if admin opens the PAL, he can see the griefer in the list, and their position with the overlay, and can take actions (such as ban).
- Generally, open PAL from either interface, in various combinations of one or both avatars:
 - newly arrived;
 - facing away from each other;
 - very far apart from each other;
 - various admin/non-admin and login combinations. N.B. that localhost typically has kick rights regardless of login state!
 - for avatars that are not in view, we don't _currently_ show the overlay, but we might later (e.g., around the edges of your display to indicate where to turn to find people, or some other "radar"). Check to make sure (e.g., in the console) that their avatar.position is changing when they move around.
 - Users.ignore(sessionIdString) and Users.unignore(sessionIdString) should work as you expect when the PAL is not open. (You can other sessionIDs in the console with JSON.stringify(AvatarList.getAvatarIdentifiers()).)
The PAL should populate, display sessionDisplayName, and for admins, the username|fingerprint.

This PR might not be how we want to implement this behavior. We're first checking out the behavior, and allowing further development. For example:
- I'm not sure what to test for interactions with physics, and whether or not this behavior is correct.
- This implementation sends identity/data packets in some PAL-opened conditions, that we might want to change this to be different packet types, a subset of the data, or at different frequencies, etc. (There's some special casing of avatar identity/data packets that might wouldn't be necessary if there's a separate packet type.)
- There's a proliferation of packet types, such as one for ignore and other for unignore, rather than one with a flag. I haven't made any attempt to simplify these. Maybe it's fine as is. (My point is that I haven't even thought about it, pending a sanity check on the actual behavior.)
- There's a proliferation of javascript slots and messages, such as Users.ignore and unignore. Same issues.
- I've deliberately left logging in for now, that should be removed before merge.
- There are likely cases where we don't get avatar data fast enough upon opening the PAL. Possibilities include a refresh button, or to have pal.js send new users whenever it notices that it is adding a new node in updateOverlays, or even when removing a node there. (There's some special handling of ignored nodes in Pal.qml that might not be necessary if we do that.)
- There's some data that should be cleared when changing domains. (See Pal.qml comments, but maybe more.)
- Instead of keeping track of ignore state in the Pal.js, we should really expose that to .js/.qml and ask it. That way things will stay in sync if some other code ignores (such as mod.js or equivalent).
- Generally, see FIXME (FIXME HRS) added by this PR.