### PR TITLE
[Case 6491] Part 2 of entitySelectionTool clean up

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1526,7 +1526,6 @@ SelectionDisplay = (function() {
         var rotateHandlesVisible = true;
         var rotationOverlaysVisible = false;
         var translateHandlesVisible = true;
-        var stretchHandlesVisible = true;
         var selectionBoxVisible = true;
         var isPointLight = false;
 
@@ -1539,11 +1538,9 @@ SelectionDisplay = (function() {
             rotationOverlaysVisible = true;
             rotateHandlesVisible = false;
             translateHandlesVisible = false;
-            stretchHandlesVisible = false;
             selectionBoxVisible = false;
         } else if (mode == "TRANSLATE_UP_DOWN" || isPointLight) {
             rotateHandlesVisible = false;
-            stretchHandlesVisible = false;
         } else if (mode != "UNKNOWN") {
             // every other mode is a stretch mode...
             rotateHandlesVisible = false;
@@ -1618,6 +1615,7 @@ SelectionDisplay = (function() {
             return;
         }
 
+        //print( "    Triggering updateRotationHandles");
         that.updateRotationHandles();
 
         var rotation, dimensions, position, registrationPoint;
@@ -1845,201 +1843,212 @@ SelectionDisplay = (function() {
         EdgeFR = Vec3.sum(position, EdgeFR);
         EdgeFL = Vec3.sum(position, EdgeFL);
 
-        var stretchHandlesVisible = spaceMode == SPACE_LOCAL;
-        var extendedStretchHandlesVisible = stretchHandlesVisible && showExtendedStretchHandles;
+        var inModeRotate = (mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL");
+        var stretchHandlesVisible = !inModeRotate && (spaceMode == SPACE_LOCAL);
+        var extendedStretchHandlesVisible = (stretchHandlesVisible && showExtendedStretchHandles);
+        var cloneHandleVisible = !inModeRotate;
+        //print("    Set Non-Light Grabbers Visible - Norm: " + stretchHandlesVisible + " Ext: " + extendedStretchHandlesVisible);
+        var isSingleSelection = (selectionManager.selections.length == 1);
 
-        if (selectionManager.selections.length == 1) {
+        if (isSingleSelection) {
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
-            if (properties.type == "Light" && properties.isSpotlight) {
+            var isLightSelection = (properties.type == "Light");
+            if ( isLightSelection ) {
+                //print("    Light Selection revoking Non-Light Grabbers Visibility!");
                 stretchHandlesVisible = false;
                 extendedStretchHandlesVisible = false;
+                cloneHandleVisible = false;
+                if(properties.isSpotlight) {
+                    //print("    Trying to show all SpotLight related grabbers");
+                    Overlays.editOverlay(grabberSpotLightCenter, {
+                        position: position,
+                        visible: false,
+                    });
+                    Overlays.editOverlay(grabberSpotLightRadius, {
+                        position: NEAR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
 
-                Overlays.editOverlay(grabberSpotLightCenter, {
-                    position: position,
-                    visible: false,
-                });
-                Overlays.editOverlay(grabberSpotLightRadius, {
-                    position: NEAR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
+                    Overlays.editOverlay(grabberSpotLightL, {
+                        position: EdgeNL,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightR, {
+                        position: EdgeNR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightT, {
+                        position: EdgeTN,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightB, {
+                        position: EdgeBN,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightCircle, {
+                        position: NEAR,
+                        dimensions: {
+                            x: distance,
+                            y: distance,
+                            z: 1
+                        },
+                        lineWidth: 1.5,
+                        rotation: rotation,
+                        visible: true,
+                    });
 
-                Overlays.editOverlay(grabberSpotLightL, {
-                    position: EdgeNL,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightR, {
-                    position: EdgeNR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightT, {
-                    position: EdgeTN,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightB, {
-                    position: EdgeBN,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightCircle, {
-                    position: NEAR,
-                    dimensions: {
-                        x: distance,
-                        y: distance,
-                        z: 1
-                    },
-                    lineWidth: 1.5,
-                    rotation: rotation,
-                    visible: true,
-                });
+                    Overlays.editOverlay(grabberSpotLightLineT, {
+                        start: position,
+                        end: EdgeTN,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineB, {
+                        start: position,
+                        end: EdgeBN,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineR, {
+                        start: position,
+                        end: EdgeNR,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineL, {
+                        start: position,
+                        end: EdgeNL,
+                        visible: true,
+                    });
 
-                Overlays.editOverlay(grabberSpotLightLineT, {
-                    start: position,
-                    end: EdgeTN,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightLineB, {
-                    start: position,
-                    end: EdgeBN,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightLineR, {
-                    start: position,
-                    end: EdgeNR,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightLineL, {
-                    start: position,
-                    end: EdgeNL,
-                    visible: true,
-                });
+                    //print("    Trying to hide all PointLight related grabbers");
+                    Overlays.editOverlay(grabberPointLightCircleX, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleY, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleZ, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightT, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightB, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightL, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightR, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightF, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightN, {
+                        visible: false
+                    });
+                } else { //..it's a PointLight
+                    //print("    Trying to show all PointLight related grabbers");
+                    Overlays.editOverlay(grabberPointLightT, {
+                        position: TOP,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightB, {
+                        position: BOTTOM,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightL, {
+                        position: LEFT,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightR, {
+                        position: RIGHT,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightF, {
+                        position: FAR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightN, {
+                        position: NEAR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleX, {
+                        position: position,
+                        rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(0, 90, 0)),
+                        dimensions: {
+                            x: properties.dimensions.z / 2.0,
+                            y: properties.dimensions.z / 2.0,
+                            z: 1
+                        },
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleY, {
+                        position: position,
+                        rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(90, 0, 0)),
+                        dimensions: {
+                            x: properties.dimensions.z / 2.0,
+                            y: properties.dimensions.z / 2.0,
+                            z: 1
+                        },
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleZ, {
+                        position: position,
+                        rotation: rotation,
+                        dimensions: {
+                            x: properties.dimensions.z / 2.0,
+                            y: properties.dimensions.z / 2.0,
+                            z: 1
+                        },
+                        visible: true,
+                    });
 
-                Overlays.editOverlay(grabberPointLightCircleX, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightCircleY, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightCircleZ, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightT, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightB, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightL, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightR, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightF, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightN, {
-                    visible: false
-                });
-            } else if (properties.type == "Light" && !properties.isSpotlight) {
-                stretchHandlesVisible = false;
-                extendedStretchHandlesVisible = false;
-                Overlays.editOverlay(grabberPointLightT, {
-                    position: TOP,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightB, {
-                    position: BOTTOM,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightL, {
-                    position: LEFT,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightR, {
-                    position: RIGHT,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightF, {
-                    position: FAR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightN, {
-                    position: NEAR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightCircleX, {
-                    position: position,
-                    rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(0, 90, 0)),
-                    dimensions: {
-                        x: properties.dimensions.z / 2.0,
-                        y: properties.dimensions.z / 2.0,
-                        z: 1
-                    },
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightCircleY, {
-                    position: position,
-                    rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(90, 0, 0)),
-                    dimensions: {
-                        x: properties.dimensions.z / 2.0,
-                        y: properties.dimensions.z / 2.0,
-                        z: 1
-                    },
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightCircleZ, {
-                    position: position,
-                    rotation: rotation,
-                    dimensions: {
-                        x: properties.dimensions.z / 2.0,
-                        y: properties.dimensions.z / 2.0,
-                        z: 1
-                    },
-                    visible: true,
-                });
-
-                Overlays.editOverlay(grabberSpotLightRadius, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightL, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightR, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightT, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightB, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightCircle, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineL, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineR, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineT, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineB, {
-                    visible: false
-                });
-            } else {
+                    //print("    Trying to hide all SpotLight related grabbers");
+                    Overlays.editOverlay(grabberSpotLightRadius, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightL, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightR, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightT, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightB, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightCircle, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineL, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineR, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineT, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineB, {
+                        visible: false
+                    });
+                }
+            } else { //..it's not a light at all
+                //print("    Trying to hide all Light related grabbers");
                 Overlays.editOverlay(grabberSpotLightCenter, {
                     visible: false
                 });
@@ -2102,7 +2111,7 @@ SelectionDisplay = (function() {
                     visible: false
                 });
             }
-        }
+        }//--end of isSingleSelection
 
 
 
@@ -2180,7 +2189,7 @@ SelectionDisplay = (function() {
         });
 
         Overlays.editOverlay(grabberCloner, {
-            visible: true,
+            visible: cloneHandleVisible,
             rotation: rotation,
             position: EdgeTR
         });
@@ -2191,7 +2200,7 @@ SelectionDisplay = (function() {
             position: selectionBoxPosition,
             dimensions: dimensions,
             rotation: rotation,
-            visible: !(mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL"),
+            visible: !inModeRotate,
         });
 
         // Create more selection box overlays if we don't have enough
@@ -2328,7 +2337,7 @@ SelectionDisplay = (function() {
         });
 
         Overlays.editOverlay(baseOfEntityProjectionOverlay, {
-            visible: mode != "ROTATE_YAW" && mode != "ROTATE_PITCH" && mode != "ROTATE_ROLL",
+            visible: !inModeRotate,
             solid: true,
             position: {
                 x: selectionManager.worldPosition.x,
@@ -4115,7 +4124,7 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE PRESS EVENT
     that.mousePressEvent = function(event) {
-        var wantDebug = true;
+        var wantDebug = false;
         if ( wantDebug ) {
             print( "=============== eST::MousePressEvent BEG =======================");
         }
@@ -4150,7 +4159,9 @@ SelectionDisplay = (function() {
 
             var tool = grabberTools[result.overlayID];
             if (tool) {
-                print("Intersected with known table tool.");
+                if (wantDebug) {
+                    print("Intersected with known table tool( mode: " + tool.mode + " )");
+                }
                 activeTool = tool;
                 mode = tool.mode;
                 somethingClicked = 'tool';
@@ -4158,10 +4169,14 @@ SelectionDisplay = (function() {
                     activeTool.onBegin(event);
                 }
             } else {
-                print("Intersected with unregistered tool...");
+                if (wantDebug) {
+                    print("Intersected with unregistered tool...");
+                }
                 switch (result.overlayID) {
                     case grabberMoveUp:
-                        print("grabberMoveUp");
+                        if (wantDebug){
+                            print("grabberMoveUp");
+                        }
                         mode = "TRANSLATE_UP_DOWN";
                         somethingClicked = mode;
 
@@ -4177,7 +4192,9 @@ SelectionDisplay = (function() {
                     case grabberNEAR:
                     case grabberEdgeTN: // TODO: maybe this should be TOP+NEAR stretching?
                     case grabberEdgeBN: // TODO: maybe this should be BOTTOM+FAR stretching?
-                        print("grabberNear variant");
+                        if(wantDebug){
+                            print("grabberNear variant");
+                        }
                         mode = "STRETCH_NEAR";
                         somethingClicked = mode;
                         break;
@@ -4185,39 +4202,54 @@ SelectionDisplay = (function() {
                     case grabberFAR:
                     case grabberEdgeTF: // TODO: maybe this should be TOP+FAR stretching?
                     case grabberEdgeBF: // TODO: maybe this should be BOTTOM+FAR stretching?
-                        print("grabberFar variant");
+                        if(wantDebug){
+                            print("grabberFar variant");
+                        }
                         mode = "STRETCH_FAR";
                         somethingClicked = mode;
                         break;
                     case grabberTOP:
-                        print("grabberTOP");
+                        if(wantDebug){
+                            print("grabberTOP");
+                        }
                         mode = "STRETCH_TOP";
                         somethingClicked = mode;
                         break;
                     case grabberBOTTOM:
-                        print("grabberBOTTOM");
+                        if(wantDebug){
+                            print("grabberBOTTOM");
+                        }
                         mode = "STRETCH_BOTTOM";
                         somethingClicked = mode;
                         break;
                     case grabberRIGHT:
                     case grabberEdgeTR: // TODO: maybe this should be TOP+RIGHT stretching?
                     case grabberEdgeBR: // TODO: maybe this should be BOTTOM+RIGHT stretching?
-                        print("grabberRight variant");
+                        if(wantDebug){
+                            print("grabberRight variant");
+                        }
                         mode = "STRETCH_RIGHT";
                         somethingClicked = mode;
                         break;
                     case grabberLEFT:
                     case grabberEdgeTL: // TODO: maybe this should be TOP+LEFT stretching?
                     case grabberEdgeBL: // TODO: maybe this should be BOTTOM+LEFT stretching?
-                        print("grabberLeft variant");
+                        if(wantDebug){
+                            print("grabberLeft variant");
+                        }
                         mode = "STRETCH_LEFT";
                         somethingClicked = mode;
                         break;
 
                     default:
-                        print("UNKNOWN( " + result.overlayID + " )");
+                        if(wantDebug){
+                            print("UNKNOWN( " + result.overlayID + " )");
+                        }
                         mode = "UNKNOWN";
                         break;
+                }
+                if(wantDebug){
+                    print("  Unregistered Tool Mode: " + mode );
                 }
             }
         }
@@ -4225,7 +4257,9 @@ SelectionDisplay = (function() {
         // if one of the items above was clicked, then we know we are in translate or stretch mode, and we
         // should hide our rotate handles...
         if (somethingClicked) {
-            print("Click is triggering hiding of handles, hopefully");
+            if(wantDebug){
+                print("    Trying to hide PitchYawRoll Handles");
+            }
             Overlays.editOverlay(yawHandle, {
                 visible: false
             });
@@ -4237,6 +4271,9 @@ SelectionDisplay = (function() {
             });
 
             if (mode != "TRANSLATE_UP_DOWN") {
+                if(wantDebug){
+                    print("    Trying to hide GrabberMoveUp");
+                }
                 Overlays.editOverlay(grabberMoveUp, {
                     visible: false
                 });
@@ -4268,30 +4305,46 @@ SelectionDisplay = (function() {
             originalRoll = roll;
 
             if (result.intersects) {
-                print("Intersection detected with handle...");
                 var resultTool = grabberTools[result.overlayID];
+                if(wantDebug){
+                    print("Intersection detected with handle...");
+                }
                 if (resultTool) {
+                    if(wantDebug){
+                        print("    " + resultTool.mode);
+                    }
                     activeTool = resultTool;
                     mode = resultTool.mode;
                     somethingClicked = 'tool';
                     if (activeTool && activeTool.onBegin) {
+                        if(wantDebug){
+                            print("    Triggering Tool's onBegin");
+                        }
                         activeTool.onBegin(event);
+                    } else if(wantDebug) {
+                        print("    Tool's missing onBegin");
                     }
                 }
                 switch (result.overlayID) {
                     case yawHandle:
-                        print("Handle_YAW");
+                        if(wantDebug){
+                            print("Handle_YAW");
+                        }
                         mode = "ROTATE_YAW";
                         somethingClicked = mode;
                         overlayOrientation = yawHandleRotation;
                         overlayCenter = yawCenter;
                         yawZero = result.intersection;
                         rotationNormal = yawNormal;
-                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        if(wantDebug){
+                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        }
                         break;
 
                     case pitchHandle:
-                        print("Handle_PITCH");
+                        if(wantDebug){
+                            print("Handle_PITCH");
+                        }
                         mode = "ROTATE_PITCH";
                         initialPosition = SelectionManager.worldPosition;
                         somethingClicked = mode;
@@ -4299,18 +4352,24 @@ SelectionDisplay = (function() {
                         overlayCenter = pitchCenter;
                         pitchZero = result.intersection;
                         rotationNormal = pitchNormal;
-                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        if(wantDebug){
+                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        }
                         break;
 
                     case rollHandle:
-                        print("Handle_ROLL");
+                        if(wantDebug){
+                            print("Handle_ROLL");
+                        }
                         mode = "ROTATE_ROLL";
                         somethingClicked = mode;
                         overlayOrientation = rollHandleRotation;
                         overlayCenter = rollCenter;
                         rollZero = result.intersection;
                         rotationNormal = rollNormal;
-                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        if(wantDebug){
+                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        }
                         break;
 
                     default:
@@ -4328,6 +4387,9 @@ SelectionDisplay = (function() {
 
             if (somethingClicked) {
 
+                if(wantDebug){
+                    print("    Trying to show rotateOverlay Handles");
+                }
                 Overlays.editOverlay(rotateOverlayTarget, {
                     visible: true,
                     rotation: overlayOrientation,
@@ -4352,6 +4414,9 @@ SelectionDisplay = (function() {
                     startAt: 0,
                     endAt: 0
                 });
+                if(wantDebug){
+                    print("    Trying to hide PitchYawRoll Handles");
+                }
                 Overlays.editOverlay(yawHandle, {
                     visible: false
                 });
@@ -4362,15 +4427,11 @@ SelectionDisplay = (function() {
                     visible: false
                 });
 
+                if(wantDebug){
+                    print("    Trying to hide Non-Light GrabberHandles");
+                }
 
-                // TODO: these three duplicate prior three, remove them.
-                Overlays.editOverlay(yawHandle, {
-                    visible: false
-                });
-                Overlays.editOverlay(pitchHandle, {
-                    visible: false
-                });
-                Overlays.editOverlay(rollHandle, {
+                Overlays.editOverlay(grabberCloner, {
                     visible: false
                 });
                 Overlays.editOverlay(grabberMoveUp, {
@@ -4466,6 +4527,9 @@ SelectionDisplay = (function() {
                 switch (result.overlayID) {
                     case selectionBox:
                         activeTool = translateXZTool;
+                        if(wantDebug){
+                            print("Clicked selectionBox, Activating Tool: " + activeTool.mode );
+                        }
                         translateXZTool.pickPlanePosition = result.intersection;
                         translateXZTool.greatestDimension = Math.max(Math.max(SelectionManager.worldDimensions.x, SelectionManager.worldDimensions.y),
                             SelectionManager.worldDimensions.z);
@@ -4499,7 +4563,10 @@ SelectionDisplay = (function() {
         }
 
         // reset everything as intersectable...
-        // TODO: we could optimize this since some of these were already flipped back
+        // TODO: we could optimize this since some of these were already flipped back(i.e:  just get rid of this)
+        if(wantDebug){
+            print("Trying to set SelectionBox & PitchYawRoll Handles to NOT_IGNORE Rays");
+        }
         Overlays.editOverlay(selectionBox, {
             ignoreRayIntersection: false
         });
@@ -4522,9 +4589,25 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE MOVE EVENT
     that.mouseMoveEvent = function(event) {
+        var wantDebug = false;
+        if(wantDebug){
+            print( "=============== eST::MouseMoveEvent BEG =======================");
+        }
         if (activeTool) {
+            if(wantDebug){
+                print("    Trigger ActiveTool( " + activeTool.mode + " )'s onMove");
+            }
             activeTool.onMove(event);
+            
+            if(wantDebug){
+                print("    Trigger SelectionManager::update");
+            }
             SelectionManager._update();
+            
+            if(wantDebug){
+                print( "=============== eST::MouseMoveEvent END =======================");
+            }
+            //--EARLY EXIT--( Move handled via active tool)
             return true;
         }
 
@@ -4647,6 +4730,9 @@ SelectionDisplay = (function() {
             }
         }
 
+        if(wantDebug){
+            print("=============== eST::MouseMoveEvent END =======================");
+        }
         return false;
     };
 
@@ -4691,13 +4777,27 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE RELEASE EVENT
     that.mouseReleaseEvent = function(event) {
-        var showHandles = false;
-        if (activeTool && activeTool.onEnd) {
-            activeTool.onEnd(event);
+        var wantDebug = false;
+        if(wantDebug){
+            print("=============== eST::MouseReleaseEvent BEG =======================");
         }
-        activeTool = null;
+        var showHandles = false;
+        if (activeTool) {
+            if( activeTool.onEnd ) {
+                if(wantDebug){
+                    print("    Triggering ActiveTool( " + activeTool.mode + " )'s onEnd");
+                }
+                activeTool.onEnd(event);
+            }else if(wantDebug){
+                print("    ActiveTool( " + activeTool.mode + " )'s missing onEnd");
+            }
+        }
+        
         // hide our rotation overlays..., and show our handles
         if (mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL") {
+            if(wantDebug){
+                print("    Triggering hide of RotateOverlays");
+            }
             Overlays.editOverlay(rotateOverlayTarget, {
                 visible: false
             });
@@ -4710,22 +4810,26 @@ SelectionDisplay = (function() {
             Overlays.editOverlay(rotateOverlayCurrent, {
                 visible: false
             });
-            showHandles = true;
+            
         }
 
-        if (mode != "UNKNOWN") {
-            showHandles = true;
-        }
-
+        showHandles = (mode != "UNKNOWN");//<base on prior mode
         mode = "UNKNOWN";
+        activeTool = null;
 
         // if something is selected, then reset the "original" properties for any potential next click+move operation
         if (SelectionManager.hasSelection()) {
             if (showHandles) {
+                if(wantDebug){
+                    print("    Triggering that.select");
+                }
                 that.select(SelectionManager.selections[0], event);
             }
         }
 
+        if(wantDebug){
+            print("=============== eST::MouseReleaseEvent END =======================");
+        }
     };
 
     // NOTE: mousePressEvent and mouseMoveEvent from the main script should call us., so we don't hook these:

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1579,20 +1579,29 @@ SelectionDisplay = (function() {
 
     // FUNCTION: SET SPACE MODE
     that.setSpaceMode = function(newSpaceMode) {
+        print("======> SetSpaceMode called. ========");
         if (spaceMode != newSpaceMode) {
+            print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
             spaceMode = newSpaceMode;
             that.updateHandles();
+        } else {
+            print("    Can't update SpaceMode. CurrentMode: " + spaceMode + " DesiredMode: " + newSpaceMode);
         }
+        print("====== SetSpaceMode called. <========");
     };
 
     // FUNCTION: TOGGLE SPACE MODE
     that.toggleSpaceMode = function() {
+        print("========> ToggleSpaceMode called. =========");
         if (spaceMode == SPACE_WORLD && SelectionManager.selections.length > 1) {
             print("Local space editing is not available with multiple selections");
             return;
         }
+        print( "PreToggle: " + spaceMode);
         spaceMode = spaceMode == SPACE_LOCAL ? SPACE_WORLD : SPACE_LOCAL;
+        print( "PostToggle: " + spaceMode);
         that.updateHandles();
+        print("======== ToggleSpaceMode called. <=========");
     };
 
     // FUNCTION: UNSELECT ALL
@@ -1601,6 +1610,9 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE HANDLES
     that.updateHandles = function() {
+        print( "======> Update Handles =======" );
+        print( "    Selections Count: " + SelectionManager.selections.length );
+        print( "    SpaceMode: " + spaceMode );
         if (SelectionManager.selections.length === 0) {
             that.setOverlaysVisible(false);
             return;
@@ -2329,6 +2341,8 @@ SelectionDisplay = (function() {
             },
             rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         });
+
+        print( "====== Update Handles <=======" );
 
     };
 
@@ -3547,15 +3561,22 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE ROTATION DEGREES OVERLAY
     function updateRotationDegreesOverlay(angleFromZero, handleRotation, centerPosition) {
+        print( "---> updateRotationDegreesOverlay ---" );
+        print("    AngleFromZero: " + angleFromZero );
+        print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
+        print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z );
         var angle = angleFromZero * (Math.PI / 180);
         var position = {
             x: Math.cos(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             y: Math.sin(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             z: 0,
         };
+        print("    Angle: " + angle );
+        print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
         position = Vec3.multiplyQbyV(handleRotation, position);
         position = Vec3.sum(centerPosition, position);
-        Overlays.editOverlay(rotationDegreesDisplay, {
+        print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
+        var overlayProps = {
             position: position,
             dimensions: {
                 x: innerRadius * ROTATION_DISPLAY_SIZE_X_MULTIPLIER,
@@ -3563,7 +3584,12 @@ SelectionDisplay = (function() {
             },
             lineHeight: innerRadius * ROTATION_DISPLAY_LINE_HEIGHT_MULTIPLIER,
             text: normalizeDegrees(angleFromZero) + "°",
-        });
+        };
+        print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
+        print("    OverlayLineHeight: " + overlayProps.lineHeight );
+        print("    OverlayText: " + overlayProps.text );
+        Overlays.editOverlay(rotationDegreesDisplay, overlayProps);
+        print( "<--- updateRotationDegreesOverlay ---" );
     }
 
     // YAW GRABBER TOOL DEFINITION
@@ -3571,6 +3597,7 @@ SelectionDisplay = (function() {
     addGrabberTool(yawHandle, {
         mode: "ROTATE_YAW",
         onBegin: function(event) {
+            print("================== HANDLE_ROLL(Beg) -> =======================");
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
 
@@ -3612,8 +3639,10 @@ SelectionDisplay = (function() {
             });
 
             updateRotationDegreesOverlay(0, yawHandleRotation, yawCenter);
+            print("================== HANDLE_YAW(Beg) <- =======================");
         },
         onEnd: function(event, reason) {
+            print("================== HANDLE_YAW(End) -> =======================");
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });
@@ -3628,8 +3657,10 @@ SelectionDisplay = (function() {
             });
 
             pushCommandForSelections();
+            print("================== HANDLE_YAW(End) <- =======================");
         },
         onMove: function(event) {
+            print("================== HANDLE_YAW(Mve) -> =======================");
             var pickRay = generalComputePickRay(event.x, event.y);
             Overlays.editOverlay(selectionBox, {
                 visible: false
@@ -3647,6 +3678,7 @@ SelectionDisplay = (function() {
                 var centerToIntersect = Vec3.subtract(result.intersection, center);
                 // Note: orientedAngle which wants normalized centerToZero and centerToIntersect
                 //             handles that internally, so it's to pass unnormalized vectors here.
+                print("    RotNormal - X: " + rotationNormal.x + " Y: " + rotationNormal.y + " Z: " + rotationNormal.z);
                 var angleFromZero = Vec3.orientedAngle(centerToZero, centerToIntersect, rotationNormal);
                 var distanceFromCenter = Vec3.distance(center, result.intersection);
                 var snapToInner = distanceFromCenter < innerRadius;
@@ -3732,6 +3764,7 @@ SelectionDisplay = (function() {
                 }
 
             }
+            print("================== HANDLE_YAW(Mve) <- =======================");
         }
     });
 
@@ -3739,6 +3772,7 @@ SelectionDisplay = (function() {
     addGrabberTool(pitchHandle, {
         mode: "ROTATE_PITCH",
         onBegin: function(event) {
+            print("================== HANDLE_PITCH(Beg) -> =======================");
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
 
@@ -3780,8 +3814,10 @@ SelectionDisplay = (function() {
             });
 
             updateRotationDegreesOverlay(0, pitchHandleRotation, pitchCenter);
+            print("================== HANDLE_PITCH(Beg) <- =======================");
         },
         onEnd: function(event, reason) {
+            print("================== HANDLE_PITCH(End) -> =======================");
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });
@@ -3796,8 +3832,10 @@ SelectionDisplay = (function() {
             });
 
             pushCommandForSelections();
+            print("================== HANDLE_PITCH(End) <- =======================");
         },
         onMove: function(event) {
+            print("================== HANDLE_PITCH(Mve) -> =======================");
             var pickRay = generalComputePickRay(event.x, event.y);
             Overlays.editOverlay(selectionBox, {
                 visible: false
@@ -3814,6 +3852,7 @@ SelectionDisplay = (function() {
                 var centerToIntersect = Vec3.subtract(result.intersection, center);
                 // Note: orientedAngle which wants normalized centerToZero & centerToIntersect, handles
                 //       this internally, so it's fine to pass non-normalized versions here.
+                print("    RotNormal - X: " + rotationNormal.x + " Y: " + rotationNormal.y + " Z: " + rotationNormal.z);
                 var angleFromZero = Vec3.orientedAngle(centerToZero, centerToIntersect, rotationNormal);
 
                 var distanceFromCenter = Vec3.distance(center, result.intersection);
@@ -3890,6 +3929,7 @@ SelectionDisplay = (function() {
                     });
                 }
             }
+            print("================== HANDLE_PITCH(Mve) <- =======================");
         }
     });
 
@@ -3897,6 +3937,7 @@ SelectionDisplay = (function() {
     addGrabberTool(rollHandle, {
         mode: "ROTATE_ROLL",
         onBegin: function(event) {
+            print("================== HANDLE_ROLL(Beg) -> =======================");
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
 
@@ -3938,8 +3979,10 @@ SelectionDisplay = (function() {
             });
 
             updateRotationDegreesOverlay(0, rollHandleRotation, rollCenter);
+            print("================== HANDLE_ROLL(Beg) <- =======================");
         },
         onEnd: function(event, reason) {
+            print("================== HANDLE_ROLL(End) -> =======================");
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });
@@ -3954,8 +3997,10 @@ SelectionDisplay = (function() {
             });
 
             pushCommandForSelections();
+            print("================== HANDLE_ROLL(End) <- =======================");
         },
         onMove: function(event) {
+            print("================== HANDLE_ROLL(Mve) -> =======================");
             var pickRay = generalComputePickRay(event.x, event.y);
             Overlays.editOverlay(selectionBox, {
                 visible: false
@@ -3972,6 +4017,7 @@ SelectionDisplay = (function() {
                 var centerToIntersect = Vec3.subtract(result.intersection, center);
                 // Note: orientedAngle which wants normalized centerToZero & centerToIntersect, handles
                 //       this internally, so it's fine to pass non-normalized versions here.
+                print("    RotNormal - X: " + rotationNormal.x + " Y: " + rotationNormal.y + " Z: " + rotationNormal.z);
                 var angleFromZero = Vec3.orientedAngle(centerToZero, centerToIntersect, rotationNormal);
 
                 var distanceFromCenter = Vec3.distance(center, result.intersection);
@@ -4047,6 +4093,8 @@ SelectionDisplay = (function() {
                     });
                 }
             }
+            print("================== HANDLE_ROLL(Mve) <- =======================");
+
         }
     });
 
@@ -4067,7 +4115,10 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE PRESS EVENT
     that.mousePressEvent = function(event) {
-        var wantDebug = false;
+        var wantDebug = true;
+        if ( wantDebug ) {
+            print( "=============== eST::MousePressEvent BEG =======================");
+        }
         if (!event.isLeftButton && !that.triggered) {
             // if another mouse button than left is pressed ignore it
             return false;
@@ -4099,6 +4150,7 @@ SelectionDisplay = (function() {
 
             var tool = grabberTools[result.overlayID];
             if (tool) {
+                print("Intersected with known table tool.");
                 activeTool = tool;
                 mode = tool.mode;
                 somethingClicked = 'tool';
@@ -4106,8 +4158,10 @@ SelectionDisplay = (function() {
                     activeTool.onBegin(event);
                 }
             } else {
+                print("Intersected with unregistered tool...");
                 switch (result.overlayID) {
                     case grabberMoveUp:
+                        print("grabberMoveUp");
                         mode = "TRANSLATE_UP_DOWN";
                         somethingClicked = mode;
 
@@ -4123,6 +4177,7 @@ SelectionDisplay = (function() {
                     case grabberNEAR:
                     case grabberEdgeTN: // TODO: maybe this should be TOP+NEAR stretching?
                     case grabberEdgeBN: // TODO: maybe this should be BOTTOM+FAR stretching?
+                        print("grabberNear variant");
                         mode = "STRETCH_NEAR";
                         somethingClicked = mode;
                         break;
@@ -4130,31 +4185,37 @@ SelectionDisplay = (function() {
                     case grabberFAR:
                     case grabberEdgeTF: // TODO: maybe this should be TOP+FAR stretching?
                     case grabberEdgeBF: // TODO: maybe this should be BOTTOM+FAR stretching?
+                        print("grabberFar variant");
                         mode = "STRETCH_FAR";
                         somethingClicked = mode;
                         break;
                     case grabberTOP:
+                        print("grabberTOP");
                         mode = "STRETCH_TOP";
                         somethingClicked = mode;
                         break;
                     case grabberBOTTOM:
+                        print("grabberBOTTOM");
                         mode = "STRETCH_BOTTOM";
                         somethingClicked = mode;
                         break;
                     case grabberRIGHT:
                     case grabberEdgeTR: // TODO: maybe this should be TOP+RIGHT stretching?
                     case grabberEdgeBR: // TODO: maybe this should be BOTTOM+RIGHT stretching?
+                        print("grabberRight variant");
                         mode = "STRETCH_RIGHT";
                         somethingClicked = mode;
                         break;
                     case grabberLEFT:
                     case grabberEdgeTL: // TODO: maybe this should be TOP+LEFT stretching?
                     case grabberEdgeBL: // TODO: maybe this should be BOTTOM+LEFT stretching?
+                        print("grabberLeft variant");
                         mode = "STRETCH_LEFT";
                         somethingClicked = mode;
                         break;
 
                     default:
+                        print("UNKNOWN( " + result.overlayID + " )");
                         mode = "UNKNOWN";
                         break;
                 }
@@ -4164,6 +4225,7 @@ SelectionDisplay = (function() {
         // if one of the items above was clicked, then we know we are in translate or stretch mode, and we
         // should hide our rotate handles...
         if (somethingClicked) {
+            print("Click is triggering hiding of handles, hopefully");
             Overlays.editOverlay(yawHandle, {
                 visible: false
             });
@@ -4206,6 +4268,7 @@ SelectionDisplay = (function() {
             originalRoll = roll;
 
             if (result.intersects) {
+                print("Intersection detected with handle...");
                 var resultTool = grabberTools[result.overlayID];
                 if (resultTool) {
                     activeTool = resultTool;
@@ -4217,15 +4280,18 @@ SelectionDisplay = (function() {
                 }
                 switch (result.overlayID) {
                     case yawHandle:
+                        print("Handle_YAW");
                         mode = "ROTATE_YAW";
                         somethingClicked = mode;
                         overlayOrientation = yawHandleRotation;
                         overlayCenter = yawCenter;
                         yawZero = result.intersection;
                         rotationNormal = yawNormal;
+                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
                         break;
 
                     case pitchHandle:
+                        print("Handle_PITCH");
                         mode = "ROTATE_PITCH";
                         initialPosition = SelectionManager.worldPosition;
                         somethingClicked = mode;
@@ -4233,15 +4299,18 @@ SelectionDisplay = (function() {
                         overlayCenter = pitchCenter;
                         pitchZero = result.intersection;
                         rotationNormal = pitchNormal;
+                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
                         break;
 
                     case rollHandle:
+                        print("Handle_ROLL");
                         mode = "ROTATE_ROLL";
                         somethingClicked = mode;
                         overlayOrientation = rollHandleRotation;
                         overlayCenter = rollCenter;
                         rollZero = result.intersection;
                         rotationNormal = rollNormal;
+                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
                         break;
 
                     default:
@@ -4443,6 +4512,10 @@ SelectionDisplay = (function() {
         Overlays.editOverlay(rollHandle, {
             ignoreRayIntersection: false
         });
+
+        if ( wantDebug ) {
+            print( "=============== eST::MousePressEvent END =======================");
+        }
 
         return somethingClicked;
     };


### PR DESCRIPTION
Part 2 of [FogBugz Case 6491](https://highfidelity.fogbugz.com/f/cases/6491/edit-js-work-proposed-by-1st-playable);  part 1 was merged via PR #11165.  The overall PR for the case is broken into preview chunks to allow for review in smaller logical pieces.

This PR matches the content of [Case 6491: Preview PR 1](https://github.com/1P-Cusack/hifi/pull/2) mentioned in pull request #11165

The current work in addition to this phase may be viewed through several preview pull requests located:
[Case 6491: Preview PR 2](https://github.com/1P-Cusack/hifi/pull/3)
[Case 6491: Preview PR 3](https://github.com/1P-Cusack/hifi/pull/4)
[Case 6491: Preview PR 4](https://github.com/1P-Cusack/hifi/pull/5)
[Case 6491: Preview PR 5](https://github.com/1P-Cusack/hifi/pull/6)
[Case 6491: Preview PR 6](https://github.com/1P-Cusack/hifi/pull/8)


Description:
This fixes the issue where grabbers would re-appear when rotating
the selected object rather than staying hidden.

updateHandles will now take the mode into account when deciding
if the non-light grabber handles should be visible.  This can be
subverted by the user selecting a light source as in line with
the previous behavior.

Adds some debug prints in event handlers guarded by local
wantDebug checks.

Has some minor cleanup changes:
* Remove unused var within updateRotationHandles
* Readability improvement for light check within updateHandles
* Pulled up rotate mode check within updateHandles
* Added grabberCloner visibility flag within updateHandles

Testing:

- Clicking on any of the rotation handles (pitch, yaw, roll) will have all grabbers on the selection go invisible.
- Actually rotating will see all the grabbers remain invisible, until the user stops rotating and releases the mouse press.
- When the user releases the mouse press, all grabbers will become visible once again.

NOTE:  The degree snapping during rotation is a known issue and will be addressed in a subsequent pull request.