### PR TITLE
Fix for disappearing toolbar after reload all scripts

### DIFF
--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -55,7 +55,7 @@ OriginalDesktop.Desktop {
         // Literal 50 is overwritten by settings from previous session, and sysToolbar.x comes from settings when not constrained.
         x: sysToolbar.x
         y: 50
-        shown: false
+        shown: true
     }
 
     Settings {

--- a/interface/resources/qml/hifi/toolbars/Toolbar.qml
+++ b/interface/resources/qml/hifi/toolbars/Toolbar.qml
@@ -49,7 +49,6 @@ Window {
         id: content
         implicitHeight: horizontal ? row.height : column.height
         implicitWidth: horizontal ? row.width : column.width
-        property bool wasVisibleBeforeBeingPinned: false
 
         Row {
             id: row
@@ -62,18 +61,6 @@ Window {
         }
 
         Component { id: toolbarButtonBuilder; ToolbarButton { } }
-
-        Connections {
-            target: desktop
-            onPinnedChanged: {
-                if (desktop.pinned) {
-                    content.wasVisibleBeforeBeingPinned = window.visible;
-                    window.visible = false;
-                } else {
-                    window.visible = content.wasVisibleBeforeBeingPinned;
-                }
-            }
-        }
     }
 
 
@@ -136,9 +123,10 @@ Window {
         buttons.push(result);
 
         result.opacity = 1;
-        updatePinned();
 
         sortButtons();
+
+        shown = true;
 
         return result;
     }
@@ -149,24 +137,12 @@ Window {
             console.warn("Tried to remove non-existent button " + name);
             return;
         }
+
         buttons[index].destroy();
         buttons.splice(index, 1);
-        updatePinned();
 
         if (buttons.length === 0) {
-            fadeOut(function () {});
+            shown = false;
         }
-    }
-
-    function updatePinned() {
-        var newPinned = false;
-        for (var i in buttons) {
-            var child = buttons[i];
-            if (child.pinned) {
-                newPinned = true;
-                break;
-            }
-        }
-        pinned = newPinned;
     }
 }


### PR DESCRIPTION
QA Test:
  * Start in desktop mode.  With "Desktop Tablet Becomes Toolbar" checked in General preferences.  Also make sure that "Clear overlays when moving" is checked.
  * Ensure that the system toolbar is visible.
  * Ensure that the system toolbar becomes invisible if you move with the arrow keys, and re-appears when you stop.
  * Enter HMD mode by pressing the VR button on the toolbar.
  * Ensure that no portion of the system toolbar is visible, even though all buttons have been removed from it.
  * Ensure that no portion of the system toolbar becomes visible after moving with the arrow keys.
  * Switch back into desktop mode by pressing the Desktop Button on the tablet.
  * Ensure that the system toolbar is visible again.