### PR TITLE
New commerce mode now depends on 1 setting; bugfixes; Tablet -> TAB key

### DIFF
--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -131,6 +131,6 @@
         { "from": "Keyboard.Space", "to": "Actions.SHIFT" },
         { "from": "Keyboard.R", "to": "Actions.ACTION1" },
         { "from": "Keyboard.T", "to": "Actions.ACTION2" },
-        { "from": "Keyboard.RightMouseClicked", "to": "Actions.ContextMenu" }
+        { "from": "Keyboard.Tab", "to": "Actions.ContextMenu" }
     ]
 }


### PR DESCRIPTION
Don't formally QA this one, please.

Three things for this PR:
1. Before, enabling marketplace inspection mode, enabling "confirm all purchases" mode, and changing the tablet to toggle upon TAB keypress required developers to change three separate settings. Now, a developer simply has to add `"inspectionMode": true,` to their `Interface.json` and both marketplace inspection mode and "confirm all purchases" mode will be enabled.
2. This PR also changes the TAB controller mapping by default. (part of above)
3. Before, the Marketplace web event bridge only opened when the user clicked on the Marketplace button. It then stayed open indefinitely. Now, the Marketplace web event bridge opens when the script starts up, then closes when the script shuts down. This enables us to utilize the web event bridge when the marketplace is opened by means other than clicking the app button (i.e. via marketplace inspection mode).