### PR TITLE
Fix reload content for baked skyboxes

### DIFF
--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -821,6 +821,7 @@ void NetworkTexture::refresh() {
         TextureCache::requestCompleted(_self);
     }
 
+    _ktxResourceState = PENDING_INITIAL_LOAD;
     Resource::refresh();
 }
 


### PR DESCRIPTION
This fixes a bug specific to baked skyboxes when reloading content.
Their state wasn't reset correctly, resulting in a stuck download.

## Test Plan:

1) Start Sandbox and interface
2) Go to `localhost/garden`
3) Open your stats and expand them
4) Wait for everything to load
5) Enable advanced settings (`Settings > Advanced Menus`)
6) Reload Content (`Edit > Reload Content (Clears all caches)`)

You should notice that on master, 4 ktx textures will stay stuck (With the latest content set).
But on this PR everything will download.