### PR TITLE
Create OpenGL 3.3 context when >= 4.3 isn't available.

### DIFF
--- a/libraries/gl/src/gl/Context.cpp
+++ b/libraries/gl/src/gl/Context.cpp
@@ -233,6 +233,8 @@ void Context::create() {
             _version = 0x0405;
         } else if (glewIsSupported("GL_VERSION_4_3")) {
             _version = 0x0403;
+        } else if (glewIsSupported("GL_VERSION_3_3")) {
+            _version = 0x0303;
         }
         glGetError();
         wglMakeCurrent(0, 0);

--- a/libraries/gl/src/gl/OpenGLVersionChecker.cpp
+++ b/libraries/gl/src/gl/OpenGLVersionChecker.cpp
@@ -22,7 +22,8 @@
 #include "GLHelpers.h"
 
 // Minimum gl version required is 4.1
-#define MINIMUM_GL_VERSION 0x0401
+// [blitter] I changed this to 3.3 and hifi boots up and is usable. Beats crashing when trying to create a 4.x context.
+#define MINIMUM_GL_VERSION 0x0303
 
 OpenGLVersionChecker::OpenGLVersionChecker(int& argc, char** argv) :
     QApplication(argc, argv)


### PR DESCRIPTION
HiFi won't run at all on my 2010 MacBook Pro without this change. My laptop sports a GTX 330m which does not support OpenGL 4 in Windows 10. Adding a code path to instead create an OpenGL 3.3 context will allow HiFi to not only launch but be usable, albeit slowly on my system. If there are known incompatibilities when using a 3.3 context, they were not apparent to me in the 30 minutes I spent walking around dev-welcome.