### PR TITLE
Fixed not being able to delete avatar entities when switching domains

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2366,6 +2366,12 @@ AvatarEntityMap AvatarData::getAvatarEntityData() const {
     return result;
 }
 
+void AvatarData::insertDetachedEntityID(const QUuid entityID) {
+    _avatarEntitiesLock.withWriteLock([&] {
+        _avatarEntityDetached.insert(entityID);
+    });
+}
+
 void AvatarData::setAvatarEntityData(const AvatarEntityMap& avatarEntityData) {
     if (avatarEntityData.size() > MAX_NUM_AVATAR_ENTITIES) {
         // the data is suspect

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -615,7 +615,7 @@ public:
     Q_INVOKABLE AvatarEntityMap getAvatarEntityData() const;
     Q_INVOKABLE void setAvatarEntityData(const AvatarEntityMap& avatarEntityData);
     void setAvatarEntityDataChanged(bool value) { _avatarEntityDataChanged = value; }
-    void insertDetachedEntityID(const QUuid entityID) { _avatarEntityDetached.insert(entityID); }
+    void insertDetachedEntityID(const QUuid entityID);
     AvatarEntityIDs getAndClearRecentlyDetachedIDs();
 
     // thread safe

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -615,6 +615,7 @@ public:
     Q_INVOKABLE AvatarEntityMap getAvatarEntityData() const;
     Q_INVOKABLE void setAvatarEntityData(const AvatarEntityMap& avatarEntityData);
     void setAvatarEntityDataChanged(bool value) { _avatarEntityDataChanged = value; }
+    void insertDetachedEntityID(const QUuid entityID) { _avatarEntityDetached.insert(entityID); }
     AvatarEntityIDs getAndClearRecentlyDetachedIDs();
 
     // thread safe

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -502,6 +502,8 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
                 AvatarSharedPointer myAvatar = avatarHashMap->getAvatarBySessionID(myNodeID);
                 if (entity->getClientOnly() && entity->getOwningAvatarID() != myNodeID) {
                     // don't delete other avatar's avatarEntities
+                    // If you actually own the entity but the onwership is not set because of a domain switch
+                    // the line below make sure the entity is deleted.
                     myAvatar->insertDetachedEntityID(id);
                     shouldDelete = false;
                     return;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -498,12 +498,12 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
 
                 auto nodeList = DependencyManager::get<NodeList>();
                 const QUuid myNodeID = nodeList->getSessionUUID();
-                auto avatarHashMap = DependencyManager::get<AvatarHashMap>();
-                AvatarSharedPointer myAvatar = avatarHashMap->getAvatarBySessionID(myNodeID);
                 if (entity->getClientOnly() && entity->getOwningAvatarID() != myNodeID) {
                     // don't delete other avatar's avatarEntities
-                    // If you actually own the entity but the onwership is not set because of a domain switch
-                    // the line below make sure the entity is deleted.
+                    // If you actually own the entity but the onwership property is not set because of a domain switch
+                    // The lines below makes sure the entity is deleted once its properties are set.
+                    auto avatarHashMap = DependencyManager::get<AvatarHashMap>();
+                    AvatarSharedPointer myAvatar = avatarHashMap->getAvatarBySessionID(myNodeID);
                     myAvatar->insertDetachedEntityID(id);
                     shouldDelete = false;
                     return;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -21,6 +21,7 @@
 #include <VariantMapToScriptValue.h>
 #include <SharedUtil.h>
 #include <SpatialParentFinder.h>
+#include <AvatarHashMap.h>
 
 #include "EntityItemID.h"
 #include "EntitiesLogging.h"
@@ -497,8 +498,11 @@ void EntityScriptingInterface::deleteEntity(QUuid id) {
 
                 auto nodeList = DependencyManager::get<NodeList>();
                 const QUuid myNodeID = nodeList->getSessionUUID();
+                auto avatarHashMap = DependencyManager::get<AvatarHashMap>();
+                AvatarSharedPointer myAvatar = avatarHashMap->getAvatarBySessionID(myNodeID);
                 if (entity->getClientOnly() && entity->getOwningAvatarID() != myNodeID) {
                     // don't delete other avatar's avatarEntities
+                    myAvatar->insertDetachedEntityID(id);
                     shouldDelete = false;
                     return;
                 }


### PR DESCRIPTION
When you have an avatar entity. Using Entities.deleteEntity() on a domain switch does not work because the interface has not yet set the entity ownership to you. So deleteEntity function has the entity ownership to {00000000-0000-0000-0000-000000000000}, thus thinking you do not own the entity.