### PR TITLE
add a timeout for ICE server DNS lookup

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -725,6 +725,9 @@ void DomainServer::timeoutICEAddressLookup() {
     if (_iceAddressLookupID != INVALID_ICE_LOOKUP_ID) {
         // we waited 5s and didn't hear back for our ICE DNS lookup
         // so time that one out and kick off another
+
+        qDebug() << "IP address lookup timed out for" << _iceServerAddr << "- retrying";
+
         QHostInfo::abortHostLookup(_iceAddressLookupID);
 
         _iceAddressLookupID = INVALID_ICE_LOOKUP_ID;

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -711,8 +711,25 @@ void DomainServer::setupICEHeartbeatForFullNetworking() {
 }
 
 void DomainServer::updateICEServerAddresses() {
-    if (_iceAddressLookupID == -1) {
+    if (_iceAddressLookupID == INVALID_ICE_LOOKUP_ID) {
         _iceAddressLookupID = QHostInfo::lookupHost(_iceServerAddr, this, SLOT(handleICEHostInfo(QHostInfo)));
+
+        // there seems to be a 5.9 bug where lookupHost never calls our slot
+        // so we add a single shot manual "timeout" to fire it off again if it hasn't called back yet
+        static const int ICE_ADDRESS_LOOKUP_TIMEOUT_MS = 5000;
+        QTimer::singleShot(ICE_ADDRESS_LOOKUP_TIMEOUT_MS, this, &DomainServer::timeoutICEAddressLookup);
+    }
+}
+
+void DomainServer::timeoutICEAddressLookup() {
+    if (_iceAddressLookupID != INVALID_ICE_LOOKUP_ID) {
+        // we waited 5s and didn't hear back for our ICE DNS lookup
+        // so time that one out and kick off another
+        QHostInfo::abortHostLookup(_iceAddressLookupID);
+
+        _iceAddressLookupID = INVALID_ICE_LOOKUP_ID;
+
+        updateICEServerAddresses();
     }
 }
 

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -39,6 +39,8 @@ typedef QMultiHash<QUuid, WalletTransaction*> TransactionHash;
 using Subnet = QPair<QHostAddress, int>;
 using SubnetList = std::vector<Subnet>;
 
+const int INVALID_ICE_LOOKUP_ID = -1;
+
 enum ReplicationServerDirection {
     Upstream,
     Downstream
@@ -113,6 +115,8 @@ private slots:
 
     void tokenGrantFinished();
     void profileRequestFinished();
+
+    void timeoutICEAddressLookup();
 
 signals:
     void iceServerChanged();
@@ -223,7 +227,7 @@ private:
 
     QList<QHostAddress> _iceServerAddresses;
     QSet<QHostAddress> _failedIceServerAddresses;
-    int _iceAddressLookupID { -1 };
+    int _iceAddressLookupID { INVALID_ICE_LOOKUP_ID };
     int _noReplyICEHeartbeats { 0 };
     int _numHeartbeatDenials { 0 };
     bool _connectedToICEServer { false };


### PR DESCRIPTION
- time out ICE server DNS lookups that don't callback in 5 seconds 