### PR TITLE
Fix domain settings not getting cleared on re-assignment

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -38,13 +38,14 @@
 #include "AudioMixer.h"
 
 static const float DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE = 0.5f;    // attenuation = -6dB * log2(distance)
+static const int DEFAULT_NUM_STATIC_JITTER_FRAMES = -1;
 static const float DEFAULT_NOISE_MUTING_THRESHOLD = 1.0f;
 static const QString AUDIO_MIXER_LOGGING_TARGET_NAME = "audio-mixer";
 static const QString AUDIO_ENV_GROUP_KEY = "audio_env";
 static const QString AUDIO_BUFFER_GROUP_KEY = "audio_buffer";
 static const QString AUDIO_THREADING_GROUP_KEY = "audio_threading";
 
-int AudioMixer::_numStaticJitterFrames{ -1 };
+int AudioMixer::_numStaticJitterFrames{ DEFAULT_NUM_STATIC_JITTER_FRAMES };
 float AudioMixer::_noiseMutingThreshold{ DEFAULT_NOISE_MUTING_THRESHOLD };
 float AudioMixer::_attenuationPerDoublingInDistance{ DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE };
 std::map<QString, std::shared_ptr<CodecPlugin>> AudioMixer::_availableCodecs{ };
@@ -56,7 +57,12 @@ QVector<AudioMixer::ReverbSettings> AudioMixer::_zoneReverbSettings;
 AudioMixer::AudioMixer(ReceivedMessage& message) :
     ThreadedAssignment(message) {
 
+    // Always clear settings first
+    // This prevents previous assignment settings from sticking around
+    clearDomainSettings();
+
     // hash the available codecs (on the mixer)
+    _availableCodecs.clear(); // Make sure struct is clean
     auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
     std::for_each(codecPlugins.cbegin(), codecPlugins.cend(),
         [&](const CodecPluginPointer& codec) {
@@ -232,7 +238,7 @@ void AudioMixer::sendStatsPacket() {
     }
 
     // general stats
-    statsObject["useDynamicJitterBuffers"] = _numStaticJitterFrames == -1;
+    statsObject["useDynamicJitterBuffers"] = _numStaticJitterFrames == DEFAULT_NUM_STATIC_JITTER_FRAMES;
 
     statsObject["threads"] = _slavePool.numThreads();
 
@@ -490,6 +496,16 @@ int AudioMixer::prepareFrame(const SharedNodePointer& node, unsigned int frame) 
     return data->checkBuffersBeforeFrameSend();
 }
 
+void AudioMixer::clearDomainSettings() {
+    _numStaticJitterFrames = DEFAULT_NUM_STATIC_JITTER_FRAMES;
+    _attenuationPerDoublingInDistance = DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE;
+    _noiseMutingThreshold = DEFAULT_NOISE_MUTING_THRESHOLD;
+    _codecPreferenceOrder.clear();
+    _audioZones.clear();
+    _zoneSettings.clear();
+    _zoneReverbSettings.clear();
+}
+
 void AudioMixer::parseSettingsObject(const QJsonObject &settingsObject) {
     qDebug() << "AVX2 Support:" << (cpuSupportsAVX2() ? "enabled" : "disabled");
 
@@ -525,7 +541,7 @@ void AudioMixer::parseSettingsObject(const QJsonObject &settingsObject) {
             qDebug() << "Static desired jitter buffer frames:" << _numStaticJitterFrames;
         } else {
             qDebug() << "Disabling dynamic jitter buffers.";
-            _numStaticJitterFrames = -1;
+            _numStaticJitterFrames = DEFAULT_NUM_STATIC_JITTER_FRAMES;
         }
 
         // check for deprecated audio settings

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -38,14 +38,14 @@
 #include "AudioMixer.h"
 
 static const float DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE = 0.5f;    // attenuation = -6dB * log2(distance)
-static const int DEFAULT_NUM_STATIC_JITTER_FRAMES = -1;
+static const int DISABLE_STATIC_JITTER_FRAMES = -1;
 static const float DEFAULT_NOISE_MUTING_THRESHOLD = 1.0f;
 static const QString AUDIO_MIXER_LOGGING_TARGET_NAME = "audio-mixer";
 static const QString AUDIO_ENV_GROUP_KEY = "audio_env";
 static const QString AUDIO_BUFFER_GROUP_KEY = "audio_buffer";
 static const QString AUDIO_THREADING_GROUP_KEY = "audio_threading";
 
-int AudioMixer::_numStaticJitterFrames{ DEFAULT_NUM_STATIC_JITTER_FRAMES };
+int AudioMixer::_numStaticJitterFrames{ DISABLE_STATIC_JITTER_FRAMES };
 float AudioMixer::_noiseMutingThreshold{ DEFAULT_NOISE_MUTING_THRESHOLD };
 float AudioMixer::_attenuationPerDoublingInDistance{ DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE };
 std::map<QString, std::shared_ptr<CodecPlugin>> AudioMixer::_availableCodecs{ };
@@ -238,7 +238,7 @@ void AudioMixer::sendStatsPacket() {
     }
 
     // general stats
-    statsObject["useDynamicJitterBuffers"] = _numStaticJitterFrames == DEFAULT_NUM_STATIC_JITTER_FRAMES;
+    statsObject["useDynamicJitterBuffers"] = _numStaticJitterFrames == DISABLE_STATIC_JITTER_FRAMES;
 
     statsObject["threads"] = _slavePool.numThreads();
 
@@ -497,7 +497,7 @@ int AudioMixer::prepareFrame(const SharedNodePointer& node, unsigned int frame) 
 }
 
 void AudioMixer::clearDomainSettings() {
-    _numStaticJitterFrames = DEFAULT_NUM_STATIC_JITTER_FRAMES;
+    _numStaticJitterFrames = DISABLE_STATIC_JITTER_FRAMES;
     _attenuationPerDoublingInDistance = DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE;
     _noiseMutingThreshold = DEFAULT_NOISE_MUTING_THRESHOLD;
     _codecPreferenceOrder.clear();
@@ -541,7 +541,7 @@ void AudioMixer::parseSettingsObject(const QJsonObject &settingsObject) {
             qDebug() << "Static desired jitter buffer frames:" << _numStaticJitterFrames;
         } else {
             qDebug() << "Disabling dynamic jitter buffers.";
-            _numStaticJitterFrames = DEFAULT_NUM_STATIC_JITTER_FRAMES;
+            _numStaticJitterFrames = DISABLE_STATIC_JITTER_FRAMES;
         }
 
         // check for deprecated audio settings

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -79,6 +79,7 @@ private:
     QString percentageForMixStats(int counter);
 
     void parseSettingsObject(const QJsonObject& settingsObject);
+    void clearDomainSettings();
 
     float _trailingMixRatio { 0.0f };
     float _throttlingRatio { 0.0f };


### PR DESCRIPTION
Fix a bug where some audio settings would not get updated after clicking on "Save & Restart"

## Test Plan:

This is pretty tricky to test correctly. Ideally, this would be done by a dev or someone familiar with manual server setups.

- Point the audio mixer to the domain manually
- Make sure it gets the right assignment
- Create 2 audio zones
- Have someone else stand in the first zone, stand in the second one
- Change the attenuation values and makes sure it updates accordingly after server restarts
(You might have to kill the audio-mixer node manually so that the dedicated AC gets the assignment)

[Bug](https://highfidelity.fogbugz.com/f/cases/3198/Zone-attenuation-effects-don-t-get-cleared-out-when-removed-from-domain-settings)