### PR TITLE
avatar whitelist

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -231,6 +231,9 @@ void AvatarMixer::manageIdentityData(const SharedNodePointer& node) {
 }
 
 bool AvatarMixer::isAvatarInWhitelist(const QUrl& url) {
+    // The avatar is in the whitelist if:
+    // 1. The avatar's URL's host matches one of the hosts of the URLs in the whitelist AND
+    // 2. The avatar's URL's path starts with the path of that same URL in the whitelist
     for (const auto& whiteListedPrefix : _avatarWhitelist) {
         auto whiteListURL = QUrl::fromUserInput(whiteListedPrefix);
         // check if this script URL matches the whitelist domain and, optionally, is beneath the path

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -132,7 +132,7 @@ void AvatarMixer::start() {
             auto start = usecTimestampNow();
             nodeList->nestedEach([&](NodeList::const_iterator cbegin, NodeList::const_iterator cend) {
                 std::for_each(cbegin, cend, [&](const SharedNodePointer& node) {
-                    manageDisplayName(node);
+                    manageIdentityData(node);
                     ++_sumListeners;
                 });
             }, &lockWait, &nodeTransform, &functor);
@@ -183,8 +183,9 @@ void AvatarMixer::start() {
 
 // NOTE: nodeData->getAvatar() might be side effected, must be called when access to node/nodeData
 // is guaranteed to not be accessed by other thread
-void AvatarMixer::manageDisplayName(const SharedNodePointer& node) {
+void AvatarMixer::manageIdentityData(const SharedNodePointer& node) {
     AvatarMixerClientData* nodeData = reinterpret_cast<AvatarMixerClientData*>(node->getLinkedData());
+    bool sendIdentity = false;
     if (nodeData && nodeData->getAvatarSessionDisplayNameMustChange()) {
         AvatarData& avatar = nodeData->getAvatar();
         const QString& existingBaseDisplayName = nodeData->getBaseDisplayName();
@@ -210,9 +211,36 @@ void AvatarMixer::manageDisplayName(const SharedNodePointer& node) {
         soFar.second++; // refcount
         nodeData->flagIdentityChange();
         nodeData->setAvatarSessionDisplayNameMustChange(false);
-        sendIdentityPacket(nodeData, node); // Tell node whose name changed about its new session display name.
+        sendIdentity = true;
         qCDebug(avatars) << "Giving session display name" << sessionDisplayName << "to node with ID" << node->getUUID();
     }
+    if (nodeData && nodeData->getAvatarSkeletonModelUrlMustChange()) { // never true for an empty _avatarWhitelist
+        nodeData->setAvatarSkeletonModelUrlMustChange(false);
+        AvatarData& avatar = nodeData->getAvatar();
+        static const QUrl emptyURL("");
+        QUrl url = avatar.cannonicalSkeletonModelURL(emptyURL);
+        if (!isAvatarInWhitelist(url)) {
+            qCDebug(avatars) << "Forbidden avatar" << nodeData->getNodeID() << avatar.getSkeletonModelURL() << "replaced with" << (_replacementAvatar.isEmpty() ? "default" : _replacementAvatar);
+            avatar.setSkeletonModelURL(_replacementAvatar);
+            sendIdentity = true;
+        }
+    }
+    if (sendIdentity) {
+        sendIdentityPacket(nodeData, node); // Tell node whose name changed about its new session display name or avatar.
+    }
+}
+
+bool AvatarMixer::isAvatarInWhitelist(const QUrl& url) {
+    for (const auto& whiteListedPrefix : _avatarWhitelist) {
+        auto whiteListURL = QUrl::fromUserInput(whiteListedPrefix);
+        // check if this script URL matches the whitelist domain and, optionally, is beneath the path
+        if (url.host().compare(whiteListURL.host(), Qt::CaseInsensitive) == 0 &&
+            url.path().startsWith(whiteListURL.path(), Qt::CaseInsensitive)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void AvatarMixer::throttle(std::chrono::microseconds duration, int frame) {
@@ -402,12 +430,16 @@ void AvatarMixer::handleAvatarIdentityPacket(QSharedPointer<ReceivedMessage> mes
             AvatarData::parseAvatarIdentityPacket(message->getMessage(), identity);
             bool identityChanged = false;
             bool displayNameChanged = false;
-            avatar.processAvatarIdentity(identity, identityChanged, displayNameChanged);
+            bool skeletonModelUrlChanged = false;
+            avatar.processAvatarIdentity(identity, identityChanged, displayNameChanged, skeletonModelUrlChanged);
             if (identityChanged) {
                 QMutexLocker nodeDataLocker(&nodeData->getMutex());
                 nodeData->flagIdentityChange();
                 if (displayNameChanged) {
                     nodeData->setAvatarSessionDisplayNameMustChange(true);
+                }
+                if (skeletonModelUrlChanged && !_avatarWhitelist.isEmpty()) {
+                    nodeData->setAvatarSkeletonModelUrlMustChange(true);
                 }
             }
         }
@@ -764,4 +796,19 @@ void AvatarMixer::parseDomainServerSettings(const QJsonObject& domainSettings) {
     qCDebug(avatars) << "This domain requires a minimum avatar scale of" << _domainMinimumScale
                      << "and a maximum avatar scale of" << _domainMaximumScale;
 
+    const QString AVATAR_WHITELIST_DEFAULT{ "" };
+    static const QString AVATAR_WHITELIST_OPTION = "avatar_whitelist";
+    _avatarWhitelist = domainSettings[AVATARS_SETTINGS_KEY].toObject()[AVATAR_WHITELIST_OPTION].toString(AVATAR_WHITELIST_DEFAULT).split(',', QString::KeepEmptyParts);
+
+     static const QString REPLACEMENT_AVATAR_OPTION = "replacement_avatar";
+    _replacementAvatar = domainSettings[AVATARS_SETTINGS_KEY].toObject()[REPLACEMENT_AVATAR_OPTION].toString(REPLACEMENT_AVATAR_DEFAULT);
+
+    if ((_avatarWhitelist.count() == 1) && _avatarWhitelist[0].isEmpty()) {
+        _avatarWhitelist.clear(); // KeepEmptyParts above will parse "," as ["", ""] (which is ok), but "" as [""] (which is not ok).
+    }
+    if (_avatarWhitelist.isEmpty()) {
+        qCDebug(avatars) << "All avatars are allowed.";
+    } else {
+        qCDebug(avatars) << "Avatars other than" << _avatarWhitelist << "will be replaced by" << (_replacementAvatar.isEmpty() ? "default" : _replacementAvatar);
+    }
 }

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -59,7 +59,12 @@ private:
     void parseDomainServerSettings(const QJsonObject& domainSettings);
     void sendIdentityPacket(AvatarMixerClientData* nodeData, const SharedNodePointer& destinationNode);
 
-    void manageDisplayName(const SharedNodePointer& node);
+    void manageIdentityData(const SharedNodePointer& node);
+    bool isAvatarInWhitelist(const QUrl& url);
+
+    const QString REPLACEMENT_AVATAR_DEFAULT{ "" };
+    QStringList _avatarWhitelist { };
+    QString _replacementAvatar { REPLACEMENT_AVATAR_DEFAULT };
 
     p_high_resolution_clock::time_point _lastFrameTimestamp;
 

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -148,7 +148,7 @@ private:
 
     uint64_t _identityChangeTimestamp;
     bool _avatarSessionDisplayNameMustChange{ true };
-    bool _avatarSkeletonModelUrlMustChange{ true };
+    bool _avatarSkeletonModelUrlMustChange{ false };
 
     int _numAvatarsSentLastFrame = 0;
     int _numFramesSinceAdjustment = 0;

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -65,6 +65,8 @@ public:
     void flagIdentityChange() { _identityChangeTimestamp = usecTimestampNow(); }
     bool getAvatarSessionDisplayNameMustChange() const { return _avatarSessionDisplayNameMustChange; }
     void setAvatarSessionDisplayNameMustChange(bool set = true) { _avatarSessionDisplayNameMustChange = set; }
+    bool getAvatarSkeletonModelUrlMustChange() const { return _avatarSkeletonModelUrlMustChange; }
+    void setAvatarSkeletonModelUrlMustChange(bool set = true) { _avatarSkeletonModelUrlMustChange = set; }
 
     void resetNumAvatarsSentLastFrame() { _numAvatarsSentLastFrame = 0; }
     void incrementNumAvatarsSentLastFrame() { ++_numAvatarsSentLastFrame; }
@@ -146,6 +148,7 @@ private:
 
     uint64_t _identityChangeTimestamp;
     bool _avatarSessionDisplayNameMustChange{ true };
+    bool _avatarSkeletonModelUrlMustChange{ true };
 
     int _numAvatarsSentLastFrame = 0;
     int _numFramesSinceAdjustment = 0;

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -866,6 +866,22 @@
           "help": "Limits the scale of avatars in your domain. Cannot be greater than 1000.",
           "placeholder": 3.0,
           "default": 3.0
+        },
+        {
+          "name": "avatar_whitelist",
+          "label": "Avatars Allowed from:",
+          "help": "Comma separated list of URLs (with optional paths) that avatar .fst files are allowed from. If someone attempts to use an avatar with a different domain, it will be rejected and the replacement avatar will be used. If left blank, any domain is allowed.",
+          "placeholder": "",
+          "default": "",
+          "advanced": true
+        },
+        {
+          "name": "replacement_avatar",
+          "label": "Replacement Avatar for disallowed avatars",
+          "help": "A URL for an avatar .fst to be used when someone tries to use an avatar that is not allowed. If left blank, the generic defalt avatar is used.",
+          "placeholder": "",
+          "default": "",
+          "advanced": true
         }
       ]
     },

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -878,7 +878,7 @@
         {
           "name": "replacement_avatar",
           "label": "Replacement Avatar for disallowed avatars",
-          "help": "A URL for an avatar .fst to be used when someone tries to use an avatar that is not allowed. If left blank, the generic defalt avatar is used.",
+          "help": "A URL for an avatar .fst to be used when someone tries to use an avatar that is not allowed. If left blank, the generic default avatar is used.",
           "placeholder": "",
           "default": "",
           "advanced": true

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5292,6 +5292,11 @@ void Application::nodeActivated(SharedNodePointer node) {
 
     if (node->getType() == NodeType::AvatarMixer) {
         // new avatar mixer, send off our identity packet on next update loop
+        // Reset skeletonModelUrl if the last server modified our choice.
+        static const QUrl empty{};
+        if (getMyAvatar()->getFullAvatarURLFromPreferences() != getMyAvatar()->cannonicalSkeletonModelURL(empty)) {
+            getMyAvatar()->resetFullAvatarURL();
+        }
         getMyAvatar()->markIdentityDataChanged();
         getMyAvatar()->resetLastSent();
     }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1504,7 +1504,7 @@ QUrl AvatarData::cannonicalSkeletonModelURL(const QUrl& emptyURL) const {
     return _skeletonModelURL.scheme() == "file" ? emptyURL : _skeletonModelURL;
 }
 
-void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged) {
+void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged, bool& skeletonModelUrlChanged) {
 
     if (identity.sequenceId < _identitySequenceId) {
         qCDebug(avatars) << "Ignoring older identity packet for avatar" << getSessionUUID()
@@ -1517,6 +1517,7 @@ void AvatarData::processAvatarIdentity(const Identity& identity, bool& identityC
     if (_firstSkeletonCheck || (identity.skeletonModelURL != cannonicalSkeletonModelURL(emptyURL))) {
         setSkeletonModelURL(identity.skeletonModelURL);
         identityChanged = true;
+        skeletonModelUrlChanged = true;
         if (_firstSkeletonCheck) {
             displayNameChanged = true;
         }

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -537,7 +537,7 @@ public:
 
     static void parseAvatarIdentityPacket(const QByteArray& data, Identity& identityOut);
 
-    // identityChanged returns true if identity has changed, false otherwise. Similarly for displaNameChanged and skeletonModelUrlChange.
+    // identityChanged returns true if identity has changed, false otherwise. Similarly for displayNameChanged and skeletonModelUrlChange.
     void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged, bool& skeletonModelUrlChanged);
 
     QByteArray identityByteArray() const;

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -368,6 +368,7 @@ public:
     virtual ~AvatarData();
 
     static const QUrl& defaultFullAvatarModelUrl();
+    QUrl cannonicalSkeletonModelURL(const QUrl& empty) const;
 
     virtual bool isMyAvatar() const { return false; }
 
@@ -536,9 +537,8 @@ public:
 
     static void parseAvatarIdentityPacket(const QByteArray& data, Identity& identityOut);
 
-    // identityChanged returns true if identity has changed, false otherwise.
-    // displayNameChanged returns true if displayName has changed, false otherwise.
-    void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged);
+    // identityChanged returns true if identity has changed, false otherwise. Similarly for displaNameChanged and skeletonModelUrlChange.
+    void processAvatarIdentity(const Identity& identity, bool& identityChanged, bool& displayNameChanged, bool& skeletonModelUrlChanged);
 
     QByteArray identityByteArray() const;
 
@@ -697,7 +697,6 @@ protected:
     QVector<AttachmentData> _attachmentData;
     QString _displayName;
     QString _sessionDisplayName { };
-    QUrl cannonicalSkeletonModelURL(const QUrl& empty) const;
 
     QHash<QString, int> _jointIndices; ///< 1-based, since zero is returned for missing keys
     QStringList _jointNames; ///< in order of depth-first traversal

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -148,8 +148,9 @@ void AvatarHashMap::processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> 
         auto avatar = newOrExistingAvatar(identity.uuid, sendingNode);
         bool identityChanged = false;
         bool displayNameChanged = false;
+        bool skeletonModelUrlChanged = false;
         // In this case, the "sendingNode" is the Avatar Mixer.
-        avatar->processAvatarIdentity(identity, identityChanged, displayNameChanged);
+        avatar->processAvatarIdentity(identity, identityChanged, displayNameChanged, skeletonModelUrlChanged);
     }
 }
 


### PR DESCRIPTION
New advanced avatar domain settings: Avatars Allowd from, and Replacement Avatar for disallowed avatars.

**Test plan**:
- Settings -> Avatars should be unchanged.
- But 'Show advanced' should make the two new settings visible. Check the explanations.
- Pick a single, specific allowed avatar in domain setttings (and leave replacement empty). Any other avatar you pick should go to system default (upon changing within the domain, or entering the domain wearing a different avatar).
 -- Make sure other users see you as the default avatar.
 -- Make sure your setting remains what picked. E.g., Settings->Avatar->Appearance shoudl be the avatar you picked in Interface (rather than what the domain sets it to). If you quit Interface and get rid of the single allowed avatar in the domain settings, and then restart both the domain server and Interface, you should be your Interface choice again.
 -- Make sure that when you to to a different domain, you have your Interface choice back again, rather than what the last domain made you be.
- Pick a specific replacement .fst file, and repeat the above.
 -- You'll always be the replacement in the domain (for yourself and as others see you), not what you picked in Interface nor the default avatar.
 -- Make sure it won't let you be the default avatar (empty Appearance field in settings).
- Make a comma separated list of specifical allowed avatar .fst urls and/or domains (with no path), and repeat the above.
- Try an empty string among the list (e.g., two commas together within the list) and confirm that the default avatar is now allowed.
- Make sure that an empty list (not even comas) does indeed allow everything!