### PR TITLE
Never store an address with an empty host

### DIFF
--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -136,7 +136,13 @@ void AddressManager::goForward() {
 }
 
 void AddressManager::storeCurrentAddress() {
-    currentAddressHandle.set(currentAddress());
+    auto url = currentAddress();
+    
+    if (!url.host().isEmpty()) {
+        currentAddressHandle.set(url);
+    } else {
+        qCWarning(networking) << "Ignoring attempt to save current address with an empty host" << url;
+    }
 }
 
 QString AddressManager::currentPath(bool withOrientation) const {


### PR DESCRIPTION
Prevent quick exits from storing a bad location.

## Test Plan
- Make sure your Sandbox is **NOT** running
- Launch Interface and go to any location
- Shutdown interface
- Launch Interface and close it as soon as you see the window open.
(The goal here is to close Interface before the window title updates from "Interface" to the name of the location you are connected too)
- Launch Interface again, you should be at your original location.

On the current master, you should observer than when launching Interface after the quick exit, you would never reconnect to your original location.
