### PR TITLE
Create render forward version of pixel shaders

### DIFF
--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -34,6 +34,13 @@
 #include "model_normal_map_frag.h"
 #include "model_normal_specular_map_frag.h"
 #include "model_specular_map_frag.h"
+
+#include "forward_model_frag.h"
+#include "forward_model_unlit_frag.h"
+#include "forward_model_normal_map_frag.h"
+#include "forward_model_normal_specular_map_frag.h"
+#include "forward_model_specular_map_frag.h"
+
 #include "model_lightmap_frag.h"
 #include "model_lightmap_normal_map_frag.h"
 #include "model_lightmap_normal_specular_map_frag.h"
@@ -227,11 +234,11 @@ void initForwardPipelines(render::ShapePlumber& plumber) {
     auto skinModelNormalMapVertex = gpu::Shader::createVertex(std::string(skin_model_normal_map_vert));
 
     // Pixel shaders
-    auto modelPixel = gpu::Shader::createPixel(std::string(model_frag));
-    auto modelUnlitPixel = gpu::Shader::createPixel(std::string(model_unlit_frag));
-    auto modelNormalMapPixel = gpu::Shader::createPixel(std::string(model_normal_map_frag));
-    auto modelSpecularMapPixel = gpu::Shader::createPixel(std::string(model_specular_map_frag));
-    auto modelNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(model_normal_specular_map_frag));
+    auto modelPixel = gpu::Shader::createPixel(std::string(forward_model_frag));
+    auto modelUnlitPixel = gpu::Shader::createPixel(std::string(forward_model_unlit_frag));
+    auto modelNormalMapPixel = gpu::Shader::createPixel(std::string(forward_model_normal_map_frag));
+    auto modelSpecularMapPixel = gpu::Shader::createPixel(std::string(forward_model_specular_map_frag));
+    auto modelNormalSpecularMapPixel = gpu::Shader::createPixel(std::string(forward_model_normal_specular_map_frag));
 
     using Key = render::ShapeKey;
     auto addPipeline = std::bind(&addPlumberPipeline, std::ref(plumber), _1, _2, _3);

--- a/libraries/render-utils/src/forward_model.slf
+++ b/libraries/render-utils/src/forward_model.slf
@@ -1,0 +1,59 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//  model.frag
+//  fragment shader
+//
+//  Created by Andrzej Kapolka on 10/14/13.
+//  Copyright 2013 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+
+<@include model/Material.slh@>
+
+<@include MaterialTextures.slh@>
+<$declareMaterialTextures(ALBEDO, ROUGHNESS, _SCRIBE_NULL, _SCRIBE_NULL, EMISSIVE, OCCLUSION)$>
+
+in vec4 _position;
+in vec3 _normal;
+in vec3 _color;
+in vec2 _texCoord0;
+in vec2 _texCoord1;
+
+
+void main(void) {
+    Material mat = getMaterial();
+    int matKey = getMaterialKey(mat);
+    <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, _SCRIBE_NULL, emissiveTex)$>
+    <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
+
+    float opacity = 1.0;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color;
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+
+    vec3 emissive = getMaterialEmissive(mat);
+    <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
+
+    float scattering = getMaterialScattering(mat);
+
+    packDeferredFragment(
+        normalize(_normal.xyz), 
+        opacity,
+        albedo,
+        roughness,
+        getMaterialMetallic(mat),
+        emissive,
+        occlusionTex,
+        scattering);
+}

--- a/libraries/render-utils/src/forward_model_normal_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_map.slf
@@ -1,0 +1,64 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  model_normal_map.frag
+//  fragment shader
+//
+//  Created by Andrzej Kapolka on 10/29/13.
+//  Copyright 2013 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+
+<@include model/Material.slh@>
+
+<@include MaterialTextures.slh@>
+<$declareMaterialTextures(ALBEDO, ROUGHNESS, NORMAL, _SCRIBE_NULL, EMISSIVE, OCCLUSION, SCATTERING)$>
+
+in vec4 _position;
+in vec2 _texCoord0;
+in vec2 _texCoord1;
+in vec3 _normal;
+in vec3 _tangent;
+in vec3 _color;
+
+void main(void) {
+    Material mat = getMaterial();
+    int matKey = getMaterialKey(mat);
+    <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, _SCRIBE_NULL, emissiveTex, scatteringTex)$>
+    <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
+
+    float opacity = 1.0;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color;
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+
+    vec3 emissive = getMaterialEmissive(mat);
+    <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
+
+    vec3 viewNormal;
+    <$tangentToViewSpace(normalTex, _normal, _tangent, viewNormal)$>
+
+    float scattering = getMaterialScattering(mat);
+    <$evalMaterialScattering(scatteringTex, scattering, matKey, scattering)$>;
+
+    packDeferredFragment(
+        viewNormal, 
+        opacity,
+        albedo,
+        roughness,
+        getMaterialMetallic(mat),
+        emissive,
+        occlusionTex,
+        scattering);
+}

--- a/libraries/render-utils/src/forward_model_normal_specular_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_specular_map.slf
@@ -1,0 +1,66 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  model_normal_specular_map.frag
+//  fragment shader
+//
+//  Created by Andrzej Kapolka on 5/6/14.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+
+<@include model/Material.slh@>
+
+<@include MaterialTextures.slh@>
+<$declareMaterialTextures(ALBEDO, ROUGHNESS, NORMAL, METALLIC, EMISSIVE, OCCLUSION)$>
+
+in vec4 _position;
+in vec2 _texCoord0;
+in vec2 _texCoord1;
+in vec3 _normal;
+in vec3 _tangent;
+in vec3 _color;
+
+void main(void) {
+    Material mat = getMaterial();
+    int matKey = getMaterialKey(mat);
+    <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex)$>
+    <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
+
+    float opacity = 1.0;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)&>;
+    <$discardTransparent(opacity)$>;
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color;
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+
+    vec3 emissive = getMaterialEmissive(mat);
+    <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
+
+    vec3 viewNormal;
+    <$tangentToViewSpace(normalTex, _normal, _tangent, viewNormal)$>
+
+    float metallic = getMaterialMetallic(mat);
+    <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
+
+    float scattering = getMaterialScattering(mat);
+
+    packDeferredFragment(
+        normalize(viewNormal.xyz), 
+        opacity,
+        albedo,
+        roughness,
+        metallic,
+        emissive,
+        occlusionTex,
+        scattering);
+}

--- a/libraries/render-utils/src/forward_model_specular_map.slf
+++ b/libraries/render-utils/src/forward_model_specular_map.slf
@@ -1,0 +1,63 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  model_specular_map.frag
+//  fragment shader
+//
+//  Created by Andrzej Kapolka on 5/6/14.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+
+<@include model/Material.slh@>
+
+<@include MaterialTextures.slh@>
+<$declareMaterialTextures(ALBEDO, ROUGHNESS, _SCRIBE_NULL, METALLIC, EMISSIVE, OCCLUSION)$>
+
+in vec4 _position;
+in vec2 _texCoord0;
+in vec2 _texCoord1;
+in vec3 _normal;
+in vec3 _color;
+
+
+void main(void) {
+    Material mat = getMaterial();
+    int matKey = getMaterialKey(mat);
+    <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
+    <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
+
+    float opacity = 1.0;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color;
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+
+    vec3 emissive = getMaterialEmissive(mat);
+    <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
+
+    float metallic = getMaterialMetallic(mat);
+    <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
+
+    float scattering = getMaterialScattering(mat);
+
+    packDeferredFragment(
+        normalize(_normal), 
+        opacity,
+        albedo,
+        roughness,
+        metallic,
+        emissive,
+        occlusionTex,
+        scattering);
+}

--- a/libraries/render-utils/src/forward_model_unlit.slf
+++ b/libraries/render-utils/src/forward_model_unlit.slf
@@ -1,0 +1,45 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  material_opaque_unlit.frag
+//  fragment shader
+//
+//  Created by Sam Gateau on 5/5/2016.
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+<@include LightingModel.slh@>
+<@include model/Material.slh@>
+
+<@include MaterialTextures.slh@>
+<$declareMaterialTextures(ALBEDO)$>
+
+in vec2 _texCoord0;
+in vec3 _normal;
+in vec3 _color;
+in float _alpha;
+
+void main(void) {
+
+    Material mat = getMaterial();
+    int matKey = getMaterialKey(mat);
+    <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
+
+    float opacity = 1.0;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color;
+
+    packDeferredFragmentUnlit(
+        normalize(_normal), 
+        opacity,
+        albedo * isUnlitEnabled());
+}


### PR DESCRIPTION
Create a duplicated version of pixel shaders for forward rendering pipeline

- forward_model_frag
- forward_model_unlit_frag
- forward_model_normal_map_frag
- forward_model_normal_specular_map_frag
- forward_model_specular_map_frag


