### PR TITLE
Fixed having more than one tablet when reloading scripts

### DIFF
--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -131,7 +131,9 @@
     }
 
     Script.scriptEnding.connect(function () {
-        Entities.deleteEntity(HMD.tabletID);
+        var tabletID = HMD.tabletID;
+        Entities.deleteEntity(tabletID);
+        Overlays.deleteOverlay(tabletID)
         HMD.tabletID = null;
         HMD.homeButtonID = null;
         HMD.tabletScreenID = null;


### PR DESCRIPTION
Made sure to delete the overlay or entity tablet when reloading scripts