### PR TITLE
Spectator camera window resize

### DIFF
--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -100,10 +100,10 @@
     var cameraRotation;
     var cameraPosition;
     //The negative y dimension for viewFinderOverlay is necessary for now due to the way Image3DOverlay
-    //    draws textures, but should be looked into at some point. Also the z dimension doesn't matter
-    //    so it is set to the glassPaneWidth
+    //    draws textures, but should be looked into at some point. Also the z dimension shouldn't affect
+    //    the overlay since it is an Image3DOverlay so it is set to 0
     var glassPaneWidth = 0.16;
-    var viewFinderOverlayDim = { x: glassPaneWidth, y: -glassPaneWidth, z: glassPaneWidth };
+    var viewFinderOverlayDim = { x: glassPaneWidth, y: -glassPaneWidth, z: 0 };
     function spectatorCameraOn() {
         // Sets the special texture size based on the window it is displayed in, which doesn't include the menu bar
         spectatorFrameRenderConfig.resetSizeSpectatorCamera(Window.innerWidth, Window.innerHeight);
@@ -307,11 +307,11 @@
         var squareScale = verticalScale * (1 + (1 - (1 / (geometryChanged.width / geometryChanged.height))));
 
         if (geometryChanged.height > geometryChanged.width) { //vertical window size
-            viewFinderOverlayDim = { x: (glassPaneWidth * verticalScale), y: (-glassPaneWidth * verticalScale), z: glassPaneWidth };
+            viewFinderOverlayDim = { x: (glassPaneWidth * verticalScale), y: (-glassPaneWidth * verticalScale), z: 0 };
         } else if ((geometryChanged.width / geometryChanged.height) < glassPaneRatio) { //square-ish window size, in-between vertical and horizontal
-            viewFinderOverlayDim = { x: (glassPaneWidth * squareScale), y: (-glassPaneWidth * squareScale), z: glassPaneWidth };
+            viewFinderOverlayDim = { x: (glassPaneWidth * squareScale), y: (-glassPaneWidth * squareScale), z: 0 };
         } else { //horizontal window size
-            viewFinderOverlayDim = { x: glassPaneWidth, y: -glassPaneWidth, z: glassPaneWidth };
+            viewFinderOverlayDim = { x: glassPaneWidth, y: -glassPaneWidth, z: 0 };
         }
 
         // The only way I found to update the viewFinderOverlay without turning the spectator camera on and off is to delete and recreate the

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -56,8 +56,6 @@
     var spectatorFrameRenderConfig = Render.getConfig("SecondaryCameraFrame");
     var beginSpectatorFrameRenderConfig = Render.getConfig("BeginSecondaryCamera");
     var viewFinderOverlay = false;
-    var backdrop = false;
-    var backdropAspect = false;
     var camera = false;
     var cameraIsDynamic = false;
     var lastCameraPosition = false;
@@ -135,40 +133,6 @@
             localPosition: { x: 0, y: 0.18, z: 0 },
             dimensions: viewFinderOverlayDim
         });
-        var backdropProp = {
-            parentID: camera,
-            "color": {
-                "blue": 0,
-                "green": 0,
-                "red": 0
-            },
-            localPosition: {x: 0, y: 0.18, z: -.0075},
-            "dimensions": {
-                "x": 0.2,
-                "y": 0.2,
-                "z": 0.01
-            },
-            "shape": "Cube",
-            "type": "Box"
-        }
-        var backdropAspectProp = {
-            parentID: camera,
-            "color": {
-                "blue": 255,
-                "green": 255,
-                "red": 255
-            },
-            localPosition: { x: 0, y: 0.18, z: -.0073 },
-            "dimensions": {
-                "x": 0.2,
-                "y": 0.1125,
-                "z": 0.01
-            },
-            "shape": "Cube",
-            "type": "Box"
-        }
-        backdrop = Entities.addEntity(backdropProp);
-        backdropAspect = Entities.addEntity(backdropAspectProp);
         setDisplay(monitorShowsCameraView);
     }
 
@@ -197,16 +161,8 @@
         if (viewFinderOverlay) {
             Overlays.deleteOverlay(viewFinderOverlay);
         }
-        if (backdrop) {
-            Overlays.deleteOverlay(backdrop);
-        }
-        if (backdropAspect) {
-            Overlays.deleteOverlay(backdropAspect);
-        }
         camera = false;
         viewFinderOverlay = false;
-        backdrop = false;
-        backdropAspect = false;
         setDisplay(monitorShowsCameraView);
     }
 
@@ -270,8 +226,6 @@
         Controller.keyPressEvent.connect(keyPressEvent);
         HMD.displayModeChanged.connect(onHMDChanged);
         viewFinderOverlay = false;
-        backdrop = false;
-        backdropAspect = false;
         camera = false;
         registerButtonMappings();
     }

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -95,7 +95,7 @@
     var farClipPlaneDistance = 100.0;
     var cameraRotation;
     var cameraPosition;
-    var viewFinderOverlayDim = { x: 0.2, y: -0.2, z: 0.2 };
+    var viewFinderOverlayDim = { x: 0.16, y: -0.16, z: 0.16 };
     function spectatorCameraOn() {
         // Set the special texture size based on the window in which it will eventually be displayed.
         spectatorFrameRenderConfig.resetSizeSpectatorCamera(Window.innerWidth, Window.innerHeight);
@@ -110,13 +110,8 @@
             "angularDamping": 0.98000001907348633,
             "collisionsWillMove": 0,
             "damping": 0.98000001907348633,
-            "dimensions": {
-                "x": .1,
-                "y": .1,
-                "z": .1
-            },
             "dynamic": cameraIsDynamic,
-            "modelURL": "http://hifi-content.s3.amazonaws.com/alan/dev/spectator-camera.fbx",
+            "modelURL": "http://hifi-content.s3.amazonaws.com/alan/dev/spectator-camera.fbx?1",
             "rotation": cameraRotation,
             "position": cameraPosition,
             "shapeType": "simple-compound",
@@ -130,7 +125,7 @@
             parentID: camera,
             alpha: 1,
             rotation: cameraRotation,
-            localPosition: { x: 0, y: 0.18, z: 0 },
+            localPosition: { x: 0.007, y: 0.15, z: -0.005 },
             dimensions: viewFinderOverlayDim
         });
         setDisplay(monitorShowsCameraView);
@@ -289,8 +284,8 @@
             parentID: camera,
             alpha: 1,
             rotation: cameraRotation,
-            localPosition: { x: 0, y: 0.18, z: 0 },
-            dimensions: { x: 0.2, y: -0.2, z: 0.2 }
+            localPosition: { x: 0.007, y: 0.15, z: -0.005 },
+            dimensions: { x: 0.16, y: -0.16, z: 0.16 }
         });
         spectatorFrameRenderConfig.resetSizeSpectatorCamera(geometryChanged.width, geometryChanged.height);
         setDisplay(monitorShowsCameraView);
@@ -300,11 +295,11 @@
         var squareScale = verticalScale * (1 + (1 - (1 / (geometryChanged.width / geometryChanged.height))));
 
         if (geometryChanged.height > geometryChanged.width) { //vertical window size
-            viewFinderOverlayDim = { x: (0.2 * verticalScale), y: (-0.2 * verticalScale), z: 0.02 };
+            viewFinderOverlayDim = { x: (0.16 * verticalScale), y: (-0.16 * verticalScale), z: 0.16 };
         } else if ((geometryChanged.width / geometryChanged.height) < previewHolderRatio) { //square window size
-            viewFinderOverlayDim = { x: (0.2 * squareScale), y: (-0.2 * squareScale), z: 0.02 };
+            viewFinderOverlayDim = { x: (0.16 * squareScale), y: (-0.16 * squareScale), z: 0.16 };
         } else { //horizontal window size
-            viewFinderOverlayDim = { x: 0.2, y: -0.2, z: 0.02 };
+            viewFinderOverlayDim = { x: 0.16, y: -0.16, z: 0.16 };
         }
         Overlays.editOverlay(viewFinderOverlay, { dimensions: viewFinderOverlayDim });
     }


### PR DESCRIPTION
Adds functionality to the viewFinderOverlay that displays the preview in the glass pane of the spectator camera appropriately when you resize your window.

To Test:
-Click on the spectator camera icon and turn it on
-Check to see that the preview above the spectator camera remains inside the glass pane
-Check to see if the preview isn't distorting the texture (i.e. a cube in front of the camera remains square in the preview)
-With the spectator camera on, resize the window and notice how the preview changes
-The preview's dimensions should match that of the window's dimensions
-Try this for vertical, square, and horizontal window dimensions
-Make sure that turning the camera on and off while in different windows doesn't change the preview
-Make sure that the preview never grows bigger than the glass pane or distorts the texture