### PR TITLE
Add protections when accessing the mip bytes of a texture when provided from a KtxStorage

### DIFF
--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -210,7 +210,16 @@ PixelsPointer KtxStorage::getMipFace(uint16 level, uint8 face) const {
     auto faceSize = _ktxDescriptor->getMipFaceTexelsSize(level, face);
     if (faceSize != 0 && faceOffset != 0) {
         auto file = maybeOpenFile();
-        result = file->createView(faceSize, faceOffset)->toMemoryStorage();
+        if (file) {
+            auto storageView = file->createView(faceSize, faceOffset);
+            if (storageView) {
+                return storageView->toMemoryStorage();
+            } else {
+                qWarning() << "Failed to get a valid storageView for faceSize=" << faceSize << "  faceOffset=" << faceOffset << "out of valid file " << QString::fromStdString(_filename);
+            }
+        } else {
+            qWarning() << "Failed to get a valid file out of maybeOpenFile " << QString::fromStdString(_filename);
+        }
     }
     return result;
 }

--- a/libraries/shared/src/shared/Storage.cpp
+++ b/libraries/shared/src/shared/Storage.cpp
@@ -25,7 +25,9 @@ StoragePointer Storage::createView(size_t viewSize, size_t offset) const {
         viewSize = selfSize;
     }
     if ((viewSize + offset) > selfSize) {
-        throw std::runtime_error("Invalid mapping range");
+        return StoragePointer();
+        //TODO: Disable te exception for now and return an empty storage instead.
+        //throw std::runtime_error("Invalid mapping range");
     }
     return std::make_shared<ViewStorage>(shared_from_this(), viewSize, data() + offset);
 }


### PR DESCRIPTION
This pr potentially address a problem and a crash if the KtxStorage file is failing to be mapped during the access sequence.
In theory this should not happen but we have seen crashes due to this:
https://www.bugsplat.com/individualCrash/?id=11792&database=interface_alpha

I have dsiabled the exception thrown from FileStorage thinking that since we don;t have a handler, this may be the reason fro another crash without a bugsplat...

This is attempting to fix this bug:
https://highfidelity.fogbugz.com/f/cases/4795/CRASH-in-storage-MemoryStorage-MemoryStorage

## TEST PLAN
No real repro for this so simply check that there is weird behavior different from current master