### PR TITLE
Updates from Threaded Rendering project

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -129,8 +129,7 @@ public:
     virtual DisplayPluginPointer getActiveDisplayPlugin() const override;
 
     enum Event {
-        Present = DisplayPlugin::Present,
-        Paint,
+        Paint = QEvent::User + 1,
         Idle,
         Lambda
     };
@@ -409,6 +408,7 @@ private slots:
     void clearDomainOctreeDetails();
     void clearDomainAvatars();
     void onAboutToQuit();
+    void onPresent(quint32 frameCount);
 
     void resettingDomain();
 
@@ -455,8 +455,8 @@ private:
 
     void cleanupBeforeQuit();
 
-    bool shouldPaint(float nsecsElapsed);
-    void idle(float nsecsElapsed);
+    bool shouldPaint();
+    void idle();
     void update(float deltaTime);
 
     // Various helper functions called during update()
@@ -518,6 +518,7 @@ private:
 
     OffscreenGLCanvas* _offscreenContext { nullptr };
     DisplayPluginPointer _displayPlugin;
+    QMetaObject::Connection _displayPluginPresentConnection;
     mutable std::mutex _displayPluginLock;
     InputPluginList _activeInputPlugins;
 

--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -12,6 +12,7 @@
 #include <map>
 
 #include <shared/QtHelpers.h>
+#include <plugins/DisplayPlugin.h>
 
 #include "AudioDevices.h"
 

--- a/interface/src/ui/ResourceImageItem.cpp
+++ b/interface/src/ui/ResourceImageItem.cpp
@@ -8,13 +8,14 @@
 // See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-//#include "Application.h"
 #include "ResourceImageItem.h"
 
 #include <QOpenGLFramebufferObjectFormat>
 #include <QOpenGLFunctions>
 #include <QOpenGLExtraFunctions>
 #include <QOpenGLContext>
+
+#include <plugins/DisplayPlugin.h>
 
 ResourceImageItem::ResourceImageItem() : QQuickFramebufferObject() {
     auto textureCache = DependencyManager::get<TextureCache>();

--- a/interface/src/ui/SnapshotAnimated.cpp
+++ b/interface/src/ui/SnapshotAnimated.cpp
@@ -13,8 +13,9 @@
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtGui/QImage>
+#include <QtConcurrent/QtConcurrentRun>
 
-#include <QtConcurrent/qtconcurrentrun.h>
+#include <plugins/DisplayPlugin.h>
 #include "SnapshotAnimated.h"
 
 QTimer* SnapshotAnimated::snapshotAnimatedTimer = NULL;

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -69,7 +69,7 @@ RenderableWebEntityItem::~RenderableWebEntityItem() {
     }
 }
 
-bool RenderableWebEntityItem::buildWebSurface(QSharedPointer<EntityTreeRenderer> renderer) {
+bool RenderableWebEntityItem::buildWebSurface() {
     if (_currentWebCount >= MAX_CONCURRENT_WEB_VIEWS) {
         qWarning() << "Too many concurrent web views to create new view";
         return false;
@@ -132,6 +132,8 @@ bool RenderableWebEntityItem::buildWebSurface(QSharedPointer<EntityTreeRenderer>
             handlePointerEvent(event);
         }
     };
+
+    auto renderer = DependencyManager::get<EntityTreeRenderer>();
     _mousePressConnection = QObject::connect(renderer.data(), &EntityTreeRenderer::mousePressOnEntity, forwardPointerEvent);
     _mouseReleaseConnection = QObject::connect(renderer.data(), &EntityTreeRenderer::mouseReleaseOnEntity, forwardPointerEvent);
     _mouseMoveConnection = QObject::connect(renderer.data(), &EntityTreeRenderer::mouseMoveOnEntity, forwardPointerEvent);
@@ -185,8 +187,7 @@ void RenderableWebEntityItem::render(RenderArgs* args) {
     #endif
 
     if (!_webSurface) {
-        auto renderer = qSharedPointerCast<EntityTreeRenderer>(args->_renderData);
-        if (!buildWebSurface(renderer)) {
+        if (!buildWebSurface()) {
             return;
         }
         _fadeStartTime = usecTimestampNow();

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -57,7 +57,7 @@ public:
     virtual QObject* getRootItem() override;
 
 private:
-    bool buildWebSurface(QSharedPointer<EntityTreeRenderer> renderer);
+    bool buildWebSurface();
     void destroyWebSurface();
     glm::vec2 getWindowSize() const;
 

--- a/libraries/render/src/render/Args.h
+++ b/libraries/render/src/render/Args.h
@@ -77,7 +77,6 @@ namespace render {
         Args() {}
 
         Args(const gpu::ContextPointer& context,
-            QSharedPointer<QObject> renderData = QSharedPointer<QObject>(nullptr),
             float sizeScale = 1.0f,
             int boundaryLevelAdjust = 0,
             RenderMode renderMode = DEFAULT_RENDER_MODE,
@@ -85,7 +84,6 @@ namespace render {
             DebugFlags debugFlags = RENDER_DEBUG_NONE,
             gpu::Batch* batch = nullptr) :
             _context(context),
-            _renderData(renderData),
             _sizeScale(sizeScale),
             _boundaryLevelAdjust(boundaryLevelAdjust),
             _renderMode(renderMode),
@@ -110,7 +108,6 @@ namespace render {
         std::shared_ptr<gpu::Context> _context;
         std::shared_ptr<gpu::Framebuffer> _blitFramebuffer;
         std::shared_ptr<render::ShapePipeline> _shapePipeline;
-        QSharedPointer<QObject> _renderData;
         std::stack<ViewFrustum> _viewFrustums;
         glm::ivec4 _viewport { 0.0f, 0.0f, 1.0f, 1.0f };
         glm::vec3 _boomOffset { 0.0f, 0.0f, 1.0f };

--- a/libraries/shared/src/ThreadHelpers.cpp
+++ b/libraries/shared/src/ThreadHelpers.cpp
@@ -10,29 +10,66 @@
 
 #include <QtCore/QDebug>
 
+// Support for viewing the thread name in the debugger.  
+// Note, Qt actually does this for you but only in debug builds
+// Code from https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
+// and matches logic in `qt_set_thread_name` in qthread_win.cpp
+#ifdef Q_OS_WIN
+#include <qt_windows.h>
+#pragma pack(push,8)  
+struct THREADNAME_INFO {
+    DWORD dwType; // Must be 0x1000.  
+    LPCSTR szName; // Pointer to name (in user addr space).  
+    DWORD dwThreadID; // Thread ID (-1=caller thread).  
+    DWORD dwFlags; // Reserved for future use, must be zero.  
+};
+#pragma pack(pop)  
+#endif
+
+void setThreadName(const std::string& name) {
+#ifdef Q_OS_WIN
+    static const DWORD MS_VC_EXCEPTION = 0x406D1388;
+    THREADNAME_INFO info{ 0x1000, name.c_str(), (DWORD)-1, 0 };
+    __try {
+        RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+    } __except (EXCEPTION_EXECUTE_HANDLER) { }
+#endif
+}
+
+void moveToNewNamedThread(QObject* object, const QString& name, std::function<void(QThread*)> preStartCallback, std::function<void()> startCallback, QThread::Priority priority) {
+    Q_ASSERT(QThread::currentThread() == object->thread());
+    // setup a thread for the NodeList and its PacketReceiver
+    QThread* thread = new QThread();
+    thread->setObjectName(name);
+
+    // Execute any additional work to do before the thread starts (like moving members to the target thread
+    preStartCallback(thread);
+
+    // Link the in-thread initialization code
+    QObject::connect(thread, &QThread::started, [name, startCallback] { 
+        if (!name.isEmpty()) {
+            // Make it easy to spot our thread processes inside the debugger
+            setThreadName("Hifi_" + name.toStdString());
+        }
+        startCallback();
+    });
+
+    // Make sure the thread will be destroyed and cleaned up
+    QObject::connect(object, &QObject::destroyed, thread, &QThread::quit);
+    QObject::connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+
+    // put the object on the thread
+    object->moveToThread(thread);
+    thread->start();
+    if (priority != QThread::InheritPriority) {
+        thread->setPriority(priority);
+    }
+}
 
 void moveToNewNamedThread(QObject* object, const QString& name, std::function<void()> startCallback, QThread::Priority priority) {
-     Q_ASSERT(QThread::currentThread() == object->thread());
-     // setup a thread for the NodeList and its PacketReceiver
-     QThread* thread = new QThread();
-     thread->setObjectName(name);
-
-     QString tempName = name;
-     QObject::connect(thread, &QThread::started, [startCallback] {
-         startCallback();
-     });
-     // Make sure the thread will be destroyed and cleaned up
-     QObject::connect(object, &QObject::destroyed, thread, &QThread::quit);
-     QObject::connect(thread, &QThread::finished, thread, &QThread::deleteLater);
-
-     // put the object on the thread
-     object->moveToThread(thread);
-     thread->start();
-     if (priority != QThread::InheritPriority) {
-         thread->setPriority(priority);
-     }
+    moveToNewNamedThread(object, name, [](QThread*){}, startCallback, priority);
 }
 
 void moveToNewNamedThread(QObject* object, const QString& name, QThread::Priority priority) {
-    moveToNewNamedThread(object, name, [] {}, priority);
+    moveToNewNamedThread(object, name, [](QThread*){}, []{}, priority);
 }

--- a/libraries/shared/src/ThreadHelpers.h
+++ b/libraries/shared/src/ThreadHelpers.h
@@ -32,8 +32,17 @@ void withLock(QMutex& lock, F function) {
     function();
 }
 
-void moveToNewNamedThread(QObject* object, const QString& name, std::function<void()> startCallback, QThread::Priority priority = QThread::InheritPriority);
-void moveToNewNamedThread(QObject* object, const QString& name, QThread::Priority priority = QThread::InheritPriority);
+void moveToNewNamedThread(QObject* object, const QString& name, 
+    std::function<void(QThread*)> preStartCallback, 
+    std::function<void()> startCallback, 
+    QThread::Priority priority = QThread::InheritPriority);
+
+void moveToNewNamedThread(QObject* object, const QString& name, 
+    std::function<void()> startCallback, 
+    QThread::Priority priority = QThread::InheritPriority);
+
+void moveToNewNamedThread(QObject* object, const QString& name, 
+    QThread::Priority priority = QThread::InheritPriority);
 
 class ConditionalGuard {
 public:

--- a/libraries/shared/src/shared/QtHelpers.h
+++ b/libraries/shared/src/shared/QtHelpers.h
@@ -14,6 +14,7 @@
 
 
 namespace hifi { namespace qt {
+void addBlockingForbiddenThread(const QString& name, QThread* thread = nullptr);
 
 bool blockingInvokeMethod(
     const char* function,

--- a/tests/render-perf/src/main.cpp
+++ b/tests/render-perf/src/main.cpp
@@ -681,7 +681,7 @@ private:
         _renderCount = _renderThread._presentCount.load();
         update();
 
-        RenderArgs renderArgs(_renderThread._gpuContext, _octree, DEFAULT_OCTREE_SIZE_SCALE,
+        RenderArgs renderArgs(_renderThread._gpuContext, DEFAULT_OCTREE_SIZE_SCALE,
             0, RenderArgs::DEFAULT_RENDER_MODE,
             RenderArgs::MONO, RenderArgs::RENDER_DEBUG_NONE);
 


### PR DESCRIPTION
This is a set of changes from the threaded rendering project that can be merged to master without impacting performance or behavior, in order to prevent too much drift in the project branch.

* Adds support for additional threads emitting warnings if blocking method invocations are made from them. Will be needed because the render thread absolutely cannot make blocking invocations.
* Add support for `moveToNewNamedThread` where a lambda can be provided that takes the target thread as a parameter.  This is needed if an object needs to move additional components to the target thread prior to the thread starting (such as an OpenGL context wrapper)
* Modify `moveToNewNamedThread` to set the thread name so that it's visible in the Visual Studio debugger.  This happens automatically inside Qt for debug builds, but not for release builds.  Since we primarily run on release, this should aid debugging.
* Remove superfluous member from `render::Args`.  This was only used in the `RenderableWebEntityItem` and can be fetched there via the dependency manager without having to pass through `Args`
* Change display plugin presentation notifications from an event to a signal.  
* Remove `DisplayPlugins.h` from `Application.h`, rely on forward declarations.
* Modify `Application.cpp` to account for the change to present notifications
* Clean up a number of C++ files that relied on `Application.h` for `DisplayPlugins.h`
* On systems where the rendering is stressed, tablet interaction still works as well as it does on master

## Testing

Application behavior and performance should be unchanged from the current dev build.  Verify the following

* Switching between display plugins is functional
* Application shuts down smoothly
* Application does not crash when minimized for more than 30-40 seconds
* Animations run properly and at the correct speed

