### PR TITLE
Add signal for avatar skeleton changing

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1356,6 +1356,7 @@ void MyAvatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
     Avatar::setSkeletonModelURL(skeletonModelURL);
     _skeletonModel->setVisibleInScene(true, qApp->getMain3DScene());
     _headBoneSet.clear();
+    emit skeletonChanged();
 }
 
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -606,6 +606,7 @@ signals:
     void onLoadComplete();
     void wentAway();
     void wentActive();
+    void skeletonChanged();
 
 private:
 


### PR DESCRIPTION
For development purposes, surface when the avatar skeleton URL has changed. Example context: I've parented a scripted entity to my avatar as a bracelet, but if I change my avatar and the joint indices have changed, the bracelet is attached in a weird location. This enables me to reset the position of the attachment to the proper joint automatically.

Test Plan
- Run https://hifi-content.s3.amazonaws.com/liv/TestAvatarSkeletonChangedSignal.js
- Open the Script Log up
- Change Avatars
- Confirm that the Skeleton Changed message appears in the console