### PR TITLE
fix empty descriptors map bug in DS

### DIFF
--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -299,7 +299,14 @@ void DomainServerSettingsManager::setupConfigMap(const QStringList& argumentList
 }
 
 QVariantMap& DomainServerSettingsManager::getDescriptorsMap() {
+
     static const QString DESCRIPTORS{ "descriptors" };
+
+    auto& settingsMap = getSettingsMap();
+    if (!getSettingsMap().contains(DESCRIPTORS)) {
+        settingsMap.insert(DESCRIPTORS, QVariantMap());
+    }
+
     return *static_cast<QVariantMap*>(getSettingsMap()[DESCRIPTORS].data());
 }
 


### PR DESCRIPTION
- fix bug with empty domain descriptors on fresh install 