### PR TITLE
Prevent deadlocks from Overlays update logic recursing into other Overlays calls

### DIFF
--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -323,7 +323,7 @@ signals:
 private:
     void cleanupOverlaysToDelete();
 
-    mutable QMutex _mutex;
+    mutable QMutex _mutex { QMutex::Recursive };
     QMap<OverlayID, Overlay::Pointer> _overlaysHUD;
     QMap<OverlayID, Overlay::Pointer> _overlaysWorld;
 #if OVERLAY_PANELS


### PR DESCRIPTION
We had our first deadlock on Qt 5.9.1 based code.  Because of the debug symbols provided by Qt I was able to reconstruct the stack trace and identify the problem easily.  

![image](https://user-images.githubusercontent.com/1533642/28700262-71f2146e-7303-11e7-8c93-304843a640fa.png)

When running `Overlays::update`, a lock is held.  However, the `Text3DOverlay` update function will sometimes call `Overlay::getTransform`.  If the `Text3DOverlay` has recently changed it's parent ID (or recently been created with a parent ID), then calling `getTransform` will trigger `SpatialParentFinder::find`, which will search for the parent ID in entities and overlays.  To find the overlay parent, it will call `Overlays::getOverlay()`, which in turn will attempt to acquire the lock which is already held further up in the stack in `Overlays::update`, thus a deadlock.

The simplest solution for now is to make the `Overlays::_mutex` member recursive, so it can be locked and unlocked multiple times within a given thread.  

## Testing

Create a Text3DOverlay parented to another overlay.  Repeatedly change the Text3DOverlay parent from null or the other overlay ID.  In master this will likely eventually deadlock.  In this build it should not deadlock.  