### PR TITLE
Prevent possible crash in texture buffering thread

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.h
@@ -86,7 +86,8 @@ public:
         void transfer();
     };
 
-    using TransferQueue = std::queue<std::unique_ptr<TransferJob>>;
+    using TransferJobPointer = std::shared_ptr<TransferJob>;
+    using TransferQueue = std::queue<TransferJobPointer>;
     static MemoryPressureState _memoryPressureState;
 
 public:
@@ -100,6 +101,7 @@ protected:
     static WorkQueue _promoteQueue;
     static WorkQueue _demoteQueue;
     static TexturePointer _currentTransferTexture;
+    static TransferJobPointer _currentTransferJob;
     static const uvec3 INITIAL_MIP_TRANSFER_DIMENSIONS;
     static const uvec3 MAX_TRANSFER_DIMENSIONS;
     static const size_t MAX_TRANSFER_SIZE;


### PR DESCRIPTION
Transfer jobs are transient objects each holding lambdas to do two things... buffer data from a `gpu::Texture` object into local memory and then transfer that buffered data to the GPU.  Because the buffering may invoke disk IO, it's done asynchronously on a separate thread from the renderer.

However, the rendering thread may decide it needs to rebuild the queue of transfer jobs for a given texture because it's memory footprint has changed.  Because of this, in the current codebase, a TransferJob may be destroyed even while it's buffering lambda is being executed on the buffering thread.  When this happens, the lambda ceases to be valid and can potentially lead to the crash described [here](https://highfidelity.fogbugz.com/f/cases/4504/CRASH-in-gpu-Texture-accessStoredMipFace).

This PR fixes this.  It changes the queue of transfer jobs from `unique_ptr` to `shared_ptr` and creates a separate `_currentTransferJob` static member in the variable allocation support class.  While a given transfer job is active, it is stored in the `_currentTransferJob` member so that it cannot leave scope.  

## Testing

The crash related to this PR is problematic, but difficult to reproduce at will.  It is most likely to occur when first loading content that has already been cached on disk, and is more likely to occur when disk access is slow, and when textures are being frequently promoted and demoted.  The best chance for reproducing it is to start the application and loading an existing high-texture content domain like `dev-welcome` or `dev-playa` over and over.  