### PR TITLE
Give implicit access to family tree of server scripted entities in ESS 

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -17,10 +17,11 @@
 #include <ScriptCache.h>
 #include <EntityEditFilters.h>
 
+#include "AssignmentParentFinder.h"
+#include "EntityNodeData.h"
 #include "EntityServer.h"
 #include "EntityServerConsts.h"
-#include "EntityNodeData.h"
-#include "AssignmentParentFinder.h"
+#include "EntityTreeSendThread.h"
 
 const char* MODEL_SERVER_NAME = "Entity";
 const char* MODEL_SERVER_LOGGING_TARGET_NAME = "entity-server";
@@ -75,6 +76,10 @@ OctreePointer EntityServer::createTree() {
     DependencyManager::set<EntityEditFilters>(std::static_pointer_cast<EntityTree>(tree));
 
     return tree;
+}
+
+OctreeServer::UniqueSendThread EntityServer::newSendThread(const SharedNodePointer& node) {
+    return std::unique_ptr<EntityTreeSendThread>(new EntityTreeSendThread(this, node));
 }
 
 void EntityServer::beforeRun() {

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -67,6 +67,7 @@ public slots:
 
 protected:
     virtual OctreePointer createTree() override;
+    virtual UniqueSendThread newSendThread(const SharedNodePointer& node) override;
 
 private slots:
     void handleEntityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);

--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -93,8 +93,6 @@ bool EntityTreeSendThread::addAncestorsToExtraFlaggedEntities(const QUuid& filte
         // first add it to the extra list of things we need to send
         bool parentWasNew = nodeData.insertFlaggedExtraEntity(filteredEntityID, entityParent->getID());
 
-//        qDebug() << "Adding" << entityParent->getID() << "which is an ancestor of" << filteredEntityID;
-
         // now recursively call ourselves to get its ancestors added too
         auto parentEntityItem = std::static_pointer_cast<EntityItem>(entityParent);
         bool ancestorsWereNew = addAncestorsToExtraFlaggedEntities(filteredEntityID, *parentEntityItem, nodeData);
@@ -121,8 +119,6 @@ bool EntityTreeSendThread::addDescendantsToExtraFlaggedEntities(const QUuid& fil
 
             // first add it to the extra list of things we need to send
             hasNewChild |= nodeData.insertFlaggedExtraEntity(filteredEntityID, child->getID());
-
-//            qDebug() << "Adding" << child->getID() <<  "which is a descendant of" << filteredEntityID;
 
             // now recursively call ourselves to get its descendants added too
             auto childEntityItem = std::static_pointer_cast<EntityItem>(child);

--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -1,0 +1,107 @@
+//
+//  EntityTreeSendThread.cpp
+//  assignment-client/src/entities
+//
+//  Created by Stephen Birarda on 2/15/17.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "EntityTreeSendThread.h"
+
+#include <EntityNodeData.h>
+#include <EntityTypes.h>
+
+#include "EntityServer.h"
+
+void EntityTreeSendThread::preDistributionProcessing() {
+    auto node = _node.toStrongRef();
+    auto nodeData = static_cast<EntityNodeData*>(node->getLinkedData());
+
+    if (nodeData) {
+        auto jsonQuery = nodeData->getJSONParameters();
+
+        // check if we have a JSON query with flags
+        auto flags = jsonQuery[EntityJSONQueryProperties::FLAGS_PROPERTY].toObject();
+        if (!flags.isEmpty()) {
+            // check the flags object for specific flags that require special pre-processing
+
+            bool includeAncestors = flags[EntityJSONQueryProperties::INCLUDE_ANCESTORS_PROPERTY].toBool();
+            bool includeDescendants = flags[EntityJSONQueryProperties::INCLUDE_DESCENDANTS_PROPERTY].toBool();
+
+            if (includeAncestors || includeDescendants) {
+                // we need to either include the ancestors, descendants, or both for entities matching the filter
+                // included in the JSON query
+
+                auto entityTree = std::static_pointer_cast<EntityTree>(_myServer->getOctree());
+
+                // enumerate the set of entity IDs we know currently match the filter
+                foreach(const QUuid& entityID, nodeData->getSentFilteredEntities()) {
+                    if (includeAncestors) {
+                        // we need to include ancestors - recurse up to reach them all and add their IDs
+                        // to the set of extra entities to include for this node
+                        entityTree->withReadLock([&]{
+                            auto filteredEntity = entityTree->findEntityByID(entityID);
+                            if (filteredEntity) {
+                                addAncestorsToExtraFlaggedEntities(entityID, *filteredEntity, *nodeData);
+                            }
+                        });
+                    }
+
+                    if (includeDescendants) {
+                        // we need to include descendants - recurse down to reach them all and add their IDs
+                        // to the set of extra entities to include for this node
+                        entityTree->withReadLock([&]{
+                            auto filteredEntity = entityTree->findEntityByID(entityID);
+                            if (filteredEntity) {
+                                addDescendantsToExtraFlaggedEntities(entityID, *filteredEntity, *nodeData);
+                            }
+                        });
+                    }
+                }
+            }
+
+        }
+    }
+}
+
+void EntityTreeSendThread::addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID,
+                                                              EntityItem& entityItem, EntityNodeData& nodeData) {
+    // check if this entity has a parent that is also an entity
+    bool success = false;
+    auto entityParent = entityItem.getParentPointer(success);
+
+    if (success && entityParent && entityParent->getNestableType() == NestableType::Entity) {
+        // we found a parent that is an entity item
+
+        // first add it to the extra list of things we need to send
+        nodeData.insertFlaggedExtraEntity(filteredEntityID, entityParent->getID());
+
+//        qDebug() << "Adding" << entityParent->getID() << "which is an ancestor of" << filteredEntityID;
+
+        // now recursively call ourselves to get its ancestors added too
+        auto parentEntityItem = std::static_pointer_cast<EntityItem>(entityParent);
+        addAncestorsToExtraFlaggedEntities(filteredEntityID, *parentEntityItem, nodeData);
+    }
+}
+
+void EntityTreeSendThread::addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID,
+                                                                EntityItem& entityItem, EntityNodeData& nodeData) {
+    // enumerate the immediate children of this entity
+    foreach (SpatiallyNestablePointer child, entityItem.getChildren()) {
+        if (child && child->getNestableType() == NestableType::Entity) {
+            // this is a child that is an entity
+
+            // first add it to the extra list of things we need to send
+            nodeData.insertFlaggedExtraEntity(filteredEntityID, child->getID());
+
+//            qDebug() << "Adding" << child->getID() <<  "which is a descendant of" << filteredEntityID;
+
+            // now recursively call ourselves to get its descendants added too
+            auto childEntityItem = std::static_pointer_cast<EntityItem>(child);
+            addDescendantsToExtraFlaggedEntities(filteredEntityID, *childEntityItem, nodeData);
+        }
+    }
+}

--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -76,7 +76,6 @@ void EntityTreeSendThread::preDistributionProcessing() {
                     nodeData->setShouldForceFullScene(requiresFullScene);
                 }
             }
-
         }
     }
 }
@@ -112,7 +111,6 @@ bool EntityTreeSendThread::addDescendantsToExtraFlaggedEntities(const QUuid& fil
 
     // enumerate the immediate children of this entity
     foreach (SpatiallyNestablePointer child, entityItem.getChildren()) {
-
 
         if (child && child->getNestableType() == NestableType::Entity) {
             // this is a child that is an entity

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -26,8 +26,9 @@ protected:
     virtual void preDistributionProcessing() override;
 
 private:
-    void addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
-    void addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
+    // the following two methods return booleans to indicate if any extra flagged entities were new additions to set
+    bool addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
+    bool addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
 
 };
 

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -1,0 +1,34 @@
+//
+//  EntityTreeSendThread.h
+//  assignment-client/src/entities
+//
+//  Created by Stephen Birarda on 2/15/17.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_EntityTreeSendThread_h
+#define hifi_EntityTreeSendThread_h
+
+#include "../octree/OctreeSendThread.h"
+
+class EntityNodeData;
+class EntityItem;
+
+class EntityTreeSendThread : public OctreeSendThread {
+
+public:
+    EntityTreeSendThread(OctreeServer* myServer, const SharedNodePointer& node) : OctreeSendThread(myServer, node) {};
+
+protected:
+    virtual void preDistributionProcessing() override;
+
+private:
+    void addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
+    void addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
+
+};
+
+#endif // hifi_EntityTreeSendThread_h

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -309,6 +309,9 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
         return 0;
     }
 
+    // give our pre-distribution processing a chance to do what it needs
+    preDistributionProcessing();
+
     // calculate max number of packets that can be sent during this interval
     int clientMaxPacketsPerInterval = std::max(1, (nodeData->getMaxQueryPacketsPerSecond() / INTERVALS_PER_SECOND));
     int maxPacketsPerInterval = std::min(clientMaxPacketsPerInterval, _myServer->getPacketsPerClientPerInterval());

--- a/assignment-client/src/octree/OctreeSendThread.h
+++ b/assignment-client/src/octree/OctreeSendThread.h
@@ -17,6 +17,8 @@
 #include <atomic>
 
 #include <GenericThread.h>
+#include <Node.h>
+#include <OctreePacketData.h>
 
 class OctreeQueryNode;
 class OctreeServer;
@@ -49,13 +51,17 @@ protected:
     /// Implements generic processing behavior for this thread.
     virtual bool process() override;
 
+    /// Called before a packetDistributor pass to allow for pre-distribution processing
+    virtual void preDistributionProcessing() {};
+
+    OctreeServer* _myServer { nullptr };
+    QWeakPointer<Node> _node;
+
 private:
     int handlePacketSend(SharedNodePointer node, OctreeQueryNode* nodeData, int& trueBytesSent, int& truePacketsSent, bool dontSuppressDuplicate = false);
     int packetDistributor(SharedNodePointer node, OctreeQueryNode* nodeData, bool viewFrustumChanged);
     
-    
-    OctreeServer* _myServer { nullptr };
-    QWeakPointer<Node> _node;
+
     QUuid _nodeUuid;
 
     OctreePacketData _packetData;

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -872,8 +872,12 @@ void OctreeServer::parsePayload() {
     }
 }
 
+OctreeServer::UniqueSendThread OctreeServer::newSendThread(const SharedNodePointer& node) {
+    return std::unique_ptr<OctreeSendThread>(new OctreeSendThread(this, node));
+}
+
 OctreeServer::UniqueSendThread OctreeServer::createSendThread(const SharedNodePointer& node) {
-    auto sendThread = std::unique_ptr<OctreeSendThread>(new OctreeSendThread(this, node));
+    auto sendThread = newSendThread(node);
     
     // we want to be notified when the thread finishes
     connect(sendThread.get(), &GenericThread::finished, this, &OctreeServer::removeSendThread);

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -158,6 +158,7 @@ protected:
     QString getStatusLink();
     
     UniqueSendThread createSendThread(const SharedNodePointer& node);
+    virtual UniqueSendThread newSendThread(const SharedNodePointer& node);
 
     int _argc;
     const char** _argv;

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -266,6 +266,14 @@ void EntityScriptServer::run() {
     QJsonObject queryJSONParameters;
     static const QString SERVER_SCRIPTS_PROPERTY = "serverScripts";
     queryJSONParameters[SERVER_SCRIPTS_PROPERTY] = EntityQueryFilterSymbol::NonDefault;
+
+    QJsonObject queryFlags;
+    static const QString INCLUDE_DESCENDANTS_PROPERTY = "includeDescendants";
+    static const QString INCLUDE_PARENTS_PROPERTY = "includeParents";
+    queryFlags[INCLUDE_DESCENDANTS_PROPERTY] = true;
+    queryFlags[INCLUDE_PARENTS_PROPERTY] = true;
+
+    queryJSONParameters["flags"] = queryFlags;
     
     // setup the JSON parameters so that OctreeQuery does not use a frustum and uses our JSON filter
     _entityViewer.getOctreeQuery().setUsesFrustum(false);

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -419,6 +419,7 @@ void EntityScriptServer::resetEntitiesScriptEngine() {
 
     connect(newEngine.data(), &ScriptEngine::update, this, [this] {
         _entityViewer.queryOctree();
+        _entityViewer.getTree()->update();
     });
 
 

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -16,6 +16,7 @@
 #include <AudioConstants.h>
 #include <AudioInjectorManager.h>
 #include <ClientServerUtils.h>
+#include <EntityNodeData.h>
 #include <EntityScriptingInterface.h>
 #include <LogHandler.h>
 #include <MessagesClient.h>
@@ -264,16 +265,14 @@ void EntityScriptServer::run() {
     
     // setup the JSON filter that asks for entities with a non-default serverScripts property
     QJsonObject queryJSONParameters;
-    static const QString SERVER_SCRIPTS_PROPERTY = "serverScripts";
-    queryJSONParameters[SERVER_SCRIPTS_PROPERTY] = EntityQueryFilterSymbol::NonDefault;
+    queryJSONParameters[EntityJSONQueryProperties::SERVER_SCRIPTS_PROPERTY] = EntityQueryFilterSymbol::NonDefault;
 
     QJsonObject queryFlags;
-    static const QString INCLUDE_DESCENDANTS_PROPERTY = "includeDescendants";
-    static const QString INCLUDE_PARENTS_PROPERTY = "includeParents";
-    queryFlags[INCLUDE_DESCENDANTS_PROPERTY] = true;
-    queryFlags[INCLUDE_PARENTS_PROPERTY] = true;
 
-    queryJSONParameters["flags"] = queryFlags;
+    queryFlags[EntityJSONQueryProperties::INCLUDE_ANCESTORS_PROPERTY] = true;
+    queryFlags[EntityJSONQueryProperties::INCLUDE_DESCENDANTS_PROPERTY] = true;
+
+    queryJSONParameters[EntityJSONQueryProperties::FLAGS_PROPERTY] = queryFlags;
     
     // setup the JSON parameters so that OctreeQuery does not use a frustum and uses our JSON filter
     _entityViewer.getOctreeQuery().setUsesFrustum(false);

--- a/libraries/entities/src/EntityNodeData.cpp
+++ b/libraries/entities/src/EntityNodeData.cpp
@@ -1,0 +1,25 @@
+//
+//  EntityNodeData.cpp
+//  libraries/entities/src
+//
+//  Created by Stephen Birarda on 2/15/17
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "EntityNodeData.h"
+
+bool EntityNodeData::isEntityFlaggedAsExtra(const QUuid& entityID) const {
+
+    // enumerate each of the sets for the entities that matched our filter
+    // and immediately return true if any of them contain this entity ID
+    foreach(QSet<QUuid> entitySet, _flaggedExtraEntities) {
+        if (entitySet.contains(entityID)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/libraries/entities/src/EntityNodeData.cpp
+++ b/libraries/entities/src/EntityNodeData.cpp
@@ -11,6 +11,11 @@
 
 #include "EntityNodeData.h"
 
+bool EntityNodeData::insertFlaggedExtraEntity(const QUuid& filteredEntityID, const QUuid& extraEntityID) {
+    _flaggedExtraEntities[filteredEntityID].insert(extraEntityID);
+    return !_previousFlaggedExtraEntities[filteredEntityID].contains(extraEntityID);
+}
+
 bool EntityNodeData::isEntityFlaggedAsExtra(const QUuid& entityID) const {
 
     // enumerate each of the sets for the entities that matched our filter

--- a/libraries/entities/src/EntityNodeData.h
+++ b/libraries/entities/src/EntityNodeData.h
@@ -36,15 +36,19 @@ public:
     bool sentFilteredEntity(const QUuid& entityID) { return _sentFilteredEntities.contains(entityID); }
     QSet<QUuid> getSentFilteredEntities() { return _sentFilteredEntities; }
 
-    // these can only be called from the OctreeSendThread for the given Node
-    void insertFlaggedExtraEntity(const QUuid& filteredEntityID, const QUuid& extraEntityID)
-        { _flaggedExtraEntities[filteredEntityID].insert(extraEntityID); }
+    // the following flagged extra entity methods can only be called from the OctreeSendThread for the given Node
+
+    // inserts the extra entity and returns a boolean indicating wether the extraEntityID was a new addition
+    bool insertFlaggedExtraEntity(const QUuid& filteredEntityID, const QUuid& extraEntityID);
+    
     bool isEntityFlaggedAsExtra(const QUuid& entityID) const;
+    void resetFlaggedExtraEntities() { _previousFlaggedExtraEntities = _flaggedExtraEntities; _flaggedExtraEntities.clear(); }
 
 private:
     quint64 _lastDeletedEntitiesSentAt { usecTimestampNow() };
     QSet<QUuid> _sentFilteredEntities;
     QHash<QUuid, QSet<QUuid>> _flaggedExtraEntities;
+    QHash<QUuid, QSet<QUuid>> _previousFlaggedExtraEntities;
 };
 
 #endif // hifi_EntityNodeData_h

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -310,16 +310,17 @@ OctreeElement::AppendState EntityTreeElement::appendElementData(OctreePacketData
 
                     if (entityMatchesFilters) {
                         // make sure this entity is in the set of entities sent last frame
-                        entityNodeData->insertEntitySentLastFrame(entity->getID());
-
-                    } else {
-                        // we might include this entity if it matched in the previous frame
-                        if (entityNodeData->sentEntityLastFrame(entity->getID())) {
-
-                            entityNodeData->removeEntitySentLastFrame(entity->getID());
-                        } else {
-                            includeThisEntity = false;
-                        }
+                        entityNodeData->insertSentFilteredEntity(entity->getID());
+                    } else if (entityNodeData->sentFilteredEntity(entity->getID())) {
+                        // this entity matched in the previous frame - we send it still so the client realizes it just
+                        // fell outside of their filter
+                        entityNodeData->removeSentFilteredEntity(entity->getID());
+                    } else if (!entityNodeData->isEntityFlaggedAsExtra(entity->getID())) {
+                        // we don't send this entity because
+                        // (1) it didn't match our filter
+                        // (2) it didn't match our filter last frame
+                        // (3) it isn't one the JSON query flags told us we should still include
+                        includeThisEntity = false;
                     }
                 }
 

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -51,7 +51,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::EntityPhysics:
             return VERSION_ENTITIES_ZONE_FILTERS;
         case PacketType::EntityQuery:
-            return static_cast<PacketVersion>(EntityQueryPacketVersion::JsonFilter);
+            return static_cast<PacketVersion>(EntityQueryPacketVersion::JSONFilterWithFamilyTree);
         case PacketType::AvatarIdentity:
         case PacketType::AvatarData:
         case PacketType::BulkAvatarData:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -207,7 +207,8 @@ const PacketVersion VERSION_ENTITIES_PHYSICS_PACKET = 67;
 const PacketVersion VERSION_ENTITIES_ZONE_FILTERS = 68;
 
 enum class EntityQueryPacketVersion: PacketVersion {
-    JsonFilter = 18
+    JSONFilter = 18,
+    JSONFilterWithFamilyTree = 19
 };
 
 enum class AssetServerPacketVersion: PacketVersion {

--- a/libraries/octree/src/OctreeQueryNode.h
+++ b/libraries/octree/src/OctreeQueryNode.h
@@ -103,6 +103,9 @@ public:
     // call only from OctreeSendThread for the given node
     bool haveJSONParametersChanged();
 
+    bool shouldForceFullScene() const { return _shouldForceFullScene; }
+    bool setShouldForceFullScene(bool shouldForceFullScene) { _shouldForceFullScene = shouldForceFullScene; }
+
 private:
     OctreeQueryNode(const OctreeQueryNode &);
     OctreeQueryNode& operator= (const OctreeQueryNode&);
@@ -148,6 +151,8 @@ private:
     std::array<char, udt::MAX_PACKET_SIZE> _lastOctreePayload;
 
     QJsonObject _lastCheckJSONParameters;
+
+    bool _shouldForceFullScene { false };
 };
 
 #endif // hifi_OctreeQueryNode_h

--- a/libraries/octree/src/OctreeQueryNode.h
+++ b/libraries/octree/src/OctreeQueryNode.h
@@ -104,7 +104,7 @@ public:
     bool haveJSONParametersChanged();
 
     bool shouldForceFullScene() const { return _shouldForceFullScene; }
-    bool setShouldForceFullScene(bool shouldForceFullScene) { _shouldForceFullScene = shouldForceFullScene; }
+    void setShouldForceFullScene(bool shouldForceFullScene) { _shouldForceFullScene = shouldForceFullScene; }
 
 private:
     OctreeQueryNode(const OctreeQueryNode &);

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -70,6 +70,9 @@ void SpatiallyNestable::setParentID(const QUuid& parentID) {
             _parentKnowsMe = false;
         }
     });
+
+    bool success = false;
+    getParentPointer(success);
 }
 
 Transform SpatiallyNestable::getParentTransform(bool& success, int depth) const {


### PR DESCRIPTION
- added optional flags "includeAncestors" and "includeDescendants" to entity JSON queries
- added sending of new optional flags by default from Entity Script Server
- added handling of "includeAncestors" and "includeDescendants" flags in Entity Server via optional Octree pre-processing step