### PR TITLE
Commerce: Use new JSON inventory format

### DIFF
--- a/interface/resources/qml/hifi/commerce/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/Checkout.qml
@@ -59,7 +59,7 @@ Rectangle {
                 console.log("Failed to get inventory", failureMessage);
             } else {
                 inventoryReceived = true;
-                if (inventory.indexOf(itemId) !== -1) {
+                if (inventoryContains(inventory.assets, itemId)) {
                     alreadyOwned = true;
                 } else {
                     alreadyOwned = false;
@@ -433,6 +433,15 @@ Rectangle {
         }
     }
     signal sendToScript(var message);
+
+    function inventoryContains(inventoryJson, id) {
+        for (var idx = 0; idx < inventoryJson.length; idx++) {
+            if(inventoryJson[idx].id === id) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     //
     // FUNCTION DEFINITIONS END

--- a/interface/resources/qml/hifi/commerce/Inventory.qml
+++ b/interface/resources/qml/hifi/commerce/Inventory.qml
@@ -40,7 +40,7 @@ Rectangle {
             if (failureMessage.length) {
                 console.log("Failed to get inventory", failureMessage);
             } else {
-                inventoryContentsList.model = inventory;
+                inventoryContentsList.model = inventory.assets;
             }
         }
     }
@@ -181,7 +181,7 @@ Rectangle {
                     size: 20;
                     // Style
                     color: hifi.colors.blueAccent;
-                    text: modelData;
+                    text: modelData.title;
                     // Alignment
                     horizontalAlignment: Text.AlignHLeft;
                 }
@@ -189,7 +189,7 @@ Rectangle {
                     anchors.fill: parent;
                     hoverEnabled: enabled;
                     onClicked: {
-                        sendToScript({method: 'inventory_itemClicked', itemId: thisItemId.text});
+                        sendToScript({method: 'inventory_itemClicked', itemId: modelData.id});
                     }
                     onEntered: {
                         thisItemId.color = hifi.colors.blueHighlight;

--- a/interface/src/commerce/Ledger.cpp
+++ b/interface/src/commerce/Ledger.cpp
@@ -44,7 +44,11 @@ void Ledger::buy(const QString& hfc_key, int cost, const QString& asset_id, cons
         return emit buyResult("Insufficient funds.");
     }
     _balance -= cost;
-    _inventory.push_back(asset_id);
+    QJsonObject inventoryAdditionObject;
+    inventoryAdditionObject["id"] = asset_id;
+    inventoryAdditionObject["title"] = "Test Title";
+    inventoryAdditionObject["preview"] = "https://www.aspca.org/sites/default/files/cat-care_cat-nutrition-tips_overweight_body4_left.jpg";
+    _inventory.push_back(inventoryAdditionObject);
     emit buyResult("");
 }
 
@@ -69,6 +73,9 @@ void Ledger::balance(const QStringList& keys) {
 
 void Ledger::inventory(const QStringList& keys) {
     // FIXME: talk to server instead
-    qCInfo(commerce) << "Inventory:" << _inventory;
-    emit inventoryResult(_inventory, "");
+    QJsonObject inventoryObject;
+    inventoryObject.insert("success", true);
+    inventoryObject.insert("assets", _inventory);
+    qCInfo(commerce) << "Inventory:" << inventoryObject;
+    emit inventoryResult(inventoryObject, "");
 }

--- a/interface/src/commerce/Ledger.h
+++ b/interface/src/commerce/Ledger.h
@@ -15,6 +15,8 @@
 #define hifi_Ledger_h
 
 #include <DependencyManager.h>
+#include <qjsonobject.h>
+#include <qjsonarray.h>
 
 class Ledger : public QObject, public Dependency {
     Q_OBJECT
@@ -30,12 +32,12 @@ signals:
     void buyResult(const QString& failureReason);
     void receiveAtResult(const QString& failureReason);
     void balanceResult(int balance, const QString& failureReason);
-    void inventoryResult(QStringList inventory, const QString& failureReason);
+    void inventoryResult(QJsonObject inventory, const QString& failureReason);
 
 private:
     // These in-memory caches is temporary, until we start sending things to the server.
     int _balance{ -1 };
-    QStringList _inventory{};
+    QJsonArray _inventory{};
     int initializedBalance() { if (_balance < 0) _balance = 100; return _balance; }
 };
 

--- a/interface/src/commerce/QmlCommerce.h
+++ b/interface/src/commerce/QmlCommerce.h
@@ -29,7 +29,7 @@ signals:
     // Balance and Inventory are NOT properties, because QML can't change them (without risk of failure), and 
     // because we can't scalably know of out-of-band changes (e.g., another machine interacting with the block chain).
     void balanceResult(int balance, const QString& failureMessage);
-    void inventoryResult(QStringList inventory, const QString& failureMessage);
+    void inventoryResult(QJsonObject inventory, const QString& failureMessage);
 
 protected:
     Q_INVOKABLE void buy(const QString& assetId, int cost, const QString& buyerUsername = "");


### PR DESCRIPTION
Don't formally test.

@davidkelly changed the return format of the inventory to be JSON so that it may contain an item title and preview image URL. Yay! This updates the test code to use the same format.

Some of this will be changed by @howard-stearns' upcoming fixes to use the live backend.