### PR TITLE
Guard against local audio crashes

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1169,8 +1169,8 @@ bool AudioClient::mixLocalAudioInjectors(float* mixBuffer) {
 
     for (AudioInjector* injector : _activeLocalAudioInjectors) {
         // the lock guarantees that injectorBuffer, if found, is invariant
-        AudioInjectorLocalBuffer* injectorBuffer;
-        if ((injectorBuffer = injector->getLocalBuffer())) {
+        AudioInjectorLocalBuffer* injectorBuffer = injector->getLocalBuffer();
+        if (injectorBuffer) {
 
             static const int HRTF_DATASET_INDEX = 1;
 
@@ -1319,8 +1319,8 @@ void AudioClient::setIsStereoInput(bool isStereoInput) {
 }
 
 bool AudioClient::outputLocalInjector(AudioInjector* injector) {
-    AudioInjectorLocalBuffer* injectorBuffer;
-    if ((injectorBuffer = injector->getLocalBuffer())) {
+    AudioInjectorLocalBuffer* injectorBuffer = injector->getLocalBuffer();
+    if (injectorBuffer) {
         // local injectors are on the AudioInjectorsThread, so we must guard access
         Lock lock(_injectorsMutex);
         if (!_activeLocalAudioInjectors.contains(injector)) {

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -96,8 +96,6 @@ public:
     using AudioPositionGetter = std::function<glm::vec3()>;
     using AudioOrientationGetter = std::function<glm::quat()>;
 
-    using RecursiveMutex = std::recursive_mutex;
-    using RecursiveLock = std::unique_lock<RecursiveMutex>;
     using Mutex = std::mutex;
     using Lock = std::unique_lock<Mutex>;
 
@@ -345,7 +343,7 @@ private:
     int16_t _localScratchBuffer[AudioConstants::NETWORK_FRAME_SAMPLES_AMBISONIC];
     float* _localOutputMixBuffer { NULL };
     AudioInjectorsThread _localAudioThread;
-    RecursiveMutex _localAudioMutex;
+    Mutex _localAudioMutex;
 
     // for output audio (used by this thread)
     int _outputPeriod { 0 };

--- a/libraries/audio/src/AbstractAudioInterface.h
+++ b/libraries/audio/src/AbstractAudioInterface.h
@@ -33,7 +33,11 @@ public:
                                 PacketType packetType, QString codecName = QString(""));
 
 public slots:
+    // threadsafe
+    // moves injector->getLocalBuffer() to another thread (so removes its parent)
+    // take care to delete it when ~AudioInjector, as parenting Qt semantics will not work
     virtual bool outputLocalInjector(AudioInjector* injector) = 0;
+
     virtual bool shouldLoopbackInjectors() { return false; }
     
     virtual void setIsStereoInput(bool stereo) = 0;

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -52,6 +52,7 @@ class AudioInjector : public QObject {
 public:
     AudioInjector(const Sound& sound, const AudioInjectorOptions& injectorOptions);
     AudioInjector(const QByteArray& audioData, const AudioInjectorOptions& injectorOptions);
+    ~AudioInjector();
     
     bool isFinished() const { return (stateHas(AudioInjectorState::Finished)); }
     
@@ -99,6 +100,7 @@ private:
     int64_t injectNextFrame();
     bool inject(bool(AudioInjectorManager::*injection)(AudioInjector*));
     bool injectLocally();
+    void deleteLocalBuffer();
     
     static AbstractAudioInterface* _localAudioInterface;
 

--- a/libraries/audio/src/AudioInjectorLocalBuffer.cpp
+++ b/libraries/audio/src/AudioInjectorLocalBuffer.cpp
@@ -11,8 +11,7 @@
 
 #include "AudioInjectorLocalBuffer.h"
 
-AudioInjectorLocalBuffer::AudioInjectorLocalBuffer(const QByteArray& rawAudioArray, QObject* parent) :
-    QIODevice(parent),
+AudioInjectorLocalBuffer::AudioInjectorLocalBuffer(const QByteArray& rawAudioArray) :
     _rawAudioArray(rawAudioArray),
     _shouldLoop(false),
     _isStopped(false),

--- a/libraries/audio/src/AudioInjectorLocalBuffer.h
+++ b/libraries/audio/src/AudioInjectorLocalBuffer.h
@@ -19,7 +19,7 @@
 class AudioInjectorLocalBuffer : public QIODevice {
     Q_OBJECT
 public:
-    AudioInjectorLocalBuffer(const QByteArray& rawAudioArray, QObject* parent);
+    AudioInjectorLocalBuffer(const QByteArray& rawAudioArray);
 
     void stop();
 


### PR DESCRIPTION
- Remove lock from audio device read
- Prevent overflow of local injectors buffer when switching devices
- Prevent data race when audio injectors are stopped during read