### PR TITLE
Fix cached ResourceCache::prefetch() state updates

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -191,7 +191,7 @@ ScriptableResource* ResourceCache::prefetch(const QUrl& url, void* extra) {
     result->setObjectName(url.toString());
 
     result->_resource = resource;
-    if (resource->isLoaded()) {
+    if (resource->isLoaded() || resource->_failedToLoad) {
         result->finished(!resource->_failedToLoad);
     } else {
         result->_progressConnection = connect(


### PR DESCRIPTION
This PR fixes an issue with `ModelCache.prefetch(url)` where once a resource fails to load, subsequent prefetches for that same URL would get stuck in the `Resource.State.QUEUED` state forever.

Testing:
* Open the *Console...* and enter `ModelCache.prefetch("file:///dev/null").state`
* The displayed value should initially be **0**, **1** or **4**.
* Now re-run the same command a few times (ie: using up arrow and enter) -- all subsequent values should be **4**.

For reference those numeric states mean:
```javascript
{
  "State": {
    "objectName": "ResourceState",
    "QUEUED": 0,
    "LOADING": 1,
    "LOADED": 2,
    "FINISHED": 3,
    "FAILED": 4
  }
}
```