### PR TITLE
fix pal connections-tab help trigger

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -308,7 +308,6 @@ Rectangle {
                         MouseArea {
                             anchors.fill: parent;
                             hoverEnabled: true;
-                            enabled: activeTab === "connectionsTab";
                             onClicked: letterbox(hifi.glyphs.question,
                                                  "Connections and Friends",
                                                  "<font color='purple'>Purple borders around profile pictures are <b>Connections</b>.</font><br>" +


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/4000/Pressing-the-button-on-the-connections-tab-opens-the-connections-tab-instead-of-the-help-button

see that ticket for testing