### PR TITLE
Adds a working "Buy" button to Checkout.qml

### DIFF
--- a/interface/resources/qml/hifi/commerce/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/Checkout.qml
@@ -25,6 +25,7 @@ Rectangle {
 
     id: checkoutRoot;
     property string itemId; 
+    property string itemHref;
     // Style
     color: hifi.colors.baseGray;
     Hifi.QmlCommerce {
@@ -234,6 +235,7 @@ Rectangle {
 
         // "Cancel" button
         HifiControlsUit.Button {
+            id: cancelButton;
             color: hifi.buttons.black;
             colorScheme: hifi.colorSchemes.dark;
             anchors.top: parent.top;
@@ -251,6 +253,8 @@ Rectangle {
 
         // "Buy" button
         HifiControlsUit.Button {
+            property bool buyFailed: false;
+            id: buyButton;
             color: hifi.buttons.black;
             colorScheme: hifi.colorSchemes.dark;
             anchors.top: parent.top;
@@ -262,7 +266,11 @@ Rectangle {
             width: parent.width/2 - anchors.rightMargin*2;
             text: "Buy"
             onClicked: {
-                sendToScript({method: 'checkout_buyClicked', params: {success: commerce.buy(itemId, parseInt(itemPriceText.text))}});
+                if (buyFailed) {
+                    sendToScript({method: 'checkout_cancelClicked', params: itemId});
+                } else {
+                    sendToScript({method: 'checkout_buyClicked', success: commerce.buy(itemId, parseInt(itemPriceText.text)), itemId: itemId, itemHref: itemHref});
+                }
             }
         }
     }
@@ -293,6 +301,13 @@ Rectangle {
                 itemNameText.text = message.params.itemName;
                 itemAuthorText.text = message.params.itemAuthor;
                 itemPriceText.text = message.params.itemPrice;
+                itemHref = message.params.itemHref;
+                buyButton.text = "Buy";
+                buyButton.buyFailed = false;
+            break;
+            case 'buyFailed':
+                buyButton.text = "Buy Failed";
+                buyButton.buyFailed = true;
             break;
             default:
                 console.log('Unrecognized message from marketplaces.js:', JSON.stringify(message));

--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -89,24 +89,29 @@
         });
     }
 
-    function buyButtonClicked(id, name, author, price) {
+    function buyButtonClicked(id, name, author, price, href) {
         EventBridge.emitWebEvent(JSON.stringify({
             type: "CHECKOUT",
             itemId: id,
             itemName: name,
             itemAuthor: author,
-            itemPrice: price
+            itemPrice: price,
+            itemHref: href
         }));
     }
 
     function injectBuyButtonOnMainPage() {
-        $('.grid-item').find('#price-or-edit').find('a').attr('href', '#');
+        $('.grid-item').find('#price-or-edit').find('a').each(function() {
+            $(this).attr('data-href', $(this).attr('href'));
+            $(this).attr('href', '#');
+            });
         $('.grid-item').find('#price-or-edit').find('.price').text("BUY");
         $('.grid-item').find('#price-or-edit').find('a').on('click', function () {
             buyButtonClicked($(this).closest('.grid-item').attr('data-item-id'),
                 $(this).closest('.grid-item').find('.item-title').text(),
                 $(this).closest('.grid-item').find('.creator').find('.value').text(),
-                10);
+                10,
+                $(this).attr('data-href'));
         });
     }
 
@@ -133,13 +138,15 @@
 
     function injectHiFiItemPageCode() {
         if (confirmAllPurchases) {
+            var href = $('#side-info').find('.btn').attr('href');
             $('#side-info').find('.btn').attr('href', '#');
             $('#side-info').find('.btn').html('<span class="glyphicon glyphicon-download"></span>Buy Item  ');
             $('#side-info').find('.btn').on('click', function () {
                 buyButtonClicked(window.location.pathname.split("/")[3],
                     $('#top-center').find('h1').text(),
                     $('#creator').find('.value').text(),
-                    10);
+                    10,
+                    href);
             });
         }
     }

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -207,7 +207,14 @@
                 //tablet.popFromStack();
                 break;
             case 'checkout_buyClicked':
-                print("fromQml: " + JSON.stringify(message));
+                if (message.success === true) {
+                    tablet.gotoWebScreen(message.itemHref);
+                    Script.setTimeout(function () {
+                        tablet.gotoWebScreen(MARKETPLACE_URL + '/items/' + message.itemId, MARKETPLACES_INJECT_SCRIPT_URL);
+                    }, 100);
+                } else {
+                    tablet.sendToQml({ method: 'buyFailed' });
+                }
                 //tablet.popFromStack();
                 break;
             default:


### PR DESCRIPTION
Please don't formally test.

This PR makes the "Buy" button on the Checkout page in the Marketplace actually do something "correct" (although the behavior is not final).

If the "buy" operation succeeds (which it is currently hardcoded to do), the marketplace will spawn the "bought" item and dump the user back on the marketplace item's page.

If the "buy" operation fails, the text of the button will be replaced with the words "Buy Failed". Clicking that button will then dump the user back on the marketplace item's page.