### PR TITLE
fix sorting by pal connections-tab friends column

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -756,7 +756,7 @@ Rectangle {
                 resizable: false;
             }
             TableViewColumn {
-                role: "friends";
+                role: "connection";
                 title: "FRIEND";
                 width: actionButtonWidth;
                 movable: false;
@@ -834,16 +834,16 @@ Rectangle {
                 // "Friends" checkbox
                 HifiControlsUit.CheckBox {
                     id: friendsCheckBox;
-                    visible: styleData.role === "friends" && model && model.userName !== myData.userName;
+                    visible: styleData.role === "connection" && model && model.userName !== myData.userName;
                     // you would think that this would work:
                     // anchors.verticalCenter: connectionsNameCard.avImage.verticalCenter
                     // but no!  you cannot anchor to a non-sibling or parent.  So:
-                    x: parent.width/2 - boxSize/2
-                    y: connectionsNameCard.avImage.y + connectionsNameCard.avImage.height/2 - boxSize/2
-                    checked: model ? (model["connection"] === "friend" ? true : false) : false;
+                    x: parent.width/2 - boxSize/2;
+                    y: connectionsNameCard.avImage.y + connectionsNameCard.avImage.height/2 - boxSize/2;
+                    checked: model && (model.connection === "friend");
                     boxSize: 24;
                     onClicked: {
-                        var newValue = !(model["connection"] === "friend");
+                        var newValue = model.connection !== "friend";
                         connectionsUserModel.setProperty(model.userIndex, styleData.role, newValue);
                         connectionsUserModelData[model.userIndex][styleData.role] = newValue; // Defensive programming
                         pal.sendToScript({method: newValue ? 'addFriend' : 'removeFriend', params: model.userName});


### PR DESCRIPTION
In pal connections tab, you can now sort by whether or not you are friends, without permanently hosing yourself