### PR TITLE
fix avatars slightly out of view in large audience from freezing

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -384,18 +384,20 @@ void AvatarMixerSlave::broadcastAvatarData(const SharedNodePointer& node) {
             if (includeThisAvatar) {
                 numAvatarDataBytes += avatarPacketList->write(otherNode->getUUID().toRfc4122());
                 numAvatarDataBytes += avatarPacketList->write(bytes);
-                _stats.numOthersIncluded++;
 
-                // increment the number of avatars sent to this reciever
-                nodeData->incrementNumAvatarsSentLastFrame();
+                if (detail != AvatarData::NoData) {
+                    _stats.numOthersIncluded++;
 
-                // set the last sent sequence number for this sender on the receiver
-                nodeData->setLastBroadcastSequenceNumber(otherNode->getUUID(),
-                    otherNodeData->getLastReceivedSequenceNumber());
+                    // increment the number of avatars sent to this reciever
+                    nodeData->incrementNumAvatarsSentLastFrame();
 
-                // remember the last time we sent details about this other node to the receiver
-                nodeData->setLastBroadcastTime(otherNode->getUUID(), start);
+                    // set the last sent sequence number for this sender on the receiver
+                    nodeData->setLastBroadcastSequenceNumber(otherNode->getUUID(), 
+                                    otherNodeData->getLastReceivedSequenceNumber());
 
+                    // remember the last time we sent details about this other node to the receiver
+                    nodeData->setLastBroadcastTime(otherNode->getUUID(), start);
+                }
             }
 
             avatarPacketList->endSegment();


### PR DESCRIPTION
Don't count NoData avatars as having been broadcast, Basically a last minute optimization to my earlier PR caused a bug that slipped past us in our testing. The "NoData" case was sending the UUID/flags so that avatars didn't fall out of the hash list, but it was also marking them as being "sent"... which resulted in them not rising up into the priority to actually have their joints sent unless you were looking at them.

Test plan:
- Run at least 50 bots in a domain... look in the center of the crowd and notice that bots on your peripheral vision still update.
- in Master, the bots not in the center of your view will freeze. In this PR they animate.