### PR TITLE
21206 Far grab improvement to draw held entity toward yourself

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2659,7 +2659,7 @@ function MyController(hand) {
 
         var distanceToObject = Vec3.length(Vec3.subtract(MyAvatar.position, this.currentObjectPosition));
         this.linearTimeScale = (this.linearTimeScale / 2);
-        if(this.linearTimeScale <= DISTANCE_HOLDING_ACTION_TIMEFRAME){
+        if (this.linearTimeScale <= DISTANCE_HOLDING_ACTION_TIMEFRAME) {
             this.linearTimeScale = DISTANCE_HOLDING_ACTION_TIMEFRAME;
         }
         var success = Entities.updateAction(this.grabbedThingID, this.actionID, {

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -75,7 +75,8 @@ var WEB_TOUCH_Y_OFFSET = 0.05; // how far forward (or back with a negative numbe
 //
 // distant manipulation
 //
-
+var shouldTravelAtRapidPace = false;
+var accelarationStartingPoint = 0;
 var DISTANCE_HOLDING_RADIUS_FACTOR = 3.5; // multiplied by distance between hand and object
 var DISTANCE_HOLDING_ACTION_TIMEFRAME = 0.1; // how quickly objects move to their new position
 var DISTANCE_HOLDING_UNITY_MASS = 1200; //  The mass at which the distance holding action timeframe is unmodified
@@ -2524,7 +2525,19 @@ function MyController(hand) {
 
         // compute the mass for the purpose of energy and how quickly to move object
         this.mass = this.getMass(grabbedProperties.dimensions, grabbedProperties.density);
+        this.shouldTravelAtRapidPace = false;
         var distanceToObject = Vec3.length(Vec3.subtract(MyAvatar.position, grabbedProperties.position));
+        
+        if(distanceToObject >= 15){ // Apply Rapid Pace only if distanceToObject is far than 15.
+            this.shouldTravelAtRapidPace = true;
+            var MyAvatarHipsPosition = MyAvatar.getJointPosition("Hips");
+            var distanceToHandFromAvatarHips =  worldControllerPosition.x - MyAvatarHipsPosition.x;
+            var ACCELERATION_START_THRESHOLD = 0.90;
+            this.accelarationStartingPoint = (distanceToHandFromAvatarHips * ACCELERATION_START_THRESHOLD);
+        }else{
+            this.shouldTravelAtRapidPace = false;
+        }
+            
         var timeScale = this.distanceGrabTimescale(this.mass, distanceToObject);
 
         this.actionID = NULL_UUID;
@@ -2619,16 +2632,22 @@ function MyController(hand) {
                                                  this.grabRadius * RADIAL_GRAB_AMPLIFIER);
         }
 
+        if(this.shouldTravelAtRapidPace = true){
+            var MyAvatarHipsPosition = MyAvatar.getJointPosition("Hips");   
+            var distanceToHandFromAvatarHips_x =  worldControllerPosition.x - MyAvatarHipsPosition.x;
+            if(distanceToHandFromAvatarHips_x <= this.accelarationStartingPoint){
+                var RAPID_PACE_RATE = 2;
+                this.grabRadius = (this.grabRadius / RAPID_PACE_RATE);
+            }
+        }
         // don't let grabRadius go all the way to zero, because it can't come back from that
         var MINIMUM_GRAB_RADIUS = 0.1;
         if (this.grabRadius < MINIMUM_GRAB_RADIUS) {
             this.grabRadius = MINIMUM_GRAB_RADIUS;
         }
-
         var newTargetPosition = Vec3.multiply(this.grabRadius, Quat.getUp(worldControllerRotation));
         newTargetPosition = Vec3.sum(newTargetPosition, worldControllerPosition);
         newTargetPosition = Vec3.sum(newTargetPosition, this.offsetPosition);
-
         var objectToAvatar = Vec3.subtract(this.currentObjectPosition, MyAvatar.position);
         var handControllerData = getEntityCustomData('handControllerKey', this.grabbedThingID, defaultMoveWithHeadData);
         if (handControllerData.disableMoveWithHead !== true) {


### PR DESCRIPTION
**Objective:** 
- Improve speed & experience of far Grabbing. Also drag the object as close as possible to Avatar.

**What to test?**
- Do far grab from some long distance for all entities and check "Object travelling speed".

**Expected behavior:**
- When we draw object from far grab range, the speed at which object travels to the Avatar is improved.
- "Object travelling speed" will vary as per entity mass and distanceToObject.

- We tested on following objects in welcome-dev area and it is working as expected.
	1) EZ-Cube
	2) EZ-Blok
	3) EZ-Tube
	4) EZ-Arch
	5) EZ-Ramp
	6) Cylinder shape object of palace
	7) Heaviest Cube
	
@themelissabrown , Please ask QA To Test.