### PR TITLE
force locked entities to be static in bullet

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2767,6 +2767,11 @@ void EntityItem::setLocked(bool value) {
     withWriteLock([&] {
         _locked = value;
     });
+    markDirtyFlags(Simulation::DIRTY_MOTION_TYPE);
+    EntityTreePointer tree = getTree();
+    if (tree) {
+        tree->entityChanged(getThisPointer());
+    }
 }
 
 QString EntityItem::getUserData() const { 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2764,13 +2764,19 @@ bool EntityItem::getLocked() const {
 }
 
 void EntityItem::setLocked(bool value) { 
+    bool changed { false };
     withWriteLock([&] {
-        _locked = value;
+        if (_locked != value) {
+            _locked = value;
+            changed = true;
+        }
     });
-    markDirtyFlags(Simulation::DIRTY_MOTION_TYPE);
-    EntityTreePointer tree = getTree();
-    if (tree) {
-        tree->entityChanged(getThisPointer());
+    if (changed) {
+        markDirtyFlags(Simulation::DIRTY_MOTION_TYPE);
+        EntityTreePointer tree = getTree();
+        if (tree) {
+            tree->entityChanged(getThisPointer());
+        }
     }
 }
 

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -185,6 +185,10 @@ PhysicsMotionType EntityMotionState::computePhysicsMotionType() const {
         return MOTION_TYPE_STATIC;
     }
 
+    if (_entity->getLocked()) {
+        return MOTION_TYPE_STATIC;
+    }
+
     if (_entity->getDynamic()) {
         if (!_entity->getParentID().isNull()) {
             // if something would have been dynamic but is a child of something else, force it to be kinematic, instead.


### PR DESCRIPTION
- when entities are locked, they will be "static" in bullet
