### PR TITLE
Fix ray pick crash on shutdown

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -707,8 +707,8 @@ private:
     QUrl _avatarOverrideUrl;
     bool _saveAvatarOverrideUrl { false };
 
-    LaserPointerManager _laserPointerManager;
     RayPickManager _rayPickManager;
+    LaserPointerManager _laserPointerManager;
 
 };
 #endif // hifi_Application_h


### PR DESCRIPTION
[FB7202](https://highfidelity.fogbugz.com/f/cases/7202/mac-interface-crash-on-quit-within-RayPickManager-removeRayPick)

The destructor for LaserPointerManager needs to be called before the destructor for RayPickManager.

Test plan:
- Shouldn't crash on shutdown (on fresh install?), on mac or windows.