### PR TITLE
Ability to disable yellow highlight around Web Overlays

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4076,9 +4076,11 @@ void Application::setKeyboardFocusOverlay(unsigned int overlayID) {
             }
             _lastAcceptedKeyPress = usecTimestampNow();
 
-            auto size = overlay->getSize() * FOCUS_HIGHLIGHT_EXPANSION_FACTOR;
-            const float OVERLAY_DEPTH = 0.0105f;
-            setKeyboardFocusHighlight(overlay->getPosition(), overlay->getRotation(), glm::vec3(size.x, size.y, OVERLAY_DEPTH));
+            if (overlay->getProperty("showKeyboardFocusHighlight").toBool()) {
+                auto size = overlay->getSize() * FOCUS_HIGHLIGHT_EXPANSION_FACTOR;
+                const float OVERLAY_DEPTH = 0.0105f;
+                setKeyboardFocusHighlight(overlay->getPosition(), overlay->getRotation(), glm::vec3(size.x, size.y, OVERLAY_DEPTH));
+            }
         }
     }
 }

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -359,7 +359,7 @@ void Web3DOverlay::setProperties(const QVariantMap& properties) {
 
     auto showKeyboardFocusHighlight = properties["showKeyboardFocusHighlight"];
     if (showKeyboardFocusHighlight.isValid()) {
-        _showKeyboardFocusHighlight = showKeyboardFocusHighlight.toBool;
+        _showKeyboardFocusHighlight = showKeyboardFocusHighlight.toBool();
     }
 }
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -50,7 +50,8 @@ Web3DOverlay::Web3DOverlay(const Web3DOverlay* Web3DOverlay) :
     _url(Web3DOverlay->_url),
     _scriptURL(Web3DOverlay->_scriptURL),
     _dpi(Web3DOverlay->_dpi),
-    _resolution(Web3DOverlay->_resolution)
+    _resolution(Web3DOverlay->_resolution),
+    _showKeyboardFocusHighlight(Web3DOverlay->_showKeyboardFocusHighlight)
 {
     _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -355,6 +355,11 @@ void Web3DOverlay::setProperties(const QVariantMap& properties) {
     if (dpi.isValid()) {
         _dpi = dpi.toFloat();
     }
+
+    auto showKeyboardFocusHighlight = properties["showKeyboardFocusHighlight"];
+    if (showKeyboardFocusHighlight.isValid()) {
+        _showKeyboardFocusHighlight = showKeyboardFocusHighlight.toBool;
+    }
 }
 
 QVariant Web3DOverlay::getProperty(const QString& property) {
@@ -369,6 +374,9 @@ QVariant Web3DOverlay::getProperty(const QString& property) {
     }
     if (property == "dpi") {
         return _dpi;
+    }
+    if (property == "showKeyboardFocusHighlight") {
+        return _showKeyboardFocusHighlight;
     }
     return Billboard3DOverlay::getProperty(property);
 }

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -68,6 +68,7 @@ private:
     float _dpi;
     vec2 _resolution{ 640, 480 };
     int _geometryId { 0 };
+    bool _showKeyboardFocusHighlight{ true };
 
     bool _pressed{ false };
     QTouchDevice _touchDevice;

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -91,7 +91,7 @@ WebTablet = function (url, width, dpi, hand, clientOnly) {
         alpha: 1.0,
         parentID: this.tabletEntityID,
         parentJointIndex: -1,
-        showKeyboardFocusHighlight: false
+        showKeyboardFocusHighlight: true
     });
 
     var HOME_BUTTON_Y_OFFSET = -0.25;

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -90,7 +90,8 @@ WebTablet = function (url, width, dpi, hand, clientOnly) {
         color: { red: 255, green: 255, blue: 255 },
         alpha: 1.0,
         parentID: this.tabletEntityID,
-        parentJointIndex: -1
+        parentJointIndex: -1,
+        showKeyboardFocusHighlight: false
     });
 
     var HOME_BUTTON_Y_OFFSET = -0.25;

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -91,7 +91,7 @@ WebTablet = function (url, width, dpi, hand, clientOnly) {
         alpha: 1.0,
         parentID: this.tabletEntityID,
         parentJointIndex: -1,
-        showKeyboardFocusHighlight: true
+        showKeyboardFocusHighlight: false
     });
 
     var HOME_BUTTON_Y_OFFSET = -0.25;


### PR DESCRIPTION
This PR contains my work on the ability to disable yellow highlight around Web Overlays. Currently, the yellow highlight indicates keyboard focus on all Web Overlays. It lets user know which overlay they are typing onto. However, the yellow highlight effect is not very desirable when it is shown around the tablet. My work here allows for a special case to turn the yellow highlight off, while keeping keyboard focus.

Test Plan:
1) Download and install build from this PR.
2) Open JS console and run the following:
        
`var front = Vec3.normalize(Quat.getFront(MyAvatar.orientation));
 var right = Vec3.normalize(Quat.getRight(MyAvatar.orientation));
 var pos = Vec3.sum(front, MyAvatar.position);
 var googleOverlayID = Overlays.addOverlay("web3d", {url:"http://google.com", position: pos});
 pos = Vec3.sum(right, pos);
 var bingOverlayID = Overlays.addOverlay("web3d", {url:"http://bing.com", position: pos});
`
This creates two web overlays in front of you with regular yellow highlight turn on. Switch between them to confirm keyboard input works correctly.

3) Now, turn one of the web overlay's highlight off by running the following line:
`Overlays.editOverlay(googleOverlayID, {showKeyboardFocusHighlight: false});`

4) Test and confirm the Google overlay now has no yellow highlight, but you can still switch between overlays and type with keyboard in them.

e.g.
![image](https://cloud.githubusercontent.com/assets/2405697/21780761/b1aac84c-d661-11e6-8dee-f8865831dd5f.png)


Next Steps:
Set the "showKeyboardFocusHighlight" property to false when initializing tablet. 