### PR TITLE
CR-1 21114 -- ScriptCache/ScriptEngine cleanup, loader states, accessible load errors

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -684,22 +684,8 @@ bool EntityScriptingInterface::getServerScriptStatus(QUuid entityID, QScriptValu
     auto client = DependencyManager::get<EntityScriptClient>();
     auto request = client->createScriptStatusRequest(entityID);
     connect(request, &GetScriptStatusRequest::finished, callback.engine(), [callback](GetScriptStatusRequest* request) mutable {
-        QString statusString;
-        switch (request->getStatus()) {
-            case RUNNING:
-                statusString = "running";
-                break;
-            case ERROR_LOADING_SCRIPT:
-                statusString = "error_loading_script";
-                break;
-            case ERROR_RUNNING_SCRIPT:
-                statusString = "error_running_script";
-                break;
-            default:
-                statusString = "";
-                break;
-        }
-        QScriptValueList args { request->getResponseReceived(), request->getIsRunning(), statusString, request->getErrorInfo() };
+        QString statusString = EntityScriptStatus_::valueToKey(request->getStatus());;
+        QScriptValueList args { request->getResponseReceived(), request->getIsRunning(), statusString.toLower(), request->getErrorInfo() };
         callback.call(QScriptValue(), args);
         request->deleteLater();
     });

--- a/libraries/networking/src/EntityScriptClient.cpp
+++ b/libraries/networking/src/EntityScriptClient.cpp
@@ -88,7 +88,7 @@ MessageID EntityScriptClient::getEntityServerScriptStatus(QUuid entityID, GetScr
         }
     }
 
-    callback(false, false, ERROR_LOADING_SCRIPT, "");
+    callback(false, false, EntityScriptStatus::ERROR_LOADING_SCRIPT, "");
     return INVALID_MESSAGE_ID;
 }
 
@@ -97,7 +97,7 @@ void EntityScriptClient::handleGetScriptStatusReply(QSharedPointer<ReceivedMessa
 
     MessageID messageID;
     bool isKnown { false };
-    EntityScriptStatus status = ERROR_LOADING_SCRIPT;
+    EntityScriptStatus status = EntityScriptStatus::ERROR_LOADING_SCRIPT;
     QString errorInfo { "" };
 
     message->readPrimitive(&messageID);
@@ -157,7 +157,7 @@ void EntityScriptClient::forceFailureOfPendingRequests(SharedNodePointer node) {
         auto messageMapIt = _pendingEntityScriptStatusRequests.find(node);
         if (messageMapIt != _pendingEntityScriptStatusRequests.end()) {
             for (const auto& value : messageMapIt->second) {
-                value.second(false, false, ERROR_LOADING_SCRIPT, "");
+                value.second(false, false, EntityScriptStatus::ERROR_LOADING_SCRIPT, "");
             }
             messageMapIt->second.clear();
         }

--- a/libraries/networking/src/EntityScriptUtils.h
+++ b/libraries/networking/src/EntityScriptUtils.h
@@ -11,11 +11,23 @@
 
 #ifndef hifi_EntityScriptUtils_h
 #define hifi_EntityScriptUtils_h
+#include <QMetaEnum>
 
-enum EntityScriptStatus {
-    ERROR_LOADING_SCRIPT,
-    ERROR_RUNNING_SCRIPT,
-    RUNNING
+class EntityScriptStatus_ : public QObject {
+    Q_OBJECT
+public:
+    enum EntityScriptStatus {
+        PENDING,
+        LOADING,
+        ERROR_LOADING_SCRIPT,
+        ERROR_RUNNING_SCRIPT,
+        RUNNING,
+        UNLOADED
+    };
+    Q_ENUM(EntityScriptStatus)
+    static QString valueToKey(EntityScriptStatus status) {
+        return QMetaEnum::fromType<EntityScriptStatus>().valueToKey(status);
+    }
 };
-
+using EntityScriptStatus = EntityScriptStatus_::EntityScriptStatus;
 #endif // hifi_EntityScriptUtils_h

--- a/libraries/networking/src/ResourceRequest.h
+++ b/libraries/networking/src/ResourceRequest.h
@@ -38,6 +38,7 @@ public:
         InvalidURL,
         NotFound
     };
+    Q_ENUM(Result)
 
     QByteArray getData() { return _data; }
     State getState() const { return _state; }

--- a/libraries/script-engine/src/BatchLoader.h
+++ b/libraries/script-engine/src/BatchLoader.h
@@ -19,15 +19,17 @@
 #include <QString>
 #include <QUrl>
 
+#include "ScriptCache.h"
+
 #include <mutex>
 
 class ScriptCacheSignalProxy : public QObject {
     Q_OBJECT
 public:
-    void receivedContent(const QString& url, const QString& contents, bool isURL, bool success);
+    void receivedContent(const QString& url, const QString& contents, bool isURL, bool success, const QString& status);
 
 signals:
-    void contentAvailable(const QString& url, const QString& contents, bool isURL, bool success);
+    void contentAvailable(const QString& url, const QString& contents, bool isURL, bool success, const QString& status);
 };
 
 class BatchLoader : public QObject {
@@ -35,11 +37,11 @@ class BatchLoader : public QObject {
 public:
     BatchLoader(const QList<QUrl>& urls);
 
-    void start();
+    void start(int maxRetries = ScriptRequest::MAX_RETRIES);
     bool isFinished() const { return _finished; };
 
 signals:
-    void finished(const QMap<QUrl, QString>& data);
+    void finished(const QMap<QUrl, QString>& data, const QMap<QUrl, QString>& status);
 
 private:
     void checkFinished();
@@ -48,6 +50,7 @@ private:
     bool _finished;
     QSet<QUrl> _urls;
     QMap<QUrl, QString> _data;
+    QMap<QUrl, QString> _status;
 };
 
 #endif // hifi_BatchLoader_h

--- a/libraries/script-engine/src/ScriptCache.h
+++ b/libraries/script-engine/src/ScriptCache.h
@@ -15,7 +15,7 @@
 #include <mutex>
 #include <ResourceCache.h>
 
-using contentAvailableCallback = std::function<void(const QString& scriptOrURL, const QString& contents, bool isURL, bool contentAvailable)>;
+using contentAvailableCallback = std::function<void(const QString& scriptOrURL, const QString& contents, bool isURL, bool contentAvailable, const QString& status)>;
 
 class ScriptUser {
 public:
@@ -25,8 +25,11 @@ public:
 
 class ScriptRequest {
 public:
+    static const int MAX_RETRIES { 5 };
+    static const int START_DELAY_BETWEEN_RETRIES { 200 };
     std::vector<contentAvailableCallback> scriptUsers { };
     int numRetries { 0 };
+    int maxRetries { MAX_RETRIES };
 };
 
 /// Interface for loading scripts
@@ -38,23 +41,17 @@ class ScriptCache : public QObject, public Dependency {
     using Lock = std::unique_lock<Mutex>;
 
 public:
+    static const QString STATUS_INLINE;
+    static const QString STATUS_CACHED;
+
     void clearCache();
     Q_INVOKABLE void clearATPScriptsFromCache();
-    void getScriptContents(const QString& scriptOrURL, contentAvailableCallback contentAvailable, bool forceDownload = false);
+    void getScriptContents(const QString& scriptOrURL, contentAvailableCallback contentAvailable, bool forceDownload = false, int maxRetries = ScriptRequest::MAX_RETRIES);
 
-
-    QString getScript(const QUrl& unnormalizedURL, ScriptUser* scriptUser, bool& isPending, bool redownload = false);
     void deleteScript(const QUrl& unnormalizedURL);
 
-    // FIXME - how do we remove a script from the bad script list in the case of a redownload?
-    void addScriptToBadScriptList(const QUrl& url) { _badScripts.insert(url); }
-    bool isInBadScriptList(const QUrl& url) { return _badScripts.contains(url); }
-    
-private slots:
-    void scriptDownloaded(); // old version
-    void scriptContentAvailable(); // new version
-
 private:
+    void scriptContentAvailable(int maxRetries); // new version
     ScriptCache(QObject* parent = NULL);
     
     Mutex _containerLock;
@@ -62,7 +59,6 @@ private:
     
     QHash<QUrl, QString> _scriptCache;
     QMultiMap<QUrl, ScriptUser*> _scriptUsers;
-    QSet<QUrl> _badScripts;
 };
 
 #endif // hifi_ScriptCache_h

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -68,9 +68,11 @@
 
 #include "MIDIEvent.h"
 
-static const QString SCRIPT_EXCEPTION_FORMAT = "[UncaughtException] %1 in %2:%3";
+const QString BaseScriptEngine::SCRIPT_EXCEPTION_FORMAT { "[UncaughtException] %1 in %2:%3" };
 static const QScriptEngine::QObjectWrapOptions DEFAULT_QOBJECT_WRAP_OPTIONS =
                 QScriptEngine::ExcludeDeleteLater | QScriptEngine::ExcludeChildObjects;
+
+static const bool HIFI_AUTOREFRESH_FILE_SCRIPTS { true };
 
 Q_DECLARE_METATYPE(QScriptEngine::FunctionSignature)
 int functionSignatureMetaID = qRegisterMetaType<QScriptEngine::FunctionSignature>();
@@ -137,38 +139,48 @@ QString encodeEntityIdIntoEntityUrl(const QString& url, const QString& entityID)
     return url + " [EntityID:" + entityID + "]";
 }
 
-static bool hasCorrectSyntax(const QScriptProgram& program, ScriptEngine* reportingEngine) {
-    const auto syntaxCheck = QScriptEngine::checkSyntax(program.sourceCode());
-    if (syntaxCheck.state() != QScriptSyntaxCheckResult::Valid) {
+QString BaseScriptEngine::lintScript(const QString& sourceCode, const QString& fileName, const int lineNumber) {
+    const auto syntaxCheck = checkSyntax(sourceCode);
+    if (syntaxCheck.state() != syntaxCheck.Valid) {
         const auto error = syntaxCheck.errorMessage();
         const auto line = QString::number(syntaxCheck.errorLineNumber());
         const auto column = QString::number(syntaxCheck.errorColumnNumber());
-        const auto message = QString("[SyntaxError] %1 in %2:%3(%4)").arg(error, program.fileName(), line, column);
-        reportingEngine->scriptErrorMessage(qPrintable(message));
-        return false;
+        const auto message = QString("[SyntaxError] %1 in %2:%3(%4)").arg(error, fileName, line, column);
+        return message;
     }
-    return true;
+    return QString();
 }
 
-static bool hadUncaughtExceptions(QScriptEngine& engine, const QString& fileName, ScriptEngine* reportingEngine, QString* exceptionMessage = nullptr) {
-    if (engine.hasUncaughtException()) {
-        const auto backtrace = engine.uncaughtExceptionBacktrace();
-        const auto exception = engine.uncaughtException().toString();
-        const auto line = QString::number(engine.uncaughtExceptionLineNumber());
-        engine.clearExceptions();
+QString BaseScriptEngine::formatUncaughtException(const QString& overrideFileName) {
+    QString message;
+    if (hasUncaughtException()) {
+        const auto error = uncaughtException();
+        const auto backtrace = uncaughtExceptionBacktrace();
+        const auto exception = error.toString();
+        auto filename = overrideFileName;
+        if (filename.isEmpty()) {
+            QScriptContextInfo ctx { currentContext() };
+            filename = ctx.fileName();
+        }
+        const auto line = QString::number(uncaughtExceptionLineNumber());
 
-        QString message = QString(SCRIPT_EXCEPTION_FORMAT).arg(exception, fileName, line);
+        message = QString(SCRIPT_EXCEPTION_FORMAT).arg(exception, overrideFileName, line);
         if (!backtrace.empty()) {
             static const auto lineSeparator = "\n    ";
             message += QString("\n[Backtrace]%1%2").arg(lineSeparator, backtrace.join(lineSeparator));
         }
-        reportingEngine->scriptErrorMessage(qPrintable(message));
-        if (exceptionMessage) {
-            *exceptionMessage = message;
-        }
-        return true;
     }
-    return false;
+    return message;
+}
+
+QString ScriptEngine::reportUncaughtException(const QString& overrideFileName) {
+    QString message;
+    if (!hasUncaughtException()) {
+        return message;
+    }
+    message = formatUncaughtException(overrideFileName.isEmpty() ? _fileNameString : overrideFileName);
+    scriptErrorMessage(qPrintable(message));
+    return message;
 }
 
 ScriptEngine::ScriptEngine(Context context, const QString& scriptContents, const QString& fileNameString) :
@@ -181,7 +193,8 @@ ScriptEngine::ScriptEngine(Context context, const QString& scriptContents, const
     DependencyManager::get<ScriptEngines>()->addScriptEngine(this);
 
     connect(this, &QScriptEngine::signalHandlerException, this, [this](const QScriptValue& exception) {
-        hadUncaughtExceptions(*this, _fileNameString, this);
+        reportUncaughtException();
+        clearExceptions();
     });
     
     setProcessEventsInterval(MSECS_PER_SECOND);
@@ -301,7 +314,10 @@ void ScriptEngine::runDebuggable() {
         }
         _lastUpdate = now;
         // Debug and clear exceptions
-        hadUncaughtExceptions(*this, _fileNameString, this);
+        if (hasUncaughtException()) {
+            reportUncaughtException();
+            clearExceptions();
+        }
     });
 
     timer->start(10);
@@ -399,8 +415,6 @@ QString ScriptEngine::getFilename() const {
     return lastPart;
 }
 
-
-// FIXME - switch this to the new model of ScriptCache callbacks
 void ScriptEngine::loadURL(const QUrl& scriptURL, bool reload) {
     if (_isRunning) {
         return;
@@ -410,19 +424,27 @@ void ScriptEngine::loadURL(const QUrl& scriptURL, bool reload) {
     _fileNameString = url.toString();
     _isReloading = reload;
 
-    bool isPending;
+    const auto maxRetries = 0; // for consistency with previous scriptCache->getScript() behavior
     auto scriptCache = DependencyManager::get<ScriptCache>();
-    scriptCache->getScript(url, this, isPending, reload);
-}
+    scriptCache->getScriptContents(url.toString(), [this](const QString& url, const QString& scriptContents, bool isURL, bool success, const QString&status) {
+        qCDebug(scriptengine) << "loadURL" << url << status << QThread::currentThread();
+        if (!success) {
+            scriptErrorMessage("ERROR Loading file (" + status + "):" + url);
+            emit errorLoadingScript(_fileNameString);
+            return;
+        }
 
-// FIXME - switch this to the new model of ScriptCache callbacks
-void ScriptEngine::scriptContentsAvailable(const QUrl& url, const QString& scriptContents) {
-    _scriptContents = scriptContents;
-    static const QString DEBUG_FLAG("#debug");
-    if (QRegularExpression(DEBUG_FLAG).match(scriptContents).hasMatch()) {
-        _debuggable = true;
-    }
-    emit scriptLoaded(url.toString());
+        _scriptContents = scriptContents;
+
+        {
+            static const QString DEBUG_FLAG("#debug");
+            if (QRegularExpression(DEBUG_FLAG).match(scriptContents).hasMatch()) {
+                qCWarning(scriptengine) << "NOTE: ScriptEngine for " << QUrl(url).fileName() << " will be launched in debug mode";
+                _debuggable = true;
+            }
+        }
+        emit scriptLoaded(url);
+    }, reload, maxRetries);
 }
 
 void ScriptEngine::scriptErrorMessage(const QString& message) {
@@ -438,12 +460,6 @@ void ScriptEngine::scriptWarningMessage(const QString& message) {
 void ScriptEngine::scriptInfoMessage(const QString& message) {
     qCInfo(scriptengine) << message;
     emit infoMessage(message);
-}
-
-// FIXME - switch this to the new model of ScriptCache callbacks
-void ScriptEngine::errorInLoadingScript(const QUrl& url) {
-    scriptErrorMessage("ERROR Loading file:" + url.toString());
-    emit errorLoadingScript(_fileNameString);
 }
 
 // Even though we never pass AnimVariantMap directly to and from javascript, the queued invokeMethod of
@@ -520,6 +536,15 @@ void ScriptEngine::init() {
 
     auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
     entityScriptingInterface->init();
+    connect(entityScriptingInterface.data(), &EntityScriptingInterface::deletingEntity, this, [this](const EntityItemID& entityID) {
+        if (_entityScripts.contains(entityID)) {
+            if (isEntityScriptRunning(entityID)) {
+                qCWarning(scriptengine) << "deletingEntity while entity script is still running!" << entityID;
+            }
+            _entityScripts.remove(entityID);
+        }
+    });
+
 
     // register various meta-types
     registerMetaTypes(this);
@@ -850,17 +875,25 @@ QScriptValue ScriptEngine::evaluate(const QString& sourceCode, const QString& fi
     }
 
     // Check syntax
-    const QScriptProgram program(sourceCode, fileName, lineNumber);
-    if (!hasCorrectSyntax(program, this)) {
+    auto syntaxError = lintScript(sourceCode, fileName);
+    QScriptProgram program { sourceCode, fileName, lineNumber };
+    if (!syntaxError.isEmpty() || program.isNull()) {
+        scriptErrorMessage(qPrintable(syntaxError));
         return QScriptValue();
     }
 
     ++_evaluatesPending;
-    const auto result = QScriptEngine::evaluate(program);
+    auto result = BaseScriptEngine::evaluate(program);
     --_evaluatesPending;
 
-    const auto hadUncaughtException = hadUncaughtExceptions(*this, program.fileName(), this);
-    emit evaluationFinished(result, hadUncaughtException);
+    if (hasUncaughtException()) {
+        result = uncaughtException();
+        reportUncaughtException(program.fileName());
+        emit evaluationFinished(result, true);
+        clearExceptions();
+    } else {
+        emit evaluationFinished(result, false);
+    }
     return result;
 }
 
@@ -1009,7 +1042,10 @@ void ScriptEngine::run() {
         _lastUpdate = now;
 
         // Debug and clear exceptions
-        hadUncaughtExceptions(*this, _fileNameString, this);
+        if (hasUncaughtException()) {
+            reportUncaughtException();
+            clearExceptions();
+        }
     }
 
     scriptInfoMessage("Script Engine stopping:" + getFilename());
@@ -1299,12 +1335,12 @@ void ScriptEngine::include(const QStringList& includeFiles, QScriptValue callbac
     EntityItemID capturedEntityIdentifier = currentEntityIdentifier;
     QUrl capturedSandboxURL = currentSandboxURL;
 
-    auto evaluateScripts = [=](const QMap<QUrl, QString>& data) {
+    auto evaluateScripts = [=](const QMap<QUrl, QString>& data, const QMap<QUrl, QString>& status) {
         auto parentURL = _parentURL;
         for (QUrl url : urls) {
             QString contents = data[url];
             if (contents.isNull()) {
-                scriptErrorMessage("Error loading file: " + url.toString());
+                scriptErrorMessage("Error loading file (" + status[url] +"): " + url.toString());
             } else {
                 std::lock_guard<std::recursive_mutex> lock(_lock);
                 if (!_includedURLs.contains(url)) {
@@ -1368,7 +1404,7 @@ void ScriptEngine::load(const QString& loadFile) {
     }
     if (!currentEntityIdentifier.isInvalidID()) {
         scriptWarningMessage("Script.load() from entity script is ignored...  loadFile:" 
-                + loadFile + "parent script:" + getFilename());
+                + loadFile + "parent script:" + getFilename() + "entity: " + currentEntityIdentifier.toString());
         return; // bail early
     }
 
@@ -1411,11 +1447,16 @@ void ScriptEngine::forwardHandlerCall(const EntityItemID& entityID, const QStrin
 int ScriptEngine::getNumRunningEntityScripts() const {
     int sum = 0;
     for (auto& st : _entityScripts) {
-        if (st.status == RUNNING) {
+        if (st.status == EntityScriptStatus::RUNNING) {
             ++sum;
         }
     }
     return sum;
+
+QString ScriptEngine::getEntityScriptStatus(const EntityItemID& entityID) {
+    if (_entityScripts.contains(entityID))
+        return EntityScriptStatus_::valueToKey(_entityScripts[entityID].status).toLower();
+    return QString();
 }
 
 bool ScriptEngine::getEntityScriptDetails(const EntityItemID& entityID, EntityScriptDetails &details) const {
@@ -1430,25 +1471,37 @@ bool ScriptEngine::getEntityScriptDetails(const EntityItemID& entityID, EntitySc
 // since all of these operations can be asynch we will always do the actual work in the response handler
 // for the download
 void ScriptEngine::loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const EntityItemID& entityID, const QString& entityScript, bool forceRedownload) {
+    {
+        // set EntityScriptDetails.status to LOADING (over on theEngine's thread)
+        QObject threadPunter;
+        connect(&threadPunter, &QObject::destroyed, theEngine.data(), [=]() {
+            EntityScriptDetails &details = theEngine.data()->_entityScripts[entityID];
+            if (details.status == EntityScriptStatus::PENDING || details.status == EntityScriptStatus::UNLOADED) {
+                details.status = EntityScriptStatus::LOADING;
+                emit entityScriptDetailsUpdated();
+            }
+        });
+    }
+
     // NOTE: If the script content is not currently in the cache, the LAMBDA here will be called on the Main Thread
     //       which means we're guaranteed that it's not the correct thread for the ScriptEngine. This means
     //       when we get into entityScriptContentAvailable() we will likely invokeMethod() to get it over
     //       to the "Entities" ScriptEngine thread.
-    DependencyManager::get<ScriptCache>()->getScriptContents(entityScript, [theEngine, entityID](const QString& scriptOrURL, const QString& contents, bool isURL, bool success) {
+    DependencyManager::get<ScriptCache>()->getScriptContents(entityScript, [theEngine, entityID](const QString& scriptOrURL, const QString& contents, bool isURL, bool success, const QString &status) {
         QSharedPointer<ScriptEngine> strongEngine = theEngine.toStrongRef();
         if (strongEngine) {
 #ifdef THREAD_DEBUGGING
             qCDebug(scriptengine) << "ScriptEngine::entityScriptContentAvailable() IN LAMBDA contentAvailable on thread ["
                 << QThread::currentThread() << "] expected thread [" << strongEngine->thread() << "]";
 #endif
-            strongEngine->entityScriptContentAvailable(entityID, scriptOrURL, contents, isURL, success);
+            strongEngine->entityScriptContentAvailable(entityID, scriptOrURL, contents, isURL, success, status);
         }
     }, forceRedownload);
 }
 
 // since all of these operations can be asynch we will always do the actual work in the response handler
 // for the download
-void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, const QString& scriptOrURL, const QString& contents, bool isURL, bool success) {
+void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, const QString& scriptOrURL, const QString& contents, bool isURL, bool success , const QString& status) {
     if (QThread::currentThread() != thread()) {
 #ifdef THREAD_DEBUGGING
         qCDebug(scriptengine) << "*** WARNING *** ScriptEngine::entityScriptContentAvailable() called on wrong thread ["
@@ -1462,7 +1515,8 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
                                   Q_ARG(const QString&, scriptOrURL),
                                   Q_ARG(const QString&, contents),
                                   Q_ARG(bool, isURL),
-                                  Q_ARG(bool, success));
+                                  Q_ARG(bool, success),
+                                  Q_ARG(const QString&, status));
         return;
     }
 
@@ -1478,22 +1532,21 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
     newDetails.scriptText = scriptOrURL;
 
     if (!success) {
-        newDetails.status = ERROR_LOADING_SCRIPT;
-        newDetails.errorInfo = "Failed to load script";
+        newDetails.status = EntityScriptStatus::ERROR_LOADING_SCRIPT;
+        newDetails.errorInfo = "Failed to load script (" + status + ")";
         _entityScripts[entityID] = newDetails;
         emit entityScriptDetailsUpdated();
         return;
     }
 
-    QScriptProgram program(contents, fileName);
-    if (!hasCorrectSyntax(program, this)) {
-        if (!isFileUrl) {
-            scriptCache->addScriptToBadScriptList(scriptOrURL);
-        }
-        newDetails.status = ERROR_RUNNING_SCRIPT;
-        newDetails.errorInfo = "Bad syntax";
+    auto syntaxError = lintScript(contents, fileName);
+    QScriptProgram program { contents, fileName };
+    if (!syntaxError.isNull() || program.isNull()) {
+        newDetails.status = EntityScriptStatus::ERROR_RUNNING_SCRIPT;
+        newDetails.errorInfo = QString("Bad syntax (%1)").arg(syntaxError);
         _entityScripts[entityID] = newDetails;
         emit entityScriptDetailsUpdated();
+        qCDebug(scriptengine) << newDetails.errorInfo << scriptOrURL;
         return; // done processing script
     }
 
@@ -1502,16 +1555,18 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
     }
 
     const int SANDBOX_TIMEOUT = 0.25 * MSECS_PER_SECOND;
-    QScriptEngine sandbox;
+    BaseScriptEngine sandbox;
     sandbox.setProcessEventsInterval(SANDBOX_TIMEOUT);
     QScriptValue testConstructor;
     {
         QTimer timeout;
         timeout.setSingleShot(true);
         timeout.start(SANDBOX_TIMEOUT);
-        connect(&timeout, &QTimer::timeout, [&sandbox, SANDBOX_TIMEOUT]{
+        connect(&timeout, &QTimer::timeout, [&sandbox, SANDBOX_TIMEOUT, scriptOrURL]{
             auto context = sandbox.currentContext();
             if (context) {
+                qCDebug(scriptengine) << "ScriptEngine::entityScriptContentAvailable timeout(" << scriptOrURL << ")";
+
                 // Guard against infinite loops and non-performant code
                 context->throwError(QString("Timed out (entity constructors are limited to %1ms)").arg(SANDBOX_TIMEOUT));
             }
@@ -1519,13 +1574,13 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         testConstructor = sandbox.evaluate(program);
     }
 
-    QString exceptionMessage;
-    if (hadUncaughtExceptions(sandbox, program.fileName(), this, &exceptionMessage)) {
-        newDetails.status = ERROR_RUNNING_SCRIPT;
+    QString exceptionMessage = sandbox.formatUncaughtException(program.fileName());
+    if (!exceptionMessage.isNull()) {
+        newDetails.status = EntityScriptStatus::ERROR_RUNNING_SCRIPT;
         newDetails.errorInfo = exceptionMessage;
         _entityScripts[entityID] = newDetails;
         emit entityScriptDetailsUpdated();
-
+        qCDebug(scriptengine) << "----- ScriptEngine::entityScriptContentAvailable -- hadUncaughtExceptions (" << scriptOrURL << ")";
         return;
     }
 
@@ -1544,15 +1599,12 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
                               + "," + testConstructorValue
                               + "," + scriptOrURL);
 
-        if (!isFileUrl) {
-            scriptCache->addScriptToBadScriptList(scriptOrURL);
-        }
-
-        newDetails.status = ERROR_RUNNING_SCRIPT;
+        newDetails.status = EntityScriptStatus::ERROR_RUNNING_SCRIPT;
         newDetails.errorInfo = "Could not find constructor";
         _entityScripts[entityID] = newDetails;
         emit entityScriptDetailsUpdated();
 
+        qCDebug(scriptengine) << "----- ScriptEngine::entityScriptContentAvailable -- failed to run (" << scriptOrURL << ")";
         return; // done processing script
     }
 
@@ -1569,6 +1621,7 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
     };
     doWithEnvironment(entityID, sandboxURL, initialization);
 
+    newDetails.status = EntityScriptStatus::RUNNING;
     newDetails.scriptObject = entityScriptObject;
     newDetails.lastModified = lastModified;
     newDetails.definingSandboxURL = sandboxURL;
@@ -1600,10 +1653,12 @@ void ScriptEngine::unloadEntityScript(const EntityItemID& entityID) {
 #endif
 
     if (_entityScripts.contains(entityID)) {
-        if (_entityScripts[entityID].status == RUNNING) {
+        if (isEntityScriptRunning(entityID)) {
             callEntityScriptMethod(entityID, "unload");
         }
-        _entityScripts.remove(entityID);
+        EntityScriptDetails details;
+        details.status = EntityScriptStatus::UNLOADED;
+        _entityScripts[entityID] = details;
         stopAllTimersForEntityScript(entityID);
         emit entityScriptDetailsUpdated();
     }
@@ -1622,9 +1677,7 @@ void ScriptEngine::unloadAllEntityScripts() {
     qCDebug(scriptengine) << "ScriptEngine::unloadAllEntityScripts() called on correct thread [" << thread() << "]";
 #endif
     foreach(const EntityItemID& entityID, _entityScripts.keys()) {
-        if (_entityScripts[entityID].status == RUNNING) {
-            callEntityScriptMethod(entityID, "unload");
-        }
+        unloadEntityScript(entityID);
     }
     _entityScripts.clear();
     emit entityScriptDetailsUpdated();
@@ -1641,7 +1694,7 @@ void ScriptEngine::unloadAllEntityScripts() {
 }
 
 void ScriptEngine::refreshFileScript(const EntityItemID& entityID) {
-    if (!_entityScripts.contains(entityID)) {
+    if (!HIFI_AUTOREFRESH_FILE_SCRIPTS || !_entityScripts.contains(entityID)) {
         return;
     }
 
@@ -1663,8 +1716,8 @@ void ScriptEngine::refreshFileScript(const EntityItemID& entityID) {
             file.open(QIODevice::ReadOnly);
             QString scriptContents = QTextStream(&file).readAll();
             this->unloadEntityScript(entityID);
-            this->entityScriptContentAvailable(entityID, details.scriptText, scriptContents, true, true);
-            if (!_entityScripts.contains(entityID) || _entityScripts[entityID].status != RUNNING) {
+            this->entityScriptContentAvailable(entityID, details.scriptText, scriptContents, true, true, "Success");
+            if (!isEntityScriptRunning(entityID)) {
                 scriptWarningMessage("Reload script " + details.scriptText + " failed");
             } else {
                 details = _entityScripts[entityID];
@@ -1692,7 +1745,10 @@ void ScriptEngine::doWithEnvironment(const EntityItemID& entityID, const QUrl& s
 #else
     operation();
 #endif
-    hadUncaughtExceptions(*this, _fileNameString, this);
+    if (hasUncaughtException()) {
+        reportUncaughtException();
+        clearExceptions();
+    }
 
     currentEntityIdentifier = oldIdentifier;
     currentSandboxURL = oldSandboxURL;
@@ -1722,8 +1778,10 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
         "entityID:" << entityID << "methodName:" << methodName;
 #endif
 
-    refreshFileScript(entityID);
-    if (_entityScripts.contains(entityID) && _entityScripts[entityID].status == RUNNING) {
+    if (HIFI_AUTOREFRESH_FILE_SCRIPTS && methodName != "unload") {
+        refreshFileScript(entityID);
+    }
+    if (isEntityScriptRunning(entityID)) {
         EntityScriptDetails details = _entityScripts[entityID];
         QScriptValue entityScript = details.scriptObject; // previously loaded
         if (entityScript.property(methodName).isFunction()) {
@@ -1754,8 +1812,10 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
         "entityID:" << entityID << "methodName:" << methodName << "event: pointerEvent";
 #endif
 
-    refreshFileScript(entityID);
-    if (_entityScripts.contains(entityID) && _entityScripts[entityID].status == RUNNING) {
+    if (HIFI_AUTOREFRESH_FILE_SCRIPTS) {
+        refreshFileScript(entityID);
+    }
+    if (isEntityScriptRunning(entityID)) {
         EntityScriptDetails details = _entityScripts[entityID];
         QScriptValue entityScript = details.scriptObject; // previously loaded
         if (entityScript.property(methodName).isFunction()) {
@@ -1787,8 +1847,10 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
         "entityID:" << entityID << "methodName:" << methodName << "otherID:" << otherID << "collision: collision";
 #endif
     
-    refreshFileScript(entityID);
-    if (_entityScripts.contains(entityID) && _entityScripts[entityID].status == RUNNING) {
+    if (HIFI_AUTOREFRESH_FILE_SCRIPTS) {
+        refreshFileScript(entityID);
+    }
+    if (isEntityScriptRunning(entityID)) {
         EntityScriptDetails details = _entityScripts[entityID];
         QScriptValue entityScript = details.scriptObject; // previously loaded
         if (entityScript.property(methodName).isFunction()) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -356,6 +356,16 @@ void ScriptEngine::runInThread() {
     workerThread->start();
 }
 
+void ScriptEngine::executeOnScriptThread(std::function<void()> function, bool blocking ) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "executeOnScriptThread", blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection,
+            Q_ARG(std::function<void()>, function));
+        return;
+    }
+
+    function();
+}
+
 void ScriptEngine::waitTillDoneRunning() {
     auto workerThread = thread();
 
@@ -1490,18 +1500,13 @@ void ScriptEngine::updateEntityScriptStatus(const EntityItemID& entityID, const 
 // since all of these operations can be asynch we will always do the actual work in the response handler
 // for the download
 void ScriptEngine::loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const EntityItemID& entityID, const QString& entityScript, bool forceRedownload) {
-
-    {
-        // set EntityScriptDetails.status to LOADING (over on theEngine's thread)
-        QObject threadPunter;
-        auto engine = theEngine.data();
-        connect(&threadPunter, &QObject::destroyed, engine, [=]() {
-            EntityScriptDetails details = engine->_entityScripts[entityID];
-            if (details.status == EntityScriptStatus::PENDING || details.status == EntityScriptStatus::UNLOADED) {
-                engine->updateEntityScriptStatus(entityID, EntityScriptStatus::LOADING, QThread::currentThread()->objectName());
-            }
-        });
-    }
+    auto engine = theEngine.data();
+    engine->executeOnScriptThread([=]{
+        EntityScriptDetails details = engine->_entityScripts[entityID];
+        if (details.status == EntityScriptStatus::PENDING || details.status == EntityScriptStatus::UNLOADED) {
+            engine->updateEntityScriptStatus(entityID, EntityScriptStatus::LOADING, QThread::currentThread()->objectName());
+        }
+    });
 
     // NOTE: If the script content is not currently in the cache, the LAMBDA here will be called on the Main Thread
     //       which means we're guaranteed that it's not the correct thread for the ScriptEngine. This means

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -98,6 +98,7 @@ public:
     /// the current script contents and calling run(). Callers will likely want to register the script with external
     /// services before calling this.
     void runInThread();
+    Q_INVOKABLE void executeOnScriptThread(std::function<void()> function, bool blocking = false);
 
     void runDebuggable();
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -59,7 +59,7 @@ typedef QHash<QString, CallbackList> RegisteredEventHandlers;
 
 class EntityScriptDetails {
 public:
-    EntityScriptStatus status { RUNNING };
+    EntityScriptStatus status { EntityScriptStatus::PENDING };
 
     // If status indicates an error, this contains a human-readable string giving more information about the error.
     QString errorInfo { "" };
@@ -70,7 +70,15 @@ public:
     QUrl definingSandboxURL { QUrl() };
 };
 
-class ScriptEngine : public QScriptEngine, public ScriptUser, public EntitiesScriptEngineProvider {
+// common base class with just QScriptEngine-dependent helper methods
+class BaseScriptEngine : public QScriptEngine {
+public:
+    static const QString SCRIPT_EXCEPTION_FORMAT;
+    QString lintScript(const QString& sourceCode, const QString& fileName, const int lineNumber = 1);
+    QString formatUncaughtException(const QString& overrideFileName = QString());
+};
+
+class ScriptEngine : public BaseScriptEngine, public EntitiesScriptEngineProvider {
     Q_OBJECT
     Q_PROPERTY(QString context READ getContext)
 public:
@@ -157,6 +165,10 @@ public:
     Q_INVOKABLE QUrl resourcesPath() const;
 
     // Entity Script Related methods
+    Q_INVOKABLE QString getEntityScriptStatus(const EntityItemID& entityID);
+    Q_INVOKABLE bool isEntityScriptRunning(const EntityItemID& entityID) {
+        return _entityScripts.contains(entityID) && _entityScripts[entityID].status == EntityScriptStatus::RUNNING;
+    }
     static void loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
@@ -180,11 +192,6 @@ public:
     void disconnectNonEssentialSignals();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // NOTE - These are the callback implementations for ScriptUser the get called by ScriptCache when the contents
-    // of a script are available.
-    virtual void scriptContentsAvailable(const QUrl& url, const QString& scriptContents) override;
-    virtual void errorInLoadingScript(const QUrl& url) override;
-
     // These are currently used by Application to track if a script is user loaded or not. Consider finding a solution
     // inside of Application so that the ScriptEngine class is not polluted by this notion
     void setUserLoaded(bool isUserLoaded) { _isUserLoaded = isUserLoaded; }
@@ -203,6 +210,7 @@ public:
     bool getEntityScriptDetails(const EntityItemID& entityID, EntityScriptDetails &details) const;
 
 public slots:
+    int evaluatePending() const { return _evaluatesPending; }
     void callAnimationStateHandler(QScriptValue callback, AnimVariantMap parameters, QStringList names, bool useNames, AnimVariantResultHandler resultHandler);
     void updateMemoryCost(const qint64&);
 
@@ -230,7 +238,7 @@ signals:
 protected:
     void init();
 
-    bool evaluatePending() const { return _evaluatesPending > 0; }
+    QString reportUncaughtException(const QString& overrideFileName = QString());
     void timerFired();
     void stopAllTimers();
     void stopAllTimersForEntityScript(const EntityItemID& entityID);
@@ -243,7 +251,7 @@ protected:
 
     QHash<EntityItemID, RegisteredEventHandlers> _registeredHandlers;
     void forwardHandlerCall(const EntityItemID& entityID, const QString& eventName, QScriptValueList eventHanderArgs);
-    Q_INVOKABLE void entityScriptContentAvailable(const EntityItemID& entityID, const QString& scriptOrURL, const QString& contents, bool isURL, bool success);
+    Q_INVOKABLE void entityScriptContentAvailable(const EntityItemID& entityID, const QString& scriptOrURL, const QString& contents, bool isURL, bool success, const QString& status);
 
     EntityItemID currentEntityIdentifier {}; // Contains the defining entity script entity id during execution, if any. Empty for interface script execution.
     QUrl currentSandboxURL {}; // The toplevel url string for the entity script that loaded the code being executed, else empty.

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -90,6 +90,7 @@ public:
         AGENT_SCRIPT
     };
 
+    static int processLevelMaxRetries;
     ScriptEngine(Context context, const QString& scriptContents = NO_SCRIPT, const QString& fileNameString = QString(""));
     ~ScriptEngine();
 
@@ -243,7 +244,8 @@ protected:
     void stopAllTimers();
     void stopAllTimersForEntityScript(const EntityItemID& entityID);
     void refreshFileScript(const EntityItemID& entityID);
-
+    void updateEntityScriptStatus(const EntityItemID& entityID, const EntityScriptStatus& status, const QString& errorInfo = QString());
+    void setEntityScriptDetails(const EntityItemID& entityID, const EntityScriptDetails& details);
     void setParentURL(const QString& parentURL) { _parentURL = parentURL; }
 
     QObject* setupTimerWithInterval(const QScriptValue& function, int intervalMS, bool isSingleShot);

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -27,6 +27,8 @@
 
 static const QString DESKTOP_LOCATION = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
 
+static const bool HIFI_SCRIPT_DEBUGGABLES { true };
+
 ScriptsModel& getScriptsModel() {
     static ScriptsModel scriptsModel;
     return scriptsModel;
@@ -517,8 +519,9 @@ void ScriptEngines::launchScriptEngine(ScriptEngine* scriptEngine) {
     for (auto initializer : _scriptInitializers) {
         initializer(scriptEngine);
     }
-    
-    if (scriptEngine->isDebuggable() || (qApp->queryKeyboardModifiers() & Qt::ShiftModifier)) {
+
+    auto const wantDebug = scriptEngine->isDebuggable() || (qApp->queryKeyboardModifiers() & Qt::ShiftModifier);
+    if (HIFI_SCRIPT_DEBUGGABLES && wantDebug) {
         scriptEngine->runDebuggable();
     } else {
         scriptEngine->runInThread();

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1463,8 +1463,8 @@ var PropertiesTool = function (opts) {
 
     function resetScriptStatus() {
         updateScriptStatus({
-            statusRetrieved: false,
-            isRunning: false,
+            statusRetrieved: undefined,
+            isRunning: undefined,
             status: "",
             errorInfo: ""
         });

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -318,6 +318,7 @@
                 <input type="text" id="property-script-url">
                 <input type="button" id="reload-script-button" class="glyph" value="F">
             </div>
+            <hr class="behavior-group" />
             <div class="behavior-group property url refresh">
                 <label for="property-server-scripts">Server Script URL</label>
                 <input type="text" id="property-server-scripts">

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -713,24 +713,22 @@ function loaded() {
             EventBridge.scriptEventReceived.connect(function(data) {
                 data = JSON.parse(data);
                 if (data.type == "server_script_status") {
-                    if (!data.statusRetrieved) {
-                        elServerScriptStatus.innerHTML = "Failed to retrieve status";
-                        elServerScriptError.style.display = "none";
+                    elServerScriptError.value = data.errorInfo;
+                    elServerScriptError.style.display = data.errorInfo ? "block" : "none";
+                    if (data.statusRetrieved === false) {
+                        elServerScriptStatus.innerText = "Failed to retrieve status";
                     } else if (data.isRunning) {
-                        if (data.status == "running") {
-                            elServerScriptStatus.innerHTML = "Running";
-                            elServerScriptError.style.display = "none";
-                        } else if (data.status == "error_loading_script") {
-                            elServerScriptStatus.innerHTML = "Error loading script";
-                            elServerScriptError.style.display = "block";
-                        } else if (data.status == "error_running_script") {
-                            elServerScriptStatus.innerHTML = "Error running script";
-                            elServerScriptError.style.display = "block";
-                        }
-                        elServerScriptError.innerHTML = data.errorInfo;;
+                        var ENTITY_SCRIPT_STATUS = {
+                            pending: "Pending",
+                            loading: "Loading",
+                            error_loading_script: "Error loading script",
+                            error_running_script: "Error running script",
+                            running: "Running",
+                            unloaded: "Unloaded",
+                        };
+                        elServerScriptStatus.innerText = ENTITY_SCRIPT_STATUS[data.status] || data.status;
                     } else {
-                        elServerScriptStatus.innerHTML = "Not running";
-                        elServerScriptError.style.display = "none";
+                        elServerScriptStatus.innerText = "Not running";
                     }
                 } else if (data.type == "update") {
 
@@ -1169,6 +1167,10 @@ function loaded() {
         elScriptURL.addEventListener('change', createEmitTextPropertyUpdateFunction('script'));
         elScriptTimestamp.addEventListener('change', createEmitNumberPropertyUpdateFunction('scriptTimestamp'));
         elServerScripts.addEventListener('change', createEmitTextPropertyUpdateFunction('serverScripts'));
+        elServerScripts.addEventListener('change', function() {
+            // invalidate the current status (so that same-same updates can still be observed visually)
+            elServerScriptStatus.innerText = '[' + elServerScriptStatus.innerText + ']';
+        });
 
         elClearUserData.addEventListener("click", function() {
             deleteJSONEditor();
@@ -1428,6 +1430,8 @@ function loaded() {
             }));
         });
         elReloadServerScriptsButton.addEventListener("click", function() {
+            // invalidate the current status (so that same-same updates can still be observed visually)
+            elServerScriptStatus.innerText = '[' + elServerScriptStatus.innerText + ']';
             EventBridge.emitWebEvent(JSON.stringify({
                 type: "action",
                 action: "reloadServerScripts"


### PR DESCRIPTION
This PR contains several changes from the `require/module` work, separated out this way to split things up a little for code review and testing.

* Add new entity script statuses (PENDING, LOADING and UNLOADED).
* Provide specific network errors for failed scripts.
* Resolve FIXMEs related to script loading/caching; cleanup dead code.
* Refactor support for JavaScript syntax checking and exception reporting.
* Update the editor's "Server Script URL" panel to reflect the new statuses.

With @huffman's help I was able to get that last part working, which now doubles as a way to test the overall changes from the UI.

A cool thing for the user is that augmented errors show up in the tablet/editor panel for server scripts -- like when a syntax error, the problematic line number; or if a script fails to load, the underlying network reason.

### Testing:

* Launch the PR build of Interface + Sandbox.
* Perform a general smoke test to do with loading Client scripts
 *(app behavior should not have changed -- but Client scripts are now fetched using a different method so just want to be sure)*
* Rez a few Entities to work with.
* Try attaching a representative sample of script URLs (in the `Script URL` and `Server Script URL` fields, but not necessarily same time).
* For Server scripts -- detailed error messages should come back in the textarea:
![image](https://cloud.githubusercontent.com/assets/94753/22858917/3ec8cbfa-f09a-11e6-8a66-c3f93560335f.png)
* For regular entity scripts -- similar error messages should get reported to the debug log:
`02/11 20:41:08] [DEBUG] [hifi.scriptengine] "Bad syntax ([SyntaxError] Illegal character in https://httpbin.org/image/png:1(1))" "https://httpbin.org/image/png"`

test urls:
* https://httpbin.org/delay/10 => ~10 seconds of *Loading* => `Could not find constructor`
* http://httpbin.org/404 => `Failed to load script (Not Found)`
* [ftp://0.0.0.0:0000](ftp://0.0.0.0:0000) => `Failed to load script (AccessDenied)`
* [http:////:ptth](http:////:ptth) => `Failed to load script (ServerUnavailable)`
* https://httpbin.org/image/png => `...[SyntaxError] Illegal character in https://httpbin.org/image/png:1(1)`
* [/scripts/developer/tests/basicEntityTest/myEntityScript.js](https://raw.githubusercontent.com/highfidelity/hifi/master/scripts/developer/tests/basicEntityTest/myEntityScript.js) => *Running* (no error)
*Clear-out a populated Server Script URL* => *Unloaded* or *Not Running* (no error)
