### PR TITLE
Fix entity "unlock" edits not being propagated to clients

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -182,6 +182,7 @@ bool EntityTree::updateEntityWithElement(EntityItemPointer entity, const EntityI
             if (!wantsLocked) {
                 EntityItemProperties tempProperties;
                 tempProperties.setLocked(wantsLocked);
+                tempProperties.setLastEdited(properties.getLastEdited());
 
                 bool success;
                 AACube queryCube = entity->getQueryAACube(success);


### PR DESCRIPTION
The lastEditedBy property was not being updated when changing the locked property of entities from true to false.