### PR TITLE
raise max mesh count for static collision entities from 500 to 1000

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -812,7 +812,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& shapeInfo) {
         auto& meshes = _model->getGeometry()->getMeshes();
         int32_t numMeshes = (int32_t)(meshes.size());
 
-        const int MAX_ALLOWED_MESH_COUNT = 500;
+        const int MAX_ALLOWED_MESH_COUNT = 1000;
         if (numMeshes > MAX_ALLOWED_MESH_COUNT) {
             // too many will cause the deadlock timer to throw...
             shapeInfo.setParams(SHAPE_TYPE_BOX, 0.5f * dimensions);


### PR DESCRIPTION
- raise max mesh count for static collision entities from 500 to 1000
