### PR TITLE
Consume fewer cpu cores in AssetServer when interface is running locally

### DIFF
--- a/assignment-client/src/assets/AssetServer.cpp
+++ b/assignment-client/src/assets/AssetServer.cpp
@@ -31,6 +31,11 @@
 #include "SendAssetTask.h"
 #include "UploadAssetTask.h"
 
+static const uint8_t MIN_CORES_FOR_MULTICORE = 4;
+static const uint8_t CPU_AFFINITY_COUNT_HIGH = 2;
+static const uint8_t CPU_AFFINITY_COUNT_LOW = 1;
+static const int INTERFACE_RUNNING_CHECK_FREQUENCY_MS = 1000;
+
 const QString ASSET_SERVER_LOGGING_TARGET_NAME = "asset-server";
 
 bool interfaceRunning() {
@@ -57,7 +62,7 @@ void updateConsumedCores() {
     wasInterfaceRunning = isInterfaceRunning;
     auto coreCount = std::thread::hardware_concurrency();
     if (isInterfaceRunning) {
-        coreCount = coreCount > 4 ? 2 : 1;
+        coreCount = coreCount > MIN_CORES_FOR_MULTICORE ? CPU_AFFINITY_COUNT_HIGH : CPU_AFFINITY_COUNT_LOW;
     } 
     qDebug() << "Setting max consumed cores to " << coreCount;
     setMaxCores(coreCount);
@@ -89,7 +94,7 @@ AssetServer::AssetServer(ReceivedMessage& message) :
     connect(qApp, &QCoreApplication::aboutToQuit, [this, timerConnection] {
         disconnect(timerConnection);
     });
-    timer->setInterval(1000);
+    timer->setInterval(INTERFACE_RUNNING_CHECK_FREQUENCY_MS);
     timer->setTimerType(Qt::CoarseTimer);
     timer->start();
 #endif

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, const char* argv[]) {
     QCoreApplication::setOrganizationDomain(BuildInfo::ORGANIZATION_DOMAIN);
     QCoreApplication::setApplicationVersion(BuildInfo::VERSION);
 
-    QString applicationName = "High Fidelity Interface - " + qgetenv("USERNAME");
+    const QString& applicationName = getInterfaceSharedMemoryName();
 
     bool instanceMightBeRunning = true;
 

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -18,6 +18,8 @@
 #include <cctype>
 #include <time.h>
 #include <mutex>
+#include <thread>
+#include <set>
 
 #include <glm/glm.hpp>
 
@@ -1022,4 +1024,54 @@ bool getProcessorInfo(ProcessorInfo& info) {
 #endif
 
     return false;
+}
+
+
+const QString& getInterfaceSharedMemoryName() {
+    static const QString applicationName = "High Fidelity Interface - " + qgetenv("USERNAME");
+    return applicationName;
+}
+
+const std::vector<uint8_t>& getAvailableCores() {
+    static std::vector<uint8_t> availableCores;
+#ifdef Q_OS_WIN
+    static std::once_flag once;
+    std::call_once(once, [&] {
+        DWORD_PTR defaultProcessAffinity = 0, defaultSystemAffinity = 0;
+        HANDLE process = GetCurrentProcess();
+        GetProcessAffinityMask(process, &defaultProcessAffinity, &defaultSystemAffinity);
+        for (uint64_t i = 0; i < sizeof(DWORD_PTR) * 8; ++i) {
+            DWORD_PTR coreMask = 1;
+            coreMask <<= i;
+            if (0 != (defaultSystemAffinity & coreMask)) {
+                availableCores.push_back(i);
+            }
+        }
+    });
+#endif
+    return availableCores;
+}
+
+void setMaxCores(uint8_t maxCores) {
+#ifdef Q_OS_WIN
+    HANDLE process = GetCurrentProcess();
+    auto availableCores = getAvailableCores();
+    if (availableCores.size() <= maxCores) {
+        DWORD_PTR currentProcessAffinity = 0, currentSystemAffinity = 0;
+        GetProcessAffinityMask(process, &currentProcessAffinity, &currentSystemAffinity);
+        SetProcessAffinityMask(GetCurrentProcess(), currentSystemAffinity);
+        return;
+    }
+
+    DWORD_PTR newProcessAffinity = 0;
+    while (maxCores) {
+        int index = randIntInRange(0, (int)availableCores.size() - 1);
+        DWORD_PTR coreMask = 1;
+        coreMask <<= availableCores[index];
+        newProcessAffinity |= coreMask;
+        availableCores.erase(availableCores.begin() + index);
+        maxCores--;
+    }
+    SetProcessAffinityMask(process, newProcessAffinity);
+#endif
 }

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -1040,7 +1040,7 @@ const std::vector<uint8_t>& getAvailableCores() {
         DWORD_PTR defaultProcessAffinity = 0, defaultSystemAffinity = 0;
         HANDLE process = GetCurrentProcess();
         GetProcessAffinityMask(process, &defaultProcessAffinity, &defaultSystemAffinity);
-        for (uint64_t i = 0; i < sizeof(DWORD_PTR) * 8; ++i) {
+        for (uint64_t i = 0; i < sizeof(DWORD_PTR) * BITS_IN_BYTE; ++i) {
             DWORD_PTR coreMask = 1;
             coreMask <<= i;
             if (0 != (defaultSystemAffinity & coreMask)) {

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -231,4 +231,8 @@ struct ProcessorInfo {
 
 bool getProcessorInfo(ProcessorInfo& info);
 
+const QString& getInterfaceSharedMemoryName();
+
+void setMaxCores(uint8_t maxCores);
+
 #endif // hifi_SharedUtil_h


### PR DESCRIPTION
The AssetServer code allows it to consume a vast number of threads (on the basis that most threads will be IO bound rather than CPU bound).  This means that when a client with a cold cache connects and starts requesting a large number of files, the server can saturate the system CPU fulfilling those requests.  

This PR modifies this by having the AssetServer check whether an instance of Interface is concurrently running, and if it is, reducing the number of cores the asset server is allowed to use to 1 or 2 (depending on whether the system has more than 4 cores available).  

[trace_tutorial_cleancache_20170117_1507.json.gz](https://github.com/highfidelity/hifi/files/712554/trace_tutorial_cleancache_20170117_1507.json.gz)

## Testing

* Install the PR build and launch Sandbox.  
* From the server console menu, select *View Logs*.
* In the filter field enter the string "max consumed"
* Start interface, and verify that the number of cores is changed to 1 for an i5 system, or 2 for an i7 system
* Stop interface and verify that the number of cores is changed to the total number of system cores
* (Optional) You can also use a tool like process explorer to verify that the core affinity for the process has actually been changed (find the assignment-client.exe process with the same process ID listed on the log lines)

