### PR TITLE
Fix for system toolbar hiding when scripts are reloaded

### DIFF
--- a/interface/resources/qml/hifi/toolbars/Toolbar.qml
+++ b/interface/resources/qml/hifi/toolbars/Toolbar.qml
@@ -120,6 +120,8 @@ Window {
     function addButton(properties) {
         properties = properties || {}
 
+        unpinnedAlpha = 1;
+
         // If a name is specified, then check if there's an existing button with that name
         // and return it if so.  This will allow multiple clients to listen to a single button,
         // and allow scripts to be idempotent so they don't duplicate buttons if they're reloaded
@@ -154,7 +156,7 @@ Window {
         updatePinned();
 
         if (buttons.length === 0) {
-            visible = false;
+            unpinnedAlpha = 0;
         }
     }
 


### PR DESCRIPTION
QA Test:  Toolbar should still be visible after reloading scripts CTRL-R.  Under the following conditions.
  * In desktop mode with Settings > General > Desktop Tablet becomes Toolbar set to true.  
  * In HMD mode with Settings > General > HMD Tablet becomes Toolbar set to true.