### PR TITLE
DNM: interface-client ignores octcode data embedded in EntityItem update packets

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -584,7 +584,7 @@ void MyAvatar::simulate(float deltaTime) {
             }
             auto now = usecTimestampNow();
             EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
-            MovingEntitiesOperator moveOperator(entityTree);
+            MovingEntitiesOperator moveOperator;
             forEachDescendant([&](SpatiallyNestablePointer object) {
                 // if the queryBox has changed, tell the entity-server
                 if (object->getNestableType() == NestableType::Entity && object->checkAndMaybeUpdateQueryAACube()) {

--- a/libraries/entities/src/AddEntityOperator.cpp
+++ b/libraries/entities/src/AddEntityOperator.cpp
@@ -9,18 +9,17 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AddEntityOperator.h"
+
 #include "EntityItem.h"
 #include "EntityTree.h"
 #include "EntityTreeElement.h"
 
-#include "AddEntityOperator.h"
-
 AddEntityOperator::AddEntityOperator(EntityTreePointer tree, EntityItemPointer newEntity) :
     _tree(tree),
     _newEntity(newEntity),
-    _foundNew(false),
-    _changeTime(usecTimestampNow()),
-    _newEntityBox()
+    _newEntityBox(),
+    _foundNew(false)
 {
     // caller must have verified existence of newEntity
     assert(_newEntity);

--- a/libraries/entities/src/AddEntityOperator.h
+++ b/libraries/entities/src/AddEntityOperator.h
@@ -12,20 +12,28 @@
 #ifndef hifi_AddEntityOperator_h
 #define hifi_AddEntityOperator_h
 
+#include <memory>
+
+#include <AABox.h>
+#include <Octree.h>
+
+#include "EntityTypes.h"
+
+class EntityTree;
+using EntityTreePointer = std::shared_ptr<EntityTree>;
+
 class AddEntityOperator : public RecurseOctreeOperator {
 public:
     AddEntityOperator(EntityTreePointer tree, EntityItemPointer newEntity);
-                            
+
     virtual bool preRecursion(const OctreeElementPointer& element) override;
     virtual bool postRecursion(const OctreeElementPointer& element) override;
     virtual OctreeElementPointer possiblyCreateChildAt(const OctreeElementPointer& element, int childIndex) override;
 private:
     EntityTreePointer _tree;
     EntityItemPointer _newEntity;
-    bool _foundNew;
-    quint64 _changeTime;
-
     AABox _newEntityBox;
+    bool _foundNew;
 };
 
 

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -141,7 +141,7 @@ void EntitySimulation::callUpdateOnEntitiesThatNeedIt(const quint64& now) {
 void EntitySimulation::sortEntitiesThatMoved() {
     // NOTE: this is only for entities that have been moved by THIS EntitySimulation.
     // External changes to entity position/shape are expected to be sorted outside of the EntitySimulation.
-    MovingEntitiesOperator moveOperator(_entityTree);
+    MovingEntitiesOperator moveOperator;
     AACube domainBounds(glm::vec3((float)-HALF_TREE_SCALE), (float)TREE_SCALE);
     SetOfEntities::iterator itemItr = _entitiesToSort.begin();
     while (itemItr != _entitiesToSort.end()) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -22,7 +22,6 @@
 #include "VariantMapToScriptValue.h"
 
 #include "AddEntityOperator.h"
-#include "MovingEntitiesOperator.h"
 #include "UpdateEntityOperator.h"
 #include "QVariantGLM.h"
 #include "EntitiesLogging.h"
@@ -105,6 +104,121 @@ void EntityTree::eraseAllOctreeElements(bool createNewRoot) {
 
     resetClientEditStats();
     clearDeletedEntities();
+}
+
+void EntityTree::readBitstreamToTree(const unsigned char* bitstream,
+            unsigned long int bufferSizeBytes, ReadBitstreamToTreeParams& args) {
+    Octree::readBitstreamToTree(bitstream, bufferSizeBytes, args);
+
+    // add entities
+    QHash<EntityItemID, EntityItemPointer>::const_iterator itr;
+    for (itr = _entitiesToAdd.constBegin(); itr != _entitiesToAdd.constEnd(); ++itr) {
+        EntityItemPointer entityItem = itr.value();
+        AddEntityOperator theOperator(getThisPointer(), entityItem);
+        recurseTreeWithOperator(&theOperator);
+        if (!entityItem->getParentID().isNull()) {
+            addToNeedsParentFixupList(entityItem);
+        }
+        postAddEntity(entityItem);
+    }
+    _entitiesToAdd.clear();
+
+    // move entities
+    if (_entityMover.hasMovingEntities()) {
+        PerformanceTimer perfTimer("recurseTreeWithOperator");
+        recurseTreeWithOperator(&_entityMover);
+        _entityMover.reset();
+    }
+}
+
+int EntityTree::readEntityDataFromBuffer(const unsigned char* data, int bytesLeftToRead, ReadBitstreamToTreeParams& args) {
+    const unsigned char* dataAt = data;
+    int bytesRead = 0;
+    uint16_t numberOfEntities = 0;
+    int expectedBytesPerEntity = EntityItem::expectedBytes();
+
+    args.elementsPerPacket++;
+
+    if (bytesLeftToRead >= (int)sizeof(numberOfEntities)) {
+        // read our entities in....
+        numberOfEntities = *(uint16_t*)dataAt;
+
+        dataAt += sizeof(numberOfEntities);
+        bytesLeftToRead -= (int)sizeof(numberOfEntities);
+        bytesRead += sizeof(numberOfEntities);
+
+        if (bytesLeftToRead >= (int)(numberOfEntities * expectedBytesPerEntity)) {
+            for (uint16_t i = 0; i < numberOfEntities; i++) {
+                int bytesForThisEntity = 0;
+                EntityItemID entityItemID = EntityItemID::readEntityItemIDFromBuffer(dataAt, bytesLeftToRead);
+                EntityItemPointer entity = findEntityByEntityItemID(entityItemID);
+
+                if (entity) {
+                    QString entityScriptBefore = entity->getScript();
+                    QUuid parentIDBefore = entity->getParentID();
+                    QString entityServerScriptsBefore = entity->getServerScripts();
+                    quint64 entityScriptTimestampBefore = entity->getScriptTimestamp();
+
+                    bytesForThisEntity = entity->readEntityDataFromBuffer(dataAt, bytesLeftToRead, args);
+                    if (entity->getDirtyFlags()) {
+                        entityChanged(entity);
+                    }
+                    _entityMover.addEntityToMoveList(entity, entity->getQueryAACube());
+
+                    QString entityScriptAfter = entity->getScript();
+                    QString entityServerScriptsAfter = entity->getServerScripts();
+                    quint64 entityScriptTimestampAfter = entity->getScriptTimestamp();
+                    bool reload = entityScriptTimestampBefore != entityScriptTimestampAfter;
+
+                    // If the script value has changed on us, or it's timestamp has changed to force
+                    // a reload then we want to send out a script changing signal...
+                    if (reload || entityScriptBefore != entityScriptAfter) {
+                        emitEntityScriptChanging(entityItemID, reload); // the entity script has changed
+                    }
+                    if (reload || entityServerScriptsBefore != entityServerScriptsAfter) {
+                        emitEntityServerScriptChanging(entityItemID, reload); // the entity server script has changed
+                    }
+
+                    QUuid parentIDAfter = entity->getParentID();
+                    if (parentIDBefore != parentIDAfter) {
+                        addToNeedsParentFixupList(entity);
+                    }
+                } else {
+                    entity = EntityTypes::constructEntityItem(dataAt, bytesLeftToRead, args);
+                    if (entity) {
+                        bytesForThisEntity = entity->readEntityDataFromBuffer(dataAt, bytesLeftToRead, args);
+
+                        // don't add if we've recently deleted....
+                        if (!isDeletedEntity(entityItemID)) {
+                            _entitiesToAdd.insert(entityItemID, entity);
+
+                            /*
+                            addEntityMapEntry(entity);
+                            oldElement->addEntityItem(entity); // add this new entity to this elements entities
+                            entityItemID = entity->getEntityItemID();
+                            postAddEntity(entity);
+                            */
+
+                            if (entity->getCreated() == UNKNOWN_CREATED_TIME) {
+                                entity->recordCreationTime();
+                            }
+                        } else {
+                            #ifdef WANT_DEBUG
+                                qCDebug(entities) << "Received packet for previously deleted entity [" <<
+                                        entityItemID << "] ignoring. (inside " << __FUNCTION__ << ")";
+                            #endif
+                        }
+                    }
+                }
+                // Move the buffer forward to read more entities
+                dataAt += bytesForThisEntity;
+                bytesLeftToRead -= bytesForThisEntity;
+                bytesRead += bytesForThisEntity;
+            }
+        }
+    }
+
+    return bytesRead;
 }
 
 bool EntityTree::handlesEditPacketType(PacketType packetType) const {
@@ -1248,7 +1362,7 @@ void EntityTree::entityChanged(EntityItemPointer entity) {
 
 
 void EntityTree::fixupNeedsParentFixups() {
-    MovingEntitiesOperator moveOperator(getThisPointer());
+    MovingEntitiesOperator moveOperator;
 
     QWriteLocker locker(&_needsParentFixupLock);
 
@@ -1665,7 +1779,7 @@ QVector<EntityItemID> EntityTree::sendEntities(EntityEditPacketSender* packetSen
     // add-entity packet to the server.
 
     // fix the queryAACubes of any children that were read in before their parents, get them into the correct element
-    MovingEntitiesOperator moveOperator(localTree);
+    MovingEntitiesOperator moveOperator;
     QHash<EntityItemID, EntityItemID>::iterator i = map.begin();
     while (i != map.end()) {
         EntityItemID newID = i.value();

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -107,7 +107,7 @@ void EntityTree::eraseAllOctreeElements(bool createNewRoot) {
 }
 
 void EntityTree::readBitstreamToTree(const unsigned char* bitstream,
-            unsigned long int bufferSizeBytes, ReadBitstreamToTreeParams& args) {
+            uint64_t bufferSizeBytes, ReadBitstreamToTreeParams& args) {
     Octree::readBitstreamToTree(bitstream, bufferSizeBytes, args);
 
     // add entities

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -19,11 +19,12 @@
 #include <SpatialParentFinder.h>
 
 class EntityTree;
-typedef std::shared_ptr<EntityTree> EntityTreePointer;
+using EntityTreePointer = std::shared_ptr<EntityTree>;
 
-
+#include "AddEntityOperator.h"
 #include "EntityTreeElement.h"
 #include "DeleteEntityOperator.h"
+#include "MovingEntitiesOperator.h"
 
 class EntityEditFilters;
 class Model;
@@ -79,6 +80,10 @@ public:
     }
 
     virtual void eraseAllOctreeElements(bool createNewRoot = true) override;
+
+    virtual void readBitstreamToTree(const unsigned char* bitstream,
+            unsigned long int bufferSizeBytes, ReadBitstreamToTreeParams& args) override;
+    int readEntityDataFromBuffer(const unsigned char* data, int bytesLeftToRead, ReadBitstreamToTreeParams& args);
 
     // These methods will allow the OctreeServer to send your tree inbound edit packets of your
     // own definition. Implement these to allow your octree based server to support editing
@@ -346,6 +351,9 @@ protected:
     bool filterProperties(EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType);
     bool _hasEntityEditFilter{ false };
     QStringList _entityScriptSourceWhitelist;
+
+    MovingEntitiesOperator _entityMover;
+    QHash<EntityItemID, EntityItemPointer> _entitiesToAdd;
 };
 
 #endif // hifi_EntityTree_h

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -82,7 +82,7 @@ public:
     virtual void eraseAllOctreeElements(bool createNewRoot = true) override;
 
     virtual void readBitstreamToTree(const unsigned char* bitstream,
-            unsigned long int bufferSizeBytes, ReadBitstreamToTreeParams& args) override;
+            uint64_t bufferSizeBytes, ReadBitstreamToTreeParams& args) override;
     int readEntityDataFromBuffer(const unsigned char* data, int bytesLeftToRead, ReadBitstreamToTreeParams& args);
 
     // These methods will allow the OctreeServer to send your tree inbound edit packets of your

--- a/libraries/entities/src/MovingEntitiesOperator.cpp
+++ b/libraries/entities/src/MovingEntitiesOperator.cpp
@@ -16,15 +16,7 @@
 
 #include "MovingEntitiesOperator.h"
 
-MovingEntitiesOperator::MovingEntitiesOperator(EntityTreePointer tree) :
-    _tree(tree),
-    _changeTime(usecTimestampNow()),
-    _foundOldCount(0),
-    _foundNewCount(0),
-    _lookingCount(0),
-    _wantDebug(false)
-{
-}
+MovingEntitiesOperator::MovingEntitiesOperator() { }
 
 MovingEntitiesOperator::~MovingEntitiesOperator() {
     if (_wantDebug) {
@@ -146,7 +138,7 @@ bool MovingEntitiesOperator::preRecursion(const OctreeElementPointer& element) {
     
     // In Pre-recursion, we're generally deciding whether or not we want to recurse this
     // path of the tree. For this operation, we want to recurse the branch of the tree if
-    // and of the following are true:
+    // any of the following are true:
     //   * We have not yet found the old entity, and this branch contains our old entity
     //   * We have not yet found the new entity, and this branch contains our new entity
     //
@@ -230,8 +222,6 @@ bool MovingEntitiesOperator::postRecursion(const OctreeElementPointer& element) 
     if ((shouldRecurseSubTree(element))) {
         element->markWithChangedTime();
     }
-    
-
 
     // It's not OK to prune if we have the potential of deleting the original containing element
     // because if we prune the containing element then new might end up reallocating the same memory later 
@@ -285,4 +275,11 @@ OctreeElementPointer MovingEntitiesOperator::possiblyCreateChildAt(const OctreeE
         }
     }
     return NULL; 
+}
+
+void MovingEntitiesOperator::reset() {
+    _entitiesToMove.clear();
+    _foundOldCount = 0;
+    _foundNewCount = 0;
+    _lookingCount = 0;
 }

--- a/libraries/entities/src/MovingEntitiesOperator.h
+++ b/libraries/entities/src/MovingEntitiesOperator.h
@@ -12,6 +12,11 @@
 #ifndef hifi_MovingEntitiesOperator_h
 #define hifi_MovingEntitiesOperator_h
 
+#include <QSet>
+
+#include "EntityTypes.h"
+#include "EntityTreeElement.h"
+
 class EntityToMoveDetails {
 public:
     EntityItemPointer entity;
@@ -34,7 +39,7 @@ inline bool operator==(const EntityToMoveDetails& a, const EntityToMoveDetails& 
 
 class MovingEntitiesOperator : public RecurseOctreeOperator {
 public:
-    MovingEntitiesOperator(EntityTreePointer tree);
+    MovingEntitiesOperator();
     ~MovingEntitiesOperator();
 
     void addEntityToMoveList(EntityItemPointer entity, const AACube& newCube);
@@ -42,16 +47,15 @@ public:
     virtual bool postRecursion(const OctreeElementPointer& element) override;
     virtual OctreeElementPointer possiblyCreateChildAt(const OctreeElementPointer& element, int childIndex) override;
     bool hasMovingEntities() const { return _entitiesToMove.size() > 0; }
+    void reset();
 private:
-    EntityTreePointer _tree;
-    QSet<EntityToMoveDetails> _entitiesToMove;
-    quint64 _changeTime;
-    int _foundOldCount;
-    int _foundNewCount;
-    int _lookingCount;
     bool shouldRecurseSubTree(const OctreeElementPointer& element);
-    
-    bool _wantDebug;
+
+    QSet<EntityToMoveDetails> _entitiesToMove;
+    int _foundOldCount { 0 };
+    int _foundNewCount { 0 };
+    int _lookingCount { 0 };
+    bool _wantDebug { false };
 };
 
 #endif // hifi_MovingEntitiesOperator_h

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -431,8 +431,7 @@ int Octree::readElementData(const OctreeElementPointer& destinationElement, cons
     return bytesRead;
 }
 
-void Octree::readBitstreamToTree(const unsigned char * bitstream, uint64_t bufferSizeBytes,
-                                 ReadBitstreamToTreeParams& args) {
+void Octree::readBitstreamToTree(const unsigned char * bitstream, uint64_t bufferSizeBytes, ReadBitstreamToTreeParams& args) {
     int bytesRead = 0;
     const unsigned char* bitstreamAt = bitstream;
 

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -232,7 +232,7 @@ public:
 
     virtual void eraseAllOctreeElements(bool createNewRoot = true);
 
-    void readBitstreamToTree(const unsigned char* bitstream,  uint64_t bufferSizeBytes, ReadBitstreamToTreeParams& args);
+    virtual void readBitstreamToTree(const unsigned char* bitstream,  uint64_t bufferSizeBytes, ReadBitstreamToTreeParams& args);
     void deleteOctalCodeFromTree(const unsigned char* codeBuffer, bool collapseEmptyTrees = DONT_COLLAPSE);
     void reaverageOctreeElements(OctreeElementPointer startElement = OctreeElementPointer());
 


### PR DESCRIPTION
Do Not Merge

This is a proof of concept that modifies the interface-client to ignore octcode data embedded in packets containing EntityItem info.  The idea is to make the interface able to accept EntityItem data packed into a shallow octree (just the root element) and to do the Right Thing: to independently figure out where to insert each EntityItem and build out the octree without relying on hints in the packets.

If this works then we have a universal interface-client that can connect to either a legacy entity-server (the data protocol hasn't changed!) or to a new entity-server that doesn't bother to embed octcode data in the packets (e.g. the work that is going on in PR-11141).