### PR TITLE
fix physics not starting up when a model is close behind

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5294,15 +5294,17 @@ bool Application::nearbyEntitiesAreReadyForPhysics() {
     if (_nearbyEntitiesStabilityCount >= MINIMUM_NEARBY_ENTITIES_STABILITY_COUNT) {
         // We've seen the same number of nearby entities for several stats packets in a row.  assume we've got all
         // the local entities.
+        bool result = true;
         foreach (EntityItemPointer entity, entities) {
             if (entity->shouldBePhysical() && !entity->isReadyToComputeShape()) {
                 static QString repeatedMessage =
                     LogHandler::getInstance().addRepeatedMessageRegex("Physics disabled until entity loads: .*");
                 qCDebug(interfaceapp) << "Physics disabled until entity loads: " << entity->getID() << entity->getName();
-                return false;
+                // don't break here because we want all the relevant entities to start their downloads
+                result = false;
             }
         }
-        return true;
+        return result;
     }
     return false;
 }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -646,6 +646,12 @@ bool RenderableModelEntityItem::isReadyToComputeShape() {
         // the model is still being downloaded.
         return false;
     } else if (type >= SHAPE_TYPE_SIMPLE_HULL && type <= SHAPE_TYPE_STATIC_MESH) {
+        if (!_model) {
+            EntityTreePointer tree = getTree();
+            if (tree) {
+                QMetaObject::invokeMethod(tree.get(), "callLoader", Qt::QueuedConnection, Q_ARG(EntityItemID, getID()));
+            }
+        }
         return (_model && _model->isLoaded());
     }
     return true;


### PR DESCRIPTION
- fixed a bug that kept physics and scripts from starting when logging-in near (but not looking at) something that's physical
