### PR TITLE
Added confirmation to domain server webpage before restarting

### DIFF
--- a/domain-server/resources/web/header.html
+++ b/domain-server/resources/web/header.html
@@ -10,6 +10,7 @@
     <link href="/css/sweetalert.css" rel="stylesheet" media="screen">
     <link href="/css/bootstrap-switch.min.css" rel="stylesheet" media="screen">
 
+    <script src='/js/sweetalert.min.js'></script>
   </head>
   <body>
     <nav class="navbar navbar-default" role="navigation">
@@ -37,6 +38,8 @@
             </li>
             <li><a href="/content/">Content</a></li>
             <li><a href="/settings/">Settings</a></li>
+          </ul>
+          <ul class="nav navbar-right navbar-nav">
             <li><a href="#" id="restart-server"><span class="glyphicon glyphicon-refresh"></span> Restart</a></li>
           </ul>
         </div>

--- a/domain-server/resources/web/js/domain-server.js
+++ b/domain-server/resources/web/js/domain-server.js
@@ -36,7 +36,7 @@ $(document).ready(function(){
   $('body').on('click', '#restart-server', function(e) {    
     swal( {
       title: "Are you sure?",
-      text: "This will restart your domain server, causing your domain server to be briefly offline.",
+      text: "This will restart your domain server, causing your domain to be briefly offline.",
       type: "warning",
       html: true,
       showCancelButton: true

--- a/domain-server/resources/web/js/domain-server.js
+++ b/domain-server/resources/web/js/domain-server.js
@@ -33,9 +33,17 @@ $(document).ready(function(){
       return this.href == url;
   }).parent().addClass('active');  
 
-  $('body').on('click', '#restart-server', function(e){
-    $.get("/restart");
-    showRestartModal();
+  $('body').on('click', '#restart-server', function(e) {    
+    swal( {
+      title: "Are you sure?",
+      text: "This will restart your domain server, causing your domain server to be briefly offline.",
+      type: "warning",
+      html: true,
+      showCancelButton: true
+    }, function() {
+      $.get("/restart");
+      showRestartModal();
+    });
     return false;
   });
 });

--- a/domain-server/resources/web/settings/index.shtml
+++ b/domain-server/resources/web/settings/index.shtml
@@ -86,7 +86,6 @@
 <script src='/js/underscore-keypath.min.js'></script>
 <script src='/js/bootbox.min.js'></script>
 <script src='js/bootstrap-switch.min.js'></script>
-<script src='/js/sweetalert.min.js'></script>
 <script src='js/settings.js'></script>
 <script src='js/form2js.min.js'></script>
 <script src='js/sha256.js'></script>


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/5520/Move-restart-button-in-domain-server-to-right-side-of-nabber-and-require-confirmation

Test Plan:
1. Start domain server
2. Visit domain server webpage
3. On the navbar you should see a button on the right that says to Restart the domain server
4. Click the restart button and verify that a warning dialog pops up that asks you if you're sure that you'd like to restart your domain server