### PR TITLE
zero velocity of deactivated dynamic entities

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4440,8 +4440,8 @@ void Application::update(float deltaTime) {
                 getEntities()->getTree()->withWriteLock([&] {
                     PerformanceTimer perfTimer("handleOutgoingChanges");
                     const VectorOfMotionStates& outgoingChanges = _physicsEngine->getOutgoingChanges();
-                    _entitySimulation->handleOutgoingChanges(outgoingChanges);
-                    avatarManager->handleOutgoingChanges(outgoingChanges);
+                    _entitySimulation->handleChangedMotionStates(outgoingChanges);
+                    avatarManager->handleChangedMotionStates(outgoingChanges);
                 });
 
                 if (!_aboutToQuit) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4439,7 +4439,10 @@ void Application::update(float deltaTime) {
 
                 getEntities()->getTree()->withWriteLock([&] {
                     PerformanceTimer perfTimer("handleOutgoingChanges");
-                    const VectorOfMotionStates& outgoingChanges = _physicsEngine->getOutgoingChanges();
+                    const VectorOfMotionStates& deactivations = _physicsEngine->getDeactivatedMotionStates();
+                    _entitySimulation->handleDeactivatedMotionStates(deactivations);
+
+                    const VectorOfMotionStates& outgoingChanges = _physicsEngine->getChangedMotionStates();
                     _entitySimulation->handleChangedMotionStates(outgoingChanges);
                     avatarManager->handleChangedMotionStates(outgoingChanges);
                 });

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -424,7 +424,7 @@ void AvatarManager::getObjectsToChange(VectorOfMotionStates& result) {
     }
 }
 
-void AvatarManager::handleOutgoingChanges(const VectorOfMotionStates& motionStates) {
+void AvatarManager::handleChangedMotionStates(const VectorOfMotionStates& motionStates) {
     // TODO: extract the MyAvatar results once we use a MotionState for it.
 }
 

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -70,7 +70,7 @@ public:
     void getObjectsToRemoveFromPhysics(VectorOfMotionStates& motionStates);
     void getObjectsToAddToPhysics(VectorOfMotionStates& motionStates);
     void getObjectsToChange(VectorOfMotionStates& motionStates);
-    void handleOutgoingChanges(const VectorOfMotionStates& motionStates);
+    void handleChangedMotionStates(const VectorOfMotionStates& motionStates);
     void handleCollisionEvents(const CollisionEvents& collisionEvents);
 
     Q_INVOKABLE float getAvatarDataRate(const QUuid& sessionID, const QString& rateName = QString("")) const;

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -676,7 +676,7 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         filterRejection = newSimOwner.getID().isNull();
         bool verbose = getName() == "fubar"; // adebug
         if (verbose && _simulationOwner != newSimOwner) {
-            std::cout << (void*)(this) << "  adebug ownership changed "
+            std::cout << (void*)(this) << "  " << secTimestampNow() << "  adebug ownership changed "
                 << _simulationOwner.getID().toString().toStdString() << "." << (int)_simulationOwner.getPriority() << "-->"
                 << newSimOwner.getID().toString().toStdString() << "." << (int)newSimOwner.getPriority()
                 << std::endl;  // adebug

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -674,13 +674,6 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
         // or rejects a set of properties, it clears this. In such cases, we don't want those custom
         // setters to ignore what the server says.
         filterRejection = newSimOwner.getID().isNull();
-        bool verbose = getName() == "fubar"; // adebug
-        if (verbose && _simulationOwner != newSimOwner) {
-            std::cout << (void*)(this) << "  " << secTimestampNow() << "  adebug ownership changed "
-                << _simulationOwner.getID().toString().toStdString() << "." << (int)_simulationOwner.getPriority() << "-->"
-                << newSimOwner.getID().toString().toStdString() << "." << (int)newSimOwner.getPriority()
-                << std::endl;  // adebug
-        }
         if (weOwnSimulation) {
             if (newSimOwner.getID().isNull() && !_simulationOwner.pendingRelease(lastEditedFromBufferAdjusted)) {
                 // entity-server is trying to clear our ownership (probably at our own request)
@@ -1891,18 +1884,12 @@ void EntityItem::updateSimulationOwner(const SimulationOwner& owner) {
 
     if (_simulationOwner.set(owner)) {
         _dirtyFlags |= Simulation::DIRTY_SIMULATOR_ID;
-        if (getName() == "fubar") {
-            std::cout << "debug updateSimulationOwner() " << _simulationOwner.getID().toString().toStdString() << "." << (int)(_simulationOwner.getPriority()) << std::endl;  // adebug
-        }
     }
 }
 
 void EntityItem::clearSimulationOwnership() {
     if (wantTerseEditLogging() && !_simulationOwner.isNull()) {
         qCDebug(entities) << "sim ownership for" << getDebugName() << "is now null";
-    }
-    if (getName() == "fubar") {
-        std::cout << "debug clearSimulationOwnership()" << std::endl;  // adebug
     }
 
     _simulationOwner.clear();

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -108,6 +108,7 @@ void EntityMotionState::handleDeactivation() {
     btTransform worldTrans;
     worldTrans.setOrigin(glmToBullet(_serverPosition));
     worldTrans.setRotation(glmToBullet(_serverRotation));
+    _body->setWorldTransform(worldTrans);
     // no need to update velocities... should already be zero
 }
 

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -104,6 +104,11 @@ void EntityMotionState::handleDeactivation() {
     _entity->setOrientation(_serverRotation, success, false);
     _entity->setVelocity(ENTITY_ITEM_ZERO_VEC3);
     _entity->setAngularVelocity(ENTITY_ITEM_ZERO_VEC3);
+    // and also to RigidBody
+    btTransform worldTrans;
+    worldTrans.setOrigin(glmToBullet(_serverPosition));
+    worldTrans.setRotation(glmToBullet(_serverRotation));
+    // no need to update velocities... should already be zero
 }
 
 // virtual

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -143,6 +143,8 @@ void EntityMotionState::handleEasyChanges(uint32_t& flags) {
                 flags &= ~Simulation::DIRTY_PHYSICS_ACTIVATION;
                 _body->setActivationState(WANTS_DEACTIVATION);
                 _outgoingPriority = 0;
+                const float ACTIVATION_EXPIRY = 3.0f; // something larger than the 2.0 hard coded in Bullet
+                _body->setDeactivationTime(ACTIVATION_EXPIRY);
                 bool verbose = _entity->getName() == "fubar"; // adebug
                 if (verbose) {
                     std::cout << (void*)(this) << "  " << secTimestampNow() << "  adebug flag for deactivation" << std::endl;  // adebug

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -29,6 +29,7 @@ public:
     virtual ~EntityMotionState();
 
     void updateServerPhysicsVariables();
+    void handleDeactivation();
     virtual void handleEasyChanges(uint32_t& flags) override;
     virtual bool handleHardAndEasyChanges(uint32_t& flags, PhysicsEngine* engine) override;
 

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -259,6 +259,19 @@ void PhysicalEntitySimulation::getObjectsToChange(VectorOfMotionStates& result) 
     _pendingChanges.clear();
 }
 
+void PhysicalEntitySimulation::handleDeactivatedMotionStates(const VectorOfMotionStates& motionStates) {
+    for (auto stateItr : motionStates) {
+        ObjectMotionState* state = &(*stateItr);
+        assert(state);
+        if (state->getType() == MOTIONSTATE_TYPE_ENTITY) {
+            EntityMotionState* entityState = static_cast<EntityMotionState*>(state);
+            entityState->handleDeactivation();
+            EntityItemPointer entity = entityState->getEntity();
+            _entitiesToSort.insert(entity);
+        }
+    }
+}
+
 void PhysicalEntitySimulation::handleChangedMotionStates(const VectorOfMotionStates& motionStates) {
     QMutexLocker lock(&_mutex);
 

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -259,13 +259,14 @@ void PhysicalEntitySimulation::getObjectsToChange(VectorOfMotionStates& result) 
     _pendingChanges.clear();
 }
 
-void PhysicalEntitySimulation::handleOutgoingChanges(const VectorOfMotionStates& motionStates) {
+void PhysicalEntitySimulation::handleChangedMotionStates(const VectorOfMotionStates& motionStates) {
     QMutexLocker lock(&_mutex);
 
     // walk the motionStates looking for those that correspond to entities
     for (auto stateItr : motionStates) {
         ObjectMotionState* state = &(*stateItr);
-        if (state && state->getType() == MOTIONSTATE_TYPE_ENTITY) {
+        assert(state);
+        if (state->getType() == MOTIONSTATE_TYPE_ENTITY) {
             EntityMotionState* entityState = static_cast<EntityMotionState*>(state);
             EntityItemPointer entity = entityState->getEntity();
             assert(entity.get());

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -56,6 +56,7 @@ public:
     void setObjectsToChange(const VectorOfMotionStates& objectsToChange);
     void getObjectsToChange(VectorOfMotionStates& result);
 
+    void handleDeactivatedMotionStates(const VectorOfMotionStates& motionStates);
     void handleChangedMotionStates(const VectorOfMotionStates& motionStates);
     void handleCollisionEvents(const CollisionEvents& collisionEvents);
 

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -56,7 +56,7 @@ public:
     void setObjectsToChange(const VectorOfMotionStates& objectsToChange);
     void getObjectsToChange(VectorOfMotionStates& result);
 
-    void handleOutgoingChanges(const VectorOfMotionStates& motionStates);
+    void handleChangedMotionStates(const VectorOfMotionStates& motionStates);
     void handleCollisionEvents(const CollisionEvents& collisionEvents);
 
     EntityEditPacketSender* getPacketSender() { return _entityPacketSender; }
@@ -67,7 +67,7 @@ private:
     SetOfEntities _entitiesToAddToPhysics;
 
     SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed
-    SetOfEntityMotionStates _outgoingChanges; // EntityMotionStates for which we need to send updates to entity-server
+    SetOfEntityMotionStates _outgoingChanges; // EntityMotionStates for which we may need to send updates to entity-server
 
     SetOfMotionStates _physicalObjects; // MotionStates of entities in PhysicsEngine
 

--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -449,7 +449,7 @@ const CollisionEvents& PhysicsEngine::getCollisionEvents() {
     return _collisionEvents;
 }
 
-const VectorOfMotionStates& PhysicsEngine::getOutgoingChanges() {
+const VectorOfMotionStates& PhysicsEngine::getChangedMotionStates() {
     BT_PROFILE("copyOutgoingChanges");
     // Bullet will not deactivate static objects (it doesn't expect them to be active)
     // so we must deactivate them ourselves

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -65,7 +65,8 @@ public:
     bool hasOutgoingChanges() const { return _hasOutgoingChanges; }
 
     /// \return reference to list of changed MotionStates.  The list is only valid until beginning of next simulation loop.
-    const VectorOfMotionStates& getOutgoingChanges();
+    const VectorOfMotionStates& getChangedMotionStates();
+    const VectorOfMotionStates& getDeactivatedMotionStates() const { return _dynamicsWorld->getDeactivatedMotionStates(); }
 
     /// \return reference to list of Collision events.  The list is only valid until beginning of next simulation loop.
     const CollisionEvents& getCollisionEvents();

--- a/libraries/physics/src/ThreadSafeDynamicsWorld.cpp
+++ b/libraries/physics/src/ThreadSafeDynamicsWorld.cpp
@@ -120,6 +120,9 @@ void ThreadSafeDynamicsWorld::synchronizeMotionState(btRigidBody* body) {
 void ThreadSafeDynamicsWorld::synchronizeMotionStates() {
     BT_PROFILE("synchronizeMotionStates");
     _changedMotionStates.clear();
+
+    // NOTE: m_synchronizeAllMotionStates is 'false' by default for optimization.
+    // See PhysicsEngine::init() where we call _dynamicsWorld->setForceUpdateAllAabbs(false)
     if (m_synchronizeAllMotionStates) {
         //iterate  over all collision objects
         for (int i=0;i<m_collisionObjects.size();i++) {

--- a/libraries/physics/src/ThreadSafeDynamicsWorld.cpp
+++ b/libraries/physics/src/ThreadSafeDynamicsWorld.cpp
@@ -136,7 +136,7 @@ void ThreadSafeDynamicsWorld::synchronizeMotionStates() {
     } else  {
         //iterate over all active rigid bodies
         // TODO? if this becomes a performance bottleneck we could derive our own SimulationIslandManager
-        // that remembers a list of objects it recently deactivated
+        // that remembers a list of objects deactivated last step
         _activeStates.clear();
         _deactivatedStates.clear();
         for (int i=0;i<m_nonStaticRigidBodies.size();i++) {
@@ -153,9 +153,6 @@ void ThreadSafeDynamicsWorld::synchronizeMotionStates() {
                 }
             }
         }
-    }
-    if (_deactivatedStates.size() > 0) {
-        std::cout << secTimestampNow() << "  adebug num deactivated = " << _deactivatedStates.size() << std::endl;  // adebug
     }
     _activeStates.swap(_lastActiveStates);
 }

--- a/libraries/physics/src/ThreadSafeDynamicsWorld.h
+++ b/libraries/physics/src/ThreadSafeDynamicsWorld.h
@@ -49,12 +49,16 @@ public:
     float getLocalTimeAccumulation() const { return m_localTime; }
 
     const VectorOfMotionStates& getChangedMotionStates() const { return _changedMotionStates; }
+    const VectorOfMotionStates& getDeactivatedMotionStates() const { return _deactivatedStates; }
 
 private:
     // call this instead of non-virtual btDiscreteDynamicsWorld::synchronizeSingleMotionState()
     void synchronizeMotionState(btRigidBody* body);
 
     VectorOfMotionStates _changedMotionStates;
+    VectorOfMotionStates _deactivatedStates;
+    SetOfMotionStates _activeStates;
+    SetOfMotionStates _lastActiveStates;
 };
 
 #endif // hifi_ThreadSafeDynamicsWorld_h


### PR DESCRIPTION
* fix transform and velocities of dynamic entities whose RigidBody is deactivated in physics simulation 
* when an entity with remote simulation ownership comes to rest: try harder to flag it for deactivation