### PR TITLE
Fix crash when cache entry lifetime exceeds cache lifetime

### DIFF
--- a/libraries/model-networking/src/model-networking/KTXCache.cpp
+++ b/libraries/model-networking/src/model-networking/KTXCache.cpp
@@ -24,9 +24,10 @@ const int KTXCache::INVALID_VERSION = 0x00;
 const char* KTXCache::SETTING_VERSION_NAME = "hifi.ktx.cache_version";
 
 KTXCache::KTXCache(const std::string& dir, const std::string& ext) :
-    FileCache(dir, ext) {
-    initialize();
+    FileCache(dir, ext) { }
 
+void KTXCache::initialize() {
+    FileCache::initialize();
     Setting::Handle<int> cacheVersionHandle(SETTING_VERSION_NAME, INVALID_VERSION);
     auto cacheVersion = cacheVersionHandle.get();
     if (cacheVersion != CURRENT_VERSION) {
@@ -35,20 +36,9 @@ KTXCache::KTXCache(const std::string& dir, const std::string& ext) :
     }
 }
 
-KTXFilePointer KTXCache::writeFile(const char* data, Metadata&& metadata) {
-    FilePointer file = FileCache::writeFile(data, std::move(metadata), true);
-    return std::static_pointer_cast<KTXFile>(file);
-}
-
-KTXFilePointer KTXCache::getFile(const Key& key) {
-    return std::static_pointer_cast<KTXFile>(FileCache::getFile(key));
-}
 
 std::unique_ptr<File> KTXCache::createFile(Metadata&& metadata, const std::string& filepath) {
     qCInfo(file_cache) << "Wrote KTX" << metadata.key.c_str();
-    return std::unique_ptr<File>(new KTXFile(std::move(metadata), filepath));
+    return FileCache::createFile(std::move(metadata), filepath);
 }
-
-KTXFile::KTXFile(Metadata&& metadata, const std::string& filepath) :
-    cache::File(std::move(metadata), filepath) {}
 

--- a/libraries/model-networking/src/model-networking/KTXCache.h
+++ b/libraries/model-networking/src/model-networking/KTXCache.h
@@ -35,20 +35,10 @@ public:
 
     KTXCache(const std::string& dir, const std::string& ext);
 
-    KTXFilePointer writeFile(const char* data, Metadata&& metadata);
-    KTXFilePointer getFile(const Key& key);
+    void initialize() override;
 
 protected:
     std::unique_ptr<cache::File> createFile(Metadata&& metadata, const std::string& filepath) override final;
-};
-
-class KTXFile : public cache::File {
-    Q_OBJECT
-
-protected:
-    friend class KTXCache;
-
-    KTXFile(Metadata&& metadata, const std::string& filepath);
 };
 
 #endif // hifi_KTXCache_h

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -189,7 +189,7 @@ private:
     static const std::string KTX_DIRNAME;
     static const std::string KTX_EXT;
 
-    KTXCache _ktxCache;
+    std::shared_ptr<cache::FileCache> _ktxCache { std::make_shared<KTXCache>(KTX_DIRNAME, KTX_EXT) };
     // Map from image hashes to texture weak pointers
     std::unordered_map<std::string, std::weak_ptr<gpu::Texture>> _texturesByHashes;
     std::mutex _texturesByHashesMutex;


### PR DESCRIPTION
Local testing of an unrelated bug revealed that when we shut down the application a crash can be caused by the `cache::File` being destroyed after the `cache::FileCache`.  This can happen because the `gpu::Texture` holds on to the cache entry and is only destroyed at the final cleanup in the `Application` destructor (technically any such objects should have been destroyed earlier, but even if they haven't been, the app should not crash on exit).  

## Testing

Repeatedly start and close interface while content is loading.  In the master build you will eventually crash during the exit (this only takes a few attempts for me).

In this PR build you should not crash on exit.  