### PR TITLE
Eagerly cache QML surfaces for Web3D overlays

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -89,6 +89,7 @@
 #include <OctalCode.h>
 #include <OctreeSceneStats.h>
 #include <OffscreenUi.h>
+#include <gl/OffscreenQmlSurfaceCache.h>
 #include <gl/OffscreenGLCanvas.h>
 #include <PathUtils.h>
 #include <PerfStat.h>
@@ -512,6 +513,7 @@ bool setupEssentials(int& argc, char** argv) {
     DependencyManager::set<InterfaceParentFinder>();
     DependencyManager::set<EntityTreeRenderer>(true, qApp, qApp);
     DependencyManager::set<CompositorHelper>();
+    DependencyManager::set<OffscreenQmlSurfaceCache>();
     return previousSessionCrashed;
 }
 
@@ -2003,6 +2005,10 @@ void Application::initializeUi() {
             showCursor(compositorHelper->getAllowMouseCapture() ? Qt::BlankCursor : Qt::ArrowCursor);
         }
     });
+
+    // Pre-create a couple of Web3D overlays to speed up tablet UI
+    auto offscreenSurfaceCache = DependencyManager::get<OffscreenQmlSurfaceCache>();
+    offscreenSurfaceCache->reserve(Web3DOverlay::QML, 2);
 }
 
 void Application::paintGL() {

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -28,14 +28,15 @@
 #include <AbstractViewStateInterface.h>
 
 #include <gl/OffscreenQmlSurface.h>
+#include <gl/OffscreenQmlSurfaceCache.h>
 
 static const float DPI = 30.47f;
 static const float INCHES_TO_METERS = 1.0f / 39.3701f;
 static const float METERS_TO_INCHES = 39.3701f;
 static const float OPAQUE_ALPHA_THRESHOLD = 0.99f;
 
-QString const Web3DOverlay::TYPE = "web3d";
-
+const QString Web3DOverlay::TYPE = "web3d";
+const QString Web3DOverlay::QML = "Web3DOverlay.qml";
 Web3DOverlay::Web3DOverlay() : _dpi(DPI) { 
     _touchDevice.setCapabilities(QTouchDevice::Position);
     _touchDevice.setType(QTouchDevice::TouchScreen);
@@ -80,8 +81,9 @@ Web3DOverlay::~Web3DOverlay() {
         // is no longer valid
         auto webSurface = _webSurface;
         AbstractViewStateInterface::instance()->postLambdaEvent([webSurface] {
-            webSurface->deleteLater();
+            DependencyManager::get<OffscreenQmlSurfaceCache>()->release(QML, webSurface);
         });
+        _webSurface.reset();
     }
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (geometryCache) {
@@ -109,23 +111,14 @@ void Web3DOverlay::render(RenderArgs* args) {
     QOpenGLContext * currentContext = QOpenGLContext::currentContext();
     QSurface * currentSurface = currentContext->surface();
     if (!_webSurface) {
-        auto deleter = [](OffscreenQmlSurface* webSurface) {
-            AbstractViewStateInterface::instance()->postLambdaEvent([webSurface] {
-                webSurface->deleteLater();
-            });
-        };
-        _webSurface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface(), deleter);
+        _webSurface = DependencyManager::get<OffscreenQmlSurfaceCache>()->acquire(QML);
+        _webSurface->setMaxFps(10);
         // FIXME, the max FPS could be better managed by being dynamic (based on the number of current surfaces
         // and the current rendering load)
-        _webSurface->setMaxFps(10);
-        _webSurface->create(currentContext);
-        _webSurface->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "/qml/"));
-        _webSurface->load("Web3DOverlay.qml");
         _webSurface->resume();
+        _webSurface->resize(QSize(_resolution.x, _resolution.y));
         _webSurface->getRootItem()->setProperty("url", _url);
         _webSurface->getRootItem()->setProperty("scriptURL", _scriptURL);
-        _webSurface->getRootContext()->setContextProperty("ApplicationInterface", qApp);
-        _webSurface->resize(QSize(_resolution.x, _resolution.y));
         currentContext->makeCurrent(currentSurface);
 
         auto forwardPointerEvent = [=](unsigned int overlayID, const PointerEvent& event) {

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -21,6 +21,7 @@ class Web3DOverlay : public Billboard3DOverlay {
     Q_OBJECT
 
 public:
+    static const QString QML;
     static QString const TYPE;
     virtual QString getType() const override { return TYPE; }
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -114,10 +114,10 @@ protected:
     bool _vsyncEnabled { true };
     QThread* _presentThread{ nullptr };
     std::queue<gpu::FramePointer> _newFrameQueue;
-    RateCounter<> _droppedFrameRate;
-    RateCounter<> _newFrameRate;
-    RateCounter<> _presentRate;
-    RateCounter<> _renderRate;
+    RateCounter<100> _droppedFrameRate;
+    RateCounter<100> _newFrameRate;
+    RateCounter<100> _presentRate;
+    RateCounter<100> _renderRate;
 
     gpu::FramePointer _currentFrame;
     gpu::Frame* _lastFrame { nullptr };

--- a/libraries/gl/src/gl/OffscreenQmlSurfaceCache.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurfaceCache.cpp
@@ -1,0 +1,57 @@
+//
+//  Created by Bradley Austin Davis on 2017-01-11
+//  Copyright 2013-2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#include "OffscreenQmlSurfaceCache.h"
+
+#include <QtGui/QOpenGLContext>
+#include <QtQml/QQmlContext>
+
+#include <PathUtils.h>
+#include "OffscreenQmlSurface.h"
+
+OffscreenQmlSurfaceCache::OffscreenQmlSurfaceCache() {
+}
+
+OffscreenQmlSurfaceCache::~OffscreenQmlSurfaceCache() {
+    _cache.clear();
+}
+
+QSharedPointer<OffscreenQmlSurface> OffscreenQmlSurfaceCache::acquire(const QString& rootSource) {
+    auto& list = _cache[rootSource];
+    if (list.empty()) {
+        list.push_back(buildSurface(rootSource));
+    }
+    auto result = list.front();
+    list.pop_front();
+    return result;
+}
+
+void OffscreenQmlSurfaceCache::reserve(const QString& rootSource, int count) {
+    auto& list = _cache[rootSource];
+    while (list.size() < count) {
+        list.push_back(buildSurface(rootSource));
+    }
+}
+
+void OffscreenQmlSurfaceCache::release(const QString& rootSource, const QSharedPointer<OffscreenQmlSurface>& surface) {
+    surface->pause();
+    _cache[rootSource].push_back(surface);
+}
+
+QSharedPointer<OffscreenQmlSurface> OffscreenQmlSurfaceCache::buildSurface(const QString& rootSource) {
+    auto surface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface());
+    QOpenGLContext* currentContext = QOpenGLContext::currentContext();
+    QSurface* currentSurface = currentContext->surface();
+    surface->create(currentContext);
+    surface->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "/qml/"));
+    surface->load(rootSource);
+    surface->getRootContext()->setContextProperty("ApplicationInterface", qApp);
+    surface->resize(QSize(100, 100));
+    currentContext->makeCurrent(currentSurface);
+    return surface;
+}
+

--- a/libraries/gl/src/gl/OffscreenQmlSurfaceCache.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurfaceCache.h
@@ -1,0 +1,34 @@
+//
+//  Created by Bradley Austin Davis on 2017-01-11
+//  Copyright 2013-2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#pragma once
+#ifndef hifi_OffscreenQmlSurfaceCache_h
+#define hifi_OffscreenQmlSurfaceCahce_h
+
+#include "DependencyManager.h"
+
+#include <QtCore/QSharedPointer>
+
+class OffscreenQmlSurface;
+
+class OffscreenQmlSurfaceCache : public Dependency {
+    SINGLETON_DEPENDENCY
+
+public:
+    OffscreenQmlSurfaceCache();
+    virtual ~OffscreenQmlSurfaceCache();
+
+    QSharedPointer<OffscreenQmlSurface> acquire(const QString& rootSource);
+    void release(const QString& rootSource, const QSharedPointer<OffscreenQmlSurface>& surface);
+    void reserve(const QString& rootSource, int count = 1);
+
+private:
+    QSharedPointer<OffscreenQmlSurface> buildSurface(const QString& rootSource);
+    QHash<QString, QList<QSharedPointer<OffscreenQmlSurface>>> _cache;
+};
+
+#endif

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -88,8 +88,6 @@ SendQueue::SendQueue(Socket* socket, HifiSockAddr dest) :
     _socket(socket),
     _destination(dest)
 {
-    PROFILE_ASYNC_BEGIN(network, "SendQueue", _destination.toString());
-
     // setup psuedo-random number generation for all instances of SendQueue
     static std::random_device rd;
     static std::mt19937 generator(rd());
@@ -108,7 +106,6 @@ SendQueue::SendQueue(Socket* socket, HifiSockAddr dest) :
 }
 
 SendQueue::~SendQueue() {
-    PROFILE_ASYNC_END(network, "SendQueue", _destination.toString());
 }
 
 void SendQueue::queuePacket(std::unique_ptr<Packet> packet) {
@@ -229,8 +226,6 @@ void SendQueue::sendHandshake() {
     if (!_hasReceivedHandshakeACK) {
         // we haven't received a handshake ACK from the client, send another now
         auto handshakePacket = ControlPacket::create(ControlPacket::Handshake, sizeof(SequenceNumber));
-        PROFILE_ASYNC_BEGIN(network, "SendQueue:Handshake", _destination.toString());
-
         handshakePacket->writePrimitive(_initialSequenceNumber);
         _socket->writeBasePacket(*handshakePacket, _destination);
         
@@ -246,8 +241,6 @@ void SendQueue::handshakeACK(SequenceNumber initialSequenceNumber) {
             std::lock_guard<std::mutex> locker { _handshakeMutex };
             _hasReceivedHandshakeACK = true;
         }
-        PROFILE_ASYNC_END(network, "SendQueue:Handshake", _destination.toString());
-
         // Notify on the handshake ACK condition
         _handshakeACKCondition.notify_one();
     }


### PR DESCRIPTION
This PR address stuttering issues seen when opening and closing the marketplace tablet UI.  

Part of the stuttering issue is caused by the creation or destruction of offscreen QML surfaces and their corresponding OpenGL contexts.  Part of it is caused by the launching of a QtWebEngineProcess executable to render the content itself.  

This PR addresses these issues by adding functionality allowing offscreen QML surfaces to be cached and reused, by modifying the Web3DOverlay type to make use of this new cache, and by modifying the application to eagerly reserve some QML surfaces at startup time for the purpose of the overlays.  

The following traces show the before and after effect of the cache...

[trace_marketplace_20170110_1338_web.json.gz](https://github.com/highfidelity/hifi/files/700250/trace_marketplace_20170110_1338_web.json.gz)
[trace_marketplace_20170111_1346_cached_overlay.json.gz](https://github.com/highfidelity/hifi/files/700251/trace_marketplace_20170111_1346_cached_overlay.json.gz)

## Testing

* Make sure Interface is in HMD mode, preferably using Oculus
* Clone the repository https://github.com/highfidelity/hifi_tests or download the scripts https://github.com/highfidelity/hifi_tests/blob/master/scripts/marketplace.js and https://github.com/highfidelity/hifi_tests/blob/master/scripts/BenchmarkLib.js to a local directory
* Run interface with the command line `interface --testScript <pathToScripts>/marketplace.js`.

This should produce a timestamped trace file in ~/Documents/traces.  When running on the current release you should see stuttering in the present thread when the tablet is loaded and when it is unloaded.  With this build the stuttering should be gone or significantly reduced (rendering a new piece of web content still has some impact).
