### PR TITLE
Spectator Camera controller button mapping + QML Language Fix

### DIFF
--- a/interface/resources/qml/hifi/SpectatorCamera.qml
+++ b/interface/resources/qml/hifi/SpectatorCamera.qml
@@ -253,7 +253,7 @@ Rectangle {
             anchors.left: parent.left;
             anchors.top: monitorShowsSwitch.bottom;
             anchors.topMargin: 25;
-            text: "Pressing Vive's Left Thumbpad Switches Monitor View";
+            text: "Pressing Ctrl+0 Switches Monitor View";
             boxSize: 24;
             onClicked: {
                 sendToScript({method: 'changeSwitchViewFromControllerPreference', params: checked});
@@ -289,7 +289,17 @@ Rectangle {
             monitorShowsSwitch.checked = message.params;
         break;
         case 'updateControllerMappingCheckbox':
-            switchViewFromControllerCheckBox.checked = message.params;
+            switchViewFromControllerCheckBox.checked = message.setting;
+            switchViewFromControllerCheckBox.enabled = true;
+            if (message.controller === "OculusTouch") {
+                switchViewFromControllerCheckBox.text = "Clicking Left Touch's Thumbstick Switches Monitor View";
+            } else if (message.controller === "Vive") {
+                switchViewFromControllerCheckBox.text = "Clicking Left Thumb Pad Switches Monitor View";
+            } else {
+                switchViewFromControllerCheckBox.text = "Pressing Ctrl+0 Switches Monitor View";
+                switchViewFromControllerCheckBox.checked = true;
+                switchViewFromControllerCheckBox.enabled = false;
+            }
         break;
         default:
             console.log('Unrecognized message from spectatorCamera.js:', JSON.stringify(message));

--- a/interface/resources/qml/hifi/SpectatorCamera.qml
+++ b/interface/resources/qml/hifi/SpectatorCamera.qml
@@ -288,6 +288,9 @@ Rectangle {
         case 'updateMonitorShowsSwitch':
             monitorShowsSwitch.checked = message.params;
         break;
+        case 'updateControllerMappingCheckbox':
+            switchViewFromControllerCheckBox.checked = message.params;
+        break;
         default:
             console.log('Unrecognized message from spectatorCamera.js:', JSON.stringify(message));
         }

--- a/interface/resources/qml/hifi/SpectatorCamera.qml
+++ b/interface/resources/qml/hifi/SpectatorCamera.qml
@@ -253,7 +253,7 @@ Rectangle {
             anchors.left: parent.left;
             anchors.top: monitorShowsSwitch.bottom;
             anchors.topMargin: 25;
-            text: "Pressing Ctrl+0 Switches Monitor View";
+            text: "";
             boxSize: 24;
             onClicked: {
                 sendToScript({method: 'changeSwitchViewFromControllerPreference', params: checked});

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -361,7 +361,7 @@
             });
         }
         setControllerMappingStatus(switchViewFromController);
-        sendToQml({ method: 'updateControllerMappingCheckbox', params: switchViewFromController });
+        sendToQml({ method: 'updateControllerMappingCheckbox', setting: switchViewFromController, controller: controllerType });
     }
 
     //
@@ -389,8 +389,8 @@
             tablet.loadQMLSource("../SpectatorCamera.qml");
             onSpectatorCameraScreen = true;
             sendToQml({ method: 'updateSpectatorCameraCheckbox', params: !!camera });
-            sendToQml({ method: 'updateMonitorShowsSwitch', params: !!Settings.getValue('spectatorCamera/monitorShowsCameraView', false) });
-            setMonitorShowsCameraViewAndSendToQml(monitorShowsCameraView);
+            sendToQml({ method: 'updateMonitorShowsSwitch', params: monitorShowsCameraView });
+            sendToQml({ method: 'updateControllerMappingCheckbox', setting: switchViewFromController, controller: controllerType });
         }
     }
 

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -303,7 +303,7 @@
     const SWITCH_VIEW_FROM_CONTROLLER_DEFAULT = false;
     var switchViewFromController = !!Settings.getValue('spectatorCamera/switchViewFromController', SWITCH_VIEW_FROM_CONTROLLER_DEFAULT);
     function setControllerMappingStatus(status) {
-        if (status === true) {
+        if (status) {
             controllerMapping.enable();
         } else {
             controllerMapping.disable();
@@ -343,7 +343,7 @@
             controllerType = "OculusTouch";
         }
 
-        controllerMappingName = 'Hifi-SpectatorCamera-Mapping-' + Math.random();
+        controllerMappingName = 'Hifi-SpectatorCamera-Mapping';
         controllerMapping = Controller.newMapping(controllerMappingName);
         if (controllerType === "OculusTouch") {
             controllerMapping.from(Controller.Standard.LS).to(function (value) {

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -336,11 +336,11 @@
     var controllerMapping;
     var controllerType = "Other";
     function registerButtonMappings() {
-        var controllersDeviceNames = Controller.getDeviceNames();
-        if (controllersDeviceNames.indexOf("OculusTouch") !== -1) {
-            controllerType = "OculusTouch";
-        } else if (controllerDeviceNames.indexOf("Vive") !== -1) {
+        var VRDevices = Controller.getDeviceNames().toString();
+        if (VRDevices.includes("Vive")) {
             controllerType = "Vive";
+        } else if (VRDevices.includes("OculusTouch")) {
+            controllerType = "OculusTouch";
         }
 
         controllerMappingName = 'Hifi-SpectatorCamera-Mapping-' + Math.random();

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -324,6 +324,7 @@
     // Relevant Variables:
     // controllerMappingName: The name of the controller mapping
     // controllerMapping: The controller mapping itself
+    // controllerType: "OculusTouch", "Vive", "Other"
     // 
     // Arguments:
     // None
@@ -333,15 +334,32 @@
     //
     var controllerMappingName;
     var controllerMapping;
+    var controllerType = "Other";
     function registerButtonMappings() {
+        var controllersDeviceNames = Controller.getDeviceNames();
+        if (controllersDeviceNames.indexOf("OculusTouch") !== -1) {
+            controllerType = "OculusTouch";
+        } else if (controllerDeviceNames.indexOf("Vive") !== -1) {
+            controllerType = "Vive";
+        }
+
         controllerMappingName = 'Hifi-SpectatorCamera-Mapping-' + Math.random();
         controllerMapping = Controller.newMapping(controllerMappingName);
-        controllerMapping.from(Controller.Standard.LS).to(function (value) {
-            if (value === 1.0) {
-                setMonitorShowsCameraViewAndSendToQml(!monitorShowsCameraView);
-            }
-            return;
-        });
+        if (controllerType === "OculusTouch") {
+            controllerMapping.from(Controller.Standard.LS).to(function (value) {
+                if (value === 1.0) {
+                    setMonitorShowsCameraViewAndSendToQml(!monitorShowsCameraView);
+                }
+                return;
+            });
+        } else if (controllerType === "Vive") {
+            controllerMapping.from(Controller.Standard.LeftPrimaryThumb).to(function (value) {
+                if (value === 1.0) {
+                    setMonitorShowsCameraViewAndSendToQml(!monitorShowsCameraView);
+                }
+                return;
+            });
+        }
         setControllerMappingStatus(switchViewFromController);
         sendToQml({ method: 'updateControllerMappingCheckbox', params: switchViewFromController });
     }


### PR DESCRIPTION
Two main changes here:
1. Checking the bottom-most checkbox in the Spectator Camera app will now actually enable the button mapping
2. The language next to that bottom-most checkbox now changes depending on what controllers the user has attached (Touch, Vive, Other)

**Test Plan:**
- Try to break the interaction between the "Left <controller-dependent language> changes monitor view" checkbox, the "MONITOR SHOWS" slider, and what the monitor actually displays 😄 
- Ensure the "Left <controller-dependent language> changes monitor view" checkbox setting persists across Interface restarts, and persists across opening/closing the Spectator Camera application
- Ensure the "MONITOR SHOWS" slider persists across Interface restarts, and persists across opening/closing the Spectator Camera application
- Ensure the checkbox label shows language appropriate to your hand controller type (Oculus Touch vs Vive).