### PR TITLE
Base requirements change : dev system must have at least 8GB of RAM.

### DIFF
--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -3,7 +3,7 @@ This is a stand-alone guide for creating your first High Fidelity build for Wind
 ## Building High Fidelity
 Note: We are now using Visual Studio 2017 and Qt 5.9.1. If you are upgrading from Visual Studio 2013 and Qt 5.6.2, do a clean uninstall of those versions before going through this guide. 
 
-Note: The prerequisites will require about 10 GB of space on your drive.
+Note: The prerequisites will require about 10 GB of space on your drive. You will also need a system with at least 8GB of main memory.
 
 ### Step 1. Visual Studio 2017
 


### PR DESCRIPTION
Issue : systems with <8GB of RAM (in this test case, 6GB) will encounter out-of-memory errors while building the HiFi source.

My solution : maybe systems with >=8GB of RAM would not have this issue?

Images attached showing this issue. Issue detected on a system built using the Windows7+VisualStudio2017 specs and required libraries (all from a fresh install) noted in hifi/BUILD_WIN.md

![outofmemory](https://user-images.githubusercontent.com/30985702/29397304-195bb11e-82d2-11e7-8a5b-1b1f2661ac6c.PNG)
![outofmemory2](https://user-images.githubusercontent.com/30985702/29397310-1d53d3c8-82d2-11e7-8982-1b2a0e6912e2.PNG)
![outofmemory3](https://user-images.githubusercontent.com/30985702/29397313-22a9861a-82d2-11e7-8070-02fa824f6129.PNG)
