### PR TITLE
Don't allow sorting on non-sortable columns in PAL

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -388,8 +388,13 @@ Rectangle {
             sortIndicatorColumn: settings.nearbySortIndicatorColumn;
             sortIndicatorOrder: settings.nearbySortIndicatorOrder;
             onSortIndicatorColumnChanged: {
-                settings.nearbySortIndicatorColumn = sortIndicatorColumn;
-                sortModel();
+                if (sortIndicatorColumn > 1) {
+                    // these are not sortable, switch back to last column
+                    sortIndicatorColumn = settings.nearbySortIndicatorColumn;
+                } else {
+                    settings.nearbySortIndicatorColumn = sortIndicatorColumn;
+                    sortModel();
+                }
             }
             onSortIndicatorOrderChanged: {
                 settings.nearbySortIndicatorOrder = sortIndicatorOrder;

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -388,7 +388,7 @@ Rectangle {
             sortIndicatorColumn: settings.nearbySortIndicatorColumn;
             sortIndicatorOrder: settings.nearbySortIndicatorOrder;
             onSortIndicatorColumnChanged: {
-                if (sortIndicatorColumn > 1) {
+                if (sortIndicatorColumn > 2) {
                     // these are not sortable, switch back to last column
                     sortIndicatorColumn = settings.nearbySortIndicatorColumn;
                 } else {


### PR DESCRIPTION
In particular, the nearby tab (if you are an admin) has silence and ban buttons.  Both of which don't have 'state' and cannot really be sorted on.  Sadly if you did sort on them, nothing happened, until next time you open the PAL.  When you do, it is blank, until you modify or wipe the settings in AppData.  

So now, clicking on those column headers does nothing.