### PR TITLE
fix includeActions so places show up in All

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -255,7 +255,7 @@ StackView {
                 TabletTextButton {
                     id: allTab;
                     text: "ALL";
-                    property string includeActions: 'snapshot, concurrency';
+                    property string includeActions: 'snapshot,concurrency';
                     selected: allTab === selectedTab;
                     action: tabSelect;
                 }


### PR DESCRIPTION
- fix bug in goto page that kept places from showing up in the All tab
