### PR TITLE
put shareable_url in UserStory details when creating

### DIFF
--- a/interface/src/ui/SnapshotUploader.cpp
+++ b/interface/src/ui/SnapshotUploader.cpp
@@ -40,6 +40,9 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
         QJsonObject userStoryObject;
         QJsonObject detailsObject;
         detailsObject.insert("image_url", imageUrl);
+        if (dataObject.contains("shareable_url")) {
+            detailsObject.insert("shareable_url", dataObject.value("shareable_url").toString());
+        }
         QString pickledDetails = QJsonDocument(detailsObject).toJson();
         userStoryObject.insert("details", pickledDetails);
         userStoryObject.insert("thumbnail_url", thumbnailUrl);


### PR DESCRIPTION
Uploading a gif now returns a new shareable_url, which points to a preview .jpg which we use in the facebook metadata if you share a user story with that snapshot.  So, we need to pop it in the details json, for that to happen.

I have this happening iff there is a shareable_url in the data returned by the snapshot upload.  Currently, we _always_ send this, but really it is a waste for non-gifs and I want to be flexible to stop creating it for .jpg uploads soon.