### PR TITLE
Fix Avatar/Audio Mixer crash

### DIFF
--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -950,7 +950,7 @@ void NodeList::maybeSendIgnoreSetToNode(SharedNodePointer newNode) {
 
         if (_personalMutedNodeIDs.size() > 0) {
             // setup a packet list so we can send the stream of ignore IDs
-            auto personalMutePacketList = NLPacketList::create(PacketType::NodeIgnoreRequest, QByteArray(), true);
+            auto personalMutePacketList = NLPacketList::create(PacketType::NodeIgnoreRequest, QByteArray(), true, true);
 
             // Force the "enabled" flag in this packet to true
             personalMutePacketList->writePrimitive(true);
@@ -977,7 +977,7 @@ void NodeList::maybeSendIgnoreSetToNode(SharedNodePointer newNode) {
 
         if (_ignoredNodeIDs.size() > 0) {
             // setup a packet list so we can send the stream of ignore IDs
-            auto ignorePacketList = NLPacketList::create(PacketType::NodeIgnoreRequest, QByteArray(), true);
+            auto ignorePacketList = NLPacketList::create(PacketType::NodeIgnoreRequest, QByteArray(), true, true);
 
             // Force the "enabled" flag in this packet to true
             ignorePacketList->writePrimitive(true);


### PR DESCRIPTION
- Fixed a bug caused by ignoring more UUIDs than can fit in a packet and that would crash the mixers.