### PR TITLE
Get marketplaceID into imported entities

### DIFF
--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -1678,13 +1678,11 @@ QString getMarketplaceID(const QString& urlString) {
     // a regex for the this is a PITA as there are several valid versions of uuids, and so
     // lets strip out the uuid (if any) and try to create a UUID from the string, relying on
     // QT to parse it
-    static const QRegularExpression re("^http:\\/\\/mpassets.highfidelity.com\\/([0-9A-Fa-f\\-]+)v[\\d]+\\/.*");
+    static const QRegularExpression re("^http:\\/\\/mpassets.highfidelity.com\\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-v[\\d]+\\/.*");
     QRegularExpressionMatch match = re.match(urlString);
     if (match.hasMatch()) {
         QString matched = match.captured(1);
-        // strip the hyphen off the end because my regex is crap
-        matched.truncate(matched.size()-1);
-        if (QUuid() == QUuid(matched)) {
+        if (QUuid(matched).isNull()) {
             qDebug() << "invalid uuid for marketplaceID";
         } else {
             return matched;

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -212,14 +212,14 @@ public:
     virtual bool handlesEditPacketType(PacketType packetType) const { return false; }
     virtual int processEditPacketData(ReceivedMessage& message, const unsigned char* editData, int maxLength,
                                       const SharedNodePointer& sourceNode) { return 0; }
-                    
+
     virtual bool recurseChildrenWithData() const { return true; }
     virtual bool rootElementHasData() const { return false; }
     virtual int minimumRequiredRootDataBytes() const { return 0; }
     virtual bool suppressEmptySubtrees() const { return true; }
     virtual void releaseSceneEncodeData(OctreeElementExtraEncodeData* extraEncodeData) const { }
     virtual bool mustIncludeAllChildData() const { return true; }
-    
+
     /// some versions of the SVO file will include breaks with buffer lengths between each buffer chunk in the SVO
     /// file. If the Octree subclass expects this for this particular version of the file, it should override this
     /// method and return true.
@@ -236,15 +236,15 @@ public:
     void reaverageOctreeElements(OctreeElementPointer startElement = OctreeElementPointer());
 
     void deleteOctreeElementAt(float x, float y, float z, float s);
-    
+
     /// Find the voxel at position x,y,z,s
     /// \return pointer to the OctreeElement or NULL if none at x,y,z,s.
     OctreeElementPointer getOctreeElementAt(float x, float y, float z, float s) const;
-    
+
     /// Find the voxel at position x,y,z,s
     /// \return pointer to the OctreeElement or to the smallest enclosing parent if none at x,y,z,s.
     OctreeElementPointer getOctreeEnclosingElementAt(float x, float y, float z, float s) const;
-    
+
     OctreeElementPointer getOrCreateChildElementAt(float x, float y, float z, float s);
     OctreeElementPointer getOrCreateChildElementContaining(const AACube& box);
 
@@ -261,7 +261,7 @@ public:
 
     int encodeTreeBitstream(const OctreeElementPointer& element, OctreePacketData* packetData, OctreeElementBag& bag,
                             EncodeBitstreamParams& params) ;
-                            
+
     bool isDirty() const { return _isDirty; }
     void clearDirtyBit() { _isDirty = false; }
     void setDirtyBit() { _isDirty = true; }
@@ -301,9 +301,9 @@ public:
     // Octree importers
     bool readFromFile(const char* filename);
     bool readFromURL(const QString& url); // will support file urls as well...
-    bool readFromStream(unsigned long streamLength, QDataStream& inputStream);
+    bool readFromStream(unsigned long streamLength, QDataStream& inputStream, const QString& marketplaceID="");
     bool readSVOFromStream(unsigned long streamLength, QDataStream& inputStream);
-    bool readJSONFromStream(unsigned long streamLength, QDataStream& inputStream);
+    bool readJSONFromStream(unsigned long streamLength, QDataStream& inputStream, const QString& marketplaceID="");
     bool readJSONFromGzippedFile(QString qFileName);
     virtual bool readFromMap(QVariantMap& entityDescription) = 0;
 


### PR DESCRIPTION
Rather than doing this on the backend, we can do it here at the time we import them.  Later we will have some support for getting an entity's identity hash and querying the backend to get a marketplaceID for them as needed.  However for now this is enough to get us moving forward.