### PR TITLE
Update DomainMetadata.cpp

### DIFF
--- a/domain-server/src/DomainMetadata.cpp
+++ b/domain-server/src/DomainMetadata.cpp
@@ -171,7 +171,7 @@ void DomainMetadata::maybeUpdateUsers() {
         if (linkedData) {
             auto nodeData = static_cast<DomainServerNodeData*>(linkedData);
 
-            if (!nodeData->wasAssigned()) {
+            if (!nodeData->wasAssigned() && node->getType() == NodeType::Agent) {
                 ++numConnected;
 
                 if (nodeData->getUsername().isEmpty()) {


### PR DESCRIPTION
Made changes to DomainMetadata.cpp to Ensure that we only count un-assigned nodes that are of type Agent for a heartbeat. Removed the bug that counts the downstream and upstream mixers as connected users. 

Testing Notes:
Run the PR (interface and domain server)
Check domain server logs, it should show 1 user
Go to http://localhost:40100/ -> Settings -> Advanced -> Broadcasting
Add a Receiving or Broadcasting Server
Check domain server logs, it should show **no increase** in the number of users
