### PR TITLE
Fix showDialog to work without defaultScripts

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1522,12 +1522,12 @@ QString Application::getUserAgent() {
     return userAgent;
 }
 
-void Application::toggleTabletUI() const {
+void Application::toggleTabletUI(bool shouldOpen) const {
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     auto hmd = DependencyManager::get<HMDScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     bool messageOpen = tablet->isMessageDialogOpen();
-    if (!messageOpen || (messageOpen && !hmd->getShouldShowTablet())) {
+    if ((!messageOpen || (messageOpen && !hmd->getShouldShowTablet())) && !(shouldOpen && hmd->getShouldShowTablet())) {
         auto HMD = DependencyManager::get<HMDScriptingInterface>();
         HMD->toggleShouldShowTablet();
     }
@@ -5771,6 +5771,9 @@ void Application::showDialog(const QUrl& widgetUrl, const QUrl& tabletUrl, const
 
     if (!tablet->getToolbarMode()) {
         onTablet = tablet->pushOntoStack(tabletUrl);
+        if (onTablet) {
+            toggleTabletUI(true);
+        }
     }
 
     if (!onTablet) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5764,25 +5764,21 @@ bool Application::displayAvatarAttachmentConfirmationDialog(const QString& name)
     }
 }
 
-void Application::toggleMenu(const QString title, const QUrl widgetUrl, const QUrl tabletUrl) const {
-    auto hmd = DependencyManager::get<HMDScriptingInterface>();
+void Application::showDialog(const QUrl& widgetUrl, const QUrl& tabletUrl, const QString& name) const {
     auto tablet = DependencyManager::get<TabletScriptingInterface>()->getTablet(SYSTEM_TABLET);
+    auto hmd = DependencyManager::get<HMDScriptingInterface>();
     bool onTablet = false;
 
-    if (!tablet->getToolbarMode() && (hmd->getShouldShowTablet() || isHMDMode())) {
+    if (!tablet->getToolbarMode()) {
         onTablet = tablet->pushOntoStack(tabletUrl);
     }
 
     if (!onTablet) {
-        DependencyManager::get<OffscreenUi>()->show(widgetUrl, title);
+        DependencyManager::get<OffscreenUi>()->show(widgetUrl, name);
     }
-}
-
-void Application::toggleMenuRunningScripts() const {
-    static const QString title("RunningScripts");
-    static const QUrl widgetUrl("hifi/dialogs/RunningScripts.qml");
-    static const QUrl tabletUrl("../../hifi/dialogs/TabletRunningScripts.qml");
-    toggleMenu(title, widgetUrl, tabletUrl);
+    if (tablet->getToolbarMode()) {
+        DependencyManager::get<OffscreenUi>()->show(widgetUrl, name);
+    }
 }
 
 void Application::showScriptLogs() {
@@ -5837,21 +5833,6 @@ void Application::addAssetToWorldFromURL(QString url) {
     auto request = ResourceManager::createResourceRequest(nullptr, QUrl(url));
     connect(request, &ResourceRequest::finished, this, &Application::addAssetToWorldFromURLRequestFinished);
     request->send();
-}
-
-void Application::showDialog(const QString& desktopURL, const QString& tabletURL, const QString& name) const {
-    auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
-    auto hmd = DependencyManager::get<HMDScriptingInterface>();
-    if (tablet->getToolbarMode()) {
-        DependencyManager::get<OffscreenUi>()->show(desktopURL, name);
-    } else {
-        tablet->pushOntoStack(tabletURL);
-        if (!hmd->getShouldShowTablet() && !isHMDMode()) {
-            hmd->openTablet();
-        }
-        
-    }
 }
 
 void Application::addAssetToWorldFromURLRequestFinished() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5764,38 +5764,25 @@ bool Application::displayAvatarAttachmentConfirmationDialog(const QString& name)
     }
 }
 
-void Application::toggleRunningScriptsWidget() const {    
-    auto scriptEngines = DependencyManager::get<ScriptEngines>();
-    bool scriptsRunning = !scriptEngines->getRunningScripts().isEmpty();
-    auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
+void Application::toggleMenu(const QString title, const QUrl widgetUrl, const QUrl tabletUrl) const {
+    auto hmd = DependencyManager::get<HMDScriptingInterface>();
+    auto tablet = DependencyManager::get<TabletScriptingInterface>()->getTablet(SYSTEM_TABLET);
+    bool onTablet = false;
 
-    if (tablet->getToolbarMode() || false == scriptsRunning) {
-        static const QUrl url("hifi/dialogs/RunningScripts.qml");
-        DependencyManager::get<OffscreenUi>()->show(url, "RunningScripts");
-    } else {
-        auto hmd = DependencyManager::get<HMDScriptingInterface>();
-        if (!hmd->getShouldShowTablet() && !isHMDMode()) {
-            static const QUrl url("hifi/dialogs/RunningScripts.qml");
-            DependencyManager::get<OffscreenUi>()->show(url, "RunningScripts");
-        } else {
-            static const QUrl url("../../hifi/dialogs/TabletRunningScripts.qml");
-            tablet->pushOntoStack(url);
-        }
+    if (!tablet->getToolbarMode() && (hmd->getShouldShowTablet() || isHMDMode())) {
+        onTablet = tablet->pushOntoStack(tabletUrl);
     }
-    //DependencyManager::get<OffscreenUi>()->show(url, "RunningScripts");
-    //if (_runningScriptsWidget->isVisible()) {
-    //    if (_runningScriptsWidget->hasFocus()) {
-    //        _runningScriptsWidget->hide();
-    //    } else {
-    //        _runningScriptsWidget->raise();
-    //        setActiveWindow(_runningScriptsWidget);
-    //        _runningScriptsWidget->setFocus();
-    //    }
-    //} else {
-    //    _runningScriptsWidget->show();
-    //    _runningScriptsWidget->setFocus();
-    //}
+
+    if (!onTablet) {
+        DependencyManager::get<OffscreenUi>()->show(widgetUrl, title);
+    }
+}
+
+void Application::toggleMenuRunningScripts() const {
+    static const QString title("RunningScripts");
+    static const QUrl widgetUrl("hifi/dialogs/RunningScripts.qml");
+    static const QUrl tabletUrl("../../hifi/dialogs/TabletRunningScripts.qml");
+    toggleMenu(title, widgetUrl, tabletUrl);
 }
 
 void Application::showScriptLogs() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -245,6 +245,8 @@ Setting::Handle<int> maxOctreePacketsPerSecond("maxOctreePPS", DEFAULT_MAX_OCTRE
 
 static const QString MARKETPLACE_CDN_HOSTNAME = "mpassets.highfidelity.com";
 
+static const QString SYSTEM_TABLET = "com.highfidelity.interface.tablet.system";
+
 const QHash<QString, Application::AcceptURLMethod> Application::_acceptedExtensions {
     { SVO_EXTENSION, &Application::importSVOFromURL },
     { SVO_JSON_EXTENSION, &Application::importSVOFromURL },
@@ -1523,7 +1525,7 @@ QString Application::getUserAgent() {
 void Application::toggleTabletUI() const {
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     auto hmd = DependencyManager::get<HMDScriptingInterface>();
-    TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     bool messageOpen = tablet->isMessageDialogOpen();
     if (!messageOpen || (messageOpen && !hmd->getShouldShowTablet())) {
         auto HMD = DependencyManager::get<HMDScriptingInterface>();
@@ -2295,7 +2297,7 @@ void Application::showHelp() {
     queryString.addQueryItem("handControllerName", handControllerName);
     queryString.addQueryItem("defaultTab", defaultTab);
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     tablet->gotoWebScreen(INFO_HELP_PATH + "?" + queryString.toString());
     //InfoView::show(INFO_HELP_PATH, false, queryString.toString());
 }
@@ -5766,7 +5768,7 @@ void Application::toggleRunningScriptsWidget() const {
     auto scriptEngines = DependencyManager::get<ScriptEngines>();
     bool scriptsRunning = !scriptEngines->getRunningScripts().isEmpty();
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
 
     if (tablet->getToolbarMode() || false == scriptsRunning) {
         static const QUrl url("hifi/dialogs/RunningScripts.qml");
@@ -5815,7 +5817,7 @@ void Application::showAssetServerWidget(QString filePath) {
         }
     };
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     auto hmd = DependencyManager::get<HMDScriptingInterface>();
     if (tablet->getToolbarMode()) {
         DependencyManager::get<OffscreenUi>()->show(url, "AssetServer", startUpload);
@@ -5852,7 +5854,7 @@ void Application::addAssetToWorldFromURL(QString url) {
 
 void Application::showDialog(const QString& desktopURL, const QString& tabletURL, const QString& name) const {
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     auto hmd = DependencyManager::get<HMDScriptingInterface>();
     if (tablet->getToolbarMode()) {
         DependencyManager::get<OffscreenUi>()->show(desktopURL, name);
@@ -6348,7 +6350,7 @@ void Application::loadScriptURLDialog() const {
 
 void Application::loadLODToolsDialog() {
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     if (tablet->getToolbarMode() || (!tablet->getTabletRoot() && !isHMDMode())) {
         auto dialogsManager = DependencyManager::get<DialogsManager>();
         dialogsManager->lodTools();
@@ -6360,7 +6362,7 @@ void Application::loadLODToolsDialog() {
 
 void Application::loadEntityStatisticsDialog() {
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     if (tablet->getToolbarMode() || (!tablet->getTabletRoot() && !isHMDMode())) {
         auto dialogsManager = DependencyManager::get<DialogsManager>();
         dialogsManager->octreeStatsDetails();
@@ -6371,7 +6373,7 @@ void Application::loadEntityStatisticsDialog() {
 
 void Application::loadDomainConnectionDialog() {
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
     if (tablet->getToolbarMode() || (!tablet->getTabletRoot() && !isHMDMode())) {
         auto dialogsManager = DependencyManager::get<DialogsManager>();
         dialogsManager->showDomainConnectionDialog();

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -318,7 +318,8 @@ public slots:
     Q_INVOKABLE void loadScriptURLDialog() const;
     void toggleLogDialog();
     void toggleEntityScriptServerLogDialog();
-    void toggleRunningScriptsWidget() const;
+    void toggleMenu(const QString title, const QUrl widgetUrl, const QUrl tabletUrl) const;
+    void toggleMenuRunningScripts() const;
     Q_INVOKABLE void showAssetServerWidget(QString filePath = "");
     Q_INVOKABLE void loadAddAvatarBookmarkDialog() const;
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -504,7 +504,7 @@ private:
     static void dragEnterEvent(QDragEnterEvent* event);
 
     void maybeToggleMenuVisible(QMouseEvent* event) const;
-    void toggleTabletUI() const;
+    void toggleTabletUI(bool shouldOpen = false) const;
 
     MainWindow* _window;
     QElapsedTimer& _sessionRunTimer;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -318,12 +318,10 @@ public slots:
     Q_INVOKABLE void loadScriptURLDialog() const;
     void toggleLogDialog();
     void toggleEntityScriptServerLogDialog();
-    void toggleMenu(const QString title, const QUrl widgetUrl, const QUrl tabletUrl) const;
-    void toggleMenuRunningScripts() const;
     Q_INVOKABLE void showAssetServerWidget(QString filePath = "");
     Q_INVOKABLE void loadAddAvatarBookmarkDialog() const;
 
-    void showDialog(const QString& desktopURL, const QString& tabletURL, const QString& name) const;
+    void showDialog(const QUrl& widgetUrl, const QUrl& tabletUrl, const QString& name) const;
 
     // FIXME: Move addAssetToWorld* methods to own class?
     void addAssetToWorldFromURL(QString url);

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -95,7 +95,7 @@ Menu::Menu() {
 
     // Edit > Running Scripts
     addActionToQMenuAndActionHash(editMenu, MenuOption::RunningScripts, Qt::CTRL | Qt::Key_J,
-        qApp, SLOT(toggleRunningScriptsWidget()));
+        qApp, SLOT(toggleMenuRunningScripts()));
 
     // Edit > Open and Run Script from File... [advanced]
     addActionToQMenuAndActionHash(editMenu, MenuOption::LoadScript, Qt::CTRL | Qt::Key_O,

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -94,8 +94,13 @@ Menu::Menu() {
     addActionToQMenuAndActionHash(editMenu, redoAction);
 
     // Edit > Running Scripts
-    addActionToQMenuAndActionHash(editMenu, MenuOption::RunningScripts, Qt::CTRL | Qt::Key_J,
-        qApp, SLOT(toggleMenuRunningScripts()));
+    auto action = addActionToQMenuAndActionHash(editMenu, MenuOption::RunningScripts, Qt::CTRL | Qt::Key_J);
+    connect(action, &QAction::triggered, [] {
+        static const QUrl widgetUrl("hifi/dialogs/RunningScripts.qml");
+        static const QUrl tabletUrl("../../hifi/dialogs/TabletRunningScripts.qml");
+        static const QString name("RunningScripts");
+        qApp->showDialog(widgetUrl, tabletUrl, name);
+    });
 
     // Edit > Open and Run Script from File... [advanced]
     addActionToQMenuAndActionHash(editMenu, MenuOption::LoadScript, Qt::CTRL | Qt::Key_O,

--- a/libraries/script-engine/src/TabletScriptingInterface.cpp
+++ b/libraries/script-engine/src/TabletScriptingInterface.cpp
@@ -439,7 +439,7 @@ void TabletProxy::loadQMLSource(const QVariant& path) {
     }
 }
 
-void TabletProxy::pushOntoStack(const QVariant& path) {
+bool TabletProxy::pushOntoStack(const QVariant& path) {
     QObject* root = nullptr;
     if (!_toolbarMode && _qmlTabletRoot) {
         root = _qmlTabletRoot;
@@ -457,6 +457,8 @@ void TabletProxy::pushOntoStack(const QVariant& path) {
     } else {
         qCDebug(scriptengine) << "tablet cannot push QML because _qmlTabletRoot or _desktopWindow is null";
     }
+
+    return root;
 }
 
 void TabletProxy::popFromStack() {

--- a/libraries/script-engine/src/TabletScriptingInterface.h
+++ b/libraries/script-engine/src/TabletScriptingInterface.h
@@ -119,7 +119,9 @@ public:
     Q_INVOKABLE void gotoWebScreen(const QString& url, const QString& injectedJavaScriptUrl);
 
     Q_INVOKABLE void loadQMLSource(const QVariant& path);
-    Q_INVOKABLE void pushOntoStack(const QVariant& path);
+    // FIXME: This currently relies on a script initializing the tablet (hence the bool denoting success);
+    //        it should be initialized internally so it cannot fail
+    Q_INVOKABLE bool pushOntoStack(const QVariant& path);
     Q_INVOKABLE void popFromStack();
 
     Q_INVOKABLE void loadQMLOnTop(const QVariant& path);


### PR DESCRIPTION
- Updates Application::showDialog to work even if Tablet is not initialized via defaultScripts.js
- Changes behavior on showDialog to avoid closing an open dialog