### PR TITLE
WL 21523 - Update text in the "How to Quit The Sandbox" Prompt

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -964,13 +964,13 @@ SectionEnd
 
       ; the process is running, ask the user to close it
       
-      ${If} $displayName == "Sandbox"
+      ${If} "${displayName}" == "Sandbox"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the system tray and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
       ${EndIf}
 
-      ${If} $displayName == "Interface"
+      ${If} "${displayName}" == "Interface"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -964,13 +964,13 @@ SectionEnd
 
       ; the process is running, ask the user to close it
       
-      ${If} ${displayName} == "Sandbox"
+      ${If} $displayName == "Sandbox"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the system tray and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
       ${EndIf}
 
-      ${If} ${displayName} == "Interface"
+      ${If} $displayName == "Interface"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -964,7 +964,7 @@ SectionEnd
 
       ; the process is running, ask the user to close it
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
-        "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it and click Retry to continue." \
+        "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the system tray and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
 
       ; If the user decided to cancel, stop the current installer/uninstaller

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -964,13 +964,13 @@ SectionEnd
 
       ; the process is running, ask the user to close it
       
-      ${If} $displayName == "Sandbox"
+      ${If} ${displayName} == "Sandbox"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the system tray and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
       ${EndIf}
 
-      ${If} $displayName == "Interface"
+      ${If} ${displayName} == "Interface"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -963,9 +963,18 @@ SectionEnd
     ${If} $R0 == 0
 
       ; the process is running, ask the user to close it
+      
+      ${If} $displayName == "Sandbox"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the system tray and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
+      ${EndIf}
+
+      ${If} $displayName == "Interface"
+      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
+        "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it and click Retry to continue." \
+        /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
+      ${EndIf}
 
       ; If the user decided to cancel, stop the current installer/uninstaller
       Abort

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -972,7 +972,7 @@ SectionEnd
 
       ${If} "${displayName}" == "Interface"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
-        "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it and click Retry to continue." \
+        "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the task bar and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
       ${EndIf}
 

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -964,13 +964,13 @@ SectionEnd
 
       ; the process is running, ask the user to close it
       
-      ${If} "${displayName}" == "Sandbox"
+      ${If} "${displayName}" == "@CONSOLE_DISPLAY_NAME@"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the system tray and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0
       ${EndIf}
 
-      ${If} "${displayName}" == "Interface"
+      ${If} "${displayName}" == "@INTERFACE_DISPLAY_NAME@"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
         "${displayName} cannot be ${action} while ${displayName} is running.$\r$\nPlease close it in the task bar and click Retry to continue." \
         /SD IDCANCEL IDRETRY Prompt_${UniqueID} IDCANCEL 0


### PR DESCRIPTION
## Test Plan
1. Install the PR
2. With the Interface still running, launch the installer again and confirm it shows a message similar to '__Interface cannot be installed while the Interface is running. Please close it in the task bar and click Retry to continue.__`
3. With the Interface still running, launch the uninstaller and confirm it shows a message similar to '__Interface cannot be uninstalled while the Interface is running. Please close it in the task bar and click Retry to continue.__`
4. With the Sandbox still running, launch the Installer again and confirm that it shows a message similar to '__Sandbox cannot be installed while Sandbox is running. Please close it in the system tray and click Retry to continue.__'.
5. With the Sandbox still running, launch the uninstaller and confirm that it shows a message similar to '__Sandbox cannot be uninstalled while Sandbox is running. Please close it in the system tray and click Retry to continue.__'.

[WL 21523](https://worklist.net/21523)