### PR TITLE
Fixed unable to select items in a TreeView

### DIFF
--- a/interface/resources/qml/controls-uit/Tree.qml
+++ b/interface/resources/qml/controls-uit/Tree.qml
@@ -27,6 +27,7 @@ TreeView {
 
     model: treeModel
     selection: ItemSelectionModel {
+	id: selectionModel
         model: treeModel
     }
 
@@ -214,6 +215,10 @@ TreeView {
     }
 
     onDoubleClicked: isExpanded(index) ? collapse(index) : expand(index)
+
+    onClicked: {
+	selectionModel.setCurrentIndex(index, ItemSelectionModel.ClearAndSelect);
+    }
 
     onActivated: {
         var path = scriptsModel.data(index, 0x100)

--- a/interface/resources/qml/controls-uit/Tree.qml
+++ b/interface/resources/qml/controls-uit/Tree.qml
@@ -27,7 +27,7 @@ TreeView {
 
     model: treeModel
     selection: ItemSelectionModel {
-	id: selectionModel
+        id: selectionModel
         model: treeModel
     }
 
@@ -217,7 +217,7 @@ TreeView {
     onDoubleClicked: isExpanded(index) ? collapse(index) : expand(index)
 
     onClicked: {
-	selectionModel.setCurrentIndex(index, ItemSelectionModel.ClearAndSelect);
+        selectionModel.setCurrentIndex(index, ItemSelectionModel.ClearAndSelect);
     }
 
     onActivated: {


### PR DESCRIPTION
The seems to be a bug with newer version of Qt regarding touch events and TreeView interaction according to blogs. This PR implements a fix of unable to select items in the TreeView.

ticket - https://highfidelity.fogbugz.com/f/cases/6908/Running-Scripts-page-does-not-work-in-Tablet-HMD