### PR TITLE
Fix for hidden cursor while using Export Entities / Import Entities form

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -16,6 +16,8 @@
 
 #include <SettingHandle.h>
 
+#include <display-plugins/CompositorHelper.h>
+
 #include "Application.h"
 #include "DomainHandler.h"
 #include "MainWindow.h"
@@ -147,6 +149,15 @@ void WindowScriptingInterface::setPreviousBrowseLocation(const QString& location
     Setting::Handle<QVariant>(LAST_BROWSE_LOCATION_SETTING).set(location);
 }
 
+/// Makes sure that the reticle is visible, use this in blocking forms that require a reticle and
+/// might be in same thread as a script that sets the reticle to invisible
+void WindowScriptingInterface::ensureReticleVisible() const {
+    auto compositorHelper = DependencyManager::get<CompositorHelper>();
+    if (!compositorHelper->getReticleVisible()) {
+        compositorHelper->setReticleVisible(true);
+    }
+}
+
 /// Display an open file dialog.  If `directory` is an invalid file or directory the browser will start at the current
 /// working directory.
 /// \param const QString& title title of the window
@@ -154,6 +165,7 @@ void WindowScriptingInterface::setPreviousBrowseLocation(const QString& location
 /// \param const QString& nameFilter filter to filter filenames by - see `QFileDialog`
 /// \return QScriptValue file path as a string if one was selected, otherwise `QScriptValue::NullValue`
 QScriptValue WindowScriptingInterface::browse(const QString& title, const QString& directory, const QString& nameFilter) {
+    ensureReticleVisible();
     QString path = directory;
     if (path.isEmpty()) {
         path = getPreviousBrowseLocation();
@@ -175,6 +187,7 @@ QScriptValue WindowScriptingInterface::browse(const QString& title, const QStrin
 /// \param const QString& nameFilter filter to filter filenames by - see `QFileDialog`
 /// \return QScriptValue file path as a string if one was selected, otherwise `QScriptValue::NullValue`
 QScriptValue WindowScriptingInterface::save(const QString& title, const QString& directory, const QString& nameFilter) {
+    ensureReticleVisible();
     QString path = directory;
     if (path.isEmpty()) {
         path = getPreviousBrowseLocation();

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -83,6 +83,8 @@ private:
     QString getPreviousBrowseLocation() const;
     void setPreviousBrowseLocation(const QString& location);
 
+    void ensureReticleVisible() const;
+
     int createMessageBox(QString title, QString text, int buttons, int defaultButton);
     QHash<int, QQuickItem*> _messageBoxes;
     int _lastMessageBoxID{ -1 };


### PR DESCRIPTION
Fixes cursor occasionally being hidden while Window.browse(), Window.save() are being called from the defaultScript.js thread.

Fixes internal bug: https://highfidelity.fogbugz.com/f/cases/1639/When-I-try-to-import-entities-my-cursor-stops-showing-up-once-the-dialogs-show-up

## QA Test

1. Make sure you're not debugging the defaultScripts.js (Developer -> debugDefaultScripts.js should be unchecked)
2. Open the console window in such a way that you do not need to hover over the rendering area of the interface window. ( Edit -> Console )
3. Manually calling Reticle.setVisible(false); from the.console
4. Open "Edit -> Import Entities" from the menu, without hovering over the 3D/render area first.
5. The cursor should be visible (Following the steps in the current master/stable build will show you the opposite)