### PR TITLE
Short circuit between DS and interface after DS downloads public key

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -636,8 +636,7 @@ void DomainGatekeeper::requestUserPublicKey(const QString& username, bool isOpti
 
 
     const QString USER_PUBLIC_KEY_PATH = "api/v1/users/%1/public_key";
- 
-   
+    
     qDebug().nospace() << "Requesting " << (isOptimistic ? "optimistic " : " ") << "public key for user " << username;
 
     DependencyManager::get<AccountManager>()->sendRequest(USER_PUBLIC_KEY_PATH.arg(username),

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -396,7 +396,7 @@ SharedNodePointer DomainGatekeeper::processAgentConnectRequest(const NodeConnect
             getGroupMemberships(username);
             verifiedUsername = username;
         } else {
-            _userSockAddress.insert(username , nodeConnection.senderSockAddr);
+            _userSockAddress.insert(username, nodeConnection.senderSockAddr);
             // they sent us a username, but it didn't check out
             requestUserPublicKey(username);
 #ifdef WANT_DEBUG
@@ -678,7 +678,7 @@ void DomainGatekeeper::publicKeyJSONCallback(QNetworkReply& requestReply) {
         if (!isOptimisticKey) {
             sendConnectionTokenPacket(username, _userSockAddress[username]);
             _userSockAddress.remove(username);
-            qDebug().nospace() << "Sending connection token packet to user " << username << " to trigger new check in";
+            qDebug() << "Sending connection token packet to user" << username << "to trigger new check in";
         }
 
     }

--- a/domain-server/src/DomainGatekeeper.h
+++ b/domain-server/src/DomainGatekeeper.h
@@ -111,6 +111,7 @@ private:
 
     QHash<QString, KeyFlagPair> _userPublicKeys; // keep track of keys and flag them as optimistic or not
     QHash<QString, bool> _inFlightPublicKeyRequests; // keep track of keys we've asked for (and if it was optimistic)
+    QHash<QString, HifiSockAddr> _userSockAddress; //keep track of usernames and associated socket addresses
     QSet<QString> _domainOwnerFriends; // keep track of friends of the domain owner
     QSet<QString> _inFlightGroupMembershipsRequests; // keep track of which we've already asked for
 

--- a/domain-server/src/DomainGatekeeper.h
+++ b/domain-server/src/DomainGatekeeper.h
@@ -111,7 +111,7 @@ private:
 
     QHash<QString, KeyFlagPair> _userPublicKeys; // keep track of keys and flag them as optimistic or not
     QHash<QString, bool> _inFlightPublicKeyRequests; // keep track of keys we've asked for (and if it was optimistic)
-    QHash<QString, HifiSockAddr> _userSockAddress; //keep track of usernames and associated socket addresses
+    QHash<QString, HifiSockAddr> _userSockAddress; // keep track of usernames and associated socket addresses
     QSet<QString> _domainOwnerFriends; // keep track of friends of the domain owner
     QSet<QString> _inFlightGroupMembershipsRequests; // keep track of which we've already asked for
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -575,6 +575,7 @@ void NodeList::processDomainServerConnectionTokenPacket(QSharedPointer<ReceivedM
     // read in the connection token from the packet, then send domain-server checkin
     _domainHandler.setConnectionToken(QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID)));
     sendDomainServerCheckIn();
+    qDebug() << "Received connection token packet from Domain Server...Re-sending check in";
 }
 
 void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) {

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -575,7 +575,7 @@ void NodeList::processDomainServerConnectionTokenPacket(QSharedPointer<ReceivedM
     // read in the connection token from the packet, then send domain-server checkin
     _domainHandler.setConnectionToken(QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID)));
     sendDomainServerCheckIn();
-    qDebug() << "Received connection token packet from Domain Server...Re-sending check in";
+    qDebug() << "Received connection token packet from Domain Server, Re-sending check in";
 }
 
 void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) {


### PR DESCRIPTION
With reference to fogbugz case https://highfidelity.fogbugz.com/f/cases/6547/Interface-waits-up-to-1s-before-re-attempting-connection-to-DS-after-DS-downloads-public-key\

This PR adds an additional short circuit between DS and interface which happens after the domain server has downloaded the public key for a user trying to connect

Testing Notes:
1) Run the built Domain Server and Interface
2) Assuming the user is already logged in, Observe the following in Domain Server logs:
    Extracted optimistic public key for "%username%"
    Username signature matches for "%username%"
3) Go to %APPDATA%/Roaming/High Fidelity{ - PRXXXX}/Interface/AccountInfo.bin and delete AccountInfo.bin
4) Restart Domain Server and Interface
5) Log in to High Fidelity in the interface
6) Observe the following logs in Domain Server:
    Extracted  public key for "%username%"
    Sending connection token packet to user "%username%" to trigger new check in
    Username signature matches for "%username%"
7) Observe Interface logs for the following: Received connection token packet from Domain Server...Re-sending check in