### PR TITLE
Focus is now changed when adding a new list item in DS settings

### DIFF
--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -1379,6 +1379,8 @@ function addTableRow(row) {
   var setting_name = table.attr("name");
   row.addClass(Settings.DATA_ROW_CLASS + " " + Settings.NEW_ROW_CLASS);
 
+  var focusChanged = false;
+
   _.each(row.children(), function(element) {
     if ($(element).hasClass("numbered")) {
       // Index row
@@ -1427,6 +1429,11 @@ function addTableRow(row) {
         keyInput.on('change', function(){
           input.attr("name", setting_name + "." +  $(this).val() + "." + colName);
         });
+      }
+
+      if (!focusChanged) {
+          input.focus();
+          focusChanged = true;
       }
 
       if (isCheckbox) {


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/3394/When-adding-a-new-list-item-in-the-domain-settings-it-would-be-nice-if-the-first-input-box-became-focused

Test Plan:

1. Start domain server
2. Go to domain server settings, select scripts
3. Go to one of the sections that allows you to add a row
4. Click add row and verify that the focus has been changed to an input element within the new row