### PR TITLE
use host check for entity script whitelist instead of startsWith

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1285,7 +1285,7 @@
         {
           "name": "entityScriptSourceWhitelist",
           "label": "Entity Scripts Allowed from:",
-          "help": "The domains that entity scripts are allowed from. A comma separated list of domains that entity scripts are allowed from, if someone attempts to create and entity or edit an entity to have a different domain, it will be rejected. If left blank, any domain is allowed.",
+          "help": "Comma separated list of URLs (with optional paths) that entity scripts are allowed from. If someone attempts to create and entity or edit an entity to have a different domain, it will be rejected. If left blank, any domain is allowed.",
           "placeholder": "",
           "default": "",
           "advanced": true

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -963,7 +963,17 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                 auto entityScriptURL = QUrl::fromUserInput(properties.getScript());
 
                 for (const auto& whiteListedPrefix : _entityScriptSourceWhitelist) {
-                    if (entityScriptURL.host().compare(whiteListedPrefix, Qt::CaseInsensitive) == 0) {
+                    auto whiteListURL = QUrl::fromUserInput(whiteListedPrefix);
+
+                    if (entityScriptURL.scheme() != whiteListURL.scheme()) {
+                        // isParentOf will be false if the schemes are different, but 
+                    }
+
+                    qDebug() << "Comparing" << entityScriptURL << "to" << whiteListURL;
+                    qDebug() << whiteListURL.isParentOf(entityScriptURL);
+
+                    // check if this script URL matches the whitelist domain and, optionally, is beneath the path
+                    if (whiteListURL.isParentOf(entityScriptURL)) {
                         passedWhiteList = true;
                         break;
                     }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -965,15 +965,9 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                 for (const auto& whiteListedPrefix : _entityScriptSourceWhitelist) {
                     auto whiteListURL = QUrl::fromUserInput(whiteListedPrefix);
 
-                    if (entityScriptURL.scheme() != whiteListURL.scheme()) {
-                        // isParentOf will be false if the schemes are different, but 
-                    }
-
-                    qDebug() << "Comparing" << entityScriptURL << "to" << whiteListURL;
-                    qDebug() << whiteListURL.isParentOf(entityScriptURL);
-
                     // check if this script URL matches the whitelist domain and, optionally, is beneath the path
-                    if (whiteListURL.isParentOf(entityScriptURL)) {
+                    if (entityScriptURL.host().compare(whiteListURL.host(), Qt::CaseInsensitive) == 0 &&
+                        entityScriptURL.path().startsWith(whiteListURL.path(), Qt::CaseInsensitive)) {
                         passedWhiteList = true;
                         break;
                     }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -958,9 +958,12 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
 
             if (validEditPacket && !_entityScriptSourceWhitelist.isEmpty() && !properties.getScript().isEmpty()) {
                 bool passedWhiteList = false;
-                auto entityScript = properties.getScript();
+
+                // grab a URL representation of the entity script so we can check the host for this script
+                auto entityScriptURL = QUrl::fromUserInput(properties.getScript());
+
                 for (const auto& whiteListedPrefix : _entityScriptSourceWhitelist) {
-                    if (entityScript.startsWith(whiteListedPrefix, Qt::CaseInsensitive)) {
+                    if (entityScriptURL.host().compare(whiteListedPrefix, Qt::CaseInsensitive) == 0) {
                         passedWhiteList = true;
                         break;
                     }


### PR DESCRIPTION
- fixed a potential entity script whitelist exploit by using a full host check instead of startsWith