### PR TITLE
Fix for findEntities not returning some entities that are within range.

### DIFF
--- a/libraries/shared/src/AABox.cpp
+++ b/libraries/shared/src/AABox.cpp
@@ -360,7 +360,7 @@ glm::vec3 AABox::getClosestPointOnFace(const glm::vec3& point, BoxFace face) con
 
         case MIN_Z_FACE:
             return glm::clamp(point, glm::vec3(_corner.x, _corner.y, _corner.z),
-                glm::vec3(_corner.x + _scale.z, _corner.y + _scale.y, _corner.z));
+                glm::vec3(_corner.x + _scale.x, _corner.y + _scale.y, _corner.z));
 
         default: //quiet windows warnings
         case MAX_Z_FACE:

--- a/tests/shared/src/AABoxTests.cpp
+++ b/tests/shared/src/AABoxTests.cpp
@@ -169,3 +169,17 @@ void AABoxTests::testScale() {
     box3 += glm::vec3(-1.0f, -1.0f, -1.0f);
     QCOMPARE(box3.contains(glm::vec3(0.5f, 0.5f, 0.5f)), true);
 }
+
+void AABoxTests::testFindSpherePenetration() {
+    vec3 searchPosition(-0.0141186f, 0.0640736f, -0.116081f);
+    float searchRadius = 0.5f;
+
+    vec3 boxMin(-0.800014f, -0.450025f, -0.00503815f);
+    vec3 boxDim(1.60003f, 0.900049f, 0.0100763f);
+    AABox testBox(boxMin, boxDim);
+
+    vec3 penetration;
+    bool hit = testBox.findSpherePenetration(searchPosition, searchRadius, penetration);
+    QCOMPARE(hit, true);
+}
+

--- a/tests/shared/src/AABoxTests.h
+++ b/tests/shared/src/AABoxTests.h
@@ -24,6 +24,7 @@ private slots:
     void testContainsPoint();
     void testTouchesSphere();
     void testScale();
+    void testFindSpherePenetration();
 };
 
 #endif // hifi_AABoxTests_h


### PR DESCRIPTION
This bug has been around a long time... introduced by commit 39ed7f7b in 2014.  This became apparent to me when testing the tablet-ui, there was a case where the hand styluses were not appearing when close to a web entity.  Because findEntities is such a fundamental feature used by handControllerGrab, this fix should make grabbing oblong/non-square objects feel more consistent and predictable.

I added a unit test that reproduces the issue.