### PR TITLE
Build 39.1 Hotfix for 30 second wifi check causing an issue with Audio

### DIFF
--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -768,9 +768,10 @@ bool similarStrings(const QString& stringA, const QString& stringB) {
 }
 
 void disableQtBearerPoll() {
-    // to work around the Qt constant wireless scanning, set the env for polling interval very high
-    const QByteArray EXTREME_BEARER_POLL_TIMEOUT = QString::number(INT16_MAX).toLocal8Bit();
-    qputenv("QT_BEARER_POLL_TIMEOUT", EXTREME_BEARER_POLL_TIMEOUT);
+    // to disable the Qt constant wireless scanning, set the env for polling interval
+    qDebug() << "Disabling Qt wireless polling by using a negative value for QTimer::setInterval";
+    const QByteArray DISABLE_BEARER_POLL_TIMEOUT = QString::number(-1).toLocal8Bit();
+    qputenv("QT_BEARER_POLL_TIMEOUT", DISABLE_BEARER_POLL_TIMEOUT);
 }
 
 void printSystemInformation() {


### PR DESCRIPTION
Build 39.1 Hotfix for 30 second wifi check causing an issue with Audio

Ensure Audio works with wired and wifi network on PC and Mac. Set your audio to echo server loopback and make sure you do not hear bad audio