### PR TITLE
Fix memory-leak in Windows audio stack (audiodg.exe grows without bound)

### DIFF
--- a/cmake/externals/wasapi/CMakeLists.txt
+++ b/cmake/externals/wasapi/CMakeLists.txt
@@ -6,8 +6,8 @@ if (WIN32)
   include(ExternalProject)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi6.zip
-    URL_MD5 fcac808c1ba0b0f5b44ea06e2612ebab
+    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi7.zip
+    URL_MD5 bc2861e50852dd590cdc773a14a041a7
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""


### PR DESCRIPTION
This PR fixes the memory-leak triggered by the constant polling for audio device changes in Interface.

QtMultimedia implements getAvailableDevices() by enumerating all audio devices, activating each interface and exhaustively testing with isFormatSupported(). Even after being freed via ComPtr and CoTaskMemFree() this results in the Windows audio process (audiodg.exe) leaking COM resources.

Fixed by adding a QAudioDeviceInfo cache of audio devices that have already been enumerated, to the audio plugin.