### PR TITLE
New simplified, stand-alone build guide for Windows

### DIFF
--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -1,104 +1,80 @@
-Please read the [general build guide](BUILD.md) for information on dependencies required for all platforms. Only Windows specific instructions are found in this file.
+This is a stand-alone guide for creating your first High Fidelity build for Windows 64-bit.
 
-Interface can be built as 32 or 64 bit.
+###Step 1. Installing Visual Studio 2013
 
-###Visual Studio 2013
+If you don't already have the Community or Professional edition of Visual Studio 2013, download and install [Visual Studio Community 2013](https://www.visualstudio.com/en-us/news/releasenotes/vs2013-community-vs). You do not need to install any of the optional components when going through the installer.
 
-You can use the Community or Professional editions of Visual Studio 2013.
+Note: Newer versions of Visual Studio are not yet compatible. 
 
-You can start a Visual Studio 2013 command prompt using the shortcut provided in the Visual Studio Tools folder installed as part of Visual Studio 2013.
+###Step 2. Installing CMake
 
-Or you can start a regular command prompt and then run:
+Download and install the "win64-x64 Installer" from the [CMake Website](https://cmake.org/download/). Make sure "Add CMake to system PATH for all users" is checked when going through the installer.
 
-    "%VS120COMNTOOLS%\vsvars32.bat"
+###Step 3. Installing Qt
 
-####Windows SDK 8.1
+Download and install the [Qt 5.6.1 Installer](https://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-msvc2013_64-5.6.1-1.exe)
 
-If using Visual Studio 2013 and building as a Visual Studio 2013 project you need the Windows 8 SDK which you should already have as part of installing Visual Studio 2013. You should be able to see it at `C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x86`.
+Make sure to select all components when going through the installer.
 
-####nmake
+###Step 4. Setting Qt Environment Variable
 
-Some of the external projects may require nmake to compile and install. If it is not installed at the location listed below, please ensure that it is in your PATH so CMake can find it when required.
+Go to "Control Panel > System > Advanced System Settings > Environment Variables > New..."
+* Set "Variable name": QT_CMAKE_PREFIX_PATH
+* Set "Variable value": `C:\Qt\Qt5.6.1\5.6\msvc2013_64\lib\cmake`
 
-We expect nmake.exe to be located at the following path.
+###Step 5. Installing OpenSSL
 
-    C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin
+Download and install the "Win64 OpenSSL v1.0.xk" Installer from [this website](https://slproweb.com/products/Win32OpenSSL.html), where "x" is the number of the latest release (ex. Win64 OpenSSL v1.0.2k).
 
-###Qt
-You can use the online installer or the offline installer. If you use the offline installer, be sure to select the "OpenGL" version.
+###Step 6. Running CMake to Generate Build Files
 
-* [Download the online installer](http://www.qt.io/download-open-source/#section-2)
-    * When it asks you to select components, ONLY select one of the following, 32- or 64-bit to match your build preference:
-        * Qt > Qt 5.6.1 > **msvc2013 32-bit**
-        * Qt > Qt 5.6.1 > **msvc2013 64-bit**
-
-* Download the offline installer, 32- or 64-bit to match your build preference:
-    * [32-bit](https://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-msvc2013-5.6.1-1.exe)
-    * [64-bit](https://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-msvc2013_64-5.6.1-1.exe)
-
-Once Qt is installed, you need to manually configure the following:
-* Set the QT_CMAKE_PREFIX_PATH environment variable to your `Qt\5.6.1\msvc2013\lib\cmake` or `Qt\5.6.1\msvc2013_64\lib\cmake` directory.
-  * You can set an environment variable from Control Panel > System > Advanced System Settings > Environment Variables > New
-
-###External Libraries
-
-All libraries should be 32- or 64-bit to match your build preference.
-
-CMake will need to know where the headers and libraries for required external dependencies are.
-
-We use CMake's `fixup_bundle` to find the DLLs all of our executable targets require, and then copy them beside the executable in a post-build step. If `fixup_bundle` is having problems finding a DLL, you can fix it manually on your end by adding the folder containing that DLL to your path. Let us know which DLL CMake had trouble finding, as it is possible a tweak to our CMake files is required.
-
-The recommended route for CMake to find the external dependencies is to place all of the dependencies in one folder and set one ENV variable - HIFI_LIB_DIR. That ENV variable should point to a directory with the following structure:
-
-    root_lib_dir
-        -> openssl
-            -> bin
-            -> include
-            -> lib
-
-For many of the external libraries where precompiled binaries are readily available you should be able to simply copy the extracted folder that you get from the download links provided at the top of the guide. Otherwise you may need to build from source and install the built product to this directory. The `root_lib_dir` in the above example can be wherever you choose on your system - as long as the environment variable HIFI_LIB_DIR is set to it. From here on, whenever you see %HIFI_LIB_DIR% you should substitute the directory that you chose.
-
-####OpenSSL
-
-Qt will use OpenSSL if it's available, but it doesn't install it, so you must install it separately.
-
-Your system may already have several versions of the OpenSSL DLL's (ssleay32.dll, libeay32.dll) lying around, but they may be the wrong version. If these DLL's are in the PATH then QT will try to use them, and if they're the wrong version then you will see the following errors in the console:
-
-    QSslSocket: cannot resolve TLSv1_1_client_method
-    QSslSocket: cannot resolve TLSv1_2_client_method
-    QSslSocket: cannot resolve TLSv1_1_server_method
-    QSslSocket: cannot resolve TLSv1_2_server_method
-    QSslSocket: cannot resolve SSL_select_next_proto
-    QSslSocket: cannot resolve SSL_CTX_set_next_proto_select_cb
-    QSslSocket: cannot resolve SSL_get0_next_proto_negotiated
-
-To prevent these problems, install OpenSSL yourself. Download one of the following binary packages [from this website](https://slproweb.com/products/Win32OpenSSL.html):
-* Win32 OpenSSL v1.0.1q
-* Win64 OpenSSL v1.0.1q
-
-Install OpenSSL into the Windows system directory, to make sure that Qt uses the version that you've just installed, and not some other version.
-
-###Build High Fidelity using Visual Studio
-Follow the same build steps from the CMake section of [BUILD.md](BUILD.md), but pass a different generator to CMake.
-
-For 32-bit builds:
-
-    cmake .. -G "Visual Studio 12"
-
-For 64-bit builds:
-
+Run Command Prompt from Start and run the following commands:
+    cd "%HIFI_DIR%"
+    mkdir build
+    cd build
     cmake .. -G "Visual Studio 12 Win64"
+    
+Where %HIFI_DIR% is the directory for the highfidelity repository.     
 
-Open %HIFI_DIR%\build\hifi.sln and compile.
+###Step 7. Making a Build
 
-###Running Interface
-If you need to debug Interface, you can run interface from within Visual Studio (see the section below). You can also run Interface by launching it from command line or File Explorer from %HIFI_DIR%\build\interface\Debug\interface.exe
+Open '%HIFI_DIR%\build\hifi.sln' using Visual Studio.
 
-###Debugging Interface
-* In the Solution Explorer, right click interface and click Set as StartUp Project
-* Set the "Working Directory" for the Interface debugging sessions to the Debug output directory so that your application can load resources. Do this: right click interface and click Properties, choose Debugging from Configuration Properties, set Working Directory to .\Debug
-* Now you can run and debug interface through Visual Studio
+Change the Solution Configuration (next to the green play button) from "Debug" to "Release" for best performance.
 
-For better performance when running debug builds, set the environment variable ```_NO_DEBUG_HEAP``` to ```1```
+Run Build > Build Solution.
 
-http://preshing.com/20110717/the-windows-heap-is-slow-when-launched-from-the-debugger/
+###Step 8. Testing the Interface
+
+Create another environment variable (see Step #4)
+* Set "Variable name": _NO_DEBUG_HEAP
+* Set "Variable value": 1
+
+In Visual Studio, right+click "interface" under the Apps folder in Solution Explorer and select "Set as Startup Project". Run Debug > Start Debugging.
+
+Now, you should have a full build of High Fidelity and be able to run the Interface using Visual Studio. Please check our [Docs](https://wiki.highfidelity.com/wiki/Main_Page) for more information regarding the programming workflow.
+
+Note: You can also run Interface by launching it from command line or File Explorer from %HIFI_DIR%\build\interface\Debug\interface.exe
+
+###Troubleshooting
+
+For any problems after Step #6, first try this: 
+* Delete the highfidelity repository
+* Restart your computer
+* Redownload the [repository](https://github.com/highfidelity/hifi) 
+* Restart directions from Step #6
+
+####CMake gives you the same error message repeatedly after the build fails
+
+Remove `CMakeCache.txt` found in the '%HIFI_DIR%\build' directory
+
+####nmake cannot be found
+
+Make sure nmake.exe is located at the following path:
+    C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin
+    
+If not, add the directory where nmake is located to the PATH environment variable.
+
+####Qt is throwing an error
+
+Make sure you have the current version (5.6.1-1) installed and 'QT_CMAKE_PREFIX_PATH' environment variable is set correctly.

--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -8,23 +8,23 @@ Note: Newer versions of Visual Studio are not yet compatible.
 
 ###Step 2. Installing CMake
 
-Download and install the "win64-x64 Installer" from the [CMake Website](https://cmake.org/download/). Make sure "Add CMake to system PATH for all users" is checked when going through the installer.
+Download and install the CMake 3.8.0-rc2 "win64-x64 Installer" from the [CMake Website](https://cmake.org/download/). Make sure "Add CMake to system PATH for all users" is checked when going through the installer.
 
 ###Step 3. Installing Qt
 
-Download and install the [Qt 5.6.1 Installer](https://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-msvc2013_64-5.6.1-1.exe)
+Download and install the [Qt 5.6.1 Installer](https://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-msvc2013_64-5.6.1-1.exe). Please note that the download file is large (850MB) and may take some time.
 
 Make sure to select all components when going through the installer.
 
 ###Step 4. Setting Qt Environment Variable
 
-Go to "Control Panel > System > Advanced System Settings > Environment Variables > New..."
+Go to "Control Panel > System > Advanced System Settings > Environment Variables > New..." (or search “Environment Variables” in Start Search).
 * Set "Variable name": QT_CMAKE_PREFIX_PATH
 * Set "Variable value": `C:\Qt\Qt5.6.1\5.6\msvc2013_64\lib\cmake`
 
 ###Step 5. Installing OpenSSL
 
-Download and install the "Win64 OpenSSL v1.0.xk" Installer from [this website](https://slproweb.com/products/Win32OpenSSL.html), where "x" is the number of the latest release (ex. Win64 OpenSSL v1.0.2k).
+Download and install the "Win64 OpenSSL v1.0.2k" Installer from [this website](https://slproweb.com/products/Win32OpenSSL.html).
 
 ###Step 6. Running CMake to Generate Build Files
 
@@ -44,7 +44,7 @@ Change the Solution Configuration (next to the green play button) from "Debug" t
 
 Run Build > Build Solution.
 
-###Step 8. Testing the Interface
+###Step 8. Testing Interface
 
 Create another environment variable (see Step #4)
 * Set "Variable name": _NO_DEBUG_HEAP
@@ -54,12 +54,12 @@ In Visual Studio, right+click "interface" under the Apps folder in Solution Expl
 
 Now, you should have a full build of High Fidelity and be able to run the Interface using Visual Studio. Please check our [Docs](https://wiki.highfidelity.com/wiki/Main_Page) for more information regarding the programming workflow.
 
-Note: You can also run Interface by launching it from command line or File Explorer from %HIFI_DIR%\build\interface\Debug\interface.exe
+Note: You can also run Interface by launching it from command line or File Explorer from %HIFI_DIR%\build\interface\Release\interface.exe
 
 ###Troubleshooting
 
 For any problems after Step #6, first try this: 
-* Delete the highfidelity repository
+* Delete your locally cloned copy of the highfidelity repository
 * Restart your computer
 * Redownload the [repository](https://github.com/highfidelity/hifi) 
 * Restart directions from Step #6
@@ -77,4 +77,5 @@ If not, add the directory where nmake is located to the PATH environment variabl
 
 ####Qt is throwing an error
 
-Make sure you have the current version (5.6.1-1) installed and 'QT_CMAKE_PREFIX_PATH' environment variable is set correctly.
+Make sure you have the correct version (5.6.1-1) installed and 'QT_CMAKE_PREFIX_PATH' environment variable is set correctly.
+


### PR DESCRIPTION
Still throws errors like this after trying to build in Visual Studio. However, does not seem to affect the ability to run Interface from VS afterwards: 

Error    9    error MSB3073: The command "setlocal
"C:\Program Files\CMake\bin\cmake.exe" "-DBUNDLE_EXECUTABLE=C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/render-perf-test.exe" "-DBUNDLE_PLUGIN_DIR=C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/plugins" -P "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/FixupBundlePostBuild.cmake"
if %errorlevel% neq 0 goto :cmEnd
:cmEnd
endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
:cmErrorLevel
exit /b %1
:cmDone
if %errorlevel% neq 0 goto :VCEnd
setlocal
CMD /C "SET PATH=%PATH%;C:/Qt/Qt5.6.1/5.6/msvc2013_64/bin && C:/Qt/Qt5.6.1/5.6/msvc2013_64/bin/windeployqt.exe  --release C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/render-perf-test.exe"
if %errorlevel% neq 0 goto :cmEnd
:cmEnd
endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
:cmErrorLevel
exit /b %1
:cmDone
if %errorlevel% neq 0 goto :VCEnd
setlocal
if exist "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio/qtaudio_windows.dll" ( "C:/Program Files/CMake/bin/cmake.exe" -E remove "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio/qtaudio_windows.dll" && "C:/Program Files/CMake/bin/cmake.exe" -E copy "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/ext/vc12/wasapi/project/src/wasapi/qtaudio_wasapi.dll" "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio" && "C:/Program Files/CMake/bin/cmake.exe" -E copy "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/ext/vc12/wasapi/project/src/wasapi/qtaudio_wasapi.pdb" "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio" )
if %errorlevel% neq 0 goto :cmEnd
if exist "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio/qtaudio_windowsd.dll" ( "C:/Program Files/CMake/bin/cmake.exe" -E remove "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio/qtaudio_windowsd.dll" && "C:/Program Files/CMake/bin/cmake.exe" -E copy "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/ext/vc12/wasapi/project/src/wasapi/qtaudio_wasapid.dll" "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio" && "C:/Program Files/CMake/bin/cmake.exe" -E copy "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/ext/vc12/wasapi/project/src/wasapi/qtaudio_wasapid.pdb" "C:/Users/Chris i5 AMD/Documents/GitHub/hifi/build/tests/render-perf/Release/audio" )
if %errorlevel% neq 0 goto :cmEnd
:cmEnd
endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
:cmErrorLevel
exit /b %1
:cmDone
if %errorlevel% neq 0 goto :VCEnd
:VCEnd" exited with code 1.    C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppCommon.targets    132    5    render-perf-test