### PR TITLE
Fixing the bug appearing on Nvidia 384.76

### DIFF
--- a/libraries/render-utils/src/local_lights_shading.slf
+++ b/libraries/render-utils/src/local_lights_shading.slf
@@ -34,6 +34,8 @@ in vec2 _texCoord0;
 out vec4 _fragColor;
 
 void main(void) {
+    _fragColor = vec4(0.0);
+
     // Grab the fragment data from the uv
     vec2 texCoord = _texCoord0.st;
 


### PR DESCRIPTION
Yep, this is it, an output value without initialization...

The new driver from nvidia apparently doesn;t start with 0.0 by default and was showing the extra random values in the lighting...

## TEST PLAN
Point and Spot lights are looking good in this PR on Nvidia GPU using driver 384.76
Looking buggy in master


Big up to @Zvork who found the solution !