### PR TITLE
7196 Mouse pointer no longer visible in HMD mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -604,6 +604,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::registerInheritance<SpatialParentFinder, InterfaceParentFinder>();
 
     // Set dependencies
+    DependencyManager::set<Cursor::Manager>();
     DependencyManager::set<AccountManager>(std::bind(&Application::getUserAgent, qApp));
     DependencyManager::set<StatTracker>();
     DependencyManager::set<ScriptEngines>(ScriptEngine::CLIENT_SCRIPT);

--- a/libraries/ui/src/CursorManager.cpp
+++ b/libraries/ui/src/CursorManager.cpp
@@ -24,13 +24,6 @@ namespace Cursor {
         return _icon;
     }
 
-
-    class MouseInstance : public Instance {
-        Source getType() const override {
-            return Source::MOUSE;
-        }
-    };
-
     QMap<uint16_t, QString> Manager::ICON_NAMES {
         { Icon::SYSTEM, "SYSTEM", },
         { Icon::DEFAULT, "DEFAULT", },
@@ -38,7 +31,7 @@ namespace Cursor {
         { Icon::ARROW, "ARROW", },
         { Icon::RETICLE, "RETICLE", },
     };
-    QMap<uint16_t, QString> Manager::ICONS;
+
     static uint16_t _customIconId = Icon::USER_BASE;
 
     Manager::Manager() {
@@ -62,8 +55,8 @@ namespace Cursor {
     }
 
     Manager& Manager::instance() {
-        static Manager instance;
-        return instance;
+        static QSharedPointer<Manager> instance = DependencyManager::get<Cursor::Manager>();
+        return *instance;
     }
 
     QList<uint16_t> Manager::registeredIcons() const {
@@ -76,7 +69,6 @@ namespace Cursor {
 
     Instance* Manager::getCursor(uint8_t index) {
         Q_ASSERT(index < getCount());
-        static MouseInstance mouseInstance;
         if (index == 0) {
             return &mouseInstance;
         }

--- a/libraries/ui/src/CursorManager.h
+++ b/libraries/ui/src/CursorManager.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <stdint.h>
+#include <DependencyManager.h>
 
 #include <GLMHelpers.h>
 
@@ -39,7 +40,15 @@ namespace Cursor {
         uint16_t _icon;
     };
 
-    class Manager {
+    class MouseInstance : public Instance {
+        Source getType() const override {
+            return Source::MOUSE;
+        }
+    };
+
+    class Manager : public QObject, public Dependency {
+        SINGLETON_DEPENDENCY
+
         Manager();
         Manager(const Manager& other) = delete;
     public:
@@ -52,12 +61,13 @@ namespace Cursor {
         QList<uint16_t> registeredIcons() const;
         const QString& getIconImage(uint16_t icon);
 
-        static QMap<uint16_t, QString> ICONS;
         static QMap<uint16_t, QString> ICON_NAMES;
         static Icon lookupIcon(const QString& name);
         static const QString& getIconName(const Icon& icon);
     private:
+        MouseInstance mouseInstance;
         float _scale{ 1.0f };
+        QMap<uint16_t, QString> ICONS;
     };
 }
 


### PR DESCRIPTION
The issue was caused by creation of additional instances of 'Cursor::Manager' in plugins, which happened because
Cursor::Manager's code is inside static library so every module was getting its own copy of it. As the result cursor-related settings from Application never reached plugins.

The fix is based on converting 'Cursor::Manager' into 'Dependency' to avoid additional instances creation in plugins


**Test plan:** 

1. Switch to VR mode
2. Ensure cursor is visible

Bonus: 
3. Ensure cursor switching via Ctrl-' works in the same way as in non-VR mode. 