### PR TITLE
Fix projection & lighting issues identified with 2nd rendering pipeline

### DIFF
--- a/interface/src/SecondaryCamera.cpp
+++ b/interface/src/SecondaryCamera.cpp
@@ -79,6 +79,7 @@ public:
 
             gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
                 batch.disableContextStereo();
+                batch.disableContextViewCorrection();
             });
 
             auto srcViewFrustum = args->getViewFrustum();
@@ -112,6 +113,7 @@ public:
 
         gpu::doInBatch(args->_context, [&](gpu::Batch& batch) {
             batch.restoreContextStereo();
+            batch.restoreContextViewCorrection();
         });
     }
 };

--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
@@ -114,7 +114,9 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
     (&::gpu::gl::GLBackend::do_getQuery),
 
     (&::gpu::gl::GLBackend::do_resetStages),
-
+    
+    (&::gpu::gl::GLBackend::do_disableContextViewCorrection),
+    (&::gpu::gl::GLBackend::do_restoreContextViewCorrection),
     (&::gpu::gl::GLBackend::do_disableContextStereo),
     (&::gpu::gl::GLBackend::do_restoreContextStereo),
 
@@ -374,6 +376,13 @@ void GLBackend::do_resetStages(const Batch& batch, size_t paramOffset) {
     resetStages();
 }
 
+void GLBackend::do_disableContextViewCorrection(const Batch& batch, size_t paramOffset) {
+    _transform._viewCorrectionEnabled = false;
+}
+
+void GLBackend::do_restoreContextViewCorrection(const Batch& batch, size_t paramOffset) {
+    _transform._viewCorrectionEnabled = true;
+}
 
 void GLBackend::do_disableContextStereo(const Batch& batch, size_t paramOffset) {
 

--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.h
@@ -143,6 +143,10 @@ public:
     // Reset stages
     virtual void do_resetStages(const Batch& batch, size_t paramOffset) final;
 
+    
+    virtual void do_disableContextViewCorrection(const Batch& batch, size_t paramOffset) final;
+    virtual void do_restoreContextViewCorrection(const Batch& batch, size_t paramOffset) final;
+
     virtual void do_disableContextStereo(const Batch& batch, size_t paramOffset) final;
     virtual void do_restoreContextStereo(const Batch& batch, size_t paramOffset) final;
 
@@ -333,6 +337,8 @@ protected:
         bool _skybox { false };
         Transform _view;
         CameraCorrection _correction;
+        bool _viewCorrectionEnabled{ true };
+
 
         Mat4 _projection;
         Vec4i _viewport { 0, 0, 1, 1 };
@@ -400,6 +406,7 @@ protected:
         bool _invalidProgram { false };
 
         BufferView _cameraCorrectionBuffer { gpu::BufferView(std::make_shared<gpu::Buffer>(sizeof(CameraCorrection), nullptr )) };
+        BufferView _cameraCorrectionBufferIdentity { gpu::BufferView(std::make_shared<gpu::Buffer>(sizeof(CameraCorrection), nullptr )) };
 
         State::Data _stateCache{ State::DEFAULT };
         State::Signature _stateSignatureCache { 0 };
@@ -409,6 +416,8 @@ protected:
 
         PipelineStageState() {
             _cameraCorrectionBuffer.edit<CameraCorrection>() = CameraCorrection();
+            _cameraCorrectionBufferIdentity.edit<CameraCorrection>() = CameraCorrection();
+            _cameraCorrectionBufferIdentity._buffer->flush();
         }
     } _pipeline;
 

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendPipeline.cpp
@@ -77,8 +77,14 @@ void GLBackend::do_setPipeline(const Batch& batch, size_t paramOffset) {
     if (_pipeline._invalidProgram) {
         glUseProgram(_pipeline._program);
         if (_pipeline._cameraCorrectionLocation != -1) {
-            auto cameraCorrectionBuffer = syncGPUObject(*_pipeline._cameraCorrectionBuffer._buffer);
+            gl::GLBuffer* cameraCorrectionBuffer = nullptr;
+            if (_transform._viewCorrectionEnabled) {
+                cameraCorrectionBuffer = syncGPUObject(*_pipeline._cameraCorrectionBuffer._buffer);
+            } else {
+                cameraCorrectionBuffer = syncGPUObject(*_pipeline._cameraCorrectionBufferIdentity._buffer);
+            }
             glBindBufferRange(GL_UNIFORM_BUFFER, _pipeline._cameraCorrectionLocation, cameraCorrectionBuffer->_id, 0, sizeof(CameraCorrection));
+
         }
         (void) CHECK_GL_ERROR();
         _pipeline._invalidProgram = false;

--- a/libraries/gpu-gl/src/gpu/gl/GLBackendTransform.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackendTransform.cpp
@@ -102,7 +102,7 @@ void GLBackend::TransformStageState::preUpdate(size_t commandIndex, const Stereo
 
     if (_invalidView) {
         // Apply the correction
-        if (_viewIsCamera && _correction.correction != glm::mat4()) {
+        if (_viewIsCamera && (_viewCorrectionEnabled && _correction.correction != glm::mat4())) {
             // FIXME should I switch to using the camera correction buffer in Transform.slf and leave this out?
             Transform result;
             _view.mult(result, _view, _correction.correction);

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -390,6 +390,13 @@ void Batch::resetStages() {
     ADD_COMMAND(resetStages);
 }
 
+void Batch::disableContextViewCorrection() {
+    ADD_COMMAND(disableContextViewCorrection);
+}
+
+void Batch::restoreContextViewCorrection() {
+    ADD_COMMAND(restoreContextViewCorrection);
+}
 
 void Batch::disableContextStereo() {
     ADD_COMMAND(disableContextStereo);

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -217,6 +217,9 @@ public:
     // Reset the stage caches and states
     void resetStages();
 
+    void disableContextViewCorrection();
+    void restoreContextViewCorrection();
+
     void disableContextStereo();
     void restoreContextStereo();
 
@@ -303,6 +306,9 @@ public:
         COMMAND_getQuery,
 
         COMMAND_resetStages,
+
+        COMMAND_disableContextViewCorrection,
+        COMMAND_restoreContextViewCorrection,
 
         COMMAND_disableContextStereo,
         COMMAND_restoreContextStereo,

--- a/libraries/render-utils/src/DeferredFrameTransform.cpp
+++ b/libraries/render-utils/src/DeferredFrameTransform.cpp
@@ -39,7 +39,7 @@ void DeferredFrameTransform::update(RenderArgs* args) {
     args->getViewFrustum().evalProjectionMatrix(frameTransformBuffer.projectionMono);
 
     // Running in stero ?
-    bool isStereo = args->_context->isStereo();
+    bool isStereo = args->isStereo();
     if (!isStereo) {
         frameTransformBuffer.projection[0] = frameTransformBuffer.projectionMono;
         frameTransformBuffer.stereoInfo = glm::vec4(0.0f, (float)args->_viewport.z, 0.0f, 0.0f);

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -406,7 +406,7 @@ void Blit::run(const RenderContextPointer& renderContext, const gpu::Framebuffer
         batch.setFramebuffer(blitFbo);
 
         if (renderArgs->_renderMode == RenderArgs::MIRROR_RENDER_MODE) {
-            if (renderArgs->_context->isStereo()) {
+            if (renderArgs->isStereo()) {
                 gpu::Vec4i srcRectLeft;
                 srcRectLeft.z = width / 2;
                 srcRectLeft.w = height;

--- a/libraries/render-utils/src/SurfaceGeometryPass.cpp
+++ b/libraries/render-utils/src/SurfaceGeometryPass.cpp
@@ -459,7 +459,7 @@ void SurfaceGeometryPass::run(const render::RenderContextPointer& renderContext,
     auto diffuseVPipeline = _diffusePass.getBlurVPipeline();
     auto diffuseHPipeline = _diffusePass.getBlurHPipeline();
 
-    _diffusePass.getParameters()->setWidthHeight(curvatureViewport.z, curvatureViewport.w, args->_context->isStereo());
+    _diffusePass.getParameters()->setWidthHeight(curvatureViewport.z, curvatureViewport.w, args->isStereo());
     glm::ivec2 textureSize(curvatureTexture->getDimensions());
     _diffusePass.getParameters()->setTexcoordTransform(gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(textureSize, curvatureViewport));
     _diffusePass.getParameters()->setDepthPerspective(args->getViewFrustum().getProjection()[1][1]);

--- a/libraries/render/src/render/Args.h
+++ b/libraries/render/src/render/Args.h
@@ -99,6 +99,8 @@ namespace render {
         void pushViewFrustum(const ViewFrustum& viewFrustum) { _viewFrustums.push(viewFrustum); }
         void popViewFrustum() { _viewFrustums.pop(); }
 
+        bool isStereo() const { return _displayMode != MONO; }
+
         std::shared_ptr<gpu::Context> _context;
         std::shared_ptr<gpu::Framebuffer> _blitFramebuffer;
         std::shared_ptr<render::ShapePipeline> _pipeline;

--- a/libraries/render/src/render/BlurTask.cpp
+++ b/libraries/render/src/render/BlurTask.cpp
@@ -217,7 +217,7 @@ void BlurGaussian::run(const RenderContextPointer& renderContext, const gpu::Fra
     auto blurVPipeline = getBlurVPipeline();
     auto blurHPipeline = getBlurHPipeline();
 
-    _parameters->setWidthHeight(args->_viewport.z, args->_viewport.w, args->_context->isStereo());
+    _parameters->setWidthHeight(args->_viewport.z, args->_viewport.w, args->isStereo());
     glm::ivec2 textureSize(blurringResources.sourceTexture->getDimensions());
     _parameters->setTexcoordTransform(gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(textureSize, args->_viewport));
 
@@ -330,7 +330,7 @@ void BlurGaussianDepthAware::run(const RenderContextPointer& renderContext, cons
 
     auto sourceViewport = args->_viewport;
 
-    _parameters->setWidthHeight(sourceViewport.z, sourceViewport.w, args->_context->isStereo());
+    _parameters->setWidthHeight(sourceViewport.z, sourceViewport.w, args->isStereo());
     glm::ivec2 textureSize(blurringResources.sourceTexture->getDimensions());
     _parameters->setTexcoordTransform(gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(textureSize, sourceViewport));
     _parameters->setDepthPerspective(args->getViewFrustum().getProjection()[1][1]);


### PR DESCRIPTION
This pr fixes the projection&  lighting pass applied to the spectator Camera frame (secondary) when the main frame is in stereo mode (or HMD).

In HMD/stereo mode some algorithms would check on the args->_context->isStereo() function to select a stereo path, when it should select the mono path instead because rendering the secondary frame.
I replaced most of these tests to instead rely on a isStereo() function on the args which is representing the correct state at the time when the function is asked.

On top of this, the View Correction matrix is applied on all view transform tagged as "camera"
but here again we don;t  want it to be applied to the case of the secondary frame.
I  introduced a way to disable / restore the capability from the Batch allowing to control if the correction matrix is used or not and specifically disabled during the secondary camera.
This is mostly visible when using the HMD Simulator which uses a spectacular ViewCorrection for the sake of debug.

## TEST PLAN
Verify that the lighting bug & projection bug are solved in this pr compared to the spectator camera main branch.
Testing the HMD simulator (available in the choice of displays when the env variable HIFI_DEBUG_HMD is defined), verify that the rendered camera frame is correct.