### PR TITLE
Enable the PAL to update data about a single connection

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -844,7 +844,7 @@ Rectangle {
                     boxSize: 24;
                     onClicked: {
                         var newValue = model.connection !== "friend";
-                        connectionsUserModel.setProperty(model.userIndex, styleData.role, newValue);
+                        connectionsUserModel.setProperty(model.userIndex, styleData.role, (newValue ? "friend" : "connection"));
                         connectionsUserModelData[model.userIndex][styleData.role] = newValue; // Defensive programming
                         pal.sendToScript({method: newValue ? 'addFriend' : 'removeFriend', params: model.userName});
 


### PR DESCRIPTION
This PR makes the following changes to the PAL:
- In the Connections tab, the PAL will no longer "shift" after friending/unfriending a Connection
- The PAL now supports updating the information (location, profile pic, etc) about a single Connection, rather than always refreshing the entire list
- This PR fixes a bug where the Connection model data wouldn't get updated, and would instead result in a console error.

**Test Plan:***
1. Ensure you have at least 10 connections and you're logged in.
2. Open the PAL.
3. Go to the "Connections" tab.
4. Scroll to your bottom connection.
5. Check the "Friends" box.
6. Verify that you see no errors in your logs, verify that the connection's profile picture border changes color, and verify that the table view doesn't shift to the top of the table.