### PR TITLE
Halve the space bubble audio volume

### DIFF
--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -64,7 +64,7 @@
         Audio.playSound(bubbleActivateSound, {
             position: { x: MyAvatar.position.x, y: MyAvatar.position.y, z: MyAvatar.position.z },
             localOnly: true,
-            volume: 0.4
+            volume: 0.2
         });
         hideOverlays();
         if (updateConnected === true) {


### PR DESCRIPTION
This is necessary because we fixed audio injectors accidentally halving their volume. As a result of that fix, some audio injectors, including the one used to play the bubble sound, are now twice as loud as they were before.

Does this really even need a PR?