### PR TITLE
more precise use of timers

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1135,7 +1135,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(&_settingsThread, SIGNAL(finished()), &_settingsTimer, SLOT(stop()));
     _settingsTimer.moveToThread(&_settingsThread);
     _settingsTimer.setSingleShot(false);
-    _settingsTimer.setInterval(SAVE_SETTINGS_INTERVAL);
+    _settingsTimer.setInterval(SAVE_SETTINGS_INTERVAL); // 10s, Qt::CoarseTimer acceptable
     _settingsThread.start();
 
     if (Menu::getInstance()->isOptionChecked(MenuOption::FirstPerson)) {
@@ -1240,7 +1240,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     // Periodically send fps as a user activity event
     QTimer* sendStatsTimer = new QTimer(this);
-    sendStatsTimer->setInterval(SEND_STATS_INTERVAL_MS);
+    sendStatsTimer->setInterval(SEND_STATS_INTERVAL_MS);  // 10s, Qt::CoarseTimer acceptable
     connect(sendStatsTimer, &QTimer::timeout, this, [this]() {
 
         QJsonObject properties = {};
@@ -1341,7 +1341,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // Periodically check for count of nearby avatars
     static int lastCountOfNearbyAvatars = -1;
     QTimer* checkNearbyAvatarsTimer = new QTimer(this);
-    checkNearbyAvatarsTimer->setInterval(CHECK_NEARBY_AVATARS_INTERVAL_MS);
+    checkNearbyAvatarsTimer->setInterval(CHECK_NEARBY_AVATARS_INTERVAL_MS); // 10 seconds, Qt::CoarseTimer ok
     connect(checkNearbyAvatarsTimer, &QTimer::timeout, this, [this]() {
         auto avatarManager = DependencyManager::get<AvatarManager>();
         int nearbyAvatars = avatarManager->numberOfAvatarsInRange(avatarManager->getMyAvatar()->getPosition(),
@@ -1499,16 +1499,16 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     // Monitor model assets (e.g., from Clara.io) added to the world that may need resizing.
     static const int ADD_ASSET_TO_WORLD_TIMER_INTERVAL_MS = 1000;
-    _addAssetToWorldResizeTimer.setInterval(ADD_ASSET_TO_WORLD_TIMER_INTERVAL_MS);
+    _addAssetToWorldResizeTimer.setInterval(ADD_ASSET_TO_WORLD_TIMER_INTERVAL_MS); // 1s, Qt::CoarseTimer acceptable
     connect(&_addAssetToWorldResizeTimer, &QTimer::timeout, this, &Application::addAssetToWorldCheckModelSize);
 
     // Auto-update and close adding asset to world info message box.
     static const int ADD_ASSET_TO_WORLD_INFO_TIMEOUT_MS = 5000;
-    _addAssetToWorldInfoTimer.setInterval(ADD_ASSET_TO_WORLD_INFO_TIMEOUT_MS);
+    _addAssetToWorldInfoTimer.setInterval(ADD_ASSET_TO_WORLD_INFO_TIMEOUT_MS); // 5s, Qt::CoarseTimer acceptable
     _addAssetToWorldInfoTimer.setSingleShot(true);
     connect(&_addAssetToWorldInfoTimer, &QTimer::timeout, this, &Application::addAssetToWorldInfoTimeout);
     static const int ADD_ASSET_TO_WORLD_ERROR_TIMEOUT_MS = 8000;
-    _addAssetToWorldErrorTimer.setInterval(ADD_ASSET_TO_WORLD_ERROR_TIMEOUT_MS);
+    _addAssetToWorldErrorTimer.setInterval(ADD_ASSET_TO_WORLD_ERROR_TIMEOUT_MS); // 8s, Qt::CoarseTimer acceptable
     _addAssetToWorldErrorTimer.setSingleShot(true);
     connect(&_addAssetToWorldErrorTimer, &QTimer::timeout, this, &Application::addAssetToWorldErrorTimeout);
 

--- a/interface/src/ui/DiskCacheEditor.cpp
+++ b/interface/src/ui/DiskCacheEditor.cpp
@@ -91,7 +91,7 @@ void DiskCacheEditor::makeDialog() {
 
     static const int REFRESH_INTERVAL = 100; // msec
     _refreshTimer = new QTimer(_dialog);
-    _refreshTimer->setInterval(REFRESH_INTERVAL); // 100ms, Qt::CoarseTimer acceptable
+    _refreshTimer->setInterval(REFRESH_INTERVAL); // Qt::CoarseTimer acceptable, no need for real time accuracy
     _refreshTimer->setSingleShot(false);
     QObject::connect(_refreshTimer.data(), &QTimer::timeout, this, &DiskCacheEditor::refresh);
     _refreshTimer->start();

--- a/interface/src/ui/DiskCacheEditor.cpp
+++ b/interface/src/ui/DiskCacheEditor.cpp
@@ -91,7 +91,7 @@ void DiskCacheEditor::makeDialog() {
 
     static const int REFRESH_INTERVAL = 100; // msec
     _refreshTimer = new QTimer(_dialog);
-    _refreshTimer->setInterval(REFRESH_INTERVAL);
+    _refreshTimer->setInterval(REFRESH_INTERVAL); // 100ms, Qt::CoarseTimer acceptable
     _refreshTimer->setSingleShot(false);
     QObject::connect(_refreshTimer.data(), &QTimer::timeout, this, &DiskCacheEditor::refresh);
     _refreshTimer->start();

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -426,7 +426,8 @@ void OffscreenQmlSurface::create(QOpenGLContext* shareContext) {
     // a timer with a small interval is used to get better performance.
     QObject::connect(&_updateTimer, &QTimer::timeout, this, &OffscreenQmlSurface::updateQuick);
     QObject::connect(qApp, &QCoreApplication::aboutToQuit, this, &OffscreenQmlSurface::onAboutToQuit);
-    _updateTimer.setInterval(MIN_TIMER_MS);
+    _updateTimer.setTimerType(Qt::PreciseTimer);
+    _updateTimer.setInterval(MIN_TIMER_MS); // 5ms, Qt::PreciseTimer required
     _updateTimer.start();
 
     auto rootContext = getRootContext();

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -41,12 +41,12 @@ DomainHandler::DomainHandler(QObject* parent) :
     
     // setup a timeout for failure on settings requests
     static const int DOMAIN_SETTINGS_TIMEOUT_MS = 5000;
-    _settingsTimer.setInterval(DOMAIN_SETTINGS_TIMEOUT_MS);
+    _settingsTimer.setInterval(DOMAIN_SETTINGS_TIMEOUT_MS); // 5s, Qt::CoarseTimer acceptable
     connect(&_settingsTimer, &QTimer::timeout, this, &DomainHandler::settingsReceiveFail);
 
     // setup the API refresh timer for auto connection information refresh from API when failing to connect
     const int API_REFRESH_TIMEOUT_MSEC = 2500;
-    _apiRefreshTimer.setInterval(API_REFRESH_TIMEOUT_MSEC);
+    _apiRefreshTimer.setInterval(API_REFRESH_TIMEOUT_MSEC); // 2.5s, Qt::CoarseTimer acceptable
 
     auto addressManager = DependencyManager::get<AddressManager>();
     connect(&_apiRefreshTimer, &QTimer::timeout, addressManager.data(), &AddressManager::refreshPreviousLookup);

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -902,7 +902,7 @@ void LimitedNodeList::startSTUNPublicSocketUpdate() {
         connect(_initialSTUNTimer.data(), &QTimer::timeout, this, &LimitedNodeList::sendSTUNRequest);
 
         const int STUN_INITIAL_UPDATE_INTERVAL_MSECS = 250;
-        _initialSTUNTimer->setInterval(STUN_INITIAL_UPDATE_INTERVAL_MSECS);
+        _initialSTUNTimer->setInterval(STUN_INITIAL_UPDATE_INTERVAL_MSECS); // 250ms, Qt::CoarseTimer acceptable
 
         // if we don't know the STUN IP yet we need to wait until it is known to start STUN requests
         if (_stunSockAddr.getAddress().isNull()) {

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -102,7 +102,7 @@ NodeList::NodeList(char newOwnerType, int socketListenPort, int dtlsListenPort) 
     connect(this, &LimitedNodeList::nodeActivated, this, &NodeList::maybeSendIgnoreSetToNode);
     
     // setup our timer to send keepalive pings (it's started and stopped on domain connect/disconnect)
-    _keepAlivePingTimer.setInterval(KEEPALIVE_PING_INTERVAL_MS);
+    _keepAlivePingTimer.setInterval(KEEPALIVE_PING_INTERVAL_MS); // 1s, Qt::CoarseTimer acceptable
     connect(&_keepAlivePingTimer, &QTimer::timeout, this, &NodeList::sendKeepAlivePings);
     connect(&_domainHandler, SIGNAL(connectedToDomain(QString)), &_keepAlivePingTimer, SLOT(start()));
     connect(&_domainHandler, &DomainHandler::disconnectedFromDomain, &_keepAlivePingTimer, &QTimer::stop);

--- a/libraries/networking/src/ThreadedAssignment.cpp
+++ b/libraries/networking/src/ThreadedAssignment.cpp
@@ -27,11 +27,11 @@ ThreadedAssignment::ThreadedAssignment(ReceivedMessage& message) :
     _statsTimer(this)
 {
     static const int STATS_TIMEOUT_MS = 1000;
-    _statsTimer.setInterval(STATS_TIMEOUT_MS);
+    _statsTimer.setInterval(STATS_TIMEOUT_MS); // 1s, Qt::CoarseTimer acceptable
     connect(&_statsTimer, &QTimer::timeout, this, &ThreadedAssignment::sendStatsPacket);
 
     connect(&_domainServerTimer, &QTimer::timeout, this, &ThreadedAssignment::checkInWithDomainServerOrExit);
-    _domainServerTimer.setInterval(DOMAIN_SERVER_CHECK_IN_MSECS);
+    _domainServerTimer.setInterval(DOMAIN_SERVER_CHECK_IN_MSECS); // 1s, Qt::CoarseTimer acceptable
 
     // if the NL tells us we got a DS response, clear our member variable of queued check-ins
     auto nodeList = DependencyManager::get<NodeList>();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1087,6 +1087,12 @@ QObject* ScriptEngine::setupTimerWithInterval(const QScriptValue& function, int 
     QTimer* newTimer = new QTimer(this);
     newTimer->setSingleShot(isSingleShot);
 
+    // The default timer type is not very accurate below about 200ms http://doc.qt.io/qt-5/qt.html#TimerType-enum
+    static const int MIN_TIMEOUT_FOR_COARSE_TIMER = 200;
+    if (intervalMS < MIN_TIMEOUT_FOR_COARSE_TIMER) {
+        newTimer->setTimerType(Qt::PreciseTimer);
+    }
+
     connect(newTimer, &QTimer::timeout, this, &ScriptEngine::timerFired);
 
     // make sure the timer stops when the script does

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -840,15 +840,6 @@ QScriptValue ScriptEngine::evaluate(const QString& sourceCode, const QString& fi
 }
 
 void ScriptEngine::run() {
-
-#ifdef _WIN32
-    // VS13 does not sleep_until unless it uses the system_clock, see:
-    // https://www.reddit.com/r/cpp_questions/comments/3o71ic/sleep_until_not_working_with_a_time_pointsteady/
-    using clock = std::chrono::system_clock;
-#else
-    using clock = std::chrono::high_resolution_clock;
-#endif
-
     if (DependencyManager::get<ScriptEngines>()->isStopped()) {
         return; // bail early - avoid setting state in init(), as evaluate() will bail too
     }
@@ -861,6 +852,14 @@ void ScriptEngine::run() {
     emit runningStateChanged();
 
     QScriptValue result = evaluate(_scriptContents, _fileNameString);
+
+#ifdef _WIN32
+    // VS13 does not sleep_until unless it uses the system_clock, see:
+    // https://www.reddit.com/r/cpp_questions/comments/3o71ic/sleep_until_not_working_with_a_time_pointsteady/
+    using clock = std::chrono::system_clock;
+#else
+    using clock = std::chrono::high_resolution_clock;
+#endif
 
     clock::time_point startTime = clock::now();
     int thisFrame = 0;

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -218,6 +218,7 @@ protected:
     void init();
 
     bool evaluatePending() const { return _evaluatesPending > 0; }
+    quint64 getTimersRemainingTime();
     void timerFired();
     void stopAllTimers();
     void stopAllTimersForEntityScript(const EntityItemID& entityID);
@@ -252,6 +253,8 @@ protected:
     std::function<bool()> _emitScriptUpdates{ [](){ return true; }  };
 
     std::recursive_mutex _lock;
+
+    std::chrono::microseconds _totalTimerExecution { 0 };
 };
 
 #endif // hifi_ScriptEngine_h

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -83,7 +83,7 @@ namespace Setting {
             _saveTimer = new QTimer(this);
             Q_CHECK_PTR(_saveTimer);
             _saveTimer->setSingleShot(true); // We will restart it once settings are saved.
-            _saveTimer->setInterval(SAVE_INTERVAL_MSEC);
+            _saveTimer->setInterval(SAVE_INTERVAL_MSEC); // 5s, Qt::CoarseTimer acceptable
             connect(_saveTimer, SIGNAL(timeout()), this, SLOT(saveAll()));
         }
         _saveTimer->start();

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -363,7 +363,7 @@ void showMinSpecWarning() {
     vrOverlay->ShowOverlay(minSpecFailedOverlay);
 
     QTimer* timer = new QTimer(&miniApp);
-    timer->setInterval(FAILED_MIN_SPEC_UPDATE_INTERVAL_MS);
+    timer->setInterval(FAILED_MIN_SPEC_UPDATE_INTERVAL_MS); // Qt::CoarseTimer acceptable, we don't need this to be frame rate accurate
     QObject::connect(timer, &QTimer::timeout, [&] {
         vr::TrackedDevicePose_t vrPoses[vr::k_unMaxTrackedDeviceCount];
         vrSystem->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0, vrPoses, vr::k_unMaxTrackedDeviceCount);

--- a/tests/gpu-test/src/TestWindow.cpp
+++ b/tests/gpu-test/src/TestWindow.cpp
@@ -34,6 +34,7 @@ TestWindow::TestWindow() {
 
 
     auto timer = new QTimer(this);
+    timer->setTimerType(Qt::PreciseTimer);
     timer->setInterval(5);
     connect(timer, &QTimer::timeout, [&] { draw(); });
     timer->start();

--- a/tests/networking/src/ResourceTests.cpp
+++ b/tests/networking/src/ResourceTests.cpp
@@ -40,6 +40,12 @@ static QSharedPointer<Resource> resource;
 static bool waitForSignal(QObject *sender, const char *signal, int timeout = 1000) {
     QEventLoop loop;
     QTimer timer;
+
+    // The default timer type is not very accurate below about 200ms http://doc.qt.io/qt-5/qt.html#TimerType-enum
+    static const int MIN_TIMEOUT_FOR_COARSE_TIMER = 200;
+    if (timeout < MIN_TIMEOUT_FOR_COARSE_TIMER) {
+        timer.setTimerType(Qt::PreciseTimer);
+    }
     timer.setInterval(timeout);
     timer.setSingleShot(true);
 
@@ -61,7 +67,7 @@ void ResourceTests::downloadFirst() {
     const int timeout = 1000;
     QEventLoop loop;
     QTimer timer;
-    timer.setInterval(timeout);
+    timer.setInterval(timeout); // 1s, Qt::CoarseTimer acceptable
     timer.setSingleShot(true);
 
     loop.connect(resource, SIGNAL(loaded(QNetworkReply&)), SLOT(quit()));
@@ -85,7 +91,7 @@ void ResourceTests::downloadAgain() {
     const int timeout = 1000;
     QEventLoop loop;
     QTimer timer;
-    timer.setInterval(timeout);
+    timer.setInterval(timeout); // 1s, Qt::CoarseTimer acceptable
     timer.setSingleShot(true);
 
     loop.connect(resource, SIGNAL(loaded(QNetworkReply&)), SLOT(quit()));

--- a/tests/render-perf/src/main.cpp
+++ b/tests/render-perf/src/main.cpp
@@ -546,7 +546,7 @@ public:
         restorePosition();
 
         QTimer* timer = new QTimer(this);
-        timer->setInterval(0);
+        timer->setInterval(0); // Qt::CoarseTimer acceptable
         connect(timer, &QTimer::timeout, this, [this] {
             draw();
         });

--- a/tests/render-texture-load/src/main.cpp
+++ b/tests/render-texture-load/src/main.cpp
@@ -355,7 +355,7 @@ public:
         }
 
         QTimer* timer = new QTimer(this);
-        timer->setInterval(0);
+        timer->setInterval(0); // Qt::CoarseTimer acceptable
         connect(timer, &QTimer::timeout, this, [this] {
             draw();
         });

--- a/tests/render-utils/src/main.cpp
+++ b/tests/render-utils/src/main.cpp
@@ -201,7 +201,7 @@ int main(int argc, char** argv) {
     QLoggingCategory::setFilterRules(LOG_FILTER_RULES);
     QTestWindow window;
     QTimer timer;
-    timer.setInterval(1);
+    timer.setInterval(1); // Qt::CoarseTimer acceptable
     app.connect(&timer, &QTimer::timeout, &app, [&] {
         window.draw();
     });

--- a/unpublishedScripts/marketplace/bow/bow.js
+++ b/unpublishedScripts/marketplace/bow/bow.js
@@ -593,3 +593,8 @@
 
     return bow;
 });
+
+var TIMER_INTERVAL = 5;
+var RPCkicker = Script.setInterval(function() {
+    // do nothing, but make sure we get RPC messages in a reliable way
+},TIMER_INTERVAL);

--- a/unpublishedScripts/marketplace/bow/bow.js
+++ b/unpublishedScripts/marketplace/bow/bow.js
@@ -595,6 +595,11 @@
 });
 
 var TIMER_INTERVAL = 5;
+var lastRPC = Date.now();
 var RPCkicker = Script.setInterval(function() {
     // do nothing, but make sure we get RPC messages in a reliable way
+    var now = Date.now();
+    deltaTime = now - lastRPC;
+    lastRPC = now;
+    print("RPCkicker interval:"+deltaTime);
 },TIMER_INTERVAL);

--- a/unpublishedScripts/marketplace/bow/bow.js
+++ b/unpublishedScripts/marketplace/bow/bow.js
@@ -154,7 +154,6 @@
         },
         continueEquip: function(entityID, args) {
             this.deltaTime = checkInterval();
-            print("continueEquip deltaTime:" + this.deltaTime);
             //debounce during debugging -- maybe we're updating too fast?
             if (USE_DEBOUNCE === true) {
                 this.sinceLastUpdate = this.sinceLastUpdate + this.deltaTime;
@@ -375,8 +374,8 @@
                     this.pullBackDistance = 0;
                     this.state = STATE_ARROW_GRABBED;
                 } else {
-                    this.updateArrowPositionInNotch(false, false);
                     this.updateString();
+                    this.updateArrowPositionInNotch(false, false);
                 }
             }
             if (this.state === STATE_ARROW_GRABBED) {
@@ -590,17 +589,6 @@
 
     Messages.subscribe('Hifi-Object-Manipulation');
     Messages.messageReceived.connect(bow.handleMessages);
-
-    var TIMER_INTERVAL = 5;
-    var lastRPC = Date.now();
-    var RPCkicker = Script.setInterval(function() {
-        // do nothing, but make sure we get RPC messages in a reliable way
-        var now = Date.now();
-        deltaTime = now - lastRPC;
-        lastRPC = now;
-        //print("RPCkicker interval:"+deltaTime);
-    },TIMER_INTERVAL);
-
 
     return bow;
 });

--- a/unpublishedScripts/marketplace/bow/bow.js
+++ b/unpublishedScripts/marketplace/bow/bow.js
@@ -154,6 +154,7 @@
         },
         continueEquip: function(entityID, args) {
             this.deltaTime = checkInterval();
+            print("continueEquip deltaTime:" + this.deltaTime);
             //debounce during debugging -- maybe we're updating too fast?
             if (USE_DEBOUNCE === true) {
                 this.sinceLastUpdate = this.sinceLastUpdate + this.deltaTime;
@@ -374,8 +375,8 @@
                     this.pullBackDistance = 0;
                     this.state = STATE_ARROW_GRABBED;
                 } else {
-                    this.updateString();
                     this.updateArrowPositionInNotch(false, false);
+                    this.updateString();
                 }
             }
             if (this.state === STATE_ARROW_GRABBED) {

--- a/unpublishedScripts/marketplace/bow/bow.js
+++ b/unpublishedScripts/marketplace/bow/bow.js
@@ -598,7 +598,7 @@
         var now = Date.now();
         deltaTime = now - lastRPC;
         lastRPC = now;
-        print("RPCkicker interval:"+deltaTime);
+        //print("RPCkicker interval:"+deltaTime);
     },TIMER_INTERVAL);
 
 

--- a/unpublishedScripts/marketplace/bow/bow.js
+++ b/unpublishedScripts/marketplace/bow/bow.js
@@ -591,15 +591,16 @@
     Messages.subscribe('Hifi-Object-Manipulation');
     Messages.messageReceived.connect(bow.handleMessages);
 
+    var TIMER_INTERVAL = 5;
+    var lastRPC = Date.now();
+    var RPCkicker = Script.setInterval(function() {
+        // do nothing, but make sure we get RPC messages in a reliable way
+        var now = Date.now();
+        deltaTime = now - lastRPC;
+        lastRPC = now;
+        print("RPCkicker interval:"+deltaTime);
+    },TIMER_INTERVAL);
+
+
     return bow;
 });
-
-var TIMER_INTERVAL = 5;
-var lastRPC = Date.now();
-var RPCkicker = Script.setInterval(function() {
-    // do nothing, but make sure we get RPC messages in a reliable way
-    var now = Date.now();
-    deltaTime = now - lastRPC;
-    lastRPC = now;
-    print("RPCkicker interval:"+deltaTime);
-},TIMER_INTERVAL);


### PR DESCRIPTION
- cleans up our use of QTimer to use precision timers for things that need to be precise
- improves Script timers to fire even if their interval is less than the script update rate
- properly punishes timers and update methods if they are taking too long to execute