### PR TITLE
Fix Parent Joint in edit js WL # 21471 : 

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1074,7 +1074,7 @@ function loaded() {
         elDimensionsZ.addEventListener('change', dimensionsChangeFunction);
 
         elParentID.addEventListener('change', createEmitTextPropertyUpdateFunction('parentID'));
-        elParentJointIndex.addEventListener('change', createEmitNumberPropertyUpdateFunction('parentJointIndex'));
+        elParentJointIndex.addEventListener('change', createEmitNumberPropertyUpdateFunction('parentJointIndex', 0));
 
         var registrationChangeFunction = createEmitVec3PropertyUpdateFunction(
             'registrationPoint', elRegistrationX, elRegistrationY, elRegistrationZ);


### PR DESCRIPTION
@themelissabrown 

In entityPropeties.js
line #1079 says:
elParentJointIndex.addEventListener('change', createEmitNumberPropertyUpdateFunction('parentJointIndex'));

The problem should be fixed by changing it to:
elParentJointIndex.addEventListener('change', createEmitNumberPropertyUpdateFunction('parentJointIndex', 0));

createEmitNumberPropertyUpdateFunction() is parsing the value as a
float to a default decimal position of 4. Looks like this field only accepts
integers. By adding in that 0 as a second argument, it should coerce the
value to one that will be recognized by the UI/backend.

Test Plan
----------

1) Add a sphere 
2) Change Parent Joint Index to 10
3) Get the Id number of the object
3) Open console and enter
print(JSON.stringify(Entities.getEntityProperties(IdNumber)));
4) Check that the parentJointIndex is set 10


