### PR TITLE
Five major improvements to context-overlays

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -72,13 +72,18 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
             glm::vec3 cameraPosition = qApp->getCamera().getPosition();
             float distanceToEntity = glm::distance(entityProperties.getPosition(), cameraPosition);
             glm::vec3 contextOverlayPosition;
+            glm::vec2 contextOverlayDimensions;
             if (distanceToEntity > 1.5f) {
                 contextOverlayPosition = (distanceToEntity - 1.0f) * glm::normalize(entityProperties.getPosition() - cameraPosition) + cameraPosition;
+                contextOverlayDimensions = glm::vec2(0.08f, 0.08f) * glm::distance(contextOverlayPosition, cameraPosition);
             } else {
-                contextOverlayPosition = (glm::quat(glm::radians(glm::vec3(0.0f, -30.0f, 0.0f))) * (entityProperties.getPosition() - cameraPosition)) + cameraPosition;
+                // If the entity is too close to the camera, rotate the context overlay to the right of the entity.
+                // This makes it easy to inspect things you're holding.
+                contextOverlayPosition = (glm::quat(glm::radians(glm::vec3(0.0f, -20.0f, 0.0f))) * (entityProperties.getPosition() - cameraPosition)) + cameraPosition;
+                contextOverlayDimensions = glm::vec2(0.12f, 0.12f) * glm::distance(contextOverlayPosition, cameraPosition);
             }
             _contextOverlay->setPosition(contextOverlayPosition);
-            _contextOverlay->setDimensions(glm::vec2(0.1f, 0.1f) * glm::distance(contextOverlayPosition, cameraPosition));
+            _contextOverlay->setDimensions(contextOverlayDimensions);
             _contextOverlay->setRotation(entityProperties.getRotation());
             _contextOverlay->setVisible(true);
             return true;
@@ -90,7 +95,6 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
 }
 
 bool ContextOverlayInterface::destroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
-
     if (_contextOverlayID != UNKNOWN_OVERLAY_ID) {
         qCDebug(context_overlay) << "Destroying Context Overlay on top of entity with ID: " << entityItemID;
         setCurrentEntityWithContextOverlay(QUuid());

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -29,6 +29,10 @@
 #include "EntityTree.h"
 #include "ContextOverlayLogging.h"
 
+#ifndef MIN
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+#endif
+
 /**jsdoc
 * @namespace ContextOverlay
 */
@@ -54,9 +58,9 @@ public:
     bool getEnabled() { return _enabled; }
 
 public slots:
-    void createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
-    void destroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
-    void destroyContextOverlay(const EntityItemID& entityItemID);
+    bool createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
+    bool destroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
+    bool destroyContextOverlay(const EntityItemID& entityItemID);
     void clickContextOverlay(const OverlayID& overlayID, const PointerEvent& event);
 
 private:

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -29,10 +29,6 @@
 #include "EntityTree.h"
 #include "ContextOverlayLogging.h"
 
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif
-
 /**jsdoc
 * @namespace ContextOverlay
 */

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -2227,8 +2227,6 @@ function MyController(hand) {
                 if (rayPickInfo.entityID === potentialEntityWithContextOverlay &&
                     !entityWithContextOverlay
                     && contextualHand !== -1) {
-                    entityWithContextOverlay = rayPickInfo.entityID;
-                    potentialEntityWithContextOverlay = false;
                     var pointerEvent = {
                         type: "Move",
                         id: contextualHand + 1, // 0 is reserved for hardware mouse
@@ -2238,7 +2236,10 @@ function MyController(hand) {
                         direction: rayPickInfo.searchRay.direction,
                         button: "Secondary"
                     };
-                    ContextOverlay.createOrDestroyContextOverlay(rayPickInfo.entityID, pointerEvent);
+                    if (ContextOverlay.createOrDestroyContextOverlay(rayPickInfo.entityID, pointerEvent)) {
+                        entityWithContextOverlay = rayPickInfo.entityID;
+                        potentialEntityWithContextOverlay = false;
+                    }
                 }
             }, 500);
             contextualHand = this.hand;

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -3633,8 +3633,6 @@ function MyController(hand) {
             };
 
             Overlays.sendMousePressOnOverlay(this.grabbedOverlay, pointerEvent);
-            entityWithContextOverlay = false;
-            potentialEntityWithContextOverlay = false;
 
             this.touchingEnterTimer = 0;
             this.touchingEnterPointerEvent = pointerEvent;


### PR DESCRIPTION
Create/Destroy returns bool; Better alpha; move (i) in front of entity; offset by angle when close; Using lasers: Hovering over entity that doesn't spawn overlay, then moving over entity that _does_ spawn overlay will correctly make hover overlay spawn.

DO NOT TEST