### PR TITLE
Logging HMD/Desktop Transitions

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6679,6 +6679,12 @@ void Application::updateDisplayMode() {
     }
 
     emit activeDisplayPluginChanged();
+    
+    if (_displayPlugin->isHmd()) {
+        qCDebug(interfaceapp) << "Entering into HMD Mode";
+    } else {
+        qCDebug(interfaceapp) << "Entering into Desktop Mode";
+    }
 
     // reset the avatar, to set head and hand palms back to a reasonable default pose.
     getMyAvatar()->reset(false);


### PR DESCRIPTION
Adding changes between HMD and Desktop into log, as well as initial log entry on startup.

In response to: 
https://highfidelity.fogbugz.com/f/cases/3094/Log-does-not-contain-HMD-desktop-transitions
https://github.com/highfidelity/hifi/issues/9487