### PR TITLE
WL21387 - Avatar Bookmarks now save Attachment Data and scale

### DIFF
--- a/interface/src/AvatarBookmarks.h
+++ b/interface/src/AvatarBookmarks.h
@@ -34,6 +34,7 @@ private:
     const QString AVATARBOOKMARKS_FILENAME = "avatarbookmarks.json";
     const QString ENTRY_AVATAR_URL = "avatarUrl";
     const QString ENTRY_AVATAR_ATTACHMENTS = "attachments";
+    const QString ENTRY_AVATAR_SCALE = "avatarScale";
     const QString ENTRY_VERSION = "version";
 
     const int AVATAR_BOOKMARK_VERSION = 3;

--- a/interface/src/AvatarBookmarks.h
+++ b/interface/src/AvatarBookmarks.h
@@ -21,18 +21,22 @@ class AvatarBookmarks: public Bookmarks, public  Dependency {
 
 public:
     AvatarBookmarks();
-
-    void setupMenus(Menu* menubar, MenuWrapper* menu) override;
+    void setupMenus(Menu* menubar, MenuWrapper* menu);
 
 public slots:
     void addBookmark();
 
 protected:
-    void addBookmarkToMenu(Menu* menubar, const QString& name, const QString& address) override;
+    void addBookmarkToMenu(Menu* menubar, const QString& name, const QVariant& bookmark);
     void readFromFile();
 
 private:
     const QString AVATARBOOKMARKS_FILENAME = "avatarbookmarks.json";
+    const QString ENTRY_AVATAR_URL = "avatarUrl";
+    const QString ENTRY_AVATAR_ATTACHMENTS = "attachments";
+    const QString ENTRY_VERSION = "version";
+
+    const int AVATAR_BOOKMARK_VERSION = 3;
 
 private slots:
     void changeToBookmarkedAvatar();

--- a/interface/src/Bookmarks.cpp
+++ b/interface/src/Bookmarks.cpp
@@ -28,49 +28,6 @@ Bookmarks::Bookmarks() :
 _isMenuSorted(false)
 {
 }
-/**
-void Bookmarks::setupMenus(Menu* menubar, MenuWrapper* menu) {
-    // Enable/Disable menus as needed
-    enableMenuItems(_bookmarks.count() > 0);
-
-    // Load Bookmarks
-    for (auto it = _bookmarks.begin(); it != _bookmarks.end(); ++it) {
-        QString bookmarkName = it.key();
-
-        QMap<QString, QVariant> *avatarData;
-        QVariant::Type type = it.value().type;
-
-        if (type == QVariant::Map){
-            QMap<QString, QObject>& map = it.value().toMap;
-
-            // Convert to map and get version.-
-            if (map.contains("version")){
-                auto version = map.find("version");
-
-                if (version == AVATAR_BOOKMARK_VERSION) {
-                    addBookmarkToMenu(menubar, bookmarkName, map);
-                }
-            }
-            else {
-                //Not valid. Skip?
-            }
-        }
-        else if (type == QVariant::String) {
-            // Bookmark String type, generic usually for avatars or locations.
-            QString bookmarkAddress = it.value().toString();
-            avatarData = new QVariantMap;
-
-            avatarData->insert();
-
-            addBookmarkToMenu(menubar, bookmarkName, bookmarkAddress);
-        }
-        else {
-            // Unexpected Type
-        }
-
-    }
-}
-*/
 void Bookmarks::deleteBookmark() {
     QStringList bookmarkList;
     QList<QAction*> menuItems = _bookmarksMenu->actions();

--- a/interface/src/Bookmarks.h
+++ b/interface/src/Bookmarks.h
@@ -27,18 +27,20 @@ class Bookmarks: public QObject {
 public:
     Bookmarks();
 
-    virtual void setupMenus(Menu* menubar, MenuWrapper* menu);
+    virtual void setupMenus(Menu* menubar, MenuWrapper* menu) = 0;
     QString addressForBookmark(const QString& name) const;
 
 protected:
-    virtual void addBookmarkToFile(const QString& bookmarkName, const QString& bookmarkAddress);
-    virtual void addBookmarkToMenu(Menu* menubar, const QString& name, const QString& address) = 0;
+    void addBookmarkToFile(const QString& bookmarkName, const QVariant& bookmark);
+    virtual void addBookmarkToMenu(Menu* menubar, const QString& name, const QVariant& bookmark) = 0;
     void enableMenuItems(bool enabled);
-    void readFromFile();
-    void insert(const QString& name, const QString& address);  // Overwrites any existing entry with same name.
+    virtual void readFromFile();
+    void insert(const QString& name, const QVariant& address);  // Overwrites any existing entry with same name.
     void sortActions(Menu* menubar, MenuWrapper* menu);
     int getMenuItemLocation(QList<QAction*> actions, const QString& name) const;
-
+    
+    bool Bookmarks::contains(const QString& name) const;
+    
     QVariantMap _bookmarks;  // { name: url, ... }
     QPointer<MenuWrapper> _bookmarksMenu;
     QPointer<QAction> _deleteBookmarksAction;
@@ -50,7 +52,6 @@ protected slots:
 
 private:
     void remove(const QString& name);
-    bool contains(const QString& name) const;
     static bool sortOrder(QAction* a, QAction* b);
 
     void persistToFile();

--- a/interface/src/LocationBookmarks.cpp
+++ b/interface/src/LocationBookmarks.cpp
@@ -41,13 +41,25 @@ void LocationBookmarks::setupMenus(Menu* menubar, MenuWrapper* menu) {
     _deleteBookmarksAction = menubar->addActionToQMenuAndActionHash(menu, MenuOption::DeleteBookmark);
     QObject::connect(_deleteBookmarksAction, SIGNAL(triggered()), this, SLOT(deleteBookmark()), Qt::QueuedConnection);
 
-    Bookmarks::setupMenus(menubar, menu);
+    // Legacy Location to Bookmark.
+
+    // Enable/Disable menus as needed
+    enableMenuItems(_bookmarks.count() > 0);
+
+    // Load Bookmarks
+    for (auto it = _bookmarks.begin(); it != _bookmarks.end(); ++it) {
+        QString bookmarkName = it.key();
+        QString bookmarkAddress = it.value().toString();
+        addBookmarkToMenu(menubar, bookmarkName, bookmarkAddress);
+    }
+
     Bookmarks::sortActions(menubar, _bookmarksMenu);
 }
 
 void LocationBookmarks::setHomeLocation() {
     auto addressManager = DependencyManager::get<AddressManager>();
     QString bookmarkAddress = addressManager->currentAddress().toString();
+
     Bookmarks::addBookmarkToFile(HOME_BOOKMARK, bookmarkAddress);
 }
 
@@ -74,7 +86,7 @@ void LocationBookmarks::addBookmark() {
     Bookmarks::addBookmarkToFile(bookmarkName, bookmarkAddress);
 }
 
-void LocationBookmarks::addBookmarkToMenu(Menu* menubar, const QString& name, const QString& address) {
+void LocationBookmarks::addBookmarkToMenu(Menu* menubar, const QString& name, const QVariant& address) {
     QAction* teleportAction = _bookmarksMenu->newAction();
     teleportAction->setData(address);
     connect(teleportAction, SIGNAL(triggered()), this, SLOT(teleportToBookmark()));

--- a/interface/src/LocationBookmarks.h
+++ b/interface/src/LocationBookmarks.h
@@ -22,14 +22,14 @@ class LocationBookmarks : public Bookmarks, public  Dependency  {
 public:
     LocationBookmarks();
 
-    void setupMenus(Menu* menubar, MenuWrapper* menu) override;
+    void setupMenus(Menu* menubar, MenuWrapper* menu);
     static const QString HOME_BOOKMARK;
 
 public slots:
     void addBookmark();
 
 protected:
-    void addBookmarkToMenu(Menu* menubar, const QString& name, const QString& address) override;
+    void addBookmarkToMenu(Menu* menubar, const QString& name, const QVariant& address);
 
 private:
     const QString LOCATIONBOOKMARKS_FILENAME = "bookmarks.json";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2524,6 +2524,21 @@ bool MyAvatar::getFlyingEnabled() {
     return _enableFlying;
 }
 
+// Public interface for targetscale
+float MyAvatar::getAvatarScale() {
+    return getTargetScale();
+}
+
+void MyAvatar::setAvatarScale(float val) {
+
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setScale", Q_ARG(float, val));
+        return;
+    }
+
+    setTargetScale(val);
+}
+
 void MyAvatar::setCollisionsEnabled(bool enabled) {
 
     if (QThread::currentThread() != thread()) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2532,7 +2532,7 @@ float MyAvatar::getAvatarScale() {
 void MyAvatar::setAvatarScale(float val) {
 
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setScale", Q_ARG(float, val));
+        QMetaObject::invokeMethod(this, "setAvatarScale", Q_ARG(float, val));
         return;
     }
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -366,7 +366,7 @@ public:
     float getDriveKey(DriveKeys key) const;
     Q_INVOKABLE float getRawDriveKey(DriveKeys key) const;
     void relayDriveKeysToCharacterController();
-
+    
     Q_INVOKABLE void disableDriveKey(DriveKeys key);
     Q_INVOKABLE void enableDriveKey(DriveKeys key);
     Q_INVOKABLE bool isDriveKeyDisabled(DriveKeys key) const;
@@ -511,6 +511,9 @@ public:
     Q_INVOKABLE bool isInAir();
     Q_INVOKABLE void setFlyingEnabled(bool enabled);
     Q_INVOKABLE bool getFlyingEnabled();
+
+    Q_INVOKABLE float getAvatarScale();
+    Q_INVOKABLE void setAvatarScale(float scale);
 
     Q_INVOKABLE void setCollisionsEnabled(bool enabled);
     Q_INVOKABLE bool getCollisionsEnabled();


### PR DESCRIPTION
Old avatar and location bookmarks should still work.
To test Access the Avatar menu and save / load / delete avatars. This should save an avatarbookmarks.json file under Roaming Appdata.

Also test Location Bookmarks again, as this update refactored the entire Bookmark system lightly.

Changes:

- Now Saves Attachments with Avatar Bookmark
- Now Saves Scale with Avatar Bookmark
- Added MyAvatar.getAvatarScale and  MyAvatar.setAvatarScale for programatic and script access to getTargetScale and setTargetScale / scale.

Test the following:

- Save Avatar Bookmark
- Load Avatar Bookmark
- Delete Avatar Bookmark
- Access MyAvatar.getAvatarScale() and see value being same as MyAvatar.scale
- MyAvatar.setAvatarScale(float) and mirror with MyAvatar.scale = float
- Save Place Bookmark
- Load Place Bookmark
- Delete Place Bookmark