### PR TITLE
New HoverOverlayInterface skeleton

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -69,6 +69,7 @@
 #include <EntityScriptClient.h>
 #include <EntityScriptServerLogClient.h>
 #include <EntityScriptingInterface.h>
+#include <HoverOverlayInterface.h>
 #include <ErrorDialog.h>
 #include <FileScriptingInterface.h>
 #include <Finally.h>
@@ -588,6 +589,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::set<Snapshot>();
     DependencyManager::set<CloseEventSender>();
     DependencyManager::set<ResourceManager>();
+    DependencyManager::set<HoverOverlayInterface>();
 
     return previousSessionCrashed;
 }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -469,7 +469,7 @@ void EntityTreeRenderer::connectSignalsToSlots(EntityScriptingInterface* entityS
     connect(this, &EntityTreeRenderer::hoverOverEntity, entityScriptingInterface, &EntityScriptingInterface::hoverOverEntity);
 
     connect(this, &EntityTreeRenderer::hoverLeaveEntity, entityScriptingInterface, &EntityScriptingInterface::hoverLeaveEntity);
-    connect(this, &EntityTreeRenderer::hoverEnterEntity, hoverOverlayInterface, &HoverOverlayInterface::destroyHoverOverlay);
+    connect(this, &EntityTreeRenderer::hoverLeaveEntity, hoverOverlayInterface, &HoverOverlayInterface::destroyHoverOverlay);
 
     connect(this, &EntityTreeRenderer::enterEntity, entityScriptingInterface, &EntityScriptingInterface::enterEntity);
     connect(this, &EntityTreeRenderer::leaveEntity, entityScriptingInterface, &EntityScriptingInterface::leaveEntity);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -26,6 +26,7 @@
 #include <PerfStat.h>
 #include <SceneScriptingInterface.h>
 #include <ScriptEngine.h>
+#include <HoverOverlayInterface.h>
 
 
 #include "RenderableEntityItem.h"
@@ -452,6 +453,8 @@ RayToEntityIntersectionResult EntityTreeRenderer::findRayIntersectionWorker(cons
 
 void EntityTreeRenderer::connectSignalsToSlots(EntityScriptingInterface* entityScriptingInterface) {
 
+    auto hoverOverlayInterface = DependencyManager::get<HoverOverlayInterface>().data();
+
     connect(this, &EntityTreeRenderer::mousePressOnEntity, entityScriptingInterface, &EntityScriptingInterface::mousePressOnEntity);
     connect(this, &EntityTreeRenderer::mouseMoveOnEntity, entityScriptingInterface, &EntityScriptingInterface::mouseMoveOnEntity);
     connect(this, &EntityTreeRenderer::mouseReleaseOnEntity, entityScriptingInterface, &EntityScriptingInterface::mouseReleaseOnEntity);
@@ -461,8 +464,12 @@ void EntityTreeRenderer::connectSignalsToSlots(EntityScriptingInterface* entityS
     connect(this, &EntityTreeRenderer::clickReleaseOnEntity, entityScriptingInterface, &EntityScriptingInterface::clickReleaseOnEntity);
 
     connect(this, &EntityTreeRenderer::hoverEnterEntity, entityScriptingInterface, &EntityScriptingInterface::hoverEnterEntity);
+    connect(this, &EntityTreeRenderer::hoverEnterEntity, hoverOverlayInterface, &HoverOverlayInterface::createHoverOverlay);
+
     connect(this, &EntityTreeRenderer::hoverOverEntity, entityScriptingInterface, &EntityScriptingInterface::hoverOverEntity);
+
     connect(this, &EntityTreeRenderer::hoverLeaveEntity, entityScriptingInterface, &EntityScriptingInterface::hoverLeaveEntity);
+    connect(this, &EntityTreeRenderer::hoverEnterEntity, hoverOverlayInterface, &HoverOverlayInterface::destroyHoverOverlay);
 
     connect(this, &EntityTreeRenderer::enterEntity, entityScriptingInterface, &EntityScriptingInterface::enterEntity);
     connect(this, &EntityTreeRenderer::leaveEntity, entityScriptingInterface, &EntityScriptingInterface::leaveEntity);

--- a/libraries/entities/src/HoverOverlayInterface.cpp
+++ b/libraries/entities/src/HoverOverlayInterface.cpp
@@ -12,6 +12,10 @@
 #include "HoverOverlayInterface.h"
 
 HoverOverlayInterface::HoverOverlayInterface() {
+    // "hover_overlay" debug log category disabled by default.
+    // Create your own "qtlogging.ini" file and set your "QT_LOGGING_CONF" environment variable
+    // if you'd like to enable/disable certain categories.
+    // More details: http://doc.qt.io/qt-5/qloggingcategory.html#configuring-categories
     QLoggingCategory::setFilterRules(QStringLiteral("hifi.hover_overlay.debug=false"));
 }
 

--- a/libraries/entities/src/HoverOverlayInterface.cpp
+++ b/libraries/entities/src/HoverOverlayInterface.cpp
@@ -12,19 +12,15 @@
 #include "HoverOverlayInterface.h"
 
 HoverOverlayInterface::HoverOverlayInterface() {
-
+    QLoggingCategory::setFilterRules(QStringLiteral("hifi.hover_overlay.debug=false"));
 }
 
 void HoverOverlayInterface::createHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
-    if (_verboseLogging) {
-        qDebug() << "Creating Hover Overlay on top of entity with ID: " << entityItemID;
-    }
+    qCDebug(hover_overlay) << "Creating Hover Overlay on top of entity with ID: " << entityItemID;
     setCurrentHoveredEntity(entityItemID);
 }
 
 void HoverOverlayInterface::destroyHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
-    if (_verboseLogging) {
-        qDebug() << "Destroying Hover Overlay on top of entity with ID: " << entityItemID;
-    }
+    qCDebug(hover_overlay) << "Destroying Hover Overlay on top of entity with ID: " << entityItemID;
     setCurrentHoveredEntity(QUuid());
 }

--- a/libraries/entities/src/HoverOverlayInterface.cpp
+++ b/libraries/entities/src/HoverOverlayInterface.cpp
@@ -16,11 +16,15 @@ HoverOverlayInterface::HoverOverlayInterface() {
 }
 
 void HoverOverlayInterface::createHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
-    qDebug() << "ZACH FOX HOVER ENTER" << entityItemID;
+    if (_verboseLogging) {
+        qDebug() << "Creating Hover Overlay on top of entity with ID: " << entityItemID;
+    }
     setCurrentHoveredEntity(entityItemID);
 }
 
 void HoverOverlayInterface::destroyHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
-    qDebug() << "ZACH FOX HOVER LEAVE" << entityItemID;
+    if (_verboseLogging) {
+        qDebug() << "Destroying Hover Overlay on top of entity with ID: " << entityItemID;
+    }
     setCurrentHoveredEntity(QUuid());
 }

--- a/libraries/entities/src/HoverOverlayInterface.cpp
+++ b/libraries/entities/src/HoverOverlayInterface.cpp
@@ -1,0 +1,26 @@
+//
+//  HoverOverlayInterface.cpp
+//  libraries/entities/src
+//
+//  Created by Zach Fox on 2017-07-14.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "HoverOverlayInterface.h"
+
+HoverOverlayInterface::HoverOverlayInterface() {
+
+}
+
+void HoverOverlayInterface::createHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
+    qDebug() << "ZACH FOX HOVER ENTER" << entityItemID;
+    setCurrentHoveredEntity(entityItemID);
+}
+
+void HoverOverlayInterface::destroyHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
+    qDebug() << "ZACH FOX HOVER LEAVE" << entityItemID;
+    setCurrentHoveredEntity(QUuid());
+}

--- a/libraries/entities/src/HoverOverlayInterface.h
+++ b/libraries/entities/src/HoverOverlayInterface.h
@@ -37,6 +37,7 @@ public slots:
     void destroyHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
 
 private:
+    bool _verboseLogging { true };
     QUuid _currentHoveredEntity{};
 };
 

--- a/libraries/entities/src/HoverOverlayInterface.h
+++ b/libraries/entities/src/HoverOverlayInterface.h
@@ -20,7 +20,7 @@
 #include <PointerEvent.h>
 
 #include "EntityTree.h"
-
+#include "HoverOverlayLogging.h"
 
 class HoverOverlayInterface : public QObject, public Dependency  {
     Q_OBJECT

--- a/libraries/entities/src/HoverOverlayInterface.h
+++ b/libraries/entities/src/HoverOverlayInterface.h
@@ -1,0 +1,43 @@
+//
+//  HoverOverlayInterface.h
+//  libraries/entities/src
+//
+//  Created by Zach Fox on 2017-07-14.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_HoverOverlayInterface_h
+#define hifi_HoverOverlayInterface_h
+
+#include <QtCore/QObject>
+#include <QUuid>
+
+#include <DependencyManager.h>
+#include <RegisteredMetaTypes.h>
+#include <PointerEvent.h>
+
+#include "EntityTree.h"
+
+
+class HoverOverlayInterface : public QObject, public Dependency  {
+    Q_OBJECT
+
+    Q_PROPERTY(QUuid currentHoveredEntity READ getCurrentHoveredEntity WRITE setCurrentHoveredEntity)
+public:
+    HoverOverlayInterface();
+
+    Q_INVOKABLE QUuid getCurrentHoveredEntity() { return _currentHoveredEntity; }
+    void setCurrentHoveredEntity(const QUuid entityID) { _currentHoveredEntity = entityID; }
+
+public slots:
+    void createHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
+    void destroyHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
+
+private:
+    QUuid _currentHoveredEntity{};
+};
+
+#endif // hifi_HoverOverlayInterface_h

--- a/libraries/entities/src/HoverOverlayInterface.h
+++ b/libraries/entities/src/HoverOverlayInterface.h
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#pragma once
 #ifndef hifi_HoverOverlayInterface_h
 #define hifi_HoverOverlayInterface_h
 
@@ -29,7 +30,7 @@ public:
     HoverOverlayInterface();
 
     Q_INVOKABLE QUuid getCurrentHoveredEntity() { return _currentHoveredEntity; }
-    void setCurrentHoveredEntity(const QUuid entityID) { _currentHoveredEntity = entityID; }
+    void setCurrentHoveredEntity(const QUuid& entityID) { _currentHoveredEntity = entityID; }
 
 public slots:
     void createHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event);

--- a/libraries/entities/src/HoverOverlayInterface.h
+++ b/libraries/entities/src/HoverOverlayInterface.h
@@ -16,7 +16,6 @@
 #include <QUuid>
 
 #include <DependencyManager.h>
-#include <RegisteredMetaTypes.h>
 #include <PointerEvent.h>
 
 #include "EntityTree.h"

--- a/libraries/entities/src/HoverOverlayLogging.cpp
+++ b/libraries/entities/src/HoverOverlayLogging.cpp
@@ -1,0 +1,14 @@
+//
+//  HoverOverlayLogging.cpp
+//  libraries/entities/src
+//
+//  Created by Zach Fox on 2017-07-17
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "HoverOverlayLogging.h"
+
+Q_LOGGING_CATEGORY(hover_overlay, "hifi.hover_overlay")

--- a/libraries/entities/src/HoverOverlayLogging.h
+++ b/libraries/entities/src/HoverOverlayLogging.h
@@ -1,0 +1,19 @@
+//
+//  HoverOverlayLogging.h
+//  libraries/entities/src
+//
+//  Created by Zach Fox on 2017-07-17
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_HoverOverlayLogging_h
+#define hifi_HoverOverlayLogging_h
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(hover_overlay)
+
+#endif // hifi_HoverOverlayLogging_h

--- a/libraries/entities/src/HoverOverlayLogging.h
+++ b/libraries/entities/src/HoverOverlayLogging.h
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#pragma once
 #ifndef hifi_HoverOverlayLogging_h
 #define hifi_HoverOverlayLogging_h
 


### PR DESCRIPTION
This PR adds a new generic `HoverOverlayInterface` to the codebase. It's the framework upon which we'll build the [Entity Marketplace Inspection](https://highfidelity.atlassian.net/wiki/spaces/HOME/pages/59446842/Entity+Marketplace+Inspection) feature (and additions to the hover overlay in the future).

**Test Plan**
This PR shouldn't change anything noticeable in Interface at all. To fully test this PR, you're required to make a `qtlogging.ini` file containing rules to enable the verbose logging implemented in this PR. To do that:
1. Make a new text file in some directory called `qtlogging.ini`.
2. Paste the following into the text file:
```
[Rules]
hifi.hover_overlay.debug=true
```
3. In an elevated command prompt, paste this command and press enter: 
`SETX QT_LOGGING_CONF "<path_to_qtlogging.ini>"`
That will set your environment variables such that Interface will know to enable verbose logging for the "hover_overlay" debug log category.
4. Reboot your PC (I haven't found a faster way to force the environment variable change to take)

After you've set up your logging filter, test this PR by doing the following:
1. Open Interface
2. Navigate to a domain containing at least two entities
3. Open your logs (Ctrl+Shift+L)
4. Using your mouse, move your cursor over some entities in the domain.
5. Verify that you see logs like `Creating Hover Overlay on top of entity with ID: <Entity ID>` and `Destroying Hover Overlay on top of entity with ID: <Entity ID>`