### PR TITLE
Changed the DEFAULT_DISCOVERABILITY_MODE to Connections

### DIFF
--- a/interface/src/DiscoverabilityManager.cpp
+++ b/interface/src/DiscoverabilityManager.cpp
@@ -25,7 +25,7 @@
 
 #include <QThread>
 
-const Discoverability::Mode DEFAULT_DISCOVERABILITY_MODE = Discoverability::Friends;
+const Discoverability::Mode DEFAULT_DISCOVERABILITY_MODE = Discoverability::Connections;
 
 DiscoverabilityManager::DiscoverabilityManager() :
     _mode("discoverabilityMode", DEFAULT_DISCOVERABILITY_MODE)


### PR DESCRIPTION
The default discoverability mode will be initialized to "Friends and Connections" instead of "Friends Only", fixing https://highfidelity.fogbugz.com/f/cases/4997

To Test:
-Reset System Settings
-Open up tablet and click on People
-Check that in right-hand corner that "Friends and Connections" is set