### PR TITLE
Don't hold KTX files open for longer than transfers require

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -85,14 +85,16 @@ TransferJob::TransferJob(const GL45VariableAllocationTexture& parent, uint16_t s
     auto transferDimensions = _parent._gpuObject.evalMipDimensions(sourceMip);
     GLenum format;
     GLenum type;
-    auto mipData = _parent._gpuObject.accessStoredMipFace(sourceMip, face);
     GLTexelFormat texelFormat = GLTexelFormat::evalGLTexelFormat(_parent._gpuObject.getTexelFormat(), _parent._gpuObject.getStoredMipFormat());
     format = texelFormat.format;
     type = texelFormat.type;
+    auto mipSize = _parent._gpuObject.getStoredMipFaceSize(sourceMip, face);
+
 
     if (0 == lines) {
-        _transferSize = mipData->getSize();
+        _transferSize = mipSize;
         _bufferingLambda = [=] {
+            auto mipData = _parent._gpuObject.accessStoredMipFace(sourceMip, face);
             _buffer.resize(_transferSize);
             memcpy(&_buffer[0], mipData->readData(), _transferSize);
             _bufferingCompleted = true;
@@ -101,11 +103,11 @@ TransferJob::TransferJob(const GL45VariableAllocationTexture& parent, uint16_t s
     } else {
         transferDimensions.y = lines;
         auto dimensions = _parent._gpuObject.evalMipDimensions(sourceMip);
-        auto mipSize = mipData->getSize();
         auto bytesPerLine = (uint32_t)mipSize / dimensions.y;
-        _transferSize = bytesPerLine * lines;
         auto sourceOffset = bytesPerLine * lineOffset;
+        _transferSize = bytesPerLine * lines;
         _bufferingLambda = [=] {
+            auto mipData = _parent._gpuObject.accessStoredMipFace(sourceMip, face);
             _buffer.resize(_transferSize);
             memcpy(&_buffer[0], mipData->readData() + sourceOffset, _transferSize);
             _bufferingCompleted = true;
@@ -585,10 +587,10 @@ void GL45ResourceTexture::populateTransferQueue() {
 
             // break down the transfers into chunks so that no single transfer is 
             // consuming more than X bandwidth
-            auto mipData = _gpuObject.accessStoredMipFace(sourceMip, face);
+            auto mipSize = _gpuObject.getStoredMipFaceSize(sourceMip, face);
             const auto lines = mipDimensions.y;
-            auto bytesPerLine = (uint32_t)mipData->getSize() / lines;
-            Q_ASSERT(0 == (mipData->getSize() % lines));
+            auto bytesPerLine = mipSize / lines;
+            Q_ASSERT(0 == (mipSize % lines));
             uint32_t linesPerTransfer = (uint32_t)(MAX_TRANSFER_SIZE / bytesPerLine);
             uint32_t lineOffset = 0;
             while (lineOffset < lines) {

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -149,6 +149,10 @@ PixelsPointer MemoryStorage::getMipFace(uint16 level, uint8 face) const {
     return PixelsPointer();
 }
 
+Size MemoryStorage::getMipFaceSize(uint16 level, uint8 face) const {
+    return getMipFace(level, face)->getSize();
+}
+
 bool MemoryStorage::isMipAvailable(uint16 level, uint8 face) const {
     PixelsPointer mipFace = getMipFace(level, face);
     return (mipFace && mipFace->getSize());
@@ -478,43 +482,39 @@ uint16 Texture::autoGenerateMips(uint16 maxMip) {
 }
 
 uint16 Texture::getStoredMipWidth(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipWidth(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipWidth(level);
 }
 
 uint16 Texture::getStoredMipHeight(uint16 level) const {
-    PixelsPointer mip = accessStoredMipFace(level);
-    if (mip && mip->getSize()) {
-        return evalMipHeight(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipHeight(level);
 }
 
 uint16 Texture::getStoredMipDepth(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipDepth(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipDepth(level);
 }
 
 uint32 Texture::getStoredMipNumTexels(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level);
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+    return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level);
 }
 
 uint32 Texture::getStoredMipSize(uint16 level) const {
-    PixelsPointer mipFace = accessStoredMipFace(level);
-    if (mipFace && mipFace->getSize()) {
-        return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level) * getTexelFormat().getSize();
+    if (!isStoredMipFaceAvailable(level)) {
+        return 0;
     }
-    return 0;
+
+    return evalMipWidth(level) * evalMipHeight(level) * evalMipDepth(level) * getTexelFormat().getSize();
 }
 
 gpu::Resource::Size Texture::getStoredSize() const {

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -42,30 +42,37 @@ struct GPUKTXPayload {
 
 std::string GPUKTXPayload::KEY { "hifi.gpu" };
 
-KtxStorage::KtxStorage(ktx::KTXUniquePointer& ktxData) {
-
-    // if the source ktx is valid let's config this KtxStorage correctly
-    if (ktxData && ktxData->getHeader()) {
-
-        // now that we know the ktx, let's get the header info to configure this Texture::Storage:
-        Format mipFormat = Format::COLOR_BGRA_32;
-        Format texelFormat = Format::COLOR_SRGBA_32;
-        if (Texture::evalTextureFormat(*ktxData->getHeader(), mipFormat, texelFormat)) {
-            _format = mipFormat;
-        }
-
-
+KtxStorage::KtxStorage(const std::string& filename) : _filename(filename) {
+    {
+        ktx::StoragePointer storage { new storage::FileStorage(_filename.c_str()) };
+        auto ktxPointer = ktx::KTX::create(storage);
+        _ktxDescriptor.reset(new ktx::KTXDescriptor(ktxPointer->toDescriptor()));
     }
 
-    _ktxData.reset(ktxData.release());
+    // now that we know the ktx, let's get the header info to configure this Texture::Storage:
+    Format mipFormat = Format::COLOR_BGRA_32;
+    Format texelFormat = Format::COLOR_SRGBA_32;
+    if (Texture::evalTextureFormat(_ktxDescriptor->header, mipFormat, texelFormat)) {
+        _format = mipFormat;
+    }
 }
 
 PixelsPointer KtxStorage::getMipFace(uint16 level, uint8 face) const {
-    return _ktxData->getMipFaceTexelsData(level, face);
+    storage::StoragePointer result;
+    auto faceOffset = _ktxDescriptor->getMipFaceTexelsOffset(level, face);
+    auto faceSize = _ktxDescriptor->getMipFaceTexelsSize(level, face);
+    if (faceSize != 0 && faceOffset != 0) {
+        result = std::make_shared<storage::FileStorage>(_filename.c_str())->createView(faceSize, faceOffset)->toMemoryStorage();
+    }
+    return result;
 }
 
-void Texture::setKtxBacking(ktx::KTXUniquePointer& ktxBacking) {
-    auto newBacking = std::unique_ptr<Storage>(new KtxStorage(ktxBacking));
+Size KtxStorage::getMipFaceSize(uint16 level, uint8 face) const {
+    return _ktxDescriptor->getMipFaceTexelsSize(level, face);
+}
+
+void Texture::setKtxBacking(const std::string& filename) {
+    auto newBacking = std::unique_ptr<Storage>(new KtxStorage(filename));
     setStorage(newBacking);
 }
 
@@ -177,11 +184,9 @@ ktx::KTXUniquePointer Texture::serialize(const Texture& texture) {
     return ktxBuffer;
 }
 
-Texture* Texture::unserialize(const ktx::KTXUniquePointer& srcData, TextureUsageType usageType, Usage usage, const Sampler::Desc& sampler) {
-    if (!srcData) {
-        return nullptr;
-    }
-    const auto& header = *srcData->getHeader();
+Texture* Texture::unserialize(const std::string& ktxfile, TextureUsageType usageType, Usage usage, const Sampler::Desc& sampler) {
+    ktx::KTXDescriptor descriptor { ktx::KTX::create(ktx::StoragePointer { new storage::FileStorage(ktxfile.c_str()) })->toDescriptor() };
+    const auto& header = descriptor.header;
 
     Format mipFormat = Format::COLOR_BGRA_32;
     Format texelFormat = Format::COLOR_SRGBA_32;
@@ -209,7 +214,7 @@ Texture* Texture::unserialize(const ktx::KTXUniquePointer& srcData, TextureUsage
     
     // If found, use the 
     GPUKTXPayload gpuktxKeyValue;
-    bool isGPUKTXPayload = GPUKTXPayload::findInKeyValues(srcData->_keyValues, gpuktxKeyValue);
+    bool isGPUKTXPayload = GPUKTXPayload::findInKeyValues(descriptor.keyValues, gpuktxKeyValue);
 
     auto tex = Texture::create( (isGPUKTXPayload ? gpuktxKeyValue._usageType : usageType),
                                 type,
@@ -225,14 +230,7 @@ Texture* Texture::unserialize(const ktx::KTXUniquePointer& srcData, TextureUsage
 
     // Assing the mips availables
     tex->setStoredMipFormat(mipFormat);
-    uint16_t level = 0;
-    for (auto& image : srcData->_images) {
-        for (uint32_t face = 0; face < image._numFaces; face++) {
-            tex->assignStoredMipFace(level, face, image._faceSize, image._faceBytes[face]);
-        }
-        level++;
-    }
-
+    tex->setKtxBacking(ktxfile);
     return tex;
 }
 

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -108,47 +108,39 @@ KTX::~KTX() {
 
 void KTX::resetStorage(const StoragePointer& storage) {
     _storage = storage;
+    if (_storage->size() >= sizeof(Header)) {
+        memcpy(&_header, _storage->data(), sizeof(Header));
+    }
 }
 
-const Header* KTX::getHeader() const {
-    if (!_storage) {
-        return nullptr;
-    } 
-    return reinterpret_cast<const Header*>(_storage->data());
+const Header& KTX::getHeader() const {
+    return _header;
 }
 
 
 size_t KTX::getKeyValueDataSize() const {
-    if (_storage) {
-        return getHeader()->bytesOfKeyValueData;
-    } else {
-        return 0;
-    }
+    return _header.bytesOfKeyValueData;
 }
 
 size_t KTX::getTexelsDataSize() const {
-    if (_storage) {
-        //return  _storage->size() - (sizeof(Header) + getKeyValueDataSize());
-        return  (_storage->data() + _storage->size()) - getTexelsData();
-    } else {
+    if (!_storage) {
         return 0;
     }
+    return  (_storage->data() + _storage->size()) - getTexelsData();
 }
 
 const Byte* KTX::getKeyValueData() const {
-    if (_storage) {
-        return (_storage->data() + sizeof(Header));
-    } else {
+    if (!_storage) {
         return nullptr;
     }
+    return (_storage->data() + sizeof(Header));
 }
 
 const Byte* KTX::getTexelsData() const {
-    if (_storage) {
-        return (_storage->data() + sizeof(Header) + getKeyValueDataSize());
-    } else {
+    if (!_storage) {
         return nullptr;
     }
+    return (_storage->data() + sizeof(Header) + getKeyValueDataSize());
 }
 
 storage::StoragePointer KTX::getMipFaceTexelsData(uint16_t mip, uint8_t face) const {
@@ -162,4 +154,59 @@ storage::StoragePointer KTX::getMipFaceTexelsData(uint16_t mip, uint8_t face) co
         }
     }
     return result;
+}
+
+size_t KTXDescriptor::getMipFaceTexelsSize(uint16_t mip, uint8_t face) const {
+    size_t result { 0 };
+    if (mip < images.size()) {
+        const auto& faces = images[mip];
+        if (face < faces._numFaces) {
+            result = faces._faceSize;
+        }
+    }
+    return result;
+}
+
+size_t KTXDescriptor::getMipFaceTexelsOffset(uint16_t mip, uint8_t face) const {
+    size_t result { 0 };
+    if (mip < images.size()) {
+        const auto& faces = images[mip];
+        if (face < faces._numFaces) {
+            result = faces._faceOffsets[face];
+        }
+    }
+    return result;
+}
+
+ImageDescriptor Image::toImageDescriptor(const Byte* baseAddress) const {
+    FaceOffsets offsets;
+    offsets.resize(_faceBytes.size());
+    for (size_t face = 0; face < _numFaces; ++face) {
+        offsets[face] = _faceBytes[face] - baseAddress;
+    }
+    // Note, implicit cast of *this to const ImageHeader&
+    return ImageDescriptor(*this, offsets);
+}
+
+Image ImageDescriptor::toImage(const ktx::StoragePointer& storage) const {
+    FaceBytes faces;
+    faces.resize(_faceOffsets.size());
+    for (size_t face = 0; face < _numFaces; ++face) {
+        faces[face] = storage->data() + _faceOffsets[face];
+    }
+    // Note, implicit cast of *this to const ImageHeader&
+    return Image(*this, faces);
+}
+
+KTXDescriptor KTX::toDescriptor() const {
+    ImageDescriptors newDescriptors;
+    auto storageStart = _storage ? _storage->data() : nullptr;
+    for (size_t i = 0; i < _images.size(); ++i) {
+        newDescriptors.emplace_back(_images[i].toImageDescriptor(storageStart));
+    }
+    return { this->_header, this->_keyValues, newDescriptors };
+}
+
+KTX::KTX(const StoragePointer& storage, const Header& header, const KeyValues& keyValues, const Images& images)
+    : _header(header), _storage(storage), _keyValues(keyValues), _images(images) {
 }

--- a/libraries/ktx/src/ktx/Reader.cpp
+++ b/libraries/ktx/src/ktx/Reader.cpp
@@ -185,10 +185,10 @@ namespace ktx {
         result->resetStorage(src);
 
         // read metadata
-        result->_keyValues = parseKeyValues(result->getHeader()->bytesOfKeyValueData, result->getKeyValueData());
+        result->_keyValues = parseKeyValues(result->getHeader().bytesOfKeyValueData, result->getKeyValueData());
 
         // populate image table
-        result->_images = parseImages(*result->getHeader(), result->getTexelsDataSize(), result->getTexelsData());
+        result->_images = parseImages(result->getHeader(), result->getTexelsDataSize(), result->getTexelsData());
 
         return result;
     }

--- a/libraries/model-networking/src/model-networking/KTXCache.cpp
+++ b/libraries/model-networking/src/model-networking/KTXCache.cpp
@@ -38,10 +38,3 @@ std::unique_ptr<File> KTXCache::createFile(Metadata&& metadata, const std::strin
 KTXFile::KTXFile(Metadata&& metadata, const std::string& filepath) :
     cache::File(std::move(metadata), filepath) {}
 
-std::unique_ptr<ktx::KTX> KTXFile::getKTX() const {
-    ktx::StoragePointer storage = std::make_shared<storage::FileStorage>(getFilepath().c_str());
-    if (*storage) {
-        return ktx::KTX::create(storage);
-    }
-    return {};
-}

--- a/libraries/model-networking/src/model-networking/KTXCache.h
+++ b/libraries/model-networking/src/model-networking/KTXCache.h
@@ -39,9 +39,6 @@ protected:
 class KTXFile : public cache::File {
     Q_OBJECT
 
-public:
-    std::unique_ptr<ktx::KTX> getKTX() const;
-
 protected:
     friend class KTXCache;
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -438,15 +438,9 @@ void NetworkTexture::loadContent(const QByteArray& content) {
         if (!texture) {
             KTXFilePointer ktxFile = textureCache->_ktxCache.getFile(hash);
             if (ktxFile) {
-                // Ensure that the KTX deserialization worked
-                auto ktx = ktxFile->getKTX();
-                if (ktx) {
-                    texture.reset(gpu::Texture::unserialize(ktx));
-                    // Ensure that the texture population worked
-                    if (texture) {
-                        texture->setKtxBacking(ktx);
-                        texture = textureCache->cacheTextureByHash(hash, texture);
-                    }
+                texture.reset(gpu::Texture::unserialize(ktxFile->getFilepath()));
+                if (texture) {
+                    texture = textureCache->cacheTextureByHash(hash, texture);
                 }
             }
         }
@@ -586,10 +580,7 @@ void ImageReader::read() {
                 qCWarning(modelnetworking) << _url << "file cache failed";
             } else {
                 resource.staticCast<NetworkTexture>()->_file = file;
-                auto fileKtx = file->getKTX();
-                if (fileKtx) {
-                    texture->setKtxBacking(fileKtx);
-                }
+                texture->setKtxBacking(file->getFilepath());
             }
         }
 

--- a/tests/ktx/src/main.cpp
+++ b/tests/ktx/src/main.cpp
@@ -111,38 +111,40 @@ int main(int argc, char** argv) {
         outFile.close();
     }
 
-    auto ktxFile = ktx::KTX::create(std::shared_ptr<storage::Storage>(new storage::FileStorage(TEST_IMAGE_KTX)));
     {
-        const auto& memStorage = ktxMemory->getStorage();
-        const auto& fileStorage = ktxFile->getStorage();
-        Q_ASSERT(memStorage->size() == fileStorage->size());
-        Q_ASSERT(memStorage->data() != fileStorage->data());
-        Q_ASSERT(0 == memcmp(memStorage->data(), fileStorage->data(), memStorage->size()));
-        Q_ASSERT(ktxFile->_images.size() == ktxMemory->_images.size());
-        auto imageCount = ktxFile->_images.size();
-        auto startMemory = ktxMemory->_storage->data();
-        auto startFile = ktxFile->_storage->data();
-        for (size_t i = 0; i < imageCount; ++i) {
-            auto memImages = ktxMemory->_images[i];
-            auto fileImages = ktxFile->_images[i];
-            Q_ASSERT(memImages._padding == fileImages._padding);
-            Q_ASSERT(memImages._numFaces == fileImages._numFaces);
-            Q_ASSERT(memImages._imageSize == fileImages._imageSize);
-            Q_ASSERT(memImages._faceSize == fileImages._faceSize);
-            Q_ASSERT(memImages._faceBytes.size() == memImages._numFaces);
-            Q_ASSERT(fileImages._faceBytes.size() == fileImages._numFaces);
-            auto faceCount = fileImages._numFaces;
-            for (uint32_t face = 0; face < faceCount; ++face) {
-                auto memFace = memImages._faceBytes[face];
-                auto memOffset = memFace - startMemory;
-                auto fileFace = fileImages._faceBytes[face];
-                auto fileOffset = fileFace - startFile;
-                Q_ASSERT(memOffset % 4 == 0);
-                Q_ASSERT(memOffset == fileOffset);
+        auto ktxFile = ktx::KTX::create(std::shared_ptr<storage::Storage>(new storage::FileStorage(TEST_IMAGE_KTX)));
+        {
+            const auto& memStorage = ktxMemory->getStorage();
+            const auto& fileStorage = ktxFile->getStorage();
+            Q_ASSERT(memStorage->size() == fileStorage->size());
+            Q_ASSERT(memStorage->data() != fileStorage->data());
+            Q_ASSERT(0 == memcmp(memStorage->data(), fileStorage->data(), memStorage->size()));
+            Q_ASSERT(ktxFile->_images.size() == ktxMemory->_images.size());
+            auto imageCount = ktxFile->_images.size();
+            auto startMemory = ktxMemory->_storage->data();
+            auto startFile = ktxFile->_storage->data();
+            for (size_t i = 0; i < imageCount; ++i) {
+                auto memImages = ktxMemory->_images[i];
+                auto fileImages = ktxFile->_images[i];
+                Q_ASSERT(memImages._padding == fileImages._padding);
+                Q_ASSERT(memImages._numFaces == fileImages._numFaces);
+                Q_ASSERT(memImages._imageSize == fileImages._imageSize);
+                Q_ASSERT(memImages._faceSize == fileImages._faceSize);
+                Q_ASSERT(memImages._faceBytes.size() == memImages._numFaces);
+                Q_ASSERT(fileImages._faceBytes.size() == fileImages._numFaces);
+                auto faceCount = fileImages._numFaces;
+                for (uint32_t face = 0; face < faceCount; ++face) {
+                    auto memFace = memImages._faceBytes[face];
+                    auto memOffset = memFace - startMemory;
+                    auto fileFace = fileImages._faceBytes[face];
+                    auto fileOffset = fileFace - startFile;
+                    Q_ASSERT(memOffset % 4 == 0);
+                    Q_ASSERT(memOffset == fileOffset);
+                }
             }
         }
     }
-    testTexture->setKtxBacking(ktxFile);
+    testTexture->setKtxBacking(TEST_IMAGE_KTX.toStdString());
     return 0;
 }
 


### PR DESCRIPTION
Reverts highfidelity/hifi#10036

After testing and qa, this pr is good to go, we can merge:

Machines with less CPU RAM seem to suffer under the new KTX system when we hold all the KTX files open all the time, despite memory mapping. This PR is a first pass at doing more explicit management of the memory mapped files. Instead of holding the memory mapped files open all the time we instead keep a descriptor of the salient details of the KTX file and have a low-impact process to open a KTX file on demand when we need actual mip data, and then to close it again once we're done.

Testing

If you run the current dev build 6209, and go to a domain with a high number of avatars like hifi://dev-chris2.highfidelity.io/100.923,1.6291,27.3687/0,0.998658,0,0.0517909 you can see the private byte count in Task Manager will be very high, on the order of 5-10 GB. Running with this build the private byte count should stay below 3GB.