### PR TITLE
Fix Steam scripting interface calls

### DIFF
--- a/libraries/plugins/src/plugins/SteamClientPlugin.h
+++ b/libraries/plugins/src/plugins/SteamClientPlugin.h
@@ -49,8 +49,8 @@ public:
     SteamScriptingInterface(QObject* parent, SteamClientPlugin* plugin) : QObject(parent), _plugin(plugin) {}
 
 public slots:
-    bool isRunning() const { return _plugin->isRunning(); }
-    void openInviteOverlay() const { _plugin->openInviteOverlay(); }
+    bool isRunning() const { return _plugin && _plugin->isRunning(); }
+    void openInviteOverlay() const { if (_plugin) { _plugin->openInviteOverlay(); } }
 
 private:
     SteamClientPlugin* _plugin;

--- a/libraries/plugins/src/plugins/SteamClientPlugin.h
+++ b/libraries/plugins/src/plugins/SteamClientPlugin.h
@@ -46,9 +46,9 @@ class SteamScriptingInterface : public QObject {
     Q_PROPERTY(bool isRunning READ isRunning)
 
 public:
-    SteamScriptingInterface(QObject* parent, SteamClientPlugin* plugin) : QObject(parent) {}
+    SteamScriptingInterface(QObject* parent, SteamClientPlugin* plugin) : QObject(parent), _plugin(plugin) {}
 
-    public slots:
+public slots:
     bool isRunning() const { return _plugin->isRunning(); }
     void openInviteOverlay() const { _plugin->openInviteOverlay(); }
 

--- a/libraries/plugins/src/plugins/SteamClientPlugin.h
+++ b/libraries/plugins/src/plugins/SteamClientPlugin.h
@@ -43,7 +43,7 @@ public:
 class SteamScriptingInterface : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(bool isRunning READ isRunning)
+    Q_PROPERTY(bool running READ isRunning)
 
 public:
     SteamScriptingInterface(QObject* parent, SteamClientPlugin* plugin) : QObject(parent), _plugin(plugin) {}


### PR DESCRIPTION
Fixes a bug in the Steam JS API that caused the app to crash.

## Test plan:
- Open the JS console
- Run `Steam.isRunning` and `Steam.openInviteOverlay()`
- This crashes on master but not with this PR.