### PR TITLE
Fixes for race conditions in DebugDraw

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
         "Clipboard": false,
         "Controller": false,
         "DialogsManager": false,
+        "DebugDraw": false,
         "Entities": false,
         "FaceTracker": false,
         "GlobalServices": false,

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -608,6 +608,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         }
     }
 
+    // make sure the debug draw singleton is initialized on the main thread.
+    DebugDraw::getInstance().removeMarker("");
 
     _runningMarker.startRunningMarker();
 

--- a/libraries/render-utils/src/AnimDebugDraw.cpp
+++ b/libraries/render-utils/src/AnimDebugDraw.cpp
@@ -346,7 +346,9 @@ void AnimDebugDraw::update() {
         numVerts += (int)markerMap.size() * VERTICES_PER_BONE;
         auto myAvatarMarkerMap = DebugDraw::getInstance().getMyAvatarMarkerMap();
         numVerts += (int)myAvatarMarkerMap.size() * VERTICES_PER_BONE;
-        numVerts += (int)DebugDraw::getInstance().getRays().size() * VERTICES_PER_RAY;
+        auto rays = DebugDraw::getInstance().getRays();
+        DebugDraw::getInstance().clearRays();
+        numVerts += (int)rays.size() * VERTICES_PER_RAY;
 
         // allocate verts!
         std::vector<AnimDebugDrawData::Vertex> vertices;
@@ -398,10 +400,9 @@ void AnimDebugDraw::update() {
         }
 
         // draw rays from shared DebugDraw singleton
-        for (auto& iter : DebugDraw::getInstance().getRays()) {
+        for (auto& iter : rays) {
             addLine(std::get<0>(iter), std::get<1>(iter), std::get<2>(iter), v);
         }
-        DebugDraw::getInstance().clearRays();
 
         data._vertexBuffer->resize(sizeof(AnimDebugDrawData::Vertex) * numVerts);
         data._vertexBuffer->setSubData<AnimDebugDrawData::Vertex>(0, vertices);


### PR DESCRIPTION
This will allow interface to run in Debug mode.  And using DebugDraw interface from JS will no longer crash.