### PR TITLE
Revamped Search Feature on Log Window

### DIFF
--- a/interface/resources/styles/log_dialog.qss
+++ b/interface/resources/styles/log_dialog.qss
@@ -7,6 +7,7 @@ QPlainTextEdit {
     color: #333333;
     background-color: #FFFFFF;
     border: none;
+    selection-background-color: #7b91b5;
 }
 
 QLineEdit {
@@ -30,6 +31,19 @@ QPushButton#searchButton {
     border-width: 0;
     border-top-left-radius: 9px;
     border-bottom-left-radius: 9px;
+}
+
+QPushButton#searchNextButton {
+    font-family: Helvetica, Arial, sans-serif;
+    background-repeat: none;
+    background-position: left center;
+    background-origin: content;
+    padding-left: 10px;
+    background-color: #333333;
+    color: #BBBBBB;
+    border-width: 0;
+    border-radius: 9px;
+    font-size: 11px;
 }
 
 QPushButton#revealLogButton {

--- a/interface/resources/styles/log_dialog.qss
+++ b/interface/resources/styles/log_dialog.qss
@@ -35,12 +35,19 @@ QPushButton#searchButton {
 
 QPushButton#searchNextButton {
     font-family: Helvetica, Arial, sans-serif;
-    background-repeat: none;
-    background-position: left center;
-    background-origin: content;
-    padding-left: 10px;
-    background-color: #333333;
-    color: #BBBBBB;
+    text-align: center;
+    background-color: #CCCCCC;
+    color: #3d3d3d;
+    border-width: 0;
+    border-radius: 9px;
+    font-size: 11px;
+}
+
+QPushButton#searchPrevButton {
+    font-family: Helvetica, Arial, sans-serif;
+    text-align: center;
+    background-color: #CCCCCC;
+    color: #3d3d3d;
     border-width: 0;
     border-radius: 9px;
     font-size: 11px;

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -158,7 +158,7 @@ void BaseLogDialog::toggleSearchPrev() {
         QString selectedTerm = searchCursor.selectedText();
         _logTextBox->find(selectedTerm, QTextDocument::FindBackward);
     } else {
-        handleSearchTextChanged(_searchTextBox.text());
+        handleSearchTextChanged(_searchTextBox->text());
     }
 }
 
@@ -168,7 +168,7 @@ void BaseLogDialog::toggleSearchNext() {
         QString selectedTerm = searchCursor.selectedText();
         _logTextBox->find(selectedTerm);
     } else {
-        handleSearchTextChanged(_searchTextBox.text());
+        handleSearchTextChanged(_searchTextBox->text());
     }
 }
 

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -14,6 +14,7 @@
 #include <QDir>
 #include <QLineEdit>
 #include <QPlainTextEdit>
+#include <QTextCursor>
 #include <QPushButton>
 #include <QSyntaxHighlighter>
 
@@ -25,6 +26,7 @@ const int INITIAL_HEIGHT = 480;
 const int MINIMAL_WIDTH = 570;
 const int SEARCH_BUTTON_LEFT = 25;
 const int SEARCH_BUTTON_WIDTH = 20;
+const int SEARCH_NEXT_BUTTON_WIDTH = 50;
 const int SEARCH_TEXT_WIDTH = 240;
 const QColor HIGHLIGHT_COLOR = QColor("#3366CC");
 
@@ -75,9 +77,16 @@ void BaseLogDialog::initControls() {
     // disable blue outline in Mac
     _searchTextBox->setAttribute(Qt::WA_MacShowFocusRect, false);
     _searchTextBox->setGeometry(_leftPad, ELEMENT_MARGIN, SEARCH_TEXT_WIDTH, ELEMENT_HEIGHT);
-    _leftPad += SEARCH_TEXT_WIDTH + CHECKBOX_MARGIN;
+    _leftPad += SEARCH_TEXT_WIDTH;
     _searchTextBox->show();
     connect(_searchTextBox, SIGNAL(textChanged(QString)), SLOT(handleSearchTextChanged(QString)));
+    
+    _searchNextButton = new QPushButton(this);
+    _searchNextButton->setObjectName("searchNextButton");
+    _searchNextButton->setGeometry(_leftPad, ELEMENT_MARGIN, SEARCH_NEXT_BUTTON_WIDTH, ELEMENT_HEIGHT);
+    _leftPad += SEARCH_NEXT_BUTTON_WIDTH + CHECKBOX_MARGIN;
+    _searchNextButton->show();
+    connect(_searchNextButton, SIGNAL(clicked()), SLOT(toggleSearchNext()));
 
     _logTextBox = new QPlainTextEdit(this);
     _logTextBox->setReadOnly(true);
@@ -105,9 +114,26 @@ void BaseLogDialog::handleSearchButton() {
 }
 
 void BaseLogDialog::handleSearchTextChanged(QString searchText) {
+    QTextCursor searchCursor = _logTextBox->textCursor();
+    searchCursor.setPosition(0, QTextCursor::MoveAnchor);
+    _logTextBox->setTextCursor(searchCursor);
+    bool foundTerm = _logTextBox->find(searchText);
+    
+    if (!foundTerm) {
+        searchCursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
+    }
+    
     _searchTerm = searchText;
     _highlighter->keyword = searchText;
     _highlighter->rehighlight();
+}
+
+void BaseLogDialog::toggleSearchNext() {
+    QTextCursor searchCursor = _logTextBox->textCursor();
+    if (searchCursor.hasSelection()) {
+        QString selectedTerm = searchCursor.selectedText();
+        _logTextBox->find(selectedTerm);
+    }
 }
 
 void BaseLogDialog::showLogData() {

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -27,7 +27,6 @@ const int MINIMAL_WIDTH = 700;
 const int SEARCH_BUTTON_LEFT = 25;
 const int SEARCH_BUTTON_WIDTH = 20;
 const int SEARCH_TOGGLE_BUTTON_WIDTH = 50;
-const int BUTTON_MARGIN = 15;
 const int SEARCH_TEXT_WIDTH = 240;
 const QColor HIGHLIGHT_COLOR = QColor("#3366CC");
 

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -23,10 +23,11 @@
 const int TOP_BAR_HEIGHT = 46;
 const int INITIAL_WIDTH = 720;
 const int INITIAL_HEIGHT = 480;
-const int MINIMAL_WIDTH = 570;
+const int MINIMAL_WIDTH = 700;
 const int SEARCH_BUTTON_LEFT = 25;
 const int SEARCH_BUTTON_WIDTH = 20;
-const int SEARCH_NEXT_BUTTON_WIDTH = 50;
+const int SEARCH_TOGGLE_BUTTON_WIDTH = 50;
+const int BUTTON_MARGIN = 15;
 const int SEARCH_TEXT_WIDTH = 240;
 const QColor HIGHLIGHT_COLOR = QColor("#3366CC");
 
@@ -77,14 +78,24 @@ void BaseLogDialog::initControls() {
     // disable blue outline in Mac
     _searchTextBox->setAttribute(Qt::WA_MacShowFocusRect, false);
     _searchTextBox->setGeometry(_leftPad, ELEMENT_MARGIN, SEARCH_TEXT_WIDTH, ELEMENT_HEIGHT);
-    _leftPad += SEARCH_TEXT_WIDTH;
+    _leftPad += SEARCH_TEXT_WIDTH + BUTTON_MARGIN;
     _searchTextBox->show();
     connect(_searchTextBox, SIGNAL(textChanged(QString)), SLOT(handleSearchTextChanged(QString)));
+    connect(_searchTextBox, SIGNAL(returnPressed()), SLOT(toggleSearchNext()));
+
+    _searchPrevButton = new QPushButton(this);
+    _searchPrevButton->setObjectName("searchPrevButton");
+    _searchPrevButton->setGeometry(_leftPad, ELEMENT_MARGIN, SEARCH_TOGGLE_BUTTON_WIDTH, ELEMENT_HEIGHT);
+    _searchPrevButton->setText("Prev");
+    _leftPad += SEARCH_TOGGLE_BUTTON_WIDTH + BUTTON_MARGIN;
+    _searchPrevButton->show();
+    connect(_searchPrevButton, SIGNAL(clicked()), SLOT(toggleSearchPrev()));
     
     _searchNextButton = new QPushButton(this);
     _searchNextButton->setObjectName("searchNextButton");
-    _searchNextButton->setGeometry(_leftPad, ELEMENT_MARGIN, SEARCH_NEXT_BUTTON_WIDTH, ELEMENT_HEIGHT);
-    _leftPad += SEARCH_NEXT_BUTTON_WIDTH + CHECKBOX_MARGIN;
+    _searchNextButton->setGeometry(_leftPad, ELEMENT_MARGIN, SEARCH_TOGGLE_BUTTON_WIDTH, ELEMENT_HEIGHT);
+    _searchNextButton->setText("Next");
+    _leftPad += SEARCH_TOGGLE_BUTTON_WIDTH + CHECKBOX_MARGIN;
     _searchNextButton->show();
     connect(_searchNextButton, SIGNAL(clicked()), SLOT(toggleSearchNext()));
 
@@ -92,6 +103,7 @@ void BaseLogDialog::initControls() {
     _logTextBox->setReadOnly(true);
     _logTextBox->show();
     _highlighter = new KeywordHighlighter(_logTextBox->document());
+    connect(_logTextBox, SIGNAL(selectionChanged()), SLOT(updateSelection()));
 
 }
 
@@ -114,13 +126,25 @@ void BaseLogDialog::handleSearchButton() {
 }
 
 void BaseLogDialog::handleSearchTextChanged(QString searchText) {
-    QTextCursor searchCursor = _logTextBox->textCursor();
-    searchCursor.setPosition(0, QTextCursor::MoveAnchor);
-    _logTextBox->setTextCursor(searchCursor);
+    if (searchText.isEmpty()) {
+        return;
+    }
+    
+    QTextCursor cursor = _logTextBox->textCursor();
+    if (cursor.hasSelection()) {
+        QString selectedTerm = cursor.selectedText();
+        if (selectedTerm == searchText) {
+          return;
+        }
+    }
+    
+    cursor.setPosition(0, QTextCursor::MoveAnchor);
+    _logTextBox->setTextCursor(cursor);
     bool foundTerm = _logTextBox->find(searchText);
     
     if (!foundTerm) {
-        searchCursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
+        cursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
+        _logTextBox->setTextCursor(cursor);
     }
     
     _searchTerm = searchText;
@@ -128,11 +152,23 @@ void BaseLogDialog::handleSearchTextChanged(QString searchText) {
     _highlighter->rehighlight();
 }
 
+void BaseLogDialog::toggleSearchPrev() {
+    QTextCursor searchCursor = _logTextBox->textCursor();
+    if (searchCursor.hasSelection()) {
+        QString selectedTerm = searchCursor.selectedText();
+        _logTextBox->find(selectedTerm, QTextDocument::FindBackward);
+    } else {
+        handleSearchTextChanged(_searchTextBox.text());
+    }
+}
+
 void BaseLogDialog::toggleSearchNext() {
     QTextCursor searchCursor = _logTextBox->textCursor();
     if (searchCursor.hasSelection()) {
         QString selectedTerm = searchCursor.selectedText();
         _logTextBox->find(selectedTerm);
+    } else {
+        handleSearchTextChanged(_searchTextBox.text());
     }
 }
 
@@ -140,6 +176,16 @@ void BaseLogDialog::showLogData() {
     _logTextBox->clear();
     _logTextBox->appendPlainText(getCurrentLog());
     _logTextBox->ensureCursorVisible();
+}
+
+void BaseLogDialog::updateSelection() {
+    QTextCursor cursor = _logTextBox->textCursor();
+    if (cursor.hasSelection()) {
+        QString selectionTerm = cursor.selectedText();
+        if (QString::compare(selectionTerm, _searchTextBox->text(), Qt::CaseInsensitive) != 0) {
+            _searchTextBox->setText(selectionTerm);
+        }
+    }
 }
 
 KeywordHighlighter::KeywordHighlighter(QTextDocument* parent) : QSyntaxHighlighter(parent) {

--- a/interface/src/ui/BaseLogDialog.h
+++ b/interface/src/ui/BaseLogDialog.h
@@ -18,6 +18,7 @@ const int ELEMENT_MARGIN = 7;
 const int ELEMENT_HEIGHT = 32;
 const int CHECKBOX_MARGIN = 12;
 const int CHECKBOX_WIDTH = 140;
+const int BUTTON_MARGIN = 8;
 
 class QPushButton;
 class QLineEdit;

--- a/interface/src/ui/BaseLogDialog.h
+++ b/interface/src/ui/BaseLogDialog.h
@@ -37,6 +37,7 @@ public slots:
 private slots:
     void handleSearchButton();
     void handleSearchTextChanged(QString text);
+    void toggleSearchNext();
 
 protected:
     int _leftPad { 0 };
@@ -49,6 +50,7 @@ private:
     QPushButton* _searchButton { nullptr };
     QLineEdit* _searchTextBox { nullptr };
     QPlainTextEdit* _logTextBox { nullptr };
+    QPushButton* _searchNextButton { nullptr };
     QString _searchTerm;
     KeywordHighlighter* _highlighter { nullptr };
     

--- a/interface/src/ui/BaseLogDialog.h
+++ b/interface/src/ui/BaseLogDialog.h
@@ -35,8 +35,10 @@ public slots:
     void appendLogLine(QString logLine);
 
 private slots:
+    void updateSelection();
     void handleSearchButton();
     void handleSearchTextChanged(QString text);
+    void toggleSearchPrev();
     void toggleSearchNext();
 
 protected:
@@ -50,6 +52,7 @@ private:
     QPushButton* _searchButton { nullptr };
     QLineEdit* _searchTextBox { nullptr };
     QPlainTextEdit* _logTextBox { nullptr };
+    QPushButton* _searchPrevButton { nullptr };
     QPushButton* _searchNextButton { nullptr };
     QString _searchTerm;
     KeywordHighlighter* _highlighter { nullptr };


### PR DESCRIPTION
Created next and prev buttons on the log to move through search results. In response to https://highfidelity.fogbugz.com/f/cases/1007/Log-window-filtering-no-longer-works

![log search](https://cloud.githubusercontent.com/assets/12736060/22956173/4183dae6-f2d5-11e6-902c-ffa1e4acb58f.PNG)

Testing Instructions:
- Open log in interface
- Search some term, using next and prev buttons to skip through results
- See that selecting a new item, using the cursor and pressing next/prev allows you to quickly search for that item.