### PR TITLE
Prevent Image3DOverlays from drifting

### DIFF
--- a/interface/src/ui/overlays/Billboard3DOverlay.cpp
+++ b/interface/src/ui/overlays/Billboard3DOverlay.cpp
@@ -37,9 +37,11 @@ QVariant Billboard3DOverlay::getProperty(const QString &property) {
     return Planar3DOverlay::getProperty(property);
 }
 
-void Billboard3DOverlay::applyTransformTo(Transform& transform, bool force) {
+bool Billboard3DOverlay::applyTransformTo(Transform& transform, bool force) {
+    bool transformChanged = false;
     if (force || usecTimestampNow() > _transformExpiry) {
-        PanelAttachable::applyTransformTo(transform, true);
-        pointTransformAtCamera(transform, getOffsetRotation());
+        transformChanged = PanelAttachable::applyTransformTo(transform, true);
+        transformChanged |= pointTransformAtCamera(transform, getOffsetRotation());
     }
+    return transformChanged;
 }

--- a/interface/src/ui/overlays/Billboard3DOverlay.h
+++ b/interface/src/ui/overlays/Billboard3DOverlay.h
@@ -27,7 +27,7 @@ public:
     QVariant getProperty(const QString& property) override;
 
 protected:
-    virtual void applyTransformTo(Transform& transform, bool force = false) override;
+    virtual bool applyTransformTo(Transform& transform, bool force = false) override;
 };
 
 #endif // hifi_Billboard3DOverlay_h

--- a/interface/src/ui/overlays/Billboardable.cpp
+++ b/interface/src/ui/overlays/Billboardable.cpp
@@ -28,7 +28,7 @@ QVariant Billboardable::getProperty(const QString &property) {
     return QVariant();
 }
 
-void Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offsetRotation) {
+bool Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offsetRotation) {
     if (isFacingAvatar()) {
         glm::vec3 billboardPos = transform.getTranslation();
         glm::vec3 cameraPos = qApp->getCamera().getPosition();
@@ -38,5 +38,7 @@ void Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offse
         glm::quat rotation(glm::vec3(elevation, azimuth, 0));
         transform.setRotation(rotation);
         transform.postRotate(offsetRotation);
+        return true;
     }
+    return false;
 }

--- a/interface/src/ui/overlays/Billboardable.h
+++ b/interface/src/ui/overlays/Billboardable.h
@@ -27,7 +27,7 @@ protected:
     void setProperties(const QVariantMap& properties);
     QVariant getProperty(const QString& property);
 
-    void pointTransformAtCamera(Transform& transform, glm::quat offsetRotation = {1, 0, 0, 0});
+    bool pointTransformAtCamera(Transform& transform, glm::quat offsetRotation = {1, 0, 0, 0});
 
 private:
     bool _isFacingAvatar = false;

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -102,6 +102,8 @@ void Image3DOverlay::render(RenderArgs* args) {
     
     Transform transform = getTransform();
     bool transformChanged = applyTransformTo(transform, true);
+    // If the transform is not modified, setting the transform to
+    // itself will cause drift over time due to floating point errors.
     if (transformChanged) {
         setTransform(transform);
     }

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -99,10 +99,12 @@ void Image3DOverlay::render(RenderArgs* args) {
     const float MAX_COLOR = 255.0f;
     xColor color = getColor();
     float alpha = getAlpha();
-
+    
     Transform transform = getTransform();
-    applyTransformTo(transform, true);
-    setTransform(transform);
+    bool transformChanged = applyTransformTo(transform, true);
+    if (transformChanged) {
+        setTransform(transform);
+    }
     transform.postScale(glm::vec3(getDimensions(), 1.0f));
 
     batch->setModelTransform(transform);

--- a/interface/src/ui/overlays/PanelAttachable.cpp
+++ b/interface/src/ui/overlays/PanelAttachable.cpp
@@ -61,7 +61,7 @@ void PanelAttachable::setProperties(const QVariantMap& properties) {
     }
 }
 
-void PanelAttachable::applyTransformTo(Transform& transform, bool force) {
+bool PanelAttachable::applyTransformTo(Transform& transform, bool force) {
     if (force || usecTimestampNow() > _transformExpiry) {
         const quint64 TRANSFORM_UPDATE_PERIOD = 100000; // frequency is 10 Hz
         _transformExpiry = usecTimestampNow() + TRANSFORM_UPDATE_PERIOD;
@@ -71,7 +71,9 @@ void PanelAttachable::applyTransformTo(Transform& transform, bool force) {
             transform.postTranslate(getOffsetPosition());
             transform.postRotate(getOffsetRotation());
             transform.postScale(getOffsetScale());
+            return true;
         }
 #endif
     }
+    return false;
 }

--- a/interface/src/ui/overlays/PanelAttachable.h
+++ b/interface/src/ui/overlays/PanelAttachable.h
@@ -67,7 +67,7 @@ protected:
 
     /// set position, rotation and scale on transform based on offsets, and parent panel offsets
     /// if force is false, only apply transform if it hasn't been applied in the last .1 seconds
-    virtual void applyTransformTo(Transform& transform, bool force = false);
+    virtual bool applyTransformTo(Transform& transform, bool force = false);
     quint64 _transformExpiry = 0;
 
 private:


### PR DESCRIPTION
**Test Plan:**
1. In HMD, use the Spectator Camera app to spawn the Spectator Camera. Close the tablet.
2. Using your hand controllers, quickly spin the spectator camera model along the same axis for 60 full seconds.
3. Stop spinning the camera. Verify that the camera viewfinder overlay is still present within the "glass" camera viewfinder and has not changed size or position within the glass.