### PR TITLE
Add support for querying the desired output audio device for OpenVR

### DIFF
--- a/plugins/openvr/CMakeLists.txt
+++ b/plugins/openvr/CMakeLists.txt
@@ -10,10 +10,10 @@ if (WIN32)
     # we're using static GLEW, so define GLEW_STATIC
     add_definitions(-DGLEW_STATIC)
     set(TARGET_NAME openvr)
-    setup_hifi_plugin(OpenGL Script Qml Widgets)
+    setup_hifi_plugin(OpenGL Script Qml Widgets Multimedia)
     link_hifi_libraries(shared gl networking controllers ui 
         plugins display-plugins ui-plugins input-plugins script-engine
-        render-utils model gpu gpu-gl render model-networking fbx ktx image procedural)
+        audio-client render-utils model gpu gpu-gl render model-networking fbx ktx image procedural)
 
     include_hifi_library_headers(octree)
 
@@ -21,4 +21,5 @@ if (WIN32)
     find_package(OpenVR REQUIRED)
     target_include_directories(${TARGET_NAME} PRIVATE ${OPENVR_INCLUDE_DIRS})
     target_link_libraries(${TARGET_NAME} ${OPENVR_LIBRARIES})
+    target_link_libraries(${TARGET_NAME} Winmm.lib)
 endif()

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -7,6 +7,9 @@
 //
 #include "OpenVrDisplayPlugin.h"
 
+// Odd ordering of header is required to avoid 'macro redinition warnings'
+#include <AudioClient.h>
+
 #include <QtCore/QThread>
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QFileInfo>
@@ -713,3 +716,30 @@ bool OpenVrDisplayPlugin::isKeyboardVisible() {
 int OpenVrDisplayPlugin::getRequiredThreadCount() const { 
     return Parent::getRequiredThreadCount() + (_threadedSubmit ? 1 : 0);
 }
+
+QString OpenVrDisplayPlugin::getPreferredAudioInDevice() const {
+    QString device = getVrSettingString(vr::k_pch_audio_Section, vr::k_pch_audio_OnPlaybackDevice_String);
+    if (!device.isEmpty()) {
+        static const WCHAR INIT = 0;
+        size_t size = device.size() + 1;
+        std::vector<WCHAR> deviceW;
+        deviceW.assign(size, INIT);
+        device.toWCharArray(deviceW.data());
+        device = AudioClient::friendlyNameForAudioDevice(deviceW.data());
+    }
+    return device;
+}
+
+QString OpenVrDisplayPlugin::getPreferredAudioOutDevice() const {
+    QString device = getVrSettingString(vr::k_pch_audio_Section, vr::k_pch_audio_OnRecordDevice_String);
+    if (!device.isEmpty()) {
+        static const WCHAR INIT = 0;
+        size_t size = device.size() + 1;
+        std::vector<WCHAR> deviceW;
+        deviceW.assign(size, INIT);
+        device.toWCharArray(deviceW.data());
+        device = AudioClient::friendlyNameForAudioDevice(deviceW.data());
+    }
+    return device;
+}
+

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -58,6 +58,9 @@ public:
     // Possibly needs an additional thread for VR submission
     int getRequiredThreadCount() const override;
 
+    QString getPreferredAudioInDevice() const override;
+    QString getPreferredAudioOutDevice() const override;
+
 protected:
     bool internalActivate() override;
     void internalDeactivate() override;

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -72,6 +72,21 @@ bool openVrSupported() {
     return (enableDebugOpenVR || !isOculusPresent()) && vr::VR_IsHmdPresent();
 }
 
+QString getVrSettingString(const char* section, const char* setting) {
+    QString result;
+    static const uint32_t BUFFER_SIZE = 1024;
+    static char BUFFER[BUFFER_SIZE];
+    vr::IVRSettings * vrSettings = vr::VRSettings();
+    if (vrSettings) {
+        vr::EVRSettingsError error = vr::VRSettingsError_None;
+        vrSettings->GetString(vr::k_pch_audio_Section, vr::k_pch_audio_OnPlaybackDevice_String, BUFFER, BUFFER_SIZE, &error);
+        if (error == vr::VRSettingsError_None) {
+            result = BUFFER;
+        }
+    }
+    return result;
+}
+
 vr::IVRSystem* acquireOpenVrSystem() {
     bool hmdPresent = vr::VR_IsHmdPresent();
     if (hmdPresent) {
@@ -82,6 +97,7 @@ vr::IVRSystem* acquireOpenVrSystem() {
             #endif
             vr::EVRInitError eError = vr::VRInitError_None;
             activeHmd = vr::VR_Init(&eError, vr::VRApplication_Scene);
+
             #if DEV_BUILD
                 qCDebug(displayplugins) << "OpenVR display: HMD is " << activeHmd << " error is " << eError;
             #endif

--- a/plugins/openvr/src/OpenVrHelpers.h
+++ b/plugins/openvr/src/OpenVrHelpers.h
@@ -25,6 +25,7 @@ bool openVrQuitRequested();
 void enableOpenVrKeyboard(PluginContainer* container);
 void disableOpenVrKeyboard();
 bool isOpenVrKeyboardShown();
+QString getVrSettingString(const char* section, const char* setting);
 
 
 template<typename F>


### PR DESCRIPTION
The SteamVR settings page has a dialog that will set the audio targets for input and output when SteamVR starts, as seen here

![image](https://user-images.githubusercontent.com/1533642/27096884-5a1ae996-5027-11e7-97f5-be325eda4875.png)

This PR exposes the values selected for when SteamVR active.  As a result, when using the OpenVR plugin to view Interface in an HMD, the audio for the application should switch to the targeted device.

## Testing

Testing requires a Vive HMD.

* Start SteamVR manually
* Edit SteamVR settings to target a specific device (like the Vive headset) when SteamVR is active.  Note that this will change your default audio output for the duration of SteamVR being open, so you may want to set whatever your actual desired default audio device is in the "When SteamVR is exited section"
* Exit SteamVR manually
* Start Interface in non-HMD mode.  Go to a location with audio and verify it is coming out of your normally selected audio device.
* Switch to the OpenVR display plugin
* Verify audio is coming out of the device you selected in the SteamVR settings panel.  
* Switch back to desktop mode
* Verify audio is coming out of your normally selected audio device.
