### PR TITLE
remove ignored avatars from PAL when they disconnect

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -502,6 +502,10 @@ Rectangle {
             ignored = {};
             gainSliderValueDB = {};
             break;
+        case 'avatarDisconnected':
+            var sessionID = message.params[0];
+            delete ignored[sessionID];
+            break;
         default:
             console.log('Unrecognized message:', JSON.stringify(message));
         }

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -261,6 +261,11 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
     if (removalReason == KillAvatarReason::TheirAvatarEnteredYourBubble || removalReason == YourAvatarEnteredTheirBubble) {
         DependencyManager::get<NodeList>()->radiusIgnoreNodeBySessionID(avatar->getSessionUUID(), true);
     }
+    if (removalReason == KillAvatarReason::AvatarDisconnected) {
+        // remove from node sets, if present
+        DependencyManager::get<NodeList>()->maintainIgnoreMuteSets(avatar->getSessionUUID());
+        DependencyManager::get<UsersScriptingInterface>()->avatarDisconnected(avatar->getSessionUUID());
+    }
     _avatarFades.push_back(removedAvatar);
 }
 

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -260,8 +260,7 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
     }
     if (removalReason == KillAvatarReason::TheirAvatarEnteredYourBubble || removalReason == YourAvatarEnteredTheirBubble) {
         DependencyManager::get<NodeList>()->radiusIgnoreNodeBySessionID(avatar->getSessionUUID(), true);
-    }
-    if (removalReason == KillAvatarReason::AvatarDisconnected) {
+    } else if (removalReason == KillAvatarReason::AvatarDisconnected) {
         // remove from node sets, if present
         DependencyManager::get<NodeList>()->removeFromIgnoreMuteSets(avatar->getSessionUUID());
         DependencyManager::get<UsersScriptingInterface>()->avatarDisconnected(avatar->getSessionUUID());

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -263,7 +263,7 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
     }
     if (removalReason == KillAvatarReason::AvatarDisconnected) {
         // remove from node sets, if present
-        DependencyManager::get<NodeList>()->maintainIgnoreMuteSets(avatar->getSessionUUID());
+        DependencyManager::get<NodeList>()->removeFromIgnoreMuteSets(avatar->getSessionUUID());
         DependencyManager::get<UsersScriptingInterface>()->avatarDisconnected(avatar->getSessionUUID());
     }
     _avatarFades.push_back(removedAvatar);

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -847,6 +847,18 @@ void NodeList::ignoreNodeBySessionID(const QUuid& nodeID, bool ignoreEnabled) {
     }
 }
 
+// removes this UUID from ignore and mute lists.  
+void NodeList::maintainIgnoreMuteSets(const QUuid& nodeID) {
+    // don't remove yourself, or nobody
+    if (!nodeID.isNull() && _sessionUUID != nodeID) {
+        QWriteLocker ignoredSetLocker{ &_ignoredSetLock };
+        QWriteLocker personalMutedSetLocker{ &_personalMutedSetLock };
+        _ignoredNodeIDs.unsafe_erase(nodeID);
+        _personalMutedNodeIDs.unsafe_erase(nodeID);
+        qCDebug(networking) << "removed" << nodeID.toString() << "from ignore/mute sets (if present)";
+    }
+}
+
 bool NodeList::isIgnoringNode(const QUuid& nodeID) const {
     QReadLocker ignoredSetLocker{ &_ignoredSetLock };
     return _ignoredNodeIDs.find(nodeID) != _ignoredNodeIDs.cend();

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -855,7 +855,6 @@ void NodeList::maintainIgnoreMuteSets(const QUuid& nodeID) {
         QWriteLocker personalMutedSetLocker{ &_personalMutedSetLock };
         _ignoredNodeIDs.unsafe_erase(nodeID);
         _personalMutedNodeIDs.unsafe_erase(nodeID);
-        qCDebug(networking) << "removed" << nodeID.toString() << "from ignore/mute sets (if present)";
     }
 }
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -847,8 +847,7 @@ void NodeList::ignoreNodeBySessionID(const QUuid& nodeID, bool ignoreEnabled) {
     }
 }
 
-// removes this UUID from ignore and mute lists.  
-void NodeList::maintainIgnoreMuteSets(const QUuid& nodeID) {
+void NodeList::removeFromIgnoreMuteSets(const QUuid& nodeID) {
     // don't remove yourself, or nobody
     if (!nodeID.isNull() && _sessionUUID != nodeID) {
         QWriteLocker ignoredSetLocker{ &_ignoredSetLock };

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -90,7 +90,7 @@ public:
     bool getRequestsDomainListData() { return _requestsDomainListData; }
     void setRequestsDomainListData(bool isRequesting);
 
-    void maintainIgnoreMuteSets(const QUuid& nodeID);
+    void removeFromIgnoreMuteSets(const QUuid& nodeID);
 
 public slots:
     void reset();

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -90,6 +90,8 @@ public:
     bool getRequestsDomainListData() { return _requestsDomainListData; }
     void setRequestsDomainListData(bool isRequesting);
 
+    void maintainIgnoreMuteSets(const QUuid& nodeID);
+
 public slots:
     void reset();
     void sendDomainServerCheckIn();

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -139,6 +139,12 @@ signals:
     */
     void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint);
 
+    /**jsdoc
+     * Notifies scripts that a user has disconnected from the domain
+     * @function Users.avatar.avatarDisconnected
+     */
+    void avatarDisconnected(const QUuid& nodeID);
+
 private:
     bool getRequestsDomainListData();
     void setRequestsDomainListData(bool requests);

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -142,6 +142,7 @@ signals:
     /**jsdoc
      * Notifies scripts that a user has disconnected from the domain
      * @function Users.avatar.avatarDisconnected
+     * @param {nodeID} NodeID The session ID of the avatar that has disconnected
      */
     void avatarDisconnected(const QUuid& nodeID);
 

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -582,7 +582,6 @@ function onClicked() {
 }
 function avatarDisconnected(nodeID) {
     // remove from the pal list
-    print("got avatarDisconnected for " + nodeID);
     pal.sendToQml({method: 'avatarDisconnected', params: [nodeID]});
 }
 //

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -580,7 +580,11 @@ function onClicked() {
     }
     pal.setVisible(!pal.visible);
 }
-
+function avatarDisconnected(nodeID) {
+    // remove from the pal list
+    print("got avatarDisconnected for " + nodeID);
+    pal.sendToQml({method: 'avatarDisconnected', params: [nodeID]});
+}
 //
 // Button state.
 //
@@ -593,6 +597,8 @@ button.clicked.connect(onClicked);
 pal.visibleChanged.connect(onVisibleChanged);
 pal.closed.connect(off);
 Users.usernameFromIDReply.connect(usernameFromIDReply);
+Users.avatarDisconnected.connect(avatarDisconnected);
+
 function clearLocalQMLDataAndClosePAL() {
     pal.sendToQml({ method: 'clearLocalQMLData' });
     if (pal.visible) {

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -620,6 +620,7 @@ Script.scriptEnding.connect(function () {
     Window.domainConnectionRefused.disconnect(clearLocalQMLDataAndClosePAL);
     Messages.unsubscribe(CHANNEL);
     Messages.messageReceived.disconnect(receiveMessage);
+    Users.avatarDisconnected.disconnect(avatarDisconnected);
     off();
 });
 


### PR DESCRIPTION
When you ignore someone, and they leave the domain, the entry for them remains in the PAL.  But, if they come back, there is a new entry for them.  The old entry is of no use, as unignoring is no longer possible.  So this PR will remove this entry when the avatar disconnects, since it is no longer of any use (unignore no longer will work once they leave the domain, even if they re-enter).

Test Plan:

Ignore an avatar.  Then, have that avatar go to another domain.  Refresh the PAL, and that entry should be gone.  Have the avatar come back.  Note that there is a new entry for them in the PAL, and they are not ignored.  

Before, you would have seen 2 entries for them, one the 'old' one (completely un-actionable since it refers to the old session), and the new one.  This simply removes the old one.  