### PR TITLE
Simplify eventBridge mechanism exposing functionality to web pages

### DIFF
--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -32,7 +32,7 @@ var EventBridge;
     var webChannel = new QWebChannel(qt.webChannelTransport, function (channel) {
         // replace the TempEventBridge with the real one.
         var tempEventBridge = EventBridge;
-        EventBridge = channel.objects.eventBridgeWrapper.eventBridge;
+        EventBridge = channel.objects.eventBridge;
         tempEventBridge._callbacks.forEach(function (callback) {
             EventBridge.scriptEventReceived.connect(callback);
         });

--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -21,8 +21,6 @@ ScrollingWindow {
     property alias url: webview.url
     property alias webView: webview
 
-    property alias eventBridge: eventBridgeWrapper.eventBridge
-
     signal loadingChanged(int status)
 
     x: 100
@@ -210,17 +208,6 @@ ScrollingWindow {
             url: "https://highfidelity.com/"
             profile: FileTypeProfile;
 
-            property alias eventBridgeWrapper: eventBridgeWrapper
-
-            QtObject {
-                id: eventBridgeWrapper
-                WebChannel.id: "eventBridgeWrapper"
-                property var eventBridge;
-            }
-            
-
-            webChannel.registeredObjects: [eventBridgeWrapper]
-
             // Create a global EventBridge object for raiseAndLowerKeyboard.
             WebEngineScript {
                 id: createGlobalEventBridge
@@ -267,6 +254,8 @@ ScrollingWindow {
             }
 
             Component.onCompleted: {
+                webChannel.registerObject("eventBridge", eventBridge);
+                webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
                 desktop.initWebviewProfileHandlers(webview.profile);
             }
         }

--- a/interface/resources/qml/QmlWebWindow.qml
+++ b/interface/resources/qml/QmlWebWindow.qml
@@ -26,14 +26,7 @@ Windows.ScrollingWindow {
     // Don't destroy on close... otherwise the JS/C++ will have a dangling pointer
     destroyOnCloseButton: false
     property alias source: webview.url
-    property alias eventBridge: eventBridgeWrapper.eventBridge;
     property alias scriptUrl: webview.userScriptUrl
-
-    QtObject {
-        id: eventBridgeWrapper
-        WebChannel.id: "eventBridgeWrapper"
-        property var eventBridge;
-    }
 
     // This is for JS/QML communication, which is unused in a WebWindow,
     // but not having this here results in spurious warnings about a 
@@ -70,7 +63,6 @@ Windows.ScrollingWindow {
             url: "about:blank"
             anchors.fill: parent
             focus: true
-            webChannel.registeredObjects: [eventBridgeWrapper]
 
             property string userScriptUrl: ""
 
@@ -107,6 +99,8 @@ Windows.ScrollingWindow {
             }
 
             Component.onCompleted: {
+                webChannel.registerObject("eventBridge", eventBridge);
+                webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
                 eventBridge.webEventReceived.connect(onWebEventReceived);
             }
         }

--- a/interface/resources/qml/QmlWindow.qml
+++ b/interface/resources/qml/QmlWindow.qml
@@ -30,15 +30,6 @@ Windows.Window {
     property bool keyboardRaised: false
     property bool punctuationMode: false
 
-    // JavaScript event bridge object in case QML content includes Web content.
-    property alias eventBridge: eventBridgeWrapper.eventBridge;
-
-    QtObject {
-        id: eventBridgeWrapper
-        WebChannel.id: "eventBridgeWrapper"
-        property var eventBridge;
-    }
-
     onSourceChanged: {
         if (dynamicContent) {
             dynamicContent.destroy();

--- a/interface/resources/qml/TabletBrowser.qml
+++ b/interface/resources/qml/TabletBrowser.qml
@@ -18,7 +18,6 @@ Item {
     property variant permissionsBar: {'securityOrigin':'none','feature':'none'}
     property alias url: webview.url
     property WebEngineView webView: webview
-    property alias eventBridge: eventBridgeWrapper.eventBridge
     property bool canGoBack: webview.canGoBack
     property bool canGoForward: webview.canGoForward
 
@@ -30,12 +29,6 @@ Item {
 
     function setProfile(profile) {
         webview.profile = profile;
-    }
-
-    QtObject {
-        id: eventBridgeWrapper
-        WebChannel.id: "eventBridgeWrapper"
-        property var eventBridge;
     }
 
     WebEngineView {
@@ -78,9 +71,10 @@ Item {
 
         property string newUrl: ""
 
-        webChannel.registeredObjects: [eventBridgeWrapper]
-
         Component.onCompleted: {
+            webChannel.registerObject("eventBridge", eventBridge);
+            webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
+
             // Ensure the JS from the web-engine makes it to our logging
             webview.javaScriptConsoleMessage.connect(function(level, message, lineNumber, sourceID) {
                 console.log("Web Entity JS message: " + sourceID + " " + lineNumber + " " +  message);

--- a/interface/resources/qml/ToolWindow.qml
+++ b/interface/resources/qml/ToolWindow.qml
@@ -79,15 +79,11 @@ ScrollingWindow {
                         id: webView
                         anchors.fill: parent
                         enabled: false
-                        property alias eventBridgeWrapper: eventBridgeWrapper
-
-                        QtObject {
-                            id: eventBridgeWrapper
-                            WebChannel.id: "eventBridgeWrapper"
-                            property var eventBridge
+                        Component.onCompleted: {
+                            webChannel.registerObject("eventBridge", eventBridge);
+                            webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
                         }
 
-                        webChannel.registeredObjects: [eventBridgeWrapper]
                         onEnabledChanged: toolWindow.updateVisiblity()
                     }
                 }
@@ -251,12 +247,9 @@ ScrollingWindow {
         tab.enabled = true;
         tab.originalUrl = properties.source;
 
-        var eventBridge = properties.eventBridge;
-
         var result = tab.item;
         result.enabled = true;
         tabView.tabCount++;
-        result.eventBridgeWrapper.eventBridge = eventBridge;
         result.url = properties.source;
         return result;
     }

--- a/interface/resources/qml/controls/TabletWebScreen.qml
+++ b/interface/resources/qml/controls/TabletWebScreen.qml
@@ -6,7 +6,6 @@ import "../controls-uit" as HiFiControls
 Item {
     property alias url: root.url
     property alias scriptURL: root.userScriptUrl
-    property alias eventBridge: eventBridgeWrapper.eventBridge
     property alias canGoBack: root.canGoBack;
     property var goBack: root.goBack;
     property alias urlTag: root.urlTag
@@ -22,12 +21,6 @@ Item {
     }
     */
 
-    QtObject {
-        id: eventBridgeWrapper
-        WebChannel.id: "eventBridgeWrapper"
-        property var eventBridge;
-    }
-    
     property alias viewProfile: root.profile
 
     WebEngineView {
@@ -71,10 +64,11 @@ Item {
         userScripts: [ createGlobalEventBridge, raiseAndLowerKeyboard, userScript ]
 
         property string newUrl: ""
-
-        webChannel.registeredObjects: [eventBridgeWrapper]
+        
 
         Component.onCompleted: {
+            webChannel.registerObject("eventBridge", eventBridge);
+            webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
             // Ensure the JS from the web-engine makes it to our logging
             root.javaScriptConsoleMessage.connect(function(level, message, lineNumber, sourceID) {
                 console.log("Web Entity JS message: " + sourceID + " " + lineNumber + " " +  message);

--- a/interface/resources/qml/controls/TabletWebView.qml
+++ b/interface/resources/qml/controls/TabletWebView.qml
@@ -17,7 +17,6 @@ Item {
     property int headerHeight: 70
     property string url
     property string scriptURL
-    property alias eventBridge: eventBridgeWrapper.eventBridge
     property bool keyboardEnabled: false
     property bool keyboardRaised: false
     property bool punctuationMode: false
@@ -135,12 +134,6 @@ Item {
         loadUrl(url);
     }
 
-    QtObject {
-        id: eventBridgeWrapper
-        WebChannel.id: "eventBridgeWrapper"
-        property var eventBridge;
-    }
-    
     WebEngineView {
         id: webview
         objectName: "webEngineView"
@@ -182,9 +175,9 @@ Item {
 
         property string newUrl: ""
 
-        webChannel.registeredObjects: [eventBridgeWrapper]
-
         Component.onCompleted: {
+            webChannel.registerObject("eventBridge", eventBridge);
+            webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
             // Ensure the JS from the web-engine makes it to our logging
             webview.javaScriptConsoleMessage.connect(function(level, message, lineNumber, sourceID) {
                 console.log("Web Entity JS message: " + sourceID + " " + lineNumber + " " +  message);

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -6,7 +6,6 @@ import "../controls-uit" as HiFiControls
 Item {
     property alias url: root.url
     property alias scriptURL: root.userScriptUrl
-    property alias eventBridge: eventBridgeWrapper.eventBridge
     property alias canGoBack: root.canGoBack;
     property var goBack: root.goBack;
     property alias urlTag: root.urlTag
@@ -22,12 +21,6 @@ Item {
     }
     */
 
-    QtObject {
-        id: eventBridgeWrapper
-        WebChannel.id: "eventBridgeWrapper"
-        property var eventBridge;
-    }
-    
     property alias viewProfile: root.profile
 
     WebEngineView {
@@ -72,9 +65,9 @@ Item {
 
         property string newUrl: ""
 
-        webChannel.registeredObjects: [eventBridgeWrapper]
-
         Component.onCompleted: {
+            webChannel.registerObject("eventBridge", eventBridge);
+            webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
             // Ensure the JS from the web-engine makes it to our logging
             root.javaScriptConsoleMessage.connect(function(level, message, lineNumber, sourceID) {
                 console.log("Web Entity JS message: " + sourceID + " " + lineNumber + " " +  message);

--- a/interface/resources/qml/dialogs/TabletLoginDialog.qml
+++ b/interface/resources/qml/dialogs/TabletLoginDialog.qml
@@ -20,7 +20,6 @@ TabletModalWindow {
     id: loginDialogRoot
     objectName: "LoginDialog"
 
-    property var eventBridge;
     signal sendToScript(var message);
     property bool isHMD: false
     property bool gotoPreviousApp: false;

--- a/interface/resources/qml/dialogs/preferences/AvatarBrowser.qml
+++ b/interface/resources/qml/dialogs/preferences/AvatarBrowser.qml
@@ -24,8 +24,6 @@ Window {
     resizable: true
     modality: Qt.ApplicationModal
 
-    property alias eventBridge: eventBridgeWrapper.eventBridge
-
     Item {
         anchors.fill: parent
 
@@ -45,16 +43,6 @@ Window {
                 bottom: keyboard.top
             }
 
-            property alias eventBridgeWrapper: eventBridgeWrapper
-
-            QtObject {
-                id: eventBridgeWrapper
-                WebChannel.id: "eventBridgeWrapper"
-                property var eventBridge;
-            }
-
-            webChannel.registeredObjects: [eventBridgeWrapper]
-
             // Create a global EventBridge object for raiseAndLowerKeyboard.
             WebEngineScript {
                 id: createGlobalEventBridge
@@ -73,6 +61,10 @@ Window {
 
             userScripts: [ createGlobalEventBridge, raiseAndLowerKeyboard ]
 
+            Component.onCompleted: {
+                webChannel.registerObject("eventBridge", eventBridge);
+                webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
+            }
         }
 
         Keyboard {

--- a/interface/resources/qml/dialogs/preferences/AvatarPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/AvatarPreference.qml
@@ -116,9 +116,7 @@ Preference {
 
         Component {
             id: tabletAvatarBrowserBuilder;
-            TabletAvatarBrowser {
-                eventBridge: tabletRoot.eventBridge
-            }
+            TabletAvatarBrowser { }
         }
 
     }

--- a/interface/resources/qml/hifi/Audio.qml
+++ b/interface/resources/qml/hifi/Audio.qml
@@ -31,7 +31,6 @@ Rectangle {
     HifiConstants { id: hifi; }
     objectName: "AudioWindow"
 
-    property var eventBridge;
     property string title: "Audio Options"
     signal sendToScript(var message);
 

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -44,7 +44,6 @@ Rectangle {
     property var activeTab: "nearbyTab";
     property bool currentlyEditingDisplayName: false
     property bool punctuationMode: false;
-    property var eventBridge;
 
     HifiConstants { id: hifi; }
 
@@ -1043,7 +1042,6 @@ Rectangle {
         } // Keyboard
 
         HifiControls.TabletWebView {
-            eventBridge: pal.eventBridge;
             id: userInfoViewer;
             anchors {
                 top: parent.top;

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -24,7 +24,6 @@ Rectangle {
     property string title: "Asset Browser"
     property bool keyboardRaised: false
 
-    property var eventBridge;
     signal sendToScript(var message);
     property bool isHMD: false
 

--- a/interface/resources/qml/hifi/dialogs/TabletDCDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletDCDialog.qml
@@ -20,7 +20,6 @@ Rectangle {
     id: root
     objectName: "DCConectionTiming"
 
-    property var eventBridge;
     signal sendToScript(var message);
     property bool isHMD: false
 

--- a/interface/resources/qml/hifi/dialogs/TabletDebugWindow.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletDebugWindow.qml
@@ -19,7 +19,6 @@ Rectangle {
     id: root
 
     objectName: "DebugWindow"
-    property var eventBridge;
 
     property var title: "Debug Window"
     property bool isHMD: false

--- a/interface/resources/qml/hifi/dialogs/TabletEntityStatistics.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletEntityStatistics.qml
@@ -20,7 +20,6 @@ Rectangle {
     id: root
     objectName: "EntityStatistics"
 
-    property var eventBridge;
     signal sendToScript(var message);
     property bool isHMD: false
 

--- a/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
@@ -20,7 +20,6 @@ Rectangle {
     id: root
     objectName: "LODTools"
 
-    property var eventBridge;
     signal sendToScript(var message);
     property bool isHMD: false
 

--- a/interface/resources/qml/hifi/dialogs/TabletRunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletRunningScripts.qml
@@ -23,7 +23,6 @@ Rectangle {
     property string title: "Running Scripts"
     HifiConstants { id: hifi }
     signal sendToScript(var message);
-    property var eventBridge;
     property var scripts: ScriptDiscoveryService;
     property var scriptsModel: scripts.scriptsModelFilter
     property var runningScriptsModel: ListModel { }

--- a/interface/resources/qml/hifi/tablet/Edit.qml
+++ b/interface/resources/qml/hifi/tablet/Edit.qml
@@ -7,14 +7,12 @@ StackView {
     objectName: "stack"
     initialItem: Qt.resolvedUrl('EditTabView.qml')
 
-    property var eventBridge;
     signal sendToScript(var message);
 
     HifiConstants { id: hifi }
 
     function pushSource(path) {
         editRoot.push(Qt.resolvedUrl(path));
-        editRoot.currentItem.eventBridge = editRoot.eventBridge;
         editRoot.currentItem.sendToScript.connect(editRoot.sendToScript);
     }
 

--- a/interface/resources/qml/hifi/tablet/EditTabView.qml
+++ b/interface/resources/qml/hifi/tablet/EditTabView.qml
@@ -181,7 +181,6 @@ TabView {
         WebView {
             id: entityListToolWebView
             url: "../../../../../scripts/system/html/entityList.html"
-            eventBridge: editRoot.eventBridge
             anchors.fill: parent
             enabled: true
         }
@@ -196,7 +195,6 @@ TabView {
         WebView {
             id: entityPropertiesWebView
             url: "../../../../../scripts/system/html/entityProperties.html"
-            eventBridge: editRoot.eventBridge
             anchors.fill: parent
             enabled: true
         }
@@ -211,7 +209,6 @@ TabView {
         WebView {
             id: gridControlsWebView
             url: "../../../../../scripts/system/html/gridControls.html"
-            eventBridge: editRoot.eventBridge
             anchors.fill: parent
             enabled: true
         }
@@ -226,7 +223,6 @@ TabView {
         WebView {
             id: particleExplorerWebView
             url: "../../../../../scripts/system/particle_explorer/particleExplorer.html"
-            eventBridge: editRoot.eventBridge
             anchors.fill: parent
             enabled: true
         }
@@ -289,7 +285,7 @@ TabView {
                 editTabView.currentIndex = id;
             } else {
                 console.warn('Attempt to switch to invalid tab:', id);
-            }			
+            }
         } else if (typeof id === 'string'){
             switch (id.toLowerCase()) {
                 case 'create':

--- a/interface/resources/qml/hifi/tablet/InputRecorder.qml
+++ b/interface/resources/qml/hifi/tablet/InputRecorder.qml
@@ -18,7 +18,6 @@ import "../../dialogs"
 
 Rectangle {
     id: inputRecorder
-    property var eventBridge;
     HifiConstants { id: hifi }
     signal sendToScript(var message);
     color: hifi.colors.baseGray;

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -20,7 +20,6 @@ Rectangle {
     // height: parent.height
     HifiConstants { id: hifi }
     color: hifi.colors.baseGray;
-    property var eventBridge;
     signal sendToScript(var message);
     property bool keyboardEnabled: false
     property bool punctuationMode: false

--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -29,7 +29,6 @@ StackView {
     initialItem: addressBarDialog
     width: parent !== null ? parent.width : undefined
     height: parent !== null ? parent.height : undefined
-    property var eventBridge;
     property int cardWidth: 212;
     property int cardHeight: 152;
     property string metaverseBase: addressBarDialog.metaverseServerUrl + "/api/v1/";
@@ -80,7 +79,6 @@ StackView {
             var card = tabletWebView.createObject();
             card.url = addressBarDialog.metaverseServerUrl + targetString;
             card.parentStackItem = root;
-            card.eventBridge = root.eventBridge;
             root.push(card);
             return;
         }

--- a/interface/resources/qml/hifi/tablet/TabletAttachmentsDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAttachmentsDialog.qml
@@ -25,7 +25,6 @@ Item {
     property bool keyboardRaised: false
     property bool punctuationMode: false
 
-    property var eventBridge;
     signal sendToScript(var message);
 
     anchors.fill: parent

--- a/interface/resources/qml/hifi/tablet/TabletAudioPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAudioPreferences.qml
@@ -19,7 +19,6 @@ StackView {
     objectName: "stack"
     property string title: "Audio Settings"
 
-    property var eventBridge;
     signal sendToScript(var message);
 
     function pushSource(path) {

--- a/interface/resources/qml/hifi/tablet/TabletAvatarPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAvatarPreferences.qml
@@ -19,7 +19,6 @@ StackView {
     objectName: "stack"
     property string title: "Avatar Settings"
 
-    property var eventBridge;
     signal sendToScript(var message);
 
     function pushSource(path) {

--- a/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
@@ -19,7 +19,6 @@ StackView {
     objectName: "stack"
     property string title: "General Settings"
     property alias gotoPreviousApp: root.gotoPreviousApp;
-    property var eventBridge;
     signal sendToScript(var message);
 
     function pushSource(path) {

--- a/interface/resources/qml/hifi/tablet/TabletGraphicsPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletGraphicsPreferences.qml
@@ -19,7 +19,6 @@ StackView {
     objectName: "stack"
     property string title: "Graphics Settings"
 
-    property var eventBridge;
     signal sendToScript(var message);
 
     function pushSource(path) {

--- a/interface/resources/qml/hifi/tablet/TabletLodPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletLodPreferences.qml
@@ -19,7 +19,6 @@ StackView {
     objectName: "stack"
     property string title: "LOD Settings"
 
-    property var eventBridge;
     signal sendToScript(var message);
 
     function pushSource(path) {

--- a/interface/resources/qml/hifi/tablet/TabletMenu.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenu.qml
@@ -21,7 +21,6 @@ FocusScope {
     property var point: Qt.point(50, 50);
     TabletMenuStack { id: menuPopperUpper }
     property string subMenu: ""
-    property var eventBridge;
     signal sendToScript(var message);
 
     Rectangle {

--- a/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
@@ -49,7 +49,6 @@ Item {
 
         function pushSource(path) {
             d.push(Qt.resolvedUrl(path));
-            d.currentItem.eventBridge = tabletMenu.eventBridge
             d.currentItem.sendToScript.connect(tabletMenu.sendToScript);
             d.currentItem.focus = true;
             d.currentItem.forceActiveFocus();

--- a/interface/resources/qml/hifi/tablet/TabletNetworkingPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletNetworkingPreferences.qml
@@ -19,7 +19,6 @@ StackView {
     objectName: "stack"
     property var title: "Networking Settings"
 
-    property var eventBridge;
     signal sendToScript(var message);
 
     function pushSource(path) {

--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -8,7 +8,6 @@ Item {
     id: tabletRoot
     objectName: "tabletRoot"
     property string username: "Unknown user"
-    property var eventBridge;
     property var rootMenu;
     property var openModal: null;
     property var openMessage: null;
@@ -111,7 +110,6 @@ Item {
     function openBrowserWindow(request, profile) {
         var component = Qt.createComponent("../../controls/TabletWebView.qml");
         var newWindow = component.createObject(tabletRoot);
-        newWindow.eventBridge = tabletRoot.eventBridge;
         newWindow.remove = true;
         newWindow.profile = profile;
         request.openIn(newWindow.webView);
@@ -175,7 +173,7 @@ Item {
         // Hook up callback for clara.io download from the marketplace.
         Connections {
             id: eventBridgeConnection
-            target: null
+            target: eventBridge
             onWebEventReceived: {
                 if (message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
                     ApplicationInterface.addAssetToWorldFromURL(message.slice(18));
@@ -184,10 +182,6 @@ Item {
         }
 
         onLoaded: {
-            if (loader.item.hasOwnProperty("eventBridge")) {
-                loader.item.eventBridge = eventBridge;
-                eventBridgeConnection.target = eventBridge
-            }
             if (loader.item.hasOwnProperty("sendToScript")) {
                 loader.item.sendToScript.connect(tabletRoot.sendToScript);
             }

--- a/interface/resources/qml/hifi/tablet/WindowRoot.qml
+++ b/interface/resources/qml/hifi/tablet/WindowRoot.qml
@@ -18,7 +18,6 @@ Windows.ScrollingWindow {
     id: tabletRoot
     objectName: "tabletRoot"
     property string username: "Unknown user"
-    property var eventBridge;
 
     property var rootMenu;
     property string subMenu: ""
@@ -93,7 +92,7 @@ Windows.ScrollingWindow {
         // Hook up callback for clara.io download from the marketplace.
         Connections {
             id: eventBridgeConnection
-            target: null
+            target: eventBridge
             onWebEventReceived: {
                 if (message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
                     ApplicationInterface.addAssetToWorldFromURL(message.slice(18));
@@ -102,10 +101,6 @@ Windows.ScrollingWindow {
         }
 
         onLoaded: {
-            if (loader.item.hasOwnProperty("eventBridge")) {
-                loader.item.eventBridge = eventBridge;
-                eventBridgeConnection.target = eventBridge
-            }
             if (loader.item.hasOwnProperty("sendToScript")) {
                 loader.item.sendToScript.connect(tabletRoot.sendToScript);
             }

--- a/interface/resources/qml/hifi/tablet/tabletWindows/preferences/TabletAvatarBrowser.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/preferences/TabletAvatarBrowser.qml
@@ -27,8 +27,6 @@ Item {
     property bool keyboardRaised: false
     property bool punctuationMode: false
 
-    property alias eventBridge: eventBridgeWrapper.eventBridge
-
     anchors.fill: parent
 
     BaseWebView {
@@ -42,14 +40,6 @@ Item {
             right: parent.right
             bottom: footer.top
         }
-
-        QtObject {
-            id: eventBridgeWrapper
-            WebChannel.id: "eventBridgeWrapper"
-            property var eventBridge;
-        }
-
-        webChannel.registeredObjects: [eventBridgeWrapper]
 
         // Create a global EventBridge object for raiseAndLowerKeyboard.
         WebEngineScript {
@@ -68,6 +58,11 @@ Item {
         }
 
         userScripts: [ createGlobalEventBridge, raiseAndLowerKeyboard ]
+
+        Component.onCompleted: {
+            webChannel.registerObject("eventBridge", eventBridge);
+            webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);
+        }
     }
 
     Rectangle {

--- a/libraries/gl/src/gl/OffscreenQmlSurface.h
+++ b/libraries/gl/src/gl/OffscreenQmlSurface.h
@@ -48,6 +48,8 @@ public:
     void resize(const QSize& size, bool forceResize = false);
     QSize size() const;
 
+    Q_INVOKABLE QObject* load(const QUrl& qmlSource, bool createNewContext, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
+    Q_INVOKABLE QObject* loadInNewContext(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
     Q_INVOKABLE QObject* load(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
     Q_INVOKABLE QObject* load(const QString& qmlSourceFile, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {}) {
         return load(QUrl(qmlSourceFile), f);
@@ -118,7 +120,7 @@ protected:
     void setFocusText(bool newFocusText);
 
 private:
-    QObject* finishQmlLoad(std::function<void(QQmlContext*, QObject*)> f);
+    QObject* finishQmlLoad(QQmlComponent* qmlComponent, QQmlContext* qmlContext, std::function<void(QQmlContext*, QObject*)> f);
     QPointF mapWindowToUi(const QPointF& sourcePosition, QObject* sourceObject);
     void setupFbo();
     bool allowNewFrame(uint8_t fps);
@@ -134,7 +136,6 @@ private:
     QQuickWindow* _quickWindow { nullptr };
     QMyQuickRenderControl* _renderControl{ nullptr };
     QQmlContext* _qmlContext { nullptr };
-    QQmlComponent* _qmlComponent { nullptr };
     QQuickItem* _rootItem { nullptr };
     OffscreenGLCanvas* _canvas { nullptr };
 

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -104,9 +104,9 @@ void QmlWindowClass::initQml(QVariantMap properties) {
         Q_ASSERT(invokeResult);
     } else {
         // Build the event bridge and wrapper on the main thread
-        offscreenUi->load(qmlSource(), [&](QQmlContext* context, QObject* object) {
+        offscreenUi->loadInNewContext(qmlSource(), [&](QQmlContext* context, QObject* object) {
             _qmlWindow = object;
-            _qmlWindow->setProperty("eventBridge", QVariant::fromValue(this));
+            context->setContextProperty("eventBridge", this);
             context->engine()->setObjectOwnership(this, QQmlEngine::CppOwnership);
             context->engine()->setObjectOwnership(object, QQmlEngine::CppOwnership);
             if (properties.contains(TITLE_PROPERTY)) {

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -123,15 +123,18 @@ bool ViveControllerManager::isSupported() const {
 bool ViveControllerManager::activate() {
     InputPlugin::activate();
 
-    _container->addMenu(MENU_PATH);
-    _container->addMenuItem(PluginType::INPUT_PLUGIN, MENU_PATH, RENDER_CONTROLLERS,
-        [this] (bool clicked) { this->setRenderControllers(clicked); },
-        true, true);
-
     if (!_system) {
         _system = acquireOpenVrSystem();
     }
-    Q_ASSERT(_system);
+
+    if (!_system) {
+        return false;
+    }
+
+    _container->addMenu(MENU_PATH);
+    _container->addMenuItem(PluginType::INPUT_PLUGIN, MENU_PATH, RENDER_CONTROLLERS,
+        [this](bool clicked) { this->setRenderControllers(clicked); },
+        true, true);
 
     enableOpenVrKeyboard(_container);
 

--- a/scripts/system/html/js/eventBridgeLoader.js
+++ b/scripts/system/html/js/eventBridgeLoader.js
@@ -13,7 +13,7 @@ var WebChannel;
 
 openEventBridge = function(callback) {
     WebChannel = new QWebChannel(qt.webChannelTransport, function (channel) {
-        EventBridge = WebChannel.objects.eventBridgeWrapper.eventBridge;
+        EventBridge = WebChannel.objects.eventBridge;
         callback(EventBridge);
     });
 }


### PR DESCRIPTION
This PR is intended to address some occasional instability inside QML containing Web content.  In cases where we need for the HTML hosted JS to interact with our own scripts, we use the functionality provided by QWebChannel to expose Qt objects (an `eventBridge`) to the Chromium JS instance.  


However, the existing logic to do this exposed the `eventBridge` as a property on the root object of the QML content, requiring a lot of passing of this `eventBridge` from parent to child, especially in the case of the tablet functionality. Additionally, because of the way the WebChannel functionality works, we had an intermediate `eventBridgeWrapper`, which would have as a property the actual eventBridge.  This was only done in order to allow the QML to assign a WebChannel.id to the `eventBridgeWrapper` so that it could be declared as

```
webChannel.registeredObjects: [eventBridgeWrapper]
```

This PR modifies the functionality by making `eventBridge` a globally visible variable, eliminating the need for any `eventBridge` property anywhere in the QML code.  Additionally, it moves to using the procedural method of injecting the eventBridge, rather than the declarartive, so the above call changes to the line of code `webChannel.registerObject("eventBridge", eventBridge);` inside an objects Component.onCompleted handler.  This eliminates the need for a wrapper as the WebChannel.id is explicit in the function call rather than needing to be implicitly part of the registered object.  

Unfortunately, since there are existing scripts on the marketplace that still use the `eventBridgeWrapper` approach, this PR includes additional work for compatibility, so there is also a `webChannel.registerObject("eventBridgeWrapper", eventBridgeWrapper);` call required, but even in this case, the registered object is now a globally scoped variable injected in the QML context by the C++ code, rather than a local item to the QML source.  

## Testing

Scripts which depend on communication between HTML based `javascript` and Application based `javascript` should still work.  For instance, editing functionality which provides the list of entities in an HTML view and the entity properties tab of the editing interface should both still function as normal.

Additionally, existing marketplace scripts which use the old eventBridgeWrapper functionality should still work (Menthal's text board is an example of this).  






