### PR TITLE
Build 37.2 Hotfix to fix a crash with texture loading and Qt build 5.6.2

### DIFF
--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -559,9 +559,12 @@ void ImageReader::read() {
         // Load the image into a gpu::Texture
         auto networkTexture = resource.staticCast<NetworkTexture>();
         texture.reset(networkTexture->getTextureLoader()(image, url));
-        texture->setSource(url);
         if (texture) {
+            texture->setSource(url);
             texture->setFallbackTexture(networkTexture->getFallbackTexture());
+        } else {
+            qCDebug(modelnetworking) << _url << "loading stopped; texture wasn't created";
+            return;
         }
 
         auto textureCache = DependencyManager::get<TextureCache>();


### PR DESCRIPTION
 - Fix to crash caused by image loading