### PR TITLE
Fix possible crash in Menu::removeSeparator

### DIFF
--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -470,8 +470,8 @@ void Menu::removeSeparator(const QString& menuName, const QString& separatorName
     if (menu) {
         int textAt = findPositionOfMenuItem(menu, separatorName);
         QList<QAction*> menuActions = menu->actions();
-        QAction* separatorText = menuActions[textAt];
         if (textAt > 0 && textAt < menuActions.size()) {
+            QAction* separatorText = menuActions[textAt];
             QAction* separatorLine = menuActions[textAt - 1];
             if (separatorLine) {
                 if (separatorLine->isSeparator()) {


### PR DESCRIPTION
This PR fixes an assertion failure in `Menu::removeSeparator` in debug mode and a potential crash in release mode by preventing out of bounds array access.

## Dev Testing

Build and run the application in debug mode with default scripts.  A number of breakpoints will be hit inside the Qt WebEngine code... ignore them and hit continue on each one.  In master, eventually you will hit a breakpoint caused by an array index out of bounds error in the modified code because `textAt` will have a value of 0xffffffff which is not a valid index for the `menuActions` array.  In this branch, the array index out of bounds will not be triggered.

## Testing

Application behavior should remain unchanged.