### PR TITLE
Fix Overlay-as-child of model entity with reg point

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -133,7 +133,6 @@ AvatarData::AvatarData() :
     setBodyPitch(0.0f);
     setBodyYaw(-90.0f);
     setBodyRoll(0.0f);
-    setParentJointIndex(0);
 
     ASSERT(sizeof(AvatarDataPacket::Header) == AvatarDataPacket::HEADER_SIZE);
     ASSERT(sizeof(AvatarDataPacket::MinimalAvatarInfo) == AvatarDataPacket::MINIMAL_AVATAR_INFO_SIZE);

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -133,6 +133,7 @@ AvatarData::AvatarData() :
     setBodyPitch(0.0f);
     setBodyYaw(-90.0f);
     setBodyRoll(0.0f);
+    setParentJointIndex(0);
 
     ASSERT(sizeof(AvatarDataPacket::Header) == AvatarDataPacket::HEADER_SIZE);
     ASSERT(sizeof(AvatarDataPacket::MinimalAvatarInfo) == AvatarDataPacket::MINIMAL_AVATAR_INFO_SIZE);

--- a/libraries/shared/src/SpatiallyNestable.h
+++ b/libraries/shared/src/SpatiallyNestable.h
@@ -26,6 +26,8 @@ using SpatiallyNestableWeakConstPointer = std::weak_ptr<const SpatiallyNestable>
 using SpatiallyNestablePointer = std::shared_ptr<SpatiallyNestable>;
 using SpatiallyNestableConstPointer = std::shared_ptr<const SpatiallyNestable>;
 
+static const uint16_t INVALID_JOINT_INDEX = -1;
+
 enum class NestableType {
     Entity,
     Avatar,
@@ -180,7 +182,7 @@ protected:
     const NestableType _nestableType; // EntityItem or an AvatarData
     QUuid _id;
     QUuid _parentID; // what is this thing's transform relative to?
-    quint16 _parentJointIndex { 0 }; // which joint of the parent is this relative to?
+    quint16 _parentJointIndex { INVALID_JOINT_INDEX }; // which joint of the parent is this relative to?
 
     mutable SpatiallyNestableWeakPointer _parent;
 


### PR DESCRIPTION
This fixes as issue where when you set the parent of an overlay to be a
model entity with a non-(0.5, 0.5, 0.5) registration point, the overlay would
still be positioned relative to the center of the model. The issue is
that the default parent joint index was 0, which is the center of the
model.

Entities, avatars, and overlays all now have a default parent joint index of `-1`.

Notes about avatars:

Avatars previously defaulted to `0`, but now default to -`1`. This subtle change will mean that you will need to set the parent joint index to `0` if you want the avatar to be positioned relative to the center of the model.

What are the repercussions of this? As far as I can tell, none, unless a script is dynamically adjusting the registration point of an entity. I haven't been able to find a way to set the avatar's local position (the position relative to the parent), so being positioned relative to the center vs registration point of an entity is irrelevant.