### PR TITLE
Fix FB3234 & ease PAL load on AvatarMixer

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -214,10 +214,10 @@ void AvatarMixer::broadcastAvatarData() {
             float avatarDataRateLastSecond = nodeData->getOutboundAvatarDataKbps();
 
             // When this is true, the AvatarMixer will send Avatar data to a client about avatars that are not in the view frustrum
-            bool getsOutOfView = nodeData->getRequestsDomainListData();
+            bool getsOutOfView = false;
 
             // When this is true, the AvatarMixer will send Avatar data to a client about avatars that they've ignored
-            bool getsIgnoredByMe = getsOutOfView;
+            bool getsIgnoredByMe = nodeData->getRequestsDomainListData();
             
             // When this is true, the AvatarMixer will send Avatar data to a client about avatars that have ignored them
             bool getsAnyIgnored = getsIgnoredByMe && node->getCanKick();

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -213,9 +213,6 @@ void AvatarMixer::broadcastAvatarData() {
             // use the data rate specifically for avatar data for FRD adjustment checks
             float avatarDataRateLastSecond = nodeData->getOutboundAvatarDataKbps();
 
-            // When this is true, the AvatarMixer will send Avatar data to a client about avatars that are not in the view frustrum
-            bool getsOutOfView = false;
-
             // When this is true, the AvatarMixer will send Avatar data to a client about avatars that they've ignored
             bool getsIgnoredByMe = nodeData->getRequestsDomainListData();
             
@@ -372,7 +369,6 @@ void AvatarMixer::broadcastAvatarData() {
                     maxAvatarDistanceThisFrame = std::max(maxAvatarDistanceThisFrame, distanceToAvatar);
 
                     if (distanceToAvatar != 0.0f
-                        && !getsOutOfView
                         && distribution(generator) > (nodeData->getFullRateDistance() / distanceToAvatar)) {
                         return;
                     }
@@ -410,7 +406,7 @@ void AvatarMixer::broadcastAvatarData() {
                     bool isInView = nodeData->otherAvatarInView(otherNodeBox);
 
                     // this throttles the extra data to only be sent every Nth message
-                    if (!isInView && !getsOutOfView && (lastSeqToReceiver % EXTRA_AVATAR_DATA_FRAME_RATIO > 0)) {
+                    if (!isInView && (lastSeqToReceiver % EXTRA_AVATAR_DATA_FRAME_RATIO > 0)) {
                         return;
                     }
 
@@ -418,7 +414,7 @@ void AvatarMixer::broadcastAvatarData() {
                     avatarPacketList->startSegment();
 
                     AvatarData::AvatarDataDetail detail;
-                    if (!isInView && !getsOutOfView) {
+                    if (!isInView) {
                         detail = AvatarData::MinimumData;
                         nodeData->incrementAvatarOutOfView();
                     } else {

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -342,6 +342,7 @@ void AvatarManager::removeAvatar(const QUuid& sessionUUID, KillAvatarReason remo
 
     auto removedAvatar = _avatarHash.take(sessionUUID);
     if (removedAvatar) {
+        qDebug() << "Removing avatar from AvatarHashMap. sessionUUID:" << sessionUUID << "Reason" << removalReason;
         handleRemovedAvatar(removedAvatar, removalReason);
     }
 }

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -228,6 +228,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         }
         break;
     case 'refresh':
+        Users.requestsDomainListData = true;
         removeOverlays();
         populateUserList(message.params);
         UserActivityLogger.palAction("refresh", "");


### PR DESCRIPTION
This PR fixes [FB3234](https://highfidelity.fogbugz.com/f/cases/3234) and also eases some strain on the AvatarMixer. I have removed a variable from the code that I don't think is necessary.

Marked DNM for now while the team discusses this change.

**Test Plan:**
1. Go to hifi://distributed
2. Stand on stage and face the 100-avatar audience
3. Load all the avatars
4. Open your tablet
5. Click on the PAL. Verify that the avatars don't freeze.
6. Close the PAL
7. Close the Tablet
8. Wait and verify that the avatars are still behaving as expected.