### PR TITLE
animate scroll of partially visible cards

### DIFF
--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -238,8 +238,24 @@ Column {
             stackShadowNarrowing: root.stackShadowNarrowing;
             shadowHeight: root.stackedCardShadowHeight;
 
-            hoverThunk: function () { scroll.currentIndex = index; }
-            unhoverThunk: function () { scroll.currentIndex = -1; }
+            hoverThunk: function () { scrollToIndex(index); }
+            unhoverThunk: function () { scrollToIndex(-1); }
         }
+    }
+    NumberAnimation {
+        id: anim;
+        target: scroll;
+        property: "contentX";
+        duration: 500;
+    }
+    function scrollToIndex(index) {
+        anim.running = false;
+        var pos = scroll.contentX;
+        var destPos;
+        scroll.positionViewAtIndex(index, ListView.Contain);
+        destPos = scroll.contentX;
+        anim.from = pos;
+        anim.to = destPos;
+        anim.running = true;
     }
 }

--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -246,7 +246,7 @@ Column {
         id: anim;
         target: scroll;
         property: "contentX";
-        duration: 500;
+        duration: 250;
     }
     function scrollToIndex(index) {
         anim.running = false;
@@ -256,6 +256,7 @@ Column {
         destPos = scroll.contentX;
         anim.from = pos;
         anim.to = destPos;
+        scroll.currentIndex = index;
         anim.running = true;
     }
 }


### PR DESCRIPTION
When you bring up the feed, typically the 3rd place card is not completely visible.  Now, when you hover, it scrolls into view without a jarring immediate move.