### PR TITLE
Disable sparse textures

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -92,6 +92,7 @@ void SparseInfo::maybeMakeSparse() {
     if (!texture._gpuObject.isAutogenerateMips()) {
         return;
     }
+    return;
 
     const uvec3 dimensions = texture._gpuObject.getDimensions();
     auto allowedPageDimensions = getPageDimensionsForFormat(texture._target, texture._internalFormat);


### PR DESCRIPTION
Disables all sparse textures, regardless of platform or user preferences.

## Testing

With this build, the application behavior should be the same, but in the stats display, the sparse textures count should remain 0 and sparse memory should stay at 0 MB.