### PR TITLE
Update WASAPI plugin

### DIFF
--- a/cmake/externals/wasapi/CMakeLists.txt
+++ b/cmake/externals/wasapi/CMakeLists.txt
@@ -6,8 +6,8 @@ if (WIN32)
   include(ExternalProject)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi8.zip
-    URL_MD5 b01510437ea15527156bc25cdf733bd9
+    URL http://hifi-public.s3.amazonaws.com/dependencies/qtaudio_wasapi9.zip
+    URL_MD5 94f4765bdbcd53cd099f349ae031e769
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""


### PR DESCRIPTION
WASAPI plugin compiled with VS2017 and linked against Qt5.9.1 qtmultimedia framework. The actual plugin code is unchanged.