### PR TITLE
Fixed a bug where you could not print polaroids if you took a gif

### DIFF
--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -144,7 +144,9 @@ function onMessage(message) {
             isDomainOpen(Settings.getValue("previousSnapshotDomainID"), function (canShare) {
                 var isGif = fileExtensionMatches(message.data, "gif");      
                 isLoggedIn = Account.isLoggedIn();                        
-                isUploadingPrintableStill = canShare && Account.isLoggedIn() && !isGif;               
+                if (!isGif) {
+                    isUploadingPrintableStill = canShare && Account.isLoggedIn();
+                }
                 if (canShare) {                  
                     if (isLoggedIn) {
                         print('Sharing snapshot with audience "for_url":', message.data);


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/5386/You-should-be-able-to-print-a-snapshot-of-still-if-you-take-a-still-GIF

Test Plan:
1. Take a snapshot while still and gif are enabled
2. Verify that after taking the snap, that you can print the polaroid