### PR TITLE
Added speed thresholds to advanced movement controls

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -69,6 +69,9 @@ const float MAX_BOOST_SPEED = 0.5f * MAX_WALKING_SPEED; // action motor gets add
 const float MIN_AVATAR_SPEED = 0.05f;
 const float MIN_AVATAR_SPEED_SQUARED = MIN_AVATAR_SPEED * MIN_AVATAR_SPEED; // speed is set to zero below this
 
+const float PARTIALLY_PRESSED_WALKING_SPEED = 0.375f * MAX_WALKING_SPEED;
+const float PARTIALLY_PRESSED_THRESHOLD = 0.90f;
+
 const float YAW_SPEED_DEFAULT = 120.0f;   // degrees/sec
 const float PITCH_SPEED_DEFAULT = 90.0f; // degrees/sec
 
@@ -2095,7 +2098,11 @@ void MyAvatar::updateActionMotor(float deltaTime) {
         _actionMotorVelocity = motorSpeed * direction;
     } else {
         // we're interacting with a floor --> simple horizontal speed and exponential decay
-        _actionMotorVelocity = MAX_WALKING_SPEED * direction;
+        if (directionLength >= PARTIALLY_PRESSED_THRESHOLD) {
+            _actionMotorVelocity = MAX_WALKING_SPEED * direction;
+        } else {
+            _actionMotorVelocity = PARTIALLY_PRESSED_WALKING_SPEED * direction;
+        }
     }
 
     float boomChange = getDriveKey(ZOOM);


### PR DESCRIPTION
Should fix https://highfidelity.fogbugz.com/f/cases/5119/Max-walk-fly-speed-should-be-proportional-to-joystick-pressure

One of these test plans requires an Oculus, and the other, a Vive.

**Test Plan 1 (Oculus Touch and/or Xbox Controller):**
1. Start interface
2. Enable advanced movement controls
3. Lightly press the left stick for movement, verify that you aren't moving at full speed
4. Press the left stick all the way, verify that you are moving at full speed

**Test Plan 2 (Vive Controllers):**
1. Start interface
2. Enable advanced movement controls
3. Using the thumpad on the controller, verify that you only move full speed or not at all

**Note:** We are actively looking for feedback on these speeds and thresholds as most people have different thresholds for motion sickness.