### PR TITLE
PAL: Display avatar count in table header

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -158,8 +158,9 @@ Rectangle {
         onSortIndicatorOrderChanged: sortModel()
 
         TableViewColumn {
+            id: displayNameHeader
             role: "displayName"
-            title: "NAMES"
+            title: table.rowCount + (table.rowCount === 1 ? " NAME" : " NAMES")
             width: nameCardWidth
             movable: false
             resizable: false
@@ -351,6 +352,11 @@ Rectangle {
         visible: iAmAdmin
         color: hifi.colors.lightGrayText
     }
+    TextMetrics {
+        id: displayNameHeaderMetrics
+        text: displayNameHeader.title
+        font: displayNameHeader.font
+    }
     // This Rectangle refers to the [?] popup button next to "NAMES"
     Rectangle {
         color: hifi.colors.tableBackgroundLight
@@ -359,7 +365,7 @@ Rectangle {
         anchors.left: table.left
         anchors.top: table.top
         anchors.topMargin: 1
-        anchors.leftMargin: nameCardWidth/2 + 24
+        anchors.leftMargin: nameCardWidth/2 + displayNameHeaderMetrics.width/2 + 6
         RalewayRegular {
             id: helpText
             text: "[?]"


### PR DESCRIPTION
This PR adds an avatar count to the left of "NAMES" in the PAL table header. Useful for stats nerds and curious people.

**Test Plan**
1. Enter Sandbox A with Avatar A and Avatar B.
2. Open the PAL on Avatar A. Verify that "1 NAME [?]" appears in the table's left-most header. NOTE that the number should reflect the number of rows in the PAL - if it's more than 1, it won't say "1 NAME".
3. Verify that the "[?]" tooltip doesn't clip into the "NAME" text
4. Have Avatar B disconnect from Sandbox A. Have Avatar A refresh the PAL. Verify that "0 NAMES [?]" appears in the table's header.
5. Verify that the "[?]" tooltip doesn't clip into the "NAME" text.
6. Rejoice.