### PR TITLE
Spectator Camera: "Learn More" link

### DIFF
--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -32,14 +32,15 @@ Item {
         radius: popupRadius
     }
     Rectangle {
-        width: Math.max(parent.width * 0.75, 400)
+        id: textContainer;
+        width: Math.max(parent.width * 0.8, 400)
         height: contentContainer.height + 50
         anchors.centerIn: parent
         radius: popupRadius
         color: "white"
         Item {
             id: contentContainer
-            width: parent.width - 60
+            width: parent.width - 50
             height: childrenRect.height
             anchors.centerIn: parent
             Item {
@@ -92,7 +93,7 @@ Item {
                     anchors.top: parent.top
                     anchors.topMargin: -20
                     anchors.right: parent.right
-                    anchors.rightMargin: -25
+                    anchors.rightMargin: -20
                     MouseArea {
                         anchors.fill: closeGlyphButton
                         hoverEnabled: true
@@ -127,11 +128,51 @@ Item {
                 color: hifi.colors.darkGray
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText
+                onLinkActivated: {
+                    Qt.openUrlExternally(link)
+                }
             }
         }
     }
+    // Left gray MouseArea
     MouseArea {
-        anchors.fill: parent
+        anchors.left: parent.left;
+        anchors.right: textContainer.left;
+        anchors.top: textContainer.top;
+        anchors.bottom: textContainer.bottom;
+        acceptedButtons: Qt.LeftButton
+        onClicked: {
+            letterbox.visible = false
+        }
+    }
+    // Right gray MouseArea
+    MouseArea {
+        anchors.left: textContainer.left;
+        anchors.right: parent.left;
+        anchors.top: textContainer.top;
+        anchors.bottom: textContainer.bottom;
+        acceptedButtons: Qt.LeftButton
+        onClicked: {
+            letterbox.visible = false
+        }
+    }
+    // Top gray MouseArea
+    MouseArea {
+        anchors.left: parent.left;
+        anchors.right: parent.right;
+        anchors.top: parent.top;
+        anchors.bottom: textContainer.top;
+        acceptedButtons: Qt.LeftButton
+        onClicked: {
+            letterbox.visible = false
+        }
+    }
+    // Bottom gray MouseArea
+    MouseArea {
+        anchors.left: parent.left;
+        anchors.right: parent.right;
+        anchors.top: textContainer.bottom;
+        anchors.bottom: parent.bottom;
         acceptedButtons: Qt.LeftButton
         onClicked: {
             letterbox.visible = false

--- a/interface/resources/qml/hifi/SpectatorCamera.qml
+++ b/interface/resources/qml/hifi/SpectatorCamera.qml
@@ -315,7 +315,7 @@ Rectangle {
             switchViewFromControllerCheckBox.checked = message.setting;
             switchViewFromControllerCheckBox.enabled = true;
             if (message.controller === "OculusTouch") {
-                switchViewFromControllerCheckBox.text = "Clicking Left Touch's Thumbstick Switches Monitor View";
+                switchViewFromControllerCheckBox.text = "Clicking Touch's Left Thumbstick Switches Monitor View";
             } else if (message.controller === "Vive") {
                 switchViewFromControllerCheckBox.text = "Clicking Left Thumb Pad Switches Monitor View";
             } else {

--- a/interface/resources/qml/hifi/SpectatorCamera.qml
+++ b/interface/resources/qml/hifi/SpectatorCamera.qml
@@ -25,6 +25,19 @@ Rectangle {
     id: spectatorCamera;
     // Style
     color: hifi.colors.baseGray;
+
+    // The letterbox used for popup messages
+    LetterboxMessage {
+        id: letterboxMessage;
+        z: 999; // Force the popup on top of everything else
+    }
+    function letterbox(headerGlyph, headerText, message) {
+        letterboxMessage.headerGlyph = headerGlyph;
+        letterboxMessage.headerText = headerText;
+        letterboxMessage.text = message;
+        letterboxMessage.visible = true;
+        letterboxMessage.popupRadius = 0;
+    }
     
     //
     // TITLE BAR START
@@ -144,7 +157,17 @@ Rectangle {
                 anchors.fill: parent;
                 hoverEnabled: enabled;
                 onClicked: {
-                    console.log("FIXME! Add popup pointing to 'Learn More' page");
+                    letterbox(hifi.glyphs.question,
+                        "Spectator Camera",
+                        "By default, your monitor shows a preview of what you're seeing in VR. " +
+                        "Using the Spectator Camera app, your monitor can display the view " +
+                        "from a virtual hand-held camera - perfect for taking selfies or filming " +
+                        "your friends!<br>" +
+                        "<h3>Streaming and Recording</h3>" +
+                        "We recommend OBS for streaming and recording the contents of your monitor to services like " +
+                        "Twitch, YouTube Live, and Facebook Live.<br><br>" +
+                        "To get started using OBS, click this link now. The page will open in an external browser:<br>" +
+                        '<font size="4"><a href="https://obsproject.com/forum/threads/official-overview-guide.402/">OBS Official Overview Guide</a></font>');
                 }
                 onEntered: parent.color = hifi.colors.blueHighlight;
                 onExited: parent.color = hifi.colors.blueAccent;

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -391,6 +391,7 @@
             sendToQml({ method: 'updateSpectatorCameraCheckbox', params: !!camera });
             sendToQml({ method: 'updateMonitorShowsSwitch', params: monitorShowsCameraView });
             sendToQml({ method: 'updateControllerMappingCheckbox', setting: switchViewFromController, controller: controllerType });
+            Menu.setIsOptionChecked("Disable Preview", false);
         }
     }
 


### PR DESCRIPTION
Adds behavior for when the user clicks the "Learn More" link in the Spectator Camera app.

This also slightly changes (improves) the behavior of our LetterboxMessage pop-ups. It has minimal effect on the pop-ups in use elsewhere on the system (but again, I think those effects are improvements).

**Test Plan:**
1. In HMD, open the Spectator Camera app.
2. Click on the "Learn More about Spectator Camera" link towards the top of the app.
3. Read through the text and make sure it all makes sense.
4. Using your hand controllers, click the link at the bottom of the popup
5. Verify that Interface pauses, and that your default browser opened up a link to [this URL](https://obsproject.com/forum/threads/official-overview-guide.402/).
6. Close that browser window and reopen Interface.
7. Click anywhere outside of the white popup (or on the popup's (X) symbol) to close it.