### PR TITLE
Resolved : Tablet "X" Button does not go back, just closes tablet.

### DIFF
--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -512,8 +512,21 @@ WebTablet.prototype.mousePressEvent = function (event) {
     if (entityPickResults.intersects && (entityPickResults.entityID === this.tabletEntityID ||
                                          entityPickResults.overlayID === this.tabletEntityID)) {
         var overlayPickResults = Overlays.findRayIntersection(pickRay, true, [this.webOverlayID, this.homeButtonID], []);
+        var isTabletScreenChanged = false;
         if (overlayPickResults.intersects && overlayPickResults.overlayID === this.homeButtonID) {
-            var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
+            // This will allow to go back to main app menu or close the tablet.
+            isTabletScreenChanged = true;
+        } else if (!HMD.active && (!overlayPickResults.intersects || overlayPickResults.overlayID !== this.webOverlayID)) {
+            this.dragging = true;
+            var invCameraXform = new Xform(Camera.orientation, Camera.position).inv();
+            this.initialLocalIntersectionPoint = invCameraXform.xformPoint(entityPickResults.intersection);
+            this.initialLocalPosition = Overlays.getProperty(this.tabletEntityID, "localPosition");
+        } else if (HMD.active && !overlayPickResults.intersects) {
+            //During help screen shown and when press "X" button then it go back to main menu screen or close the tablet.
+            isTabletScreenChanged = true;
+        }
+        var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
+        if (isTabletScreenChanged) {
             var onHomeScreen = tablet.onHomeScreen();
             var isMessageOpen = tablet.isMessageDialogOpen();
             if (onHomeScreen) {
@@ -526,11 +539,6 @@ WebTablet.prototype.mousePressEvent = function (event) {
                     this.setHomeButtonTexture();
                 }
             }
-        } else if (!HMD.active && (!overlayPickResults.intersects || overlayPickResults.overlayID !== this.webOverlayID)) {
-            this.dragging = true;
-            var invCameraXform = new Xform(Camera.orientation, Camera.position).inv();
-            this.initialLocalIntersectionPoint = invCameraXform.xformPoint(entityPickResults.intersection);
-            this.initialLocalPosition = Overlays.getProperty(this.tabletEntityID, "localPosition");
         }
     }
 };


### PR DESCRIPTION
Fix for case 4980: Tablet "X" Button does not go back, just closes the tablet
https://highfidelity.fogbugz.com/f/cases/4980

**Bug details**
First start the Interface and End up in welcome (or dev-welcome), open the tablet, and the help screen is already up, and when you press the "X" button on tablet, it prevent the tablet to going back to the main app menu or closes the tablet.

**How To Test**
1. Clean the install of Interface (i.e.) NO config in appData tree.
2. Do NOT start sandbox.
3. Start Interface.
4. End up in welcome (or dev-welcome).
5. Bring up tablet immediately[using mouse right click].
6. it's displaying "help" content on tablet.
7. press the "X" button on tablet.

**Expected Result**
When you press "X" button on tablet, the tablet screen will go back to the main menu screen.