### PR TITLE
Spectator camera resize fix

### DIFF
--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -127,15 +127,7 @@
             "userData": "{\"grabbableKey\":{\"grabbable\":true}}"
         }, true);
         // This image3d overlay acts as the camera's preview screen.
-        viewFinderOverlay = Overlays.addOverlay("image3d", {
-            url: "resource://spectatorCameraFrame",
-            emissive: true,
-            parentID: camera,
-            alpha: 1,
-            localRotation: { w: 1, x: 0, y: 0, z: 0 },
-            localPosition: { x: 0.007, y: 0.15, z: -0.005 },
-            dimensions: viewFinderOverlayDim
-        });
+        updateOverlay();
         setDisplay(monitorShowsCameraView);
     }
 
@@ -284,6 +276,22 @@
             setMonitorShowsCameraViewAndSendToQml(!monitorShowsCameraView);
         }
     }
+    function updateOverlay() {
+        // The only way I found to update the viewFinderOverlay without turning the spectator camera on and off is to delete and recreate the
+        //     overlay, which is inefficient but resizing the window shouldn't be performed often
+        if (viewFinderOverlay) {
+            Overlays.deleteOverlay(viewFinderOverlay);
+        }
+        viewFinderOverlay = Overlays.addOverlay("image3d", {
+            url: "resource://spectatorCameraFrame",
+            emissive: true,
+            parentID: camera,
+            alpha: 1,
+            localRotation: { w: 1, x: 0, y: 0, z: 0 },
+            localPosition: { x: 0.007, y: 0.15, z: -0.005 },
+            dimensions: viewFinderOverlayDim
+        });
+    }
 
     //
     // Function Name: resizeViewFinderOverlay()
@@ -313,19 +321,7 @@
         } else { //horizontal window size
             viewFinderOverlayDim = { x: glassPaneWidth, y: -glassPaneWidth, z: 0 };
         }
-
-        // The only way I found to update the viewFinderOverlay without turning the spectator camera on and off is to delete and recreate the
-        //     overlay, which is inefficient but resizing the window shouldn't be performed often
-        Overlays.deleteOverlay(viewFinderOverlay);
-        viewFinderOverlay = Overlays.addOverlay("image3d", {
-            url: "resource://spectatorCameraFrame",
-            emissive: true,
-            parentID: camera,
-            alpha: 1,
-            localRotation: { w: 1, x: 0, y: 0, z: 0 },
-            localPosition: { x: 0.007, y: 0.15, z: -0.005 },
-            dimensions: viewFinderOverlayDim
-        });
+        updateOverlay();
         spectatorFrameRenderConfig.resetSizeSpectatorCamera(geometryChanged.width, geometryChanged.height);
         setDisplay(monitorShowsCameraView);
     }

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -132,7 +132,7 @@
             emissive: true,
             parentID: camera,
             alpha: 1,
-            localRotation: { x: 0, y: 0, z: 0 },
+            localRotation: { w: 1, x: 0, y: 0, z: 0 },
             localPosition: { x: 0.007, y: 0.15, z: -0.005 },
             dimensions: viewFinderOverlayDim
         });
@@ -322,7 +322,7 @@
             emissive: true,
             parentID: camera,
             alpha: 1,
-            localRotation: { x: 0, y: 0, z: 0 },
+            localRotation: { w: 1, x: 0, y: 0, z: 0 },
             localPosition: { x: 0.007, y: 0.15, z: -0.005 },
             dimensions: viewFinderOverlayDim
         });

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -132,7 +132,7 @@
             emissive: true,
             parentID: camera,
             alpha: 1,
-            rotation: cameraRotation,
+            localRotation: { x: 0, y: 0, z: 0 },
             localPosition: { x: 0.007, y: 0.15, z: -0.005 },
             dimensions: viewFinderOverlayDim
         });
@@ -322,7 +322,7 @@
             emissive: true,
             parentID: camera,
             alpha: 1,
-            rotation: cameraRotation,
+            localRotation: { x: 0, y: 0, z: 0 },
             localPosition: { x: 0.007, y: 0.15, z: -0.005 },
             dimensions: viewFinderOverlayDim
         });


### PR DESCRIPTION
Should fix bug where the preview in the glass pane of the spectator camera will rotate, move, and stretch outside of the glass pane. 

To Test:
-Click on Spectator Camera in tablet, and turn it on
-Stretch your window size and then put on HMD
-Move and rotate the camera, make sure that the preview never leaves the glass pane
-Repeat for different window sizes