### PR TITLE
Fix settings hitch

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1137,6 +1137,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _settingsTimer.moveToThread(&_settingsThread);
     _settingsTimer.setSingleShot(false);
     _settingsTimer.setInterval(SAVE_SETTINGS_INTERVAL); // 10s, Qt::CoarseTimer acceptable
+    _settingsThread.setPriority(QThread::LowestPriority);
     _settingsThread.start();
 
     if (Menu::getInstance()->isOptionChecked(MenuOption::FirstPerson)) {

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -74,7 +74,9 @@ void Settings::endGroup() {
 }
 
 void Settings::setValue(const QString& name, const QVariant& value) {
-    _manager->setValue(name, value);
+    if (_manager->value(name) != value) {
+        _manager->setValue(name, value);
+    }
 }
 
 QVariant Settings::value(const QString& name, const QVariant& defaultValue) const {


### PR DESCRIPTION
- Check setting value actually changed
- Set setting thread priority to lowest


Test Plan:
- Deactivate snap turns
- Spin in a circle
- Previous build should have a hitch every 10 sec, this one shouldn't
