### PR TITLE
Fix for resource downloads getting capped

### DIFF
--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -324,11 +324,11 @@ public:
         void reset() override { }
 
     protected:
-        std::shared_ptr<storage::FileStorage> maybeOpenFile();
+        std::shared_ptr<storage::FileStorage> maybeOpenFile() const;
 
-        std::mutex _cacheFileCreateMutex;
-        std::mutex _cacheFileWriteMutex;
-        std::weak_ptr<storage::FileStorage> _cacheFile;
+        mutable std::mutex _cacheFileCreateMutex;
+        mutable std::mutex _cacheFileWriteMutex;
+        mutable std::weak_ptr<storage::FileStorage> _cacheFile;
 
         std::string _filename;
         std::atomic<uint8_t> _minMipLevelAvailable;

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -128,7 +128,7 @@ KtxStorage::KtxStorage(const std::string& filename) : _filename(filename) {
     }
 }
 
-std::shared_ptr<storage::FileStorage> KtxStorage::maybeOpenFile() {
+std::shared_ptr<storage::FileStorage> KtxStorage::maybeOpenFile() const {
     std::shared_ptr<storage::FileStorage> file = _cacheFile.lock();
     if (file) {
         return file;
@@ -154,7 +154,8 @@ PixelsPointer KtxStorage::getMipFace(uint16 level, uint8 face) const {
     auto faceOffset = _ktxDescriptor->getMipFaceTexelsOffset(level, face);
     auto faceSize = _ktxDescriptor->getMipFaceTexelsSize(level, face);
     if (faceSize != 0 && faceOffset != 0) {
-        result = std::make_shared<storage::FileStorage>(_filename.c_str())->createView(faceSize, faceOffset)->toMemoryStorage();
+        auto file = maybeOpenFile();
+        result = file->createView(faceSize, faceOffset)->toMemoryStorage();
     }
     return result;
 }

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -330,6 +330,22 @@ private:
     int _maxNumPixels;
 };
 
+NetworkTexture::~NetworkTexture() {
+    if (_ktxHeaderRequest || _ktxMipRequest) {
+        if (_ktxHeaderRequest) {
+            _ktxHeaderRequest->disconnect(this);
+            _ktxHeaderRequest->deleteLater();
+            _ktxHeaderRequest = nullptr;
+        }
+        if (_ktxMipRequest) {
+            _ktxMipRequest->disconnect(this);
+            _ktxMipRequest->deleteLater();
+            _ktxMipRequest = nullptr;
+        }
+        ResourceCache::requestCompleted(_self);
+    }
+}
+
 const uint16_t NetworkTexture::NULL_MIP_LEVEL = std::numeric_limits<uint16_t>::max();
 void NetworkTexture::makeRequest() {
     if (!_sourceIsKTX) {

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -394,12 +394,17 @@ void NetworkTexture::startRequestForNextMipLevel() {
     }
 
     if (_ktxResourceState == WAITING_FOR_MIP_REQUEST) {
+        auto self = _self.lock();
+        if (!self) {
+            return;
+        }
+
         _ktxResourceState = PENDING_MIP_REQUEST;
 
         init();
         setLoadPriority(this, -static_cast<int>(_originalKtxDescriptor->header.numberOfMipmapLevels) + _lowestKnownPopulatedMip);
         _url.setFragment(QString::number(_lowestKnownPopulatedMip - 1));
-        TextureCache::attemptRequest(_self);
+        TextureCache::attemptRequest(self);
     }
 }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -342,7 +342,7 @@ NetworkTexture::~NetworkTexture() {
             _ktxMipRequest->deleteLater();
             _ktxMipRequest = nullptr;
         }
-        ResourceCache::requestCompleted(_self);
+        TextureCache::requestCompleted(_self);
     }
 }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -473,19 +473,16 @@ void NetworkTexture::ktxMipRequestFinished() {
                 texture->assignStoredMip(_ktxMipLevelRangeInFlight.first,
                     _ktxMipRequest->getData().size(), reinterpret_cast<uint8_t*>(_ktxMipRequest->getData().data()));
                 _lowestKnownPopulatedMip = _textureSource->getGPUTexture()->minAvailableMipLevel();
-            }
-            else {
+            } else {
                 qWarning(networking) << "Trying to update mips but texture is null";
             }
             finishedLoading(true);
             _ktxResourceState = WAITING_FOR_MIP_REQUEST;
-        }
-        else {
+        } else {
             finishedLoading(false);
             if (handleFailedRequest(_ktxMipRequest->getResult())) {
                 _ktxResourceState = PENDING_MIP_REQUEST;
-            }
-            else {
+            } else {
                 qWarning(networking) << "Failed to load mip: " << _url;
                 _ktxResourceState = FAILED_TO_LOAD;
             }
@@ -497,8 +494,7 @@ void NetworkTexture::ktxMipRequestFinished() {
         if (_ktxResourceState == WAITING_FOR_MIP_REQUEST && _lowestRequestedMipLevel < _lowestKnownPopulatedMip) {
             startRequestForNextMipLevel();
         }
-    }
-    else {
+    } else {
         qWarning() << "Mip request finished in an unexpected state: " << _ktxResourceState;
     }
 }

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -46,6 +46,7 @@ class NetworkTexture : public Resource, public Texture {
 
 public:
     NetworkTexture(const QUrl& url, image::TextureUsage::Type type, const QByteArray& content, int maxNumPixels);
+    ~NetworkTexture() override;
 
     QString getType() const override { return "NetworkTexture"; }
 

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -344,7 +344,7 @@ class Resource : public QObject {
 public:
     
     Resource(const QUrl& url);
-    ~Resource();
+    virtual ~Resource();
 
     virtual QString getType() const { return "Resource"; }
     


### PR DESCRIPTION
This fixes a few bugs:

 * ResourceCache max downloads getting capped below 16
 * GPU access of ktx file not being thread-safe
 * NetworkTexture not checking if _self is null (no references) when requesting a lower mip

All of these revolve around loading KTX files and switching between domains while downloading/loading them.
