### PR TITLE
Fix teleporting to another user from the PAL

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -590,14 +590,11 @@ Item {
             console.log("This avatar is no longer present. goToUserInDomain() failed.");
             return;
         }
-        var vector = Vec3.subtract(avatar.position, MyAvatar.position);
-        var distance = Vec3.length(vector);
-        var target = Vec3.multiply(Vec3.normalize(vector), distance - 2.0);
         // FIXME: We would like the avatar to recompute the avatar's "maybe fly" test at the new position, so that if high enough up,
         // the avatar goes into fly mode rather than falling. However, that is not exposed to Javascript right now.
         // FIXME: it would be nice if this used the same teleport steps and smoothing as in the teleport.js script.
         // Note, however, that this script allows teleporting to a person in the air, while teleport.js is going to a grounded target.
-        MyAvatar.orientation = Quat.lookAtSimple(MyAvatar.position, avatar.position);
-        MyAvatar.position = Vec3.sum(MyAvatar.position, target);
+        MyAvatar.position = Vec3.sum(avatar.position, Vec3.multiplyQbyV(avatar.orientation, {x: 0, y: 0, z: -2}));
+        MyAvatar.orientation = Quat.multiply(avatar.orientation, {y: 1});
     }
 }

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -243,7 +243,7 @@ Item {
                 enabled: selected && pal.activeTab == "nearbyTab" && thisNameCard.userName !== "" && isPresent;
                 hoverEnabled: enabled
                 onClicked: {
-                    AddressManager.goToUser(thisNameCard.userName);
+                    goToUserInDomain(thisNameCard.uuid);
                     UserActivityLogger.palAction("go_to_user_in_domain", thisNameCard.uuid);
                 }
                 onEntered: {
@@ -338,7 +338,7 @@ Item {
             enabled: selected && pal.activeTab == "nearbyTab" && thisNameCard.userName !== "" && isPresent;
             hoverEnabled: enabled
             onClicked: {
-                AddressManager.goToUser(thisNameCard.userName);
+                goToUserInDomain(thisNameCard.uuid);
                 UserActivityLogger.palAction("go_to_user_in_domain", thisNameCard.uuid);
             }
             onEntered: {
@@ -581,5 +581,23 @@ Item {
         if (isReleased) {
            UserActivityLogger.palAction("avatar_gain_changed", avatarUuid);
         }
+    }
+
+    // Function body by Howard Stearns 2017-01-08
+    function goToUserInDomain(avatarUuid) {
+        var avatar = AvatarList.getAvatar(avatarUuid);
+        if (!avatar) {
+            console.log("This avatar is no longer present. goToUserInDomain() failed.");
+            return;
+        }
+        var vector = Vec3.subtract(avatar.position, MyAvatar.position);
+        var distance = Vec3.length(vector);
+        var target = Vec3.multiply(Vec3.normalize(vector), distance - 2.0);
+        // FIXME: We would like the avatar to recompute the avatar's "maybe fly" test at the new position, so that if high enough up,
+        // the avatar goes into fly mode rather than falling. However, that is not exposed to Javascript right now.
+        // FIXME: it would be nice if this used the same teleport steps and smoothing as in the teleport.js script.
+        // Note, however, that this script allows teleporting to a person in the air, while teleport.js is going to a grounded target.
+        MyAvatar.orientation = Quat.lookAtSimple(MyAvatar.position, avatar.position);
+        MyAvatar.position = Vec3.sum(MyAvatar.position, target);
     }
 }

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -243,7 +243,7 @@ Item {
                 enabled: selected && pal.activeTab == "nearbyTab" && thisNameCard.userName !== "" && isPresent;
                 hoverEnabled: enabled
                 onClicked: {
-                    goToUserInDomain(thisNameCard.uuid);
+                    AddressManager.goToUser(thisNameCard.userName);
                     UserActivityLogger.palAction("go_to_user_in_domain", thisNameCard.uuid);
                 }
                 onEntered: {
@@ -338,7 +338,7 @@ Item {
             enabled: selected && pal.activeTab == "nearbyTab" && thisNameCard.userName !== "" && isPresent;
             hoverEnabled: enabled
             onClicked: {
-                goToUserInDomain(thisNameCard.uuid);
+                AddressManager.goToUser(thisNameCard.userName);
                 UserActivityLogger.palAction("go_to_user_in_domain", thisNameCard.uuid);
             }
             onEntered: {
@@ -581,23 +581,5 @@ Item {
         if (isReleased) {
            UserActivityLogger.palAction("avatar_gain_changed", avatarUuid);
         }
-    }
-
-    // Function body by Howard Stearns 2017-01-08
-    function goToUserInDomain(avatarUuid) {
-        var avatar = AvatarList.getAvatar(avatarUuid);
-        if (!avatar) {
-            console.log("This avatar is no longer present. goToUserInDomain() failed.");
-            return;
-        }
-        var vector = Vec3.subtract(avatar.position, MyAvatar.position);
-        var distance = Vec3.length(vector);
-        var target = Vec3.multiply(Vec3.normalize(vector), distance - 2.0);
-        // FIXME: We would like the avatar to recompute the avatar's "maybe fly" test at the new position, so that if high enough up,
-        // the avatar goes into fly mode rather than falling. However, that is not exposed to Javascript right now.
-        // FIXME: it would be nice if this used the same teleport steps and smoothing as in the teleport.js script.
-        // Note, however, that this script allows teleporting to a person in the air, while teleport.js is going to a grounded target.
-        MyAvatar.orientation = Quat.lookAtSimple(MyAvatar.position, avatar.position);
-        MyAvatar.position = Vec3.sum(MyAvatar.position, target);
     }
 }


### PR DESCRIPTION
Previously, teleporting to another user using the PAL would frequently result in your avatar's orientation being skewed. If you were in HMD, this was especially nauseating.

Now, that doesn't happen :)

**Test Plan:**
1. In Desktop mode, navigate to a domain with at least one other avatar in it. The other avatar's availability must be set such that you can see their username in the PAL.
2. Click on their display name or username.
3. Verify that you are teleported in front of that user and that the orientation of your avatar is correct.
4. Switch to HMD mode and perform steps (2) and (3) again.
5. Scale your avatar wayyyy up so that you're a giant compared to the other avatar! Then repeat steps (2) and (3) again.
6. Scale your avatar wayyyy down so that you're tiny compared to the other avatar! Then repeat steps (2) and (3) again.