### PR TITLE
WL21389 PR2: Representation of collision shapes need updating (details below).

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -120,6 +120,7 @@
 #include <SceneScriptingInterface.h>
 #include <ScriptEngines.h>
 #include <ScriptCache.h>
+#include <ShapeEntityItem.h>
 #include <SoundCache.h>
 #include <ui/TabletScriptingInterface.h>
 #include <ui/ToolbarScriptingInterface.h>
@@ -4227,6 +4228,10 @@ void Application::init() {
 
     // fire off an immediate domain-server check in now that settings are loaded
     DependencyManager::get<NodeList>()->sendDomainServerCheckIn();
+
+    // This allows collision to be set up properly for shape entities supported by GeometryCache.
+    // This is before entity setup to ensure that it's ready for whenever instance collision is initialized.
+    ShapeEntityItem::setShapeInfoCalulator(ShapeEntityItem::ShapeInfoCalculator(&shapeInfoCalculator));
 
     getEntities()->init();
     getEntities()->setEntityLoadingPriorityFunction([this](const EntityItem& item) {

--- a/interface/src/Util.cpp
+++ b/interface/src/Util.cpp
@@ -398,9 +398,9 @@ void runUnitTests() {
 void shapeInfoCalculator(const ShapeEntityItem * const shapeEntity, ShapeInfo &shapeInfo) {
     ShapeInfo::PointCollection pointCollection;
     ShapeInfo::PointList points;
-
-    GeometryCache::computeSimpleHullPointListForShape(shapeEntity, points);
     pointCollection.push_back(points);
+
+    GeometryCache::computeSimpleHullPointListForShape(shapeEntity, pointCollection.back());
     shapeInfo.setPointCollection(pointCollection);
 }
 

--- a/interface/src/Util.cpp
+++ b/interface/src/Util.cpp
@@ -28,6 +28,8 @@
 #include <GeometryCache.h>
 #include <OctreeConstants.h>
 #include <SharedUtil.h>
+#include <ShapeEntityItem.h>
+#include <ShapeInfo.h>
 
 #include "InterfaceLogging.h"
 #include "world.h"
@@ -391,6 +393,15 @@ void runUnitTests() {
         }
 
     }
+}
+
+void shapeInfoCalculator(const ShapeEntityItem * const shapeEntity, ShapeInfo &shapeInfo) {
+    ShapeInfo::PointCollection pointCollection;
+    ShapeInfo::PointList points;
+
+    GeometryCache::computeSimpleHullPointListForShape(shapeEntity, points);
+    pointCollection.push_back(points);
+    shapeInfo.setPointCollection(pointCollection);
 }
 
 

--- a/interface/src/Util.cpp
+++ b/interface/src/Util.cpp
@@ -407,7 +407,7 @@ void shapeInfoCalculator(const ShapeEntityItem * const shapeEntity, ShapeInfo &s
     ShapeInfo::PointList points;
     pointCollection.push_back(points);
 
-    GeometryCache::computeSimpleHullPointListForShape((int)shapeEntity->getShape(), shapeEntity->getDimensions() * 0.5f, pointCollection.back());
+    GeometryCache::computeSimpleHullPointListForShape((int)shapeEntity->getShape(), shapeEntity->getDimensions(), pointCollection.back());
     shapeInfo.setPointCollection(pointCollection);
 }
 

--- a/interface/src/Util.cpp
+++ b/interface/src/Util.cpp
@@ -396,11 +396,18 @@ void runUnitTests() {
 }
 
 void shapeInfoCalculator(const ShapeEntityItem * const shapeEntity, ShapeInfo &shapeInfo) {
+
+    if (shapeEntity == nullptr) {
+
+        //--EARLY EXIT--
+        return;
+    }
+
     ShapeInfo::PointCollection pointCollection;
     ShapeInfo::PointList points;
     pointCollection.push_back(points);
 
-    GeometryCache::computeSimpleHullPointListForShape(shapeEntity, pointCollection.back());
+    GeometryCache::computeSimpleHullPointListForShape((int)shapeEntity->getShape(), shapeEntity->getDimensions() * 0.5f, pointCollection.back());
     shapeInfo.setPointCollection(pointCollection);
 }
 

--- a/interface/src/Util.h
+++ b/interface/src/Util.h
@@ -18,6 +18,9 @@
 #include <gpu/Batch.h>
 #include <render/Forward.h>
 
+class ShapeEntityItem;
+class ShapeInfo;
+
 void renderWorldBox(RenderArgs* args, gpu::Batch& batch);
 
 void runTimingTests();
@@ -27,5 +30,7 @@ bool rayIntersectsSphere(const glm::vec3& rayStarting, const glm::vec3& rayNorma
     const glm::vec3& sphereCenter, float sphereRadius, float& distance);
 
 bool pointInSphere(glm::vec3& point, glm::vec3& sphereCenter, double sphereRadius);
+
+void shapeInfoCalculator(const ShapeEntityItem * const shapeEntity, ShapeInfo &shapeInfo);
 
 #endif // hifi_Util_h

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -154,6 +154,6 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
         }
     }
 
-    static const auto triCount = geometryCache->getShapeTriangleCount(geometryShape);
+    const auto triCount = geometryCache->getShapeTriangleCount(geometryShape);
     args->_details._trianglesRendered += (int)triCount;
 }

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -84,28 +84,11 @@ void EntityItemProperties::setLastEdited(quint64 usecTime) {
     _lastEdited = usecTime > _created ? usecTime : _created;
 }
 
-const char* shapeTypeNames[] = {
-    "none",
-    "box",
-    "sphere",
-    "capsule-x",
-    "capsule-y",
-    "capsule-z",
-    "cylinder-x",
-    "cylinder-y",
-    "cylinder-z",
-    "hull",
-    "plane",
-    "compound",
-    "simple-hull",
-    "simple-compound",
-    "static-mesh"
-};
 
 QHash<QString, ShapeType> stringToShapeTypeLookup;
 
 void addShapeType(ShapeType type) {
-    stringToShapeTypeLookup[shapeTypeNames[type]] = type;
+    stringToShapeTypeLookup[ShapeInfo::getNameForShapeType(type)] = type;
 }
 
 void buildStringToShapeTypeLookup() {
@@ -180,9 +163,7 @@ void EntityItemProperties::setCollisionMaskFromString(const QString& maskString)
 }
 
 QString EntityItemProperties::getShapeTypeAsString() const {
-    if (_shapeType < sizeof(shapeTypeNames) / sizeof(char *))
-        return QString(shapeTypeNames[_shapeType]);
-    return QString(shapeTypeNames[SHAPE_TYPE_NONE]);
+    return ShapeInfo::getNameForShapeType(_shapeType);
 }
 
 void EntityItemProperties::setShapeTypeFromString(const QString& shapeName) {

--- a/libraries/entities/src/ShapeEntityItem.cpp
+++ b/libraries/entities/src/ShapeEntityItem.cpp
@@ -283,15 +283,23 @@ void ShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
 
         }
         break;
-        // gons, ones, & angles built via GeometryCache::extrudePolygon
-        case entity::Shape::Triangle:
-        case entity::Shape::Hexagon:
-        case entity::Shape::Octagon:
         case entity::Shape::Cone: {
             if (shapeCalculator) {
                 shapeCalculator(this, info);
                 // shapeCalculator only supports convex shapes (e.g. SHAPE_TYPE_HULL)
-                // TODO: figure out how to support concave shapes
+                _collisionShapeType = SHAPE_TYPE_SIMPLE_HULL;
+            } else {
+                _collisionShapeType = SHAPE_TYPE_ELLIPSOID;
+            }
+        }
+        break;
+        // gons, ones, & angles built via GeometryCache::extrudePolygon
+        case entity::Shape::Triangle:
+        case entity::Shape::Hexagon:
+        case entity::Shape::Octagon: {
+            if (shapeCalculator) {
+                shapeCalculator(this, info);
+                // shapeCalculator only supports convex shapes (e.g. SHAPE_TYPE_HULL)
                 _collisionShapeType = SHAPE_TYPE_SIMPLE_HULL;
             } else {
                 _collisionShapeType = SHAPE_TYPE_ELLIPSOID;
@@ -306,12 +314,10 @@ void ShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
             if ( shapeCalculator ) {
                 shapeCalculator(this, info);
                 // shapeCalculator only supports convex shapes (e.g. SHAPE_TYPE_HULL)
-                // TODO: figure out how to support concave shapes
                 _collisionShapeType = SHAPE_TYPE_SIMPLE_HULL;
             } else {
                 _collisionShapeType = SHAPE_TYPE_ELLIPSOID;
             }
-
         }
         break;
         case entity::Shape::Torus: {

--- a/libraries/entities/src/ShapeEntityItem.cpp
+++ b/libraries/entities/src/ShapeEntityItem.cpp
@@ -95,6 +95,7 @@ EntityItemProperties ShapeEntityItem::getProperties(EntityPropertyFlags desiredP
 }
 
 void ShapeEntityItem::setShape(const entity::Shape& shape) {
+    const entity::Shape prevShape = _shape;
     _shape = shape;
     switch (_shape) {
         case entity::Shape::Cube:
@@ -106,6 +107,11 @@ void ShapeEntityItem::setShape(const entity::Shape& shape) {
         default:
             _type = EntityTypes::Shape;
             break;
+    }
+
+    if (_shape != prevShape) {
+        // Internally grabs writeLock
+        markDirtyFlags(Simulation::DIRTY_SHAPE);
     }
 }
 
@@ -227,6 +233,7 @@ void ShapeEntityItem::debugDump() const {
     qCDebug(entities) << "SHAPE EntityItem id:" << getEntityItemID() << "---------------------------------------------";
     qCDebug(entities) << "               name:" << _name;
     qCDebug(entities) << "              shape:" << stringFromShape(_shape) << " (EnumId: " << _shape << " )";
+    qCDebug(entities) << " collisionShapeType:" << ShapeInfo::getNameForShapeType(getShapeType());
     qCDebug(entities) << "              color:" << _color[0] << "," << _color[1] << "," << _color[2];
     qCDebug(entities) << "           position:" << debugTreeVector(getPosition());
     qCDebug(entities) << "         dimensions:" << debugTreeVector(getDimensions());

--- a/libraries/entities/src/ShapeEntityItem.h
+++ b/libraries/entities/src/ShapeEntityItem.h
@@ -34,7 +34,6 @@ namespace entity {
     ::QString stringFromShape(Shape shape);
 }
 
-
 class ShapeEntityItem : public EntityItem {
     using Pointer = std::shared_ptr<ShapeEntityItem>;
     static Pointer baseFactory(const EntityItemID& entityID, const EntityItemProperties& properties);
@@ -42,6 +41,9 @@ public:
     static EntityItemPointer factory(const EntityItemID& entityID, const EntityItemProperties& properties);
     static EntityItemPointer sphereFactory(const EntityItemID& entityID, const EntityItemProperties& properties);
     static EntityItemPointer boxFactory(const EntityItemID& entityID, const EntityItemProperties& properties);
+
+    using ShapeInfoCalculator = std::function<void(ShapeInfo& info, entity::Shape shape, glm::vec3 dimensions)>;
+    static void setShapeInfoCalulator(ShapeInfoCalculator callback);
 
     ShapeEntityItem(const EntityItemID& entityItemID);
 

--- a/libraries/entities/src/ShapeEntityItem.h
+++ b/libraries/entities/src/ShapeEntityItem.h
@@ -42,7 +42,7 @@ public:
     static EntityItemPointer sphereFactory(const EntityItemID& entityID, const EntityItemProperties& properties);
     static EntityItemPointer boxFactory(const EntityItemID& entityID, const EntityItemProperties& properties);
 
-    using ShapeInfoCalculator = std::function<void(ShapeInfo& info, entity::Shape shape, glm::vec3 dimensions)>;
+    using ShapeInfoCalculator = std::function<void( const ShapeEntityItem * const shapeEntity, ShapeInfo& info)>;
     static void setShapeInfoCalulator(ShapeInfoCalculator callback);
 
     ShapeEntityItem(const EntityItemID& entityItemID);

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -66,7 +66,7 @@ class PhysicsEngine;
 
 class ObjectMotionState : public btMotionState {
 public:
-    // These poroperties of the PhysicsEngine are "global" within the context of all ObjectMotionStates
+    // These properties of the PhysicsEngine are "global" within the context of all ObjectMotionStates
     // (assuming just one PhysicsEngine).  They are cached as statics for fast calculations in the
     // ObjectMotionState context.
     static void setWorldOffset(const glm::vec3& offset);

--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -314,6 +314,7 @@ const btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info)
             shape = new btCylinderShapeZ(btHalfExtents);
         }
         break;
+        case SHAPE_TYPE_CIRCLE:
         case SHAPE_TYPE_CYLINDER_Y: {
             const glm::vec3 halfExtents = info.getHalfExtents();
             const btVector3 btHalfExtents(halfExtents.x, halfExtents.y, halfExtents.z);

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -126,7 +126,7 @@ void GeometryCache::computeSimpleHullPointListForShape(const int entityShape, co
     QVector<glm::vec3> uniqueVerts;
     uniqueVerts.reserve((int)numItems);
 
-    const float SQUARED_MAX_INCLUSIVE_FILTER_DISTANCE = 0.0025f;
+    const float MAX_INCLUSIVE_FILTER_DISTANCE_SQUARED = 1.0e-6f; //< 1mm^2
     for (gpu::BufferView::Index i = 0; i < (gpu::BufferView::Index)numItems; ++i) {
         const int numUniquePoints = (int)uniqueVerts.size();
         const geometry::Vec &curVert = shapeVerts.get<geometry::Vec>(i);
@@ -136,7 +136,7 @@ void GeometryCache::computeSimpleHullPointListForShape(const int entityShape, co
             const geometry::Vec knownVert = uniqueVerts[uniqueIndex];
             const float distToKnownPoint = glm::length2(knownVert - curVert);
 
-            if (fabsf(distToKnownPoint) <= SQUARED_MAX_INCLUSIVE_FILTER_DISTANCE) {
+            if (distToKnownPoint <= MAX_INCLUSIVE_FILTER_DISTANCE_SQUARED) {
                 isUniquePoint = false;
                 break;
             }

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -113,7 +113,7 @@ void GeometryCache::computeSimpleHullPointListForShape(const ShapeEntityItem * c
     qCDebug(entities) << "------------------ Begin Vert Info( ComputeShapeInfo )[FlatShapes] -----------------------------";
     qCDebug(entities) << " name:" << shapePtr->getName() << ": has " << numItems << " vert info pairs.";
 #endif
-    outPointList.reserve(numItems);
+    outPointList.reserve((int)numItems);
     for (gpu::BufferView::Index i = 0; i < (gpu::BufferView::Index)numItems; ++i) {
         const geometry::Vec &curNorm = shapeNorms.get<geometry::Vec>(i);
 #if DEBUG_SIMPLE_HULL_POINT_GENERATION
@@ -514,7 +514,7 @@ void GeometryCache::buildShapes() {
 }
 
 const GeometryCache::ShapeData * GeometryCache::getShapeData(const Shape shape) const {
-    if (((int)shape < 0) || ((int)shape >= _shapes.size())){
+    if (((int)shape < 0) || ((int)shape >= (int)_shapes.size())){
         return nullptr;
     }
 
@@ -522,7 +522,7 @@ const GeometryCache::ShapeData * GeometryCache::getShapeData(const Shape shape) 
 }
 
 GeometryCache::Shape GeometryCache::getShapeForEntityShape(int entityShape) {
-    if ((entityShape < 0) || (entityShape >= MAPPING.size())){
+    if ((entityShape < 0) || (entityShape >= (int)MAPPING.size())){
         return GeometryCache::Sphere;
     }
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -96,7 +96,8 @@ void GeometryCache::computeSimpleHullPointListForShape(const ShapeEntityItem * c
     }
 
     auto geometryCache = DependencyManager::get<GeometryCache>();
-    const GeometryCache::ShapeData * shapeData = geometryCache->getShapeData(MAPPING[shapePtr->getShape()]);
+    const GeometryCache::Shape entityGeometryShape = GeometryCache::getShapeForEntityShape(shapePtr->getShape());
+    const GeometryCache::ShapeData * shapeData = geometryCache->getShapeData( entityGeometryShape );
     if (!shapeData){
         //--EARLY EXIT--( data isn't ready for some reason... )
         return;
@@ -522,7 +523,7 @@ const GeometryCache::ShapeData * GeometryCache::getShapeData(const Shape shape) 
 
 GeometryCache::Shape GeometryCache::getShapeForEntityShape(int entityShape) {
     if ((entityShape < 0) || (entityShape >= MAPPING.size())){
-        return NUM_SHAPES;
+        return GeometryCache::Sphere;
     }
 
     return MAPPING[entityShape];

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -105,7 +105,7 @@ void GeometryCache::computeSimpleHullPointListForShape(const int entityShape, co
     const gpu::BufferView & shapeNorms = shapeData->_normalView;
     assert(shapeData->_positionView._size == shapeNorms._size);
 
-    const gpu::BufferView::Size numItems = shapeVerts.getNumElements();
+    const gpu::BufferView::Size numItems = shapeNorms.getNumElements();
 
     outPointList.reserve((int)numItems);
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -108,31 +108,12 @@ void GeometryCache::computeSimpleHullPointListForShape(const ShapeEntityItem * c
 
     const gpu::BufferView::Size numItems = shapeVerts.getNumElements();
     const glm::vec3 halfExtents = shapePtr->getDimensions() * 0.5f;
-#if DEBUG_SIMPLE_HULL_POINT_GENERATION
-    shapePtr->debugDump();
-    qCDebug(entities) << "------------------ Begin Vert Info( ComputeShapeInfo )[FlatShapes] -----------------------------";
-    qCDebug(entities) << " name:" << shapePtr->getName() << ": has " << numItems << " vert info pairs.";
-#endif
+
     outPointList.reserve((int)numItems);
     for (gpu::BufferView::Index i = 0; i < (gpu::BufferView::Index)numItems; ++i) {
         const geometry::Vec &curNorm = shapeNorms.get<geometry::Vec>(i);
-#if DEBUG_SIMPLE_HULL_POINT_GENERATION
-        const geometry::Vec &curVert = shapeVerts.get<geometry::Vec>(i);
-        qCDebug(entities) << "    --------------------";
-        qCDebug(entities) << "         Vert( " << i << " ): " << debugTreeVector(curVert);
-        qCDebug(entities) << "         Norm( " << i << " ): " << debugTreeVector(curNorm);
-#endif
         outPointList.push_back(curNorm * halfExtents);
-
-#if DEBUG_SIMPLE_HULL_POINT_GENERATION
-        qCDebug(entities) << "         Point( " << i << " ): " << debugTreeVector((curNorm * halfExtents));
-#endif
     }
-
-#if DEBUG_SIMPLE_HULL_POINT_GENERATION
-    qCDebug(entities) << "-------------------- End Vert Info( ComputeShapeInfo ) -----------------------------";
-#endif
-
 }
 
 template <size_t SIDES>

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -101,13 +101,14 @@ void GeometryCache::computeSimpleHullPointListForShape(const int entityShape, co
         //--EARLY EXIT--( data isn't ready for some reason... )
         return;
     }
-    const gpu::BufferView & shapeVerts = shapeData->_positionView;
+
     const gpu::BufferView & shapeNorms = shapeData->_normalView;
-    assert(shapeVerts._size == shapeNorms._size);
+    assert(shapeData->_positionView._size == shapeNorms._size);
 
     const gpu::BufferView::Size numItems = shapeVerts.getNumElements();
 
     outPointList.reserve((int)numItems);
+
     for (gpu::BufferView::Index i = 0; i < (gpu::BufferView::Index)numItems; ++i) {
         const geometry::Vec &curNorm = shapeNorms.get<geometry::Vec>(i);
         outPointList.push_back(curNorm * entityHalfExtents);

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -109,7 +109,7 @@ static gpu::Stream::FormatPointer INSTANCED_SOLID_FADE_STREAM_FORMAT;
 static const uint SHAPE_VERTEX_STRIDE = sizeof(glm::vec3) * 2; // vertices and normals
 static const uint SHAPE_NORMALS_OFFSET = sizeof(glm::vec3);
 
-void GeometryCache::computeSimpleHullPointListForShape(const int entityShape, const glm::vec3 &entityHalfExtents, QVector<glm::vec3> &outPointList) {
+void GeometryCache::computeSimpleHullPointListForShape(const int entityShape, const glm::vec3 &entityExtents, QVector<glm::vec3> &outPointList) {
 
     auto geometryCache = DependencyManager::get<GeometryCache>();
     const GeometryCache::Shape geometryShape = GeometryCache::getShapeForEntityShape( entityShape );
@@ -150,7 +150,7 @@ void GeometryCache::computeSimpleHullPointListForShape(const int entityShape, co
 
 
         uniqueVerts.push_back(curVert);
-        outPointList.push_back(curVert * entityHalfExtents);
+        outPointList.push_back(curVert * entityExtents);
     }
 }
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -170,7 +170,7 @@ void GeometryCache::ShapeData::setupVertices(gpu::BufferPointer& vertexBuffer, c
     gpu::Buffer::Size offset = vertexBuffer->getSize();
     vertexBuffer->append(vertices);
 
-    gpu::Buffer::Size viewSize = vertices.size() * 2 * sizeof(glm::vec3);
+    gpu::Buffer::Size viewSize = vertices.size() * sizeof(glm::vec3);
 
     _positionView = gpu::BufferView(vertexBuffer, offset,
         viewSize, SHAPE_VERTEX_STRIDE, POSITION_ELEMENT);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -155,7 +155,7 @@ public:
     static GeometryCache::Shape getShapeForEntityShape(int entityShapeEnum);
     static QString stringFromShape(GeometryCache::Shape geoShape);
 
-    static void computeSimpleHullPointListForShape(int entityShape, const glm::vec3 &entityHalfExtents, QVector<glm::vec3> &outPointList);
+    static void computeSimpleHullPointListForShape(int entityShape, const glm::vec3 &entityExtents, QVector<glm::vec3> &outPointList);
 
     static uint8_t CUSTOM_PIPELINE_NUMBER;
     static render::ShapePipelinePointer shapePipelineFactory(const render::ShapePlumber& plumber, const render::ShapeKey& key);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -153,6 +153,7 @@ public:
     ///         the GeometryCache::Shape enum which aligns with the 
     ///         specified entityShapeEnum
     static GeometryCache::Shape getShapeForEntityShape(int entityShapeEnum);
+    static QString stringFromShape(GeometryCache::Shape geoShape);
 
     static void computeSimpleHullPointListForShape(int entityShape, const glm::vec3 &entityHalfExtents, QVector<glm::vec3> &outPointList);
 

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -32,6 +32,7 @@
 #include <model/Asset.h>
 
 class SimpleProgramKey;
+class ShapeEntityItem;
 
 typedef QPair<glm::vec2, float> Vec2FloatPair;
 typedef QPair<Vec2FloatPair, Vec2FloatPair> Vec2FloatPairPair;
@@ -146,6 +147,15 @@ public:
         Cylinder, 
         NUM_SHAPES,
     };
+
+    /// @param entityShapeEnum:  The entity::Shape enumeration for the shape
+    ///           whose GeometryCache::Shape is desired.
+    /// @return GeometryCache::NUM_SHAPES in the event of an error; otherwise,
+    ///         the GeometryCache::Shape enum which aligns with the 
+    ///         specified entityShapeEnum
+    static GeometryCache::Shape getShapeForEntityShape(int entityShapeEnum);
+
+    static void computeSimpleHullPointListForShape(const ShapeEntityItem * const shapePtr, QVector<glm::vec3> &outPointList);
 
     static uint8_t CUSTOM_PIPELINE_NUMBER;
     static render::ShapePipelinePointer shapePipelineFactory(const render::ShapePlumber& plumber, const render::ShapeKey& key);
@@ -355,15 +365,21 @@ public:
 
     using VShape = std::array<ShapeData, NUM_SHAPES>;
 
-    VShape _shapes;
+    /// returns ShapeData associated with the specified shape,
+    /// otherwise nullptr in the event of an error.
+    const ShapeData * getShapeData(Shape shape) const;
 
 private:
+
     GeometryCache();
     virtual ~GeometryCache();
     void buildShapes();
 
     typedef QPair<int, int> IntPair;
     typedef QPair<unsigned int, unsigned int> VerticesIndices;
+    
+    
+    VShape _shapes;
 
     gpu::PipelinePointer _standardDrawPipeline;
     gpu::PipelinePointer _standardDrawPipelineNoBlend;

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -32,7 +32,6 @@
 #include <model/Asset.h>
 
 class SimpleProgramKey;
-class ShapeEntityItem;
 
 typedef QPair<glm::vec2, float> Vec2FloatPair;
 typedef QPair<Vec2FloatPair, Vec2FloatPair> Vec2FloatPairPair;
@@ -155,7 +154,7 @@ public:
     ///         specified entityShapeEnum
     static GeometryCache::Shape getShapeForEntityShape(int entityShapeEnum);
 
-    static void computeSimpleHullPointListForShape(const ShapeEntityItem * const shapePtr, QVector<glm::vec3> &outPointList);
+    static void computeSimpleHullPointListForShape(int entityShape, const glm::vec3 &entityHalfExtents, QVector<glm::vec3> &outPointList);
 
     static uint8_t CUSTOM_PIPELINE_NUMBER;
     static render::ShapePipelinePointer shapePipelineFactory(const render::ShapePlumber& plumber, const render::ShapeKey& key);

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -234,7 +234,6 @@ bool ShapeInfo::contains(const glm::vec3& point) const {
 }
 
 const DoubleHashKey& ShapeInfo::getHash() const {
-    //TODO WL21389: Need to include the pointlist for SIMPLE_HULL in hash
     // NOTE: we cache the key so we only ever need to compute it once for any valid ShapeInfo instance.
     if (_doubleHashKey.isNull() && _type != SHAPE_TYPE_NONE) {
         bool useOffset = glm::length2(_offset) > MIN_SHAPE_OFFSET * MIN_SHAPE_OFFSET;
@@ -245,41 +244,82 @@ const DoubleHashKey& ShapeInfo::getHash() const {
         uint32_t primeIndex = 0;
         _doubleHashKey.computeHash((uint32_t)_type, primeIndex++);
 
-        // compute hash1
-        uint32_t hash = _doubleHashKey.getHash();
-        for (int j = 0; j < 3; ++j) {
-            // NOTE: 0.49f is used to bump the float up almost half a millimeter
-            // so the cast to int produces a round() effect rather than a floor()
-            hash ^= DoubleHashKey::hashFunction(
+        if (_type != SHAPE_TYPE_SIMPLE_HULL) {
+            // compute hash1
+            uint32_t hash = _doubleHashKey.getHash();
+            for (int j = 0; j < 3; ++j) {
+                // NOTE: 0.49f is used to bump the float up almost half a millimeter
+                // so the cast to int produces a round() effect rather than a floor()
+                hash ^= DoubleHashKey::hashFunction(
                     (uint32_t)(_halfExtents[j] * MILLIMETERS_PER_METER + copysignf(1.0f, _halfExtents[j]) * 0.49f),
                     primeIndex++);
-            if (useOffset) {
-                hash ^= DoubleHashKey::hashFunction(
+                if (useOffset) {
+                    hash ^= DoubleHashKey::hashFunction(
                         (uint32_t)(_offset[j] * MILLIMETERS_PER_METER + copysignf(1.0f, _offset[j]) * 0.49f),
                         primeIndex++);
+                }
             }
-        }
-        _doubleHashKey.setHash(hash);
+            _doubleHashKey.setHash(hash);
 
-        // compute hash2
-        hash = _doubleHashKey.getHash2();
-        for (int j = 0; j < 3; ++j) {
-            // NOTE: 0.49f is used to bump the float up almost half a millimeter
-            // so the cast to int produces a round() effect rather than a floor()
-            uint32_t floatHash = DoubleHashKey::hashFunction2(
+            // compute hash2
+            hash = _doubleHashKey.getHash2();
+            for (int j = 0; j < 3; ++j) {
+                // NOTE: 0.49f is used to bump the float up almost half a millimeter
+                // so the cast to int produces a round() effect rather than a floor()
+                uint32_t floatHash = DoubleHashKey::hashFunction2(
                     (uint32_t)(_halfExtents[j] * MILLIMETERS_PER_METER + copysignf(1.0f, _halfExtents[j]) * 0.49f));
-            if (useOffset) {
-                floatHash ^= DoubleHashKey::hashFunction2(
+                if (useOffset) {
+                    floatHash ^= DoubleHashKey::hashFunction2(
                         (uint32_t)(_offset[j] * MILLIMETERS_PER_METER + copysignf(1.0f, _offset[j]) * 0.49f));
+                }
+                hash += ~(floatHash << 17);
+                hash ^= (floatHash >> 11);
+                hash += (floatHash << 4);
+                hash ^= (floatHash >> 7);
+                hash += ~(floatHash << 10);
+                hash = (hash << 16) | (hash >> 16);
             }
-            hash += ~(floatHash << 17);
-            hash ^=  (floatHash >> 11);
-            hash +=  (floatHash << 4);
-            hash ^=  (floatHash >> 7);
-            hash += ~(floatHash << 10);
-            hash = (hash << 16) | (hash >> 16);
+            _doubleHashKey.setHash2(hash);
+        } else {
+
+            assert(_pointCollection.size() == (size_t)1);
+            const PointList & points = _pointCollection.back();
+            const size_t numPoints = points.size();
+            uint32_t hash = _doubleHashKey.getHash();
+            uint32_t hash2 = _doubleHashKey.getHash2();
+
+            for (int pointIndex = 0; pointIndex < numPoints; ++pointIndex) {
+                // compute hash1 & 2
+                const glm::vec3 &curPoint = points[pointIndex];
+                for (int vecCompIndex = 0; vecCompIndex < 3; ++vecCompIndex) {
+
+                    // NOTE: 0.49f is used to bump the float up almost half a millimeter
+                    // so the cast to int produces a round() effect rather than a floor()
+                    uint32_t valueToHash = (uint32_t)(curPoint[vecCompIndex] * MILLIMETERS_PER_METER + copysignf(1.0f, curPoint[vecCompIndex]) * 0.49f);
+                    
+                    hash ^= DoubleHashKey::hashFunction(valueToHash, primeIndex++);
+                    uint32_t floatHash = DoubleHashKey::hashFunction2(valueToHash);
+
+                    if (useOffset) {
+
+                        const uint32_t offsetValToHash = (uint32_t)(_offset[vecCompIndex] * MILLIMETERS_PER_METER + copysignf(1.0f, _offset[vecCompIndex])* 0.49f);
+
+                        hash ^= DoubleHashKey::hashFunction(offsetValToHash, primeIndex++);
+                        floatHash ^= DoubleHashKey::hashFunction2(offsetValToHash);
+                    }
+                    
+                    hash2 += ~(floatHash << 17);
+                    hash2 ^= (floatHash >> 11);
+                    hash2 += (floatHash << 4);
+                    hash2 ^= (floatHash >> 7);
+                    hash2 += ~(floatHash << 10);
+                    hash2 = (hash2 << 16) | (hash2 >> 16);
+                }
+            }
+
+            _doubleHashKey.setHash(hash);
+            _doubleHashKey.setHash2(hash2);
         }
-        _doubleHashKey.setHash2(hash);
 
         if (_type == SHAPE_TYPE_COMPOUND || _type == SHAPE_TYPE_STATIC_MESH) {
             QString url = _url.toString();

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -40,7 +40,7 @@ static const size_t SHAPETYPE_NAME_COUNT = (sizeof(shapeTypeNames) / sizeof((sha
 const float MIN_HALF_EXTENT = 0.005f; // 0.5 cm
 
 QString ShapeInfo::getNameForShapeType(ShapeType type) {
-    if (((int)type <= 0) || ((int)type >= SHAPETYPE_NAME_COUNT)) {
+    if (((int)type <= 0) || ((int)type >= (int)SHAPETYPE_NAME_COUNT)) {
         type = (ShapeType)0;
     }
 

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -15,8 +15,37 @@
 
 #include "NumericalConstants.h" // for MILLIMETERS_PER_METER
 
+// Originally within EntityItemProperties.cpp
+const char* shapeTypeNames[] = {
+    "none",
+    "box",
+    "sphere",
+    "capsule-x",
+    "capsule-y",
+    "capsule-z",
+    "cylinder-x",
+    "cylinder-y",
+    "cylinder-z",
+    "hull",
+    "plane",
+    "compound",
+    "simple-hull",
+    "simple-compound",
+    "static-mesh"
+};
+
+static const size_t SHAPETYPE_NAME_COUNT = (sizeof(shapeTypeNames) / sizeof((shapeTypeNames)[0]));
+
 // Bullet doesn't support arbitrarily small shapes
 const float MIN_HALF_EXTENT = 0.005f; // 0.5 cm
+
+QString ShapeInfo::getNameForShapeType(ShapeType type) {
+    if (((int)type <= 0) || ((int)type >= SHAPETYPE_NAME_COUNT)) {
+        type = (ShapeType)0;
+    }
+
+    return shapeTypeNames[(int)type];
+}
 
 void ShapeInfo::clear() {
     _url.clear();

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -45,6 +45,10 @@ void ShapeInfo::setParams(ShapeType type, const glm::vec3& halfExtents, QString 
                 _halfExtents = glm::vec3(radius);
             }
             break;
+        case SHAPE_TYPE_CIRCLE: {
+            _halfExtents = glm::vec3(_halfExtents.x, MIN_HALF_EXTENT, _halfExtents.z);
+        }
+        break;
         case SHAPE_TYPE_COMPOUND:
         case SHAPE_TYPE_STATIC_MESH:
             _url = QUrl(url);
@@ -75,9 +79,7 @@ void ShapeInfo::setSphere(float radius) {
 }
 
 void ShapeInfo::setPointCollection(const ShapeInfo::PointCollection& pointCollection) {
-    //TODO WL21389: May need to skip resetting type here.
     _pointCollection = pointCollection;
-    _type = (_pointCollection.size() > 0) ? SHAPE_TYPE_COMPOUND : SHAPE_TYPE_NONE;
     _doubleHashKey.clear();
 }
 
@@ -124,7 +126,7 @@ int ShapeInfo::getLargestSubshapePointCount() const {
 }
 
 float ShapeInfo::computeVolume() const {
-    //TODO WL21389: Add support for other ShapeTypes( CYLINDER_X, CYLINDER_Y, etc).
+    //TODO WL21389: Add support for other ShapeTypes( CYLINDER_X, CYLINDER_Z, etc).
     const float DEFAULT_VOLUME = 1.0f;
     float volume = DEFAULT_VOLUME;
     switch(_type) {

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -284,7 +284,7 @@ const DoubleHashKey& ShapeInfo::getHash() const {
 
             assert(_pointCollection.size() == (size_t)1);
             const PointList & points = _pointCollection.back();
-            const size_t numPoints = points.size();
+            const int numPoints = (int)points.size();
             uint32_t hash = _doubleHashKey.getHash();
             uint32_t hash2 = _doubleHashKey.getHash2();
 

--- a/libraries/shared/src/ShapeInfo.h
+++ b/libraries/shared/src/ShapeInfo.h
@@ -58,6 +58,8 @@ public:
     using PointCollection = QVector<PointList>;
     using TriangleIndices = QVector<int32_t>;
 
+    static QString getNameForShapeType(ShapeType type);
+
     void clear();
 
     void setParams(ShapeType type, const glm::vec3& halfExtents, QString url="");

--- a/libraries/shared/src/ShapeInfo.h
+++ b/libraries/shared/src/ShapeInfo.h
@@ -46,7 +46,8 @@ enum ShapeType {
     SHAPE_TYPE_SIMPLE_HULL,
     SHAPE_TYPE_SIMPLE_COMPOUND,
     SHAPE_TYPE_STATIC_MESH,
-    SHAPE_TYPE_ELLIPSOID
+    SHAPE_TYPE_ELLIPSOID,
+    SHAPE_TYPE_CIRCLE
 };
 
 class ShapeInfo {
@@ -66,7 +67,7 @@ public:
     void setCapsuleY(float radius, float halfHeight);
     void setOffset(const glm::vec3& offset);
 
-    int getType() const { return _type; }
+    ShapeType getType() const { return _type; }
 
     const glm::vec3& getHalfExtents() const { return _halfExtents; }
     const glm::vec3& getOffset() const { return _offset; }


### PR DESCRIPTION
This pull request adds support for the polyhedrons and polygons sans Torus and Quad which aren't currently supported within GeometryCache.

This build upon Part 1 from https://github.com/highfidelity/hifi/pull/11048, and is an updated version of [PR2Preview](https://github.com/1P-Cusack/hifi/pull/1).  This is also updated to adjust for recent render thread & render-utils changes.

**Testing:**

1. Within the interface, select the Create button.
2. Create each of the available shapes.
    - Shapes other than Sphere & Cube require choosing an available shape option from the Create tab, then selecting a more specific shape within the Properties Tab.
3. Collision should act in accordance to the expected results mentioned below.

**Expected Results:**

1. Cylinder, Cube, & Sphere:  Should retain the functionality they had as of https://github.com/highfidelity/hifi/pull/11048
2. Circle:  The avatar should be able to stand atop a circle without sliding off and walk underneath any circle high enough to serve as a ceiling.
3. The following shapes should collide as though they're the indicated hull shapes as opposed to the current behavior of being treated as a sphere.
    - Triangle
    - Hexagon
    - Octagon
    - Tetrahedron
    - Octahedron
    - Dodecahedron
    - Icosahedron
    - Cone

These shapes may have some visible gaps between them and the surfaces they touch; however, this is expected as the bullet library places margins around the hulls.  This means that there's also may be some gap between the avatar colliding with the shape's collision surface.  Also sharp edges on the _geometry_ shapes may be rounded in on the _collision_ shape given how bullet treats it's convex hulls.

This pull request doesn't handle cases of rotated shapes which have asymmetric cross sections.  For example, cylinders that have been rotated to be slanted (like a leaning tower), or cylinders that have been scaled to have non-circular slices.

**Pre-existing Issue(s)**
* During testing it was observed that at times, collision didn't appear to be on for the shapes entities.  It was observed with the various shapes.  Checking the properties verified that the `collisionless` flag was off, this appears to be a variation of a pre-existing issue mentioned in the initial PR: https://github.com/highfidelity/hifi/pull/11048.
    * This behavior has been observed when newly creating a shape and when opening the sandbox and loading a pre-existing layout and shapes.  It was seen effecting 1 shape out of several and at times with all shapes.
    * The issue appears to clear up between 1 and several restarts of the interface.
* Non-dynamic shapes may at times behave dynamically.  (For more details see https://github.com/highfidelity/hifi/pull/11336#issuecomment-338240414 and https://github.com/highfidelity/hifi/pull/11336#issuecomment-338279233)

**Note(s):**
* This pull request is based on tags/RELEASE-7339 (as of 24/10/17) as opposed to master@HEAD.
* A previous interim PR can be found at: https://github.com/highfidelity/hifi/pull/11024 and is the basis for breaking WL21389 into chunks.