### PR TITLE
Spectator-camera : Provide a way to render the side camera always mono

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
@@ -115,6 +115,9 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
 
     (&::gpu::gl::GLBackend::do_resetStages),
 
+    (&::gpu::gl::GLBackend::do_disableContextStereo),
+    (&::gpu::gl::GLBackend::do_restoreContextStereo),
+
     (&::gpu::gl::GLBackend::do_runLambda),
 
     (&::gpu::gl::GLBackend::do_startNamedCall),
@@ -224,6 +227,14 @@ void GLBackend::renderPassTransfer(const Batch& batch) {
                     _transform.preUpdate(_commandIndex, _stereo);
                     break;
 
+                case Batch::COMMAND_disableContextStereo:
+                    _stereo._contextDisable = true;
+                    break;
+
+                case Batch::COMMAND_restoreContextStereo:
+                    _stereo._contextDisable = false;
+                    break;
+
                 case Batch::COMMAND_setViewportTransform:
                 case Batch::COMMAND_setViewTransform:
                 case Batch::COMMAND_setProjectionTransform: {
@@ -308,16 +319,16 @@ void GLBackend::render(const Batch& batch) {
     }
 
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
-    if (_stereo._enable) {
+    if (_stereo.isStereo()) {
         glEnable(GL_CLIP_DISTANCE0);
     }
 #endif
     {
-        PROFILE_RANGE(render_gpu_gl_detail, _stereo._enable ? "Render Stereo" : "Render");
+        PROFILE_RANGE(render_gpu_gl_detail, _stereo.isStereo() ? "Render Stereo" : "Render");
         renderPassDraw(batch);
     }
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
-    if (_stereo._enable) {
+    if (_stereo.isStereo()) {
         glDisable(GL_CLIP_DISTANCE0);
     }
 #endif
@@ -356,6 +367,15 @@ void GLBackend::setupStereoSide(int side) {
 
 void GLBackend::do_resetStages(const Batch& batch, size_t paramOffset) {
     resetStages();
+}
+
+
+void GLBackend::do_disableContextStereo(const Batch& batch, size_t paramOffset) {
+
+}
+
+void GLBackend::do_restoreContextStereo(const Batch& batch, size_t paramOffset) {
+
 }
 
 void GLBackend::do_runLambda(const Batch& batch, size_t paramOffset) {

--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.h
@@ -143,6 +143,9 @@ public:
     // Reset stages
     virtual void do_resetStages(const Batch& batch, size_t paramOffset) final;
 
+    virtual void do_disableContextStereo(const Batch& batch, size_t paramOffset) final;
+    virtual void do_restoreContextStereo(const Batch& batch, size_t paramOffset) final;
+
     virtual void do_runLambda(const Batch& batch, size_t paramOffset) final;
 
     virtual void do_startNamedCall(const Batch& batch, size_t paramOffset) final;

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendOutput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendOutput.cpp
@@ -48,7 +48,7 @@ void GLBackend::do_setFramebuffer(const Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::do_clearFramebuffer(const Batch& batch, size_t paramOffset) {
-    if (_stereo._enable && !_pipeline._stateCache.scissorEnable) {
+    if (_stereo.isStereo() && !_pipeline._stateCache.scissorEnable) {
         qWarning("Clear without scissor in stereo mode");
     }
 

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendState.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendState.cpp
@@ -322,7 +322,7 @@ void GLBackend::do_setStateScissorRect(const Batch& batch, size_t paramOffset) {
     Vec4i rect;
     memcpy(&rect, batch.readData(batch._params[paramOffset]._uint), sizeof(Vec4i));
 
-    if (_stereo._enable) {
+    if (_stereo.isStereo()) {
         rect.z /= 2;
         if (_stereo._pass) {
             rect.x += rect.z;

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendTransform.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendTransform.cpp
@@ -37,7 +37,7 @@ void GLBackend::do_setViewportTransform(const Batch& batch, size_t paramOffset) 
         glViewport(vp.x, vp.y, vp.z, vp.w);
 
         // Where we assign the GL viewport
-        if (_stereo._enable) {
+        if (_stereo.isStereo()) {
             vp.z /= 2;
             if (_stereo._pass) {
                 vp.x += vp.z;

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -390,6 +390,15 @@ void Batch::resetStages() {
     ADD_COMMAND(resetStages);
 }
 
+
+void Batch::disableContextStereo() {
+    ADD_COMMAND(disableContextStereo);
+}
+
+void Batch::restoreContextStereo() {
+    ADD_COMMAND(restoreContextStereo);
+}
+
 void Batch::runLambda(std::function<void()> f) {
     ADD_COMMAND(runLambda);
     _params.emplace_back(_lambdas.cache(f));

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -217,6 +217,9 @@ public:
     // Reset the stage caches and states
     void resetStages();
 
+    void disableContextStereo();
+    void restoreContextStereo();
+
     // Debugging
     void pushProfileRange(const char* name);
     void popProfileRange();
@@ -300,6 +303,9 @@ public:
         COMMAND_getQuery,
 
         COMMAND_resetStages,
+
+        COMMAND_disableContextStereo,
+        COMMAND_restoreContextStereo,
 
         COMMAND_runLambda,
 
@@ -467,7 +473,7 @@ public:
     NamedBatchDataMap _namedData;
 
     bool _enableStereo{ true };
-    bool _enableSkybox{ false };
+    bool _enableSkybox { false };
 
 protected:
     friend class Context;

--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -145,7 +145,7 @@ void Context::enableStereo(bool enable) {
 }
 
 bool Context::isStereo() {
-    return _stereo._enable;
+    return _stereo.isStereo();
 }
 
 void Context::setStereoProjections(const mat4 eyeProjections[2]) {

--- a/libraries/gpu/src/gpu/Context.h
+++ b/libraries/gpu/src/gpu/Context.h
@@ -118,7 +118,7 @@ public:
 
 protected:
     virtual bool isStereo() {
-        return _stereo._enable;
+        return _stereo.isStereo();
     }
 
     void getStereoProjections(mat4* eyeProjections) const {

--- a/libraries/gpu/src/gpu/Forward.h
+++ b/libraries/gpu/src/gpu/Forward.h
@@ -93,7 +93,11 @@ namespace gpu {
     using TextureViews = std::vector<TextureView>;
 
     struct StereoState {
+        bool isStereo() const {
+            return _enable && !_contextDisable;
+        }
         bool _enable{ false };
+        bool _contextDisable { false };
         bool _skybox{ false };
         // 0 for left eye, 1 for right eye
         uint8 _pass{ 0 };

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -115,7 +115,7 @@
             // Must be something about the view frustum projection matrix?
             // But don't go changing that in (c++ code) without getting all the way to a desktop display!
             orientation: flip(cameraRotation),
-            scale: -1.0,
+            scale: -0.35,
         });
     }
 

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -115,7 +115,7 @@
             // Must be something about the view frustum projection matrix?
             // But don't go changing that in (c++ code) without getting all the way to a desktop display!
             orientation: flip(cameraRotation),
-            scale: -0.35,
+            scale: -1.0,
         });
     }
 


### PR DESCRIPTION
Quick fix to introduce a mechanism to force the context level stereo flag to be disabled