### PR TITLE
Protect against oob _uniformMappings in GLShader::getUniformLocation.

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLShader.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLShader.h
@@ -48,7 +48,10 @@ public:
     }
 
     GLint getUniformLocation(GLint srcLoc, Version version = Mono) const {
-        // This check protect against potential invalid src location for this shader, if unknown then return -1.
+        // These checks protect against potential invalid src location for this shader, if unknown then return -1.
+        if (version >= _uniformMappings.size()) {
+            return -1;
+        }
         const auto& mapping = _uniformMappings[version];
         auto found = mapping.find(srcLoc);
         if (found == mapping.end()) {


### PR DESCRIPTION
Spawning and rotating a new object in the sandbox, I was occasionally tripping over cases where _uniformMappings was empty.  Since there already is a (probably more expensive) check against missing mappings, added another bounds check here.

Note this doesn't account for possible negative values, could do a (size_t) cast on the lhs of the compare (version) if desired.

(If this is the wrong approach, that's fine; holler if you'd prefer an Issue opened or similar instead.  I can likely refine repro steps and figure out something closer to root cause if desired.)