### PR TITLE
Fix Entities.setLocalJointTranslations

### DIFF
--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -429,7 +429,7 @@ void ModelEntityItem::setJointTranslations(const QVector<glm::vec3>& translation
         for (int index = 0; index < translations.size(); index++) {
             if (_localJointTranslationsSet[index]) {
                 _localJointTranslations[index] = translations[index];
-                _localJointTranslationsSet[index] = true;
+                _localJointTranslationsDirty[index] = true;
             }
         }
     });


### PR DESCRIPTION
This PR fixes a typo that was preventing joint translations set with `Entities.setLocalJointTranslations` from being seen by others.

### Testing:

Two instances of Interface are needed -- a "transmitting" and a "receiving" side.  Only the receiving side actually has to be running this PR (in case that makes it easier to find someone to test with).

* Launch two instances somewhere with rez rights.
* On the transmitting side, run this Client script:
```javascript
var id = Entities.addEntity({
     type: 'Model',
     position: MyAvatar.position,
     modelURL: MyAvatar.skeletonModelURL,
     lifetime: 600,
});
var interval = Script.setInterval(function(){
  Entities.setLocalJointTranslations(id, [{ x: -100 * Math.random(), y: 0, z: 0 }]);
}, 1000);
```
* On the receiving side, while running this PR, you should see the T-pose Model Entity bouncing around randomly.

(Same test could be run using a recent beta on the receiving side to confirm the functionality was broken before.)