### PR TITLE
Bug/5976

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -75,6 +75,7 @@
     {
       "name": "descriptors",
       "label": "Description",
+      "restart": false,
       "help": "This data will be queryable from your server. It may be collected by High Fidelity and used to share your domain with others.",
       "settings": [
         {

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -162,8 +162,10 @@ DomainServer::DomainServer(int argc, char* argv[]) :
 
     _gatekeeper.preloadAllowedUserPublicKeys(); // so they can connect on first request
 
+    //send signal to DomainMetadata when descriptors changed
     _metadata = new DomainMetadata(this);
-
+    connect(&_settingsManager, &DomainServerSettingsManager::settingsUpdated,
+            _metadata, &DomainMetadata::descriptorsChanged);
 
     qDebug() << "domain-server is running";
     static const QString AC_SUBNET_WHITELIST_SETTING_PATH = "security.ac_subnet_whitelist";

--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -1198,6 +1198,7 @@ bool DomainServerSettingsManager::recurseJSONObjectAndOverwriteSettings(const QJ
     static const QString SECURITY_ROOT_KEY = "security";
     static const QString AC_SUBNET_WHITELIST_KEY = "ac_subnet_whitelist";
     static const QString BROADCASTING_KEY = "broadcasting";
+    static const QString DESCRIPTION_ROOT_KEY = "descriptors";
 
     auto& settingsVariant = _configMap.getConfig();
     bool needRestart = false;
@@ -1265,7 +1266,7 @@ bool DomainServerSettingsManager::recurseJSONObjectAndOverwriteSettings(const QJ
                 if (!matchingDescriptionObject.isEmpty()) {
                     const QJsonValue& settingValue = rootValue.toObject()[settingKey];
                     updateSetting(settingKey, settingValue, *thisMap, matchingDescriptionObject);
-                    if ((rootKey != SECURITY_ROOT_KEY && rootKey != BROADCASTING_KEY)
+                    if ((rootKey != SECURITY_ROOT_KEY && rootKey != BROADCASTING_KEY && rootKey != DESCRIPTION_ROOT_KEY)
                         || settingKey == AC_SUBNET_WHITELIST_KEY) {
                         needRestart = true;
                     }


### PR DESCRIPTION
Edited describe-settings.json and DomainServerSettingsManager.cpp so that Adding a Description does not require a server restart. Edited DomainServer.cpp to send signal to DomainMetadata when descriptors changed

Testing Notes:
Build and Run the PR
Launch the interface and domain-server
go to localhost:40100 -> Settings -> Change any parameter of Description (Description, Maturity, Hosts, Username,Tags) -> Save.

Check the domain-server logs, it should show NO restart.
( Sample Line to Check: [07/05 13:43:05] [DEBUG] [default] domain-server is restarting. **This line should NOT be there in the logs**)

Check domain-server logs for Domain meta data updates. 
(Sample Lines: [07/05 17:56:29] [DEBUG] [default] Domain metadata descriptors set: QJsonObject({"capacity":0,"description":"testing description","hosts":[],"maturity":"mature","restriction":"open","tags":[]})
[07/05 17:56:29] [DEBUG] [default] Domain metadata sent to "/api/v1/domains/b3976aad-da09-40a5-887f-85802a24b9d2"
[07/05 17:56:29] [DEBUG] [default] Domain metadata update: "{\"domain\":{\"capacity\":0,\"description\":\"testing description\",\"hosts\":[],\"maturity\":\"mature\",\"restriction\":\"open\",\"tags\":[]}}")
 
Check the interface when adding a description. The interface should NOT go *Not Connected* for sometime when the description is added.
