### PR TITLE
DNM: Experimenting faster getters on Avatar for scripts

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -404,8 +404,10 @@ void Rig::setJointRotation(int index, bool valid, const glm::quat& rotation, flo
 }
 
 bool Rig::getJointPositionInWorldFrame(int jointIndex, glm::vec3& position, glm::vec3 translation, glm::quat rotation) const {
-    if (isIndexValid(jointIndex)) {
-        position = (rotation * _internalPoseSet._absolutePoses[jointIndex].trans()) + translation;
+  //  if (isIndexValid(jointIndex)) {
+    QReadLocker readLock(&_externalPoseSetLock);
+    if (jointIndex >= 0 && jointIndex < (int)_externalPoseSet._absolutePoses.size()) {
+        position = (rotation * _externalPoseSet._absolutePoses[jointIndex].trans()) + translation;
         return true;
     } else {
         return false;
@@ -413,17 +415,24 @@ bool Rig::getJointPositionInWorldFrame(int jointIndex, glm::vec3& position, glm:
 }
 
 bool Rig::getJointPosition(int jointIndex, glm::vec3& position) const {
+/*
     if (isIndexValid(jointIndex)) {
         position = _internalPoseSet._absolutePoses[jointIndex].trans();
         return true;
     } else {
         return false;
-    }
+    }*/
+    return getAbsoluteJointTranslationInRigFrame(jointIndex, position);
 }
 
 bool Rig::getJointRotationInWorldFrame(int jointIndex, glm::quat& result, const glm::quat& rotation) const {
-    if (isIndexValid(jointIndex)) {
-        result = rotation * _internalPoseSet._absolutePoses[jointIndex].rot();
+   // if (isIndexValid(jointIndex)) {
+   //     result = rotation * _internalPoseSet._absolutePoses[jointIndex].rot();
+   //     return true;
+
+    QReadLocker readLock(&_externalPoseSetLock);
+    if (jointIndex >= 0 && jointIndex < (int)_externalPoseSet._absolutePoses.size()) {
+        result = rotation * _externalPoseSet._absolutePoses[jointIndex].rot();
         return true;
     } else {
         return false;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1008,12 +1008,12 @@ glm::vec3 Avatar::getAbsoluteJointTranslationInObjectFrame(int index) const {
 }
 
 int Avatar::getJointIndex(const QString& name) const {
-    if (QThread::currentThread() != thread()) {
+ /*   if (QThread::currentThread() != thread()) {
         int result;
         QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointIndex", Qt::BlockingQueuedConnection,
             Q_RETURN_ARG(int, result), Q_ARG(const QString&, name));
         return result;
-    }
+    } */
     int result = getFauxJointIndex(name);
     if (result != -1) {
         return result;
@@ -1022,34 +1022,34 @@ int Avatar::getJointIndex(const QString& name) const {
 }
 
 QStringList Avatar::getJointNames() const {
-    if (QThread::currentThread() != thread()) {
+/*    if (QThread::currentThread() != thread()) {
         QStringList result;
         QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointNames", Qt::BlockingQueuedConnection,
             Q_RETURN_ARG(QStringList, result));
         return result;
-    }
+    }*/
     return _skeletonModel->isActive() ? _skeletonModel->getFBXGeometry().getJointNames() : QStringList();
 }
 
 glm::vec3 Avatar::getJointPosition(int index) const {
-    if (QThread::currentThread() != thread()) {
+/*    if (QThread::currentThread() != thread()) {
         glm::vec3 position;
         QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointPosition", Qt::BlockingQueuedConnection,
                                   Q_RETURN_ARG(glm::vec3, position), Q_ARG(const int, index));
         return position;
-    }
+    }*/
     glm::vec3 position;
     _skeletonModel->getJointPositionInWorldFrame(index, position);
     return position;
 }
 
 glm::vec3 Avatar::getJointPosition(const QString& name) const {
-    if (QThread::currentThread() != thread()) {
+/*    if (QThread::currentThread() != thread()) {
         glm::vec3 position;
         QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointPosition", Qt::BlockingQueuedConnection,
                                   Q_RETURN_ARG(glm::vec3, position), Q_ARG(const QString&, name));
         return position;
-    }
+    }*/
     glm::vec3 position;
     _skeletonModel->getJointPositionInWorldFrame(getJointIndex(name), position);
     return position;


### PR DESCRIPTION
THis pr experiment a prototype solution to this bug:
https://highfidelity.fogbugz.com/f/cases/5806/Script-performances-of-Controller-js-are-affected-by-getter-calls-on-MyAvatar

We re trying to remove the thread safe messaging of the getters on MyAvatar / Avatar / Rig on the joints values and names in order to optimize the script calling these functions.

The goal is to point out the performance issue that shows when using the Teleport.js  (this would be probably true for any other scripts of the Controller.js pool)

Ideally someone can take over this task and implement a clean version of the same idea (i have no idea if what i have changed is safe /correct or not).


I did investigate 2 scenarios, 2 traces for each case:

I captured the traces running interface with the following test script:
https://raw.githubusercontent.com/highfidelity/hifi_tests/master/benchmarks/dev-welcome-start_at_10sIn.js

1/ In HMD, in dev-welcome, simply move your hands around without triggering any buttons.
- with this pr and the optimization:  https://hifi-public.s3.amazonaws.com/sam/temp/scriptPerfoInvestigation-2017-06/trace_Dev-Welcome_20170629_1249-optimized.json.gz
- with dev-master (6794) https://hifi-public.s3.amazonaws.com/sam/temp/scriptPerfoInvestigation-2017-06/trace_Dev-Welcome_20170629_1542-master.json.gz

2/ in HMD, in dev-welcome, Keep the the teleport button down and move around your hand controller seeing the teleport laser and destination disk
- with this pr and the optimization: https://hifi-public.s3.amazonaws.com/sam/temp/scriptPerfoInvestigation-2017-06/trace_Dev-Welcome_20170629_1546-teleport-master.json.gz
- with dev-master (6794) https://hifi-public.s3.amazonaws.com/sam/temp/scriptPerfoInvestigation-2017-06/trace_Dev-Welcome_20170629_1703_teleport_master.json.gz

Looking into the traces you will discover that the time spent in the timerFIred in this PR is way less than in master.
this free up a lot of time so the update call of the Telport.js can be executed at the expected 60Hz correctly.
THis is not the case with the current dev-master, where the timerFIred calls can last very long and prevent the teleport.js to execute at a proper rate.