### PR TITLE
Save JS "Console..." history across sessions

### DIFF
--- a/interface/src/ui/JSConsole.cpp
+++ b/interface/src/ui/JSConsole.cpp
@@ -122,7 +122,7 @@ void JSConsole::setScriptEngine(ScriptEngine* scriptEngine) {
 }
 
 void JSConsole::executeCommand(const QString& command) {
-    if (_commandHistory.constFirst() != command) {
+    if (_commandHistory.isEmpty() || _commandHistory.constFirst() != command) {
         _commandHistory.prepend(command);
         if (_commandHistory.length() > MAX_HISTORY_SIZE) {
             _commandHistory.removeLast();

--- a/interface/src/ui/JSConsole.cpp
+++ b/interface/src/ui/JSConsole.cpp
@@ -23,13 +23,14 @@
 #include "ScriptHighlighting.h"
 
 const int NO_CURRENT_HISTORY_COMMAND = -1;
-const int MAX_HISTORY_SIZE = 64;
+const int MAX_HISTORY_SIZE = 256;
+const QString HISTORY_FILENAME = "JSConsole.history.txt";
 
 const QString COMMAND_STYLE = "color: #266a9b;";
 
 const QString RESULT_SUCCESS_STYLE = "color: #677373;";
 const QString RESULT_INFO_STYLE = "color: #223bd1;";
-const QString RESULT_WARNING_STYLE = "color: #d13b22;";
+const QString RESULT_WARNING_STYLE = "color: #999922;";
 const QString RESULT_ERROR_STYLE = "color: #d13b22;";
 
 const QString GUTTER_PREVIOUS_COMMAND = "<span style=\"color: #57b8bb;\">&lt;</span>";
@@ -37,14 +38,26 @@ const QString GUTTER_ERROR = "<span style=\"color: #d13b22;\">X</span>";
 
 const QString JSConsole::_consoleFileName { "about:console" };
 
+QList<QString> _readLines(const QString& filename) {
+    QFile file(filename);
+    file.open(QFile::ReadOnly);
+    return QTextStream(&file).readAll().split("\r\n");
+}
+
+void _writeLines(const QString& filename, const QList<QString>& lines) {
+    QFile file(filename);
+    file.open(QFile::WriteOnly);
+    QTextStream(&file) << lines.join("\r\n");
+}
+
 JSConsole::JSConsole(QWidget* parent, ScriptEngine* scriptEngine) :
     QWidget(parent),
     _ui(new Ui::Console),
     _currentCommandInHistory(NO_CURRENT_HISTORY_COMMAND),
-    _commandHistory(),
+    _savedHistoryFilename(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/" + HISTORY_FILENAME),
+    _commandHistory(_readLines(_savedHistoryFilename)),
     _ownScriptEngine(scriptEngine == NULL),
     _scriptEngine(NULL) {
-
     _ui->setupUi(this);
     _ui->promptTextEdit->setLineWrapMode(QTextEdit::NoWrap);
     _ui->promptTextEdit->setWordWrapMode(QTextOption::NoWrap);
@@ -100,9 +113,12 @@ void JSConsole::setScriptEngine(ScriptEngine* scriptEngine) {
 }
 
 void JSConsole::executeCommand(const QString& command) {
-    _commandHistory.prepend(command);
-    if (_commandHistory.length() > MAX_HISTORY_SIZE) {
-        _commandHistory.removeLast();
+    if (_commandHistory.constFirst() != command) {
+        _commandHistory.prepend(command);
+        if (_commandHistory.length() > MAX_HISTORY_SIZE) {
+            _commandHistory.removeLast();
+        }
+        _writeLines(_savedHistoryFilename, _commandHistory);
     }
 
     _ui->promptTextEdit->setDisabled(true);
@@ -181,7 +197,7 @@ bool JSConsole::eventFilter(QObject* sender, QEvent* event) {
                     // a new QTextBlock isn't created.
                     keyEvent->setModifiers(keyEvent->modifiers() & ~Qt::ShiftModifier);
                 } else {
-                    QString command = _ui->promptTextEdit->toPlainText().trimmed();
+                    QString command = _ui->promptTextEdit->toPlainText().replace("\r\n","\n").trimmed();
 
                     if (!command.isEmpty()) {
                         QTextCursor cursor = _ui->promptTextEdit->textCursor();

--- a/interface/src/ui/JSConsole.h
+++ b/interface/src/ui/JSConsole.h
@@ -63,6 +63,7 @@ private:
     QFutureWatcher<QScriptValue> _executeWatcher;
     Ui::Console* _ui;
     int _currentCommandInHistory;
+    QString _savedHistoryFilename;
     QList<QString> _commandHistory;
     // Keeps track if the script engine is created inside the JSConsole
     bool _ownScriptEngine;


### PR DESCRIPTION
This PR keeps the history of recent "Console..." commands available across app restarts.

Currently it's possible to use <kbd>up</kbd> and <kbd>down</kbd> to recall and re-execute recent commands at the prompt, but only for the current session.  With this PR the history is automatically saved and restored between sessions to/from a `JSConsole.history.json` file in the app data folder (next to `bookmarks.json`, etc.).

#### Testing
* Launch this PR's Interface.
* Open the "Edit > Console... " prompt.
* Execute some JS commands; eg:
    * `Vec3.print('position', MyAvatar.position);`
    * `MyAvatar.sessionUUID`
    * `print(MyAvatar.getJointIndex('Head'))`
* Exit and restart the application.
* Open the "Edit > Console... " prompt.
* Verify the command history is still available by using <kbd>up</kbd> and <kbd>enter</kbd> to re-execute some commands from the last session.
