### PR TITLE
avoid invisible avatars when source interface stops sending updates to avatar-mixer

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -69,7 +69,7 @@ void AvatarMixerSlave::processIncomingPackets(const SharedNodePointer& node) {
 int AvatarMixerSlave::sendIdentityPacket(const AvatarMixerClientData* nodeData, const SharedNodePointer& destinationNode) {
     int bytesSent = 0;
     QByteArray individualData = nodeData->getConstAvatarData()->identityByteArray();
-    auto identityPacket = NLPacket::create(PacketType::AvatarIdentity, individualData.size());
+    auto identityPacket = NLPacket::create(PacketType::AvatarIdentity, individualData.size(), true, true);
     individualData.replace(0, NUM_BYTES_RFC4122_UUID, nodeData->getNodeID().toRfc4122()); // FIXME, this looks suspicious
     bytesSent += individualData.size();
     identityPacket->write(individualData);

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -110,6 +110,8 @@ const char LEFT_HAND_POINTING_FLAG = 1;
 const char RIGHT_HAND_POINTING_FLAG = 2;
 const char IS_FINGER_POINTING_FLAG = 4;
 
+const qint64 AVATAR_UPDATE_TIMEOUT = 5 * USECS_PER_SECOND;
+
 // AvatarData state flags - we store the details about the packet encoding in the first byte, 
 // before the "header" structure
 const char AVATARDATA_FLAGS_MINIMUM = 0;
@@ -599,10 +601,7 @@ public:
     }
 
 
-    bool shouldDie() const {
-        const qint64 AVATAR_SILENCE_THRESHOLD_USECS = 5 * USECS_PER_SECOND;
-        return _owningAvatarMixer.isNull() || getUsecsSinceLastUpdate() > AVATAR_SILENCE_THRESHOLD_USECS;
-    }
+    bool shouldDie() const { return _owningAvatarMixer.isNull() || getUsecsSinceLastUpdate() > AVATAR_UPDATE_TIMEOUT; }
 
     static const float OUT_OF_VIEW_PENALTY;
 


### PR DESCRIPTION
* fix a mode by which other avatars can vanish if their interface is loaded
* avatar-mixer sends identity packets as 'reliable'