### PR TITLE
Cancel Avatar velocity when sitting down.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4383,16 +4383,16 @@ void Application::update(float deltaTime) {
     myAvatar->clearDriveKeys();
     if (_myCamera.getMode() != CAMERA_MODE_INDEPENDENT) {
         if (!_controllerScriptingInterface->areActionsCaptured()) {
-            myAvatar->setDriveKey(TRANSLATE_Z, -1.0f * userInputMapper->getActionState(controller::Action::TRANSLATE_Z));
-            myAvatar->setDriveKey(TRANSLATE_Y, userInputMapper->getActionState(controller::Action::TRANSLATE_Y));
-            myAvatar->setDriveKey(TRANSLATE_X, userInputMapper->getActionState(controller::Action::TRANSLATE_X));
+            myAvatar->setDriveKey(MyAvatar::TRANSLATE_Z, -1.0f * userInputMapper->getActionState(controller::Action::TRANSLATE_Z));
+            myAvatar->setDriveKey(MyAvatar::TRANSLATE_Y, userInputMapper->getActionState(controller::Action::TRANSLATE_Y));
+            myAvatar->setDriveKey(MyAvatar::TRANSLATE_X, userInputMapper->getActionState(controller::Action::TRANSLATE_X));
             if (deltaTime > FLT_EPSILON) {
-                myAvatar->setDriveKey(PITCH, -1.0f * userInputMapper->getActionState(controller::Action::PITCH));
-                myAvatar->setDriveKey(YAW, -1.0f * userInputMapper->getActionState(controller::Action::YAW));
-                myAvatar->setDriveKey(STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW));
+                myAvatar->setDriveKey(MyAvatar::PITCH, -1.0f * userInputMapper->getActionState(controller::Action::PITCH));
+                myAvatar->setDriveKey(MyAvatar::YAW, -1.0f * userInputMapper->getActionState(controller::Action::YAW));
+                myAvatar->setDriveKey(MyAvatar::STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW));
             }
         }
-        myAvatar->setDriveKey(ZOOM, userInputMapper->getActionState(controller::Action::TRANSLATE_CAMERA_Z));
+        myAvatar->setDriveKey(MyAvatar::ZOOM, userInputMapper->getActionState(controller::Action::TRANSLATE_CAMERA_Z));
     }
 
     controller::Pose leftHandPose = userInputMapper->getPoseState(controller::Action::LEFT_HAND);
@@ -5503,8 +5503,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     scriptEngine->registerGlobalObject("Rates", new RatesScriptingInterface(this));
 
     // hook our avatar and avatar hash map object into this script engine
-    scriptEngine->registerGlobalObject("MyAvatar", getMyAvatar().get());
-    qScriptRegisterMetaType(scriptEngine, audioListenModeToScriptValue, audioListenModeFromScriptValue);
+    getMyAvatar()->registerMetaTypes(scriptEngine);
 
     scriptEngine->registerGlobalObject("AvatarList", DependencyManager::get<AvatarManager>().data());
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4383,16 +4383,16 @@ void Application::update(float deltaTime) {
     myAvatar->clearDriveKeys();
     if (_myCamera.getMode() != CAMERA_MODE_INDEPENDENT) {
         if (!_controllerScriptingInterface->areActionsCaptured()) {
-            myAvatar->setDriveKeys(TRANSLATE_Z, -1.0f * userInputMapper->getActionState(controller::Action::TRANSLATE_Z));
-            myAvatar->setDriveKeys(TRANSLATE_Y, userInputMapper->getActionState(controller::Action::TRANSLATE_Y));
-            myAvatar->setDriveKeys(TRANSLATE_X, userInputMapper->getActionState(controller::Action::TRANSLATE_X));
+            myAvatar->setDriveKey(TRANSLATE_Z, -1.0f * userInputMapper->getActionState(controller::Action::TRANSLATE_Z));
+            myAvatar->setDriveKey(TRANSLATE_Y, userInputMapper->getActionState(controller::Action::TRANSLATE_Y));
+            myAvatar->setDriveKey(TRANSLATE_X, userInputMapper->getActionState(controller::Action::TRANSLATE_X));
             if (deltaTime > FLT_EPSILON) {
-                myAvatar->setDriveKeys(PITCH, -1.0f * userInputMapper->getActionState(controller::Action::PITCH));
-                myAvatar->setDriveKeys(YAW, -1.0f * userInputMapper->getActionState(controller::Action::YAW));
-                myAvatar->setDriveKeys(STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW));
+                myAvatar->setDriveKey(PITCH, -1.0f * userInputMapper->getActionState(controller::Action::PITCH));
+                myAvatar->setDriveKey(YAW, -1.0f * userInputMapper->getActionState(controller::Action::YAW));
+                myAvatar->setDriveKey(STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW));
             }
         }
-        myAvatar->setDriveKeys(ZOOM, userInputMapper->getActionState(controller::Action::TRANSLATE_CAMERA_Z));
+        myAvatar->setDriveKey(ZOOM, userInputMapper->getActionState(controller::Action::TRANSLATE_CAMERA_Z));
     }
 
     controller::Pose leftHandPose = userInputMapper->getPoseState(controller::Action::LEFT_HAND);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2091,14 +2091,78 @@ bool MyAvatar::getCharacterControllerEnabled() {
 }
 
 void MyAvatar::clearDriveKeys() {
-    for (int i = 0; i < MAX_DRIVE_KEYS; ++i) {
-        setDriveKey(i, 0.0f);
+    _driveKeys.fill(0.0f);
+}
+
+void MyAvatar::setDriveKey(int key, float val) {
+    try {
+        _driveKeys.at(key) = val;
+    } catch (const std::exception& exception) {
+        qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
+    }
+}
+
+float MyAvatar::getDriveKey(int key) const {
+    return isDriveKeyDisabled(key) ? 0.0f : getRawDriveKey(key);
+}
+
+float MyAvatar::getRawDriveKey(int key) const {
+    try {
+        return _driveKeys.at(key);
+    } catch (const std::exception& exception) {
+        qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
+        return 0.0f;
     }
 }
 
 void MyAvatar::relayDriveKeysToCharacterController() {
     if (getDriveKey(TRANSLATE_Y) > 0.0f) {
         _characterController.jump();
+    }
+}
+
+void MyAvatar::disableDriveKey(int key) {
+    try {
+        _disabledDriveKeys.set(key);
+    } catch (const std::exception& exception) {
+        qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
+    }
+}
+
+void MyAvatar::enableDriveKey(int key) {
+    try {
+        _disabledDriveKeys.reset(key);
+    } catch (const std::exception& exception) {
+        qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
+    }
+}
+
+void MyAvatar::disableDriveKeys(std::vector<int> key) {
+    try {
+        std::for_each(std::begin(key), std::end(key), [&](int val){
+            _disabledDriveKeys.set(val);
+        });
+    } catch (const std::exception& exception) {
+        qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
+    }
+}
+
+void MyAvatar::enableDriveKeys(std::vector<int> key) {
+    try {
+        std::for_each(std::begin(key), std::end(key), [&](int val) {
+            _disabledDriveKeys.reset(val);
+        });
+    } catch (const std::exception& exception) {
+        qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
+    }
+}
+
+bool MyAvatar::isDriveKeyDisabled(int key) const {
+    try {
+        return _disabledDriveKeys.test(key);
+    } catch (const std::exception& exception) {
+        qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
+        return false;
     }
 }
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2162,7 +2162,7 @@ bool MyAvatar::isDriveKeyDisabled(int key) const {
         return _disabledDriveKeys.test(key);
     } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
-        return false;
+        return true;
     }
 }
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2097,7 +2097,7 @@ void MyAvatar::clearDriveKeys() {
 void MyAvatar::setDriveKey(int key, float val) {
     try {
         _driveKeys.at(key) = val;
-    } catch (const std::exception& exception) {
+    } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
     }
 }
@@ -2109,7 +2109,7 @@ float MyAvatar::getDriveKey(int key) const {
 float MyAvatar::getRawDriveKey(int key) const {
     try {
         return _driveKeys.at(key);
-    } catch (const std::exception& exception) {
+    } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
         return 0.0f;
     }
@@ -2124,7 +2124,7 @@ void MyAvatar::relayDriveKeysToCharacterController() {
 void MyAvatar::disableDriveKey(int key) {
     try {
         _disabledDriveKeys.set(key);
-    } catch (const std::exception& exception) {
+    } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
     }
 }
@@ -2132,7 +2132,7 @@ void MyAvatar::disableDriveKey(int key) {
 void MyAvatar::enableDriveKey(int key) {
     try {
         _disabledDriveKeys.reset(key);
-    } catch (const std::exception& exception) {
+    } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
     }
 }
@@ -2142,7 +2142,7 @@ void MyAvatar::disableDriveKeys(std::vector<int> key) {
         std::for_each(std::begin(key), std::end(key), [&](int val){
             _disabledDriveKeys.set(val);
         });
-    } catch (const std::exception& exception) {
+    } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
     }
 }
@@ -2152,7 +2152,7 @@ void MyAvatar::enableDriveKeys(std::vector<int> key) {
         std::for_each(std::begin(key), std::end(key), [&](int val) {
             _disabledDriveKeys.reset(val);
         });
-    } catch (const std::exception& exception) {
+    } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
     }
 }
@@ -2160,7 +2160,7 @@ void MyAvatar::enableDriveKeys(std::vector<int> key) {
 bool MyAvatar::isDriveKeyDisabled(int key) const {
     try {
         return _disabledDriveKeys.test(key);
-    } catch (const std::exception& exception) {
+    } catch (const std::exception&) {
         qCCritical(interfaceapp) << Q_FUNC_INFO << ": Index out of bounds";
         return false;
     }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -182,14 +182,16 @@ public:
 
     //  Set what driving keys are being pressed to control thrust levels
     void clearDriveKeys();
-    void setDriveKey(int key, float val) { _driveKeys[key] = val; };
-    float getDriveKey(int key) const { return isDriveKeyDisabled(key) ? 0.0f : _driveKeys[key]; };
-    Q_INVOKABLE float getRawDriveKey(int key) const { return _driveKeys[key]; };
+    void setDriveKey(int key, float val);
+    float getDriveKey(int key) const;
+    Q_INVOKABLE float getRawDriveKey(int key) const;
     void relayDriveKeysToCharacterController();
 
-    Q_INVOKABLE void disableDriveKey(int key) { _disabledDriveKeys.set(key); }
-    Q_INVOKABLE void enableDriveKey(int key) { _disabledDriveKeys.reset(key); }
-    Q_INVOKABLE bool isDriveKeyDisabled(int key) const { return _disabledDriveKeys.test(key); }
+    Q_INVOKABLE void disableDriveKey(int key);
+    Q_INVOKABLE void enableDriveKey(int key);
+    Q_INVOKABLE void disableDriveKeys(std::vector<int> key);
+    Q_INVOKABLE void enableDriveKeys(std::vector<int> key);
+    Q_INVOKABLE bool isDriveKeyDisabled(int key) const;
 
     eyeContactTarget getEyeContactTarget();
 
@@ -395,7 +397,7 @@ private:
     void clampScaleChangeToDomainLimits(float desiredScale);
     glm::mat4 computeCameraRelativeHandControllerMatrix(const glm::mat4& controllerSensorMatrix) const;
 
-    float _driveKeys[MAX_DRIVE_KEYS];
+    std::array<float, MAX_DRIVE_KEYS> _driveKeys;
     std::bitset<MAX_DRIVE_KEYS> _disabledDriveKeys;
 
     bool _wasPushing;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -31,20 +31,6 @@
 class AvatarActionHold;
 class ModelItemID;
 
-enum DriveKeys {
-    TRANSLATE_X = 0,
-    TRANSLATE_Y,
-    TRANSLATE_Z,
-    YAW,
-    STEP_TRANSLATE_X,
-    STEP_TRANSLATE_Y,
-    STEP_TRANSLATE_Z,
-    STEP_YAW,
-    PITCH,
-    ZOOM,
-    MAX_DRIVE_KEYS
-};
-
 enum eyeContactTarget {
     LEFT_EYE,
     RIGHT_EYE,
@@ -90,8 +76,25 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(bool characterControllerEnabled READ getCharacterControllerEnabled WRITE setCharacterControllerEnabled)
 
 public:
+    enum DriveKeys {
+        TRANSLATE_X = 0,
+        TRANSLATE_Y,
+        TRANSLATE_Z,
+        YAW,
+        STEP_TRANSLATE_X,
+        STEP_TRANSLATE_Y,
+        STEP_TRANSLATE_Z,
+        STEP_YAW,
+        PITCH,
+        ZOOM,
+        MAX_DRIVE_KEYS
+    };
+    Q_ENUM(DriveKeys)
+
     explicit MyAvatar(RigPointer rig);
     ~MyAvatar();
+
+    void registerMetaTypes(QScriptEngine* engine);
 
     virtual void simulateAttachments(float deltaTime) override;
 
@@ -182,16 +185,14 @@ public:
 
     //  Set what driving keys are being pressed to control thrust levels
     void clearDriveKeys();
-    void setDriveKey(int key, float val);
-    float getDriveKey(int key) const;
-    Q_INVOKABLE float getRawDriveKey(int key) const;
+    void setDriveKey(DriveKeys key, float val);
+    float getDriveKey(DriveKeys key) const;
+    Q_INVOKABLE float getRawDriveKey(DriveKeys key) const;
     void relayDriveKeysToCharacterController();
 
-    Q_INVOKABLE void disableDriveKey(int key);
-    Q_INVOKABLE void enableDriveKey(int key);
-    Q_INVOKABLE void disableDriveKeys(std::vector<int> key);
-    Q_INVOKABLE void enableDriveKeys(std::vector<int> key);
-    Q_INVOKABLE bool isDriveKeyDisabled(int key) const;
+    Q_INVOKABLE void disableDriveKey(DriveKeys key);
+    Q_INVOKABLE void enableDriveKey(DriveKeys key);
+    Q_INVOKABLE bool isDriveKeyDisabled(DriveKeys key) const;
 
     eyeContactTarget getEyeContactTarget();
 
@@ -551,5 +552,8 @@ private:
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);
 void audioListenModeFromScriptValue(const QScriptValue& object, AudioListenerMode& audioListenerMode);
+
+QScriptValue driveKeysToScriptValue(QScriptEngine* engine, const MyAvatar::DriveKeys& driveKeys);
+void driveKeysFromScriptValue(const QScriptValue& object, MyAvatar::DriveKeys& driveKeys);
 
 #endif // hifi_MyAvatar_h

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -89,8 +89,6 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(bool hmdLeanRecenterEnabled READ getHMDLeanRecenterEnabled WRITE setHMDLeanRecenterEnabled)
     Q_PROPERTY(bool characterControllerEnabled READ getCharacterControllerEnabled WRITE setCharacterControllerEnabled)
 
-    Q_ENUMS(DriveKeys)
-
 public:
     explicit MyAvatar(RigPointer rig);
     ~MyAvatar();
@@ -185,13 +183,13 @@ public:
     //  Set what driving keys are being pressed to control thrust levels
     void clearDriveKeys();
     void setDriveKey(int key, float val) { _driveKeys[key] = val; };
-    float getDriveKey(int key) const { return isDriveKeyCaptured(key) ? 0.0f : _driveKeys[key]; };
+    float getDriveKey(int key) const { return isDriveKeyDisabled(key) ? 0.0f : _driveKeys[key]; };
     Q_INVOKABLE float getRawDriveKey(int key) const { return _driveKeys[key]; };
     void relayDriveKeysToCharacterController();
 
-    Q_INVOKABLE void captureDriveKey(int key) { _capturedDriveKeys.set(key); }
-    Q_INVOKABLE void releaseDriveKey(int key) { _capturedDriveKeys.reset(key); }
-    Q_INVOKABLE bool isDriveKeyCaptured(int key) const { return _capturedDriveKeys.test(key); }
+    Q_INVOKABLE void disableDriveKey(int key) { _disabledDriveKeys.set(key); }
+    Q_INVOKABLE void enableDriveKey(int key) { _disabledDriveKeys.reset(key); }
+    Q_INVOKABLE bool isDriveKeyDisabled(int key) const { return _disabledDriveKeys.test(key); }
 
     eyeContactTarget getEyeContactTarget();
 
@@ -397,8 +395,8 @@ private:
     void clampScaleChangeToDomainLimits(float desiredScale);
     glm::mat4 computeCameraRelativeHandControllerMatrix(const glm::mat4& controllerSensorMatrix) const;
 
-    std::array<float, MAX_DRIVE_KEYS> _driveKeys;
-    std::bitset<MAX_DRIVE_KEYS> _capturedDriveKeys;
+    float _driveKeys[MAX_DRIVE_KEYS];
+    std::bitset<MAX_DRIVE_KEYS> _disabledDriveKeys;
 
     bool _wasPushing;
     bool _isPushing;

--- a/scripts/tutorials/entity_scripts/sit.js
+++ b/scripts/tutorials/entity_scripts/sit.js
@@ -125,18 +125,14 @@
             return { headType: 0 };
         }, ["headType"]);
         Script.update.connect(this, this.update);
-        for (var i in OVERRIDEN_DRIVE_KEYS) {
-            MyAvatar.disableDriveKey(OVERRIDEN_DRIVE_KEYS[i]);
-        }
+        MyAvatar.disableDriveKey(OVERRIDEN_DRIVE_KEYS);
     }
 
     this.standUp = function() {
         print("Standing up (" + this.entityID + ")");
         MyAvatar.removeAnimationStateHandler(this.animStateHandlerID);
         Script.update.disconnect(this, this.update);
-        for (var i in OVERRIDEN_DRIVE_KEYS) {
-            MyAvatar.enableDriveKey(OVERRIDEN_DRIVE_KEYS[i]);
-        }
+        MyAvatar.enableDriveKey(OVERRIDEN_DRIVE_KEYS);
 
         this.setSeatUser(null);
         if (Settings.getValue(SETTING_KEY) === this.entityID) {

--- a/scripts/tutorials/entity_scripts/sit.js
+++ b/scripts/tutorials/entity_scripts/sit.js
@@ -14,7 +14,14 @@
     var DESKTOP_MAX_DISTANCE = 5;
     var SIT_DELAY = 25;
     var MAX_RESET_DISTANCE = 0.5; // meters
-    var OVERRIDEN_DRIVE_KEYS = [0, 1, 2, 4, 5, 6];
+    var OVERRIDEN_DRIVE_KEYS = [
+        DriveKeys.TRANSLATE_X,
+        DriveKeys.TRANSLATE_Y,
+        DriveKeys.TRANSLATE_Z,
+        DriveKeys.STEP_TRANSLATE_X,
+        DriveKeys.STEP_TRANSLATE_Y,
+        DriveKeys.STEP_TRANSLATE_Z,
+    ];
 
     this.entityID = null;
     this.animStateHandlerID = null;
@@ -125,14 +132,18 @@
             return { headType: 0 };
         }, ["headType"]);
         Script.update.connect(this, this.update);
-        MyAvatar.disableDriveKey(OVERRIDEN_DRIVE_KEYS);
+        for (var i in OVERRIDEN_DRIVE_KEYS) {
+            MyAvatar.disableDriveKey(OVERRIDEN_DRIVE_KEYS[i]);
+        }
     }
 
     this.standUp = function() {
         print("Standing up (" + this.entityID + ")");
         MyAvatar.removeAnimationStateHandler(this.animStateHandlerID);
         Script.update.disconnect(this, this.update);
-        MyAvatar.enableDriveKey(OVERRIDEN_DRIVE_KEYS);
+        for (var i in OVERRIDEN_DRIVE_KEYS) {
+            MyAvatar.enableDriveKey(OVERRIDEN_DRIVE_KEYS[i]);
+        }
 
         this.setSeatUser(null);
         if (Settings.getValue(SETTING_KEY) === this.entityID) {

--- a/scripts/tutorials/entity_scripts/sit.js
+++ b/scripts/tutorials/entity_scripts/sit.js
@@ -6,26 +6,28 @@
     var ANIMATION_FPS = 30;
     var ANIMATION_FIRST_FRAME = 1;
     var ANIMATION_LAST_FRAME = 10;
-    var RELEASE_KEYS = ['w', 'a', 's', 'd', 'UP', 'LEFT', 'DOWN', 'RIGHT'];
     var RELEASE_TIME = 500; // ms
     var RELEASE_DISTANCE = 0.2; // meters
     var MAX_IK_ERROR = 30;
+    var IK_SETTLE_TIME = 250; // ms
     var DESKTOP_UI_CHECK_INTERVAL = 100;
     var DESKTOP_MAX_DISTANCE = 5;
-    var SIT_DELAY = 25
-    var MAX_RESET_DISTANCE = 0.5
+    var SIT_DELAY = 25;
+    var MAX_RESET_DISTANCE = 0.5; // meters
+    var OVERRIDEN_DRIVE_KEYS = [0, 1, 2, 4, 5, 6];
 
     this.entityID = null;
-    this.timers = {};
     this.animStateHandlerID = null;
     this.interval = null;
+    this.sitDownTimestamp = null;
+    this.lastTimeNoDriveKeys = null;
 
     this.preload = function(entityID) {
         this.entityID = entityID;
     }
     this.unload = function() {
         if (Settings.getValue(SETTING_KEY) === this.entityID) {
-            this.sitUp();
+            this.standUp();
         }
         if (this.interval !== null) {
             Script.clearInterval(this.interval);
@@ -96,6 +98,10 @@
             print("Someone is already sitting in that chair.");
             return;
         }
+        print("Sitting down (" + this.entityID + ")");
+
+        this.sitDownTimestamp = Date.now();
+        this.lastTimeNoDriveKeys = this.sitDownTimestamp;
 
         var previousValue = Settings.getValue(SETTING_KEY);
         Settings.setValue(SETTING_KEY, this.entityID);
@@ -118,20 +124,17 @@
             return { headType: 0 };
         }, ["headType"]);
         Script.update.connect(this, this.update);
-        Controller.keyPressEvent.connect(this, this.keyPressed);
-        Controller.keyReleaseEvent.connect(this, this.keyReleased);
-        for (var i in RELEASE_KEYS) {
-            Controller.captureKeyEvents({ text: RELEASE_KEYS[i] });
+        for (var i in OVERRIDEN_DRIVE_KEYS) {
+            MyAvatar.captureDriveKey(OVERRIDEN_DRIVE_KEYS[i]);
         }
     }
 
-    this.sitUp = function() {
+    this.standUp = function() {
+        print("Standing up (" + this.entityID + ")");
         MyAvatar.removeAnimationStateHandler(this.animStateHandlerID);
         Script.update.disconnect(this, this.update);
-        Controller.keyPressEvent.disconnect(this, this.keyPressed);
-        Controller.keyReleaseEvent.disconnect(this, this.keyReleased);
-        for (var i in RELEASE_KEYS) {
-            Controller.releaseKeyEvents({ text: RELEASE_KEYS[i] });
+        for (var i in OVERRIDEN_DRIVE_KEYS) {
+            MyAvatar.releaseDriveKey(OVERRIDEN_DRIVE_KEYS[i]);
         }
 
         this.setSeatUser(null);
@@ -156,6 +159,7 @@
         }
     }
 
+    // function called by teleport.js if it detects the appropriate userData
     this.sit = function () {
         this.sitDown();
     }
@@ -207,7 +211,36 @@
             var properties = Entities.getEntityProperties(this.entityID);
             var avatarDistance = Vec3.distance(MyAvatar.position, properties.position);
             var ikError = MyAvatar.getIKErrorOnLastSolve();
-            if (avatarDistance > RELEASE_DISTANCE || ikError > MAX_IK_ERROR) {
+            var now = Date.now();
+            var shouldStandUp = false;
+
+            // Check if a drive key is pressed
+            var hasActiveDriveKey = false;
+            for (var i in OVERRIDEN_DRIVE_KEYS) {
+                if (MyAvatar.getRawDriveKey(OVERRIDEN_DRIVE_KEYS[i]) != 0.0) {
+                    hasActiveDriveKey = true;
+                    break;
+                }
+            }
+
+            // Only standup if user has been pushing a drive key for RELEASE_TIME
+            if (hasActiveDriveKey) {
+                var elapsed = now - this.lastTimeNoDriveKeys;
+                shouldStandUp = elapsed > RELEASE_TIME;
+            } else {
+                this.lastTimeNoDriveKeys = Date.now();
+            }
+
+            // Allow some time for the IK to settle
+            if (ikError > MAX_IK_ERROR) {
+                var elapsed = now - this.sitDownTimestamp;
+                if (elapsed > IK_SETTLE_TIME) {
+                    shouldStandUp = true;
+                }
+            }
+
+
+            if (shouldStandUp || avatarDistance > RELEASE_DISTANCE) {
                 print("IK error: " + ikError + ", distance from chair: " + avatarDistance);
 
                 // Move avatar in front of the chair to avoid getting stuck in collision hulls
@@ -215,45 +248,13 @@
                     var offset = { x: 0, y: 1.0, z: -0.5 - properties.dimensions.z * properties.registrationPoint.z };
                     var position = Vec3.sum(properties.position, Vec3.multiplyQbyV(properties.rotation, offset));
                     MyAvatar.position = position;
+                    print("Moving Avatar in front of the chair.")
                 }
 
-                this.sitUp();
+                this.standUp();
             }
         }
     }
-    this.keyPressed = function(event) {
-        if (isInEditMode()) {
-            return;
-        }
-
-        if (RELEASE_KEYS.indexOf(event.text) !== -1) {
-            var that = this;
-            this.timers[event.text] = Script.setTimeout(function() {
-                delete that.timers[event.text];
-
-                var properties = Entities.getEntityProperties(that.entityID);
-                var avatarDistance = Vec3.distance(MyAvatar.position, properties.position);
-
-                // Move avatar in front of the chair to avoid getting stuck in collision hulls
-                if (avatarDistance < MAX_RESET_DISTANCE) {
-                    var offset = { x: 0, y: 1.0, z: -0.5 - properties.dimensions.z * properties.registrationPoint.z };
-                    var position = Vec3.sum(properties.position, Vec3.multiplyQbyV(properties.rotation, offset));
-                    MyAvatar.position = position;
-                }
-
-                that.sitUp();
-            }, RELEASE_TIME);
-        }
-    }
-    this.keyReleased = function(event) {
-        if (RELEASE_KEYS.indexOf(event.text) !== -1) {
-            if (this.timers[event.text]) {
-                Script.clearTimeout(this.timers[event.text]);
-                delete this.timers[event.text];
-            }
-        }
-    }
-
     this.canSitDesktop = function() {
         var properties = Entities.getEntityProperties(this.entityID, ["position"]);
         var distanceFromSeat = Vec3.distance(MyAvatar.position, properties.position);


### PR DESCRIPTION
- Added a mechanism to override an avatar's drive keys
- Canceled velocity of Avatar when sitting down


## Test plan:
- Import [this chair](https://gist.githubusercontent.com/Atlante45/81df7b998b768dcf3701ec5e5571e2ee/raw/30aeeb9a355716e3f8eb00df92fcfa8fbd2dcf94/green_chair.json) (Edit > Import Entities From URL)


- Try to sit while jumping/moving and make sure the avatar stays sitted.

This PR is based off [PR9880](https://github.com/highfidelity/hifi/pull/9880), so the diff won't be accurate until the later is merged.


[Bug](https://highfidelity.fogbugz.com/f/cases/3480/Avatar-pops-out-of-chair-when-trying-to-sit)