### PR TITLE
Correctly initialize a file cache with the proper key

### DIFF
--- a/libraries/networking/src/FileCache.cpp
+++ b/libraries/networking/src/FileCache.cpp
@@ -67,9 +67,9 @@ void FileCache::initialize() {
 
         // load persisted files
         foreach(QString filename, files) {
-            const Key key = filename.section('.', 0, 1).toStdString();
+            const Key key = filename.section('.', 0, 0).toStdString();
             const std::string filepath = dir.filePath(filename).toStdString();
-            const size_t length = std::ifstream(filepath, std::ios::binary | std::ios::ate).tellg();
+            const size_t length = QFileInfo(filepath.c_str()).size();
             addFile(Metadata(key, length), filepath);
         }
 


### PR DESCRIPTION
When initializing a `FileCache` we want to look at all the existing files and insert them into the in-memory table of existing cache entries.  The current code takes a filename like `db5478a1e31d1664809e605aebd36ac5.ktx` and attempts to extract the hash from the filename using `filename.section('.', 0, 1)`.  However, the docs for `QString::section` make it clear that the begin and end tokens specified as arguments 2 and 3 are inclusive... so this code simply returns the original string in this case.  The correct arguments should be `filename.section('.', 0, 0)` so that it will return only the first token. 

## Testing

* Load current master build of interface and go to a scene with no content changing (including avatars other than yourself coming and going)
* Exit interface once the scene is fully loaded.
* In explorer, open the folder `<HOME>\AppData\Local\High Fidelity\Interface\ktx_cache` and examine the file dates.  There should be a number of them with dates from the most recent run, representing cached textures that were seen.
* If you restart interface and load the same scene you'll see that these files are getting written again, even though they already exist in the cache.  

If you go through the same process with this PR build, you should not see the file dates change for existing cached items when you visit a scene that you've fully loaded previously.  Note that for this build the directory to look in is `<HOME>\AppData\Local\High Fidelity - PR 9997\Interface\ktx_cache`
