### PR TITLE
Make Debug defaultScripts.js option less error prone.

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -20,7 +20,7 @@ var DEFAULT_SCRIPTS = [
     "system/bubble.js",
     "system/snapshot.js",
     "system/help.js",
-    "system/pal.js", //"system/mod.js", // older UX, if you prefer
+    "system/pal.js", // "system/mod.js", // older UX, if you prefer
     "system/goto.js",
     "system/marketplaces/marketplaces.js",
     "system/edit.js",
@@ -54,9 +54,6 @@ if (previousSetting === true || previousSetting === 'true') {
     previousSetting = true;
 }
 
-
-
-
 if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_ITEM)) {
     Menu.addMenuItem({
         menuName: MENU_CATEGORY,
@@ -78,11 +75,11 @@ function runDefaultsSeparately() {
         Script.load(DEFAULT_SCRIPTS[i]);
     }
 }
+
 // start all scripts
 if (Menu.isOptionChecked(MENU_ITEM)) {
     // we're debugging individual default scripts
     // so we load each into its own ScriptEngine instance
-    debuggingDefaultScripts = true;
     runDefaultsSeparately();
 } else {
     // include all default scripts into this ScriptEngine
@@ -90,32 +87,14 @@ if (Menu.isOptionChecked(MENU_ITEM)) {
 }
 
 function menuItemEvent(menuItem) {
-    if (menuItem == MENU_ITEM) {
-
-        isChecked = Menu.isOptionChecked(MENU_ITEM);
+    if (menuItem === MENU_ITEM) {
+        var isChecked = Menu.isOptionChecked(MENU_ITEM);
         if (isChecked === true) {
             Settings.setValue(SETTINGS_KEY, true);
         } else if (isChecked === false) {
             Settings.setValue(SETTINGS_KEY, false);
         }
-         Window.alert('You must reload all scripts for this to take effect.')
-    }
-
-
-}
-
-
-
-function stopLoadedScripts() {
-        // remove debug script loads
-    var runningScripts = ScriptDiscoveryService.getRunning();
-    for (var i in runningScripts) {
-        var scriptName = runningScripts[i].name;
-        for (var j in DEFAULT_SCRIPTS) {
-            if (DEFAULT_SCRIPTS[j].slice(-scriptName.length) === scriptName) {
-                ScriptDiscoveryService.stopScript(runningScripts[i].url);
-            }
-        }
+        Window.alert('You must reload all scripts for this to take effect.');
     }
 }
 
@@ -126,7 +105,6 @@ function removeMenuItem() {
 }
 
 Script.scriptEnding.connect(function() {
-    stopLoadedScripts();
     removeMenuItem();
 });
 

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -94,7 +94,7 @@ function menuItemEvent(menuItem) {
         } else if (isChecked === false) {
             Settings.setValue(SETTINGS_KEY, false);
         }
-        Window.alert('You must reload all scripts for this to take effect.');
+        console.log('You must reload all scripts for this to take effect.');
     }
 }
 

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -94,7 +94,7 @@ function menuItemEvent(menuItem) {
         } else if (isChecked === false) {
             Settings.setValue(SETTINGS_KEY, false);
         }
-        console.log('You must reload all scripts for this to take effect.');
+        Menu.triggerOption("Reload All Scripts");
     }
 }
 


### PR DESCRIPTION
Previously, clicking Debug defaultScripts.js was somewhat dangerous.  It could result in deadlocks & crashes on exit.  To fix this I've made the following changes.

* No longer display an alert dialog directing the user to reload scripts.  We just go ahead and reload the scripts directly.  The alert dialog was causing the entire defaultScripts.js thread to block, causing hand controllers to not function anymore.
* No longer attempt to stop other running scripts when defaultScripts.js is shutting down.  This was causing a use after free crash on exit. It was causing raw ScriptEngine pointers to be stopped after they've already been deleted.
