### PR TITLE
Added option in the installer for a clean install

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -49,7 +49,7 @@
     Var STR_CONTAINS_VAR_3
     Var STR_CONTAINS_VAR_4
     Var STR_RETURN_VAR
-
+ 
     Function StrContains
       Exch $STR_NEEDLE
       Exch 1
@@ -267,6 +267,7 @@ Var substringResult
 
   "${SecName}_unchanged:"
 !macroend
+
 ;--- End of Add/Remove macros ---
 
 ;--------------------------------
@@ -438,6 +439,7 @@ Var DesktopServerCheckbox
 Var ServerStartupCheckbox
 Var LaunchServerNowCheckbox
 Var LaunchClientNowCheckbox
+Var CleanInstallCheckbox
 Var CurrentOffset
 Var OffsetUnits
 Var CopyFromProductionCheckbox
@@ -479,23 +481,14 @@ Function PostInstallOptionsPage
     ; set the checkbox state depending on what is present in the registry
     !insertmacro SetPostInstallOption $DesktopClientCheckbox @CLIENT_DESKTOP_SHORTCUT_REG_KEY@ ${BST_CHECKED}
   ${EndIf}
-
+  
   ${If} ${SectionIsSelected} ${@SERVER_COMPONENT_NAME@}
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Create a desktop shortcut for @CONSOLE_HF_SHORTCUT_NAME@"
     Pop $DesktopServerCheckbox
+    IntOp $CurrentOffset $CurrentOffset + 15
 
     ; set the checkbox state depending on what is present in the registry
     !insertmacro SetPostInstallOption $DesktopServerCheckbox @CONSOLE_DESKTOP_SHORTCUT_REG_KEY@ ${BST_UNCHECKED}
-
-    IntOp $CurrentOffset $CurrentOffset + 15
-
-    ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Launch @CONSOLE_HF_SHORTCUT_NAME@ on startup"
-    Pop $ServerStartupCheckbox
-
-    ; set the checkbox state depending on what is present in the registry
-    !insertmacro SetPostInstallOption $ServerStartupCheckbox @CONSOLE_STARTUP_REG_KEY@ ${BST_CHECKED}
-
-    IntOp $CurrentOffset $CurrentOffset + 15
   ${EndIf}
 
   ${If} ${SectionIsSelected} ${@SERVER_COMPONENT_NAME@}
@@ -513,15 +506,34 @@ Function PostInstallOptionsPage
   ${EndIf}
 
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
-	  ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Launch @INTERFACE_HF_SHORTCUT_NAME@ after install"
-	  Pop $LaunchClientNowCheckbox
-
-	  ; set the checkbox state depending on what is present in the registry
-	  !insertmacro SetPostInstallOption $LaunchClientNowCheckbox @CLIENT_LAUNCH_NOW_REG_KEY@ ${BST_CHECKED}
-      ${StrContains} $substringResult "/forceNoLaunchClient" $CMDLINE
-      ${IfNot} $substringResult == ""
-          ${NSD_SetState} $LaunchClientNowCheckbox ${BST_UNCHECKED}
-      ${EndIf}
+    ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Launch @INTERFACE_HF_SHORTCUT_NAME@ after install"
+    Pop $LaunchClientNowCheckbox
+    IntOp $CurrentOffset $CurrentOffset + 30
+    
+    ; set the checkbox state depending on what is present in the registry
+    !insertmacro SetPostInstallOption $LaunchClientNowCheckbox @CLIENT_LAUNCH_NOW_REG_KEY@ ${BST_CHECKED}
+    ${StrContains} $substringResult "/forceNoLaunchClient" $CMDLINE
+    ${IfNot} $substringResult == ""
+    ${NSD_SetState} $LaunchClientNowCheckbox ${BST_UNCHECKED}
+    ${EndIf}
+  ${EndIf}
+  
+  ${If} ${SectionIsSelected} ${@SERVER_COMPONENT_NAME@}
+    ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Launch @CONSOLE_HF_SHORTCUT_NAME@ on startup"
+    Pop $ServerStartupCheckbox
+    IntOp $CurrentOffset $CurrentOffset + 15
+    
+    ; set the checkbox state depending on what is present in the registry
+    !insertmacro SetPostInstallOption $ServerStartupCheckbox @CONSOLE_STARTUP_REG_KEY@ ${BST_CHECKED}
+  ${EndIf}
+  
+  ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
+    ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Perform a clean install (Delete older settings and content)"
+    Pop $CleanInstallCheckbox
+    IntOp $CurrentOffset $CurrentOffset + 15
+    
+    ; not saving checkbox state in registry
+    !insertmacro SetPostInstallOption $CleanInstallCheckbox @@ ${BST_UNCHECKED}
   ${EndIf}
 
   ${If} @PR_BUILD@ == 1
@@ -543,7 +555,7 @@ Function PostInstallOptionsPage
 
     ${NSD_SetState} $CopyFromProductionCheckbox ${BST_CHECKED}
   ${EndIf}
-
+  
   nsDialogs::Show
 FunctionEnd
 
@@ -558,6 +570,7 @@ Var ServerStartupState
 Var LaunchServerNowState
 Var LaunchClientNowState
 Var CopyFromProductionState
+Var CleanInstallState
 
 Function ReadPostInstallOptions
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
@@ -579,13 +592,18 @@ Function ReadPostInstallOptions
   ${EndIf}
 
   ${If} ${SectionIsSelected} ${@SERVER_COMPONENT_NAME@}
-	  ; check if we need to launch the server post-install
-	  ${NSD_GetState} $LaunchServerNowCheckbox $LaunchServerNowState
+    ; check if we need to launch the server post-install
+    ${NSD_GetState} $LaunchServerNowCheckbox $LaunchServerNowState
   ${EndIf}
 
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
-	  ; check if we need to launch the client post-install
-	  ${NSD_GetState} $LaunchClientNowCheckbox $LaunchClientNowState
+    ; check if we need to launch the client post-install
+    ${NSD_GetState} $LaunchClientNowCheckbox $LaunchClientNowState
+  ${EndIf}
+   
+  ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
+    ; check if the user asked for a clean install
+    ${NSD_GetState} $CleanInstallCheckbox $CleanInstallState
   ${EndIf}
 FunctionEnd
 
@@ -626,6 +644,15 @@ Function HandlePostInstallOptions
       !insertmacro WritePostInstallOption @CONSOLE_STARTUP_REG_KEY@ YES
     ${Else}
       !insertmacro WritePostInstallOption @CONSOLE_STARTUP_REG_KEY@ NO
+    ${EndIf}
+  ${EndIf}
+  
+  ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
+    ; check if the user asked for a clean install
+    ${If} $CleanInstallState == ${BST_CHECKED}
+      SetShellVarContext current
+      RMDir /r "$APPDATA\@BUILD_ORGANIZATION@"
+      RMDir /r "$LOCALAPPDATA\@BUILD_ORGANIZATION@"
     ${EndIf}
   ${EndIf}
 
@@ -683,6 +710,7 @@ Function HandlePostInstallOptions
     ${EndIf}
 
   ${EndIf}
+  
 FunctionEnd
 
 ;--------------------------------

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -49,7 +49,7 @@
     Var STR_CONTAINS_VAR_3
     Var STR_CONTAINS_VAR_4
     Var STR_RETURN_VAR
- 
+    
     Function StrContains
       Exch $STR_NEEDLE
       Exch 1
@@ -267,7 +267,6 @@ Var substringResult
 
   "${SecName}_unchanged:"
 !macroend
-
 ;--- End of Add/Remove macros ---
 
 ;--------------------------------
@@ -477,7 +476,7 @@ Function PostInstallOptionsPage
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Create a desktop shortcut for @INTERFACE_HF_SHORTCUT_NAME@"
     Pop $DesktopClientCheckbox
     IntOp $CurrentOffset $CurrentOffset + 15
-
+    
     ; set the checkbox state depending on what is present in the registry
     !insertmacro SetPostInstallOption $DesktopClientCheckbox @CLIENT_DESKTOP_SHORTCUT_REG_KEY@ ${BST_CHECKED}
   ${EndIf}
@@ -486,7 +485,7 @@ Function PostInstallOptionsPage
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Create a desktop shortcut for @CONSOLE_HF_SHORTCUT_NAME@"
     Pop $DesktopServerCheckbox
     IntOp $CurrentOffset $CurrentOffset + 15
-
+    
     ; set the checkbox state depending on what is present in the registry
     !insertmacro SetPostInstallOption $DesktopServerCheckbox @CONSOLE_DESKTOP_SHORTCUT_REG_KEY@ ${BST_UNCHECKED}
   ${EndIf}
@@ -504,7 +503,7 @@ Function PostInstallOptionsPage
 
     IntOp $CurrentOffset $CurrentOffset + 15
   ${EndIf}
-
+  
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Launch @INTERFACE_HF_SHORTCUT_NAME@ after install"
     Pop $LaunchClientNowCheckbox
@@ -595,7 +594,7 @@ Function ReadPostInstallOptions
     ; check if we need to launch the server post-install
     ${NSD_GetState} $LaunchServerNowCheckbox $LaunchServerNowState
   ${EndIf}
-
+  
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
     ; check if we need to launch the client post-install
     ${NSD_GetState} $LaunchClientNowCheckbox $LaunchClientNowState
@@ -710,7 +709,6 @@ Function HandlePostInstallOptions
     ${EndIf}
 
   ${EndIf}
-  
 FunctionEnd
 
 ;--------------------------------

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -530,9 +530,6 @@ Function PostInstallOptionsPage
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Perform a clean install (Delete older settings and content)"
     Pop $CleanInstallCheckbox
     IntOp $CurrentOffset $CurrentOffset + 15
-    
-    ; not saving checkbox state in registry
-    !insertmacro SetPostInstallOption $CleanInstallCheckbox @@ ${BST_UNCHECKED}
   ${EndIf}
 
   ${If} @PR_BUILD@ == 1


### PR DESCRIPTION
Added a checkbox in the installer. If the checkbox is selected, previous settings and content are deleted on installation.

Testing Notes:
Build the PR
Generate the installer following these documents: https://github.com/highfidelity/hifi/blob/master/INSTALL.md 
https://github.com/highfidelity/hifi/pull/6870
Run the installer. 
Check if a new checkbox is present now. It has the text : Perform a clean install (Delete older settings and content)
Select this checkbox and complete the installation.
Check AppData->Roaming and AppData-> Local folders. 
AppData-> Roaming, must have a recently generated High Fidelity folder (related to this build), with all previous content deleted. 
AppData-> Local will have NO High Fidelity folder (related to this build). 
Run the interface and a new High Fidelity folder will be created in AppData->Local.
After the installation, run the installer again. The "clean install" checkbox should be unchecked now- The installer doesn't save user input on the checkbox for subsequent runs of the installer. 

Alternate: 
First install without selecting "clean install", then install again with "clean install" selected. Check AppData both times. Must observe old data being deleted when installed with "clean install"  
