### PR TITLE
Script getmeshes for models

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -23,6 +23,7 @@
 #include <PerfStat.h>
 #include <render/Scene.h>
 #include <DependencyManager.h>
+#include <shared/QtHelpers.h>
 
 #include "EntityTreeRenderer.h"
 #include "EntitiesRendererLogging.h"
@@ -1287,5 +1288,6 @@ bool RenderableModelEntityItem::getMeshes(MeshProxyList& result) {
     if (!_model || !_model->isLoaded()) {
         return false;
     }
-    return _model->getMeshes(result);
+    BLOCKING_INVOKE_METHOD(_model.get(), "getMeshes", Q_RETURN_ARG(MeshProxyList, result));
+    return !result.isEmpty();
 }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1282,3 +1282,10 @@ void RenderableModelEntityItem::mapJoints(const QStringList& modelJointNames) {
         }
     }
 }
+
+bool RenderableModelEntityItem::getMeshes(MeshProxyList& result) {
+    if (!_model || !_model->isLoaded()) {
+        return false;
+    }
+    return _model->getMeshes(result);
+}

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -116,6 +116,8 @@ public:
         return _animation;
     }
 
+    bool getMeshes(MeshProxyList& result) override;
+
 private:
     QVariantMap parseTexturesToMap(QString textures);
     void remapTextures();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1663,6 +1663,7 @@ bool RenderablePolyVoxEntityItem::getMeshes(MeshProxyList& result) {
             // the mesh will be in voxel-space.  transform it into object-space
             meshProxy = new SimpleMeshProxy(
                 _mesh->map([=](glm::vec3 position){ return glm::vec3(transform * glm::vec4(position, 1.0f)); },
+                           [=](glm::vec3 color){ return color; },
                            [=](glm::vec3 normal){ return glm::normalize(glm::vec3(transform * glm::vec4(normal, 0.0f))); },
                            [&](uint32_t index){ return index; }));
             result << meshProxy;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1738,7 +1738,7 @@ glm::mat4 EntityScriptingInterface::getEntityTransform(const QUuid& entityID) {
                 glm::mat4 rotation = glm::mat4_cast(entity->getRotation());
                 glm::mat4 registration = glm::translate(ENTITY_ITEM_DEFAULT_REGISTRATION_POINT -
                                                         entity->getRegistrationPoint());
-                result = translation * rotation * registration;
+                result = translation * rotation /* * registration */;
             }
         });
     }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1736,9 +1736,7 @@ glm::mat4 EntityScriptingInterface::getEntityTransform(const QUuid& entityID) {
             if (entity) {
                 glm::mat4 translation = glm::translate(entity->getPosition());
                 glm::mat4 rotation = glm::mat4_cast(entity->getRotation());
-                glm::mat4 registration = glm::translate(ENTITY_ITEM_DEFAULT_REGISTRATION_POINT -
-                                                        entity->getRegistrationPoint());
-                result = translation * rotation /* * registration */;
+                result = translation * rotation;
             }
         });
     }
@@ -1753,9 +1751,7 @@ glm::mat4 EntityScriptingInterface::getEntityLocalTransform(const QUuid& entityI
             if (entity) {
                 glm::mat4 translation = glm::translate(entity->getLocalPosition());
                 glm::mat4 rotation = glm::mat4_cast(entity->getLocalOrientation());
-                glm::mat4 registration = glm::translate(ENTITY_ITEM_DEFAULT_REGISTRATION_POINT -
-                                                        entity->getRegistrationPoint());
-                result = translation * rotation * registration;
+                result = translation * rotation;
             }
         });
     }

--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -118,7 +118,7 @@ glm::vec3 OBJTokenizer::getVec3() {
     auto z = getFloat();
     auto v = glm::vec3(x, y, z);
     while (isNextTokenFloat()) {
-        // the spec(s) get(s) vague here.  might be w, might be a color... chop it off.
+        // ignore any following floats
         nextToken();
     }
     return v;
@@ -130,6 +130,7 @@ bool OBJTokenizer::getVertex(glm::vec3& vertex, glm::vec3& vertexColor) {
     auto y = getFloat(); // And order of arguments is different on Windows/Linux.
     auto z = getFloat();
     vertex = glm::vec3(x, y, z);
+    vertexColor = glm::vec3(1.0f); // default, in case there is not color information
 
     auto r = 1.0f, g = 1.0f, b = 1.0f;
     bool hasVertexColor = false;
@@ -139,7 +140,7 @@ bool OBJTokenizer::getVertex(glm::vec3& vertex, glm::vec3& vertexColor) {
         // only a single value) that it's a vertex color.
         r = getFloat();
         if (isNextTokenFloat()) {
-            // Safe to assume the following values are the green/blue components. 
+            // Safe to assume the following values are the green/blue components.
             g = getFloat();
             b = getFloat();
 
@@ -351,6 +352,8 @@ bool OBJReader::parseOBJGroup(OBJTokenizer& tokenizer, const QVariantHash& mappi
     bool result = true;
     int originalFaceCountForDebugging = 0;
     QString currentGroup;
+    bool anyVertexColor { false };
+    int vertexCount { 0 };
 
     setMeshPartDefaults(meshPart, QString("dontknow") + QString::number(mesh.parts.count()));
 
@@ -416,10 +419,20 @@ bool OBJReader::parseOBJGroup(OBJTokenizer& tokenizer, const QVariantHash& mappi
 
             bool hasVertexColor = tokenizer.getVertex(vertex, vertexColor);
             vertices.append(vertex);
-            
-            if(hasVertexColor) {
+
+            // if any vertex has color, they all need to.
+            if (hasVertexColor && !anyVertexColor) {
+                // we've had a gap of zero or more vertices without color, followed
+                // by one that has color.  catch up:
+                for (int i = 0; i < vertexCount; i++) {
+                    vertexColors.append(glm::vec3(1.0f));
+                }
+                anyVertexColor = true;
+            }
+            if (anyVertexColor) {
                 vertexColors.append(vertexColor);
             }
+            vertexCount++;
         } else if (token == "vn") {
             normals.append(tokenizer.getVec3());
         } else if (token == "vt") {

--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -130,7 +130,6 @@ bool OBJTokenizer::getVertex(glm::vec3& vertex, glm::vec3& vertexColor) {
     auto y = getFloat(); // And order of arguments is different on Windows/Linux.
     auto z = getFloat();
     vertex = glm::vec3(x, y, z);
-    vertexColor = glm::vec3(1.0f); // default, in case there is not color information
 
     auto r = 1.0f, g = 1.0f, b = 1.0f;
     bool hasVertexColor = false;
@@ -415,7 +414,8 @@ bool OBJReader::parseOBJGroup(OBJTokenizer& tokenizer, const QVariantHash& mappi
                 #endif
             }
         } else if (token == "v") {
-            glm::vec3 vertex, vertexColor;
+            glm::vec3 vertex;
+            glm::vec3 vertexColor { glm::vec3(1.0f) };
 
             bool hasVertexColor = tokenizer.getVertex(vertex, vertexColor);
             vertices.append(vertex);

--- a/libraries/gpu/src/gpu/Buffer.h
+++ b/libraries/gpu/src/gpu/Buffer.h
@@ -192,7 +192,7 @@ public:
     BufferView(const BufferPointer& buffer, Size offset, Size size, const Element& element = DEFAULT_ELEMENT);
     BufferView(const BufferPointer& buffer, Size offset, Size size, uint16 stride, const Element& element = DEFAULT_ELEMENT);
 
-    Size getNumElements() const { return (_size - _offset) / _stride; }
+    Size getNumElements() const { return _size / _stride; }
 
     //Template iterator with random access on the buffer sysmem
     template<typename T>

--- a/libraries/model/src/model/Geometry.cpp
+++ b/libraries/model/src/model/Geometry.cpp
@@ -11,8 +11,6 @@
 
 #include "Geometry.h"
 
-#include <QDebug>
-
 using namespace model;
 
 Mesh::Mesh() :
@@ -136,11 +134,13 @@ Box Mesh::evalPartsBound(int partStart, int partEnd) const {
 
 
 model::MeshPointer Mesh::map(std::function<glm::vec3(glm::vec3)> vertexFunc,
+                             std::function<glm::vec3(glm::vec3)> colorFunc,
                              std::function<glm::vec3(glm::vec3)> normalFunc,
                              std::function<uint32_t(uint32_t)> indexFunc) const {
     // vertex data
     const gpu::BufferView& vertexBufferView = getVertexBuffer();
     gpu::BufferView::Index numVertices = (gpu::BufferView::Index)getNumVertices();
+
     gpu::Resource::Size vertexSize = numVertices * sizeof(glm::vec3);
     unsigned char* resultVertexData = new unsigned char[vertexSize];
     unsigned char* vertexDataCursor = resultVertexData;
@@ -149,6 +149,23 @@ model::MeshPointer Mesh::map(std::function<glm::vec3(glm::vec3)> vertexFunc,
         glm::vec3 pos = vertexFunc(vertexBufferView.get<glm::vec3>(i));
         memcpy(vertexDataCursor, &pos, sizeof(pos));
         vertexDataCursor += sizeof(pos);
+    }
+
+    // color data
+    // static const gpu::Element COLOR_ELEMENT { gpu::VEC4, gpu::NUINT8, gpu::RGBA };
+    // int attributeTypeColor = gpu::Stream::InputSlot::COLOR; // libraries/gpu/src/gpu/Stream.h
+    int attributeTypeColor = gpu::Stream::COLOR;
+    const gpu::BufferView& colorsBufferView = getAttributeBuffer(attributeTypeColor);
+    gpu::BufferView::Index numColors = (gpu::BufferView::Index)colorsBufferView.getNumElements();
+
+    gpu::Resource::Size colorSize = numColors * sizeof(glm::vec3);
+    unsigned char* resultColorData = new unsigned char[colorSize];
+    unsigned char* colorDataCursor = resultColorData;
+
+    for (gpu::BufferView::Index i = 0; i < numColors; i++) {
+        glm::vec3 color = colorFunc(colorsBufferView.get<glm::vec3>(i));
+        memcpy(colorDataCursor, &color, sizeof(color));
+        colorDataCursor += sizeof(color);
     }
 
     // normal data
@@ -187,6 +204,12 @@ model::MeshPointer Mesh::map(std::function<glm::vec3(glm::vec3)> vertexFunc,
     gpu::BufferView resultVertexBufferView(resultVertexBufferPointer, vertexElement);
     result->setVertexBuffer(resultVertexBufferView);
 
+    gpu::Element colorElement = gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ);
+    gpu::Buffer* resultColorsBuffer = new gpu::Buffer(colorSize, resultColorData);
+    gpu::BufferPointer resultColorsBufferPointer(resultColorsBuffer);
+    gpu::BufferView resultColorsBufferView(resultColorsBufferPointer, colorElement);
+    result->addAttribute(attributeTypeColor, resultColorsBufferView);
+
     gpu::Element normalElement = gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ);
     gpu::Buffer* resultNormalsBuffer = new gpu::Buffer(normalSize, resultNormalData);
     gpu::BufferPointer resultNormalsBufferPointer(resultNormalsBuffer);
@@ -215,6 +238,7 @@ model::MeshPointer Mesh::map(std::function<glm::vec3(glm::vec3)> vertexFunc,
 
 
 void Mesh::forEach(std::function<void(glm::vec3)> vertexFunc,
+                   std::function<void(glm::vec3)> colorFunc,
                    std::function<void(glm::vec3)> normalFunc,
                    std::function<void(uint32_t)> indexFunc) {
     // vertex data
@@ -222,6 +246,15 @@ void Mesh::forEach(std::function<void(glm::vec3)> vertexFunc,
     gpu::BufferView::Index numVertices = (gpu::BufferView::Index)getNumVertices();
     for (gpu::BufferView::Index i = 0; i < numVertices; i++) {
         vertexFunc(vertexBufferView.get<glm::vec3>(i));
+    }
+
+    // color data
+    int attributeTypeColor = gpu::Stream::InputSlot::COLOR; // libraries/gpu/src/gpu/Stream.h
+    // int attributeTypeColor = gpu::Stream::COLOR;
+    const gpu::BufferView& colorsBufferView = getAttributeBuffer(attributeTypeColor);
+    gpu::BufferView::Index numColors =  (gpu::BufferView::Index)colorsBufferView.getNumElements();
+    for (gpu::BufferView::Index i = 0; i < numColors; i++) {
+        colorFunc(colorsBufferView.get<glm::vec3>(i));
     }
 
     // normal data

--- a/libraries/model/src/model/Geometry.cpp
+++ b/libraries/model/src/model/Geometry.cpp
@@ -152,8 +152,6 @@ model::MeshPointer Mesh::map(std::function<glm::vec3(glm::vec3)> vertexFunc,
     }
 
     // color data
-    // static const gpu::Element COLOR_ELEMENT { gpu::VEC4, gpu::NUINT8, gpu::RGBA };
-    // int attributeTypeColor = gpu::Stream::InputSlot::COLOR; // libraries/gpu/src/gpu/Stream.h
     int attributeTypeColor = gpu::Stream::COLOR;
     const gpu::BufferView& colorsBufferView = getAttributeBuffer(attributeTypeColor);
     gpu::BufferView::Index numColors = (gpu::BufferView::Index)colorsBufferView.getNumElements();
@@ -250,7 +248,6 @@ void Mesh::forEach(std::function<void(glm::vec3)> vertexFunc,
 
     // color data
     int attributeTypeColor = gpu::Stream::InputSlot::COLOR; // libraries/gpu/src/gpu/Stream.h
-    // int attributeTypeColor = gpu::Stream::COLOR;
     const gpu::BufferView& colorsBufferView = getAttributeBuffer(attributeTypeColor);
     gpu::BufferView::Index numColors =  (gpu::BufferView::Index)colorsBufferView.getNumElements();
     for (gpu::BufferView::Index i = 0; i < numColors; i++) {

--- a/libraries/model/src/model/Geometry.cpp
+++ b/libraries/model/src/model/Geometry.cpp
@@ -137,7 +137,7 @@ Box Mesh::evalPartsBound(int partStart, int partEnd) const {
 
 model::MeshPointer Mesh::map(std::function<glm::vec3(glm::vec3)> vertexFunc,
                              std::function<glm::vec3(glm::vec3)> normalFunc,
-                             std::function<uint32_t(uint32_t)> indexFunc) {
+                             std::function<uint32_t(uint32_t)> indexFunc) const {
     // vertex data
     const gpu::BufferView& vertexBufferView = getVertexBuffer();
     gpu::BufferView::Index numVertices = (gpu::BufferView::Index)getNumVertices();

--- a/libraries/model/src/model/Geometry.h
+++ b/libraries/model/src/model/Geometry.h
@@ -124,7 +124,7 @@ public:
     // create a copy of this mesh after passing its vertices, normals, and indexes though the provided functions
     MeshPointer map(std::function<glm::vec3(glm::vec3)> vertexFunc,
                     std::function<glm::vec3(glm::vec3)> normalFunc,
-                    std::function<uint32_t(uint32_t)> indexFunc);
+                    std::function<uint32_t(uint32_t)> indexFunc) const;
 
     void forEach(std::function<void(glm::vec3)> vertexFunc,
                  std::function<void(glm::vec3)> normalFunc,

--- a/libraries/model/src/model/Geometry.h
+++ b/libraries/model/src/model/Geometry.h
@@ -123,10 +123,12 @@ public:
 
     // create a copy of this mesh after passing its vertices, normals, and indexes though the provided functions
     MeshPointer map(std::function<glm::vec3(glm::vec3)> vertexFunc,
+                    std::function<glm::vec3(glm::vec3)> colorFunc,
                     std::function<glm::vec3(glm::vec3)> normalFunc,
                     std::function<uint32_t(uint32_t)> indexFunc) const;
 
     void forEach(std::function<void(glm::vec3)> vertexFunc,
+                 std::function<void(glm::vec3)> colorFunc,
                  std::function<void(glm::vec3)> normalFunc,
                  std::function<void(uint32_t)> indexFunc);
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -463,7 +463,7 @@ bool Model::convexHullContains(glm::vec3 point) {
     return false;
 }
 
-MeshProxyList Model::getMeshes() {
+MeshProxyList Model::getMeshes() const {
     MeshProxyList result;
     const Geometry::Pointer& renderGeometry = getGeometry();
     const Geometry::GeometryMeshes& meshes = renderGeometry->getMeshes();

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -463,12 +463,13 @@ bool Model::convexHullContains(glm::vec3 point) {
     return false;
 }
 
-bool Model::getMeshes(MeshProxyList& result) {
+MeshProxyList Model::getMeshes() {
+    MeshProxyList result;
     const Geometry::Pointer& renderGeometry = getGeometry();
     const Geometry::GeometryMeshes& meshes = renderGeometry->getMeshes();
 
     if (!isLoaded()) {
-        return false;
+        return result;
     }
 
     Transform offset;
@@ -490,7 +491,7 @@ bool Model::getMeshes(MeshProxyList& result) {
         result << meshProxy;
     }
 
-    return true;
+    return result;
 }
 
 void Model::calculateTriangleSets() {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -473,10 +473,15 @@ bool Model::getMeshes(MeshProxyList& result) {
 
     Transform offset;
     offset.setScale(_scale);
-    // not set -- far to the right
-    // offset.postTranslate(_offset); // far to right
-    // offset.postTranslate(-_offset); // a bit to left
+    // offset.postTranslate(_offset);
     glm::mat4 offsetMat = offset.getMatrix();
+
+    Extents modelExtents = getUnscaledMeshExtents();
+    glm::vec3 dimensions = modelExtents.maximum - modelExtents.minimum;
+
+    const glm::vec3 DEFAULT_ENTITY_REGISTRATION_POINT = glm::vec3(0.5f, 0.5f, 0.5f);
+    glm::vec3 regis = (DEFAULT_ENTITY_REGISTRATION_POINT - _registrationPoint);
+    glm::vec3 regisOffset = dimensions * regis;
 
     for (std::shared_ptr<const model::Mesh> mesh : meshes) {
         if (!mesh) {
@@ -485,9 +490,7 @@ bool Model::getMeshes(MeshProxyList& result) {
 
         MeshProxy* meshProxy = new SimpleMeshProxy(
             mesh->map([=](glm::vec3 position) {
-                const glm::vec3 DEFAULT_ENTITY_REGISTRATION_POINT = glm::vec3(0.5f, 0.5f, 0.5f);
-                glm::vec3 regis = _registrationPoint - DEFAULT_ENTITY_REGISTRATION_POINT;
-                return glm::vec3(offsetMat * glm::vec4(position + _offset, 1.0f)) + regis; // very close
+                return glm::vec3(offsetMat * glm::vec4(position, 1.0f));
             },
             [=](glm::vec3 normal){ return glm::normalize(glm::vec3(offsetMat * glm::vec4(normal, 0.0f))); },
             [&](uint32_t index){ return index; }));

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -483,11 +483,13 @@ MeshProxyList Model::getMeshes() {
         }
 
         MeshProxy* meshProxy = new SimpleMeshProxy(
-            mesh->map([=](glm::vec3 position) {
-                return glm::vec3(offsetMat * glm::vec4(position, 1.0f));
-            },
-            [=](glm::vec3 normal){ return glm::normalize(glm::vec3(offsetMat * glm::vec4(normal, 0.0f))); },
-            [&](uint32_t index){ return index; }));
+            mesh->map(
+                [=](glm::vec3 position) {
+                    return glm::vec3(offsetMat * glm::vec4(position, 1.0f));
+                },
+                [=](glm::vec3 color) { return color; },
+                [=](glm::vec3 normal) { return glm::normalize(glm::vec3(offsetMat * glm::vec4(normal, 0.0f))); },
+                [&](uint32_t index) { return index; }));
         result << meshProxy;
     }
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -473,15 +473,8 @@ bool Model::getMeshes(MeshProxyList& result) {
 
     Transform offset;
     offset.setScale(_scale);
-    // offset.postTranslate(_offset);
+    offset.postTranslate(_offset);
     glm::mat4 offsetMat = offset.getMatrix();
-
-    Extents modelExtents = getUnscaledMeshExtents();
-    glm::vec3 dimensions = modelExtents.maximum - modelExtents.minimum;
-
-    const glm::vec3 DEFAULT_ENTITY_REGISTRATION_POINT = glm::vec3(0.5f, 0.5f, 0.5f);
-    glm::vec3 regis = (DEFAULT_ENTITY_REGISTRATION_POINT - _registrationPoint);
-    glm::vec3 regisOffset = dimensions * regis;
 
     for (std::shared_ptr<const model::Mesh> mesh : meshes) {
         if (!mesh) {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -488,7 +488,9 @@ MeshProxyList Model::getMeshes() {
                     return glm::vec3(offsetMat * glm::vec4(position, 1.0f));
                 },
                 [=](glm::vec3 color) { return color; },
-                [=](glm::vec3 normal) { return glm::normalize(glm::vec3(offsetMat * glm::vec4(normal, 0.0f))); },
+                [=](glm::vec3 normal) {
+                    return glm::normalize(glm::vec3(offsetMat * glm::vec4(normal, 0.0f)));
+                },
                 [&](uint32_t index) { return index; }));
         result << meshProxy;
     }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -257,7 +257,7 @@ public:
     int getResourceDownloadAttempts() { return _renderWatcher.getResourceDownloadAttempts(); }
     int getResourceDownloadAttemptsRemaining() { return _renderWatcher.getResourceDownloadAttemptsRemaining(); }
 
-    bool getMeshes(MeshProxyList& result);
+    Q_INVOKABLE MeshProxyList getMeshes();
 
 public slots:
     void loadURLFinished(bool success);

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -257,7 +257,7 @@ public:
     int getResourceDownloadAttempts() { return _renderWatcher.getResourceDownloadAttempts(); }
     int getResourceDownloadAttemptsRemaining() { return _renderWatcher.getResourceDownloadAttemptsRemaining(); }
 
-    Q_INVOKABLE MeshProxyList getMeshes();
+    Q_INVOKABLE MeshProxyList getMeshes() const;
 
 public slots:
     void loadURLFinished(bool success);

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -257,6 +257,8 @@ public:
     int getResourceDownloadAttempts() { return _renderWatcher.getResourceDownloadAttempts(); }
     int getResourceDownloadAttemptsRemaining() { return _renderWatcher.getResourceDownloadAttemptsRemaining(); }
 
+    bool getMeshes(MeshProxyList& result);
+
 public slots:
     void loadURLFinished(bool success);
 

--- a/libraries/script-engine/src/ModelScriptingInterface.cpp
+++ b/libraries/script-engine/src/ModelScriptingInterface.cpp
@@ -138,6 +138,41 @@ QScriptValue ModelScriptingInterface::transformMesh(glm::mat4 transform, MeshPro
     return meshToScriptValue(_modelScriptEngine, resultProxy);
 }
 
+QScriptValue ModelScriptingInterface::getVertexCount(MeshProxy* meshProxy) {
+    if (!meshProxy) {
+        return QScriptValue(false);
+    }
+    MeshPointer mesh = meshProxy->getMeshPointer();
+    if (!mesh) {
+        return QScriptValue(false);
+    }
+
+    gpu::BufferView::Index numVertices = (gpu::BufferView::Index)mesh->getNumVertices();
+
+    return numVertices;
+}
+
+QScriptValue ModelScriptingInterface::getVertex(MeshProxy* meshProxy, int vertexIndex) {
+    if (!meshProxy) {
+        return QScriptValue(false);
+    }
+    MeshPointer mesh = meshProxy->getMeshPointer();
+    if (!mesh) {
+        return QScriptValue(false);
+    }
+
+    const gpu::BufferView& vertexBufferView = mesh->getVertexBuffer();
+    gpu::BufferView::Index numVertices = (gpu::BufferView::Index)mesh->getNumVertices();
+
+    if (vertexIndex < 0 || vertexIndex >= numVertices) {
+        return QScriptValue(false);
+    }
+
+    glm::vec3 pos = vertexBufferView.get<glm::vec3>(vertexIndex);
+    return vec3toScriptValue(_modelScriptEngine, pos);
+}
+
+
 QScriptValue ModelScriptingInterface::newMesh(const QVector<glm::vec3>& vertices,
                                               const QVector<glm::vec3>& normals,
                                               const QVector<MeshFace>& faces) {

--- a/libraries/script-engine/src/ModelScriptingInterface.cpp
+++ b/libraries/script-engine/src/ModelScriptingInterface.cpp
@@ -38,16 +38,22 @@ QString ModelScriptingInterface::meshToOBJ(MeshProxyList in) {
 QScriptValue ModelScriptingInterface::appendMeshes(MeshProxyList in) {
     // figure out the size of the resulting mesh
     size_t totalVertexCount { 0 };
-    size_t totalAttributeCount { 0 };
+    size_t totalColorCount { 0 };
+    size_t totalNormalCount { 0 };
     size_t totalIndexCount { 0 };
     foreach (const MeshProxy* meshProxy, in) {
         MeshPointer mesh = meshProxy->getMeshPointer();
         totalVertexCount += mesh->getNumVertices();
 
+        int attributeTypeColor = gpu::Stream::InputSlot::COLOR; // libraries/gpu/src/gpu/Stream.h
+        const gpu::BufferView& colorsBufferView = mesh->getAttributeBuffer(attributeTypeColor);
+        gpu::BufferView::Index numColors = (gpu::BufferView::Index)colorsBufferView.getNumElements();
+        totalColorCount += numColors;
+
         int attributeTypeNormal = gpu::Stream::InputSlot::NORMAL; // libraries/gpu/src/gpu/Stream.h
         const gpu::BufferView& normalsBufferView = mesh->getAttributeBuffer(attributeTypeNormal);
         gpu::BufferView::Index numNormals = (gpu::BufferView::Index)normalsBufferView.getNumElements();
-        totalAttributeCount += numNormals;
+        totalNormalCount += numNormals;
 
         totalIndexCount += mesh->getNumIndices();
     }
@@ -57,7 +63,11 @@ QScriptValue ModelScriptingInterface::appendMeshes(MeshProxyList in) {
     unsigned char* combinedVertexData  = new unsigned char[combinedVertexSize];
     unsigned char* combinedVertexDataCursor = combinedVertexData;
 
-    gpu::Resource::Size combinedNormalSize = totalAttributeCount * sizeof(glm::vec3);
+    gpu::Resource::Size combinedColorSize = totalColorCount * sizeof(glm::vec3);
+    unsigned char* combinedColorData  = new unsigned char[combinedColorSize];
+    unsigned char* combinedColorDataCursor = combinedColorData;
+
+    gpu::Resource::Size combinedNormalSize = totalNormalCount * sizeof(glm::vec3);
     unsigned char* combinedNormalData  = new unsigned char[combinedNormalSize];
     unsigned char* combinedNormalDataCursor = combinedNormalData;
 
@@ -73,6 +83,10 @@ QScriptValue ModelScriptingInterface::appendMeshes(MeshProxyList in) {
             [&](glm::vec3 position){
                 memcpy(combinedVertexDataCursor, &position, sizeof(position));
                 combinedVertexDataCursor += sizeof(position);
+            },
+            [&](glm::vec3 color){
+                memcpy(combinedColorDataCursor, &color, sizeof(color));
+                combinedColorDataCursor += sizeof(color);
             },
             [&](glm::vec3 normal){
                 memcpy(combinedNormalDataCursor, &normal, sizeof(normal));
@@ -95,6 +109,13 @@ QScriptValue ModelScriptingInterface::appendMeshes(MeshProxyList in) {
     gpu::BufferPointer combinedVertexBufferPointer(combinedVertexBuffer);
     gpu::BufferView combinedVertexBufferView(combinedVertexBufferPointer, vertexElement);
     result->setVertexBuffer(combinedVertexBufferView);
+
+    int attributeTypeColor = gpu::Stream::InputSlot::COLOR; // libraries/gpu/src/gpu/Stream.h
+    gpu::Element colorElement = gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ);
+    gpu::Buffer* combinedColorsBuffer = new gpu::Buffer(combinedColorSize, combinedColorData);
+    gpu::BufferPointer combinedColorsBufferPointer(combinedColorsBuffer);
+    gpu::BufferView combinedColorsBufferView(combinedColorsBufferPointer, colorElement);
+    result->addAttribute(attributeTypeColor, combinedColorsBufferView);
 
     int attributeTypeNormal = gpu::Stream::InputSlot::NORMAL; // libraries/gpu/src/gpu/Stream.h
     gpu::Element normalElement = gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ);
@@ -132,6 +153,7 @@ QScriptValue ModelScriptingInterface::transformMesh(glm::mat4 transform, MeshPro
     }
 
     model::MeshPointer result = mesh->map([&](glm::vec3 position){ return glm::vec3(transform * glm::vec4(position, 1.0f)); },
+                                          [&](glm::vec3 color){ return color; },
                                           [&](glm::vec3 normal){ return glm::vec3(transform * glm::vec4(normal, 0.0f)); },
                                           [&](uint32_t index){ return index; });
     MeshProxy* resultProxy = new SimpleMeshProxy(result);

--- a/libraries/script-engine/src/ModelScriptingInterface.h
+++ b/libraries/script-engine/src/ModelScriptingInterface.h
@@ -29,6 +29,8 @@ public:
     Q_INVOKABLE QScriptValue newMesh(const QVector<glm::vec3>& vertices,
                                      const QVector<glm::vec3>& normals,
                                      const QVector<MeshFace>& faces);
+    Q_INVOKABLE QScriptValue getVertexCount(MeshProxy* meshProxy);
+    Q_INVOKABLE QScriptValue getVertex(MeshProxy* meshProxy, int vertexIndex);
 
 private:
     QScriptEngine* _modelScriptEngine { nullptr };

--- a/tools/atp-client/src/ATPClientApp.cpp
+++ b/tools/atp-client/src/ATPClientApp.cpp
@@ -23,6 +23,7 @@
 #include <DependencyManager.h>
 #include <SettingHandle.h>
 #include <AssetUpload.h>
+#include <StatTracker.h>
 
 #include "ATPClientApp.h"
 
@@ -137,6 +138,7 @@ ATPClientApp::ATPClientApp(int argc, char* argv[]) :
     Setting::init();
     DependencyManager::registerInheritance<LimitedNodeList, NodeList>();
 
+    DependencyManager::set<StatTracker>();
     DependencyManager::set<AccountManager>([&]{ return QString(HIGH_FIDELITY_ATP_CLIENT_USER_AGENT); });
     DependencyManager::set<AddressManager>();
     DependencyManager::set<NodeList>(NodeType::Agent, _listenPort);


### PR DESCRIPTION
- vertex-color support for OBJ writer
- OBJ reader is now resilient against some vertices having colors while others don't
- EntityScriptingInterface::getMeshes support for model entities
- fix a bug in BufferView::getNumElements when the buffer-view has a non-zero offset
- vertex color support for ModelScriptingInterface
- new js calls in ModelScriptingInterface: getVertexCount and getVertex
