### PR TITLE
Adding a test to protect Uniform Buffer binding at wrong slot

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
@@ -149,6 +149,10 @@ void GLBackend::resetUniformStage() {
 
 void GLBackend::do_setUniformBuffer(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 3]._uint;
+    if (slot > GLBackend::MAX_NUM_UNIFORM_BUFFERS) {
+        // "GLBackend::do_setUniformBuffer: Trying to set a uniform Buffer at slot #" + slot + " which doesn't exist. MaxNumUniformBuffers = " + getMaxNumUniformBuffers());
+        return;
+    }
     BufferPointer uniformBuffer = batch._buffers.get(batch._params[paramOffset + 2]._uint);
     GLintptr rangeStart = batch._params[paramOffset + 1]._uint;
     GLsizeiptr rangeSize = batch._params[paramOffset + 0]._uint;

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
@@ -149,8 +149,8 @@ void GLBackend::resetUniformStage() {
 
 void GLBackend::do_setUniformBuffer(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 3]._uint;
-    if (slot > GLBackend::MAX_NUM_UNIFORM_BUFFERS) {
-        // "GLBackend::do_setUniformBuffer: Trying to set a uniform Buffer at slot #" + slot + " which doesn't exist. MaxNumUniformBuffers = " + getMaxNumUniformBuffers());
+    if (slot >(GLuint)MAX_NUM_UNIFORM_BUFFERS) {
+        qCDebug(gpugllogging) << "GLBackend::do_setUniformBuffer: Trying to set a uniform Buffer at slot #" << slot << " which doesn't exist. MaxNumUniformBuffers = " << getMaxNumUniformBuffers();
         return;
     }
     BufferPointer uniformBuffer = batch._buffers.get(batch._params[paramOffset + 2]._uint);
@@ -207,7 +207,7 @@ void GLBackend::resetResourceStage() {
 void GLBackend::do_setResourceBuffer(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 1]._uint;
     if (slot >= (GLuint)MAX_NUM_RESOURCE_BUFFERS) {
-        // "GLBackend::do_setResourceBuffer: Trying to set a resource Buffer at slot #" + slot + " which doesn't exist. MaxNumResourceBuffers = " + getMaxNumResourceBuffers());
+        qCDebug(gpugllogging) << "GLBackend::do_setResourceBuffer: Trying to set a resource Buffer at slot #" << slot << " which doesn't exist. MaxNumResourceBuffers = " << getMaxNumResourceBuffers();
         return;
     }
 
@@ -237,7 +237,7 @@ void GLBackend::do_setResourceBuffer(const Batch& batch, size_t paramOffset) {
 void GLBackend::do_setResourceTexture(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 1]._uint;
     if (slot >= (GLuint) MAX_NUM_RESOURCE_TEXTURES) {
-        // "GLBackend::do_setResourceTexture: Trying to set a resource Texture at slot #" + slot + " which doesn't exist. MaxNumResourceTextures = " + getMaxNumResourceTextures());
+        qCDebug(gpugllogging) << "GLBackend::do_setResourceTexture: Trying to set a resource Texture at slot #" << slot << " which doesn't exist. MaxNumResourceTextures = " << getMaxNumResourceTextures();
         return;
     }
 


### PR DESCRIPTION
Simply add a range test on the slot where to bind a uniform buffer to make sure it s valid.
Some crashes  expose this problem and that should never happen.
THis bug: https://highfidelity.fogbugz.com/f/cases/4569/CRASH-GLBackend-do_setUniformBuffer-162

## TEST PLAN
Nothing should be changed.
Simply need a code review