### PR TITLE
Add function findEntitiesByType EntityScriptingInterface

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -673,7 +673,7 @@ QVector<QUuid> EntityScriptingInterface::findEntitiesByType(const QString entity
 		});
 
 		foreach(EntityItemPointer entity, entities) {
-			if (entity->getType() == type){
+			if (entity->getType() == type) {
 				result << entity->getEntityItemID();
 			}
 		}

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -673,8 +673,7 @@ QVector<QUuid> EntityScriptingInterface::findEntitiesByType(const QString entity
 		});
 
 		foreach(EntityItemPointer entity, entities) {
-			if (entity->getType() == type)
-			{
+			if (entity->getType() == type){
 				result << entity->getEntityItemID();
 			}
 		}

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -662,6 +662,26 @@ QVector<QUuid> EntityScriptingInterface::findEntitiesInFrustum(QVariantMap frust
     return result;
 }
 
+QVector<QUuid> EntityScriptingInterface::findEntitiesByType(const QString entityType, const glm::vec3& center, float radius) const {
+	EntityTypes::EntityType type = EntityTypes::getEntityTypeFromName(entityType);
+
+	QVector<QUuid> result;
+	if (_entityTree) {
+		QVector<EntityItemPointer> entities;
+		_entityTree->withReadLock([&] {
+			_entityTree->findEntities(center, radius, entities);
+		});
+
+		foreach(EntityItemPointer entity, entities) {
+			if (entity->getType() == type)
+			{
+				result << entity->getEntityItemID();
+			}
+		}
+	}
+	return result;
+}
+
 RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersection(const PickRay& ray, bool precisionPicking, 
                 const QScriptValue& entityIdsToInclude, const QScriptValue& entityIdsToDiscard, bool visibleOnly, bool collidableOnly) {
     PROFILE_RANGE(script_entities, __FUNCTION__);

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -212,14 +212,14 @@ public slots:
     /// - orientation
     /// - projection
     /// - centerRadius
-    /// this function will not find any models in script engine contexts which don't have access to models
+    /// this function will not find any models in script engine contexts which don't have access to entities
     Q_INVOKABLE QVector<QUuid> findEntitiesInFrustum(QVariantMap frustum) const;
 
 	/// finds models within a sphere given by the center point and radius
 	/// @param {QString} string representation of entity type
 	/// @param {vec3} center point
 	/// @param {float} radius to search
-	/// this function will not find any models in script engine contexts which don't have access to models
+	/// this function will not find any entities in script engine contexts which don't have access to models
 	Q_INVOKABLE QVector<QUuid> findEntitiesByType(const QString entityType, const glm::vec3& center, float radius) const;
 
     /// If the scripting context has visible entities, this will determine a ray intersection, the results

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -215,6 +215,13 @@ public slots:
     /// this function will not find any models in script engine contexts which don't have access to models
     Q_INVOKABLE QVector<QUuid> findEntitiesInFrustum(QVariantMap frustum) const;
 
+	/// finds models within a sphere given by the center point and radius
+	/// @param {QString} string representation of entity type
+	/// @param {vec3} center point
+	/// @param {float} radius to search
+	/// this function will not find any models in script engine contexts which don't have access to models
+	Q_INVOKABLE QVector<QUuid> findEntitiesByType(const QString entityType, const glm::vec3& center, float radius) const;
+
     /// If the scripting context has visible entities, this will determine a ray intersection, the results
     /// may be inaccurate if the engine is unable to access the visible entities, in which case result.accurate
     /// will be false.

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -215,11 +215,11 @@ public slots:
     /// this function will not find any models in script engine contexts which don't have access to entities
     Q_INVOKABLE QVector<QUuid> findEntitiesInFrustum(QVariantMap frustum) const;
 
-	/// finds models within a sphere given by the center point and radius
+	/// finds entities of the indicated type within a sphere given by the center point and radius
 	/// @param {QString} string representation of entity type
 	/// @param {vec3} center point
 	/// @param {float} radius to search
-	/// this function will not find any entities in script engine contexts which don't have access to models
+	/// this function will not find any entities in script engine contexts which don't have access to entities
 	Q_INVOKABLE QVector<QUuid> findEntitiesByType(const QString entityType, const glm::vec3& center, float radius) const;
 
     /// If the scripting context has visible entities, this will determine a ray intersection, the results


### PR DESCRIPTION
Updated EntityScriptingInterface.cpp and .h to create a new function for
the Entities API that can be called to filter out entities found by a
specific entity type.

Test Plan:
- In a domain where you have edit rights, run https://hifi-content.s3.amazonaws.com/liv/dev/TestFindEntitiesByType.js and verify that the results for each test type are the same

Manual Test:
- In a domain where you have edit rights (e.g. your Sandbox) , open up the edit menu and search in a given radius
- Sort by types and select all of a particular entity type (e.g. 'Zone', 'Light')
- Note the number and run Entities.findEntitiesByType(TYPE, MyAvatar.position, RADIUS) depending on your search in edit

Additional robustness: 
- Add and remove entities and ensure that the values update properly
- Confirm returned entityIDs match (I can add this to the test script as well)

Should probably add:
- Error handling in the event the entity type QString does not match the expected actual type (highly specific to capitalization)

Code question:
- Should this be implemented further down in the entity tree to avoid having to search through returned items for valid ones at the API layer?