### PR TITLE
DS HTTP auth will no longer accept any password if the assigned password is blank

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -158,7 +158,7 @@
           "label": "HTTP Password",
           "type": "password",
           "help": "Password used for basic HTTP authentication. Leave this alone if you do not want to change it.",
-          "default" : "password",
+          "password_placeholder" : "******",
           "value-hidden": true
         },
         {

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -157,7 +157,8 @@
           "name": "http_password",
           "label": "HTTP Password",
           "type": "password",
-          "help": "Password used for basic HTTP authentication. Leave this blank if you do not want to change it.",
+          "help": "Password used for basic HTTP authentication. Leave this alone if you do not want to change it.",
+          "default" : "password",
           "value-hidden": true
         },
         {

--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -123,7 +123,7 @@ var viewHelpers = {
 
           form_group += "<input type='" + input_type + "'" +  common_attrs() +
             "placeholder='" + (_.has(setting, 'placeholder') ? setting.placeholder : "") +
-            "' value='" + setting_value + "'/>"
+            "' value='" + (_.has(setting, 'password_placeholder') ? setting.password_placeholder : setting_value) + "'/>"
         }
 
         form_group += "<span class='help-block'>" + setting.help + "</span>"
@@ -981,40 +981,38 @@ function saveSettings() {
 
   if (validateInputs()) {
     // POST the form JSON to the domain-server settings.json endpoint so the settings are saved
+    var canPost = true;
 
     // disable any inputs not changed
-    $("input:not([data-changed])").each(function(){
+    $("input:not([data-changed])").each(function () {
       $(this).prop('disabled', true);
     });
 
     // grab a JSON representation of the form via form2js
     var formJSON = form2js('settings-form', ".", false, cleanupFormValues, true);
 
-    // check if we've set the basic http password - if so convert it to base64
+    // check if we've set the basic http password
     if (formJSON["security"]) {
+
       var password = formJSON["security"]["http_password"];
-      if (password && password.length > 0) {
+      var verify_password = formJSON["security"]["verify_http_password"];
+
+      // if they've only emptied out the default password field, we should go ahead and acknowledge 
+      // the verify password field
+      if (password != undefined && verify_password == undefined) {
+        verify_password = "";
+      }
+
+      // if we have a password and its verification, convert it to sha256 for comparison
+      if (password != undefined && verify_password != undefined) {
         formJSON["security"]["http_password"] = sha256_digest(password);
-      }
-      var verify_password = formJSON["security"]["verify_http_password"];
-      if (verify_password && verify_password.length > 0) {
         formJSON["security"]["verify_http_password"] = sha256_digest(verify_password);
-      }
-    }
 
-    // verify that the password and confirmation match before saving
-    var canPost = true;
-
-    if (formJSON["security"]) {
-      var password = formJSON["security"]["http_password"];
-      var verify_password = formJSON["security"]["verify_http_password"];
-
-      if (password && password.length > 0) {
-        if (password != verify_password) {
-          bootbox.alert({"message": "Passwords must match!", "title":"Password Error"});
-          canPost = false;
-        } else {
+        if (password == verify_password) {
           delete formJSON["security"]["verify_http_password"];
+        } else {
+          bootbox.alert({ "message": "Passwords must match!", "title": "Password Error" });
+          canPost = false;
         }
       }
     }
@@ -1023,7 +1021,7 @@ function saveSettings() {
     console.log(formJSON);
 
     // re-enable all inputs
-    $("input").each(function(){
+    $("input").each(function () {
       $(this).prop('disabled', false);
     });
 
@@ -1031,6 +1029,27 @@ function saveSettings() {
     $(this).blur();
 
     if (canPost) {
+      if (formJSON["security"]) {
+        var username = formJSON["security"]["http_username"];
+        var password = formJSON["security"]["http_password"];
+
+        if ((password == sha256_digest("")) && (username == undefined || (username && username.length != 0))) {
+          swal({
+            title: "Are you sure?",
+            text: "You have entered a blank password with a non-blank username. Are you sure you want to require a blank password?",
+            type: "warning",
+            showCancelButton: true,
+            confirmButtonColor: "#5cb85c",
+            confirmButtonText: "Yes!",
+            closeOnConfirm: true
+          },
+          function () {
+              formJSON["security"]["http_password"] = "";
+              postSettings(formJSON);
+          });
+          return;
+        }
+      }
       // POST the form JSON to the domain-server settings.json endpoint so the settings are saved
       postSettings(formJSON);
     }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -2114,10 +2114,10 @@ bool DomainServer::isAuthenticatedRequest(HTTPConnection* connection, const QUrl
                     const QVariant* settingsPasswordVariant = valueForKeyPath(settingsMap, BASIC_AUTH_PASSWORD_KEY_PATH);
 
                     QString settingsPassword = settingsPasswordVariant ? settingsPasswordVariant->toString() : "";
-                    QString hexHeaderPassword = QCryptographicHash::hash(headerPassword.toUtf8(), QCryptographicHash::Sha256).toHex();
-
-                    if (settingsUsername == headerUsername
-                        && (settingsPassword.isEmpty() || hexHeaderPassword == settingsPassword)) {
+                    QString hexHeaderPassword = headerPassword.isEmpty() ?
+                        "" : QCryptographicHash::hash(headerPassword.toUtf8(), QCryptographicHash::Sha256).toHex();
+                        
+                    if (settingsUsername == headerUsername && hexHeaderPassword == settingsPassword) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/3707/Sandbox-allows-blank-password

To Test:

1. Start domain server
2. Go to security settings and set a username and set the password field to be empty
3. Apply the settings, upon refreshing you should be asked to log in
4. Verify that you cannot log in with the username if you supply a non-empty password
5. Verify that you can log in with the username and an empty password
6. Additionally, you should try changing the password to a non-empty string, re-authenticate, and then making it blank again and test.