### PR TITLE
Added refreshing of Account Managers access token

### DIFF
--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -98,13 +98,13 @@ public:
 public slots:
     void requestAccessToken(const QString& login, const QString& password);
     void requestAccessTokenWithSteam(QByteArray authSessionTicket);
-    void requestNewAccessToken();
+    void refreshAccessToken();
 
     void requestAccessTokenFinished();
-    void requestNewAccessTokenFinished();
+    void refreshAccessTokenFinished();
     void requestProfileFinished();
     void requestAccessTokenError(QNetworkReply::NetworkError error);
-    void requestNewAccessTokenError(QNetworkReply::NetworkError error);
+    void refreshAccessTokenError(QNetworkReply::NetworkError error);
     void requestProfileError(QNetworkReply::NetworkError error);
     void logout();
     void generateNewUserKeypair() { generateNewKeypair(); }

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -79,6 +79,7 @@ public:
 
     bool isLoggedIn() { return !_authURL.isEmpty() && hasValidAccessToken(); }
     bool hasValidAccessToken();
+    bool needsToRefreshToken();
     Q_INVOKABLE bool checkAndSignalForAccessToken();
     void setAccessTokenForCurrentAuthURL(const QString& accessToken);
 
@@ -97,10 +98,13 @@ public:
 public slots:
     void requestAccessToken(const QString& login, const QString& password);
     void requestAccessTokenWithSteam(QByteArray authSessionTicket);
+    void requestNewAccessToken();
 
     void requestAccessTokenFinished();
+    void requestNewAccessTokenFinished();
     void requestProfileFinished();
     void requestAccessTokenError(QNetworkReply::NetworkError error);
+    void requestNewAccessTokenError(QNetworkReply::NetworkError error);
     void requestProfileError(QNetworkReply::NetworkError error);
     void logout();
     void generateNewUserKeypair() { generateNewKeypair(); }
@@ -141,6 +145,7 @@ private:
     QMap<QNetworkReply*, JSONCallbackParameters> _pendingCallbackMap;
 
     DataServerAccountInfo _accountInfo;
+    bool _isWaitingForTokenRefresh { false };
     bool _isAgent { false };
 
     bool _isWaitingForKeypairResponse { false };


### PR DESCRIPTION
Implemented refresh_token in the OAuth Account Manager, should now request a new access token using our given refresh token if we see that our current access token will expire soon.

Should fix https://highfidelity.fogbugz.com/f/cases/4228/Logged-out-account-still-shows-name-of-account-in-title-bar

To Test:

1. Download this file: [AccountInfo.zip](https://github.com/highfidelity/hifi/files/1020434/AccountInfo.zip)
2. Place attached AccountInfo.bin into your Interface's AppData folder 
3. Start your interface, verify that you are signed in (username should be seefotest)
4. Open the marketplace and verify that (our username) 'seefotest' appears in the upper-right drop down


Notes:

- The attached AccountInfo.bin contains a single-use refresh key, once consumed, you will have to ask for the refresh key to be unrevoked.  You can request that to be done by leaving a comment.
- If you attempt to use the AccountInfo.bin and see that you are not signed in, see the first note.