### PR TITLE
Fix avatar lean

### DIFF
--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -488,13 +488,7 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
                 // measure new _hipsOffset for next frame
                 // by looking for discrepancies between where a targeted endEffector is
                 // and where it wants to be (after IK solutions are done)
-
-                // use weighted average between HMD and other targets
-                float HMD_WEIGHT = 10.0f;
-                float OTHER_WEIGHT = 1.0f;
-                float totalWeight = 0.0f;
-
-                glm::vec3 additionalHipsOffset = Vectors::ZERO;
+                glm::vec3 newHipsOffset = Vectors::ZERO;
                 for (auto& target: targets) {
                     int targetIndex = target.getIndex();
                     if (targetIndex == _headIndex && _headIndex != -1) {
@@ -505,42 +499,34 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
                             glm::vec3 under = _skeleton->getAbsolutePose(_headIndex, underPoses).trans();
                             glm::vec3 actual = _skeleton->getAbsolutePose(_headIndex, _relativePoses).trans();
                             const float HEAD_OFFSET_SLAVE_FACTOR = 0.65f;
-                            additionalHipsOffset += (OTHER_WEIGHT * HEAD_OFFSET_SLAVE_FACTOR) * (under- actual);
-                            totalWeight += OTHER_WEIGHT;
+                            newHipsOffset += HEAD_OFFSET_SLAVE_FACTOR * (actual - under);
                         } else if (target.getType() == IKTarget::Type::HmdHead) {
+                            // we want to shift the hips to bring the head to its designated position
                             glm::vec3 actual = _skeleton->getAbsolutePose(_headIndex, _relativePoses).trans();
-                            glm::vec3 thisOffset = target.getTranslation() - actual;
-                            glm::vec3 futureHipsOffset = _hipsOffset + thisOffset;
-                            if (glm::length(glm::vec2(futureHipsOffset.x, futureHipsOffset.z)) < _maxHipsOffsetLength) {
-                                // it is imperative to shift the hips and bring the head to its designated position
-                                // so we slam newHipsOffset here and ignore all other targets
-                                additionalHipsOffset = futureHipsOffset - _hipsOffset;
-                                totalWeight = 0.0f;
-                                break;
-                            } else {
-                                additionalHipsOffset += HMD_WEIGHT * (target.getTranslation() - actual);
-                                totalWeight += HMD_WEIGHT;
-                            }
+                            _hipsOffset += target.getTranslation() - actual;
+                            // and ignore all other targets
+                            newHipsOffset = _hipsOffset;
+                            break;
+                        } else if (target.getType() == IKTarget::Type::RotationAndPosition) {
+                            glm::vec3 actualPosition = _skeleton->getAbsolutePose(targetIndex, _relativePoses).trans();
+                            glm::vec3 targetPosition = target.getTranslation();
+                            newHipsOffset += targetPosition - actualPosition;
+
+                            // Add downward pressure on the hips
+                            newHipsOffset *= 0.95f;
+                            newHipsOffset -= 1.0f;
                         }
                     } else if (target.getType() == IKTarget::Type::RotationAndPosition) {
                         glm::vec3 actualPosition = _skeleton->getAbsolutePose(targetIndex, _relativePoses).trans();
                         glm::vec3 targetPosition = target.getTranslation();
-                        additionalHipsOffset += OTHER_WEIGHT * (targetPosition - actualPosition);
-                        totalWeight += OTHER_WEIGHT;
+                        newHipsOffset += targetPosition - actualPosition;
                     }
                 }
-                if (totalWeight > 1.0f) {
-                    additionalHipsOffset /= totalWeight;
-                }
-
-                // Add downward pressure on the hips
-                additionalHipsOffset *= 0.95f;
-                additionalHipsOffset -= 1.0f;
 
                 // smooth transitions by relaxing _hipsOffset toward the new value
                 const float HIPS_OFFSET_SLAVE_TIMESCALE = 0.10f;
                 float tau = dt < HIPS_OFFSET_SLAVE_TIMESCALE ?  dt / HIPS_OFFSET_SLAVE_TIMESCALE : 1.0f;
-                _hipsOffset += additionalHipsOffset * tau;
+                _hipsOffset += (newHipsOffset - _hipsOffset) * tau;
 
                 // clamp the hips offset
                 float hipsOffsetLength = glm::length(_hipsOffset);


### PR DESCRIPTION
This fixes a lean in the avatar idle animations that was amplified by the IK.

- Remove weighted average pulled from the out of body branch
- Special case downward pressure when the head target type is position and rotation.


## Test plan:
- This PR should only have a slight lean on the left leg compared to the big on on the current master. 
- Make sure seats in dev-demo still function as expected
