### PR TITLE
Should fix crash in general setting dialog

### DIFF
--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -163,12 +163,15 @@ void ViveControllerManager::pluginUpdate(float deltaTime, const controller::Inpu
 }
 
 ViveControllerManager::InputDevice::InputDevice(vr::IVRSystem*& system) : controller::InputDevice("Vive"), _system(system) {
+
     _configStringMap[Config::Auto] =  QString("Auto");
     _configStringMap[Config::Feet] =  QString("Feet");
     _configStringMap[Config::FeetAndHips] =  QString("FeetAndHips");
     _configStringMap[Config::FeetHipsAndChest] =  QString("FeetHipsAndChest");
 
-    createPreferences();
+    if (openVrSupported()) {
+        createPreferences();
+    }
 }
 
 void ViveControllerManager::InputDevice::update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) {

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -163,12 +163,12 @@ void ViveControllerManager::pluginUpdate(float deltaTime, const controller::Inpu
 }
 
 ViveControllerManager::InputDevice::InputDevice(vr::IVRSystem*& system) : controller::InputDevice("Vive"), _system(system) {
-    createPreferences();
-
     _configStringMap[Config::Auto] =  QString("Auto");
     _configStringMap[Config::Feet] =  QString("Feet");
     _configStringMap[Config::FeetAndHips] =  QString("FeetAndHips");
     _configStringMap[Config::FeetHipsAndChest] =  QString("FeetHipsAndChest");
+
+    createPreferences();
 }
 
 void ViveControllerManager::InputDevice::update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) {


### PR DESCRIPTION
This fixes https://highfidelity.fogbugz.com/f/cases/4756/CRASH-Tablet-in-Desktop-Settings-General

If you don't have a vive, when you bring up the settings -> general dialog, you crash.  In desktop you can see this by bringing up the dialog, and unchecking the Desktop Tablet Becomes Toolbar button.  Then try to bring it up again.  Note if you have a vive, this will not crash.