### PR TITLE
Fix crash in entity ScriptEngine

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -397,16 +397,12 @@ void ScriptEngine::waitTillDoneRunning() {
                 }
             }
 
-            // NOTE: This will be called on the main application thread from stopAllScripts.
-            //       The application thread will need to continue to process events, because
+            // NOTE: This will be called on the main application thread (among other threads) from stopAllScripts.
+            //       The thread will need to continue to process events, because
             //       the scripts will likely need to marshall messages across to the main thread, e.g.
             //       if they access Settings or Menu in any of their shutdown code. So:
-            // Process events for the main application thread, allowing invokeMethod calls to pass between threads.
+            // Process events for this thread, allowing invokeMethod calls to pass between threads.
             QCoreApplication::processEvents();
-            // In some cases (debugging), processEvents may give the thread enough time to shut down, so recheck it.
-            if (!thread()) {
-                break;
-            }
 
             // Avoid a pure busy wait
             QThread::yieldCurrentThread();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -231,7 +231,7 @@ void ScriptEngine::disconnectNonEssentialSignals() {
     // Ensure the thread should be running, and does exist
     if (_isRunning && _isThreaded && (workerThread = thread())) {
         connect(this, &ScriptEngine::doneRunning, workerThread, &QThread::quit);
-        connect(workerThread, &QThread::finished, workerThread, &QObject::deleteLater);
+        connect(this, &QObject::destroyed, workerThread, &QObject::deleteLater);
     }
 }
 
@@ -346,7 +346,7 @@ void ScriptEngine::runInThread() {
     // disconnectNonEssentialSignals() method
     connect(workerThread, &QThread::started, this, &ScriptEngine::run);
     connect(this, &ScriptEngine::doneRunning, workerThread, &QThread::quit);
-    connect(workerThread, &QThread::finished, workerThread, &QObject::deleteLater);
+    connect(this, &QObject::destroyed, workerThread, &QObject::deleteLater);
 
     workerThread->start();
 }


### PR DESCRIPTION
This is a speculative fix for a crash in `ScriptEngine::waitTillDoneRunning` that appeared to occur if the ScriptEngine's QThread was deleted earlier than expected. As far as I could tell there was nothing keeping this from happening because the worker thread queues up a deletion before it stops, which could be before the ScriptEngine is deleted.