### PR TITLE
6718 PR11082: Help text cannot be dismissed by clicking on the text i…

### DIFF
--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -137,48 +137,11 @@ Item {
             }
         }
     }
-    // Left gray MouseArea
     MouseArea {
-        anchors.left: parent.left;
-        anchors.right: textContainer.left;
-        anchors.top: textContainer.top;
-        anchors.bottom: textContainer.bottom;
+        anchors.fill: parent
         acceptedButtons: Qt.LeftButton
         onClicked: {
-            letterbox.visible = false
-        }
-    }
-    // Right gray MouseArea
-    MouseArea {
-        anchors.left: textContainer.left;
-        anchors.right: parent.left;
-        anchors.top: textContainer.top;
-        anchors.bottom: textContainer.bottom;
-        acceptedButtons: Qt.LeftButton
-        onClicked: {
-            letterbox.visible = false
-        }
-    }
-    // Top gray MouseArea
-    MouseArea {
-        anchors.left: parent.left;
-        anchors.right: parent.right;
-        anchors.top: parent.top;
-        anchors.bottom: textContainer.top;
-        acceptedButtons: Qt.LeftButton
-        onClicked: {
-            letterbox.visible = false
-        }
-    }
-    // Bottom gray MouseArea
-    MouseArea {
-        anchors.left: parent.left;
-        anchors.right: parent.right;
-        anchors.top: textContainer.bottom;
-        anchors.bottom: parent.bottom;
-        acceptedButtons: Qt.LeftButton
-        onClicked: {
-            letterbox.visible = false
+            letterbox.visible = false;
         }
     }
 }


### PR DESCRIPTION
…nside the box.

**Test plan:**

1. Boot up Interface
2. Click on the People menu in your toolbar
3. Click on the "?" in the Connections tab
4. Click on the text displayed in the Help text box
5. Help text box must close

The same behavior should be global for all such a popups. 

https://highfidelity.fogbugz.com/f/cases/6718/PR11082-Help-text-cannot-be-dismissed-by-clicking-on-the-text-inside-the-box