### PR TITLE
dialogs that are push onto the menu stack now have focus

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
@@ -51,6 +51,8 @@ Item {
             d.push(Qt.resolvedUrl(path));
             d.currentItem.eventBridge = tabletMenu.eventBridge
             d.currentItem.sendToScript.connect(tabletMenu.sendToScript);
+            d.currentItem.focus = true;
+            d.currentItem.forceActiveFocus();
             breadcrumbText.text = d.currentItem.title;
         }
 


### PR DESCRIPTION
Fixed the issue of menu items do not have focus when pushed from the pushOntstack function