### PR TITLE
Fix a few sitting bugs noticed at the meetup

### DIFF
--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -440,7 +440,12 @@ function getTeleportTargetType(intersection) {
     var props = Entities.getEntityProperties(intersection.entityID, ['userData', 'visible']);
     var data = parseJSON(props.userData);
     if (data !== undefined && data.seat !== undefined) {
-        return TARGET.SEAT;
+        var avatarUuid = Uuid.fromString(data.seat.user);
+        if (Uuid.isNull(avatarUuid) || !AvatarList.getAvatar(avatarUuid)) {
+            return TARGET.SEAT;
+        } else {
+            return TARGET.INVALID;
+        }
     }
 
     if (!props.visible) {

--- a/scripts/tutorials/entity_scripts/sit.js
+++ b/scripts/tutorials/entity_scripts/sit.js
@@ -156,7 +156,10 @@
         MyAvatar.removeAnimationStateHandler(this.animStateHandlerID);
         Script.update.disconnect(this, this.update);
 
-        this.setSeatUser(null);
+        if (MyAvatar.sessionUUID === this.getSeatUser()) {
+            this.setSeatUser(null);
+        }
+
         if (Settings.getValue(SETTING_KEY) === this.entityID) {
             Settings.setValue(SETTING_KEY, "");
 
@@ -261,6 +264,9 @@
                 shouldStandUp = true;
             }
 
+            if (MyAvatar.sessionUUID !== this.getSeatUser()) {
+                shouldStandUp = true;
+            }
 
             if (shouldStandUp || avatarDistance > RELEASE_DISTANCE) {
                 print("IK error: " + ikError + ", distance from chair: " + avatarDistance);

--- a/scripts/tutorials/entity_scripts/sit.js
+++ b/scripts/tutorials/entity_scripts/sit.js
@@ -276,7 +276,11 @@
                     var offset = { x: 0, y: 1.0, z: -0.5 - properties.dimensions.z * properties.registrationPoint.z };
                     var position = Vec3.sum(properties.position, Vec3.multiplyQbyV(properties.rotation, offset));
                     MyAvatar.position = position;
-                    print("Moving Avatar in front of the chair.")
+                    print("Moving Avatar in front of the chair.");
+                    // Delay standing up by 1 cycle.
+                    // This leaves times for the avatar to actually move since a lot
+                    // of the stand up operations are threaded
+                    return;
                 }
 
                 this.standUp();

--- a/scripts/tutorials/entity_scripts/sit.js
+++ b/scripts/tutorials/entity_scripts/sit.js
@@ -10,7 +10,13 @@
 
 (function() {
     Script.include("/~/system/libraries/utils.js");
-   
+    if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function(searchString, position){
+          position = position || 0;
+          return this.substr(position, searchString.length) === searchString;
+      };
+    }
+
     var SETTING_KEY = "com.highfidelity.avatar.isSitting";
     var ANIMATION_URL = "https://s3-us-west-1.amazonaws.com/hifi-content/clement/production/animations/sitting_idle.fbx";
     var ANIMATION_FPS = 30;
@@ -111,6 +117,12 @@
         return seatUser !== null;
     }
 
+    this.rolesToOverride = function() {
+        return MyAvatar.getAnimationRoles().filter(function(role) {
+            return role === "fly" || role.startsWith("inAir");
+        });
+    }
+
     this.sitDown = function() {
         if (this.checkSeatForAvatar()) {
             print("Someone is already sitting in that chair.");
@@ -129,9 +141,9 @@
         if (previousValue === "") {
             MyAvatar.characterControllerEnabled = false;
             MyAvatar.hmdLeanRecenterEnabled = false;
-            var ROLES = MyAvatar.getAnimationRoles();
-            for (i in ROLES) {
-                MyAvatar.overrideRoleAnimation(ROLES[i], ANIMATION_URL, ANIMATION_FPS, true, ANIMATION_FIRST_FRAME, ANIMATION_LAST_FRAME);
+            var roles = this.rolesToOverride();
+            for (i in roles) {
+                MyAvatar.overrideRoleAnimation(roles[i], ANIMATION_URL, ANIMATION_FPS, true, ANIMATION_FIRST_FRAME, ANIMATION_LAST_FRAME);
             }
 
             for (var i in OVERRIDEN_DRIVE_KEYS) {
@@ -167,9 +179,9 @@
                 MyAvatar.enableDriveKey(OVERRIDEN_DRIVE_KEYS[i]);
             }
 
-            var ROLES = MyAvatar.getAnimationRoles();
-            for (i in ROLES) {
-                MyAvatar.restoreRoleAnimation(ROLES[i]);
+            var roles = this.rolesToOverride();
+            for (i in roles) {
+                MyAvatar.restoreRoleAnimation(roles[i]);
             }
             MyAvatar.characterControllerEnabled = true;
             MyAvatar.hmdLeanRecenterEnabled = true;

--- a/scripts/tutorials/entity_scripts/sit.js
+++ b/scripts/tutorials/entity_scripts/sit.js
@@ -46,6 +46,9 @@
     this.lastTimeNoDriveKeys = null;
     this.sittingDown = false;
 
+    // Preload the animation file
+    this.animation = AnimationCache.prefetch(ANIMATION_URL);
+
     this.preload = function(entityID) {
         this.entityID = entityID;
     }


### PR DESCRIPTION
- Teleport target say cancel if someone is sitting in the chair
- Fingers can move while seated
- Prefetch sitting animation
- If several users manage to get in a seat at the same time, pop one out of it
- Tall avatar are less likely to get stuck in geometry


## Test Plan:

[Chair](https://s3-us-west-1.amazonaws.com/hifi-content/clement/dev/chair.json)
Make sure you are using the defaultScripts.js from this PR.

#### SIT-08 Test
Objective: Teleport target say cancel if someone is sitting in the chair.
Precondition: You must be in an HMD.
Step 1: Point your teleport beam at a chair with someone sitting in it.
Test Data: Use the chair provided.
Expected Result: The teleport target should turn yellow and say "Cancel"
#### SIT-09 Test
Objective: Fingers can move while seated.
Precondition: You must be in an HMD.
Step 1: Sit down on the chair
Step 2: Move your fingers, squeeze your hands with the grab button.
Test Data: Use the chair provided.
Expected Result: Your fingers should move as expected.
#### SIT-10 Test
Objective: Can't have several people sit in the same chair.
Precondition: Enter a domain with one other person or use 2 computers at the same time.
Step 1: Using voice to synchronize, try to sit in the same chair at the exact same time.
Test Data: Use the chair provided.
Expected Result: Both avatars should get teleported to the chair, but one should immediately pop out of it.
#### SIT-11 Test
Objective: Sitting animation is prefetched.
Precondition: Delete or save you interface cache if you don't want to lose it. `C:\Users\<username>\AppData\Local\High Fidelity[ - PRxxxx]\Interface\data8`
Step 1: Start interface.
Step 2: Go to a chair.
Step 3: Look at your legs while sitting down
Test Data: Use the chair provided.
Expected Result: There should be no perceivable delay between the time you get teleported to the chair and the time your avatar gets into a sitting pose.

