### PR TITLE
increase max renderable web entity FPS to 30 for Youtube.com

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -37,6 +37,8 @@ static uint64_t MAX_NO_RENDER_INTERVAL = 30 * USECS_PER_SECOND;
 
 static int MAX_WINDOW_SIZE = 4096;
 static float OPAQUE_ALPHA_THRESHOLD = 0.99f;
+static int DEFAULT_MAX_FPS = 10;
+static int YOUTUBE_MAX_FPS = 30;
 
 EntityItemPointer RenderableWebEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
     EntityItemPointer entity{ new RenderableWebEntityItem(entityID) };
@@ -113,14 +115,7 @@ bool RenderableWebEntityItem::buildWebSurface(QSharedPointer<EntityTreeRenderer>
 
     // FIXME, the max FPS could be better managed by being dynamic (based on the number of current surfaces
     // and the current rendering load)
-
-    // We special case YouTube URLs since we know they are videos that we should play with at least 30 FPS.
-    if (QUrl(_sourceUrl).host().endsWith("youtube.com", Qt::CaseInsensitive)) {
-        _webSurface->setMaxFps(30);
-    } else {
-        _webSurface->setMaxFps(10);
-    }
-
+    _webSurface->setMaxFps(DEFAULT_MAX_FPS);
 
     // The lifetime of the QML surface MUST be managed by the main thread
     // Additionally, we MUST use local variables copied by value, rather than
@@ -263,11 +258,21 @@ void RenderableWebEntityItem::loadSourceURL() {
         _sourceUrl.toLower().endsWith(".htm") || _sourceUrl.toLower().endsWith(".html")) {
         _contentType = htmlContent;
         _webSurface->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "qml/controls/"));
+
+        // We special case YouTube URLs since we know they are videos that we should play with at least 30 FPS.
+        if (sourceUrl.host().endsWith("youtube.com", Qt::CaseInsensitive)) {
+            _webSurface->setMaxFps(YOUTUBE_MAX_FPS);
+        } else {
+            _webSurface->setMaxFps(DEFAULT_MAX_FPS);
+        }
+
         _webSurface->load("WebView.qml", [&](QQmlContext* context, QObject* obj) {
             context->setContextProperty("eventBridgeJavaScriptToInject", QVariant(_javaScriptToInject));
         });
         _webSurface->getRootItem()->setProperty("url", _sourceUrl);
         _webSurface->getRootContext()->setContextProperty("desktop", QVariant());
+
+
 
     } else {
         _contentType = qmlContent;

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -269,10 +269,9 @@ void RenderableWebEntityItem::loadSourceURL() {
         _webSurface->load("WebView.qml", [&](QQmlContext* context, QObject* obj) {
             context->setContextProperty("eventBridgeJavaScriptToInject", QVariant(_javaScriptToInject));
         });
+
         _webSurface->getRootItem()->setProperty("url", _sourceUrl);
         _webSurface->getRootContext()->setContextProperty("desktop", QVariant());
-
-
 
     } else {
         _contentType = qmlContent;

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -113,7 +113,7 @@ bool RenderableWebEntityItem::buildWebSurface(QSharedPointer<EntityTreeRenderer>
 
     // FIXME, the max FPS could be better managed by being dynamic (based on the number of current surfaces
     // and the current rendering load)
-    _webSurface->setMaxFps(10);
+    _webSurface->setMaxFps(30);
 
     // The lifetime of the QML surface MUST be managed by the main thread
     // Additionally, we MUST use local variables copied by value, rather than

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -113,7 +113,14 @@ bool RenderableWebEntityItem::buildWebSurface(QSharedPointer<EntityTreeRenderer>
 
     // FIXME, the max FPS could be better managed by being dynamic (based on the number of current surfaces
     // and the current rendering load)
-    _webSurface->setMaxFps(30);
+
+    // We special case YouTube URLs since we know they are videos that we should play with at least 30 FPS.
+    if (QUrl(_sourceUrl).host().endsWith("youtube.com", Qt::CaseInsensitive)) {
+        _webSurface->setMaxFps(30);
+    } else {
+        _webSurface->setMaxFps(10);
+    }
+
 
     // The lifetime of the QML surface MUST be managed by the main thread
     // Additionally, we MUST use local variables copied by value, rather than


### PR DESCRIPTION
#### Test Plan

Smoke test for performance in our domains and domains you normally visit. YouTube web entities will now render at a higher rate, so we want to make sure this doesn't adversely affect overall performance. 

Spawn a number of web entities playing YouTube videos. Note how each additional web entity affects performance and confirm the the YouTube videos play smoothly.

On master you should expect better performance for the same number of web entities, but video playback should be noticeably choppy.