### PR TITLE
Ensure complete population of allocated mip levels

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -168,7 +168,7 @@ public:
         //bool canPromoteNoAllocate() const { return _allocatedMip < _populatedMip; }
         bool canPromote() const { return _allocatedMip > 0; }
         bool canDemote() const { return _allocatedMip < _maxAllocatedMip; }
-        bool hasPendingTransfers() const { return !_pendingTransfers.empty(); }
+        bool hasPendingTransfers() const { return _populatedMip > _allocatedMip; }
         void executeNextTransfer(const TexturePointer& currentTexture);
         uint32 size() const override { return _size; }
         virtual void populateTransferQueue() = 0;

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -338,6 +338,7 @@ void GL45VariableAllocationTexture::updateMemoryPressure() {
         _transferQueue = WorkQueue();
         _promoteQueue = WorkQueue();
         _demoteQueue = WorkQueue();
+
         // Populate the existing textures into the queue
         for (const auto& texture : strongTextures) {
             addToWorkQueue(texture);
@@ -387,7 +388,7 @@ void GL45VariableAllocationTexture::processWorkQueues() {
     }
 
     if (workQueue.empty()) {
-        _memoryPressureState = MemoryPressureState::Idle;
+        _memoryPressureStateStale = true;
     }
 }
 
@@ -406,6 +407,14 @@ GL45VariableAllocationTexture::~GL45VariableAllocationTexture() {
 }
 
 void GL45VariableAllocationTexture::executeNextTransfer(const TexturePointer& currentTexture) {
+    if (_populatedMip <= _allocatedMip) {
+        return;
+    }
+
+    if (_pendingTransfers.empty()) {
+        populateTransferQueue();
+    }
+
     if (!_pendingTransfers.empty()) {
         // Keeping hold of a strong pointer during the transfer ensures that the transfer thread cannot try to access a destroyed texture
         _currentTransferTexture = currentTexture;


### PR DESCRIPTION
For some reason the pending transfer queues were running out of work even though not all the allocated mip levels were populated.  I've refactored the `hasPendingTransfers` method to simply compare the `_populatedMip` with the `_allocatedMip` since if they are not the same, the texture is implicitly not fully transferred.  I've also added code to the transfer logic to recreate the pending transfers queue if it's empty but logically should not be.

