### PR TITLE
People Action List

### DIFF
--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -76,7 +76,7 @@ OriginalDesktop.Desktop {
         WebEngine.settings.localContentCanAccessRemoteUrls = true;
 
         [ // Allocate the standard buttons in the correct order. They will get images, etc., via scripts.
-            "hmdToggle", "mute", "mod", "bubble", "help",
+            "hmdToggle", "mute", "pal", "bubble", "help",
             "hudToggle",
             "com.highfidelity.interface.system.editButton", "marketplace", "snapshot", "goto"
         ].forEach(function (name) {

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -20,7 +20,7 @@ var DEFAULT_SCRIPTS = [
     "system/hmd.js",
     "system/marketplaces/marketplace.js",
     "system/edit.js",
-    "system/mod.js",
+    "system/pal.js", //"system/mod.js", // older UX, if you prefer
     "system/selectAudioDevice.js",
     "system/notifications.js",
     "system/controllers/controllerDisplayManager.js",

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -11,7 +11,7 @@
 // See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-// FIXME when we make this a defaultScript: (function() { // BEGIN LOCAL_SCOPE
+(function() { // BEGIN LOCAL_SCOPE
 
 Script.include("/~/system/libraries/controllers.js");
 
@@ -91,7 +91,7 @@ function HighlightedEntity(id, entityProperties) {
         },
         lineWidth: 1.0,
         ignoreRayIntersection: true,
-        drawInFront: true
+        drawInFront: false // Arguable. For now, let's not distract with mysterious wires around the scene.
     });
     HighlightedEntity.overlays.push(this);
 }
@@ -416,4 +416,4 @@ Script.scriptEnding.connect(function () {
 });
 
 
-// FIXME: }()); // END LOCAL_SCOPE
+}()); // END LOCAL_SCOPE


### PR DESCRIPTION
Creates a People Action List with which you can click on avatar nodes to select in a list, or click in the list to show the selected avatar nodes. The list shows identifying information and options, that are stable as people move around.

This has been present for a while. This PR just replaces mod.js with pal.js in defaultScripts.