### PR TITLE
Prevent another GIF from being captured while one is processing

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6428,7 +6428,7 @@ void Application::takeSnapshot(bool notify, bool includeAnimated, float aspectRa
         if (!includeAnimated) {
             // Tell the dependency manager that the capture of the still snapshot has taken place.
             emit DependencyManager::get<WindowScriptingInterface>()->stillSnapshotTaken(path, notify);
-        } else {
+        } else if (!SnapshotAnimated::isAlreadyTakingSnapshotAnimated()) {
             // Get an animated GIF snapshot and save it
             SnapshotAnimated::saveSnapshotAnimated(path, aspectRatio, qApp, DependencyManager::get<WindowScriptingInterface>());
         }

--- a/interface/src/ui/SnapshotAnimated.h
+++ b/interface/src/ui/SnapshotAnimated.h
@@ -51,6 +51,7 @@ private:
     static void processFrames();
 public:
     static void saveSnapshotAnimated(QString pathStill, float aspectRatio, Application* app, QSharedPointer<WindowScriptingInterface> dm);
+    static bool isAlreadyTakingSnapshotAnimated() { return snapshotAnimatedFirstFrameTimestamp != 0; };
     static Setting::Handle<bool> alsoTakeAnimatedSnapshot;
     static Setting::Handle<float> snapshotAnimatedDuration;
 };

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -44,6 +44,7 @@ function showSetupComplete() {
             '<p>Snapshot location set.</p>' +
             '<p>Press the big red button to take a snap!</p>' +
         '</div>';
+    document.getElementById("snap-button").disabled = false;
 }
 function showSnapshotInstructions() {
     var snapshotImagesDiv = document.getElementById("snapshot-images");
@@ -69,7 +70,6 @@ function login() {
     }));
 }
 function clearImages() {
-    document.getElementById("snap-button").disabled = false;
     var snapshotImagesDiv = document.getElementById("snapshot-images");
     snapshotImagesDiv.classList.remove("snapshotInstructions");
     while (snapshotImagesDiv.hasChildNodes()) {
@@ -650,6 +650,7 @@ window.onload = function () {
                             shareForUrl("p1");
                             appendShareBar("p1", messageOptions.isLoggedIn, messageOptions.canShare, true, false, false, messageOptions.canBlast);
                             document.getElementById("p1").classList.remove("processingGif");
+                            document.getElementById("snap-button").disabled = false;
                         }
                     } else {
                         imageCount = message.image_data.length;
@@ -688,6 +689,9 @@ function takeSnapshot() {
         type: "snapshot",
         action: "takeSnapshot"
     }));
+    if (document.getElementById('stillAndGif').checked === true) {
+        document.getElementById("snap-button").disabled = true;
+    }
 }
 
 function testInBrowser(test) {


### PR DESCRIPTION
This PR does two things:
1. It disables the red Snapshot button in the Snapshot app while a GIF taken from the Snapshot app is processing
2. At the C++ level, it prevents another GIF from being captured while a previous GIF is being processed.

It'd be best if we could handle capturing and displaying an infinite number of GIF snapshots and still snapshots simultaneously, but that's a big project that I'm not going to do right now. I could imagine the Snapshot app being redesigned as a "camera roll" instead of only showing the previous two snapshots, but not now...

**Test Plan:**
(HMD or Desktop; it doesn't matter)
1. Set the Snapshot app to take a GIF + a Still snapshot.
2. Click the red button in the Snapshot app to take a Still + Gif snapshot.
3. When the Snapshot app reappears and the GIF is shown as "Processing", verify that the red Capture button isn't clickable and is gray.
4. Verify that, after the GIF is finished processing, the Capture button turns red again and becomes clickable.