### PR TITLE
Remove most dependencies on 'onVisibleChanged'

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -28,14 +28,14 @@ Rectangle {
     property string activeView: "initialize";
     property bool purchasesReceived: false;
     property bool balanceReceived: false;
+    property bool securityImageResultReceived: false;
+    property bool keyFilePathIfExistsResultReceived: false;
     property string itemId: "";
     property string itemHref: "";
     property double balanceAfterPurchase: 0;
     property bool alreadyOwned: false;
     property int itemPriceFull: 0;
     property bool itemIsJson: true;
-    property bool securityImageResultReceived: false;
-    property bool keyFilePathIfExistsResultReceived: false;
     // Style
     color: hifi.colors.baseGray;
     Hifi.QmlCommerce {
@@ -48,6 +48,8 @@ Rectangle {
                 root.activeView = "initialize";
                 commerce.getSecurityImage();
                 commerce.getKeyFilePathIfExists();
+                commerce.balance();
+                commerce.inventory();
             }
         }
 
@@ -190,6 +192,10 @@ Rectangle {
         color: hifi.colors.baseGray;
 
         Component.onCompleted: {
+            securityImageResultReceived = false;
+            purchasesReceived = false;
+            balanceReceived = false;
+            keyFilePathIfExistsResultReceived = false;
             commerce.getLoginStatus();
         }
     }
@@ -310,13 +316,6 @@ Rectangle {
         anchors.bottom: parent.bottom;
         anchors.left: parent.left;
         anchors.right: parent.right;
-
-        onVisibleChanged: {
-            if (visible) {
-                commerce.balance();
-                commerce.inventory();
-            }
-        }
 
         //
         // ITEM DESCRIPTION START

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -29,7 +29,7 @@ Rectangle {
     property string referrerURL: "";
     property bool securityImageResultReceived: false;
     property bool keyFilePathIfExistsResultReceived: false;
-    property bool inventoryReceived: false;
+    property bool purchasesReceived: false;
     property bool punctuationMode: false;
     // Style
     color: hifi.colors.baseGray;
@@ -43,6 +43,7 @@ Rectangle {
                 root.activeView = "initialize";
                 commerce.getSecurityImage();
                 commerce.getKeyFilePathIfExists();
+                commerce.inventory();
             }
         }
 
@@ -69,7 +70,7 @@ Rectangle {
         }
 
         onInventoryResult: {
-            inventoryReceived = true;
+            purchasesReceived = true;
             if (result.status !== 'success') {
                 console.log("Failed to get purchases", result.message);
             } else {
@@ -161,6 +162,9 @@ Rectangle {
         color: hifi.colors.baseGray;
 
         Component.onCompleted: {
+            securityImageResultReceived = false;
+            purchasesReceived = false;
+            keyFilePathIfExistsResultReceived = false;
             commerce.getLoginStatus();
         }
     }
@@ -283,14 +287,7 @@ Rectangle {
         anchors.top: titleBarContainer.bottom;
         anchors.topMargin: 8;
         anchors.bottom: actionButtonsContainer.top;
-        anchors.bottomMargin: 8;        
-
-        onVisibleChanged: {
-            if (visible) {
-                commerce.balance();
-                commerce.inventory();
-            }
-        }
+        anchors.bottomMargin: 8;
         
         //
         // FILTER BAR START
@@ -378,7 +375,7 @@ Rectangle {
 
         Item {
             id: noPurchasesAlertContainer;
-            visible: !purchasesContentsList.visible && root.inventoryReceived;
+            visible: !purchasesContentsList.visible && root.purchasesReceived;
             anchors.top: filterBarContainer.bottom;
             anchors.topMargin: 12;
             anchors.left: parent.left;

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -45,6 +45,10 @@ Item {
         }
     }
 
+    // This will cause a bug -- if you bring up passphrase selection in HUD mode while
+    // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
+    // HMD preview will stay off.
+    // TODO: Fix this unlikely bug
     onVisibleChanged: {
         if (visible) {
             passphraseField.focus = true;
@@ -68,12 +72,6 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: "passphrase";
-
-        onVisibleChanged: {
-            if (visible) {
-                text = "";
-            }
-        }
 
         onFocusChanged: {
             if (focus) {
@@ -104,12 +102,6 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: "re-enter passphrase";
-
-        onVisibleChanged: {
-            if (visible) {
-                text = "";
-            }
-        }
 
         onFocusChanged: {
             if (focus) {
@@ -279,6 +271,12 @@ Item {
 
     function setErrorText(text) {
         errorText.text = text;
+    }
+
+    function clearPassphraseFields() {
+        passphraseField.text = "";
+        passphraseFieldAgain.text = "";
+        setErrorText("");
     }
 
     signal sendMessageToLightbox(var msg);

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelectionLightbox.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelectionLightbox.qml
@@ -27,12 +27,6 @@ Rectangle {
     // Style
     color: hifi.colors.baseGray;
 
-    onVisibleChanged: {
-        if (visible) {
-            root.resetSubmitButton();
-        }
-    }
-
     //
     // SECURE PASSPHRASE SELECTION START
     //
@@ -174,5 +168,9 @@ Rectangle {
     function resetSubmitButton() {
         passphraseSubmitButton.enabled = true;
         passphraseSubmitButton.text = "Submit";
+    }
+
+    function clearPassphraseFields() {
+        passphraseSelection.clearPassphraseFields();
     }
 }

--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
@@ -24,14 +24,13 @@ Item {
     HifiConstants { id: hifi; }
 
     id: root;
-
-    Hifi.QmlCommerce {
-        id: commerce;
-    }
-
+    
+    // This will cause a bug -- if you bring up security image selection in HUD mode while
+    // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
+    // HMD preview will stay off.
+    // TODO: Fix this unlikely bug
     onVisibleChanged: {
         if (visible) {
-            commerce.getSecurityImage();
             sendSignalToWallet({method: 'disableHmdPreview'});
         } else {
             sendSignalToWallet({method: 'maybeEnableHmdPreview'});

--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelectionLightbox.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelectionLightbox.qml
@@ -28,12 +28,6 @@ Rectangle {
     // Style
     color: hifi.colors.baseGray;
 
-    onVisibleChanged: {
-        if (visible) {
-            root.resetSubmitButton();
-        }
-    }
-
     Hifi.QmlCommerce {
         id: commerce;
 

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -277,6 +277,7 @@ Rectangle {
             onSendSignalToWallet: {
                 if (msg.method === 'walletSecurity_changePassphrase') {
                     passphraseSelectionLightbox.visible = true;
+                    passphraseSelectionLightbox.clearPassphraseFields();
                 } else if (msg.method === 'walletSecurity_changeSecurityImage') {
                     securityImageSelectionLightbox.visible = true;
                 }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetupLightbox.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetupLightbox.qml
@@ -197,6 +197,7 @@ Rectangle {
                     commerce.chooseSecurityImage(securityImagePath);
                     securityImageContainer.visible = false;
                     choosePassphraseContainer.visible = true;
+                    passphraseSelection.clearPassphraseFields();
                 }
             }
         }


### PR DESCRIPTION
Don't formally test.

Using `onVisibleChanged` in some critical flow areas of Commerce causes problems. For example, if the user is in HUD mode, has a QML window up, and starts to drive, `onVisibleChanged` fires on the visible components as the HUD fades out.

There are still some instances where `onVisibleChange` fires unnecessarily, but the worst that happens in those cases is that the user gets some more up-to-date information about their balance/security image:)