### PR TITLE
Fixing the roughness/reflection quantization bug

### DIFF
--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -76,6 +76,7 @@ static const std::string DEFAULT_ROUGHNESS_SHADER {
     "vec4 getFragmentColor() {"
     "    DeferredFragment frag = unpackDeferredFragmentNoPosition(uv);"
     "    return vec4(vec3(pow(frag.roughness, 1.0 / 2.2)), 1.0);"
+   // "    return vec4(vec3(pow(colorRamp(frag.roughness), vec3(1.0 / 2.2))), 1.0);"
     " }"
 };
 static const std::string DEFAULT_NORMAL_SHADER {

--- a/libraries/render-utils/src/LightAmbient.slh
+++ b/libraries/render-utils/src/LightAmbient.slh
@@ -39,7 +39,7 @@ vec3 evalAmbientSpecularIrradiance(LightAmbient ambient, vec3 fragEyeDir, vec3 f
             <@if supportAmbientMap@>
         {
             float levels = getLightAmbientMapNumMips(ambient);
-            float lod = min(floor((roughness)* levels), levels);
+            float lod = min(((roughness)* levels), levels);
             specularLight = evalSkyboxLight(direction, lod).xyz;
         }
     <@endif@>

--- a/libraries/render-utils/src/debug_deferred_buffer.slf
+++ b/libraries/render-utils/src/debug_deferred_buffer.slf
@@ -13,6 +13,8 @@
 //
 
 <@include DeferredBufferRead.slh@>
+<@include gpu/Color.slh@>
+<$declareColorWheel()$>
 
 uniform sampler2D linearDepthMap;
 uniform sampler2D halfLinearDepthMap;

--- a/libraries/render-utils/src/surfaceGeometry_downsampleDepthNormal.slf
+++ b/libraries/render-utils/src/surfaceGeometry_downsampleDepthNormal.slf
@@ -24,8 +24,8 @@ void main(void) {
     // Gather 2 by 2 quads from texture
 
     // Try different filters for Z
-//    vec4 Zeyes = textureGather(linearDepthMap, varTexCoord0, 0);
-  //  float Zeye = min(min(Zeyes.x, Zeyes.y), min(Zeyes.z, Zeyes.w));
+    //vec4 Zeyes = textureGather(linearDepthMap, varTexCoord0, 0);
+    //float Zeye = min(min(Zeyes.x, Zeyes.y), min(Zeyes.z, Zeyes.w));
     float Zeye = texture(linearDepthMap, varTexCoord0).x;
 
     vec4 rawNormalsX = textureGather(normalMap, varTexCoord0, 0);


### PR DESCRIPTION
The specular reflection of the ambient map is interpolating between different mips of the ambient map based on the roughness of the surface.
WE were forcing the mip level to be an integer and we weren't taking advantage of the interpolation between different mips!
THis is now fixed with this pr.

THis is this issue:
https://github.com/highfidelity/hifi/issues/7911
brilliantly reported by by @Menithal 
Only took me a year to fix...

WIth this PR:
![image](https://cloud.githubusercontent.com/assets/2230265/24334215/ab152784-121b-11e7-9e05-26349292b1b0.png)

IN Master:
![image](https://cloud.githubusercontent.com/assets/2230265/24334232/ec6648d0-121b-11e7-8b16-40f2ec9c6bb7.png)

## TEST PLAN
AS indicated in the issue,
Bring the model 
http://www.norteclabs.com/HF/experiment/RoughnessGradient2.fbx
in a zone with a nice shinny ambient map (or skymap.
YOu should see the same banding issue as indicated with master.
Not anymore with this PR

Anything else should be the same