### PR TITLE
Improve positioning of assets when added / imported

### DIFF
--- a/libraries/shared/src/Extents.h
+++ b/libraries/shared/src/Extents.h
@@ -69,7 +69,7 @@ public:
     glm::vec3 size() const { return maximum - minimum; }
     float largestDimension() const { return glm::compMax(size()); }
 
-    /// \return new Extents which is original rotated around orign by rotation
+    /// \return new Extents which is original rotated around origin by rotation
     Extents getRotated(const glm::quat& rotation) const {
         Extents temp(minimum, maximum);
         temp.rotate(rotation);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1415,8 +1415,8 @@ function getPositionToCreateEntity() {
         position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), CREATE_DISTANCE));
     } else {
         position = Vec3.sum(MyAvatar.position, Vec3.multiply(Quat.getForward(MyAvatar.orientation), CREATE_DISTANCE));
+        position.y += 0.5;
     }
-    position.y += 0.5;
 
     if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
         return null;

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1490,30 +1490,14 @@ function handeMenuEvent(menuItem) {
 
 var HALF_TREE_SCALE = 16384;
 
-function getPositionToCreateEntity() {
+function getPositionToCreateEntity(extra) {
     var CREATE_DISTANCE = 2;
     var position;
+    var delta = extra !== undefined ? extra : 0;
     if (Camera.mode === "entity" || Camera.mode === "independent") {
-        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), CREATE_DISTANCE));
+        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), CREATE_DISTANCE + delta));
     } else {
-        position = Vec3.sum(MyAvatar.position, Vec3.multiply(Quat.getForward(MyAvatar.orientation), CREATE_DISTANCE));
-        position.y += 0.5;
-    }
-
-    if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
-        return null;
-    }
-    return position;
-}
-
-function getPositionToImportEntities() {
-    var CREATE_DISTANCE = 2;
-    var distance = CREATE_DISTANCE + Clipboard.getClipboardContentsLargestDimension() / 2;
-    var position;
-    if (Camera.mode === "entity" || Camera.mode === "independent") {
-        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), distance));
-    } else {
-        position = Vec3.sum(MyAvatar.position, Vec3.multiply(Quat.getForward(MyAvatar.orientation), distance));
+        position = Vec3.sum(MyAvatar.position, Vec3.multiply(Quat.getForward(MyAvatar.orientation), CREATE_DISTANCE + delta));
         position.y += 0.5;
     }
 
@@ -1543,7 +1527,7 @@ function importSVO(importURL) {
         var isLargeImport = Clipboard.getClipboardContentsLargestDimension() >= VERY_LARGE;
         var position = Vec3.ZERO;
         if (!isLargeImport) {
-            position = getPositionToImportEntities();
+            position = getPositionToCreateEntity(Clipboard.getClipboardContentsLargestDimension() / 2);
         }
         if (position !== null && position !== undefined) {
             var pastedEntityIDs = Clipboard.pasteEntities(position);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -256,8 +256,6 @@ var toolBar = (function () {
         tablet = null;
 
     function createNewEntity(properties) {
-
-
         var dimensions = properties.dimensions ? properties.dimensions : DEFAULT_DIMENSIONS;
         var position = getPositionToCreateEntity();
         var entityID = null;
@@ -307,7 +305,7 @@ var toolBar = (function () {
                 var dimensionsCheckCount = 0;
                 var dimensionsCheckFunction = function () {
                     dimensionsCheckCount++;
-                    var properties = Entities.getEntityProperties(entityID, ["dimensions", "registrationPoint", "orientation", "rotation"]);
+                    var properties = Entities.getEntityProperties(entityID, ["dimensions", "registrationPoint", "rotation"]);
                     if (!Vec3.equal(properties.dimensions, initialDimensions)) {
                         position = adjustPositionPerBoundingBox(position, direction, properties.registrationPoint,
                             properties.dimensions, properties.rotation);
@@ -1551,12 +1549,13 @@ function importSVO(importURL) {
                 for (var i = 0, length = pastedEntityIDs.length; i < length; i++) {
                     var properties = Entities.getEntityProperties(pastedEntityIDs[i], ["position", "dimensions",
                         "registrationPoint", "rotation"]);
-                    var adjustedPosition = adjustPositionPerBoundingBox(targetPosition, targetDirection, properties.registrationPoint,
-                        properties.dimensions, properties.rotation);
+                    var adjustedPosition = adjustPositionPerBoundingBox(targetPosition, targetDirection,
+                        properties.registrationPoint, properties.dimensions, properties.rotation);
                     var delta = Vec3.subtract(adjustedPosition, properties.position);
                     var distance = Vec3.dot(delta, targetDirection);
                     deltaParallel = Math.min(distance, deltaParallel);
-                    deltaPerpendicular = Vec3.sum(Vec3.subtract(delta, Vec3.multiply(distance, targetDirection)), deltaPerpendicular);
+                    deltaPerpendicular = Vec3.sum(Vec3.subtract(delta, Vec3.multiply(distance, targetDirection)),
+                        deltaPerpendicular);
                     entityPositions[i] = properties.position;
                 }
                 deltaPerpendicular = Vec3.multiply(1 / pastedEntityIDs.length, deltaPerpendicular);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1486,8 +1486,9 @@ function handeMenuEvent(menuItem) {
     tooltip.show(false);
 }
 
+var HALF_TREE_SCALE = 16384;
+
 function getPositionToCreateEntity() {
-    var HALF_TREE_SCALE = 16384;
     var CREATE_DISTANCE = 2;
     var position;
     if (Camera.mode === "entity" || Camera.mode === "independent") {
@@ -1503,22 +1504,20 @@ function getPositionToCreateEntity() {
     return position;
 }
 
-function getPositionToImportEntity() {
-    var dimensions = Clipboard.getContentsDimensions();
-    var HALF_TREE_SCALE = 16384;
-    var direction = Quat.getForward(MyAvatar.orientation);
-    var longest = 1;
-    longest = Math.sqrt(Math.pow(dimensions.x, 2) + Math.pow(dimensions.z, 2));
-    var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, longest));
-
+function getPositionToImportEntities() {
+    var CREATE_DISTANCE = 2;
+    var distance = CREATE_DISTANCE + Clipboard.getClipboardContentsLargestDimension() / 2;
+    var position;
     if (Camera.mode === "entity" || Camera.mode === "independent") {
-        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), longest));
+        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), distance));
+    } else {
+        position = Vec3.sum(MyAvatar.position, Vec3.multiply(Quat.getForward(MyAvatar.orientation), distance));
+        position.y += 0.5;
     }
 
     if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
         return null;
     }
-
     return position;
 }
 function importSVO(importURL) {
@@ -1544,7 +1543,7 @@ function importSVO(importURL) {
             z: 0
         };
         if (Clipboard.getClipboardContentsLargestDimension() < VERY_LARGE) {
-            position = getPositionToImportEntity();
+            position = getPositionToImportEntities();
         }
         if (position !== null && position !== undefined) {
             var pastedEntityIDs = Clipboard.pasteEntities(position);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1559,8 +1559,17 @@ function importSVO(importURL) {
                     entityPositions[i] = properties.position;
                 }
                 deltaPerpendicular = Vec3.multiply(1 / pastedEntityIDs.length, deltaPerpendicular);
-
                 var deltaPosition = Vec3.sum(Vec3.multiply(deltaParallel, targetDirection), deltaPerpendicular);
+
+                if (grid.getSnapToGrid()) {
+                    var properties = Entities.getEntityProperties(pastedEntityIDs[0], ["position", "dimensions",
+                        "registrationPoint"]);
+                    var position = Vec3.sum(deltaPosition, properties.position);
+                    position = grid.snapToSurface(grid.snapToGrid(position, false, properties.dimensions, 
+                            properties.registrationPoint), properties.dimensions, properties.registrationPoint);
+                    deltaPosition = Vec3.subtract(position, properties.position);
+                }
+
                 for (var i = 0, length = pastedEntityIDs.length; i < length; i++) {
                     Entities.editEntity(pastedEntityIDs[i], {
                         position: Vec3.sum(deltaPosition, entityPositions[i])

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1409,14 +1409,15 @@ function handeMenuEvent(menuItem) {
 }
 function getPositionToCreateEntity() {
     var HALF_TREE_SCALE = 16384;
-    var direction = Quat.getForward(MyAvatar.orientation);
-    var distance = 1;
-    var position = Vec3.sum(MyAvatar.position, Vec3.multiply(direction, distance));
-
+    var CREATE_DISTANCE = 2;
+    var position;
     if (Camera.mode === "entity" || Camera.mode === "independent") {
-        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), distance));
+        position = Vec3.sum(Camera.position, Vec3.multiply(Quat.getForward(Camera.orientation), CREATE_DISTANCE));
+    } else {
+        position = Vec3.sum(MyAvatar.position, Vec3.multiply(Quat.getForward(MyAvatar.orientation), CREATE_DISTANCE));
     }
     position.y += 0.5;
+
     if (position.x > HALF_TREE_SCALE || position.y > HALF_TREE_SCALE || position.z > HALF_TREE_SCALE) {
         return null;
     }

--- a/scripts/system/libraries/gridTool.js
+++ b/scripts/system/libraries/gridTool.js
@@ -79,29 +79,37 @@ Grid = function(opts) {
         }
     }
 
-    that.snapToSurface = function(position, dimensions) {
+    that.snapToSurface = function(position, dimensions, registration) {
         if (!snapToGrid) {
             return position;
         }
 
         if (dimensions === undefined) {
             dimensions = { x: 0, y: 0, z: 0 };
+        }
+
+        if (registration === undefined) {
+            registration = { x: 0.5, y: 0.5, z: 0.5 };
         }
 
         return {
             x: position.x,
-            y: origin.y + (dimensions.y / 2),
+            y: origin.y + (registration.y * dimensions.y),
             z: position.z
         };
     }
 
-    that.snapToGrid = function(position, majorOnly, dimensions) {
+    that.snapToGrid = function(position, majorOnly, dimensions, registration) {
         if (!snapToGrid) {
             return position;
         }
 
         if (dimensions === undefined) {
             dimensions = { x: 0, y: 0, z: 0 };
+        }
+
+        if (registration === undefined) {
+            registration = { x: 0.5, y: 0.5, z: 0.5 };
         }
 
         var spacing = majorOnly ? majorGridEvery : minorGridEvery;
@@ -112,7 +120,7 @@ Grid = function(opts) {
         position.y = Math.round(position.y / spacing) * spacing;
         position.z = Math.round(position.z / spacing) * spacing;
 
-        return Vec3.sum(Vec3.sum(position, Vec3.multiply(0.5, dimensions)), origin);
+        return Vec3.sum(Vec3.sum(position, Vec3.multiplyVbyV(registration, dimensions)), origin);
     }
 
     that.snapToSpacing = function(delta, majorOnly) {

--- a/scripts/system/libraries/gridTool.js
+++ b/scripts/system/libraries/gridTool.js
@@ -161,9 +161,9 @@ Grid = function(opts) {
 
         if (data.origin) {
             var pos = data.origin;
-            pos.x = pos.x === undefined ? origin.x : pos.x;
-            pos.y = pos.y === undefined ? origin.y : pos.y;
-            pos.z = pos.z === undefined ? origin.z : pos.z;
+            pos.x = pos.x === undefined ? origin.x : parseFloat(pos.x);
+            pos.y = pos.y === undefined ? origin.y : parseFloat(pos.y);
+            pos.z = pos.z === undefined ? origin.z : parseFloat(pos.z);
             that.setPosition(pos, true);
         }
 


### PR DESCRIPTION
This PR makes the positioning of entities created and imported more predictable: when it makes sense, they're rezzed such that their bounding boxes are 2m in front of your avatar/camera (this rather than sometimes appearing on top of or even behind your avatar).