### PR TITLE
fix rquestsDomainListData

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -410,7 +410,7 @@ void AvatarMixer::broadcastAvatarData() {
                     bool isInView = nodeData->otherAvatarInView(otherNodeBox);
 
                     // this throttles the extra data to only be sent every Nth message
-                    if (!isInView && getsOutOfView && (lastSeqToReceiver % EXTRA_AVATAR_DATA_FRAME_RATIO > 0)) {
+                    if (!isInView && !getsOutOfView && (lastSeqToReceiver % EXTRA_AVATAR_DATA_FRAME_RATIO > 0)) {
                         return;
                     }
 
@@ -572,6 +572,7 @@ void AvatarMixer::handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMess
             bool isRequesting;
             message->readPrimitive(&isRequesting);
             nodeData->setRequestsDomainListData(isRequesting);
+            qDebug() << "node" << nodeData->getNodeID() << "requestsDomainListData" << isRequesting;
         }
     }
 }


### PR DESCRIPTION
I've done the qa on this myself, because it's sort of impossible to test:
- Found highest number of agents that can be summoned in domain without falling over.
- Open PAL and referesh, and make sure the numbers match. Should not be seeing avatar count go down while PAL is open, even as you rotate to have different numbers in view.

However, this isn't necessarily the last source of blank lines in PAL at high numbers of avatars. I simply can't make it to 100 using only my machine, so I need to get this merged and onto dev-distributed.