### PR TITLE
Resolved FB5087

### DIFF
--- a/interface/src/CrashHandler.cpp
+++ b/interface/src/CrashHandler.cpp
@@ -73,7 +73,7 @@ CrashHandler::Action CrashHandler::promptUserForAction(bool showCrashMessage) {
     layout->addWidget(label);
 
     QRadioButton* option1 = new QRadioButton("Reset all my settings");
-    QRadioButton* option2 = new QRadioButton("Reset my settings but retain avatar info.");
+    QRadioButton* option2 = new QRadioButton("Reset my settings but keep essential info");
     QRadioButton* option3 = new QRadioButton("Continue with my current settings");
     option3->setChecked(true);
     layout->addWidget(option1);
@@ -95,7 +95,7 @@ CrashHandler::Action CrashHandler::promptUserForAction(bool showCrashMessage) {
             return CrashHandler::DELETE_INTERFACE_INI;
         }
         if (option2->isChecked()) {
-            return CrashHandler::RETAIN_AVATAR_INFO;
+            return CrashHandler::RETAIN_IMPORTANT_INFO;
         }
     }
 
@@ -104,7 +104,7 @@ CrashHandler::Action CrashHandler::promptUserForAction(bool showCrashMessage) {
 }
 
 void CrashHandler::handleCrash(CrashHandler::Action action) {
-    if (action != CrashHandler::DELETE_INTERFACE_INI && action != CrashHandler::RETAIN_AVATAR_INFO) {
+    if (action != CrashHandler::DELETE_INTERFACE_INI && action != CrashHandler::RETAIN_IMPORTANT_INFO) {
         // CrashHandler::DO_NOTHING or unexpected value
         return;
     }
@@ -116,12 +116,15 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
     const QString DISPLAY_NAME_KEY = "displayName";
     const QString FULL_AVATAR_URL_KEY = "fullAvatarURL";
     const QString FULL_AVATAR_MODEL_NAME_KEY = "fullAvatarModelName";
+    const QString TUTORIAL_COMPLETE_FLAG_KEY = "tutorialComplete";
+
     QString displayName;
     QUrl fullAvatarURL;
     QString fullAvatarModelName;
     QUrl address;
+    bool tutorialComplete;
 
-    if (action == CrashHandler::RETAIN_AVATAR_INFO) {
+    if (action == CrashHandler::RETAIN_IMPORTANT_INFO) {
         // Read avatar info
 
         // Location and orientation
@@ -135,6 +138,9 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
         fullAvatarURL = settings.value(FULL_AVATAR_URL_KEY).toUrl();
         fullAvatarModelName = settings.value(FULL_AVATAR_MODEL_NAME_KEY).toString();
         settings.endGroup();
+
+        // Tutorial complete
+        tutorialComplete = settings.value(TUTORIAL_COMPLETE_FLAG_KEY).toBool();
     }
 
     // Delete Interface.ini
@@ -143,7 +149,7 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
         settingsFile.remove();
     }
 
-    if (action == CrashHandler::RETAIN_AVATAR_INFO) {
+    if (action == CrashHandler::RETAIN_IMPORTANT_INFO) {
         // Write avatar info
 
         // Location and orientation
@@ -157,6 +163,9 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
         settings.setValue(FULL_AVATAR_URL_KEY, fullAvatarURL);
         settings.setValue(FULL_AVATAR_MODEL_NAME_KEY, fullAvatarModelName);
         settings.endGroup();
+
+        // Tutorial complete
+        settings.setValue(TUTORIAL_COMPLETE_FLAG_KEY, tutorialComplete);
     }
 }
 

--- a/interface/src/CrashHandler.cpp
+++ b/interface/src/CrashHandler.cpp
@@ -122,7 +122,7 @@ void CrashHandler::handleCrash(CrashHandler::Action action) {
     QUrl fullAvatarURL;
     QString fullAvatarModelName;
     QUrl address;
-    bool tutorialComplete;
+    bool tutorialComplete = false;
 
     if (action == CrashHandler::RETAIN_IMPORTANT_INFO) {
         // Read avatar info

--- a/interface/src/CrashHandler.h
+++ b/interface/src/CrashHandler.h
@@ -22,7 +22,7 @@ public:
 private:
     enum Action {
         DELETE_INTERFACE_INI,
-        RETAIN_AVATAR_INFO,
+        RETAIN_IMPORTANT_INFO,
         DO_NOTHING
     };
 


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/5087/Change-Reset-settings-but-keep-avatar-to-keep-essential-and-don-t-clear-your-tutorial-flag

Test Plan:

1. Start interface with HMD + hand controllers and do the tutorial
2. Restart the interface and verify that you do not return to the tutorial
3. Invoke a crash by selecting `Menu > Developer > Crash > New Fault`
4. Restart interface (still with HMD/hand controllers), upon starting you should see a dialog asking you about your settings
5. From the dialog, verify that an option labeled "Reset my settings but keep essential info" is present
6. Select the "Reset my settings but keep essential info" option
7. Verify that you do not return to the tutorial
8. Restart the interface and verify that you do not return to the tutorial
9. Invoke a crash by selecting `Menu > Developer > Crash > New Fault`
10. Restart interface (still with HMD/hand controllers), upon starting you should see a dialog asking you about your settings
11. Select the "Reset all my settings" option
12. Verify that you have returned to the tutorial