### PR TITLE
Ensure snapshots without story_ids get uploaded

### DIFF
--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -300,7 +300,7 @@ function addImage(image_data, isLoggedIn, canShare, isGifLoading, isShowingPrevi
     if (!isGifLoading) {
         appendShareBar(id, isLoggedIn, canShare, isGif, blastButtonDisabled, hifiButtonDisabled, canBlast);
     }
-    if (!isGifLoading && !isShowingPreviousImages) {
+    if (!isGifLoading || (isShowingPreviousImages && !image_data.story_id)) {
         shareForUrl(id);
     }
     if (isShowingPreviousImages && isLoggedIn && image_data.story_id) {

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -138,10 +138,10 @@ function onMessage(message) {
                     isLoggedIn = Account.isLoggedIn();
                     if (isLoggedIn) {
                         print('Sharing snapshot with audience "for_url":', message.data);
-                        Window.shareSnapshot(message.data, message.href || href);
+                        Window.shareSnapshot(message.data, Settings.getValue("previousSnapshotHref"));
                     } else {
                         shareAfterLogin = true;
-                        snapshotToShareAfterLogin.push({ path: message.data, href: message.href || href });
+                        snapshotToShareAfterLogin.push({ path: message.data, href: Settings.getValue("previousSnapshotHref") });
                     }
                 }
             });
@@ -349,6 +349,7 @@ function takeSnapshot() {
     // We will record snapshots based on the starting location. That could change, e.g., when recording a .gif.
     // Even the domainId could change (e.g., if the user falls into a teleporter while recording).
     href = location.href;
+    Settings.setValue("previousSnapshotHref", href);
     domainId = location.domainId;
     Settings.setValue("previousSnapshotDomainID", domainId);
 


### PR DESCRIPTION
This PR fixes the bug noted in [this FogBugz ticket](https://highfidelity.fogbugz.com/f/cases/4825/Can-t-share-Snapshot-after-closing-and-Opening-Interface). More specifically, this PR ensures that snapshots taken in a previous session that don't have `story_id`s get uploaded the next time the snapshot app is opened. Yay, robustness!

**Test Plan:**

*Testing Still Snapshot Upload Robustness:*
1. In HMD OR desktop (doesn't matter), take a Still + GIF snapshot using the Snapshot app
2. _Immediately_ after the Snapshot app re-opens, close Interface
3. Open Interface and open the Snapshot app
4. Verify that your STILL snapshot is there (the GIF is not displayed because it did not finish processing)
5. Wait 5 seconds.
6. Click on the Twitter share button.
7. The Twitter webpage opens in a browser.
8. Copy and paste the user_story link present in the pre-filled Tweet text into an external browser. Verify that the snapshot on that user_story page matches the snapshot you took before closing Interface.

*Testing Animated Snapshot Upload Robustness:*
1. In HMD OR desktop (doesn't matter), take a Still + GIF snapshot using the Snapshot app
2. _Immediately_ after the Animated Snapshot finishes processing and is displayed, close Interface
3. Open Interface and open the Snapshot app
4. Verify that both your Still and GIF snapshots from your previous session are there
5. Quickly click on the GIF's Twitter share button.
6. For between 1 and 30 seconds, the text "Preparing to Share" appears over the GIF (this occurs while the GIF is uploading to the High Fidelity servers)
7. After 1-30 seconds,. the Twitter webpage opens in a browser with some pre-filled Tweet text.
8. Copy and paste the user_story link present in the pre-filled Tweet text into an external browser. Verify that the snapshot on that user_story page matches the GIF snapshot you took before closing Interface.