### PR TITLE
Fix ACClient on Linux

### DIFF
--- a/libraries/shared/src/ThreadHelpers.cpp
+++ b/libraries/shared/src/ThreadHelpers.cpp
@@ -17,10 +17,6 @@ void moveToNewNamedThread(QObject* object, const QString& name, std::function<vo
      QThread* thread = new QThread();
      thread->setObjectName(name);
 
-     if (priority != QThread::InheritPriority) {
-         thread->setPriority(priority);
-     }
-
      QString tempName = name;
      QObject::connect(thread, &QThread::started, [startCallback] {
          startCallback();
@@ -32,6 +28,9 @@ void moveToNewNamedThread(QObject* object, const QString& name, std::function<vo
      // put the object on the thread
      object->moveToThread(thread);
      thread->start();
+     if (priority != QThread::InheritPriority) {
+         thread->setPriority(priority);
+     }
 }
 
 void moveToNewNamedThread(QObject* object, const QString& name, QThread::Priority priority) {

--- a/tools/ac-client/src/ACClientApp.cpp
+++ b/tools/ac-client/src/ACClientApp.cpp
@@ -90,13 +90,15 @@ ACClientApp::ACClientApp(int argc, char* argv[]) :
 
 
     auto nodeList = DependencyManager::get<NodeList>();
-    // start the nodeThread so its event loop is running
-    nodeList->startThread();
 
     // setup a timer for domain-server check ins
     QTimer* domainCheckInTimer = new QTimer(nodeList.data());
     connect(domainCheckInTimer, &QTimer::timeout, nodeList.data(), &NodeList::sendDomainServerCheckIn);
     domainCheckInTimer->start(DOMAIN_SERVER_CHECK_IN_MSECS);
+
+    // start the nodeThread so its event loop is running 
+    // (must happen after the checkin timer is created with the nodelist as it's parent)
+    nodeList->startThread();
 
     const DomainHandler& domainHandler = nodeList->getDomainHandler();
 


### PR DESCRIPTION
The original code didn't move the `NodeList` to a new thread until after the `domainCheckInTimer` had been created.  This code restores that behavior.  Additionally, you can't set a thread priority for a non-running thread.  This code fixes that and eliminates the resulting warnings.  

## Testing

ACClient should function on Linux