### PR TITLE
PAL: Fix "Last Editor" popup bug; Fix log spam

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -416,9 +416,11 @@ Rectangle {
         }
     }
     }
+    // Timer used when selecting table rows that aren't yet present in the model
+    // (i.e. when selecting avatars using edit.js or sphere overlays)
     Timer {
-        property var selected
-        property int userIndex
+        property bool selected // Selected or deselected?
+        property int userIndex // The userIndex of the avatar we want to select
         id: selectionTimer
         onTriggered: {
             if (selected) {
@@ -472,15 +474,20 @@ Rectangle {
             if (sessionIds.length > 1) {
                 letterbox("", "", 'Only one user can be selected at a time.');
             } else if (userIndex < 0) {
+                // If we've already refreshed the PAL and the avatar still isn't present in the model...
                 if (alreadyRefreshed === true) {
                     letterbox('', '', 'The last editor of this object is either you or not among this list of users.');
                 } else {
                     pal.sendToScript({method: 'refresh', params: message.params});
                 }
             } else {
+                // If we've already refreshed the PAL and found the avatar in the model
                 if (alreadyRefreshed === true) {
+                    // Wait a little bit before trying to actually select the avatar in the table
                     selectionTimer.interval = 250;
                 } else {
+                    // If we've found the avatar in the model and didn't need to refresh,
+                    // select the avatar in the table immediately
                     selectionTimer.interval = 0;
                 }
                 selectionTimer.selected = selected;

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -218,10 +218,10 @@ Rectangle {
                 id: nameCard
                 // Properties
                 displayName: styleData.value
-                userName: model && model.userName
-                audioLevel: model && model.audioLevel
+                userName: model ? model.userName : ""
+                audioLevel: model ? model.audioLevel : 0.0
                 visible: !isCheckBox && !isButton
-                uuid: model && model.sessionId
+                uuid: model ? model.sessionId : ""
                 selected: styleData.selected
                 isAdmin: model && model.admin
                 // Size
@@ -241,9 +241,9 @@ Rectangle {
                 id: actionCheckBox
                 visible: isCheckBox
                 anchors.centerIn: parent
-                checked: model[styleData.role]
+                checked: model ? model[styleData.role] : false
                 // If this is a "Personal Mute" checkbox, disable the checkbox if the "Ignore" checkbox is checked.
-                enabled: !(styleData.role === "personalMute" && model["ignore"])
+                enabled: !(styleData.role === "personalMute" && (model ? model["ignore"] : true))
                 boxSize: 24
                 onClicked: {
                     var newValue = !model[styleData.role]

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -134,7 +134,7 @@ EntityListTool = function(opts) {
                 Window.alert('There were no recent users of the ' + selectionManager.selections.length + ' selected objects.');
             } else {
                 // No need to subscribe if we're just sending.
-                Messages.sendMessage('com.highfidelity.pal', JSON.stringify({method: 'select', params: [dedupped, true]}), 'local');
+                Messages.sendMessage('com.highfidelity.pal', JSON.stringify({method: 'select', params: [dedupped, true, false]}), 'local');
             }
         } else if (data.type == "delete") {
             deleteSelectedEntities();

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -233,7 +233,7 @@ pal.fromQml.connect(function (message) { // messages are {method, params}, like 
         break;
     case 'refresh':
         removeOverlays();
-        populateUserList();
+        populateUserList(message.params);
         UserActivityLogger.palAction("refresh", "");
         break;
     case 'updateGain':
@@ -271,7 +271,7 @@ function addAvatarNode(id) {
          color: color(selected, false, 0.0),
          ignoreRayIntersection: false}, selected, true);
 }
-function populateUserList() {
+function populateUserList(selectData) {
     var data = [];
     AvatarList.getAvatarIdentifiers().sort().forEach(function (id) { // sorting the identifiers is just an aid for debugging
         var avatar = AvatarList.getAvatar(id);
@@ -295,7 +295,11 @@ function populateUserList() {
         data.push(avatarPalDatum);
         print('PAL data:', JSON.stringify(avatarPalDatum));
     });
-    pal.sendToQml({method: 'users', params: data});
+    pal.sendToQml({ method: 'users', params: data });
+    if (selectData) {
+        selectData[2] = true;
+        pal.sendToQml({ method: 'select', params: selectData });
+    }
 }
 
 // The function that handles the reply from the server
@@ -388,7 +392,7 @@ function removeOverlays() {
 function handleClick(pickRay) {
     ExtendedOverlay.applyPickRay(pickRay, function (overlay) {
         // Don't select directly. Tell qml, who will give us back a list of ids.
-        var message = {method: 'select', params: [[overlay.key], !overlay.selected]};
+        var message = {method: 'select', params: [[overlay.key], !overlay.selected, false]};
         pal.sendToQml(message);
         return true;
     });


### PR DESCRIPTION
This PR accomplishes two things:
1. It eliminates errant occurrences of the popup in the PAL that reads "The last editor is not among this list of users"
2. Using an imperfect method, it prevents logspam that used to occur from occurring.

**Test Plan**
This test plan requires two clients running this PR: Clients A and B. Run Sandbox from Client A.

*Testing "Fix 'Last Editor' Popup"*
* On only Client A, join Sandbox A. Open the PAL.
* On Client B, join Sandbox A. Wait 10 seconds for Client B to fully join the domain.
* On Client A, click on Avatar B's sphere overlay. Verify that Avatar B is selected in the PAL.
* On Client B, interact with an object in Sandbox A (I've been using the torch)
* On Client B, disconnect from the Sandbox A.
* On Client A, refresh the PAL. Open the Edit menu using the toolbar. Click on the object that Client B touched. Click on the "Entity List" tab. Click the "user" button to the right of "Jump to Selection". Verify that a PAL popup appears that states the user isn't present.
* On Client B, reconnect to Sandbox A. Wait 10 seconds. Interact with the same object as before.
* On Client A, press the same "user" button in the Entity List. Verify that Avatar B is selected in the PAL.

*Testing "Fix Log Spam"*
* Open Interface's log with CTRL+SHIFT+L.
* Quickly press the PAL refresh button at least 5x.
* Verify that the logs are full of wonderful information, but no errors 😄 