### PR TITLE
Add pending texture transfer size to tracked stats

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -253,6 +253,9 @@ Item {
                         text: "  Decimated: " + root.decimatedTextureCount;
                     }
                     StatText {
+                        text: "  Pending Transfer: " + root.texturePendingTransfers + " MB";
+                    }
+                    StatText {
                         text: "  Resource Memory: " + root.gpuTextureMemory + " MB";
                     }
                     StatText {

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -321,6 +321,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(glContextSwapchainMemory, (int)BYTES_TO_MB(gl::Context::getSwapchainMemoryUsage()));
 
     STAT_UPDATE(qmlTextureMemory, (int)BYTES_TO_MB(OffscreenQmlSurface::getUsedTextureMemory()));
+    STAT_UPDATE(texturePendingTransfers, (int)BYTES_TO_MB(gpu::Texture::getTextureTransferPendingSize()));
     STAT_UPDATE(gpuTextureMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUMemoryUsage()));
     STAT_UPDATE(gpuTextureVirtualMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUVirtualMemoryUsage()));
     STAT_UPDATE(gpuTextureFramebufferMemory, (int)BYTES_TO_MB(gpu::Texture::getTextureGPUFramebufferMemoryUsage()));

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -105,6 +105,7 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, gpuTexturesSparse, 0)
     STATS_PROPERTY(int, glContextSwapchainMemory, 0)
     STATS_PROPERTY(int, qmlTextureMemory, 0)
+    STATS_PROPERTY(int, texturePendingTransfers, 0)
     STATS_PROPERTY(int, gpuTextureMemory, 0)
     STATS_PROPERTY(int, gpuTextureVirtualMemory, 0)
     STATS_PROPERTY(int, gpuTextureFramebufferMemory, 0)
@@ -210,6 +211,7 @@ signals:
     void timingStatsChanged();
     void glContextSwapchainMemoryChanged();
     void qmlTextureMemoryChanged();
+    void texturePendingTransfersChanged();
     void gpuBuffersChanged();
     void gpuBufferMemoryChanged();
     void gpuTexturesChanged();

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -128,6 +128,7 @@ public:
             TransferJob(const TransferJob& other) = delete;
             TransferJob(const GL45VariableAllocationTexture& parent, std::function<void()> transferLambda);
             TransferJob(const GL45VariableAllocationTexture& parent, uint16_t sourceMip, uint16_t targetMip, uint8_t face, uint32_t lines = 0, uint32_t lineOffset = 0);
+            ~TransferJob();
             bool tryTransfer();
 
 #if THREADED_TEXTURE_BUFFERING
@@ -136,6 +137,7 @@ public:
 #endif
 
         private:
+            size_t _transferSize { 0 };
 #if THREADED_TEXTURE_BUFFERING
             void startBuffering();
 #endif

--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -241,6 +241,7 @@ std::atomic<Buffer::Size> Context::_bufferGPUMemoryUsage { 0 };
 
 std::atomic<uint32_t> Context::_textureGPUCount{ 0 };
 std::atomic<uint32_t> Context::_textureGPUSparseCount { 0 };
+std::atomic<Texture::Size> Context::_textureTransferPendingSize { 0 };
 std::atomic<Texture::Size> Context::_textureGPUMemoryUsage { 0 };
 std::atomic<Texture::Size> Context::_textureGPUVirtualMemoryUsage { 0 };
 std::atomic<Texture::Size> Context::_textureGPUFramebufferMemoryUsage { 0 };
@@ -317,6 +318,17 @@ void Context::decrementTextureGPUSparseCount() {
     --_textureGPUSparseCount;
 }
 
+void Context::updateTextureTransferPendingSize(Size prevObjectSize, Size newObjectSize) {
+    if (prevObjectSize == newObjectSize) {
+        return;
+    }
+    if (newObjectSize > prevObjectSize) {
+        _textureTransferPendingSize.fetch_add(newObjectSize - prevObjectSize);
+    } else {
+        _textureTransferPendingSize.fetch_sub(prevObjectSize - newObjectSize);
+    }
+}
+
 void Context::updateTextureGPUMemoryUsage(Size prevObjectSize, Size newObjectSize) {
     if (prevObjectSize == newObjectSize) {
         return;
@@ -390,6 +402,10 @@ uint32_t Context::getTextureGPUSparseCount() {
     return _textureGPUSparseCount.load();
 }
 
+Context::Size Context::getTextureTransferPendingSize() {
+    return _textureTransferPendingSize.load();
+}
+
 Context::Size Context::getTextureGPUMemoryUsage() {
     return _textureGPUMemoryUsage.load();
 }
@@ -419,6 +435,7 @@ void Backend::incrementTextureGPUCount() { Context::incrementTextureGPUCount(); 
 void Backend::decrementTextureGPUCount() { Context::decrementTextureGPUCount(); }
 void Backend::incrementTextureGPUSparseCount() { Context::incrementTextureGPUSparseCount(); }
 void Backend::decrementTextureGPUSparseCount() { Context::decrementTextureGPUSparseCount(); }
+void Backend::updateTextureTransferPendingSize(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureTransferPendingSize(prevObjectSize, newObjectSize); }
 void Backend::updateTextureGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::updateTextureGPUVirtualMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUVirtualMemoryUsage(prevObjectSize, newObjectSize); }
 void Backend::updateTextureGPUFramebufferMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize) { Context::updateTextureGPUFramebufferMemoryUsage(prevObjectSize, newObjectSize); }

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -101,6 +101,7 @@ public:
     static void decrementTextureGPUCount();
     static void incrementTextureGPUSparseCount();
     static void decrementTextureGPUSparseCount();
+    static void updateTextureTransferPendingSize(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void updateTextureGPUMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void updateTextureGPUSparseMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
     static void updateTextureGPUVirtualMemoryUsage(Resource::Size prevObjectSize, Resource::Size newObjectSize);
@@ -220,6 +221,7 @@ public:
     static uint32_t getTextureGPUSparseCount();
     static Size getFreeGPUMemory();
     static Size getUsedGPUMemory();
+    static Size getTextureTransferPendingSize();
     static Size getTextureGPUMemoryUsage();
     static Size getTextureGPUVirtualMemoryUsage();
     static Size getTextureGPUFramebufferMemoryUsage();
@@ -263,6 +265,7 @@ protected:
     static void decrementTextureGPUCount();
     static void incrementTextureGPUSparseCount();
     static void decrementTextureGPUSparseCount();
+    static void updateTextureTransferPendingSize(Size prevObjectSize, Size newObjectSize);
     static void updateTextureGPUMemoryUsage(Size prevObjectSize, Size newObjectSize);
     static void updateTextureGPUSparseMemoryUsage(Size prevObjectSize, Size newObjectSize);
     static void updateTextureGPUVirtualMemoryUsage(Size prevObjectSize, Size newObjectSize);
@@ -279,6 +282,7 @@ protected:
 
     static std::atomic<uint32_t> _textureGPUCount;
     static std::atomic<uint32_t> _textureGPUSparseCount;
+    static std::atomic<Size> _textureTransferPendingSize;
     static std::atomic<Size> _textureGPUMemoryUsage;
     static std::atomic<Size> _textureGPUSparseMemoryUsage;
     static std::atomic<Size> _textureGPUVirtualMemoryUsage;

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -89,6 +89,10 @@ uint32_t Texture::getTextureGPUSparseCount() {
     return Context::getTextureGPUSparseCount();
 }
 
+Texture::Size Texture::getTextureTransferPendingSize() {
+    return Context::getTextureTransferPendingSize();
+}
+
 Texture::Size Texture::getTextureGPUMemoryUsage() {
     return Context::getTextureGPUMemoryUsage();
 }

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -166,6 +166,7 @@ public:
     static Size getTextureCPUMemoryUsage();
     static uint32_t getTextureGPUCount();
     static uint32_t getTextureGPUSparseCount();
+    static Size getTextureTransferPendingSize();
     static Size getTextureGPUMemoryUsage();
     static Size getTextureGPUVirtualMemoryUsage();
     static Size getTextureGPUFramebufferMemoryUsage();


### PR DESCRIPTION
Keeps track of how much texture memory we have to transfer to the GPU