### PR TITLE
Fix marketplaces message passing

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -398,16 +398,18 @@
 
     function onLoad() {
         EventBridge.scriptEventReceived.connect(function (message) {
-            var parsedJsonMessage = JSON.parse(message);
-
             if (message.slice(0, CAN_WRITE_ASSETS.length) === CAN_WRITE_ASSETS) {
                 canWriteAssets = message.slice(-4) === "true";
             } else if (message.slice(0, CLARA_IO_CANCEL_DOWNLOAD.length) === CLARA_IO_CANCEL_DOWNLOAD) {
                 cancelClaraDownload();
-            } else if (parsedJsonMessage.type === "marketplaces") {
-                if (parsedJsonMessage.action === "inspectionModeSetting") {
-                    confirmAllPurchases = !!parsedJsonMessage.data;
-                    injectCode();
+            } else {
+                var parsedJsonMessage = JSON.parse(message);
+                
+                if (parsedJsonMessage.type === "marketplaces") {
+                    if (parsedJsonMessage.action === "inspectionModeSetting") {
+                        confirmAllPurchases = !!parsedJsonMessage.data;
+                        injectCode();
+                    }
                 }
             }
         });

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -101,31 +101,14 @@
     Entities.canWriteAssetsChanged.connect(onCanWriteAssetsChanged);
 
     function onMessage(message) {
-        var parsedJsonMessage = JSON.parse(message);
-        if (parsedJsonMessage.type === "CHECKOUT") {
-            tablet.sendToQml({ method: 'updateCheckoutQML', params: parsedJsonMessage });
-            tablet.pushOntoStack(MARKETPLACE_CHECKOUT_QML_PATH);
-        } else if (parsedJsonMessage.type === "REQUEST_SETTING") {
-            tablet.emitScriptEvent(JSON.stringify({
-                type: "marketplaces",
-                action: "inspectionModeSetting",
-                data: Settings.getValue("inspectionMode", false)
-            }));
-        }
 
         if (message === GOTO_DIRECTORY) {
             tablet.gotoWebScreen(MARKETPLACES_URL, MARKETPLACES_INJECT_SCRIPT_URL);
-        }
-
-        if (message === QUERY_CAN_WRITE_ASSETS) {
+        } else if (message === QUERY_CAN_WRITE_ASSETS) {
             tablet.emitScriptEvent(CAN_WRITE_ASSETS + " " + Entities.canWriteAssets());
-        }
-
-        if (message === WARN_USER_NO_PERMISSIONS) {
+        } else if (message === WARN_USER_NO_PERMISSIONS) {
             Window.alert(NO_PERMISSIONS_ERROR_MESSAGE);
-        }
-
-        if (message.slice(0, CLARA_IO_STATUS.length) === CLARA_IO_STATUS) {
+        } else if (message.slice(0, CLARA_IO_STATUS.length) === CLARA_IO_STATUS) {
             if (isDownloadBeingCancelled) {
                 return;
             }
@@ -137,18 +120,26 @@
                 Window.updateMessageBox(messageBox, CLARA_DOWNLOAD_TITLE, text, CANCEL_BUTTON, NO_BUTTON);
             }
             return;
-        }
-
-        if (message.slice(0, CLARA_IO_DOWNLOAD.length) === CLARA_IO_DOWNLOAD) {
+        } else if (message.slice(0, CLARA_IO_DOWNLOAD.length) === CLARA_IO_DOWNLOAD) {
             if (messageBox !== null) {
                 Window.closeMessageBox(messageBox);
                 messageBox = null;
             }
             return;
-        }
-
-        if (message === CLARA_IO_CANCELLED_DOWNLOAD) {
+        } else if (message === CLARA_IO_CANCELLED_DOWNLOAD) {
             isDownloadBeingCancelled = false;
+        } else {
+            var parsedJsonMessage = JSON.parse(message);
+            if (parsedJsonMessage.type === "CHECKOUT") {
+                tablet.sendToQml({ method: 'updateCheckoutQML', params: parsedJsonMessage });
+                tablet.pushOntoStack(MARKETPLACE_CHECKOUT_QML_PATH);
+            } else if (parsedJsonMessage.type === "REQUEST_SETTING") {
+                tablet.emitScriptEvent(JSON.stringify({
+                    type: "marketplaces",
+                    action: "inspectionModeSetting",
+                    data: Settings.getValue("inspectionMode", false)
+                }));
+            }
         }
     }
 


### PR DESCRIPTION
If a message isn't JSON (like when clicking "All Markets"), it can't be parsed and will throw an error. This PR fixes that. My bad.

Don't QA. This shouldn't have been affected in my previous PRs, but it accidentally was.