### PR TITLE
Fix for sliding feet when leaning in HMD mode.

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1204,7 +1204,7 @@ void Rig::updateFromHandAndFeetParameters(const HandAndFeetParameters& params, f
         } else {
             _animVars.unset("leftFootPosition");
             _animVars.unset("leftFootRotation");
-            _animVars.set("leftFootType", (int)IKTarget::Type::HipsRelativeRotationAndPosition);
+            _animVars.set("leftFootType", (int)IKTarget::Type::RotationAndPosition);
         }
 
         if (params.isRightFootEnabled) {
@@ -1214,7 +1214,7 @@ void Rig::updateFromHandAndFeetParameters(const HandAndFeetParameters& params, f
         } else {
             _animVars.unset("rightFootPosition");
             _animVars.unset("rightFootRotation");
-            _animVars.set("rightFootType", (int)IKTarget::Type::HipsRelativeRotationAndPosition);
+            _animVars.set("rightFootType", (int)IKTarget::Type::RotationAndPosition);
         }
 
     }


### PR DESCRIPTION
QA Test:
  * while in HMD mode.
  * stand still and lean left and right.
  * your feet should stay planted on the ground.  On master they slide underneath your hips.