### PR TITLE
improved noise gate

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1052,7 +1052,12 @@ void AudioClient::handleAudioInput() {
         auto packetType = _shouldEchoToServer ?
             PacketType::MicrophoneAudioWithEcho : PacketType::MicrophoneAudioNoEcho;
 
-        if (_lastInputLoudness == 0) {
+        // if the _inputGate closed in this last frame, then we don't actually want
+        // to send a silent packet, instead, we want to go ahead and encode and send
+        // the output from the input gate (eventually, this could be crossfaded)
+        // and allow the codec to properly encode down to silent/zero. If we still
+        // have _lastInputLoudness of 0 in our NEXT frame, we will send a silent packet
+        if (_lastInputLoudness == 0 && !_inputGate.closedInLastFrame()) {
             packetType = PacketType::SilentAudioFrame;
         }
         Transform audioTransform;

--- a/libraries/audio-client/src/AudioNoiseGate.cpp
+++ b/libraries/audio-client/src/AudioNoiseGate.cpp
@@ -58,8 +58,6 @@ void AudioNoiseGate::removeDCOffset(int16_t* samples, int numSamples) {
     }
 }
 
-#include <QDebug>
-
 void AudioNoiseGate::gateSamples(int16_t* samples, int numSamples) {
     //
     //  Impose Noise Gate

--- a/libraries/audio-client/src/AudioNoiseGate.cpp
+++ b/libraries/audio-client/src/AudioNoiseGate.cpp
@@ -77,8 +77,6 @@ void AudioNoiseGate::gateSamples(int16_t* samples, int numSamples) {
     //                      More means better rejection but also can reject continuous things like singing.
     // NUMBER_OF_NOISE_SAMPLE_FRAMES:  How often should we re-evaluate the noise floor?
 
-    _closedInLastFrame = false;
-    
     float loudness = 0;
     int thisSample = 0;
     int samplesOverNoiseGate = 0;
@@ -142,14 +140,13 @@ void AudioNoiseGate::gateSamples(int16_t* samples, int numSamples) {
         _sampleCounter = 0;
         
     }
+
     if (samplesOverNoiseGate > NOISE_GATE_WIDTH) {
         _isOpen = true;
         _framesToClose = NOISE_GATE_CLOSE_FRAME_DELAY;
     } else {
         if (--_framesToClose == 0) {
-            if (_isOpen) {
-                _closedInLastFrame = true;
-            }
+            _closedInLastFrame = !_isOpen;
             _isOpen = false;
         }
     }

--- a/libraries/audio-client/src/AudioNoiseGate.cpp
+++ b/libraries/audio-client/src/AudioNoiseGate.cpp
@@ -58,6 +58,7 @@ void AudioNoiseGate::removeDCOffset(int16_t* samples, int numSamples) {
     }
 }
 
+#include <QDebug>
 
 void AudioNoiseGate::gateSamples(int16_t* samples, int numSamples) {
     //
@@ -77,7 +78,8 @@ void AudioNoiseGate::gateSamples(int16_t* samples, int numSamples) {
     //  NOISE_GATE_FRAMES_TO_AVERAGE:  How many audio frames should we average together to compute noise floor.
     //                      More means better rejection but also can reject continuous things like singing.
     // NUMBER_OF_NOISE_SAMPLE_FRAMES:  How often should we re-evaluate the noise floor?
-    
+
+    _closedInLastFrame = false;
     
     float loudness = 0;
     int thisSample = 0;
@@ -147,6 +149,9 @@ void AudioNoiseGate::gateSamples(int16_t* samples, int numSamples) {
         _framesToClose = NOISE_GATE_CLOSE_FRAME_DELAY;
     } else {
         if (--_framesToClose == 0) {
+            if (_isOpen) {
+                _closedInLastFrame = true;
+            }
             _isOpen = false;
         }
     }

--- a/libraries/audio-client/src/AudioNoiseGate.h
+++ b/libraries/audio-client/src/AudioNoiseGate.h
@@ -24,6 +24,10 @@ public:
     void removeDCOffset(int16_t* samples, int numSamples);
     
     bool clippedInLastFrame() const { return _didClipInLastFrame; }
+
+    bool closedInLastFrame() const { return _closedInLastFrame; }
+
+    bool isOpen() const { return _isOpen; }
     float getMeasuredFloor() const { return _measuredFloor; }
     float getLastLoudness() const { return _lastLoudness; }
     
@@ -40,6 +44,7 @@ private:
     float _sampleFrames[NUMBER_OF_NOISE_SAMPLE_FRAMES];
     int _sampleCounter;
     bool _isOpen;
+    bool _closedInLastFrame { false };
     int _framesToClose;
 };
 

--- a/libraries/audio-client/src/AudioNoiseGate.h
+++ b/libraries/audio-client/src/AudioNoiseGate.h
@@ -24,10 +24,7 @@ public:
     void removeDCOffset(int16_t* samples, int numSamples);
     
     bool clippedInLastFrame() const { return _didClipInLastFrame; }
-
     bool closedInLastFrame() const { return _closedInLastFrame; }
-
-    bool isOpen() const { return _isOpen; }
     float getMeasuredFloor() const { return _measuredFloor; }
     float getLastLoudness() const { return _lastLoudness; }
     

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -163,7 +163,7 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
 
                     // Since the data in the stream is using a codec that we aren't prepared for,
                     // we need to let the codec know that we don't have data for it, this will
-                    // allowe the codec to interpolate missing data and produce a fade to silence.
+                    // allow the codec to interpolate missing data and produce a fade to silence.
                     lostAudioData(1);
 
                     // inform others of the mismatch
@@ -248,7 +248,7 @@ int InboundAudioStream::parseAudioData(PacketType type, const QByteArray& packet
 int InboundAudioStream::writeDroppableSilentFrames(int silentFrames) {
 
     // We can't guarentee that all clients have faded the stream down
-    // to silence and encoding that silence before sending us a 
+    // to silence and encoded that silence before sending us a 
     // SilentAudioFrame. If the encoder has truncated the stream it will
     // leave the decoder holding some unknown loud state. To handle this 
     // case we will call the decoder's lostFrame() method, which indicates

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -137,7 +137,7 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
         }
         case SequenceNumberStats::Early: {
             // Packet is early. Treat the packets as if all the packets between the last
-            // OnTime packet and this packet was lost. If we're using a codec this will 
+            // OnTime packet and this packet were lost. If we're using a codec this will 
             // also result in allowing the codec to interpolate lost data. Then
             // fall through to the "on time" logic to actually handle this packet
             int packetsDropped = arrivalInfo._seqDiffFromExpected;
@@ -161,9 +161,9 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
                 } else {
                     qDebug(audio) << "Codec mismatch: expected" << _selectedCodecName << "got" << codecInPacket << "writing silence";
 
-                    // Since the data in the stream is using a codec that we're not prepared for,
+                    // Since the data in the stream is using a codec that we aren't prepared for,
                     // we need to let the codec know that we don't have data for it, this will
-                    // flush any internal codec state and produce fade to silence.
+                    // allowe the codec to interpolate missing data and produce a fade to silence.
                     lostAudioData(1);
 
                     // inform others of the mismatch
@@ -248,12 +248,12 @@ int InboundAudioStream::parseAudioData(PacketType type, const QByteArray& packet
 int InboundAudioStream::writeDroppableSilentFrames(int silentFrames) {
 
     // We can't guarentee that all clients have faded the stream down
-    // to silence and encode that silence before sending us a 
-    // SilentAudioFrame. The encoder may have truncated the stream and 
-    // left the decoder holding some loud state. To handle this case
-    // we will call the decoder's lostFrame() method, which indicates
-    // that it should interpolate from it's last known state (which may
-    // be some unknown loud state) down toward silence.
+    // to silence and encoding that silence before sending us a 
+    // SilentAudioFrame. If the encoder has truncated the stream it will
+    // leave the decoder holding some unknown loud state. To handle this 
+    // case we will call the decoder's lostFrame() method, which indicates
+    // that it should interpolate from its last known state down toward 
+    // silence.
     if (_decoder) {
         // FIXME - We could potentially use the output from the codec, in which 
         // case we might get a cleaner fade toward silence. NOTE: The below logic 


### PR DESCRIPTION
- fix a bug in mixers handling of silent packet transitions
- flush the encoder to silence when closing the noise gate on the client

**Test Plan**
- To test the noise gate behavior follow these steps:
    - Turn up your mic gain a lot so you get lots of background noise
    - Make sure Developer > Audio > Audio Noise Reduction is enabled
    - go to a quiet domain so you're the only one there.
    - Enable Server Loopback
    - Enable Audio Scope
    - Be as quiet as you can... watch that the audio is flat and you don't hear your loopback
    - make a relatively quiet noise (like a whisper or a jaw pop) -- listen for the server loop back. 
    - Verify you see a "clean" nearly identical echo in the scope... something like this:
![image](https://cloud.githubusercontent.com/assets/2093195/23732083/ddf1e1c8-0425-11e7-9d55-f489a7e03f62.png)

NOTE: There is a fix to each side client and server which in all cases will "improve" this artifact. The ideal result is from using a new client and new server, but since clients can't be trusted the server has it's own guards against old or malformed clients to reduce the artifact.

- You can test this with OLD clients and this NEW server. You should see...
![image](https://cloud.githubusercontent.com/assets/2093195/23732217/a47c5fa8-0426-11e7-8a03-a84db31f6c28.png)

Notice that in this case it's not perfect, but it's pretty close.

- You can also test this with this NEW client and OLD servers. You should see...
![image](https://cloud.githubusercontent.com/assets/2093195/23732135/22176a62-0426-11e7-88de-4d6d51e392b0.png)

Notice that in this case it's better and much closer to perfect.

For reference, here's an OLD client with an OLD server...
![image](https://cloud.githubusercontent.com/assets/2093195/23732260/e4395902-0426-11e7-8864-d398f40e2104.png)

In this case you can clearly see that the first 5-6 frames of the echoed sample are completely wrong. That's because they are from the samples before the noise gate closed.


