### PR TITLE
Use loadQMlSource if no stack is aviable when calling PushOnToStack

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -8,7 +8,6 @@ Item {
     objectName: "tabletRoot"
     property string username: "Unknown user"
     property var eventBridge;
-
     property var rootMenu;
     property var openModal: null;
     property var openMessage: null;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5848,10 +5848,14 @@ void Application::showDialog(const QString& desktopURL, const QString& tabletURL
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
     auto hmd = DependencyManager::get<HMDScriptingInterface>();
-    if (tablet->getToolbarMode() || (!hmd->getShouldShowTablet() && !isHMDMode())) {
+    if (tablet->getToolbarMode()) {
         DependencyManager::get<OffscreenUi>()->show(desktopURL, name);
     } else {
         tablet->pushOntoStack(tabletURL);
+        if (!hmd->getShouldShowTablet() && !isHMDMode()) {
+            hmd->openTablet();
+        }
+        
     }
 }
 

--- a/libraries/script-engine/src/TabletScriptingInterface.cpp
+++ b/libraries/script-engine/src/TabletScriptingInterface.cpp
@@ -358,7 +358,7 @@ void TabletProxy::pushOntoStack(const QVariant& path) {
         if (stack) {
             QMetaObject::invokeMethod(stack, "pushSource", Q_ARG(const QVariant&, path));
         } else {
-            qCDebug(scriptengine) << "tablet cannot push QML because _qmlTabletRoot doesn't have child stack";
+            loadQMLSource(path);
         }
     } else if (_desktopWindow) {
         auto stack = _desktopWindow->asQuickItem()->findChild<QQuickItem*>("stack");


### PR DESCRIPTION
If pushOntoStack is called and the tablet does not have a stack view available. Just load the qml to the tablet root.