### PR TITLE
Be sure to callback even on profile failure.

### DIFF
--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -400,6 +400,7 @@ function getProfilePicture(username, callback) { // callback(url) if successfull
         var matched = !error && html.match(/img class="users-img" src="([^"]*)"/);
         if (!matched) {
             print('Error: Unable to get profile picture for', username, error);
+            callback('');
             return;
         }
         callback(matched[1]);


### PR DESCRIPTION
Fixes https://highfidelity.fogbugz.com/f/cases/4230/error-in-profile-picture-causes-PAL-connections-to-freeze

There's no good test for this, unless you  happen to be a connection of Zappoman. (This PR works around the effects of  https://highfidelity.fogbugz.com/f/cases/4232/user-profile-failure.)

One _could_ test by editing scripts/system/pal.js in yoru installation to always fail at line 401:
   if (true) {  // instead of (!matched)
That's what I did.