### PR TITLE
Fix rescale avatar bug

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -826,11 +826,7 @@ function MyController(hand) {
 
     this.update = function(deltaTime, timestamp) {
         this.updateSmoothedTrigger();
-        //  If both trigger and grip buttons squeezed and nothing is held, rescale my avatar!
-        //if (this.hand === RIGHT_HAND && this.state === STATE_SEARCHING &&
-        //    this.getOtherHandController().state === STATE_SEARCHING) {
         this.maybeScaleMyAvatar();
-        //}
 
         if (this.ignoreInput()) {
 

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -26,6 +26,7 @@ Script.include("/~/system/libraries/controllers.js");
 //
 // add lines where the hand ray picking is happening
 //
+
 var WANT_DEBUG = false;
 var WANT_DEBUG_STATE = false;
 var WANT_DEBUG_SEARCH_NAME = null;
@@ -752,6 +753,7 @@ function MyController(hand) {
     this.previouslyUnhooked = {};
 
     this.shouldScale = false;
+    this.isScalingAvatar = false;
 
     // handPosition is where the avatar's hand appears to be, in-world.
     this.getHandPosition = function () {
@@ -825,10 +827,10 @@ function MyController(hand) {
     this.update = function(deltaTime, timestamp) {
         this.updateSmoothedTrigger();
         //  If both trigger and grip buttons squeezed and nothing is held, rescale my avatar!
-        if (this.hand === RIGHT_HAND && this.state === STATE_SEARCHING &&
-            this.getOtherHandController().state === STATE_SEARCHING) {
-            this.maybeScaleMyAvatar();
-        }
+        //if (this.hand === RIGHT_HAND && this.state === STATE_SEARCHING &&
+        //    this.getOtherHandController().state === STATE_SEARCHING) {
+        this.maybeScaleMyAvatar();
+        //}
 
         if (this.ignoreInput()) {
 
@@ -2595,25 +2597,34 @@ function MyController(hand) {
     };
 
     this.maybeScaleMyAvatar = function() {
-        if (!myAvatarScalingEnabled) {
+        if (!myAvatarScalingEnabled || this.shouldScale || this.hand === LEFT_HAND) {
+            //  If scaling disabled, or if we are currently scaling an entity, don't scale avatar
+            //  and only rescale avatar for one hand (so we're not doing it twice)
             return;
         }
 
-        if (!this.shouldScale) {
+        // Only scale avatar if both triggers and grips are squeezed
+        var tryingToScale = this.secondarySqueezed() && this.getOtherHandController().secondarySqueezed() &&
+                            this.triggerSmoothedSqueezed() && this.getOtherHandController().triggerSmoothedSqueezed();
+
+
+        if (!this.isScalingAvatar) {
             //  If both secondary triggers squeezed, start scaling
-            if (this.secondarySqueezed() && this.getOtherHandController().secondarySqueezed()) {
+            if (tryingToScale) {
                 this.scalingStartDistance = Vec3.length(Vec3.subtract(this.getHandPosition(),
                                                                       this.getOtherHandController().getHandPosition()));
                 this.scalingStartAvatarScale = MyAvatar.scale;
-                this.shouldScale = true;
+                this.isScalingAvatar = true;
             }
-        } else if (!this.secondarySqueezed() || !this.getOtherHandController().secondarySqueezed()) {
-            this.shouldScale = false;
+        } else if (!tryingToScale) {
+            this.isScalingAvatar = false;
         }
-        if (this.shouldScale) {
+        if (this.isScalingAvatar) {
             var scalingCurrentDistance = Vec3.length(Vec3.subtract(this.getHandPosition(),
                                                                    this.getOtherHandController().getHandPosition()));
             var newAvatarScale = (scalingCurrentDistance / this.scalingStartDistance) * this.scalingStartAvatarScale;
+            if (MyAvatar.scale != newAvatarScale) {
+            }
             MyAvatar.scale = newAvatarScale;
         }
     };

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2619,8 +2619,6 @@ function MyController(hand) {
             var scalingCurrentDistance = Vec3.length(Vec3.subtract(this.getHandPosition(),
                                                                    this.getOtherHandController().getHandPosition()));
             var newAvatarScale = (scalingCurrentDistance / this.scalingStartDistance) * this.scalingStartAvatarScale;
-            if (MyAvatar.scale != newAvatarScale) {
-            }
             MyAvatar.scale = newAvatarScale;
         }
     };


### PR DESCRIPTION
Avatar rescaling was sometimes happening with just the grip buttons.  Fixed that.  

Test plan: 

You should only be able to rescale your avatar by holding down both the triggers and the grip (on both controllers).  You should not be able to rescale yourself with only the grips. 

You should be able to rescale objects by holding them and squeezing both grips to resize. 