### PR TITLE
Fix possible corruption of ktx cache files

### DIFF
--- a/libraries/networking/src/FileCache.cpp
+++ b/libraries/networking/src/FileCache.cpp
@@ -112,9 +112,8 @@ FilePointer FileCache::writeFile(const char* data, File::Metadata&& metadata) {
     }
 
     QSaveFile saveFile(QString::fromStdString(filepath));
-    saveFile.open(QIODevice::WriteOnly);
-    saveFile.write(data, metadata.length);
-    if (saveFile.commit()) {
+    if (saveFile.open(QIODevice::WriteOnly) && saveFile.write(data, metadata.length) == metadata.length
+        && saveFile.commit()) {
         file = addFile(std::move(metadata), filepath);
     } else {
         qCWarning(file_cache, "[%s] Failed to write %s", _dirname.c_str(), metadata.key.c_str());

--- a/libraries/networking/src/FileCache.cpp
+++ b/libraries/networking/src/FileCache.cpp
@@ -112,8 +112,10 @@ FilePointer FileCache::writeFile(const char* data, File::Metadata&& metadata) {
     }
 
     QSaveFile saveFile(QString::fromStdString(filepath));
-    if (saveFile.open(QIODevice::WriteOnly) && saveFile.write(data, metadata.length) == metadata.length
+    if (saveFile.open(QIODevice::WriteOnly)
+        && saveFile.write(data, metadata.length) == static_cast<qint64>(metadata.length)
         && saveFile.commit()) {
+
         file = addFile(std::move(metadata), filepath);
     } else {
         qCWarning(file_cache, "[%s] Failed to write %s", _dirname.c_str(), metadata.key.c_str());


### PR DESCRIPTION
When creating a file like this:

  1. Create file
  2. Write file
  3. Close file

there is an opening before the file is written and closed where, if the
application were to crash (or not finish for any other reason), the file
would be left in an undefined state. Instead, this change updates it to
do this:

  1. Create temp file
  2. Write temp file
  3. Close temp file
  4. Move temp file to final path

This ensures that at step 3 we have a valid file, before we rename it.
We should never end up with a final file in an undefined state, but it is
possible to end up with a temp file that is an undefined state if we,
for instance, crash during step 2.