### PR TITLE
Misc servers debug asserts fixes

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -801,6 +801,7 @@ void Agent::aboutToFinish() {
 
     emit stopAvatarAudioTimer();
     _avatarAudioTimerThread.quit();
+    _avatarAudioTimerThread.wait();
 
     // cleanup codec & encoder
     if (_codec && _encoder) {

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -81,7 +81,8 @@ Agent::Agent(ReceivedMessage& message) :
 
     DependencyManager::set<RecordingScriptingInterface>();
     DependencyManager::set<UsersScriptingInterface>();
-    
+
+    // Needed to ensure the creation of the DebugDraw instance on the main thread
     DebugDraw::getInstance();
 
 

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -23,6 +23,7 @@
 #include <AvatarHashMap.h>
 #include <AudioInjectorManager.h>
 #include <AssetClient.h>
+#include <DebugDraw.h>
 #include <LocationScriptingInterface.h>
 #include <MessagesClient.h>
 #include <NetworkAccessManager.h>
@@ -80,6 +81,8 @@ Agent::Agent(ReceivedMessage& message) :
 
     DependencyManager::set<RecordingScriptingInterface>();
     DependencyManager::set<UsersScriptingInterface>();
+    
+    DebugDraw::getInstance();
 
 
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();

--- a/assignment-client/src/audio/AudioMixerSlavePool.cpp
+++ b/assignment-client/src/audio/AudioMixerSlavePool.cpp
@@ -76,7 +76,7 @@ void AudioMixerSlavePool::processPackets(ConstIter begin, ConstIter end) {
 
 void AudioMixerSlavePool::mix(ConstIter begin, ConstIter end, unsigned int frame, float throttlingRatio) {
     _function = &AudioMixerSlave::mix;
-    _configure = [&](AudioMixerSlave& slave) {
+    _configure = [=](AudioMixerSlave& slave) {
         slave.configureMix(_begin, _end, _frame, _throttlingRatio);
     };
     _frame = frame;

--- a/assignment-client/src/avatars/AvatarMixerSlavePool.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlavePool.cpp
@@ -69,7 +69,7 @@ static AvatarMixerSlave slave;
 
 void AvatarMixerSlavePool::processIncomingPackets(ConstIter begin, ConstIter end) {
     _function = &AvatarMixerSlave::processIncomingPackets;
-    _configure = [&](AvatarMixerSlave& slave) { 
+    _configure = [=](AvatarMixerSlave& slave) { 
         slave.configure(begin, end);
     };
     run(begin, end);
@@ -79,7 +79,7 @@ void AvatarMixerSlavePool::broadcastAvatarData(ConstIter begin, ConstIter end,
                                                p_high_resolution_clock::time_point lastFrameTimestamp,
                                                float maxKbpsPerNode, float throttlingRatio) {
     _function = &AvatarMixerSlave::broadcastAvatarData;
-    _configure = [&](AvatarMixerSlave& slave) { 
+    _configure = [=](AvatarMixerSlave& slave) { 
         slave.configureBroadcast(begin, end, lastFrameTimestamp, maxKbpsPerNode, throttlingRatio);
    };
     run(begin, end);

--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -50,6 +50,12 @@ EntityServer::~EntityServer() {
     tree->removeNewlyCreatedHook(this);
 }
 
+void EntityServer::aboutToFinish() {
+    DependencyManager::get<ResourceManager>()->cleanup();
+
+    OctreeServer::aboutToFinish();
+}
+
 void EntityServer::handleEntityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
     if (_octreeInboundPacketProcessor) {
         _octreeInboundPacketProcessor->queueReceivedPacket(message, senderNode);

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -59,6 +59,8 @@ public:
     virtual void trackSend(const QUuid& dataID, quint64 dataLastEdited, const QUuid& sessionID) override;
     virtual void trackViewerGone(const QUuid& sessionID) override;
 
+    virtual void aboutToFinish() override;
+
 public slots:
     virtual void nodeAdded(SharedNodePointer node) override;
     virtual void nodeKilled(SharedNodePointer node) override;

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -68,6 +68,7 @@ EntityScriptServer::EntityScriptServer(ReceivedMessage& message) : ThreadedAssig
     DependencyManager::set<ScriptCache>();
     DependencyManager::set<ScriptEngines>(ScriptEngine::ENTITY_SERVER_SCRIPT);
 
+    // Needed to ensure the creation of the DebugDraw instance on the main thread
     DebugDraw::getInstance();
 
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -16,6 +16,7 @@
 #include <AudioConstants.h>
 #include <AudioInjectorManager.h>
 #include <ClientServerUtils.h>
+#include <DebugDraw.h>
 #include <EntityNodeData.h>
 #include <EntityScriptingInterface.h>
 #include <LogHandler.h>
@@ -66,6 +67,8 @@ EntityScriptServer::EntityScriptServer(ReceivedMessage& message) : ThreadedAssig
 
     DependencyManager::set<ScriptCache>();
     DependencyManager::set<ScriptEngines>(ScriptEngine::ENTITY_SERVER_SCRIPT);
+
+    DebugDraw::getInstance();
 
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
     packetReceiver.registerListenerForTypes({ PacketType::OctreeStats, PacketType::EntityData, PacketType::EntityErase },


### PR DESCRIPTION
- Fixed `sendEvent called on the wrong thread` assert during the Agent and ESS startup.
- Fixed `QThread destroyed while running` assert during the Agent and EntityServer shutdown.
- Fixed `invalid read access` during Audio/Avatar Mixer shutdown.