### PR TITLE
Fix crash in Context Overlays code

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -257,15 +257,23 @@ void ContextOverlayInterface::openMarketplace() {
 }
 
 void ContextOverlayInterface::enableEntityHighlight(const EntityItemID& entityItemID) {
-    if (!qApp->getEntities()->getTree()->findEntityByEntityItemID(entityItemID)->getShouldHighlight()) {
-        qCDebug(context_overlay) << "Setting 'shouldHighlight' to 'true' for Entity ID:" << entityItemID;
-        qApp->getEntities()->getTree()->findEntityByEntityItemID(entityItemID)->setShouldHighlight(true);
-    }
+    auto entityTree = qApp->getEntities()->getTree();
+    entityTree->withReadLock([&] {
+        auto entityItem = entityTree->findEntityByEntityItemID(entityItemID);
+        if ((entityItem != NULL) && !entityItem->getShouldHighlight()) {
+            qCDebug(context_overlay) << "Setting 'shouldHighlight' to 'true' for Entity ID:" << entityItemID;
+            entityItem->setShouldHighlight(true);
+        }
+    });
 }
 
 void ContextOverlayInterface::disableEntityHighlight(const EntityItemID& entityItemID) {
-    if (qApp->getEntities()->getTree()->findEntityByEntityItemID(entityItemID)->getShouldHighlight()) {
-        qCDebug(context_overlay) << "Setting 'shouldHighlight' to 'false' for Entity ID:" << entityItemID;
-        qApp->getEntities()->getTree()->findEntityByEntityItemID(entityItemID)->setShouldHighlight(false);
-    }
+    auto entityTree = qApp->getEntities()->getTree();
+    entityTree->withReadLock([&] {
+        auto entityItem = entityTree->findEntityByEntityItemID(entityItemID);
+        if ((entityItem != NULL) && entityItem->getShouldHighlight()) {
+            qCDebug(context_overlay) << "Setting 'shouldHighlight' to 'false' for Entity ID:" << entityItemID;
+            entityItem->setShouldHighlight(false);
+        }
+    });
 }


### PR DESCRIPTION
Fixes [FB6798](https://highfidelity.fogbugz.com/f/cases/6798). I was able to reproduce this by spawning the xylophone from the marketplace, opening the Create app, clicking the xylophone, deleting it, then moving my mouse.

I also added a readlock on the entity tree inside `enableEntityHighlight()` and `disableEntityHighlight()` because everywhere else we do `findEntityByEntityItemID()` we have a readlock. It makes sense to do that.

Easy test plan here.

**Test Plan**
1. After installing Interface, open `Interface.json` and change `inspectionMode` to `true`.
2. Spawn something from the marketplace in some domain.
3. Hover over the entity with your mouse and verify that the yellow bounding box appears around the entity.
4. Hover off of the entity and verify that the yellow bounding box disappears.
5. Open the Create app. Hover over the entity. Left-click the entity. Press "Delete" on your keyboard. Verify that the entity disappears.
6. Move your mouse. Verify that you don't crash.