### PR TITLE
username stays around now when tabbing to connections

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -302,7 +302,7 @@ Item {
         height: usernameTextPixelSize + 4
         // Anchors
         anchors.top: isMyCard ? myDisplayName.bottom : pal.activeTab == "nearbyTab" ? displayNameContainer.bottom : undefined //(parent.height - displayNameTextPixelSize/2));
-        anchors.verticalCenter: pal.activeTab == "connectionsTab" ? avatarImage.verticalCenter : undefined
+        anchors.verticalCenter: pal.activeTab == "connectionsTab" && !isMyCard ? avatarImage.verticalCenter : undefined
         anchors.left: avatarImage.right;
         anchors.leftMargin: avatarImage.visible ? 5 : 0;
         anchors.rightMargin: 5;


### PR DESCRIPTION
fixes [this bug](https://highfidelity.fogbugz.com/f/cases/4036/), where you would see your username disappear (beneath your display name) when tabbing to connections tab.