### PR TITLE
Removing some PAL-related interface log spam

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -476,8 +476,6 @@ Rectangle {
                     // Set the userName appropriately
                     userModel.setProperty(userIndex, "userName", userName);
                     userModelData[userIndex].userName = userName; // Defensive programming
-                } else {
-                    console.log("updateUsername() called with unknown UUID: ", userId);
                 }
             }
             break;
@@ -493,8 +491,6 @@ Rectangle {
                     if (userIndex != -1) {
                         userModel.setProperty(userIndex, "audioLevel", audioLevel);
                         userModelData[userIndex].audioLevel = audioLevel; // Defensive programming
-                    } else {
-                        console.log("updateUsername() called with unknown UUID: ", userId);
                     }
                 }
             }

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -498,7 +498,6 @@ function getAudioLevel(id) {
     var audioLevel = 0.0;
     var data = id ? ExtendedOverlay.get(id) : myData;
     if (!data) {
-        print('no data for', id);
         return audioLevel;
     }
 


### PR DESCRIPTION
There is one more that happens sometimes, which I've not yet found a good way to prevent.  These are the biggest offenders in any case.

Test Plan

Open PAL in a busy place, where people enter/leave while the PAL is open.  There was a lot of logging done before, which is now gone.  So verify that, then since nothing changes functionally, a smoketest of PAL should be good enough.