### PR TITLE
made changes to size of content to display 'choose file' button

### DIFF
--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -506,7 +506,7 @@ Rectangle {
         }
         HifiControls.Tree {
             id: treeView
-            height: 430
+            height: 290
             anchors.leftMargin: hifi.dimensions.contentMargin.x + 2  // Extra for border
             anchors.rightMargin: hifi.dimensions.contentMargin.x + 2  // Extra for border
             anchors.left: parent.left


### PR DESCRIPTION
With reference to https://highfidelity.fogbugz.com/f/cases/6219/The-Choose-File-button-doesn-t-show-up-in-the-Asset-Browser-in-Tablet-mode

Made changes in the size of content in TabletAssetServer.qml so that "Choose File" button is visible.

Testing Notes:
1) Build and Run the PR
2) Open the tablet -> Create -> Open this domain's asset server
3) Observe the "Choose File" button appears on bottom right
4) Click on the Choose File button and upload a file
5) Observe the spinner and status are visible during upload 