### PR TITLE
Add QMetaObject for AvatarEntityMap

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2309,3 +2309,22 @@ void RayToAvatarIntersectionResultFromScriptValue(const QScriptValue& object, Ra
         vec3FromScriptValue(intersection, value.intersection);
     }
 }
+
+QScriptValue AvatarEntityMapToScriptValue(QScriptEngine* engine, const AvatarEntityMap& value) {
+    QScriptValue obj = engine->newObject();
+    for (auto entityID : value.keys()) {
+        QScriptValue EntityProperties = engine->newVariant(QVariant::fromValue(value.value(entityID)));
+        QString key = entityID.toString();
+        obj.setProperty(key, EntityProperties);
+    }
+    return obj;
+}
+
+void AvatarEntityMapFromScriptValue(const QScriptValue& object, AvatarEntityMap& value) {
+    QScriptValueIterator itr(object);
+    while (itr.hasNext()) {
+        itr.next();
+        QUuid EntityID = QUuid(itr.name());
+        value[EntityID] = qvariant_cast<QByteArray>(itr.value().data().toVariant());
+    }
+}

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -44,6 +44,7 @@ typedef unsigned long long quint64;
 #include <QVariantMap>
 #include <QVector>
 #include <QtScript/QScriptable>
+#include <QtScript/QScriptValueIterator>
 #include <QReadWriteLock>
 
 #include <JointData.h>
@@ -815,6 +816,11 @@ Q_DECLARE_METATYPE(RayToAvatarIntersectionResult)
 
 QScriptValue RayToAvatarIntersectionResultToScriptValue(QScriptEngine* engine, const RayToAvatarIntersectionResult& results);
 void RayToAvatarIntersectionResultFromScriptValue(const QScriptValue& object, RayToAvatarIntersectionResult& results);
+
+Q_DECLARE_METATYPE(AvatarEntityMap)
+
+QScriptValue AvatarEntityMapToScriptValue(QScriptEngine* engine, const AvatarEntityMap& value);
+void AvatarEntityMapFromScriptValue(const QScriptValue& object, AvatarEntityMap& value);
 
 // faux joint indexes (-1 means invalid)
 const int SENSOR_TO_WORLD_MATRIX_INDEX = 65534; // -2

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -576,6 +576,7 @@ void ScriptEngine::init() {
     qScriptRegisterMetaType(this, EntityItemIDtoScriptValue, EntityItemIDfromScriptValue);
     qScriptRegisterMetaType(this, RayToEntityIntersectionResultToScriptValue, RayToEntityIntersectionResultFromScriptValue);
     qScriptRegisterMetaType(this, RayToAvatarIntersectionResultToScriptValue, RayToAvatarIntersectionResultFromScriptValue);
+    qScriptRegisterMetaType(this, AvatarEntityMapToScriptValue, AvatarEntityMapFromScriptValue);
     qScriptRegisterSequenceMetaType<QVector<QUuid>>(this);
     qScriptRegisterSequenceMetaType<QVector<EntityItemID>>(this);
 


### PR DESCRIPTION
Resolution to the issue described in: 
- https://github.com/highfidelity/hifi/issues/9447

Error Details:
[CRITICAL] [hifi.scriptengine] "[UncaughtException] TypeError: cannot call getAvatarEntityData(): unknown return type `AvatarEntityMap' (register the type with qScriptRegisterMetaType()) in Entities 8:32\n[Backtrace]\n (id = '{a275bceb-f49b-4554-bd9b-f51f30bae780}', ) at url:32\n () at -1"

Testing Instructions: 
- Call MyAvatar.getAvatarEntityData to get data into the scripting layer, ensure some entity is loaded otherwise data will be empty.
- Manipulate the data by changing some entity (color, position, etc)
- Call MyAvatar.setAvatarEntityData and check that changes follow what is expected