### PR TITLE
Bug fix for HMD roll causing avatar yaw when standing still

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1898,8 +1898,8 @@ void MyAvatar::updateOrientation(float deltaTime) {
         totalBodyYaw += (speedFactor * deltaAngle * (180.0f / PI));
     }
 
-    // Use head/HMD roll to turn while walking or flying.
-    if (qApp->isHMDMode() && _hmdRollControlEnabled) {
+    // Use head/HMD roll to turn while walking or flying, but not when standing still
+    if (qApp->isHMDMode() && _hmdRollControlEnabled && hasDriveInput()) {
         // Turn with head roll.
         const float MIN_CONTROL_SPEED = 0.01f;
         float speed = glm::length(getVelocity());


### PR DESCRIPTION
HMD roll should only cause the avatar to yaw when actively driving.  This problem was introduced by this PR #10685