### PR TITLE
some tweaks to users and menus got tablet

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
@@ -168,7 +168,6 @@ Item {
             d.popMenu();
             return true;
         }
-            
         return false;
     }
 

--- a/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMouseHandler.qml
@@ -87,7 +87,11 @@ Item {
                 if (topMenu.objectName === "") {
                     breadcrumbText.text = "Menu";
                 } else {
-                    breadcrumbText.text = topMenu.objectName;
+                    if (menuStack.length === 1) {
+                        breadcrumbText.text = "Menu";
+                    } else {
+                        breadcrumbText.text = topMenu.objectName;
+                    }
                 }
             } else {
                 breadcrumbText.text = "Menu";
@@ -164,6 +168,7 @@ Item {
             d.popMenu();
             return true;
         }
+            
         return false;
     }
 

--- a/scripts/system/tablet-users.js
+++ b/scripts/system/tablet-users.js
@@ -12,6 +12,7 @@
 
 (function() { // BEGIN LOCAL_SCOPE
     var USERS_URL = "https://hifi-content.s3.amazonaws.com/faye/tablet-dev/users.html";
+    var HOME_BUTTON_TEXTURE = Script.resourcesPath() + "meshes/tablet-with-home-button.fbx/tablet-with-home-button.fbm/button-root.png";
 
     var FRIENDS_WINDOW_URL = "https://metaverse.highfidelity.com/user/friends";
     var FRIENDS_WINDOW_WIDTH = 290;
@@ -39,6 +40,10 @@
     });
 
     function onClicked() {
+        var tabletEntity = HMD.tabletID;
+        if (tabletEntity) {
+            Entities.editEntity(tabletEntity, {textures: JSON.stringify({"tex.close" : HOME_BUTTON_TEXTURE})});
+        }
         tablet.gotoWebScreen(USERS_URL);
     }
 


### PR DESCRIPTION
Test 1
 - Click users on use on the tablet and the home button at the bottom should change.

Test 2 
- Click menu on the tablet then click on a submenu, then click the menu name at the top, which brings you back to the previous menu( in this test the main menu). The name on top should say "Menu" not 
"root" 