### PR TITLE
add blocking crash event sending to signal handlers

### DIFF
--- a/interface/src/networking/CloseEventSender.h
+++ b/interface/src/networking/CloseEventSender.h
@@ -27,6 +27,8 @@ public:
     bool hasTimedOutQuitEvent();
     bool hasFinishedQuitEvent() { return _hasFinishedQuitEvent; }
 
+    void sendCrashEventSync();
+
 public slots:
     void sendQuitEventAsync();
 


### PR DESCRIPTION
This PR sends a crash event to our API when Interface catches a crash. This will only occur for builds that use Bugsplat and for users that are not opted-out of sending us usage data.