### PR TITLE
High Fidelity Interface Application Rename

### DIFF
--- a/cmake/macros/SetPackagingParameters.cmake
+++ b/cmake/macros/SetPackagingParameters.cmake
@@ -111,10 +111,10 @@ macro(SET_PACKAGING_PARAMETERS)
 
     # shortcut names
     if (PRODUCTION_BUILD)
-      set(INTERFACE_SHORTCUT_NAME "Interface")
+      set(INTERFACE_SHORTCUT_NAME "High Fidelity Interface")
       set(CONSOLE_SHORTCUT_NAME "Sandbox")
     else ()
-      set(INTERFACE_SHORTCUT_NAME "Interface - ${BUILD_VERSION}")
+      set(INTERFACE_SHORTCUT_NAME "High Fidelity Interface - ${BUILD_VERSION}")
       set(CONSOLE_SHORTCUT_NAME "Sandbox - ${BUILD_VERSION}")
     endif ()
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -712,7 +712,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     qInstallMessageHandler(messageHandler);
 
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "styles/Inconsolata.otf");
-    _window->setWindowTitle("Interface");
+    _window->setWindowTitle("High Fidelity Interface");
 
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us
 


### PR DESCRIPTION
Renames "Interface" app to be "High Fidelity Interface"

Test Plan:
1. Using Windows Search, search for "High Fidelity". "High Fidelity Interface" should show up.
2. Start Interface. The top bar should initially say "High Fidelity Interface" instead of just "Interface"