### PR TITLE
Hide the scrollbar on the marketplace

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -38,6 +38,7 @@
                 '#marketplace-navigation input#back-button { position: absolute; left: 20px; margin-top: 12px; padding-left: 0; padding-right: 5px; }' +
                 '#marketplace-navigation input#all-markets { position: absolute; right: 20px; margin-top: 12px; padding-left: 15px; padding-right: 15px; }' +
                 '#marketplace-navigation .right { position: absolute; right: 20px; }' +
+                '::-webkit-scrollbar { width: 0px; background: transparent; }' +
             '</style>'
         );
 

--- a/scripts/system/html/js/marketplacesInjectNoScrollbar.js
+++ b/scripts/system/html/js/marketplacesInjectNoScrollbar.js
@@ -38,6 +38,7 @@
                 '#marketplace-navigation input#back-button { position: absolute; left: 20px; margin-top: 12px; padding-left: 0; padding-right: 5px; }' +
                 '#marketplace-navigation input#all-markets { position: absolute; right: 20px; margin-top: 12px; padding-left: 15px; padding-right: 15px; }' +
                 '#marketplace-navigation .right { position: absolute; right: 20px; }' +
+                '::-webkit-scrollbar { width: 0px; background: transparent; }' +
             '</style>'
         );
 

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -19,6 +19,7 @@ var MARKETPLACE_URL = "https://metaverse.highfidelity.com/marketplace";
 var MARKETPLACE_URL_INITIAL = MARKETPLACE_URL + "?";  // Append "?" to signal injected script that it's the initial page.
 var MARKETPLACES_URL = Script.resolvePath("../html/marketplaces.html");
 var MARKETPLACES_INJECT_SCRIPT_URL = Script.resolvePath("../html/js/marketplacesInject.js");
+var MARKETPLACES_INJECT_NO_SCROLLBAR_SCRIPT_URL = Script.resolvePath("../html/js/marketplacesInjectNoScrollbar.js");
 
 var HOME_BUTTON_TEXTURE = "http://hifi-content.s3.amazonaws.com/alan/dev/tablet-with-home-button.fbx/tablet-with-home-button.fbm/button-root.png";
 // var HOME_BUTTON_TEXTURE = Script.resourcesPath() + "meshes/tablet-with-home-button.fbx/tablet-with-home-button.fbm/button-root.png";
@@ -59,7 +60,13 @@ function showMarketplace() {
     UserActivityLogger.openedMarketplace();
 
     shouldActivateButton = true;
-    tablet.gotoWebScreen(MARKETPLACE_URL_INITIAL, MARKETPLACES_INJECT_SCRIPT_URL);
+
+    // by default the marketplace should NOT have a scrollbar, except when tablet is in toolbar mode.
+    var injectURL = MARKETPLACES_INJECT_NO_SCROLLBAR_SCRIPT_URL;
+    if (tablet.toolbarMode) {
+        injectURL = MARKETPLACES_INJECT_SCRIPT_URL;
+    }
+    tablet.gotoWebScreen(MARKETPLACE_URL_INITIAL, injectURL);
     onMarketplaceScreen = true;
 
     tablet.webEventReceived.connect(function (message) {


### PR DESCRIPTION
To avoid problems when grabbing the scrollbar via touch events... Hide the scrollbar, but only in tablet mode.  In 2D toolbar mode the scrollbar is still visible.