### PR TITLE
Don't use blocking connections on the main thread

### DIFF
--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -142,7 +142,7 @@ void AssignmentClient::stopAssignmentClient() {
         QThread* currentAssignmentThread = _currentAssignment->thread();
 
         // ask the current assignment to stop
-        hifi::qt::blockingInvokeMethod(_currentAssignment, "stop");
+        BLOCKING_INVOKE_METHOD(_currentAssignment, "stop");
 
         // ask the current assignment to delete itself on its thread
         _currentAssignment->deleteLater();

--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -16,6 +16,7 @@
 #include <QThread>
 #include <QTimer>
 
+#include <shared/QtHelpers.h>
 #include <AccountManager.h>
 #include <AddressManager.h>
 #include <Assignment.h>
@@ -141,7 +142,7 @@ void AssignmentClient::stopAssignmentClient() {
         QThread* currentAssignmentThread = _currentAssignment->thread();
 
         // ask the current assignment to stop
-        QMetaObject::invokeMethod(_currentAssignment, "stop", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(_currentAssignment, "stop");
 
         // ask the current assignment to delete itself on its thread
         _currentAssignment->deleteLater();

--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -13,6 +13,7 @@
 #include <QThread>
 #include <glm/gtx/transform.hpp>
 
+#include <shared/QtHelpers.h>
 #include <GLMHelpers.h>
 #include <AnimUtil.h>
 #include "ScriptableAvatar.h"
@@ -49,7 +50,7 @@ void ScriptableAvatar::stopAnimation() {
 AnimationDetails ScriptableAvatar::getAnimationDetails() {
     if (QThread::currentThread() != thread()) {
         AnimationDetails result;
-        QMetaObject::invokeMethod(this, "getAnimationDetails", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "getAnimationDetails", 
                                   Q_RETURN_ARG(AnimationDetails, result));
         return result;
     }

--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -50,7 +50,7 @@ void ScriptableAvatar::stopAnimation() {
 AnimationDetails ScriptableAvatar::getAnimationDetails() {
     if (QThread::currentThread() != thread()) {
         AnimationDetails result;
-        hifi::qt::blockingInvokeMethod(this, "getAnimationDetails", 
+        BLOCKING_INVOKE_METHOD(this, "getAnimationDetails", 
                                   Q_RETURN_ARG(AnimationDetails, result));
         return result;
     }

--- a/gvr-interface/src/RenderingClient.cpp
+++ b/gvr-interface/src/RenderingClient.cpp
@@ -63,10 +63,7 @@ void RenderingClient::sendAvatarPacket() {
 }
 
 void RenderingClient::cleanupBeforeQuit() {
-    
-    QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(),
-                              "stop", Qt::BlockingQueuedConnection);
-    
+    DependencyManager::get<AudioClient>()->cleanupBeforeQuit();
     // destroy the AudioClient so it and its thread will safely go down
     DependencyManager::destroy<AudioClient>();
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1844,7 +1844,7 @@ void Application::cleanupBeforeQuit() {
 
     // FIXME: something else is holding a reference to AudioClient,
     // so it must be explicitly synchronously stopped here
-    QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "cleanupBeforeQuit", Qt::BlockingQueuedConnection);
+    DependencyManager::get<AudioClient>()->cleanupBeforeQuit();
 
     // destroy Audio so it and its threads have a chance to go down safely
     // this must happen after QML, as there are unexplained audio crashes originating in qtwebengine

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1656,7 +1656,7 @@ QString Application::getUserAgent() {
     if (QThread::currentThread() != thread()) {
         QString userAgent;
 
-        hifi::qt::blockingInvokeMethod(this, "getUserAgent", Q_RETURN_ARG(QString, userAgent));
+        BLOCKING_INVOKE_METHOD(this, "getUserAgent", Q_RETURN_ARG(QString, userAgent));
 
         return userAgent;
     }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -25,6 +25,7 @@
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QUndoStack>
 
+#include <ThreadHelpers.h>
 #include <AbstractScriptingServicesInterface.h>
 #include <AbstractViewStateInterface.h>
 #include <EntityEditPacketSender.h>
@@ -596,8 +597,7 @@ private:
 
     bool _notifiedPacketVersionMismatchThisDomain;
 
-    QThread _settingsThread;
-    QTimer _settingsTimer;
+    ConditionalGuard _settingsGuard;
 
     GLCanvas* _glWidget{ nullptr };
 

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -25,6 +25,7 @@
 #endif
 
 
+#include <shared/QtHelpers.h>
 #include <AvatarData.h>
 #include <PerfStat.h>
 #include <RegisteredMetaTypes.h>
@@ -482,7 +483,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersection(const PickRay& 
                                                                  const QScriptValue& avatarIdsToDiscard) {
     RayToAvatarIntersectionResult result;
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(const_cast<AvatarManager*>(this), "findRayIntersection", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarManager*>(this), "findRayIntersection",
                                   Q_RETURN_ARG(RayToAvatarIntersectionResult, result),
                                   Q_ARG(const PickRay&, ray),
                                   Q_ARG(const QScriptValue&, avatarIdsToInclude),

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -483,7 +483,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersection(const PickRay& 
                                                                  const QScriptValue& avatarIdsToDiscard) {
     RayToAvatarIntersectionResult result;
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarManager*>(this), "findRayIntersection",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarManager*>(this), "findRayIntersection",
                                   Q_RETURN_ARG(RayToAvatarIntersectionResult, result),
                                   Q_ARG(const PickRay&, ray),
                                   Q_ARG(const QScriptValue&, avatarIdsToInclude),

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -21,6 +21,7 @@
 
 #include <QtCore/QTimer>
 
+#include <shared/QtHelpers.h>
 #include <scripting/HMDScriptingInterface.h>
 #include <AccountManager.h>
 #include <AddressManager.h>
@@ -897,7 +898,7 @@ void MyAvatar::restoreAnimation() {
 QStringList MyAvatar::getAnimationRoles() {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        QMetaObject::invokeMethod(this, "getAnimationRoles", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QStringList, result));
+        hifi::qt::blockingInvokeMethod(this, "getAnimationRoles", Q_RETURN_ARG(QStringList, result));
         return result;
     }
     return _skeletonModel->getRig().getAnimationRoles();
@@ -1368,7 +1369,7 @@ void MyAvatar::resetFullAvatarURL() {
 void MyAvatar::useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelName) {
 
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "useFullAvatarURL", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "useFullAvatarURL",
                                   Q_ARG(const QUrl&, fullAvatarURL),
                                   Q_ARG(const QString&, modelName));
         return;
@@ -1394,7 +1395,7 @@ void MyAvatar::useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelN
 
 void MyAvatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setAttachmentData", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "setAttachmentData",
                                   Q_ARG(const QVector<AttachmentData>, attachmentData));
         return;
     }
@@ -2358,7 +2359,7 @@ bool MyAvatar::safeLanding(const glm::vec3& position) {
 
     if (QThread::currentThread() != thread()) {
         bool result;
-        QMetaObject::invokeMethod(this, "safeLanding", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, result), Q_ARG(const glm::vec3&, position));
+        hifi::qt::blockingInvokeMethod(this, "safeLanding", Q_RETURN_ARG(bool, result), Q_ARG(const glm::vec3&, position));
         return result;
     }
     glm::vec3 better;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -898,7 +898,7 @@ void MyAvatar::restoreAnimation() {
 QStringList MyAvatar::getAnimationRoles() {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        hifi::qt::blockingInvokeMethod(this, "getAnimationRoles", Q_RETURN_ARG(QStringList, result));
+        BLOCKING_INVOKE_METHOD(this, "getAnimationRoles", Q_RETURN_ARG(QStringList, result));
         return result;
     }
     return _skeletonModel->getRig().getAnimationRoles();
@@ -1369,7 +1369,7 @@ void MyAvatar::resetFullAvatarURL() {
 void MyAvatar::useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelName) {
 
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "useFullAvatarURL",
+        BLOCKING_INVOKE_METHOD(this, "useFullAvatarURL",
                                   Q_ARG(const QUrl&, fullAvatarURL),
                                   Q_ARG(const QString&, modelName));
         return;
@@ -1395,7 +1395,7 @@ void MyAvatar::useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelN
 
 void MyAvatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "setAttachmentData",
+        BLOCKING_INVOKE_METHOD(this, "setAttachmentData",
                                   Q_ARG(const QVector<AttachmentData>, attachmentData));
         return;
     }
@@ -2359,7 +2359,7 @@ bool MyAvatar::safeLanding(const glm::vec3& position) {
 
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "safeLanding", Q_RETURN_ARG(bool, result), Q_ARG(const glm::vec3&, position));
+        BLOCKING_INVOKE_METHOD(this, "safeLanding", Q_RETURN_ARG(bool, result), Q_ARG(const glm::vec3&, position));
         return result;
     }
     glm::vec3 better;

--- a/interface/src/scripting/Audio.h
+++ b/interface/src/scripting/Audio.h
@@ -62,9 +62,12 @@ signals:
     void contextChanged(const QString& context);
 
 public slots:
-    void onMutedChanged();
     void onContextChanged();
-    void onInputChanged();
+
+private slots:
+    void onMutedChanged();
+    void onNoiseReductionChanged();
+    void onInputVolumeChanged(float volume);
     void onInputLoudnessChanged(float loudness);
 
 protected:

--- a/interface/src/scripting/AudioDevices.h
+++ b/interface/src/scripting/AudioDevices.h
@@ -58,7 +58,7 @@ private:
 
     static QHash<int, QByteArray> _roles;
     static Qt::ItemFlags _flags;
-
+    bool _userSelection { false };
     QAudio::Mode _mode;
     QAudioDeviceInfo _selectedDevice;
     QList<AudioDevice> _devices;

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -27,7 +27,7 @@ float ClipboardScriptingInterface::getClipboardContentsLargestDimension() {
 
 bool ClipboardScriptingInterface::exportEntities(const QString& filename, const QVector<EntityItemID>& entityIDs) {
     bool retVal;
-    hifi::qt::blockingInvokeMethod(qApp, "exportEntities",
+    BLOCKING_INVOKE_METHOD(qApp, "exportEntities",
                               Q_RETURN_ARG(bool, retVal),
                               Q_ARG(const QString&, filename),
                               Q_ARG(const QVector<EntityItemID>&, entityIDs));
@@ -36,7 +36,7 @@ bool ClipboardScriptingInterface::exportEntities(const QString& filename, const 
 
 bool ClipboardScriptingInterface::exportEntities(const QString& filename, float x, float y, float z, float s) {
     bool retVal;
-    hifi::qt::blockingInvokeMethod(qApp, "exportEntities",
+    BLOCKING_INVOKE_METHOD(qApp, "exportEntities",
                               Q_RETURN_ARG(bool, retVal),
                               Q_ARG(const QString&, filename),
                               Q_ARG(float, x),
@@ -48,7 +48,7 @@ bool ClipboardScriptingInterface::exportEntities(const QString& filename, float 
 
 bool ClipboardScriptingInterface::importEntities(const QString& filename) {
     bool retVal;
-    hifi::qt::blockingInvokeMethod(qApp, "importEntities",
+    BLOCKING_INVOKE_METHOD(qApp, "importEntities",
                               Q_RETURN_ARG(bool, retVal),
                               Q_ARG(const QString&, filename));
     return retVal;
@@ -56,7 +56,7 @@ bool ClipboardScriptingInterface::importEntities(const QString& filename) {
 
 QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(glm::vec3 position) {
     QVector<EntityItemID> retVal;
-    hifi::qt::blockingInvokeMethod(qApp, "pasteEntities",
+    BLOCKING_INVOKE_METHOD(qApp, "pasteEntities",
                               Q_RETURN_ARG(QVector<EntityItemID>, retVal),
                               Q_ARG(float, position.x),
                               Q_ARG(float, position.y),

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -8,8 +8,11 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include "Application.h"
 #include "ClipboardScriptingInterface.h"
+
+#include <shared/QtHelpers.h>
+
+#include "Application.h"
 
 ClipboardScriptingInterface::ClipboardScriptingInterface() {
 }
@@ -24,7 +27,7 @@ float ClipboardScriptingInterface::getClipboardContentsLargestDimension() {
 
 bool ClipboardScriptingInterface::exportEntities(const QString& filename, const QVector<EntityItemID>& entityIDs) {
     bool retVal;
-    QMetaObject::invokeMethod(qApp, "exportEntities", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(qApp, "exportEntities",
                               Q_RETURN_ARG(bool, retVal),
                               Q_ARG(const QString&, filename),
                               Q_ARG(const QVector<EntityItemID>&, entityIDs));
@@ -33,7 +36,7 @@ bool ClipboardScriptingInterface::exportEntities(const QString& filename, const 
 
 bool ClipboardScriptingInterface::exportEntities(const QString& filename, float x, float y, float z, float s) {
     bool retVal;
-    QMetaObject::invokeMethod(qApp, "exportEntities", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(qApp, "exportEntities",
                               Q_RETURN_ARG(bool, retVal),
                               Q_ARG(const QString&, filename),
                               Q_ARG(float, x),
@@ -45,7 +48,7 @@ bool ClipboardScriptingInterface::exportEntities(const QString& filename, float 
 
 bool ClipboardScriptingInterface::importEntities(const QString& filename) {
     bool retVal;
-    QMetaObject::invokeMethod(qApp, "importEntities", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(qApp, "importEntities",
                               Q_RETURN_ARG(bool, retVal),
                               Q_ARG(const QString&, filename));
     return retVal;
@@ -53,7 +56,7 @@ bool ClipboardScriptingInterface::importEntities(const QString& filename) {
 
 QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(glm::vec3 position) {
     QVector<EntityItemID> retVal;
-    QMetaObject::invokeMethod(qApp, "pasteEntities", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(qApp, "pasteEntities",
                               Q_RETURN_ARG(QVector<EntityItemID>, retVal),
                               Q_ARG(float, position.x),
                               Q_ARG(float, position.y),

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -13,6 +13,10 @@
 
 #include <QObject>
 
+#include <glm/glm.hpp>
+
+#include <EntityItemID.h>
+
 /**jsdoc
  * @namespace Clipboard
  */

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -13,6 +13,7 @@
 
 #include <QtScript/QScriptContext>
 
+#include <shared/QtHelpers.h>
 #include <avatar/AvatarManager.h>
 #include <display-plugins/DisplayPlugin.h>
 #include <display-plugins/CompositorHelper.h>
@@ -152,22 +153,31 @@ QString HMDScriptingInterface::preferredAudioOutput() const {
     return qApp->getActiveDisplayPlugin()->getPreferredAudioOutDevice();
 }
 
-bool HMDScriptingInterface::setHandLasers(int hands, bool enabled, const glm::vec4& color, const glm::vec3& direction) const {
+bool HMDScriptingInterface::setHandLasers(int hands, bool enabled, const glm::vec4& color, const glm::vec3& direction) {
+    if (QThread::currentThread() != thread()) {
+        bool result;
+        hifi::qt::blockingInvokeMethod(this, "setHandLasers", Q_RETURN_ARG(bool, result), 
+            Q_ARG(int, hands), Q_ARG(bool, enabled), Q_ARG(glm::vec4, color), Q_ARG(glm::vec3, direction));
+        return result;
+    }
+
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->executeOnUiThread([offscreenUi, enabled] {
-        offscreenUi->getDesktop()->setProperty("hmdHandMouseActive", enabled);
-    });
+    offscreenUi->getDesktop()->setProperty("hmdHandMouseActive", enabled);
     return qApp->getActiveDisplayPlugin()->setHandLaser(hands,
         enabled ? DisplayPlugin::HandLaserMode::Overlay : DisplayPlugin::HandLaserMode::None,
         color, direction);
 }
 
-bool HMDScriptingInterface::setExtraLaser(const glm::vec3& worldStart, bool enabled, const glm::vec4& color, const glm::vec3& direction) const {
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->executeOnUiThread([offscreenUi, enabled] {
-        offscreenUi->getDesktop()->setProperty("hmdHandMouseActive", enabled);
-    });
+bool HMDScriptingInterface::setExtraLaser(const glm::vec3& worldStart, bool enabled, const glm::vec4& color, const glm::vec3& direction) {
+    if (QThread::currentThread() != thread()) {
+        bool result;
+        hifi::qt::blockingInvokeMethod(this, "setExtraLaser", Q_RETURN_ARG(bool, result), 
+            Q_ARG(glm::vec3, worldStart), Q_ARG(bool, enabled), Q_ARG(glm::vec4, color), Q_ARG(glm::vec3, direction));
+        return result;
+    }
 
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    offscreenUi->getDesktop()->setProperty("hmdHandMouseActive", enabled);
 
     auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
     auto sensorToWorld = myAvatar->getSensorToWorldMatrix();
@@ -179,11 +189,11 @@ bool HMDScriptingInterface::setExtraLaser(const glm::vec3& worldStart, bool enab
         color, sensorStart, sensorDirection);
 }
 
-void HMDScriptingInterface::disableExtraLaser() const {
+void HMDScriptingInterface::disableExtraLaser() {
     setExtraLaser(vec3(0), false, vec4(0), vec3(0));
 }
 
-void HMDScriptingInterface::disableHandLasers(int hands) const {
+void HMDScriptingInterface::disableHandLasers(int hands) {
     setHandLasers(hands, false, vec4(0), vec3(0));
 }
 

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -156,7 +156,7 @@ QString HMDScriptingInterface::preferredAudioOutput() const {
 bool HMDScriptingInterface::setHandLasers(int hands, bool enabled, const glm::vec4& color, const glm::vec3& direction) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "setHandLasers", Q_RETURN_ARG(bool, result), 
+        BLOCKING_INVOKE_METHOD(this, "setHandLasers", Q_RETURN_ARG(bool, result), 
             Q_ARG(int, hands), Q_ARG(bool, enabled), Q_ARG(glm::vec4, color), Q_ARG(glm::vec3, direction));
         return result;
     }
@@ -171,7 +171,7 @@ bool HMDScriptingInterface::setHandLasers(int hands, bool enabled, const glm::ve
 bool HMDScriptingInterface::setExtraLaser(const glm::vec3& worldStart, bool enabled, const glm::vec4& color, const glm::vec3& direction) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "setExtraLaser", Q_RETURN_ARG(bool, result), 
+        BLOCKING_INVOKE_METHOD(this, "setExtraLaser", Q_RETURN_ARG(bool, result), 
             Q_ARG(glm::vec3, worldStart), Q_ARG(bool, enabled), Q_ARG(glm::vec4, color), Q_ARG(glm::vec3, direction));
         return result;
     }

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -51,11 +51,11 @@ public:
     Q_INVOKABLE void requestHideHandControllers();
     Q_INVOKABLE bool shouldShowHandControllers() const;
 
-    Q_INVOKABLE bool setHandLasers(int hands, bool enabled, const glm::vec4& color, const glm::vec3& direction) const;
-    Q_INVOKABLE void disableHandLasers(int hands) const;
+    Q_INVOKABLE bool setHandLasers(int hands, bool enabled, const glm::vec4& color, const glm::vec3& direction);
+    Q_INVOKABLE void disableHandLasers(int hands);
 
-    Q_INVOKABLE bool setExtraLaser(const glm::vec3& worldStart, bool enabled, const glm::vec4& color, const glm::vec3& direction) const;
-    Q_INVOKABLE void disableExtraLaser() const;
+    Q_INVOKABLE bool setExtraLaser(const glm::vec3& worldStart, bool enabled, const glm::vec4& color, const glm::vec3& direction);
+    Q_INVOKABLE void disableExtraLaser();
 
 
     /// Suppress the activation of any on-screen keyboard so that a script operation will

--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -14,6 +14,7 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QThread>
 
+#include <shared/QtHelpers.h>
 #include <MenuItemProperties.h>
 #include "Menu.h"
 
@@ -43,7 +44,7 @@ bool MenuScriptingInterface::menuExists(const QString& menu) {
         return Menu::getInstance()->menuExists(menu);
     }
     bool result;
-    QMetaObject::invokeMethod(Menu::getInstance(), "menuExists", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "menuExists",
                 Q_RETURN_ARG(bool, result), 
                 Q_ARG(const QString&, menu));
     return result;
@@ -86,7 +87,7 @@ bool MenuScriptingInterface::menuItemExists(const QString& menu, const QString& 
         return Menu::getInstance()->menuItemExists(menu, menuitem);
     }
     bool result;
-    QMetaObject::invokeMethod(Menu::getInstance(), "menuItemExists", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "menuItemExists",
         Q_RETURN_ARG(bool, result),
         Q_ARG(const QString&, menu),
         Q_ARG(const QString&, menuitem));
@@ -114,7 +115,7 @@ bool MenuScriptingInterface::isOptionChecked(const QString& menuOption) {
         return Menu::getInstance()->isOptionChecked(menuOption);
     }
     bool result;
-    QMetaObject::invokeMethod(Menu::getInstance(), "isOptionChecked", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "isOptionChecked",
                 Q_RETURN_ARG(bool, result), 
                 Q_ARG(const QString&, menuOption));
     return result;
@@ -131,7 +132,7 @@ bool MenuScriptingInterface::isMenuEnabled(const QString& menuOption) {
         return Menu::getInstance()->isOptionChecked(menuOption);
     }
     bool result;
-    QMetaObject::invokeMethod(Menu::getInstance(), "isMenuEnabled", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "isMenuEnabled",
         Q_RETURN_ARG(bool, result),
         Q_ARG(const QString&, menuOption));
     return result;
@@ -157,7 +158,7 @@ bool MenuScriptingInterface::isInfoViewVisible(const QString& path) {
     }
         
     bool result;
-    QMetaObject::invokeMethod(Menu::getInstance(), "isInfoViewVisible", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "isInfoViewVisible",
         Q_RETURN_ARG(bool, result), Q_ARG(const QString&, path));
     return result;
 }

--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -44,7 +44,7 @@ bool MenuScriptingInterface::menuExists(const QString& menu) {
         return Menu::getInstance()->menuExists(menu);
     }
     bool result;
-    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "menuExists",
+    BLOCKING_INVOKE_METHOD(Menu::getInstance(), "menuExists",
                 Q_RETURN_ARG(bool, result), 
                 Q_ARG(const QString&, menu));
     return result;
@@ -87,7 +87,7 @@ bool MenuScriptingInterface::menuItemExists(const QString& menu, const QString& 
         return Menu::getInstance()->menuItemExists(menu, menuitem);
     }
     bool result;
-    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "menuItemExists",
+    BLOCKING_INVOKE_METHOD(Menu::getInstance(), "menuItemExists",
         Q_RETURN_ARG(bool, result),
         Q_ARG(const QString&, menu),
         Q_ARG(const QString&, menuitem));
@@ -115,7 +115,7 @@ bool MenuScriptingInterface::isOptionChecked(const QString& menuOption) {
         return Menu::getInstance()->isOptionChecked(menuOption);
     }
     bool result;
-    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "isOptionChecked",
+    BLOCKING_INVOKE_METHOD(Menu::getInstance(), "isOptionChecked",
                 Q_RETURN_ARG(bool, result), 
                 Q_ARG(const QString&, menuOption));
     return result;
@@ -132,7 +132,7 @@ bool MenuScriptingInterface::isMenuEnabled(const QString& menuOption) {
         return Menu::getInstance()->isOptionChecked(menuOption);
     }
     bool result;
-    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "isMenuEnabled",
+    BLOCKING_INVOKE_METHOD(Menu::getInstance(), "isMenuEnabled",
         Q_RETURN_ARG(bool, result),
         Q_ARG(const QString&, menuOption));
     return result;
@@ -158,7 +158,7 @@ bool MenuScriptingInterface::isInfoViewVisible(const QString& path) {
     }
         
     bool result;
-    hifi::qt::blockingInvokeMethod(Menu::getInstance(), "isInfoViewVisible",
+    BLOCKING_INVOKE_METHOD(Menu::getInstance(), "isInfoViewVisible",
         Q_RETURN_ARG(bool, result), Q_ARG(const QString&, path));
     return result;
 }

--- a/interface/src/scripting/TestScriptingInterface.cpp
+++ b/interface/src/scripting/TestScriptingInterface.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QThread>
 
+#include <shared/QtHelpers.h>
 #include <DependencyManager.h>
 #include <Trace.h>
 #include <StatTracker.h>
@@ -57,20 +58,25 @@ void TestScriptingInterface::waitIdle() {
 }
 
 bool TestScriptingInterface::loadTestScene(QString scene) {
+    if (QThread::currentThread() != thread()) {
+        bool result;
+        hifi::qt::blockingInvokeMethod(this, "loadTestScene", Q_RETURN_ARG(bool, result), Q_ARG(QString, scene));
+        return result;
+    }
+
     static const QString TEST_ROOT = "https://raw.githubusercontent.com/highfidelity/hifi_tests/master/";
     static const QString TEST_BINARY_ROOT = "https://hifi-public.s3.amazonaws.com/test_scene_data/";
     static const QString TEST_SCRIPTS_ROOT = TEST_ROOT + "scripts/";
     static const QString TEST_SCENES_ROOT = TEST_ROOT + "scenes/";
-    return DependencyManager::get<OffscreenUi>()->returnFromUiThread([scene]()->QVariant {
-        DependencyManager::get<ResourceManager>()->setUrlPrefixOverride("atp:/", TEST_BINARY_ROOT + scene + ".atp/");
-        auto tree = qApp->getEntities()->getTree();
-        auto treeIsClient = tree->getIsClient();
-        // Force the tree to accept the load regardless of permissions
-        tree->setIsClient(false);
-        auto result = tree->readFromURL(TEST_SCENES_ROOT + scene + ".json");
-        tree->setIsClient(treeIsClient);
-        return result;
-    }).toBool();
+    
+    DependencyManager::get<ResourceManager>()->setUrlPrefixOverride("atp:/", TEST_BINARY_ROOT + scene + ".atp/");
+    auto tree = qApp->getEntities()->getTree();
+    auto treeIsClient = tree->getIsClient();
+    // Force the tree to accept the load regardless of permissions
+    tree->setIsClient(false);
+    auto result = tree->readFromURL(TEST_SCENES_ROOT + scene + ".json");
+    tree->setIsClient(treeIsClient);
+    return result;
 }
 
 bool TestScriptingInterface::startTracing(QString logrules) {

--- a/interface/src/scripting/TestScriptingInterface.cpp
+++ b/interface/src/scripting/TestScriptingInterface.cpp
@@ -60,7 +60,7 @@ void TestScriptingInterface::waitIdle() {
 bool TestScriptingInterface::loadTestScene(QString scene) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "loadTestScene", Q_RETURN_ARG(bool, result), Q_ARG(QString, scene));
+        BLOCKING_INVOKE_METHOD(this, "loadTestScene", Q_RETURN_ARG(bool, result), Q_ARG(QString, scene));
         return result;
     }
 

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -317,7 +317,7 @@ bool WindowScriptingInterface::isPhysicsEnabled() {
 int WindowScriptingInterface::openMessageBox(QString title, QString text, int buttons, int defaultButton) {
     if (QThread::currentThread() != thread()) {
         int result;
-        hifi::qt::blockingInvokeMethod(this, "openMessageBox",
+        BLOCKING_INVOKE_METHOD(this, "openMessageBox",
             Q_RETURN_ARG(int, result),
             Q_ARG(QString, title),
             Q_ARG(QString, text),

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -9,11 +9,14 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "WindowScriptingInterface.h"
+
 #include <QClipboard>
 #include <QtCore/QDir>
 #include <QMessageBox>
 #include <QScriptValue>
 
+#include <shared/QtHelpers.h>
 #include <SettingHandle.h>
 
 #include <display-plugins/CompositorHelper.h>
@@ -23,8 +26,6 @@
 #include "MainWindow.h"
 #include "Menu.h"
 #include "OffscreenUi.h"
-
-#include "WindowScriptingInterface.h"
 
 static const QString DESKTOP_LOCATION = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
 static const QString LAST_BROWSE_LOCATION_SETTING = "LastBrowseLocation";
@@ -316,7 +317,7 @@ bool WindowScriptingInterface::isPhysicsEnabled() {
 int WindowScriptingInterface::openMessageBox(QString title, QString text, int buttons, int defaultButton) {
     if (QThread::currentThread() != thread()) {
         int result;
-        QMetaObject::invokeMethod(this, "openMessageBox", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "openMessageBox",
             Q_RETURN_ARG(int, result),
             Q_ARG(QString, title),
             Q_ARG(QString, text),

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -18,6 +18,8 @@
 #include <QtScript/QScriptValue>
 #include <QtWidgets/QMessageBox>
 
+#include <DependencyManager.h>
+
 class CustomPromptResult {
 public:
     QVariant value;

--- a/interface/src/ui/JSConsole.cpp
+++ b/interface/src/ui/JSConsole.cpp
@@ -116,7 +116,7 @@ void JSConsole::executeCommand(const QString& command) {
 
 QScriptValue JSConsole::executeCommandInWatcher(const QString& command) {
     QScriptValue result;
-    hifi::qt::blockingInvokeMethod(_scriptEngine, "evaluate",
+    BLOCKING_INVOKE_METHOD(_scriptEngine, "evaluate",
                               Q_RETURN_ARG(QScriptValue, result),
                               Q_ARG(const QString&, command),
                               Q_ARG(const QString&, _consoleFileName));

--- a/interface/src/ui/JSConsole.cpp
+++ b/interface/src/ui/JSConsole.cpp
@@ -15,6 +15,7 @@
 #include <QScrollBar>
 #include <QtConcurrent/QtConcurrentRun>
 
+#include <shared/QtHelpers.h>
 #include <ScriptEngines.h>
 #include <PathUtils.h>
 
@@ -115,7 +116,7 @@ void JSConsole::executeCommand(const QString& command) {
 
 QScriptValue JSConsole::executeCommandInWatcher(const QString& command) {
     QScriptValue result;
-    QMetaObject::invokeMethod(_scriptEngine, "evaluate", Qt::ConnectionType::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(_scriptEngine, "evaluate",
                               Q_RETURN_ARG(QScriptValue, result),
                               Q_ARG(const QString&, command),
                               Q_ARG(const QString&, _consoleFileName));

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -45,11 +45,13 @@ Image3DOverlay::~Image3DOverlay() {
 }
 
 void Image3DOverlay::update(float deltatime) {
+#if OVERLAY_PANELS
     if (usecTimestampNow() > _transformExpiry) {
         Transform transform = getTransform();
         applyTransformTo(transform);
         setTransform(transform);
     }
+#endif
 }
 
 void Image3DOverlay::render(RenderArgs* args) {

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -84,9 +84,9 @@ public:
     void setColorPulse(float value) { _colorPulse = value; }
     void setAlphaPulse(float value) { _alphaPulse = value; }
 
-    virtual void setProperties(const QVariantMap& properties);
-    virtual Overlay* createClone() const = 0;
-    virtual QVariant getProperty(const QString& property);
+    Q_INVOKABLE virtual void setProperties(const QVariantMap& properties);
+    Q_INVOKABLE virtual Overlay* createClone() const = 0;
+    Q_INVOKABLE virtual QVariant getProperty(const QString& property);
 
     render::ItemID getRenderItemID() const { return _renderItemID; }
     void setRenderItemID(render::ItemID renderItemID) { _renderItemID = renderItemID; }

--- a/interface/src/ui/overlays/OverlayPanel.cpp
+++ b/interface/src/ui/overlays/OverlayPanel.cpp
@@ -11,6 +11,8 @@
 
 #include "OverlayPanel.h"
 
+#if OVERLAY_PANELS
+
 #include <QVariant>
 #include <RegisteredMetaTypes.h>
 #include <DependencyManager.h>
@@ -185,3 +187,4 @@ void OverlayPanel::applyTransformTo(Transform& transform, bool force) {
         pointTransformAtCamera(transform, getOffsetRotation());
     }
 }
+#endif

--- a/interface/src/ui/overlays/OverlayPanel.h
+++ b/interface/src/ui/overlays/OverlayPanel.h
@@ -22,6 +22,7 @@
 #include "Billboardable.h"
 #include "Overlay.h"
 
+#if OVERLAY_PANELS
 class PropertyBinding {
 public:
     PropertyBinding() {}
@@ -79,5 +80,7 @@ private:
 
     QScriptEngine* _scriptEngine;
 };
+
+#endif
 
 #endif // hifi_OverlayPanel_h

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -145,7 +145,7 @@ Overlay::Pointer Overlays::getOverlay(OverlayID id) const {
 OverlayID Overlays::addOverlay(const QString& type, const QVariant& properties) {
     if (QThread::currentThread() != thread()) {
         OverlayID result;
-        hifi::qt::blockingInvokeMethod(this, "addOverlay", Q_RETURN_ARG(OverlayID, result), Q_ARG(QString, type), Q_ARG(QVariant, properties));
+        BLOCKING_INVOKE_METHOD(this, "addOverlay", Q_RETURN_ARG(OverlayID, result), Q_ARG(QString, type), Q_ARG(QVariant, properties));
         return result;
     }
 
@@ -209,7 +209,7 @@ OverlayID Overlays::addOverlay(const Overlay::Pointer& overlay) {
 OverlayID Overlays::cloneOverlay(OverlayID id) {
     if (QThread::currentThread() != thread()) {
         OverlayID result;
-        hifi::qt::blockingInvokeMethod(this, "cloneOverlay", Q_RETURN_ARG(OverlayID, result), Q_ARG(OverlayID, id));
+        BLOCKING_INVOKE_METHOD(this, "cloneOverlay", Q_RETURN_ARG(OverlayID, result), Q_ARG(OverlayID, id));
         return result;
     }
 
@@ -232,7 +232,7 @@ OverlayID Overlays::cloneOverlay(OverlayID id) {
 bool Overlays::editOverlay(OverlayID id, const QVariant& properties) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "editOverlay", Q_RETURN_ARG(bool, result), Q_ARG(OverlayID, id), Q_ARG(QVariant, properties));
+        BLOCKING_INVOKE_METHOD(this, "editOverlay", Q_RETURN_ARG(bool, result), Q_ARG(OverlayID, id), Q_ARG(QVariant, properties));
         return result;
     }
 
@@ -247,7 +247,7 @@ bool Overlays::editOverlay(OverlayID id, const QVariant& properties) {
 bool Overlays::editOverlays(const QVariant& propertiesById) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "editOverlays", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, propertiesById));
+        BLOCKING_INVOKE_METHOD(this, "editOverlays", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, propertiesById));
         return result;
     }
 
@@ -299,7 +299,7 @@ void Overlays::deleteOverlay(OverlayID id) {
 QString Overlays::getOverlayType(OverlayID overlayId) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        hifi::qt::blockingInvokeMethod(this, "getOverlayType", Q_RETURN_ARG(QString, result), Q_ARG(OverlayID, overlayId));
+        BLOCKING_INVOKE_METHOD(this, "getOverlayType", Q_RETURN_ARG(QString, result), Q_ARG(OverlayID, overlayId));
         return result;
     }
 
@@ -313,7 +313,7 @@ QString Overlays::getOverlayType(OverlayID overlayId) {
 QObject* Overlays::getOverlayObject(OverlayID id) {
     if (QThread::currentThread() != thread()) {
         QObject* result;
-        hifi::qt::blockingInvokeMethod(this, "getOverlayObject", Q_RETURN_ARG(QObject*, result), Q_ARG(OverlayID, id));
+        BLOCKING_INVOKE_METHOD(this, "getOverlayObject", Q_RETURN_ARG(QObject*, result), Q_ARG(OverlayID, id));
         return result;
     }
 
@@ -370,7 +370,7 @@ void Overlays::setParentPanel(OverlayID childId, OverlayID panelId) {
 OverlayID Overlays::getOverlayAtPoint(const glm::vec2& point) {
     if (QThread::currentThread() != thread()) {
         OverlayID result;
-        hifi::qt::blockingInvokeMethod(this, "getOverlayAtPoint", Q_RETURN_ARG(OverlayID, result), Q_ARG(glm::vec2, point));
+        BLOCKING_INVOKE_METHOD(this, "getOverlayAtPoint", Q_RETURN_ARG(OverlayID, result), Q_ARG(glm::vec2, point));
         return result;
     }
 
@@ -408,7 +408,7 @@ OverlayID Overlays::getOverlayAtPoint(const glm::vec2& point) {
 OverlayPropertyResult Overlays::getProperty(OverlayID id, const QString& property) {
     if (QThread::currentThread() != thread()) {
         OverlayPropertyResult result;
-        hifi::qt::blockingInvokeMethod(this, "getProperty", Q_RETURN_ARG(OverlayPropertyResult, result), Q_ARG(OverlayID, id), Q_ARG(QString, property));
+        BLOCKING_INVOKE_METHOD(this, "getProperty", Q_RETURN_ARG(OverlayPropertyResult, result), Q_ARG(OverlayID, id), Q_ARG(QString, property));
         return result;
     }
 
@@ -453,7 +453,7 @@ RayToOverlayIntersectionResult Overlays::findRayIntersectionInternal(const PickR
                                                                      bool visibleOnly, bool collidableOnly) {
     if (QThread::currentThread() != thread()) {
         RayToOverlayIntersectionResult result;
-        hifi::qt::blockingInvokeMethod(this, "findRayIntersectionInternal", Q_RETURN_ARG(RayToOverlayIntersectionResult, result), 
+        BLOCKING_INVOKE_METHOD(this, "findRayIntersectionInternal", Q_RETURN_ARG(RayToOverlayIntersectionResult, result), 
             Q_ARG(PickRay, ray), 
             Q_ARG(bool, precisionPicking), 
             Q_ARG(QVector<OverlayID>, overlaysToInclude), 
@@ -580,7 +580,7 @@ void RayToOverlayIntersectionResultFromScriptValue(const QScriptValue& objectVar
 bool Overlays::isLoaded(OverlayID id) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "isLoaded", Q_RETURN_ARG(bool, result), Q_ARG(OverlayID, id));
+        BLOCKING_INVOKE_METHOD(this, "isLoaded", Q_RETURN_ARG(bool, result), Q_ARG(OverlayID, id));
         return result;
     }
 
@@ -594,7 +594,7 @@ bool Overlays::isLoaded(OverlayID id) {
 QSizeF Overlays::textSize(OverlayID id, const QString& text) {
     if (QThread::currentThread() != thread()) {
         QSizeF result;
-        hifi::qt::blockingInvokeMethod(this, "textSize", Q_RETURN_ARG(QSizeF, result), Q_ARG(OverlayID, id), Q_ARG(QString, text));
+        BLOCKING_INVOKE_METHOD(this, "textSize", Q_RETURN_ARG(QSizeF, result), Q_ARG(OverlayID, id), Q_ARG(QString, text));
         return result;
     }
 
@@ -671,7 +671,7 @@ void Overlays::deletePanel(OverlayID panelId) {
 bool Overlays::isAddedOverlay(OverlayID id) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "isAddedOverlay", Q_RETURN_ARG(bool, result), Q_ARG(OverlayID, id));
+        BLOCKING_INVOKE_METHOD(this, "isAddedOverlay", Q_RETURN_ARG(bool, result), Q_ARG(OverlayID, id));
         return result;
     }
 
@@ -705,7 +705,7 @@ void Overlays::sendHoverLeaveOverlay(OverlayID  id, PointerEvent event) {
 OverlayID Overlays::getKeyboardFocusOverlay() {
     if (QThread::currentThread() != thread()) {
         OverlayID result;
-        hifi::qt::blockingInvokeMethod(this, "getKeyboardFocusOverlay", Q_RETURN_ARG(OverlayID, result));
+        BLOCKING_INVOKE_METHOD(this, "getKeyboardFocusOverlay", Q_RETURN_ARG(OverlayID, result));
         return result;
     }
 
@@ -724,7 +724,7 @@ void Overlays::setKeyboardFocusOverlay(OverlayID id) {
 float Overlays::width() {
     if (QThread::currentThread() != thread()) {
         float result;
-        hifi::qt::blockingInvokeMethod(this, "width", Q_RETURN_ARG(float, result));
+        BLOCKING_INVOKE_METHOD(this, "width", Q_RETURN_ARG(float, result));
         return result;
     }
 
@@ -735,7 +735,7 @@ float Overlays::width() {
 float Overlays::height() {
     if (QThread::currentThread() != thread()) {
         float result;
-        hifi::qt::blockingInvokeMethod(this, "height", Q_RETURN_ARG(float, result));
+        BLOCKING_INVOKE_METHOD(this, "height", Q_RETURN_ARG(float, result));
         return result;
     }
 
@@ -945,7 +945,7 @@ bool Overlays::mouseMoveEvent(QMouseEvent* event) {
 QVector<QUuid> Overlays::findOverlays(const glm::vec3& center, float radius) {
     QVector<QUuid> result;
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "findOverlays", Q_RETURN_ARG(QVector<QUuid>, result), Q_ARG(glm::vec3, center), Q_ARG(float, radius));
+        BLOCKING_INVOKE_METHOD(this, "findOverlays", Q_RETURN_ARG(QVector<QUuid>, result), Q_ARG(glm::vec3, center), Q_ARG(float, radius));
         return result;
     }
 

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -25,8 +25,9 @@
 #include <PointerEvent.h>
 
 #include "Overlay.h"
-#include "OverlayPanel.h"
+
 #include "PanelAttachable.h"
+#include "OverlayPanel.h"
 
 class PickRay;
 
@@ -41,6 +42,8 @@ Q_DECLARE_METATYPE(OverlayPropertyResult);
 QScriptValue OverlayPropertyResultToScriptValue(QScriptEngine* engine, const OverlayPropertyResult& value);
 void OverlayPropertyResultFromScriptValue(const QScriptValue& object, OverlayPropertyResult& value);
 
+const OverlayID UNKNOWN_OVERLAY_ID = OverlayID();
+
 /**jsdoc
  * @typedef Overlays.RayToOverlayIntersectionResult
  * @property {bool} intersects True if the PickRay intersected with a 3D overlay.
@@ -51,10 +54,9 @@ void OverlayPropertyResultFromScriptValue(const QScriptValue& object, OverlayPro
  */
 class RayToOverlayIntersectionResult {
 public:
-    RayToOverlayIntersectionResult();
-    bool intersects;
-    OverlayID overlayID;
-    float distance;
+    bool intersects { false };
+    OverlayID overlayID { UNKNOWN_OVERLAY_ID };
+    float distance { 0 };
     BoxFace face;
     glm::vec3 surfaceNormal;
     glm::vec3 intersection;
@@ -77,8 +79,6 @@ void RayToOverlayIntersectionResultFromScriptValue(const QScriptValue& object, R
  * @namespace Overlays
  */
 
-const OverlayID UNKNOWN_OVERLAY_ID = OverlayID();
-
 class Overlays : public QObject {
     Q_OBJECT
 
@@ -94,11 +94,13 @@ public:
     void enable();
 
     Overlay::Pointer getOverlay(OverlayID id) const;
+#if OVERLAY_PANELS
     OverlayPanel::Pointer getPanel(OverlayID id) const { return _panels[id]; }
+#endif
 
     /// adds an overlay that's already been created
     OverlayID addOverlay(Overlay* overlay) { return addOverlay(Overlay::Pointer(overlay)); }
-    OverlayID addOverlay(Overlay::Pointer overlay);
+    OverlayID addOverlay(const Overlay::Pointer& overlay);
 
     bool mousePressEvent(QMouseEvent* event);
     bool mouseDoublePressEvent(QMouseEvent* event);
@@ -156,7 +158,7 @@ public slots:
      * @param {Overlays.OverlayID} overlayID The ID of the overlay to get the type of.
      * @return {string} The type of the overlay if found, otherwise the empty string.
      */
-    QString getOverlayType(OverlayID overlayId) const;
+    QString getOverlayType(OverlayID overlayId);
 
     /**jsdoc
     * Get the overlay Script object.
@@ -215,7 +217,7 @@ public slots:
      * @param {float} radius search radius
      * @return {Overlays.OverlayID[]} list of overlays withing the radius
      */
-    QVector<QUuid> findOverlays(const glm::vec3& center, float radius) const;
+    QVector<QUuid> findOverlays(const glm::vec3& center, float radius);
 
     /**jsdoc
      * Check whether an overlay's assets have been loaded. For example, if the
@@ -237,7 +239,7 @@ public slots:
      * @param {string} The string to measure.
      * @return {Vec2} The size of the text.
      */
-    QSizeF textSize(OverlayID id, const QString& text) const;
+    QSizeF textSize(OverlayID id, const QString& text);
 
     /**jsdoc
      * Get the width of the virtual 2D HUD.
@@ -245,7 +247,7 @@ public slots:
      * @function Overlays.width
      * @return {float} The width of the 2D HUD.
      */
-    float width() const;
+    float width();
 
     /**jsdoc
      * Get the height of the virtual 2D HUD.
@@ -253,11 +255,12 @@ public slots:
      * @function Overlays.height
      * @return {float} The height of the 2D HUD.
      */
-    float height() const;
+    float height();
 
     /// return true if there is an overlay with that id else false
     bool isAddedOverlay(OverlayID id);
 
+#if OVERLAY_PANELS
     OverlayID getParentPanel(OverlayID childId) const;
     void setParentPanel(OverlayID childId, OverlayID panelId);
 
@@ -279,6 +282,8 @@ public slots:
     /// return true if there is a panel with that id else false
     bool isAddedPanel(OverlayID id) { return _panels.contains(id); }
 
+#endif
+
     void sendMousePressOnOverlay(OverlayID overlayID, const PointerEvent& event);
     void sendMouseReleaseOnOverlay(OverlayID overlayID, const PointerEvent& event);
     void sendMouseMoveOnOverlay(OverlayID overlayID, const PointerEvent& event);
@@ -287,7 +292,7 @@ public slots:
     void sendHoverOverOverlay(OverlayID id, PointerEvent event);
     void sendHoverLeaveOverlay(OverlayID id, PointerEvent event);
 
-    OverlayID getKeyboardFocusOverlay() const;
+    OverlayID getKeyboardFocusOverlay();
     void setKeyboardFocusOverlay(OverlayID id);
 
 signals:
@@ -316,13 +321,15 @@ private:
 
     QMap<OverlayID, Overlay::Pointer> _overlaysHUD;
     QMap<OverlayID, Overlay::Pointer> _overlaysWorld;
+#if OVERLAY_PANELS
     QMap<OverlayID, OverlayPanel::Pointer> _panels;
+#endif
     QList<Overlay::Pointer> _overlaysToDelete;
     unsigned int _stackOrder { 1 };
 
-    QReadWriteLock _lock;
-    QReadWriteLock _deleteLock;
+#if OVERLAY_PANELS
     QScriptEngine* _scriptEngine;
+#endif
     bool _enabled = true;
 
     PointerEvent calculatePointerEvent(Overlay::Pointer overlay, PickRay ray, RayToOverlayIntersectionResult rayPickResult,
@@ -331,7 +338,7 @@ private:
     OverlayID _currentClickingOnOverlayID { UNKNOWN_OVERLAY_ID };
     OverlayID _currentHoverOverOverlayID { UNKNOWN_OVERLAY_ID };
 
-    RayToOverlayIntersectionResult findRayIntersectionInternal(const PickRay& ray, bool precisionPicking,
+    Q_INVOKABLE RayToOverlayIntersectionResult findRayIntersectionInternal(const PickRay& ray, bool precisionPicking,
                                                                const QVector<OverlayID>& overlaysToInclude,
                                                                const QVector<OverlayID>& overlaysToDiscard,
                                                                bool visibleOnly = false, bool collidableOnly = false);

--- a/interface/src/ui/overlays/PanelAttachable.cpp
+++ b/interface/src/ui/overlays/PanelAttachable.cpp
@@ -16,11 +16,15 @@
 #include "OverlayPanel.h"
 
 bool PanelAttachable::getParentVisible() const {
+#if OVERLAY_PANELS
     if (getParentPanel()) {
         return getParentPanel()->getVisible() && getParentPanel()->getParentVisible();
     } else {
         return true;
     }
+#else
+    return true;
+#endif
 }
 
 QVariant PanelAttachable::getProperty(const QString& property) {
@@ -61,11 +65,13 @@ void PanelAttachable::applyTransformTo(Transform& transform, bool force) {
     if (force || usecTimestampNow() > _transformExpiry) {
         const quint64 TRANSFORM_UPDATE_PERIOD = 100000; // frequency is 10 Hz
         _transformExpiry = usecTimestampNow() + TRANSFORM_UPDATE_PERIOD;
+#if OVERLAY_PANELS
         if (getParentPanel()) {
             getParentPanel()->applyTransformTo(transform, true);
             transform.postTranslate(getOffsetPosition());
             transform.postRotate(getOffsetRotation());
             transform.postScale(getOffsetScale());
         }
+#endif
     }
 }

--- a/interface/src/ui/overlays/PanelAttachable.h
+++ b/interface/src/ui/overlays/PanelAttachable.h
@@ -30,6 +30,8 @@
 #ifndef hifi_PanelAttachable_h
 #define hifi_PanelAttachable_h
 
+#define OVERLAY_PANELS 0
+
 #include <memory>
 
 #include <glm/glm.hpp>
@@ -39,18 +41,21 @@
 #include <QUuid>
 
 class OverlayPanel;
-
 class PanelAttachable {
 public:
     // getters
+#if OVERLAY_PANELS
     std::shared_ptr<OverlayPanel> getParentPanel() const { return _parentPanel; }
+#endif
     glm::vec3 getOffsetPosition() const { return _offset.getTranslation(); }
     glm::quat getOffsetRotation() const { return _offset.getRotation(); }
     glm::vec3 getOffsetScale() const { return _offset.getScale(); }
     bool getParentVisible() const;
 
     // setters
+#if OVERLAY_PANELS
     void setParentPanel(std::shared_ptr<OverlayPanel> panel) { _parentPanel = panel; }
+#endif
     void setOffsetPosition(const glm::vec3& position) { _offset.setTranslation(position); }
     void setOffsetRotation(const glm::quat& rotation) { _offset.setRotation(rotation); }
     void setOffsetScale(float scale) { _offset.setScale(scale); }
@@ -66,7 +71,9 @@ protected:
     quint64 _transformExpiry = 0;
 
 private:
+#if OVERLAY_PANELS
     std::shared_ptr<OverlayPanel> _parentPanel = nullptr;
+#endif
     Transform _offset;
 };
 

--- a/interface/src/ui/overlays/QmlOverlay.cpp
+++ b/interface/src/ui/overlays/QmlOverlay.cpp
@@ -32,21 +32,20 @@ QmlOverlay::QmlOverlay(const QUrl& url, const QmlOverlay* textOverlay)
 }
 
 void QmlOverlay::buildQmlElement(const QUrl& url) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "buildQmlElement", Q_ARG(QUrl, url));
+        return;
+    }
+
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->returnFromUiThread([=] {
-        offscreenUi->load(url, [=](QQmlContext* context, QObject* object) {
-            QQuickItem* rawPtr = dynamic_cast<QQuickItem*>(object);
-            // Create a shared ptr with a custom deleter lambda, that calls deleteLater
-            _qmlElement = std::shared_ptr<QQuickItem>(rawPtr, [](QQuickItem* ptr) {
-                if (ptr) {
-                    ptr->deleteLater();
-                }
-            });
+    offscreenUi->load(url, [=](QQmlContext* context, QObject* object) {
+        QQuickItem* rawPtr = dynamic_cast<QQuickItem*>(object);
+        // Create a shared ptr with a custom deleter lambda, that calls deleteLater
+        _qmlElement = std::shared_ptr<QQuickItem>(rawPtr, [](QQuickItem* ptr) {
+            if (ptr) {
+                ptr->deleteLater();
+            }
         });
-        while (!_qmlElement) {
-            qApp->processEvents();
-        }
-        return QVariant();
     });
 }
 
@@ -55,20 +54,23 @@ QmlOverlay::~QmlOverlay() {
 }
 
 void QmlOverlay::setProperties(const QVariantMap& properties) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setProperties", Q_ARG(QVariantMap, properties));
+        return;
+    }
+
     Overlay2D::setProperties(properties);
     auto bounds = _bounds;
     std::weak_ptr<QQuickItem> weakQmlElement = _qmlElement;
-    DependencyManager::get<OffscreenUi>()->executeOnUiThread([weakQmlElement, bounds, properties] {
-        // check to see if qmlElement still exists
-        auto qmlElement = weakQmlElement.lock();
-        if (qmlElement) {
-            qmlElement->setX(bounds.left());
-            qmlElement->setY(bounds.top());
-            qmlElement->setWidth(bounds.width());
-            qmlElement->setHeight(bounds.height());
-            QMetaObject::invokeMethod(qmlElement.get(), "updatePropertiesFromScript", Qt::DirectConnection, Q_ARG(QVariant, properties));
-        }
-    });
+    // check to see if qmlElement still exists
+    auto qmlElement = weakQmlElement.lock();
+    if (qmlElement) {
+        qmlElement->setX(bounds.left());
+        qmlElement->setY(bounds.top());
+        qmlElement->setWidth(bounds.width());
+        qmlElement->setHeight(bounds.height());
+        QMetaObject::invokeMethod(qmlElement.get(), "updatePropertiesFromScript", Qt::DirectConnection, Q_ARG(QVariant, properties));
+    }
 }
 
 void QmlOverlay::render(RenderArgs* args) {

--- a/interface/src/ui/overlays/QmlOverlay.h
+++ b/interface/src/ui/overlays/QmlOverlay.h
@@ -32,7 +32,7 @@ public:
     void render(RenderArgs* args) override;
 
 private:
-    void buildQmlElement(const QUrl& url);
+    Q_INVOKABLE void buildQmlElement(const QUrl& url);
 
 protected:
     std::shared_ptr<QQuickItem> _qmlElement;

--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -34,7 +34,7 @@ AnimationCache::AnimationCache(QObject* parent) :
 AnimationPointer AnimationCache::getAnimation(const QUrl& url) {
     if (QThread::currentThread() != thread()) {
         AnimationPointer result;
-        hifi::qt::blockingInvokeMethod(this, "getAnimation",
+        BLOCKING_INVOKE_METHOD(this, "getAnimation",
             Q_RETURN_ARG(AnimationPointer, result), Q_ARG(const QUrl&, url));
         return result;
     }
@@ -100,7 +100,7 @@ bool Animation::isLoaded() const {
 QStringList Animation::getJointNames() const {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        hifi::qt::blockingInvokeMethod(const_cast<Animation*>(this), "getJointNames",
+        BLOCKING_INVOKE_METHOD(const_cast<Animation*>(this), "getJointNames",
             Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -114,7 +114,7 @@ QStringList Animation::getJointNames() const {
 QVector<FBXAnimationFrame> Animation::getFrames() const {
     if (QThread::currentThread() != thread()) {
         QVector<FBXAnimationFrame> result;
-        hifi::qt::blockingInvokeMethod(const_cast<Animation*>(this), "getFrames", 
+        BLOCKING_INVOKE_METHOD(const_cast<Animation*>(this), "getFrames", 
             Q_RETURN_ARG(QVector<FBXAnimationFrame>, result));
         return result;
     }

--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -9,14 +9,17 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AnimationCache.h"
+
 #include <QRunnable>
 #include <QThreadPool>
 
-#include "AnimationCache.h"
-#include "AnimationLogging.h"
+#include <shared/QtHelpers.h>
 #include <Trace.h>
 #include <StatTracker.h>
 #include <Profile.h>
+
+#include "AnimationLogging.h"
 
 int animationPointerMetaTypeId = qRegisterMetaType<AnimationPointer>();
 
@@ -31,7 +34,7 @@ AnimationCache::AnimationCache(QObject* parent) :
 AnimationPointer AnimationCache::getAnimation(const QUrl& url) {
     if (QThread::currentThread() != thread()) {
         AnimationPointer result;
-        QMetaObject::invokeMethod(this, "getAnimation", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "getAnimation",
             Q_RETURN_ARG(AnimationPointer, result), Q_ARG(const QUrl&, url));
         return result;
     }
@@ -97,7 +100,7 @@ bool Animation::isLoaded() const {
 QStringList Animation::getJointNames() const {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        QMetaObject::invokeMethod(const_cast<Animation*>(this), "getJointNames", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<Animation*>(this), "getJointNames",
             Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -111,7 +114,7 @@ QStringList Animation::getJointNames() const {
 QVector<FBXAnimationFrame> Animation::getFrames() const {
     if (QThread::currentThread() != thread()) {
         QVector<FBXAnimationFrame> result;
-        QMetaObject::invokeMethod(const_cast<Animation*>(this), "getFrames", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<Animation*>(this), "getFrames", 
             Q_RETURN_ARG(QVector<FBXAnimationFrame>, result));
         return result;
     }

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -180,7 +180,8 @@ public slots:
 
     virtual void setIsStereoInput(bool stereo) override;
 
-    void setNoiseReduction(bool isNoiseGateEnabled) { _isNoiseGateEnabled = isNoiseGateEnabled; }
+    void setNoiseReduction(bool isNoiseGateEnabled);
+    bool isNoiseReductionEnabled() const { return _isNoiseGateEnabled; }
 
     void toggleLocalEcho() { _shouldEchoLocally = !_shouldEchoLocally; }
     void toggleServerEcho() { _shouldEchoToServer = !_shouldEchoToServer; }
@@ -197,7 +198,7 @@ public slots:
     bool switchAudioDevice(QAudio::Mode mode, const QString& deviceName);
 
     float getInputVolume() const { return (_audioInput) ? (float)_audioInput->volume() : 0.0f; }
-    void setInputVolume(float volume) { if (_audioInput) _audioInput->setVolume(volume); }
+    void setInputVolume(float volume);
     void setReverb(bool reverb);
     void setReverbOptions(const AudioEffectOptions* options);
 
@@ -207,7 +208,9 @@ public slots:
     void saveSettings();
 
 signals:
-    bool muteToggled();
+    void inputVolumeChanged(float volume);
+    void muteToggled();
+    void noiseReductionChanged();
     void mutedByMixer();
     void inputReceived(const QByteArray& inputSamples);
     void inputLoudnessChanged(float loudness);

--- a/libraries/audio/src/SoundCache.cpp
+++ b/libraries/audio/src/SoundCache.cpp
@@ -32,7 +32,7 @@ SoundCache::SoundCache(QObject* parent) :
 SharedSoundPointer SoundCache::getSound(const QUrl& url) {
     if (QThread::currentThread() != thread()) {
         SharedSoundPointer result;
-        hifi::qt::blockingInvokeMethod(this, "getSound", 
+        BLOCKING_INVOKE_METHOD(this, "getSound", 
                                   Q_RETURN_ARG(SharedSoundPointer, result), Q_ARG(const QUrl&, url));
         return result;
     }

--- a/libraries/audio/src/SoundCache.cpp
+++ b/libraries/audio/src/SoundCache.cpp
@@ -9,10 +9,13 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <qthread.h>
+#include "SoundCache.h"
+
+#include <QtCore/QThread>
+
+#include <shared/QtHelpers.h>
 
 #include "AudioLogging.h"
-#include "SoundCache.h"
 
 static const int SOUNDS_LOADING_PRIORITY { -7 }; // Make sure sounds load after the low rez texture mips
 
@@ -29,7 +32,7 @@ SoundCache::SoundCache(QObject* parent) :
 SharedSoundPointer SoundCache::getSound(const QUrl& url) {
     if (QThread::currentThread() != thread()) {
         SharedSoundPointer result;
-        QMetaObject::invokeMethod(this, "getSound", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "getSound", 
                                   Q_RETURN_ARG(SharedSoundPointer, result), Q_ARG(const QUrl&, url));
         return result;
     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1011,7 +1011,7 @@ glm::vec3 Avatar::getAbsoluteJointTranslationInObjectFrame(int index) const {
 int Avatar::getJointIndex(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         int result;
-        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointIndex",
+        BLOCKING_INVOKE_METHOD(const_cast<Avatar*>(this), "getJointIndex",
             Q_RETURN_ARG(int, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1025,7 +1025,7 @@ int Avatar::getJointIndex(const QString& name) const {
 QStringList Avatar::getJointNames() const {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointNames",
+        BLOCKING_INVOKE_METHOD(const_cast<Avatar*>(this), "getJointNames",
             Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -1035,7 +1035,7 @@ QStringList Avatar::getJointNames() const {
 glm::vec3 Avatar::getJointPosition(int index) const {
     if (QThread::currentThread() != thread()) {
         glm::vec3 position;
-        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointPosition",
+        BLOCKING_INVOKE_METHOD(const_cast<Avatar*>(this), "getJointPosition",
                                   Q_RETURN_ARG(glm::vec3, position), Q_ARG(const int, index));
         return position;
     }
@@ -1047,7 +1047,7 @@ glm::vec3 Avatar::getJointPosition(int index) const {
 glm::vec3 Avatar::getJointPosition(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         glm::vec3 position;
-        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointPosition",
+        BLOCKING_INVOKE_METHOD(const_cast<Avatar*>(this), "getJointPosition",
                                   Q_RETURN_ARG(glm::vec3, position), Q_ARG(const QString&, name));
         return position;
     }
@@ -1106,7 +1106,7 @@ static std::shared_ptr<Model> allocateAttachmentModel(bool isSoft, const Rig& ri
 
 void Avatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "setAttachmentData",
+        BLOCKING_INVOKE_METHOD(this, "setAttachmentData",
                                   Q_ARG(const QVector<AttachmentData>, attachmentData));
         return;
     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -15,6 +15,7 @@
 #include <glm/gtx/transform.hpp>
 #include <glm/gtx/vector_query.hpp>
 
+#include <shared/QtHelpers.h>
 #include <DeferredLightingEffect.h>
 #include <EntityTreeRenderer.h>
 #include <NodeList.h>
@@ -1010,7 +1011,7 @@ glm::vec3 Avatar::getAbsoluteJointTranslationInObjectFrame(int index) const {
 int Avatar::getJointIndex(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         int result;
-        QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointIndex", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointIndex",
             Q_RETURN_ARG(int, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1024,7 +1025,7 @@ int Avatar::getJointIndex(const QString& name) const {
 QStringList Avatar::getJointNames() const {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointNames", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointNames",
             Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -1034,7 +1035,7 @@ QStringList Avatar::getJointNames() const {
 glm::vec3 Avatar::getJointPosition(int index) const {
     if (QThread::currentThread() != thread()) {
         glm::vec3 position;
-        QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointPosition", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointPosition",
                                   Q_RETURN_ARG(glm::vec3, position), Q_ARG(const int, index));
         return position;
     }
@@ -1046,7 +1047,7 @@ glm::vec3 Avatar::getJointPosition(int index) const {
 glm::vec3 Avatar::getJointPosition(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         glm::vec3 position;
-        QMetaObject::invokeMethod(const_cast<Avatar*>(this), "getJointPosition", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<Avatar*>(this), "getJointPosition",
                                   Q_RETURN_ARG(glm::vec3, position), Q_ARG(const QString&, name));
         return position;
     }
@@ -1105,7 +1106,7 @@ static std::shared_ptr<Model> allocateAttachmentModel(bool isSoft, const Rig& ri
 
 void Avatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setAttachmentData", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "setAttachmentData",
                                   Q_ARG(const QVector<AttachmentData>, attachmentData));
         return;
     }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -25,6 +25,7 @@
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QNetworkRequest>
 
+#include <shared/QtHelpers.h>
 #include <QVariantGLM.h>
 #include <Transform.h>
 #include <NetworkAccessManager.h>
@@ -1227,7 +1228,7 @@ bool AvatarData::isJointDataValid(int index) const {
     }
     if (QThread::currentThread() != thread()) {
         bool result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "isJointDataValid", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "isJointDataValid", 
             Q_RETURN_ARG(bool, result), Q_ARG(int, index));
         return result;
     }
@@ -1240,7 +1241,7 @@ glm::quat AvatarData::getJointRotation(int index) const {
     }
     if (QThread::currentThread() != thread()) {
         glm::quat result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "getJointRotation", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointRotation", 
             Q_RETURN_ARG(glm::quat, result), Q_ARG(int, index));
         return result;
     }
@@ -1255,7 +1256,7 @@ glm::vec3 AvatarData::getJointTranslation(int index) const {
     }
     if (QThread::currentThread() != thread()) {
         glm::vec3 result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "getJointTranslation", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointTranslation", 
             Q_RETURN_ARG(glm::vec3, result), Q_ARG(int, index));
         return result;
     }
@@ -1266,7 +1267,7 @@ glm::vec3 AvatarData::getJointTranslation(int index) const {
 glm::vec3 AvatarData::getJointTranslation(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         glm::vec3 result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "getJointTranslation", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointTranslation", 
             Q_RETURN_ARG(glm::vec3, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1344,7 +1345,7 @@ void AvatarData::clearJointData(const QString& name) {
 bool AvatarData::isJointDataValid(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         bool result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "isJointDataValid", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "isJointDataValid", 
             Q_RETURN_ARG(bool, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1354,7 +1355,7 @@ bool AvatarData::isJointDataValid(const QString& name) const {
 glm::quat AvatarData::getJointRotation(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         glm::quat result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "getJointRotation", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointRotation", 
             Q_RETURN_ARG(glm::quat, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1364,8 +1365,7 @@ glm::quat AvatarData::getJointRotation(const QString& name) const {
 QVector<glm::quat> AvatarData::getJointRotations() const {
     if (QThread::currentThread() != thread()) {
         QVector<glm::quat> result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this),
-                                  "getJointRotations", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointRotations",
                                   Q_RETURN_ARG(QVector<glm::quat>, result));
         return result;
     }
@@ -1380,8 +1380,7 @@ QVector<glm::quat> AvatarData::getJointRotations() const {
 void AvatarData::setJointRotations(QVector<glm::quat> jointRotations) {
     if (QThread::currentThread() != thread()) {
         QVector<glm::quat> result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this),
-                                  "setJointRotations", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "setJointRotations",
                                   Q_ARG(QVector<glm::quat>, jointRotations));
     }
     QWriteLocker writeLock(&_jointDataLock);
@@ -1398,8 +1397,7 @@ void AvatarData::setJointRotations(QVector<glm::quat> jointRotations) {
 QVector<glm::vec3> AvatarData::getJointTranslations() const {
     if (QThread::currentThread() != thread()) {
         QVector<glm::vec3> result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this),
-                                  "getJointTranslations", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointTranslations",
                                   Q_RETURN_ARG(QVector<glm::vec3>, result));
         return result;
     }
@@ -1414,8 +1412,7 @@ QVector<glm::vec3> AvatarData::getJointTranslations() const {
 void AvatarData::setJointTranslations(QVector<glm::vec3> jointTranslations) {
     if (QThread::currentThread() != thread()) {
         QVector<glm::quat> result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this),
-                                  "setJointTranslations", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "setJointTranslations",
                                   Q_ARG(QVector<glm::vec3>, jointTranslations));
     }
     QWriteLocker writeLock(&_jointDataLock);
@@ -1616,7 +1613,7 @@ void AvatarData::setDisplayName(const QString& displayName) {
 QVector<AttachmentData> AvatarData::getAttachmentData() const {
     if (QThread::currentThread() != thread()) {
         QVector<AttachmentData> result;
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "getAttachmentData", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getAttachmentData",
             Q_RETURN_ARG(QVector<AttachmentData>, result));
         return result;
     }
@@ -2339,7 +2336,7 @@ void AvatarData::clearAvatarEntity(const QUuid& entityID) {
 AvatarEntityMap AvatarData::getAvatarEntityData() const {
     AvatarEntityMap result;
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "getAvatarEntityData", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getAvatarEntityData",
                                   Q_RETURN_ARG(AvatarEntityMap, result));
         return result;
     }
@@ -2380,7 +2377,7 @@ void AvatarData::setAvatarEntityData(const AvatarEntityMap& avatarEntityData) {
 AvatarEntityIDs AvatarData::getAndClearRecentlyDetachedIDs() {
     AvatarEntityIDs result;
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(const_cast<AvatarData*>(this), "getAndClearRecentlyDetachedIDs", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getAndClearRecentlyDetachedIDs",
                                   Q_RETURN_ARG(AvatarEntityIDs, result));
         return result;
     }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1228,7 +1228,7 @@ bool AvatarData::isJointDataValid(int index) const {
     }
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "isJointDataValid", 
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "isJointDataValid", 
             Q_RETURN_ARG(bool, result), Q_ARG(int, index));
         return result;
     }
@@ -1241,7 +1241,7 @@ glm::quat AvatarData::getJointRotation(int index) const {
     }
     if (QThread::currentThread() != thread()) {
         glm::quat result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointRotation", 
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getJointRotation", 
             Q_RETURN_ARG(glm::quat, result), Q_ARG(int, index));
         return result;
     }
@@ -1256,7 +1256,7 @@ glm::vec3 AvatarData::getJointTranslation(int index) const {
     }
     if (QThread::currentThread() != thread()) {
         glm::vec3 result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointTranslation", 
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getJointTranslation", 
             Q_RETURN_ARG(glm::vec3, result), Q_ARG(int, index));
         return result;
     }
@@ -1267,7 +1267,7 @@ glm::vec3 AvatarData::getJointTranslation(int index) const {
 glm::vec3 AvatarData::getJointTranslation(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         glm::vec3 result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointTranslation", 
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getJointTranslation", 
             Q_RETURN_ARG(glm::vec3, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1345,7 +1345,7 @@ void AvatarData::clearJointData(const QString& name) {
 bool AvatarData::isJointDataValid(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "isJointDataValid", 
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "isJointDataValid", 
             Q_RETURN_ARG(bool, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1355,7 +1355,7 @@ bool AvatarData::isJointDataValid(const QString& name) const {
 glm::quat AvatarData::getJointRotation(const QString& name) const {
     if (QThread::currentThread() != thread()) {
         glm::quat result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointRotation", 
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getJointRotation", 
             Q_RETURN_ARG(glm::quat, result), Q_ARG(const QString&, name));
         return result;
     }
@@ -1365,7 +1365,7 @@ glm::quat AvatarData::getJointRotation(const QString& name) const {
 QVector<glm::quat> AvatarData::getJointRotations() const {
     if (QThread::currentThread() != thread()) {
         QVector<glm::quat> result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointRotations",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getJointRotations",
                                   Q_RETURN_ARG(QVector<glm::quat>, result));
         return result;
     }
@@ -1380,7 +1380,7 @@ QVector<glm::quat> AvatarData::getJointRotations() const {
 void AvatarData::setJointRotations(QVector<glm::quat> jointRotations) {
     if (QThread::currentThread() != thread()) {
         QVector<glm::quat> result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "setJointRotations",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "setJointRotations",
                                   Q_ARG(QVector<glm::quat>, jointRotations));
     }
     QWriteLocker writeLock(&_jointDataLock);
@@ -1397,7 +1397,7 @@ void AvatarData::setJointRotations(QVector<glm::quat> jointRotations) {
 QVector<glm::vec3> AvatarData::getJointTranslations() const {
     if (QThread::currentThread() != thread()) {
         QVector<glm::vec3> result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getJointTranslations",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getJointTranslations",
                                   Q_RETURN_ARG(QVector<glm::vec3>, result));
         return result;
     }
@@ -1412,7 +1412,7 @@ QVector<glm::vec3> AvatarData::getJointTranslations() const {
 void AvatarData::setJointTranslations(QVector<glm::vec3> jointTranslations) {
     if (QThread::currentThread() != thread()) {
         QVector<glm::quat> result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "setJointTranslations",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "setJointTranslations",
                                   Q_ARG(QVector<glm::vec3>, jointTranslations));
     }
     QWriteLocker writeLock(&_jointDataLock);
@@ -1613,7 +1613,7 @@ void AvatarData::setDisplayName(const QString& displayName) {
 QVector<AttachmentData> AvatarData::getAttachmentData() const {
     if (QThread::currentThread() != thread()) {
         QVector<AttachmentData> result;
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getAttachmentData",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getAttachmentData",
             Q_RETURN_ARG(QVector<AttachmentData>, result));
         return result;
     }
@@ -2336,7 +2336,7 @@ void AvatarData::clearAvatarEntity(const QUuid& entityID) {
 AvatarEntityMap AvatarData::getAvatarEntityData() const {
     AvatarEntityMap result;
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getAvatarEntityData",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getAvatarEntityData",
                                   Q_RETURN_ARG(AvatarEntityMap, result));
         return result;
     }
@@ -2377,7 +2377,7 @@ void AvatarData::setAvatarEntityData(const AvatarEntityMap& avatarEntityData) {
 AvatarEntityIDs AvatarData::getAndClearRecentlyDetachedIDs() {
     AvatarEntityIDs result;
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(const_cast<AvatarData*>(this), "getAndClearRecentlyDetachedIDs",
+        BLOCKING_INVOKE_METHOD(const_cast<AvatarData*>(this), "getAndClearRecentlyDetachedIDs",
                                   Q_RETURN_ARG(AvatarEntityIDs, result));
         return result;
     }

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -291,7 +291,7 @@ glm::vec2 CompositorHelper::getReticleMaximumPosition() const {
 
 void CompositorHelper::sendFakeMouseEvent() {
     if (qApp->thread() != QThread::currentThread()) {
-        hifi::qt::blockingInvokeMethod(this, "sendFakeMouseEvent");
+        BLOCKING_INVOKE_METHOD(this, "sendFakeMouseEvent");
         return;
     }
 

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -11,14 +11,16 @@
 #include <memory>
 #include <math.h>
 
+#include <glm/gtc/type_ptr.hpp>
+
 #include <QtCore/QTimer>
 #include <QtCore/QThread>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDesktopWidget>
-#include <glm/gtc/type_ptr.hpp>
 #include <QtGui/QWindow>
 #include <QQuickWindow>
 
+#include <shared/QtHelpers.h>
 #include <ui/Menu.h>
 #include <NumericalConstants.h>
 #include <DependencyManager.h>
@@ -289,7 +291,7 @@ glm::vec2 CompositorHelper::getReticleMaximumPosition() const {
 
 void CompositorHelper::sendFakeMouseEvent() {
     if (qApp->thread() != QThread::currentThread()) {
-        QMetaObject::invokeMethod(this, "sendFakeMouseEvent", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "sendFakeMouseEvent");
         return;
     }
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -381,7 +381,7 @@ ModelPointer EntityTreeRenderer::allocateModel(const QString& url, float loading
 
     // Only create and delete models on the thread that owns the EntityTreeRenderer
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "allocateModel",
+        BLOCKING_INVOKE_METHOD(this, "allocateModel",
                 Q_RETURN_ARG(ModelPointer, model),
                 Q_ARG(const QString&, url));
 
@@ -398,7 +398,7 @@ ModelPointer EntityTreeRenderer::allocateModel(const QString& url, float loading
 ModelPointer EntityTreeRenderer::updateModel(ModelPointer model, const QString& newUrl) {
     // Only create and delete models on the thread that owns the EntityTreeRenderer
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "updateModel",
+        BLOCKING_INVOKE_METHOD(this, "updateModel",
             Q_RETURN_ARG(ModelPointer, model),
                 Q_ARG(ModelPointer, model),
                 Q_ARG(const QString&, newUrl));

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -17,6 +17,7 @@
 #include <QScriptSyntaxCheckResult>
 #include <QThreadPool>
 
+#include <shared/QtHelpers.h>
 #include <ColorUtils.h>
 #include <AbstractScriptingServicesInterface.h>
 #include <AbstractViewStateInterface.h>
@@ -380,7 +381,7 @@ ModelPointer EntityTreeRenderer::allocateModel(const QString& url, float loading
 
     // Only create and delete models on the thread that owns the EntityTreeRenderer
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "allocateModel", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "allocateModel",
                 Q_RETURN_ARG(ModelPointer, model),
                 Q_ARG(const QString&, url));
 
@@ -397,7 +398,7 @@ ModelPointer EntityTreeRenderer::allocateModel(const QString& url, float loading
 ModelPointer EntityTreeRenderer::updateModel(ModelPointer model, const QString& newUrl) {
     // Only create and delete models on the thread that owns the EntityTreeRenderer
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "updateModel", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "updateModel",
             Q_RETURN_ARG(ModelPointer, model),
                 Q_ARG(ModelPointer, model),
                 Q_ARG(const QString&, newUrl));

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1489,7 +1489,7 @@ int EntityScriptingInterface::getJointIndex(const QUuid& entityID, const QString
         return -1;
     }
     int result;
-    hifi::qt::blockingInvokeMethod(_entityTree.get(), "getJointIndex",
+    BLOCKING_INVOKE_METHOD(_entityTree.get(), "getJointIndex",
                               Q_RETURN_ARG(int, result), Q_ARG(QUuid, entityID), Q_ARG(QString, name));
     return result;
 }
@@ -1499,7 +1499,7 @@ QStringList EntityScriptingInterface::getJointNames(const QUuid& entityID) {
         return QStringList();
     }
     QStringList result;
-    hifi::qt::blockingInvokeMethod(_entityTree.get(), "getJointNames",
+    BLOCKING_INVOKE_METHOD(_entityTree.get(), "getJointNames",
                               Q_RETURN_ARG(QStringList, result), Q_ARG(QUuid, entityID));
     return result;
 }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -9,19 +9,20 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "EntityScriptingInterface.h"
+
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/transform.hpp>
-
-#include "EntityScriptingInterface.h"
 
 #include <QFutureWatcher>
 #include <QtConcurrent/QtConcurrentRun>
 
-#include "EntityItemID.h"
+#include <shared/QtHelpers.h>
 #include <VariantMapToScriptValue.h>
 #include <SharedUtil.h>
 #include <SpatialParentFinder.h>
 
+#include "EntityItemID.h"
 #include "EntitiesLogging.h"
 #include "EntityDynamicFactoryInterface.h"
 #include "EntityDynamicInterface.h"
@@ -1488,7 +1489,7 @@ int EntityScriptingInterface::getJointIndex(const QUuid& entityID, const QString
         return -1;
     }
     int result;
-    QMetaObject::invokeMethod(_entityTree.get(), "getJointIndex", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(_entityTree.get(), "getJointIndex",
                               Q_RETURN_ARG(int, result), Q_ARG(QUuid, entityID), Q_ARG(QString, name));
     return result;
 }
@@ -1498,7 +1499,7 @@ QStringList EntityScriptingInterface::getJointNames(const QUuid& entityID) {
         return QStringList();
     }
     QStringList result;
-    QMetaObject::invokeMethod(_entityTree.get(), "getJointNames", Qt::BlockingQueuedConnection,
+    hifi::qt::blockingInvokeMethod(_entityTree.get(), "getJointNames",
                               Q_RETURN_ARG(QStringList, result), Q_ARG(QUuid, entityID));
     return result;
 }

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -233,7 +233,7 @@ void NodeList::processICEPingPacket(QSharedPointer<ReceivedMessage> message) {
 
 void NodeList::reset() {
     if (thread() != QThread::currentThread()) {
-        hifi::qt::blockingInvokeMethod(this, "reset");
+        QMetaObject::invokeMethod(this, "reset");
         return;
     }
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -20,6 +20,7 @@
 #include <QtNetwork/QHostInfo>
 #include <QtNetwork/QNetworkInterface>
 
+#include <shared/QtHelpers.h>
 #include <ThreadHelpers.h>
 #include <LogHandler.h>
 #include <UUID.h>
@@ -232,7 +233,7 @@ void NodeList::processICEPingPacket(QSharedPointer<ReceivedMessage> message) {
 
 void NodeList::reset() {
     if (thread() != QThread::currentThread()) {
-        QMetaObject::invokeMethod(this, "reset", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "reset");
         return;
     }
 

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -9,22 +9,24 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "ResourceCache.h"
+
 #include <cfloat>
 #include <cmath>
+#include <assert.h>
 
 #include <QThread>
 #include <QTimer>
 
 #include <SharedUtil.h>
-#include <assert.h>
+#include <shared/QtHelpers.h>
+#include <Trace.h>
+#include <Profile.h>
 
 #include "NetworkAccessManager.h"
 #include "NetworkLogging.h"
 #include "NodeList.h"
 
-#include "ResourceCache.h"
-#include <Trace.h>
-#include <Profile.h>
 
 #define clamp(x, min, max) (((x) < (min)) ? (min) :\
                            (((x) > (max)) ? (max) :\
@@ -178,7 +180,7 @@ ScriptableResource* ResourceCache::prefetch(const QUrl& url, void* extra) {
 
     if (QThread::currentThread() != thread()) {
         // Must be called in thread to ensure getResource returns a valid pointer
-        QMetaObject::invokeMethod(this, "prefetch", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "prefetch",
             Q_RETURN_ARG(ScriptableResource*, result),
             Q_ARG(QUrl, url), Q_ARG(void*, extra));
         return result;
@@ -301,7 +303,7 @@ QVariantList ResourceCache::getResourceList() {
     QVariantList list;
     if (QThread::currentThread() != thread()) {
         // NOTE: invokeMethod does not allow a const QObject*
-        QMetaObject::invokeMethod(this, "getResourceList", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "getResourceList",
             Q_RETURN_ARG(QVariantList, list));
     } else {
         auto resources = _resources.uniqueKeys();

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -180,7 +180,7 @@ ScriptableResource* ResourceCache::prefetch(const QUrl& url, void* extra) {
 
     if (QThread::currentThread() != thread()) {
         // Must be called in thread to ensure getResource returns a valid pointer
-        hifi::qt::blockingInvokeMethod(this, "prefetch",
+        BLOCKING_INVOKE_METHOD(this, "prefetch",
             Q_RETURN_ARG(ScriptableResource*, result),
             Q_ARG(QUrl, url), Q_ARG(void*, extra));
         return result;
@@ -303,7 +303,7 @@ QVariantList ResourceCache::getResourceList() {
     QVariantList list;
     if (QThread::currentThread() != thread()) {
         // NOTE: invokeMethod does not allow a const QObject*
-        hifi::qt::blockingInvokeMethod(this, "getResourceList",
+        BLOCKING_INVOKE_METHOD(this, "getResourceList",
             Q_RETURN_ARG(QVariantList, list));
     } else {
         auto resources = _resources.uniqueKeys();

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -277,7 +277,7 @@ Connection* Socket::findOrCreateConnection(const HifiSockAddr& sockAddr) {
 
 void Socket::clearConnections() {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "clearConnections");
+        BLOCKING_INVOKE_METHOD(this, "clearConnections");
         return;
     }
 

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -17,6 +17,7 @@
 
 #include <QtCore/QThread>
 
+#include <shared/QtHelpers.h>
 #include <LogHandler.h>
 
 #include "../NetworkLogging.h"
@@ -276,7 +277,7 @@ Connection* Socket::findOrCreateConnection(const HifiSockAddr& sockAddr) {
 
 void Socket::clearConnections() {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "clearConnections", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "clearConnections");
         return;
     }
 

--- a/libraries/plugins/src/plugins/InputConfiguration.cpp
+++ b/libraries/plugins/src/plugins/InputConfiguration.cpp
@@ -23,7 +23,7 @@ InputConfiguration::InputConfiguration() {
 QStringList InputConfiguration::inputPlugins() {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        hifi::qt::blockingInvokeMethod(this, "inputPlugins",
+        BLOCKING_INVOKE_METHOD(this, "inputPlugins",
                                   Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -44,7 +44,7 @@ QStringList InputConfiguration::inputPlugins() {
 QStringList InputConfiguration::activeInputPlugins() {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        hifi::qt::blockingInvokeMethod(this, "activeInputPlugins",
+        BLOCKING_INVOKE_METHOD(this, "activeInputPlugins",
                                    Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -66,7 +66,7 @@ QStringList InputConfiguration::activeInputPlugins() {
 QString InputConfiguration::configurationLayout(QString pluginName) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        hifi::qt::blockingInvokeMethod(this, "configurationLayout",
+        BLOCKING_INVOKE_METHOD(this, "configurationLayout",
                                   Q_RETURN_ARG(QString, result),
                                   Q_ARG(QString, pluginName));
         return result;
@@ -83,7 +83,7 @@ QString InputConfiguration::configurationLayout(QString pluginName) {
 
 void InputConfiguration::setConfigurationSettings(QJsonObject configurationSettings, QString pluginName) {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "setConfigurationSettings",
+        BLOCKING_INVOKE_METHOD(this, "setConfigurationSettings",
                                   Q_ARG(QJsonObject, configurationSettings),
                                   Q_ARG(QString, pluginName));
         return;
@@ -99,7 +99,7 @@ void InputConfiguration::setConfigurationSettings(QJsonObject configurationSetti
 QJsonObject InputConfiguration::configurationSettings(QString pluginName) {
     if (QThread::currentThread() != thread()) {
         QJsonObject result;
-        hifi::qt::blockingInvokeMethod(this, "configurationSettings",
+        BLOCKING_INVOKE_METHOD(this, "configurationSettings",
                                   Q_RETURN_ARG(QJsonObject, result),
                                   Q_ARG(QString, pluginName));
         return result;
@@ -115,7 +115,7 @@ QJsonObject InputConfiguration::configurationSettings(QString pluginName) {
 
 void InputConfiguration::calibratePlugin(QString pluginName) {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "calibratePlugin");
+        BLOCKING_INVOKE_METHOD(this, "calibratePlugin");
         return;
     }
 
@@ -130,7 +130,7 @@ void InputConfiguration::calibratePlugin(QString pluginName) {
 bool InputConfiguration::uncalibratePlugin(QString pluginName) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "uncalibratePlugin",
+        BLOCKING_INVOKE_METHOD(this, "uncalibratePlugin",
                                   Q_ARG(bool, result));
         return result;
     }

--- a/libraries/plugins/src/plugins/InputConfiguration.cpp
+++ b/libraries/plugins/src/plugins/InputConfiguration.cpp
@@ -11,6 +11,8 @@
 
 #include <QThread>
 
+#include <shared/QtHelpers.h>
+
 #include "DisplayPlugin.h"
 #include "InputPlugin.h"
 #include "PluginManager.h"
@@ -21,7 +23,7 @@ InputConfiguration::InputConfiguration() {
 QStringList InputConfiguration::inputPlugins() {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        QMetaObject::invokeMethod(this, "inputPlugins", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "inputPlugins",
                                   Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -42,7 +44,7 @@ QStringList InputConfiguration::inputPlugins() {
 QStringList InputConfiguration::activeInputPlugins() {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        QMetaObject::invokeMethod(this, "activeInputPlugins", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "activeInputPlugins",
                                    Q_RETURN_ARG(QStringList, result));
         return result;
     }
@@ -64,7 +66,7 @@ QStringList InputConfiguration::activeInputPlugins() {
 QString InputConfiguration::configurationLayout(QString pluginName) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        QMetaObject::invokeMethod(this, "configurationLayout", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "configurationLayout",
                                   Q_RETURN_ARG(QString, result),
                                   Q_ARG(QString, pluginName));
         return result;
@@ -81,7 +83,7 @@ QString InputConfiguration::configurationLayout(QString pluginName) {
 
 void InputConfiguration::setConfigurationSettings(QJsonObject configurationSettings, QString pluginName) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setConfigurationSettings", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "setConfigurationSettings",
                                   Q_ARG(QJsonObject, configurationSettings),
                                   Q_ARG(QString, pluginName));
         return;
@@ -97,7 +99,7 @@ void InputConfiguration::setConfigurationSettings(QJsonObject configurationSetti
 QJsonObject InputConfiguration::configurationSettings(QString pluginName) {
     if (QThread::currentThread() != thread()) {
         QJsonObject result;
-        QMetaObject::invokeMethod(this, "configurationSettings", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "configurationSettings",
                                   Q_RETURN_ARG(QJsonObject, result),
                                   Q_ARG(QString, pluginName));
         return result;
@@ -113,7 +115,7 @@ QJsonObject InputConfiguration::configurationSettings(QString pluginName) {
 
 void InputConfiguration::calibratePlugin(QString pluginName) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "calibratePlugin", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "calibratePlugin");
         return;
     }
 
@@ -128,7 +130,7 @@ void InputConfiguration::calibratePlugin(QString pluginName) {
 bool InputConfiguration::uncalibratePlugin(QString pluginName) {
     if (QThread::currentThread() != thread()) {
         bool result;
-        QMetaObject::invokeMethod(this, "uncalibratePlugin", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "uncalibratePlugin",
                                   Q_ARG(bool, result));
         return result;
     }

--- a/libraries/recording/src/recording/ClipCache.cpp
+++ b/libraries/recording/src/recording/ClipCache.cpp
@@ -39,7 +39,7 @@ ClipCache::ClipCache(QObject* parent) :
 NetworkClipLoaderPointer ClipCache::getClipLoader(const QUrl& url) {
     if (QThread::currentThread() != thread()) {
         NetworkClipLoaderPointer result;
-        hifi::qt::blockingInvokeMethod(this, "getClipLoader",
+        BLOCKING_INVOKE_METHOD(this, "getClipLoader",
                                   Q_RETURN_ARG(NetworkClipLoaderPointer, result), Q_ARG(const QUrl&, url));
         return result;
     }

--- a/libraries/recording/src/recording/ClipCache.cpp
+++ b/libraries/recording/src/recording/ClipCache.cpp
@@ -8,6 +8,8 @@
 
 #include <QThread>
 
+#include <shared/QtHelpers.h>
+
 #include "ClipCache.h"
 #include "impl/PointerClip.h"
 #include "Logging.h"
@@ -37,7 +39,7 @@ ClipCache::ClipCache(QObject* parent) :
 NetworkClipLoaderPointer ClipCache::getClipLoader(const QUrl& url) {
     if (QThread::currentThread() != thread()) {
         NetworkClipLoaderPointer result;
-        QMetaObject::invokeMethod(this, "getClipLoader", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "getClipLoader",
                                   Q_RETURN_ARG(NetworkClipLoaderPointer, result), Q_ARG(const QUrl&, url));
         return result;
     }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -871,7 +871,7 @@ bool Model::getRelativeDefaultJointTranslation(int jointIndex, glm::vec3& transl
 QStringList Model::getJointNames() const {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        hifi::qt::blockingInvokeMethod(const_cast<Model*>(this), "getJointNames",
+        BLOCKING_INVOKE_METHOD(const_cast<Model*>(this), "getJointNames",
             Q_RETURN_ARG(QStringList, result));
         return result;
     }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -18,6 +18,7 @@
 #include <glm/gtx/transform.hpp>
 #include <glm/gtx/norm.hpp>
 
+#include <shared/QtHelpers.h>
 #include <GeometryUtil.h>
 #include <PathUtils.h>
 #include <PerfStat.h>
@@ -870,7 +871,7 @@ bool Model::getRelativeDefaultJointTranslation(int jointIndex, glm::vec3& transl
 QStringList Model::getJointNames() const {
     if (QThread::currentThread() != thread()) {
         QStringList result;
-        QMetaObject::invokeMethod(const_cast<Model*>(this), "getJointNames", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(const_cast<Model*>(this), "getJointNames",
             Q_RETURN_ARG(QStringList, result));
         return result;
     }

--- a/libraries/render/src/task/Config.cpp
+++ b/libraries/render/src/task/Config.cpp
@@ -10,8 +10,11 @@
 //
 #include "Config.h"
 
-#include "Task.h"
 #include <QtCore/QThread>
+
+#include <shared/QtHelpers.h>
+
+#include "Task.h"
 
 using namespace task;
 
@@ -58,7 +61,7 @@ void TaskConfig::transferChildrenConfigs(QConfigPointer source) {
 
 void TaskConfig::refresh() {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "refresh", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "refresh");
         return;
     }
 

--- a/libraries/render/src/task/Config.cpp
+++ b/libraries/render/src/task/Config.cpp
@@ -61,7 +61,7 @@ void TaskConfig::transferChildrenConfigs(QConfigPointer source) {
 
 void TaskConfig::refresh() {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "refresh");
+        BLOCKING_INVOKE_METHOD(this, "refresh");
         return;
     }
 

--- a/libraries/script-engine/src/AudioScriptingInterface.cpp
+++ b/libraries/script-engine/src/AudioScriptingInterface.cpp
@@ -13,6 +13,8 @@
 
 #include <QVector3D>
 
+#include <shared/QtHelpers.h>
+
 #include "ScriptAudioInjector.h"
 #include "ScriptEngineLogging.h"
 
@@ -32,7 +34,7 @@ ScriptAudioInjector* AudioScriptingInterface::playSound(SharedSoundPointer sound
     if (QThread::currentThread() != thread()) {
         ScriptAudioInjector* injector = NULL;
 
-        QMetaObject::invokeMethod(this, "playSound", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "playSound",
                                   Q_RETURN_ARG(ScriptAudioInjector*, injector),
                                   Q_ARG(SharedSoundPointer, sound),
                                   Q_ARG(const AudioInjectorOptions&, injectorOptions));

--- a/libraries/script-engine/src/AudioScriptingInterface.cpp
+++ b/libraries/script-engine/src/AudioScriptingInterface.cpp
@@ -34,7 +34,7 @@ ScriptAudioInjector* AudioScriptingInterface::playSound(SharedSoundPointer sound
     if (QThread::currentThread() != thread()) {
         ScriptAudioInjector* injector = NULL;
 
-        hifi::qt::blockingInvokeMethod(this, "playSound",
+        BLOCKING_INVOKE_METHOD(this, "playSound",
                                   Q_RETURN_ARG(ScriptAudioInjector*, injector),
                                   Q_ARG(SharedSoundPointer, sound),
                                   Q_ARG(const AudioInjectorOptions&, injectorOptions));

--- a/libraries/script-engine/src/RecordingScriptingInterface.cpp
+++ b/libraries/script-engine/src/RecordingScriptingInterface.cpp
@@ -14,6 +14,7 @@
 #include <QtScript/QScriptValue>
 #include <QtWidgets/QFileDialog>
 
+#include <shared/QtHelpers.h>
 #include <AssetClient.h>
 #include <AssetUpload.h>
 #include <BuildInfo.h>
@@ -98,7 +99,7 @@ void RecordingScriptingInterface::loadRecording(const QString& url, QScriptValue
 
 void RecordingScriptingInterface::startPlaying() {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "startPlaying", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "startPlaying");
         return;
     }
 
@@ -115,7 +116,7 @@ void RecordingScriptingInterface::setPlayerAudioOffset(float audioOffset) {
 
 void RecordingScriptingInterface::setPlayerTime(float time) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setPlayerTime", Qt::BlockingQueuedConnection, Q_ARG(float, time));
+        hifi::qt::blockingInvokeMethod(this, "setPlayerTime", Q_ARG(float, time));
         return;
     }
     _player->seek(time);
@@ -147,7 +148,7 @@ void RecordingScriptingInterface::setPlayerUseSkeletonModel(bool useSkeletonMode
 
 void RecordingScriptingInterface::pausePlayer() {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "pausePlayer", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "pausePlayer");
         return;
     }
     _player->pause();
@@ -155,7 +156,7 @@ void RecordingScriptingInterface::pausePlayer() {
 
 void RecordingScriptingInterface::stopPlaying() {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "stopPlaying", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "stopPlaying");
         return;
     }
     _player->stop();
@@ -176,7 +177,7 @@ void RecordingScriptingInterface::startRecording() {
     }
 
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "startRecording", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "startRecording");
         return;
     }
 
@@ -199,7 +200,7 @@ QString RecordingScriptingInterface::getDefaultRecordingSaveDirectory() {
 
 void RecordingScriptingInterface::saveRecording(const QString& filename) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "saveRecording", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "saveRecording",
             Q_ARG(QString, filename));
         return;
     }
@@ -220,7 +221,7 @@ bool RecordingScriptingInterface::saveRecordingToAsset(QScriptValue getClipAtpUr
 
     if (QThread::currentThread() != thread()) {
         bool result;
-        QMetaObject::invokeMethod(this, "saveRecordingToAsset", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "saveRecordingToAsset",
             Q_RETURN_ARG(bool, result),
             Q_ARG(QScriptValue, getClipAtpUrl));
         return result;
@@ -257,7 +258,7 @@ bool RecordingScriptingInterface::saveRecordingToAsset(QScriptValue getClipAtpUr
 
 void RecordingScriptingInterface::loadLastRecording() {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "loadLastRecording", Qt::BlockingQueuedConnection);
+        hifi::qt::blockingInvokeMethod(this, "loadLastRecording");
         return;
     }
 

--- a/libraries/script-engine/src/RecordingScriptingInterface.cpp
+++ b/libraries/script-engine/src/RecordingScriptingInterface.cpp
@@ -99,7 +99,7 @@ void RecordingScriptingInterface::loadRecording(const QString& url, QScriptValue
 
 void RecordingScriptingInterface::startPlaying() {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "startPlaying");
+        BLOCKING_INVOKE_METHOD(this, "startPlaying");
         return;
     }
 
@@ -116,7 +116,7 @@ void RecordingScriptingInterface::setPlayerAudioOffset(float audioOffset) {
 
 void RecordingScriptingInterface::setPlayerTime(float time) {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "setPlayerTime", Q_ARG(float, time));
+        BLOCKING_INVOKE_METHOD(this, "setPlayerTime", Q_ARG(float, time));
         return;
     }
     _player->seek(time);
@@ -148,7 +148,7 @@ void RecordingScriptingInterface::setPlayerUseSkeletonModel(bool useSkeletonMode
 
 void RecordingScriptingInterface::pausePlayer() {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "pausePlayer");
+        BLOCKING_INVOKE_METHOD(this, "pausePlayer");
         return;
     }
     _player->pause();
@@ -156,7 +156,7 @@ void RecordingScriptingInterface::pausePlayer() {
 
 void RecordingScriptingInterface::stopPlaying() {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "stopPlaying");
+        BLOCKING_INVOKE_METHOD(this, "stopPlaying");
         return;
     }
     _player->stop();
@@ -177,7 +177,7 @@ void RecordingScriptingInterface::startRecording() {
     }
 
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "startRecording");
+        BLOCKING_INVOKE_METHOD(this, "startRecording");
         return;
     }
 
@@ -200,7 +200,7 @@ QString RecordingScriptingInterface::getDefaultRecordingSaveDirectory() {
 
 void RecordingScriptingInterface::saveRecording(const QString& filename) {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "saveRecording",
+        BLOCKING_INVOKE_METHOD(this, "saveRecording",
             Q_ARG(QString, filename));
         return;
     }
@@ -221,7 +221,7 @@ bool RecordingScriptingInterface::saveRecordingToAsset(QScriptValue getClipAtpUr
 
     if (QThread::currentThread() != thread()) {
         bool result;
-        hifi::qt::blockingInvokeMethod(this, "saveRecordingToAsset",
+        BLOCKING_INVOKE_METHOD(this, "saveRecordingToAsset",
             Q_RETURN_ARG(bool, result),
             Q_ARG(QScriptValue, getClipAtpUrl));
         return result;
@@ -258,7 +258,7 @@ bool RecordingScriptingInterface::saveRecordingToAsset(QScriptValue getClipAtpUr
 
 void RecordingScriptingInterface::loadLastRecording() {
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "loadLastRecording");
+        BLOCKING_INVOKE_METHOD(this, "loadLastRecording");
         return;
     }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -965,7 +965,7 @@ QScriptValue ScriptEngine::evaluate(const QString& sourceCode, const QString& fi
         qCDebug(scriptengine) << "*** WARNING *** ScriptEngine::evaluate() called on wrong thread [" << QThread::currentThread() << "], invoking on correct thread [" << thread() << "] "
             "sourceCode:" << sourceCode << " fileName:" << fileName << "lineNumber:" << lineNumber;
 #endif
-        hifi::qt::blockingInvokeMethod(this, "evaluate",
+        BLOCKING_INVOKE_METHOD(this, "evaluate",
                                   Q_RETURN_ARG(QScriptValue, result),
                                   Q_ARG(const QString&, sourceCode),
                                   Q_ARG(const QString&, fileName),

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -36,6 +36,7 @@
 
 #include <QtScriptTools/QScriptEngineDebugger>
 
+#include <shared/QtHelpers.h>
 #include <AudioConstants.h>
 #include <AudioEffectOptions.h>
 #include <AvatarData.h>
@@ -436,12 +437,12 @@ void ScriptEngine::loadURL(const QUrl& scriptURL, bool reload) {
     _fileNameString = url.toString();
     _isReloading = reload;
 
-	// Check that script has a supported file extension
+    // Check that script has a supported file extension
     if (!hasValidScriptSuffix(_fileNameString)) {
         scriptErrorMessage("File extension of file: " + _fileNameString + " is not a currently supported script type");
         emit errorLoadingScript(_fileNameString);
         return;
-	}
+    }
 
     const auto maxRetries = 0; // for consistency with previous scriptCache->getScript() behavior
     auto scriptCache = DependencyManager::get<ScriptCache>();
@@ -964,7 +965,7 @@ QScriptValue ScriptEngine::evaluate(const QString& sourceCode, const QString& fi
         qCDebug(scriptengine) << "*** WARNING *** ScriptEngine::evaluate() called on wrong thread [" << QThread::currentThread() << "], invoking on correct thread [" << thread() << "] "
             "sourceCode:" << sourceCode << " fileName:" << fileName << "lineNumber:" << lineNumber;
 #endif
-        QMetaObject::invokeMethod(this, "evaluate", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "evaluate",
                                   Q_RETURN_ARG(QScriptValue, result),
                                   Q_ARG(const QString&, sourceCode),
                                   Q_ARG(const QString&, fileName),

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -12,6 +12,7 @@
 
 #include <QtWidgets/QApplication>
 
+#include <shared/QtHelpers.h>
 #include <SettingHandle.h>
 #include <UserActivityLogger.h>
 #include <PathUtils.h>
@@ -452,7 +453,7 @@ ScriptEngine* ScriptEngines::loadScript(const QUrl& scriptFilename, bool isUserL
                                         bool activateMainWindow, bool reload) {
     if (thread() != QThread::currentThread()) {
         ScriptEngine* result { nullptr };
-        QMetaObject::invokeMethod(this, "loadScript", Qt::BlockingQueuedConnection, Q_RETURN_ARG(ScriptEngine*, result),
+        hifi::qt::blockingInvokeMethod(this, "loadScript", Q_RETURN_ARG(ScriptEngine*, result),
             Q_ARG(QUrl, scriptFilename),
             Q_ARG(bool, isUserLoaded),
             Q_ARG(bool, loadScriptFromEditor),

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -453,7 +453,7 @@ ScriptEngine* ScriptEngines::loadScript(const QUrl& scriptFilename, bool isUserL
                                         bool activateMainWindow, bool reload) {
     if (thread() != QThread::currentThread()) {
         ScriptEngine* result { nullptr };
-        hifi::qt::blockingInvokeMethod(this, "loadScript", Q_RETURN_ARG(ScriptEngine*, result),
+        BLOCKING_INVOKE_METHOD(this, "loadScript", Q_RETURN_ARG(ScriptEngine*, result),
             Q_ARG(QUrl, scriptFilename),
             Q_ARG(bool, isUserLoaded),
             Q_ARG(bool, loadScriptFromEditor),

--- a/libraries/shared/src/shared/QtHelpers.cpp
+++ b/libraries/shared/src/shared/QtHelpers.cpp
@@ -1,0 +1,57 @@
+//
+//  Created by Bradley Austin Davis on 2015/11/09
+//  Copyright 2013-2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "QtHelpers.h"
+
+#include <QtCore/QThread>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QLoggingCategory>
+
+Q_LOGGING_CATEGORY(thread_safety, "hifi.thread_safety")
+
+namespace hifi { namespace qt {
+
+bool blockingInvokeMethod(
+    QObject *obj, const char *member,
+    QGenericReturnArgument ret,
+    QGenericArgument val0,
+    QGenericArgument val1,
+    QGenericArgument val2,
+    QGenericArgument val3,
+    QGenericArgument val4,
+    QGenericArgument val5,
+    QGenericArgument val6,
+    QGenericArgument val7,
+    QGenericArgument val8,
+    QGenericArgument val9) {
+    if (QThread::currentThread() == qApp->thread()) {
+        qCWarning(thread_safety, "BlockingQueuedConnection invoked on main thread!");
+    }
+    return QMetaObject::invokeMethod(obj, member,
+            Qt::BlockingQueuedConnection, ret, val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
+}
+
+bool blockingInvokeMethod(
+    QObject *obj, const char *member,
+    QGenericArgument val0,
+    QGenericArgument val1,
+    QGenericArgument val2,
+    QGenericArgument val3,
+    QGenericArgument val4,
+    QGenericArgument val5,
+    QGenericArgument val6,
+    QGenericArgument val7,
+    QGenericArgument val8,
+    QGenericArgument val9) {
+    qCWarning(thread_safety, "BlockingQueuedConnection invoked without return value!");
+    return blockingInvokeMethod(obj, member, QGenericReturnArgument(), val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
+}
+
+
+
+} }

--- a/libraries/shared/src/shared/QtHelpers.cpp
+++ b/libraries/shared/src/shared/QtHelpers.cpp
@@ -17,6 +17,7 @@ Q_LOGGING_CATEGORY(thread_safety, "hifi.thread_safety")
 namespace hifi { namespace qt {
 
 bool blockingInvokeMethod(
+    const char* function,
     QObject *obj, const char *member,
     QGenericReturnArgument ret,
     QGenericArgument val0,
@@ -30,13 +31,14 @@ bool blockingInvokeMethod(
     QGenericArgument val8,
     QGenericArgument val9) {
     if (QThread::currentThread() == qApp->thread()) {
-        qCWarning(thread_safety, "BlockingQueuedConnection invoked on main thread!");
+        qCWarning(thread_safety) << "BlockingQueuedConnection invoked on main thread from " << function;
     }
     return QMetaObject::invokeMethod(obj, member,
             Qt::BlockingQueuedConnection, ret, val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
 }
 
 bool blockingInvokeMethod(
+    const char* function,
     QObject *obj, const char *member,
     QGenericArgument val0,
     QGenericArgument val1,
@@ -48,8 +50,7 @@ bool blockingInvokeMethod(
     QGenericArgument val7,
     QGenericArgument val8,
     QGenericArgument val9) {
-    qCWarning(thread_safety, "BlockingQueuedConnection invoked without return value!");
-    return blockingInvokeMethod(obj, member, QGenericReturnArgument(), val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
+    return blockingInvokeMethod(function, obj, member, QGenericReturnArgument(), val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
 }
 
 

--- a/libraries/shared/src/shared/QtHelpers.h
+++ b/libraries/shared/src/shared/QtHelpers.h
@@ -1,0 +1,47 @@
+//
+//  Created by Bradley Austin Davis on 2017/06/29
+//  Copyright 2013-2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+#ifndef hifi_Shared_QtHelpers_h
+#define hifi_Shared_QtHelpers_h
+
+#include <QtCore/QObject>
+
+namespace hifi { namespace qt {
+
+bool blockingInvokeMethod(
+    QObject *obj, const char *member,
+    QGenericReturnArgument ret,
+    QGenericArgument val0 = QGenericArgument(Q_NULLPTR),
+    QGenericArgument val1 = QGenericArgument(),
+    QGenericArgument val2 = QGenericArgument(),
+    QGenericArgument val3 = QGenericArgument(),
+    QGenericArgument val4 = QGenericArgument(),
+    QGenericArgument val5 = QGenericArgument(),
+    QGenericArgument val6 = QGenericArgument(),
+    QGenericArgument val7 = QGenericArgument(),
+    QGenericArgument val8 = QGenericArgument(),
+    QGenericArgument val9 = QGenericArgument());
+
+bool blockingInvokeMethod(
+    QObject *obj, const char *member,
+    QGenericArgument val0 = QGenericArgument(Q_NULLPTR),
+    QGenericArgument val1 = QGenericArgument(),
+    QGenericArgument val2 = QGenericArgument(),
+    QGenericArgument val3 = QGenericArgument(),
+    QGenericArgument val4 = QGenericArgument(),
+    QGenericArgument val5 = QGenericArgument(),
+    QGenericArgument val6 = QGenericArgument(),
+    QGenericArgument val7 = QGenericArgument(),
+    QGenericArgument val8 = QGenericArgument(),
+    QGenericArgument val9 = QGenericArgument());
+
+} }
+
+
+#endif

--- a/libraries/shared/src/shared/QtHelpers.h
+++ b/libraries/shared/src/shared/QtHelpers.h
@@ -12,9 +12,11 @@
 
 #include <QtCore/QObject>
 
+
 namespace hifi { namespace qt {
 
 bool blockingInvokeMethod(
+    const char* function,
     QObject *obj, const char *member,
     QGenericReturnArgument ret,
     QGenericArgument val0 = QGenericArgument(Q_NULLPTR),
@@ -29,6 +31,7 @@ bool blockingInvokeMethod(
     QGenericArgument val9 = QGenericArgument());
 
 bool blockingInvokeMethod(
+    const char* function,
     QObject *obj, const char *member,
     QGenericArgument val0 = QGenericArgument(Q_NULLPTR),
     QGenericArgument val1 = QGenericArgument(),
@@ -43,5 +46,7 @@ bool blockingInvokeMethod(
 
 } }
 
+#define BLOCKING_INVOKE_METHOD(obj, member, ...) \
+    hifi::qt::blockingInvokeMethod(__FUNCTION__, obj, member, ##__VA_ARGS__)
 
 #endif

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -15,6 +15,7 @@
 #include <QtQuick/QQuickWindow>
 #include <QtQml/QtQml>
 
+#include <shared/QtHelpers.h>
 #include <gl/GLHelpers.h>
 
 #include <AbstractUriHandler.h>
@@ -249,7 +250,7 @@ int OffscreenUi::waitForMessageBoxResult(QQuickItem* messageBox) {
 QMessageBox::StandardButton OffscreenUi::messageBox(Icon icon, const QString& title, const QString& text, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton) {
     if (QThread::currentThread() != thread()) {
         QMessageBox::StandardButton result = QMessageBox::StandardButton::NoButton;
-        QMetaObject::invokeMethod(this, "messageBox", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "messageBox",
             Q_RETURN_ARG(QMessageBox::StandardButton, result),
             Q_ARG(Icon, icon),
             Q_ARG(QString, title),
@@ -351,7 +352,7 @@ QVariant OffscreenUi::getCustomInfo(const Icon icon, const QString& title, const
 QVariant OffscreenUi::inputDialog(const Icon icon, const QString& title, const QString& label, const QVariant& current) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        QMetaObject::invokeMethod(this, "inputDialog", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "inputDialog",
             Q_RETURN_ARG(QVariant, result),
             Q_ARG(Icon, icon),
             Q_ARG(QString, title),
@@ -366,7 +367,7 @@ QVariant OffscreenUi::inputDialog(const Icon icon, const QString& title, const Q
 QVariant OffscreenUi::customInputDialog(const Icon icon, const QString& title, const QVariantMap& config) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        QMetaObject::invokeMethod(this, "customInputDialog", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "customInputDialog",
                                   Q_RETURN_ARG(QVariant, result),
                                   Q_ARG(Icon, icon),
                                   Q_ARG(QString, title),
@@ -640,7 +641,7 @@ QString OffscreenUi::fileDialog(const QVariantMap& properties) {
 QString OffscreenUi::fileOpenDialog(const QString& caption, const QString& dir, const QString& filter, QString* selectedFilter, QFileDialog::Options options) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        QMetaObject::invokeMethod(this, "fileOpenDialog", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "fileOpenDialog",
             Q_RETURN_ARG(QString, result),
             Q_ARG(QString, caption),
             Q_ARG(QString, dir),
@@ -662,7 +663,7 @@ QString OffscreenUi::fileOpenDialog(const QString& caption, const QString& dir, 
 QString OffscreenUi::fileSaveDialog(const QString& caption, const QString& dir, const QString& filter, QString* selectedFilter, QFileDialog::Options options) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        QMetaObject::invokeMethod(this, "fileSaveDialog", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "fileSaveDialog",
             Q_RETURN_ARG(QString, result),
             Q_ARG(QString, caption),
             Q_ARG(QString, dir),
@@ -686,7 +687,7 @@ QString OffscreenUi::fileSaveDialog(const QString& caption, const QString& dir, 
 QString OffscreenUi::existingDirectoryDialog(const QString& caption, const QString& dir, const QString& filter, QString* selectedFilter, QFileDialog::Options options) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        QMetaObject::invokeMethod(this, "existingDirectoryDialog", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "existingDirectoryDialog",
                                   Q_RETURN_ARG(QString, result),
                                   Q_ARG(QString, caption),
                                   Q_ARG(QString, dir),
@@ -773,7 +774,7 @@ QString OffscreenUi::assetOpenDialog(const QString& caption, const QString& dir,
     // ATP equivalent of fileOpenDialog().
     if (QThread::currentThread() != thread()) {
         QString result;
-        QMetaObject::invokeMethod(this, "assetOpenDialog", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "assetOpenDialog",
             Q_RETURN_ARG(QString, result),
             Q_ARG(QString, caption),
             Q_ARG(QString, dir),

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -250,7 +250,7 @@ int OffscreenUi::waitForMessageBoxResult(QQuickItem* messageBox) {
 QMessageBox::StandardButton OffscreenUi::messageBox(Icon icon, const QString& title, const QString& text, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton) {
     if (QThread::currentThread() != thread()) {
         QMessageBox::StandardButton result = QMessageBox::StandardButton::NoButton;
-        hifi::qt::blockingInvokeMethod(this, "messageBox",
+        BLOCKING_INVOKE_METHOD(this, "messageBox",
             Q_RETURN_ARG(QMessageBox::StandardButton, result),
             Q_ARG(Icon, icon),
             Q_ARG(QString, title),
@@ -352,7 +352,7 @@ QVariant OffscreenUi::getCustomInfo(const Icon icon, const QString& title, const
 QVariant OffscreenUi::inputDialog(const Icon icon, const QString& title, const QString& label, const QVariant& current) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        hifi::qt::blockingInvokeMethod(this, "inputDialog",
+        BLOCKING_INVOKE_METHOD(this, "inputDialog",
             Q_RETURN_ARG(QVariant, result),
             Q_ARG(Icon, icon),
             Q_ARG(QString, title),
@@ -367,7 +367,7 @@ QVariant OffscreenUi::inputDialog(const Icon icon, const QString& title, const Q
 QVariant OffscreenUi::customInputDialog(const Icon icon, const QString& title, const QVariantMap& config) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        hifi::qt::blockingInvokeMethod(this, "customInputDialog",
+        BLOCKING_INVOKE_METHOD(this, "customInputDialog",
                                   Q_RETURN_ARG(QVariant, result),
                                   Q_ARG(Icon, icon),
                                   Q_ARG(QString, title),
@@ -641,7 +641,7 @@ QString OffscreenUi::fileDialog(const QVariantMap& properties) {
 QString OffscreenUi::fileOpenDialog(const QString& caption, const QString& dir, const QString& filter, QString* selectedFilter, QFileDialog::Options options) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        hifi::qt::blockingInvokeMethod(this, "fileOpenDialog",
+        BLOCKING_INVOKE_METHOD(this, "fileOpenDialog",
             Q_RETURN_ARG(QString, result),
             Q_ARG(QString, caption),
             Q_ARG(QString, dir),
@@ -663,7 +663,7 @@ QString OffscreenUi::fileOpenDialog(const QString& caption, const QString& dir, 
 QString OffscreenUi::fileSaveDialog(const QString& caption, const QString& dir, const QString& filter, QString* selectedFilter, QFileDialog::Options options) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        hifi::qt::blockingInvokeMethod(this, "fileSaveDialog",
+        BLOCKING_INVOKE_METHOD(this, "fileSaveDialog",
             Q_RETURN_ARG(QString, result),
             Q_ARG(QString, caption),
             Q_ARG(QString, dir),
@@ -687,7 +687,7 @@ QString OffscreenUi::fileSaveDialog(const QString& caption, const QString& dir, 
 QString OffscreenUi::existingDirectoryDialog(const QString& caption, const QString& dir, const QString& filter, QString* selectedFilter, QFileDialog::Options options) {
     if (QThread::currentThread() != thread()) {
         QString result;
-        hifi::qt::blockingInvokeMethod(this, "existingDirectoryDialog",
+        BLOCKING_INVOKE_METHOD(this, "existingDirectoryDialog",
                                   Q_RETURN_ARG(QString, result),
                                   Q_ARG(QString, caption),
                                   Q_ARG(QString, dir),
@@ -774,7 +774,7 @@ QString OffscreenUi::assetOpenDialog(const QString& caption, const QString& dir,
     // ATP equivalent of fileOpenDialog().
     if (QThread::currentThread() != thread()) {
         QString result;
-        hifi::qt::blockingInvokeMethod(this, "assetOpenDialog",
+        BLOCKING_INVOKE_METHOD(this, "assetOpenDialog",
             Q_RETURN_ARG(QString, result),
             Q_ARG(QString, caption),
             Q_ARG(QString, dir),

--- a/libraries/ui/src/QmlWebWindowClass.cpp
+++ b/libraries/ui/src/QmlWebWindowClass.cpp
@@ -37,7 +37,7 @@ QScriptValue QmlWebWindowClass::constructor(QScriptContext* context, QScriptEngi
 
 QString QmlWebWindowClass::getURL() {
     if (QThread::currentThread() != thread()) {
-        QString result = false;
+        QString result;
         hifi::qt::blockingInvokeMethod(this, "getURL", Q_RETURN_ARG(QString, result));
         return result;
     }

--- a/libraries/ui/src/QmlWebWindowClass.cpp
+++ b/libraries/ui/src/QmlWebWindowClass.cpp
@@ -38,7 +38,7 @@ QScriptValue QmlWebWindowClass::constructor(QScriptContext* context, QScriptEngi
 QString QmlWebWindowClass::getURL() {
     if (QThread::currentThread() != thread()) {
         QString result;
-        hifi::qt::blockingInvokeMethod(this, "getURL", Q_RETURN_ARG(QString, result));
+        BLOCKING_INVOKE_METHOD(this, "getURL", Q_RETURN_ARG(QString, result));
         return result;
     }
 

--- a/libraries/ui/src/QmlWebWindowClass.cpp
+++ b/libraries/ui/src/QmlWebWindowClass.cpp
@@ -13,6 +13,7 @@
 #include <QtScript/QScriptContext>
 #include <QtScript/QScriptEngine>
 
+#include <shared/QtHelpers.h>
 #include "OffscreenUi.h"
 
 static const char* const URL_PROPERTY = "source";
@@ -21,39 +22,51 @@ static const char* const SCRIPT_PROPERTY = "scriptUrl";
 // Method called by Qt scripts to create a new web window in the overlay
 QScriptValue QmlWebWindowClass::constructor(QScriptContext* context, QScriptEngine* engine) {
     auto properties = parseArguments(context);
-    QmlWebWindowClass* retVal { nullptr };
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->executeOnUiThread([&] {
-        retVal = new QmlWebWindowClass();
-        retVal->initQml(properties);
-    }, true);
+    QmlWebWindowClass* retVal = new QmlWebWindowClass();
     Q_ASSERT(retVal);
+    if (QThread::currentThread() != qApp->thread()) {
+        retVal->moveToThread(qApp->thread());
+        QMetaObject::invokeMethod(retVal, "initQml", Q_ARG(QVariantMap, properties));
+    } else {
+        retVal->initQml(properties);
+    }
     connect(engine, &QScriptEngine::destroyed, retVal, &QmlWindowClass::deleteLater);
     return engine->newQObject(retVal);
 }
 
-QString QmlWebWindowClass::getURL() const {
-    QVariant result = DependencyManager::get<OffscreenUi>()->returnFromUiThread([&]()->QVariant {
-        if (_qmlWindow.isNull()) {
-            return QVariant();
-        }
-        return _qmlWindow->property(URL_PROPERTY);
-    });
-    return result.toString();
+QString QmlWebWindowClass::getURL() {
+    if (QThread::currentThread() != thread()) {
+        QString result = false;
+        hifi::qt::blockingInvokeMethod(this, "getURL", Q_RETURN_ARG(QString, result));
+        return result;
+    }
+
+    if (_qmlWindow.isNull()) {
+        return QString();
+    }
+        
+    return _qmlWindow->property(URL_PROPERTY).toString();
 }
 
 void QmlWebWindowClass::setURL(const QString& urlString) {
-    DependencyManager::get<OffscreenUi>()->executeOnUiThread([=] {
-        if (!_qmlWindow.isNull()) {
-            _qmlWindow->setProperty(URL_PROPERTY, urlString);
-        }
-    });
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setURL", Q_ARG(QString, urlString));
+        return;
+    }
+
+    if (!_qmlWindow.isNull()) {
+        _qmlWindow->setProperty(URL_PROPERTY, urlString);
+    }
 }
 
 void QmlWebWindowClass::setScriptURL(const QString& script) {
-    DependencyManager::get<OffscreenUi>()->executeOnUiThread([=] {
-        if (!_qmlWindow.isNull()) {
-            _qmlWindow->setProperty(SCRIPT_PROPERTY, script);
-        }
-    });
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setScriptURL", Q_ARG(QString, script));
+        return;
+    }
+
+    if (!_qmlWindow.isNull()) {
+        _qmlWindow->setProperty(SCRIPT_PROPERTY, script);
+    }
 }

--- a/libraries/ui/src/QmlWebWindowClass.h
+++ b/libraries/ui/src/QmlWebWindowClass.h
@@ -20,7 +20,7 @@ public:
     static QScriptValue constructor(QScriptContext* context, QScriptEngine* engine);
 
 public slots:
-    QString getURL() const;
+    QString getURL();
     void setURL(const QString& url);
     void setScriptURL(const QString& script);
 

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -79,7 +79,7 @@ QScriptValue QmlWindowClass::constructor(QScriptContext* context, QScriptEngine*
     Q_ASSERT(retVal);
     if (QThread::currentThread() != qApp->thread()) {
         retVal->moveToThread(qApp->thread());
-        hifi::qt::blockingInvokeMethod(retVal, "initQml", Q_ARG(QVariantMap, properties));
+        BLOCKING_INVOKE_METHOD(retVal, "initQml", Q_ARG(QVariantMap, properties));
     } else {
         retVal->initQml(properties);
     }
@@ -111,7 +111,7 @@ void QmlWindowClass::initQml(QVariantMap properties) {
         // Build the event bridge and wrapper on the main thread
         offscreenUi->loadInNewContext(qmlSource(), [&](QQmlContext* context, QObject* object) {
             _qmlWindow = object;
-            context->setContextProperty("eventBridge", this);
+            context->setContextProperty(EVENT_BRIDGE_PROPERTY, this);
             context->engine()->setObjectOwnership(this, QQmlEngine::CppOwnership);
             context->engine()->setObjectOwnership(object, QQmlEngine::CppOwnership);
             if (properties.contains(TITLE_PROPERTY)) {
@@ -243,7 +243,7 @@ void QmlWindowClass::setVisible(bool visible) {
 bool QmlWindowClass::isVisible() {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        hifi::qt::blockingInvokeMethod(this, "isVisible", Q_RETURN_ARG(bool, result));
+        BLOCKING_INVOKE_METHOD(this, "isVisible", Q_RETURN_ARG(bool, result));
         return result;
     }
 
@@ -264,7 +264,7 @@ bool QmlWindowClass::isVisible() {
 glm::vec2 QmlWindowClass::getPosition() {
     if (QThread::currentThread() != thread()) {
         vec2 result;
-        hifi::qt::blockingInvokeMethod(this, "getPosition", Q_RETURN_ARG(vec2, result));
+        BLOCKING_INVOKE_METHOD(this, "getPosition", Q_RETURN_ARG(vec2, result));
         return result;
     }
 
@@ -299,7 +299,7 @@ glm::vec2 toGlm(const QSizeF& size) {
 glm::vec2 QmlWindowClass::getSize() {
     if (QThread::currentThread() != thread()) {
         vec2 result;
-        hifi::qt::blockingInvokeMethod(this, "getSize", Q_RETURN_ARG(vec2, result));
+        BLOCKING_INVOKE_METHOD(this, "getSize", Q_RETURN_ARG(vec2, result));
         return result;
     }
 

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -31,18 +31,18 @@ public:
     QmlWindowClass();
     ~QmlWindowClass();
 
-    virtual void initQml(QVariantMap properties);
+    Q_INVOKABLE virtual void initQml(QVariantMap properties);
     QQuickItem* asQuickItem() const;
 
 public slots:
-    bool isVisible() const;
+    bool isVisible();
     void setVisible(bool visible);
 
-    glm::vec2 getPosition() const;
+    glm::vec2 getPosition();
     void setPosition(const glm::vec2& position);
     void setPosition(int x, int y);
 
-    glm::vec2 getSize() const;
+    glm::vec2 getSize();
     void setSize(const glm::vec2& size);
     void setSize(int width, int height);
     void setTitle(const QString& title);

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -19,6 +19,8 @@
 class QScriptEngine;
 class QScriptContext;
 
+#define QML_TOOL_WINDOW 0
+
 // FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping 
 class QmlWindowClass : public QObject {
     Q_OBJECT
@@ -85,9 +87,12 @@ protected:
 
     virtual QString qmlSource() const { return "QmlWindow.qml"; }
 
+#if QML_TOOL_WINDOW
     // FIXME needs to be initialized in the ctor once we have support
     // for tool window panes in QML
     bool _toolWindow { false };
+#endif
+
     QPointer<QObject> _qmlWindow;
     QString _source;
 

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -13,12 +13,12 @@
 #include <QtWidgets/QShortcut>
 
 #include <SettingHandle.h>
+#include <shared/QtHelpers.h>
 
 #include "../VrMenu.h"
 #include "../OffscreenUi.h"
 
 #include "Logging.h"
-
 using namespace ui;
 
 static QList<QString> groups;
@@ -246,7 +246,7 @@ void Menu::removeAction(MenuWrapper* menu, const QString& actionName) {
 
 void Menu::setIsOptionChecked(const QString& menuOption, bool isChecked) {
     if (thread() != QThread::currentThread()) {
-        QMetaObject::invokeMethod(this, "setIsOptionChecked", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "setIsOptionChecked",
                     Q_ARG(const QString&, menuOption),
                     Q_ARG(bool, isChecked));
         return;

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -246,7 +246,7 @@ void Menu::removeAction(MenuWrapper* menu, const QString& actionName) {
 
 void Menu::setIsOptionChecked(const QString& menuOption, bool isChecked) {
     if (thread() != QThread::currentThread()) {
-        hifi::qt::blockingInvokeMethod(this, "setIsOptionChecked",
+        BLOCKING_INVOKE_METHOD(this, "setIsOptionChecked",
                     Q_ARG(const QString&, menuOption),
                     Q_ARG(bool, isChecked));
         return;

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -887,28 +887,6 @@ QQmlContext* OffscreenQmlSurface::getSurfaceContext() {
     return _qmlContext;
 }
 
-void OffscreenQmlSurface::executeOnUiThread(std::function<void()> function, bool blocking ) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "executeOnUiThread", blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection,
-            Q_ARG(std::function<void()>, function));
-        return;
-    }
-
-    function();
-}
-
-QVariant OffscreenQmlSurface::returnFromUiThread(std::function<QVariant()> function) {
-    if (QThread::currentThread() != thread()) {
-        QVariant result;
-        hifi::qt::blockingInvokeMethod(this, "returnFromUiThread",
-            Q_RETURN_ARG(QVariant, result),
-            Q_ARG(std::function<QVariant()>, function));
-        return result;
-    }
-
-    return function();
-}
-
 void OffscreenQmlSurface::focusDestroyed(QObject *obj) {
     _currentFocusItem = nullptr;
 }

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -25,6 +25,8 @@
 #include <QtCore/QWaitCondition>
 
 #include <shared/NsightHelpers.h>
+#include <shared/GlobalAppProperties.h>
+#include <shared/QtHelpers.h>
 #include <PerfStat.h>
 #include <DependencyManager.h>
 #include <NumericalConstants.h>
@@ -34,7 +36,6 @@
 #include <AccountManager.h>
 #include <NetworkAccessManager.h>
 #include <GLMHelpers.h>
-#include <shared/GlobalAppProperties.h>
 
 #include <gl/OffscreenGLCanvas.h>
 #include <gl/GLHelpers.h>
@@ -899,7 +900,7 @@ void OffscreenQmlSurface::executeOnUiThread(std::function<void()> function, bool
 QVariant OffscreenQmlSurface::returnFromUiThread(std::function<QVariant()> function) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        QMetaObject::invokeMethod(this, "returnFromUiThread", Qt::BlockingQueuedConnection,
+        hifi::qt::blockingInvokeMethod(this, "returnFromUiThread",
             Q_RETURN_ARG(QVariant, result),
             Q_ARG(std::function<QVariant()>, function));
         return result;

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -55,10 +55,6 @@ public:
         return load(QUrl(qmlSourceFile), f);
     }
     void clearCache();
-
-    Q_INVOKABLE void executeOnUiThread(std::function<void()> function, bool blocking = false);
-    Q_INVOKABLE QVariant returnFromUiThread(std::function<QVariant()> function);
-
     void setMaxFps(uint8_t maxFps) { _maxFps = maxFps; }
     // Optional values for event handling
     void setProxyWindow(QWindow* window);

--- a/libraries/ui/src/ui/QmlWrapper.cpp
+++ b/libraries/ui/src/ui/QmlWrapper.cpp
@@ -38,7 +38,7 @@ void QmlWrapper::writeProperties(QVariant propertyMap) {
 QVariant QmlWrapper::readProperty(const QString& propertyName) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        hifi::qt::blockingInvokeMethod(this, "readProperty", Q_RETURN_ARG(QVariant, result), Q_ARG(QString, propertyName));
+        BLOCKING_INVOKE_METHOD(this, "readProperty", Q_RETURN_ARG(QVariant, result), Q_ARG(QString, propertyName));
         return result;
     }
 
@@ -48,7 +48,7 @@ QVariant QmlWrapper::readProperty(const QString& propertyName) {
 QVariant QmlWrapper::readProperties(const QVariant& propertyList) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        hifi::qt::blockingInvokeMethod(this, "readProperties", Q_RETURN_ARG(QVariant, result), Q_ARG(QVariant, propertyList));
+        BLOCKING_INVOKE_METHOD(this, "readProperties", Q_RETURN_ARG(QVariant, result), Q_ARG(QVariant, propertyList));
         return result;
     }
 

--- a/libraries/ui/src/ui/QmlWrapper.cpp
+++ b/libraries/ui/src/ui/QmlWrapper.cpp
@@ -11,6 +11,8 @@
 #include <QtCore/QThread>
 #include <QtCore/QCoreApplication>
 
+#include <shared/QtHelpers.h>
+
 QmlWrapper::QmlWrapper(QObject* qmlObject, QObject* parent)
     : QObject(parent), _qmlObject(qmlObject) {
     Q_ASSERT(QThread::currentThread() == qApp->thread());
@@ -36,7 +38,7 @@ void QmlWrapper::writeProperties(QVariant propertyMap) {
 QVariant QmlWrapper::readProperty(const QString& propertyName) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        QMetaObject::invokeMethod(this, "readProperty", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QVariant, result), Q_ARG(QString, propertyName));
+        hifi::qt::blockingInvokeMethod(this, "readProperty", Q_RETURN_ARG(QVariant, result), Q_ARG(QString, propertyName));
         return result;
     }
 
@@ -46,7 +48,7 @@ QVariant QmlWrapper::readProperty(const QString& propertyName) {
 QVariant QmlWrapper::readProperties(const QVariant& propertyList) {
     if (QThread::currentThread() != thread()) {
         QVariant result;
-        QMetaObject::invokeMethod(this, "readProperties", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QVariant, result), Q_ARG(QVariant, propertyList));
+        hifi::qt::blockingInvokeMethod(this, "readProperties", Q_RETURN_ARG(QVariant, result), Q_ARG(QVariant, propertyList));
         return result;
     }
 

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -43,7 +43,7 @@ ToolbarProxy* TabletScriptingInterface::getSystemToolbarProxy() {
 TabletProxy* TabletScriptingInterface::getTablet(const QString& tabletId) {
     TabletProxy* tabletProxy = nullptr;
     if (QThread::currentThread() != thread()) {
-        hifi::qt::blockingInvokeMethod(this, "getTablet", Q_RETURN_ARG(TabletProxy*, tabletProxy), Q_ARG(QString, tabletId));
+        BLOCKING_INVOKE_METHOD(this, "getTablet", Q_RETURN_ARG(TabletProxy*, tabletProxy), Q_ARG(QString, tabletId));
         return tabletProxy;
     } 
 
@@ -291,7 +291,7 @@ void TabletProxy::initialScreen(const QVariant& url) {
 bool TabletProxy::isMessageDialogOpen() {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        hifi::qt::blockingInvokeMethod(this, "isMessageDialogOpen", Q_RETURN_ARG(bool, result));
+        BLOCKING_INVOKE_METHOD(this, "isMessageDialogOpen", Q_RETURN_ARG(bool, result));
         return result;
     }
 
@@ -316,7 +316,7 @@ void TabletProxy::emitWebEvent(const QVariant& msg) {
 bool TabletProxy::isPathLoaded(const QVariant& path) {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        hifi::qt::blockingInvokeMethod(this, "isPathLoaded", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
+        BLOCKING_INVOKE_METHOD(this, "isPathLoaded", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
         return result;
     }
 
@@ -479,7 +479,7 @@ void TabletProxy::loadQMLSource(const QVariant& path) {
 bool TabletProxy::pushOntoStack(const QVariant& path) {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        hifi::qt::blockingInvokeMethod(this, "pushOntoStack", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
+        BLOCKING_INVOKE_METHOD(this, "pushOntoStack", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
         return result;
     }
 
@@ -605,7 +605,7 @@ void TabletProxy::gotoWebScreen(const QString& url, const QString& injectedJavaS
 TabletButtonProxy* TabletProxy::addButton(const QVariant& properties) {
     if (QThread::currentThread() != thread()) {
         TabletButtonProxy* result = nullptr;
-        hifi::qt::blockingInvokeMethod(this, "addButton", Q_RETURN_ARG(TabletButtonProxy*, result), Q_ARG(QVariant, properties));
+        BLOCKING_INVOKE_METHOD(this, "addButton", Q_RETURN_ARG(TabletButtonProxy*, result), Q_ARG(QVariant, properties));
         return result;
     }
 
@@ -632,7 +632,7 @@ TabletButtonProxy* TabletProxy::addButton(const QVariant& properties) {
 bool TabletProxy::onHomeScreen() {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        hifi::qt::blockingInvokeMethod(this, "onHomeScreen", Q_RETURN_ARG(bool, result));
+        BLOCKING_INVOKE_METHOD(this, "onHomeScreen", Q_RETURN_ARG(bool, result));
         return result;
     }
 
@@ -839,7 +839,7 @@ void TabletButtonProxy::setToolbarButtonProxy(QObject* toolbarButtonProxy) {
 QVariantMap TabletButtonProxy::getProperties() {
     if (QThread::currentThread() != thread()) {
         QVariantMap result;
-        hifi::qt::blockingInvokeMethod(this, "getProperties", Q_RETURN_ARG(QVariantMap, result));
+        BLOCKING_INVOKE_METHOD(this, "getProperties", Q_RETURN_ARG(QVariantMap, result));
         return result;
     }
 

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -214,20 +214,18 @@ void TabletProxy::setToolbarMode(bool toolbarMode) {
 
         // create new desktop window
         auto offscreenUi = DependencyManager::get<OffscreenUi>();
-        offscreenUi->executeOnUiThread([=] {
-            auto tabletRootWindow = new TabletRootWindow();
-            tabletRootWindow->initQml(QVariantMap());
-            auto quickItem = tabletRootWindow->asQuickItem();
-            _desktopWindow = tabletRootWindow;
-            QMetaObject::invokeMethod(quickItem, "setShown", Q_ARG(const QVariant&, QVariant(false)));
+        auto tabletRootWindow = new TabletRootWindow();
+        tabletRootWindow->initQml(QVariantMap());
+        auto quickItem = tabletRootWindow->asQuickItem();
+        _desktopWindow = tabletRootWindow;
+        QMetaObject::invokeMethod(quickItem, "setShown", Q_ARG(const QVariant&, QVariant(false)));
 
-            QObject::connect(quickItem, SIGNAL(windowClosed()), this, SLOT(desktopWindowClosed()));
+        QObject::connect(quickItem, SIGNAL(windowClosed()), this, SLOT(desktopWindowClosed()));
 
-            QObject::connect(tabletRootWindow, SIGNAL(webEventReceived(QVariant)), this, SLOT(emitWebEvent(QVariant)), Qt::DirectConnection);
+        QObject::connect(tabletRootWindow, SIGNAL(webEventReceived(QVariant)), this, SLOT(emitWebEvent(QVariant)), Qt::DirectConnection);
 
-            // forward qml surface events to interface js
-            connect(tabletRootWindow, &QmlWindowClass::fromQml, this, &TabletProxy::fromQml);
-        });
+        // forward qml surface events to interface js
+        connect(tabletRootWindow, &QmlWindowClass::fromQml, this, &TabletProxy::fromQml);
     } else {
         _state = State::Home;
         removeButtonsFromToolbar();

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QThread>
 #include <QtQml/QQmlProperty>
 
+#include <shared/QtHelpers.h>
 #include <PathUtils.h>
 #include <DependencyManager.h>
 #include <AccountManager.h>
@@ -42,7 +43,7 @@ ToolbarProxy* TabletScriptingInterface::getSystemToolbarProxy() {
 TabletProxy* TabletScriptingInterface::getTablet(const QString& tabletId) {
     TabletProxy* tabletProxy = nullptr;
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "getTablet", Qt::BlockingQueuedConnection, Q_RETURN_ARG(TabletProxy*, tabletProxy), Q_ARG(QString, tabletId));
+        hifi::qt::blockingInvokeMethod(this, "getTablet", Q_RETURN_ARG(TabletProxy*, tabletProxy), Q_ARG(QString, tabletId));
         return tabletProxy;
     } 
 
@@ -292,7 +293,7 @@ void TabletProxy::initialScreen(const QVariant& url) {
 bool TabletProxy::isMessageDialogOpen() {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        QMetaObject::invokeMethod(this, "isMessageDialogOpen", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, result));
+        hifi::qt::blockingInvokeMethod(this, "isMessageDialogOpen", Q_RETURN_ARG(bool, result));
         return result;
     }
 
@@ -317,7 +318,7 @@ void TabletProxy::emitWebEvent(const QVariant& msg) {
 bool TabletProxy::isPathLoaded(const QVariant& path) {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        QMetaObject::invokeMethod(this, "isPathLoaded", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
+        hifi::qt::blockingInvokeMethod(this, "isPathLoaded", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
         return result;
     }
 
@@ -480,7 +481,7 @@ void TabletProxy::loadQMLSource(const QVariant& path) {
 bool TabletProxy::pushOntoStack(const QVariant& path) {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        QMetaObject::invokeMethod(this, "pushOntoStack", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
+        hifi::qt::blockingInvokeMethod(this, "pushOntoStack", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, path));
         return result;
     }
 
@@ -606,7 +607,7 @@ void TabletProxy::gotoWebScreen(const QString& url, const QString& injectedJavaS
 TabletButtonProxy* TabletProxy::addButton(const QVariant& properties) {
     if (QThread::currentThread() != thread()) {
         TabletButtonProxy* result = nullptr;
-        QMetaObject::invokeMethod(this, "addButton", Qt::BlockingQueuedConnection, Q_RETURN_ARG(TabletButtonProxy*, result), Q_ARG(QVariant, properties));
+        hifi::qt::blockingInvokeMethod(this, "addButton", Q_RETURN_ARG(TabletButtonProxy*, result), Q_ARG(QVariant, properties));
         return result;
     }
 
@@ -633,7 +634,7 @@ TabletButtonProxy* TabletProxy::addButton(const QVariant& properties) {
 bool TabletProxy::onHomeScreen() {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        QMetaObject::invokeMethod(this, "onHomeScreen", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, result));
+        hifi::qt::blockingInvokeMethod(this, "onHomeScreen", Q_RETURN_ARG(bool, result));
         return result;
     }
 
@@ -840,7 +841,7 @@ void TabletButtonProxy::setToolbarButtonProxy(QObject* toolbarButtonProxy) {
 QVariantMap TabletButtonProxy::getProperties() {
     if (QThread::currentThread() != thread()) {
         QVariantMap result;
-        QMetaObject::invokeMethod(this, "getProperties", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QVariantMap, result));
+        hifi::qt::blockingInvokeMethod(this, "getProperties", Q_RETURN_ARG(QVariantMap, result));
         return result;
     }
 

--- a/libraries/ui/src/ui/ToolbarScriptingInterface.cpp
+++ b/libraries/ui/src/ui/ToolbarScriptingInterface.cpp
@@ -12,6 +12,8 @@
 #include <QtQuick/QQuickItem>
 #include <QtScript/QScriptValue>
 #include <QtScript/QScriptEngine>
+
+#include <shared/QtHelpers.h>
 #include "../OffscreenUi.h"
 
 QScriptValue toolbarToScriptValue(QScriptEngine* engine, ToolbarProxy* const &in) {
@@ -68,7 +70,7 @@ ToolbarProxy::ToolbarProxy(QObject* qmlObject, QObject* parent) : QmlWrapper(qml
 ToolbarButtonProxy* ToolbarProxy::addButton(const QVariant& properties) {
     if (QThread::currentThread() != thread()) {
         ToolbarButtonProxy* result = nullptr;
-        QMetaObject::invokeMethod(this, "addButton", Qt::BlockingQueuedConnection, Q_RETURN_ARG(ToolbarButtonProxy*, result), Q_ARG(QVariant, properties));
+        hifi::qt::blockingInvokeMethod(this, "addButton", Q_RETURN_ARG(ToolbarButtonProxy*, result), Q_ARG(QVariant, properties));
         return result;
     }
 
@@ -99,18 +101,14 @@ void ToolbarProxy::removeButton(const QVariant& name) {
 ToolbarProxy* ToolbarScriptingInterface::getToolbar(const QString& toolbarId) {
     if (QThread::currentThread() != thread()) {
         ToolbarProxy* result = nullptr;
-        QMetaObject::invokeMethod(this, "getToolbar", Qt::BlockingQueuedConnection, Q_RETURN_ARG(ToolbarProxy*, result), Q_ARG(QString, toolbarId));
+        hifi::qt::blockingInvokeMethod(this, "getToolbar", Q_RETURN_ARG(ToolbarProxy*, result), Q_ARG(QString, toolbarId));
         return result;
     }
 
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     auto desktop = offscreenUi->getDesktop();
-    Qt::ConnectionType connectionType = Qt::AutoConnection;
-    if (QThread::currentThread() != desktop->thread()) {
-        connectionType = Qt::BlockingQueuedConnection;
-    }
     QVariant resultVar;
-    bool invokeResult = QMetaObject::invokeMethod(desktop, "getToolbar", connectionType, Q_RETURN_ARG(QVariant, resultVar), Q_ARG(QVariant, toolbarId));
+    bool invokeResult = QMetaObject::invokeMethod(desktop, "getToolbar", Q_RETURN_ARG(QVariant, resultVar), Q_ARG(QVariant, toolbarId));
     if (!invokeResult) {
         return nullptr;
     }

--- a/libraries/ui/src/ui/ToolbarScriptingInterface.cpp
+++ b/libraries/ui/src/ui/ToolbarScriptingInterface.cpp
@@ -70,7 +70,7 @@ ToolbarProxy::ToolbarProxy(QObject* qmlObject, QObject* parent) : QmlWrapper(qml
 ToolbarButtonProxy* ToolbarProxy::addButton(const QVariant& properties) {
     if (QThread::currentThread() != thread()) {
         ToolbarButtonProxy* result = nullptr;
-        hifi::qt::blockingInvokeMethod(this, "addButton", Q_RETURN_ARG(ToolbarButtonProxy*, result), Q_ARG(QVariant, properties));
+        BLOCKING_INVOKE_METHOD(this, "addButton", Q_RETURN_ARG(ToolbarButtonProxy*, result), Q_ARG(QVariant, properties));
         return result;
     }
 
@@ -101,7 +101,7 @@ void ToolbarProxy::removeButton(const QVariant& name) {
 ToolbarProxy* ToolbarScriptingInterface::getToolbar(const QString& toolbarId) {
     if (QThread::currentThread() != thread()) {
         ToolbarProxy* result = nullptr;
-        hifi::qt::blockingInvokeMethod(this, "getToolbar", Q_RETURN_ARG(ToolbarProxy*, result), Q_ARG(QString, toolbarId));
+        BLOCKING_INVOKE_METHOD(this, "getToolbar", Q_RETURN_ARG(ToolbarProxy*, result), Q_ARG(QString, toolbarId));
         return result;
     }
 


### PR DESCRIPTION
We're still seeing a lot of deadlocks in the application and crashes in QtScript / QtQml.

Some of this is potentially coming from the `Audio` scripting interface on the main thread calling blocking functions on the `AudioClient` (which runs on it's own thread).  

Some of it is also potentially from threading issues wherever scripts interact with QML in a non-thread safe way, such as in QML based overlays.  

This PR makes several changes.  

* Adds new helper functions and macros for making blocking method invocations.
  * These emit log warning if they occur from the main thread
  * Macro usage ensures that the log warning include the calling function in which the blocking was made
* Migrates _all_ use of `QMetaObject::invokeMethod` that uses `Qt::BlockingQueuedConnection` to use the new methods / macros
* Modified Audio scripting interface to not use blocking functions when communicating with the AudioClient.  
* Modifies Overlay instances to always live on the main thread.  All interaction with the Overlay scripting interface now funnels through the main thread.
* Modifies OvlerayWindows and OverlayWebWindows to live on the main thread.  
* Updates many scripting interfaces to use the self-invocation pattern when they are called from another thread
* Eliminates the unused OverlayPanel code (using the preprocessor so that it can be restored easily if there is some user script taking advantage of it)
* Eliminates support for the tabbed tool window, previously only used by the edit.js code

## Testing

* Verify startup and shutdown function without hanging or crashing
* Verify Overlay functionality still works.  (this [script](https://raw.githubusercontent.com/jherico/DreamingScripts/master/tests/overlays.js) creates a number of overlays)
* Verify audio settings dialog still functions properly (check boxes work, changing input and output devices works)
* Smoke test functionality
* Monitor log output for warnings containing the string `BlockingQueuedConnection` (this doesn't fail the PR, it just informative and should give us clues to additional sources of race conditions)

