### PR TITLE
Change default scripts to include clara

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -18,7 +18,7 @@ var DEFAULT_SCRIPTS = [
     "system/mute.js",
     "system/goto.js",
     "system/hmd.js",
-    "system/marketplaces/marketplace.js",
+    "system/marketplaces/marketplaces.js",
     "system/edit.js",
     "system/pal.js", //"system/mod.js", // older UX, if you prefer
     "system/selectAudioDevice.js",


### PR DESCRIPTION
Change default scripts to include clara. This enabled the clara marketplace to come up by default. 

Test Plan:

Make sure that default scripts works by testing that the marketplace still comes up . 