### PR TITLE
Add double click message support to entities and overlays

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3174,7 +3174,23 @@ void Application::mousePressEvent(QMouseEvent* event) {
     }
 }
 
-void Application::mouseDoublePressEvent(QMouseEvent* event) const {
+void Application::mouseDoublePressEvent(QMouseEvent* event) {
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    auto eventPosition = getApplicationCompositor().getMouseEventPosition(event);
+    QPointF transformedPos = offscreenUi->mapToVirtualScreen(eventPosition, _glWidget);
+    QMouseEvent mappedEvent(event->type(),
+        transformedPos,
+        event->screenPos(), event->button(),
+        event->buttons(), event->modifiers());
+
+    if (!_aboutToQuit) {
+        getOverlays().mouseDoublePressEvent(&mappedEvent);
+        if (!_controllerScriptingInterface->areEntityClicksCaptured()) {
+            getEntities()->mouseDoublePressEvent(&mappedEvent);
+        }
+    }
+
+
     // if one of our scripts have asked to capture this event, then stop processing it
     if (_controllerScriptingInterface->isMouseCaptured()) {
         return;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -494,7 +494,7 @@ private:
 
     void mouseMoveEvent(QMouseEvent* event);
     void mousePressEvent(QMouseEvent* event);
-    void mouseDoublePressEvent(QMouseEvent* event) const;
+    void mouseDoublePressEvent(QMouseEvent* event);
     void mouseReleaseEvent(QMouseEvent* event);
 
     void touchBeginEvent(QTouchEvent* event);

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -769,6 +769,26 @@ bool Overlays::mousePressEvent(QMouseEvent* event) {
     return false;
 }
 
+bool Overlays::mouseDoublePressEvent(QMouseEvent* event) {
+    PerformanceTimer perfTimer("Overlays::mouseDoublePressEvent");
+
+    PickRay ray = qApp->computePickRay(event->x(), event->y());
+    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionForMouseEvent(ray);
+    if (rayPickResult.intersects) {
+        _currentClickingOnOverlayID = rayPickResult.overlayID;
+
+        // Only Web overlays can have focus.
+        auto thisOverlay = std::dynamic_pointer_cast<Web3DOverlay>(getOverlay(_currentClickingOnOverlayID));
+        if (thisOverlay) {
+            auto pointerEvent = calculatePointerEvent(thisOverlay, ray, rayPickResult, event, PointerEvent::Press);
+            emit mouseDoublePressOnOverlay(_currentClickingOnOverlayID, pointerEvent);
+            return true;
+        }
+    }
+    emit mouseDoublePressOffOverlay();
+    return false;
+}
+
 bool Overlays::mouseReleaseEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mouseReleaseEvent");
 

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -101,6 +101,7 @@ public:
     OverlayID addOverlay(Overlay::Pointer overlay);
 
     bool mousePressEvent(QMouseEvent* event);
+    bool mouseDoublePressEvent(QMouseEvent* event);
     bool mouseReleaseEvent(QMouseEvent* event);
     bool mouseMoveEvent(QMouseEvent* event);
 
@@ -300,9 +301,11 @@ signals:
     void panelDeleted(OverlayID id);
 
     void mousePressOnOverlay(OverlayID overlayID, const PointerEvent& event);
+    void mouseDoublePressOnOverlay(OverlayID overlayID, const PointerEvent& event);
     void mouseReleaseOnOverlay(OverlayID overlayID, const PointerEvent& event);
     void mouseMoveOnOverlay(OverlayID overlayID, const PointerEvent& event);
     void mousePressOffOverlay();
+    void mouseDoublePressOffOverlay();
 
     void hoverEnterOverlay(OverlayID overlayID, const PointerEvent& event);
     void hoverOverOverlay(OverlayID overlayID, const PointerEvent& event);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -90,6 +90,7 @@ public:
     // event handles which may generate entity related events
     void mouseReleaseEvent(QMouseEvent* event);
     void mousePressEvent(QMouseEvent* event);
+    void mouseDoublePressEvent(QMouseEvent* event);
     void mouseMoveEvent(QMouseEvent* event);
 
     /// connect our signals to anEntityScriptingInterface for firing of events related clicking,
@@ -103,9 +104,11 @@ public:
 
 signals:
     void mousePressOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
+    void mouseDoublePressOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
     void mouseMoveOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
     void mouseReleaseOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
     void mousePressOffEntity();
+    void mouseDoublePressOffEntity();
 
     void clickDownOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
     void holdingClickOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);

--- a/libraries/shared/src/PointerEvent.cpp
+++ b/libraries/shared/src/PointerEvent.cpp
@@ -47,6 +47,9 @@ QScriptValue PointerEvent::toScriptValue(QScriptEngine* engine, const PointerEve
     case Press:
         obj.setProperty("type", "Press");
         break;
+    case DoublePress:
+        obj.setProperty("type", "DoublePress");
+        break;
     case Release:
         obj.setProperty("type", "Release");
         break;
@@ -128,6 +131,8 @@ void PointerEvent::fromScriptValue(const QScriptValue& object, PointerEvent& eve
         QString typeStr = type.isString() ? type.toString() : "Move";
         if (typeStr == "Press") {
             event._type = Press;
+        } else if (typeStr == "DoublePress") {
+            event._type = DoublePress;
         } else if (typeStr == "Release") {
             event._type = Release;
         } else {

--- a/libraries/shared/src/PointerEvent.h
+++ b/libraries/shared/src/PointerEvent.h
@@ -26,9 +26,10 @@ public:
     };
 
     enum EventType {
-        Press,     // A button has just been pressed
-        Release,   // A button has just been released
-        Move       // The pointer has just moved
+        Press,       // A button has just been pressed
+        DoublePress, // A button has just been double pressed
+        Release,     // A button has just been released
+        Move         // The pointer has just moved
     };
 
     PointerEvent();

--- a/script-archive/entityScripts/doubleClickExample.js
+++ b/script-archive/entityScripts/doubleClickExample.js
@@ -1,0 +1,19 @@
+(function() {
+    var _this;
+    function DoubleClickExample() {
+        _this = this;
+        return;
+    }
+
+    DoubleClickExample.prototype = {
+        clickDownOnEntity: function() {
+            print("clickDownOnEntity");
+        },
+
+        doubleclickOnEntity: function() {
+            print("doubleclickOnEntity");
+        }
+
+    };
+    return new DoubleClickExample();
+});


### PR DESCRIPTION
Test plan:
- smoke test
- add [this script](https://raw.githubusercontent.com/ZappoMan/hifi/d7c3677b2211bd3b906bbf40c1d23b61f827b2d5/script-archive/entityScripts/doubleClickExample.js) to an entity, and double click on the entity, see that in the log you get the following output:
```
[03/07 17:58:00] [DEBUG] [hifi.scriptengine.script] script:print()<< clickDownOnEntity
[03/07 17:58:00] [DEBUG] [hifi.scriptengine.script] script:print()<< doubleclickOnEntity
```