### PR TITLE
ENTITY FILTERS: "Zone Filter"

### DIFF
--- a/script-archive/entity-server-filter-example.js
+++ b/script-archive/entity-server-filter-example.js
@@ -29,6 +29,28 @@ function filter(p) {
 			p.acceleration.z = 0;
 		}
     }
+    
+    /* Define an axis-aligned zone in which entities are not allowed to enter. */
+    /* This example zone corresponds to an area to the right of the spawnpoint
+    in your Sandbox. It's an area near the big rock to the right. If an entity
+    enters the zone, it'll move behind the rock.*/
+    var boxMin = {x: 25.5, y: -0.48, z: -9.9};
+    var boxMax = {x: 31.1, y: 4, z: -3.79};
+    var zero = {x: 0.0, y: 0.0, z: 0.0};
+    
+    if (p.position) {
+        var x = p.position.x;
+        var y = p.position.y;
+        var z = p.position.z;
+        if ((x > boxMin.x && x < boxMax.x) &&
+            (y > boxMin.y && y < boxMax.y) &&
+            (z > boxMin.z && z < boxMax.z)) {
+            /* Move it to the origin of the zone */
+            p.position = boxMin;
+            p.velocity = zero;
+            p.acceleration = zero;
+        }
+    }
 
     /* If we make it this far, return the (possibly modified) properties. */
     return p;


### PR DESCRIPTION
In this PR, I've included V1 of another entity filter.

1. A filter that prevents entities from entering a specific axis-aligned zone.

**To test this filters' efficacy:**
*Filter 1*
1. Enter your sandbox (I'm assuming you're using the default spawn point in the default sandbox).
2. Spawn a beach ball from the Marketplace immediately in front of you.
3. Use the domain settings page to apply Filter 1 to your sandbox, then apply the settings and restart the sandbox.
4. In your sandbox, throw the beach ball towards the corner of your sandbox to your *right*.
5. Verify that, mid-flight, the beach ball disappears and reappears behind the rock to your right.

See screenshot for zone location, etc. The Zone is hastily circled in Red; entities that enter the Zone will appear where the blue arrows are pointing.

![zone](https://cloud.githubusercontent.com/assets/3409031/22273566/580df8bc-e256-11e6-99b3-1b6a2a75b1a0.PNG)
