### PR TITLE
Ensure admins see PAL admin column

### DIFF
--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -482,10 +482,10 @@ function populateNearbyUserList(selectData, oldAudioData) {
             isPresent: true,
             isReplicated: avatar.isReplicated
         };
+        // Everyone needs to see admin status. Username and fingerprint returns default constructor output if the requesting user isn't an admin.
+        Users.requestUsernameFromID(id);
         if (id) {
             addAvatarNode(id); // No overlay for ourselves
-            // Everyone needs to see admin status. Username and fingerprint returns default constructor output if the requesting user isn't an admin.
-            Users.requestUsernameFromID(id);
             avatarsOfInterest[id] = true;
         } else {
             // Return our username from the Account API


### PR DESCRIPTION
[FB 4717](https://highfidelity.fogbugz.com/f/cases/edit/4717/Admin-not-seeing-Admin-settings-in-PAL).

Honestly, I'm not totally sure how this worked before? How did `null` entries in the `AvatarList` get past the `if (null)` check? in `pal.js`? Anyway...

**Test Plan:**
1. Visit a domain where you're an Admin. Open the PAL. Verify that you see the Admin column.
2. Attempt some daft trickery, like opening the PAL as soon as you get to a domain where you're an admin. Verify that you can't break the visibility of the Admin column in the PAL when you're an Admin.
3. Visit a domain where you're not an Admin, you plebeian scum. Verify that you _can't_ see the Admin column.