### PR TITLE
Add unpublishedScripts content to the JS project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,9 +208,10 @@ foreach(CUSTOM_MACRO ${HIFI_CUSTOM_MACROS})
   include(${CUSTOM_MACRO})
 endforeach()
 
-file(GLOB_RECURSE JS_SRC scripts/*.js)
+file(GLOB_RECURSE JS_SRC scripts/*.js unpublishedScripts/*.js)
 add_custom_target(js SOURCES ${JS_SRC})
 GroupSources("scripts")
+GroupSources("unpublishedScripts")
 
 if (UNIX)
    install(


### PR DESCRIPTION
Adds the "unpublishedScripts" folder to the "js" project displayed in Visual Studio or equivalent.