### PR TITLE
Adding support for disabling texturing from the material

### DIFF
--- a/libraries/render-utils/src/LightingModel.cpp
+++ b/libraries/render-utils/src/LightingModel.cpp
@@ -92,6 +92,15 @@ bool LightingModel::isAlbedoEnabled() const {
     return (bool)_parametersBuffer.get<Parameters>().enableAlbedo;
 }
 
+void LightingModel::setMaterialTexturing(bool enable) {
+    if (enable != isMaterialTexturingEnabled()) {
+        _parametersBuffer.edit<Parameters>().enableMaterialTexturing = (float)enable;
+    }
+}
+bool LightingModel::isMaterialTexturingEnabled() const {
+    return (bool)_parametersBuffer.get<Parameters>().enableMaterialTexturing;
+}
+
 void LightingModel::setAmbientLight(bool enable) {
     if (enable != isAmbientLightEnabled()) {
         _parametersBuffer.edit<Parameters>().enableAmbientLight = (float)enable;
@@ -150,6 +159,8 @@ void MakeLightingModel::configure(const Config& config) {
     _lightingModel->setSpecular(config.enableSpecular);
     _lightingModel->setAlbedo(config.enableAlbedo);
 
+    _lightingModel->setMaterialTexturing(config.enableMaterialTexturing);
+
     _lightingModel->setAmbientLight(config.enableAmbientLight);
     _lightingModel->setDirectionalLight(config.enableDirectionalLight);
     _lightingModel->setPointLight(config.enablePointLight);
@@ -160,5 +171,8 @@ void MakeLightingModel::configure(const Config& config) {
 
 void MakeLightingModel::run(const render::SceneContextPointer& sceneContext, const render::RenderContextPointer& renderContext, LightingModelPointer& lightingModel) {
 
-    lightingModel = _lightingModel; 
+    lightingModel = _lightingModel;
+
+    // make sure the enableTexturing flag of the render ARgs is in sync
+    renderContext->args->_enableTexturing = _lightingModel->isMaterialTexturingEnabled();
 }

--- a/libraries/render-utils/src/LightingModel.h
+++ b/libraries/render-utils/src/LightingModel.h
@@ -49,6 +49,8 @@ public:
     void setAlbedo(bool enable);
     bool isAlbedoEnabled() const;
 
+    void setMaterialTexturing(bool enable);
+    bool isMaterialTexturingEnabled() const;
 
     void setAmbientLight(bool enable);
     bool isAmbientLightEnabled() const;
@@ -88,9 +90,12 @@ protected:
         float enableSpotLight{ 1.0f };
 
         float showLightContour{ 0.0f }; // false by default
+
         float enableObscurance{ 1.0f };
 
-        glm::vec2 spares{ 0.0f };
+        float enableMaterialTexturing { 1.0f };
+
+        float spares{ 0.0f };
 
         Parameters() {}
     };
@@ -117,6 +122,8 @@ class MakeLightingModelConfig : public render::Job::Config {
     Q_PROPERTY(bool enableSpecular MEMBER enableSpecular NOTIFY dirty)
     Q_PROPERTY(bool enableAlbedo MEMBER enableAlbedo NOTIFY dirty)
 
+    Q_PROPERTY(bool enableMaterialTexturing MEMBER enableMaterialTexturing NOTIFY dirty)
+
     Q_PROPERTY(bool enableAmbientLight MEMBER enableAmbientLight NOTIFY dirty)
     Q_PROPERTY(bool enableDirectionalLight MEMBER enableDirectionalLight NOTIFY dirty)
     Q_PROPERTY(bool enablePointLight MEMBER enablePointLight NOTIFY dirty)
@@ -136,12 +143,15 @@ public:
     bool enableScattering{ true };
     bool enableDiffuse{ true };
     bool enableSpecular{ true };
+
     bool enableAlbedo{ true };
+    bool enableMaterialTexturing { true };
 
     bool enableAmbientLight{ true };
     bool enableDirectionalLight{ true };
     bool enablePointLight{ true };
     bool enableSpotLight{ true };
+
 
     bool showLightContour { false }; // false by default
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -129,7 +129,7 @@ void MeshPartPayload::bindMesh(gpu::Batch& batch) const {
     }
 }
 
-void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::LocationsPointer locations) const {
+void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::LocationsPointer locations, bool enableTextures) const {
     if (!_drawMaterial) {
         return;
     }
@@ -148,7 +148,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Albedo
-    if (materialKey.isAlbedoMap()) {
+    if (enableTextures && materialKey.isAlbedoMap()) {
         auto itr = textureMaps.find(model::MaterialKey::ALBEDO_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::ALBEDO, itr->second->getTextureView());
@@ -160,7 +160,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Roughness map
-    if (materialKey.isRoughnessMap()) {
+    if (enableTextures && materialKey.isRoughnessMap()) {
         auto itr = textureMaps.find(model::MaterialKey::ROUGHNESS_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::ROUGHNESS, itr->second->getTextureView());
@@ -174,7 +174,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Normal map
-    if (materialKey.isNormalMap()) {
+    if (enableTextures && materialKey.isNormalMap()) {
         auto itr = textureMaps.find(model::MaterialKey::NORMAL_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::NORMAL, itr->second->getTextureView());
@@ -188,7 +188,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Metallic map
-    if (materialKey.isMetallicMap()) {
+    if (enableTextures && materialKey.isMetallicMap()) {
         auto itr = textureMaps.find(model::MaterialKey::METALLIC_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::METALLIC, itr->second->getTextureView());
@@ -202,7 +202,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Occlusion map
-    if (materialKey.isOcclusionMap()) {
+    if (enableTextures && materialKey.isOcclusionMap()) {
         auto itr = textureMaps.find(model::MaterialKey::OCCLUSION_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::OCCLUSION, itr->second->getTextureView());
@@ -216,7 +216,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Scattering map
-    if (materialKey.isScatteringMap()) {
+    if (enableTextures && materialKey.isScatteringMap()) {
         auto itr = textureMaps.find(model::MaterialKey::SCATTERING_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::SCATTERING, itr->second->getTextureView());
@@ -230,7 +230,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Emissive / Lightmap
-    if (materialKey.isLightmapMap()) {
+    if (enableTextures && materialKey.isLightmapMap()) {
         auto itr = textureMaps.find(model::MaterialKey::LIGHTMAP_MAP);
 
         if (itr != textureMaps.end() && itr->second->isDefined()) {
@@ -238,7 +238,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
         } else {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, textureCache->getGrayTexture());
         }
-    } else if (materialKey.isEmissiveMap()) {
+    } else if (enableTextures && materialKey.isEmissiveMap()) {
         auto itr = textureMaps.find(model::MaterialKey::EMISSIVE_MAP);
 
         if (itr != textureMaps.end() && itr->second->isDefined()) {
@@ -271,7 +271,7 @@ void MeshPartPayload::render(RenderArgs* args) const {
     bindMesh(batch);
 
     // apply material properties
-    bindMaterial(batch, locations);
+    bindMaterial(batch, locations, args->_enableTexturing);
 
     if (args) {
         args->_details._materialSwitches++;
@@ -588,7 +588,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     bindMesh(batch);
 
     // apply material properties
-    bindMaterial(batch, locations);
+    bindMaterial(batch, locations, args->_enableTexturing);
 
     args->_details._materialSwitches++;
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -147,8 +147,19 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
         numUnlit++;
     }
 
+    if (!enableTextures) {
+        batch.setResourceTexture(ShapePipeline::Slot::ALBEDO, textureCache->getWhiteTexture());
+        batch.setResourceTexture(ShapePipeline::Slot::MAP::ROUGHNESS, textureCache->getWhiteTexture());
+        batch.setResourceTexture(ShapePipeline::Slot::MAP::NORMAL, nullptr);
+        batch.setResourceTexture(ShapePipeline::Slot::MAP::METALLIC, nullptr);
+        batch.setResourceTexture(ShapePipeline::Slot::MAP::OCCLUSION, nullptr);
+        batch.setResourceTexture(ShapePipeline::Slot::MAP::SCATTERING, nullptr);
+        batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, nullptr);
+        return;
+    }
+
     // Albedo
-    if (enableTextures && materialKey.isAlbedoMap()) {
+    if (materialKey.isAlbedoMap()) {
         auto itr = textureMaps.find(model::MaterialKey::ALBEDO_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::ALBEDO, itr->second->getTextureView());
@@ -160,7 +171,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Roughness map
-    if (enableTextures && materialKey.isRoughnessMap()) {
+    if (materialKey.isRoughnessMap()) {
         auto itr = textureMaps.find(model::MaterialKey::ROUGHNESS_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::ROUGHNESS, itr->second->getTextureView());
@@ -174,7 +185,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Normal map
-    if (enableTextures && materialKey.isNormalMap()) {
+    if (materialKey.isNormalMap()) {
         auto itr = textureMaps.find(model::MaterialKey::NORMAL_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::NORMAL, itr->second->getTextureView());
@@ -188,7 +199,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Metallic map
-    if (enableTextures && materialKey.isMetallicMap()) {
+    if (materialKey.isMetallicMap()) {
         auto itr = textureMaps.find(model::MaterialKey::METALLIC_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::METALLIC, itr->second->getTextureView());
@@ -202,7 +213,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Occlusion map
-    if (enableTextures && materialKey.isOcclusionMap()) {
+    if (materialKey.isOcclusionMap()) {
         auto itr = textureMaps.find(model::MaterialKey::OCCLUSION_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::OCCLUSION, itr->second->getTextureView());
@@ -216,7 +227,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Scattering map
-    if (enableTextures && materialKey.isScatteringMap()) {
+    if (materialKey.isScatteringMap()) {
         auto itr = textureMaps.find(model::MaterialKey::SCATTERING_MAP);
         if (itr != textureMaps.end() && itr->second->isDefined()) {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::SCATTERING, itr->second->getTextureView());
@@ -230,7 +241,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
     }
 
     // Emissive / Lightmap
-    if (enableTextures && materialKey.isLightmapMap()) {
+    if (materialKey.isLightmapMap()) {
         auto itr = textureMaps.find(model::MaterialKey::LIGHTMAP_MAP);
 
         if (itr != textureMaps.end() && itr->second->isDefined()) {
@@ -238,7 +249,7 @@ void MeshPartPayload::bindMaterial(gpu::Batch& batch, const ShapePipeline::Locat
         } else {
             batch.setResourceTexture(ShapePipeline::Slot::MAP::EMISSIVE_LIGHTMAP, textureCache->getGrayTexture());
         }
-    } else if (enableTextures && materialKey.isEmissiveMap()) {
+    } else if (materialKey.isEmissiveMap()) {
         auto itr = textureMaps.find(model::MaterialKey::EMISSIVE_MAP);
 
         if (itr != textureMaps.end() && itr->second->isDefined()) {

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -51,7 +51,7 @@ public:
     // ModelMeshPartPayload functions to perform render
     void drawCall(gpu::Batch& batch) const;
     virtual void bindMesh(gpu::Batch& batch) const;
-    virtual void bindMaterial(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations) const;
+    virtual void bindMaterial(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, bool enableTextures) const;
     virtual void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const;
 
     // Payload resource cached values

--- a/libraries/shared/src/RenderArgs.h
+++ b/libraries/shared/src/RenderArgs.h
@@ -122,6 +122,7 @@ public:
     gpu::Batch* _batch = nullptr;
 
     std::shared_ptr<gpu::Texture> _whiteTexture;
+    bool _enableTexturing { true };
 
     RenderDetails _details;
 };

--- a/scripts/developer/utilities/render/deferredLighting.qml
+++ b/scripts/developer/utilities/render/deferredLighting.qml
@@ -25,6 +25,7 @@ Column {
                      "Lightmap:LightingModel:enableLightmap",
                      "Background:LightingModel:enableBackground",                      
                      "ssao:AmbientOcclusion:enabled",                      
+                     "Textures:LightingModel:enableMaterialTexturing",                      
                 ]
                 CheckBox {
                     text: modelData.split(":")[0]


### PR DESCRIPTION
a new toggle carried by the LightingModel object to eventually disable the usage of the material textures  and instead fall back to the default simple textures.

If disabled before any texture is used for rendering in a frame then this also a way to test the cost of the loading time of the textures by avoiding it and compare the time saved vs the normal case.

## Test Plan
By default there is zero change compared to the current master
Runnning the script debugDeferredLighting.js  (from this pr) you should see a new checkbox "Textures" in the first column at the bottom. When disabling it all the material textures should disappear.
When starting from an empty scene and disableing the Textures feature then going to a texture rich environment (such as playa for exemple) you should expect a much faster loading of the scene, no stuttering at all and controlling the gpu memory consumption in the stats window, no texture allocated.