### PR TITLE
WebTablet.js: Don't remove or add mouse callbacks onHMDChanged

### DIFF
--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -429,16 +429,6 @@ WebTablet.prototype.calculateTabletAttachmentProperties = function (hand, useMou
 
 WebTablet.prototype.onHmdChanged = function () {
 
-    if (HMD.active) {
-        Controller.mousePressEvent.disconnect(this.myMousePressEvent);
-        Controller.mouseMoveEvent.disconnect(this.myMouseMoveEvent);
-        Controller.mouseReleaseEvent.disconnect(this.myMouseReleaseEvent);
-    } else {
-        Controller.mousePressEvent.connect(this.myMousePressEvent);
-        Controller.mouseMoveEvent.connect(this.myMouseMoveEvent);
-        Controller.mouseReleaseEvent.connect(this.myMouseReleaseEvent);
-    }
-
     var tabletProperties = {};
     // compute position, rotation & parentJointIndex of the tablet
     this.calculateTabletAttachmentProperties(NO_HANDS, false, tabletProperties);


### PR DESCRIPTION
This should prevent the exception on destroy, caused by disconnecting a signal that is not attached.