### PR TITLE
brew tap homebrew/versions no longer works. (or is needed)

### DIFF
--- a/BUILD_OSX.md
+++ b/BUILD_OSX.md
@@ -4,7 +4,6 @@ Please read the [general build guide](BUILD.md) for information on dependencies 
 
 [Homebrew](https://brew.sh/) is an excellent package manager for OS X. It makes install of some High Fidelity dependencies very simple.
 
-    brew tap homebrew/versions
     brew install cmake openssl
 
 ### OpenSSL


### PR DESCRIPTION
The command now outputs:

> brew tap homebrew/versions
Warning: homebrew/versions was deprecated. This tap is now empty as all its formulae were migrated.

nonetheless: 

>   brew install cmake openssl

still works.