### PR TITLE
Add versioning support to the KTX cache

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -407,6 +407,12 @@ Menu::Menu() {
 #endif
 
 
+    {
+        auto action = addActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::RenderClearKtxCache);
+        connect(action, &QAction::triggered, []{
+            Setting::Handle<int>(KTXCache::SETTING_VERSION_NAME, KTXCache::INVALID_VERSION).set(KTXCache::INVALID_VERSION);
+        });
+    }
 
     // Developer > Render > LOD Tools
     addActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::LodTools, 0,

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -145,6 +145,7 @@ namespace MenuOption {
     const QString Quit =  "Quit";
     const QString ReloadAllScripts = "Reload All Scripts";
     const QString ReloadContent = "Reload Content (Clears all caches)";
+    const QString RenderClearKtxCache = "Clear KTX Cache (requires restart)";
     const QString RenderMaxTextureMemory = "Maximum Texture Memory";
     const QString RenderMaxTextureAutomatic = "Automatic Texture Memory";
     const QString RenderMaxTexture4MB = "4 MB";

--- a/libraries/model-networking/src/model-networking/KTXCache.cpp
+++ b/libraries/model-networking/src/model-networking/KTXCache.cpp
@@ -21,13 +21,13 @@ using FilePointer = cache::FilePointer;
 // this value should be incremented.  This will force the KTX cache to be wiped
 const int KTXCache::CURRENT_VERSION = 0x01;
 const int KTXCache::INVALID_VERSION = 0x00;
-
+const char* KTXCache::SETTING_VERSION_NAME = "hifi.ktx.cache_version";
 
 KTXCache::KTXCache(const std::string& dir, const std::string& ext) :
     FileCache(dir, ext) {
     initialize();
 
-    Setting::Handle<int> cacheVersionHandle("hifi.ktx.cache_version", KTXCache::INVALID_VERSION);
+    Setting::Handle<int> cacheVersionHandle(SETTING_VERSION_NAME, INVALID_VERSION);
     auto cacheVersion = cacheVersionHandle.get();
     if (cacheVersion != CURRENT_VERSION) {
         wipe();

--- a/libraries/model-networking/src/model-networking/KTXCache.h
+++ b/libraries/model-networking/src/model-networking/KTXCache.h
@@ -31,6 +31,7 @@ public:
     // this value should be incremented.  This will force the KTX cache to be wiped
     static const int CURRENT_VERSION;
     static const int INVALID_VERSION;
+    static const char* SETTING_VERSION_NAME;
 
     KTXCache(const std::string& dir, const std::string& ext);
 

--- a/libraries/model-networking/src/model-networking/KTXCache.h
+++ b/libraries/model-networking/src/model-networking/KTXCache.h
@@ -27,6 +27,11 @@ class KTXCache : public cache::FileCache {
     Q_OBJECT
 
 public:
+    // Whenever a change is made to the serialized format for the KTX cache that isn't backward compatible,
+    // this value should be incremented.  This will force the KTX cache to be wiped
+    static const int CURRENT_VERSION;
+    static const int INVALID_VERSION;
+
     KTXCache(const std::string& dir, const std::string& ext);
 
     KTXFilePointer writeFile(const char* data, Metadata&& metadata);

--- a/libraries/networking/src/FileCache.h
+++ b/libraries/networking/src/FileCache.h
@@ -46,6 +46,9 @@ public:
     FileCache(const std::string& dirname, const std::string& ext, QObject* parent = nullptr);
     virtual ~FileCache();
 
+    // Remove all unlocked items from the cache
+    void wipe();
+
     size_t getNumTotalFiles() const { return _numTotalFiles; }
     size_t getNumCachedFiles() const { return _numUnusedFiles; }
     size_t getSizeTotalFiles() const { return _totalFilesSize; }
@@ -95,6 +98,9 @@ public:
 private:
     using Mutex = std::recursive_mutex;
     using Lock = std::unique_lock<Mutex>;
+    using Map = std::unordered_map<Key, std::weak_ptr<File>>;
+    using Set = std::unordered_set<FilePointer>;
+    using KeySet = std::unordered_set<Key>;
 
     friend class File;
 
@@ -105,6 +111,8 @@ private:
     void removeUnusedFile(const FilePointer& file);
     void clean();
     void clear();
+    // Remove a file from the cache
+    void eject(const FilePointer& file);
 
     size_t getOverbudgetAmount() const;
 
@@ -122,10 +130,10 @@ private:
     std::string _dirpath;
     bool _initialized { false };
 
-    std::unordered_map<Key, std::weak_ptr<File>> _files;
+    Map _files;
     Mutex _filesMutex;
 
-    std::unordered_set<FilePointer> _unusedFiles;
+    Set _unusedFiles;
     Mutex _unusedFilesMutex;
 };
 
@@ -136,8 +144,8 @@ public:
     using Key = FileCache::Key;
     using Metadata = FileCache::Metadata;
 
-    Key getKey() const { return _key; }
-    size_t getLength() const { return _length; }
+    const Key& getKey() const { return _key; }
+    const size_t& getLength() const { return _length; }
     std::string getFilepath() const { return _filepath; }
 
     virtual ~File();

--- a/tests/networking/src/FileCacheTests.h
+++ b/tests/networking/src/FileCacheTests.h
@@ -20,6 +20,7 @@ private slots:
     void testUnusedFiles();
     void testFreeSpacePreservation();
     void cleanupTestCase();
+    void testWipe();
 
 private:
     size_t getFreeSpace() const;


### PR DESCRIPTION
This updates the KTX caching code to clear the cache of all content based on a versioning system.  The current version is now set to 1, and can be updated in the `KTXCache.h` header when the serialized format of the cache changes in a non-backward compatible way.

Fogbugz 5091

## Testing

* Download and run the PR
* Visit a domain with some textures, such as dev-welcome.  Allow the scene to load.
* Then go to an empty location (you can go to `hifi://127.0.0.0`)
* Exit Interface
* Open your KTX cache directory (`~/AppData/Local/High Fidelity - PR10599/Interface/ktx_cache`) and see that it's populated.  If you loaded dev-welcome or another populated domain there should be over 300 files.
* Open the Interface JSON config file (`~/AppData/Roaming/High Fidelity - PR10599/Interface/Interface.json`) and find the `hifi.ktx.cache_version` entry.  it should be set to 1
* Remove the `hifi.ktx.cache_version` and save the file
* With the KTX cache directory visible, restart interface.  It should navigate to the last location `hifi://127.0.0.0`
* The cache files should all disappear.  Some KTX files will be immediately regenerated (the default skybox and any textures used by the avatar, plus some common textures built into the application), but there should be no more than 50 or so.  Note that the speed of cache file generation may make it seem like the directory is never strictly empty, but for a brief moment it will be. 
* Reload the config JSON file.  The `hifi.ktx.cache_version` should be there again
* If you repeat the steps without modifying the JSON file, the KTX cache files should NOT disappear when you restart interface.