### PR TITLE
Removing logspam on toggling scripts window

### DIFF
--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -34,9 +34,6 @@ ScrollingWindow {
     property var runningScriptsModel: ListModel { }
     property bool isHMD: false
 
-    onVisibleChanged: console.log("Running scripts visible changed to " + visible)
-    onShownChanged: console.log("Running scripts visible changed to " + visible)
-
     Settings {
         category: "Overlay.RunningScripts"
         property alias x: root.x


### PR DESCRIPTION
Removing log spam

## Testing

in this build, when showing or hiding the running scripts dialog, you should no longer see a log line that says `Running scripts visible changed to false/true`