### PR TITLE
Allow for compatibility with old mod.js script after PAL changes

### DIFF
--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -37,7 +37,7 @@ public slots:
     * @param {nodeID} nodeID The node or session ID of the user you want to ignore.
     * @param {bool} enable True for ignored; false for un-ignored.
     */
-    void ignore(const QUuid& nodeID, bool ignoreEnabled);
+    void ignore(const QUuid& nodeID, bool ignoreEnabled = true);
 
     /**jsdoc
     * Gets a bool containing whether you have ignored the given Avatar UUID.
@@ -52,7 +52,7 @@ public slots:
     * @param {nodeID} nodeID The node or session ID of the user you want to mute.
     * @param {bool} enable True for enabled; false for disabled.
     */
-    void personalMute(const QUuid& nodeID, bool muteEnabled);
+    void personalMute(const QUuid& nodeID, bool muteEnabled = true);
 
     /**jsdoc
     * Requests a bool containing whether you have personally muted the given Avatar UUID.


### PR DESCRIPTION
Test plan:
* On a domain with >=2 avatars present, use the PAL to ignore and unignore an avatar. Ensure ignoring and unignoring works as expected.
* On the same domain, use the old mod.js script to ignore the same avatar. Ensure ignoring works as expected.