### PR TITLE
21258 - Don't render (or heavily use GPU) when window in minimized

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6485,7 +6485,6 @@ void Application::windowMinimizedChanged(bool minimized) {
     }
 }
 
-
 void Application::postLambdaEvent(std::function<void()> f) {
     if (this->thread() == QThread::currentThread()) {
         f();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1429,6 +1429,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     entityPacketSender->setMyAvatar(myAvatar.get());
 
     connect(this, &Application::applicationStateChanged, this, &Application::activeChanged);
+    connect(_window, SIGNAL(windowMinimizedChanged(bool)), this, SLOT(windowMinimizedChanged(bool)));
     qCDebug(interfaceapp, "Startup time: %4.2f seconds.", (double)startupTimer.elapsed() / 1000.0);
 
     auto textureCache = DependencyManager::get<TextureCache>();
@@ -6475,6 +6476,15 @@ void Application::activeChanged(Qt::ApplicationState state) {
             break;
     }
 }
+
+void Application::windowMinimizedChanged(bool minimized) {
+    if (!minimized && !getActiveDisplayPlugin()->isActive()) {
+        getActiveDisplayPlugin()->activate();
+    } else if (minimized && getActiveDisplayPlugin()->isActive()) {
+        getActiveDisplayPlugin()->deactivate();
+    }
+}
+
 
 void Application::postLambdaEvent(std::function<void()> f) {
     if (this->thread() == QThread::currentThread()) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2071,7 +2071,7 @@ void Application::initializeUi() {
 
 void Application::paintGL() {
     // Some plugins process message events, allowing paintGL to be called reentrantly.
-    if (_inPaint || _aboutToQuit) {
+    if (_inPaint || _aboutToQuit || _window->isMinimized()) {
         return;
     }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -416,6 +416,7 @@ private slots:
     void faceTrackerMuteToggled();
 
     void activeChanged(Qt::ApplicationState state);
+    void windowMinimizedChanged(bool minimized);
 
     void notifyPacketVersionMismatch();
 

--- a/libraries/ui/src/MainWindow.cpp
+++ b/libraries/ui/src/MainWindow.cpp
@@ -105,12 +105,17 @@ void MainWindow::hideEvent(QHideEvent* event) {
 void MainWindow::changeEvent(QEvent* event) {
     if (event->type() == QEvent::WindowStateChange) {
         QWindowStateChangeEvent* stateChangeEvent = static_cast<QWindowStateChangeEvent*>(event);
+
         if ((stateChangeEvent->oldState() == Qt::WindowNoState ||
             stateChangeEvent->oldState() == Qt::WindowMaximized) &&
             windowState() == Qt::WindowMinimized) {
             emit windowShown(false);
+            emit windowMinimizedChanged(true);
         } else {
             emit windowShown(true);
+            if (stateChangeEvent->oldState() == Qt::WindowMinimized) {
+                emit windowMinimizedChanged(false);
+            }
         }
     } else if (event->type() == QEvent::ActivationChange) {
         if (isActiveWindow()) {

--- a/libraries/ui/src/MainWindow.cpp
+++ b/libraries/ui/src/MainWindow.cpp
@@ -105,7 +105,6 @@ void MainWindow::hideEvent(QHideEvent* event) {
 void MainWindow::changeEvent(QEvent* event) {
     if (event->type() == QEvent::WindowStateChange) {
         QWindowStateChangeEvent* stateChangeEvent = static_cast<QWindowStateChangeEvent*>(event);
-
         if ((stateChangeEvent->oldState() == Qt::WindowNoState ||
             stateChangeEvent->oldState() == Qt::WindowMaximized) &&
             windowState() == Qt::WindowMinimized) {

--- a/libraries/ui/src/MainWindow.h
+++ b/libraries/ui/src/MainWindow.h
@@ -29,6 +29,7 @@ public slots:
 signals:
     void windowGeometryChanged(QRect geometry);
     void windowShown(bool shown);
+    void windowMinimizedChanged(bool minimized);
 
 protected:
     virtual void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
**Test Plan:**

Run the PR in an area with content that should put a high load on your GPU. Observe the resources being used by interface. On this PR the resources should reduce when interface is minimized.