### PR TITLE
Fix potential crash on asynchronous QML loads

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7389,7 +7389,10 @@ void Application::updateDisplayMode() {
         getApplicationCompositor().setDisplayPlugin(newDisplayPlugin);
         _displayPlugin = newDisplayPlugin;
         connect(_displayPlugin.get(), &DisplayPlugin::presented, this, &Application::onPresent);
-        offscreenUi->getDesktop()->setProperty("repositionLocked", wasRepositionLocked);
+        auto desktop = offscreenUi->getDesktop();
+        if (desktop) {
+            desktop->setProperty("repositionLocked", wasRepositionLocked);
+        }
     }
 
     bool isHmd = _displayPlugin->isHmd();

--- a/interface/src/ui/LoginDialog.cpp
+++ b/interface/src/ui/LoginDialog.cpp
@@ -169,12 +169,14 @@ void LoginDialog::openUrl(const QString& url) const {
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
 
     if (tablet->getToolbarMode()) {
-        auto browser = offscreenUi->load("Browser.qml");
-        browser->setProperty("url", url);
+        offscreenUi->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
+            newObject->setProperty("url", url);
+        });
     } else {
         if (!hmd->getShouldShowTablet() && !qApp->isHMDMode()) {
-            auto browser = offscreenUi->load("Browser.qml");
-            browser->setProperty("url", url);
+            offscreenUi->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
+                newObject->setProperty("url", url);
+            });
         } else {
             tablet->gotoWebScreen(url);
         }

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -554,20 +554,19 @@ void OffscreenUi::createDesktop(const QUrl& url) {
     getSurfaceContext()->setContextProperty("DebugQML", QVariant(false));
 #endif
 
-    _desktop = dynamic_cast<QQuickItem*>(load(url));
-    Q_ASSERT(_desktop);
-    getSurfaceContext()->setContextProperty("desktop", _desktop);
+    load(url, [=](QQmlContext* context, QObject* newObject) {
+        _desktop = static_cast<QQuickItem*>(newObject);
+        getSurfaceContext()->setContextProperty("desktop", _desktop);
+        _toolWindow = _desktop->findChild<QQuickItem*>("ToolWindow");
 
-    _toolWindow = _desktop->findChild<QQuickItem*>("ToolWindow");
+        _vrMenu = new VrMenu(this);
+        for (const auto& menuInitializer : _queuedMenuInitializers) {
+            menuInitializer(_vrMenu);
+        }
 
-    _vrMenu = new VrMenu(this);
-    for (const auto& menuInitializer : _queuedMenuInitializers) {
-        menuInitializer(_vrMenu);
-    }
-
-    new KeyboardFocusHack();
-
-    connect(_desktop, SIGNAL(showDesktop()), this, SIGNAL(showDesktop()));
+        new KeyboardFocusHack();
+        connect(_desktop, SIGNAL(showDesktop()), this, SIGNAL(showDesktop()));
+    });
 }
 
 QQuickItem* OffscreenUi::getDesktop() {

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -50,10 +50,10 @@ public:
     void resize(const QSize& size, bool forceResize = false);
     QSize size() const;
 
-    Q_INVOKABLE QObject* load(const QUrl& qmlSource, bool createNewContext, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
-    Q_INVOKABLE QObject* loadInNewContext(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
-    Q_INVOKABLE QObject* load(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
-    Q_INVOKABLE QObject* load(const QString& qmlSourceFile, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {}) {
+    Q_INVOKABLE void load(const QUrl& qmlSource, bool createNewContext, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
+    Q_INVOKABLE void loadInNewContext(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
+    Q_INVOKABLE void load(const QUrl& qmlSource, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
+    Q_INVOKABLE void load(const QString& qmlSourceFile, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {}) {
         return load(QUrl(qmlSourceFile), f);
     }
     void clearCache();
@@ -120,7 +120,7 @@ protected:
 private:
     static QOpenGLContext* getSharedContext();
 
-    QObject* finishQmlLoad(QQmlComponent* qmlComponent, QQmlContext* qmlContext, std::function<void(QQmlContext*, QObject*)> f);
+    void finishQmlLoad(QQmlComponent* qmlComponent, QQmlContext* qmlContext, std::function<void(QQmlContext*, QObject*)> f);
     QPointF mapWindowToUi(const QPointF& sourcePosition, QObject* sourceObject);
     void setupFbo();
     bool allowNewFrame(uint8_t fps);


### PR DESCRIPTION
Addresses [this crash mode](http://www.bugsplat.com/individualCrash/?id=14341&database=interface_alpha)

Qml loading from files involves loading the file into a QmlComponent, and then using the component to instantiate an instance.  However, there's no guarantee that when you request a load of a file into a QmlComponent that it will complete synchronously.  Thus the `OffscreenQmlSurface::load` logic has to either call `finishQmlLoad` synchronously if the component loaded, or asynchronously based on a signal if the component didn't load.  Unfortunately, some of our code doesn't properly handle the async path, assuming that the value returned from `OffscreenQmlSurface::load` will never be null.  Even worse, the `OffscreenUi` makes this assumption when populating the `_desktop` member.

This PR modifies the API so that the `OffscreenQmlSurface::load` methods now return void, discouraging clients from trying to use the returned value to do things.  Instead, clients should use the lambda parameter to `OffscreenQmlSurface::load` to operator on the newly created QML object once it has completed loading (sync or async aside).  The `OffscreenUi` class has been updated to follow this path.

Additionally, the logic in `Application::updateDisplayMode` has been updated to take into account the possibility of a null desktop.

## Testing

This addresses a crash on startup that was seen on a small number of client machines.  Unfortunately there's no reliable way to reproduce the crash if you weren't already experiencing it.  For now a simple smoke test of startup functioning correctly and interaction with the main desktop & the tablet should suffice.
