### PR TITLE
Remove dependency between codec plugins and UI

### DIFF
--- a/assignment-client/CMakeLists.txt
+++ b/assignment-client/CMakeLists.txt
@@ -11,7 +11,7 @@ endif ()
 link_hifi_libraries(
   audio avatars octree gpu model fbx entities
   networking animation recording shared script-engine embedded-webserver
-  controllers physics plugins
+  physics plugins
 )
 
 if (WIN32)

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -166,19 +166,6 @@ void AudioMixer::handleMuteEnvironmentPacket(QSharedPointer<ReceivedMessage> mes
     }
 }
 
-DisplayPluginList getDisplayPlugins() {
-    DisplayPluginList result;
-    return result;
-}
-
-InputPluginList getInputPlugins() {
-    InputPluginList result;
-    return result;
-}
-
-// must be here to satisfy a reference in PluginManager::saveSettings()
-void saveInputPluginSettings(const InputPluginList& plugins) {}
-
 const std::pair<QString, CodecPluginPointer> AudioMixer::negotiateCodec(std::vector<QString> codecs) {
     QString selectedCodecName;
     CodecPluginPointer selectedCodec;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -441,6 +441,11 @@ static const QString STATE_ADVANCED_MOVEMENT_CONTROLS = "AdvancedMovement";
 static const QString STATE_GROUNDED = "Grounded";
 static const QString STATE_NAV_FOCUSED = "NavigationFocused";
 
+// Statically provided display and input plugins
+extern DisplayPluginList getDisplayPlugins();
+extern InputPluginList getInputPlugins();
+extern void saveInputPluginSettings(const InputPluginList& plugins);
+
 bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     const char** constArgv = const_cast<const char**>(argv);
 
@@ -479,6 +484,11 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     bool previousSessionCrashed = CrashHandler::checkForResetSettings(runningMarkerExisted, suppressPrompt);
 
     Setting::init();
+
+    // Tell the plugin manager about our statically linked plugins
+    PluginManager::setInputPluginProvider([] { return getInputPlugins(); });
+    PluginManager::setDisplayPluginProvider([] { return getDisplayPlugins(); });
+    PluginManager::setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });
 
     if (auto steamClient = PluginManager::getInstance()->getSteamClientPlugin()) {
         steamClient->init();

--- a/libraries/plugins/src/plugins/Forward.h
+++ b/libraries/plugins/src/plugins/Forward.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <memory>
+#include <functional>
 
 enum class PluginType {
     DISPLAY_PLUGIN,
@@ -26,8 +27,12 @@ class PluginManager;
 
 using DisplayPluginPointer = std::shared_ptr<DisplayPlugin>;
 using DisplayPluginList = std::vector<DisplayPluginPointer>;
+using DisplayPluginProvider = std::function<DisplayPluginList()>;
 using InputPluginPointer = std::shared_ptr<InputPlugin>;
 using InputPluginList = std::vector<InputPluginPointer>;
+using InputPluginProvider = std::function<InputPluginList()>;
 using CodecPluginPointer = std::shared_ptr<CodecPlugin>;
 using CodecPluginList = std::vector<CodecPluginPointer>;
+using CodecPluginProvider = std::function<CodecPluginList()>;
 using SteamClientPluginPointer = std::shared_ptr<SteamClientPlugin>;
+using InputPluginSettingsPersister = std::function<void(const InputPluginList&)>;

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -31,6 +31,18 @@ public:
     void setContainer(PluginContainer* container) { _container = container; }
 
     void shutdown();
+
+    // Application that have statically linked plugins can expose them to the plugin manager with these function
+    static void setDisplayPluginProvider(const DisplayPluginProvider& provider);
+    static void setInputPluginProvider(const InputPluginProvider& provider);
+    static void setCodecPluginProvider(const CodecPluginProvider& provider);
+    static void setInputPluginSettingsPersister(const InputPluginSettingsPersister& persister);
+    
 private:
+    static DisplayPluginProvider _displayPluginProvider;
+    static InputPluginProvider _inputPluginProvider;  
+    static CodecPluginProvider _codecPluginProvider;
+    static InputPluginSettingsPersister _inputSettingsPersister;
+
     PluginContainer* _container { nullptr };
 };

--- a/plugins/hifiCodec/CMakeLists.txt
+++ b/plugins/hifiCodec/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 set(TARGET_NAME hifiCodec)
 setup_hifi_client_server_plugin()
-link_hifi_libraries(audio plugins input-plugins display-plugins)
+link_hifi_libraries(audio plugins)
 add_dependency_external_projects(hifiAudioCodec)
 target_include_directories(${TARGET_NAME} PRIVATE ${HIFIAUDIOCODEC_INCLUDE_DIRS})
 target_link_libraries(${TARGET_NAME} ${HIFIAUDIOCODEC_LIBRARIES})

--- a/plugins/hifiNeuron/CMakeLists.txt
+++ b/plugins/hifiNeuron/CMakeLists.txt
@@ -10,7 +10,7 @@ if (APPLE OR WIN32)
     
     set(TARGET_NAME hifiNeuron)
     setup_hifi_plugin(Script Qml Widgets)
-    link_hifi_libraries(shared controllers ui plugins input-plugins display-plugins)
+    link_hifi_libraries(shared controllers ui plugins input-plugins)
     target_neuron()
 
 endif()

--- a/plugins/hifiSdl2/CMakeLists.txt
+++ b/plugins/hifiSdl2/CMakeLists.txt
@@ -8,5 +8,5 @@
 
 set(TARGET_NAME hifiSdl2)
 setup_hifi_plugin(Script Qml Widgets)
-link_hifi_libraries(shared controllers ui plugins input-plugins script-engine display-plugins)
+link_hifi_libraries(shared controllers ui plugins input-plugins script-engine)
 target_sdl2()

--- a/plugins/hifiSixense/CMakeLists.txt
+++ b/plugins/hifiSixense/CMakeLists.txt
@@ -9,6 +9,6 @@
 if (NOT ANDROID)
   set(TARGET_NAME hifiSixense)
   setup_hifi_plugin(Script Qml Widgets)
-  link_hifi_libraries(shared controllers ui plugins ui-plugins input-plugins display-plugins)
+  link_hifi_libraries(shared controllers ui plugins ui-plugins input-plugins)
   target_sixense()
 endif ()

--- a/plugins/pcmCodec/CMakeLists.txt
+++ b/plugins/pcmCodec/CMakeLists.txt
@@ -8,6 +8,6 @@
 
 set(TARGET_NAME pcmCodec)
 setup_hifi_client_server_plugin()
-link_hifi_libraries(shared plugins input-plugins display-plugins)
+link_hifi_libraries(shared plugins)
 install_beside_console()
 


### PR DESCRIPTION
Removes [recently added](https://github.com/highfidelity/hifi/pull/10729) dependency from audio codec plugins to `input-plugins` and `display-plugins` and thus to `ui`.  

## Testing

Verify keyboard and mouse input controls still work.  Verify that built-in display plugins (like the basic 2D display plugin) still work.  Application behavior should be unchanged.  