### PR TITLE
fix teleport vs stuck-in-floor work

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -605,7 +605,7 @@ bool RenderableModelEntityItem::findDetailedRayIntersection(const glm::vec3& ori
 
     QString extraInfo;
     return _model->findRayIntersectionAgainstSubMeshes(origin, direction, distance,
-                                                       face, surfaceNormal, extraInfo, precisionPicking, precisionPicking);
+                                                       face, surfaceNormal, extraInfo, precisionPicking, false);
 }
 
 void RenderableModelEntityItem::getCollisionGeometryResource() {


### PR DESCRIPTION
Addresses issue with https://github.com/highfidelity/hifi/pull/10654#issuecomment-307645700 (teleport during tutorial), while keeping most of the benefits of https://github.com/highfidelity/hifi/pull/10553.

Test plan:
1. Make sure you can teleport to various places in the tutorial, as various avatars.
2. Repeat the tests from PR 10553 as various avatars.  
  ==> You may find that the "Simple Robot" doesn't do so well (e.g., going to hifi://dev-demo/89.8552,-1.91111,41.9404/0,-0.223106,0,0.974794).   We'll have to live with that for now.

10553 included an attempt to more accurately identify intersections with a ray that originates inside a mesh, and I got that wrong. This turns that "improvement" off. 