### PR TITLE
Mac fixes

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -144,25 +144,33 @@ int main(int argc, const char* argv[]) {
 #endif
     }
 
+
+    // FIXME this method of checking the OpenGL version screws up the `QOpenGLContext::globalShareContext()` value, which in turn
+    // leads to crashes when creating the real OpenGL instance.  Disabling for now until we come up with a better way of checking
+    // the GL version on the system without resorting to creating a full Qt application
+#if 0
     // Check OpenGL version.
     // This is done separately from the main Application so that start-up and shut-down logic within the main Application is
     // not made more complicated than it already is.
-    bool override = false;
+    bool overrideGLCheck = false;
+
     QJsonObject glData;
     {
         OpenGLVersionChecker openGLVersionChecker(argc, const_cast<char**>(argv));
         bool valid = true;
-        glData = openGLVersionChecker.checkVersion(valid, override);
+        glData = openGLVersionChecker.checkVersion(valid, overrideGLCheck);
         if (!valid) {
-            if (override) {
+            if (overrideGLCheck) {
                 auto glVersion = glData["version"].toString();
-                qCDebug(interfaceapp, "Running on insufficient OpenGL version: %s.", glVersion.toStdString().c_str());
+                qCWarning(interfaceapp, "Running on insufficient OpenGL version: %s.", glVersion.toStdString().c_str());
             } else {
-                qCDebug(interfaceapp, "Early exit due to OpenGL version.");
+                qCWarning(interfaceapp, "Early exit due to OpenGL version.");
                 return 0;
             }
         }
     }
+#endif
+
 
     // Debug option to demonstrate that the client's local time does not
     // need to be in sync with any other network node. This forces clock
@@ -223,8 +231,9 @@ int main(int argc, const char* argv[]) {
 
         Application app(argcExtended, const_cast<char**>(argvExtended.data()), startupTime, runningMarkerExisted);
 
+#if 0
         // If we failed the OpenGLVersion check, log it.
-        if (override) {
+        if (overrideGLcheck) {
             auto accountManager = DependencyManager::get<AccountManager>();
             if (accountManager->isLoggedIn()) {
                 UserActivityLogger::getInstance().insufficientGLVersion(glData);
@@ -238,6 +247,8 @@ int main(int argc, const char* argv[]) {
                 });
             }
         }
+#endif
+        
 
         // Setup local server
         QLocalServer server { &app };

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -91,7 +91,12 @@ void entitiesScriptEngineDeleter(ScriptEngine* engine) {
     };
 
     // Wait for the scripting thread from the thread pool to avoid hanging the main thread
-    QThreadPool::globalInstance()->start(new WaitRunnable(engine));
+    auto threadPool = QThreadPool::globalInstance();
+    if (threadPool) {
+        threadPool->start(new WaitRunnable(engine));
+    } else {
+        delete engine;
+    }
 }
 
 void EntityTreeRenderer::resetEntitiesScriptEngine() {

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.h
@@ -93,9 +93,8 @@ private:
     };
 
 
-    void createParticle(uint64_t now);
+    static CpuParticle createParticle(uint64_t now, const Transform& baseTransform, const particle::Properties& particleProperties);
     void stepSimulation();
-    bool emitting() const;
 
     particle::Properties _particleProperties;
     CpuParticles _cpuParticles;

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -30,14 +30,11 @@ TextEntityRenderer::TextEntityRenderer(const EntityItemPointer& entity) :
 
 }
 
-
-void TextEntityRenderer::onRemoveFromSceneTyped(const TypedEntityPointer& entity) {
+TextEntityRenderer::~TextEntityRenderer() {
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (_geometryID && geometryCache) {
         geometryCache->releaseID(_geometryID);
     }
-    delete _textRenderer;
-    _textRenderer = nullptr;
 }
 
 bool TextEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const {

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.h
@@ -24,14 +24,13 @@ class TextEntityRenderer : public TypedEntityRenderer<TextEntityItem> {
     using Pointer = std::shared_ptr<TextEntityRenderer>;
 public:
     TextEntityRenderer(const EntityItemPointer& entity);
-
+    ~TextEntityRenderer();
 private:
-    virtual void onRemoveFromSceneTyped(const TypedEntityPointer& entity) override;
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
     virtual void doRender(RenderArgs* args) override;
     int _geometryID{ 0 };
-    TextRenderer3D* _textRenderer;
+    std::shared_ptr<TextRenderer3D> _textRenderer;
     bool _faceCamera;
     glm::vec3 _dimensions;
     glm::vec3 _textColor;

--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -104,7 +104,7 @@ bool operator!=(const Properties& a, const Properties& b) {
     return !(a == b);
 }
 
-bool particle::Properties::valid() const {
+bool Properties::valid() const {
     if (glm::any(glm::isnan(emission.orientation))) {
         qCWarning(entities) << "Bad particle data";
         return false;
@@ -132,6 +132,19 @@ bool particle::Properties::valid() const {
         (radius.range.finish == glm::clamp(radius.range.finish, MINIMUM_PARTICLE_RADIUS, MAXIMUM_PARTICLE_RADIUS)) &&
         (radius.gradient.spread == glm::clamp(radius.gradient.spread, MINIMUM_PARTICLE_RADIUS, MAXIMUM_PARTICLE_RADIUS));
 }
+
+bool Properties::emitting() const {
+    return emission.rate > 0.0f && lifespan > 0.0f && polar.start <= polar.finish;
+    
+}
+
+uint64_t Properties::emitIntervalUsecs() const {
+    if (emission.rate > 0.0f) {
+        return (uint64_t)(USECS_PER_SECOND / emission.rate);
+    }
+    return 0;
+}
+
 
 EntityItemPointer ParticleEffectEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
     EntityItemPointer entity { new ParticleEffectEntityItem(entityID) };

--- a/libraries/entities/src/ParticleEffectEntityItem.h
+++ b/libraries/entities/src/ParticleEffectEntityItem.h
@@ -160,7 +160,9 @@ namespace particle {
         Properties() {};
         Properties(const Properties& other) { *this = other; }
         bool valid() const;
-
+        bool emitting() const;
+        uint64_t emitIntervalUsecs() const;
+        
         Properties& operator =(const Properties& other) {
             color = other.color;
             alpha = other.alpha;

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -40,8 +40,11 @@ const QSurfaceFormat& getDefaultOpenGLSurfaceFormat() {
 
 int glVersionToInteger(QString glVersion) {
     QStringList versionParts = glVersion.split(QRegularExpression("[\\.\\s]"));
-    int majorNumber = versionParts[0].toInt();
-    int minorNumber = versionParts[1].toInt();
+    int majorNumber = 0, minorNumber = 0;
+    if (versionParts.size() >= 2) {
+        majorNumber = versionParts[0].toInt();
+        minorNumber = versionParts[1].toInt();
+    }
     return (majorNumber << 16) | minorNumber;
 }
 

--- a/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLTexture.cpp
@@ -467,12 +467,14 @@ void GLVariableAllocationSupport::updateMemoryPressure() {
         _demoteQueue = WorkQueue();
 
         // Populate the existing textures into the queue
-        for (const auto& texture : strongTextures) {
-            // Race conditions can still leave nulls in the list, so we need to check
-            if (!texture) {
-                continue;
+        if (_memoryPressureState != MemoryPressureState::Idle) {
+            for (const auto& texture : strongTextures) {
+                // Race conditions can still leave nulls in the list, so we need to check
+                if (!texture) {
+                    continue;
+                }
+                addToWorkQueue(texture);
             }
-            addToWorkQueue(texture);
         }
     }
 }

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -528,6 +528,12 @@ void OffscreenQmlSurface::create() {
 
     connect(_quickWindow, &QQuickWindow::focusObjectChanged, this, &OffscreenQmlSurface::onFocusObjectChanged);
 
+    // acquireEngine interrogates the GL context, so we need to have the context current here
+    if (!_canvas->makeCurrent()) {
+        qFatal("Failed to make context current for QML Renderer");
+        return;
+    }
+    
     // Create a QML engine.
     auto qmlEngine = acquireEngine(_quickWindow);
 
@@ -540,11 +546,6 @@ void OffscreenQmlSurface::create() {
     // FIXME Compatibility mechanism for existing HTML and JS that uses eventBridgeWrapper
     // Find a way to flag older scripts using this mechanism and wanr that this is deprecated
     _qmlContext->setContextProperty("eventBridgeWrapper", new EventBridgeWrapper(this, _qmlContext));
-
-    if (!_canvas->makeCurrent()) {
-        qWarning("Failed to make context current for QML Renderer");
-        return;
-    }
     _renderControl->initialize(_canvas->getContext());
 
     // When Quick says there is a need to render, we will not render immediately. Instead,


### PR DESCRIPTION
## Note

This PR can be QA'd and dev approved but should not be merged until ops enables Qt 5.9.1 builds for mac for the main development build

## Fixes

* Rendering freezing when executing a handshake
* A crash on startup
* A potential crash on leaving a domain with a text entity
* A potential crash on shutdown (there may be others)

## Testing

With a mac client and a fresh install, start up the application.  On clean installs with the current master this may always crash.  

Uses the X command on the keyboard to extend your hand for a handshake and shake hands with another avatar who is doing the same.  On master builds this will cause the rendering to simply stop rendering, while the application continues running.  On this build it should not freeze.

This build may still crash on shutdown, but I want to defer that to another PR if it does.  It may also have been something specific to a debug build that triggered that crash.  