### PR TITLE
Still trying to address QML crashes

### DIFF
--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -264,9 +264,6 @@ QNetworkAccessManager* QmlNetworkAccessManagerFactory::create(QObject* parent) {
     return new QmlNetworkAccessManager(parent);
 }
 
-static QQmlEngine* globalEngine { nullptr };
-static size_t globalEngineRefCount { 0 };
-
 QString getEventBridgeJavascript() {
     // FIXME: Refactor with similar code in RenderableWebEntityItem
     QString javaScriptToInject;
@@ -300,9 +297,44 @@ private:
 };
 
 
+#define SINGLE_QML_ENGINE 0
+
+#if SINGLE_QML_ENGINE
+static QQmlEngine* globalEngine{ nullptr };
+static size_t globalEngineRefCount{ 0 };
+#endif
+
+void initializeQmlEngine(QQmlEngine* engine, QQuickWindow* window) {
+    engine->setNetworkAccessManagerFactory(new QmlNetworkAccessManagerFactory);
+    auto importList = engine->importPathList();
+    importList.insert(importList.begin(), PathUtils::resourcesPath());
+    engine->setImportPathList(importList);
+    for (const auto& path : importList) {
+        qDebug() << path;
+    }
+
+    if (!engine->incubationController()) {
+        engine->setIncubationController(window->incubationController());
+    }
+    auto rootContext = engine->rootContext();
+    rootContext->setContextProperty("GL", ::getGLContextData());
+    rootContext->setContextProperty("urlHandler", new UrlHandler());
+    rootContext->setContextProperty("resourceDirectoryUrl", QUrl::fromLocalFile(PathUtils::resourcesPath()));
+    rootContext->setContextProperty("pathToFonts", "../../");
+    rootContext->setContextProperty("ApplicationInterface", qApp);
+    auto javaScriptToInject = getEventBridgeJavascript();
+    if (!javaScriptToInject.isEmpty()) {
+        rootContext->setContextProperty("eventBridgeJavaScriptToInject", QVariant(javaScriptToInject));
+    }
+    rootContext->setContextProperty("FileTypeProfile", new FileTypeProfile(rootContext));
+    rootContext->setContextProperty("HFWebEngineProfile", new HFWebEngineProfile(rootContext));
+    rootContext->setContextProperty("HFTabletWebEngineProfile", new HFTabletWebEngineProfile(rootContext));
+}
 
 QQmlEngine* acquireEngine(QQuickWindow* window) {
     Q_ASSERT(QThread::currentThread() == qApp->thread());
+
+    QQmlEngine* result = nullptr;
     if (QThread::currentThread() != qApp->thread()) {
         qCWarning(uiLogging) << "Cannot acquire QML engine on any thread but the main thread";
     }
@@ -311,47 +343,34 @@ QQmlEngine* acquireEngine(QQuickWindow* window) {
         qmlRegisterType<SoundEffect>("Hifi", 1, 0, "SoundEffect");
     });
 
+
+#if SINGLE_QML_ENGINE
     if (!globalEngine) {
         Q_ASSERT(0 == globalEngineRefCount);
         globalEngine = new QQmlEngine();
-        globalEngine->setNetworkAccessManagerFactory(new QmlNetworkAccessManagerFactory);
-
-        auto importList = globalEngine->importPathList();
-        importList.insert(importList.begin(), PathUtils::resourcesPath());
-        globalEngine->setImportPathList(importList);
-        for (const auto& path : importList) {
-            qDebug() << path;
-        }
-
-        if (!globalEngine->incubationController()) {
-            globalEngine->setIncubationController(window->incubationController());
-        }
-        auto rootContext = globalEngine->rootContext();
-        rootContext->setContextProperty("GL", ::getGLContextData());
-        rootContext->setContextProperty("urlHandler", new UrlHandler());
-        rootContext->setContextProperty("resourceDirectoryUrl", QUrl::fromLocalFile(PathUtils::resourcesPath()));
-        rootContext->setContextProperty("pathToFonts", "../../");
-        rootContext->setContextProperty("ApplicationInterface", qApp);
-        auto javaScriptToInject = getEventBridgeJavascript();
-        if (!javaScriptToInject.isEmpty()) {
-            rootContext->setContextProperty("eventBridgeJavaScriptToInject", QVariant(javaScriptToInject));
-        }
-        rootContext->setContextProperty("FileTypeProfile", new FileTypeProfile(rootContext));
-        rootContext->setContextProperty("HFWebEngineProfile", new HFWebEngineProfile(rootContext));
-        rootContext->setContextProperty("HFTabletWebEngineProfile", new HFTabletWebEngineProfile(rootContext));
+        initializeQmlEngine(result, window);
+        ++globalEngineRefCount;
     }
+    result = globalEngine;
+#else
+    result = new QQmlEngine();
+    initializeQmlEngine(result, window);
+#endif
 
-    ++globalEngineRefCount;
-    return globalEngine;
+    return result;
 }
 
-void releaseEngine() {
+void releaseEngine(QQmlEngine* engine) {
     Q_ASSERT(QThread::currentThread() == qApp->thread());
+#if SINGLE_QML_ENGINE
     Q_ASSERT(0 != globalEngineRefCount);
     if (0 == --globalEngineRefCount) {
         globalEngine->deleteLater();
         globalEngine = nullptr;
     }
+#else
+    engine->deleteLater();
+#endif
 }
 
 void OffscreenQmlSurface::cleanup() {
@@ -456,11 +475,11 @@ OffscreenQmlSurface::~OffscreenQmlSurface() {
     QObject::disconnect(qApp);
 
     cleanup();
-
+    auto engine = _qmlContext->engine();
     _canvas->deleteLater();
     _rootItem->deleteLater();
     _quickWindow->deleteLater();
-    releaseEngine();
+    releaseEngine(engine);
 }
 
 void OffscreenQmlSurface::onAboutToQuit() {


### PR DESCRIPTION
Trying to address QML crashes by reverting to one QML engine per surface (a total shot in the dark).  The change is actually smaller than it looks because I've moved the QML engine initialization code to a separate function so that the logic in the `acquireEngine` function is easier to follow in both cases (multi-engine and single-engine).



## Testing

On-screen UI should still work.  Tablet interfaces should still work.  Web entities and overlays should still work.  Please test moving from domains with web entities to domains without them and vice versa.  Please test proper shutdown.  