### PR TITLE
Allow users to take a snapshot from the Secondary Camera!

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6911,6 +6911,12 @@ void Application::takeSnapshot(bool notify, bool includeAnimated, float aspectRa
     });
 }
 
+void Application::takeSecondaryCameraSnapshot() {
+    postLambdaEvent([this] {
+        Snapshot::saveSnapshot(getActiveDisplayPlugin()->getSecondaryCameraScreenshot());
+    });
+}
+
 void Application::shareSnapshot(const QString& path, const QUrl& href) {
     postLambdaEvent([path, href] {
         // not much to do here, everything is done in snapshot code...

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -274,6 +274,7 @@ public:
     float getAverageSimsPerSecond() const { return _simCounter.rate(); }
 
     void takeSnapshot(bool notify, bool includeAnimated = false, float aspectRatio = 0.0f);
+    void takeSecondaryCameraSnapshot();
     void shareSnapshot(const QString& filename, const QUrl& href = QUrl(""));
 
     model::SkyboxPointer getDefaultSkybox() const { return _defaultSkybox; }

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -294,6 +294,10 @@ void WindowScriptingInterface::takeSnapshot(bool notify, bool includeAnimated, f
     qApp->takeSnapshot(notify, includeAnimated, aspectRatio);
 }
 
+void WindowScriptingInterface::takeSecondaryCameraSnapshot() {
+    qApp->takeSecondaryCameraSnapshot();
+}
+
 void WindowScriptingInterface::shareSnapshot(const QString& path, const QUrl& href) {
     qApp->shareSnapshot(path, href);
 }

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -60,6 +60,7 @@ public slots:
     void showAssetServer(const QString& upload = "");
     void copyToClipboard(const QString& text);
     void takeSnapshot(bool notify = true, bool includeAnimated = false, float aspectRatio = 0.0f);
+    void takeSecondaryCameraSnapshot();
     void makeConnection(bool success, const QString& userNameOrError);
     void displayAnnouncement(const QString& message);
     void shareSnapshot(const QString& path, const QUrl& href = QUrl(""));

--- a/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.cpp
@@ -34,3 +34,7 @@ void NullDisplayPlugin::submitFrame(const gpu::FramePointer& frame) {
 QImage NullDisplayPlugin::getScreenshot(float aspectRatio) const {
     return QImage();
 }
+
+QImage NullDisplayPlugin::getSecondaryCameraScreenshot() const {
+    return QImage();
+}

--- a/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/NullDisplayPlugin.h
@@ -19,6 +19,7 @@ public:
     bool hasFocus() const override;
     void submitFrame(const gpu::FramePointer& newFrame) override;
     QImage getScreenshot(float aspectRatio = 0.0f) const override;
+    QImage getSecondaryCameraScreenshot() const override;
     void copyTextureToQuickFramebuffer(NetworkTexturePointer source, QOpenGLFramebufferObject* target, GLsync* fenceSync) override {};
 private:
     static const QString NAME;

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -775,6 +775,19 @@ QImage OpenGLDisplayPlugin::getScreenshot(float aspectRatio) const {
     return screenshot.mirrored(false, true);
 }
 
+QImage OpenGLDisplayPlugin::getSecondaryCameraScreenshot() const {
+    auto textureCache = DependencyManager::get<TextureCache>();
+    auto secondaryCameraFramebuffer = textureCache->getSpectatorCameraFramebuffer();
+    gpu::Vec4i region(0, 0, secondaryCameraFramebuffer->getWidth(), secondaryCameraFramebuffer->getHeight());
+
+    auto glBackend = const_cast<OpenGLDisplayPlugin&>(*this).getGLBackend();
+    QImage screenshot(region.z, region.w, QImage::Format_ARGB32);
+    withMainThreadContext([&] {
+        glBackend->downloadFramebuffer(secondaryCameraFramebuffer, region, screenshot);
+    });
+    return screenshot.mirrored(false, true);
+}
+
 glm::uvec2 OpenGLDisplayPlugin::getSurfacePixels() const {
     uvec2 result;
     auto window = _container->getPrimaryWidget();

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -60,6 +60,7 @@ public:
     virtual bool setDisplayTexture(const QString& name) override;
     virtual bool onDisplayTextureReset() { return false; };
     QImage getScreenshot(float aspectRatio = 0.0f) const override;
+    QImage getSecondaryCameraScreenshot() const override;
 
     float presentRate() const override;
 

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -183,6 +183,7 @@ public:
 
     // Fetch the most recently displayed image as a QImage
     virtual QImage getScreenshot(float aspectRatio = 0.0f) const = 0;
+    virtual QImage getSecondaryCameraScreenshot() const = 0;
 
     // will query the underlying hmd api to compute the most recent head pose
     virtual bool beginFrameRender(uint32_t frameIndex) { return true; }


### PR DESCRIPTION
Enables lots of fun features (none of which are implemented) - like being able to write [a script to quickly generate an ambient map in a zone](https://www.dropbox.com/s/5y0psczpvlrykoo/generateCubemapImages.js?dl=0), or being able to create an in-world selfie stick! 😄

**Test Plan:**
1. Define a "Put my snapshots here" location in Settings -> General
2. Grab the Spectator Camera from the Marketplace
3. Enter VR mode
4. Enable the Spectator Camera and point it at something beautiful
5. While still in VR Mode, copy and paste this line into your JS Scripting Console (Ctrl + Alt + J): `Window.takeSecondaryCameraSnapshot();` Press enter.
6. Open your file explorer to the Snapshot Location. Verify that you see a .jpg image corresponding to what your Spectator Camera was pointed at!
7. Celebrate! 🎉 

![hifi-snap-by-zfox-on-2017-08-16_16-01-52](https://user-images.githubusercontent.com/3409031/29388985-69901cbe-829c-11e7-9633-c644cd01e07e.jpg)
