### PR TITLE
Lots of Snapshot app improvements, Round One

### DIFF
--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -111,7 +111,7 @@ void setupPreferences() {
     static const QString SNAPSHOTS { "Snapshots" };
     {
         auto getter = []()->QString { return Snapshot::snapshotsLocation.get(); };
-        auto setter = [](const QString& value) { Snapshot::snapshotsLocation.set(value); };
+        auto setter = [](const QString& value) { Snapshot::snapshotsLocation.set(value); emit DependencyManager::get<Snapshot>()->snapshotLocationSet(value); };
         auto preference = new BrowsePreference(SNAPSHOTS, "Put my snapshots here", getter, setter);
         preferences->addPreference(preference);
     }

--- a/interface/src/ui/Snapshot.h
+++ b/interface/src/ui/Snapshot.h
@@ -44,6 +44,9 @@ public:
     static Setting::Handle<QString> snapshotsLocation;
     static void uploadSnapshot(const QString& filename, const QUrl& href = QUrl(""));
 
+signals:
+    void snapshotLocationSet(const QString& value);
+
 public slots:
     Q_INVOKABLE QString getSnapshotsLocation();
     Q_INVOKABLE void setSnapshotsLocation(const QString& location);

--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -82,6 +82,7 @@ input[type=button].naked:active {
     width: 100%;
     display: flex;
     justify-content: center;
+    flex-direction: column;
 }
 
 #snapshot-images img {

--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -80,6 +80,8 @@ input[type=button].naked:active {
 
 #snapshot-images {
     width: 100%;
+    display: flex;
+    justify-content: center;
 }
 
 #snapshot-images img {
@@ -119,13 +121,13 @@ input[type=button].naked:active {
 .shareButtons {
     display: flex;
     align-items: center;
-    margin-left: 30px;
+    margin-left: 15px;
     height: 100%;
-    width: 80%;
+    width: 75%;
 }
 .blastToConnections {
     text-align: left;
-    margin-right: 25px;
+    margin-right: 20px;
     height: 29px;
 }
 .shareWithEveryone {
@@ -158,10 +160,11 @@ input[type=button].naked:active {
     font-family: Raleway-SemiBold;
     font-size: 14px;
     color: white;
-    text-shadow: 2px 2px 3px #000000;
     height: 100%;
     margin-right: 10px;
-    width: 20%;
+}
+.showShareButtonsButtonDiv > label {
+    text-shadow: 2px 2px 3px #000000;
 }
 .showShareButton {
     width: 40px;
@@ -193,22 +196,16 @@ input[type=button].naked:active {
     background-color: white;
 }
 .showShareButtonDots {
-    display: flex;
-    width: 32px;
+    display: block;
+    width: 40px;
     height: 40px;
+    font-family: HiFi-Glyphs;
+    font-size: 60px;
     position: absolute;
-    top: 5px;
-    right: 14px;
+    right: 20px;
+    bottom: 15px;
+    color: #00b4ef;
     pointer-events: none;
-}
-.showShareButtonDots > span {
-    width: 10px;
-    height: 10px;
-    margin: auto;
-    background-color: #0093C5;
-    border-radius: 50%;
-    border-width: 0;
-    display: inline;
 }
 /*
 // END styling of share overlay

--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -110,7 +110,7 @@ input[type=button].naked:active {
     justify-content: space-between;
     flex-direction: row;
     align-items: center;
-    height: 50px;
+    height: 45px;
     line-height: 60px;
     width: calc(100% - 8px);
     position: absolute;
@@ -203,7 +203,7 @@ input[type=button].naked:active {
     font-size: 60px;
     position: absolute;
     right: 20px;
-    bottom: 15px;
+    bottom: 12px;
     color: #00b4ef;
     pointer-events: none;
 }

--- a/scripts/system/html/css/hifi-style.css
+++ b/scripts/system/html/css/hifi-style.css
@@ -101,9 +101,11 @@ input[type=radio] {
   opacity: 0;
 }
 input[type=radio] + label{
-  display: inline-block;
-  margin-left: -2em;
-  line-height: 2em;
+    display: inline-block;
+    margin-left: -2em;
+    line-height: 2em;
+    font-family: Raleway-SemiBold;
+    font-size: 14px;
 }
 input[type=radio] + label > span{
   display: inline-block;
@@ -157,7 +159,6 @@ input[type=radio]:active + label > span > span{
     border-width: 0px;
     background-image: linear-gradient(#00B4EF, #1080B8);
     min-height: 30px;
-
 }
 .blueButton:hover {
     background-image: linear-gradient(#00B4EF, #00B4EF);

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -83,7 +83,7 @@ function addImage(image_data, isGifLoading, canShare, isShowingPreviousImages, b
     }
     if (!isGifLoading && !isShowingPreviousImages && canShare) {
         shareForUrl(id);
-    } else if (isShowingPreviousImages && canShare) {
+    } else if (isShowingPreviousImages && canShare && image_data.story_id) {
         appendShareBar(id, image_data.story_id, isGif, blastButtonDisabled, hifiButtonDisabled)
     }
 }
@@ -241,7 +241,7 @@ function handleCaptureSetting(setting) {
 window.onload = function () {
     // Uncomment the line below to test functionality in a browser.
     // See definition of "testInBrowser()" to modify tests.
-    testInBrowser(false);
+    //testInBrowser(false);
     openEventBridge(function () {
         // Set up a handler for receiving the data, and tell the .js we are ready to receive it.
         EventBridge.scriptEventReceived.connect(function (message) {
@@ -280,18 +280,18 @@ window.onload = function () {
                     if (messageOptions.containsGif) {
                         if (messageOptions.processingGif) {
                             imageCount = message.image_data.length + 1; // "+1" for the GIF that'll finish processing soon
-                            message.image_data.unshift({ localPath: messageOptions.loadingGifPath });
+                            message.image_data.push({ localPath: messageOptions.loadingGifPath });
                             message.image_data.forEach(function (element, idx, array) {
-                                addImage(element, idx === 0, messageOptions.canShare, false);
+                                addImage(element, idx === 1, idx === 0 && messageOptions.canShare, false);
                             });
                         } else {
                             var gifPath = message.image_data[0].localPath;
-                            var p0img = document.getElementById('p0img');
-                            p0img.src = gifPath;
+                            var p1img = document.getElementById('p1img');
+                            p1img.src = gifPath;
 
-                            paths[0] = gifPath;
+                            paths[1] = gifPath;
                             if (messageOptions.canShare) {
-                                shareForUrl("p0");
+                                shareForUrl("p1");
                             }
                         }
                     } else {
@@ -306,7 +306,7 @@ window.onload = function () {
                     break;
                 case 'snapshotUploadComplete':
                     var isGif = message.image_url.split('.').pop().toLowerCase() === "gif";
-                    appendShareBar(isGif || imageCount === 1 ? "p0" : "p1", message.story_id, isGif);
+                    appendShareBar(isGif ? "p1" : "p0", message.story_id, isGif);
                     break;
                 default:
                     console.log("Unknown message action received in SnapshotReview.js.");

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -232,7 +232,7 @@ function handleCaptureSetting(setting) {
 window.onload = function () {
     // Uncomment the line below to test functionality in a browser.
     // See definition of "testInBrowser()" to modify tests.
-    testInBrowser(false);
+    //testInBrowser(false);
     openEventBridge(function () {
         // Set up a handler for receiving the data, and tell the .js we are ready to receive it.
         EventBridge.scriptEventReceived.connect(function (message) {

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -60,8 +60,9 @@ function addImage(image_data, isGifLoading, canShare, isShowingPreviousImages, b
     // imageContainer setup
     var imageContainer = document.createElement("DIV");
     imageContainer.id = id;
-    imageContainer.style.width = "100%";
-    imageContainer.style.height = "251px";
+    imageContainer.style.width = "95%";
+    imageContainer.style.height = "240px";
+    imageContainer.style.margin = "5px 0";
     imageContainer.style.display = "flex";
     imageContainer.style.justifyContent = "center";
     imageContainer.style.alignItems = "center";
@@ -118,7 +119,7 @@ function createShareBar(parentID, isGif, shareURL, blastButtonDisabled, hifiButt
             '<label id="' + showShareButtonsLabelID + '" for="' + showShareButtonsButtonID + '">SHARE</label>' +
             '<input type="button" class="showShareButton inactive" id="' + showShareButtonsButtonID + '" onclick="selectImageToShare(' + parentID + ', true)" />' +
             '<div class="showShareButtonDots">' +
-                '<span></span><span></span><span></span>' +
+                '&#xe019;' +
             '</div>' +
         '</div>';
 
@@ -231,7 +232,7 @@ function handleCaptureSetting(setting) {
 window.onload = function () {
     // Uncomment the line below to test functionality in a browser.
     // See definition of "testInBrowser()" to modify tests.
-    //testInBrowser(true);
+    testInBrowser(false);
     openEventBridge(function () {
         // Set up a handler for receiving the data, and tell the .js we are ready to receive it.
         EventBridge.scriptEventReceived.connect(function (message) {

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -62,7 +62,7 @@ function addImage(image_data, isGifLoading, canShare, isShowingPreviousImages, b
     imageContainer.id = id;
     imageContainer.style.width = "95%";
     imageContainer.style.height = "240px";
-    imageContainer.style.margin = "5px 0";
+    imageContainer.style.margin = "5px auto";
     imageContainer.style.display = "flex";
     imageContainer.style.justifyContent = "center";
     imageContainer.style.alignItems = "center";
@@ -150,6 +150,15 @@ function selectImageToShare(selectedID, isSelected) {
         shareBar.style.backgroundColor = "rgba(0, 0, 0, 0.5)";
 
         shareButtonsDiv.style.visibility = "visible";
+
+        var containers = document.getElementsByClassName("shareControls");
+        var parentID;
+        for (var i = 0; i < containers.length; ++i) {
+            parentID = containers[i].id.slice(0, 2);
+            if (parentID !== selectedID) {
+                selectImageToShare(parentID, false);
+            }
+        }
     } else {
         showShareButtonsButton.onclick = function () { selectImageToShare(selectedID, true) };
         showShareButtonsButton.classList.remove("active");
@@ -232,7 +241,7 @@ function handleCaptureSetting(setting) {
 window.onload = function () {
     // Uncomment the line below to test functionality in a browser.
     // See definition of "testInBrowser()" to modify tests.
-    //testInBrowser(false);
+    testInBrowser(false);
     openEventBridge(function () {
         // Set up a handler for receiving the data, and tell the .js we are ready to receive it.
         EventBridge.scriptEventReceived.connect(function (message) {
@@ -330,6 +339,7 @@ function testInBrowser(isTestingSetupInstructions) {
     } else {
         imageCount = 1;
         //addImage({ localPath: 'http://lorempixel.com/553/255' });
-        addImage({ localPath: 'C:/Users/valef/Desktop/hifi-snap-by-zfox-on-2017-04-26_10-26-53.gif' }, false, true, true, false, false);
+        addImage({ localPath: 'C:/Users/valef/Desktop/hifi-snap-by-zfox-on-2017-05-01_15-48-15.gif' }, false, true, true, false, false);
+        addImage({ localPath: 'C:/Users/valef/Desktop/hifi-snap-by-zfox-on-2017-05-01_15-48-15.jpg' }, false, true, true, false, false);
     }
 }

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -117,13 +117,15 @@ function onMessage(message) {
                 setting: Settings.getValue("alsoTakeAnimatedSnapshot", true)
             }));
             if (Snapshot.getSnapshotsLocation() !== "") {
-                tablet.emitScriptEvent(JSON.stringify({
-                    type: "snapshot",
-                    action: "showPreviousImages",
-                    options: snapshotOptions,
-                    image_data: imageData,
-                    canShare: !isDomainOpen(Settings.getValue("previousSnapshotDomainID"))
-                }));
+                isDomainOpen(Settings.getValue("previousSnapshotDomainID"), function (canShare) {
+                    tablet.emitScriptEvent(JSON.stringify({
+                        type: "snapshot",
+                        action: "showPreviousImages",
+                        options: snapshotOptions,
+                        image_data: imageData,
+                        canShare: canShare
+                    }));
+                });                
             } else {
                 tablet.emitScriptEvent(JSON.stringify({
                     type: "snapshot",
@@ -131,10 +133,12 @@ function onMessage(message) {
                 }));
                 Settings.setValue("previousStillSnapPath", "");
                 Settings.setValue("previousStillSnapStoryID", "");
-                Settings.setValue("previousStillSnapSharingDisabled", false);
+                Settings.setValue("previousStillSnapBlastingDisabled", false);
+                Settings.setValue("previousStillSnapHifiSharingDisabled", false);
                 Settings.setValue("previousAnimatedSnapPath", "");
                 Settings.setValue("previousAnimatedSnapStoryID", "");
-                Settings.setValue("previousAnimatedSnapSharingDisabled", false);
+                Settings.setValue("previousAnimatedSnapBlastingDisabled", false);
+                Settings.setValue("previousAnimatedSnapHifiSharingDisabled", false);
             }
             break;
         case 'chooseSnapshotLocation':
@@ -180,9 +184,9 @@ function onMessage(message) {
             isLoggedIn = Account.isLoggedIn();
             storyIDsToMaybeDelete.splice(storyIDsToMaybeDelete.indexOf(message.story_id), 1);
             if (message.isGif) {
-                Settings.setValue("previousAnimatedSnapSharingDisabled", true);
+                Settings.setValue("previousAnimatedSnapBlastingDisabled", true);
             } else {
-                Settings.setValue("previousStillSnapSharingDisabled", true);
+                Settings.setValue("previousStillSnapBlastingDisabled", true);
             }
 
             if (isLoggedIn) {
@@ -220,9 +224,9 @@ function onMessage(message) {
                             if (error || (response.status !== 'success')) {
                                 print("ERROR uploading announcement story: ", error || response.status);
                                 if (message.isGif) {
-                                    Settings.setValue("previousAnimatedSnapSharingDisabled", false);
+                                    Settings.setValue("previousAnimatedSnapBlastingDisabled", false);
                                 } else {
-                                    Settings.setValue("previousStillSnapSharingDisabled", false);
+                                    Settings.setValue("previousStillSnapBlastingDisabled", false);
                                 }
                                 return;
                             } else {
@@ -240,9 +244,9 @@ function onMessage(message) {
             isLoggedIn = Account.isLoggedIn();
             storyIDsToMaybeDelete.splice(storyIDsToMaybeDelete.indexOf(message.story_id), 1);
             if (message.isGif) {
-                Settings.setValue("previousAnimatedSnapSharingDisabled", true);
+                Settings.setValue("previousAnimatedSnapHifiSharingDisabled", true);
             } else {
-                Settings.setValue("previousStillSnapSharingDisabled", true);
+                Settings.setValue("previousStillSnapHifiSharingDisabled", true);
             }
 
             if (isLoggedIn) {
@@ -264,9 +268,9 @@ function onMessage(message) {
                     if (error || (response.status !== 'success')) {
                         print("ERROR changing audience: ", error || response.status);
                         if (message.isGif) {
-                            Settings.setValue("previousAnimatedSnapSharingDisabled", false);
+                            Settings.setValue("previousAnimatedSnapHifiSharingDisabled", false);
                         } else {
-                            Settings.setValue("previousStillSnapSharingDisabled", false);
+                            Settings.setValue("previousStillSnapHifiSharingDisabled", false);
                         }
                         return;
                     } else {
@@ -301,10 +305,12 @@ function onButtonClicked() {
         shouldActivateButton = true;
         var previousStillSnapPath = Settings.getValue("previousStillSnapPath");
         var previousStillSnapStoryID = Settings.getValue("previousStillSnapStoryID");
-        var previousStillSnapSharingDisabled = Settings.getValue("previousStillSnapSharingDisabled");
+        var previousStillSnapBlastingDisabled = Settings.getValue("previousStillSnapBlastingDisabled");
+        var previousStillSnapHifiSharingDisabled = Settings.getValue("previousStillSnapHifiSharingDisabled");
         var previousAnimatedSnapPath = Settings.getValue("previousAnimatedSnapPath");
         var previousAnimatedSnapStoryID = Settings.getValue("previousAnimatedSnapStoryID");
-        var previousAnimatedSnapSharingDisabled = Settings.getValue("previousAnimatedSnapSharingDisabled");
+        var previousAnimatedSnapBlastingDisabled = Settings.getValue("previousAnimatedSnapBlastingDisabled");
+        var previousAnimatedSnapHifiSharingDisabled = Settings.getValue("previousAnimatedSnapHifiSharingDisabled");
         snapshotOptions = {
             containsGif: previousAnimatedSnapPath !== "",
             processingGif: false,
@@ -312,10 +318,20 @@ function onButtonClicked() {
         }
         imageData = [];
         if (previousAnimatedSnapPath !== "") {
-            imageData.push({ localPath: previousAnimatedSnapPath, story_id: previousAnimatedSnapStoryID, buttonDisabled: previousAnimatedSnapSharingDisabled });
+            imageData.push({
+                localPath: previousAnimatedSnapPath,
+                story_id: previousAnimatedSnapStoryID,
+                blastButtonDisabled: previousAnimatedSnapBlastingDisabled,
+                hifiButtonDisabled: previousAnimatedSnapHifiSharingDisabled
+            });
         }
         if (previousStillSnapPath !== "") {
-            imageData.push({ localPath: previousStillSnapPath, story_id: previousStillSnapStoryID, buttonDisabled: previousStillSnapSharingDisabled });
+            imageData.push({
+                localPath: previousStillSnapPath,
+                story_id: previousStillSnapStoryID,
+                blastButtonDisabled: previousStillSnapBlastingDisabled,
+                hifiButtonDisabled: previousStillSnapHifiSharingDisabled
+            });
         }
         tablet.gotoWebScreen(SNAPSHOT_REVIEW_URL);
         tablet.webEventReceived.connect(onMessage);
@@ -355,10 +371,12 @@ function takeSnapshot() {
     }));
     Settings.setValue("previousStillSnapPath", "");
     Settings.setValue("previousStillSnapStoryID", "");
-    Settings.setValue("previousStillSnapSharingDisabled", false);
+    Settings.setValue("previousStillSnapBlastingDisabled", false);
+    Settings.setValue("previousStillSnapHifiSharingDisabled", false);
     Settings.setValue("previousAnimatedSnapPath", "");
     Settings.setValue("previousAnimatedSnapStoryID", "");
-    Settings.setValue("previousAnimatedSnapSharingDisabled", false);
+    Settings.setValue("previousAnimatedSnapBlastingDisabled", false);
+    Settings.setValue("previousAnimatedSnapHifiSharingDisabled", false);
 
     // Raising the desktop for the share dialog at end will interact badly with clearOverlayWhenMoving.
     // Turn it off now, before we start futzing with things (and possibly moving).
@@ -403,32 +421,34 @@ function takeSnapshot() {
     }, FINISH_SOUND_DELAY);
 }
 
-function isDomainOpen(id) {
+function isDomainOpen(id, callback) {
     print("Checking open status of domain with ID:", id);
-    if (!id) {
-        return false;
+    var status = false;
+    if (id) {
+        var options = [
+            'now=' + new Date().toISOString(),
+            'include_actions=concurrency',
+            'domain_id=' + id.slice(1, -1),
+            'restriction=open,hifi' // If we're sharing, we're logged in
+            // If we're here, protocol matches, and it is online
+        ];
+        var url = METAVERSE_BASE + "/api/v1/user_stories?" + options.join('&');
+
+        request({
+            uri: url,
+            method: 'GET'
+        }, function (error, response) {
+            if (error || (response.status !== 'success')) {
+                print("ERROR getting open status of domain: ", error || response.status);
+            } else {
+                status = response.total_entries ? true : false;
+            }
+            print("Domain open status:", status);
+            callback(status);
+        });
+    } else {
+        callback(status);
     }
-
-    var options = [
-        'now=' + new Date().toISOString(),
-        'include_actions=concurrency',
-        'domain_id=' + id.slice(1, -1),
-        'restriction=open,hifi' // If we're sharing, we're logged in
-        // If we're here, protocol matches, and it is online
-    ];
-    var url = METAVERSE_BASE + "/api/v1/user_stories?" + options.join('&');
-
-    return request({
-        uri: url,
-        method: 'GET'
-    }, function (error, response) {
-        if (error || (response.status !== 'success')) {
-            print("ERROR getting open status of domain: ", error || response.status);
-            return false;
-        } else {
-            return response.total_entries;
-        }
-    });
 }
 
 function stillSnapshotTaken(pathStillSnapshot, notify) {
@@ -448,25 +468,27 @@ function stillSnapshotTaken(pathStillSnapshot, notify) {
     // during which time the user may have moved. So stash that info in the dialog so that
     // it records the correct href. (We can also stash in .jpegs, but not .gifs.)
     // last element in data array tells dialog whether we can share or not
-    snapshotOptions = {
-        containsGif: false,
-        processingGif: false,
-        canShare: !isDomainOpen(domainId)
-    };
-    imageData = [{ localPath: pathStillSnapshot, href: href }];
     Settings.setValue("previousStillSnapPath", pathStillSnapshot);
-
-    tablet.emitScriptEvent(JSON.stringify({
-        type: "snapshot",
-        action: "addImages",
-        options: snapshotOptions,
-        image_data: imageData
-    }));
 
     if (clearOverlayWhenMoving) {
         MyAvatar.setClearOverlayWhenMoving(true); // not until after the share dialog
     }
     HMD.openTablet();
+
+    isDomainOpen(domainId, function (canShare) {
+        snapshotOptions = {
+            containsGif: false,
+            processingGif: false,
+            canShare: canShare
+        };
+        imageData = [{ localPath: pathStillSnapshot, href: href }];
+        tablet.emitScriptEvent(JSON.stringify({
+            type: "snapshot",
+            action: "addImages",
+            options: snapshotOptions,
+            image_data: imageData
+        }));
+    });
 }
 
 function processingGifStarted(pathStillSnapshot) {
@@ -478,27 +500,28 @@ function processingGifStarted(pathStillSnapshot) {
     if (resetOverlays) {
         Menu.setIsOptionChecked("Overlays", true);
     }
-
-    snapshotOptions = {
-        containsGif: true,
-        processingGif: true,
-        loadingGifPath: Script.resolvePath(Script.resourcesPath() + 'icons/loadingDark.gif'),
-        canShare: !isDomainOpen(domainId)
-    };
-    imageData = [{ localPath: pathStillSnapshot, href: href }];
     Settings.setValue("previousStillSnapPath", pathStillSnapshot);
-
-    tablet.emitScriptEvent(JSON.stringify({
-        type: "snapshot",
-        action: "addImages",
-        options: snapshotOptions,
-        image_data: imageData
-    }));
 
     if (clearOverlayWhenMoving) {
         MyAvatar.setClearOverlayWhenMoving(true); // not until after the share dialog
     }
     HMD.openTablet();
+    
+    isDomainOpen(domainId, function (canShare) {
+        snapshotOptions = {
+            containsGif: true,
+            processingGif: true,
+            loadingGifPath: Script.resolvePath(Script.resourcesPath() + 'icons/loadingDark.gif'),
+            canShare: canShare
+        };
+        imageData = [{ localPath: pathStillSnapshot, href: href }];
+        tablet.emitScriptEvent(JSON.stringify({
+            type: "snapshot",
+            action: "addImages",
+            options: snapshotOptions,
+            image_data: imageData
+        }));
+    });
 }
 
 function processingGifCompleted(pathAnimatedSnapshot) {
@@ -508,20 +531,22 @@ function processingGifCompleted(pathAnimatedSnapshot) {
         buttonConnected = true;
     }
 
-    snapshotOptions = {
-        containsGif: true,
-        processingGif: false,
-        canShare: !isDomainOpen(domainId)
-    }
-    imageData = [{ localPath: pathAnimatedSnapshot, href: href }];
     Settings.setValue("previousAnimatedSnapPath", pathAnimatedSnapshot);
 
-    tablet.emitScriptEvent(JSON.stringify({
-        type: "snapshot",
-        action: "addImages",
-        options: snapshotOptions,
-        image_data: imageData
-    }));
+    isDomainOpen(domainId, function (canShare) {
+        snapshotOptions = {
+            containsGif: true,
+            processingGif: false,
+            canShare: canShare
+        };
+        imageData = [{ localPath: pathAnimatedSnapshot, href: href }];
+        tablet.emitScriptEvent(JSON.stringify({
+            type: "snapshot",
+            action: "addImages",
+            options: snapshotOptions,
+            image_data: imageData
+        }));
+    });
 }
 function maybeDeleteSnapshotStories() {
     storyIDsToMaybeDelete.forEach(function (element, idx, array) {

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -317,20 +317,20 @@ function onButtonClicked() {
             shouldUpload: false
         }
         imageData = [];
-        if (previousAnimatedSnapPath !== "") {
-            imageData.push({
-                localPath: previousAnimatedSnapPath,
-                story_id: previousAnimatedSnapStoryID,
-                blastButtonDisabled: previousAnimatedSnapBlastingDisabled,
-                hifiButtonDisabled: previousAnimatedSnapHifiSharingDisabled
-            });
-        }
         if (previousStillSnapPath !== "") {
             imageData.push({
                 localPath: previousStillSnapPath,
                 story_id: previousStillSnapStoryID,
                 blastButtonDisabled: previousStillSnapBlastingDisabled,
                 hifiButtonDisabled: previousStillSnapHifiSharingDisabled
+            });
+        }
+        if (previousAnimatedSnapPath !== "") {
+            imageData.push({
+                localPath: previousAnimatedSnapPath,
+                story_id: previousAnimatedSnapStoryID,
+                blastButtonDisabled: previousAnimatedSnapBlastingDisabled,
+                hifiButtonDisabled: previousAnimatedSnapHifiSharingDisabled
             });
         }
         tablet.gotoWebScreen(SNAPSHOT_REVIEW_URL);

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -582,12 +582,21 @@ function onUsernameChanged() {
         shareAfterLogin = false;
     }
 }
+function snapshotLocationSet(location) {
+    if (location !== "") {
+        tablet.emitScriptEvent(JSON.stringify({
+            type: "snapshot",
+            action: "snapshotLocationChosen"
+        }));
+    }
+}
 
 button.clicked.connect(onButtonClicked);
 buttonConnected = true;
 Window.snapshotShared.connect(snapshotUploaded);
 tablet.screenChanged.connect(onTabletScreenChanged);
 Account.usernameChanged.connect(onUsernameChanged);
+Snapshot.snapshotLocationSet.connect(snapshotLocationSet);
 Script.scriptEnding.connect(function () {
     if (buttonConnected) {
         button.clicked.disconnect(onButtonClicked);
@@ -598,6 +607,7 @@ Script.scriptEnding.connect(function () {
     }
     Window.snapshotShared.disconnect(snapshotUploaded);
     tablet.screenChanged.disconnect(onTabletScreenChanged);
+    Snapshot.snapshotLocationSet.disconnect(snapshotLocationSet);
 });
 
 }()); // END LOCAL_SCOPE

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -395,6 +395,7 @@ function takeSnapshot() {
     resetOverlays = Menu.isOptionChecked("Overlays"); // For completeness. Certainly true if the button is visible to be clicked.
     reticleVisible = Reticle.visible;
     Reticle.visible = false;
+    Reticle.allowMouseCapture = false;
     
     var includeAnimated = Settings.getValue("alsoTakeAnimatedSnapshot", true);
     if (includeAnimated) {
@@ -454,6 +455,7 @@ function isDomainOpen(id, callback) {
 function stillSnapshotTaken(pathStillSnapshot, notify) {
     // show hud
     Reticle.visible = reticleVisible;
+    Reticle.allowMouseCapture = true;
     // show overlays if they were on
     if (resetOverlays) {
         Menu.setIsOptionChecked("Overlays", true);
@@ -496,6 +498,7 @@ function processingGifStarted(pathStillSnapshot) {
     Window.processingGifCompleted.connect(processingGifCompleted);
     // show hud
     Reticle.visible = reticleVisible;
+    Reticle.allowMouseCapture = true;
     // show overlays if they were on
     if (resetOverlays) {
         Menu.setIsOptionChecked("Overlays", true);


### PR DESCRIPTION
This PR makes the following improvements to the New Snapshot App:
- Disable "Blast" and "HiFi-ShareToFeed" buttons independently
- Share button visibility is now tied to shareable domain status, which matches where-taken, not where-now
- Added small vertical and horizontal margins between snapshots
- Updated typeface of radio button labels
- Updated look of SHARE button ellipses
- Changed Share Bar behavior - only one share bar is visible at once; clicking the other image closes any open Share Bars
- Still appears on top; GIF appears beneath it (when taking both)
- Cursor is no longer visible in snapshots (still nor GIF)

QA Test Plan irrelevant; Holistic testing will be done when feature-complete