### PR TITLE
Now you can forget connections

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -45,7 +45,7 @@ Item {
     property bool isPresent: true
     property string placeName: ""
     property string profilePicBorderColor: (connectionStatus == "connection" ? hifi.colors.indigoAccent : (connectionStatus == "friend" ? hifi.colors.greenHighlight : "transparent"))
-
+    property alias avImage: avatarImage
     Item {
         id: avatarImage
         visible: profileUrl !== "" && userName !== "";
@@ -367,14 +367,13 @@ Item {
         text: "Info"
         color: hifi.colors.baseGray
     }
-    StateImage {
+    HiFiGlyphs {
         id: nameCardRemoveConnectionImage
         visible: selected && !isMyCard && pal.activeTab == "connectionsTab"
-        imageURL: "../../images/info-icon-2-state.svg" // PLACEHOLDER!!!
-        size: 32;
-        buttonState: 0;
+        text: hifi.glyphs.close
+        size: 28;
         x: 120
-        anchors.bottom: parent.bottom
+        anchors.verticalCenter: nameCardConnectionInfoImage.verticalCenter
     }
     MouseArea {
         anchors.fill:nameCardRemoveConnectionImage
@@ -385,10 +384,10 @@ Item {
             pal.sendToScript({method: 'removeConnection', params: thisNameCard.userName});
         }
         onEntered: {
-            nameCardRemoveConnectionImage.buttonState = 1;
+            nameCardRemoveConnectionImage.text = hifi.glyphs.closeInverted;
         }
         onExited: {
-            nameCardRemoveConnectionImage.buttonState = 0;
+            nameCardRemoveConnectionImage.text = hifi.glyphs.close;
         }
     }
     FiraSansRegular {

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -81,25 +81,6 @@ Item {
             anchors.fill: parent;
             visible: userImage.status != Image.Ready;
         }
-        StateImage {
-            id: infoHoverImage;
-            visible: false;
-            imageURL: "../../images/info-icon-2-state.svg";
-            size: 32;
-            buttonState: 1;
-            anchors.centerIn: parent;
-        }
-        MouseArea {
-            anchors.fill: parent
-            enabled: selected || isMyCard;
-            hoverEnabled: enabled
-            onClicked: {
-                userInfoViewer.url = defaultBaseUrl + "/users/" + userName;
-                userInfoViewer.visible = true;
-            }
-            onEntered: infoHoverImage.visible = true;
-            onExited: infoHoverImage.visible = false;
-        }
     }
 
     // Colored border around avatarImage

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -763,7 +763,7 @@ Rectangle {
             // This Rectangle refers to each Row in the connectionsTable.
             rowDelegate: Rectangle {
                 // Size
-                height: rowHeight;
+                height: rowHeight + (styleData.selected ? 15 : 0);
                 color: rowColor(styleData.selected, styleData.alternate);
             }
 
@@ -779,6 +779,7 @@ Rectangle {
                     profileUrl: (model && model.profileUrl) || "";
                     displayName: "";
                     userName: model ? model.userName : "";
+                    placeName: model ? model.placeName : ""
                     connectionStatus : model ? model.connection : "";
                     selected: styleData.selected;
                     // Size
@@ -792,7 +793,7 @@ Rectangle {
                 FiraSansRegular {
                     id: connectionsLocationData
                     // Properties
-                    visible: styleData.role === "placeName";
+                    visible: !connectionsNameCard.selected && styleData.role === "placeName";
                     text: (model && model.placeName) || "";
                     elide: Text.ElideRight;
                     // Size
@@ -822,7 +823,7 @@ Rectangle {
                 // "Friends" checkbox
                 HifiControlsUit.CheckBox {
                     id: friendsCheckBox;
-                    visible: styleData.role === "friends" && model.userName !== myData.userName;
+                    visible: styleData.role === "friends" && model && model.userName !== myData.userName;
                     anchors.centerIn: parent;
                     checked: model ? (model["connection"] === "friend" ? true : false) : false;
                     boxSize: 24;

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -793,17 +793,21 @@ Rectangle {
                 FiraSansRegular {
                     id: connectionsLocationData
                     // Properties
-                    visible: !connectionsNameCard.selected && styleData.role === "placeName";
+                    visible: styleData.role === "placeName";
                     text: (model && model.placeName) || "";
                     elide: Text.ElideRight;
                     // Size
                     width: parent.width;
-                    // Anchors
-                    anchors.fill: parent;
+                    // you would think that this would work:
+                    // anchors.verticalCenter: connectionsNameCard.avImage.verticalCenter
+                    // but no!  you cannot anchor to a non-sibling or parent.  So I will
+                    // align with the friends checkbox, where I did the manual alignment
+                    anchors.verticalCenter: friendsCheckBox.verticalCenter
                     // Text Size
                     size: 16;
                     // Text Positioning
                     verticalAlignment: Text.AlignVCenter
+                    horizontalAlignment: Text.AlignHCenter
                     // Style
                     color: hifi.colors.blueAccent;
                     font.underline: true;
@@ -824,7 +828,11 @@ Rectangle {
                 HifiControlsUit.CheckBox {
                     id: friendsCheckBox;
                     visible: styleData.role === "friends" && model && model.userName !== myData.userName;
-                    anchors.centerIn: parent;
+                    // you would think that this would work:
+                    // anchors.verticalCenter: connectionsNameCard.avImage.verticalCenter
+                    // but no!  you cannot anchor to a non-sibling or parent.  So:
+                    x: parent.width/2 - boxSize/2
+                    y: connectionsNameCard.avImage.y + connectionsNameCard.avImage.height/2 - boxSize/2
                     checked: model ? (model["connection"] === "friend" ? true : false) : false;
                     boxSize: 24;
                     onClicked: {
@@ -902,7 +910,7 @@ Rectangle {
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText;
                 // Text
-                text: HMD.active ?
+                text: HMD.isMounted ?
                 "<b>When you meet someone you want to remember later, you can <font color='purple'>connect</font> with a handshake:</b><br><br>" +
                 "1. Put your hand out onto their hand and squeeze your controller's grip button on its side.<br>" +
                 "2. Once the other person puts their hand onto yours, you'll see your connection form.<br>" +
@@ -961,7 +969,6 @@ Rectangle {
                 // Text size
                 size: hifi.fontSizes.tabularData;
                 // Anchors
-                anchors.top: myCard.top;
                 anchors.left: parent.left;
                 // Style
                 color: hifi.colors.baseGrayHighlight;

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -275,7 +275,6 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
             uri: METAVERSE_BASE + '/api/v1/user/connections/' + connectionUserName,
             method: 'DELETE'
         }, function (error, response) {
-            print(JSON.stringify(response));
             if (error || (response.status !== 'success')) {
                 print("Error: unable to remove connection", connectionUserName, error || response.status);
                 return;
@@ -290,7 +289,6 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
             uri: METAVERSE_BASE + '/api/v1/user/friends/' + friendUserName,
             method: 'DELETE'
         }, function (error, response) {
-            print(JSON.stringify(response));
             if (error || (response.status !== 'success')) {
                 print("Error: unable to unfriend", friendUserName, error || response.status);
                 return;

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -269,6 +269,21 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         getConnectionData();
         UserActivityLogger.palAction("refresh_connections", "");
         break;
+    case 'removeConnection':
+        connectionUserName = message.params;
+        request({
+            uri: METAVERSE_BASE + '/api/v1/user/connections/' + connectionUserName,
+            method: 'DELETE'
+        }, function (error, response) {
+            print(JSON.stringify(response));
+            if (error || (response.status !== 'success')) {
+                print("Error: unable to remove connection", connectionUserName, error || response.status);
+                return;
+            }
+            getConnectionData();
+        });
+        break
+
     case 'removeFriend':
         friendUserName = message.params;
         request({


### PR DESCRIPTION
This addresses [this bug](https://highfidelity.fogbugz.com/f/cases/3935/Add-ability-to-forget-a-connection).  Main thing here is we now can forget a connection, and the connections tab now looks a bit different when selected.

Note we have images for forgetting and info that already existed.  They are (IMHO) less than perfect.  Good enough?