### PR TITLE
21256 - Add packet loss % to stats

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -130,7 +130,7 @@ Item {
                     id: pingCol
                     spacing: 4; x: 4; y: 4;
                     StatText {
-                        text: "Audio ping: " + root.audioPing
+                        text: "Audio ping/loss: " + root.audioPing + " / " + root.audioPacketLoss + "%"
                     }
                     StatText {
                         text: "Avatar ping: " + root.avatarPing

--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -130,7 +130,7 @@ Item {
                     id: pingCol
                     spacing: 4; x: 4; y: 4;
                     StatText {
-                        text: "Audio ping/loss: " + root.audioPing + " / " + root.audioPacketLoss + "%"
+                        text: "Audio ping/loss: " + root.audioPing + "/" + root.audioPacketLoss + "%"
                     }
                     StatText {
                         text: "Avatar ping: " + root.avatarPing

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -126,7 +126,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(updatedAvatarCount, avatarManager->getNumAvatarsUpdated());
     STAT_UPDATE(notUpdatedAvatarCount, avatarManager->getNumAvatarsNotUpdated());
     STAT_UPDATE(serverCount, (int)nodeList->size());
-    STAT_UPDATE(framerate, qApp->getFps());
+    STAT_UPDATE_FLOAT(framerate, qApp->getFps(), 0.1f);
     if (qApp->getActiveDisplayPlugin()) {
         auto displayPlugin = qApp->getActiveDisplayPlugin();
         auto stats = displayPlugin->getHardwareStats();
@@ -134,11 +134,11 @@ void Stats::updateStats(bool force) {
         STAT_UPDATE(longrenders, stats["long_render_count"].toInt());
         STAT_UPDATE(longsubmits, stats["long_submit_count"].toInt());
         STAT_UPDATE(longframes, stats["long_frame_count"].toInt());
-        STAT_UPDATE(renderrate, displayPlugin->renderRate());
-        STAT_UPDATE(presentrate, displayPlugin->presentRate());
-        STAT_UPDATE(presentnewrate, displayPlugin->newFramePresentRate());
-        STAT_UPDATE(presentdroprate, displayPlugin->droppedFrameRate());
-        STAT_UPDATE(stutterrate, displayPlugin->stutterRate());
+        STAT_UPDATE_FLOAT(renderrate, displayPlugin->renderRate(), 0.1f);
+        STAT_UPDATE_FLOAT(presentrate, displayPlugin->presentRate(), 0.1f);
+        STAT_UPDATE_FLOAT(presentnewrate, displayPlugin->newFramePresentRate(), 0.1f);
+        STAT_UPDATE_FLOAT(presentdroprate, displayPlugin->droppedFrameRate(), 0.1f);
+        STAT_UPDATE_FLOAT(stutterrate, displayPlugin->stutterRate(), 0.1f);
     } else {
         STAT_UPDATE(appdropped, -1);
         STAT_UPDATE(longrenders, -1);
@@ -151,8 +151,8 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(avatarSimrate, (int)qApp->getAvatarSimrate());
 
     auto bandwidthRecorder = DependencyManager::get<BandwidthRecorder>();
-    STAT_UPDATE(packetInCount, bandwidthRecorder->getCachedTotalAverageInputPacketsPerSecond());
-    STAT_UPDATE(packetOutCount, bandwidthRecorder->getCachedTotalAverageOutputPacketsPerSecond());
+    STAT_UPDATE(packetInCount, (int)bandwidthRecorder->getCachedTotalAverageInputPacketsPerSecond());
+    STAT_UPDATE(packetOutCount, (int)bandwidthRecorder->getCachedTotalAverageOutputPacketsPerSecond());
     STAT_UPDATE_FLOAT(mbpsIn, (float)bandwidthRecorder->getCachedTotalAverageInputKilobitsPerSecond() / 1000.0f, 0.01f);
     STAT_UPDATE_FLOAT(mbpsOut, (float)bandwidthRecorder->getCachedTotalAverageOutputKilobitsPerSecond() / 1000.0f, 0.01f);
 
@@ -166,7 +166,7 @@ void Stats::updateStats(bool force) {
     SharedNodePointer messageMixerNode = nodeList->soloNodeOfType(NodeType::MessagesMixer);
     auto mixerStream = _audioStats->data()->getMixerStream();
     STAT_UPDATE(audioPing, audioMixerNode ? audioMixerNode->getPingMs() : -1);
-    STAT_UPDATE(audioPacketLoss, mixerStream ? roundf(mixerStream->lossRateWindow() * 100.0f) : -1);
+    STAT_UPDATE(audioPacketLoss, mixerStream ? (int)roundf(mixerStream->lossRateWindow() * 100.0f) : -1);
     STAT_UPDATE(avatarPing, avatarMixerNode ? avatarMixerNode->getPingMs() : -1);
     STAT_UPDATE(assetPing, assetServerNode ? assetServerNode->getPingMs() : -1);
     STAT_UPDATE(messagePing, messageMixerNode ? messageMixerNode->getPingMs() : -1);
@@ -198,36 +198,36 @@ void Stats::updateStats(bool force) {
     if (_expanded || force) {
         SharedNodePointer avatarMixer = nodeList->soloNodeOfType(NodeType::AvatarMixer);
         if (avatarMixer) {
-            STAT_UPDATE(avatarMixerInKbps, roundf(bandwidthRecorder->getAverageInputKilobitsPerSecond(NodeType::AvatarMixer)));
-            STAT_UPDATE(avatarMixerInPps, roundf(bandwidthRecorder->getAverageInputPacketsPerSecond(NodeType::AvatarMixer)));
-            STAT_UPDATE(avatarMixerOutKbps, roundf(bandwidthRecorder->getAverageOutputKilobitsPerSecond(NodeType::AvatarMixer)));
-            STAT_UPDATE(avatarMixerOutPps, roundf(bandwidthRecorder->getAverageOutputPacketsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerInKbps, (int)roundf(bandwidthRecorder->getAverageInputKilobitsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerInPps, (int)roundf(bandwidthRecorder->getAverageInputPacketsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerOutKbps, (int)roundf(bandwidthRecorder->getAverageOutputKilobitsPerSecond(NodeType::AvatarMixer)));
+            STAT_UPDATE(avatarMixerOutPps, (int)roundf(bandwidthRecorder->getAverageOutputPacketsPerSecond(NodeType::AvatarMixer)));
         } else {
             STAT_UPDATE(avatarMixerInKbps, -1);
             STAT_UPDATE(avatarMixerInPps, -1);
             STAT_UPDATE(avatarMixerOutKbps, -1);
             STAT_UPDATE(avatarMixerOutPps, -1);
         }
-        STAT_UPDATE(myAvatarSendRate, avatarManager->getMyAvatarSendRate());
+        STAT_UPDATE_FLOAT(myAvatarSendRate, avatarManager->getMyAvatarSendRate(), 0.1f);
 
         SharedNodePointer audioMixerNode = nodeList->soloNodeOfType(NodeType::AudioMixer);
         auto audioClient = DependencyManager::get<AudioClient>();
         if (audioMixerNode || force) {
-            STAT_UPDATE(audioMixerKbps, roundf(
+            STAT_UPDATE(audioMixerKbps, (int)roundf(
                 bandwidthRecorder->getAverageInputKilobitsPerSecond(NodeType::AudioMixer) +
                 bandwidthRecorder->getAverageOutputKilobitsPerSecond(NodeType::AudioMixer)));
-            STAT_UPDATE(audioMixerPps, roundf(
+            STAT_UPDATE(audioMixerPps, (int)roundf(
                 bandwidthRecorder->getAverageInputPacketsPerSecond(NodeType::AudioMixer) +
                 bandwidthRecorder->getAverageOutputPacketsPerSecond(NodeType::AudioMixer)));
 
-            STAT_UPDATE(audioMixerInKbps, roundf(bandwidthRecorder->getAverageInputKilobitsPerSecond(NodeType::AudioMixer)));
-            STAT_UPDATE(audioMixerInPps, roundf(bandwidthRecorder->getAverageInputPacketsPerSecond(NodeType::AudioMixer)));
-            STAT_UPDATE(audioMixerOutKbps, roundf(bandwidthRecorder->getAverageOutputKilobitsPerSecond(NodeType::AudioMixer)));
-            STAT_UPDATE(audioMixerOutPps, roundf(bandwidthRecorder->getAverageOutputPacketsPerSecond(NodeType::AudioMixer)));
-            STAT_UPDATE(audioAudioInboundPPS, audioClient->getAudioInboundPPS());
-            STAT_UPDATE(audioSilentInboundPPS, audioClient->getSilentInboundPPS());
-            STAT_UPDATE(audioOutboundPPS, audioClient->getAudioOutboundPPS());
-            STAT_UPDATE(audioSilentOutboundPPS, audioClient->getSilentOutboundPPS());
+            STAT_UPDATE(audioMixerInKbps, (int)roundf(bandwidthRecorder->getAverageInputKilobitsPerSecond(NodeType::AudioMixer)));
+            STAT_UPDATE(audioMixerInPps, (int)roundf(bandwidthRecorder->getAverageInputPacketsPerSecond(NodeType::AudioMixer)));
+            STAT_UPDATE(audioMixerOutKbps, (int)roundf(bandwidthRecorder->getAverageOutputKilobitsPerSecond(NodeType::AudioMixer)));
+            STAT_UPDATE(audioMixerOutPps, (int)roundf(bandwidthRecorder->getAverageOutputPacketsPerSecond(NodeType::AudioMixer)));
+            STAT_UPDATE(audioAudioInboundPPS, (int)audioClient->getAudioInboundPPS());
+            STAT_UPDATE(audioSilentInboundPPS, (int)audioClient->getSilentInboundPPS());
+            STAT_UPDATE(audioOutboundPPS, (int)audioClient->getAudioOutboundPPS());
+            STAT_UPDATE(audioSilentOutboundPPS, (int)audioClient->getSilentOutboundPPS());
         } else {
             STAT_UPDATE(audioMixerKbps, -1);
             STAT_UPDATE(audioMixerPps, -1);

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -165,8 +165,8 @@ void Stats::updateStats(bool force) {
     SharedNodePointer assetServerNode = nodeList->soloNodeOfType(NodeType::AssetServer);
     SharedNodePointer messageMixerNode = nodeList->soloNodeOfType(NodeType::MessagesMixer);
     STAT_UPDATE(audioPing, audioMixerNode ? audioMixerNode->getPingMs() : -1); 
-    int mixerLossRate = (int)roundf(_audioStats->data()->getMixerStream()->lossRateWindow() * 100.0f);
-    int clientLossRate = (int)roundf(_audioStats->data()->getClientStream()->lossRateWindow() * 100.0f);
+    const int mixerLossRate = (int)roundf(_audioStats->data()->getMixerStream()->lossRateWindow() * 100.0f);
+    const int clientLossRate = (int)roundf(_audioStats->data()->getClientStream()->lossRateWindow() * 100.0f);
     int largestLossRate = mixerLossRate > clientLossRate ? mixerLossRate : clientLossRate;
     STAT_UPDATE(audioPacketLoss, audioMixerNode ? largestLossRate : -1);
     STAT_UPDATE(avatarPing, avatarMixerNode ? avatarMixerNode->getPingMs() : -1);

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -164,9 +164,11 @@ void Stats::updateStats(bool force) {
     SharedNodePointer avatarMixerNode = nodeList->soloNodeOfType(NodeType::AvatarMixer);
     SharedNodePointer assetServerNode = nodeList->soloNodeOfType(NodeType::AssetServer);
     SharedNodePointer messageMixerNode = nodeList->soloNodeOfType(NodeType::MessagesMixer);
-    auto mixerStream = _audioStats->data()->getMixerStream();
-    STAT_UPDATE(audioPing, audioMixerNode ? audioMixerNode->getPingMs() : -1);
-    STAT_UPDATE(audioPacketLoss, mixerStream ? (int)roundf(mixerStream->lossRateWindow() * 100.0f) : -1);
+    STAT_UPDATE(audioPing, audioMixerNode ? audioMixerNode->getPingMs() : -1); 
+    int mixerLossRate = (int)roundf(_audioStats->data()->getMixerStream()->lossRateWindow() * 100.0f);
+    int clientLossRate = (int)roundf(_audioStats->data()->getClientStream()->lossRateWindow() * 100.0f);
+    int largestLossRate = mixerLossRate > clientLossRate ? mixerLossRate : clientLossRate;
+    STAT_UPDATE(audioPacketLoss, audioMixerNode ? largestLossRate : -1);
     STAT_UPDATE(avatarPing, avatarMixerNode ? avatarMixerNode->getPingMs() : -1);
     STAT_UPDATE(assetPing, assetServerNode ? assetServerNode->getPingMs() : -1);
     STAT_UPDATE(messagePing, messageMixerNode ? messageMixerNode->getPingMs() : -1);

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -164,7 +164,9 @@ void Stats::updateStats(bool force) {
     SharedNodePointer avatarMixerNode = nodeList->soloNodeOfType(NodeType::AvatarMixer);
     SharedNodePointer assetServerNode = nodeList->soloNodeOfType(NodeType::AssetServer);
     SharedNodePointer messageMixerNode = nodeList->soloNodeOfType(NodeType::MessagesMixer);
+    auto mixerStream = _audioStats->data()->getMixerStream();
     STAT_UPDATE(audioPing, audioMixerNode ? audioMixerNode->getPingMs() : -1);
+    STAT_UPDATE(audioPacketLoss, mixerStream ? roundf(mixerStream->lossRateWindow() * 100.0f) : -1);
     STAT_UPDATE(avatarPing, avatarMixerNode ? avatarMixerNode->getPingMs() : -1);
     STAT_UPDATE(assetPing, assetServerNode ? assetServerNode->getPingMs() : -1);
     STAT_UPDATE(messagePing, messageMixerNode ? messageMixerNode->getPingMs() : -1);

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -167,7 +167,7 @@ void Stats::updateStats(bool force) {
     STAT_UPDATE(audioPing, audioMixerNode ? audioMixerNode->getPingMs() : -1); 
     const int mixerLossRate = (int)roundf(_audioStats->data()->getMixerStream()->lossRateWindow() * 100.0f);
     const int clientLossRate = (int)roundf(_audioStats->data()->getClientStream()->lossRateWindow() * 100.0f);
-    int largestLossRate = mixerLossRate > clientLossRate ? mixerLossRate : clientLossRate;
+    const int largestLossRate = mixerLossRate > clientLossRate ? mixerLossRate : clientLossRate;
     STAT_UPDATE(audioPacketLoss, audioMixerNode ? largestLossRate : -1);
     STAT_UPDATE(avatarPing, avatarMixerNode ? avatarMixerNode->getPingMs() : -1);
     STAT_UPDATE(assetPing, assetServerNode ? assetServerNode->getPingMs() : -1);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -81,6 +81,7 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, audioSilentOutboundPPS, 0)
     STATS_PROPERTY(int, audioAudioInboundPPS, 0)
     STATS_PROPERTY(int, audioSilentInboundPPS, 0)
+    STATS_PROPERTY(int, audioPacketLoss, 0)
     STATS_PROPERTY(QString, audioCodec, QString())
     STATS_PROPERTY(QString, audioNoiseGate, QString())
 
@@ -204,6 +205,7 @@ signals:
     void audioSilentOutboundPPSChanged();
     void audioAudioInboundPPSChanged();
     void audioSilentInboundPPSChanged();
+    void audioPacketLossChanged();
     void audioCodecChanged();
     void audioNoiseGateChanged();
 
@@ -263,4 +265,3 @@ private:
 };
 
 #endif // hifi_Stats_h
-


### PR DESCRIPTION
**Test Plan:**

In the existing stats, there is a column with 'Audio ping:' , etc which gives the milliseconds of ping to the audio server. 
This PR should modify that line to now show 'Audio ping/loss:' with the loss shown as a percentage.

To test: You can use some software to simulate dropping packets of outbound network data to cause the loss.
Using http://jagt.github.io/clumsy/ you would enable drop. The chance percentage value should be reflected in the stats.