### PR TITLE
Fixing the bad rendering of the instanced primitives on 4.1

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -571,10 +571,15 @@ void OpenGLDisplayPlugin::compositeLayers() {
         compositeScene();
     }
 
+
+#ifdef HIFI_ENABLE_NSIGHT_DEBUG
+    if (false) // do not compositeoverlay if running nsight debug
+#endif
     {
         PROFILE_RANGE_EX(render_detail, "compositeOverlay", 0xff0077ff, (uint64_t)presentCount())
         compositeOverlay();
     }
+
     auto compositorHelper = DependencyManager::get<CompositorHelper>();
     if (compositorHelper->getReticleVisible()) {
         PROFILE_RANGE_EX(render_detail, "compositePointer", 0xff0077ff, (uint64_t)presentCount())

--- a/libraries/gl/src/gl/Config.h
+++ b/libraries/gl/src/gl/Config.h
@@ -28,6 +28,9 @@
 
 #include <GL/wglew.h>
 
+// Uncomment this define and recompile to be able to avoid code path preventing to be able to run nsight graphics debug
+//#define HIFI_ENABLE_NSIGHT_DEBUG 1
+
 #endif
 
 #endif // hifi_gpu_GPUConfig_h

--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -278,6 +278,11 @@ void OffscreenQmlSurface::cleanup() {
 }
 
 void OffscreenQmlSurface::render() {
+
+#ifdef HIFI_ENABLE_NSIGHT_DEBUG
+    return;
+#endif
+
     if (_paused) {
         return;
     }

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTransform.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTransform.cpp
@@ -95,7 +95,6 @@ void GL41Backend::updateTransform(const Batch& batch) {
     } else {
         if (!_transform._enabledDrawcallInfoBuffer) {
             glEnableVertexAttribArray(gpu::Stream::DRAW_CALL_INFO); // Make sure attrib array is enabled
-            glBindBuffer(GL_ARRAY_BUFFER, _transform._drawCallInfoBuffer);
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
             glVertexAttribDivisor(gpu::Stream::DRAW_CALL_INFO, (isStereo() ? 2 : 1));
 #else
@@ -103,6 +102,7 @@ void GL41Backend::updateTransform(const Batch& batch) {
 #endif
             _transform._enabledDrawcallInfoBuffer = true;
         }
+        glBindBuffer(GL_ARRAY_BUFFER, _transform._drawCallInfoBuffer);
         glVertexAttribIPointer(gpu::Stream::DRAW_CALL_INFO, 2, GL_UNSIGNED_SHORT, 0, _transform._drawCallInfoOffsets[batch._currentNamedCall]);
     }
 


### PR DESCRIPTION
This pr fixes a n old bug we introduced on 4.1 when rendering instanced primitives (cube, sphere and shape entities)

The drawcallInfoBuffer wasn;t bound correctly after the first named call, now fixed.

Working on this bug i added a define to be able to compile and rung interface through Nsight Graphics Debug.

## TEST PLAN
- running with 4.1 backend (on mac, on intel gpu or setting the env variable "HIFI_DISABLE_OPENGL_45" it should be obvious in dev-welcome for example that the primitives (box, sphere or shapes) are  rendering correctly with this PR and not in master.

- (Not required for Pass) If you are curious to test Nsight, simply uncomment the line in gl library / Config.h and recompile, You should be able to run nsught graphics debug correctly (need to start the capture from the viusal studio interface though, and confirm to actually attempt doing the capture)