### PR TITLE
PAL: Raise virtual keyboard when editing DisplayName in HMD

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -34,6 +34,7 @@ Item {
     property bool isMyCard: false
     property bool selected: false
     property bool isAdmin: false
+    property bool currentlyEditingDisplayName: false
 
     /* User image commented out for now - will probably be re-introduced later.
     Column {
@@ -104,6 +105,7 @@ Item {
                     focus = false
                     myDisplayName.border.width = 0
                     color = hifi.colors.darkGray
+                    currentlyEditingDisplayName = false
                 }
             }
             MouseArea {
@@ -115,10 +117,12 @@ Item {
                     myDisplayNameText.focus ? myDisplayNameText.cursorPosition = myDisplayNameText.positionAt(mouseX, mouseY, TextInput.CursorOnCharacter) : myDisplayNameText.selectAll();
                     myDisplayNameText.focus = true
                     myDisplayNameText.color = "black"
+                    currentlyEditingDisplayName = true
                 }
                 onDoubleClicked: {
                     myDisplayNameText.selectAll();
                     myDisplayNameText.focus = true;
+                    currentlyEditingDisplayName = true
                 }
                 onEntered: myDisplayName.color = hifi.colors.lightGrayText
                 onExited: myDisplayName.color = hifi.colors.textFieldLightBackground

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -51,6 +51,7 @@ Rectangle {
 
     // This is the container for the PAL
     Rectangle {
+        property bool punctuationMode: false
         id: palContainer
         // Size
         width: pal.width - 50
@@ -419,6 +420,16 @@ Rectangle {
                                  "<b>Ban</b> removes a user from this domain and prevents them from returning. Admins can un-ban users from the Sandbox Domain Settings page.")
             onEntered: adminHelpText.color = "#94132e"
             onExited: adminHelpText.color = hifi.colors.redHighlight
+        }
+    }
+    HifiControls.Keyboard {
+        id: keyboard
+        raised: myCard.currentlyEditingDisplayName && HMD.active
+        numeric: parent.punctuationMode
+        anchors {
+            bottom: parent.bottom
+            left: parent.left
+            right: parent.right
         }
     }
     }


### PR DESCRIPTION
This PR raises the virtual keyboard when editing DisplayName in the PAL while in HMD.

**Test Plan:**
* In desktop mode, open the PAL. Click on your DisplayName at the top of the PAL. Verify that the virtual keyboard **doesn't** come up and that you can edit the DisplayName as before.
* In HMD mode, open the PAL. Click on your DisplayName at the top of the PAL. Verify that the virtual keyboard **does** come up and that you can edit the DisplayName as before. Verify that the virtual keyboard closes when you press enter or click off the DisplayName field.