### PR TITLE
Return existing textures when matching hash for a previously found live texture

### DIFF
--- a/libraries/model-networking/src/model-networking/KTXCache.cpp
+++ b/libraries/model-networking/src/model-networking/KTXCache.cpp
@@ -40,5 +40,8 @@ KTXFile::KTXFile(Metadata&& metadata, const std::string& filepath) :
 
 std::unique_ptr<ktx::KTX> KTXFile::getKTX() const {
     ktx::StoragePointer storage = std::make_shared<storage::FileStorage>(getFilepath().c_str());
-    return ktx::KTX::create(storage);
+    if (*storage) {
+        return ktx::KTX::create(storage);
+    }
+    return {};
 }

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -137,6 +137,10 @@ public:
     NetworkTexturePointer getTexture(const QUrl& url, Type type = Type::DEFAULT_TEXTURE,
         const QByteArray& content = QByteArray(), int maxNumPixels = ABSOLUTE_MAX_TEXTURE_NUM_PIXELS);
 
+
+    gpu::TexturePointer getTextureByHash(const std::string& hash);
+    gpu::TexturePointer cacheTextureByHash(const std::string& hash, const gpu::TexturePointer& texture);
+
 protected:
     // Overload ResourceCache::prefetch to allow specifying texture type for loads
     Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type, int maxNumPixels = ABSOLUTE_MAX_TEXTURE_NUM_PIXELS);
@@ -155,6 +159,9 @@ private:
     static const std::string KTX_DIRNAME;
     static const std::string KTX_EXT;
     KTXCache _ktxCache;
+    // Map from image hashes to texture weak pointers
+    std::unordered_map<std::string, std::weak_ptr<gpu::Texture>> _texturesByHashes;
+    std::mutex _texturesByHashesMutex;
 
     gpu::TexturePointer _permutationNormalTexture;
     gpu::TexturePointer _whiteTexture;

--- a/libraries/shared/src/shared/Storage.cpp
+++ b/libraries/shared/src/shared/Storage.cpp
@@ -8,7 +8,11 @@
 
 #include "Storage.h"
 
-#include <QFileInfo>
+#include <QtCore/QFileInfo>
+#include <QtCore/QDebug>
+#include <QtCore/QLoggingCategory>
+
+Q_LOGGING_CATEGORY(storagelogging, "hifi.core.storage")
 
 using namespace storage;
 
@@ -64,12 +68,15 @@ StoragePointer FileStorage::create(const QString& filename, size_t size, const u
 }
 
 FileStorage::FileStorage(const QString& filename) : _file(filename) {
-    if (!_file.open(QFile::ReadOnly)) {
-        throw std::runtime_error("Unable to open file");
-    }
-    _mapped = _file.map(0, _file.size());
-    if (!_mapped) {
-        throw std::runtime_error("Unable to map file");
+    if (_file.open(QFile::ReadOnly)) {
+        _mapped = _file.map(0, _file.size());
+        if (_mapped) {
+            _valid = true;
+        } else {
+            qCWarning(storagelogging) << "Failed to map file " << filename;
+        }
+    } else {
+        qCWarning(storagelogging) << "Failed to open file " << filename;
     }
 }
 

--- a/libraries/shared/src/shared/Storage.h
+++ b/libraries/shared/src/shared/Storage.h
@@ -25,6 +25,7 @@ namespace storage {
         virtual ~Storage() {}
         virtual const uint8_t* data() const = 0;
         virtual size_t size() const = 0;
+        virtual operator bool() const { return true; }
 
         StoragePointer createView(size_t size = 0, size_t offset = 0) const;
         StoragePointer toFileStorage(const QString& filename) const;
@@ -41,6 +42,7 @@ namespace storage {
         const uint8_t* data() const override { return _data.data(); }
         uint8_t* data() { return _data.data(); }
         size_t size() const override { return _data.size(); }
+        operator bool() const override { return true; }
     private:
         std::vector<uint8_t> _data;
     };
@@ -56,7 +58,9 @@ namespace storage {
 
         const uint8_t* data() const override { return _mapped; }
         size_t size() const override { return _file.size(); }
+        operator bool() const override { return _valid; }
     private:
+        bool _valid { false };
         QFile _file;
         uint8_t* _mapped { nullptr };
     };
@@ -66,6 +70,7 @@ namespace storage {
         ViewStorage(const storage::StoragePointer& owner, size_t size, const uint8_t* data);
         const uint8_t* data() const override { return _data; }
         size_t size() const override { return _size; }
+        operator bool() const override { return *_owner; }
     private:
         const storage::StoragePointer _owner;
         const size_t _size;


### PR DESCRIPTION
This PR allows matching textures that are embedded in multiple model files or fetched from various URLs to be represented by the same live gpu::Texture object at runtime.  It also guards against some race and error conditions when loading or serializing KTX textures.  