### PR TITLE
Fix entity scripts not loading in certain cases

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -148,7 +148,7 @@ private:
     bool layerZoneAndHasSkybox(const std::shared_ptr<ZoneEntityItem>& zone);
     bool applySkyboxAndHasAmbient();
 
-    void checkAndCallPreload(const EntityItemID& entityID, const bool reload = false);
+    void checkAndCallPreload(const EntityItemID& entityID, const bool reload = false, const bool unloadFirst = false);
 
     QList<ModelPointer> _releasedModels;
     RayToEntityIntersectionResult findRayIntersectionWorker(const PickRay& ray, Octree::lockType lockType,

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -446,6 +446,7 @@ public:
     bool shouldPreloadScript() const { return !_script.isEmpty() &&
                                               ((_loadedScript != _script) || (_loadedScriptTimestamp != _scriptTimestamp)); }
     void scriptHasPreloaded() { _loadedScript = _script; _loadedScriptTimestamp = _scriptTimestamp; }
+    void scriptHasUnloaded() { _loadedScript = ""; _loadedScriptTimestamp = 0; }
 
     bool getClientOnly() const { return _clientOnly; }
     void setClientOnly(bool clientOnly) { _clientOnly = clientOnly; }


### PR DESCRIPTION
This fixes a bug where an entity script would be loaded but immediately
unloaded. This happens when the script property of the entity is changed shortly
after it is added.

Flow of events:

  Entity added
  => Entity added event emitted
  Entity edited
  => Script changing event emitted
  <= Entity added event received
  Script loaded
  <= Script changing event received
  Script stopped
  Tries to load script again, but because the script hasn't changed
    since it was last loaded, it is not loaded again.

The change here is to modify the behavior when receiving a script
changing event. Instead of always unloading and then conditionally
loading the script, it will either do both (unload + load) or neither.