### PR TITLE
Fix edit.js from deselecting an object when trying to delete it

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -687,11 +687,22 @@ function mouseReleaseEvent(event) {
     }
 }
 
+function wasTabletClicked(event) {
+    var rayPick = Camera.computePickRay(event.x, event.y);
+    var result = Overlays.findRayIntersection(rayPick, true, [HMD.tabletID, HMD.tabletScreenID, HMD.homeButtonID]);
+    return result.intersects;
+}
+    
 function mouseClickEvent(event) {
     var wantDebug = false;
-    var result, properties;
+    var result, properties, tabletClicked;
     if (isActive && event.isLeftButton) {
         result = findClickedEntity(event);
+        tabletClicked = wasTabletClicked(event);
+        if (tabletClicked) {
+            return;
+        }
+        
         if (result === null || result === undefined) {
             if (!event.isShifted) {
                 selectionManager.clearSelections();


### PR DESCRIPTION
Test plan
- be in desktop mode and tablet mode
- while in edit mode select an object then click on the tablet.
- The selected object should stay selected