### PR TITLE
bad serialization of Avatar Entity parentID

### DIFF
--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -60,8 +60,10 @@ void EntityEditPacketSender::queueEditAvatarEntityMessage(PacketType type,
 
     // the ID of the parent/avatar changes from session to session.  use a special UUID to indicate the avatar
     QJsonObject jsonObject = jsonProperties.object();
-    if (QUuid(jsonObject["parentID"].toString()) == _myAvatar->getID()) {
-        jsonObject["parentID"] = AVATAR_SELF_ID.toString();
+    if(jsonObject.contains("parentID")) {
+        if (QUuid(jsonObject["parentID"].toString()) == _myAvatar->getID()) {
+            jsonObject["parentID"] = AVATAR_SELF_ID.toString();
+        }
     }
     jsonProperties = QJsonDocument(jsonObject);
 

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -60,7 +60,7 @@ void EntityEditPacketSender::queueEditAvatarEntityMessage(PacketType type,
 
     // the ID of the parent/avatar changes from session to session.  use a special UUID to indicate the avatar
     QJsonObject jsonObject = jsonProperties.object();
-    if(jsonObject.contains("parentID")) {
+    if (jsonObject.contains("parentID")) {
         if (QUuid(jsonObject["parentID"].toString()) == _myAvatar->getID()) {
             jsonObject["parentID"] = AVATAR_SELF_ID.toString();
         }


### PR DESCRIPTION
Well, really just if you didn't give it one.  In that case, you would end up with `parentID: null` in the avatar entity json, which leads to the error in [this bug](https://highfidelity.fogbugz.com/f/cases/3536/Avatar-Entities-produce-lots-of-errors-in-logs), when deserializing it on the other clients.  The effect is: you create the avatar entity, and every other client in that domain sees this error in their logs.  And again every time you update it.  The fix is to not call jsonObject["parentID"] unless that key really is there, because it is there afterward (as a QJsonValue::Undefined).  