### PR TITLE
Fix SharedNodePointer leak

### DIFF
--- a/assignment-client/src/octree/OctreeInboundPacketProcessor.cpp
+++ b/assignment-client/src/octree/OctreeInboundPacketProcessor.cpp
@@ -47,7 +47,7 @@ void OctreeInboundPacketProcessor::resetStats() {
     _singleSenderStats.clear();
 }
 
-unsigned long OctreeInboundPacketProcessor::getMaxWait() const {
+uint32_t OctreeInboundPacketProcessor::getMaxWait() const {
     // calculate time until next sendNackPackets()
     quint64 nextNackTime = _lastNackTime + TOO_LONG_SINCE_LAST_NACK;
     quint64 now = usecTimestampNow();

--- a/assignment-client/src/octree/OctreeInboundPacketProcessor.h
+++ b/assignment-client/src/octree/OctreeInboundPacketProcessor.h
@@ -80,7 +80,7 @@ protected:
 
     virtual void processPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) override;
 
-    virtual unsigned long getMaxWait() const override;
+    virtual uint32_t getMaxWait() const override;
     virtual void preProcess() override;
     virtual void midProcess() override;
 

--- a/libraries/networking/src/Node.h
+++ b/libraries/networking/src/Node.h
@@ -40,7 +40,7 @@ public:
     Node(const QUuid& uuid, NodeType_t type,
          const HifiSockAddr& publicSocket, const HifiSockAddr& localSocket,
          const NodePermissions& permissions, const QUuid& connectionSecret = QUuid(),
-         QObject* parent = 0);
+         QObject* parent = nullptr);
 
     bool operator==(const Node& otherNode) const { return _uuid == otherNode._uuid; }
     bool operator!=(const Node& otherNode) const { return !(*this == otherNode); }

--- a/libraries/networking/src/ReceivedPacketProcessor.h
+++ b/libraries/networking/src/ReceivedPacketProcessor.h
@@ -65,7 +65,7 @@ protected:
     /// Implements generic processing behavior for this thread.
     virtual bool process() override;
 
-    /// Determines the timeout of the wait when there are no packets to process. Default value means no timeout
+    /// Determines the timeout of the wait when there are no packets to process. Default value is 100ms to allow for regular event processing.
     virtual unsigned long getMaxWait() const { return MAX_WAIT_TIME; }
 
     /// Override to do work before the packets processing loop. Default does nothing.

--- a/libraries/networking/src/ReceivedPacketProcessor.h
+++ b/libraries/networking/src/ReceivedPacketProcessor.h
@@ -20,6 +20,8 @@
 class ReceivedPacketProcessor : public GenericThread {
     Q_OBJECT
 public:
+    static const unsigned long MAX_WAIT_TIME { 100 };
+
     ReceivedPacketProcessor();
 
     /// Add packet from network receive thread to the processing queue.
@@ -64,7 +66,7 @@ protected:
     virtual bool process() override;
 
     /// Determines the timeout of the wait when there are no packets to process. Default value means no timeout
-    virtual unsigned long getMaxWait() const { return ULONG_MAX; }
+    virtual unsigned long getMaxWait() const { return MAX_WAIT_TIME; }
 
     /// Override to do work before the packets processing loop. Default does nothing.
     virtual void preProcess() { }

--- a/libraries/networking/src/ReceivedPacketProcessor.h
+++ b/libraries/networking/src/ReceivedPacketProcessor.h
@@ -20,7 +20,7 @@
 class ReceivedPacketProcessor : public GenericThread {
     Q_OBJECT
 public:
-    static const unsigned long MAX_WAIT_TIME { 100 };
+    static const uint64_t MAX_WAIT_TIME { 100 }; // Max wait time in ms
 
     ReceivedPacketProcessor();
 
@@ -66,7 +66,7 @@ protected:
     virtual bool process() override;
 
     /// Determines the timeout of the wait when there are no packets to process. Default value is 100ms to allow for regular event processing.
-    virtual unsigned long getMaxWait() const { return MAX_WAIT_TIME; }
+    virtual uint32_t getMaxWait() const { return MAX_WAIT_TIME; }
 
     /// Override to do work before the packets processing loop. Default does nothing.
     virtual void preProcess() { }

--- a/libraries/octree/src/JurisdictionListener.cpp
+++ b/libraries/octree/src/JurisdictionListener.cpp
@@ -35,14 +35,13 @@ void JurisdictionListener::nodeKilled(SharedNodePointer node) {
 }
 
 bool JurisdictionListener::queueJurisdictionRequest() {
-    auto packet = NLPacket::create(PacketType::JurisdictionRequest, 0);
-    
     auto nodeList = DependencyManager::get<NodeList>();
 
     int nodeCount = 0;
 
     nodeList->eachNode([&](const SharedNodePointer& node) {
         if (node->getType() == getNodeType() && node->getActiveSocket()) {
+            auto packet = NLPacket::create(PacketType::JurisdictionRequest, 0);
             _packetSender.queuePacketForSending(node, std::move(packet));
             nodeCount++;
         }

--- a/libraries/octree/src/JurisdictionSender.cpp
+++ b/libraries/octree/src/JurisdictionSender.cpp
@@ -41,8 +41,6 @@ bool JurisdictionSender::process() {
 
     // call our ReceivedPacketProcessor base class process so we'll get any pending packets
     if (continueProcessing && (continueProcessing = ReceivedPacketProcessor::process())) {
-        auto packet = (_jurisdictionMap) ? _jurisdictionMap->packIntoPacket()
-                                         : JurisdictionMap::packEmptyJurisdictionIntoMessage(getNodeType());
         int nodeCount = 0;
 
         lockRequestingNodes();
@@ -53,6 +51,8 @@ bool JurisdictionSender::process() {
             SharedNodePointer node = DependencyManager::get<NodeList>()->nodeWithUUID(nodeUUID);
 
             if (node && node->getActiveSocket()) {
+                auto packet = (_jurisdictionMap) ? _jurisdictionMap->packIntoPacket()
+                                                 : JurisdictionMap::packEmptyJurisdictionIntoMessage(getNodeType());
                 _packetSender.queuePacketForSending(node, std::move(packet));
                 nodeCount++;
             }

--- a/libraries/shared/src/GenericThread.cpp
+++ b/libraries/shared/src/GenericThread.cpp
@@ -10,6 +10,7 @@
 //
 
 #include <QDebug>
+#include <QtCore/QCoreApplication>
 
 #include "GenericThread.h"
 
@@ -73,6 +74,7 @@ void GenericThread::threadRoutine() {
     }
 
     while (!_stopThread) {
+        QCoreApplication::processEvents();
 
         // override this function to do whatever your class actually does, return false to exit thread early
         if (!process()) {


### PR DESCRIPTION
This PR fixes 3 separate issues that were causing us to keep all nodes alive until the end of the application's lifetime.

1) A lambda was capturing a strong ref for each node.
2) Nodes were managed by a shared pointer AND had a parent.
3) JurisdicitonListener was connected to `LimitedNodeList::nodeKilled` but would never process the event:
      1) JurisdictionListener thread was blocked on a wait condition with a gigantic timeout (we do not receive jurisdiction packets anymore) effectively locking that thread.
      2) JurisdictionListener thread was not processing events

## Test Plan:
- Standard smoke test
- Make sure you can connect to domains and that you are connected to all 6 servers.
- Jump from domains to domains many times (Ideally 20+ times).
    - Go back and forth between dev-welcome and you sandbox a few times.
    - Make sure to log in/log out every so often during the test

[Bug](https://highfidelity.fogbugz.com/f/cases/4408/Node-objects-are-not-being-cleaned-up-until-Interface-is-stopped)