### PR TITLE
Fix skyboxes sometimes not showing

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -246,8 +246,13 @@ bool EntityTreeRenderer::findBestZoneAndMaybeContainingEntities(QVector<EntityIt
 
                     // if this entity is a zone and visible, determine if it is the bestZone
                     if (isZone && entity->getVisible()) {
-                        auto zone = std::dynamic_pointer_cast<ZoneEntityItem>(entity);
-                        _layeredZones.insert(zone);
+                        auto renderID = std::dynamic_pointer_cast<RenderableZoneEntityItem>(entity)->getRenderItemID();
+                        bool isValidRenderID = (renderID != render::Item::INVALID_ITEM_ID);
+
+                        if (isValidRenderID) {
+                            auto zone = std::dynamic_pointer_cast<ZoneEntityItem>(entity);
+                            _layeredZones.insert(zone);
+                        }
                     }
                 }
             }
@@ -354,6 +359,7 @@ bool EntityTreeRenderer::applyLayeredZones() {
 
         for (auto& zone : _layeredZones) {
             auto id = std::dynamic_pointer_cast<RenderableZoneEntityItem>(zone.zone)->getRenderItemID();
+            Q_ASSERT(id != render::Item::INVALID_ITEM_ID);
             list.push_back(id);
         }
         render::Selection selection("RankedZones", list);


### PR DESCRIPTION
This bug occured when we collected and sent the zones to the render engine before the zone with the top level skybox been assigned a render item ID.

I fixed it by considering such zones as non eligible until the item ID is assigned.

## Test Plan:

1) Start your Sandbox and Interface.
2) Go to `localhost/garden`.
3) Restart your domain and wait for it to load again using the tray icon menu.
4) Repeat step 3 a dozen times.

On the current build this should cause the skybox to never load at some point and the send to look black/white.
It should not happen on this PR build.