### PR TITLE
Capitalize "ENTER VR"

### DIFF
--- a/scripts/system/hmd.js
+++ b/scripts/system/hmd.js
@@ -43,8 +43,8 @@ var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
 // Independent and Entity mode make people sick; disable them in hmd.
 var desktopOnlyViews = ['Independent Mode', 'Entity Mode'];
 
-var switchToVR = "Enter VR";
-var switchToDesktop = "Exit VR";
+var switchToVR = "ENTER VR";
+var switchToDesktop = "EXIT VR";
 
 function onHmdChanged(isHmd) {
     HMD.closeTablet();


### PR DESCRIPTION
Sorry, the change that caused this should have been more carefully design-reviewed before being merged.

Changes "Enter VR" and "Exit VR" to "ENTER VR" and "EXIT VR".

Test Plan:
In HMD mode, open the tablet. The Desktop icon should now say "EXIT VR".
In Desktop mode, the toolbar VR icon should now say "ENTER VR".