### PR TITLE
Cap fbx texture size

### DIFF
--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -105,7 +105,7 @@ public:
     glm::mat4 inverseBindMatrix;
 };
 
-const int MAX_FBX_TEXTURE_SIZE = 1024 * 1024;
+const int MAX_FBX_TEXTURE_NUM_PIXELS = 1024 * 1024;
 
 /// A texture map in an FBX document.
 class FBXTexture {
@@ -115,7 +115,7 @@ public:
     QByteArray content;
 
     Transform transform;
-    int maxSize { MAX_FBX_TEXTURE_SIZE };
+    int maxNumPixels { MAX_FBX_TEXTURE_NUM_PIXELS };
     int texcoordSet;
     QString texcoordSetName;
 

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -13,6 +13,7 @@
 #define hifi_FBXReader_h
 
 #include <QMetaType>
+#include <QSet>
 #include <QUrl>
 #include <QVarLengthArray>
 #include <QVariant>
@@ -105,7 +106,7 @@ public:
     glm::mat4 inverseBindMatrix;
 };
 
-const int MAX_FBX_TEXTURE_NUM_PIXELS = 1024 * 1024;
+const int MAX_NUM_PIXELS_FOR_FBX_TEXTURE = 2048 * 2048;
 
 /// A texture map in an FBX document.
 class FBXTexture {
@@ -115,7 +116,7 @@ public:
     QByteArray content;
 
     Transform transform;
-    int maxNumPixels { MAX_FBX_TEXTURE_NUM_PIXELS };
+    int maxNumPixels { MAX_NUM_PIXELS_FOR_FBX_TEXTURE };
     int texcoordSet;
     QString texcoordSetName;
 
@@ -145,6 +146,9 @@ public:
         emissiveColor(emissiveColor),
         shininess(shininess),
         opacity(opacity)  {}
+
+    void getTextureNames(QSet<QString>& textureList) const;
+    void setMaxNumPixelsPerTexture(int maxNumPixels);
 
     glm::vec3 diffuseColor{ 1.0f };
     float diffuseFactor{ 1.0f };

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -100,10 +100,12 @@ public:
 /// A single binding to a joint in an FBX document.
 class FBXCluster {
 public:
-    
+
     int jointIndex;
     glm::mat4 inverseBindMatrix;
 };
+
+const int MAX_FBX_TEXTURE_SIZE = 1024 * 1024;
 
 /// A texture map in an FBX document.
 class FBXTexture {
@@ -111,11 +113,12 @@ public:
     QString name;
     QByteArray filename;
     QByteArray content;
-    
+
     Transform transform;
+    int maxSize { MAX_FBX_TEXTURE_SIZE };
     int texcoordSet;
     QString texcoordSetName;
-    
+
     bool isBumpmap{ false };
 
     bool isNull() const { return name.isEmpty() && filename.isEmpty() && content.isEmpty(); }

--- a/libraries/fbx/src/FBXReader_Material.cpp
+++ b/libraries/fbx/src/FBXReader_Material.cpp
@@ -47,10 +47,10 @@ FBXTexture FBXReader::getTexture(const QString& textureID) {
     texture.texcoordSet = 0;
     if (_textureParams.contains(textureID)) {
         auto p = _textureParams.value(textureID);
-        
+
         texture.transform.setTranslation(p.translation);
         texture.transform.setRotation(glm::quat(glm::radians(p.rotation)));
-        
+
         auto scaling = p.scaling;
         // Protect from bad scaling which should never happen
         if (scaling.x == 0.0f) {
@@ -63,7 +63,7 @@ FBXTexture FBXReader::getTexture(const QString& textureID) {
             scaling.z = 1.0f;
         }
         texture.transform.setScale(scaling);
-        
+
         if ((p.UVSet != "map1") && (p.UVSet != "UVSet0")) {
             texture.texcoordSet = 1;
         }
@@ -78,11 +78,10 @@ void FBXReader::consolidateFBXMaterials(const QVariantHash& mapping) {
     QJsonDocument materialMapDocument = QJsonDocument::fromJson(materialMapString.toUtf8());
     QJsonObject materialMap = materialMapDocument.object();
 
-    // foreach (const QString& materialID, materials) {
     for (QHash<QString, FBXMaterial>::iterator it = _fbxMaterials.begin(); it != _fbxMaterials.end(); it++) {
         FBXMaterial& material = (*it);
 
-        // Maya is the exporting the shading model and we aretrying to use it
+        // Maya is the exporting the shading model and we are trying to use it
         bool isMaterialLambert = (material.shadingModel.toLower() == "lambert");
 
         // the pure material associated with this part
@@ -127,21 +126,19 @@ void FBXReader::consolidateFBXMaterials(const QVariantHash& mapping) {
             detectDifferentUVs |= (transparentTexture.texcoordSet != 0) || (!transparentTexture.transform.isIdentity());
         }
 
-
-
         FBXTexture normalTexture;
         QString bumpTextureID = bumpTextures.value(material.materialID);
         QString normalTextureID = normalTextures.value(material.materialID);
         if (!normalTextureID.isNull()) {
             normalTexture = getTexture(normalTextureID);
             normalTexture.isBumpmap = false;
-            
+
             material.normalTexture = normalTexture;
             detectDifferentUVs |= (normalTexture.texcoordSet != 0) || (!normalTexture.transform.isIdentity());
         } else if (!bumpTextureID.isNull()) {
             normalTexture = getTexture(bumpTextureID);
             normalTexture.isBumpmap = true;
-            
+
             material.normalTexture = normalTexture;
             detectDifferentUVs |= (normalTexture.texcoordSet != 0) || (!normalTexture.transform.isIdentity());
         }
@@ -151,7 +148,7 @@ void FBXReader::consolidateFBXMaterials(const QVariantHash& mapping) {
         if (!specularTextureID.isNull()) {
             specularTexture = getTexture(specularTextureID);
             detectDifferentUVs |= (specularTexture.texcoordSet != 0) || (!specularTexture.transform.isIdentity());
-            material.specularTexture = specularTexture;            
+            material.specularTexture = specularTexture;
         }
 
         FBXTexture metallicTexture;
@@ -222,7 +219,7 @@ void FBXReader::consolidateFBXMaterials(const QVariantHash& mapping) {
                 ambientTextureID = ambientFactorTextures.value(material.materialID);
             }
         }
-        
+
         if (_loadLightmaps && !ambientTextureID.isNull()) {
             ambientTexture = getTexture(ambientTextureID);
             detectDifferentUVs |= (ambientTexture.texcoordSet != 0) || (!ambientTexture.transform.isIdentity());

--- a/libraries/fbx/src/FBXReader_Material.cpp
+++ b/libraries/fbx/src/FBXReader_Material.cpp
@@ -27,6 +27,56 @@
 
 #include "ModelFormatLogging.h"
 
+void FBXMaterial::getTextureNames(QSet<QString>& textureList) const {
+    if (!normalTexture.isNull()) {
+        textureList.insert(normalTexture.name);
+    }
+    if (!albedoTexture.isNull()) {
+        textureList.insert(albedoTexture.name);
+    }
+    if (!opacityTexture.isNull()) {
+        textureList.insert(opacityTexture.name);
+    }
+    if (!glossTexture.isNull()) {
+        textureList.insert(glossTexture.name);
+    }
+    if (!roughnessTexture.isNull()) {
+        textureList.insert(roughnessTexture.name);
+    }
+    if (!specularTexture.isNull()) {
+        textureList.insert(specularTexture.name);
+    }
+    if (!metallicTexture.isNull()) {
+        textureList.insert(metallicTexture.name);
+    }
+    if (!emissiveTexture.isNull()) {
+        textureList.insert(emissiveTexture.name);
+    }
+    if (!occlusionTexture.isNull()) {
+        textureList.insert(occlusionTexture.name);
+    }
+    if (!scatteringTexture.isNull()) {
+        textureList.insert(scatteringTexture.name);
+    }
+    if (!lightmapTexture.isNull()) {
+        textureList.insert(lightmapTexture.name);
+    }
+}
+
+void FBXMaterial::setMaxNumPixelsPerTexture(int maxNumPixels) {
+    normalTexture.maxNumPixels = maxNumPixels;
+    albedoTexture.maxNumPixels = maxNumPixels;
+    opacityTexture.maxNumPixels = maxNumPixels;
+    glossTexture.maxNumPixels = maxNumPixels;
+    roughnessTexture.maxNumPixels = maxNumPixels;
+    specularTexture.maxNumPixels = maxNumPixels;
+    metallicTexture.maxNumPixels = maxNumPixels;
+    emissiveTexture.maxNumPixels = maxNumPixels;
+    occlusionTexture.maxNumPixels = maxNumPixels;
+    scatteringTexture.maxNumPixels = maxNumPixels;
+    lightmapTexture.maxNumPixels = maxNumPixels;
+}
+
 bool FBXMaterial::needTangentSpace() const {
     return !normalTexture.isNull();
 }

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -472,7 +472,7 @@ QUrl NetworkMaterial::getTextureUrl(const QUrl& baseUrl, const FBXTexture& textu
 model::TextureMapPointer NetworkMaterial::fetchTextureMap(const QUrl& baseUrl, const FBXTexture& fbxTexture,
                                                         TextureType type, MapChannel channel) {
     const auto url = getTextureUrl(baseUrl, fbxTexture);
-    const auto texture = DependencyManager::get<TextureCache>()->getTexture(url, type, fbxTexture.content);
+    const auto texture = DependencyManager::get<TextureCache>()->getTexture(url, type, fbxTexture.content, fbxTexture.maxSize);
     _textures[channel] = Texture { fbxTexture.name, texture };
 
     auto map = std::make_shared<model::TextureMap>();

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -472,7 +472,7 @@ QUrl NetworkMaterial::getTextureUrl(const QUrl& baseUrl, const FBXTexture& textu
 model::TextureMapPointer NetworkMaterial::fetchTextureMap(const QUrl& baseUrl, const FBXTexture& fbxTexture,
                                                         TextureType type, MapChannel channel) {
     const auto url = getTextureUrl(baseUrl, fbxTexture);
-    const auto texture = DependencyManager::get<TextureCache>()->getTexture(url, type, fbxTexture.content, fbxTexture.maxSize);
+    const auto texture = DependencyManager::get<TextureCache>()->getTexture(url, type, fbxTexture.content, fbxTexture.maxNumPixels);
     _textures[channel] = Texture { fbxTexture.name, texture };
 
     auto map = std::make_shared<model::TextureMap>();

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -159,7 +159,7 @@ protected:
     class Texture {
     public:
         QString name;
-        QSharedPointer<NetworkTexture> texture;
+        NetworkTexturePointer texture;
     };
     using Textures = std::vector<Texture>;
 

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -23,7 +23,7 @@
 #include <ResourceCache.h>
 #include <model/TextureMap.h>
 
-const int ABSOLUTE_MAX_TEXTURE_SIZE = 8192 * 8192;
+const int ABSOLUTE_MAX_TEXTURE_NUM_PIXELS = 8192 * 8192;
 
 namespace gpu {
 class Batch;
@@ -62,7 +62,7 @@ public:
     typedef gpu::Texture* TextureLoader(const QImage& image, const std::string& srcImageName);
     using TextureLoaderFunc = std::function<TextureLoader>;
 
-    NetworkTexture(const QUrl& url, Type type, const QByteArray& content, int maxSize);
+    NetworkTexture(const QUrl& url, Type type, const QByteArray& content, int maxNumPixels);
     NetworkTexture(const QUrl& url, const TextureLoaderFunc& textureLoader, const QByteArray& content);
 
     QString getType() const override { return "NetworkTexture"; }
@@ -94,7 +94,7 @@ private:
     int _originalHeight { 0 };
     int _width { 0 };
     int _height { 0 };
-    int _maxSize { ABSOLUTE_MAX_TEXTURE_SIZE };
+    int _maxNumPixels { ABSOLUTE_MAX_TEXTURE_NUM_PIXELS };
 };
 
 using NetworkTexturePointer = QSharedPointer<NetworkTexture>;
@@ -132,11 +132,11 @@ public:
 
     /// Loads a texture from the specified URL.
     NetworkTexturePointer getTexture(const QUrl& url, Type type = Type::DEFAULT_TEXTURE,
-        const QByteArray& content = QByteArray(), int maxSize = ABSOLUTE_MAX_TEXTURE_SIZE);
+        const QByteArray& content = QByteArray(), int maxNumPixels = ABSOLUTE_MAX_TEXTURE_NUM_PIXELS);
 
 protected:
     // Overload ResourceCache::prefetch to allow specifying texture type for loads
-    Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type, int maxSize = ABSOLUTE_MAX_TEXTURE_SIZE);
+    Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type, int maxNumPixels = ABSOLUTE_MAX_TEXTURE_NUM_PIXELS);
 
     virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
         const void* extra) override;

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -23,6 +23,8 @@
 #include <ResourceCache.h>
 #include <model/TextureMap.h>
 
+const int ABSOLUTE_MAX_TEXTURE_SIZE = 8192 * 8192;
+
 namespace gpu {
 class Batch;
 }
@@ -60,7 +62,7 @@ public:
     typedef gpu::Texture* TextureLoader(const QImage& image, const std::string& srcImageName);
     using TextureLoaderFunc = std::function<TextureLoader>;
 
-    NetworkTexture(const QUrl& url, Type type, const QByteArray& content);
+    NetworkTexture(const QUrl& url, Type type, const QByteArray& content, int maxSize);
     NetworkTexture(const QUrl& url, const TextureLoaderFunc& textureLoader, const QByteArray& content);
 
     QString getType() const override { return "NetworkTexture"; }
@@ -70,7 +72,7 @@ public:
     int getWidth() const { return _width; }
     int getHeight() const { return _height; }
     Type getTextureType() const { return _type;  }
-    
+
     TextureLoaderFunc getTextureLoader() const;
 
 signals:
@@ -81,7 +83,7 @@ protected:
     virtual bool isCacheable() const override { return _loaded; }
 
     virtual void downloadFinished(const QByteArray& data) override;
-          
+
     Q_INVOKABLE void loadContent(const QByteArray& content);
     Q_INVOKABLE void setImage(gpu::TexturePointer texture, int originalWidth, int originalHeight);
 
@@ -92,6 +94,7 @@ private:
     int _originalHeight { 0 };
     int _width { 0 };
     int _height { 0 };
+    int _maxSize { ABSOLUTE_MAX_TEXTURE_SIZE };
 };
 
 using NetworkTexturePointer = QSharedPointer<NetworkTexture>;
@@ -129,11 +132,11 @@ public:
 
     /// Loads a texture from the specified URL.
     NetworkTexturePointer getTexture(const QUrl& url, Type type = Type::DEFAULT_TEXTURE,
-        const QByteArray& content = QByteArray());
+        const QByteArray& content = QByteArray(), int maxSize = ABSOLUTE_MAX_TEXTURE_SIZE);
 
 protected:
     // Overload ResourceCache::prefetch to allow specifying texture type for loads
-    Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type);
+    Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type, int maxSize = ABSOLUTE_MAX_TEXTURE_SIZE);
 
     virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
         const void* extra) override;

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -86,7 +86,7 @@ private:
 /// Wrapper to expose resources to JS/QML
 class ScriptableResource : public QObject {
     Q_OBJECT
-    Q_PROPERTY(QUrl url READ getUrl)
+    Q_PROPERTY(QUrl url READ getURL)
     Q_PROPERTY(int state READ getState NOTIFY stateChanged)
 
     /**jsdoc
@@ -125,7 +125,7 @@ public:
      */
     Q_INVOKABLE void release();
 
-    const QUrl& getUrl() const { return _url; }
+    const QUrl& getURL() const { return _url; }
     int getState() const { return (int)_state; }
     const QSharedPointer<Resource>& getResource() const { return _resource; }
 


### PR DESCRIPTION
* absolute cap of 8192x8192 for all textures
* cap textures from FBX files to 2048x2048, with smaller caps for models that use many textures:
    1-8 unique textures = 2048x2048
    9-32 unique textures = 1024x1024
    33-128 unique textures = 512x512