### PR TITLE
Fix potential nullptr access in EntityTreeElement

### DIFF
--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -1001,7 +1001,10 @@ int EntityTreeElement::readElementDataFromBuffer(const unsigned char* data, int 
                         if (!bestFitBefore && bestFitAfter) {
                             // This is the case where the entity existed, and is in some element in our tree...
                             if (currentContainingElement.get() != this) {
-                                currentContainingElement->removeEntityItem(entityItem);
+                                // if the currentContainingElement is non-null, remove the entity from it
+                                if (currentContainingElement) {
+                                    currentContainingElement->removeEntityItem(entityItem);
+                                }
                                 addEntityItem(entityItem);
                             }
                         }


### PR DESCRIPTION
Traced [BS crash](https://www.bugsplat.com/individualCrash/?id=13525&database=interface_alpha) to this code.  Not sure if it's supposed to be possible for this item to be empty, but it was, triggering the crash in this case.  Opened a FB ticket [here](https://highfidelity.fogbugz.com/f/cases/6658/crash-in-EntityTreeElement-readElementDataFromBuffer)

## Testing 

Smoke test.  I have no idea how to intentionally trigger this crash.  