### PR TITLE
Disable touch event emulation for tablet until we fix crash

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -337,11 +337,19 @@ void Web3DOverlay::setProxyWindow(QWindow* proxyWindow) {
 }
 
 void Web3DOverlay::handlePointerEvent(const PointerEvent& event) {
+    // FIXME touch event emulation is broken in some way.  Do NOT enable this code
+    // unless you have done a debug build of the application and verified that 
+    // you are not getting assertion errors on handling the touch events inside
+    // Qt.
+#if 0
     if (_inputMode == Touch) {
         handlePointerEventAsTouch(event);
     } else {
         handlePointerEventAsMouse(event);
     }
+#else
+    handlePointerEventAsMouse(event);
+#endif
 }
 
 void Web3DOverlay::handlePointerEventAsTouch(const PointerEvent& event) {


### PR DESCRIPTION
A number of crashes are coming from deep inside QML processing for QQuickWindow, related to something called a mouseGrabber.

Building in debug mode revealed assertion failures when sending touch event from `Web3DOverlay::handlePointerEventAsTouch`.  This clearly indicates that whatever we're doing in that function to create our synthetic touch events is somehow incorrect and is breaking the internal state of Qt's QML system.  Until we can further debug this and determine the correct way to simulate touch events, this code path needs to be disabled.

## Testing

With a HMD and hand controllers, open the tablet and select 'Go To'.  Select the address bar and then use both hands to start typing on the virtual keyboard.  In the master build you will rapidly crash.  In this build you will not crash.  