### PR TITLE
Require password verification in domain-server settings

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -373,6 +373,13 @@
           "value-hidden": true
         },
         {
+            "name": "verify_http_password",
+            "label": "Verify HTTP Password",
+            "type": "password",
+            "help": "Must match the password entered above for change to be saved.",
+            "value-hidden": true
+        },
+        {
           "name": "maximum_user_capacity",
           "label": "Maximum User Capacity",
           "help": "The limit on how many users can be connected at once (0 means no limit). Avatars connected from the same machine will not count towards this limit.",

--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -904,10 +904,18 @@ function saveSettings() {
   var formJSON = form2js('settings-form', ".", false, cleanupFormValues, true);
 
   // check if we've set the basic http password - if so convert it to base64
+  var canPost = true;
   if (formJSON["security"]) {
     var password = formJSON["security"]["http_password"];
+    var verify_password = formJSON["security"]["verify_http_password"];
     if (password && password.length > 0) {
-      formJSON["security"]["http_password"] = sha256_digest(password);
+      if (password != verify_password) {
+        bootbox.alert({"message": "Passwords must match!", "title":"Password Error"});
+        canPost = false;
+      } else {
+        formJSON["security"]["http_password"] = sha256_digest(password);
+        delete formJSON["security"]["verify_http_password"];
+      }
     }
   }
 
@@ -923,7 +931,9 @@ function saveSettings() {
   $(this).blur();
 
   // POST the form JSON to the domain-server settings.json endpoint so the settings are saved
-  postSettings(formJSON);
+  if (canPost) {
+    postSettings(formJSON);
+  }
 }
 
 $('body').on('click', '.save-button', function(e){


### PR DESCRIPTION
If you modify the security settings to use a username/password for access to the domain server settings, we now have a second password field which must match the first one you entered.  If they do not match, the settings are not saved, and there is a simple message to alert the user.