### PR TITLE
Some minor handshake improvements

### DIFF
--- a/scripts/system/makeUserConnection.js
+++ b/scripts/system/makeUserConnection.js
@@ -122,7 +122,8 @@
     function debug() {
         var stateString = "<" + STATE_STRINGS[state] + ">";
         var connecting = "[" + connectingId + "/" + connectingHandJointIndex + "]";
-        print.apply(null, [].concat.apply([LABEL, stateString, JSON.stringify(waitingList), connecting],
+        var current = "[" + currentHand + "/" + currentHandJointIndex + "]"
+        print.apply(null, [].concat.apply([LABEL, stateString, current, JSON.stringify(waitingList), connecting],
             [].map.call(arguments, JSON.stringify)));
     }
 
@@ -768,11 +769,20 @@
                     // value for isKeyboard, as we should not change the animation
                     // state anyways (if any)
                     startHandshake();
+                } else {
+                    // they just created a connection request to us, and we are connecting to
+                    // them, so lets just stop connecting and make connection..
+                    makeConnection(connectingId);
+                    stopConnecting();
                 }
             } else {
-                // if waiting or inactive, lets clear the connecting id. If in makingConnection,
-                // do nothing
-                if (state !== STATES.MAKING_CONNECTION && connectingId === senderID) {
+                if (state == STATES.MAKING_CONNECTION && connectingId === senderID) {
+                    // we are making connection, they just started, so lets reset the
+                    // poll count just in case
+                    pollCount = 0;
+                } else {
+                    // if waiting or inactive, lets clear the connecting id. If in makingConnection,
+                    // do nothing
                     clearConnecting();
                     if (state !== STATES.INACTIVE) {
                         startHandshake();

--- a/scripts/system/makeUserConnection.js
+++ b/scripts/system/makeUserConnection.js
@@ -760,7 +760,10 @@
             break;
         case "done":
             delete waitingList[senderID];
-            if (state === STATES.CONNECTING && connectingId === senderID) {
+            if (connectionId !== senderID) {
+                break;
+            }
+            if (state === STATES.CONNECTING) {
                 // if they are done, and didn't connect us, terminate our
                 // connecting
                 if (message.connectionId !== MyAvatar.sessionUUID) {
@@ -776,7 +779,7 @@
                     stopConnecting();
                 }
             } else {
-                if (state == STATES.MAKING_CONNECTION && connectingId === senderID) {
+                if (state == STATES.MAKING_CONNECTION) {
                     // we are making connection, they just started, so lets reset the
                     // poll count just in case
                     pollCount = 0;


### PR DESCRIPTION
When some processing is delayed, we could be in a situation where the 2 parties in a handshake are done at somewhat different times.  Now, we detect when the other party has called the backend to create a connection request.  If we were still waiting for the 1.6 seconds till the handshake was 'done', we stop and immediately create our connection request.  If instead we are polling to see if they have created theirs, we reset the polling count, giving us a bit more time to see it connect us.  This _should_ help with some of the handshake issues we saw.  

Also -- added the current hand/joint index to the logging, which will help debugging other issues. 