### PR TITLE
More low level optimizations

### DIFF
--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -89,7 +89,7 @@ void ScriptableAvatar::update(float deltatime) {
                 int mapping = _bind->getGeometry().getJointIndex(name);
                 if (mapping != -1 && !_maskedJoints.contains(name)) {
                     // Eventually, this should probably deal with post rotations and translations, too.
-                    poses[mapping].rot = modelJoints[mapping].preRotation *
+                    poses[mapping].rot() = modelJoints[mapping].preRotation *
                         safeMix(floorFrame.rotations.at(i), ceilFrame.rotations.at(i), frameFraction);;
                  }
             }
@@ -97,8 +97,8 @@ void ScriptableAvatar::update(float deltatime) {
             for (int i = 0; i < nJoints; i++) {
                 JointData& data = _jointData[i];
                 AnimPose& pose = poses[i];
-                if (data.rotation != pose.rot) {
-                    data.rotation = pose.rot;
+                if (data.rotation != pose.rot()) {
+                    data.rotation = pose.rot();
                     data.rotationSet = true;
                 }
             }

--- a/interface/src/avatar/AvatarActionHold.cpp
+++ b/interface/src/avatar/AvatarActionHold.cpp
@@ -503,8 +503,8 @@ void AvatarActionHold::lateAvatarUpdate(const AnimPose& prePhysicsRoomPose, cons
     // then transform it back into world uisng the postAvatarUpdate sensor-to-world matrix.
     AnimPose newWorldBodyPose = postAvatarUpdateRoomPose * prePhysicsRoomPose.inverse() * worldBodyPose;
 
-    worldTrans.setOrigin(glmToBullet(newWorldBodyPose.trans));
-    worldTrans.setRotation(glmToBullet(newWorldBodyPose.rot));
+    worldTrans.setOrigin(glmToBullet(newWorldBodyPose.trans()));
+    worldTrans.setRotation(glmToBullet(newWorldBodyPose.rot()));
     rigidBody->setWorldTransform(worldTrans);
 
     bool positionSuccess;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2091,10 +2091,10 @@ glm::mat4 MyAvatar::deriveBodyFromHMDSensor() const {
 
     glm::vec3 rigMiddleEyePos = DEFAULT_RIG_MIDDLE_EYE_POS;
     if (leftEyeIndex >= 0 && rightEyeIndex >= 0) {
-        rigMiddleEyePos = (_rig->getAbsoluteDefaultPose(leftEyeIndex).trans + _rig->getAbsoluteDefaultPose(rightEyeIndex).trans) / 2.0f;
+        rigMiddleEyePos = (_rig->getAbsoluteDefaultPose(leftEyeIndex).trans() + _rig->getAbsoluteDefaultPose(rightEyeIndex).trans()) / 2.0f;
     }
-    glm::vec3 rigNeckPos = neckIndex != -1 ? _rig->getAbsoluteDefaultPose(neckIndex).trans : DEFAULT_RIG_NECK_POS;
-    glm::vec3 rigHipsPos = hipsIndex != -1 ? _rig->getAbsoluteDefaultPose(hipsIndex).trans : DEFAULT_RIG_HIPS_POS;
+    glm::vec3 rigNeckPos = neckIndex != -1 ? _rig->getAbsoluteDefaultPose(neckIndex).trans() : DEFAULT_RIG_NECK_POS;
+    glm::vec3 rigHipsPos = hipsIndex != -1 ? _rig->getAbsoluteDefaultPose(hipsIndex).trans() : DEFAULT_RIG_HIPS_POS;
 
     glm::vec3 localEyes = (rigMiddleEyePos - rigHipsPos);
     glm::vec3 localNeck = (rigNeckPos - rigHipsPos);
@@ -2274,16 +2274,16 @@ void MyAvatar::FollowHelper::prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat
 
     AnimPose followWorldPose(currentWorldMatrix);
     if (isActive(Rotation)) {
-        followWorldPose.rot = glmExtractRotation(desiredWorldMatrix);
+        followWorldPose.rot() = glmExtractRotation(desiredWorldMatrix);
     }
     if (isActive(Horizontal)) {
         glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
-        followWorldPose.trans.x = desiredTranslation.x;
-        followWorldPose.trans.z = desiredTranslation.z;
+        followWorldPose.trans().x = desiredTranslation.x;
+        followWorldPose.trans().z = desiredTranslation.z;
     }
     if (isActive(Vertical)) {
         glm::vec3 desiredTranslation = extractTranslation(desiredWorldMatrix);
-        followWorldPose.trans.y = desiredTranslation.y;
+        followWorldPose.trans().y = desiredTranslation.y;
     }
 
     myAvatar.getCharacterController()->setFollowParameters(followWorldPose, getMaxTimeRemaining());

--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -143,13 +143,13 @@ void AnimClip::copyFromNetworkAnim() {
                     postRot = animSkeleton.getPostRotationPose(animJoint);
                 } else {
                     // In order to support Blender, which does not have preRotation FBX support, we use the models defaultPose as the reference frame for the animations.
-                    preRot = AnimPose(glm::vec3(1.0f), _skeleton->getRelativeBindPose(skeletonJoint).rot, glm::vec3());
+                    preRot = AnimPose(glm::vec3(1.0f), _skeleton->getRelativeBindPose(skeletonJoint).rot(), glm::vec3());
                     postRot = AnimPose::identity;
                 }
 
                 // cancel out scale
-                preRot.scale = glm::vec3(1.0f);
-                postRot.scale = glm::vec3(1.0f);
+                preRot.scale() = glm::vec3(1.0f);
+                postRot.scale() = glm::vec3(1.0f);
 
                 AnimPose rot(glm::vec3(1.0f), fbxAnimRot, glm::vec3());
 
@@ -160,10 +160,10 @@ void AnimClip::copyFromNetworkAnim() {
                 float boneLengthScale = 1.0f;
                 const float EPSILON = 0.0001f;
                 if (fabsf(glm::length(fbxZeroTrans)) > EPSILON) {
-                    boneLengthScale = glm::length(relDefaultPose.trans) / glm::length(fbxZeroTrans);
+                    boneLengthScale = glm::length(relDefaultPose.trans()) / glm::length(fbxZeroTrans);
                 }
 
-                AnimPose trans = AnimPose(glm::vec3(1.0f), glm::quat(), relDefaultPose.trans + boneLengthScale * (fbxAnimTrans - fbxZeroTrans));
+                AnimPose trans = AnimPose(glm::vec3(1.0f), glm::quat(), relDefaultPose.trans() + boneLengthScale * (fbxAnimTrans - fbxZeroTrans));
 
                 _anim[frame][skeletonJoint] = trans * preRot * rot * postRot;
             }

--- a/libraries/animation/src/AnimManipulator.cpp
+++ b/libraries/animation/src/AnimManipulator.cpp
@@ -103,9 +103,9 @@ AnimPose AnimManipulator::computeRelativePoseFromJointVar(const AnimVariantMap& 
     if (jointVar.type == JointVar::Type::AbsoluteRotation || jointVar.type == JointVar::Type::AbsolutePosition) {
 
         if (jointVar.type == JointVar::Type::AbsoluteRotation) {
-            defaultAbsPose.rot = animVars.lookupRigToGeometry(jointVar.var, defaultAbsPose.rot);
+            defaultAbsPose.rot() = animVars.lookupRigToGeometry(jointVar.var, defaultAbsPose.rot());
         } else if (jointVar.type == JointVar::Type::AbsolutePosition) {
-            defaultAbsPose.trans = animVars.lookupRigToGeometry(jointVar.var, defaultAbsPose.trans);
+            defaultAbsPose.trans() = animVars.lookupRigToGeometry(jointVar.var, defaultAbsPose.trans());
         }
 
         // because jointVar is absolute, we must use an absolute parent frame to convert into a relative pose.
@@ -123,9 +123,9 @@ AnimPose AnimManipulator::computeRelativePoseFromJointVar(const AnimVariantMap& 
         // override the default rel pose
         AnimPose relPose = defaultRelPose;
         if (jointVar.type == JointVar::Type::RelativeRotation) {
-            relPose.rot = animVars.lookupRigToGeometry(jointVar.var, defaultRelPose.rot);
+            relPose.rot() = animVars.lookupRigToGeometry(jointVar.var, defaultRelPose.rot());
         } else if (jointVar.type == JointVar::Type::RelativePosition) {
-            relPose.trans = animVars.lookupRigToGeometry(jointVar.var, defaultRelPose.trans);
+            relPose.trans() = animVars.lookupRigToGeometry(jointVar.var, defaultRelPose.trans());
         }
 
         return relPose;

--- a/libraries/animation/src/AnimPose.cpp
+++ b/libraries/animation/src/AnimPose.cpp
@@ -26,7 +26,7 @@ AnimPose::AnimPose(const glm::mat4& mat) : _dirty(false) {
     _rot = glm::quat_cast(tmp);
     float lengthSquared = glm::length2(_rot);
     if (glm::abs(lengthSquared - 1.0f) > EPSILON) {
-        float oneOverLength = 1.0f / sqrt(lengthSquared);
+        float oneOverLength = 1.0f / sqrtf(lengthSquared);
         _rot = glm::quat(_rot.w * oneOverLength, _rot.x * oneOverLength, _rot.y * oneOverLength, _rot.z * oneOverLength);
     }
     _trans = extractTranslation(mat);

--- a/libraries/animation/src/AnimPose.cpp
+++ b/libraries/animation/src/AnimPose.cpp
@@ -18,11 +18,17 @@ const AnimPose AnimPose::identity = AnimPose(glm::vec3(1.0f),
                                              glm::vec3(0.0f));
 
 AnimPose::AnimPose(const glm::mat4& mat) : _dirty(false) {
+    static const float EPSILON = 0.0001f;
     _mat = mat;
     _scale = extractScale(mat);
     // quat_cast doesn't work so well with scaled matrices, so cancel it out.
     glm::mat4 tmp = glm::scale(mat, 1.0f / _scale);
-    _rot = glm::normalize(glm::quat_cast(tmp));
+    _rot = glm::quat_cast(tmp);
+    float lengthSquared = glm::length2(_rot);
+    if (glm::abs(lengthSquared - 1.0f) > EPSILON) {
+        float oneOverLength = 1.0f / sqrt(lengthSquared);
+        _rot = glm::quat(_rot.w * oneOverLength, _rot.x * oneOverLength, _rot.y * oneOverLength, _rot.z * oneOverLength);
+    }
     _trans = extractTranslation(mat);
 }
 

--- a/libraries/animation/src/AnimPose.cpp
+++ b/libraries/animation/src/AnimPose.cpp
@@ -17,16 +17,17 @@ const AnimPose AnimPose::identity = AnimPose(glm::vec3(1.0f),
                                              glm::quat(),
                                              glm::vec3(0.0f));
 
-AnimPose::AnimPose(const glm::mat4& mat) {
-    scale = extractScale(mat);
+AnimPose::AnimPose(const glm::mat4& mat) : _dirty(false) {
+    _mat = mat;
+    _scale = extractScale(mat);
     // quat_cast doesn't work so well with scaled matrices, so cancel it out.
-    glm::mat4 tmp = glm::scale(mat, 1.0f / scale);
-    rot = glm::normalize(glm::quat_cast(tmp));
-    trans = extractTranslation(mat);
+    glm::mat4 tmp = glm::scale(mat, 1.0f / _scale);
+    _rot = glm::normalize(glm::quat_cast(tmp));
+    _trans = extractTranslation(mat);
 }
 
 glm::vec3 AnimPose::operator*(const glm::vec3& rhs) const {
-    return trans + (rot * (scale * rhs));
+    return _trans + (_rot * (_scale * rhs));
 }
 
 glm::vec3 AnimPose::xformPoint(const glm::vec3& rhs) const {
@@ -35,16 +36,25 @@ glm::vec3 AnimPose::xformPoint(const glm::vec3& rhs) const {
 
 // really slow
 glm::vec3 AnimPose::xformVector(const glm::vec3& rhs) const {
-    glm::vec3 xAxis = rot * glm::vec3(scale.x, 0.0f, 0.0f);
-    glm::vec3 yAxis = rot * glm::vec3(0.0f, scale.y, 0.0f);
-    glm::vec3 zAxis = rot * glm::vec3(0.0f, 0.0f, scale.z);
+    glm::vec3 xAxis = _rot * glm::vec3(_scale.x, 0.0f, 0.0f);
+    glm::vec3 yAxis = _rot * glm::vec3(0.0f, _scale.y, 0.0f);
+    glm::vec3 zAxis = _rot * glm::vec3(0.0f, 0.0f, _scale.z);
     glm::mat3 mat(xAxis, yAxis, zAxis);
     glm::mat3 transInvMat = glm::inverse(glm::transpose(mat));
     return transInvMat * rhs;
 }
 
 AnimPose AnimPose::operator*(const AnimPose& rhs) const {
+#if GLM_ARCH & GLM_ARCH_SSE2
+    glm::mat4 result;
+    glm::mat4 lhsMat = *this;
+    glm::mat4 rhsMat = rhs;
+    glm_mat4_mul((glm_vec4*)&lhsMat, (glm_vec4*)&rhsMat, (glm_vec4*)&result);
+    return AnimPose(result);
+#else 
     return AnimPose(static_cast<glm::mat4>(*this) * static_cast<glm::mat4>(rhs));
+#endif
+
 }
 
 AnimPose AnimPose::inverse() const {
@@ -53,13 +63,17 @@ AnimPose AnimPose::inverse() const {
 
 // mirror about x-axis without applying negative scale.
 AnimPose AnimPose::mirror() const {
-    return AnimPose(scale, glm::quat(rot.w, rot.x, -rot.y, -rot.z), glm::vec3(-trans.x, trans.y, trans.z));
+    return AnimPose(_scale, glm::quat(_rot.w, _rot.x, -_rot.y, -_rot.z), glm::vec3(-_trans.x, _trans.y, _trans.z));
 }
 
-AnimPose::operator glm::mat4() const {
-    glm::vec3 xAxis = rot * glm::vec3(scale.x, 0.0f, 0.0f);
-    glm::vec3 yAxis = rot * glm::vec3(0.0f, scale.y, 0.0f);
-    glm::vec3 zAxis = rot * glm::vec3(0.0f, 0.0f, scale.z);
-    return glm::mat4(glm::vec4(xAxis, 0.0f), glm::vec4(yAxis, 0.0f),
-                     glm::vec4(zAxis, 0.0f), glm::vec4(trans, 1.0f));
+AnimPose::operator const glm::mat4&() const {
+    if (_dirty) {
+        glm::vec3 xAxis = _rot * glm::vec3(_scale.x, 0.0f, 0.0f);
+        glm::vec3 yAxis = _rot * glm::vec3(0.0f, _scale.y, 0.0f);
+        glm::vec3 zAxis = _rot * glm::vec3(0.0f, 0.0f, _scale.z);
+        _mat = glm::mat4(glm::vec4(xAxis, 0.0f), glm::vec4(yAxis, 0.0f),
+            glm::vec4(zAxis, 0.0f), glm::vec4(_trans, 1.0f));
+        _dirty = false;
+    }
+    return _mat;
 }

--- a/libraries/animation/src/AnimPose.cpp
+++ b/libraries/animation/src/AnimPose.cpp
@@ -17,9 +17,8 @@ const AnimPose AnimPose::identity = AnimPose(glm::vec3(1.0f),
                                              glm::quat(),
                                              glm::vec3(0.0f));
 
-AnimPose::AnimPose(const glm::mat4& mat) : _dirty(false) {
+AnimPose::AnimPose(const glm::mat4& mat) {
     static const float EPSILON = 0.0001f;
-    _mat = mat;
     _scale = extractScale(mat);
     // quat_cast doesn't work so well with scaled matrices, so cancel it out.
     glm::mat4 tmp = glm::scale(mat, 1.0f / _scale);
@@ -60,7 +59,6 @@ AnimPose AnimPose::operator*(const AnimPose& rhs) const {
 #else 
     return AnimPose(static_cast<glm::mat4>(*this) * static_cast<glm::mat4>(rhs));
 #endif
-
 }
 
 AnimPose AnimPose::inverse() const {
@@ -72,14 +70,10 @@ AnimPose AnimPose::mirror() const {
     return AnimPose(_scale, glm::quat(_rot.w, _rot.x, -_rot.y, -_rot.z), glm::vec3(-_trans.x, _trans.y, _trans.z));
 }
 
-AnimPose::operator const glm::mat4&() const {
-    if (_dirty) {
-        glm::vec3 xAxis = _rot * glm::vec3(_scale.x, 0.0f, 0.0f);
-        glm::vec3 yAxis = _rot * glm::vec3(0.0f, _scale.y, 0.0f);
-        glm::vec3 zAxis = _rot * glm::vec3(0.0f, 0.0f, _scale.z);
-        _mat = glm::mat4(glm::vec4(xAxis, 0.0f), glm::vec4(yAxis, 0.0f),
-            glm::vec4(zAxis, 0.0f), glm::vec4(_trans, 1.0f));
-        _dirty = false;
-    }
-    return _mat;
+AnimPose::operator glm::mat4() const {
+    glm::vec3 xAxis = _rot * glm::vec3(_scale.x, 0.0f, 0.0f);
+    glm::vec3 yAxis = _rot * glm::vec3(0.0f, _scale.y, 0.0f);
+    glm::vec3 zAxis = _rot * glm::vec3(0.0f, 0.0f, _scale.z);
+    return glm::mat4(glm::vec4(xAxis, 0.0f), glm::vec4(yAxis, 0.0f),
+        glm::vec4(zAxis, 0.0f), glm::vec4(_trans, 1.0f));
 }

--- a/libraries/animation/src/AnimPose.h
+++ b/libraries/animation/src/AnimPose.h
@@ -17,10 +17,11 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 
-struct AnimPose {
+class AnimPose {
+public:
     AnimPose() {}
     explicit AnimPose(const glm::mat4& mat);
-    AnimPose(const glm::vec3& scaleIn, const glm::quat& rotIn, const glm::vec3& transIn) : scale(scaleIn), rot(rotIn), trans(transIn) {}
+    AnimPose(const glm::vec3& scaleIn, const glm::quat& rotIn, const glm::vec3& transIn) : _scale(scaleIn), _rot(rotIn), _trans(transIn) {}
     static const AnimPose identity;
 
     glm::vec3 xformPoint(const glm::vec3& rhs) const;
@@ -31,15 +32,29 @@ struct AnimPose {
 
     AnimPose inverse() const;
     AnimPose mirror() const;
-    operator glm::mat4() const;
+    operator const glm::mat4&() const;
 
-    glm::vec3 scale;
-    glm::quat rot;
-    glm::vec3 trans;
+    const glm::vec3& scale() const { return _scale; }
+    glm::vec3& scale() { _dirty = true; return _scale; }
+
+    const glm::quat& rot() const { return _rot; }
+    glm::quat& rot() { _dirty = true; return _rot; }
+
+    const glm::vec3& trans() const { return _trans; }
+    glm::vec3& trans() { _dirty = true;  return _trans; }
+
+private:
+    friend QDebug operator<<(QDebug debug, const AnimPose& pose);
+
+    mutable bool _dirty { true };
+    mutable glm::mat4 _mat;
+    glm::vec3 _scale { 1.0f };
+    glm::quat _rot;
+    glm::vec3 _trans;
 };
 
 inline QDebug operator<<(QDebug debug, const AnimPose& pose) {
-    debug << "AnimPose, trans = (" << pose.trans.x << pose.trans.y << pose.trans.z << "), rot = (" << pose.rot.x << pose.rot.y << pose.rot.z << pose.rot.w << "), scale = (" << pose.scale.x << pose.scale.y << pose.scale.z << ")";
+    debug << "AnimPose, trans = (" << pose.trans().x << pose.trans().y << pose.trans().z << "), rot = (" << pose.rot().x << pose.rot().y << pose.rot().z << pose.rot().w << "), scale = (" << pose.scale().x << pose.scale().y << pose.scale().z << ")";
     return debug;
 }
 

--- a/libraries/animation/src/AnimPose.h
+++ b/libraries/animation/src/AnimPose.h
@@ -32,22 +32,19 @@ public:
 
     AnimPose inverse() const;
     AnimPose mirror() const;
-    operator const glm::mat4&() const;
+    operator glm::mat4() const;
 
     const glm::vec3& scale() const { return _scale; }
-    glm::vec3& scale() { _dirty = true; return _scale; }
+    glm::vec3& scale() { return _scale; }
 
     const glm::quat& rot() const { return _rot; }
-    glm::quat& rot() { _dirty = true; return _rot; }
+    glm::quat& rot() { return _rot; }
 
     const glm::vec3& trans() const { return _trans; }
-    glm::vec3& trans() { _dirty = true;  return _trans; }
+    glm::vec3& trans() { return _trans; }
 
 private:
     friend QDebug operator<<(QDebug debug, const AnimPose& pose);
-
-    mutable bool _dirty { true };
-    mutable glm::mat4 _mat;
     glm::vec3 _scale { 1.0f };
     glm::quat _rot;
     glm::vec3 _trans;

--- a/libraries/animation/src/AnimSkeleton.cpp
+++ b/libraries/animation/src/AnimSkeleton.cpp
@@ -32,10 +32,10 @@ AnimSkeleton::AnimSkeleton(const std::vector<FBXJoint>& joints) {
 
 int AnimSkeleton::nameToJointIndex(const QString& jointName) const {
     auto itr = _jointIndicesByName.find(jointName);
-    if (_jointIndicesByName.end() == itr) {
-        return -1;
+    if (_jointIndicesByName.end() != itr) {
+        return itr.value();
     }
-    return itr.value();
+    return -1;
 }
 
 int AnimSkeleton::getNumJoints() const {
@@ -202,6 +202,10 @@ void AnimSkeleton::buildSkeletonFromJoints(const std::vector<FBXJoint>& joints) 
         }
     }
 
+    for (int i = 0; i < _jointsSize; i++) {
+        _jointIndicesByName[_joints[i].name] = i;
+    }
+
     // build mirror map.
     _nonMirroredIndices.clear();
     _mirrorMap.reserve(_jointsSize);
@@ -224,10 +228,6 @@ void AnimSkeleton::buildSkeletonFromJoints(const std::vector<FBXJoint>& joints) 
         } else {
             _mirrorMap.push_back(i);
         }
-    }
-
-    for (int i = 0; i < _jointsSize; i++) {
-        _jointIndicesByName[_joints[i].name] = i;
     }
 }
 

--- a/libraries/animation/src/AnimSkeleton.h
+++ b/libraries/animation/src/AnimSkeleton.h
@@ -70,6 +70,7 @@ protected:
     void buildSkeletonFromJoints(const std::vector<FBXJoint>& joints);
 
     std::vector<FBXJoint> _joints;
+    int _jointsSize { 0 };
     AnimPoseVec _absoluteBindPoses;
     AnimPoseVec _relativeBindPoses;
     AnimPoseVec _relativeDefaultPoses;
@@ -79,6 +80,7 @@ protected:
     mutable AnimPoseVec _nonMirroredPoses;
     std::vector<int> _nonMirroredIndices;
     std::vector<int> _mirrorMap;
+    QHash<QString, int> _jointIndicesByName;
 
     // no copies
     AnimSkeleton(const AnimSkeleton&) = delete;

--- a/libraries/animation/src/AnimUtil.cpp
+++ b/libraries/animation/src/AnimUtil.cpp
@@ -20,16 +20,16 @@ void blend(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, A
         const AnimPose& bPose = b[i];
 
         // adjust signs if necessary
-        const glm::quat& q1 = aPose.rot;
-        glm::quat q2 = bPose.rot;
+        const glm::quat& q1 = aPose.rot();
+        glm::quat q2 = bPose.rot();
         float dot = glm::dot(q1, q2);
         if (dot < 0.0f) {
             q2 = -q2;
         }
 
-        result[i].scale = lerp(aPose.scale, bPose.scale, alpha);
-        result[i].rot = glm::normalize(glm::lerp(aPose.rot, q2, alpha));
-        result[i].trans = lerp(aPose.trans, bPose.trans, alpha);
+        result[i].scale() = lerp(aPose.scale(), bPose.scale(), alpha);
+        result[i].rot() = glm::normalize(glm::lerp(aPose.rot(), q2, alpha));
+        result[i].trans() = lerp(aPose.trans(), bPose.trans(), alpha);
     }
 }
 

--- a/libraries/animation/src/IKTarget.cpp
+++ b/libraries/animation/src/IKTarget.cpp
@@ -10,8 +10,8 @@
 #include "IKTarget.h"
 
 void IKTarget::setPose(const glm::quat& rotation, const glm::vec3& translation) {
-    _pose.rot = rotation;
-    _pose.trans = translation;
+    _pose.rot() = rotation;
+    _pose.trans() = translation;
 }
 
 void IKTarget::setType(int type) {

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -26,8 +26,8 @@ public:
 
     IKTarget() {}
 
-    const glm::vec3& getTranslation() const { return _pose.trans; }
-    const glm::quat& getRotation() const { return _pose.rot; }
+    const glm::vec3& getTranslation() const { return _pose.trans(); }
+    const glm::quat& getRotation() const { return _pose.rot(); }
     int getIndex() const { return _index; }
     Type getType() const { return _type; }
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -262,9 +262,9 @@ QString Rig::nameOfJoint(int jointIndex) const {
 
 void Rig::setModelOffset(const glm::mat4& modelOffsetMat) {
     AnimPose newModelOffset = AnimPose(modelOffsetMat);
-    if (!isEqual(_modelOffset.trans, newModelOffset.trans) ||
-        !isEqual(_modelOffset.rot, newModelOffset.rot) ||
-        !isEqual(_modelOffset.scale, newModelOffset.scale)) {
+    if (!isEqual(_modelOffset.trans(), newModelOffset.trans()) ||
+        !isEqual(_modelOffset.rot(), newModelOffset.rot()) ||
+        !isEqual(_modelOffset.scale(), newModelOffset.scale())) {
 
         _modelOffset = newModelOffset;
 
@@ -334,7 +334,7 @@ void Rig::setJointTranslation(int index, bool valid, const glm::vec3& translatio
                 _internalPoseSet._overrideFlags[index] = true;
                 ++_numOverrides;
             }
-            _internalPoseSet._overridePoses[index].trans = translation;
+            _internalPoseSet._overridePoses[index].trans() = translation;
         }
     }
 }
@@ -346,8 +346,8 @@ void Rig::setJointState(int index, bool valid, const glm::quat& rotation, const 
             _internalPoseSet._overrideFlags[index] = true;
             ++_numOverrides;
         }
-        _internalPoseSet._overridePoses[index].rot = rotation;
-        _internalPoseSet._overridePoses[index].trans = translation;
+        _internalPoseSet._overridePoses[index].rot() = rotation;
+        _internalPoseSet._overridePoses[index].trans() = translation;
     }
 }
 
@@ -359,7 +359,7 @@ void Rig::setJointRotation(int index, bool valid, const glm::quat& rotation, flo
                 _internalPoseSet._overrideFlags[index] = true;
                 ++_numOverrides;
             }
-            _internalPoseSet._overridePoses[index].rot = rotation;
+            _internalPoseSet._overridePoses[index].rot() = rotation;
         }
     }
 }
@@ -376,7 +376,7 @@ void Rig::restoreJointTranslation(int index, float fraction, float priority) {
 
 bool Rig::getJointPositionInWorldFrame(int jointIndex, glm::vec3& position, glm::vec3 translation, glm::quat rotation) const {
     if (isIndexValid(jointIndex)) {
-        position = (rotation * _internalPoseSet._absolutePoses[jointIndex].trans) + translation;
+        position = (rotation * _internalPoseSet._absolutePoses[jointIndex].trans()) + translation;
         return true;
     } else {
         return false;
@@ -385,7 +385,7 @@ bool Rig::getJointPositionInWorldFrame(int jointIndex, glm::vec3& position, glm:
 
 bool Rig::getJointPosition(int jointIndex, glm::vec3& position) const {
     if (isIndexValid(jointIndex)) {
-        position = _internalPoseSet._absolutePoses[jointIndex].trans;
+        position = _internalPoseSet._absolutePoses[jointIndex].trans();
         return true;
     } else {
         return false;
@@ -394,7 +394,7 @@ bool Rig::getJointPosition(int jointIndex, glm::vec3& position) const {
 
 bool Rig::getJointRotationInWorldFrame(int jointIndex, glm::quat& result, const glm::quat& rotation) const {
     if (isIndexValid(jointIndex)) {
-        result = rotation * _internalPoseSet._absolutePoses[jointIndex].rot;
+        result = rotation * _internalPoseSet._absolutePoses[jointIndex].rot();
         return true;
     } else {
         return false;
@@ -404,7 +404,7 @@ bool Rig::getJointRotationInWorldFrame(int jointIndex, glm::quat& result, const 
 bool Rig::getJointRotation(int jointIndex, glm::quat& rotation) const {
     QReadLocker readLock(&_externalPoseSetLock);
     if (jointIndex >= 0 && jointIndex < (int)_externalPoseSet._relativePoses.size()) {
-        rotation = _externalPoseSet._relativePoses[jointIndex].rot;
+        rotation = _externalPoseSet._relativePoses[jointIndex].rot();
         return true;
     } else {
         return false;
@@ -414,7 +414,7 @@ bool Rig::getJointRotation(int jointIndex, glm::quat& rotation) const {
 bool Rig::getAbsoluteJointRotationInRigFrame(int jointIndex, glm::quat& rotation) const {
     QReadLocker readLock(&_externalPoseSetLock);
     if (jointIndex >= 0 && jointIndex < (int)_externalPoseSet._absolutePoses.size()) {
-        rotation = _externalPoseSet._absolutePoses[jointIndex].rot;
+        rotation = _externalPoseSet._absolutePoses[jointIndex].rot();
         return true;
     } else {
         return false;
@@ -424,7 +424,7 @@ bool Rig::getAbsoluteJointRotationInRigFrame(int jointIndex, glm::quat& rotation
 bool Rig::getJointTranslation(int jointIndex, glm::vec3& translation) const {
     QReadLocker readLock(&_externalPoseSetLock);
     if (jointIndex >= 0 && jointIndex < (int)_externalPoseSet._relativePoses.size()) {
-        translation = _externalPoseSet._relativePoses[jointIndex].trans;
+        translation = _externalPoseSet._relativePoses[jointIndex].trans();
         return true;
     } else {
         return false;
@@ -434,7 +434,7 @@ bool Rig::getJointTranslation(int jointIndex, glm::vec3& translation) const {
 bool Rig::getAbsoluteJointTranslationInRigFrame(int jointIndex, glm::vec3& translation) const {
     QReadLocker readLock(&_externalPoseSetLock);
     if (jointIndex >= 0 && jointIndex < (int)_externalPoseSet._absolutePoses.size()) {
-        translation = _externalPoseSet._absolutePoses[jointIndex].trans;
+        translation = _externalPoseSet._absolutePoses[jointIndex].trans();
         return true;
     } else {
         return false;
@@ -498,7 +498,7 @@ const AnimPoseVec& Rig::getAbsoluteDefaultPoses() const {
 
 bool Rig::getRelativeDefaultJointRotation(int index, glm::quat& rotationOut) const {
     if (_animSkeleton && index >= 0 && index < _animSkeleton->getNumJoints()) {
-        rotationOut = _animSkeleton->getRelativeDefaultPose(index).rot;
+        rotationOut = _animSkeleton->getRelativeDefaultPose(index).rot();
         return true;
     } else {
         return false;
@@ -507,7 +507,7 @@ bool Rig::getRelativeDefaultJointRotation(int index, glm::quat& rotationOut) con
 
 bool Rig::getRelativeDefaultJointTranslation(int index, glm::vec3& translationOut) const {
     if (_animSkeleton && index >= 0 && index < _animSkeleton->getNumJoints()) {
-        translationOut = _animSkeleton->getRelativeDefaultPose(index).trans;
+        translationOut = _animSkeleton->getRelativeDefaultPose(index).trans();
         return true;
     } else {
         return false;
@@ -998,8 +998,8 @@ void Rig::computeHeadNeckAnimVars(const AnimPose& hmdPose, glm::vec3& headPositi
                                   glm::vec3& neckPositionOut, glm::quat& neckOrientationOut) const {
 
     // the input hmd values are in avatar/rig space
-    const glm::vec3 hmdPosition = hmdPose.trans;
-    const glm::quat hmdOrientation = hmdPose.rot;
+    const glm::vec3& hmdPosition = hmdPose.trans();
+    const glm::quat& hmdOrientation = hmdPose.rot();
 
     // TODO: cache jointIndices
     int rightEyeIndex = indexOfJoint("RightEye");
@@ -1007,10 +1007,10 @@ void Rig::computeHeadNeckAnimVars(const AnimPose& hmdPose, glm::vec3& headPositi
     int headIndex = indexOfJoint("Head");
     int neckIndex = indexOfJoint("Neck");
 
-    glm::vec3 absRightEyePos = rightEyeIndex != -1 ? getAbsoluteDefaultPose(rightEyeIndex).trans : DEFAULT_RIGHT_EYE_POS;
-    glm::vec3 absLeftEyePos = leftEyeIndex != -1 ? getAbsoluteDefaultPose(leftEyeIndex).trans : DEFAULT_LEFT_EYE_POS;
-    glm::vec3 absHeadPos = headIndex != -1 ? getAbsoluteDefaultPose(headIndex).trans : DEFAULT_HEAD_POS;
-    glm::vec3 absNeckPos = neckIndex != -1 ? getAbsoluteDefaultPose(neckIndex).trans : DEFAULT_NECK_POS;
+    glm::vec3 absRightEyePos = rightEyeIndex != -1 ? getAbsoluteDefaultPose(rightEyeIndex).trans() : DEFAULT_RIGHT_EYE_POS;
+    glm::vec3 absLeftEyePos = leftEyeIndex != -1 ? getAbsoluteDefaultPose(leftEyeIndex).trans() : DEFAULT_LEFT_EYE_POS;
+    glm::vec3 absHeadPos = headIndex != -1 ? getAbsoluteDefaultPose(headIndex).trans() : DEFAULT_HEAD_POS;
+    glm::vec3 absNeckPos = neckIndex != -1 ? getAbsoluteDefaultPose(neckIndex).trans() : DEFAULT_NECK_POS;
 
     glm::vec3 absCenterEyePos = (absRightEyePos + absLeftEyePos) / 2.0f;
     glm::vec3 eyeOffset = absCenterEyePos - absHeadPos;
@@ -1026,7 +1026,7 @@ void Rig::computeHeadNeckAnimVars(const AnimPose& hmdPose, glm::vec3& headPositi
     neckPositionOut = hmdPosition - hmdOrientation * (headOffset + eyeOffset);
 
     // slerp between default orientation and hmdOrientation
-    neckOrientationOut = safeMix(hmdOrientation, _animSkeleton->getRelativeDefaultPose(neckIndex).rot, 0.5f);
+    neckOrientationOut = safeMix(hmdOrientation, _animSkeleton->getRelativeDefaultPose(neckIndex).rot(), 0.5f);
 }
 
 void Rig::updateNeckJoint(int index, const HeadParameters& params) {
@@ -1077,14 +1077,14 @@ void Rig::updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm
     // TODO: does not properly handle avatar scale.
 
     if (isIndexValid(index)) {
-        glm::mat4 rigToWorld = createMatFromQuatAndPos(modelRotation, modelTranslation);
-        glm::mat4 worldToRig = glm::inverse(rigToWorld);
-        glm::vec3 lookAtVector = glm::normalize(transformPoint(worldToRig, lookAtSpot) - _internalPoseSet._absolutePoses[index].trans);
+        const glm::mat4 rigToWorld = createMatFromQuatAndPos(modelRotation, modelTranslation);
+        const glm::mat4 worldToRig = glm::inverse(rigToWorld);
+        const glm::vec3 lookAtVector = glm::normalize(transformPoint(worldToRig, lookAtSpot) - _internalPoseSet._absolutePoses[index].trans());
 
         int headIndex = indexOfJoint("Head");
         glm::quat headQuat;
         if (headIndex >= 0) {
-            headQuat = _internalPoseSet._absolutePoses[headIndex].rot;
+            headQuat = _internalPoseSet._absolutePoses[headIndex].rot();
         }
 
         glm::vec3 headUp = headQuat * Vectors::UNIT_Y;
@@ -1103,7 +1103,7 @@ void Rig::updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm
         }
 
         // directly set absolutePose rotation
-        _internalPoseSet._absolutePoses[index].rot = deltaQuat * headQuat;
+        _internalPoseSet._absolutePoses[index].rot() = deltaQuat * headQuat;
     }
 }
 
@@ -1114,7 +1114,7 @@ void Rig::updateFromHandParameters(const HandParameters& params, float dt) {
         int hipsIndex = indexOfJoint("Hips");
         glm::vec3 hipsTrans;
         if (hipsIndex >= 0) {
-            hipsTrans = _internalPoseSet._absolutePoses[hipsIndex].trans;
+            hipsTrans = _internalPoseSet._absolutePoses[hipsIndex].trans();
         }
 
         // Use this capsule to represent the avatar body.
@@ -1188,7 +1188,7 @@ void Rig::initAnimGraph(const QUrl& url) {
 
 bool Rig::getModelRegistrationPoint(glm::vec3& modelRegistrationPointOut) const {
     if (_animSkeleton && _rootJointIndex >= 0) {
-        modelRegistrationPointOut = _geometryOffset * -_animSkeleton->getAbsoluteDefaultPose(_rootJointIndex).trans;
+        modelRegistrationPointOut = _geometryOffset * -_animSkeleton->getAbsoluteDefaultPose(_rootJointIndex).trans();
         return true;
     } else {
         return false;
@@ -1233,11 +1233,12 @@ void Rig::buildAbsoluteRigPoses(const AnimPoseVec& relativePoses, AnimPoseVec& a
     }
 }
 
-glm::mat4 Rig::getJointTransform(int jointIndex) const {
+const glm::mat4& Rig::getJointTransform(int jointIndex) const {
+    static const glm::mat4 IDENTITY;
     if (isIndexValid(jointIndex)) {
         return _internalPoseSet._absolutePoses[jointIndex];
     } else {
-        return glm::mat4();
+        return IDENTITY;
     }
 }
 
@@ -1250,14 +1251,14 @@ void Rig::copyJointsIntoJointData(QVector<JointData>& jointDataVec) const {
         JointData& data = jointDataVec[i];
         if (isIndexValid(i)) {
             // rotations are in absolute rig frame.
-            glm::quat defaultAbsRot = geometryToRigPose.rot * _animSkeleton->getAbsoluteDefaultPose(i).rot;
-            data.rotation = _internalPoseSet._absolutePoses[i].rot;
+            glm::quat defaultAbsRot = geometryToRigPose.rot() * _animSkeleton->getAbsoluteDefaultPose(i).rot();
+            data.rotation = _internalPoseSet._absolutePoses[i].rot();
             data.rotationSet = !isEqual(data.rotation, defaultAbsRot);
 
             // translations are in relative frame but scaled so that they are in meters,
             // instead of geometry units.
-            glm::vec3 defaultRelTrans = _geometryOffset.scale * _animSkeleton->getRelativeDefaultPose(i).trans;
-            data.translation = _geometryOffset.scale * _internalPoseSet._relativePoses[i].trans;
+            glm::vec3 defaultRelTrans = _geometryOffset.scale() * _animSkeleton->getRelativeDefaultPose(i).trans();
+            data.translation = _geometryOffset.scale() * _internalPoseSet._relativePoses[i].trans();
             data.translationSet = !isEqual(data.translation, defaultRelTrans);
         } else {
             data.translationSet = false;
@@ -1272,7 +1273,7 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
         // make a vector of rotations in absolute-geometry-frame
         const AnimPoseVec& absoluteDefaultPoses = _animSkeleton->getAbsoluteDefaultPoses();
         std::vector<glm::quat> rotations;
-        rotations.reserve(_animSkeleton->getAbsoluteDefaultPoses().size());
+        rotations.reserve(absoluteDefaultPoses.size());
         const glm::quat rigToGeometryRot(glmExtractRotation(_rigToGeometryTransform));
         for (int i = 0; i < jointDataVec.size(); i++) {
             const JointData& data = jointDataVec.at(i);
@@ -1280,7 +1281,7 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
                 // JointData rotations are in absolute rig-frame so we rotate them to absolute geometry-frame
                 rotations.push_back(rigToGeometryRot * data.rotation);
             } else {
-                rotations.push_back(absoluteDefaultPoses[i].rot);
+                rotations.push_back(absoluteDefaultPoses[i].rot());
             }
         }
 
@@ -1291,13 +1292,13 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
         const AnimPoseVec& relativeDefaultPoses = _animSkeleton->getRelativeDefaultPoses();
         for (int i = 0; i < jointDataVec.size(); i++) {
             const JointData& data = jointDataVec.at(i);
-            _internalPoseSet._relativePoses[i].scale = Vectors::ONE;
-            _internalPoseSet._relativePoses[i].rot = rotations[i];
+            _internalPoseSet._relativePoses[i].scale() = Vectors::ONE;
+            _internalPoseSet._relativePoses[i].rot() = rotations[i];
             if (data.translationSet) {
                 // JointData translations are in scaled relative-frame so we scale back to regular relative-frame
-                _internalPoseSet._relativePoses[i].trans = _invGeometryOffset.scale * data.translation;
+                _internalPoseSet._relativePoses[i].trans() = _invGeometryOffset.scale() * data.translation;
             } else {
-                _internalPoseSet._relativePoses[i].trans = relativeDefaultPoses[i].trans;
+                _internalPoseSet._relativePoses[i].trans() = relativeDefaultPoses[i].trans();
             }
         }
     }
@@ -1346,10 +1347,10 @@ void Rig::computeAvatarBoundingCapsule(
     }
     AnimVariantMap animVars;
     glm::quat handRotation = glm::angleAxis(PI, Vectors::UNIT_X);
-    animVars.set("leftHandPosition", hips.trans);
+    animVars.set("leftHandPosition", hips.trans());
     animVars.set("leftHandRotation", handRotation);
     animVars.set("leftHandType", (int)IKTarget::Type::RotationAndPosition);
-    animVars.set("rightHandPosition", hips.trans);
+    animVars.set("rightHandPosition", hips.trans());
     animVars.set("rightHandRotation", handRotation);
     animVars.set("rightHandType", (int)IKTarget::Type::RotationAndPosition);
 
@@ -1405,7 +1406,7 @@ void Rig::computeAvatarBoundingCapsule(
     radiusOut = 0.5f * sqrtf(0.5f * (diagonal.x * diagonal.x + diagonal.z * diagonal.z));
     heightOut = diagonal.y - 2.0f * radiusOut;
 
-    glm::vec3 rootPosition = finalPoses[geometry.rootJointIndex].trans;
+    glm::vec3 rootPosition = finalPoses[geometry.rootJointIndex].trans();
     glm::vec3 rigCenter = (geometryToRig * (0.5f * (totalExtents.maximum + totalExtents.minimum)));
     localOffsetOut = rigCenter - (geometryToRig * rootPosition);
 }

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1233,7 +1233,7 @@ void Rig::buildAbsoluteRigPoses(const AnimPoseVec& relativePoses, AnimPoseVec& a
     }
 }
 
-const glm::mat4& Rig::getJointTransform(int jointIndex) const {
+glm::mat4 Rig::getJointTransform(int jointIndex) const {
     static const glm::mat4 IDENTITY;
     if (isIndexValid(jointIndex)) {
         return _internalPoseSet._absolutePoses[jointIndex];

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -141,7 +141,7 @@ public:
     bool getJointCombinedRotation(int jointIndex, glm::quat& result, const glm::quat& rotation) const;
 
     // rig space
-    glm::mat4 getJointTransform(int jointIndex) const;
+    const glm::mat4& getJointTransform(int jointIndex) const;
 
     // Start or stop animations as needed.
     void computeMotionAnimationState(float deltaTime, const glm::vec3& worldPosition, const glm::vec3& worldVelocity, const glm::quat& worldRotation, CharacterControllerState ccState);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -141,7 +141,7 @@ public:
     bool getJointCombinedRotation(int jointIndex, glm::quat& result, const glm::quat& rotation) const;
 
     // rig space
-    const glm::mat4& getJointTransform(int jointIndex) const;
+    glm::mat4 getJointTransform(int jointIndex) const;
 
     // Start or stop animations as needed.
     void computeMotionAnimationState(float deltaTime, const glm::vec3& worldPosition, const glm::vec3& worldVelocity, const glm::quat& worldRotation, CharacterControllerState ccState);

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1055,10 +1055,10 @@ bool RenderableModelEntityItem::setAbsoluteJointRotationInObjectFrame(int index,
     if (!success) {
         return false;
     }
-    jointAbsolutePose.rot = rotation;
+    jointAbsolutePose.rot() = rotation;
 
     AnimPose jointRelativePose = jointParentInversePose * jointAbsolutePose;
-    return setLocalJointRotation(index, jointRelativePose.rot);
+    return setLocalJointRotation(index, jointRelativePose.rot());
 }
 
 bool RenderableModelEntityItem::setAbsoluteJointTranslationInObjectFrame(int index, const glm::vec3& translation) {
@@ -1088,10 +1088,10 @@ bool RenderableModelEntityItem::setAbsoluteJointTranslationInObjectFrame(int ind
     if (!success) {
         return false;
     }
-    jointAbsolutePose.trans = translation;
+    jointAbsolutePose.trans() = translation;
 
     AnimPose jointRelativePose = jointParentInversePose * jointAbsolutePose;
-    return setLocalJointTranslation(index, jointRelativePose.trans);
+    return setLocalJointTranslation(index, jointRelativePose.trans());
 }
 
 glm::quat RenderableModelEntityItem::getLocalJointRotation(int index) const {

--- a/libraries/render-utils/src/AnimDebugDraw.cpp
+++ b/libraries/render-utils/src/AnimDebugDraw.cpp
@@ -168,7 +168,7 @@ static void addBone(const AnimPose& rootPose, const AnimPose& pose, float radius
     const uint32_t color = toRGBA(vecColor);
 
     AnimPose finalPose = rootPose * pose;
-    glm::vec3 base = rootPose * pose.trans;
+    glm::vec3 base = rootPose * pose.trans();
 
     glm::vec3 xRing[NUM_CIRCLE_SLICES + 1];  // one extra for last index.
     glm::vec3 yRing[NUM_CIRCLE_SLICES + 1];
@@ -245,7 +245,7 @@ static void addLink(const AnimPose& rootPose, const AnimPose& pose, const AnimPo
     AnimPose pose0 = rootPose * parentPose;
     AnimPose pose1 = rootPose * pose;
 
-    glm::vec3 boneAxisWorld = glm::normalize(pose1.trans - pose0.trans);
+    glm::vec3 boneAxisWorld = glm::normalize(pose1.trans() - pose0.trans());
     glm::vec3 boneAxis0 = glm::normalize(pose0.inverse().xformVector(boneAxisWorld));
     glm::vec3 boneAxis1 = glm::normalize(pose1.inverse().xformVector(boneAxisWorld));
 
@@ -255,7 +255,7 @@ static void addLink(const AnimPose& rootPose, const AnimPose& pose, const AnimPo
     const int NUM_BASE_CORNERS = 4;
 
     // make sure there's room between the two bones to draw a nice bone link.
-    if (glm::dot(boneTip - pose0.trans, boneAxisWorld) > glm::dot(boneBase - pose0.trans, boneAxisWorld)) {
+    if (glm::dot(boneTip - pose0.trans(), boneAxisWorld) > glm::dot(boneBase - pose0.trans(), boneAxisWorld)) {
 
         // there is room, so lets draw a nice bone
 
@@ -290,10 +290,10 @@ static void addLink(const AnimPose& rootPose, const AnimPose& pose, const AnimPo
         // just draw a line between the two bone centers.
         // We add the same line multiple times, so the vertex count is correct.
         for (int i = 0; i < NUM_BASE_CORNERS * 2; i++) {
-            v->pos = pose0.trans;
+            v->pos = pose0.trans();
             v->rgba = color;
             v++;
-            v->pos = pose1.trans;
+            v->pos = pose1.trans();
             v->rgba = color;
             v++;
         }
@@ -365,7 +365,7 @@ void AnimDebugDraw::update() {
             glm::vec4 color = std::get<3>(iter.second);
 
             for (int i = 0; i < skeleton->getNumJoints(); i++) {
-                const float radius = BONE_RADIUS / (absPoses[i].scale.x * rootPose.scale.x);
+                const float radius = BONE_RADIUS / (absPoses[i].scale().x * rootPose.scale().x);
 
                 // draw bone
                 addBone(rootPose, absPoses[i], radius, color, v);

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -140,8 +140,8 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::MATERIAL, _drawMaterial->getSchemaBuffer());
     batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::TEXMAPARRAY, _drawMaterial->getTexMapArrayBuffer());
 
-    auto materialKey = _drawMaterial->getKey();
-    auto textureMaps = _drawMaterial->getTextureMaps();
+    const auto& materialKey = _drawMaterial->getKey();
+    const auto& textureMaps = _drawMaterial->getTextureMaps();
 
     int numUnlit = 0;
     if (materialKey.isUnlit()) {
@@ -150,9 +150,9 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
 
     // Albedo
     if (materialKey.isAlbedoMap()) {
-        auto albedoMap = textureMaps[model::MaterialKey::ALBEDO_MAP];
-        if (albedoMap && albedoMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::ALBEDO, albedoMap->getTextureView());
+        auto itr = textureMaps.find(model::MaterialKey::ALBEDO_MAP);
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::ALBEDO, itr->second->getTextureView());
         } else {
             batch.setResourceTexture(ShapePipeline::Slot::ALBEDO, textureCache->getGrayTexture());
         }
@@ -162,9 +162,9 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
 
     // Roughness map
     if (materialKey.isRoughnessMap()) {
-        auto roughnessMap = textureMaps[model::MaterialKey::ROUGHNESS_MAP];
-        if (roughnessMap && roughnessMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::MAP::ROUGHNESS, roughnessMap->getTextureView());
+        auto itr = textureMaps.find(model::MaterialKey::ROUGHNESS_MAP);
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::MAP::ROUGHNESS, itr->second->getTextureView());
 
             // texcoord are assumed to be the same has albedo
         } else {
@@ -176,9 +176,9 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
 
     // Normal map
     if (materialKey.isNormalMap()) {
-        auto normalMap = textureMaps[model::MaterialKey::NORMAL_MAP];
-        if (normalMap && normalMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::MAP::NORMAL, normalMap->getTextureView());
+        auto itr = textureMaps.find(model::MaterialKey::NORMAL_MAP);
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::MAP::NORMAL, itr->second->getTextureView());
 
             // texcoord are assumed to be the same has albedo
         } else {
@@ -190,9 +190,9 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
 
     // Metallic map
     if (materialKey.isMetallicMap()) {
-        auto specularMap = textureMaps[model::MaterialKey::METALLIC_MAP];
-        if (specularMap && specularMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::MAP::METALLIC, specularMap->getTextureView());
+        auto itr = textureMaps.find(model::MaterialKey::METALLIC_MAP);
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::MAP::METALLIC, itr->second->getTextureView());
 
             // texcoord are assumed to be the same has albedo
         } else {
@@ -204,9 +204,9 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
 
     // Occlusion map
     if (materialKey.isOcclusionMap()) {
-        auto specularMap = textureMaps[model::MaterialKey::OCCLUSION_MAP];
-        if (specularMap && specularMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::MAP::OCCLUSION, specularMap->getTextureView());
+        auto itr = textureMaps.find(model::MaterialKey::OCCLUSION_MAP);
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::MAP::OCCLUSION, itr->second->getTextureView());
 
             // texcoord are assumed to be the same has albedo
         } else {
@@ -218,9 +218,9 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
 
     // Scattering map
     if (materialKey.isScatteringMap()) {
-        auto scatteringMap = textureMaps[model::MaterialKey::SCATTERING_MAP];
-        if (scatteringMap && scatteringMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::MAP::SCATTERING, scatteringMap->getTextureView());
+        auto itr = textureMaps.find(model::MaterialKey::SCATTERING_MAP);
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::MAP::SCATTERING, itr->second->getTextureView());
 
             // texcoord are assumed to be the same has albedo
         } else {
@@ -232,18 +232,18 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
 
     // Emissive / Lightmap
     if (materialKey.isLightmapMap()) {
-        auto lightmapMap = textureMaps[model::MaterialKey::LIGHTMAP_MAP];
+        auto itr = textureMaps.find(model::MaterialKey::LIGHTMAP_MAP);
 
-        if (lightmapMap && lightmapMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, lightmapMap->getTextureView());
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, itr->second->getTextureView());
         } else {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, textureCache->getGrayTexture());
         }
     } else if (materialKey.isEmissiveMap()) {
-        auto emissiveMap = textureMaps[model::MaterialKey::EMISSIVE_MAP];
+        auto itr = textureMaps.find(model::MaterialKey::EMISSIVE_MAP);
 
-        if (emissiveMap && emissiveMap->isDefined()) {
-            batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, emissiveMap->getTextureView());
+        if (itr != textureMaps.end() && itr->second->isDefined()) {
+            batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, itr->second->getTextureView());
         } else {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, textureCache->getBlackTexture());
         }

--- a/libraries/shared/src/Profile.cpp
+++ b/libraries/shared/src/Profile.cpp
@@ -25,8 +25,9 @@ Q_LOGGING_CATEGORY(trace_simulation_physics, "trace.simulation.physics")
 #define NSIGHT_TRACING
 #endif
 
-Duration::Duration(const QLoggingCategory& category, const QString& name, uint32_t argbColor, uint64_t payload, QVariantMap args) : _name(name), _category(category) {
+Duration::Duration(const QLoggingCategory& category, const QString& name, uint32_t argbColor, uint64_t payload, const QVariantMap& baseArgs) : _name(name), _category(category) {
     if (_category.isDebugEnabled()) {
+        QVariantMap args = baseArgs;
         args["nv_payload"] = QVariant::fromValue(payload);
         tracing::traceEvent(_category, _name, tracing::DurationBegin, "", args);
 

--- a/libraries/shared/src/Profile.cpp
+++ b/libraries/shared/src/Profile.cpp
@@ -25,8 +25,12 @@ Q_LOGGING_CATEGORY(trace_simulation_physics, "trace.simulation.physics")
 #define NSIGHT_TRACING
 #endif
 
+static bool tracingEnabled() {
+    return DependencyManager::get<tracing::Tracer>()->isEnabled();
+}
+
 Duration::Duration(const QLoggingCategory& category, const QString& name, uint32_t argbColor, uint64_t payload, const QVariantMap& baseArgs) : _name(name), _category(category) {
-    if (_category.isDebugEnabled()) {
+    if (tracingEnabled() && category.isDebugEnabled()) {
         QVariantMap args = baseArgs;
         args["nv_payload"] = QVariant::fromValue(payload);
         tracing::traceEvent(_category, _name, tracing::DurationBegin, "", args);
@@ -48,7 +52,7 @@ Duration::Duration(const QLoggingCategory& category, const QString& name, uint32
 }
 
 Duration::~Duration() {
-    if (_category.isDebugEnabled()) {
+    if (tracingEnabled() && _category.isDebugEnabled()) {
         tracing::traceEvent(_category, _name, tracing::DurationEnd);
 #ifdef NSIGHT_TRACING
         nvtxRangePop();
@@ -59,7 +63,7 @@ Duration::~Duration() {
 // FIXME
 uint64_t Duration::beginRange(const QLoggingCategory& category, const char* name, uint32_t argbColor) {
 #ifdef NSIGHT_TRACING
-    if (category.isDebugEnabled()) {
+    if (tracingEnabled() && category.isDebugEnabled()) {
         nvtxEventAttributes_t eventAttrib = { 0 };
         eventAttrib.version = NVTX_VERSION;
         eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
@@ -76,7 +80,7 @@ uint64_t Duration::beginRange(const QLoggingCategory& category, const char* name
 // FIXME
 void Duration::endRange(const QLoggingCategory& category, uint64_t rangeId) {
 #ifdef NSIGHT_TRACING
-    if (category.isDebugEnabled()) {
+    if (tracingEnabled() && category.isDebugEnabled()) {
         nvtxRangeEnd(rangeId);
     }
 #endif

--- a/libraries/shared/src/Profile.h
+++ b/libraries/shared/src/Profile.h
@@ -26,7 +26,7 @@ Q_DECLARE_LOGGING_CATEGORY(trace_simulation_physics)
 
 class Duration {
 public:
-    Duration(const QLoggingCategory& category, const QString& name, uint32_t argbColor = 0xff0000ff, uint64_t payload = 0, QVariantMap args = QVariantMap());
+    Duration(const QLoggingCategory& category, const QString& name, uint32_t argbColor = 0xff0000ff, uint64_t payload = 0, const QVariantMap& args = QVariantMap());
     ~Duration();
 
     static uint64_t beginRange(const QLoggingCategory& category, const char* name, uint32_t argbColor);


### PR DESCRIPTION
## Improvments in `paintGL`

* Improve MeshPartPayload::`bindMaterial` to reduce copying of types, cost goes from 2.52% to 1.17% 

![image](https://cloud.githubusercontent.com/assets/1533642/21530868/a45a9824-ccf8-11e6-82fa-e6b60dd199c6.png)
![image](https://cloud.githubusercontent.com/assets/1533642/21530873/ac2ccb3a-ccf8-11e6-9af2-4088c674f8d1.png)

## Improvments in `idle`

Overall improvments to `AvatarManager::updateOtherAvatars`  cost goes from 10.69% to 8.07%

![image](https://cloud.githubusercontent.com/assets/1533642/21531028/c034cffa-ccf9-11e6-8f87-357f2905c679.png)
![image](https://cloud.githubusercontent.com/assets/1533642/21531030/c580c9aa-ccf9-11e6-9cf5-650e6b31fe83.png)

### Details

* Modifies AnimPose to hide its members, so that optimizations can be done internally without worrying about clients getting invalid results
* Modifies `AnimPose(const glm::mat4&)` constructor to do less work if it can (avoid a `glm::normalize` call)

![image](https://cloud.githubusercontent.com/assets/1533642/21530886/bd5fb930-ccf8-11e6-98ec-ba528ffc4502.png)
![image](https://cloud.githubusercontent.com/assets/1533642/21530888/c19575d0-ccf8-11e6-9c46-377c08a40460.png)

* Create a map of name to joint index in AnimSkeleton to improve performance of `Rig::indexOfJoint`
* Cache size of joint vector in AnimSkeleton

![image](https://cloud.githubusercontent.com/assets/1533642/21530897/cda784bc-ccf8-11e6-8762-a812e7f7578d.png)
![image](https://cloud.githubusercontent.com/assets/1533642/21530901/d499a80e-ccf8-11e6-96a3-6122b23b095a.png)

* Reduce the cost of the tracing Duration class if tracing isn't active
