### PR TITLE
Fix installer issues

### DIFF
--- a/cmake/macros/GenerateInstallers.cmake
+++ b/cmake/macros/GenerateInstallers.cmake
@@ -24,21 +24,12 @@ macro(GENERATE_INSTALLERS)
   set(CPACK_NSIS_PACKAGE_NAME ${_DISPLAY_NAME})
   set(CPACK_PACKAGE_INSTALL_DIRECTORY ${_DISPLAY_NAME})
 
+
   if (WIN32)
-    # include CMake module that will install compiler system libraries
-    # so that we have msvcr120 and msvcp120 installed with targets
-    set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ${INTERFACE_INSTALL_DIR})
-
-    # as long as we're including sixense plugin with installer
-    # we need re-distributables for VS 2011 as well
-    # this should be removed if/when sixense support is pulled
-    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS
-      "${EXTERNALS_BINARY_DIR}/sixense/project/src/sixense/samples/win64/msvcr100.dll"
-      "${EXTERNALS_BINARY_DIR}/sixense/project/src/sixense/samples/win64/msvcp100.dll"
-    )
-
+    # Do not install the Visual Studio C runtime libraries.  The installer will do this automatically
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
+    
     include(InstallRequiredSystemLibraries)
-
     set(CPACK_NSIS_MUI_ICON "${HF_CMAKE_DIR}/installer/installer.ico")
 
     # install and reference the Add/Remove icon
@@ -90,3 +81,4 @@ macro(GENERATE_INSTALLERS)
 
   include(CPack)
 endmacro()
+

--- a/cmake/macros/InstallBesideConsole.cmake
+++ b/cmake/macros/InstallBesideConsole.cmake
@@ -22,9 +22,12 @@ macro(install_beside_console)
     else ()
       # setup install of executable and things copied by fixup/windeployqt
       install(
-        FILES "$<TARGET_FILE_DIR:${TARGET_NAME}>/"
+        DIRECTORY "$<TARGET_FILE_DIR:${TARGET_NAME}>/"
         DESTINATION ${COMPONENT_INSTALL_DIR}
         COMPONENT ${SERVER_COMPONENT}
+        PATTERN "*.pdb" EXCLUDE
+        PATTERN "*.lib" EXCLUDE
+        PATTERN "*.exp" EXCLUDE
       )
 
       # on windows for PR and production builds, sign the executable

--- a/cmake/templates/FixupBundlePostBuild.cmake.in
+++ b/cmake/templates/FixupBundlePostBuild.cmake.in
@@ -11,33 +11,27 @@
 
 include(BundleUtilities)
 
-# replace copy_resolved_item_into_bundle
-#
-# The official version of copy_resolved_item_into_bundle will print out a "warning:" when
-# the resolved item matches the resolved embedded item. This not not really an issue that
-# should rise to the level of a "warning" so we replace this message with a "status:"
-#
-function(copy_resolved_item_into_bundle resolved_item resolved_embedded_item)
-  if (WIN32)
-    # ignore case on Windows
-    string(TOLOWER "${resolved_item}" resolved_item_compare)
-    string(TOLOWER "${resolved_embedded_item}" resolved_embedded_item_compare)
-  else()
-    set(resolved_item_compare "${resolved_item}")
-    set(resolved_embedded_item_compare "${resolved_embedded_item}")
+function(gp_resolved_file_type_override resolved_file type_var)
+  if( file MATCHES ".*VCRUNTIME140.*" )
+    set(type "system" PARENT_SCOPE)
   endif()
-
-  if ("${resolved_item_compare}" STREQUAL "${resolved_embedded_item_compare}")
-    # this is our only change from the original version
-    message(STATUS "status: resolved_item == resolved_embedded_item - not copying...")
-  else()
-    #message(STATUS "copying COMMAND ${CMAKE_COMMAND} -E copy ${resolved_item} ${resolved_embedded_item}")
-    execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${resolved_item}" "${resolved_embedded_item}")
-    if(UNIX AND NOT APPLE)
-        file(RPATH_REMOVE FILE "${resolved_embedded_item}")
-    endif()
+  if( file MATCHES ".*concrt140.*" )
+    set(type "system" PARENT_SCOPE)
+  endif()
+  if( file MATCHES ".*msvcp140.*" )
+    set(type "system" PARENT_SCOPE)
+  endif()
+  if( file MATCHES ".*vcruntime140.*" )
+    set(type "system" PARENT_SCOPE)
+  endif()
+  if( file MATCHES ".*api-ms-win-crt-conio.*" )
+    set(type "system" PARENT_SCOPE)
+  endif()
+  if( file MATCHES ".*api-ms-win-core-winrt.*" )
+    set(type "system" PARENT_SCOPE)
   endif()
 endfunction()
+
 
 message(STATUS "FIXUP_LIBS for fixup_bundle called for bundle ${BUNDLE_EXECUTABLE} are @FIXUP_LIBS@")
 message(STATUS "Scanning for plugins from ${BUNDLE_PLUGIN_DIR}")
@@ -52,3 +46,4 @@ endif()
 
 file(GLOB EXTRA_PLUGINS "${BUNDLE_PLUGIN_DIR}/*.${PLUGIN_EXTENSION}")
 fixup_bundle("${BUNDLE_EXECUTABLE}" "${EXTRA_PLUGINS}" "@FIXUP_LIBS@")
+

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -853,9 +853,11 @@ Section "-Core installation"
   ; Rename the incorrectly cased Raleway font
   Rename "$INSTDIR\resources\qml\styles-uit\RalewaySemibold.qml" "$INSTDIR\resources\qml\styles-uit\RalewaySemiBold.qml"
 
+  ExecWait "$INSTDIR\vcredist_x64.exe /install /passive /norestart"
+
   ; Remove the Old Interface directory and vcredist_x64.exe (from installs prior to Server Console)
   RMDir /r "$INSTDIR\Interface"
-  Delete "$INSTDIR\vcredist_x64.exe"
+  ;Delete "$INSTDIR\vcredist_x64.exe"
 
   ;Use the entire tree produced by the INSTALL target.  Keep the
   ;list of directories here in sync with the RMDir commands below.

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -857,7 +857,7 @@ Section "-Core installation"
 
   ; Remove the Old Interface directory and vcredist_x64.exe (from installs prior to Server Console)
   RMDir /r "$INSTDIR\Interface"
-  ;Delete "$INSTDIR\vcredist_x64.exe"
+  Delete "$INSTDIR\vcredist_x64.exe"
 
   ;Use the entire tree produced by the INSTALL target.  Keep the
   ;list of directories here in sync with the RMDir commands below.

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -309,9 +309,12 @@ else (APPLE)
 
     # setup install of executable and things copied by fixup/windeployqt
     install(
-      FILES "$<TARGET_FILE_DIR:${TARGET_NAME}>/"
+      DIRECTORY "$<TARGET_FILE_DIR:${TARGET_NAME}>/"
       DESTINATION ${INTERFACE_INSTALL_DIR}
       COMPONENT ${CLIENT_COMPONENT}
+      PATTERN "*.pdb" EXCLUDE
+      PATTERN "*.lib" EXCLUDE
+      PATTERN "*.exp" EXCLUDE
     )
 
     set(SCRIPTS_INSTALL_DIR "${INTERFACE_INSTALL_DIR}")

--- a/plugins/hifiSixense/CMakeLists.txt
+++ b/plugins/hifiSixense/CMakeLists.txt
@@ -6,9 +6,11 @@
 #  See the accompanying file LICENSE or http:#www.apache.org/licenses/LICENSE-2.0.html
 #
 
-if (NOT ANDROID)
-  set(TARGET_NAME hifiSixense)
-  setup_hifi_plugin(Script Qml Widgets)
-  link_hifi_libraries(shared controllers ui plugins ui-plugins input-plugins)
-  target_sixense()
-endif ()
+# FIXME if we want to re-enable this, we need to fix the mechanism for installing the 
+# dependency dlls `msvcr100` and `msvcp100` WITHOUT using CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS
+#if (NOT ANDROID)
+#  set(TARGET_NAME hifiSixense)
+#  setup_hifi_plugin(Script Qml Widgets)
+#  link_hifi_libraries(shared controllers ui plugins ui-plugins input-plugins)
+#  target_sixense()
+#endif ()


### PR DESCRIPTION
This fixes several installer issues.  

* Remove the vcruntime140.dll, msvcrt140.dll and mscvrp140.dll artifacts from the installer by using `CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP`.  The vcredist call does what we need, so we don't need these dlls in the installer.
* Eliminate the PDB files getting added to the installer.   Changing the install commands from `INSTALL(FILES ...` to `INSTALL(DIRECTORY ...` allows us to add patterns for files to be excluded.  The lib, exp and pdb files from the build process should not be sent packed into the installer.  
* Eliminate sixense plugin for now, until we either decide it can be retired or we can fix the installation of its dependent dlls which are based on a MUCH older version of visual studio.  

## Testing

Basic smoke test.  This only modifies the installer. 

* Does interface still run?
* Do the server components (assignment client and domain server) still run?
* Does the sandbox function?

Installer size for windows should be significantly smaller than the current installer.. ~100 MB in my tests.  