### PR TITLE
Fix tablet button crash

### DIFF
--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -825,7 +825,13 @@ TabletButtonProxy::~TabletButtonProxy() {
 
 void TabletButtonProxy::setQmlButton(QQuickItem* qmlButton) {
     Q_ASSERT(QThread::currentThread() == qApp->thread());
+    if (_qmlButton) {
+        QObject::disconnect(_qmlButton, &QQuickItem::destroyed, this, nullptr);
+    }
     _qmlButton = qmlButton;
+    if (_qmlButton) {
+        QObject::connect(_qmlButton, &QQuickItem::destroyed, this, [this] { _qmlButton = nullptr; });
+    }
 }
 
 void TabletButtonProxy::setToolbarButtonProxy(QObject* toolbarButtonProxy) {


### PR DESCRIPTION
This crash is frequently showing up when switching between desktop and HMD mode although the underlying cause seems to be related to switching toolbar and tablet mode.  For some reason an invalid QML object pointer is being retained inside the TabletButtonProxy, and is causing the crash when we attempt to invoke methods on it to update the properties of the button.  


This PR avoids the problem by connecting to the destruction signal of the QML button object and clearing the pointer if the button is destroyed.  It's possible that this may cause incorrect behavior as I still don't quite understand how the button is being destroyed, although it seems to be related to the `addButtonsToHomeScreen` logic being called multiple times after switching to tablet mode.  However, it should prevent a crash

Fixes https://highfidelity.fogbugz.com/f/cases/6561/Crash-In-VR-change-to-desktop-click-VR-press-Esc-crash

## Testing

Start in VR mode.  Switch to desktop and back to VR.  If it doesn't immediately crash, try pressing escape.  This seems to reliably crash in master.  In this build it should not crash.  