### PR TITLE
Fix overlay event handling thread issues

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -706,27 +706,27 @@ bool Overlays::isAddedOverlay(OverlayID id) {
 }
 
 void Overlays::sendMousePressOnOverlay(OverlayID overlayID, const PointerEvent& event) {
-    emit mousePressOnOverlay(overlayID, event);
+    QMetaObject::invokeMethod(this, "mousePressOnOverlay", Q_ARG(OverlayID, overlayID), Q_ARG(PointerEvent, event));
 }
 
 void Overlays::sendMouseReleaseOnOverlay(OverlayID overlayID, const PointerEvent& event) {
-    emit mouseReleaseOnOverlay(overlayID, event);
+    QMetaObject::invokeMethod(this, "mouseReleaseOnOverlay", Q_ARG(OverlayID, overlayID), Q_ARG(PointerEvent, event));
 }
 
 void Overlays::sendMouseMoveOnOverlay(OverlayID overlayID, const PointerEvent& event) {
-    emit mouseMoveOnOverlay(overlayID, event);
+    QMetaObject::invokeMethod(this, "mouseMoveOnOverlay", Q_ARG(OverlayID, overlayID), Q_ARG(PointerEvent, event));
 }
 
 void Overlays::sendHoverEnterOverlay(OverlayID id, PointerEvent event) {
-    emit hoverEnterOverlay(id, event);
+    QMetaObject::invokeMethod(this, "hoverEnterOverlay", Q_ARG(OverlayID, id), Q_ARG(PointerEvent, event));
 }
 
 void Overlays::sendHoverOverOverlay(OverlayID  id, PointerEvent event) {
-    emit hoverOverOverlay(id, event);
+    QMetaObject::invokeMethod(this, "hoverOverOverlay", Q_ARG(OverlayID, id), Q_ARG(PointerEvent, event));
 }
 
 void Overlays::sendHoverLeaveOverlay(OverlayID  id, PointerEvent event) {
-    emit hoverLeaveOverlay(id, event);
+    QMetaObject::invokeMethod(this, "hoverLeaveOverlay", Q_ARG(OverlayID, id), Q_ARG(PointerEvent, event));
 }
 
 OverlayID Overlays::getKeyboardFocusOverlay() {

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -72,7 +72,6 @@ signals:
 private:
     InputMode _inputMode { Touch };
     QSharedPointer<OffscreenQmlSurface> _webSurface;
-    QMetaObject::Connection _connection;
     gpu::TexturePointer _texture;
     QString _url;
     QString _scriptURL;
@@ -88,14 +87,6 @@ private:
     uint8_t _currentMaxFPS { 0 };
 
     bool _mayNeedResize { false };
-
-    QMetaObject::Connection _mousePressConnection;
-    QMetaObject::Connection _mouseReleaseConnection;
-    QMetaObject::Connection _mouseMoveConnection;
-    QMetaObject::Connection _hoverLeaveConnection;
-
-    QMetaObject::Connection _emitScriptEventConnection;
-    QMetaObject::Connection _webEventReceivedConnection;
 };
 
 #endif // hifi_Web3DOverlay_h


### PR DESCRIPTION
Several issues were leading to intermittent crashes in the QML code.  

First, having a function like this

    void Overlays::sendMouseMoveOnOverlay(OverlayID overlayID, const PointerEvent& event) {
        emit mousePressOnOverlay(overlayID, event);
    }

makes no sense.  The apparent intent would be to translate the method call to a signal on the correct thread, but this does not happen.  The signal is emitted on the source thread, and any handler which is using a `Qt::DirectConnection` will be triggered _on that thread_.  The better alternative is to use method invokation to trigger the signal like so

    void Overlays::sendMousePressOnOverlay(OverlayID overlayID, const PointerEvent& event) {
        QMetaObject::invokeMethod(this, "mousePressOnOverlay", Q_ARG(OverlayID, overlayID), Q_ARG(PointerEvent, event));
    }

This ensures that the signal will be sent on the correct thread.  

The second issue was the use of `Qt::DirectConnection` in `Web3DOverlay`.  Except in very few cases, the use of `Qt::AutoConnection` is preferred.  If the signal happens on the same thread as the handler's owner thread, then `Qt::AutoConnection` will behave the same as  `Qt::DirectConnection` anyway.  The only time `Qt::DirectConnection` should be use is when the functionality is time critical _AND_ you know that the handler code is safe to be run on any thread.  In this instance, that's explicitly not the case.  

Next, the use of `postEvent` to forward synthetic touch and mouse events to a QML surface that might be destroyed between the sending of the event and the processing of the event is dangerous.  `sendEvent` should be used instead.  

Finally, the use of explicit `QMetaObject::Connection` objects turns out to be unnecessary.  It's possible to disconnect a given sender / signal from all of a given receivers handling, including lambda handlers with the syntax `QObject::connect(sender, &Sender::signal, receiver, nullptr);`

## Testing

This crash seems to be related to interacting with the tablet repeatedly in stylus mode, possibly related to opening and closing the tablet, but not necessarily.  Rapidly moving the stylus around the tablet buttons and clicking on and then returning from resulting pages may trigger crashes on master.  This build should not crash.