### PR TITLE
Fix broken eventBridge on tablet after Reload All Scripts.

### DIFF
--- a/libraries/gl/src/gl/OffscreenQmlSurface.cpp
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.cpp
@@ -576,7 +576,9 @@ QObject* OffscreenQmlSurface::finishQmlLoad(std::function<void(QQmlContext*, QOb
         return nullptr;
     }
 
+    _qmlEngine->setObjectOwnership(this, QQmlEngine::CppOwnership);
     newObject->setProperty("eventBridge", QVariant::fromValue(this));
+
     newContext->setContextProperty("eventBridgeJavaScriptToInject", QVariant(javaScriptToInject));
 
     f(newContext, newObject);

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -974,6 +974,8 @@ void ScriptEngine::run() {
         return; // bail early - avoid setting state in init(), as evaluate() will bail too
     }
 
+    scriptInfoMessage("Script Engine starting:" + getFilename());
+
     if (!_isInitialized) {
         init();
     }

--- a/libraries/script-engine/src/TabletScriptingInterface.h
+++ b/libraries/script-engine/src/TabletScriptingInterface.h
@@ -63,7 +63,7 @@ signals:
      * @returns {Signal}
      */
     void tabletNotification();
-    
+
 private:
     void processMenuEvents(QObject* object, const QKeyEvent* event);
     void processTabletEvents(QObject* object, const QKeyEvent* event);
@@ -209,6 +209,7 @@ signals:
 protected slots:
     void addButtonsToHomeScreen();
     void desktopWindowClosed();
+    void emitWebEvent(QVariant msg);
 protected:
     void removeButtonsFromHomeScreen();
     void loadHomeScreen(bool forceOntoHomeScreen);
@@ -216,7 +217,7 @@ protected:
     void removeButtonsFromToolbar();
 
     bool _initialScreen { false };
-    QVariant _initialPath { "" }; 
+    QVariant _initialPath { "" };
     QString _name;
     std::mutex _mutex;
     std::vector<QSharedPointer<TabletButtonProxy>> _tabletButtonProxies;

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -271,6 +271,13 @@
     }
 
     Script.scriptEnding.connect(function () {
+
+        // if we reload scripts in tablet mode make sure we close the currently open window, by calling gotoHomeScreen
+        var tabletProxy = Tablet.getTablet("com.highfidelity.interface.tablet.system");
+        if (tabletProxy && tabletProxy.toolbarMode) {
+            tabletProxy.gotoHomeScreen();
+        }
+
         var tabletID = HMD.tabletID;
         Entities.deleteEntity(tabletID);
         Overlays.deleteOverlay(tabletID)


### PR DESCRIPTION
The main issue here was the "webEventReceived" connection between the OffscreenQMLSurface and the TabletProxy object. For whatever reason, if this is not a direct Signal to Slot connection, the webEventReceived event does not propagate.

This fixes issue #10055

QA Test:
  * In the running script dialog, run the hifi/scripts/developer/tests/tabletEventBridgeTest.js from this PR.
  * Once it is running you should see a Sounds script on the tablet.
  * Press the Sounds script, it should transition you to a simple screen with two buttons.
  * Press the buttons, ensure that a sound effect plays, and that the button is grayed out while the sound is playing.
  * Reload all scripts, by using the menu or the Ctrl-r keyboard short cut.
  * Once the reload is complete, the Sounds button should still be on the tablet, and it should function as before.  On master the sounds to not play after the reload.