### PR TITLE
new switches to override avatarURL

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -863,10 +863,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // no need to do so here.  If someone specifies both --avatarURL
     // and --replaceAvatarURL, the replaceAvatarURL wins.
     QString avatarURL = getCmdOption(argc, constArgv, "--avatarURL");
-    qDebug() << "XXXXXXXXXXXXXXXXXXXXX" << avatarURL;
     _avatarOverrideUrl = QUrl::fromUserInput(avatarURL);
     QString replaceURL = getCmdOption(argc, constArgv, "--replaceAvatarURL");
-    qDebug() << "YYYYYYYYYYYYYYYYYYYYYY" << replaceURL;
     if (!replaceURL.isEmpty()) {
         _avatarOverrideUrl = QUrl::fromUserInput(replaceURL);
         _saveAvatarOverrideUrl = true;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -214,7 +214,7 @@ static QTimer pingTimer;
 
 static const int MAX_CONCURRENT_RESOURCE_DOWNLOADS = 16;
 
-// For processing on QThreadPool, we target a number of threads after reserving some 
+// For processing on QThreadPool, we target a number of threads after reserving some
 // based on how many are being consumed by the application and the display plugin.  However,
 // we will never drop below the 'min' value
 static const int MIN_PROCESSING_THREAD_POOL_SIZE = 1;
@@ -859,6 +859,19 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     }
     ResourceCache::setRequestLimit(concurrentDownloads);
 
+    // perhaps override the avatar url.  We test later for validity, so
+    // no need to do so here.  If someone specifies both --avatarURL
+    // and --replaceAvatarURL, the replaceAvatarURL wins.
+    QString avatarURL = getCmdOption(argc, constArgv, "--avatarURL");
+    qDebug() << "XXXXXXXXXXXXXXXXXXXXX" << avatarURL;
+    _avatarOverrideUrl = QUrl::fromUserInput(avatarURL);
+    QString replaceURL = getCmdOption(argc, constArgv, "--replaceAvatarURL");
+    qDebug() << "YYYYYYYYYYYYYYYYYYYYYY" << replaceURL;
+    if (!replaceURL.isEmpty()) {
+        _avatarOverrideUrl = QUrl::fromUserInput(replaceURL);
+        _saveAvatarOverrideUrl = true;
+    }
+
     _glWidget = new GLCanvas();
     getApplicationCompositor().setRenderingWidget(_glWidget);
     _window->setCentralWidget(_glWidget);
@@ -1248,7 +1261,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // Add periodic checks to send user activity data
     static int CHECK_NEARBY_AVATARS_INTERVAL_MS = 10000;
     static int NEARBY_AVATAR_RADIUS_METERS = 10;
-    
+
     // setup the stats interval depending on if the 1s faster hearbeat was requested
     static const QString FAST_STATS_ARG = "--fast-heartbeat";
     static int SEND_STATS_INTERVAL_MS = arguments().indexOf(FAST_STATS_ARG) != -1 ? 1000 : 10000;
@@ -1398,10 +1411,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
         _autoSwitchDisplayModeSupportedHMDPlugin = nullptr;
         foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getDisplayPlugins()) {
-            if (displayPlugin->isHmd() && 
+            if (displayPlugin->isHmd() &&
                 displayPlugin->getSupportsAutoSwitch()) {
                 _autoSwitchDisplayModeSupportedHMDPlugin = displayPlugin;
-                _autoSwitchDisplayModeSupportedHMDPluginName = 
+                _autoSwitchDisplayModeSupportedHMDPluginName =
                     _autoSwitchDisplayModeSupportedHMDPlugin->getName();
                 _previousHMDWornStatus =
                     _autoSwitchDisplayModeSupportedHMDPlugin->isDisplayVisible();
@@ -1653,7 +1666,7 @@ void Application::onAboutToQuit() {
     }
 
     getActiveDisplayPlugin()->deactivate();
-    if (_autoSwitchDisplayModeSupportedHMDPlugin 
+    if (_autoSwitchDisplayModeSupportedHMDPlugin
         && _autoSwitchDisplayModeSupportedHMDPlugin->isSessionActive()) {
         _autoSwitchDisplayModeSupportedHMDPlugin->endSession();
     }
@@ -1722,8 +1735,8 @@ void Application::cleanupBeforeQuit() {
 
     // Cleanup all overlays after the scripts, as scripts might add more
     _overlays.cleanupAllOverlays();
-    // The cleanup process enqueues the transactions but does not process them.  Calling this here will force the actual 
-    // removal of the items.  
+    // The cleanup process enqueues the transactions but does not process them.  Calling this here will force the actual
+    // removal of the items.
     // See https://highfidelity.fogbugz.com/f/cases/5328
     _main3DScene->processTransactionQueue();
 
@@ -5217,7 +5230,7 @@ void Application::clearDomainOctreeDetails() {
     skyStage->setBackgroundMode(model::SunSkyStage::SKY_DEFAULT);
 
     _recentlyClearedDomain = true;
-    
+
     DependencyManager::get<AnimationCache>()->clearUnusedResources();
     DependencyManager::get<ModelCache>()->clearUnusedResources();
     DependencyManager::get<SoundCache>()->clearUnusedResources();
@@ -5281,6 +5294,10 @@ void Application::nodeActivated(SharedNodePointer node) {
     if (node->getType() == NodeType::AvatarMixer) {
         // new avatar mixer, send off our identity packet on next update loop
         // Reset skeletonModelUrl if the last server modified our choice.
+        // Override the avatar url (but not model name) here too.
+        if (_avatarOverrideUrl.isValid()) {
+            getMyAvatar()->useFullAvatarURL(_avatarOverrideUrl);
+        }
         static const QUrl empty{};
         if (getMyAvatar()->getFullAvatarURLFromPreferences() != getMyAvatar()->cannonicalSkeletonModelURL(empty)) {
             getMyAvatar()->resetFullAvatarURL();
@@ -7034,4 +7051,9 @@ OverlayID Application::getTabletHomeButtonID() const {
 QUuid Application::getTabletFrameID() const {
     auto HMD = DependencyManager::get<HMDScriptingInterface>();
     return HMD->getCurrentTabletFrameID();
+}
+
+void Application::setAvatarOverrideUrl(const QUrl& url, bool save) {
+    _avatarOverrideUrl = url;
+    _saveAvatarOverrideUrl = save;
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -859,11 +859,14 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     }
     ResourceCache::setRequestLimit(concurrentDownloads);
 
-    // perhaps override the avatar url.  We test later for validity, so
-    // no need to do so here.  If someone specifies both --avatarURL
-    // and --replaceAvatarURL, the replaceAvatarURL wins.
+    // perhaps override the avatar url.  Since we will test later for validity
+    // we don't need to do so here.
     QString avatarURL = getCmdOption(argc, constArgv, "--avatarURL");
     _avatarOverrideUrl = QUrl::fromUserInput(avatarURL);
+
+    // If someone specifies both --avatarURL and --replaceAvatarURL,
+    // the replaceAvatarURL wins.  So only set the _overrideUrl if this
+    // does have a non-empty string.
     QString replaceURL = getCmdOption(argc, constArgv, "--replaceAvatarURL");
     if (!replaceURL.isEmpty()) {
         _avatarOverrideUrl = QUrl::fromUserInput(replaceURL);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -102,9 +102,9 @@ class Application;
 #endif
 #define qApp (static_cast<Application*>(QCoreApplication::instance()))
 
-class Application : public QApplication, 
-                    public AbstractViewStateInterface, 
-                    public AbstractScriptingServicesInterface, 
+class Application : public QApplication,
+                    public AbstractViewStateInterface,
+                    public AbstractScriptingServicesInterface,
                     public AbstractUriHandler,
                     public PluginContainer {
     Q_OBJECT
@@ -293,6 +293,10 @@ public:
     OverlayID getTabletScreenID() const;
     OverlayID getTabletHomeButtonID() const;
     QUuid getTabletFrameID() const; // may be an entity or an overlay
+
+    void setAvatarOverrideUrl(const QUrl& url, bool save);
+    QUrl getAvatarOverrideUrl() { return _avatarOverrideUrl; }
+    bool getSaveAvatarOverrideUrl() { return _saveAvatarOverrideUrl; }
 
 signals:
     void svoImportRequested(const QString& url);
@@ -675,11 +679,14 @@ private:
     FileScriptingInterface* _fileDownload;
     AudioInjector* _snapshotSoundInjector { nullptr };
     SharedSoundPointer _snapshotSound;
-	
+
     DisplayPluginPointer _autoSwitchDisplayModeSupportedHMDPlugin;
     QString _autoSwitchDisplayModeSupportedHMDPluginName;
     bool _previousHMDWornStatus;
     void startHMDStandBySession();
     void endHMDSession();
+
+    QUrl _avatarOverrideUrl;
+    bool _saveAvatarOverrideUrl { false };
 };
 #endif // hifi_Application_h

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -929,10 +929,14 @@ void MyAvatar::saveData() {
 
     settings.setValue("scale", _targetScale);
 
-    settings.setValue("fullAvatarURL",
+    // only save the fullAvatarURL if it has not been overwritten on command line, or it
+    // has but we want it saved
+    if (qApp->getSaveAvatarOverrideUrl() || !qApp->getAvatarOverrideUrl().isValid() ) {
+        settings.setValue("fullAvatarURL",
                       _fullAvatarURLFromPreferences == AvatarData::defaultFullAvatarModelUrl() ?
                       "" :
                       _fullAvatarURLFromPreferences.toString());
+    }
 
     settings.setValue("fullAvatarModelName", _fullAvatarModelName);
 
@@ -2430,7 +2434,7 @@ bool MyAvatar::requiresSafeLanding(const glm::vec3& positionIn, glm::vec3& bette
         // Our head may be embedded, but our center is out and there's room below. See corresponding comment above.
         return false; // nothing below
     }
- 
+
     // See if we have room between entities above and below, but that we are not contained.
     // First check if the surface above us is the bottom of something, and the surface below us it the top of something.
     // I.e., we are in a clearing between two objects.
@@ -3150,6 +3154,6 @@ void MyAvatar::updateHoldActions(const AnimPose& prePhysicsPose, const AnimPose&
     }
 }
 
-const MyHead* MyAvatar::getMyHead() const { 
-    return static_cast<const MyHead*>(getHead()); 
+const MyHead* MyAvatar::getMyHead() const {
+    return static_cast<const MyHead*>(getHead());
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -929,8 +929,9 @@ void MyAvatar::saveData() {
 
     settings.setValue("scale", _targetScale);
 
-    // only save the fullAvatarURL if it has not been overwritten on command line, or it
-    // has but we want it saved
+    // only save the fullAvatarURL if it has not been overwritten on command line
+    // (so the overrideURL is not valid), or it was overridden _and_ we specified
+    // --replaceAvatarURL (so _saveAvatarOverrideUrl is true)
     if (qApp->getSaveAvatarOverrideUrl() || !qApp->getAvatarOverrideUrl().isValid() ) {
         settings.setValue("fullAvatarURL",
                       _fullAvatarURLFromPreferences == AvatarData::defaultFullAvatarModelUrl() ?


### PR DESCRIPTION
We have 2 new command-line switches:  --avatarURL and --replaceAvatarURL.  The former uses the url specified as your avatarURL for this session only, the latter also persists it.  Note in either case, you are free to change it at any time, and that will persist.  