### PR TITLE
Fix ktx image size in progrssively loaded cubemaps

### DIFF
--- a/libraries/ktx/src/ktx/Writer.cpp
+++ b/libraries/ktx/src/ktx/Writer.cpp
@@ -149,7 +149,8 @@ namespace ktx {
 
         for (size_t i = 0; i < descriptors.size(); ++i) {
             auto ptr = reinterpret_cast<uint32_t*>(currentDestPtr);
-            *ptr = descriptors[i]._imageSize;
+            uint32_t imageFaceSize = descriptors[i]._faceSize;
+            *ptr = imageFaceSize; // the imageSize written in the ktx is the FACE size
 
 #ifdef DEBUG
             ptr++;


### PR DESCRIPTION
The size being written was the full image size (size of all faces), when
it should have been the face size.