### PR TITLE
UI navigation work with game pads

### DIFF
--- a/interface/resources/controllers/standard_navigation.json
+++ b/interface/resources/controllers/standard_navigation.json
@@ -1,6 +1,5 @@
 {
-    "name": "Standard to Action",
-    "when": "Application.NavigationFocused",
+    "name": "Standard to UI Navigation Action",
     "channels": [
         { "from": "Standard.DU", "to": "Actions.UiNavVertical" },
         { "from": "Standard.DD", "to": "Actions.UiNavVertical", "filters": "invert" },
@@ -9,42 +8,7 @@
         { "from": "Standard.LB", "to": "Actions.UiNavGroup","filters": "invert" },
         { "from": "Standard.RB", "to": "Actions.UiNavGroup" },
         { "from": [ "Standard.A", "Standard.X" ], "to": "Actions.UiNavSelect" },
-        { "from": [ "Standard.B", "Standard.Y" ], "to": "Actions.UiNavBack" },
-        { "from": [ "Standard.RTClick", "Standard.LTClick" ], "to": "Actions.UiNavSelect" },
-        {
-            "from": "Standard.LX", "to": "Actions.UiNavLateral",
-            "filters": [
-                { "type": "deadZone", "min": 0.95 },
-                "constrainToInteger",
-                { "type": "pulse", "interval": 0.4 }
-            ]
-        },
-        { 
-            "from": "Standard.LY", "to": "Actions.UiNavVertical", 
-            "filters": [
-                "invert",
-                { "type": "deadZone", "min": 0.95 },
-                "constrainToInteger",
-                { "type": "pulse", "interval": 0.4 }
-            ]
-        },
-        { 
-            "from": "Standard.RX", "to": "Actions.UiNavLateral",
-            "filters": [
-                { "type": "deadZone", "min": 0.95 },
-                "constrainToInteger",
-                { "type": "pulse", "interval": 0.4 }
-            ]
-        },
-        { 
-            "from": "Standard.RY", "to": "Actions.UiNavVertical",
-            "filters": [
-                "invert",
-                { "type": "deadZone", "min": 0.95 },
-                "constrainToInteger",
-                { "type": "pulse", "interval": 0.4 }
-            ]
-        }
+        { "from": [ "Standard.B", "Standard.Y" ], "to": "Actions.UiNavBack" }
     ]
 }
 

--- a/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
@@ -90,7 +90,6 @@ Item {
             } else {
                 breadcrumbText.text = "Menu";
                 topMenu = null;
-                offscreenFlags.navigationFocused = false;
             }
         }
 
@@ -99,7 +98,6 @@ Item {
             topMenu = newMenu;
             topMenu.focus = true;
             topMenu.forceActiveFocus();
-            offscreenFlags.navigationFocused = true;
         }
 
         function clearMenus() {

--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -46,11 +46,8 @@ Item {
                 });
             }
             loader.item.forceActiveFocus();
-            offscreenFlags.navigationFocused = true;
         }
     }
-   
-    Component.onDestruction: { offscreenFlags.navigationFocused = false; }
 
     width: 480
     height: 720

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -978,7 +978,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         using namespace controller;
         auto offscreenUi = DependencyManager::get<OffscreenUi>();
         auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-        if (offscreenUi->navigationFocused()) {
+        {
             auto actionEnum = static_cast<Action>(action);
             int key = Qt::Key_unknown;
             static int lastKey = Qt::Key_unknown;


### PR DESCRIPTION
The tablet UI can be long lived, unlike the previous VRMenu.
So instead of using a dynamic mapping that was only enabled when the VRMenu was shown, standard_navigation.json, now it is always active.  Also, standard_navigation.json has been changed.
Left and Right click and stick events never become UINav events. Only Dpad A, B, X, Y, LB and RB are mapped to UINav events.