### PR TITLE
Added CLI to Oven tool

### DIFF
--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -19,11 +19,10 @@
 #include "FBXBaker.h"
 #include "TextureBaker.h"
 
-BakerCLI::BakerCLI(Oven* parent) : QObject() {
+BakerCLI::BakerCLI(Oven* parent) : QObject(parent) {
 }
 
-void BakerCLI::bakeFile(const QString inputFilename, const QString outputPath) {
-    QUrl inputUrl(inputFilename);
+void BakerCLI::bakeFile(QUrl inputUrl, const QString outputPath) {
 
     // if the URL doesn't have a scheme, assume it is a local file
     if (inputUrl.scheme() != "http" && inputUrl.scheme() != "https" && inputUrl.scheme() != "ftp") {
@@ -33,11 +32,11 @@ void BakerCLI::bakeFile(const QString inputFilename, const QString outputPath) {
     static const QString MODEL_EXTENSION { ".fbx" };
 
     // check what kind of baker we should be creating
-    bool isFBX = inputFilename.endsWith(MODEL_EXTENSION, Qt::CaseInsensitive);
+    bool isFBX = inputUrl.toDisplayString().endsWith(MODEL_EXTENSION, Qt::CaseInsensitive);
     bool isSupportedImage = false;
 
     for (QByteArray format : QImageReader::supportedImageFormats()) {
-        isSupportedImage |= inputFilename.endsWith(format, Qt::CaseInsensitive);
+        isSupportedImage |= inputUrl.toDisplayString().endsWith(format, Qt::CaseInsensitive);
     }
 
     // create our appropiate baker

--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -1,0 +1,69 @@
+//
+//  BakerCLI.cpp
+//  tools/oven/src
+//
+//  Created by Robbie Uvanni on 6/6/17.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <memory>
+
+#include <QImageReader>
+#include <QtCore/QDebug>
+#include "ModelBakingLoggingCategory.h"
+
+#include "Oven.h"
+#include "BakerCLI.h"
+
+#include "FBXBaker.h"
+#include "TextureBaker.h"
+
+void BakerCLI::bakeFile(const QString inputFilename, const QString outputFilename) {
+    QUrl inputUrl(inputFilename);
+
+    // if the URL doesn't have a scheme, assume it is a local file
+    if (inputUrl.scheme() != "http" && inputUrl.scheme() != "https" && inputUrl.scheme() != "ftp") {
+        inputUrl.setScheme("file");
+    }
+
+    static const QString MODEL_EXTENSION { ".fbx" };
+
+    // check what kind of baker we should be creating
+    bool isFBX = inputFilename.endsWith(MODEL_EXTENSION, Qt::CaseInsensitive);
+    bool isSupportedImage = false;
+
+    for (QByteArray format : QImageReader::supportedImageFormats()) {
+        isSupportedImage |= inputFilename.endsWith(format, Qt::CaseInsensitive);
+    }
+
+    // create our appropiate baker
+    Baker* baker;
+
+    if (isFBX) {
+        baker = new FBXBaker(inputUrl, outputFilename, []() -> QThread* {
+            return qApp->getNextWorkerThread();
+        });
+        baker->moveToThread(qApp->getFBXBakerThread());
+    } else if (isSupportedImage) {
+        baker = new TextureBaker(inputUrl, image::TextureUsage::CUBE_TEXTURE, outputFilename);
+        baker->moveToThread(qApp->getNextWorkerThread());
+    } else {
+        qCDebug(model_baking) << "Failed to determine baker type for file" << inputUrl;
+        return;
+    }
+
+    // invoke the bake method on the baker thread
+    QMetaObject::invokeMethod(baker, "bake");
+
+    // make sure we hear about the results of this baker when it is done
+    connect(baker, &Baker::finished, this, &BakerCLI::handleFinishedBaker);
+}
+
+void BakerCLI::handleFinishedBaker() {
+    qCDebug(model_baking) << "Finished baking file.";
+    sender()->deleteLater();
+    QApplication::quit();
+}

--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -9,16 +9,20 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <QObject>
 #include <QImageReader>
 #include <QtCore/QDebug>
-#include "ModelBakingLoggingCategory.h"
 
+#include "ModelBakingLoggingCategory.h"
 #include "Oven.h"
 #include "BakerCLI.h"
 #include "FBXBaker.h"
 #include "TextureBaker.h"
 
-void BakerCLI::bakeFile(const QString inputFilename, const QString outputFilename) {
+BakerCLI::BakerCLI(Oven* parent) : QObject() {
+}
+
+void BakerCLI::bakeFile(const QString inputFilename, const QString outputPath) {
     QUrl inputUrl(inputFilename);
 
     // if the URL doesn't have a scheme, assume it is a local file
@@ -40,12 +44,12 @@ void BakerCLI::bakeFile(const QString inputFilename, const QString outputFilenam
     Baker* baker;
 
     if (isFBX) {
-        baker = new FBXBaker(inputUrl, outputFilename, []() -> QThread* {
+        baker = new FBXBaker(inputUrl, outputPath, []() -> QThread* {
             return qApp->getNextWorkerThread();
         });
         baker->moveToThread(qApp->getFBXBakerThread());
     } else if (isSupportedImage) {
-        baker = new TextureBaker(inputUrl, image::TextureUsage::CUBE_TEXTURE, outputFilename);
+        baker = new TextureBaker(inputUrl, image::TextureUsage::CUBE_TEXTURE, outputPath);
         baker->moveToThread(qApp->getNextWorkerThread());
     } else {
         qCDebug(model_baking) << "Failed to determine baker type for file" << inputUrl;

--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -9,15 +9,12 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <memory>
-
 #include <QImageReader>
 #include <QtCore/QDebug>
 #include "ModelBakingLoggingCategory.h"
 
 #include "Oven.h"
 #include "BakerCLI.h"
-
 #include "FBXBaker.h"
 #include "TextureBaker.h"
 

--- a/tools/oven/src/BakerCLI.h
+++ b/tools/oven/src/BakerCLI.h
@@ -14,6 +14,7 @@
 
 #include <QtCore/QObject>
 
+#include "Baker.h"
 #include "Oven.h"
 
 class BakerCLI : public QObject {
@@ -24,8 +25,10 @@ public:
     void bakeFile(QUrl inputUrl, const QString outputPath);
 
 private slots:
-    void handleFinishedBaker();
+    void handleFinishedBaker();  
 
+private:
+    std::unique_ptr<Baker> _baker;
 };
 
 #endif // hifi_BakerCLI_h

--- a/tools/oven/src/BakerCLI.h
+++ b/tools/oven/src/BakerCLI.h
@@ -21,7 +21,7 @@ class BakerCLI : public QObject {
 
 public:
     BakerCLI(Oven* parent);
-    void bakeFile(const QString inputFilename, const QString outputPath);
+    void bakeFile(QUrl inputUrl, const QString outputPath);
 
 private slots:
     void handleFinishedBaker();

--- a/tools/oven/src/BakerCLI.h
+++ b/tools/oven/src/BakerCLI.h
@@ -14,11 +14,14 @@
 
 #include <QtCore/QObject>
 
+#include "Oven.h"
+
 class BakerCLI : public QObject {
     Q_OBJECT   
 
 public:
-    void bakeFile(const QString inputFilename, const QString outputFilename);
+    BakerCLI(Oven* parent);
+    void bakeFile(const QString inputFilename, const QString outputPath);
 
 private slots:
     void handleFinishedBaker();

--- a/tools/oven/src/BakerCLI.h
+++ b/tools/oven/src/BakerCLI.h
@@ -1,0 +1,32 @@
+//
+//  BakerCLI.h
+//  tools/oven/src
+//
+//  Created by Robbie Uvanni on 6/6/17.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_BakerCLI_h
+#define hifi_BakerCLI_h
+
+#include <QString>
+#include <QUrl>
+
+#include <QtCore/QThread>
+#include <QtCore/QObject>
+
+class BakerCLI : public QObject {
+    Q_OBJECT   
+
+public:
+    void bakeFile(const QString inputFilename, const QString outputFilename);
+
+private slots:
+    void handleFinishedBaker();
+
+};
+
+#endif // hifi_BakerCLI_h

--- a/tools/oven/src/BakerCLI.h
+++ b/tools/oven/src/BakerCLI.h
@@ -12,10 +12,6 @@
 #ifndef hifi_BakerCLI_h
 #define hifi_BakerCLI_h
 
-#include <QString>
-#include <QUrl>
-
-#include <QtCore/QThread>
 #include <QtCore/QObject>
 
 class BakerCLI : public QObject {

--- a/tools/oven/src/Oven.cpp
+++ b/tools/oven/src/Oven.cpp
@@ -58,9 +58,14 @@ Oven::Oven(int argc, char* argv[]) :
     setupFBXBakerThread();
 
     // check if we were passed any command line arguments that would tell us just to run without the GUI
-    if (parser.isSet(CLI_INPUT_PARAMETER) && parser.isSet(CLI_OUTPUT_PARAMETER)) {
-        BakerCLI* cli = new BakerCLI(this);
-        cli->bakeFile(parser.value(CLI_INPUT_PARAMETER), parser.value(CLI_OUTPUT_PARAMETER));
+    if (parser.isSet(CLI_INPUT_PARAMETER) || parser.isSet(CLI_OUTPUT_PARAMETER)) {
+        if (parser.isSet(CLI_INPUT_PARAMETER) && parser.isSet(CLI_OUTPUT_PARAMETER)) {
+            BakerCLI* cli = new BakerCLI(this);
+            cli->bakeFile(parser.value(CLI_INPUT_PARAMETER), parser.value(CLI_OUTPUT_PARAMETER));
+        } else {
+            parser.showHelp();
+            QApplication::quit();
+        } 
     } else {
         // setup the GUI
         _mainWindow = new OvenMainWindow;

--- a/tools/oven/src/Oven.cpp
+++ b/tools/oven/src/Oven.cpp
@@ -12,13 +12,11 @@
 #include <QtCore/QDebug>
 #include <QtCore/QThread>
 #include <QtCore/QCommandLineParser>
-#include <QtCore/QCoreApplication>
 
 #include <image/Image.h>
 #include <SettingInterface.h>
 
 #include "ui/OvenMainWindow.h"
-#include "ModelBakingLoggingCategory.h"
 #include "Oven.h"
 #include "BakerCli.h"
 
@@ -37,11 +35,10 @@ Oven::Oven(int argc, char* argv[]) :
     QCommandLineParser parser;
    
     parser.addOptions({
-        { "i", "Input filename.", "input" },
-        { "o", "Output filename.", "output" }
+        { "i", "Path to file that you would like to bake.", "input" },
+        { "o", "Path to folder that will be used as output.", "output" }
     });
     parser.addHelpOption();
-
     parser.process(*this);
 
     // enable compression in image library, except for cube maps

--- a/tools/oven/src/Oven.cpp
+++ b/tools/oven/src/Oven.cpp
@@ -22,6 +22,9 @@
 
 static const QString OUTPUT_FOLDER = "/Users/birarda/code/hifi/lod/test-oven/export";
 
+static const QString CLI_INPUT_PARAMETER = "i";
+static const QString CLI_OUTPUT_PARAMETER = "o";
+
 Oven::Oven(int argc, char* argv[]) :
     QApplication(argc, argv)
 {
@@ -35,8 +38,8 @@ Oven::Oven(int argc, char* argv[]) :
     QCommandLineParser parser;
    
     parser.addOptions({
-        { "i", "Path to file that you would like to bake.", "input" },
-        { "o", "Path to folder that will be used as output.", "output" }
+        { CLI_INPUT_PARAMETER, "Path to file that you would like to bake.", "input" },
+        { CLI_OUTPUT_PARAMETER, "Path to folder that will be used as output.", "output" }
     });
     parser.addHelpOption();
     parser.process(*this);
@@ -55,9 +58,9 @@ Oven::Oven(int argc, char* argv[]) :
     setupFBXBakerThread();
 
     // check if we were passed any command line arguments that would tell us just to run without the GUI
-    if (parser.isSet("i") && parser.isSet("o")) {
-        BakerCLI* cli = new BakerCLI();
-        cli->bakeFile(parser.value("i"), parser.value("o"));
+    if (parser.isSet(CLI_INPUT_PARAMETER) && parser.isSet(CLI_OUTPUT_PARAMETER)) {
+        BakerCLI* cli = new BakerCLI(this);
+        cli->bakeFile(parser.value(CLI_INPUT_PARAMETER), parser.value(CLI_OUTPUT_PARAMETER));
     } else {
         // setup the GUI
         _mainWindow = new OvenMainWindow;


### PR DESCRIPTION
Test Plan

1. Download `teapot.fbx` from [here](https://github.com/McNopper/GraphicsEngine/blob/master/GE_Binaries/teapot.fbx)
2. Copy the `teapot.fbx` to the root folder of your `oven.exe`
3. Using the oven tool (on Windows, `oven.exe`, I am unsure if this is included in the PR installer) verify that you can use the CLI as an alternative to the GUI
4. In order to test the CLI, open a command prompt (`Windows Key + R -> cmd-> Enter`) and navigate to the folder containing your `oven.exe` and `teapot.fbx`
5. Run the following command: `oven.exe -i teapot.fbx -o ./`

You should see something like:
```
hifi.gpu: [TEXTURE TRANSFER SUPPORT]
        idealThreadCount: 12
        RECOMMENDED enableSparseTextures: true
hifi.shared: Settings file: "[...]Oven.json"
hifi.shared: Settings thread started.
hifi.model-baking: Baking QUrl("file:teapot.fbx")
hifi.model-baking: Creating FBX output folder ".//teapot-3/"
hifi.model-baking: Imported QUrl("file:teapot.fbx") to FbxScene
hifi.model-baking: Exported QUrl("file:teapot.fbx") with re-written paths to ".//teapot-3/baked/teapot.baked.fbx"
hifi.model-baking: Finished baking QUrl("file:teapot.fbx")
hifi.model-baking: Finished baking file.

```