### PR TITLE
force tablet on to home screen option

### DIFF
--- a/libraries/script-engine/src/TabletScriptingInterface.cpp
+++ b/libraries/script-engine/src/TabletScriptingInterface.cpp
@@ -393,7 +393,7 @@ void TabletProxy::popFromStack() {
 }
 
 void TabletProxy::loadHomeScreen(bool forceOntoHomeScreen) {
-    if (_state != State::Home && ( _state != State::Uninitialized || forceOntoHomeScreen)) {
+    if ((_state != State::Home && _state != State::Uninitialized) || forceOntoHomeScreen) {
         if (!_toolbarMode && _qmlTabletRoot) {
             auto loader = _qmlTabletRoot->findChild<QQuickItem*>("loader");
             QObject::connect(loader, SIGNAL(loaded()), this, SLOT(addButtonsToHomeScreen()), Qt::DirectConnection);


### PR DESCRIPTION
fix the logic that forces the tablet onto the home screen when the tablet is being initialized