### PR TITLE
Organize the files in the JS and QML projects to appear in a folder hierarchy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ endforeach()
 
 file(GLOB_RECURSE JS_SRC scripts/*.js)
 add_custom_target(js SOURCES ${JS_SRC})
+GroupSources("scripts")
 
 if (UNIX)
    install(

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -65,6 +65,7 @@ set(INTERFACE_SRCS ${INTERFACE_SRCS} "${QT_UI_HEADERS}" "${QT_RESOURCES}")
 
 file(GLOB_RECURSE QML_SRC resources/qml/*.qml resources/qml/*.js)
 add_custom_target(qml SOURCES ${QML_SRC})
+GroupSources("resources/qml")
 
 if (UNIX)
   install(


### PR DESCRIPTION
The current cmake build creates custom QML and JS projects to allow 'easy' access to these resource files from an IDE.  However, because of the way the files are added, ALL FILES in the project are shown directly under the project root, making the list very long to navigate and potentially taking a while to expand.  Additionally, it makes it difficult to tell what file you're looking at if there are multiple files with the same name in different directories.  

This PR uses our existing CMake macro of `GroupSources` to organize the files into a hierarchy within the project in order to match the filesystem layout.  

## Testing

No QA is needed... this is strictly a cosmetic change to the generated project files and will not affect the built application.