### PR TITLE
Fix static plugin initialization on Linux

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -486,11 +486,11 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     Setting::init();
 
     // Tell the plugin manager about our statically linked plugins
-    PluginManager::setInputPluginProvider([] { return getInputPlugins(); });
-    PluginManager::setDisplayPluginProvider([] { return getDisplayPlugins(); });
-    PluginManager::setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });
-
-    if (auto steamClient = PluginManager::getInstance()->getSteamClientPlugin()) {
+    auto pluginManager = PluginManager::getInstance();
+    pluginManager->setInputPluginProvider([] { return getInputPlugins(); });
+    pluginManager->setDisplayPluginProvider([] { return getDisplayPlugins(); });
+    pluginManager->setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });
+    if (auto steamClient = pluginManager->getSteamClientPlugin()) {
         steamClient->init();
     }
 

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -23,10 +23,6 @@
 #include "InputPlugin.h"
 #include "PluginLogging.h"
 
-DisplayPluginProvider PluginManager::_displayPluginProvider = []()->DisplayPluginList { return {}; };
-InputPluginProvider PluginManager::_inputPluginProvider = []()->InputPluginList { return {}; };
-CodecPluginProvider PluginManager::_codecPluginProvider = []()->CodecPluginList { return {}; };
-InputPluginSettingsPersister PluginManager::_inputSettingsPersister = [](const InputPluginList& list) {};
 
 void PluginManager::setDisplayPluginProvider(const DisplayPluginProvider& provider) {
     _displayPluginProvider = provider;

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -33,16 +33,15 @@ public:
     void shutdown();
 
     // Application that have statically linked plugins can expose them to the plugin manager with these function
-    static void setDisplayPluginProvider(const DisplayPluginProvider& provider);
-    static void setInputPluginProvider(const InputPluginProvider& provider);
-    static void setCodecPluginProvider(const CodecPluginProvider& provider);
-    static void setInputPluginSettingsPersister(const InputPluginSettingsPersister& persister);
+    void setDisplayPluginProvider(const DisplayPluginProvider& provider);
+    void setInputPluginProvider(const InputPluginProvider& provider);
+    void setCodecPluginProvider(const CodecPluginProvider& provider);
+    void setInputPluginSettingsPersister(const InputPluginSettingsPersister& persister);
     
 private:
-    static DisplayPluginProvider _displayPluginProvider;
-    static InputPluginProvider _inputPluginProvider;  
-    static CodecPluginProvider _codecPluginProvider;
-    static InputPluginSettingsPersister _inputSettingsPersister;
-
+    DisplayPluginProvider _displayPluginProvider { []()->DisplayPluginList { return {}; } };
+    InputPluginProvider _inputPluginProvider { []()->InputPluginList { return {}; } };
+    CodecPluginProvider _codecPluginProvider { []()->CodecPluginList { return {}; } };
+    InputPluginSettingsPersister _inputSettingsPersister { [](const InputPluginList& list) {} };
     PluginContainer* _container { nullptr };
 };


### PR DESCRIPTION
There's some bizarre static initialization issue on Linux with the new way we're exposing statically linked plugins.  However there's no need for the lambdas to be static variables within a singleton, they can just be regular variables and this seems to resolve the issue.  

## Testing

The desktop display should function on Windows, Mac and Linux builds.  