### PR TITLE
fix no audio device from previously removed audio device

### DIFF
--- a/interface/src/scripting/AudioDeviceScriptingInterface.cpp
+++ b/interface/src/scripting/AudioDeviceScriptingInterface.cpp
@@ -48,15 +48,31 @@ AudioDeviceScriptingInterface::AudioDeviceScriptingInterface(): QAbstractListMod
     SettingsScriptingInterface* settings = SettingsScriptingInterface::getInstance();
     const QString inDevice = settings->getValue("audio_input_device", _currentInputDevice).toString();
     if (inDevice != _currentInputDevice) {
-        qCDebug(audioclient) << __FUNCTION__ << "about to call setInputDeviceAsync() device: [" << inDevice << "] _currentInputDevice:" << _currentInputDevice;
-        setInputDeviceAsync(inDevice);
+        // before using the old setting, check to make sure the device still exists....
+        bool inDeviceExists = DependencyManager::get<AudioClient>()->getNamedAudioDeviceForModeExists(QAudio::AudioInput, inDevice);
+
+        if (inDeviceExists) {
+            qCDebug(audioclient) << __FUNCTION__ << "about to call setInputDeviceAsync() device: [" << inDevice << "] _currentInputDevice:" << _currentInputDevice;
+            setInputDeviceAsync(inDevice);
+        } else {
+            qCDebug(audioclient) << __FUNCTION__ << "previously selected device no longer exists inDevice: [" << inDevice << "] keeping device _currentInputDevice:" << _currentInputDevice;
+        }
     }
 
     // If the audio_output_device setting is not available, use the _currentOutputDevice
     auto outDevice = settings->getValue("audio_output_device", _currentOutputDevice).toString();
+
     if (outDevice != _currentOutputDevice) {
-        qCDebug(audioclient) << __FUNCTION__ << "about to call setOutputDeviceAsync() outDevice: [" << outDevice << "] _currentOutputDevice:" << _currentOutputDevice;
-        setOutputDeviceAsync(outDevice);
+        // before using the old setting, check to make sure the device still exists....
+        bool outDeviceExists = DependencyManager::get<AudioClient>()->getNamedAudioDeviceForModeExists(QAudio::AudioOutput, outDevice);
+
+        if (outDeviceExists) {
+            qCDebug(audioclient) << __FUNCTION__ << "about to call setOutputDeviceAsync() outDevice: [" << outDevice << "] _currentOutputDevice:" << _currentOutputDevice;
+            setOutputDeviceAsync(outDevice);
+        } else {
+            qCDebug(audioclient) << __FUNCTION__ << "previously selected device no longer exists outDevice: [" << outDevice << "] keeping device _currentOutputDevice:" << _currentOutputDevice;
+        }
+
     }
 }
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -395,6 +395,11 @@ QAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
     return (mode == QAudio::AudioInput) ? QAudioDeviceInfo::defaultInputDevice() : QAudioDeviceInfo::defaultOutputDevice();
 }
 
+bool AudioClient::getNamedAudioDeviceForModeExists(QAudio::Mode mode, const QString& deviceName) {
+    return (getNamedAudioDeviceForMode(mode, deviceName).deviceName() == deviceName);
+}
+
+
 // attempt to use the native sample rate and channel count
 bool nativeFormatForAudioDevice(const QAudioDeviceInfo& audioDevice,
                                 QAudioFormat& audioFormat) {

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -149,6 +149,8 @@ public:
 
     static const float CALLBACK_ACCELERATOR_RATIO;
 
+    bool getNamedAudioDeviceForModeExists(QAudio::Mode mode, const QString& deviceName);
+
 #ifdef Q_OS_WIN
     static QString friendlyNameForAudioDevice(wchar_t* guid);
 #endif


### PR DESCRIPTION
one more case of the audio device not being properly set when the previously selected audio device no longer exists.

# To test:
**In master or production**
1) run interface
2) select some audio device that you can disable (for example blue tooth headphones)
3) verify your audio device is in use and working
4) quit interface
5) turn off or disable this audio device (for example with BT headphones turn them off, or you could use the windows control panel and disable the audio device) - make sure there is some other audio device available and set to your default in windows
6) run interface
7) ---- repro no audio ----

**In this PR**
1) run interface
2) select some audio device that you can disable (for example blue tooth headphones)
3) verify your audio device is in use and working
4) quit interface
5) turn off or disable this audio device (for example with BT headphones turn them off, or you could use the windows control panel and disable the audio device) - make sure there is some other audio device available and set to your default in windows
6) run interface
7) The "default" device should be selected and working.


