### PR TITLE
Fix crash in render-perf-test

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -996,7 +996,7 @@ void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, const
         }
         bool shouldLoad = entity->shouldPreloadScript() && _entitiesScriptEngine;
         QString scriptUrl = entity->getScript();
-        if ((unloadFirst && shouldLoad) || scriptUrl.isEmpty()) {
+        if (shouldLoad && (unloadFirst || scriptUrl.isEmpty())) {
             _entitiesScriptEngine->unloadEntityScript(entityID);
             entity->scriptHasUnloaded();
         }


### PR DESCRIPTION
The render-perf tool does not provide a scripting engine to the entities it renders, so the code must be sensitive to the possibility that `_entitiesScriptEngine` may be null.  The code here does that imperfectly.  `shouldLoad` is only true if `_entitiesScriptEngine` is non null, however, because of the placement of the or clause, if `scriptUrl` is empty, then the conditional block will execute even if there is no script engine.  Line 1000 here will immediately crash.  

