### PR TITLE
Restore mutex in overlay interface

### DIFF
--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -319,6 +319,7 @@ signals:
 private:
     void cleanupOverlaysToDelete();
 
+    mutable QMutex _mutex;
     QMap<OverlayID, Overlay::Pointer> _overlaysHUD;
     QMap<OverlayID, Overlay::Pointer> _overlaysWorld;
 #if OVERLAY_PANELS


### PR DESCRIPTION
The design of the overlay script interface changed in PR #10860 to ensure all overlay objects are owned by the main thread, in order to combat issues with QtScript/QtQml crashes.  In the process, some mutexes were removed as superfluous.  However, it turns out there are a couple cases where Overlays are accessed from the C++ code off the main thread, such as in `InterfaceParentFinder`.  As such, this PR restores the mutex protecting the `_overlaysHUD` and `_overlaysWorld` members of the scripting interface, to ensure that accesses from different threads is safe.  

## Testing

Open Interface and go to dev welcome.  Walk around for a bit, especially near the sittable cushions.  Wave your mouse over the cushions.  In the current dev build 6811 this will likely crash within seconds or minutes.  With this build there should be no crash.  