### PR TITLE
Fix right-click popup menus in web views

### DIFF
--- a/interface/resources/QtWebEngine/UIDelegates/Menu.qml
+++ b/interface/resources/QtWebEngine/UIDelegates/Menu.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.5
 import QtQuick.Controls 1.4 as Controls
 
-import "../../qml/menus"
 import "../../qml/controls-uit"
 import "../../qml/styles-uit"
 


### PR DESCRIPTION
This PR fixes a regression where `UIDelegates/Menu.qml` was referring to an old import (which apparently got removed or relocated by #9343), breaking all right-click support inside of web views. 

Testing:
* load interface in Desktop mode
* use <kbd>ctrl</kbd>-<kbd>b</kbd> to open the built-in web browser
* right-click on something and a context menu should appear
