### PR TITLE
Fixed bugs related to express installer

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -942,7 +942,7 @@ Section "-Core installation"
   
   !insertmacro MUI_STARTMENU_WRITE_END
   
-  @CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
+@CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
   
   ; Handle whichever post install options were set
   Call HandlePostInstallOptions

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -518,7 +518,6 @@ FunctionEnd
 
 Function AbortFunction
   ; Check if Express is set, if so, abort the post install options page
-  ; Call HandleInstallTypes ; Sets Express if ExpressInstallRadioButton is checked
   StrCmp $Express "1" 0 end
   Abort
   end:
@@ -942,9 +941,9 @@ Section "-Core installation"
   Call ConditionalAddToRegisty
 
   !insertmacro MUI_STARTMENU_WRITE_END
-
+  
   @CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
-
+  
   ; Handle whichever post install options were set
   Call HandlePostInstallOptions
 

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -939,7 +939,7 @@ Section "-Core installation"
   Push "StartMenu"
   Push "$STARTMENU_FOLDER"
   Call ConditionalAddToRegisty
-
+  
   !insertmacro MUI_STARTMENU_WRITE_END
   
   @CPACK_NSIS_EXTRA_INSTALL_COMMANDS@

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -484,16 +484,14 @@ Function InstallTypesPage
   StrCpy $OffsetUnits u
   StrCpy $Express "0"  
   
-  ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
-    ${NSD_CreateRadioButton} 30% $CurrentOffset$OffsetUnits 100% 10u "Express Install (Recommended)"; $\nInstalls High Fidelity Interface and High Fidelity Sandbox"
-    pop $ExpressInstallRadioButton
-    ${NSD_OnClick} $ExpressInstallRadioButton ChangeExpressLabel
-    IntOp $CurrentOffset $CurrentOffset + 15
+  ${NSD_CreateRadioButton} 30% $CurrentOffset$OffsetUnits 100% 10u "Express Install (Recommended)"; $\nInstalls High Fidelity Interface and High Fidelity Sandbox"
+  pop $ExpressInstallRadioButton
+  ${NSD_OnClick} $ExpressInstallRadioButton ChangeExpressLabel
+  IntOp $CurrentOffset $CurrentOffset + 15
   
-    ${NSD_CreateRadiobutton} 30% $CurrentOffset$OffsetUnits 100% 10u "Custom Install (Advanced)"
-    pop $CustomInstallRadioButton
-    ${NSD_OnClick} $CustomInstallRadioButton ChangeCustomLabel 
-  ${EndIf}
+  ${NSD_CreateRadiobutton} 30% $CurrentOffset$OffsetUnits 100% 10u "Custom Install (Advanced)"
+  pop $CustomInstallRadioButton
+  ${NSD_OnClick} $CustomInstallRadioButton ChangeCustomLabel 
   
   ; Express Install selected by default
   ${NSD_Check} $ExpressInstallRadioButton
@@ -651,9 +649,11 @@ Function ReadInstallTypes
     StrCpy $ServerStartupState ${BST_CHECKED} 
     StrCpy $LaunchServerNowState ${BST_CHECKED}
     StrCpy $LaunchClientNowState ${BST_CHECKED}
+    StrCpy $CleanInstallState ${BST_UNCHECKED}
+    StrCpy $DesktopServerState ${BST_UNCHECKED}
 
     ${If} @PR_BUILD@ == 1
-      ${NSD_SetState} $CopyFromProductionCheckbox ${BST_UNCHECKED}
+      StrCpy $CopyFromProductionState ${BST_UNCHECKED}
     ${EndIf}
     
   ${EndIf}
@@ -842,6 +842,8 @@ Section "-Core installation"
   ; Rename the incorrectly cased Raleway font
   Rename "$INSTDIR\resources\qml\styles-uit\RalewaySemibold.qml" "$INSTDIR\resources\qml\styles-uit\RalewaySemiBold.qml"
 
+  ExecWait "$INSTDIR\vcredist_x64.exe /install /q /norestart"
+  
   ; Remove the Old Interface directory and vcredist_x64.exe (from installs prior to Server Console)
   RMDir /r "$INSTDIR\Interface"
   Delete "$INSTDIR\vcredist_x64.exe"
@@ -939,10 +941,10 @@ Section "-Core installation"
   Push "StartMenu"
   Push "$STARTMENU_FOLDER"
   Call ConditionalAddToRegisty
-  
+
   !insertmacro MUI_STARTMENU_WRITE_END
   
-@CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
+  @CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
   
   ; Handle whichever post install options were set
   Call HandlePostInstallOptions

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -518,7 +518,7 @@ FunctionEnd
 
 Function AbortFunction
   ; Check if Express is set, if so, abort the post install options page
-  Call HandleInstallTypes ; Sets Express if ExpressInstallRadioButton is checked and installs with defaults
+  ; Call HandleInstallTypes ; Sets Express if ExpressInstallRadioButton is checked
   StrCmp $Express "1" 0 end
   Abort
   end:
@@ -529,10 +529,15 @@ Function PostInstallOptionsPage
 
   nsDialogs::Create 1018
   Pop $PostInstallDialog
-
+  
   ${If} $PostInstallDialog == error
     Abort
   ${EndIf}
+  
+  ; Check if Express is set, if so, abort the post install options page
+  StrCmp $Express "1" 0 end
+  Abort
+  end:
 
   StrCpy $CurrentOffset 0
   StrCpy $OffsetUnits u
@@ -617,12 +622,6 @@ Function PostInstallOptionsPage
     ${NSD_SetState} $CopyFromProductionCheckbox ${BST_UNCHECKED}
   ${EndIf}
   
-  ; Check if Express is set, if so, abort the post install options page
-  Call HandleInstallTypes ; Sets Express if ExpressInstallRadioButton is checked and installs with defaults
-  StrCmp $Express "1" 0 end
-  Abort
-  end:
-  
   nsDialogs::Show
 FunctionEnd
 
@@ -638,15 +637,28 @@ Var LaunchServerNowState
 Var LaunchClientNowState
 Var CopyFromProductionState
 Var CleanInstallState
-Var ExpressInstallState 
+Var ExpressInstallState
 Var CustomInstallState
 
 Function ReadInstallTypes
-  ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
-    ; check if the user asked for express/custom install
-    ${NSD_GetState} $ExpressInstallRadioButton $ExpressInstallState
-    ${NSD_GetState} $CustomInstallRadioButton $CustomInstallState
+  ; check if the user asked for express/custom install
+  ${NSD_GetState} $ExpressInstallRadioButton $ExpressInstallState
+  ${NSD_GetState} $CustomInstallRadioButton $CustomInstallState
+  
+  ${If} $ExpressInstallState == ${BST_CHECKED}
+    StrCpy $Express "1"
+    
+    StrCpy $DesktopClientState ${BST_CHECKED}  
+    StrCpy $ServerStartupState ${BST_CHECKED} 
+    StrCpy $LaunchServerNowState ${BST_CHECKED}
+    StrCpy $LaunchClientNowState ${BST_CHECKED}
+
+    ${If} @PR_BUILD@ == 1
+      ${NSD_SetState} $CopyFromProductionCheckbox ${BST_UNCHECKED}
+    ${EndIf}
+    
   ${EndIf}
+  
 FunctionEnd
 
 Function ReadPostInstallOptions
@@ -681,28 +693,6 @@ Function ReadPostInstallOptions
   ${If} ${SectionIsSelected} ${@CLIENT_COMPONENT_NAME@}
     ; check if the user asked for a clean install
     ${NSD_GetState} $CleanInstallCheckbox $CleanInstallState
-  ${EndIf}
-FunctionEnd
-
-Function HandleInstallTypes
-  ${If} $ExpressInstallState == ${BST_CHECKED}
-    
-    StrCpy $Express "1"
-    
-    ; over ride custom checkboxes and select defaults 
-    ${NSD_SetState} $DesktopClientCheckbox ${BST_CHECKED} 
-    ${NSD_SetState} $ServerStartupCheckbox ${BST_CHECKED} 
-    ${NSD_SetState} $LaunchServerNowCheckbox ${BST_CHECKED}
-    ${NSD_SetState} $LaunchClientNowCheckbox ${BST_CHECKED}
-    
-    ${If} @PR_BUILD@ == 1
-      ${NSD_SetState} $CopyFromProductionCheckbox ${BST_UNCHECKED}
-    ${EndIf}    
-    
-    ; call ReadPostInstallOptions and HandlePostInstallOptions with defaults selected
-    Call ReadPostInstallOptions 
-    Call HandlePostInstallOptions 
-      
   ${EndIf}
 FunctionEnd
 
@@ -853,8 +843,6 @@ Section "-Core installation"
   ; Rename the incorrectly cased Raleway font
   Rename "$INSTDIR\resources\qml\styles-uit\RalewaySemibold.qml" "$INSTDIR\resources\qml\styles-uit\RalewaySemiBold.qml"
 
-  ExecWait "$INSTDIR\vcredist_x64.exe /install /q /norestart"
-
   ; Remove the Old Interface directory and vcredist_x64.exe (from installs prior to Server Console)
   RMDir /r "$INSTDIR\Interface"
   Delete "$INSTDIR\vcredist_x64.exe"
@@ -955,7 +943,7 @@ Section "-Core installation"
 
   !insertmacro MUI_STARTMENU_WRITE_END
 
-@CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
+  @CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
 
   ; Handle whichever post install options were set
   Call HandlePostInstallOptions


### PR DESCRIPTION
With reference to the fogbugz case: https://highfidelity.fogbugz.com/f/cases/6834/Express-Installer-Install-express-over-existing-install-install-fails-previous-install-broken
Testing Notes:
1) Run the installer
2) Observe a new page - "Choose Installation Type"
a) "Express Install" is selected by default
b) Lower button panel has labels: Back, Install, Cancel
c) Click on "Custom Install"
d) Button panel changes to Back, Next, Cancel
3) Install with Express install selected
a) No Post Install Options page
b) Software installs with following defaults:
Create a desktop shortcut for Interface
Launch Sandbox after install
Launch Interface after install
Launch Sandbox on startup
4) Install with Custom Install selected
a) Post Install options page appears
b) If it is a PR build, Observe that checkbox for copying settings from Production is unchecked by default
c) Change any of the default settings (For example uncheck Desktop shortcut creation)
d) Observe the settings are reflected (For example Desktop shortcut is not created)
5)Come back and Install again with "Express Install" selected
a) Observe changes made in custom install (For example uncheck Desktop shortcut creation), are over ridden by defaults, i.e Desktop shortcut IS created
6)PR build tests:
a) In custom install, select the "copy from production" checkbox and install
b) Come back and install with Express Install, it **Does Not** copy settings/content from production