### PR TITLE
Don't show SPECTATOR app in Desktop mode

### DIFF
--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -131,10 +131,10 @@
     // Relevant Variables:
     //   -button: The tablet button.
     //   -buttonName: The name of the button.
-    //   -showInDesktop: Set to "true" to show the "SPECTATOR" app in desktop mode.
+    //   -showSpectatorInDesktop: Set to "true" to show the "SPECTATOR" app in desktop mode.
     var button = false;
     var buttonName = "SPECTATOR";
-    var showSpectatorInDesktop = true;
+    var showSpectatorInDesktop = false;
     function addOrRemoveButton(isShuttingDown, isHMDMode) {
         if (!tablet) {
             print("Warning in addOrRemoveButton(): 'tablet' undefined!");


### PR DESCRIPTION
#### Test Plan

| Test | Expected Result | Pass/Fail | Notes |
|------|-----------------|-----------|-------|
| Look at your toolbar. | Verify that the "SPECTATOR" button _is not_ present. |||
| Navigate to Settings->General and _uncheck_ "Desktop Tablet Becomes Toolbar". Open your Tablet. | Verify that the "SPECTATOR" app _is not_ present. |||
| Switch to VR mode. Open your Tablet. | Verify that the "SPECTATOR" app _is_ present. |||