### PR TITLE
AC shutdown info + PPID watcher on Unix

### DIFF
--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -44,7 +44,7 @@ public:
     void stopChildProcesses();
 private slots:
     void checkSpares();
-    void childProcessFinished(qint64 pid);
+    void childProcessFinished(qint64 pid, int exitCode, QProcess::ExitStatus exitStatus);
     void handleChildStatusPacket(QSharedPointer<ReceivedMessage> message);
 
     bool handleHTTPRequest(HTTPConnection* connection, const QUrl& url, bool skipSubHandler = false) override;


### PR DESCRIPTION
- AC monitor now prints the error code the child AC returned when it finished.
- Implemented automatic shutdown of child processes when the parent dies for Mac/Linux