### PR TITLE
protect _text member of Text3DOverlay with mutex

### DIFF
--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -29,9 +29,9 @@ Text3DOverlay::Text3DOverlay() : _mutex() {
 }
 
 Text3DOverlay::Text3DOverlay(const Text3DOverlay* text3DOverlay) :
-    _mutex(),
     Billboard3DOverlay(text3DOverlay),
     _text(text3DOverlay->_text),
+    _mutex(),
     _backgroundColor(text3DOverlay->_backgroundColor),
     _textAlpha(text3DOverlay->_textAlpha),
     _lineHeight(text3DOverlay->_lineHeight),

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -23,7 +23,7 @@ const float LINE_SCALE_RATIO = 1.2f;
 
 QString const Text3DOverlay::TYPE = "text3d";
 
-Text3DOverlay::Text3DOverlay() : _mutex() {
+Text3DOverlay::Text3DOverlay() {
     _textRenderer = TextRenderer3D::getInstance(SANS_FONT_FAMILY, FIXED_FONT_POINT_SIZE);
     _geometryId = DependencyManager::get<GeometryCache>()->allocateID();
 }
@@ -31,7 +31,6 @@ Text3DOverlay::Text3DOverlay() : _mutex() {
 Text3DOverlay::Text3DOverlay(const Text3DOverlay* text3DOverlay) :
     Billboard3DOverlay(text3DOverlay),
     _text(text3DOverlay->_text),
-    _mutex(),
     _backgroundColor(text3DOverlay->_backgroundColor),
     _textAlpha(text3DOverlay->_textAlpha),
     _lineHeight(text3DOverlay->_lineHeight),

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -12,14 +12,14 @@
 #define hifi_Text3DOverlay_h
 
 #include <QString>
-
+#include <QtCore/QMutex>
 #include "Billboard3DOverlay.h"
 
 class TextRenderer3D;
 
 class Text3DOverlay : public Billboard3DOverlay {
     Q_OBJECT
-    
+
 public:
     static QString const TYPE;
     virtual QString getType() const override { return TYPE; }
@@ -34,7 +34,7 @@ public:
     virtual const render::ShapeKey getShapeKey() override;
 
     // getters
-    const QString& getText() const { return _text; }
+    const QString getText() const;
     float getLineHeight() const { return _lineHeight; }
     float getLeftMargin() const { return _leftMargin; }
     float getTopMargin() const { return _topMargin; }
@@ -45,7 +45,7 @@ public:
     float getBackgroundAlpha() { return getAlpha(); }
 
     // setters
-    void setText(const QString& text) { _text = text; }
+    void setText(const QString& text);
     void setTextAlpha(float alpha) { _textAlpha = alpha; }
     void setLineHeight(float value) { _lineHeight = value; }
     void setLeftMargin(float margin) { _leftMargin = margin; }
@@ -58,15 +58,16 @@ public:
 
     QSizeF textSize(const QString& test) const;  // Meters
 
-    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
+    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
                                         BoxFace& face, glm::vec3& surfaceNormal) override;
 
     virtual Text3DOverlay* createClone() const override;
 
 private:
     TextRenderer3D* _textRenderer = nullptr;
-    
+
     QString _text;
+    mutable QMutex _mutex; // used to make get/setText threadsafe, mutable so can be used in const functions
     xColor _backgroundColor = xColor { 0, 0, 0 };
     float _textAlpha { 1.0f };
     float _lineHeight { 1.0f };


### PR DESCRIPTION
This fixes a crash bug reported in https://highfidelity.fogbugz.com/f/cases/4873/CRASH-without-Bugsplat-standing-around-listening-to-people-talking.   We need to protect the text member of this class, and not pass around references to it, as you can catch it in the middle of updating.  QString does some internal allocation, and trying to use it in the middle of that will cause crashes.  