### PR TITLE
Snapshots: Fix case when user story would be incorrectly deleted

### DIFF
--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -359,7 +359,7 @@ function showUploadingMessage(selectedID, destination) {
     shareBarHelp.classList.add("uploading");
     shareBarHelp.setAttribute("data-destination", destination);
 }
-function hideUploadingMessageAndShare(selectedID, storyID) {
+function hideUploadingMessageAndMaybeShare(selectedID, storyID) {
     if (selectedID.id) {
         selectedID = selectedID.id; // sometimes (?), `containerID` is passed as an HTML object to these functions; we just want the ID
     }
@@ -382,21 +382,28 @@ function hideUploadingMessageAndShare(selectedID, storyID) {
                 var facebookButton = document.getElementById(selectedID + "facebookButton");
                 window.open(facebookButton.getAttribute("href"), "_blank");
                 shareBarHelp.innerHTML = facebookShareText;
+                // This emitWebEvent() call isn't necessary in the "hifi" and "blast" cases
+                // because the "removeFromStoryIDsToMaybeDelete()" call happens
+                // in snapshot.js when sharing with that method.
+                EventBridge.emitWebEvent(JSON.stringify({
+                    type: "snapshot",
+                    action: "removeFromStoryIDsToMaybeDelete",
+                    story_id: storyID
+                }));
                 break;
             case 'twitter':
                 var twitterButton = document.getElementById(selectedID + "twitterButton");
                 window.open(twitterButton.getAttribute("href"), "_blank");
                 shareBarHelp.innerHTML = twitterShareText;
+                EventBridge.emitWebEvent(JSON.stringify({
+                    type: "snapshot",
+                    action: "removeFromStoryIDsToMaybeDelete",
+                    story_id: storyID
+                }));
                 break;
         }
 
         shareBarHelp.setAttribute("data-destination", "");
-
-        EventBridge.emitWebEvent(JSON.stringify({
-            type: "snapshot",
-            action: "removeFromStoryIDsToMaybeDelete",
-            story_id: storyID
-        }));
     }
 }
 function updateShareInfo(containerID, storyID) {
@@ -417,7 +424,7 @@ function updateShareInfo(containerID, storyID) {
     twitterButton.setAttribute("target", "_blank");
     twitterButton.setAttribute("href", 'https://twitter.com/intent/tweet?text=I%20just%20took%20a%20snapshot!&url=' + shareURL + '&via=highfidelityinc&hashtags=VR,HiFi');
 
-    hideUploadingMessageAndShare(containerID, storyID);
+    hideUploadingMessageAndMaybeShare(containerID, storyID);
 }
 function blastToConnections(selectedID, isGif) {
     if (selectedID.id) {
@@ -552,6 +559,12 @@ function shareButtonClicked(destination, selectedID) {
 
     if (!storyID) {
         showUploadingMessage(selectedID, destination);
+    } else {
+        EventBridge.emitWebEvent(JSON.stringify({
+            type: "snapshot",
+            action: "removeFromStoryIDsToMaybeDelete",
+            story_id: storyID
+        }));
     }
 }
 

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -51,6 +51,11 @@ function openLoginWindow() {
     }
 }
 
+function removeFromStoryIDsToMaybeDelete(story_id) {
+    storyIDsToMaybeDelete.splice(storyIDsToMaybeDelete.indexOf(story_id), 1);
+    print('storyIDsToMaybeDelete[] now:', JSON.stringify(storyIDsToMaybeDelete));
+}
+
 function onMessage(message) {
     // Receives message from the html dialog via the qwebchannel EventBridge. This is complicated by the following:
     // 1. Although we can send POJOs, we cannot receive a toplevel object. (Arrays of POJOs are fine, though.)
@@ -191,6 +196,7 @@ function onMessage(message) {
                                 return;
                             } else {
                                 print("SUCCESS uploading announcement story! Story ID:", response.user_story.id);
+                                removeFromStoryIDsToMaybeDelete(message.story_id); // Don't delete original "for_url" story
                             }
                         });
                     }
@@ -230,13 +236,13 @@ function onMessage(message) {
                         return;
                     } else {
                         print("SUCCESS changing audience" + (message.isAnnouncement ? " and posting announcement!" : "!"));
+                        removeFromStoryIDsToMaybeDelete(message.story_id);
                     }
                 });
             }
             break;
         case 'removeFromStoryIDsToMaybeDelete':
-            storyIDsToMaybeDelete.splice(storyIDsToMaybeDelete.indexOf(message.story_id), 1);
-            print('storyIDsToMaybeDelete[] now:', JSON.stringify(storyIDsToMaybeDelete));
+            removeFromStoryIDsToMaybeDelete(message.story_id);
             break;
         default:
             print('Unknown message action received by snapshot.js!');


### PR DESCRIPTION
Whoops. Before this PR, if a user took a snapshot, waited for it to upload, *then* shared it (which is likely the most common use case of sharing), the next time they took a snapshot, their original user_story on the High Fidelity website would get deleted. This was an oversight on my part - I should have pruned the list of stories to delete in more cases than I was.

Workarounds for the broken behavior in Master (both of which are unacceptable, but working workarounds):
1. After sharing a snapshot, reload all scripts before taking a new one.
2. After sharing a snapshot, reload Interface before taking a new one.

**Test Plan:**
1. Take a still snapshot in a shareable domain.
2. When the Snapshot app re-opens after capture, wait 15 seconds.
3. Click the Twitter "share" button overlaid on top of the snapshot. Copy the URL present in the pre-filled tweet to your clipboard, and open the URL in an external browser (i.e. Chrome). Verify that you have navigated to a valid page.
4. From within HiFi, Log in to Twitter and tweet the Tweet. Revel in the fact that you have entertained your followers. For extra QA points, @mention @Valefox.
5. Use the Snapshot app to take another snapshot.
6. Press Ctrl+F5 in your external browser to force an uncached refresh of the page. Verify that the user_story page is still valid.