### PR TITLE
Lots of Snapshot app improvements, Round Three

### DIFF
--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -158,7 +158,7 @@ input[type=button].naked:active {
     align-items: flex-end;
     height: 40px;
     width: calc(100% - 60px);
-    margin-bottom: 25px;
+    margin-bottom: -24px;
     margin-left: 0;
 }
 .shareButtons img {
@@ -178,7 +178,7 @@ input[type=button].naked:active {
     height: 25px;
     line-height: 25px;
     position: absolute;
-    bottom: 0;
+    bottom: 40px;
     left: 73px;
     right: 0;
     font-family: Raleway-Regular;

--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -198,7 +198,6 @@ input[type=button].naked:active {
     font-family: Raleway-Regular;
     font-weight: 500;
     font-size: 16px;
-    text-align: right;
     color: white;
 }
 /*

--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -187,6 +187,20 @@ input[type=button].naked:active {
     padding-left: 8px;
     color: white;
 }
+.helpTextDiv {
+    width: 350px;
+    height: 65px;
+    margin-right: 15px;
+    line-height: 65px;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    font-family: Raleway-Regular;
+    font-weight: 500;
+    font-size: 16px;
+    text-align: right;
+    color: white;
+}
 /*
 // END styling of share overlay
 */

--- a/scripts/system/html/css/hifi-style.css
+++ b/scripts/system/html/css/hifi-style.css
@@ -136,11 +136,14 @@ input[type=radio]:active + label > span > span{
 }
 
 .grayButton {
-    font-family: FiraSans-SemiBold;
-    color: white;
+    font-family: Raleway-Bold;
+    font-size: 13px;
+    color: black;
     padding: 0px 10px;
+    border-radius: 3px;
     border-width: 0px;
     background-image: linear-gradient(#FFFFFF, #AFAFAF);
+    min-height: 30px;
 }
 .grayButton:hover {
     background-image: linear-gradient(#FFFFFF, #FFFFFF);
@@ -152,7 +155,8 @@ input[type=radio]:active + label > span > span{
     background-image: linear-gradient(#FFFFFF, ##AFAFAF);
 }
 .blueButton {
-    font-family: FiraSans-SemiBold;
+    font-family: Raleway-Bold;
+    font-size: 13px;
     color: white;
     padding: 0px 10px;
     border-radius: 3px;

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -261,6 +261,7 @@ function showUploadingMessage(selectedID, destination) {
     var shareBarHelp = document.getElementById(selectedID + "shareBarHelp");
 
     shareBarHelp.innerHTML = '<img style="display:inline;width:25px;height:25px;" src="./img/loader.gif"></img><span style="position:relative;margin-left:5px;bottom:7px;">Preparing to Share</span>';
+    shareBarHelp.classList.add("uploading");
     shareBarHelp.setAttribute("data-destination", destination);
 }
 function hideUploadingMessageAndShare(selectedID, storyID) {
@@ -270,6 +271,8 @@ function hideUploadingMessageAndShare(selectedID, storyID) {
 
     var shareBarHelp = document.getElementById(selectedID + "shareBarHelp"),
         shareBarHelpDestination = shareBarHelp.getAttribute("data-destination");
+
+    shareBarHelp.classList.remove("uploading");
     if (shareBarHelpDestination) {
         switch (shareBarHelpDestination) {
             case 'blast':
@@ -387,54 +390,56 @@ function shareButtonHovered(destination, selectedID) {
         shareButtonsDiv = document.getElementById(selectedID + "shareButtonsDiv").childNodes,
         itr;
 
-    for (itr = 0; itr < shareButtonsDiv.length; itr += 1) {
-        shareButtonsDiv[itr].style.backgroundColor = "rgba(0, 0, 0, 0)";
-    }
-    shareBarHelp.style.opacity = "1.0";
+    if (!shareBarHelp.classList.contains("uploading")) {
 
-    switch (destination) {
-        case 'blast':
-            var blastToConnectionsButton = document.getElementById(selectedID + "blastToConnectionsButton");
-            if (!blastToConnectionsButton.classList.contains("disabled")) {
-                shareBarHelp.style.backgroundColor = "#EA4C5F";
-                shareBarHelp.style.opacity = "1.0";
-                blastToConnectionsButton.style.backgroundColor = "#EA4C5F";
-                blastToConnectionsButton.style.opacity = "1.0";
-                shareBarHelp.innerHTML = blastShareText;
-            } else {
-                shareBarHelp.style.backgroundColor = "#000000";
-                shareBarHelp.style.opacity = "0.5";
-                blastToConnectionsButton.style.backgroundColor = "#000000";
-                blastToConnectionsButton.style.opacity = "0.5";
-                shareBarHelp.innerHTML = blastAlreadySharedText;
-            }
-            break;
-        case 'hifi':
-            var shareWithEveryoneButton = document.getElementById(selectedID + "shareWithEveryoneButton");
-            if (!shareWithEveryoneButton.classList.contains("disabled")) {
-                shareBarHelp.style.backgroundColor = "#1FC6A6";
-                shareBarHelp.style.opacity = "1.0";
-                shareWithEveryoneButton.style.backgroundColor = "#1FC6A6";
-                shareWithEveryoneButton.style.opacity = "1.0";
-                shareBarHelp.innerHTML = hifiShareText;
-            } else {
-                shareBarHelp.style.backgroundColor = "#000000";
-                shareBarHelp.style.opacity = "0.5";
-                shareWithEveryoneButton.style.backgroundColor = "#000000";
-                shareWithEveryoneButton.style.opacity = "0.5";
-                shareBarHelp.innerHTML = hifiAlreadySharedText;
-            }
-            break;
-        case 'facebook':
-            shareBarHelp.style.backgroundColor = "#3C58A0";
-            shareBarHelp.innerHTML = facebookShareText;
-            document.getElementById(selectedID + "facebookButton").style.backgroundColor = "#3C58A0";
-            break;
-        case 'twitter':
-            shareBarHelp.style.backgroundColor = "#00B4EE";
-            shareBarHelp.innerHTML = twitterShareText;
-            document.getElementById(selectedID + "twitterButton").style.backgroundColor = "#00B4EE";
-            break;
+        for (itr = 0; itr < shareButtonsDiv.length; itr += 1) {
+            shareButtonsDiv[itr].style.backgroundColor = "rgba(0, 0, 0, 0)";
+        }
+        shareBarHelp.style.opacity = "1.0";
+        switch (destination) {
+            case 'blast':
+                var blastToConnectionsButton = document.getElementById(selectedID + "blastToConnectionsButton");
+                if (!blastToConnectionsButton.classList.contains("disabled")) {
+                    shareBarHelp.style.backgroundColor = "#EA4C5F";
+                    shareBarHelp.style.opacity = "1.0";
+                    blastToConnectionsButton.style.backgroundColor = "#EA4C5F";
+                    blastToConnectionsButton.style.opacity = "1.0";
+                    shareBarHelp.innerHTML = blastShareText;
+                } else {
+                    shareBarHelp.style.backgroundColor = "#000000";
+                    shareBarHelp.style.opacity = "0.5";
+                    blastToConnectionsButton.style.backgroundColor = "#000000";
+                    blastToConnectionsButton.style.opacity = "0.5";
+                    shareBarHelp.innerHTML = blastAlreadySharedText;
+                }
+                break;
+            case 'hifi':
+                var shareWithEveryoneButton = document.getElementById(selectedID + "shareWithEveryoneButton");
+                if (!shareWithEveryoneButton.classList.contains("disabled")) {
+                    shareBarHelp.style.backgroundColor = "#1FC6A6";
+                    shareBarHelp.style.opacity = "1.0";
+                    shareWithEveryoneButton.style.backgroundColor = "#1FC6A6";
+                    shareWithEveryoneButton.style.opacity = "1.0";
+                    shareBarHelp.innerHTML = hifiShareText;
+                } else {
+                    shareBarHelp.style.backgroundColor = "#000000";
+                    shareBarHelp.style.opacity = "0.5";
+                    shareWithEveryoneButton.style.backgroundColor = "#000000";
+                    shareWithEveryoneButton.style.opacity = "0.5";
+                    shareBarHelp.innerHTML = hifiAlreadySharedText;
+                }
+                break;
+            case 'facebook':
+                shareBarHelp.style.backgroundColor = "#3C58A0";
+                shareBarHelp.innerHTML = facebookShareText;
+                document.getElementById(selectedID + "facebookButton").style.backgroundColor = "#3C58A0";
+                break;
+            case 'twitter':
+                shareBarHelp.style.backgroundColor = "#00B4EE";
+                shareBarHelp.innerHTML = twitterShareText;
+                document.getElementById(selectedID + "twitterButton").style.backgroundColor = "#00B4EE";
+                break;
+        }
     }
 }
 function shareButtonClicked(destination, selectedID) {

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -217,8 +217,8 @@ function createShareBar(parentID, isLoggedIn, canShare, isGif, blastButtonDisabl
                         '&#xe019;' +
                     '</div>' +
                 '</div>' +
-                '<div class="helpTextDiv" id="' + parentID + 'helpTextDiv' + '" style="visibility:hidden;text-align:left;font-size: 13px;">' +
-                    'Snaps taken from the pictured domain can\'t be shared.' +
+                '<div class="helpTextDiv" id="' + parentID + 'helpTextDiv' + '" style="visibility:hidden;text-align:left;">' +
+                    'This snap was taken in an unshareable domain.' +
                 '</div>';
             // Add onclick handler to parent DIV's img to toggle share buttons
             document.getElementById(parentID + 'img').onclick = function () { selectImageWithHelpText(parentID, true); };

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -143,11 +143,11 @@ function createShareBar(parentID, isGif, blastButtonDisabled, hifiButtonDisabled
         '</div>' +
         '<div class="shareButtons" id="' + shareButtonsDivID + '" style="visibility:hidden">';
     if (canBlast) {
-        shareBarInnerHTML += '<div class="shareButton blastToConnections' + (blastButtonDisabled ? ' disabled' : '') + '" id="' + blastToConnectionsButtonID + '" onmouseover="shareButtonHovered(\'blast\', ' + parentID + ')" onclick="' + (blastButtonDisabled ? '' : 'blastToConnections(' + parentID + ', ' + isGif + ')') + '"><img src="img/blast_icon.svg"></div>';
+        shareBarInnerHTML += '<div class="shareButton blastToConnections' + (blastButtonDisabled ? ' disabled' : '') + '" id="' + blastToConnectionsButtonID + '" onmouseover="shareButtonHovered(\'blast\', ' + parentID + ', true)" onclick="' + (blastButtonDisabled ? '' : 'blastToConnections(' + parentID + ', ' + isGif + ')') + '"><img src="img/blast_icon.svg"></div>';
     }
-    shareBarInnerHTML += '<div class="shareButton shareWithEveryone' + (hifiButtonDisabled ? ' disabled' : '') + '" id="' + shareWithEveryoneButtonID + '" onmouseover="shareButtonHovered(\'hifi\', ' + parentID + ')" onclick="' + (hifiButtonDisabled ? '' : 'shareWithEveryone(' + parentID + ', ' + isGif + ')') + '"><img src="img/hifi_icon.svg" style="width:35px;height:35px;margin:2px 0 0 2px;"></div>' +
-            '<a class="shareButton facebookButton" id="' + facebookButtonID + '" onmouseover="shareButtonHovered(\'facebook\', ' + parentID + ')" onclick="shareButtonClicked(\'facebook\', ' + parentID + ')"><img src="img/fb_icon.svg"></a>' +
-            '<a class="shareButton twitterButton" id="' + twitterButtonID + '" onmouseover="shareButtonHovered(\'twitter\', ' + parentID + ')" onclick="shareButtonClicked(\'twitter\', ' + parentID + ')"><img src="img/twitter_icon.svg"></a>' +
+    shareBarInnerHTML += '<div class="shareButton shareWithEveryone' + (hifiButtonDisabled ? ' disabled' : '') + '" id="' + shareWithEveryoneButtonID + '" onmouseover="shareButtonHovered(\'hifi\', ' + parentID + ', true)" onclick="' + (hifiButtonDisabled ? '' : 'shareWithEveryone(' + parentID + ', ' + isGif + ')') + '"><img src="img/hifi_icon.svg" style="width:35px;height:35px;margin:2px 0 0 2px;"></div>' +
+            '<a class="shareButton facebookButton" id="' + facebookButtonID + '" onmouseover="shareButtonHovered(\'facebook\', ' + parentID + ', true)" onclick="shareButtonClicked(\'facebook\', ' + parentID + ')"><img src="img/fb_icon.svg"></a>' +
+            '<a class="shareButton twitterButton" id="' + twitterButtonID + '" onmouseover="shareButtonHovered(\'twitter\', ' + parentID + ', true)" onclick="shareButtonClicked(\'twitter\', ' + parentID + ')"><img src="img/twitter_icon.svg"></a>' +
         '</div>';
 
     shareBar.innerHTML = shareBarInnerHTML;
@@ -164,11 +164,11 @@ function appendShareBar(divID, isGif, blastButtonDisabled, hifiButtonDisabled, c
     document.getElementById(divID).appendChild(createShareBar(divID, isGif, blastButtonDisabled, hifiButtonDisabled, canBlast));
     if (divID === "p0") {
         selectImageToShare(divID, true);
-        if (canBlast) {
-            shareButtonHovered('blast', divID);
-        } else {
-            shareButtonHovered('hifi', divID);
-        }
+    }
+    if (canBlast) {
+        shareButtonHovered('blast', divID, false);
+    } else {
+        shareButtonHovered('hifi', divID, false);
     }
 }
 function shareForUrl(selectedID) {
@@ -382,7 +382,7 @@ function shareWithEveryone(selectedID, isGif) {
         showUploadingMessage(selectedID, 'hifi');
     }
 }
-function shareButtonHovered(destination, selectedID) {
+function shareButtonHovered(destination, selectedID, shouldAlsoModifyOther) {
     if (selectedID.id) {
         selectedID = selectedID.id; // sometimes (?), `selectedID` is passed as an HTML object to these functions; we just want the ID
     }
@@ -391,7 +391,6 @@ function shareButtonHovered(destination, selectedID) {
         itr;
 
     if (!shareBarHelp.classList.contains("uploading")) {
-
         for (itr = 0; itr < shareButtonsDiv.length; itr += 1) {
             shareButtonsDiv[itr].style.backgroundColor = "rgba(0, 0, 0, 0)";
         }
@@ -439,6 +438,14 @@ function shareButtonHovered(destination, selectedID) {
                 shareBarHelp.innerHTML = twitterShareText;
                 document.getElementById(selectedID + "twitterButton").style.backgroundColor = "#00B4EE";
                 break;
+        }
+    }
+
+    if (shouldAlsoModifyOther && imageCount > 1) {
+        if (selectedID === "p0" && !document.getElementById("p1").classList.contains("processingGif")) {
+            shareButtonHovered(destination, "p1", false);
+        } else if (selectedID === "p1") {
+            shareButtonHovered(destination, "p0", false);
         }
     }
 }
@@ -525,6 +532,7 @@ window.onload = function () {
                             message.image_data.forEach(function (element, idx) {
                                 addImage(element, idx === 1, idx === 0 && messageOptions.canShare, false);
                             });
+                            document.getElementById("p1").classList.add("processingGif");
                         } else {
                             var gifPath = message.image_data[0].localPath,
                                 p1img = document.getElementById('p1img');
@@ -534,6 +542,7 @@ window.onload = function () {
                             if (messageOptions.canShare) {
                                 shareForUrl("p1");
                                 appendShareBar("p1", true, false, false, true);
+                                document.getElementById("p1").classList.remove("processingGif");
                             }
                         }
                     } else {

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -217,8 +217,8 @@ function createShareBar(parentID, isLoggedIn, canShare, isGif, blastButtonDisabl
                         '&#xe019;' +
                     '</div>' +
                 '</div>' +
-                '<div class="helpTextDiv" id="' + parentID + 'helpTextDiv' + '" style="visibility:hidden">' +
-                    'Snaps taken in this domain can\'t be shared.' +
+                '<div class="helpTextDiv" id="' + parentID + 'helpTextDiv' + '" style="visibility:hidden;text-align:left;font-size: 13px;">' +
+                    'Snaps taken from the pictured domain can\'t be shared.' +
                 '</div>';
             // Add onclick handler to parent DIV's img to toggle share buttons
             document.getElementById(parentID + 'img').onclick = function () { selectImageWithHelpText(parentID, true); };
@@ -230,7 +230,7 @@ function createShareBar(parentID, isLoggedIn, canShare, isGif, blastButtonDisabl
                     '&#xe019;' +
                 '</div>' +
             '</div>' +
-            '<div class="helpTextDiv" id="' + parentID + 'helpTextDiv' + '" style="visibility:hidden">' +
+            '<div class="helpTextDiv" id="' + parentID + 'helpTextDiv' + '" style="visibility:hidden;text-align:right;">' +
                 'Please log in to share snaps' + '<input class="grayButton" style="margin-left:20px;width:95px;height:30px;" type="button" value="LOG IN" onclick="login()" />' +
             '</div>';
         // Add onclick handler to parent DIV's img to toggle share buttons
@@ -249,9 +249,9 @@ function appendShareBar(divID, isLoggedIn, canShare, isGif, blastButtonDisabled,
     if (divID === "p0") {
         if (isLoggedIn) {
             if (canShare) {
-                selectImageWithHelpText(divID, true);
-            } else {
                 selectImageToShare(divID, true);
+            } else {
+                selectImageWithHelpText(divID, true);
             }
         } else {
             selectImageWithHelpText(divID, true);
@@ -625,7 +625,7 @@ window.onload = function () {
                             imageCount = message.image_data.length + 1; // "+1" for the GIF that'll finish processing soon
                             message.image_data.push({ localPath: messageOptions.loadingGifPath });
                             message.image_data.forEach(function (element, idx) {
-                                addImage(element, messageOptions.isLoggedIn, idx === 0 && messageOptions.canShare, idx === 1, false);
+                                addImage(element, messageOptions.isLoggedIn, idx === 0 && messageOptions.canShare, idx === 1, false, false, false, true);
                             });
                             document.getElementById("p1").classList.add("processingGif");
                         } else {
@@ -634,16 +634,14 @@ window.onload = function () {
                             p1img.src = gifPath;
 
                             paths[1] = gifPath;
-                            if (messageOptions.canShare) {
-                                shareForUrl("p1");
-                                appendShareBar("p1", messageOptions.isLoggedIn, true, false, false, true);
-                                document.getElementById("p1").classList.remove("processingGif");
-                            }
+                            shareForUrl("p1");
+                            appendShareBar("p1", messageOptions.isLoggedIn, messageOptions.canShare, true, false, false, messageOptions.canBlast);
+                            document.getElementById("p1").classList.remove("processingGif");
                         }
                     } else {
                         imageCount = message.image_data.length;
                         message.image_data.forEach(function (element) {
-                            addImage(element, messageOptions.isLoggedIn, messageOptions.canShare, false, false);
+                            addImage(element, messageOptions.isLoggedIn, messageOptions.canShare, false, false, false, false, true);
                         });
                     }
                     break;

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -134,7 +134,8 @@ function createShareBar(parentID, isGif, blastButtonDisabled, hifiButtonDisabled
 
     shareBar.id = parentID + "shareBar";
     shareBar.className = "shareControls";
-    var shareBarInnerHTML = '<div class="showShareButtonsButtonDiv inactive" id="' + showShareButtonsButtonDivID + '" onclick="selectImageToShare(' + parentID + ', true)">' +
+    var shareBarInnerHTML = '<div class="shareControlsHelp" id="' + shareBarHelpID + '" style="visibility:hidden;' + ((canBlast && blastButtonDisabled || !canBlast && hifiButtonDisabled) ? "background-color:#000;opacity:0.5;" : "") + '"></div>' +
+        '<div class="showShareButtonsButtonDiv inactive" id="' + showShareButtonsButtonDivID + '" onclick="selectImageToShare(' + parentID + ', true)">' +
             '<label id="' + showShareButtonsLabelID + '">SHARE</label>' +
             '<span class="showShareButtonDots">' +
                 '&#xe019;' +
@@ -150,8 +151,6 @@ function createShareBar(parentID, isGif, blastButtonDisabled, hifiButtonDisabled
         '</div>';
 
     shareBar.innerHTML = shareBarInnerHTML;
-
-    shareBar.innerHTML += '<div class="shareControlsHelp" id="' + shareBarHelpID + '" style="visibility:hidden;' + ((canBlast && blastButtonDisabled || !canBlast && hifiButtonDisabled) ? "background-color:#000;opacity:0.5;" : "") + '"></div>';
 
     // Add onclick handler to parent DIV's img to toggle share buttons
     document.getElementById(parentID + 'img').onclick = function () { selectImageToShare(parentID, true); };


### PR DESCRIPTION
Lots of polish, lots of necessary feature-additions.

Just like last time, no test plan here. Holistic testing will be done when feature-complete.

This PR makes the following improvements to the New Snapshot App:
- New behavior for snapshots taken before the user logs in (!)
- New behavior for snapshots app as user logs in and out (!)
- New behavior for snapshots taken in a domain from which snapshots cannot be shared (!)
- Moved the "help text bar" above the share buttons instead of below
- Locked the ability to hover over other share buttons after the user clicks a share button before the image is uploaded to HiFi
- Put both share button hover states in lock-step (i.e. hover over Facebook button in the GIF, Facebook button is in the hover state the next time you click on the still)