### PR TITLE
Add AvatarIdentityRequest protocol to avatar-mixer

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -394,6 +394,13 @@ void AvatarMixer::handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMess
 }
 
 void AvatarMixer::handleAvatarIdentityRequest(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
+    AvatarMixerClientData* nodeData = dynamic_cast<AvatarMixerClientData*>(senderNode->getLinkedData());
+    if (nodeData) {
+        while (message->getBytesLeftToRead() >= NUM_BYTES_RFC4122_UUID) {
+            QUuid otherNodeID = QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID));
+            nodeData->clearLastBroadcastTime(otherNodeID);
+        }
+    }
 }
 
 void AvatarMixer::handleAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -53,6 +53,7 @@ AvatarMixer::AvatarMixer(ReceivedMessage& message) :
     packetReceiver.registerListener(PacketType::NodeIgnoreRequest, this, "handleNodeIgnoreRequestPacket");
     packetReceiver.registerListener(PacketType::RadiusIgnoreRequest, this, "handleRadiusIgnoreRequestPacket");
     packetReceiver.registerListener(PacketType::RequestsDomainListData, this, "handleRequestsDomainListDataPacket");
+    packetReceiver.registerListener(PacketType::AvatarIdentityRequest, this, "handleAvatarIdentityRequest");
 
     auto nodeList = DependencyManager::get<NodeList>();
     connect(nodeList.data(), &NodeList::packetVersionMismatch, this, &AvatarMixer::handlePacketVersionMismatch);
@@ -390,6 +391,9 @@ void AvatarMixer::handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMess
     }
     auto end = usecTimestampNow();
     _handleRequestsDomainListDataPacketElapsedTime += (end - start);
+}
+
+void AvatarMixer::handleAvatarIdentityRequest(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
 }
 
 void AvatarMixer::handleAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -46,6 +46,7 @@ private slots:
     void handleNodeIgnoreRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleRadiusIgnoreRequestPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
     void handleRequestsDomainListDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
+    void handleAvatarIdentityRequest(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void domainSettingsRequestComplete();
     void handlePacketVersionMismatch(PacketType type, const HifiSockAddr& senderSockAddr, const QUuid& senderUUID);
     void start();

--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -83,6 +83,13 @@ uint16_t AvatarMixerClientData::getLastBroadcastSequenceNumber(const QUuid& node
     return 0;
 }
 
+void AvatarMixerClientData::clearLastBroadcastTime(const QUuid& nodeUUID) {
+    std::unordered_map<QUuid, uint64_t>::iterator itr = _lastBroadcastTimes.find(nodeUUID);
+    if (itr != _lastBroadcastTimes.end()) {
+        itr->second = 0;
+    }
+}
+
 void AvatarMixerClientData::ignoreOther(SharedNodePointer self, SharedNodePointer other) {
     if (!isRadiusIgnoring(other->getUUID())) {
         addToRadiusIgnoringSet(other->getUUID());

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -52,6 +52,7 @@ public:
 
     uint64_t getLastBroadcastTime(const QUuid& nodeUUID) const;
     void setLastBroadcastTime(const QUuid& nodeUUID, uint64_t broadcastTime) { _lastBroadcastTimes[nodeUUID] = broadcastTime; }
+    void clearLastBroadcastTime(const QUuid& nodeUUID);
     Q_INVOKABLE void removeLastBroadcastTime(const QUuid& nodeUUID) { _lastBroadcastTimes.erase(nodeUUID); }
 
     Q_INVOKABLE void cleanupKilledNode(const QUuid& nodeUUID) {

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -147,11 +147,6 @@ void Avatar::init() {
     _initialized = true;
 }
 
-void Avatar::processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged) {
-    AvatarData::processAvatarIdentity(identity, identityChanged, displayNameChanged);
-    _identityRequestExpiry = 0;
-}
-
 glm::vec3 Avatar::getChestPosition() const {
     // for now, let's just assume that the "chest" is halfway between the root and the neck
     glm::vec3 neckPosition;

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -11,8 +11,6 @@
 #ifndef hifi_Avatar_h
 #define hifi_Avatar_h
 
-#include <stdint.h>
-
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <QtCore/QUuid>

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -73,7 +73,6 @@ public:
     typedef std::shared_ptr<render::Item::PayloadInterface> PayloadPointer;
 
     void init();
-    void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged) override;
     void updateAvatarEntities();
     void simulate(float deltaTime, bool inView);
     virtual void simulateAttachments(float deltaTime);

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -11,15 +11,15 @@
 #ifndef hifi_Avatar_h
 #define hifi_Avatar_h
 
+#include <stdint.h>
+
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
-
 #include <QtCore/QUuid>
 
 #include <AvatarData.h>
 #include <ShapeInfo.h>
 #include <render/Scene.h>
-
 
 #include "Head.h"
 #include "SkeletonModel.h"
@@ -73,6 +73,7 @@ public:
     typedef std::shared_ptr<render::Item::PayloadInterface> PayloadPointer;
 
     void init();
+    void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged) override;
     void updateAvatarEntities();
     void simulate(float deltaTime, bool inView);
     virtual void simulateAttachments(float deltaTime);
@@ -228,6 +229,8 @@ public:
 
     bool hasNewJointData() const { return _hasNewJointData; }
 
+	void requestIdentityData();
+
     inline float easeInOutQuad(float lerpValue) {
         assert(!((lerpValue < 0.0f) || (lerpValue > 1.0f)));
 
@@ -346,6 +349,7 @@ private:
     MapOfAvatarEntityDataHashes _avatarEntityDataHashes;
 
     uint64_t _lastRenderUpdateTime { 0 };
+    uint64_t _identityRequestExpiry { 0 };
     int _leftPointerGeometryID { 0 };
     int _rightPointerGeometryID { 0 };
     int _nameRectGeometryID { 0 };

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -330,37 +330,6 @@ AvatarSharedPointer AvatarManager::newSharedAvatar() {
     return std::make_shared<Avatar>(qApp->thread(), std::make_shared<Rig>());
 }
 
-void AvatarManager::processAvatarDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) {
-    PerformanceTimer perfTimer("receiveAvatar");
-    // enumerate over all of the avatars in this packet
-    // only add them if mixerWeakPointer points to something (meaning that mixer is still around)
-    while (message->getBytesLeftToRead()) {
-        AvatarSharedPointer avatarData = parseAvatarData(message, sendingNode);
-        if (avatarData) {
-            auto avatar = std::static_pointer_cast<Avatar>(avatarData);
-            if (avatar->isInScene()) {
-                if (!_shouldRender) {
-                    // rare transition so we process the transaction immediately
-                    const render::ScenePointer& scene = qApp->getMain3DScene();
-                    render::Transaction transaction;
-                    avatar->removeFromScene(avatar, scene, transaction);
-                    if (scene) {
-                        scene->enqueueTransaction(transaction);
-                    }
-                }
-            } else if (_shouldRender) {
-                // very rare transition so we process the transaction immediately
-                const render::ScenePointer& scene = qApp->getMain3DScene();
-                render::Transaction transaction;
-                avatar->addToScene(avatar, scene, transaction);
-                if (scene) {
-                    scene->enqueueTransaction(transaction);
-                }
-            }
-        }
-    }
-}
-
 void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar, KillAvatarReason removalReason) {
     // removedAvatar is a shared pointer to an AvatarData but we need to get to the derived Avatar
     // class in this context so we can call methods that don't exist at the base class.

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -98,9 +98,6 @@ public slots:
     void setShouldShowReceiveStats(bool shouldShowReceiveStats) { _shouldShowReceiveStats = shouldShowReceiveStats; }
     void updateAvatarRenderStatus(bool shouldRenderAvatars);
 
-protected slots:
-    void processAvatarDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) override;
-
 private:
     explicit AvatarManager(QObject* parent = 0);
     explicit AvatarManager(const AvatarManager& other);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -228,6 +228,8 @@ public:
 
     void setEnableDebugDrawIKTargets(bool enableDebugDrawIKTargets) { _enableDebugDrawIKTargets = enableDebugDrawIKTargets; }
 
+    int getNumJoints() const { return _animSkeleton ? _animSkeleton->getNumJoints() : 0; }
+
 signals:
     void onLoadComplete();
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -536,7 +536,7 @@ public:
 
     // identityChanged returns true if identity has changed, false otherwise.
     // displayNameChanged returns true if displayName has changed, false otherwise.
-    virtual void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged);
+    void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged);
 
     QByteArray identityByteArray() const;
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -536,7 +536,7 @@ public:
 
     // identityChanged returns true if identity has changed, false otherwise.
     // displayNameChanged returns true if displayName has changed, false otherwise.
-    void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged);
+    virtual void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged);
 
     QByteArray identityByteArray() const;
 

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -57,7 +57,7 @@ public slots:
 protected slots:
     void sessionUUIDChanged(const QUuid& sessionUUID, const QUuid& oldUUID);
 
-    virtual void processAvatarDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
+    void processAvatarDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void processKillAvatar(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     void processExitingSpaceBubble(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
@@ -65,7 +65,6 @@ protected slots:
 protected:
     AvatarHashMap();
 
-    virtual AvatarSharedPointer parseAvatarData(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
     virtual AvatarSharedPointer newSharedAvatar();
     virtual AvatarSharedPointer addAvatar(const QUuid& sessionUUID, const QWeakPointer<Node>& mixerWeakPointer);
     AvatarSharedPointer newOrExistingAvatar(const QUuid& sessionUUID, const QWeakPointer<Node>& mixerWeakPointer);

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -84,6 +84,8 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::MicrophoneAudioWithEcho:
         case PacketType::AudioStreamStats:
             return static_cast<PacketVersion>(AudioVersion::HighDynamicRangeVolume);
+        case PacketType::AvatarIdentityRequest:
+            return VERSION_AVATAR_IDENTITY_REQUEST;
 
         default:
             return 17;

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -113,6 +113,7 @@ public:
         EntityPhysics,
         EntityServerScriptLog,
         AdjustAvatarSorting,
+        AvatarIdentityRequest,
         LAST_PACKET_TYPE = AdjustAvatarSorting
     };
 };
@@ -206,6 +207,7 @@ const PacketVersion VERSION_ENTITIES_LAST_EDITED_BY = 65;
 const PacketVersion VERSION_ENTITIES_SERVER_SCRIPTS = 66;
 const PacketVersion VERSION_ENTITIES_PHYSICS_PACKET = 67;
 const PacketVersion VERSION_ENTITIES_ZONE_FILTERS = 68;
+const PacketVersion VERSION_AVATAR_IDENTITY_REQUEST = 70;
 
 enum class EntityQueryPacketVersion: PacketVersion {
     JSONFilter = 18,


### PR DESCRIPTION
* fix "invisible avatar" bug once and for all (I mean it this time)
* fix bug where old avatars remain visible for a few seconds after teleporting to new domain
* when signing out of (or into) a domain other avatars will vanish... but will be replaced by new copies