### PR TITLE
better scrolling and fixed button touching

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2911,7 +2911,7 @@ function MyController(hand) {
             var pos3D = intersectInfo.point;
 
             if (this.state == STATE_OVERLAY_STYLUS_TOUCHING &&
-                !this.deadspotExpired &&
+                !this.tabletStabbed &&
                 intersectInfo.distance < WEB_STYLUS_LENGTH / 2.0 + WEB_TOUCH_TOO_CLOSE) {
                 // they've stabbed the tablet, don't send events until they pull back
                 this.tabletStabbed = true;
@@ -2919,8 +2919,15 @@ function MyController(hand) {
                 this.tabletStabbedPos3D = pos3D;
                 return;
             }
+
             if (this.tabletStabbed) {
-                return;
+                var origin = {x: this.tabletStabbedPos2D.x, y: this.tabletStabbedPos2D.y, z: 0};
+                var point = {x: pos2D.x, y: pos2D.y, z: 0};
+                var offset = Vec3.distance(origin, point);
+                var radius = 0.05;
+                if (offset < radius) {
+                    return;
+                }
             }
 
             if (Overlays.keyboardFocusOverlay != this.grabbedOverlay) {


### PR DESCRIPTION
Test
- when the tablet is up...stick your stylus through it (stab it)  when you move the stylus the tablet should scroll (up or down)
- ensure that clicking on tablet buttons is still easy