### PR TITLE
Fix toolbar button mouse click when they were added via the tablet scripting interface

### DIFF
--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -623,7 +623,8 @@ TabletButtonProxy* TabletProxy::addButton(const QVariant& properties) {
         auto toolbarProxy = DependencyManager::get<TabletScriptingInterface>()->getSystemToolbarProxy();
         if (toolbarProxy) {
             // copy properties from tablet button proxy to toolbar button proxy.
-            toolbarProxy->addButton(tabletButtonProxy->getProperties());
+            auto toolbarButtonProxy = toolbarProxy->addButton(tabletButtonProxy->getProperties());
+            tabletButtonProxy->setToolbarButtonProxy(toolbarButtonProxy);
         }
     }
     return tabletButtonProxy.data();


### PR DESCRIPTION
There was some logic that got missed in the refactor.  This restores it so that scripts that use the tablet interface to add a button still get a click event when the tablet is acting in toolbar mode.

## Testing

Click on one of the default toolbar icons.  In the current dev build it will do nothing.  In this build it should trigger the action for the button.  