### PR TITLE
Fix log warnings from non-notifiable properties

### DIFF
--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -25,8 +25,8 @@
 class PathUtils : public QObject, public Dependency {
     Q_OBJECT
     SINGLETON_DEPENDENCY
-    Q_PROPERTY(QString resources READ resourcesPath)
-    Q_PROPERTY(QUrl defaultScripts READ defaultScriptsLocation)
+    Q_PROPERTY(QString resources READ resourcesPath CONSTANT)
+    Q_PROPERTY(QUrl defaultScripts READ defaultScriptsLocation CONSTANT)
 public:
     static const QString& resourcesPath();
 


### PR DESCRIPTION
A recent fix to expose the `PathUtil` object to tablet QML surfaces started triggering this warning in the logs

```
[WARNING] [default] QQmlExpression: Expression file:///.../qml/hifi/tablet/EditTabView.qml:225:18 depends on non-NOTIFYable properties:
[WARNING] [default]     PathUtils::defaultScripts
```

To avoid this warning, a Q_PROPERTY used in QML must either have a `NOTIFY` signal function, or must be marked `CONSTANT`.  In this case, the value never changes over the lifetime of the object, so it's safe to set it to `CONSTANT`.  

## Testing

Verify the tablet edit functionality still works.  Verify that when using the edit controls on the tablet the above warning does not appear in the log.  