### PR TITLE
Fix for multiple settings dialogs

### DIFF
--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -111,7 +111,7 @@ function onMessage(message) {
         case 'openSettings':
             if ((HMD.active && Settings.getValue("hmdTabletBecomesToolbar", false))
                 || (!HMD.active && Settings.getValue("desktopTabletBecomesToolbar", true))) {
-                Desktop.show("hifi/dialogs/GeneralPreferencesDialog.qml", "General Preferences");
+                Desktop.show("hifi/dialogs/GeneralPreferencesDialog.qml", "GeneralPreferencesDialog");
             } else {
                 tablet.loadQMLOnTop("TabletGeneralPreferences.qml");
             }


### PR DESCRIPTION
In the snapshot dialog, hitting the setting button multiple times was bringing up multiple settings dialogs.  That's bad.  Now, it doesn't.  That's good.