### PR TITLE
Remove extraneous calls to sendIdentityPacket()

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5258,9 +5258,8 @@ void Application::nodeActivated(SharedNodePointer node) {
     }
 
     if (node->getType() == NodeType::AvatarMixer) {
-        // new avatar mixer, send off our identity packet right away
+        // new avatar mixer, send off our identity packet on next update loop
         getMyAvatar()->markIdentityDataChanged();
-        getMyAvatar()->sendIdentityPacket();
         getMyAvatar()->resetLastSent();
     }
 }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1588,8 +1588,6 @@ void AvatarData::setDisplayName(const QString& displayName) {
     _displayName = displayName;
     _sessionDisplayName = "";
 
-    sendIdentityPacket();
-
     qCDebug(avatars) << "Changing display name for avatar to" << displayName;
     markIdentityDataChanged();
 }


### PR DESCRIPTION
Extraneous calls to sendIdentityPacket() could cause problems given our current system of timestamping identity packets. This PR removes those extraneous calls.

[Item number 2 of this FogBugz ticket.](https://highfidelity.fogbugz.com/f/cases/4801/T-posers-and-unable-to-use-PAL)

**Test Plan:**
Prerequisites:
- This plan requires two Interface clients running - Interface A and Interface B.
- The machine running Interface A should also be running Sandbox A.
- Use unique avatars and display names for Interface A and Interface B.

Test Plan:
1. Using Interface B, connect to Sandbox A.
3. Using Interface A, connect to Sandbox A.
4. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
5. Using Interface A, disconnect from Sandbox A.
6. Wait 20 seconds.
7. Using Interface A, connect to Sandbox A.
8. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
9. Using Interface B, disconnect from Sandbox A.
10. Wait 10 seconds.
11. Using Interface B, connect to Sandbox A.
12. Verify that both clients can see each other's avatars correctly, and that each appears in the other's PAL.
13. Set Interface B to use the same display name as Interface A, then refresh Interface B's PAL.
14. Verify that both Interface A and Interface B see the same Session Display Name - it should be "<Interface A's Display Name>_1"
15. Restart Interface B. Re-verify the results from Step 14.