### PR TITLE
Avatar Recorder and Playback Fixes

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -154,9 +154,12 @@ MyAvatar::MyAvatar(RigPointer rig) :
             if (recordingInterface->getPlayFromCurrentLocation()) {
                 setRecordingBasis();
             }
+            _wasCharacterControllerEnabled = _characterController.isEnabled();
+            _characterController.setEnabled(false);
         } else {
             clearRecordingBasis();
             useFullAvatarURL(_fullAvatarURLFromPreferences, _fullAvatarModelName);
+            _characterController.setEnabled(_wasCharacterControllerEnabled);
         }
 
         auto audioIO = DependencyManager::get<AudioClient>();

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -411,6 +411,7 @@ private:
     SharedSoundPointer _collisionSound;
 
     MyCharacterController _characterController;
+    bool _wasCharacterControllerEnabled { true };
 
     AvatarWeakPointer _lookAtTargetAvatar;
     glm::vec3 _targetAvatarPosition;

--- a/libraries/recording/src/recording/Deck.cpp
+++ b/libraries/recording/src/recording/Deck.cpp
@@ -154,8 +154,8 @@ void Deck::processFrames() {
             // if doing relative movement
             emit looped();
         } else {
-            // otherwise pause playback
-            pause();
+            // otherwise stop playback
+            stop();
         }
         return;
     } 

--- a/libraries/recording/src/recording/Deck.cpp
+++ b/libraries/recording/src/recording/Deck.cpp
@@ -33,6 +33,7 @@ void Deck::queueClip(ClipPointer clip, float timeOffset) {
 
     // FIXME disabling multiple clips for now
     _clips.clear();
+    _length = 0.0f;
 
     // if the time offset is not zero, wrap in an OffsetClip
     if (timeOffset != 0.0f) {

--- a/scripts/developer/utilities/record/recorder.js
+++ b/scripts/developer/utilities/record/recorder.js
@@ -90,7 +90,7 @@ function setupToolBar() {
         visible: true
     }, false);
     
-    timerOffset = toolBar.width;
+    timerOffset = toolBar.width + ToolBar.SPACING;
     spacing = toolBar.addSpacing(0);
     
     saveIcon = toolBar.addTool({
@@ -116,8 +116,8 @@ function setupTimer() {
         text: (0.00).toFixed(3),
         backgroundColor: COLOR_OFF,
         x: 0, y: 0,
-        width: 200, height: 37,
-        leftMargin: 5, topMargin: 10,
+        width: 200, height: 25,
+        leftMargin: 5, topMargin: 3,
         alpha: 1.0, backgroundAlpha: 1.0,
         visible: true
     });
@@ -149,10 +149,9 @@ function setupTimer() {
 }
 
 function onToolbarMove(newX, newY, deltaX, deltaY) {
-    print(newX);
     Overlays.editOverlay(timer, {
         x: newX + timerOffset - ToolBar.SPACING,
-        y: newY - ToolBar.SPACING
+        y: newY
     });
     
     slider.x = newX - ToolBar.SPACING;
@@ -182,7 +181,7 @@ function updateTimer() {
         text: text,
         width: timerWidth
     });
-    toolBar.changeSpacing(timerWidth, spacing);
+    toolBar.changeSpacing(timerWidth + ToolBar.SPACING, spacing);
     
     if (Recording.isRecording()) {
         slider.pos = 1.0;

--- a/scripts/developer/utilities/record/recorder.js
+++ b/scripts/developer/utilities/record/recorder.js
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+/* globals HIFI_PUBLIC_BUCKET:true, Tool, ToolBar */
+
 HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
 Script.include("/~/system/libraries/toolBars.js");
 
@@ -47,7 +49,7 @@ setupTimer();
 var watchStop = false;
 
 function setupToolBar() {
-    if (toolBar != null) {
+    if (toolBar !== null) {
         print("Multiple calls to Recorder.js:setupToolBar()");
         return;
     }
@@ -112,15 +114,15 @@ function setupTimer() {
         text: (0.00).toFixed(3),
         backgroundColor: COLOR_OFF,
         x: 0, y: 0,
-        width: 0, height: 0,
-        leftMargin: 10, topMargin: 10,
+        width: 200, height: 37,
+        leftMargin: 5, topMargin: 10,
         alpha: 1.0, backgroundAlpha: 1.0,
         visible: true
     });
 
     slider = { x: 0, y: 0,
         w: 200, h: 20,
-        pos: 0.0, // 0.0 <= pos <= 1.0
+        pos: 0.0 // 0.0 <= pos <= 1.0
     };
     slider.background = Overlays.addOverlay("text", {
         text: "",
@@ -148,16 +150,17 @@ function updateTimer() {
     var text = "";
     if (Recording.isRecording()) {
         text = formatTime(Recording.recorderElapsed());
-        
     } else {
-        text = formatTime(Recording.playerElapsed()) + " / " +
-        formatTime(Recording.playerLength());
+        text = formatTime(Recording.playerElapsed()) + " / " + formatTime(Recording.playerLength());
     }
 
+    var timerWidth = text.length * 8 + ((Recording.isRecording()) ? 15 : 0);
+
     Overlays.editOverlay(timer, {
-        text: text
-    })
-    toolBar.changeSpacing(text.length * 8 + ((Recording.isRecording()) ? 15 : 0), spacing);
+        text: text,
+        width: timerWidth
+    });
+    toolBar.changeSpacing(timerWidth, spacing);
     
     if (Recording.isRecording()) {
         slider.pos = 1.0;
@@ -173,7 +176,7 @@ function updateTimer() {
 function formatTime(time) {
     var MIN_PER_HOUR = 60;
     var SEC_PER_MIN = 60;
-    var MSEC_PER_SEC = 1000;
+    var MSEC_DIGITS = 3;
 
     var hours = Math.floor(time / (SEC_PER_MIN * MIN_PER_HOUR));
     time -= hours * (SEC_PER_MIN * MIN_PER_HOUR);
@@ -184,11 +187,9 @@ function formatTime(time) {
     var seconds = time;
 
     var text = "";
-    text += (hours > 0) ? hours + ":" :
-    "";
-    text += (minutes > 0) ? ((minutes < 10 && text != "") ? "0" : "") + minutes + ":" :
-    "";
-    text += ((seconds < 10 && text != "") ? "0" : "") + seconds.toFixed(3);
+    text += (hours > 0) ? hours + ":" : "";
+    text += (minutes > 0) ? ((minutes < 10 && text !== "") ? "0" : "") + minutes + ":" : "";
+    text += ((seconds < 10 && text !== "") ? "0" : "") + seconds.toFixed(MSEC_DIGITS);
     return text;
 }
 
@@ -205,16 +206,16 @@ function moveUI() {
     
     Overlays.editOverlay(slider.background, {
         x: slider.x,
-        y: slider.y,
+        y: slider.y
     });
     Overlays.editOverlay(slider.foreground, {
         x: slider.x,
-        y: slider.y,
+        y: slider.y
     });
 }
 
 function mousePressEvent(event) {
-    clickedOverlay = Overlays.getOverlayAtPoint({ x: event.x, y: event.y });
+    var clickedOverlay = Overlays.getOverlayAtPoint({ x: event.x, y: event.y });
     
     if (recordIcon === toolBar.clicked(clickedOverlay, false) && !Recording.isPlaying()) {
         if (!Recording.isRecording()) {
@@ -226,7 +227,8 @@ function mousePressEvent(event) {
             toolBar.setAlpha(ALPHA_OFF, loadIcon);
         } else {
             Recording.stopRecording();
-            toolBar.selectTool(recordIcon, true );
+            toolBar.selectTool(recordIcon, true);
+            Recording.setPlayerTime(0);
             Recording.loadLastRecording();
             toolBar.setAlpha(ALPHA_ON, playIcon);
             toolBar.setAlpha(ALPHA_ON, playLoopIcon);
@@ -263,7 +265,7 @@ function mousePressEvent(event) {
             toolBar.setAlpha(ALPHA_OFF, loadIcon);
         }
     } else if (saveIcon === toolBar.clicked(clickedOverlay)) {
-        if (!Recording.isRecording() && !Recording.isPlaying() && Recording.playerLength() != 0) {
+        if (!Recording.isRecording() && !Recording.isPlaying() && Recording.playerLength() !== 0) {
             recordingFile = Window.save("Save recording to file", ".", "Recordings (*.hfr)");
             if (!(recordingFile === "null" || recordingFile === null || recordingFile === "")) {
                 Recording.saveRecording(recordingFile);
@@ -282,8 +284,8 @@ function mousePressEvent(event) {
             }
         }
     } else if (Recording.playerLength() > 0 &&
-    slider.x < event.x && event.x < slider.x + slider.w &&
-    slider.y < event.y && event.y < slider.y + slider.h) {
+               slider.x < event.x && event.x < slider.x + slider.w &&
+               slider.y < event.y && event.y < slider.y + slider.h) {
         isSliding = true;
         slider.pos = (event.x - slider.x) / slider.w;
         Recording.setPlayerTime(slider.pos * Recording.playerLength());
@@ -308,7 +310,7 @@ function mouseReleaseEvent(event) {
 
 function update() {
     var newDimensions = Controller.getViewportDimensions();
-    if (windowDimensions.x != newDimensions.x || windowDimensions.y != newDimensions.y) {
+    if (windowDimensions.x !== newDimensions.x || windowDimensions.y !== newDimensions.y) {
         windowDimensions = newDimensions;
         moveUI();
     }

--- a/scripts/developer/utilities/record/recorder.js
+++ b/scripts/developer/utilities/record/recorder.js
@@ -16,7 +16,7 @@ Script.include("/~/system/libraries/toolBars.js");
 
 var recordingFile = "recording.hfr";
 
-function setPlayerOptions() {
+function setDefaultPlayerOptions() {
     Recording.setPlayFromCurrentLocation(true);
     Recording.setPlayerUseDisplayName(false);
     Recording.setPlayerUseAttachments(false);
@@ -40,10 +40,10 @@ var saveIcon;
 var loadIcon;
 var spacing;
 var timerOffset;
-setupToolBar();
-
 var timer = null;
 var slider = null;
+
+setupToolBar();
 setupTimer();
 
 var watchStop = false;
@@ -58,6 +58,8 @@ function setupToolBar() {
     
     toolBar = new ToolBar(0, 0, ToolBar.HORIZONTAL);
     
+    toolBar.onMove = onToolbarMove;
+
     toolBar.setBack(COLOR_TOOL_BAR, ALPHA_OFF);
     
     recordIcon = toolBar.addTool({
@@ -146,6 +148,26 @@ function setupTimer() {
     });
 }
 
+function onToolbarMove(newX, newY, deltaX, deltaY) {
+    print(newX);
+    Overlays.editOverlay(timer, {
+        x: newX + timerOffset - ToolBar.SPACING,
+        y: newY - ToolBar.SPACING
+    });
+    
+    slider.x = newX - ToolBar.SPACING;
+    slider.y = newY - slider.h - ToolBar.SPACING;
+    
+    Overlays.editOverlay(slider.background, {
+        x: slider.x,
+        y: slider.y
+    });
+    Overlays.editOverlay(slider.foreground, {
+        x: slider.x,
+        y: slider.y
+    });
+}
+
 function updateTimer() {
     var text = "";
     if (Recording.isRecording()) {
@@ -196,22 +218,6 @@ function formatTime(time) {
 function moveUI() {
     var relative = { x: 70, y: 40 };
     toolBar.move(relative.x, windowDimensions.y - relative.y);
-    Overlays.editOverlay(timer, {
-        x: relative.x + timerOffset - ToolBar.SPACING,
-        y: windowDimensions.y - relative.y - ToolBar.SPACING
-    });
-    
-    slider.x = relative.x - ToolBar.SPACING;
-    slider.y = windowDimensions.y - relative.y - slider.h - ToolBar.SPACING;
-    
-    Overlays.editOverlay(slider.background, {
-        x: slider.x,
-        y: slider.y
-    });
-    Overlays.editOverlay(slider.foreground, {
-        x: slider.x,
-        y: slider.y
-    });
 }
 
 function mousePressEvent(event) {
@@ -228,6 +234,9 @@ function mousePressEvent(event) {
         } else {
             Recording.stopRecording();
             toolBar.selectTool(recordIcon, true);
+            setDefaultPlayerOptions();
+            // Plays the recording at the same spot as you recorded it
+            Recording.setPlayFromCurrentLocation(false);
             Recording.setPlayerTime(0);
             Recording.loadLastRecording();
             toolBar.setAlpha(ALPHA_ON, playIcon);
@@ -242,7 +251,6 @@ function mousePressEvent(event) {
             toolBar.setAlpha(ALPHA_ON, saveIcon);
             toolBar.setAlpha(ALPHA_ON, loadIcon);
         } else if (Recording.playerLength() > 0) {
-            setPlayerOptions();
             Recording.setPlayerLoop(false);
             Recording.startPlaying();
             toolBar.setAlpha(ALPHA_OFF, recordIcon);
@@ -257,7 +265,6 @@ function mousePressEvent(event) {
             toolBar.setAlpha(ALPHA_ON, saveIcon);
             toolBar.setAlpha(ALPHA_ON, loadIcon);
         } else if (Recording.playerLength() > 0) {
-            setPlayerOptions();
             Recording.setPlayerLoop(true);
             Recording.startPlaying();
             toolBar.setAlpha(ALPHA_OFF, recordIcon);
@@ -276,6 +283,7 @@ function mousePressEvent(event) {
             recordingFile = Window.browse("Load recording from file", ".", "Recordings (*.hfr *.rec *.HFR *.REC)");
             if (!(recordingFile === "null" || recordingFile === null || recordingFile === "")) {
                 Recording.loadRecording(recordingFile);
+                setDefaultPlayerOptions();
             }
             if (Recording.playerLength() > 0) {
                 toolBar.setAlpha(ALPHA_ON, playIcon);

--- a/scripts/system/libraries/toolBars.js
+++ b/scripts/system/libraries/toolBars.js
@@ -160,6 +160,7 @@ ToolBar = function(x, y, direction, optionalPersistenceKey, optionalInitialPosit
                     visible: false
                 });
     this.spacing = [];
+    this.onMove = null;
     
     this.addTool = function(properties, selectable, selected) {
         if (direction == ToolBar.HORIZONTAL) {
@@ -254,6 +255,9 @@ ToolBar = function(x, y, direction, optionalPersistenceKey, optionalInitialPosit
                 y: y - ToolBar.SPACING
             });
         }
+        if (this.onMove !== null) {
+            this.onMove(x, y, dx, dy);
+        };
     }
 
     this.setAlpha = function(alpha, tool) {


### PR DESCRIPTION
- Fixes the clip length display.
- Disables the avatars physics during a playback.
- Stops the clip after the clip reaches the end rather than pausing it. (Makes it easier to hit play again)
- Fixed the timer display, which was hidden because it was too small.
- Made the timer and slider to follow the toolbar.

## QA Test

- Test if the `developer/utilities/record/recorder.js` script works as expected.
- Test using this QA build.
- Try recording with walking and without walking. Also saving and loading recordings should be still functional.