### PR TITLE
Fix bug in clearFramebuffer with Stencil Buffer

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLBackendOutput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendOutput.cpp
@@ -63,11 +63,17 @@ void GLBackend::do_clearFramebuffer(const Batch& batch, size_t paramOffset) {
     int useScissor = batch._params[paramOffset + 0]._int;
 
     GLuint glmask = 0;
+    bool restoreStencilMask = false;
+    uint8_t cacheStencilMask = 0xFF;
     if (masks & Framebuffer::BUFFER_STENCIL) {
         glClearStencil(stencil);
         glmask |= GL_STENCIL_BUFFER_BIT;
-        // TODO: we will probably need to also check the write mask of stencil like we do
-        // for depth buffer, but as would say a famous Fez owner "We'll cross that bridge when we come to it"
+    
+        cacheStencilMask = _pipeline._stateCache.stencilActivation.getWriteMaskFront();
+        if (cacheStencilMask != 0xFF) {
+            restoreStencilMask = true;
+            glStencilMask( 0xFF);
+        }
     }
 
     bool restoreDepthMask = false;
@@ -119,6 +125,11 @@ void GLBackend::do_clearFramebuffer(const Batch& batch, size_t paramOffset) {
     // Restore scissor if needed
     if (doEnableScissor) {
         glDisable(GL_SCISSOR_TEST);
+    }
+
+    // Restore Stencil write mask
+    if (restoreStencilMask) {
+        glStencilMask(cacheStencilMask);
     }
 
     // Restore write mask meaning turn back off


### PR DESCRIPTION
This PR fixes a bug in the GLBackend in the do_clearFramebuffer call.

In opengl, the glClear instruction is affected by the Writing mask for the Stencil (and all the other buffers)
In gpu lib, we are not expecting the mask to affect the clear command.
Thus we need to make sure the stencil writing mask is on when doing the clear command and then restoring the mask to the state value if needed.

This is a nice expected bug that we didn't fixed because we didn't encountered it until now. We just did working on the spectator camera project.

## TEST PLAN
The bug is only visible in the spectator camera branch and addressed in PR 10673
The code here is just the same brought to master.

There is not really any way to validate that bug in this branch.
There should be no difference in this pr compared to master.
