### PR TITLE
minor fix for --scripts switch

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -915,11 +915,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         _saveAvatarOverrideUrl = true;
     }
 
-    QString defaultScriptsLocation = getCmdOption(argc, constArgv, "--scripts");
-    if (!defaultScriptsLocation.isEmpty()) {
-        PathUtils::defaultScriptsLocation(defaultScriptsLocation);
-    }
-
     _glWidget = new GLCanvas();
     getApplicationCompositor().setRenderingWidget(_glWidget);
     _window->setCentralWidget(_glWidget);
@@ -1186,7 +1181,12 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // do this as late as possible so that all required subsystems are initialized
     // If we've overridden the default scripts location, just load default scripts
     // otherwise, load 'em all
-    if (!defaultScriptsLocation.isEmpty()) {
+
+    // we just want to see if --scripts was set, we've already parsed it and done
+    // the change in PathUtils.  Rather than pass that in the constructor, lets just
+    // look (this could be debated)
+    QDir defaultScriptsLocation(getCmdOption(argc, constArgv, "--scripts"));
+    if (!defaultScriptsLocation.exists()) {
         scriptEngines->loadDefaultScripts();
         scriptEngines->defaultScriptsLocationOverridden(true);
     } else {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1185,7 +1185,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // we just want to see if --scripts was set, we've already parsed it and done
     // the change in PathUtils.  Rather than pass that in the constructor, lets just
     // look (this could be debated)
-    QDir defaultScriptsLocation(getCmdOption(argc, constArgv, "--scripts"));
+    QString scriptsSwitch = QString("--").append(SCRIPTS_SWITCH);
+    QDir defaultScriptsLocation(getCmdOption(argc, constArgv, scriptsSwitch.toStdString().c_str()));
     if (!defaultScriptsLocation.exists()) {
         scriptEngines->loadDefaultScripts();
         scriptEngines->defaultScriptsLocationOverridden(true);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -95,6 +95,7 @@ static const UINT UWM_SHOW_APPLICATION =
 #endif
 
 static const QString RUNNING_MARKER_FILENAME = "Interface.running";
+static const QString SCRIPTS_SWITCH = "scripts";
 
 class Application;
 #if defined(qApp)

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -73,12 +73,14 @@ int main(int argc, const char* argv[]) {
     QCommandLineOption serverContentPathOption("serverContentPath", "Where to find server content", "serverContentPath");
     QCommandLineOption allowMultipleInstancesOption("allowMultipleInstances", "Allow multiple instances to run");
     QCommandLineOption overrideAppLocalDataPathOption("cache", "set test cache <dir>", "dir");
+    QCommandLineOption overrideScriptsPathOption("scripts", "set scripts <path>", "path");
     parser.addOption(urlOption);
     parser.addOption(noUpdaterOption);
     parser.addOption(checkMinSpecOption);
     parser.addOption(runServerOption);
     parser.addOption(serverContentPathOption);
     parser.addOption(overrideAppLocalDataPathOption);
+    parser.addOption(overrideScriptsPathOption);
     parser.addOption(allowMultipleInstancesOption);
     parser.parse(arguments);
 
@@ -99,6 +101,14 @@ int main(int argc, const char* argv[]) {
     if (allowMultipleInstances) {
         instanceMightBeRunning = false;
     }
+
+    if (parser.isSet(overrideScriptsPathOption)) {
+        QDir scriptsPath(parser.value(overrideScriptsPathOption));
+        if (scriptsPath.exists()) {
+            PathUtils::defaultScriptsLocation(scriptsPath.path());
+        }
+    }
+
     if (parser.isSet(overrideAppLocalDataPathOption)) {
         // get dir to use for cache
         QString cacheDir = parser.value(overrideAppLocalDataPathOption);

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, const char* argv[]) {
     QCommandLineOption serverContentPathOption("serverContentPath", "Where to find server content", "serverContentPath");
     QCommandLineOption allowMultipleInstancesOption("allowMultipleInstances", "Allow multiple instances to run");
     QCommandLineOption overrideAppLocalDataPathOption("cache", "set test cache <dir>", "dir");
-    QCommandLineOption overrideScriptsPathOption("scripts", "set scripts <path>", "path");
+    QCommandLineOption overrideScriptsPathOption(SCRIPTS_SWITCH, "set scripts <path>", "path");
     parser.addOption(urlOption);
     parser.addOption(noUpdaterOption);
     parser.addOption(checkMinSpecOption);
@@ -101,7 +101,9 @@ int main(int argc, const char* argv[]) {
     if (allowMultipleInstances) {
         instanceMightBeRunning = false;
     }
-
+    // this needs to be done here in main, as the mechanism for setting the 
+    // scripts directory appears not to work.  See the bug report
+    // https://highfidelity.fogbugz.com/f/cases/5759/Issues-changing-scripts-directory-in-ScriptsEngine
     if (parser.isSet(overrideScriptsPathOption)) {
         QDir scriptsPath(parser.value(overrideScriptsPathOption));
         if (scriptsPath.exists()) {


### PR DESCRIPTION
If you pass in `--scripts <full path of some directory>`, when you open the running scripts, the tree of scripts to select will be from that directory.