### PR TITLE
Fix warnings about creating QObjects with parents in different thread

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -713,9 +713,13 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     updateHeartbeat();
 
     // setup a timer for domain-server check ins
-    QTimer* domainCheckInTimer = new QTimer(nodeList.data());
+    QTimer* domainCheckInTimer = new QTimer(this);
     connect(domainCheckInTimer, &QTimer::timeout, nodeList.data(), &NodeList::sendDomainServerCheckIn);
     domainCheckInTimer->start(DOMAIN_SERVER_CHECK_IN_MSECS);
+    connect(this, &QCoreApplication::aboutToQuit, [domainCheckInTimer] {
+        domainCheckInTimer->stop();
+        domainCheckInTimer->deleteLater();
+    });
 
 
     auto audioIO = DependencyManager::get<AudioClient>();

--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
@@ -179,6 +179,11 @@ void GLBackend::init() {
             qCDebug(gpugllogging, "V-Sync is %s\n", (swapInterval > 0 ? "ON" : "OFF"));
         }*/
 #endif
+#if THREADED_TEXTURE_BUFFERING
+        // This has to happen on the main thread in order to give the thread 
+        // pool a reasonable parent object
+        GLVariableAllocationSupport::TransferJob::startBufferingThread();
+#endif
     });
 }
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -461,11 +461,6 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
 
     if (newState != _memoryPressureState) {
         _memoryPressureState = newState;
-#if THREADED_TEXTURE_BUFFERING
-        if (MemoryPressureState::Transfer == _memoryPressureState) {
-            TransferJob::startBufferingThread();
-        }
-#endif
         // Clear the existing queue
         _transferQueue = WorkQueue();
         _promoteQueue = WorkQueue();


### PR DESCRIPTION
Qt will emit a warning if you create a QObject derived instance and pass a parent QObject that was created in another thread.  There are at least two places in the code we do this.  The first is in the application where we create a timer to checkin to the domain, passing the `nodeList` as a parent.  The second is in the GL backend where we create a new threadpool for texture transfers, passing the application as a parent.  

## Testing

Application behavior should be unchanged, but starting the application should no longer produce any log entries like this
`[06/23 10:08:46] [WARNING] [default] QObject: Cannot create children for a parent that is in a different thread.`

Test that application startup and shutdown proceed normally and that the application does not hang or crash on exit (any more than it currently does, i.e. any crashes reported as related to this should be reliably reproducible, not the sporadic crashes deep inside Qt that we're currently seeing).
