### PR TITLE
fix avatar mixer sending empty avatar identities

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -285,6 +285,13 @@ void AvatarMixer::start() {
 // is guaranteed to not be accessed by other thread
 void AvatarMixer::manageIdentityData(const SharedNodePointer& node) {
     AvatarMixerClientData* nodeData = reinterpret_cast<AvatarMixerClientData*>(node->getLinkedData());
+
+    // there is no need to manage identity data we haven't received yet
+    // so bail early if we've never received an identity packet for this avatar
+    if (!nodeData->getAvatar().hasProcessedFirstIdentity()) {
+        return;
+    }
+
     bool sendIdentity = false;
     if (nodeData && nodeData->getAvatarSessionDisplayNameMustChange()) {
         AvatarData& avatar = nodeData->getAvatar();

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -288,7 +288,7 @@ void AvatarMixer::manageIdentityData(const SharedNodePointer& node) {
 
     // there is no need to manage identity data we haven't received yet
     // so bail early if we've never received an identity packet for this avatar
-    if (!nodeData->getAvatar().hasProcessedFirstIdentity()) {
+    if (!nodeData || !nodeData->getAvatar().hasProcessedFirstIdentity()) {
         return;
     }
 

--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -327,6 +327,9 @@ void AvatarMixerSlave::broadcastAvatarDataToAgent(const SharedNodePointer& node)
         if (otherAvatar->hasProcessedFirstIdentity()
             && nodeData->getLastBroadcastTime(otherNode->getUUID()) <= otherNodeData->getIdentityChangeTimestamp()) {
             identityBytesSent += sendIdentityPacket(otherNodeData, node);
+
+            // remember the last time we sent identity details about this other node to the receiver
+            nodeData->setLastBroadcastTime(otherNode->getUUID(), usecTimestampNow());
         }
 
         glm::vec3 otherPosition = otherAvatar->getClientGlobalPosition();
@@ -401,9 +404,6 @@ void AvatarMixerSlave::broadcastAvatarDataToAgent(const SharedNodePointer& node)
                 // set the last sent sequence number for this sender on the receiver
                 nodeData->setLastBroadcastSequenceNumber(otherNode->getUUID(),
                                                          otherNodeData->getLastReceivedSequenceNumber());
-
-                // remember the last time we sent details about this other node to the receiver
-                nodeData->setLastBroadcastTime(otherNode->getUUID(), start);
             }
         }
 

--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -320,14 +320,15 @@ void AvatarMixerSlave::broadcastAvatarDataToAgent(const SharedNodePointer& node)
         ++numOtherAvatars;
 
         const AvatarMixerClientData* otherNodeData = reinterpret_cast<const AvatarMixerClientData*>(otherNode->getLinkedData());
+        const AvatarData* otherAvatar = otherNodeData->getConstAvatarData();
 
         // If the time that the mixer sent AVATAR DATA about Avatar B to Avatar A is BEFORE OR EQUAL TO
         // the time that Avatar B flagged an IDENTITY DATA change, send IDENTITY DATA about Avatar B to Avatar A.
-        if (nodeData->getLastBroadcastTime(otherNode->getUUID()) <= otherNodeData->getIdentityChangeTimestamp()) {
+        if (otherAvatar->hasProcessedFirstIdentity()
+            && nodeData->getLastBroadcastTime(otherNode->getUUID()) <= otherNodeData->getIdentityChangeTimestamp()) {
             identityBytesSent += sendIdentityPacket(otherNodeData, node);
         }
 
-        const AvatarData* otherAvatar = otherNodeData->getConstAvatarData();
         glm::vec3 otherPosition = otherAvatar->getClientGlobalPosition();
 
         // determine if avatar is in view, to determine how much data to include...

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -627,6 +627,7 @@ public:
     void markIdentityDataChanged() { _identityDataChanged = true; }
 
     void pushIdentitySequenceNumber() { ++_identitySequenceNumber; };
+    bool hasProcessedFirstIdentity() const { return _hasProcessedFirstIdentity; }
 
     float getDensity() const { return _density; }
 


### PR DESCRIPTION
- fixed a bug with empty avatar identity packets being sent from the avatar mixer
- fixed a bug with avatar mixer possibly not sending identity packets after race