### PR TITLE
Huge cleanup of Wallet logic

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Security.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Security.qml
@@ -40,10 +40,8 @@ Item {
             }
         }
 
-        onKeyFilePathResult: {
-            if (path !== "") {
-                keyFilePath.text = path;
-            }
+        onKeyFilePathIfExistsResult: {
+            keyFilePath.text = path;
         }
     }
 
@@ -264,7 +262,7 @@ Item {
 
             onVisibleChanged: {
                 if (visible) {
-                    commerce.getKeyFilePath();
+                    commerce.getKeyFilePathIfExists();
                 }
             }
         }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetupLightbox.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetupLightbox.qml
@@ -56,10 +56,8 @@ Rectangle {
             }
         }
 
-        onKeyFilePathResult: {
-            if (path !== "") {
-                keyFilePath.text = path;
-            }
+        onKeyFilePathIfExistsResult: {
+            keyFilePath.text = path;
         }
     }
 
@@ -455,10 +453,10 @@ Rectangle {
                 text: "Next";
                 onClicked: {
                     if (passphraseSelection.validateAndSubmitPassphrase()) {
-                        root.lastPage = "passphrase";
+                        root.lastPage = "choosePassphrase";
+                        commerce.balance(); // Do this here so that keys are generated. Order might change as backend changes?
                         choosePassphraseContainer.visible = false;
                         privateKeysReadyContainer.visible = true;
-                        commerce.balance(); // Do this here so that keys are generated. Order might change as backend changes?
                     }
                 }
             }
@@ -562,7 +560,7 @@ Rectangle {
 
             onVisibleChanged: {
                 if (visible) {
-                    commerce.getKeyFilePath();
+                    commerce.getKeyFilePathIfExists();
                 }
             }
         }

--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -25,7 +25,7 @@ QmlCommerce::QmlCommerce(QQuickItem* parent) : OffscreenQmlDialog(parent) {
     connect(ledger.data(), &Ledger::balanceResult, this, &QmlCommerce::balanceResult);
     connect(ledger.data(), &Ledger::inventoryResult, this, &QmlCommerce::inventoryResult);
     connect(wallet.data(), &Wallet::securityImageResult, this, &QmlCommerce::securityImageResult);
-    connect(wallet.data(), &Wallet::keyFilePathResult, this, &QmlCommerce::keyFilePathResult);
+    connect(wallet.data(), &Wallet::keyFilePathIfExistsResult, this, &QmlCommerce::keyFilePathIfExistsResult);
 }
 
 void QmlCommerce::buy(const QString& assetId, int cost, const QString& buyerUsername) {
@@ -69,7 +69,7 @@ void QmlCommerce::setPassphrase(const QString& passphrase) {
 void QmlCommerce::getPassphraseSetupStatus() {
     emit passphraseSetupStatusResult(false);
 }
-void QmlCommerce::getKeyFilePath() {
+void QmlCommerce::getKeyFilePathIfExists() {
     auto wallet = DependencyManager::get<Wallet>();
-    wallet->getKeyFilePath();
+    wallet->sendKeyFilePathIfExists();
 }

--- a/interface/src/commerce/QmlCommerce.h
+++ b/interface/src/commerce/QmlCommerce.h
@@ -36,7 +36,7 @@ signals:
     void securityImageResult(bool exists);
     void loginStatusResult(bool isLoggedIn);
     void passphraseSetupStatusResult(bool passphraseIsSetup);
-    void keyFilePathResult(const QString& path);
+    void keyFilePathIfExistsResult(const QString& path);
 
 protected:
     Q_INVOKABLE void buy(const QString& assetId, int cost, const QString& buyerUsername = "");
@@ -47,7 +47,7 @@ protected:
     Q_INVOKABLE void getLoginStatus();
     Q_INVOKABLE void setPassphrase(const QString& passphrase);
     Q_INVOKABLE void getPassphraseSetupStatus();
-    Q_INVOKABLE void getKeyFilePath();
+    Q_INVOKABLE void getKeyFilePathIfExists();
 };
 
 #endif // hifi_QmlCommerce_h

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -359,6 +359,7 @@ bool Wallet::createIfNeeded() {
 bool Wallet::generateKeyPair() {
     qCInfo(commerce) << "Generating keypair.";
     auto keyPair = generateRSAKeypair();
+    sendKeyFilePathIfExists();
     QString oldKey = _publicKeys.count() == 0 ? "" : _publicKeys.last();
     QString key = keyPair.first->toBase64();
     _publicKeys.push_back(key);
@@ -471,6 +472,12 @@ void Wallet::getSecurityImage() {
         emit securityImageResult(false);
     }
 }
-void Wallet::getKeyFilePath() {
-    emit keyFilePathResult(keyFilePath());
+void Wallet::sendKeyFilePathIfExists() {
+    QString filePath(keyFilePath());
+    QFileInfo fileInfo(filePath);
+    if (fileInfo.exists()) {
+        emit keyFilePathIfExistsResult(filePath);
+    } else {
+        emit keyFilePathIfExistsResult("");
+    }
 }

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -30,7 +30,7 @@ public:
     QString signWithKey(const QByteArray& text, const QString& key);
     void chooseSecurityImage(const QString& imageFile);
     void getSecurityImage();
-    void getKeyFilePath();
+    void sendKeyFilePathIfExists();
 
     void setSalt(const QByteArray& salt) { _salt = salt; }
     QByteArray getSalt() { return _salt; }
@@ -40,7 +40,7 @@ public:
 
 signals:
     void securityImageResult(bool exists) ;
-    void keyFilePathResult(const QString& path);
+    void keyFilePathIfExistsResult(const QString& path);
 
 protected:
     enum SecurityImage {

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -24,12 +24,12 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/makeUserConnection.js",
     "system/tablet-goto.js",
     "system/marketplaces/marketplaces.js",
+    "system/commerce/wallet.js",
     "system/edit.js",
     "system/notifications.js",
     "system/dialTone.js",
     "system/firstPersonHMD.js",
-    "system/tablet-ui/tabletUI.js",
-    "system/commerce/wallet.js"
+    "system/tablet-ui/tabletUI.js"
 ];
 var DEFAULT_SCRIPTS_SEPARATE = [
     "system/controllers/controllerScripts.js",

--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -126,7 +126,8 @@
             button = tablet.addButton({
                 text: buttonName,
                 icon: "icons/tablet-icons/wallet-i.svg",
-                activeIcon: "icons/tablet-icons/wallet-a.svg"
+                activeIcon: "icons/tablet-icons/wallet-a.svg",
+                sortOrder: 10
             });
             button.clicked.connect(onButtonClicked);
             tablet.screenChanged.connect(onTabletScreenChanged);


### PR DESCRIPTION
Don't externally test.

- Better, more accurate handling of key file status
- Removed unnecessary (and erroneous) calls to get balance, securityimage, and key file path in Wallet.qml
- Calls to get balance, securityimage, and key file path are now in the right place, reducing likelihood of bugs
- Added new "initialize" state to Wallet
- Moved Wallet to be after Marketplace in button order

The only problem with fixing these problems is that now you have to restart your client to test the FTUE flow :)