### PR TITLE
Reduce log spam

### DIFF
--- a/scripts/tutorials/halfDuplex.js
+++ b/scripts/tutorials/halfDuplex.js
@@ -34,13 +34,15 @@ Script.update.connect(function () {
     var avatars = AvatarList.getAvatarIdentifiers();
     avatars.forEach(function (id) {
         var avatar = AvatarList.getAvatar(id);
-        if ((MyAvatar.sessionUUID !== avatar.sessionUUID) && (avatar.displayName.indexOf(MICROPHONE_DISPLAY_NAME) !== 0)) {
-            othersLoudness += Math.round(avatar.audioLoudness); 
-        }
-        //  Mute other microphone avatars to not feedback with muti-source environment
-        if (avatar.displayName.indexOf(MICROPHONE_DISPLAY_NAME) === 0) {
-            if (!Users.getPersonalMuteStatus(avatar.sessionUUID)) {
-                Users.personalMute(avatar.sessionUUID, true);
+        if (MyAvatar.sessionUUID !== avatar.sessionUUID) {
+            if (avatar.displayName.indexOf(MICROPHONE_DISPLAY_NAME) !== 0) {
+                othersLoudness += Math.round(avatar.audioLoudness); 
+            }
+            //  Mute other microphone avatars to not feedback with muti-source environment
+            if (avatar.displayName.indexOf(MICROPHONE_DISPLAY_NAME) === 0) {
+                if (!Users.getPersonalMuteStatus(avatar.sessionUUID)) {
+                    Users.personalMute(avatar.sessionUUID, true);
+                }
             }
         }
     });


### PR DESCRIPTION
Turns out calling getPersonalMuteStatus on yourself creates log spam.  

Test plan:  Gotta be done by a Hifi person at Langton - test if the Kitchen setup (with two laptops with mics) is working without feedback when a third person talks.  

There should be no log spam. 