### PR TITLE
Fix for no-audio on clean install

### DIFF
--- a/interface/resources/qml/hifi/Audio.qml
+++ b/interface/resources/qml/hifi/Audio.qml
@@ -161,7 +161,12 @@ Rectangle {
                     text.text: devicename
                     onCheckBoxClicked: {
                         if (checked) {
-                            AudioDevice.setInputDeviceAsync(devicename)
+                            if (devicename.length > 0) {
+                                console.log("Audio.qml about to call AudioDevice.setInputDeviceAsync().devicename:" + devicename);
+                                AudioDevice.setInputDeviceAsync(devicename);
+                            } else {
+                                console.log("Audio.qml attempted to set input device to empty device name.");
+                            }
                         }
                     }
                 }
@@ -217,7 +222,13 @@ Rectangle {
                     text.text: devicename
                     onCheckBoxClicked: {
                         if (checked) {
-                            AudioDevice.setOutputDeviceAsync(devicename)
+                            if (devicename.length > 0) {
+                                console.log("Audio.qml about to call AudioDevice.setOutputDeviceAsync().devicename:" + devicename);
+                                AudioDevice.setOutputDeviceAsync(devicename);
+                            } else {
+                                console.log("Audio.qml attempted to set output device to empty device name.");
+                            }
+
                         }
                     }
                 }

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -216,7 +216,10 @@ AudioClient::AudioClient() :
 
     connect(&_receivedAudioStream, &MixedProcessedAudioStream::processSamples,
             this, &AudioClient::processReceivedSamples, Qt::DirectConnection);
-    connect(this, &AudioClient::changeDevice, this, [=](const QAudioDeviceInfo& outputDeviceInfo) { switchOutputToAudioDevice(outputDeviceInfo); });
+    connect(this, &AudioClient::changeDevice, this, [=](const QAudioDeviceInfo& outputDeviceInfo) { 
+        qCDebug(audioclient) << "got AudioClient::changeDevice signal, about to call switchOutputToAudioDevice() outputDeviceInfo: [" << outputDeviceInfo.deviceName() << "]";
+        switchOutputToAudioDevice(outputDeviceInfo); 
+    });
 
     connect(&_receivedAudioStream, &InboundAudioStream::mismatchedAudioCodec, this, &AudioClient::handleMismatchAudioFormat);
 
@@ -438,7 +441,8 @@ QAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
         CoUninitialize();
     }
 
-    qCDebug(audioclient) << "[" << deviceName << "] [" << getNamedAudioDeviceForMode(mode, deviceName).deviceName() << "]";
+    qCDebug(audioclient) << "defaultAudioDeviceForMode mode: " << (mode == QAudio::AudioOutput ? "Output" : "Input")
+        << " [" << deviceName << "] [" << getNamedAudioDeviceForMode(mode, deviceName).deviceName() << "]";
 
     return getNamedAudioDeviceForMode(mode, deviceName);
 #endif
@@ -614,8 +618,12 @@ void AudioClient::start() {
 }
 
 void AudioClient::stop() {
+
     // "switch" to invalid devices in order to shut down the state
+    qCDebug(audioclient) << "AudioClient::stop(), about to call switchInputToAudioDevice(null)";
     switchInputToAudioDevice(QAudioDeviceInfo());
+
+    qCDebug(audioclient) << "AudioClient::stop(), about to call switchOutputToAudioDevice(null)";
     switchOutputToAudioDevice(QAudioDeviceInfo());
 }
 
@@ -807,12 +815,12 @@ QVector<QString> AudioClient::getDeviceNames(QAudio::Mode mode) {
 }
 
 bool AudioClient::switchInputToAudioDevice(const QString& inputDeviceName) {
-    qCDebug(audioclient) << "[" << inputDeviceName << "] [" << getNamedAudioDeviceForMode(QAudio::AudioInput, inputDeviceName).deviceName() << "]";
+    qCDebug(audioclient) << "switchInputToAudioDevice [" << inputDeviceName << "] [" << getNamedAudioDeviceForMode(QAudio::AudioInput, inputDeviceName).deviceName() << "]";
     return switchInputToAudioDevice(getNamedAudioDeviceForMode(QAudio::AudioInput, inputDeviceName));
 }
 
 bool AudioClient::switchOutputToAudioDevice(const QString& outputDeviceName) {
-    qCDebug(audioclient) << "[" << outputDeviceName << "] [" << getNamedAudioDeviceForMode(QAudio::AudioOutput, outputDeviceName).deviceName() << "]";
+    qCDebug(audioclient) << "switchOutputToAudioDevice [" << outputDeviceName << "] [" << getNamedAudioDeviceForMode(QAudio::AudioOutput, outputDeviceName).deviceName() << "]";
     return switchOutputToAudioDevice(getNamedAudioDeviceForMode(QAudio::AudioOutput, outputDeviceName));
 }
 
@@ -1357,6 +1365,7 @@ void AudioClient::setIsStereoInput(bool isStereoInput) {
         }
 
         // change in channel count for desired input format, restart the input device
+        qCDebug(audioclient) << __FUNCTION__ << "about to call switchInputToAudioDevice:" << _inputAudioDeviceName;
         switchInputToAudioDevice(_inputAudioDeviceName);
     }
 }
@@ -1395,6 +1404,7 @@ void AudioClient::outputFormatChanged() {
 }
 
 bool AudioClient::switchInputToAudioDevice(const QAudioDeviceInfo& inputDeviceInfo) {
+    qCDebug(audioclient) << __FUNCTION__ << "inputDeviceInfo: [" << inputDeviceInfo.deviceName() << "]";
     bool supportedFormat = false;
 
     // cleanup any previously initialized device
@@ -1509,6 +1519,8 @@ void AudioClient::outputNotify() {
 }
 
 bool AudioClient::switchOutputToAudioDevice(const QAudioDeviceInfo& outputDeviceInfo) {
+    qCDebug(audioclient) << "AudioClient::switchOutputToAudioDevice() outputDeviceInfo: [" << outputDeviceInfo.deviceName() << "]";
+
     bool supportedFormat = false;
 
     Lock localAudioLock(_localAudioMutex);
@@ -1643,7 +1655,11 @@ bool AudioClient::switchOutputToAudioDevice(const QAudioDeviceInfo& outputDevice
 }
 
 int AudioClient::setOutputBufferSize(int numFrames, bool persist) {
+    qCDebug(audioclient) << __FUNCTION__ << "numFrames:" << numFrames << "persist:" << persist;
+
     numFrames = std::min(std::max(numFrames, MIN_BUFFER_FRAMES), MAX_BUFFER_FRAMES);
+    qCDebug(audioclient) << __FUNCTION__ << "clamped numFrames:" << numFrames << "_sessionOutputBufferSizeFrames:" << _sessionOutputBufferSizeFrames;
+
     if (numFrames != _sessionOutputBufferSizeFrames) {
         qCInfo(audioclient, "Audio output buffer set to %d frames", numFrames);
         _sessionOutputBufferSizeFrames = numFrames;
@@ -1655,6 +1671,7 @@ int AudioClient::setOutputBufferSize(int numFrames, bool persist) {
             // The buffer size can't be adjusted after QAudioOutput::start() has been called, so
             // recreate the device by switching to the default.
             QAudioDeviceInfo outputDeviceInfo = defaultAudioDeviceForMode(QAudio::AudioOutput);
+            qCDebug(audioclient) << __FUNCTION__ << "about to send changeDevice signal outputDeviceInfo: [" << outputDeviceInfo.deviceName() << "]";
             emit changeDevice(outputDeviceInfo);  // On correct thread, please, as setOutputBufferSize can be called from main thread.
         }
     }


### PR DESCRIPTION
This fixes a bug where on clean install (no settings file) the audio device would get "unset" even though the menuitems and tablet UI showed a device being selected. This PR also adds some additional debugging to help debug other cases of no-audio.