### PR TITLE
Fix compressed KTX loading

### DIFF
--- a/libraries/ktx/src/khronos/KHR.h
+++ b/libraries/ktx/src/khronos/KHR.h
@@ -212,10 +212,11 @@ namespace khronos {
             template <uint32_t ALIGNMENT> 
             inline uint32_t evalAlignedCompressedBlockCount(uint32_t value) {
                 // FIXME add static assert that ALIGNMENT is a power of 2
-                return (value + (ALIGNMENT - 1) / ALIGNMENT);
+                static uint32_t ALIGNMENT_REMAINDER = ALIGNMENT - 1;
+                return (value + ALIGNMENT_REMAINDER) / ALIGNMENT;
             }
 
-            inline uint8_t evalBlockAlignemnt(InternalFormat format, uint32_t value) {
+            inline uint32_t evalCompressedBlockCount(InternalFormat format, uint32_t value) {
                 switch (format) {
                     case InternalFormat::COMPRESSED_SRGB_S3TC_DXT1_EXT: // BC1
                     case InternalFormat::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT: // BC1A

--- a/libraries/ktx/src/ktx/KTX.cpp
+++ b/libraries/ktx/src/ktx/KTX.cpp
@@ -30,7 +30,7 @@ uint32_t Header::evalMaxDimension() const {
 
 uint32_t Header::evalPixelOrBlockDimension(uint32_t pixelDimension) const {
     if (isCompressed()) {
-        return khronos::gl::texture::evalBlockAlignemnt(getGLInternaFormat(), pixelDimension);
+        return khronos::gl::texture::evalCompressedBlockCount(getGLInternaFormat(), pixelDimension);
     } 
     return pixelDimension;
 }


### PR DESCRIPTION
A recent refactor introduced two bugs.  One was bad placement of the parens in a statement that combined addition and division.  This bug didn't break the loading, but was incorrect.  A future PR will add additional unit test logic to this method.

The second bug was incorrectly returning a uint8_t when the value could be much larger than 0xFF.  This was causing most or all of the mip sizes to be evaluated as 0 dimensions for compressed images, breaking the generation of the template files.  

## Testing

Load dev welcome.  In master, much of the content will be untextured.  In this PR the textures will properly render.  