### PR TITLE
Hide webview context menus when clicked

### DIFF
--- a/interface/resources/QtWebEngine/UIDelegates/Menu.qml
+++ b/interface/resources/QtWebEngine/UIDelegates/Menu.qml
@@ -33,6 +33,7 @@ Item {
         propagateComposedEvents: true
         acceptedButtons: "AllButtons"
         onClicked: {
+            menu.visible = false;
             menu.done();
             mouse.accepted = false;
         }

--- a/interface/resources/QtWebEngine/UIDelegates/MenuItem.qml
+++ b/interface/resources/QtWebEngine/UIDelegates/MenuItem.qml
@@ -32,6 +32,7 @@ Item {
     MouseArea {
         anchors.fill: parent
         onClicked: {
+            menu.visible = false;
             root.triggered();
             menu.done();
         }


### PR DESCRIPTION
This PR fixes an issue where context menus remain visible even after selecting a menu item or clicking on the page background to dismiss.

To test:
* Open a webview from Desktop mode (like the <kbd>ctrl</kbd>-<kbd>b</kbd> browser or Marketplace).
* Bring up the context menu and verify that it disappears when:
  * clicking a disabled menu item.
  * clicking an active menu item (like "Reload," which should still perform the action).
  * clicking anywhere else on the web page.
