### PR TITLE
Reduce audio clicks/pops caused by packet loss

### DIFF
--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -129,12 +129,6 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
     int propertyBytes = parseStreamProperties(message.getType(), message.readWithoutCopy(message.getBytesLeftToRead()), networkFrames);
     message.seek(prePropertyPosition + propertyBytes);
 
-    // simulate 1% packetloss
-    if (rand() < (RAND_MAX/100)) {
-        arrivalInfo._status = SequenceNumberStats::Unreasonable;
-        qDebug(audio) << "Simulated a lost packet...";
-    }
-
     // handle this packet based on its arrival status.
     switch (arrivalInfo._status) {
         case SequenceNumberStats::Unreasonable: {

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -432,10 +432,6 @@ void InboundAudioStream::packetReceivedUpdateTimingStats() {
     _lastPacketReceivedTime = now;
 }
 
-int InboundAudioStream::writeFramesForDroppedPackets(int networkFrames) {
-    return writeLastFrameRepeatedWithFade(networkFrames);
-}
-
 int InboundAudioStream::writeLastFrameRepeatedWithFade(int frames) {
     AudioRingBuffer::ConstIterator frameToRepeat = _ringBuffer.lastFrameWritten();
     int frameSize = _ringBuffer.getNumFrameSamples();

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -432,25 +432,6 @@ void InboundAudioStream::packetReceivedUpdateTimingStats() {
     _lastPacketReceivedTime = now;
 }
 
-int InboundAudioStream::writeLastFrameRepeatedWithFade(int frames) {
-    AudioRingBuffer::ConstIterator frameToRepeat = _ringBuffer.lastFrameWritten();
-    int frameSize = _ringBuffer.getNumFrameSamples();
-    int samplesToWrite = frames * _numChannels;
-    int indexOfRepeat = 0;
-    do {
-        int samplesToWriteThisIteration = std::min(samplesToWrite, frameSize);
-        float fade = calculateRepeatedFrameFadeFactor(indexOfRepeat);
-        if (fade == 1.0f) {
-            samplesToWrite -= _ringBuffer.writeSamples(frameToRepeat, samplesToWriteThisIteration);
-        } else {
-            samplesToWrite -= _ringBuffer.writeSamplesWithFade(frameToRepeat, samplesToWriteThisIteration, fade);
-        }
-        indexOfRepeat++;
-    } while (samplesToWrite > 0);
-
-    return frames;
-}
-
 AudioStreamStats InboundAudioStream::getAudioStreamStats() const {
     AudioStreamStats streamStats;
 

--- a/libraries/audio/src/InboundAudioStream.h
+++ b/libraries/audio/src/InboundAudioStream.h
@@ -134,6 +134,9 @@ protected:
     /// default implementation assumes packet contains raw audio samples after stream properties
     virtual int parseAudioData(PacketType type, const QByteArray& packetAfterStreamProperties);
 
+    /// produces audio data for lost network packets.
+    virtual int lostAudioData(int numPackets);
+
     /// writes silent frames to the buffer that may be dropped to reduce latency caused by the buffer
     virtual int writeDroppableSilentFrames(int silentFrames);
 

--- a/libraries/audio/src/InboundAudioStream.h
+++ b/libraries/audio/src/InboundAudioStream.h
@@ -137,10 +137,6 @@ protected:
 
     /// writes silent frames to the buffer that may be dropped to reduce latency caused by the buffer
     virtual int writeDroppableSilentFrames(int silentFrames);
-
-    /// writes the last written frame repeatedly, gradually fading to silence.
-    /// used for writing samples for dropped packets.
-    virtual int writeLastFrameRepeatedWithFade(int frames);
     
 protected:
 

--- a/libraries/audio/src/InboundAudioStream.h
+++ b/libraries/audio/src/InboundAudioStream.h
@@ -115,8 +115,6 @@ public slots:
 private:
     void packetReceivedUpdateTimingStats();
 
-    int writeFramesForDroppedPackets(int networkFrames);
-
     void popSamplesNoCheck(int samples);
     void framesAvailableChanged();
 

--- a/libraries/audio/src/MixedProcessedAudioStream.cpp
+++ b/libraries/audio/src/MixedProcessedAudioStream.cpp
@@ -31,13 +31,6 @@ int MixedProcessedAudioStream::writeDroppableSilentFrames(int silentFrames) {
     return deviceSilentFramesWritten;
 }
 
-int MixedProcessedAudioStream::writeLastFrameRepeatedWithFade(int frames) {
-    int deviceFrames = networkToDeviceFrames(frames);
-    int deviceFramesWritten = InboundAudioStream::writeLastFrameRepeatedWithFade(deviceFrames);
-    emit addedLastFrameRepeatedWithFade(deviceToNetworkFrames(deviceFramesWritten));
-    return deviceFramesWritten;
-}
-
 int MixedProcessedAudioStream::lostAudioData(int numPackets) {
     QByteArray decodedBuffer;
     QByteArray outputBuffer;

--- a/libraries/audio/src/MixedProcessedAudioStream.cpp
+++ b/libraries/audio/src/MixedProcessedAudioStream.cpp
@@ -38,6 +38,28 @@ int MixedProcessedAudioStream::writeLastFrameRepeatedWithFade(int frames) {
     return deviceFramesWritten;
 }
 
+int MixedProcessedAudioStream::lostAudioData(int numPackets) {
+    QByteArray decodedBuffer;
+    QByteArray outputBuffer;
+
+    while (numPackets--) {
+        if (_decoder) {
+            _decoder->lostFrame(decodedBuffer);
+        } else {
+            decodedBuffer.resize(AudioConstants::NETWORK_FRAME_BYTES_STEREO);
+            memset(decodedBuffer.data(), 0, decodedBuffer.size());
+        }
+
+        emit addedStereoSamples(decodedBuffer);
+
+        emit processSamples(decodedBuffer, outputBuffer);
+
+        _ringBuffer.writeData(outputBuffer.data(), outputBuffer.size());
+        qCDebug(audiostream, "Wrote %d samples to buffer (%d available)", outputBuffer.size() / (int)sizeof(int16_t), getSamplesAvailable());
+    }
+    return 0;
+}
+
 int MixedProcessedAudioStream::parseAudioData(PacketType type, const QByteArray& packetAfterStreamProperties) {
     QByteArray decodedBuffer;
     if (_decoder) {

--- a/libraries/audio/src/MixedProcessedAudioStream.h
+++ b/libraries/audio/src/MixedProcessedAudioStream.h
@@ -34,7 +34,6 @@ public:
 
 protected:
     int writeDroppableSilentFrames(int silentFrames) override;
-    int writeLastFrameRepeatedWithFade(int frames) override;
     int parseAudioData(PacketType type, const QByteArray& packetAfterStreamProperties) override;
     int lostAudioData(int numPackets) override;
 

--- a/libraries/audio/src/MixedProcessedAudioStream.h
+++ b/libraries/audio/src/MixedProcessedAudioStream.h
@@ -36,6 +36,7 @@ protected:
     int writeDroppableSilentFrames(int silentFrames) override;
     int writeLastFrameRepeatedWithFade(int frames) override;
     int parseAudioData(PacketType type, const QByteArray& packetAfterStreamProperties) override;
+    int lostAudioData(int numPackets) override;
 
 private:
     int networkToDeviceFrames(int networkFrames);

--- a/libraries/plugins/src/plugins/CodecPlugin.h
+++ b/libraries/plugins/src/plugins/CodecPlugin.h
@@ -23,8 +23,7 @@ public:
     virtual ~Decoder() { }
     virtual void decode(const QByteArray& encodedBuffer, QByteArray& decodedBuffer) = 0;
 
-    // numFrames - number of samples (mono) or sample-pairs (stereo)
-    virtual void trackLostFrames(int numFrames) = 0;
+    virtual void lostFrame(QByteArray& decodedBuffer) = 0;
 };
 
 class CodecPlugin : public Plugin {

--- a/plugins/hifiCodec/src/HiFiCodec.cpp
+++ b/plugins/hifiCodec/src/HiFiCodec.cpp
@@ -65,12 +65,10 @@ public:
         AudioDecoder::process((const int16_t*)encodedBuffer.constData(), (int16_t*)decodedBuffer.data(), AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL, true);
     }
 
-    virtual void trackLostFrames(int numFrames)  override { 
-        QByteArray encodedBuffer;
-        QByteArray decodedBuffer;
+    virtual void lostFrame(QByteArray& decodedBuffer) override {
         decodedBuffer.resize(_decodedSize);
-        // NOTE: we don't actually use the results of this decode, we just do it to keep the state of the codec clean
-        AudioDecoder::process((const int16_t*)encodedBuffer.constData(), (int16_t*)decodedBuffer.data(), AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL, false);
+        // this performs packet loss interpolation
+        AudioDecoder::process(nullptr, (int16_t*)decodedBuffer.data(), AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL, false);
     }
 private:
     int _decodedSize;

--- a/plugins/pcmCodec/src/PCMCodecManager.h
+++ b/plugins/pcmCodec/src/PCMCodecManager.h
@@ -38,11 +38,14 @@ public:
     virtual void encode(const QByteArray& decodedBuffer, QByteArray& encodedBuffer) override {
         encodedBuffer = decodedBuffer;
     }
+
     virtual void decode(const QByteArray& encodedBuffer, QByteArray& decodedBuffer) override {
         decodedBuffer = encodedBuffer;
     }
 
-    virtual void trackLostFrames(int numFrames)  override { }
+    virtual void lostFrame(QByteArray& decodedBuffer) override {
+        memset(decodedBuffer.data(), 0, decodedBuffer.size());
+    }
 
 private:
     static const char* NAME;
@@ -77,7 +80,9 @@ public:
         decodedBuffer = qUncompress(encodedBuffer);
     }
 
-    virtual void trackLostFrames(int numFrames)  override { }
+    virtual void lostFrame(QByteArray& decodedBuffer) override {
+        memset(decodedBuffer.data(), 0, decodedBuffer.size());
+    }
 
 private:
     static const char* NAME;


### PR DESCRIPTION
This PR attempts to improve audio quality during packet loss with two changes:
 - use the interpolated audio from the codec for the lost audio data
 - always process the result through the audio pipeline

The old code bypasses the audio pipeline (inserting samples directly into the ringbuffer) during packet loss. Since processing in the audio pipeline is stateful (resamplers, HRTF filters, reverb, limiter depend on sample history) this results in loud pops/clicks. The new code inserts lost audio into the audio pipeline.