### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation
 =========
 Documentation is available at [docs.highfidelity.com](https://docs.highfidelity.com), if something is missing, please suggest it via a new job on Worklist (add to the hifi-docs project).
 
-There is also detailed [documentation on our coding standards](https://wiki.highfidelity.com/wiki/Coding_Standards).
+There is also detailed [documentation on our coding standards](https://docs.highfidelity.com/build-guide/coding-standards).
 
 Build Instructions 
 =========


### PR DESCRIPTION
The link for the coding standards is currently broken.  It was pointing to https://wiki.highfidelity.com/wiki/Coding_Standards which sends you to the docs.hifidelity.com's 404 page.  

I found this in the doc's build guide:  
https://docs.highfidelity.com/build-guide/coding-standards

Updated the above link to that one for now.