### PR TITLE
Force _identityUpdatedAt to stay above 0, fixing more identity packet bugs

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1538,7 +1538,14 @@ void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityC
 
     // use the timestamp from this identity, since we want to honor the updated times in "server clock"
     // this will overwrite any changes we made locally to this AvatarData's _identityUpdatedAt
-    _identityUpdatedAt = identity.updatedAt - clockSkew;
+    // Additionally, ensure that the timestamp that we try to record isn't negative, as
+    // "_identityUpdatedAt" is an *unsigned* 64-bit integer. Furthermore, negative timestamps
+    // wouldn't make sense.
+    if (identity.updatedAt - clockSkew >= 0) {
+        _identityUpdatedAt = identity.updatedAt - clockSkew;
+    } else {
+        _identityUpdatedAt = 0;
+    }
 }
 
 QByteArray AvatarData::identityByteArray() const {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1541,7 +1541,7 @@ void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityC
     // Additionally, ensure that the timestamp that we try to record isn't negative, as
     // "_identityUpdatedAt" is an *unsigned* 64-bit integer. Furthermore, negative timestamps
     // wouldn't make sense.
-    if (identity.updatedAt - clockSkew >= 0) {
+    if (identity.updatedAt > clockSkew) {
         _identityUpdatedAt = identity.updatedAt - clockSkew;
     } else {
         _identityUpdatedAt = 0;


### PR DESCRIPTION
PR #10398 addressed the fact that identity packet timestamps didn't take server clock skew into consideration. However, I forgot to include a check to prevent the timestamp from being recorded as negative, which has two problems:
1. Absolute negative timestamps don't make sense.
2. The timestamp data type is an unsigned integer; attempting to assign a negative timestamp to `_identityUpdatedAt` causes the value to underflow.

**Test Plan:**
Prerequisites:
- This plan requires two Interface clients running - Interface A and Interface B.
- The machine running Interface A should also be running Sandbox A.
- Use unique avatars for Interface A and Interface B.
- Set the system clock of the machine running Interface B to be five minutes **ahead of** Machine A's system clock.

Test Plan:
1. Using Interface B, connect to Sandbox A.
2. Wait 10 seconds.
3. Using Interface A, connect to Sandbox A.
4. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
5. Using Interface A, disconnect from Sandbox A.
6. Wait 20 seconds.
7. Using Interface A, connect to Sandbox A.
8. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
9. Using Interface B, disconnect from Sandbox A.
10. Wait 10 seconds.
11. Using Interface B, connect to Sandbox A.
12. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
13. **Repeat steps 1-12** after setting the system clock of the machine running Interface B to be five minutes **behind** Machine A's system clock.