### PR TITLE
Fix polyline crash and flicker

### DIFF
--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -126,6 +126,7 @@ void PolyLineEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& 
         auto textures = entity->getTextures();
         QString path = textures.isEmpty() ? PathUtils::resourcesPath() + "images/paintStroke.png" : textures;
         if (!_texture || _lastTextures != path) {
+            _lastTextures = path;
             _texture = DependencyManager::get<TextureCache>()->getTexture(QUrl(path));
         }
     }
@@ -220,7 +221,7 @@ void PolyLineEntityRenderer::doRender(RenderArgs* args) {
     batch.setModelTransform(Transform{ _modelTransform }.setScale(vec3(1)));
     batch.setUniformBuffer(PAINTSTROKE_UNIFORM_SLOT, _uniformBuffer);
 
-    if (_texture->isLoaded()) {
+    if (_texture && _texture->isLoaded()) {
         batch.setResourceTexture(PAINTSTROKE_TEXTURE_SLOT, _texture->getGPUTexture());
     } else {
         batch.setResourceTexture(PAINTSTROKE_TEXTURE_SLOT, nullptr);

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -141,6 +141,10 @@ void PolyLineEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
     auto normalsChanged = entity->normalsChanged();
     entity->resetPolyLineChanged();
 
+    _polylineTransform = Transform();
+    _polylineTransform.setTranslation(entity->getPosition());
+    _polylineTransform.setRotation(entity->getRotation());
+
     if (pointsChanged) {
         _lastPoints = entity->getLinePoints();
     }
@@ -218,7 +222,7 @@ void PolyLineEntityRenderer::doRender(RenderArgs* args) {
     Q_ASSERT(args->_batch);
 
     gpu::Batch& batch = *args->_batch;
-    batch.setModelTransform(Transform{ _modelTransform }.setScale(vec3(1)));
+    batch.setModelTransform(_polylineTransform);
     batch.setUniformBuffer(PAINTSTROKE_UNIFORM_SLOT, _uniformBuffer);
 
     if (_texture && _texture->isLoaded()) {

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -121,14 +121,18 @@ bool PolyLineEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityP
 }
 
 void PolyLineEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) {
+    static const QUrl DEFAULT_POLYLINE_TEXTURE = QUrl(PathUtils::resourcesPath() + "images/paintStroke.png");
+    QUrl entityTextures = DEFAULT_POLYLINE_TEXTURE;
     if (entity->texturesChanged()) {
         entity->resetTexturesChanged();
         auto textures = entity->getTextures();
-        QString path = textures.isEmpty() ? PathUtils::resourcesPath() + "images/paintStroke.png" : textures;
-        if (!_texture || _lastTextures != path) {
-            _lastTextures = path;
-            _texture = DependencyManager::get<TextureCache>()->getTexture(QUrl(path));
+        if (!textures.isEmpty()) {
+            entityTextures = QUrl(textures);
         }
+    }
+
+    if (!_texture || _texture->getURL() != entityTextures) {
+        _texture = DependencyManager::get<TextureCache>()->getTexture(entityTextures);
     }
 }
 
@@ -228,7 +232,7 @@ void PolyLineEntityRenderer::doRender(RenderArgs* args) {
     if (_texture && _texture->isLoaded()) {
         batch.setResourceTexture(PAINTSTROKE_TEXTURE_SLOT, _texture->getGPUTexture());
     } else {
-        batch.setResourceTexture(PAINTSTROKE_TEXTURE_SLOT, nullptr);
+        batch.setResourceTexture(PAINTSTROKE_TEXTURE_SLOT, DependencyManager::get<TextureCache>()->getWhiteTexture());
     }
 
     batch.setInputFormat(polylineFormat);

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
@@ -55,7 +55,6 @@ protected:
     gpu::BufferView _uniformBuffer;
     uint32_t _numVertices { 0 };
     bool _empty{ true };
-    QString _lastTextures;
     NetworkTexturePointer _texture;
 };
 

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
@@ -47,6 +47,7 @@ protected:
     void updateGeometry(const std::vector<Vertex>& vertices);
     static std::vector<Vertex> updateVertices(const QVector<glm::vec3>& points, const QVector<glm::vec3>& normals, const QVector<float>& strokeWidths);
 
+    Transform _polylineTransform;
     QVector<glm::vec3> _lastPoints;
     QVector<glm::vec3> _lastNormals;
     QVector<float> _lastStrokeWidths;


### PR DESCRIPTION
Fix [FB7374](https://highfidelity.fogbugz.com/f/cases/7374)

# Testing 
- Run fingerPaint.js from scripts directory.
- Enter VR mode.
- Turn finger painting on.
- Press controller trigger to start drawing a line.

In the current master build this will crash.  In this build it should not crash.  