### PR TITLE
Audio level calculation in tabletUI.js

### DIFF
--- a/interface/resources/qml/hifi/tablet/Tablet.qml
+++ b/interface/resources/qml/hifi/tablet/Tablet.qml
@@ -10,7 +10,7 @@ Item {
     width: parent.width
     height: parent.height
 
-    // called by C++ code to keep mic level display bar UI updated
+    // called by C++ code to keep audio bar updated
     function setMicLevel(newMicLevel) {
         tablet.micLevel = newMicLevel;
     }

--- a/interface/resources/qml/hifi/tablet/Tablet.qml
+++ b/interface/resources/qml/hifi/tablet/Tablet.qml
@@ -5,10 +5,15 @@ Item {
     id: tablet
     objectName: "tablet"
 
-    property double miclevel: 0.8
+    property double micLevel: 0.8
 
     width: parent.width
     height: parent.height
+
+    // called by C++ code to keep mic level display bar UI updated
+    function setMicLevel(newMicLevel) {
+        tablet.micLevel = newMicLevel;
+    }
 
     // used to look up a button by its uuid
     function findButtonIndex(uuid) {
@@ -101,7 +106,7 @@ Item {
                 }
                 Rectangle {
                     id: audioBarMask
-                    width: parent.width * tablet.miclevel
+                    width: parent.width * tablet.micLevel
                     color: "#333333"
                     radius: 5
                     anchors.bottom: parent.bottom
@@ -205,7 +210,7 @@ Item {
 
             PropertyChanges {
                 target: tablet
-                miclevel: 0
+                micLevel: 0
             }
         }
     ]

--- a/libraries/script-engine/src/TabletScriptingInterface.cpp
+++ b/libraries/script-engine/src/TabletScriptingInterface.cpp
@@ -146,7 +146,7 @@ void TabletProxy::updateAudioBar(const double micLevel) {
     if (!tablet) {
         qCCritical(scriptengine) << "Could not find tablet in TabletRoot.qml";
     } else {
-        QMetaObject::invokeMethod(tablet, "setMicLevel", Qt::AutoConnection, Q_ARG(QVariant, QVariant::QVariant(micLevel)));
+        QMetaObject::invokeMethod(tablet, "setMicLevel", Qt::AutoConnection, Q_ARG(QVariant, QVariant(micLevel)));
     }
 }
 

--- a/libraries/script-engine/src/TabletScriptingInterface.cpp
+++ b/libraries/script-engine/src/TabletScriptingInterface.cpp
@@ -141,6 +141,15 @@ void TabletProxy::removeButton(QObject* tabletButtonProxy) {
     }
 }
 
+void TabletProxy::updateAudioBar(const double micLevel) {
+    auto tablet = getQmlTablet();
+    if (!tablet) {
+        qCCritical(scriptengine) << "Could not find tablet in TabletRoot.qml";
+    } else {
+        QMetaObject::invokeMethod(tablet, "setMicLevel", Qt::AutoConnection, Q_ARG(QVariant, QVariant::QVariant(micLevel)));
+    }
+}
+
 void TabletProxy::addButtonsToHomeScreen() {
     auto tablet = getQmlTablet();
     if (!tablet) {

--- a/libraries/script-engine/src/TabletScriptingInterface.h
+++ b/libraries/script-engine/src/TabletScriptingInterface.h
@@ -84,6 +84,13 @@ public:
      */
     Q_INVOKABLE void removeButton(QObject* tabletButtonProxy);
 
+    /**jsdoc
+     * @function TabletProxy#updateAudioBar
+     * Updates the audio bar in tablet to reflect latest mic level
+     * @param micLevel {double} mic level value between 0 and 1
+     */
+    Q_INVOKABLE void updateAudioBar(const double micLevel);
+    
     QString getName() const { return _name; }
 protected:
 

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -67,4 +67,37 @@
     Script.update.connect(updateShowTablet);
     // Script.setInterval(updateShowTablet, 1000);
 
+    // Initialise variables used to calculate audio level
+    var accumulatedLevel = 0.0;
+    // Note: Might have to tweak the following two based on the rate we're getting the data
+    var AVERAGING_RATIO = 0.05;
+    var AUDIO_LEVEL_UPDATE_INTERVAL_MS = 100;
+
+    // Calculate audio level with the same scaling equation (log scale, exponentially averaged) in AvatarInputs and pal.js
+    function getAudioLevel() {
+        var LOUDNESS_FLOOR = 11.0;
+        var LOUDNESS_SCALE = 2.8 / 5.0;
+        var LOG2 = Math.log(2.0);
+        var audioLevel = 0.0;
+        accumulatedLevel = AVERAGING_RATIO * accumulatedLevel + (1 - AVERAGING_RATIO) * (MyAvatar.audioLoudness);
+        // Convert to log base 2
+        var logLevel = Math.log(accumulatedLevel + 1) / LOG2;
+        
+        if (logLevel <= LOUDNESS_FLOOR) {
+            audioLevel = logLevel / LOUDNESS_FLOOR * LOUDNESS_SCALE;
+        } else {
+            audioLevel = (logLevel - (LOUDNESS_FLOOR - 1.0)) * LOUDNESS_SCALE;
+        }
+        if (audioLevel > 1.0) {
+            audioLevel = 1.0;
+        }
+        return audioLevel;
+    }
+
+    Script.setInterval(function() {
+        var currentAudioLevel = getAudioLevel();
+        // TODO: send the audio level to QML
+
+    }, AUDIO_LEVEL_UPDATE_INTERVAL_MS);
+
 }()); // END LOCAL_SCOPE

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -95,9 +95,11 @@
     }
 
     Script.setInterval(function() {
-        var currentMicLevel = getMicLevel();
-        var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");      
-        tablet.updateAudioBar(currentMicLevel);
+       if (tabletShown) {
+            var currentMicLevel = getMicLevel();
+            var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");      
+            tablet.updateAudioBar(currentMicLevel);
+        }
     }, MIC_LEVEL_UPDATE_INTERVAL_MS);
 
 }()); // END LOCAL_SCOPE

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -71,33 +71,33 @@
     var accumulatedLevel = 0.0;
     // Note: Might have to tweak the following two based on the rate we're getting the data
     var AVERAGING_RATIO = 0.05;
-    var AUDIO_LEVEL_UPDATE_INTERVAL_MS = 100;
+    var MIC_LEVEL_UPDATE_INTERVAL_MS = 100;
 
-    // Calculate audio level with the same scaling equation (log scale, exponentially averaged) in AvatarInputs and pal.js
-    function getAudioLevel() {
+    // Calculate microphone level with the same scaling equation (log scale, exponentially averaged) in AvatarInputs and pal.js
+    function getMicLevel() {
         var LOUDNESS_FLOOR = 11.0;
         var LOUDNESS_SCALE = 2.8 / 5.0;
         var LOG2 = Math.log(2.0);
-        var audioLevel = 0.0;
+        var micLevel = 0.0;
         accumulatedLevel = AVERAGING_RATIO * accumulatedLevel + (1 - AVERAGING_RATIO) * (MyAvatar.audioLoudness);
         // Convert to log base 2
         var logLevel = Math.log(accumulatedLevel + 1) / LOG2;
         
         if (logLevel <= LOUDNESS_FLOOR) {
-            audioLevel = logLevel / LOUDNESS_FLOOR * LOUDNESS_SCALE;
+            micLevel = logLevel / LOUDNESS_FLOOR * LOUDNESS_SCALE;
         } else {
-            audioLevel = (logLevel - (LOUDNESS_FLOOR - 1.0)) * LOUDNESS_SCALE;
+            micLevel = (logLevel - (LOUDNESS_FLOOR - 1.0)) * LOUDNESS_SCALE;
         }
-        if (audioLevel > 1.0) {
-            audioLevel = 1.0;
+        if (micLevel > 1.0) {
+            micLevel = 1.0;
         }
-        return audioLevel;
+        return micLevel;
     }
 
     Script.setInterval(function() {
-        var currentAudioLevel = getAudioLevel();
-        // TODO: send the audio level to QML
-
-    }, AUDIO_LEVEL_UPDATE_INTERVAL_MS);
+        var currentMicLevel = getMicLevel();
+        var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");      
+        tablet.updateAudioBar(currentMicLevel);
+    }, MIC_LEVEL_UPDATE_INTERVAL_MS);
 
 }()); // END LOCAL_SCOPE


### PR DESCRIPTION
Taking inspirations from the recent vu meters feature from People Action List, I put together similar calculation for the mic level in tablet. In this PR, I've properly scaled the user's audio loudness to a 0 to 1 value, which I hope we could integrate with the audio bar UI display I've previously written in QML.

Love to get some feedback on how to proceed from here! Thanks! (: