### PR TITLE
Implement PR10462 correctly & fix identity packet bugs again

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1496,13 +1496,18 @@ QUrl AvatarData::cannonicalSkeletonModelURL(const QUrl& emptyURL) const {
 }
 
 void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged, const qint64 clockSkew) {
+    quint64 identityPacketUpdatedAt = identity.updatedAt;
+
+    if (identityPacketUpdatedAt <= (uint64_t)(abs(clockSkew))) { // Incoming timestamp is bad - compute our own timestamp
+        identityPacketUpdatedAt = usecTimestampNow() + clockSkew;
+    }
 
     // Consider the case where this packet is being processed on Client A, and Client A is connected to Sandbox B.
     // If Client A's system clock is *ahead of* Sandbox B's system clock, "clockSkew" will be *negative*.
     // If Client A's system clock is *behind* Sandbox B's system clock, "clockSkew" will be *positive*.
-    if ((_identityUpdatedAt > identity.updatedAt - clockSkew) && (_identityUpdatedAt != 0)) {
+    if ((_identityUpdatedAt > identityPacketUpdatedAt - clockSkew) && (_identityUpdatedAt != 0)) {
         qCDebug(avatars) << "Ignoring late identity packet for avatar " << getSessionUUID() 
-            << "_identityUpdatedAt (" << _identityUpdatedAt << ") is greater than identity.updatedAt - clockSkew (" << identity.updatedAt << "-" << clockSkew << ")";
+            << "_identityUpdatedAt (" << _identityUpdatedAt << ") is greater than identityPacketUpdatedAt - clockSkew (" << identityPacketUpdatedAt << "-" << clockSkew << ")";
         return;
     }
 
@@ -1538,14 +1543,7 @@ void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityC
 
     // use the timestamp from this identity, since we want to honor the updated times in "server clock"
     // this will overwrite any changes we made locally to this AvatarData's _identityUpdatedAt
-    // Additionally, ensure that the timestamp that we try to record isn't negative, as
-    // "_identityUpdatedAt" is an *unsigned* 64-bit integer. Furthermore, negative timestamps
-    // wouldn't make sense.
-    if (identity.updatedAt > clockSkew) {
-        _identityUpdatedAt = identity.updatedAt - clockSkew;
-    } else {
-        _identityUpdatedAt = 0;
-    }
+    _identityUpdatedAt = identityPacketUpdatedAt - clockSkew;
 }
 
 QByteArray AvatarData::identityByteArray() const {


### PR DESCRIPTION
PR #10642 attempted to address the fact that identity packet timestamps didn't take server clock skew into consideration. However, I implemented the fix incorrectly due to some fascinating interactions between unsigned and signed 64-bit integers.

Test plan is the same as #10642, so I'm going to QA it myself.

**Test Plan:**
Prerequisites:
- This plan requires two Interface clients running - Interface A and Interface B.
- The machine running Interface A should also be running Sandbox A.
- Use unique avatars for Interface A and Interface B.
- Set the system clock of the machine running Interface B to be five minutes **ahead of** Machine A's system clock.

Test Plan:
1. Using Interface B, connect to Sandbox A.
2. Wait 10 seconds.
3. Using Interface A, connect to Sandbox A.
4. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
5. Using Interface A, disconnect from Sandbox A.
6. Wait 20 seconds.
7. Using Interface A, connect to Sandbox A.
8. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
9. Using Interface B, disconnect from Sandbox A.
10. Wait 10 seconds.
11. Using Interface B, connect to Sandbox A.
12. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
13. **Repeat steps 1-12** after setting the system clock of the machine running Interface B to be five minutes **behind** Machine A's system clock.