### PR TITLE
Don't use a blocking connection for a high-frequency script function

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -231,9 +231,12 @@ OverlayID Overlays::cloneOverlay(OverlayID id) {
 
 bool Overlays::editOverlay(OverlayID id, const QVariant& properties) {
     if (QThread::currentThread() != thread()) {
-        bool result;
-        BLOCKING_INVOKE_METHOD(this, "editOverlay", Q_RETURN_ARG(bool, result), Q_ARG(OverlayID, id), Q_ARG(QVariant, properties));
-        return result;
+        // NOTE editOverlay can be called very frequently in scripts and can't afford to 
+        // block waiting on the main thread.  Additionally, no script actually 
+        // examines the return value and does something useful with it, so use a non-blocking
+        // invoke and just always return true
+        QMetaObject::invokeMethod(this, "editOverlay", Q_ARG(OverlayID, id), Q_ARG(QVariant, properties));
+        return true;
     }
 
     Overlay::Pointer thisOverlay = getOverlay(id);
@@ -246,9 +249,9 @@ bool Overlays::editOverlay(OverlayID id, const QVariant& properties) {
 
 bool Overlays::editOverlays(const QVariant& propertiesById) {
     if (QThread::currentThread() != thread()) {
-        bool result;
-        BLOCKING_INVOKE_METHOD(this, "editOverlays", Q_RETURN_ARG(bool, result), Q_ARG(QVariant, propertiesById));
-        return result;
+        // NOTE see comment on editOverlay for why this is not a blocking call
+        QMetaObject::invokeMethod(this, "editOverlays", Q_ARG(QVariant, propertiesById));
+        return true;
     }
 
     QVariantMap map = propertiesById.toMap();


### PR DESCRIPTION
`Overlays.editOverlay` can be called by many scripts and many times per frame.  #10860 changed the code for the interface to use a blocking self-invocation in order to try to resolve some recent crash issues in QtScript and QtQml.  Unfortunately because the main thread blocks on idle processing and rendering, this effectively limits overlay edits to only a small number per frame, blocking the script processing while they're handled.  This makes tablet interaction (and other UI that involves both 2D and 3D ovlerays) completely unusable. 

However, the only reason that the blocking connection is used is because `Overlays.editOverlay` returns a boolean value to the caller.  Absolutely no script examines this value and does anything useful with it (only one script I could find even captures it, but only for logging).  Converting these calls from blocking to non-blocking clears up the laggy behavior of the tablet for me.  

## Testing

In HMD mode, attempt to use the tablet interface to change your audio settings and mute or unmute yourself.  In the current dev build, it is completely unusable.  In this build it should be fine / similar to the current RC.