### PR TITLE
EntityTreeRender uses RayPick API with precision picking

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1736,7 +1736,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(&_myCamera, &Camera::modeUpdated, this, &Application::cameraModeChanged);
 
     // Setup the mouse ray pick and related operators
-    DependencyManager::get<EntityTreeRenderer>()->setMouseRayPickID(_rayPickManager.createRayPick(RayPickFilter(RayPickFilter::PICK_ENTITIES), 0.0f, true));
+    DependencyManager::get<EntityTreeRenderer>()->setMouseRayPickID(_rayPickManager.createRayPick(
+        RayPickFilter(DependencyManager::get<RayPickScriptingInterface>()->PICK_ENTITIES() | DependencyManager::get<RayPickScriptingInterface>()->PICK_INCLUDE_NONCOLLIDABLE()),
+        0.0f, true));
     DependencyManager::get<EntityTreeRenderer>()->setMouseRayPickResultOperator([&](QUuid rayPickID) {
         RayToEntityIntersectionResult entityResult;
         RayPickResult result = _rayPickManager.getPrevRayPickResult(rayPickID);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1735,6 +1735,25 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     connect(&_myCamera, &Camera::modeUpdated, this, &Application::cameraModeChanged);
 
+    // Setup the mouse ray pick and related operators
+    DependencyManager::get<EntityTreeRenderer>()->setMouseRayPickID(_rayPickManager.createRayPick(RayPickFilter(RayPickFilter::PICK_ENTITIES), 0.0f, true));
+    DependencyManager::get<EntityTreeRenderer>()->setMouseRayPickResultOperator([&](QUuid rayPickID) {
+        RayToEntityIntersectionResult entityResult;
+        RayPickResult result = _rayPickManager.getPrevRayPickResult(rayPickID);
+        entityResult.intersects = result.type != DependencyManager::get<RayPickScriptingInterface>()->INTERSECTED_NONE();
+        if (entityResult.intersects) {
+            entityResult.intersection = result.intersection;
+            entityResult.distance = result.distance;
+            entityResult.surfaceNormal = result.surfaceNormal;
+            entityResult.entityID = result.objectID;
+            entityResult.entity = DependencyManager::get<EntityTreeRenderer>()->getTree()->findEntityByID(entityResult.entityID);
+        }
+        return entityResult;
+    });
+    DependencyManager::get<EntityTreeRenderer>()->setSetPrecisionPickingOperator([&](QUuid rayPickID, bool value) {
+        _rayPickManager.setPrecisionPicking(rayPickID, value);
+    });
+
     qCDebug(interfaceapp) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(accountManager->getSessionID());
 }
 

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -64,6 +64,7 @@ public:
     // You cannot use editRenderState to change the overlay type of any part of the laser pointer.  You can only edit the properties of the existing overlays.
     void editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps);
 
+    void setPrecisionPicking(const bool precisionPicking) { DependencyManager::get<RayPickScriptingInterface>()->setPrecisionPicking(_rayPickUID, precisionPicking); }
     void setIgnoreEntities(const QScriptValue& ignoreEntities) { DependencyManager::get<RayPickScriptingInterface>()->setIgnoreEntities(_rayPickUID, ignoreEntities); }
     void setIncludeEntities(const QScriptValue& includeEntities) { DependencyManager::get<RayPickScriptingInterface>()->setIncludeEntities(_rayPickUID, includeEntities); }
     void setIgnoreOverlays(const QScriptValue& ignoreOverlays) { DependencyManager::get<RayPickScriptingInterface>()->setIgnoreOverlays(_rayPickUID, ignoreOverlays); }

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -97,6 +97,14 @@ void LaserPointerManager::update() {
     }
 }
 
+void LaserPointerManager::setPrecisionPicking(QUuid uid, const bool precisionPicking) {
+    QReadLocker lock(&_containsLock);
+    if (_laserPointers.contains(uid)) {
+        QWriteLocker laserLock(_laserPointerLocks[uid].get());
+        _laserPointers[uid]->setPrecisionPicking(precisionPicking);
+    }
+}
+
 void LaserPointerManager::setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) {
     QReadLocker lock(&_containsLock);
     if (_laserPointers.contains(uid)) {

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -31,6 +31,7 @@ public:
     void editRenderState(QUuid uid, const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps);
     const RayPickResult getPrevRayPickResult(const QUuid uid);
 
+    void setPrecisionPicking(QUuid uid, const bool precisionPicking);
     void setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities);
     void setIncludeEntities(QUuid uid, const QScriptValue& includeEntities);
     void setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays);

--- a/interface/src/raypick/LaserPointerScriptingInterface.h
+++ b/interface/src/raypick/LaserPointerScriptingInterface.h
@@ -30,6 +30,7 @@ public slots:
     Q_INVOKABLE void setRenderState(QUuid uid, const QString& renderState) { qApp->getLaserPointerManager().setRenderState(uid, renderState.toStdString()); }
     Q_INVOKABLE RayPickResult getPrevRayPickResult(QUuid uid) { return qApp->getLaserPointerManager().getPrevRayPickResult(uid); }
 
+    Q_INVOKABLE void setPrecisionPicking(QUuid uid, const bool precisionPicking) { qApp->getLaserPointerManager().setPrecisionPicking(uid, precisionPicking); }
     Q_INVOKABLE void setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) { qApp->getLaserPointerManager().setIgnoreEntities(uid, ignoreEntities); }
     Q_INVOKABLE void setIncludeEntities(QUuid uid, const QScriptValue& includeEntities) { qApp->getLaserPointerManager().setIncludeEntities(uid, includeEntities); }
     Q_INVOKABLE void setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays) { qApp->getLaserPointerManager().setIgnoreOverlays(uid, ignoreOverlays); }

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -98,12 +98,12 @@ public:
     void disable() { _enabled = false; }
 
     const RayPickFilter& getFilter() { return _filter; }
-    const float& getMaxDistance() { return _maxDistance; }
-    const bool& isEnabled() { return _enabled; }
+    float getMaxDistance() { return _maxDistance; }
+    bool isEnabled() { return _enabled; }
     const RayPickResult& getPrevRayPickResult() { return _prevResult; }
 
     void setPrecisionPicking(bool precisionPicking) { _precisionPicking = precisionPicking; }
-    const bool& doesPrecisionPicking() { return _precisionPicking; }
+    bool doesPrecisionPicking() { return _precisionPicking; }
 
     void setRayPickResult(const RayPickResult& rayPickResult) { _prevResult = rayPickResult; }
 

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -47,6 +47,8 @@ public:
     bool operator== (const RayPickFilter& rhs) const { return _flags == rhs._flags; }
     bool operator!= (const RayPickFilter& rhs) const { return _flags != rhs._flags; }
 
+    void setFlag(FlagBit flag, bool value) { _flags[flag] = value; }
+
     bool doesPickNothing() const { return _flags[PICK_NOTHING]; }
     bool doesPickEntities() const { return _flags[PICK_ENTITIES]; }
     bool doesPickOverlays() const { return _flags[PICK_OVERLAYS]; }
@@ -102,8 +104,7 @@ public:
     bool isEnabled() { return _enabled; }
     const RayPickResult& getPrevRayPickResult() { return _prevResult; }
 
-    void setPrecisionPicking(bool precisionPicking) { _precisionPicking = precisionPicking; }
-    bool doesPrecisionPicking() { return _precisionPicking; }
+    void setPrecisionPicking(bool precisionPicking) { _filter.setFlag(RayPickFilter::PICK_COURSE, !precisionPicking); }
 
     void setRayPickResult(const RayPickResult& rayPickResult) { _prevResult = rayPickResult; }
 
@@ -126,7 +127,6 @@ private:
     bool _enabled;
     RayPickResult _prevResult;
 
-    bool _precisionPicking { true };
     QVector<EntityItemID> _ignoreEntities;
     QVector<EntityItemID> _includeEntities;
     QVector<OverlayID> _ignoreOverlays;

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -102,6 +102,9 @@ public:
     const bool& isEnabled() { return _enabled; }
     const RayPickResult& getPrevRayPickResult() { return _prevResult; }
 
+    void setPrecisionPicking(bool precisionPicking) { _precisionPicking = precisionPicking; }
+    const bool& doesPrecisionPicking() { return _precisionPicking; }
+
     void setRayPickResult(const RayPickResult& rayPickResult) { _prevResult = rayPickResult; }
 
     const QVector<EntityItemID>& getIgnoreEntites() { return _ignoreEntities; }
@@ -123,6 +126,7 @@ private:
     bool _enabled;
     RayPickResult _prevResult;
 
+    bool _precisionPicking { true };
     QVector<EntityItemID> _ignoreEntities;
     QVector<EntityItemID> _includeEntities;
     QVector<OverlayID> _ignoreOverlays;

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -41,7 +41,7 @@ public:
     // The key is the Flags
     Flags _flags;
 
-    RayPickFilter() : _flags(PICK_NOTHING) {}
+    RayPickFilter() : _flags(getBitMask(PICK_NOTHING)) {}
     RayPickFilter(const Flags& flags) : _flags(flags) {}
 
     bool operator== (const RayPickFilter& rhs) const { return _flags == rhs._flags; }
@@ -63,27 +63,27 @@ public:
 
     // Helpers for RayPickManager
     Flags getEntityFlags() const {
-        Flags toReturn(PICK_ENTITIES);
+        unsigned int toReturn = getBitMask(PICK_ENTITIES);
         if (doesPickInvisible()) {
-            toReturn |= Flags(PICK_INCLUDE_INVISIBLE);
+            toReturn |= getBitMask(PICK_INCLUDE_INVISIBLE);
         }
         if (doesPickNonCollidable()) {
-            toReturn |= Flags(PICK_INCLUDE_NONCOLLIDABLE);
+            toReturn |= getBitMask(PICK_INCLUDE_NONCOLLIDABLE);
         }
-        return toReturn;
+        return Flags(toReturn);
     }
     Flags getOverlayFlags() const {
-        Flags toReturn(PICK_OVERLAYS);
+        unsigned int toReturn = getBitMask(PICK_OVERLAYS);
         if (doesPickInvisible()) {
-            toReturn |= Flags(PICK_INCLUDE_INVISIBLE);
+            toReturn |= getBitMask(PICK_INCLUDE_INVISIBLE);
         }
         if (doesPickNonCollidable()) {
-            toReturn |= Flags(PICK_INCLUDE_NONCOLLIDABLE);
+            toReturn |= getBitMask(PICK_INCLUDE_NONCOLLIDABLE);
         }
-        return toReturn;
+        return Flags(toReturn);
     }
-    Flags getAvatarFlags() const { return Flags(PICK_AVATARS); }
-    Flags getHUDFlags() const { return Flags(PICK_HUD); }
+    Flags getAvatarFlags() const { return Flags(getBitMask(PICK_AVATARS)); }
+    Flags getHUDFlags() const { return Flags(getBitMask(PICK_HUD)); }
 
     static unsigned int getBitMask(FlagBit bit) { return 1 << bit; }
 

--- a/interface/src/raypick/RayPickManager.cpp
+++ b/interface/src/raypick/RayPickManager.cpp
@@ -67,7 +67,8 @@ void RayPickManager::update() {
             bool noncollidable = rayPick->getFilter().doesPickNonCollidable();
             RayPickFilter::Flags entityMask = rayPick->getFilter().getEntityFlags();
             if (!checkAndCompareCachedResults(rayKey, results, res, entityMask)) {
-                entityRes = DependencyManager::get<EntityScriptingInterface>()->findRayIntersectionVector(ray, true, rayPick->getIncludeEntites(), rayPick->getIgnoreEntites(), !invisible, !noncollidable);
+                entityRes = DependencyManager::get<EntityScriptingInterface>()->findRayIntersectionVector(ray, rayPick->doesPrecisionPicking(),
+                    rayPick->getIncludeEntites(), rayPick->getIgnoreEntites(), !invisible, !noncollidable);
                 fromCache = false;
             }
 
@@ -84,7 +85,8 @@ void RayPickManager::update() {
             bool noncollidable = rayPick->getFilter().doesPickNonCollidable();
             RayPickFilter::Flags overlayMask = rayPick->getFilter().getOverlayFlags();
             if (!checkAndCompareCachedResults(rayKey, results, res, overlayMask)) {
-                overlayRes = qApp->getOverlays().findRayIntersectionVector(ray, true, rayPick->getIncludeOverlays(), rayPick->getIgnoreOverlays(), !invisible, !noncollidable);
+                overlayRes = qApp->getOverlays().findRayIntersectionVector(ray, rayPick->doesPrecisionPicking(),
+                    rayPick->getIncludeOverlays(), rayPick->getIgnoreOverlays(), !invisible, !noncollidable);
                 fromCache = false;
             }
 
@@ -202,6 +204,14 @@ const RayPickResult RayPickManager::getPrevRayPickResult(const QUuid uid) {
         return _rayPicks[uid]->getPrevRayPickResult();
     }
     return RayPickResult();
+}
+
+void RayPickManager::setPrecisionPicking(QUuid uid, const bool precisionPicking) {
+    QReadLocker containsLock(&_containsLock);
+    if (_rayPicks.contains(uid)) {
+        QWriteLocker lock(_rayPickLocks[uid].get());
+        _rayPicks[uid]->setPrecisionPicking(precisionPicking);
+    }
 }
 
 void RayPickManager::setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) {

--- a/interface/src/raypick/RayPickManager.cpp
+++ b/interface/src/raypick/RayPickManager.cpp
@@ -64,11 +64,11 @@ void RayPickManager::update() {
             RayToEntityIntersectionResult entityRes;
             bool fromCache = true;
             bool invisible = rayPick->getFilter().doesPickInvisible();
-            bool noncollidable = rayPick->getFilter().doesPickNonCollidable();
+            bool nonCollidable = rayPick->getFilter().doesPickNonCollidable();
             RayPickFilter::Flags entityMask = rayPick->getFilter().getEntityFlags();
             if (!checkAndCompareCachedResults(rayKey, results, res, entityMask)) {
-                entityRes = DependencyManager::get<EntityScriptingInterface>()->findRayIntersectionVector(ray, rayPick->doesPrecisionPicking(),
-                    rayPick->getIncludeEntites(), rayPick->getIgnoreEntites(), !invisible, !noncollidable);
+                entityRes = DependencyManager::get<EntityScriptingInterface>()->findRayIntersectionVector(ray, !rayPick->getFilter().doesPickCourse(),
+                    rayPick->getIncludeEntites(), rayPick->getIgnoreEntites(), !invisible, !nonCollidable);
                 fromCache = false;
             }
 
@@ -82,11 +82,11 @@ void RayPickManager::update() {
             RayToOverlayIntersectionResult overlayRes;
             bool fromCache = true;
             bool invisible = rayPick->getFilter().doesPickInvisible();
-            bool noncollidable = rayPick->getFilter().doesPickNonCollidable();
+            bool nonCollidable = rayPick->getFilter().doesPickNonCollidable();
             RayPickFilter::Flags overlayMask = rayPick->getFilter().getOverlayFlags();
             if (!checkAndCompareCachedResults(rayKey, results, res, overlayMask)) {
-                overlayRes = qApp->getOverlays().findRayIntersectionVector(ray, rayPick->doesPrecisionPicking(),
-                    rayPick->getIncludeOverlays(), rayPick->getIgnoreOverlays(), !invisible, !noncollidable);
+                overlayRes = qApp->getOverlays().findRayIntersectionVector(ray, !rayPick->getFilter().doesPickCourse(),
+                    rayPick->getIncludeOverlays(), rayPick->getIgnoreOverlays(), !invisible, !nonCollidable);
                 fromCache = false;
             }
 

--- a/interface/src/raypick/RayPickManager.h
+++ b/interface/src/raypick/RayPickManager.h
@@ -38,6 +38,7 @@ public:
     void disableRayPick(const QUuid uid);
     const RayPickResult getPrevRayPickResult(const QUuid uid);
 
+    void setPrecisionPicking(QUuid uid, const bool precisionPicking);
     void setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities);
     void setIncludeEntities(QUuid uid, const QScriptValue& includeEntities);
     void setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays);

--- a/interface/src/raypick/RayPickScriptingInterface.cpp
+++ b/interface/src/raypick/RayPickScriptingInterface.cpp
@@ -82,6 +82,10 @@ RayPickResult RayPickScriptingInterface::getPrevRayPickResult(QUuid uid) {
     return qApp->getRayPickManager().getPrevRayPickResult(uid);
 }
 
+void RayPickScriptingInterface::setPrecisionPicking(QUuid uid, const bool precisionPicking) {
+    qApp->getRayPickManager().setPrecisionPicking(uid, precisionPicking);
+}
+
 void RayPickScriptingInterface::setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) {
     qApp->getRayPickManager().setIgnoreEntities(uid, ignoreEntities);
 }

--- a/interface/src/raypick/RayPickScriptingInterface.h
+++ b/interface/src/raypick/RayPickScriptingInterface.h
@@ -43,6 +43,7 @@ public slots:
     Q_INVOKABLE void removeRayPick(QUuid uid);
     Q_INVOKABLE RayPickResult getPrevRayPickResult(QUuid uid);
 
+    Q_INVOKABLE void setPrecisionPicking(QUuid uid, const bool precisionPicking);
     Q_INVOKABLE void setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities);
     Q_INVOKABLE void setIncludeEntities(QUuid uid, const QScriptValue& includeEntities);
     Q_INVOKABLE void setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays);
@@ -50,7 +51,6 @@ public slots:
     Q_INVOKABLE void setIgnoreAvatars(QUuid uid, const QScriptValue& ignoreAvatars);
     Q_INVOKABLE void setIncludeAvatars(QUuid uid, const QScriptValue& includeAvatars);
 
-private:
     unsigned int PICK_NOTHING() { return RayPickFilter::getBitMask(RayPickFilter::FlagBit::PICK_NOTHING); }
     unsigned int PICK_ENTITIES() { return RayPickFilter::getBitMask(RayPickFilter::FlagBit::PICK_ENTITIES); }
     unsigned int PICK_OVERLAYS() { return RayPickFilter::getBitMask(RayPickFilter::FlagBit::PICK_OVERLAYS); }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -59,6 +59,10 @@ public:
     float getEntityLoadingPriority(const EntityItem& item) const { return _calculateEntityLoadingPriorityFunc(item); }
     void setEntityLoadingPriorityFunction(CalculateEntityLoadingPriority fn) { this->_calculateEntityLoadingPriorityFunc = fn; }
 
+    void setMouseRayPickID(QUuid rayPickID) { _mouseRayPickID = rayPickID; }
+    void setMouseRayPickResultOperator(std::function<RayToEntityIntersectionResult(QUuid)> getPrevRayPickResultOperator) { _getPrevRayPickResultOperator = getPrevRayPickResultOperator;  }
+    void setSetPrecisionPickingOperator(std::function<void(QUuid, bool)> setPrecisionPickingOperator) { _setPrecisionPickingOperator = setPrecisionPickingOperator; }
+
     void shutdown();
     void update();
 
@@ -130,7 +134,7 @@ public slots:
 
     // optional slots that can be wired to menu items
     void setDisplayModelBounds(bool value) { _displayModelBounds = value; }
-    void setDontDoPrecisionPicking(bool value) { _dontDoPrecisionPicking = value; }
+    void setPrecisionPicking(bool value) { _setPrecisionPickingOperator(_mouseRayPickID, value); }
 
 protected:
     virtual OctreePointer createTree() override {
@@ -150,10 +154,6 @@ private:
     void checkAndCallPreload(const EntityItemID& entityID, bool reload = false, bool unloadFirst = false);
 
     QList<ModelPointer> _releasedModels;
-    RayToEntityIntersectionResult findRayIntersectionWorker(const PickRay& ray, Octree::lockType lockType,
-                                                                bool precisionPicking, const QVector<EntityItemID>& entityIdsToInclude = QVector<EntityItemID>(),
-                                                                const QVector<EntityItemID>& entityIdsToDiscard = QVector<EntityItemID>(), bool visibleOnly=false,
-                                                                bool collidableOnly = false);
 
     EntityItemID _currentHoverOverEntityID;
     EntityItemID _currentClickingOnEntityID;
@@ -176,11 +176,14 @@ private:
     AbstractViewStateInterface* _viewState;
     AbstractScriptingServicesInterface* _scriptingServices;
     bool _displayModelBounds;
-    bool _dontDoPrecisionPicking;
 
     bool _shuttingDown { false };
 
     QMultiMap<QUrl, EntityItemID> _waitingOnPreload;
+
+    QUuid _mouseRayPickID;
+    std::function<RayToEntityIntersectionResult(QUuid)> _getPrevRayPickResultOperator;
+    std::function<void(QUuid, bool)> _setPrecisionPickingOperator;
 
     class LayeredZone {
     public:

--- a/scripts/system/controllers/handControllerGrab.js
+++ b/scripts/system/controllers/handControllerGrab.js
@@ -1182,7 +1182,7 @@ function MyController(hand) {
     this.fullEnd = fullEnd;
     this.laserPointer = LaserPointers.createLaserPointer({
         joint: (hand == RIGHT_HAND) ? "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND" : "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND",
-        filter: RayPick.PICK_ENTITIES | RayPick.PICK_OVERLAYS,
+        filter: RayPick.PICK_ENTITIES | RayPick.PICK_OVERLAYS | RayPick.PICK_INCLUDE_NONCOLLIDABLE,
         maxDistance: PICK_MAX_DISTANCE,
         posOffset: getGrabPointSphereOffset(this.handToController()),
         renderStates: renderStates,
@@ -1191,7 +1191,7 @@ function MyController(hand) {
     });
     this.headLaserPointer = LaserPointers.createLaserPointer({
         joint: "Avatar",
-        filter: RayPick.PICK_ENTITIES | RayPick.PICK_OVERLAYS,
+        filter: RayPick.PICK_ENTITIES | RayPick.PICK_OVERLAYS | RayPick.PICK_INCLUDE_NONCOLLIDABLE,
         maxDistance: PICK_MAX_DISTANCE,
         renderStates: headRenderStates,
         faceAvatar: true,


### PR DESCRIPTION
Also now you can set whether or not a laser pointer/ray pick uses precision picking, and fixes a bug with the RayPickResult caching.

Test plan:
- Spawn the chess set from marketplace.
- Close Interface.
- Open the settings for this PR (/Users/[you]/AppData/Roaming/High Fidelity - PR11226/Interface.json
- Set "inspectionMode": true
- Reopen Interface.
- In desktop mode, mouse over the chess set and the chess pieces.  When you hover over them, a yellow bounding box should appear.  The picking should seem precise (when you hover just between two chess pieces, neither should be highlighted).
- You should also be able to highlight the pieces with the handControllerGrab lasers.
- See Howard's test plan below.