### PR TITLE
add support for ignore radius from agent scripts

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -31,6 +31,7 @@
 #include <ScriptCache.h>
 #include <ScriptEngines.h>
 #include <SoundCache.h>
+#include <UsersScriptingInterface.h>
 #include <UUID.h>
 
 #include <recording/ClipCache.h>
@@ -75,6 +76,8 @@ Agent::Agent(ReceivedMessage& message) :
     DependencyManager::set<ScriptEngines>(ScriptEngine::AGENT_SCRIPT);
 
     DependencyManager::set<RecordingScriptingInterface>();
+    DependencyManager::set<UsersScriptingInterface>();
+
 
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
 
@@ -350,6 +353,10 @@ void Agent::executeScript() {
 
     // give this AvatarData object to the script engine
     _scriptEngine->registerGlobalObject("Avatar", scriptedAvatar.data());
+
+    // give scripts access to the Users object
+    _scriptEngine->registerGlobalObject("Users", DependencyManager::get<UsersScriptingInterface>().data());
+
 
     auto player = DependencyManager::get<recording::Deck>();
     connect(player.data(), &recording::Deck::playbackStateChanged, [=] {

--- a/script-archive/acScripts/BetterClientSimulationBotFromRecording.js
+++ b/script-archive/acScripts/BetterClientSimulationBotFromRecording.js
@@ -126,6 +126,8 @@ Vec3.print("RANDOM LOCATION SELECTED:", LOCATION);
 var playFromCurrentLocation = true;
 var loop = true;
 
+// Disable the privacy bubble
+Users.disableIgnoreRadius();
 
 // Set position here if playFromCurrentLocation is true
 Avatar.position = LOCATION;

--- a/script-archive/acScripts/PlayRecordingOnAC.js
+++ b/script-archive/acScripts/PlayRecordingOnAC.js
@@ -20,6 +20,9 @@ Avatar.orientation = Quat.fromPitchYawRollDegrees(0, 0, 0);
 Avatar.scale = 1.0;
 Agent.isAvatar = true;
 
+// Disable the privacy bubble
+Users.disableIgnoreRadius();
+
 Recording.loadRecording(recordingFile, function(success) {
     if (success) {
         Script.update.connect(update);


### PR DESCRIPTION
**Test plan:**
- Run this version of the sandbox
- In domain settings page -- add the following script to your scripts list: https://raw.githubusercontent.com/ZappoMan/hifi/8dc41ca8b9ed812a297fac86281c5f7ee595f85d/script-archive/acScripts/BetterClientSimulationBotFromRecording.js
- Go to the domain, and go to approximately 105,0,30 and look in the direction of ~-160 yaw... you should see a random bot running...
- Approach the bot... you should be able to get close to it without it disappearing.
- If you compare this to Master and the following script: https://raw.githubusercontent.com/highfidelity/hifi/master/script-archive/acScripts/BetterClientSimulationBotFromRecording.js you will notice that as you approach the bot, the space bubble engages and the bot disappears.