### PR TITLE
WL 21453 - Add a "Dominant Hand" setting

### DIFF
--- a/interface/resources/qml/controls-uit/RadioButton.qml
+++ b/interface/resources/qml/controls-uit/RadioButton.qml
@@ -32,7 +32,7 @@ Original.RadioButton {
             id: box
             width: boxSize
             height: boxSize
-            radius: boxRadius
+            radius: 7
             gradient: Gradient {
                 GradientStop {
                     position: 0.2
@@ -52,7 +52,7 @@ Original.RadioButton {
                 id: check
                 width: checkSize
                 height: checkSize
-                radius: checkRadius
+                radius: 7
                 anchors.centerIn: parent
                 color: hifi.colors.checkBoxChecked
                 border.width: 1

--- a/interface/resources/qml/controls-uit/RadioButton.qml
+++ b/interface/resources/qml/controls-uit/RadioButton.qml
@@ -54,9 +54,9 @@ Original.RadioButton {
                 height: checkSize
                 radius: 7
                 anchors.centerIn: parent
-                color: hifi.colors.checkBoxChecked
+                color: "#00B4EF"
                 border.width: 1
-                border.color: hifi.colors.checkBoxCheckedBorder
+                border.color: "#36CDFF"
                 visible: checked && !pressed || !checked && pressed
             }
         }

--- a/interface/resources/qml/controls-uit/RadioButton.qml
+++ b/interface/resources/qml/controls-uit/RadioButton.qml
@@ -1,0 +1,71 @@
+//
+//  RadioButton.qml
+//
+//  Created by Cain Kilgore on 20th July 2017
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import QtQuick 2.5
+import QtQuick.Controls 1.4 as Original
+import QtQuick.Controls.Styles 1.4
+
+import "../styles-uit"
+import "../controls-uit" as HifiControls
+
+Original.RadioButton {
+    id: radioButton
+    HifiConstants { id: hifi }
+
+    property int colorScheme: hifi.colorSchemes.light
+    readonly property bool isLightColorScheme: colorScheme == hifi.colorSchemes.light
+
+    readonly property int boxSize: 14
+    readonly property int boxRadius: 3
+    readonly property int checkSize: 10
+    readonly property int checkRadius: 2
+
+    style: RadioButtonStyle {
+        indicator: Rectangle {
+            id: box
+            width: boxSize
+            height: boxSize
+            radius: boxRadius
+            gradient: Gradient {
+                GradientStop {
+                    position: 0.2
+                    color: pressed || hovered
+                           ? (radioButton.isLightColorScheme ? hifi.colors.checkboxDarkStart : hifi.colors.checkboxLightStart)
+                           : (radioButton.isLightColorScheme ? hifi.colors.checkboxLightStart : hifi.colors.checkboxDarkStart)
+                }
+                GradientStop {
+                    position: 1.0
+                    color: pressed || hovered
+                           ? (radioButton.isLightColorScheme ? hifi.colors.checkboxDarkFinish : hifi.colors.checkboxLightFinish)
+                           : (radioButton.isLightColorScheme ? hifi.colors.checkboxLightFinish : hifi.colors.checkboxDarkFinish)
+                }
+            }
+
+            Rectangle {
+                id: check
+                width: checkSize
+                height: checkSize
+                radius: checkRadius
+                anchors.centerIn: parent
+                color: hifi.colors.checkBoxChecked
+                border.width: 1
+                border.color: hifi.colors.checkBoxCheckedBorder
+                visible: checked && !pressed || !checked && pressed
+            }
+        }
+
+        label: RalewaySemiBold {
+            text: control.text
+            size: hifi.fontSizes.inputLabel
+            color: isLightColorScheme ? hifi.colors.lightGray : hifi.colors.lightGrayText
+            x: radioButton.boxSize / 2
+        }
+    }
+}

--- a/interface/resources/qml/controls/RadioButton.qml
+++ b/interface/resources/qml/controls/RadioButton.qml
@@ -1,0 +1,17 @@
+import QtQuick.Controls 1.3 as Original
+import QtQuick.Controls.Styles 1.3
+import "../styles"
+import "."
+Original.RadioButton {
+    text: "Radio Button"
+    style: RadioButtonStyle {
+        indicator: FontAwesome {
+            text: control.checked ? "\uf046" : "\uf096"
+        }
+        label: Text {
+            text: control.text
+            renderType: Text.QtRendering
+        }
+    }
+
+}

--- a/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
@@ -28,7 +28,6 @@ Preference {
     }
 
     function save() {
-        // Box1 = True, Box2 = False (Right Hand for Default)
         if (box1.checked && !box2.checked) {
             preference.value = "left";
         }

--- a/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
@@ -20,7 +20,7 @@ Preference {
     height: control.height + hifi.dimensions.controlInterlineHeight
 
     Component.onCompleted: {
-        if(preference.value) {
+        if (preference.value) {
             box1.checked = true;
         } else {
             box2.checked = true;
@@ -28,13 +28,13 @@ Preference {
     }
 
     function save() {
-		// Box1 = True, Box2 = False (Right Hand for Default)
-		if(box1.checked && !box2.checked) {
-			preference.value = true;
-		}
-		if(!box1.checked && box2.checked) {
-			preference.value = false;
-		}
+        // Box1 = True, Box2 = False (Right Hand for Default)
+        if (box1.checked && !box2.checked) {
+            preference.value = true;
+        }
+        if (!box1.checked && box2.checked) {
+            preference.value = false;
+        }
         preference.save();
     }
 
@@ -70,10 +70,10 @@ Preference {
                 verticalCenter: parent.verticalCenter
             }
             onClicked: {
-                if(box2.checked) {
+                if (box2.checked) {
                     box2.checked = false;
                 }
-                if(!box1.checked && !box2.checked) {
+                if (!box1.checked && !box2.checked) {
                     box2.checked = true;
                 }
             }

--- a/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
@@ -89,10 +89,10 @@ Preference {
                 verticalCenter: parent.verticalCenter
             }
             onClicked: {
-                if(box1.checked) {
+                if (box1.checked) {
                     box1.checked = false;
                 }
-                if(!box1.checked && !box2.checked) {
+                if (!box1.checked && !box2.checked) {
                     box2.checked = true;
                 }
             }

--- a/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
@@ -1,0 +1,102 @@
+//
+//  PrimaryHandPreference.qml
+//
+//  Created by Cain Kilgore on 20th July 2017
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import QtQuick 2.5
+
+import "../../controls-uit"
+
+Preference {
+    id: root
+    property alias box1: box1
+    property alias box2: box2
+    
+    height: control.height + hifi.dimensions.controlInterlineHeight
+
+    Component.onCompleted: {
+        if(preference.value) {
+            box1.checked = true;
+        } else {
+            box2.checked = true;
+        }
+    }
+
+    function save() {
+		// Box1 = True, Box2 = False (Right Hand for Default)
+		if(box1.checked && !box2.checked) {
+			preference.value = true;
+		}
+		if(!box1.checked && box2.checked) {
+			preference.value = false;
+		}
+        preference.save();
+    }
+
+    Item {
+        id: control
+        anchors {
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+        height: Math.max(labelName.height, box1.height, box2.height)
+
+        Label {
+            id: labelName
+            text: root.label + ":"
+            colorScheme: hifi.colorSchemes.dark
+            anchors {
+                left: parent.left
+                right: box1.left
+                rightMargin: hifi.dimensions.labelPadding
+                verticalCenter: parent.verticalCenter
+            }
+            horizontalAlignment: Text.AlignRight
+            wrapMode: Text.Wrap
+        }
+
+        RadioButton {
+            id: box1
+            text: "Left"
+            width: 60
+            anchors {
+                right: box2.left
+                verticalCenter: parent.verticalCenter
+            }
+            onClicked: {
+                if(box2.checked) {
+                    box2.checked = false;
+                }
+                if(!box1.checked && !box2.checked) {
+                    box2.checked = true;
+                }
+            }
+            colorScheme: hifi.colorSchemes.dark
+        }
+        
+        RadioButton {
+            id: box2
+            text: "Right"
+            width: 60
+            anchors {
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+            }
+            onClicked: {
+                if(box1.checked) {
+                    box1.checked = false;
+                }
+                if(!box1.checked && !box2.checked) {
+                    box2.checked = true;
+                }
+            }
+            colorScheme: hifi.colorSchemes.dark
+        }
+    }
+}

--- a/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
@@ -20,7 +20,7 @@ Preference {
     height: control.height + hifi.dimensions.controlInterlineHeight
 
     Component.onCompleted: {
-        if (preference.value) {
+        if (preference.value == "left") {
             box1.checked = true;
         } else {
             box2.checked = true;
@@ -30,10 +30,10 @@ Preference {
     function save() {
         // Box1 = True, Box2 = False (Right Hand for Default)
         if (box1.checked && !box2.checked) {
-            preference.value = true;
+            preference.value = "left";
         }
         if (!box1.checked && box2.checked) {
-            preference.value = false;
+            preference.value = "right";
         }
         preference.save();
     }

--- a/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/PrimaryHandPreference.qml
@@ -74,7 +74,7 @@ Preference {
                     box2.checked = false;
                 }
                 if (!box1.checked && !box2.checked) {
-                    box2.checked = true;
+                    box1.checked = true;
                 }
             }
             colorScheme: hifi.colorSchemes.dark

--- a/interface/resources/qml/dialogs/preferences/Section.qml
+++ b/interface/resources/qml/dialogs/preferences/Section.qml
@@ -73,7 +73,7 @@ Preference {
         property var buttonBuilder: Component { ButtonPreference { } }
         property var comboBoxBuilder: Component { ComboBoxPreference { } }
         property var spinnerSliderBuilder: Component { SpinnerSliderPreference { } }
-		property var primaryHandBuilder: Component { PrimaryHandPreference { } }
+        property var primaryHandBuilder: Component { PrimaryHandPreference { } }
         property var preferences: []
         property int checkBoxCount: 0
 
@@ -135,6 +135,7 @@ Preference {
                     checkBoxCount = 0;
                     builder = spinnerSliderBuilder;
                     break;
+                    
                 case Preference.PrimaryHand:
                     checkBoxCount++;
                     builder = primaryHandBuilder;

--- a/interface/resources/qml/dialogs/preferences/Section.qml
+++ b/interface/resources/qml/dialogs/preferences/Section.qml
@@ -73,6 +73,7 @@ Preference {
         property var buttonBuilder: Component { ButtonPreference { } }
         property var comboBoxBuilder: Component { ComboBoxPreference { } }
         property var spinnerSliderBuilder: Component { SpinnerSliderPreference { } }
+		property var primaryHandBuilder: Component { PrimaryHandPreference { } }
         property var preferences: []
         property int checkBoxCount: 0
 
@@ -133,6 +134,10 @@ Preference {
                 case Preference.SpinnerSlider:
                     checkBoxCount = 0;
                     builder = spinnerSliderBuilder;
+                    break;
+                case Preference.PrimaryHand:
+                    checkBoxCount++;
+                    builder = primaryHandBuilder;
                     break;
             };
 

--- a/interface/resources/qml/hifi/tablet/tabletWindows/preferences/Section.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/preferences/Section.qml
@@ -82,6 +82,7 @@ Preference {
         property var buttonBuilder: Component { ButtonPreference { } }
         property var comboBoxBuilder: Component { ComboBoxPreference { } }
         property var spinnerSliderBuilder: Component { SpinnerSliderPreference { } }
+        property var primaryHandBuilder: Component { PrimaryHandPreference { } }
         property var preferences: []
         property int checkBoxCount: 0
 
@@ -144,9 +145,15 @@ Preference {
                     //to be not overlapped when drop down is active
                     zpos = root.z + 1000 - itemNum
                     break;
+
                 case Preference.SpinnerSlider:
                     checkBoxCount = 0;
                     builder = spinnerSliderBuilder;
+                    break;
+
+                case Preference.PrimaryHand:
+                    checkBoxCount++;
+                    builder = primaryHandBuilder;
                     break;
             };
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -72,9 +72,6 @@ const float MIN_AVATAR_SPEED_SQUARED = MIN_AVATAR_SPEED * MIN_AVATAR_SPEED; // s
 const float YAW_SPEED_DEFAULT = 120.0f;   // degrees/sec
 const float PITCH_SPEED_DEFAULT = 90.0f; // degrees/sec
 
-const QString DOMINANT_HAND_LEFT = "left";
-const QString DOMINANT_HAND_RIGHT = "right";
-
 // TODO: normalize avatar speed for standard avatar size, then scale all motion logic
 // to properly follow avatar size.
 float MAX_AVATAR_SPEED = 30.0f;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -87,9 +87,6 @@ const float MyAvatar::ZOOM_MIN = 0.5f;
 const float MyAvatar::ZOOM_MAX = 25.0f;
 const float MyAvatar::ZOOM_DEFAULT = 1.5f;
 
-const QString& DOMINANT_LEFT_HAND = "left";
-const QString& DOMINANT_RIGHT_HAND = "right";
-
 // default values, used when avatar is missing joints... (avatar space)
 static const glm::quat DEFAULT_AVATAR_MIDDLE_EYE_ROT { Quaternions::Y_180 };
 static const glm::vec3 DEFAULT_AVATAR_MIDDLE_EYE_POS { 0.0f, 0.6f, 0.0f };
@@ -259,7 +256,7 @@ MyAvatar::~MyAvatar() {
 }
 
 void MyAvatar::setDominantHand(const QString& hand) {
-    if (hand == DOMINANT_HAND_LEFT || hand == DOMINANT_HAND_RIGHT) {
+    if (hand == DOMINANT_LEFT_HAND || hand == DOMINANT_RIGHT_HAND) {
         _dominantHand = hand;
     }
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -926,7 +926,7 @@ void MyAvatar::saveData() {
     Settings settings;
     settings.beginGroup("Avatar");
 
-    settings.setValue("useAlternativeHand", _useAlternativeHand);
+    settings.setValue("dominantHand", _dominantHand);
     settings.setValue("headPitch", getHead()->getBasePitch());
 
     settings.setValue("scale", _targetScale);
@@ -1123,7 +1123,7 @@ void MyAvatar::loadData() {
     setCollisionSoundURL(settings.value("collisionSoundURL", DEFAULT_AVATAR_COLLISION_SOUND_URL).toString());
     setSnapTurn(settings.value("useSnapTurn", _useSnapTurn).toBool());
     setClearOverlayWhenMoving(settings.value("clearOverlayWhenMoving", _clearOverlayWhenMoving).toBool());
-    setUseAlternativeHand(settings.value("useAlternativeHand", _useAlternativeHand).toBool());
+    setDominantHand(settings.value("dominantHand", _dominantHand).toString().toLower());
     settings.endGroup();
 
     setEnableMeshVisible(Menu::getInstance()->isOptionChecked(MenuOption::MeshVisible));

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -72,6 +72,9 @@ const float MIN_AVATAR_SPEED_SQUARED = MIN_AVATAR_SPEED * MIN_AVATAR_SPEED; // s
 const float YAW_SPEED_DEFAULT = 120.0f;   // degrees/sec
 const float PITCH_SPEED_DEFAULT = 90.0f; // degrees/sec
 
+const QString DOMINANT_HAND_LEFT = "left";
+const QString DOMINANT_HAND_RIGHT = "right";
+
 // TODO: normalize avatar speed for standard avatar size, then scale all motion logic
 // to properly follow avatar size.
 float MAX_AVATAR_SPEED = 30.0f;
@@ -86,6 +89,9 @@ const QString& DEFAULT_AVATAR_COLLISION_SOUND_URL = "https://hifi-public.s3.amaz
 const float MyAvatar::ZOOM_MIN = 0.5f;
 const float MyAvatar::ZOOM_MAX = 25.0f;
 const float MyAvatar::ZOOM_DEFAULT = 1.5f;
+
+const QString& DOMINANT_LEFT_HAND = "left";
+const QString& DOMINANT_RIGHT_HAND = "right";
 
 // default values, used when avatar is missing joints... (avatar space)
 static const glm::quat DEFAULT_AVATAR_MIDDLE_EYE_ROT { Quaternions::Y_180 };
@@ -253,6 +259,12 @@ MyAvatar::MyAvatar(QThread* thread) :
 
 MyAvatar::~MyAvatar() {
     _lookAtTargetAvatar.reset();
+}
+
+void MyAvatar::setDominantHand(const QString& hand) {
+    if (hand == DOMINANT_HAND_LEFT || hand == DOMINANT_HAND_RIGHT) {
+        _dominantHand = hand;
+    }
 }
 
 void MyAvatar::registerMetaTypes(QScriptEngine* engine) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -926,6 +926,7 @@ void MyAvatar::saveData() {
     Settings settings;
     settings.beginGroup("Avatar");
 
+    settings.setValue("useAlternativeHand", _useAlternativeHand);
     settings.setValue("headPitch", getHead()->getBasePitch());
 
     settings.setValue("scale", _targetScale);
@@ -1122,7 +1123,7 @@ void MyAvatar::loadData() {
     setCollisionSoundURL(settings.value("collisionSoundURL", DEFAULT_AVATAR_COLLISION_SOUND_URL).toString());
     setSnapTurn(settings.value("useSnapTurn", _useSnapTurn).toBool());
     setClearOverlayWhenMoving(settings.value("clearOverlayWhenMoving", _clearOverlayWhenMoving).toBool());
-
+    setUseAlternativeHand(settings.value("useAlternativeHand", _useAlternativeHand).toBool());
     settings.endGroup();
 
     setEnableMeshVisible(Menu::getInstance()->isOptionChecked(MenuOption::MeshVisible));

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -142,6 +142,9 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(float hmdRollControlDeadZone READ getHMDRollControlDeadZone WRITE setHMDRollControlDeadZone)
     Q_PROPERTY(float hmdRollControlRate READ getHMDRollControlRate WRITE setHMDRollControlRate)
 
+    const QString DOMINANT_LEFT_HAND = "left";
+    const QString DOMINANT_RIGHT_HAND = "right";
+
 public:
     enum DriveKeys {
         TRANSLATE_X = 0,
@@ -341,7 +344,6 @@ public:
     Q_INVOKABLE void setClearOverlayWhenMoving(bool on) { _clearOverlayWhenMoving = on; }
 
     Q_INVOKABLE void setDominantHand(const QString& hand);
-
     Q_INVOKABLE QString getDominantHand() const { return _dominantHand; }
 
     Q_INVOKABLE void setHMDLeanRecenterEnabled(bool value) { _hmdLeanRecenterEnabled = value; }
@@ -724,7 +726,7 @@ private:
     QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
     bool _clearOverlayWhenMoving { true };
-    QString _dominantHand{ DOMINANT_RIGHT_HAND };
+    QString _dominantHand { DOMINANT_RIGHT_HAND };
 
     const float ROLL_CONTROL_DEAD_ZONE_DEFAULT = 8.0f; // deg
     const float ROLL_CONTROL_RATE_DEFAULT = 2.5f; // deg/sec/deg

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -43,6 +43,12 @@ enum AudioListenerMode {
     FROM_CAMERA,
     CUSTOM
 };
+
+enum DominantHand {
+    LEFT_HAND,
+    RIGHT_HAND
+};
+
 Q_DECLARE_METATYPE(AudioListenerMode);
 
 class MyAvatar : public Avatar {
@@ -339,11 +345,7 @@ public:
     Q_INVOKABLE bool getClearOverlayWhenMoving() const { return _clearOverlayWhenMoving; }
     Q_INVOKABLE void setClearOverlayWhenMoving(bool on) { _clearOverlayWhenMoving = on; }
 
-    Q_INVOKABLE void setDominantHand(const QString& hand) {
-        if (hand == "left" || hand == "right") {
-            _dominantHand = hand;
-        }
-    }
+    Q_INVOKABLE void setDominantHand(const QString& hand);
 
     Q_INVOKABLE QString getDominantHand() const { return _dominantHand; }
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -339,6 +339,9 @@ public:
     Q_INVOKABLE bool getClearOverlayWhenMoving() const { return _clearOverlayWhenMoving; }
     Q_INVOKABLE void setClearOverlayWhenMoving(bool on) { _clearOverlayWhenMoving = on; }
 
+    Q_INVOKABLE void setUseAlternativeHand(bool hand) { _useAlternativeHand = hand; }
+    Q_INVOKABLE bool getUseAlternativeHand() const { return _useAlternativeHand; }
+
     Q_INVOKABLE void setHMDLeanRecenterEnabled(bool value) { _hmdLeanRecenterEnabled = value; }
     Q_INVOKABLE bool getHMDLeanRecenterEnabled() const { return _hmdLeanRecenterEnabled; }
 
@@ -423,7 +426,6 @@ public:
     Q_INVOKABLE QUrl getFullAvatarURLFromPreferences() const { return _fullAvatarURLFromPreferences; }
     Q_INVOKABLE QString getFullAvatarModelName() const { return _fullAvatarModelName; }
     void resetFullAvatarURL();
-
 
     virtual void setAttachmentData(const QVector<AttachmentData>& attachmentData) override;
 
@@ -720,6 +722,7 @@ private:
     QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
     bool _clearOverlayWhenMoving { true };
+    bool _useAlternativeHand{ false }; // False defaults to right hand, true to left
 
     const float ROLL_CONTROL_DEAD_ZONE_DEFAULT = 8.0f; // deg
     const float ROLL_CONTROL_RATE_DEFAULT = 2.5f; // deg/sec/deg

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -44,11 +44,6 @@ enum AudioListenerMode {
     CUSTOM
 };
 
-enum DominantHand {
-    LEFT_HAND,
-    RIGHT_HAND
-};
-
 Q_DECLARE_METATYPE(AudioListenerMode);
 
 class MyAvatar : public Avatar {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -724,7 +724,7 @@ private:
     QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
     bool _clearOverlayWhenMoving { true };
-    QString _dominantHand{ "right" };
+    QString _dominantHand{ DOMINANT_RIGHT_HAND };
 
     const float ROLL_CONTROL_DEAD_ZONE_DEFAULT = 8.0f; // deg
     const float ROLL_CONTROL_RATE_DEFAULT = 2.5f; // deg/sec/deg

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -339,8 +339,13 @@ public:
     Q_INVOKABLE bool getClearOverlayWhenMoving() const { return _clearOverlayWhenMoving; }
     Q_INVOKABLE void setClearOverlayWhenMoving(bool on) { _clearOverlayWhenMoving = on; }
 
-    Q_INVOKABLE void setUseAlternativeHand(bool hand) { _useAlternativeHand = hand; }
-    Q_INVOKABLE bool getUseAlternativeHand() const { return _useAlternativeHand; }
+    Q_INVOKABLE void setDominantHand(const QString& hand) {
+        if (hand == "left" || hand == "right") {
+            _dominantHand = hand;
+        }
+    }
+
+    Q_INVOKABLE QString getDominantHand() const { return _dominantHand; }
 
     Q_INVOKABLE void setHMDLeanRecenterEnabled(bool value) { _hmdLeanRecenterEnabled = value; }
     Q_INVOKABLE bool getHMDLeanRecenterEnabled() const { return _hmdLeanRecenterEnabled; }
@@ -722,7 +727,7 @@ private:
     QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
     bool _clearOverlayWhenMoving { true };
-    bool _useAlternativeHand{ false }; // False defaults to right hand, true to left
+    QString _dominantHand{ "right" };
 
     const float ROLL_CONTROL_DEAD_ZONE_DEFAULT = 8.0f; // deg
     const float ROLL_CONTROL_RATE_DEFAULT = 2.5f; // deg/sec/deg

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -68,8 +68,8 @@ void setupPreferences() {
         preferences->addPreference(new CheckPreference(AVATAR_BASICS, "Clear overlays when moving", getter, setter));
     }
     {
-        auto getter = [=]()->bool { return myAvatar->getUseAlternativeHand(); };
-        auto setter = [=](bool value) { myAvatar->setUseAlternativeHand(value); };
+        auto getter = [=]()->QString { return myAvatar->getDominantHand(); };
+        auto setter = [=](const QString& value) { myAvatar->setDominantHand(value); };
         preferences->addPreference(new PrimaryHandPreference(AVATAR_BASICS, "Dominant Hand", getter, setter));
     }
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -67,11 +67,6 @@ void setupPreferences() {
         auto setter = [=](bool value) { myAvatar->setClearOverlayWhenMoving(value); };
         preferences->addPreference(new CheckPreference(AVATAR_BASICS, "Clear overlays when moving", getter, setter));
     }
-    {
-        auto getter = [=]()->QString { return myAvatar->getDominantHand(); };
-        auto setter = [=](const QString& value) { myAvatar->setDominantHand(value); };
-        preferences->addPreference(new PrimaryHandPreference(AVATAR_BASICS, "Dominant Hand", getter, setter));
-    }
 
     // UI
     static const QString UI_CATEGORY { "UI" };
@@ -185,6 +180,11 @@ void setupPreferences() {
         preference->setMax(180);
         preference->setStep(1);
         preferences->addPreference(preference);
+    }
+    {
+        auto getter = [=]()->QString { return myAvatar->getDominantHand(); };
+        auto setter = [=](const QString& value) { myAvatar->setDominantHand(value); };
+        preferences->addPreference(new PrimaryHandPreference(AVATAR_TUNING, "Dominant Hand", getter, setter));
     }
     {
         auto getter = [=]()->float { return myAvatar->getUniformScale(); };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -67,6 +67,12 @@ void setupPreferences() {
         auto setter = [=](bool value) { myAvatar->setClearOverlayWhenMoving(value); };
         preferences->addPreference(new CheckPreference(AVATAR_BASICS, "Clear overlays when moving", getter, setter));
     }
+    {
+        auto getter = [=]()->bool { return myAvatar->getUseAlternativeHand(); };
+        auto setter = [=](bool value) { myAvatar->setUseAlternativeHand(value); };
+        preferences->addPreference(new PrimaryHandPreference(AVATAR_BASICS, "Dominant Hand", getter, setter));
+        
+    }
 
     // UI
     static const QString UI_CATEGORY { "UI" };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -71,7 +71,6 @@ void setupPreferences() {
         auto getter = [=]()->bool { return myAvatar->getUseAlternativeHand(); };
         auto setter = [=](bool value) { myAvatar->setUseAlternativeHand(value); };
         preferences->addPreference(new PrimaryHandPreference(AVATAR_BASICS, "Dominant Hand", getter, setter));
-        
     }
 
     // UI

--- a/libraries/shared/src/Preferences.h
+++ b/libraries/shared/src/Preferences.h
@@ -340,11 +340,11 @@ public:
     Type getType() override { return Checkbox; }
 };
 
-class PrimaryHandPreference : public BoolPreference {
+class PrimaryHandPreference : public StringPreference {
     Q_OBJECT
 public:
     PrimaryHandPreference(const QString& category, const QString& name, Getter getter, Setter setter)
-        : BoolPreference(category, name, getter, setter) { }
+        : StringPreference(category, name, getter, setter) { }
     Type getType() override { return PrimaryHand; }
 };
 

--- a/libraries/shared/src/Preferences.h
+++ b/libraries/shared/src/Preferences.h
@@ -56,6 +56,7 @@ public:
         Checkbox,
         Button,
         ComboBox,
+        PrimaryHand,
         // Special casing for an unusual preference
         Avatar
     };
@@ -337,6 +338,14 @@ public:
     CheckPreference(const QString& category, const QString& name, Getter getter, Setter setter)
         : BoolPreference(category, name, getter, setter) { }
     Type getType() override { return Checkbox; }
+};
+
+class PrimaryHandPreference : public BoolPreference {
+    Q_OBJECT
+public:
+    PrimaryHandPreference(const QString& category, const QString& name, Getter getter, Setter setter)
+        : BoolPreference(category, name, getter, setter) { }
+    Type getType() override { return PrimaryHand; }
 };
 
 #endif


### PR DESCRIPTION
> Add a "Dominant Hand" setting:
> In Settings > Avatar, add two checkboxes (one of which has to be checked at all times): "Right Hand" and "Left Hand". It should be accessible by our scripting API as a property.
> Worklist: https://worklist.net/21453

## Test Plan
1. Launch the Interface
2. Open the Console and Type `MyAvatar.getDominantHand()`
3. Confirm that it returns `right`.
4. **In Desktop Mode**, go to Settings > Avatar
5. Confirm that you see the Left and Right Dominant Hand Setting under Avatar Tuning
6. Confirm that one Radio Box must be ticked at all times.
7. Confirm that when you select Left and Save Settings, that the Command From Step 2 returns `left`.
8. **In Tablet Mode**, launch the Tablet and  go to Menu > Settings > Avatar
9. Confirm that you see the Left and Right Dominant Hand Setting under Avatar Tuning
10. Confirm that one Radio Box must be ticked at all times.
11. Confirm that when you select Right and Save Settings, that the Command From Step 2 returns `right`.
12. Open the Console and Type `MyAvatar.setDominantHand("left")`
13. Confirm that it sets successfully, and re-running the Command from Step 2 returns `left`.
14. Check to ensure that each setting is updating in the Avatar Settings **in both Desktop & Tablet**.
15. Relaunch the game and confirm that the settings for both left and right stay put.