### PR TITLE
Fixed goto hmd keyboard not entering text

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -99,7 +99,13 @@ StackView {
         height: parent.height
 
         MouseArea {
-            anchors.fill: parent
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+                bottom: keyboard.top
+            }
+
             propagateComposedEvents: true
             onPressed: {
                 parent.forceActiveFocus();


### PR DESCRIPTION
Fixing the issue that I introduced of HMD keyboard not entering when fixing the hmd keyboard no popping up for goto.