### PR TITLE
Small rendering improvements based on spectator-camera changes

### DIFF
--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -40,9 +40,9 @@ Antialiasing::~Antialiasing() {
     }
 }
 
-const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
-    int width = DependencyManager::get<FramebufferCache>()->getFrameBufferSize().width();
-    int height = DependencyManager::get<FramebufferCache>()->getFrameBufferSize().height();
+const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline(RenderArgs* args) {
+    int width = args->_viewport.z;
+    int height = args->_viewport.w;
 
     if (_antialiasingBuffer && _antialiasingBuffer->getSize() != uvec2(width, height)) {
         _antialiasingBuffer.reset();
@@ -115,10 +115,8 @@ void Antialiasing::run(const render::RenderContextPointer& renderContext, const 
         batch.setViewportTransform(args->_viewport);
 
         // FIXME: NEED to simplify that code to avoid all the GeometryCahce call, this is purely pixel manipulation
-        auto framebufferCache = DependencyManager::get<FramebufferCache>();
-        QSize framebufferSize = framebufferCache->getFrameBufferSize();
-        float fbWidth = framebufferSize.width();
-        float fbHeight = framebufferSize.height();
+        float fbWidth = renderContext->args->_viewport.z;
+        float fbHeight = renderContext->args->_viewport.w;
         // float sMin = args->_viewport.x / fbWidth;
         // float sWidth = args->_viewport.z / fbWidth;
         // float tMin = args->_viewport.y / fbHeight;
@@ -133,10 +131,10 @@ void Antialiasing::run(const render::RenderContextPointer& renderContext, const 
         batch.setModelTransform(Transform());
 
         // FXAA step
-        getAntialiasingPipeline();
+        auto pipeline = getAntialiasingPipeline(renderContext->args);
         batch.setResourceTexture(0, sourceBuffer->getRenderBuffer(0));
         batch.setFramebuffer(_antialiasingBuffer);
-        batch.setPipeline(getAntialiasingPipeline());
+        batch.setPipeline(pipeline);
 
         // initialize the view-space unpacking uniforms using frustum data
         float left, right, bottom, top, nearVal, farVal;

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -19,7 +19,6 @@
 #include "AntialiasingEffect.h"
 #include "StencilMaskPass.h"
 #include "TextureCache.h"
-#include "FramebufferCache.h"
 #include "DependencyManager.h"
 #include "ViewFrustum.h"
 #include "GeometryCache.h"
@@ -51,7 +50,7 @@ const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline(RenderArgs* ar
     if (!_antialiasingBuffer) {
         // Link the antialiasing FBO to texture
         _antialiasingBuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("antialiasing"));
-        auto format = gpu::Element::COLOR_SRGBA_32; // DependencyManager::get<FramebufferCache>()->getLightingTexture()->getTexelFormat();
+        auto format = gpu::Element::COLOR_SRGBA_32;
         auto defaultSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT);
         _antialiasingTexture = gpu::Texture::createRenderBuffer(format, width, height, gpu::Texture::SINGLE_MIP, defaultSampler);
         _antialiasingBuffer->setRenderBuffer(0, _antialiasingTexture);

--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -33,7 +33,7 @@ public:
     void configure(const Config& config) {}
     void run(const render::RenderContextPointer& renderContext, const gpu::FramebufferPointer& sourceBuffer);
 
-    const gpu::PipelinePointer& getAntialiasingPipeline();
+    const gpu::PipelinePointer& getAntialiasingPipeline(RenderArgs* args);
     const gpu::PipelinePointer& getBlendPipeline();
 
 private:

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -19,7 +19,6 @@
 #include <ViewFrustum.h>
 
 #include "GeometryCache.h"
-#include "FramebufferCache.h"
 #include "TextureCache.h"
 #include "DeferredLightingEffect.h"
 
@@ -410,7 +409,6 @@ void DebugDeferredBuffer::run(const RenderContextPointer& renderContext, const I
         batch.setViewportTransform(args->_viewport);
 
         const auto geometryBuffer = DependencyManager::get<GeometryCache>();
-        const auto framebufferCache = DependencyManager::get<FramebufferCache>();
         const auto textureCache = DependencyManager::get<TextureCache>();
 
         glm::mat4 projMat;

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -418,10 +418,7 @@ model::MeshPointer DeferredLightingEffect::getSpotLightMesh() {
 }
 
 void PreparePrimaryFramebuffer::run(const RenderContextPointer& renderContext, gpu::FramebufferPointer& primaryFramebuffer) {
-
-    auto framebufferCache = DependencyManager::get<FramebufferCache>();
-    auto framebufferSize = framebufferCache->getFrameBufferSize();
-    glm::uvec2 frameSize(framebufferSize.width(), framebufferSize.height());
+    glm::uvec2 frameSize(renderContext->args->_viewport.z, renderContext->args->_viewport.w);
 
     // Resizing framebuffers instead of re-building them seems to cause issues with threaded 
     // rendering


### PR DESCRIPTION
At @samcake's request, this PR takes some rendering changes present in PR #10678 (whose target is the `spectator-camera` branch) and applies them to the `master` branch. These changes reduce the system's dependency on the `FramebufferCache` singleton.

**Test Plan:**
- General rendering smoke test: go to `dev-welcome` and verify that everything renders as you'd expect both in desktop mode and in HMD.