### PR TITLE
Enabled multiple selection and deletion in Asset Browser

### DIFF
--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -28,6 +28,7 @@ ScrollingWindow {
     minSize: Qt.vector2d(200, 300)
 
     property int colorScheme: hifi.colorSchemes.dark
+    property int selectionMode: SelectionMode.ExtendedSelection
 
     HifiConstants { id: hifi }
 
@@ -35,7 +36,8 @@ ScrollingWindow {
     property var assetProxyModel: Assets.proxyModel;
     property var assetMappingsModel: Assets.mappingModel;
     property var currentDirectory;
-
+    property var selectedItems: treeView.selection.selectedIndexes.length;
+    
     Settings {
         category: "Overlay.AssetServer"
         property alias x: root.x
@@ -48,7 +50,7 @@ ScrollingWindow {
         assetMappingsModel.errorGettingMappings.connect(handleGetMappingsError);
         reload();
     }
-
+    
     function doDeleteFile(path) {
         console.log("Deleting " + path);
 
@@ -118,10 +120,22 @@ ScrollingWindow {
 
     function canAddToWorld(path) {
         var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i];
+        
+        if (selectedItems > 1) {
+            return false;
+        }
 
         return supportedExtensions.reduce(function(total, current) {
             return total | new RegExp(current).test(path);
         }, false);
+    }
+    
+    function canRename() {    
+        if (treeView.selection.hasSelection && selectedItems == 1) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     function clear() {
@@ -289,24 +303,38 @@ ScrollingWindow {
         });
     }
     function deleteFile(index) {
+        var path=[];
+        
         if (!index) {
-            index = treeView.selection.currentIndex;
+            for (var i = 0; i < selectedItems; i++) {
+                 treeView.selection.setCurrentIndex(treeView.selection.selectedIndexes[i], 0x100);
+                 index = treeView.selection.currentIndex;
+                 path[i] = assetProxyModel.data(index, 0x100);                  
+            }
         }
-        var path = assetProxyModel.data(index, 0x100);
+        
         if (!path) {
             return;
         }
-
+        
+        var modalMessage = "";
+        var items = selectedItems.toString();
         var isFolder = assetProxyModel.data(treeView.selection.currentIndex, 0x101);
         var typeString = isFolder ? 'folder' : 'file';
-
+        
+        if (selectedItems > 1) {
+            modalMessage = "You are about to delete " + items + " items \nDo you want to continue?";
+        } else {
+            modalMessage = "You are about to delete the following " + typeString + ":\n" + path + "\nDo you want to continue?";
+        }
+        
         var object = desktop.messageBox({
             icon: hifi.icons.question,
             buttons: OriginalDialogs.StandardButton.Yes + OriginalDialogs.StandardButton.No,
             defaultButton: OriginalDialogs.StandardButton.Yes,
             title: "Delete",
-            text: "You are about to delete the following " + typeString + ":\n" + path + "\nDo you want to continue?"
-        });
+            text: modalMessage
+            });
         object.selected.connect(function(button) {
             if (button === OriginalDialogs.StandardButton.Yes) {
                 doDeleteFile(path);
@@ -445,20 +473,20 @@ ScrollingWindow {
                     color: hifi.buttons.black
                     colorScheme: root.colorScheme
                     width: 120
-
+                    
                     enabled: canAddToWorld(assetProxyModel.data(treeView.selection.currentIndex, 0x100))
-
+                    
                     onClicked: root.addToWorld()
                 }
-
+                
                 HifiControls.Button {
                     text: "Rename"
                     color: hifi.buttons.black
                     colorScheme: root.colorScheme
                     width: 80
-
+                    
                     onClicked: root.renameFile()
-                    enabled: treeView.selection.hasSelection
+                    enabled: canRename()
                 }
 
                 HifiControls.Button {
@@ -514,6 +542,7 @@ ScrollingWindow {
             treeModel: assetProxyModel
             canEdit: true
             colorScheme: root.colorScheme
+            selectionMode: SelectionMode.ExtendedSelection
 
             modifyEl: renameEl
 

--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -334,7 +334,7 @@ ScrollingWindow {
             defaultButton: OriginalDialogs.StandardButton.Yes,
             title: "Delete",
             text: modalMessage
-            });
+        });
         object.selected.connect(function(button) {
             if (button === OriginalDialogs.StandardButton.Yes) {
                 doDeleteFile(path);

--- a/interface/resources/qml/AssetServer.qml
+++ b/interface/resources/qml/AssetServer.qml
@@ -303,7 +303,7 @@ ScrollingWindow {
         });
     }
     function deleteFile(index) {
-        var path=[];
+        var path = [];
         
         if (!index) {
             for (var i = 0; i < selectedItems; i++) {

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -303,7 +303,7 @@ Rectangle {
         });
     }
     function deleteFile(index) {
-        var path=[];
+        var path = [];
         
         if (!index) {
             for (var i = 0; i < selectedItems; i++) {

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -37,6 +37,7 @@ Rectangle {
     property var assetProxyModel: Assets.proxyModel;
     property var assetMappingsModel: Assets.mappingModel;
     property var currentDirectory;
+    property var selectedItems: treeView.selection.selectedIndexes.length;
 
     Settings {
         category: "Overlay.AssetServer"
@@ -119,10 +120,22 @@ Rectangle {
 
     function canAddToWorld(path) {
         var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i];
+        
+        if (selectedItems > 1) {
+            return false;
+        }
 
         return supportedExtensions.reduce(function(total, current) {
             return total | new RegExp(current).test(path);
         }, false);
+    }
+    
+    function canRename() {    
+        if (treeView.selection.hasSelection && selectedItems == 1) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     function clear() {
@@ -290,23 +303,37 @@ Rectangle {
         });
     }
     function deleteFile(index) {
+        var path=[];
+        
         if (!index) {
-            index = treeView.selection.currentIndex;
+            for (var i = 0; i < selectedItems; i++) {
+                 treeView.selection.setCurrentIndex(treeView.selection.selectedIndexes[i], 0x100);
+                 index = treeView.selection.currentIndex;
+                 path[i] = assetProxyModel.data(index, 0x100);                  
+            }
         }
-        var path = assetProxyModel.data(index, 0x100);
+        
         if (!path) {
             return;
         }
 
+        var modalMessage = "";
+        var items = selectedItems.toString();
         var isFolder = assetProxyModel.data(treeView.selection.currentIndex, 0x101);
         var typeString = isFolder ? 'folder' : 'file';
+        
+        if (selectedItems > 1) {
+            modalMessage = "You are about to delete " + items + " items \nDo you want to continue?";
+        } else {
+            modalMessage = "You are about to delete the following " + typeString + ":\n" + path + "\nDo you want to continue?";
+        }
 
         var object = tabletRoot.messageBox({
                                             icon: hifi.icons.question,
                                             buttons: OriginalDialogs.StandardButton.Yes + OriginalDialogs.StandardButton.No,
                                             defaultButton: OriginalDialogs.StandardButton.Yes,
                                             title: "Delete",
-                                            text: "You are about to delete the following " + typeString + ":\n" + path + "\nDo you want to continue?"
+                                            text: modalMessage
                                         });
         object.selected.connect(function(button) {
             if (button === OriginalDialogs.StandardButton.Yes) {
@@ -459,7 +486,7 @@ Rectangle {
                     width: 80
 
                     onClicked: root.renameFile()
-                    enabled: treeView.selection.hasSelection
+                    enabled: canRename()
                 }
 
                 HifiControls.Button {
@@ -515,6 +542,7 @@ Rectangle {
             treeModel: assetProxyModel
             canEdit: true
             colorScheme: root.colorScheme
+            selectionMode: SelectionMode.ExtendedSelection
 
             modifyEl: renameEl
 


### PR DESCRIPTION
With reference to https://highfidelity.fogbugz.com/f/cases/6513/Allow-a-user-to-select-more-than-one-thing-in-the-asset-browser
Allowed user to select multiple items in the asset browser (using ctrl+click or cmd+click and shift+click)
Multiple items can be deleted together

Testing Notes:
1) Run the built PR
2) Open Asset Browser
3) Click one item and ctrl+click (cmd+click) on another item -> Both the items should get selected
4) Click one item and shift+click on another item -> The entire range of items gets selected.
5) When multiple items are selected, observe "Add to World" and "Rename" buttons are disabled
6) Select multiple items and click "Delete"
7) Observe resulting modal displays the count of items marked for deletion.
8) Observe the selected items are deleted

Note: When a single item is selected, the Delete modal displays if the item being deleted is a file/folder and its path. When multiple items are selected, it just displays the number of items marked for deletion. 
