### PR TITLE
Fix the PAL & Space Bubble interaction

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -68,6 +68,7 @@ AudioMixer::AudioMixer(ReceivedMessage& message) :
     packetReceiver.registerListener(PacketType::KillAvatar, this, "handleKillAvatarPacket");
     packetReceiver.registerListener(PacketType::NodeMuteRequest, this, "handleNodeMuteRequestPacket");
     packetReceiver.registerListener(PacketType::RadiusIgnoreRequest, this, "handleRadiusIgnoreRequestPacket");
+    packetReceiver.registerListener(PacketType::RequestsDomainListData, this, "handleRequestsDomainListDataPacket");
 
     connect(nodeList.data(), &NodeList::nodeKilled, this, &AudioMixer::handleNodeKilled);
 }
@@ -218,6 +219,20 @@ void AudioMixer::handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, 
                 listenerClientData->removeHRTFForStream(sendingNode->getUUID());
             }
         });
+    }
+}
+
+void AudioMixer::handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
+    auto nodeList = DependencyManager::get<NodeList>();
+    nodeList->getOrCreateLinkedData(senderNode);
+
+    if (senderNode->getLinkedData()) {
+        AudioMixerClientData* nodeData = dynamic_cast<AudioMixerClientData*>(senderNode->getLinkedData());
+        if (nodeData != nullptr) {
+            bool isRequesting;
+            message->readPrimitive(&isRequesting);
+            nodeData->setRequestsDomainListData(isRequesting);
+        }
     }
 }
 

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -61,6 +61,7 @@ private slots:
     void handleMuteEnvironmentPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleNegotiateAudioFormat(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void handleNodeKilled(SharedNodePointer killedNode);
+    void handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleKillAvatarPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -92,6 +92,8 @@ public:
     glm::vec3 getPosition() { return getAvatarAudioStream() ? getAvatarAudioStream()->getPosition() : glm::vec3(0); }
     glm::vec3 getAvatarBoundingBoxCorner() { return getAvatarAudioStream() ? getAvatarAudioStream()->getAvatarBoundingBoxCorner() : glm::vec3(0); }
     glm::vec3 getAvatarBoundingBoxScale() { return getAvatarAudioStream() ? getAvatarAudioStream()->getAvatarBoundingBoxScale() : glm::vec3(0); }
+    bool getRequestsDomainListData() { return _requestsDomainListData; }
+    void setRequestsDomainListData(bool requesting) { _requestsDomainListData = requesting; }
 
 signals:
     void injectorStreamFinished(const QUuid& streamIdentifier);
@@ -122,6 +124,7 @@ private:
     bool _shouldFlushEncoder { false };
 
     bool _shouldMuteClient { false };
+    bool _requestsDomainListData { false };
 };
 
 #endif // hifi_AudioMixerClientData_h

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -214,7 +214,7 @@ bool AudioMixerSlave::prepareMix(const SharedNodePointer& node) {
         bool getsAnyIgnored = nodeData->getRequestsDomainListData() && node->getCanKick();
 
         if (otherData
-            && !node->isIgnoringNodeWithID(otherNode->getUUID())
+            && (!node->isIgnoringNodeWithID(otherNode->getUUID()) || (otherData->getRequestsDomainListData() && otherNode->getCanKick()))
             && (!otherNode->isIgnoringNodeWithID(node->getUUID()) || getsAnyIgnored))  {
 
             // check to see if we're ignoring in radius
@@ -256,7 +256,7 @@ bool AudioMixerSlave::prepareMix(const SharedNodePointer& node) {
                 auto otherNodeStream = streamPair.second;
                 bool isSelfWithEcho = ((*otherNode == *node) && (otherNodeStream->shouldLoopbackForNode()));
                 // Add all audio streams that should be added to the mix
-                if (isSelfWithEcho || (!isSelfWithEcho && !insideIgnoreRadius && getsAnyIgnored)) {
+                if (isSelfWithEcho || (!isSelfWithEcho && !insideIgnoreRadius)) {
                     addStreamToMix(*nodeData, otherNode->getUUID(), *nodeAudioStream, *otherNodeStream);
                 }
             }

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -326,7 +326,7 @@ void AvatarMixer::broadcastAvatarData() {
                             // Perform the collision check between the two bounding boxes
                             if (nodeBox.touches(otherNodeBox)) {
                                 nodeData->ignoreOther(node, otherNode);
-                                return getsIgnoredByMe || getsAnyIgnored;
+                                return getsAnyIgnored;
                             }
                         }
                         // Not close enough to ignore

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -299,7 +299,7 @@ void AvatarMixer::broadcastAvatarData() {
                         AvatarMixerClientData* otherData = reinterpret_cast<AvatarMixerClientData*>(otherNode->getLinkedData());
                         AvatarMixerClientData* nodeData = reinterpret_cast<AvatarMixerClientData*>(node->getLinkedData());
                         // Check to see if the space bubble is enabled
-                        if ((node->isIgnoreRadiusEnabled() && !getsIgnoredByMe) || (otherNode->isIgnoreRadiusEnabled() && !getsAnyIgnored)) {
+                        if (node->isIgnoreRadiusEnabled() || otherNode->isIgnoreRadiusEnabled()) {
                             // Define the minimum bubble size
                             static const glm::vec3 minBubbleSize = glm::vec3(0.3f, 1.3f, 0.3f);
                             // Define the scale of the box for the current node
@@ -326,11 +326,11 @@ void AvatarMixer::broadcastAvatarData() {
                             // Perform the collision check between the two bounding boxes
                             if (nodeBox.touches(otherNodeBox)) {
                                 nodeData->ignoreOther(node, otherNode);
-                                return false;
+                                return getsIgnoredByMe || getsAnyIgnored;
                             }
                         }
                         // Not close enough to ignore
-                        nodeData->removeFromRadiusIgnoringSet(otherNode->getUUID());
+                        nodeData->removeFromRadiusIgnoringSet(node, otherNode->getUUID());
                         return true;
                     }
                 },

--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -57,6 +57,15 @@ void AvatarMixerClientData::ignoreOther(SharedNodePointer self, SharedNodePointe
     }
 }
 
+void AvatarMixerClientData::removeFromRadiusIgnoringSet(SharedNodePointer self, const QUuid& other) {
+    if (isRadiusIgnoring(other)) {
+        _radiusIgnoredOthers.erase(other);
+        auto exitingSpaceBubblePacket = NLPacket::create(PacketType::ExitingSpaceBubble, NUM_BYTES_RFC4122_UUID);
+        exitingSpaceBubblePacket->write(other.toRfc4122());
+        DependencyManager::get<NodeList>()->sendUnreliablePacket(*exitingSpaceBubblePacket, *self);
+    }
+}
+
 void AvatarMixerClientData::readViewFrustumPacket(const QByteArray& message) {
     _currentViewFrustum.fromByteArray(message);
 }

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -89,7 +89,7 @@ public:
     glm::vec3 getGlobalBoundingBoxCorner() { return _avatar ? _avatar->getGlobalBoundingBoxCorner() : glm::vec3(0); }
     bool isRadiusIgnoring(const QUuid& other) { return _radiusIgnoredOthers.find(other) != _radiusIgnoredOthers.end(); }
     void addToRadiusIgnoringSet(const QUuid& other) { _radiusIgnoredOthers.insert(other); }
-    void removeFromRadiusIgnoringSet(const QUuid& other) { _radiusIgnoredOthers.erase(other); }
+    void removeFromRadiusIgnoringSet(SharedNodePointer self, const QUuid& other);
     void ignoreOther(SharedNodePointer self, SharedNodePointer other);
 
     void readViewFrustumPacket(const QByteArray& message);

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1339,7 +1339,9 @@ void Avatar::addToScene(AvatarSharedPointer myHandle) {
     render::ScenePointer scene = qApp->getMain3DScene();
     if (scene) {
         render::PendingChanges pendingChanges;
-        if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars() && !DependencyManager::get<NodeList>()->isIgnoringNode(getSessionUUID())) {
+        if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()
+            && !DependencyManager::get<NodeList>()->isIgnoringNode(getSessionUUID())
+            && !DependencyManager::get<NodeList>()->isRadiusIgnoringNode(getSessionUUID())) {
             addToScene(myHandle, scene, pendingChanges);
         }
         scene->enqueuePendingChanges(pendingChanges);

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1339,9 +1339,10 @@ void Avatar::addToScene(AvatarSharedPointer myHandle) {
     render::ScenePointer scene = qApp->getMain3DScene();
     if (scene) {
         render::PendingChanges pendingChanges;
+        auto nodelist = DependencyManager::get<NodeList>();
         if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars()
-            && !DependencyManager::get<NodeList>()->isIgnoringNode(getSessionUUID())
-            && !DependencyManager::get<NodeList>()->isRadiusIgnoringNode(getSessionUUID())) {
+            && !nodelist->isIgnoringNode(getSessionUUID())
+            && !nodelist->isRadiusIgnoringNode(getSessionUUID())) {
             addToScene(myHandle, scene, pendingChanges);
         }
         scene->enqueuePendingChanges(pendingChanges);

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -257,6 +257,8 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
 
     if (removalReason == KillAvatarReason::TheirAvatarEnteredYourBubble) {
         emit DependencyManager::get<UsersScriptingInterface>()->enteredIgnoreRadius();
+    }
+    if (removalReason == KillAvatarReason::TheirAvatarEnteredYourBubble || removalReason == YourAvatarEnteredTheirBubble) {
         DependencyManager::get<NodeList>()->radiusIgnoreNodeBySessionID(avatar->getSessionUUID(), true);
     }
     _avatarFades.push_back(removedAvatar);

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -79,6 +79,7 @@ AvatarManager::AvatarManager(QObject* parent) :
     packetReceiver.registerListener(PacketType::BulkAvatarData, this, "processAvatarDataPacket");
     packetReceiver.registerListener(PacketType::KillAvatar, this, "processKillAvatar");
     packetReceiver.registerListener(PacketType::AvatarIdentity, this, "processAvatarIdentityPacket");
+    packetReceiver.registerListener(PacketType::ExitingSpaceBubble, this, "processExitingSpaceBubble");
 
     // when we hear that the user has ignored an avatar by session UUID
     // immediately remove that avatar instead of waiting for the absence of packets from avatar mixer
@@ -256,6 +257,7 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
 
     if (removalReason == KillAvatarReason::TheirAvatarEnteredYourBubble) {
         emit DependencyManager::get<UsersScriptingInterface>()->enteredIgnoreRadius();
+        DependencyManager::get<NodeList>()->radiusIgnoreNodeBySessionID(avatar->getSessionUUID(), true);
     }
     _avatarFades.push_back(removedAvatar);
 }

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -161,6 +161,13 @@ void AvatarHashMap::processKillAvatar(QSharedPointer<ReceivedMessage> message, S
     removeAvatar(sessionUUID, reason);
 }
 
+void AvatarHashMap::processExitingSpaceBubble(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) {
+    // read the node id
+    QUuid sessionUUID = QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID));
+    auto nodeList = DependencyManager::get<NodeList>();
+    nodeList->radiusIgnoreNodeBySessionID(sessionUUID, false);
+}
+
 void AvatarHashMap::removeAvatar(const QUuid& sessionUUID, KillAvatarReason removalReason) {
     QWriteLocker locker(&_hashLock);
 

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -57,6 +57,7 @@ private slots:
     void processAvatarDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void processKillAvatar(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
+    void processExitingSpaceBubble(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
 
 protected:
     AvatarHashMap();

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -1040,12 +1040,12 @@ void NodeList::processUsernameFromIDReply(QSharedPointer<ReceivedMessage> messag
 }
 
 void NodeList::setRequestsDomainListData(bool isRequesting) {
-    // Tell the avatar mixer whether I want to receive any additional data to which I might be entitled
+    // Tell the avatar mixer and audio mixer whether I want to receive any additional data to which I might be entitled
     if (_requestsDomainListData == isRequesting) {
         return;
     }
     eachMatchingNode([](const SharedNodePointer& node)->bool {
-        return node->getType() == NodeType::AvatarMixer;
+        return (node->getType() == NodeType::AudioMixer || node->getType() == NodeType::AvatarMixer);
     }, [this, isRequesting](const SharedNodePointer& destinationNode) {
         auto packet = NLPacket::create(PacketType::RequestsDomainListData, sizeof(bool), true); // reliable
         packet->writePrimitive(isRequesting);

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -76,6 +76,8 @@ public:
     void toggleIgnoreRadius() { ignoreNodesInRadius(!getIgnoreRadiusEnabled()); }
     void enableIgnoreRadius() { ignoreNodesInRadius(true); }
     void disableIgnoreRadius() { ignoreNodesInRadius(false); }
+    void radiusIgnoreNodeBySessionID(const QUuid& nodeID, bool radiusIgnoreEnabled);
+    bool isRadiusIgnoringNode(const QUuid& other) const;
     void ignoreNodeBySessionID(const QUuid& nodeID, bool ignoreEnabled);
     bool isIgnoringNode(const QUuid& nodeID) const;
     void personalMuteNodeBySessionID(const QUuid& nodeID, bool muteEnabled);
@@ -159,6 +161,8 @@ private:
     QTimer _keepAlivePingTimer;
     bool _requestsDomainListData;
 
+    mutable QReadWriteLock _radiusIgnoredSetLock;
+    tbb::concurrent_unordered_set<QUuid, UUIDHasher> _radiusIgnoredNodeIDs;
     mutable QReadWriteLock _ignoredSetLock;
     tbb::concurrent_unordered_set<QUuid, UUIDHasher> _ignoredNodeIDs;
     mutable QReadWriteLock _personalMutedSetLock;

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -105,7 +105,8 @@ public:
         UsernameFromIDReply,
         ViewFrustum,
         RequestsDomainListData,
-        LAST_PACKET_TYPE = RequestsDomainListData
+        ExitingSpaceBubble,
+        LAST_PACKET_TYPE = ExitingSpaceBubble //FIXME
     };
 };
 

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -106,7 +106,7 @@ public:
         ViewFrustum,
         RequestsDomainListData,
         ExitingSpaceBubble,
-        LAST_PACKET_TYPE = ExitingSpaceBubble //FIXME
+        LAST_PACKET_TYPE = ExitingSpaceBubble
     };
 };
 


### PR DESCRIPTION
[Trello Card](https://trello.com/c/v3Abvhlu/43-bug-when-pal-open-bubble-doesn-t-work-correctly)

Test Plan:
* In a domain with 2+ avatars present, perform a space bubble sanity check without the PAL open to see if it works as expected.
* In the same domain, as the admin, enable the PAL and ensure you can see and hear all avatars (even if they've ignored you).
* In the same domain, as the admin, enable the space bubble and the PAL, then walk into another avatar. That avatar should disappear, but their sphere overlay should remain. You shouldn't be able to hear them.
* In the same domain, as the non-admin, enable the space bubble and the PAL, then walk into another avatar. That avatar should disappear, *and* their sphere overlay should disappear. You shouldn't be able to hear them.
* In the same domain, as the non-admin, mute the admin. The admin should not be able to hear the non-admin, and vice versa. As the admin, open the PAL. The admin and non-admin should now be able to speak to and hear each other.

More detailed test plan pending a write-up from @howard-stearns.