### PR TITLE
Make the Spectator button only appear in HMD (also add a debug mode for devs)

### DIFF
--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -187,12 +187,6 @@
         setDisplay(monitorShowsCameraView);
     }
 
-    function onHMDChanged(isHMDMode) {
-        // Will also eventually enable disable app, camera, etc.
-        setDisplay(monitorShowsCameraView);
-        addOrRemoveButton(false, isHMDMode);
-    }
-
     //
     // Function Name: addOrRemoveButton()
     //
@@ -404,6 +398,26 @@
                 break;
             default:
                 print('Unrecognized message from SpectatorCamera.qml:', JSON.stringify(message));
+        }
+    }
+
+    //
+    // Function Name: onHMDChanged()
+    //
+    // Relevant Variables:
+    // None
+    // 
+    // Arguments:
+    // isHMDMode: "true" if HMD is on; "false" otherwise
+    // 
+    // Description:
+    // Called from C++ when HMD mode is changed
+    //
+    function onHMDChanged(isHMDMode) {
+        setDisplay(monitorShowsCameraView);
+        addOrRemoveButton(false, isHMDMode);
+        if (!isHMDMode && !showSpectatorInDesktop) {
+            spectatorCameraOff();
         }
     }
 

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -194,7 +194,7 @@
     }
 
     //
-    // Function Names: addOrRemoveButton()
+    // Function Name: addOrRemoveButton()
     //
     // Relevant Variables:
     // button: The tablet button.
@@ -203,7 +203,7 @@
     // showInDesktop: Set to "true" to show the "SPECTATOR" app in desktop mode
     // 
     // Arguments:
-    // forceRemove: Set to "true" to force removal of the button, i.e. upon shutdown
+    // shouldntAdd: Set to "true" if you don't want to add the button, i.e. upon shutdown
     // isHMDMode: "true" if user is in HMD; false otherwise
     // 
     // Description:
@@ -212,10 +212,10 @@
     var button = false;
     var buttonName = "SPECTATOR";
     var tablet = null;
-    var showSpectatorInDesktop = false;
-    function addOrRemoveButton(forceRemove, isHMDMode) {
+    var showSpectatorInDesktop = true;
+    function addOrRemoveButton(shouldntAdd, isHMDMode) {
         if (!button) {
-            if ((isHMDMode || showSpectatorInDesktop) && !forceRemove) {
+            if ((isHMDMode || showSpectatorInDesktop) && !shouldntAdd) {
                 button = tablet.addButton({
                     text: buttonName
                 });
@@ -226,7 +226,7 @@
             tablet.removeButton(button);
             button = false;
         } else {
-            print("ERROR adding/removing Spectator button!")
+            print("ERROR adding/removing Spectator button!");
         }
     }
 

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -197,7 +197,7 @@
     // showInDesktop: Set to "true" to show the "SPECTATOR" app in desktop mode
     // 
     // Arguments:
-    // shouldntAdd: Set to "true" if you don't want to add the button, i.e. upon shutdown
+    // isShuttingDown: Set to "true" if you're calling this function upon script shutdown
     // isHMDMode: "true" if user is in HMD; false otherwise
     // 
     // Description:
@@ -207,18 +207,20 @@
     var buttonName = "SPECTATOR";
     var tablet = null;
     var showSpectatorInDesktop = true;
-    function addOrRemoveButton(shouldntAdd, isHMDMode) {
+    function addOrRemoveButton(isShuttingDown, isHMDMode) {
         if (!button) {
-            if ((isHMDMode || showSpectatorInDesktop) && !shouldntAdd) {
+            if ((isHMDMode || showSpectatorInDesktop) && !isShuttingDown) {
                 button = tablet.addButton({
                     text: buttonName
                 });
                 button.clicked.connect(onTabletButtonClicked);
             }
         } else if (button) {
-            button.clicked.disconnect(onTabletButtonClicked);
-            tablet.removeButton(button);
-            button = false;
+            if ((!showSpectatorInDesktop || isShuttingDown) && !isHMDMode) {
+                button.clicked.disconnect(onTabletButtonClicked);
+                tablet.removeButton(button);
+                button = false;
+            }
         } else {
             print("ERROR adding/removing Spectator button!");
         }

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -17,7 +17,8 @@
     //
     // FUNCTION VAR DECLARATIONS
     //
-    var sendToQml, onTabletScreenChanged, fromQml, onTabletButtonClicked, wireEventBridge, startup, shutdown;
+    var sendToQml, addOrRemoveButton, onTabletScreenChanged, fromQml,
+        onTabletButtonClicked, wireEventBridge, startup, shutdown;
 
 
 
@@ -189,15 +190,51 @@
     function onHMDChanged(isHMDMode) {
         // Will also eventually enable disable app, camera, etc.
         setDisplay(monitorShowsCameraView);
+        addOrRemoveButton(false, isHMDMode);
+    }
+
+    //
+    // Function Names: addOrRemoveButton()
+    //
+    // Relevant Variables:
+    // button: The tablet button.
+    // buttonName: The name of the button.
+    // tablet: The tablet instance to be modified.
+    // showInDesktop: Set to "true" to show the "SPECTATOR" app in desktop mode
+    // 
+    // Arguments:
+    // forceRemove: Set to "true" to force removal of the button, i.e. upon shutdown
+    // isHMDMode: "true" if user is in HMD; false otherwise
+    // 
+    // Description:
+    // Used to add or remove the "SPECTATOR" app button from the HUD/tablet
+    //
+    var button = false;
+    var buttonName = "SPECTATOR";
+    var tablet = null;
+    var showSpectatorInDesktop = false;
+    function addOrRemoveButton(forceRemove, isHMDMode) {
+        if (!button) {
+            if ((isHMDMode || showSpectatorInDesktop) && !forceRemove) {
+                button = tablet.addButton({
+                    text: buttonName
+                });
+                button.clicked.connect(onTabletButtonClicked);
+            }
+        } else if (button) {
+            button.clicked.disconnect(onTabletButtonClicked);
+            tablet.removeButton(button);
+            button = false;
+        } else {
+            print("ERROR adding/removing Spectator button!")
+        }
     }
 
     //
     // Function Name: startup()
     //
     // Relevant Variables:
-    // button: The tablet button.
-    // buttonName: The name of the button.
-    // tablet: The tablet instance to be modified.
+    // None
     // 
     // Arguments:
     // None
@@ -205,15 +242,9 @@
     // Description:
     // startup() will be called when the script is loaded.
     //
-    var button;
-    var buttonName = "SPECTATOR";
-    var tablet = null;
     function startup() {
         tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
-        button = tablet.addButton({
-            text: buttonName
-        });
-        button.clicked.connect(onTabletButtonClicked);
+        addOrRemoveButton(false, HMD.active);
         tablet.screenChanged.connect(onTabletScreenChanged);
         Window.domainChanged.connect(spectatorCameraOff);
         Controller.keyPressEvent.connect(keyPressEvent);
@@ -320,7 +351,9 @@
     function onTabletScreenChanged(type, url) {
         wireEventBridge(shouldActivateButton);
         // for toolbar mode: change button to active when window is first openend, false otherwise.
-        button.editProperties({ isActive: shouldActivateButton });
+        if (button) {
+            button.editProperties({ isActive: shouldActivateButton });
+        }
         shouldActivateButton = false;
         onSpectatorCameraScreen = false;
     }
@@ -389,8 +422,7 @@
     function shutdown() {
         spectatorCameraOff();
         Window.domainChanged.disconnect(spectatorCameraOff);
-        tablet.removeButton(button);
-        button.clicked.disconnect(onTabletButtonClicked);
+        addOrRemoveButton(true, HMD.active);
         tablet.screenChanged.disconnect(onTabletScreenChanged);
         HMD.displayModeChanged.disconnect(onHMDChanged);
         Controller.keyPressEvent.disconnect(keyPressEvent);


### PR DESCRIPTION
Does what it says on the tin. Also disables the camera when switching from HMD to Desktop.

**Test plan:**
1. Don't touch the `spectatorCamera.js` script. Open Interface in Desktop mode.
2. Verify that the "SPECTATOR" HUD button is _present_ (because the `showSpectatorInDesktop` debug flag is set to `true` in this PR by default)
3. Switch to HMD mode
4. Verify that the "SPECTATOR" Tablet app is _present_
5. Quit Interface
6. Open `spectatorCamera.js` in your favorite text editor
7. Find the `showSpectatorInDesktop` variable and set it to `false`.
8. Open Interface in HMD mode
9. Verify that the "SPECTATOR" Tablet app is _present_
10. Switch to Desktop mode
11. Verify that the "SPECTATOR" HUD button is _not present_
12. Close Interface
13. Re-open Interface in Desktop mode
14. Verify that the "SPECTATOR" HUD button is _not present_
15. Switch to HMD mode
16. Verify that the "SPECTATOR" Tablet app is _present_
17. Turn the camera ON using the Tablet app. _Switch the "MONITOR SHOWS" slider to "Camera View"._
18. Switch to Desktop mode.
19. Verify that the camera entity is gone _and that your monitor correctly shows your avatar's point of view._