### PR TITLE
MacOS: Fix for audio, toolbar and tablet.

### DIFF
--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -94,6 +94,8 @@ public:
     using AudioPositionGetter = std::function<glm::vec3()>;
     using AudioOrientationGetter = std::function<glm::quat()>;
 
+    using RecursiveMutex = std::recursive_mutex;
+    using RecursiveLock = std::unique_lock<RecursiveMutex>;
     using Mutex = std::mutex;
     using Lock = std::unique_lock<Mutex>;
 
@@ -328,7 +330,7 @@ private:
     int16_t _localScratchBuffer[AudioConstants::NETWORK_FRAME_SAMPLES_AMBISONIC];
     float* _localOutputMixBuffer { NULL };
     AudioInjectorsThread _localAudioThread;
-    Mutex _localAudioMutex;
+    RecursiveMutex _localAudioMutex;
 
     // for output audio (used by this thread)
     int _outputPeriod { 0 };


### PR DESCRIPTION
There was a deadlock on the audio thread, This would prevent audio from playing, but it would also prevent defaultScripts from running properly.  Which affected pretty much everything, including the toolbar and tablet buttons.  Specifically selectAudioDevice.js would block when it called AudioDevice.getInputDevices().