### PR TITLE
Fixing the rendering bug triggered with Nvidia driver 381.65

### DIFF
--- a/libraries/gl/src/gl/Config.h
+++ b/libraries/gl/src/gl/Config.h
@@ -29,7 +29,7 @@
 #include <GL/wglew.h>
 
 // Uncomment this define and recompile to be able to avoid code path preventing to be able to run nsight graphics debug
-//#define HIFI_ENABLE_NSIGHT_DEBUG 1
+#define HIFI_ENABLE_NSIGHT_DEBUG 1
 
 #endif
 

--- a/libraries/gl/src/gl/Config.h
+++ b/libraries/gl/src/gl/Config.h
@@ -29,7 +29,7 @@
 #include <GL/wglew.h>
 
 // Uncomment this define and recompile to be able to avoid code path preventing to be able to run nsight graphics debug
-#define HIFI_ENABLE_NSIGHT_DEBUG 1
+//#define HIFI_ENABLE_NSIGHT_DEBUG 1
 
 #endif
 

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -85,30 +85,14 @@ static const std::string DEFAULT_NORMAL_SHADER {
     "    return vec4(vec3(0.5) + (frag.normal * 0.5), 1.0);"
     " }"
 };
-/*
-static const std::string DEFAULT_OCCLUSION_SHADER{
-    "vec4 getFragmentColor() {"
- //   "    DeferredFragment frag = unpackDeferredFragmentNoPosition(uv);"
- //   "    return vec4(vec3(pow(frag.obscurance, 1.0 / 2.2)), 1.0);"
- //   "    return vec4(vec3(pow(texture(specularMap, uv).a, 1.0 / 2.2)), 1.0);"
-    "    return vec4(vec3(texture(specularMap, uv).w), 1.0);"
-    " }"
-};
-*/
-static const std::string DEFAULT_OCCLUSION_SHADER{
-    "vec4 getFragmentColor() {"
- //   "    DeferredFragment frag = unpackDeferredFragmentNoPosition(uv);"
- //   "    return vec4(vec3(pow(frag.obscurance, 1.0 / 2.2)), 1.0);"
-    "    vec4 midNormalCurvature;"
-    "    vec4 lowNormalCurvature;"
-    "    unpackMidLowNormalCurvature(uv, midNormalCurvature, lowNormalCurvature);"
-    "    float ambientOcclusion = curvatureAO(lowNormalCurvature.a * 20.0f) * 0.5f;"
-    "    float ambientOcclusionHF = curvatureAO(midNormalCurvature.a * 8.0f) * 0.5f;"
-    "    ambientOcclusion = min(ambientOcclusion, ambientOcclusionHF);"
-    "    return vec4(vec3(ambientOcclusion), 1.0);"
-    " }"
-};
 
+static const std::string DEFAULT_OCCLUSION_SHADER{
+    "vec4 getFragmentColor() {"
+ //   "    DeferredFragment frag = unpackDeferredFragmentNoPosition(uv);"
+ //   "    return vec4(vec3(pow(frag.obscurance, 1.0 / 2.2)), 1.0);"
+    "    return vec4(vec3(pow(texture(specularMap, uv).a, 1.0 / 2.2)), 1.0);"
+    " }"
+};
 
 static const std::string DEFAULT_EMISSIVE_SHADER{
     "vec4 getFragmentColor() {"
@@ -211,6 +195,18 @@ static const std::string DEFAULT_DIFFUSED_NORMAL_CURVATURE_SHADER{
     " }"
 };
 
+static const std::string DEFAULT_CURVATURE_OCCLUSION_SHADER{
+    "vec4 getFragmentColor() {"
+    "    vec4 midNormalCurvature;"
+    "    vec4 lowNormalCurvature;"
+    "    unpackMidLowNormalCurvature(uv, midNormalCurvature, lowNormalCurvature);"
+    "    float ambientOcclusion = curvatureAO(lowNormalCurvature.a * 20.0f) * 0.5f;"
+    "    float ambientOcclusionHF = curvatureAO(midNormalCurvature.a * 8.0f) * 0.5f;"
+    "    ambientOcclusion = min(ambientOcclusion, ambientOcclusionHF);"
+    "    return vec4(vec3(ambientOcclusion), 1.0);"
+    " }"
+};
+
 static const std::string DEFAULT_DEBUG_SCATTERING_SHADER{
     "vec4 getFragmentColor() {"
     "    return vec4(pow(vec3(texture(scatteringMap, uv).xyz), vec3(1.0 / 2.2)), 1.0);"
@@ -220,7 +216,7 @@ static const std::string DEFAULT_DEBUG_SCATTERING_SHADER{
 
 static const std::string DEFAULT_AMBIENT_OCCLUSION_SHADER{
     "vec4 getFragmentColor() {"
-    "    return vec4(vec3(texture(obscuranceMap, uv).xyz), 1.0);"
+    "    return vec4(vec3(texture(obscuranceMap, uv).x), 1.0);"
     // When drawing color "    return vec4(vec3(texture(occlusionMap, uv).xyz), 1.0);"
     // when drawing normal"    return vec4(normalize(texture(occlusionMap, uv).xyz * 2.0 - vec3(1.0)), 1.0);"
     " }"
@@ -305,6 +301,8 @@ std::string DebugDeferredBuffer::getShaderSourceCode(Mode mode, std::string cust
             return DEFAULT_DIFFUSED_CURVATURE_SHADER;
         case DiffusedNormalCurvatureMode:
             return DEFAULT_DIFFUSED_NORMAL_CURVATURE_SHADER;
+        case CurvatureOcclusionMode:
+            return DEFAULT_CURVATURE_OCCLUSION_SHADER;
         case ScatteringDebugMode:
             return DEFAULT_DEBUG_SCATTERING_SHADER;
         case AmbientOcclusionMode:

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -85,13 +85,30 @@ static const std::string DEFAULT_NORMAL_SHADER {
     "    return vec4(vec3(0.5) + (frag.normal * 0.5), 1.0);"
     " }"
 };
-
+/*
 static const std::string DEFAULT_OCCLUSION_SHADER{
     "vec4 getFragmentColor() {"
-    "    DeferredFragment frag = unpackDeferredFragmentNoPosition(uv);"
-    "    return vec4(vec3(pow(frag.obscurance, 1.0 / 2.2)), 1.0);"
+ //   "    DeferredFragment frag = unpackDeferredFragmentNoPosition(uv);"
+ //   "    return vec4(vec3(pow(frag.obscurance, 1.0 / 2.2)), 1.0);"
+ //   "    return vec4(vec3(pow(texture(specularMap, uv).a, 1.0 / 2.2)), 1.0);"
+    "    return vec4(vec3(texture(specularMap, uv).w), 1.0);"
     " }"
 };
+*/
+static const std::string DEFAULT_OCCLUSION_SHADER{
+    "vec4 getFragmentColor() {"
+ //   "    DeferredFragment frag = unpackDeferredFragmentNoPosition(uv);"
+ //   "    return vec4(vec3(pow(frag.obscurance, 1.0 / 2.2)), 1.0);"
+    "    vec4 midNormalCurvature;"
+    "    vec4 lowNormalCurvature;"
+    "    unpackMidLowNormalCurvature(uv, midNormalCurvature, lowNormalCurvature);"
+    "    float ambientOcclusion = curvatureAO(lowNormalCurvature.a * 20.0f) * 0.5f;"
+    "    float ambientOcclusionHF = curvatureAO(midNormalCurvature.a * 8.0f) * 0.5f;"
+    "    ambientOcclusion = min(ambientOcclusion, ambientOcclusionHF);"
+    "    return vec4(vec3(ambientOcclusion), 1.0);"
+    " }"
+};
+
 
 static const std::string DEFAULT_EMISSIVE_SHADER{
     "vec4 getFragmentColor() {"

--- a/libraries/render-utils/src/DebugDeferredBuffer.h
+++ b/libraries/render-utils/src/DebugDeferredBuffer.h
@@ -72,6 +72,7 @@ protected:
         NormalCurvatureMode,
         DiffusedCurvatureMode,
         DiffusedNormalCurvatureMode,
+        CurvatureOcclusionMode,
         ScatteringDebugMode,
         AmbientOcclusionMode,
         AmbientOcclusionBlurredMode,

--- a/libraries/render-utils/src/DeferredBufferRead.slh
+++ b/libraries/render-utils/src/DeferredBufferRead.slh
@@ -67,11 +67,7 @@ DeferredFragment unpackDeferredFragmentNoPosition(vec2 texcoord) {
     frag.scattering = 0.0;
     unpackModeMetallic(diffuseVal.w, frag.mode, frag.metallic);
 
-
-  //  frag.obscurance = min(specularVal.w, frag.obscurance);
-
-    frag.obscurance = specularVal.w;
-
+    frag.obscurance = min(specularVal.w, frag.obscurance);
 
     if (frag.mode == FRAG_MODE_SCATTERING) {
         frag.scattering = specularVal.x;

--- a/libraries/render-utils/src/DeferredBufferRead.slh
+++ b/libraries/render-utils/src/DeferredBufferRead.slh
@@ -67,8 +67,10 @@ DeferredFragment unpackDeferredFragmentNoPosition(vec2 texcoord) {
     frag.scattering = 0.0;
     unpackModeMetallic(diffuseVal.w, frag.mode, frag.metallic);
 
-    //frag.emissive = specularVal.xyz;
-    frag.obscurance = min(specularVal.w, frag.obscurance);
+
+  //  frag.obscurance = min(specularVal.w, frag.obscurance);
+
+    frag.obscurance = specularVal.w;
 
 
     if (frag.mode == FRAG_MODE_SCATTERING) {

--- a/libraries/render-utils/src/DeferredFramebuffer.cpp
+++ b/libraries/render-utils/src/DeferredFramebuffer.cpp
@@ -55,7 +55,7 @@ void DeferredFramebuffer::allocate() {
 
     _deferredColorTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(colorFormat, width, height, gpu::Texture::SINGLE_MIP, defaultSampler));
     _deferredNormalTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(linearFormat, width, height, gpu::Texture::SINGLE_MIP, defaultSampler));
-    _deferredSpecularTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(colorFormat, width, height, gpu::Texture::SINGLE_MIP, defaultSampler));
+    _deferredSpecularTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(linearFormat, width, height, gpu::Texture::SINGLE_MIP, defaultSampler));
 
     _deferredFramebuffer->setRenderBuffer(0, _deferredColorTexture);
     _deferredFramebuffer->setRenderBuffer(1, _deferredNormalTexture);

--- a/libraries/render-utils/src/LightAmbient.slh
+++ b/libraries/render-utils/src/LightAmbient.slh
@@ -62,7 +62,7 @@ vec3 evalAmbientSpecularIrradiance(LightAmbient ambient, vec3 fragEyeDir, vec3 f
 
 <@if supportScattering@>
 float curvatureAO(in float k) {
-    return 1.0f - (0.0022f * k * k) + (0.0776f * k) + 0.7369;
+    return 1.0f - (0.0022f * k * k) + (0.0776f * k) + 0.7369f;
 }
 <@endif@>
 
@@ -83,13 +83,12 @@ void evalLightingAmbient(out vec3 diffuse, out vec3 specular, LightAmbient ambie
     specular = evalAmbientSpecularIrradiance(ambient, eyeDir, normal, roughness)  * ambientFresnel;
 
 <@if supportScattering@>
-    float ambientOcclusion = curvatureAO(lowNormalCurvature.w * 20.0f) * 0.5f;
-    float ambientOcclusionHF = curvatureAO(midNormalCurvature.w * 8.0f) * 0.5f;
-    ambientOcclusion = min(ambientOcclusion, ambientOcclusionHF);
-
-    obscurance = min(obscurance, ambientOcclusion);
-
     if (scattering * isScatteringEnabled() > 0.0) {
+        float ambientOcclusion = curvatureAO(lowNormalCurvature.w * 20.0f) * 0.5f;
+        float ambientOcclusionHF = curvatureAO(midNormalCurvature.w * 8.0f) * 0.5f;
+        ambientOcclusion = min(ambientOcclusion, ambientOcclusionHF);
+
+        obscurance = min(obscurance, ambientOcclusion);
 
         // Diffuse from ambient
         diffuse = sphericalHarmonics_evalSphericalLight(getLightAmbientSphere(ambient), lowNormalCurvature.xyz).xyz;

--- a/libraries/render-utils/src/debug_deferred_buffer.slf
+++ b/libraries/render-utils/src/debug_deferred_buffer.slf
@@ -16,14 +16,19 @@
 <@include gpu/Color.slh@>
 <$declareColorWheel()$>
 
+
 uniform sampler2D linearDepthMap;
 uniform sampler2D halfLinearDepthMap;
 uniform sampler2D halfNormalMap;
 uniform sampler2D occlusionMap;
 uniform sampler2D occlusionBlurredMap;
-uniform sampler2D curvatureMap;
-uniform sampler2D diffusedCurvatureMap;
 uniform sampler2D scatteringMap;
+
+<$declareDeferredCurvature()$>
+
+float curvatureAO(float k) {
+    return 1.0f - (0.0022f * k * k) + (0.0776f * k) + 0.7369f;
+}
 
 in vec2 uv;
 out vec4 outFragColor;

--- a/scripts/developer/utilities/render/deferredLighting.qml
+++ b/scripts/developer/utilities/render/deferredLighting.qml
@@ -63,7 +63,8 @@ Column {
                      "Directional:LightingModel:enableDirectionalLight",
                      "Point:LightingModel:enablePointLight",
                      "Spot:LightingModel:enableSpotLight",
-                     "Light Contour:LightingModel:showLightContour"
+                     "Light Contour:LightingModel:showLightContour",
+                     "Shadow:RenderShadowTask:enabled"
                 ]
                 CheckBox {
                     text: modelData.split(":")[0]

--- a/scripts/developer/utilities/render/deferredLighting.qml
+++ b/scripts/developer/utilities/render/deferredLighting.qml
@@ -151,6 +151,7 @@ Column {
                 ListElement { text: "Mid Normal"; color: "White" }
                 ListElement { text: "Low Curvature"; color: "White" }
                 ListElement { text: "Low Normal"; color: "White" }
+                ListElement { text: "Curvature Occlusion"; color: "White" }
                 ListElement { text: "Debug Scattering"; color: "White" }
                 ListElement { text: "Ambient Occlusion"; color: "White" }
                 ListElement { text: "Ambient Occlusion Blurred"; color: "White" }


### PR DESCRIPTION
THis PR fixes the rendering bug that showed with a new nv driver (381.65).

THe bug is with the final evaluation of the occlusion value used to attenuate the ambient lighting.
This evaluation combine 3 potential sources of attenuation and keeps the min of it:
ambient provided by the material of a model,
ssao (if enabled)
and "curvature ambient" which is computed based on the curvature buffers

This last one seems to give bad results in the general case except for a very small portion of the screen.
I do not understand why this causes the bug that we see since when i debug the values individually (through the debug script) i don't see any problem.
This could be an actual bug from the driver when compiling the shader glsl code but i really don't know.
The very odd thing is that the exact same code works fine when shadow is enabled and it has nothing to do with that...

I fixed this problem by removing the "curvature ambient" contribution to the occlusion and only keep it for scattering pixels. Noit a big change visually but it fixes the problem. we can move on and i ll try to dig it when i have more time (ah ah)...

During that investigation i changed a few things in the render buffer debugger to better understand the issue and i kept it in this pr.

## TEST PLAN
This bug is specific to NVIDIA GPU using driver 381.65 on windows (i don't know about linux)
In master in welcome or anywhere with a ambient map /skymap there should be a big shadow accross the screen which is view dependent.

THe problem is gone with this pr hoppefully...

Optionally you could test the script "developer/utilities/render/debugDeferredLighting.js"
There is now the shadow checkbox to turn it on/off
Make sure that the combo box "Debug Framebuffer" shows the new item "Curvature Occlusion"

And voila


