### PR TITLE
Allow multiple instances to run if environment variable is set

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -74,6 +74,11 @@ int main(int argc, const char* argv[]) {
     instanceMightBeRunning = !sharedMemory.create(1, QSharedMemory::ReadOnly);
 #endif
 
+    // allow multiple interfaces to run if this environment variable is set.
+    if (QProcessEnvironment::systemEnvironment().contains("HIFI_ALLOW_MULTIPLE_INSTANCES")) {
+        instanceMightBeRunning = false;
+    }
+
     if (instanceMightBeRunning) {
         // Try to connect and send message to existing interface instance
         QLocalSocket socket;


### PR DESCRIPTION
If the environment variable HIFI_ALLOW_MULTIPLE_INSTANCES is present, the value is ignored,
then you can have multiple copies of interface running on the same machine.
