### PR TITLE
ENTITY FILTERS: "Can't change model" & "Can't exceed velocity X"

### DIFF
--- a/script-archive/entity-server-filter-example.js
+++ b/script-archive/entity-server-filter-example.js
@@ -16,16 +16,16 @@ function filter(p) {
 	/* Clamp velocity to maxVelocity units/second. Zeroing each component of acceleration keeps us from slamming.*/
 	var maxVelocity = 5;
     if (p.velocity) {
-		if (p.velocity.x > maxVelocity) {
-			p.velocity.x = maxVelocity;
+		if (Math.abs(p.velocity.x) > maxVelocity) {
+			p.velocity.x = Math.sign(p.velocity.x) * maxVelocity;
 			p.acceleration.x = 0;
 		}
-		if (p.velocity.y > maxVelocity) {
-			p.velocity.y = maxVelocity;
+		if (Math.abs(p.velocity.y) > maxVelocity) {
+			p.velocity.y = Math.sign(p.velocity.y) * maxVelocity;
 			p.acceleration.y = 0;
 		}
-		if (p.velocity.z > maxVelocity) {
-			p.velocity.z = maxVelocity;
+		if (Math.abs(p.velocity.z) > maxVelocity) {
+			p.velocity.z = Math.sign(p.velocity.z) * maxVelocity;
 			p.acceleration.z = 0;
 		}
     }

--- a/script-archive/entity-server-filter-example.js
+++ b/script-archive/entity-server-filter-example.js
@@ -9,6 +9,25 @@ function filter(p) {
 
     /* Can also reject altogether */
     if (p.userData) { return false; }
+	
+    /* Reject if modifications made to Model properties */
+    if (p.modelURL || p.compoundShapeURL || p.shape || p.shapeType || p.url || p.fps || p.currentFrame || p.running || p.loop || p.firstFrame || p.lastFrame || p.hold || p.textures || p.xTextureURL || p.yTextureURL || p.zTextureURL) { return false; }
+	
+	/* Clamp velocity to 10 units/second. Zeroing each component of acceleration keeps us from slamming.*/
+    if (p.velocity) {
+		if (p.velocity.x > 10) {
+			p.velocity.x = 10;
+			p.acceleration.x = 0;
+		}
+		if (p.velocity.y > 10) {
+			p.velocity.y = 10;
+			p.acceleration.y = 0;
+		}
+		if (p.velocity.z > 10) {
+			p.velocity.z = 10;
+			p.acceleration.z = 0;
+		}
+    }
 
     /* If we make it this far, return the (possibly modified) properties. */
     return p;

--- a/script-archive/entity-server-filter-example.js
+++ b/script-archive/entity-server-filter-example.js
@@ -13,18 +13,18 @@ function filter(p) {
     /* Reject if modifications made to Model properties */
     if (p.modelURL || p.compoundShapeURL || p.shape || p.shapeType || p.url || p.fps || p.currentFrame || p.running || p.loop || p.firstFrame || p.lastFrame || p.hold || p.textures || p.xTextureURL || p.yTextureURL || p.zTextureURL) { return false; }
 	
-	/* Clamp velocity to 10 units/second. Zeroing each component of acceleration keeps us from slamming.*/
+	/* Clamp velocity to 5 units/second. Zeroing each component of acceleration keeps us from slamming.*/
     if (p.velocity) {
-		if (p.velocity.x > 10) {
-			p.velocity.x = 10;
+		if (p.velocity.x > 5) {
+			p.velocity.x = 5;
 			p.acceleration.x = 0;
 		}
-		if (p.velocity.y > 10) {
-			p.velocity.y = 10;
+		if (p.velocity.y > 5) {
+			p.velocity.y = 5;
 			p.acceleration.y = 0;
 		}
-		if (p.velocity.z > 10) {
-			p.velocity.z = 10;
+		if (p.velocity.z > 5) {
+			p.velocity.z = 5;
 			p.acceleration.z = 0;
 		}
     }

--- a/script-archive/entity-server-filter-example.js
+++ b/script-archive/entity-server-filter-example.js
@@ -13,18 +13,19 @@ function filter(p) {
     /* Reject if modifications made to Model properties */
     if (p.modelURL || p.compoundShapeURL || p.shape || p.shapeType || p.url || p.fps || p.currentFrame || p.running || p.loop || p.firstFrame || p.lastFrame || p.hold || p.textures || p.xTextureURL || p.yTextureURL || p.zTextureURL) { return false; }
 	
-	/* Clamp velocity to 5 units/second. Zeroing each component of acceleration keeps us from slamming.*/
+	/* Clamp velocity to maxVelocity units/second. Zeroing each component of acceleration keeps us from slamming.*/
+	var maxVelocity = 5;
     if (p.velocity) {
-		if (p.velocity.x > 5) {
-			p.velocity.x = 5;
+		if (p.velocity.x > maxVelocity) {
+			p.velocity.x = maxVelocity;
 			p.acceleration.x = 0;
 		}
-		if (p.velocity.y > 5) {
-			p.velocity.y = 5;
+		if (p.velocity.y > maxVelocity) {
+			p.velocity.y = maxVelocity;
 			p.acceleration.y = 0;
 		}
-		if (p.velocity.z > 5) {
-			p.velocity.z = 5;
+		if (p.velocity.z > maxVelocity) {
+			p.velocity.z = maxVelocity;
 			p.acceleration.z = 0;
 		}
     }


### PR DESCRIPTION
In this PR, I've included V1 of two entity filters.
1. A filter that prevents users from changing any entity properties under the "MODEL" header of the EDIT menu.
2. A filter that prevents any component of an entity's velocity from exceeding 5 units/second.

**To test these filters' efficacy:**
*Filter 1*
1. Enter your sandbox.
2. Spawn a beach ball from the Marketplace.
3. Use the domain settings page to apply Filter 1 to your sandbox, then apply the settings and restart the sandbox.
4. In your sandbox, open the Edit menu, then select the beach ball, then click the "Entity Properties" tab.
5. Attempt to change any field underneath the "MODEL" header.
For example, you can try changing the "Model URL" to `http://mpassets.highfidelity.com/6af97d4e-1338-4b4f-97bd-4d80449d5542-v1/CircusHammer.fbx`, which is the circus hammer model. Verify that changing any property under the MODEL header results in no change to the model appearance or behavior.
Note that some entity server rejections may apply but not be immediately visible in the "Entity Properties" edit window.

*Filter 2*
1. Enter your sandbox.
2. Spawn a beach ball from the Marketplace.
3. Use the domain settings page to apply Filter 2 to your sandbox, then apply the settings and restart the sandbox.
4. In your sandbox, grab the beach ball and attempt to throw it as hard as you can. Don't break your monitor.
5. Verify that the beach ball didn't go as fast as you wish it did.
You may notice the beach ball snap back a little as it flies through the air - this is normal, as it's the entity server rejecting your hard through. You're a regular Tom Brady.
Also note that the filter will apply even if you're far-grabbing an object - which means pulling the beach ball to your body quickly will result in the beach ball jumping around a little bit.