### PR TITLE
fixed tablet spawn position for oculus menu button

### DIFF
--- a/scripts/system/controllers/handControllerPointer.js
+++ b/scripts/system/controllers/handControllerPointer.js
@@ -451,7 +451,7 @@ clickMapping.from(Controller.Standard.Start).peek().to(function (clicked) {
     if (clicked) {
         activeHudPoint2dGamePad();
         var noHands = -1;
-        Messages.sendLocalMessage("toggleHand", noHands);
+        Messages.sendLocalMessage("toggleHand", Controller.Standard.LeftHand);
       }
 
       wantsMenu = clicked;


### PR DESCRIPTION
When pressing the menu button on the oculus controller, the tablet is positioned the same why when you press the Y or B button.

ticket - https://highfidelity.fogbugz.com/f/cases/6417/Oculus-Touch-Menu-button-displays-tablet-at-wrong-position