### PR TITLE
Opened up setForceFaceTrackerConnected

### DIFF
--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -547,7 +547,7 @@ public:
     Q_INVOKABLE void updateAvatarEntity(const QUuid& entityID, const QByteArray& entityData);
     Q_INVOKABLE void clearAvatarEntity(const QUuid& entityID);
 
-    void setForceFaceTrackerConnected(bool connected) { _forceFaceTrackerConnected = connected; }
+    Q_INVOKABLE void setForceFaceTrackerConnected(bool connected) { _forceFaceTrackerConnected = connected; }
 
     // key state
     void setKeyState(KeyState s) { _keyState = s; }


### PR DESCRIPTION
As per @humbletim's suggestion. Opened this up for some interesting applications.  enabling setForceFaceTrackerConnected allows set blendshapes to be transmitted to other users. This allows for interesting control of the avatar's face, and probably allowing avatars to emote again.

https://www.youtube.com/watch?v=oCDC_EA2yWE

And this is especially interesting when paired with the camera, and a control method for the avatar face expressions.

https://www.youtube.com/watch?v=pXfK2tlsjhI

This is an Experimental Non Worklist item.