### PR TITLE
Fix toolbar button activation states

### DIFF
--- a/scripts/system/audio.js
+++ b/scripts/system/audio.js
@@ -15,6 +15,7 @@
 
 var TABLET_BUTTON_NAME = "AUDIO";
 var HOME_BUTTON_TEXTURE = "http://hifi-content.s3.amazonaws.com/alan/dev/tablet-with-home-button.fbx/tablet-with-home-button.fbm/button-root.png";
+var AUDIO_QML_SOURCE = "../audio/Audio.qml";
 
 var MUTE_ICONS = {
     icon: "icons/tablet-icons/mic-mute-i.svg",
@@ -34,7 +35,6 @@ function onMuteToggled() {
     }
 }
 
-var shouldActivateButton = false;
 var onAudioScreen = false;
 
 function onClicked() {
@@ -44,18 +44,14 @@ function onClicked() {
     } else {
         var entity = HMD.tabletID;
         Entities.editEntity(entity, { textures: JSON.stringify({ "tex.close": HOME_BUTTON_TEXTURE }) });
-        shouldActivateButton = true;
-        shouldActivateButton = true;
-        tablet.loadQMLSource("../audio/Audio.qml");
-        onAudioScreen = true;
+        tablet.loadQMLSource(AUDIO_QML_SOURCE);
     }
 }
 
 function onScreenChanged(type, url) {
+    onAudioScreen = (type === "QML" && url === AUDIO_QML_SOURCE);
     // for toolbar mode: change button to active when window is first openend, false otherwise.
-    button.editProperties({isActive: shouldActivateButton});
-    shouldActivateButton = false;
-    onAudioScreen = false;
+    button.editProperties({isActive: onAudioScreen});
 }
 
 var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");

--- a/scripts/system/help.js
+++ b/scripts/system/help.js
@@ -40,7 +40,8 @@
     }
 
     function onScreenChanged(type, url) {
-        onHelpScreen = false;
+        onHelpScreen = type === "Web" && url.startsWith("../../../html/tabletHelp.html");
+        button.editProperties({ isActive: onHelpScreen });
     }
 
     button.clicked.connect(onClicked);

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -52,17 +52,11 @@ function onMessageBoxClosed(id, button) {
 
 Window.messageBoxClosed.connect(onMessageBoxClosed);
 
-var shouldActivateButton = false;
 var onMarketplaceScreen = false;
 
 function showMarketplace() {
     UserActivityLogger.openedMarketplace();
-
-    shouldActivateButton = true;
-
     tablet.gotoWebScreen(MARKETPLACE_URL_INITIAL, MARKETPLACES_INJECT_SCRIPT_URL);
-    onMarketplaceScreen = true;
-
     tablet.webEventReceived.connect(function (message) {
 
         if (message === GOTO_DIRECTORY) {
@@ -122,7 +116,6 @@ function onClick() {
     if (onMarketplaceScreen) {
         // for toolbar-mode: go back to home screen, this will close the window.
         tablet.gotoHomeScreen();
-        onMarketplaceScreen = false;
     } else {
         var entity = HMD.tabletID;
         Entities.editEntity(entity, {textures: JSON.stringify({"tex.close": HOME_BUTTON_TEXTURE})});
@@ -131,10 +124,9 @@ function onClick() {
 }
 
 function onScreenChanged(type, url) {
+    onMarketplaceScreen = type === "Web" && url === MARKETPLACE_URL_INITIAL 
     // for toolbar mode: change button to active when window is first openend, false otherwise.
-    marketplaceButton.editProperties({isActive: shouldActivateButton});
-    shouldActivateButton = false;
-    onMarketplaceScreen = false;
+    marketplaceButton.editProperties({isActive: onMarketplaceScreen});
 }
 
 marketplaceButton.clicked.connect(onClick);

--- a/scripts/system/menu.js
+++ b/scripts/system/menu.js
@@ -21,7 +21,6 @@ var HOME_BUTTON_TEXTURE = "http://hifi-content.s3.amazonaws.com/alan/dev/tablet-
         sortOrder: 3
     });
 
-    var shouldActivateButton = false;
     var onMenuScreen = false;
 
     function onClicked() {
@@ -31,17 +30,13 @@ var HOME_BUTTON_TEXTURE = "http://hifi-content.s3.amazonaws.com/alan/dev/tablet-
         } else {
             var entity = HMD.tabletID;
             Entities.editEntity(entity, {textures: JSON.stringify({"tex.close": HOME_BUTTON_TEXTURE})});
-            shouldActivateButton = true;
             tablet.gotoMenuScreen();
-            onMenuScreen = true;
         }
     }
 
     function onScreenChanged(type, url) {
-        // for toolbar mode: change button to active when window is first openend, false otherwise.
-        button.editProperties({isActive: shouldActivateButton});
-        shouldActivateButton = false;
-        onMenuScreen = false;
+        onMenuScreen = type === "Menu";
+        button.editProperties({isActive: onMenuScreen});
     }
 
     button.clicked.connect(onClicked);

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -40,7 +40,7 @@ var HOVER_TEXTURES = {
 var UNSELECTED_COLOR = { red: 0x1F, green: 0xC6, blue: 0xA6};
 var SELECTED_COLOR = {red: 0xF3, green: 0x91, blue: 0x29};
 var HOVER_COLOR = {red: 0xD0, green: 0xD0, blue: 0xD0}; // almost white for now
-
+var PAL_QML_SOURCE = "../Pal.qml";
 var conserveResources = true;
 
 Script.include("/~/system/libraries/controllers.js");
@@ -727,17 +727,14 @@ function tabletVisibilityChanged() {
 }
 
 var onPalScreen = false;
-var shouldActivateButton = false;
 
 function onTabletButtonClicked() {
     if (onPalScreen) {
         // for toolbar-mode: go back to home screen, this will close the window.
         tablet.gotoHomeScreen();
     } else {
-        shouldActivateButton = true;
-        tablet.loadQMLSource("../Pal.qml");
+        tablet.loadQMLSource(PAL_QML_SOURCE);
         tablet.tabletShownChanged.connect(tabletVisibilityChanged);
-        onPalScreen = true;
         Users.requestsDomainListData = true;
         populateNearbyUserList();
         isWired = true;
@@ -765,14 +762,13 @@ function wireEventBridge(on) {
 }
 
 function onTabletScreenChanged(type, url) {
-    wireEventBridge(shouldActivateButton);
+    onPalScreen = (type === "QML" && url === PAL_QML_SOURCE);
+    wireEventBridge(onPalScreen);
     // for toolbar mode: change button to active when window is first openend, false otherwise.
-    button.editProperties({isActive: shouldActivateButton});
-    shouldActivateButton = false;
-    onPalScreen = false;
+    button.editProperties({isActive: onPalScreen});
 
     // disable sphere overlays when not on pal screen.
-    if (type !== "QML" || url !== "../Pal.qml") {
+    if (!onPalScreen) {
         off();
     }
 }

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -377,18 +377,15 @@ function fillImageDataFromPrevious() {
 
 var SNAPSHOT_REVIEW_URL = Script.resolvePath("html/SnapshotReview.html");
 var isInSnapshotReview = false;
-var shouldActivateButton = false;
 function onButtonClicked() {
     if (isInSnapshotReview){
         // for toolbar-mode: go back to home screen, this will close the window.
         tablet.gotoHomeScreen();
     } else {
-        shouldActivateButton = true;
         fillImageDataFromPrevious();
         tablet.gotoWebScreen(SNAPSHOT_REVIEW_URL);
         tablet.webEventReceived.connect(onMessage);
         HMD.openTablet();
-        isInSnapshotReview = true;
     }
 }
 
@@ -662,11 +659,10 @@ function maybeDeleteSnapshotStories() {
     storyIDsToMaybeDelete = [];
 }
 function onTabletScreenChanged(type, url) {
-    button.editProperties({ isActive: shouldActivateButton });
-    shouldActivateButton = false;
-    if (isInSnapshotReview) {
+    isInSnapshotReview = (type === "Web" && url === SNAPSHOT_REVIEW_URL);
+    button.editProperties({ isActive: isInSnapshotReview });
+    if (!isInSnapshotReview) {
         tablet.webEventReceived.disconnect(onMessage);
-        isInSnapshotReview = false;
     }
 }
 function onUsernameChanged() {


### PR DESCRIPTION
Fix for [FB5640](https://highfidelity.fogbugz.com/f/cases/5640).  This bug popped up during the refactor of the Tablet and Toolbar scripting interfaces in #10792. It turns out the scripts that were using the Tablet interface we relying on a very specific ordering of operations.  Specifically, when a button was clicked and triggered the `onClicked` method in a script, the script would then call something like `tablet.gotoMenuScreen();`.  The tablet then emits a `screenChanged` event in response to the tablet location being changed, and all these scripts had behavior triggered on this event.  

However, they all relied on the fact that the `onScreenChanged` handler would be called synchronously when you used a `tablet.gotoXXX` method, i.e. while you were still in the `onClicked` handler.  This producing a complicated order of operations where a button would get activated, flags would get cleared, and then the `onClicked` would re-set some of those flags to true.  

However, the refactor meant that the `onScreenChanged` handler is now called asynchronously, well after `onClicked` has returned.  As a result the logic in the scripts needs to change, so that rather than clearing flags and then resetting them further up the stack, we just use one flag and we explicitly set it in the `onScreenChanged` handler based on the inputs `type` and `url`.  

## Testing

Open Interface and click on any one of the buttons "Menu", "Audio", "People", "Help" or "Market".  

In the current dev build, clicking on a button will show the appropriate dialog, but the button state isn't set to active.  Additionally, clicking the button again may or may not close it.

In this PR, the corresponding button should light up, as well as properly un-light if you close the window manually.  Additionally, if you click the button while it's lit, it should also close the corresponding window.  
