### PR TITLE
Add profiling in Context batch execution and shortcuts for trace names

### DIFF
--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -81,6 +81,7 @@ FramePointer Context::endFrame() {
 }
 
 void Context::executeBatch(Batch& batch) const {
+    PROFILE_RANGE(render_gpu, __FUNCTION__);
     batch.flush();
     _backend->render(batch);
 }
@@ -94,6 +95,8 @@ void Context::consumeFrameUpdates(const FramePointer& frame) const {
 }
 
 void Context::executeFrame(const FramePointer& frame) const {
+    PROFILE_RANGE(render_gpu, __FUNCTION__);
+
     // Grab the stats at the around the frame and delta to have a consistent sampling
     ContextStats beginStats;
     getStats(beginStats);

--- a/libraries/shared/src/Trace.cpp
+++ b/libraries/shared/src/Trace.cpp
@@ -16,6 +16,7 @@
 #include <QtCore/QFileInfo>
 #include <QtCore/QDir>
 #include <QtCore/QStandardPaths>
+#include <QtCore/QDateTime>
 
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
@@ -106,6 +107,12 @@ void TraceEvent::writeJson(QTextStream& out) const {
 void Tracer::serialize(const QString& originalPath) {
 
     QString path = originalPath;
+
+    // Filter for specific tokens potentially present in the path:
+    auto now = QDateTime::currentDateTime();
+
+    path = path.replace("{DATE}", now.date().toString("yyyyMMdd"));
+    path = path.replace("{TIME}", now.time().toString("HHmm"));
 
     // If the filename is relative, turn it into an absolute path relative to the document directory.
     QFileInfo originalFileInfo(path);


### PR DESCRIPTION
This PR simply add new profiling around the gpu::Batch execution 
And aliases to easily add the current date and time to the trace name

## Test Plan
Smoke test, nothing should change
To Test the new tracing feature, run Interface in test mode with the script [https://raw.githubusercontent.com/highfidelity/hifi_tests/master/scripts/benchLocalhost.js](url)
A trace file named "testScriptTrace_{DATE}_{TIME}.json.gz" should be created in your Username/Document/traces folder where {DATE} and {TIME} are replaced by the current date and time of the day