### PR TITLE
Fix entity script unloads

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -481,14 +481,14 @@ void EntityScriptServer::deletingEntity(const EntityItemID& entityID) {
     }
 }
 
-void EntityScriptServer::entityServerScriptChanging(const EntityItemID& entityID, const bool reload) {
+void EntityScriptServer::entityServerScriptChanging(const EntityItemID& entityID, bool reload) {
     if (_entityViewer.getTree() && !_shuttingDown) {
         _entitiesScriptEngine->unloadEntityScript(entityID, true);
         checkAndCallPreload(entityID, reload);
     }
 }
 
-void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, const bool reload) {
+void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, bool reload) {
     if (_entityViewer.getTree() && !_shuttingDown && _entitiesScriptEngine) {
 
         EntityItemPointer entity = _entityViewer.getTree()->findEntityByEntityItemID(entityID);

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -67,8 +67,8 @@ private:
 
     void addingEntity(const EntityItemID& entityID);
     void deletingEntity(const EntityItemID& entityID);
-    void entityServerScriptChanging(const EntityItemID& entityID, const bool reload);
-    void checkAndCallPreload(const EntityItemID& entityID, const bool reload = false);
+    void entityServerScriptChanging(const EntityItemID& entityID, bool reload);
+    void checkAndCallPreload(const EntityItemID& entityID, bool reload = false);
 
     void cleanupOldKilledListeners();
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1015,11 +1015,11 @@ void EntityTreeRenderer::addEntityToScene(EntityItemPointer entity) {
 }
 
 
-void EntityTreeRenderer::entityScriptChanging(const EntityItemID& entityID, const bool reload) {
+void EntityTreeRenderer::entityScriptChanging(const EntityItemID& entityID, bool reload) {
     checkAndCallPreload(entityID, reload, true);
 }
 
-void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, const bool reload, const bool unloadFirst) {
+void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, bool reload, bool unloadFirst) {
     if (_tree && !_shuttingDown) {
         EntityItemPointer entity = getTree()->findEntityByEntityItemID(entityID);
         if (!entity) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1027,11 +1027,11 @@ void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, bool 
         }
         bool shouldLoad = entity->shouldPreloadScript() && _entitiesScriptEngine;
         QString scriptUrl = entity->getScript();
-        if (shouldLoad && (unloadFirst || scriptUrl.isEmpty())) {
+        if ((shouldLoad && unloadFirst) || scriptUrl.isEmpty()) {
             _entitiesScriptEngine->unloadEntityScript(entityID);
             entity->scriptHasUnloaded();
         }
-        if (shouldLoad && !scriptUrl.isEmpty()) {
+        if (shouldLoad) {
             scriptUrl = ResourceManager::normalizeURL(scriptUrl);
             _entitiesScriptEngine->loadEntityScript(entityID, scriptUrl, reload);
             entity->scriptHasPreloaded();

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -152,7 +152,7 @@ private:
     bool applySkyboxAndHasAmbient();
     bool applyLayeredZones();
 
-    void checkAndCallPreload(const EntityItemID& entityID, const bool reload = false, const bool unloadFirst = false);
+    void checkAndCallPreload(const EntityItemID& entityID, bool reload = false, bool unloadFirst = false);
 
     QList<ModelPointer> _releasedModels;
     RayToEntityIntersectionResult findRayIntersectionWorker(const PickRay& ray, Octree::lockType lockType,


### PR DESCRIPTION
Make sure entity scripts unload when the field is cleared.

## Test Plan:
- Create Entity
- Add the script bellow to the entity
- Click on the entity
- Clear the script URL field
- Click on the entity

You should notice the script unloading and no longer responding to click event in the log contrarily to master.

```js
(function() {
    this.preload = function() {
        print(">>>> Preload <<<<");
        Controller.mousePressEvent.connect(this.mousePressEvent);
    }
    this.unload = function() {
        print(">>>> Unload <<<<");
        Controller.mousePressEvent.disconnect(this.mousePressEvent);
    }
    this.mousePressEvent = function() {
        print(">>>> Still running. <<<<");
    };
})
```

[Bug](https://highfidelity.fogbugz.com/f/cases/2932/Sometimes-entity-client-scripts-aren-t-stopped-after-the-script-url-is-removed)