### PR TITLE
Fix for duplicate tablet/toolbar buttons

### DIFF
--- a/libraries/script-engine/CMakeLists.txt
+++ b/libraries/script-engine/CMakeLists.txt
@@ -16,6 +16,6 @@ if (NOT ANDROID)
 
 endif ()
 
-link_hifi_libraries(shared networking octree gpu procedural model model-networking ktx recording avatars fbx entities controllers animation audio physics image)
+link_hifi_libraries(shared networking octree gpu procedural model model-networking ktx recording avatars fbx entities controllers animation audio physics image ui)
 # ui includes gl, but link_hifi_libraries does not use transitive includes, so gl must be explicit
 include_hifi_library_headers(gl)

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -196,6 +196,8 @@ public:
 
     QQuickItem* getQmlMenu() const;
 
+    void removeButtonsFromToolbar();
+
 signals:
     /**jsdoc
      * Signaled when this tablet receives an event from the html/js embedded in the tablet
@@ -236,7 +238,6 @@ protected:
     void removeButtonsFromHomeScreen();
     void loadHomeScreen(bool forceOntoHomeScreen);
     void addButtonsToToolbar();
-    void removeButtonsFromToolbar();
 
     bool _initialScreen { false };
     QVariant _initialPath { "" };


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/5278/In-Desktop-mode-when-reloading-all-scripts-sometimes-get-duplicates-of-all-HUD-buttons

We are still trying to come up with test plans for this as we haven't been able to come up with a solid repro for this happening when you take off the HMD.  There are apparently other ways this may happen so if you have experienced this issue before, try to reproduce it under this PR the same way it had happened in the past.  More information can be found in the above FogBugz report.

**Test Plan 1:**
1. Start interface
2. Open running scripts window
3. Spam the reload scripts button, verify that no buttons are duplicates

**More Test Plans TBD**

**Note:** This isn't the final state of this PR, I just wanted to get this on here to see if other people could reproduce the duplicate buttons issue on this since I haven't been able to repro it myself. 

