### PR TITLE
Clear caches on domain switch

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5152,6 +5152,7 @@ void Application::updateWindowTitle() const {
 #endif
     _window->setWindowTitle(title);
 }
+
 void Application::clearDomainOctreeDetails() {
 
     // if we're about to quit, we really don't need to do any of these things...
@@ -5181,6 +5182,12 @@ void Application::clearDomainOctreeDetails() {
     skyStage->setBackgroundMode(model::SunSkyStage::SKY_DEFAULT);
 
     _recentlyClearedDomain = true;
+
+    DependencyManager::get<AvatarManager>()->clearOtherAvatars();
+    DependencyManager::get<AnimationCache>()->clearUnusedResources();
+    DependencyManager::get<ModelCache>()->clearUnusedResources();
+    DependencyManager::get<SoundCache>()->clearUnusedResources();
+    DependencyManager::get<TextureCache>()->clearUnusedResources();
 }
 
 void Application::domainChanged(const QString& domainHostname) {

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -221,7 +221,7 @@ ResourceCache::ResourceCache(QObject* parent) : QObject(parent) {
 }
 
 ResourceCache::~ResourceCache() {
-    clearUnusedResource();
+    clearUnusedResources();
 }
 
 void ResourceCache::clearATPAssets() {
@@ -265,7 +265,7 @@ void ResourceCache::clearATPAssets() {
 
 void ResourceCache::refreshAll() {
     // Clear all unused resources so we don't have to reload them
-    clearUnusedResource();
+    clearUnusedResources();
     resetResourceCounters();
 
     QHash<QUrl, QWeakPointer<Resource>> resources;
@@ -418,7 +418,7 @@ void ResourceCache::reserveUnusedResource(qint64 resourceSize) {
     }
 }
 
-void ResourceCache::clearUnusedResource() {
+void ResourceCache::clearUnusedResources() {
     // the unused resources may themselves reference resources that will be added to the unused
     // list on destruction, so keep clearing until there are no references left
     QWriteLocker locker(&_unusedResourcesLock);

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -249,6 +249,7 @@ public:
     
     void refreshAll();
     void refresh(const QUrl& url);
+    void clearUnusedResources();
 
 signals:
     void dirty();
@@ -298,7 +299,7 @@ protected:
     
     void addUnusedResource(const QSharedPointer<Resource>& resource);
     void removeUnusedResource(const QSharedPointer<Resource>& resource);
-    
+
     /// Attempt to load a resource if requests are below the limit, otherwise queue the resource for loading
     /// \return true if the resource began loading, otherwise false if the resource is in the pending queue
     static bool attemptRequest(QSharedPointer<Resource> resource);
@@ -309,7 +310,6 @@ private:
     friend class Resource;
 
     void reserveUnusedResource(qint64 resourceSize);
-    void clearUnusedResource();
     void resetResourceCounters();
     void removeResource(const QUrl& url, qint64 size = 0);
 


### PR DESCRIPTION
Currently, the ModelCache allows up to 100 MB of models that are not currently in use to remain in memory, consuming CPU and GPU resources.  However, the size calculation does not cover the textures attached to these models, which in fact will likely make up the vast majority of the memory on both the CPU and GPU.  This PR attempts to mitigate the situation by clearing out caches when switching between domains.

## Testing

Here is an example of dev-welcome after coming from [dev-chris2.highfidelity.io](hifi://dev-chris2.highfidelity.io/102.097,0.710212,26.7103/0,0.992718,0,0.120464).  Note the texture memory usage and the high count of textures (464).
![image](https://cloud.githubusercontent.com/assets/1533642/22999888/b0cca64a-f392-11e6-8dd2-4ab2fb4115e7.png)

Here is an example of dev-welcome after coming from a low texture domain (dreaming).  Note again the texture count and memory usage.  
![image](https://cloud.githubusercontent.com/assets/1533642/22999935/f129e496-f392-11e6-8425-085f531a45d5.png)

This PR should produce something more like the latter result regardless of where the user is coming from.  
