### PR TITLE
21356 - Reorder Edit.js

### DIFF
--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -449,8 +449,68 @@ input[type=checkbox]:checked + label:hover {
     border: 1.5pt solid black;
 }
 
+.shape-section, .light-section, .model-section, .web-section, .hyperlink-section, .text-section, .zone-section {
+	display: table;
+}
 
-.section-header, .sub-section-header, hr {
+
+
+#properties-list fieldset {
+	position: relative;
+	/* 0.1px on the top is to prevent margin collapsing between this and it's first child */
+	margin: 21px -21px 0px -21px;
+    padding: 0.1px 21px 0px 21px;
+	border: none;
+	border-top: 1px rgb(90,90,90) solid;
+	box-shadow: 0px -1px 0px rgb(37,37,37);
+}
+
+#properties-list fieldset.fstuple, #properties-list fieldset.fsrow {
+	margin-top: 21px;
+	border: none;
+	box-shadow: none;
+}
+
+#properties-list > fieldset[data-collapsed="true"] + fieldset {
+	margin-top: 0px;
+}
+
+#properties-list > fieldset[data-collapsed="true"] > *:not(legend) {
+	 display: none !important;
+}
+
+#properties-list legend + fieldset {
+	margin-top: 0px;
+	border: none;
+	box-shadow: none;
+}
+
+#properties-list > fieldset#properties-header {
+	margin-top: 0px;
+	padding-bottom: 0px;
+}
+
+
+
+#properties-list > fieldset > legend {
+	position: relative;
+    display: table;
+    width: 100%;
+    margin: 21px -21px 0 -21px;
+    padding: 14px 21px 0 21px;
+    font-family: Raleway-Regular;
+    font-size: 12px;
+    color: #afafaf;
+    height: 28px;
+    text-transform: uppercase;
+    outline: none;
+	background-color: #404040;
+	border: none;
+	border-top: 1px rgb(90,90,90) solid;
+	box-shadow: 0 -1px 0 rgb(37,37,37), 0 4px 4px 0 rgba(0,0,0,0.75);
+}
+
+div.section-header, .sub-section-header, hr {
     display: table;
     width: 100%;
     margin: 21px -21px 0 -21px;
@@ -463,16 +523,18 @@ input[type=checkbox]:checked + label:hover {
     outline: none;
 }
 
-.section-header {
-    position: relative;
-    background: #404040 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAqCAIAAAAbNW1vAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAmSURBVChTY1BFAgzhSIDBAQmMcoYHRwIJMCgjAQZ9JMBgBQdWVgBh5XmBV5A2FQAAAABJRU5ErkJggg==) repeat-x top left;
+
+
+.column .sub-section-header {
+	background-image: none;
+	padding-top: 0;
 }
 
 .sub-section-header, .no-collapse, hr {
     background: #404040 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAjSURBVBhXY1RVVf3PgARYjIyMoEwIYHRwcEBRwQSloYCBAQCwjgPMiI7W2QAAAABJRU5ErkJggg==) repeat-x top left;
 }
 
-.section-header:first-child {
+div.section-header:first-child {
     margin-top: -2px;
     padding-top: 0;
     background: none;
@@ -483,7 +545,7 @@ input[type=checkbox]:checked + label:hover {
     margin-bottom: -10px;
 }
 
-.section-header span {
+#properties-list > fieldset > legend span, .section-header span {
     font-family: HiFi-Glyphs;
     font-size: 30px;
     float: right;
@@ -537,11 +599,28 @@ hr {
     font-size: 13px;
 }
 
+.property legend, .number legend {
+    display: table-cell;
+    vertical-align: middle;
+    font-family: Raleway-SemiBold;
+    font-size: 14px;
+}
+.property legend .unit, .number legend .unit {
+    margin-left: 8px;
+    font-family: Raleway-Light;
+    font-size: 13px;
+}
+
 .value {
     display: block;
     min-height: 18px;
 }
 .value label {
+    display: inline-block;
+    vertical-align: top;
+    width: 48px;
+}
+.value legend {
     display: inline-block;
     vertical-align: top;
     width: 48px;
@@ -567,6 +646,13 @@ hr {
 }
 
 .text label, .url label, .number label, .textarea label, .rgb label, .xyz label, .pyr label, .dropdown label, .gen label {
+    float: left;
+    margin-left: 1px;
+    margin-bottom: 3px;
+    margin-top: -2px;
+}
+
+.text legend, .url legend, .number legend, .textarea legend, .rgb legend, .xyz legend, .pyr legend, .dropdown legend, .gen legend {
     float: left;
     margin-left: 1px;
     margin-bottom: 3px;
@@ -715,6 +801,14 @@ div.refresh input[type="button"] {
     display: none !important;
 }
 
+#property-color-control1 {
+	display: table-cell;
+	float: none;
+}
+
+#property-color-control1 + label  {
+	border-left: 20px transparent solid;
+}
 
 .rgb label {
     float: left;
@@ -722,6 +816,15 @@ div.refresh input[type="button"] {
     margin-left: 21px;
 }
 .rgb label + * {
+    clear: both;
+}
+
+.rgb legend {
+    float: left;
+    margin-top: 10px;
+    margin-left: 21px;
+}
+.rgb legend + * {
     clear: both;
 }
 
@@ -814,6 +917,42 @@ tuple, .blue:focus, .tuple .z:focus, .tuple .roll:focus {
     display: table-cell;
     width: 50%;
 }
+
+#properties-list fieldset .two-column {
+	padding-top:21px;
+	display: flex;
+}
+
+#properties-list .two-column  fieldset {
+    /*display: table-cell;*/
+    width: 50%;
+	margin: 0;
+	padding: 0;
+	border-top: none;
+	box-shadow: none;
+}
+
+#properties-list .two-column  fieldset legend {
+	display: table;
+    width: 100%;
+	margin: 21px -21px 0px -21px;
+    padding: 0px 0px 0px 21px;
+    font-family: Raleway-Regular;
+    font-size: 12px;
+    color: #afafaf;
+    height: 28px;
+    text-transform: uppercase;
+    outline: none;
+}
+
+fieldset .checkbox-sub-props {
+	 margin-top: 0;
+ }
+
+fieldset .checkbox-sub-props .property:first-child {
+	margin-top: 0;
+}
+
 .column {
     vertical-align: top;
 }
@@ -1155,9 +1294,11 @@ th#entity-hasScript {
 }
 
 
-#properties-header {
+#properties-list #properties-header {
     display: table-row;
     height: 28px;
+	border-top: none;
+	box-shadow: none;
 }
 
 #properties-header .property {
@@ -1261,4 +1402,261 @@ input#reset-to-natural-dimensions {
     margin-top:5px;
     font-size:16px;
     display:none;
+}
+
+#properties-list #collision-info > fieldset:first-of-type {
+	border-top: none !important;
+	box-shadow: none;
+	margin-top: 0;
+}
+
+#properties-list {
+	display: flex;
+	flex-direction: column;
+}
+
+/* -----   Order of Menu items for Primitive   ----- */
+#properties-list.ShapeMenu #general,
+#properties-list.BoxMenu #general,
+#properties-list.SphereMenu #general {
+	order: 1;
+}
+
+#properties-list.ShapeMenu #collision-info,
+#properties-list.BoxMenu #collision-info,
+#properties-list.SphereMenu #collision-info {
+	order: 2;
+}
+
+#properties-list.ShapeMenu #physical,
+#properties-list.BoxMenu #physical,
+#properties-list.SphereMenu #physical {
+	order: 3;
+}
+
+#properties-list.ShapeMenu #spatial,
+#properties-list.BoxMenu #spatial,
+#properties-list.SphereMenu #spatial {
+	order: 4;
+}
+
+#properties-list.ShapeMenu #behavior,
+#properties-list.BoxMenu #behavior,
+#properties-list.SphereMenu #behavior {
+	order: 5;
+}
+
+#properties-list.ShapeMenu #hyperlink,
+#properties-list.BoxMenu #hyperlink,
+#properties-list.SphereMenu #hyperlink {
+	order: 6;
+}
+
+#properties-list.ShapeMenu #light,
+#properties-list.BoxMenu #light,
+#properties-list.SphereMenu #light,
+#properties-list.ShapeMenu #model,
+#properties-list.BoxMenu #model,
+#properties-list.SphereMenu #model,
+#properties-list.ShapeMenu #zone,
+#properties-list.BoxMenu #zone,
+#properties-list.SphereMenu #zone,
+#properties-list.ShapeMenu #text,
+#properties-list.BoxMenu #text,
+#properties-list.SphereMenu #text,
+#properties-list.ShapeMenu #web,
+#properties-list.BoxMenu #web,
+#properties-list.SphereMenu #web {
+	display: none;
+}
+
+
+/* -----   Order of Menu items for Light   ----- */
+#properties-list.LightMenu #general {
+	order: 1;
+}
+#properties-list.LightMenu #light {
+	order: 2;
+}
+#properties-list.LightMenu #physical {
+	order: 3;
+}
+#properties-list.LightMenu #spatial {
+	order: 4;
+}
+#properties-list.LightMenu #behavior {
+	order: 5;
+}
+#properties-list.LightMenu #collision-info {
+	order: 6;
+}
+#properties-list.LightMenu #hyperlink {
+	order: 7;
+}
+/* sections to hide	*/
+#properties-list.LightMenu #model,
+#properties-list.LightMenu #zone,
+#properties-list.LightMenu #text,
+#properties-list.LightMenu #web {
+	display: none;
+}
+/* items to hide */
+#properties-list.LightMenu .shape-group.shape-section.property.dropdown,
+#properties-list.LightMenu color-section.color-control1 {
+	display: none
+}
+
+
+/* -----   Order of Menu items for Model   ----- */
+#properties-list.ModelMenu #general {
+	order: 1;
+}
+#properties-list.ModelMenu #model {
+	order: 2;
+}
+#properties-list.ModelMenu #collision-info {
+	order: 3;
+}
+#properties-list.ModelMenu #physical {
+	order: 4;
+}
+#properties-list.ModelMenu #spatial {
+	order: 5;
+}
+#properties-list.ModelMenu #behavior {
+	order: 6;
+}
+#properties-list.ModelMenu #hyperlink {
+	order: 7;
+}
+/* sections to hide	*/
+#properties-list.ModelMenu #light,
+#properties-list.ModelMenu #zone,
+#properties-list.ModelMenu #text,
+#properties-list.ModelMenu #web {
+	display: none;
+}
+/* items to hide */
+#properties-list.ModelMenu .shape-group.shape-section.property.dropdown,
+#properties-list.ModelMenu .color-section.color-control1 {
+	display: none
+}
+
+
+/* -----   Order of Menu items for Zone   ----- */
+#properties-list.ZoneMenu #general {
+	order: 1;
+}
+#properties-list.ZoneMenu #zone {
+	order: 2;
+}
+#properties-list.ZoneMenu #physical {
+	order: 3;
+}
+#properties-list.ZoneMenu #spatial {
+	order: 4;
+}
+#properties-list.ZoneMenu #behavior {
+	order: 5;
+}
+#properties-list.ZoneMenu #collision-info {
+	order: 6;
+}
+#properties-list.ZoneMenu #hyperlink {
+	order: 7;
+}
+/* sections to hide	*/
+#properties-list.ZoneMenu #light,
+#properties-list.ZoneMenu #model,
+#properties-list.ZoneMenu #text,
+#properties-list.ZoneMenu #web {
+	display: none;
+}
+/* items to hide */
+#properties-list.ZoneMenu .shape-group.shape-section.property.dropdown,
+#properties-list.ZoneMenu .color-section.color-control1 {
+	display: none
+}
+
+
+/* -----   Order of Menu items for Web   ----- */
+#properties-list.WebMenu #general {
+	order: 1;
+}
+#properties-list.WebMenu #web {
+	order: 2;
+}
+#properties-list.WebMenu #collision-info {
+	order: 3;
+}
+#properties-list.WebMenu #physical {
+	order: 4;
+}
+#properties-list.WebMenu #spatial {
+	order: 5;
+}
+#properties-list.WebMenu #behavior {
+	order: 6;
+}
+#properties-list.WebMenu #hyperlink {
+	order: 7;
+}
+/* sections to hide	*/
+#properties-list.WebMenu #light,
+#properties-list.WebMenu #model,
+#properties-list.WebMenu #zone,
+#properties-list.WebMenu #text {
+	display: none;
+}
+/* items to hide */
+#properties-list.WebMenu .shape-group.shape-section.property.dropdown,
+#properties-list.WebMenu .color-section.color-control1 {
+	display: none;
+}
+
+
+
+/* -----   Order of Menu items for Text   ----- */
+#properties-list.TextMenu #general {
+	order: 1;
+}
+#properties-list.TextMenu #text {
+	order: 2;
+}
+#properties-list.TextMenu #collision-info {
+	order: 3;
+}
+#properties-list.TextMenu #physical {
+	order: 4;
+}
+#properties-list.TextMenu #spatial {
+	order: 5;
+}
+#properties-list.TextMenu #behavior {
+	order: 6;
+}
+#properties-list.TextMenu #hyperlink {
+	order: 7;
+}
+/* sections to hide	*/
+#properties-list.TextMenu #light,
+#properties-list.TextMenu #model,
+#properties-list.TextMenu #zone,
+#properties-list.TextMenu #web {
+	display: none;
+}
+/* items to hide */
+#properties-list.TextMenu .shape-group.shape-section.property.dropdown,
+#properties-list.TextMenu .color-section.color-control1 {
+	display: none
+}
+
+
+/* Currently always hidden */
+#properties-list #polyvox {
+	display: none;
+}
+
+.skybox-section {
+	display: none;
 }

--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -450,50 +450,50 @@ input[type=checkbox]:checked + label:hover {
 }
 
 .shape-section, .light-section, .model-section, .web-section, .hyperlink-section, .text-section, .zone-section {
-	display: table;
+    display: table;
 }
 
 
 
 #properties-list fieldset {
-	position: relative;
-	/* 0.1px on the top is to prevent margin collapsing between this and it's first child */
-	margin: 21px -21px 0px -21px;
+    position: relative;
+    /* 0.1px on the top is to prevent margin collapsing between this and it's first child */
+    margin: 21px -21px 0px -21px;
     padding: 0.1px 21px 0px 21px;
-	border: none;
-	border-top: 1px rgb(90,90,90) solid;
-	box-shadow: 0px -1px 0px rgb(37,37,37);
+    border: none;
+    border-top: 1px rgb(90,90,90) solid;
+    box-shadow: 0px -1px 0px rgb(37,37,37);
 }
 
 #properties-list fieldset.fstuple, #properties-list fieldset.fsrow {
-	margin-top: 21px;
-	border: none;
-	box-shadow: none;
+    margin-top: 21px;
+    border: none;
+    box-shadow: none;
 }
 
 #properties-list > fieldset[data-collapsed="true"] + fieldset {
-	margin-top: 0px;
+    margin-top: 0px;
 }
 
 #properties-list > fieldset[data-collapsed="true"] > *:not(legend) {
-	 display: none !important;
+     display: none !important;
 }
 
 #properties-list legend + fieldset {
-	margin-top: 0px;
-	border: none;
-	box-shadow: none;
+    margin-top: 0px;
+    border: none;
+    box-shadow: none;
 }
 
 #properties-list > fieldset#properties-header {
-	margin-top: 0px;
-	padding-bottom: 0px;
+    margin-top: 0px;
+    padding-bottom: 0px;
 }
 
 
 
 #properties-list > fieldset > legend {
-	position: relative;
+    position: relative;
     display: table;
     width: 100%;
     margin: 21px -21px 0 -21px;
@@ -504,10 +504,10 @@ input[type=checkbox]:checked + label:hover {
     height: 28px;
     text-transform: uppercase;
     outline: none;
-	background-color: #404040;
-	border: none;
-	border-top: 1px rgb(90,90,90) solid;
-	box-shadow: 0 -1px 0 rgb(37,37,37), 0 4px 4px 0 rgba(0,0,0,0.75);
+    background-color: #404040;
+    border: none;
+    border-top: 1px rgb(90,90,90) solid;
+    box-shadow: 0 -1px 0 rgb(37,37,37), 0 4px 4px 0 rgba(0,0,0,0.75);
 }
 
 div.section-header, .sub-section-header, hr {
@@ -526,8 +526,8 @@ div.section-header, .sub-section-header, hr {
 
 
 .column .sub-section-header {
-	background-image: none;
-	padding-top: 0;
+    background-image: none;
+    padding-top: 0;
 }
 
 .sub-section-header, .no-collapse, hr {
@@ -802,12 +802,12 @@ div.refresh input[type="button"] {
 }
 
 #property-color-control1 {
-	display: table-cell;
-	float: none;
+    display: table-cell;
+    float: none;
 }
 
 #property-color-control1 + label  {
-	border-left: 20px transparent solid;
+    border-left: 20px transparent solid;
 }
 
 .rgb label {
@@ -919,23 +919,23 @@ tuple, .blue:focus, .tuple .z:focus, .tuple .roll:focus {
 }
 
 #properties-list fieldset .two-column {
-	padding-top:21px;
-	display: flex;
+    padding-top:21px;
+    display: flex;
 }
 
 #properties-list .two-column  fieldset {
     /*display: table-cell;*/
     width: 50%;
-	margin: 0;
-	padding: 0;
-	border-top: none;
-	box-shadow: none;
+    margin: 0;
+    padding: 0;
+    border-top: none;
+    box-shadow: none;
 }
 
 #properties-list .two-column  fieldset legend {
-	display: table;
+    display: table;
     width: 100%;
-	margin: 21px -21px 0px -21px;
+    margin: 21px -21px 0px -21px;
     padding: 0px 0px 0px 21px;
     font-family: Raleway-Regular;
     font-size: 12px;
@@ -946,11 +946,11 @@ tuple, .blue:focus, .tuple .z:focus, .tuple .roll:focus {
 }
 
 fieldset .checkbox-sub-props {
-	 margin-top: 0;
+     margin-top: 0;
  }
 
 fieldset .checkbox-sub-props .property:first-child {
-	margin-top: 0;
+    margin-top: 0;
 }
 
 .column {
@@ -1297,8 +1297,8 @@ th#entity-hasScript {
 #properties-list #properties-header {
     display: table-row;
     height: 28px;
-	border-top: none;
-	box-shadow: none;
+    border-top: none;
+    box-shadow: none;
 }
 
 #properties-header .property {
@@ -1405,51 +1405,51 @@ input#reset-to-natural-dimensions {
 }
 
 #properties-list #collision-info > fieldset:first-of-type {
-	border-top: none !important;
-	box-shadow: none;
-	margin-top: 0;
+    border-top: none !important;
+    box-shadow: none;
+    margin-top: 0;
 }
 
 #properties-list {
-	display: flex;
-	flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 /* -----   Order of Menu items for Primitive   ----- */
 #properties-list.ShapeMenu #general,
 #properties-list.BoxMenu #general,
 #properties-list.SphereMenu #general {
-	order: 1;
+    order: 1;
 }
 
 #properties-list.ShapeMenu #collision-info,
 #properties-list.BoxMenu #collision-info,
 #properties-list.SphereMenu #collision-info {
-	order: 2;
+    order: 2;
 }
 
 #properties-list.ShapeMenu #physical,
 #properties-list.BoxMenu #physical,
 #properties-list.SphereMenu #physical {
-	order: 3;
+    order: 3;
 }
 
 #properties-list.ShapeMenu #spatial,
 #properties-list.BoxMenu #spatial,
 #properties-list.SphereMenu #spatial {
-	order: 4;
+    order: 4;
 }
 
 #properties-list.ShapeMenu #behavior,
 #properties-list.BoxMenu #behavior,
 #properties-list.SphereMenu #behavior {
-	order: 5;
+    order: 5;
 }
 
 #properties-list.ShapeMenu #hyperlink,
 #properties-list.BoxMenu #hyperlink,
 #properties-list.SphereMenu #hyperlink {
-	order: 6;
+    order: 6;
 }
 
 #properties-list.ShapeMenu #light,
@@ -1467,196 +1467,196 @@ input#reset-to-natural-dimensions {
 #properties-list.ShapeMenu #web,
 #properties-list.BoxMenu #web,
 #properties-list.SphereMenu #web {
-	display: none;
+    display: none;
 }
 
 
 /* -----   Order of Menu items for Light   ----- */
 #properties-list.LightMenu #general {
-	order: 1;
+    order: 1;
 }
 #properties-list.LightMenu #light {
-	order: 2;
+    order: 2;
 }
 #properties-list.LightMenu #physical {
-	order: 3;
+    order: 3;
 }
 #properties-list.LightMenu #spatial {
-	order: 4;
+    order: 4;
 }
 #properties-list.LightMenu #behavior {
-	order: 5;
+    order: 5;
 }
 #properties-list.LightMenu #collision-info {
-	order: 6;
+    order: 6;
 }
 #properties-list.LightMenu #hyperlink {
-	order: 7;
+    order: 7;
 }
-/* sections to hide	*/
+/* sections to hide    */
 #properties-list.LightMenu #model,
 #properties-list.LightMenu #zone,
 #properties-list.LightMenu #text,
 #properties-list.LightMenu #web {
-	display: none;
+    display: none;
 }
 /* items to hide */
 #properties-list.LightMenu .shape-group.shape-section.property.dropdown,
 #properties-list.LightMenu color-section.color-control1 {
-	display: none
+    display: none
 }
 
 
 /* -----   Order of Menu items for Model   ----- */
 #properties-list.ModelMenu #general {
-	order: 1;
+    order: 1;
 }
 #properties-list.ModelMenu #model {
-	order: 2;
+    order: 2;
 }
 #properties-list.ModelMenu #collision-info {
-	order: 3;
+    order: 3;
 }
 #properties-list.ModelMenu #physical {
-	order: 4;
+    order: 4;
 }
 #properties-list.ModelMenu #spatial {
-	order: 5;
+    order: 5;
 }
 #properties-list.ModelMenu #behavior {
-	order: 6;
+    order: 6;
 }
 #properties-list.ModelMenu #hyperlink {
-	order: 7;
+    order: 7;
 }
-/* sections to hide	*/
+/* sections to hide    */
 #properties-list.ModelMenu #light,
 #properties-list.ModelMenu #zone,
 #properties-list.ModelMenu #text,
 #properties-list.ModelMenu #web {
-	display: none;
+    display: none;
 }
 /* items to hide */
 #properties-list.ModelMenu .shape-group.shape-section.property.dropdown,
 #properties-list.ModelMenu .color-section.color-control1 {
-	display: none
+    display: none
 }
 
 
 /* -----   Order of Menu items for Zone   ----- */
 #properties-list.ZoneMenu #general {
-	order: 1;
+    order: 1;
 }
 #properties-list.ZoneMenu #zone {
-	order: 2;
+    order: 2;
 }
 #properties-list.ZoneMenu #physical {
-	order: 3;
+    order: 3;
 }
 #properties-list.ZoneMenu #spatial {
-	order: 4;
+    order: 4;
 }
 #properties-list.ZoneMenu #behavior {
-	order: 5;
+    order: 5;
 }
 #properties-list.ZoneMenu #collision-info {
-	order: 6;
+    order: 6;
 }
 #properties-list.ZoneMenu #hyperlink {
-	order: 7;
+    order: 7;
 }
-/* sections to hide	*/
+/* sections to hide    */
 #properties-list.ZoneMenu #light,
 #properties-list.ZoneMenu #model,
 #properties-list.ZoneMenu #text,
 #properties-list.ZoneMenu #web {
-	display: none;
+    display: none;
 }
 /* items to hide */
 #properties-list.ZoneMenu .shape-group.shape-section.property.dropdown,
 #properties-list.ZoneMenu .color-section.color-control1 {
-	display: none
+    display: none
 }
 
 
 /* -----   Order of Menu items for Web   ----- */
 #properties-list.WebMenu #general {
-	order: 1;
+    order: 1;
 }
 #properties-list.WebMenu #web {
-	order: 2;
+    order: 2;
 }
 #properties-list.WebMenu #collision-info {
-	order: 3;
+    order: 3;
 }
 #properties-list.WebMenu #physical {
-	order: 4;
+    order: 4;
 }
 #properties-list.WebMenu #spatial {
-	order: 5;
+    order: 5;
 }
 #properties-list.WebMenu #behavior {
-	order: 6;
+    order: 6;
 }
 #properties-list.WebMenu #hyperlink {
-	order: 7;
+    order: 7;
 }
-/* sections to hide	*/
+/* sections to hide    */
 #properties-list.WebMenu #light,
 #properties-list.WebMenu #model,
 #properties-list.WebMenu #zone,
 #properties-list.WebMenu #text {
-	display: none;
+    display: none;
 }
 /* items to hide */
 #properties-list.WebMenu .shape-group.shape-section.property.dropdown,
 #properties-list.WebMenu .color-section.color-control1 {
-	display: none;
+    display: none;
 }
 
 
 
 /* -----   Order of Menu items for Text   ----- */
 #properties-list.TextMenu #general {
-	order: 1;
+    order: 1;
 }
 #properties-list.TextMenu #text {
-	order: 2;
+    order: 2;
 }
 #properties-list.TextMenu #collision-info {
-	order: 3;
+    order: 3;
 }
 #properties-list.TextMenu #physical {
-	order: 4;
+    order: 4;
 }
 #properties-list.TextMenu #spatial {
-	order: 5;
+    order: 5;
 }
 #properties-list.TextMenu #behavior {
-	order: 6;
+    order: 6;
 }
 #properties-list.TextMenu #hyperlink {
-	order: 7;
+    order: 7;
 }
-/* sections to hide	*/
+/* sections to hide    */
 #properties-list.TextMenu #light,
 #properties-list.TextMenu #model,
 #properties-list.TextMenu #zone,
 #properties-list.TextMenu #web {
-	display: none;
+    display: none;
 }
 /* items to hide */
 #properties-list.TextMenu .shape-group.shape-section.property.dropdown,
 #properties-list.TextMenu .color-section.color-control1 {
-	display: none
+    display: none
 }
 
 
 /* Currently always hidden */
 #properties-list #polyvox {
-	display: none;
+    display: none;
 }
 
 .skybox-section {
-	display: none;
+    display: none;
 }

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -8,130 +8,267 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 -->
 <html>
-    <head>
-        <title>Properties</title>
-        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-        <link rel="stylesheet" type="text/css" href="css/edit-style.css">
-        <link rel="stylesheet" type="text/css" href="css/colpick.css">
-        <link href="css/jsoneditor.css" rel="stylesheet" type="text/css">
-        <script src="js/jquery-2.1.4.min.js"></script>
-        <script src="js/colpick.js"></script>
-        <script type="text/javascript" src="qrc:///qtwebchannel/qwebchannel.js"></script>
-        <script type="text/javascript" src="js/eventBridgeLoader.js"></script>
-        <script type="text/javascript" src="js/spinButtons.js"></script>
-        <script type="text/javascript" src="js/keyboardControl.js"></script>
-        <script type="text/javascript" src="js/entityProperties.js"></script>
-        <script src="js/jsoneditor.min.js"></script>
-    </head>
-    <body onload='loaded();'>
-        <div id="properties-list">
-            <div id="properties-header">
-                <div id="type" class="property value">
-                    <span id="type-icon"></span><label id="property-type"><i>No selection</i></label>
-                </div>
-                <div class="property checkbox">
-                    <input type="checkbox" id="property-locked">
-                    <label for="property-locked"><span>&#xe006;</span>&nbsp;Locked</label>
-                </div>
-                <div class="property checkbox">
-                    <input type="checkbox" id="property-visible">
-                    <label for="property-visible"><span>&#xe007;</span>&nbsp;Visible</label>
-                </div>
+
+<head>
+    <title>Properties</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link rel="stylesheet" type="text/css" href="css/edit-style.css">
+    <link rel="stylesheet" type="text/css" href="css/colpick.css">
+    <link href="css/jsoneditor.css" rel="stylesheet" type="text/css">
+    <script src="js/jquery-2.1.4.min.js"></script>
+    <script src="js/colpick.js"></script>
+    <script type="text/javascript" src="qrc:///qtwebchannel/qwebchannel.js"></script>
+    <script type="text/javascript" src="js/eventBridgeLoader.js"></script>
+    <script type="text/javascript" src="js/spinButtons.js"></script>
+    <script type="text/javascript" src="js/keyboardControl.js"></script>
+    <script type="text/javascript" src="js/entityProperties.js"></script>
+    <script src="js/jsoneditor.min.js"></script>
+</head>
+
+<body onload='loaded();'>
+    <div id="properties-list">
+
+        <fieldset id="properties-header">
+            <div id="type" class="property value">
+                <span id="type-icon"></span><label id="property-type"><i>No selection</i></label>
             </div>
-            <hr />
+            <div class="property checkbox">
+                <input type="checkbox" id="property-locked">
+                <label for="property-locked"><span>&#xe006;</span>&nbsp;Locked</label>
+            </div>
+            <div class="property checkbox">
+                <input type="checkbox" id="property-visible">
+                <label for="property-visible"><span>&#xe007;</span>&nbsp;Visible</label>
+            </div>
+        </fieldset>
+
+
+        <fieldset id="general" class="major">
             <div class="shape-group shape-section property dropdown">
                 <label for="property-shape">Shape</label>
                 <select name="SelectShape" id="property-shape">
-                    <option value="Cube">Box</option>
-                    <option value="Sphere">Sphere</option>
-                    <option value="Tetrahedron">Tetrahedron</option>
-                    <option value="Octahedron">Octahedron</option>
-                    <option value="Icosahedron">Icosahedron</option>
-                    <option value="Dodecahedron">Dodecahedron</option>
-                    <option value="Hexagon">Hexagon</option>
-                    <option value="Triangle">Triangle</option>
-                    <option value="Octagon">Octagon</option>
-                    <option value="Cylinder">Cylinder</option>
-                    <option value="Cone">Cone</option>
-                    <option value="Circle">Circle</option>
-                </select>
+						<option value="Cube">Box</option>
+						<option value="Sphere">Sphere</option>
+						<option value="Tetrahedron">Tetrahedron</option>
+						<option value="Octahedron">Octahedron</option>
+						<option value="Icosahedron">Icosahedron</option>
+						<option value="Dodecahedron">Dodecahedron</option>
+						<option value="Hexagon">Hexagon</option>
+						<option value="Triangle">Triangle</option>
+						<option value="Octagon">Octagon</option>
+						<option value="Cylinder">Cylinder</option>
+						<option value="Cone">Cone</option>
+						<option value="Circle">Circle</option>
+					</select>
             </div>
             <div class="property text">
                 <label for="property-name">Name</label>
                 <input type="text" id="property-name">
             </div>
-            <div class="property text">
-                <label for="property-description">Description</label>
-                <input type="text" id="property-description">
-            </div>
+			<div class="physical-group color-section property color-control1">
+				<div class="color-picker" id="property-color-control1"></div>
+				<label>Entity color</label>
+			</div>
+		</fieldset>
+		<fieldset id="collision-info">
+			<fieldset class="minor">
+				<div class="behavior-group property checkbox">
+					<input type="checkbox" id="property-collisionless">
+					<label for="property-collisionless">Collisionless</label>
+				</div>
+				<div class="behavior-group property checkbox">
+					<input type="checkbox" id="property-dynamic">
+					<label for="property-dynamic">Dynamic</label>
+				</div>
+			</fieldset>
+			<fieldset class="minor">
+				<div class="behavior-group two-column">
+					<fieldset class="column">
+						<legend class="sub-section-header">
+							Collides With
+						</legend>
+						<div class="checkbox-sub-props">
+							<div class="property checkbox">
+								<input type="checkbox" id="property-collide-static">
+								<label for="property-collide-static">Static entities</label>
+							</div>
+							<div class="property checkbox">
+								<input type="checkbox" id="property-collide-dynamic">
+								<label for="property-collide-dynamic">Dynamic entities</label>
+							</div>
+							<div class="property checkbox">
+								<input type="checkbox" id="property-collide-kinematic">
+								<label for="property-collide-kinematic">Kinematic entities</label>
+							</div>
+							<div class="property checkbox">
+								<input type="checkbox" id="property-collide-myAvatar">
+								<label for="property-collide-myAvatar">My avatar</label>
+							</div>
+							<div class="property checkbox">
+								<input type="checkbox" id="property-collide-otherAvatar">
+								<label for="property-collide-otherAvatar">Other avatars</label>
+							</div>
+						</div>
+					</fieldset>
+					<fieldset class="column">
+						<legend class="sub-section-header">
+							Grabbing
+						</legend>
+						<div class="checkbox-sub-props">
+							<div class="property checkbox">
+								<input type="checkbox" id="property-grabbable">
+								<label for="property-grabbable">Grabbable</label>
+							</div>
+							<div class="property checkbox">
+								<input type="checkbox" id="property-wants-trigger">
+								<label for="property-wants-trigger">Triggerable</label>
+							</div>
+							<div class="property checkbox">
+								<input type="checkbox" id="property-cloneable">
+								<label for="property-cloneable">Cloneable</label>
+							</div>
+							<div class="property checkbox">
+								<input type="checkbox" id="property-ignore-ik">
+								<label for="property-ignore-ik">Ignore inverse kinematics</label>
+							</div>
+						</div>
+					</fieldset>
+					<fieldset style="display:none;">
+						<!-- extra column ------------------------------------------------------------------------------------ -->
+						<div class="column" id="group-cloneable-group" style="display:none;">
+							<div class="sub-section-header">
+								<span>Cloneable Settings</span>
+							</div>
+							<div class="cloneable-group property gen">
+								<div><label>Clone Lifetime</label><input type="number" data-user-data-type="cloneLifetime" id="property-cloneable-lifetime"></div>
+								<div><label>Clone Limit</label><input type="number" data-user-data-type="cloneLimit" id="property-cloneable-limit"></div>
+								<div class="property checkbox">
+									<input type="checkbox" id="property-cloneable-dynamic">
+									<label for="property-cloneable-dynamic">Clone Dynamic</label>
+								</div>
+							</div>
+						</div>
+					</fieldset>
+				</div>
+			</fieldset>
+        </fieldset>
 
-            <div class="property textarea">
-                <label for="property-user-data">User data</label>
-                <br>
-                <div class="row">
-                    <input type="button" class="red" id="userdata-clear" value="Clear User Data">
-                    <input type="button" class="blue" id="userdata-new-editor" value="Edit as JSON">
-                    <input disabled type="button" class="black" id="userdata-save" value="Save User Data">
-                    <span id="userdata-saved">Saved!</span>
+
+		<fieldset id="physical" class="major">
+            <legend class="section-header physical-group">
+                Physical<span>M</span>
+            </legend>
+            <fieldset class="minor">
+                <fieldset class="physical-group property xyz fstuple">
+                    <legend>Linear velocity <span class="unit">m/s</span></legend>
+                    <div class="tuple">
+                        <div><input type="number" class="x" id="property-lvel-x"><label for="property-lvel-x">X:</label></div>
+                        <div><input type="number" class="y" id="property-lvel-y"><label for="property-lvel-y">Y:</label></div>
+                        <div><input type="number" class="z" id="property-lvel-z"><label for="property-lvel-z">Z:</label></div>
+                    </div>
+                </fieldset>
+                <div class="physical-group property number">
+                    <label>Linear damping</label>
+                    <input type="number" id="property-ldamping">
                 </div>
-                <div id="static-userdata"></div>
-                <div id="userdata-editor"></div>
-                <textarea id="property-user-data"></textarea>
-            </div>
-            <div id="id" class="property value">
-                <label>ID:</label>
-                <input type="text" id="property-id" readonly>
-            </div>
-            <div class="section-header hyperlink-group hyperlink-section">
-                <label>Hyperlink</label><span>M</span>
-            </div>
-            <div class="hyperlink-group hyperlink-section property url">
-                <label for="property-hyperlink-href">Href - hifi://address</label>
-                <input type="text" id="property-hyperlink-href">
-            </div>
-            <div class="section-header spatial-group">
-                <label>Spatial</label><span>M</span>
-            </div>
-            <div class="spatial-group property xyz">
-                <label>Position <span class="unit">m</span></label>
+            </fieldset>
+            <fieldset class="minor">
+                <fieldset class="physical-group property pyr fstuple">
+                    <legend>Angular velocity <span class="unit">deg/s</span></legend>
+                    <div class="tuple">
+                        <div><input type="number" class="pitch" id="property-avel-x"><label for="property-avel-x">Pitch:</label></div>
+                        <div><input type="number" class="yaw" id="property-avel-y"><label for="property-avel-y">Yaw:</label></div>
+                        <div><input type="number" class="roll" id="property-avel-z"><label for="property-avel-z">Roll:</label></div>
+                    </div>
+                </fieldset>
+                <div class="physical-group property number">
+                    <label>Angular damping</label>
+                    <input type="number" id="property-adamping">
+                </div>
+            </fieldset>
+            <fieldset class="physical-group property gen fstuple">
+                <div class="tuple">
+                    <div><label>Restitution</label><input type="number" id="property-restitution"></div>
+                    <div><label>Friction</label><input type="number" id="property-friction"></div>
+                    <div><label>Density</label><input type="number" id="property-density"></div>
+                </div>
+            </fieldset>
+            <fieldset class="minor">
+                <fieldset class="physical-group property xyz fstuple">
+                    <legend>Gravity <span class="unit">m/s<sup>2</sup></span></legend>
+                    <div class="tuple">
+                        <div><input type="number" class="x" id="property-grav-x"><label for="property-grav-x">X:</label></div>
+                        <div><input type="number" class="y" id="property-grav-y"><label for="property-grav-y">Y:</label></div>
+                        <div><input type="number" class="z" id="property-grav-z"><label for="property-grav-z">Z:</label></div>
+                    </div>
+                </fieldset>
+                <fieldset class="physical-group property xyz fstuple">
+                    <legend>Acceleration <span class="unit">m/s<sup>2</sup></span></legend>
+                    <div class="tuple">
+                        <div><input type="number" class="x" id="property-lacc-x"><label for="property-lacc-x">X:</label></div>
+                        <div><input type="number" class="y" id="property-lacc-y"><label for="property-lacc-y">Y:</label></div>
+                        <div><input type="number" class="z" id="property-lacc-z"><label for="property-lacc-z">Z:</label></div>
+                    </div>
+                </fieldset>
+            </fieldset>
+            <fieldset class="minor">
+                <div class="physical-group color-section property rgb fstuple">
+                    <div class="color-picker" id="property-color-control2"></div>
+                    <label>Entity color</label>
+                    <div class="tuple">
+                        <div><input type="number" class="red" id="property-color-red"><label for="property-color-red">Red:</label></div>
+                        <div><input type="number" class="green" id="property-color-green"><label for="property-color-green">Green:</label></div>
+                        <div><input type="number" class="blue" id="property-color-blue"><label for="property-color-blue">Blue:</label></div>
+                    </div>
+                </div>
+            </fieldset>
+        </fieldset>
+
+
+        <fieldset id="spatial" class="major">
+            <legend class="section-header spatial-group">
+                Spatial<span>M</span>
+            </legend>
+            <fieldset class="spatial-group property xyz fstuple">
+                <legend>Position <span class="unit">m</span></legend>
                 <div class="tuple">
                     <div><input type="number" class="x" id="property-pos-x"><label for="property-pos-x">X:</label></div>
                     <div><input type="number" class="y" id="property-pos-y"><label for="property-pos-y">Y:</label></div>
                     <div><input type="number" class="z" id="property-pos-z"><label for="property-pos-z">Z:</label></div>
                 </div>
-            </div>
-            <div class="spatial-group property pyr">
-                <label>Rotation <span class="unit">deg</span></label>
+            </fieldset>
+            <fieldset class="spatial-group property pyr fstuple">
+                <legend>Rotation <span class="unit">deg</span></legend>
                 <div class="tuple">
                     <div><input type="number" class="pitch" id="property-rot-x" step="0.1"><label for="property-rot-x">Pitch:</label></div>
                     <div><input type="number" class="yaw" id="property-rot-y" step="0.1"><label for="property-rot-y">Yaw:</label></div>
                     <div><input type="number" class="roll" id="property-rot-z" step="0.1"><label for="property-rot-z">Roll:</label></div>
                 </div>
-            </div>
-            <div class="spatial-group property xyz">
-                <label>Dimensions <span class="unit">m</span></label>
+            </fieldset>
+            <fieldset class="spatial-group property xyz fstuple">
+                <legend>Dimensions <span class="unit">m</span></legend>
                 <div class="tuple">
                     <div><input type="number" class="x" id="property-dim-x" step="0.1"><label for="property-dim-x">X:</label></div>
                     <div><input type="number" class="y" id="property-dim-y" step="0.1"><label for="property-dim-y">Y:</label></div>
                     <div><input type="number" class="z" id="property-dim-z" step="0.1"><label for="property-dim-z">Z:</label></div>
                 </div>
-            </div>
-            <div class="spatial-group property xyz">
-                <label>Registration <span class="unit">(pivot offset as ratio of dimension)</span></label>
+            </fieldset>
+            <fieldset class="spatial-group property xyz fstuple">
+                <legend>Registration <span class="unit">(pivot offset as ratio of dimension)</span></legend>
                 <div class="tuple">
                     <div><input type="number" class="x" id="property-reg-x" step="0.1"><label for="property-reg-x">X:</label></div>
                     <div><input type="number" class="y" id="property-reg-y" step="0.1"><label for="property-reg-y">Y:</label></div>
                     <div><input type="number" class="z" id="property-reg-z" step="0.1"><label for="property-reg-z">Z:</label></div>
                 </div>
-            </div>
-            <div class="spatial-group property gen">
-                <label>Scale <span class="unit">%</span></label>
+            </fieldset>
+            <fieldset class="spatial-group property gen fsrow">
+                <legend>Scale <span class="unit">%</span></legend>
                 <div class="row">
                     <input type="number" id="dimension-rescale-pct" value=100>
                     <input type="button" class="blue" id="dimension-rescale-button" value="Rescale">
                     <input type="button" class="red" id="reset-to-natural-dimensions" value="Reset Dimensions">
                 </div>
-            </div>
+            </fieldset>
             <div class="spatial-group row">
                 <div class="property text">
                     <label for="property-parent-id">Parent ID</label>
@@ -153,278 +290,311 @@
                     </div>
                 </div>
             </div>
-            <hr class="spatial-group poly-vox-section" />
-            <div class="spatial-group poly-vox-section property xyz">
-                <label>Voxel volume size <span class="unit">m</span></label>
-                <div class="tuple">
-                    <div><input type="number" class="x" id="property-voxel-volume-size-x"><label for="property-voxel-volume-size-x">X:</label></div>
-                    <div><input type="number" class="y" id="property-voxel-volume-size-y"><label for="property-voxel-volume-size-y">Y:</label></div>
-                    <div><input type="number" class="z" id="property-voxel-volume-size-z"><label for="property-voxel-volume-size-z">Z:</label></div>
+        </fieldset>
+
+
+        <fieldset id="behavior" class="major">
+            <legend class="section-header behavior-group">
+                Behavior<span>M</span>
+            </legend>
+			<div class="property textarea">
+				<label for="property-user-data">User data</label>
+				<br>
+				<div class="row">
+					<input type="button" class="red" id="userdata-clear" value="Clear User Data">
+					<input type="button" class="blue" id="userdata-new-editor" value="Edit as JSON">
+					<input disabled type="button" class="black" id="userdata-save" value="Save User Data">
+					<span id="userdata-saved">Saved!</span>
+				</div>
+				<div id="static-userdata"></div>
+				<div id="userdata-editor"></div>
+				<textarea id="property-user-data"></textarea>
+			</div>
+			<div id="id" class="property value">
+				<label>ID:</label>
+				<input type="text" id="property-id" readonly>
+			</div>
+
+            <fieldset class="minor">
+                <div class="behavior-group property url ">
+                    <label for="property-collision-sound-url">Collision sound URL</label>
+                    <input type="text" id="property-collision-sound-url">
                 </div>
-            </div>
-            <div class="spatial-group poly-vox-section property dropdown">
-                <label>Surface extractor</label>
-                <select name="SelectVoxelSurfaceStyle" id="property-voxel-surface-style">
-                    <option value="0">Marching cubes</option>
-                    <option value="1">Cubic</option>
-                    <option value="2">Edged cubic</option>
-                    <option value="3">Edged marching cubes</option>
-                </select>
-            </div>
-            <div class="spatial-group poly-vox-section property url ">
-                <label for="property-x-texture-url">X-axis texture URL</label>
-                <input type="text" id="property-x-texture-url">
-            </div>
-            <div class="spatial-group poly-vox-section property url ">
-                <label for="property-y-texture-url">Y-axis texture URL</label>
-                <input type="text" id="property-y-texture-url">
-            </div>
-            <div class="spatial-group poly-vox-section property url ">
-                <label for="property-z-texture-url">Z-axis texture URL</label>
-                <input type="text" id="property-z-texture-url">
-            </div>
-            <div class="section-header physical-group">
-                <label>Physical</label><span>M</span>
-            </div>
-            <div class="physical-group property xyz">
-                <label>Linear velocity <span class="unit">m/s</span></label>
-                <div class="tuple">
-                    <div><input type="number" class="x" id="property-lvel-x"><label for="property-lvel-x">X:</label></div>
-                    <div><input type="number" class="y" id="property-lvel-y"><label for="property-lvel-y">Y:</label></div>
-                    <div><input type="number" class="z" id="property-lvel-z"><label for="property-lvel-z">Z:</label></div>
+                <div class="behavior-group property number">
+                    <label>Lifetime <span class="unit">s</span></label>
+                    <input type="number" id="property-lifetime">
                 </div>
-            </div>
-            <div class="physical-group property number">
-                <label>Linear damping</label>
-                <input type="number" id="property-ldamping">
-            </div>
-            <hr class="physical-group"  />
-            <div class="physical-group property pyr">
-                <label>Angular velocity <span class="unit">deg/s</span></label>
-                <div class="tuple">
-                    <div><input type="number" class="pitch" id="property-avel-x"><label for="property-avel-x">Pitch:</label></div>
-                    <div><input type="number" class="yaw" id="property-avel-y"><label for="property-avel-y">Yaw:</label></div>
-                    <div><input type="number" class="roll" id="property-avel-z"><label for="property-avel-z">Roll:</label></div>
+            </fieldset>
+            <fieldset class="minor">
+                <div class="behavior-group property url refresh">
+                    <input type="hidden" id="property-script-timestamp" class="value">
+                    <label for="property-script-url">Script URL</label>
+                    <input type="text" id="property-script-url">
+                    <input type="button" id="reload-script-button" class="glyph" value="F">
                 </div>
-            </div>
-            <div class="physical-group property number">
-                <label>Angular damping</label>
-                <input type="number" id="property-adamping">
-            </div>
-            <hr class="physical-group" />
-            <div class="physical-group property gen">
-                <div class="tuple">
-                    <div><label>Restitution</label><input type="number" id="property-restitution"></div>
-                    <div><label>Friction</label><input type="number" id="property-friction"></div>
-                    <div><label>Density</label><input type="number" id="property-density"></div>
+            </fieldset>
+            <fieldset class="minor">
+                <div class="behavior-group property url refresh">
+                    <label for="property-server-scripts">Server Script URL</label>
+                    <input type="text" id="property-server-scripts">
+                    <input type="button" id="reload-server-scripts-button" class="glyph" value="F">
                 </div>
-            </div>
-            <hr class="physical-group" />
-            <div class="physical-group property xyz">
-                <label>Gravity <span class="unit">m/s<sup>2</sup></span></label>
-                <div class="tuple">
-                    <div><input type="number" class="x" id="property-grav-x"><label for="property-grav-x">X:</label></div>
-                    <div><input type="number" class="y" id="property-grav-y"><label for="property-grav-y">Y:</label></div>
-                    <div><input type="number" class="z" id="property-grav-z"><label for="property-grav-z">Z:</label></div>
+                <div class="behavior-group property">
+                    <label for="server-script-status">Server Script Status</label>
+                    <span id="server-script-status"></span>
                 </div>
-            </div>
-            <div class="physical-group property xyz">
-                <label>Acceleration <span class="unit">m/s<sup>2</sup></span></label>
-                <div class="tuple">
-                    <div><input type="number" class="x" id="property-lacc-x"><label for="property-lacc-x">X:</label></div>
-                    <div><input type="number" class="y" id="property-lacc-y"><label for="property-lacc-y">Y:</label></div>
-                    <div><input type="number" class="z" id="property-lacc-z"><label for="property-lacc-z">Z:</label></div>
+                <div class="behavior-group property">
+                    <textarea id="server-script-error"></textarea>
                 </div>
+            </fieldset>
+			<div class="property text">
+				<label for="property-description">Description</label>
+				<input type="text" id="property-description">
+			</div>
+        </fieldset>
+
+
+        <fieldset id="hyperlink" class="major">
+            <legend class="section-header hyperlink-group hyperlink-section">
+                Hyperlink<span>M</span>
+            </legend>
+            <div class="hyperlink-group hyperlink-section property url">
+                <label for="property-hyperlink-href">Href - hifi://address</label>
+                <input type="text" id="property-hyperlink-href">
             </div>
-            <hr class="physical-group color-section" />
-            <div class="physical-group color-section property rgb">
-                <div id="property-color" class="color-picker"></div>
-                <label>Entity color</label>
-                <div class="tuple">
-                    <div><input type="number" class="red" id="property-color-red"><label for="property-color-red">Red:</label></div>
-                    <div><input type="number" class="green" id="property-color-green"><label for="property-color-green">Green:</label></div>
-                    <div><input type="number" class="blue" id="property-color-blue"><label for="property-color-blue">Blue:</label></div>
+        </fieldset>
+
+
+
+		<fieldset id="light" class="major">
+ 		   <legend class="section-header light-group light-section">
+ 			   Light<span>M</span>
+ 		   </legend>
+ 		   <fieldset class="light-group light-section property rgb fstuple">
+ 			   <div class="color-picker" id="property-light-color"></div>
+ 			   <legend>Light color</legend>
+ 			   <div class="tuple">
+ 				   <div><input type="number" class="red" id="property-light-color-red"><label for="property-light-color-red">Red:</label></div>
+ 				   <div><input type="number" class="green" id="property-light-color-green"><label for="property-light-color-green">Green:</label></div>
+ 				   <div><input type="number" class="blue" id="property-light-color-blue"><label for="property-light-color-blue">Blue:</label></div>
+ 			   </div>
+ 		   </fieldset>
+ 		   <fieldset class="light-group light-section property gen fstuple">
+ 			   <div class="tuple">
+ 				   <div><label>Intensity</label><input type="number" id="property-light-intensity" min="0" step="0.1"></div>
+ 				   <div><label>Fall-off radius <span class="unit">m</span></label><input type="number" id="property-light-falloff-radius" min="0" step="0.1"></div>
+ 				   <div></div>
+ 			   </div>
+ 		   </fieldset>
+ 		   <div class="light-group light-section property checkbox">
+ 			   <input type="checkbox" id="property-light-spot-light">
+ 			   <label for="property-light-spot-light">Spotlight</label>
+ 		   </div>
+ 		   <fieldset class="light-group light-section property gen fstuple">
+ 			   <div class="tuple">
+ 				   <div><label>Spotlight exponent</label><input type="number" id="property-light-exponent" step="0.01"></div>
+ 				   <div><label>Spotlight cut-off</label><input type="number" id="property-light-cutoff" step="0.01"></div>
+ 				   <div></div>
+ 			   </div>
+ 		   </fieldset>
+ 	   </fieldset>
+
+
+        <fieldset id="model" class="major">
+            <legend class="section-header model-group model-section zone-section">
+                Model<span>M</span>
+            </legend>
+            <fieldset class="minor">
+                <div class="model-group model-section property url ">
+                    <label for="property-model-url">Model URL</label>
+                    <input type="text" id="property-model-url">
                 </div>
-            </div>
-            <div class="section-header behavior-group">
-                <label>Behavior</label><span>M</span>
-            </div>
-            <div class="behavior-group property checkbox">
-                <input type="checkbox" id="property-collisionless">
-                <label for="property-collisionless">Collisionless</label>
-            </div>
-            <div class="behavior-group property checkbox">
-                <input type="checkbox" id="property-dynamic">
-                <label for="property-dynamic">Dynamic</label>
-            </div>
-            <div class="behavior-group two-column">
-                <div class="column">
-                    <div class="sub-section-header">
-                        <span>Collides With</span>
-                    </div>
-                    <div class="checkbox-sub-props">
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-collide-static">
-                            <label for="property-collide-static">Static entities</label>
-                        </div>
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-collide-dynamic">
-                            <label for="property-collide-dynamic">Dynamic entities</label>
-                        </div>
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-collide-kinematic">
-                            <label for="property-collide-kinematic">Kinematic entities</label>
-                        </div>
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-collide-myAvatar">
-                            <label for="property-collide-myAvatar">My avatar</label>
-                        </div>
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-collide-otherAvatar">
-                            <label for="property-collide-otherAvatar">Other avatars</label>
-                        </div>
-                    </div>
+                <div class="model-group model-section zone-section property dropdown">
+                    <label>Collision shape type</label>
+                    <select name="SelectShapeType" id="property-shape-type">
+		   				<option value="none">No Collision</option>
+		   				<option value="box">Box</option>
+		   				<option value="sphere">Sphere</option>
+		   				<option value="compound">Compound</option>
+		   				<option value="simple-hull">Basic - Whole model</option>
+		   				<option value="simple-compound">Good - Sub-meshes</option>
+		   				<option value="static-mesh">Exact - All polygons (non-dynamic only)</option>
+		   			</select>
                 </div>
-                <div class="column">
-                    <div class="sub-section-header">
-                        <span>Grabbing</span>
-                    </div>
-                    <div class="checkbox-sub-props">
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-grabbable">
-                            <label for="property-grabbable">Grabbable</label>
-                        </div>
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-wants-trigger">
-                            <label for="property-wants-trigger">Triggerable</label>
-                        </div>
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-cloneable">
-                            <label for="property-cloneable">Cloneable</label>
-                        </div>
-                        <div class="property checkbox">
-                            <input type="checkbox" id="property-ignore-ik">
-                            <label for="property-ignore-ik">Ignore inverse kinematics</label>
-                        </div>
-                    </div>
+                <div class="model-group model-section zone-section property url ">
+                    <label for="property-compound-shape-url">Compound shape URL</label>
+                    <input type="text" id="property-compound-shape-url">
                 </div>
-                <div class="column" id="group-cloneable-group" style="display:none;">
-                    <div class="sub-section-header">
-                        <span>Cloneable Settings</span>
-                    </div>
-                    <div class="cloneable-group property gen">
-                        <div><label>Clone Lifetime</label><input type="number" data-user-data-type="cloneLifetime" id="property-cloneable-lifetime"></div>
-                        <div><label>Clone Limit</label><input type="number" data-user-data-type="cloneLimit" id="property-cloneable-limit"></div>
+            </fieldset>
+            <fieldset class="minor">
+                <div class="model-group model-section property url ">
+                    <label for="property-model-animation-url">Animation URL</label>
+                    <input type="text" id="property-model-animation-url">
+                </div>
+
+                <div class="model-group model-section two-column">
+                    <div class="column">
                         <div class="property checkbox">
-                            <input type="checkbox" id="property-cloneable-dynamic">
-                            <label for="property-cloneable-dynamic">Clone Dynamic</label>
+                            <input type="checkbox" id="property-model-animation-playing">
+                            <label for="property-model-animation-playing">Animation playing</label>
+                        </div>
+                        <div class="property checkbox indent">
+                            <input type="checkbox" id="property-model-animation-loop">
+                            <label for="property-model-animation-loop">Animation loop</label>
+                        </div>
+                        <div class="property checkbox indent">
+                            <input type="checkbox" id="property-model-animation-hold">
+                            <label for="property-model-animation-hold">Animation hold</label>
+                        </div>
+                        <div id="animation-fps" class="property number">
+                            <label>Animation FPS</label>
+                            <input type="number" id="property-model-animation-fps">
                         </div>
                     </div>
-                </div>
-            </div>
-            <hr class="behavior-group" />
-            <div class="behavior-group property url ">
-                <label for="property-collision-sound-url">Collision sound URL</label>
-                <input type="text" id="property-collision-sound-url">
-            </div>
-            <div class="behavior-group property number">
-                <label>Lifetime <span class="unit">s</span></label>
-                <input type="number" id="property-lifetime">
-            </div>
-            <hr class="behavior-group" />
-            <div class="behavior-group property url refresh">
-                <input type="hidden" id="property-script-timestamp" class="value">
-                <label for="property-script-url">Script URL</label>
-                <input type="text" id="property-script-url">
-                <input type="button" id="reload-script-button" class="glyph" value="F">
-            </div>
-            <hr class="behavior-group" />
-            <div class="behavior-group property url refresh">
-                <label for="property-server-scripts">Server Script URL</label>
-                <input type="text" id="property-server-scripts">
-                <input type="button" id="reload-server-scripts-button" class="glyph" value="F">
-            </div>
-            <div class="behavior-group property">
-                <label for="server-script-status">Server Script Status</label>
-                <span id="server-script-status"></span>
-            </div>
-            <div class="behavior-group property">
-                <textarea id="server-script-error"></textarea>
-            </div>
-            <div class="section-header model-group model-section zone-section">
-                <label>Model</label><span>M</span>
-            </div>
-            <div class="model-group model-section property url ">
-                <label for="property-model-url">Model URL</label>
-                <input type="text" id="property-model-url">
-            </div>
-            <div class="model-group model-section zone-section property dropdown">
-                <label>Collision shape type</label>
-                <select name="SelectShapeType" id="property-shape-type">
-                    <option value="none">No Collision</option>
-                    <option value="box">Box</option>
-                    <option value="sphere">Sphere</option>
-                    <option value="compound">Compound</option>
-                    <option value="simple-hull">Basic - Whole model</option>
-                    <option value="simple-compound">Good - Sub-meshes</option>
-                    <option value="static-mesh">Exact - All polygons (non-dynamic only)</option>
-                </select>
-            </div>
-            <div class="model-group model-section zone-section property url ">
-                <label for="property-compound-shape-url">Compound shape URL</label>
-                <input type="text" id="property-compound-shape-url">
-            </div>
-            <hr class="model-group model-section" />
-            <div class="model-group model-section property url ">
-                <label for="property-model-animation-url">Animation URL</label>
-                <input type="text" id="property-model-animation-url">
-            </div>
-            <div class="model-group model-section two-column">
-                <div class="column">
-                    <div class="property checkbox">
-                        <input type="checkbox" id="property-model-animation-playing">
-                        <label for="property-model-animation-playing">Animation playing</label>
-                    </div>
-                    <div class="property checkbox indent">
-                        <input type="checkbox" id="property-model-animation-loop">
-                        <label for="property-model-animation-loop">Animation loop</label>
-                    </div>
-                    <div class="property checkbox indent">
-                        <input type="checkbox" id="property-model-animation-hold">
-                        <label for="property-model-animation-hold">Animation hold</label>
-                    </div>
-                    <div id="animation-fps" class="property number">
-                        <label>Animation FPS</label>
-                        <input type="number" id="property-model-animation-fps">
+                    <div class="column">
+                        <div class="property number">
+                            <label>Animation frame</label>
+                            <input type="number" id="property-model-animation-frame">
+                        </div>
+                        <div class="property number">
+                            <label>First frame</label>
+                            <input type="number" id="property-model-animation-first-frame">
+                        </div>
+                        <div class="property number">
+                            <label>Last frame</label>
+                            <input type="number" id="property-model-animation-last-frame">
+                        </div>
                     </div>
                 </div>
-                <div class="column">
-                    <div class="property number">
-                        <label>Animation frame</label>
-                        <input type="number" id="property-model-animation-frame">
-                    </div>
-                    <div class="property number">
-                        <label>First frame</label>
-                        <input type="number" id="property-model-animation-first-frame">
-                    </div>
-                    <div class="property number">
-                        <label>Last frame</label>
-                        <input type="number" id="property-model-animation-last-frame">
-                    </div>
+            </fieldset>
+            <fieldset class="minor">
+                <div class="model-group model-section property textarea">
+                    <label for="property-model-textures">Textures</label>
+                    <textarea id="property-model-textures"></textarea>
                 </div>
-            </div>
-            <hr class="model-group model-section" />
-            <div class="model-group model-section property textarea">
-                <label for="property-model-textures">Textures</label>
-                <textarea id="property-model-textures"></textarea>
-            </div>
-            <div class="model-group model-section property textarea">
-                <label for="property-model-original-textures">Original textures</label>
-                <textarea id="property-model-original-textures" readonly></textarea>
-            </div>
-            <div class="section-header text-group text-section">
-                <label>Text</label><span>M</span>
-            </div>
+                <div class="model-group model-section property textarea">
+                    <label for="property-model-original-textures">Original textures</label>
+                    <textarea id="property-model-original-textures" readonly></textarea>
+                </div>
+            </fieldset>
+        </fieldset>
+
+
+		<fieldset id="zone" class="major">
+ 		   <legend class="section-header zone-group zone-section">
+ 			   Zone<span>M</span>
+ 		   </legend>
+ 		   <fieldset class="minor">
+ 			   <div class="zone-group zone-section property checkbox">
+ 				   <input type="checkbox" id="property-zone-stage-sun-model-enabled">
+ 				   <label for="property-zone-stage-sun-model-enabled">Enable stage sun model</label>
+ 			   </div>
+ 			   <div class="zone-group zone-section property checkbox">
+ 				   <input type="checkbox" id="property-zone-flying-allowed">
+ 				   <label for="property-zone-flying-allowed">Flying allowed</label>
+ 			   </div>
+ 			   <div class="zone-group zone-section property checkbox">
+ 				   <input type="checkbox" id="property-zone-ghosting-allowed">
+ 				   <label for="property-zone-ghosting-allowed">Ghosting allowed</label>
+ 			   </div>
+ 		   </fieldset>
+ 		   <fieldset class="minor">
+ 			   <div class="zone-group zone-section property url ">
+ 				   <label for="property-zone-filter-url">Filter URL</label>
+ 				   <input type="text" id="property-zone-filter-url">
+ 			   </div>
+ 			   <div class="sub-section-header zone-group zone-section keylight-section">
+ 				   <label>Key Light</label>
+ 			   </div>
+ 			   <div class="zone-section keylight-section zone-group property rgb">
+ 				   <div class="color-picker" id="property-zone-key-light-color"></div>
+ 				   <label>Key light color</label>
+ 				   <div class="tuple">
+ 					   <div><input type="number" class="red" id="property-zone-key-light-color-red" min="0" max="255" step="1"><label for="property-zone-key-light-color-red">Red:</label></div>
+ 					   <div><input type="number" class="green" id="property-zone-key-light-color-green" min="0" max="255" step="1"><label for="property-zone-key-light-color-green">Green:</label></div>
+ 					   <div><input type="number" class="blue" id="property-zone-key-light-color-blue" min="0" max="255" step="1"><label for="property-zone-key-light-color-blue">Blue:</label></div>
+ 				   </div>
+ 			   </div>
+ 			   <div class="zone-section keylight-section zone-group property number">
+ 				   <label>Light intensity</label>
+ 				   <input type="number" id="property-zone-key-intensity" min="0" max="10" step="0.1">
+ 			   </div>
+ 			   <div class="zone-group zone-section keylight-section property gen">
+ 				   <div class="tuple">
+ 					   <div><label>Light altitude <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-x"></div>
+ 					   <div><label>Light azimuth <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-y"></div>
+ 					   <div></div>
+ 				   </div>
+ 			   </div>
+ 			   <div class="zone-group zone-section keylight-section property number">
+ 				   <label>Ambient intensity</label>
+ 				   <input type="number" id="property-zone-key-ambient-intensity" min="0" max="10" step="0.1">
+ 			   </div>
+ 			   <div class="zone-group zone-section keylight-section property url ">
+ 				   <label for="property-zone-key-ambient-url">Ambient URL</label>
+ 				   <input type="text" id="property-zone-key-ambient-url">
+ 			   </div>
+ 		   </fieldset>
+ 		   <fieldset class="minor">
+ 			   <legend class="sub-section-header zone-group zone-section stage-section">
+ 				   Stage
+ 			   </legend>
+ 			   <fieldset class="zone-group zone-section stage-section property gen fstuple">
+ 				   <div class="tuple">
+ 					   <div><label>Latitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-latitude" min="-90" max="90" step="1"></div>
+ 					   <div><label>Longitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-longitude" min="-180" max="180" step="1"></div>
+ 					   <div><label>Altitude <span class="unit">m</span></label><input type="number" id="property-zone-stage-altitude" step="1"></div>
+ 				   </div>
+ 			   </fieldset>
+ 			   <div class="zone-group zone-section stage-section property checkbox">
+ 				   <input type="checkbox" id="property-zone-stage-automatic-hour-day">
+ 				   <label for="property-zone-stage-automatic-hour-day">Match stage hour and day to location</label>
+ 			   </div>
+ 			   <fieldset class="zone-group zone-section stage-section property gen fstuple">
+ 				   <div class="tuple">
+ 					   <div><label>Day of year</label><input type="number" id="property-zone-stage-day" min="0" max="365" step="1"></div>
+ 					   <div><label>Hour</label><input type="number" id="property-zone-stage-hour" min="0" max="24" step="0.5"></div>
+ 					   <div></div>
+ 				   </div>
+ 			   </fieldset>
+ 		   </fieldset>
+ 		   <fieldset class="minor">
+ 			   <legend class="sub-section-header zone-group zone-section background-section">
+ 				   Background
+ 			   </legend>
+ 			   <div class="zone-group zone-section background-section property dropdown">
+ 				   <label>Background mode</label>
+ 				   <select name="SelectBackgroundMode" id="property-zone-background-mode">
+ 					   <option value="inherit">Nothing</option>
+ 					   <option value="skybox">Skybox</option>
+ 				   </select>
+ 			   </div>
+ 		   </fieldset>
+ 		   <fieldset class="minor skybox-section">
+ 			   <legend class="sub-section-header zone-group zone-section skybox-section">
+ 				   Skybox
+ 			   </legend>
+ 			   <fieldset class="zone-group zone-section skybox-section property rgb fstuple">
+ 				   <div class="color-picker" id="property-zone-skybox-color"></div>
+ 				   <legend>Skybox color</legend>
+ 				   <div class="tuple">
+ 					   <div><input type="number" class="red" id="property-zone-skybox-color-red"><label for="property-zone-skybox-color-red">Red:</label></div>
+ 					   <div><input type="number" class="green" id="property-zone-skybox-color-green"><label for="property-zone-skybox-color-green">Green:</label></div>
+ 					   <div><input type="number" class="blue" id="property-zone-skybox-color-blue"><label for="property-zone-skybox-color-blue">Blue:</label></div>
+ 				   </div>
+ 			   </fieldset>
+ 			   <div class="zone-group zone-section skybox-section property url ">
+ 				   <label for="property-zone-skybox-url">Skybox URL</label>
+ 				   <input type="text" id="property-zone-skybox-url">
+ 			   </div>
+ 		   </fieldset>
+ 	   </fieldset>
+
+
+        <fieldset id="text" class="major">
+            <legend class="section-header text-group text-section">
+                Text<span>M</span>
+            </legend>
             <div class="text-group text-section property text">
                 <label for="property-text-text">Text content</label>
                 <input type="text" id="property-text-text">
@@ -446,116 +616,22 @@
                     <div><input type="number" class="blue" id="property-text-text-color-blue"><label for="property-text-text-color-blue">Blue:</label></div>
                 </div>
             </div>
-            <div class="text-group text-section property rgb">
+            <fieldset class="text-group text-section property rgb fstuple">
                 <div class="color-picker" id="property-text-background-color"></div>
-                <label>Background color</label>
+                <legend>Background color</legend>
                 <div class="tuple">
                     <div><input type="number" class="red" id="property-text-background-color-red"><label for="roperty-text-background-color-red">Red:</label></div>
                     <div><input type="number" class="green" id="property-text-background-color-green"><label for="property-text-background-color-green">Green:</label></div>
                     <div><input type="number" class="blue" id="property-text-background-color-blue"><label for="property-text-background-color-blue">Blue:</label></div>
                 </div>
-            </div>
-            <div class="section-header zone-group zone-section">
-                <label>Zone</label><span>M</span>
-            </div>
-            <div class="zone-group zone-section property checkbox">
-                <input type="checkbox" id="property-zone-stage-sun-model-enabled">
-                <label for="property-zone-stage-sun-model-enabled">Enable stage sun model</label>
-            </div>
-            <div class="zone-group zone-section property checkbox">
-                <input type="checkbox" id="property-zone-flying-allowed">
-                <label for="property-zone-flying-allowed">Flying allowed</label>
-            </div>
-            <div class="zone-group zone-section property checkbox">
-                <input type="checkbox" id="property-zone-ghosting-allowed">
-                <label for="property-zone-ghosting-allowed">Ghosting allowed</label>
-            </div>
-            <hr class="zone-group zone-section">
-            <div class="zone-group zone-section property url ">
-                <label for="property-zone-filter-url">Filter URL</label>
-                <input type="text" id="property-zone-filter-url">
-            </div>
-            <div class="sub-section-header zone-group zone-section keylight-section">
-                <label>Key Light</label>
-            </div>
-            <div class="zone-section keylight-section zone-group property rgb">
-                <div class="color-picker" id="property-zone-key-light-color"></div>
-                <label>Key light color</label>
-                <div class="tuple">
-                    <div><input type="number" class="red" id="property-zone-key-light-color-red" min="0" max="255" step="1"><label for="property-zone-key-light-color-red">Red:</label></div>
-                    <div><input type="number" class="green" id="property-zone-key-light-color-green" min="0" max="255" step="1"><label for="property-zone-key-light-color-green">Green:</label></div>
-                    <div><input type="number" class="blue" id="property-zone-key-light-color-blue" min="0" max="255" step="1"><label for="property-zone-key-light-color-blue">Blue:</label></div>
-                </div>
-            </div>
-            <div class="zone-section keylight-section zone-group property number">
-                <label>Light intensity</label>
-                <input type="number" id="property-zone-key-intensity" min="0" max="10" step="0.1">
-            </div>
-            <div class="zone-group zone-section keylight-section property gen">
-                <div class="tuple">
-                    <div><label>Light altitude <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-x"></div>
-                    <div><label>Light azimuth <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-y"></div>
-                    <div></div>
-                </div>
-            </div>
-            <div class="zone-group zone-section keylight-section property number">
-                <label>Ambient intensity</label>
-                <input type="number" id="property-zone-key-ambient-intensity" min="0" max="10" step="0.1">
-            </div>
-            <div class="zone-group zone-section keylight-section property url ">
-                <label for="property-zone-key-ambient-url">Ambient URL</label>
-                <input type="text" id="property-zone-key-ambient-url">
-            </div>
-            <div class="sub-section-header zone-group zone-section stage-section">
-                <label>Stage</label>
-            </div>
-            <div class="zone-group zone-section stage-section property gen">
-                <div class="tuple">
-                    <div><label>Latitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-latitude" min="-90" max="90" step="1"></div>
-                    <div><label>Longitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-longitude" min="-180" max="180" step="1"></div>
-                    <div><label>Altitude <span class="unit">m</span></label><input type="number" id="property-zone-stage-altitude" step="1"></div>
-                </div>
-            </div>
-            <div class="zone-group zone-section stage-section property checkbox">
-                <input type="checkbox" id="property-zone-stage-automatic-hour-day">
-                <label for="property-zone-stage-automatic-hour-day">Match stage hour and day to location</label>
-            </div>
-            <div class="zone-group zone-section stage-section property gen">
-                <div class="tuple">
-                    <div><label>Day of year</label><input type="number" id="property-zone-stage-day" min="0" max="365" step="1"></div>
-                    <div><label>Hour</label><input type="number" id="property-zone-stage-hour" min="0" max="24" step="0.5"></div>
-                    <div></div>
-                </div>
-            </div>
-            <div class="sub-section-header zone-group zone-section background-section">
-                <label>Background</label>
-            </div>
-            <div class="zone-group zone-section background-section property dropdown">
-                <label>Background mode</label>
-                <select name="SelectBackgroundMode" id="property-zone-background-mode">
-                    <option value="inherit">Nothing</option>
-                    <option value="skybox">Skybox</option>
-                </select>
-            </div>
-            <div class="sub-section-header zone-group zone-section skybox-section">
-                <label>Skybox</label>
-            </div>
-            <div class="zone-group zone-section skybox-section property rgb">
-                <div class="color-picker" id="property-zone-skybox-color"></div>
-                <label>Skybox color</label>
-                <div class="tuple">
-                    <div><input type="number" class="red" id="property-zone-skybox-color-red"><label for="property-zone-skybox-color-red">Red:</label></div>
-                    <div><input type="number" class="green" id="property-zone-skybox-color-green"><label for="property-zone-skybox-color-green">Green:</label></div>
-                    <div><input type="number" class="blue" id="property-zone-skybox-color-blue"><label for="property-zone-skybox-color-blue">Blue:</label></div>
-                </div>
-            </div>
-            <div class="zone-group zone-section skybox-section property url ">
-                <label for="property-zone-skybox-url">Skybox URL</label>
-                <input type="text" id="property-zone-skybox-url">
-            </div>
-            <div class="section-header web-group web-section">
-                <label>Web</label><span>M</span>
-            </div>
+            </fieldset>
+        </fieldset>
+
+
+        <fieldset id="web" class="major">
+            <legend class="section-header web-group web-section">
+                Web<span>M</span>
+            </legend>
             <div class="web-group web-section property url ">
                 <label for="property-web-source-url">Source URL</label>
                 <input type="text" id="property-web-source-url">
@@ -564,36 +640,45 @@
                 <label for="property-web-dpi">Resolution (DPI)</label>
                 <input type="number" id="property-web-dpi">
             </div>
-            <div class="section-header light-group light-section">
-                <label>Light</label><span>M</span>
-            </div>
-            <div class="light-group light-section property rgb">
-                <div class="color-picker" id="property-light-color"></div>
-                <label>Light color</label>
-                <div class="tuple">
-                    <div><input type="number" class="red" id="property-light-color-red"><label for="property-light-color-red">Red:</label></div>
-                    <div><input type="number" class="green" id="property-light-color-green"><label for="property-light-color-green">Green:</label></div>
-                    <div><input type="number" class="blue" id="property-light-color-blue"><label for="property-light-color-blue">Blue:</label></div>
-                </div>
-            </div>
-            <div class="light-group light-section property gen">
-                <div class="tuple">
-                    <div><label>Intensity</label><input type="number" id="property-light-intensity" min="0" step="0.1"></div>
-                    <div><label>Fall-off radius <span class="unit">m</span></label><input type="number" id="property-light-falloff-radius" min="0" step="0.1"></div>
-                    <div></div>
-                </div>
-            </div>
-            <div class="light-group light-section property checkbox">
-                <input type="checkbox" id="property-light-spot-light">
-                <label for="property-light-spot-light">Spotlight</label>
-            </div>
-            <div class="light-group light-section property gen">
-                <div class="tuple">
-                    <div><label>Spotlight exponent</label><input type="number" id="property-light-exponent" step="0.01"></div>
-                    <div><label>Spotlight cut-off</label><input type="number" id="property-light-cutoff" step="0.01"></div>
-                    <div></div>
-                </div>
-            </div>
-        </div>
-    </body>
+        </fieldset>
+
+
+
+
+
+		<fieldset id="polyvox" class="major">
+ 		   <legend class="section-header spatial-group poly-vox-section property xyz">
+ 			   Voxel volume size <span>m</span>
+ 		   </legend>
+ 		   <div class="tuple">
+ 			   <div><input type="number" class="x" id="property-voxel-volume-size-x"><label for="property-voxel-volume-size-x">X:</label></div>
+ 			   <div><input type="number" class="y" id="property-voxel-volume-size-y"><label for="property-voxel-volume-size-y">Y:</label></div>
+ 			   <div><input type="number" class="z" id="property-voxel-volume-size-z"><label for="property-voxel-volume-size-z">Z:</label></div>
+ 		   </div>
+ 		   <div class="spatial-group poly-vox-section property dropdown">
+ 			   <label>Surface extractor</label>
+ 			   <select name="SelectVoxelSurfaceStyle" id="property-voxel-surface-style">
+ 					<option value="0">Marching cubes</option>
+ 					<option value="1">Cubic</option>
+ 					<option value="2">Edged cubic</option>
+ 					<option value="3">Edged marching cubes</option>
+ 				</select>
+ 		   </div>
+ 		   <div class="spatial-group poly-vox-section property url ">
+ 			   <label for="property-x-texture-url">X-axis texture URL</label>
+ 			   <input type="text" id="property-x-texture-url">
+ 		   </div>
+ 		   <div class="spatial-group poly-vox-section property url ">
+ 			   <label for="property-y-texture-url">Y-axis texture URL</label>
+ 			   <input type="text" id="property-y-texture-url">
+ 		   </div>
+ 		   <div class="spatial-group poly-vox-section property url ">
+ 			   <label for="property-z-texture-url">Z-axis texture URL</label>
+ 			   <input type="text" id="property-z-texture-url">
+ 		   </div>
+ 	   </fieldset>
+
+    </div>
+</body>
+
 </html>

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -47,114 +47,114 @@
             <div class="shape-group shape-section property dropdown">
                 <label for="property-shape">Shape</label>
                 <select name="SelectShape" id="property-shape">
-						<option value="Cube">Box</option>
-						<option value="Sphere">Sphere</option>
-						<option value="Tetrahedron">Tetrahedron</option>
-						<option value="Octahedron">Octahedron</option>
-						<option value="Icosahedron">Icosahedron</option>
-						<option value="Dodecahedron">Dodecahedron</option>
-						<option value="Hexagon">Hexagon</option>
-						<option value="Triangle">Triangle</option>
-						<option value="Octagon">Octagon</option>
-						<option value="Cylinder">Cylinder</option>
-						<option value="Cone">Cone</option>
-						<option value="Circle">Circle</option>
-					</select>
+                        <option value="Cube">Box</option>
+                        <option value="Sphere">Sphere</option>
+                        <option value="Tetrahedron">Tetrahedron</option>
+                        <option value="Octahedron">Octahedron</option>
+                        <option value="Icosahedron">Icosahedron</option>
+                        <option value="Dodecahedron">Dodecahedron</option>
+                        <option value="Hexagon">Hexagon</option>
+                        <option value="Triangle">Triangle</option>
+                        <option value="Octagon">Octagon</option>
+                        <option value="Cylinder">Cylinder</option>
+                        <option value="Cone">Cone</option>
+                        <option value="Circle">Circle</option>
+                    </select>
             </div>
             <div class="property text">
                 <label for="property-name">Name</label>
                 <input type="text" id="property-name">
             </div>
-			<div class="physical-group color-section property color-control1">
-				<div class="color-picker" id="property-color-control1"></div>
-				<label>Entity color</label>
-			</div>
-		</fieldset>
-		<fieldset id="collision-info">
-			<fieldset class="minor">
-				<div class="behavior-group property checkbox">
-					<input type="checkbox" id="property-collisionless">
-					<label for="property-collisionless">Collisionless</label>
-				</div>
-				<div class="behavior-group property checkbox">
-					<input type="checkbox" id="property-dynamic">
-					<label for="property-dynamic">Dynamic</label>
-				</div>
-			</fieldset>
-			<fieldset class="minor">
-				<div class="behavior-group two-column">
-					<fieldset class="column">
-						<legend class="sub-section-header">
-							Collides With
-						</legend>
-						<div class="checkbox-sub-props">
-							<div class="property checkbox">
-								<input type="checkbox" id="property-collide-static">
-								<label for="property-collide-static">Static entities</label>
-							</div>
-							<div class="property checkbox">
-								<input type="checkbox" id="property-collide-dynamic">
-								<label for="property-collide-dynamic">Dynamic entities</label>
-							</div>
-							<div class="property checkbox">
-								<input type="checkbox" id="property-collide-kinematic">
-								<label for="property-collide-kinematic">Kinematic entities</label>
-							</div>
-							<div class="property checkbox">
-								<input type="checkbox" id="property-collide-myAvatar">
-								<label for="property-collide-myAvatar">My avatar</label>
-							</div>
-							<div class="property checkbox">
-								<input type="checkbox" id="property-collide-otherAvatar">
-								<label for="property-collide-otherAvatar">Other avatars</label>
-							</div>
-						</div>
-					</fieldset>
-					<fieldset class="column">
-						<legend class="sub-section-header">
-							Grabbing
-						</legend>
-						<div class="checkbox-sub-props">
-							<div class="property checkbox">
-								<input type="checkbox" id="property-grabbable">
-								<label for="property-grabbable">Grabbable</label>
-							</div>
-							<div class="property checkbox">
-								<input type="checkbox" id="property-wants-trigger">
-								<label for="property-wants-trigger">Triggerable</label>
-							</div>
-							<div class="property checkbox">
-								<input type="checkbox" id="property-cloneable">
-								<label for="property-cloneable">Cloneable</label>
-							</div>
-							<div class="property checkbox">
-								<input type="checkbox" id="property-ignore-ik">
-								<label for="property-ignore-ik">Ignore inverse kinematics</label>
-							</div>
-						</div>
-					</fieldset>
-					<fieldset style="display:none;">
-						<!-- extra column ------------------------------------------------------------------------------------ -->
-						<div class="column" id="group-cloneable-group" style="display:none;">
-							<div class="sub-section-header">
-								<span>Cloneable Settings</span>
-							</div>
-							<div class="cloneable-group property gen">
-								<div><label>Clone Lifetime</label><input type="number" data-user-data-type="cloneLifetime" id="property-cloneable-lifetime"></div>
-								<div><label>Clone Limit</label><input type="number" data-user-data-type="cloneLimit" id="property-cloneable-limit"></div>
-								<div class="property checkbox">
-									<input type="checkbox" id="property-cloneable-dynamic">
-									<label for="property-cloneable-dynamic">Clone Dynamic</label>
-								</div>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-			</fieldset>
+            <div class="physical-group color-section property color-control1">
+                <div class="color-picker" id="property-color-control1"></div>
+                <label>Entity color</label>
+            </div>
+        </fieldset>
+        <fieldset id="collision-info">
+            <fieldset class="minor">
+                <div class="behavior-group property checkbox">
+                    <input type="checkbox" id="property-collisionless">
+                    <label for="property-collisionless">Collisionless</label>
+                </div>
+                <div class="behavior-group property checkbox">
+                    <input type="checkbox" id="property-dynamic">
+                    <label for="property-dynamic">Dynamic</label>
+                </div>
+            </fieldset>
+            <fieldset class="minor">
+                <div class="behavior-group two-column">
+                    <fieldset class="column">
+                        <legend class="sub-section-header">
+                            Collides With
+                        </legend>
+                        <div class="checkbox-sub-props">
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-collide-static">
+                                <label for="property-collide-static">Static entities</label>
+                            </div>
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-collide-dynamic">
+                                <label for="property-collide-dynamic">Dynamic entities</label>
+                            </div>
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-collide-kinematic">
+                                <label for="property-collide-kinematic">Kinematic entities</label>
+                            </div>
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-collide-myAvatar">
+                                <label for="property-collide-myAvatar">My avatar</label>
+                            </div>
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-collide-otherAvatar">
+                                <label for="property-collide-otherAvatar">Other avatars</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                    <fieldset class="column">
+                        <legend class="sub-section-header">
+                            Grabbing
+                        </legend>
+                        <div class="checkbox-sub-props">
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-grabbable">
+                                <label for="property-grabbable">Grabbable</label>
+                            </div>
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-wants-trigger">
+                                <label for="property-wants-trigger">Triggerable</label>
+                            </div>
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-cloneable">
+                                <label for="property-cloneable">Cloneable</label>
+                            </div>
+                            <div class="property checkbox">
+                                <input type="checkbox" id="property-ignore-ik">
+                                <label for="property-ignore-ik">Ignore inverse kinematics</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                    <fieldset style="display:none;">
+                        <!-- extra column ------------------------------------------------------------------------------------ -->
+                        <div class="column" id="group-cloneable-group" style="display:none;">
+                            <div class="sub-section-header">
+                                <span>Cloneable Settings</span>
+                            </div>
+                            <div class="cloneable-group property gen">
+                                <div><label>Clone Lifetime</label><input type="number" data-user-data-type="cloneLifetime" id="property-cloneable-lifetime"></div>
+                                <div><label>Clone Limit</label><input type="number" data-user-data-type="cloneLimit" id="property-cloneable-limit"></div>
+                                <div class="property checkbox">
+                                    <input type="checkbox" id="property-cloneable-dynamic">
+                                    <label for="property-cloneable-dynamic">Clone Dynamic</label>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+            </fieldset>
         </fieldset>
 
 
-		<fieldset id="physical" class="major">
+        <fieldset id="physical" class="major">
             <legend class="section-header physical-group">
                 Physical<span>M</span>
             </legend>
@@ -297,23 +297,23 @@
             <legend class="section-header behavior-group">
                 Behavior<span>M</span>
             </legend>
-			<div class="property textarea">
-				<label for="property-user-data">User data</label>
-				<br>
-				<div class="row">
-					<input type="button" class="red" id="userdata-clear" value="Clear User Data">
-					<input type="button" class="blue" id="userdata-new-editor" value="Edit as JSON">
-					<input disabled type="button" class="black" id="userdata-save" value="Save User Data">
-					<span id="userdata-saved">Saved!</span>
-				</div>
-				<div id="static-userdata"></div>
-				<div id="userdata-editor"></div>
-				<textarea id="property-user-data"></textarea>
-			</div>
-			<div id="id" class="property value">
-				<label>ID:</label>
-				<input type="text" id="property-id" readonly>
-			</div>
+            <div class="property textarea">
+                <label for="property-user-data">User data</label>
+                <br>
+                <div class="row">
+                    <input type="button" class="red" id="userdata-clear" value="Clear User Data">
+                    <input type="button" class="blue" id="userdata-new-editor" value="Edit as JSON">
+                    <input disabled type="button" class="black" id="userdata-save" value="Save User Data">
+                    <span id="userdata-saved">Saved!</span>
+                </div>
+                <div id="static-userdata"></div>
+                <div id="userdata-editor"></div>
+                <textarea id="property-user-data"></textarea>
+            </div>
+            <div id="id" class="property value">
+                <label>ID:</label>
+                <input type="text" id="property-id" readonly>
+            </div>
 
             <fieldset class="minor">
                 <div class="behavior-group property url ">
@@ -347,10 +347,10 @@
                     <textarea id="server-script-error"></textarea>
                 </div>
             </fieldset>
-			<div class="property text">
-				<label for="property-description">Description</label>
-				<input type="text" id="property-description">
-			</div>
+            <div class="property text">
+                <label for="property-description">Description</label>
+                <input type="text" id="property-description">
+            </div>
         </fieldset>
 
 
@@ -366,38 +366,38 @@
 
 
 
-		<fieldset id="light" class="major">
- 		   <legend class="section-header light-group light-section">
- 			   Light<span>M</span>
- 		   </legend>
- 		   <fieldset class="light-group light-section property rgb fstuple">
- 			   <div class="color-picker" id="property-light-color"></div>
- 			   <legend>Light color</legend>
- 			   <div class="tuple">
- 				   <div><input type="number" class="red" id="property-light-color-red"><label for="property-light-color-red">Red:</label></div>
- 				   <div><input type="number" class="green" id="property-light-color-green"><label for="property-light-color-green">Green:</label></div>
- 				   <div><input type="number" class="blue" id="property-light-color-blue"><label for="property-light-color-blue">Blue:</label></div>
- 			   </div>
- 		   </fieldset>
- 		   <fieldset class="light-group light-section property gen fstuple">
- 			   <div class="tuple">
- 				   <div><label>Intensity</label><input type="number" id="property-light-intensity" min="0" step="0.1"></div>
- 				   <div><label>Fall-off radius <span class="unit">m</span></label><input type="number" id="property-light-falloff-radius" min="0" step="0.1"></div>
- 				   <div></div>
- 			   </div>
- 		   </fieldset>
- 		   <div class="light-group light-section property checkbox">
- 			   <input type="checkbox" id="property-light-spot-light">
- 			   <label for="property-light-spot-light">Spotlight</label>
- 		   </div>
- 		   <fieldset class="light-group light-section property gen fstuple">
- 			   <div class="tuple">
- 				   <div><label>Spotlight exponent</label><input type="number" id="property-light-exponent" step="0.01"></div>
- 				   <div><label>Spotlight cut-off</label><input type="number" id="property-light-cutoff" step="0.01"></div>
- 				   <div></div>
- 			   </div>
- 		   </fieldset>
- 	   </fieldset>
+        <fieldset id="light" class="major">
+            <legend class="section-header light-group light-section">
+                Light<span>M</span>
+            </legend>
+            <fieldset class="light-group light-section property rgb fstuple">
+                <div class="color-picker" id="property-light-color"></div>
+                <legend>Light color</legend>
+                <div class="tuple">
+                    <div><input type="number" class="red" id="property-light-color-red"><label for="property-light-color-red">Red:</label></div>
+                    <div><input type="number" class="green" id="property-light-color-green"><label for="property-light-color-green">Green:</label></div>
+                    <div><input type="number" class="blue" id="property-light-color-blue"><label for="property-light-color-blue">Blue:</label></div>
+                </div>
+            </fieldset>
+            <fieldset class="light-group light-section property gen fstuple">
+                <div class="tuple">
+                    <div><label>Intensity</label><input type="number" id="property-light-intensity" min="0" step="0.1"></div>
+                    <div><label>Fall-off radius <span class="unit">m</span></label><input type="number" id="property-light-falloff-radius" min="0" step="0.1"></div>
+                    <div></div>
+                </div>
+            </fieldset>
+            <div class="light-group light-section property checkbox">
+                <input type="checkbox" id="property-light-spot-light">
+                <label for="property-light-spot-light">Spotlight</label>
+            </div>
+            <fieldset class="light-group light-section property gen fstuple">
+                <div class="tuple">
+                    <div><label>Spotlight exponent</label><input type="number" id="property-light-exponent" step="0.01"></div>
+                    <div><label>Spotlight cut-off</label><input type="number" id="property-light-cutoff" step="0.01"></div>
+                    <div></div>
+                </div>
+            </fieldset>
+        </fieldset>
 
 
         <fieldset id="model" class="major">
@@ -412,14 +412,14 @@
                 <div class="model-group model-section zone-section property dropdown">
                     <label>Collision shape type</label>
                     <select name="SelectShapeType" id="property-shape-type">
-		   				<option value="none">No Collision</option>
-		   				<option value="box">Box</option>
-		   				<option value="sphere">Sphere</option>
-		   				<option value="compound">Compound</option>
-		   				<option value="simple-hull">Basic - Whole model</option>
-		   				<option value="simple-compound">Good - Sub-meshes</option>
-		   				<option value="static-mesh">Exact - All polygons (non-dynamic only)</option>
-		   			</select>
+                           <option value="none">No Collision</option>
+                           <option value="box">Box</option>
+                           <option value="sphere">Sphere</option>
+                           <option value="compound">Compound</option>
+                           <option value="simple-hull">Basic - Whole model</option>
+                           <option value="simple-compound">Good - Sub-meshes</option>
+                           <option value="static-mesh">Exact - All polygons (non-dynamic only)</option>
+                       </select>
                 </div>
                 <div class="model-group model-section zone-section property url ">
                     <label for="property-compound-shape-url">Compound shape URL</label>
@@ -480,115 +480,115 @@
         </fieldset>
 
 
-		<fieldset id="zone" class="major">
- 		   <legend class="section-header zone-group zone-section">
- 			   Zone<span>M</span>
- 		   </legend>
- 		   <fieldset class="minor">
- 			   <div class="zone-group zone-section property checkbox">
- 				   <input type="checkbox" id="property-zone-stage-sun-model-enabled">
- 				   <label for="property-zone-stage-sun-model-enabled">Enable stage sun model</label>
- 			   </div>
- 			   <div class="zone-group zone-section property checkbox">
- 				   <input type="checkbox" id="property-zone-flying-allowed">
- 				   <label for="property-zone-flying-allowed">Flying allowed</label>
- 			   </div>
- 			   <div class="zone-group zone-section property checkbox">
- 				   <input type="checkbox" id="property-zone-ghosting-allowed">
- 				   <label for="property-zone-ghosting-allowed">Ghosting allowed</label>
- 			   </div>
- 		   </fieldset>
- 		   <fieldset class="minor">
- 			   <div class="zone-group zone-section property url ">
- 				   <label for="property-zone-filter-url">Filter URL</label>
- 				   <input type="text" id="property-zone-filter-url">
- 			   </div>
- 			   <div class="sub-section-header zone-group zone-section keylight-section">
- 				   <label>Key Light</label>
- 			   </div>
- 			   <div class="zone-section keylight-section zone-group property rgb">
- 				   <div class="color-picker" id="property-zone-key-light-color"></div>
- 				   <label>Key light color</label>
- 				   <div class="tuple">
- 					   <div><input type="number" class="red" id="property-zone-key-light-color-red" min="0" max="255" step="1"><label for="property-zone-key-light-color-red">Red:</label></div>
- 					   <div><input type="number" class="green" id="property-zone-key-light-color-green" min="0" max="255" step="1"><label for="property-zone-key-light-color-green">Green:</label></div>
- 					   <div><input type="number" class="blue" id="property-zone-key-light-color-blue" min="0" max="255" step="1"><label for="property-zone-key-light-color-blue">Blue:</label></div>
- 				   </div>
- 			   </div>
- 			   <div class="zone-section keylight-section zone-group property number">
- 				   <label>Light intensity</label>
- 				   <input type="number" id="property-zone-key-intensity" min="0" max="10" step="0.1">
- 			   </div>
- 			   <div class="zone-group zone-section keylight-section property gen">
- 				   <div class="tuple">
- 					   <div><label>Light altitude <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-x"></div>
- 					   <div><label>Light azimuth <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-y"></div>
- 					   <div></div>
- 				   </div>
- 			   </div>
- 			   <div class="zone-group zone-section keylight-section property number">
- 				   <label>Ambient intensity</label>
- 				   <input type="number" id="property-zone-key-ambient-intensity" min="0" max="10" step="0.1">
- 			   </div>
- 			   <div class="zone-group zone-section keylight-section property url ">
- 				   <label for="property-zone-key-ambient-url">Ambient URL</label>
- 				   <input type="text" id="property-zone-key-ambient-url">
- 			   </div>
- 		   </fieldset>
- 		   <fieldset class="minor">
- 			   <legend class="sub-section-header zone-group zone-section stage-section">
- 				   Stage
- 			   </legend>
- 			   <fieldset class="zone-group zone-section stage-section property gen fstuple">
- 				   <div class="tuple">
- 					   <div><label>Latitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-latitude" min="-90" max="90" step="1"></div>
- 					   <div><label>Longitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-longitude" min="-180" max="180" step="1"></div>
- 					   <div><label>Altitude <span class="unit">m</span></label><input type="number" id="property-zone-stage-altitude" step="1"></div>
- 				   </div>
- 			   </fieldset>
- 			   <div class="zone-group zone-section stage-section property checkbox">
- 				   <input type="checkbox" id="property-zone-stage-automatic-hour-day">
- 				   <label for="property-zone-stage-automatic-hour-day">Match stage hour and day to location</label>
- 			   </div>
- 			   <fieldset class="zone-group zone-section stage-section property gen fstuple">
- 				   <div class="tuple">
- 					   <div><label>Day of year</label><input type="number" id="property-zone-stage-day" min="0" max="365" step="1"></div>
- 					   <div><label>Hour</label><input type="number" id="property-zone-stage-hour" min="0" max="24" step="0.5"></div>
- 					   <div></div>
- 				   </div>
- 			   </fieldset>
- 		   </fieldset>
- 		   <fieldset class="minor">
- 			   <legend class="sub-section-header zone-group zone-section background-section">
- 				   Background
- 			   </legend>
- 			   <div class="zone-group zone-section background-section property dropdown">
- 				   <label>Background mode</label>
- 				   <select name="SelectBackgroundMode" id="property-zone-background-mode">
- 					   <option value="inherit">Nothing</option>
- 					   <option value="skybox">Skybox</option>
- 				   </select>
- 			   </div>
- 		   </fieldset>
- 		   <fieldset class="minor skybox-section">
- 			   <legend class="sub-section-header zone-group zone-section skybox-section">
- 				   Skybox
- 			   </legend>
- 			   <fieldset class="zone-group zone-section skybox-section property rgb fstuple">
- 				   <div class="color-picker" id="property-zone-skybox-color"></div>
- 				   <legend>Skybox color</legend>
- 				   <div class="tuple">
- 					   <div><input type="number" class="red" id="property-zone-skybox-color-red"><label for="property-zone-skybox-color-red">Red:</label></div>
- 					   <div><input type="number" class="green" id="property-zone-skybox-color-green"><label for="property-zone-skybox-color-green">Green:</label></div>
- 					   <div><input type="number" class="blue" id="property-zone-skybox-color-blue"><label for="property-zone-skybox-color-blue">Blue:</label></div>
- 				   </div>
- 			   </fieldset>
- 			   <div class="zone-group zone-section skybox-section property url ">
- 				   <label for="property-zone-skybox-url">Skybox URL</label>
- 				   <input type="text" id="property-zone-skybox-url">
- 			   </div>
- 		   </fieldset>
- 	   </fieldset>
+        <fieldset id="zone" class="major">
+            <legend class="section-header zone-group zone-section">
+                Zone<span>M</span>
+            </legend>
+            <fieldset class="minor">
+                <div class="zone-group zone-section property checkbox">
+                    <input type="checkbox" id="property-zone-stage-sun-model-enabled">
+                    <label for="property-zone-stage-sun-model-enabled">Enable stage sun model</label>
+                </div>
+                <div class="zone-group zone-section property checkbox">
+                    <input type="checkbox" id="property-zone-flying-allowed">
+                    <label for="property-zone-flying-allowed">Flying allowed</label>
+                </div>
+                <div class="zone-group zone-section property checkbox">
+                    <input type="checkbox" id="property-zone-ghosting-allowed">
+                    <label for="property-zone-ghosting-allowed">Ghosting allowed</label>
+                </div>
+            </fieldset>
+            <fieldset class="minor">
+                <div class="zone-group zone-section property url ">
+                    <label for="property-zone-filter-url">Filter URL</label>
+                    <input type="text" id="property-zone-filter-url">
+                </div>
+                <div class="sub-section-header zone-group zone-section keylight-section">
+                    <label>Key Light</label>
+                </div>
+                <div class="zone-section keylight-section zone-group property rgb">
+                    <div class="color-picker" id="property-zone-key-light-color"></div>
+                    <label>Key light color</label>
+                    <div class="tuple">
+                        <div><input type="number" class="red" id="property-zone-key-light-color-red" min="0" max="255" step="1"><label for="property-zone-key-light-color-red">Red:</label></div>
+                        <div><input type="number" class="green" id="property-zone-key-light-color-green" min="0" max="255" step="1"><label for="property-zone-key-light-color-green">Green:</label></div>
+                        <div><input type="number" class="blue" id="property-zone-key-light-color-blue" min="0" max="255" step="1"><label for="property-zone-key-light-color-blue">Blue:</label></div>
+                    </div>
+                </div>
+                <div class="zone-section keylight-section zone-group property number">
+                    <label>Light intensity</label>
+                    <input type="number" id="property-zone-key-intensity" min="0" max="10" step="0.1">
+                </div>
+                <div class="zone-group zone-section keylight-section property gen">
+                    <div class="tuple">
+                        <div><label>Light altitude <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-x"></div>
+                        <div><label>Light azimuth <span class="unit">deg</span></label><input type="number" id="property-zone-key-light-direction-y"></div>
+                        <div></div>
+                    </div>
+                </div>
+                <div class="zone-group zone-section keylight-section property number">
+                    <label>Ambient intensity</label>
+                    <input type="number" id="property-zone-key-ambient-intensity" min="0" max="10" step="0.1">
+                </div>
+                <div class="zone-group zone-section keylight-section property url ">
+                    <label for="property-zone-key-ambient-url">Ambient URL</label>
+                    <input type="text" id="property-zone-key-ambient-url">
+                </div>
+            </fieldset>
+            <fieldset class="minor">
+                <legend class="sub-section-header zone-group zone-section stage-section">
+                    Stage
+                </legend>
+                <fieldset class="zone-group zone-section stage-section property gen fstuple">
+                    <div class="tuple">
+                        <div><label>Latitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-latitude" min="-90" max="90" step="1"></div>
+                        <div><label>Longitude <span class="unit">deg</span></label><input type="number" id="property-zone-stage-longitude" min="-180" max="180" step="1"></div>
+                        <div><label>Altitude <span class="unit">m</span></label><input type="number" id="property-zone-stage-altitude" step="1"></div>
+                    </div>
+                </fieldset>
+                <div class="zone-group zone-section stage-section property checkbox">
+                    <input type="checkbox" id="property-zone-stage-automatic-hour-day">
+                    <label for="property-zone-stage-automatic-hour-day">Match stage hour and day to location</label>
+                </div>
+                <fieldset class="zone-group zone-section stage-section property gen fstuple">
+                    <div class="tuple">
+                        <div><label>Day of year</label><input type="number" id="property-zone-stage-day" min="0" max="365" step="1"></div>
+                        <div><label>Hour</label><input type="number" id="property-zone-stage-hour" min="0" max="24" step="0.5"></div>
+                        <div></div>
+                    </div>
+                </fieldset>
+            </fieldset>
+            <fieldset class="minor">
+                <legend class="sub-section-header zone-group zone-section background-section">
+                    Background
+                </legend>
+                <div class="zone-group zone-section background-section property dropdown">
+                    <label>Background mode</label>
+                    <select name="SelectBackgroundMode" id="property-zone-background-mode">
+                        <option value="inherit">Nothing</option>
+                        <option value="skybox">Skybox</option>
+                    </select>
+                </div>
+            </fieldset>
+            <fieldset class="minor skybox-section">
+                <legend class="sub-section-header zone-group zone-section skybox-section">
+                    Skybox
+                </legend>
+                <fieldset class="zone-group zone-section skybox-section property rgb fstuple">
+                    <div class="color-picker" id="property-zone-skybox-color"></div>
+                    <legend>Skybox color</legend>
+                    <div class="tuple">
+                        <div><input type="number" class="red" id="property-zone-skybox-color-red"><label for="property-zone-skybox-color-red">Red:</label></div>
+                        <div><input type="number" class="green" id="property-zone-skybox-color-green"><label for="property-zone-skybox-color-green">Green:</label></div>
+                        <div><input type="number" class="blue" id="property-zone-skybox-color-blue"><label for="property-zone-skybox-color-blue">Blue:</label></div>
+                    </div>
+                </fieldset>
+                <div class="zone-group zone-section skybox-section property url ">
+                    <label for="property-zone-skybox-url">Skybox URL</label>
+                    <input type="text" id="property-zone-skybox-url">
+                </div>
+            </fieldset>
+        </fieldset>
 
 
         <fieldset id="text" class="major">
@@ -646,37 +646,37 @@
 
 
 
-		<fieldset id="polyvox" class="major">
- 		   <legend class="section-header spatial-group poly-vox-section property xyz">
- 			   Voxel volume size <span>m</span>
- 		   </legend>
- 		   <div class="tuple">
- 			   <div><input type="number" class="x" id="property-voxel-volume-size-x"><label for="property-voxel-volume-size-x">X:</label></div>
- 			   <div><input type="number" class="y" id="property-voxel-volume-size-y"><label for="property-voxel-volume-size-y">Y:</label></div>
- 			   <div><input type="number" class="z" id="property-voxel-volume-size-z"><label for="property-voxel-volume-size-z">Z:</label></div>
- 		   </div>
- 		   <div class="spatial-group poly-vox-section property dropdown">
- 			   <label>Surface extractor</label>
- 			   <select name="SelectVoxelSurfaceStyle" id="property-voxel-surface-style">
- 					<option value="0">Marching cubes</option>
- 					<option value="1">Cubic</option>
- 					<option value="2">Edged cubic</option>
- 					<option value="3">Edged marching cubes</option>
- 				</select>
- 		   </div>
- 		   <div class="spatial-group poly-vox-section property url ">
- 			   <label for="property-x-texture-url">X-axis texture URL</label>
- 			   <input type="text" id="property-x-texture-url">
- 		   </div>
- 		   <div class="spatial-group poly-vox-section property url ">
- 			   <label for="property-y-texture-url">Y-axis texture URL</label>
- 			   <input type="text" id="property-y-texture-url">
- 		   </div>
- 		   <div class="spatial-group poly-vox-section property url ">
- 			   <label for="property-z-texture-url">Z-axis texture URL</label>
- 			   <input type="text" id="property-z-texture-url">
- 		   </div>
- 	   </fieldset>
+        <fieldset id="polyvox" class="major">
+            <legend class="section-header spatial-group poly-vox-section property xyz">
+                Voxel volume size <span>m</span>
+            </legend>
+            <div class="tuple">
+                <div><input type="number" class="x" id="property-voxel-volume-size-x"><label for="property-voxel-volume-size-x">X:</label></div>
+                <div><input type="number" class="y" id="property-voxel-volume-size-y"><label for="property-voxel-volume-size-y">Y:</label></div>
+                <div><input type="number" class="z" id="property-voxel-volume-size-z"><label for="property-voxel-volume-size-z">Z:</label></div>
+            </div>
+            <div class="spatial-group poly-vox-section property dropdown">
+                <label>Surface extractor</label>
+                <select name="SelectVoxelSurfaceStyle" id="property-voxel-surface-style">
+                     <option value="0">Marching cubes</option>
+                     <option value="1">Cubic</option>
+                     <option value="2">Edged cubic</option>
+                     <option value="3">Edged marching cubes</option>
+                 </select>
+            </div>
+            <div class="spatial-group poly-vox-section property url ">
+                <label for="property-x-texture-url">X-axis texture URL</label>
+                <input type="text" id="property-x-texture-url">
+            </div>
+            <div class="spatial-group poly-vox-section property url ">
+                <label for="property-y-texture-url">Y-axis texture URL</label>
+                <input type="text" id="property-y-texture-url">
+            </div>
+            <div class="spatial-group poly-vox-section property url ">
+                <label for="property-z-texture-url">Z-axis texture URL</label>
+                <input type="text" id="property-z-texture-url">
+            </div>
+        </fieldset>
 
     </div>
 </body>

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -479,7 +479,7 @@ function loaded() {
     openEventBridge(function() {
 
         var allSections = [];
-		var elPropertiesList = document.getElementById("properties-list");
+        var elPropertiesList = document.getElementById("properties-list");
         var elID = document.getElementById("property-id");
         var elType = document.getElementById("property-type");
         var elTypeIcon = document.getElementById("type-icon");
@@ -566,8 +566,8 @@ function loaded() {
         var elJSONEditor = document.getElementById("userdata-editor");
         var elNewJSONEditor = document.getElementById('userdata-new-editor');
         var elColorSections = document.querySelectorAll(".color-section");
-		var elColorControl1 = document.getElementById("property-color-control1");
-		var elColorControl2 = document.getElementById("property-color-control2");
+        var elColorControl1 = document.getElementById("property-color-control1");
+        var elColorControl2 = document.getElementById("property-color-control2");
         var elColorRed = document.getElementById("property-color-red");
         var elColorGreen = document.getElementById("property-color-green");
         var elColorBlue = document.getElementById("property-color-blue");
@@ -681,7 +681,9 @@ function loaded() {
                 data = JSON.parse(data);
                 if (data.type == "server_script_status") {
                     elServerScriptError.value = data.errorInfo;
-					// If we just set elServerScriptError's diplay to block or none, we still end up with it's parent contributing 21px bottom padding even when elServerScriptError is display:none. So set it's parent to block or none
+                    // If we just set elServerScriptError's diplay to block or none, we still end up with
+                    //it's parent contributing 21px bottom padding even when elServerScriptError is display:none.
+                    // So set it's parent to block or none
                     elServerScriptError.parentElement.style.display = data.errorInfo ? "block" : "none";
                     if (data.statusRetrieved === false) {
                         elServerScriptStatus.innerText = "Failed to retrieve status";
@@ -1194,11 +1196,11 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
-				// Keep the companion control in sync
-				elColorControl2.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
+                // Keep the companion control in sync
+                elColorControl2.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
             }
         }));
-		colorPickers.push($('#property-color-control2').colpick({
+        colorPickers.push($('#property-color-control2').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
@@ -1212,8 +1214,8 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
-				// Keep the companion control in sync
-				elColorControl1.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
+                // Keep the companion control in sync
+                elColorControl1.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
 
             }
         }));
@@ -1478,9 +1480,9 @@ function loaded() {
     var elCollapsible = document.getElementsByClassName("section-header");
 
     var toggleCollapsedEvent = function(event) {
-		var element = event.target.parentNode.parentNode;
-		var isCollapsed = element.dataset.collapsed !== "true";
-		element.dataset.collapsed = isCollapsed ? "true" : false
+        var element = event.target.parentNode.parentNode;
+        var isCollapsed = element.dataset.collapsed !== "true";
+        element.dataset.collapsed = isCollapsed ? "true" : false
         element.setAttribute("collapsed", isCollapsed ? "true" : "false");
         element.getElementsByTagName("span")[0].textContent = isCollapsed ? "L" : "M";
     };

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -479,6 +479,7 @@ function loaded() {
     openEventBridge(function() {
 
         var allSections = [];
+		var elPropertiesList = document.getElementById("properties-list");
         var elID = document.getElementById("property-id");
         var elType = document.getElementById("property-type");
         var elTypeIcon = document.getElementById("type-icon");
@@ -565,7 +566,8 @@ function loaded() {
         var elJSONEditor = document.getElementById("userdata-editor");
         var elNewJSONEditor = document.getElementById('userdata-new-editor');
         var elColorSections = document.querySelectorAll(".color-section");
-        var elColor = document.getElementById("property-color");
+		var elColorControl1 = document.getElementById("property-color-control1");
+		var elColorControl2 = document.getElementById("property-color-control2");
         var elColorRed = document.getElementById("property-color-red");
         var elColorGreen = document.getElementById("property-color-green");
         var elColorBlue = document.getElementById("property-color-blue");
@@ -679,7 +681,8 @@ function loaded() {
                 data = JSON.parse(data);
                 if (data.type == "server_script_status") {
                     elServerScriptError.value = data.errorInfo;
-                    elServerScriptError.style.display = data.errorInfo ? "block" : "none";
+					// If we just set elServerScriptError's diplay to block or none, we still end up with it's parent contributing 21px bottom padding even when elServerScriptError is display:none. So set it's parent to block or none
+                    elServerScriptError.parentElement.style.display = data.errorInfo ? "block" : "none";
                     if (data.statusRetrieved === false) {
                         elServerScriptStatus.innerText = "Failed to retrieve status";
                     } else if (data.isRunning) {
@@ -705,6 +708,7 @@ function loaded() {
                         elTypeIcon.style.display = "none";
                         elType.innerHTML = "<i>No selection</i>";
                         elID.value = "";
+                        elPropertiesList.className = '';
                         disableProperties();
                     } else if (data.selections && data.selections.length > 1) {
                         deleteJSONEditor();
@@ -733,6 +737,7 @@ function loaded() {
                         elType.innerHTML = type + " (" + data.selections.length + ")";
                         elTypeIcon.innerHTML = ICON_FOR_TYPE[type];
                         elTypeIcon.style.display = "inline-block";
+                        elPropertiesList.className = '';
 
                         elID.value = "";
 
@@ -749,6 +754,7 @@ function loaded() {
                         lastEntityID = '"' + properties.id + '"';
                         elID.value = properties.id;
 
+                        elPropertiesList.className = properties.type + 'Menu';
                         elType.innerHTML = properties.type;
                         elTypeIcon.innerHTML = ICON_FOR_TYPE[properties.type];
                         elTypeIcon.style.display = "inline-block";
@@ -883,48 +889,20 @@ function loaded() {
                         elHyperlinkHref.value = properties.href;
                         elDescription.value = properties.description;
 
-                        for (var i = 0; i < allSections.length; i++) {
-                            for (var j = 0; j < allSections[i].length; j++) {
-                                allSections[i][j].style.display = 'none';
-                            }
-                        }
-
-                        for (var i = 0; i < elHyperlinkSections.length; i++) {
-                            elHyperlinkSections[i].style.display = 'table';
-                        }
 
                         if (properties.type == "Shape" || properties.type == "Box" || properties.type == "Sphere") {
-                            for (var i = 0; i < elShapeSections.length; i++) {
-                                elShapeSections[i].style.display = 'table';
-                            }
                             elShape.value = properties.shape;
                             setDropdownText(elShape);
-
-                        } else {
-                            for (var i = 0; i < elShapeSections.length; i++) {
-                                elShapeSections[i].style.display = 'none';
-                            }
                         }
 
                         if (properties.type == "Shape" || properties.type == "Box" || properties.type == "Sphere" || properties.type == "ParticleEffect") {
-                            for (var i = 0; i < elColorSections.length; i++) {
-                                elColorSections[i].style.display = 'table';
-                            }
                             elColorRed.value = properties.color.red;
                             elColorGreen.value = properties.color.green;
                             elColorBlue.value = properties.color.blue;
-                            elColor.style.backgroundColor = "rgb(" + properties.color.red + "," + properties.color.green + "," + properties.color.blue + ")";
-                        } else {
-                            for (var i = 0; i < elColorSections.length; i++) {
-                                elColorSections[i].style.display = 'none';
-                            }
+                            elColorControl1.style.backgroundColor = elColorControl2.style.backgroundColor = "rgb(" + properties.color.red + "," + properties.color.green + "," + properties.color.blue + ")";
                         }
 
                         if (properties.type == "Model") {
-                            for (var i = 0; i < elModelSections.length; i++) {
-                                elModelSections[i].style.display = 'table';
-                            }
-
                             elModelURL.value = properties.modelURL;
                             elShapeType.value = properties.shapeType;
                             setDropdownText(elShapeType);
@@ -942,20 +920,9 @@ function loaded() {
                             elModelOriginalTextures.value = properties.originalTextures;
                             setTextareaScrolling(elModelOriginalTextures);
                         } else if (properties.type == "Web") {
-                            for (var i = 0; i < elWebSections.length; i++) {
-                                elWebSections[i].style.display = 'table';
-                            }
-                            for (var i = 0; i < elHyperlinkSections.length; i++) {
-                                elHyperlinkSections[i].style.display = 'none';
-                            }
-
                             elWebSourceURL.value = properties.sourceUrl;
                             elWebDPI.value = properties.dpi;
                         } else if (properties.type == "Text") {
-                            for (var i = 0; i < elTextSections.length; i++) {
-                                elTextSections[i].style.display = 'table';
-                            }
-
                             elTextText.value = properties.text;
                             elTextLineHeight.value = properties.lineHeight.toFixed(4);
                             elTextFaceCamera.checked = properties.faceCamera;
@@ -967,10 +934,6 @@ function loaded() {
                             elTextBackgroundColorGreen.value = properties.backgroundColor.green;
                             elTextBackgroundColorBlue.value = properties.backgroundColor.blue;
                         } else if (properties.type == "Light") {
-                            for (var i = 0; i < elLightSections.length; i++) {
-                                elLightSections[i].style.display = 'table';
-                            }
-
                             elLightSpotLight.checked = properties.isSpotlight;
 
                             elLightColor.style.backgroundColor = "rgb(" + properties.color.red + "," + properties.color.green + "," + properties.color.blue + ")";
@@ -983,10 +946,6 @@ function loaded() {
                             elLightExponent.value = properties.exponent.toFixed(2);
                             elLightCutoff.value = properties.cutoff.toFixed(2);
                         } else if (properties.type == "Zone") {
-                            for (var i = 0; i < elZoneSections.length; i++) {
-                                elZoneSections[i].style.display = 'table';
-                            }
-
                             elZoneStageSunModelEnabled.checked = properties.stage.sunModelEnabled;
                             elZoneKeyLightColor.style.backgroundColor = "rgb(" + properties.keyLight.color.red + "," + properties.keyLight.color.green + "," + properties.keyLight.color.blue + ")";
                             elZoneKeyLightColorRed.value = properties.keyLight.color.red;
@@ -1023,10 +982,6 @@ function loaded() {
 
                             showElements(document.getElementsByClassName('skybox-section'), elZoneBackgroundMode.value == 'skybox');
                         } else if (properties.type == "PolyVox") {
-                            for (var i = 0; i < elPolyVoxSections.length; i++) {
-                                elPolyVoxSections[i].style.display = 'table';
-                            }
-
                             elVoxelVolumeSizeX.value = properties.voxelVolumeSize.x.toFixed(2);
                             elVoxelVolumeSizeY.value = properties.voxelVolumeSize.y.toFixed(2);
                             elVoxelVolumeSizeZ.value = properties.voxelVolumeSize.z.toFixed(2);
@@ -1225,20 +1180,41 @@ function loaded() {
         elColorRed.addEventListener('change', colorChangeFunction);
         elColorGreen.addEventListener('change', colorChangeFunction);
         elColorBlue.addEventListener('change', colorChangeFunction);
-        colorPickers.push($('#property-color').colpick({
+        colorPickers.push($('#property-color-control1').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
-                $('#property-color').attr('active', 'true');
+                $('#property-color-control1').attr('active', 'true');
             },
             onHide: function(colpick) {
-                $('#property-color').attr('active', 'false');
+                $('#property-color-control1').attr('active', 'false');
             },
             onSubmit: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
                 $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
+				// Keep the companion control in sync
+				elColorControl2.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
+            }
+        }));
+		colorPickers.push($('#property-color-control2').colpick({
+            colorScheme: 'dark',
+            layout: 'hex',
+            color: '000000',
+            onShow: function(colpick) {
+                $('#property-color-control2').attr('active', 'true');
+            },
+            onHide: function(colpick) {
+                $('#property-color-control2').attr('active', 'false');
+            },
+            onSubmit: function(hsb, hex, rgb, el) {
+                $(el).css('background-color', '#' + hex);
+                $(el).colpickHide();
+                emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
+				// Keep the companion control in sync
+				elColorControl1.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
+
             }
         }));
 
@@ -1502,11 +1478,9 @@ function loaded() {
     var elCollapsible = document.getElementsByClassName("section-header");
 
     var toggleCollapsedEvent = function(event) {
-        var element = event.target;
-        if (element.nodeName !== "DIV") {
-            element = element.parentNode;
-        }
-        var isCollapsed = element.getAttribute("collapsed") !== "true";
+		var element = event.target.parentNode.parentNode;
+		var isCollapsed = element.dataset.collapsed !== "true";
+		element.dataset.collapsed = isCollapsed ? "true" : false
         element.setAttribute("collapsed", isCollapsed ? "true" : "false");
         element.getElementsByTagName("span")[0].textContent = isCollapsed ? "L" : "M";
     };


### PR DESCRIPTION

[TestPlan_21356.pdf](https://github.com/highfidelity/hifi/files/1137176/TestPlan_21356.pdf)
Made changes to the 3 sub files for the properties tabs. Although
visually the existing menu looked like it was in different sections,
structurally it was all just one run of item after item, with a fair
amount of div-itis. I added in fieldsets to provide true groups and
replaced much of the div-ities with additional feildsets as they are the
semantic element to use here.

Rather than doing the reordering in javascript, the js simply adds or changes a class on the #properties-list div. The CSS then uses Flexblox ordering to reorder the sections based on that class. This way there is only one dom manipulation rather than many so it is much less expensive.