### PR TITLE
redo cache switch

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -480,6 +480,12 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     static const auto SUPPRESS_SETTINGS_RESET = "--suppress-settings-reset";
     bool suppressPrompt = cmdOptionExists(argc, const_cast<const char**>(argv), SUPPRESS_SETTINGS_RESET);
     bool previousSessionCrashed = CrashHandler::checkForResetSettings(runningMarkerExisted, suppressPrompt);
+    // get dir to use for cache
+    static const auto CACHE_SWITCH = "--cache";
+    QString cacheDir = getCmdOption(argc, const_cast<const char**>(argv), CACHE_SWITCH);
+    if (!cacheDir.isEmpty()) {
+        qApp->setProperty(hifi::properties::APP_LOCAL_DATA_PATH, cacheDir);
+    }
 
     Setting::init();
 
@@ -1218,8 +1224,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
             settingsTimer->stop();
             // Delete it (this will trigger the thread destruction
             settingsTimer->deleteLater();
-            // Mark the settings thread as finished, so we know we can safely save in the main application 
-            // shutdown code 
+            // Mark the settings thread as finished, so we know we can safely save in the main application
+            // shutdown code
             _settingsGuard.trigger();
         });
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -299,7 +299,6 @@ public:
     void setAvatarOverrideUrl(const QUrl& url, bool save);
     QUrl getAvatarOverrideUrl() { return _avatarOverrideUrl; }
     bool getSaveAvatarOverrideUrl() { return _saveAvatarOverrideUrl; }
-    void setCacheOverrideDir(const QString& dirName) { _cacheDir = dirName; }
 
 signals:
     void svoImportRequested(const QString& url);
@@ -691,6 +690,5 @@ private:
     QUrl _avatarOverrideUrl;
     bool _saveAvatarOverrideUrl { false };
 
-    QString _cacheDir;
 };
 #endif // hifi_Application_h

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -101,27 +101,13 @@ int main(int argc, const char* argv[]) {
     if (allowMultipleInstances) {
         instanceMightBeRunning = false;
     }
-    // this needs to be done here in main, as the mechanism for setting the 
+    // this needs to be done here in main, as the mechanism for setting the
     // scripts directory appears not to work.  See the bug report
     // https://highfidelity.fogbugz.com/f/cases/5759/Issues-changing-scripts-directory-in-ScriptsEngine
     if (parser.isSet(overrideScriptsPathOption)) {
         QDir scriptsPath(parser.value(overrideScriptsPathOption));
         if (scriptsPath.exists()) {
             PathUtils::defaultScriptsLocation(scriptsPath.path());
-        }
-    }
-
-    if (parser.isSet(overrideAppLocalDataPathOption)) {
-        // get dir to use for cache
-        QString cacheDir = parser.value(overrideAppLocalDataPathOption);
-        if (!cacheDir.isEmpty()) {
-            // tell everyone to use the right cache location
-            //
-            // this handles data8 and prepared
-            DependencyManager::get<ResourceManager>()->setCacheDir(cacheDir);
-
-            // this does the ktx_cache
-            PathUtils::getAppLocalDataPath(cacheDir);
         }
     }
 

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -49,7 +49,7 @@ using ProgressCallback = std::function<void(qint64 totalReceived, qint64 total)>
 class AssetClient : public QObject, public Dependency {
     Q_OBJECT
 public:
-    AssetClient(const QString& cacheDir="");
+    AssetClient();
 
     Q_INVOKABLE GetMappingRequest* createGetMappingRequest(const AssetPath& path);
     Q_INVOKABLE GetAllMappingsRequest* createGetAllMappingsRequest();

--- a/libraries/networking/src/ResourceManager.cpp
+++ b/libraries/networking/src/ResourceManager.cpp
@@ -28,7 +28,7 @@
 ResourceManager::ResourceManager() {
     _thread.setObjectName("Resource Manager Thread");
 
-    auto assetClient = DependencyManager::set<AssetClient>(_cacheDir);
+    auto assetClient = DependencyManager::set<AssetClient>();
     assetClient->moveToThread(&_thread);
     QObject::connect(&_thread, &QThread::started, assetClient.data(), &AssetClient::init);
 
@@ -160,7 +160,3 @@ bool ResourceManager::resourceExists(const QUrl& url) {
     return false;
 }
 
-void ResourceManager::setCacheDir(const QString& cacheDir) {
-    // TODO: check for existence?  
-    _cacheDir = cacheDir;
-}

--- a/libraries/networking/src/ResourceManager.h
+++ b/libraries/networking/src/ResourceManager.h
@@ -59,7 +59,6 @@ private:
     PrefixMap _prefixMap;
     QMutex _prefixMapLock;
 
-    QString _cacheDir;
 };
 
 #endif

--- a/libraries/shared/src/PathUtils.cpp
+++ b/libraries/shared/src/PathUtils.cpp
@@ -19,6 +19,7 @@
 #include "PathUtils.h"
 #include <QtCore/QStandardPaths>
 #include <mutex> // std::once
+#include "shared/GlobalAppProperties.h"
 
 const QString& PathUtils::resourcesPath() {
 #ifdef Q_OS_MAC
@@ -34,12 +35,8 @@ QString PathUtils::getAppDataPath() {
     return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/";
 }
 
-QString PathUtils::getAppLocalDataPath(const QString& overridePath /* = "" */) {
-    static QString overriddenPath = "";
-    // set the overridden path if one was passed in
-    if (!overridePath.isEmpty()) {
-        overriddenPath = overridePath;
-    }
+QString PathUtils::getAppLocalDataPath() {
+    QString overriddenPath = qApp->property(hifi::properties::APP_LOCAL_DATA_PATH).toString();
     // return overridden path if set
     if (!overriddenPath.isEmpty()) {
         return overriddenPath;

--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -28,7 +28,7 @@ public:
     static const QString& resourcesPath();
 
     static QString getAppDataPath();
-    static QString getAppLocalDataPath(const QString& overridePath = "");
+    static QString getAppLocalDataPath();
 
     static QString getAppDataFilePath(const QString& filename);
     static QString getAppLocalDataFilePath(const QString& filename);

--- a/libraries/shared/src/shared/GlobalAppProperties.cpp
+++ b/libraries/shared/src/shared/GlobalAppProperties.cpp
@@ -17,6 +17,7 @@ namespace hifi { namespace properties {
     const char* TEST = "com.highfidelity.test";
     const char* TRACING = "com.highfidelity.tracing";
     const char* HMD = "com.highfidelity.hmd";
+    const char* APP_LOCAL_DATA_PATH = "com.highfidelity.appLocalDataPath";
 
     namespace gl {
         const char* BACKEND = "com.highfidelity.gl.backend";

--- a/libraries/shared/src/shared/GlobalAppProperties.h
+++ b/libraries/shared/src/shared/GlobalAppProperties.h
@@ -19,6 +19,7 @@ namespace hifi { namespace properties {
     extern const char* TEST;
     extern const char* TRACING;
     extern const char* HMD;
+    extern const char* APP_LOCAL_DATA_PATH;
 
     namespace gl {
         extern const char* BACKEND;


### PR DESCRIPTION
When the ResourceManager was re-worked a bit, it broke the --cache switch (causing a segfault) when starting interface.  This re-implements it in a manner consistent with those changes.