### PR TITLE
Set admin status even if QML can't find user in PAL

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -1099,9 +1099,9 @@ Rectangle {
         case 'nearbyUsers':
             var data = message.params;
             var index = -1;
+            iAmAdmin = Users.canKick;
             index = findNearbySessionIndex('', data);
             if (index !== -1) {
-                iAmAdmin = Users.canKick;
                 myData = data[index];
                 data.splice(index, 1);
             } else {

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -865,6 +865,9 @@ function avatarDisconnected(nodeID) {
 
 function clearLocalQMLDataAndClosePAL() {
     sendToQml({ method: 'clearLocalQMLData' });
+    if (onPalScreen) {
+        tablet.gotoHomeScreen();
+    }
 }
 
 function avatarAdded(avatarID) {


### PR DESCRIPTION
Related to #10903. I think that PR was good code, but I don't think it completed the fix.

This PR _ensures_ that `iAmAdmin` in the PAL QML is set to `true` iff the user is an admin when the nearbyUsers list is refreshed (i.e. when the PAL is opened).

I'm realizing now that something else fishy might be going on when a user isn't seeing the ADMIN column when they know they're an admin...I don't know what might cause that, but this should be another step in the right direction to prevent it from happening.

Same test plan as before:
1. Visit a domain where you're an Admin. Open the PAL. Verify that you see the Admin column.
2. Attempt some daft trickery, like opening the PAL as soon as you get to a domain where you're an admin. Verify that you can't break the visibility of the Admin column in the PAL when you're an Admin.
3. Visit a domain where you're not an Admin, Verify that you _can't_ see the Admin column.