### PR TITLE
wallet cleanup

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Help.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Help.qml
@@ -55,6 +55,7 @@ Item {
         text: "DEBUG: Clear Cached Passphrase";
         onClicked: {
             commerce.setPassphrase("");
+            sendSignalToWallet({method: 'passphraseReset'});
         }
     }
     HifiControlsUit.Button {

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -318,7 +318,7 @@ Rectangle {
 
         Connections {
             onSendSignalToWallet: {
-                if (msg.method === 'walletReset') {
+                if (msg.method === 'walletReset' || msg.method == 'passphraseReset') {
                     sendToScript(msg);
                 }
             }

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -318,7 +318,7 @@ Rectangle {
 
         Connections {
             onSendSignalToWallet: {
-                if (msg.method === 'walletReset' || msg.method == 'passphraseReset') {
+                if (msg.method === 'walletReset' || msg.method === 'passphraseReset') {
                     sendToScript(msg);
                 }
             }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetupLightbox.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetupLightbox.qml
@@ -325,7 +325,7 @@ Rectangle {
                 onClicked: {
                     if (passphraseSelection.validateAndSubmitPassphrase()) {
                         root.lastPage = "choosePassphrase";
-                        commerce.balance(); // Do this here so that keys are generated. Order might change as backend changes?
+                        commerce.generateKeyPair();
                         choosePassphraseContainer.visible = false;
                         privateKeysReadyContainer.visible = true;
                     }

--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -86,11 +86,17 @@ void QmlCommerce::history() {
 
 void QmlCommerce::setPassphrase(const QString& passphrase) {
     auto wallet = DependencyManager::get<Wallet>();
-    if (wallet->getPassphrase() && !wallet->getPassphrase()->isEmpty()) {
+    if(wallet->getPassphrase() && !wallet->getPassphrase()->isEmpty() && !passphrase.isEmpty()) {
         wallet->changePassphrase(passphrase);
     } else {
         wallet->setPassphrase(passphrase);
     }
+    getWalletAuthenticatedStatus();
+}
+
+void QmlCommerce::generateKeyPair() {
+    auto wallet = DependencyManager::get<Wallet>();
+    wallet->generateKeyPair();
     getWalletAuthenticatedStatus();
 }
 

--- a/interface/src/commerce/QmlCommerce.h
+++ b/interface/src/commerce/QmlCommerce.h
@@ -53,7 +53,7 @@ protected:
     Q_INVOKABLE void balance();
     Q_INVOKABLE void inventory();
     Q_INVOKABLE void history();
-
+    Q_INVOKABLE void generateKeyPair();
     Q_INVOKABLE void reset();
 };
 

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -26,7 +26,6 @@ public:
 
     ~Wallet();
     // These are currently blocking calls, although they might take a moment.
-    bool createIfNeeded();
     bool generateKeyPair();
     QStringList listPublicKeys();
     QString signWithKey(const QByteArray& text, const QString& key);

--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -71,6 +71,10 @@
             case 'maybeEnableHmdPreview':
                 Menu.setIsOptionChecked("Disable Preview", isHmdPreviewDisabled);
                 break;
+            case 'passphraseReset':
+                onButtonClicked();
+                onButtonClicked();
+                break;
             case 'walletReset':
                 onButtonClicked();
                 onButtonClicked();


### PR DESCRIPTION
Seems a couple things that were fixed creeped back into the wallet.  This re-fixes them -- the clearing of your cached passphrase in particular.  Also our caching of the passphrase, and the logic around set vs change passphrase was problematic.   Now, whenever the private key will not decrypt, we clear the passphrase (since it is wrong).  This fixes issues with entering the wrong passphrase, having it cached, and next time you enter it (in passphrase modal), us thinking it is a change to the passphrase.  That guaranteed you couldn't decrypt as we first decrypt with cached passphrase before changing it.  

Finally, I removed createIfNeeded.  We _never_ just create a keypair.  There is a call to generate the keypair, and that is now exposed so it can be called directly when needed.  Since this was called as part of a balance call for instance, you could inadvertently create keys after one of the above failures, creating keys with either a cached or empty passphrase.  