### PR TITLE
Fix for rendering of tablet ModelEntity in desktop mode.

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -495,6 +495,7 @@ ModelPointer RenderableModelEntityItem::getModel(QSharedPointer<EntityTreeRender
         // If we don't have a model, allocate one *immediately*
         if (!_model) {
             _model = _myRenderer->allocateModel(getModelURL(), renderer->getEntityLoadingPriority(*this));
+            _model->setSpatiallyNestableOverride(shared_from_this());
             _needsInitialSimulation = true;
         // If we need to change URLs, update it *after rendering* (to avoid access violations)
         } else if (QUrl(getModelURL()) != _model->getURL()) {
@@ -1173,8 +1174,7 @@ void RenderableModelEntityItem::locationChanged(bool tellPhysics) {
     PerformanceTimer pertTimer("locationChanged");
     EntityItem::locationChanged(tellPhysics);
     if (_model && _model->isActive()) {
-        _model->setRotation(getRotation());
-        _model->setTranslation(getPosition());
+        _model->updateRenderItems();
 
         void* key = (void*)this;
         std::weak_ptr<RenderableModelEntityItem> weakSelf =

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -27,6 +27,7 @@
 #include <gpu/Batch.h>
 #include <render/Scene.h>
 #include <Transform.h>
+#include <SpatiallyNestable.h>
 
 #include "GeometryCache.h"
 #include "TextureCache.h"
@@ -203,9 +204,12 @@ public:
 
     void setTranslation(const glm::vec3& translation);
     void setRotation(const glm::quat& rotation);
+    void setSpatiallyNestableOverride(SpatiallyNestablePointer ptr);
 
     const glm::vec3& getTranslation() const { return _translation; }
     const glm::quat& getRotation() const { return _rotation; }
+
+    Transform getTransform() const;
 
     void setScale(const glm::vec3& scale);
     const glm::vec3& getScale() const { return _scale; }
@@ -288,6 +292,9 @@ protected:
     glm::vec3 _translation;
     glm::quat _rotation;
     glm::vec3 _scale;
+
+    SpatiallyNestableWeakPointer _spatiallyNestableOverride;
+
     glm::vec3 _offset;
 
     static float FAKE_DIMENSION_PLACEHOLDER;


### PR DESCRIPTION
The Model pendingChanges.updateItem() lambda now directly calls into SpatiallyNestable.  This occurs late enough in the update loop to have the most up-to-date camera transform used for rendering.