### PR TITLE
Attachment Scale fix (Breaks previous set attachment scales)

### DIFF
--- a/interface/resources/qml/hifi/dialogs/attachments/Attachment.qml
+++ b/interface/resources/qml/hifi/dialogs/attachments/Attachment.qml
@@ -181,10 +181,10 @@ Item {
                 HifiControls.SpinBox {
                     id: scaleSpinner;
                     anchors { left: parent.left; right: parent.right; bottom: parent.bottom; }
-                    decimals: 1;
-                    minimumValue: 0.1
+                    decimals: 2;
+                    minimumValue: 0.01
                     maximumValue: 10
-                    stepSize: 0.1;
+                    stepSize: 0.05;
                     value: attachment ? attachment.scale : 1.0
                     colorScheme: hifi.colorSchemes.dark
                     onValueChanged: {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -684,7 +684,8 @@ void Avatar::simulateAttachments(float deltaTime) {
                 _skeletonModel->getJointRotationInWorldFrame(jointIndex, jointRotation)) {
                 model->setTranslation(jointPosition + jointRotation * attachment.translation * getUniformScale());
                 model->setRotation(jointRotation * attachment.rotation);
-                model->setScaleToFit(true, getUniformScale() * attachment.scale, true); // hack to force rescale
+                float scale = getUniformScale() * attachment.scale;
+                model->setScaleToFit(true, model->getNaturalDimensions() * scale, true); // hack to force rescale
                 model->setSnapModelToCenter(false); // hack to force resnap
                 model->setSnapModelToCenter(true);
                 model->simulate(deltaTime);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -716,6 +716,11 @@ Extents Model::getBindExtents() const {
     return scaledExtents;
 }
 
+glm::vec3 Model::getNaturalDimensions() const {
+    Extents modelMeshExtents = getUnscaledMeshExtents();
+    return modelMeshExtents.maximum - modelMeshExtents.minimum;
+}
+
 Extents Model::getMeshExtents() const {
     if (!isActive()) {
         return Extents();
@@ -939,8 +944,8 @@ void Blender::run() {
         Q_ARG(const QVector<glm::vec3>&, normals));
 }
 
-void Model::setScaleToFit(bool scaleToFit, const glm::vec3& dimensions) {
-    if (_scaleToFit != scaleToFit || _scaleToFitDimensions != dimensions) {
+void Model::setScaleToFit(bool scaleToFit, const glm::vec3& dimensions, bool forceRescale) {
+    if (forceRescale || _scaleToFit != scaleToFit || _scaleToFitDimensions != dimensions) {
         _scaleToFit = scaleToFit;
         _scaleToFitDimensions = dimensions;
         _scaledToFit = false; // force rescaling

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -122,8 +122,6 @@ public:
     void init();
     void reset();
 
-    void setScaleToFit(bool scaleToFit, const glm::vec3& dimensions);
-
     void setSnapModelToRegistrationPoint(bool snapModelToRegistrationPoint, const glm::vec3& registrationPoint);
     bool getSnapModelToRegistrationPoint() { return _snapModelToRegistrationPoint; }
 
@@ -164,6 +162,7 @@ public:
     const glm::vec3& getOffset() const { return _offset; }
 
     void setScaleToFit(bool scaleToFit, float largestDimension = 0.0f, bool forceRescale = false);
+    void setScaleToFit(bool scaleToFit, const glm::vec3& dimensions, bool forceRescale = false);
     bool getScaleToFit() const { return _scaleToFit; } /// is scale to fit enabled
 
     void setSnapModelToCenter(bool snapModelToCenter) {
@@ -208,6 +207,8 @@ public:
 
     const glm::vec3& getTranslation() const { return _translation; }
     const glm::quat& getRotation() const { return _rotation; }
+
+    glm::vec3 getNaturalDimensions() const;
 
     Transform getTransform() const;
 


### PR DESCRIPTION
This PR will fix the attachments to be scaled based on a models naturalDimensions. This will give a more expected result while first attaching an object, since you will be able to define the models dimensions from the modelling software rather than always having to tweak it in the attachments window.

This PR also adds more precision to the attachment scale field in the attachments dialog.

Internal bug tracker: https://highfidelity.fogbugz.com/f/cases/1716/Avatar-Attachments-Scaling-Problems

## QA Test
- Use any model, I've used `http://hifi-content.s3.amazonaws.com/alan/dev/EZ-Cube.fbx` .
- Add the model in world, using `Create` , and make it is at its natural dimensions (should happen when you add it in world, otherwise you can set it in the properties panel)
- Make sure your avatar scale is 1.  ( Avatar -> Size -> Reset Avatar Size )
- Go to `Avatar -> Attachments..` and add the new attachment using the same URL.
- The scale should be 1.00 by default, and it should match the natural dimensions. Compare it with the object you brought in world using edit.js.
- You can now alter the scale of the attachment and see if the results are expected.
- To make this test complete try and grow and shrink your avatar, the attachments should follow the avatar scale.