### PR TITLE
Fix JS exception messages formatting

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -142,7 +142,7 @@ QString encodeEntityIdIntoEntityUrl(const QString& url, const QString& entityID)
 
 QString ScriptEngine::logException(const QScriptValue& exception) {
     auto message = formatException(exception);
-    scriptErrorMessage(qPrintable(message));
+    scriptErrorMessage(message);
     return message;
 }
 
@@ -453,7 +453,7 @@ void ScriptEngine::loadURL(const QUrl& scriptURL, bool reload) {
 }
 
 void ScriptEngine::scriptErrorMessage(const QString& message) {
-    qCCritical(scriptengine) << message;
+    qCCritical(scriptengine) << qPrintable(message);
     emit errorMessage(message);
 }
 


### PR DESCRIPTION
Before:
![screenshot_3](https://cloud.githubusercontent.com/assets/4036492/23868602/3e4b42d4-07dd-11e7-862c-e928287c1ca4.png)

After:
![screenshot_4](https://cloud.githubusercontent.com/assets/4036492/23868610/42872f66-07dd-11e7-96b1-3cbfead6bcbb.png)

## Test build:
- Run a script with an exception and make sure the carriage returns are respected.
Ex:
```js
function foo(arg) {
   return arg.nonExistingMethod();
}
function bar(arg) {
    return foo(arg);
}
bar(null);
```