### PR TITLE
Updates to texture managment

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -108,16 +108,10 @@ public:
             using VoidLambdaQueue = std::queue<VoidLambda>;
             using ThreadPointer = std::shared_ptr<std::thread>;
             const GL45VariableAllocationTexture& _parent;
-            const uint16_t _sourceMip;
-            const uint16_t _targetMip;
-            const uint8_t _face;
-            const uint32_t _lines;
-            const uint32_t _lineOffset;
             // Holds the contents to transfer to the GPU in CPU memory
             std::vector<uint8_t> _buffer;
             // Indicates if a transfer from backing storage to interal storage has started
             bool _bufferingStarted { false };
-            bool _transferOnly { false };
             bool _bufferingCompleted { false };
             VoidLambda _transferLambda;
             VoidLambda _bufferingLambda;
@@ -128,6 +122,7 @@ public:
             static void bufferLoop();
 
         public:
+            TransferJob(const TransferJob& other) = delete;
             TransferJob(const GL45VariableAllocationTexture& parent, std::function<void()> transferLambda);
             TransferJob(const GL45VariableAllocationTexture& parent, uint16_t sourceMip, uint16_t targetMip, uint8_t face, uint32_t lines = 0, uint32_t lineOffset = 0);
             bool tryTransfer();
@@ -139,7 +134,7 @@ public:
             void transfer();
         };
 
-        using TransferQueue = std::queue<TransferJob>;
+        using TransferQueue = std::queue<std::unique_ptr<TransferJob>>;
         static MemoryPressureState _memoryPressureState;
     protected:
         static std::atomic<bool> _memoryPressureStateStale;

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -72,7 +72,7 @@ ktx::KTXUniquePointer Texture::serialize(const Texture& texture) {
     for (uint32_t level = 0; level < header.numberOfMipmapLevels; level++) {
         auto mip = texture.accessStoredMipFace(level);
         if (mip) {
-            images.emplace_back(ktx::Image(mip->getSize(), 0, mip->readData()));
+            images.emplace_back(ktx::Image((uint32_t)mip->getSize(), 0, mip->readData()));
         }
     }
 

--- a/libraries/shared/src/shared/Storage.h
+++ b/libraries/shared/src/shared/Storage.h
@@ -23,13 +23,15 @@ namespace storage {
     using MemoryStoragePointer = std::unique_ptr<MemoryStorage>;
     class FileStorage;
     using FileStoragePointer = std::unique_ptr<FileStorage>;
+    class ViewStorage;
+    using ViewStoragePointer = std::unique_ptr<ViewStorage>;
 
     class Storage {
     public:
         virtual ~Storage() {}
         virtual const uint8_t* data() const = 0;
         virtual size_t size() const = 0;
-
+        ViewStoragePointer createView(size_t size, size_t offset = 0) const;
         FileStoragePointer toFileStorage(const QString& filename) const;
         MemoryStoragePointer toMemoryStorage() const;
     };
@@ -37,8 +39,8 @@ namespace storage {
     class MemoryStorage : public Storage {
     public:
         MemoryStorage(size_t size, const uint8_t* data);
-        const uint8_t* data() const override;
-        size_t size() const override;
+        const uint8_t* data() const override { return _data.data(); }
+        size_t size() const override { return _data.size(); }
     private:
         std::vector<uint8_t> _data;
     };
@@ -52,13 +54,22 @@ namespace storage {
         FileStorage(const FileStorage& other) = delete;
         FileStorage& operator=(const FileStorage& other) = delete;
 
-        const uint8_t* data() const override;
-        size_t size() const override;
+        const uint8_t* data() const override { return _mapped; }
+        size_t size() const override { return _file.size(); }
     private:
         QFile _file;
         uint8_t* _mapped { nullptr };
     };
 
+    class ViewStorage : public Storage {
+    public:
+        ViewStorage(size_t size, const uint8_t* data) : _size(size), _data(data) {}
+        const uint8_t* data() const override { return _data; }
+        size_t size() const override { return _size; }
+    private:
+        const size_t _size;
+        const uint8_t* _data;
+    };
 
 }
 


### PR DESCRIPTION
* Adds a new storage 'ViewStorage' which is a view with a specific size and offset onto another storage object (does not manage it's own memory)
* Fixes some bugs in the TransferJob
** makes TransferJob non-copyable (which was breaking lambda usage)
** fixes the dimensions of the upload
** disables threaded buffering for now
* Switching the backing of Texture::Pixels to an opaque storage type, rather than sysmem
** Removes the ability to 'resize' pixels... they are now const objects and must be fully initialized at creation time

