### PR TITLE
minor handshake script update

### DIFF
--- a/scripts/system/makeUserConnection.js
+++ b/scripts/system/makeUserConnection.js
@@ -366,6 +366,8 @@
         return nearestAvatar;
     }
     function messageSend(message) {
+        // we always append whether or not we are logged in...
+        message.isLoggedIn = Account.isLoggedIn();
         Messages.sendMessage(MESSAGE_CHANNEL, JSON.stringify(message));
     }
     function handStringMessageSend(message) {
@@ -463,7 +465,9 @@
         endHandshakeAnimation();
         // No-op if we were successful, but this way we ensure that failures and abandoned handshakes don't leave us
         // in a weird state.
-        request({ uri: requestUrl, method: 'DELETE' }, debug);
+        if (Account.isLoggedIn()) {
+            request({ uri: requestUrl, method: 'DELETE' }, debug);
+        }
     }
 
     function updateTriggers(value, fromKeyboard, hand) {
@@ -590,7 +594,7 @@
         }
     }
 
-    function makeConnection(id) {
+    function makeConnection(id, isLoggedIn) {
         // send done to let the connection know you have made connection.
         messageSend({
             key: "done",
@@ -606,7 +610,10 @@
         // It would be "simpler" to skip this and just look at the response, but:
         // 1. We don't want to bother the metaverse with request that we know will fail.
         // 2. We don't want our code here to be dependent on precisely how the metaverse responds (400, 401, etc.)
-        if (!Account.isLoggedIn()) {
+        // 3. We also don't want to connect to someone who is anonymous _now_, but was not earlier and still has
+        //    the same node id.  Since the messaging doesn't say _who_ isn't logged in, fail the same as if we are
+        //    not logged in.
+        if (!Account.isLoggedIn() || !isLoggedIn) {
             handleConnectionResponseAndMaybeRepeat("401:Unauthorized", {statusCode: 401});
             return;
         }
@@ -628,8 +635,12 @@
     // we change states, start the connectionInterval where we check
     // to be sure the hand is still close enough.  If not, we terminate
     // the interval, go back to the waiting state.  If we make it
-    // the entire CONNECTING_TIME, we make the connection.
-    function startConnecting(id, jointIndex) {
+    // the entire CONNECTING_TIME, we make the connection.  We pass in
+    // whether or not the connecting id is actually logged in, as now we 
+    // will allow to start the connection process but have it stop with a 
+    // fail message before trying to call the backend if the other guy isn't
+    // logged in.
+    function startConnecting(id, jointIndex, isLoggedIn) {
         var count = 0;
         debug("connecting", id, "hand", jointIndex);
         // do we need to do this?
@@ -671,7 +682,7 @@
                 startHandshake();
             } else if (count > CONNECTING_TIME / CONNECTING_INTERVAL) {
                 debug("made connection with " + id);
-                makeConnection(id);
+                makeConnection(id, isLoggedIn);
                 stopConnecting();
             }
         }, CONNECTING_INTERVAL);
@@ -736,7 +747,7 @@
             if (state === STATES.WAITING && (!connectingId || connectingId === senderID)) {
                 if (message.id === MyAvatar.sessionUUID) {
                     stopWaiting();
-                    startConnecting(senderID, exisitingOrSearchedJointIndex());
+                    startConnecting(senderID, exisitingOrSearchedJointIndex(), message.isLoggedIn);
                 } else if (connectingId) {
                     // this is for someone else (we lost race in connectionRequest),
                     // so lets start over
@@ -755,7 +766,7 @@
                     startHandshake();
                     break;
                 }
-                startConnecting(senderID, connectingHandJointIndex);
+                startConnecting(senderID, connectingHandJointIndex, message.isLoggedIn);
             }
             break;
         case "done":
@@ -775,7 +786,7 @@
                 } else {
                     // they just created a connection request to us, and we are connecting to
                     // them, so lets just stop connecting and make connection..
-                    makeConnection(connectingId);
+                    makeConnection(connectingId, message.isLoggedIn);
                     stopConnecting();
                 }
             } else {

--- a/scripts/system/makeUserConnection.js
+++ b/scripts/system/makeUserConnection.js
@@ -613,7 +613,7 @@
         // 3. We also don't want to connect to someone who is anonymous _now_, but was not earlier and still has
         //    the same node id.  Since the messaging doesn't say _who_ isn't logged in, fail the same as if we are
         //    not logged in.
-        if (!Account.isLoggedIn() || !isLoggedIn) {
+        if (!Account.isLoggedIn() || isLoggedIn === false) {
             handleConnectionResponseAndMaybeRepeat("401:Unauthorized", {statusCode: 401});
             return;
         }


### PR DESCRIPTION
We don't want to send connection requests to the backend that we know are going to fail.  So, if we send our logged-in status with the messages, both parties know if a handshake should not work, and can avoid sending the POST or DELETE to metaverse in the first place.

Maybe later we can use this to have different visualization, etc...