### PR TITLE
Ensure avatar identity packet at mixer.

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -145,7 +145,7 @@ private:
     std::unordered_map<QUuid, QVector<JointData>> _lastOtherAvatarSentJoints;
 
     uint64_t _identityChangeTimestamp;
-    bool _avatarSessionDisplayNameMustChange{ false };
+    bool _avatarSessionDisplayNameMustChange{ true };
 
     int _numAvatarsSentLastFrame = 0;
     int _numFramesSinceAdjustment = 0;


### PR DESCRIPTION
Ensure that the avatar mixer sends an identity packet for all new nodes, even if none are received from client.