### PR TITLE
Reduce min threads in threadpool to 1

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -197,7 +197,7 @@ static const int MAX_CONCURRENT_RESOURCE_DOWNLOADS = 16;
 // For processing on QThreadPool, we target a number of threads after reserving some 
 // based on how many are being consumed by the application and the display plugin.  However,
 // we will never drop below the 'min' value
-static const int MIN_PROCESSING_THREAD_POOL_SIZE = 2;
+static const int MIN_PROCESSING_THREAD_POOL_SIZE = 1;
 
 static const QString SNAPSHOT_EXTENSION  = ".jpg";
 static const QString SVO_EXTENSION  = ".svo";


### PR DESCRIPTION
This reduces the minimum number of threads in the global threadpool to 1.  This will impact i5 systems by increasing the amount of time required to load a scene, but reducing the amount of stutter in rendering the scene while loading.  

This also includes a new macro of `PROFILE_COUNTER_IF_CHANGED` that keeps a small static variable so that the number of trace events is reduced.  