### PR TITLE
Adding support for loading obj.gz files in ModelCache.

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -20,6 +20,8 @@
 
 #include <QThreadPool>
 
+#include <Gzip.h>
+
 #include "ModelNetworkingLogging.h"
 #include <Trace.h>
 #include <StatTracker.h>
@@ -171,7 +173,9 @@ void GeometryReader::run() {
 
         QString urlname = _url.path().toLower();
         if (!urlname.isEmpty() && !_url.path().isEmpty() &&
-            (_url.path().toLower().endsWith(".fbx") || _url.path().toLower().endsWith(".obj"))) {
+			(_url.path().toLower().endsWith(".fbx") || 
+			_url.path().toLower().endsWith(".obj") || 
+			_url.path().toLower().endsWith(".gz"))) {
             FBXGeometry::Pointer fbxGeometry;
 
             if (_url.path().toLower().endsWith(".fbx")) {
@@ -181,7 +185,12 @@ void GeometryReader::run() {
                 }
             } else if (_url.path().toLower().endsWith(".obj")) {
                 fbxGeometry.reset(OBJReader().readOBJ(_data, _mapping, _combineParts, _url));
-            } else {
+			} else if (_url.path().toLower().endsWith(".gz")) {
+				QByteArray uncompressedData;
+				if (gunzip(_data, uncompressedData)){
+					fbxGeometry.reset(OBJReader().readOBJ(uncompressedData, _mapping, _combineParts, _url));
+				}
+			} else {
                 throw QString("unsupported format");
             }
 

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -175,7 +175,7 @@ void GeometryReader::run() {
         if (!urlname.isEmpty() && !_url.path().isEmpty() &&
 			(_url.path().toLower().endsWith(".fbx") || 
 			_url.path().toLower().endsWith(".obj") || 
-			_url.path().toLower().endsWith(".gz"))) {
+			_url.path().toLower().endsWith(".obj.gz"))) {
             FBXGeometry::Pointer fbxGeometry;
 
             if (_url.path().toLower().endsWith(".fbx")) {
@@ -185,11 +185,14 @@ void GeometryReader::run() {
                 }
             } else if (_url.path().toLower().endsWith(".obj")) {
                 fbxGeometry.reset(OBJReader().readOBJ(_data, _mapping, _combineParts, _url));
-			} else if (_url.path().toLower().endsWith(".gz")) {
+			} else if (_url.path().toLower().endsWith(".obj.gz")) {
 				QByteArray uncompressedData;
 				if (gunzip(_data, uncompressedData)){
 					fbxGeometry.reset(OBJReader().readOBJ(uncompressedData, _mapping, _combineParts, _url));
+				} else {
+					throw QString("failed to decompress .obj.gz" );
 				}
+
 			} else {
                 throw QString("unsupported format");
             }


### PR DESCRIPTION
This adds support for adding obj.gz files to ModelCache.  To test this, import an obj file to the interface to confirm that it loads, and then compress that same obj file with gzip, ensuring the resulting archive has the extension .obj.gz and load that model in the interface.  The gzipped model should behave exactly the same as the original. 