### PR TITLE
Add entity clicks capture capabilities

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3111,7 +3111,10 @@ void Application::mousePressEvent(QMouseEvent* event) {
 
     if (!_aboutToQuit) {
         getOverlays().mousePressEvent(&mappedEvent);
-        getEntities()->mousePressEvent(&mappedEvent);
+
+        if (!_controllerScriptingInterface->areEntityClicksCaptured()) {
+            getEntities()->mousePressEvent(&mappedEvent);
+        }
     }
 
     _controllerScriptingInterface->emitMousePressEvent(&mappedEvent); // send events to any registered scripts

--- a/interface/src/scripting/ControllerScriptingInterface.cpp
+++ b/interface/src/scripting/ControllerScriptingInterface.cpp
@@ -60,6 +60,18 @@ void ControllerScriptingInterface::releaseKeyEvents(const KeyEvent& event) {
     }
 }
 
+bool ControllerScriptingInterface::areEntityClicksCaptured() const {
+    return _captureEntityClicks;
+}
+
+void ControllerScriptingInterface::captureEntityClickEvents() {
+    _captureEntityClicks = true;
+}
+
+void ControllerScriptingInterface::releaseEntityClickEvents() {
+    _captureEntityClicks = false;
+}
+
 bool ControllerScriptingInterface::isJoystickCaptured(int joystickIndex) const {
     return _capturedJoysticks.contains(joystickIndex);
 }

--- a/interface/src/scripting/ControllerScriptingInterface.h
+++ b/interface/src/scripting/ControllerScriptingInterface.h
@@ -84,6 +84,7 @@ public:
     bool isKeyCaptured(QKeyEvent* event) const;
     bool isKeyCaptured(const KeyEvent& event) const;
     bool isJoystickCaptured(int joystickIndex) const;
+    bool areEntityClicksCaptured() const;
 
     void updateInputControllers();
 
@@ -94,6 +95,9 @@ public slots:
 
     virtual void captureJoystick(int joystickIndex);
     virtual void releaseJoystick(int joystickIndex);
+
+    virtual void captureEntityClickEvents();
+    virtual void releaseEntityClickEvents();
 
     virtual glm::vec2 getViewportDimensions() const;
     virtual QVariant getRecommendedOverlayRect() const;
@@ -128,6 +132,7 @@ private:
 
     QMultiMap<int,KeyEvent> _capturedKeys;
     QSet<int> _capturedJoysticks;
+    bool _captureEntityClicks;
 
     using InputKey = controller::InputController::Key;
     using InputControllerMap = std::map<InputKey, controller::InputController::Pointer>;

--- a/scripts/system/controllers/grab.js
+++ b/scripts/system/controllers/grab.js
@@ -404,7 +404,7 @@ Grabber.prototype.pressEvent = function(event) {
 };
 
 Grabber.prototype.releaseEvent = function(event) {
-        if (event.isLeftButton!==true ||event.isRightButton===true || event.isMiddleButton===true) {
+    if (event.isLeftButton!==true ||event.isRightButton===true || event.isMiddleButton===true) {
         return;
     }
 

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -462,6 +462,11 @@ var toolBar = (function () {
 
     that.setActive = function (active) {
         Settings.setValue(EDIT_SETTING, active);
+        if (active) {
+            Controller.captureEntityClickEvents();
+        } else {
+            Controller.releaseEntityClickEvents();
+        }
         if (active === isActive) {
             return;
         }
@@ -965,6 +970,7 @@ function cleanupModelMenus() {
 }
 
 Script.scriptEnding.connect(function () {
+    toolBar.setActive(false);
     Settings.setValue(SETTING_AUTO_FOCUS_ON_SELECT, Menu.isOptionChecked(MENU_AUTO_FOCUS_ON_SELECT));
     Settings.setValue(SETTING_EASE_ON_FOCUS, Menu.isOptionChecked(MENU_EASE_ON_FOCUS));
     Settings.setValue(SETTING_SHOW_LIGHTS_IN_EDIT_MODE, Menu.isOptionChecked(MENU_SHOW_LIGHTS_IN_EDIT_MODE));

--- a/scripts/system/libraries/utils.js
+++ b/scripts/system/libraries/utils.js
@@ -9,7 +9,7 @@
 // note: this constant is currently duplicated in edit.js
 EDIT_SETTING = "io.highfidelity.isEditting";
 isInEditMode = function isInEditMode() {
-    return Settings.getValue(EDIT_SETTING) === "false" ? false : !!Settings.getValue(EDIT_SETTING);
+    return Settings.getValue(EDIT_SETTING);
 };
 
 if (!Function.prototype.bind) {


### PR DESCRIPTION
Allow scripts to capture entity clicks.
This allow scripts to pause direct interaction with entities in special circumstances like editing.

## Test Plan:
- Go to dev-welcome
- Go to edit mode
- Click the block launcher
- On previous builds, it would get selected and would shoot a block
- On the build, it will only get selected and not shoot a block
- Test that going in and out of edit mode/ switching domains while in different modes doesn't break the behavior.

Fixes: https://highfidelity.fogbugz.com/f/cases/2913/Entities-are-triggerable-in-edit-mode