### PR TITLE
Fixed a bug where restart modal was shown when it shouldn't be

### DIFF
--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -424,7 +424,11 @@ function postSettings(jsonSettings) {
     type: 'POST'
   }).done(function(data){
     if (data.status == "success") {
-      showRestartModal();
+      if ($(".save-button").html() === SAVE_BUTTON_LABEL_RESTART) {
+        showRestartModal();
+      } else {
+        location.reload(true);
+      }
     } else {
       showErrorMessage("Error", SETTINGS_ERROR_MESSAGE)
       reloadSettings();


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/5533/When-domain-server-settings-change-is-not-restarting-don-t-show-restart-modal

Test Plan:
1. Start domain server
2. Visit domain server settings webpage
3. Make a change to a section that doesn't cause a restart
4. Click save and verify that the restart dialog doesn't appear and that the page reloads