### PR TITLE
Bug 4255: When you are in HMD and you go to file menu quit, it crashe…

### DIFF
--- a/libraries/script-engine/src/TabletScriptingInterface.cpp
+++ b/libraries/script-engine/src/TabletScriptingInterface.cpp
@@ -250,6 +250,10 @@ static void addButtonProxyToQmlTablet(QQuickItem* qmlTablet, TabletButtonProxy* 
     if (QThread::currentThread() != qmlTablet->thread()) {
         connectionType = Qt::BlockingQueuedConnection;
     }
+	if (buttonProxy == NULL){
+		qCCritical(scriptengine) << "TabletScriptingInterface addButtonProxyToQmlTablet buttonProxy is NULL";
+		return;
+	}
     bool hasResult = QMetaObject::invokeMethod(qmlTablet, "addButtonProxy", connectionType,
                                                Q_RETURN_ARG(QVariant, resultVar), Q_ARG(QVariant, buttonProxy->getProperties()));
     if (!hasResult) {


### PR DESCRIPTION
Fix for Bug 4255: "When you are in HMD and you go to file menu quit, it crashes and you have no menus when you come back."

# **QA To Test**

HMD / Handcontrollers required

1) Put on HMD.
2) Open Tablet UI
3) Select File Menu --> Quit

**Expected Result :** Application should not crash and when you will able to see menus when you come back.

**_Note:_** Dev tested on Windows 10 + Oculus Rift