### PR TITLE
21384: Added Support to Disabling flight from client side

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -200,6 +200,9 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::EnableAvatarCollisions, 0, true,
         avatar.get(), SLOT(updateMotionBehaviorFromMenu()));
 
+    addCheckableActionToQMenuAndActionHash(avatarMenu, MenuOption::EnableFlying, 0, true,
+        avatar.get(), SLOT(setFlyingEnabled(bool)));
+
     // Avatar > AvatarBookmarks related menus -- Note: the AvatarBookmarks class adds its own submenus here.
     auto avatarBookmarks = DependencyManager::get<AvatarBookmarks>();
     avatarBookmarks->setupMenus(this, avatarMenu);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -96,6 +96,7 @@ namespace MenuOption {
     const QString DontRenderEntitiesAsScene = "Don't Render Entities as Scene";
     const QString EchoLocalAudio = "Echo Local Audio";
     const QString EchoServerAudio = "Echo Server Audio";
+    const QString EnableFlying = "Enable Flying";
     const QString EnableAvatarCollisions = "Enable Avatar Collisions";
     const QString EnableInverseKinematics = "Enable Inverse Kinematics";
     const QString EntityScriptServerLog = "Entity Script Server Log";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2475,6 +2475,11 @@ void MyAvatar::setFlyingEnabled(bool enabled) {
 
     _enableFlying = enabled;
 }
+
+bool MyAvatar::getFlyingEnabled() {
+    return _enableFlying;
+}
+
 void MyAvatar::setCollisionsEnabled(bool enabled) {
 
     if (QThread::currentThread() != thread()) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2476,6 +2476,14 @@ void MyAvatar::setFlyingEnabled(bool enabled) {
     _enableFlying = enabled;
 }
 
+bool MyAvatar::isFlying() {
+    return _characterController.getState() == CharacterController::State::Hover;
+}
+
+bool MyAvatar::isInAir() {
+    return _characterController.getState() == CharacterController::State::InAir;
+}
+
 bool MyAvatar::getFlyingEnabled() {
     return _enableFlying;
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2487,6 +2487,7 @@ bool MyAvatar::isInAir() {
 }
 
 bool MyAvatar::getFlyingEnabled() {
+    // May return true even if client is not allowed to fly in the zone.
     return _enableFlying;
 }
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -590,7 +590,7 @@ void MyAvatar::simulate(float deltaTime) {
     auto entityTreeRenderer = qApp->getEntities();
     EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
     if (entityTree) {
-        bool flyingAllowed = true && _enableFlying;
+        bool flyingAllowed = true;
         bool collisionlessAllowed = true;
         entityTree->withWriteLock([&] {
             std::shared_ptr<ZoneEntityItem> zone = entityTreeRenderer->myAvatarZone();
@@ -626,7 +626,7 @@ void MyAvatar::simulate(float deltaTime) {
                 entityTree->recurseTreeWithOperator(&moveOperator);
             }
         });
-        _characterController.setFlyingAllowed(flyingAllowed);
+        _characterController.setFlyingAllowed(flyingAllowed && _enableFlying);
         _characterController.setCollisionlessAllowed(collisionlessAllowed);
     }
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2477,11 +2477,13 @@ void MyAvatar::setFlyingEnabled(bool enabled) {
 }
 
 bool MyAvatar::isFlying() {
+    // Avatar is Flying, and is not Falling, or Taking off
     return _characterController.getState() == CharacterController::State::Hover;
 }
 
 bool MyAvatar::isInAir() {
-    return _characterController.getState() == CharacterController::State::InAir;
+    // If Avatar is Hover, Falling, or Taking off, they are in Air.
+    return _characterController.getState() != CharacterController::State::Ground;
 }
 
 bool MyAvatar::getFlyingEnabled() {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -590,7 +590,7 @@ void MyAvatar::simulate(float deltaTime) {
     auto entityTreeRenderer = qApp->getEntities();
     EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
     if (entityTree) {
-        bool flyingAllowed = true;
+        bool flyingAllowed = true && _enableFlying;
         bool collisionlessAllowed = true;
         entityTree->withWriteLock([&] {
             std::shared_ptr<ZoneEntityItem> zone = entityTreeRenderer->myAvatarZone();
@@ -2467,6 +2467,14 @@ void MyAvatar::updateMotionBehaviorFromMenu() {
     setCollisionsEnabled(menu->isOptionChecked(MenuOption::EnableAvatarCollisions));
 }
 
+void MyAvatar::setFlyingEnabled(bool enabled) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setFlyingEnabled", Q_ARG(bool, enabled));
+        return;
+    }
+
+    _enableFlying = enabled;
+}
 void MyAvatar::setCollisionsEnabled(bool enabled) {
 
     if (QThread::currentThread() != thread()) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -590,12 +590,12 @@ void MyAvatar::simulate(float deltaTime) {
     auto entityTreeRenderer = qApp->getEntities();
     EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
     if (entityTree) {
-        bool flyingAllowed = true;
+        bool zoneAllowsFlying = true;
         bool collisionlessAllowed = true;
         entityTree->withWriteLock([&] {
             std::shared_ptr<ZoneEntityItem> zone = entityTreeRenderer->myAvatarZone();
             if (zone) {
-                flyingAllowed = zone->getFlyingAllowed();
+                zoneAllowsFlying = zone->getFlyingAllowed();
                 collisionlessAllowed = zone->getGhostingAllowed();
             }
             auto now = usecTimestampNow();
@@ -626,7 +626,7 @@ void MyAvatar::simulate(float deltaTime) {
                 entityTree->recurseTreeWithOperator(&moveOperator);
             }
         });
-        _characterController.setFlyingAllowed(flyingAllowed && _enableFlying);
+        _characterController.setFlyingAllowed(zoneAllowsFlying && _enableFlying);
         _characterController.setCollisionlessAllowed(collisionlessAllowed);
     }
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -557,7 +557,7 @@ public slots:
     void setEnableDebugDrawSensorToWorldMatrix(bool isEnabled);
     void setEnableDebugDrawIKTargets(bool isEnabled);
     void setEnableDebugDrawIKConstraints(bool isEnabled);
-    void setEnableDebugDrawIKChains(bool isEnabled);    
+    void setEnableDebugDrawIKChains(bool isEnabled);
 
     bool getEnableMeshVisible() const { return _skeletonModel->isVisible(); }
     void setEnableMeshVisible(bool isEnabled);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -491,6 +491,8 @@ public:
 
     bool hasDriveInput() const;
 
+    Q_INVOKABLE void setFlyingEnabled(bool enabled);
+
     Q_INVOKABLE void setCollisionsEnabled(bool enabled);
     Q_INVOKABLE bool getCollisionsEnabled();
     Q_INVOKABLE void setCharacterControllerEnabled(bool enabled); // deprecated
@@ -552,7 +554,8 @@ public slots:
     void setEnableDebugDrawSensorToWorldMatrix(bool isEnabled);
     void setEnableDebugDrawIKTargets(bool isEnabled);
     void setEnableDebugDrawIKConstraints(bool isEnabled);
-    void setEnableDebugDrawIKChains(bool isEnabled);
+    void setEnableDebugDrawIKChains(bool isEnabled);    
+
     bool getEnableMeshVisible() const { return _skeletonModel->isVisible(); }
     void setEnableMeshVisible(bool isEnabled);
     void setUseAnimPreAndPostRotations(bool isEnabled);
@@ -625,6 +628,7 @@ private:
     std::array<float, MAX_DRIVE_KEYS> _driveKeys;
     std::bitset<MAX_DRIVE_KEYS> _disabledDriveKeys;
 
+    bool _enableFlying { true };
     bool _wasPushing { false };
     bool _isPushing { false };
     bool _isBeingPushed { false };
@@ -767,7 +771,6 @@ private:
     ThreadSafeValueCache<controller::Pose> _rightArmControllerPoseInSensorFrameCache{ controller::Pose() };
 
     bool _hmdLeanRecenterEnabled = true;
-
     AnimPose _prePhysicsRoomPose;
     std::mutex _holdActionsMutex;
     std::vector<AvatarActionHold*> _holdActions;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -491,6 +491,8 @@ public:
 
     bool hasDriveInput() const;
 
+    Q_INVOKABLE bool isFlying();
+    Q_INVOKABLE bool isInAir();
     Q_INVOKABLE void setFlyingEnabled(bool enabled);
     Q_INVOKABLE bool getFlyingEnabled();
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -492,6 +492,7 @@ public:
     bool hasDriveInput() const;
 
     Q_INVOKABLE void setFlyingEnabled(bool enabled);
+    Q_INVOKABLE bool getFlyingEnabled();
 
     Q_INVOKABLE void setCollisionsEnabled(bool enabled);
     Q_INVOKABLE bool getCollisionsEnabled();


### PR DESCRIPTION
Added Four new interfaces to MyAvatar, and Adds a menu item under the Avatar Menu.

```javascript
void MyAvatar.setFlyingEnabled(bool); // Sets Client Flying on/off
bool MyAvatar.getFlyingEnabled(); // Gets the current setting

bool MyAvatar.isInAir(); // Returns false if avatar is on ground, true if in air, even if not flying.
bool MyAvatar.isFlying(); // Returns true if avatar is flying, but false if not.
```


To test: 

Run Interface, and in console use
isInAir and isFlying to check states while flying and on ground

setFlyingEnabled(false) should turn off flight, and not allow user to fly even if pressing up or down. until setFlyingEnabled(true)

setFlyingEnabled should not override zone rules, and while in a no-fly zone, the user should not be able to fly, regardless of the setting.

getFlyingEnabled should always return the above state.


You can also check this by using the new hookshot: While equipped, you cannot fly. When unequipped, the user should be able to fly.

http://mpassets.highfidelity.com/de2f7e5c-4945-48a0-a045-fe602d7fa4b9-v2/hookshot.json
