### PR TITLE
Code Review for Job #21139 - Do not allow grab or far-grab or click while editing objects

### DIFF
--- a/scripts/system/controllers/grab.js
+++ b/scripts/system/controllers/grab.js
@@ -45,8 +45,6 @@ var DEFAULT_GRABBABLE_DATA = {
 
 var ACTION_TTL = 10; // seconds
 
-var enabled = true;
-
 function getTag() {
     return "grab-" + MyAvatar.sessionUUID;
 }
@@ -321,7 +319,7 @@ Grabber.prototype.computeNewGrabPlane = function() {
 }
 
 Grabber.prototype.pressEvent = function(event) {
-    if (!enabled) {
+    if (isInEditMode()) {
         return;
     }
 
@@ -633,31 +631,10 @@ function keyReleaseEvent(event) {
     grabber.keyReleaseEvent(event);
 }
 
-function editEvent(channel, message, sender, localOnly) {
-    if (channel != "edit-events") {
-        return;
-    }
-    if (sender != MyAvatar.sessionUUID) {
-        return;
-    }
-    if (!localOnly) {
-        return;
-    }
-    try {
-        var data = JSON.parse(message);
-        if ("enabled" in data) {
-            enabled = !data["enabled"];
-        }
-    } catch(e) {
-    }
-}
-
 Controller.mousePressEvent.connect(pressEvent);
 Controller.mouseMoveEvent.connect(moveEvent);
 Controller.mouseReleaseEvent.connect(releaseEvent);
 Controller.keyPressEvent.connect(keyPressEvent);
 Controller.keyReleaseEvent.connect(keyReleaseEvent);
-Messages.subscribe("edit-events");
-Messages.messageReceived.connect(editEvent);
 
 }()); // END LOCAL_SCOPE

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -842,14 +842,14 @@ function MyController(hand) {
     };
 
     this.callEntityMethodOnGrabbed = function(entityMethodName) {
-        if (isInEditMode()) {
-            return;
-        }
         var args = [this.hand === RIGHT_HAND ? "right" : "left", MyAvatar.sessionUUID];
         Entities.callEntityMethod(this.grabbedEntity, entityMethodName, args);
     };
 
     this.setState = function(newState, reason) {
+        if (isInEditMode() && newState !== STATE_OFF && newState !== STATE_SEARCHING) {
+            return;
+        }
         setGrabCommunications((newState === STATE_DISTANCE_HOLDING) || (newState === STATE_NEAR_GRABBING));
         if (WANT_DEBUG || WANT_DEBUG_STATE) {
             var oldStateName = stateToName(this.state);

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -493,11 +493,9 @@ function removeMyAvatarFromCollidesWith(origCollidesWith) {
 // If another script is managing the reticle (as is done by HandControllerPointer), we should not be setting it here,
 // and we should not be showing lasers when someone else is using the Reticle to indicate a 2D minor mode.
 var EXTERNALLY_MANAGED_2D_MINOR_MODE = true;
-var EDIT_SETTING = "io.highfidelity.isEditting";
 
 function isEditing() {
-    var actualSettingValue = Settings.getValue(EDIT_SETTING) === "false" ? false : !!Settings.getValue(EDIT_SETTING);
-    return EXTERNALLY_MANAGED_2D_MINOR_MODE && actualSettingValue;
+    return EXTERNALLY_MANAGED_2D_MINOR_MODE && isInEditMode();
 }
 
 function isIn2DMode() {
@@ -844,6 +842,9 @@ function MyController(hand) {
     };
 
     this.callEntityMethodOnGrabbed = function(entityMethodName) {
+        if (isInEditMode()) {
+            return;
+        }
         var args = [this.hand === RIGHT_HAND ? "right" : "left", MyAvatar.sessionUUID];
         Entities.callEntityMethod(this.grabbedEntity, entityMethodName, args);
     };

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -429,7 +429,6 @@ var toolBar = (function () {
             });
         });
 
-
         that.setActive(false);
     }
 
@@ -446,6 +445,7 @@ var toolBar = (function () {
     };
 
     that.setActive = function (active) {
+        Settings.setValue(EDIT_SETTING, active);
         if (active === isActive) {
             return;
         }
@@ -457,7 +457,6 @@ var toolBar = (function () {
             enabled: active
         }));
         isActive = active;
-        Settings.setValue(EDIT_SETTING, active);
         if (!isActive) {
             entityListTool.setVisible(false);
             gridTool.setVisible(false);

--- a/scripts/system/libraries/utils.js
+++ b/scripts/system/libraries/utils.js
@@ -6,6 +6,12 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+// note: this constant is currently duplicated in edit.js
+EDIT_SETTING = "io.highfidelity.isEditting";
+isInEditMode = function isInEditMode() {
+    return Settings.getValue(EDIT_SETTING) === "false" ? false : !!Settings.getValue(EDIT_SETTING);
+};
+
 if (!Function.prototype.bind) {
     Function.prototype.bind = function(oThis) {
         if (typeof this !== 'function') {


### PR DESCRIPTION
Workitem available at https://www.worklist.net/21139

#### Testing

Note: This PR affects both Desktop and HMD based editing modes so the below test should be repeated once per mode.

* Open Interface to a Domain with Rez perms.
* Rez some grabbable Entities to work with.
* Verify Entities can be grabbed and moved around in general.
* Enter EDIT mode.
* Verify that you can no longer grab Entities (in the grab.js / handControllerGrab.js sense).
* Verify that you can still "select" and "drag" Entities around (in the edit.js sense).
