### PR TITLE
Hack to mod tablet orientation when clicking context overlay

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -38,9 +38,8 @@ ContextOverlayInterface::ContextOverlayInterface() {
             QUuid tabletFrameID = _hmdScriptingInterface->getCurrentTabletFrameID();
             QVariantMap props;
             auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-            glm::vec3 position = myAvatar->getJointPosition("Head") + 0.6f * (myAvatar->getOrientation() * Vectors::FRONT);
-            props.insert("position", vec3toVariant(position));
-            props.insert("orientation", quatToVariant(myAvatar->getOrientation() * glm::quat(0.0f, 0.0f, 1.0f, 0.0f)));
+            props.insert("position", vec3toVariant(myAvatar->getEyePosition() + glm::quat(glm::radians(glm::vec3(0.0f, 30.0f, 0.0f))) * (0.65f * (myAvatar->getHeadOrientation() * Vectors::FRONT))));
+            props.insert("orientation", quatToVariant(myAvatar->getHeadOrientation() * glm::quat(glm::radians(glm::vec3(0.0f, 210.0f, 0.0f)))));
             qApp->getOverlays().editOverlay(tabletFrameID, props);
             _contextOverlayJustClicked = false;
         }

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -19,6 +19,7 @@
 #include <DependencyManager.h>
 #include <PointerEvent.h>
 #include <ui/TabletScriptingInterface.h>
+#include "avatar/AvatarManager.h"
 
 #include "EntityScriptingInterface.h"
 #include "ui/overlays/Image3DOverlay.h"
@@ -66,6 +67,7 @@ private:
     bool _enabled { true };
     QUuid _currentEntityWithContextOverlay{};
     QString _entityMarketplaceID;
+    bool _contextOverlayJustClicked { false };
 
     void openMarketplace();
 };

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -104,7 +104,6 @@
 
     function showTabletUI() {
         checkTablet()
-        gTablet.tabletShown = true;
 
         if (!tabletRezzed || !tabletIsValid()) {
             closeTabletUI();
@@ -123,6 +122,7 @@
             Overlays.editOverlay(HMD.tabletScreenID, { visible: true });
             Overlays.editOverlay(HMD.tabletScreenID, { maxFPS: 90 });
         }
+        gTablet.tabletShown = true;
     }
 
     function hideTabletUI() {


### PR DESCRIPTION
DO NOT TEST.

I kind of hate that I wrote this code, but I don't know another way to do this given the current tablet capabilities.