### PR TITLE
PAL: Fix Spam upon Identity Change

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -593,10 +593,15 @@ void AvatarMixer::handleAvatarIdentityPacket(QSharedPointer<ReceivedMessage> mes
             // parse the identity packet and update the change timestamp if appropriate
             AvatarData::Identity identity;
             AvatarData::parseAvatarIdentityPacket(message->getMessage(), identity);
-            if (avatar.processAvatarIdentity(identity)) {
+            bool identityChanged = false;
+            bool displayNameChanged = false;
+            avatar.processAvatarIdentity(identity, identityChanged, displayNameChanged);
+            if (identityChanged) {
                 QMutexLocker nodeDataLocker(&nodeData->getMutex());
                 nodeData->flagIdentityChange();
-                nodeData->setAvatarSessionDisplayNameMustChange(true);
+                if (displayNameChanged) {
+                    nodeData->setAvatarSessionDisplayNameMustChange(true);
+                }
             }
         }
     }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1336,24 +1336,24 @@ const QUrl& AvatarData::cannonicalSkeletonModelURL(const QUrl& emptyURL) {
     return _skeletonModelURL.scheme() == "file" ? emptyURL : _skeletonModelURL;
 }
 
-bool AvatarData::processAvatarIdentity(const Identity& identity) {
-    bool hasIdentityChanged = false;
+void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged) {
 
     if (_firstSkeletonCheck || (identity.skeletonModelURL != cannonicalSkeletonModelURL(emptyURL))) {
         setSkeletonModelURL(identity.skeletonModelURL);
-        hasIdentityChanged = true;
+        identityChanged = true;
         _firstSkeletonCheck = false;
     }
 
     if (identity.displayName != _displayName) {
         _displayName = identity.displayName;
-        hasIdentityChanged = true;
+        identityChanged = true;
+        displayNameChanged = true;
     }
     maybeUpdateSessionDisplayNameFromTransport(identity.sessionDisplayName);
 
     if (identity.attachmentData != _attachmentData) {
         setAttachmentData(identity.attachmentData);
-        hasIdentityChanged = true;
+        identityChanged = true;
     }
 
     bool avatarEntityDataChanged = false;
@@ -1362,10 +1362,8 @@ bool AvatarData::processAvatarIdentity(const Identity& identity) {
     });
     if (avatarEntityDataChanged) {
         setAvatarEntityData(identity.avatarEntityData);
-        hasIdentityChanged = true;
+        identityChanged = true;
     }
-
-    return hasIdentityChanged;
 }
 
 QByteArray AvatarData::identityByteArray() {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1341,6 +1341,9 @@ void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityC
     if (_firstSkeletonCheck || (identity.skeletonModelURL != cannonicalSkeletonModelURL(emptyURL))) {
         setSkeletonModelURL(identity.skeletonModelURL);
         identityChanged = true;
+        if (_firstSkeletonCheck) {
+            displayNameChanged = true;
+        }
         _firstSkeletonCheck = false;
     }
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -471,8 +471,9 @@ public:
 
     static void parseAvatarIdentityPacket(const QByteArray& data, Identity& identityOut);
 
-    // returns true if identity has changed, false otherwise.
-    bool processAvatarIdentity(const Identity& identity);
+    // identityChanged returns true if identity has changed, false otherwise.
+    // displayNameChanged returns true if displayName has changed, false otherwise.
+    void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged);
 
     QByteArray identityByteArray();
 

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -148,7 +148,9 @@ void AvatarHashMap::processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> 
     if (!nodeList->isIgnoringNode(identity.uuid) || nodeList->getRequestsDomainListData()) {
         // mesh URL for a UUID, find avatar in our list
         auto avatar = newOrExistingAvatar(identity.uuid, sendingNode);
-        avatar->processAvatarIdentity(identity);
+        bool identityChanged = false;
+        bool displayNameChanged = false;
+        avatar->processAvatarIdentity(identity, identityChanged, displayNameChanged);
     }
 }
 


### PR DESCRIPTION
This PR fixes the bug where moving the tablet results in the Avatar Mixer spamming "Giving display name X to UUID Y". The bug was actually due to a problem with an original design choice I made with this code.

From the client side, no changes should be visible. Thus, the test plan here is pretty barebones.

**Test Plan:**
1. Open the PAL via the tablet. Verify that you have a display name.
2. Move the tablet around. Refresh the PAL.
3. Verify that you still have the same display name. Close the PAL.
4. Have another avatar connect to the same domain as you.  Open the PAL. Verify that both of you have unique display names.
5. Change your display name. On the other client, refresh the PAL. Verify that the new display name appears. on their PAL.