### PR TITLE
Fix for crash when attempting to teleport while avatar was loading

### DIFF
--- a/scripts/system/controllers/teleport.js
+++ b/scripts/system/controllers/teleport.js
@@ -381,7 +381,13 @@ function getAvatarFootOffset() {
     }
     if (footJointIndex != -1) {
         // default vertical offset from foot to avatar root.
-        return -MyAvatar.getAbsoluteDefaultJointTranslationInObjectFrame(footJointIndex).y;
+        var footPos = MyAvatar.getAbsoluteDefaultJointTranslationInObjectFrame(footJointIndex);
+        if (footPos.x === 0 && footPos.y === 0 && footPos.z === 0.0) {
+            // if footPos is exactly zero, it's probably wrong because avatar is currently loading, fall back to default.
+            return DEFAULT_ROOT_TO_FOOT_OFFSET * MyAvatar.scale;
+        } else {
+            return -footPos.y;
+        }
     } else {
         return DEFAULT_ROOT_TO_FOOT_OFFSET * MyAvatar.scale;
     }


### PR DESCRIPTION
The fix had two parts.
  * Make Avatar::getAbsoluteDefaultJointXXXInObjectFrame thread safe
  * Make teleport.js handle a zero foot offset more gracefully, to prevent the avatar from teleporting into the floor.