### PR TITLE
Optimized NVTT library with fast gamma conversion

### DIFF
--- a/cmake/externals/nvtt/CMakeLists.txt
+++ b/cmake/externals/nvtt/CMakeLists.txt
@@ -8,8 +8,8 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 if (WIN32)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://s3.amazonaws.com/hifi-public/dependencies/nvtt-win-2.1.0.zip
-    URL_MD5 3ea6eeadbcc69071acf9c49ba565760e
+    URL http://s3.amazonaws.com/hifi-public/dependencies/nvtt-win-2.1.0.hifi.zip
+    URL_MD5 907f2c683e2bcf8b8089576ec38747b4
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
@@ -29,8 +29,8 @@ else ()
   
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://hifi-public.s3.amazonaws.com/dependencies/nvidia-texture-tools-2.1.0.zip
-    URL_MD5 81b8fa6a9ee3f986088eb6e2215d6a57
+    URL http://hifi-public.s3.amazonaws.com/dependencies/nvidia-texture-tools-2.1.0.hifi.zip
+    URL_MD5 cda96482825225511d3effabbc1ddc7e
     CONFIGURE_COMMAND CMAKE_ARGS  ${ANDROID_CMAKE_ARGS} -DNVTT_SHARED=1 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     LOG_DOWNLOAD 1
     LOG_CONFIGURE 1

--- a/cmake/externals/nvtt/CMakeLists.txt
+++ b/cmake/externals/nvtt/CMakeLists.txt
@@ -9,7 +9,7 @@ if (WIN32)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
     URL http://s3.amazonaws.com/hifi-public/dependencies/nvtt-win-2.1.0.hifi.zip
-    URL_MD5 907f2c683e2bcf8b8089576ec38747b4
+    URL_MD5 10da01cf601f88f6dc12a6bc13c89136
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
@@ -30,7 +30,7 @@ else ()
   ExternalProject_Add(
     ${EXTERNAL_NAME}
     URL http://hifi-public.s3.amazonaws.com/dependencies/nvidia-texture-tools-2.1.0.hifi.zip
-    URL_MD5 cda96482825225511d3effabbc1ddc7e
+    URL_MD5 5794b950f8b265a9a41b2839b3bf7ebb
     CONFIGURE_COMMAND CMAKE_ARGS  ${ANDROID_CMAKE_ARGS} -DNVTT_SHARED=1 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     LOG_DOWNLOAD 1
     LOG_CONFIGURE 1


### PR DESCRIPTION
When creating mipmaps, NVTT spends a huge amount of CPU calling powf() to remove and reapply gamma. This seems to cause a slow startup when entering an uncached/unbaked domain. Texture filtering in linear-light does give a noticeable improvement in texture quality.

This PR adds very fast approximations of powf(x, 2.2f) and powf(x, 1/2.2f) with vectorized implementations for SSE2, that are ~15x faster than powf() on i7-4770k with no loss of quality (relative accuracy > 16 bits). The approximation error is shown below.

My changes to NVTT are checked in here:
https://github.com/kencooke/nvidia-texture-tools/commit/96b73af196bdece35bcfaa8987d2713fdd656995


![pow_11_5_poly5](https://cloud.githubusercontent.com/assets/13965157/26765089/6cfc7e62-4929-11e7-928c-44a955770506.png)
![pow_5_11_poly5](https://cloud.githubusercontent.com/assets/13965157/26765091/731bfeda-4929-11e7-9153-7f094aa7dda7.png)
