### PR TITLE
WL 21487: Fix Camera behavior in Mirror mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4483,11 +4483,9 @@ void Application::cameraModeChanged() {
 void Application::cameraMenuChanged() {
     auto menu = Menu::getInstance();
     if (menu->isOptionChecked(MenuOption::FullscreenMirror)) {
-        if (isHMDMode()) {
-            menu->setIsOptionChecked(MenuOption::FullscreenMirror, false);
-            menu->setIsOptionChecked(MenuOption::FirstPerson, true);
-        } else if (_myCamera.getMode() != CAMERA_MODE_MIRROR) {
+        if (_myCamera.getMode() != CAMERA_MODE_MIRROR) {
             _myCamera.setMode(CAMERA_MODE_MIRROR);
+            getMyAvatar()->reset(false, false, false); // to reset any active MyAvatar::FollowHelpers
         }
     } else if (menu->isOptionChecked(MenuOption::FirstPerson)) {
         if (_myCamera.getMode() != CAMERA_MODE_FIRST_PERSON) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2849,7 +2849,8 @@ bool MyAvatar::FollowHelper::shouldActivateVertical(const MyAvatar& myAvatar, co
 void MyAvatar::FollowHelper::prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat4& desiredBodyMatrix,
                                               const glm::mat4& currentBodyMatrix, bool hasDriveInput) {
 
-    if (myAvatar.getHMDLeanRecenterEnabled()) {
+    if (myAvatar.getHMDLeanRecenterEnabled() &&
+        qApp->getCamera().getMode() != CAMERA_MODE_MIRROR) {
         if (!isActive(Rotation) && (shouldActivateRotation(myAvatar, desiredBodyMatrix, currentBodyMatrix) || hasDriveInput)) {
             activate(Rotation);
         }

--- a/scripts/system/hmd.js
+++ b/scripts/system/hmd.js
@@ -40,9 +40,8 @@ function updateControllerDisplay() {
 var button;
 var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
 
-// Independent and Entity mode make people sick. Third Person and Mirror have traps that we need to work through.
-// Disable them in hmd.
-var desktopOnlyViews = ['Mirror', 'Independent Mode', 'Entity Mode'];
+// Independent and Entity mode make people sick; disable them in hmd.
+var desktopOnlyViews = ['Independent Mode', 'Entity Mode'];
 
 function onHmdChanged(isHmd) {
     HMD.closeTablet();


### PR DESCRIPTION
This PR disables the Avatar "follow" behavior while in fullscreen Mirror mode, which was previously causing sickening camera shifts for HMD users.  It also restores use of the existing keyboard shortcut and menu item for switching into Mirror mode from HMD.

Worklist specs: https://worklist.net/21487

### Testing
In roomscale HMD:
* Enable fullscreen Mirror mode (using <kbd>Ctrl</kbd>-<kbd>H</kbd> or "View > Mirror" menu item).
* Zoom out a bit so you can see yourself.
* In real life:
  * Walk forward or backward.
  * Look left/right.
  * Lean over in various directions.
* Verify the camera tracks your HMD's position and orientation -- but _does not_ attempt to automatically follow or recenter with your avatar. 
