### PR TITLE
Fix MyAvatar getting stuck in T-pose on loading

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -648,7 +648,9 @@ void Avatar::render(RenderArgs* renderArgs) {
         return;
     }
 
-    fixupModelsInScene(renderArgs->_scene);
+    if (!isMyAvatar()) {
+        fixupModelsInScene(renderArgs->_scene);
+    }
 
     if (showCollisionShapes && shouldRenderHead(renderArgs) && _skeletonModel->isRenderable()) {
         PROFILE_RANGE_BATCH(batch, __FUNCTION__":skeletonBoundingCollisionShapes");


### PR DESCRIPTION
Before this change, there was a race condition between the main thread calling Model::initWhenReady,
and the render thread calling Avatar::fixupModelsInScene().  They both would end up setting the
Model::_addedToScene flag.  This race caused Model::initWhenReady() to never return true, which
resulted in the MyAvatar class never initializing the animation system.