### PR TITLE
Don't allow a ban of any node on same machine as domain-server

### DIFF
--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -667,7 +667,17 @@ void DomainServerSettingsManager::processNodeKickRequestPacket(QSharedPointer<Re
                     auto& kickAddress = matchingNode->getActiveSocket()
                         ? matchingNode->getActiveSocket()->getAddress()
                         : matchingNode->getPublicSocket().getAddress();
-
+                    
+                    // probably isLoopback covers it, as whenever I try to ban an agent on same machine as the domain-server
+                    // it is always 127.0.0.1, but looking at the public and local addresses just to be sure
+                    // TODO: soon we will have feedback (in the form of a message to the client) after we kick.  When we
+                    // do, we will have a success flag, and perhaps a reason for failure.  For now, just don't do it.  
+                    if (kickAddress == limitedNodeList->getPublicSockAddr().getAddress() ||
+                        kickAddress == limitedNodeList->getLocalSockAddr().getAddress() ||
+                        kickAddress.isLoopback() ) {
+                        qWarning() << "attempt to kick node running on same machine as domain server, ignoring KickRequest";
+                        return;
+                    }
                     NodePermissionsKey ipAddressKey(kickAddress.toString(), QUuid());
 
                     // check if there were already permissions for the IP


### PR DESCRIPTION
If you do, then all the assignment clients (if they run on same box as the domain-server) are also kicked, leaving the domain basically dead until someone fixes the permissions in the domain server setting page.

Ideally, we would have added a message (say, KickResponse) which gives an indication of success/failure and why, etc...  But that is really part of an additional feature, which allows for un-banning and so on.  

This only addresses this one issue where we ban something at 127.0.0.1 and the whole domain goes down.  Look for more fancy features building on this later!