### PR TITLE
Remove snap to item. Add caching for scrolling speedup

### DIFF
--- a/interface/resources/qml/hifi/dialogs/content/AttachmentsContent.qml
+++ b/interface/resources/qml/hifi/dialogs/content/AttachmentsContent.qml
@@ -50,7 +50,7 @@ Item {
                         margins: 4
                     }
                     clip: true
-                    snapMode: ListView.SnapToItem
+                    cacheBuffer: 4000
 
                     model: ListModel {}
                     delegate: Item {


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/5525/Attachment-Window-Scrolls-Very-Slowly

Test plan:
- open Tablet
- goto Avatar->Attachments
- add some more attachments
- note if the scrolling speed/smoothness is better then in previous builds
