### PR TITLE
hotfix for server-console watching via pid rather than marker

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -199,7 +199,7 @@ int main(int argc, const char* argv[]) {
         bool serverContentPathOptionIsSet = parser.isSet(serverContentPathOption);
         QString serverContentPath = serverContentPathOptionIsSet ? parser.value(serverContentPathOption) : QString();
         if (runServer) {
-            SandboxUtils::runLocalSandbox(serverContentPath, true, RUNNING_MARKER_FILENAME, noUpdater);
+            SandboxUtils::runLocalSandbox(serverContentPath, true, noUpdater);
         }
 
         Application app(argc, const_cast<char**>(argv), startupTime, runningMarkerExisted);

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -190,7 +190,7 @@ int main(int argc, const char* argv[]) {
 
     int exitCode;
     {
-        RunningMarker runningMarker(nullptr, RUNNING_MARKER_FILENAME);
+        RunningMarker runningMarker(RUNNING_MARKER_FILENAME);
         bool runningMarkerExisted = runningMarker.fileExists();
         runningMarker.writeRunningMarkerFile();
 
@@ -203,9 +203,6 @@ int main(int argc, const char* argv[]) {
         }
 
         Application app(argc, const_cast<char**>(argv), startupTime, runningMarkerExisted);
-
-        // Now that the main event loop is setup, launch running marker thread
-        runningMarker.startRunningMarker();
 
         // If we failed the OpenGLVersion check, log it.
         if (override) {

--- a/libraries/networking/src/SandboxUtils.cpp
+++ b/libraries/networking/src/SandboxUtils.cpp
@@ -74,8 +74,7 @@ void runLocalSandbox(QString contentPath, bool autoShutdown, bool noUpdater) {
 
     if (autoShutdown) {
         auto pid = qApp->applicationPid();
-        qCDebug(networking) << "autoShutdown pid is" << pid;
-        args << "--watchProcessShutdown" << QString::number(pid);
+        args << "--shutdownWith" << QString::number(pid);
     }
 
     if (noUpdater) {

--- a/libraries/networking/src/SandboxUtils.cpp
+++ b/libraries/networking/src/SandboxUtils.cpp
@@ -52,9 +52,8 @@ bool readStatus(QByteArray statusData) {
     return false;
 }
 
-void runLocalSandbox(QString contentPath, bool autoShutdown, QString runningMarkerName, bool noUpdater) {
+void runLocalSandbox(QString contentPath, bool autoShutdown, bool noUpdater) {
     QString serverPath = "./server-console/server-console.exe";
-    qCDebug(networking) << "Running marker path is: " << runningMarkerName;
     qCDebug(networking) << "Server path is: " << serverPath;
     qCDebug(networking) << "autoShutdown: " << autoShutdown;
     qCDebug(networking) << "noUpdater: " << noUpdater;
@@ -74,8 +73,9 @@ void runLocalSandbox(QString contentPath, bool autoShutdown, QString runningMark
     }
 
     if (autoShutdown) {
-        QString interfaceRunningStateFile = RunningMarker::getMarkerFilePath(runningMarkerName);
-        args << "--shutdownWatcher" << interfaceRunningStateFile;
+        auto pid = qApp->applicationPid();
+        qCDebug(networking) << "autoShutdown pid is" << pid;
+        args << "--watchProcessShutdown" << QString::number(pid);
     }
 
     if (noUpdater) {

--- a/libraries/networking/src/SandboxUtils.cpp
+++ b/libraries/networking/src/SandboxUtils.cpp
@@ -73,7 +73,7 @@ void runLocalSandbox(QString contentPath, bool autoShutdown, bool noUpdater) {
     }
 
     if (autoShutdown) {
-        auto pid = qApp->applicationPid();
+        auto pid = QCoreApplication::applicationPid();
         args << "--shutdownWith" << QString::number(pid);
     }
 

--- a/libraries/networking/src/SandboxUtils.h
+++ b/libraries/networking/src/SandboxUtils.h
@@ -21,7 +21,7 @@ namespace SandboxUtils {
 
     QNetworkReply* getStatus();
     bool readStatus(QByteArray statusData);
-    void runLocalSandbox(QString contentPath, bool autoShutdown, QString runningMarkerName, bool noUpdater);
+    void runLocalSandbox(QString contentPath, bool autoShutdown, bool noUpdater);
 };
 
 #endif // hifi_SandboxUtils_h

--- a/libraries/shared/src/RunningMarker.h
+++ b/libraries/shared/src/RunningMarker.h
@@ -12,21 +12,14 @@
 #ifndef hifi_RunningMarker_h
 #define hifi_RunningMarker_h
 
-#include <QObject>
 #include <QString>
-
-class QThread;
-class QTimer;
 
 class RunningMarker {
 public:
-    RunningMarker(QObject* parent, QString name);
+    RunningMarker(QString name);
     ~RunningMarker();
 
-    void startRunningMarker();
-
     QString getFilePath() const;
-    static QString getMarkerFilePath(QString name);
 
     bool fileExists() const;
 
@@ -34,10 +27,7 @@ public:
     void deleteRunningMarkerFile();
 
 private:
-    QObject* _parent { nullptr };
     QString _name;
-    QThread* _runningMarkerThread { nullptr };
-    QTimer* _runningMarkerTimer { nullptr };
 };
 
 #endif // hifi_RunningMarker_h

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -823,8 +823,7 @@ const notificationIcon = path.join(__dirname, '../resources/console-notification
 
 function isProcessRunning(pid) {
     try {
-        running = process.kill(pid, 0);
-        return true;
+        return process.kill(pid, 0);
     } catch (e) {
     }
     return false;

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -902,32 +902,6 @@ function onContentLoaded() {
                 clearTimeout(checkProcessInterval);
                 forcedShutdown();
             }
-
-    // If we were launched with the shutdownWatcher option, then we need to watch for the interface app
-    // shutting down. The interface app will regularly update a running state file which we will check.
-    // If the file doesn't exist or stops updating for a significant amount of time, we will shut down.
-    if (argv.shutdownWatcher) {
-        log.debug("Shutdown watcher requested... argv.shutdownWatcher:", argv.shutdownWatcher);
-        var MAX_TIME_SINCE_EDIT = 5000; // 5 seconds between updates
-        var firstAttemptToCheck = new Date().getTime();
-        var shutdownWatchInterval = setInterval(function(){
-            var stats = fs.stat(argv.shutdownWatcher, function(err, stats) {
-                if (err) {
-                    var sinceFirstCheck = new Date().getTime() - firstAttemptToCheck;
-                    if (sinceFirstCheck > MAX_TIME_SINCE_EDIT) {
-                        log.debug("Running state file is missing, assume interface has shutdown... shutting down snadbox.");
-                        forcedShutdown();
-                        clearTimeout(shutdownWatchInterval);
-                    }
-                } else {
-                    var sinceEdit = new Date().getTime() - stats.mtime.getTime();
-                    if (sinceEdit > MAX_TIME_SINCE_EDIT) {
-                        log.debug("Running state of interface hasn't updated in MAX time... shutting down.");
-                        forcedShutdown();
-                        clearTimeout(shutdownWatchInterval);
-                    }
-                }
-            });
         }, 1000);
     }
 }

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -823,6 +823,9 @@ const notificationIcon = path.join(__dirname, '../resources/console-notification
 
 function isProcessRunning(pid) {
     try {
+        // Sending a signal of 0 is effectively a NOOP.
+        // If sending the signal is successful, kill will return true.
+        // If the process is not running, an exception will be thrown.
         return process.kill(pid, 0);
     } catch (e) {
     }

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -890,18 +890,18 @@ function onContentLoaded() {
         startInterface();
     }
 
-    if (argv.watchProcessShutdown) {
-        let pid = argv.watchProcessShutdown;
-        console.log("Watching process: ", pid);
-        let watchProcessInterval = setInterval(function() {
+    // If we were launched with the shutdownWith option, then we need to shutdown when that process (pid)
+    // is no longer running.
+    if (argv.shutdownWith) {
+        let pid = argv.shutdownWith;
+        console.log("Shutting down with process: ", pid);
+        let checkProcessInterval = setInterval(function() {
             let isRunning = isProcessRunning(pid);
             if (!isRunning) {
                 log.debug("Watched process is no longer running, shutting down");
-                clearTimeout(watchProcessInterval);
+                clearTimeout(checkProcessInterval);
                 forcedShutdown();
             }
-        }, 5000);
-    }
 
     // If we were launched with the shutdownWatcher option, then we need to watch for the interface app
     // shutting down. The interface app will regularly update a running state file which we will check.

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -821,6 +821,15 @@ for (var key in trayIcons) {
 
 const notificationIcon = path.join(__dirname, '../resources/console-notification.png');
 
+function isProcessRunning(pid) {
+    try {
+        running = process.kill(pid, 0);
+        return true;
+    } catch (e) {
+    }
+    return false;
+}
+
 function onContentLoaded() {
     // Disable splash window for now.
     // maybeShowSplash();
@@ -880,6 +889,19 @@ function onContentLoaded() {
     if (argv.launchInterface) {
         log.debug("Interface launch requested... argv.launchInterface:", argv.launchInterface);
         startInterface();
+    }
+
+    if (argv.watchProcessShutdown) {
+        let pid = argv.watchProcessShutdown;
+        console.log("Watching process: ", pid);
+        let watchProcessInterval = setInterval(function() {
+            let isRunning = isProcessRunning(pid);
+            if (!isRunning) {
+                log.debug("Watched process is no longer running, shutting down");
+                clearTimeout(watchProcessInterval);
+                forcedShutdown();
+            }
+        }, 5000);
     }
 
     // If we were launched with the shutdownWatcher option, then we need to watch for the interface app


### PR DESCRIPTION
To test:

-Run special test build of this PR from steam (@atlante45 has the details)
-Sandbox should start
-Close interface after 30 seconds
-Sandbox should close shortly thereafter