### PR TITLE
Increment _identitySequenceId before sending ID packet for agents

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -584,6 +584,7 @@ void Agent::setIsAvatar(bool isAvatar) {
 void Agent::sendAvatarIdentityPacket() {
     if (_isAvatar) {
         auto scriptedAvatar = DependencyManager::get<ScriptableAvatar>();
+        scriptedAvatar->markIdentityDataChanged();
         scriptedAvatar->sendIdentityPacket();
     }
 }


### PR DESCRIPTION
Does what it says on the tin.

**Test Plan:**
1. On a clean installation (i.e. reset settings) of Interface and Sandbox, run Sandbox. Connect to your Sandbox from Interface.
2. Verify that your sandbox's logs are not spammed, once per second, with
`[avatar-mixer] Ignoring older identity packet for avatar QUuid("{00000000-0000-0000-0000-000000000000}") _identitySequenceId ( 4 ) is greater than 2`

Note that you may see the above message happen once with different values (instead of 4 and 2), but this should not be considered a fail. You might see those messages because we haven't fully fixed the way scripted agents send identity packets.