### PR TITLE
Fix lookAt eye snapping

### DIFF
--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -38,6 +38,13 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
     // make sure lookAt is not too close to face (avoid crosseyes)
     glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
+    glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
+    float focusDistance = glm::length(focusOffset);
+    const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;
+    if (focusDistance < MIN_LOOK_AT_FOCUS_DISTANCE && focusDistance > EPSILON) {
+        lookAt = _owningAvatar->getHead()->getEyePosition() + (MIN_LOOK_AT_FOCUS_DISTANCE / focusDistance) * focusOffset;
+    }
+
     MyAvatar* myAvatar = static_cast<MyAvatar*>(_owningAvatar);
 
     Rig::HeadParameters headParams;

--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -147,6 +147,9 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     auto orientation = myAvatar->getLocalOrientation();
     _rig->computeMotionAnimationState(deltaTime, position, velocity, orientation, ccState);
 
+    // evaluate AnimGraph animation and update jointStates.
+    Model::updateRig(deltaTime, parentTransform);
+
     Rig::EyeParameters eyeParams;
     eyeParams.eyeLookAt = lookAt;
     eyeParams.eyeSaccade = head->getSaccade();
@@ -156,8 +159,5 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     eyeParams.rightEyeJointIndex = geometry.rightEyeJointIndex;
 
     _rig->updateFromEyeParameters(eyeParams);
-
-    // evaluate AnimGraph animation and update jointStates.
-    Parent::updateRig(deltaTime, parentTransform);
 }
 

--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -37,7 +37,7 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     Head* head = _owningAvatar->getHead();
 
     // make sure lookAt is not too close to face (avoid crosseyes)
-    glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
+    glm::vec3 lookAt = head->getLookAtPosition();
     glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
     float focusDistance = glm::length(focusOffset);
     const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -73,51 +73,50 @@ void SkeletonModel::initJointStates() {
 
 // Called within Model::simulate call, below.
 void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
-    if (!_owningAvatar->isMyAvatar()) {
-        const FBXGeometry& geometry = getFBXGeometry();
+    assert(!_owningAvatar->isMyAvatar());
+    const FBXGeometry& geometry = getFBXGeometry();
 
-        Head* head = _owningAvatar->getHead();
+    Head* head = _owningAvatar->getHead();
 
-        // make sure lookAt is not too close to face (avoid crosseyes)
-        glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
-        glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
-        float focusDistance = glm::length(focusOffset);
-        const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;
-        if (focusDistance < MIN_LOOK_AT_FOCUS_DISTANCE && focusDistance > EPSILON) {
-            lookAt = _owningAvatar->getHead()->getEyePosition() + (MIN_LOOK_AT_FOCUS_DISTANCE / focusDistance) * focusOffset;
-        }
+    // make sure lookAt is not too close to face (avoid crosseyes)
+    glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
+    glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
+    float focusDistance = glm::length(focusOffset);
+    const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;
+    if (focusDistance < MIN_LOOK_AT_FOCUS_DISTANCE && focusDistance > EPSILON) {
+        lookAt = _owningAvatar->getHead()->getEyePosition() + (MIN_LOOK_AT_FOCUS_DISTANCE / focusDistance) * focusOffset;
+    }
 
-        // no need to call Model::updateRig() because otherAvatars get their joint state
-        // copied directly from AvtarData::_jointData (there are no Rig animations to blend)
-        _needsUpdateClusterMatrices = true;
+    // no need to call Model::updateRig() because otherAvatars get their joint state
+    // copied directly from AvtarData::_jointData (there are no Rig animations to blend)
+    _needsUpdateClusterMatrices = true;
 
-        // This is a little more work than we really want.
-        //
-        // Other avatars joint, including their eyes, should already be set just like any other joints
-        // from the wire data. But when looking at me, we want the eyes to use the corrected lookAt.
-        //
-        // Thus this should really only be ... else if (_owningAvatar->getHead()->isLookingAtMe()) {...
-        // However, in the !isLookingAtMe case, the eyes aren't rotating the way they should right now.
-        // We will revisit that as priorities allow, and particularly after the new rig/animation/joints.
+    // This is a little more work than we really want.
+    //
+    // Other avatars joint, including their eyes, should already be set just like any other joints
+    // from the wire data. But when looking at me, we want the eyes to use the corrected lookAt.
+    //
+    // Thus this should really only be ... else if (_owningAvatar->getHead()->isLookingAtMe()) {...
+    // However, in the !isLookingAtMe case, the eyes aren't rotating the way they should right now.
+    // We will revisit that as priorities allow, and particularly after the new rig/animation/joints.
 
-        // If the head is not positioned, updateEyeJoints won't get the math right
-        glm::quat headOrientation;
-        _rig->getJointRotation(geometry.headJointIndex, headOrientation);
-        glm::vec3 eulers = safeEulerAngles(headOrientation);
-        head->setBasePitch(glm::degrees(-eulers.x));
-        head->setBaseYaw(glm::degrees(eulers.y));
-        head->setBaseRoll(glm::degrees(-eulers.z));
+    // If the head is not positioned, updateEyeJoints won't get the math right
+    glm::quat headOrientation;
+    _rig->getJointRotation(geometry.headJointIndex, headOrientation);
+    glm::vec3 eulers = safeEulerAngles(headOrientation);
+    head->setBasePitch(glm::degrees(-eulers.x));
+    head->setBaseYaw(glm::degrees(eulers.y));
+    head->setBaseRoll(glm::degrees(-eulers.z));
 
-        Rig::EyeParameters eyeParams;
-        eyeParams.eyeLookAt = lookAt;
-        eyeParams.eyeSaccade = glm::vec3(0.0f);
-        eyeParams.modelRotation = getRotation();
-        eyeParams.modelTranslation = getTranslation();
-        eyeParams.leftEyeJointIndex = geometry.leftEyeJointIndex;
-        eyeParams.rightEyeJointIndex = geometry.rightEyeJointIndex;
+    Rig::EyeParameters eyeParams;
+    eyeParams.eyeLookAt = lookAt;
+    eyeParams.eyeSaccade = glm::vec3(0.0f);
+    eyeParams.modelRotation = getRotation();
+    eyeParams.modelTranslation = getTranslation();
+    eyeParams.leftEyeJointIndex = geometry.leftEyeJointIndex;
+    eyeParams.rightEyeJointIndex = geometry.rightEyeJointIndex;
 
-        _rig->updateFromEyeParameters(eyeParams);
-     }
+    _rig->updateFromEyeParameters(eyeParams);
 }
 
 void SkeletonModel::updateAttitude() {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -73,20 +73,20 @@ void SkeletonModel::initJointStates() {
 
 // Called within Model::simulate call, below.
 void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
-    const FBXGeometry& geometry = getFBXGeometry();
-
-    Head* head = _owningAvatar->getHead();
-
-    // make sure lookAt is not too close to face (avoid crosseyes)
-    glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
-    glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
-    float focusDistance = glm::length(focusOffset);
-    const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;
-    if (focusDistance < MIN_LOOK_AT_FOCUS_DISTANCE && focusDistance > EPSILON) {
-        lookAt = _owningAvatar->getHead()->getEyePosition() + (MIN_LOOK_AT_FOCUS_DISTANCE / focusDistance) * focusOffset;
-    }
-
     if (!_owningAvatar->isMyAvatar()) {
+        const FBXGeometry& geometry = getFBXGeometry();
+
+        Head* head = _owningAvatar->getHead();
+
+        // make sure lookAt is not too close to face (avoid crosseyes)
+        glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
+        glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
+        float focusDistance = glm::length(focusOffset);
+        const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;
+        if (focusDistance < MIN_LOOK_AT_FOCUS_DISTANCE && focusDistance > EPSILON) {
+            lookAt = _owningAvatar->getHead()->getEyePosition() + (MIN_LOOK_AT_FOCUS_DISTANCE / focusDistance) * focusOffset;
+        }
+
         // no need to call Model::updateRig() because otherAvatars get their joint state
         // copied directly from AvtarData::_jointData (there are no Rig animations to blend)
         _needsUpdateClusterMatrices = true;
@@ -118,9 +118,6 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         _rig->updateFromEyeParameters(eyeParams);
      }
-
-    // evaluate AnimGraph animation and update jointStates.
-    Parent::updateRig(deltaTime, parentTransform);
 }
 
 void SkeletonModel::updateAttitude() {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -79,7 +79,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     Head* head = _owningAvatar->getHead();
 
     // make sure lookAt is not too close to face (avoid crosseyes)
-    glm::vec3 lookAt = _owningAvatar->isMyAvatar() ?  head->getLookAtPosition() : head->getCorrectedLookAtPosition();
+    glm::vec3 lookAt = head->getCorrectedLookAtPosition();
     glm::vec3 focusOffset = lookAt - _owningAvatar->getHead()->getEyePosition();
     float focusDistance = glm::length(focusOffset);
     const float MIN_LOOK_AT_FOCUS_DISTANCE = 1.0f;


### PR DESCRIPTION
This PR fixes a regression in master where lookAt eye snapping was no longer updating as of side-effect of some of the Avatar refactoring changes.

#### Testing:
* Launch two instances of this PR's Interface with avatar models where the eyeballs are visible (eg: "Photo-Real" Male or Female from the marketplace).
* Position your avatar in front of the other avatar and look/gaze around in some wide arcs.
* Verify that when you are approximately making eye contact (ie: +/- a heads-worth or two), both your and their eyes "snap" into making direct eye contact.