### PR TITLE
Do not allow divide by zero on assigning mip data

### DIFF
--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -304,7 +304,7 @@ public:
         bool isMipAvailable(uint16 level, uint8 face = 0) const override;
 
     protected:
-        bool allocateMip(uint16 level);
+        void allocateMip(uint16 level);
         std::vector<std::vector<PixelsPointer>> _mips; // an array of mips, each mip is an array of faces
     };
 


### PR DESCRIPTION
Fix for a divide by zero crash bug in texture when assigning mip data.  Unfortunately I have no way to reproduce the crash but I've modified the code to ensure that it should be impossible for the reported divide by zero to occur.

## Testing

Application behavior should be unchanged.  Unfortunately without repro steps I can't provide any instructions on how to test and validate the fix.  