### PR TITLE
Fix debug builds startup crash

### DIFF
--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -27,8 +27,6 @@
 #include "AudioSRC.h"
 #include "AudioHelpers.h"
 
-int audioInjectorPtrMetaTypeId = qRegisterMetaType<AudioInjector*>();
-
 AbstractAudioInterface* AudioInjector::_localAudioInterface{ nullptr };
 
 AudioInjectorState operator& (AudioInjectorState lhs, AudioInjectorState rhs) {

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -125,6 +125,4 @@ private:
     friend class AudioInjectorManager;
 };
 
-Q_DECLARE_METATYPE(AudioInjectorPointer)
-
 #endif // hifi_AudioInjector_h


### PR DESCRIPTION
Since the interface between scripts and audio injectors is now handled by `ScriptAudioInjector`, those are no longer necessary.