### PR TITLE
CR-2 21114 -- BaseScriptEngine.cpp, order-of-operations fixes, reworked JS Exceptions

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -395,7 +395,7 @@ void EntityScriptServer::selectAudioFormat(const QString& selectedCodecName) {
 }
 
 void EntityScriptServer::resetEntitiesScriptEngine() {
-    auto engineName = QString("Entities %1").arg(++_entitiesScriptEngineCount);
+    auto engineName = QString("about:Entities %1").arg(++_entitiesScriptEngineCount);
     auto newEngine = QSharedPointer<ScriptEngine>(new ScriptEngine(ScriptEngine::ENTITY_SERVER_SCRIPT, NO_SCRIPT, engineName));
 
     auto webSocketServerConstructorValue = newEngine->newFunction(WebSocketServerClass::constructor);
@@ -477,7 +477,7 @@ void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, const
             if (!scriptUrl.isEmpty()) {
                 scriptUrl = ResourceManager::normalizeURL(scriptUrl);
                 qCDebug(entity_script_server) << "Loading entity server script" << scriptUrl << "for" << entityID;
-                ScriptEngine::loadEntityScript(_entitiesScriptEngine, entityID, scriptUrl, reload);
+                _entitiesScriptEngine->loadEntityScript(entityID, scriptUrl, reload);
             }
         }
     }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -101,7 +101,7 @@ void EntityTreeRenderer::resetEntitiesScriptEngine() {
     // Keep a ref to oldEngine until newEngine is ready so EntityScriptingInterface has something to use
     auto oldEngine = _entitiesScriptEngine;
 
-    auto newEngine = new ScriptEngine(ScriptEngine::ENTITY_CLIENT_SCRIPT, NO_SCRIPT, QString("Entities %1").arg(++_entitiesScriptEngineCount));
+    auto newEngine = new ScriptEngine(ScriptEngine::ENTITY_CLIENT_SCRIPT, NO_SCRIPT, QString("about:Entities %1").arg(++_entitiesScriptEngineCount));
     _entitiesScriptEngine = QSharedPointer<ScriptEngine>(newEngine, entitiesScriptEngineDeleter);
 
     _scriptingServices->registerScriptEngineWithApplicationServices(_entitiesScriptEngine.data());
@@ -148,7 +148,7 @@ void EntityTreeRenderer::reloadEntityScripts() {
     _entitiesScriptEngine->unloadAllEntityScripts();
     foreach(auto entity, _entitiesInScene) {
         if (!entity->getScript().isEmpty()) {
-            ScriptEngine::loadEntityScript(_entitiesScriptEngine, entity->getEntityItemID(), entity->getScript(), true);
+            _entitiesScriptEngine->loadEntityScript(entity->getEntityItemID(), entity->getScript(), true);
         }
     }
 }
@@ -950,7 +950,7 @@ void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, const
         if (entity && entity->shouldPreloadScript() && _entitiesScriptEngine) {
             QString scriptUrl = entity->getScript();
             scriptUrl = ResourceManager::normalizeURL(scriptUrl);
-            ScriptEngine::loadEntityScript(_entitiesScriptEngine, entityID, scriptUrl, reload);
+            _entitiesScriptEngine->loadEntityScript(entityID, scriptUrl, reload);
             entity->scriptHasPreloaded();
         }
     }

--- a/libraries/script-engine/src/BaseScriptEngine.cpp
+++ b/libraries/script-engine/src/BaseScriptEngine.cpp
@@ -1,0 +1,321 @@
+//
+//  BaseScriptEngine.cpp
+//  libraries/script-engine/src
+//
+//  Created by Timothy Dedischew on 02/01/17.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "BaseScriptEngine.h"
+
+#include <QtCore/QString>
+#include <QtCore/QThread>
+#include <QtCore/QUrl>
+#include <QtScript/QScriptValue>
+#include <QtScript/QScriptValueIterator>
+#include <QtScript/QScriptContextInfo>
+
+#include "ScriptEngineLogging.h"
+#include "Profile.h"
+
+const QString BaseScriptEngine::_SETTINGS_ENABLE_EXTENDED_EXCEPTIONS {
+    "com.highfidelity.experimental.enableExtendedJSExceptions"
+};
+
+const QString BaseScriptEngine::SCRIPT_EXCEPTION_FORMAT { "[%0] %1 in %2:%3" };
+const QString BaseScriptEngine::SCRIPT_BACKTRACE_SEP { "\n    " };
+
+// engine-aware JS Error copier and factory
+QScriptValue BaseScriptEngine::makeError(const QScriptValue& _other, const QString& type) {
+    auto other = _other;
+    if (other.isString()) {
+        other = newObject();
+        other.setProperty("message", _other.toString());
+    }
+    auto proto = globalObject().property(type);
+    if (!proto.isFunction()) {
+        proto = globalObject().property(other.prototype().property("constructor").property("name").toString());
+    }
+    if (!proto.isFunction()) {
+#ifdef DEBUG_JS_EXCEPTIONS
+        qCDebug(scriptengine) << "BaseScriptEngine::makeError -- couldn't find constructor for" << type << " -- using Error instead";
+#endif
+        proto = globalObject().property("Error");
+    }
+    if (other.engine() != this) {
+        // JS Objects are parented to a specific script engine instance
+        // -- this effectively ~clones it locally by routing through a QVariant and back
+        other = toScriptValue(other.toVariant());
+    }
+    // ~ var err = new Error(other.message)
+    auto err = proto.construct(QScriptValueList({other.property("message")}));
+
+    // transfer over any existing properties
+    QScriptValueIterator it(other);
+    while (it.hasNext()) {
+        it.next();
+        err.setProperty(it.name(), it.value());
+    }
+    return err;
+}
+
+// check syntax and when there are issues returns an actual "SyntaxError" with the details
+QScriptValue BaseScriptEngine::lintScript(const QString& sourceCode, const QString& fileName, const int lineNumber) {
+    const auto syntaxCheck = checkSyntax(sourceCode);
+    if (syntaxCheck.state() != QScriptSyntaxCheckResult::Valid) {
+        auto err = globalObject().property("SyntaxError")
+            .construct(QScriptValueList({syntaxCheck.errorMessage()}));
+        err.setProperty("fileName", fileName);
+        err.setProperty("lineNumber", syntaxCheck.errorLineNumber());
+        err.setProperty("expressionBeginOffset", syntaxCheck.errorColumnNumber());
+        err.setProperty("stack", currentContext()->backtrace().join(SCRIPT_BACKTRACE_SEP));
+        {
+            const auto error = syntaxCheck.errorMessage();
+            const auto line = QString::number(syntaxCheck.errorLineNumber());
+            const auto column = QString::number(syntaxCheck.errorColumnNumber());
+            // for compatibility with legacy reporting
+            const auto message = QString("[SyntaxError] %1 in %2:%3(%4)").arg(error, fileName, line, column);
+            err.setProperty("formatted", message);
+        }
+        return err;
+    }
+    return undefinedValue();
+}
+
+// this pulls from the best available information to create a detailed snapshot of the current exception
+QScriptValue BaseScriptEngine::cloneUncaughtException(const QString& extraDetail) {
+    if (!hasUncaughtException()) {
+        return QScriptValue();
+    }
+    auto exception = uncaughtException();
+    // ensure the error object is engine-local
+    auto err = makeError(exception);
+
+    // not sure why Qt does't offer uncaughtExceptionFileName -- but the line number
+    // on its own is often useless/wrong if arbitrarily married to a filename.
+    // when the error object already has this info, it seems to be the most reliable
+    auto fileName = exception.property("fileName").toString();
+    auto lineNumber = exception.property("lineNumber").toInt32();
+
+    // the backtrace, on the other hand, seems most reliable taken from uncaughtExceptionBacktrace
+    auto backtrace = uncaughtExceptionBacktrace();
+    if (backtrace.isEmpty()) {
+        // fallback to the error object
+        backtrace = exception.property("stack").toString().split(SCRIPT_BACKTRACE_SEP);
+    }
+    // the ad hoc "detail" property can be used now to embed additional clues
+    auto detail = exception.property("detail").toString();
+    if (detail.isEmpty()) {
+        detail = extraDetail;
+    } else if (!extraDetail.isEmpty()) {
+        detail += "(" + extraDetail + ")";
+    }
+    if (lineNumber <= 0) {
+        lineNumber = uncaughtExceptionLineNumber();
+    }
+    if (fileName.isEmpty()) {
+        // climb the stack frames looking for something useful to display
+        for(auto ctx = currentContext(); ctx && fileName.isEmpty(); ctx = ctx->parentContext()) {
+            QScriptContextInfo info { ctx };
+            if (!info.fileName().isEmpty()) {
+                // take fileName:lineNumber as a pair
+                fileName = info.fileName();
+                lineNumber = info.lineNumber();
+                if (backtrace.isEmpty()) {
+                    backtrace = ctx->backtrace();
+                }
+                break;
+            }
+        }
+    }
+    err.setProperty("fileName", fileName);
+    err.setProperty("lineNumber", lineNumber );
+    err.setProperty("detail", detail);
+    err.setProperty("stack", backtrace.join(SCRIPT_BACKTRACE_SEP));
+
+#ifdef DEBUG_JS_EXCEPTIONS
+    err.setProperty("_fileName", exception.property("fileName").toString());
+    err.setProperty("_stack", uncaughtExceptionBacktrace().join(SCRIPT_BACKTRACE_SEP));
+    err.setProperty("_lineNumber", uncaughtExceptionLineNumber());
+#endif
+    return err;
+}
+
+QString BaseScriptEngine::formatException(const QScriptValue& exception) {
+    QString note { "UncaughtException" };
+    QString result;
+
+    if (!exception.isObject()) {
+        return result;
+    }
+    const auto message = exception.toString();
+    const auto fileName = exception.property("fileName").toString();
+    const auto lineNumber = exception.property("lineNumber").toString();
+    const auto stacktrace =  exception.property("stack").toString();
+
+    if (_enableExtendedJSExceptions.get()) {
+        // This setting toggles display of the hints now being added during the loading process.
+        // Example difference:
+        //   [UncaughtExceptions] Error: Can't find variable: foobar in atp:/myentity.js\n...
+        //   [UncaughtException (construct {1eb5d3fa-23b1-411c-af83-163af7220e3f})] Error: Can't find variable: foobar in atp:/myentity.js\n...
+        if (exception.property("detail").isValid()) {
+            note += " " + exception.property("detail").toString();
+        }
+    }
+
+    result = QString(SCRIPT_EXCEPTION_FORMAT).arg(note, message, fileName, lineNumber);
+    if (!stacktrace.isEmpty()) {
+        result += QString("\n[Backtrace]%1%2").arg(SCRIPT_BACKTRACE_SEP).arg(stacktrace);
+    }
+    return result;
+}
+
+QScriptValue BaseScriptEngine::evaluateInClosure(const QScriptValue& closure, const QScriptProgram& program) {
+    PROFILE_RANGE(script, "evaluateInClosure");
+    if (QThread::currentThread() != thread()) {
+        qCCritical(scriptengine) << "*** CRITICAL *** ScriptEngine::evaluateInClosure() is meant to be called from engine thread only.";
+        // note: a recursive mutex might be needed around below code if this method ever becomes Q_INVOKABLE
+        return QScriptValue();
+    }
+
+    //_debugDump("evaluateInClosure.closure", closure);
+
+    const auto fileName = program.fileName();
+    const auto shortName = QUrl(fileName).fileName();
+
+    QScriptValue result;
+    QScriptValue oldGlobal;
+    auto global = closure.property("global");
+    if (global.isObject()) {
+#ifdef DEBUG_JS
+        qCDebug(scriptengine) << " setting global = closure.global" << shortName;
+#endif
+        oldGlobal = globalObject();
+        setGlobalObject(global);
+    }
+
+    auto ctx = pushContext();
+
+    auto thiz = closure.property("this");
+    if (thiz.isObject()) {
+#ifdef DEBUG_JS
+        qCDebug(scriptengine) << " setting this = closure.this" << shortName;
+#endif
+        ctx->setThisObject(thiz);
+    }
+
+    ctx->pushScope(closure);
+#ifdef DEBUG_JS
+    qCDebug(scriptengine) << QString("[%1] evaluateInClosure %2").arg(isEvaluating()).arg(shortName);
+#endif
+    {
+        ExceptionEmitter tryCatch(this, __FUNCTION__);
+        result = BaseScriptEngine::evaluate(program);
+        if (tryCatch.hasPending()) {
+            auto err = tryCatch.pending();
+#ifdef DEBUG_JS_EXCEPTIONS
+            qCWarning(scriptengine) << __FUNCTION__ << "---------- hasCaught:" << err.toString() << result.toString();
+            err.setProperty("_result", result);
+#endif
+            result = err;
+        }
+    }
+#ifdef DEBUG_JS
+    qCDebug(scriptengine) << QString("[%1] //evaluateInClosure %2").arg(isEvaluating()).arg(shortName);
+#endif
+    popContext();
+
+    if (oldGlobal.isValid()) {
+#ifdef DEBUG_JS
+        qCDebug(scriptengine) << " restoring global" << shortName;
+#endif
+        setGlobalObject(oldGlobal);
+    }
+
+    return result;
+}
+
+// Lambda
+
+QScriptValue BaseScriptEngine::newLambdaFunction(std::function<QScriptValue(QScriptContext *, QScriptEngine*)> operation, const QScriptValue& data, const QScriptEngine::ValueOwnership& ownership) {
+    auto lambda = new Lambda(this, operation, data);
+    auto object = newQObject(lambda, ownership);
+    auto call = object.property("call");
+    call.setPrototype(object); // ctx->callee().prototype() === Lambda QObject
+    call.setData(data);        // ctx->callee().data() will === data param
+    return call;
+}
+QString Lambda::toString() const {
+    return QString("[Lambda%1]").arg(data.isValid() ? " " + data.toString() : data.toString());
+}
+
+Lambda::~Lambda() {
+#ifdef DEBUG_JS_LAMBDA_FUNCS
+    qDebug() << "~Lambda" << "this" << this;
+#endif
+}
+
+Lambda::Lambda(QScriptEngine *engine, std::function<QScriptValue(QScriptContext *, QScriptEngine*)> operation, QScriptValue data)
+    : engine(engine), operation(operation), data(data) {
+#ifdef DEBUG_JS_LAMBDA_FUNCS
+    qDebug() << "Lambda" << data.toString();
+#endif
+}
+QScriptValue Lambda::call() {
+    return operation(engine->currentContext(), engine);
+}
+
+// BaseScriptEngine::ExceptionEmitter
+
+void BaseScriptEngine::_emitUnhandledException(const QScriptValue& exception) {
+    emit unhandledException(exception);
+}
+BaseScriptEngine::ExceptionEmitter::ExceptionEmitter(BaseScriptEngine* engine, const QString& debugName)
+    : _engine(engine), _debugName(debugName) {
+}
+bool BaseScriptEngine::ExceptionEmitter::hasPending() {
+    return _engine->hasUncaughtException();
+}
+QScriptValue BaseScriptEngine::ExceptionEmitter::pending() {
+    return _engine->cloneUncaughtException(_debugName);
+}
+QScriptValue BaseScriptEngine::ExceptionEmitter::consume() {
+    if (hasPending()) {
+        _consumedException = pending();
+        _engine->clearExceptions();
+    }
+    return _consumedException;
+}
+bool BaseScriptEngine::ExceptionEmitter::wouldEmit() {
+    return !_engine->isEvaluating() && _engine->hasUncaughtException();
+}
+BaseScriptEngine::ExceptionEmitter::~ExceptionEmitter() {
+    if (wouldEmit()) {
+        _engine->_emitUnhandledException(consume());
+    }
+}
+
+
+#ifdef DEBUG_JS
+void BaseScriptEngine::_debugDump(const QString& header, const QScriptValue& object, const QString& footer) {
+    if (!header.isEmpty()) {
+        qCDebug(scriptengine) << header;
+    }
+    if (!object.isObject()) {
+        qCDebug(scriptengine) << "(!isObject)" << object.toVariant().toString() << object.toString();
+        return;
+    }
+    QScriptValueIterator it(object);
+    while (it.hasNext()) {
+        it.next();
+        qCDebug(scriptengine) << it.name() << ":" << it.value().toString();
+    }
+    if (!footer.isEmpty()) {
+        qCDebug(scriptengine) << footer;
+    }
+}
+#endif
+

--- a/libraries/script-engine/src/BaseScriptEngine.h
+++ b/libraries/script-engine/src/BaseScriptEngine.h
@@ -46,25 +46,6 @@ protected:
 #ifdef DEBUG_JS
     static void _debugDump(const QString& header, const QScriptValue& object, const QString& footer = QString());
 #endif
-
-    // ExceptionEmitter can be placed above calls that might throw JS exceptions and it'll
-    // automatically signal BaseScriptEngine when falling out of scope (recursion aware).
-    class ExceptionEmitter {
-    public:
-        ExceptionEmitter(BaseScriptEngine* engine, const QString& debugName = QString());
-        // is there a pending exception?
-        bool hasPending();
-        QScriptValue pending();
-        // would it be emitted at scope's end?
-        bool wouldEmit();
-        // consume and return the pending exception
-        QScriptValue consume();
-        ~ExceptionEmitter();
-    protected:
-        BaseScriptEngine* _engine;
-        QString _debugName;
-        QScriptValue _consumedException;
-    };
 };
 
 // Lambda helps create callable QScriptValues out of std::functions:

--- a/libraries/script-engine/src/BaseScriptEngine.h
+++ b/libraries/script-engine/src/BaseScriptEngine.h
@@ -39,7 +39,7 @@ signals:
 
 protected:
     void _emitUnhandledException(const QScriptValue& exception);
-    QScriptValue newLambdaFunction(std::function<QScriptValue(QScriptContext *ctx, QScriptEngine* engine)> operation, const QScriptValue& data = QScriptValue(), const QScriptEngine::ValueOwnership& ownership = QScriptEngine::AutoOwnership);
+    QScriptValue newLambdaFunction(std::function<QScriptValue(QScriptContext *context, QScriptEngine* engine)> operation, const QScriptValue& data = QScriptValue(), const QScriptEngine::ValueOwnership& ownership = QScriptEngine::AutoOwnership);
 
     static const QString _SETTINGS_ENABLE_EXTENDED_EXCEPTIONS;
     Setting::Handle<bool> _enableExtendedJSExceptions { _SETTINGS_ENABLE_EXTENDED_EXCEPTIONS, true };
@@ -72,14 +72,14 @@ protected:
 class Lambda : public QObject {
     Q_OBJECT
 public:
-    Lambda(QScriptEngine *engine, std::function<QScriptValue(QScriptContext *ctx, QScriptEngine* engine)> operation, QScriptValue data);
+    Lambda(QScriptEngine *engine, std::function<QScriptValue(QScriptContext *context, QScriptEngine* engine)> operation, QScriptValue data);
     ~Lambda();
     public slots:
         QScriptValue call();
     QString toString() const;
 private:
     QScriptEngine* engine;
-    std::function<QScriptValue(QScriptContext *ctx, QScriptEngine* engine)> operation;
+    std::function<QScriptValue(QScriptContext *context, QScriptEngine* engine)> operation;
     QScriptValue data;
 };
 

--- a/libraries/script-engine/src/BaseScriptEngine.h
+++ b/libraries/script-engine/src/BaseScriptEngine.h
@@ -1,0 +1,86 @@
+//
+//  BaseScriptEngine.h
+//  libraries/script-engine/src
+//
+//  Created by Timothy Dedischew on 02/01/17.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_BaseScriptEngine_h
+#define hifi_BaseScriptEngine_h
+
+#include <functional>
+#include <QtCore/QDebug>
+#include <QtScript/QScriptEngine>
+
+#include "SettingHandle.h"
+
+// common base class for extending QScriptEngine itself
+class BaseScriptEngine : public QScriptEngine {
+    Q_OBJECT
+public:
+    static const QString SCRIPT_EXCEPTION_FORMAT;
+    static const QString SCRIPT_BACKTRACE_SEP;
+
+    BaseScriptEngine() {}
+
+    Q_INVOKABLE QScriptValue evaluateInClosure(const QScriptValue& locals, const QScriptProgram& program);
+
+    Q_INVOKABLE QScriptValue lintScript(const QString& sourceCode, const QString& fileName, const int lineNumber = 1);
+    Q_INVOKABLE QScriptValue makeError(const QScriptValue& other = QScriptValue(), const QString& type = "Error");
+    Q_INVOKABLE QString formatException(const QScriptValue& exception);
+    QScriptValue cloneUncaughtException(const QString& detail = QString());
+
+signals:
+    void unhandledException(const QScriptValue& exception);
+
+protected:
+    void _emitUnhandledException(const QScriptValue& exception);
+    QScriptValue newLambdaFunction(std::function<QScriptValue(QScriptContext *ctx, QScriptEngine* engine)> operation, const QScriptValue& data = QScriptValue(), const QScriptEngine::ValueOwnership& ownership = QScriptEngine::AutoOwnership);
+
+    static const QString _SETTINGS_ENABLE_EXTENDED_EXCEPTIONS;
+    Setting::Handle<bool> _enableExtendedJSExceptions { _SETTINGS_ENABLE_EXTENDED_EXCEPTIONS, true };
+#ifdef DEBUG_JS
+    static void _debugDump(const QString& header, const QScriptValue& object, const QString& footer = QString());
+#endif
+
+    // ExceptionEmitter can be placed above calls that might throw JS exceptions and it'll
+    // automatically signal BaseScriptEngine when falling out of scope (recursion aware).
+    class ExceptionEmitter {
+    public:
+        ExceptionEmitter(BaseScriptEngine* engine, const QString& debugName = QString());
+        // is there a pending exception?
+        bool hasPending();
+        QScriptValue pending();
+        // would it be emitted at scope's end?
+        bool wouldEmit();
+        // consume and return the pending exception
+        QScriptValue consume();
+        ~ExceptionEmitter();
+    protected:
+        BaseScriptEngine* _engine;
+        QString _debugName;
+        QScriptValue _consumedException;
+    };
+};
+
+// Lambda helps create callable QScriptValues out of std::functions:
+// (just meant for use from within the script engine itself)
+class Lambda : public QObject {
+    Q_OBJECT
+public:
+    Lambda(QScriptEngine *engine, std::function<QScriptValue(QScriptContext *ctx, QScriptEngine* engine)> operation, QScriptValue data);
+    ~Lambda();
+    public slots:
+        QScriptValue call();
+    QString toString() const;
+private:
+    QScriptEngine* engine;
+    std::function<QScriptValue(QScriptContext *ctx, QScriptEngine* engine)> operation;
+    QScriptValue data;
+};
+
+#endif // hifi_BaseScriptEngine_h

--- a/libraries/script-engine/src/BatchLoader.cpp
+++ b/libraries/script-engine/src/BatchLoader.cpp
@@ -66,7 +66,7 @@ void BatchLoader::start(int maxRetries) {
                 qCDebug(scriptengine) << "Loaded: " << url;
             } else {
                 _data.insert(url, QString());
-                qCDebug(scriptengine) << "Could not load: " << url;
+                qCDebug(scriptengine) << "Could not load: " << url << status;
             }
 
             if (!_finished && _urls.size() == _data.size()) {

--- a/libraries/script-engine/src/ScriptCache.cpp
+++ b/libraries/script-engine/src/ScriptCache.cpp
@@ -188,6 +188,8 @@ void ScriptCache::scriptContentAvailable(int maxRetries) {
 
                 }
             }
+        } else {
+            qCWarning(scriptengine) << "Warning: scriptContentAvailable for inactive url: " << url;
         }
     }
 

--- a/libraries/script-engine/src/ScriptCache.h
+++ b/libraries/script-engine/src/ScriptCache.h
@@ -43,6 +43,9 @@ class ScriptCache : public QObject, public Dependency {
 public:
     static const QString STATUS_INLINE;
     static const QString STATUS_CACHED;
+    static bool isSuccessStatus(const QString& status) {
+        return status == "Success" || status == STATUS_INLINE || status == STATUS_CACHED;
+    }
 
     void clearCache();
     Q_INVOKABLE void clearATPScriptsFromCache();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1506,7 +1506,7 @@ void ScriptEngine::processDeferredEntityLoads(const QString& entityScript, const
             i.remove();
         }
     }
-    foreach(auto &retry, retryLoads) {
+    foreach(DeferredLoadEntity retry, retryLoads) {
         // check whether entity was since been deleted
         if (!_entityScripts.contains(retry.entityID)) {
             qCDebug(scriptengine) << "processDeferredEntityLoads -- entity details gone (entity deleted?)"
@@ -1528,7 +1528,7 @@ void ScriptEngine::processDeferredEntityLoads(const QString& entityScript, const
             qCDebug(scriptengine) << QString("... pending load of %1 cancelled (leader: %2 status: %3)")
                 .arg(retry.entityID.toString()).arg(leaderID.toString()).arg(leaderDetails.status);
 
-            auto extraDetail = "\n(propagated from " + leaderID.toString() + ")";
+            auto extraDetail = QString("\n(propagated from %1)").arg(leaderID.toString());
             if (leaderDetails.status == EntityScriptStatus::ERROR_LOADING_SCRIPT ||
                 leaderDetails.status == EntityScriptStatus::ERROR_RUNNING_SCRIPT) {
                 // propagate same error so User doesn't have to hunt down stampede's leader
@@ -1599,7 +1599,7 @@ void ScriptEngine::loadEntityScript(const EntityItemID& entityID, const QString&
             // another entity is busy loading from this script URL so wait for them to finish
 #ifdef DEBUG_ENTITY_STATES
             qCDebug(scriptengine) << QString("loadEntityScript.deferring[%0] entity: %1 script: %2 (waiting on %3)")
-                .arg( _deferredEntityLoads.size()).arg(entityID.toString()).arg(entityScript).arg(currentEntityID.toString());
+                .arg(_deferredEntityLoads.size()).arg(entityID.toString()).arg(entityScript).arg(currentEntityID.toString());
 #endif
             _deferredEntityLoads.push_back({ entityID, entityScript });
             return;
@@ -1679,7 +1679,7 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
     auto fileName = isURL ? scriptOrURL : "about:EmbeddedEntityScript";
 
     const EntityScriptDetails &oldDetails = _entityScripts[entityID];
-    const auto entityScript = oldDetails.scriptText;
+    const QString entityScript = oldDetails.scriptText;
 
     EntityScriptDetails newDetails;
     newDetails.scriptText = scriptOrURL;
@@ -1852,7 +1852,7 @@ void ScriptEngine::unloadEntityScript(const EntityItemID& entityID) {
 #endif
 
     if (_entityScripts.contains(entityID)) {
-        auto oldDetails = _entityScripts[entityID];
+        const EntityScriptDetails &oldDetails = _entityScripts[entityID];
         if (isEntityScriptRunning(entityID)) {
             callEntityScriptMethod(entityID, "unload");
         } else {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1624,7 +1624,8 @@ void ScriptEngine::loadEntityScript(const EntityItemID& entityID, const QString&
     QWeakPointer<ScriptEngine> weakRef(sharedFromThis());
     scriptCache->getScriptContents(entityScript,
         [this, weakRef, entityScript, entityID](const QString& url, const QString& contents, bool isURL, bool success, const QString& status) {
-            if (!weakRef) {
+            QSharedPointer<ScriptEngine> strongRef(weakRef);
+            if (!strongRef) {
                 qCWarning(scriptengine) << "loadEntityScript.contentAvailable -- ScriptEngine was deleted during getScriptContents!!";
                 return;
             }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1494,7 +1494,7 @@ bool ScriptEngine::getEntityScriptDetails(const EntityItemID& entityID, EntitySc
     return true;
 }
 
-const auto RETRY_ATTEMPT_BATCH = 10; //glm::clamp(qgetenv("RETRY_ATTEMPT_BATCH").toInt(), 1, 50);
+const auto RETRY_ATTEMPT_BATCH = 100; //glm::clamp(qgetenv("RETRY_ATTEMPT_BATCH").toInt(), 1, 50);
 const auto RETRY_ATTEMPT_MSECS = 250; //glm::clamp(qgetenv("RETRY_ATTEMPT_MSECS").toInt(), 50, 1000);
 
 void ScriptEngine::deferLoadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1365,12 +1365,12 @@ void ScriptEngine::include(const QStringList& includeFiles, QScriptValue callbac
                     doWithEnvironment(capturedEntityIdentifier, capturedSandboxURL, operation);
                     if (tryCatch.hasPending()) {
                         // match previous include behavior where possible by logging, not propagating, exceptions.
-                        // for nested evaluations, exceptions are now allowed to propagate
                         auto err = tryCatch.pending();
                         emit unhandledException(err);
-                        if (tryCatch.wouldEmit()) {
-                            tryCatch.consume();
-                        }
+                        // FIXME: to be revisited with next PR 21114-part3 for compat with require/module
+                        //if (tryCatch.wouldEmit()) {
+                        tryCatch.consume();
+                        //}
                     }
                 } else {
                     scriptWarningMessage("Script.include() skipping evaluation of previously included url:" + url.toString());

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1620,8 +1620,14 @@ void ScriptEngine::loadEntityScript(const EntityItemID& entityID, const QString&
     setEntityScriptDetails(entityID, newDetails);
 
     auto scriptCache = DependencyManager::get<ScriptCache>();
+    // note: see EntityTreeRenderer.cpp for shared pointer lifecycle management
+    QWeakPointer<ScriptEngine> weakRef(sharedFromThis());
     scriptCache->getScriptContents(entityScript,
-        [this, entityScript, entityID](const QString& url, const QString& contents, bool isURL, bool success, const QString& status) {
+        [this, weakRef, entityScript, entityID](const QString& url, const QString& contents, bool isURL, bool success, const QString& status) {
+            if (!weakRef) {
+                qCWarning(scriptengine) << "loadEntityScript.contentAvailable -- ScriptEngine was deleted during getScriptContents!!";
+                return;
+            }
             if (isStopping()) {
 #ifdef DEBUG_ENTITY_STATES
                 qCDebug(scriptengine) << "loadEntityScript.contentAvailable -- stopping";

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1492,8 +1492,6 @@ bool ScriptEngine::getEntityScriptDetails(const EntityItemID& entityID, EntitySc
     return true;
 }
 
-const auto RETRY_ATTEMPT_BATCH = 100; //glm::clamp(qgetenv("RETRY_ATTEMPT_BATCH").toInt(), 1, 50);
-const auto RETRY_ATTEMPT_MSECS = 250; //glm::clamp(qgetenv("RETRY_ATTEMPT_MSECS").toInt(), 50, 1000);
 const static EntityItemID BAD_SCRIPT_UUID_PLACEHOLDER { "{20170224-dead-face-0000-cee000021114}" };
 
 void ScriptEngine::processDeferredEntityLoads(const QString& entityScript, const EntityItemID& leaderID) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1587,16 +1587,20 @@ void ScriptEngine::loadEntityScript(const EntityItemID& entityID, const QString&
             } else {
                 // since not reloading, assume that the exact same input would produce the exact same output again
                 // note: this state gets reset with "reload all scripts," leaving/returning to a Domain, clear cache, etc.
+#ifdef DEBUG_ENTITY_STATES
                 qCDebug(scriptengine) << QString("loadEntityScript.cancelled entity: %1 script: %2 (previous script failure)")
                     .arg(entityID.toString()).arg(entityScript);
+#endif
                 updateEntityScriptStatus(entityID, EntityScriptStatus::ERROR_LOADING_SCRIPT,
                                          "A previous Entity failed to load using this script URL; reload to try again.");
                 return;
             }
         } else {
             // another entity is busy loading from this script URL so wait for them to finish
+#ifdef DEBUG_ENTITY_STATES
             qCDebug(scriptengine) << QString("loadEntityScript.deferring[%0] entity: %1 script: %2 (waiting on %3)")
                 .arg( _deferredEntityLoads.size()).arg(entityID.toString()).arg(entityScript).arg(currentEntityID.toString());
+#endif
             _deferredEntityLoads.push_back({ entityID, entityScript });
             return;
         }
@@ -1687,7 +1691,9 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         newDetails.status = status;
         setEntityScriptDetails(entityID, newDetails);
 
+#ifdef DEBUG_ENTITY_STATES
         qCDebug(scriptengine) << "entityScriptContentAvailable -- flagging " << entityScript << " as BAD_SCRIPT_UUID_PLACEHOLDER";
+#endif
         // flag the original entityScript as unusuable
         _occupiedScriptURLs[entityScript] = BAD_SCRIPT_UUID_PLACEHOLDER;
         processDeferredEntityLoads(entityScript, entityID);

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -270,7 +270,7 @@ protected:
     QHash<QTimer*, CallbackData> _timerFunctionMap;
     QSet<QUrl> _includedURLs;
     QHash<EntityItemID, EntityScriptDetails> _entityScripts;
-    std::map<QString, QMutex> _lockPerUniqueScriptURL;
+    QHash<QString, EntityItemID> _occupiedScriptURLs;
     QList<DeferredLoadEntity> _pendingLoadEntities;
 
     bool _isThreaded { false };

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -170,7 +170,6 @@ public:
     Q_INVOKABLE bool isEntityScriptRunning(const EntityItemID& entityID) {
         return _entityScripts.contains(entityID) && _entityScripts[entityID].status == EntityScriptStatus::RUNNING;
     }
-    Q_INVOKABLE void deferLoadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
     Q_INVOKABLE void loadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
@@ -247,6 +246,7 @@ protected:
     void updateEntityScriptStatus(const EntityItemID& entityID, const EntityScriptStatus& status, const QString& errorInfo = QString());
     void setEntityScriptDetails(const EntityItemID& entityID, const EntityScriptDetails& details);
     void setParentURL(const QString& parentURL) { _parentURL = parentURL; }
+    void processDeferredEntityLoads(const QString& entityScript, const EntityItemID& leaderID);
 
     QObject* setupTimerWithInterval(const QScriptValue& function, int intervalMS, bool isSingleShot);
     void stopTimer(QTimer* timer);
@@ -271,7 +271,7 @@ protected:
     QSet<QUrl> _includedURLs;
     QHash<EntityItemID, EntityScriptDetails> _entityScripts;
     QHash<QString, EntityItemID> _occupiedScriptURLs;
-    QList<DeferredLoadEntity> _pendingLoadEntities;
+    QList<DeferredLoadEntity> _deferredEntityLoads;
 
     bool _isThreaded { false };
     QScriptEngineDebugger* _debugger { nullptr };

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -35,6 +35,7 @@
 #include "ArrayBufferClass.h"
 #include "AssetScriptingInterface.h"
 #include "AudioScriptingInterface.h"
+#include "BaseScriptEngine.h"
 #include "Quat.h"
 #include "Mat4.h"
 #include "ScriptCache.h"
@@ -54,6 +55,13 @@ public:
     QUrl definingSandboxURL;
 };
 
+class DeferredLoadEntity {
+public:
+    EntityItemID entityID;
+    QString entityScript;
+    //bool forceRedownload;
+};
+
 typedef QList<CallbackData> CallbackList;
 typedef QHash<QString, CallbackList> RegisteredEventHandlers;
 
@@ -67,15 +75,7 @@ public:
     QString scriptText { "" };
     QScriptValue scriptObject { QScriptValue() };
     int64_t lastModified { 0 };
-    QUrl definingSandboxURL { QUrl() };
-};
-
-// common base class with just QScriptEngine-dependent helper methods
-class BaseScriptEngine : public QScriptEngine {
-public:
-    static const QString SCRIPT_EXCEPTION_FORMAT;
-    QString lintScript(const QString& sourceCode, const QString& fileName, const int lineNumber = 1);
-    QString formatUncaughtException(const QString& overrideFileName = QString());
+    QUrl definingSandboxURL { QUrl("about:EntityScript") };
 };
 
 class ScriptEngine : public BaseScriptEngine, public EntitiesScriptEngineProvider {
@@ -91,14 +91,13 @@ public:
     };
 
     static int processLevelMaxRetries;
-    ScriptEngine(Context context, const QString& scriptContents = NO_SCRIPT, const QString& fileNameString = QString(""));
+    ScriptEngine(Context context, const QString& scriptContents = NO_SCRIPT, const QString& fileNameString = QString("about:ScriptEngine"));
     ~ScriptEngine();
 
     /// run the script in a dedicated thread. This will have the side effect of evalulating
     /// the current script contents and calling run(). Callers will likely want to register the script with external
     /// services before calling this.
     void runInThread();
-    Q_INVOKABLE void executeOnScriptThread(std::function<void()> function, bool blocking = false);
 
     void runDebuggable();
 
@@ -162,16 +161,17 @@ public:
     Q_INVOKABLE QObject* setTimeout(const QScriptValue& function, int timeoutMS);
     Q_INVOKABLE void clearInterval(QObject* timer) { stopTimer(reinterpret_cast<QTimer*>(timer)); }
     Q_INVOKABLE void clearTimeout(QObject* timer) { stopTimer(reinterpret_cast<QTimer*>(timer)); }
+
     Q_INVOKABLE void print(const QString& message);
     Q_INVOKABLE QUrl resolvePath(const QString& path) const;
     Q_INVOKABLE QUrl resourcesPath() const;
 
     // Entity Script Related methods
-    Q_INVOKABLE QString getEntityScriptStatus(const EntityItemID& entityID);
     Q_INVOKABLE bool isEntityScriptRunning(const EntityItemID& entityID) {
         return _entityScripts.contains(entityID) && _entityScripts[entityID].status == EntityScriptStatus::RUNNING;
     }
-    static void loadEntityScript(QWeakPointer<ScriptEngine> theEngine, const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
+    Q_INVOKABLE void deferLoadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
+    Q_INVOKABLE void loadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload);
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName,
@@ -212,7 +212,6 @@ public:
     bool getEntityScriptDetails(const EntityItemID& entityID, EntityScriptDetails &details) const;
 
 public slots:
-    int evaluatePending() const { return _evaluatesPending; }
     void callAnimationStateHandler(QScriptValue callback, AnimVariantMap parameters, QStringList names, bool useNames, AnimVariantResultHandler resultHandler);
     void updateMemoryCost(const qint64&);
 
@@ -228,7 +227,6 @@ signals:
     void warningMessage(const QString& message);
     void infoMessage(const QString& message);
     void runningStateChanged();
-    void evaluationFinished(QScriptValue result, bool isException);
     void loadScript(const QString& scriptName, bool isUserLoaded);
     void reloadScript(const QString& scriptName, bool isUserLoaded);
     void doneRunning();
@@ -239,8 +237,9 @@ signals:
 
 protected:
     void init();
+    Q_INVOKABLE void executeOnScriptThread(std::function<void()> function, const Qt::ConnectionType& type = Qt::QueuedConnection );
 
-    QString reportUncaughtException(const QString& overrideFileName = QString());
+    QString logException(const QScriptValue& exception);
     void timerFired();
     void stopAllTimers();
     void stopAllTimersForEntityScript(const EntityItemID& entityID);
@@ -262,17 +261,18 @@ protected:
     void callWithEnvironment(const EntityItemID& entityID, const QUrl& sandboxURL, QScriptValue function, QScriptValue thisObject, QScriptValueList args);
 
     Context _context;
-
     QString _scriptContents;
     QString _parentURL;
     std::atomic<bool> _isFinished { false };
     std::atomic<bool> _isRunning { false };
     std::atomic<bool> _isStopping { false };
-    int _evaluatesPending { 0 };
     bool _isInitialized { false };
     QHash<QTimer*, CallbackData> _timerFunctionMap;
     QSet<QUrl> _includedURLs;
     QHash<EntityItemID, EntityScriptDetails> _entityScripts;
+    std::map<QString, QMutex> _lockPerUniqueScriptURL;
+    QList<DeferredLoadEntity> _pendingLoadEntities;
+
     bool _isThreaded { false };
     QScriptEngineDebugger* _debugger { nullptr };
     bool _debuggable { false };

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -78,7 +78,7 @@ public:
     QUrl definingSandboxURL { QUrl("about:EntityScript") };
 };
 
-class ScriptEngine : public BaseScriptEngine, public EntitiesScriptEngineProvider {
+class ScriptEngine : public BaseScriptEngine, public EntitiesScriptEngineProvider, public QEnableSharedFromThis<ScriptEngine> {
     Q_OBJECT
     Q_PROPERTY(QString context READ getContext)
 public:

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -364,25 +364,43 @@ QStringList ScriptEngines::getRunningScripts() {
 }
 
 void ScriptEngines::stopAllScripts(bool restart) {
+    QVector<QString> toReload;
     QReadLocker lock(&_scriptEnginesHashLock);
     for (QHash<QUrl, ScriptEngine*>::const_iterator it = _scriptEnginesHash.constBegin();
         it != _scriptEnginesHash.constEnd(); it++) {
+        ScriptEngine *scriptEngine = it.value();
         // skip already stopped scripts
-        if (it.value()->isFinished() || it.value()->isStopping()) {
+        if (scriptEngine->isFinished() || scriptEngine->isStopping()) {
             continue;
         }
 
         // queue user scripts if restarting
-        if (restart && it.value()->isUserLoaded()) {
-            connect(it.value(), &ScriptEngine::finished, this, [this](QString scriptName, ScriptEngine* engine) {
-                reloadScript(scriptName);
-            });
+        if (restart && scriptEngine->isUserLoaded()) {
+            toReload << it.key().toString();
         }
 
         // stop all scripts
-        it.value()->stop(true);
         qCDebug(scriptengine) << "stopping script..." << it.key();
+        scriptEngine->stop();
     }
+    // wait for engines to stop (ie: providing time for .scriptEnding cleanup handlers to run) before
+    // triggering reload of any Client scripts / Entity scripts
+    QTimer::singleShot(500, this, [=]() {
+        for(const auto &scriptName : toReload) {
+            auto scriptEngine = getScriptEngine(scriptName);
+            if (scriptEngine && !scriptEngine->isFinished()) {
+                qCDebug(scriptengine) << "waiting on script:" << scriptName;
+                scriptEngine->waitTillDoneRunning();
+                qCDebug(scriptengine) << "done waiting on script:" << scriptName;
+            }
+            qCDebug(scriptengine) << "reloading script..." << scriptName;
+            reloadScript(scriptName);
+        }
+        if (restart) {
+            qCDebug(scriptengine) << "stopAllScripts -- emitting scriptsReloading";
+            emit scriptsReloading();
+        }
+    });
 }
 
 bool ScriptEngines::stopScript(const QString& rawScriptURL, bool restart) {
@@ -421,9 +439,10 @@ void ScriptEngines::setScriptsLocation(const QString& scriptsLocation) {
 }
 
 void ScriptEngines::reloadAllScripts() {
+    qCDebug(scriptengine) << "reloadAllScripts -- clearing caches";
     DependencyManager::get<ScriptCache>()->clearCache();
     DependencyManager::get<OffscreenUi>()->clearCache();
-    emit scriptsReloading();
+    qCDebug(scriptengine) << "reloadAllScripts -- stopping all scripts";
     stopAllScripts(true);
 }
 
@@ -456,7 +475,7 @@ ScriptEngine* ScriptEngines::loadScript(const QUrl& scriptFilename, bool isUserL
         return scriptEngine;
     }
 
-    scriptEngine = new ScriptEngine(_context, NO_SCRIPT, "");
+    scriptEngine = new ScriptEngine(_context, NO_SCRIPT, "about:" + scriptFilename.fileName());
     scriptEngine->setUserLoaded(isUserLoaded);
     connect(scriptEngine, &ScriptEngine::doneRunning, this, [scriptEngine] {
         scriptEngine->deleteLater();

--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -28,6 +28,11 @@ class PathUtils : public QObject, public Dependency {
 public:
     static const QString& resourcesPath();
     static QString getRootDataDirectory();
+
+    static Qt::CaseSensitivity getFSCaseSensitivity();
+    static QString stripFilename(const QUrl& url);
+    // note: this is FS-case-sensitive version of parentURL.isParentOf(childURL)
+    static bool isDescendantOf(const QUrl& childURL, const QUrl& parentURL);
 };
 
 QString fileNameWithoutExtension(const QString& fileName, const QVector<QString> possibleExtensions);

--- a/scripts/developer/tests/entityServerStampedeTest-entity.js
+++ b/scripts/developer/tests/entityServerStampedeTest-entity.js
@@ -2,7 +2,7 @@
     return {
         preload: function(uuid) {
             var props = Entities.getEntityProperties(uuid);
-            var shape = props.shape === 'Sphere' ? 'Cube' : 'Sphere';
+            var shape = props.shape === 'Sphere' ? 'Hexagon' : 'Sphere';
 
             Entities.editEntity(uuid, {
                 shape: shape,
@@ -14,7 +14,7 @@
         unload: function(uuid) {
             print("unload", this.name);
             Entities.editEntity(uuid, {
-                color: { red: 0xff, green: 0x0f, blue: 0x0f },
+                color: { red: 0x0f, green: 0x0f, blue: 0xff },
             });
         },
     };

--- a/scripts/developer/tests/entityServerStampedeTest.js
+++ b/scripts/developer/tests/entityServerStampedeTest.js
@@ -1,0 +1,33 @@
+var NUM_ENTITIES = 100;
+var RADIUS = 2;
+var DIV = NUM_ENTITIES / Math.PI / 2;
+var PASS_SCRIPT_URL = Script.resolvePath('entityStampedeTest-entity.js');
+var FAIL_SCRIPT_URL = Script.resolvePath('entityStampedeTest-entity-fail.js');
+
+var origin = Vec3.sum(MyAvatar.position, Vec3.multiply(5, Quat.getFront(MyAvatar.orientation)));
+origin.y += HMD.eyeHeight;
+
+var uuids = [];
+
+Script.scriptEnding.connect(function() {
+    uuids.forEach(function(id) {
+        Entities.deleteEntity(id);
+    });
+});
+
+for (var i=0; i < NUM_ENTITIES; i++) {
+    var failGroup = i % 2;
+    uuids.push(Entities.addEntity({
+        type: 'Shape',
+        shape: failGroup ? 'Sphere' : 'Icosahedron',
+        name: 'SERVER-entityStampedeTest-' + i,
+        lifetime: 120,
+        position: Vec3.sum(origin, Vec3.multiplyQbyV(
+            MyAvatar.orientation, { x: Math.sin(i / DIV) * RADIUS, y: Math.cos(i / DIV) * RADIUS, z: 0 }
+        )),
+        serverScripts: (failGroup ? FAIL_SCRIPT_URL : PASS_SCRIPT_URL) + Settings.getValue('cache_buster'),
+        dimensions: Vec3.HALF,
+        color: { red: 0, green: 0, blue: 0 },
+    }, !Entities.serversExist()));
+}
+

--- a/scripts/developer/tests/entityServerStampedeTest.js
+++ b/scripts/developer/tests/entityServerStampedeTest.js
@@ -1,7 +1,7 @@
 var NUM_ENTITIES = 100;
 var RADIUS = 2;
 var DIV = NUM_ENTITIES / Math.PI / 2;
-var PASS_SCRIPT_URL = Script.resolvePath('entityStampedeTest-entity.js');
+var PASS_SCRIPT_URL = Script.resolvePath('entityServerStampedeTest-entity.js');
 var FAIL_SCRIPT_URL = Script.resolvePath('entityStampedeTest-entity-fail.js');
 
 var origin = Vec3.sum(MyAvatar.position, Vec3.multiply(5, Quat.getFront(MyAvatar.orientation)));

--- a/scripts/developer/tests/entityStampedeTest-entity-fail.js
+++ b/scripts/developer/tests/entityStampedeTest-entity-fail.js
@@ -1,0 +1,3 @@
+(function() {
+    throw new Error(Script.resolvePath(''));
+})

--- a/scripts/developer/tests/entityStampedeTest-entity.js
+++ b/scripts/developer/tests/entityStampedeTest-entity.js
@@ -1,0 +1,12 @@
+(function() {
+    return {
+        preload: function(uuid) {
+            var shape = Entities.getEntityProperties(uuid).shape === 'Sphere' ? 'Cube' : 'Sphere';
+
+            Entities.editEntity(uuid, {
+                shape: shape,
+                color: { red: 0xff, green: 0xff, blue: 0xff },
+            });
+        }
+    };
+})

--- a/scripts/developer/tests/entityStampedeTest.js
+++ b/scripts/developer/tests/entityStampedeTest.js
@@ -1,0 +1,32 @@
+var NUM_ENTITIES = 100;
+var RADIUS = 2;
+var DIV = NUM_ENTITIES / Math.PI / 2;
+var PASS_SCRIPT_URL = Script.resolvePath('').replace('.js', '-entity.js');
+var FAIL_SCRIPT_URL = Script.resolvePath('').replace('.js', '-entity-fail.js');
+
+var origin = Vec3.sum(MyAvatar.position, Vec3.multiply(5, Quat.getFront(MyAvatar.orientation)));
+origin.y += HMD.eyeHeight;
+
+var uuids = [];
+
+Script.scriptEnding.connect(function() {
+    uuids.forEach(function(id) {
+        Entities.deleteEntity(id);
+    });
+});
+
+for (var i=0; i < NUM_ENTITIES; i++) {
+    var failGroup = i % 2;
+    uuids.push(Entities.addEntity({
+        type: 'Shape',
+        shape: failGroup ? 'Sphere' : 'Icosahedron',
+        name: 'entityStampedeTest-' + i,
+        lifetime: 120,
+        position: Vec3.sum(origin, Vec3.multiplyQbyV(
+            MyAvatar.orientation, { x: Math.sin(i / DIV) * RADIUS, y: Math.cos(i / DIV) * RADIUS, z: 0 }
+        )),
+        script: (failGroup ? FAIL_SCRIPT_URL : PASS_SCRIPT_URL) + Settings.getValue('cache_buster'),
+        dimensions: Vec3.HALF,
+        color: { red: 0, green: 0, blue: 0 },
+    }, !Entities.serversExist()));
+}

--- a/scripts/developer/tests/unit_tests/scriptTests/error.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/error.js
@@ -1,0 +1,6 @@
+afterError = false;
+throw new Error('error.js');
+afterError = true;
+
+(1,eval)('this').$finishes.push(Script.resolvePath(''));
+

--- a/scripts/developer/tests/unit_tests/scriptTests/nested-error.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/nested-error.js
@@ -1,0 +1,10 @@
+afterError = false;
+outer = null;
+Script.include('./nested/error.js?' + Settings.getValue('cache_buster'));
+outer = {
+    inner: inner.lib,
+    sibling: sibling.lib,
+};
+afterError = true;
+
+(1,eval)("this").$finishes.push(Script.resolvePath(''));

--- a/scripts/developer/tests/unit_tests/scriptTests/nested-syntax-error.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/nested-syntax-error.js
@@ -1,0 +1,10 @@
+afterError = false;
+outer = null;
+Script.include('./nested/syntax-error.js?' + Settings.getValue('cache_buster'));
+outer = {
+    inner: inner.lib,
+    sibling: sibling.lib,
+};
+afterError = true;
+
+(1,eval)("this").$finishes.push(Script.resolvePath(''));

--- a/scripts/developer/tests/unit_tests/scriptTests/nested/error.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/nested/error.js
@@ -1,0 +1,5 @@
+afterError = false;
+throw new Error('nested/error.js');
+afterError = true;
+
+(1,eval)("this").$finishes.push(Script.resolvePath(''));

--- a/scripts/developer/tests/unit_tests/scriptTests/nested/lib.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/nested/lib.js
@@ -1,0 +1,5 @@
+Script.include('sibling.js');
+inner = {
+    lib: "nested/lib.js",
+};
+

--- a/scripts/developer/tests/unit_tests/scriptTests/nested/sibling.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/nested/sibling.js
@@ -1,0 +1,3 @@
+sibling = {
+    lib: "nested/sibling",
+};

--- a/scripts/developer/tests/unit_tests/scriptTests/nested/syntax-error.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/nested/syntax-error.js
@@ -1,0 +1,3 @@
+function() {
+    // intentional SyntaxError...
+    

--- a/scripts/developer/tests/unit_tests/scriptTests/top-level-error.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/top-level-error.js
@@ -1,0 +1,11 @@
+afterError = false;
+outer = null;
+Script.include('./nested/lib.js');
+Undefined_symbol;
+outer = {
+    inner: inner.lib,
+    sibling: sibling.lib,
+};
+afterError = true;
+
+(1,eval)("this").$finishes.push(Script.resolvePath(''));

--- a/scripts/developer/tests/unit_tests/scriptTests/top-level.js
+++ b/scripts/developer/tests/unit_tests/scriptTests/top-level.js
@@ -1,0 +1,5 @@
+Script.include('./nested/lib.js');
+outer = {
+    inner: inner.lib,
+    sibling: sibling.lib,
+};

--- a/scripts/developer/tests/unit_tests/scriptUnitTests.js
+++ b/scripts/developer/tests/unit_tests/scriptUnitTests.js
@@ -31,8 +31,7 @@ describe('Script', function () {
            '/~/libraries/utils.js': 'file:///~/libraries/utils.js',
                    '/temp/file.js': 'file:///temp/file.js',
                              '/~/': 'file:///~/',
-        };
-    }
+    };
     describe('resolvePath', function () {
         Object.keys(testCases).forEach(function(input) {
             it('(' + JSON.stringify(input) + ')', function () {

--- a/scripts/developer/tests/unit_tests/scriptUnitTests.js
+++ b/scripts/developer/tests/unit_tests/scriptUnitTests.js
@@ -1,0 +1,126 @@
+/* eslint-env jasmine */
+
+instrument_testrunner();
+
+describe('Script', function () {
+    // get the current filename without calling Script.resolvePath('')
+    try {
+        throw new Error('stack');
+    } catch(e) {
+        var filename = e.fileName;
+        var dirname = filename.split('/').slice(0, -1).join('/') + '/';
+        var parentdir = dirname.split('/').slice(0, -2).join('/') + '/';
+    }
+
+    // characterization tests
+    // initially these are just to capture how the app works currently
+    var testCases = {
+                                '': filename,
+                               '.': dirname,
+                              '..': parentdir,
+                'about:Entities 1': '',
+                      'Entities 1': dirname + 'Entities 1',
+                       './file.js': dirname + 'file.js',
+                        'c:/temp/': 'file:///c:/temp/',
+                         'c:/temp': 'file:///c:/temp',
+                          '/temp/': 'file:///temp/',
+                             'c:/': 'file:///c:/',
+                              'c:': 'file:///c:',
+        'file:///~/libraries/a.js': 'file:///~/libraries/a.js',
+         '/temp/tested/../file.js': 'file:///temp/tested/../file.js',
+           '/~/libraries/utils.js': 'file:///~/libraries/utils.js',
+                   '/temp/file.js': 'file:///temp/file.js',
+                             '/~/': 'file:///~/',
+        };
+    }
+    describe('resolvePath', function () {
+        Object.keys(testCases).forEach(function(input) {
+            it('(' + JSON.stringify(input) + ')', function () {
+                expect(Script.resolvePath(input)).toEqual(testCases[input]);
+            });
+        });
+    });
+
+    describe('include', function () {
+        var old_cache_buster;
+        var cache_buster = '#' + +new Date;
+        beforeAll(function() {
+            old_cache_buster = Settings.getValue('cache_buster');
+            Settings.setValue('cache_buster', cache_buster);
+        });
+        afterAll(function() {
+            Settings.setValue('cache_buster', old_cache_buster);
+        });
+        beforeEach(function() {
+            vec3toStr = undefined;
+        });
+        it('file:///~/system/libraries/utils.js' + cache_buster, function() {
+            Script.include('file:///~/system/libraries/utils.js' + cache_buster);
+            expect(vec3toStr).toEqual(jasmine.any(Function));
+        });
+        it('nested' + cache_buster, function() {
+            Script.include('./scriptTests/top-level.js' + cache_buster);
+            expect(outer).toEqual(jasmine.any(Object));
+            expect(inner).toEqual(jasmine.any(Object));
+            expect(sibling).toEqual(jasmine.any(Object));
+            expect(outer.inner).toEqual(inner.lib);
+            expect(outer.sibling).toEqual(sibling.lib);
+        });
+        describe('errors' + cache_buster, function() {
+            var finishes, oldFinishes;
+            beforeAll(function() {
+                oldFinishes = (1,eval)('this').$finishes;
+            });
+            afterAll(function() {
+                (1,eval)('this').$finishes = oldFinishes;
+            });
+            beforeEach(function() {
+                finishes = (1,eval)('this').$finishes = [];
+            });
+            it('error', function() {
+                // a thrown Error in top-level include aborts that include, but does not throw the error back to JS
+                expect(function() {
+                    Script.include('./scriptTests/error.js' + cache_buster);
+                }).not.toThrowError("error.js");
+                expect(finishes.length).toBe(0);
+            });
+            it('top-level-error', function() {
+                // an organice Error in a top-level include aborts that include, but does not throw the error
+                expect(function() {
+                    Script.include('./scriptTests/top-level-error.js' + cache_buster);
+                }).not.toThrowError(/Undefined_symbol/);
+                expect(finishes.length).toBe(0);
+            });
+            it('nested', function() {
+                // a thrown Error in a nested include aborts the nested include, but does not abort the top-level script
+                expect(function() {
+                    Script.include('./scriptTests/nested-error.js' + cache_buster);
+                }).not.toThrowError("nested/error.js");
+                expect(finishes.length).toBe(1);
+            });
+            it('nested-syntax-error', function() {
+                // a SyntaxError in a nested include breaks only that include (the main script should finish unimpeded)
+                expect(function() {
+                    Script.include('./scriptTests/nested-syntax-error.js' + cache_buster);
+                }).not.toThrowError(/SyntaxEror/);
+                expect(finishes.length).toBe(1);
+            });
+        });
+    });
+});
+
+// enable scriptUnitTests to be loaded directly
+function run() {}
+function instrument_testrunner() {
+    if (typeof describe === 'undefined') {
+        print('instrumenting jasmine', Script.resolvePath(''));
+        Script.include('../../libraries/jasmine/jasmine.js');
+        Script.include('../../libraries/jasmine/hifi-boot.js');
+        jasmine.getEnv().addReporter({ jasmineDone: Script.stop });
+        run = function() {
+            print('executing jasmine', Script.resolvePath(''));
+            jasmine.getEnv().execute();
+        };
+    }
+}
+run();


### PR DESCRIPTION
Here is a rundown of the changes included with this PR -- feedback welcomed.

A key feature here is unlocking the standard JS exception mechanisms -- which are needed for consistent `require/module` support.

#### Extended support for JS syntax errors, exception tracking, stack traces, JS Error objects
* JS exceptions can now be used across nested C++/JS stack frames -- which was the main thing making it difficult to leverage them before.
Before a script had no (direct) way for example to know that an include had failed -- now exceptions could flow to the surface if wanted; making this sort of thing possible:

```javascript
try {
  include('preferred.js');
} catch(e) {
  include('fallback.js');
}
```

* A new helper class named `BaseScriptEngine::ExceptionEmitter` takes care of monitoring/escalating/clearing JS exceptions.  The idea was to make it as simple as using `QMutexLocker` is for locking -- declare an instance of the class inside of a C++ scope, and now that scope is protected from leaking/losing exceptions.
*  Here is the typical path an exception would take getting into the log files:
	* Code that involves JS errors now generates and ->throw's an actual JS `Error`.
	* `ExceptionEmitter` makes sure those get escalated where/when needed.
	*  Uncaught exceptions end up at `BaseScriptEngine::unhandledException(Error)`.  
	* ScriptEngine connects to that and responds by logging the errors as `[UncaughtException]` messages.

#### Entity bootstrapping process
* Errors while booting an Entity are now thrown as JS exceptions, which get logged by the same means as above.
* JS Errors can hold metadata -- for example, I was having trouble working backwards from Entity script errors to a specific point in the boot process, so went through and decorated the main errors to include better clues.
* Currently this extra detail gets printed with the exception.  This might make the log more verbose than people want by default so added a manual override Setting `com.highfidelity.experimental.enableExtendedJSExceptions`:

Off (false):
```
 [UncaughtExceptions] Error: Can't find variable: foobar in about:EmbeddedEntityScript:16\n[Backtrace]...
```

On (true):
```text
[UncaughtException (construct {1eb5d3fa-23b1-411c-af83-163af7220e3f})] Error: Can't find variable: foobar in about:EmbeddedEntityScript:16\n[Backtrace]...
```
* The loading process now takes into account multiple Entities trying to stampede-load from the same script URL.
  * Instead of letting them stall in ScriptCache, ScriptEngine now detects and queues the 2nd+ member of such sets locally.  When the first Entity reaches a RUNNING state -- the remaining are allowed through.  Or if it doesn't they are canceled as a set.  
  * note: stampede loads are very common right now -- for example, anytime someone visits Welcome (the 4+ portals share one script URL).  Or like when someone rezzes multiple copies of a scripted Entity; doesn't matter how slow they do it -- if they relog, the Entities will likely stampede-load; if anybody else shows up, same.

#### Misc

* Migrated overlapping logic for path verification from include() into PathUtils.
* Internal ScriptEngine names are now prefixed `about:`, which avoids `QUrl` from interpreting as relative, local file paths.
* `debugPrint` now invokes JS `Script.print` using the QScriptEngine API.
* Added `BaseScriptEngine::evaluateInClosure(locals, program)` (which `require` needs to created `module` scopes, but might also be useful for other things).
* Added `BaseScriptEngine::newLambdaFunction` which lets C++ lambdas become callable `QScriptValue` functions even when capturing things like `this`.  Only meant for use within the scripting engine itself.  This allows for example using `setInterval` and `setTimeout` to schedule lightweight C++ timers that automatically track/stop with the scripting engine.