### PR TITLE
Removing tutorial paths for first run experience

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2746,13 +2746,8 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
 
     // Get controller availability
     bool hasHandControllers = false;
-    HandControllerType handControllerType = Vive;
-    if (PluginUtils::isViveControllerAvailable()) {
+    if (PluginUtils::isViveControllerAvailable() || PluginUtils::isOculusTouchControllerAvailable()) {
         hasHandControllers = true;
-        handControllerType = Vive;
-    } else if (PluginUtils::isOculusTouchControllerAvailable()) {
-        hasHandControllers = true;
-        handControllerType = Oculus;
     }
 
     // Check HMD use (may be technically available without being in use)

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2755,26 +2755,18 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
         handControllerType = Oculus;
     }
 
-    // Check tutorial content versioning
-    bool hasTutorialContent = contentVersion >= MIN_CONTENT_VERSION.at(handControllerType);
-
     // Check HMD use (may be technically available without being in use)
     bool hasHMD = PluginUtils::isHMDAvailable();
     bool isUsingHMD = _displayPlugin->isHmd();
     bool isUsingHMDAndHandControllers = hasHMD && hasHandControllers && isUsingHMD;
 
-    Setting::Handle<bool> tutorialComplete{ "tutorialComplete", false };
     Setting::Handle<bool> firstRun{ Settings::firstRun, true };
 
     const QString HIFI_SKIP_TUTORIAL_COMMAND_LINE_KEY = "--skipTutorial";
     // Skips tutorial/help behavior, and does NOT clear firstRun setting.
     bool skipTutorial = arguments().contains(HIFI_SKIP_TUTORIAL_COMMAND_LINE_KEY);
-    bool isTutorialComplete = tutorialComplete.get();
-    bool shouldGoToTutorial = isUsingHMDAndHandControllers && hasTutorialContent && !isTutorialComplete && !skipTutorial;
 
     qCDebug(interfaceapp) << "HMD:" << hasHMD << ", Hand Controllers: " << hasHandControllers << ", Using HMD: " << isUsingHMDAndHandControllers;
-    qCDebug(interfaceapp) << "Tutorial version:" << contentVersion << ", sufficient:" << hasTutorialContent <<
-        ", complete:" << isTutorialComplete << ", should go:" << shouldGoToTutorial;
 
     // when --url in command line, teleport to location
     const QString HIFI_URL_COMMAND_LINE_KEY = "--url";
@@ -2784,39 +2776,15 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
         addressLookupString = arguments().value(urlIndex + 1);
     }
 
-    const QString TUTORIAL_PATH = "/tutorial_begin";
-
-    static const QString SENT_TO_TUTORIAL = "tutorial";
     static const QString SENT_TO_PREVIOUS_LOCATION = "previous_location";
     static const QString SENT_TO_ENTRY = "entry";
     static const QString SENT_TO_SANDBOX = "sandbox";
 
     QString sentTo;
 
-    if (shouldGoToTutorial) {
-        if (sandboxIsRunning) {
-            qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
-            DependencyManager::get<AddressManager>()->goToLocalSandbox(TUTORIAL_PATH);
-            sentTo = SENT_TO_TUTORIAL;
-        } else {
-            qCDebug(interfaceapp) << "Home sandbox does not appear to be running, going to Entry.";
-            if (firstRun.get()) {
-                showHelp();
-            }
-            if (addressLookupString.isEmpty()) {
-                DependencyManager::get<AddressManager>()->goToEntry();
-                sentTo = SENT_TO_ENTRY;
-            } else {
-                DependencyManager::get<AddressManager>()->loadSettings(addressLookupString);
-                sentTo = SENT_TO_PREVIOUS_LOCATION;
-            }
-        }
-    } else {
-
         // If this is a first run we short-circuit the address passed in
-        if (firstRun.get() && !skipTutorial) {
+        if (firstRun.get()) {
             showHelp();
-            if (isUsingHMDAndHandControllers) {
                 if (sandboxIsRunning) {
                     qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
                     DependencyManager::get<AddressManager>()->goToLocalSandbox();
@@ -2826,16 +2794,12 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
                     DependencyManager::get<AddressManager>()->goToEntry();
                     sentTo = SENT_TO_ENTRY;
                 }
-            } else {
-                DependencyManager::get<AddressManager>()->goToEntry();
-                sentTo = SENT_TO_ENTRY;
-            }
+
         } else {
             qCDebug(interfaceapp) << "Not first run... going to" << qPrintable(addressLookupString.isEmpty() ? QString("previous location") : addressLookupString);
             DependencyManager::get<AddressManager>()->loadSettings(addressLookupString);
             sentTo = SENT_TO_PREVIOUS_LOCATION;
         }
-    }
 
     UserActivityLogger::getInstance().logAction("startup_sent_to", {
         { "sent_to", sentTo },
@@ -2844,18 +2808,10 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
         { "has_hand_controllers", hasHandControllers },
         { "is_using_hmd", isUsingHMD },
         { "is_using_hmd_and_hand_controllers", isUsingHMDAndHandControllers },
-        { "content_version", contentVersion },
-        { "is_tutorial_complete", isTutorialComplete },
-        { "has_tutorial_content", hasTutorialContent },
-        { "should_go_to_tutorial", shouldGoToTutorial }
+        { "content_version", contentVersion }
     });
 
     _connectionMonitor.init();
-
-    // After all of the constructor is completed, then set firstRun to false.
-    if (!skipTutorial) {
-        firstRun.set(false);
-    }
 }
 
 bool Application::importJSONFromURL(const QString& urlString) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2762,10 +2762,6 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
 
     Setting::Handle<bool> firstRun{ Settings::firstRun, true };
 
-    const QString HIFI_SKIP_TUTORIAL_COMMAND_LINE_KEY = "--skipTutorial";
-    // Skips tutorial/help behavior, and does NOT clear firstRun setting.
-    bool skipTutorial = arguments().contains(HIFI_SKIP_TUTORIAL_COMMAND_LINE_KEY);
-
     qCDebug(interfaceapp) << "HMD:" << hasHMD << ", Hand Controllers: " << hasHandControllers << ", Using HMD: " << isUsingHMDAndHandControllers;
 
     // when --url in command line, teleport to location

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2776,15 +2776,16 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
         // If this is a first run we short-circuit the address passed in
         if (firstRun.get()) {
             showHelp();
-                if (sandboxIsRunning) {
-                    qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
-                    DependencyManager::get<AddressManager>()->goToLocalSandbox();
-                    sentTo = SENT_TO_SANDBOX;
-                } else {
-                    qCDebug(interfaceapp) << "Home sandbox does not appear to be running, going to Entry.";
-                    DependencyManager::get<AddressManager>()->goToEntry();
-                    sentTo = SENT_TO_ENTRY;
-                }
+            if (sandboxIsRunning) {
+                qCDebug(interfaceapp) << "Home sandbox appears to be running, going to Home.";
+                DependencyManager::get<AddressManager>()->goToLocalSandbox();
+                sentTo = SENT_TO_SANDBOX;
+            } else {
+                qCDebug(interfaceapp) << "Home sandbox does not appear to be running, going to Entry.";
+                DependencyManager::get<AddressManager>()->goToEntry();
+                sentTo = SENT_TO_ENTRY;
+            }
+            firstRun.set(false);
 
         } else {
             qCDebug(interfaceapp) << "Not first run... going to" << qPrintable(addressLookupString.isEmpty() ? QString("previous location") : addressLookupString);


### PR DESCRIPTION
This change is to align with the modification of the existing sandbox default content set to remove the tea house tutorial and to land the user directly on the builder grid, which will be moved to /0,-10,0 as part of a content set update that will go with this PR. 
