### PR TITLE
Prevent ping-ponging of texture quality when oversubscribed

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -535,12 +535,14 @@ void GLVariableAllocationSupport::processWorkQueue(WorkQueue& workQueue) {
             vartexture->demote();
             workQueue.pop();
             addToWorkQueue(texture);
+            _memoryPressureStateStale = true;
             break;
 
         case MemoryPressureState::Undersubscribed:
             vartexture->promote();
             workQueue.pop();
             addToWorkQueue(texture);
+            _memoryPressureStateStale = true;
             break;
 
         case MemoryPressureState::Transfer:


### PR DESCRIPTION
## Testing

* Load a high texture environment such as Dev-Playa or Playa 
* Look around to ensure you have a large amount of texture allocation (Playa or Dev-Playa should consume more than 512 MB once loaded)
* Once you've exceeded 512 MB of texture allocation, go into Developer / Render / Maximum Texture Memory and reduce the allowed texture memory to 512 MB.

In the current master build you will see the textures rapidly lose resolution and the visual quality drop rapidly to well below 512 MB.  Eventually this will bottom out and start rising again.  Once it maxes out, it will then drop again, repeating this cycle continuously.  In this PR build, the memory should instead drop to just at or below 512 MB and then stop. 