### PR TITLE
Log dialog doesn't float on top

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6144,7 +6144,7 @@ void Application::loadScriptURLDialog() const {
 
 void Application::toggleLogDialog() {
     if (! _logDialog) {
-        _logDialog = new LogDialog(_glWidget, getLogger());
+        _logDialog = new LogDialog(nullptr, getLogger());
     }
 
     if (_logDialog->isVisible()) {

--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -44,7 +44,7 @@ const QString HIGHLIGHT_COLOR = "#3366CC";
 int qTextCursorMeta = qRegisterMetaType<QTextCursor>("QTextCursor");
 int qTextBlockMeta = qRegisterMetaType<QTextBlock>("QTextBlock");
 
-LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : QDialog(parent, Qt::Dialog) {
+LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : QDialog(parent, Qt::Window) {
 
     _logger = logger;
     setWindowTitle("Log");


### PR DESCRIPTION
Test Plan:
- Check Log dialog doesn't float on top anymore
- Open/Close log dialog several times to make sure everything works as expected