### PR TITLE
Loosen audio memoization precondition

### DIFF
--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -548,9 +548,6 @@ AudioMixerClientData::IgnoreZone& AudioMixerClientData::IgnoreZoneMemo::get(unsi
             _zone = box;
             unsigned int oldFrame = _frame.exchange(frame, std::memory_order_release);
             Q_UNUSED(oldFrame);
-
-            // check the precondition
-            assert(oldFrame == 0 || frame == (oldFrame + 1));
         }
     }
 

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -44,7 +44,7 @@ public:
     AvatarAudioStream* getAvatarAudioStream();
 
     // returns whether self (this data's node) should ignore node, memoized by frame
-    // precondition: frame is monotonically increasing after first call
+    // precondition: frame is increasing after first call (including overflow wrap)
     bool shouldIgnore(SharedNodePointer self, SharedNodePointer node, unsigned int frame);
 
     // the following methods should be called from the AudioMixer assignment thread ONLY
@@ -131,7 +131,7 @@ private:
 
         // returns an ignore zone, memoized by frame (lockless if the zone is already memoized)
         // preconditions:
-        //  - frame is monotonically increasing after first call
+        //  - frame is increasing after first call (including overflow wrap)
         //  - there are no references left from calls to getIgnoreZone(frame - 1)
         IgnoreZone& get(unsigned int frame);
 


### PR DESCRIPTION
Removes an assertion based on the incorrect assumption that agents could not skip frames in the audio-mixer, which caused failed assertion crashes in debug builds of `assignment-client -t 0`.