### PR TITLE
security image shows up in every qml engine now

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -183,7 +183,6 @@
 #include "ui/UpdateDialog.h"
 #include "ui/overlays/Overlays.h"
 #include "ui/DomainConnectionModel.h"
-#include "ui/ImageProvider.h"
 #include "Util.h"
 #include "InterfaceParentFinder.h"
 #include "ui/OctreeStatsProvider.h"
@@ -264,7 +263,7 @@ private:
         switch ((int)event->type()) {
             case ApplicationEvent::Render:
                 render();
-                // Ensure we never back up the render events.  Each render should be triggered only in response 
+                // Ensure we never back up the render events.  Each render should be triggered only in response
                 // to the NEXT render event after the last render occured
                 QCoreApplication::removePostedEvents(this, ApplicationEvent::Render);
                 return true;
@@ -2243,8 +2242,6 @@ void Application::initializeUi() {
         qApp->quit();
     });
 
-    // register the pixmap image provider (used only for security image, for now)
-    engine->addImageProvider(ImageProvider::PROVIDER_NAME, new ImageProvider());
 
     setupPreferences();
 
@@ -5164,7 +5161,7 @@ void Application::update(float deltaTime) {
         }
     } else {
         // update the rendering without any simulation
-        getEntities()->update(false); 
+        getEntities()->update(false);
     }
 
     // AvatarManager update

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -23,6 +23,8 @@ class Wallet : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
 
 public:
+
+    ~Wallet();
     // These are currently blocking calls, although they might take a moment.
     bool createIfNeeded();
     bool generateKeyPair();
@@ -59,6 +61,7 @@ private:
     QByteArray _salt {"iamsalt!"};
     QString* _passphrase { new QString("pwd") };
 
+    void updateImageProvider();
     bool encryptFile(const QString& inputFilePath, const QString& outputFilePath);
     bool decryptFile(const QString& inputFilePath, unsigned char** outputBufferPtr, int* outputBufferLen);
 };

--- a/libraries/ui/src/ui/ImageProvider.cpp
+++ b/libraries/ui/src/ui/ImageProvider.cpp
@@ -19,10 +19,8 @@ QReadWriteLock ImageProvider::_rwLock;
 QPixmap* ImageProvider::_securityImage = nullptr;
 
 void ImageProvider::setSecurityImage(QPixmap* pixmap) {
-    // we are responsible for the pointer so no need to copy
-    // but we do need to delete the old one.
-    QWriteLocker lock(&_rwLock);
     // no need to delete old one, that is managed by the wallet
+    QWriteLocker lock(&_rwLock);
     _securityImage = pixmap;
 }
 

--- a/libraries/ui/src/ui/ImageProvider.cpp
+++ b/libraries/ui/src/ui/ImageProvider.cpp
@@ -10,13 +10,26 @@
 //
 
 #include "ImageProvider.h"
-#include <QDebug>
+
+#include <QReadLocker>
+#include <QWriteLocker>
 
 const QString ImageProvider::PROVIDER_NAME = "security";
+QReadWriteLock ImageProvider::_rwLock;
+QPixmap* ImageProvider::_securityImage = nullptr;
+
+void ImageProvider::setSecurityImage(QPixmap* pixmap) {
+    // we are responsible for the pointer so no need to copy
+    // but we do need to delete the old one.
+    QWriteLocker lock(&_rwLock);
+    // no need to delete old one, that is managed by the wallet
+    _securityImage = pixmap;
+}
 
 QPixmap ImageProvider::requestPixmap(const QString& id, QSize* size, const QSize& requestedSize) {
 
     // adjust the internal pixmap to have the requested size
+    QReadLocker lock(&_rwLock);
     if (id == "securityImage" && _securityImage) {
         *size = _securityImage->size();
         if (requestedSize.width() > 0 && requestedSize.height() > 0) {

--- a/libraries/ui/src/ui/ImageProvider.h
+++ b/libraries/ui/src/ui/ImageProvider.h
@@ -13,6 +13,7 @@
 #define hifi_ImageProvider_h
 
 #include <QQuickImageProvider>
+#include <QReadWriteLock>
 
 class ImageProvider: public QQuickImageProvider {
 public:
@@ -22,10 +23,10 @@ public:
 
     QPixmap requestPixmap(const QString& id, QSize* size, const QSize& requestedSize) override;
 
-    void setSecurityImage(QPixmap* pixmap) { _securityImage = pixmap; }
-
+    void setSecurityImage(QPixmap* pixmap);
 protected:
-    QPixmap* _securityImage { nullptr };
+    static QReadWriteLock _rwLock;
+    static QPixmap* _securityImage;
 
 };
 


### PR DESCRIPTION
When we create a new QQmlEngine, we give it an image provider.  The image provider now keeps a static pointer to the image so calling setSecurityImage on any one of the providers changes it on all of them.  Also added read/write locks, which really were needed even if there was just one copy.  And, we don't leak the pixmap when the wallet is destroyed.