### PR TITLE
Adding tracking of Oculus renders, submits, and frames that are over budget

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -84,6 +84,18 @@ Item {
                         visible: root.appdropped > 0;
                     }
                     StatText {
+                        text: "Long Render Count: " + root.longrenders;
+                        visible: root.longrenders > 0;
+                    }
+                    StatText {
+                        text: "Long Submit Count: " + root.longsubmits;
+                        visible: root.longsubmits > 0;
+                    }
+                    StatText {
+                        text: "Long Frame Count: " + root.longframes;
+                        visible: root.longframes > 0;
+                    }
+                    StatText {
                         text: "Packets In/Out: " + root.packetInCount + "/" + root.packetOutCount
                     }
                     StatText {

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -127,12 +127,18 @@ void Stats::updateStats(bool force) {
         auto displayPlugin = qApp->getActiveDisplayPlugin();
         auto stats = displayPlugin->getHardwareStats();
         STAT_UPDATE(appdropped, stats["app_dropped_frame_count"].toInt());
+        STAT_UPDATE(longrenders, stats["long_render_count"].toInt());
+        STAT_UPDATE(longsubmits, stats["long_submit_count"].toInt());
+        STAT_UPDATE(longframes, stats["long_frame_count"].toInt());
         STAT_UPDATE(renderrate, displayPlugin->renderRate());
         STAT_UPDATE(presentrate, displayPlugin->presentRate());
         STAT_UPDATE(presentnewrate, displayPlugin->newFramePresentRate());
         STAT_UPDATE(presentdroprate, displayPlugin->droppedFrameRate());
         STAT_UPDATE(stutterrate, displayPlugin->stutterRate());
     } else {
+        STAT_UPDATE(appdropped, -1);
+        STAT_UPDATE(longrenders, -1);
+        STAT_UPDATE(longsubmits, -1);
         STAT_UPDATE(presentrate, -1);
         STAT_UPDATE(presentnewrate, -1);
         STAT_UPDATE(presentdroprate, -1);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -40,6 +40,9 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(float, stutterrate, 0)
 
     STATS_PROPERTY(int, appdropped, 0)
+    STATS_PROPERTY(int, longsubmits, 0)
+    STATS_PROPERTY(int, longrenders, 0)
+    STATS_PROPERTY(int, longframes, 0)
 
     STATS_PROPERTY(float, presentnewrate, 0)
     STATS_PROPERTY(float, presentdroprate, 0)
@@ -137,6 +140,9 @@ public slots:
     void forceUpdateStats() { updateStats(true); }
 
 signals:
+    void longsubmitsChanged();
+    void longrendersChanged();
+    void longframesChanged();
     void appdroppedChanged();
     void framerateChanged();
     void expandedChanged();

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -41,5 +41,8 @@ private:
 
     std::atomic_int _compositorDroppedFrames;
     std::atomic_int _appDroppedFrames;
+    std::atomic_int _longSubmits;
+    std::atomic_int _longRenders;
+    std::atomic_int _longFrames;
 };
 


### PR DESCRIPTION
This adds a few new stats to the Oculus HMD display plugin.  It tracks the interval from one `ovr_Submit` call to the next, as well as the time taken by the `ovr_Submit` call itself.  If either is over a budget of 11 ms, it increments tracked value (either 'long render' or 'long submit') shown in the stats display.  If the combination of the two are over 15 ms it increments a 'long frame' stat.

## Testing

- Smoke test.
- There should be no visible change to the application behavior other than the new stats when in Oculus mode

