### PR TITLE
Fixes for qt asserts in debug

### DIFF
--- a/libraries/script-engine/src/TabletScriptingInterface.cpp
+++ b/libraries/script-engine/src/TabletScriptingInterface.cpp
@@ -53,7 +53,6 @@ void TabletScriptingInterface::setQmlTabletRoot(QString tabletId, QQuickItem* qm
 
 static const char* TABLET_SOURCE_URL = "Tablet.qml";
 static const char* WEB_VIEW_SOURCE_URL = "TabletWebView.qml";
-static const char* LOADER_SOURCE_PROPERTY_NAME = "LoaderSource";
 static const char* VRMENU_SOURCE_URL = "TabletMenu.qml";
 
 TabletProxy::TabletProxy(QString name) : _name(name) {

--- a/libraries/script-engine/src/TabletScriptingInterface.h
+++ b/libraries/script-engine/src/TabletScriptingInterface.h
@@ -36,7 +36,6 @@ class TabletScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
 public:
     TabletScriptingInterface();
-    virtual ~TabletScriptingInterface();
 
     /**jsdoc
      * Creates or retruns a new TabletProxy and returns it.
@@ -132,6 +131,9 @@ protected:
     std::vector<QSharedPointer<TabletButtonProxy>> _tabletButtonProxies;
     QQuickItem* _qmlTabletRoot { nullptr };
     QObject* _qmlOffscreenSurface { nullptr };
+
+    enum class State { Uninitialized, Home, Web, Menu };
+    State _state { State::Uninitialized };
 };
 
 /**jsdoc


### PR DESCRIPTION
* The TabletScriptingInterface destructor is invoked on app shutdown after the logging system has been destroyed. To avoid this I removed the destructor.  The log was only for debug purposes anyway.
* Removed calls to setProperty() these calls are not thread safe and were causing asserts during debug. Instead of getting and setting the property we maintain the TabletProxy state using an enum.