### PR TITLE
Remove unnecessary assert in Model.cpp

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1052,7 +1052,6 @@ void Model::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
 void Model::computeMeshPartLocalBounds() {
     for (auto& part : _modelMeshRenderItems) {
-        assert(part->_meshIndex < _modelMeshRenderItems.size());
         const Model::MeshState& state = _meshStates.at(part->_meshIndex);
         part->computeAdjustedLocalBound(state.clusterMatrices);
     }


### PR DESCRIPTION
This clause inside was not longer valid - it is a valid state for
part->_meshIndex < _modelMeshRenderItems.size(). A better check might be
to compare it to the size of _meshStates which we use below, but we use
_meshStates.at(...) which will do the bounds checking, which makes the
assert unnecessary.