### PR TITLE
Tweaks to the Physics Simulation Ownership Icon Rendering

### DIFF
--- a/libraries/render/src/render/drawItemStatus.slv
+++ b/libraries/render/src/render/drawItemStatus.slv
@@ -75,7 +75,7 @@ void main(void) {
         vec4(1.0, 1.0, 0.0, 1.0)
     );
 
-    const vec2 ICON_PIXEL_SIZE = vec2(20, 20);
+    const vec2 ICON_PIXEL_SIZE = vec2(36, 36);
     const vec2 MARGIN_PIXEL_SIZE = vec2(2, 2);
     const vec2 ICON_GRID_SLOTS[MAX_NUM_ICONS] = vec2[MAX_NUM_ICONS](vec2(-1.5, 0.5),
                                                                     vec2(-0.5, 0.5),
@@ -114,7 +114,7 @@ void main(void) {
     varColor = vec4(paintRainbow(abs(iconStatus.y)), 1.0);
 
     // Pass the texcoord and the z texcoord is representing the texture icon
-    varTexcoord = vec3((quadPos.xy + 1.0) * 0.5, iconStatus.z);
+    varTexcoord = vec3( (quadPos.x + 1.0) * 0.5, (quadPos.y + 1.0) * -0.5, iconStatus.z);
 
     // Also changes the size of the notification
     vec2 iconScale = ICON_PIXEL_SIZE;


### PR DESCRIPTION
- Doubled-ish (20x20 px to 36x36px) the size of the physics status icons.
- Fixed texture coordinates to be right-side up.

To test, just enable Developer->Physics->Show Simulation Ownership.

NOTE: This does not address the sub-mesh status indicators being drawn instead of simply the overarching entity due to a seeming lack of way of querying mesh vs. entity anywhere near where this render task occurs.

https://worklist.net/21215