### PR TITLE
Remove context overlay (if present) when removing entity

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -55,6 +55,8 @@ ContextOverlayInterface::ContextOverlayInterface() {
             _contextOverlayJustClicked = false;
         }
     });
+    auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>().data();
+    connect(entityScriptingInterface, &EntityScriptingInterface::deletingEntity, this, &ContextOverlayInterface::deletingEntity);
 }
 
 static const uint32_t LEFT_HAND_HW_ID = 1;
@@ -277,4 +279,10 @@ void ContextOverlayInterface::disableEntityHighlight(const EntityItemID& entityI
             entityItem->setShouldHighlight(false);
         }
     });
+}
+
+void ContextOverlayInterface::deletingEntity(const EntityItemID& entityID) {
+    if (_currentEntityWithContextOverlay == entityID) {
+        destroyContextOverlay(_currentEntityWithContextOverlay, PointerEvent());
+    }
 }

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -80,6 +80,7 @@ private:
     void enableEntityHighlight(const EntityItemID& entityItemID);
     void disableEntityHighlight(const EntityItemID& entityItemID);
 
+    void deletingEntity(const EntityItemID& entityItemID);
 };
 
 #endif // hifi_ContextOverlayInterface_h


### PR DESCRIPTION
**Test Plan:**
1. Add the following line to your `Interface.json` file: `"inspectionMode": true,`
2. Open Interface
3. Spawn a confetti gun from the Marketplace
4. Right click the confetti gun. Verify it has a context overlay.
5. Click the context overlay. Verify the context overlay disappears and the Marketplace opens.
6. Close the Marketplace.
7. Right click the confetti gun. Verify it has a context overlay.
8. Open Create mode
9. Carefully left-click on the confetti gun (not the overlay)
10. Press the Delete key on your keyboard
11. Verify that both the confetti gun and the context overlay disappear.