### PR TITLE
Fix chat bubble length

### DIFF
--- a/scripts/system/chat.js
+++ b/scripts/system/chat.js
@@ -650,7 +650,7 @@
         var width = textSize.width + fudge;
         var height = speechBubbleLineHeight + fudge;
 
-        if(textSize.width >= SPEECH_BUBBLE_MAX_WIDTH) {
+        if (textSize.width >= SPEECH_BUBBLE_MAX_WIDTH) {
             var numLines = Math.ceil(width);
             height = speechBubbleLineHeight * numLines + fudge;
             width = SPEECH_BUBBLE_MAX_WIDTH;
@@ -681,7 +681,7 @@
             Vec3.sum(
                 headPosition,
                 rotatedOffset);
-        position.y += height / 2; // offset based on wrapped height of bubble
+        position.y += height / 2; // offset based on half of bubble height
         speechBubbleParams.position = position;
 
         if (!speechBubbleTextID) {

--- a/scripts/system/chat.js
+++ b/scripts/system/chat.js
@@ -654,7 +654,7 @@
             var numLines = Math.ceil(width);
             height = speechBubbleLineHeight * numLines + fudge;
             width = SPEECH_BUBBLE_MAX_WIDTH;
-        }; 
+        } 
 
         dimensions = {
             x: width,

--- a/scripts/system/chat.js
+++ b/scripts/system/chat.js
@@ -43,6 +43,7 @@
     var speechBubbleOffset = {x: 0, y: 0.3, z: 0.0}; // The offset from the joint to whic the speech bubble is attached.
     var speechBubbleJointName = 'Head'; // The name of the joint to which the speech bubble is attached.
     var speechBubbleLineHeight = 0.05; // The height of a line of text in the speech bubble.
+    var SPEECH_BUBBLE_MAX_WIDTH = 1; // meters
 
     // Load the persistent variables from the Settings, with defaults.
     function loadSettings() {
@@ -645,8 +646,16 @@
         //print("updateSpeechBubble:", "speechBubbleMessage", speechBubbleMessage, "textSize", textSize.width, textSize.height);
 
         var fudge = 0.02;
+
         var width = textSize.width + fudge;
-        var height = textSize.height + fudge;
+        var height = speechBubbleLineHeight + fudge;
+
+        if(textSize.width >= SPEECH_BUBBLE_MAX_WIDTH) {
+            var numLines = Math.ceil(width);
+            height = speechBubbleLineHeight * numLines + fudge;
+            width = SPEECH_BUBBLE_MAX_WIDTH;
+        }; 
+
         dimensions = {
             x: width,
             y: height,
@@ -672,6 +681,7 @@
             Vec3.sum(
                 headPosition,
                 rotatedOffset);
+        position.y += height / 2; // offset based on wrapped height of bubble
         speechBubbleParams.position = position;
 
         if (!speechBubbleTextID) {


### PR DESCRIPTION
Attempts to adjust the size of the text entity displaying a chat message based on the length of the message.

Test plan:
----------
Run this version of chat.js from scripts > system > chat.js (not the marketplace version)
Try writing messages of varying lengths in the chat box

Observe that the text wraps in the box and does not create boxes with exceptionally large widths

Not in Scope:
---------------
There is a bug in the existing code base that prohibits messages of an exceptionally large length. This does not attempt to fix that bug in this PR. If you have a message that is past a certain length and the box isn't adjusting, please confirm in the message area that the end was truncated in the same place, or with the existing chat.js from Marketplace to see if the behavior is actually different.