### PR TITLE
Do not show lasers when editing in 2D mode.

### DIFF
--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1801,11 +1801,16 @@ function MyController(hand) {
 
         this.processStylus();
 
-        if (isInEditMode() && !this.isNearStylusTarget && HMD.isHandControllerAvailable() && HMD.active) {
+        if (isInEditMode() && !this.isNearStylusTarget && HMD.isHandControllerAvailable()) {
             // Always showing lasers while in edit mode and hands/stylus is not active.
+
             var rayPickInfo = this.calcRayPickInfo(this.hand);
-            this.intersectionDistance = (rayPickInfo.entityID || rayPickInfo.overlayID) ? rayPickInfo.distance : 0;
-            this.searchIndicatorOn(rayPickInfo.searchRay);
+            if (rayPickInfo.isValid) {
+                this.intersectionDistance = (rayPickInfo.entityID || rayPickInfo.overlayID) ? rayPickInfo.distance : 0;
+                this.searchIndicatorOn(rayPickInfo.searchRay);
+            } else {
+                this.searchIndicatorOff();
+            }
         } else {
             this.searchIndicatorOff();
         }
@@ -1854,12 +1859,14 @@ function MyController(hand) {
     this.calcRayPickInfo = function(hand, pickRayOverride) {
 
         var pickRay;
+        var valid = true
         if (pickRayOverride) {
             pickRay = pickRayOverride;
         } else {
             var controllerLocation = getControllerWorldLocation(this.handToController(), true);
             var worldHandPosition = controllerLocation.position;
             var worldHandRotation = controllerLocation.orientation;
+            valid = !(worldHandPosition === undefined);
 
             pickRay = {
                 origin: PICK_WITH_HAND_RAY ? worldHandPosition : Camera.position,
@@ -1874,7 +1881,8 @@ function MyController(hand) {
             entityID: null,
             overlayID: null,
             searchRay: pickRay,
-            distance: PICK_MAX_DISTANCE
+            distance: PICK_MAX_DISTANCE,
+            isValid: valid
         };
 
         var now = Date.now();

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1801,7 +1801,7 @@ function MyController(hand) {
 
         this.processStylus();
 
-        if (isInEditMode() && !this.isNearStylusTarget && HMD.isHandControllerAvailable()) {
+        if (isInEditMode() && !this.isNearStylusTarget && HMD.isHandControllerAvailable() && HMD.active) {
             // Always showing lasers while in edit mode and hands/stylus is not active.
             var rayPickInfo = this.calcRayPickInfo(this.hand);
             this.intersectionDistance = (rayPickInfo.entityID || rayPickInfo.overlayID) ? rayPickInfo.distance : 0;


### PR DESCRIPTION
- prevent the lasers being shown when you are editing in 2D mode.