### PR TITLE
Prevent crash on switching to 3D display twice

### DIFF
--- a/libraries/ui/src/VrMenu.cpp
+++ b/libraries/ui/src/VrMenu.cpp
@@ -37,15 +37,17 @@ public:
         qmlObject->setObjectName(uuid.toString());
         // Make sure we can find it again in the future
         updateQmlItemFromAction();
-        auto connection = QObject::connect(action, &QAction::changed, [=] {
+        _changedConnection = QObject::connect(action, &QAction::changed, [=] {
             updateQmlItemFromAction();
         });
-        QObject::connect(qApp, &QCoreApplication::aboutToQuit, [=] {
-            QObject::disconnect(connection);
+        _shutdownConnection = QObject::connect(qApp, &QCoreApplication::aboutToQuit, [=] {
+            QObject::disconnect(_changedConnection);
         });
     }
 
     ~MenuUserData() {
+        QObject::disconnect(_changedConnection);
+        QObject::disconnect(_shutdownConnection);
         _action->setUserData(USER_DATA_ID, nullptr);
         _qml->setUserData(USER_DATA_ID, nullptr);
     }
@@ -104,6 +106,8 @@ public:
 private:
     MenuUserData(const MenuUserData&);
 
+    QMetaObject::Connection _shutdownConnection;
+    QMetaObject::Connection _changedConnection;
     QAction* _action { nullptr };
     QObject* _qml { nullptr };
 };


### PR DESCRIPTION
In the current master build, if you switch to "3D side by side", then to "Destkop" and back to "3D side by side" a crash occurs.  This crash appears to be related to menu manipulation.  Specifically the VR menu helper classes create connections to lambdas that manipulate the VR shadow copy of the menu.  However, these connections remain active even after the menu item has been removed.  When you add the menu item a second time, it triggers the original lambda which is no longer valid, causing the crash.

https://highfidelity.fogbugz.com/f/cases/3998/CRASH-when-selecting-Display-3D-TV-Side-by-Side-Stereo

## Testing

Switch to "3D side by side", then to "Desktop" and then back to "3D side by side".  In master a crash will occur.  In this build, not so much.  