### PR TITLE
added additional collision types to asset browser and new model dialog

### DIFF
--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -153,9 +153,7 @@ ScrollingWindow {
         var SHAPE_TYPE_STATIC_MESH = 3;
         var SHAPE_TYPE_BOX = 4;
         var SHAPE_TYPE_SPHERE = 5;
-        var SHAPE_TYPE_COMPOUND = 6;
-
-
+        
         var SHAPE_TYPES = [];
         SHAPE_TYPES[SHAPE_TYPE_NONE] = "No Collision";
         SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
@@ -163,9 +161,7 @@ ScrollingWindow {
         SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
         SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
         SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
-        SHAPE_TYPES[SHAPE_TYPE_COMPOUND] = "Compound";
-
-
+        
         var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
         var DYNAMIC_DEFAULT = false;
         var prompt = desktop.customInputDialog({
@@ -209,9 +205,6 @@ ScrollingWindow {
                         break;
                     case SHAPE_TYPE_SPHERE:
                         shapeType = "sphere";
-                        break;
-                    case SHAPE_TYPE_COMPOUND:
-                        shapeType = "compound";
                         break;
                     default:
                         shapeType = "none";

--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -151,12 +151,20 @@ ScrollingWindow {
         var SHAPE_TYPE_SIMPLE_HULL = 1;
         var SHAPE_TYPE_SIMPLE_COMPOUND = 2;
         var SHAPE_TYPE_STATIC_MESH = 3;
+        var SHAPE_TYPE_BOX = 4;
+        var SHAPE_TYPE_SPHERE = 5;
+        var SHAPE_TYPE_COMPOUND = 6;
+
 
         var SHAPE_TYPES = [];
         SHAPE_TYPES[SHAPE_TYPE_NONE] = "No Collision";
         SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
         SHAPE_TYPES[SHAPE_TYPE_SIMPLE_COMPOUND] = "Good - Sub-meshes";
         SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
+        SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
+        SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
+        SHAPE_TYPES[SHAPE_TYPE_COMPOUND] = "Compound";
+
 
         var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
         var DYNAMIC_DEFAULT = false;
@@ -195,6 +203,15 @@ ScrollingWindow {
                         break;
                     case SHAPE_TYPE_STATIC_MESH:
                         shapeType = "static-mesh";
+                        break;
+                    case SHAPE_TYPE_BOX:
+                        shapeType = "box";
+                        break;
+                    case SHAPE_TYPE_SPHERE:
+                        shapeType = "sphere";
+                        break;
+                    case SHAPE_TYPE_COMPOUND:
+                        shapeType = "compound";
                         break;
                     default:
                         shapeType = "none";

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -154,9 +154,7 @@ Rectangle {
         var SHAPE_TYPE_STATIC_MESH = 3;
         var SHAPE_TYPE_BOX = 4;
         var SHAPE_TYPE_SPHERE = 5;
-        var SHAPE_TYPE_COMPOUND = 6;
         
-
         var SHAPE_TYPES = [];
         SHAPE_TYPES[SHAPE_TYPE_NONE] = "No Collision";
         SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
@@ -164,8 +162,7 @@ Rectangle {
         SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
         SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
         SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
-        SHAPE_TYPES[SHAPE_TYPE_COMPOUND] = "Compound";
-
+        
         var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
         var DYNAMIC_DEFAULT = false;
         var prompt = tabletRoot.customInputDialog({
@@ -209,9 +206,6 @@ Rectangle {
                     break;
                 case SHAPE_TYPE_SPHERE:
                     shapeType = "sphere";
-                    break;
-                case SHAPE_TYPE_COMPOUND:
-                    shapeType = "compound";
                     break;
                 default:
                     shapeType = "none";

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -152,12 +152,19 @@ Rectangle {
         var SHAPE_TYPE_SIMPLE_HULL = 1;
         var SHAPE_TYPE_SIMPLE_COMPOUND = 2;
         var SHAPE_TYPE_STATIC_MESH = 3;
+        var SHAPE_TYPE_BOX = 4;
+        var SHAPE_TYPE_SPHERE = 5;
+        var SHAPE_TYPE_COMPOUND = 6;
+        
 
         var SHAPE_TYPES = [];
         SHAPE_TYPES[SHAPE_TYPE_NONE] = "No Collision";
         SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
         SHAPE_TYPES[SHAPE_TYPE_SIMPLE_COMPOUND] = "Good - Sub-meshes";
         SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
+        SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
+        SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
+        SHAPE_TYPES[SHAPE_TYPE_COMPOUND] = "Compound";
 
         var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
         var DYNAMIC_DEFAULT = false;
@@ -196,6 +203,15 @@ Rectangle {
                     break;
                 case SHAPE_TYPE_STATIC_MESH:
                     shapeType = "static-mesh";
+                    break;
+                case SHAPE_TYPE_BOX:
+                    shapeType = "box";
+                    break;
+                case SHAPE_TYPE_SPHERE:
+                    shapeType = "sphere";
+                    break;
+                case SHAPE_TYPE_COMPOUND:
+                    shapeType = "compound";
                     break;
                 default:
                     shapeType = "none";

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -145,7 +145,10 @@ Rectangle {
                     model: ["No Collision",
                             "Basic - Whole model",
                             "Good - Sub-meshes",
-                            "Exact - All polygons"]
+                            "Exact - All polygons", 
+                            "Box", 
+                            "Sphere", 
+                            "Compound"]
                 }
 
                 Row {

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -147,8 +147,7 @@ Rectangle {
                             "Good - Sub-meshes",
                             "Exact - All polygons", 
                             "Box", 
-                            "Sphere", 
-                            "Compound"]
+                            "Sphere"]
                 }
 
                 Row {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -339,7 +339,6 @@ var toolBar = (function () {
     var SHAPE_TYPE_STATIC_MESH = 3;
     var SHAPE_TYPE_BOX = 4;
     var SHAPE_TYPE_SPHERE = 5;
-    var SHAPE_TYPE_COMPOUND = 6;
     var DYNAMIC_DEFAULT = false;
 
     function handleNewModelDialogResult(result) {
@@ -361,9 +360,6 @@ var toolBar = (function () {
                 break;
             case SHAPE_TYPE_SPHERE:
                 shapeType = "sphere";
-                break;
-            case SHAPE_TYPE_COMPOUND:
-                shapeType = "compound";
                 break;
             default:
                 shapeType = "none";
@@ -464,7 +460,6 @@ var toolBar = (function () {
             SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
             SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
             SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
-            SHAPE_TYPES[SHAPE_TYPE_COMPOUND] = "Compound";
             var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
 
             // tablet version of new-model dialog

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -337,6 +337,9 @@ var toolBar = (function () {
     var SHAPE_TYPE_SIMPLE_HULL = 1;
     var SHAPE_TYPE_SIMPLE_COMPOUND = 2;
     var SHAPE_TYPE_STATIC_MESH = 3;
+    var SHAPE_TYPE_BOX = 4;
+    var SHAPE_TYPE_SPHERE = 5;
+    var SHAPE_TYPE_COMPOUND = 6;
     var DYNAMIC_DEFAULT = false;
 
     function handleNewModelDialogResult(result) {
@@ -352,6 +355,15 @@ var toolBar = (function () {
                 break;
             case SHAPE_TYPE_STATIC_MESH:
                 shapeType = "static-mesh";
+                break;
+            case SHAPE_TYPE_BOX:
+                shapeType = "box";
+                break;
+            case SHAPE_TYPE_SPHERE:
+                shapeType = "sphere";
+                break;
+            case SHAPE_TYPE_COMPOUND:
+                shapeType = "compound";
                 break;
             default:
                 shapeType = "none";
@@ -450,6 +462,9 @@ var toolBar = (function () {
             SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
             SHAPE_TYPES[SHAPE_TYPE_SIMPLE_COMPOUND] = "Good - Sub-meshes";
             SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
+            SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
+            SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
+            SHAPE_TYPES[SHAPE_TYPE_COMPOUND] = "Compound";
             var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
 
             // tablet version of new-model dialog


### PR DESCRIPTION
With reference to https://highfidelity.fogbugz.com/f/cases/2157/Asset-Browser-s-add-to-world-dialog-provides-only-4-collision-types

Added additional collision types to Asset Browser and New Model Dialog

Testing Notes:
1) Run the built PR
2) Run Interface, Go to Asset Browser -> Select an object -> Add to World
3) In the window that appears, check the dropdown, it should have 7 collision types, namely: No Collision, Basic, Good, Exact, Box, Sphere and Compound
4) Go to Create -> Model 
5) In the window that appears, check the dropdown, it should also have the above 7 collision types. 