### PR TITLE
Fix AC cleanup

### DIFF
--- a/assignment-client/src/AssignmentClientApp.h
+++ b/assignment-client/src/AssignmentClientApp.h
@@ -27,7 +27,6 @@ const QString ASSIGNMENT_MAX_FORKS_OPTION = "max";
 const QString ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION = "monitor-port";
 const QString ASSIGNMENT_HTTP_STATUS_PORT = "http-status-port";
 const QString ASSIGNMENT_LOG_DIRECTORY = "log-directory";
-const QString ASSIGNMENT_PARENT_PID = "parent-pid";
 
 class AssignmentClientApp : public QCoreApplication {
     Q_OBJECT

--- a/assignment-client/src/AssignmentClientApp.h
+++ b/assignment-client/src/AssignmentClientApp.h
@@ -27,6 +27,7 @@ const QString ASSIGNMENT_MAX_FORKS_OPTION = "max";
 const QString ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION = "monitor-port";
 const QString ASSIGNMENT_HTTP_STATUS_PORT = "http-status-port";
 const QString ASSIGNMENT_LOG_DIRECTORY = "log-directory";
+const QString ASSIGNMENT_PARENT_PID = "parent-pid";
 
 class AssignmentClientApp : public QCoreApplication {
     Q_OBJECT

--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -159,6 +159,10 @@ void AssignmentClientMonitor::spawnChildClient() {
     // for now they simply talk to us on localhost
     _childArguments.append("--" + ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION);
     _childArguments.append(QString::number(DependencyManager::get<NodeList>()->getLocalSockAddr().getPort()));
+    
+
+    _childArguments.append("--" + ASSIGNMENT_PARENT_PID);
+    _childArguments.append(QString::number(QCoreApplication::applicationPid()));
 
     QString nowString, stdoutFilenameTemp, stderrFilenameTemp, stdoutPathTemp, stderrPathTemp;
 

--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -131,7 +131,6 @@ void AssignmentClientMonitor::aboutToQuit() {
 void AssignmentClientMonitor::spawnChildClient() {
     QProcess* assignmentClient = new QProcess(this);
 
-
     // unparse the parts of the command-line that the child cares about
     QStringList _childArguments;
     if (_assignmentPool != "") {
@@ -159,9 +158,8 @@ void AssignmentClientMonitor::spawnChildClient() {
     // for now they simply talk to us on localhost
     _childArguments.append("--" + ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION);
     _childArguments.append(QString::number(DependencyManager::get<NodeList>()->getLocalSockAddr().getPort()));
-    
 
-    _childArguments.append("--" + ASSIGNMENT_PARENT_PID);
+    _childArguments.append("--" + PARENT_PID_OPTION);
     _childArguments.append(QString::number(QCoreApplication::applicationPid()));
 
     QString nowString, stdoutFilenameTemp, stderrFilenameTemp, stdoutPathTemp, stderrPathTemp;

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -221,6 +221,8 @@ void DomainServer::parseCommandLine() {
     const QCommandLineOption masterConfigOption("master-config", "Deprecated config-file option");
     parser.addOption(masterConfigOption);
 
+    const QCommandLineOption parentPIDOption(PARENT_PID_OPTION, "PID of the parent process", "parent-pid");
+    parser.addOption(parentPIDOption);
 
     if (!parser.parse(QCoreApplication::arguments())) {
         qWarning() << parser.errorText() << endl;
@@ -248,6 +250,17 @@ void DomainServer::parseCommandLine() {
         _overridingDomainID = QUuid(parser.value(domainIDOption));
         _overrideDomainID = true;
         qDebug() << "domain-server ID is" << _overridingDomainID;
+    }
+
+
+    if (parser.isSet(parentPIDOption)) {
+        bool ok = false;
+        int parentPID = parser.value(parentPIDOption).toInt(&ok);
+
+        if (ok) {
+            qDebug() << "Parent process PID is" << parentPID;
+            watchParentProcess(parentPID);
+        }
     }
 }
 

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -1076,3 +1076,24 @@ void setMaxCores(uint8_t maxCores) {
     SetProcessAffinityMask(process, newProcessAffinity);
 #endif
 }
+
+#ifdef Q_OS_WIN
+VOID CALLBACK parentDiedCallback(PVOID lpParameter, BOOLEAN timerOrWaitFired) {
+    if (!timerOrWaitFired && qApp) {
+        qDebug() << "Parent process died, quitting";
+        qApp->quit();
+    }
+}
+
+void watchParentProcess(int parentPID) {
+    DWORD processID = parentPID;
+    HANDLE procHandle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, processID);
+
+    HANDLE newHandle;
+    RegisterWaitForSingleObject(&newHandle, procHandle, parentDiedCallback, NULL, INFINITE, WT_EXECUTEONLYONCE);
+}
+#else
+void watchParentProcess(int parentPID) {
+    qWarning() << "Parent PID option not implemented on this plateform";
+}
+#endif // Q_OS_WIN

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -235,4 +235,7 @@ const QString& getInterfaceSharedMemoryName();
 
 void setMaxCores(uint8_t maxCores);
 
+const QString PARENT_PID_OPTION = "parent-pid";
+void watchParentProcess(int parentPID);
+
 #endif // hifi_SharedUtil_h

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -334,6 +334,7 @@ function startInterface(url) {
 
     // create a new Interface instance - Interface makes sure only one is running at a time
     var pInterface = new Process('interface', interfacePath, argArray);
+    pInterface.detached = true;
     pInterface.start();
 }
 
@@ -894,15 +895,16 @@ function onContentLoaded() {
     if (dsPath && acPath) {
         var dsArguments = ['--get-temp-name',
                            '--parent-pid', process.pid];
-        domainServer = new Process('domain-server', dsPath, dsArguments,
-                                   logPath, true);
+        domainServer = new Process('domain-server', dsPath, dsArguments, logPath);
+        domainServer.restartOnCrash = true;
 
         var acArguments = ['-n7',
                            '--log-directory', logPath,
                            '--http-status-port', httpStatusPort,
                            '--parent-pid', process.pid];
         acMonitor = new ACMonitorProcess('ac-monitor', acPath, acArguments,
-                                         httpStatusPort, logPath, true);
+                                         httpStatusPort, logPath);
+        acMonitor.restartOnCrash = true;
 
         homeServer = new ProcessGroup('home', [domainServer, acMonitor]);
         logWindow = new LogWindow(acMonitor, domainServer);

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -892,12 +892,18 @@ function onContentLoaded() {
     deleteOldFiles(logPath, DELETE_LOG_FILES_OLDER_THAN_X_SECONDS, LOG_FILE_REGEX);
 
     if (dsPath && acPath) {
-        domainServer = new Process('domain-server', dsPath, ['--get-temp-name',
-                                                             '--parent-pid', process.pid], logPath);
-        acMonitor = new ACMonitorProcess('ac-monitor', acPath, ['-n7',
-                                                                '--log-directory', logPath,
-                                                                '--http-status-port', httpStatusPort,
-                                                                '--parent-pid', process.pid], httpStatusPort, logPath);
+        var dsArguments = ['--get-temp-name',
+                           '--parent-pid', process.pid];
+        domainServer = new Process('domain-server', dsPath, dsArguments,
+                                   logPath, true);
+
+        var acArguments = ['-n7',
+                           '--log-directory', logPath,
+                           '--http-status-port', httpStatusPort,
+                           '--parent-pid', process.pid];
+        acMonitor = new ACMonitorProcess('ac-monitor', acPath, acArguments,
+                                         httpStatusPort, logPath, true);
+
         homeServer = new ProcessGroup('home', [domainServer, acMonitor]);
         logWindow = new LogWindow(acMonitor, domainServer);
 

--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -892,10 +892,12 @@ function onContentLoaded() {
     deleteOldFiles(logPath, DELETE_LOG_FILES_OLDER_THAN_X_SECONDS, LOG_FILE_REGEX);
 
     if (dsPath && acPath) {
-        domainServer = new Process('domain-server', dsPath, ["--get-temp-name"], logPath);
+        domainServer = new Process('domain-server', dsPath, ['--get-temp-name',
+                                                             '--parent-pid', process.pid], logPath);
         acMonitor = new ACMonitorProcess('ac-monitor', acPath, ['-n7',
                                                                 '--log-directory', logPath,
-                                                                '--http-status-port', httpStatusPort], httpStatusPort, logPath);
+                                                                '--http-status-port', httpStatusPort,
+                                                                '--parent-pid', process.pid], httpStatusPort, logPath);
         homeServer = new ProcessGroup('home', [domainServer, acMonitor]);
         logWindow = new LogWindow(acMonitor, domainServer);
 

--- a/server-console/src/modules/hf-process.js
+++ b/server-console/src/modules/hf-process.js
@@ -102,7 +102,7 @@ ProcessGroup.prototype = extend(ProcessGroup.prototype, {
 });
 
 var ID = 0;
-function Process(name, command, commandArgs, logDirectory) {
+function Process(name, command, commandArgs, logDirectory, restartOnCrash) {
     events.EventEmitter.call(this);
 
     this.id = ++ID;
@@ -113,6 +113,7 @@ function Process(name, command, commandArgs, logDirectory) {
     this.logDirectory = logDirectory;
     this.logStdout = null;
     this.logStderr = null;
+    this.restartOnCrash = restartOnCrash;
 
     this.state = ProcessStates.STOPPED;
 };
@@ -271,7 +272,7 @@ Process.prototype = extend(Process.prototype, {
         var unexpectedShutdown = this.state != ProcessStates.STOPPING;
         this.updateState(ProcessStates.STOPPED);
 
-        if (unexpectedShutdown) {
+        if (unexpectedShutdown && this.restartOnCrash) {
             log.warn("Child stopped unexpectedly, restarting.");
             this.start();
             return;
@@ -282,8 +283,8 @@ Process.prototype = extend(Process.prototype, {
 // ACMonitorProcess is an extension of Process that keeps track of the AC Montior's
 // children status and log locations.
 const CHECK_AC_STATUS_INTERVAL = 1000;
-function ACMonitorProcess(name, path, args, httpStatusPort, logPath) {
-    Process.call(this, name, path, args, logPath);
+function ACMonitorProcess(name, path, args, httpStatusPort, logPath, restartOnCrash) {
+    Process.call(this, name, path, args, logPath, restartOnCrash);
 
     this.httpStatusPort = httpStatusPort;
 

--- a/server-console/src/modules/hf-process.js
+++ b/server-console/src/modules/hf-process.js
@@ -102,7 +102,7 @@ ProcessGroup.prototype = extend(ProcessGroup.prototype, {
 });
 
 var ID = 0;
-function Process(name, command, commandArgs, logDirectory, restartOnCrash) {
+function Process(name, command, commandArgs, logDirectory) {
     events.EventEmitter.call(this);
 
     this.id = ++ID;
@@ -113,7 +113,8 @@ function Process(name, command, commandArgs, logDirectory, restartOnCrash) {
     this.logDirectory = logDirectory;
     this.logStdout = null;
     this.logStderr = null;
-    this.restartOnCrash = restartOnCrash;
+    this.detached = false;
+    this.restartOnCrash = false;
 
     this.state = ProcessStates.STOPPED;
 };
@@ -166,7 +167,7 @@ Process.prototype = extend(Process.prototype, {
 
         try {
             this.child = childProcess.spawn(this.command, this.commandArgs, {
-                detached: false,
+                detached: this.detached,
                 stdio: ['ignore', logStdout, logStderr]
             });
             log.debug("Spawned " + this.command + " with pid " + this.child.pid);
@@ -283,8 +284,8 @@ Process.prototype = extend(Process.prototype, {
 // ACMonitorProcess is an extension of Process that keeps track of the AC Montior's
 // children status and log locations.
 const CHECK_AC_STATUS_INTERVAL = 1000;
-function ACMonitorProcess(name, path, args, httpStatusPort, logPath, restartOnCrash) {
-    Process.call(this, name, path, args, logPath, restartOnCrash);
+function ACMonitorProcess(name, path, args, httpStatusPort, logPath) {
+    Process.call(this, name, path, args, logPath);
 
     this.httpStatusPort = httpStatusPort;
 

--- a/server-console/src/modules/hf-process.js
+++ b/server-console/src/modules/hf-process.js
@@ -267,7 +267,15 @@ Process.prototype = extend(Process.prototype, {
             clearTimeout(this.stoppingTimeoutID);
             this.stoppingTimeoutID = null;
         }
+        // Grab current state berofe updating it.
+        var unexpectedShutdown = this.state != ProcessStates.STOPPING;
         this.updateState(ProcessStates.STOPPED);
+
+        if (unexpectedShutdown) {
+            log.warn("Child stopped unexpectedly, restarting.");
+            this.start();
+            return;
+        }
     }
 });
 

--- a/server-console/src/modules/hf-process.js
+++ b/server-console/src/modules/hf-process.js
@@ -168,6 +168,7 @@ Process.prototype = extend(Process.prototype, {
                 detached: false,
                 stdio: ['ignore', logStdout, logStderr]
             });
+            log.debug("Spawned " + this.command + " with pid " + this.child.pid);
         } catch (e) {
             log.debug("Got error starting child process for " + this.name, e);
             this.child = null;


### PR DESCRIPTION
- Added cli to the DS/AC for the parent PID.
    - Child process will track its parent and terminate if the parent process finishes.
- AC Monitor starts all ACs with the parent PID option.
- Sandbox starts the DS and AC Monitor with the parent PID option.
- Sandbox restarts the DS/AC if they terminate unexpectedly.
- Fixed a bug where using "Go Home" and closing the Sandbox would close Interface as well.