### PR TITLE
Fix the local lights issue

### DIFF
--- a/libraries/render-utils/src/LightClusters.cpp
+++ b/libraries/render-utils/src/LightClusters.cpp
@@ -548,6 +548,7 @@ glm::ivec3 LightClusters::updateClusters() {
 
 
 LightClusteringPass::LightClusteringPass() {
+    _lightClusters = std::make_shared<LightClusters>();
 }
 
 
@@ -566,12 +567,7 @@ void LightClusteringPass::run(const render::RenderContextPointer& renderContext,
     auto deferredTransform = inputs.get0();
     auto lightingModel = inputs.get1();
     auto surfaceGeometryFramebuffer = inputs.get2();
-    
-    
-    if (!_lightClusters) {
-        _lightClusters = std::make_shared<LightClusters>();
-    }
-    
+
     // first update the Grid with the new frustum
     if (!_freeze) {
         _lightClusters->updateFrustum(args->getViewFrustum());

--- a/scripts/developer/utilities/render/ambientOcclusionPass.qml
+++ b/scripts/developer/utilities/render/ambientOcclusionPass.qml
@@ -13,6 +13,7 @@ import "configSlider"
 import "../lib/plotperf"
 
 Column {
+    property var mainViewTask: Render.getConfig("RenderMainView")
     spacing: 8
     Column {
         id: surfaceGeometry
@@ -32,7 +33,7 @@ Column {
                 ConfigSlider {
                     label: qsTr(modelData.split(":")[0])
                     integral: (modelData.split(":")[3] == 'true')
-                    config: Render.getConfig("AmbientOcclusion")
+                    config: mainViewTask.getConfig("AmbientOcclusion")
                     property: modelData.split(":")[1]
                     max: modelData.split(":")[2]
                     min: 0.0
@@ -50,8 +51,8 @@ Column {
                     ]
                     CheckBox {
                         text: qsTr(modelData.split(":")[0])
-                        checked: Render.getConfig("AmbientOcclusion")[modelData.split(":")[1]]
-                        onCheckedChanged: { Render.getConfig("AmbientOcclusion")[modelData.split(":")[1]] = checked }
+                        checked: mainViewTask.getConfig("AmbientOcclusion")[modelData.split(":")[1]]
+                        onCheckedChanged: { mainViewTask.getConfig("AmbientOcclusion")[modelData.split(":")[1]] = checked }
                     } 
                 }
             }
@@ -62,8 +63,8 @@ Column {
                     ]
                     CheckBox {
                         text: qsTr(modelData.split(":")[0])
-                        checked: Render.getConfig("DebugAmbientOcclusion")[modelData.split(":")[1]]
-                        onCheckedChanged: { Render.getConfig("DebugAmbientOcclusion")[modelData.split(":")[1]] = checked }
+                        checked: mainViewTask.getConfig("DebugAmbientOcclusion")[modelData.split(":")[1]]
+                        onCheckedChanged: { mainViewTask.getConfig("DebugAmbientOcclusion")[modelData.split(":")[1]] = checked }
                     } 
                 }
             }    
@@ -72,7 +73,7 @@ Column {
         PlotPerf {
             title: "Timing"
             height: 50
-            object: Render.getConfig("AmbientOcclusion")
+            object: mainViewTask.getConfig("AmbientOcclusion")
             valueUnit: "ms"
             valueScale: 1
             valueNumDigits: "3"

--- a/scripts/developer/utilities/render/culling.qml
+++ b/scripts/developer/utilities/render/culling.qml
@@ -14,8 +14,9 @@ import "configSlider"
 Column {
     id: root
     spacing: 8
-    property var sceneOctree: Render.getConfig("DrawSceneOctree");
-    property var itemSelection: Render.getConfig("DrawItemSelection");
+    property var mainViewTask: Render.getConfig("RenderMainView");
+    property var sceneOctree: mainViewTask.getConfig("DrawSceneOctree");
+    property var itemSelection: mainViewTask.getConfig("DrawItemSelection");
 
      Component.onCompleted: {
         sceneOctree.enabled = true;
@@ -30,8 +31,8 @@ Column {
     Component.onDestruction: {
         sceneOctree.enabled = false;
         itemSelection.enabled = false;  
-        Render.getConfig("FetchSceneSelection").freezeFrustum = false;
-        Render.getConfig("CullSceneSelection").freezeFrustum = false;                     
+        mainViewTask.getConfig("FetchSceneSelection").freezeFrustum = false;
+        mainViewTask.getConfig("CullSceneSelection").freezeFrustum = false;                     
     }
 
     GroupBox {
@@ -45,8 +46,8 @@ Column {
                     text: "Freeze Culling Frustum"
                     checked: false
                     onCheckedChanged: { 
-                        Render.getConfig("FetchSceneSelection").freezeFrustum = checked;
-                        Render.getConfig("CullSceneSelection").freezeFrustum = checked;
+                        mainViewTask.getConfig("FetchSceneSelection").freezeFrustum = checked;
+                        mainViewTask.getConfig("CullSceneSelection").freezeFrustum = checked;
                     }
                 }
                 Label {
@@ -103,7 +104,7 @@ Column {
                 ConfigSlider {
                     label: qsTr(modelData.split(":")[0])
                     integral: true
-                    config: Render.getConfig(modelData.split(":")[1])
+                    config: mainViewTask.getConfig(modelData.split(":")[1])
                     property: "maxDrawn"
                     max: config.numDrawn
                     min: -1

--- a/scripts/developer/utilities/render/debugAmbientOcclusionPass.js
+++ b/scripts/developer/utilities/render/debugAmbientOcclusionPass.js
@@ -34,5 +34,5 @@ function setDebugCursor(x, y) {
     nx = (x / Window.innerWidth);
     ny = 1.0 - ((y) / (Window.innerHeight - 32));
 
-     Render.getConfig("DebugAmbientOcclusion").debugCursorTexcoord = { x: nx, y: ny };
+     Render.getConfig("RenderMainView").getConfig("DebugAmbientOcclusion").debugCursorTexcoord = { x: nx, y: ny };
 }

--- a/scripts/developer/utilities/render/debugSubsurfaceScattering.js
+++ b/scripts/developer/utilities/render/debugSubsurfaceScattering.js
@@ -33,5 +33,5 @@ function setDebugCursor(x, y) {
     nx = (x / Window.innerWidth);
     ny = 1.0 - ((y) / (Window.innerHeight - 32));
 
-     Render.getConfig("DebugScattering").debugCursorTexcoord = { x: nx, y: ny };
+     Render.getConfig("RenderMainView").getConfig("DebugScattering").debugCursorTexcoord = { x: nx, y: ny };
 }

--- a/scripts/developer/utilities/render/deferredLighting.qml
+++ b/scripts/developer/utilities/render/deferredLighting.qml
@@ -13,6 +13,7 @@ import "configSlider"
 
 Column {
     spacing: 8
+    property var mainViewTask: Render.getConfig("RenderMainView")
     
     Row {
         spacing: 8
@@ -29,8 +30,8 @@ Column {
                 ]
                 CheckBox {
                     text: modelData.split(":")[0]
-                    checked: Render.getConfig(modelData.split(":")[1])[modelData.split(":")[2]]
-                    onCheckedChanged: { Render.getConfig(modelData.split(":")[1])[modelData.split(":")[2]] = checked }
+                    checked: mainViewTask.getConfig(modelData.split(":")[1])[modelData.split(":")[2]]
+                    onCheckedChanged: { mainViewTask.getConfig(modelData.split(":")[1])[modelData.split(":")[2]] = checked }
                 }
             }
         }
@@ -49,8 +50,8 @@ Column {
                 ]
                 CheckBox {
                     text: modelData.split(":")[0]
-                    checked: Render.getConfig(modelData.split(":")[1])[modelData.split(":")[2]]
-                    onCheckedChanged: { Render.getConfig(modelData.split(":")[1])[modelData.split(":")[2]] = checked }
+                    checked: mainViewTask.getConfig(modelData.split(":")[1])[modelData.split(":")[2]]
+                    onCheckedChanged: { mainViewTask.getConfig(modelData.split(":")[1])[modelData.split(":")[2]] = checked }
                 }
             }
         }
@@ -69,8 +70,8 @@ Column {
                 ]
                 CheckBox {
                     text: modelData.split(":")[0]
-                    checked: Render.getConfig(modelData.split(":")[1])[modelData.split(":")[2]]
-                    onCheckedChanged: { Render.getConfig(modelData.split(":")[1])[modelData.split(":")[2]] = checked }
+                    checked: mainViewTask.getConfig(modelData.split(":")[1])[modelData.split(":")[2]]
+                    onCheckedChanged: { mainViewTask.getConfig(modelData.split(":")[1])[modelData.split(":")[2]] = checked }
                 }
             }
         }
@@ -83,7 +84,7 @@ Column {
             ConfigSlider {
                     label: qsTr(modelData.split(":")[0])
                     integral: false
-                    config: Render.getConfig(modelData.split(":")[1])
+                    config: mainViewTask.getConfig(modelData.split(":")[1])
                     property: modelData.split(":")[2]
                     max: modelData.split(":")[3]
                     min: modelData.split(":")[4]
@@ -107,7 +108,7 @@ Column {
                     ListElement { text: "Filmic"; color: "White" }
                 }
                 width: 200
-                onCurrentIndexChanged: { Render.getConfig("ToneMapping")["curve"] = currentIndex }
+                onCurrentIndexChanged: { mainViewTask.getConfig("ToneMapping")["curve"] = currentIndex }
             }
         }
     }
@@ -120,7 +121,7 @@ Column {
             anchors.left: root.left           
         }
         
-        property var config: Render.getConfig("DebugDeferredBuffer")
+        property var config: mainViewTask.getConfig("DebugDeferredBuffer")
 
         function setDebugMode(mode) {
             framebuffer.config.enabled = (mode != 0);
@@ -168,40 +169,40 @@ Column {
 
         CheckBox {
             text: "Opaques"
-            checked: Render.getConfig("DrawOpaqueBounds")["enabled"]
-            onCheckedChanged: { Render.getConfig("DrawOpaqueBounds")["enabled"] = checked }
+            checked: mainViewTask.getConfig("DrawOpaqueBounds")["enabled"]
+            onCheckedChanged: { mainViewTask.getConfig("DrawOpaqueBounds")["enabled"] = checked }
         }
         CheckBox {
             text: "Transparents"
-            checked: Render.getConfig("DrawTransparentBounds")["enabled"]
-            onCheckedChanged: { Render.getConfig("DrawTransparentBounds")["enabled"] = checked }
+            checked: mainViewTask.getConfig("DrawTransparentBounds")["enabled"]
+            onCheckedChanged: { mainViewTask.getConfig("DrawTransparentBounds")["enabled"] = checked }
         }
         CheckBox {
             text: "Overlay Opaques"
-            checked: Render.getConfig("DrawOverlayOpaqueBounds")["enabled"]
-            onCheckedChanged: { Render.getConfig("DrawOverlayOpaqueBounds")["enabled"] = checked }
+            checked: mainViewTask.getConfig("DrawOverlayOpaqueBounds")["enabled"]
+            onCheckedChanged: { mainViewTask.getConfig("DrawOverlayOpaqueBounds")["enabled"] = checked }
         }
         CheckBox {
             text: "Overlay Transparents"
-            checked: Render.getConfig("DrawOverlayTransparentBounds")["enabled"]
-            onCheckedChanged: { Render.getConfig("DrawOverlayTransparentBounds")["enabled"] = checked }
+            checked: mainViewTask.getConfig("DrawOverlayTransparentBounds")["enabled"]
+            onCheckedChanged: { mainViewTask.getConfig("DrawOverlayTransparentBounds")["enabled"] = checked }
         }
     }
     Column {
         CheckBox {
             text: "Metas"
-            checked: Render.getConfig("DrawMetaBounds")["enabled"]
-            onCheckedChanged: { Render.getConfig("DrawMetaBounds")["enabled"] = checked }
+            checked: mainViewTask.getConfig("DrawMetaBounds")["enabled"]
+            onCheckedChanged: { mainViewTask.getConfig("DrawMetaBounds")["enabled"] = checked }
         }   
         CheckBox {
             text: "Lights"
-            checked: Render.getConfig("DrawLightBounds")["enabled"]
-            onCheckedChanged: { Render.getConfig("DrawLightBounds")["enabled"] = checked; }
+            checked: mainViewTask.getConfig("DrawLightBounds")["enabled"]
+            onCheckedChanged: { mainViewTask.getConfig("DrawLightBounds")["enabled"] = checked; }
         }
         CheckBox {
             text: "Zones"
-            checked: Render.getConfig("DrawZones")["enabled"]
-            onCheckedChanged: { Render.getConfig("ZoneRenderer")["enabled"] = checked; Render.getConfig("DrawZones")["enabled"] = checked; }
+            checked: mainViewTask.getConfig("DrawZones")["enabled"]
+            onCheckedChanged: { mainViewTask.getConfig("ZoneRenderer")["enabled"] = checked; mainViewTask.getConfig("DrawZones")["enabled"] = checked; }
         }
     }
     }

--- a/scripts/developer/utilities/render/lightClustering.qml
+++ b/scripts/developer/utilities/render/lightClustering.qml
@@ -17,18 +17,19 @@ Column {
     Column {
         id: lightClustering
         spacing: 10
+        property var mainViewTask: Render.getConfig("RenderMainView");
 
         Column{
             PlotPerf {
                 title: "Light CLustering Timing"
                 height: 50
-                object: Render.getConfig("LightClustering")
+                object: mainViewTask.getConfig("LightClustering")
                 valueUnit: "ms"
                 valueScale: 1
                 valueNumDigits: "4"
                 plots: [
                     {
-                       object: Render.getConfig("LightClustering"),
+                       object: mainViewTask.getConfig("LightClustering"),
                        prop: "cpuRunTime",
                        label: "time",
                        scale: 1,
@@ -40,19 +41,19 @@ Column {
             PlotPerf {
                 title: "Lights"
                 height: 50
-                object: Render.getConfig("LightClustering")
+                object: mainViewTask.getConfig("LightClustering")
                 valueUnit: ""
                 valueScale: 1
                 valueNumDigits: "0"
                 plots: [
                     {
-                       object: Render.getConfig("LightClustering"),
+                       object: mainViewTask.getConfig("LightClustering"),
                        prop: "numClusteredLights",
                        label: "visible",
                        color: "#D959FE"
                    },
                    {
-                        object: Render.getConfig("LightClustering"),
+                        object: mainViewTask.getConfig("LightClustering"),
                         prop: "numInputLights",
                         label: "input",
                         color: "#FED959"
@@ -63,25 +64,25 @@ Column {
              PlotPerf {
                 title: "Scene Lights"
                 height: 80
-                object: Render.getConfig("LightClustering")
+                object: mainViewTask.getConfig("LightClustering")
                 valueUnit: ""
                 valueScale: 1
                 valueNumDigits: "0"
                 plots: [
                     {
-                       object: Render.getConfig("LightClustering"),
+                       object: mainViewTask.getConfig("LightClustering"),
                        prop: "numSceneLights",
                        label: "current",
                        color: "#00B4EF"
                    },
                    {
-                        object: Render.getConfig("LightClustering"),
+                        object: mainViewTask.getConfig("LightClustering"),
                         prop: "numFreeSceneLights",
                         label: "free",
                         color: "#1AC567"
                     },
                    {
-                        object: Render.getConfig("LightClustering"),
+                        object: mainViewTask.getConfig("LightClustering"),
                         prop: "numAllocatedSceneLights",
                         label: "allocated",
                         color: "#9495FF"
@@ -92,7 +93,7 @@ Column {
             ConfigSlider {
                 label: qsTr("Range Near [m]")
                 integral: false
-                config: Render.getConfig("LightClustering")
+                config: mainViewTask.getConfig("LightClustering")
                 property: "rangeNear"
                 max: 20.0
                 min: 0.1
@@ -100,7 +101,7 @@ Column {
             ConfigSlider {
                 label: qsTr("Range Far [m]")
                 integral: false
-                config: Render.getConfig("LightClustering")
+                config: mainViewTask.getConfig("LightClustering")
                 property: "rangeFar"
                 max: 500.0
                 min: 100.0
@@ -108,7 +109,7 @@ Column {
             ConfigSlider {
                 label: qsTr("Grid X")
                 integral: true
-                config: Render.getConfig("LightClustering")
+                config: mainViewTask.getConfig("LightClustering")
                 property: "dimX"
                 max: 32
                 min: 1
@@ -116,7 +117,7 @@ Column {
             ConfigSlider {
                 label: qsTr("Grid Y")
                 integral: true
-                config: Render.getConfig("LightClustering")
+                config: mainViewTask.getConfig("LightClustering")
                 property: "dimY"
                 max: 32
                 min: 1
@@ -124,33 +125,33 @@ Column {
             ConfigSlider {
                 label: qsTr("Grid Z")
                 integral: true
-                config: Render.getConfig("LightClustering")
+                config: mainViewTask.getConfig("LightClustering")
                 property: "dimZ"
                 max: 31
                 min: 1
             }
             CheckBox {
                     text: "Freeze"
-                    checked: Render.getConfig("LightClustering")["freeze"]
-                    onCheckedChanged: { Render.getConfig("LightClustering")["freeze"] = checked }
+                    checked: mainViewTask.getConfig("LightClustering")["freeze"]
+                    onCheckedChanged: { mainViewTask.getConfig("LightClustering")["freeze"] = checked }
             }
             CheckBox {
                     text: "Draw Grid"
-                    checked: Render.getConfig("DebugLightClusters")["doDrawGrid"]
-                    onCheckedChanged: { Render.getConfig("DebugLightClusters")["doDrawGrid"] = checked }
+                    checked: mainViewTask.getConfig("DebugLightClusters")["doDrawGrid"]
+                    onCheckedChanged: { mainViewTask.getConfig("DebugLightClusters")["doDrawGrid"] = checked }
             }
             CheckBox {
                     text: "Draw Cluster From Depth"
-                    checked: Render.getConfig("DebugLightClusters")["doDrawClusterFromDepth"]
-                    onCheckedChanged: { Render.getConfig("DebugLightClusters")["doDrawClusterFromDepth"] = checked }
+                    checked: mainViewTask.getConfig("DebugLightClusters")["doDrawClusterFromDepth"]
+                    onCheckedChanged: { mainViewTask.getConfig("DebugLightClusters")["doDrawClusterFromDepth"] = checked }
             }
             CheckBox {
                     text: "Draw Content"
-                    checked: Render.getConfig("DebugLightClusters")["doDrawContent"]
-                    onCheckedChanged: { Render.getConfig("DebugLightClusters")["doDrawContent"] = checked }
+                    checked: mainViewTask.getConfig("DebugLightClusters")["doDrawContent"]
+                    onCheckedChanged: { mainViewTask.getConfig("DebugLightClusters")["doDrawContent"] = checked }
             }
             Label {
-                text:  "Num Cluster Items = " + Render.getConfig("LightClustering")["numClusteredLightReferences"].toFixed(0)
+                text:  "Num Cluster Items = " + mainViewTask.getConfig("LightClustering")["numClusteredLightReferences"].toFixed(0)
             }
             
         }

--- a/scripts/developer/utilities/render/stats.qml
+++ b/scripts/developer/utilities/render/stats.qml
@@ -21,7 +21,8 @@ Item {
         spacing: 8
         anchors.fill:parent
 
-        property var config: Render.getConfig("Stats")
+        property var mainViewTask: Render.getConfig("RenderMainView");
+        property var config: mainViewTask.getConfig("Stats")
 
         function evalEvenHeight() {
             // Why do we have to do that manually ? cannot seem to find a qml / anchor / layout mode that does that ?
@@ -182,9 +183,9 @@ Item {
             ]
         }
 
-        property var drawOpaqueConfig: Render.getConfig("DrawOpaqueDeferred")
-        property var drawTransparentConfig: Render.getConfig("DrawTransparentDeferred")
-        property var drawLightConfig: Render.getConfig("DrawLight")
+        property var drawOpaqueConfig: mainViewTask.getConfig("DrawOpaqueDeferred")
+        property var drawTransparentConfig: mainViewTask.getConfig("DrawTransparentDeferred")
+        property var drawLightConfig: mainViewTask.getConfig("DrawLight")
 
         PlotPerf {
             title: "Items"
@@ -199,13 +200,13 @@ Item {
                     color: "#1AC567"
                 },
                 {
-                    object: Render.getConfig("DrawTransparentDeferred"),
+                    object: mainViewTask.getConfig("DrawTransparentDeferred"),
                     prop: "numDrawn",
                     label: "Translucents",
                     color: "#00B4EF"
                 },
                 {
-                    object: Render.getConfig("DrawLight"),
+                    object: mainViewTask.getConfig("DrawLight"),
                     prop: "numDrawn",
                     label: "Lights",
                     color: "#FED959"
@@ -222,25 +223,25 @@ Item {
            valueNumDigits: "2"
            plots: [
                {
-                   object: Render.getConfig("DrawOpaqueDeferred"),
+                   object: mainViewTask.getConfig("DrawOpaqueDeferred"),
                    prop: "cpuRunTime",
                    label: "Opaques",
                    color: "#1AC567"
                },
                {
-                   object: Render.getConfig("DrawTransparentDeferred"),
+                   object: mainViewTask.getConfig("DrawTransparentDeferred"),
                    prop: "cpuRunTime",
                    label: "Translucents",
                    color: "#00B4EF"
                },
                {
-                   object: Render.getConfig("RenderDeferred"),
+                   object: mainViewTask.getConfig("RenderDeferred"),
                    prop: "cpuRunTime",
                    label: "Lighting",
                    color: "#FED959"
                },
                {
-                   object: Render.getConfig("RenderDeferredTask"),
+                   object: mainViewTask.getConfig("RenderDeferredTask"),
                    prop: "cpuRunTime",
                    label: "RenderFrame",
                    color: "#E2334D"

--- a/scripts/developer/utilities/render/statsGPU.qml
+++ b/scripts/developer/utilities/render/statsGPU.qml
@@ -21,7 +21,8 @@ Item {
         spacing: 8
         anchors.fill:parent
  
-        property var config: Render.getConfig("Stats")
+        property var mainViewTask: Render.getConfig("RenderMainView");
+        property var config: mainViewTask.getConfig("Stats")
  
         function evalEvenHeight() {
             // Why do we have to do that manually ? cannot seem to find a qml / anchor / layout mode that does that ?
@@ -38,31 +39,31 @@ Item {
            valueNumDigits: "4"
            plots: [
             {
-                   object: Render.getConfig("OpaqueRangeTimer"),
+                   object: mainViewTask.getConfig("OpaqueRangeTimer"),
                    prop: "gpuRunTime",
                    label: "Opaque",
                    color: "#FFFFFF"
                }, 
                {
-                   object: Render.getConfig("LinearDepth"),
+                   object: mainViewTask.getConfig("LinearDepth"),
                    prop: "gpuRunTime",
                    label: "LinearDepth",
                    color: "#00FF00"
                },{
-                   object: Render.getConfig("SurfaceGeometry"),
+                   object: mainViewTask.getConfig("SurfaceGeometry"),
                    prop: "gpuRunTime",
                    label: "SurfaceGeometry",
                    color: "#00FFFF"
                },
                {
-                   object: Render.getConfig("RenderDeferred"),
+                   object: mainViewTask.getConfig("RenderDeferred"),
                    prop: "gpuRunTime",
                    label: "DeferredLighting",
                    color: "#FF00FF"
                }
                ,
                {
-                   object: Render.getConfig("ToneAndPostRangeTimer"),
+                   object: mainViewTask.getConfig("ToneAndPostRangeTimer"),
                    prop: "gpuRunTime",
                    label: "tone and post",
                    color: "#FF0000"
@@ -78,31 +79,31 @@ Item {
            valueNumDigits: "3"
            plots: [
             {
-                   object: Render.getConfig("OpaqueRangeTimer"),
+                   object: mainViewTask.getConfig("OpaqueRangeTimer"),
                    prop: "batchRunTime",
                    label: "Opaque",
                    color: "#FFFFFF"
                }, 
                {
-                   object: Render.getConfig("LinearDepth"),
+                   object: mainViewTask.getConfig("LinearDepth"),
                    prop: "batchRunTime",
                    label: "LinearDepth",
                    color: "#00FF00"
                },{
-                   object: Render.getConfig("SurfaceGeometry"),
+                   object: mainViewTask.getConfig("SurfaceGeometry"),
                    prop: "batchRunTime",
                    label: "SurfaceGeometry",
                    color: "#00FFFF"
                },
                {
-                   object: Render.getConfig("RenderDeferred"),
+                   object: mainViewTask.getConfig("RenderDeferred"),
                    prop: "batchRunTime",
                    label: "DeferredLighting",
                    color: "#FF00FF"
                }
                ,
                {
-                   object: Render.getConfig("ToneAndPostRangeTimer"),
+                   object: mainViewTask.getConfig("ToneAndPostRangeTimer"),
                    prop: "batchRunTime",
                    label: "tone and post",
                    color: "#FF0000"

--- a/scripts/developer/utilities/render/subsurfaceScattering.qml
+++ b/scripts/developer/utilities/render/subsurfaceScattering.qml
@@ -16,28 +16,29 @@ Column {
     Column {
         id: scattering
         spacing: 10
+        property var mainViewTask: Render.getConfig("RenderMainView");
 
        Column{
             CheckBox {
                 text: "Scattering"
-                checked: Render.getConfig("Scattering").enableScattering
-                onCheckedChanged: { Render.getConfig("Scattering").enableScattering = checked }
+                checked: mainViewTask.getConfig("Scattering").enableScattering
+                onCheckedChanged: { mainViewTask.getConfig("Scattering").enableScattering = checked }
             }
 
             CheckBox {
                 text: "Show Scattering BRDF"
-                checked: Render.getConfig("Scattering").showScatteringBRDF
-                onCheckedChanged: { Render.getConfig("Scattering").showScatteringBRDF = checked }
+                checked: mainViewTask.getConfig("Scattering").showScatteringBRDF
+                onCheckedChanged: { mainViewTask.getConfig("Scattering").showScatteringBRDF = checked }
             }
             CheckBox {
                 text: "Show Curvature"
-                checked: Render.getConfig("Scattering").showCurvature
-                onCheckedChanged: { Render.getConfig("Scattering").showCurvature = checked }
+                checked: mainViewTask.getConfig("Scattering").showCurvature
+                onCheckedChanged: { mainViewTask.getConfig("Scattering").showCurvature = checked }
             }
             CheckBox {
                 text: "Show Diffused Normal"
-                checked: Render.getConfig("Scattering").showDiffusedNormal
-                onCheckedChanged: { Render.getConfig("Scattering").showDiffusedNormal = checked }
+                checked: mainViewTask.getConfig("Scattering").showDiffusedNormal
+                onCheckedChanged: { mainViewTask.getConfig("Scattering").showDiffusedNormal = checked }
             }
             Repeater {
                 model: [ "Scattering Bent Red:Scattering:bentRed:2.0",
@@ -50,7 +51,7 @@ Column {
                 ConfigSlider {
                     label: qsTr(modelData.split(":")[0])
                     integral: false
-                    config: Render.getConfig(modelData.split(":")[1])
+                    config: mainViewTask.getConfig(modelData.split(":")[1])
                     property: modelData.split(":")[2]
                     max: modelData.split(":")[3]
                     min: 0.0
@@ -58,23 +59,23 @@ Column {
             }
             CheckBox {
                 text: "Scattering Profile"
-                checked: Render.getConfig("DebugScattering").showProfile
-                onCheckedChanged: { Render.getConfig("DebugScattering").showProfile = checked }
+                checked: mainViewTask.getConfig("DebugScattering").showProfile
+                onCheckedChanged: { mainViewTask.getConfig("DebugScattering").showProfile = checked }
             }
             CheckBox {
                 text: "Scattering Table"
-                checked: Render.getConfig("DebugScattering").showLUT
-                onCheckedChanged: { Render.getConfig("DebugScattering").showLUT = checked }
+                checked: mainViewTask.getConfig("DebugScattering").showLUT
+                onCheckedChanged: { mainViewTask.getConfig("DebugScattering").showLUT = checked }
             }
             CheckBox {
                 text: "Cursor Pixel"
-                checked: Render.getConfig("DebugScattering").showCursorPixel
-                onCheckedChanged: { Render.getConfig("DebugScattering").showCursorPixel = checked }
+                checked: mainViewTask.getConfig("DebugScattering").showCursorPixel
+                onCheckedChanged: { mainViewTask.getConfig("DebugScattering").showCursorPixel = checked }
             }
             CheckBox {
                 text: "Skin Specular Beckmann"
-                checked: Render.getConfig("DebugScattering").showSpecularTable
-                onCheckedChanged: { Render.getConfig("DebugScattering").showSpecularTable = checked }
+                checked: mainViewTask.getConfig("DebugScattering").showSpecularTable
+                onCheckedChanged: { mainViewTask.getConfig("DebugScattering").showSpecularTable = checked }
             }
         }
     }

--- a/scripts/developer/utilities/render/surfaceGeometryPass.qml
+++ b/scripts/developer/utilities/render/surfaceGeometryPass.qml
@@ -16,12 +16,13 @@ Column {
     Column {
         id: surfaceGeometry
         spacing: 10
+        property var mainViewTask: Render.getConfig("RenderMainView");
 
         Column{
                 ConfigSlider {
                     label: qsTr("Depth Threshold [cm]")
                     integral: false
-                    config: Render.getConfig("SurfaceGeometry")
+                    config: mainViewTask.getConfig("SurfaceGeometry")
                     property: "depthThreshold"
                     max: 5.0
                     min: 0.0
@@ -34,7 +35,7 @@ Column {
                 ConfigSlider {
                     label: qsTr(modelData.split(":")[0])
                     integral: (modelData.split(":")[3] == 'true')
-                    config: Render.getConfig("SurfaceGeometry")
+                    config: mainViewTask.getConfig("SurfaceGeometry")
                     property: modelData.split(":")[1]
                     max: modelData.split(":")[2]
                     min: 0.0
@@ -42,8 +43,8 @@ Column {
             }
             CheckBox {
                     text: "Half Resolution"
-                    checked: Render.getConfig("SurfaceGeometry")["resolutionLevel"]
-                    onCheckedChanged: { Render.getConfig("SurfaceGeometry")["resolutionLevel"] = checked }
+                    checked: mainViewTask.getConfig("SurfaceGeometry")["resolutionLevel"]
+                    onCheckedChanged: { mainViewTask.getConfig("SurfaceGeometry")["resolutionLevel"] = checked }
             }
     
             Repeater {
@@ -53,7 +54,7 @@ Column {
                 ConfigSlider {
                     label: qsTr(modelData.split(":")[0])
                     integral: false
-                    config: Render.getConfig(modelData.split(":")[1])
+                    config: mainViewTask.getConfig(modelData.split(":")[1])
                     property: modelData.split(":")[2]
                     max: modelData.split(":")[3]
                     min: 0.0

--- a/scripts/developer/utilities/render/textureMonitor.qml
+++ b/scripts/developer/utilities/render/textureMonitor.qml
@@ -22,7 +22,8 @@ Item {
         spacing: 8
         anchors.fill:parent
  
-        property var config: Render.getConfig("Stats")
+        property var mainViewTask: Render.getConfig("RenderMainView");
+        property var config: mainViewTask.getConfig("Stats")
 
         function evalEvenHeight() {
             // Why do we have to do that manually ? cannot seem to find a qml / anchor / layout mode that does that ?


### PR DESCRIPTION
this one is on me when i did PR10659 

The first configuration of the LightClustering pass doesn't initialize the pass completely because the _lightClusters member is not created.
Before the PR10659 this configuration call would happen continuously for other bad reasons. so after the first time, the _lightClusters would be allocated and configured correctly.
I removed the bad continous call, but didon;t see that problem. my bad....

While i was at it,  i  noticed a bunch of my favorite Developer/Utilities/Render/ scripts were failing because the newly introduced second camera Pipeline screws the getCOnfig behavior...
Just did a pass over these scripts to work again.

## TEST PLAN
The local lights work in this PR, not in master

Optional: All the scripts in the Developer/Utilities/Render/ work fine, they don't in master