### PR TITLE
Fixed an issue where toolbar buttons duplicated themselves when reloading scripts

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -110,6 +110,7 @@ protected:
     ScriptsModel _scriptsModel;
     ScriptsModelFilter _scriptsModelFilter;
     std::atomic<bool> _isStopped { false };
+    std::atomic<bool> _isReloading { false };
 };
 
 QUrl normalizeScriptURL(const QUrl& rawScriptURL);

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -41,7 +41,16 @@ var numStillSnapshotUploadsPending = 0;
 
 // It's totally unnecessary to return to C++ to perform many of these requests, such as DELETEing an old story,
 // POSTING a new one, PUTTING a new audience, or GETTING story data. It's far more efficient to do all of that within JS
-var request = Script.require('request').request;
+var request;
+
+try {
+    // Due to an issue where if the user spams 'script reload', this call could cause an exception
+    // preventing our scriptEnding to not properly be initialized resulting in the tablet button
+    // duplicating itself where you end up with a bunch of SNAP buttons on your toolbar
+    request = Script.require('request').request;
+} catch(err) {
+    print('Failed to resolve request api, error: ' + err);
+}
 
 function openLoginWindow() {
     if ((HMD.active && Settings.getValue("hmdTabletBecomesToolbar", false))
@@ -750,11 +759,10 @@ Script.scriptEnding.connect(function () {
     }
     if (tablet) {
         tablet.removeButton(button);
+        tablet.screenChanged.disconnect(onTabletScreenChanged);
     }
     Window.snapshotShared.disconnect(snapshotUploaded);
-    tablet.screenChanged.disconnect(onTabletScreenChanged);
     Snapshot.snapshotLocationSet.disconnect(snapshotLocationSet);
-    
     Entities.canRezChanged.disconnect(processRezPermissionChange);
     Entities.canRezTmpChanged.disconnect(processRezPermissionChange);
 });


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/5278/In-Desktop-mode-when-reloading-all-scripts-sometimes-get-duplicates-of-all-HUD-buttons

Test Plan:
1. Start interface in Desktop mode
2. Open the running scripts panel
3. Remove all scripts and then press the default scripts button
4. Spam the 'Reload Scripts' button several times, verify that the buttons do not duplicate themselves and only appear once