### PR TITLE
fix frozen bots

### DIFF
--- a/libraries/recording/src/recording/Deck.cpp
+++ b/libraries/recording/src/recording/Deck.cpp
@@ -167,7 +167,7 @@ void Deck::processFrames() {
         auto nextFrameTime = nextClip->positionFrameTime();
         nextInterval = (int)Frame::frameTimeToMilliseconds(nextFrameTime - _position);
         if (nextInterval < 0) {
-            qCWarning(recordingLog) << " Unexected nextInterval < 0 nextFrameTime:" << nextFrameTime 
+            qCWarning(recordingLog) << "Unexpected nextInterval < 0 nextFrameTime:" << nextFrameTime 
                                     << "_position:" << _position << "-- setting nextInterval to 0";
             nextInterval = 0;
         }

--- a/libraries/recording/src/recording/Deck.cpp
+++ b/libraries/recording/src/recording/Deck.cpp
@@ -166,6 +166,12 @@ void Deck::processFrames() {
     if (!overLimit) {
         auto nextFrameTime = nextClip->positionFrameTime();
         nextInterval = (int)Frame::frameTimeToMilliseconds(nextFrameTime - _position);
+        if (nextInterval < 0) {
+            qCWarning(recordingLog) << " Unexected nextInterval < 0 nextFrameTime:" << nextFrameTime 
+                                    << "_position:" << _position << "-- setting nextInterval to 0";
+            nextInterval = 0;
+        }
+
 #ifdef WANT_RECORDING_DEBUG
         qCDebug(recordingLog) << "Now " << _position;
         qCDebug(recordingLog) << "Next frame time " << nextInterval;


### PR DESCRIPTION
after much debugging - I found the root cause of frozen bots... there was a subtle bug in our recording playback that would sometimes cause the frame timer to be set for an infinite time in the future.

Test plan:
- verify recording playback works without freezing. (note: freezing was random, but Anshuman has some tips on how to repro this)