### PR TITLE
fixed log spamming from windowRoot.qml in toolbar mode

### DIFF
--- a/interface/resources/qml/hifi/tablet/WindowRoot.qml
+++ b/interface/resources/qml/hifi/tablet/WindowRoot.qml
@@ -52,8 +52,10 @@ Windows.ScrollingWindow {
 
     // used to receive messages from interface script
     function fromScript(message) {
-        if (loader.item.hasOwnProperty("fromScript")) {
-            loader.item.fromScript(message);
+        if (loader.item !== null) {
+            if (loader.item.hasOwnProperty("fromScript")) {
+                loader.item.fromScript(message);
+            }
         }
     }
 


### PR DESCRIPTION
prevent windowRoot.qml from spamming the login toolbar mode