### PR TITLE
Expose dropped frames count to stats UI

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -80,6 +80,10 @@ Item {
                         text: "Avatar Simrate: " + root.avatarSimrate
                     }
                     StatText {
+                        text: "Missed Frame Count: " + root.appdropped;
+                        visible: root.appdropped > 0;
+                    }
+                    StatText {
                         text: "Packets In/Out: " + root.packetInCount + "/" + root.packetOutCount
                     }
                     StatText {

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -125,6 +125,8 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(framerate, qApp->getFps());
     if (qApp->getActiveDisplayPlugin()) {
         auto displayPlugin = qApp->getActiveDisplayPlugin();
+        auto stats = displayPlugin->getHardwareStats();
+        STAT_UPDATE(appdropped, stats["app_dropped_frame_count"].toInt());
         STAT_UPDATE(renderrate, displayPlugin->renderRate());
         STAT_UPDATE(presentrate, displayPlugin->presentRate());
         STAT_UPDATE(presentnewrate, displayPlugin->newFramePresentRate());

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -39,6 +39,8 @@ class Stats : public QQuickItem {
     // How often the display device reprojecting old frames
     STATS_PROPERTY(float, stutterrate, 0)
 
+    STATS_PROPERTY(int, appdropped, 0)
+
     STATS_PROPERTY(float, presentnewrate, 0)
     STATS_PROPERTY(float, presentdroprate, 0)
     STATS_PROPERTY(int, simrate, 0)
@@ -135,6 +137,7 @@ public slots:
     void forceUpdateStats() { updateStats(true); }
 
 signals:
+    void appdroppedChanged();
     void framerateChanged();
     void expandedChanged();
     void timingExpandedChanged();


### PR DESCRIPTION
When running in the Oculus, this will display a realtime count of the total number of dropped frames as reported by the Oculus API.

## Testing

Switch to the Oculus display plugin.  The stats display should show a new value `Missed Frame Count` that will increment whenever we fail to submit a frame to Oculus in time for the next display refresh.  