### PR TITLE
turn ContextOverlays completely off/on

### DIFF
--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -15,7 +15,7 @@
         { "comment" : "Mouse turn need to be small continuous increments",
           "from": { "makeAxis" : [
                 [ "Keyboard.MouseMoveLeft" ],
-                [ "Keyboard.MouseMoveRight" ] 
+                [ "Keyboard.MouseMoveRight" ]
             ]
           },
           "when": [ "Application.InHMD", "Application.SnapTurn", "Keyboard.RightMouseButton" ],
@@ -31,8 +31,8 @@
         { "comment" : "Touchpad turn need to be small continuous increments, but without the RMB constraint",
           "from": { "makeAxis" : [
                 [ "Keyboard.TouchpadLeft" ],
-                [ "Keyboard.TouchpadRight" ] 
-            ] 
+                [ "Keyboard.TouchpadRight" ]
+            ]
           },
           "when": [ "Application.InHMD", "Application.SnapTurn" ],
           "to": "Actions.StepYaw",
@@ -131,6 +131,6 @@
         { "from": "Keyboard.Space", "to": "Actions.SHIFT" },
         { "from": "Keyboard.R", "to": "Actions.ACTION1" },
         { "from": "Keyboard.T", "to": "Actions.ACTION2" },
-        { "from": "Keyboard.Tab", "to": "Actions.ContextMenu" }
+        { "from": "Keyboard.RightMouseClicked", "to": "Actions.ContextMenu" }
     ]
 }

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -34,6 +34,11 @@ ContextOverlayInterface::ContextOverlayInterface() {
     _entityPropertyFlags += PROP_DIMENSIONS;
     _entityPropertyFlags += PROP_REGISTRATION_POINT;
 
+    // initially, set _enabled to match the switch.  Later we enable/disable via the getter/setters
+    // if we are in edit or pal (for instance).  Note this is temporary, as we expect to enable this all
+    // the time after getting edge highlighting, etc...
+    _enabled = _settingSwitch.get();
+
     auto entityTreeRenderer = DependencyManager::get<EntityTreeRenderer>().data();
     connect(entityTreeRenderer, SIGNAL(mousePressOnEntity(const EntityItemID&, const PointerEvent&)), this, SLOT(createOrDestroyContextOverlay(const EntityItemID&, const PointerEvent&)));
     connect(_tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"), &TabletProxy::tabletShownChanged, this, [&]() {
@@ -65,6 +70,16 @@ static const float CONTEXT_OVERLAY_UNHOVERED_PULSEMAX = 1.0f;
 static const float CONTEXT_OVERLAY_UNHOVERED_PULSEPERIOD = 1.0f;
 static const float CONTEXT_OVERLAY_UNHOVERED_COLORPULSE = 1.0f;
 static const float CONTEXT_OVERLAY_FAR_OFFSET = 0.1f;
+
+void ContextOverlayInterface::setEnabled(bool enabled) {
+    // only enable/disable if the setting in 'on'.   If it is 'off',
+    // make sure _enabled is always false.
+    if (_settingSwitch.get()) {
+        _enabled = enabled;
+    } else {
+        _enabled = false;
+    }
+}
 
 bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event) {
     if (_enabled && event.getButton() == PointerEvent::SecondaryButton) {

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -51,7 +51,7 @@ public:
 
     Q_INVOKABLE QUuid getCurrentEntityWithContextOverlay() { return _currentEntityWithContextOverlay; }
     void setCurrentEntityWithContextOverlay(const QUuid& entityID) { _currentEntityWithContextOverlay = entityID; }
-    void setEnabled(bool enabled) { _enabled = enabled; }
+    void setEnabled(bool enabled);
     bool getEnabled() { return _enabled; }
 
 public slots:
@@ -73,6 +73,8 @@ private:
 
     bool contextOverlayFilterPassed(const EntityItemID& entityItemID);
     glm::vec3 drawOutlineOverlay(const EntityItemID& entityItemID);
+
+    Setting::Handle<bool> _settingSwitch { "inspectionMode", false };
 };
 
 #endif // hifi_ContextOverlayInterface_h


### PR DESCRIPTION
This setting is temporary, and defaults to false so we don't have context overlays by default.