### PR TITLE
install the bundled vcredist_x64

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -853,9 +853,11 @@ Section "-Core installation"
   ; Rename the incorrectly cased Raleway font
   Rename "$INSTDIR\resources\qml\styles-uit\RalewaySemibold.qml" "$INSTDIR\resources\qml\styles-uit\RalewaySemiBold.qml"
 
+  ExecWait "$INSTDIR\vcredist_x64.exe /install /passive /norestart"
+
   ; Remove the Old Interface directory and vcredist_x64.exe (from installs prior to Server Console)
   RMDir /r "$INSTDIR\Interface"
-  Delete "$INSTDIR\vcredist_x64.exe"
+  ;Delete "$INSTDIR\vcredist_x64.exe"
 
   ;Use the entire tree produced by the INSTALL target.  Keep the
   ;list of directories here in sync with the RMDir commands below.


### PR DESCRIPTION
 instead of relying on DLLs being setup by cmake directly in the install folder