### PR TITLE
Flex and weight IK tuning parameters

### DIFF
--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -57,6 +57,8 @@
                                     "positionVar": "hipsPosition",
                                     "rotationVar": "hipsRotation",
                                     "typeVar": "hipsType",
+                                    "weightVar": "hipsWeight",
+                                    "weight": 1.0,
                                     "flexCoefficients": [1]
                                 },
                                 {
@@ -64,20 +66,26 @@
                                     "positionVar": "rightHandPosition",
                                     "rotationVar": "rightHandRotation",
                                     "typeVar": "rightHandType",
-                                    "flexCoefficients": [1, 0.5, 0.5, 0.5, 0.25, 0.1, 0.1, 0.1, 0.1]
+                                    "weightVar": "rightHandWeight",
+                                    "weight": 1.0,
+                                    "flexCoefficients": [1, 0.5, 0.5, 0.25, 0.1, 0.05, 0.01, 0.0, 0.0]
                                 },
                                 {
                                     "jointName": "LeftHand",
                                     "positionVar": "leftHandPosition",
                                     "rotationVar": "leftHandRotation",
                                     "typeVar": "leftHandType",
-                                    "flexCoefficients": [1, 0.5, 0.5, 0.5, 0.25, 0.1, 0.1, 0.1, 0.1]
+                                    "weightVar": "leftHandWeight",
+                                    "weight": 1.0,
+                                    "flexCoefficients": [1, 0.5, 0.5, 0.25, 0.1, 0.05, 0.01, 0.0, 0.0]
                                 },
                                 {
                                     "jointName": "RightFoot",
                                     "positionVar": "rightFootPosition",
                                     "rotationVar": "rightFootRotation",
                                     "typeVar": "rightFootType",
+                                    "weightVar": "rightFootWeight",
+                                    "weight": 1.0,
                                     "flexCoefficients": [1, 0.45, 0.45]
                                 },
                                 {
@@ -85,6 +93,8 @@
                                     "positionVar": "leftFootPosition",
                                     "rotationVar": "leftFootRotation",
                                     "typeVar": "leftFootType",
+                                    "weightVar": "leftFootWeight",
+                                    "weight": 1.0,
                                     "flexCoefficients": [1, 0.45, 0.45]
                                 },
                                 {
@@ -92,6 +102,8 @@
                                     "positionVar": "spine2Position",
                                     "rotationVar": "spine2Rotation",
                                     "typeVar": "spine2Type",
+                                    "weightVar": "spine2Weight",
+                                    "weight": 1.0,
                                     "flexCoefficients": [0.45, 0.45]
                                 },
                                 {
@@ -99,7 +111,9 @@
                                     "positionVar": "headPosition",
                                     "rotationVar": "headRotation",
                                     "typeVar": "headType",
-                                    "flexCoefficients": [1, 0.5, 0.25, 0.25, 0.25]
+                                    "weightVar": "headWeight",
+                                    "weight": 4.0,
+                                    "flexCoefficients": [1, 0.5, 0.5, 0.5, 0.5]
                                 }
                             ]
                         },

--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -56,43 +56,50 @@
                                     "jointName": "Hips",
                                     "positionVar": "hipsPosition",
                                     "rotationVar": "hipsRotation",
-                                    "typeVar": "hipsType"
+                                    "typeVar": "hipsType",
+                                    "flexCoefficients": [1]
                                 },
                                 {
                                     "jointName": "RightHand",
                                     "positionVar": "rightHandPosition",
                                     "rotationVar": "rightHandRotation",
-                                    "typeVar": "rightHandType"
+                                    "typeVar": "rightHandType",
+                                    "flexCoefficients": [1, 0.5, 0.5, 0.5, 0.25, 0.1, 0.1, 0.1, 0.1]
                                 },
                                 {
                                     "jointName": "LeftHand",
                                     "positionVar": "leftHandPosition",
                                     "rotationVar": "leftHandRotation",
-                                    "typeVar": "leftHandType"
+                                    "typeVar": "leftHandType",
+                                    "flexCoefficients": [1, 0.5, 0.5, 0.5, 0.25, 0.1, 0.1, 0.1, 0.1]
                                 },
                                 {
                                     "jointName": "RightFoot",
                                     "positionVar": "rightFootPosition",
                                     "rotationVar": "rightFootRotation",
-                                    "typeVar": "rightFootType"
+                                    "typeVar": "rightFootType",
+                                    "flexCoefficients": [1, 0.45, 0.45]
                                 },
                                 {
                                     "jointName": "LeftFoot",
                                     "positionVar": "leftFootPosition",
                                     "rotationVar": "leftFootRotation",
-                                    "typeVar": "leftFootType"
+                                    "typeVar": "leftFootType",
+                                    "flexCoefficients": [1, 0.45, 0.45]
                                 },
                                 {
                                     "jointName": "Spine2",
                                     "positionVar": "spine2Position",
                                     "rotationVar": "spine2Rotation",
-                                    "typeVar": "spine2Type"
+                                    "typeVar": "spine2Type",
+                                    "flexCoefficients": [0.45, 0.45]
                                 },
                                 {
                                     "jointName": "Head",
                                     "positionVar": "headPosition",
                                     "rotationVar": "headRotation",
-                                    "typeVar": "headType"
+                                    "typeVar": "headType",
+                                    "flexCoefficients": [1, 0.5, 0.25, 0.25, 0.25]
                                 }
                             ]
                         },

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -23,12 +23,12 @@
 
 AnimInverseKinematics::IKTargetVar::IKTargetVar(const QString& jointNameIn, const QString& positionVarIn, const QString& rotationVarIn,
                                                 const QString& typeVarIn, const QString& weightVarIn, float weightIn, const std::vector<float>& flexCoefficientsIn) :
+    jointName(jointNameIn),
     positionVar(positionVarIn),
     rotationVar(rotationVarIn),
     typeVar(typeVarIn),
     weightVar(weightVarIn),
     weight(weightIn),
-    jointName(jointNameIn),
     numFlexCoefficients(flexCoefficientsIn.size()),
     jointIndex(-1)
 {
@@ -39,12 +39,12 @@ AnimInverseKinematics::IKTargetVar::IKTargetVar(const QString& jointNameIn, cons
 }
 
 AnimInverseKinematics::IKTargetVar::IKTargetVar(const IKTargetVar& orig) :
+    jointName(orig.jointName),
     positionVar(orig.positionVar),
     rotationVar(orig.rotationVar),
     typeVar(orig.typeVar),
     weightVar(orig.weightVar),
     weight(orig.weight),
-    jointName(orig.jointName),
     numFlexCoefficients(orig.numFlexCoefficients),
     jointIndex(orig.jointIndex)
 {
@@ -305,7 +305,7 @@ int AnimInverseKinematics::solveTargetWithCCD(const IKTarget& target, AnimPoseVe
     // cache tip absolute position
     glm::vec3 tipPosition = absolutePoses[tipIndex].trans();
 
-    int chainDepth = 1;
+    size_t chainDepth = 1;
 
     // descend toward root, pivoting each joint to get tip closer to target position
     while (pivotIndex != _hipsIndex && pivotsParentIndex != -1) {

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -32,7 +32,7 @@ AnimInverseKinematics::IKTargetVar::IKTargetVar(const QString& jointNameIn, cons
     numFlexCoefficients(flexCoefficientsIn.size()),
     jointIndex(-1)
 {
-    numFlexCoefficients = std::min(numFlexCoefficients, MAX_FLEX_COEFFICIENTS);
+    numFlexCoefficients = std::min(numFlexCoefficients, (size_t)MAX_FLEX_COEFFICIENTS);
     for (size_t i = 0; i < numFlexCoefficients; i++) {
         flexCoefficients[i] = flexCoefficientsIn[i];
     }
@@ -48,7 +48,7 @@ AnimInverseKinematics::IKTargetVar::IKTargetVar(const IKTargetVar& orig) :
     numFlexCoefficients(orig.numFlexCoefficients),
     jointIndex(orig.jointIndex)
 {
-    numFlexCoefficients = std::min(numFlexCoefficients, MAX_FLEX_COEFFICIENTS);
+    numFlexCoefficients = std::min(numFlexCoefficients, (size_t)MAX_FLEX_COEFFICIENTS);
     for (size_t i = 0; i < numFlexCoefficients; i++) {
         flexCoefficients[i] = orig.flexCoefficients[i];
     }

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -84,11 +84,11 @@ protected:
                     const QString& typeVarIn, const QString& weightVarIn, float weightIn, const std::vector<float>& flexCoefficientsIn);
         IKTargetVar(const IKTargetVar& orig);
 
+        QString jointName;
         QString positionVar;
         QString rotationVar;
         QString typeVar;
         QString weightVar;
-        QString jointName;
         float weight;
         float flexCoefficients[MAX_FLEX_COEFFICIENTS];
         size_t numFlexCoefficients;

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -33,7 +33,7 @@ public:
     void computeAbsolutePoses(AnimPoseVec& absolutePoses) const;
 
     void setTargetVars(const QString& jointName, const QString& positionVar, const QString& rotationVar,
-                       const QString& typeVar, const std::vector<float>& flexCoefficients);
+                       const QString& typeVar, const QString& weightVar, float weight, const std::vector<float>& flexCoefficients);
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimNode::Triggers& triggersOut) override;
     virtual const AnimPoseVec& overlay(const AnimVariantMap& animVars, const AnimContext& context, float dt, Triggers& triggersOut, const AnimPoseVec& underPoses) override;
@@ -81,13 +81,15 @@ protected:
     static const size_t MAX_FLEX_COEFFICIENTS = 10;
     struct IKTargetVar {
         IKTargetVar(const QString& jointNameIn, const QString& positionVarIn, const QString& rotationVarIn,
-                    const QString& typeVarIn, const std::vector<float>& flexCoefficientsIn);
+                    const QString& typeVarIn, const QString& weightVarIn, float weightIn, const std::vector<float>& flexCoefficientsIn);
         IKTargetVar(const IKTargetVar& orig);
 
         QString positionVar;
         QString rotationVar;
         QString typeVar;
+        QString weightVar;
         QString jointName;
+        float weight;
         float flexCoefficients[MAX_FLEX_COEFFICIENTS];
         size_t numFlexCoefficients;
         int jointIndex; // cached joint index

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -78,7 +78,7 @@ protected:
     AnimInverseKinematics(const AnimInverseKinematics&) = delete;
     AnimInverseKinematics& operator=(const AnimInverseKinematics&) = delete;
 
-    static const size_t MAX_FLEX_COEFFICIENTS = 10;
+    enum FlexCoefficients { MAX_FLEX_COEFFICIENTS = 10 };
     struct IKTargetVar {
         IKTargetVar(const QString& jointNameIn, const QString& positionVarIn, const QString& rotationVarIn,
                     const QString& typeVarIn, const QString& weightVarIn, float weightIn, const std::vector<float>& flexCoefficientsIn);

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -32,7 +32,8 @@ public:
     void loadPoses(const AnimPoseVec& poses);
     void computeAbsolutePoses(AnimPoseVec& absolutePoses) const;
 
-    void setTargetVars(const QString& jointName, const QString& positionVar, const QString& rotationVar, const QString& typeVar);
+    void setTargetVars(const QString& jointName, const QString& positionVar, const QString& rotationVar,
+                       const QString& typeVar, const std::vector<float>& flexCoefficients);
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimNode::Triggers& triggersOut) override;
     virtual const AnimPoseVec& overlay(const AnimVariantMap& animVars, const AnimContext& context, float dt, Triggers& triggersOut, const AnimPoseVec& underPoses) override;
@@ -77,22 +78,18 @@ protected:
     AnimInverseKinematics(const AnimInverseKinematics&) = delete;
     AnimInverseKinematics& operator=(const AnimInverseKinematics&) = delete;
 
+    static const size_t MAX_FLEX_COEFFICIENTS = 10;
     struct IKTargetVar {
-        IKTargetVar(const QString& jointNameIn,
-                const QString& positionVarIn,
-                const QString& rotationVarIn,
-                const QString& typeVarIn) :
-            positionVar(positionVarIn),
-            rotationVar(rotationVarIn),
-            typeVar(typeVarIn),
-            jointName(jointNameIn),
-            jointIndex(-1)
-        {}
+        IKTargetVar(const QString& jointNameIn, const QString& positionVarIn, const QString& rotationVarIn,
+                    const QString& typeVarIn, const std::vector<float>& flexCoefficientsIn);
+        IKTargetVar(const IKTargetVar& orig);
 
         QString positionVar;
         QString rotationVar;
         QString typeVar;
         QString jointName;
+        float flexCoefficients[MAX_FLEX_COEFFICIENTS];
+        size_t numFlexCoefficients;
         int jointIndex; // cached joint index
     };
 

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -471,7 +471,18 @@ AnimNode::Pointer loadInverseKinematicsNode(const QJsonObject& jsonObj, const QS
         READ_STRING(rotationVar, targetObj, id, jsonUrl, nullptr);
         READ_OPTIONAL_STRING(typeVar, targetObj);
 
-        node->setTargetVars(jointName, positionVar, rotationVar, typeVar);
+        auto flexCoefficientsValue = targetObj.value("flexCoefficients");
+        if (!flexCoefficientsValue.isArray()) {
+            qCCritical(animation) << "AnimNodeLoader, bad or missing flexCoefficients array in \"targets\", id =" << id << ", url =" << jsonUrl.toDisplayString();
+            return nullptr;
+        }
+        auto flexCoefficientsArray = flexCoefficientsValue.toArray();
+        std::vector<float> flexCoefficients;
+        for (const auto& value : flexCoefficientsArray) {
+            flexCoefficients.push_back((float)value.toDouble());
+        }
+
+        node->setTargetVars(jointName, positionVar, rotationVar, typeVar, flexCoefficients);
     };
 
     READ_OPTIONAL_STRING(solutionSource, jsonObj);

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -173,6 +173,13 @@ static NodeProcessFunc animNodeTypeToProcessFunc(AnimNode::Type type) {
     }                                                                   \
     float NAME = (float)NAME##_VAL.toDouble()
 
+#define READ_OPTIONAL_FLOAT(NAME, JSON_OBJ, DEFAULT)                    \
+    auto NAME##_VAL = JSON_OBJ.value(#NAME);                            \
+    float NAME = (float)DEFAULT;                                        \
+    if (NAME##_VAL.isDouble()) {                                        \
+        NAME = (float)NAME##_VAL.toDouble();                            \
+    }                                                                   \
+    do {} while (0)
 
 static AnimNode::Pointer loadNode(const QJsonObject& jsonObj, const QUrl& jsonUrl) {
     auto idVal = jsonObj.value("id");
@@ -470,6 +477,8 @@ AnimNode::Pointer loadInverseKinematicsNode(const QJsonObject& jsonObj, const QS
         READ_STRING(positionVar, targetObj, id, jsonUrl, nullptr);
         READ_STRING(rotationVar, targetObj, id, jsonUrl, nullptr);
         READ_OPTIONAL_STRING(typeVar, targetObj);
+        READ_OPTIONAL_STRING(weightVar, targetObj);
+        READ_OPTIONAL_FLOAT(weight, targetObj, 1.0f);
 
         auto flexCoefficientsValue = targetObj.value("flexCoefficients");
         if (!flexCoefficientsValue.isArray()) {
@@ -482,7 +491,7 @@ AnimNode::Pointer loadInverseKinematicsNode(const QJsonObject& jsonObj, const QS
             flexCoefficients.push_back((float)value.toDouble());
         }
 
-        node->setTargetVars(jointName, positionVar, rotationVar, typeVar, flexCoefficients);
+        node->setTargetVars(jointName, positionVar, rotationVar, typeVar, weightVar, weight, flexCoefficients);
     };
 
     READ_OPTIONAL_STRING(solutionSource, jsonObj);

--- a/libraries/animation/src/IKTarget.cpp
+++ b/libraries/animation/src/IKTarget.cpp
@@ -15,7 +15,7 @@ void IKTarget::setPose(const glm::quat& rotation, const glm::vec3& translation) 
 }
 
 void IKTarget::setFlexCoefficients(size_t numFlexCoefficientsIn, const float* flexCoefficientsIn) {
-    _numFlexCoefficients = std::min(numFlexCoefficientsIn, MAX_FLEX_COEFFICIENTS);
+    _numFlexCoefficients = std::min(numFlexCoefficientsIn, (size_t)MAX_FLEX_COEFFICIENTS);
     for (size_t i = 0; i < _numFlexCoefficients; i++) {
         _flexCoefficients[i] = flexCoefficientsIn[i];
     }

--- a/libraries/animation/src/IKTarget.cpp
+++ b/libraries/animation/src/IKTarget.cpp
@@ -14,6 +14,22 @@ void IKTarget::setPose(const glm::quat& rotation, const glm::vec3& translation) 
     _pose.trans() = translation;
 }
 
+void IKTarget::setFlexCoefficients(size_t numFlexCoefficientsIn, const float* flexCoefficientsIn) {
+    _numFlexCoefficients = std::min(numFlexCoefficientsIn, MAX_FLEX_COEFFICIENTS);
+    for (size_t i = 0; i < _numFlexCoefficients; i++) {
+        _flexCoefficients[i] = flexCoefficientsIn[i];
+    }
+}
+
+float IKTarget::getFlexCoefficient(int chainDepth) const {
+    const float DEFAULT_FLEX_COEFFICIENT = 0.5f;
+    if (chainDepth >= 0 && chainDepth < _numFlexCoefficients) {
+        return _flexCoefficients[chainDepth];
+    } else {
+        return DEFAULT_FLEX_COEFFICIENT;
+    }
+}
+
 void IKTarget::setType(int type) {
     switch (type) {
         case (int)Type::RotationAndPosition:

--- a/libraries/animation/src/IKTarget.cpp
+++ b/libraries/animation/src/IKTarget.cpp
@@ -21,10 +21,10 @@ void IKTarget::setFlexCoefficients(size_t numFlexCoefficientsIn, const float* fl
     }
 }
 
-float IKTarget::getFlexCoefficient(int chainDepth) const {
+float IKTarget::getFlexCoefficient(size_t chainDepth) const {
     const float DEFAULT_FLEX_COEFFICIENT = 0.5f;
 
-    if (chainDepth >= 0 && chainDepth < _numFlexCoefficients) {
+    if (chainDepth < _numFlexCoefficients) {
         return _flexCoefficients[chainDepth];
     } else {
         return DEFAULT_FLEX_COEFFICIENT;

--- a/libraries/animation/src/IKTarget.cpp
+++ b/libraries/animation/src/IKTarget.cpp
@@ -23,6 +23,7 @@ void IKTarget::setFlexCoefficients(size_t numFlexCoefficientsIn, const float* fl
 
 float IKTarget::getFlexCoefficient(int chainDepth) const {
     const float DEFAULT_FLEX_COEFFICIENT = 0.5f;
+
     if (chainDepth >= 0 && chainDepth < _numFlexCoefficients) {
         return _flexCoefficients[chainDepth];
     } else {

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -38,14 +38,15 @@ public:
     void setFlexCoefficients(size_t numFlexCoefficientsIn, const float* flexCoefficientsIn);
     float getFlexCoefficient(int chainDepth) const;
 
-    // HACK: give HmdHead targets more "weight" during IK algorithm
-    float getWeight() const { return _type == Type::HmdHead ? HACK_HMD_TARGET_WEIGHT : 1.0f; }
+    void setWeight(float weight) { _weight = weight; }
+    float getWeight() const { return _weight; }
 
     static const size_t MAX_FLEX_COEFFICIENTS = 10;
 private:
     AnimPose _pose;
     int _index{-1};
     Type _type{Type::RotationAndPosition};
+    float _weight;
     float _flexCoefficients[MAX_FLEX_COEFFICIENTS];
     size_t _numFlexCoefficients;
 };

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -36,7 +36,7 @@ public:
     void setIndex(int index) { _index = index; }
     void setType(int);
     void setFlexCoefficients(size_t numFlexCoefficientsIn, const float* flexCoefficientsIn);
-    float getFlexCoefficient(int chainDepth) const;
+    float getFlexCoefficient(size_t chainDepth) const;
 
     void setWeight(float weight) { _weight = weight; }
     float getWeight() const { return _weight; }

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -35,15 +35,19 @@ public:
     void setPose(const glm::quat& rotation, const glm::vec3& translation);
     void setIndex(int index) { _index = index; }
     void setType(int);
+    void setFlexCoefficients(size_t numFlexCoefficientsIn, const float* flexCoefficientsIn);
+    float getFlexCoefficient(int chainDepth) const;
 
     // HACK: give HmdHead targets more "weight" during IK algorithm
     float getWeight() const { return _type == Type::HmdHead ? HACK_HMD_TARGET_WEIGHT : 1.0f; }
 
+    static const size_t MAX_FLEX_COEFFICIENTS = 10;
 private:
     AnimPose _pose;
     int _index{-1};
     Type _type{Type::RotationAndPosition};
-
+    float _flexCoefficients[MAX_FLEX_COEFFICIENTS];
+    size_t _numFlexCoefficients;
 };
 
 #endif // hifi_IKTarget_h

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -41,7 +41,8 @@ public:
     void setWeight(float weight) { _weight = weight; }
     float getWeight() const { return _weight; }
 
-    static const size_t MAX_FLEX_COEFFICIENTS = 10;
+    enum FlexCoefficients { MAX_FLEX_COEFFICIENTS = 10 };
+
 private:
     AnimPose _pose;
     int _index{-1};

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1400,22 +1400,24 @@ void Rig::computeAvatarBoundingCapsule(
 
     AnimInverseKinematics ikNode("boundingShape");
     ikNode.setSkeleton(_animSkeleton);
+
+    // AJT: FIX ME!!!!! ensure that empty weights vector does something reasonable....
     ikNode.setTargetVars("LeftHand",
                          "leftHandPosition",
                          "leftHandRotation",
-                         "leftHandType");
+                         "leftHandType", {});
     ikNode.setTargetVars("RightHand",
                          "rightHandPosition",
                          "rightHandRotation",
-                         "rightHandType");
+                         "rightHandType", {});
     ikNode.setTargetVars("LeftFoot",
                          "leftFootPosition",
                          "leftFootRotation",
-                         "leftFootType");
+                         "leftFootType", {});
     ikNode.setTargetVars("RightFoot",
                          "rightFootPosition",
                          "rightFootRotation",
-                         "rightFootType");
+                         "rightFootType", {});
 
     AnimPose geometryToRig = _modelOffset * _geometryOffset;
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1088,10 +1088,12 @@ void Rig::updateHeadAnimVars(const HeadParameters& params) {
                 // Since there is an explicit hips ik target, switch the head to use the more generic RotationAndPosition IK chain type.
                 // this will allow the spine to bend more, ensuring that it can reach the head target position.
                 _animVars.set("headType", (int)IKTarget::Type::RotationAndPosition);
+                _animVars.unset("headWeight");  // use the default weight for this target.
             } else {
                 // When there is no hips IK target, use the HmdHead IK chain type.  This will make the spine very stiff,
                 // but because the IK _hipsOffset is enabled, the hips will naturally follow underneath the head.
                 _animVars.set("headType", (int)IKTarget::Type::HmdHead);
+                _animVars.set("headWeight", 8.0f);
             }
         } else {
             _animVars.unset("headPosition");
@@ -1405,19 +1407,19 @@ void Rig::computeAvatarBoundingCapsule(
     ikNode.setTargetVars("LeftHand",
                          "leftHandPosition",
                          "leftHandRotation",
-                         "leftHandType", {});
+                         "leftHandType", "leftHandWeight", 1.0f, {});
     ikNode.setTargetVars("RightHand",
                          "rightHandPosition",
                          "rightHandRotation",
-                         "rightHandType", {});
+                         "rightHandType", "rightHandWeight", 1.0f, {});
     ikNode.setTargetVars("LeftFoot",
                          "leftFootPosition",
                          "leftFootRotation",
-                         "leftFootType", {});
+                         "leftFootType", "leftFootWeight", 1.0f, {});
     ikNode.setTargetVars("RightFoot",
                          "rightFootPosition",
                          "rightFootRotation",
-                         "rightFootType", {});
+                         "rightFootType", "rightFootWeight", 1.0f, {});
 
     AnimPose geometryToRig = _modelOffset * _geometryOffset;
 


### PR DESCRIPTION
Added two major features to the IK system
* Each IK chain contains an array of "flex coefficients" which determine how flexible each joint in the chain is.  This is used to prevent the arm chains from exerting undue influence over the spine.
* Each IK chain also contains a dynamic tunable "weight" parameter. This weight is used when each combining each IK chain at the end of each solver iteration.  Typically the head has a higher weight than other IK chains.  Previously this was hard coded, now it is dynamically tunable at run-time via an animVar.