### PR TITLE
Cleanup top menu on menu re instantiation

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
@@ -114,6 +114,7 @@ Item {
         }
 
         function clearMenus() {
+            topMenu = null
             d.clear()
         }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/6154/menus-in-tablet-change-case

Test plan:
- open Tablet, goto Menu
- check that Menu items are in upper case
- click on "sandwich" menu button on top left corner
- make sure menu stays in uppercase mode
- go to submenus
- make sure that submenus have only 1st letter in caps
- go back to top level
- make sure all menu is in upper case