### PR TITLE
remove extra activity logger call

### DIFF
--- a/scripts/system/makeUserConnection.js
+++ b/scripts/system/makeUserConnection.js
@@ -613,7 +613,6 @@
                 error = "All participants must be logged in to connect.";
             }
             result = error ? {status: 'error', connection: error} : response;
-            UserActivityLogger.makeUserConnection(connectingId, false, error || response);
             connectionRequestCompleted();
         } else {
             result = response;
@@ -668,8 +667,8 @@
     // to be sure the hand is still close enough.  If not, we terminate
     // the interval, go back to the waiting state.  If we make it
     // the entire CONNECTING_TIME, we make the connection.  We pass in
-    // whether or not the connecting id is actually logged in, as now we 
-    // will allow to start the connection process but have it stop with a 
+    // whether or not the connecting id is actually logged in, as now we
+    // will allow to start the connection process but have it stop with a
     // fail message before trying to call the backend if the other guy isn't
     // logged in.
     function startConnecting(id, jointIndex, isLoggedIn) {


### PR DESCRIPTION
Turns out this leaves turds in our data.  We always call connectionRequestCompleted, which does the logging correctly.  Turns out here, we sometimes have an object in the response, which serializes to "details": "[object Object]".  Simple fix.  Seems correlated with times when a connection request returns exists, where we get this bad logging before the good one. 

In any case, why log twice.  I'm assuming the logic changed, and that this used to make sense as we didn't go through the connectionRequestCompleted function for everything.