### PR TITLE
Open marketplace when we know the marketplaceID of an entity

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -11,10 +11,8 @@
 
 #include "ContextOverlayInterface.h"
 #include "Application.h"
-#include "scripting/HMDScriptingInterface.h"
 
 #include <EntityTreeRenderer.h>
-#include <ui/TabletScriptingInterface.h>
 
 ContextOverlayInterface::ContextOverlayInterface() {
     // "context_overlay" debug log category disabled by default.
@@ -24,6 +22,9 @@ ContextOverlayInterface::ContextOverlayInterface() {
     QLoggingCategory::setFilterRules(QStringLiteral("hifi.context_overlay.debug=false"));
 
     _entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
+    _hmdScriptingInterface = DependencyManager::get<HMDScriptingInterface>();
+    _tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
+
     _entityPropertyFlags += PROP_POSITION;
     _entityPropertyFlags += PROP_ROTATION;
 
@@ -87,16 +88,13 @@ void ContextOverlayInterface::openMarketplace() {
     // the marketplace (if the current entity has a
     // marketplaceID)
     if (!_currentEntityWithContextOverlay.isNull()) {
-        auto hmd = DependencyManager::get<HMDScriptingInterface>();
         auto entity = qApp->getEntities()->getTree()->findEntityByID(_currentEntityWithContextOverlay);
-
         if (entity->getMarketplaceID().length() > 0) {
-            auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-            auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+            auto tablet = dynamic_cast<TabletProxy*>(_tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
             // construct the url to the marketplace item
             QString url = MARKETPLACE_BASE_URL + entity->getMarketplaceID();
             tablet->gotoWebScreen(url);
-            hmd->openTablet();
+            _hmdScriptingInterface->openTablet();
         }
     }
 }

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -18,9 +18,12 @@
 
 #include <DependencyManager.h>
 #include <PointerEvent.h>
+#include <ui/TabletScriptingInterface.h>
+
 #include "EntityScriptingInterface.h"
 #include "ui/overlays/Image3DOverlay.h"
 #include "ui/overlays/Overlays.h"
+#include "scripting/HMDScriptingInterface.h"
 
 #include "EntityTree.h"
 #include "ContextOverlayLogging.h"
@@ -34,6 +37,8 @@ class ContextOverlayInterface : public QObject, public Dependency  {
     Q_PROPERTY(QUuid entityWithContextOverlay READ getCurrentEntityWithContextOverlay WRITE setCurrentEntityWithContextOverlay)
     QSharedPointer<EntityScriptingInterface> _entityScriptingInterface;
     EntityPropertyFlags _entityPropertyFlags;
+    QSharedPointer<HMDScriptingInterface> _hmdScriptingInterface;
+    QSharedPointer<TabletScriptingInterface> _tabletScriptingInterface;
     OverlayID _contextOverlayID { UNKNOWN_OVERLAY_ID };
     std::shared_ptr<Image3DOverlay> _contextOverlay { nullptr };
 public:

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -51,7 +51,7 @@ public slots:
 private:
     bool _verboseLogging { true };
     QUuid _currentEntityWithContextOverlay{};
-
+    void openMarketplace();
 };
 
 #endif // hifi_ContextOverlayInterface_h


### PR DESCRIPTION
When we get the context overlay, and click on it, this will bring up the tablet and go to the page in the marketplace where one could get the item.  If the entity has no marketplaceID, then it does nothing.