### PR TITLE
21232 - Remove Mini Mirror from View menu

### DIFF
--- a/interface/resources/qml/AvatarInputs.qml
+++ b/interface/resources/qml/AvatarInputs.qml
@@ -15,12 +15,11 @@ import Qt.labs.settings 1.0
 Hifi.AvatarInputs {
     id: root
     objectName: "AvatarInputs"
-    width: mirrorWidth
-    height: controls.height + mirror.height 
+    width: rootWidth
+    height: controls.height
     x: 10; y: 5
 
-    readonly property int mirrorHeight: 215
-    readonly property int mirrorWidth: 265
+    readonly property int rootWidth: 265
     readonly property int iconSize: 24
     readonly property int iconPadding: 5
 
@@ -40,60 +39,14 @@ Hifi.AvatarInputs {
     }
 
     Item {
-        id: mirror
-        width: root.mirrorWidth
-        height: root.mirrorVisible ? root.mirrorHeight : 0
-        visible: root.mirrorVisible
-        anchors.left: parent.left
-        clip: true
-
-        Image {
-            id: closeMirror
-            visible: hover.containsMouse
-            width: root.iconSize
-            height: root.iconSize
-            anchors.top: parent.top
-            anchors.topMargin: root.iconPadding
-            anchors.left: parent.left
-            anchors.leftMargin: root.iconPadding
-            source: "../images/close.svg"
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    root.closeMirror();
-                }
-            }
-        }
-
-        Image {
-            id: zoomIn
-            visible: hover.containsMouse
-            width: root.iconSize
-            height: root.iconSize
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: root.iconPadding
-            anchors.left: parent.left
-            anchors.leftMargin: root.iconPadding
-            source: root.mirrorZoomed ? "../images/minus.svg" : "../images/plus.svg"
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    root.toggleZoom();
-                }
-            }
-        }
-    }
-
-    Item {
         id: controls
-        width: root.mirrorWidth
+        width: root.rootWidth
         height: 44
         visible: root.showAudioTools
-        anchors.top: mirror.bottom
 
         Rectangle {
             anchors.fill: parent
-            color: root.mirrorVisible ? (root.audioClipping ? "red" : "#696969") : "#00000000"
+            color: "#00000000"
 
             Item {
                 id: audioMeter

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2863,30 +2863,30 @@ void Application::keyPressEvent(QKeyEvent* event) {
                 break;
 #endif
 
-            case Qt::Key_H:
+            case Qt::Key_H: {
                 // whenever switching to/from full screen mirror from the keyboard, remember
                 // the state you were in before full screen mirror, and return to that.
                 auto previousMode = _myCamera.getMode();
                 if (previousMode != CAMERA_MODE_MIRROR) {
                     switch (previousMode) {
-                        case CAMERA_MODE_FIRST_PERSON:
-                            _returnFromFullScreenMirrorTo = MenuOption::FirstPerson;
-                            break;
-                        case CAMERA_MODE_THIRD_PERSON:
-                            _returnFromFullScreenMirrorTo = MenuOption::ThirdPerson;
-                            break;
+                    case CAMERA_MODE_FIRST_PERSON:
+                        _returnFromFullScreenMirrorTo = MenuOption::FirstPerson;
+                        break;
+                    case CAMERA_MODE_THIRD_PERSON:
+                        _returnFromFullScreenMirrorTo = MenuOption::ThirdPerson;
+                        break;
 
                         // FIXME - it's not clear that these modes make sense to return to...
-                        case CAMERA_MODE_INDEPENDENT:
-                            _returnFromFullScreenMirrorTo = MenuOption::IndependentMode;
-                            break;
-                        case CAMERA_MODE_ENTITY:
-                            _returnFromFullScreenMirrorTo = MenuOption::CameraEntityMode;
-                            break;
+                    case CAMERA_MODE_INDEPENDENT:
+                        _returnFromFullScreenMirrorTo = MenuOption::IndependentMode;
+                        break;
+                    case CAMERA_MODE_ENTITY:
+                        _returnFromFullScreenMirrorTo = MenuOption::CameraEntityMode;
+                        break;
 
-                        default:
-                            _returnFromFullScreenMirrorTo = MenuOption::ThirdPerson;
-                            break;
+                    default:
+                        _returnFromFullScreenMirrorTo = MenuOption::ThirdPerson;
+                        break;
                     }
                 }
 
@@ -2904,6 +2904,8 @@ void Application::keyPressEvent(QKeyEvent* event) {
                 }
                 cameraMenuChanged();
                 break;
+            }
+
             case Qt::Key_P: {
                 if (!(isShifted || isMeta || isOption)) {
                     bool isFirstPersonChecked = Menu::getInstance()->isOptionChecked(MenuOption::FirstPerson);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -276,8 +276,6 @@ public:
 
     virtual void pushPostUpdateLambda(void* key, std::function<void()> func) override;
 
-    const QRect& getMirrorViewRect() const { return _mirrorViewRect; }
-
     void updateMyAvatarLookAtPosition();
 
     float getAvatarSimrate() const { return _avatarSimCounter.rate(); }
@@ -557,8 +555,6 @@ private:
     int _avatarSimsPerSecondReport {0};
     quint64 _lastAvatarSimsPerSecondUpdate {0};
     Camera _myCamera;                            // My view onto the world
-    Camera _mirrorCamera;                        // Camera for mirror view
-    QRect _mirrorViewRect;
 
     Setting::Handle<QString> _previousScriptLocation;
     Setting::Handle<float> _fieldOfView;

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -249,9 +249,6 @@ Menu::Menu() {
 
     viewMenu->addSeparator();
 
-    // View > Mini Mirror
-    addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::MiniMirror, 0, false);
-
     // View > Center Player In View
     addCheckableActionToQMenuAndActionHash(viewMenu, MenuOption::CenterPlayerInView,
         0, true, qApp, SLOT(rotationModeChanged()),

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -123,7 +123,6 @@ namespace MenuOption {
     const QString LogExtraTimings = "Log Extra Timing Details";
     const QString LowVelocityFilter = "Low Velocity Filter";
     const QString MeshVisible = "Draw Mesh";
-    const QString MiniMirror = "Mini Mirror";
     const QString MuteAudio = "Mute Microphone";
     const QString MuteEnvironment = "Mute Environment";
     const QString MuteFaceTracking = "Mute Face Tracking";

--- a/interface/src/ui/ApplicationOverlay.h
+++ b/interface/src/ui/ApplicationOverlay.h
@@ -31,8 +31,6 @@ public:
 private:
     void renderStatsAndLogs(RenderArgs* renderArgs);
     void renderDomainConnectionStatusBorder(RenderArgs* renderArgs);
-    void renderRearViewToFbo(RenderArgs* renderArgs);
-    void renderRearView(RenderArgs* renderArgs);
     void renderQmlUi(RenderArgs* renderArgs);
     void renderAudioScope(RenderArgs* renderArgs);
     void renderOverlays(RenderArgs* renderArgs);
@@ -51,7 +49,6 @@ private:
     gpu::TexturePointer _overlayColorTexture;
     gpu::FramebufferPointer _overlayFramebuffer;
     int _qmlGeometryId { 0 };
-    int _rearViewGeometryId { 0 };
 };
 
 #endif // hifi_ApplicationOverlay_h

--- a/interface/src/ui/AvatarInputs.cpp
+++ b/interface/src/ui/AvatarInputs.cpp
@@ -20,10 +20,6 @@ HIFI_QML_DEF(AvatarInputs)
 
 
 static AvatarInputs* INSTANCE{ nullptr };
-static const char SETTINGS_GROUP_NAME[] = "Rear View Tools";
-static const char ZOOM_LEVEL_SETTINGS[] = "ZoomLevel";
-
-static Setting::Handle<int> rearViewZoomLevel(QStringList() << SETTINGS_GROUP_NAME << ZOOM_LEVEL_SETTINGS, 0);
 
 AvatarInputs* AvatarInputs::getInstance() {
     if (!INSTANCE) {
@@ -36,8 +32,6 @@ AvatarInputs* AvatarInputs::getInstance() {
 
 AvatarInputs::AvatarInputs(QQuickItem* parent) :  QQuickItem(parent) {
     INSTANCE = this;
-    int zoomSetting = rearViewZoomLevel.get();
-    _mirrorZoomed = zoomSetting == 0;
 }
 
 #define AI_UPDATE(name, src) \
@@ -62,8 +56,6 @@ void AvatarInputs::update() {
     if (!Menu::getInstance()) {
         return;
     }
-    AI_UPDATE(mirrorVisible, Menu::getInstance()->isOptionChecked(MenuOption::MiniMirror) && !qApp->isHMDMode()
-        && !Menu::getInstance()->isOptionChecked(MenuOption::FullscreenMirror));
     AI_UPDATE(cameraEnabled, !Menu::getInstance()->isOptionChecked(MenuOption::NoFaceTracking));
     AI_UPDATE(cameraMuted, Menu::getInstance()->isOptionChecked(MenuOption::MuteFaceTracking));
     AI_UPDATE(isHMD, qApp->isHMDMode());
@@ -121,16 +113,4 @@ void AvatarInputs::toggleAudioMute() {
 
 void AvatarInputs::resetSensors() {
     qApp->resetSensors();
-}
-
-void AvatarInputs::toggleZoom() {
-    _mirrorZoomed = !_mirrorZoomed;
-    rearViewZoomLevel.set(_mirrorZoomed ? 0 : 1);
-    emit mirrorZoomedChanged();
-}
-
-void AvatarInputs::closeMirror() {
-    if (Menu::getInstance()->isOptionChecked(MenuOption::MiniMirror)) {
-        Menu::getInstance()->triggerOption(MenuOption::MiniMirror);
-    }
 }

--- a/interface/src/ui/AvatarInputs.h
+++ b/interface/src/ui/AvatarInputs.h
@@ -28,8 +28,6 @@ class AvatarInputs : public QQuickItem {
     AI_PROPERTY(bool, audioMuted, false)
     AI_PROPERTY(bool, audioClipping, false)
     AI_PROPERTY(float, audioLevel, 0)
-    AI_PROPERTY(bool, mirrorVisible, false)
-    AI_PROPERTY(bool, mirrorZoomed, true)
     AI_PROPERTY(bool, isHMD, false)
     AI_PROPERTY(bool, showAudioTools, true)
 
@@ -44,8 +42,6 @@ signals:
     void audioMutedChanged();
     void audioClippingChanged();
     void audioLevelChanged();
-    void mirrorVisibleChanged();
-    void mirrorZoomedChanged();
     void isHMDChanged();
     void showAudioToolsChanged();
 
@@ -53,8 +49,6 @@ protected:
     Q_INVOKABLE void resetSensors();
     Q_INVOKABLE void toggleCameraMute();
     Q_INVOKABLE void toggleAudioMute();
-    Q_INVOKABLE void toggleZoom();
-    Q_INVOKABLE void closeMirror();
 
 private: 
     float _trailingAudioLoudness{ 0 };

--- a/libraries/render-utils/src/FramebufferCache.cpp
+++ b/libraries/render-utils/src/FramebufferCache.cpp
@@ -29,10 +29,6 @@ void FramebufferCache::setFrameBufferSize(QSize frameBufferSize) {
 }
 
 void FramebufferCache::createPrimaryFramebuffer() {
-    auto colorFormat = gpu::Element::COLOR_SRGBA_32;
-    auto width = _frameBufferSize.width();
-    auto height = _frameBufferSize.height();
-
     auto defaultSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT);
 
     auto smoothSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR);

--- a/libraries/render-utils/src/FramebufferCache.cpp
+++ b/libraries/render-utils/src/FramebufferCache.cpp
@@ -21,7 +21,6 @@ void FramebufferCache::setFrameBufferSize(QSize frameBufferSize) {
     //If the size changed, we need to delete our FBOs
     if (_frameBufferSize != frameBufferSize) {
         _frameBufferSize = frameBufferSize;
-        _selfieFramebuffer.reset();
         {
             std::unique_lock<std::mutex> lock(_mutex);
             _cachedFramebuffers.clear();
@@ -35,10 +34,6 @@ void FramebufferCache::createPrimaryFramebuffer() {
     auto height = _frameBufferSize.height();
 
     auto defaultSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT);
-
-    _selfieFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("selfie"));
-    auto tex = gpu::TexturePointer(gpu::Texture::create2D(colorFormat, width * 0.5, height * 0.5, defaultSampler));
-    _selfieFramebuffer->setRenderBuffer(0, tex);
 
     auto smoothSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_MIP_LINEAR);
 }
@@ -59,11 +54,4 @@ void FramebufferCache::releaseFramebuffer(const gpu::FramebufferPointer& framebu
     if (QSize(framebuffer->getSize().x, framebuffer->getSize().y) == _frameBufferSize) {
         _cachedFramebuffers.push_back(framebuffer);
     }
-}
-
-gpu::FramebufferPointer FramebufferCache::getSelfieFramebuffer() {
-    if (!_selfieFramebuffer) {
-        createPrimaryFramebuffer();
-    }
-    return _selfieFramebuffer;
 }

--- a/libraries/render-utils/src/FramebufferCache.h
+++ b/libraries/render-utils/src/FramebufferCache.h
@@ -27,9 +27,6 @@ public:
     void setFrameBufferSize(QSize frameBufferSize);
     const QSize& getFrameBufferSize() const { return _frameBufferSize; } 
 
-    /// Returns the framebuffer object used to render selfie maps;
-    gpu::FramebufferPointer getSelfieFramebuffer();
-
     /// Returns a free framebuffer with a single color attachment for temp or intra-frame operations
     gpu::FramebufferPointer getFramebuffer();
 
@@ -41,8 +38,6 @@ private:
     void createPrimaryFramebuffer();
 
     gpu::FramebufferPointer _shadowFramebuffer;
-
-    gpu::FramebufferPointer _selfieFramebuffer;
 
     QSize _frameBufferSize{ 100, 100 };
 


### PR DESCRIPTION
**Test Plan:**

The Mini Mirror option should be removed from the View menu.
The Mirror option should still be available with no change to behavior, the audio level meter should also have no change to behavior. 
