### PR TITLE
Rework Context Menu QML to Be Suitable for Tablet

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletMenu.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenu.qml
@@ -4,18 +4,63 @@ import QtQuick.Controls 1.4
 import QtQml 2.2
 import "."
 
-
 Item {
     id: tabletMenu
     objectName: "tabletMenu"
 
-    width: parent.width
-    height: parent.height
+    width: 480
+    height: 720
 
     property var rootMenu: Menu { objectName:"rootMenu" }
     property var point: Qt.point(50, 50)
 
     TabletMouseHandler { id: menuPopperUpper }
+
+    Rectangle {
+        id: bgNavBar
+        height: 90
+        z: 1
+        gradient: Gradient {
+            GradientStop {
+                position: 0
+                color: "#2b2b2b"
+            }
+
+            GradientStop {
+                position: 1
+                color: "#1e1e1e"
+            }
+        }
+        anchors.right: parent.right
+        anchors.rightMargin: 0
+        anchors.left: parent.left
+        anchors.leftMargin: 0
+        anchors.topMargin: 0
+        anchors.top: parent.top
+
+        Image {
+            id: menuRootIcon
+            width: 40
+            height: 40
+            source: "../../../icons/tablet-icons/menu-i.svg"
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: 15
+
+            MouseArea {
+                anchors.fill: parent
+                // navigate back to top level menu
+                onClicked: buildMenu();
+            }
+        }
+
+        ColorOverlay {
+            id: iconColorOverlay
+            anchors.fill: menuRootIcon
+            source: menuRootIcon
+            color: "#ffffff"
+        }
+    }
 
     function setRootMenu(menu) {
         tabletMenu.rootMenu = menu

--- a/interface/resources/qml/hifi/tablet/TabletMenu.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenu.qml
@@ -50,6 +50,9 @@ Item {
 
             MouseArea {
                 anchors.fill: parent
+                hoverEnabled: true
+                onEntered: iconColorOverlay.color = "#1fc6a6";
+                onExited: iconColorOverlay.color = "#ffffff";
                 // navigate back to root level menu
                 onClicked: buildMenu();
             }
@@ -72,6 +75,9 @@ Item {
             anchors.leftMargin: 15
             MouseArea {
                 anchors.fill: parent
+                hoverEnabled: true
+                onEntered: breadcrumbText.color = "#1fc6a6";
+                onExited: breadcrumbText.color = "#ffffff";
                 // navigate back to parent level menu
                 onClicked: menuPopperUpper.closeLastMenu();
             }

--- a/interface/resources/qml/hifi/tablet/TabletMenu.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenu.qml
@@ -3,6 +3,7 @@ import QtGraphicalEffects 1.0
 import QtQuick.Controls 1.4
 import QtQml 2.2
 import "."
+import "../../styles-uit"
 
 Item {
     id: tabletMenu
@@ -49,7 +50,7 @@ Item {
 
             MouseArea {
                 anchors.fill: parent
-                // navigate back to top level menu
+                // navigate back to root level menu
                 onClicked: buildMenu();
             }
         }
@@ -59,6 +60,21 @@ Item {
             anchors.fill: menuRootIcon
             source: menuRootIcon
             color: "#ffffff"
+        }
+
+        RalewayBold {
+            id: breadcrumbText
+            text: "MENU"
+            size: 18
+            color: "#ffffff"
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: menuRootIcon.right
+            anchors.leftMargin: 15
+            MouseArea {
+                anchors.fill: parent
+                // navigate back to parent level menu
+                onClicked: menuPopperUpper.closeLastMenu();
+            }
         }
     }
 

--- a/interface/resources/qml/hifi/tablet/TabletMenu.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenu.qml
@@ -64,7 +64,7 @@ Item {
 
         RalewayBold {
             id: breadcrumbText
-            text: "MENU"
+            text: "Menu"
             size: 18
             color: "#ffffff"
             anchors.verticalCenter: parent.verticalCenter

--- a/interface/resources/qml/hifi/tablet/TabletMenuItem.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuItem.qml
@@ -31,7 +31,7 @@ Item {
         // FIXME: Should use radio buttons if source.exclusiveGroup.
         anchors {
             left: parent.left
-            leftMargin: hifi.dimensions.menuPadding.x
+            leftMargin: hifi.dimensions.menuPadding.x + 15
             top: label.top
             topMargin: 0
         }

--- a/interface/resources/qml/hifi/tablet/TabletMenuView.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuView.qml
@@ -37,9 +37,10 @@ FocusScope {
 
     ListView {
         id: listView
-        x: 8; y: 8
-        width: parent.width
-        height: parent.height
+        x: 0
+        y: 0
+        width: 480
+        height: 720
         topMargin: hifi.dimensions.menuPadding.y
         onEnabledChanged: recalcSize();
         onVisibleChanged: recalcSize();

--- a/interface/resources/qml/hifi/tablet/TabletMenuView.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuView.qml
@@ -11,7 +11,6 @@
 import QtQuick 2.5
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
-import QtGraphicalEffects 1.0
 
 import "../../styles-uit"
 
@@ -26,63 +25,6 @@ FocusScope {
     signal selected(var item)
 
     HifiConstants { id: hifi }
-
-    Rectangle {
-        id: bgNavBar
-        height: 90
-        z: 1
-        gradient: Gradient {
-            GradientStop {
-                position: 0
-                color: "#2b2b2b"
-            }
-
-            GradientStop {
-                position: 1
-                color: "#1e1e1e"
-            }
-        }
-        anchors.right: parent.right
-        anchors.rightMargin: 0
-        anchors.left: parent.left
-        anchors.leftMargin: 0
-        anchors.topMargin: 0
-        anchors.top: parent.top
-
-        Image {
-            id: menuRootIcon
-            width: 40
-            height: 40
-            source: "../../../icons/tablet-icons/menu-i.svg"
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.left
-            anchors.leftMargin: 15
-
-            MouseArea {
-                anchors.fill: parent
-                // TODO: navigate back to top level menu
-                onClicked: iconColorOverlay.color = "#1fc6a6"
-            }
-        }
-
-        ColorOverlay {
-            id: iconColorOverlay
-            anchors.fill: menuRootIcon
-            source: menuRootIcon
-            color: "#ffffff"
-        }
-
-        RalewayBold {
-            id: breadcrumbText
-            text: "MENU"
-            size: 18
-            color: "#ffffff"
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: menuRootIcon.right
-            anchors.leftMargin: 15
-        }
-
-    }
 
     Rectangle {
         id: background

--- a/interface/resources/qml/hifi/tablet/TabletMenuView.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuView.qml
@@ -11,6 +11,7 @@
 import QtQuick 2.5
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
+import QtGraphicalEffects 1.0
 
 import "../../styles-uit"
 
@@ -47,6 +48,40 @@ FocusScope {
         anchors.leftMargin: 0
         anchors.topMargin: 0
         anchors.top: parent.top
+
+        Image {
+            id: menuRootIcon
+            width: 40
+            height: 40
+            source: "../../../icons/tablet-icons/menu-i.svg"
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: 15
+
+            MouseArea {
+                anchors.fill: parent
+                // TODO: navigate back to top level menu
+                onClicked: iconColorOverlay.color = "#1fc6a6"
+            }
+        }
+
+        ColorOverlay {
+            id: iconColorOverlay
+            anchors.fill: menuRootIcon
+            source: menuRootIcon
+            color: "#ffffff"
+        }
+
+        RalewayBold {
+            id: breadcrumbText
+            text: "MENU"
+            size: 18
+            color: "#ffffff"
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: menuRootIcon.right
+            anchors.leftMargin: 15
+        }
+
     }
 
     Rectangle {

--- a/interface/resources/qml/hifi/tablet/TabletMenuView.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuView.qml
@@ -27,12 +27,36 @@ FocusScope {
     HifiConstants { id: hifi }
 
     Rectangle {
+        id: bgNavBar
+        height: 90
+        z: 1
+        gradient: Gradient {
+            GradientStop {
+                position: 0
+                color: "#2b2b2b"
+            }
+
+            GradientStop {
+                position: 1
+                color: "#1e1e1e"
+            }
+        }
+        anchors.right: parent.right
+        anchors.rightMargin: 0
+        anchors.left: parent.left
+        anchors.leftMargin: 0
+        anchors.topMargin: 0
+        anchors.top: parent.top
+    }
+
+    Rectangle {
         id: background
         anchors.fill: listView
         radius: hifi.dimensions.borderRadius
         border.width: hifi.dimensions.borderWidth
         border.color: hifi.colors.lightGrayText80
-        color: isSubMenu ? hifi.colors.faintGray : hifi.colors.faintGray80
+        color: hifi.colors.faintGray
+        //color: isSubMenu ? hifi.colors.faintGray : hifi.colors.faintGray80
     }
 
     ListView {
@@ -41,7 +65,8 @@ FocusScope {
         y: 0
         width: 480
         height: 720
-        topMargin: hifi.dimensions.menuPadding.y
+
+        topMargin: hifi.dimensions.menuPadding.y + 90
         onEnabledChanged: recalcSize();
         onVisibleChanged: recalcSize();
         onCountChanged: recalcSize();

--- a/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
@@ -81,7 +81,14 @@ Item {
             if (menuStack.length) {
                 topMenu = menuStack[menuStack.length - 1];
                 topMenu.focus = true;
+                // show current menu level on nav bar
+                if (topMenu.objectName === "") {
+                    breadcrumbText.text = "Menu";
+                } else {
+                    breadcrumbText.text = topMenu.objectName;
+                }
             } else {
+                breadcrumbText.text = "Menu";
                 topMenu = null;
                 //offscreenFlags.navigationFocused = false;
                 menuRoot.enabled = false;
@@ -133,6 +140,8 @@ Item {
                 case MenuItemType.Menu:
                     var target = Qt.vector2d(topMenu.x, topMenu.y).plus(Qt.vector2d(selectedItem.x + 96, selectedItem.y));
                     buildMenu(item.items, target).objectName = item.title;
+                    // show current menu level on nav bar
+                    breadcrumbText.text = item.title;
                     break;
 
                 case MenuItemType.Item:


### PR DESCRIPTION
This PR contains a few changes in QML I made to make context menu look and feel like it belongs to the tablet. Things I changed include:

- Addition of a Navigation Bar. It contains a hamburger icon that bring user back to top level menu, and a breadcrumb text indicating which level of the menu user is in.
- Width and Height change to fit in Tablet sreen
- Minor margin layout changes

Test Plan:
1. Download and install Interface from this PR
2. Bring out Tablet, and click the "Menu" button.
3. Confirm that you see the context menu fitting in the Tablet screen, and that there is a top nav bar that says "Menu"
4. Try the different menu options. Confirm each time you click a next level pop up  (such as **Avatar >**), you see the pop up taking over the whole screen. Also confirm that the breadcrumb text update.
5. Try using the navigation elements on the nav bar. The hamburger icon takes you back to top level, and the text take you to the parent level of current level.
5. Repeat and check it works well with both desktop mouse click and stylus in HMD.

![hifi-snap-by-faye-on-2017-01-13_09-27-30](https://cloud.githubusercontent.com/assets/2405697/21938995/966bf330-d972-11e6-83ce-cb8b7c7cd006.jpg)
