### PR TITLE
Add Inventory to Commerce

### DIFF
--- a/interface/resources/qml/hifi/commerce/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/Checkout.qml
@@ -269,7 +269,13 @@ Rectangle {
                 if (buyFailed) {
                     sendToScript({method: 'checkout_cancelClicked', params: itemId});
                 } else {
-                    sendToScript({method: 'checkout_buyClicked', success: commerce.buy(itemId, parseInt(itemPriceText.text)), itemId: itemId, itemHref: itemHref});
+                    var success = commerce.buy(itemId, parseInt(itemPriceText.text));
+                    sendToScript({method: 'checkout_buyClicked', success: success, itemId: itemId, itemHref: itemHref});
+                    if (success) {
+                        if (urlHandler.canHandleUrl(itemHref)) {
+                            urlHandler.handleUrl(itemHref);
+                        }
+                    }
                 }
             }
         }

--- a/interface/resources/qml/hifi/commerce/Inventory.qml
+++ b/interface/resources/qml/hifi/commerce/Inventory.qml
@@ -120,6 +120,77 @@ Rectangle {
     // HFC BALANCE END
     //
     
+    //
+    // INVENTORY CONTENTS START
+    //
+    Item {
+        id: inventoryContentsContainer;
+        // Anchors
+        anchors.left: parent.left;
+        anchors.leftMargin: 16;
+        anchors.right: parent.right;
+        anchors.rightMargin: 16;
+        anchors.top: hfcBalanceContainer.bottom;
+        anchors.topMargin: 8;
+        anchors.bottom: actionButtonsContainer.top;
+        anchors.bottomMargin: 8;
+        
+        RalewaySemiBold {
+            id: inventoryContentsLabel;
+            text: "Inventory:";
+            // Anchors
+            anchors.top: parent.top;
+            anchors.left: parent.left;
+            width: paintedWidth;
+            // Text size
+            size: 24;
+            // Style
+            color: hifi.colors.lightGrayText;
+            // Alignment
+            horizontalAlignment: Text.AlignHLeft;
+            verticalAlignment: Text.AlignVCenter;
+        }
+        ListView {
+            id: inventoryContentsList;
+            // Anchors
+            anchors.top: inventoryContentsLabel.bottom;
+            anchors.topMargin: 8;
+            anchors.left: parent.left;
+            anchors.bottom: parent.bottom;
+            width: parent.width;
+            model: commerce.inventory();
+            delegate: Item {
+                width: parent.width;
+                height: 30;
+                RalewayRegular {
+                    id: thisItemId;
+                    // Text size
+                    size: 20;
+                    // Style
+                    color: hifi.colors.blueAccent;
+                    text: modelData;
+                    // Alignment
+                    horizontalAlignment: Text.AlignHLeft;
+                }
+                MouseArea {
+                    anchors.fill: parent;
+                    hoverEnabled: enabled;
+                    onClicked: {
+                        sendToScript({method: 'inventory_itemClicked', itemId: thisItemId.text});
+                    }
+                    onEntered: {
+                        thisItemId.color = hifi.colors.blueHighlight;
+                    }
+                    onExited: {
+                        thisItemId.color = hifi.colors.blueAccent;
+                    }
+                }
+            }
+        }
+    }
+    //
+    // INVENTORY CONTENTS END
+    //
     
     //
     // ACTION BUTTONS START
@@ -131,7 +202,8 @@ Rectangle {
         height: 40;
         // Anchors
         anchors.left: parent.left;
-        anchors.top: hfcBalanceContainer.bottom;
+        anchors.bottom: parent.bottom;
+        anchors.bottomMargin: 8;
 
         // "Back" button
         HifiControlsUit.Button {

--- a/interface/resources/qml/hifi/commerce/Inventory.qml
+++ b/interface/resources/qml/hifi/commerce/Inventory.qml
@@ -1,0 +1,188 @@
+//
+//  Inventory.qml
+//  qml/hifi/commerce
+//
+//  Inventory
+//
+//  Created by Zach Fox on 2017-08-10
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import Hifi 1.0 as Hifi
+import QtQuick 2.5
+import QtQuick.Controls 1.4
+import "../../styles-uit"
+import "../../controls-uit" as HifiControlsUit
+import "../../controls" as HifiControls
+
+// references XXX from root context
+
+Rectangle {
+    HifiConstants { id: hifi; }
+
+    id: inventoryRoot;
+    property string referrerURL: "";
+    // Style
+    color: hifi.colors.baseGray;
+    Hifi.QmlCommerce {
+        id: commerce;
+    }
+
+    //
+    // TITLE BAR START
+    //
+    Item {
+        id: titleBarContainer;
+        // Size
+        width: inventoryRoot.width;
+        height: 50;
+        // Anchors
+        anchors.left: parent.left;
+        anchors.top: parent.top;
+
+        // Title Bar text
+        RalewaySemiBold {
+            id: titleBarText;
+            text: "Inventory";
+            // Text size
+            size: hifi.fontSizes.overlayTitle;
+            // Anchors
+            anchors.fill: parent;
+            anchors.leftMargin: 16;
+            // Style
+            color: hifi.colors.lightGrayText;
+            // Alignment
+            horizontalAlignment: Text.AlignHLeft;
+            verticalAlignment: Text.AlignVCenter;
+        }
+
+        // Separator
+        HifiControlsUit.Separator {
+            anchors.left: parent.left;
+            anchors.right: parent.right;
+            anchors.bottom: parent.bottom;
+        }
+    }
+    //
+    // TITLE BAR END
+    //
+
+    //
+    // HFC BALANCE START
+    //
+    Item {
+        id: hfcBalanceContainer; 
+        // Size
+        width: inventoryRoot.width;
+        height: childrenRect.height + 20;
+        // Anchors
+        anchors.left: parent.left;
+        anchors.leftMargin: 16;
+        anchors.top: titleBarContainer.bottom;
+        anchors.topMargin: 4;
+
+        RalewaySemiBold {
+            id: hfcBalanceTextLabel;
+            text: "HFC Balance:";
+            // Anchors
+            anchors.top: parent.top;
+            anchors.left: parent.left;
+            width: paintedWidth;
+            // Text size
+            size: 20;
+            // Style
+            color: hifi.colors.lightGrayText;
+            // Alignment
+            horizontalAlignment: Text.AlignHLeft;
+            verticalAlignment: Text.AlignVCenter;
+        }
+        RalewayRegular {
+            id: hfcBalanceText;
+            // Text size
+            size: hfcBalanceTextLabel.size;
+            // Anchors
+            anchors.top: parent.top;
+            anchors.left: hfcBalanceTextLabel.right;
+            anchors.leftMargin: 16;
+            width: paintedWidth;
+            // Style
+            color: hifi.colors.lightGrayText;
+            // Alignment
+            horizontalAlignment: Text.AlignHLeft;
+            verticalAlignment: Text.AlignVCenter;
+        }
+    }
+    //
+    // HFC BALANCE END
+    //
+    
+    
+    //
+    // ACTION BUTTONS START
+    //
+    Item {
+        id: actionButtonsContainer;
+        // Size
+        width: inventoryRoot.width;
+        height: 40;
+        // Anchors
+        anchors.left: parent.left;
+        anchors.top: hfcBalanceContainer.bottom;
+
+        // "Back" button
+        HifiControlsUit.Button {
+            id: backButton;
+            color: hifi.buttons.black;
+            colorScheme: hifi.colorSchemes.dark;
+            anchors.top: parent.top;
+            anchors.topMargin: 3;
+            anchors.bottom: parent.bottom;
+            anchors.bottomMargin: 3;
+            anchors.left: parent.left;
+            anchors.leftMargin: 20;
+            width: parent.width/2 - anchors.leftMargin*2;
+            text: "Back"
+            onClicked: {
+                sendToScript({method: 'inventory_backClicked', referrerURL: referrerURL});
+            }
+        }
+    }
+    //
+    // ACTION BUTTONS END
+    //
+
+    //
+    // FUNCTION DEFINITIONS START
+    //
+    //
+    // Function Name: fromScript()
+    //
+    // Relevant Variables:
+    // None
+    //
+    // Arguments:
+    // message: The message sent from the JavaScript, in this case the Marketplaces JavaScript.
+    //     Messages are in format "{method, params}", like json-rpc.
+    //
+    // Description:
+    // Called when a message is received from a script.
+    //
+    function fromScript(message) {
+        switch (message.method) {
+            case 'updateInventory':
+                referrerURL = message.referrerURL;
+                hfcBalanceText.text = message.hfcBalance;
+            break;
+            default:
+                console.log('Unrecognized message from marketplaces.js:', JSON.stringify(message));
+        }
+    }
+    signal sendToScript(var message);
+
+    //
+    // FUNCTION DEFINITIONS END
+    //
+}

--- a/interface/resources/qml/hifi/commerce/Inventory.qml
+++ b/interface/resources/qml/hifi/commerce/Inventory.qml
@@ -101,6 +101,7 @@ Rectangle {
         }
         RalewayRegular {
             id: hfcBalanceText;
+            text: commerce.balance();
             // Text size
             size: hfcBalanceTextLabel.size;
             // Anchors
@@ -174,7 +175,6 @@ Rectangle {
         switch (message.method) {
             case 'updateInventory':
                 referrerURL = message.referrerURL;
-                hfcBalanceText.text = message.hfcBalance;
             break;
             default:
                 console.log('Unrecognized message from marketplaces.js:', JSON.stringify(message));

--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -151,9 +151,9 @@
 
             // Try this here in case it works (it will if the user just pressed the "back" button,
             //     since that doesn't trigger another AJAX request.
-            injectBuyButtonOnMainPage();
+            injectBuyButtonOnMainPage;
+            addInventoryButton();
         }
-        addInventoryButton();
     }
 
     function injectHiFiItemPageCode() {
@@ -168,8 +168,8 @@
                     10,
                     href);
             });
+            addInventoryButton();
         }
-        addInventoryButton();
     }
 
     function updateClaraCode() {

--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -114,7 +114,7 @@
             itemId: id,
             itemName: name,
             itemAuthor: author,
-            itemPrice: price,
+            itemPrice: Math.round(Math.random() * 50),
             itemHref: href
         }));
     }

--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -89,6 +89,25 @@
         });
     }
 
+    function addInventoryButton() {
+        // Why isn't this an id?! This really shouldn't be a class on the website, but it is.
+        var navbarBrandElement = document.getElementsByClassName('navbar-brand')[0];
+        var inventoryElement = document.createElement('a');
+        inventoryElement.classList.add("btn");
+        inventoryElement.classList.add("btn-default");
+        inventoryElement.id = "inventoryButton";
+        inventoryElement.setAttribute('href', "#");
+        inventoryElement.innerHTML = "INVENTORY";
+        inventoryElement.style = "height:100%;margin-top:0;padding:15px 15px;";
+        navbarBrandElement.parentNode.insertAdjacentElement('beforeend', inventoryElement);
+        $('#inventoryButton').on('click', function () {
+            EventBridge.emitWebEvent(JSON.stringify({
+                type: "INVENTORY",
+                referrerURL: window.location.href
+            }));
+        });
+    }
+
     function buyButtonClicked(id, name, author, price, href) {
         EventBridge.emitWebEvent(JSON.stringify({
             type: "CHECKOUT",
@@ -134,6 +153,7 @@
             //     since that doesn't trigger another AJAX request.
             injectBuyButtonOnMainPage();
         }
+        addInventoryButton();
     }
 
     function injectHiFiItemPageCode() {
@@ -149,6 +169,7 @@
                     href);
             });
         }
+        addInventoryButton();
     }
 
     function updateClaraCode() {

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -144,8 +144,7 @@
                 tablet.pushOntoStack(MARKETPLACE_INVENTORY_QML_PATH);
                 tablet.sendToQml({
                     method: 'updateInventory',
-                    referrerURL: parsedJsonMessage.referrerURL,
-                    hfcBalance: 10
+                    referrerURL: parsedJsonMessage.referrerURL
                 });
             }
         }

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -212,6 +212,12 @@
                 }
                 //tablet.popFromStack();
                 break;
+            case 'inventory_itemClicked':
+                var itemId = message.itemId;
+                if (itemId && itemId !== "") {
+                    tablet.gotoWebScreen(MARKETPLACE_URL + '/items/' + itemId, MARKETPLACES_INJECT_SCRIPT_URL);
+                }
+                break;
             case 'inventory_backClicked':
                 tablet.gotoWebScreen(message.referrerURL, MARKETPLACES_INJECT_SCRIPT_URL);
                 break;


### PR DESCRIPTION
Don't formally test.

Leverages the synchronous commerce API to create an `Inventory.qml` page (accessible via the top of Marketplace) and update the `Checkout.qml` page.

NOTE that this implementation doesn't let you (easily) re-spawn items from the Marketplace that you've already purchased. This will, of course, be fixed quickly by allowing you to spawn entities you already own _ad infinitum_, because it impacts testing.

ALSO NOTE that the Inventory currently returns a simple list of strings corresponding to purchased Item IDs. This will (probably) change soon with a data-web change that @davidkelly will make that returns inventory in a more detailed JSON format.