### PR TITLE
use fromUserInput to avoid web entity crashes with bad URLs

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -247,8 +247,15 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
 
 void RenderableWebEntityItem::setSourceUrl(const QString& value) {
     if (_sourceUrl != value) {
-        qCDebug(entities) << "Setting web entity source URL to " << value;
-        _sourceUrl = value;
+        auto newURL = QUrl::fromUserInput(value);
+
+        if (newURL.isValid()) {
+            qCDebug(entities) << "Setting web entity source URL to " << value;
+            _sourceUrl = newURL.toDisplayString();
+        } else {
+            qCDebug(entities) << "Clearing web entity source URL since" << value << "cannot be parsed to a valid URL.";
+        }
+        
         if (_webSurface) {
             AbstractViewStateInterface::instance()->postLambdaEvent([this] {
                 _webSurface->getRootItem()->setProperty("url", _sourceUrl);

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -246,21 +246,14 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
 }
 
 void RenderableWebEntityItem::setSourceUrl(const QString& value) {
-    if (_sourceUrl != value) {
-        auto newURL = QUrl::fromUserInput(value);
+    auto valueBeforeSuperclassSet = _sourceUrl;
 
-        if (newURL.isValid()) {
-            qCDebug(entities) << "Setting web entity source URL to " << value;
-            _sourceUrl = newURL.toDisplayString();
-        } else {
-            qCDebug(entities) << "Clearing web entity source URL since" << value << "cannot be parsed to a valid URL.";
-        }
-        
-        if (_webSurface) {
-            AbstractViewStateInterface::instance()->postLambdaEvent([this] {
-                _webSurface->getRootItem()->setProperty("url", _sourceUrl);
-            });
-        }
+    WebEntityItem::setSourceUrl(value);
+
+    if (_sourceUrl != valueBeforeSuperclassSet && _webSurface) {
+        AbstractViewStateInterface::instance()->postLambdaEvent([this] {
+            _webSurface->getRootItem()->setProperty("url", _sourceUrl);
+        });
     }
 }
 

--- a/libraries/entities/src/WebEntityItem.cpp
+++ b/libraries/entities/src/WebEntityItem.cpp
@@ -128,8 +128,8 @@ void WebEntityItem::setSourceUrl(const QString& value) {
         auto newURL = QUrl::fromUserInput(value);
 
         if (newURL.isValid()) {
-            qCDebug(entities) << "Setting web entity source URL to " << value;
             _sourceUrl = newURL.toDisplayString();
+            qCDebug(entities) << "Changed web entity source URL to " << _sourceUrl;
         } else {
             qCDebug(entities) << "Clearing web entity source URL since" << value << "cannot be parsed to a valid URL.";
         }

--- a/libraries/entities/src/WebEntityItem.cpp
+++ b/libraries/entities/src/WebEntityItem.cpp
@@ -125,7 +125,14 @@ bool WebEntityItem::findDetailedRayIntersection(const glm::vec3& origin, const g
 
 void WebEntityItem::setSourceUrl(const QString& value) {
     if (_sourceUrl != value) {
-        _sourceUrl = value;
+        auto newURL = QUrl::fromUserInput(value);
+
+        if (newURL.isValid()) {
+            qCDebug(entities) << "Setting web entity source URL to " << value;
+            _sourceUrl = newURL.toDisplayString();
+        } else {
+            qCDebug(entities) << "Clearing web entity source URL since" << value << "cannot be parsed to a valid URL.";
+        }
     }
 }
 


### PR DESCRIPTION
- parse new URLs for web entities with QUrl::fromUserInput to avoid using bad URLs that can crash interface