### PR TITLE
FB3651: Fix audio devices switching when they shouldn't

### DIFF
--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -80,6 +80,7 @@ public:
 
 signals:
     bool shouldShowHandControllersChanged();
+    void mountedChanged();
 
 public:
     HMDScriptingInterface();

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -80,7 +80,6 @@ public:
 
 signals:
     bool shouldShowHandControllersChanged();
-    void mountedChanged();
 
 public:
     HMDScriptingInterface();

--- a/scripts/system/selectAudioDevice.js
+++ b/scripts/system/selectAudioDevice.js
@@ -154,6 +154,7 @@ function switchAudioDevice(audioDeviceMenuString) {
             }
         } else {
             debug("Selected input device is the same as the current input device!")
+            Settings.setValue(INPUT_DEVICE_SETTING, selectedDevice);
             Menu.setIsOptionChecked(audioDeviceMenuString, true);
             AudioDevice.setInputDevice(selectedDevice); // Still try to force-set the device (in case the user's trying to forcefully debug an issue)
         }
@@ -172,6 +173,7 @@ function switchAudioDevice(audioDeviceMenuString) {
             }
         } else {
             debug("Selected output device is the same as the current output device!")
+            Settings.setValue(OUTPUT_DEVICE_SETTING, selectedDevice);
             Menu.setIsOptionChecked(audioDeviceMenuString, true);
             AudioDevice.setOutputDevice(selectedDevice); // Still try to force-set the device (in case the user's trying to forcefully debug an issue)
         }

--- a/scripts/system/selectAudioDevice.js
+++ b/scripts/system/selectAudioDevice.js
@@ -129,6 +129,11 @@ function onDevicechanged() {
 }
 
 function switchAudioDevice(audioDeviceMenuString) {
+    // if the device is not plugged in, short-circuit
+    if (!~audioDevicesList.indexOf(audioDeviceMenuString)) {
+        return;
+    }
+
     Menu.menuItemEvent.disconnect(switchAudioDevice);
 
     var selection = parseMenuItem(audioDeviceMenuString);

--- a/scripts/system/selectAudioDevice.js
+++ b/scripts/system/selectAudioDevice.js
@@ -95,6 +95,7 @@ function setupAudioMenus() {
         audioDevicesList.push(menuItem);
         if (thisDeviceSelected) {
             selectedInputMenu = menuItem;
+            print("selectAudioDevice: selectedInputMenu: " + selectedInputMenu);
         }
     }
 
@@ -120,6 +121,7 @@ function setupAudioMenus() {
         audioDevicesList.push(menuItem);
         if (thisDeviceSelected) {
             selectedOutputMenu = menuItem;
+            print("selectAudioDevice: selectedOutputMenu: " + selectedOutputMenu);
         }
     }
     if (!menuConnected) {
@@ -180,9 +182,6 @@ function switchAudioDevice(isInput, device) {
     if (isInput) {
         print("selectAudioDevice: Switching audio INPUT device to:", device);
         if (AudioDevice.setInputDevice(device)) {
-            Menu.setIsOptionChecked(selectedInputMenu, false);
-            selectedInputMenu = "Use " + device + " for Input";
-            Menu.setIsOptionChecked(selectedInputMenu, true);
             Settings.setValue(INPUT_DEVICE_SETTING, device);
         } else {
             print("selectAudioDevice: Error setting audio input device!")
@@ -190,14 +189,12 @@ function switchAudioDevice(isInput, device) {
     } else {
         print("selectAudioDevice: Switching audio OUTPUT device to:", device);
         if (AudioDevice.setOutputDevice(device)) {
-            Menu.setIsOptionChecked(selectedOutputMenu, false);
-            selectedOutputMenu = "Use " + device + " for Output";
-            Menu.setIsOptionChecked(selectedOutputMenu, true);
             Settings.setValue(OUTPUT_DEVICE_SETTING, device);
         } else {
             print("selectAudioDevice: Error setting audio output device!")
         }
     }
+    setupAudioMenus();
     if (!menuConnected) {
         Menu.menuItemEvent.connect(menuItemEvent);
         menuConnected = true;
@@ -218,6 +215,10 @@ function restoreAudio() {
 }
 
 function checkHMDAudio() {
+    if (menuConnected) {
+        Menu.menuItemEvent.disconnect(menuItemEvent);
+        menuConnected = false;
+    }
     // HMD Active state is changing; handle switching
     if (HMD.active != wasHmdActive) {
         print("selectAudioDevice: HMD Active state changed!");
@@ -256,6 +257,10 @@ function checkHMDAudio() {
         }
     }
     wasHmdActive = HMD.active;
+    if (!menuConnected) {
+        Menu.menuItemEvent.connect(menuItemEvent);
+        menuConnected = true;
+    }
 }
 /****************************************
     END FUNCTION DEFINITIONS
@@ -269,10 +274,11 @@ Script.setTimeout(function () {
     print("selectAudioDevice: Connecting deviceChanged() and displayModeChanged()");
     AudioDevice.deviceChanged.connect(onDevicechanged);
     HMD.displayModeChanged.connect(checkHMDAudio);
+    print ("selectAudioDevice: Checking HMD audio status...")
+    checkHMDAudio();
     print("selectAudioDevice: Setting up Audio > Devices menu for the first time");
     setupAudioMenus();
-    checkHMDAudio();
-}, 5000);
+}, 3000);
 
 print("selectAudioDevice: Connecting menuItemEvent() and scriptEnding()");
 Menu.menuItemEvent.connect(menuItemEvent);

--- a/scripts/system/selectAudioDevice.js
+++ b/scripts/system/selectAudioDevice.js
@@ -45,26 +45,43 @@ if (typeof String.prototype.trimEndsWith != 'function') {
     };
 }
 
+/****************************************
+    VAR DEFINITIONS
+****************************************/
 const INPUT_DEVICE_SETTING = "audio_input_device";
 const OUTPUT_DEVICE_SETTING = "audio_output_device";
-
 var selectedInputMenu = "";
 var selectedOutputMenu = "";
+var audioDevicesList = [];
+// Some HMDs (like Oculus CV1) have a built in audio device. If they
+// do, then this function will handle switching to that device automatically
+// when you goActive with the HMD active.
+var wasHmdActive = false; // assume it's not active to start
+var switchedAudioInputToHMD = false;
+var switchedAudioOutputToHMD = false;
+var previousSelectedInputAudioDevice = "";
+var previousSelectedOutputAudioDevice = "";
 
-    var audioDevicesList = [];
+/****************************************
+    BEGIN FUNCTION DEFINITIONS
+****************************************/
 function setupAudioMenus() {
     removeAudioMenus();
-    Menu.addSeparator("Audio", "Input Audio Device");
 
+    /* Setup audio input devices */
+    Menu.addSeparator("Audio", "Input Audio Device");
     var inputDeviceSetting = Settings.getValue(INPUT_DEVICE_SETTING);
     var inputDevices = AudioDevice.getInputDevices();
     var selectedInputDevice = AudioDevice.getInputDevice();
     if (inputDevices.indexOf(inputDeviceSetting) != -1 && selectedInputDevice != inputDeviceSetting) {
+        print ("Audio input device SETTING does not match Input AudioDevice. Attempting to change Input AudioDevice...")
         if (AudioDevice.setInputDevice(inputDeviceSetting)) {
             selectedInputDevice = inputDeviceSetting;
+        } else {
+            print("Error setting audio input device!")
         }
     }
-    print("audio input devices: " + inputDevices);
+    print("Audio input devices: " + inputDevices);
     for(var i = 0; i < inputDevices.length; i++) {
         var thisDeviceSelected = (inputDevices[i] == selectedInputDevice);
         var menuItem = "Use " + inputDevices[i] + " for Input";
@@ -80,17 +97,20 @@ function setupAudioMenus() {
         }
     }
 
+    /* Setup audio output devices */
     Menu.addSeparator("Audio", "Output Audio Device");
-
     var outputDeviceSetting = Settings.getValue(OUTPUT_DEVICE_SETTING);
     var outputDevices = AudioDevice.getOutputDevices();
     var selectedOutputDevice = AudioDevice.getOutputDevice();
     if (outputDevices.indexOf(outputDeviceSetting) != -1 && selectedOutputDevice != outputDeviceSetting) {
+        print("Audio output device SETTING does not match Output AudioDevice. Attempting to change Output AudioDevice...")
         if (AudioDevice.setOutputDevice(outputDeviceSetting)) {
             selectedOutputDevice = outputDeviceSetting;
+        } else {
+            print("Error setting audio output device!")
         }
     }
-    print("audio output devices: " + outputDevices);
+    print("Audio output devices: " + outputDevices);
     for (var i = 0; i < outputDevices.length; i++) {
         var thisDeviceSelected = (outputDevices[i] == selectedOutputDevice);
         var menuItem = "Use " + outputDevices[i] + " for Output";
@@ -115,127 +135,125 @@ function removeAudioMenus() {
         Menu.removeMenuItem("Audio", audioDevicesList[index]);
     }
 
+    Menu.removeMenu("Audio > Devices");
+
     audioDevicesList = [];
 }
 
 function onDevicechanged() {
-    print("audio devices changed, removing Audio > Devices menu...");
-    Menu.removeMenu("Audio > Devices");
-    print("now setting up Audio > Devices menu");
+    print("System audio device changed. Removing and replacing Audio Menus...");
     setupAudioMenus();
 }
-
-// Have a small delay before the menu's get setup and the audio devices can switch to the last selected ones
-Script.setTimeout(function () {
-    print("connecting deviceChanged");
-    AudioDevice.deviceChanged.connect(onDevicechanged);
-    print("setting up Audio > Devices menu for first time");
-    setupAudioMenus();
-}, 5000);
-
-function scriptEnding() {
-    Menu.removeMenu("Audio > Devices");
-}
-Script.scriptEnding.connect(scriptEnding);
-
 
 function menuItemEvent(menuItem) {
     if (menuItem.startsWith("Use ")) {
-        if (menuItem.endsWith(" for Output")) {
-            var selectedDevice = menuItem.trimStartsWith("Use ").trimEndsWith(" for Output");
-            print("output audio selection..." + selectedDevice);
-            Menu.menuItemEvent.disconnect(menuItemEvent);
-            Menu.setIsOptionChecked(selectedOutputMenu, false);
-            selectedOutputMenu = menuItem;
-            Menu.setIsOptionChecked(selectedOutputMenu, true);
-            if (AudioDevice.setOutputDevice(selectedDevice)) {
-                Settings.setValue(OUTPUT_DEVICE_SETTING, selectedDevice);
-            }
-            Menu.menuItemEvent.connect(menuItemEvent);
-        } else if (menuItem.endsWith(" for Input")) {
+        if (menuItem.endsWith(" for Input")) {
             var selectedDevice = menuItem.trimStartsWith("Use ").trimEndsWith(" for Input");
-            print("input audio selection..." + selectedDevice);
+            print("User selected a new Audio Input Device: " + selectedDevice);
             Menu.menuItemEvent.disconnect(menuItemEvent);
             Menu.setIsOptionChecked(selectedInputMenu, false);
             selectedInputMenu = menuItem;
             Menu.setIsOptionChecked(selectedInputMenu, true);
             if (AudioDevice.setInputDevice(selectedDevice)) {
                 Settings.setValue(INPUT_DEVICE_SETTING, selectedDevice);
+            } else {
+                print("Error setting audio input device!")
+            }
+            Menu.menuItemEvent.connect(menuItemEvent);
+        } else if (menuItem.endsWith(" for Output")) {
+            var selectedDevice = menuItem.trimStartsWith("Use ").trimEndsWith(" for Output");
+            print("User selected a new Audio Output Device: " + selectedDevice);
+            Menu.menuItemEvent.disconnect(menuItemEvent);
+            Menu.setIsOptionChecked(selectedOutputMenu, false);
+            selectedOutputMenu = menuItem;
+            Menu.setIsOptionChecked(selectedOutputMenu, true);
+            if (AudioDevice.setOutputDevice(selectedDevice)) {
+                Settings.setValue(OUTPUT_DEVICE_SETTING, selectedDevice);
+            } else {
+                print("Error setting audio output device!")
             }
             Menu.menuItemEvent.connect(menuItemEvent);
         }
     }
 }
 
-Menu.menuItemEvent.connect(menuItemEvent);
-
-// Some HMDs (like Oculus CV1) have a built in audio device. If they
-// do, then this function will handle switching to that device automatically
-// when you goActive with the HMD active.
-var wasHmdMounted = false; // assume it's un-mounted to start
-var switchedAudioInputToHMD = false;
-var switchedAudioOutputToHMD = false;
-var previousSelectedInputAudioDevice = "";
-var previousSelectedOutputAudioDevice = "";
-
 function restoreAudio() {
     if (switchedAudioInputToHMD) {
-        print("switching back from HMD preferred audio input to:" + previousSelectedInputAudioDevice);
+        print("Switching back from HMD preferred audio input to: " + previousSelectedInputAudioDevice);
         menuItemEvent("Use " + previousSelectedInputAudioDevice + " for Input");
+        switchedAudioInputToHMD = false;
     }
     if (switchedAudioOutputToHMD) {
-        print("switching back from HMD preferred audio output to:" + previousSelectedOutputAudioDevice);
+        print("Switching back from HMD preferred audio output to: " + previousSelectedOutputAudioDevice);
         menuItemEvent("Use " + previousSelectedOutputAudioDevice + " for Output");
+        switchedAudioOutputToHMD = false;
     }
 }
 
 function checkHMDAudio() {
-    // Mounted state is changing... handle switching
-    if (HMD.mounted != wasHmdMounted) {
-        print("HMD mounted changed...");
+    // HMD Active state is changing; handle switching
+    if (HMD.active != wasHmdActive) {
+        print("HMD Active state changed!");
 
-        // We're putting the HMD on... switch to those devices
-        if (HMD.mounted) {
-            print("NOW mounted...");
+        // We're putting the HMD on; switch to those devices
+        if (HMD.active) {
+            print("HMD is now Active.");
             var hmdPreferredAudioInput = HMD.preferredAudioInput();
             var hmdPreferredAudioOutput = HMD.preferredAudioOutput();
-            print("hmdPreferredAudioInput:" + hmdPreferredAudioInput);
-            print("hmdPreferredAudioOutput:" + hmdPreferredAudioOutput);
+            print("hmdPreferredAudioInput: " + hmdPreferredAudioInput);
+            print("hmdPreferredAudioOutput: " + hmdPreferredAudioOutput);
 
 
-            var hmdHasPreferredAudio = (hmdPreferredAudioInput !== "") || (hmdPreferredAudioOutput !== "");
-            if (hmdHasPreferredAudio) {
-                print("HMD has preferred audio!");
+            if (hmdPreferredAudioInput !== "") {
+                print("HMD has preferred audio input device.");
                 previousSelectedInputAudioDevice = Settings.getValue(INPUT_DEVICE_SETTING);
-                previousSelectedOutputAudioDevice = Settings.getValue(OUTPUT_DEVICE_SETTING);
-                print("previousSelectedInputAudioDevice:" + previousSelectedInputAudioDevice);
-                print("previousSelectedOutputAudioDevice:" + previousSelectedOutputAudioDevice);
-                if (hmdPreferredAudioInput != previousSelectedInputAudioDevice && hmdPreferredAudioInput !== "") {
-                    print("switching to HMD preferred audio input to:" + hmdPreferredAudioInput);
+                print("previousSelectedInputAudioDevice: " + previousSelectedInputAudioDevice);
+                if (hmdPreferredAudioInput != previousSelectedInputAudioDevice) {
+                    print("Switching Audio Input device to HMD preferred device: " + hmdPreferredAudioInput);
                     switchedAudioInputToHMD = true;
                     menuItemEvent("Use " + hmdPreferredAudioInput + " for Input");
                 }
-                if (hmdPreferredAudioOutput != previousSelectedOutputAudioDevice && hmdPreferredAudioOutput !== "") {
-                    print("switching to HMD preferred audio output to:" + hmdPreferredAudioOutput);
+            }
+            if (hmdPreferredAudioOutput !== "") {
+                print("HMD has preferred audio output device.");
+                previousSelectedOutputAudioDevice = Settings.getValue(OUTPUT_DEVICE_SETTING);
+                print("previousSelectedOutputAudioDevice: " + previousSelectedOutputAudioDevice);
+                if (hmdPreferredAudioOutput != previousSelectedOutputAudioDevice) {
+                    print("Switching Audio Output device to HMD preferred device: " + hmdPreferredAudioOutput);
                     switchedAudioOutputToHMD = true;
                     menuItemEvent("Use " + hmdPreferredAudioOutput + " for Output");
                 }
             }
         } else {
-            print("HMD NOW un-mounted...");
+            print("HMD no longer active. Restoring audio I/O devices...");
             restoreAudio();
         }
     }
-    wasHmdMounted = HMD.mounted;
+    wasHmdActive = HMD.active;
 }
+/****************************************
+    END FUNCTION DEFINITIONS
+****************************************/
 
-Script.update.connect(checkHMDAudio);
+/****************************************
+    BEGIN SCRIPT BODY
+****************************************/
+// Have a small delay before the menus get setup so the audio devices can switch to the last selected ones
+Script.setTimeout(function () {
+    print("Connecting deviceChanged() and displayModeChanged()");
+    AudioDevice.deviceChanged.connect(onDevicechanged);
+    HMD.displayModeChanged.connect(checkHMDAudio);
+    print("Setting up Audio > Devices menu for the first time");
+    setupAudioMenus();
+}, 2000);
 
+print("Connecting menuItemEvent() and scriptEnding()");
+Menu.menuItemEvent.connect(menuItemEvent);
 Script.scriptEnding.connect(function () {
     restoreAudio();
     removeAudioMenus();
     Menu.menuItemEvent.disconnect(menuItemEvent);
-    Script.update.disconnect(checkHMDAudio);
+    HMD.displayModeChanged.disconnect(checkHMDAudio);
 });
 
 }()); // END LOCAL_SCOPE

--- a/scripts/system/selectAudioDevice.js
+++ b/scripts/system/selectAudioDevice.js
@@ -123,8 +123,6 @@ function removeAudioMenus() {
 function onDevicechanged() {
     debug("System audio devices changed. Removing and replacing Audio Menus...");
     setupAudioMenus();
-    AudioDevice.setOutputDevice(AudioDevice.getOutputDevice());
-    AudioDevice.setInputDevice(AudioDevice.getInputDevice());
     checkDeviceMismatch();
 }
 

--- a/scripts/system/selectAudioDevice.js
+++ b/scripts/system/selectAudioDevice.js
@@ -15,34 +15,19 @@
 
 (function() { // BEGIN LOCAL_SCOPE
 
-if (typeof String.prototype.startsWith != 'function') {
-    String.prototype.startsWith = function (str){
-        return this.slice(0, str.length) == str;
-    };
-}
-
-if (typeof String.prototype.endsWith != 'function') {
-    String.prototype.endsWith = function (str){
-        return this.slice(-str.length) == str;
-    };
-}
-
-if (typeof String.prototype.trimStartsWith != 'function') {
-    String.prototype.trimStartsWith = function (str){
-        if (this.startsWith(str)) {
-            return this.substr(str.length);
-        }
-        return this;
-    };
-}
-
-if (typeof String.prototype.trimEndsWith != 'function') {
-    String.prototype.trimEndsWith = function (str){
-        if (this.endsWith(str)) {
-            return this.substr(0,this.length - str.length);
-        }
-        return this;
-    };
+const INPUT = "Input";
+const OUTPUT = "Output";
+function parseMenuItem(item) {
+	const USE = "Use ";
+	const FOR_INPUT = " for " + INPUT;
+	const FOR_OUTPUT = " for " + OUTPUT;
+	if (item.slice(0, USE.length) == USE) {
+		if (item.slice(-FOR_INPUT.length) == FOR_INPUT) {
+			return { device: item.slice(USE.length, -FOR_INPUT.length), mode: INPUT };
+		} else if (item.slice(-FOR_OUTPUT.length) == FOR_OUTPUT) {
+			return { device: item.slice(USE.length, -FOR_OUTPUT.length), mode: OUTPUT };
+		}
+	}
 }
 
 //
@@ -146,45 +131,44 @@ function onDevicechanged() {
 function switchAudioDevice(audioDeviceMenuString) {
     Menu.menuItemEvent.disconnect(switchAudioDevice);
 
-    if (audioDeviceMenuString.startsWith("Use ")) {
-        if (audioDeviceMenuString.endsWith(" for Input")) {
-            var selectedDevice = audioDeviceMenuString.trimStartsWith("Use ").trimEndsWith(" for Input");
-            var currentInputDevice = AudioDevice.getInputDevice();
-            if (selectedDevice != currentInputDevice) {
-                debug("Switching audio INPUT device from " + currentInputDevice + " to " + selectedDevice);
-                Menu.setIsOptionChecked("Use " + currentInputDevice + " for Input", false);
-                if (AudioDevice.setInputDevice(selectedDevice)) {
-                    Settings.setValue(INPUT_DEVICE_SETTING, selectedDevice);
-                    Menu.setIsOptionChecked(audioDeviceMenuString, true);
-                } else {
-                    debug("Error setting audio input device!")
-                    Menu.setIsOptionChecked(audioDeviceMenuString, false);
-                }
-            } else {
-                debug("Selected input device is the same as the current input device!")
+    var selection = parseMenuItem(audioDeviceMenuString);
+    if (!selection) {
+        debug("Invalid Audio audioDeviceMenuString! Doesn't end with 'for Input' or 'for Output'")
+    } else if (selection.mode == INPUT) {
+        var selectedDevice = selection.device;
+        var currentInputDevice = AudioDevice.getInputDevice();
+        if (selectedDevice != currentInputDevice) {
+            debug("Switching audio INPUT device from " + currentInputDevice + " to " + selectedDevice);
+            Menu.setIsOptionChecked("Use " + currentInputDevice + " for Input", false);
+            if (AudioDevice.setInputDevice(selectedDevice)) {
+                Settings.setValue(INPUT_DEVICE_SETTING, selectedDevice);
                 Menu.setIsOptionChecked(audioDeviceMenuString, true);
-                AudioDevice.setInputDevice(selectedDevice); // Still try to force-set the device (in case the user's trying to forcefully debug an issue)
-            }
-        } else if (audioDeviceMenuString.endsWith(" for Output")) {
-            var selectedDevice = audioDeviceMenuString.trimStartsWith("Use ").trimEndsWith(" for Output");
-            var currentOutputDevice = AudioDevice.getOutputDevice();
-            if (selectedDevice != currentOutputDevice) {
-                debug("Switching audio OUTPUT device from " + currentOutputDevice + " to " + selectedDevice);
-                Menu.setIsOptionChecked("Use " + currentOutputDevice + " for Output", false);
-                if (AudioDevice.setOutputDevice(selectedDevice)) {
-                    Settings.setValue(OUTPUT_DEVICE_SETTING, selectedDevice);
-                    Menu.setIsOptionChecked(audioDeviceMenuString, true);
-                } else {
-                    debug("Error setting audio output device!")
-                    Menu.setIsOptionChecked(audioDeviceMenuString, false);
-                }
             } else {
-                debug("Selected output device is the same as the current output device!")
-                Menu.setIsOptionChecked(audioDeviceMenuString, true);
-                AudioDevice.setOutputDevice(selectedDevice); // Still try to force-set the device (in case the user's trying to forcefully debug an issue)
+                debug("Error setting audio input device!")
+                Menu.setIsOptionChecked(audioDeviceMenuString, false);
             }
         } else {
-            debug("Invalid Audio audioDeviceMenuString! Doesn't end with 'for Input' or 'for Output'")
+            debug("Selected input device is the same as the current input device!")
+            Menu.setIsOptionChecked(audioDeviceMenuString, true);
+            AudioDevice.setInputDevice(selectedDevice); // Still try to force-set the device (in case the user's trying to forcefully debug an issue)
+        }
+    } else if (selection.mode == OUTPUT) {
+        var selectedDevice = selection.device;
+        var currentOutputDevice = AudioDevice.getOutputDevice();
+        if (selectedDevice != currentOutputDevice) {
+            debug("Switching audio OUTPUT device from " + currentOutputDevice + " to " + selectedDevice);
+            Menu.setIsOptionChecked("Use " + currentOutputDevice + " for Output", false);
+            if (AudioDevice.setOutputDevice(selectedDevice)) {
+                Settings.setValue(OUTPUT_DEVICE_SETTING, selectedDevice);
+                Menu.setIsOptionChecked(audioDeviceMenuString, true);
+            } else {
+                debug("Error setting audio output device!")
+                Menu.setIsOptionChecked(audioDeviceMenuString, false);
+            }
+        } else {
+            debug("Selected output device is the same as the current output device!")
+            Menu.setIsOptionChecked(audioDeviceMenuString, true);
+            AudioDevice.setOutputDevice(selectedDevice); // Still try to force-set the device (in case the user's trying to forcefully debug an issue)
         }
     }
 


### PR DESCRIPTION
Also, I cleaned up the script and added better logging (in case we have to debug an issue with device selection again (the likelihood of which is almost 100%)).

**Test Plan:**
Generally, just try to break audio device selection. See if you can achieve unexpected behavior with respect to audio input/output devices.

Some things to try:
- Start Interface both in HMD mode and not in HMD mode
- Unplug the audio input device that you're using while Interface is running
- Unplug the audio input device that you're _not_ using while Interface is running
- Unplug the audio output device that you're using while Interface is running
- Unplug the audio output device that you're _not_ using while Interface is running
- Go into HMD mode, then back out of HMD mode, ensuring that the audio device switches back to what it was when you were in Desktop mode
- Go into HMD mode while you already have HMD audio devices selected
- Move between domains

In all of the above cases, make sure that your Audio menu displays the checked device correctly (both at the top of the Interface window and in the Tablet).

NOTE that the "Mute Microphone" option toggles in some cases while switching audio devices. This is not a result of this script and should be considered intended.