### PR TITLE
Add Item Highlight Scripting Interface - Am I on the right track?

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5551,17 +5551,6 @@ void Application::displaySide(RenderArgs* renderArgs, Camera& theCamera, bool se
             }
             renderArgs->_debugFlags = renderDebugFlags;
             //ViveControllerManager::getInstance().updateRendering(renderArgs, _main3DScene, transaction);
-
-            RenderArgs::OutlineFlags renderOutlineFlags = RenderArgs::RENDER_OUTLINE_NONE;
-            auto contextOverlayInterface = DependencyManager::get<ContextOverlayInterface>();
-            if (contextOverlayInterface->getEnabled()) {
-                if (DependencyManager::get<ContextOverlayInterface>()->getIsInMarketplaceInspectionMode()) {
-                    renderOutlineFlags = RenderArgs::RENDER_OUTLINE_MARKETPLACE_MODE;
-                } else {
-                    renderOutlineFlags = RenderArgs::RENDER_OUTLINE_WIREFRAMES;
-                }
-            }
-            renderArgs->_outlineFlags = renderOutlineFlags;
         }
     }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -166,6 +166,7 @@
 #include "scripting/WindowScriptingInterface.h"
 #include "scripting/ControllerScriptingInterface.h"
 #include "scripting/RatesScriptingInterface.h"
+#include "scripting/ItemHighlightScriptingInterface.h"
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
 #include "SpeechRecognizer.h"
 #endif
@@ -611,6 +612,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::set<ContextOverlayInterface>();
     DependencyManager::set<Ledger>();
     DependencyManager::set<Wallet>();
+    DependencyManager::set<ItemHighlightScriptingInterface>(qApp);
 
     DependencyManager::set<LaserPointerScriptingInterface>();
     DependencyManager::set<RayPickScriptingInterface>();

--- a/interface/src/scripting/ItemHighlightScriptingInterface.cpp
+++ b/interface/src/scripting/ItemHighlightScriptingInterface.cpp
@@ -1,0 +1,16 @@
+﻿//
+//  ItemHighlightScriptingInterface.cpp
+//  interface/src/scripting
+//
+//  Created by Zach Fox on 2017-08-22.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ItemHighlightScriptingInterface.h"
+
+ItemHighlightScriptingInterface::ItemHighlightScriptingInterface() {
+
+}

--- a/interface/src/scripting/ItemHighlightScriptingInterface.cpp
+++ b/interface/src/scripting/ItemHighlightScriptingInterface.cpp
@@ -16,46 +16,83 @@ ItemHighlightScriptingInterface::ItemHighlightScriptingInterface(AbstractViewSta
     _viewState = viewState;
 }
 
-bool ItemHighlightScriptingInterface::addToHighlightedItemsList(const EntityItemID& entityID) {
+//
+// START HANDLING ENTITIES
+//
+render::ItemID getItemIDFromEntityID(const EntityItemID& entityID) {
     auto entityTree = qApp->getEntities()->getTree();
     entityTree->withReadLock([&] {
         auto entityItem = entityTree->findEntityByEntityItemID(entityID);
-        if ((entityItem != NULL)) {
-            addToHighlightedItemsList(entityItem->getRenderItemID());
+        if (entityItem != NULL) {
+            auto renderableInterface = entityItem->getRenderableInterface();
+            if (renderableInterface != NULL) {
+                return renderableInterface->getMetaRenderItemID();
+            }
         }
+        return render::Item::INVALID_ITEM_ID;
     });
+    return render::Item::INVALID_ITEM_ID;
+}
+bool ItemHighlightScriptingInterface::addToHighlightedItemsList(const EntityItemID& entityID) {
+    render::ItemID itemID = getItemIDFromEntityID(entityID);
+    if (itemID != render::Item::INVALID_ITEM_ID) {
+        return addToHighlightedItemsList(itemID);
+    }
+    return false;
 }
 bool ItemHighlightScriptingInterface::removeFromHighlightedItemsList(const EntityItemID& entityID) {
+    render::ItemID itemID = getItemIDFromEntityID(entityID);
+    if (itemID != render::Item::INVALID_ITEM_ID) {
+        return removeFromHighlightedItemsList(itemID);
+    }
+    return false;
 }
+//
+// END HANDLING ENTITIES
+//
 
-bool ItemHighlightScriptingInterface::addToHighlightedItemsList(const OverlayID& overlayID) {
+//
+// START HANDLING OVERLAYS
+//
+render::ItemID getItemIDFromOverlayID(const OverlayID& overlayID) {
     auto& overlays = qApp->getOverlays();
     auto overlay = overlays.getOverlay(overlayID);
     if (overlay != NULL) {
         auto itemID = overlay->getRenderItemID();
         if (itemID != render::Item::INVALID_ITEM_ID) {
-            addToHighlightedItemsList(overlay->getRenderItemID());
+            return overlay->getRenderItemID();
         }
     }
+    return render::Item::INVALID_ITEM_ID;
+}
+bool ItemHighlightScriptingInterface::addToHighlightedItemsList(const OverlayID& overlayID) {
+    render::ItemID itemID = getItemIDFromOverlayID(overlayID);
+    if (itemID != render::Item::INVALID_ITEM_ID) {
+        return addToHighlightedItemsList(itemID);
+    }
+    return false;
 }
 bool ItemHighlightScriptingInterface::removeFromHighlightedItemsList(const OverlayID& overlayID) {
-    auto& overlays = qApp->getOverlays();
-    auto overlay = overlays.getOverlay(overlayID);
-    if (overlay != NULL) {
-        auto itemID = overlay->getRenderItemID();
-        if (itemID != render::Item::INVALID_ITEM_ID) {
-            removeFromHighlightedItemsList(overlay->getRenderItemID());
-        }
+    render::ItemID itemID = getItemIDFromOverlayID(overlayID);
+    if (itemID != render::Item::INVALID_ITEM_ID) {
+        return removeFromHighlightedItemsList(itemID);
     }
+    return false;
 }
+//
+// END HANDLING OVERLAYS
+//
 
+//
+// START HANDLING GENERIC ITEMS
+//
 bool ItemHighlightScriptingInterface::addToHighlightedItemsList(render::ItemID idToAdd) {
-    _highlightedItemsList.push_back(idToAdd);
+    _highlightedItemsList.push_back(idToAdd); // TODO: Ensure thread safety
     updateRendererHighlightList();
     return true;
 }
 bool ItemHighlightScriptingInterface::removeFromHighlightedItemsList(render::ItemID idToRemove) {
-    auto itr = std::find(_highlightedItemsList.begin(), _highlightedItemsList.end(), idToRemove);
+    auto itr = std::find(_highlightedItemsList.begin(), _highlightedItemsList.end(), idToRemove); // TODO: Ensure thread safety
     if (itr == _highlightedItemsList.end()) {
         return false;
     } else {
@@ -64,6 +101,9 @@ bool ItemHighlightScriptingInterface::removeFromHighlightedItemsList(render::Ite
         return true;
     }
 }
+//
+// END HANDLING GENERIC ITEMS
+//
 
 void ItemHighlightScriptingInterface::updateRendererHighlightList() {
     auto scene = _viewState->getMain3DScene();

--- a/interface/src/scripting/ItemHighlightScriptingInterface.h
+++ b/interface/src/scripting/ItemHighlightScriptingInterface.h
@@ -17,7 +17,7 @@
 
 #include <AbstractViewStateInterface.h>
 
-#include "EntityItemID.h"
+#include "RenderableEntityItem.h"
 #include "ui/overlays/Overlay.h"
 
 class ItemHighlightScriptingInterface : public QObject, public Dependency {

--- a/interface/src/scripting/ItemHighlightScriptingInterface.h
+++ b/interface/src/scripting/ItemHighlightScriptingInterface.h
@@ -12,17 +12,36 @@
 #ifndef hifi_ItemHighlightScriptingInterface_h
 #define hifi_ItemHighlightScriptingInterface_h
 
-class ItemHighlightScriptingInterface : public Dependency {
+#include <QtCore/QObject>
+#include <DependencyManager.h>
+
+#include <AbstractViewStateInterface.h>
+
+#include "EntityItemID.h"
+#include "ui/overlays/Overlay.h"
+
+class ItemHighlightScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
 
 public:
+    ItemHighlightScriptingInterface(AbstractViewStateInterface* viewState);
 
-signals:
+    Q_INVOKABLE bool addToHighlightedItemsList(const EntityItemID& entityID);
+    Q_INVOKABLE bool removeFromHighlightedItemsList(const EntityItemID& entityID);
+    
+    Q_INVOKABLE bool addToHighlightedItemsList(const OverlayID& overlayID);
+    Q_INVOKABLE bool removeFromHighlightedItemsList(const OverlayID& overlayID);
 
-public:
-    ItemHighlightScriptingInterface();
+//signals:
 
 private:
+    AbstractViewStateInterface* _viewState;
+    render::ItemIDs _highlightedItemsList;
+
+    bool addToHighlightedItemsList(render::ItemID idToAdd);
+    bool removeFromHighlightedItemsList(render::ItemID idToRemove);
+
+    void updateRendererHighlightList();
 };
 
 #endif // hifi_ItemHighlightScriptingInterface_h

--- a/interface/src/scripting/ItemHighlightScriptingInterface.h
+++ b/interface/src/scripting/ItemHighlightScriptingInterface.h
@@ -1,0 +1,28 @@
+
+//  ItemHighlightScriptingInterface.h
+//  interface/src/scripting
+//
+//  Created by Zach Fox on 2017-08-22.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_ItemHighlightScriptingInterface_h
+#define hifi_ItemHighlightScriptingInterface_h
+
+class ItemHighlightScriptingInterface : public Dependency {
+    Q_OBJECT
+
+public:
+
+signals:
+
+public:
+    ItemHighlightScriptingInterface();
+
+private:
+};
+
+#endif // hifi_ItemHighlightScriptingInterface_h

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -260,25 +260,11 @@ void ContextOverlayInterface::openMarketplace() {
 }
 
 void ContextOverlayInterface::enableEntityHighlight(const EntityItemID& entityItemID) {
-    auto entityTree = qApp->getEntities()->getTree();
-    entityTree->withReadLock([&] {
-        auto entityItem = entityTree->findEntityByEntityItemID(entityItemID);
-        if ((entityItem != NULL) && !entityItem->getShouldHighlight()) {
-            qCDebug(context_overlay) << "Setting 'shouldHighlight' to 'true' for Entity ID:" << entityItemID;
-            entityItem->setShouldHighlight(true);
-        }
-    });
+
 }
 
 void ContextOverlayInterface::disableEntityHighlight(const EntityItemID& entityItemID) {
-    auto entityTree = qApp->getEntities()->getTree();
-    entityTree->withReadLock([&] {
-        auto entityItem = entityTree->findEntityByEntityItemID(entityItemID);
-        if ((entityItem != NULL) && entityItem->getShouldHighlight()) {
-            qCDebug(context_overlay) << "Setting 'shouldHighlight' to 'false' for Entity ID:" << entityItemID;
-            entityItem->setShouldHighlight(false);
-        }
-    });
+
 }
 
 void ContextOverlayInterface::deletingEntity(const EntityItemID& entityID) {

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -27,6 +27,7 @@ ContextOverlayInterface::ContextOverlayInterface() {
     _entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
     _hmdScriptingInterface = DependencyManager::get<HMDScriptingInterface>();
     _tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
+    _itemHighlightScriptingInterface = DependencyManager::get<ItemHighlightScriptingInterface>();
 
     _entityPropertyFlags += PROP_POSITION;
     _entityPropertyFlags += PROP_ROTATION;
@@ -260,11 +261,11 @@ void ContextOverlayInterface::openMarketplace() {
 }
 
 void ContextOverlayInterface::enableEntityHighlight(const EntityItemID& entityItemID) {
-
+    _itemHighlightScriptingInterface->addToHighlightedItemsList(entityItemID);
 }
 
 void ContextOverlayInterface::disableEntityHighlight(const EntityItemID& entityItemID) {
-
+    _itemHighlightScriptingInterface->removeFromHighlightedItemsList(entityItemID);
 }
 
 void ContextOverlayInterface::deletingEntity(const EntityItemID& entityID) {

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -25,6 +25,7 @@
 #include "ui/overlays/Image3DOverlay.h"
 #include "ui/overlays/Overlays.h"
 #include "scripting/HMDScriptingInterface.h"
+#include "scripting/ItemHighlightScriptingInterface.h"
 
 #include "EntityTree.h"
 #include "ContextOverlayLogging.h"
@@ -42,6 +43,7 @@ class ContextOverlayInterface : public QObject, public Dependency  {
     EntityPropertyFlags _entityPropertyFlags;
     QSharedPointer<HMDScriptingInterface> _hmdScriptingInterface;
     QSharedPointer<TabletScriptingInterface> _tabletScriptingInterface;
+    QSharedPointer<ItemHighlightScriptingInterface> _itemHighlightScriptingInterface;
     OverlayID _contextOverlayID { UNKNOWN_OVERLAY_ID };
     std::shared_ptr<Image3DOverlay> _contextOverlay { nullptr };
 public:

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -44,6 +44,9 @@ public:
     const SharedSoundPointer& getCollisionSound() { return _collisionSound; }
     void setCollisionSound(const SharedSoundPointer& sound) { _collisionSound = sound; }
     virtual RenderableEntityInterface* getRenderableInterface() { return nullptr; }
+
+    virtual render::ItemID getMetaRenderItemID() { return render::Item::INVALID_ITEM_ID; }
+
 private:
     SharedSoundPointer _collisionSound;
 };
@@ -86,6 +89,7 @@ public: \
     virtual void locationChanged(bool tellPhysics = true) override { EntityItem::locationChanged(tellPhysics); notifyChanged(); } \
     virtual void dimensionsChanged() override { EntityItem::dimensionsChanged(); notifyChanged(); } \
     virtual RenderableEntityInterface* getRenderableInterface() override { return this; } \
+    render::ItemID getMetaRenderItemID() override { return render::Item::INVALID_ITEM_ID; } \
     void checkFading() { \
         bool transparent = isTransparent(); \
         if (transparent != _prevIsTransparent) { \

--- a/libraries/entities-renderer/src/RenderableLightEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableLightEntityItem.h
@@ -24,6 +24,8 @@ public:
 
     RenderableEntityInterface* getRenderableInterface() override { return this; }
 
+    render::ItemID getMetaRenderItemID() override { return render::Item::INVALID_ITEM_ID; }
+
     virtual bool supportsDetailedRayIntersection() const override { return true; }
     virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
                          bool& keepSearching, OctreeElementPointer& element, float& distance, 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -381,21 +381,6 @@ void RenderableModelEntityItem::render(RenderArgs* args) {
         _model->updateRenderItems();
     }
 
-    // this simple logic should say we set showingEntityHighlight to true whenever we are in marketplace mode and we have a marketplace id, or
-    // whenever we are not set to none and shouldHighlight is true.
-    bool showingEntityHighlight = ((bool)(args->_outlineFlags & (int)RenderArgs::RENDER_OUTLINE_MARKETPLACE_MODE) && getMarketplaceID().length() != 0) ||
-                                  (args->_outlineFlags != RenderArgs::RENDER_OUTLINE_NONE && getShouldHighlight());
-    if (showingEntityHighlight) {
-        static glm::vec4 yellowColor(1.0f, 1.0f, 0.0f, 1.0f);
-        gpu::Batch& batch = *args->_batch;
-        bool success;
-        auto shapeTransform = getTransformToCenter(success);
-        if (success) {
-            batch.setModelTransform(shapeTransform); // we want to include the scale as well
-            DependencyManager::get<GeometryCache>()->renderWireCubeInstance(args, batch, yellowColor);
-        }
-    }
-
     if (!hasModel() || (_model && _model->didVisualGeometryRequestFail())) {
         static glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);
         gpu::Batch& batch = *args->_batch;

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -34,6 +34,8 @@ public:
 
     RenderableEntityInterface* getRenderableInterface() override { return this; }
 
+    render::ItemID getMetaRenderItemID() override { return _myMetaItem; }
+
     virtual void setDimensions(const glm::vec3& value) override;
     virtual void setModelURL(const QString& url) override;
 

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.h
@@ -23,6 +23,8 @@ public:
 
     RenderableEntityInterface* getRenderableInterface() override { return this; }
 
+    render::ItemID getMetaRenderItemID() override { return _renderItemId; }
+
     virtual void update(const quint64& now) override;
 
     void updateRenderItem();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
@@ -68,6 +68,8 @@ public:
 
     RenderableEntityInterface* getRenderableInterface() override { return this; }
 
+    render::ItemID getMetaRenderItemID() override { return _myItem; }
+
     void initializePolyVox();
 
     virtual void somethingChangedNotification() override {

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.h
@@ -33,6 +33,8 @@ public:
     
     RenderableEntityInterface* getRenderableInterface() override { return this; }
 
+    render::ItemID getMetaRenderItemID() override { return _myMetaItem; }
+
     virtual bool setProperties(const EntityItemProperties& properties) override;
     virtual void somethingChangedNotification() override;
 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -133,7 +133,6 @@ EntityPropertyFlags EntityItem::getEntityProperties(EncodeBitstreamParams& param
     requestedProperties += PROP_LOCKED;
     requestedProperties += PROP_USER_DATA;
     requestedProperties += PROP_MARKETPLACE_ID;
-    requestedProperties += PROP_SHOULD_HIGHLIGHT;
     requestedProperties += PROP_NAME;
     requestedProperties += PROP_HREF;
     requestedProperties += PROP_DESCRIPTION;
@@ -279,7 +278,6 @@ OctreeElement::AppendState EntityItem::appendEntityData(OctreePacketData* packet
         APPEND_ENTITY_PROPERTY(PROP_LOCKED, getLocked());
         APPEND_ENTITY_PROPERTY(PROP_USER_DATA, getUserData());
         APPEND_ENTITY_PROPERTY(PROP_MARKETPLACE_ID, getMarketplaceID());
-        APPEND_ENTITY_PROPERTY(PROP_SHOULD_HIGHLIGHT, getShouldHighlight());
         APPEND_ENTITY_PROPERTY(PROP_NAME, getName());
         APPEND_ENTITY_PROPERTY(PROP_COLLISION_SOUND_URL, getCollisionSoundURL());
         APPEND_ENTITY_PROPERTY(PROP_HREF, getHref());
@@ -829,10 +827,6 @@ int EntityItem::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
 
     if (args.bitstreamVersion >= VERSION_ENTITIES_HAS_MARKETPLACE_ID) {
         READ_ENTITY_PROPERTY(PROP_MARKETPLACE_ID, QString, setMarketplaceID);
-    }
-
-    if (args.bitstreamVersion >= VERSION_ENTITIES_HAS_SHOULD_HIGHLIGHT) {
-        READ_ENTITY_PROPERTY(PROP_SHOULD_HIGHLIGHT, bool, setShouldHighlight);
     }
 
     READ_ENTITY_PROPERTY(PROP_NAME, QString, setName);
@@ -2806,20 +2800,6 @@ QString EntityItem::getMarketplaceID() const {
 void EntityItem::setMarketplaceID(const QString& value) { 
     withWriteLock([&] {
         _marketplaceID = value;
-    });
-}
-
-bool EntityItem::getShouldHighlight() const {
-    bool result;
-    withReadLock([&] {
-        result = _shouldHighlight;
-    });
-    return result;
-}
-
-void EntityItem::setShouldHighlight(const bool value) {
-    withWriteLock([&] {
-        _shouldHighlight = value;
     });
 }
 

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -316,9 +316,6 @@ public:
     QString getMarketplaceID() const;
     void setMarketplaceID(const QString& value);
 
-    bool getShouldHighlight() const;
-    void setShouldHighlight(const bool value);
-
     // TODO: get rid of users of getRadius()...
     float getRadius() const;
 
@@ -535,7 +532,6 @@ protected:
     QString _userData;
     SimulationOwner _simulationOwner;
     QString _marketplaceID;
-    bool _shouldHighlight { false };
     QString _name;
     QString _href; //Hyperlink href
     QString _description; //Hyperlink description

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -289,7 +289,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
     CHECK_PROPERTY_CHANGE(PROP_RADIUS_START, radiusStart);
     CHECK_PROPERTY_CHANGE(PROP_RADIUS_FINISH, radiusFinish);
     CHECK_PROPERTY_CHANGE(PROP_MARKETPLACE_ID, marketplaceID);
-    CHECK_PROPERTY_CHANGE(PROP_SHOULD_HIGHLIGHT, shouldHighlight);
     CHECK_PROPERTY_CHANGE(PROP_NAME, name);
     CHECK_PROPERTY_CHANGE(PROP_BACKGROUND_MODE, backgroundMode);
     CHECK_PROPERTY_CHANGE(PROP_SOURCE_URL, sourceUrl);
@@ -407,7 +406,6 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_LOCKED, locked);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_USER_DATA, userData);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_MARKETPLACE_ID, marketplaceID);
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_SHOULD_HIGHLIGHT, shouldHighlight);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_NAME, name);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COLLISION_SOUND_URL, collisionSoundURL);
 
@@ -984,7 +982,6 @@ void EntityItemProperties::entityPropertyFlagsFromScriptValue(const QScriptValue
         ADD_PROPERTY_TO_MAP(PROP_RADIUS_START, RadiusStart, radiusStart, float);
         ADD_PROPERTY_TO_MAP(PROP_RADIUS_FINISH, RadiusFinish, radiusFinish, float);
         ADD_PROPERTY_TO_MAP(PROP_MARKETPLACE_ID, MarketplaceID, marketplaceID, QString);
-        ADD_PROPERTY_TO_MAP(PROP_SHOULD_HIGHLIGHT, ShouldHighlight, shouldHighlight, bool);
         ADD_PROPERTY_TO_MAP(PROP_KEYLIGHT_COLOR, KeyLightColor, keyLightColor, xColor);
         ADD_PROPERTY_TO_MAP(PROP_KEYLIGHT_INTENSITY, KeyLightIntensity, keyLightIntensity, float);
         ADD_PROPERTY_TO_MAP(PROP_KEYLIGHT_AMBIENT_INTENSITY, KeyLightAmbientIntensity, keyLightAmbientIntensity, float);
@@ -1337,7 +1334,6 @@ bool EntityItemProperties::encodeEntityEditPacket(PacketType command, EntityItem
                 APPEND_ENTITY_PROPERTY(PROP_SHAPE, properties.getShape());
             }
             APPEND_ENTITY_PROPERTY(PROP_MARKETPLACE_ID, properties.getMarketplaceID());
-            APPEND_ENTITY_PROPERTY(PROP_SHOULD_HIGHLIGHT, properties.getShouldHighlight());
             APPEND_ENTITY_PROPERTY(PROP_NAME, properties.getName());
             APPEND_ENTITY_PROPERTY(PROP_COLLISION_SOUND_URL, properties.getCollisionSoundURL());
             APPEND_ENTITY_PROPERTY(PROP_ACTION_DATA, properties.getActionData());
@@ -1636,7 +1632,6 @@ bool EntityItemProperties::decodeEntityEditPacket(const unsigned char* data, int
     }
 
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_MARKETPLACE_ID, QString, setMarketplaceID);
-    READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_SHOULD_HIGHLIGHT, bool, setShouldHighlight);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_NAME, QString, setName);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_COLLISION_SOUND_URL, QString, setCollisionSoundURL);
     READ_ENTITY_PROPERTY_TO_PROPERTIES(PROP_ACTION_DATA, QByteArray, setActionData);
@@ -1751,7 +1746,6 @@ void EntityItemProperties::markAllChanged() {
     //_alphaFinishChanged = true;
 
     _marketplaceIDChanged = true;
-    _shouldHighlightChanged = true;
 
     _keyLight.markAllChanged();
 

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -171,7 +171,6 @@ public:
     DEFINE_PROPERTY(PROP_RADIUS_FINISH, RadiusFinish, radiusFinish, float, ParticleEffectEntityItem::DEFAULT_RADIUS_FINISH);
     DEFINE_PROPERTY(PROP_EMITTER_SHOULD_TRAIL, EmitterShouldTrail, emitterShouldTrail, bool, ParticleEffectEntityItem::DEFAULT_EMITTER_SHOULD_TRAIL);
     DEFINE_PROPERTY_REF(PROP_MARKETPLACE_ID, MarketplaceID, marketplaceID, QString, ENTITY_ITEM_DEFAULT_MARKETPLACE_ID);
-    DEFINE_PROPERTY_REF(PROP_SHOULD_HIGHLIGHT, ShouldHighlight, shouldHighlight, bool, ENTITY_ITEM_DEFAULT_SHOULD_HIGHLIGHT);
     DEFINE_PROPERTY_GROUP(KeyLight, keyLight, KeyLightPropertyGroup);
     DEFINE_PROPERTY_REF(PROP_VOXEL_VOLUME_SIZE, VoxelVolumeSize, voxelVolumeSize, glm::vec3, PolyVoxEntityItem::DEFAULT_VOXEL_VOLUME_SIZE);
     DEFINE_PROPERTY_REF(PROP_VOXEL_DATA, VoxelData, voxelData, QByteArray, PolyVoxEntityItem::DEFAULT_VOXEL_DATA);

--- a/libraries/entities/src/EntityItemPropertiesDefaults.h
+++ b/libraries/entities/src/EntityItemPropertiesDefaults.h
@@ -27,7 +27,6 @@ const glm::vec3 ENTITY_ITEM_HALF_VEC3 = glm::vec3(0.5f);
 const bool ENTITY_ITEM_DEFAULT_LOCKED = false;
 const QString ENTITY_ITEM_DEFAULT_USER_DATA = QString("");
 const QString ENTITY_ITEM_DEFAULT_MARKETPLACE_ID = QString("");
-const bool ENTITY_ITEM_DEFAULT_SHOULD_HIGHLIGHT = false;
 const QUuid ENTITY_ITEM_DEFAULT_SIMULATOR_ID = QUuid();
 
 const float ENTITY_ITEM_DEFAULT_ALPHA = 1.0f;

--- a/libraries/entities/src/EntityPropertyFlags.h
+++ b/libraries/entities/src/EntityPropertyFlags.h
@@ -78,7 +78,6 @@ enum EntityPropertyList {
 
     PROP_COMPOUND_SHAPE_URL, // used by Model + zones entities
     PROP_MARKETPLACE_ID, // all entities
-    PROP_SHOULD_HIGHLIGHT, // all entities
     PROP_ACCELERATION, // all entities
     PROP_SIMULATION_OWNER, // formerly known as PROP_SIMULATOR_ID
     PROP_NAME, // all entities

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -30,7 +30,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::EntityEdit:
         case PacketType::EntityData:
         case PacketType::EntityPhysics:
-            return VERSION_ENTITIES_HAS_SHOULD_HIGHLIGHT;
+            return VERSION_ENTITIES_HAS_HIGHLIGHT_SCRIPTING_INTERFACE;
         case PacketType::EntityQuery:
             return static_cast<PacketVersion>(EntityQueryPacketVersion::JSONFilterWithFamilyTree);
         case PacketType::AvatarIdentity:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -259,6 +259,7 @@ const PacketVersion VERSION_ENTITIES_ZONE_FILTERS = 68;
 const PacketVersion VERSION_ENTITIES_HINGE_CONSTRAINT = 69;
 const PacketVersion VERSION_ENTITIES_BULLET_DYNAMICS = 70;
 const PacketVersion VERSION_ENTITIES_HAS_SHOULD_HIGHLIGHT = 71;
+const PacketVersion VERSION_ENTITIES_HAS_HIGHLIGHT_SCRIPTING_INTERFACE = 72;
 
 enum class EntityQueryPacketVersion: PacketVersion {
     JSONFilter = 18,

--- a/libraries/render/src/render/Args.h
+++ b/libraries/render/src/render/Args.h
@@ -63,12 +63,6 @@ namespace render {
     public:
         enum RenderMode { DEFAULT_RENDER_MODE, SHADOW_RENDER_MODE, DIFFUSE_RENDER_MODE, NORMAL_RENDER_MODE, MIRROR_RENDER_MODE, SECONDARY_CAMERA_RENDER_MODE };
         enum DisplayMode { MONO, STEREO_MONITOR, STEREO_HMD };
-        enum OutlineFlags {
-            RENDER_OUTLINE_NONE = 0,
-            RENDER_OUTLINE_WIREFRAMES = 1,
-            RENDER_OUTLINE_MARKETPLACE_MODE = 2,
-            RENDER_OUTLINE_SHADER = 4
-        };
         enum DebugFlags {
             RENDER_DEBUG_NONE = 0,
             RENDER_DEBUG_HULLS = 1
@@ -115,7 +109,6 @@ namespace render {
         int _boundaryLevelAdjust { 0 };
         RenderMode _renderMode { DEFAULT_RENDER_MODE };
         DisplayMode _displayMode { MONO };
-        OutlineFlags _outlineFlags{ RENDER_OUTLINE_NONE };
         DebugFlags _debugFlags { RENDER_DEBUG_NONE };
         gpu::Batch* _batch = nullptr;
 


### PR DESCRIPTION
DNM PR for now - I'd like to get some feedback, especially from @samcake, just to see if I'm on the right track here.

There are two parts to this PR:
1. Remove the old method of drawing a bounding box around "highlighted" entities (which used entity properties to determine whether or not an entity should be highlighted)
2. Add a new Item Highlight Scripting Interface: Allow JS and C++ to pass entity/overlay IDs to the interface, which then adds the corresponding `render::ItemID` to a list that is passed, via a `Transaction`, to the scene, which will then be processed by the code in #11160 ("Outline effect").
    * I'll have to add the ability to add Avatar IDs to the list (this will come later in this same PR).