### PR TITLE
filter gets isAdd argument

### DIFF
--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -357,7 +357,7 @@ protected:
 
     float _maxTmpEntityLifetime { DEFAULT_MAX_TMP_ENTITY_LIFETIME };
 
-    bool filterProperties(EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged);
+    bool filterProperties(EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, bool isAdd);
     bool _hasEntityEditFilter{ false };
     QScriptEngine* _entityEditFilterEngine{};
     QScriptValue _entityEditFilterFunction{};


### PR DESCRIPTION
Entity filter functions now accept an optional boolean indicating whether the request is to add an entity (as opposed to editing one).