### PR TITLE
WL21484 _- Hotfix - Solve Joint array issues with Similar, but not same Skeletons

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -912,7 +912,6 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
     auto& animationGeometry = _animation->getGeometry();
     auto& animationJointNames = animationGeometry.getJointNames();
     auto& fbxJoints = animationGeometry.joints;
-    auto& _debugFbxJoints = animationGeometry.jointIndices;
 
     auto& originalFbx = _model->getFBXGeometry();
     auto& originalFbxJoints = originalFbx.joints;
@@ -967,8 +966,7 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
                 translationMat = glm::translate(translations[index]);
             } else if (!allowTranslation && index < animationJointNames.size()){
                 QString jointName = fbxJoints[index].name; // Pushing this here so its not done on every entity, with the exceptions of those allowing for translation
-                 
-
+                
                 if (originalFbxIndices.contains(jointName)) {
                     // Making sure the joint names exist in the original model the animation is trying to apply onto. If they do, then remap and get it's translation.
                     int remappedIndex = originalFbxIndices[jointName] - 1; // JointIndeces seem to always start from 1 and the found index is always 1 higher than actual.

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -909,13 +909,11 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
     QVector<JointData> jointsData;
 
     const QVector<FBXAnimationFrame>&  frames = _animation->getFramesReference(); // NOTE: getFrames() is too heavy
-    auto& animationGeometry = _animation->getGeometry();
-    auto& animationJointNames = animationGeometry.getJointNames();
-    auto& fbxJoints = animationGeometry.joints;
+    QStringList animationJointNames = _animation->getGeometry().getJointNames();
+    auto& fbxJoints = _animation->getGeometry().joints;
 
-    auto& originalFbx = _model->getFBXGeometry();
-    auto& originalFbxJoints = originalFbx.joints;
-    auto& originalFbxIndices = originalFbx.jointIndices;
+    auto& originalFbxJoints = _model->getFBXGeometry().joints;
+    auto& originalFbxIndices = _model->getFBXGeometry().jointIndices;
 
     bool allowTranslation = entity->getAnimationAllowTranslation();
     int frameCount = frames.size();

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -909,13 +909,6 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
     QVector<JointData> jointsData;
 
     const QVector<FBXAnimationFrame>&  frames = _animation->getFramesReference(); // NOTE: getFrames() is too heavy
-    QStringList animationJointNames = _animation->getGeometry().getJointNames();
-    auto& fbxJoints = _animation->getGeometry().joints;
-
-    auto& originalFbxJoints = _model->getFBXGeometry().joints;
-    auto& originalFbxIndices = _model->getFBXGeometry().jointIndices;
-
-    bool allowTranslation = entity->getAnimationAllowTranslation();
     int frameCount = frames.size();
     if (frameCount <= 0) {
         return;
@@ -950,6 +943,14 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
         return;
     }
 
+    QStringList animationJointNames = _animation->getGeometry().getJointNames();
+    auto& fbxJoints = _animation->getGeometry().joints;
+
+    auto& originalFbxJoints = _model->getFBXGeometry().joints;
+    auto& originalFbxIndices = _model->getFBXGeometry().jointIndices;
+
+    bool allowTranslation = entity->getAnimationAllowTranslation();
+
     const QVector<glm::quat>& rotations = frames[_lastKnownCurrentFrame].rotations;
     const QVector<glm::vec3>& translations = frames[_lastKnownCurrentFrame].translations;
                 
@@ -960,9 +961,11 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
         if (index >= 0) {
             glm::mat4 translationMat;
 
-            if (allowTranslation && index < translations.size()) {
-                translationMat = glm::translate(translations[index]);
-            } else if (!allowTranslation && index < animationJointNames.size()){
+            if (allowTranslation) {
+                if(index < translations.size()){
+                    translationMat = glm::translate(translations[index]);
+                }
+            } else if (index < animationJointNames.size()){
                 QString jointName = fbxJoints[index].name; // Pushing this here so its not done on every entity, with the exceptions of those allowing for translation
                 
                 if (originalFbxIndices.contains(jointName)) {


### PR DESCRIPTION
Fix for #11290 To Solve Boneitis on Entity Avatars.

## Test Plan in Comments!

This PR Fixes a specific issue with the #11290 Update, where A skeleton similar, but not same in structure got distorted due to bones. This occurred due to the arrays of the Target skeleton and the Animation being different.

Solution was to use BoneIndeces to match the joints between the target and animation.