### PR TITLE
Fix crash on exit when tablet is open

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1721,6 +1721,10 @@ void Application::cleanupBeforeQuit() {
 
     // Cleanup all overlays after the scripts, as scripts might add more
     _overlays.cleanupAllOverlays();
+    // The cleanup process enqueues the transactions but does not process them.  Calling this here will force the actual 
+    // removal of the items.  
+    // See https://highfidelity.fogbugz.com/f/cases/5328
+    _main3DScene->processTransactionQueue();
 
     // first stop all timers directly or by invokeMethod
     // depending on what thread they run in


### PR DESCRIPTION
Technically this will trigger a crash if the tablet has EVER been open, or if any script has a creates a Web3DOverlay and doesn't clean it up.

The cleanup code now destroys the `OffscreenQmlSurfaceCache` earlier than it used to (part of the changes for Qt 5.9).  However, the `Web3DOverlay` destructor references the cache and will crash if it doesn't exist.  In theory the overlays are supposed to have been cleaned up before we destroy the cache, but it turns out that the call to `_overlays.cleanupAllOverlays();` enqueues a bunch of scene transactions to remove the overlays, but does not actually execute the transaction.  As a result, the scene holds on to the `Web3DOverlay` object long after the `cleanupAllOverlays` call, right up until the `Scene` destructor, which then causes a crash if a `Web3DOverlay` was created and never destoyed.

This PR adds an explicit call to process the pending transactions right after `cleanupAllOverlays` which should ensure that the overlays are destroyed _then_.

## Testing

* Open interface
* Open the tablet interface (if running in desktop mode you may need to go into the general preferences and uncheck "Desktop tablet becomes toolbar")
* Exit interface

In the current dev download, this will crash on exit, every time.  In this build it should exit normally. 

