### PR TITLE
Android doc to build on Mac OSX & Windows

### DIFF
--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,35 +1,170 @@
+## Prerequisites
 
-## Qt
+### Qt
 http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist
 
-## Android Studio
+### Android Studio
 https://developer.android.com/studio/index.html
 
-## Inside the package manager (once android studio is installed)
+### Android SDK and tools versions
+Inside the package manager (with android studio installed)
 - Android SDK Api level 24
 - sdk tools 25.2.2
 - sdk platform-tools 25
 
-## NDK
-If the ndk-bundle is a different version than ndk r12b, download it separately
-Android NDK r12b
-https://developer.android.com/ndk/downloads/older_releases.html#ndk-12b-downloads
+### NDK
+If the ndk-bundle is a different version than ndk r12b, download it separately: 
+[Android NDK r12b](https://developer.android.com/ndk/downloads/older_releases.html#ndk-12b-downloads)
 
-## Cmake 3.3.2
+ndk-bundle or the uncompressed folder for r12b should be in the environment variable ANDROID_NDK.
 
-## Google Gvr sdk
-Clone this branch https://github.com/Cristo86/gvr-android-sdk/tree/common_prev_version into the workspace folder (folder that will contain hifi repo too, so if "hifi" is the checkouted folder, gvr-android-sdk might be a sister of it)
+### Cmake 3.3.2
+The build process was fully tested and done with [Cmake 3.3.2](https://cmake.org/files/v3.3/cmake-3.3.2-Darwin-x86_64.tar.gz). Newer versions also worked but may have deprecated some macros and functions that would require changes in our Cmake files.
 
-## Create a standalone toolchain (android NDK)
-${ANDROID_NDK}/build/tools/make_standalone_toolchain.py --arch arm --api 24 --stl=gnustl --install-dir ${ANDROID_NDK}/toolchains/my-tc-24-gnu
+### ant 1.9.4
+http://ant.apache.org/bindownload.cgi
 
-## Get this pre-compiled for android openSSL folder
+
+## Environment
+
+### Create a standalone toolchain (android NDK)
+The toolchain for HiFi must target API Level 24, for ARM and using GNU STL. The build process needs a toolchain called "my-tc-24-gnu" in the toolchaing folder inside the ndk. It can be generated running:
+`${ANDROID_NDK}/build/tools/make_standalone_toolchain.py --arch arm --api 24 --stl=gnustl --install-dir ${ANDROID_NDK}/toolchains/my-tc-24-gnu`
+
+### CMake
+
+We use CMake to generate the makefiles that compile and deploy the Android APKs to your device. In order to create Makefiles for the Android targets, CMake requires that some environment variables are set, and that other variables are passed to it when it is run.
+
+The following must be set in your environment:
+
+* ANDROID_NDK - the root of your Android NDK install
+* ANDROID_HOME - the root of your Android SDK install
+* ANDROID_LIB_DIR - the directory containing cross-compiled versions of dependencies.
+
+##### About ANDROID_LIB_DIR
+
+In general 'hifi' is cloned inside ANDROID_LIB_DIR and other dependencies end up being sister directories of 'hifi'.
+For example:
+````
+workspace-hifi  (ANDROID_LIB_DIR)
+|-- hifi (Clone from https://github.com/highfidelity/hifi.git )
+|-- gvr-android-sdk
+|-- openssl
+|-- etc..
+````
+
+### Scribe
+High Fidelity has a shader pre-processing tool called scribe that various libraries will call on during the build process.
+CMake will fatally error if it does not find the scribe executable while using the android toolchain.
+
+#### Precompiled binary
+[https://drive.google.com/file/d/0B76YuDlpp2i8NDJoejdIU2lhNkE/view?usp=sharing](Download) and save it in any folder. That path should be set in an ENV variable SCRIBE_PATH.
+
+#### Build it yourself
+You must compile scribe using your native toolchain (following the build instructions for your platform - MAC) and then pass a CMake variable or set an ENV variable SCRIBE_PATH that is a path where the scribe executable is.
+
+## Libraries
+
+### Google Gvr sdk
+Clone this project https://github.com/googlevr/gvr-android-sdk.git into the workspace folder (folder that will contain hifi repo too, so if "hifi" is the checkouted folder, gvr-android-sdk should be a sister of it).
+Current integration targets Gvr SDK version 1.40.0, so cloning it should retrieve all tags, then run:
+ `$ git checkout tags/v1.40.0 -b branch_1_40_0`
+ (Or any name you want for that branch)
+Finally, set the ENV variable HIFI_ANDROID_GVR as the name of this cloned repository:
+For example:
+Example, having:
+````
+workspace-hifi  (ANDROID_LIB_DIR)
+|-- hifi (Clone from `https://github.com/highfidelity/hifi.git` )
+|-- gvr-android-sdk
+|-- etc..
+````
+HIFI_ANDROID_GVR must be 'gvr-android-sdk' (full path is completed with ANDROID_LIB_DIR)
+
+### OpenSSL
+
+#### Precompiled binary
 https://www.dropbox.com/s/0ozqzfh9rh0mdzs/openssl.tar.gz?dl=0
 (donwload and unpack it to the same workspace folder, being sister of hifi and gvr-android-sdk)
 
-## ant 1.9.4
-http://ant.apache.org/bindownload.cgi
+#### Build it yourself
+Cross-compilation of OpenSSL has been tested from an OS X machine running 10.10 compiling OpenSSL 1.0.2. It is likely that the steps below will work for other OpenSSL versions than 1.0.2.
 
-## Other conventions
-Be sure to follow also the conventions about env. variables from the original build_android instructions and Scribe:
-https://github.com/highfidelity/hifi/blob/master/BUILD_ANDROID.md
+The original instructions to compile OpenSSL for Android from your host environment can be found [here](http://wiki.openssl.org/index.php/Android). We required some tweaks to get OpenSSL to successfully compile, those tweaks are explained below.
+
+Download the [OpenSSL source](https://www.openssl.org/source/) and extract the tarball inside your `ANDROID_LIB_DIR`. Rename the extracted folder to `openssl`.
+
+You will need the [setenv-android.sh script](http://wiki.openssl.org/index.php/File:Setenv-android.sh) from the OpenSSL wiki.
+
+You must change three values at the top of the `setenv-android.sh` script - `_ANDROID_NDK`, `_ANDROID_EABI` and `_ANDROID_API`.
+`_ANDROID_NDK` should be `android-ndk-r10`, `_ANDROID_EABI` should be `arm-linux-androidebi-4.9` and `_ANDROID_API` should be `19`.
+
+First, make sure `ANDROID_NDK_ROOT` is set in your env. This should be the path to the root of your Android NDK install. `setenv-android.sh` needs `ANDROID_NDK_ROOT` to set the environment variables required for building OpenSSL.
+
+Source the `setenv-android.sh` script so it can set environment variables that OpenSSL will use while compiling. If you use zsh as your shell you may need to modify the `setenv-android.sh` for it to set the correct variables in your env.
+
+```
+export ANDROID_NDK_ROOT=YOUR_NDK_ROOT
+source setenv-android.sh
+```
+
+Then, from the OpenSSL directory, run the following commands.
+
+```
+perl -pi -e 's/install: all install_docs install_sw/install: install_docs install_sw/g' Makefile.org
+./config shared -no-ssl2 -no-ssl3 -no-comp -no-hw -no-engine --openssldir=/usr/local/ssl/$ANDROID_API
+make depend
+make all
+```
+
+This should generate libcrypto and libssl in the root of the OpenSSL directory. YOU MUST remove the `libssl.so` and `libcrypto.so` files that are generated. They are symlinks to `libssl.so.VER` and `libcrypto.so.VER` which Android does not know how to handle. By removing `libssl.so` and `libcrypto.so` the FindOpenSSL module will find the static libs and use those instead.
+
+If you have been building other components it is possible that the OpenSSL compile will fail based on the values other cross-compilations (tbb, bullet) have set. Ensure that you are in a new terminal window to avoid compilation errors from previously set environment variables.
+
+## HiFi
+
+Clone `https://github.com/highfidelity/hifi.git` (conveniently inside ANDROID_LIB_DIR) and then switch to a branch with the latest Android source code.
+
+Branch "Android" should be the one to use. If you check that this file BUILD_ANDROID_MAC.md is not in the root dir, then switch because necessary changes to make the android app run will not be there.
+
+## Build
+
+### CMake
+
+The following must be passed to CMake when it is run:
+
+* USE_ANDROID_TOOLCHAIN - set to true to build for Android
+
+Example running cmake inside a build dir (which itself is inside the project dir e.g. 'hifi')
+````
+cmake -DUSE_ANDROID_TOOLCHAIN=1 -DANDROID_QT_CMAKE_PREFIX_PATH=$QT_CMAKE_PREFIX_PATH ..
+````
+Where QT_CMAKE_PREFIX_PATH must be `/QtInstallDir/5.6/android_armv7/lib/cmake`
+(With QtInstallDir is the correct path where Qt for Android was installed)
+
+### make
+
+After cmake: run to build the apk
+````
+make interface-apk
+````
+
+## Appendix I - Environment variables recap
+````
+$ export
+declare -x ANDROID_HOME="/Users/user/Library/Android/sdk"
+declare -x ANDROID_LIB_DIR="/Users/user/dev/workspace-hifi/"
+declare -x ANDROID_NDK="/Users/user/Library/Android/sdk/ndk-bundle"
+declare -x ANDROID_NDK_ROOT="/Users/user/Library/Android/sdk/ndk-bundle"
+declare -x HIFI_ANDROID_GVR="gvr-android-sdk-upd"
+declare -x HIFI_ANDROID_MGD="/Users/user/Downloads/dev/mali/Mali_Graphics_Debugger_v4.5.0.b3737c88_MacOSX_x64"
+declare -x NDK_HOME="/Users/user/Library/Android/sdk/ndk-bundle"
+declare -x PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/user/Library/Android/sdk/ndk-bundle:/Users/user/dev/bin/apache-ant-1.9.4/bin"
+declare -x QT_CMAKE_PREFIX_PATH="/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake"
+declare -x SCRIBE_PATH="/Users/user/dev/workspace-hifi/myhififork/build_osx/tools/scribe"
+````
+#### Notes
+* ANDROID_HOME targets the sdk, which in this case was installed with Android Studio. If using an standalone SDK, set that path as that variable.
+* Output shows that ndk-bundle is used as the NDK, because it was indeed version r12b. (Version can be checked in the last line of package.xml inside the ndk dir)
+* The Mali graphics debugger can be enabled setting the variable HIFI_ANDROID_MGD.
+* PATH is just an example, as there may be more paths in other systems (ndk and ant are important to be there).

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,7 +1,13 @@
 ## Prerequisites
 
 ### Qt
-http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist
+Tested in [Qt 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist)
+Newer versions like Qt 5.6.2 may have problems with the build process.
+Environment variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake dir
+For example if Qt was installed in ~/Qt5.6.1
+````
+"/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake"
+````
 
 ### Android Studio
 https://developer.android.com/studio/index.html
@@ -39,7 +45,7 @@ The following must be set in your environment:
 
 * ANDROID_NDK - the root of your Android NDK install
 * ANDROID_HOME - the root of your Android SDK install
-* ANDROID_LIB_DIR - the directory containing cross-compiled versions of dependencies.
+* ANDROID_LIB_DIR - the directory containing cross-compiled versions of dependencies. (Details below)
 
 ##### About ANDROID_LIB_DIR
 
@@ -57,17 +63,17 @@ workspace-hifi  (ANDROID_LIB_DIR)
 High Fidelity has a shader pre-processing tool called scribe that various libraries will call on during the build process.
 CMake will fatally error if it does not find the scribe executable while using the android toolchain.
 
-#### Precompiled binary
-[https://drive.google.com/file/d/0B76YuDlpp2i8NDJoejdIU2lhNkE/view?usp=sharing](Download) and save it in any folder. That path should be set in an ENV variable SCRIBE_PATH.
+#### Precompiled binary (recommended)
+[Download](https://drive.google.com/file/d/0B76YuDlpp2i8NDJoejdIU2lhNkE/view?usp=sharing) and save it in any folder. That path should be set in an ENV variable SCRIBE_PATH.
 
-#### Build it yourself
+#### Build it yourself (skip if you have a binary)
 You must compile scribe using your native toolchain (following the build instructions for your platform - MAC) and then pass a CMake variable or set an ENV variable SCRIBE_PATH that is a path where the scribe executable is.
 
 ## Libraries
 
 ### Google Gvr sdk
 Clone this project https://github.com/googlevr/gvr-android-sdk.git into the workspace folder (folder that will contain hifi repo too, so if "hifi" is the checkouted folder, gvr-android-sdk should be a sister of it).
-Current integration targets Gvr SDK version 1.40.0, so cloning it should retrieve all tags, then run:
+Current integration targets GVR SDK version 1.40.0, so cloning it should retrieve all tags, then run:
  `$ git checkout tags/v1.40.0 -b branch_1_40_0`
  (Or any name you want for that branch)
 Finally, set the ENV variable HIFI_ANDROID_GVR as the name of this cloned repository:
@@ -83,11 +89,11 @@ HIFI_ANDROID_GVR must be 'gvr-android-sdk' (full path is completed with ANDROID_
 
 ### OpenSSL
 
-#### Precompiled binary
+#### Precompiled binary (recommended)
 https://www.dropbox.com/s/0ozqzfh9rh0mdzs/openssl.tar.gz?dl=0
 (donwload and unpack it to the same workspace folder, being sister of hifi and gvr-android-sdk)
 
-#### Build it yourself
+#### Build it yourself  (skip if you have a binary)
 Cross-compilation of OpenSSL has been tested from an OS X machine running 10.10 compiling OpenSSL 1.0.2. It is likely that the steps below will work for other OpenSSL versions than 1.0.2.
 
 The original instructions to compile OpenSSL for Android from your host environment can be found [here](http://wiki.openssl.org/index.php/Android). We required some tweaks to get OpenSSL to successfully compile, those tweaks are explained below.
@@ -127,6 +133,30 @@ Clone `https://github.com/highfidelity/hifi.git` (conveniently inside ANDROID_LI
 
 Branch "Android" should be the one to use. If you check that this file BUILD_ANDROID_MAC.md is not in the root dir, then switch because necessary changes to make the android app run will not be there.
 
+## Environment variables recap
+
+Check all your environment variables and check the Notes below:
+
+````
+$ export
+declare -x ANDROID_HOME="/Users/user/Library/Android/sdk"
+declare -x ANDROID_LIB_DIR="/Users/user/dev/workspace-hifi/"
+declare -x ANDROID_NDK="/Users/user/Library/Android/sdk/ndk-bundle"
+declare -x ANDROID_NDK_ROOT="/Users/user/Library/Android/sdk/ndk-bundle"
+declare -x HIFI_ANDROID_GVR="gvr-android-sdk-upd"
+declare -x HIFI_ANDROID_MGD="/Users/user/Downloads/dev/mali/Mali_Graphics_Debugger_v4.5.0.b3737c88_MacOSX_x64"
+declare -x NDK_HOME="/Users/user/Library/Android/sdk/ndk-bundle"
+declare -x PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/user/Library/Android/sdk/ndk-bundle:/Users/user/dev/bin/apache-ant-1.9.4/bin"
+declare -x QT_CMAKE_PREFIX_PATH="/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake"
+declare -x SCRIBE_PATH="/Users/user/dev/workspace-hifi/myhififork/build_osx/tools/scribe"
+````
+#### Notes
+* ANDROID_HOME targets the sdk, which in this case was installed with Android Studio. If using an standalone SDK, set that path as that variable.
+* Output shows that ndk-bundle is used as the NDK, because it was indeed version r12b. (Version can be checked in the last line of package.xml inside the ndk dir)
+* The Mali graphics debugger can be enabled setting the variable HIFI_ANDROID_MGD (Optional).
+* PATH is just an example, as there may be more paths in other systems (ndk and ant are important to be there).
+* SCRIBE_PATH is like that because in that case the developer built the entire OSX environment (including tools/scribe). It can simply be the folder where the downloaded scribe executable is at.
+
 ## Build
 
 ### CMake
@@ -149,22 +179,5 @@ After cmake: run to build the apk
 make interface-apk
 ````
 
-## Appendix I - Environment variables recap
-````
-$ export
-declare -x ANDROID_HOME="/Users/user/Library/Android/sdk"
-declare -x ANDROID_LIB_DIR="/Users/user/dev/workspace-hifi/"
-declare -x ANDROID_NDK="/Users/user/Library/Android/sdk/ndk-bundle"
-declare -x ANDROID_NDK_ROOT="/Users/user/Library/Android/sdk/ndk-bundle"
-declare -x HIFI_ANDROID_GVR="gvr-android-sdk-upd"
-declare -x HIFI_ANDROID_MGD="/Users/user/Downloads/dev/mali/Mali_Graphics_Debugger_v4.5.0.b3737c88_MacOSX_x64"
-declare -x NDK_HOME="/Users/user/Library/Android/sdk/ndk-bundle"
-declare -x PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/user/Library/Android/sdk/ndk-bundle:/Users/user/dev/bin/apache-ant-1.9.4/bin"
-declare -x QT_CMAKE_PREFIX_PATH="/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake"
-declare -x SCRIBE_PATH="/Users/user/dev/workspace-hifi/myhififork/build_osx/tools/scribe"
-````
-#### Notes
-* ANDROID_HOME targets the sdk, which in this case was installed with Android Studio. If using an standalone SDK, set that path as that variable.
-* Output shows that ndk-bundle is used as the NDK, because it was indeed version r12b. (Version can be checked in the last line of package.xml inside the ndk dir)
-* The Mali graphics debugger can be enabled setting the variable HIFI_ANDROID_MGD.
-* PATH is just an example, as there may be more paths in other systems (ndk and ant are important to be there).
+
+

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,3 +1,42 @@
+
+## Table of Contents
+
+  * [Prerequisites](#prerequisites)
+    * [Qt](#qt)
+    * [Android Studio](#android-studio)
+    * [Android SDK and tools versions](#android-sdk-and-tools-versions)
+    * [NDK](#ndk)
+    * [Cmake 3\.3\.2](#cmake-332)
+    * [ant 1\.9\.4](#ant-194)
+  * [Environment](#environment)
+    * [Create a standalone toolchain (android NDK)](#create-a-standalone-toolchain-android-ndk)
+    * [CMake](#cmake)
+        * [About ANDROID\_LIB\_DIR](#about-android_lib_dir)
+    * [Scribe](#scribe)
+      * [Precompiled binary (recommended)](#precompiled-binary-recommended)
+      * [Build it yourself (skip if you have a binary)](#build-it-yourself-skip-if-you-have-a-binary)
+      * [Scribe path](#scribe-path)
+  * [Libraries](#libraries)
+    * [Google Gvr sdk](#google-gvr-sdk)
+    * [OpenSSL](#openssl)
+      * [Precompiled binary (recommended)](#precompiled-binary-recommended-1)
+      * [Build it yourself  (skip if you have a binary)](#build-it-yourself--skip-if-you-have-a-binary)
+  * [HiFi](#hifi)
+  * [Environment variables recap](#environment-variables-recap)
+      * [Notes](#notes)
+  * [Build](#build)
+    * [CMake](#cmake-1)
+    * [make](#make)
+  * [Appendix I \- Troubleshooting \- The "android" command is deprecated\.](#appendix-i---troubleshooting---the-android-command-is-deprecated)
+  * [Appendix II \- Troubleshooting \- Could not find Qt5LinguistTools](#appendix-ii---troubleshooting---could-not-find-qt5linguisttools)
+  * [Appendix III \- Troubleshooting \- Android device](#appendix-iii---troubleshooting---android-device)
+    * [Enable USB Debugging](#enable-usb-debugging)
+    * [Huawei Mate 9 Pro logcat](#huawei-mate-9-pro-logcat)
+    * [Daydream setup](#daydream-setup)
+
+(Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go))
+
+
 ## Prerequisites
 
 ### Qt

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,0 +1,35 @@
+
+## Qt
+http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist
+
+## Android Studio
+https://developer.android.com/studio/index.html
+
+## Inside the package manager (once android studio is installed)
+- Android SDK Api level 24
+- sdk tools 25.2.2
+- sdk platform-tools 25
+
+## NDK
+If the ndk-bundle is a different version than ndk r12b, download it separately
+Android NDK r12b
+https://developer.android.com/ndk/downloads/older_releases.html#ndk-12b-downloads
+
+## Cmake 3.3.2
+
+## Google Gvr sdk
+Clone this branch https://github.com/Cristo86/gvr-android-sdk/tree/common_prev_version into the workspace folder (folder that will contain hifi repo too, so if "hifi" is the checkouted folder, gvr-android-sdk might be a sister of it)
+
+## Create a standalone toolchain (android NDK)
+${ANDROID_NDK}/build/tools/make_standalone_toolchain.py --arch arm --api 24 --stl=gnustl --install-dir ${ANDROID_NDK}/toolchains/my-tc-24-gnu
+
+## Get this pre-compiled for android openSSL folder
+https://www.dropbox.com/s/0ozqzfh9rh0mdzs/openssl.tar.gz?dl=0
+(donwload and unpack it to the same workspace folder, being sister of hifi and gvr-android-sdk)
+
+## ant 1.9.4
+http://ant.apache.org/bindownload.cgi
+
+## Other conventions
+Be sure to follow also the conventions about env. variables from the original build_android instructions and Scribe:
+https://github.com/highfidelity/hifi/blob/master/BUILD_ANDROID.md

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,3 +1,4 @@
+
 ## Table of Contents
 
   * [Prerequisites](#prerequisites)
@@ -10,6 +11,7 @@
     * [Java 1\.8](#java-18)
   * [Environment](#environment)
     * [Create a standalone toolchain (android NDK)](#create-a-standalone-toolchain-android-ndk)
+    * [Important About Android Build Tools The "android" command is deprecated\.](#important-about-android-build-tools-the-android-command-is-deprecated)
     * [CMake](#cmake)
     * [Scribe](#scribe)
   * [Libraries](#libraries)
@@ -20,14 +22,14 @@
   * [Build](#build)
     * [CMake](#cmake-1)
     * [make](#make)
-  * [Appendix I (Troubleshooting) The "android" command is deprecated\.](#appendix-i-troubleshooting-the-android-command-is-deprecated)
-  * [Appendix II (Troubleshooting) Could not find Qt5LinguistTools](#appendix-ii-troubleshooting-could-not-find-qt5linguisttools)
-  * [Appendix III (Troubleshooting) Android device](#appendix-iii-troubleshooting-android-device)
+  * [Appendix I (Troubleshooting) Could not find Qt5LinguistTools](#appendix-i-troubleshooting-could-not-find-qt5linguisttools)
+  * [Appendix II (Troubleshooting) Android device](#appendix-ii-troubleshooting-android-device)
     * [Enable USB Debugging](#enable-usb-debugging)
     * [Huawei Mate 9 Pro logcat](#huawei-mate-9-pro-logcat)
     * [Daydream setup](#daydream-setup)
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
+
 
 ## Prerequisites
 
@@ -80,6 +82,45 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.77-b03, mixed mode)
 ### Create a standalone toolchain (android NDK)
 The toolchain for HiFi must target API Level 24, for ARM and using GNU STL. The build process needs a toolchain called "my-tc-24-gnu" in the toolchaing folder inside the ndk. It can be generated running:
 `${ANDROID_NDK}/build/tools/make_standalone_toolchain.py --arch arm --api 24 --stl=gnustl --install-dir ${ANDROID_NDK}/toolchains/my-tc-24-gnu`
+
+### Important About Android Build Tools The "android" command is deprecated.
+
+Newer android tools will not run `android update lib-project` which was deprecated:
+
+````
+*************************************************************************
+The "android" command is deprecated.
+For manual SDK, AVD, and project management, please use Android Studio.
+For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
+*************************************************************************
+Invalid or unsupported command "update lib-project -p . -t android-24"
+
+Supported commands are:
+android list target
+android list avd
+android list device
+android create avd
+android move avd
+android delete avd
+android list sdk
+android update sdk
+-- toolchain_setup_args start
+[...]
+````
+
+Our current toolchain still uses the non gradle build setup for Android, so to make it work a downgrade is needed:
+1. Download [Tools r25.2.2](https://dl-ssl.google.com/android/repository/tools_r25.2.2-macosx.zip)
+2. Backup your tools dir inside your Android SDK home
+3. Copy the uncompressed tools directory from tools_r25.2.2-macosx.zip into the Android SDK home, replacing the previous/original one.
+For example:
+With ANDROID_HOME or ANDROID_SDK as /Users/user/Library/Android/sdk
+````
+Library
+ |---- Android
+        |------- sdk
+                  |------- toolsbackup  (the original one, new, that deprecates what we need)
+                  |------- tools        (tools_r25.2.2-macosx downloaded)
+````
 
 ### CMake
 
@@ -234,46 +275,7 @@ After cmake: run to build the apk
 make interface-apk
 ````
 
-## Appendix I (Troubleshooting) The "android" command is deprecated.
-
-Newer android tools will not run `android update lib-project` which was deprecated:
-
-````
-*************************************************************************
-The "android" command is deprecated.
-For manual SDK, AVD, and project management, please use Android Studio.
-For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
-*************************************************************************
-Invalid or unsupported command "update lib-project -p . -t android-24"
-
-Supported commands are:
-android list target
-android list avd
-android list device
-android create avd
-android move avd
-android delete avd
-android list sdk
-android update sdk
--- toolchain_setup_args start
-[...]
-````
-
-Our current toolchain still uses the non gradle build setup for Android, so to make it work a downgrade is needed:
-1. Download [Tools r25.2.2](https://dl-ssl.google.com/android/repository/tools_r25.2.2-macosx.zip)
-2. Backup your tools dir inside your Android SDK home
-3. Copy the uncompressed tools directory from tools_r25.2.2-macosx.zip into the Android SDK home, replacing the previous/original one.
-For example:
-With ANDROID_HOME or ANDROID_SDK as /Users/user/Library/Android/sdk
-````
-Library
- |---- Android
-        |------- sdk
-                  |------- toolsbackup  (the original one, new, that deprecates what we need)
-                  |------- tools        (tools_r25.2.2-macosx downloaded)
-````
-
-## Appendix II (Troubleshooting) Could not find Qt5LinguistTools
+## Appendix I (Troubleshooting) Could not find Qt5LinguistTools
 If an error like to following happens:
 
 ````
@@ -293,7 +295,7 @@ Check these requirements:
 1. Env variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake as a full path like `/Users/cduarte/Qt5.6.1/5.6/android_armv7/lib/cmake`
 2. Qt for android should be [version 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist).
 
-## Appendix III (Troubleshooting) Android device
+## Appendix II (Troubleshooting) Android device
 
 Some setup that comes in handy when dealing with Android devices.
 

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,6 +1,7 @@
 
 ## Table of Contents
 
+  * [Table of Contents](#table-of-contents)
   * [Prerequisites](#prerequisites)
     * [Qt](#qt)
     * [Android Studio](#android-studio)
@@ -8,34 +9,30 @@
     * [NDK](#ndk)
     * [Cmake 3\.3\.2](#cmake-332)
     * [ant 1\.9\.4](#ant-194)
+    * [Java 1\.8](#java-18)
   * [Environment](#environment)
     * [Create a standalone toolchain (android NDK)](#create-a-standalone-toolchain-android-ndk)
     * [CMake](#cmake)
-        * [About ANDROID\_LIB\_DIR](#about-android_lib_dir)
     * [Scribe](#scribe)
-      * [Precompiled binary (recommended)](#precompiled-binary-recommended)
-      * [Build it yourself (skip if you have a binary)](#build-it-yourself-skip-if-you-have-a-binary)
-      * [Scribe path](#scribe-path)
   * [Libraries](#libraries)
     * [Google Gvr sdk](#google-gvr-sdk)
     * [OpenSSL](#openssl)
-      * [Precompiled binary (recommended)](#precompiled-binary-recommended-1)
-      * [Build it yourself  (skip if you have a binary)](#build-it-yourself--skip-if-you-have-a-binary)
   * [HiFi](#hifi)
   * [Environment variables recap](#environment-variables-recap)
-      * [Notes](#notes)
   * [Build](#build)
     * [CMake](#cmake-1)
     * [make](#make)
-  * [Appendix I \- Troubleshooting \- The "android" command is deprecated\.](#appendix-i---troubleshooting---the-android-command-is-deprecated)
-  * [Appendix II \- Troubleshooting \- Could not find Qt5LinguistTools](#appendix-ii---troubleshooting---could-not-find-qt5linguisttools)
-  * [Appendix III \- Troubleshooting \- Android device](#appendix-iii---troubleshooting---android-device)
+  * [Appendix I (Troubleshooting) The "android" command is deprecated\.](#appendix-i-troubleshooting-the-android-command-is-deprecated)
+  * [Appendix II (Troubleshooting) Could not find Qt5LinguistTools](#appendix-ii-troubleshooting-could-not-find-qt5linguisttools)
+  * [Appendix III (Troubleshooting) Android device](#appendix-iii-troubleshooting-android-device)
     * [Enable USB Debugging](#enable-usb-debugging)
     * [Huawei Mate 9 Pro logcat](#huawei-mate-9-pro-logcat)
     * [Daydream setup](#daydream-setup)
 
-(Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go))
+Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
 
+
+Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
 
 ## Prerequisites
 
@@ -243,7 +240,7 @@ After cmake: run to build the apk
 make interface-apk
 ````
 
-## Appendix I - Troubleshooting - The "android" command is deprecated.
+## Appendix I (Troubleshooting) The "android" command is deprecated.
 
 Newer android tools will not run `android update lib-project` which was deprecated:
 
@@ -282,7 +279,7 @@ Library
                   |------- tools        (tools_r25.2.2-macosx downloaded)
 ````
 
-## Appendix II - Troubleshooting - Could not find Qt5LinguistTools
+## Appendix II (Troubleshooting) Could not find Qt5LinguistTools
 If an error like to following happens:
 
 ````
@@ -302,7 +299,7 @@ Check these requirements:
 1. Env variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake as a full path like `/Users/cduarte/Qt5.6.1/5.6/android_armv7/lib/cmake`
 2. Qt for android should be [version 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist).
 
-## Appendix III - Troubleshooting - Android device
+## Appendix III (Troubleshooting) Android device
 
 Some setup that comes in handy dealing with Android devices.
 

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -193,3 +193,82 @@ make interface-apk
 
 ## Appendix I - Troubleshooting - The "android" command is deprecated.
 
+Newer android tools will not run `android update lib-project` which was deprecated:
+
+````
+*************************************************************************
+The "android" command is deprecated.
+For manual SDK, AVD, and project management, please use Android Studio.
+For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
+*************************************************************************
+Invalid or unsupported command "update lib-project -p . -t android-24"
+
+Supported commands are:
+android list target
+android list avd
+android list device
+android create avd
+android move avd
+android delete avd
+android list sdk
+android update sdk
+-- toolchain_setup_args start
+[...]
+````
+
+Our current toolchain still uses the non gradle build setup for Android, so to make it work a downgrade is needed:
+1. Download [Tools r25.2.2](https://dl-ssl.google.com/android/repository/tools_r25.2.2-macosx.zip)
+2. Backup your tools dir inside your Android SDK home
+3. Copy the uncompressed tools directory from tools_r25.2.2-macosx.zip into the Android SDK home, replacing the previous/original one.
+For example:
+With ANDROID_HOME or ANDROID_SDK as /Users/user/Library/Android/sdk
+````
+Library
+ |---- Android
+        |------- sdk
+                  |------- toolsbackup  (the original one, new, that deprecates what we need)
+                  |------- tools        (tools_r25.2.2-macosx downloaded)
+````
+
+## Appendix II - Troubleshooting - Could not find Qt5LinguistTools
+If an error like to following happens:
+
+````
+Could not find a package configuration file provided by "Qt5LinguistTools"
+ with any of the following names:
+
+   Qt5LinguistToolsConfig.cmake
+   qt5linguisttools-config.cmake
+
+ Add the installation prefix of "Qt5LinguistTools" to CMAKE_PREFIX_PATH or
+ set "Qt5LinguistTools_DIR" to a directory containing one of the above
+ files.  If "Qt5LinguistTools" provides a separate development package or
+ SDK, be sure it has been installed.
+````
+
+Check these requirements:
+1. Env variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake as a full path like `/Users/cduarte/Qt5.6.1/5.6/android_armv7/lib/cmake`
+2. Qt for android should be [version 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist).
+
+## Appendix III - Troubleshooting - Android device
+
+Some setup that comes in handy dealing with Android devices.
+
+### Enable USB Debugging
+
+(Instructions and menu flows for other devices may vary)
+
+Settings -> about phone -> click "build number" several times until a "You are now a Developer" message pops up.
+
+Then in "Developer options" menu, enable "Developer options" and "USB Debugging".
+
+### Huawei Mate 9 Pro logcat
+
+By default, logs are turned off on that phone. To enable them:
+
+Dial
+
+````
+*#*#2846579#*#*
+````
+and you will see a hidden menu. Go to the Project Menu > Background Setting > Log setting and define the log availability (log switch) and level (log level setting). [source](https://stackoverflow.com/a/18395092/939781)

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -2,6 +2,7 @@
 ## Table of Contents
 
   * [Prerequisites](#prerequisites)
+    * [About environment variables](#about-environment-variables)
     * [Qt](#qt)
     * [Android Studio](#android-studio)
     * [Android SDK and tools versions](#android-sdk-and-tools-versions)
@@ -32,6 +33,27 @@ Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
 
 
 ## Prerequisites
+
+### About environment variables
+
+The build process requires environment variables to be set for some software and libraries.
+For example, a QT_CMAKE_PREFIX_PATH for a Qt path and ANDROID_NDK for the NDK path should be set. To set the former, on the terminal we should run:
+
+````
+export QT_CMAKE_PREFIX_PATH=/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake
+````
+
+Everytime a [Terminal](http://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line) is opened, we should set all variables, so a way to make them permanent is creating a .bash_profile file in the user home directory:
+
+Example of .bash_profile
+
+````
+export QT_CMAKE_PREFIX_PATH=/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake
+export ANDROID_NDK=/Users/user/Library/Android/sdk/ndk-bundle
+````
+
+After saving it, opening a new Terminal will set those variables. To check current variables, just type `export`.
+
 
 ### Qt
 Tested in [Qt 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist)

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -31,9 +31,6 @@
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
 
-
-Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
-
 ## Prerequisites
 
 ### Qt
@@ -213,10 +210,9 @@ declare -x HIFI_ANDROID_MGD="/Users/user/Downloads/dev/mali/Mali_Graphics_Debugg
 ````
 #### Notes
 * ANDROID_HOME targets the sdk, which in this case was installed with Android Studio. If using an standalone SDK, set that path as that variable.
-* The Mali graphics debugger can be enabled setting the variable HIFI_ANDROID_MGD (Optional).
+* The Mali graphics debugger can be enabled setting the variable HIFI_ANDROID_MGD (Optional [download](https://developer.arm.com/products/software-development-tools/graphics-development-tools/mali-graphics-debugger/downloads) and [installation instructions](https://developer.arm.com/products/software-development-tools/graphics-development-tools/mali-graphics-debugger/docs/dui0986/latest/target-installation/android/unrooted-android/installation/installing-the-mgd-android-application)).
 * PATH is just an example, as there may be more paths in other systems (ant is important to be there).
 * SCRIBE_PATH is like that because in that case the developer built the entire OSX environment (including tools). It can simply be the folder where the downloaded scribe executable is at.
-*  
 
 ## Build
 
@@ -301,7 +297,7 @@ Check these requirements:
 
 ## Appendix III (Troubleshooting) Android device
 
-Some setup that comes in handy dealing with Android devices.
+Some setup that comes in handy when dealing with Android devices.
 
 ### Enable USB Debugging
 

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,7 +1,5 @@
-
 ## Table of Contents
 
-  * [Table of Contents](#table-of-contents)
   * [Prerequisites](#prerequisites)
     * [Qt](#qt)
     * [Android Studio](#android-studio)

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -3,8 +3,10 @@
 ### Qt
 Tested in [Qt 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist)
 Newer versions like Qt 5.6.2 may have problems with the build process.
+
 Environment variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake dir
-For example if Qt was installed in ~/Qt5.6.1
+
+For example if Qt was installed in ~/Qt5.6.1 :
 ````
 "/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake"
 ````
@@ -69,7 +71,9 @@ CMake will have a fatal error if it does not find the scribe executable while us
 #### Build it yourself (skip if you have a binary)
 You must compile scribe using your native toolchain (following the build instructions for your platform - MAC) and then pass a CMake variable or set an ENV variable SCRIBE_PATH that is a path where the scribe executable is.
 
-For example, if the scribe executable is in a tools (sic) directory...
+#### Scribe path
+
+For example, if the scribe executable is in a tools directory:
 
 ````
 workspace-hifi  (ANDROID_LIB_DIR)
@@ -272,3 +276,7 @@ Dial
 *#*#2846579#*#*
 ````
 and you will see a hidden menu. Go to the Project Menu > Background Setting > Log setting and define the log availability (log switch) and level (log level setting). [source](https://stackoverflow.com/a/18395092/939781)
+
+### Daydream setup
+
+Full Daydream setup (includes entering payment information) is required to properly run Daydream and Daydream Apps like Hifi "Interface".

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -32,6 +32,17 @@ The build process was fully tested and done with [Cmake 3.3.2](https://cmake.org
 ### ant 1.9.4
 http://ant.apache.org/bindownload.cgi
 
+### Java 1.8
+
+Java is needed on the final step to package the apk. Be sure [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) is installed in your system
+
+````
+$ java -version
+java version "1.8.0_77"
+Java(TM) SE Runtime Environment (build 1.8.0_77-b03)
+Java HotSpot(TM) 64-Bit Server VM (build 25.77-b03, mixed mode)
+````
+
 
 ## Environment
 
@@ -66,10 +77,10 @@ High Fidelity has a shader pre-processing tool called scribe that various librar
 CMake will have a fatal error if it does not find the scribe executable while using the android toolchain.
 
 #### Precompiled binary (recommended)
-[Download](https://drive.google.com/file/d/0B76YuDlpp2i8NDJoejdIU2lhNkE/view?usp=sharing) and save it in any folder. That path should be set in an ENV variable SCRIBE_PATH.
+[Download](https://drive.google.com/open?id=0BzVk5wZGx4ZtOTlMQWwtaW1BUzA) and uncompress it in any folder. That folder path should be set in an ENV variable SCRIBE_PATH.
 
 #### Build it yourself (skip if you have a binary)
-You must compile scribe using your native toolchain (following the build instructions for your platform - MAC) and then pass a CMake variable or set an ENV variable SCRIBE_PATH that is a path where the scribe executable is.
+Follow the [instructions](./BUILD_SCRIBE_MAC.md) to build scribe and then set an ENV variable SCRIBE_PATH that is a path where the scribe executable is.
 
 #### Scribe path
 
@@ -157,21 +168,19 @@ Check all your environment variables and check the Notes below:
 $ export
 declare -x ANDROID_HOME="/Users/user/Library/Android/sdk"
 declare -x ANDROID_LIB_DIR="/Users/user/dev/workspace-hifi/"
-declare -x ANDROID_NDK="/Users/user/Library/Android/sdk/ndk-bundle"
-declare -x ANDROID_NDK_ROOT="/Users/user/Library/Android/sdk/ndk-bundle"
+declare -x ANDROID_NDK="/Users/user/android-ndk-r12b"
 declare -x HIFI_ANDROID_GVR="gvr-android-sdk-upd"
-declare -x HIFI_ANDROID_MGD="/Users/user/Downloads/dev/mali/Mali_Graphics_Debugger_v4.5.0.b3737c88_MacOSX_x64"
-declare -x NDK_HOME="/Users/user/Library/Android/sdk/ndk-bundle"
-declare -x PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/user/Library/Android/sdk/ndk-bundle:/Users/user/dev/bin/apache-ant-1.9.4/bin"
+declare -x PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/user/dev/bin/apache-ant-1.9.4/bin"
 declare -x QT_CMAKE_PREFIX_PATH="/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake"
-declare -x SCRIBE_PATH="/Users/user/dev/workspace-hifi/myhififork/build_osx/tools/scribe"
+declare -x SCRIBE_PATH="/Users/user/dev/workspace-hifi/myhififork/build_osx/tools"
+declare -x HIFI_ANDROID_MGD="/Users/user/Downloads/dev/mali/Mali_Graphics_Debugger_v4.5.0.b3737c88_MacOSX_x64"
 ````
 #### Notes
 * ANDROID_HOME targets the sdk, which in this case was installed with Android Studio. If using an standalone SDK, set that path as that variable.
-* Output shows that ndk-bundle is used as the NDK, because it was indeed version r12b. (Version can be checked in the last line of package.xml inside the ndk dir or as the latest version in CHANGELOG.md)
 * The Mali graphics debugger can be enabled setting the variable HIFI_ANDROID_MGD (Optional).
-* PATH is just an example, as there may be more paths in other systems (ndk and ant are important to be there).
-* SCRIBE_PATH is like that because in that case the developer built the entire OSX environment (including tools/scribe). It can simply be the folder where the downloaded scribe executable is at.
+* PATH is just an example, as there may be more paths in other systems (ant is important to be there).
+* SCRIBE_PATH is like that because in that case the developer built the entire OSX environment (including tools). It can simply be the folder where the downloaded scribe executable is at.
+*  
 
 ## Build
 

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -1,4 +1,3 @@
-
 ## Table of Contents
 
   * [Prerequisites](#prerequisites)
@@ -314,7 +313,7 @@ Could not find a package configuration file provided by "Qt5LinguistTools"
 ````
 
 Check these requirements:
-1. Env variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake as a full path like `/Users/cduarte/Qt5.6.1/5.6/android_armv7/lib/cmake`
+1. Env variable QT_CMAKE_PREFIX_PATH should target the `android_armv7/lib/cmake` directory as a full path like `/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake`
 2. Qt for android should be [version 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist).
 
 ## Appendix II (Troubleshooting) Android device

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -164,7 +164,7 @@ declare -x SCRIBE_PATH="/Users/user/dev/workspace-hifi/myhififork/build_osx/tool
 ````
 #### Notes
 * ANDROID_HOME targets the sdk, which in this case was installed with Android Studio. If using an standalone SDK, set that path as that variable.
-* Output shows that ndk-bundle is used as the NDK, because it was indeed version r12b. (Version can be checked in the last line of package.xml inside the ndk dir)
+* Output shows that ndk-bundle is used as the NDK, because it was indeed version r12b. (Version can be checked in the last line of package.xml inside the ndk dir or as the latest version in CHANGELOG.md)
 * The Mali graphics debugger can be enabled setting the variable HIFI_ANDROID_MGD (Optional).
 * PATH is just an example, as there may be more paths in other systems (ndk and ant are important to be there).
 * SCRIBE_PATH is like that because in that case the developer built the entire OSX environment (including tools/scribe). It can simply be the folder where the downloaded scribe executable is at.

--- a/BUILD_ANDROID_MAC.md
+++ b/BUILD_ANDROID_MAC.md
@@ -61,13 +61,25 @@ workspace-hifi  (ANDROID_LIB_DIR)
 
 ### Scribe
 High Fidelity has a shader pre-processing tool called scribe that various libraries will call on during the build process.
-CMake will fatally error if it does not find the scribe executable while using the android toolchain.
+CMake will have a fatal error if it does not find the scribe executable while using the android toolchain.
 
 #### Precompiled binary (recommended)
 [Download](https://drive.google.com/file/d/0B76YuDlpp2i8NDJoejdIU2lhNkE/view?usp=sharing) and save it in any folder. That path should be set in an ENV variable SCRIBE_PATH.
 
 #### Build it yourself (skip if you have a binary)
 You must compile scribe using your native toolchain (following the build instructions for your platform - MAC) and then pass a CMake variable or set an ENV variable SCRIBE_PATH that is a path where the scribe executable is.
+
+For example, if the scribe executable is in a tools (sic) directory...
+
+````
+workspace-hifi  (ANDROID_LIB_DIR)
+|-- hifi (Clone from https://github.com/highfidelity/hifi.git )
+|-- gvr-android-sdk
+|-- openssl
+|-- tools
+	 |------ scribe (executable)
+````
+SCRIBE_PATH should be `/ParentOfWorkspace/tools/`
 
 ## Libraries
 
@@ -179,5 +191,5 @@ After cmake: run to build the apk
 make interface-apk
 ````
 
-
+## Appendix I - Troubleshooting - The "android" command is deprecated.
 

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -1,4 +1,3 @@
-
 ## Table of Contents
 
   * [Prerequisites](#prerequisites)
@@ -31,6 +30,7 @@
     * [Create a build directory](#create-a-build-directory)
     * [CMake](#cmake-1)
     * [make](#make)
+    * [Command failed "make" error message](#command-failed-make-error-message)
     * [Currently known problem with '\.\.' command\.](#currently-known-problem-with--command)
   * [Appendix I (Troubleshooting) Could not find Qt5LinguistTools](#appendix-i-troubleshooting-could-not-find-qt5linguisttools)
   * [Appendix II (Troubleshooting) Android device](#appendix-ii-troubleshooting-android-device)
@@ -339,7 +339,35 @@ After cmake: run to build the apk (inside the build folder).
 make interface-apk
 ````
 
-The following described problem is very likely to happen:
+Following described problems are very likely to happen:
+
+### Command failed "make" error message
+
+A possible not so descriptive error may occur: 
+
+````
+CMake Error at C:/Users/user/dev/workspace-hifi/hifi/build-android-00/ext/android/makefiles/bullet/project/src/bullet-stamp/bullet-build-.cmake:16 (message):
+  Command failed: 2
+
+   'make'
+
+  See also
+
+    C:/Users/user/dev/workspace-hifi/hifi/build-android-00/ext/android/makefiles/bullet/project/src/bullet-stamp/bullet-build-*.log
+
+
+make[3]: *** [ext/android/makefiles/bullet/project/src/bullet-stamp/bullet-build] Error 1
+make[2]: *** [ext/android/makefiles/bullet/CMakeFiles/bullet.dir/all] Error 2
+````
+
+If checking the bullet-build-*.log the last successful output (in a file `bullet-build-out.log` in this case) was like
+
+````
+Linking CXX shared library..
+````
+
+Maybe the command to execute the linker is too long for the Windows command line to handle.
+
 
 ### Currently known problem with '..' command.
 

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -366,7 +366,20 @@ If checking the bullet-build-*.log the last successful output (in a file `bullet
 Linking CXX shared library..
 ````
 
-Maybe the command to execute the linker is too long for the Windows command line to handle.
+Maybe the command to execute the linker is [too long](https://support.microsoft.com/en-us/help/830473/command-prompt-cmd.-exe-command-line-string-limitation) for the Windows command line to handle.
+
+A workaround is done by setting the following 4 flags in ext\android\makefiles\bullet\project\src\bullet\CMakeLists.txt and retrying `make interface-apk`
+
+````
+cmake_minimum_required
+# workaround: add these 4 lines 
+SET(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+SET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+SET(CMAKE_C_RESPONSE_FILE_LINK_FLAG "@")
+SET(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "@")
+...
+````
+
 
 
 ### Currently known problem with '..' command.

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -20,7 +20,7 @@ Some steps described here require to add tools locations in the PATH variable. [
 Tested in [Qt 5.6.1-1](http://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-android-5.6.1-1.exe.mirrorlist).
 Newer versions like Qt 5.6.2 may have problems with the build process.
 
-Environment variable QT_CMAKE_PREFIX_PATH should target the `android_armv7\lib\cmake dir`
+Environment variable QT_CMAKE_PREFIX_PATH should target the `C:\Qt\Qt5.6.1\5.6\android_armv7\lib\cmake`
 
 For example if Qt was installed in C:\Qt\Qt5.6.1 :
 ````
@@ -40,6 +40,8 @@ Inside the package manager (with android studio installed)
 - sdk tools 25.2.2
 - sdk platform-tools 25
 
+If you are installing a recent version of android sdk check this [important note](#important-about-android-build-tools-the-android-command-is-deprecated)
+
 ### NDK
 If the ndk-bundle is a different version than ndk r12b, download it separately: 
 [Android NDK r12b](https://developer.android.com/ndk/downloads/older_releases.html#ndk-12b-downloads)
@@ -51,21 +53,20 @@ set ANDROID_NDK=C:/Users/user/workspace-hifi/android-ndk-r12b
 setx ANDROID_NDK=%ANDROID_NDK%
 ````
 
-### Cmake 3.3.2
-The build process was fully tested and done with [Cmake 3.3.2](https://cmake.org/files/v3.3/cmake-3.3.2-win32-x86.zip). Newer versions also worked but may have deprecated some macros and functions that would require changes in our Cmake files.
+### CMake 3.3.2
+The build process was fully tested and done with [CMake 3.3.2](https://cmake.org/files/v3.3/cmake-3.3.2-win32-x86.zip). Newer versions also worked but may have deprecated some macros and functions that would require changes in our CMake files.
 
 ### ant 1.9.4
-http://ant.apache.org/bindownload.cgi
+
+Download [ant](http://ant.apache.org/bindownload.cgi), install it and add the **bin** directory to the PATH variable
 
 ### Java 1.8
 
 Java is needed on the final step to package the apk. Be sure [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) is installed in your system and remember to set JAVA_HOME pointing to your JDK.
 
 ````
-C:\Users\user>java -version
-java version "1.8.0_131"
-Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
-Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
+C:\Users\user>javac -version
+javac 1.8.0_131
 C:\Users\user>
 
 ````
@@ -181,7 +182,7 @@ SCRIBE_PATH should be `C:\Users\user\workspace-hifi\tools`
 
 ### cp.bat
 
-CMake generates a makefiles that use `cp` (Unix name) instead of `copy` (which is the command-line tool to copy files on Windows).
+CMake generates makefiles that use `cp` (Unix name) instead of `copy` (which is the command-line tool to copy files on Windows).
 
 A workaround is done by placing a [cp.bat script](https://drive.google.com/open?id=0BzVk5wZGx4ZtYVBhaDgyM0UzcTg) in the PATH.
 
@@ -251,6 +252,7 @@ C:\> SET ANDROID_LIB_DIR="C:/Users/user/workspace-hifi"
 C:\> SET ANDROID_NDK="C:/Users/user/workspace-hifi/android-ndk-r12b"
 C:\> SET HIFI_ANDROID_GVR="gvr-android-sdk-upd"
 C:\> SET SCRIBE_PATH="C:\Users\user\workspace-hifi\tools"
+C:\> SET QT_CMAKE_PREFIX_PATH=C:\Qt\Qt5.6.1\5.6\android_armv7\lib\cmake
 C:\> SET PATH=%PATH%:"C:\Program Files\ant\bin:%JAVA_HOME%\bin"
 
 C:\> SETX ANDROID_HOME %ANDROID_HOME%
@@ -258,6 +260,7 @@ C:\> SETX ANDROID_LIB_DIR %ANDROID_LIB_DIR%
 C:\> SETX ANDROID_NDK %ANDROID_NDK%
 C:\> SETX HIFI_ANDROID_GVR %HIFI_ANDROID_GVR%
 C:\> SETX SCRIBE_PATH %SCRIBE_PATH%
+C:\> SETX QT_CMAKE_PREFIX_PATH %QT_CMAKE_PREFIX_PATH%
 C:\> SETX PATH %PATH%
 
 ````
@@ -282,7 +285,7 @@ Example running CMake inside a build dir (which itself is inside the project dir
 ````
 cmake -G "Unix Makefiles" -DUSE_NSIGHT=0 -DUSE_ANDROID_TOOLCHAIN=1 -DANDROID_QT_CMAKE_PREFIX_PATH=%QT_CMAKE_PREFIX_PATH% ..
 ````
-Where QT_CMAKE_PREFIX_PATH must be `/QtInstallDir/5.6/android_armv7/lib/cmake`
+Where QT_CMAKE_PREFIX_PATH must be `C:\QtInstallDir\5.6\android_armv7\lib\cmake`
 (With QtInstallDir is the correct path where Qt for Android was installed)
 
 ### make
@@ -350,7 +353,7 @@ Could not find a package configuration file provided by "Qt5LinguistTools"
 ````
 
 Check these requirements:
-1. Env variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake as a full path like `/Users/cduarte/Qt5.6.1/5.6/android_armv7/lib/cmake`
+1. Env variable QT_CMAKE_PREFIX_PATH should target the android_armv7/lib/cmake as a full path like `C:\Qt\Qt5.6.1\5.6\android_armv7\lib\cmake`
 2. Qt for android should be [version 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1/qt-opensource-mac-x64-android-5.6.1.dmg.mirrorlist).
 
 ## Appendix II (Troubleshooting) Android device

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -1,3 +1,46 @@
+
+## Table of Contents
+
+  * [Prerequisites](#prerequisites)
+    * [About environment variables](#about-environment-variables)
+    * [About adding locations to the PATH variable](#about-adding-locations-to-the-path-variable)
+    * [Qt](#qt)
+    * [Visual Studio 12\.0 (Community is enough)](#visual-studio-120-community-is-enough)
+    * [Android Studio](#android-studio)
+    * [Android SDK and tools versions](#android-sdk-and-tools-versions)
+    * [NDK](#ndk)
+    * [CMake 3\.3\.2](#cmake-332)
+    * [ant 1\.9\.4](#ant-194)
+    * [Java 1\.8](#java-18)
+    * [GNU Make for Windows](#gnu-make-for-windows)
+    * [Python](#python)
+    * [Check prerequisites](#check-prerequisites)
+  * [Environment](#environment)
+    * [Create a standalone toolchain (android NDK)](#create-a-standalone-toolchain-android-ndk)
+    * [Important About Android Build Tools The "android" command is deprecated\.](#important-about-android-build-tools-the-android-command-is-deprecated)
+    * [CMake](#cmake)
+    * [Scribe](#scribe)
+    * [cp\.bat](#cpbat)
+  * [Libraries](#libraries)
+    * [Google Gvr sdk](#google-gvr-sdk)
+    * [OpenSSL](#openssl)
+  * [HiFi](#hifi)
+    * [Fix toolchain file in HiFi](#fix-toolchain-file-in-hifi)
+  * [Environment variables recap](#environment-variables-recap)
+  * [Build](#build)
+    * [Create a build directory](#create-a-build-directory)
+    * [CMake](#cmake-1)
+    * [make](#make)
+    * [Currently known problem with '\.\.' command\.](#currently-known-problem-with--command)
+  * [Appendix I (Troubleshooting) Could not find Qt5LinguistTools](#appendix-i-troubleshooting-could-not-find-qt5linguisttools)
+  * [Appendix II (Troubleshooting) Android device](#appendix-ii-troubleshooting-android-device)
+    * [Enable USB Debugging](#enable-usb-debugging)
+    * [Huawei Mate 9 Pro logcat](#huawei-mate-9-pro-logcat)
+    * [Daydream setup](#daydream-setup)
+  * [Appendix III (Troubleshooting) Weird errors (must see)](#appendix-iii-troubleshooting-weird-errors-must-see)
+
+Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
+
 ## Prerequisites
 
 ### About environment variables

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -508,7 +508,7 @@ Next to it there should be a call to *clang++.cmd*, replace it for **clang38++.e
 #### build.xml error when running qtcreateapk
 
 Apparently the code that runs "android update" on the gvr-common library doesn't run at all on Windows.
-Manually run inside build-dir/interface/gvr-common:
+Manually run inside build-dir/interface/gvr-common and build-dir/interface/gvr-base:
 ```
 %ANDROID_HOME%/tools/android update lib-project -p . -t android-24
 ```

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -17,10 +17,10 @@ Notice that setx will make persistent the variables for new terminal windows (bu
 Some steps described here require to add tools locations in the PATH variable. [How-to by Microsoft](https://msdn.microsoft.com/en-us/library/office/ee537574(v=office.14).aspx).
 
 ### Qt
-Tested in [Qt 5.6.1-1](http://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-android-5.6.1-1.exe.mirrorlist)
+Tested in [Qt 5.6.1-1](http://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-android-5.6.1-1.exe.mirrorlist).
 Newer versions like Qt 5.6.2 may have problems with the build process.
 
-Environment variable QT_CMAKE_PREFIX_PATH should target the android_armv7\lib\cmake dir
+Environment variable QT_CMAKE_PREFIX_PATH should target the `android_armv7\lib\cmake dir`
 
 For example if Qt was installed in C:\Qt\Qt5.6.1 :
 ````

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -1,35 +1,3 @@
-## Table of Contents
-
-  * [Prerequisites](#prerequisites)
-    * [About environment variables](#about-environment-variables)
-    * [Qt](#qt)
-    * [Android Studio](#android-studio)
-    * [Android SDK and tools versions](#android-sdk-and-tools-versions)
-    * [NDK](#ndk)
-    * [Cmake 3\.3\.2](#cmake-332)
-    * [ant 1\.9\.4](#ant-194)
-    * [Java 1\.8](#java-18)
-  * [Environment](#environment)
-    * [Create a standalone toolchain (android NDK)](#create-a-standalone-toolchain-android-ndk)
-    * [Important About Android Build Tools The "android" command is deprecated\.](#important-about-android-build-tools-the-android-command-is-deprecated)
-    * [CMake](#cmake)
-    * [Scribe](#scribe)
-  * [Libraries](#libraries)
-    * [Google Gvr sdk](#google-gvr-sdk)
-    * [OpenSSL](#openssl)
-  * [HiFi](#hifi)
-  * [Environment variables recap](#environment-variables-recap)
-  * [Build](#build)
-    * [CMake](#cmake-1)
-    * [make](#make)
-  * [Appendix I (Troubleshooting) Could not find Qt5LinguistTools](#appendix-i-troubleshooting-could-not-find-qt5linguisttools)
-  * [Appendix II (Troubleshooting) Android device](#appendix-ii-troubleshooting-android-device)
-    * [Enable USB Debugging](#enable-usb-debugging)
-    * [Huawei Mate 9 Pro logcat](#huawei-mate-9-pro-logcat)
-    * [Daydream setup](#daydream-setup)
-
-Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
-
 
 ## Prerequisites
 
@@ -51,9 +19,9 @@ Newer versions like Qt 5.6.2 may have problems with the build process.
 
 Environment variable QT_CMAKE_PREFIX_PATH should target the android_armv7\lib\cmake dir
 
-For example if Qt was installed in ~/Qt5.6.1 :
+For example if Qt was installed in C:\Qt\Qt5.6.1 :
 ````
-"/Users/user/Qt5.6.1/5.6/android_armv7/lib/cmake"
+"C:\Qt\Qt5.6.1\5.6\android_armv7\lib\cmake"
 ````
 
 ### Visual Studio 12.0 (Community is enough)
@@ -73,7 +41,7 @@ Inside the package manager (with android studio installed)
 If the ndk-bundle is a different version than ndk r12b, download it separately: 
 [Android NDK r12b](https://developer.android.com/ndk/downloads/older_releases.html#ndk-12b-downloads)
 
-ndk-bundle or the uncompressed folder for r12b should be in the environment variable ANDROID_NDK *using unix slashes*.
+ndk-bundle or the uncompressed folder for r12b should be in the environment variable ANDROID_NDK **using unix slashes**.
 
 ````
 set ANDROID_NDK=C:/Users/user/workspace-hifi/android-ndk-r12b
@@ -106,11 +74,11 @@ setx JAVA_HOME %JAVA_HOME%
 
 ### GNU Make for Windows 
 
-GNU Make is needed to build the all the libraries and the project itself. Download at [gnuwin32](http://gnuwin32.sourceforge.net/packages/make.htm)
+GNU Make is needed to build the all the libraries and the project itself. Download [gnuwin32](http://gnuwin32.sourceforge.net/packages/make.htm).
 
 ### Python
 
-Python is used to execute the Android NDK script that creates a standalone toolchain. Download and install [Python](https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi)
+Python is used to execute the Android NDK script that creates a standalone toolchain. Download and install [Python](https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi).
 
 ### check prerequisites
 
@@ -127,12 +95,14 @@ The toolchain for HiFi must target API Level 24, for ARM and using GNU STL. The 
 Newer android tools will not run `android update lib-project` which was deprecated:
 
 ````
-*************************************************************************
+**************************************************************************
 The "android" command is deprecated.
 For manual SDK, AVD, and project management, please use Android Studio.
-For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
-*************************************************************************
-Invalid or unsupported command "update lib-project -p . -t android-24"
+For command-line tools, use tools\bin\sdkmanager.bat
+and tools\bin\avdmanager.bat
+**************************************************************************
+
+Invalid or unsupported command ""
 
 Supported commands are:
 android list target
@@ -143,7 +113,6 @@ android move avd
 android delete avd
 android list sdk
 android update sdk
--- toolchain_setup_args start
 [...]
 ````
 
@@ -233,7 +202,7 @@ https://www.dropbox.com/s/0ozqzfh9rh0mdzs/openssl.tar.gz?dl=0
 
 #### Build it yourself  (skip if you have a binary)
 
-Check [Build OpenSSL for Mac](/BUILD_ANDROID_MAC.md#build-it-yourself-skip-if-you-have-a-binary-1)
+Check [Build OpenSSL for Mac](/BUILD_ANDROID_MAC.md#build-it-yourself-skip-if-you-have-a-binary-1).
 
 ## HiFi
 
@@ -257,7 +226,7 @@ C:\> SETX ANDROID_HOME %ANDROID_HOME%
 C:\> SETX ANDROID_LIB_DIR %ANDROID_LIB_DIR%
 C:\> SETX ANDROID_NDK %ANDROID_NDK%
 C:\> SETX HIFI_ANDROID_GVR %HIFI_ANDROID_GVR%
-C:\> SETX SCRIBE_PATH=%SCRIBE_PATH%
+C:\> SETX SCRIBE_PATH %SCRIBE_PATH%
 C:\> SETX PATH %PATH%
 
 ````

--- a/BUILD_ANDROID_WIN.md
+++ b/BUILD_ANDROID_WIN.md
@@ -1,4 +1,3 @@
-
 ## Prerequisites
 
 ### About environment variables
@@ -13,8 +12,12 @@ setx QT_CMAKE_PREFIX_PATH=%QT_CMAKE_PREFIX_PATH%
 
 Notice that setx will make persistent the variables for new terminal windows (but not for the already opened ones). You can also add the environment variable [manually] (https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/sysdm_advancd_environmnt_addchange_variable.mspx?mfr=true)
 
+### About adding locations to the PATH variable
+
+Some steps described here require to add tools locations in the PATH variable. [How-to by Microsoft](https://msdn.microsoft.com/en-us/library/office/ee537574(v=office.14).aspx).
+
 ### Qt
-Tested in [Qt 5.6.1](http://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-android-5.6.1-1.exe.mirrorlist)
+Tested in [Qt 5.6.1-1](http://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-windows-x86-android-5.6.1-1.exe.mirrorlist)
 Newer versions like Qt 5.6.2 may have problems with the build process.
 
 Environment variable QT_CMAKE_PREFIX_PATH should target the android_armv7\lib\cmake dir
@@ -78,9 +81,9 @@ GNU Make is needed to build the all the libraries and the project itself. Downlo
 
 ### Python
 
-Python is used to execute the Android NDK script that creates a standalone toolchain. Download and install [Python](https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi).
+Python is used to execute the Android NDK script that creates a standalone toolchain. Download and install [Python 2.7.12](https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi). (Newer versions haven't been tested but may work).
 
-### check prerequisites
+### Check prerequisites
 
 With the utility [checkhifi.bat](https://drive.google.com/open?id=0BzVk5wZGx4ZtaFZudjluQzNXcU0) you can check if you have the needed variables and programs.
 
@@ -176,6 +179,16 @@ workspace-hifi  (ANDROID_LIB_DIR)
 ````
 SCRIBE_PATH should be `C:\Users\user\workspace-hifi\tools`
 
+### cp.bat
+
+CMake generates a makefiles that use `cp` (Unix name) instead of `copy` (which is the command-line tool to copy files on Windows).
+
+A workaround is done by placing a [cp.bat script](https://drive.google.com/open?id=0BzVk5wZGx4ZtYVBhaDgyM0UzcTg) in the PATH.
+
+(That script simply calls `copy`)
+
+Another untested approach is installing GNU tools on Windows through [Cygwin](https://www.cygwin.com/) or [MiniGW](http://www.mingw.org/). The `cp.bat` approach is still more lightweight.
+
 ## Libraries
 
 ### Google Gvr sdk
@@ -197,18 +210,36 @@ HIFI_ANDROID_GVR must be 'gvr-android-sdk' (full path is completed with ANDROID_
 ### OpenSSL
 
 #### Precompiled binary (recommended)
-https://www.dropbox.com/s/0ozqzfh9rh0mdzs/openssl.tar.gz?dl=0
-(donwload and unpack it to the same workspace folder, being sister of hifi and gvr-android-sdk)
+[Download](https://www.dropbox.com/s/0ozqzfh9rh0mdzs/openssl.tar.gz?dl=0) and unpack it on the same workspace folder, being sister of hifi and gvr-android-sdk).
+
+It's important to preserve permissions and symbolic links in that archive.
+
+WinRAR successfully uncompresses keeping file permissions and symbolic links.
+
+Another way to uncompress it, is running from a Git Bash Terminal (or any bash terminal on Windows):
+
+````
+tar -zxvf openssl.tar.gz
+````
 
 #### Build it yourself  (skip if you have a binary)
 
-Check [Build OpenSSL for Mac](/BUILD_ANDROID_MAC.md#build-it-yourself-skip-if-you-have-a-binary-1).
+Check [Build OpenSSL in Mac](/BUILD_ANDROID_MAC.md#build-it-yourself-skip-if-you-have-a-binary-1).
 
 ## HiFi
 
 Clone `https://github.com/highfidelity/hifi.git` (conveniently inside ANDROID_LIB_DIR) and then switch to a branch with the latest Android source code.
 
 Branch "Android" should be the one to use. If you check that this file BUILD_ANDROID_MAC.md is not in the root dir, then switch because necessary changes to make the android app run will not be there.
+
+### Fix toolchain file in HiFi
+
+File `cmake\android\android.toolchain.cmake` needs a change to support the clang.cmd executable from the ndk on Windows.
+
+Download this already [modified version](https://drive.google.com/open?id=0B7PJO9XsQw2gNWxmRzJIbmFyc3c) and replace your file.
+
+An alternative is to apply [this patch](https://gist.github.com/Cristo86/d1fc1439cb145ea50528717408df3399) but using the already modified version is still recommended.
+
 
 ## Environment variables recap
 
@@ -236,13 +267,17 @@ C:\> SETX PATH %PATH%
 
 ## Build
 
+### Create a build directory
+
+Create a folder "build" (recommended) inside the hifi folder. Actually any place is ok but some instructions here suppose that location.
+
 ### CMake
 
 The following must be passed to CMake when it is run:
 
 * USE_ANDROID_TOOLCHAIN - set to true to build for Android
 
-Example running cmake inside a build dir (which itself is inside the project dir e.g. 'hifi')
+Example running CMake inside a build dir (which itself is inside the project dir e.g. 'hifi')
 
 ````
 cmake -G "Unix Makefiles" -DUSE_NSIGHT=0 -DUSE_ANDROID_TOOLCHAIN=1 -DANDROID_QT_CMAKE_PREFIX_PATH=%QT_CMAKE_PREFIX_PATH% ..
@@ -252,12 +287,53 @@ Where QT_CMAKE_PREFIX_PATH must be `/QtInstallDir/5.6/android_armv7/lib/cmake`
 
 ### make
 
-After cmake: run to build the apk
+After cmake: run to build the apk (inside the build folder).
+
 ````
 make interface-apk
 ````
 
+The following described problem is very likely to happen:
+
+### Currently known problem with '..' command.
+
+During the build process, when scribe is needed to execute, an error about unknown '..' commands will happen. Following instructions make it possible to continue building:
+
+#### Fix makefiles that use scribe
+Generated makefiles use .. which is not working on Windows. So we must replace
+  ```
+  ../../../tools/scribe/build/Debug/scribe.exe
+  ```
+  for
+  ```
+  c:/Users/user/dev/workspace-hifi/hifi/tools/scribe/build/Debug/scribe.exe
+  ```
+  (Or in your case your full path to scribe)
+
+In several files, e.g. `<build-dir>\libraries\display-plugins\CMakeFiles\display-plugins.dir\build.make`
+
+To automate that process, use the `fixscribeinmakes.bat` script described below:
+
+#### Use fixscribeinmakes.bat
+
+First of all, `fixscribeinmakes.bat` requires the script [replacerx.bat](https://drive.google.com/open?id=0BzVk5wZGx4Zta1JIYzk1Mjh6Q0E) to be in the PATH so it can be run by simply typing `replacerx`.
+
+[Download fixscribeinmakes.bat](https://drive.google.com/open?id=0BzVk5wZGx4ZteHdOM3lSZnpXelk) and edit it, particularly to match paths in your system. Must check these variables inside:
+
+`FIX_SCRIBE_OLD` - Path to scribe.exe that starts with ../../.. which is not supported and needs to be replaced
+
+`FIX_SCRIBE_NEW` - Full path to the scribe.exe tool
+
+`FIX_HIFI_LIBRARIES_DIR` - Full path should point your current <build-dir>\libraries
+
+As we use full paths fixscribeinmakes.bat can be run from anywhere (anyway, it's recommended to place it in your workspace-folder, outside 'hifi').
+
+Note: The replace string routine may take some time so, wait until the entire script is done.
+
+After running `fixscribeinmakes.bat` run inside the build directory, `make interface-apk` again.
+
 ## Appendix I (Troubleshooting) Could not find Qt5LinguistTools
+
 If an error like to following happens:
 
 ````
@@ -305,147 +381,7 @@ and you will see a hidden menu. Go to the Project Menu > Background Setting > Lo
 Full Daydream setup (includes entering payment information) is required to properly run Daydream and Daydream Apps like Hifi "Interface".
 
 
-# HiFi interface - Android build on Windows
-
-## Fix makefiles that use scribe
-Generated makefiles use .. which is not working on Windows. So we must replace
-  ```
-  ../../../tools/scribe/build/Debug/scribe.exe
-  ```
-  for
-  ```
-  c:/Users/user/dev/workspace-hifi/hifi/tools/scribe/build/Debug/scribe.exe
-  ```
-  (Or in your case your full path to scribe)
-
-### Use fixscribeinmakes.bat
-
-Edit it, particularly to match paths in your system. Must check these variables inside:
-```
-FIX_SCRIBE_OLD
-FIX_SCRIBE_NEW
-```
-And the line that changes dir to libraries should point your actual build-dir\libraries
-```
-cd  C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries
-```
-
-## Build
-Use build_android.bat that runs cmake for you and creates a build folder.
-Inside the build folder, run
-```
-make interface-apk
-```
-
-## ndk r12b + android-24 + Google VR
-
-### prerequisites
-
-download gvr
-git clone https://github.com/googlevr/gvr-android-sdk
-(where? in android_lib_dir location, generally one level outside the cloned hifi)
-
-sdk:
-android 7.0
-sdk tools 25.2.2
-sdk platform-tools 25
-
-download r12b
-https://github.com/android-ndk/ndk/wiki
-
-python to make a standalone toolchain
-https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi
-
-new openssl to replace old one
-targeting android-24
-(given a tar.gz, use
-```
-tar -zxvf backup.tar.gz
-```
-from git bash.
-
-### create standalone toolchain
-```
-C:\Users\user\dev\bin\android-ndk-r12b\build\tools>make_standalone_toolchain.py --arch arm --api 24 --stl=libc++ --install-dir C:\Users\user\dev\bin\android-ndk-r12b\toolchains\my-tc-24-libc
-```
-  creates folder
-  ```
-  C:\Users\user\dev\bin\android-ndk-r12b\toolchains\my-tc-24-libc
-  ```
-
-Complete toolchain by copying libsupc
-```
-c:\Users\user\dev\bin\android-ndk-r12b\sources\cxx-stl\gnu-libstdc++\4.9\libs\armeabi-v7a\libsupc++.a
-to
-c:\Users\user\dev\bin\android-ndk-r12b\toolchains\my-tc-24-libc\arm-linux-androideabi\lib\armv7-a\
-```
-## Additional changes
-
-### fix toolchain
-
-Separate the suffix for clang from other tools (so some will use .exe, clang .cmd)
-
-```
-+++ b/cmake/android/android.toolchain.cmake
-@@ -362,6 +362,7 @@ if( NOT DEFINED ANDROID_NDK_HOST_X64 AND (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "a
- endif()
-
- set( TOOL_OS_SUFFIX "" )
-+set( TOOL_OS_CLANG_SCRIPT_SUFFIX "" )
- if( CMAKE_HOST_APPLE )
-  set( ANDROID_NDK_HOST_SYSTEM_NAME "darwin-x86_64" )
-  set( ANDROID_NDK_HOST_SYSTEM_NAME2 "darwin-x86" )
-@@ -369,6 +370,7 @@ elseif( CMAKE_HOST_WIN32 )
-  set( ANDROID_NDK_HOST_SYSTEM_NAME "windows-x86_64" )
-  set( ANDROID_NDK_HOST_SYSTEM_NAME2 "windows" )
-  set( TOOL_OS_SUFFIX ".exe" )
-+ set( TOOL_OS_CLANG_SCRIPT_SUFFIX ".cmd" )
- elseif( CMAKE_HOST_UNIX )
-  set( ANDROID_NDK_HOST_SYSTEM_NAME "linux-x86_64" )
-  set( ANDROID_NDK_HOST_SYSTEM_NAME2 "linux-x86" )
-@@ -1108,23 +1110,24 @@ else()
- endif()
- unset( _ndk_ccache )
-
--
-+message (STATUS "CMAKE_C_COMPILER ${CMAKE_C_COMPILER}")
-+message (STATUS "CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER}")
- # setup the cross-compiler
- if( NOT CMAKE_C_COMPILER )
-  if( NDK_CCACHE AND NOT ANDROID_SYSROOT MATCHES "[ ;\"]" )
-   set( CMAKE_C_COMPILER   "${NDK_CCACHE}" CACHE PATH "ccache as C compiler" )
-   set( CMAKE_CXX_COMPILER "${NDK_CCACHE}" CACHE PATH "ccache as C++ compiler" )
-   if( ANDROID_COMPILER_IS_CLANG )
--   set( CMAKE_C_COMPILER_ARG1   "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}${TOOL_OS_SUFFIX}"   CACHE PATH "C compiler")
--   set( CMAKE_CXX_COMPILER_ARG1 "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}++${TOOL_OS_SUFFIX}" CACHE PATH "C++ compiler")
-+   set( CMAKE_C_COMPILER_ARG1   "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}${TOOL_OS_CLANG_SCRIPT_SUFFIX}"   CACHE PATH "C compiler")
-+   set( CMAKE_CXX_COMPILER_ARG1 "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}++${TOOL_OS_CLANG_SCRIPT_SUFFIX}" CACHE PATH "C++ compiler")
-   else()
-    set( CMAKE_C_COMPILER_ARG1   "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-gcc${TOOL_OS_SUFFIX}" CACHE PATH "C compiler")
-    set( CMAKE_CXX_COMPILER_ARG1 "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-g++${TOOL_OS_SUFFIX}" CACHE PATH "C++ compiler")
-   endif()
-  else()
-   if( ANDROID_COMPILER_IS_CLANG )
--   set( CMAKE_C_COMPILER   "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}${TOOL_OS_SUFFIX}"   CACHE PATH "C compiler")
--   set( CMAKE_CXX_COMPILER "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}++${TOOL_OS_SUFFIX}" CACHE PATH "C++ compiler")
-+   set( CMAKE_C_COMPILER   "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}${TOOL_OS_CLANG_SCRIPT_SUFFIX}"   CACHE PATH "C compiler")
-+   set( CMAKE_CXX_COMPILER "${ANDROID_CLANG_TOOLCHAIN_ROOT}/bin/${_clang_name}++${TOOL_OS_CLANG_SCRIPT_SUFFIX}" CACHE PATH "C++ compiler")
-   else()
-    set( CMAKE_C_COMPILER   "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-gcc${TOOL_OS_SUFFIX}"    CACHE PATH "C compiler" )
-    set( CMAKE_CXX_COMPILER "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-g++${TOOL_OS_SUFFIX}"    CACHE PATH "C++ compiler" )
-@@ -1144,7 +1147,8 @@ if( NOT CMAKE_C_COMPILER )
-  set( CMAKE_OBJDUMP      "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-objdump${TOOL_OS_SUFFIX}" CACHE PATH "objdump" )
-  set( CMAKE_RANLIB       "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-ranlib${TOOL_OS_SUFFIX}"  CACHE PATH "ranlib" )
- endif()
--
-+message (STATUS "CMAKE_C_COMPILER ${CMAKE_C_COMPILER}")
-+message (STATUS "CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER}")
- set( _CMAKE_TOOLCHAIN_PREFIX "${ANDROID_TOOLCHAIN_MACHINE_NAME}-" )
-:
-```
-(USE .cmd for compilers)
-
-### Troubleshooting
+## Appendix III (Troubleshooting) Weird errors (must see)
 
 #### Path errors
 
@@ -494,293 +430,4 @@ Run interface-apk again inside build-dir.
 
 
 
-
-## Appendix - Custom scripts
-  We have some helpul and needed scripts to build Android on Windows as the process was outlined for OS X in the first place. Further work should make it possible to skip them.
-
-  All these scripts should be accessible, by being in the PATH.
-
-  checkhifi.bat - shows needed variables and executables
-  ```
-  @echo OFF
-
-  ::call:checkVar ANDROID_HOME %ANDROID_HOME%
-
-  echo:
-  echo Checking environment variables...
-  echo:
-  SET VAR=ANDROID_HOME
-  SET VAL=%ANDROID_HOME%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  SET VAR=ANDROID_NDK
-  SET VAL=%ANDROID_NDK%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  SET VAR=NDK_HOME
-  SET VAL=%NDK_HOME%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  SET VAR=ANDROID_NDK_ROOT
-  SET VAL=%ANDROID_NDK_ROOT%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  SET VAR=ANDROID_LIB_DIR
-  SET VAL=%ANDROID_LIB_DIR%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  SET VAR=QT_CMAKE_PREFIX_PATH
-  SET VAL=%QT_CMAKE_PREFIX_PATH%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  SET VAR=QT_CMAKE_PREFIX_PATH_ANDROID
-  SET VAL=%QT_CMAKE_PREFIX_PATH_ANDROID%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  SET VAR=SCRIBE_PATH
-  SET VAL=%SCRIBE_PATH%
-  if "%VAL%" == "" ( echo [ERROR] %VAR% Not defined ****** ) else ( echo [INFO ] %VAR% defined as [%VAL%] )
-  echo:
-  @echo Check finished...
-  echo:
-  echo:
-  @echo Checking programs in path...
-  echo:
-  SET PROG=cl.exe
-  for %%X in (%PROG%) do (set FOUND=%%~$PATH:X)
-  if "%FOUND%" == "" (
-      echo [ERROR] %PROG% not found ******
-      echo [INFO ] Must run "vcvarsall.bat" x64 from your "Visual Studio\VC" installation to find cl
-  ) else (
-      echo [INFO ] %PROG% found at "%FOUND%"
-  )
-
-  SET PROG=make.exe
-  for %%X in (%PROG%) do (set FOUND=%%~$PATH:X)
-  if "%FOUND%" == "" ( echo [ERROR] %PROG% not found ****** ) else ( echo [INFO ] %PROG% found at "%FOUND%" )
-
-  SET PROG=cp.bat
-  for %%X in (%PROG%) do (set FOUND=%%~$PATH:X)
-  if "%FOUND%" == "" ( echo [ERROR] %PROG% not found ****** ) else ( echo [INFO ] %PROG% found at "%FOUND%" )
-
-  SET PROG=cmake.exe
-  for %%X in (%PROG%) do (set FOUND=%%~$PATH:X)
-  if "%FOUND%" == "" ( echo [ERROR] %PROG% not found ****** ) else ( echo [INFO ] %PROG% found at "%FOUND%" )
-
-  SET PROG=java.exe
-  for %%X in (%PROG%) do (set FOUND=%%~$PATH:X)
-  if "%FOUND%" == "" ( echo [ERROR] %PROG% not found ****** ) else ( echo [INFO ] %PROG% found at "%FOUND%" )
-
-  SET PROG=javac.exe
-  for %%X in (%PROG%) do (set FOUND=%%~$PATH:X)
-  if "%FOUND%" == "" ( echo [ERROR] %PROG% not found ****** ) else ( echo [INFO ] %PROG% found at "%FOUND%" )
-
-  goto:eof
-
-  :eof
-  ```
-
-  cp.bat - "cp" for windows adaptation (make uses cp instead of copy)
-  ```
-  @echo off
-  set a=%1
-  set b=%2
-  set a=%a:/=\%
-  set b=%b:/=\%
-  rem echo %a%
-  rem echo %b%
-  copy %a% %b%
-  ```
-
-  vars.bat (sets env vars automatically without having to go to the UI, edit first!)
-  ```
-  set ANDROID_HOME=c:/Users/user/dev/bin/android-sdk-windows/
-  set ANDROID_NDK=c:\Users\user\dev\bin\android-ndk-r10e\
-  set NDK_HOME=%ANDROID_NDK%
-  set ANDROID_NDK_ROOT=%ANDROID_NDK%
-  set ANDROID_LIB_DIR=c:\Users\user\dev\workspace-hifi\
-  set QT_CMAKE_PREFIX_PATH=c:\Qt\Qt5.6.1\5.6\android_armv7\lib\cmake\
-  set QT_CMAKE_PREFIX_PATH_ANDROID=c:\Qt\Qt5.6.1\5.6\android_armv7\lib\cmake\
-  set SCRIBE_PATH=c:\Users\user\dev\workspace-hifi\hifi\tools\scribe\build\Debug\
-
-  setx ANDROID_HOME %ANDROID_HOME%
-  setx ANDROID_NDK %ANDROID_NDK%
-  setx NDK_HOME %ANDROID_NDK%
-  setx ANDROID_NDK_ROOT %ANDROID_NDK%
-  setx ANDROID_LIB_DIR %ANDROID_LIB_DIR%
-  setx QT_CMAKE_PREFIX_PATH %QT_CMAKE_PREFIX_PATH%
-  setx SCRIBE_PATH %SCRIBE_PATH%
-
-  :: Be sure to have the Path environment variable correctly set up
-  :: With at least the following:
-  ::
-  :: JDK 8 
-  :: e.g. c:\Program Files\Java\jdk1.8.0_101\bin
-  ::
-  :: ant
-  :: C:\Users\user\dev\bin\apache-ant-1.9.4\bin
-  ::
-  :: cmake
-  :: C:\Users\user\dev\bin\cmake-3.3.2-win32-x86\bin
-  ::
-  :: git 
-  :: e.g. C:\Program Files\Git\cmd
-  ::
-  :: make for Windows
-  :: c:\Program Files (x86)\GnuWin32\bin
-  ::
-  :: cp.bat
-  :: c:\whereveryouputit
-  ::
-  ```
-
-  replacerx.bat (replaces a string in a file and outputs) - **must be in PATH to make fixscribeinmakes.bat work**
-  ```
-  @echo off
-  REM -- Prepare the Command Processor --
-  SETLOCAL ENABLEEXTENSIONS
-  SETLOCAL DISABLEDELAYEDEXPANSION
-
-  ::BatchSubstitude - parses a File line by line and replaces a substring"
-  ::syntax: BatchSubstitude.bat OldStr NewStr File
-  ::          OldStr [in] - string to be replaced
-  ::          NewStr [in] - string to replace with
-  ::          File   [in] - file to be parsed
-  :$changed 20100115
-  :$source http://www.dostips.com
-  if "%~1"=="" findstr "^::" "%~f0"&GOTO:EOF
-  for /f "tokens=1,* delims=]" %%A in ('"type %3|find /n /v """') do (
-      set "line=%%B"
-      if defined line (
-          call set "line=echo.%%line:%~1=%~2%%"
-          for /f "delims=" %%X in ('"echo."%%line%%""') do %%~X
-      ) ELSE echo.
-  )
-  ```
-
-  fixscribeinmakes.bat (edit first! predefined files use .. and is not working on cmd)
-  ```
-  @echo off
-
-  REM ****************************************
-  REM 1 replacerx.bat in path
-
-  REM ****************************************
-  REM 2 locate all needed to change files:
-  REM C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries\display-plugins\CMakeFiles\display-plugins.dir\build.make:
-  REM C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries\entities-renderer\CMakeFiles\entities-renderer.dir\build.make:
-  REM C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries\gpu\CMakeFiles\gpu.dir\build.make:
-  REM C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries\model\CMakeFiles\model.dir\build.make:
-  REM C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries\procedural\CMakeFiles\procedural.dir\build.make:
-  REM C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries\render\CMakeFiles\render.dir\build.make:
-  REM C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries\render-utils\CMakeFiles\render-utils.dir\build.make:
-
-  REM ****************************************
-  REM 3 detect what to replace
-  REM result:
-  REM ../../../tools/scribe/build/Debug/scribe.exe
-  SET FIX_SCRIBE_OLD=../../../tools/scribe/build/Debug/scribe.exe
-
-  REM ****************************************
-  REM 4 detect what for
-  REM result:
-  REM c:/Users/user/dev/workspace-hifi/hifi/tools/scribe/build/Debug/scribe.exe
-  SET FIX_SCRIBE_NEW=c:/Users/user/dev/workspace-hifi/hifi/tools/scribe/build/Debug/scribe.exe
-
-  REM ****************************************
-  REM 5 go to libraries folder
-  cd  C:\Users\user\dev\workspace-hifi\hifi\build-android-interface\libraries
-  echo "in %cd%"
-
-  REM ****************************************
-  REM 6 run for each
-  cd "display-plugins\CMakeFiles\display-plugins.dir"
-  echo "in %cd%"
-  erase build.makexx
-  call replacerx %FIX_SCRIBE_OLD% %FIX_SCRIBE_NEW% build.make > build.makexx
-  erase build.make
-  move build.makexx build.make
-  cd ..\..\..
-  echo "in %cd%"
-
-  REM ****************************************
-  REM run for each
-  cd "entities-renderer\CMakeFiles\entities-renderer.dir"
-  echo "in %cd%"
-  erase build.makexx
-  call replacerx %FIX_SCRIBE_OLD% %FIX_SCRIBE_NEW% build.make > build.makexx
-  erase build.make
-  move build.makexx build.make
-  cd ..\..\..
-  echo "in %cd%"
-
-  REM ****************************************
-  REM run for each
-  cd "gpu\CMakeFiles\gpu.dir"
-  echo "in %cd%"
-  erase build.makexx
-  call replacerx %FIX_SCRIBE_OLD% %FIX_SCRIBE_NEW% build.make > build.makexx
-  erase build.make
-  move build.makexx build.make
-  cd ..\..\..
-  echo "in %cd%"
-
-  REM ****************************************
-  REM run for each
-  cd "model\CMakeFiles\model.dir"
-  echo "in %cd%"
-  erase build.makexx
-  call replacerx %FIX_SCRIBE_OLD% %FIX_SCRIBE_NEW% build.make > build.makexx
-  erase build.make
-  move build.makexx build.make
-  cd ..\..\..
-  echo "in %cd%"
-
-  REM ****************************************
-  REM run for each
-  cd "procedural\CMakeFiles\procedural.dir"
-  echo "in %cd%"
-  erase build.makexx
-  call replacerx %FIX_SCRIBE_OLD% %FIX_SCRIBE_NEW% build.make > build.makexx
-  erase build.make
-  move build.makexx build.make
-  cd ..\..\..
-  echo "in %cd%"
-
-  REM ****************************************
-  REM run for each
-  cd "render\CMakeFiles\render.dir"
-  echo "in %cd%"
-  erase build.makexx
-  call replacerx %FIX_SCRIBE_OLD% %FIX_SCRIBE_NEW% build.make > build.makexx
-  erase build.make
-  move build.makexx build.make
-  cd ..\..\..
-  echo "in %cd%"
-
-  REM ****************************************
-  REM run for each
-  cd "render-utils\CMakeFiles\render-utils.dir"
-  echo "in %cd%"
-  erase build.makexx
-  call replacerx %FIX_SCRIBE_OLD% %FIX_SCRIBE_NEW% build.make > build.makexx
-  erase build.make
-  move build.makexx build.make
-  cd ..\..\..
-  echo "in %cd%"
-  ```
-  
-build_android.bat (not needed in path, but it is recommended to be one level outside the cloned hifi folder) Edit it for correct folder paths!
-```
-:: Script to build android interface in windows development environment
-@ECHO OFF
-RMDIR /S /Q hifi\build-android
-MKDIR hifi\build-android
-CD hifi\build-android
-SET QT_CMAKE_PREFIX_PATH=%QT_CMAKE_PREFIX_PATH_ANDROID%
-ECHO QT_CMAKE_PREFIX_PATH=%QT_CMAKE_PREFIX_PATH%
-java -version
-cmake -G "Unix Makefiles" -DUSE_NSIGHT=0 -DUSE_ANDROID_TOOLCHAIN=1 -DANDROID_QT_CMAKE_PREFIX_PATH=%QT_CMAKE_PREFIX_PATH% ..
-IF %ERRORLEVEL% NEQ 0 (
- ECHO Cmake failed
-) ELSE (
- ECHO Cmake succeeded
- REM make interface-apk
-)
-cd .. 
-ECHO ON
-```
 

--- a/BUILD_SCRIBE_MAC.md
+++ b/BUILD_SCRIBE_MAC.md
@@ -1,0 +1,90 @@
+## Build Scribe only
+
+This section is intended to build scribe without having to build the entire HiFi project for Mac or Windows
+
+
+## Binary
+
+You can alternatively download an already [built scribe binary](https://drive.google.com/open?id=0BzVk5wZGx4ZtOTlMQWwtaW1BUzA)
+
+## Build it yourself
+
+1. Create a new file in tools/scribe/SetupHifiProject.cmake and paste this content
+
+````
+#
+#  SetupHifiProject.cmake
+#
+#  Copyright 2013 High Fidelity, Inc.
+#
+#  Distributed under the Apache License, Version 2.0.
+#  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+#
+
+macro(SETUP_HIFI_PROJECT)
+  project(${TARGET_NAME})
+
+  # grab the implemenation and header files
+  file(GLOB TARGET_SRCS src/*)
+
+  file(GLOB SRC_SUBDIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/src/*)
+
+  foreach(DIR ${SRC_SUBDIRS})
+    if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/${DIR}")
+      file(GLOB DIR_CONTENTS "src/${DIR}/*")
+      set(TARGET_SRCS ${TARGET_SRCS} "${DIR_CONTENTS}")
+    endif ()
+  endforeach()
+
+  add_executable(${TARGET_NAME} ${TARGET_SRCS} ${AUTOSCRIBE_SHADER_LIB_SRC})
+
+  # include the generated application version header
+  target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_BINARY_DIR}/includes")
+
+  #set(${TARGET_NAME}_DEPENDENCY_QT_MODULES ${ARGN})
+  #list(APPEND ${TARGET_NAME}_DEPENDENCY_QT_MODULES Core)
+
+  # find these Qt modules and link them to our own target
+  #find_package(Qt5 COMPONENTS ${${TARGET_NAME}_DEPENDENCY_QT_MODULES} REQUIRED)
+
+  # disable /OPT:REF and /OPT:ICF for the Debug builds
+  # This will prevent the following linker warnings
+  # LINK : warning LNK4075: ignoring '/INCREMENTAL' due to '/OPT:ICF' specification
+  if (WIN32)
+     set_property(TARGET ${TARGET_NAME} APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "/OPT:NOREF /OPT:NOICF")
+  endif()
+
+ # foreach(QT_MODULE ${${TARGET_NAME}_DEPENDENCY_QT_MODULES})
+ #   target_link_libraries(${TARGET_NAME} Qt5::${QT_MODULE})
+ # endforeach()
+
+ # target_glm()
+
+endmacro()
+````
+
+2. Modify the file tools/scribe/CMakeLists.txt so it looks like this
+
+````
+cmake_minimum_required(VERSION 3.3)
+set(TARGET_NAME scribe)
+include("SetupHifiProject.cmake")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+setup_hifi_project()
+````
+
+3. Create a build directory and run cmake
+
+````
+  cd tools/scribe
+  md build 
+  cd build
+  cmake ..
+````
+
+4. Build scribe
+
+````
+  make all
+````
+

--- a/BUILD_SCRIBE_WIN.md
+++ b/BUILD_SCRIBE_WIN.md
@@ -14,8 +14,7 @@ You can alternatively download an already [built scribe binary](https://drive.go
 2. CMake 3.3.2
 
 ## Steps
-
-1. Create a new file in tools\scribe\SetupHifiProject.cmake and paste this content
+1. Create a new file in tools\scribe\SetupHifiProject.cmake and paste this content.
 
 ````
 #
@@ -68,9 +67,7 @@ macro(SETUP_HIFI_PROJECT)
 
 endmacro()
 ````
-
 2. Modify the file tools\scribe\CMakeLists.txt so it looks like this
-
 ````
 cmake_minimum_required(VERSION 3.3)
 set(TARGET_NAME scribe)
@@ -78,16 +75,13 @@ include("SetupHifiProject.cmake")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 setup_hifi_project()
 ````
-
 3. Create a build directory and run cmake
-
 ````
   cd tools\scribe
   mkdir build 
   cd build
   cmake ..
 ````
-
 4. Build scribe
 
 Check the path where Visual Studio 12 2013 is installed and run these lines
@@ -97,7 +91,6 @@ Check the path where Visual Studio 12 2013 is installed and run these lines
 MSBuild /nologo /t:Build scribe.vcxproj
 
 ````
-
 At this point you should get scribe.exe inside the Debug folder. Move it to the path contained in %SCRIBE_PATH% or update the environment variable to point out the Debug folder
 
 

--- a/BUILD_SCRIBE_WIN.md
+++ b/BUILD_SCRIBE_WIN.md
@@ -4,7 +4,7 @@ This section is intended to build scribe without having to build the entire HiFi
 
 ## Binary
 
-You can alternatively download an already [built scribe binary](https://drive.google.com/open?id=0BzVk5wZGx4ZtOTlMQWwtaW1BUzA)
+You can alternatively download an already [built scribe binary](https://drive.google.com/open?id=0BzVk5wZGx4Ztc0tpelgxdjF1dkU)
 
 ## Build it yourself
 
@@ -12,7 +12,6 @@ You can alternatively download an already [built scribe binary](https://drive.go
 
 1. Visual Studio 12 2013
 2. CMake 3.3.2
-3. GNU Make for Windows
 
 ## Steps
 
@@ -84,7 +83,7 @@ setup_hifi_project()
 
 ````
   cd tools\scribe
-  mddir build 
+  mkdir build 
   cd build
   cmake ..
 ````
@@ -94,7 +93,7 @@ setup_hifi_project()
 Check the path where Visual Studio 12 2013 is installed and run these lines
 
 ````
-c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
+"c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
 MSBuild /nologo /t:Build scribe.vcxproj
 
 ````

--- a/BUILD_SCRIBE_WIN.md
+++ b/BUILD_SCRIBE_WIN.md
@@ -1,0 +1,104 @@
+## Build Scribe only
+
+This section is intended to build scribe without having to build the entire HiFi project for Windows
+
+## Binary
+
+You can alternatively download an already [built scribe binary](https://drive.google.com/open?id=0BzVk5wZGx4ZtOTlMQWwtaW1BUzA)
+
+## Build it yourself
+
+### Prerequisites
+
+1. Visual Studio 12 2013
+2. CMake 3.3.2
+3. GNU Make for Windows
+
+## Steps
+
+1. Create a new file in tools\scribe\SetupHifiProject.cmake and paste this content
+
+````
+#
+#  SetupHifiProject.cmake
+#
+#  Copyright 2013 High Fidelity, Inc.
+#
+#  Distributed under the Apache License, Version 2.0.
+#  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+#
+
+macro(SETUP_HIFI_PROJECT)
+  project(${TARGET_NAME})
+
+  # grab the implemenation and header files
+  file(GLOB TARGET_SRCS src/*)
+
+  file(GLOB SRC_SUBDIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/src/*)
+
+  foreach(DIR ${SRC_SUBDIRS})
+    if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/${DIR}")
+      file(GLOB DIR_CONTENTS "src/${DIR}/*")
+      set(TARGET_SRCS ${TARGET_SRCS} "${DIR_CONTENTS}")
+    endif ()
+  endforeach()
+
+  add_executable(${TARGET_NAME} ${TARGET_SRCS} ${AUTOSCRIBE_SHADER_LIB_SRC})
+
+  # include the generated application version header
+  target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_BINARY_DIR}/includes")
+
+  #set(${TARGET_NAME}_DEPENDENCY_QT_MODULES ${ARGN})
+  #list(APPEND ${TARGET_NAME}_DEPENDENCY_QT_MODULES Core)
+
+  # find these Qt modules and link them to our own target
+  #find_package(Qt5 COMPONENTS ${${TARGET_NAME}_DEPENDENCY_QT_MODULES} REQUIRED)
+
+  # disable /OPT:REF and /OPT:ICF for the Debug builds
+  # This will prevent the following linker warnings
+  # LINK : warning LNK4075: ignoring '/INCREMENTAL' due to '/OPT:ICF' specification
+  if (WIN32)
+     set_property(TARGET ${TARGET_NAME} APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "/OPT:NOREF /OPT:NOICF")
+  endif()
+
+ # foreach(QT_MODULE ${${TARGET_NAME}_DEPENDENCY_QT_MODULES})
+ #   target_link_libraries(${TARGET_NAME} Qt5::${QT_MODULE})
+ # endforeach()
+
+ # target_glm()
+
+endmacro()
+````
+
+2. Modify the file tools\scribe\CMakeLists.txt so it looks like this
+
+````
+cmake_minimum_required(VERSION 3.3)
+set(TARGET_NAME scribe)
+include("SetupHifiProject.cmake")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+setup_hifi_project()
+````
+
+3. Create a build directory and run cmake
+
+````
+  cd tools\scribe
+  mddir build 
+  cd build
+  cmake ..
+````
+
+4. Build scribe
+
+Check the path where Visual Studio 12 2013 is installed and run these lines
+
+````
+c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
+MSBuild /nologo /t:Build scribe.vcxproj
+
+````
+
+At this point you should get scribe.exe inside the Debug folder. Move it to the path contained in %SCRIBE_PATH% or update the environment variable to point out the Debug folder
+
+


### PR DESCRIPTION
Improve BUILD_ANDROID_MAC.md (tested in clean mac user)
Improve BUILD_ANDROID_WIN.md (tested on a clean Windows 7)
New BUILD_SCRIBE_MAC.md and BUILD_SCRIBE_WIN.md (alternative to download the binary)
