### PR TITLE
render issue fixes

### DIFF
--- a/interface/src/ui/ResourceImageItem.cpp
+++ b/interface/src/ui/ResourceImageItem.cpp
@@ -92,16 +92,11 @@ QOpenGLFramebufferObject* ResourceImageItemRenderer::createFramebufferObject(con
 
 void ResourceImageItemRenderer::render() {
     auto f = QOpenGLContext::currentContext()->extraFunctions();
-    bool doUpdate = false;
-    // black background
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
 
     if (_fenceSync) {
         f->glWaitSync(_fenceSync, 0, GL_TIMEOUT_IGNORED);
         f->glDeleteSync(_fenceSync);
         _fenceSync = 0;
-        doUpdate = true;
     }
     if (_ready) {
         _fboMutex.lock();
@@ -116,9 +111,6 @@ void ResourceImageItemRenderer::render() {
         _copyFbo->release();
 
         _fboMutex.unlock();
-        if (doUpdate) {
-            update();
-        }
     }
     glFlush();
     _window->resetOpenGLState();

--- a/interface/src/ui/ResourceImageItem.h
+++ b/interface/src/ui/ResourceImageItem.h
@@ -34,7 +34,7 @@ private:
     NetworkTexturePointer _networkTexture;
     QQuickWindow* _window;
     QMutex _fboMutex;
-    QOpenGLFramebufferObject* _copyFbo;
+    QOpenGLFramebufferObject* _copyFbo { nullptr };
     GLsync _fenceSync { 0 };
     QTimer _updateTimer;
 public slots:


### PR DESCRIPTION
Added code to get network texture in timer if not there when timer has started.  That should fix any issues with the preview not showing up the first time you launch the camera.  Also, I now clear the copyFbo texture between renderings, which should eliminate the ghost image from rendering past when the aspect ratio changes.   And I was leaking, so fixed that.