### PR TITLE
[Don't Merge] Worklist Item #21389: Representation of collision shapes need updating.

### DIFF
--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -16,6 +16,7 @@
 #include <StencilMaskPass.h>
 #include <GeometryCache.h>
 #include <PerfStat.h>
+#include <ShapeFactory.h>
 
 #include <render-utils/simple_vert.h>
 #include <render-utils/simple_frag.h>
@@ -84,6 +85,23 @@ bool RenderableShapeEntityItem::isTransparent() {
     } else {
         return getLocalRenderAlpha() < 1.0f || EntityItem::isTransparent();
     }
+}
+
+void RenderableShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
+
+	if (_collisionShapeType == ShapeType::SHAPE_TYPE_NONE) {
+		if (_shape == entity::Shape::NUM_SHAPES)
+		{
+			EntityItem::computeShapeInfo(info);
+
+			//--EARLY EXIT--( allow default handling to process )
+			return;
+		}
+
+		_collisionShapeType = ShapeFactory::computeShapeType(getShape(), getDimensions());
+	}
+
+	return EntityItem::computeShapeInfo(info);
 }
 
 void RenderableShapeEntityItem::render(RenderArgs* args) {

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -48,18 +48,22 @@ RenderableShapeEntityItem::Pointer RenderableShapeEntityItem::baseFactory(const 
 }
 
 EntityItemPointer RenderableShapeEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    return baseFactory(entityID, properties);
+	auto result = baseFactory(entityID, properties);
+
+	qCDebug(entities) << "Creating RenderableShapeEntityItem( " << result->_name << " ): " << result.get() << " ID: " << result->_id;
+
+	return result;
 }
 
 EntityItemPointer RenderableShapeEntityItem::boxFactory(const EntityItemID& entityID, const EntityItemProperties& properties) {
     auto result = baseFactory(entityID, properties);
-    result->setShape(entity::Cube);
+    result->setShape(entity::Shape::Cube);
     return result;
 }
 
 EntityItemPointer RenderableShapeEntityItem::sphereFactory(const EntityItemID& entityID, const EntityItemProperties& properties) {
     auto result = baseFactory(entityID, properties);
-    result->setShape(entity::Sphere);
+    result->setShape(entity::Shape::Sphere);
     return result;
 }
 

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.h
@@ -28,6 +28,8 @@ public:
 
     bool isTransparent() override;
 
+	void computeShapeInfo(ShapeInfo& info);
+
 private:
     std::unique_ptr<Procedural> _procedural { nullptr };
 

--- a/libraries/entities/CMakeLists.txt
+++ b/libraries/entities/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET_NAME entities)
 setup_hifi_library(Network Script)
-link_hifi_libraries(shared networking octree avatars physics)
+link_hifi_libraries(shared networking octree avatars)
 

--- a/libraries/entities/CMakeLists.txt
+++ b/libraries/entities/CMakeLists.txt
@@ -1,3 +1,4 @@
 set(TARGET_NAME entities)
 setup_hifi_library(Network Script)
-link_hifi_libraries(shared networking octree avatars)
+link_hifi_libraries(shared networking octree avatars physics)
+

--- a/libraries/entities/src/ShapeEntityItem.cpp
+++ b/libraries/entities/src/ShapeEntityItem.cpp
@@ -12,7 +12,6 @@
 #include <QtCore/QDebug>
 
 #include <GeometryUtil.h>
-#include <ShapeFactory.h>
 
 #include "EntitiesLogging.h"
 #include "EntityItemProperties.h"
@@ -96,9 +95,11 @@ void ShapeEntityItem::setShape(const entity::Shape& shape) {
     switch (_shape) {
         case entity::Shape::Cube:
             _type = EntityTypes::Box;
+			_collisionShapeType = ShapeType::SHAPE_TYPE_BOX;
             break;
         case entity::Shape::Sphere:
             _type = EntityTypes::Sphere;
+			_collisionShapeType = ShapeType::SHAPE_TYPE_ELLIPSOID;
             break;
         default:
             _type = EntityTypes::Shape;
@@ -170,23 +171,6 @@ void ShapeEntityItem::appendSubclassData(OctreePacketData* packetData, EncodeBit
     APPEND_ENTITY_PROPERTY(PROP_ALPHA, getAlpha());
 }
 
-void ShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
-
-	if ( _collisionShapeType == ShapeType::SHAPE_TYPE_NONE ) {
-		if (_shape == entity::Shape::NUM_SHAPES)
-		{
-			EntityItem::computeShapeInfo(info);
-
-			//--EARLY EXIT--( allow default handling to process )
-			return;
-		}
-
-		_collisionShapeType = ShapeFactory::computeShapeType(getShape(), getDimensions());
-	}
-
-	return EntityItem::computeShapeInfo(info);
-}
-
 // This value specifes how the shape should be treated by physics calculations.  
 // For now, all polys will act as spheres
 ShapeType ShapeEntityItem::getShapeType() const {
@@ -203,11 +187,11 @@ ShapeType ShapeEntityItem::getShapeType() const {
 	//// Original functionality:  Everything not a cube, is treated like an ellipsoid/sphere
 	//return (_shape == entity::Shape::Cube) ? SHAPE_TYPE_BOX : SHAPE_TYPE_ELLIPSOID;
 
-	if (_collisionShapeType == ShapeType::SHAPE_TYPE_NONE)
-	{
-		//--EARLY EXIT--( Maintain previous behavior of treating invalid as Ellipsoid/Sphere )
-		return SHAPE_TYPE_ELLIPSOID;
-	}
+	//if (_collisionShapeType == ShapeType::SHAPE_TYPE_NONE)
+	//{
+	//	//--EARLY EXIT--( Maintain previous behavior of treating invalid as Ellipsoid/Sphere )
+	//	return SHAPE_TYPE_ELLIPSOID;
+	//}
 
 	return _collisionShapeType;
 }

--- a/libraries/entities/src/ShapeEntityItem.h
+++ b/libraries/entities/src/ShapeEntityItem.h
@@ -70,7 +70,7 @@ public:
 
     entity::Shape getShape() const { return _shape; }
     void setShape(const entity::Shape& shape);
-    void setShape(const QString& shape) { setShape(entity::shapeFromString(shape)); }
+	void setShape(const QString& shape);
 
     float getAlpha() const { return _alpha; };
     void setAlpha(float alpha) { _alpha = alpha; }
@@ -84,6 +84,7 @@ public:
     QColor getQColor() const;
     void setColor(const QColor& value);
 
+	void computeShapeInfo(ShapeInfo& info);
     ShapeType getShapeType() const override;
     bool shouldBePhysical() const override { return !isDead(); }
     
@@ -100,6 +101,7 @@ protected:
     float _alpha { 1 };
     rgbColor _color;
     entity::Shape _shape { entity::Shape::Sphere };
+	ShapeType _collisionShapeType{ ShapeType::SHAPE_TYPE_NONE };
 };
 
 #endif // hifi_ShapeEntityItem_h

--- a/libraries/entities/src/ShapeEntityItem.h
+++ b/libraries/entities/src/ShapeEntityItem.h
@@ -84,7 +84,6 @@ public:
     QColor getQColor() const;
     void setColor(const QColor& value);
 
-	void computeShapeInfo(ShapeInfo& info);
     ShapeType getShapeType() const override;
     bool shouldBePhysical() const override { return !isDead(); }
     

--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -247,7 +247,7 @@ void deleteStaticMeshArray(btTriangleIndexVertexArray* dataArray) {
     delete dataArray;
 }
 
-ShapeType validateShapeType(ShapeType type, const glm::vec3 &halfExtents, btCollisionShape *outCollisionShape = nullptr)
+ShapeType validateShapeType(ShapeType type, const glm::vec3 &halfExtents, btCollisionShape **outCollisionShape = NULL)
 {
 	if ((type == SHAPE_TYPE_SPHERE) || (type == SHAPE_TYPE_ELLIPSOID))
 	{
@@ -259,7 +259,7 @@ ShapeType validateShapeType(ShapeType type, const glm::vec3 &halfExtents, btColl
 			&& fabsf(radius - halfExtents.z) / radius < MIN_RELATIVE_SPHERICAL_ERROR) {
 			// close enough to true sphere
 			if (outCollisionShape) {
-				outCollisionShape = new btSphereShape(radius);
+				(*outCollisionShape) = new btSphereShape(radius);
 			}
 
 			return SHAPE_TYPE_SPHERE;
@@ -271,7 +271,7 @@ ShapeType validateShapeType(ShapeType type, const glm::vec3 &halfExtents, btColl
 				points.push_back(bulletToGLM(_unitSphereDirections[i]) * halfExtents);
 			}
 			if (outCollisionShape) {
-				outCollisionShape = createConvexHull(points);
+				(*outCollisionShape) = createConvexHull(points);
 			}
 
 			return SHAPE_TYPE_ELLIPSOID;
@@ -280,23 +280,23 @@ ShapeType validateShapeType(ShapeType type, const glm::vec3 &halfExtents, btColl
 	else if ((type == SHAPE_TYPE_CYLINDER_X) || (type == SHAPE_TYPE_CYLINDER_Y) || (type == SHAPE_TYPE_CYLINDER_Z))
 	{
 		const btVector3 btHalfExtents(halfExtents.x, halfExtents.y, halfExtents.z);
-		if ((halfExtents.y > halfExtents.x) && (halfExtents.y > halfExtents.z)) {
+		if ((halfExtents.y >= halfExtents.x) && (halfExtents.y >= halfExtents.z)) {
 			if (outCollisionShape) {
-				outCollisionShape = new btCylinderShape(btHalfExtents);
+				(*outCollisionShape) = new btCylinderShape(btHalfExtents);
 			}
 
 			return SHAPE_TYPE_CYLINDER_Y;
 		}
-		else if (halfExtents.x > halfExtents.z) {
+		else if (halfExtents.x >= halfExtents.z) {
 			if (outCollisionShape) {
-				outCollisionShape = new btCylinderShapeX(btHalfExtents);
+				(*outCollisionShape) = new btCylinderShapeX(btHalfExtents);
 			}
 
 			return SHAPE_TYPE_CYLINDER_X;
 		}
 		else if (halfExtents.z > halfExtents.x) {
 			if (outCollisionShape) {
-				outCollisionShape = new btCylinderShapeZ(btHalfExtents);
+				(*outCollisionShape) = new btCylinderShapeZ(btHalfExtents);
 			}
 
 			return SHAPE_TYPE_CYLINDER_Z;
@@ -399,7 +399,7 @@ const btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info)
             //    shape = createConvexHull(points);
             //}
 
-			validateShapeType(SHAPE_TYPE_ELLIPSOID, halfExtents, shape);
+			validateShapeType(SHAPE_TYPE_ELLIPSOID, halfExtents, &shape);
         }
         break;
         case SHAPE_TYPE_CAPSULE_Y: {
@@ -442,7 +442,7 @@ const btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info)
 			//{
 			//	//TODO_CUSACK: Shunt to ELLIPSOID handling
 			//}
-			validateShapeType(SHAPE_TYPE_CYLINDER_Y, halfExtents, shape);
+			validateShapeType(SHAPE_TYPE_CYLINDER_Y, halfExtents, &shape);
 		}
 		break;
         case SHAPE_TYPE_COMPOUND:

--- a/libraries/physics/src/ShapeFactory.h
+++ b/libraries/physics/src/ShapeFactory.h
@@ -15,11 +15,14 @@
 #include <btBulletDynamicsCommon.h>
 #include <glm/glm.hpp>
 
+#include <ShapeEntityItem.h> //< Needed for entity::Shape
 #include <ShapeInfo.h>
 
 // translates between ShapeInfo and btShape
 
 namespace ShapeFactory {
+
+	ShapeType computeShapeType( entity::Shape shape, const glm::vec3 &entityDimensions);
     const btCollisionShape* createShapeFromInfo(const ShapeInfo& info);
     void deleteShape(const btCollisionShape* shape);
 

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -124,7 +124,10 @@ float ShapeInfo::computeVolume() const {
         }
         case SHAPE_TYPE_CAPSULE_Y: {
             float radius = _halfExtents.x;
-            volume = PI * radius * radius * (2.0f * (_halfExtents.y - _halfExtents.x) + 4.0f * radius / 3.0f);
+            // Need to offset halfExtents.y by x to account for the system treating
+            // the y extent of the capsule as the cylindrical height + spherical radius.
+            float cylinderHeight = 2.0f * (_halfExtents.y - _halfExtents.x);
+            volume = PI * radius * radius * (cylinderHeight + 4.0f * radius / 3.0f);
             break;
         }
         default:

--- a/scripts/developer/tests/basicEntityTest/shapeSpawner.js
+++ b/scripts/developer/tests/basicEntityTest/shapeSpawner.js
@@ -8,9 +8,9 @@
   var SCRIPT_URL = Script.resolvePath("myEntityScript.js")
 
   var myEntity = Entities.addEntity({
-      name: "Cusack_Testing",
+      name: "ShapeSpawnTest",
       type: "Shape",
-      shapeType: "Cylinder",
+      shape: "Cylinder",
       color: {
           red: 200,
           green: 10,

--- a/scripts/developer/tests/basicEntityTest/shapeSpawner.js
+++ b/scripts/developer/tests/basicEntityTest/shapeSpawner.js
@@ -1,33 +1,30 @@
-  var orientation = Camera.getOrientation();
-  orientation = Quat.safeEulerAngles(orientation);
-  orientation.x = 0;
-  orientation = Quat.fromVec3Degrees(orientation);
-  var center = Vec3.sum(MyAvatar.position, Vec3.multiply(3, Quat.getForward(orientation)));
+// compute a position to create the object relative to avatar
+var forwardOffset = Vec3.multiply(2.0, Quat.getFront(MyAvatar.orientation));
+var objectPosition = Vec3.sum(MyAvatar.position, forwardOffset);
 
-  // Math.random ensures no caching of script
-  var SCRIPT_URL = Script.resolvePath("myEntityScript.js")
+var LIFETIME = 1800; //seconds
+var DIM_HEIGHT = 1, DIM_WIDTH = 1, DIM_DEPTH = 1;
+var COLOR_R = 100, COLOR_G = 10, COLOR_B = 200;
 
-  var myEntity = Entities.addEntity({
-      name: "ShapeSpawnTest",
-      type: "Shape",
-      shape: "Cylinder",
-      color: {
-          red: 200,
-          green: 10,
-          blue: 200
-      },
-      position: center,
-      dimensions: {
-          x: 1,
-          y: 1,
-          z: 1
-      },
-      script: SCRIPT_URL
-  })
+var properties = {
+        name: "ShapeSpawnTest",
+        type: "Shape",
+        shape: "Cylinder",
+        dimensions: {x: DIM_WIDTH, y: DIM_HEIGHT, z: DIM_DEPTH},
+        color: {red: COLOR_R, green: COLOR_G, blue: COLOR_B},
+        position: objectPosition,
+        lifetime: LIFETIME,
+};
+
+// create the object
+var entityId = Entities.addEntity(properties);
+
+function cleanup() {
+    Entities.deleteEntity(entityId);
+}
+
+// delete the object when this script is stopped
+Script.scriptEnding.connect(cleanup);
 
 
-  function cleanup() {
-      // Entities.deleteEntity(myEntity);
-  }
 
-  Script.scriptEnding.connect(cleanup);


### PR DESCRIPTION
Interim PR (NOT FINAL)
Purpose:  This PR is to allow for feedback and confirming if this approach is reasonable prior to going further.

* This is a work in progress.
* This is has the majority of the foundation of the fix for Worklist Item #21389.
** The current progress is vetting the current approach using <code>entity::Shape:Cylinder</code>
** There are some additional integration points which need to be amended or added which aren't present as of yet.
*** Planned integration points
**** ShapeEntityItem
**** RenderableShapeEntityItem
**** ShapeFactory
* Suggested Review Order:
** 4f22883
** 893ffa1

The approach here is to determine and retain the most appropriate ShapeType to associate with a <code>RenderableShapeEntityItem</code> instance so that information is available when the physics are initialized for the instance.  When the physics are set up for the instance, the correct hash key and bullet shape should be created based on this information.  This will also allow any other systems querying the info from <code>getShapeType()</code> to have the correct data dispersed to it.

The <code>computeShapeInfo</code> function appears to be the appropriate place to determine <code>ShapeType</code> as it's a prerequisite of the physics initialization process.  <code>RenderableShapeEntityItem</code> overrides <code>computeShapeInfo</code>.   This specified version will determine its <code>ShapeType</code> if needed, prior to setting up the <code>ShapeInfo</code>.  The <code>ShapeType</code> will be determined by a helper function added to the <code>ShapeFactory</code> which is responsible for creating the appropriate bullet collision shape objects for the instances of shapes.