### PR TITLE
Fixed bug: Disconnected domain (no access token present) is unnecessarily hitting /api/v1/user/friends

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -927,8 +927,7 @@ void DomainGatekeeper::getDomainOwnerFriendsList() {
     callbackParams.errorCallbackMethod = "getDomainOwnerFriendsListErrorCallback";
 
     const QString GET_FRIENDS_LIST_PATH = "api/v1/user/friends";
-    if (DependencyManager::get<AccountManager>()->hasValidAccessToken())
-    {
+    if (DependencyManager::get<AccountManager>()->hasValidAccessToken()) {
         DependencyManager::get<AccountManager>()->sendRequest(GET_FRIENDS_LIST_PATH, AccountManagerAuth::Required,
                                                               QNetworkAccessManager::GetOperation, callbackParams, QByteArray(),
                                                               NULL, QVariantMap());

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -930,8 +930,8 @@ void DomainGatekeeper::getDomainOwnerFriendsList() {
     if (DependencyManager::get<AccountManager>()->hasValidAccessToken())
     {
         DependencyManager::get<AccountManager>()->sendRequest(GET_FRIENDS_LIST_PATH, AccountManagerAuth::Required,
-            QNetworkAccessManager::GetOperation, callbackParams, QByteArray(),
-            NULL, QVariantMap());
+                                                              QNetworkAccessManager::GetOperation, callbackParams, QByteArray(),
+                                                              NULL, QVariantMap());
     }
     
 }

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -927,9 +927,13 @@ void DomainGatekeeper::getDomainOwnerFriendsList() {
     callbackParams.errorCallbackMethod = "getDomainOwnerFriendsListErrorCallback";
 
     const QString GET_FRIENDS_LIST_PATH = "api/v1/user/friends";
-    DependencyManager::get<AccountManager>()->sendRequest(GET_FRIENDS_LIST_PATH, AccountManagerAuth::Required,
-                                                          QNetworkAccessManager::GetOperation, callbackParams, QByteArray(),
-                                                          NULL, QVariantMap());
+    if (DependencyManager::get<AccountManager>()->hasValidAccessToken())
+    {
+        DependencyManager::get<AccountManager>()->sendRequest(GET_FRIENDS_LIST_PATH, AccountManagerAuth::Required,
+            QNetworkAccessManager::GetOperation, callbackParams, QByteArray(),
+            NULL, QVariantMap());
+    }
+    
 }
 
 void DomainGatekeeper::getDomainOwnerFriendsListJSONCallback(QNetworkReply& requestReply) {


### PR DESCRIPTION
Refer to Fogbugz case: https://highfidelity.fogbugz.com/f/cases/6470/Disconnected-domain-no-access-token-present-is-unnecessarily-hitting-api-v1-user-friends

Made sendRequest from  getDomainOwnerFriendsList depend on hasValidAccessToken being true 

Testing Notes:
1) Run the built PR
2) Run the domain server
3) Check domain server logs, following sample line should **NOT** be there:
[07/21 20:24:04] [DEBUG] [hifi.networking] No valid access token present. Bailing on invoked request to "api/v1/user/friends" that requires authentication

