### PR TITLE
toolbar becomes visible after taking a snapshot

### DIFF
--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -81,6 +81,10 @@ void  HMDScriptingInterface::closeTablet() {
     _showTablet = false;
 }
 
+void HMDScriptingInterface::openTablet() {
+    _showTablet = true;
+}
+
 QScriptValue HMDScriptingInterface::getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine) {
     glm::vec3 hudIntersection;
     auto instance = DependencyManager::get<HMDScriptingInterface>();

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -76,6 +76,8 @@ public:
 
     Q_INVOKABLE void closeTablet();
 
+    Q_INVOKABLE void openTablet();
+
 signals:
     bool shouldShowHandControllersChanged();
 

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -191,12 +191,12 @@ function resetButtons(pathStillSnapshot, pathAnimatedSnapshot, notify) {
     if (clearOverlayWhenMoving) {
         MyAvatar.setClearOverlayWhenMoving(true); // not until after the share dialog
     }
+    HMD.openTablet();
 }
 
 function processingGif() {
     // show hud
     Reticle.visible = reticleVisible;
-
     button.clicked.disconnect(onClicked);
     buttonConnected = false;
     // show overlays if they were on


### PR DESCRIPTION
One snapshot is finished, the toolbar becomes visible again