### PR TITLE
Hotfix for Audio deadlock

### DIFF
--- a/interface/src/scripting/AudioDevices.h
+++ b/interface/src/scripting/AudioDevices.h
@@ -39,7 +39,7 @@ public:
     QVariant data(const QModelIndex& index, int role) const override;
 
     // reset device to the last selected device in this context, or the default
-    void resetDevice(bool contextIsHMD, const QString& device);
+    void resetDevice(bool contextIsHMD);
 
 signals:
     void deviceChanged(const QAudioDeviceInfo& device);
@@ -87,8 +87,10 @@ private:
 
     AudioDeviceList _inputs { QAudio::AudioInput };
     AudioDeviceList _outputs { QAudio::AudioOutput };
+    QAudioDeviceInfo _requestedOutputDevice;
+    QAudioDeviceInfo _requestedInputDevice;
 
-    bool& _contextIsHMD;
+    const bool& _contextIsHMD;
 };
 
 };


### PR DESCRIPTION
For some reason, the use of the blocking connections on the main thread is causing a deadlock.  In my testing, the main thread was in the blocking connection waiting on the `AudioClient` thread, while the `AudioClient` thread was for some reason stuck in `usecTimestampNow`.  This may point a problem with `usecTimestampNow` which uses a single QElapsedTimer across all threads, even though the docs specifically say it's reentrant, not thread safe.

## Testing

If you're experiencing deadlocks on startup with build 6896, please test with this build and see if they still occur.

To test further...  

  * remove any `Audio/XXX/INPUT` entries from your Interface.json file (located in `~\AppData\Roaming\High Fidelity\` or `~\AppData\Roaming\High Fidelity - dev` for PR builds
 * Open Interface
 * In desktop mode, the audio input and output should match the defaults in your system control panel
 * In Oculus mode the audio inputs and output should automatically switch to the appropriate Rift default devices
 * In either mode, if you change the settings and exit interface, when you restart and go back into that mode (desktop or HMD) the settings should be preserved.

