### PR TITLE
Added a page in installer for express/custom installation

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -354,7 +354,8 @@ SectionEnd
   !insertmacro MUI_PAGE_STARTMENU Application $STARTMENU_FOLDER
 
   @CPACK_NSIS_PAGE_COMPONENTS@
-
+  
+  Page custom InstallTypesPage ReadInstallTypes
   Page custom PostInstallOptionsPage ReadPostInstallOptions
 
   !insertmacro MUI_PAGE_INSTFILES
@@ -442,6 +443,10 @@ Var CleanInstallCheckbox
 Var CurrentOffset
 Var OffsetUnits
 Var CopyFromProductionCheckbox
+Var ExpressInstallRadioButton
+Var CustomInstallRadioButton
+Var InstallTypeDialog
+Var Express
 
 !macro SetPostInstallOption Checkbox OptionName Default
   ; reads the value for the given post install option to the registry
@@ -458,6 +463,52 @@ Var CopyFromProductionCheckbox
     ${NSD_SetState} ${Checkbox} ${Default}
   ${EndIf}
 !macroend
+
+Function InstallTypesPage
+  !insertmacro MUI_HEADER_TEXT "Choose Installation Type" "Express or Custom Install"
+  
+  nsDialogs::Create 1018
+  Pop $InstallTypeDialog
+  
+  ${If} $InstallTypeDialog == error
+    Abort
+  ${EndIf}
+  
+  StrCpy $CurrentOffset 0
+  StrCpy $OffsetUnits u
+  StrCpy $Express "0"  
+  
+  ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
+    ${NSD_CreateRadioButton} 30% $CurrentOffset$OffsetUnits 100% 10u "Express Install (Recommended)"; $\nInstalls High Fidelity Interface and High Fidelity Sandbox"
+    pop $ExpressInstallRadioButton
+    ${NSD_OnClick} $ExpressInstallRadioButton ChangeExpressLabel
+    IntOp $CurrentOffset $CurrentOffset + 15
+  
+    ${NSD_CreateRadiobutton} 30% $CurrentOffset$OffsetUnits 100% 10u "Custom Install (Advanced)"
+    pop $CustomInstallRadioButton
+    ${NSD_OnClick} $CustomInstallRadioButton ChangeCustomLabel 
+  ${EndIf}
+  
+  ; Express Install selected by default
+  ${NSD_Check} $ExpressInstallRadioButton
+  Call ChangeExpressLabel
+  
+  nsDialogs::Show
+FunctionEnd
+
+Function ChangeExpressLabel
+  Push $R1
+  GetDlgItem $R1 $HWNDPARENT 1
+  SendMessage $R1 ${WM_SETTEXT} 0 "STR:Install"
+  Pop $R1
+FunctionEnd
+
+Function ChangeCustomLabel
+  Push $R1
+  GetDlgItem $R1 $HWNDPARENT 1
+  SendMessage $R1 ${WM_SETTEXT} 0 "STR:Next >"
+  Pop $R1
+FunctionEnd
 
 Function PostInstallOptionsPage
   !insertmacro MUI_HEADER_TEXT "Setup Options" ""
@@ -552,6 +603,12 @@ Function PostInstallOptionsPage
     ${NSD_SetState} $CopyFromProductionCheckbox ${BST_CHECKED}
   ${EndIf}
   
+  ; Check if Express is set, if so, abort the post install options page
+  Call HandleInstallTypes ; Sets Express if ExpressInstallRadioButton is checked and installs with defaults
+  StrCmp $Express "1" 0 end
+  Abort
+  end:
+  
   nsDialogs::Show
 FunctionEnd
 
@@ -567,6 +624,16 @@ Var LaunchServerNowState
 Var LaunchClientNowState
 Var CopyFromProductionState
 Var CleanInstallState
+Var ExpressInstallState 
+Var CustomInstallState
+
+Function ReadInstallTypes
+${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
+    ; check if the user asked for express/custom install
+    ${NSD_GetState} $ExpressInstallRadioButton $ExpressInstallState
+    ${NSD_GetState} $CustomInstallRadioButton $CustomInstallState
+${EndIf}
+FunctionEnd
 
 Function ReadPostInstallOptions
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
@@ -603,6 +670,28 @@ Function ReadPostInstallOptions
   ${EndIf}
 FunctionEnd
 
+Function HandleInstallTypes
+  ${If} $ExpressInstallState == ${BST_CHECKED}
+    
+    StrCpy $Express "1"
+    
+    ; over ride custom checkboxes and select defaults 
+    ${NSD_SetState} $DesktopClientCheckbox ${BST_CHECKED} 
+    ${NSD_SetState} $ServerStartupCheckbox ${BST_CHECKED} 
+    ${NSD_SetState} $LaunchServerNowCheckbox ${BST_CHECKED}
+    ${NSD_SetState} $LaunchClientNowCheckbox ${BST_CHECKED}
+    
+    ${If} @PR_BUILD@ == 1
+      ${NSD_SetState} $CopyFromProductionCheckbox ${BST_CHECKED}
+    ${EndIf}
+    
+    ; call ReadPostInstallOptions and HandlePostInstallOptions with defaults selected
+    Call ReadPostInstallOptions 
+    Call HandlePostInstallOptions 
+      
+  ${EndIf}
+FunctionEnd
+
 Function HandlePostInstallOptions
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
     ; check if the user asked for a desktop shortcut to High Fidelity
@@ -624,6 +713,7 @@ Function HandlePostInstallOptions
       !insertmacro WritePostInstallOption @CONSOLE_DESKTOP_SHORTCUT_REG_KEY@ NO
     ${EndIf}
 
+    
     ; check if the user asked to have Sandbox launched every startup
     ${If} $ServerStartupState == ${BST_CHECKED}
       ; in case we added a shortcut in the global context, pull that now

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -49,7 +49,7 @@
     Var STR_CONTAINS_VAR_3
     Var STR_CONTAINS_VAR_4
     Var STR_RETURN_VAR
-    
+        
     Function StrContains
       Exch $STR_NEEDLE
       Exch 1
@@ -343,23 +343,29 @@ SectionEnd
 ;--------------------------------
 ;Pages
   !insertmacro MUI_PAGE_WELCOME
-
+  
   !insertmacro MUI_PAGE_LICENSE "@CPACK_RESOURCE_FILE_LICENSE@"
+  
+  Page custom InstallTypesPage ReadInstallTypes
+  
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE AbortFunction
   !insertmacro MUI_PAGE_DIRECTORY
-
+  
   ;Start Menu Folder Page Configuration
   !define MUI_STARTMENUPAGE_REGISTRY_ROOT "HKLM"
   !define MUI_STARTMENUPAGE_REGISTRY_KEY "Software\@CPACK_PACKAGE_VENDOR@\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@"
   !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "Start Menu Folder"
-  !insertmacro MUI_PAGE_STARTMENU Application $STARTMENU_FOLDER
-
-  @CPACK_NSIS_PAGE_COMPONENTS@
   
-  Page custom InstallTypesPage ReadInstallTypes
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE AbortFunction
+  !insertmacro MUI_PAGE_STARTMENU Application $STARTMENU_FOLDER
+  
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE AbortFunction
+  @CPACK_NSIS_PAGE_COMPONENTS@
+    
   Page custom PostInstallOptionsPage ReadPostInstallOptions
 
   !insertmacro MUI_PAGE_INSTFILES
-
+  
   !insertmacro MUI_UNPAGE_CONFIRM
   !insertmacro MUI_UNPAGE_INSTFILES
 
@@ -510,6 +516,14 @@ Function ChangeCustomLabel
   Pop $R1
 FunctionEnd
 
+Function AbortFunction
+  ; Check if Express is set, if so, abort the post install options page
+  Call HandleInstallTypes ; Sets Express if ExpressInstallRadioButton is checked and installs with defaults
+  StrCmp $Express "1" 0 end
+  Abort
+  end:
+FunctionEnd  
+
 Function PostInstallOptionsPage
   !insertmacro MUI_HEADER_TEXT "Setup Options" ""
 
@@ -628,11 +642,11 @@ Var ExpressInstallState
 Var CustomInstallState
 
 Function ReadInstallTypes
-${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
+  ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
     ; check if the user asked for express/custom install
     ${NSD_GetState} $ExpressInstallRadioButton $ExpressInstallState
     ${NSD_GetState} $CustomInstallRadioButton $CustomInstallState
-${EndIf}
+  ${EndIf}
 FunctionEnd
 
 Function ReadPostInstallOptions
@@ -712,6 +726,7 @@ Function HandlePostInstallOptions
     ${Else}
       !insertmacro WritePostInstallOption @CONSOLE_DESKTOP_SHORTCUT_REG_KEY@ NO
     ${EndIf}
+
     
     ; check if the user asked to have Sandbox launched every startup
     ${If} $ServerStartupState == ${BST_CHECKED}

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -600,7 +600,7 @@ Function PostInstallOptionsPage
     ${NSD_CreateCheckbox} 0 $CurrentOffset$OffsetUnits 100% 10u "&Copy settings and content from production install"
     Pop $CopyFromProductionCheckbox
 
-    ${NSD_SetState} $CopyFromProductionCheckbox ${BST_CHECKED}
+    ${NSD_SetState} $CopyFromProductionCheckbox ${BST_UNCHECKED}
   ${EndIf}
   
   ; Check if Express is set, if so, abort the post install options page
@@ -682,8 +682,8 @@ Function HandleInstallTypes
     ${NSD_SetState} $LaunchClientNowCheckbox ${BST_CHECKED}
     
     ${If} @PR_BUILD@ == 1
-      ${NSD_SetState} $CopyFromProductionCheckbox ${BST_CHECKED}
-    ${EndIf}
+      ${NSD_SetState} $CopyFromProductionCheckbox ${BST_UNCHECKED}
+    ${EndIf}    
     
     ; call ReadPostInstallOptions and HandlePostInstallOptions with defaults selected
     Call ReadPostInstallOptions 


### PR DESCRIPTION
Added a page in the installer to choose express/custom installation type 
Express install -> No Post Install Options provided to user. Software installed with default options. 
Custom Install -> Post Install Options provided to user

Testing Notes:
1) Build the PR
2) Generate the installer following these documents: https://github.com/highfidelity/hifi/blob/master/INSTALL.md , #6870
3) Run the installer
4) Observe a new page - "Choose Installation Type"
   a) "Express Install" is selected by default
   b) Lower button panel has labels: Back, Install, Cancel
   c) Click on "Custom Install"
   d) Button panel changes to Back, Next, Cancel
5) Install with Express install selected
   a) No Post Install Options page
   b) Software installs with following defaults: 
       Create a desktop shortcut for Interface
       Launch Sandbox after install
       Launch Interface after install
       Launch Sandbox on startup
6) Install with Custom Install selected
   a) Post Install options page appears
   b) If it is a PR build, Observe that checkbox for copying settings from Production is unchecked by default   
   c) Change any of the default settings (For example uncheck Desktop shortcut creation)
   d) Observe the settings are reflected (For example Desktop shortcut is not created)
7) Come back and Install again with "Express Install" selected
   a) Observe changes made in custom install (For example uncheck Desktop shortcut creation), are over ridden by defaults, i.e Desktop shortcut IS created
8) PR build tests:
    a) In custom install, select the "copy from production" checkbox and install
    b) Come back and install with Express Install, it **Does Not** copy settings/content from production