### PR TITLE
OpenGL Core Profile fixes and glew 2.1

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -160,24 +160,12 @@ Size GL45Texture::copyMipFaceLinesFromTexture(uint16_t mip, uint8_t face, const 
             case GL_COMPRESSED_RG_RGTC2:
             case GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM:
             case GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT:
-                if (glCompressedTextureSubImage2DEXT) {
-                    auto target = GLTexture::CUBE_FACE_LAYOUT[face];
-                    glCompressedTextureSubImage2DEXT(_id, target, mip, 0, yOffset, size.x, size.y, internalFormat,
-                                                     static_cast<GLsizei>(sourceSize), sourcePointer);
-                } else {
-                    glCompressedTextureSubImage3D(_id, mip, 0, yOffset, face, size.x, size.y, 1, internalFormat,
-                                                  static_cast<GLsizei>(sourceSize), sourcePointer);
-                }
+                glCompressedTextureSubImage3D(_id, mip, 0, yOffset, face, size.x, size.y, 1, internalFormat,
+                                                    static_cast<GLsizei>(sourceSize), sourcePointer);
+
                 break;
             default:
-                // DSA ARB does not work on AMD, so use EXT
-                // unless EXT is not available on the driver
-                if (glTextureSubImage2DEXT) {
-                    auto target = GLTexture::CUBE_FACE_LAYOUT[face];
-                    glTextureSubImage2DEXT(_id, target, mip, 0, yOffset, size.x, size.y, format, type, sourcePointer);
-                } else {
-                    glTextureSubImage3D(_id, mip, 0, yOffset, face, size.x, size.y, 1, format, type, sourcePointer);
-                }
+                glTextureSubImage3D(_id, mip, 0, yOffset, face, size.x, size.y, 1, format, type, sourcePointer);
                 break;
         }
     } else {


### PR DESCRIPTION
I was trying high fidelity on mesa and had some of the usual trouble. glewInit() would throw an error because glew 1.13 didn't properly support the core profile.

With glew 2.1, once glewExperimental was removed, the glCompressedTextureSubImage2DEXT function wasn't available anymore. There is really no need to use an EXT function when the standardized equivalent is in core.

There was a comment that it doesn't work on AMD drivers (on windows?). Can anyone retest this? And if this is still true, maybe make a workaround for this one specific driver?

The first commit is commenting out the line that segfaults on my Archlinux with qt 5.9.1 and which I have reported at https://github.com/highfidelity/hifi/issues/11217. I don't really know if this is doing something important, so I can of course remove it from the PR.

Tested only on my RX 480 with the mesa drivers.