### PR TITLE
Some initial analytics for PAL usage

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -283,7 +283,12 @@ Item {
             maximumValue: 20.0
             stepSize: 5
             updateValueWhileDragging: true
-            onValueChanged: updateGainFromQML(uuid, value)
+            onValueChanged: updateGainFromQML(uuid, value, false)
+            onPressedChanged: {
+                if (!pressed) {
+                    updateGainFromQML(uuid, value, true)
+                }
+            }
             MouseArea {
                 anchors.fill: parent
                 onWheel: {
@@ -297,7 +302,8 @@ Item {
                     mouse.accepted = false
                 }
                 onReleased: {
-                    // Pass through to Slider
+                    // the above mouse.accepted seems to make this 
+                    // never get called, nonetheless...
                     mouse.accepted = false
                 }
             }
@@ -319,12 +325,13 @@ Item {
         }
     }
 
-    function updateGainFromQML(avatarUuid, sliderValue) {
-        if (pal.gainSliderValueDB[avatarUuid] !== sliderValue) {
+    function updateGainFromQML(avatarUuid, sliderValue, isReleased) {
+        if (isReleased || pal.gainSliderValueDB[avatarUuid] !== sliderValue) {
             pal.gainSliderValueDB[avatarUuid] = sliderValue;
             var data = {
                 sessionId: avatarUuid,
-                gain: sliderValue
+                gain: sliderValue,
+                isReleased: isReleased
             };
             pal.sendToScript({method: 'updateGain', params: data});
         }

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -247,7 +247,7 @@ Rectangle {
                     userModel.setProperty(model.userIndex, styleData.role, newValue)
                     userModelData[model.userIndex][styleData.role] = newValue // Defensive programming
                     Users[styleData.role](model.sessionId, newValue)
-                    UserActivityLogger["palAction"](newValue ? "un-" + styleData.role : styleData.role, model.sessionId)
+                    UserActivityLogger["palAction"](newValue ? styleData.role : "un-" + styleData.role, model.sessionId)
                     if (styleData.role === "ignore") {
                         userModel.setProperty(model.userIndex, "personalMute", newValue)
                         userModelData[model.userIndex]["personalMute"] = newValue // Defensive programming

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -247,6 +247,7 @@ Rectangle {
                     userModel.setProperty(model.userIndex, styleData.role, newValue)
                     userModelData[model.userIndex][styleData.role] = newValue // Defensive programming
                     Users[styleData.role](model.sessionId, newValue)
+                    UserActivityLogger["palAction"](newValue ? "un-" + styleData.role : styleData.role, model.sessionId)
                     if (styleData.role === "ignore") {
                         userModel.setProperty(model.userIndex, "personalMute", newValue)
                         userModelData[model.userIndex]["personalMute"] = newValue // Defensive programming
@@ -273,6 +274,7 @@ Rectangle {
                 height: 24
                 onClicked: {
                     Users[styleData.role](model.sessionId)
+                    UserActivityLogger["palAction"](styleData.role, model.sessionId)
                     if (styleData.role === "kick") {
                         // Just for now, while we cannot undo "Ban":
                         userModel.remove(model.userIndex)

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1937,6 +1937,8 @@ void Application::initializeUi() {
     rootContext->setContextProperty("AvatarList", DependencyManager::get<AvatarManager>().data());
     rootContext->setContextProperty("Users", DependencyManager::get<UsersScriptingInterface>().data());
 
+    rootContext->setContextProperty("UserActivityLogger", DependencyManager::get<UserActivityLoggerScriptingInterface>().data());
+
     rootContext->setContextProperty("Camera", &_myCamera);
 
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -38,6 +38,21 @@ void UserActivityLoggerScriptingInterface::tutorialProgress( QString stepName, i
 
 }
 
+void UserActivityLoggerScriptingInterface::palAction(QString action, QString target) {
+    QJsonObject payload;
+    payload["action"] = action;
+    if (target.length() > 0) {
+        payload["target"] = target;
+    }
+    logAction("pal_activity", payload);
+}
+
+void UserActivityLoggerScriptingInterface::palOpened(float secondsOpened) {
+    logAction("pal_opened", { 
+        { "seconds_opened", secondsOpened }
+    });
+}
+
 void UserActivityLoggerScriptingInterface::logAction(QString action, QJsonObject details) {
     QMetaObject::invokeMethod(&UserActivityLogger::getInstance(), "logAction",
                               Q_ARG(QString, action),

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.h
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.h
@@ -25,7 +25,8 @@ public:
     Q_INVOKABLE void toggledAway(bool isAway);
     Q_INVOKABLE void tutorialProgress(QString stepName, int stepNumber, float secondsToComplete,
         float tutorialElapsedTime, QString tutorialRunID = "", int tutorialVersion = 0, QString controllerType = "");
-
+    Q_INVOKABLE void palAction(QString action, QString target);
+    Q_INVOKABLE void palOpened(float secondsOpen);
 private:
     void logAction(QString action, QJsonObject details = {});
 };


### PR DESCRIPTION
I track a few things:  
* duration the PAL was open
* select of an avatar (with the target uuid)
* ban, silence, mute, ignore (with the target uuid)
* refresh of pal
* display name change
* volume slider change 

Test Plan
Well first, you need to have a metabase account.  If you do, then open the pal, click avatars and buttons to your heart's content.  Then, close the PAL.  Then do a query on the User Activities table, restricting to your user id.  Wait a really long time, and you will see the results.  The pal_action and pal_opened stats should all be in there.