### PR TITLE
Add dependency to Ubuntu documentation

### DIFF
--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -3,4 +3,4 @@ Please read the [general build guide](BUILD.md) for information on dependencies 
 ###Qt5 Dependencies
 Should you choose not to install Qt5 via a package manager that handles dependencies for you, you may be missing some Qt5 dependencies. On Ubuntu, for example, the following additional packages are required:
 
-    libasound2 libxmu-dev libxi-dev freeglut3-dev libasound2-dev libjack0 libjack-dev libxrandr-dev libudev-dev
+    libasound2 libxmu-dev libxi-dev freeglut3-dev libasound2-dev libjack0 libjack-dev libxrandr-dev libudev-dev libssl-dev


### PR DESCRIPTION
Fix this:
$ cmake .. -DQT_CMAKE_PREFIX_PATH=/usr/local/Qt5.6.1/5.6/gcc_64/lib/cmake
-- Performing Test COMPILER_SUPPORTS_CXX11
-- Performing Test COMPILER_SUPPORTS_CXX11 - Success
-- Performing Test COMPILER_SUPPORTS_CXX0X
-- Performing Test COMPILER_SUPPORTS_CXX0X - Success
-- The BUILD_BRANCH variable is:
-- The BRANCH environment variable is:
-- The RELEASE_TYPE variable is:
-- The BUILD_GLOBAL_SERVICES variable is: DEVELOPMENT
-- The USE_STABLE_GLOBAL_SERVICES variable is: 0
-- Found GLM: /home/jmferrerm/trabajo/SL/hifi/build/ext/makefiles/glm/project/include
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.8")
CMake Error at /usr/share/cmake-3.5/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
  Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_LIBRARIES
  OPENSSL_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.5/Modules/FindPackageHandleStandardArgs.cmake:388 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindOpenSSL.cmake:217 (find_package_handle_standard_args)
  libraries/networking/CMakeLists.txt:15 (find_package)

-- Configuring incomplete, errors occurred!
See also "/home/jmferrerm/trabajo/SL/hifi/build/CMakeFiles/CMakeOutput.log".