### PR TITLE
Fix for Web Entity not leaving Focus

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1216,6 +1216,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         if (entity && entity->wantsKeyboardFocus()) {
             setKeyboardFocusOverlay(UNKNOWN_OVERLAY_ID);
             setKeyboardFocusEntity(entityItemID);
+        } else {
+            setKeyboardFocusEntity(UNKNOWN_ENTITY_ID);
         }
     });
 


### PR DESCRIPTION
Response to: https://highfidelity.fogbugz.com/f/cases/3183/Clicking-off-of-a-web-entity-doesn-t-take-the-web-entity-out-of-focus

When clicking outside of the web entity but into another entity, the web entity it would not leave focus. This removes focus even if you click on another entity that doesn't require keyboard focus.

Testing instructions: 
- Load a Web Entity
- Click into the entity to give it keyboard focus
- Click on a different entity and notice the web entity leaves focus (This would not happen on previous builds)