### PR TITLE
inform gatekeeper immediately when kicking someone

### DIFF
--- a/domain-server/CMakeLists.txt
+++ b/domain-server/CMakeLists.txt
@@ -20,7 +20,7 @@ endif ()
 symlink_or_copy_directory_beside_target(${_SHOULD_SYMLINK_RESOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/resources" "resources")
 
 # link the shared hifi libraries
-link_hifi_libraries(embedded-webserver networking shared)
+link_hifi_libraries(embedded-webserver networking shared avatars)
 
 # find OpenSSL
 find_package(OpenSSL REQUIRED)

--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -29,7 +29,7 @@
 #include <NLPacketList.h>
 #include <NumericalConstants.h>
 #include <SettingHandle.h>
-
+#include <AvatarData.h> //for KillAvatarReason
 #include "DomainServerNodeData.h"
 
 const QString SETTINGS_DESCRIPTION_RELATIVE_PATH = "/resources/describe-settings.json";
@@ -711,6 +711,13 @@ void DomainServerSettingsManager::processNodeKickRequestPacket(QSharedPointer<Re
                         }
                     }
                 }
+                // if we are here, then we kicked them, so send the KillAvatar message to everyone
+                auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID + sizeof(KillAvatarReason), true);
+                packet->write(nodeUUID.toRfc4122());
+                packet->writePrimitive(KillAvatarReason::NoReason);
+                
+                // send to avatar mixer, it sends the kill to everyone else
+                limitedNodeList->broadcastToNodes(std::move(packet), NodeSet() << NodeType::AvatarMixer);
 
                 if (newPermissions) {
                     qDebug() << "Removing connect permission for node" << uuidStringWithoutCurlyBraces(matchingNode->getUUID())
@@ -718,9 +725,12 @@ void DomainServerSettingsManager::processNodeKickRequestPacket(QSharedPointer<Re
 
                     // we've changed permissions, time to store them to disk and emit our signal to say they have changed
                     packPermissions();
-                } else {
-                    emit updateNodePermissions();
                 }
+                
+                // we emit this no matter what -- though if this isn't a new permission probably 2 people are racing to kick and this
+                // person lost the race.  No matter, just be sure this is called as otherwise it takes like 10s for the person being banned
+                // to go away
+                emit updateNodePermissions();
 
             } else {
                 qWarning() << "Node kick request received for unknown node. Refusing to process.";


### PR DESCRIPTION
We seem to have not informed the gatekeeper that we'd banned someone, so it waited until it noticed (about 10s or so), and then kicked them.  Now, we tell gatekeeper right  away, and they are gone.  Seems like it takes about 2 seconds and they are gone.

