### PR TITLE
print the metaverse session ID to the debug log

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1459,6 +1459,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     updateSystemTabletMode();
 
     connect(&_myCamera, &Camera::modeUpdated, this, &Application::cameraModeChanged);
+
+    qCDebug(interfaceapp) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(accountManager->getSessionID());
 }
 
 void Application::domainConnectionRefused(const QString& reasonMessage, int reasonCodeInt, const QString& extraInfo) {

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -90,8 +90,6 @@ AccountManager::AccountManager(UserAgentGetter userAgentGetter) :
     qRegisterMetaType<QHttpMultiPart*>("QHttpMultiPart*");
 
     qRegisterMetaType<AccountManagerAuth::Type>();
-
-    qCDebug(networking) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(_sessionID);
 }
 
 const QString DOUBLE_SLASH_SUBSTITUTE = "slashslash";

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -201,6 +201,13 @@ void AccountManager::setAuthURL(const QUrl& authURL) {
     }
 }
 
+void AccountManager::setSessionID(const QUuid& sessionID) {
+    if (_sessionID != sessionID) {
+        qCDebug(networking) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(sessionID);
+        _sessionID = sessionID;
+    }
+}
+
 void AccountManager::sendRequest(const QString& path,
                                  AccountManagerAuth::Type authType,
                                  QNetworkAccessManager::Operation operation,

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -90,6 +90,8 @@ AccountManager::AccountManager(UserAgentGetter userAgentGetter) :
     qRegisterMetaType<QHttpMultiPart*>("QHttpMultiPart*");
 
     qRegisterMetaType<AccountManagerAuth::Type>();
+
+    qCDebug(networking) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(_sessionID);
 }
 
 const QString DOUBLE_SLASH_SUBSTITUTE = "slashslash";
@@ -203,7 +205,7 @@ void AccountManager::setAuthURL(const QUrl& authURL) {
 
 void AccountManager::setSessionID(const QUuid& sessionID) {
     if (_sessionID != sessionID) {
-        qCDebug(networking) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(sessionID);
+        qCDebug(networking) << "Metaverse session ID changed to" << uuidStringWithoutCurlyBraces(sessionID);
         _sessionID = sessionID;
     }
 }

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -90,7 +90,7 @@ public:
     static QJsonObject dataObjectFromResponse(QNetworkReply& requestReply);
 
     QUuid getSessionID() const { return _sessionID; }
-    void setSessionID(const QUuid& sessionID) { _sessionID = sessionID; }
+    void setSessionID(const QUuid& sessionID);
 
     void setTemporaryDomain(const QUuid& domainID, const QString& key);
     const QString& getTemporaryDomainKey(const QUuid& domainID) { return _accountInfo.getTemporaryDomainKey(domainID); }


### PR DESCRIPTION
Added debug to print the metaverse session ID to the debug log, once it is received.