### PR TITLE
Fix "Reset Settings" window poping up every time

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -431,7 +431,7 @@ static const QString STATE_ADVANCED_MOVEMENT_CONTROLS = "AdvancedMovement";
 static const QString STATE_GROUNDED = "Grounded";
 static const QString STATE_NAV_FOCUSED = "NavigationFocused";
 
-bool setupEssentials(int& argc, char** argv) {
+bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     const char** constArgv = const_cast<const char**>(argv);
     const char* portStr = getCmdOption(argc, constArgv, "--listenPort");
     const int listenPort = portStr ? atoi(portStr) : INVALID_PORT;
@@ -458,7 +458,7 @@ bool setupEssentials(int& argc, char** argv) {
 
     static const auto SUPPRESS_SETTINGS_RESET = "--suppress-settings-reset";
     bool suppressPrompt = cmdOptionExists(argc, const_cast<const char**>(argv), SUPPRESS_SETTINGS_RESET);
-    bool previousSessionCrashed = CrashHandler::checkForResetSettings(suppressPrompt);
+    bool previousSessionCrashed = CrashHandler::checkForResetSettings(runningMarkerExisted, suppressPrompt);
 
     DependencyManager::registerInheritance<LimitedNodeList, NodeList>();
     DependencyManager::registerInheritance<AvatarHashMap, AvatarManager>();
@@ -563,11 +563,11 @@ const bool DEFAULT_DESKTOP_TABLET_BECOMES_TOOLBAR = true;
 const bool DEFAULT_HMD_TABLET_BECOMES_TOOLBAR = false;
 const bool DEFAULT_PREFER_AVATAR_FINGER_OVER_STYLUS = false;
 
-Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer) :
+Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bool runningMarkerExisted) :
     QApplication(argc, argv),
     _window(new MainWindow(desktop())),
     _sessionRunTimer(startupTimer),
-    _previousSessionCrashed(setupEssentials(argc, argv)),
+    _previousSessionCrashed(setupEssentials(argc, argv, runningMarkerExisted)),
     _undoStackScriptingInterface(&_undoStack),
     _entitySimulation(new PhysicalEntitySimulation()),
     _physicsEngine(new PhysicsEngine(Vectors::ZERO)),

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -136,7 +136,7 @@ public:
     static void initPlugins(const QStringList& arguments);
     static void shutdownPlugins();
 
-    Application(int& argc, char** argv, QElapsedTimer& startup_time);
+    Application(int& argc, char** argv, QElapsedTimer& startup_time, bool runningMarkerExisted);
     ~Application();
 
     void postLambdaEvent(std::function<void()> f) override;

--- a/interface/src/CrashHandler.cpp
+++ b/interface/src/CrashHandler.cpp
@@ -28,7 +28,7 @@
 
 #include <RunningMarker.h>
 
-bool CrashHandler::checkForResetSettings(bool suppressPrompt) {
+bool CrashHandler::checkForResetSettings(bool wasLikelyCrash, bool suppressPrompt) {
     Settings settings;
     settings.beginGroup("Developer");
     QVariant displayCrashOptions = settings.value(MenuOption::DisplayCrashOptions);
@@ -38,9 +38,6 @@ bool CrashHandler::checkForResetSettings(bool suppressPrompt) {
 
     // If option does not exist in Interface.ini so assume default behavior.
     bool displaySettingsResetOnCrash = !displayCrashOptions.isValid() || displayCrashOptions.toBool();
-
-    QFile runningMarkerFile(RunningMarker::getMarkerFilePath(RUNNING_MARKER_FILENAME));
-    bool wasLikelyCrash = runningMarkerFile.exists();
 
     if (suppressPrompt) {
         return wasLikelyCrash;

--- a/interface/src/CrashHandler.h
+++ b/interface/src/CrashHandler.h
@@ -17,7 +17,7 @@
 class CrashHandler {
 
 public:
-    static bool checkForResetSettings(bool suppressPrompt = false);
+    static bool checkForResetSettings(bool wasLikelyCrash, bool suppressPrompt = false);
 
 private:
     enum Action {

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -192,6 +192,7 @@ int main(int argc, const char* argv[]) {
     int exitCode;
     {
         RunningMarker runningMarker(nullptr, RUNNING_MARKER_FILENAME);
+        bool runningMarkerExisted = runningMarker.fileExists();
         runningMarker.writeRunningMarkerFile();
 
         bool noUpdater = parser.isSet(noUpdaterOption);
@@ -202,7 +203,7 @@ int main(int argc, const char* argv[]) {
             SandboxUtils::runLocalSandbox(serverContentPath, true, RUNNING_MARKER_FILENAME, noUpdater);
         }
 
-        Application app(argc, const_cast<char**>(argv), startupTime);
+        Application app(argc, const_cast<char**>(argv), startupTime, runningMarkerExisted);
 
         // Now that the main event loop is setup, launch running marker thread
         runningMarker.startRunningMarker();

--- a/libraries/shared/src/RunningMarker.cpp
+++ b/libraries/shared/src/RunningMarker.cpp
@@ -53,6 +53,11 @@ RunningMarker::~RunningMarker() {
     _runningMarkerThread->deleteLater();
 }
 
+bool RunningMarker::fileExists() const {
+    QFile runningMarkerFile(getFilePath());
+    return runningMarkerFile.exists();
+}
+
 void RunningMarker::writeRunningMarkerFile() {
     QFile runningMarkerFile(getFilePath());
 
@@ -69,7 +74,7 @@ void RunningMarker::deleteRunningMarkerFile() {
     }
 }
 
-QString RunningMarker::getFilePath() {
+QString RunningMarker::getFilePath() const {
     return QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/" + _name;
 }
 

--- a/libraries/shared/src/RunningMarker.h
+++ b/libraries/shared/src/RunningMarker.h
@@ -25,8 +25,10 @@ public:
 
     void startRunningMarker();
 
-    QString getFilePath();
+    QString getFilePath() const;
     static QString getMarkerFilePath(QString name);
+
+    bool fileExists() const;
 
     void writeRunningMarkerFile();
     void deleteRunningMarkerFile();


### PR DESCRIPTION
## Test plan:
- Launch PR build
- Enable Developer Settings
- Go through several Interface runs by randomly shutting down interface properly or selecting one of the options in "Developer > Crash"
- The "Reset Settings" popup should only show up after a crash