### PR TITLE
Remove duplicate snapshot settings in general settings and avatar settings

### DIFF
--- a/interface/resources/qml/hifi/dialogs/AvatarPreferencesDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/AvatarPreferencesDialog.qml
@@ -7,7 +7,7 @@ PreferencesDialog {
     id: root
     objectName: "AvatarPreferencesDialog"
     title: "Avatar Settings"
-    showCategories: [ "Avatar Basics", "Snapshots", "Avatar Tuning", "Avatar Camera" ]
+    showCategories: [ "Avatar Basics", "Avatar Tuning", "Avatar Camera" ]
     property var settings: Settings {
         category: root.objectName
         property alias x: root.x

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -104,7 +104,7 @@ void setupPreferences() {
     {
         auto getter = []()->bool { return SnapshotAnimated::alsoTakeAnimatedSnapshot.get(); };
         auto setter = [](bool value) { SnapshotAnimated::alsoTakeAnimatedSnapshot.set(value); };
-        preferences->addPreference(new CheckPreference(SNAPSHOTS, "Take Animated GIF Snapshot with HUD Button", getter, setter));
+        preferences->addPreference(new CheckPreference(SNAPSHOTS, "Take Animated GIF Snapshot with tablet button", getter, setter));
     }
     {
         auto getter = []()->float { return SnapshotAnimated::snapshotAnimatedDuration.get(); };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -104,7 +104,7 @@ void setupPreferences() {
     {
         auto getter = []()->bool { return SnapshotAnimated::alsoTakeAnimatedSnapshot.get(); };
         auto setter = [](bool value) { SnapshotAnimated::alsoTakeAnimatedSnapshot.set(value); };
-        preferences->addPreference(new CheckPreference(SNAPSHOTS, "Take Animated GIF Snapshot with tablet button", getter, setter));
+        preferences->addPreference(new CheckPreference(SNAPSHOTS, "Take Animated GIF Snapshot", getter, setter));
     }
     {
         auto getter = []()->float { return SnapshotAnimated::snapshotAnimatedDuration.get(); };


### PR DESCRIPTION
Test - check that the snapshot settings appear under Settings > General.. and not under Settings > Avatar
Under the snapshot category in Setting > General.. , the checkable item should say "Take animated GIF snapshot" and "Take animated GIF snapshot with HUD button"

Link to fogzbug issue https://highfidelity.fogbugz.com/f/cases/3031/snapshot-settings-are-duplicated