### PR TITLE
Sort Running Scripts... list alphabetically

### DIFF
--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -54,7 +54,20 @@ ScrollingWindow {
     }
 
     function updateRunningScripts() {
+        function simplify(path) {
+            // trim URI querystring/fragment
+            path = (path+'').replace(/[#?].*$/,'');
+            // normalize separators and grab last path segment (ie: just the filename)
+            path = path.replace(/\\/g, '/').split('/').pop();
+            // return lowercased because we want to sort mnemonically
+            return path.toLowerCase();
+        }
         var runningScripts = ScriptDiscoveryService.getRunning();
+        runningScripts.sort(function(a,b) {
+            a = simplify(a.path);
+            b = simplify(b.path);
+            return a < b ? -1 : a > b ? 1 : 0;
+        });
         runningScriptsModel.clear()
         for (var i = 0; i < runningScripts.length; ++i) {
             runningScriptsModel.append(runningScripts[i]);


### PR DESCRIPTION
This PR updates the "Running Scripts..." dialog to automatically sort scripts alphabetically by caseless filename.

Before -- when loading, reloading or unloading a client script, the list would sometimes appear to "randomize" itself (in terms of display order).  Now -- the display order remains consistent across changes.

#### Testing:
* Load this PR's Interface build.
* Pull up "Edit > Running Scripts..."
* Verify the list is consistently sorted:
    * When loading additional client scripts (eg: use "filter" box to load avatarFinderBeacon.js, debugWindow.js, etc.)
    * When refreshing an individual script (which should remain in the same spot before/after).
    * When unloading a script.
