### PR TITLE
Fix crash when putting on HMD for Qt 5.9

### DIFF
--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -126,15 +126,17 @@ void OculusBaseDisplayPlugin::internalDeactivate() {
 }
 
 bool OculusBaseDisplayPlugin::activateStandBySession() {
-    _session = acquireOculusSession();
     if (!_session) {
-        return false;
+        _session = acquireOculusSession();
     }
-    return true;
+    return _session;
 }
 void OculusBaseDisplayPlugin::deactivateSession() {
-    releaseOculusSession();
-    _session = nullptr;
+    // FIXME
+    // Switching to Qt 5.9 exposed a race condition or similar issue that caused a crash when putting on an Rift
+    // while already in VR mode.  Commenting these out is a workaround.
+    //releaseOculusSession();
+    //_session = nullptr;
 }
 void OculusBaseDisplayPlugin::updatePresentPose() {
     //mat4 sensorResetMat;


### PR DESCRIPTION
Alternate solution to [10971](https://github.com/highfidelity/hifi/pull/10971).

Fixes a crash in OculusDisplayPlugin::hmdPresent() when putting on a Rift while already in VR mode as a result of a race condition or related issue that appears with Qt 5.9.

Test plan:

- Gustavo's Qt 5.6 build should behave the same as master. Should not crash if you start Interface in VR mode with the Rift off and then put the Rift on.
- If you build from scratch with Qt 5.9, should no longer crash when you do that.
- It would be nice to try with a Vive, too.