### PR TITLE
Add progressive load for KTX textures

### DIFF
--- a/assignment-client/src/assets/SendAssetTask.cpp
+++ b/assignment-client/src/assets/SendAssetTask.cpp
@@ -60,7 +60,7 @@ void SendAssetTask::run() {
 
     replyPacketList->writePrimitive(messageID);
 
-    if (byteRange.toExclusive < byteRange.fromInclusive) {
+    if (byteRange.toExclusive < byteRange.fromInclusive || byteRange.toExclusive < 0) {
         replyPacketList->writePrimitive(AssetServerError::InvalidByteRange);
     } else {
         QString filePath = _resourcesDir.filePath(QString(hexHash));

--- a/assignment-client/src/assets/SendAssetTask.cpp
+++ b/assignment-client/src/assets/SendAssetTask.cpp
@@ -68,11 +68,9 @@ void SendAssetTask::run() {
         QFile file { filePath };
 
         if (file.open(QIODevice::ReadOnly)) {
-            if (!byteRange.isSet()) {
-                // if the byte range is not set, force it to be from 0 to the end of the file
-                byteRange.fromInclusive = 0;
-                byteRange.toExclusive = file.size();
-            }
+
+            // first fixup the range based on the now known file size
+            byteRange.fixupRange(file.size());
 
             // check if we're being asked to read data that we just don't have
             // because of the file size
@@ -82,10 +80,6 @@ void SendAssetTask::run() {
                     << byteRange.fromInclusive << ":" << byteRange.toExclusive;
             } else {
                 // we have a valid byte range, handle it and send the asset
-
-                // first fixup the range based on the now known file size
-                byteRange.fixupRange(file.size());
-
                 auto size = byteRange.size();
 
                 if (byteRange.fromInclusive >= 0) {

--- a/assignment-client/src/assets/SendAssetTask.cpp
+++ b/assignment-client/src/assets/SendAssetTask.cpp
@@ -74,7 +74,7 @@ void SendAssetTask::run() {
                 byteRange.toExclusive = file.size();
             }
 
-            if (file.size() < std::abs(byteRange.toExclusive)) {
+            if (file.size() < std::abs(byteRange.fromInclusive) || file.size() < byteRange.toExclusive) {
                 replyPacketList->writePrimitive(AssetServerError::InvalidByteRange);
                 qCDebug(networking) << "Bad byte range: " << hexHash << " "
                     << byteRange.fromInclusive << ":" << byteRange.toExclusive;

--- a/assignment-client/src/assets/SendAssetTask.cpp
+++ b/assignment-client/src/assets/SendAssetTask.cpp
@@ -88,7 +88,7 @@ void SendAssetTask::run() {
 
                 auto size = byteRange.size();
 
-                if (byteRange.fromInclusive > 0) {
+                if (byteRange.fromInclusive >= 0) {
 
                     // this range is positive, meaning we just need to seek into the file and then read from there
                     file.seek(byteRange.fromInclusive);

--- a/assignment-client/src/assets/SendAssetTask.cpp
+++ b/assignment-client/src/assets/SendAssetTask.cpp
@@ -68,7 +68,7 @@ void SendAssetTask::run() {
         QFile file { filePath };
 
         if (file.open(QIODevice::ReadOnly)) {
-            if (byteRange.isSet()) {
+            if (!byteRange.isSet()) {
                 // if the byte range is not set, force it to be from 0 to the end of the file
                 byteRange.fromInclusive = 0;
                 byteRange.toExclusive = file.size();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -188,7 +188,6 @@
 #include <src/scripting/LimitlessVoiceRecognitionScriptingInterface.h>
 #include <EntityScriptClient.h>
 #include <ModelScriptingInterface.h>
-#include <QtNetwork/QNetworkProxy>
 
 // On Windows PC, NVidia Optimus laptop, we want to enable NVIDIA GPU
 // FIXME seems to be broken.
@@ -605,7 +604,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     {
         const QString TEST_SCRIPT = "--testScript";
         const QString TRACE_FILE = "--traceFile";
-        const QString HTTP_PROXY = "--httpProxy";
         const QStringList args = arguments();
         for (int i = 0; i < args.size() - 1; ++i) {
             if (args.at(i) == TEST_SCRIPT) {
@@ -617,16 +615,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
                 QString traceFilePath = args.at(i + 1);
                 setProperty(hifi::properties::TRACING, traceFilePath);
                 DependencyManager::get<tracing::Tracer>()->startTracing();
-            } else if (args.at(i) == HTTP_PROXY) {
             }
         }
     }
-
-    QNetworkProxy proxy;
-    proxy.setType(QNetworkProxy::HttpProxy);
-    proxy.setHostName("127.0.0.1");
-    proxy.setPort(8888);
-    QNetworkProxy::setApplicationProxy(proxy);
 
     // make sure the debug draw singleton is initialized on the main thread.
     DebugDraw::getInstance().removeMarker("");

--- a/libraries/audio/src/SoundCache.cpp
+++ b/libraries/audio/src/SoundCache.cpp
@@ -14,6 +14,8 @@
 #include "AudioLogging.h"
 #include "SoundCache.h"
 
+static const int SOUNDS_LOADING_PRIORITY { -7 }; // Make sure sounds load after the low rez texture mips
+
 int soundPointerMetaTypeId = qRegisterMetaType<SharedSoundPointer>();
 
 SoundCache::SoundCache(QObject* parent) :
@@ -37,5 +39,7 @@ SharedSoundPointer SoundCache::getSound(const QUrl& url) {
 QSharedPointer<Resource> SoundCache::createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
     const void* extra) {
     qCDebug(audio) << "Requesting sound at" << url.toString();
-    return QSharedPointer<Resource>(new Sound(url), &Resource::deleter);
+    auto resource = QSharedPointer<Resource>(new Sound(url), &Resource::deleter);
+    resource->setLoadPriority(this, SOUNDS_LOADING_PRIORITY);
+    return resource;
 }

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -31,7 +31,7 @@
 const float METERS_TO_INCHES = 39.3701f;
 static uint32_t _currentWebCount { 0 };
 // Don't allow more than 100 concurrent web views
-static const uint32_t MAX_CONCURRENT_WEB_VIEWS = 0;
+static const uint32_t MAX_CONCURRENT_WEB_VIEWS = 20;
 // If a web-view hasn't been rendered for 30 seconds, de-allocate the framebuffer
 static uint64_t MAX_NO_RENDER_INTERVAL = 30 * USECS_PER_SECOND;
 
@@ -71,7 +71,7 @@ RenderableWebEntityItem::~RenderableWebEntityItem() {
 
 bool RenderableWebEntityItem::buildWebSurface(QSharedPointer<EntityTreeRenderer> renderer) {
     if (_currentWebCount >= MAX_CONCURRENT_WEB_VIEWS) {
-        //qWarning() << "Too many concurrent web views to create new view";
+        qWarning() << "Too many concurrent web views to create new view";
         return false;
     }
     QString javaScriptToInject;

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
@@ -259,9 +259,7 @@ void GLBackend::do_setResourceTexture(const Batch& batch, size_t paramOffset) {
         glActiveTexture(GL_TEXTURE0 + slot);
         glBindTexture(target, to);
 
-        if (CHECK_GL_ERROR()) {
-            qDebug() << "slot: " << slot << ", target: " << target << ", to: " << to;
-        }
+        (void) CHECK_GL_ERROR();
 
         _resource._textures[slot] = resourceTexture;
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -450,7 +450,7 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
         // Track how much we're actually using
         totalVariableMemoryAllocation += gltexture->size();
         canDemote |= vartexture->canDemote();
-        canPromote |= vartexture->canPromote();
+        canPromote |= vartexture->canPromote() || (texture->minAvailableMipLevel() < vartexture->_allocatedMip);
         hasTransfers |= vartexture->hasPendingTransfers();
     }
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -521,8 +521,7 @@ void GLVariableAllocationSupport::processWorkQueues() {
             vartexture->demote();
             _memoryPressureStateStale = true;
         } else if (MemoryPressureState::Undersubscribed == _memoryPressureState) {
-            if (!vartexture->canPromote()) {
-                vartexture->populateTransferQueue();
+            if (!vartexture->canPromote() || !vartexture->canPopulate()) {
                 continue;
             }
             vartexture->promote();

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -464,7 +464,7 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
         newState = MemoryPressureState::Transfer;
     } else if (pressure > OVERSUBSCRIBED_PRESSURE_VALUE && canDemote) {
         newState = MemoryPressureState::Oversubscribed;
-    } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && ((unallocated != 0 && canPromote) || canPopulate)) {
+    } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && ((unallocated != 0 && canPromote) && canPopulate)) {
         newState = MemoryPressureState::Undersubscribed;
     }
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -461,13 +461,10 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
 
     auto newState = MemoryPressureState::Idle;
     if (hasTransfers) {
-        qDebug() << "Transferring";
         newState = MemoryPressureState::Transfer;
     } else if (pressure > OVERSUBSCRIBED_PRESSURE_VALUE && canDemote) {
-        qDebug() << "Demoting";
         newState = MemoryPressureState::Oversubscribed;
     } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && ((unallocated != 0 && canPromote) || canPopulate)) {
-        qDebug() << "Promoting";
         newState = MemoryPressureState::Undersubscribed;
     }
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -437,6 +437,7 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
     size_t idealMemoryAllocation = 0;
     bool canDemote = false;
     bool canPromote = false;
+    bool canPopulate = false;
     bool hasTransfers = false;
     for (const auto& texture : strongTextures) {
         // Race conditions can still leave nulls in the list, so we need to check
@@ -450,7 +451,8 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
         // Track how much we're actually using
         totalVariableMemoryAllocation += gltexture->size();
         canDemote |= vartexture->canDemote();
-        canPromote |= vartexture->canPromote() || (texture->minAvailableMipLevel() < vartexture->_allocatedMip);
+        canPromote |= vartexture->canPromote();
+        canPopulate |= vartexture->canPopulate();
         hasTransfers |= vartexture->hasPendingTransfers();
     }
 
@@ -464,7 +466,7 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
     } else if (pressure > OVERSUBSCRIBED_PRESSURE_VALUE && canDemote) {
         qDebug() << "Demoting";
         newState = MemoryPressureState::Oversubscribed;
-    } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && unallocated != 0 && canPromote) {
+    } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && ((unallocated != 0 && canPromote) || canPopulate)) {
         qDebug() << "Promoting";
         newState = MemoryPressureState::Undersubscribed;
     }

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -458,12 +458,12 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
     float pressure = (float)totalVariableMemoryAllocation / (float)allowedMemoryAllocation;
 
     auto newState = MemoryPressureState::Idle;
-    if (hasTransfers) {
-        newState = MemoryPressureState::Transfer;
+    if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && (unallocated != 0 && canPromote)) {
+        newState = MemoryPressureState::Undersubscribed;
     } else if (pressure > OVERSUBSCRIBED_PRESSURE_VALUE && canDemote) {
         newState = MemoryPressureState::Oversubscribed;
-    } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && (unallocated != 0 && canPromote)) {
-        newState = MemoryPressureState::Undersubscribed;
+    } else if (hasTransfers) {
+        newState = MemoryPressureState::Transfer;
     }
 
     if (newState != _memoryPressureState) {
@@ -539,6 +539,7 @@ void GLVariableAllocationSupport::processWorkQueues() {
     }
 
     if (workQueue.empty()) {
+        _memoryPressureState = MemoryPressureState::Idle;
         _memoryPressureStateStale = true;
     }
 }

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -437,7 +437,6 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
     size_t idealMemoryAllocation = 0;
     bool canDemote = false;
     bool canPromote = false;
-    bool canPopulate = false;
     bool hasTransfers = false;
     for (const auto& texture : strongTextures) {
         // Race conditions can still leave nulls in the list, so we need to check
@@ -452,7 +451,6 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
         totalVariableMemoryAllocation += gltexture->size();
         canDemote |= vartexture->canDemote();
         canPromote |= vartexture->canPromote();
-        canPopulate |= vartexture->canPopulate();
         hasTransfers |= vartexture->hasPendingTransfers();
     }
 
@@ -464,7 +462,7 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
         newState = MemoryPressureState::Transfer;
     } else if (pressure > OVERSUBSCRIBED_PRESSURE_VALUE && canDemote) {
         newState = MemoryPressureState::Oversubscribed;
-    } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && ((unallocated != 0 && canPromote) && canPopulate)) {
+    } else if (pressure < UNDERSUBSCRIBED_PRESSURE_VALUE && (unallocated != 0 && canPromote)) {
         newState = MemoryPressureState::Undersubscribed;
     }
 
@@ -521,7 +519,7 @@ void GLVariableAllocationSupport::processWorkQueues() {
             vartexture->demote();
             _memoryPressureStateStale = true;
         } else if (MemoryPressureState::Undersubscribed == _memoryPressureState) {
-            if (!vartexture->canPromote() || !vartexture->canPopulate()) {
+            if (!vartexture->canPromote()) {
                 continue;
             }
             vartexture->promote();

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.h
@@ -112,11 +112,11 @@ protected:
     static void manageMemory();
 
     //bool canPromoteNoAllocate() const { return _allocatedMip < _populatedMip; }
-    bool canPromote() const { return _allocatedMip > 0 || _populatedMip > 0; }
+    virtual bool canPopulate() const = 0;
+    bool canPromote() const { return _allocatedMip > 0; }
     bool canDemote() const { return _allocatedMip < _maxAllocatedMip; }
     bool hasPendingTransfers() const { return _pendingTransfers.size() > 0; }
     void executeNextTransfer(const TexturePointer& currentTexture);
-    virtual bool canPopulate() const = 0;
     virtual void populateTransferQueue() = 0;
     virtual void promote() = 0;
     virtual void demote() = 0;

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.h
@@ -114,7 +114,7 @@ protected:
     //bool canPromoteNoAllocate() const { return _allocatedMip < _populatedMip; }
     bool canPromote() const { return _allocatedMip > _minAllocatedMip; }
     bool canDemote() const { return _allocatedMip < _maxAllocatedMip; }
-    bool hasPendingTransfers() const { return _pendingTransfers.size() > 0; }
+    bool hasPendingTransfers() const { return _populatedMip > _allocatedMip; }
     void executeNextTransfer(const TexturePointer& currentTexture);
     virtual void populateTransferQueue() = 0;
     virtual void promote() = 0;

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.h
@@ -112,8 +112,7 @@ protected:
     static void manageMemory();
 
     //bool canPromoteNoAllocate() const { return _allocatedMip < _populatedMip; }
-    virtual bool canPopulate() const = 0;
-    bool canPromote() const { return _allocatedMip > 0; }
+    bool canPromote() const { return _allocatedMip > _minAllocatedMip; }
     bool canDemote() const { return _allocatedMip < _maxAllocatedMip; }
     bool hasPendingTransfers() const { return _pendingTransfers.size() > 0; }
     void executeNextTransfer(const TexturePointer& currentTexture);
@@ -131,6 +130,9 @@ protected:
     // The highest (lowest resolution) mip that we will support, relative to the number 
     // of mips in the gpu::Texture object
     uint16 _maxAllocatedMip { 0 };
+    // The lowest (highest resolution) mip that we will support, relative to the number
+    // of mips in the gpu::Texture object
+    uint16 _minAllocatedMip { 0 };
     // Contains a series of lambdas that when executed will transfer data to the GPU, modify 
     // the _populatedMip and update the sampler in order to fully populate the allocated texture 
     // until _populatedMip == _allocatedMip

--- a/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
@@ -100,7 +100,7 @@ public:
         GL41VariableAllocationTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture);
         ~GL41VariableAllocationTexture();
 
-        bool canPopulate() const override { return _gpuObject.isStoredMipFaceAvailable(_populatedMip - 1, 0); }
+        bool canPopulate() const override { return _populatedMip > _allocatedMip && _gpuObject.isStoredMipFaceAvailable(_populatedMip - 1, 0); }
         void allocateStorage(uint16 allocatedMip);
         void syncSampler() const override;
         void promote() override;

--- a/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
@@ -100,7 +100,7 @@ public:
         GL41VariableAllocationTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture);
         ~GL41VariableAllocationTexture();
 
-        bool canPopulate() const override { return _populatedMip > _allocatedMip && _gpuObject.isStoredMipFaceAvailable(_populatedMip - 1, 0); }
+        bool canPopulate() const override { return _gpuObject.isStoredMipFaceAvailable(_populatedMip - 1, 0); }
         void allocateStorage(uint16 allocatedMip);
         void syncSampler() const override;
         void promote() override;

--- a/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
@@ -100,7 +100,6 @@ public:
         GL41VariableAllocationTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture);
         ~GL41VariableAllocationTexture();
 
-        bool canPopulate() const override { return _gpuObject.isStoredMipFaceAvailable(_populatedMip - 1, 0); }
         void allocateStorage(uint16 allocatedMip);
         void syncSampler() const override;
         void promote() override;

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -395,7 +395,6 @@ void GL41VariableAllocationTexture::populateTransferQueue() {
         bool didQueueTransfer = false;
         for (uint8_t face = 0; face < maxFace; ++face) {
             if (!_gpuObject.isStoredMipFaceAvailable(sourceMip, face)) {
-                const_cast<gpu::Texture&>(_gpuObject).requestInterestInMip(sourceMip);
                 continue;
             }
 

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -244,18 +244,17 @@ GL41VariableAllocationTexture::GL41VariableAllocationTexture(const std::weak_ptr
     auto mipLevels = texture.getNumMips();
     _allocatedMip = mipLevels;
     _maxAllocatedMip = _populatedMip = mipLevels;
-    uint16_t minAvailableMip = texture.minAvailableMipLevel();
+    _minAllocatedMip = texture.minAvailableMipLevel();
     uvec3 mipDimensions;
-    for (uint16_t mip = 0; mip < mipLevels; ++mip) {
-        if (glm::all(glm::lessThanEqual(texture.evalMipDimensions(mip), INITIAL_MIP_TRANSFER_DIMENSIONS))
-            && mip >= minAvailableMip) {
+    for (uint16_t mip = _minAllocatedMip; mip < mipLevels; ++mip) {
+        if (glm::all(glm::lessThanEqual(texture.evalMipDimensions(mip), INITIAL_MIP_TRANSFER_DIMENSIONS))) {
             _maxAllocatedMip = _populatedMip = mip;
             break;
         }
     }
 
     auto targetMip = _populatedMip - std::min<uint16_t>(_populatedMip, 2);
-    uint16_t allocatedMip = std::max<uint16_t>(minAvailableMip, targetMip);
+    uint16_t allocatedMip = std::max<uint16_t>(_minAllocatedMip, targetMip);
 
     allocateStorage(allocatedMip);
     _memoryPressureStateStale = true;

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -245,6 +245,7 @@ GL41VariableAllocationTexture::GL41VariableAllocationTexture(const std::weak_ptr
     _allocatedMip = mipLevels;
     _maxAllocatedMip = _populatedMip = mipLevels;
     _minAllocatedMip = texture.minAvailableMipLevel();
+
     uvec3 mipDimensions;
     for (uint16_t mip = _minAllocatedMip; mip < mipLevels; ++mip) {
         if (glm::all(glm::lessThanEqual(texture.evalMipDimensions(mip), INITIAL_MIP_TRANSFER_DIMENSIONS))) {
@@ -310,11 +311,7 @@ void GL41VariableAllocationTexture::promote() {
     Q_ASSERT(_allocatedMip > 0);
 
     uint16_t targetAllocatedMip = _allocatedMip - std::min<uint16_t>(_allocatedMip, 2);
-    targetAllocatedMip = std::max<uint16_t>(_gpuObject.minAvailableMipLevel(), targetAllocatedMip);
-
-    if (targetAllocatedMip >= _allocatedMip || !_gpuObject.isStoredMipFaceAvailable(targetAllocatedMip, 0)) {
-        return;
-    }
+    targetAllocatedMip = std::max<uint16_t>(_minAllocatedMip, targetAllocatedMip);
 
     GLuint oldId = _id;
     auto oldSize = _size;

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -416,7 +416,6 @@ void GL41VariableAllocationTexture::populateTransferQueue() {
         --sourceMip;
         auto targetMip = sourceMip - _allocatedMip;
         auto mipDimensions = _gpuObject.evalMipDimensions(sourceMip);
-        bool didQueueTransfer = false;
         for (uint8_t face = 0; face < maxFace; ++face) {
             if (!_gpuObject.isStoredMipFaceAvailable(sourceMip, face)) {
                 continue;
@@ -426,7 +425,6 @@ void GL41VariableAllocationTexture::populateTransferQueue() {
             if (glm::all(glm::lessThanEqual(mipDimensions, MAX_TRANSFER_DIMENSIONS))) {
                 // Can the mip be transferred in one go
                 _pendingTransfers.emplace(new TransferJob(*this, sourceMip, targetMip, face));
-                didQueueTransfer = true;
                 continue;
             }
 
@@ -442,17 +440,14 @@ void GL41VariableAllocationTexture::populateTransferQueue() {
                 uint32_t linesToCopy = std::min<uint32_t>(lines - lineOffset, linesPerTransfer);
                 _pendingTransfers.emplace(new TransferJob(*this, sourceMip, targetMip, face, linesToCopy, lineOffset));
                 lineOffset += linesToCopy;
-                didQueueTransfer = true;
             }
         }
 
         // queue up the sampler and populated mip change for after the transfer has completed
-        if (didQueueTransfer) {
-            _pendingTransfers.emplace(new TransferJob(*this, [=] {
-                _populatedMip = sourceMip;
-                syncSampler();
-            }));
-        }
+        _pendingTransfers.emplace(new TransferJob(*this, [=] {
+            _populatedMip = sourceMip;
+            syncSampler();
+        }));
     } while (sourceMip != _allocatedMip);
 }
 

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -55,6 +55,18 @@ GLTexture* GL41Backend::syncGPUObject(const TexturePointer& texturePointer) {
             default:
                 Q_UNREACHABLE();
         }
+    } else {
+        if (texture.getUsageType() == TextureUsageType::RESOURCE) {
+            auto varTex = static_cast<GL41VariableAllocationTexture*> (object);
+
+            if (varTex->_minAllocatedMip > 0) {
+                auto minAvailableMip = texture.minAvailableMipLevel();
+                if (minAvailableMip < varTex->_minAllocatedMip) {
+                    varTex->_minAllocatedMip = minAvailableMip;
+                    GL41VariableAllocationTexture::_memoryPressureStateStale = true;
+                }
+            }
+        }
     }
 
     return object;

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -117,6 +117,8 @@ public:
 
         void allocateStorage(uint16 mip);
         void copyMipsFromTexture();
+
+        uint16 _lowestRequestedMip { 0 };
     };
 
 #if 0

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -117,8 +117,6 @@ public:
 
         void allocateStorage(uint16 mip);
         void copyMipsFromTexture();
-
-        uint16 _lowestRequestedMip { 0 };
     };
 
 #if 0

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -100,7 +100,6 @@ public:
         GL45VariableAllocationTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture);
         ~GL45VariableAllocationTexture();
         Size size() const override { return _size; }
-        bool canPopulate() const override { return _gpuObject.isStoredMipFaceAvailable(_populatedMip - 1, 0); }
         Size _size { 0 };
     };
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -119,8 +119,10 @@ GL45Texture::GL45Texture(const std::weak_ptr<GLBackend>& backend, const Texture&
 GLuint GL45Texture::allocate(const Texture& texture) {
     GLuint result;
     glCreateTextures(getGLTextureType(texture), 1, &result);
+#ifdef DEBUG
     auto source = texture.source();
     glObjectLabel(GL_TEXTURE, result, source.length(), source.data());
+#endif
     return result;
 }
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -85,7 +85,7 @@ GLTexture* GL45Backend::syncGPUObject(const TexturePointer& texturePointer) {
         if (texture.getUsageType() == TextureUsageType::RESOURCE) {
             auto varTex = static_cast<GL45VariableAllocationTexture*> (object);
 
-            if (varTex->canPromoteAndPopulate()) {
+            if (varTex->canPromote() && varTex->canPopulate()) {
                 GL45VariableAllocationTexture::_memoryPressureStateStale = true;
             }
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -85,10 +85,13 @@ GLTexture* GL45Backend::syncGPUObject(const TexturePointer& texturePointer) {
         if (texture.getUsageType() == TextureUsageType::RESOURCE) {
             auto varTex = static_cast<GL45VariableAllocationTexture*> (object);
 
-            if (varTex->canPromote() && varTex->canPopulate()) {
-                GL45VariableAllocationTexture::_memoryPressureStateStale = true;
+            if (varTex->_minAllocatedMip > 0) {
+                auto minAvailableMip = texture.minAvailableMipLevel();
+                if (minAvailableMip < varTex->_minAllocatedMip) {
+                    varTex->_minAllocatedMip = minAvailableMip;
+                    GL45VariableAllocationTexture::_memoryPressureStateStale = true;
+                }
             }
-
         }
     }
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -98,18 +98,14 @@ void GL45ResourceTexture::copyMipsFromTexture() {
 void GL45ResourceTexture::syncSampler() const {
     Parent::syncSampler();
     qDebug() << "glTextureParameteri " << QString::fromStdString(_source) << _populatedMip << _populatedMip - _allocatedMip;
-    if (_source == "test" && _populatedMip == 0) {
-        qDebug() << "here";
-    }
     glTextureParameteri(_id, GL_TEXTURE_BASE_LEVEL, _populatedMip - _allocatedMip);
 }
 
 void GL45ResourceTexture::promote() {
     PROFILE_RANGE(render_gpu_gl, __FUNCTION__);
     //Q_ASSERT(_allocatedMip > 0);
-    uint16_t sourceMip = _populatedMip;
-    if (!_gpuObject.isStoredMipFaceAvailable(sourceMip, 0)) {
-        const_cast<gpu::Texture&>(_gpuObject).requestInterestInMip(sourceMip);
+    if (!_gpuObject.isStoredMipFaceAvailable(_populatedMip - 1, 0)) {
+        const_cast<gpu::Texture&>(_gpuObject).requestInterestInMip(_populatedMip - 1);
         return;
     }
     GLuint oldId = _id;

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -93,7 +93,6 @@ void GL45ResourceTexture::copyMipsFromTexture() {
 
 void GL45ResourceTexture::syncSampler() const {
     Parent::syncSampler();
-    qDebug() << "glTextureParameteri " << QString::fromStdString(_source) << _populatedMip << _populatedMip - _allocatedMip;
     glTextureParameteri(_id, GL_TEXTURE_BASE_LEVEL, _populatedMip - _allocatedMip);
 }
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -76,10 +76,6 @@ void GL45ResourceTexture::allocateStorage(uint16 allocatedMip) {
         _size += _gpuObject.evalMipSize(mip);
     }
 
-    if (!_gpuObject.isStoredMipFaceAvailable(allocatedMip, 0)) {
-        const_cast<gpu::Texture&>(_gpuObject).requestInterestInMip(allocatedMip);
-    }
-
     Backend::updateTextureGPUMemoryUsage(0, _size);
 
 }

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -43,9 +43,7 @@ using GL45ResourceTexture = GL45Backend::GL45ResourceTexture;
 GL45ResourceTexture::GL45ResourceTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture) : GL45VariableAllocationTexture(backend, texture) {
     auto mipLevels = texture.getNumMips();
     _allocatedMip = mipLevels;
-
     _maxAllocatedMip = _populatedMip = mipLevels;
-
     _minAllocatedMip = texture.minAvailableMipLevel();
 
     uvec3 mipDimensions;
@@ -104,11 +102,8 @@ void GL45ResourceTexture::promote() {
     Q_ASSERT(_allocatedMip > 0);
 
     uint16_t targetAllocatedMip = _allocatedMip - std::min<uint16_t>(_allocatedMip, 2);
-    targetAllocatedMip = std::max<uint16_t>(_gpuObject.minAvailableMipLevel(), targetAllocatedMip);
+    targetAllocatedMip = std::max<uint16_t>(_minAllocatedMip, targetAllocatedMip);
 
-    if (targetAllocatedMip >= _allocatedMip || !_gpuObject.isStoredMipFaceAvailable(targetAllocatedMip, 0)) {
-        return;
-    }
     GLuint oldId = _id;
     auto oldSize = _size;
     // create new texture

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -46,19 +46,18 @@ GL45ResourceTexture::GL45ResourceTexture(const std::weak_ptr<GLBackend>& backend
 
     _maxAllocatedMip = _populatedMip = mipLevels;
 
-    uint16_t minAvailableMip = texture.minAvailableMipLevel();
+    _minAllocatedMip = texture.minAvailableMipLevel();
 
     uvec3 mipDimensions;
-    for (uint16_t mip = 0; mip < mipLevels; ++mip) {
-        if (glm::all(glm::lessThanEqual(texture.evalMipDimensions(mip), INITIAL_MIP_TRANSFER_DIMENSIONS))
-            && mip >= minAvailableMip) {
+    for (uint16_t mip = _minAllocatedMip; mip < mipLevels; ++mip) {
+        if (glm::all(glm::lessThanEqual(texture.evalMipDimensions(mip), INITIAL_MIP_TRANSFER_DIMENSIONS))) {
             _maxAllocatedMip = _populatedMip = mip;
             break;
         }
     }
 
     auto targetMip = _populatedMip - std::min<uint16_t>(_populatedMip, 2);
-    uint16_t allocatedMip = std::max<uint16_t>(minAvailableMip, targetMip);
+    uint16_t allocatedMip = std::max<uint16_t>(_minAllocatedMip, targetMip);
 
     allocateStorage(allocatedMip);
     _memoryPressureStateStale = true;

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -476,30 +476,8 @@ void Texture::assignStoredMipFace(uint16 level, uint8 face, storage::StoragePoin
     }
 }
 
-void Texture::requestInterestInMip(uint16 level) {
-    if (!_storage->isMipAvailable(level, 0)) {
-        std::lock_guard<std::mutex> lock(_mipInterestListenersMutex);
-        for (auto& callback : _mipInterestListeners) {
-            callback->handleMipInterestCallback(level);
-        }
-    }
-}
-
 bool Texture::isStoredMipFaceAvailable(uint16 level, uint8 face) const {
     return _storage->isMipAvailable(level, face);
-}
-
-void Texture::registerMipInterestListener(MipInterestListener* listener) {
-    std::lock_guard<std::mutex> lock(_mipInterestListenersMutex);
-    _mipInterestListeners.push_back(listener);
-}
-
-void Texture::unregisterMipInterestListener(MipInterestListener* listener) {
-    std::lock_guard<std::mutex> lock(_mipInterestListenersMutex);
-    auto it = find(_mipInterestListeners.begin(), _mipInterestListeners.end(), listener);
-    if (it != _mipInterestListeners.end()) {
-        _mipInterestListeners.erase(it);
-    }
 }
 
 void Texture::setAutoGenerateMips(bool enable) {

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -397,7 +397,6 @@ Size Texture::evalTotalSize(uint16 startingMip) const {
     Size size = 0;
     uint16 minMipLevel = std::max(getMinMip(), startingMip);
     uint16 maxMipLevel = getMaxMip();
-    qDebug() << " min: " << minMipLevel << " " << maxMipLevel;
     for (uint16 level = minMipLevel; level <= maxMipLevel; level++) {
         size += evalMipSize(level);
     }

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -397,6 +397,7 @@ Size Texture::evalTotalSize(uint16 startingMip) const {
     Size size = 0;
     uint16 minMipLevel = std::max(getMinMip(), startingMip);
     uint16 maxMipLevel = getMaxMip();
+    qDebug() << " min: " << minMipLevel << " " << maxMipLevel;
     for (uint16 level = minMipLevel; level <= maxMipLevel; level++) {
         size += evalMipSize(level);
     }

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -35,6 +35,7 @@ namespace ktx {
 namespace gpu {
 
 extern const std::string SOURCE_HASH_KEY;
+const uint8 SOURCE_HASH_BYTES = 16;
 
 // THe spherical harmonics is a nice tool for cubemap, so if required, the irradiance SH can be automatically generated
 // with the cube texture

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -154,7 +154,7 @@ protected:
     Desc _desc;
 };
 
-enum class TextureUsageType {
+enum class TextureUsageType : uint8 {
     RENDERBUFFER,       // Used as attachments to a framebuffer
     RESOURCE,           // Resource textures, like materials... subject to memory manipulation
     STRICT_RESOURCE,    // Resource textures not subject to manipulation, like the normal fitting texture
@@ -527,8 +527,8 @@ public:
     // Serialize a texture into a KTX file
     static ktx::KTXUniquePointer serialize(const Texture& texture);
 
-    static TexturePointer unserialize(const std::string& ktxFile, TextureUsageType usageType = TextureUsageType::RESOURCE, Usage usage = Usage(), const Sampler::Desc& sampler = Sampler::Desc());
-    static TexturePointer unserialize(const std::string& ktxFile, const ktx::KTXDescriptor& descriptor, TextureUsageType usageType = TextureUsageType::RESOURCE, Usage usage = Usage(), const Sampler::Desc& sampler = Sampler::Desc());
+    static TexturePointer unserialize(const std::string& ktxFile);
+    static TexturePointer unserialize(const std::string& ktxFile, const ktx::KTXDescriptor& descriptor);
 
     static bool evalKTXFormat(const Element& mipFormat, const Element& texelFormat, ktx::Header& header);
     static bool evalTextureFormat(const ktx::Header& header, Element& mipFormat, Element& texelFormat);

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -480,7 +480,7 @@ public:
 
     // Access the stored mips and faces
     const PixelsPointer accessStoredMipFace(uint16 level, uint8 face = 0) const { return _storage->getMipFace(level, face); }
-    bool isStoredMipFaceAvailable(uint16 level, uint8 face = 0) const;// { return _storage->isMipAvailable(level, face); }
+    bool isStoredMipFaceAvailable(uint16 level, uint8 face = 0) const;
     Size getStoredMipFaceSize(uint16 level, uint8 face = 0) const { return _storage->getMipFaceSize(level, face); }
     Size getStoredMipSize(uint16 level) const;
     Size getStoredSize() const;

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -330,6 +330,7 @@ public:
 
         std::string _filename;
         std::atomic<uint8_t> _minMipLevelAvailable;
+        size_t _offsetToMinMipKV;
 
         ktx::KTXDescriptorPointer _ktxDescriptor;
         friend class Texture;

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -524,9 +524,6 @@ public:
 
     ExternalUpdates getUpdates() const;
 
-    // Serialize ktx header and keyvalues directly to a file, and return a Texture representing that file
-    static TexturePointer serializeHeader(const std::string& ktxfile, const ktx::Header& header, const ktx::KeyValues& keyValues);
-
     // Serialize a texture into a KTX file
     static ktx::KTXUniquePointer serialize(const Texture& texture);
 

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -488,17 +488,6 @@ public:
     void setStorage(std::unique_ptr<Storage>& newStorage);
     void setKtxBacking(const std::string& filename);
 
-    class MipInterestListener {
-        public:
-            virtual void handleMipInterestCallback(uint16 level) = 0;
-    };
-    void registerMipInterestListener(MipInterestListener* listener);
-    void unregisterMipInterestListener(MipInterestListener* listener);
-    std::vector<MipInterestListener*> _mipInterestListeners;
-    std::mutex _mipInterestListenersMutex;
-
-    void requestInterestInMip(uint16 level);
-
     // Usage is a a set of flags providing Semantic about the usage of the Texture.
     void setUsage(const Usage& usage) { _usage = usage; }
     Usage getUsage() const { return _usage; }

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -34,7 +34,9 @@ namespace ktx {
 
 namespace gpu {
 
-extern const std::string SOURCE_HASH_KEY;
+
+const std::string SOURCE_HASH_KEY { "hifi.sourceHash" };
+
 const uint8 SOURCE_HASH_BYTES = 16;
 
 // THe spherical harmonics is a nice tool for cubemap, so if required, the irradiance SH can be automatically generated

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -11,11 +11,12 @@
 
 
 #include "Texture.h"
-#include <qdebug.h>
 
 #include <QtCore/QByteArray>
 
 #include <ktx/KTX.h>
+
+#include "GPULogging.h"
 
 using namespace gpu;
 

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -134,21 +134,9 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
         return;
     }
 
-
-    //auto fileStorage = new storage::FileStorage(_filename.c_str());
-    //ktx::StoragePointer file { fileStorage };
     auto file = maybeOpenFile();
+
     auto data = file->mutableData();
-    data += file->size();
-
-    // TODO Cache this data inside Image or ImageDescriptor?
-    for (int i = _ktxDescriptor->header.numberOfMipmapLevels - 1; i >= level; --i) {
-        data -= _ktxDescriptor->images[i]._imageSize;
-        data -= 4;
-    }
-    data += 4;
-
-    data = file->mutableData();
     data += ktx::KTX_HEADER_SIZE + _ktxDescriptor->header.bytesOfKeyValueData + _ktxDescriptor->images[level]._imageOffset;
     data += 4;
 
@@ -172,7 +160,6 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
 void KtxStorage::assignMipFaceData(uint16 level, uint8 face, const storage::StoragePointer& storage) {
     throw std::runtime_error("Invalid call");
 }
-
 
 void Texture::setKtxBacking(const std::string& filename) {
     // Check the KTX file for validity before using it as backing storage
@@ -362,13 +349,6 @@ TexturePointer Texture::unserialize(const std::string& ktxfile, const ktx::KTXDe
     tex->setStoredMipFormat(mipFormat);
     tex->setKtxBacking(ktxfile);
     return tex;
-}
-
-TexturePointer Texture::serializeHeader(const std::string& ktxfile, const ktx::Header& header, const ktx::KeyValues& keyValues) {
-    // Create a memory-backed KTX object
-    auto ktxBuffer = ktx::KTX::createBare(header, keyValues);
-
-    return unserialize(ktxfile, ktxBuffer->toDescriptor());
 }
 
 bool Texture::evalKTXFormat(const Element& mipFormat, const Element& texelFormat, ktx::Header& header) {

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -52,7 +52,7 @@ KtxStorage::KtxStorage(const std::string& filename) : _filename(filename) {
         auto ktxPointer = ktx::KTX::create(storage);
         _ktxDescriptor.reset(new ktx::KTXDescriptor(ktxPointer->toDescriptor()));
         if (_ktxDescriptor->images.size() < _ktxDescriptor->header.numberOfMipmapLevels) {
-            qDebug() << "bad images found";
+            qWarning() << "Bad images found in ktx";
         }
         auto& keyValues = _ktxDescriptor->keyValues;
         auto found = std::find_if(keyValues.begin(), keyValues.end(), [](const ktx::KeyValue& val) -> bool {
@@ -96,7 +96,6 @@ std::shared_ptr<storage::FileStorage> KtxStorage::maybeOpenFile() {
 }
 
 PixelsPointer KtxStorage::getMipFace(uint16 level, uint8 face) const {
-    //qDebug() << "getMipFace: " << QString::fromStdString(_filename) << ": " << level << " " << face;
     storage::StoragePointer result;
     auto faceOffset = _ktxDescriptor->getMipFaceTexelsOffset(level, face);
     auto faceSize = _ktxDescriptor->getMipFaceTexelsSize(level, face);
@@ -112,10 +111,7 @@ Size KtxStorage::getMipFaceSize(uint16 level, uint8 face) const {
 
 
 bool KtxStorage::isMipAvailable(uint16 level, uint8 face) const {
-    auto avail = level >= _minMipLevelAvailable;
-    //qDebug() << "isMipAvailable: " << QString::fromStdString(_filename) << ": " << level << " " << face << avail << _minMipLevelAvailable << " " << _ktxDescriptor->header.numberOfMipmapLevels;
-    //return true;
-    return avail;
+    return level >= _minMipLevelAvailable;
 }
 
 uint16 KtxStorage::minAvailableMipLevel() const {
@@ -123,10 +119,8 @@ uint16 KtxStorage::minAvailableMipLevel() const {
 }
 
 void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& storage) {
-    qDebug() << "Populating " << level << " " << _filename.c_str();
     if (level != _minMipLevelAvailable - 1) {
         qWarning() << "Invalid level to be stored, expected: " << (_minMipLevelAvailable - 1) << ", got: " << level << " " << _filename.c_str();
-        //throw std::runtime_error("Invalid image size for level");
         return;
     }
 
@@ -135,9 +129,8 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
     }
 
     if (storage->size() != _ktxDescriptor->images[level]._imageSize) {
-        qDebug() << "Invalid image size: " << storage->size() << ", expected: " << _ktxDescriptor->images[level]._imageSize
+        qWarning() << "Invalid image size: " << storage->size() << ", expected: " << _ktxDescriptor->images[level]._imageSize
             << ", level: " << level << ", filename: " << QString::fromStdString(_filename);
-        //throw std::runtime_error("Invalid image size for level");
         return;
     }
 

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -207,7 +207,7 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
         memcpy(data, storage->data(), _ktxDescriptor->images[level]._imageSize);
         _minMipLevelAvailable = level;
         if (offset > 0) {
-            memcpy(file->mutableData() + ktx::KTX_HEADER_SIZE + offset, (void*)&_minMipLevelAvailable, 1);
+            memcpy(file->mutableData() + ktx::KTX_HEADER_SIZE + 4 + offset, (void*)&_minMipLevelAvailable, 1);
         }
     }
 }

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -13,7 +13,10 @@
 #include "Texture.h"
 #include <qdebug.h>
 
+#include <QtCore/QByteArray>
+
 #include <ktx/KTX.h>
+
 using namespace gpu;
 
 using PixelsPointer = Texture::PixelsPointer;
@@ -312,7 +315,10 @@ ktx::KTXUniquePointer Texture::serialize(const Texture& texture) {
 
     auto hash = texture.sourceHash();
     if (!hash.empty()) {
-        keyValues.emplace_back(SOURCE_HASH_KEY, static_cast<uint32>(hash.size()), (ktx::Byte*) hash.c_str());
+        // the sourceHash is an std::string in hex
+        // we use QByteArray to take the hex and turn it into the smaller binary representation (16 bytes)
+        auto binaryHash = QByteArray::fromHex(QByteArray::fromStdString(hash));
+        keyValues.emplace_back(SOURCE_HASH_KEY, static_cast<uint32>(binaryHash.size()), (ktx::Byte*) binaryHash.data());
     }
 
     auto ktxBuffer = ktx::KTX::create(header, images, keyValues);

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -123,8 +123,9 @@ uint16 KtxStorage::minAvailableMipLevel() const {
 }
 
 void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& storage) {
+    qDebug() << "Populating " << level << " " << _filename.c_str();
     if (level != _minMipLevelAvailable - 1) {
-        qWarning() << "Invalid level to be stored, expected: " << (_minMipLevelAvailable - 1) << ", got: " << level;
+        qWarning() << "Invalid level to be stored, expected: " << (_minMipLevelAvailable - 1) << ", got: " << level << " " << _filename.c_str();
         //throw std::runtime_error("Invalid image size for level");
         return;
     }

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -191,9 +191,9 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
 
     auto file = maybeOpenFile();
 
-    auto data = file->mutableData();
-    data += ktx::KTX_HEADER_SIZE + _ktxDescriptor->header.bytesOfKeyValueData + _ktxDescriptor->images[level]._imageOffset;
-    data += ktx::IMAGE_SIZE_WIDTH;
+    auto imageData = file->mutableData();
+    imageData += ktx::KTX_HEADER_SIZE + _ktxDescriptor->header.bytesOfKeyValueData + _ktxDescriptor->images[level]._imageOffset;
+    imageData += ktx::IMAGE_SIZE_WIDTH;
 
     auto offset = _ktxDescriptor->getValueOffsetForKey(ktx::HIFI_MIN_POPULATED_MIP_KEY);
     {
@@ -204,10 +204,11 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
             return;
         }
 
-        memcpy(data, storage->data(), _ktxDescriptor->images[level]._imageSize);
+        memcpy(imageData, storage->data(), _ktxDescriptor->images[level]._imageSize);
         _minMipLevelAvailable = level;
         if (offset > 0) {
-            memcpy(file->mutableData() + ktx::KTX_HEADER_SIZE + ktx::KV_SIZE_WIDTH + offset, (void*)&_minMipLevelAvailable, 1);
+            auto minMipKeyData = file->mutableData() + ktx::KTX_HEADER_SIZE + ktx::KV_SIZE_WIDTH + offset;
+            memcpy(minMipKeyData, (void*)&_minMipLevelAvailable, 1);
         }
     }
 }

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -193,7 +193,7 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
 
     auto data = file->mutableData();
     data += ktx::KTX_HEADER_SIZE + _ktxDescriptor->header.bytesOfKeyValueData + _ktxDescriptor->images[level]._imageOffset;
-    data += 4;
+    data += ktx::IMAGE_SIZE_WIDTH;
 
     auto offset = _ktxDescriptor->getValueOffsetForKey(ktx::HIFI_MIN_POPULATED_MIP_KEY);
     {
@@ -207,7 +207,7 @@ void KtxStorage::assignMipData(uint16 level, const storage::StoragePointer& stor
         memcpy(data, storage->data(), _ktxDescriptor->images[level]._imageSize);
         _minMipLevelAvailable = level;
         if (offset > 0) {
-            memcpy(file->mutableData() + ktx::KTX_HEADER_SIZE + 4 + offset, (void*)&_minMipLevelAvailable, 1);
+            memcpy(file->mutableData() + ktx::KTX_HEADER_SIZE + ktx::KV_SIZE_WIDTH + offset, (void*)&_minMipLevelAvailable, 1);
         }
     }
 }
@@ -300,7 +300,7 @@ ktx::KTXUniquePointer Texture::serialize(const Texture& texture) {
                 }
                 images.emplace_back(ktx::Image(imageOffset, (uint32_t)mip->getSize(), 0, cubeFaces));
             }
-            imageOffset += static_cast<uint32_t>(mip->getSize()) + 4;
+            imageOffset += static_cast<uint32_t>(mip->getSize()) + ktx::IMAGE_SIZE_WIDTH;
         }
     }
 

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -97,7 +97,6 @@ struct GPUKTXPayload {
         return false;
     }
 };
-const std::string gpu::SOURCE_HASH_KEY { "hifi.sourceHash" };
 const std::string GPUKTXPayload::KEY { "hifi.gpu" };
 
 KtxStorage::KtxStorage(const std::string& filename) : _filename(filename) {

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -91,9 +91,9 @@ size_t Header::evalPixelOrBlockSize() const {
             return 4;
         }
     }
+
     qWarning() << "Unknown ktx format: " << glFormat << " " << glBaseInternalFormat << " " << glInternalFormat;
     return 0;
-    //throw std::runtime_error("Unknown format");
 }
 
 size_t Header::evalRowSize(uint32_t level) const {
@@ -284,7 +284,6 @@ Image ImageDescriptor::toImage(const ktx::StoragePointer& storage) const {
     FaceBytes faces;
     faces.resize(_faceOffsets.size());
     for (size_t face = 0; face < _numFaces; ++face) {
-        // TODO Should we be storing pointers to unowned data?
         faces[face] = storage->data() + _faceOffsets[face];
     }
     // Note, implicit cast of *this to const ImageHeader&

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -136,7 +136,7 @@ size_t KTXDescriptor::getValueOffsetForKey(const std::string& key) const {
 ImageDescriptors Header::generateImageDescriptors() const {
     ImageDescriptors descriptors;
 
-    uint32_t imageOffset = 0;
+    size_t imageOffset = 0;
     for (uint32_t level = 0; level < numberOfMipmapLevels; ++level) {
         auto imageSize = static_cast<uint32_t>(evalImageSize(level));
         if (imageSize == 0) {
@@ -149,7 +149,7 @@ ImageDescriptors Header::generateImageDescriptors() const {
             0
         };
 
-        imageOffset += (imageSize * numberOfFaces) + 4;
+        imageOffset += (imageSize * numberOfFaces) + ktx::IMAGE_SIZE_WIDTH;
 
         ImageHeader::FaceOffsets offsets;
         // TODO Add correct face offsets

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -126,7 +126,7 @@ size_t KTXDescriptor::getValueOffsetForKey(const std::string& key) const {
     size_t offset { 0 };
     for (auto& kv : keyValues) {
         if (kv._key == key) {
-            return offset + kv._key.size() + 1;
+            return offset + ktx::KV_SIZE_WIDTH + kv._key.size() + 1;
         }
         offset += kv.serializedByteSize();
     }

--- a/libraries/ktx/src/ktx/KTX.h
+++ b/libraries/ktx/src/ktx/KTX.h
@@ -419,8 +419,8 @@ namespace ktx {
 
         // This is the byte offset from the _start_ of the image region. For example, level 0
         // will have a byte offset of 0.
-        const uint32_t _imageOffset;
         const uint32_t _numFaces;
+        const uint32_t _imageOffset;
         const uint32_t _imageSize;
         const uint32_t _faceSize;
         const uint32_t _padding;

--- a/libraries/ktx/src/ktx/KTX.h
+++ b/libraries/ktx/src/ktx/KTX.h
@@ -390,6 +390,8 @@ namespace ktx {
     };
     static const size_t KTX_HEADER_SIZE = 64;
     static_assert(sizeof(Header) == KTX_HEADER_SIZE, "KTX Header size is static and should not change from the spec");
+    static const size_t KV_SIZE_WIDTH = 4; // Number of bytes for keyAndValueByteSize
+    static const size_t IMAGE_SIZE_WIDTH = 4; // Number of bytes for imageSize
 
     // Key Values
     struct KeyValue {

--- a/libraries/ktx/src/ktx/KTX.h
+++ b/libraries/ktx/src/ktx/KTX.h
@@ -70,10 +70,9 @@ end
 
 
 namespace ktx {
-    const std::string HIFI_MIN_POPULATED_MIP_KEY = "hifi.minMip";
-
-
     const uint32_t PACKING_SIZE { sizeof(uint32_t) };
+    const std::string HIFI_MIN_POPULATED_MIP_KEY{ "hifi.minMip" };
+
     using Byte = uint8_t;
 
     enum class GLType : uint32_t {

--- a/libraries/ktx/src/ktx/KTX.h
+++ b/libraries/ktx/src/ktx/KTX.h
@@ -422,11 +422,11 @@ namespace ktx {
         // This is the byte offset from the _start_ of the image region. For example, level 0
         // will have a byte offset of 0.
         const uint32_t _numFaces;
-        const uint32_t _imageOffset;
+        const size_t _imageOffset;
         const uint32_t _imageSize;
         const uint32_t _faceSize;
         const uint32_t _padding;
-        ImageHeader(bool cube, uint32_t imageOffset, uint32_t imageSize, uint32_t padding) :
+        ImageHeader(bool cube, size_t imageOffset, uint32_t imageSize, uint32_t padding) :
             _numFaces(cube ? NUM_CUBEMAPFACES : 1),
             _imageOffset(imageOffset),
             _imageSize(imageSize * _numFaces),
@@ -448,10 +448,10 @@ namespace ktx {
     struct Image : public ImageHeader {
         FaceBytes _faceBytes;
         Image(const ImageHeader& header, const FaceBytes& faces) : ImageHeader(header), _faceBytes(faces) {}
-        Image(uint32_t imageOffset, uint32_t imageSize, uint32_t padding, const Byte* bytes) :
+        Image(size_t imageOffset, uint32_t imageSize, uint32_t padding, const Byte* bytes) :
             ImageHeader(false, imageOffset, imageSize, padding),
             _faceBytes(1, bytes) {}
-        Image(uint32_t imageOffset, uint32_t pageSize, uint32_t padding, const FaceBytes& cubeFaceBytes) :
+        Image(size_t imageOffset, uint32_t pageSize, uint32_t padding, const FaceBytes& cubeFaceBytes) :
             ImageHeader(true, imageOffset, pageSize, padding)
             {
                 if (cubeFaceBytes.size() == NUM_CUBEMAPFACES) {

--- a/libraries/ktx/src/ktx/Reader.cpp
+++ b/libraries/ktx/src/ktx/Reader.cpp
@@ -50,7 +50,7 @@ namespace ktx {
 
     bool checkIdentifier(const Byte* identifier) {
         if (!(0 == memcmp(identifier, Header::IDENTIFIER.data(), Header::IDENTIFIER_LENGTH))) {
-            throw ReaderException("identifier field invalid");
+            //throw ReaderException("identifier field invalid");
             return false;
         }
         return true;

--- a/libraries/ktx/src/ktx/Reader.cpp
+++ b/libraries/ktx/src/ktx/Reader.cpp
@@ -50,7 +50,7 @@ namespace ktx {
 
     bool checkIdentifier(const Byte* identifier) {
         if (!(0 == memcmp(identifier, Header::IDENTIFIER.data(), Header::IDENTIFIER_LENGTH))) {
-            //throw ReaderException("identifier field invalid");
+            throw ReaderException("identifier field invalid");
             return false;
         }
         return true;

--- a/libraries/ktx/src/ktx/Writer.cpp
+++ b/libraries/ktx/src/ktx/Writer.cpp
@@ -43,12 +43,9 @@ namespace ktx {
     std::unique_ptr<KTX> KTX::createBare(const Header& header, const KeyValues& keyValues) {
         auto descriptors = header.generateImageDescriptors();
 
-        auto newHeader = header;
-
         Byte minMip = header.numberOfMipmapLevels;
         auto newKeyValues = keyValues;
         newKeyValues.emplace_back(KeyValue(HIFI_MIN_POPULATED_MIP_KEY, sizeof(Byte), &minMip));
-        newHeader.bytesOfKeyValueData = KeyValue::serializedKeyValuesByteSize(newKeyValues);
 
         StoragePointer storagePointer;
         {

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -364,7 +364,6 @@ void Geometry::setTextures(const QVariantMap& textureMap) {
 
 bool Geometry::areTexturesLoaded() const {
     if (!_areTexturesLoaded) {
-        //qDebug() << "Textures not loaded for " << _fbxGeometry->originalURL;
         for (auto& material : _materials) {
             // Check if material textures are loaded
             bool materialMissingTexture = std::any_of(material->_textures.cbegin(), material->_textures.cend(),

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -559,13 +559,16 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
             });
             std::string filename;
             std::string hash;
-            if (found == keyValues.end() || found->_value.size() != 32) {
+            if (found == keyValues.end() || found->_value.size() != gpu::SOURCE_HASH_BYTES) {
                 qWarning("Invalid source hash key found, bailing");
                 _ktxResourceState = FAILED_TO_LOAD;
                 finishedLoading(false);
                 return;
             } else {
-                hash = filename = std::string(reinterpret_cast<char*>(found->_value.data()), 32);
+                // at this point the source hash is in binary 16-byte form
+                // and we need it in a hexadecimal string
+                auto binaryHash = QByteArray(reinterpret_cast<char*>(found->_value.data()), gpu::SOURCE_HASH_BYTES);
+                hash = filename = binaryHash.toHex().toStdString();
             }
 
             auto textureCache = DependencyManager::get<TextureCache>();

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -627,14 +627,6 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
                 texture = textureCache->cacheTextureByHash(filename, texture);
             }
 
-            _lowestKnownPopulatedMip = _originalKtxDescriptor->header.numberOfMipmapLevels;
-            for (uint16_t l = 0; l < 200; l++) {
-                if (texture->isStoredMipFaceAvailable(l)) {
-                    _lowestKnownPopulatedMip = l;
-                    break;
-                }
-            }
-
             _lowestKnownPopulatedMip = texture->minAvailableMipLevel();
 
             _ktxResourceState = WAITING_FOR_MIP_REQUEST;

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -635,8 +635,6 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
                 // images with the same hash being loaded concurrently.  Only one of them will make it into the cache by hash first and will
                 // be the winner
                 texture = textureCache->cacheTextureByHash(filename, texture);
-
-
             }
 
             _lowestKnownPopulatedMip = _originalKtxDescriptor->header.numberOfMipmapLevels;
@@ -660,6 +658,7 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
             _ktxMipRequest->deleteLater();
             _ktxMipRequest = nullptr;
         }
+        startRequestForNextMipLevel();
     }
 }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -619,14 +619,13 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
                 uint8_t* ktxData = reinterpret_cast<uint8_t*>(ktxHighMipData.data());
                 ktxData += ktxHighMipData.size();
                 // TODO Move image offset calculation to ktx ImageDescriptor
-                int level;
-                for (level = images.size() - 1; level >= 0; --level) {
+                for (auto level = images.size() - 1; level >= 0; --level) {
                     auto& image = images[level];
                     if (image._imageSize > imageSizeRemaining) {
                         break;
                     }
                     ktxData -= image._imageSize;
-                    texture->assignStoredMip(level, image._imageSize, ktxData);
+                    texture->assignStoredMip(static_cast<gpu::uint16>(level), image._imageSize, ktxData);
                     ktxData -= 4;
                     imageSizeRemaining -= (image._imageSize + 4);
                 }

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -338,7 +338,9 @@ void NetworkTexture::makeRequest() {
     if (_ktxResourceState == PENDING_INITIAL_LOAD) {
         _ktxResourceState = LOADING_INITIAL_DATA;
 
-        qDebug() << ">>> Making request to " << _url << " for header";
+        // Add a fragment to the base url so we can identify the section of the ktx being requested when debugging
+        // The actual requested url is _activeUrl and will not contain the fragment
+        _url.setFragment("head");
         _ktxHeaderRequest = ResourceManager::createResourceRequest(this, _activeUrl);
 
         if (!_ktxHeaderRequest) {
@@ -366,7 +368,12 @@ void NetworkTexture::makeRequest() {
     } else if (_ktxResourceState == PENDING_MIP_REQUEST) {
         if (_lowestKnownPopulatedMip > 0) {
             _ktxResourceState = REQUESTING_MIP;
-            startMipRangeRequest(_lowestKnownPopulatedMip - 1, _lowestKnownPopulatedMip - 1);
+
+            // Add a fragment to the base url so we can identify the section of the ktx being requested when debugging
+            // The actual requested url is _activeUrl and will not contain the fragment
+            uint16_t nextMip = _lowestKnownPopulatedMip - 1;
+            _url.setFragment(QString::number(nextMip));
+            startMipRangeRequest(nextMip, nextMip);
         }
     } else {
         qWarning(networking) << "NetworkTexture::makeRequest() called while not in a valid state: " << _ktxResourceState;
@@ -632,7 +639,6 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
 
             _ktxResourceState = WAITING_FOR_MIP_REQUEST;
             setImage(texture, header->getPixelWidth(), header->getPixelHeight());
-            qDebug() << "Loaded KTX: " << QString::fromStdString(hash) << " : " << _url;
 
             _ktxHeaderRequest->deleteLater();
             _ktxHeaderRequest = nullptr;

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -588,8 +588,7 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
                     _ktxResourceState = FAILED_TO_LOAD;
                     finishedLoading(false);
                     return;
-                }
-                else {
+                } else {
                     _file = file;
                 }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -411,7 +411,7 @@ void NetworkTexture::startRequestForNextMipLevel() {
         setLoadPriority(this, -_originalKtxDescriptor->header.numberOfMipmapLevels + _lowestKnownPopulatedMip);
 
         init();
-        ResourceCache::attemptRequest(_self);
+        TextureCache::attemptRequest(_self);
     }
 }
 
@@ -471,7 +471,7 @@ void NetworkTexture::ktxMipRequestFinished() {
     }
     else if (_ktxResourceState == REQUESTING_MIP) {
         Q_ASSERT(_ktxMipLevelRangeInFlight.first != NULL_MIP_LEVEL);
-        ResourceCache::requestCompleted(_self);
+        TextureCache::requestCompleted(_self);
 
         if (_ktxMipRequest->getResult() == ResourceRequest::Success) {
             Q_ASSERT(_ktxMipLevelRangeInFlight.second - _ktxMipLevelRangeInFlight.first == 0);
@@ -519,7 +519,7 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
 
     if (_ktxHeaderRequestFinished && _ktxHighMipRequestFinished) {
 
-        ResourceCache::requestCompleted(_self);
+        TextureCache::requestCompleted(_self);
 
         if (_ktxHeaderRequest->getResult() != ResourceRequest::Success || _ktxMipRequest->getResult() != ResourceRequest::Success) {
             if (handleFailedRequest(_ktxMipRequest->getResult())) {

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -399,7 +399,7 @@ void NetworkTexture::startRequestForNextMipLevel() {
     if (_ktxResourceState == WAITING_FOR_MIP_REQUEST) {
         _ktxResourceState = PENDING_MIP_REQUEST;
 
-        setLoadPriority(this, -_originalKtxDescriptor->header.numberOfMipmapLevels + _lowestKnownPopulatedMip);
+        setLoadPriority(this, -static_cast<int>(_originalKtxDescriptor->header.numberOfMipmapLevels) + _lowestKnownPopulatedMip);
 
         init();
         TextureCache::attemptRequest(_self);

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -391,9 +391,9 @@ void NetworkTexture::startRequestForNextMipLevel() {
     if (_ktxResourceState == WAITING_FOR_MIP_REQUEST) {
         _ktxResourceState = PENDING_MIP_REQUEST;
 
-        setLoadPriority(this, -static_cast<int>(_originalKtxDescriptor->header.numberOfMipmapLevels) + _lowestKnownPopulatedMip);
-
         init();
+        setLoadPriority(this, -static_cast<int>(_originalKtxDescriptor->header.numberOfMipmapLevels) + _lowestKnownPopulatedMip);
+        _url.setFragment(QString::number(_lowestKnownPopulatedMip - 1));
         TextureCache::attemptRequest(_self);
     }
 }

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -458,8 +458,7 @@ void NetworkTexture::ktxMipRequestFinished() {
     if (_ktxResourceState == LOADING_INITIAL_DATA) {
         _ktxHighMipRequestFinished = true;
         maybeHandleFinishedInitialLoad();
-    }
-    else if (_ktxResourceState == REQUESTING_MIP) {
+    } else if (_ktxResourceState == REQUESTING_MIP) {
         Q_ASSERT(_ktxMipLevelRangeInFlight.first != NULL_MIP_LEVEL);
         TextureCache::requestCompleted(_self);
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -619,7 +619,7 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
                 uint8_t* ktxData = reinterpret_cast<uint8_t*>(ktxHighMipData.data());
                 ktxData += ktxHighMipData.size();
                 // TODO Move image offset calculation to ktx ImageDescriptor
-                for (auto level = images.size() - 1; level >= 0; --level) {
+                for (int level = static_cast<int>(images.size()) - 1; level >= 0; --level) {
                     auto& image = images[level];
                     if (image._imageSize > imageSizeRemaining) {
                         break;

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -272,8 +272,8 @@ QSharedPointer<Resource> TextureCache::createResource(const QUrl& url, const QSh
 NetworkTexture::NetworkTexture(const QUrl& url, image::TextureUsage::Type type, const QByteArray& content, int maxNumPixels) :
     Resource(url),
     _type(type),
-    _maxNumPixels(maxNumPixels),
-    _sourceIsKTX(url.path().endsWith(".ktx"))
+    _sourceIsKTX(url.path().endsWith(".ktx")),
+    _maxNumPixels(maxNumPixels)
 {
     _textureSource = std::make_shared<gpu::TextureSource>();
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -50,6 +50,8 @@ Q_LOGGING_CATEGORY(trace_resource_parse_image_ktx, "trace.resource.parse.image.k
 const std::string TextureCache::KTX_DIRNAME { "ktx_cache" };
 const std::string TextureCache::KTX_EXT { "ktx" };
 
+static const int SKYBOX_LOAD_PRIORITY { 10 }; // Make sure skybox loads first
+
 TextureCache::TextureCache() :
     _ktxCache(KTX_DIRNAME, KTX_EXT) {
     setUnusedResourceCacheSize(0);
@@ -259,6 +261,9 @@ QSharedPointer<Resource> TextureCache::createResource(const QUrl& url, const QSh
     auto content = textureExtra ? textureExtra->content : QByteArray();
     auto maxNumPixels = textureExtra ? textureExtra->maxNumPixels : ABSOLUTE_MAX_TEXTURE_NUM_PIXELS;
     NetworkTexture* texture = new NetworkTexture(url, type, content, maxNumPixels);
+    if (type == image::TextureUsage::CUBE_TEXTURE) {
+        texture->setLoadPriority(this, SKYBOX_LOAD_PRIORITY);
+    }
     return QSharedPointer<Resource>(texture, &Resource::deleter);
 }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -245,13 +245,6 @@ gpu::TexturePointer getFallbackTextureForType(image::TextureUsage::Type type) {
     return result;
 }
 
-NetworkTexture::~NetworkTexture() {
-    auto texture = _textureSource->getGPUTexture();
-    if (texture) {
-        texture->unregisterMipInterestListener(this);
-    }
-}
-
 /// Returns a texture version of an image file
 gpu::TexturePointer TextureCache::getImageTexture(const QString& path, image::TextureUsage::Type type, QVariantMap options) {
     QImage image = QImage(path);
@@ -379,15 +372,6 @@ void NetworkTexture::makeRequest() {
         qWarning(networking) << "NetworkTexture::makeRequest() called while not in a valid state: " << _ktxResourceState;
     }
 
-}
-
-void NetworkTexture::handleMipInterestCallback(uint16_t level) {
-    QMetaObject::invokeMethod(this, "handleMipInterestLevel", Qt::QueuedConnection, Q_ARG(int, level));
-}
-
-void NetworkTexture::handleMipInterestLevel(int level) {
-    _lowestRequestedMipLevel = std::min((uint16_t)level, _lowestRequestedMipLevel);
-    startRequestForNextMipLevel();
 }
 
 void NetworkTexture::startRequestForNextMipLevel() {
@@ -647,8 +631,6 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
 
             _lowestKnownPopulatedMip = texture->minAvailableMipLevel();
 
-
-            texture->registerMipInterestListener(this);
             _ktxResourceState = WAITING_FOR_MIP_REQUEST;
             setImage(texture, header->getPixelWidth(), header->getPixelHeight());
             qDebug() << "Loaded KTX: " << QString::fromStdString(hash) << " : " << _url;

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -276,6 +276,7 @@ NetworkTexture::NetworkTexture(const QUrl& url, image::TextureUsage::Type type, 
     _maxNumPixels(maxNumPixels)
 {
     _textureSource = std::make_shared<gpu::TextureSource>();
+    _lowestRequestedMipLevel = 0;
 
     if (!url.isValid()) {
         _loaded = true;

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -422,9 +422,10 @@ void NetworkTexture::startMipRangeRequest(uint16_t low, uint16_t high) {
 
     _ktxMipLevelRangeInFlight = { low, high };
     if (isHighMipRequest) {
+        static const int HIGH_MIP_MAX_SIZE = 5516;
         // This is a special case where we load the high 7 mips
         ByteRange range;
-        range.fromInclusive = -15000;
+        range.fromInclusive = -HIGH_MIP_MAX_SIZE;
         _ktxMipRequest->setByteRange(range);
     } else {
         ByteRange range;

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -429,7 +429,7 @@ void NetworkTexture::startMipRangeRequest(uint16_t low, uint16_t high) {
     } else {
         ByteRange range;
         range.fromInclusive = ktx::KTX_HEADER_SIZE + _originalKtxDescriptor->header.bytesOfKeyValueData
-                              + _originalKtxDescriptor->images[low]._imageOffset + 4;
+                              + _originalKtxDescriptor->images[low]._imageOffset + ktx::IMAGE_SIZE_WIDTH;
         range.toExclusive = ktx::KTX_HEADER_SIZE + _originalKtxDescriptor->header.bytesOfKeyValueData
                               + _originalKtxDescriptor->images[high + 1]._imageOffset;
         _ktxMipRequest->setByteRange(range);
@@ -622,8 +622,8 @@ void NetworkTexture::maybeHandleFinishedInitialLoad() {
                     }
                     ktxData -= image._imageSize;
                     texture->assignStoredMip(static_cast<gpu::uint16>(level), image._imageSize, ktxData);
-                    ktxData -= 4;
-                    imageSizeRemaining -= (image._imageSize + 4);
+                    ktxData -= ktx::IMAGE_SIZE_WIDTH;
+                    imageSizeRemaining -= (image._imageSize + ktx::IMAGE_SIZE_WIDTH);
                 }
 
                 // We replace the texture with the one stored in the cache.  This deals with the possible race condition of two different 

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -46,7 +46,6 @@ class NetworkTexture : public Resource, public Texture {
 
 public:
     NetworkTexture(const QUrl& url, image::TextureUsage::Type type, const QByteArray& content, int maxNumPixels);
-    ~NetworkTexture() override;
 
     QString getType() const override { return "NetworkTexture"; }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -46,7 +46,7 @@ class NetworkTexture : public Resource, public Texture, public gpu::Texture::Mip
 
 public:
     NetworkTexture(const QUrl& url, image::TextureUsage::Type type, const QByteArray& content, int maxNumPixels);
-    NetworkTexture::~NetworkTexture() override;
+    ~NetworkTexture() override;
 
     QString getType() const override { return "NetworkTexture"; }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -41,7 +41,7 @@ public:
 };
 
 /// A texture loaded from the network.
-class NetworkTexture : public Resource, public Texture, public gpu::Texture::MipInterestListener {
+class NetworkTexture : public Resource, public Texture {
     Q_OBJECT
 
 public:
@@ -57,9 +57,6 @@ public:
     image::TextureUsage::Type getTextureType() const { return _type; }
 
     gpu::TexturePointer getFallbackTexture() const;
-
-    void handleMipInterestCallback(uint16_t level) override;
-    Q_INVOKABLE void handleMipInterestLevel(int level);
 
 signals:
     void networkTextureCreated(const QWeakPointer<NetworkTexture>& self);

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -67,7 +67,6 @@ void AssetClient::init() {
     }
 }
 
-
 void AssetClient::cacheInfoRequest(QObject* reciever, QString slot) {
     if (QThread::currentThread() != thread()) {
         QMetaObject::invokeMethod(this, "cacheInfoRequest", Qt::QueuedConnection,
@@ -182,8 +181,8 @@ RenameMappingRequest* AssetClient::createRenameMappingRequest(const AssetPath& o
     return request;
 }
 
-AssetRequest* AssetClient::createRequest(const AssetHash& hash) {
-    auto request = new AssetRequest(hash);
+AssetRequest* AssetClient::createRequest(const AssetHash& hash, ByteRange byteRange) {
+    auto request = new AssetRequest(hash, byteRange);
 
     // Move to the AssetClient thread in case we are not currently on that thread (which will usually be the case)
     request->moveToThread(thread());

--- a/libraries/networking/src/AssetClient.cpp
+++ b/libraries/networking/src/AssetClient.cpp
@@ -181,7 +181,7 @@ RenameMappingRequest* AssetClient::createRenameMappingRequest(const AssetPath& o
     return request;
 }
 
-AssetRequest* AssetClient::createRequest(const AssetHash& hash, ByteRange byteRange) {
+AssetRequest* AssetClient::createRequest(const AssetHash& hash, const ByteRange& byteRange) {
     auto request = new AssetRequest(hash, byteRange);
 
     // Move to the AssetClient thread in case we are not currently on that thread (which will usually be the case)

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -21,6 +21,7 @@
 #include <DependencyManager.h>
 
 #include "AssetUtils.h"
+#include "ByteRange.h"
 #include "ClientServerUtils.h"
 #include "LimitedNodeList.h"
 #include "Node.h"
@@ -55,7 +56,7 @@ public:
     Q_INVOKABLE DeleteMappingsRequest* createDeleteMappingsRequest(const AssetPathList& paths);
     Q_INVOKABLE SetMappingRequest* createSetMappingRequest(const AssetPath& path, const AssetHash& hash);
     Q_INVOKABLE RenameMappingRequest* createRenameMappingRequest(const AssetPath& oldPath, const AssetPath& newPath);
-    Q_INVOKABLE AssetRequest* createRequest(const AssetHash& hash);
+    Q_INVOKABLE AssetRequest* createRequest(const AssetHash& hash, ByteRange byteRange = ByteRange());
     Q_INVOKABLE AssetUpload* createUpload(const QString& filename);
     Q_INVOKABLE AssetUpload* createUpload(const QByteArray& data);
 

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -56,7 +56,7 @@ public:
     Q_INVOKABLE DeleteMappingsRequest* createDeleteMappingsRequest(const AssetPathList& paths);
     Q_INVOKABLE SetMappingRequest* createSetMappingRequest(const AssetPath& path, const AssetHash& hash);
     Q_INVOKABLE RenameMappingRequest* createRenameMappingRequest(const AssetPath& oldPath, const AssetPath& newPath);
-    Q_INVOKABLE AssetRequest* createRequest(const AssetHash& hash, ByteRange byteRange = ByteRange());
+    Q_INVOKABLE AssetRequest* createRequest(const AssetHash& hash, const ByteRange& byteRange = ByteRange());
     Q_INVOKABLE AssetUpload* createUpload(const QString& filename);
     Q_INVOKABLE AssetUpload* createUpload(const QByteArray& data);
 

--- a/libraries/networking/src/AssetRequest.cpp
+++ b/libraries/networking/src/AssetRequest.cpp
@@ -23,19 +23,18 @@
 
 static int requestID = 0;
 
-AssetRequest::AssetRequest(const QString& hash) :
+AssetRequest::AssetRequest(const QString& hash, ByteRange byteRange) :
     _requestID(++requestID),
-    _hash(hash)
+    _hash(hash),
+    _byteRange(byteRange)
 {
+    
 }
 
 AssetRequest::~AssetRequest() {
     auto assetClient = DependencyManager::get<AssetClient>();
     if (_assetRequestID) {
         assetClient->cancelGetAssetRequest(_assetRequestID);
-    }
-    if (_assetInfoRequestID) {
-        assetClient->cancelGetAssetInfoRequest(_assetInfoRequestID);
     }
 }
 
@@ -62,108 +61,74 @@ void AssetRequest::start() {
     // Try to load from cache
     _data = loadFromCache(getUrl());
     if (!_data.isNull()) {
-        _info.hash = _hash;
-        _info.size = _data.size();
         _error = NoError;
         
         _state = Finished;
         emit finished(this);
         return;
     }
-    
-    _state = WaitingForInfo;
-    
+
+    _state = WaitingForData;
+
     auto assetClient = DependencyManager::get<AssetClient>();
-    _assetInfoRequestID = assetClient->getAssetInfo(_hash,
-            [this](bool responseReceived, AssetServerError serverError, AssetInfo info) {
+    auto that = QPointer<AssetRequest>(this); // Used to track the request's lifetime
+    auto hash = _hash;
 
-        _assetInfoRequestID = INVALID_MESSAGE_ID;
+    _assetRequestID = assetClient->getAsset(_hash, _byteRange.fromInclusive, _byteRange.toExclusive,
+        [this, that, hash](bool responseReceived, AssetServerError serverError, const QByteArray& data) {
 
-        _info = info;
+            if (!that) {
+            qCWarning(asset_client) << "Got reply for dead asset request " << hash << "- error code" << _error;
+            // If the request is dead, return
+            return;
+        }
+        _assetRequestID = INVALID_MESSAGE_ID;
 
         if (!responseReceived) {
             _error = NetworkError;
         } else if (serverError != AssetServerError::NoError) {
-            switch(serverError) {
+            switch (serverError) {
                 case AssetServerError::AssetNotFound:
                     _error = NotFound;
+                    break;
+                case AssetServerError::InvalidByteRange:
+                    _error = InvalidByteRange;
                     break;
                 default:
                     _error = UnknownError;
                     break;
             }
-        }
+        } else {
+            if (_byteRange.isSet()) {
+                // we had a byte range, the size of the data does not match what we expect, so we return an error
+                if (data.size() != _byteRange.size()) {
+                    _error = SizeVerificationFailed;
+                }
+            } else if (hashData(data).toHex() != _hash) {
+                // the hash of the received data does not match what we expect, so we return an error
+                _error = HashVerificationFailed;
+            }
 
+            if (_error == NoError) {
+                _data = data;
+                _totalReceived += data.size();
+                emit progress(_totalReceived, data.size());
+                
+                saveToCache(getUrl(), data);
+            }
+        }
+        
         if (_error != NoError) {
-            qCWarning(asset_client) << "Got error retrieving asset info for" << _hash;
-            _state = Finished;
-            emit finished(this);
-            
+            qCWarning(asset_client) << "Got error retrieving asset" << _hash << "- error code" << _error;
+        }
+        
+        _state = Finished;
+        emit finished(this);
+    }, [this, that](qint64 totalReceived, qint64 total) {
+        if (!that) {
+            // If the request is dead, return
             return;
         }
-        
-        _state = WaitingForData;
-        _data.resize(info.size);
-        
-        qCDebug(asset_client) << "Got size of " << _hash << " : " << info.size << " bytes";
-        
-        int start = 0, end = _info.size;
-        
-        auto assetClient = DependencyManager::get<AssetClient>();
-        auto that = QPointer<AssetRequest>(this); // Used to track the request's lifetime
-        auto hash = _hash;
-        _assetRequestID = assetClient->getAsset(_hash, start, end,
-                [this, that, hash, start, end](bool responseReceived, AssetServerError serverError, const QByteArray& data) {
-            if (!that) {
-                qCWarning(asset_client) << "Got reply for dead asset request " << hash << "- error code" << _error;
-                // If the request is dead, return
-                return;
-            }
-            _assetRequestID = INVALID_MESSAGE_ID;
-
-            if (!responseReceived) {
-                _error = NetworkError;
-            } else if (serverError != AssetServerError::NoError) {
-                switch (serverError) {
-                    case AssetServerError::AssetNotFound:
-                        _error = NotFound;
-                        break;
-                    case AssetServerError::InvalidByteRange:
-                        _error = InvalidByteRange;
-                        break;
-                    default:
-                        _error = UnknownError;
-                        break;
-                }
-            } else {
-                Q_ASSERT(data.size() == (end - start));
-                
-                // we need to check the hash of the received data to make sure it matches what we expect
-                if (hashData(data).toHex() == _hash) {
-                    memcpy(_data.data() + start, data.constData(), data.size());
-                    _totalReceived += data.size();
-                    emit progress(_totalReceived, _info.size);
-                    
-                    saveToCache(getUrl(), data);
-                } else {
-                    // hash doesn't match - we have an error
-                    _error = HashVerificationFailed;
-                }
-                
-            }
-            
-            if (_error != NoError) {
-                qCWarning(asset_client) << "Got error retrieving asset" << _hash << "- error code" << _error;
-            }
-            
-            _state = Finished;
-            emit finished(this);
-        }, [this, that](qint64 totalReceived, qint64 total) {
-            if (!that) {
-                // If the request is dead, return
-                return;
-            }
-            emit progress(totalReceived, total);
-        });
+        emit progress(totalReceived, total);
     });
 }

--- a/libraries/networking/src/AssetRequest.cpp
+++ b/libraries/networking/src/AssetRequest.cpp
@@ -23,7 +23,7 @@
 
 static int requestID = 0;
 
-AssetRequest::AssetRequest(const QString& hash, ByteRange byteRange) :
+AssetRequest::AssetRequest(const QString& hash, const ByteRange& byteRange) :
     _requestID(++requestID),
     _hash(hash),
     _byteRange(byteRange)

--- a/libraries/networking/src/AssetRequest.h
+++ b/libraries/networking/src/AssetRequest.h
@@ -17,15 +17,15 @@
 #include <QString>
 
 #include "AssetClient.h"
-
 #include "AssetUtils.h"
+
+#include "ByteRange.h"
 
 class AssetRequest : public QObject {
    Q_OBJECT
 public:
     enum State {
         NotStarted = 0,
-        WaitingForInfo,
         WaitingForData,
         Finished
     };
@@ -36,11 +36,12 @@ public:
         InvalidByteRange,
         InvalidHash,
         HashVerificationFailed,
+        SizeVerificationFailed,
         NetworkError,
         UnknownError
     };
 
-    AssetRequest(const QString& hash);
+    AssetRequest(const QString& hash, ByteRange byteRange);
     virtual ~AssetRequest() override;
 
     Q_INVOKABLE void start();
@@ -59,13 +60,12 @@ private:
     int _requestID;
     State _state = NotStarted;
     Error _error = NoError;
-    AssetInfo _info;
     uint64_t _totalReceived { 0 };
     QString _hash;
     QByteArray _data;
     int _numPendingRequests { 0 };
     MessageID _assetRequestID { INVALID_MESSAGE_ID };
-    MessageID _assetInfoRequestID { INVALID_MESSAGE_ID };
+    ByteRange _byteRange;
 };
 
 #endif

--- a/libraries/networking/src/AssetRequest.h
+++ b/libraries/networking/src/AssetRequest.h
@@ -41,7 +41,7 @@ public:
         UnknownError
     };
 
-    AssetRequest(const QString& hash, ByteRange byteRange);
+    AssetRequest(const QString& hash, ByteRange byteRange = ByteRange());
     virtual ~AssetRequest() override;
 
     Q_INVOKABLE void start();

--- a/libraries/networking/src/AssetRequest.h
+++ b/libraries/networking/src/AssetRequest.h
@@ -41,7 +41,7 @@ public:
         UnknownError
     };
 
-    AssetRequest(const QString& hash, ByteRange byteRange = ByteRange());
+    AssetRequest(const QString& hash, const ByteRange& byteRange = ByteRange());
     virtual ~AssetRequest() override;
 
     Q_INVOKABLE void start();
@@ -65,7 +65,7 @@ private:
     QByteArray _data;
     int _numPendingRequests { 0 };
     MessageID _assetRequestID { INVALID_MESSAGE_ID };
-    ByteRange _byteRange;
+    const ByteRange _byteRange;
 };
 
 #endif

--- a/libraries/networking/src/AssetResourceRequest.cpp
+++ b/libraries/networking/src/AssetResourceRequest.cpp
@@ -114,7 +114,7 @@ void AssetResourceRequest::requestMappingForPath(const AssetPath& path) {
 void AssetResourceRequest::requestHash(const AssetHash& hash) {
     // Make request to atp
     auto assetClient = DependencyManager::get<AssetClient>();
-    _assetRequest = assetClient->createRequest(hash);
+    _assetRequest = assetClient->createRequest(hash, _byteRange);
 
     connect(_assetRequest, &AssetRequest::progress, this, &AssetResourceRequest::onDownloadProgress);
     connect(_assetRequest, &AssetRequest::finished, this, [this](AssetRequest* req) {

--- a/libraries/networking/src/ByteRange.h
+++ b/libraries/networking/src/ByteRange.h
@@ -24,9 +24,9 @@ struct ByteRange {
     // (2) the toExclusive of the range is less than the fromInclusive, and isn't zero
     // (3) the fromExclusive of the range is negative, and the toExclusive isn't zero
     bool isValid() {
-        return toExclusive < 0
-            || (toExclusive < fromInclusive && toExclusive != 0)
-            || (fromInclusive < 0 && toExclusive != 0);
+        return toExclusive >= 0
+                && (toExclusive >= fromInclusive || toExclusive == 0)
+                && (fromInclusive >= 0 || toExclusive == 0);
     }
 
     void fixupRange(int64_t fileSize) {

--- a/libraries/networking/src/ByteRange.h
+++ b/libraries/networking/src/ByteRange.h
@@ -30,6 +30,12 @@ struct ByteRange {
     }
 
     void fixupRange(int64_t fileSize) {
+        if (!isSet()) {
+            // if the byte range is not set, force it to be from 0 to the end of the file
+            fromInclusive = 0;
+            toExclusive = fileSize;
+        }
+
         if (fromInclusive > 0 && toExclusive == 0) {
             // we have a left side of the range that is non-zero
             // if the RHS of the range is zero, set it to the end of the file now

--- a/libraries/networking/src/ByteRange.h
+++ b/libraries/networking/src/ByteRange.h
@@ -18,6 +18,29 @@ struct ByteRange {
 
     bool isSet() { return fromInclusive < 0 || fromInclusive < toExclusive; }
     int64_t size() { return toExclusive - fromInclusive; }
+
+    // byte ranges are invalid if:
+    // (1) the toExclusive of the range is negative
+    // (2) the toExclusive of the range is less than the fromInclusive, and isn't zero
+    // (3) the fromExclusive of the range is negative, and the toExclusive isn't zero
+    bool isValid() {
+        return toExclusive < 0
+            || (toExclusive < fromInclusive && toExclusive != 0)
+            || (fromInclusive < 0 && toExclusive != 0);
+    }
+
+    void fixupRange(int64_t fileSize) {
+        if (fromInclusive > 0 && toExclusive == 0) {
+            // we have a left side of the range that is non-zero
+            // if the RHS of the range is zero, set it to the end of the file now
+            toExclusive = fileSize;
+        } else if (-fromInclusive >= fileSize) {
+            // we have a negative range that is equal or greater than the full size of the file
+            // so we just set this to be a range across the entire file, from 0
+            fromInclusive = 0;
+            toExclusive = fileSize;
+        }
+    }
 };
 
 

--- a/libraries/networking/src/ByteRange.h
+++ b/libraries/networking/src/ByteRange.h
@@ -1,0 +1,24 @@
+//
+//  ByteRange.h
+//  libraries/networking/src
+//
+//  Created by Stephen Birarda on 4/17/17.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_ByteRange_h
+#define hifi_ByteRange_h
+
+struct ByteRange {
+    int64_t fromInclusive { 0 };
+    int64_t toExclusive { 0 };
+
+    bool isSet() { return fromInclusive < 0 || fromInclusive < toExclusive; }
+    int64_t size() { return toExclusive - fromInclusive; }
+};
+
+
+#endif // hifi_ByteRange_h

--- a/libraries/networking/src/ByteRange.h
+++ b/libraries/networking/src/ByteRange.h
@@ -16,8 +16,8 @@ struct ByteRange {
     int64_t fromInclusive { 0 };
     int64_t toExclusive { 0 };
 
-    bool isSet() { return fromInclusive < 0 || fromInclusive < toExclusive; }
-    int64_t size() { return toExclusive - fromInclusive; }
+    bool isSet() const { return fromInclusive < 0 || fromInclusive < toExclusive; }
+    int64_t size() const { return toExclusive - fromInclusive; }
 
     // byte ranges are invalid if:
     // (1) the toExclusive of the range is negative

--- a/libraries/networking/src/FileResourceRequest.cpp
+++ b/libraries/networking/src/FileResourceRequest.cpp
@@ -23,45 +23,46 @@ void FileResourceRequest::doSend() {
     if (filename.isEmpty()) {
         filename = _url.toString();
     }
-    
-    QFile file(filename);
-    if (file.exists()) {
-        if (file.open(QFile::ReadOnly)) {
 
-            if (!_byteRange.isSet()) {
-                // no byte range, read the whole file
-                _data = file.readAll();
-            } else {
-                if (file.size() < std::abs(_byteRange.fromInclusive) || file.size() < _byteRange.toExclusive) {
+    if (!_byteRange.isValid()) {
+        _result = ResourceRequest::InvalidByteRange;
+    } else {
+        QFile file(filename);
+        if (file.exists()) {
+            if (file.open(QFile::ReadOnly)) {
+
+                if (file.size() < _byteRange.fromInclusive || file.size() < _byteRange.toExclusive) {
                     _result = ResourceRequest::InvalidByteRange;
                 } else {
-                    // we have a byte range to handle
-                    if (_byteRange.fromInclusive > 0) {
-                        // this is a positive byte range, simply skip to that part of the file and read from there
-                        file.seek(_byteRange.fromInclusive);
-                        _data = file.read(_byteRange.size());
+                    if (!_byteRange.isSet()) {
+                        // no byte range, read the whole file
+                        _data = file.readAll();
                     } else {
-                        // this is a negative byte range, we'll need to grab data from the end of the file first
-                        file.seek(file.size() + _byteRange.fromInclusive);
-                        _data = file.read(-_byteRange.fromInclusive);
+                        // we have a byte range to handle
 
-                        if (_byteRange.toExclusive > 0) {
-                            // there is additional data to read from the front of the file
-                            // handle that now
-                            file.seek(0);
-                            _data.append(file.read(_byteRange.toExclusive));
+                        // fix it up based on the known size of the file
+                        _byteRange.fixupRange(file.size());
+
+                        if (_byteRange.fromInclusive > 0) {
+                            // this is a positive byte range, simply skip to that part of the file and read from there
+                            file.seek(_byteRange.fromInclusive);
+                            _data = file.read(_byteRange.size());
+                        } else {
+                            // this is a negative byte range, we'll need to grab data from the end of the file first
+                            file.seek(file.size() + _byteRange.fromInclusive);
+                            _data = file.read(_byteRange.size());
                         }
                     }
+
+                    _result = ResourceRequest::Success;
                 }
 
+            } else {
+                _result = ResourceRequest::AccessDenied;
             }
-
-            _result = ResourceRequest::Success;
         } else {
-            _result = ResourceRequest::AccessDenied;
+            _result = ResourceRequest::NotFound;
         }
-    } else {
-        _result = ResourceRequest::NotFound;
     }
     
     _state = Finished;

--- a/libraries/networking/src/FileResourceRequest.cpp
+++ b/libraries/networking/src/FileResourceRequest.cpp
@@ -11,6 +11,8 @@
 
 #include "FileResourceRequest.h"
 
+#include <cstdlib>
+
 #include <QFile>
 
 void FileResourceRequest::doSend() {
@@ -25,7 +27,35 @@ void FileResourceRequest::doSend() {
     QFile file(filename);
     if (file.exists()) {
         if (file.open(QFile::ReadOnly)) {
-            _data = file.readAll();
+
+            if (!_byteRange.isSet()) {
+                // no byte range, read the whole file
+                _data = file.readAll();
+            } else {
+                if (file.size() < std::abs(_byteRange.fromInclusive) || file.size() < _byteRange.toExclusive) {
+                    _result = ResourceRequest::InvalidByteRange;
+                } else {
+                    // we have a byte range to handle
+                    if (_byteRange.fromInclusive > 0) {
+                        // this is a positive byte range, simply skip to that part of the file and read from there
+                        file.seek(_byteRange.fromInclusive);
+                        _data = file.read(_byteRange.size());
+                    } else {
+                        // this is a negative byte range, we'll need to grab data from the end of the file first
+                        file.seek(file.size() + _byteRange.fromInclusive);
+                        _data = file.read(-_byteRange.fromInclusive);
+
+                        if (_byteRange.toExclusive > 0) {
+                            // there is additional data to read from the front of the file
+                            // handle that now
+                            file.seek(0);
+                            _data.append(file.read(_byteRange.toExclusive));
+                        }
+                    }
+                }
+
+            }
+
             _result = ResourceRequest::Success;
         } else {
             _result = ResourceRequest::AccessDenied;

--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -132,7 +132,6 @@ void HTTPResourceRequest::onRequestFinished() {
                     uint64_t size;
                     std::tie(success, size) = parseContentRangeHeader(contentRangeHeader);
                     if (success) {
-                        //qWarning(networking) << "Total http resource size is: " << size;
                         _totalSizeOfResource = size;
                     } else {
                         qWarning(networking) << "Error parsing content-range header: " << contentRangeHeader;

--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -22,7 +22,6 @@
 #include "NetworkLogging.h"
 
 HTTPResourceRequest::~HTTPResourceRequest() {
-    qDebug() << "Cleaning up:" << _url << " " << _byteRange.fromInclusive << "-" << _byteRange.toExclusive;
     if (_reply) {
         _reply->disconnect(this);
         _reply->deleteLater();
@@ -68,7 +67,6 @@ void HTTPResourceRequest::doSend() {
             // HTTP byte ranges are inclusive on the `to` end: [from, to]
             byteRange = QString("bytes=%1-%2").arg(_byteRange.fromInclusive).arg(_byteRange.toExclusive - 1);
         }
-        qDebug() << "Setting http range to " << byteRange;
         networkRequest.setRawHeader("Range", byteRange.toLatin1());
     }
     networkRequest.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, false);
@@ -79,12 +77,9 @@ void HTTPResourceRequest::doSend() {
     connect(_reply, &QNetworkReply::downloadProgress, this, &HTTPResourceRequest::onDownloadProgress);
 
     setupTimer();
-    qDebug() << "Sent: " << _url;
 }
 
 void HTTPResourceRequest::onRequestFinished() {
-    qDebug() << "On request finished: " << _url;
-
     Q_ASSERT(_state == InProgress);
     Q_ASSERT(_reply);
 

--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -71,7 +71,7 @@ void HTTPResourceRequest::doSend() {
         qDebug() << "Setting http range to " << byteRange;
         networkRequest.setRawHeader("Range", byteRange.toLatin1());
     }
-    networkRequest.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
+    networkRequest.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, false);
 
     _reply = NetworkAccessManager::getInstance().get(networkRequest);
     

--- a/libraries/networking/src/NetworkAccessManager.cpp
+++ b/libraries/networking/src/NetworkAccessManager.cpp
@@ -19,14 +19,7 @@ QThreadStorage<QNetworkAccessManager*> networkAccessManagers;
 
 QNetworkAccessManager& NetworkAccessManager::getInstance() {
     if (!networkAccessManagers.hasLocalData()) {
-        auto nm = new QNetworkAccessManager();
-        networkAccessManagers.setLocalData(nm);
-
-        QNetworkProxy proxy;
-        proxy.setType(QNetworkProxy::HttpProxy);
-        proxy.setHostName("127.0.0.1");
-        proxy.setPort(8888);
-        nm->setProxy(proxy);
+        networkAccessManagers.setLocalData(new QNetworkAccessManager());
     }
     
     return *networkAccessManagers.localData();

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -555,6 +555,10 @@ void Resource::clearLoadPriority(const QPointer<QObject>& owner) {
 }
 
 float Resource::getLoadPriority() {
+    if (_loadPriorities.size() == 0) {
+        return 0;
+    }
+
     float highestPriority = -FLT_MAX;
     for (QHash<QPointer<QObject>, float>::iterator it = _loadPriorities.begin(); it != _loadPriorities.end(); ) {
         if (it.key().isNull()) {

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -667,7 +667,6 @@ void Resource::makeRequest() {
     }
 
     PROFILE_ASYNC_BEGIN(resource, "Resource:" + getType(), QString::number(_requestID), { { "url", _url.toString() }, { "activeURL", _activeUrl.toString() } });
-    qDebug() << "Making request to " << _url << " for byte range " << _requestByteRange.fromInclusive << "-" << _requestByteRange.toExclusive;
 
     _request = ResourceManager::createResourceRequest(this, _activeUrl);
 
@@ -700,7 +699,6 @@ void Resource::handleDownloadProgress(uint64_t bytesReceived, uint64_t bytesTota
 }
 
 void Resource::handleReplyFinished() {
-    qDebug() << "Got response for " << _activeUrl;
     Q_ASSERT_X(_request, "Resource::handleReplyFinished", "Request should not be null while in handleReplyFinished");
 
     PROFILE_ASYNC_END(resource, "Resource:" + getType(), QString::number(_requestID), {

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -643,12 +643,12 @@ void Resource::attemptRequest() {
 void Resource::finishedLoading(bool success) {
     if (success) {
         qCDebug(networking).noquote() << "Finished loading:" << _url.toDisplayString();
+        _loadPriorities.clear();
         _loaded = true;
     } else {
         qCDebug(networking).noquote() << "Failed to load:" << _url.toDisplayString();
         _failedToLoad = true;
     }
-    _loadPriorities.clear();
     emit finished(success);
 }
 

--- a/libraries/networking/src/ResourceRequest.h
+++ b/libraries/networking/src/ResourceRequest.h
@@ -37,6 +37,7 @@ public:
         Timeout,
         ServerUnavailable,
         AccessDenied,
+        InvalidByteRange,
         InvalidURL,
         NotFound
     };

--- a/libraries/networking/src/ResourceRequest.h
+++ b/libraries/networking/src/ResourceRequest.h
@@ -17,12 +17,7 @@
 
 #include <cstdint>
 
-struct ByteRange {
-    int64_t fromInclusive { 0 };
-    int64_t toExclusive { 0 };
-
-    bool isSet() { return fromInclusive < 0 || fromInclusive < toExclusive; }
-};
+#include "ByteRange.h"
 
 class ResourceRequest : public QObject {
     Q_OBJECT

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -64,7 +64,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AssetGetInfo:
         case PacketType::AssetGet:
         case PacketType::AssetUpload:
-            return static_cast<PacketVersion>(AssetServerPacketVersion::VegasCongestionControl);
+            return static_cast<PacketVersion>(AssetServerPacketVersion::RangeRequestSupport);
         case PacketType::NodeIgnoreRequest:
             return 18; // Introduction of node ignore request (which replaced an unused packet tpye)
 

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -214,7 +214,8 @@ enum class EntityQueryPacketVersion: PacketVersion {
 };
 
 enum class AssetServerPacketVersion: PacketVersion {
-    VegasCongestionControl = 19
+    VegasCongestionControl = 19,
+    RangeRequestSupport
 };
 
 enum class AvatarMixerPacketVersion : PacketVersion {

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -118,7 +118,7 @@ void MeshPartPayload::drawCall(gpu::Batch& batch) const {
     batch.drawIndexed(gpu::TRIANGLES, _drawPart._numIndices, _drawPart._startIndex);
 }
 
-void MeshPartPayload::bindMesh(gpu::Batch& batch) const {
+void MeshPartPayload::bindMesh(gpu::Batch& batch) {
     batch.setIndexBuffer(gpu::UINT32, (_drawMesh->getIndexBuffer()._buffer), 0);
 
     batch.setInputFormat((_drawMesh->getVertexFormat()));
@@ -255,7 +255,7 @@ void MeshPartPayload::bindTransform(gpu::Batch& batch, const ShapePipeline::Loca
 }
 
 
-void MeshPartPayload::render(RenderArgs* args) const {
+void MeshPartPayload::render(RenderArgs* args) {
     PerformanceTimer perfTimer("MeshPartPayload::render");
 
     gpu::Batch& batch = *(args->_batch);
@@ -485,7 +485,7 @@ ShapeKey ModelMeshPartPayload::getShapeKey() const {
     return builder.build();
 }
 
-void ModelMeshPartPayload::bindMesh(gpu::Batch& batch) const {
+void ModelMeshPartPayload::bindMesh(gpu::Batch& batch) {
     if (!_isBlendShaped) {
         batch.setIndexBuffer(gpu::UINT32, (_drawMesh->getIndexBuffer()._buffer), 0);
 
@@ -517,7 +517,7 @@ void ModelMeshPartPayload::bindTransform(gpu::Batch& batch, const ShapePipeline:
     batch.setModelTransform(_transform);
 }
 
-float ModelMeshPartPayload::computeFadeAlpha() const {
+float ModelMeshPartPayload::computeFadeAlpha() {
     if (_fadeState == FADE_WAITING_TO_START) {
         return 0.0f;
     }
@@ -536,7 +536,7 @@ float ModelMeshPartPayload::computeFadeAlpha() const {
     return Interpolate::simpleNonLinearBlend(fadeAlpha);
 }
 
-void ModelMeshPartPayload::render(RenderArgs* args) const {
+void ModelMeshPartPayload::render(RenderArgs* args) {
     PerformanceTimer perfTimer("ModelMeshPartPayload::render");
 
     if (!_model->addedToScene() || !_model->isVisible()) {
@@ -544,7 +544,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     }
 
     if (_fadeState == FADE_WAITING_TO_START) {
-        if (_model->isLoaded() && _model->getGeometry()->areTexturesLoaded()) {
+        if (_model->isLoaded()) {
             if (EntityItem::getEntitiesShouldFadeFunction()()) {
                 _fadeStartTime = usecTimestampNow();
                 _fadeState = FADE_IN_PROGRESS;
@@ -555,6 +555,12 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
         } else {
             return;
         }
+    }
+
+    if (_materialNeedsUpdate && _model->getGeometry()->areTexturesLoaded()) {
+        qDebug() << "Updating for textures";
+        _model->setRenderItemsNeedUpdate();
+        _materialNeedsUpdate = false;
     }
 
     if (!args) {

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -544,7 +544,6 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     }
 
     if (_fadeState == FADE_WAITING_TO_START) {
-        //if (_model->isLoaded() && _model->getGeometry()->areTexturesLoaded()) {
         if (_model->isLoaded()) {
             if (EntityItem::getEntitiesShouldFadeFunction()()) {
                 _fadeStartTime = usecTimestampNow();

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -544,7 +544,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) const {
     }
 
     if (_fadeState == FADE_WAITING_TO_START) {
-        if (_model->isLoaded()) {
+        if (_model->isLoaded() && _model->getGeometry()->areTexturesLoaded()) {
             if (EntityItem::getEntitiesShouldFadeFunction()()) {
                 _fadeStartTime = usecTimestampNow();
                 _fadeState = FADE_IN_PROGRESS;

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -558,7 +558,6 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
     }
 
     if (_materialNeedsUpdate && _model->getGeometry()->areTexturesLoaded()) {
-        qDebug() << "Updating for textures";
         _model->setRenderItemsNeedUpdate();
         _materialNeedsUpdate = false;
     }

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -46,11 +46,11 @@ public:
     virtual render::ItemKey getKey() const;
     virtual render::Item::Bound getBound() const;
     virtual render::ShapeKey getShapeKey() const; // shape interface
-    virtual void render(RenderArgs* args) const;
+    virtual void render(RenderArgs* args);
 
     // ModelMeshPartPayload functions to perform render
     void drawCall(gpu::Batch& batch) const;
-    virtual void bindMesh(gpu::Batch& batch) const;
+    virtual void bindMesh(gpu::Batch& batch);
     virtual void bindMaterial(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, bool enableTextures) const;
     virtual void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const;
 
@@ -93,16 +93,16 @@ public:
             const Transform& boundTransform,
             const gpu::BufferPointer& buffer);
 
-    float computeFadeAlpha() const;
+    float computeFadeAlpha();
 
     // Render Item interface
     render::ItemKey getKey() const override;
     int getLayer() const;
     render::ShapeKey getShapeKey() const override; // shape interface
-    void render(RenderArgs* args) const override;
+    void render(RenderArgs* args) override;
 
     // ModelMeshPartPayload functions to perform render
-    void bindMesh(gpu::Batch& batch) const override;
+    void bindMesh(gpu::Batch& batch) override;
     void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const override;
 
     void initCache();
@@ -116,11 +116,12 @@ public:
     int _shapeID;
 
     bool _isSkinned{ false };
-    bool _isBlendShaped{ false };
+    bool _isBlendShaped { false };
+    bool _materialNeedsUpdate { true };
 
 private:
-    mutable quint64 _fadeStartTime { 0 };
-    mutable uint8_t _fadeState { FADE_WAITING_TO_START };
+    quint64 _fadeStartTime { 0 };
+    uint8_t _fadeState { FADE_WAITING_TO_START };
 };
 
 namespace render {

--- a/libraries/shared/src/shared/Storage.cpp
+++ b/libraries/shared/src/shared/Storage.cpp
@@ -67,10 +67,8 @@ StoragePointer FileStorage::create(const QString& filename, size_t size, const u
     return std::make_shared<FileStorage>(filename);
 }
 
-// Represents a memory mapped file
 FileStorage::FileStorage(const QString& filename) : _file(filename) {
     if (_file.open(QFile::ReadWrite)) {
-        //qDebug() << ">>> Opening mmapped file: " << filename;
         _mapped = _file.map(0, _file.size());
         if (_mapped) {
             _valid = true;
@@ -83,7 +81,6 @@ FileStorage::FileStorage(const QString& filename) : _file(filename) {
 }
 
 FileStorage::~FileStorage() {
-    //qDebug() << ">>> Closing mmapped file: " << _file.fileName();
     if (_mapped) {
         if (!_file.unmap(_mapped)) {
             throw std::runtime_error("Unable to unmap file");

--- a/libraries/shared/src/shared/Storage.h
+++ b/libraries/shared/src/shared/Storage.h
@@ -43,7 +43,7 @@ namespace storage {
         MemoryStorage(size_t size, const uint8_t* data = nullptr);
         const uint8_t* data() const override { return _data.data(); }
         uint8_t* data() { return _data.data(); }
-        uint8_t* mutableData() override { return 0; }
+        uint8_t* mutableData() override { return _data.data(); }
         size_t size() const override { return _data.size(); }
         operator bool() const override { return true; }
     private:
@@ -73,7 +73,7 @@ namespace storage {
     public:
         ViewStorage(const storage::StoragePointer& owner, size_t size, const uint8_t* data);
         const uint8_t* data() const override { return _data; }
-        uint8_t* mutableData() override { return 0; }
+        uint8_t* mutableData() override { throw std::runtime_error("Cannot modify ViewStorage");  }
         size_t size() const override { return _size; }
         operator bool() const override { return *_owner; }
     private:

--- a/tests/render-texture-load/CMakeLists.txt
+++ b/tests/render-texture-load/CMakeLists.txt
@@ -10,7 +10,7 @@ setup_hifi_project(Quick Gui OpenGL)
 set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Tests/manual-tests/")
 
 # link in the shared libraries
-link_hifi_libraries(shared octree gl gpu gpu-gl render model model-networking networking render-utils fbx entities entities-renderer animation audio avatars script-engine physics image)
+link_hifi_libraries(shared octree gl gpu gpu-gl render model model-networking networking render-utils fbx entities entities-renderer animation audio avatars script-engine physics ktx image)
 
 package_libraries_for_deployment()
 


### PR DESCRIPTION
### Test Plan

This PR changes Interface texture loading to add support for progressive downloading of KTX textures from HTTP/ATP/File. The test plan will first ensure that existing domain content loads as it did before and then will test the progessive download of models with external KTX textures.

Before each test, please clear your KTX cache and Interface cache. This will ensure that the results of a previous test are not interfering. The easiest way to ensure that these caches are completely cleared is by deleting the `data8` and `ktx_cache` folders in your `%APPDATA%/Local/High Fidelity/Interface` folder.

#### Existing Content

For this test you will need to use the Sandbox included with this PR, because there is a packet version change to the Asset Server packets. You will be unable to connect to existing domains with this PR.

- Connect to the Sandbox of this PR and ensure that the default Sandbox content, or whatever content you choose to load in the Sandbox, loads as you would expect.
    - This means that all content downloads eventually complete or fail appropriately (if linking to missing content), and all textures appear correctly as they do on master or stable builds. 
    - It may be easiest to compare to a dev-download or stable Sandbox, assuming that you also have the default content present in that Sandbox.

#### Baked Content

For this test you will need an entities file for a baked domain. Contact me for one.

This entities file is a baked version of one of our domains and has models that reference baked compressed KTX textures. Stop your Sandbox and change your Sandbox entities file for this file. Restart your Sandbox and connect to it with a clean cache.

- Textures should load progressively, meaning that you should see low resolution textures shown on the models first before later seeing progressively higher resolution textures once they have downloaded.
- The skybox texture should load progressively in the same manner.
- All textures on all models in the domain should appear as you expect. You may need to use master or stable to connect to BAKED_DOMAIN to confirm that it looks the same.
- Compare a clean cache load time using this PR in your Sandbox with the baked content, and using master or stable in BAKED_DOMAIN. Though subjective, this PR should provide a more pleasing loading experience, meaning that you should get a noticeably faster sense of what is around you in the domain with this PR.

#### ATP/File KTX Textures

[Baked model](https://hifi-content.s3.amazonaws.com/clement/dev/ez-tube.zip)

This compressed folder contains a single baked model.

- Using this compressed folder, add this model and KTX texture to ATP.
    - You can drag and drop the `.ktx` texture and then the `.baked.fbx` model onto your Interface to upload it to your Asset Server. 
- Add the `.baked.fbx` model to your domain and confirm that it loads with its texture over ATP. You should see the model load and notice the same progressive loading described in the 'Baked Content' section. 
- Add the `.baked.fbx` model to your domain, referencing it on the local file system with a `file:\\\` URL. Ensure that the `.ktx` texture file is present beside the model. You should see the model load and notice the same progressive loading described in the 'Baked Content' section.