### PR TITLE
PAL: Fix card visibility when selecting out-of-table users

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -426,7 +426,7 @@ Rectangle {
             if (selected) {
                 table.selection.clear(); // for now, no multi-select
                 table.selection.select(userIndex);
-                table.positionViewAtRow(userIndex, ListView.Visible);
+                table.positionViewAtRow(userIndex, ListView.Beginning);
             } else {
                 table.selection.deselect(userIndex);
             }


### PR DESCRIPTION
Super quick fix.

**Test Plan**
Before: In a domain with lots of users, scrolling down in the PAL and then clicking on the sphere overlay of the user who shows up at the top of the PAL **would make only that user's VU meter visible.**

After: In a domain with lots of users, scrolling down in the PAL and then clicking on the sphere overlay of the user who shows up at the top of the PAL **will make that user's entire PAL card visible.**