### PR TITLE
Added isAway (paused) property to myAvatar

### DIFF
--- a/interface/resources/qml/windows/Window.qml
+++ b/interface/resources/qml/windows/Window.qml
@@ -296,6 +296,10 @@ Fadable {
                 // fall through
 
             default:
+                if (MyAvatar.isAway) {
+                    // If stuck in a window and a key is pressed this should exit paused mode
+                    MyAvatar.isAway = false;
+                }
                 // Consume unmodified keyboard entries while the window is focused, to prevent them
                 // from propagating to the application
                 if (event.modifiers === Qt.NoModifier) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2365,7 +2365,10 @@ void MyAvatar::setAway(bool value) {
         return;
     }
     _isAway = value;
-    _isAway ? emit wentAway() : emit wentActive();
+    if (_isAway):
+        emit wentAway();
+    else:
+        emit wentActive();
 }
 
 // The resulting matrix is used to render the hand controllers, even if the camera is decoupled from the avatar.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2361,18 +2361,16 @@ bool MyAvatar::hasDriveInput() const {
 }
 
 void MyAvatar::setAway(bool value) {
-    if (_isAway == value) {
-        return;
-    }
     _isAway = value;
-    if (_isAway):
+    if (_isAway) {
         emit wentAway();
-    else:
+    } else {
         emit wentActive();
+    }
 }
 
 // The resulting matrix is used to render the hand controllers, even if the camera is decoupled from the avatar.
-// Specifically, if we are rendering using a third person camera.  We would like to render the hand controllers in front of the camera,
+// Specificly, if we are rendering using a third person camera.  We would like to render the hand controllers in front of the camera,
 // not in front of the avatar.
 glm::mat4 MyAvatar::computeCameraRelativeHandControllerMatrix(const glm::mat4& controllerSensorMatrix) const {
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2369,10 +2369,6 @@ void MyAvatar::setAway(bool value) {
     }
 }
 
-bool MyAvatar::getIsAway() {
-    return _isAway;
-}
-
 // The resulting matrix is used to render the hand controllers, even if the camera is decoupled from the avatar.
 // Specificly, if we are rendering using a third person camera.  We would like to render the hand controllers in front of the camera,
 // not in front of the avatar.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2361,16 +2361,15 @@ bool MyAvatar::hasDriveInput() const {
 }
 
 void MyAvatar::setAway(bool value) {
-    _isAway = value;
-    if (_isAway) {
-        emit wentAway();
-    } else {
-        emit wentActive();
+    if (_isAway == value) {
+        return;
     }
+    _isAway = value;
+    _isAway ? emit wentAway() : emit wentActive();
 }
 
 // The resulting matrix is used to render the hand controllers, even if the camera is decoupled from the avatar.
-// Specificly, if we are rendering using a third person camera.  We would like to render the hand controllers in front of the camera,
+// Specifically, if we are rendering using a third person camera.  We would like to render the hand controllers in front of the camera,
 // not in front of the avatar.
 glm::mat4 MyAvatar::computeCameraRelativeHandControllerMatrix(const glm::mat4& controllerSensorMatrix) const {
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -88,6 +88,7 @@ MyAvatar::MyAvatar(RigPointer rig) :
     _isPushing(false),
     _isBeingPushed(false),
     _isBraking(false),
+    _isAway(false),
     _boomLength(ZOOM_DEFAULT),
     _yawSpeed(YAW_SPEED_DEFAULT),
     _pitchSpeed(PITCH_SPEED_DEFAULT),
@@ -2357,6 +2358,19 @@ bool MyAvatar::didTeleport() {
 
 bool MyAvatar::hasDriveInput() const {
     return fabsf(_driveKeys[TRANSLATE_X]) > 0.0f || fabsf(_driveKeys[TRANSLATE_Y]) > 0.0f || fabsf(_driveKeys[TRANSLATE_Z]) > 0.0f;
+}
+
+void MyAvatar::setAway(bool value) {
+    _isAway = value;
+    if (_isAway) {
+        emit wentAway();
+    } else {
+        emit wentActive();
+    }
+}
+
+bool MyAvatar::getIsAway() {
+    return _isAway;
 }
 
 // The resulting matrix is used to render the hand controllers, even if the camera is decoupled from the avatar.

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -523,8 +523,8 @@ private:
     float getEnergy();
     void setEnergy(float value);
     bool didTeleport();
+    bool getIsAway() const { return _isAway; }
     void setAway(bool value);
-    bool getIsAway();
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -82,6 +82,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(controller::Pose rightHandTipPose READ getRightHandTipPose)
 
     Q_PROPERTY(float energy READ getEnergy WRITE setEnergy)
+    Q_PROPERTY(float isAway READ getIsAway WRITE setAway)
 
     Q_PROPERTY(bool hmdLeanRecenterEnabled READ getHMDLeanRecenterEnabled WRITE setHMDLeanRecenterEnabled)
     Q_PROPERTY(bool characterControllerEnabled READ getCharacterControllerEnabled WRITE setCharacterControllerEnabled)
@@ -328,6 +329,8 @@ signals:
     void energyChanged(float newEnergy);
     void positionGoneTo();
     void onLoadComplete();
+    void wentAway();
+    void wentActive();
 
 private:
 
@@ -385,6 +388,7 @@ private:
     bool _isPushing;
     bool _isBeingPushed;
     bool _isBraking;
+    bool _isAway;
 
     float _boomLength;
     float _yawSpeed; // degrees/sec
@@ -519,6 +523,8 @@ private:
     float getEnergy();
     void setEnergy(float value);
     bool didTeleport();
+    void setAway(bool value);
+    bool getIsAway();
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);


### PR DESCRIPTION
I added an isAway property to the myAvatar class, with signals for when paused/leaving paused mode. Scripts can then connect to this and modify the way that pauses are handled, or invoke pause on custom behavior. This also allows there to be some default behavior for pauses stored in the C++ logic.

This can also be used as a fix for when users get stuck in paused mode in certain situations.