### PR TITLE
Moved audio asset processing to a separate thread

### DIFF
--- a/libraries/audio/src/Sound.cpp
+++ b/libraries/audio/src/Sound.cpp
@@ -56,8 +56,8 @@ Sound::Sound(const QUrl& url, bool isStereo, bool isAmbisonic) :
 void Sound::downloadFinished(const QByteArray& data) {
     // this is a QRunnable, will delete itself after it has finished running
     SoundProcessor* soundProcessor = new SoundProcessor(_url, data, _isStereo, _isAmbisonic);
-    connect(soundProcessor, SIGNAL(onSuccess(QByteArray, bool, bool, float)), SLOT(soundProcessSuccess(QByteArray, bool, bool, float)));
-    connect(soundProcessor, SIGNAL(onError(int, QString)), SLOT(soundProcessError(int, QString)));
+    connect(soundProcessor, &SoundProcessor::onSuccess, this, &Sound::soundProcessSuccess);
+    connect(soundProcessor, &SoundProcessor::onError, this, &Sound::soundProcessError);
     QThreadPool::globalInstance()->start(soundProcessor);
 }
 

--- a/libraries/audio/src/Sound.h
+++ b/libraries/audio/src/Sound.h
@@ -53,7 +53,7 @@ class SoundProcessor : public QObject, public QRunnable {
     Q_OBJECT
 
 public:
-    SoundProcessor(const QUrl& url, const QByteArray& data, const bool stereo, const bool ambisonic)
+    SoundProcessor(const QUrl& url, const QByteArray& data, bool stereo, bool ambisonic)
         : _url(url), _data(data), _isStereo(stereo), _isAmbisonic(ambisonic)
     {
     }

--- a/libraries/audio/src/Sound.h
+++ b/libraries/audio/src/Sound.h
@@ -32,14 +32,12 @@ public:
  
     const QByteArray& getByteArray() const { return _byteArray; }
 
-    void setStereo(bool stereo) { _isStereo = stereo; }
-    void setReady(bool ready);
-
-    void downSample(const QByteArray& rawAudioByteArray, int sampleRate);
-    int interpretAsWav(const QByteArray& inputAudioByteArray, QByteArray& outputAudioByteArray);
-
 signals:
     void ready();
+
+protected slots:
+    void soundProcessSuccess(QByteArray data, bool stereo, bool ambisonic, float duration);
+    void soundProcessError(int error, QString str);
     
 private:
     QByteArray _byteArray;
@@ -55,18 +53,26 @@ class SoundProcessor : public QObject, public QRunnable {
     Q_OBJECT
 
 public:
-    SoundProcessor(const QUrl& url, const QByteArray& data, Sound* sound)
-        : _url(url), _data(data), _sound(sound)
+    SoundProcessor(const QUrl& url, const QByteArray& data, const bool stereo, const bool ambisonic)
+        : _url(url), _data(data), _isStereo(stereo), _isAmbisonic(ambisonic)
     {
     }
 
     virtual void run() override;
 
+    void downSample(const QByteArray& rawAudioByteArray, int sampleRate);
+    int interpretAsWav(const QByteArray& inputAudioByteArray, QByteArray& outputAudioByteArray);
+
+signals:
+    void onSuccess(QByteArray data, bool stereo, bool ambisonic, float duration);
+    void onError(int error, QString str);
+
 private:
     QUrl _url;
     QByteArray _data;
-    Sound* _sound;
-
+    bool _isStereo;
+    bool _isAmbisonic;
+    float _duration;
 };
 
 typedef QSharedPointer<Sound> SharedSoundPointer;

--- a/libraries/audio/src/Sound.h
+++ b/libraries/audio/src/Sound.h
@@ -12,6 +12,7 @@
 #ifndef hifi_Sound_h
 #define hifi_Sound_h
 
+#include <QRunnable>
 #include <QtCore/QObject>
 #include <QtNetwork/QNetworkReply>
 #include <QtScript/qscriptengine.h>
@@ -28,9 +29,14 @@ public:
     bool isAmbisonic() const { return _isAmbisonic; }    
     bool isReady() const { return _isReady; }
     float getDuration() const { return _duration; }
-
  
     const QByteArray& getByteArray() const { return _byteArray; }
+
+    void setStereo(bool stereo) { _isStereo = stereo; }
+    void setReady(bool ready);
+
+    void downSample(const QByteArray& rawAudioByteArray, int sampleRate);
+    int interpretAsWav(const QByteArray& inputAudioByteArray, QByteArray& outputAudioByteArray);
 
 signals:
     void ready();
@@ -42,10 +48,25 @@ private:
     bool _isReady;
     float _duration; // In seconds
     
-    void downSample(const QByteArray& rawAudioByteArray, int sampleRate);
-    int interpretAsWav(const QByteArray& inputAudioByteArray, QByteArray& outputAudioByteArray);
-    
     virtual void downloadFinished(const QByteArray& data) override;
+};
+
+class SoundProcessor : public QObject, public QRunnable {
+    Q_OBJECT
+
+public:
+    SoundProcessor(const QUrl& url, const QByteArray& data, Sound* sound)
+        : _url(url), _data(data), _sound(sound)
+    {
+    }
+
+    virtual void run() override;
+
+private:
+    QUrl _url;
+    QByteArray _data;
+    Sound* _sound;
+
 };
 
 typedef QSharedPointer<Sound> SharedSoundPointer;


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/4857/Move-sounds-on-to-a-different-thread-so-they-don-t-lock-up-rendering

Test Plan

1. Start interface
2. Visit an area or do something where you will be forced to download new audio files
3. Verify that the audio files have been obtained and that they play correctly
4. Compare loading times of this PR vs. master, verify that this PR finishes loads scene faster when there are a significant amount of sound assets that need to be fetched (see @ZappoMan's comment below)


