### PR TITLE
Fix loading standalone baked textures from Asset Server

### DIFF
--- a/libraries/baking/src/TextureBaker.cpp
+++ b/libraries/baking/src/TextureBaker.cpp
@@ -43,6 +43,14 @@ void TextureBaker::bake() {
     loadTexture();
 }
 
+const QStringList TextureBaker::getSupportedFormats() {
+    auto formats = QImageReader::supportedImageFormats();
+    QStringList stringFormats;
+    std::transform(formats.begin(), formats.end(), std::back_inserter(stringFormats),
+                   [](auto& format) -> QString { return format; });
+    return stringFormats;
+}
+
 void TextureBaker::loadTexture() {
     // check if the texture is local or first needs to be downloaded
     if (_textureURL.isLocalFile()) {

--- a/libraries/baking/src/TextureBaker.h
+++ b/libraries/baking/src/TextureBaker.h
@@ -15,6 +15,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QUrl>
 #include <QtCore/QRunnable>
+#include <QImageReader>
 
 #include <image/Image.h>
 
@@ -27,6 +28,8 @@ class TextureBaker : public Baker {
 
 public:
     TextureBaker(const QUrl& textureURL, image::TextureUsage::Type textureType, const QDir& outputDirectory);
+
+    static const QStringList getSupportedFormats();
 
     const QByteArray& getOriginalTexture() const { return _originalTexture; }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -75,6 +75,8 @@ protected:
 
     virtual void downloadFinished(const QByteArray& data) override;
 
+    bool handleFailedRequest(ResourceRequest::Result result) override;
+
     Q_INVOKABLE void loadContent(const QByteArray& content);
     Q_INVOKABLE void setImage(gpu::TexturePointer texture, int originalWidth, int originalHeight);
 

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -687,8 +687,9 @@ void Resource::makeRequest() {
         PROFILE_ASYNC_END(resource, "Resource:" + getType(), QString::number(_requestID));
         return;
     }
-    
+
     _request->setByteRange(_requestByteRange);
+    _request->setFailOnRedirect(_shouldFailOnRedirect);
 
     qCDebug(resourceLog).noquote() << "Starting request for:" << _url.toDisplayString();
     emit loading();

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -449,12 +449,13 @@ protected:
     Q_INVOKABLE void allReferencesCleared();
 
     /// Return true if the resource will be retried
-    bool handleFailedRequest(ResourceRequest::Result result);
+    virtual bool handleFailedRequest(ResourceRequest::Result result);
 
     QUrl _url;
     QUrl _effectiveBaseURL{ _url };
     QUrl _activeUrl;
     ByteRange _requestByteRange;
+    bool _shouldFailOnRedirect { false };
 
     // _loaded == true means we are in a loaded and usable state. It is possible that there may still be
     // active requests/loading while in this state. Example: Progressive KTX downloads, where higher resolution

--- a/libraries/networking/src/ResourceRequest.h
+++ b/libraries/networking/src/ResourceRequest.h
@@ -57,7 +57,8 @@ public:
         AccessDenied,
         InvalidByteRange,
         InvalidURL,
-        NotFound
+        NotFound,
+        RedirectFail
     };
     Q_ENUM(Result)
 
@@ -70,6 +71,7 @@ public:
     bool loadedFromCache() const { return _loadedFromCache; }
     bool getRangeRequestSuccessful() const { return _rangeRequestSuccessful; }
     bool getTotalSizeOfResource() const { return _totalSizeOfResource; }
+    void setFailOnRedirect(bool failOnRedirect) { _failOnRedirect = failOnRedirect; }
 
     void setCacheEnabled(bool value) { _cacheEnabled = value; }
     void setByteRange(ByteRange byteRange) { _byteRange = byteRange; }
@@ -89,6 +91,7 @@ protected:
     State _state { NotStarted };
     Result _result;
     QByteArray _data;
+    bool _failOnRedirect { false };
     bool _cacheEnabled { true };
     bool _loadedFromCache { false };
     ByteRange _byteRange;


### PR DESCRIPTION
NetworkTexture was not properly handling redirected ATP files. For
instance, if going from .jpg -> .ktx, the NetworkTexture class needs to
be aware of this so it can stop the current request and make multiple
requests for the individual mip levels.