### PR TITLE
WL 21537 - Improve log naming

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2095,8 +2095,6 @@ Application::~Application() {
     _octreeProcessor.terminate();
     _entityEditSender.terminate();
 
-    disconnect(getMyAvatar().get(), &AvatarData::sessionUUIDChanged, _logger, nullptr);
-
     DependencyManager::destroy<AvatarManager>();
     DependencyManager::destroy<AnimationCache>();
     DependencyManager::destroy<FramebufferCache>();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -510,6 +510,13 @@ void messageHandler(QtMsgType type, const QMessageLogContext& context, const QSt
         OutputDebugStringA(logMessage.toLocal8Bit().constData());
         OutputDebugStringA("\n");
 #endif
+        auto avatarManager = DependencyManager::get<AvatarManager>();
+        auto myAvatar = avatarManager ? avatarManager->getMyAvatar() : nullptr;
+
+        QUuid fileLoggerSessionID = myAvatar->getSessionUUID();
+        if (!fileLoggerSessionID.isNull()) {
+            qApp->getLogger()->setSessionID(fileLoggerSessionID);
+        }
         qApp->getLogger()->addMessage(qPrintable(logMessage + "\n"));
     }
 }
@@ -804,6 +811,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _deadlockWatchdogThread = new DeadlockWatchdogThread();
     _deadlockWatchdogThread->start();
 
+    // Set File Logger Session UUID
+    auto avatarManager = DependencyManager::get<AvatarManager>();
+    auto myAvatar = avatarManager ? avatarManager->getMyAvatar() : nullptr;
+
     if (steamClient) {
         qCDebug(interfaceapp) << "[VERSION] SteamVR buildID:" << steamClient->getSteamVRBuildID();
     }
@@ -919,8 +930,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     // send a location update immediately
     discoverabilityManager->updateLocation();
-
-    auto myAvatar = getMyAvatar();
 
     connect(nodeList.data(), &NodeList::nodeAdded, this, &Application::nodeAdded);
     connect(nodeList.data(), &NodeList::nodeKilled, this, &Application::nodeKilled);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -789,9 +789,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 #endif
 
     
-    qInstallMessageHandler(messageHandler);
-
     _logger = new FileLogger(this);
+    qInstallMessageHandler(messageHandler);
 
     connect(getMyAvatar().get(), &AvatarData::sessionUUIDChanged, _logger, [this] {
         auto myAvatar = getMyAvatar();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -937,9 +937,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // you might think we could just do this in NodeList but we only want this connection for Interface
     connect(nodeList.data(), &NodeList::limitOfSilentDomainCheckInsReached, nodeList.data(), &NodeList::reset);
 
-    // connect to appropriate slots on AccountManager
-    // auto accountManager = DependencyManager::get<AccountManager>();
-
     auto dialogsManager = DependencyManager::get<DialogsManager>();
     connect(accountManager.data(), &AccountManager::authRequired, dialogsManager.data(), &DialogsManager::showLoginDialog);
     connect(accountManager.data(), &AccountManager::usernameChanged, this, &Application::updateWindowTitle);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -513,10 +513,13 @@ void messageHandler(QtMsgType type, const QMessageLogContext& context, const QSt
         auto avatarManager = DependencyManager::get<AvatarManager>();
         auto myAvatar = avatarManager ? avatarManager->getMyAvatar() : nullptr;
 
-        QUuid fileLoggerSessionID = myAvatar->getSessionUUID();
-        if (!fileLoggerSessionID.isNull()) {
-            qApp->getLogger()->setSessionID(fileLoggerSessionID);
+        if (myAvatar) {
+            QUuid fileLoggerSessionID = myAvatar->getSessionUUID();
+            if (!fileLoggerSessionID.isNull()) {
+                qApp->getLogger()->setSessionID(fileLoggerSessionID);
+            }
         }
+
         qApp->getLogger()->addMessage(qPrintable(logMessage + "\n"));
     }
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -792,14 +792,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _logger = new FileLogger(this);
     qInstallMessageHandler(messageHandler);
 
-    connect(getMyAvatar().get(), &AvatarData::sessionUUIDChanged, _logger, [this] {
-        auto myAvatar = getMyAvatar();
-        if (myAvatar) {
-            _logger->setSessionID(myAvatar->getSessionUUID());
-        }
-    });
-
-
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "styles/Inconsolata.otf");
     _window->setWindowTitle("High Fidelity Interface");
 
@@ -815,6 +807,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // Set File Logger Session UUID
     auto avatarManager = DependencyManager::get<AvatarManager>();
     auto myAvatar = avatarManager ? avatarManager->getMyAvatar() : nullptr;
+    auto accountManager = DependencyManager::get<AccountManager>();
+
+    _logger->setSessionID(accountManager->getSessionID());
 
     if (steamClient) {
         qCDebug(interfaceapp) << "[VERSION] SteamVR buildID:" << steamClient->getSteamVRBuildID();
@@ -943,7 +938,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(nodeList.data(), &NodeList::limitOfSilentDomainCheckInsReached, nodeList.data(), &NodeList::reset);
 
     // connect to appropriate slots on AccountManager
-    auto accountManager = DependencyManager::get<AccountManager>();
+    // auto accountManager = DependencyManager::get<AccountManager>();
 
     auto dialogsManager = DependencyManager::get<DialogsManager>();
     connect(accountManager.data(), &AccountManager::authRequired, dialogsManager.data(), &DialogsManager::showLoginDialog);

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -381,7 +381,7 @@ class AvatarData : public QObject, public SpatiallyNestable {
 
     Q_PROPERTY(QStringList jointNames READ getJointNames)
 
-    Q_PROPERTY(QUuid sessionUUID READ getSessionUUID)
+    Q_PROPERTY(QUuid sessionUUID READ getSessionUUID NOTIFY sessionUUIDChanged)
 
     Q_PROPERTY(glm::mat4 sensorToWorldMatrix READ getSensorToWorldMatrix)
     Q_PROPERTY(glm::mat4 controllerLeftHandMatrix READ getControllerLeftHandMatrix)
@@ -667,13 +667,19 @@ public:
 signals:
     void displayNameChanged();
     void lookAtSnappingChanged(bool enabled);
+    void sessionUUIDChanged();
 
 public slots:
     void sendAvatarDataPacket();
     void sendIdentityPacket();
 
     void setJointMappingsFromNetworkReply();
-    void setSessionUUID(const QUuid& sessionUUID) { setID(sessionUUID); }
+    void setSessionUUID(const QUuid& sessionUUID) {
+        if (sessionUUID != getID()) {
+            setID(sessionUUID);
+            emit sessionUUIDChanged();
+        }
+    }
 
     virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
     virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -41,7 +41,7 @@ private:
 
 
 
-static const QString FILENAME_FORMAT = "hifi-log%1_%2.txt";
+static const QString FILENAME_FORMAT = "hifi-log_%1%2.txt";
 static const QString DATETIME_FORMAT = "yyyy-MM-dd_hh.mm.ss";
 static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
@@ -69,7 +69,7 @@ QString getLogRollerFilename() {
         fileSessionID = "_" + SESSION_ID.toString().replace("{", "").replace("}", "");
     }
 
-    result.append(QString(FILENAME_FORMAT).arg(fileSessionID, now.toString(DATETIME_FORMAT)));
+    result.append(QString(FILENAME_FORMAT).arg(now.toString(DATETIME_FORMAT), fileSessionID));
     return result;
 }
 

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -48,7 +48,7 @@ static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
 static const QString DATETIME_WILDCARD = "20[0-9][0-9]-[0,1][0-9]-[0-3][0-9]_[0-2][0-9].[0-6][0-9].[0-6][0-9]";
 static const QString FILENAME_WILDCARD = "hifi-log_" + IPADDR_WILDCARD + "_" + DATETIME_WILDCARD + ".txt";
-static QUuid& SESSION_ID = QUuid("{00000000-0000-0000-0000-000000000000}");
+QUuid& SESSION_ID = QUuid("{00000000-0000-0000-0000-000000000000}");
 
 // Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
 // small so it doesn't go over the 2MB zipped limit for all of the files we send.

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -48,6 +48,8 @@ static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
 static const QString DATETIME_WILDCARD = "20[0-9][0-9]-[0,1][0-9]-[0-3][0-9]_[0-2][0-9].[0-6][0-9].[0-6][0-9]";
 static const QString FILENAME_WILDCARD = "hifi-log_" + IPADDR_WILDCARD + "_" + DATETIME_WILDCARD + ".txt";
+static QUuid& SESSION_ID = QUuid::QUuid("{00000000-0000-0000-0000-000000000000}");
+
 // Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
 // small so it doesn't go over the 2MB zipped limit for all of the files we send.
 static const qint64 MAX_LOG_SIZE = 512 * 1024;
@@ -62,7 +64,10 @@ QString getLogRollerFilename() {
     QString result = FileUtils::standardPath(LOGS_DIRECTORY);
     QHostAddress clientAddress = getGuessedLocalAddress();
     QDateTime now = QDateTime::currentDateTime();
-    result.append(QString(FILENAME_FORMAT).arg(clientAddress.toString(), now.toString(DATETIME_FORMAT)));
+
+    auto FILE_SESSION_ID = SESSION_ID.toString().replace("{", "").replace("}", "");
+
+    result.append(QString(FILENAME_FORMAT).arg(FILE_SESSION_ID, now.toString(DATETIME_FORMAT)));
     return result;
 }
 
@@ -140,6 +145,10 @@ FileLogger::FileLogger(QObject* parent) :
 
 FileLogger::~FileLogger() {
     _persistThreadInstance->terminate();
+}
+
+void FileLogger::setSessionID(const QUuid& message) {
+    SESSION_ID = message; // This is for the output of log files. It will change if the Avatar enters a different domain.
 }
 
 void FileLogger::addMessage(const QString& message) {

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -48,7 +48,7 @@ static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
 static const QString DATETIME_WILDCARD = "20[0-9][0-9]-[0,1][0-9]-[0-3][0-9]_[0-2][0-9].[0-6][0-9].[0-6][0-9]";
 static const QString FILENAME_WILDCARD = "hifi-log_" + IPADDR_WILDCARD + "_" + DATETIME_WILDCARD + ".txt";
-QUuid SESSION_ID;
+QUuid _sessionId;
 
 // Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
 // small so it doesn't go over the 2MB zipped limit for all of the files we send.
@@ -64,13 +64,13 @@ QString getLogRollerFilename() {
     QString result = FileUtils::standardPath(LOGS_DIRECTORY);
     QHostAddress clientAddress = getGuessedLocalAddress();
     QDateTime now = QDateTime::currentDateTime();
-    QString FILE_SESSION_ID;
+    QString fileSessionID;
 
-    if (!SESSION_ID.isNull()) {
-        FILE_SESSION_ID = "_" + SESSION_ID.toString().replace("{", "").replace("}", "");
+    if (!_sessionId.isNull()) {
+        fileSessionID = "_" + _sessionId.toString().replace("{", "").replace("}", "");
     }
 
-    result.append(QString(FILENAME_FORMAT).arg(FILE_SESSION_ID, now.toString(DATETIME_FORMAT)));
+    result.append(QString(FILENAME_FORMAT).arg(fileSessionID, now.toString(DATETIME_FORMAT)));
     return result;
 }
 
@@ -151,8 +151,10 @@ FileLogger::~FileLogger() {
 }
 
 void FileLogger::setSessionID(const QUuid& message) {
-    SESSION_ID = message; // This is for the output of log files. It will change if the Avatar enters a different domain.
-}
+    // This is for the output of log files. Once the application is first started, 
+    // this function runs and grabs the AccountManager Session ID and saves it here.
+    _sessionId = message;
+    }
 
 void FileLogger::addMessage(const QString& message) {
     _persistThreadInstance->queueItem(message);

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -26,7 +26,6 @@ class FilePersistThread : public GenericQueueThread < QString > {
     Q_OBJECT
 public:
     FilePersistThread(const FileLogger& logger);
-
 signals:
     void rollingLogFile(QString newFilename);
 
@@ -48,7 +47,7 @@ static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
 static const QString DATETIME_WILDCARD = "20[0-9][0-9]-[0,1][0-9]-[0-3][0-9]_[0-2][0-9].[0-6][0-9].[0-6][0-9]";
 static const QString FILENAME_WILDCARD = "hifi-log_" + IPADDR_WILDCARD + "_" + DATETIME_WILDCARD + ".txt";
-QUuid _sessionId;
+static QUuid SESSION_ID;
 
 // Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
 // small so it doesn't go over the 2MB zipped limit for all of the files we send.
@@ -66,8 +65,8 @@ QString getLogRollerFilename() {
     QDateTime now = QDateTime::currentDateTime();
     QString fileSessionID;
 
-    if (!_sessionId.isNull()) {
-        fileSessionID = "_" + _sessionId.toString().replace("{", "").replace("}", "");
+    if (!SESSION_ID.isNull()) {
+        fileSessionID = "_" + SESSION_ID.toString().replace("{", "").replace("}", "");
     }
 
     result.append(QString(FILENAME_FORMAT).arg(fileSessionID, now.toString(DATETIME_FORMAT)));
@@ -153,7 +152,7 @@ FileLogger::~FileLogger() {
 void FileLogger::setSessionID(const QUuid& message) {
     // This is for the output of log files. Once the application is first started, 
     // this function runs and grabs the AccountManager Session ID and saves it here.
-    _sessionId = message;
+    SESSION_ID = message;
     }
 
 void FileLogger::addMessage(const QString& message) {

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -48,7 +48,7 @@ static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
 static const QString DATETIME_WILDCARD = "20[0-9][0-9]-[0,1][0-9]-[0-3][0-9]_[0-2][0-9].[0-6][0-9].[0-6][0-9]";
 static const QString FILENAME_WILDCARD = "hifi-log_" + IPADDR_WILDCARD + "_" + DATETIME_WILDCARD + ".txt";
-QUuid& SESSION_ID = QUuid("{00000000-0000-0000-0000-000000000000}");
+QUuid SESSION_ID = QUuid("{00000000-0000-0000-0000-000000000000}");
 
 // Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
 // small so it doesn't go over the 2MB zipped limit for all of the files we send.

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -42,13 +42,13 @@ private:
 
 
 
-static const QString FILENAME_FORMAT = "hifi-log_%1_%2.txt";
+static const QString FILENAME_FORMAT = "hifi-log%1_%2.txt";
 static const QString DATETIME_FORMAT = "yyyy-MM-dd_hh.mm.ss";
 static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
 static const QString DATETIME_WILDCARD = "20[0-9][0-9]-[0,1][0-9]-[0-3][0-9]_[0-2][0-9].[0-6][0-9].[0-6][0-9]";
 static const QString FILENAME_WILDCARD = "hifi-log_" + IPADDR_WILDCARD + "_" + DATETIME_WILDCARD + ".txt";
-QUuid SESSION_ID = QUuid("{00000000-0000-0000-0000-000000000000}");
+QUuid SESSION_ID;
 
 // Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
 // small so it doesn't go over the 2MB zipped limit for all of the files we send.
@@ -64,8 +64,11 @@ QString getLogRollerFilename() {
     QString result = FileUtils::standardPath(LOGS_DIRECTORY);
     QHostAddress clientAddress = getGuessedLocalAddress();
     QDateTime now = QDateTime::currentDateTime();
+    QString FILE_SESSION_ID;
 
-    auto FILE_SESSION_ID = SESSION_ID.toString().replace("{", "").replace("}", "");
+    if (!SESSION_ID.isNull()) {
+        FILE_SESSION_ID = "_" + SESSION_ID.toString().replace("{", "").replace("}", "");
+    }
 
     result.append(QString(FILENAME_FORMAT).arg(FILE_SESSION_ID, now.toString(DATETIME_FORMAT)));
     return result;

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -48,7 +48,7 @@ static const QString LOGS_DIRECTORY = "Logs";
 static const QString IPADDR_WILDCARD = "[0-9]*.[0-9]*.[0-9]*.[0-9]*";
 static const QString DATETIME_WILDCARD = "20[0-9][0-9]-[0,1][0-9]-[0-3][0-9]_[0-2][0-9].[0-6][0-9].[0-6][0-9]";
 static const QString FILENAME_WILDCARD = "hifi-log_" + IPADDR_WILDCARD + "_" + DATETIME_WILDCARD + ".txt";
-static QUuid& SESSION_ID = QUuid::QUuid("{00000000-0000-0000-0000-000000000000}");
+static QUuid& SESSION_ID = QUuid("{00000000-0000-0000-0000-000000000000}");
 
 // Max log size is 512 KB. We send log files to our crash reporter, so we want to keep this relatively
 // small so it doesn't go over the 2MB zipped limit for all of the files we send.

--- a/libraries/shared/src/shared/FileLogger.h
+++ b/libraries/shared/src/shared/FileLogger.h
@@ -26,6 +26,7 @@ public:
 
     QString getFilename() const { return _fileName; }
     virtual void addMessage(const QString&) override;
+    virtual void setSessionID(const QUuid&);
     virtual QString getLogData() override;
     virtual void locateLog() override;
     virtual void sync() override;


### PR DESCRIPTION
> Improve log naming so that logs from a single session can be grouped together by their filename.
> Rename log files to the following format:
> hifi-log_{session_id}_{date}_{time}

# Test Plan
1. Install this PR
2. Keep an eye on the Log Directory `(eg. %appdata%\Local\High Fidelity - PR11326\Interface\Logs)`
3. Check that the filename, once rolled over past 512KB, changes to something like `hifi-log_a2ccebf6-926e-498e-bb83-31a6184e76c7_2017-09-08_03.17.00.txt`
4. Check that switching domains and building the log file up to roll again prints out the same UUID.
5. If there's a log file (`hifi-log.txt`) inside the directory and you launch the Interface, it should create a more simple log file name like `hifi-log_2017-09-09_17.17.53.txt`.

Over time your directory will start looking like below:
![013de998-1042-4a17-b6df-fab0f2f6b7df](https://user-images.githubusercontent.com/898687/30193494-5c0eb5d6-9445-11e7-9379-c3cd53f79d41.png)


[Worklist #21537](https://worklist.net/21537) (thanks @jherico for the help!)