### PR TITLE
Make avatar's mouths move again

### DIFF
--- a/interface/src/avatar/Head.cpp
+++ b/interface/src/avatar/Head.cpp
@@ -77,7 +77,7 @@ void Head::simulate(float deltaTime, bool isMine) {
     float audioLoudness = 0.0f;
 
     if (_owningAvatar) {
-        _owningAvatar->getAudioLoudness();
+        audioLoudness = _owningAvatar->getAudioLoudness();
     }
 
     //  Update audio trailing average for rendering facial animations


### PR DESCRIPTION
Oh no...

Test Plan:
1. Avatars A and B should enter a domain and look at each other.
2. Make Avatar B speak by speaking into the microphone.
3. Avatar A should see Avatar B's mouth move.
4. Slap me for missing this in code review.