### PR TITLE
Fix for potential crash in JS console

### DIFF
--- a/interface/src/ui/JSConsole.h
+++ b/interface/src/ui/JSConsole.h
@@ -17,6 +17,7 @@
 #include <QFutureWatcher>
 #include <QObject>
 #include <QWidget>
+#include <QSharedPointer>
 
 #include "ui_console.h"
 #include "ScriptEngine.h"
@@ -29,10 +30,10 @@ const int CONSOLE_HEIGHT = 200;
 class JSConsole : public QWidget {
     Q_OBJECT
 public:
-    JSConsole(QWidget* parent, ScriptEngine* scriptEngine = NULL);
+    JSConsole(QWidget* parent, const QSharedPointer<ScriptEngine>& scriptEngine = QSharedPointer<ScriptEngine>());
     ~JSConsole();
 
-    void setScriptEngine(ScriptEngine* scriptEngine = NULL);
+    void setScriptEngine(const QSharedPointer<ScriptEngine>& scriptEngine = QSharedPointer<ScriptEngine>());
     void clear();
 
 public slots:
@@ -58,17 +59,14 @@ private:
     void setToNextCommandInHistory();
     void setToPreviousCommandInHistory();
     void resetCurrentCommandHistory();
-    QScriptValue executeCommandInWatcher(const QString& command);
 
     QFutureWatcher<QScriptValue> _executeWatcher;
     Ui::Console* _ui;
     int _currentCommandInHistory;
     QString _savedHistoryFilename;
     QList<QString> _commandHistory;
-    // Keeps track if the script engine is created inside the JSConsole
-    bool _ownScriptEngine;
     QString _rootCommand;
-    ScriptEngine* _scriptEngine;
+    QSharedPointer<ScriptEngine> _scriptEngine;
     static const QString _consoleFileName;
 };
 

--- a/interface/src/ui/TestingDialog.cpp
+++ b/interface/src/ui/TestingDialog.cpp
@@ -24,12 +24,12 @@ TestingDialog::TestingDialog(QWidget* parent) :
     _console->setFixedHeight(TESTING_CONSOLE_HEIGHT);
 
     auto _engines = DependencyManager::get<ScriptEngines>();
-    _engine = _engines->loadScript(qApp->applicationDirPath() + testRunnerRelativePath);
+    _engine.reset(_engines->loadScript(qApp->applicationDirPath() + testRunnerRelativePath));
     _console->setScriptEngine(_engine);
-    connect(_engine, &ScriptEngine::finished, this, &TestingDialog::onTestingFinished);
+    connect(_engine.data(), &ScriptEngine::finished, this, &TestingDialog::onTestingFinished);
 }
 
 void TestingDialog::onTestingFinished(const QString& scriptPath) {
-    _engine = nullptr;
-    _console->setScriptEngine(nullptr);
+    _engine.reset();
+    _console->setScriptEngine();
 }

--- a/interface/src/ui/TestingDialog.h
+++ b/interface/src/ui/TestingDialog.h
@@ -29,7 +29,7 @@ public:
 
 private:
     std::unique_ptr<JSConsole> _console;
-    ScriptEngine* _engine;
+    QSharedPointer<ScriptEngine> _engine;
 };
 
 #endif


### PR DESCRIPTION
From [Bugsplat 13523](https://www.bugsplat.com/individualCrash/?id=13523&database=interface_alpha).

The JS console issues commands by using QtConcurrent to run a function which then invokes a blocking queued connection to do the actual evaluation of the command.  However, there is no guard against either the `this` pointer or the `_scriptEngine` pointer becoming invalid between the call to `QtConcurrent::run` and the actual blocking invocation.  

This PR changes the JSConsole script engine member to be a `QSharedPointer<ScriptEngine>` rather than a `ScriptEngine*`.  This enables us to grab a weak pointer to it and pass the weak pointer by reference into a lambda passed to `QtConcurrent::run`.  This means that the invocation no longer depends on `this` at all and will now safely do nothing if the script engine has already been destroyed.

## Testing

It appears that this bug could be triggered by opening issuing a command in the JS console and then immediately closing the window, although what kind of timing is required is unclear.  It will likely be easier to reproduce on a machine with limited cores (an i5) during heavy loading when the thread pool is already occupied with a lot of work, so during loading of a content heavy domain.  

On the master branch, executing a command and immediately closing the console _may_ result in a crash.  On this build it should not.  