### PR TITLE
make building tools (besides 'scribe') optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,8 @@ if (BUILD_CLIENT OR BUILD_SERVER)
     add_subdirectory(plugins)
 endif()
 
-if (BUILD_TOOLS)
-  add_subdirectory(tools)
-endif()
+# BUILD_TOOLS option will be handled inside the tools's CMakeLists.txt because 'scribe' tool is required for build anyway
+add_subdirectory(tools)
 
 if (BUILD_TESTS)
     add_subdirectory(tests)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,23 +2,25 @@
 add_subdirectory(scribe)
 set_target_properties(scribe PROPERTIES FOLDER "Tools")
 
-add_subdirectory(udt-test)
-set_target_properties(udt-test PROPERTIES FOLDER "Tools")
+if (BUILD_TOOLS)
+  add_subdirectory(udt-test)
+  set_target_properties(udt-test PROPERTIES FOLDER "Tools")
 
-add_subdirectory(vhacd-util)
-set_target_properties(vhacd-util PROPERTIES FOLDER "Tools")
+  add_subdirectory(vhacd-util)
+  set_target_properties(vhacd-util PROPERTIES FOLDER "Tools")
 
-add_subdirectory(ice-client)
-set_target_properties(ice-client PROPERTIES FOLDER "Tools")
+  add_subdirectory(ice-client)
+  set_target_properties(ice-client PROPERTIES FOLDER "Tools")
 
-add_subdirectory(ac-client)
-set_target_properties(ac-client PROPERTIES FOLDER "Tools")
+  add_subdirectory(ac-client)
+  set_target_properties(ac-client PROPERTIES FOLDER "Tools")
 
-add_subdirectory(skeleton-dump)
-set_target_properties(skeleton-dump PROPERTIES FOLDER "Tools")
+  add_subdirectory(skeleton-dump)
+  set_target_properties(skeleton-dump PROPERTIES FOLDER "Tools")
 
-add_subdirectory(atp-client)
-set_target_properties(atp-client PROPERTIES FOLDER "Tools")
+  add_subdirectory(atp-client)
+  set_target_properties(atp-client PROPERTIES FOLDER "Tools")
 
-add_subdirectory(oven)
-set_target_properties(oven PROPERTIES FOLDER "Tools")
+  add_subdirectory(oven)
+  set_target_properties(oven PROPERTIES FOLDER "Tools")
+endif()


### PR DESCRIPTION
Again, purely to speedup dev builds. Unfortunately it turned out 'scribe' tool is required for build so it is not excluded at the moment. 