### PR TITLE
re-enable sixense and update comment

### DIFF
--- a/plugins/hifiSixense/CMakeLists.txt
+++ b/plugins/hifiSixense/CMakeLists.txt
@@ -6,11 +6,13 @@
 #  See the accompanying file LICENSE or http:#www.apache.org/licenses/LICENSE-2.0.html
 #
 
-# FIXME if we want to re-enable this, we need to fix the mechanism for installing the 
+# FIXME if we want to properly re-enable this, we need to fix the mechanism for installing the 
 # dependency dlls `msvcr100` and `msvcp100` WITHOUT using CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS
-#if (NOT ANDROID)
-#  set(TARGET_NAME hifiSixense)
-#  setup_hifi_plugin(Script Qml Widgets)
-#  link_hifi_libraries(shared controllers ui plugins ui-plugins input-plugins)
-#  target_sixense()
-#endif ()
+# currently this will build the hifiSixense plugin, but unless the user has previously installed
+# the msvcr100 runtime support, the plugin will not load.
+if (NOT ANDROID)
+  set(TARGET_NAME hifiSixense)
+  setup_hifi_plugin(Script Qml Widgets)
+  link_hifi_libraries(shared controllers ui plugins ui-plugins input-plugins)
+  target_sixense()
+endif ()


### PR DESCRIPTION
This will re-enable hydra support for users who have previously installed HiFi and previously been using hydras.

# Test plan:
Preparation - Determine if your system has `msvcp100.dll` and `msvcr100.dll` installed in your path or in the windows system directory. If so you will be asked to temporarily remove those files from that location (you can rename the DLL to accomplish this) - A tool like `which` available in the git command line will help.

Test 1 - Verify that a previous beta install, with working hydras, still works after this PR.
1) install version 6895 of HiFi into a FRESH directory.
2) verify that in your Program Files/[install directory] - you have the following files: `msvcp100.dll` and `msvcr100,dll`
3) run interface and verify that hydras still work
4) install this PR into the same directory... 
5) run interface and verify that hydras still work

Test 2 - Verify that with `msvcr100.dll` missing from your system directory or path, that hydras *don't work* but nothing else bad happens.
1) install this PR into a new/different directory (not the same as step 1)
2) temporarily rename the `msvcr100.dll` DLL you found in your preparation step.
3) verify that in your install directory - you do not have the file: `msvcp100.dll` or `msvcr100.dll`
4) verify that when you run interface, that it starts up, but that Sixense is missing from Settings > General, and the hydras don't work
5) make sure things startup and shutdown as normal


