### PR TITLE
Fix sped up animations

### DIFF
--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -140,9 +140,6 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     auto orientation = myAvatar->getLocalOrientation();
     _rig->computeMotionAnimationState(deltaTime, position, velocity, orientation, ccState);
 
-    // evaluate AnimGraph animation and update jointStates.
-    Model::updateRig(deltaTime, parentTransform);
-
     Rig::EyeParameters eyeParams;
     eyeParams.eyeLookAt = lookAt;
     eyeParams.eyeSaccade = head->getSaccade();
@@ -153,6 +150,7 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
     _rig->updateFromEyeParameters(eyeParams);
 
+    // evaluate AnimGraph animation and update jointStates.
     Parent::updateRig(deltaTime, parentTransform);
 }
 

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -120,7 +120,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
      }
 
     // evaluate AnimGraph animation and update jointStates.
-    Model::updateRig(deltaTime, parentTransform);
+    Parent::updateRig(deltaTime, parentTransform);
 }
 
 void SkeletonModel::updateAttitude() {
@@ -136,7 +136,7 @@ void SkeletonModel::simulate(float deltaTime, bool fullUpdate) {
     if (fullUpdate) {
         setBlendshapeCoefficients(_owningAvatar->getHead()->getSummedBlendshapeCoefficients());
 
-        Model::simulate(deltaTime, fullUpdate);
+        Parent::simulate(deltaTime, fullUpdate);
 
         // let rig compute the model offset
         glm::vec3 registrationPoint;
@@ -144,7 +144,7 @@ void SkeletonModel::simulate(float deltaTime, bool fullUpdate) {
             setOffset(registrationPoint);
         }
     } else {
-        Model::simulate(deltaTime, fullUpdate);
+        Parent::simulate(deltaTime, fullUpdate);
     }
 
     if (!isActive() || !_owningAvatar->isMyAvatar()) {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
@@ -23,6 +23,7 @@ using SkeletonModelWeakPointer = std::weak_ptr<SkeletonModel>;
 
 /// A skeleton loaded from a model.
 class SkeletonModel : public CauterizedModel {
+    using Parent = CauterizedModel;
     Q_OBJECT
 
 public:

--- a/libraries/render-utils/src/CauterizedModel.h
+++ b/libraries/render-utils/src/CauterizedModel.h
@@ -28,10 +28,10 @@ public:
     const std::unordered_set<int>& getCauterizeBoneSet() const { return _cauterizeBoneSet; }
     void setCauterizeBoneSet(const std::unordered_set<int>& boneSet) { _cauterizeBoneSet = boneSet; }
 
-	void deleteGeometry() override;
-	bool updateGeometry() override;
+    void deleteGeometry() override;
+    bool updateGeometry() override;
 
-	void createVisibleRenderItemSet() override;
+    void createVisibleRenderItemSet() override;
     void createCollisionRenderItemSet() override;
 
     virtual void updateClusterMatrices() override;
@@ -41,7 +41,7 @@ public:
 
 protected:
     std::unordered_set<int> _cauterizeBoneSet;
-	QVector<Model::MeshState> _cauterizeMeshStates;
+    QVector<Model::MeshState> _cauterizeMeshStates;
     bool _isCauterized { false };
     bool _enableCauterization { false };
 };


### PR DESCRIPTION
The recent refactor of avatar rendering into a library had one parent method being called multiple times per frame.  

## Testing

Walk around an environment with an avatar.  In master the walk animation will be sped up.  In this build it should be correctly paced.  