### PR TITLE
Fixing overlay crashes, for real

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -307,6 +307,7 @@ void Overlays::deleteOverlay(OverlayID id) {
     }
 #endif
 
+
     _overlaysToDelete.push_back(overlayToDelete);
     emit overlayDeleted(id);
 }
@@ -606,22 +607,16 @@ QSizeF Overlays::textSize(OverlayID id, const QString& text) {
         return result;
     }
 
-    Overlay::Pointer thisOverlay;
-    {
-        QMutexLocker locker(&_mutex);
-        thisOverlay = _overlaysHUD[id];
-    }
+    Overlay::Pointer thisOverlay = getOverlay(id);
     if (thisOverlay) {
-        if (auto textOverlay = std::dynamic_pointer_cast<TextOverlay>(thisOverlay)) {
-            return textOverlay->textSize(text);
-        }
-    } else {
-        { 
-            QMutexLocker locker(&_mutex);
-            thisOverlay = _overlaysWorld[id];
-        }
-        if (auto text3dOverlay = std::dynamic_pointer_cast<Text3DOverlay>(thisOverlay)) {
-            return text3dOverlay->textSize(text);
+        if (thisOverlay->is3D()) {
+            if (auto text3dOverlay = std::dynamic_pointer_cast<Text3DOverlay>(thisOverlay)) {
+                return text3dOverlay->textSize(text);
+            }
+        } else {
+            if (auto textOverlay = std::dynamic_pointer_cast<TextOverlay>(thisOverlay)) {
+                return textOverlay->textSize(text);
+            }
         }
     }
     return QSizeF(0.0f, 0.0f);


### PR DESCRIPTION
Since some recent changes to the Overlays (intended to make them less crash prone) we've been seeing a significant number of new crashes in the overlay code that look as if the overlay maps contain empty pointers.  

I was finally able to reproduce this when using the chat script and able to track it down.  The issue was in the `Overlays::textSize` function.  Previously the function had been declared as `QSizeF Overlays::textSize(OverlayID id, const QString& text) const`, but the refactor removed the const modifier, because Qt can't do a cross thread method invocation on a const object.

Unfortunately removing the const had a nasty side effect.  The implementation of the function was using the map `operator[]` method to see if a given map contained the key being queried.  `QMap::operator[] const`  will simply return a default constructed value if the key doesn't exist.  However, the non-const version `QMap::operator[]` will create the default constructed value _and insert it into the map at the given key_.  This meant that every time someone called `textSize` on a Text3DOverlay, it would first check the `_overlaysHUD` map, insert a new empty value at that key into that map, and then check the `_overlaysWorld` map.  This empty value in `_overlaysHUD` completely screwed up the rest of the classes assumptions, leading to crashes when the empty pointer was de-referenced.  

The fix simply involves removing the use of `operator[]` from the `textSize` function (and verifying it's used incorrectly nowhere else).  

## Testing

Run the marketplace chat script, Chat.js.  Open the chat window and type any message.  The current master build will crash instantly.  This PR build should not.  
