### PR TITLE
Modified space bubble entry effect

### DIFF
--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -41,7 +41,7 @@
     var updateConnected = false;
 
     const BUBBLE_VISIBLE_DURATION_MS = 3000;
-    const BUBBLE_RAISE_ANIMATION_DURATION_MS = 750;
+    const BUBBLE_RAISE_ANIMATION_DURATION_MS = 500;
     const BUBBLE_HUD_ICON_FLASH_INTERVAL_MS = 500;
 
     var ASSETS_PATH = Script.resolvePath("assets");


### PR DESCRIPTION
Using this PR, avatars that enter your bubble will freeze for a moment before fading. This is to potentially give users a better idea of what's happening when they enter your bubble.