### PR TITLE
Tablet Audio Bar Improvements

### DIFF
--- a/interface/resources/qml/hifi/tablet/Tablet.qml
+++ b/interface/resources/qml/hifi/tablet/Tablet.qml
@@ -127,11 +127,19 @@ Item {
                     gradient: Gradient {
                         GradientStop {
                             position: 0
-                            color: "#00b8ff"
+                            color: "#2c8e72"
+                        }
+                        GradientStop {
+                            position: 0.9
+                            color: "#1fc6a6"
+                        }
+                        GradientStop {
+                            position: 0.91
+                            color: "#ea4c5f"
                         }
                         GradientStop {
                             position: 1
-                            color: "#ff2d73"
+                            color: "#ea4c5f"
                         }
                     }
                 }

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -160,7 +160,7 @@ Menu::Menu() {
         audioIO.data(), SLOT(toggleMute()));
 
     // Audio > Show Level Meter
-    addCheckableActionToQMenuAndActionHash(audioMenu, MenuOption::AudioTools, 0, true);
+    addCheckableActionToQMenuAndActionHash(audioMenu, MenuOption::AudioTools, 0, false);
 
 
     // Avatar menu ----------------------------------


### PR DESCRIPTION
Two improvements on tablet audio bar:

1) Further reduce persistent HUD UI by getting rid of the old mic level meter on screen. The mic level element is now default to hidden. You may still bring it back by checking Audio > Show Level Meter on the windows bar.

2) Color scheme on tablet audio bar. We iterated the design based on feedback from last time. It is now a dark green to light green gradient with a red part for warning at the end. It looks more like a classic vu meter and the red is brighter to notify users that they may be clipping audio.

![audiobarscreenshot](https://cloud.githubusercontent.com/assets/2405697/21822313/991f3fc2-d72b-11e6-87cc-4b4bf37df0fe.PNG)
![audiobarscreenshot2](https://cloud.githubusercontent.com/assets/2405697/21822312/991ebed0-d72b-11e6-9ee0-8feccac4ce7d.PNG)

