### PR TITLE
PAL WebView is now a TabletWebView

### DIFF
--- a/interface/resources/qml/controls/TabletWebView.qml
+++ b/interface/resources/qml/controls/TabletWebView.qml
@@ -308,7 +308,6 @@ Item {
     Component.onCompleted: {
         web.isDesktop = (typeof desktop !== "undefined");
         address = url;
-        console.log("FIXME", eventBridge);
     }
 
     Keys.onPressed: {

--- a/interface/resources/qml/controls/TabletWebView.qml
+++ b/interface/resources/qml/controls/TabletWebView.qml
@@ -308,6 +308,7 @@ Item {
     Component.onCompleted: {
         web.isDesktop = (typeof desktop !== "undefined");
         address = url;
+        console.log("FIXME", eventBridge);
     }
 
     Keys.onPressed: {

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -44,6 +44,7 @@ Rectangle {
     property var activeTab: "nearbyTab";
     property bool currentlyEditingDisplayName: false
     property bool punctuationMode: false;
+    property var eventBridge;
 
     HifiConstants { id: hifi; }
 
@@ -1036,139 +1037,16 @@ Rectangle {
             }
         } // Keyboard
 
-        Item {
-            id: webViewContainer;
-            anchors.fill: parent;
-
-            Rectangle {
-                id: navigationContainer;
-                visible: userInfoViewer.visible;
-                height: 60;
-                anchors {
-                    top: parent.top;
-                    left: parent.left;
-                    right: parent.right;
-                }
-                color: hifi.colors.faintGray;
-
-                Item {
-                    id: backButton
-                    anchors {
-                        top: parent.top;
-                        left: parent.left;
-                    }
-                    height: parent.height - addressBar.height;
-                    width: parent.width/2;
-
-                    FiraSansSemiBold {
-                        // Properties
-                        text: "BACK";
-                        elide: Text.ElideRight;
-                        // Anchors
-                        anchors.fill: parent;
-                        // Text Size
-                        size: 16;
-                        // Text Positioning
-                        verticalAlignment: Text.AlignVCenter
-                        horizontalAlignment: Text.AlignHCenter;
-                        // Style
-                        color: backButtonMouseArea.containsMouse || !userInfoViewer.canGoBack ? hifi.colors.lightGray : hifi.colors.darkGray;
-                        MouseArea {
-                            id: backButtonMouseArea;
-                            anchors.fill: parent
-                            hoverEnabled: enabled
-                            onClicked: {
-                                if (userInfoViewer.canGoBack) {
-                                    userInfoViewer.goBack();
-                                }
-                            }
-                        }
-                    }
-                }
-
-                Item {
-                    id: closeButtonContainer
-                    anchors {
-                        top: parent.top;
-                        right: parent.right;
-                    }
-                    height: parent.height - addressBar.height;
-                    width: parent.width/2;
-
-                    FiraSansSemiBold {
-                        id: closeButton;
-                        // Properties
-                        text: "CLOSE";
-                        elide: Text.ElideRight;
-                        // Anchors
-                        anchors.fill: parent;
-                        // Text Size
-                        size: 16;
-                        // Text Positioning
-                        verticalAlignment: Text.AlignVCenter
-                        horizontalAlignment: Text.AlignHCenter;
-                        // Style
-                        color: hifi.colors.redHighlight;
-                        MouseArea {
-                            anchors.fill: parent
-                            hoverEnabled: enabled
-                            onClicked: userInfoViewer.visible = false;
-                            onEntered: closeButton.color = hifi.colors.redAccent;
-                            onExited: closeButton.color = hifi.colors.redHighlight;
-                        }
-                    }
-                }
-
-                Item {
-                    id: addressBar
-                    anchors {
-                        top: closeButtonContainer.bottom;
-                        left: parent.left;
-                        right: parent.right;
-                    }
-                    height: 30;
-                    width: parent.width;
-
-                    FiraSansRegular {
-                        // Properties
-                        text: userInfoViewer.url;
-                        elide: Text.ElideRight;
-                        // Anchors
-                        anchors.fill: parent;
-                        anchors.leftMargin: 5;
-                        // Text Size
-                        size: 14;
-                        // Text Positioning
-                        verticalAlignment: Text.AlignVCenter
-                        horizontalAlignment: Text.AlignLeft;
-                        // Style
-                        color: hifi.colors.lightGray;
-                    }
-                }
+        HifiControls.TabletWebView {
+            eventBridge: pal.eventBridge;
+            id: userInfoViewer;
+            anchors {
+                top: parent.top;
+                bottom: parent.bottom;
+                left: parent.left;
+                right: parent.right;
             }
-
-            Rectangle {
-                id: webViewBackground;
-                color: "white";
-                visible: userInfoViewer.visible;
-                anchors {
-                    top: navigationContainer.bottom;
-                    bottom: parent.bottom;
-                    left: parent.left;
-                    right: parent.right;
-                }
-            }
-
-            HifiControls.WebView {
-                id: userInfoViewer;
-                anchors {
-                    top: navigationContainer.bottom;
-                    bottom: parent.bottom;
-                    left: parent.left;
-                    right: parent.right;
-                }
-                visible: false;
-            }
+            visible: false;
         }
 
     // Timer used when selecting nearbyTable rows that aren't yet present in the model


### PR DESCRIPTION
Before this PR, the PAL used its own custom WebView. After this PR, it uses the same TabletWebView as is used in the Address Bar and HTML apps like SnapshotReview.

**Test Plan:**
In both HMD and desktop, and while logged in:
1. Open the PAL.
2. Click on your profile picture in the top left of the PAL. This opens a TabletWebView. Within this TabletWebView:
    - Verify that the Back and Close buttons work
    - Verify that the URL displayed at the top of the WebView matches what you'd expect as you navigate in the browser
    - Verify that the keyboard comes up after clicking on a text field located on, for example, the Twitter page (that'll appear after clicking the "Tweet" link on your profile page)
    - Verify that closing and re-opening the WebView behaves as you'd expect

