### PR TITLE
Selfie Stick Script

### DIFF
--- a/script-archive/selfieStick.js
+++ b/script-archive/selfieStick.js
@@ -7,6 +7,15 @@
 // For best result, turn off avatar collisions(Developer > Avatar > Uncheck Enable Avatar Collisions)
 // 
 
+// selfieStick.js
+//
+// Created by Faye Li on March 23, 2016
+//
+// Usage instruction: Spacebar toggles camera control - WASD first person free movement or no movement but allowing others to grab the selfie stick 
+// and control your camera.
+// For best result, turn off avatar collisions(Developer > Avatar > Uncheck Enable Avatar Collisions)
+// 
+
 (function() { // BEGIN LOCAL_SCOPE
     var MODEL_URL = "https://hifi-content.s3.amazonaws.com/faye/twitch-stream/selfie_stick.json";
     var AVATAR_URL =  "https://hifi-content.s3.amazonaws.com/jimi/avatar/camera/fst/camera.fst";
@@ -19,8 +28,8 @@
     changeAvatar();
     importModel();
     processImportedEntities();
-    parentEntityToAvatar();
     setupSpaceBarControl();
+    Script.update.connect(update);
 
     function changeAvatar() {
         originalAvatar = MyAvatar.skeletonModelURL;
@@ -46,28 +55,6 @@
         });
     }
 
-    function parentEntityToAvatar() {
-        var props = {
-            "parentID" : MyAvatar.sessionUUID
-        };
-        Entities.editEntity(selfieStickEntityID, props);
-    }
-
-    function unparentEntityFromAvatar() {
-        var props = {
-            "parentID" : 0
-        };
-        Entities.editEntity(selfieStickEntityID, props);
-    }
-
-    function parentAvatarToEntity() {
-        MyAvatar.setParentID(selfieStickEntityID);
-    }
-
-    function unparentAvatarFromEntity() {
-        MyAvatar.setParentID(0);
-    }
-
     function setupSpaceBarControl() {
         var mappingName = "Handheld-Cam-Space-Bar";
         var myMapping = Controller.newMapping(mappingName);
@@ -77,18 +64,39 @@
             }
             if (freeMovementMode) {
                 freeMovementMode = false;
-                // Camera.mode = "entity";
-                // Camera.cameraEntity = lensEntityID;
-                unparentEntityFromAvatar();
-                parentAvatarToEntity();
+                Camera.mode = "entity";
+                Camera.cameraEntity = lensEntityID;
             } else {
                 freeMovementMode = true;
-                // Camera.mode = "first person";
-                unparentAvatarFromEntity();
-                parentEntityToAvatar();
+                Camera.mode = "first person";
             }
         });
         Controller.enableMapping(mappingName);
+    }
+
+    function update(deltaTime) {
+        if (freeMovementMode) {
+            var upFactor = 0.1;
+            var upUnitVec = Vec3.normalize(Quat.getUp(MyAvatar.orientation));
+            var upOffset = Vec3.multiply(upUnitVec, upFactor);
+            var forwardFactor = -0.1;
+            var forwardUnitVec = Vec3.normalize(Quat.getFront(MyAvatar.orientation));
+            var forwardOffset = Vec3.multiply(forwardUnitVec, forwardFactor);
+            var newPos = Vec3.sum(Vec3.sum(MyAvatar.position, upOffset), forwardOffset);
+            var newRot = MyAvatar.orientation;
+            Entities.editEntity(selfieStickEntityID, {position: newPos, rotation: newRot});
+        } else {
+            var props = Entities.getEntityProperties(selfieStickEntityID);
+            var upFactor = 0.1;
+            var upUnitVec = Vec3.normalize(Quat.getUp(props.rotation));
+            var upOffset = Vec3.multiply(upUnitVec, -upFactor);
+            var forwardFactor = -0.1;
+            var forwardUnitVec = Vec3.normalize(Quat.getFront(props.rotation));
+            var forwardOffset = Vec3.multiply(forwardUnitVec, -forwardFactor);
+            var newPos = Vec3.sum(Vec3.sum(props.position, upOffset), forwardOffset);
+            MyAvatar.position = newPos;
+            MyAvatar.orientation = props.rotation;
+        }
     }
 
     // Removes all entities we imported and reset settings we've changed

--- a/script-archive/selfieStick.js
+++ b/script-archive/selfieStick.js
@@ -1,0 +1,104 @@
+// selfieStick.js
+//
+// Created by Faye Li on March 23, 2016
+//
+// Usage instruction: Spacebar toggles camera control - WASD first person free movement or no movement but allowing others to grab the selfie stick 
+// and control your camera.
+// For best result, turn off avatar collisions(Developer > Avatar > Uncheck Enable Avatar Collisions)
+// 
+
+(function() { // BEGIN LOCAL_SCOPE
+    var MODEL_URL = "https://hifi-content.s3.amazonaws.com/faye/twitch-stream/selfie_stick.json";
+    var AVATAR_URL =  "https://hifi-content.s3.amazonaws.com/jimi/avatar/camera/fst/camera.fst";
+    var originalAvatar = null;
+    var importedEntityIDs = [];
+    var selfieStickEntityID = null;
+    var lensEntityID = null;
+    var freeMovementMode = true;
+
+    changeAvatar();
+    importModel();
+    processImportedEntities();
+    parentEntityToAvatar();
+    setupSpaceBarControl();
+
+    function changeAvatar() {
+        originalAvatar = MyAvatar.skeletonModelURL;
+        MyAvatar.skeletonModelURL = AVATAR_URL;
+    }
+
+    function importModel() {
+        var success = Clipboard.importEntities(MODEL_URL);
+        var spawnLocation = MyAvatar.position;
+        if (success) {
+            importedEntityIDs = Clipboard.pasteEntities(spawnLocation);    
+        }
+    }
+
+    function processImportedEntities() {
+        importedEntityIDs.forEach(function(id){
+            var props = Entities.getEntityProperties(id);
+            if (props.name === "Selfie Stick") {
+                selfieStickEntityID = id;
+            } else if (props.name === "Lens") {
+                lensEntityID = id;
+            }
+        });
+    }
+
+    function parentEntityToAvatar() {
+        var props = {
+            "parentID" : MyAvatar.sessionUUID
+        };
+        Entities.editEntity(selfieStickEntityID, props);
+    }
+
+    function unparentEntityFromAvatar() {
+        var props = {
+            "parentID" : 0
+        };
+        Entities.editEntity(selfieStickEntityID, props);
+    }
+
+    function parentAvatarToEntity() {
+        MyAvatar.setParentID(selfieStickEntityID);
+    }
+
+    function unparentAvatarFromEntity() {
+        MyAvatar.setParentID(0);
+    }
+
+    function setupSpaceBarControl() {
+        var mappingName = "Handheld-Cam-Space-Bar";
+        var myMapping = Controller.newMapping(mappingName);
+        myMapping.from(Controller.Hardware.Keyboard.Space).to(function(value){
+            if ( value === 0 ) {
+                return;
+            }
+            if (freeMovementMode) {
+                freeMovementMode = false;
+                // Camera.mode = "entity";
+                // Camera.cameraEntity = lensEntityID;
+                unparentEntityFromAvatar();
+                parentAvatarToEntity();
+            } else {
+                freeMovementMode = true;
+                // Camera.mode = "first person";
+                unparentAvatarFromEntity();
+                parentEntityToAvatar();
+            }
+        });
+        Controller.enableMapping(mappingName);
+    }
+
+    // Removes all entities we imported and reset settings we've changed
+    function cleanup() {
+        importedEntityIDs.forEach(function(id) {
+            Entities.deleteEntity(id);
+        });
+        Camera.mode = "first person";
+        Controller.disableMapping("Handheld-Cam-Space-Bar");
+        MyAvatar.skeletonModelURL = originalAvatar;
+    }
+    Script.scriptEnding.connect(cleanup);
+}()); // END LOCAL_SCOPE

--- a/script-archive/selfieStick.js
+++ b/script-archive/selfieStick.js
@@ -13,7 +13,6 @@
 //
 // Usage instruction: Spacebar toggles camera control - WASD first person free movement or no movement but allowing others to grab the selfie stick 
 // and control your camera.
-// For best result, turn off avatar collisions(Developer > Avatar > Uncheck Enable Avatar Collisions)
 // 
 
 (function() { // BEGIN LOCAL_SCOPE
@@ -25,11 +24,20 @@
     var lensEntityID = null;
     var freeMovementMode = true;
 
+    turnOffAvatarCollisions();
     changeAvatar();
     importModel();
     processImportedEntities();
     setupSpaceBarControl();
     Script.update.connect(update);
+
+    function turnOffAvatarCollisions() {
+        Menu.setIsOptionChecked("Enable avatar collisions", 0);
+    }
+
+    function turnOnAvatarCollisions() {
+        Menu.setIsOptionChecked("Enable avatar collisions", 1);
+    }
 
     function changeAvatar() {
         originalAvatar = MyAvatar.skeletonModelURL;
@@ -107,6 +115,7 @@
         Camera.mode = "first person";
         Controller.disableMapping("Handheld-Cam-Space-Bar");
         MyAvatar.skeletonModelURL = originalAvatar;
+        turnOnAvatarCollisions();
     }
     Script.scriptEnding.connect(cleanup);
 }()); // END LOCAL_SCOPE


### PR DESCRIPTION
This script turns your interface into a camera that can be used to stream events.
- It changes your avatar to the camera eye 
- It includes a selfie stick that lets other control the camera by grabbing and moving the selfie stick

Usage:
1) Run selfieStick.js in desktop mode
2) You're now in "free movement mode" which means you can move around the camera with first person controls (WASD + mouse)
3) Hit space bar toggle you to give away free movement. You may no longer control the camera with your keyboard, but others around you can grab the selfie stick under you and move your camera around.
4) When you end the script, it should put you back to your original avatar.

Test Plan:
- requires 2+ testers. One runs selfieStick.js in desktop mode following Usage instructions above, other tester can try grabbing and moving the camera via hand controller.