### PR TITLE
PAL: Admin Labels, Updated Letterboxes

### DIFF
--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -812,7 +812,7 @@ void DomainServerSettingsManager::processUsernameFromIDRequestPacket(QSharedPoin
                 usernameFromIDReplyPacket->write(machineFingerprint.toRfc4122());
             } else {
                 usernameFromIDReplyPacket->writeString(verifiedUsername);
-                usernameFromIDReplyPacket->writeString(machineFingerprint.toRfc4122());
+                usernameFromIDReplyPacket->write(machineFingerprint.toRfc4122());
             }
             // Write whether or not the user is an admin
             bool isAdmin = matchingNode->getCanKick();

--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -782,21 +782,24 @@ void DomainServerSettingsManager::processNodeKickRequestPacket(QSharedPointer<Re
 void DomainServerSettingsManager::processUsernameFromIDRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) {
     // From the packet, pull the UUID we're identifying
     QUuid nodeUUID = QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID));
-    if (!nodeUUID.isNull()) {
-        // Before we do any processing on this packet, make sure it comes from a node that is allowed to kick (is an admin)
-        // OR from a node whose UUID matches the one in the packet
-        if (sendingNode->getCanKick() || nodeUUID == sendingNode->getUUID()) {
-            // First, make sure we actually have a node with this UUID
-            auto limitedNodeList = DependencyManager::get<LimitedNodeList>();
-            auto matchingNode = limitedNodeList->nodeWithUUID(nodeUUID);
 
-            // If we do have a matching node...
-            if (matchingNode) {
+    if (!nodeUUID.isNull()) {
+        // First, make sure we actually have a node with this UUID
+        auto limitedNodeList = DependencyManager::get<LimitedNodeList>();
+        auto matchingNode = limitedNodeList->nodeWithUUID(nodeUUID);
+
+        // If we do have a matching node...
+        if (matchingNode) {
+            // Setup the packet
+            auto usernameFromIDReplyPacket = NLPacket::create(PacketType::UsernameFromIDReply);
+
+            bool isAdmin = matchingNode->getCanKick();
+
+            // Check if the sending node has permission to kick (is an admin)
+            if (sendingNode->getCanKick()) {
                 // It's time to figure out the username
                 QString verifiedUsername = matchingNode->getPermissions().getVerifiedUserName();
 
-                // Setup the packet
-                auto usernameFromIDReplyPacket = NLPacket::create(PacketType::UsernameFromIDReply);
                 usernameFromIDReplyPacket->write(nodeUUID.toRfc4122());
                 usernameFromIDReplyPacket->writeString(verifiedUsername);
 
@@ -804,19 +807,20 @@ void DomainServerSettingsManager::processUsernameFromIDRequestPacket(QSharedPoin
                 DomainServerNodeData* nodeData = reinterpret_cast<DomainServerNodeData*>(matchingNode->getLinkedData());
                 QUuid machineFingerprint = nodeData ? nodeData->getMachineFingerprint() : QUuid();
                 usernameFromIDReplyPacket->write(machineFingerprint.toRfc4122());
-                
-                qDebug() << "Sending username" << verifiedUsername << "and machine fingerprint" << machineFingerprint << "associated with node" << nodeUUID;
-
-                // Ship it!
-                limitedNodeList->sendPacket(std::move(usernameFromIDReplyPacket), *sendingNode);
+                qDebug() << "Sending username" << verifiedUsername << "and machine fingerprint" << machineFingerprint << "associated with node" << nodeUUID << ". Node admin status: " << isAdmin;
             } else {
-                qWarning() << "Node username request received for unknown node. Refusing to process.";
+                usernameFromIDReplyPacket->write(nodeUUID.toRfc4122());
+                usernameFromIDReplyPacket->writeString("");
+                usernameFromIDReplyPacket->writeString("");
             }
+            // Write whether or not the user is an admin
+            usernameFromIDReplyPacket->writePrimitive(isAdmin);
+                
+            // Ship it!
+            limitedNodeList->sendPacket(std::move(usernameFromIDReplyPacket), *sendingNode);
         } else {
-            qWarning() << "Refusing to process a username request packet from node" << uuidStringWithoutCurlyBraces(sendingNode->getUUID())
-                << ". Either node doesn't have kick permissions or is requesting a username not from their UUID.";
+            qWarning() << "Node username request received for unknown node. Refusing to process.";
         }
-
     } else {
         qWarning() << "Node username request received for invalid node ID. Refusing to process.";
     }

--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -796,7 +796,8 @@ void DomainServerSettingsManager::processUsernameFromIDRequestPacket(QSharedPoin
             bool isAdmin = matchingNode->getCanKick();
 
             // Check if the sending node has permission to kick (is an admin)
-            if (sendingNode->getCanKick()) {
+            // OR if the message is from a node whose UUID matches the one in the packet
+            if (sendingNode->getCanKick() || nodeUUID == sendingNode->getUUID()) {
                 // It's time to figure out the username
                 QString verifiedUsername = matchingNode->getPermissions().getVerifiedUserName();
 

--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -15,7 +15,12 @@ import "../styles-uit"
 
 Item {
     property alias text: popupText.text
+    property alias headerGlyph: headerGlyph.text
+    property alias headerText: headerText.text
     property real popupRadius: hifi.dimensions.borderRadius
+    property real headerTextPixelSize: 22
+    FontLoader { id: ralewayRegular; source: "../../fonts/Raleway-Regular.ttf"; }
+    FontLoader { id: ralewaySemiBold; source: "../../fonts/Raleway-SemiBold.ttf"; }
     visible: false
     id: letterbox
     anchors.fill: parent
@@ -27,19 +32,73 @@ Item {
     }
     Rectangle {
         width: Math.max(parent.width * 0.75, 400)
-        height: popupText.contentHeight*1.5
+        height: contentContainer.height*1.5
         anchors.centerIn: parent
         radius: popupRadius
         color: "white"
-        FiraSansSemiBold {
-            id: popupText
-            size: hifi.fontSizes.textFieldInput
-            color: hifi.colors.darkGray
-            horizontalAlignment: Text.AlignHCenter
-            anchors.fill: parent
-            anchors.leftMargin: 15
-            anchors.rightMargin: 15
-            wrapMode: Text.WordWrap
+        Item {
+            id: contentContainer
+            anchors.centerIn: parent
+            anchors.margins: 20
+            height: childrenRect.height
+            Item {
+                id: popupHeaderContainer
+                visible: headerText.text !== "" || glyphText.text !== ""
+                // Size
+                width: parent.width
+                height: childrenRect.height
+                // Anchors
+                anchors.top: parent.top
+                anchors.left: parent.left
+                // Header Glyph
+                HiFiGlyphs {
+                    id: headerGlyph
+                    visible: headerText.text !== ""
+                    // Text Size
+                    size: headerTextPixelSize * 2.5
+                    // Anchors
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.rightMargin: 5
+                    // Style
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    color: hifi.colors.darkGray
+                }
+                Text {
+                    id: headerText
+                    visible: headerGlyph.text !== ""
+                    // Text Size
+                    font.pixelSize: headerTextPixelSize
+                    // Anchors
+                    anchors.top: parent.top
+                    anchors.left: headerGlyph.right
+                    // Style
+                    font.family: ralewaySemiBold.name
+                    color: hifi.colors.darkGray
+                    verticalAlignment: Text.AlignVCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
+                    textFormat: Text.StyledText
+                }
+            }
+            Text {
+                id: popupText
+                // Anchors
+                anchors.top: popupHeaderContainer.visible ? popupHeaderContainer.anchors.bottom : parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                // Text alignment
+                verticalAlignment: Text.AlignVCenter
+                horizontalAlignment: Text.AlignHCenter
+                // Style
+                font.pixelSize: hifi.fontSizes.textFieldInput
+                font.family: ralewayRegular.name
+                color: hifi.colors.darkGray
+                wrapMode: Text.WordWrap
+                textFormat: Text.StyledText
+            }
         }
     }
     MouseArea {

--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -37,71 +37,74 @@ Item {
         anchors.centerIn: parent
         radius: popupRadius
         color: "white"
-        Column {
+        Item {
             id: contentContainer
             width: parent.width - 60
+            height: childrenRect.height
             anchors.centerIn: parent
-            spacing: 20
-            Row {
+            Item {
                 id: popupHeaderContainer
                 visible: headerText.text !== "" || headerGlyph.text !== ""
                 height: 30
-                Column {
-                    // Header Glyph
-                    HiFiGlyphs {
-                        id: headerGlyph
-                        visible: headerGlyph.text !== ""
-                        // Size
-                        height: parent.parent.height
-                        // Anchors
-                        anchors.left: parent.left
-                        anchors.leftMargin: -15
-                        // Text Size
-                        size: headerTextPixelSize*2.5
-                        // Style
-                        horizontalAlignment: Text.AlignHLeft
-                        verticalAlignment: Text.AlignVCenter
-                        color: hifi.colors.darkGray
-                    }
-                }
-                Column {
-                    // Header Text
-                    Text {
-                        id: headerText
-                        visible: headerText.text !== ""
-                        // Size
-                        height: parent.parent.height
-                        // Anchors
-                        anchors.left: parent.left
-                        anchors.leftMargin: -15
-                        // Text Size
-                        font.pixelSize: headerTextPixelSize
-                        // Style
-                        font.family: ralewaySemiBold.name
-                        color: hifi.colors.darkGray
-                        horizontalAlignment: Text.AlignHLeft
-                        verticalAlignment: Text.AlignVCenter
-                        wrapMode: Text.WordWrap
-                        textFormat: Text.StyledText
-                    }
-                }
-            }
-            Row {
-                // Popup Text
-                Text {
-                    id: popupText
+                // Anchors
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                // Header Glyph
+                HiFiGlyphs {
+                    id: headerGlyph
+                    visible: headerGlyph.text !== ""
                     // Size
-                    width: parent.parent.width
-                    // Text alignment
-                    verticalAlignment: Text.AlignVCenter
-                    horizontalAlignment: Text.AlignHLeft
+                    height: parent.height
+                    // Anchors
+                    anchors.left: parent.left
+                    anchors.leftMargin: -15
+                    // Text Size
+                    size: headerTextPixelSize*2.5
                     // Style
-                    font.pixelSize: popupTextPixelSize
-                    font.family: ralewayRegular.name
+                    horizontalAlignment: Text.AlignHLeft
+                    verticalAlignment: Text.AlignVCenter
                     color: hifi.colors.darkGray
+                }
+                // Header Text
+                Text {
+                    id: headerText
+                    visible: headerText.text !== ""
+                    // Size
+                    height: parent.height
+                    // Anchors
+                    anchors.left: headerGlyph.right
+                    anchors.leftMargin: -5
+                    // Text Size
+                    font.pixelSize: headerTextPixelSize
+                    // Style
+                    font.family: ralewaySemiBold.name
+                    color: hifi.colors.darkGray
+                    horizontalAlignment: Text.AlignHLeft
+                    verticalAlignment: Text.AlignVCenter
                     wrapMode: Text.WordWrap
                     textFormat: Text.StyledText
                 }
+            }
+            // Popup Text
+            Text {
+                id: popupText
+                // Size
+                width: parent.width
+                // Anchors
+                anchors.top: popupHeaderContainer.visible ? popupHeaderContainer.bottom : parent.top
+                anchors.topMargin: popupHeaderContainer.visible ? 15 : 0
+                anchors.left: parent.left
+                anchors.right: parent.right
+                // Text alignment
+                verticalAlignment: Text.AlignVCenter
+                horizontalAlignment: Text.AlignHLeft
+                // Style
+                font.pixelSize: popupTextPixelSize
+                font.family: ralewayRegular.name
+                color: hifi.colors.darkGray
+                wrapMode: Text.WordWrap
+                textFormat: Text.StyledText
             }
         }
     }

--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -33,7 +33,7 @@ Item {
     }
     Rectangle {
         width: Math.max(parent.width * 0.75, 400)
-        height: childrenRect.height + 50
+        height: contentContainer.height + 50
         anchors.centerIn: parent
         radius: popupRadius
         color: "white"

--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -19,6 +19,7 @@ Item {
     property alias headerText: headerText.text
     property real popupRadius: hifi.dimensions.borderRadius
     property real headerTextPixelSize: 22
+    property real popupTextPixelSize: 16
     FontLoader { id: ralewayRegular; source: "../../fonts/Raleway-Regular.ttf"; }
     FontLoader { id: ralewaySemiBold; source: "../../fonts/Raleway-SemiBold.ttf"; }
     visible: false
@@ -32,72 +33,75 @@ Item {
     }
     Rectangle {
         width: Math.max(parent.width * 0.75, 400)
-        height: contentContainer.height*1.5
+        height: childrenRect.height + 50
         anchors.centerIn: parent
         radius: popupRadius
         color: "white"
-        Item {
+        Column {
             id: contentContainer
+            width: parent.width - 60
             anchors.centerIn: parent
-            anchors.margins: 20
-            height: childrenRect.height
-            Item {
+            spacing: 20
+            Row {
                 id: popupHeaderContainer
-                visible: headerText.text !== "" || glyphText.text !== ""
-                // Size
-                width: parent.width
-                height: childrenRect.height
-                // Anchors
-                anchors.top: parent.top
-                anchors.left: parent.left
-                // Header Glyph
-                HiFiGlyphs {
-                    id: headerGlyph
-                    visible: headerText.text !== ""
-                    // Text Size
-                    size: headerTextPixelSize * 2.5
-                    // Anchors
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    anchors.rightMargin: 5
-                    // Style
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    color: hifi.colors.darkGray
+                visible: headerText.text !== "" || headerGlyph.text !== ""
+                height: 30
+                Column {
+                    // Header Glyph
+                    HiFiGlyphs {
+                        id: headerGlyph
+                        visible: headerGlyph.text !== ""
+                        // Size
+                        height: parent.parent.height
+                        // Anchors
+                        anchors.left: parent.left
+                        anchors.leftMargin: -15
+                        // Text Size
+                        size: headerTextPixelSize*2.5
+                        // Style
+                        horizontalAlignment: Text.AlignHLeft
+                        verticalAlignment: Text.AlignVCenter
+                        color: hifi.colors.darkGray
+                    }
                 }
+                Column {
+                    // Header Text
+                    Text {
+                        id: headerText
+                        visible: headerText.text !== ""
+                        // Size
+                        height: parent.parent.height
+                        // Anchors
+                        anchors.left: parent.left
+                        anchors.leftMargin: -15
+                        // Text Size
+                        font.pixelSize: headerTextPixelSize
+                        // Style
+                        font.family: ralewaySemiBold.name
+                        color: hifi.colors.darkGray
+                        horizontalAlignment: Text.AlignHLeft
+                        verticalAlignment: Text.AlignVCenter
+                        wrapMode: Text.WordWrap
+                        textFormat: Text.StyledText
+                    }
+                }
+            }
+            Row {
+                // Popup Text
                 Text {
-                    id: headerText
-                    visible: headerGlyph.text !== ""
-                    // Text Size
-                    font.pixelSize: headerTextPixelSize
-                    // Anchors
-                    anchors.top: parent.top
-                    anchors.left: headerGlyph.right
-                    // Style
-                    font.family: ralewaySemiBold.name
-                    color: hifi.colors.darkGray
+                    id: popupText
+                    // Size
+                    width: parent.parent.width
+                    // Text alignment
                     verticalAlignment: Text.AlignVCenter
-                    horizontalAlignment: Text.AlignHCenter
+                    horizontalAlignment: Text.AlignHLeft
+                    // Style
+                    font.pixelSize: popupTextPixelSize
+                    font.family: ralewayRegular.name
+                    color: hifi.colors.darkGray
                     wrapMode: Text.WordWrap
                     textFormat: Text.StyledText
                 }
-            }
-            Text {
-                id: popupText
-                // Anchors
-                anchors.top: popupHeaderContainer.visible ? popupHeaderContainer.anchors.bottom : parent.top
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                // Text alignment
-                verticalAlignment: Text.AlignVCenter
-                horizontalAlignment: Text.AlignHCenter
-                // Style
-                font.pixelSize: hifi.fontSizes.textFieldInput
-                font.family: ralewayRegular.name
-                color: hifi.colors.darkGray
-                wrapMode: Text.WordWrap
-                textFormat: Text.StyledText
             }
         }
     }

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -164,7 +164,7 @@ Item {
                 text: thisNameCard.displayName
                 elide: Text.ElideRight
                 // Size
-                width: Math.min(displayNameTextMetrics.tightBoundingRect.width, parent.width - adminLabelText.width - adminLabelQuestionMark.width)
+                width: isAdmin ? Math.min(displayNameTextMetrics.tightBoundingRect.width + 8, parent.width - adminLabelText.width - adminLabelQuestionMark.width + 8) : parent.width
                 // Anchors
                 anchors.top: parent.top
                 anchors.left: parent.left
@@ -183,13 +183,13 @@ Item {
             // "ADMIN" label for other users' cards
             RalewaySemiBold {
                 id: adminLabelText
+                visible: isAdmin
                 text: "ADMIN"
                 // Text size
                 size: displayNameText.size - 4
                 // Anchors
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: displayNameText.right
-                anchors.leftMargin: 8
                 // Style
                 font.capitalization: Font.AllUppercase
                 color: hifi.colors.redHighlight
@@ -200,6 +200,7 @@ Item {
             // This Rectangle refers to the [?] popup button next to "ADMIN"
             Item {
                 id: adminLabelQuestionMark
+                visible: isAdmin
                 // Size
                 width: 20
                 height: displayNameText.height

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -221,9 +221,9 @@ Item {
                     anchors.fill: parent
                     acceptedButtons: Qt.LeftButton
                     hoverEnabled: true
-                    onClicked: letterbox("This user is an admin on this domain. Admins can <b>Silence</b> and <b>Ban</b> other users at their discretion - so be extra nice!",
-                    hifi.glyphs.question,
-                    "Domain Admin")
+                    onClicked: letterbox(hifi.glyphs.question,
+                    "Domain Admin",
+                    "This user is an admin on this domain. Admins can <b>Silence</b> and <b>Ban</b> other users at their discretion - so be extra nice!")
                     onEntered: adminLabelQuestionMarkText.color = "#94132e"
                     onExited: adminLabelQuestionMarkText.color = hifi.colors.redHighlight
                 }

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -33,6 +33,7 @@ Item {
     property real audioLevel: 0.0
     property bool isMyCard: false
     property bool selected: false
+    property bool isAdmin: false
 
     /* User image commented out for now - will probably be re-introduced later.
     Column {
@@ -139,32 +140,84 @@ Item {
             }
         }
         // Spacer for DisplayName for my card
-        Rectangle {
+        Item {
             id: myDisplayNameSpacer
-            width: myDisplayName.width
+            width: 1
+            height: 4
             // Anchors
             anchors.top: myDisplayName.bottom
-            height: 5
-            visible: isMyCard
-            opacity: 0
         }
-        // DisplayName Text for others' cards
-        FiraSansSemiBold {
-            id: displayNameText
-            // Properties
-            text: thisNameCard.displayName
-            elide: Text.ElideRight
+        // DisplayName container for others' cards
+        Item {
+            id: displayNameContainer
             visible: !isMyCard
             // Size
             width: parent.width
+            height: displayNameTextPixelSize + 4
             // Anchors
             anchors.top: parent.top
-            // Text Size
-            size: displayNameTextPixelSize
-            // Text Positioning
-            verticalAlignment: Text.AlignVCenter
-            // Style
-            color: hifi.colors.darkGray
+            anchors.left: parent.left
+            // DisplayName Text for others' cards
+            FiraSansSemiBold {
+                id: displayNameText
+                // Properties
+                text: thisNameCard.displayName
+                elide: Text.ElideRight
+                // Anchors
+                anchors.top: parent.top
+                anchors.left: parent.left
+                // Text Size
+                size: displayNameTextPixelSize
+                // Text Positioning
+                verticalAlignment: Text.AlignVCenter
+                // Style
+                color: hifi.colors.darkGray
+            }
+            // "ADMIN" label for other users' cards
+            RalewaySemiBold {
+                id: adminLabelText
+                text: "ADMIN"
+                // Text size
+                size: displayNameText.size - 4
+                // Anchors
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: displayNameText.right
+                anchors.leftMargin: 8
+                // Style
+                font.capitalization: Font.AllUppercase
+                color: hifi.colors.redHighlight
+                // Alignment
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignTop
+            }
+            // This Rectangle refers to the [?] popup button next to "ADMIN"
+            Item {
+                // Size
+                width: 20
+                height: displayNameText.height
+                // Anchors
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: adminLabelText.right
+                RalewayRegular {
+                    id: adminLabelQuestionMark
+                    text: "[?]"
+                    size: adminLabelText.size
+                    font.capitalization: Font.AllUppercase
+                    color: hifi.colors.redHighlight
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    anchors.fill: parent
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton
+                    hoverEnabled: true
+                    onClicked: letterbox('Silencing a user mutes their microphone. Silenced users can unmute themselves by clicking the "UNMUTE" button on their HUD.\n\n' +
+                                            "Banning a user will remove them from this domain and prevent them from returning. You can un-ban users from your domain's settings page.)")
+                    onEntered: adminLabelQuestionMark.color = "#94132e"
+                    onExited: adminLabelQuestionMark.color = hifi.colors.redHighlight
+                }
+            }
         }
 
         // UserName Text
@@ -177,7 +230,7 @@ Item {
             // Size
             width: parent.width
             // Anchors
-            anchors.top: isMyCard ? myDisplayNameSpacer.bottom : displayNameText.bottom
+            anchors.top: isMyCard ? myDisplayNameSpacer.bottom : displayNameContainer.bottom
             // Text Size
             size: thisNameCard.usernameTextHeight
             // Text Positioning
@@ -188,7 +241,7 @@ Item {
 
         // Spacer
         Item {
-            id: spacer
+            id: userNameSpacer
             height: 4
             width: parent.width
             // Anchors
@@ -202,7 +255,7 @@ Item {
             width: isMyCard ? myDisplayName.width - 20 : ((gainSlider.value - gainSlider.minimumValue)/(gainSlider.maximumValue - gainSlider.minimumValue)) * parent.width
             height: 8
             // Anchors
-            anchors.top: spacer.bottom
+            anchors.top: userNameSpacer.bottom
             // Style
             radius: 4
             color: "#c5c5c5"

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -220,7 +220,9 @@ Item {
                     anchors.fill: parent
                     acceptedButtons: Qt.LeftButton
                     hoverEnabled: true
-                    onClicked: letterbox("This user is an admin on this domain. Admins can <b>Silence</b> and <b>Ban</b> other users at their discretion - so be extra nice!", hifi.glyphs.question, "Domain Admin")
+                    onClicked: letterbox("This user is an admin on this domain. Admins can <b>Silence</b> and <b>Ban</b> other users at their discretion - so be extra nice!",
+                    hifi.glyphs.question,
+                    "Domain Admin")
                     onEntered: adminLabelQuestionMarkText.color = "#94132e"
                     onExited: adminLabelQuestionMarkText.color = hifi.colors.redHighlight
                 }

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -261,7 +261,7 @@ Item {
         Rectangle {
             id: nameCardVUMeter
             // Size
-            width: isMyCard ? myDisplayName.width - 20 : ((gainSlider.value - gainSlider.minimumValue)/(gainSlider.maximumValue - gainSlider.minimumValue)) * parent.width
+            width: isMyCard ? myDisplayName.width - 70 : ((gainSlider.value - gainSlider.minimumValue)/(gainSlider.maximumValue - gainSlider.minimumValue)) * parent.width
             height: 8
             // Anchors
             anchors.top: userNameSpacer.bottom

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -163,6 +163,8 @@ Item {
                 // Properties
                 text: thisNameCard.displayName
                 elide: Text.ElideRight
+                // Size
+                width: Math.min(displayNameTextMetrics.tightBoundingRect.width, parent.width - adminLabelText.width - adminLabelQuestionMark.width)
                 // Anchors
                 anchors.top: parent.top
                 anchors.left: parent.left
@@ -172,6 +174,11 @@ Item {
                 verticalAlignment: Text.AlignVCenter
                 // Style
                 color: hifi.colors.darkGray
+            }
+            TextMetrics {
+                id:     displayNameTextMetrics
+                font:   displayNameText.font
+                text:   displayNameText.text
             }
             // "ADMIN" label for other users' cards
             RalewaySemiBold {
@@ -192,6 +199,7 @@ Item {
             }
             // This Rectangle refers to the [?] popup button next to "ADMIN"
             Item {
+                id: adminLabelQuestionMark
                 // Size
                 width: 20
                 height: displayNameText.height
@@ -199,7 +207,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: adminLabelText.right
                 RalewayRegular {
-                    id: adminLabelQuestionMark
+                    id: adminLabelQuestionMarkText
                     text: "[?]"
                     size: adminLabelText.size
                     font.capitalization: Font.AllUppercase
@@ -212,10 +220,9 @@ Item {
                     anchors.fill: parent
                     acceptedButtons: Qt.LeftButton
                     hoverEnabled: true
-                    onClicked: letterbox('Silencing a user mutes their microphone. Silenced users can unmute themselves by clicking the "UNMUTE" button on their HUD.\n\n' +
-                                            "Banning a user will remove them from this domain and prevent them from returning. You can un-ban users from your domain's settings page.)")
-                    onEntered: adminLabelQuestionMark.color = "#94132e"
-                    onExited: adminLabelQuestionMark.color = hifi.colors.redHighlight
+                    onClicked: letterbox("This user is an admin on this domain. Admins can <b>Silence</b> and <b>Ban</b> other users at their discretion - so be extra nice!", hifi.glyphs.question, "Domain Admin")
+                    onEntered: adminLabelQuestionMarkText.color = "#94132e"
+                    onExited: adminLabelQuestionMarkText.color = hifi.colors.redHighlight
                 }
             }
         }

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -221,6 +221,7 @@ Rectangle {
                 visible: !isCheckBox && !isButton
                 uuid: model && model.sessionId
                 selected: styleData.selected
+                isAdmin: model && model.isAdmin
                 // Size
                 width: nameCardWidth
                 height: parent.height
@@ -465,6 +466,7 @@ Rectangle {
             var userId = message.params[0];
             // The text that goes in the userName field is the second parameter in the message.
             var userName = message.params[1];
+            var isAdmin = message.params[2];
             // If the userId is empty, we're updating "myData".
             if (!userId) {
                 myData.userName = userName;
@@ -476,6 +478,9 @@ Rectangle {
                     // Set the userName appropriately
                     userModel.setProperty(userIndex, "userName", userName);
                     userModelData[userIndex].userName = userName; // Defensive programming
+                    // Set the admin status appropriately
+                    userModel.setProperty(userIndex, "isAdmin", isAdmin);
+                    userModelData[userIndex].isAdmin = isAdmin; // Defensive programming
                 } else {
                     console.log("updateUsername() called with unknown UUID: ", userId);
                 }

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -28,7 +28,7 @@ Rectangle {
     property int rowHeight: 70
     property int actionButtonWidth: 75
     property int nameCardWidth: palContainer.width - actionButtonWidth*(iAmAdmin ? 4 : 2) - 4 - hifi.dimensions.scrollbarBackgroundWidth
-    property var myData: ({displayName: "", userName: "", audioLevel: 0.0}) // valid dummy until set
+    property var myData: ({displayName: "", userName: "", audioLevel: 0.0, admin: true}) // valid dummy until set
     property var ignored: ({}); // Keep a local list of ignored avatars & their data. Necessary because HashMap is slow to respond after ignoring.
     property var userModelData: [] // This simple list is essentially a mirror of the userModel listModel without all the extra complexities.
     property bool iAmAdmin: false
@@ -223,7 +223,7 @@ Rectangle {
                 visible: !isCheckBox && !isButton
                 uuid: model && model.sessionId
                 selected: styleData.selected
-                isAdmin: model && model.isAdmin
+                isAdmin: model && model.admin
                 // Size
                 width: nameCardWidth
                 height: parent.height
@@ -472,7 +472,7 @@ Rectangle {
             var userId = message.params[0];
             // The text that goes in the userName field is the second parameter in the message.
             var userName = message.params[1];
-            var isAdmin = message.params[2];
+            var admin = message.params[2];
             // If the userId is empty, we're updating "myData".
             if (!userId) {
                 myData.userName = userName;
@@ -485,8 +485,8 @@ Rectangle {
                     userModel.setProperty(userIndex, "userName", userName);
                     userModelData[userIndex].userName = userName; // Defensive programming
                     // Set the admin status appropriately
-                    userModel.setProperty(userIndex, "isAdmin", isAdmin);
-                    userModelData[userIndex].isAdmin = isAdmin; // Defensive programming
+                    userModel.setProperty(userIndex, "admin", admin);
+                    userModelData[userIndex].admin = admin; // Defensive programming
                 } else {
                     console.log("updateUsername() called with unknown UUID: ", userId);
                 }

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -403,8 +403,10 @@ Rectangle {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             hoverEnabled: true
-            onClicked: letterbox('Silencing a user mutes their microphone. Silenced users can unmute themselves by clicking the "UNMUTE" button on their HUD.\n\n' +
-                                 "Banning a user will remove them from this domain and prevent them from returning. You can un-ban users from your domain's settings page.)", "", "")
+            onClicked: letterbox("<b>Silence</b> mutes a user's microphone. Silenced users can unmute themselves by clicking &quot;UNMUTE&quot; on their toolbar.<br><br>" +
+                                 "<b>Ban</b> removes a user from this domain and prevents them from returning. Admins can un-ban users from the Sandbox Domain Settings Page.)",
+                                 hifi.glyphs.question,
+                                 "Admin Actions")
             onEntered: adminHelpText.color = "#94132e"
             onExited: adminHelpText.color = hifi.colors.redHighlight
         }

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -372,9 +372,11 @@ Rectangle {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             hoverEnabled: true
-            onClicked: letterbox("Bold names in the list are Avatar Display Names.\n" +
-                                 "If a Display Name isn't set, a unique Session Display Name is assigned." +
-                                 "\n\nAdministrators of this domain can also see the Username or Machine ID associated with each avatar present.", "", "")
+            onClicked: letterbox("Bold names in the list are <b>avatar display names</b>.<br>" +
+                                 "If a display name isn't set, a unique <b>session display name</b> is assigned." +
+                                 "<br><br>Administrators of this domain can also see the <b>username</b> or <b>machine ID</b> associated with each avatar present.", 
+                                 hifi.glyphs.question,
+                                 "Display Names")
             onEntered: helpText.color = hifi.colors.baseGrayHighlight
             onExited: helpText.color = hifi.colors.darkGray
         }
@@ -404,7 +406,7 @@ Rectangle {
             acceptedButtons: Qt.LeftButton
             hoverEnabled: true
             onClicked: letterbox("<b>Silence</b> mutes a user's microphone. Silenced users can unmute themselves by clicking &quot;UNMUTE&quot; on their toolbar.<br><br>" +
-                                 "<b>Ban</b> removes a user from this domain and prevents them from returning. Admins can un-ban users from the Sandbox Domain Settings Page.)",
+                                 "<b>Ban</b> removes a user from this domain and prevents them from returning. Admins can un-ban users from the Sandbox Domain Settings page.",
                                  hifi.glyphs.question,
                                  "Admin Actions")
             onEntered: adminHelpText.color = "#94132e"

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -487,8 +487,6 @@ Rectangle {
                     // Set the admin status appropriately
                     userModel.setProperty(userIndex, "admin", admin);
                     userModelData[userIndex].admin = admin; // Defensive programming
-                } else {
-                    console.log("updateUsername() called with unknown UUID: ", userId);
                 }
             }
             break;
@@ -504,8 +502,6 @@ Rectangle {
                     if (userIndex != -1) {
                         userModel.setProperty(userIndex, "audioLevel", audioLevel);
                         userModelData[userIndex].audioLevel = audioLevel; // Defensive programming
-                    } else {
-                        console.log("updateAudioLevel() called with unknown UUID: ", userId);
                     }
                 }
             }

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -41,10 +41,10 @@ Rectangle {
         id: letterboxMessage
         z: 999 // Force the popup on top of everything else
     }
-    function letterbox(message, headerGlyph, headerText) {
-        letterboxMessage.text = message
+    function letterbox(headerGlyph, headerText, message) {
         letterboxMessage.headerGlyph = headerGlyph
         letterboxMessage.headerText = headerText
+        letterboxMessage.text = message
         letterboxMessage.visible = true
         letterboxMessage.popupRadius = 0
     }
@@ -372,11 +372,11 @@ Rectangle {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             hoverEnabled: true
-            onClicked: letterbox("Bold names in the list are <b>avatar display names</b>.<br>" +
+            onClicked: letterbox(hifi.glyphs.question,
+                                 "Display Names",
+                                 "Bold names in the list are <b>avatar display names</b>.<br>" +
                                  "If a display name isn't set, a unique <b>session display name</b> is assigned." +
-                                 "<br><br>Administrators of this domain can also see the <b>username</b> or <b>machine ID</b> associated with each avatar present.", 
-                                 hifi.glyphs.question,
-                                 "Display Names")
+                                 "<br><br>Administrators of this domain can also see the <b>username</b> or <b>machine ID</b> associated with each avatar present.")
             onEntered: helpText.color = hifi.colors.baseGrayHighlight
             onExited: helpText.color = hifi.colors.darkGray
         }
@@ -405,10 +405,10 @@ Rectangle {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             hoverEnabled: true
-            onClicked: letterbox("<b>Silence</b> mutes a user's microphone. Silenced users can unmute themselves by clicking &quot;UNMUTE&quot; on their toolbar.<br><br>" +
-                                 "<b>Ban</b> removes a user from this domain and prevents them from returning. Admins can un-ban users from the Sandbox Domain Settings page.",
-                                 hifi.glyphs.question,
-                                 "Admin Actions")
+            onClicked: letterbox(hifi.glyphs.question,
+                                 "Admin Actions",
+                                 "<b>Silence</b> mutes a user's microphone. Silenced users can unmute themselves by clicking &quot;UNMUTE&quot; on their toolbar.<br><br>" +
+                                 "<b>Ban</b> removes a user from this domain and prevents them from returning. Admins can un-ban users from the Sandbox Domain Settings page.")
             onEntered: adminHelpText.color = "#94132e"
             onExited: adminHelpText.color = hifi.colors.redHighlight
         }
@@ -453,9 +453,9 @@ Rectangle {
             var selected = message.params[1];
             var userIndex = findSessionIndex(sessionIds[0]);
             if (sessionIds.length > 1) {
-                letterbox('Only one user can be selected at a time.', "", "");
+                letterbox("", "", 'Only one user can be selected at a time.');
             } else if (userIndex < 0) {
-                letterbox('The last editor is not among this list of users.', "", "");
+                letterbox("", "", 'The last editor is not among this list of users.');
             } else {
                 if (selected) {
                     table.selection.clear(); // for now, no multi-select

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -41,8 +41,10 @@ Rectangle {
         id: letterboxMessage
         z: 999 // Force the popup on top of everything else
     }
-    function letterbox(message) {
+    function letterbox(message, headerGlyph, headerText) {
         letterboxMessage.text = message
+        letterboxMessage.headerGlyph = headerGlyph
+        letterboxMessage.headerText = headerText
         letterboxMessage.visible = true
         letterboxMessage.popupRadius = 0
     }
@@ -372,7 +374,7 @@ Rectangle {
             hoverEnabled: true
             onClicked: letterbox("Bold names in the list are Avatar Display Names.\n" +
                                  "If a Display Name isn't set, a unique Session Display Name is assigned." +
-                                 "\n\nAdministrators of this domain can also see the Username or Machine ID associated with each avatar present.")
+                                 "\n\nAdministrators of this domain can also see the Username or Machine ID associated with each avatar present.", "", "")
             onEntered: helpText.color = hifi.colors.baseGrayHighlight
             onExited: helpText.color = hifi.colors.darkGray
         }
@@ -402,7 +404,7 @@ Rectangle {
             acceptedButtons: Qt.LeftButton
             hoverEnabled: true
             onClicked: letterbox('Silencing a user mutes their microphone. Silenced users can unmute themselves by clicking the "UNMUTE" button on their HUD.\n\n' +
-                                 "Banning a user will remove them from this domain and prevent them from returning. You can un-ban users from your domain's settings page.)")
+                                 "Banning a user will remove them from this domain and prevent them from returning. You can un-ban users from your domain's settings page.)", "", "")
             onEntered: adminHelpText.color = "#94132e"
             onExited: adminHelpText.color = hifi.colors.redHighlight
         }
@@ -447,9 +449,9 @@ Rectangle {
             var selected = message.params[1];
             var userIndex = findSessionIndex(sessionIds[0]);
             if (sessionIds.length > 1) {
-                letterbox('Only one user can be selected at a time.');
+                letterbox('Only one user can be selected at a time.', "", "");
             } else if (userIndex < 0) {
-                letterbox('The last editor is not among this list of users.');
+                letterbox('The last editor is not among this list of users.', "", "");
             } else {
                 if (selected) {
                     table.selection.clear(); // for now, no multi-select
@@ -499,7 +501,7 @@ Rectangle {
                         userModel.setProperty(userIndex, "audioLevel", audioLevel);
                         userModelData[userIndex].audioLevel = audioLevel; // Defensive programming
                     } else {
-                        console.log("updateUsername() called with unknown UUID: ", userId);
+                        console.log("updateAudioLevel() called with unknown UUID: ", userId);
                     }
                 }
             }

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -1040,25 +1040,20 @@ void NodeList::muteNodeBySessionID(const QUuid& nodeID) {
 }
 
 void NodeList::requestUsernameFromSessionID(const QUuid& nodeID) {
-    // send a request to domain-server to get the username associated with the given session ID
-    if (getThisNodeCanKick() || nodeID.isNull()) {
-        // setup the packet
-        auto usernameFromIDRequestPacket = NLPacket::create(PacketType::UsernameFromIDRequest, NUM_BYTES_RFC4122_UUID, true);
+    // send a request to domain-server to get the username/machine fingerprint/admin status associated with the given session ID
+    // If the requesting user isn't an admin, the username and machine fingerprint will return "".
+    auto usernameFromIDRequestPacket = NLPacket::create(PacketType::UsernameFromIDRequest, NUM_BYTES_RFC4122_UUID, true);
 
-        // write the node ID to the packet
-        if (nodeID.isNull()) {
-            usernameFromIDRequestPacket->write(getSessionUUID().toRfc4122());
-        } else {
-            usernameFromIDRequestPacket->write(nodeID.toRfc4122());
-        }
-
-        qCDebug(networking) << "Sending packet to get username of node" << uuidStringWithoutCurlyBraces(nodeID);
-
-        sendPacket(std::move(usernameFromIDRequestPacket), _domainHandler.getSockAddr());
+    // write the node ID to the packet
+    if (nodeID.isNull()) {
+        usernameFromIDRequestPacket->write(getSessionUUID().toRfc4122());
     } else {
-        qWarning() << "You do not have permissions to kick in this domain."
-            << "Request to get the username of node" << uuidStringWithoutCurlyBraces(nodeID) << "will not be sent";
+        usernameFromIDRequestPacket->write(nodeID.toRfc4122());
     }
+
+    qCDebug(networking) << "Sending packet to get username/fingerprint/admin status of node" << uuidStringWithoutCurlyBraces(nodeID);
+
+    sendPacket(std::move(usernameFromIDRequestPacket), _domainHandler.getSockAddr());
 }
 
 void NodeList::processUsernameFromIDReply(QSharedPointer<ReceivedMessage> message) {
@@ -1071,7 +1066,8 @@ void NodeList::processUsernameFromIDReply(QSharedPointer<ReceivedMessage> messag
     bool isAdmin;
     message->readPrimitive(&isAdmin);
 
-    qCDebug(networking) << "Got username" << username << "and machine fingerprint" << machineFingerprintString << "for node" << nodeUUIDString;
+    qCDebug(networking) << "Got username" << username << "and machine fingerprint"
+        << machineFingerprintString << "for node" << nodeUUIDString << ". isAdmin:" << isAdmin;
 
     emit usernameFromIDReply(nodeUUIDString, username, machineFingerprintString, isAdmin);
 }

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -1068,10 +1068,12 @@ void NodeList::processUsernameFromIDReply(QSharedPointer<ReceivedMessage> messag
     QString username = message->readString();
     // read the machine fingerprint from the packet
     QString machineFingerprintString = (QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID))).toString();
+    bool isAdmin;
+    message->readPrimitive(&isAdmin);
 
     qCDebug(networking) << "Got username" << username << "and machine fingerprint" << machineFingerprintString << "for node" << nodeUUIDString;
 
-    emit usernameFromIDReply(nodeUUIDString, username, machineFingerprintString);
+    emit usernameFromIDReply(nodeUUIDString, username, machineFingerprintString, isAdmin);
 }
 
 void NodeList::setRequestsDomainListData(bool isRequesting) {

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -120,7 +120,7 @@ signals:
     void receivedDomainServerList();
     void ignoredNode(const QUuid& nodeID, bool enabled);
     void ignoreRadiusEnabledChanged(bool isIgnored);
-    void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint);
+    void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint, bool isAdmin);
 
 private slots:
     void stopKeepalivePingTimer();

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -135,9 +135,10 @@ signals:
 
     /**jsdoc
     * Notifies scripts of the username and machine fingerprint associated with a UUID.
+    * Username and machineFingerprint will be empty strings if the requesting user isn't an admin.
     * @function Users.usernameFromIDReply
     */
-    void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint);
+    void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint, bool isAdmin);
 
     /**jsdoc
      * Notifies scripts that a user has disconnected from the domain

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -135,7 +135,7 @@ signals:
 
     /**jsdoc
     * Notifies scripts of the username and machine fingerprint associated with a UUID.
-    * Username and machineFingerprint will be empty strings if the requesting user isn't an admin.
+    * Username and machineFingerprint will be their default constructor output if the requesting user isn't an admin.
     * @function Users.usernameFromIDReply
     */
     void usernameFromIDReply(const QString& nodeID, const QString& username, const QString& machineFingerprint, bool isAdmin);

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -271,7 +271,7 @@ function populateUserList() {
             admin: false
         };
         // Request the username, fingerprint, and admin status from the given UUID
-        // Username and fingerprint returns "" if the requesting user isn't an admin
+        // Username and fingerprint returns default constructor output if the requesting user isn't an admin
         Users.requestUsernameFromID(id);
         // Request personal mute status and ignore status
         // from NodeList (as long as we're not requesting it for our own ID)
@@ -292,13 +292,15 @@ function usernameFromIDReply(id, username, machineFingerprint, isAdmin) {
     // If the ID we've received is our ID...
     if (MyAvatar.sessionUUID === id) {
         // Set the data to contain specific strings.
-        data = ['', username];
-    } else {
+        data = ['', username, isAdmin];
+    } else if (Users.canKick) {
         // Set the data to contain the ID and the username (if we have one)
         // or fingerprint (if we don't have a username) string.
-        data = [id, username || machineFingerprint];
+        data = [id, username || machineFingerprint, isAdmin];
+    } else {
+        // Set the data to contain specific strings.
+        data = [id, '', isAdmin];
     }
-    data.push(isAdmin);
     print('Username Data:', JSON.stringify(data));
     // Ship the data off to QML
     pal.sendToQml({ method: 'updateUsername', params: data });

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -267,7 +267,8 @@ function populateUserList() {
             displayName: avatar.sessionDisplayName,
             userName: '',
             sessionId: id || '',
-            audioLevel: 0.0
+            audioLevel: 0.0,
+            admin: false
         };
         // Request the username, fingerprint, and admin status from the given UUID
         // Username and fingerprint returns "" if the requesting user isn't an admin

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -269,12 +269,9 @@ function populateUserList() {
             sessionId: id || '',
             audioLevel: 0.0
         };
-        // If the current user is an admin OR
-        // they're requesting their own username ("id" is blank)...
-        if (Users.canKick || !id) {
-            // Request the username from the given UUID
-            Users.requestUsernameFromID(id);
-        }
+        // Request the username, fingerprint, and admin status from the given UUID
+        // Username and fingerprint returns "" if the requesting user isn't an admin
+        Users.requestUsernameFromID(id);
         // Request personal mute status and ignore status
         // from NodeList (as long as we're not requesting it for our own ID)
         if (id) {
@@ -289,7 +286,7 @@ function populateUserList() {
 }
 
 // The function that handles the reply from the server
-function usernameFromIDReply(id, username, machineFingerprint) {
+function usernameFromIDReply(id, username, machineFingerprint, isAdmin) {
     var data;
     // If the ID we've received is our ID...
     if (MyAvatar.sessionUUID === id) {
@@ -300,6 +297,7 @@ function usernameFromIDReply(id, username, machineFingerprint) {
         // or fingerprint (if we don't have a username) string.
         data = [id, username || machineFingerprint];
     }
+    data.push(isAdmin);
     print('Username Data:', JSON.stringify(data));
     // Ship the data off to QML
     pal.sendToQml({ method: 'updateUsername', params: data });

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -497,7 +497,6 @@ function getAudioLevel(id) {
     var audioLevel = 0.0;
     var data = id ? ExtendedOverlay.get(id) : myData;
     if (!data) {
-        print('no data for', id);
         return audioLevel;
     }
 


### PR DESCRIPTION
This PR adds "ADMIN" labels to the right of Display Names on PAL cards corresponding to domain administrators. This PR also updates the visual style of the letterbox popups that appear when clicking on "[?]" buttons (and in some error cases).

**Test Plan**
This test plan requires two clients running this PR: Clients A and B. Run Sandbox from Client A; Client A will have admin privileges on the domain.
* On Clients A and B, join Sandbox A
* Open the PAL on both clients
* On Client A, verify that both Client A's and Client B's usernames appear below their display names in the PAL.
* On Client B, verify that only Client B's username appears below their display name in the PAL.
* On Client A, use the PAL to change its display name to something very long, like "TESTING TESTING TESTING TESTING".
* On Client B, refresh the PAL. Verify the presence of an "ADMIN [?]" label to the right of Client A's elided display name
* Change Client A's display name to something short, like "Test".
* On Client B, refresh the PAL. Verify that the "ADMIN [?]" label is still present to the right of Client A's un-elided display name.
* On Client A, verify that there is no label to the right of Client B's display name
* On Client B, click on the "[?]" button to the right of the "ADMIN" text. Verify that the popup appears and looks better than the old letterbox :smile:. Close the popup by clicking anywhere within the PAL.
* On Client B, click the "[?]" button to the right of the "USERS" header text. Verify that the popup appears and looks better than the old letterbox. Close the popup.
* On Client A, click the "[?]" button to the right of the "ADMIN" tab text. Verify that the popup appears and looks better than the old letterbox. Close the popup.

Thanks for your QAing help! :+1: