### PR TITLE
Fix animation jitter

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -320,12 +320,9 @@ bool RenderableModelEntityItem::getAnimationFrame() {
                         glm::mat4 finalMat = (translationMat * fbxJoints[index].preTransform *
                                               rotationMat * fbxJoints[index].postTransform);
                         _localJointTranslations[j] = extractTranslation(finalMat);
-                        _localJointTranslationsSet[j] = true;
                         _localJointTranslationsDirty[j] = true;
 
                         _localJointRotations[j] = glmExtractRotation(finalMat);
-
-                        _localJointRotationsSet[j] = true;
                         _localJointRotationsDirty[j] = true;
                     }
                 }


### PR DESCRIPTION
Don't set joint "set" flags for animation values

Test plan:
- In HMD mode, run [this script](http://hifi-pet.herokuapp.com/scripts/summonDragonJointCrashAnimated.js)
- move your head around
- On master, the animation will jitter, not on this PR


Fixes [2194](https://highfidelity.fogbugz.com/f/cases/2194)