### PR TITLE
Fix access to menu on background thread

### DIFF
--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -51,7 +51,6 @@ protected:
     virtual void postPreview() {};
     virtual void updatePresentPose();
 
-    bool beginFrameRender(uint32_t frameIndex) override;
     bool internalActivate() override;
     void internalDeactivate() override;
     void compositeOverlay() override;
@@ -87,7 +86,6 @@ private:
     ivec4 getViewportForSourceSize(const uvec2& size) const;
     float getLeftCenterPixel() const;
 
-    bool _disablePreviewItemAdded { false };
     bool _monoPreview { true };
     bool _clearPreviewFlag { false };
     gpu::TexturePointer _previewTexture;


### PR DESCRIPTION
The HMD display plugin base class is attempting to modify the menu from a function that now runs on the render thread.  This PR migrates it to the main thread in `internalActivate` but adds a delay to allow the `_vsyncEnabled` variable to be populated.  Kind of a hack, but better than debug asserts / crashes.  

## Testing

No application behavior should be changed, other than less crashing.  If your video card supports no-vsync modes then you should still have a menu item when using a VR display plugin that allows you to enable the on-screen preview.  