### PR TITLE
Tablet Button Active State's Text and Icon

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletButton.qml
+++ b/interface/resources/qml/hifi/tablet/TabletButton.qml
@@ -6,6 +6,8 @@ Item {
     property var uuid;
     property string text: "EDIT"
     property string icon: "icons/edit-icon.svg"
+    property string activeText: tabletButton.text
+    property string activeIcon: tabletButton.icon
     property bool isActive: false
     property bool inDebugMode: false
     property bool isEntered: false
@@ -170,11 +172,17 @@ Item {
             PropertyChanges {
                 target: text
                 color: "#333333"
+                text: tabletButton.activeText
             }
 
             PropertyChanges {
                 target: iconColorOverlay
                 color: "#333333"
+            }
+
+            PropertyChanges {
+                target: icon
+                source: "../../../" + tabletButton.activeIcon
             }
         },
         State {

--- a/scripts/system/mute.js
+++ b/scripts/system/mute.js
@@ -20,7 +20,9 @@ function muteURL() {
 }
 var button = tablet.addButton({
     icon: "icons/tablet-icons/mic-a.svg",
-    text: "MUTE"
+    text: "MUTE",
+    activeIcon: "icons/tablet-icons/mic-i.svg",
+    activeText: "UNMUTE"
 });
 
 function onMuteToggled() {

--- a/scripts/system/mute.js
+++ b/scripts/system/mute.js
@@ -15,9 +15,6 @@
 
 var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
 
-function muteURL() {
-    return "icons/tablet-icons/" + (AudioDevice.getMuted() ? "mic-a.svg" : "mic-i.svg"); 
-}
 var button = tablet.addButton({
     icon: "icons/tablet-icons/mic-a.svg",
     text: "MUTE",
@@ -26,7 +23,7 @@ var button = tablet.addButton({
 });
 
 function onMuteToggled() {
-    button.editProperties({icon: muteURL()});
+    button.editProperties({isActive: AudioDevice.getMuted()});
 }
 onMuteToggled();
 function onClicked(){


### PR DESCRIPTION
Adding support for different text and icon when a tablet button is in active state.

Usage: When you create a new tablet button, just specify the text and icon you'd like for its active state. 

e.g. 
` var button = tablet.addButton({
      icon: "icons/tablet-icons/mic-a.svg",
      text: "MUTE"
      activeIcon: "icons/tablet-icons/mic-i.svg",
      activeText: "UNMUTE"
  });`

When not specified, activeIcon and activeText are default to the regular text and icon.

