### PR TITLE
Cleanup CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,254 +4,81 @@ else()
   cmake_minimum_required(VERSION 3.2)
 endif()
 
-if (USE_ANDROID_TOOLCHAIN)
-  set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/android/android.toolchain.cmake")
-  set(ANDROID_NATIVE_API_LEVEL 19)
-  set(ANDROID_TOOLCHAIN_NAME arm-linux-androideabi-clang3.5)
-  set(ANDROID_STL c++_shared)
-endif ()
-
-if (WIN32)
-  cmake_policy(SET CMP0020 NEW)
-endif (WIN32)
-
-if (POLICY CMP0043)
-  cmake_policy(SET CMP0043 OLD)
-endif ()
-
-if (POLICY CMP0042)
-  cmake_policy(SET CMP0042 OLD)
-endif ()
-
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMakeTargets")
+include("cmake/init.cmake")
 
 project(hifi)
-add_definitions(-DGLM_FORCE_RADIANS)
-set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
-find_package( Threads )
+include("cmake/compiler.cmake")
 
-if (WIN32)
-  if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-    message( FATAL_ERROR "Only 64 bit builds supported." )
-  endif()
-
-  add_definitions(-DNOMINMAX -D_CRT_SECURE_NO_WARNINGS)
-
-  if (NOT WINDOW_SDK_PATH)
-    set(DEBUG_DISCOVERED_SDK_PATH TRUE)
-  endif()
-
-  # sets path for Microsoft SDKs
-  # if you get build error about missing 'glu32' this path is likely wrong
-  if (MSVC_VERSION GREATER_EQUAL 1910) # VS 2017
-    set(WINDOW_SDK_PATH "C:/Program Files (x86)/Windows Kits/10/Lib/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/x64" CACHE PATH "Windows SDK PATH")
-  elseif (MSVC_VERSION GREATER_EQUAL 1800) # VS 2013
-    set(WINDOW_SDK_PATH "C:\\Program Files (x86)\\Windows Kits\\8.1\\Lib\\winv6.3\\um\\${WINDOW_SDK_FOLDER}" CACHE PATH "Windows SDK PATH")
-  else()
-    message( FATAL_ERROR "Visual Studio 2013 or higher required." )
-  endif()
-
-  if (DEBUG_DISCOVERED_SDK_PATH)
-    message(STATUS "The discovered Windows SDK path is ${WINDOW_SDK_PATH}")
-  endif ()
-
-  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${WINDOW_SDK_PATH})
-  # /wd4351 disables warning C4351: new behavior: elements of array will be default initialized
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /wd4351")
-  # /LARGEADDRESSAWARE enables 32-bit apps to use more than 2GB of memory.
-  # Caveats: http://stackoverflow.com/questions/2288728/drawbacks-of-using-largeaddressaware-for-32-bit-windows-executables
-  # TODO: Remove when building 64-bit.
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
-  # always produce symbols as PDB files
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:REF /OPT:ICF")
-else ()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-strict-aliasing -Wno-unused-parameter")
-  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -Woverloaded-virtual -Wdouble-promotion")
-      if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.1") # gcc 5.1 and on have suggest-override
-          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
-      endif ()
-  endif ()
-endif(WIN32)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.3")
-    # GLM 0.9.8 on Ubuntu 14 (gcc 4.4) has issues with the simd declarations
-    add_definitions(-DGLM_FORCE_PURE)
-  endif()
+if (NOT DEFINED SERVER_ONLY)
+  set(SERVER_ONLY 0)
 endif()
 
-if (NOT ANDROID)
-  if ((NOT MSVC12) AND (NOT MSVC14))
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-    CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-
-    if (COMPILER_SUPPORTS_CXX11)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    elseif(COMPILER_SUPPORTS_CXX0X)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-    else()
-      message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-    endif()
-  endif ()
-else ()
-  # assume that the toolchain selected for android has C++11 support
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif ()
-
-if (APPLE)
-  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
-  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --stdlib=libc++")
-endif ()
-
-if (NOT ANDROID_LIB_DIR)
-  set(ANDROID_LIB_DIR $ENV{ANDROID_LIB_DIR})
-endif ()
-
-if (ANDROID)
-  if (NOT ANDROID_QT_CMAKE_PREFIX_PATH)
-    set(QT_CMAKE_PREFIX_PATH ${ANDROID_LIB_DIR}/Qt/5.5/android_armv7/lib/cmake)
-  else ()
-    set(QT_CMAKE_PREFIX_PATH ${ANDROID_QT_CMAKE_PREFIX_PATH})
-  endif ()
-
-  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
-
-  if (ANDROID_LIB_DIR)
-    list(APPEND CMAKE_FIND_ROOT_PATH ${ANDROID_LIB_DIR})
-  endif ()
-else ()
-  if (NOT QT_CMAKE_PREFIX_PATH)
-    set(QT_CMAKE_PREFIX_PATH $ENV{QT_CMAKE_PREFIX_PATH})
-  endif ()
-  if (NOT QT_CMAKE_PREFIX_PATH)
-    get_filename_component(QT_CMAKE_PREFIX_PATH "${Qt5_DIR}/.." REALPATH)
-  endif ()
-endif ()
-
-set(QT_DIR $ENV{QT_DIR})
-
-if (WIN32)
-    if (NOT EXISTS ${QT_CMAKE_PREFIX_PATH})
-        message(FATAL_ERROR "Could not determine QT_CMAKE_PREFIX_PATH.")
-    endif ()
+if (ANDROID OR UWP)
+    set(MOBILE 1)
+else()
+    set(MOBILE 0)
 endif()
 
-# figure out where the qt dir is
-get_filename_component(QT_DIR "${QT_CMAKE_PREFIX_PATH}/../../" ABSOLUTE)
+if (ANDROID OR UWP)
+    option(BUILD_SERVER "Build server components" OFF)
+    option(BUILD_TOOLS "Build tools" OFF)
+else()
+    option(BUILD_SERVER "Build server components" ON)
+    option(BUILD_TOOLS "Build tools" ON)
+endif()
 
-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QT_CMAKE_PREFIX_PATH})
+if (SERVER_ONLY)
+    option(BUILD_CLIENT "Build client components" OFF)
+    option(BUILD_TESTS "Build tests" OFF)
+else()
+    option(BUILD_CLIENT "Build client components" ON)
+    option(BUILD_TESTS "Build tests" ON)
+endif()
 
-if (APPLE)
+option(BUILD_INSTALLER "Build installer" ON)
 
-  exec_program(sw_vers ARGS -productVersion  OUTPUT_VARIABLE OSX_VERSION)
-  string(REGEX MATCH "^[0-9]+\\.[0-9]+" OSX_VERSION ${OSX_VERSION})
-  message(STATUS "Detected OS X version = ${OSX_VERSION}")
+MESSAGE(STATUS "Build server:    " ${BUILD_SERVER})
+MESSAGE(STATUS "Build client:    " ${BUILD_CLIENT})
+MESSAGE(STATUS "Build tests:     " ${BUILD_TESTS})
+MESSAGE(STATUS "Build tools:     " ${BUILD_TOOLS})
+MESSAGE(STATUS "Build installer: " ${BUILD_INSTALLER})
 
-  set(OSX_SDK "${OSX_VERSION}" CACHE String "OS X SDK version to look for inside Xcode bundle or at OSX_SDK_PATH")
+if (UNIX AND DEFINED ENV{HIFI_MEMORY_DEBUGGING})
+    MESSAGE(STATUS "Memory debugging is enabled")
+endif()
 
-  # set our OS X deployment target
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.8)
-
-  # find the SDK path for the desired SDK
-  find_path(
-    _OSX_DESIRED_SDK_PATH
-    NAME MacOSX${OSX_SDK}.sdk
-    HINTS ${OSX_SDK_PATH}
-    PATHS /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
-          /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
-  )
-
-  if (NOT _OSX_DESIRED_SDK_PATH)
-    message(STATUS "Could not find OS X ${OSX_SDK} SDK. Will fall back to default. If you want a specific SDK, please pass OSX_SDK and optionally OSX_SDK_PATH to CMake.")
-  else ()
-    message(STATUS "Found OS X ${OSX_SDK} SDK at ${_OSX_DESIRED_SDK_PATH}/MacOSX${OSX_SDK}.sdk")
-
-    # set that as the SDK to use
-    set(CMAKE_OSX_SYSROOT ${_OSX_DESIRED_SDK_PATH}/MacOSX${OSX_SDK}.sdk)
-  endif ()
-
-endif ()
-
-# Hide automoc folders (for IDEs)
-set(AUTOGEN_TARGETS_FOLDER "hidden/generated")
-
-# Find includes in corresponding build directories
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-# Instruct CMake to run moc automatically when needed.
-set(CMAKE_AUTOMOC ON)
-# Instruct CMake to run rcc automatically when needed
-set(CMAKE_AUTORCC ON)
-
-set(HIFI_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries")
-
-# setup for find modules
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
-
-if (CMAKE_BUILD_TYPE)
-  string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
-else ()
-  set(UPPER_CMAKE_BUILD_TYPE DEBUG)
-endif ()
-
-set(HF_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-set(MACRO_DIR "${HF_CMAKE_DIR}/macros")
-set(EXTERNAL_PROJECT_DIR "${HF_CMAKE_DIR}/externals")
-
-file(GLOB HIFI_CUSTOM_MACROS "cmake/macros/*.cmake")
-foreach(CUSTOM_MACRO ${HIFI_CUSTOM_MACROS})
-  include(${CUSTOM_MACRO})
-endforeach()
+#
+# Helper projects
+#
+file(GLOB_RECURSE CMAKE_SRC cmake/*.cmake cmake/CMakeLists.txt)
+add_custom_target(cmake SOURCES ${CMAKE_SRC})
+GroupSources("cmake")
 
 file(GLOB_RECURSE JS_SRC scripts/*.js unpublishedScripts/*.js)
 add_custom_target(js SOURCES ${JS_SRC})
 GroupSources("scripts")
 GroupSources("unpublishedScripts")
 
-if (UNIX)
-   install(
-   DIRECTORY "${CMAKE_SOURCE_DIR}/scripts"
-   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/interface
-   COMPONENT ${CLIENT_COMPONENT}
-   )
-endif()
+# Locate the required Qt build on the filesystem
+setup_qt()
+list(APPEND CMAKE_PREFIX_PATH "${QT_CMAKE_PREFIX_PATH}")
 
-if (ANDROID)
-  file(GLOB ANDROID_CUSTOM_MACROS "cmake/android/*.cmake")
-  foreach(CUSTOM_MACRO ${ANDROID_CUSTOM_MACROS})
-    include(${CUSTOM_MACRO})
-  endforeach()
-endif ()
+find_package( Threads )
+
+add_definitions(-DGLM_FORCE_RADIANS)
+set(HIFI_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries")
 
 set(EXTERNAL_PROJECT_PREFIX "project")
 set_property(DIRECTORY PROPERTY EP_PREFIX ${EXTERNAL_PROJECT_PREFIX})
 setup_externals_binary_dir()
 
 option(USE_NSIGHT "Attempt to find the nSight libraries" 1)
-option(GET_QUAZIP "Get QuaZip library automatically as external project" 1)
-
-
-if (WIN32)
-  add_paths_to_fixup_libs("${QT_DIR}/bin")
-endif ()
-
-if (NOT DEFINED SERVER_ONLY)
-  set(SERVER_ONLY 0)
-endif()
 
 set_packaging_parameters()
 
-option(BUILD_TESTS "Build tests" ON)
-MESSAGE(STATUS "Build tests: " ${BUILD_TESTS})
-
 # add subdirectories for all targets
-if (NOT ANDROID)
+if (BUILD_SERVER)
   add_subdirectory(assignment-client)
   set_target_properties(assignment-client PROPERTIES FOLDER "Apps")
   add_subdirectory(domain-server)
@@ -259,30 +86,36 @@ if (NOT ANDROID)
   add_subdirectory(ice-server)
   set_target_properties(ice-server PROPERTIES FOLDER "Apps")
   add_subdirectory(server-console)
-  if (NOT SERVER_ONLY)
+endif()
+
+if (BUILD_CLIENT)
     add_subdirectory(interface)
     set_target_properties(interface PROPERTIES FOLDER "Apps")
-    if (BUILD_TESTS)
-      add_subdirectory(tests)
+    if (ANDROID)
+        add_subdirectory(gvr-interface)
+        set_target_properties(gvr-interface PROPERTIES FOLDER "Apps")
     endif()
-  endif()
-  add_subdirectory(plugins)
+endif()
+
+if (BUILD_CLIENT OR BUILD_SERVER)
+    add_subdirectory(plugins)
+endif()
+
+if (BUILD_TOOLS)
   add_subdirectory(tools)
 endif()
 
-if (ANDROID OR DESKTOP_GVR)
-  add_subdirectory(interface)
-  add_subdirectory(gvr-interface)
-  add_subdirectory(plugins)
-endif ()
+if (BUILD_TESTS)
+    add_subdirectory(tests)
+endif()
 
-if (DEFINED ENV{HIFI_MEMORY_DEBUGGING})
-  SET( HIFI_MEMORY_DEBUGGING true )
-endif ()
-if (HIFI_MEMORY_DEBUGGING)
-  if (UNIX)
-    MESSAGE("-- Memory debugging is enabled")
-  endif (UNIX)
-endif ()
-
-generate_installers()
+if (BUILD_INSTALLER)
+    if (UNIX)
+        install(
+            DIRECTORY "${CMAKE_SOURCE_DIR}/scripts"
+            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/interface
+            COMPONENT ${CLIENT_COMPONENT}
+        )
+    endif()
+    generate_installers()
+endif()

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -1,0 +1,106 @@
+set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+
+if (WIN32)
+  if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+    message( FATAL_ERROR "Only 64 bit builds supported." )
+  endif()
+
+  add_definitions(-DNOMINMAX -D_CRT_SECURE_NO_WARNINGS)
+
+  if (NOT WINDOW_SDK_PATH)
+    set(DEBUG_DISCOVERED_SDK_PATH TRUE)
+  endif()
+
+  # sets path for Microsoft SDKs
+  # if you get build error about missing 'glu32' this path is likely wrong
+  if (MSVC_VERSION GREATER_EQUAL 1910) # VS 2017
+    set(WINDOW_SDK_PATH "C:/Program Files (x86)/Windows Kits/10/Lib/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/x64" CACHE PATH "Windows SDK PATH")
+  elseif (MSVC_VERSION GREATER_EQUAL 1800) # VS 2013
+    set(WINDOW_SDK_PATH "C:\\Program Files (x86)\\Windows Kits\\8.1\\Lib\\winv6.3\\um\\${WINDOW_SDK_FOLDER}" CACHE PATH "Windows SDK PATH")
+  else()
+    message( FATAL_ERROR "Visual Studio 2013 or higher required." )
+  endif()
+
+  if (DEBUG_DISCOVERED_SDK_PATH)
+    message(STATUS "The discovered Windows SDK path is ${WINDOW_SDK_PATH}")
+  endif ()
+
+  list(APPEND CMAKE_PREFIX_PATH "${WINDOW_SDK_PATH}")
+
+  # /wd4351 disables warning C4351: new behavior: elements of array will be default initialized
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /wd4351")
+  # /LARGEADDRESSAWARE enables 32-bit apps to use more than 2GB of memory.
+  # Caveats: http://stackoverflow.com/questions/2288728/drawbacks-of-using-largeaddressaware-for-32-bit-windows-executables
+  # TODO: Remove when building 64-bit.
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
+  # always produce symbols as PDB files
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:REF /OPT:ICF")
+else ()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-strict-aliasing -Wno-unused-parameter")
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -Woverloaded-virtual -Wdouble-promotion")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.1") # gcc 5.1 and on have suggest-override
+          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+      endif ()
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.3")
+          # GLM 0.9.8 on Ubuntu 14 (gcc 4.4) has issues with the simd declarations
+          add_definitions(-DGLM_FORCE_PURE)
+      endif()
+  endif ()
+endif()
+
+if (ANDROID)
+    # assume that the toolchain selected for android has C++11 support
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif ((NOT MSVC12) AND (NOT MSVC14))
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+    if (COMPILER_SUPPORTS_CXX11)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    elseif(COMPILER_SUPPORTS_CXX0X)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    else()
+        message(FATAL_ERROR  "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+    endif()
+endif ()
+
+if (APPLE)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --stdlib=libc++")
+endif ()
+
+if (NOT ANDROID_LIB_DIR)
+  set(ANDROID_LIB_DIR $ENV{ANDROID_LIB_DIR})
+endif ()
+
+if (APPLE)
+  exec_program(sw_vers ARGS -productVersion  OUTPUT_VARIABLE OSX_VERSION)
+  string(REGEX MATCH "^[0-9]+\\.[0-9]+" OSX_VERSION ${OSX_VERSION})
+  message(STATUS "Detected OS X version = ${OSX_VERSION}")
+
+  set(OSX_SDK "${OSX_VERSION}" CACHE String "OS X SDK version to look for inside Xcode bundle or at OSX_SDK_PATH")
+
+  # set our OS X deployment target
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.8)
+
+  # find the SDK path for the desired SDK
+  find_path(
+    _OSX_DESIRED_SDK_PATH
+    NAME MacOSX${OSX_SDK}.sdk
+    HINTS ${OSX_SDK_PATH}
+    PATHS /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
+          /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
+  )
+
+  if (NOT _OSX_DESIRED_SDK_PATH)
+    message(STATUS "Could not find OS X ${OSX_SDK} SDK. Will fall back to default. If you want a specific SDK, please pass OSX_SDK and optionally OSX_SDK_PATH to CMake.")
+  else ()
+    message(STATUS "Found OS X ${OSX_SDK} SDK at ${_OSX_DESIRED_SDK_PATH}/MacOSX${OSX_SDK}.sdk")
+
+    # set that as the SDK to use
+    set(CMAKE_OSX_SYSROOT ${_OSX_DESIRED_SDK_PATH}/MacOSX${OSX_SDK}.sdk)
+  endif ()
+endif ()

--- a/cmake/externals/LibOVR/CMakeLists.txt
+++ b/cmake/externals/LibOVR/CMakeLists.txt
@@ -33,7 +33,6 @@ if (WIN32)
   include(SelectLibraryConfigurations)
   select_library_configurations(LIBOVR)
   set(${EXTERNAL_NAME_UPPER}_LIBRARIES ${${EXTERNAL_NAME_UPPER}_LIBRARIES} CACHE TYPE INTERNAL)
-  message("Libs ${EXTERNAL_NAME_UPPER}_LIBRARIES ${${EXTERNAL_NAME_UPPER}_LIBRARIES}")
 
 elseif(APPLE)
   

--- a/cmake/externals/quazip/CMakeLists.txt
+++ b/cmake/externals/quazip/CMakeLists.txt
@@ -4,14 +4,6 @@ cmake_policy(SET CMP0046 OLD)
 
 include(ExternalProject)
 
-if (WIN32)
-    # windows shell does not like backslashes expanded on the command line,
-    # so convert all backslashes in the QT path to forward slashes
-    string(REPLACE \\ / QT_CMAKE_PREFIX_PATH $ENV{QT_CMAKE_PREFIX_PATH})
-elseif ($ENV{QT_CMAKE_PREFIX_PATH})
-    set(QT_CMAKE_PREFIX_PATH $ENV{QT_CMAKE_PREFIX_PATH})
-endif ()
-
 set(QUAZIP_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${QT_CMAKE_PREFIX_PATH} -DCMAKE_INSTALL_NAME_DIR:PATH=<INSTALL_DIR>/lib -DZLIB_ROOT=${ZLIB_ROOT} -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
 
 if (APPLE)
@@ -34,9 +26,9 @@ add_dependencies(quazip zlib)
 
 # Hide this external target (for ide users)
 set_target_properties(${EXTERNAL_NAME} PROPERTIES 
-	FOLDER "hidden/externals"
-	INSTALL_NAME_DIR ${INSTALL_DIR}/lib
-	BUILD_WITH_INSTALL_RPATH True)
+    FOLDER "hidden/externals"
+    INSTALL_NAME_DIR ${INSTALL_DIR}/lib
+    BUILD_WITH_INSTALL_RPATH True)
 
 ExternalProject_Get_Property(${EXTERNAL_NAME} INSTALL_DIR)
 set(${EXTERNAL_NAME_UPPER}_INCLUDE_DIR ${INSTALL_DIR}/include CACHE PATH "List of QuaZip include directories")

--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -1,0 +1,43 @@
+if (WIN32)
+  cmake_policy(SET CMP0020 NEW)
+endif (WIN32)
+
+if (POLICY CMP0043)
+  cmake_policy(SET CMP0043 OLD)
+endif ()
+
+if (POLICY CMP0042)
+  cmake_policy(SET CMP0042 OLD)
+endif ()
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMakeTargets")
+# Hide automoc folders (for IDEs)
+set(AUTOGEN_TARGETS_FOLDER "hidden/generated")
+# Find includes in corresponding build directories
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+if (CMAKE_BUILD_TYPE)
+  string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
+else ()
+  set(UPPER_CMAKE_BUILD_TYPE DEBUG)
+endif ()
+
+# CMAKE_CURRENT_SOURCE_DIR is the parent folder here
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
+
+set(HF_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(MACRO_DIR "${HF_CMAKE_DIR}/macros")
+set(EXTERNAL_PROJECT_DIR "${HF_CMAKE_DIR}/externals")
+
+file(GLOB HIFI_CUSTOM_MACROS "cmake/macros/*.cmake")
+foreach(CUSTOM_MACRO ${HIFI_CUSTOM_MACROS})
+  include(${CUSTOM_MACRO})
+endforeach()
+
+if (ANDROID)
+  file(GLOB ANDROID_CUSTOM_MACROS "cmake/android/*.cmake")
+  foreach(CUSTOM_MACRO ${ANDROID_CUSTOM_MACROS})
+    include(${CUSTOM_MACRO})
+  endforeach()
+endif ()

--- a/cmake/macros/SetupHifiClientServerPlugin.cmake
+++ b/cmake/macros/SetupHifiClientServerPlugin.cmake
@@ -9,11 +9,13 @@ macro(SETUP_HIFI_CLIENT_SERVER_PLUGIN)
   set(${TARGET_NAME}_SHARED 1)
   setup_hifi_library(${ARGV})
 
-  if (NOT DEFINED SERVER_ONLY)
+  if (BUILD_CLIENT)
     add_dependencies(interface ${TARGET_NAME})
   endif()
 
-  add_dependencies(assignment-client ${TARGET_NAME})
+  if (BUILD_SERVER)
+    add_dependencies(assignment-client ${TARGET_NAME})
+  endif()
 
   set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Plugins")
 

--- a/cmake/macros/SetupHifiPlugin.cmake
+++ b/cmake/macros/SetupHifiPlugin.cmake
@@ -8,7 +8,9 @@
 macro(SETUP_HIFI_PLUGIN)
     set(${TARGET_NAME}_SHARED 1)
     setup_hifi_library(${ARGV})
-    add_dependencies(interface ${TARGET_NAME})
+    if (BUILD_CLIENT)
+        add_dependencies(interface ${TARGET_NAME})
+    endif()
     target_link_libraries(${TARGET_NAME} ${CMAKE_THREAD_LIBS_INIT})
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Plugins")
 

--- a/cmake/macros/SetupQt.cmake
+++ b/cmake/macros/SetupQt.cmake
@@ -60,13 +60,15 @@ macro(setup_qt)
         string(REPLACE \\ / QT_DIR ${QT_DIR})
     endif()
 
-
-    if (NOT EXISTS "${QT_DIR}/include/QtCore/QtGlobal")
-        message(FATAL_ERROR "Unable to locate Qt includes in ${QT_DIR}")
-    endif()
+    # This check doesn't work on Mac
+    #if (NOT EXISTS "${QT_DIR}/include/QtCore/QtGlobal")
+    #    message(FATAL_ERROR "Unable to locate Qt includes in ${QT_DIR}")
+    #endif()
+    
     if (NOT EXISTS "${QT_CMAKE_PREFIX_PATH}/Qt5Core/Qt5CoreConfig.cmake")
         message(FATAL_ERROR "Unable to locate Qt cmake config in ${QT_CMAKE_PREFIX_PATH}")
     endif()
+    
     message(STATUS "The Qt build in use is: \"${QT_DIR}\"")
 
     # Instruct CMake to run moc automatically when needed.

--- a/cmake/macros/SetupQt.cmake
+++ b/cmake/macros/SetupQt.cmake
@@ -1,0 +1,82 @@
+# 
+#  Copyright 2015 High Fidelity, Inc.
+#  Created by Bradley Austin Davis on 2015/10/10
+#
+#  Distributed under the Apache License, Version 2.0.
+#  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+# 
+
+function(set_from_env _RESULT_NAME _ENV_VAR_NAME _DEFAULT_VALUE)
+    if ("$ENV{${_ENV_VAR_NAME}}" STREQUAL "")
+        set (${_RESULT_NAME} ${_DEFAULT_VALUE} PARENT_SCOPE)
+    else()
+        set (${_RESULT_NAME} $ENV{${_ENV_VAR_NAME}} PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Construct a default QT location from a root path, a version and an architecture
+function(calculate_default_qt_dir _RESULT_NAME)
+    if (ANDROID)
+        set(QT_DEFAULT_ARCH "android_armv7")
+    elseif(UWP)
+        set(QT_DEFAULT_ARCH "winrt_x64_msvc2017")
+    elseif(APPLE)
+        set(QT_DEFAULT_ARCH "clang_64")
+    elseif(WIN32)
+        set(QT_DEFAULT_ARCH "msvc2017_64")
+    else()
+        set(QT_DEFAULT_ARCH "gcc_64")
+    endif()
+
+    if (WIN32)
+        set(QT_DEFAULT_ROOT "c:/Qt")
+    else()
+        set(QT_DEFAULT_ROOT "$ENV{HOME}/Qt")
+    endif()
+
+    set_from_env(QT_ROOT QT_ROOT ${QT_DEFAULT_ROOT})
+    set_from_env(QT_VERSION QT_VERSION "5.9.1")
+    set_from_env(QT_ARCH QT_ARCH ${QT_DEFAULT_ARCH})
+
+    set(${_RESULT_NAME} "${QT_ROOT}/${QT_VERSION}/${QT_ARCH}" PARENT_SCOPE)
+endfunction()
+
+# Sets the QT_CMAKE_PREFIX_PATH and QT_DIR variables
+# Also enables CMAKE_AUTOMOC and CMAKE_AUTORCC
+macro(setup_qt)
+    set(QT_CMAKE_PREFIX_PATH "$ENV{QT_CMAKE_PREFIX_PATH}")
+    if (("QT_CMAKE_PREFIX_PATH" STREQUAL "") OR (NOT EXISTS "${QT_CMAKE_PREFIX_PATH}"))
+        calculate_default_qt_dir(QT_DIR)
+        set(QT_CMAKE_PREFIX_PATH "${QT_DIR}/lib/cmake")
+    else()
+        # figure out where the qt dir is
+        get_filename_component(QT_DIR "${QT_CMAKE_PREFIX_PATH}/../../" ABSOLUTE)
+    endif()
+
+    if (WIN32)
+        # windows shell does not like backslashes expanded on the command line,
+        # so convert all backslashes in the QT path to forward slashes
+        string(REPLACE \\ / QT_CMAKE_PREFIX_PATH ${QT_CMAKE_PREFIX_PATH})
+        string(REPLACE \\ / QT_DIR ${QT_DIR})
+    endif()
+
+
+    if (NOT EXISTS "${QT_DIR}/include/QtCore/QtGlobal")
+        message(FATAL_ERROR "Unable to locate Qt includes in ${QT_DIR}")
+    endif()
+    if (NOT EXISTS "${QT_CMAKE_PREFIX_PATH}/Qt5Core/Qt5CoreConfig.cmake")
+        message(FATAL_ERROR "Unable to locate Qt cmake config in ${QT_CMAKE_PREFIX_PATH}")
+    endif()
+    message(STATUS "The Qt build in use is: \"${QT_DIR}\"")
+
+    # Instruct CMake to run moc automatically when needed.
+    set(CMAKE_AUTOMOC ON)
+
+    # Instruct CMake to run rcc automatically when needed
+    set(CMAKE_AUTORCC ON)
+    
+    if (WIN32)
+        add_paths_to_fixup_libs("${QT_DIR}/bin")
+    endif ()
+
+endmacro()


### PR DESCRIPTION
This modifies a number of cmake files in order to ease multi-platform development and make the individual files easier to read and manage.  

- Modify the way Qt is located to ease multi-platform development on a single machine (see below)
- Move a large amount of boilerplate relating to our standard usage of CMake to `cmake/init.cmake`
- Move a large amount of boilerplate relating to compiler options to `cmake/compiler.cmake`
- Add options for toggling individual parts of the build..,  `BUILD_SERVER`, `BUILD_CLIENT` etc
  - The pre-existing SERVER_ONLY cmake flag is still honored and should result in the same build targets as before
- Add all the CMake macros, modules and other files to a new top level `cmake` project in the IDE to make them easier to access and edit.  Visual Studio 2017 actually has a very nice CMake editor that does auto completion.

## Qt Setup

Currently our Qt libraries are located via the environment variable `QT_CMAKE_PREFIX_PATH`.  Unless you're building for Android, in which case `ANDROID_QT_CMAKE_PREFIX_PATH`.  Or if you're building for UWP, then `UWP_QT_CMAKE_PREFIX_PATH`.  This needlessly complicates the setup for doing builds for alternative platforms which require cross-compiling or a different Qt runtime.  

The new system does away with the variants of `QT_CMAKE_PREFIX_PATH` and instead uses knowledge of the well defined locations of various Qt runtimes within a Qt installation directory.  _If_ you have an environment variable `QT_CMAKE_PREFIX_PATH` it will still take precedence over the new mechanism.  However, if you set no variable, CMake will attempt to find the root of the Qt install in it's default directory (`C:/Qt` for Windows, `~/Qt` for all other platforms).  This location can be overridden with the `QT_ROOT` environment variable.  It will then look for the version directory inside Qt root, defaulting to `5.9.1`, but again, this can be overridden by a `QT_VERSION` environment variable.  Finally it will look for the actual runtime folder, the name of which will vary depending on the current platform and build target.  This last can be overridden with a `QT_ARCH` environment variable.  

The resulting `QT_DIR` will be set to `${QT_ROOT}/${QT_VERSION}/${QT_ARCH}` and `QT_CMAKE_PREFIX_PATH` will be set to `${QT_DIR}/lib/cmake`.  

The upshot is that if you don't set any environment variables at all, but you've installed Qt in the default location, everything will just work.  

*This means you'll be able to go from a Mac build directory directly to an Android build directory and run `cmake` without having to worry about what environment variables are set.  It also means that an IDE that triggers a CMake regeneration won't fail because it needs environment variables you've only set in shell window.  

## Testing

No application testing required.  This will only affect the build process, not the application itself.  