### PR TITLE
fixed typo leads to lost touch or mouse release events

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -252,7 +252,7 @@ void Web3DOverlay::render(RenderArgs* args) {
             if (overlayID == selfOverlayID && (self->_pressed || (!self->_activeTouchPoints.empty() && self->_touchBeginAccepted))) {
                 PointerEvent endEvent(PointerEvent::Release, event.getID(), event.getPos2D(), event.getPos3D(), event.getNormal(), event.getDirection(),
                                       event.getButton(), event.getButtons(), event.getKeyboardModifiers());
-                forwardPointerEvent(overlayID, event);
+                forwardPointerEvent(overlayID, endEvent);
             }
         });
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/6348/The-scrollbar-in-the-tablet-is-never-released-if-you-mouse-up-outside-of-the-tablet

Test plan:
- open tablet 
- goto Create->Properties
- start dragging scrollbar with mouse and release when the mouse is off the tablet.
- make sure dragging is stopped, ie. dragging does not follow mouse anymore
