### PR TITLE
Fixing potential crashes when loading  invalid KTX cached textures

### DIFF
--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -471,7 +471,8 @@ void Texture::assignStoredMipFace(uint16 level, uint8 face, storage::StoragePoin
     // THen check that the mem texture passed make sense with its format
     Size expectedSize = evalStoredMipFaceSize(level, getStoredMipFormat());
     auto size = storage->size();
-    if (size <= expectedSize) {
+    if (size < expectedSize) {
+        _storage->assignMipFaceData(level, face, storage);
         _stamp++;
     } else if (size == expectedSize) {
         _storage->assignMipFaceData(level, face, storage);

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -441,7 +441,10 @@ void Texture::assignStoredMip(uint16 level, storage::StoragePointer& storage) {
     // THen check that the mem texture passed make sense with its format
     Size expectedSize = evalStoredMipSize(level, getStoredMipFormat());
     auto size = storage->size();
-    if (storage->size() <= expectedSize) {
+    if (storage->size() < expectedSize) {
+        _storage->assignMipData(level, storage);
+        _stamp++;
+    } else if (size == expectedSize) {
         _storage->assignMipData(level, storage);
         _stamp++;
     } else if (size > expectedSize) {
@@ -469,6 +472,8 @@ void Texture::assignStoredMipFace(uint16 level, uint8 face, storage::StoragePoin
     Size expectedSize = evalStoredMipFaceSize(level, getStoredMipFormat());
     auto size = storage->size();
     if (size <= expectedSize) {
+        _stamp++;
+    } else if (size == expectedSize) {
         _storage->assignMipFaceData(level, face, storage);
         _stamp++;
     } else if (size > expectedSize) {

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -441,6 +441,7 @@ void Texture::assignStoredMip(uint16 level, storage::StoragePointer& storage) {
     // THen check that the mem texture passed make sense with its format
     Size expectedSize = evalStoredMipSize(level, getStoredMipFormat());
     auto size = storage->size();
+    // NOTE: doing the same thing in all the next block but beeing able to breakpoint with more accuracy
     if (storage->size() < expectedSize) {
         _storage->assignMipData(level, storage);
         _stamp++;
@@ -471,6 +472,7 @@ void Texture::assignStoredMipFace(uint16 level, uint8 face, storage::StoragePoin
     // THen check that the mem texture passed make sense with its format
     Size expectedSize = evalStoredMipFaceSize(level, getStoredMipFormat());
     auto size = storage->size();
+    // NOTE: doing the same thing in all the next block but beeing able to breakpoint with more accuracy
     if (size < expectedSize) {
         _storage->assignMipFaceData(level, face, storage);
         _stamp++;

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -542,6 +542,13 @@ bool Texture::evalTextureFormat(const ktx::Header& header, Element& mipFormat, E
         } else {
             return false;
         }
+    } else if (header.getGLFormat() == ktx::GLFormat::RG && header.getGLType() == ktx::GLType::UNSIGNED_BYTE && header.getTypeSize() == 1) {
+        mipFormat = Format::VEC2NU8_XY;
+        if (header.getGLInternaFormat_Uncompressed() == ktx::GLInternalFormat_Uncompressed::RG8) {
+            texelFormat = Format::VEC2NU8_XY;
+        } else {
+            return false;
+        }
     } else if (header.getGLFormat() == ktx::GLFormat::COMPRESSED_FORMAT && header.getGLType() == ktx::GLType::COMPRESSED_TYPE) {
         if (header.getGLInternaFormat_Compressed() == ktx::GLInternalFormat_Compressed::COMPRESSED_SRGB_S3TC_DXT1_EXT) {
             mipFormat = Format::COLOR_COMPRESSED_SRGB;

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -114,6 +114,9 @@ size_t Header::evalFaceSize(uint32_t level) const {
 }
 size_t Header::evalImageSize(uint32_t level) const {
     auto faceSize = evalFaceSize(level);
+    if ((faceSize < 4) || ((faceSize & 0x3) != 0)) {
+        return 0;
+    }
     if (numberOfFaces == NUM_CUBEMAPFACES && numberOfArrayElements == 0) {
         return faceSize;
     } else {
@@ -139,6 +142,9 @@ ImageDescriptors Header::generateImageDescriptors() const {
     size_t imageOffset = 0;
     for (uint32_t level = 0; level < numberOfMipmapLevels; ++level) {
         auto imageSize = static_cast<uint32_t>(evalImageSize(level));
+        if ((imageSize < 4) || ((imageSize & 0x3) != 0)) {
+            return ImageDescriptors();
+        }
         if (imageSize == 0) {
             return ImageDescriptors();
         }

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -22,6 +22,9 @@ uint32_t Header::evalPadding(size_t byteSize) {
     return (uint32_t) (3 - (byteSize + 3) % PACKING_SIZE);// padding ? PACKING_SIZE - padding : 0);
 }
 
+bool Header::checkAlignment(size_t byteSize) {
+    return ((byteSize & 0x3) == 0);
+}
 
 const Header::Identifier ktx::Header::IDENTIFIER {{
     0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A
@@ -114,7 +117,7 @@ size_t Header::evalFaceSize(uint32_t level) const {
 }
 size_t Header::evalImageSize(uint32_t level) const {
     auto faceSize = evalFaceSize(level);
-    if ((faceSize < 4) || ((faceSize & 0x3) != 0)) {
+    if (!checkAlignment(faceSize)) {
         return 0;
     }
     if (numberOfFaces == NUM_CUBEMAPFACES && numberOfArrayElements == 0) {
@@ -142,7 +145,7 @@ ImageDescriptors Header::generateImageDescriptors() const {
     size_t imageOffset = 0;
     for (uint32_t level = 0; level < numberOfMipmapLevels; ++level) {
         auto imageSize = static_cast<uint32_t>(evalImageSize(level));
-        if ((imageSize < 4) || ((imageSize & 0x3) != 0)) {
+        if (!checkAlignment(imageSize)) {
             return ImageDescriptors();
         }
         if (imageSize == 0) {

--- a/libraries/ktx/src/ktx/KTX.h
+++ b/libraries/ktx/src/ktx/KTX.h
@@ -309,6 +309,7 @@ namespace ktx {
         static const uint32_t REVERSE_ENDIAN_TEST = 0x01020304;
 
         static uint32_t evalPadding(size_t byteSize);
+        static bool checkAlignment(size_t byteSize);
 
         Header();
 

--- a/libraries/ktx/src/ktx/Reader.cpp
+++ b/libraries/ktx/src/ktx/Reader.cpp
@@ -148,12 +148,24 @@ namespace ktx {
             size_t imageSize = *reinterpret_cast<const uint32_t*>(currentPtr);
             currentPtr += sizeof(uint32_t);
 
+            auto expectedImageSize = header.evalImageSize(images.size());
+            if (imageSize != expectedImageSize) {
+                break;
+            } else if ((imageSize < 4) || (imageSize & 0x3)) {
+                break;
+            }
+
+            // The image size is the face size, beware!
+            size_t faceSize = imageSize;
+            if (numFaces == NUM_CUBEMAPFACES) {
+                imageSize = NUM_CUBEMAPFACES * faceSize;
+            }
+
             // If enough data ahead then capture the pointer
             if ((currentPtr - srcBytes) + imageSize <= (srcSize)) {
                 auto padding = Header::evalPadding(imageSize);
 
                 if (numFaces == NUM_CUBEMAPFACES) {
-                    size_t faceSize = imageSize / NUM_CUBEMAPFACES;
                     Image::FaceBytes faces(NUM_CUBEMAPFACES);
                     for (uint32_t face = 0; face < NUM_CUBEMAPFACES; face++) {
                         faces[face] = currentPtr;
@@ -166,6 +178,7 @@ namespace ktx {
                     currentPtr += imageSize + padding;
                 }
             } else {
+                // Stop here
                 break;
             }
         }
@@ -190,6 +203,10 @@ namespace ktx {
 
         // populate image table
         result->_images = parseImages(result->getHeader(), result->getTexelsDataSize(), result->getTexelsData());
+        if (result->_images.size() != result->getHeader().getNumberOfLevels()) {
+            // Fail if the number of images produced doesn't match the header number of levels
+            return nullptr;
+        }
 
         return result;
     }

--- a/libraries/ktx/src/ktx/Reader.cpp
+++ b/libraries/ktx/src/ktx/Reader.cpp
@@ -151,7 +151,7 @@ namespace ktx {
             auto expectedImageSize = header.evalImageSize(images.size());
             if (imageSize != expectedImageSize) {
                 break;
-            } else if ((imageSize < 4) || (imageSize & 0x3)) {
+            } else if (!Header::checkAlignment(imageSize)) {
                 break;
             }
 

--- a/libraries/ktx/src/ktx/Reader.cpp
+++ b/libraries/ktx/src/ktx/Reader.cpp
@@ -148,7 +148,7 @@ namespace ktx {
             size_t imageSize = *reinterpret_cast<const uint32_t*>(currentPtr);
             currentPtr += sizeof(uint32_t);
 
-            auto expectedImageSize = header.evalImageSize(images.size());
+            auto expectedImageSize = header.evalImageSize((uint32_t) images.size());
             if (imageSize != expectedImageSize) {
                 break;
             } else if (!Header::checkAlignment(imageSize)) {

--- a/libraries/ktx/src/ktx/Writer.cpp
+++ b/libraries/ktx/src/ktx/Writer.cpp
@@ -210,7 +210,8 @@ namespace ktx {
             if (currentDataSize + sizeof(uint32_t) < allocatedImagesDataSize) {
                 uint32_t imageOffset = currentPtr - destBytes;
                 size_t imageSize = srcImages[l]._imageSize;
-                *(reinterpret_cast<uint32_t*> (currentPtr)) = (uint32_t) imageSize;
+                size_t imageFaceSize = srcImages[l]._faceSize;
+                *(reinterpret_cast<uint32_t*> (currentPtr)) = (uint32_t)imageFaceSize; // the imageSize written in the ktx is the FACE size
                 currentPtr += sizeof(uint32_t);
                 currentDataSize += sizeof(uint32_t);
 

--- a/libraries/model-networking/src/model-networking/KTXCache.cpp
+++ b/libraries/model-networking/src/model-networking/KTXCache.cpp
@@ -22,7 +22,7 @@ KTXCache::KTXCache(const std::string& dir, const std::string& ext) :
 }
 
 KTXFilePointer KTXCache::writeFile(const char* data, Metadata&& metadata) {
-    FilePointer file = FileCache::writeFile(data, std::move(metadata));
+    FilePointer file = FileCache::writeFile(data, std::move(metadata), true);
     return std::static_pointer_cast<KTXFile>(file);
 }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -792,6 +792,8 @@ void ImageReader::read() {
                 texture = gpu::Texture::unserialize(ktxFile->getFilepath());
                 if (texture) {
                     texture = textureCache->cacheTextureByHash(hash, texture);
+                } else {
+                    qCWarning(modelnetworking) << "Invalid cached KTX " << _url << " under hash " << hash.c_str() << ", recreating...";
                 }
             }
         }
@@ -835,7 +837,7 @@ void ImageReader::read() {
             const char* data = reinterpret_cast<const char*>(memKtx->_storage->data());
             size_t length = memKtx->_storage->size();
             auto& ktxCache = textureCache->_ktxCache;
-            networkTexture->_file = ktxCache.writeFile(data, KTXCache::Metadata(hash, length));
+            networkTexture->_file = ktxCache.writeFile(data, KTXCache::Metadata(hash, length)); // 
             if (!networkTexture->_file) {
                 qCWarning(modelnetworking) << _url << "file cache failed";
             } else {

--- a/libraries/networking/src/FileCache.cpp
+++ b/libraries/networking/src/FileCache.cpp
@@ -97,7 +97,7 @@ FilePointer FileCache::addFile(Metadata&& metadata, const std::string& filepath)
     return file;
 }
 
-FilePointer FileCache::writeFile(const char* data, File::Metadata&& metadata) {
+FilePointer FileCache::writeFile(const char* data, File::Metadata&& metadata, bool overwrite) {
     assert(_initialized);
 
     std::string filepath = getFilepath(metadata.key);
@@ -107,8 +107,13 @@ FilePointer FileCache::writeFile(const char* data, File::Metadata&& metadata) {
     // if file already exists, return it
     FilePointer file = getFile(metadata.key);
     if (file) {
-        qCWarning(file_cache, "[%s] Attempted to overwrite %s", _dirname.c_str(), metadata.key.c_str());
-        return file;
+        if (!overwrite) {
+            qCWarning(file_cache, "[%s] Attempted to overwrite %s", _dirname.c_str(), metadata.key.c_str());
+            return file;
+        } else {
+            qCWarning(file_cache, "[%s] Overwriting %s", _dirname.c_str(), metadata.key.c_str());
+            file.reset();
+        }
     }
 
     QSaveFile saveFile(QString::fromStdString(filepath));

--- a/libraries/networking/src/FileCache.h
+++ b/libraries/networking/src/FileCache.h
@@ -80,7 +80,7 @@ protected:
     /// must be called after construction to create the cache on the fs and restore persisted files
     void initialize();
 
-    FilePointer writeFile(const char* data, Metadata&& metadata);
+    FilePointer writeFile(const char* data, Metadata&& metadata, bool overwrite = false);
     FilePointer getFile(const Key& key);
 
     /// create a file

--- a/libraries/shared/src/shared/Storage.cpp
+++ b/libraries/shared/src/shared/Storage.cpp
@@ -21,10 +21,6 @@ ViewStorage::ViewStorage(const storage::StoragePointer& owner, size_t size, cons
 
 StoragePointer Storage::createView(size_t viewSize, size_t offset) const {
     auto selfSize = size();
-    if ((viewSize < 4) || ((viewSize & 0x3) != 0)) {
-        throw std::runtime_error("Invalid mapping range");
-    }
-
     if (0 == viewSize) {
         viewSize = selfSize;
     }

--- a/libraries/shared/src/shared/Storage.cpp
+++ b/libraries/shared/src/shared/Storage.cpp
@@ -21,6 +21,10 @@ ViewStorage::ViewStorage(const storage::StoragePointer& owner, size_t size, cons
 
 StoragePointer Storage::createView(size_t viewSize, size_t offset) const {
     auto selfSize = size();
+    if ((viewSize < 4) || ((viewSize & 0x3) != 0)) {
+        throw std::runtime_error("Invalid mapping range");
+    }
+
     if (0 == viewSize) {
         viewSize = selfSize;
     }


### PR DESCRIPTION
Adding a validation step at runtime for the cached KTX file in order to regenerate them if anything seems wrong.
This should prevent many of the crashes we are observing right now in the gl driver. This is happening when trying to load previously cached textures which are stored in the ktx_cache folder.
This pr add checks on the bytesize of each mips contained in the the file to validate that it s matching the expected size computed from the dimensions / format of the texture available in the Header.
If anything goes wrong, we simply bailout and regenerate the KTX texture (from the original source image) and overwrite the old cached ktx file with the new one.
We also fixed a problem with cube map in the way we were storing sizes in the KTX. The generated files are now valid compatible KTX that can be open with other viewers.

## TEST PLAN
To test this PR, you need to run the interface with different version of the KTX_cache folder in order to validate the new behavior.
The texture cache folder for a given version of High Fidelity on your computer is at the following appdata path:
 %UserName%/AppData/Local/%HighFidelityVersionName%/Interface/ktx_cache
For master or RC, HighFidelityVersionName is "High Fidelity"
For this PR, HighFidelityVersionName is "High Fidelity - PR10454"
HighFidelityVersionName is picked during the installation wizard, these are the name by default.

A ktx_cache folder with invalid ktx is available in this zip, it contains cached textures for dev-welcome.
1/ download this zip, open and rename the "ktx_cache_old" folder (containing all the ktx files) to "ktx_cache_invalid"
https://s3-us-west-1.amazonaws.com/hifi-content/chris/dev/office/ktx_cacheold.zip
2/ install this PR and current RC on your computer.
2 bis/ run both the PR and the RC and go to "dev-welcome" wait there  a few seconds for the content to be loaded and quit.
3/ Go in both appdata folders (for each versions) and rename the existing ktx_cache folder to "ktx_cache_ori"
4/ Copy in both appdata folders the downloaded ktx_cache_invalid (next to the existing one that you just renamed "ktx_cache_ori"
5/ Rename ktx_cache_invalid into ktx_cache (in both appdata folders)

At this point, you should be ready to run both master and this pr and spawn in "dev-welcome"
for each version, the ktx_cache contains the "invalid" cached ktx files.
In RC, it maybe run without any problem but will likely crash on some texture load/transfer. YOu should expect a crash.

In PR, this should run and not crash. Looking at the log, you should see a bunch of messages informing that 
"Invalid cached KTX url(...faultyTexture.png) under hash <HASHOFTHATFAULTYTEX> , recreating..."
ANd then a few lines later in the log you should see:
"Overwriting <HASHOFTHATFAULTYTEX>"
THis means that the invalid texture has been detected and has been recreated and stored in the ktx_cache folder replacing the faulty version.
After looking around the domain and loading most of the content you can quit.
Run the PR again and you shouldn't see any more "Invalid cached" message in the log at all (because it has been fixed in the previous run.

Once your done with all the testing, you can delete the ktx_cache folder in the appdata and replace it with the original one we renammed to ktx_cache_ori. simply rename it to ktx_cache.
Or just delete all these ktx_cache folders adn redownload everything fresh on the next run.

## TO DO
Need to update the Default skymap which is invalid right now...
THe default "blue horizon" skybox won't show because it's provided as a ktx file in the resources folder and it's invalid at this moment.