### PR TITLE
Adding Import Entities button on the Create tab of Edit

### DIFF
--- a/interface/resources/qml/hifi/tablet/Edit.qml
+++ b/interface/resources/qml/hifi/tablet/Edit.qml
@@ -186,6 +186,11 @@ StackView {
                         anchors.leftMargin: 55
                         anchors.top: assetServerButton.bottom
                         anchors.topMargin: 20
+                        onClicked: {
+                            editRoot.sendToScript({
+                                method: "newEntityButtonClicked", params: { buttonName: "importEntitiesButton" }
+                            });
+                        }
                     }
                 }
             }

--- a/interface/resources/qml/hifi/tablet/Edit.qml
+++ b/interface/resources/qml/hifi/tablet/Edit.qml
@@ -177,7 +177,7 @@ StackView {
                     }
 
                     HifiControls.Button {
-                        text: "Import Entities"
+                        text: "Import Entities (.json)"
                         color: hifi.buttons.black
                         colorScheme: hifi.colorSchemes.dark
                         anchors.right: parent.right

--- a/interface/resources/qml/hifi/tablet/Edit.qml
+++ b/interface/resources/qml/hifi/tablet/Edit.qml
@@ -7,6 +7,7 @@ import "../../controls"
 import "../toolbars"
 import HFWebEngineProfile 1.0
 import QtGraphicalEffects 1.0
+import "../../controls-uit" as HifiControls
 import "../../styles-uit"
 
 StackView {
@@ -16,6 +17,8 @@ StackView {
 
     property var eventBridge;
     signal sendToScript(var message);
+
+    HifiConstants { id: hifi }
 
     function pushSource(path) {
         editRoot.push(Qt.resolvedUrl(path));
@@ -246,6 +249,18 @@ StackView {
                                 }
                             }
                         ]
+                    }
+
+                    HifiControls.Button {
+                        text: "Import Entities"
+                        color: hifi.buttons.black
+                        colorScheme: hifi.colorSchemes.dark
+                        anchors.right: parent.right
+                        anchors.rightMargin: 55
+                        anchors.left: parent.left
+                        anchors.leftMargin: 55
+                        anchors.top: assetServerButton.bottom
+                        anchors.topMargin: 35
                     }
                 }
             }

--- a/interface/resources/qml/hifi/tablet/Edit.qml
+++ b/interface/resources/qml/hifi/tablet/Edit.qml
@@ -158,97 +158,22 @@ StackView {
                         }
                     }
 
-                    Item {
+                    HifiControls.Button {
                         id: assetServerButton
-                        width: 370
-                        height: 38
-                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "Open This Domain's Asset Server"
+                        color: hifi.buttons.black
+                        colorScheme: hifi.colorSchemes.dark
+                        anchors.right: parent.right
+                        anchors.rightMargin: 55
+                        anchors.left: parent.left
+                        anchors.leftMargin: 55
                         anchors.top: createEntitiesFlow.bottom
                         anchors.topMargin: 35
-                        
-                        Rectangle {
-                            id: assetServerButtonBg
-                            color: "black"
-                            opacity: 1
-                            radius: 6
-                            anchors.right: parent.right
-                            anchors.rightMargin: 0
-                            anchors.left: parent.left
-                            anchors.leftMargin: 0
-                            anchors.bottom: parent.bottom
-                            anchors.bottomMargin: 0
-                            anchors.top: parent.top
-                            anchors.topMargin: 0
+                        onClicked: {
+                            editRoot.sendToScript({
+                                method: "newEntityButtonClicked", params: { buttonName: "openAssetBrowserButton" }
+                            });
                         }
-
-                        Rectangle {
-                            id: assetServerButtonGradient
-                            gradient: Gradient {
-                                GradientStop {
-                                    position: 0
-                                    color: "#383838"
-                                }
-
-                                GradientStop {
-                                    position: 1
-                                    color: "black"
-                                }
-                            }
-                            opacity: 1
-                            radius: 6
-                            anchors.right: parent.right
-                            anchors.rightMargin: 0
-                            anchors.left: parent.left
-                            anchors.leftMargin: 0
-                            anchors.bottom: parent.bottom
-                            anchors.bottomMargin: 0
-                            anchors.top: parent.top
-                            anchors.topMargin: 0
-                        }
-
-                        Text {
-                            color: "#ffffff"
-                            text: "OPEN THIS DOMAIN'S ASSET SERVER"
-                            font.bold: true
-                            font.pixelSize: 14
-                            anchors.centerIn: parent
-                        }
-
-                        MouseArea {
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            enabled: true
-                            onClicked: {
-                                editRoot.sendToScript({
-                                    method: "newEntityButtonClicked", params: { buttonName: "openAssetBrowserButton" }
-                                });
-                            }
-                            onEntered: {
-                                assetServerButton.state = "hover state";
-                            }
-                            onExited: {
-                                assetServerButton.state = "base state";
-                            }
-                        }
-
-                        states: [
-                            State {
-                                name: "hover state"
-
-                                PropertyChanges {
-                                    target: assetServerButtonGradient
-                                    opacity: 0
-                                }
-                            },
-                            State {
-                                name: "base state"
-
-                                PropertyChanges {
-                                    target: assetServerButtonGradient
-                                    opacity: 1
-                                }
-                            }
-                        ]
                     }
 
                     HifiControls.Button {
@@ -260,7 +185,7 @@ StackView {
                         anchors.left: parent.left
                         anchors.leftMargin: 55
                         anchors.top: assetServerButton.bottom
-                        anchors.topMargin: 35
+                        anchors.topMargin: 20
                     }
                 }
             }

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -294,7 +294,21 @@ var toolBar = (function () {
             that.toggle();
         });
 
-        addButton("openAssetBrowserButton", "assets-01.svg", function(){
+        addButton("importEntitiesButton", "assets-01.svg", function() {
+            var importURL = null;
+            var fullPath = Window.browse("Select Model to Import", "", "*.json");
+            if (fullPath) {
+                importURL = "file:///" + fullPath;
+            }
+            if (importURL) {
+                if (!isActive && (Entities.canRez() && Entities.canRezTmp())) {
+                    toolBar.toggle();
+                }
+                importSVO(importURL);
+            }
+        });
+
+        addButton("openAssetBrowserButton", "assets-01.svg", function() {
             Window.showAssetServer();
         });
 


### PR DESCRIPTION
This button has the same functionality as the menu's Edit -> Import Entities, but we now place it inside of the edit's create tab so that user can quickly import json of entities as they are building.

Test plan: 
Open Tablet, go to Edit. In create tab, confirm their is a "Import Entities (.json)" button at the bottom of the screen. Click it and try importing a json. Try with different tablet modes too (e.g. toolbar in desktop, hand controllers in HMD)