### PR TITLE
Remove avatarEntityData cruft from settings

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -931,6 +931,10 @@ void MyAvatar::loadData() {
         updateAvatarEntity(entityID, properties);
     }
     settings.endArray();
+    if (avatarEntityCount == 0) {
+        // HACK: manually remove empty 'avatarEntityData' else legacy data may persist in settings file
+        settings.remove("avatarEntityData");
+    }
     setAvatarEntityDataChanged(true);
 
     setDisplayName(settings.value("displayName").toString());

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -795,6 +795,11 @@ void MyAvatar::saveData() {
     }
     settings.endArray();
 
+    if (_avatarEntityData.size() == 0) {
+        // HACK: manually remove empty 'avatarEntityData' else deleted avatarEntityData may show up in settings file
+        settings.remove("avatarEntityData");
+    }
+
     settings.beginWriteArray("avatarEntityData");
     int avatarEntityIndex = 0;
     auto hmdInterface = DependencyManager::get<HMDScriptingInterface>();

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -28,9 +28,10 @@ QString Settings::fileName() const {
 }
 
 void Settings::remove(const QString& key) {
-    if (key == "" || _manager->contains(key)) {
-        _manager->remove(key);
-    }
+    // NOTE: you can't check _manager->contains(key) here because it will return 'false'
+    // when the key is a valid child group with child keys.
+    // However, calling remove() without checking will do the right thing.
+    _manager->remove(key);
 }
 
 QStringList Settings::childGroups() const {
@@ -46,6 +47,7 @@ QStringList Settings::allKeys() const {
 }
 
 bool Settings::contains(const QString& key) const {
+    // NOTE: this will return 'false' if key is a valid child group with child keys.
     return _manager->contains(key);
 }
 


### PR DESCRIPTION
* fix a bug where old 'client-side only entities' cruft could be left in the interface's settings file