### PR TITLE
Create/Destroy Hover Overlays using hand controller lasers

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2116,6 +2116,7 @@ void Application::initializeUi() {
     surfaceContext->setContextProperty("ApplicationCompositor", &getApplicationCompositor());
 
     surfaceContext->setContextProperty("AvatarInputs", AvatarInputs::getInstance());
+    surfaceContext->setContextProperty("HoverOverlay", DependencyManager::get<HoverOverlayInterface>().data());
 
     if (auto steamClient = PluginManager::getInstance()->getSteamClientPlugin()) {
         surfaceContext->setContextProperty("Steam", new SteamScriptingInterface(engine, steamClient.get()));
@@ -5818,6 +5819,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEngine* scri
     auto entityScriptServerLog = DependencyManager::get<EntityScriptServerLogClient>();
     scriptEngine->registerGlobalObject("EntityScriptServerLog", entityScriptServerLog.data());
     scriptEngine->registerGlobalObject("AvatarInputs", AvatarInputs::getInstance());
+    scriptEngine->registerGlobalObject("HoverOverlay", DependencyManager::get<HoverOverlayInterface>().data());
 
     qScriptRegisterMetaType(scriptEngine, OverlayIDtoScriptValue, OverlayIDfromScriptValue);
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -464,12 +464,12 @@ void EntityTreeRenderer::connectSignalsToSlots(EntityScriptingInterface* entityS
     connect(this, &EntityTreeRenderer::clickReleaseOnEntity, entityScriptingInterface, &EntityScriptingInterface::clickReleaseOnEntity);
 
     connect(this, &EntityTreeRenderer::hoverEnterEntity, entityScriptingInterface, &EntityScriptingInterface::hoverEnterEntity);
-    connect(this, &EntityTreeRenderer::hoverEnterEntity, hoverOverlayInterface, &HoverOverlayInterface::createHoverOverlay);
+    connect(this, SIGNAL(hoverEnterEntity(const EntityItemID&, const PointerEvent&)), hoverOverlayInterface, SLOT(createHoverOverlay(const EntityItemID&, const PointerEvent&)));
 
     connect(this, &EntityTreeRenderer::hoverOverEntity, entityScriptingInterface, &EntityScriptingInterface::hoverOverEntity);
 
     connect(this, &EntityTreeRenderer::hoverLeaveEntity, entityScriptingInterface, &EntityScriptingInterface::hoverLeaveEntity);
-    connect(this, &EntityTreeRenderer::hoverLeaveEntity, hoverOverlayInterface, &HoverOverlayInterface::destroyHoverOverlay);
+    connect(this, SIGNAL(hoverLeaveEntity(const EntityItemID&, const PointerEvent&)), hoverOverlayInterface, SLOT(destroyHoverOverlay(const EntityItemID&, const PointerEvent&)));
 
     connect(this, &EntityTreeRenderer::enterEntity, entityScriptingInterface, &EntityScriptingInterface::enterEntity);
     connect(this, &EntityTreeRenderer::leaveEntity, entityScriptingInterface, &EntityScriptingInterface::leaveEntity);

--- a/libraries/entities/src/HoverOverlayInterface.cpp
+++ b/libraries/entities/src/HoverOverlayInterface.cpp
@@ -24,7 +24,15 @@ void HoverOverlayInterface::createHoverOverlay(const EntityItemID& entityItemID,
     setCurrentHoveredEntity(entityItemID);
 }
 
+void HoverOverlayInterface::createHoverOverlay(const EntityItemID& entityItemID) {
+    HoverOverlayInterface::createHoverOverlay(entityItemID, PointerEvent());
+}
+
 void HoverOverlayInterface::destroyHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
     qCDebug(hover_overlay) << "Destroying Hover Overlay on top of entity with ID: " << entityItemID;
     setCurrentHoveredEntity(QUuid());
+}
+
+void HoverOverlayInterface::destroyHoverOverlay(const EntityItemID& entityItemID) {
+    HoverOverlayInterface::destroyHoverOverlay(entityItemID, PointerEvent());
 }

--- a/libraries/entities/src/HoverOverlayInterface.h
+++ b/libraries/entities/src/HoverOverlayInterface.h
@@ -22,6 +22,9 @@
 #include "EntityTree.h"
 #include "HoverOverlayLogging.h"
 
+/**jsdoc
+* @namespace HoverOverlay
+*/
 class HoverOverlayInterface : public QObject, public Dependency  {
     Q_OBJECT
 
@@ -34,7 +37,9 @@ public:
 
 public slots:
     void createHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
+    void createHoverOverlay(const EntityItemID& entityItemID);
     void destroyHoverOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
+    void destroyHoverOverlay(const EntityItemID& entityItemID);
 
 private:
     bool _verboseLogging { true };

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -3774,6 +3774,11 @@ function MyController(hand) {
     this.release = function() {
         this.turnOffVisualizations();
 
+        entitiesWithHoverOverlays.forEach(function (element) {
+            HoverOverlay.destroyHoverOverlay(element);
+        });
+        entitiesWithHoverOverlays = [];
+
         if (this.grabbedThingID !== null) {
 
             Messages.sendMessage('Hifi-Teleport-Ignore-Remove', this.grabbedThingID);

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -187,6 +187,8 @@ var DEFAULT_GRABBABLE_DATA = {
 var USE_BLACKLIST = true;
 var blacklist = [];
 
+var entitiesWithHoverOverlays = [];
+
 var FORBIDDEN_GRAB_NAMES = ["Grab Debug Entity", "grab pointer"];
 var FORBIDDEN_GRAB_TYPES = ["Unknown", "Light", "PolyLine", "Zone"];
 
@@ -2199,6 +2201,15 @@ function MyController(hand) {
 
         if (rayPickInfo.entityID) {
             entityPropertiesCache.addEntity(rayPickInfo.entityID);
+        }
+
+        if (rayPickInfo.entityID && entitiesWithHoverOverlays.indexOf(rayPickInfo.entityID) == -1) {
+            entitiesWithHoverOverlays.forEach(function (element) {
+                HoverOverlay.destroyHoverOverlay(element);
+            });
+            entitiesWithHoverOverlays = [];
+            HoverOverlay.createHoverOverlay(rayPickInfo.entityID);
+            entitiesWithHoverOverlays.push(rayPickInfo.entityID);
         }
 
         var candidateHotSpotEntities = Entities.findEntities(handPosition, MAX_EQUIP_HOTSPOT_RADIUS);


### PR DESCRIPTION
This PR uses the JS-accessible `HoverOverlayInterface` such that hand controller lasers now create and destroy hover overlays.

Similar Test Plan as #10978.

**Test Plan**
This PR shouldn't change anything noticeable in Interface at all. To fully test this PR, you're required to make a `qtlogging.ini` file containing rules to enable the verbose logging implemented in this PR. To do that:
1. Make a new text file in some directory called `qtlogging.ini`.
2. Paste the following into the text file:
```
[Rules]
hifi.hover_overlay.debug=true
```
3. In an elevated command prompt, paste this command and press enter: 
`SETX QT_LOGGING_CONF "<path_to_qtlogging.ini>"`
That will set your environment variables such that Interface will know to enable verbose logging for the "hover_overlay" debug log category.
4. Reboot your PC (I haven't found a faster way to force the environment variable change to take)

After you've set up your logging filter, test this PR by doing the following:
1. Open Interface
2. Navigate to a domain containing at least two entities
3. Open your logs (Ctrl+Shift+L)
4. Using your mouse, move your cursor over some entities in the domain.
5. Verify that you see logs like `Creating Hover Overlay on top of entity with ID: <Entity ID>` and `Destroying Hover Overlay on top of entity with ID: <Entity ID>`
6. Switch into HMD mode.
7. Using your hand controllers, depress a trigger until you see the blue or red laser. Then, move the laser over some entities in the domain.
8. Verify that you see logs like `Creating Hover Overlay on top of entity with ID: <Entity ID>` and `Destroying Hover Overlay on top of entity with ID: <Entity ID>`