### PR TITLE
Fix invalid volume values in injector options silencing all injectors

### DIFF
--- a/libraries/audio/src/AudioInjectorOptions.cpp
+++ b/libraries/audio/src/AudioInjectorOptions.cpp
@@ -9,9 +9,13 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AudioInjectorOptions.h"
+
+#include <QScriptValueIterator>
+
 #include <RegisteredMetaTypes.h>
 
-#include "AudioInjectorOptions.h"
+#include "AudioLogging.h"
 
 AudioInjectorOptions::AudioInjectorOptions() :
     position(0.0f, 0.0f, 0.0f),
@@ -22,7 +26,7 @@ AudioInjectorOptions::AudioInjectorOptions() :
     ambisonic(false),
     ignorePenumbra(false),
     localOnly(false),
-    secondOffset(0.0)
+    secondOffset(0.0f)
 {
 
 }
@@ -40,31 +44,51 @@ QScriptValue injectorOptionsToScriptValue(QScriptEngine* engine, const AudioInje
 }
 
 void injectorOptionsFromScriptValue(const QScriptValue& object, AudioInjectorOptions& injectorOptions) {
-    if (object.property("position").isValid()) {
-        vec3FromScriptValue(object.property("position"), injectorOptions.position);
+    if (!object.isObject()) {
+        qWarning() << "Audio injector options is not an object.";
+        return;
     }
-    
-    if (object.property("volume").isValid()) {
-        injectorOptions.volume = object.property("volume").toNumber();
-    }
-    
-    if (object.property("loop").isValid()) {
-        injectorOptions.loop = object.property("loop").toBool();
-    }
-    
-    if (object.property("orientation").isValid()) {
-        quatFromScriptValue(object.property("orientation"), injectorOptions.orientation);
-    }
-    
-    if (object.property("ignorePenumbra").isValid()) {
-        injectorOptions.ignorePenumbra = object.property("ignorePenumbra").toBool();
-    }
-    
-    if (object.property("localOnly").isValid()) {
-        injectorOptions.localOnly = object.property("localOnly").toBool();
-    }
-    
-    if (object.property("secondOffset").isValid()) {
-        injectorOptions.secondOffset = object.property("secondOffset").toNumber();
+
+    QScriptValueIterator it(object);
+    while (it.hasNext()) {
+        it.next();
+
+        if (it.name() == "position") {
+            vec3FromScriptValue(object.property("position"), injectorOptions.position);
+        } else if (it.name() == "orientation") {
+            quatFromScriptValue(object.property("orientation"), injectorOptions.orientation);
+        } else if (it.name() == "volume") {
+            if (it.value().isNumber()) {
+                injectorOptions.volume = it.value().toNumber();
+            } else {
+                qCWarning(audio) << "Audio injector options: volume is not a number";
+            }
+        } else if (it.name() == "loop") {
+            if (it.value().isBool()) {
+                injectorOptions.loop = it.value().toBool();
+            } else {
+                qCWarning(audio) << "Audio injector options: loop is not a boolean";
+            }
+        } else if (it.name() == "ignorePenumbra") {
+            if (it.value().isBool()) {
+                injectorOptions.ignorePenumbra = it.value().toBool();
+            } else {
+                qCWarning(audio) << "Audio injector options: ignorePenumbra is not a boolean";
+            }
+        } else if (it.name() == "localOnly") {
+            if (it.value().isBool()) {
+                injectorOptions.localOnly = it.value().toBool();
+            } else {
+                qCWarning(audio) << "Audio injector options: localOnly is not a boolean";
+            }
+        } else if (it.name() == "secondOffset") {
+            if (it.value().isNumber()) {
+                injectorOptions.secondOffset = it.value().toNumber();
+            } else {
+                qCWarning(audio) << "Audio injector options: secondOffset is not a number";
+            }
+        } else {
+            qCWarning(audio) << "Unknown audio injector option:" << it.name();
+        }
     }
  }


### PR DESCRIPTION
This fixes a bug where, if you pass an invalid value for the audio option volume, the latter would be set to `nan` and messup all the other injectors.

## Test plan:

- Go to a domain with injectors (Your sandbox should work)
- Create a cube entity
- Save this script to a local file and attach it to the cube entity:
```js
(function() {
  this.preload = function() {
    this.sound = SoundCache.getSound("https://s3-us-west-1.amazonaws.com/hifi-content/DomainContent/Welcome+Area/Sounds/low_pulse_1.L.wav");
};

  this.clickDownOnEntity = function(entityID, mouseEvent) {
    Audio.playSound(this.sound, {
      position: MyAvatar.position,
      volume: "bad value"
    });
  };
});
```
- Click the entity to play the sound
- This should quiet all the injectors on the current master, but play at the default volume in this PR.
- I also added some debug in the log so people know what's going on.


Fixes: https://highfidelity.fogbugz.com/f/cases/1746/