### PR TITLE
ensure AvatarMixerClientData AvatarData has session ID

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -16,7 +16,14 @@
 
 #include "AvatarMixerClientData.h"
 
+AvatarMixerClientData::AvatarMixerClientData(const QUuid& nodeID) :
+    NodeData(nodeID)
+{
+    _currentViewFrustum.invalidate();
 
+    // in case somebody calls getSessionUUID on the AvatarData instance, make sure it has the right ID
+    _avatar->setID(nodeID);
+}
 
 void AvatarMixerClientData::queuePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer node) {
     if (!_packetQueue.node) {

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -36,7 +36,7 @@ const QString INBOUND_AVATAR_DATA_STATS_KEY = "inbound_av_data_kbps";
 class AvatarMixerClientData : public NodeData {
     Q_OBJECT
 public:
-    AvatarMixerClientData(const QUuid& nodeID = QUuid()) : NodeData(nodeID) { _currentViewFrustum.invalidate(); }
+    AvatarMixerClientData(const QUuid& nodeID = QUuid());
     virtual ~AvatarMixerClientData() {}
     using HRCTime = p_high_resolution_clock::time_point;
 


### PR DESCRIPTION
- pass the session ID for Avatar Mixer client data to the underlying Avatar data