### PR TITLE
Audio mic bar show only rectangle on mouse over

### DIFF
--- a/interface/resources/qml/hifi/audio/MicBar.qml
+++ b/interface/resources/qml/hifi/audio/MicBar.qml
@@ -27,7 +27,7 @@ Rectangle {
 
     color: "#00000000";
     border {
-        width: (standalone || Audio.muted || mouseArea.containsMouse) ? 2 : 0;
+        width: mouseArea.containsMouse || mouseArea.containsPress ? 2 : 0;
         color: colors.border;
     }
 
@@ -61,7 +61,7 @@ Rectangle {
         drag.target: dragTarget;
     }
 
-    Item {
+    QtObject {
         id: colors;
 
         readonly property string unmuted: "#FFF";
@@ -72,7 +72,7 @@ Rectangle {
         readonly property string red: colors.muted;
         readonly property string fill: "#55000000";
         readonly property string border: standalone ? "#80FFFFFF" : "#55FFFFFF";
-        readonly property string icon: (Audio.muted && !mouseArea.containsMouse) ? muted : unmuted;
+        readonly property string icon: Audio.muted ? muted : unmuted;
     }
 
     Item {
@@ -92,10 +92,8 @@ Rectangle {
                 readonly property string unmutedIcon: "../../../icons/tablet-icons/mic-unmute-i.svg";
                 readonly property string mutedIcon: "../../../icons/tablet-icons/mic-mute-i.svg";
 
-                function exclusiveOr(a, b) { return (a || b) && !(a && b); }
-
                 id: image;
-                source: exclusiveOr(Audio.muted, mouseArea.containsMouse) ? mutedIcon : unmutedIcon;
+                source: Audio.muted ? mutedIcon : unmutedIcon;
 
                 width: 30;
                 height: 30;
@@ -118,9 +116,9 @@ Rectangle {
     Item {
         id: status;
 
-        readonly property string color: (Audio.muted && !mouseArea.containsMouse) ? colors.muted : colors.unmuted;
+        readonly property string color: Audio.muted ? colors.muted : colors.unmuted;
 
-        visible: Audio.muted || mouseArea.containsMouse;
+        visible: Audio.muted;
 
         anchors {
             left: parent.left;
@@ -133,14 +131,14 @@ Rectangle {
 
         Text {
             anchors {
-        horizontalCenter: parent.horizontalCenter;
+                horizontalCenter: parent.horizontalCenter;
                 verticalCenter: parent.verticalCenter;
             }
 
             color: parent.color;
 
-            text: Audio.muted ? (mouseArea.containsMouse ? "UNMUTE" : "MUTED") : "MUTE";
-        font.pointSize: 12;
+            text: Audio.muted ? "MUTED" : "MUTE";
+            font.pointSize: 12;
         }
 
         Rectangle {
@@ -150,7 +148,7 @@ Rectangle {
             }
 
             width: 50;
-        height: 4;
+            height: 4;
             color: parent.color;
         }
 
@@ -161,7 +159,7 @@ Rectangle {
             }
 
             width: 50;
-        height: 4;
+            height: 4;
             color: parent.color;
         }
     }


### PR DESCRIPTION
Case:
https://highfidelity.fogbugz.com/f/cases/6614/Remove-OnHover-Behavior-for-Audio-Meter-other-than-White-Highlight

Test plan:
- Open the tablet
- Using your stylus, hover over the audio meter at the top
- make sure only border around audio meter appears when mouse is over