### PR TITLE
Ensure spectator camera preview is up when reopening tablet

### DIFF
--- a/interface/resources/qml/hifi/SpectatorCamera.qml
+++ b/interface/resources/qml/hifi/SpectatorCamera.qml
@@ -251,8 +251,8 @@ Rectangle {
             // Spectator Camera Preview
             Hifi.ResourceImageItem {
                 id: spectatorCameraPreview;
-                visible: false;
-                url: "resource://spectatorCameraFrame";
+                visible: cameraToggleCheckbox.checked;
+                url: monitorShowsSwitch.checked ? "resource://spectatorCameraFrame" : "resource://hmdPreviewFrame";
                 ready: cameraToggleCheckBox.checked;
                 mirrorVertically: true;
                 anchors.fill: parent;

--- a/interface/src/ui/ResourceImageItem.cpp
+++ b/interface/src/ui/ResourceImageItem.cpp
@@ -69,7 +69,7 @@ void ResourceImageItemRenderer::synchronize(QQuickFramebufferObject* item) {
     bool visibleChanged = false;
     if (_visible != resourceImageItem->isVisible()) {
         _visible = resourceImageItem->isVisible();
-        visibleChanged=true;
+        visibleChanged = true;
     }
     _window = resourceImageItem->window();
 

--- a/interface/src/ui/ResourceImageItem.cpp
+++ b/interface/src/ui/ResourceImageItem.cpp
@@ -66,15 +66,20 @@ void ResourceImageItemRenderer::synchronize(QQuickFramebufferObject* item) {
         _ready = resourceImageItem->getReady();
         readyChanged = true;
     }
-
+    bool visibleChanged = false;
+    if (_visible != resourceImageItem->isVisible()) {
+        _visible = resourceImageItem->isVisible();
+        visibleChanged=true;
+    }
     _window = resourceImageItem->window();
-    if (_ready && !_url.isNull() && !_url.isEmpty() && (urlChanged || readyChanged || !_networkTexture)) {
+
+    if (_ready && _visible && !_url.isNull() && !_url.isEmpty() && (visibleChanged || urlChanged || readyChanged || !_networkTexture)) {
         _networkTexture = DependencyManager::get<TextureCache>()->getTexture(_url);
     }
     static const int UPDATE_TIMER_DELAY_IN_MS = 100; // 100 ms = 10 hz for now
-    if (_ready && !_updateTimer.isActive()) {
+    if (_ready && _visible && !_updateTimer.isActive()) {
         _updateTimer.start(UPDATE_TIMER_DELAY_IN_MS);
-    } else if (!_ready && _updateTimer.isActive()) {
+    } else if (!(_ready && _visible) && _updateTimer.isActive()) {
         _updateTimer.stop();
     }
 }

--- a/interface/src/ui/ResourceImageItem.h
+++ b/interface/src/ui/ResourceImageItem.h
@@ -30,6 +30,7 @@ public:
 private:
     bool _ready;
     QString _url;
+    bool _visible;
 
     NetworkTexturePointer _networkTexture;
     QQuickWindow* _window;


### PR DESCRIPTION
If you dismissed the tablet with the spectator camera running, then opened it again, the preview was not being shown.  Now it is.  While there, also made sure we stop updating the preview window when it isn't visible, as that is just a waste of resources.