### PR TITLE
don't save ATP range requests to cache

### DIFF
--- a/libraries/networking/src/AssetRequest.cpp
+++ b/libraries/networking/src/AssetRequest.cpp
@@ -113,8 +113,10 @@ void AssetRequest::start() {
                 _data = data;
                 _totalReceived += data.size();
                 emit progress(_totalReceived, data.size());
-                
-                saveToCache(getUrl(), data);
+
+                if (!_byteRange.isSet()) {
+                    saveToCache(getUrl(), data);
+                }
             }
         }
         


### PR DESCRIPTION
- fixed a bug caching ATP range requests as if they were the full file