### PR TITLE
avoid a crashing data-race by caching keylight values in ZoneEntityRenderer

### DIFF
--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -250,7 +250,11 @@ bool ZoneEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPoint
         return true;
     }
 
-    if (entity->getKeyLightProperties() != _keyLightProperties) {
+    KeyLightPropertyGroup keyLightProperties;
+    withReadLock([&] {
+        keyLightProperties = _keyLightProperties;
+    });
+    if (entity->getKeyLightProperties() != keyLightProperties) {
         return true;
     }
 

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -210,12 +210,12 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
     }
 
     // make a copy of the keylight properties
-    const KeyLightPropertyGroup& newKeyLightProperties = entity->getKeyLightProperties();
-    if (newKeyLightProperties != _keyLightProperties) {
-        withWriteLock([&] {
+    withWriteLock([&] {
+        const KeyLightPropertyGroup& newKeyLightProperties = entity->getKeyLightProperties();
+        if (newKeyLightProperties != _keyLightProperties) {
             _keyLightProperties = newKeyLightProperties;
-        });
-    }
+        }
+    });
 }
 
 void ZoneEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) {
@@ -284,9 +284,11 @@ void ZoneEntityRenderer::updateKeySunFromEntity(const TypedEntityPointer& entity
     sunLight->setOrientation(_lastRotation);
 
     // Set the keylight
-    sunLight->setColor(ColorUtils::toVec3(_keyLightProperties.getColor()));
-    sunLight->setIntensity(_keyLightProperties.getIntensity());
-    sunLight->setDirection(_keyLightProperties.getDirection());
+    withReadLock([&] {
+        sunLight->setColor(ColorUtils::toVec3(_keyLightProperties.getColor()));
+        sunLight->setIntensity(_keyLightProperties.getIntensity());
+        sunLight->setDirection(_keyLightProperties.getDirection());
+    });
 }
 
 void ZoneEntityRenderer::updateKeyAmbientFromEntity(const TypedEntityPointer& entity) {
@@ -297,13 +299,15 @@ void ZoneEntityRenderer::updateKeyAmbientFromEntity(const TypedEntityPointer& en
 
 
     // Set the keylight
-    ambientLight->setAmbientIntensity(_keyLightProperties.getAmbientIntensity());
+    withReadLock([&] {
+        ambientLight->setAmbientIntensity(_keyLightProperties.getAmbientIntensity());
 
-    if (_keyLightProperties.getAmbientURL().isEmpty()) {
-        setAmbientURL(entity->getSkyboxProperties().getURL());
-    } else {
-        setAmbientURL(_keyLightProperties.getAmbientURL());
-    }
+        if (_keyLightProperties.getAmbientURL().isEmpty()) {
+            setAmbientURL(entity->getSkyboxProperties().getURL());
+        } else {
+            setAmbientURL(_keyLightProperties.getAmbientURL());
+        }
+    });
 }
 
 void ZoneEntityRenderer::updateKeyBackgroundFromEntity(const TypedEntityPointer& entity) {

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -211,7 +211,7 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
 
     // make a copy of the keylight properties
     withWriteLock([&] {
-        const KeyLightPropertyGroup& newKeyLightProperties = entity->getKeyLightProperties();
+        KeyLightPropertyGroup newKeyLightProperties = entity->getKeyLightProperties();
         if (newKeyLightProperties != _keyLightProperties) {
             _keyLightProperties = newKeyLightProperties;
         }

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -208,6 +208,14 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
     if (backgroundChanged || skyboxChanged) {
         updateKeyBackgroundFromEntity(entity);
     }
+
+    // make a copy of the keylight properties
+    const KeyLightPropertyGroup& newKeyLightProperties = entity->getKeyLightProperties();
+    if (newKeyLightProperties != _keyLightProperties) {
+        withWriteLock([&] {
+            _keyLightProperties = newKeyLightProperties;
+        });
+    }
 }
 
 void ZoneEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) {
@@ -242,6 +250,10 @@ bool ZoneEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPoint
         return true;
     }
 
+    if (entity->getKeyLightProperties() != _keyLightProperties) {
+        return true;
+    }
+
 #if 0
     if (_typedEntity->getCompoundShapeURL() != _lastShapeURL) {
         return true;
@@ -272,9 +284,9 @@ void ZoneEntityRenderer::updateKeySunFromEntity(const TypedEntityPointer& entity
     sunLight->setOrientation(_lastRotation);
 
     // Set the keylight
-    sunLight->setColor(ColorUtils::toVec3(entity->getKeyLightProperties().getColor()));
-    sunLight->setIntensity(entity->getKeyLightProperties().getIntensity());
-    sunLight->setDirection(entity->getKeyLightProperties().getDirection());
+    sunLight->setColor(ColorUtils::toVec3(_keyLightProperties.getColor()));
+    sunLight->setIntensity(_keyLightProperties.getIntensity());
+    sunLight->setDirection(_keyLightProperties.getDirection());
 }
 
 void ZoneEntityRenderer::updateKeyAmbientFromEntity(const TypedEntityPointer& entity) {
@@ -285,12 +297,12 @@ void ZoneEntityRenderer::updateKeyAmbientFromEntity(const TypedEntityPointer& en
 
 
     // Set the keylight
-    ambientLight->setAmbientIntensity(entity->getKeyLightProperties().getAmbientIntensity());
+    ambientLight->setAmbientIntensity(_keyLightProperties.getAmbientIntensity());
 
-    if (entity->getKeyLightProperties().getAmbientURL().isEmpty()) {
+    if (_keyLightProperties.getAmbientURL().isEmpty()) {
         setAmbientURL(entity->getSkyboxProperties().getURL());
     } else {
-        setAmbientURL(entity->getKeyLightProperties().getAmbientURL());
+        setAmbientURL(_keyLightProperties.getAmbientURL());
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.h
@@ -101,9 +101,11 @@ private:
     bool _validSkyboxTexture{ false };
 
     QString _proceduralUserData;
+
+    KeyLightPropertyGroup _keyLightProperties;
 };
 
-} } // namespace 
+} } // namespace
 
 #if 0
 

--- a/libraries/entities/src/KeyLightPropertyGroup.cpp
+++ b/libraries/entities/src/KeyLightPropertyGroup.cpp
@@ -23,6 +23,19 @@ const float KeyLightPropertyGroup::DEFAULT_KEYLIGHT_INTENSITY = 1.0f;
 const float KeyLightPropertyGroup::DEFAULT_KEYLIGHT_AMBIENT_INTENSITY = 0.5f;
 const glm::vec3 KeyLightPropertyGroup::DEFAULT_KEYLIGHT_DIRECTION = { 0.0f, -1.0f, 0.0f };
 
+bool operator==(const KeyLightPropertyGroup& a, const KeyLightPropertyGroup& b) {
+    return
+        (a._color == b._color &&
+         a._intensity == b._intensity &&
+         a._ambientIntensity == b._ambientIntensity &&
+         a._direction == b._direction &&
+         a._ambientURL == b._ambientURL);
+}
+
+bool operator!=(const KeyLightPropertyGroup& a, const KeyLightPropertyGroup& b) {
+    return !(a == b);
+}
+
 void KeyLightPropertyGroup::copyToScriptValue(const EntityPropertyFlags& desiredProperties, QScriptValue& properties, QScriptEngine* engine, bool skipDefaults, EntityItemProperties& defaultEntityProperties) const {
     
     COPY_GROUP_PROPERTY_TO_QSCRIPTVALUE(PROP_KEYLIGHT_COLOR, KeyLight, keyLight, Color, color);

--- a/libraries/entities/src/KeyLightPropertyGroup.cpp
+++ b/libraries/entities/src/KeyLightPropertyGroup.cpp
@@ -29,7 +29,7 @@ bool operator==(const KeyLightPropertyGroup& a, const KeyLightPropertyGroup& b) 
          a._intensity == b._intensity &&
          a._ambientIntensity == b._ambientIntensity &&
          a._direction == b._direction &&
-         a._ambientURL == b._ambientURL);
+         a.getAmbientURL() == b.getAmbientURL());
 }
 
 bool operator!=(const KeyLightPropertyGroup& a, const KeyLightPropertyGroup& b) {

--- a/libraries/entities/src/KeyLightPropertyGroup.h
+++ b/libraries/entities/src/KeyLightPropertyGroup.h
@@ -84,6 +84,10 @@ public:
     DEFINE_PROPERTY(PROP_KEYLIGHT_AMBIENT_INTENSITY, AmbientIntensity, ambientIntensity, float, DEFAULT_KEYLIGHT_AMBIENT_INTENSITY);
     DEFINE_PROPERTY_REF(PROP_KEYLIGHT_DIRECTION, Direction, direction, glm::vec3, DEFAULT_KEYLIGHT_DIRECTION);
     DEFINE_PROPERTY_REF(PROP_KEYLIGHT_AMBIENT_URL, AmbientURL, ambientURL, QString, "");
+
+protected:
+    friend bool operator==(const KeyLightPropertyGroup& a, const KeyLightPropertyGroup& b);
+    friend bool operator!=(const KeyLightPropertyGroup& a, const KeyLightPropertyGroup& b);
 };
 
 #endif // hifi_KeyLightPropertyGroup_h

--- a/libraries/entities/src/KeyLightPropertyGroup.h
+++ b/libraries/entities/src/KeyLightPropertyGroup.h
@@ -17,6 +17,8 @@
 
 #include <glm/glm.hpp>
 
+#include <shared/ReadWriteLockable.h>
+
 #include <QtScript/QScriptEngine>
 #include "EntityItemPropertiesMacros.h"
 #include "PropertyGroup.h"

--- a/libraries/entities/src/ZoneEntityItem.h
+++ b/libraries/entities/src/ZoneEntityItem.h
@@ -63,7 +63,7 @@ public:
     QString getCompoundShapeURL() const;
     virtual void setCompoundShapeURL(const QString& url);
 
-    const KeyLightPropertyGroup& getKeyLightProperties() const { return _keyLightProperties; }
+    KeyLightPropertyGroup getKeyLightProperties() const { QReadLocker locker(&_keyLightLock); return _keyLightProperties; }
 
     void setBackgroundMode(BackgroundMode value) { _backgroundMode = value; _backgroundPropertiesChanged = true; }
     BackgroundMode getBackgroundMode() const { return _backgroundMode; }
@@ -122,6 +122,9 @@ protected:
 
     static bool _drawZoneBoundaries;
     static bool _zonesArePickable;
+
+private:
+    mutable QReadWriteLock _keyLightLock { QReadWriteLock::Recursive };
 };
 
 #endif // hifi_ZoneEntityItem_h

--- a/libraries/entities/src/ZoneEntityItem.h
+++ b/libraries/entities/src/ZoneEntityItem.h
@@ -63,7 +63,7 @@ public:
     QString getCompoundShapeURL() const;
     virtual void setCompoundShapeURL(const QString& url);
 
-    KeyLightPropertyGroup getKeyLightProperties() const { QReadLocker locker(&_keyLightLock); return _keyLightProperties; }
+    KeyLightPropertyGroup getKeyLightProperties() const { return resultWithReadLock<KeyLightPropertyGroup>([&]{ return _keyLightProperties; }); }
 
     void setBackgroundMode(BackgroundMode value) { _backgroundMode = value; _backgroundPropertiesChanged = true; }
     BackgroundMode getBackgroundMode() const { return _backgroundMode; }
@@ -122,9 +122,6 @@ protected:
 
     static bool _drawZoneBoundaries;
     static bool _zonesArePickable;
-
-private:
-    mutable QReadWriteLock _keyLightLock { QReadWriteLock::Recursive };
 };
 
 #endif // hifi_ZoneEntityItem_h


### PR DESCRIPTION
- avoid a crashing data-race by caching keylight values in ZoneEntityRenderer
