### PR TITLE
Enable Map/List storage in the settings

### DIFF
--- a/libraries/shared/src/SettingHelpers.cpp
+++ b/libraries/shared/src/SettingHelpers.cpp
@@ -126,17 +126,6 @@ QJsonDocument variantMapToJsonDocument(const QSettings::SettingsMap& map) {
         }
 
         switch (variantType) {
-            case QVariant::Map: {
-                auto varmap = variant.toMap();
-                for (auto mapit = varmap.cbegin(); mapit != varmap.cend(); ++mapit) {
-                    auto& mapkey = mapit.key();
-                    auto& mapvariant = mapit.value();
-                    object.insert(key + "/" + mapkey, QJsonValue::fromVariant(mapvariant));
-                }
-                break;
-            }
-
-            case QVariant::List:
             case QVariant::Hash: {
                 qCritical() << "Unsupported variant type" << variant.typeName();
                 Q_ASSERT(false);
@@ -152,6 +141,8 @@ QJsonDocument variantMapToJsonDocument(const QSettings::SettingsMap& map) {
             case QVariant::UInt:
             case QVariant::Bool:
             case QVariant::Double:
+            case QVariant::Map:
+            case QVariant::List:
                 object.insert(key, QJsonValue::fromVariant(variant));
                 break;
 


### PR DESCRIPTION
This enables storing maps and lists in the Settings.

## Test Plan:
- Open your scripting console
- Enter the following
```js
Settings.setValue("Map", { a: 1, b: "2", c: [3, "4"] });
Settings.setValue("List", [ 1, "2", { a: 3, b: "4" }]);
```
- Restart Interface
- Open your scripting console
- Enter the following
```js
JSON.stringify(Settings.getValue("Map"));
```
- The console should print out:
```js
{"a":1,"b":"2","c":[3,"4"]}
```
- Enter the following
```js
JSON.stringify(Settings.getValue("List"));
```
- The console should print out:
```js
[1,"2",{"a":3,"b":"4"}]
```