### PR TITLE
Fix Oculus Touch + Remote not being detected after initial launch

### DIFF
--- a/plugins/oculus/src/OculusControllerManager.h
+++ b/plugins/oculus/src/OculusControllerManager.h
@@ -91,6 +91,8 @@ private:
         friend class OculusControllerManager;
     };
 
+    void checkForConnectedDevices();
+
     ovrSession _session { nullptr };
     ovrInputState _inputState {};
     RemoteDevice::Pointer _remote;


### PR DESCRIPTION
We were only checking whether the touch or remote were connected on launch - this now checks each `pluginUpdate`. I profiled it to make sure the ovr call had minimal overhead. If any devs are curious, I have attached the profile.

[trace-touch-1490311028.json.gz](https://github.com/highfidelity/hifi/files/866470/trace-touch-1490311028.json.gz)
