### PR TITLE
Fix Edit.js rescale for decimal values

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1556,7 +1556,7 @@ var PropertiesTool = function (opts) {
                     Camera.cameraEntity = selectionManager.selections[0];
                 }
             } else if (data.action === "rescaleDimensions") {
-                var multiplier = data.percentage / 100;
+                var multiplier = data.percentage / 100.0;
                 if (selectionManager.hasSelection()) {
                     selectionManager.saveProperties();
                     for (i = 0; i < selectionManager.selections.length; i++) {

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1392,7 +1392,7 @@ function loaded() {
             EventBridge.emitWebEvent(JSON.stringify({
                 type: "action",
                 action: "rescaleDimensions",
-                percentage: parseInt(elRescaleDimensionsPct.value),
+                percentage: parseFloat(elRescaleDimensionsPct.value),
             }));
         });
         elReloadScriptButton.addEventListener("click", function() {


### PR DESCRIPTION
## Test plan:

- Spawn a cube
- Set its size to 2, 2, 2
- rescale to 50.5%
- On master the resulting cube will be 1, 1, 1 but on this PR it will be 1.01, 1.01, 1.01


Fixes: https://highfidelity.fogbugz.com/f/cases/1527