### PR TITLE
Use a higher thread priority for Oculus present

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -165,6 +165,7 @@ public:
 
                         if (newPlugin) {
                             bool hasVsync = true;
+                            QThread::setPriority(newPlugin->getPresentPriority());
                             bool wantVsync = newPlugin->wantVsync();
                             _context->makeCurrent();
 #if defined(Q_OS_WIN)

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <queue>
 
+#include <QtCore/QThread>
 #include <QtCore/QTimer>
 #include <QtGui/QImage>
 
@@ -80,6 +81,7 @@ protected:
 
     void updateCompositeFramebuffer();
 
+    virtual QThread::Priority getPresentPriority() { return QThread::HighPriority; }
     virtual void compositeLayers();
     virtual void compositeScene();
     virtual void compositeOverlay();

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -24,6 +24,8 @@ public:
     virtual QJsonObject getHardwareStats() const;
 
 protected:
+    QThread::Priority getPresentPriority() override { return QThread::TimeCriticalPriority; }
+
     bool internalActivate() override;
     void hmdPresent() override;
     bool isHmdMounted() const override;


### PR DESCRIPTION
Allow OpenGL plugins to specify priority for the present thread.  Use time critical priority for Oculus.

## Testing

- Smoke test.
- There should be no visible change to the application behavior.
 - Frame dropping might be lower in this build compared to master.
- We should not see a significant increase in CPU usage.
- Make sure to test on i5.
- Make sure other CPU related tasks aren't negatively impacted:
    - audio shouldn't stutter
    - content shouldn't load significantly slower