### PR TITLE
Additional trace details for GPU timing, frame data updates

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3398,6 +3398,8 @@ void Application::idle(float nsecsElapsed) {
     PROFILE_COUNTER(app, "cpuSystem", { { "system", kernelUserAndSystem.z } });
 #endif
 
+
+
     auto displayPlugin = getActiveDisplayPlugin();
     if (displayPlugin) {
         PROFILE_COUNTER_IF_CHANGED(app, "present", float, displayPlugin->presentRate());
@@ -3407,9 +3409,15 @@ void Application::idle(float nsecsElapsed) {
     PROFILE_COUNTER_IF_CHANGED(app, "pendingDownloads", int, ResourceCache::getPendingRequestCount());
     PROFILE_COUNTER_IF_CHANGED(app, "currentProcessing", int, DependencyManager::get<StatTracker>()->getStat("Processing").toInt());
     PROFILE_COUNTER_IF_CHANGED(app, "pendingProcessing", int, DependencyManager::get<StatTracker>()->getStat("PendingProcessing").toInt());
-
-
-
+    auto renderConfig = _renderEngine->getConfiguration();
+    PROFILE_COUNTER_IF_CHANGED(render, "gpuTime", float, (float)_gpuContext->getFrameTimerGPUAverage());
+    PROFILE_COUNTER(render_detail, "gpuTimes", {
+        { "OpaqueRangeTimer", renderConfig->getConfig("OpaqueRangeTimer")->property("gpuRunTime") },
+        { "LinearDepth", renderConfig->getConfig("LinearDepth")->property("gpuRunTime") },
+        { "SurfaceGeometry", renderConfig->getConfig("SurfaceGeometry")->property("gpuRunTime") },
+        { "RenderDeferred", renderConfig->getConfig("RenderDeferred")->property("gpuRunTime") },
+        { "ToneAndPostRangeTimer", renderConfig->getConfig("ToneAndPostRangeTimer")->property("gpuRunTime") }
+    });
 
     PROFILE_RANGE(app, __FUNCTION__);
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -482,6 +482,7 @@ void OpenGLDisplayPlugin::submitFrame(const gpu::FramePointer& newFrame) {
 }
 
 void OpenGLDisplayPlugin::updateFrameData() {
+    PROFILE_RANGE(render, __FUNCTION__)
     if (_lockCurrentTexture) {
         return;
     }
@@ -596,12 +597,16 @@ void OpenGLDisplayPlugin::internalPresent() {
 }
 
 void OpenGLDisplayPlugin::present() {
-    PROFILE_RANGE_EX(render, __FUNCTION__, 0xffffff00, (uint64_t)presentCount())
-    updateFrameData();
+    auto frameId = (uint64_t)presentCount();
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xffffff00, frameId)
+    {
+        PROFILE_RANGE_EX(render, "updateFrameData", 0xff00ff00, frameId)
+        updateFrameData();
+    }
     incrementPresentCount();
 
     {
-        PROFILE_RANGE_EX(render, "recycle", 0xff00ff00, (uint64_t)presentCount())
+        PROFILE_RANGE_EX(render, "recycle", 0xff00ff00, frameId)
         _gpuContext->recycle();
     }
 
@@ -615,19 +620,19 @@ void OpenGLDisplayPlugin::present() {
                 _lastFrame = _currentFrame.get();
             });
             // Execute the frame rendering commands
-            PROFILE_RANGE_EX(render, "execute", 0xff00ff00, (uint64_t)presentCount())
+            PROFILE_RANGE_EX(render, "execute", 0xff00ff00, frameId)
             _gpuContext->executeFrame(_currentFrame);
         }
 
         // Write all layers to a local framebuffer
         {
-            PROFILE_RANGE_EX(render, "composite", 0xff00ffff, (uint64_t)presentCount())
+            PROFILE_RANGE_EX(render, "composite", 0xff00ffff, frameId)
             compositeLayers();
         }
 
         // Take the composite framebuffer and send it to the output device
         {
-            PROFILE_RANGE_EX(render, "internalPresent", 0xff00ffff, (uint64_t)presentCount())
+            PROFILE_RANGE_EX(render, "internalPresent", 0xff00ffff, frameId)
             internalPresent();
         }
 


### PR DESCRIPTION
* Adds GPU timing to trace output
* Adds coverage of the `updateFrameData` function to the trace output

## Testing

Application behavior and performance should be unaffected.  

Produce a trace file as normal.  Examine the trace output.  There should now be a new counter row for runtime of various gpu tasks, as seen here:

![image](https://cloud.githubusercontent.com/assets/1533642/22078940/d2a03a5a-dd6e-11e6-91a4-bc981f81a261.png)

There should also be a new block underneath the pluginPresent blocks labeled updateFrameData that was previously unoccupied, like this:

![image](https://cloud.githubusercontent.com/assets/1533642/22078904/9c8e316a-dd6e-11e6-8d4e-e6dc7e251560.png)
