### PR TITLE
Potentially fix a crash in font loading

### DIFF
--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -14,6 +14,8 @@
 #include "../RenderUtilsLogging.h"
 #include "FontFamilies.h"
 
+static std::mutex fontMutex;
+
 struct TextureVertex {
     glm::vec2 pos;
     glm::vec2 tex;
@@ -56,6 +58,7 @@ Font::Pointer Font::load(QIODevice& fontFile) {
 }
 
 Font::Pointer Font::load(const QString& family) {
+    std::lock_guard<std::mutex> lock(fontMutex);
     if (!LOADED_FONTS.contains(family)) {
 
         static const QString SDFF_COURIER_PRIME_FILENAME{ ":/CourierPrime.sdff" };

--- a/libraries/render-utils/src/text/Font.h
+++ b/libraries/render-utils/src/text/Font.h
@@ -31,10 +31,10 @@ public:
         const glm::vec4* color, EffectType effectType,
         const glm::vec2& bound, bool layered = false);
 
-    static Pointer load(QIODevice& fontFile);
     static Pointer load(const QString& family);
 
 private:
+    static Pointer load(QIODevice& fontFile);
     QStringList tokenizeForWrapping(const QString& str) const;
     QStringList splitLines(const QString& str) const;
     glm::vec2 computeTokenExtent(const QString& str) const;


### PR DESCRIPTION
This PR attempts to fix [FB5260](https://highfidelity.fogbugz.com/f/cases/5260/CRASH-going-into-Zaru).

**Test Plan:**
1. Go to a domain with lots of people (i.e. dev-distributed)
2. Spawn hundreds of entities, each with `sit.js` attached (dev-distributed already has this).
3. Load `nameTag.js` (the name tag script)
4. Use Edit->Reload Content 10x, wait for all content to load
6. Verify that you don't crash, and that you see the nametags above each avatar each time content loads