### PR TITLE
Miscellaneous logging fixes

### DIFF
--- a/interface/resources/qml/Web3DOverlay.qml
+++ b/interface/resources/qml/Web3DOverlay.qml
@@ -15,6 +15,11 @@ import "controls" as Controls
 
 Controls.WebView {
 
+    // This is for JS/QML communication, which is unused in a Web3DOverlay,
+    // but not having this here results in spurious warnings about a
+    // missing signal
+    signal sendToScript(var message);
+
     function onWebEventReceived(event) {
         if (event.slice(0, 17) === "CLARA.IO DOWNLOAD") {
             ApplicationInterface.addAssetToWorldFromURL(event.slice(18));

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -41,6 +41,11 @@ FocusScope {
     // when they're opened.
     signal showDesktop();
 
+    // This is for JS/QML communication, which is unused in the Desktop,
+    // but not having this here results in spurious warnings about a
+    // missing signal
+    signal sendToScript(var message);
+
     // Allows QML/JS to find the desktop through the parent chain
     property bool desktopRoot: true
 

--- a/interface/resources/qml/hifi/dialogs/AttachmentsDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/AttachmentsDialog.qml
@@ -28,6 +28,11 @@ ScrollingWindow {
 
     HifiConstants { id: hifi }
 
+    // This is for JS/QML communication, which is unused in the AttachmentsDialog,
+    // but not having this here results in spurious warnings about a
+    // missing signal
+    signal sendToScript(var message);
+
     property var settings: Settings {
         category: "AttachmentsDialog"
         property alias x: root.x

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1228,7 +1228,7 @@ Script.scriptEnding.connect(function () {
     Controller.mouseMoveEvent.disconnect(mouseMoveEventBuffered);
     Controller.mouseReleaseEvent.disconnect(mouseReleaseEvent);
 
-    Messages.messageReceived.disconnect(handleOverlaySelectionToolUpdates);
+    Messages.messageReceived.disconnect(handleMessagesReceived);
     Messages.unsubscribe("entityToolUpdates");
     Messages.unsubscribe("Toolbar-DomainChanged");
     createButton = null;

--- a/scripts/system/help.js
+++ b/scripts/system/help.js
@@ -61,6 +61,7 @@
             tablet.gotoHomeScreen();
         }
         button.clicked.disconnect(onClicked);
+        tablet.screenChanged.disconnect(onScreenChanged);
         Script.clearInterval(interval);
         if (tablet) {
             tablet.removeButton(button);

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -764,8 +764,8 @@ Script.scriptEnding.connect(function () {
     }
     Window.snapshotShared.disconnect(snapshotUploaded);
     Snapshot.snapshotLocationSet.disconnect(snapshotLocationSet);
-    Entities.canRezChanged.disconnect(processRezPermissionChange);
-    Entities.canRezTmpChanged.disconnect(processRezPermissionChange);
+    Entities.canRezChanged.disconnect(updatePrintPermissions);
+    Entities.canRezTmpChanged.disconnect(updatePrintPermissions);
 });
 
 }()); // END LOCAL_SCOPE


### PR DESCRIPTION
There were some errors being logged that were bothering me.

Specifically:
- 3 backtraces from mismatched script connect/disconnects
- 1 error from a missing script disconnect
- 3 missing sendToScripts in QML

Test plan:
- Functionally nothing has changed.
- Reload default scripts and check your logs.
- Shouldn't see any backtraces from messed up signal disconnects.
- Shouldn't see an error about an undefined button in help.js.
- Shouldn't see logged errors about missing "sendToScript" signals.