### PR TITLE
Monitor display of texture

### DIFF
--- a/interface/resources/qml/hifi/SpectatorCamera.qml
+++ b/interface/resources/qml/hifi/SpectatorCamera.qml
@@ -242,7 +242,7 @@ Rectangle {
             labelTextOn: "Camera View";
             labelGlyphOnText: hifi.glyphs.alert;
             onCheckedChanged: {
-                sendToScript({method: (checked ? 'showCameraViewOnMonitor' : 'showHmdPreviewOnMonitor')});
+                sendToScript({method: 'setMonitorShowsCameraView', params: checked});
             }
         }
 

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -284,6 +284,11 @@ void WindowScriptingInterface::copyToClipboard(const QString& text) {
     QApplication::clipboard()->setText(text);
 }
 
+
+bool WindowScriptingInterface::setDisplayTexture(const QString& name) {
+    return  qApp->getActiveDisplayPlugin()->setDisplayTexture(name);   // Plugins that don't know how, answer false.
+}
+
 void WindowScriptingInterface::takeSnapshot(bool notify, bool includeAnimated, float aspectRatio) {
     qApp->takeSnapshot(notify, includeAnimated, aspectRatio);
 }

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -62,6 +62,7 @@ public slots:
     void displayAnnouncement(const QString& message);
     void shareSnapshot(const QString& path, const QUrl& href = QUrl(""));
     bool isPhysicsEnabled();
+    bool setDisplayTexture(const QString& name);
 
     int openMessageBox(QString title, QString text, int buttons, int defaultButton);
     void updateMessageBox(int id, QString title, QString text, int buttons, int defaultButton);

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -616,7 +616,8 @@ void OpenGLDisplayPlugin::compositeLayers() {
 
 void OpenGLDisplayPlugin::internalPresent() {
     render([&](gpu::Batch& batch) {
-        auto viewport = ivec4(uvec2(0), getSurfacePixels());
+        uvec2 dims = _displayTexture ? uvec2(_displayTexture->getDimensions()) : getSurfacePixels();
+        auto viewport = ivec4(uvec2(0),  dims);
         renderFromTexture(batch, _displayTexture ? _displayTexture : _compositeFramebuffer->getRenderBuffer(0), viewport, viewport);
      });
     swapBuffers();

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -616,6 +616,7 @@ void OpenGLDisplayPlugin::compositeLayers() {
 
 void OpenGLDisplayPlugin::internalPresent() {
     render([&](gpu::Batch& batch) {
+        // Note: _displayTexture must currently be the same size as the display.
         uvec2 dims = _displayTexture ? uvec2(_displayTexture->getDimensions()) : getSurfacePixels();
         auto viewport = ivec4(uvec2(0),  dims);
         renderFromTexture(batch, _displayTexture ? _displayTexture : _compositeFramebuffer->getRenderBuffer(0), viewport, viewport);
@@ -702,16 +703,17 @@ void OpenGLDisplayPlugin::withMainThreadContext(std::function<void()> f) const {
 }
 
 bool OpenGLDisplayPlugin::setDisplayTexture(const QString& name) {
+    // Note: it is the caller's responsibility to keep the network texture in cache.
     if (name.isEmpty()) {
         _displayTexture.reset();
         return true;
     }
     auto textureCache = DependencyManager::get<TextureCache>();
-    auto networkTexture = textureCache->getTexture(name);
-    if (!networkTexture) {
+    auto displayNetworkTexture = textureCache->getTexture(name);
+    if (!displayNetworkTexture) {
         return false;
     }
-    _displayTexture = networkTexture->getGPUTexture();
+    _displayTexture = displayNetworkTexture->getGPUTexture();
     return !!_displayTexture;
 }
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -57,6 +57,7 @@ public:
         return getSurfaceSize();
     }
 
+    virtual bool setDisplayTexture(const QString& name) override;
     QImage getScreenshot(float aspectRatio = 0.0f) const override;
 
     float presentRate() const override;
@@ -109,6 +110,7 @@ protected:
     // Plugin specific functionality to send the composed scene to the output window or device
     virtual void internalPresent();
 
+    void renderFromTexture(gpu::Batch& batch, const gpu::TexturePointer texture, glm::ivec4 viewport, const glm::ivec4 scissor);
     virtual void updateFrameData();
 
     void withMainThreadContext(std::function<void()> f) const;
@@ -134,6 +136,7 @@ protected:
     gpu::PipelinePointer _simplePipeline;
     gpu::PipelinePointer _presentPipeline;
     gpu::PipelinePointer _cursorPipeline;
+    gpu::TexturePointer _displayTexture{};
     float _compositeOverlayAlpha { 1.0f };
 
     struct CursorData {

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -27,6 +27,7 @@
 #include <gpu/StandardShaderLib.h>
 #include <gpu/gl/GLBackend.h>
 
+#include <TextureCache.h>
 #include <PathUtils.h>
 
 #include "../Logging.h"
@@ -211,7 +212,13 @@ void HmdDisplayPlugin::internalPresent() {
     // Composite together the scene, overlay and mouse cursor
     hmdPresent();
 
-    if (!_disablePreview) {
+    if (_displayTexture) {
+        auto viewport = getViewportForSourceSize(uvec2(_displayTexture->getDimensions()));
+        render([&](gpu::Batch& batch) {
+            renderFromTexture(batch, _displayTexture, viewport, viewport);
+        });
+        swapBuffers();
+    } else if (!_disablePreview) {
         // screen preview mirroring
         auto sourceSize = _renderTargetSize;
         if (_monoPreview) {
@@ -272,16 +279,7 @@ void HmdDisplayPlugin::internalPresent() {
 
                 viewport.z *= 2;
             }
-
-            batch.enableStereo(false);
-            batch.resetViewTransform();
-            batch.setFramebuffer(gpu::FramebufferPointer());
-            batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, vec4(0));
-            batch.setStateScissorRect(scissor); // was viewport
-            batch.setViewportTransform(viewport);
-            batch.setResourceTexture(0, _compositeFramebuffer->getRenderBuffer(0));
-            batch.setPipeline(_presentPipeline);
-            batch.draw(gpu::TRIANGLE_STRIP, 4);
+            renderFromTexture(batch, _compositeFramebuffer->getRenderBuffer(0), viewport, scissor);
         });
         swapBuffers();
     } else if (_clearPreviewFlag) {
@@ -310,15 +308,7 @@ void HmdDisplayPlugin::internalPresent() {
         auto viewport = getViewportForSourceSize(uvec2(_previewTexture->getDimensions()));
 
         render([&](gpu::Batch& batch) {
-            batch.enableStereo(false);
-            batch.resetViewTransform();
-            batch.setFramebuffer(gpu::FramebufferPointer());
-            batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, vec4(0));
-            batch.setStateScissorRect(viewport);
-            batch.setViewportTransform(viewport);
-            batch.setResourceTexture(0, _previewTexture);
-            batch.setPipeline(_presentPipeline);
-            batch.draw(gpu::TRIANGLE_STRIP, 4);
+            renderFromTexture(batch, _previewTexture, viewport, viewport);
         });
         _clearPreviewFlag = false;
         swapBuffers();

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -213,7 +213,8 @@ void HmdDisplayPlugin::internalPresent() {
     hmdPresent();
 
     if (_displayTexture) {
-        auto viewport = getViewportForSourceSize(uvec2(_displayTexture->getDimensions()));
+        uvec2 dims = uvec2(_displayTexture->getDimensions());
+        auto viewport = ivec4(uvec2(0), dims);
         render([&](gpu::Batch& batch) {
             renderFromTexture(batch, _displayTexture, viewport, viewport);
         });

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -213,6 +213,7 @@ void HmdDisplayPlugin::internalPresent() {
     hmdPresent();
 
     if (_displayTexture) {
+        // Note: _displayTexture must currently be the same size as the display.
         uvec2 dims = uvec2(_displayTexture->getDimensions());
         auto viewport = ivec4(uvec2(0), dims);
         render([&](gpu::Batch& batch) {

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -184,6 +184,9 @@ public:
     // will query the underlying hmd api to compute the most recent head pose
     virtual bool beginFrameRender(uint32_t frameIndex) { return true; }
 
+    // Set the texture to display on the monitor and return true, if allowed. Empty string resets.
+    virtual bool setDisplayTexture(const QString& name) { return false; }
+
     virtual float devicePixelRatio() { return 1.0f; }
     // Rate at which we render frames
     virtual float renderRate() const { return -1.0f; }

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -117,6 +117,7 @@
             orientation: flip(cameraRotation),
             scale: -0.35,
         });
+        setDisplay(monitorShowsCameraView);
     }
 
     //
@@ -147,6 +148,12 @@
         }
         camera = false;
         viewFinderOverlay = false;
+        setDisplay(monitorShowsCameraView);
+    }
+
+    function onHMDChanged(isHMDMode) {
+        // Will also eventually enable disable app, camera, etc.
+        setDisplay(monitorShowsCameraView);
     }
 
     //
@@ -175,6 +182,7 @@
         tablet.screenChanged.connect(onTabletScreenChanged);
         Window.domainChanged.connect(spectatorCameraOff);
         Controller.keyPressEvent.connect(keyPressEvent);
+        HMD.displayModeChanged.connect(onHMDChanged);
         viewFinderOverlay = false;
         camera = false;
     }
@@ -206,7 +214,11 @@
         }
     }
 
-    const CAMERA_PREVIEW_WHEN_OFF = "http://1.bp.blogspot.com/-1GABEq__054/T03B00j_OII/AAAAAAAAAa8/jo55LcvEPHI/s1600/Winning.jpg"; // FIXME instructions?
+    function setDisplay(showCameraView) {
+        // It would be fancy if (showCameraView && !isUpdateRenderWired) would show instructions, but that's out of scope for now.
+        var url = (showCameraView && isUpdateRenderWired) ? "http://selfieFrame" : "";
+        Window.setDisplayTexture(url);
+    }
     const MONITOR_SHOWS_CAMERA_VIEW_DEFAULT = false;
     var monitorShowsCameraView = !!Settings.getValue('spectatorCamera/monitorShowsCameraView', MONITOR_SHOWS_CAMERA_VIEW_DEFAULT);
     function setMonitorShowsCameraView(showCameraView) {
@@ -214,8 +226,7 @@
             return;
         }
         monitorShowsCameraView = showCameraView;
-        var url = (showCameraView && isUpdateRenderWired) ? "http://selfieFrame" : "";
-        Window.setDisplayTexture(url);
+        setDisplay(showCameraView);
         Settings.setValue('spectatorCamera/monitorShowsCameraView', showCameraView);
     }
     function setMonitorShowsCameraViewAndSendToQml(showCameraView) {
@@ -345,6 +356,7 @@
         tablet.removeButton(button);
         button.clicked.disconnect(onTabletButtonClicked);
         tablet.screenChanged.disconnect(onTabletScreenChanged);
+        HMD.displayModeChanged.disconnect(onHMDChanged);
         Controller.keyPressEvent.disconnect(keyPressEvent);
     }
 

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -174,6 +174,7 @@
         button.clicked.connect(onTabletButtonClicked);
         tablet.screenChanged.connect(onTabletScreenChanged);
         Window.domainChanged.connect(spectatorCameraOff);
+        Controller.keyPressEvent.connect(keyPressEvent);
         viewFinderOverlay = false;
         camera = false;
     }
@@ -213,10 +214,18 @@
             return;
         }
         monitorShowsCameraView = showCameraView;
-        var url = showCameraView ? (isUpdateRenderWired ? "http://selfieFrame" : CAMERA_PREVIEW_WHEN_OFF) : "";
-        print('setDisplayTexture', url,
-            Window.setDisplayTexture(url));
+        var url = (showCameraView && isUpdateRenderWired) ? "http://selfieFrame" : "";
+        Window.setDisplayTexture(url);
         Settings.setValue('spectatorCamera/monitorShowsCameraView', showCameraView);
+    }
+    function setMonitorShowsCameraViewAndSendToQml(showCameraView) {
+        setMonitorShowsCameraView(showCameraView);
+        sendToQml({ method: 'updateMonitorShowsSwitch', params: showCameraView });
+    }
+    function keyPressEvent(event) {
+        if ((event.text === "0") && !event.isAutoRepeat && !event.isShifted && !event.isMeta && event.isControl && !event.isAlt) {
+            setMonitorShowsCameraViewAndSendToQml(!monitorShowsCameraView);
+        }
     }
 
     //
@@ -243,9 +252,8 @@
             shouldActivateButton = true;
             tablet.loadQMLSource("../SpectatorCamera.qml");
             onSpectatorCameraScreen = true;
-            sendToQml({ method: 'updateSpectatorCameraCheckbox', params: !!camera });;
-            setMonitorShowsCameraView(monitorShowsCameraView);
-            sendToQml({ method: 'updateMonitorShowsSwitch', params: monitorShowsCameraView });
+            sendToQml({ method: 'updateSpectatorCameraCheckbox', params: !!camera });
+            setMonitorShowsCameraViewAndSendToQml(monitorShowsCameraView);
         }
     }
 
@@ -337,6 +345,7 @@
         tablet.removeButton(button);
         button.clicked.disconnect(onTabletButtonClicked);
         tablet.screenChanged.disconnect(onTabletScreenChanged);
+        Controller.keyPressEvent.disconnect(keyPressEvent);
     }
 
     //

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -205,6 +205,20 @@
         }
     }
 
+    const CAMERA_PREVIEW_WHEN_OFF = "http://1.bp.blogspot.com/-1GABEq__054/T03B00j_OII/AAAAAAAAAa8/jo55LcvEPHI/s1600/Winning.jpg"; // FIXME instructions?
+    const MONITOR_SHOWS_CAMERA_VIEW_DEFAULT = false;
+    var monitorShowsCameraView = !!Settings.getValue('spectatorCamera/monitorShowsCameraView', MONITOR_SHOWS_CAMERA_VIEW_DEFAULT);
+    function setMonitorShowsCameraView(showCameraView) {
+        if (showCameraView === monitorShowsCameraView) {
+            return;
+        }
+        monitorShowsCameraView = showCameraView;
+        var url = showCameraView ? (isUpdateRenderWired ? "http://selfieFrame" : CAMERA_PREVIEW_WHEN_OFF) : "";
+        print('setDisplayTexture', url,
+            Window.setDisplayTexture(url));
+        Settings.setValue('spectatorCamera/monitorShowsCameraView', showCameraView);
+    }
+
     //
     // Function Name: onTabletButtonClicked()
     //
@@ -229,8 +243,9 @@
             shouldActivateButton = true;
             tablet.loadQMLSource("../SpectatorCamera.qml");
             onSpectatorCameraScreen = true;
-            sendToQml({ method: 'updateSpectatorCameraCheckbox', params: !!camera });
-            sendToQml({ method: 'updateMonitorShowsSwitch', params: !!Settings.getValue('spectatorCamera/monitorShowsCameraView', false) });
+            sendToQml({ method: 'updateSpectatorCameraCheckbox', params: !!camera });;
+            setMonitorShowsCameraView(monitorShowsCameraView);
+            sendToQml({ method: 'updateMonitorShowsSwitch', params: monitorShowsCameraView });
         }
     }
 
@@ -293,13 +308,8 @@
             case 'spectatorCameraOff':
                 spectatorCameraOff();
                 break;
-            case 'showHmdPreviewOnMonitor':
-                print('FIXME: showHmdPreviewOnMonitor');
-                Settings.setValue('spectatorCamera/monitorShowsCameraView', false);
-                break;
-            case 'showCameraViewOnMonitor':
-                print('FIXME: showCameraViewOnMonitor');
-                Settings.setValue('spectatorCamera/monitorShowsCameraView', true);
+            case 'setMonitorShowsCameraView':
+                setMonitorShowsCameraView(message.params);
                 break;
             case 'changeSwitchViewFromControllerPreference':
                 print('FIXME: Preference is now: ' + message.params);


### PR DESCRIPTION
When spectator camera app monitor display switch is set to "camera view", the main screen display now shows the camera view IFF the camera is on.

ctrl-0 toggles the app display switch.

Under the hood, both hmd and opengl plugins allow a dynamic texture to be set for use by the display. Currently, it must be the size of the display. Javascript can set this on the current plugin using Window.setDisplayTexture(specialResourceUrl).