### PR TITLE
Fix drawInFront overlays only rendering in left eye

### DIFF
--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -32,6 +32,8 @@ Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
     _length = line3DOverlay->getLength();
     _endParentID = line3DOverlay->getEndParentID();
     _endParentJointIndex = line3DOverlay->getEndJointIndex();
+    _glow = line3DOverlay->getGlow();
+    _glowWidth = line3DOverlay->getGlowWidth();
 }
 
 Line3DOverlay::~Line3DOverlay() {
@@ -138,11 +140,9 @@ void Line3DOverlay::render(RenderArgs* args) {
             // TODO: add support for color to renderDashedLine()
             geometryCache->bindSimpleProgram(*batch, false, false, false, true, true);
             geometryCache->renderDashedLine(*batch, start, end, colorv4, _geometryCacheID);
-        } else if (_glow > 0.0f) {
-            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _glowWidth, _geometryCacheID);
         } else {
-            geometryCache->bindSimpleProgram(*batch, false, false, false, true, true);
-            geometryCache->renderLine(*batch, start, end, colorv4, _geometryCacheID);
+            // renderGlowLine handles both glow = 0 and glow > 0 cases
+            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _glowWidth, _geometryCacheID);
         }
     }
 }
@@ -228,9 +228,9 @@ void Line3DOverlay::setProperties(const QVariantMap& originalProperties) {
         }
     }
 
-    auto glowWidth = properties["glow"];
+    auto glowWidth = properties["glowWidth"];
     if (glowWidth.isValid()) {
-        setGlow(glowWidth.toFloat());
+        setGlowWidth(glowWidth.toFloat());
     }
 
 }

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1640,7 +1640,11 @@ void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const
 #endif
 
     if (glowIntensity <= 0) {
-        bindSimpleProgram(batch, false, false, false, true, false);
+        if (color.a >= 1.0) {
+            bindSimpleProgram(batch, false, false, false, true, true);
+        } else {
+            bindSimpleProgram(batch, false, true, false, true, true);
+        }
         renderLine(batch, p1, p2, color, id);
         return;
     }

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1639,8 +1639,8 @@ void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const
     glowIntensity = 0.0f;
 #endif
 
-    if (glowIntensity <= 0) {
-        if (color.a >= 1.0) {
+    if (glowIntensity <= 0.0f) {
+        if (color.a >= 1.0f) {
             bindSimpleProgram(batch, false, false, false, true, true);
         } else {
             bindSimpleProgram(batch, false, true, false, true, true);

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -357,7 +357,7 @@ void DrawOverlay3D::run(const RenderContextPointer& renderContext, const Inputs&
         if (_opaquePass) {
             gpu::doInBatch(args->_context, [&](gpu::Batch& batch){
                 batch.enableStereo(false);
-                batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTH, glm::vec4(), 1.f, 0, true);
+                batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTH, glm::vec4(), 1.f, 0, false);
             });
         }
 


### PR DESCRIPTION
Fixes a bug that caused some overlays (specifically, all line 3d overlays and dashed line cube overlays) to only render in your left eye when they had drawInFront enabled.  Also some small inconsequential fixes to the line 3d code.

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/2915eef3a31f8832e923714543f9b3eb/raw/1016fe46c76526da43b72e10d8529caad4cd1ad4/DrawInFrontTest.js).  It will create a bunch of shapes and lines down the z axis from you.  Move or create an entity so that the overlays are being blocked.
- In HMD mode, on master, you would see this (most of the overlays were not rendered in the right eye):
![drawinfrontbefore](https://user-images.githubusercontent.com/7650116/29294448-3d5244e0-8104-11e7-8e1e-d1cd08a4eddb.png)
- In this build, you should see this:
![drawinfrontafter](https://user-images.githubusercontent.com/7650116/29294537-b049ffc4-8104-11e7-9ef1-a9a6cfd3ae8a.png)