### PR TITLE
Fix "retain avatar info"

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -436,6 +436,10 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     const char* portStr = getCmdOption(argc, constArgv, "--listenPort");
     const int listenPort = portStr ? atoi(portStr) : INVALID_PORT;
 
+    static const auto SUPPRESS_SETTINGS_RESET = "--suppress-settings-reset";
+    bool suppressPrompt = cmdOptionExists(argc, const_cast<const char**>(argv), SUPPRESS_SETTINGS_RESET);
+    bool previousSessionCrashed = CrashHandler::checkForResetSettings(runningMarkerExisted, suppressPrompt);
+
     Setting::init();
 
     if (auto steamClient = PluginManager::getInstance()->getSteamClientPlugin()) {
@@ -455,10 +459,6 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     }
     QCoreApplication::addLibraryPath(audioDLLPath);
 #endif
-
-    static const auto SUPPRESS_SETTINGS_RESET = "--suppress-settings-reset";
-    bool suppressPrompt = cmdOptionExists(argc, const_cast<const char**>(argv), SUPPRESS_SETTINGS_RESET);
-    bool previousSessionCrashed = CrashHandler::checkForResetSettings(runningMarkerExisted, suppressPrompt);
 
     DependencyManager::registerInheritance<LimitedNodeList, NodeList>();
     DependencyManager::registerInheritance<AvatarHashMap, AvatarManager>();

--- a/interface/src/CrashHandler.cpp
+++ b/interface/src/CrashHandler.cpp
@@ -24,12 +24,15 @@
 
 #include "Application.h"
 #include "Menu.h"
-#include <SettingHandle.h>
 
 #include <RunningMarker.h>
+#include <SettingHandle.h>
+#include <SettingHelpers.h>
+
 
 bool CrashHandler::checkForResetSettings(bool wasLikelyCrash, bool suppressPrompt) {
-    Settings settings;
+    QSettings::setDefaultFormat(JSON_FORMAT);
+    QSettings settings;
     settings.beginGroup("Developer");
     QVariant displayCrashOptions = settings.value(MenuOption::DisplayCrashOptions);
     QVariant askToResetSettingsOption = settings.value(MenuOption::AskToResetSettings);
@@ -106,7 +109,7 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
         return;
     }
 
-    Settings settings;
+    QSettings settings;
     const QString ADDRESS_MANAGER_GROUP = "AddressManager";
     const QString ADDRESS_KEY = "address";
     const QString AVATAR_GROUP = "Avatar";


### PR DESCRIPTION
Fixes the "Reset my settings but retain avatar info." option after a crash.

## Test Plan:
- Make sure your `AppData/Roaming/High Fidelity - PR10563` folder is empty.
- Launch interface
- Change your avatar/display name/location
- Enable Developer settings
- Click `Developer > Crash > Abort`
- Launch interface
- Pick one of the 3 "reset settings" options
- Repeat for each option

Expected results:
- "Reset all my settings":
    You should end up back in dev-welcome with the default avatar/no display name and Developer settings disabled.
- "Reset my settings but retain avatar info.":
    You should stay at your new location, with your new avatar/display name add Developer settings disabled.
- "Continue with my current settings"
    You should stay at your new location, with your new avatar/display name add Developer settings enabled.

