### PR TITLE
Replace permission error messages with login window

### DIFF
--- a/interface/src/scripting/DialogsManagerScriptingInterface.cpp
+++ b/interface/src/scripting/DialogsManagerScriptingInterface.cpp
@@ -29,5 +29,10 @@ void DialogsManagerScriptingInterface::toggleAddressBar() {
 
 void DialogsManagerScriptingInterface::showFeed() {
     QMetaObject::invokeMethod(DependencyManager::get<DialogsManager>().data(),
-        "showFeed", Qt::QueuedConnection);
+                              "showFeed", Qt::QueuedConnection);
+}
+
+void DialogsManagerScriptingInterface::showLoginDialog() {
+    QMetaObject::invokeMethod(DependencyManager::get<DialogsManager>().data(),
+                              "showLoginDialog", Qt::QueuedConnection);
 }

--- a/interface/src/scripting/DialogsManagerScriptingInterface.h
+++ b/interface/src/scripting/DialogsManagerScriptingInterface.h
@@ -19,6 +19,7 @@ class DialogsManagerScriptingInterface : public QObject {
 public:
     DialogsManagerScriptingInterface();
     Q_INVOKABLE void showFeed();
+    Q_INVOKABLE void showLoginDialog();
 
 public slots:
     void toggleAddressBar();

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -466,7 +466,9 @@ var toolBar = (function () {
             return;
         }
         if (active && !Entities.canRez() && !Entities.canRezTmp()) {
-            DialogsManager.showLoginDialog();
+            if (!Account.isLoggedIn()) {
+                DialogsManager.showLoginDialog();
+            }
             Window.notifyEditError(INSUFFICIENT_PERMISSIONS_ERROR_MSG);
             return;
         }
@@ -1231,7 +1233,9 @@ function getPositionToImportEntity() {
 }
 function importSVO(importURL) {
     if (!Entities.canRez() && !Entities.canRezTmp()) {
-        DialogsManager.showLoginDialog();
+        if (!Account.isLoggedIn()) {
+            DialogsManager.showLoginDialog();
+        }
         Window.notifyEditError(INSUFFICIENT_PERMISSIONS_IMPORT_ERROR_MSG);
         return;
     }

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -466,7 +466,9 @@ var toolBar = (function () {
             return;
         }
         if (active && !Entities.canRez() && !Entities.canRezTmp()) {
-            Window.notifyEditError(INSUFFICIENT_PERMISSIONS_ERROR_MSG);
+            // Window.notifyEditError(INSUFFICIENT_PERMISSIONS_ERROR_MSG);
+            DialogsManager.toggleLoginDialog();
+            print("testing login window popup")
             return;
         }
         Messages.sendLocalMessage("edit-events", JSON.stringify({

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -466,9 +466,8 @@ var toolBar = (function () {
             return;
         }
         if (active && !Entities.canRez() && !Entities.canRezTmp()) {
-            // Window.notifyEditError(INSUFFICIENT_PERMISSIONS_ERROR_MSG);
-            DialogsManager.toggleLoginDialog();
-            print("testing login window popup")
+            DialogsManager.showLoginDialog();
+            Window.notifyEditError(INSUFFICIENT_PERMISSIONS_ERROR_MSG);
             return;
         }
         Messages.sendLocalMessage("edit-events", JSON.stringify({
@@ -1232,6 +1231,7 @@ function getPositionToImportEntity() {
 }
 function importSVO(importURL) {
     if (!Entities.canRez() && !Entities.canRezTmp()) {
+        DialogsManager.showLoginDialog();
         Window.notifyEditError(INSUFFICIENT_PERMISSIONS_IMPORT_ERROR_MSG);
         return;
     }

--- a/scripts/tutorials/createDice.js
+++ b/scripts/tutorials/createDice.js
@@ -6,8 +6,8 @@
 //  Persist toolbar by HRS 6/11/15.
 //  Copyright 2015 High Fidelity, Inc.
 //
-//  Press the dice button to throw some dice from the center of the screen. 
-//  Change NUMBER_OF_DICE to change the number thrown (Yahtzee, anyone?) 
+//  Press the dice button to throw some dice from the center of the screen.
+//  Change NUMBER_OF_DICE to change the number thrown (Yahtzee, anyone?)
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -78,6 +78,9 @@ var MAX_ANGULAR_SPEED = Math.PI;
 function shootDice(position, velocity) {
   if (!Entities.canRez()) {
     Window.alert(INSUFFICIENT_PERMISSIONS_ERROR_MSG);
+    if (!Account.isLoggedIn()) {
+        DialogsManager.showLoginDialog();
+    }
   } else {
     for (var i = 0; i < NUMBER_OF_DICE; i++) {
       dice.push(Entities.addEntity({


### PR DESCRIPTION
Resolution for: https://highfidelity.fogbugz.com/f/cases/2830/Swap-the-necessary-permissions-message-for-a-login-button 

Add showLoginDialog to Scripting Interface. Open login prompt on permissions error if user is not logged in. Affects the errors: INSUFFICIENT_PERMISSIONS_IMPORT_ERROR_MSG and INSUFFICIENT_PERMISSIONS_ERROR_MSG.

Test by triggering these errors while logged out, and while logged in. Login window should open on these errors, when logged out only.