### PR TITLE
tablet-ui: Bug fixes

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -540,6 +540,9 @@ Q_GUI_EXPORT void qt_gl_set_global_share_context(QOpenGLContext *context);
 
 Setting::Handle<int> sessionRunTime{ "sessionRunTime", 0 };
 
+const float DEFAULT_HMD_TABLET_SCALE_PERCENT = 100.0f;
+const float DEFAULT_DESKTOP_TABLET_SCALE_PERCENT = 75.0f;
+
 Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bool runServer, QString runServerPathOption) :
     QApplication(argc, argv),
     _shouldRunServer(runServer),
@@ -557,6 +560,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _mirrorViewRect(QRect(MIRROR_VIEW_LEFT_PADDING, MIRROR_VIEW_TOP_PADDING, MIRROR_VIEW_WIDTH, MIRROR_VIEW_HEIGHT)),
     _previousScriptLocation("LastScriptLocation", DESKTOP_LOCATION),
     _fieldOfView("fieldOfView", DEFAULT_FIELD_OF_VIEW_DEGREES),
+    _hmdTabletScale("hmdTabletScale", DEFAULT_HMD_TABLET_SCALE_PERCENT),
+    _desktopTabletScale("desktopTabletScale", DEFAULT_DESKTOP_TABLET_SCALE_PERCENT),
     _constrainToolbarPosition("toolbar/constrainToolbarToCenterX", true),
     _scaleMirror(1.0f),
     _rotateMirror(0.0f),
@@ -2316,6 +2321,14 @@ void Application::setFieldOfView(float fov) {
         _fieldOfView.set(fov);
         resizeGL();
     }
+}
+
+void Application::setHMDTabletScale(float hmdTabletScale) {
+    _hmdTabletScale.set(hmdTabletScale);
+}
+
+void Application::setDesktopTabletScale(float desktopTabletScale) {
+    _desktopTabletScale.set(desktopTabletScale);
 }
 
 void Application::setSettingConstrainToolbarPosition(bool setting) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -208,6 +208,11 @@ public:
     float getFieldOfView() { return _fieldOfView.get(); }
     void setFieldOfView(float fov);
 
+    float getHMDTabletScale() { return _hmdTabletScale.get(); }
+    void setHMDTabletScale(float hmdTabletScale);
+    float getDesktopTabletScale() { return _desktopTabletScale.get(); }
+    void setDesktopTabletScale(float desktopTabletScale);
+
     float getSettingConstrainToolbarPosition() { return _constrainToolbarPosition.get(); }
     void setSettingConstrainToolbarPosition(bool setting);
 
@@ -539,6 +544,8 @@ private:
 
     Setting::Handle<QString> _previousScriptLocation;
     Setting::Handle<float> _fieldOfView;
+    Setting::Handle<float> _hmdTabletScale;
+    Setting::Handle<float> _desktopTabletScale;
     Setting::Handle<bool> _constrainToolbarPosition;
 
     float _scaleMirror;

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -70,10 +70,27 @@ void setupPreferences() {
     }
 
     // UI
+    static const QString UI_CATEGORY { "UI" };
     {
         auto getter = []()->bool { return qApp->getSettingConstrainToolbarPosition(); };
         auto setter = [](bool value) { qApp->setSettingConstrainToolbarPosition(value); };
-        preferences->addPreference(new CheckPreference("UI", "Constrain Toolbar Position to Horizontal Center", getter, setter));
+        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Constrain Toolbar Position to Horizontal Center", getter, setter));
+    }
+    {
+        auto getter = []()->float { return qApp->getHMDTabletScale(); };
+        auto setter = [](float value) { qApp->setHMDTabletScale(value); };
+        auto preference = new SpinnerPreference(UI_CATEGORY, "HMD Tablet Scale %", getter, setter);
+        preference->setMin(20);
+        preference->setMax(500);
+        preferences->addPreference(preference);
+    }
+    {
+        auto getter = []()->float { return qApp->getDesktopTabletScale(); };
+        auto setter = [](float value) { qApp->setDesktopTabletScale(value); };
+        auto preference = new SpinnerPreference(UI_CATEGORY, "Desktop Tablet Scale %", getter, setter);
+        preference->setMin(20);
+        preference->setMax(500);
+        preferences->addPreference(preference);
     }
 
     // Snapshots

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2572,7 +2572,7 @@ function MyController(hand) {
     };
 
     this.maybeScale = function(props) {
-        if (!objectScalingEnabled) {
+        if (!objectScalingEnabled || this.isTablet(this.grabbedEntity)) {
             return;
         }
 

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -95,7 +95,12 @@ WebTablet = function (url, width, dpi, hand, clientOnly) {
     var tabletScaleFactor = this.width / TABLET_NATURAL_DIMENSIONS.x;
     this.height = TABLET_NATURAL_DIMENSIONS.y * tabletScaleFactor;
     this.depth = TABLET_NATURAL_DIMENSIONS.z * tabletScaleFactor;
-    this.dpi = dpi || DEFAULT_DPI;
+
+    if (dpi) {
+        this.dpi = dpi;
+    } else {
+        this.dpi = DEFAULT_DPI * (DEFAULT_WIDTH / this.width);
+    }
 
     var tabletProperties = {
         name: "WebTablet Tablet",
@@ -252,13 +257,14 @@ WebTablet.prototype.geometryChanged = function (geometry) {
 // calclulate the appropriate position of the tablet in world space, such that it fits in the center of the screen.
 // with a bit of padding on the top and bottom.
 WebTablet.prototype.calculateWorldAttitudeRelativeToCamera = function () {
-
+    var DEFAULT_DESKTOP_TABLET_SCALE = 75;
+    var DESKTOP_TABLET_SCALE = Settings.getValue("desktopTabletScale") || DEFAULT_DESKTOP_TABLET_SCALE;
     var fov = (Settings.getValue('fieldOfView') || DEFAULT_VERTICAL_FIELD_OF_VIEW) * (Math.PI / 180);
     var MAX_PADDING_FACTOR = 2.2;
     var PADDING_FACTOR = Math.min(Window.innerHeight / TABLET_TEXTURE_RESOLUTION.y, MAX_PADDING_FACTOR);
     var TABLET_HEIGHT = (TABLET_TEXTURE_RESOLUTION.y / this.dpi) * INCHES_TO_METERS;
     var WEB_ENTITY_Z_OFFSET = (this.depth / 2);
-    var dist = (PADDING_FACTOR * TABLET_HEIGHT) / (2 * Math.tan(fov / 2)) - WEB_ENTITY_Z_OFFSET;
+    var dist = (PADDING_FACTOR * TABLET_HEIGHT) / (2 * Math.tan(fov / 2) * (DESKTOP_TABLET_SCALE / 100)) - WEB_ENTITY_Z_OFFSET;
     return {
         position: Vec3.sum(Camera.position, Vec3.multiply(dist, Quat.getFront(Camera.orientation))),
         rotation: Quat.multiply(Camera.orientation, ROT_Y_180)

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -252,6 +252,7 @@ WebTablet.prototype.geometryChanged = function (geometry) {
 // calclulate the appropriate position of the tablet in world space, such that it fits in the center of the screen.
 // with a bit of padding on the top and bottom.
 WebTablet.prototype.calculateWorldAttitudeRelativeToCamera = function () {
+
     var fov = (Settings.getValue('fieldOfView') || DEFAULT_VERTICAL_FIELD_OF_VIEW) * (Math.PI / 180);
     var MAX_PADDING_FACTOR = 2.2;
     var PADDING_FACTOR = Math.min(Window.innerHeight / TABLET_TEXTURE_RESOLUTION.y, MAX_PADDING_FACTOR);
@@ -357,7 +358,7 @@ WebTablet.prototype.getPosition = function () {
 
 WebTablet.prototype.mousePressEvent = function (event) {
     var pickRay = Camera.computePickRay(event.x, event.y);
-    var entityPickResults = Entities.findRayIntersection(pickRay, true); // non-accurate picking
+    var entityPickResults = Entities.findRayIntersection(pickRay, true, [this.tabletEntityID]); // non-accurate picking
     if (entityPickResults.intersects && entityPickResults.entityID === this.tabletEntityID) {
         var overlayPickResults = Overlays.findRayIntersection(pickRay);
         if (overlayPickResults.intersects && overlayPickResults.overlayID === HMD.homeButtonID) {

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -24,7 +24,11 @@
     function showTabletUI() {
         tabletShown = true;
         print("show tablet-ui");
-        UIWebTablet = new WebTablet("qml/hifi/tablet/TabletRoot.qml", null, null, activeHand, true);
+
+        var DEFAULT_WIDTH = 0.4375;
+        var DEFAULT_HMD_TABLET_SCALE = 100;
+        var HMD_TABLET_SCALE = Settings.getValue("hmdTabletScale") || DEFAULT_HMD_TABLET_SCALE;
+        UIWebTablet = new WebTablet("qml/hifi/tablet/TabletRoot.qml", DEFAULT_WIDTH * (HMD_TABLET_SCALE / 100), null, activeHand, true);
         UIWebTablet.register();
         HMD.tabletID = UIWebTablet.tabletEntityID;
         HMD.homeButtonID = UIWebTablet.homeButtonEntity;


### PR DESCRIPTION
   * You can no longer scale the tablet with double-grab
   * Can now move/drag tablet in 2d mode even when it is embedded in geometry
   * Added preferences for scaling the tablet in HMD and desktop modes.
   * Default size of desktop tablet is reduced by 75%.