### PR TITLE
Throttle audio with PI controller, by node

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -464,14 +464,11 @@ std::chrono::microseconds AudioMixer::timeFrame(p_high_resolution_clock::time_po
     // compute how long the last frame took
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(now - timestamp);
 
-    // sleep until the next frame should start
-    if (nextTimestamp > now) {
-        auto timeToSleep = std::chrono::duration_cast<std::chrono::microseconds>(nextTimestamp - now);
-        std::this_thread::sleep_for(timeToSleep);
-    }
-
     // set the new frame timestamp
-    timestamp = p_high_resolution_clock::now();
+    timestamp = std::max(now, nextTimestamp);
+
+    // sleep until the next frame should start
+    std::this_thread::sleep_until(timestamp);
 
     return duration;
 }

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -487,7 +487,7 @@ void AudioMixer::throttle(std::chrono::microseconds duration, int frame) {
     // on a "regular" machine with 100 avatars, this is the largest value where
     // - overthrottling can be recovered
     // - oscillations will not occur after the recovery
-    const float BACKOFF_TARGET = 0.47f;
+    const float BACKOFF_TARGET = 0.44f;
 
     // the mixer is known to struggle at about 80 on a "regular" machine
     // so throttle 2/80 the streams to ensure smooth audio (throttling is linear)

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -403,7 +403,7 @@ void AudioMixer::start() {
 
     // mix state
     unsigned int frame = 1;
-    auto frameTimestamp = p_high_resolution_clock::time_point::min();
+    auto frameTimestamp = p_high_resolution_clock::now();
 
     while (!_isFinished) {
         auto ticTimer = _ticTiming.timer();

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -36,7 +36,6 @@
 
 #include "AudioMixer.h"
 
-static const float LOUDNESS_TO_DISTANCE_RATIO = 0.00001f;
 static const float DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE = 0.5f;    // attenuation = -6dB * log2(distance)
 static const float DEFAULT_NOISE_MUTING_THRESHOLD = 0.003f;
 static const QString AUDIO_MIXER_LOGGING_TARGET_NAME = "audio-mixer";

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -294,6 +294,9 @@ void AudioMixer::sendStatsPacket() {
 
     // general stats
     statsObject["useDynamicJitterBuffers"] = _numStaticJitterFrames == -1;
+
+    statsObject["threads"] = _slavePool.numThreads();
+
     statsObject["trailing_sleep_percentage"] = _trailingSleepRatio * 100.0f;
     statsObject["performance_throttling_ratio"] = _performanceThrottlingRatio;
 

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -73,7 +73,7 @@ private slots:
 private:
     // mixing helpers
     std::chrono::microseconds timeFrame(p_high_resolution_clock::time_point& timestamp);
-    void throttle(std::chrono::microseconds frameDuration);
+    void throttle(std::chrono::microseconds frameDuration, int frame);
     // pop a frame from any streams on the node
     // returns the number of available streams
     int prepareFrame(const SharedNodePointer& node, unsigned int frame);
@@ -84,7 +84,7 @@ private:
 
     void parseSettingsObject(const QJsonObject& settingsObject);
 
-    float _throttlingIntegral { 0.0f };
+    float _trailingMixRatio { 0.0f };
     float _throttlingRatio { 0.0f };
 
     int _numStatFrames { 0 };

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -46,7 +46,6 @@ public:
     static int getStaticJitterFrames() { return _numStaticJitterFrames; }
     static bool shouldMute(float quietestFrame) { return quietestFrame > _noiseMutingThreshold; }
     static float getAttenuationPerDoublingInDistance() { return _attenuationPerDoublingInDistance; }
-    static float getMinimumAudibilityThreshold() { return _performanceThrottlingRatio > 0.0f ? _minAudibilityThreshold : 0.0f; }
     static const QHash<QString, AABox>& getAudioZones() { return _audioZones; }
     static const QVector<ZoneSettings>& getZoneSettings() { return _zoneSettings; }
     static const QVector<ReverbSettings>& getReverbSettings() { return _zoneReverbSettings; }
@@ -73,8 +72,8 @@ private slots:
 
 private:
     // mixing helpers
-    // check and maybe throttle mixer load by changing audibility threshold
-    void manageLoad(p_high_resolution_clock::time_point& frameTimestamp, unsigned int& framesSinceManagement);
+    std::chrono::microseconds timeFrame(p_high_resolution_clock::time_point& timestamp);
+    void throttle(std::chrono::microseconds frameDuration);
     // pop a frame from any streams on the node
     // returns the number of available streams
     int prepareFrame(const SharedNodePointer& node, unsigned int frame);
@@ -84,6 +83,9 @@ private:
     QString percentageForMixStats(int counter);
 
     void parseSettingsObject(const QJsonObject& settingsObject);
+
+    float _throttlingIntegral { 0.0f };
+    float _throttlingRatio { 0.0f };
 
     int _numStatFrames { 0 };
     AudioMixerStats _stats;
@@ -122,9 +124,6 @@ private:
     static int _numStaticJitterFrames; // -1 denotes dynamic jitter buffering
     static float _noiseMutingThreshold;
     static float _attenuationPerDoublingInDistance;
-    static float _trailingSleepRatio;
-    static float _performanceThrottlingRatio;
-    static float _minAudibilityThreshold;
     static QHash<QString, AABox> _audioZones;
     static QVector<ZoneSettings> _zoneSettings;
     static QVector<ReverbSettings> _zoneReverbSettings;

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -115,6 +115,7 @@ private:
         uint64_t _history[TIMER_TRAILING_SECONDS] {};
         int _index { 0 };
     };
+    Timer _ticTiming;
     Timer _sleepTiming;
     Timer _frameTiming;
     Timer _prepareTiming;

--- a/assignment-client/src/audio/AudioMixerSlave.h
+++ b/assignment-client/src/audio/AudioMixerSlave.h
@@ -41,17 +41,10 @@ public:
 private:
     // create mix, returns true if mix has audio
     bool prepareMix(const SharedNodePointer& listener);
-    // check whether a node should be ignored
-    bool shouldIgnoreNode(const SharedNodePointer& listener, const SharedNodePointer& node);
     // add a stream to the mix
     void addStreamToMix(AudioMixerClientData& listenerData, const QUuid& streamerID,
             const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer,
             bool throttle = false);
-
-    float gainForSource(const AvatarAudioStream& listener, const PositionalAudioStream& streamer,
-            const glm::vec3& relativePosition, bool isEcho);
-    float azimuthForSource(const AvatarAudioStream& listener, const PositionalAudioStream& streamer,
-            const glm::vec3& relativePosition);
 
     // mixing buffers
     float _mixSamples[AudioConstants::NETWORK_FRAME_SAMPLES_STEREO];

--- a/assignment-client/src/audio/AudioMixerSlave.h
+++ b/assignment-client/src/audio/AudioMixerSlave.h
@@ -44,8 +44,10 @@ private:
     void throttleStream(AudioMixerClientData& listenerData, const QUuid& streamerID,
             const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer);
     void mixStream(AudioMixerClientData& listenerData, const QUuid& streamerID,
+            const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer);
+    void addStream(AudioMixerClientData& listenerData, const QUuid& streamerID,
             const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer,
-            bool throttle = false);
+            bool throttle);
 
     // mixing buffers
     float _mixSamples[AudioConstants::NETWORK_FRAME_SAMPLES_STEREO];

--- a/assignment-client/src/audio/AudioMixerSlave.h
+++ b/assignment-client/src/audio/AudioMixerSlave.h
@@ -41,8 +41,9 @@ public:
 private:
     // create mix, returns true if mix has audio
     bool prepareMix(const SharedNodePointer& listener);
-    // add a stream to the mix
-    void addStreamToMix(AudioMixerClientData& listenerData, const QUuid& streamerID,
+    void throttleStream(AudioMixerClientData& listenerData, const QUuid& streamerID,
+            const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer);
+    void mixStream(AudioMixerClientData& listenerData, const QUuid& streamerID,
             const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer,
             bool throttle = false);
 

--- a/assignment-client/src/audio/AudioMixerSlave.h
+++ b/assignment-client/src/audio/AudioMixerSlave.h
@@ -30,7 +30,7 @@ class AudioMixerSlave {
 public:
     using ConstIter = NodeList::const_iterator;
 
-    void configure(ConstIter begin, ConstIter end, unsigned int frame);
+    void configure(ConstIter begin, ConstIter end, unsigned int frame, float throttlingRatio);
 
     // mix and broadcast non-ignored streams to the node
     // returns true if a mixed packet was sent to the node
@@ -43,7 +43,8 @@ private:
     bool prepareMix(const SharedNodePointer& node);
     // add a stream to the mix
     void addStreamToMix(AudioMixerClientData& listenerData, const QUuid& streamerID,
-            const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer);
+            const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer,
+            bool throttle);
 
     float gainForSource(const AvatarAudioStream& listener, const PositionalAudioStream& streamer,
             const glm::vec3& relativePosition, bool isEcho);
@@ -58,6 +59,7 @@ private:
     ConstIter _begin;
     ConstIter _end;
     unsigned int _frame { 0 };
+    float _throttlingRatio { 0.0f };
 };
 
 #endif // hifi_AudioMixerSlave_h

--- a/assignment-client/src/audio/AudioMixerSlave.h
+++ b/assignment-client/src/audio/AudioMixerSlave.h
@@ -40,11 +40,13 @@ public:
 
 private:
     // create mix, returns true if mix has audio
-    bool prepareMix(const SharedNodePointer& node);
+    bool prepareMix(const SharedNodePointer& listener);
+    // check whether a node should be ignored
+    bool shouldIgnoreNode(const SharedNodePointer& listener, const SharedNodePointer& node);
     // add a stream to the mix
     void addStreamToMix(AudioMixerClientData& listenerData, const QUuid& streamerID,
             const AvatarAudioStream& listenerStream, const PositionalAudioStream& streamer,
-            bool throttle);
+            bool throttle = false);
 
     float gainForSource(const AvatarAudioStream& listener, const PositionalAudioStream& streamer,
             const glm::vec3& relativePosition, bool isEcho);

--- a/assignment-client/src/audio/AudioMixerSlavePool.cpp
+++ b/assignment-client/src/audio/AudioMixerSlavePool.cpp
@@ -41,7 +41,7 @@ void AudioMixerSlaveThread::wait() {
         });
         ++_pool._numStarted;
     }
-    configure(_pool._begin, _pool._end, _pool._frame);
+    configure(_pool._begin, _pool._end, _pool._frame, _pool._throttlingRatio);
 }
 
 void AudioMixerSlaveThread::notify(bool stopping) {
@@ -64,13 +64,14 @@ bool AudioMixerSlaveThread::try_pop(SharedNodePointer& node) {
 static AudioMixerSlave slave;
 #endif
 
-void AudioMixerSlavePool::mix(ConstIter begin, ConstIter end, unsigned int frame) {
+void AudioMixerSlavePool::mix(ConstIter begin, ConstIter end, unsigned int frame, float throttlingRatio) {
     _begin = begin;
     _end = end;
     _frame = frame;
+    _throttlingRatio = throttlingRatio;
 
 #ifdef AUDIO_SINGLE_THREADED
-    slave.configure(_begin, _end, frame);
+    slave.configure(_begin, _end, frame, throttlingRatio);
     std::for_each(begin, end, [&](const SharedNodePointer& node) {
         slave.mix(node);
     });

--- a/assignment-client/src/audio/AudioMixerSlavePool.h
+++ b/assignment-client/src/audio/AudioMixerSlavePool.h
@@ -61,7 +61,7 @@ public:
     ~AudioMixerSlavePool() { resize(0); }
 
     // mix on slave threads
-    void mix(ConstIter begin, ConstIter end, unsigned int frame);
+    void mix(ConstIter begin, ConstIter end, unsigned int frame, float throttlingRatio);
 
     // iterate over all slaves
     void each(std::function<void(AudioMixerSlave& slave)> functor);
@@ -90,6 +90,7 @@ private:
     // frame state
     Queue _queue;
     unsigned int _frame { 0 };
+    float _throttlingRatio { 0.0f };
     ConstIter _begin;
     ConstIter _end;
 };

--- a/assignment-client/src/audio/AudioMixerStats.cpp
+++ b/assignment-client/src/audio/AudioMixerStats.cpp
@@ -17,7 +17,7 @@ void AudioMixerStats::reset() {
     totalMixes = 0;
     hrtfRenders = 0;
     hrtfSilentRenders = 0;
-    hrtfStruggleRenders = 0;
+    hrtfThrottleRenders = 0;
     manualStereoMixes = 0;
     manualEchoMixes = 0;
 }
@@ -28,7 +28,7 @@ void AudioMixerStats::accumulate(const AudioMixerStats& otherStats) {
     totalMixes += otherStats.totalMixes;
     hrtfRenders += otherStats.hrtfRenders;
     hrtfSilentRenders += otherStats.hrtfSilentRenders;
-    hrtfStruggleRenders += otherStats.hrtfStruggleRenders;
+    hrtfThrottleRenders += otherStats.hrtfThrottleRenders;
     manualStereoMixes += otherStats.manualStereoMixes;
     manualEchoMixes += otherStats.manualEchoMixes;
 }

--- a/assignment-client/src/audio/AudioMixerStats.h
+++ b/assignment-client/src/audio/AudioMixerStats.h
@@ -20,7 +20,7 @@ struct AudioMixerStats {
 
     int hrtfRenders { 0 };
     int hrtfSilentRenders { 0 };
-    int hrtfStruggleRenders { 0 };
+    int hrtfThrottleRenders { 0 };
 
     int manualStereoMixes { 0 };
     int manualEchoMixes { 0 };


### PR DESCRIPTION
- Updates timing statistics for audio-mixer
- Updates sleep mechanism for audio-mixer (verified by new statistics)
- Updates throttle controller to use time-to-work instead of time-to-sleep
- Updates throttle controller (`AudioMixer::manageLoad` is now `AudioMixer::throttle`) to a proportional-integral controller (was exponential) with annotated constants
- Updates throttle mechanism to throttle by a fraction of each listening node's streams (was done by global volume)