### PR TITLE
Track dropped frames as reported by the Oculus SDK

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1271,6 +1271,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         properties["sim_rate"] = getAverageSimsPerSecond();
         properties["avatar_sim_rate"] = getAvatarSimrate();
         properties["has_async_reprojection"] = displayPlugin->hasAsyncReprojection();
+        properties["hardware_stats"] = displayPlugin->getHardwareStats();
 
         auto bandwidthRecorder = DependencyManager::get<BandwidthRecorder>();
         properties["packet_rate_in"] = bandwidthRecorder->getCachedTotalAverageInputPacketsPerSecond();

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -16,6 +16,7 @@
 #include <QtCore/QSize>
 #include <QtCore/QPoint>
 #include <QtCore/QElapsedTimer>
+#include <QtCore/QJsonObject>
 
 #include <GLMHelpers.h>
 #include <RegisteredMetaTypes.h>
@@ -194,6 +195,9 @@ public:
     virtual float newFramePresentRate() const { return -1.0f; }
     // Rate at which rendered frames are being skipped
     virtual float droppedFrameRate() const { return -1.0f; }
+    
+    // Hardware specific stats
+    virtual QJsonObject getHardwareStats() const { return QJsonObject(); }
 
     uint32_t presentCount() const { return _presentedFrameIndex; }
     // Time since last call to incrementPresentCount (only valid if DEBUG_PAINT_DELAY is defined)

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -147,17 +147,25 @@ void OculusDisplayPlugin::hmdPresent() {
             logWarning("Failed to present");
         }
 
-        static int droppedFrames = 0;
+        static int compositorDroppedFrames = 0;
+        static int appDroppedFrames = 0;
         ovrPerfStats perfStats;
         ovr_GetPerfStats(_session, &perfStats);
         for (int i = 0; i < perfStats.FrameStatsCount; ++i) {
             const auto& frameStats = perfStats.FrameStats[i];
-            int delta = frameStats.CompositorDroppedFrameCount - droppedFrames;
+            int delta = frameStats.CompositorDroppedFrameCount - compositorDroppedFrames;
             _stutterRate.increment(delta);
-            droppedFrames = frameStats.CompositorDroppedFrameCount;
+            compositorDroppedFrames = frameStats.CompositorDroppedFrameCount;
+            appDroppedFrames = frameStats.AppDroppedFrameCount;
         }
+        _hardwareStats["app_dropped_frame_count"] = appDroppedFrames;
     }
     _presentRate.increment();
+}
+
+
+QJsonObject OculusDisplayPlugin::getHardwareStats() const {
+    return _hardwareStats;
 }
 
 bool OculusDisplayPlugin::isHmdMounted() const {

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -19,6 +19,8 @@ public:
 
     QString getPreferredAudioInDevice() const override;
     QString getPreferredAudioOutDevice() const override;
+    
+    virtual QJsonObject getHardwareStats() const;
 
 protected:
     bool internalActivate() override;
@@ -33,5 +35,7 @@ private:
     ovrTextureSwapChain _textureSwapChain;
     gpu::FramebufferPointer _outputFramebuffer;
     bool _customized { false };
+
+    QJsonObject _hardwareStats;
 };
 


### PR DESCRIPTION
- Allow display plugins to return custom stats
- Track the dropped frames count reported by OVR.