### PR TITLE
Clarify setDisplayTexture() cases, also fixing crash bug

### DIFF
--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -223,9 +223,19 @@
         }
     }
 
+    // Function Name: setDisplay()
+    //
+    // Description:
+    //   -There are two bool variables that determine what the "url" argument to "setDisplayTexture(url)" should be:
+    //     Camera on/off switch, and the "Monitor Shows" on/off switch.
+    //     This results in four possible cases for the argument. Those four cases are:
+    //     1. Camera is off; "Monitor Shows" is "HMD Preview": "url" is ""
+    //     2. Camera is off; "Monitor Shows" is "Camera View": "url" is ""
+    //     3. Camera is on; "Monitor Shows" is "HMD Preview":  "url" is ""
+    //     4. Camera is on; "Monitor Shows" is "Camera View":  "url" is "resource://spectatorCameraFrame"
     function setDisplay(showCameraView) {
-        // It would be fancy if (showCameraView && !cameraUpdateInterval) would show instructions, but that's out of scope for now.
-        var url = (showCameraView && cameraUpdateInterval) ? "resource://spectatorCameraFrame" : "";
+        // It would be fancy if the app would show instructions when (url === ""), but that's out of scope for now.
+        var url = (camera && showCameraView && cameraUpdateInterval) ? "resource://spectatorCameraFrame" : "";
         Window.setDisplayTexture(url);
     }
     const MONITOR_SHOWS_CAMERA_VIEW_DEFAULT = false;


### PR DESCRIPTION
The crash fix that this PR implements cannot be tested here; the crash fix only affects PR #10856. Thus, the test plan for this PR is extremely simple...

**Test Plan:**
1. In HMD, turn the Spectator Camera on using the SPECTATOR tablet app. Verify that the camera model shows up, and the camera model's glass panel displays a preview of what the camera is seeing.
2. Using the SPECTATOR tablet app, turn the camera off.  Verify that the camera model disappears.