### PR TITLE
Hand controller lasers work better in thirdPerson camera mode.

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1376,7 +1376,9 @@ function MyController(hand) {
                 visible: true,
                 alpha: 1,
                 parentID: AVATAR_SELF_ID,
-                parentJointIndex: this.controllerJointIndex,
+                parentJointIndex: MyAvatar.getJointIndex(this.hand === RIGHT_HAND ?
+                                                         "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND" :
+                                                         "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"),
                 endParentID: farParentID
             };
             this.overlayLine = Overlays.addOverlay("line3d", lineProperties);


### PR DESCRIPTION
Hand controllers are now parented to the camera relative controller joint.  This means they work better in third person view.