### PR TITLE
fetch entity filter script asynchronously (but reject edits while waiting)

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -294,7 +294,9 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
     }
 
     if (readOptionString("entityEditFilter", settingsSectionObject, _entityEditFilter) && !_entityEditFilter.isEmpty()) {
-        // Fetch script from file synchronously. We don't want the server processing edits while a restarting entity server is fetching from a DOS'd source.
+        // Tell the tree that we have a filter, so that it doesn't accept edits until we have a filter function set up.
+        std::static_pointer_cast<EntityTree>(_tree)->setHasEntityFilter(true);
+        // Now fetch script from file asynchronously.
         QUrl scriptURL(_entityEditFilter);
 
         // The following should be abstracted out for use in Agent.cpp (and maybe later AvatarMixer.cpp)
@@ -315,8 +317,6 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
         qInfo() << "Requesting script at URL" << qPrintable(scriptRequest->getUrl().toString());
         scriptRequest->send();
         qDebug() << "script request sent";
-        _scriptRequestLoop.exec(); // Block here, but allow the request to be processed and its signals to be handled.
-        qDebug() << "script request event loop complete";
     }
 }
 
@@ -367,11 +367,7 @@ void EntityServer::scriptRequestFinished() {
                     return hadUncaughtExceptions(_entityEditFilterEngine, _entityEditFilter);
                 });
                 scriptRequest->deleteLater();
-                qDebug() << "script request ending event loop. running:" << _scriptRequestLoop.isRunning();
-                if (_scriptRequestLoop.isRunning()) {
-                    _scriptRequestLoop.quit();
-                }
-                qDebug() << "script request event loop quit";
+                qDebug() << "script request filter processed";
                 return;
             }
         }
@@ -386,11 +382,6 @@ void EntityServer::scriptRequestFinished() {
     // Alas, only indications will be the above logging with assignment client restarting repeatedly, and clients will not see any entities.
     qDebug() << "script request failure causing stop";
     stop();
-    qDebug() << "script request ending event loop. running:" << _scriptRequestLoop.isRunning();
-    if (_scriptRequestLoop.isRunning()) {
-        _scriptRequestLoop.quit();
-    }
-    qDebug() << "script request event loop quit";
 }
 
 void EntityServer::nodeAdded(SharedNodePointer node) {

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -80,7 +80,6 @@ private:
 
     QString _entityEditFilter{};
     QScriptEngine _entityEditFilterEngine{};
-    QEventLoop _scriptRequestLoop{};
 };
 
 #endif // hifi_EntityServer_h

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -267,6 +267,7 @@ public:
     void notifyNewCollisionSoundURL(const QString& newCollisionSoundURL, const EntityItemID& entityID);
 
     void initEntityEditFilterEngine(QScriptEngine* engine, std::function<bool()> entityEditFilterHadUncaughtExceptions);
+    void setHasEntityFilter(bool hasFilter) { _hasEntityEditFilter = hasFilter; }
 
     static const float DEFAULT_MAX_TMP_ENTITY_LIFETIME;
 


### PR DESCRIPTION
This is an attempt to workaround the problem with filters on Linux.