### PR TITLE
Change to Log Font and Formatting

### DIFF
--- a/interface/resources/styles/log_dialog.qss
+++ b/interface/resources/styles/log_dialog.qss
@@ -1,6 +1,6 @@
 
 QPlainTextEdit {
-    font-family: Inconsolata, Lucida Console, Andale Mono, Monaco;
+    font-family: Courier New, Courier, Monotype;
     font-size: 16px;
     padding-left: 28px;
     padding-top: 7px;
@@ -11,7 +11,7 @@ QPlainTextEdit {
 }
 
 QLineEdit {
-    font-family: Inconsolata, Lucida Console, Andale Mono, Monaco;
+    font-family: Courier New, Courier, Monotype;
     padding-left: 7px;
     background-color: #CCCCCC;
     border-width: 0;

--- a/interface/resources/styles/log_dialog.qss
+++ b/interface/resources/styles/log_dialog.qss
@@ -1,6 +1,6 @@
 
 QPlainTextEdit {
-    font-family: Courier New, Courier, Monotype;
+    font-family: Inconsolata, Consolas, Courier New, monospace;
     font-size: 16px;
     padding-left: 28px;
     padding-top: 7px;
@@ -11,7 +11,7 @@ QPlainTextEdit {
 }
 
 QLineEdit {
-    font-family: Courier New, Courier, Monotype;
+    font-family: Inconsolata, Consolas, Courier New, monospace;
     padding-left: 7px;
     background-color: #CCCCCC;
     border-width: 0;

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -29,6 +29,7 @@ const int SEARCH_BUTTON_WIDTH = 20;
 const int SEARCH_TOGGLE_BUTTON_WIDTH = 50;
 const int SEARCH_TEXT_WIDTH = 240;
 const int TIME_STAMP_LENGTH = 16;
+const int FONT_WEIGHT = 75;
 const QColor HIGHLIGHT_COLOR = QColor("#3366CC");
 const QColor BOLD_COLOR = QColor("#445c8c");
 const QString BOLD_PATTERN = "\\[\\d*\\/.*:\\d*:\\d*\\]";
@@ -38,7 +39,7 @@ public:
     Highlighter(QTextDocument* parent = nullptr);
     void setBold(int indexToBold);
     QString keyword;
-    
+
 protected:
     void highlightBlock(const QString& text) override;
 
@@ -94,7 +95,7 @@ void BaseLogDialog::initControls() {
     _leftPad += SEARCH_TOGGLE_BUTTON_WIDTH + BUTTON_MARGIN;
     _searchPrevButton->show();
     connect(_searchPrevButton, SIGNAL(clicked()), SLOT(toggleSearchPrev()));
-    
+
     _searchNextButton = new QPushButton(this);
     _searchNextButton->setObjectName("searchNextButton");
     _searchNextButton->setGeometry(_leftPad, ELEMENT_MARGIN, SEARCH_TOGGLE_BUTTON_WIDTH, ELEMENT_HEIGHT);
@@ -134,7 +135,7 @@ void BaseLogDialog::handleSearchTextChanged(QString searchText) {
     if (searchText.isEmpty()) {
         return;
     }
-    
+
     QTextCursor cursor = _logTextBox->textCursor();
     if (cursor.hasSelection()) {
         QString selectedTerm = cursor.selectedText();
@@ -142,16 +143,16 @@ void BaseLogDialog::handleSearchTextChanged(QString searchText) {
           return;
         }
     }
-    
+
     cursor.setPosition(0, QTextCursor::MoveAnchor);
     _logTextBox->setTextCursor(cursor);
     bool foundTerm = _logTextBox->find(searchText);
-    
+
     if (!foundTerm) {
         cursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
         _logTextBox->setTextCursor(cursor);
     }
-    
+
     _searchTerm = searchText;
     _highlighter->keyword = searchText;
     _highlighter->rehighlight();
@@ -195,10 +196,10 @@ void BaseLogDialog::updateSelection() {
 }
 
 Highlighter::Highlighter(QTextDocument* parent) : QSyntaxHighlighter(parent) {
-    boldFormat.setFontWeight(75);
+    boldFormat.setFontWeight(FONT_WEIGHT);
     boldFormat.setForeground(BOLD_COLOR);
     keywordFormat.setForeground(HIGHLIGHT_COLOR);
-  }
+}
 
 void Highlighter::highlightBlock(const QString& text) {
     QRegExp expression(BOLD_PATTERN);
@@ -206,11 +207,11 @@ void Highlighter::highlightBlock(const QString& text) {
     int index = text.indexOf(expression, 0);
 
     while (index >= 0) {
-      int length = expression.matchedLength();
-      setFormat(index, length, boldFormat);
-      index = text.indexOf(expression, index + length);
+        int length = expression.matchedLength();
+        setFormat(index, length, boldFormat);
+        index = text.indexOf(expression, index + length);
     }
-    
+
     if (keyword.isNull() || keyword.isEmpty()) {
         return;
     }

--- a/interface/src/ui/BaseLogDialog.h
+++ b/interface/src/ui/BaseLogDialog.h
@@ -23,7 +23,7 @@ const int BUTTON_MARGIN = 8;
 class QPushButton;
 class QLineEdit;
 class QPlainTextEdit;
-class KeywordHighlighter;
+class Highlighter;
 
 class BaseLogDialog : public QDialog {
     Q_OBJECT
@@ -56,7 +56,7 @@ private:
     QPushButton* _searchPrevButton { nullptr };
     QPushButton* _searchNextButton { nullptr };
     QString _searchTerm;
-    KeywordHighlighter* _highlighter { nullptr };
+    Highlighter* _highlighter { nullptr };
     
     void initControls();
     void showLogData();


### PR DESCRIPTION
Different font on log window (Courier) and colored/bolded timestamps. Feedback welcome!

New log window looks like:
![final](https://cloud.githubusercontent.com/assets/12736060/23685702/60a94efc-035a-11e7-80f1-9086c52f2305.PNG) 

In response to: https://highfidelity.fogbugz.com/f/cases/3322/Font-in-log-window-is-hard-to-read