### PR TITLE
More stable IK when hips, feet and chest are controlled via external input

### DIFF
--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -49,6 +49,8 @@
                         "id": "ik",
                         "type": "inverseKinematics",
                         "data": {
+                            "solutionSource": "relaxToUnderPoses",
+                            "solutionSourceVar": "solutionSource",
                             "targets": [
                                 {
                                     "jointName": "Hips",

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -523,6 +523,8 @@ Menu::Menu() {
         avatar.get(), SLOT(setEnableDebugDrawSensorToWorldMatrix(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderIKTargets, 0, false,
         avatar.get(), SLOT(setEnableDebugDrawIKTargets(bool)));
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderIKConstraints, 0, false,
+        avatar.get(), SLOT(setEnableDebugDrawIKConstraints(bool)));
 
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ActionMotorControl,
         Qt::CTRL | Qt::SHIFT | Qt::Key_K, true, avatar.get(), SLOT(updateMotionBehaviorFromMenu()),

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -161,6 +161,7 @@ namespace MenuOption {
     const QString RenderResolutionQuarter = "1/4";
     const QString RenderSensorToWorldMatrix = "Show SensorToWorld Matrix";
     const QString RenderIKTargets = "Show IK Targets";
+    const QString RenderIKConstraints = "Show IK Constraints";
     const QString ResetAvatarSize = "Reset Avatar Size";
     const QString ResetSensors = "Reset Sensors";
     const QString RunningScripts = "Running Scripts...";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -505,6 +505,7 @@ void MyAvatar::simulate(float deltaTime) {
 
         if (_rig) {
             _rig->setEnableDebugDrawIKTargets(_enableDebugDrawIKTargets);
+            _rig->setEnableDebugDrawIKConstraints(_enableDebugDrawIKConstraints);
         }
 
         _skeletonModel->simulate(deltaTime);
@@ -928,6 +929,10 @@ void MyAvatar::setEnableDebugDrawSensorToWorldMatrix(bool isEnabled) {
 
 void MyAvatar::setEnableDebugDrawIKTargets(bool isEnabled) {
     _enableDebugDrawIKTargets = isEnabled;
+}
+
+void MyAvatar::setEnableDebugDrawIKConstraints(bool isEnabled) {
+    _enableDebugDrawIKConstraints = isEnabled;
 }
 
 void MyAvatar::setEnableMeshVisible(bool isEnabled) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1707,30 +1707,6 @@ void MyAvatar::postUpdate(float deltaTime) {
         initAnimGraph();
     }
 
-    // AJT: REMOVE.
-    /*
-    {
-        auto ikNode = _rig->getAnimInverseKinematicsNode();
-        if (ikNode) {
-            // the rig is in the skeletonModel frame
-            AnimPose xform(glm::vec3(1), _skeletonModel->getRotation(), _skeletonModel->getTranslation());
-            AnimPoseVec limitCenterPoses = ikNode->getLimitCenterPoses();
-
-            // HACK: convert joints from geom to avatar space
-            int hipsIndex = _rig->indexOfJoint("Hips");
-            for (size_t i = 0; i < limitCenterPoses.size(); i++) {
-                if (i == hipsIndex) {
-                    limitCenterPoses[i].trans() = glm::vec3(); // zero the hips
-                }
-                // convert from cm to m
-                limitCenterPoses[i].trans() = 0.01f * limitCenterPoses[i].trans();
-            }
-            _rig->getAnimSkeleton()->convertRelativePosesToAbsolute(limitCenterPoses);
-            AnimDebugDraw::getInstance().addAbsolutePoses("myAvatarLimitCenterPoses", _rig->getAnimSkeleton(), limitCenterPoses, xform, glm::vec4(1));
-        }
-    }
-    */
-
     if (_enableDebugDrawDefaultPose || _enableDebugDrawAnimPose) {
 
         auto animSkeleton = _rig->getAnimSkeleton();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1703,6 +1703,7 @@ void MyAvatar::postUpdate(float deltaTime) {
     }
 
     // AJT: REMOVE.
+    /*
     {
         auto ikNode = _rig->getAnimInverseKinematicsNode();
         if (ikNode) {
@@ -1714,7 +1715,7 @@ void MyAvatar::postUpdate(float deltaTime) {
             int hipsIndex = _rig->indexOfJoint("Hips");
             for (size_t i = 0; i < limitCenterPoses.size(); i++) {
                 if (i == hipsIndex) {
-                    //limitCenterPoses[i].trans() = glm::vec3(); // zero the hips
+                    limitCenterPoses[i].trans() = glm::vec3(); // zero the hips
                 }
                 // convert from cm to m
                 limitCenterPoses[i].trans() = 0.01f * limitCenterPoses[i].trans();
@@ -1723,6 +1724,7 @@ void MyAvatar::postUpdate(float deltaTime) {
             AnimDebugDraw::getInstance().addAbsolutePoses("myAvatarLimitCenterPoses", _rig->getAnimSkeleton(), limitCenterPoses, xform, glm::vec4(1));
         }
     }
+    */
 
     if (_enableDebugDrawDefaultPose || _enableDebugDrawAnimPose) {
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -518,6 +518,7 @@ public slots:
     void setEnableDebugDrawHandControllers(bool isEnabled);
     void setEnableDebugDrawSensorToWorldMatrix(bool isEnabled);
     void setEnableDebugDrawIKTargets(bool isEnabled);
+    void setEnableDebugDrawIKConstraints(bool isEnabled);
     bool getEnableMeshVisible() const { return _skeletonModel->isVisible(); }
     void setEnableMeshVisible(bool isEnabled);
     void setUseAnimPreAndPostRotations(bool isEnabled);
@@ -703,6 +704,7 @@ private:
     bool _enableDebugDrawHandControllers { false };
     bool _enableDebugDrawSensorToWorldMatrix { false };
     bool _enableDebugDrawIKTargets { false };
+    bool _enableDebugDrawIKConstraints { false };
 
     AudioListenerMode _audioListenerMode;
     glm::vec3 _customListenPosition;

--- a/libraries/animation/src/AnimContext.cpp
+++ b/libraries/animation/src/AnimContext.cpp
@@ -10,7 +10,9 @@
 
 #include "AnimContext.h"
 
-AnimContext::AnimContext(bool enableDebugDrawIKTargets, const glm::mat4& geometryToRigMatrix) :
+AnimContext::AnimContext(bool enableDebugDrawIKTargets, const glm::mat4& geometryToRigMatrix, const glm::mat4& rigToWorldMatrix) :
     _enableDebugDrawIKTargets(enableDebugDrawIKTargets),
-    _geometryToRigMatrix(geometryToRigMatrix) {
+    _geometryToRigMatrix(geometryToRigMatrix),
+    _rigToWorldMatrix(rigToWorldMatrix)
+{
 }

--- a/libraries/animation/src/AnimContext.cpp
+++ b/libraries/animation/src/AnimContext.cpp
@@ -10,8 +10,10 @@
 
 #include "AnimContext.h"
 
-AnimContext::AnimContext(bool enableDebugDrawIKTargets, const glm::mat4& geometryToRigMatrix, const glm::mat4& rigToWorldMatrix) :
+AnimContext::AnimContext(bool enableDebugDrawIKTargets, bool enableDebugDrawIKConstraints,
+                         const glm::mat4& geometryToRigMatrix, const glm::mat4& rigToWorldMatrix) :
     _enableDebugDrawIKTargets(enableDebugDrawIKTargets),
+    _enableDebugDrawIKConstraints(enableDebugDrawIKConstraints),
     _geometryToRigMatrix(geometryToRigMatrix),
     _rigToWorldMatrix(rigToWorldMatrix)
 {

--- a/libraries/animation/src/AnimContext.h
+++ b/libraries/animation/src/AnimContext.h
@@ -16,15 +16,18 @@
 
 class AnimContext {
 public:
-    AnimContext(bool enableDebugDrawIKTargets, const glm::mat4& geometryToRigMatrix, const glm::mat4& rigToWorldMatrix);
+    AnimContext(bool enableDebugDrawIKTargets, bool enableDebugDrawIKConstraints,
+                const glm::mat4& geometryToRigMatrix, const glm::mat4& rigToWorldMatrix);
 
     bool getEnableDebugDrawIKTargets() const { return _enableDebugDrawIKTargets; }
+    bool getEnableDebugDrawIKConstraints() const { return _enableDebugDrawIKConstraints; }
     const glm::mat4& getGeometryToRigMatrix() const { return _geometryToRigMatrix; }
     const glm::mat4& getRigToWorldMatrix() const { return _rigToWorldMatrix; }
 
 protected:
 
     bool _enableDebugDrawIKTargets { false };
+    bool _enableDebugDrawIKConstraints{ false };
     glm::mat4 _geometryToRigMatrix;
     glm::mat4 _rigToWorldMatrix;
 };

--- a/libraries/animation/src/AnimContext.h
+++ b/libraries/animation/src/AnimContext.h
@@ -16,15 +16,17 @@
 
 class AnimContext {
 public:
-    AnimContext(bool enableDebugDrawIKTargets, const glm::mat4& geometryToRigMatrix);
+    AnimContext(bool enableDebugDrawIKTargets, const glm::mat4& geometryToRigMatrix, const glm::mat4& rigToWorldMatrix);
 
     bool getEnableDebugDrawIKTargets() const { return _enableDebugDrawIKTargets; }
     const glm::mat4& getGeometryToRigMatrix() const { return _geometryToRigMatrix; }
+    const glm::mat4& getRigToWorldMatrix() const { return _rigToWorldMatrix; }
 
 protected:
 
     bool _enableDebugDrawIKTargets { false };
     glm::mat4 _geometryToRigMatrix;
+    glm::mat4 _rigToWorldMatrix;
 };
 
 #endif  // hifi_AnimContext_h

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -734,21 +734,21 @@ void AnimInverseKinematics::initConstraints() {
             std::vector<glm::vec3> swungDirections;
             float deltaTheta = PI / 4.0f;
             float theta = 0.0f;
-            swungDirections.push_back(glm::vec3(cosf(theta), -0.25f, sinf(theta)));
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), -0.25f, sinf(theta)));
             theta += deltaTheta;
-            swungDirections.push_back(glm::vec3(cosf(theta), 0.0f, sinf(theta)));
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), 0.0f, sinf(theta)));
             theta += deltaTheta;
-            swungDirections.push_back(glm::vec3(cosf(theta), 0.25f, sinf(theta))); // posterior
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), 0.25f, sinf(theta))); // posterior
             theta += deltaTheta;
-            swungDirections.push_back(glm::vec3(cosf(theta), 0.0f, sinf(theta)));
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), 0.0f, sinf(theta)));
             theta += deltaTheta;
-            swungDirections.push_back(glm::vec3(cosf(theta), -0.25f, sinf(theta)));
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), -0.25f, sinf(theta)));
             theta += deltaTheta;
-            swungDirections.push_back(glm::vec3(cosf(theta), -0.5f, sinf(theta)));
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), -0.5f, sinf(theta)));
             theta += deltaTheta;
-            swungDirections.push_back(glm::vec3(cosf(theta), -0.5f, sinf(theta))); // anterior
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), -0.5f, sinf(theta))); // anterior
             theta += deltaTheta;
-            swungDirections.push_back(glm::vec3(cosf(theta), -0.5f, sinf(theta)));
+            swungDirections.push_back(glm::vec3(mirror * cosf(theta), -0.5f, sinf(theta)));
 
             std::vector<float> minDots;
             for (size_t i = 0; i < swungDirections.size(); i++) {

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -957,6 +957,19 @@ void AnimInverseKinematics::initConstraints() {
     }
 }
 
+void AnimInverseKinematics::initLimitCenterPoses() {
+    assert(_skeleton);
+    _limitCenterPoses.reserve(_skeleton->getNumJoints());
+    for (int i = 0; i < _skeleton->getNumJoints(); i++) {
+        AnimPose pose = _skeleton->getRelativeDefaultPose(i);
+        RotationConstraint* constraint = getConstraint(i);
+        if (constraint) {
+            pose.rot() = constraint->computeCenterRotation();
+        }
+        _limitCenterPoses.push_back(pose);
+    }
+}
+
 void AnimInverseKinematics::setSkeletonInternal(AnimSkeleton::ConstPointer skeleton) {
     AnimNode::setSkeletonInternal(skeleton);
 
@@ -973,6 +986,7 @@ void AnimInverseKinematics::setSkeletonInternal(AnimSkeleton::ConstPointer skele
 
     if (skeleton) {
         initConstraints();
+        initLimitCenterPoses();
         _headIndex = _skeleton->nameToJointIndex("Head");
         _hipsIndex = _skeleton->nameToJointIndex("Hips");
 

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -751,7 +751,7 @@ void AnimInverseKinematics::initConstraints() {
             swungDirections.push_back(glm::vec3(cosf(theta), -0.5f, sinf(theta)));
 
             std::vector<float> minDots;
-            for (int i = 0; i < swungDirections.size(); i++) {
+            for (size_t i = 0; i < swungDirections.size(); i++) {
                 minDots.push_back(glm::dot(glm::normalize(swungDirections[i]), Vectors::UNIT_Y));
             }
             stConstraint->setSwingLimits(minDots);
@@ -961,11 +961,11 @@ void AnimInverseKinematics::initLimitCenterPoses() {
     const float UPPER_ARM_THETA = PI / 3.0f;  // 60 deg
     int leftArmIndex = _skeleton->nameToJointIndex("LeftArm");
     const glm::quat armRot = glm::angleAxis(UPPER_ARM_THETA, Vectors::UNIT_X);
-    if (leftArmIndex >= 0 && leftArmIndex < _limitCenterPoses.size()) {
+    if (leftArmIndex >= 0 && leftArmIndex < (int)_limitCenterPoses.size()) {
         _limitCenterPoses[leftArmIndex].rot() = _limitCenterPoses[leftArmIndex].rot() * armRot;
     }
     int rightArmIndex = _skeleton->nameToJointIndex("RightArm");
-    if (rightArmIndex >= 0 && rightArmIndex < _limitCenterPoses.size()) {
+    if (rightArmIndex >= 0 && rightArmIndex < (int)_limitCenterPoses.size()) {
         _limitCenterPoses[rightArmIndex].rot() = _limitCenterPoses[rightArmIndex].rot() * armRot;
     }
 }
@@ -1027,7 +1027,7 @@ void AnimInverseKinematics::debugDrawConstraints(const AnimContext& context) con
         AnimPoseVec poses = _skeleton->getRelativeDefaultPoses();
 
         // copy reference rotations into the relative poses
-        for (int i = 0; i < poses.size(); i++) {
+        for (int i = 0; i < (int)poses.size(); i++) {
             const RotationConstraint* constraint = getConstraint(i);
             if (constraint) {
                 poses[i].rot() = constraint->getReferenceRotation();
@@ -1040,7 +1040,7 @@ void AnimInverseKinematics::debugDrawConstraints(const AnimContext& context) con
         mat4 geomToWorldMatrix = context.getRigToWorldMatrix() * context.getGeometryToRigMatrix();
 
         // draw each pose and constraint
-        for (int i = 0; i < poses.size(); i++) {
+        for (int i = 0; i < (int)poses.size(); i++) {
             // transform local axes into world space.
             auto pose = poses[i];
             glm::vec3 xAxis = transformVectorFast(geomToWorldMatrix, pose.rot() * Vectors::UNIT_X);

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -1075,9 +1075,6 @@ void AnimInverseKinematics::debugDrawConstraints(const AnimContext& context) con
                     glm::quat minRot = glm::angleAxis(elbowConstraint->getMinAngle(), elbowConstraint->getHingeAxis());
                     glm::quat maxRot = glm::angleAxis(elbowConstraint->getMaxAngle(), elbowConstraint->getHingeAxis());
 
-                    glm::vec3 minYAxis = transformVectorFast(geomToWorldMatrix, parentAbsRot * minRot * refRot * Vectors::UNIT_Y);
-                    glm::vec3 maxYAxis = transformVectorFast(geomToWorldMatrix, parentAbsRot * maxRot * refRot * Vectors::UNIT_Y);
-
                     const int NUM_SWING_STEPS = 10;
                     for (int i = 0; i < NUM_SWING_STEPS + 1; i++) {
                         glm::quat rot = glm::normalize(glm::lerp(minRot, maxRot, i * (1.0f / NUM_SWING_STEPS)));
@@ -1095,9 +1092,6 @@ void AnimInverseKinematics::debugDrawConstraints(const AnimContext& context) con
 
                         glm::quat minRot = glm::angleAxis(swingTwistConstraint->getMinTwist(), Vectors::UNIT_Y);
                         glm::quat maxRot = glm::angleAxis(swingTwistConstraint->getMaxTwist(), Vectors::UNIT_Y);
-
-                        glm::vec3 minTwistYAxis = transformVectorFast(geomToWorldMatrix, parentAbsRot * minRot * refRot * Vectors::UNIT_X);
-                        glm::vec3 maxTwistYAxis = transformVectorFast(geomToWorldMatrix, parentAbsRot * maxRot * refRot * Vectors::UNIT_X);
 
                         const int NUM_SWING_STEPS = 10;
                         for (int i = 0; i < NUM_SWING_STEPS + 1; i++) {

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -955,6 +955,19 @@ void AnimInverseKinematics::initLimitCenterPoses() {
         }
         _limitCenterPoses.push_back(pose);
     }
+
+    // The limit center rotations for the LeftArm and RightArm form a t-pose.
+    // In order for the elbows to look more natural, we rotate them down by the avatar's sides
+    const float UPPER_ARM_THETA = 3.0f * PI / 8.0f;  // 67.5 deg
+    int leftArmIndex = _skeleton->nameToJointIndex("LeftArm");
+    const glm::quat armRot = glm::angleAxis(UPPER_ARM_THETA, Vectors::UNIT_X);
+    if (leftArmIndex >= 0 && leftArmIndex < _limitCenterPoses.size()) {
+        _limitCenterPoses[leftArmIndex].rot() = _limitCenterPoses[leftArmIndex].rot() * armRot;
+    }
+    int rightArmIndex = _skeleton->nameToJointIndex("RightArm");
+    if (rightArmIndex >= 0 && rightArmIndex < _limitCenterPoses.size()) {
+        _limitCenterPoses[rightArmIndex].rot() = _limitCenterPoses[rightArmIndex].rot() * armRot;
+    }
 }
 
 void AnimInverseKinematics::setSkeletonInternal(AnimSkeleton::ConstPointer skeleton) {

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -399,6 +399,9 @@ const AnimPoseVec& AnimInverseKinematics::evaluate(const AnimVariantMap& animVar
 //virtual
 const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars, const AnimContext& context, float dt, Triggers& triggersOut, const AnimPoseVec& underPoses) {
 
+    // allows solutionSource to be overridden by an animVar
+    auto solutionSource = animVars.lookup(_solutionSourceVar, (int)_solutionSource);
+
     if (context.getEnableDebugDrawIKConstraints()) {
         debugDrawConstraints(context);
     }
@@ -414,7 +417,7 @@ const AnimPoseVec& AnimInverseKinematics::overlay(const AnimVariantMap& animVars
 
         PROFILE_RANGE_EX(simulation_animation, "ik/relax", 0xffff00ff, 0);
 
-        initRelativePosesFromSolutionSource(underPoses);
+        initRelativePosesFromSolutionSource((SolutionSource)solutionSource, underPoses);
 
         if (!underPoses.empty()) {
             // Sometimes the underpose itself can violate the constraints.  Rather than
@@ -1135,8 +1138,8 @@ void AnimInverseKinematics::relaxToPoses(const AnimPoseVec& poses) {
     }
 }
 
-void AnimInverseKinematics::initRelativePosesFromSolutionSource(const AnimPoseVec& underPoses) {
-    switch (_solutionSource) {
+void AnimInverseKinematics::initRelativePosesFromSolutionSource(SolutionSource solutionSource, const AnimPoseVec& underPoses) {
+    switch (solutionSource) {
     default:
     case SolutionSource::RelaxToUnderPoses:
         relaxToPoses(underPoses);

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -43,9 +43,6 @@ public:
 
     float getMaxErrorOnLastSolve() { return _maxErrorOnLastSolve; }
 
-    // AJT: TODO REMOVE? for debugging.
-    const AnimPoseVec& getLimitCenterPoses() const { return _limitCenterPoses; }
-
 protected:
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets, const AnimPoseVec& underPoses);
     void solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets);

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -48,10 +48,12 @@ public:
         RelaxToLimitCenterPoses,
         PreviousSolution,
         UnderPoses,
-        LimitCenterPoses
+        LimitCenterPoses,
+        NumSolutionSources,
     };
 
     void setSolutionSource(SolutionSource solutionSource) { _solutionSource = solutionSource; }
+    void setSolutionSourceVar(const QString& solutionSourceVar) { _solutionSourceVar = solutionSourceVar; }
 
 protected:
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets, const AnimPoseVec& underPoses);
@@ -59,7 +61,7 @@ protected:
     int solveTargetWithCCD(const IKTarget& target, AnimPoseVec& absolutePoses);
     virtual void setSkeletonInternal(AnimSkeleton::ConstPointer skeleton) override;
     void debugDrawConstraints(const AnimContext& context) const;
-    void initRelativePosesFromSolutionSource(const AnimPoseVec& underPose);
+    void initRelativePosesFromSolutionSource(SolutionSource solutionSource, const AnimPoseVec& underPose);
     void relaxToPoses(const AnimPoseVec& poses);
 
     // for AnimDebugDraw rendering
@@ -116,6 +118,7 @@ protected:
     float _maxErrorOnLastSolve { FLT_MAX };
     bool _previousEnableDebugIKTargets { false };
     SolutionSource _solutionSource { SolutionSource::RelaxToUnderPoses };
+    QString _solutionSourceVar;
 };
 
 #endif // hifi_AnimInverseKinematics_h

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -51,11 +51,12 @@ protected:
     void solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets);
     int solveTargetWithCCD(const IKTarget& target, AnimPoseVec& absolutePoses);
     virtual void setSkeletonInternal(AnimSkeleton::ConstPointer skeleton) override;
+    void debugDrawConstraints(const AnimContext& context) const;
 
     // for AnimDebugDraw rendering
     virtual const AnimPoseVec& getPosesInternal() const override { return _relativePoses; }
 
-    RotationConstraint* getConstraint(int index);
+    RotationConstraint* getConstraint(int index) const;
     void clearConstraints();
     void initConstraints();
     void initLimitCenterPoses();

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -43,12 +43,24 @@ public:
 
     float getMaxErrorOnLastSolve() { return _maxErrorOnLastSolve; }
 
+    enum class SolutionSource {
+        RelaxToUnderPoses = 0,
+        RelaxToLimitCenterPoses,
+        PreviousSolution,
+        UnderPoses,
+        LimitCenterPoses
+    };
+
+    void setSolutionSource(SolutionSource solutionSource) { _solutionSource = solutionSource; }
+
 protected:
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets, const AnimPoseVec& underPoses);
     void solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets);
     int solveTargetWithCCD(const IKTarget& target, AnimPoseVec& absolutePoses);
     virtual void setSkeletonInternal(AnimSkeleton::ConstPointer skeleton) override;
     void debugDrawConstraints(const AnimContext& context) const;
+    void initRelativePosesFromSolutionSource(const AnimPoseVec& underPose);
+    void relaxToPoses(const AnimPoseVec& poses);
 
     // for AnimDebugDraw rendering
     virtual const AnimPoseVec& getPosesInternal() const override { return _relativePoses; }
@@ -103,6 +115,7 @@ protected:
 
     float _maxErrorOnLastSolve { FLT_MAX };
     bool _previousEnableDebugIKTargets { false };
+    SolutionSource _solutionSource { SolutionSource::RelaxToUnderPoses };
 };
 
 #endif // hifi_AnimInverseKinematics_h

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -62,7 +62,7 @@ protected:
     virtual void setSkeletonInternal(AnimSkeleton::ConstPointer skeleton) override;
     void debugDrawConstraints(const AnimContext& context) const;
     void initRelativePosesFromSolutionSource(SolutionSource solutionSource, const AnimPoseVec& underPose);
-    void relaxToPoses(const AnimPoseVec& poses);
+    void blendToPoses(const AnimPoseVec& targetPoses, const AnimPoseVec& underPose, float blendFactor);
 
     // for AnimDebugDraw rendering
     virtual const AnimPoseVec& getPosesInternal() const override { return _relativePoses; }

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -43,6 +43,9 @@ public:
 
     float getMaxErrorOnLastSolve() { return _maxErrorOnLastSolve; }
 
+    // AJT: TODO REMOVE? for debugging.
+    const AnimPoseVec& getLimitCenterPoses() const { return _limitCenterPoses; }
+
 protected:
     void computeTargets(const AnimVariantMap& animVars, std::vector<IKTarget>& targets, const AnimPoseVec& underPoses);
     void solveWithCyclicCoordinateDescent(const std::vector<IKTarget>& targets);
@@ -55,6 +58,7 @@ protected:
     RotationConstraint* getConstraint(int index);
     void clearConstraints();
     void initConstraints();
+    void initLimitCenterPoses();
     void computeHipsOffset(const std::vector<IKTarget>& targets, const AnimPoseVec& underPoses, float dt);
 
     // no copies
@@ -85,6 +89,7 @@ protected:
     std::vector<IKTargetVar> _targetVarVec;
     AnimPoseVec _defaultRelativePoses; // poses of the relaxed state
     AnimPoseVec _relativePoses; // current relative poses
+    AnimPoseVec _limitCenterPoses;  // relative
 
     // experimental data for moving hips during IK
     glm::vec3 _hipsOffset { Vectors::ZERO };

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -352,7 +352,7 @@ static AnimOverlay::BoneSet stringToBoneSetEnum(const QString& str) {
     return AnimOverlay::NumBoneSets;
 }
 
-static const char* solutionSourceStrings[AnimInverseKinematics::SolutionSource::NumSolutionSources] = {
+static const char* solutionSourceStrings[(int)AnimInverseKinematics::SolutionSource::NumSolutionSources] = {
     "relaxToUnderPoses",
     "relaxToLimitCenterPoses",
     "previousSolution",

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -477,8 +477,6 @@ AnimNode::Pointer loadInverseKinematicsNode(const QJsonObject& jsonObj, const QS
     READ_OPTIONAL_STRING(solutionSource, jsonObj);
 
     if (!solutionSource.isEmpty()) {
-        qCDebug(animation) << "AJT: REMOVE solutionSource = " << solutionSource;
-
         AnimInverseKinematics::SolutionSource solutionSourceType = stringToSolutionSourceEnum(solutionSource);
         if (solutionSourceType != AnimInverseKinematics::SolutionSource::NumSolutionSources) {
             node->setSolutionSource(solutionSourceType);
@@ -490,7 +488,6 @@ AnimNode::Pointer loadInverseKinematicsNode(const QJsonObject& jsonObj, const QS
     READ_OPTIONAL_STRING(solutionSourceVar, jsonObj);
 
     if (!solutionSourceVar.isEmpty()) {
-        qCDebug(animation) << "AJT: REMOVE solutionSourceVar = " << solutionSourceVar;
         node->setSolutionSourceVar(solutionSourceVar);
     }
 

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -352,6 +352,23 @@ static AnimOverlay::BoneSet stringToBoneSetEnum(const QString& str) {
     return AnimOverlay::NumBoneSets;
 }
 
+static const char* solutionSourceStrings[AnimInverseKinematics::SolutionSource::NumSolutionSources] = {
+    "relaxToUnderPoses",
+    "relaxToLimitCenterPoses",
+    "previousSolution",
+    "underPoses",
+    "limitCenterPoses"
+};
+
+static AnimInverseKinematics::SolutionSource stringToSolutionSourceEnum(const QString& str) {
+    for (int i = 0; i < (int)AnimInverseKinematics::SolutionSource::NumSolutionSources; i++) {
+        if (str == solutionSourceStrings[i]) {
+            return (AnimInverseKinematics::SolutionSource)i;
+        }
+    }
+    return AnimInverseKinematics::SolutionSource::NumSolutionSources;
+}
+
 static AnimNode::Pointer loadOverlayNode(const QJsonObject& jsonObj, const QString& id, const QUrl& jsonUrl) {
 
     READ_STRING(boneSet, jsonObj, id, jsonUrl, nullptr);
@@ -456,6 +473,26 @@ AnimNode::Pointer loadInverseKinematicsNode(const QJsonObject& jsonObj, const QS
 
         node->setTargetVars(jointName, positionVar, rotationVar, typeVar);
     };
+
+    READ_OPTIONAL_STRING(solutionSource, jsonObj);
+
+    if (!solutionSource.isEmpty()) {
+        qCDebug(animation) << "AJT: REMOVE solutionSource = " << solutionSource;
+
+        AnimInverseKinematics::SolutionSource solutionSourceType = stringToSolutionSourceEnum(solutionSource);
+        if (solutionSourceType != AnimInverseKinematics::SolutionSource::NumSolutionSources) {
+            node->setSolutionSource(solutionSourceType);
+        } else {
+            qCWarning(animation) << "AnimNodeLoader, bad solutionSourceType in \"solutionSource\", id = " << id << ", url = " << jsonUrl.toDisplayString();
+        }
+    }
+
+    READ_OPTIONAL_STRING(solutionSourceVar, jsonObj);
+
+    if (!solutionSourceVar.isEmpty()) {
+        qCDebug(animation) << "AJT: REMOVE solutionSourceVar = " << solutionSourceVar;
+        node->setSolutionSourceVar(solutionSourceVar);
+    }
 
     return node;
 }

--- a/libraries/animation/src/AnimPose.cpp
+++ b/libraries/animation/src/AnimPose.cpp
@@ -39,7 +39,7 @@ glm::vec3 AnimPose::xformPoint(const glm::vec3& rhs) const {
     return *this * rhs;
 }
 
-// really slow
+// really slow, but accurate for transforms with non-uniform scale
 glm::vec3 AnimPose::xformVector(const glm::vec3& rhs) const {
     glm::vec3 xAxis = _rot * glm::vec3(_scale.x, 0.0f, 0.0f);
     glm::vec3 yAxis = _rot * glm::vec3(0.0f, _scale.y, 0.0f);
@@ -47,6 +47,11 @@ glm::vec3 AnimPose::xformVector(const glm::vec3& rhs) const {
     glm::mat3 mat(xAxis, yAxis, zAxis);
     glm::mat3 transInvMat = glm::inverse(glm::transpose(mat));
     return transInvMat * rhs;
+}
+
+// faster, but does not handle non-uniform scale correctly.
+glm::vec3 AnimPose::xformVectorFast(const glm::vec3& rhs) const {
+    return _rot * (_scale * rhs);
 }
 
 AnimPose AnimPose::operator*(const AnimPose& rhs) const {

--- a/libraries/animation/src/AnimPose.h
+++ b/libraries/animation/src/AnimPose.h
@@ -25,7 +25,8 @@ public:
     static const AnimPose identity;
 
     glm::vec3 xformPoint(const glm::vec3& rhs) const;
-    glm::vec3 xformVector(const glm::vec3& rhs) const;  // really slow
+    glm::vec3 xformVector(const glm::vec3& rhs) const;  // really slow, but accurate for transforms with non-uniform scale
+    glm::vec3 xformVectorFast(const glm::vec3& rhs) const;  // faster, but does not handle non-uniform scale correctly.
 
     glm::vec3 operator*(const glm::vec3& rhs) const; // same as xformPoint
     AnimPose operator*(const AnimPose& rhs) const;

--- a/libraries/animation/src/AnimUtil.cpp
+++ b/libraries/animation/src/AnimUtil.cpp
@@ -37,16 +37,15 @@ glm::quat averageQuats(size_t numQuats, const glm::quat* quats) {
     if (numQuats == 0) {
         return glm::quat();
     }
-    float alpha = 1.0f / (float)numQuats;
-    glm::quat accum(0, 0, 0, 0);
+    glm::quat accum = quats[0];
     glm::quat firstRot = quats[0];
-    for (size_t i = 0; i < numQuats; i++) {
+    for (size_t i = 1; i < numQuats; i++) {
         glm::quat rot = quats[i];
         float dot = glm::dot(firstRot, rot);
         if (dot < 0.0f) {
             rot = -rot;
         }
-        accum += alpha * rot;
+        accum += rot;
     }
     return glm::normalize(accum);
 }

--- a/libraries/animation/src/AnimUtil.cpp
+++ b/libraries/animation/src/AnimUtil.cpp
@@ -33,6 +33,24 @@ void blend(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, A
     }
 }
 
+glm::quat averageQuats(size_t numQuats, const glm::quat* quats) {
+    if (numQuats == 0) {
+        return glm::quat();
+    }
+    float alpha = 1.0f / (float)numQuats;
+    glm::quat accum(0, 0, 0, 0);
+    glm::quat firstRot = quats[0];
+    for (size_t i = 0; i < numQuats; i++) {
+        glm::quat rot = quats[i];
+        float dot = glm::dot(firstRot, rot);
+        if (dot < 0.0f) {
+            rot = -rot;
+        }
+        accum += alpha * rot;
+    }
+    return glm::normalize(accum);
+}
+
 float accumulateTime(float startFrame, float endFrame, float timeScale, float currentFrame, float dt, bool loopFlag,
                      const QString& id, AnimNode::Triggers& triggersOut) {
 

--- a/libraries/animation/src/AnimUtil.h
+++ b/libraries/animation/src/AnimUtil.h
@@ -16,9 +16,9 @@
 // this is where the magic happens
 void blend(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, AnimPose* result);
 
+glm::quat averageQuats(size_t numQuats, const glm::quat* quats);
+
 float accumulateTime(float startFrame, float endFrame, float timeScale, float currentFrame, float dt, bool loopFlag,
                      const QString& id, AnimNode::Triggers& triggersOut);
 
 #endif
-
-

--- a/libraries/animation/src/ElbowConstraint.cpp
+++ b/libraries/animation/src/ElbowConstraint.cpp
@@ -13,6 +13,7 @@
 
 #include <GeometryUtil.h>
 #include <NumericalConstants.h>
+#include "AnimUtil.h"
 
 ElbowConstraint::ElbowConstraint() :
         _minAngle(-PI),
@@ -77,3 +78,10 @@ bool ElbowConstraint::apply(glm::quat& rotation) const {
     return false;
 }
 
+glm::quat ElbowConstraint::computeCenterRotation() const {
+    const size_t NUM_LIMITS = 2;
+    glm::quat limits[NUM_LIMITS];
+    limits[0] = glm::angleAxis(_minAngle, _axis) * _referenceRotation;
+    limits[1] = glm::angleAxis(_maxAngle, _axis) * _referenceRotation;
+    return averageQuats(NUM_LIMITS, limits);
+}

--- a/libraries/animation/src/ElbowConstraint.h
+++ b/libraries/animation/src/ElbowConstraint.h
@@ -19,6 +19,11 @@ public:
     void setAngleLimits(float minAngle, float maxAngle);
     virtual bool apply(glm::quat& rotation) const override;
     virtual glm::quat computeCenterRotation() const override;
+
+    glm::vec3 getHingeAxis() const { return _axis; }
+    float getMinAngle() const { return _minAngle; }
+    float getMaxAngle() const { return _maxAngle; }
+
 protected:
     glm::vec3 _axis;
     glm::vec3 _perpAxis;

--- a/libraries/animation/src/ElbowConstraint.h
+++ b/libraries/animation/src/ElbowConstraint.h
@@ -18,6 +18,7 @@ public:
     void setHingeAxis(const glm::vec3& axis);
     void setAngleLimits(float minAngle, float maxAngle);
     virtual bool apply(glm::quat& rotation) const override;
+    virtual glm::quat computeCenterRotation() const override;
 protected:
     glm::vec3 _axis;
     glm::vec3 _perpAxis;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -954,7 +954,8 @@ void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform, glm::mat4 r
         updateAnimationStateHandlers();
         _animVars.setRigToGeometryTransform(_rigToGeometryTransform);
 
-        AnimContext context(_enableDebugDrawIKTargets, getGeometryToRigTransform(), rigToWorldTransform);
+        AnimContext context(_enableDebugDrawIKTargets, _enableDebugDrawIKConstraints,
+                            getGeometryToRigTransform(), rigToWorldTransform);
 
         // evaluate the animation
         AnimNode::Triggers triggersOut;
@@ -1445,7 +1446,7 @@ void Rig::computeAvatarBoundingCapsule(
 
     // call overlay twice: once to verify AnimPoseVec joints and again to do the IK
     AnimNode::Triggers triggersOut;
-    AnimContext context(false, glm::mat4(), glm::mat4());
+    AnimContext context(false, false, glm::mat4(), glm::mat4());
     float dt = 1.0f; // the value of this does not matter
     ikNode.overlay(animVars, context, dt, triggersOut, _animSkeleton->getRelativeBindPoses());
     AnimPoseVec finalPoses =  ikNode.overlay(animVars, context, dt, triggersOut, _animSkeleton->getRelativeBindPoses());

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1031,7 +1031,7 @@ void Rig::updateFromHeadParameters(const HeadParameters& params, float dt) {
     _animVars.set("notIsTalking", !params.isTalking);
 
     if (params.hipsEnabled) {
-        _animVars.set("solutionSource", (int)AnimInverseKinematics::SolutionSource::RelaxToCenterJointLimits);
+        _animVars.set("solutionSource", (int)AnimInverseKinematics::SolutionSource::RelaxToLimitCenterPoses);
         _animVars.set("hipsType", (int)IKTarget::Type::RotationAndPosition);
         _animVars.set("hipsPosition", extractTranslation(params.hipsMatrix));
         _animVars.set("hipsRotation", glmExtractRotation(params.hipsMatrix));

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1031,10 +1031,12 @@ void Rig::updateFromHeadParameters(const HeadParameters& params, float dt) {
     _animVars.set("notIsTalking", !params.isTalking);
 
     if (params.hipsEnabled) {
+        _animVars.set("solutionSource", (int)AnimInverseKinematics::SolutionSource::RelaxToCenterJointLimits);
         _animVars.set("hipsType", (int)IKTarget::Type::RotationAndPosition);
         _animVars.set("hipsPosition", extractTranslation(params.hipsMatrix));
         _animVars.set("hipsRotation", glmExtractRotation(params.hipsMatrix));
     } else {
+        _animVars.set("solutionSource", (int)AnimInverseKinematics::SolutionSource::RelaxToUnderPoses);
         _animVars.set("hipsType", (int)IKTarget::Type::Unknown);
     }
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -941,7 +941,7 @@ void Rig::updateAnimationStateHandlers() { // called on avatar update thread (wh
     }
 }
 
-void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform, glm::mat4 rigToWorldTransform) {
+void Rig::updateAnimations(float deltaTime, const glm::mat4& rootTransform, const glm::mat4& rigToWorldTransform) {
 
     PROFILE_RANGE_EX(simulation_animation_detail, __FUNCTION__, 0xffff00ff, 0);
     PerformanceTimer perfTimer("updateAnimations");

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -941,7 +941,7 @@ void Rig::updateAnimationStateHandlers() { // called on avatar update thread (wh
     }
 }
 
-void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
+void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform, glm::mat4 rigToWorldTransform) {
 
     PROFILE_RANGE_EX(simulation_animation_detail, __FUNCTION__, 0xffff00ff, 0);
     PerformanceTimer perfTimer("updateAnimations");
@@ -954,7 +954,7 @@ void Rig::updateAnimations(float deltaTime, glm::mat4 rootTransform) {
         updateAnimationStateHandlers();
         _animVars.setRigToGeometryTransform(_rigToGeometryTransform);
 
-        AnimContext context(_enableDebugDrawIKTargets, getGeometryToRigTransform());
+        AnimContext context(_enableDebugDrawIKTargets, getGeometryToRigTransform(), rigToWorldTransform);
 
         // evaluate the animation
         AnimNode::Triggers triggersOut;
@@ -1445,7 +1445,7 @@ void Rig::computeAvatarBoundingCapsule(
 
     // call overlay twice: once to verify AnimPoseVec joints and again to do the IK
     AnimNode::Triggers triggersOut;
-    AnimContext context(false, glm::mat4());
+    AnimContext context(false, glm::mat4(), glm::mat4());
     float dt = 1.0f; // the value of this does not matter
     ikNode.overlay(animVars, context, dt, triggersOut, _animSkeleton->getRelativeBindPoses());
     AnimPoseVec finalPoses =  ikNode.overlay(animVars, context, dt, triggersOut, _animSkeleton->getRelativeBindPoses());

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -305,30 +305,35 @@ void Rig::clearJointAnimationPriority(int index) {
     }
 }
 
-void Rig::clearIKJointLimitHistory() {
+std::shared_ptr<AnimInverseKinematics> Rig::getAnimInverseKinematicsNode() const {
+    std::shared_ptr<AnimInverseKinematics> result;
     if (_animNode) {
         _animNode->traverse([&](AnimNode::Pointer node) {
             // only report clip nodes as valid roles.
             auto ikNode = std::dynamic_pointer_cast<AnimInverseKinematics>(node);
             if (ikNode) {
-                ikNode->clearIKJointLimitHistory();
+                result = ikNode;
+                return false;
+            } else {
+                return true;
             }
-            return true;
         });
+    }
+    return result;
+}
+
+void Rig::clearIKJointLimitHistory() {
+    auto ikNode = getAnimInverseKinematicsNode();
+    if (ikNode) {
+        ikNode->clearIKJointLimitHistory();
     }
 }
 
 void Rig::setMaxHipsOffsetLength(float maxLength) {
     _maxHipsOffsetLength = maxLength;
-
-    if (_animNode) {
-        _animNode->traverse([&](AnimNode::Pointer node) {
-            auto ikNode = std::dynamic_pointer_cast<AnimInverseKinematics>(node);
-            if (ikNode) {
-                ikNode->setMaxHipsOffsetLength(_maxHipsOffsetLength);
-            }
-            return true;
-        });
+    auto ikNode = getAnimInverseKinematicsNode();
+    if (ikNode) {
+        ikNode->setMaxHipsOffsetLength(_maxHipsOffsetLength);
     }
 }
 

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -231,6 +231,7 @@ public:
     const glm::mat4& getGeometryToRigTransform() const { return _geometryToRigTransform; }
 
     void setEnableDebugDrawIKTargets(bool enableDebugDrawIKTargets) { _enableDebugDrawIKTargets = enableDebugDrawIKTargets; }
+    void setEnableDebugDrawIKConstraints(bool enableDebugDrawIKConstraints) { _enableDebugDrawIKConstraints = enableDebugDrawIKConstraints; }
 
     // input assumed to be in rig space
     void computeHeadFromHMD(const AnimPose& hmdPose, glm::vec3& headPositionOut, glm::quat& headOrientationOut) const;
@@ -341,6 +342,7 @@ protected:
     float _maxHipsOffsetLength { 1.0f };
 
     bool _enableDebugDrawIKTargets { false };
+    bool _enableDebugDrawIKConstraints { false };
 
 private:
     QMap<int, StateHandler> _stateHandlers;

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -112,7 +112,7 @@ public:
     void clearJointStates();
     void clearJointAnimationPriority(int index);
 
-    std::shared_ptr<AnimInverseKinematics> Rig::getAnimInverseKinematicsNode() const;
+    std::shared_ptr<AnimInverseKinematics> getAnimInverseKinematicsNode() const;
 
     void clearIKJointLimitHistory();
     void setMaxHipsOffsetLength(float maxLength);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -26,6 +26,7 @@
 #include "SimpleMovingAverage.h"
 
 class Rig;
+class AnimInverseKinematics;
 typedef std::shared_ptr<Rig> RigPointer;
 
 // Rig instances are reentrant.
@@ -110,6 +111,8 @@ public:
     void clearJointState(int index);
     void clearJointStates();
     void clearJointAnimationPriority(int index);
+
+    std::shared_ptr<AnimInverseKinematics> Rig::getAnimInverseKinematicsNode() const;
 
     void clearIKJointLimitHistory();
     void setMaxHipsOffsetLength(float maxLength);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -162,7 +162,7 @@ public:
     void computeMotionAnimationState(float deltaTime, const glm::vec3& worldPosition, const glm::vec3& worldVelocity, const glm::quat& worldRotation, CharacterControllerState ccState);
 
     // Regardless of who started the animations or how many, update the joints.
-    void updateAnimations(float deltaTime, glm::mat4 rootTransform);
+    void updateAnimations(float deltaTime, glm::mat4 rootTransform, glm::mat4 rigToWorldTransform);
 
     // legacy
     void inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::quat& targetRotation, float priority,

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -162,7 +162,7 @@ public:
     void computeMotionAnimationState(float deltaTime, const glm::vec3& worldPosition, const glm::vec3& worldVelocity, const glm::quat& worldRotation, CharacterControllerState ccState);
 
     // Regardless of who started the animations or how many, update the joints.
-    void updateAnimations(float deltaTime, glm::mat4 rootTransform, glm::mat4 rigToWorldTransform);
+    void updateAnimations(float deltaTime, const glm::mat4& rootTransform, const glm::mat4& rigToWorldTransform);
 
     // legacy
     void inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::quat& targetRotation, float priority,

--- a/libraries/animation/src/RotationConstraint.h
+++ b/libraries/animation/src/RotationConstraint.h
@@ -38,6 +38,9 @@ public:
     /// \brief reset any remembered joint limit history
     virtual void clearHistory() {};
 
+    /// \brief return the rotation that lies at the "center" of all the joint limits.
+    virtual glm::quat computeCenterRotation() const = 0;
+
 protected:
     glm::quat _referenceRotation = glm::quat();
 };

--- a/libraries/animation/src/SwingTwistConstraint.cpp
+++ b/libraries/animation/src/SwingTwistConstraint.cpp
@@ -435,13 +435,13 @@ void SwingTwistConstraint::clearHistory() {
 glm::quat SwingTwistConstraint::computeCenterRotation() const {
     const size_t NUM_MIN_DOTS = getMinDots().size();
     const size_t NUM_LIMITS = 2 * NUM_MIN_DOTS;
-    std::vector<glm::quat> limits;
-    limits.reserve(NUM_LIMITS);
-    glm::quat minTwistRot;
-    glm::quat maxTwistRot;
+    std::vector<glm::quat> swingLimits;
+    swingLimits.reserve(NUM_LIMITS);
+
+    glm::quat twistLimits[2];
     if (_minTwist != _maxTwist) {
-        minTwistRot = glm::angleAxis(_minTwist, _referenceRotation * Vectors::UNIT_Y);
-        minTwistRot = glm::angleAxis(_maxTwist, _referenceRotation * Vectors::UNIT_Y);
+        twistLimits[0] = glm::angleAxis(_minTwist, _referenceRotation * Vectors::UNIT_Y);
+        twistLimits[1] = glm::angleAxis(_maxTwist, _referenceRotation * Vectors::UNIT_Y);
     }
     const float D_THETA = TWO_PI / NUM_MIN_DOTS;
     float theta = 0.0f;
@@ -451,9 +451,11 @@ glm::quat SwingTwistConstraint::computeCenterRotation() const {
         float cos_phi = getMinDots()[i];
         float sin_phi = sinf(phi);
         glm::vec3 swungAxis(sin_phi * cosf(theta), cos_phi, sin_phi * sinf(theta));
-        glm::quat swing = glm::angleAxis(phi, glm::cross(Vectors::UNIT_Y, swungAxis));
-        limits.push_back(swing * minTwistRot);
-        limits.push_back(swing * maxTwistRot);
+        glm::quat swing = glm::angleAxis(phi, glm::normalize(glm::cross(Vectors::UNIT_Y, swungAxis)));
+        swingLimits.push_back(swing);
     }
-    return averageQuats(limits.size(), &limits[0]);
+    glm::quat limits[2];
+    limits[0] = averageQuats(swingLimits.size(), &swingLimits[0]);
+    limits[1] = averageQuats(2, twistLimits);
+    return averageQuats(2, limits);
 }

--- a/libraries/animation/src/SwingTwistConstraint.cpp
+++ b/libraries/animation/src/SwingTwistConstraint.cpp
@@ -433,15 +433,16 @@ void SwingTwistConstraint::clearHistory() {
 }
 
 glm::quat SwingTwistConstraint::computeCenterRotation() const {
+    const size_t NUM_TWIST_LIMITS = 2;
     const size_t NUM_MIN_DOTS = getMinDots().size();
-    const size_t NUM_LIMITS = 2 * NUM_MIN_DOTS;
     std::vector<glm::quat> swingLimits;
-    swingLimits.reserve(NUM_LIMITS);
+    swingLimits.reserve(NUM_MIN_DOTS);
 
-    glm::quat twistLimits[2];
+    glm::quat twistLimits[NUM_TWIST_LIMITS];
     if (_minTwist != _maxTwist) {
-        twistLimits[0] = glm::angleAxis(_minTwist, _referenceRotation * Vectors::UNIT_Y);
-        twistLimits[1] = glm::angleAxis(_maxTwist, _referenceRotation * Vectors::UNIT_Y);
+        // to ensure that twists do not flip the center rotation, we devide twist angle by 2.
+        twistLimits[0] = glm::angleAxis(_minTwist / 2.0f, _referenceRotation * Vectors::UNIT_Y);
+        twistLimits[1] = glm::angleAxis(_maxTwist / 2.0f, _referenceRotation * Vectors::UNIT_Y);
     }
     const float D_THETA = TWO_PI / (NUM_MIN_DOTS - 1);
     float theta = 0.0f;
@@ -450,7 +451,7 @@ glm::quat SwingTwistConstraint::computeCenterRotation() const {
         float phi = acos(getMinDots()[i]);
         float cos_phi = getMinDots()[i];
         float sin_phi = sinf(phi);
-        glm::vec3 swungAxis(sin_phi * cosf(theta), cos_phi, sin_phi * sinf(theta));
+        glm::vec3 swungAxis(sin_phi * cosf(theta), cos_phi, -sin_phi * sinf(theta));
 
         // to ensure that swings > 90 degrees do not flip the center rotation, we devide phi / 2
         glm::quat swing = glm::angleAxis(phi / 2, glm::normalize(glm::cross(Vectors::UNIT_Y, swungAxis)));

--- a/libraries/animation/src/SwingTwistConstraint.h
+++ b/libraries/animation/src/SwingTwistConstraint.h
@@ -101,8 +101,8 @@ public:
 
     virtual glm::quat computeCenterRotation() const override;
 
-    const float getMinTwist() const { return _minTwist; }
-    const float getMaxTwist() const { return _maxTwist; }
+    float getMinTwist() const { return _minTwist; }
+    float getMaxTwist() const { return _maxTwist; }
 
 private:
     float handleTwistBoundaryConditions(float twistAngle) const;

--- a/libraries/animation/src/SwingTwistConstraint.h
+++ b/libraries/animation/src/SwingTwistConstraint.h
@@ -58,7 +58,7 @@ public:
     virtual void dynamicallyAdjustLimits(const glm::quat& rotation) override;
 
     // for testing purposes
-    const std::vector<float>& getMinDots() { return _swingLimitFunction.getMinDots(); }
+    const std::vector<float>& getMinDots() const { return _swingLimitFunction.getMinDots(); }
 
     // SwingLimitFunction is an implementation of the constraint check described in the paper:
     // "The Parameterization of Joint Rotation with the Unit Quaternion" by Quang Liu and Edmond C. Prakash
@@ -81,7 +81,7 @@ public:
         float getMinDot(float theta) const;
 
         // for testing purposes
-        const std::vector<float>& getMinDots() { return _minDots; }
+        const std::vector<float>& getMinDots() const { return _minDots; }
 
     private:
         // the limits are stored in a lookup table with cyclic boundary conditions
@@ -98,6 +98,8 @@ public:
     const SwingLimitFunction& getSwingLimitFunction() const { return _swingLimitFunction; }
 
     void clearHistory() override;
+
+    virtual glm::quat computeCenterRotation() const override;
 
 private:
     float handleTwistBoundaryConditions(float twistAngle) const;

--- a/libraries/animation/src/SwingTwistConstraint.h
+++ b/libraries/animation/src/SwingTwistConstraint.h
@@ -101,6 +101,9 @@ public:
 
     virtual glm::quat computeCenterRotation() const override;
 
+    const float getMinTwist() const { return _minTwist; }
+    const float getMaxTwist() const { return _maxTwist; }
+
 private:
     float handleTwistBoundaryConditions(float twistAngle) const;
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1046,7 +1046,8 @@ void Model::simulate(float deltaTime, bool fullUpdate) {
 //virtual
 void Model::updateRig(float deltaTime, glm::mat4 parentTransform) {
     _needsUpdateClusterMatrices = true;
-    _rig->updateAnimations(deltaTime, parentTransform);
+    glm::mat4 rigToWorldTransform = createMatFromQuatAndPos(getRotation(), getTranslation());
+    _rig->updateAnimations(deltaTime, parentTransform, rigToWorldTransform);
 }
 
 void Model::computeMeshPartLocalBounds() {


### PR DESCRIPTION
* When hips are controlled by external input, the IK solver starts from a mix of the previous solution and the center of the joint limits.  This results in fewer gyrations in free joints due to unexpected animations playing from the underPoses.  For example, while driving, talking or jumping.
* Added "Developer > Avatar > Show IK Constraints" menu option to visualize the skeleton's joint constraints.
* Bug fixes for elliptical swing constraints, lateral and anterior limits were rotated 90 degrees and side cusps have been removed.
* More accurate calculation for hip constraints
* Added xformVectorFast method to AnimPose class.
