### PR TITLE
Implemented no connection dialog for Tablet UI

### DIFF
--- a/interface/resources/qml/dialogs/TabletConnectionFailureDialog.qml
+++ b/interface/resources/qml/dialogs/TabletConnectionFailureDialog.qml
@@ -1,0 +1,32 @@
+//
+//  TabletConnectionFailureDialog.qml
+//
+//  Created by Vlad Stelmahovsky on 29 Mar 2017
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import Hifi 1.0
+import QtQuick 2.5
+import QtQuick.Controls 1.4
+import QtQuick.Dialogs 1.2 as OriginalDialogs
+
+Item {
+    Component.onCompleted: {
+        var object = tabletRoot.messageBox({
+                                            icon: OriginalDialogs.StandardIcon.Warning,
+                                            buttons: OriginalDialogs.StandardButton.Ok,
+                                            defaultButton: OriginalDialogs.StandardButton.NoButton,
+                                            title: "No Connection",
+                                            text: "Unable to connect to this domain. Click the 'GO TO' button on the toolbar to visit another domain."
+                                        });
+        object.selected.connect(function(button) {
+            if (button === OriginalDialogs.StandardButton.Ok) {
+                var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
+                tablet.gotoHomeScreen()
+            }
+        });
+    }
+}

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -60,10 +60,25 @@ void DialogsManager::showFeed() {
 }
 
 void DialogsManager::setDomainConnectionFailureVisibility(bool visible) {
-    if (visible) {
-        ConnectionFailureDialog::show();
+    qDebug() << "DialogsManager::setDomainConnectionFailureVisibility: visible" << visible;
+    auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+
+    if (tablet->getToolbarMode()) {
+        if (visible) {
+            ConnectionFailureDialog::show();
+        } else {
+            ConnectionFailureDialog::hide();
+        }
     } else {
-        ConnectionFailureDialog::hide();
+        static const QUrl url("../../dialogs/TabletConnectionFailureDialog.qml");
+        auto hmd = DependencyManager::get<HMDScriptingInterface>();
+        if (visible) {
+            tablet->initialScreen(url);
+            if (!hmd->getShouldShowTablet()) {
+                hmd->openTablet();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Test plan
- open Goto and enter non existing address, f.ex: hifi://123.123.123.123
- after few seconds No connection dialog should appear within Tablet
- press OK will bring Home menu