### PR TITLE
Add a /forceNoLaunch switch to the installer

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -470,6 +470,7 @@ Function PostInstallOptionsPage
 
   StrCpy $CurrentOffset 0
   StrCpy $OffsetUnits u
+  ${StrContains} $AR_RegFlags "/forceNoLaunch" $CMDLINE
 
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Create a desktop shortcut for @INTERFACE_HF_SHORTCUT_NAME@"
@@ -504,6 +505,9 @@ Function PostInstallOptionsPage
 
     ; set the checkbox state depending on what is present in the registry
     !insertmacro SetPostInstallOption $LaunchServerNowCheckbox @SERVER_LAUNCH_NOW_REG_KEY@ ${BST_CHECKED}
+    ${If} $AR_RegFlags == "/forceNoLaunch"
+        ${NSD_SetState} $LaunchServerNowCheckbox ${BST_UNCHECKED}
+    ${EndIf}
 
     IntOp $CurrentOffset $CurrentOffset + 15
   ${EndIf}
@@ -514,6 +518,9 @@ Function PostInstallOptionsPage
 
 	  ; set the checkbox state depending on what is present in the registry
 	  !insertmacro SetPostInstallOption $LaunchClientNowCheckbox @CLIENT_LAUNCH_NOW_REG_KEY@ ${BST_CHECKED}
+      ${If} $AR_RegFlags == "/forceNoLaunch"
+          ${NSD_SetState} $LaunchClientNowCheckbox ${BST_UNCHECKED}
+      ${EndIf}
   ${EndIf}
 
   ${If} @PR_BUILD@ == 1

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -470,7 +470,6 @@ Function PostInstallOptionsPage
 
   StrCpy $CurrentOffset 0
   StrCpy $OffsetUnits u
-  ${StrContains} $AR_RegFlags "/forceNoLaunch" $CMDLINE
 
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Create a desktop shortcut for @INTERFACE_HF_SHORTCUT_NAME@"
@@ -505,7 +504,8 @@ Function PostInstallOptionsPage
 
     ; set the checkbox state depending on what is present in the registry
     !insertmacro SetPostInstallOption $LaunchServerNowCheckbox @SERVER_LAUNCH_NOW_REG_KEY@ ${BST_CHECKED}
-    ${If} $AR_RegFlags == "/forceNoLaunch"
+    ${StrContains} $substringResult "/forceNoLaunchServer" $CMDLINE
+    ${IfNot} $substringResult == ""
         ${NSD_SetState} $LaunchServerNowCheckbox ${BST_UNCHECKED}
     ${EndIf}
 
@@ -518,7 +518,8 @@ Function PostInstallOptionsPage
 
 	  ; set the checkbox state depending on what is present in the registry
 	  !insertmacro SetPostInstallOption $LaunchClientNowCheckbox @CLIENT_LAUNCH_NOW_REG_KEY@ ${BST_CHECKED}
-      ${If} $AR_RegFlags == "/forceNoLaunch"
+      ${StrContains} $substringResult "/forceNoLaunchClient" $CMDLINE
+      ${IfNot} $substringResult == ""
           ${NSD_SetState} $LaunchClientNowCheckbox ${BST_UNCHECKED}
       ${EndIf}
   ${EndIf}


### PR DESCRIPTION
Does what it says on the tin.

**Test Plan:**
1. Run the latest installer from http://highfidelity.com/dev-download. When installing, make sure to check the box corresponding to "Launch High Fidelity Interface after install" AND checkbox next to "Launch High Fidelity Sandbox after install". Let the installer complete. Close Interface.
2. Run the installer from this PR built by Gustavo.
3. Press "Next" until you see the screen about choosing components. Select Interface AND Sandbox.
4. Press "Next" until you see the screen about desktop shortcuts and automatically launching Interface. CHECK the checkbox next to "Launch High Fidelity Interface after install" is CHECKED. ALSO CHECK the checkbox next to "Launch High Fidelity Sandbox after install"
5. Press "Cancel" on the installer.
6. Run the same installer from step (2), except, this time, do it from the command line and specify the `/forceNoLaunchClient` switch AND the `/forceNoLaunchServer` switch, i.e. `interface_installer.exe /forceNoLaunchClient /forceNoLaunchServer`
7. Press "Next" until you see the screen about choosing components. Select Interface and Sandbox.
8. Press "Next" until you see the screen about desktop shortcuts and automatically launching Interface. Verify that the checkbox next to "Launch High Fidelity Interface after install" is UNCHECKED. Also verify that the checkbox next to "Launch High Fidelity Sandbox after install" is UNCHECKED.