### PR TITLE
added far grab and near grab capabilities in edit mode

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2564,7 +2564,7 @@ SelectionDisplay = (function() {
 
 
     var MIN_FAR_GRAB_DISTANCE = 0.3;
-    var FAR_GRAB_PUSH_FACTOR = 15;
+    var FAR_GRAB_PUSH_FACTOR = 60;
 
     var farGrabTranslateTool = {
         mode: 'FAR_GRAB_TRANSLATE',


### PR DESCRIPTION
Makes editing in the HMD more natural with Far Grab and Near Grab.
Far grabbing the selected item works similarly to far grabbing dynamic objects
Near grabbing works at any distance making rotation easier because your hand becomes the axis.

Testing
Rez a cube.
Select it in Create Mode
Far grab and move it with 6 degrees of freedom
Near grab it at any distance (even without touching it) to rotate and position it.

