### PR TITLE
Don't hold KTX files open for longer than transfers require

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -222,6 +222,7 @@ GL45StrictResourceTexture::GL45StrictResourceTexture(const std::weak_ptr<GLBacke
             copyMipFaceFromTexture(sourceMip, targetMip, face);
         }
     }
+    _gpuObject.finishTransfer();
     if (texture.isAutogenerateMips()) {
         generateMips();
     }

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -222,7 +222,6 @@ GL45StrictResourceTexture::GL45StrictResourceTexture(const std::weak_ptr<GLBacke
             copyMipFaceFromTexture(sourceMip, targetMip, face);
         }
     }
-    _gpuObject.finishTransfer();
     if (texture.isAutogenerateMips()) {
         generateMips();
     }

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -431,7 +431,6 @@ void GL45VariableAllocationTexture::executeNextTransfer(const TexturePointer& cu
         _currentTransferTexture = currentTexture;
         if (_pendingTransfers.front()->tryTransfer()) {
             _pendingTransfers.pop();
-            _currentTransferTexture->finishTransfer();
             _currentTransferTexture.reset();
         }
     }
@@ -456,7 +455,7 @@ GL45ResourceTexture::GL45ResourceTexture(const std::weak_ptr<GLBackend>& backend
     _memoryPressureStateStale = true;
     copyMipsFromTexture();
     syncSampler();
-	_gpuObject.finishTransfer();
+
 }
 
 void GL45ResourceTexture::allocateStorage(uint16 allocatedMip) {

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -149,6 +149,10 @@ PixelsPointer MemoryStorage::getMipFace(uint16 level, uint8 face) const {
     return PixelsPointer();
 }
 
+Size MemoryStorage::getMipFaceSize(uint16 level, uint8 face) const {
+    return getMipFace(level, face)->getSize();
+}
+
 bool MemoryStorage::isMipAvailable(uint16 level, uint8 face) const {
     PixelsPointer mipFace = getMipFace(level, face);
     return (mipFace && mipFace->getSize());
@@ -979,4 +983,10 @@ Texture::ExternalUpdates Texture::getUpdates() const {
 
 void Texture::setStorage(std::unique_ptr<Storage>& newStorage) {
     _storage.swap(newStorage);
+}
+
+void Texture::finishTransfer() const {
+    if (_storage) {
+        _storage->releaseTempResources();
+    }
 }

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -482,43 +482,39 @@ uint16 Texture::autoGenerateMips(uint16 maxMip) {
 }
 
 uint16 Texture::getStoredMipWidth(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipWidth(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipWidth(level);
 }
 
 uint16 Texture::getStoredMipHeight(uint16 level) const {
-    PixelsPointer mip = accessStoredMipFace(level);
-    if (mip && mip->getSize()) {
-        return evalMipHeight(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipHeight(level);
 }
 
 uint16 Texture::getStoredMipDepth(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipDepth(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipDepth(level);
 }
 
 uint32 Texture::getStoredMipNumTexels(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level);
 }
 
 uint32 Texture::getStoredMipSize(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level) * getTexelFormat().getSize();
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+
+    return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level) * getTexelFormat().getSize();
 }
 
 gpu::Resource::Size Texture::getStoredSize() const {
@@ -983,10 +979,4 @@ Texture::ExternalUpdates Texture::getUpdates() const {
 
 void Texture::setStorage(std::unique_ptr<Storage>& newStorage) {
     _storage.swap(newStorage);
-}
-
-void Texture::finishTransfer() const {
-    if (_storage) {
-        _storage->releaseTempResources();
-    }
 }

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -267,7 +267,6 @@ public:
         virtual void assignMipData(uint16 level, const storage::StoragePointer& storage) = 0;
         virtual void assignMipFaceData(uint16 level, uint8 face, const storage::StoragePointer& storage) = 0;
         virtual bool isMipAvailable(uint16 level, uint8 face = 0) const = 0;
-        virtual void releaseTempResources() const {}
         Texture::Type getType() const { return _type; }
 
         Stamp getStamp() const { return _stamp; }
@@ -316,12 +315,10 @@ public:
             throw std::runtime_error("Invalid call");
         }
         void reset() override { }
-        void releaseTempResources() const override { _ktxData.release(); }
 
     protected:
         std::string _filename;
         ktx::KTXDescriptorPointer _ktxDescriptor;
-        mutable ktx::KTXUniquePointer _ktxData;
         friend class Texture;
     };
 
@@ -526,11 +523,9 @@ public:
 
     ExternalUpdates getUpdates() const;
 
-    void finishTransfer() const;
-
     // Textures can be serialized directly to  ktx data file, here is how
     static ktx::KTXUniquePointer serialize(const Texture& texture);
-    static Texture* unserialize(const ktx::KTXUniquePointer& srcData, TextureUsageType usageType = TextureUsageType::RESOURCE, Usage usage = Usage(), const Sampler::Desc& sampler = Sampler::Desc());
+    static Texture* unserialize(const std::string& ktxFile, TextureUsageType usageType = TextureUsageType::RESOURCE, Usage usage = Usage(), const Sampler::Desc& sampler = Sampler::Desc());
     static bool evalKTXFormat(const Element& mipFormat, const Element& texelFormat, ktx::Header& header);
     static bool evalTextureFormat(const ktx::Header& header, Element& mipFormat, Element& texelFormat);
 

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -208,4 +208,5 @@ KTXDescriptor KTX::toDescriptor() const {
 }
 
 KTX::KTX(const StoragePointer& storage, const Header& header, const KeyValues& keyValues, const Images& images)
-    : _storage(storage), _header(header), _keyValues(keyValues), _images(images) { }
+    : _header(header), _storage(storage), _keyValues(keyValues), _images(images) {
+}

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -167,6 +167,17 @@ size_t KTXDescriptor::getMipFaceTexelsSize(uint16_t mip, uint8_t face) const {
     return result;
 }
 
+size_t KTXDescriptor::getMipFaceTexelsOffset(uint16_t mip, uint8_t face) const {
+    size_t result { 0 };
+    if (mip < images.size()) {
+        const auto& faces = images[mip];
+        if (face < faces._numFaces) {
+            result = faces._faceOffsets[face];
+        }
+    }
+    return result;
+}
+
 ImageDescriptor Image::toImageDescriptor(const Byte* baseAddress) const {
     FaceOffsets offsets;
     offsets.resize(_faceBytes.size());
@@ -194,15 +205,6 @@ KTXDescriptor KTX::toDescriptor() const {
         newDescriptors.emplace_back(_images[i].toImageDescriptor(storageStart));
     }
     return { this->_header, this->_keyValues, newDescriptors };
-}
-
-std::unique_ptr<KTX> KTXDescriptor::toKTX(const ktx::StoragePointer& storage) const {
-    Images newImages;
-    for (size_t i = 0; i < images.size(); ++i) {
-        newImages.emplace_back(images[i].toImage(storage));
-    }
-
-    return std::unique_ptr<KTX>(new KTX { storage, header, keyValues, newImages });
 }
 
 KTX::KTX(const StoragePointer& storage, const Header& header, const KeyValues& keyValues, const Images& images)

--- a/libraries/ktx/src/ktx/KTX.h
+++ b/libraries/ktx/src/ktx/KTX.h
@@ -407,43 +407,69 @@ namespace ktx {
     };
     using KeyValues = KeyValue::KeyValues;
 
-
-    struct Image {
+    struct ImageHeader {
+        using FaceOffsets = std::vector<size_t>;
         using FaceBytes = std::vector<const Byte*>;
-
-        uint32_t _numFaces{ 1 };
-        uint32_t _imageSize;
-        uint32_t _faceSize;
-        uint32_t _padding;
-        FaceBytes _faceBytes;
-        
-
-        Image(uint32_t imageSize, uint32_t padding, const Byte* bytes) :
-            _numFaces(1),
-            _imageSize(imageSize),
+        const uint32_t _numFaces;
+        const uint32_t _imageSize;
+        const uint32_t _faceSize;
+        const uint32_t _padding;
+        ImageHeader(bool cube, uint32_t imageSize, uint32_t padding) : 
+            _numFaces(cube ? NUM_CUBEMAPFACES : 1),
+            _imageSize(imageSize * _numFaces),
             _faceSize(imageSize),
-            _padding(padding),
-            _faceBytes(1, bytes) {}
+            _padding(padding) {
+        }
+    };
 
+    struct Image;
+
+    struct ImageDescriptor : public ImageHeader {
+        const FaceOffsets _faceOffsets;
+        ImageDescriptor(const ImageHeader& header, const FaceOffsets& offsets) : ImageHeader(header), _faceOffsets(offsets) {}
+        Image toImage(const ktx::StoragePointer& storage) const;
+    };
+
+    using ImageDescriptors = std::vector<ImageDescriptor>;
+
+    struct Image : public ImageHeader {
+        FaceBytes _faceBytes;
+        Image(const ImageHeader& header, const FaceBytes& faces) : ImageHeader(header), _faceBytes(faces) {}
+        Image(uint32_t imageSize, uint32_t padding, const Byte* bytes) :
+            ImageHeader(false, imageSize, padding),
+            _faceBytes(1, bytes) {}
         Image(uint32_t pageSize, uint32_t padding, const FaceBytes& cubeFaceBytes) :
-            _numFaces(NUM_CUBEMAPFACES),
-            _imageSize(pageSize * NUM_CUBEMAPFACES),
-            _faceSize(pageSize),
-            _padding(padding)
+            ImageHeader(true, pageSize, padding)
             {
                 if (cubeFaceBytes.size() == NUM_CUBEMAPFACES) {
                     _faceBytes = cubeFaceBytes;
                 }
             }
+
+        ImageDescriptor toImageDescriptor(const Byte* baseAddress) const;
     };
+
     using Images = std::vector<Image>;
+
+    class KTX;
+
+    // A KTX descriptor is a lightweight container for all the information about a serialized KTX file, but without the 
+    // actual image / face data available.
+    struct KTXDescriptor {
+        KTXDescriptor(const Header& header, const KeyValues& keyValues, const ImageDescriptors& imageDescriptors) : header(header), keyValues(keyValues), images(imageDescriptors) {}
+        const Header header;
+        const KeyValues keyValues;
+        const ImageDescriptors images;
+        size_t getMipFaceTexelsSize(uint16_t mip = 0, uint8_t face = 0) const;
+        std::unique_ptr<KTX> toKTX(const ktx::StoragePointer& storage) const;
+    };
 
     class KTX {
         void resetStorage(const StoragePointer& src);
 
         KTX();
+        KTX(const StoragePointer& storage, const Header& header, const KeyValues& keyValues, const Images& images);
     public:
-
         ~KTX();
 
         // Define a KTX object manually to write it somewhere (in a file on disk?)
@@ -475,18 +501,23 @@ namespace ktx {
         static Images parseImages(const Header& header, size_t srcSize, const Byte* srcBytes);
 
         // Access raw pointers to the main sections of the KTX
-        const Header* getHeader() const;
+        const Header& getHeader() const;
+
         const Byte* getKeyValueData() const;
         const Byte* getTexelsData() const;
         storage::StoragePointer getMipFaceTexelsData(uint16_t mip = 0, uint8_t face = 0) const;
         const StoragePointer& getStorage() const { return _storage; }
 
+        KTXDescriptor toDescriptor() const;
         size_t getKeyValueDataSize() const;
         size_t getTexelsDataSize() const;
 
+        Header _header;
         StoragePointer _storage;
         KeyValues _keyValues;
         Images _images;
+
+        friend struct KTXDescriptor;
     };
 
 }

--- a/libraries/ktx/src/ktx/KTX.h
+++ b/libraries/ktx/src/ktx/KTX.h
@@ -461,7 +461,7 @@ namespace ktx {
         const KeyValues keyValues;
         const ImageDescriptors images;
         size_t getMipFaceTexelsSize(uint16_t mip = 0, uint8_t face = 0) const;
-        std::unique_ptr<KTX> toKTX(const ktx::StoragePointer& storage) const;
+        size_t getMipFaceTexelsOffset(uint16_t mip = 0, uint8_t face = 0) const;
     };
 
     class KTX {

--- a/libraries/ktx/src/ktx/Reader.cpp
+++ b/libraries/ktx/src/ktx/Reader.cpp
@@ -185,10 +185,10 @@ namespace ktx {
         result->resetStorage(src);
 
         // read metadata
-        result->_keyValues = parseKeyValues(result->getHeader()->bytesOfKeyValueData, result->getKeyValueData());
+        result->_keyValues = parseKeyValues(result->getHeader().bytesOfKeyValueData, result->getKeyValueData());
 
         // populate image table
-        result->_images = parseImages(*result->getHeader(), result->getTexelsDataSize(), result->getTexelsData());
+        result->_images = parseImages(result->getHeader(), result->getTexelsDataSize(), result->getTexelsData());
 
         return result;
     }

--- a/libraries/model-networking/src/model-networking/KTXCache.cpp
+++ b/libraries/model-networking/src/model-networking/KTXCache.cpp
@@ -38,10 +38,3 @@ std::unique_ptr<File> KTXCache::createFile(Metadata&& metadata, const std::strin
 KTXFile::KTXFile(Metadata&& metadata, const std::string& filepath) :
     cache::File(std::move(metadata), filepath) {}
 
-std::unique_ptr<ktx::KTX> KTXFile::getKTX() const {
-    ktx::StoragePointer storage = std::make_shared<storage::FileStorage>(getFilepath().c_str());
-    if (*storage) {
-        return ktx::KTX::create(storage);
-    }
-    return {};
-}

--- a/libraries/model-networking/src/model-networking/KTXCache.h
+++ b/libraries/model-networking/src/model-networking/KTXCache.h
@@ -39,9 +39,6 @@ protected:
 class KTXFile : public cache::File {
     Q_OBJECT
 
-public:
-    std::unique_ptr<ktx::KTX> getKTX() const;
-
 protected:
     friend class KTXCache;
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -438,15 +438,9 @@ void NetworkTexture::loadContent(const QByteArray& content) {
         if (!texture) {
             KTXFilePointer ktxFile = textureCache->_ktxCache.getFile(hash);
             if (ktxFile) {
-                // Ensure that the KTX deserialization worked
-                auto ktx = ktxFile->getKTX();
-                if (ktx) {
-                    texture.reset(gpu::Texture::unserialize(ktx));
-                    // Ensure that the texture population worked
-                    if (texture) {
-                        texture->setKtxBacking(ktxFile->getFilepath());
-                        texture = textureCache->cacheTextureByHash(hash, texture);
-                    }
+                texture.reset(gpu::Texture::unserialize(ktxFile->getFilepath()));
+                if (texture) {
+                    texture = textureCache->cacheTextureByHash(hash, texture);
                 }
             }
         }

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -444,7 +444,7 @@ void NetworkTexture::loadContent(const QByteArray& content) {
                     texture.reset(gpu::Texture::unserialize(ktx));
                     // Ensure that the texture population worked
                     if (texture) {
-                        texture->setKtxBacking(ktx);
+                        texture->setKtxBacking(ktxFile->getFilepath());
                         texture = textureCache->cacheTextureByHash(hash, texture);
                     }
                 }
@@ -586,10 +586,7 @@ void ImageReader::read() {
                 qCWarning(modelnetworking) << _url << "file cache failed";
             } else {
                 resource.staticCast<NetworkTexture>()->_file = file;
-                auto fileKtx = file->getKTX();
-                if (fileKtx) {
-                    texture->setKtxBacking(fileKtx);
-                }
+                texture->setKtxBacking(file->getFilepath());
             }
         }
 

--- a/tests/ktx/src/main.cpp
+++ b/tests/ktx/src/main.cpp
@@ -111,38 +111,40 @@ int main(int argc, char** argv) {
         outFile.close();
     }
 
-    auto ktxFile = ktx::KTX::create(std::shared_ptr<storage::Storage>(new storage::FileStorage(TEST_IMAGE_KTX)));
     {
-        const auto& memStorage = ktxMemory->getStorage();
-        const auto& fileStorage = ktxFile->getStorage();
-        Q_ASSERT(memStorage->size() == fileStorage->size());
-        Q_ASSERT(memStorage->data() != fileStorage->data());
-        Q_ASSERT(0 == memcmp(memStorage->data(), fileStorage->data(), memStorage->size()));
-        Q_ASSERT(ktxFile->_images.size() == ktxMemory->_images.size());
-        auto imageCount = ktxFile->_images.size();
-        auto startMemory = ktxMemory->_storage->data();
-        auto startFile = ktxFile->_storage->data();
-        for (size_t i = 0; i < imageCount; ++i) {
-            auto memImages = ktxMemory->_images[i];
-            auto fileImages = ktxFile->_images[i];
-            Q_ASSERT(memImages._padding == fileImages._padding);
-            Q_ASSERT(memImages._numFaces == fileImages._numFaces);
-            Q_ASSERT(memImages._imageSize == fileImages._imageSize);
-            Q_ASSERT(memImages._faceSize == fileImages._faceSize);
-            Q_ASSERT(memImages._faceBytes.size() == memImages._numFaces);
-            Q_ASSERT(fileImages._faceBytes.size() == fileImages._numFaces);
-            auto faceCount = fileImages._numFaces;
-            for (uint32_t face = 0; face < faceCount; ++face) {
-                auto memFace = memImages._faceBytes[face];
-                auto memOffset = memFace - startMemory;
-                auto fileFace = fileImages._faceBytes[face];
-                auto fileOffset = fileFace - startFile;
-                Q_ASSERT(memOffset % 4 == 0);
-                Q_ASSERT(memOffset == fileOffset);
+        auto ktxFile = ktx::KTX::create(std::shared_ptr<storage::Storage>(new storage::FileStorage(TEST_IMAGE_KTX)));
+        {
+            const auto& memStorage = ktxMemory->getStorage();
+            const auto& fileStorage = ktxFile->getStorage();
+            Q_ASSERT(memStorage->size() == fileStorage->size());
+            Q_ASSERT(memStorage->data() != fileStorage->data());
+            Q_ASSERT(0 == memcmp(memStorage->data(), fileStorage->data(), memStorage->size()));
+            Q_ASSERT(ktxFile->_images.size() == ktxMemory->_images.size());
+            auto imageCount = ktxFile->_images.size();
+            auto startMemory = ktxMemory->_storage->data();
+            auto startFile = ktxFile->_storage->data();
+            for (size_t i = 0; i < imageCount; ++i) {
+                auto memImages = ktxMemory->_images[i];
+                auto fileImages = ktxFile->_images[i];
+                Q_ASSERT(memImages._padding == fileImages._padding);
+                Q_ASSERT(memImages._numFaces == fileImages._numFaces);
+                Q_ASSERT(memImages._imageSize == fileImages._imageSize);
+                Q_ASSERT(memImages._faceSize == fileImages._faceSize);
+                Q_ASSERT(memImages._faceBytes.size() == memImages._numFaces);
+                Q_ASSERT(fileImages._faceBytes.size() == fileImages._numFaces);
+                auto faceCount = fileImages._numFaces;
+                for (uint32_t face = 0; face < faceCount; ++face) {
+                    auto memFace = memImages._faceBytes[face];
+                    auto memOffset = memFace - startMemory;
+                    auto fileFace = fileImages._faceBytes[face];
+                    auto fileOffset = fileFace - startFile;
+                    Q_ASSERT(memOffset % 4 == 0);
+                    Q_ASSERT(memOffset == fileOffset);
+                }
             }
         }
     }
-    testTexture->setKtxBacking(ktxFile);
+    testTexture->setKtxBacking(TEST_IMAGE_KTX.toStdString());
     return 0;
 }
 


### PR DESCRIPTION
Machines with less CPU RAM seem to suffer under the new KTX system when we hold all the KTX files open all the time, despite memory mapping.  This PR is a first pass at doing more explicit management of the memory mapped files.  Instead of holding the memory mapped files open all the time we instead keep a descriptor of the salient details of the KTX file and have a low-impact process to open a KTX file on demand when we need actual mip data, and then to close it again once we're done.  

## Testing

If you run the current dev build 6209, and go to a domain with a high number of avatars like hifi://dev-chris2.highfidelity.io/100.923,1.6291,27.3687/0,0.998658,0,0.0517909 you can see the private byte count in Task Manager will be very high, on the order of 5-10 GB.  Running with this build the private byte count should stay below 3GB.  