### PR TITLE
Fix recorder.js playback in interface

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -160,7 +160,7 @@ MyAvatar::MyAvatar(RigPointer rig) :
         }
 
         auto audioIO = DependencyManager::get<AudioClient>();
-        audioIO->setPlayingBackRecording(isPlaying);
+        audioIO->setIsPlayingBackRecording(isPlaying);
 
         if (_rig) {
             _rig->setEnableAnimations(!isPlaying);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -486,6 +486,7 @@ private:
     std::unordered_set<int> _headBoneSet;
     RigPointer _rig;
     bool _prevShouldDrawHead;
+    bool _rigEnabled { true };
 
     bool _enableDebugDrawDefaultPose { false };
     bool _enableDebugDrawAnimPose { false };

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -483,6 +483,10 @@ void Rig::setEnableInverseKinematics(bool enable) {
     _enableInverseKinematics = enable;
 }
 
+void Rig::setEnableAnimations(bool enable) {
+    _enabledAnimations = enable;
+}
+
 AnimPose Rig::getAbsoluteDefaultPose(int index) const {
     if (_animSkeleton && index >= 0 && index < _animSkeleton->getNumJoints()) {
         return _absoluteDefaultPoses[index];
@@ -907,7 +911,7 @@ void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
 
     setModelOffset(rootTransform);
 
-    if (_animNode) {
+    if (_animNode && _enabledAnimations) {
         PerformanceTimer perfTimer("handleTriggers");
 
         updateAnimationStateHandlers();

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -210,6 +210,7 @@ public:
     void computeAvatarBoundingCapsule(const FBXGeometry& geometry, float& radiusOut, float& heightOut, glm::vec3& offsetOut) const;
 
     void setEnableInverseKinematics(bool enable);
+    void setEnableAnimations(bool enable);
 
     const glm::mat4& getGeometryToRigTransform() const { return _geometryToRigTransform; }
 
@@ -314,6 +315,7 @@ protected:
     int32_t _numOverrides { 0 };
     bool _lastEnableInverseKinematics { true };
     bool _enableInverseKinematics { true };
+    bool _enabledAnimations { true };
 
     mutable uint32_t _jointNameWarningCount { 0 };
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -148,17 +148,17 @@ static inline float convertToFloat(int16_t sample) {
 AudioClient::AudioClient() :
     AbstractAudioInterface(),
     _gate(this),
-    _audioInput(nullptr),
+    _audioInput(NULL),
     _desiredInputFormat(),
     _inputFormat(),
     _numInputCallbackBytes(0),
-    _audioOutput(nullptr),
+    _audioOutput(NULL),
     _desiredOutputFormat(),
     _outputFormat(),
     _outputFrameSize(0),
     _numOutputCallbackBytes(0),
-    _loopbackAudioOutput(nullptr),
-    _loopbackOutputDevice(nullptr),
+    _loopbackAudioOutput(NULL),
+    _loopbackOutputDevice(NULL),
     _inputRingBuffer(0),
     _localInjectorsStream(0),
     _receivedAudioStream(RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES),
@@ -176,9 +176,9 @@ AudioClient::AudioClient() :
     _isNoiseGateEnabled(true),
     _reverb(false),
     _reverbOptions(&_scriptReverbOptions),
-    _inputToNetworkResampler(nullptr),
-    _networkToOutputResampler(nullptr),
-    _localToOutputResampler(nullptr),
+    _inputToNetworkResampler(NULL),
+    _networkToOutputResampler(NULL),
+    _localToOutputResampler(NULL),
     _localAudioThread(this),
     _audioLimiter(AudioConstants::SAMPLE_RATE, OUTPUT_CHANNEL_COUNT),
     _outgoingAvatarAudioSequenceNumber(0),
@@ -393,9 +393,9 @@ QAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
         }
     } else {
         HRESULT hr = S_OK;
-        CoInitialize(nullptr);
-        IMMDeviceEnumerator* pMMDeviceEnumerator = nullptr;
-        CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&pMMDeviceEnumerator);
+        CoInitialize(NULL);
+        IMMDeviceEnumerator* pMMDeviceEnumerator = NULL;
+        CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&pMMDeviceEnumerator);
         IMMDevice* pEndpoint;
         hr = pMMDeviceEnumerator->GetDefaultAudioEndpoint(mode == QAudio::AudioOutput ? eRender : eCapture, eMultimedia, &pEndpoint);
         if (hr == E_NOTFOUND) {
@@ -405,7 +405,7 @@ QAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
             deviceName = friendlyNameForAudioDevice(pEndpoint);
         }
         pMMDeviceEnumerator->Release();
-        pMMDeviceEnumerator = nullptr;
+        pMMDeviceEnumerator = NULL;
         CoUninitialize();
     }
 
@@ -965,7 +965,7 @@ void AudioClient::handleLocalEchoAndReverb(QByteArray& inputByteArray) {
 }
 
 void AudioClient::handleAudioInput() {
-    if (!_inputDevice || _playingBackRecording) {
+    if (!_inputDevice || _isPlayingBackRecording) {
         return;
     }
 
@@ -1354,10 +1354,10 @@ bool AudioClient::switchInputToAudioDevice(const QAudioDeviceInfo& inputDeviceIn
         // That in turn causes it to be disconnected (see for example
         // http://stackoverflow.com/questions/9264750/qt-signals-and-slots-object-disconnect).
         _audioInput->stop();
-        _inputDevice = nullptr;
+        _inputDevice = NULL;
 
         delete _audioInput;
-        _audioInput = nullptr;
+        _audioInput = NULL;
         _numInputCallbackBytes = 0;
 
         _inputAudioDeviceName = "";
@@ -1366,7 +1366,7 @@ bool AudioClient::switchInputToAudioDevice(const QAudioDeviceInfo& inputDeviceIn
     if (_inputToNetworkResampler) {
         // if we were using an input to network resampler, delete it here
         delete _inputToNetworkResampler;
-        _inputToNetworkResampler = nullptr;
+        _inputToNetworkResampler = NULL;
     }
 
     if (!inputDeviceInfo.isNull()) {
@@ -1461,29 +1461,29 @@ bool AudioClient::switchOutputToAudioDevice(const QAudioDeviceInfo& outputDevice
         _audioOutput->stop();
 
         delete _audioOutput;
-        _audioOutput = nullptr;
+        _audioOutput = NULL;
 
-        _loopbackOutputDevice = nullptr;
+        _loopbackOutputDevice = NULL;
         delete _loopbackAudioOutput;
-        _loopbackAudioOutput = nullptr;
+        _loopbackAudioOutput = NULL;
 
         delete[] _outputMixBuffer;
-        _outputMixBuffer = nullptr;
+        _outputMixBuffer = NULL;
 
         delete[] _outputScratchBuffer;
-        _outputScratchBuffer = nullptr;
+        _outputScratchBuffer = NULL;
 
         delete[] _localOutputMixBuffer;
-        _localOutputMixBuffer = nullptr;
+        _localOutputMixBuffer = NULL;
     }
 
     if (_networkToOutputResampler) {
         // if we were using an input to network resampler, delete it here
         delete _networkToOutputResampler;
-        _networkToOutputResampler = nullptr;
+        _networkToOutputResampler = NULL;
 
         delete _localToOutputResampler;
-        _localToOutputResampler = nullptr;
+        _localToOutputResampler = NULL;
     }
 
     if (!outputDeviceInfo.isNull()) {

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -145,7 +145,7 @@ public:
     void setPositionGetter(AudioPositionGetter positionGetter) { _positionGetter = positionGetter; }
     void setOrientationGetter(AudioOrientationGetter orientationGetter) { _orientationGetter = orientationGetter; }
 
-    void setPlayingBackRecording(bool playingBackRecording) { _playingBackRecording = playingBackRecording; }
+    void setIsPlayingBackRecording(bool isPlayingBackRecording) { _isPlayingBackRecording = isPlayingBackRecording; }
 
     Q_INVOKABLE void setAvatarBoundingBoxParameters(glm::vec3 corner, glm::vec3 scale);
 
@@ -328,14 +328,14 @@ private:
     // for local audio (used by audio injectors thread)
     float _localMixBuffer[AudioConstants::NETWORK_FRAME_SAMPLES_STEREO];
     int16_t _localScratchBuffer[AudioConstants::NETWORK_FRAME_SAMPLES_AMBISONIC];
-    float* _localOutputMixBuffer { nullptr };
+    float* _localOutputMixBuffer { NULL };
     AudioInjectorsThread _localAudioThread;
     Mutex _localAudioMutex;
 
     // for output audio (used by this thread)
     int _outputPeriod { 0 };
-    float* _outputMixBuffer { nullptr };
-    int16_t* _outputScratchBuffer { nullptr };
+    float* _outputMixBuffer { NULL };
+    int16_t* _outputScratchBuffer { NULL };
 
     AudioLimiter _audioLimiter;
 
@@ -373,7 +373,7 @@ private:
 
     QVector<AudioInjector*> _activeLocalAudioInjectors;
 
-    bool _playingBackRecording { false };
+    bool _isPlayingBackRecording { false };
 
     CodecPluginPointer _codec;
     QString _selectedCodecName;

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -378,7 +378,6 @@ private:
     CodecPluginPointer _codec;
     QString _selectedCodecName;
     Encoder* _encoder { nullptr }; // for outbound mic stream
-    Encoder* _playbackEncoder { nullptr };
 
     QThread* _checkDevicesThread { nullptr };
 };

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -145,6 +145,8 @@ public:
     void setPositionGetter(AudioPositionGetter positionGetter) { _positionGetter = positionGetter; }
     void setOrientationGetter(AudioOrientationGetter orientationGetter) { _orientationGetter = orientationGetter; }
 
+    void setPlayingBackRecording(bool playingBackRecording) { _playingBackRecording = playingBackRecording; }
+
     Q_INVOKABLE void setAvatarBoundingBoxParameters(glm::vec3 corner, glm::vec3 scale);
 
     void checkDevices();
@@ -326,14 +328,14 @@ private:
     // for local audio (used by audio injectors thread)
     float _localMixBuffer[AudioConstants::NETWORK_FRAME_SAMPLES_STEREO];
     int16_t _localScratchBuffer[AudioConstants::NETWORK_FRAME_SAMPLES_AMBISONIC];
-    float* _localOutputMixBuffer { NULL };
+    float* _localOutputMixBuffer { nullptr };
     AudioInjectorsThread _localAudioThread;
     Mutex _localAudioMutex;
 
     // for output audio (used by this thread)
     int _outputPeriod { 0 };
-    float* _outputMixBuffer { NULL };
-    int16_t* _outputScratchBuffer { NULL };
+    float* _outputMixBuffer { nullptr };
+    int16_t* _outputScratchBuffer { nullptr };
 
     AudioLimiter _audioLimiter;
 
@@ -367,13 +369,16 @@ private:
     QVector<QString> _inputDevices;
     QVector<QString> _outputDevices;
 
-    bool _hasReceivedFirstPacket = false;
+    bool _hasReceivedFirstPacket { false };
 
     QVector<AudioInjector*> _activeLocalAudioInjectors;
+
+    bool _playingBackRecording { false };
 
     CodecPluginPointer _codec;
     QString _selectedCodecName;
     Encoder* _encoder { nullptr }; // for outbound mic stream
+    Encoder* _playbackEncoder { nullptr };
 
     QThread* _checkDevicesThread { nullptr };
 };

--- a/libraries/audio/src/AudioInjectorOptions.cpp
+++ b/libraries/audio/src/AudioInjectorOptions.cpp
@@ -91,4 +91,4 @@ void injectorOptionsFromScriptValue(const QScriptValue& object, AudioInjectorOpt
             qCWarning(audio) << "Unknown audio injector option:" << it.name();
         }
     }
- }
+}

--- a/scripts/developer/utilities/record/recorder.js
+++ b/scripts/developer/utilities/record/recorder.js
@@ -1,4 +1,3 @@
-debugger;
 //
 //  Recorder.js
 //  examples

--- a/scripts/developer/utilities/record/recorder.js
+++ b/scripts/developer/utilities/record/recorder.js
@@ -1,3 +1,4 @@
+debugger;
 //
 //  Recorder.js
 //  examples
@@ -12,14 +13,14 @@
 HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
 Script.include("/~/system/libraries/toolBars.js");
 
-var recordingFile = "recording.rec";
+var recordingFile = "recording.hfr";
 
 function setPlayerOptions() {
     Recording.setPlayFromCurrentLocation(true);
     Recording.setPlayerUseDisplayName(false);
     Recording.setPlayerUseAttachments(false);
     Recording.setPlayerUseHeadModel(false);
-    Recording.setPlayerUseSkeletonModel(false);
+    Recording.setPlayerUseSkeletonModel(true);
 }
 
 var windowDimensions = Controller.getViewportDimensions();
@@ -142,7 +143,6 @@ function setupTimer() {
         backgroundAlpha: 1.0,
         visible: true
     });
-
 }
 
 function updateTimer() {
@@ -272,7 +272,7 @@ function mousePressEvent(event) {
         }
     } else if (loadIcon === toolBar.clicked(clickedOverlay)) {
         if (!Recording.isRecording() && !Recording.isPlaying()) {
-            recordingFile = Window.browse("Load recorcding from file", ".", "Recordings (*.hfr *.rec *.HFR *.REC)");
+            recordingFile = Window.browse("Load recording from file", ".", "Recordings (*.hfr *.rec *.HFR *.REC)");
             if (!(recordingFile === "null" || recordingFile === null || recordingFile === "")) {
                 Recording.loadRecording(recordingFile);
             }
@@ -345,5 +345,3 @@ Script.scriptEnding.connect(scriptEnding);
 
 // Should be called last to put everything into position
 moveUI();
-
-


### PR DESCRIPTION
Stops microphone input while a recording is playing back through the interface. Also pushes the raw joint data from the recording though the rig so that it is displayed correctly in Interface.

Internal bug-tracker URL: https://highfidelity.fogbugz.com/f/cases/2897/Fix-recorder-js

## QA Test
This is a two person test, a recorder and an observer.

1. both: open interface and go to the same domain.
2. recorder: Open `developer/utilities/record/recorder.js`
3. recorder: Record a clip
4. recorder: Play the clip back in interface
5. both: The audio should be heard clearly by the observer as well as the recorder.
6. both: The recorded animations should be visible to both parties.
