### PR TITLE
Fix Landscape mode, when menu pushed in Create mode

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -192,7 +192,6 @@ void Web3DOverlay::loadSourceURL() {
             _webSurface->getSurfaceContext()->setContextProperty("SoundCache", DependencyManager::get<SoundCache>().data());
 
             _webSurface->getSurfaceContext()->setContextProperty("pathToFonts", "../../");
-            _webSurface->getSurfaceContext()->setContextProperty("Paths", DependencyManager::get<PathUtils>().data());
 
             tabletScriptingInterface->setQmlTabletRoot("com.highfidelity.interface.tablet.system", _webSurface.data());
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -205,6 +205,8 @@ void Web3DOverlay::loadSourceURL() {
             _webSurface->getSurfaceContext()->setContextProperty("SoundCache", DependencyManager::get<SoundCache>().data());
 
             _webSurface->getSurfaceContext()->setContextProperty("pathToFonts", "../../");
+            _webSurface->getSurfaceContext()->setContextProperty("Paths", DependencyManager::get<PathUtils>().data());
+
             tabletScriptingInterface->setQmlTabletRoot("com.highfidelity.interface.tablet.system", _webSurface.data());
 
             // mark the TabletProxy object as cpp ownership.

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -483,6 +483,11 @@ bool TabletProxy::pushOntoStack(const QVariant& path) {
         return result;
     }
 
+    //set landscape off when pushing menu items while in Create mode
+    if (_landscape) {
+        setLandscape(false);
+    }
+
     QObject* root = nullptr;
     if (!_toolbarMode && _qmlTabletRoot) {
         root = _qmlTabletRoot;


### PR DESCRIPTION
Test plan:
- in Tablet in desktop mode click on Create button
- check Tablet switched to Landscape
- on Desktop menu select Settings->General (Audio etc)
- check if Tablet switched back to portrait mode
