### PR TITLE
Record total number of ATP/HTTP/File bytes downloaded during session

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1466,6 +1466,14 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         properties["atp_mapping_requests"] = atpMappingRequests;
 
         properties["throttled"] = _displayPlugin ? _displayPlugin->isThrottled() : false;
+        
+        QJsonObject bytesDownloaded;
+        bytesDownloaded["atp"] = statTracker->getStat(STAT_ATP_RESOURCE_TOTAL_BYTES).toInt();
+        bytesDownloaded["http"] = statTracker->getStat(STAT_HTTP_RESOURCE_TOTAL_BYTES).toInt();
+        bytesDownloaded["file"] = statTracker->getStat(STAT_FILE_RESOURCE_TOTAL_BYTES).toInt();
+        bytesDownloaded["total"] = bytesDownloaded["atp"].toInt() + bytesDownloaded["http"].toInt()
+            + bytesDownloaded["file"].toInt();
+        properties["bytesDownloaded"] = bytesDownloaded;
 
         auto myAvatar = getMyAvatar();
         glm::vec3 avatarPosition = myAvatar->getPosition();

--- a/libraries/networking/src/AssetResourceRequest.cpp
+++ b/libraries/networking/src/AssetResourceRequest.cpp
@@ -187,6 +187,9 @@ void AssetResourceRequest::onDownloadProgress(qint64 bytesReceived, qint64 bytes
     emit progress(bytesReceived, bytesTotal);
 
     auto now = p_high_resolution_clock::now();
+	
+    // Recording ATP bytes downloaded in stats
+    DependencyManager::get<StatTracker>()->updateStat(STAT_ATP_RESOURCE_TOTAL_BYTES, bytesReceived);
 
     // if we haven't received the full asset check if it is time to output progress to log
     // we do so every X seconds to assist with ATP download tracking
@@ -201,6 +204,5 @@ void AssetResourceRequest::onDownloadProgress(qint64 bytesReceived, qint64 bytes
 
         _lastProgressDebug = now;
     }
-
 }
 

--- a/libraries/networking/src/FileResourceRequest.cpp
+++ b/libraries/networking/src/FileResourceRequest.cpp
@@ -20,7 +20,7 @@
 void FileResourceRequest::doSend() {
     auto statTracker = DependencyManager::get<StatTracker>();
     statTracker->incrementStat(STAT_FILE_REQUEST_STARTED);
-
+    int fileSize = 0;
     QString filename = _url.toLocalFile();
     
     // sometimes on windows, we see the toLocalFile() return null,
@@ -53,6 +53,7 @@ void FileResourceRequest::doSend() {
                     }
 
                     _result = ResourceRequest::Success;
+                    fileSize = file.size();
                 }
 
             } else {
@@ -68,6 +69,8 @@ void FileResourceRequest::doSend() {
 
     if (_result == ResourceRequest::Success) {
         statTracker->incrementStat(STAT_FILE_REQUEST_SUCCESS);
+        // Recording FILE bytes downloaded in stats
+        statTracker->updateStat(STAT_FILE_RESOURCE_TOTAL_BYTES,fileSize);
     } else {
         statTracker->incrementStat(STAT_FILE_REQUEST_FAILED);
     }

--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -201,6 +201,11 @@ void HTTPResourceRequest::onDownloadProgress(qint64 bytesReceived, qint64 bytesT
     _sendTimer->start();
 
     emit progress(bytesReceived, bytesTotal);
+	
+    // Recording HTTP bytes downloaded in stats
+    DependencyManager::get<StatTracker>()->updateStat(STAT_HTTP_RESOURCE_TOTAL_BYTES, bytesReceived);
+	
+	
 }
 
 void HTTPResourceRequest::onTimeout() {

--- a/libraries/networking/src/ResourceRequest.h
+++ b/libraries/networking/src/ResourceRequest.h
@@ -33,6 +33,9 @@ const QString STAT_HTTP_REQUEST_CACHE = "CacheHTTPRequest";
 const QString STAT_ATP_MAPPING_REQUEST_STARTED = "StartedATPMappingRequest";
 const QString STAT_ATP_MAPPING_REQUEST_FAILED = "FailedATPMappingRequest";
 const QString STAT_ATP_MAPPING_REQUEST_SUCCESS = "SuccessfulATPMappingRequest";
+const QString STAT_HTTP_RESOURCE_TOTAL_BYTES = "HTTPBytesDownloaded";
+const QString STAT_ATP_RESOURCE_TOTAL_BYTES = "ATPBytesDownloaded";
+const QString STAT_FILE_RESOURCE_TOTAL_BYTES = "FILEBytesDownloaded";
 
 class ResourceRequest : public QObject {
     Q_OBJECT


### PR DESCRIPTION
Records total bytes in the stats and sends the data over to metaverse API.

Testing Notes:
Run Interface
Check Metabase ( http://metabase.highfidelity.com/)
Get session ID for the particular user ID
Check User Activities for the obtained session ID
In user Activities check the row with Action = stats
Sample line: "bytesDownloaded": {"atp": 0, "file": 27567737, "http": 106976449, "total": 134544186}
