### PR TITLE
minor cleanup of render pipeline for models and avatars

### DIFF
--- a/interface/src/avatar/CauterizedMeshPartPayload.cpp
+++ b/interface/src/avatar/CauterizedMeshPartPayload.cpp
@@ -20,33 +20,11 @@ using namespace render;
 CauterizedMeshPartPayload::CauterizedMeshPartPayload(Model* model, int meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform)
     : ModelMeshPartPayload(model, meshIndex, partIndex, shapeIndex, transform, offsetTransform) {}
 
-void CauterizedMeshPartPayload::updateTransformForSkinnedCauterizedMesh(const Transform& transform,
-        const QVector<glm::mat4>& clusterMatrices,
-        const QVector<glm::mat4>& cauterizedClusterMatrices) {
-    _transform = transform;
-    _cauterizedTransform = transform;
-
-    if (clusterMatrices.size() > 0) {
-        _worldBound = AABox();
-        for (auto& clusterMatrix : clusterMatrices) {
-            AABox clusterBound = _localBound;
-            clusterBound.transform(clusterMatrix);
-            _worldBound += clusterBound;
-        }
-
-        _worldBound.transform(transform);
-        if (clusterMatrices.size() == 1) {
-            _transform = _transform.worldTransform(Transform(clusterMatrices[0]));
-            if (cauterizedClusterMatrices.size() != 0) {
-                _cauterizedTransform = _cauterizedTransform.worldTransform(Transform(cauterizedClusterMatrices[0]));
-            } else {
-                _cauterizedTransform = _transform;
-            }
-        }
-    } else {
-        _worldBound = _localBound;
-        _worldBound.transform(_drawTransform);
-    }
+void CauterizedMeshPartPayload::updateTransformForCauterizedMesh(
+		const Transform& renderTransform,
+        const gpu::BufferPointer& buffer) {
+    _cauterizedTransform = renderTransform;
+    _cauterizedClusterBuffer = buffer;
 }
 
 void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const {
@@ -55,20 +33,16 @@ void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::S
     SkeletonModel* skeleton = static_cast<SkeletonModel*>(_model);
     bool useCauterizedMesh = (renderMode != RenderArgs::RenderMode::SHADOW_RENDER_MODE) && skeleton->getEnableCauterization();
 
-    if (state.clusterBuffer) {
-        if (useCauterizedMesh) {
-            const Model::MeshState& cState = skeleton->getCauterizeMeshState(_meshIndex);
-            batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, cState.clusterBuffer);
-        } else {
-            batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, state.clusterBuffer);
+	if (useCauterizedMesh) {
+        if (_cauterizedClusterBuffer) {
+            batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, _cauterizedClusterBuffer);
+        }
+        batch.setModelTransform(_cauterizedTransform);
+	} else {
+        if (_clusterBuffer) {
+            batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, _clusterBuffer);
         }
         batch.setModelTransform(_transform);
-    } else {
-        if (useCauterizedMesh) {
-            batch.setModelTransform(_cauterizedTransform);
-        } else {
-            batch.setModelTransform(_transform);
-        }
     }
 }
 

--- a/interface/src/avatar/CauterizedMeshPartPayload.cpp
+++ b/interface/src/avatar/CauterizedMeshPartPayload.cpp
@@ -29,7 +29,6 @@ void CauterizedMeshPartPayload::updateTransformForCauterizedMesh(
 
 void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const {
     // Still relying on the raw data from the model
-    const Model::MeshState& state = _model->getMeshState(_meshIndex);
     SkeletonModel* skeleton = static_cast<SkeletonModel*>(_model);
     bool useCauterizedMesh = (renderMode != RenderArgs::RenderMode::SHADOW_RENDER_MODE) && skeleton->getEnableCauterization();
 

--- a/interface/src/avatar/CauterizedMeshPartPayload.cpp
+++ b/interface/src/avatar/CauterizedMeshPartPayload.cpp
@@ -21,7 +21,7 @@ CauterizedMeshPartPayload::CauterizedMeshPartPayload(Model* model, int meshIndex
     : ModelMeshPartPayload(model, meshIndex, partIndex, shapeIndex, transform, offsetTransform) {}
 
 void CauterizedMeshPartPayload::updateTransformForCauterizedMesh(
-		const Transform& renderTransform,
+        const Transform& renderTransform,
         const gpu::BufferPointer& buffer) {
     _cauterizedTransform = renderTransform;
     _cauterizedClusterBuffer = buffer;
@@ -33,12 +33,12 @@ void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::S
     SkeletonModel* skeleton = static_cast<SkeletonModel*>(_model);
     bool useCauterizedMesh = (renderMode != RenderArgs::RenderMode::SHADOW_RENDER_MODE) && skeleton->getEnableCauterization();
 
-	if (useCauterizedMesh) {
+    if (useCauterizedMesh) {
         if (_cauterizedClusterBuffer) {
             batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, _cauterizedClusterBuffer);
         }
         batch.setModelTransform(_cauterizedTransform);
-	} else {
+    } else {
         if (_clusterBuffer) {
             batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, _clusterBuffer);
         }

--- a/interface/src/avatar/CauterizedMeshPartPayload.h
+++ b/interface/src/avatar/CauterizedMeshPartPayload.h
@@ -17,12 +17,13 @@
 class CauterizedMeshPartPayload : public ModelMeshPartPayload {
 public:
     CauterizedMeshPartPayload(Model* model, int meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform);
-    void updateTransformForSkinnedCauterizedMesh(const Transform& transform,
-            const QVector<glm::mat4>& clusterMatrices,
-            const QVector<glm::mat4>& cauterizedClusterMatrices);
+
+    void updateTransformForCauterizedMesh(const Transform& renderTransform, const gpu::BufferPointer& buffer);
 
     void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const override;
+
 private:
+    gpu::BufferPointer _cauterizedClusterBuffer;
     Transform _cauterizedTransform;
 };
 

--- a/interface/src/avatar/CauterizedModel.cpp
+++ b/interface/src/avatar/CauterizedModel.cpp
@@ -26,8 +26,8 @@ CauterizedModel::~CauterizedModel() {
 }
 
 void CauterizedModel::deleteGeometry() {
-	Model::deleteGeometry();
-	_cauterizeMeshStates.clear();
+    Model::deleteGeometry();
+    _cauterizeMeshStates.clear();
 }
 
 bool CauterizedModel::updateGeometry() {
@@ -41,7 +41,7 @@ bool CauterizedModel::updateGeometry() {
             _cauterizeMeshStates.append(state);
         }
     }
-	return needsFullUpdate;
+    return needsFullUpdate;
 }
 
 void CauterizedModel::createVisibleRenderItemSet() {
@@ -86,13 +86,13 @@ void CauterizedModel::createVisibleRenderItemSet() {
             }
         }
     } else {
-	    Model::createVisibleRenderItemSet();
+        Model::createVisibleRenderItemSet();
     }
 }
 
 void CauterizedModel::createCollisionRenderItemSet() {
     // Temporary HACK: use base class method for now
-	Model::createCollisionRenderItemSet();
+    Model::createCollisionRenderItemSet();
 }
 
 void CauterizedModel::updateClusterMatrices() {
@@ -122,8 +122,8 @@ void CauterizedModel::updateClusterMatrices() {
                 state.clusterBuffer->setSubData(0, state.clusterMatrices.size() * sizeof(glm::mat4),
                                                 (const gpu::Byte*) state.clusterMatrices.constData());
             }
-		}
-	}
+        }
+    }
 
     // as an optimization, don't build cautrizedClusterMatrices if the boneSet is empty.
     if (!_cauterizeBoneSet.empty()) {
@@ -212,31 +212,22 @@ void CauterizedModel::updateRenderItems() {
                     if (data._model && data._model->isLoaded()) {
                         // Ensure the model geometry was not reset between frames
                         if (deleteGeometryCounter == data._model->getGeometryCounter()) {
-							// this stuff identical to what happens in regular Model
-                          	const Model::MeshState& state = data._model->getMeshState(data._meshIndex);
-                          	Transform renderTransform = modelTransform;
-                          	if (state.clusterMatrices.size() == 1) {
-                              	renderTransform = modelTransform.worldTransform(Transform(state.clusterMatrices[0]));
-                          	}
-                          	data.updateTransformForSkinnedMesh(renderTransform, modelTransform, state.clusterBuffer);
-
-							// this stuff for cauterized mesh
-                            CauterizedModel* cModel = static_cast<CauterizedModel*>(data._model);
-                          	const Model::MeshState& cState = cModel->getCauterizeMeshState(data._meshIndex);
-                          	renderTransform = modelTransform;
-                          	if (cState.clusterMatrices.size() == 1) {
-                              	renderTransform = modelTransform.worldTransform(Transform(cState.clusterMatrices[0]));
-                          	}
-                          	data.updateTransformForCauterizedMesh(renderTransform, cState.clusterBuffer);
-
-/*
-                            // update the model transform and bounding box for this render item.
+                            // this stuff identical to what happens in regular Model
                             const Model::MeshState& state = data._model->getMeshState(data._meshIndex);
+                            Transform renderTransform = modelTransform;
+                            if (state.clusterMatrices.size() == 1) {
+                                renderTransform = modelTransform.worldTransform(Transform(state.clusterMatrices[0]));
+                            }
+                            data.updateTransformForSkinnedMesh(renderTransform, modelTransform, state.clusterBuffer);
+
+                            // this stuff for cauterized mesh
                             CauterizedModel* cModel = static_cast<CauterizedModel*>(data._model);
-                            assert(data._meshIndex < cModel->_cauterizeMeshStates.size());
-                            const Model::MeshState& cState = cModel->_cauterizeMeshStates.at(data._meshIndex);
-                            data.updateTransformForSkinnedCauterizedMesh(modelTransform, state.clusterMatrices, cState.clusterMatrices);
-*/
+                            const Model::MeshState& cState = cModel->getCauterizeMeshState(data._meshIndex);
+                            renderTransform = modelTransform;
+                            if (cState.clusterMatrices.size() == 1) {
+                                renderTransform = modelTransform.worldTransform(Transform(cState.clusterMatrices[0]));
+                            }
+                            data.updateTransformForCauterizedMesh(renderTransform, cState.clusterBuffer);
                         }
                     }
                 });

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -372,19 +372,12 @@ void ModelMeshPartPayload::notifyLocationChanged() {
 
 }
 
-void ModelMeshPartPayload::updateTransformForSkinnedMesh(const Transform& transform, const QVector<glm::mat4>& clusterMatrices) {
-    _transform = transform;
-
-    if (clusterMatrices.size() > 0) {
-        _worldBound = _adjustedLocalBound;
-        _worldBound.transform(_transform);
-        if (clusterMatrices.size() == 1) {
-            _transform = _transform.worldTransform(Transform(clusterMatrices[0]));
-        }
-    } else {
-        _worldBound = _localBound;
-        _worldBound.transform(_transform);
-    }
+void ModelMeshPartPayload::updateTransformForSkinnedMesh(const Transform& renderTransform, const Transform& boundTransform,
+        const gpu::BufferPointer& buffer) {
+    _transform = renderTransform;
+    _worldBound = _adjustedLocalBound;
+    _worldBound.transform(boundTransform);
+    _clusterBuffer = buffer;
 }
 
 ItemKey ModelMeshPartPayload::getKey() const {
@@ -532,9 +525,8 @@ void ModelMeshPartPayload::bindMesh(gpu::Batch& batch) const {
 
 void ModelMeshPartPayload::bindTransform(gpu::Batch& batch, const ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const {
     // Still relying on the raw data from the model
-    const Model::MeshState& state = _model->getMeshState(_meshIndex);
-    if (state.clusterBuffer) {
-        batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, state.clusterBuffer);
+    if (_clusterBuffer) {
+        batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, _clusterBuffer);
     }
     batch.setModelTransform(_transform);
 }
@@ -590,8 +582,11 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     auto locations =  args->_pipeline->locations;
     assert(locations);
 
-    // Bind the model transform and the skinCLusterMatrices if needed
+    // update the clusterMatrices if necessary
+    // TODO: we want to remove this updateClusterMatrices() call in this context
+    // but I recall we tried this before and broke something. - Andrew
     _model->updateClusterMatrices();
+
     bindTransform(batch, locations, args->_renderMode);
 
     //Bind the index buffer and vertex buffer and Blend shapes if needed

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -582,11 +582,6 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     auto locations =  args->_pipeline->locations;
     assert(locations);
 
-    // update the clusterMatrices if necessary
-    // TODO: we want to remove this updateClusterMatrices() call in this context
-    // but I recall we tried this before and broke something. - Andrew
-    _model->updateClusterMatrices();
-
     bindTransform(batch, locations, args->_renderMode);
 
     //Bind the index buffer and vertex buffer and Blend shapes if needed

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -89,8 +89,9 @@ public:
     typedef Payload::DataPointer Pointer;
 
     void notifyLocationChanged() override;
-    void updateTransformForSkinnedMesh(const Transform& transform,
-            const QVector<glm::mat4>& clusterMatrices);
+    void updateTransformForSkinnedMesh(const Transform& renderTransform,
+            const Transform& boundTransform,
+            const gpu::BufferPointer& buffer);
 
     float computeFadeAlpha() const;
 
@@ -108,6 +109,7 @@ public:
 
     void computeAdjustedLocalBound(const QVector<glm::mat4>& clusterMatrices);
 
+    gpu::BufferPointer _clusterBuffer;
     Model* _model;
 
     int _meshIndex;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -228,7 +228,7 @@ void Model::updateRenderItems() {
         }
 
         // lazy update of cluster matrices used for rendering.
-        // We need to update them here, so we can correctly update the bounding box.
+        // We need to update them here so we can correctly update the bounding box.
         self->updateClusterMatrices();
 
         render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
@@ -245,10 +245,10 @@ void Model::updateRenderItems() {
                         modelTransform.setScale(glm::vec3(1.0f));
 
                         const Model::MeshState& state = data._model->getMeshState(data._meshIndex);
-						Transform renderTransform = modelTransform;
-						if (state.clusterMatrices.size() == 1) {
-							renderTransform = modelTransform.worldTransform(Transform(state.clusterMatrices[0]));
-						}
+                        Transform renderTransform = modelTransform;
+                        if (state.clusterMatrices.size() == 1) {
+                            renderTransform = modelTransform.worldTransform(Transform(state.clusterMatrices[0]));
+                        }
                         data.updateTransformForSkinnedMesh(renderTransform, modelTransform, state.clusterBuffer);
                     }
                 }
@@ -1052,7 +1052,7 @@ void Model::updateRig(float deltaTime, glm::mat4 parentTransform) {
 }
 
 void Model::computeMeshPartLocalBounds() {
-	for (auto& part : _modelMeshRenderItemsSet) {
+    for (auto& part : _modelMeshRenderItemsSet) {
         assert(part->_meshIndex < _modelMeshRenderItemsSet.size());
         const Model::MeshState& state = _meshStates.at(part->_meshIndex);
         part->computeAdjustedLocalBound(state.clusterMatrices);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -227,6 +227,10 @@ void Model::updateRenderItems() {
             return;
         }
 
+        // lazy update of cluster matrices used for rendering.
+        // We need to update them here, so we can correctly update the bounding box.
+        self->updateClusterMatrices();
+
         render::ScenePointer scene = AbstractViewStateInterface::instance()->getMain3DScene();
 
         uint32_t deleteGeometryCounter = self->_deleteGeometryCounter;
@@ -240,12 +244,12 @@ void Model::updateRenderItems() {
                         Transform modelTransform = data._model->getTransform();
                         modelTransform.setScale(glm::vec3(1.0f));
 
-                        // lazy update of cluster matrices used for rendering.  We need to update them here, so we can correctly update the bounding box.
-                        data._model->updateClusterMatrices();
-
-                        // update the model transform and bounding box for this render item.
-                        const Model::MeshState& state = data._model->_meshStates.at(data._meshIndex);
-                        data.updateTransformForSkinnedMesh(modelTransform, state.clusterMatrices);
+                        const Model::MeshState& state = data._model->getMeshState(data._meshIndex);
+						Transform renderTransform = modelTransform;
+						if (state.clusterMatrices.size() == 1) {
+							renderTransform = modelTransform.worldTransform(Transform(state.clusterMatrices[0]));
+						}
+                        data.updateTransformForSkinnedMesh(renderTransform, modelTransform, state.clusterBuffer);
                     }
                 }
             });


### PR DESCRIPTION
* compute render and bounds transforms in preRenderLambda context instead of processPendingChangesQueue