### PR TITLE
updated availability combo dialog

### DIFF
--- a/interface/resources/qml/hifi/ComboDialog.qml
+++ b/interface/resources/qml/hifi/ComboDialog.qml
@@ -92,8 +92,7 @@ Item {
                     color: selectedOptionIndex === index ? '#cee6ff' : 'white';
                     Rectangle {
                         id: comboOptionSelected;
-                        visible: selectedOptionIndex === index ? true : false;
-                        color: hifi.colors.blueAccent;
+                        color: selectedOptionIndex == index ? hifi.colors.blueAccent : 'white';
                         anchors.left: parent.left;
                         anchors.leftMargin: 20;
                         anchors.top: parent.top;
@@ -102,7 +101,7 @@ Item {
                         height: width;
                         radius: width;
                         border.width: 3;
-                        border.color: hifi.colors.blueHighlight;
+                        border.color: selectedOptionIndex === index ? hifi.colors.blueHighlight: hifi.colors.lightGrayText;
                     }
 
 

--- a/interface/resources/qml/hifi/ComboDialog.qml
+++ b/interface/resources/qml/hifi/ComboDialog.qml
@@ -12,6 +12,7 @@
 import QtQuick 2.5
 import QtQuick.Controls 1.4
 import "../styles-uit"
+import "../controls-uit"
 
 Item {
     property var dialogTitleText : "";
@@ -66,6 +67,29 @@ Item {
             horizontalAlignment: Text.AlignLeft;
             verticalAlignment: Text.AlignTop;
         }
+
+        HiFiGlyphs {
+            id: closeGlyphButton;
+            text: hifi.glyphs.close;
+            size: 32;
+            anchors.verticalCenter: dialogTitle.verticalCenter;
+            anchors.right: parent.right;
+            anchors.rightMargin: 20;
+            MouseArea {
+                anchors.fill: closeGlyphButton;
+                hoverEnabled: true;
+                onEntered: {
+                    parent.text = hifi.glyphs.closeInverted;
+                }
+                onExited: {
+                    parent.text = hifi.glyphs.close;
+                }
+                onClicked: {
+                    combo.visible = false;
+                }
+            }
+        }
+
 
         ListModel {
             id: comboListViewModel;

--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -85,6 +85,28 @@ Item {
                     wrapMode: Text.WordWrap
                     textFormat: Text.StyledText
                 }
+                HiFiGlyphs {
+                    id: closeGlyphButton
+                    text: hifi.glyphs.close
+                    size: headerTextPixelSize
+                    anchors.top: parent.top
+                    anchors.topMargin: -20
+                    anchors.right: parent.right
+                    anchors.rightMargin: -25
+                    MouseArea {
+                        anchors.fill: closeGlyphButton
+                        hoverEnabled: true
+                        onEntered: {
+                            parent.text = hifi.glyphs.closeInverted;
+                        }
+                        onExited: {
+                            parent.text = hifi.glyphs.close;
+                        }
+                        onClicked: {
+                            letterbox.visible = false;
+                        }
+                    }
+                }
             }
             // Popup Text
             Text {

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -311,9 +311,9 @@ Rectangle {
                             enabled: activeTab === "connectionsTab";
                             onClicked: letterbox(hifi.glyphs.question,
                                                  "Connections and Friends",
-                                                 "<font color='purple'>Purple borders around profile pictures are <b>Connections</b>.</font><br>" +
+                                                 "<font color='purple'>Purple borders around profile pictures represent <b>Connections</b>.</font><br>" +
                                                  "When your availability is set to Everyone, Connections can see your username and location.<br><br>" +
-                                                 "<font color='green'>Green borders around profile pictures are <b>Friends</b>.</font><br>" +
+                                                 "<font color='green'>Green borders around profile pictures represent <b>Friends</b>.</font><br>" +
                                                  "When your availability is set to Friends, only Friends can see your username and location.");
                             onEntered: connectionsHelpText.color = hifi.colors.blueHighlight;
                             onExited: connectionsHelpText.color = hifi.colors.blueAccent;


### PR DESCRIPTION
Makes the combo dialog look more 'button-y'.  See [this bug](https://highfidelity.fogbugz.com/f/cases/3938/The-modal-for-selecting-your-availability-does-not-look-very-button-y-and-info-close) for design change.  Also, added a close dialog button to the letterbox (help text) and the combo dialog.  And a tiny change in help text for connections.