### PR TITLE
Fixing the broken rendering of subsurface scattering

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -8,8 +8,6 @@
 
 #include "GLTexture.h"
 
-//#include <NumericalConstants.h>
-
 #include "GLBackend.h"
 
 using namespace gpu;

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -8,7 +8,7 @@
 
 #include "GLTexture.h"
 
-#include <NumericalConstants.h>
+//#include <NumericalConstants.h>
 
 #include "GLBackend.h"
 

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -72,7 +72,7 @@ GL41Texture::GL41Texture(const std::weak_ptr<GLBackend>& backend, const Texture&
     incrementTextureGPUCount();
     withPreservedTexture([&] {
         GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat(), _gpuObject.getStoredMipFormat());
-        auto numMips = _gpuObject.evalNumMips();
+        auto numMips = _gpuObject.getNumMipLevels();
         for (uint16_t mipLevel = 0; mipLevel < numMips; ++mipLevel) {
             // Get the mip level dimensions, accounting for the downgrade level
             Vec3u dimensions = _gpuObject.evalMipDimensions(mipLevel);

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -186,8 +186,10 @@ GL45FixedAllocationTexture::~GL45FixedAllocationTexture() {
 void GL45FixedAllocationTexture::allocateStorage() const {
     const GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat());
     const auto dimensions = _gpuObject.getDimensions();
-    const auto mips = _gpuObject.evalNumMips();
+    const auto mips = _gpuObject.getNumMipLevels();
+
     glTextureStorage2D(_id, mips, texelFormat.internalFormat, dimensions.x, dimensions.y);
+    glTextureParameteri(_id, GL_TEXTURE_BASE_LEVEL, 0);
 }
 
 void GL45FixedAllocationTexture::syncSampler() const {
@@ -214,7 +216,7 @@ GL45AttachmentTexture::~GL45AttachmentTexture() {
 using GL45StrictResourceTexture = GL45Backend::GL45StrictResourceTexture;
 
 GL45StrictResourceTexture::GL45StrictResourceTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture) : GL45FixedAllocationTexture(backend, texture) {
-    auto mipLevels = _gpuObject.evalNumMips();
+    auto mipLevels = _gpuObject.getNumMipLevels();
     for (uint16_t sourceMip = 0; sourceMip < mipLevels; ++sourceMip) {
         uint16_t targetMip = sourceMip;
         size_t maxFace = GLTexture::getFaceCount(_target);

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -461,10 +461,10 @@ void GL45ResourceTexture::allocateStorage(uint16 allocatedMip) {
     _allocatedMip = allocatedMip;
     const GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_gpuObject.getTexelFormat());
     const auto dimensions = _gpuObject.evalMipDimensions(_allocatedMip);
-    const auto totalMips = _gpuObject.evalNumMips();
+    const auto totalMips = _gpuObject.getNumMipLevels();
     const auto mips = totalMips - _allocatedMip;
     glTextureStorage2D(_id, mips, texelFormat.internalFormat, dimensions.x, dimensions.y);
-    auto mipLevels = _gpuObject.evalNumMips();
+    auto mipLevels = _gpuObject.getNumMipLevels();
     _size = 0;
     for (uint16_t mip = _allocatedMip; mip < mipLevels; ++mip) {
         _size += _gpuObject.evalMipSize(mip);
@@ -474,7 +474,7 @@ void GL45ResourceTexture::allocateStorage(uint16 allocatedMip) {
 }
 
 void GL45ResourceTexture::copyMipsFromTexture() {
-    auto mipLevels = _gpuObject.evalNumMips();
+    auto mipLevels = _gpuObject.getNumMipLevels();
     size_t maxFace = GLTexture::getFaceCount(_target);
     for (uint16_t sourceMip = _populatedMip; sourceMip < mipLevels; ++sourceMip) {
         uint16_t targetMip = sourceMip - _allocatedMip;
@@ -499,7 +499,7 @@ void GL45ResourceTexture::promote() {
     uint16_t oldAllocatedMip = _allocatedMip;
     // allocate storage for new level
     allocateStorage(_allocatedMip - std::min<uint16_t>(_allocatedMip, 2));
-    uint16_t mips = _gpuObject.evalNumMips();
+    uint16_t mips = _gpuObject.getNumMipLevels();
     // copy pre-existing mips
     for (uint16_t mip = _populatedMip; mip < mips; ++mip) {
         auto mipDimensions = _gpuObject.evalMipDimensions(mip);
@@ -532,7 +532,7 @@ void GL45ResourceTexture::demote() {
     const_cast<GLuint&>(_id) = allocate(_gpuObject);
     allocateStorage(_allocatedMip + 1);
     _populatedMip = std::max(_populatedMip, _allocatedMip);
-    uint16_t mips = _gpuObject.evalNumMips();
+    uint16_t mips = _gpuObject.getNumMipLevels();
     // copy pre-existing mips
     for (uint16_t mip = _populatedMip; mip < mips; ++mip) {
         auto mipDimensions = _gpuObject.evalMipDimensions(mip);

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -418,8 +418,8 @@ public:
 
     uint32 evalTotalSize(uint16 startingMip = 0) const {
         uint32 size = 0;
-        uint16 minMipLevel = std::max(minMip(), startingMip);
-        uint16 maxMipLevel = maxMip();
+        uint16 minMipLevel = std::max(getMinMip(), startingMip);
+        uint16 maxMipLevel = getMaxMip();
         for (uint16 l = minMipLevel; l <= maxMipLevel; l++) {
             size += evalMipSize(l);
         }
@@ -429,12 +429,9 @@ public:
     // max mip is in the range [ 0 if no sub mips, log2(max(width, height, depth))]
     // if autoGenerateMip is on => will provide the maxMIp level specified
     // else provide the deepest mip level provided through assignMip
-    uint16 maxMip() const { return _maxMip; }
-
-    uint16 minMip() const { return _minMip; }
-    
-    uint16 mipLevels() const { return _maxMip + 1; }
-    
+    uint16 getMaxMip() const { return _maxMip; }
+    uint16 getMinMip() const { return _minMip; }
+    uint16 getNumMipLevels() const { return _maxMip + 1; }
     uint16 usedMipLevels() const { return (_maxMip - _minMip) + 1; }
 
     const std::string& source() const { return _source; }

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -121,7 +121,7 @@ ktx::KTXUniquePointer Texture::serialize(const Texture& texture) {
     }
 
     // Number level of mips coming
-    header.numberOfMipmapLevels = texture.maxMip() + 1;
+    header.numberOfMipmapLevels = texture.getNumMipLevels();
 
     ktx::Images images;
     for (uint32_t level = 0; level < header.numberOfMipmapLevels; level++) {

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -74,11 +74,12 @@ void AmbientOcclusionFramebuffer::allocate() {
     auto width = _frameSize.x;
     auto height = _frameSize.y;
     
-    _occlusionTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
+ //   _occlusionTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
+    _occlusionTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
     _occlusionFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("occlusion"));
     _occlusionFramebuffer->setRenderBuffer(0, _occlusionTexture);
    
-    _occlusionBlurredTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
+    _occlusionBlurredTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
     _occlusionBlurredFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("occlusionBlurred"));
     _occlusionBlurredFramebuffer->setRenderBuffer(0, _occlusionBlurredTexture);
 }

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -73,12 +73,11 @@ void AmbientOcclusionFramebuffer::allocate() {
     
     auto width = _frameSize.x;
     auto height = _frameSize.y;
-    
- //   _occlusionTexture = gpu::TexturePointer(gpu::Texture::create2D(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
+
     _occlusionTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
     _occlusionFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("occlusion"));
     _occlusionFramebuffer->setRenderBuffer(0, _occlusionTexture);
-   
+
     _occlusionBlurredTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element::COLOR_RGBA_32, width, height, gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
     _occlusionBlurredFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("occlusionBlurred"));
     _occlusionBlurredFramebuffer->setRenderBuffer(0, _occlusionBlurredTexture);

--- a/libraries/render-utils/src/SurfaceGeometryPass.cpp
+++ b/libraries/render-utils/src/SurfaceGeometryPass.cpp
@@ -72,14 +72,14 @@ void LinearDepthFramebuffer::allocate() {
     auto height = _frameSize.y;
 
     // For Linear Depth:
-    _linearDepthTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::RGB), width, height,
+    _linearDepthTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::RED), width, height,
         gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
     _linearDepthFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("linearDepth"));
     _linearDepthFramebuffer->setRenderBuffer(0, _linearDepthTexture);
     _linearDepthFramebuffer->setDepthStencilBuffer(_primaryDepthTexture, _primaryDepthTexture->getTexelFormat());
 
     // For Downsampling:
-    _halfLinearDepthTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::RGB), _halfFrameSize.x, _halfFrameSize.y,
+    _halfLinearDepthTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::RED), _halfFrameSize.x, _halfFrameSize.y,
         gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
     _halfLinearDepthTexture->autoGenerateMips(5);
 

--- a/libraries/render-utils/src/SurfaceGeometryPass.cpp
+++ b/libraries/render-utils/src/SurfaceGeometryPass.cpp
@@ -83,7 +83,7 @@ void LinearDepthFramebuffer::allocate() {
         gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
     _halfLinearDepthTexture->autoGenerateMips(5);
 
-    _halfNormalTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element(gpu::VEC3, gpu::NUINT8, gpu::RGB), _halfFrameSize.x, _halfFrameSize.y,
+    _halfNormalTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(gpu::Element::COLOR_RGBA_32, _halfFrameSize.x, _halfFrameSize.y,
         gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT)));
 
     _downsampleFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("halfLinearDepth"));

--- a/tests/render-texture-load/src/main.cpp
+++ b/tests/render-texture-load/src/main.cpp
@@ -456,7 +456,7 @@ protected:
             return;
         }
         auto texture = _textures[_currentTextureIndex];
-        texture->setMinMip(texture->minMip() + 1);
+        texture->setMinMip(texture->getMinMip() + 1);
     }
 
     void loadTexture() {


### PR DESCRIPTION
After merging the new Texture Streaming project we ahve discovered a few bugs.
THis pr fixes the rendering of the AO and Subsurface scattering not rendering properly.
THis PR fix the bug for OpenGL 4.5 platforms (PC windows or linux) not for 4.1 backend (mac and intel gpu  pc). WE are working on that next

## TEST PLAN
- Using Matthew or Pricilia avatar model, their skin should show correctly with this PR and be corrupted with current master

- Turning AO effect own should work in this PR and not in current Master
