### PR TITLE
Fix Password Setting Bug

### DIFF
--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -996,6 +996,10 @@ function saveSettings() {
       if (password && password.length > 0) {
         formJSON["security"]["http_password"] = sha256_digest(password);
       }
+      var verify_password = formJSON["security"]["verify_http_password"];
+      if (verify_password && verify_password.length > 0) {
+        formJSON["security"]["verify_http_password"] = sha256_digest(verify_password);
+      }
     }
 
     // verify that the password and confirmation match before saving
@@ -1010,7 +1014,6 @@ function saveSettings() {
           bootbox.alert({"message": "Passwords must match!", "title":"Password Error"});
           canPost = false;
         } else {
-          formJSON["security"]["http_password"] = sha256_digest(password);
           delete formJSON["security"]["verify_http_password"];
         }
       }


### PR DESCRIPTION
Resolution to: https://highfidelity.fogbugz.com/f/cases/3227/Unable-to-set-password-for-domain-server-web-control-interface

The form was comparing a hashed version of password and a non-hashed version of verified_password, which means that they would never match. Also it was saving a double hash of the password.

Testing instructions:
- Start domain server, and go to security
- Set a username and password
- Verify that it does not error saying mismatched passwords
- Verify that you can log in with username/password