### PR TITLE
Fix getAvatar() not working for AC scripts

### DIFF
--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -41,7 +41,7 @@ public:
     Q_INVOKABLE QVector<QUuid> getAvatarIdentifiers();
 
     // Null/Default-constructed QUuids will return MyAvatar
-    virtual ScriptAvatarData* getAvatar(QUuid avatarID) { return new ScriptAvatarData(getAvatarBySessionID(avatarID)); }
+    Q_INVOKABLE virtual ScriptAvatarData* getAvatar(QUuid avatarID) { return new ScriptAvatarData(getAvatarBySessionID(avatarID)); }
 
     virtual AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID) const { return findAvatar(sessionID); }
     int numberOfAvatarsInRange(const glm::vec3& position, float rangeMeters);


### PR DESCRIPTION
**Test Plan:**
1. After a clean install of Interface and Sandbox, enter your Sandbox in Desktop mode.
2. Ensure you hear the chimes in the Garden area.