### PR TITLE
Possible fix for "screeching noise" after audio input device changes

### DIFF
--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -109,7 +109,7 @@ private:
     QHash<QUuid, quint16> _outgoingScriptAudioSequenceNumbers;
 
     AudioGate _audioGate;
-    bool _audioGateOpen { false };
+    bool _audioGateOpen { true };
     bool _isNoiseGateEnabled { false };
 
     CodecPluginPointer _codec;

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -364,7 +364,7 @@ private:
     AudioIOStats _stats;
 
     AudioGate* _audioGate { nullptr };
-    bool _audioGateOpen { false };
+    bool _audioGateOpen { true };
 
     AudioPositionGetter _positionGetter;
     AudioOrientationGetter _orientationGetter;


### PR DESCRIPTION
Because the codec is not flushed when audio devices are changed, and the input device gets changed from default device to selected device during startup while the mic is potentially hot, it is possible that if Noise Reduction is enabled and the codec history is not silent when the device change occurs, stale codec state could get injected into the mic stream during Interface startup. 

Suppressing silent packets at audio gate startup should prevent this from ever occurring.