### PR TITLE
Make the PAL's tab background color white

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -128,7 +128,7 @@ Rectangle {
         pal.sendToScript({method: 'refreshNearby', params: params});
     }
 
-    Item {
+    Rectangle {
         id: palTabContainer;
         // Anchors
         anchors {
@@ -137,6 +137,7 @@ Rectangle {
             left: parent.left;
             right: parent.right;
         }
+        color: "white";
         Rectangle {
             id: tabSelectorContainer;
             // Anchors


### PR DESCRIPTION
Trivial fix.

**Test Plan:**
1. Open the PAL.
2. Verify that the background color behind the tables in both the "NEARBY" and "CONNECTIONS" tabs is white instead of gray. See image below for clarification.

![image](https://user-images.githubusercontent.com/3409031/27108461-2343a694-5052-11e7-8193-52e16dc81815.png)
