### PR TITLE
WL21424 hide head attachments when head joint is hidden

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1893,6 +1893,17 @@ void MyAvatar::preDisplaySide(RenderArgs* renderArgs) {
     const bool shouldDrawHead = shouldRenderHead(renderArgs);
     if (shouldDrawHead != _prevShouldDrawHead) {
         _skeletonModel->setEnableCauterization(!shouldDrawHead);
+
+        for (int i = 0; i < _attachmentData.size(); i++) {
+            if (_attachmentData[i].jointName.compare("Head", Qt::CaseInsensitive) == 0 ||
+                _attachmentData[i].jointName.compare("Neck", Qt::CaseInsensitive) == 0 ||
+                _attachmentData[i].jointName.compare("LeftEye", Qt::CaseInsensitive) == 0 ||
+                _attachmentData[i].jointName.compare("RightEye", Qt::CaseInsensitive) == 0 ||
+                _attachmentData[i].jointName.compare("HeadTop_End", Qt::CaseInsensitive) == 0 ||
+                _attachmentData[i].jointName.compare("Face", Qt::CaseInsensitive) == 0) {
+                _attachmentModels[i]->setVisibleInScene(shouldDrawHead, qApp->getMain3DScene());
+            }
+        }
     }
     _prevShouldDrawHead = shouldDrawHead;
 }


### PR DESCRIPTION
### Verify head attachments are visible in third person
1. Change interface camera to third person mode.
2. Add a head attachment to avatar.
3. Verify attachment model is visible.

### Verify head attachments are not visible in first person
1. Change interface camera to first person mode.
2. Add a head attachment to avatar.
3. Verify attachment model is not visible.

### Verify head attachment visibility changes with camera mode
1. Change interface camera to third person mode.
2. Add a head attachment to avatar.
3. Verify attachment model is visible.
4. Change interface camera to first person mode.
5. Verify attachment model is not visible.
6. Change interface camera to third person mode.
7. Verify attachment model is visible.

### Verify attachment model is always visible to other clients
1. Change interface camera to third person mode.
2. Add a head attachment to avatar.
3. Verify attachment model is visible on local client.
4. Verify attachment model is visible on remote client.
5. Change interface camera to first person mode.
6. Verify attachment model is not visible on local client.
7. Verify attachment model is visible on remote client.