### PR TITLE
bypass entity-server edit filter if you have lock/unlock rights

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1053,7 +1053,8 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
 
                 startFilter = usecTimestampNow();
                 bool wasChanged = false;
-                bool allowed = filterProperties(properties, properties, wasChanged);
+                // Having (un)lock rights bypasses the filter.
+                bool allowed = senderNode->isAllowedEditor() || filterProperties(properties, properties, wasChanged);
                 if (!allowed) {
                     properties = EntityItemProperties();
                 }


### PR DESCRIPTION
This PR is against the edit-entity-filter branch.

test plan:
- add the filter in script-archive/entity-server-filter-example.js (see instructions on https://github.com/highfidelity/hifi/pull/9477)
- violate it with lock rights and attempt to violate it (and fail) without lock rights.

Btw, beware that by default, localhost has lock rights.