### PR TITLE
Fix the typo in the assert for isWireframe

### DIFF
--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -307,7 +307,7 @@ void initForwardPipelines(render::ShapePlumber& plumber) {
 void addPlumberPipeline(ShapePlumber& plumber,
         const ShapeKey& key, const gpu::ShaderPointer& vertex, const gpu::ShaderPointer& pixel) {
     // These key-values' pipelines are added by this functor in addition to the key passed
-    assert(!key.isWireFrame());
+    assert(!key.isWireframe());
     assert(!key.isDepthBiased());
     assert(key.isCullFace());
 


### PR DESCRIPTION
I introduced a typo in my past that is causing an error when building in debug.
This is fixed with this

TEST PLAN:
Trust me ?
Compile in debug and there shouldn't be anymore issues