### PR TITLE
Set max packet per second on the agent

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -56,6 +56,7 @@ Agent::Agent(ReceivedMessage& message) :
     ThreadedAssignment(message),
     _receivedAudioStream(RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES, RECEIVED_AUDIO_STREAM_CAPACITY_FRAMES)
 {
+    _entityEditSender.setPacketsPerSecond(DEFAULT_ENTITY_PPS_PER_SCRIPT);
     DependencyManager::get<EntityScriptingInterface>()->setPacketSender(&_entityEditSender);
 
     ResourceManager::init();

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -24,9 +24,6 @@
 #include <ScriptEngine.h>
 #include <ThreadedAssignment.h>
 
-static const int DEFAULT_MAX_ENTITY_PPS = 9000;
-static const int DEFAULT_ENTITY_PPS_PER_SCRIPT = 900;
-
 class EntityScriptServer : public ThreadedAssignment {
     Q_OBJECT
 

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -48,6 +48,8 @@ class QScriptEngineDebugger;
 static const QString NO_SCRIPT("");
 
 static const int SCRIPT_FPS = 60;
+static const int DEFAULT_MAX_ENTITY_PPS = 9000;
+static const int DEFAULT_ENTITY_PPS_PER_SCRIPT = 900;
 
 class CallbackData {
 public:


### PR DESCRIPTION
Increase rate limit on the agent in the same way the ESS does to avoid lagged entity update.

## Test Plan:
- Run the following script as an Assignment Client script
- Watch the assignment-client memory usage for a few minutes

Memory usage should go up with the old build and keep stable on this one.


```js
var entityID = Entities.addEntity({
    textColor: { red: 255, green: 255, blue: 255 },
    type: "Text",
    text: i,
    lineHeight: 0.14,
    backgroundColor: { red: 64, green: 64, blue: 64 },
    dimensions: { x: 0.6, y: 0.2, z: 0.01 },
    position: { x: 100, y: 100, z: 100 },
});

var i = 0;
function update(dt) {
    var testProps = {
      text: i
    };
    Entities.editEntity(entityID, testProps);
    i++;
}
Script.update.connect(update);
```

[Bug](https://highfidelity.fogbugz.com/f/cases/2933/Memory-leak-in-the-agent)