### PR TITLE
Fixes for Qt 5.9 compatibility

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -166,11 +166,7 @@ void Agent::run() {
 
     // Setup MessagesClient
     auto messagesClient = DependencyManager::set<MessagesClient>();
-    QThread* messagesThread = new QThread;
-    messagesThread->setObjectName("Messages Client Thread");
-    messagesClient->moveToThread(messagesThread);
-    connect(messagesThread, &QThread::started, messagesClient.data(), &MessagesClient::init);
-    messagesThread->start();
+    messagesClient->startThread();
 
     // make sure we hear about connected nodes so we can grab an ATP script if a request is pending
     connect(nodeList.data(), &LimitedNodeList::nodeActivated, this, &Agent::nodeActivated);

--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -69,17 +69,7 @@ AssignmentClient::AssignmentClient(Assignment::Type requestAssignmentType, QStri
     DependencyManager::set<ResourceScriptingInterface>();
     DependencyManager::set<UserActivityLoggerScriptingInterface>();
 
-    // setup a thread for the NodeList and its PacketReceiver
-    QThread* nodeThread = new QThread(this);
-    nodeThread->setObjectName("NodeList Thread");
-    nodeThread->start();
-
-    // make sure the node thread is given highest priority
-    nodeThread->setPriority(QThread::TimeCriticalPriority);
-
-    // put the NodeList on the node thread
-    nodeList->moveToThread(nodeThread);
-
+    nodeList->startThread();
     // set the logging target to the the CHILD_TARGET_NAME
     LogHandler::getInstance().setTargetName(ASSIGNMENT_CLIENT_TARGET_NAME);
 
@@ -166,14 +156,8 @@ void AssignmentClient::stopAssignmentClient() {
 }
 
 AssignmentClient::~AssignmentClient() {
-    QThread* nodeThread = DependencyManager::get<NodeList>()->thread();
-    
     // remove the NodeList from the DependencyManager
     DependencyManager::destroy<NodeList>();
-
-    // ask the node thread to quit and wait until it is done
-    nodeThread->quit();
-    nodeThread->wait();
 }
 
 void AssignmentClient::aboutToQuit() {

--- a/assignment-client/src/audio/AudioMixerSlavePool.h
+++ b/assignment-client/src/audio/AudioMixerSlavePool.h
@@ -16,9 +16,9 @@
 #include <mutex>
 #include <vector>
 
-#include <tbb/concurrent_queue.h>
-
 #include <QThread>
+
+#include <TBBHelpers.h>
 
 #include "AudioMixerSlave.h"
 

--- a/assignment-client/src/avatars/AvatarMixerSlavePool.h
+++ b/assignment-client/src/avatars/AvatarMixerSlavePool.h
@@ -16,10 +16,9 @@
 #include <mutex>
 #include <vector>
 
-#include <tbb/concurrent_queue.h>
-
 #include <QThread>
 
+#include <TBBHelpers.h>
 #include <NodeList.h>
 
 #include "AvatarMixerSlave.h"

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -236,11 +236,7 @@ void EntityScriptServer::run() {
 
     // Setup MessagesClient
     auto messagesClient = DependencyManager::set<MessagesClient>();
-    QThread* messagesThread = new QThread;
-    messagesThread->setObjectName("Messages Client Thread");
-    messagesClient->moveToThread(messagesThread);
-    connect(messagesThread, &QThread::started, messagesClient.data(), &MessagesClient::init);
-    messagesThread->start();
+    messagesClient->startThread();
 
     DomainHandler& domainHandler = DependencyManager::get<NodeList>()->getDomainHandler();
     connect(&domainHandler, &DomainHandler::settingsReceived, this, &EntityScriptServer::handleSettings);

--- a/gvr-interface/src/RenderingClient.cpp
+++ b/gvr-interface/src/RenderingClient.cpp
@@ -37,20 +37,12 @@ RenderingClient::RenderingClient(QObject *parent, const QString& launchURLString
     DependencyManager::set<AvatarHashMap>();
     
     // get our audio client setup on its own thread
-    QThread* audioThread = new QThread();
     auto audioClient = DependencyManager::set<AudioClient>();
-    
     audioClient->setPositionGetter(getPositionForAudio);
     audioClient->setOrientationGetter(getOrientationForAudio);
+    audioClient->startThread();
     
-    audioClient->moveToThread(audioThread);
-    connect(audioThread, &QThread::started, audioClient.data(), &AudioClient::start);
-    connect(audioClient.data(), &AudioClient::destroyed, audioThread, &QThread::quit);
-    connect(audioThread, &QThread::finished, audioThread, &QThread::deleteLater);
-
-    audioThread->start();
-    
-    
+   
     connect(&_avatarTimer, &QTimer::timeout, this, &RenderingClient::sendAvatarPacket);
     _avatarTimer.setInterval(16); // 60 FPS
     _avatarTimer.start();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -651,6 +651,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us
 
     auto nodeList = DependencyManager::get<NodeList>();
+    nodeList->startThread();
 
     // Set up a watchdog thread to intentionally crash the application on deadlocks
     _deadlockWatchdogThread = new DeadlockWatchdogThread();
@@ -676,25 +677,11 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     updateHeartbeat();
 
-    // start the nodeThread so its event loop is running
-    QThread* nodeThread = new QThread(this);
-    nodeThread->setObjectName("NodeList Thread");
-    nodeThread->start();
-
-    // make sure the node thread is given highest priority
-    nodeThread->setPriority(QThread::TimeCriticalPriority);
-
     // setup a timer for domain-server check ins
     QTimer* domainCheckInTimer = new QTimer(nodeList.data());
     connect(domainCheckInTimer, &QTimer::timeout, nodeList.data(), &NodeList::sendDomainServerCheckIn);
     domainCheckInTimer->start(DOMAIN_SERVER_CHECK_IN_MSECS);
 
-    // put the NodeList and datagram processing on the node thread
-    nodeList->moveToThread(nodeThread);
-
-    // put the audio processing on a separate thread
-    QThread* audioThread = new QThread();
-    audioThread->setObjectName("Audio Thread");
 
     auto audioIO = DependencyManager::get<AudioClient>();
     audioIO->setPositionGetter([]{
@@ -710,7 +697,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         return myAvatar ? myAvatar->getOrientationForAudio() : Quaternions::IDENTITY;
     });
 
-    audioIO->moveToThread(audioThread);
     recording::Frame::registerFrameHandler(AudioConstants::getAudioFrameName(), [=](recording::Frame::ConstPointer frame) {
         audioIO->handleRecordedAudioInput(frame->data);
     });
@@ -724,9 +710,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     });
 
     auto audioScriptingInterface = DependencyManager::set<AudioScriptingInterface>();
-    connect(audioThread, &QThread::started, audioIO.data(), &AudioClient::start);
-    connect(audioIO.data(), &AudioClient::destroyed, audioThread, &QThread::quit);
-    connect(audioThread, &QThread::finished, audioThread, &QThread::deleteLater);
     connect(audioIO.data(), &AudioClient::muteToggled, this, &Application::audioMuteToggled);
     connect(audioIO.data(), &AudioClient::mutedByMixer, audioScriptingInterface.data(), &AudioScriptingInterface::mutedByMixer);
     connect(audioIO.data(), &AudioClient::receivedFirstPacket, audioScriptingInterface.data(), &AudioScriptingInterface::receivedFirstPacket);
@@ -744,19 +727,14 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         }
     });
 
-    audioThread->start();
+    audioIO->startThread();
 
     ResourceManager::init();
     // Make sure we don't time out during slow operations at startup
     updateHeartbeat();
 
     // Setup MessagesClient
-    auto messagesClient = DependencyManager::get<MessagesClient>();
-    QThread* messagesThread = new QThread;
-    messagesThread->setObjectName("Messages Client Thread");
-    messagesClient->moveToThread(messagesThread);
-    connect(messagesThread, &QThread::started, messagesClient.data(), &MessagesClient::init);
-    messagesThread->start();
+    DependencyManager::get<MessagesClient>()->startThread();
 
     const DomainHandler& domainHandler = nodeList->getDomainHandler();
 
@@ -1648,12 +1626,7 @@ void Application::aboutToQuit() {
     getActiveDisplayPlugin()->deactivate();
 
     // use the CloseEventSender via a QThread to send an event that says the user asked for the app to close
-    auto closeEventSender = DependencyManager::get<CloseEventSender>();
-    QThread* closureEventThread = new QThread(this);
-    closeEventSender->moveToThread(closureEventThread);
-    // sendQuitEventAsync will bail immediately if the UserActivityLogger is not enabled
-    connect(closureEventThread, &QThread::started, closeEventSender.data(), &CloseEventSender::sendQuitEventAsync);
-    closureEventThread->start();
+    DependencyManager::get<CloseEventSender>()->startThread();
 
     // Hide Running Scripts dialog so that it gets destroyed in an orderly manner; prevents warnings at shutdown.
     DependencyManager::get<OffscreenUi>()->hide("RunningScripts");
@@ -1741,6 +1714,8 @@ void Application::cleanupBeforeQuit() {
     // stop QML
     DependencyManager::destroy<OffscreenUi>();
 
+    DependencyManager::destroy<OffscreenQmlSurfaceCache>();
+
     if (_snapshotSoundInjector != nullptr) {
         _snapshotSoundInjector->stop();
     }
@@ -1800,14 +1775,8 @@ Application::~Application() {
 
     ResourceManager::cleanup();
 
-    QThread* nodeThread = DependencyManager::get<NodeList>()->thread();
-
     // remove the NodeList from the DependencyManager
     DependencyManager::destroy<NodeList>();
-
-    // ask the node thread to quit and wait until it is done
-    nodeThread->quit();
-    nodeThread->wait();
 
     Leapmotion::destroy();
 

--- a/interface/src/networking/CloseEventSender.cpp
+++ b/interface/src/networking/CloseEventSender.cpp
@@ -14,6 +14,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtNetwork/QNetworkReply>
 
+#include <ThreadHelpers.h>
 #include <AccountManager.h>
 #include <NetworkAccessManager.h>
 #include <NetworkingConstants.h>
@@ -87,4 +88,8 @@ bool CloseEventSender::hasTimedOutQuitEvent() {
         && QDateTime::currentMSecsSinceEpoch() - _quitEventStartTimestamp > CLOSURE_EVENT_TIMEOUT_MS;
 }
 
-
+void CloseEventSender::startThread() {
+    moveToNewNamedThread(this, "CloseEvent Logger Thread", [this] { 
+        sendQuitEventAsync(); 
+    });
+}

--- a/interface/src/networking/CloseEventSender.h
+++ b/interface/src/networking/CloseEventSender.h
@@ -24,6 +24,7 @@ class CloseEventSender : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
 
 public:
+    void startThread();
     bool hasTimedOutQuitEvent();
     bool hasFinishedQuitEvent() { return _hasFinishedQuitEvent; }
 

--- a/interface/src/scripting/LimitlessVoiceRecognitionScriptingInterface.cpp
+++ b/interface/src/scripting/LimitlessVoiceRecognitionScriptingInterface.cpp
@@ -9,9 +9,12 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QtConcurrent/QtConcurrentRun>
+
+#include <ThreadHelpers.h>
 #include <src/InterfaceLogging.h>
 #include <src/ui/AvatarInputs.h>
-#include <QtConcurrent/QtConcurrentRun>
+
 #include "LimitlessVoiceRecognitionScriptingInterface.h"
 
 const float LimitlessVoiceRecognitionScriptingInterface::_audioLevelThreshold = 0.33f;
@@ -24,9 +27,7 @@ LimitlessVoiceRecognitionScriptingInterface::LimitlessVoiceRecognitionScriptingI
     connect(&_voiceTimer, &QTimer::timeout, this, &LimitlessVoiceRecognitionScriptingInterface::voiceTimeout);
     connect(&_connection, &LimitlessConnection::onReceivedTranscription, this, [this](QString transcription){emit onReceivedTranscription(transcription);});
     connect(&_connection, &LimitlessConnection::onFinishedSpeaking, this, [this](QString transcription){emit onFinishedSpeaking(transcription);});
-    _connection.moveToThread(&_connectionThread);
-    _connectionThread.setObjectName("Limitless Connection");
-    _connectionThread.start();
+    moveToNewNamedThread(&_connection, "Limitless Connection");
 }
 
 void LimitlessVoiceRecognitionScriptingInterface::update() {

--- a/interface/src/scripting/LimitlessVoiceRecognitionScriptingInterface.h
+++ b/interface/src/scripting/LimitlessVoiceRecognitionScriptingInterface.h
@@ -41,7 +41,6 @@ private:
     static const int _voiceTimeoutDuration;
 
     QTimer _voiceTimer;
-    QThread _connectionThread;
     LimitlessConnection _connection;
 
     void voiceTimeout();

--- a/interface/src/ui/ModelsBrowser.cpp
+++ b/interface/src/ui/ModelsBrowser.cpp
@@ -23,6 +23,7 @@
 #include <QUrlQuery>
 #include <QXmlStreamReader>
 
+#include <ThreadHelpers.h>
 #include <NetworkAccessManager.h>
 #include <SharedUtil.h>
 
@@ -84,12 +85,7 @@ ModelsBrowser::ModelsBrowser(FSTReader::ModelType modelsType, QWidget* parent) :
     _handler->connect(this, SIGNAL(destroyed()), SLOT(exit()));
     
     // Setup and launch update thread
-    QThread* thread = new QThread();
-    thread->setObjectName("Models Browser");
-    thread->connect(_handler, SIGNAL(destroyed()), SLOT(quit()));
-    thread->connect(thread, SIGNAL(finished()), SLOT(deleteLater()));
-    _handler->moveToThread(thread);
-    thread->start();
+    moveToNewNamedThread(_handler, "Models Browser");
     emit startDownloading();
     
     // Initialize the view

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -31,10 +31,13 @@
 #include <VersionHelpers.h>
 #endif
 
+#include <QtConcurrent/QtConcurrent>
+#include <QtCore/QThreadPool>
 #include <QtCore/QBuffer>
 #include <QtMultimedia/QAudioInput>
 #include <QtMultimedia/QAudioOutput>
 
+#include <ThreadHelpers.h>
 #include <NodeList.h>
 #include <plugins/CodecPlugin.h>
 #include <plugins/PluginManager.h>
@@ -75,59 +78,6 @@ Setting::Handle<int> staticJitterBufferFrames("staticJitterBufferFrames",
 using Mutex = std::mutex;
 using Lock = std::unique_lock<Mutex>;
 static Mutex _deviceMutex;
-
-class BackgroundThread : public QThread {
-public:
-    BackgroundThread(AudioClient* client) : QThread((QObject*)client), _client(client) {}
-    virtual void join() = 0;
-protected:
-    AudioClient* _client;
-};
-
-// background thread continuously polling device changes
-class CheckDevicesThread : public BackgroundThread {
-public:
-    CheckDevicesThread(AudioClient* client) : BackgroundThread(client) {}
-
-    void join() override {
-        _shouldQuit = true;
-        std::unique_lock<std::mutex> lock(_joinMutex);
-        _joinCondition.wait(lock, [&]{ return !_isRunning; });
-    }
-
-protected:
-    void run() override {
-        while (!_shouldQuit) {
-            _client->checkDevices();
-
-            const unsigned long DEVICE_CHECK_INTERVAL_MSECS = 2 * 1000;
-            QThread::msleep(DEVICE_CHECK_INTERVAL_MSECS);
-        }
-        std::lock_guard<std::mutex> lock(_joinMutex);
-        _isRunning = false;
-        _joinCondition.notify_one();
-    }
-
-private:
-    std::atomic<bool> _shouldQuit { false };
-    bool _isRunning { true };
-    std::mutex _joinMutex;
-    std::condition_variable _joinCondition;
-};
-
-// background thread buffering local injectors
-class LocalInjectorsThread : public BackgroundThread {
-    Q_OBJECT
-public:
-    LocalInjectorsThread(AudioClient* client) : BackgroundThread(client) {}
-
-    void join() override { return; }
-
-private slots:
-    void prepare() { _client->prepareLocalAudioInjectors(); }
-};
-
-#include "AudioClient.moc"
 
 static void channelUpmix(int16_t* source, int16_t* dest, int numSamples, int numExtraChannels) {
     for (int i = 0; i < numSamples/2; i++) {
@@ -223,16 +173,15 @@ AudioClient::AudioClient() :
     _inputDevices = getDeviceNames(QAudio::AudioInput);
     _outputDevices = getDeviceNames(QAudio::AudioOutput);
 
-    // start a thread to detect any device changes
-    _checkDevicesThread = new CheckDevicesThread(this);
-    _checkDevicesThread->setObjectName("AudioClient CheckDevices Thread");
-    _checkDevicesThread->setPriority(QThread::LowPriority);
-    _checkDevicesThread->start();
 
-    // start a thread to process local injectors
-    _localInjectorsThread = new LocalInjectorsThread(this);
-    _localInjectorsThread->setObjectName("AudioClient LocalInjectors Thread");
-    _localInjectorsThread->start();
+    // start a thread to detect any device changes
+    _checkDevicesTimer = new QTimer(this);
+    connect(_checkDevicesTimer, &QTimer::timeout, [this] {
+        QtConcurrent::run(QThreadPool::globalInstance(), [this] {
+            checkDevices();
+        });
+    });
+
 
     configureReverb();
 
@@ -263,15 +212,7 @@ void AudioClient::cleanupBeforeQuit() {
 
     stop();
 
-    if (_checkDevicesThread) {
-        static_cast<BackgroundThread*>(_checkDevicesThread)->join();
-        delete _checkDevicesThread;
-    }
-
-    if (_localInjectorsThread) {
-        static_cast<BackgroundThread*>(_localInjectorsThread)->join();
-        delete _localInjectorsThread;
-    }
+    _checkDevicesTimer->stop();
 }
 
 void AudioClient::handleMismatchAudioFormat(SharedNodePointer node, const QString& currentCodec, const QString& recievedCodec) {
@@ -1369,10 +1310,8 @@ bool AudioClient::outputLocalInjector(AudioInjector* injector) {
         if (!_activeLocalAudioInjectors.contains(injector)) {
             qCDebug(audioclient) << "adding new injector";
             _activeLocalAudioInjectors.append(injector);
-
             // move local buffer to the LocalAudioThread to avoid dataraces with AudioInjector (like stop())
             injectorBuffer->setParent(nullptr);
-            injectorBuffer->moveToThread(_localInjectorsThread);
 
             // update the flag
             _localInjectorsAvailable.exchange(true, std::memory_order_release);
@@ -1782,7 +1721,9 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
     }
 
     // prepare injectors for the next callback
-    QMetaObject::invokeMethod(_audio->_localInjectorsThread, "prepare", Qt::QueuedConnection);
+    QtConcurrent::run(QThreadPool::globalInstance(), [this] {
+        _audio->prepareLocalAudioInjectors();
+    });
 
     int samplesPopped = std::max(networkSamplesPopped, injectorSamplesPopped);
     int framesPopped = samplesPopped / AudioConstants::STEREO;
@@ -1854,4 +1795,9 @@ void AudioClient::saveSettings() {
 void AudioClient::setAvatarBoundingBoxParameters(glm::vec3 corner, glm::vec3 scale) {
     avatarBoundingBoxCorner = corner;
     avatarBoundingBoxScale = scale;
+}
+
+
+void AudioClient::startThread() {
+    moveToNewNamedThread(this, "Audio Thread", [this] { start(); });
 }

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -104,6 +104,7 @@ public:
         int _unfulfilledReads;
     };
 
+    void startThread();
     void negotiateAudioFormat();
     void selectAudioFormat(const QString& selectedCodecName);
 
@@ -386,8 +387,7 @@ private:
     RateCounter<> _silentInbound;
     RateCounter<> _audioInbound;
 
-    QThread* _checkDevicesThread { nullptr };
-    QThread* _localInjectorsThread { nullptr };
+    QTimer* _checkDevicesTimer { nullptr };
 };
 
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -22,8 +22,6 @@
 #include <QtCore/QUrl>
 #include <QtNetwork/QHostInfo>
 
-#include <tbb/parallel_for.h>
-
 #include <LogHandler.h>
 #include <shared/NetworkUtils.h>
 #include <NumericalConstants.h>

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -31,7 +31,7 @@
 #include <QtNetwork/QUdpSocket>
 #include <QtNetwork/QHostAddress>
 
-#include <tbb/concurrent_unordered_map.h>
+#include <TBBHelpers.h>
 
 #include <DependencyManager.h>
 #include <SharedUtil.h>
@@ -68,9 +68,8 @@ const QString USERNAME_UUID_REPLACEMENT_STATS_KEY = "$username";
 
 const QString LOCAL_SOCKET_CHANGE_STAT = "LocalSocketChanges";
 
-using namespace tbb;
 typedef std::pair<QUuid, SharedNodePointer> UUIDNodePair;
-typedef concurrent_unordered_map<QUuid, SharedNodePointer, UUIDHasher> NodeHash;
+typedef tbb::concurrent_unordered_map<QUuid, SharedNodePointer, UUIDHasher> NodeHash;
 
 typedef quint8 PingType_t;
 namespace PingType {

--- a/libraries/networking/src/MessagesClient.cpp
+++ b/libraries/networking/src/MessagesClient.cpp
@@ -16,6 +16,8 @@
 #include <QtCore/QBuffer>
 #include <QtCore/QThread>
 
+#include <ThreadHelpers.h>
+
 #include "NetworkLogging.h"
 #include "NodeList.h"
 #include "PacketReceiver.h"
@@ -28,12 +30,6 @@ MessagesClient::MessagesClient() {
     auto& packetReceiver = nodeList->getPacketReceiver();
     packetReceiver.registerListener(PacketType::MessagesData, this, "handleMessagesPacket");
     connect(nodeList.data(), &LimitedNodeList::nodeActivated, this, &MessagesClient::handleNodeActivated);
-}
-
-void MessagesClient::init() {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "init", Qt::BlockingQueuedConnection);
-    }
 }
 
 void MessagesClient::decodeMessagesPacket(QSharedPointer<ReceivedMessage> receivedMessage, QString& channel, 
@@ -184,4 +180,8 @@ void MessagesClient::handleNodeActivated(SharedNodePointer node) {
             subscribe(channel);
         }
     }
+}
+
+void MessagesClient::startThread() {
+    moveToNewNamedThread(this, "Messages Client Thread");
 }

--- a/libraries/networking/src/MessagesClient.h
+++ b/libraries/networking/src/MessagesClient.h
@@ -28,7 +28,7 @@ class MessagesClient : public QObject, public Dependency {
 public:
     MessagesClient();
     
-    Q_INVOKABLE void init();
+    void startThread();
 
     Q_INVOKABLE void sendMessage(QString channel, QString message, bool localOnly = false);
     Q_INVOKABLE void sendLocalMessage(QString channel, QString message);

--- a/libraries/networking/src/Node.h
+++ b/libraries/networking/src/Node.h
@@ -24,7 +24,7 @@
 #include <QReadLocker>
 #include <UUIDHasher.h>
 
-#include <tbb/concurrent_unordered_set.h>
+#include <TBBHelpers.h>
 
 #include "HifiSockAddr.h"
 #include "NetworkPeer.h"

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -20,6 +20,7 @@
 #include <QtNetwork/QHostInfo>
 #include <QtNetwork/QNetworkInterface>
 
+#include <ThreadHelpers.h>
 #include <LogHandler.h>
 #include <UUID.h>
 
@@ -1114,4 +1115,9 @@ void NodeList::setRequestsDomainListData(bool isRequesting) {
         sendPacket(std::move(packet), *destinationNode);
     });
     _requestsDomainListData = isRequesting;
+}
+
+
+void NodeList::startThread() {
+    moveToNewNamedThread(this, "NodeList Thread", QThread::TimeCriticalPriority);
 }

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -20,7 +20,7 @@
 #include <unistd.h> // not on windows, not needed for mac or windows
 #endif
 
-#include <tbb/concurrent_unordered_set.h>
+#include <TBBHelpers.h>
 
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QMutex>

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -52,6 +52,7 @@ class NodeList : public LimitedNodeList {
     SINGLETON_DEPENDENCY
 
 public:
+    void startThread();
     NodeType_t getOwnerType() const { return _ownerType.load(); }
     void setOwnerType(NodeType_t ownerType) { _ownerType.store(ownerType); }
 

--- a/libraries/shared/src/TBBHelpers.h
+++ b/libraries/shared/src/TBBHelpers.h
@@ -1,0 +1,28 @@
+//
+//  Created by Bradley Austin Davis on 2017/06/06
+//  Copyright 2013-2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+#ifndef hifi_TBBHelpers_h
+#define hifi_TBBHelpers_h
+
+#ifdef _WIN32
+#pragma warning( push )
+#pragma warning( disable : 4334 )
+#endif
+
+#include <tbb/concurrent_queue.h>
+#include <tbb/concurrent_unordered_map.h>
+#include <tbb/concurrent_unordered_set.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/parallel_for.h>
+
+#ifdef _WIN32
+#pragma warning( pop )
+#endif
+
+#endif // hifi_TBBHelpers_h

--- a/libraries/shared/src/ThreadHelpers.cpp
+++ b/libraries/shared/src/ThreadHelpers.cpp
@@ -1,0 +1,39 @@
+//
+//  Created by Bradley Austin Davis on 2017/06/06
+//  Copyright 2013-2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ThreadHelpers.h"
+
+#include <QtCore/QDebug>
+
+
+void moveToNewNamedThread(QObject* object, const QString& name, std::function<void()> startCallback, QThread::Priority priority) {
+     Q_ASSERT(QThread::currentThread() == object->thread());
+     // setup a thread for the NodeList and its PacketReceiver
+     QThread* thread = new QThread();
+     thread->setObjectName(name);
+
+     if (priority != QThread::InheritPriority) {
+         thread->setPriority(priority);
+     }
+
+     QString tempName = name;
+     QObject::connect(thread, &QThread::started, [startCallback] {
+         startCallback();
+     });
+     // Make sure the thread will be destroyed and cleaned up
+     QObject::connect(object, &QObject::destroyed, thread, &QThread::quit);
+     QObject::connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+
+     // put the object on the thread
+     object->moveToThread(thread);
+     thread->start();
+}
+
+void moveToNewNamedThread(QObject* object, const QString& name, QThread::Priority priority) {
+    moveToNewNamedThread(object, name, [] {}, priority);
+}

--- a/libraries/shared/src/ThreadHelpers.h
+++ b/libraries/shared/src/ThreadHelpers.h
@@ -12,8 +12,13 @@
 #define hifi_ThreadHelpers_h
 
 #include <exception>
-#include <QMutex>
-#include <QMutexLocker>
+#include <functional>
+
+#include <QtCore/QMutex>
+#include <QtCore/QMutexLocker>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QThread>
 
 template <typename L, typename F>
 void withLock(L lock, F function) {
@@ -25,5 +30,8 @@ void withLock(QMutex& lock, F function) {
     QMutexLocker locker(&lock);
     function();
 }
+
+void moveToNewNamedThread(QObject* object, const QString& name, std::function<void()> startCallback, QThread::Priority priority = QThread::InheritPriority);
+void moveToNewNamedThread(QObject* object, const QString& name, QThread::Priority priority = QThread::InheritPriority);
 
 #endif

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -143,7 +143,7 @@ private:
 
         int _trackedControllers { 0 };
         vr::IVRSystem*& _system;
-        quint64 _timeTilCalibration { 0.0f };
+        quint64 _timeTilCalibration { 0 };
         float _leftHapticStrength { 0.0f };
         float _leftHapticDuration { 0.0f };
         float _rightHapticStrength { 0.0f };

--- a/tests/qt59/CMakeLists.txt
+++ b/tests/qt59/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+set(TARGET_NAME qt59)
+ 
+if (WIN32)
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4049 /ignore:4217")
+endif()
+
+# This is not a testcase -- just set it up as a regular hifi project
+setup_hifi_project(Gui)
+set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Tests/manual-tests/")
+
+# link in the shared libraries
+link_hifi_libraries(shared networking)
+
+package_libraries_for_deployment()

--- a/tests/qt59/src/main.cpp
+++ b/tests/qt59/src/main.cpp
@@ -1,0 +1,78 @@
+//
+//  Created by Bradley Austin Davis on 2017/06/06
+//  Copyright 2013-2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <mutex>
+
+#include <QtCore/QCoreApplication>
+
+#include <NodeList.h>
+#include <AccountManager.h>
+#include <AddressManager.h>
+#include <MessagesClient.h>
+
+#include <BuildInfo.h>
+
+
+class Qt59TestApp : public QCoreApplication {
+    Q_OBJECT
+public:
+    Qt59TestApp(int argc, char* argv[]);
+    ~Qt59TestApp();
+
+private:
+    void finish(int exitCode);
+};
+
+
+
+Qt59TestApp::Qt59TestApp(int argc, char* argv[]) :
+    QCoreApplication(argc, argv)
+{
+
+    Setting::init();
+    DependencyManager::registerInheritance<LimitedNodeList, NodeList>();
+    DependencyManager::set<AccountManager>([&] { return QString("Mozilla/5.0 (HighFidelityACClient)"); });
+    DependencyManager::set<AddressManager>();
+    DependencyManager::set<NodeList>(NodeType::Agent, 0);
+    auto nodeList = DependencyManager::get<NodeList>();
+    nodeList->startThread();
+    auto messagesClient = DependencyManager::set<MessagesClient>();
+    messagesClient->startThread();
+    QTimer::singleShot(1000, [this] { finish(0); });
+}
+
+Qt59TestApp::~Qt59TestApp() {
+}
+
+
+void Qt59TestApp::finish(int exitCode) {
+    auto nodeList = DependencyManager::get<NodeList>();
+
+    // send the domain a disconnect packet, force stoppage of domain-server check-ins
+    nodeList->getDomainHandler().disconnect();
+    nodeList->setIsShuttingDown(true);
+    nodeList->getPacketReceiver().setShouldDropPackets(true);
+
+    // remove the NodeList from the DependencyManager
+    DependencyManager::destroy<NodeList>();
+    QCoreApplication::exit(exitCode);
+}
+
+
+int main(int argc, char * argv[]) {
+    QCoreApplication::setApplicationName("Qt59Test");
+    QCoreApplication::setOrganizationName(BuildInfo::MODIFIED_ORGANIZATION);
+    QCoreApplication::setOrganizationDomain(BuildInfo::ORGANIZATION_DOMAIN);
+    QCoreApplication::setApplicationVersion(BuildInfo::VERSION);
+
+    Qt59TestApp app(argc, argv);
+
+    return app.exec();
+}
+
+#include "main.moc"

--- a/tools/ac-client/src/ACClientApp.cpp
+++ b/tools/ac-client/src/ACClientApp.cpp
@@ -90,22 +90,13 @@ ACClientApp::ACClientApp(int argc, char* argv[]) :
 
 
     auto nodeList = DependencyManager::get<NodeList>();
-
     // start the nodeThread so its event loop is running
-    QThread* nodeThread = new QThread(this);
-    nodeThread->setObjectName("NodeList Thread");
-    nodeThread->start();
-
-    // make sure the node thread is given highest priority
-    nodeThread->setPriority(QThread::TimeCriticalPriority);
+    nodeList->startThread();
 
     // setup a timer for domain-server check ins
     QTimer* domainCheckInTimer = new QTimer(nodeList.data());
     connect(domainCheckInTimer, &QTimer::timeout, nodeList.data(), &NodeList::sendDomainServerCheckIn);
     domainCheckInTimer->start(DOMAIN_SERVER_CHECK_IN_MSECS);
-
-    // put the NodeList and datagram processing on the node thread
-    nodeList->moveToThread(nodeThread);
 
     const DomainHandler& domainHandler = nodeList->getDomainHandler();
 
@@ -239,12 +230,8 @@ void ACClientApp::finish(int exitCode) {
     // tell the packet receiver we're shutting down, so it can drop packets
     nodeList->getPacketReceiver().setShouldDropPackets(true);
 
-    QThread* nodeThread = DependencyManager::get<NodeList>()->thread();
     // remove the NodeList from the DependencyManager
     DependencyManager::destroy<NodeList>();
-    // ask the node thread to quit and wait until it is done
-    nodeThread->quit();
-    nodeThread->wait();
 
     printFailedServers();
     QCoreApplication::exit(exitCode);

--- a/tools/oven/src/Oven.h
+++ b/tools/oven/src/Oven.h
@@ -14,7 +14,7 @@
 
 #include <QtWidgets/QApplication>
 
-#include <tbb/concurrent_vector.h>
+#include <TBBHelpers.h>
 
 #include <atomic>
 


### PR DESCRIPTION
In testing Qt 5.9, I've discovered two issues.  One is a 64 bit value initialized from a float (this triggers an error in VS 2017, while it didn't in VS 2013).  The second issue is `QThread` related.   

In Qt 5.6 if a thread was not properly stopped before the `QThread` object was destroyed, then it would log a warning (which we probably would never see since these destructors would usually be called after we had removed our logging mechanisms).  In Qt 5.9, instead of a `qWarning`, a `qFatal` is emitted, and this crashes the application on exit.

Our code had a number of places doing explicit thread management.  Some of them had proper cleanup, and some didn't.  Even those that did weren't always doing it in a way that made it obvious the thread was properly stopped and destroyed (looking at you `NodeList`).  This PR adds some helper functionality to the shared library that associates a given QObject with a new thread, and ensures when that object is destroyed that the thread itself is stopped and also deleted.  A number of classes that were previously doing explicit thread creation are now using this helper function.  Additionally, the `AudioClient` threads that is previously created have been removed in favor of using QtConcurrent with the existing global thread pool.  The old approach failed to properly stop at least one of the threads.  

Possibly related to https://highfidelity.fogbugz.com/f/cases/4812/crash-in-OffscreenQmlSurface-resume-RenderableWebEntityItem-buildWebSurface

## Testing

While targeting better stability and the ability to compile on Qt 5.9, these changes should have zero impact on Qt 5.6 based builds.  

In particular, if the NodeList wasn't functional, we wouldn't be able to connect to anything.  If the AudioClient wasn't functional, you wouldn't be able to hear or say anything.  The MessagesClient is used by a number of default scripts, but I'm unclear how broken Message functionality would manifest.  

As such a basic smoke test should be sufficient.  Ensure you can...
* connect to domains
* hear ambient sound
* hear and be heard by others
* use the attachedEntititesManager.js functionality.