### PR TITLE
Reset passphrase fix

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -59,7 +59,7 @@ Rectangle {
         }
 
         onWalletAuthenticatedStatusResult: {
-            if (!isAuthenticated && !passphraseModal.visible) {
+            if (!isAuthenticated && passphraseModal && !passphraseModal.visible) {
                 passphraseModal.visible = true;
             } else if (isAuthenticated) {
                 root.activeView = "walletHome";


### PR DESCRIPTION
Need to clear the _publicKeys when setting the passphrase.  This fixes the somewhat broken reset passphrase debug button, plus prevents some unnecessary encryption attempts, etc...  Also one-liner to get rid of errors in Wallet.qml.