### PR TITLE
fix OBJ model load hang

### DIFF
--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -273,10 +273,9 @@ std::tuple<bool, QByteArray> requestData(QUrl& url) {
         return std::make_tuple(false, QByteArray());
     }
 
-    request->send();
-
     QEventLoop loop;
     QObject::connect(request, &ResourceRequest::finished, &loop, &QEventLoop::quit);
+    request->send();
     loop.exec();
 
     if (request->getResult() == ResourceRequest::Success) {


### PR DESCRIPTION
- fix a bug that could cause OBJ models with mtl references to block the loading thread
