### PR TITLE
Adding Export Entities Functionality in Tablet Edit

### DIFF
--- a/scripts/system/html/entityList.html
+++ b/scripts/system/html/entityList.html
@@ -25,7 +25,6 @@
                 <input type="button" id="visible" class="glyph" value="&#xe007;" />
             </div>
             <input type="button" id="export" value="Export Selection" />
-            <input type="button" id="teleport" value="Jump to Selection" style="display: none"/>
             <input type="button" id="pal" class="glyph" value="&#xe00c;" />
             <input type="button" class="red" id="delete" value="Delete" />
         </div>

--- a/scripts/system/html/entityList.html
+++ b/scripts/system/html/entityList.html
@@ -24,7 +24,8 @@
                 <input type="button" id="locked" class="glyph" value="&#xe006;" />
                 <input type="button" id="visible" class="glyph" value="&#xe007;" />
             </div>
-            <input type="button" id="teleport" value="Jump To Selection" />
+            <input type="button" id="export" value="Export Selection" />
+            <input type="button" id="teleport" value="Jump to Selection" style="display: none"/>
             <input type="button" id="pal" class="glyph" value="&#xe00c;" />
             <input type="button" class="red" id="delete" value="Delete" />
         </div>

--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -39,7 +39,6 @@ function loaded() {
       elFilter = document.getElementById("filter");
       elInView = document.getElementById("in-view")
       elRadius = document.getElementById("radius");
-      elTeleport = document.getElementById("teleport");
       elExport = document.getElementById("export");
       elPal = document.getElementById("pal");
       elEntityTable = document.getElementById("entity-table");
@@ -273,9 +272,6 @@ function loaded() {
       }
       elToggleVisible.onclick = function () {
           EventBridge.emitWebEvent(JSON.stringify({ type: 'toggleVisible' }));
-      }
-      elTeleport.onclick = function () {
-          EventBridge.emitWebEvent(JSON.stringify({ type: 'teleport' }));
       }
       elExport.onclick = function() {
           EventBridge.emitWebEvent(JSON.stringify({ type: 'export'}));

--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -40,6 +40,7 @@ function loaded() {
       elInView = document.getElementById("in-view")
       elRadius = document.getElementById("radius");
       elTeleport = document.getElementById("teleport");
+      elExport = document.getElementById("export");
       elPal = document.getElementById("pal");
       elEntityTable = document.getElementById("entity-table");
       elInfoToggle = document.getElementById("info-toggle");
@@ -275,6 +276,9 @@ function loaded() {
       }
       elTeleport.onclick = function () {
           EventBridge.emitWebEvent(JSON.stringify({ type: 'teleport' }));
+      }
+      elExport.onclick = function() {
+          EventBridge.emitWebEvent(JSON.stringify({ type: 'export'}));
       }
       elPal.onclick = function () {
           EventBridge.emitWebEvent(JSON.stringify({ type: 'pal' }));

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -128,6 +128,18 @@ EntityListTool = function(opts) {
             if (selectionManager.hasSelection()) {
                 MyAvatar.position = selectionManager.worldPosition;
             }
+        } else if (data.type == "export") {
+            if (!selectionManager.hasSelection()) {
+                Window.notifyEditError("No entities have been selected.");
+            } else {
+                var filename = Window.save("Select Where to Save", "", "*.json");
+                if (filename) {
+                    var success = Clipboard.exportEntities(filename, selectionManager.selections);
+                    if (!success) {
+                        Window.notifyEditError("Export failed.");
+                    }
+                }
+            }
         } else if (data.type == "pal") {
             var sessionIds = {}; // Collect the sessionsIds of all selected entitities, w/o duplicates.
             selectionManager.selections.forEach(function (id) {


### PR DESCRIPTION
This is a fix for this issue: https://github.com/highfidelity/hifi/issues/9905

Replacing "Jump to Selection" with "Export Selection" since it is a more oftenly used function for Edit's Entity List. You can select entities from the list or in world and then click the "Export Selection" button to export as a JSON file.

Note: This PR is waiting on a fix (on selection focus) by Dante in order to fully function.

