### PR TITLE
Fix web touch emulation

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -248,7 +248,7 @@ void Web3DOverlay::render(RenderArgs* args) {
             if (!self) {
                 return;
             }
-            if (self->_pressed && overlayID == selfOverlayID) {
+            if (overlayID == selfOverlayID && (self->_pressed || (!self->_activeTouchPoints.empty() && self->_touchBeginAccepted))) {
                 PointerEvent endEvent(PointerEvent::Release, event.getID(), event.getPos2D(), event.getPos3D(), event.getNormal(), event.getDirection(),
                                       event.getButton(), event.getButtons(), event.getKeyboardModifiers());
                 forwardPointerEvent(overlayID, event);
@@ -337,19 +337,11 @@ void Web3DOverlay::setProxyWindow(QWindow* proxyWindow) {
 }
 
 void Web3DOverlay::handlePointerEvent(const PointerEvent& event) {
-    // FIXME touch event emulation is broken in some way.  Do NOT enable this code
-    // unless you have done a debug build of the application and verified that 
-    // you are not getting assertion errors on handling the touch events inside
-    // Qt.
-#if 0
     if (_inputMode == Touch) {
         handlePointerEventAsTouch(event);
     } else {
         handlePointerEventAsMouse(event);
     }
-#else
-    handlePointerEventAsMouse(event);
-#endif
 }
 
 void Web3DOverlay::handlePointerEventAsTouch(const PointerEvent& event) {
@@ -357,19 +349,68 @@ void Web3DOverlay::handlePointerEventAsTouch(const PointerEvent& event) {
         return;
     }
 
-    glm::vec2 windowPos = event.getPos2D() * (METERS_TO_INCHES * _dpi);
-    QPointF windowPoint(windowPos.x, windowPos.y);
-
-    if (event.getType() == PointerEvent::Press && event.getButton() == PointerEvent::PrimaryButton) {
-        this->_pressed = true;
-    } else if (event.getType() == PointerEvent::Release && event.getButton() == PointerEvent::PrimaryButton) {
-        this->_pressed = false;
+    //do not send secondary button events to tablet
+    if (event.getButton() == PointerEvent::SecondaryButton ||
+        //do not block composed events
+        event.getButtons() == PointerEvent::SecondaryButton) {
+        return;
     }
 
-    QEvent::Type touchType;
-    Qt::TouchPointState touchPointState;
-    QEvent::Type mouseType;
 
+    QPointF windowPoint;
+    {
+        glm::vec2 windowPos = event.getPos2D() * (METERS_TO_INCHES * _dpi);
+        windowPoint = QPointF(windowPos.x, windowPos.y);
+    }
+
+    Qt::TouchPointState state = Qt::TouchPointStationary;
+    if (event.getType() == PointerEvent::Press && event.getButton() == PointerEvent::PrimaryButton) {
+        state = Qt::TouchPointPressed;
+    } else if (event.getType() == PointerEvent::Release) {
+        state = Qt::TouchPointReleased;
+    } else if (_activeTouchPoints.count(event.getID()) && windowPoint != _activeTouchPoints[event.getID()].pos()) {
+        state = Qt::TouchPointMoved;
+    }
+
+    QEvent::Type touchType = QEvent::TouchUpdate;
+    if (_activeTouchPoints.empty()) {
+        // If the first active touch point is being created, send a begin
+        touchType = QEvent::TouchBegin;
+    } if (state == Qt::TouchPointReleased && _activeTouchPoints.size() == 1 && _activeTouchPoints.count(event.getID())) {
+        // If the last active touch point is being released, send an end
+        touchType = QEvent::TouchEnd;
+    } 
+
+    {
+        QTouchEvent::TouchPoint point;
+        point.setId(event.getID());
+        point.setState(state);
+        point.setPos(windowPoint);
+        point.setScreenPos(windowPoint);
+        _activeTouchPoints[event.getID()] = point;
+    }
+
+    QTouchEvent touchEvent(touchType, &_touchDevice, event.getKeyboardModifiers());
+    {
+        QList<QTouchEvent::TouchPoint> touchPoints;
+        Qt::TouchPointStates touchPointStates;
+        for (const auto& entry : _activeTouchPoints) {
+            touchPointStates |= entry.second.state();
+            touchPoints.push_back(entry.second);
+        }
+
+        touchEvent.setWindow(_webSurface->getWindow());
+        touchEvent.setTarget(_webSurface->getRootItem());
+        touchEvent.setTouchPoints(touchPoints);
+        touchEvent.setTouchPointStates(touchPointStates);
+    }
+
+    // Send mouse events to the Web surface so that HTML dialog elements work with mouse press and hover.
+    // FIXME: Scroll bar dragging is a bit unstable in the tablet (content can jump up and down at times).
+    // This may be improved in Qt 5.8. Release notes: "Cleaned up touch and mouse event delivery".
+    //
+    // In Qt 5.9 mouse events must be sent before touch events to make sure some QtQuick components will
+    // receive mouse events
     Qt::MouseButton button = Qt::NoButton;
     Qt::MouseButtons buttons = Qt::NoButton;
     if (event.getButton() == PointerEvent::PrimaryButton) {
@@ -379,84 +420,27 @@ void Web3DOverlay::handlePointerEventAsTouch(const PointerEvent& event) {
         buttons |= Qt::LeftButton;
     }
 
-    switch (event.getType()) {
-        case PointerEvent::Press:
-            touchType = QEvent::TouchBegin;
-            touchPointState = Qt::TouchPointPressed;
-            mouseType = QEvent::MouseButtonPress;
-            break;
-        case PointerEvent::Release:
-            touchType = QEvent::TouchEnd;
-            touchPointState = Qt::TouchPointReleased;
-            mouseType = QEvent::MouseButtonRelease;
-            break;
-        case PointerEvent::Move:
-            touchType = QEvent::TouchUpdate;
-            touchPointState = Qt::TouchPointMoved;
-            mouseType = QEvent::MouseMove;
-
-            if (((event.getButtons() & PointerEvent::PrimaryButton) > 0) != this->_pressed) {
-                // Mouse was pressed/released while off the overlay; convert touch and mouse events to press/release to reflect
-                // current mouse/touch status.
-                this->_pressed = !this->_pressed;
-                if (this->_pressed) {
-                    touchType = QEvent::TouchBegin;
-                    touchPointState = Qt::TouchPointPressed;
-                    mouseType = QEvent::MouseButtonPress;
-
-                } else {
-                    touchType = QEvent::TouchEnd;
-                    touchPointState = Qt::TouchPointReleased;
-                    mouseType = QEvent::MouseButtonRelease;
-
-                }
-                button = Qt::LeftButton;
-                buttons |= Qt::LeftButton;
-            }
-
-            break;
-        default:
-            return;
-    }
-
-    //do not send secondary button events to tablet
-    if (event.getButton() == PointerEvent::SecondaryButton ||
-            //do not block composed events
-            event.getButtons() == PointerEvent::SecondaryButton) {
-        return;
-    }
-
-    QTouchEvent::TouchPoint point;
-    point.setId(event.getID());
-    point.setState(touchPointState);
-    point.setPos(windowPoint);
-    point.setScreenPos(windowPoint);
-    QList<QTouchEvent::TouchPoint> touchPoints;
-    touchPoints.push_back(point);
-
-    QTouchEvent touchEvent(touchType, &_touchDevice, event.getKeyboardModifiers());
-    touchEvent.setWindow(_webSurface->getWindow());
-    touchEvent.setTarget(_webSurface->getRootItem());
-    touchEvent.setTouchPoints(touchPoints);
-    touchEvent.setTouchPointStates(touchPointState);
-
-    // Send mouse events to the Web surface so that HTML dialog elements work with mouse press and hover.
-    // FIXME: Scroll bar dragging is a bit unstable in the tablet (content can jump up and down at times).
-    // This may be improved in Qt 5.8. Release notes: "Cleaned up touch and mouse event delivery".
-    //
-    // In Qt 5.9 mouse events must be sent before touch events to make sure some QtQuick components will
-    // receive mouse events
 #if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
     if (event.getType() == PointerEvent::Move) {
-        QMouseEvent mouseEvent(mouseType, windowPoint, windowPoint, windowPoint, button, buttons, Qt::NoModifier);
+        QMouseEvent mouseEvent(QEvent::MouseMove, windowPoint, windowPoint, windowPoint, button, buttons, Qt::NoModifier);
         QCoreApplication::sendEvent(_webSurface->getWindow(), &mouseEvent);
     }
 #endif
-    QCoreApplication::sendEvent(_webSurface->getWindow(), &touchEvent);
+
+    if (touchType == QEvent::TouchBegin) {
+        _touchBeginAccepted = QCoreApplication::sendEvent(_webSurface->getWindow(), &touchEvent);
+    } else if (_touchBeginAccepted) {
+        QCoreApplication::sendEvent(_webSurface->getWindow(), &touchEvent);
+    }
+
+    // If this was a release event, remove the point from the active touch points
+    if (state == Qt::TouchPointReleased) {
+        _activeTouchPoints.erase(event.getID());
+    }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
     if (event.getType() == PointerEvent::Move) {
-        QMouseEvent mouseEvent(mouseType, windowPoint, windowPoint, windowPoint, button, buttons, Qt::NoModifier);
+        QMouseEvent mouseEvent(QEvent::MouseMove, windowPoint, windowPoint, windowPoint, button, buttons, Qt::NoModifier);
         QCoreApplication::sendEvent(_webSurface->getWindow(), &mouseEvent);
     }
 #endif

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -81,6 +81,8 @@ private:
     bool _showKeyboardFocusHighlight{ true };
 
     bool _pressed{ false };
+    bool _touchBeginAccepted { false };
+    std::map<uint32_t, QTouchEvent::TouchPoint> _activeTouchPoints;
     QTouchDevice _touchDevice;
 
     uint8_t _desiredMaxFPS { 10 };


### PR DESCRIPTION
The touch events have been leading to occasional crashes.  This is particularly easy to replicate by using multiple hands on the tablet at once.  Running in debug mode this rapidly leads to assertion errors inside the QML code.  I believe the problem is that we're not sending touch events the way actual hardware would and as such we're breaking the internal state of the QML classes, which have some fairly complicated internal logic on how to process touch events (examine [qquickwindow.cpp](http://code.qt.io/cgit/qt/qtdeclarative.git/tree/src/quick/items/qquickwindow.cpp?h=5.9) and see all the instances of `touchMouseId` for example).

Fortunately I have a laptop with a multi-touch screen and was able to create a small test app that reported incoming touch events.  Armed with the documentation for touch processing as well as some empirical data, I determined how we should behave... 

The rules for touch events are:

 * When a first touch point is detected, send a `TouchBegin` event.  If this `TouchBegin` event is accepted, further `TouchUpdate` events and eventually a `TouchEnd` event will be sent.  If `TouchBegin` is _not_ accepted, no further events will be sent until the next `TouchBegin`
* If a second touch point is added in between an accepted `TouchBegin` and `TouchEnd`, it arrives as a `TouchUpdate` where the new touch point has the flag `TouchPointPressed`.  
* Similarly, if we release a touch point between `TouchBegin` and `TouchEnd` and it is NOT the last touch point, it arrives as a `TouchUpdate` where the leaving touch point has the flag `TouchPointReleased`, and subsequent `TouchUpdate` and `TouchEnd` events do not include this point unless it is re-added as in the previous bullet point

The old code sent `TouchBegin` and `TouchEnd` events strictly based on the pressed / released state of the incoming pointer event and without regard to whether an existing `TouchBegin` had already been sent.  This meant that you could have got interleaved or nested `TouchBegin`/`TouchEnd` messages from the left and right hands, depending on the order of operations.  Since both hands were reporting the same `TouchDevice` this likely violated the contract for how touch events would be delivered.  Additionally the old code did not respect the promise that a non-accepted `TouchBegin` message would result in no further messages until the next `TouchBegin`.

The new code instead tracks the active touch points, and send a `TouchBegin` when a first point becomes active, and a `TouchEnd` when the last point ceases to be active.  All other messages are sent as `TouchUpdate`.  The code also tracks whether a given `TouchBegin` was accepted and only sends the `TouchUpdate` and `TouchEnd` if it was.  It still tracks the state of all the points, so it knows when to send the next `TouchBegin`

## Testing

This is a well scoped change (it only applies to the Web3DOverlay type) but is a serious change in logic, with significant new amount of internal state tracking in order to try to emulate the expected behavior of touch events.  

Care should be taken to thoroughly test the tablet functionality with hand controllers, as well as with mouse and eye tracking interaction.  


