### PR TITLE
Use new hfc account endpoint

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -33,12 +33,19 @@ Rectangle {
     Hifi.QmlCommerce {
         id: commerce;
 
+        onAccountResult: {
+            if(result.status === "success") {
+                commerce.getKeyFilePathIfExists();
+            } else {
+                // unsure how to handle a failure here. We definitely cannot proceed.
+            }
+        }
         onLoginStatusResult: {
             if (!isLoggedIn && root.activeView !== "needsLogIn") {
                 root.activeView = "needsLogIn";
             } else if (isLoggedIn) {
                 root.activeView = "initialize";
-                commerce.getKeyFilePathIfExists();
+                commerce.account();
             }
         }
 

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -34,7 +34,7 @@ Rectangle {
         id: commerce;
 
         onAccountResult: {
-            if(result.status === "success") {
+            if (result.status === "success") {
                 commerce.getKeyFilePathIfExists();
             } else {
                 // unsure how to handle a failure here. We definitely cannot proceed.

--- a/interface/src/commerce/Ledger.h
+++ b/interface/src/commerce/Ledger.h
@@ -29,6 +29,7 @@ public:
     void balance(const QStringList& keys);
     void inventory(const QStringList& keys);
     void history(const QStringList& keys);
+    void account();
     void reset();
 
 signals:
@@ -37,6 +38,7 @@ signals:
     void balanceResult(QJsonObject result);
     void inventoryResult(QJsonObject result);
     void historyResult(QJsonObject result);
+    void accountResult(QJsonObject result);
 
 public slots:
     void buySuccess(QNetworkReply& reply);
@@ -51,6 +53,8 @@ public slots:
     void historyFailure(QNetworkReply& reply);
     void resetSuccess(QNetworkReply& reply);
     void resetFailure(QNetworkReply& reply);
+    void accountSuccess(QNetworkReply& reply);
+    void accountFailure(QNetworkReply& reply);
 
 private:
     QJsonObject apiResponse(const QString& label, QNetworkReply& reply);

--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -27,6 +27,7 @@ QmlCommerce::QmlCommerce(QQuickItem* parent) : OffscreenQmlDialog(parent) {
     connect(wallet.data(), &Wallet::securityImageResult, this, &QmlCommerce::securityImageResult);
     connect(ledger.data(), &Ledger::historyResult, this, &QmlCommerce::historyResult);
     connect(wallet.data(), &Wallet::keyFilePathIfExistsResult, this, &QmlCommerce::keyFilePathIfExistsResult);
+    connect(ledger.data(), &Ledger::accountResult, this, &QmlCommerce::accountResult);
 }
 
 void QmlCommerce::getLoginStatus() {
@@ -105,4 +106,9 @@ void QmlCommerce::reset() {
     auto wallet = DependencyManager::get<Wallet>();
     ledger->reset();
     wallet->reset();
+}
+
+void QmlCommerce::account() {
+    auto ledger = DependencyManager::get<Ledger>();
+    ledger->account();
 }

--- a/interface/src/commerce/QmlCommerce.h
+++ b/interface/src/commerce/QmlCommerce.h
@@ -39,6 +39,7 @@ signals:
     void balanceResult(QJsonObject result);
     void inventoryResult(QJsonObject result);
     void historyResult(QJsonObject result);
+    void accountResult(QJsonObject result);
 
 protected:
     Q_INVOKABLE void getLoginStatus();
@@ -55,6 +56,7 @@ protected:
     Q_INVOKABLE void history();
     Q_INVOKABLE void generateKeyPair();
     Q_INVOKABLE void reset();
+    Q_INVOKABLE void account();
 };
 
 #endif // hifi_QmlCommerce_h

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -257,10 +257,10 @@ RSA* readPrivateKey(const char* filename) {
 static const unsigned char IVEC[16] = "IAmAnIVecYay123";
 
 void initializeAESKeys(unsigned char* ivec, unsigned char* ckey, const QByteArray& salt) {
-    // first ivec
-    memcpy(ivec, IVEC, 16);
-    auto hash = QCryptographicHash::hash(salt, QCryptographicHash::Sha256);
-    memcpy(ckey, hash.data(), 32);
+    // use the ones in the wallet
+    auto wallet = DependencyManager::get<Wallet>();
+    memcpy(ivec, wallet->getIv(), 16);
+    memcpy(ckey, wallet->getCKey(), 32);
 }
 
 Wallet::~Wallet() {

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -35,6 +35,10 @@ public:
 
     void setSalt(const QByteArray& salt) { _salt = salt; }
     QByteArray getSalt() { return _salt; }
+    void setIv(const QByteArray& iv) { _iv = iv; }
+    QByteArray getIv() { return _iv; }
+    void setCKey(const QByteArray& ckey) { _ckey = ckey; }
+    QByteArray getCKey() { return _ckey; }
 
     void setPassphrase(const QString& passphrase);
     QString* getPassphrase() { return _passphrase; }
@@ -52,6 +56,8 @@ private:
     QStringList _publicKeys{};
     QPixmap* _securityImage { nullptr };
     QByteArray _salt {"iamsalt!"};
+    QByteArray _iv;
+    QByteArray _ckey;
     QString* _passphrase { new QString("") };
 
     void updateImageProvider();


### PR DESCRIPTION
Eliminated hardcoded salt, we now get that from the server via a new call to the metaverse.  While at it, we get the iv and ckey we use to encrypt the security image (and soon maybe public keys) from the server too.  Also now really using the salt with the passphrase, which we'd not bothered with until now.  

