### PR TITLE
Fix the filtering problem on color and normals

### DIFF
--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -399,7 +399,7 @@ void ImageReader::run() {
         int originalHeight = imageHeight;
         imageWidth = (int)(scaleFactor * (float)imageWidth + 0.5f);
         imageHeight = (int)(scaleFactor * (float)imageHeight + 0.5f);
-        QImage newImage = image.scaled(QSize(imageWidth, imageHeight), Qt::IgnoreAspectRatio);
+        QImage newImage = image.scaled(QSize(imageWidth, imageHeight), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
         image.swap(newImage);
         qCDebug(modelnetworking) << "Downscale image" << _url
             << "from" << originalWidth << "x" << originalHeight

--- a/libraries/model/src/model/TextureMap.cpp
+++ b/libraries/model/src/model/TextureMap.cpp
@@ -74,7 +74,7 @@ QImage processSourceImage(const QImage& srcImage, bool cubemap) {
     if (targetSize != srcImageSize) {
          PROFILE_RANGE(resource_parse, "processSourceImage Rectify");
          qCDebug(modelLog) << "Resizing texture from " << srcImageSize.x << "x" << srcImageSize.y << " to " << targetSize.x << "x" << targetSize.y;
-        return srcImage.scaled(fromGlm(targetSize));
+         return srcImage.scaled(fromGlm(targetSize), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
 
     return srcImage;
@@ -202,14 +202,19 @@ const QImage& image, bool isLinear, bool doCompress) {
 
 #define CPU_MIPMAPS 1
 
-void generateMips(gpu::Texture* texture, QImage& image, gpu::Element formatMip) {
+void generateMips(gpu::Texture* texture, QImage& image, gpu::Element formatMip, bool fastResize) {
 #if CPU_MIPMAPS
     PROFILE_RANGE(resource_parse, "generateMips");
     auto numMips = texture->evalNumMips();
     for (uint16 level = 1; level < numMips; ++level) {
         QSize mipSize(texture->evalMipWidth(level), texture->evalMipHeight(level));
-        image = image.scaled(mipSize);
-        texture->assignStoredMip(level, formatMip, image.byteCount(), image.constBits());
+        if (fastResize) {
+            image = image.scaled(mipSize);
+            texture->assignStoredMip(level, formatMip, image.byteCount(), image.constBits());
+        } else {
+            QImage mipImage = image.scaled(mipSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+            texture->assignStoredMip(level, formatMip, mipImage.byteCount(), mipImage.constBits());
+        }
     }
 #else
     texture->autoGenerateMips(-1);
@@ -222,8 +227,8 @@ void generateFaceMips(gpu::Texture* texture, QImage& image, gpu::Element formatM
     auto numMips = texture->evalNumMips();
     for (uint16 level = 1; level < numMips; ++level) {
         QSize mipSize(texture->evalMipWidth(level), texture->evalMipHeight(level));
-        image = image.scaled(mipSize);
-        texture->assignStoredMipFace(level, formatMip, image.byteCount(), image.constBits(), face);
+        QImage mipImage = image.scaled(mipSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+        texture->assignStoredMipFace(level, formatMip, mipImage.byteCount(), mipImage.constBits(), face);
     }
 #else
     texture->autoGenerateMips(-1);
@@ -257,7 +262,7 @@ gpu::Texture* TextureUsage::process2DTextureColorFromImage(const QImage& srcImag
         theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
 
         if (generateMips) {
-            ::generateMips(theTexture, image, formatMip);
+            ::generateMips(theTexture, image, formatMip, false);
         }
     }
 
@@ -300,7 +305,7 @@ gpu::Texture* TextureUsage::createNormalTextureFromNormalImage(const QImage& src
         theTexture = (gpu::Texture::create2D(formatGPU, image.width(), image.height(), gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR)));
         theTexture->setSource(srcImageName);
         theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
-        generateMips(theTexture, image, formatMip);
+        generateMips(theTexture, image, formatMip, true);
     }
 
     return theTexture;
@@ -386,7 +391,7 @@ gpu::Texture* TextureUsage::createNormalTextureFromBumpImage(const QImage& srcIm
         theTexture = (gpu::Texture::create2D(formatGPU, image.width(), image.height(), gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR)));
         theTexture->setSource(srcImageName);
         theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
-        generateMips(theTexture, image, formatMip);
+        generateMips(theTexture, image, formatMip, true);
     }
 
     return theTexture;
@@ -419,7 +424,7 @@ gpu::Texture* TextureUsage::createRoughnessTextureFromImage(const QImage& srcIma
         theTexture = (gpu::Texture::create2D(formatGPU, image.width(), image.height(), gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR)));
         theTexture->setSource(srcImageName);
         theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
-        generateMips(theTexture, image, formatMip);
+        generateMips(theTexture, image, formatMip, true);
 
         // FIXME queue for transfer to GPU and block on completion
     }
@@ -458,7 +463,7 @@ gpu::Texture* TextureUsage::createRoughnessTextureFromGlossImage(const QImage& s
         theTexture = (gpu::Texture::create2D(formatGPU, image.width(), image.height(), gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR)));
         theTexture->setSource(srcImageName);
         theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
-        generateMips(theTexture, image, formatMip);
+        generateMips(theTexture, image, formatMip, true);
         
         // FIXME queue for transfer to GPU and block on completion
     }
@@ -494,7 +499,7 @@ gpu::Texture* TextureUsage::createMetallicTextureFromImage(const QImage& srcImag
         theTexture = (gpu::Texture::create2D(formatGPU, image.width(), image.height(), gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR)));
         theTexture->setSource(srcImageName);
         theTexture->assignStoredMip(0, formatMip, image.byteCount(), image.constBits());
-        generateMips(theTexture, image, formatMip);
+        generateMips(theTexture, image, formatMip, true);
 
         // FIXME queue for transfer to GPU and block on completion
     }

--- a/libraries/render-utils/src/MaterialTextures.slh
+++ b/libraries/render-utils/src/MaterialTextures.slh
@@ -63,7 +63,8 @@ float fetchRoughnessMap(vec2 uv) {
 <@if withNormal@>
 uniform sampler2D normalMap;
 vec3 fetchNormalMap(vec2 uv) {
-    return texture(normalMap, uv).xyz;
+    // unpack normal, swizzle to get into hifi tangent space with Y axis pointing out
+    return normalize(texture(normalMap, uv).xzy -vec3(0.5, 0.5, 0.5));
 }
 <@endif@>
 
@@ -148,8 +149,20 @@ vec3 fetchLightmapMap(vec2 uv) {
     vec3 normalizedNormal = normalize(<$interpolatedNormal$>.xyz);
     vec3 normalizedTangent = normalize(<$interpolatedTangent$>.xyz);
     vec3 normalizedBitangent = normalize(cross(normalizedNormal, normalizedTangent));
-    vec3 localNormal = normalize(<$fetchedNormal$> - vec3(0.5, 0.5, 0.5));
+    vec3 localNormal = <$fetchedNormal$>;
     <$normal$> = vec3(normalizedTangent * localNormal.x + normalizedBitangent * localNormal.y + normalizedNormal * localNormal.z);
+}
+<@endfunc@>
+
+<@func tangentToViewSpaceLOD(fragPos, fetchedNormal, interpolatedNormal, interpolatedTangent, normal)@>
+{
+    vec3 normalizedNormal = normalize(<$interpolatedNormal$>.xyz);
+    vec3 normalizedTangent = normalize(<$interpolatedTangent$>.xyz);
+    vec3 normalizedBitangent = normalize(cross(normalizedNormal, normalizedTangent));
+    // attenuate the normal map divergence from the mesh normal based on distance
+    // THe attenuation range [20,100] meters from the eye is arbitrary for now
+    vec3 localNormal = mix(<$fetchedNormal$>, vec3(0.0, 1.0, 0.0), smoothstep(20, 100, (-<$fragPos$>).z));
+    <$normal$> = vec3(normalizedTangent * localNormal.x + normalizedNormal * localNormal.y + normalizedBitangent * localNormal.z);
 }
 <@endfunc@>
 

--- a/libraries/render-utils/src/forward_model_normal_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_map.slf
@@ -47,7 +47,7 @@ void main(void) {
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
     vec3 viewNormal;
-    <$tangentToViewSpace(normalTex, _normal, _tangent, viewNormal)$>
+    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
 
     float scattering = getMaterialScattering(mat);
     <$evalMaterialScattering(scatteringTex, scattering, matKey, scattering)$>;

--- a/libraries/render-utils/src/forward_model_normal_specular_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_specular_map.slf
@@ -47,7 +47,7 @@ void main(void) {
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
     vec3 viewNormal;
-    <$tangentToViewSpace(normalTex, _normal, _tangent, viewNormal)$>
+    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
 
     float metallic = getMaterialMetallic(mat);
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;

--- a/libraries/render-utils/src/model_lightmap_normal_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slf
@@ -34,7 +34,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
 
     vec3 viewNormal;
-    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
+    <$tangentToViewSpaceLOD(_position, normalTexel, _normal, _tangent, viewNormal)$>
 
     packDeferredFragmentLightmap(
         normalize(viewNormal.xyz), 

--- a/libraries/render-utils/src/model_lightmap_normal_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slf
@@ -34,7 +34,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
 
     vec3 viewNormal;
-    <$tangentToViewSpace(normalTexel, _normal, _tangent, viewNormal)$>
+    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
 
     packDeferredFragmentLightmap(
         normalize(viewNormal.xyz), 

--- a/libraries/render-utils/src/model_lightmap_normal_specular_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_specular_map.slf
@@ -34,7 +34,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
     
     vec3 viewNormal;
-    <$tangentToViewSpace(normalTexel, _normal, _tangent, viewNormal)$>
+    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
 
     packDeferredFragmentLightmap(
         normalize(viewNormal.xyz), 

--- a/libraries/render-utils/src/model_lightmap_normal_specular_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_specular_map.slf
@@ -34,7 +34,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
     
     vec3 viewNormal;
-    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
+    <$tangentToViewSpaceLOD(_position, normalTexel, _normal, _tangent, viewNormal)$>
 
     packDeferredFragmentLightmap(
         normalize(viewNormal.xyz), 

--- a/libraries/render-utils/src/model_normal_map.slf
+++ b/libraries/render-utils/src/model_normal_map.slf
@@ -47,7 +47,7 @@ void main(void) {
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
     vec3 viewNormal;
-    <$tangentToViewSpace(normalTex, _normal, _tangent, viewNormal)$>
+   <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
 
     float scattering = getMaterialScattering(mat);
     <$evalMaterialScattering(scatteringTex, scattering, matKey, scattering)$>;

--- a/libraries/render-utils/src/model_normal_specular_map.slf
+++ b/libraries/render-utils/src/model_normal_specular_map.slf
@@ -47,7 +47,7 @@ void main(void) {
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
     vec3 viewNormal;
-    <$tangentToViewSpace(normalTex, _normal, _tangent, viewNormal)$>
+    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
 
     float metallic = getMaterialMetallic(mat);
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;


### PR DESCRIPTION
Which was introduced since we generate mips with QImage (pr 9606)

Enable higher quality of filtering through QImage feature for color images in general to avoid the bad filtering we saw in the distance (dev-welcome ground surface)

For normal Maps, the mip generation is not good enough anyway. so we introduced a simple attenuation based on distance in the shader.
THe normal for a fragment is less affected by the normal map in the distance thus avoiding the bad lighting effect due to the normal map contribution in the distance (in dev-play the ground is showing bad patterns in the distance)

## Test Plan
This should fix the problem of filtering of textures in the distance
- in dev-welcome the flour grid should show correctly filtered
- in dev-playa the ground texture should not get darker and shimery in the distance

![image](https://cloud.githubusercontent.com/assets/2230265/22841692/652f23e8-ef87-11e6-8ff9-d9a28e15b124.png)
Dev-playa with current Master

![image](https://cloud.githubusercontent.com/assets/2230265/22841780/abbfae9a-ef87-11e6-9e41-319d7f486bce.png)
Dev-playa with this PR

![image](https://cloud.githubusercontent.com/assets/2230265/22841964/6b6096d8-ef88-11e6-97c0-6d416fb4a8a3.png)
Dev-Welcome with Master

![image](https://cloud.githubusercontent.com/assets/2230265/22841890/25c5889a-ef88-11e6-9f3c-57c1d69400fd.png)
Dev-Welcome with this PR