### PR TITLE
Workaround the bug where Avatar Entities can't get deleted after switching domains

### DIFF
--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -113,6 +113,14 @@
     //    destroy the camera entity. "isChangingDomains" is true when this function is called
     //    from the "Window.domainChanged()" signal.
     function spectatorCameraOff(isChangingDomains) {
+
+        function deleteCamera() {
+            Entities.deleteEntity(camera);
+            camera = false;
+            // Change button to active when window is first openend OR if the camera is on, false otherwise.
+            button.editProperties({ isActive: onSpectatorCameraScreen || camera });
+        }
+
         spectatorCameraConfig.attachedEntityId = false;
         spectatorCameraConfig.enableSecondaryCameraRenderConfigs(false);
         if (camera) {
@@ -121,12 +129,10 @@
             // Should be removed after FB6155 is fixed.
             if (isChangingDomains) {
                 Script.setTimeout(function () {
-                    Entities.deleteEntity(camera);
-                    camera = false;
+                    deleteCamera();
                 }, 1 * 1000);
             } else {
-                Entities.deleteEntity(camera);
-                camera = false;
+                deleteCamera();
             }
         }
         if (viewFinderOverlay) {
@@ -134,10 +140,6 @@
         }
         viewFinderOverlay = false;
         setDisplay(monitorShowsCameraView);
-        // Change button to active when window is first openend OR if the camera is on, false otherwise.
-        if (button) {
-            button.editProperties({ isActive: onSpectatorCameraScreen || camera });
-        }
     }
 
     // Function Name: addOrRemoveButton()

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -130,6 +130,7 @@
             if (isChangingDomains) {
                 Script.setTimeout(function () {
                     deleteCamera();
+                    spectatorCameraOn();
                 }, 1 * 1000);
             } else {
                 deleteCamera();

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -112,6 +112,7 @@
     //   -Call this function to shut down the spectator camera and
     //    destroy the camera entity. "isChangingDomains" is true when this function is called
     //    from the "Window.domainChanged()" signal.
+    var WAIT_AFTER_DOMAIN_SWITCH_BEFORE_CAMERA_DELETE_MS = 1 * 1000;
     function spectatorCameraOff(isChangingDomains) {
 
         function deleteCamera() {
@@ -131,7 +132,7 @@
                 Script.setTimeout(function () {
                     deleteCamera();
                     spectatorCameraOn();
-                }, 1 * 1000);
+                }, WAIT_AFTER_DOMAIN_SWITCH_BEFORE_CAMERA_DELETE_MS);
             } else {
                 deleteCamera();
             }

--- a/scripts/system/spectatorCamera.js
+++ b/scripts/system/spectatorCamera.js
@@ -190,9 +190,7 @@
         tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
         addOrRemoveButton(false, HMD.active);
         tablet.screenChanged.connect(onTabletScreenChanged);
-        Window.domainChanged.connect(function () {
-            spectatorCameraOff(true);
-        });
+        Window.domainChanged.connect(onDomainChanged);
         Window.geometryChanged.connect(resizeViewFinderOverlay);
         Controller.keyPressEvent.connect(keyPressEvent);
         HMD.displayModeChanged.connect(onHMDChanged);
@@ -483,9 +481,7 @@
     //   -shutdown() will be called when the script ends (i.e. is stopped).
     function shutdown() {
         spectatorCameraOff();
-        Window.domainChanged.disconnect(function () {
-            spectatorCameraOff(true);
-        });
+        Window.domainChanged.disconnect(onDomainChanged);
         Window.geometryChanged.disconnect(resizeViewFinderOverlay);
         addOrRemoveButton(true, HMD.active);
         if (tablet) {
@@ -499,6 +495,14 @@
         if (controllerMapping) {
             controllerMapping.disable();
         }
+    }
+
+    // Function Name: onDomainChanged()
+    //
+    // Description:
+    //   -A small utility function used when the Window.domainChanged() signal is fired.
+    function onDomainChanged() {
+        spectatorCameraOff(true);
     }
 
     // These functions will be called when the script is loaded.


### PR DESCRIPTION
This PR will be code reviewed normally, but tested as part of the overall test plan on #10875.

Also re-enable spectator camera after switching domains.