### PR TITLE
7452 regression: flickering keyboard

### DIFF
--- a/interface/resources/html/tabletHelp.html
+++ b/interface/resources/html/tabletHelp.html
@@ -48,7 +48,7 @@
 
             #image_area {
                 width: 480;
-                height: 720;
+                height: 706;
                 margin: auto;
                 position: absolute;
                 top: 0; left: 0; bottom: 0; right: 0;
@@ -172,7 +172,7 @@
 
     <body onload="load()">
         <div id="image_area">
-            <img id="main_image" src="img/tablet-help-keyboard.jpg" width="480px" height="720px"></img>
+            <img id="main_image" src="img/tablet-help-keyboard.jpg" width="480px" height="706px"></img>
             <a href="#" id="left_button" onmousedown="cycleLeft()"></a>
             <a href="#" id="right_button" onmousedown="cycleRight()"></a>
         </div>


### PR DESCRIPTION
note: regression was happening because of url reloading on geometry change which resulted in showing keyboard which resulted in geometry change which resulted .... 

the logic has been updated to avoid reloading. unfortunately due to Qt bug in WebEngine fix looks like this