### PR TITLE
Switch off snap behavior

### DIFF
--- a/interface/resources/qml/hifi/Card.qml
+++ b/interface/resources/qml/hifi/Card.qml
@@ -46,6 +46,8 @@ Item {
     property int stackShadowNarrowing: 5;
     property string defaultThumbnail: Qt.resolvedUrl("../../images/default-domain.gif");
     property int shadowHeight: 10;
+    property bool hovered: false
+
     HifiConstants { id: hifi }
 
     function pastTime(timestamp) { // Answer a descriptive string
@@ -231,6 +233,13 @@ Item {
     // to that which is being hovered over.
     property var hoverThunk: function () { };
     property var unhoverThunk: function () { };
+    Rectangle {
+        anchors.fill: parent;
+        visible: root.hovered
+        color: "transparent";
+        border.width: 4; border.color: hifiStyleConstants.colors.primaryHighlight;
+        z: 1;
+    }
     MouseArea {
         anchors.fill: parent;
         acceptedButtons: Qt.LeftButton;

--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -206,9 +206,9 @@ Column {
         id: scroll;
         model: suggestions;
         orientation: ListView.Horizontal;
+        highlightFollowsCurrentItem: false
         highlightMoveDuration: -1;
         highlightMoveVelocity: -1;
-        highlight: Rectangle { color: "transparent"; border.width: 4; border.color: hifiStyleConstants.colors.primaryHighlight; z: 1; }
         currentIndex: -1;
 
         spacing: 12;
@@ -237,6 +237,8 @@ Column {
             textSizeSmall: root.textSizeSmall;
             stackShadowNarrowing: root.stackShadowNarrowing;
             shadowHeight: root.stackedCardShadowHeight;
+            hoverThunk: function () { hovered = true }
+            unhoverThunk: function () { hovered = false }
         }
     }
     NumberAnimation {

--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -237,9 +237,6 @@ Column {
             textSizeSmall: root.textSizeSmall;
             stackShadowNarrowing: root.stackShadowNarrowing;
             shadowHeight: root.stackedCardShadowHeight;
-
-            hoverThunk: function () { scrollToIndex(index); }
-            unhoverThunk: function () { scrollToIndex(-1); }
         }
     }
     NumberAnimation {


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/7075/Remove-Snap-Scroll-Behavior-in-Go-To

Test plan
- Open Goto dialog
- Hover over a place card. Make sure it highlights blue.
- Hover over rightmost place card. Make sure cards are not "snapping" to place
- Try to scroll through cards using stylus. Make sure it is scrolling smoothly
