### PR TITLE
[Case 6491] Remainder of entitySelectionTool clean up (details below).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,15 @@ Makefile
 local.properties
 android/libraries
 
+# VSCode
+# List taken from Github Global Ignores master@435c4d92 
+# https://github.com/github/gitignore/commits/master/Global/VisualStudioCode.gitignore
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
 # Xcode
 *.xcodeproj
 *.xcworkspace

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1087,23 +1087,23 @@ SelectionDisplay = (function() {
         return tool;
     }
 
-    // toolHandle:  The overlayID associated with the tool
-    // that correlates to the tool you wish to query.
+    // @param: toolHandle:  The overlayID associated with the tool
+    //         that correlates to the tool you wish to query.
+    // @note: If toolHandle is null or undefined then activeTool
+    //        will be checked against those values as opposed to
+    //        the tool registered under toolHandle.  Null & Undefined 
+    //        are treated as separate values.
     // @return: bool - Indicates if the activeTool is that queried.
     function isActiveTool(toolHandle) {
-        var wantDebug = false;
-        if ( ! activeTool || ! toolHandle ){
-            if(wantDebug){
-                if ( activeTool ){
-                    print("WARNING: entitySelectionTool.isActiveTool - Encountered invalid toolHandle: " + toolHandle );
-                }
-            }
-            return false;
+        if ( ! toolHandle ) {
+            // Allow isActiveTool( null ) and similar to return true if there's
+            // no active tool
+            return ( activeTool === toolHandle );
         }
+
         if ( ! grabberTools.hasOwnProperty( toolHandle ) ) {
-            if(wantDebug){
-                print("WARNING: entitySelectionTool.isActiveTool - Encountered unknown grabberToolHandle: " + toolHandle );
-            }
+            print("WARNING: entitySelectionTool.isActiveTool - Encountered unknown grabberToolHandle: " + toolHandle + ". Tools should be egistered via addGrabberTool." );
+            //--EARLY EXIT--
             return false;
         }
 

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2393,7 +2393,7 @@ SelectionDisplay = (function() {
         startingDistance: 0.0,
         startingElevation: 0.0,
         onBegin: function(event,isAltFromGrab, intersectInfo) {
-            var wantDebug = true;
+            var wantDebug = false;
             if(wantDebug){
                 print("================== TRANSLATE_XZ(Beg) -> =======================");
                 Vec3.print("    intersectInfo.queryRay", intersectInfo.queryRay);
@@ -3634,7 +3634,7 @@ SelectionDisplay = (function() {
     addGrabberTool(yawHandle, {
         mode: "ROTATE_YAW",
         onBegin: function(event) {
-            var wantDebug = true;
+            var wantDebug = false;
             if (wantDebug) {
                 print("================== HANDLE_YAW(Beg) -> =======================");
             }
@@ -3838,7 +3838,7 @@ SelectionDisplay = (function() {
     addGrabberTool(pitchHandle, {
         mode: "ROTATE_PITCH",
         onBegin: function (event) {
-            var wantDebug = true;
+            var wantDebug = false;
             if (wantDebug){
                 print("================== HANDLE_PITCH(Beg) -> =======================");
             }
@@ -4032,7 +4032,7 @@ SelectionDisplay = (function() {
     addGrabberTool(rollHandle, {
         mode: "ROTATE_ROLL",
         onBegin: function (event) {
-            var wantDebug = true;
+            var wantDebug = false;
             if(wantDebug){
                 print("================== HANDLE_ROLL(Beg) -> =======================");
             }
@@ -4255,7 +4255,7 @@ SelectionDisplay = (function() {
 
     // FUNCTION DEF(s): Intersection Check Helpers
     function testRayIntersect(queryRay, overlayIncludes, overlayExcludes) {
-        var wantDebug = true;
+        var wantDebug = false;
         if ((queryRay === undefined) || (queryRay === null)) {
             if (wantDebug) {
                 print("testRayIntersect - EARLY EXIT -> queryRay is undefined OR null!");
@@ -4306,12 +4306,10 @@ SelectionDisplay = (function() {
 
         return intersectObj;
     }
-    //--------------------
 
-    //---------------------------------------
     // FUNCTION: MOUSE PRESS EVENT
     that.mousePressEvent = function (event) {
-        var wantDebug = true;
+        var wantDebug = false;
         if (wantDebug) {
             print("=============== eST::MousePressEvent BEG =======================");
         }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -238,8 +238,14 @@ SelectionManager = (function() {
 
 // Normalize degrees to be in the range (-180, 180]
 function normalizeDegrees(degrees) {
-    while (degrees > 180) degrees -= 360;
-    while (degrees <= -180) degrees += 360;
+    while (degrees > 180) {
+     degrees -= 360;
+    }
+
+    while (degrees <= -180) {
+     degrees += 360;
+    }
+    
     return degrees;
 }
 
@@ -2143,7 +2149,9 @@ SelectionDisplay = (function() {
                 var curBoxPosition = Vec3.sum(props.position, offset);
 
                 var color = {red: 255, green: 128, blue: 0};
-                if (i >= selectionManager.selections.length - 1) color = {red: 255, green: 255, blue: 64};
+                if (i >= selectionManager.selections.length - 1) {
+                    color = {red: 255, green: 255, blue: 64};
+                }
 
                 Overlays.editOverlay(selectionBoxes[i], {
                     position: curBoxPosition,
@@ -4134,7 +4142,7 @@ SelectionDisplay = (function() {
                     print("    Triggering ActiveTool(" + activeTool.mode + ")'s onEnd");
                 }
                 activeTool.onEnd(event);
-            }else if (wantDebug) {
+            } else if (wantDebug) {
                 print("    ActiveTool(" + activeTool.mode + ")'s missing onEnd");
             }
         }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -239,13 +239,13 @@ SelectionManager = (function() {
 // Normalize degrees to be in the range (-180, 180]
 function normalizeDegrees(degrees) {
     while (degrees > 180) {
-     degrees -= 360;
+        degrees -= 360;
     }
 
     while (degrees <= -180) {
-     degrees += 360;
+        degrees += 360;
     }
-    
+
     return degrees;
 }
 

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -3629,6 +3629,38 @@ SelectionDisplay = (function() {
         print( "<--- updateRotationDegreesOverlay ---" );
     }
 
+    // FUNCTION DEF: updateSelectionsRotation
+    //    Helper func used by rotation grabber tools 
+    function updateSelectionsRotation( rotationChange ) {
+        if ( ! rotationChange ) {
+            print("ERROR( updateSelectionsRotation ) - Invalid arg specified!!");
+
+            //--EARLY EXIT--
+            return;
+        }
+        
+        // Entities should only reposition if we are rotating multiple selections around
+        // the selections center point.  Otherwise, the rotation will be around the entities
+        // registration point which does not need repositioning.
+        var reposition = (SelectionManager.selections.length > 1);
+        for (var i = 0; i < SelectionManager.selections.length; i++) {
+            var entityID = SelectionManager.selections[i];
+            var initialProperties = SelectionManager.savedProperties[entityID];
+
+            var newProperties = {
+                rotation: Quat.multiply(rotationChange, initialProperties.rotation),
+            };
+
+            if (reposition) {
+                var dPos = Vec3.subtract(initialProperties.position, initialPosition);
+                dPos = Vec3.multiplyQbyV(rotationChange, dPos);
+                newProperties.position = Vec3.sum(initialPosition, dPos);
+            }
+
+            Entities.editEntity(entityID, newProperties);
+        }
+    }
+
     // YAW GRABBER TOOL DEFINITION
     var initialPosition = SelectionManager.worldPosition;
     addGrabberTool(yawHandle, {
@@ -3756,27 +3788,7 @@ SelectionDisplay = (function() {
                     z: 0
                 });
 
-                // Entities should only reposition if we are rotating multiple selections around
-                // the selections center point.  Otherwise, the rotation will be around the entities
-                // registration point which does not need repositioning.
-                var reposition = SelectionManager.selections.length > 1;
-                for (var i = 0; i < SelectionManager.selections.length; i++) {
-                    var entityID = SelectionManager.selections[i];
-                    var properties = Entities.getEntityProperties(entityID);
-                    var initialProperties = SelectionManager.savedProperties[entityID];
-
-                    var newProperties = {
-                        rotation: Quat.multiply(yawChange, initialProperties.rotation),
-                    };
-
-                    if (reposition) {
-                        var dPos = Vec3.subtract(initialProperties.position, initialPosition);
-                        dPos = Vec3.multiplyQbyV(yawChange, dPos);
-                        newProperties.position = Vec3.sum(initialPosition, dPos);
-                    }
-
-                    Entities.editEntity(entityID, newProperties);
-                }
+                updateSelectionsRotation( yawChange );
 
                 updateRotationDegreesOverlay(angleFromZero, yawHandleRotation, yawCenter);
 
@@ -3961,17 +3973,7 @@ SelectionDisplay = (function() {
                     z: 0
                 });
 
-                for (var i = 0; i < SelectionManager.selections.length; i++) {
-                    var entityID = SelectionManager.selections[i];
-                    var initialProperties = SelectionManager.savedProperties[entityID];
-                    var dPos = Vec3.subtract(initialProperties.position, initialPosition);
-                    dPos = Vec3.multiplyQbyV(pitchChange, dPos);
-
-                    Entities.editEntity(entityID, {
-                        position: Vec3.sum(initialPosition, dPos),
-                        rotation: Quat.multiply(pitchChange, initialProperties.rotation),
-                    });
-                }
+                updateSelectionsRotation( pitchChange );
 
                 updateRotationDegreesOverlay(angleFromZero, pitchHandleRotation, pitchCenter);
 
@@ -4154,17 +4156,8 @@ SelectionDisplay = (function() {
                     y: 0,
                     z: angleFromZero
                 });
-                for (var i = 0; i < SelectionManager.selections.length; i++) {
-                    var entityID = SelectionManager.selections[i];
-                    var initialProperties = SelectionManager.savedProperties[entityID];
-                    var dPos = Vec3.subtract(initialProperties.position, initialPosition);
-                    dPos = Vec3.multiplyQbyV(rollChange, dPos);
 
-                    Entities.editEntity(entityID, {
-                        position: Vec3.sum(initialPosition, dPos),
-                        rotation: Quat.multiply(rollChange, initialProperties.rotation),
-                    });
-                }
+                updateSelectionsRotation( rollChange );
 
                 updateRotationDegreesOverlay(angleFromZero, rollHandleRotation, rollCenter);
 

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2770,7 +2770,6 @@ SelectionDisplay = (function() {
             }
             
             planeNormal = Vec3.multiplyQbyV(rotation, planeNormal);
-            var pickRay = generalComputePickRay(event.x, event.y);
             lastPick = rayPlaneIntersection(pickRay,
                 pickRayPosition,
                 planeNormal);

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2429,7 +2429,7 @@ SelectionDisplay = (function() {
             var MIN_ELEVATION = 0.02; //  largest dimension of object divided by distance to it
             var elevation = translateXZTool.elevation(pickRay.origin, pick);
             if (wantDebug) {
-                    print("Start Elevation: " + translateXZTool.startingElevation + ", elevation: " + elevation);
+                print("Start Elevation: " + translateXZTool.startingElevation + ", elevation: " + elevation);
             }
             if ((translateXZTool.startingElevation > 0.0 && elevation < MIN_ELEVATION) ||
                 (translateXZTool.startingElevation < 0.0 && elevation > -MIN_ELEVATION)) {
@@ -2642,11 +2642,11 @@ SelectionDisplay = (function() {
 
     // FUNCTION: VEC 3 MULT
     var vec3Mult = function(v1, v2) {
-            return {
-                x: v1.x * v2.x,
-                y: v1.y * v2.y,
-                z: v1.z * v2.z
-            };
+        return {
+            x: v1.x * v2.x,
+            y: v1.y * v2.y,
+            z: v1.z * v2.z
+        };
     };
 
     // FUNCTION: MAKE STRETCH TOOL
@@ -2740,8 +2740,7 @@ SelectionDisplay = (function() {
                 deltaPivot3D = Vec3.subtract(centeredRP, scaledPivot3D);
                 
                 var scaledOffsetWorld3D = vec3Mult(initialDimensions, 
-                    Vec3.subtract(Vec3.multiply(0.5, Vec3.multiply(-1.0, directionFor3DStretch)), 
-                    centeredRP));
+                    Vec3.subtract(Vec3.multiply(0.5, Vec3.multiply(-1.0, directionFor3DStretch)), centeredRP));
                 
                 pickRayPosition3D = Vec3.sum(initialPosition, Vec3.multiplyQbyV(rotation, scaledOffsetWorld));
             }
@@ -2921,8 +2920,8 @@ SelectionDisplay = (function() {
                 
             } else {
                 newPick = rayPlaneIntersection(pickRay,
-                pickRayPosition,
-                planeNormal);
+                    pickRayPosition,
+                    planeNormal);
                 vector = Vec3.subtract(newPick, lastPick);
 
                 vector = Vec3.multiplyQbyV(Quat.inverse(rotation), vector);

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2016,7 +2016,6 @@ SelectionDisplay = (function() {
         }// end of isSingleSelection
 
 
-
         Overlays.editOverlay(grabberLBN, {
             visible: stretchHandlesVisible,
             rotation: rotation,
@@ -2515,7 +2514,6 @@ SelectionDisplay = (function() {
                 cornerPosition);
 
 
-
             for (var i = 0; i < SelectionManager.selections.length; i++) {
                 var properties = SelectionManager.savedProperties[SelectionManager.selections[i]];
                 if (!properties) {
@@ -2639,7 +2637,6 @@ SelectionDisplay = (function() {
     });
 
 
-
     // FUNCTION: VEC 3 MULT
     var vec3Mult = function(v1, v2) {
         return {
@@ -2677,8 +2674,7 @@ SelectionDisplay = (function() {
             y: Math.abs(direction.y) > 0 ? 1 : 0,
             z: Math.abs(direction.z) > 0 ? 1 : 0
         };
-        
-        
+
 
         var numDimensions = mask.x + mask.y + mask.z;
 
@@ -4185,7 +4181,6 @@ SelectionDisplay = (function() {
     //       Controller.mousePressEvent.connect(that.mousePressEvent);
     //       Controller.mouseMoveEvent.connect(that.mouseMoveEvent);
     Controller.mouseReleaseEvent.connect(that.mouseReleaseEvent);
-
 
 
     return that;

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1095,14 +1095,14 @@ SelectionDisplay = (function() {
     //        are treated as separate values.
     // @return: bool - Indicates if the activeTool is that queried.
     function isActiveTool(toolHandle) {
-        if ( ! toolHandle ) {
-            // Allow isActiveTool( null ) and similar to return true if there's
+        if (!toolHandle) {
+            // Allow isActiveTool(null) and similar to return true if there's
             // no active tool
-            return ( activeTool === toolHandle );
+            return (activeTool === toolHandle);
         }
 
-        if ( ! grabberTools.hasOwnProperty( toolHandle ) ) {
-            print("WARNING: entitySelectionTool.isActiveTool - Encountered unknown grabberToolHandle: " + toolHandle + ". Tools should be egistered via addGrabberTool." );
+        if (!grabberTools.hasOwnProperty(toolHandle)) {
+            print("WARNING: entitySelectionTool.isActiveTool - Encountered unknown grabberToolHandle: " + toolHandle + ". Tools should be egistered via addGrabberTool.");
             //--EARLY EXIT--
             return false;
         }
@@ -1483,15 +1483,15 @@ SelectionDisplay = (function() {
             isPointLight = properties.type == "Light" && !properties.isSpotlight;
         }
 
-        if ( isActiveTool(yawHandle) || isActiveTool(pitchHandle) || 
+        if (isActiveTool(yawHandle) || isActiveTool(pitchHandle) || 
                 isActiveTool(rollHandle) || isActiveTool(selectionBox) || isActiveTool(grabberCloner)) {
             rotationOverlaysVisible = true;
             rotateHandlesVisible = false;
             //translateHandlesVisible = false;
             //selectionBoxVisible = false;
-        } else if ( isActiveTool(grabberMoveUp) || isPointLight) {
+        } else if (isActiveTool(grabberMoveUp) || isPointLight) {
             rotateHandlesVisible = false;
-        } else if ( activeTool ) {
+        } else if (activeTool) {
             // every other mode is a stretch mode...
             rotateHandlesVisible = false;
             //translateHandlesVisible = false;
@@ -1594,12 +1594,12 @@ SelectionDisplay = (function() {
             return;
         }
         if (wantDebug) {
-            print( "PreToggle: " + spaceMode);
+            print("PreToggle: " + spaceMode);
         }
         spaceMode = spaceMode == SPACE_LOCAL ? SPACE_WORLD : SPACE_LOCAL;
         that.updateHandles();
         if (wantDebug) {
-            print( "PostToggle: " + spaceMode);        
+            print("PostToggle: " + spaceMode);        
             print("======== ToggleSpaceMode called. <=========");
         }
     };
@@ -1612,17 +1612,17 @@ SelectionDisplay = (function() {
     that.updateHandles = function() {
         var wantDebug = false;
         if (wantDebug) {
-            print( "======> Update Handles =======" );
-            print( "    Selections Count: " + SelectionManager.selections.length );
-            print( "    SpaceMode: " + spaceMode );
-            print( "    DisplayMode: " + getMode() );
+            print("======> Update Handles =======");
+            print("    Selections Count: " + SelectionManager.selections.length);
+            print("    SpaceMode: " + spaceMode);
+            print("    DisplayMode: " + getMode());
         }
         if (SelectionManager.selections.length === 0) {
             that.setOverlaysVisible(false);
             return;
         }
 
-        //print( "    Triggering updateRotationHandles");
+        //print("    Triggering updateRotationHandles");
         that.updateRotationHandles();
 
         var rotation, dimensions, position, registrationPoint;
@@ -1863,7 +1863,7 @@ SelectionDisplay = (function() {
         if (isSingleSelection) {
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
             var isLightSelection = (properties.type == "Light");
-            if ( isLightSelection ) {
+            if (isLightSelection) {
                 if (wantDebug) {
                     print("    Light Selection revoking Non-Light Grabbers Visibility!");
                 }
@@ -1871,10 +1871,10 @@ SelectionDisplay = (function() {
                 extendedStretchHandlesVisible = false;
                 cloneHandleVisible = false;
                 if (properties.isSpotlight) {
-                    that.setPointLightHandlesVisible( false );
+                    that.setPointLightHandlesVisible(false);
 
                     var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
-                    var showEdgeSpotGrabbers = ! (inModeTranslate || inModeRotate);
+                    var showEdgeSpotGrabbers = !(inModeTranslate || inModeRotate);
                     Overlays.editOverlay(grabberSpotLightCenter, {
                         position: position,
                         visible: false,
@@ -1939,9 +1939,9 @@ SelectionDisplay = (function() {
                     });
 
                 } else { //..it's a PointLight
-                    that.setSpotLightHandlesVisible( false );
+                    that.setSpotLightHandlesVisible(false);
 
-                    var showEdgePointGrabbers = ! inModeTranslate;
+                    var showEdgePointGrabbers = !inModeTranslate;
                     Overlays.editOverlay(grabberPointLightT, {
                         position: TOP,
                         rotation: rotation,
@@ -2004,8 +2004,8 @@ SelectionDisplay = (function() {
                     });
                 }
             } else { //..it's not a light at all
-                that.setSpotLightHandlesVisible( false );
-                that.setPointLightHandlesVisible( false );
+                that.setSpotLightHandlesVisible(false);
+                that.setPointLightHandlesVisible(false);
             }
         }//--end of isSingleSelection
 
@@ -2229,7 +2229,7 @@ SelectionDisplay = (function() {
             z: position.z
         };
         Overlays.editOverlay(grabberMoveUp, {
-            visible: ( ! activeTool ) || isActiveTool(grabberMoveUp)
+            visible: (!activeTool) || isActiveTool(grabberMoveUp)
         });
 
         Overlays.editOverlay(baseOfEntityProjectionOverlay, {
@@ -2248,12 +2248,12 @@ SelectionDisplay = (function() {
         });
 
         if (wantDebug) {
-            print( "====== Update Handles <=======" );
+            print("====== Update Handles <=======");
         }
 
     };
 
-    function helperSetOverlaysVisibility( handleArray, isVisible ) {
+    function helperSetOverlaysVisibility(handleArray, isVisible) {
         var numHandles = handleArray.length;
         var visibilityUpdate = { visible: isVisible };
         for (var handleIndex = 0; handleIndex < numHandles; ++handleIndex) {
@@ -2263,8 +2263,8 @@ SelectionDisplay = (function() {
 
     // FUNCTION: SET OVERLAYS VISIBLE
     that.setOverlaysVisible = function(isVisible) {
-        helperSetOverlaysVisibility( allOverlays, isVisible );
-        helperSetOverlaysVisibility( selectionBoxes, isVisible );
+        helperSetOverlaysVisibility(allOverlays, isVisible);
+        helperSetOverlaysVisibility(selectionBoxes, isVisible);
     };
 
     // FUNCTION: SET ROTATION HANDLES VISIBLE
@@ -2277,7 +2277,7 @@ SelectionDisplay = (function() {
 
     // FUNCTION: SET STRETCH HANDLES VISIBLE
     that.setStretchHandlesVisible = function(isVisible) {
-        helperSetOverlaysVisibility( stretchHandles, isVisible );
+        helperSetOverlaysVisibility(stretchHandles, isVisible);
     };
 
     // FUNCTION: SET GRABBER MOVE UP VISIBLE
@@ -2288,24 +2288,24 @@ SelectionDisplay = (function() {
     // FUNCTION: SET GRABBER TOOLS UP VISIBLE
     that.setGrabberToolsVisible = function(isVisible) {
         var visibilityUpdate = { visible: isVisible };
-        for ( var toolKey in grabberTools ) {
-            if ( ! grabberTools.hasOwnProperty( toolKey ) ) {
-                //--EARLY ITERATION EXIT--( On to the next one )
+        for (var toolKey in grabberTools) {
+            if (!grabberTools.hasOwnProperty(toolKey)) {
+                //--EARLY ITERATION EXIT--(On to the next one)
                 continue;
             }
 
-            Overlays.editOverlay( toolKey, visibilityUpdate );
+            Overlays.editOverlay(toolKey, visibilityUpdate);
         }
     };
 
     // FUNCTION: SET POINT LIGHT HANDLES VISIBLE
     that.setPointLightHandlesVisible = function(isVisible) {
-        helperSetOverlaysVisibility( pointLightGrabberHandles, isVisible );
+        helperSetOverlaysVisibility(pointLightGrabberHandles, isVisible);
     };
 
     // FUNCTION: SET SPOT LIGHT HANDLES VISIBLE
     that.setSpotLightHandlesVisible = function(isVisible) {
-        helperSetOverlaysVisibility( spotLightGrabberHandles, isVisible );
+        helperSetOverlaysVisibility(spotLightGrabberHandles, isVisible);
     };
 
     // FUNCTION: UNSELECT
@@ -2335,9 +2335,9 @@ SelectionDisplay = (function() {
             }
 
             SelectionManager.saveProperties();
-            that.setRotationHandlesVisible( false );
-            that.setStretchHandlesVisible( false );
-            that.setGrabberMoveUpVisible( false );
+            that.setRotationHandlesVisible(false);
+            that.setStretchHandlesVisible(false);
+            that.setGrabberMoveUpVisible(false);
 
             startPosition = SelectionManager.worldPosition;
 
@@ -2411,7 +2411,7 @@ SelectionDisplay = (function() {
                     print("    "+ translateXZTool.mode + "Pick ray does not intersect XZ plane.");
                 }
                 
-                //--EARLY EXIT--( Invalid ray detected. )
+                //--EARLY EXIT--(Invalid ray detected.)
                 return;
             }
 
@@ -2429,7 +2429,7 @@ SelectionDisplay = (function() {
                     print("    "+ translateXZTool.mode + " - too close to horizon!");
                 }
 
-                //--EARLY EXIT--( Don't proceed past the reached limit. )
+                //--EARLY EXIT--(Don't proceed past the reached limit.)
                 return;
             }
 
@@ -2547,9 +2547,9 @@ SelectionDisplay = (function() {
             lastXYPick = rayPlaneIntersection(pickRay, SelectionManager.worldPosition, upDownPickNormal);
 
             SelectionManager.saveProperties();
-            that.setGrabberMoveUpVisible( true );
-            that.setStretchHandlesVisible( false );
-            that.setRotationHandlesVisible( false );
+            that.setGrabberMoveUpVisible(true);
+            that.setStretchHandlesVisible(false);
+            that.setRotationHandlesVisible(false);
 
             // Duplicate entities if alt is pressed.  This will make a
             // copy of the selected entities and move the _original_ entities, not
@@ -3534,10 +3534,10 @@ SelectionDisplay = (function() {
     function updateRotationDegreesOverlay(angleFromZero, handleRotation, centerPosition) {
         var wantDebug = false;
         if (wantDebug) {
-            print( "---> updateRotationDegreesOverlay ---" );
-            print("    AngleFromZero: " + angleFromZero );
-            print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
-            print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z );
+            print("---> updateRotationDegreesOverlay ---");
+            print("    AngleFromZero: " + angleFromZero);
+            print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z);
+            print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z);
         }
 
         var angle = angleFromZero * (Math.PI / 180);
@@ -3547,7 +3547,7 @@ SelectionDisplay = (function() {
             z: 0,
         };
         if (wantDebug) {
-            print("    Angle: " + angle );
+            print("    Angle: " + angle);
             print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
         }
         
@@ -3564,21 +3564,21 @@ SelectionDisplay = (function() {
         };
         if (wantDebug) {
             print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
-            print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
-            print("    OverlayLineHeight: " + overlayProps.lineHeight );
-            print("    OverlayText: " + overlayProps.text );
+            print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z);
+            print("    OverlayLineHeight: " + overlayProps.lineHeight);
+            print("    OverlayText: " + overlayProps.text);
         }
 
         Overlays.editOverlay(rotationDegreesDisplay, overlayProps);
         if (wantDebug) {
-            print( "<--- updateRotationDegreesOverlay ---" );
+            print("<--- updateRotationDegreesOverlay ---");
         }
     }
 
     // FUNCTION DEF: updateSelectionsRotation
     //    Helper func used by rotation grabber tools 
-    function updateSelectionsRotation( rotationChange ) {
-        if ( ! rotationChange ) {
+    function updateSelectionsRotation(rotationChange) {
+        if (!rotationChange) {
             print("ERROR: entitySelectionTool.updateSelectionsRotation - Invalid arg specified!!");
 
             //--EARLY EXIT--
@@ -3607,16 +3607,16 @@ SelectionDisplay = (function() {
         }
     }
 
-    function helperRotationHandleOnBegin( event, pickRay, rotAroundAxis, rotCenter, handleRotation ) {
+    function helperRotationHandleOnBegin(event, pickRay, rotAroundAxis, rotCenter, handleRotation) {
         var wantDebug = false;
         if (wantDebug) {
             print("================== " + getMode() + "(rotation helper onBegin) -> =======================");
         }
 
         SelectionManager.saveProperties();
-        that.setRotationHandlesVisible( false );
-        that.setStretchHandlesVisible( false );
-        that.setGrabberMoveUpVisible( false );
+        that.setRotationHandlesVisible(false);
+        that.setStretchHandlesVisible(false);
+        that.setGrabberMoveUpVisible(false);
 
         initialPosition = SelectionManager.worldPosition;
         rotationNormal = { x: 0, y: 0, z: 0 };
@@ -3669,7 +3669,7 @@ SelectionDisplay = (function() {
         
         // editOverlays may not have committed rotation changes.
         // Compute zero position based on where the overlay will be eventually.
-        var result = rayPlaneIntersection( pickRay, rotCenter, rotationNormal );
+        var result = rayPlaneIntersection(pickRay, rotCenter, rotationNormal);
         // In case of a parallel ray, this will be null, which will cause early-out
         // in the onMove helper.
         rotZero = result;
@@ -3677,12 +3677,12 @@ SelectionDisplay = (function() {
         if (wantDebug) {
             print("================== " + getMode() + "(rotation helper onBegin) <- =======================");
         }
-    }//--End_Function( helperRotationHandleOnBegin )
+    }//--End_Function(helperRotationHandleOnBegin)
 
-    function helperRotationHandleOnMove( event, rotAroundAxis, rotCenter, handleRotation ) {
+    function helperRotationHandleOnMove(event, rotAroundAxis, rotCenter, handleRotation) {
 
-        if ( ! rotZero ) {
-            print("ERROR: entitySelectionTool.handleRotationHandleOnMove - Invalid RotationZero Specified (missed rotation target plane?)" );
+        if (!rotZero) {
+            print("ERROR: entitySelectionTool.handleRotationHandleOnMove - Invalid RotationZero Specified (missed rotation target plane?)");
 
             //--EARLY EXIT--
             return;
@@ -3701,7 +3701,7 @@ SelectionDisplay = (function() {
             visible: false
         });
 
-        var result = rayPlaneIntersection( pickRay, rotCenter, rotationNormal );
+        var result = rayPlaneIntersection(pickRay, rotCenter, rotationNormal);
         if (result) {
             var centerToZero = Vec3.subtract(rotZero, rotCenter);
             var centerToIntersect = Vec3.subtract(result, rotCenter);
@@ -3724,8 +3724,8 @@ SelectionDisplay = (function() {
 
             var vec3Degrees = { x: 0, y: 0, z: 0 };
             vec3Degrees[rotAroundAxis] = angleFromZero;
-            var rotChange = Quat.fromVec3Degrees( vec3Degrees );
-            updateSelectionsRotation( rotChange );
+            var rotChange = Quat.fromVec3Degrees(vec3Degrees);
+            updateSelectionsRotation(rotChange);
 
             updateRotationDegreesOverlay(angleFromZero, handleRotation, rotCenter);
 
@@ -3777,12 +3777,12 @@ SelectionDisplay = (function() {
                     minorTickMarksLength: 0.1,
                 });
             }
-        }//--End_If( results.intersects )
+        }//--End_If(results.intersects)
 
         if (wantDebug) {
             print("================== "+ getMode() + "(rotation helper onMove) <- =======================");
         }
-    }//--End_Function( helperRotationHandleOnMove )
+    }//--End_Function(helperRotationHandleOnMove)
 
     function helperRotationHandleOnEnd() {
         var wantDebug = false;
@@ -3807,7 +3807,7 @@ SelectionDisplay = (function() {
         if (wantDebug) {
             print("================== " + getMode() + "(onEnd) <- =======================");
         }
-    }//--End_Function( helperRotationHandleOnEnd )
+    }//--End_Function(helperRotationHandleOnEnd)
 
 
     // YAW GRABBER TOOL DEFINITION
@@ -3815,13 +3815,13 @@ SelectionDisplay = (function() {
     addGrabberTool(yawHandle, {
         mode: "ROTATE_YAW",
         onBegin: function(event, pickRay, pickResult) {
-            helperRotationHandleOnBegin( event, pickRay, "y", yawCenter, yawHandleRotation );
+            helperRotationHandleOnBegin(event, pickRay, "y", yawCenter, yawHandleRotation);
         },
         onEnd: function(event, reason) {
             helperRotationHandleOnEnd();
         },
         onMove: function(event) {
-            helperRotationHandleOnMove( event, "y", yawCenter, yawHandleRotation );
+            helperRotationHandleOnMove(event, "y", yawCenter, yawHandleRotation);
         }
     });
 
@@ -3830,13 +3830,13 @@ SelectionDisplay = (function() {
     addGrabberTool(pitchHandle, {
         mode: "ROTATE_PITCH",
         onBegin: function(event, pickRay, pickResult) {
-            helperRotationHandleOnBegin( event, pickRay, "x", pitchCenter, pitchHandleRotation );
+            helperRotationHandleOnBegin(event, pickRay, "x", pitchCenter, pitchHandleRotation);
         },
         onEnd: function(event, reason) {
             helperRotationHandleOnEnd();
         },
         onMove: function (event) {
-            helperRotationHandleOnMove( event, "x", pitchCenter, pitchHandleRotation );
+            helperRotationHandleOnMove(event, "x", pitchCenter, pitchHandleRotation);
         }
     });
 
@@ -3845,13 +3845,13 @@ SelectionDisplay = (function() {
     addGrabberTool(rollHandle, {
         mode: "ROTATE_ROLL",
         onBegin: function(event, pickRay, pickResult) {
-            helperRotationHandleOnBegin( event, pickRay, "z", rollCenter, rollHandleRotation );
+            helperRotationHandleOnBegin(event, pickRay, "z", rollCenter, rollHandleRotation);
         },
         onEnd: function (event, reason) {
             helperRotationHandleOnEnd();
         },
         onMove: function(event) {
-            helperRotationHandleOnMove( event, "z", rollCenter, rollHandleRotation );
+            helperRotationHandleOnMove(event, "z", rollCenter, rollHandleRotation);
         }
     });
 
@@ -3899,10 +3899,10 @@ SelectionDisplay = (function() {
         var intersectObj = Overlays.findRayIntersection(queryRay, true, overlayIncludes, overlayExcludes);
 
         if (wantDebug) {
-            if ( ! overlayIncludes ) {
+            if (!overlayIncludes) {
                 print("testRayIntersect - no overlayIncludes provided.");
             }
-            if ( ! overlayExcludes ) {
+            if (!overlayExcludes) {
                 print("testRayIntersect - no overlayExcludes provided.");
             }
             print("testRayIntersect - Hit: " + intersectObj.intersects);
@@ -3932,17 +3932,17 @@ SelectionDisplay = (function() {
         var interactiveOverlays = [HMD.tabletID, HMD.tabletScreenID, HMD.homeButtonID, selectionBox];
         for (var key in grabberTools) {
             if (grabberTools.hasOwnProperty(key)) {
-                interactiveOverlays.push( key );
+                interactiveOverlays.push(key);
             }
         }
 
         // Start with unknown mode, in case no tool can handle this.
         activeTool = null;
 
-        var results = testRayIntersect( pickRay, interactiveOverlays );
-        if ( results.intersects ) {
+        var results = testRayIntersect(pickRay, interactiveOverlays);
+        if (results.intersects) {
             var hitOverlayID = results.overlayID;
-            if ( (hitOverlayID == HMD.tabletID) || (hitOverlayID == HMD.tabletScreenID) || (hitOverlayID == HMD.homeButtonID) ) {
+            if ((hitOverlayID == HMD.tabletID) || (hitOverlayID == HMD.tabletScreenID) || (hitOverlayID == HMD.homeButtonID)) {
                 //--EARLY EXIT-(mouse clicks on the tablet should override the edit affordances)
                 return false;
             }
@@ -3950,17 +3950,17 @@ SelectionDisplay = (function() {
             entityIconOverlayManager.setIconsSelectable(selectionManager.selections, true);
 
             var hitTool = grabberTools[ hitOverlayID ];
-            if ( hitTool ) {
+            if (hitTool) {
                 activeTool = hitTool;
                 if (activeTool.onBegin) {
                     activeTool.onBegin(event, pickRay, results);
                 } else {
-                    print("ERROR: entitySelectionTool.mousePressEvent - ActiveTool( " + activeTool.mode + " ) missing onBegin");
+                    print("ERROR: entitySelectionTool.mousePressEvent - ActiveTool(" + activeTool.mode + ") missing onBegin");
                 }
             } else {
                 print("ERROR: entitySelectionTool.mousePressEvent - Hit unexpected object, check interactiveOverlays");
-            }//--End_if ( hitTool )
-        }//--End_If( results.intersects )
+            }//--End_if (hitTool)
+        }//--End_If(results.intersects)
 
         if (wantDebug) {
             print("    DisplayMode: " + getMode());
@@ -3976,11 +3976,11 @@ SelectionDisplay = (function() {
     that.mouseMoveEvent = function(event) {
         var wantDebug = false;
         if (wantDebug) {
-            print( "=============== eST::MouseMoveEvent BEG =======================");
+            print("=============== eST::MouseMoveEvent BEG =======================");
         }
         if (activeTool) {
             if (wantDebug) {
-                print("    Trigger ActiveTool( " + activeTool.mode + " )'s onMove");
+                print("    Trigger ActiveTool(" + activeTool.mode + ")'s onMove");
             }
             activeTool.onMove(event);
 
@@ -3992,7 +3992,7 @@ SelectionDisplay = (function() {
             if (wantDebug) {
                 print("=============== eST::MouseMoveEvent END =======================");
             }
-            //--EARLY EXIT--( Move handled via active tool)
+            //--EARLY EXIT--(Move handled via active tool)
             return true;
         }
 
@@ -4129,18 +4129,18 @@ SelectionDisplay = (function() {
         }
         var showHandles = false;
         if (activeTool) {
-            if ( activeTool.onEnd ) {
+            if (activeTool.onEnd) {
                 if (wantDebug) {
-                    print("    Triggering ActiveTool( " + activeTool.mode + " )'s onEnd");
+                    print("    Triggering ActiveTool(" + activeTool.mode + ")'s onEnd");
                 }
                 activeTool.onEnd(event);
             }else if (wantDebug) {
-                print("    ActiveTool( " + activeTool.mode + " )'s missing onEnd");
+                print("    ActiveTool(" + activeTool.mode + ")'s missing onEnd");
             }
         }
         
         // hide our rotation overlays..., and show our handles
-        if ( isActiveTool(yawHandle) || isActiveTool(pitchHandle) || isActiveTool(rollHandle)) {
+        if (isActiveTool(yawHandle) || isActiveTool(pitchHandle) || isActiveTool(rollHandle)) {
             if (wantDebug) {
                 print("    Triggering hide of RotateOverlays");
             }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -217,7 +217,7 @@ SelectionManager = (function() {
             that.worldPosition = {
                 x: brn.x + (that.worldDimensions.x / 2),
                 y: brn.y + (that.worldDimensions.y / 2),
-                z: brn.z + (that.worldDimensions.z / 2),
+                z: brn.z + (that.worldDimensions.z / 2)
             };
 
             // For 1+ selections we can only modify selections in world space
@@ -373,7 +373,7 @@ SelectionDisplay = (function() {
         dashed: false,
         lineWidth: grabberLineWidth,
         drawInFront: true,
-        borderSize: 1.4,
+        borderSize: 1.4
     };
 
     var grabberPropertiesEdge = {
@@ -390,7 +390,7 @@ SelectionDisplay = (function() {
         dashed: false,
         lineWidth: grabberLineWidth,
         drawInFront: true,
-        borderSize: 1.4,
+        borderSize: 1.4
     };
 
     var grabberPropertiesFace = {
@@ -407,7 +407,7 @@ SelectionDisplay = (function() {
         dashed: false,
         lineWidth: grabberLineWidth,
         drawInFront: true,
-        borderSize: 1.4,
+        borderSize: 1.4
     };
 
     var grabberPropertiesCloner = {
@@ -424,12 +424,12 @@ SelectionDisplay = (function() {
         dashed: false,
         lineWidth: grabberLineWidth,
         drawInFront: true,
-        borderSize: 1.4,
+        borderSize: 1.4
     };
 
     var spotLightLineProperties = {
         color: lightOverlayColor,
-        lineWidth: 1.5,
+        lineWidth: 1.5
     };
 
     var highlightBox = Overlays.addOverlay("cube", {
@@ -469,7 +469,7 @@ SelectionDisplay = (function() {
         solid: false,
         visible: false,
         dashed: false,
-        lineWidth: 1.0,
+        lineWidth: 1.0
     });
 
     var selectionBoxes = [];
@@ -505,7 +505,7 @@ SelectionDisplay = (function() {
         topMargin: 0,
         rightMargin: 0,
         bottomMargin: 0,
-        leftMargin: 0,
+        leftMargin: 0
     });
 
     var grabberMoveUp = Overlays.addOverlay("image3d", {
@@ -521,7 +521,7 @@ SelectionDisplay = (function() {
         size: 0.1,
         scale: 0.1,
         isFacingAvatar: true,
-        drawInFront: true,
+        drawInFront: true
     });
 
     // var normalLine = Overlays.addOverlay("line3d", {
@@ -613,7 +613,7 @@ SelectionDisplay = (function() {
     var pointLightGrabberHandles = [
         grabberPointLightCircleX, grabberPointLightCircleY, grabberPointLightCircleZ,
         grabberPointLightT, grabberPointLightB, grabberPointLightL,
-        grabberPointLightR, grabberPointLightF, grabberPointLightN,
+        grabberPointLightR, grabberPointLightF, grabberPointLightN
     ];
 
     var grabberCloner = Overlays.addOverlay("cube", grabberPropertiesCloner);
@@ -692,7 +692,7 @@ SelectionDisplay = (function() {
         width: 300,
         height: 200,
         rotation: baseOverlayRotation,
-        ignoreRayIntersection: true, // always ignore this
+        ignoreRayIntersection: true // always ignore this
     });
 
     var yawOverlayAngles = {
@@ -793,7 +793,7 @@ SelectionDisplay = (function() {
             green: 0,
             blue: 0
         },
-        ignoreRayIntersection: true, // always ignore this
+        ignoreRayIntersection: true // always ignore this
     });
 
     var rotateCurrentOverlay = Overlays.addOverlay("line3d", {
@@ -814,7 +814,7 @@ SelectionDisplay = (function() {
             green: 0,
             blue: 255
         },
-        ignoreRayIntersection: true, // always ignore this
+        ignoreRayIntersection: true // always ignore this
     });
 
 
@@ -849,7 +849,7 @@ SelectionDisplay = (function() {
             green: 0,
             blue: 0
         },
-        ignoreRayIntersection: true, // always ignore this
+        ignoreRayIntersection: true // always ignore this
     });
 
     var rotateOverlayOuter = Overlays.addOverlay("circle3d", {
@@ -884,7 +884,7 @@ SelectionDisplay = (function() {
             green: 0,
             blue: 0
         },
-        ignoreRayIntersection: true, // always ignore this
+        ignoreRayIntersection: true // always ignore this
     });
 
     var rotateOverlayCurrent = Overlays.addOverlay("circle3d", {
@@ -914,7 +914,7 @@ SelectionDisplay = (function() {
             red: 0,
             green: 0,
             blue: 0
-        },
+        }
     });
 
     var yawHandle = Overlays.addOverlay("image3d", {
@@ -930,7 +930,7 @@ SelectionDisplay = (function() {
         size: 0.1,
         scale: 0.1,
         isFacingAvatar: false,
-        drawInFront: true,
+        drawInFront: true
     });
 
 
@@ -947,7 +947,7 @@ SelectionDisplay = (function() {
         size: 0.1,
         scale: 0.1,
         isFacingAvatar: false,
-        drawInFront: true,
+        drawInFront: true
     });
 
 
@@ -964,7 +964,7 @@ SelectionDisplay = (function() {
         size: 0.1,
         scale: 0.1,
         isFacingAvatar: false,
-        drawInFront: true,
+        drawInFront: true
     });
 
     var allOverlays = [
@@ -987,7 +987,7 @@ SelectionDisplay = (function() {
         grabberSpotLightCircle,
         grabberPointLightCircleX,
         grabberPointLightCircleY,
-        grabberPointLightCircleZ,
+        grabberPointLightCircleZ
 
     ].concat(stretchHandles);
 
@@ -1532,20 +1532,20 @@ SelectionDisplay = (function() {
 
             for (var i = 0; i < stretchHandles.length; i++) {
                 Overlays.editOverlay(stretchHandles[i], {
-                    size: grabberSize,
+                    size: grabberSize
                 });
             }
             var handleSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 7;
             handleSize = Math.min(handleSize, avgDimension / 3);
 
             Overlays.editOverlay(yawHandle, {
-                scale: handleSize,
+                scale: handleSize
             });
             Overlays.editOverlay(pitchHandle, {
-                scale: handleSize,
+                scale: handleSize
             });
             Overlays.editOverlay(rollHandle, {
-                scale: handleSize,
+                scale: handleSize
             });
             var pos = Vec3.sum(grabberMoveUpPosition, {
                 x: 0,
@@ -1554,7 +1554,7 @@ SelectionDisplay = (function() {
             });
             Overlays.editOverlay(grabberMoveUp, {
                 position: pos,
-                scale: handleSize / 1.25,
+                scale: handleSize / 1.25
             });
         }
     };
@@ -1642,7 +1642,7 @@ SelectionDisplay = (function() {
         var registrationPointDimensions = {
             x: dimensions.x * registrationPoint.x,
             y: dimensions.y * registrationPoint.y,
-            z: dimensions.z * registrationPoint.z,
+            z: dimensions.z * registrationPoint.z
         };
 
         // Center of entity, relative to registration point
@@ -1877,33 +1877,33 @@ SelectionDisplay = (function() {
                     var showEdgeSpotGrabbers = !(inModeTranslate || inModeRotate);
                     Overlays.editOverlay(grabberSpotLightCenter, {
                         position: position,
-                        visible: false,
+                        visible: false
                     });
                     Overlays.editOverlay(grabberSpotLightRadius, {
                         position: NEAR,
                         rotation: rotation,
-                        visible: showEdgeSpotGrabbers,
+                        visible: showEdgeSpotGrabbers
                     });
 
                     Overlays.editOverlay(grabberSpotLightL, {
                         position: EdgeNL,
                         rotation: rotation,
-                        visible: showEdgeSpotGrabbers,
+                        visible: showEdgeSpotGrabbers
                     });
                     Overlays.editOverlay(grabberSpotLightR, {
                         position: EdgeNR,
                         rotation: rotation,
-                        visible: showEdgeSpotGrabbers,
+                        visible: showEdgeSpotGrabbers
                     });
                     Overlays.editOverlay(grabberSpotLightT, {
                         position: EdgeTN,
                         rotation: rotation,
-                        visible: showEdgeSpotGrabbers,
+                        visible: showEdgeSpotGrabbers
                     });
                     Overlays.editOverlay(grabberSpotLightB, {
                         position: EdgeBN,
                         rotation: rotation,
-                        visible: showEdgeSpotGrabbers,
+                        visible: showEdgeSpotGrabbers
                     });
                     Overlays.editOverlay(grabberSpotLightCircle, {
                         position: NEAR,
@@ -1914,28 +1914,28 @@ SelectionDisplay = (function() {
                         },
                         lineWidth: 1.5,
                         rotation: rotation,
-                        visible: true,
+                        visible: true
                     });
 
                     Overlays.editOverlay(grabberSpotLightLineT, {
                         start: position,
                         end: EdgeTN,
-                        visible: true,
+                        visible: true
                     });
                     Overlays.editOverlay(grabberSpotLightLineB, {
                         start: position,
                         end: EdgeBN,
-                        visible: true,
+                        visible: true
                     });
                     Overlays.editOverlay(grabberSpotLightLineR, {
                         start: position,
                         end: EdgeNR,
-                        visible: true,
+                        visible: true
                     });
                     Overlays.editOverlay(grabberSpotLightLineL, {
                         start: position,
                         end: EdgeNL,
-                        visible: true,
+                        visible: true
                     });
 
                 } else { // ..it's a PointLight
@@ -1945,32 +1945,32 @@ SelectionDisplay = (function() {
                     Overlays.editOverlay(grabberPointLightT, {
                         position: TOP,
                         rotation: rotation,
-                        visible: showEdgePointGrabbers,
+                        visible: showEdgePointGrabbers
                     });
                     Overlays.editOverlay(grabberPointLightB, {
                         position: BOTTOM,
                         rotation: rotation,
-                        visible: showEdgePointGrabbers,
+                        visible: showEdgePointGrabbers
                     });
                     Overlays.editOverlay(grabberPointLightL, {
                         position: LEFT,
                         rotation: rotation,
-                        visible: showEdgePointGrabbers,
+                        visible: showEdgePointGrabbers
                     });
                     Overlays.editOverlay(grabberPointLightR, {
                         position: RIGHT,
                         rotation: rotation,
-                        visible: showEdgePointGrabbers,
+                        visible: showEdgePointGrabbers
                     });
                     Overlays.editOverlay(grabberPointLightF, {
                         position: FAR,
                         rotation: rotation,
-                        visible: showEdgePointGrabbers,
+                        visible: showEdgePointGrabbers
                     });
                     Overlays.editOverlay(grabberPointLightN, {
                         position: NEAR,
                         rotation: rotation,
-                        visible: showEdgePointGrabbers,
+                        visible: showEdgePointGrabbers
                     });
                     Overlays.editOverlay(grabberPointLightCircleX, {
                         position: position,
@@ -1980,7 +1980,7 @@ SelectionDisplay = (function() {
                             y: properties.dimensions.z / 2.0,
                             z: 1
                         },
-                        visible: true,
+                        visible: true
                     });
                     Overlays.editOverlay(grabberPointLightCircleY, {
                         position: position,
@@ -1990,7 +1990,7 @@ SelectionDisplay = (function() {
                             y: properties.dimensions.z / 2.0,
                             z: 1
                         },
-                        visible: true,
+                        visible: true
                     });
                     Overlays.editOverlay(grabberPointLightCircleZ, {
                         position: position,
@@ -2000,7 +2000,7 @@ SelectionDisplay = (function() {
                             y: properties.dimensions.z / 2.0,
                             z: 1
                         },
-                        visible: true,
+                        visible: true
                     });
                 }
             } else { // ..it's not a light at all
@@ -2096,7 +2096,7 @@ SelectionDisplay = (function() {
             position: selectionBoxPosition,
             dimensions: dimensions,
             rotation: rotation,
-            visible: !inModeRotate,
+            visible: !inModeRotate
         });
 
         // Create more selection box overlays if we don't have enough
@@ -2120,7 +2120,7 @@ SelectionDisplay = (function() {
                     visible: false,
                     dashed: false,
                     lineWidth: 1.0,
-                    ignoreRayIntersection: true,
+                    ignoreRayIntersection: true
                 }));
         }
 
@@ -2150,7 +2150,7 @@ SelectionDisplay = (function() {
                     color: color,
                     rotation: props.rotation,
                     dimensions: props.dimensions,
-                    visible: true,
+                    visible: true
                 });
             }
         }
@@ -2244,7 +2244,7 @@ SelectionDisplay = (function() {
                 x: selectionManager.worldDimensions.x,
                 y: selectionManager.worldDimensions.z
             },
-            rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
+            rotation: Quat.fromPitchYawRollDegrees(90, 0, 0)
         });
 
         if (wantDebug) {
@@ -2368,7 +2368,7 @@ SelectionDisplay = (function() {
                         var entityID = Entities.addEntity(properties);
                         duplicatedEntityIDs.push({
                             entityID: entityID,
-                            properties: properties,
+                            properties: properties
                         });
                     }
                 }
@@ -2519,7 +2519,7 @@ SelectionDisplay = (function() {
                     z: vector.z
                 });
                 Entities.editEntity(SelectionManager.selections[i], {
-                    position: newPosition,
+                    position: newPosition
                 });
 
                 if (wantDebug) {
@@ -2562,7 +2562,7 @@ SelectionDisplay = (function() {
                         var entityID = Entities.addEntity(properties);
                         duplicatedEntityIDs.push({
                             entityID: entityID,
-                            properties: properties,
+                            properties: properties
                         });
                     }
                 }
@@ -2602,12 +2602,12 @@ SelectionDisplay = (function() {
                 var newPosition = Vec3.sum(properties.position, vector);
 
                 Entities.editEntity(id, {
-                    position: newPosition,
+                    position: newPosition
                 });
             }
 
             SelectionManager._update();
-        },
+        }
     });
 
     // GRABBER TOOL: GRABBER CLONER
@@ -2661,13 +2661,13 @@ SelectionDisplay = (function() {
         var signs = {
             x: direction.x < 0 ? -1 : (direction.x > 0 ? 1 : 0),
             y: direction.y < 0 ? -1 : (direction.y > 0 ? 1 : 0),
-            z: direction.z < 0 ? -1 : (direction.z > 0 ? 1 : 0),
+            z: direction.z < 0 ? -1 : (direction.z > 0 ? 1 : 0)
         };
 
         var mask = {
             x: Math.abs(direction.x) > 0 ? 1 : 0,
             y: Math.abs(direction.y) > 0 ? 1 : 0,
-            z: Math.abs(direction.z) > 0 ? 1 : 0,
+            z: Math.abs(direction.z) > 0 ? 1 : 0
         };
         
         
@@ -2755,7 +2755,7 @@ SelectionDisplay = (function() {
                 Overlays.editOverlay(xRailOverlay, {
                     start: start,
                     end: end,
-                    visible: true,
+                    visible: true
                 });
             }
             if ((numDimensions === 1) && mask.y) {
@@ -2774,7 +2774,7 @@ SelectionDisplay = (function() {
                 Overlays.editOverlay(yRailOverlay, {
                     start: start,
                     end: end,
-                    visible: true,
+                    visible: true
                 });
             }
             if ((numDimensions === 1) && mask.z) {
@@ -2793,7 +2793,7 @@ SelectionDisplay = (function() {
                 Overlays.editOverlay(zRailOverlay, {
                     start: start,
                     end: end,
-                    visible: true,
+                    visible: true
                 });
             }
             if (numDimensions === 1) {
@@ -2962,7 +2962,7 @@ SelectionDisplay = (function() {
                 for (var i = 0; i < SelectionManager.selections.length; i++) {
                     Entities.editEntity(SelectionManager.selections[i], {
                         position: newPosition,
-                        dimensions: newDimensions,
+                        dimensions: newDimensions
                     });
                 }
                 
@@ -3090,7 +3090,7 @@ SelectionDisplay = (function() {
         var cutoff = Math.atan2(newSize, radius) * 180 / Math.PI;
 
         Entities.editEntity(selectionManager.selections[0], {
-            cutoff: cutoff,
+            cutoff: cutoff
         });
 
         SelectionManager._update();
@@ -3117,7 +3117,7 @@ SelectionDisplay = (function() {
         };
 
         Entities.editEntity(selectionManager.selections[0], {
-            dimensions: newDimensions,
+            dimensions: newDimensions
         });
 
         SelectionManager._update();
@@ -3544,7 +3544,7 @@ SelectionDisplay = (function() {
         var position = {
             x: Math.cos(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             y: Math.sin(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
-            z: 0,
+            z: 0
         };
         if (wantDebug) {
             print("    Angle: " + angle);
@@ -3560,7 +3560,7 @@ SelectionDisplay = (function() {
                 y: innerRadius * ROTATION_DISPLAY_SIZE_Y_MULTIPLIER
             },
             lineHeight: innerRadius * ROTATION_DISPLAY_LINE_HEIGHT_MULTIPLIER,
-            text: normalizeDegrees(angleFromZero) + "°",
+            text: normalizeDegrees(angleFromZero) + "°"
         };
         if (wantDebug) {
             print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
@@ -3594,7 +3594,7 @@ SelectionDisplay = (function() {
             var initialProperties = SelectionManager.savedProperties[entityID];
 
             var newProperties = {
-                rotation: Quat.multiply(rotationChange, initialProperties.rotation),
+                rotation: Quat.multiply(rotationChange, initialProperties.rotation)
             };
 
             if (reposition) {
@@ -3637,7 +3637,7 @@ SelectionDisplay = (function() {
             innerRadius: 0.9,
             startAt: 0,
             endAt: 360,
-            alpha: innerAlpha,
+            alpha: innerAlpha
         });
 
         Overlays.editOverlay(rotateOverlayOuter, {
@@ -3648,7 +3648,7 @@ SelectionDisplay = (function() {
             innerRadius: 0.9,
             startAt: 0,
             endAt: 360,
-            alpha: outerAlpha,
+            alpha: outerAlpha
         });
 
         Overlays.editOverlay(rotateOverlayCurrent, {
@@ -3658,11 +3658,11 @@ SelectionDisplay = (function() {
             size: outerRadius,
             startAt: 0,
             endAt: 0,
-            innerRadius: 0.9,
+            innerRadius: 0.9
         });
 
         Overlays.editOverlay(rotationDegreesDisplay, {
-            visible: true,
+            visible: true
         });
 
         updateRotationDegreesOverlay(0, handleRotation, rotCenter);
@@ -3756,7 +3756,7 @@ SelectionDisplay = (function() {
                     majorTickMarksAngle: innerSnapAngle,
                     minorTickMarksAngle: 0,
                     majorTickMarksLength: -0.25,
-                    minorTickMarksLength: 0,
+                    minorTickMarksLength: 0
                 });
             } else {
                 Overlays.editOverlay(rotateOverlayInner, {
@@ -3774,7 +3774,7 @@ SelectionDisplay = (function() {
                     majorTickMarksAngle: 45.0,
                     minorTickMarksAngle: 5,
                     majorTickMarksLength: 0.25,
-                    minorTickMarksLength: 0.1,
+                    minorTickMarksLength: 0.1
                 });
             }
         }// End_If(results.intersects)

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1091,7 +1091,7 @@ SelectionDisplay = (function() {
     // that correlates to the tool you wish to query.
     // @return: bool - Indicates if the activeTool is that queried.
     function isActiveTool(toolHandle) {
-        var wantDebug = true;
+        var wantDebug = false;
         if ( ! activeTool || ! toolHandle ){
             if(wantDebug){
                 if ( activeTool ){
@@ -1610,7 +1610,7 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE HANDLES
     that.updateHandles = function() {
-        var wantDebug = true;
+        var wantDebug = false;
         if(wantDebug){
             print( "======> Update Handles =======" );
             print( "    Selections Count: " + SelectionManager.selections.length );
@@ -1873,6 +1873,8 @@ SelectionDisplay = (function() {
                 if(properties.isSpotlight) {
                     that.setPointLightHandlesVisible( false );
 
+                    var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
+                    var showEdgeSpotGrabbers = ! (inModeTranslate || inModeRotate);
                     Overlays.editOverlay(grabberSpotLightCenter, {
                         position: position,
                         visible: false,
@@ -1880,29 +1882,28 @@ SelectionDisplay = (function() {
                     Overlays.editOverlay(grabberSpotLightRadius, {
                         position: NEAR,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgeSpotGrabbers,
                     });
-                    var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
 
                     Overlays.editOverlay(grabberSpotLightL, {
                         position: EdgeNL,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgeSpotGrabbers,
                     });
                     Overlays.editOverlay(grabberSpotLightR, {
                         position: EdgeNR,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgeSpotGrabbers,
                     });
                     Overlays.editOverlay(grabberSpotLightT, {
                         position: EdgeTN,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgeSpotGrabbers,
                     });
                     Overlays.editOverlay(grabberSpotLightB, {
                         position: EdgeBN,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgeSpotGrabbers,
                     });
                     Overlays.editOverlay(grabberSpotLightCircle, {
                         position: NEAR,
@@ -1939,36 +1940,37 @@ SelectionDisplay = (function() {
 
                 } else { //..it's a PointLight
                     that.setSpotLightHandlesVisible( false );
-                    
+
+                    var showEdgePointGrabbers = ! inModeTranslate;
                     Overlays.editOverlay(grabberPointLightT, {
                         position: TOP,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgePointGrabbers,
                     });
                     Overlays.editOverlay(grabberPointLightB, {
                         position: BOTTOM,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgePointGrabbers,
                     });
                     Overlays.editOverlay(grabberPointLightL, {
                         position: LEFT,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgePointGrabbers,
                     });
                     Overlays.editOverlay(grabberPointLightR, {
                         position: RIGHT,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgePointGrabbers,
                     });
                     Overlays.editOverlay(grabberPointLightF, {
                         position: FAR,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgePointGrabbers,
                     });
                     Overlays.editOverlay(grabberPointLightN, {
                         position: NEAR,
                         rotation: rotation,
-                        visible: true,
+                        visible: showEdgePointGrabbers,
                     });
                     Overlays.editOverlay(grabberPointLightCircleX, {
                         position: position,

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1492,6 +1492,45 @@ SelectionDisplay = (function() {
         });
     };
 
+    // FUNCTION: UPDATE HANDLE SIZES
+    that.updateHandleSizes = function() {
+        if (selectionManager.hasSelection()) {
+            var diff = Vec3.subtract(selectionManager.worldPosition, Camera.getPosition());
+            var grabberSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 5;
+            var dimensions = SelectionManager.worldDimensions;
+            var avgDimension = (dimensions.x + dimensions.y + dimensions.z) / 3;
+            grabberSize = Math.min(grabberSize, avgDimension / 10);
+
+            for (var i = 0; i < stretchHandles.length; i++) {
+                Overlays.editOverlay(stretchHandles[i], {
+                    size: grabberSize,
+                });
+            }
+            var handleSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 7;
+            handleSize = Math.min(handleSize, avgDimension / 3);
+
+            Overlays.editOverlay(yawHandle, {
+                scale: handleSize,
+            });
+            Overlays.editOverlay(pitchHandle, {
+                scale: handleSize,
+            });
+            Overlays.editOverlay(rollHandle, {
+                scale: handleSize,
+            });
+            var pos = Vec3.sum(grabberMoveUpPosition, {
+                x: 0,
+                y: Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 3,
+                z: 0
+            });
+            Overlays.editOverlay(grabberMoveUp, {
+                position: pos,
+                scale: handleSize / 1.25,
+            });
+        }
+    };
+    Script.update.connect(that.updateHandleSizes);
+
     // FUNCTION: SET SPACE MODE
     that.setSpaceMode = function(newSpaceMode) {
         var wantDebug = false;
@@ -4052,45 +4091,6 @@ SelectionDisplay = (function() {
         }
         return false;
     };
-
-    // FUNCTION: UPDATE HANDLE SIZES
-    that.updateHandleSizes = function() {
-        if (selectionManager.hasSelection()) {
-            var diff = Vec3.subtract(selectionManager.worldPosition, Camera.getPosition());
-            var grabberSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 5;
-            var dimensions = SelectionManager.worldDimensions;
-            var avgDimension = (dimensions.x + dimensions.y + dimensions.z) / 3;
-            grabberSize = Math.min(grabberSize, avgDimension / 10);
-
-            for (var i = 0; i < stretchHandles.length; i++) {
-                Overlays.editOverlay(stretchHandles[i], {
-                    size: grabberSize,
-                });
-            }
-            var handleSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 7;
-            handleSize = Math.min(handleSize, avgDimension / 3);
-
-            Overlays.editOverlay(yawHandle, {
-                scale: handleSize,
-            });
-            Overlays.editOverlay(pitchHandle, {
-                scale: handleSize,
-            });
-            Overlays.editOverlay(rollHandle, {
-                scale: handleSize,
-            });
-            var pos = Vec3.sum(grabberMoveUpPosition, {
-                x: 0,
-                y: Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 3,
-                z: 0
-            });
-            Overlays.editOverlay(grabberMoveUp, {
-                position: pos,
-                scale: handleSize / 1.25,
-            });
-        }
-    };
-    Script.update.connect(that.updateHandleSizes);
 
     // FUNCTION: MOUSE RELEASE EVENT
     that.mouseReleaseEvent = function(event) {

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1176,8 +1176,8 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE ROTATION HANDLES
     that.updateRotationHandles = function() {
-        var diagonal = (Vec3.length(selectionManager.worldDimensions) / 2) * 1.1;
-        var halfDimensions = Vec3.multiply(selectionManager.worldDimensions, 0.5);
+        var diagonal = (Vec3.length(SelectionManager.worldDimensions) / 2) * 1.1;
+        var halfDimensions = Vec3.multiply(SelectionManager.worldDimensions, 0.5);
         var innerActive = false;
         var innerAlpha = 0.2;
         var outerAlpha = 0.2;
@@ -1484,8 +1484,8 @@ SelectionDisplay = (function() {
         // var translateHandlesVisible = true;
         // var selectionBoxVisible = true;
         var isPointLight = false;
-        if (selectionManager.selections.length === 1) {
-            var properties = Entities.getEntityProperties(selectionManager.selections[0]);
+        if (SelectionManager.selections.length === 1) {
+            var properties = Entities.getEntityProperties(SelectionManager.selections[0]);
             isPointLight = (properties.type === "Light") && !properties.isSpotlight;
         }
 
@@ -1529,8 +1529,8 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE HANDLE SIZES
     that.updateHandleSizes = function() {
-        if (selectionManager.hasSelection()) {
-            var diff = Vec3.subtract(selectionManager.worldPosition, Camera.getPosition());
+        if (SelectionManager.hasSelection()) {
+            var diff = Vec3.subtract(SelectionManager.worldPosition, Camera.getPosition());
             var grabberSize = Vec3.length(diff) * GRABBER_DISTANCE_TO_SIZE_RATIO * 5;
             var dimensions = SelectionManager.worldDimensions;
             var avgDimension = (dimensions.x + dimensions.y + dimensions.z) / 3;
@@ -1864,10 +1864,10 @@ SelectionDisplay = (function() {
         if (wantDebug) {
             print("    Set Non-Light Grabbers Visible - Norm: " + stretchHandlesVisible + " Ext: " + extendedStretchHandlesVisible);
         }
-        var isSingleSelection = (selectionManager.selections.length === 1);
+        var isSingleSelection = (SelectionManager.selections.length === 1);
 
         if (isSingleSelection) {
-            var properties = Entities.getEntityProperties(selectionManager.selections[0]);
+            var properties = Entities.getEntityProperties(SelectionManager.selections[0]);
             var isLightSelection = (properties.type === "Light");
             if (isLightSelection) {
                 if (wantDebug) {
@@ -2106,7 +2106,7 @@ SelectionDisplay = (function() {
         });
 
         // Create more selection box overlays if we don't have enough
-        var overlaysNeeded = selectionManager.selections.length - selectionBoxes.length;
+        var overlaysNeeded = SelectionManager.selections.length - selectionBoxes.length;
         for (var i = 0; i < overlaysNeeded; i++) {
             selectionBoxes.push(
                 Overlays.addOverlay("cube", {
@@ -2132,9 +2132,9 @@ SelectionDisplay = (function() {
 
         i = 0;
         // Only show individual selections boxes if there is more than 1 selection
-        if (selectionManager.selections.length > 1) {
-            for (; i < selectionManager.selections.length; i++) {
-                var props = Entities.getEntityProperties(selectionManager.selections[i]);
+        if (SelectionManager.selections.length > 1) {
+            for (; i < SelectionManager.selections.length; i++) {
+                var props = Entities.getEntityProperties(SelectionManager.selections[i]);
 
                 // Adjust overlay position to take registrationPoint into account
                 // centeredRP = registrationPoint with range [-0.5, 0.5]
@@ -2149,7 +2149,7 @@ SelectionDisplay = (function() {
                 var curBoxPosition = Vec3.sum(props.position, offset);
 
                 var color = {red: 255, green: 128, blue: 0};
-                if (i >= selectionManager.selections.length - 1) {
+                if (i >= SelectionManager.selections.length - 1) {
                     color = {red: 255, green: 255, blue: 64};
                 }
 
@@ -2244,13 +2244,13 @@ SelectionDisplay = (function() {
             visible: !inModeRotate,
             solid: true,
             position: {
-                x: selectionManager.worldPosition.x,
+                x: SelectionManager.worldPosition.x,
                 y: grid.getOrigin().y,
-                z: selectionManager.worldPosition.z
+                z: SelectionManager.worldPosition.z
             },
             dimensions: {
-                x: selectionManager.worldDimensions.x,
-                y: selectionManager.worldDimensions.z
+                x: SelectionManager.worldDimensions.x,
+                y: SelectionManager.worldDimensions.z
             },
             rotation: Quat.fromPitchYawRollDegrees(90, 0, 0)
         });
@@ -2509,7 +2509,7 @@ SelectionDisplay = (function() {
             }
 
             constrainMajorOnly = event.isControl;
-            var cornerPosition = Vec3.sum(startPosition, Vec3.multiply(-0.5, selectionManager.worldDimensions));
+            var cornerPosition = Vec3.sum(startPosition, Vec3.multiply(-0.5, SelectionManager.worldDimensions));
             vector = Vec3.subtract(
                 grid.snapToGrid(Vec3.sum(cornerPosition, vector), constrainMajorOnly),
                 cornerPosition);
@@ -2604,7 +2604,7 @@ SelectionDisplay = (function() {
             }
             for (var i = 0; i < SelectionManager.selections.length; i++) {
                 var id = SelectionManager.selections[i];
-                var properties = selectionManager.savedProperties[id];
+                var properties = SelectionManager.savedProperties[id];
 
                 var original = properties.position;
                 var newPosition = Vec3.sum(properties.position, vector);
@@ -3088,7 +3088,7 @@ SelectionDisplay = (function() {
             Vec3.print("Radius stretch: ", vector);
         }
         var length = vector.x + vector.y + vector.z;
-        var props = selectionManager.savedProperties[selectionManager.selections[0]];
+        var props = SelectionManager.savedProperties[SelectionManager.selections[0]];
 
         var radius = props.dimensions.z / 2;
         var originalCutoff = props.cutoff;
@@ -3097,7 +3097,7 @@ SelectionDisplay = (function() {
         var newSize = originalSize + length;
         var cutoff = Math.atan2(newSize, radius) * 180 / Math.PI;
 
-        Entities.editEntity(selectionManager.selections[0], {
+        Entities.editEntity(SelectionManager.selections[0], {
             cutoff: cutoff
         });
 
@@ -3106,7 +3106,7 @@ SelectionDisplay = (function() {
 
     // FUNCTION: RADIUS STRETCH FUNC
     function radiusStretchFunc(vector, change) {
-        var props = selectionManager.savedProperties[selectionManager.selections[0]];
+        var props = SelectionManager.savedProperties[SelectionManager.selections[0]];
 
         // Find the axis being adjusted
         var size;
@@ -3124,7 +3124,7 @@ SelectionDisplay = (function() {
             z: size
         };
 
-        Entities.editEntity(selectionManager.selections[0], {
+        Entities.editEntity(SelectionManager.selections[0], {
             dimensions: newDimensions
         });
 
@@ -3631,8 +3631,8 @@ SelectionDisplay = (function() {
         rotationNormal[rotAroundAxis] = 1;
 
         // Size the overlays to the current selection size
-        var diagonal = (Vec3.length(selectionManager.worldDimensions) / 2) * 1.1;
-        var halfDimensions = Vec3.multiply(selectionManager.worldDimensions, 0.5);
+        var diagonal = (Vec3.length(SelectionManager.worldDimensions) / 2) * 1.1;
+        var halfDimensions = Vec3.multiply(SelectionManager.worldDimensions, 0.5);
         innerRadius = diagonal;
         outerRadius = diagonal * 1.15;
         var innerAlpha = 0.2;
@@ -3955,7 +3955,7 @@ SelectionDisplay = (function() {
                 return false;
             }
 
-            entityIconOverlayManager.setIconsSelectable(selectionManager.selections, true);
+            entityIconOverlayManager.setIconsSelectable(SelectionManager.selections, true);
 
             var hitTool = grabberTools[ hitOverlayID ];
             if (hitTool) {

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2392,13 +2392,30 @@ SelectionDisplay = (function() {
         greatestDimension: 0.0,
         startingDistance: 0.0,
         startingElevation: 0.0,
-        onBegin: function(event,isAltFromGrab) {
+        onBegin: function(event,isAltFromGrab, intersectInfo) {
+            var wantDebug = true;
+            if(wantDebug){
+                print("================== TRANSLATE_XZ(Beg) -> =======================");
+                Vec3.print("    intersectInfo.queryRay", intersectInfo.queryRay);
+                Vec3.print("    intersectInfo.queryRay.origin", intersectInfo.queryRay.origin);
+                Vec3.print("    intersectInfo.results.intersection", intersectInfo.results.intersection);
+            }
+
             SelectionManager.saveProperties();
             startPosition = SelectionManager.worldPosition;
-            var dimensions = SelectionManager.worldDimensions;
+            mode = translateXZTool.mode;
 
-            var pickRay = generalComputePickRay(event.x, event.y);
-            initialXZPick = rayPlaneIntersection(pickRay, translateXZTool.pickPlanePosition, {
+            translateXZTool.pickPlanePosition = intersectInfo.results.intersection;
+            translateXZTool.greatestDimension = Math.max(Math.max(SelectionManager.worldDimensions.x, SelectionManager.worldDimensions.y), SelectionManager.worldDimensions.z);
+            translateXZTool.startingDistance = Vec3.distance(intersectInfo.queryRay.origin, SelectionManager.position);
+            translateXZTool.startingElevation = translateXZTool.elevation(intersectInfo.queryRay.origin, translateXZTool.pickPlanePosition);
+            if (wantDebug) {
+                print("    longest dimension: " + translateXZTool.greatestDimension);
+                print("    starting distance: " + translateXZTool.startingDistance);
+                print("    starting elevation: " + translateXZTool.startingElevation);
+            }
+
+            initialXZPick = rayPlaneIntersection(intersectInfo.queryRay, translateXZTool.pickPlanePosition, {
                 x: 0,
                 y: 1,
                 z: 0
@@ -2424,6 +2441,9 @@ SelectionDisplay = (function() {
             }
 
             isConstrained = false;
+            if(wantDebug){
+                print("================== TRANSLATE_XZ(End) <- =======================");
+            }
         },
         onEnd: function(event, reason) {
             pushCommandForSelections(duplicatedEntityIDs);
@@ -2452,8 +2472,10 @@ SelectionDisplay = (function() {
             // this will happen when someone drags across the horizon from the side they started on.
             if (!pick) {
                 if (wantDebug) {
-                    print("Pick ray does not intersect XZ plane.");
+                    print("    "+ translateXZTool.mode + "Pick ray does not intersect XZ plane.");
                 }
+                
+                //--EARLY EXIT--( Invalid ray detected. )
                 return;
             }
 
@@ -2468,8 +2490,10 @@ SelectionDisplay = (function() {
             if ((translateXZTool.startingElevation > 0.0 && elevation < MIN_ELEVATION) ||
                 (translateXZTool.startingElevation < 0.0 && elevation > -MIN_ELEVATION)) {
                 if (wantDebug) {
-                    print("too close to horizon!");
+                    print("    "+ translateXZTool.mode + " - too close to horizon!");
                 }
+
+                //--EARLY EXIT--( Don't proceed past the reached limit. )
                 return;
             }
 
@@ -3610,9 +3634,24 @@ SelectionDisplay = (function() {
     addGrabberTool(yawHandle, {
         mode: "ROTATE_YAW",
         onBegin: function(event) {
-            print("================== HANDLE_ROLL(Beg) -> =======================");
+            var wantDebug = true;
+            if (wantDebug) {
+                print("================== HANDLE_YAW(Beg) -> =======================");
+            }
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
+            mode = "ROTATE_YAW";
+            rotationNormal = yawNormal;
+            //note: It's expected that the intersection is passed when this is called.
+            if (arguments.length >= 2 ) {
+                yawZero = arguments[ 1 ];
+            } else {
+                print("ERROR( yawHandle.onBegin ) - Intersection wasn't passed!");
+            }
+
+            if (wantDebug) {
+                Vec3.print("    yawZero: ", yawZero);
+            }
 
             // Size the overlays to the current selection size
             var diagonal = (Vec3.length(selectionManager.worldDimensions) / 2) * 1.1;
@@ -3623,15 +3662,19 @@ SelectionDisplay = (function() {
             var outerAlpha = 0.2;
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: true,
+                rotation: yawHandleRotation,
+                position: yawCenter,
                 size: innerRadius,
                 innerRadius: 0.9,
                 startAt: 0,
                 endAt: 360,
-                alpha: innerAlpha
+                alpha: innerAlpha,
             });
 
             Overlays.editOverlay(rotateOverlayOuter, {
                 visible: true,
+                rotation: yawHandleRotation,
+                position: yawCenter,
                 size: outerRadius,
                 innerRadius: 0.9,
                 startAt: 0,
@@ -3641,10 +3684,18 @@ SelectionDisplay = (function() {
 
             Overlays.editOverlay(rotateOverlayCurrent, {
                 visible: true,
+                rotation: yawHandleRotation,
+                position: yawCenter,
                 size: outerRadius,
                 startAt: 0,
                 endAt: 0,
                 innerRadius: 0.9,
+            });
+
+            Overlays.editOverlay(rotateOverlayTarget, {
+                visible: true,
+                rotation: yawHandleRotation,
+                position: yawCenter
             });
 
             Overlays.editOverlay(rotationDegreesDisplay, {
@@ -3652,7 +3703,9 @@ SelectionDisplay = (function() {
             });
 
             updateRotationDegreesOverlay(0, yawHandleRotation, yawCenter);
-            print("================== HANDLE_YAW(Beg) <- =======================");
+            if(wantDebug){
+                print("================== HANDLE_YAW(Beg) <- =======================");
+            }
         },
         onEnd: function(event, reason) {
             print("================== HANDLE_YAW(End) -> =======================");
@@ -3784,10 +3837,25 @@ SelectionDisplay = (function() {
     // PITCH GRABBER TOOL DEFINITION
     addGrabberTool(pitchHandle, {
         mode: "ROTATE_PITCH",
-        onBegin: function(event) {
-            print("================== HANDLE_PITCH(Beg) -> =======================");
+        onBegin: function (event) {
+            var wantDebug = true;
+            if (wantDebug){
+                print("================== HANDLE_PITCH(Beg) -> =======================");
+            }
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
+            mode = "ROTATE_PITCH";
+            rotationNormal = pitchNormal;
+            //note: It's expected that the intersection is passed when this is called.
+            if (arguments.length >= 2 ) {
+                pitchZero = arguments[ 1 ];
+            } else {
+                print("ERROR( pitchHandle.onBegin ) - Intersection wasn't passed!");
+            }
+            
+            if (wantDebug) {
+                Vec3.print("    pitchZero: ", pitchZero);
+            }
 
             // Size the overlays to the current selection size
             var diagonal = (Vec3.length(selectionManager.worldDimensions) / 2) * 1.1;
@@ -3798,6 +3866,8 @@ SelectionDisplay = (function() {
             var outerAlpha = 0.2;
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: true,
+                rotation: pitchHandleRotation,
+                position: pitchCenter,
                 size: innerRadius,
                 innerRadius: 0.9,
                 startAt: 0,
@@ -3807,6 +3877,8 @@ SelectionDisplay = (function() {
 
             Overlays.editOverlay(rotateOverlayOuter, {
                 visible: true,
+                rotation: pitchHandleRotation,
+                position: pitchCenter,
                 size: outerRadius,
                 innerRadius: 0.9,
                 startAt: 0,
@@ -3816,6 +3888,8 @@ SelectionDisplay = (function() {
 
             Overlays.editOverlay(rotateOverlayCurrent, {
                 visible: true,
+                rotation: pitchHandleRotation,
+                position: pitchCenter,
                 size: outerRadius,
                 startAt: 0,
                 endAt: 0,
@@ -3826,8 +3900,16 @@ SelectionDisplay = (function() {
                 visible: true,
             });
 
+            Overlays.editOverlay(rotateOverlayTarget, {
+                visible: true,
+                rotation: pitchHandleRotation,
+                position: pitchCenter
+            });
+
             updateRotationDegreesOverlay(0, pitchHandleRotation, pitchCenter);
-            print("================== HANDLE_PITCH(Beg) <- =======================");
+            if(wantDebug){
+                print("================== HANDLE_PITCH(Beg) <- =======================");
+            }
         },
         onEnd: function(event, reason) {
             print("================== HANDLE_PITCH(End) -> =======================");
@@ -3847,7 +3929,7 @@ SelectionDisplay = (function() {
             pushCommandForSelections();
             print("================== HANDLE_PITCH(End) <- =======================");
         },
-        onMove: function(event) {
+        onMove: function (event) {
             print("================== HANDLE_PITCH(Mve) -> =======================");
             var pickRay = generalComputePickRay(event.x, event.y);
             Overlays.editOverlay(selectionBox, {
@@ -3949,10 +4031,25 @@ SelectionDisplay = (function() {
     // ROLL GRABBER TOOL DEFINITION
     addGrabberTool(rollHandle, {
         mode: "ROTATE_ROLL",
-        onBegin: function(event) {
-            print("================== HANDLE_ROLL(Beg) -> =======================");
+        onBegin: function (event) {
+            var wantDebug = true;
+            if(wantDebug){
+                print("================== HANDLE_ROLL(Beg) -> =======================");
+            }
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
+            mode = "ROTATE_ROLL";
+            rotationNormal = rollNormal;
+            //note: It's expected that the intersection is passed when this is called.
+            if (arguments.length >= 2 ) {
+                rollZero = arguments[ 1 ];
+            } else {
+                print("ERROR( rollHandle.onBegin ) - Intersection wasn't passed!");
+            }
+            
+            if (wantDebug) {
+                Vec3.print("    rollZero: ", rollZero);
+            }
 
             // Size the overlays to the current selection size
             var diagonal = (Vec3.length(selectionManager.worldDimensions) / 2) * 1.1;
@@ -3963,6 +4060,8 @@ SelectionDisplay = (function() {
             var outerAlpha = 0.2;
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: true,
+                rotation: rollHandleRotation,
+                position: rollCenter,
                 size: innerRadius,
                 innerRadius: 0.9,
                 startAt: 0,
@@ -3972,6 +4071,8 @@ SelectionDisplay = (function() {
 
             Overlays.editOverlay(rotateOverlayOuter, {
                 visible: true,
+                rotation: rollHandleRotation,
+                position: rollCenter,
                 size: outerRadius,
                 innerRadius: 0.9,
                 startAt: 0,
@@ -3981,6 +4082,8 @@ SelectionDisplay = (function() {
 
             Overlays.editOverlay(rotateOverlayCurrent, {
                 visible: true,
+                rotation: rollHandleRotation,
+                position: rollCenter,
                 size: outerRadius,
                 startAt: 0,
                 endAt: 0,
@@ -3991,10 +4094,18 @@ SelectionDisplay = (function() {
                 visible: true,
             });
 
+            Overlays.editOverlay(rotateOverlayTarget, {
+                visible: true,
+                rotation: rollHandleRotation,
+                position: rollCenter
+            });
+
             updateRotationDegreesOverlay(0, rollHandleRotation, rollCenter);
-            print("================== HANDLE_ROLL(Beg) <- =======================");
+            if(wantDebug){
+                print("================== HANDLE_ROLL(Beg) <- =======================");
+            }
         },
-        onEnd: function(event, reason) {
+        onEnd: function (event, reason) {
             print("================== HANDLE_ROLL(End) -> =======================");
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
@@ -4141,11 +4252,68 @@ SelectionDisplay = (function() {
         }
     };
 
+
+    // FUNCTION DEF(s): Intersection Check Helpers
+    function testRayIntersect(queryRay, overlayIncludes, overlayExcludes) {
+        var wantDebug = true;
+        if ((queryRay === undefined) || (queryRay === null)) {
+            if (wantDebug) {
+                print("testRayIntersect - EARLY EXIT -> queryRay is undefined OR null!");
+            }
+            return null;
+        }
+
+        var intersectObj = Overlays.findRayIntersection(queryRay, true, overlayIncludes, overlayExcludes);
+
+        if (wantDebug) {
+            if ( ! overlayIncludes ){
+                print("testRayIntersect - no overlayIncludes provided.");
+            }
+            if ( ! overlayExcludes ){
+                print("testRayIntersect - no overlayExcludes provided.");
+            }
+            print("testRayIntersect - Hit: " + intersectObj.intersects);
+            print("    intersectObj.overlayID:" + intersectObj.overlayID + "[" + overlayNames[intersectObj.overlayID] + "]");
+            print("        OverlayName: " + overlayNames[intersectObj.overlayID]);
+            print("    intersectObj.distance:" + intersectObj.distance);
+            print("    intersectObj.face:" + intersectObj.face);
+            Vec3.print("    intersectObj.intersection:", intersectObj.intersection);
+        }
+
+        return intersectObj;
+    }
+
+    function checkIntersectWithHUD(queryRay) {
+        var intersectObj = testRayIntersect(queryRay, [HMD.tabletID, HMD.tabletScreenID, HMD.homeButtonID]);
+
+        return intersectObj;
+    }
+
+    function checkIntersectWithNonSelectionItems(queryRay) {
+        var intersectObj = testRayIntersect(queryRay, null, [yawHandle, pitchHandle, rollHandle, selectionBox]);
+
+        return intersectObj;
+    }
+
+    function checkIntersectWithRotationHandles(queryRay) {
+        var intersectObj = testRayIntersect(queryRay, [yawHandle, pitchHandle, rollHandle]);
+
+        return intersectObj;
+    }
+
+    function checkIntersectWithSelectionBox(queryRay) {
+        var intersectObj = testRayIntersect(queryRay, [selectionBox]);
+
+        return intersectObj;
+    }
+    //--------------------
+
+    //---------------------------------------
     // FUNCTION: MOUSE PRESS EVENT
-    that.mousePressEvent = function(event) {
-        var wantDebug = false;
-        if ( wantDebug ) {
-            print( "=============== eST::MousePressEvent BEG =======================");
+    that.mousePressEvent = function (event) {
+        var wantDebug = true;
+        if (wantDebug) {
+            print("=============== eST::MousePressEvent BEG =======================");
         }
         if (!event.isLeftButton && !that.triggered) {
             // if another mouse button than left is pressed ignore it
@@ -4155,28 +4323,18 @@ SelectionDisplay = (function() {
         var somethingClicked = false;
         var pickRay = generalComputePickRay(event.x, event.y);
 
-        var result = Overlays.findRayIntersection(pickRay, true, [HMD.tabletID, HMD.tabletScreenID, HMD.homeButtonID]);
-        if (result.intersects) {
+        var results_checkHUD = checkIntersectWithHUD(pickRay);
+        if (results_checkHUD.intersects) {
             // mouse clicks on the tablet should override the edit affordances
             return false;
         }
 
-        entityIconOverlayManager.setIconsSelectable(selectionManager.selections,true);
+        entityIconOverlayManager.setIconsSelectable(selectionManager.selections, true);
 
         // ignore ray intersection for our selection box and yaw/pitch/roll
-        result = Overlays.findRayIntersection(pickRay, true, null, [ yawHandle, pitchHandle, rollHandle, selectionBox ] );
-        if (result.intersects) {
-            if (wantDebug) {
-                print("something intersects... ");
-                print("   result.overlayID:" + result.overlayID + "[" + overlayNames[result.overlayID] + "]");
-                print("   result.intersects:" + result.intersects);
-                print("   result.overlayID:" + result.overlayID);
-                print("   result.distance:" + result.distance);
-                print("   result.face:" + result.face);
-                Vec3.print("   result.intersection:", result.intersection);
-            }
-
-            var tool = grabberTools[result.overlayID];
+        var results_checkNonSelection = checkIntersectWithNonSelectionItems(pickRay);
+        if (results_checkNonSelection.intersects) {
+            var tool = grabberTools[results_checkNonSelection.overlayID];
             if (tool) {
                 if (wantDebug) {
                     print("Intersected with known table tool( mode: " + tool.mode + " )");
@@ -4184,99 +4342,20 @@ SelectionDisplay = (function() {
                 activeTool = tool;
                 mode = tool.mode;
                 somethingClicked = 'tool';
-                if (activeTool && activeTool.onBegin) {
+                if (activeTool.onBegin) {
                     activeTool.onBegin(event);
+                } else if (wantDebug) {
+                        print("    ActiveTool( " + activeTool.mode + " ) missing onBegin");
                 }
             } else {
-                if (wantDebug) {
-                    print("Intersected with unregistered tool...");
-                }
-                switch (result.overlayID) {
-                    case grabberMoveUp:
-                        if (wantDebug){
-                            print("grabberMoveUp");
-                        }
-                        mode = "TRANSLATE_UP_DOWN";
-                        somethingClicked = mode;
-
-                        // in translate mode, we hide our stretch handles...
-                        for (var i = 0; i < stretchHandles.length; i++) {
-                            Overlays.editOverlay(stretchHandles[i], {
-                                visible: false
-                            });
-                        }
-                        break;
-
-
-                    case grabberNEAR:
-                    case grabberEdgeTN: // TODO: maybe this should be TOP+NEAR stretching?
-                    case grabberEdgeBN: // TODO: maybe this should be BOTTOM+FAR stretching?
-                        if(wantDebug){
-                            print("grabberNear variant");
-                        }
-                        mode = "STRETCH_NEAR";
-                        somethingClicked = mode;
-                        break;
-
-                    case grabberFAR:
-                    case grabberEdgeTF: // TODO: maybe this should be TOP+FAR stretching?
-                    case grabberEdgeBF: // TODO: maybe this should be BOTTOM+FAR stretching?
-                        if(wantDebug){
-                            print("grabberFar variant");
-                        }
-                        mode = "STRETCH_FAR";
-                        somethingClicked = mode;
-                        break;
-                    case grabberTOP:
-                        if(wantDebug){
-                            print("grabberTOP");
-                        }
-                        mode = "STRETCH_TOP";
-                        somethingClicked = mode;
-                        break;
-                    case grabberBOTTOM:
-                        if(wantDebug){
-                            print("grabberBOTTOM");
-                        }
-                        mode = "STRETCH_BOTTOM";
-                        somethingClicked = mode;
-                        break;
-                    case grabberRIGHT:
-                    case grabberEdgeTR: // TODO: maybe this should be TOP+RIGHT stretching?
-                    case grabberEdgeBR: // TODO: maybe this should be BOTTOM+RIGHT stretching?
-                        if(wantDebug){
-                            print("grabberRight variant");
-                        }
-                        mode = "STRETCH_RIGHT";
-                        somethingClicked = mode;
-                        break;
-                    case grabberLEFT:
-                    case grabberEdgeTL: // TODO: maybe this should be TOP+LEFT stretching?
-                    case grabberEdgeBL: // TODO: maybe this should be BOTTOM+LEFT stretching?
-                        if(wantDebug){
-                            print("grabberLeft variant");
-                        }
-                        mode = "STRETCH_LEFT";
-                        somethingClicked = mode;
-                        break;
-
-                    default:
-                        if(wantDebug){
-                            print("UNKNOWN( " + result.overlayID + " )");
-                        }
-                        mode = "UNKNOWN";
-                        break;
-                }
-                if(wantDebug){
-                    print("  Unregistered Tool Mode: " + mode );
-                }
-            }
-        }
+                mode = "UNKNOWN";
+            }//--End_if(tool)
+        }//--End_if(results_checkNonSelection.intersects)
 
         // if one of the items above was clicked, then we know we are in translate or stretch mode, and we
         // should hide our rotate handles...
         if (somethingClicked) {
-            if(wantDebug){
+            if (wantDebug) {
                 print("    Trying to hide PitchYawRoll Handles");
             }
             Overlays.editOverlay(yawHandle, {
@@ -4307,133 +4386,45 @@ SelectionDisplay = (function() {
 
 
             // Only intersect versus yaw/pitch/roll.
-            result = Overlays.findRayIntersection(pickRay, true, [ yawHandle, pitchHandle, rollHandle ] );
-
-            var overlayOrientation;
-            var overlayCenter;
-
+            var results_checkRotationHandles = checkIntersectWithRotationHandles(pickRay);
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
             var angles = Quat.safeEulerAngles(properties.rotation);
             var pitch = angles.x;
             var yaw = angles.y;
             var roll = angles.z;
 
+            //TODO_Case6491:  Should these only be updated when we actually touched
+            //                a handle. (The answer is most likley: Yes)  Potentially move chunk
+            //                to either tool's onBegin or before rayCast here when refactored.
             originalRotation = properties.rotation;
             originalPitch = pitch;
             originalYaw = yaw;
             originalRoll = roll;
 
-            if (result.intersects) {
-                var resultTool = grabberTools[result.overlayID];
-                if(wantDebug){
+            if (results_checkRotationHandles.intersects) {
+                var resultTool = grabberTools[results_checkRotationHandles.overlayID];
+                if (wantDebug) {
                     print("Intersection detected with handle...");
                 }
                 if (resultTool) {
-                    if(wantDebug){
+                    if (wantDebug) {
                         print("    " + resultTool.mode);
                     }
                     activeTool = resultTool;
-                    mode = resultTool.mode;
-                    somethingClicked = 'tool';
-                    if (activeTool && activeTool.onBegin) {
-                        if(wantDebug){
-                            print("    Triggering Tool's onBegin");
-                        }
-                        activeTool.onBegin(event);
-                    } else if(wantDebug) {
-                        print("    Tool's missing onBegin");
+                    somethingClicked = resultTool.mode;
+                    if(activeTool.onBegin) {
+                        activeTool.onBegin(event, results_checkRotationHandles.intersection);
+                    } else if (wantDebug) {
+                        print("    ActiveTool( " + activeTool.mode + " ) missing onBegin");
                     }
-                }
-                switch (result.overlayID) {
-                    case yawHandle:
-                        if(wantDebug){
-                            print("Handle_YAW");
-                        }
-                        mode = "ROTATE_YAW";
-                        somethingClicked = mode;
-                        overlayOrientation = yawHandleRotation;
-                        overlayCenter = yawCenter;
-                        yawZero = result.intersection;
-                        rotationNormal = yawNormal;
-                        if(wantDebug){
-                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
-                        }
-                        break;
+                }//--End_If(resultTool)
+            }//--End_If(results_checkRotationHandles.intersects)
 
-                    case pitchHandle:
-                        if(wantDebug){
-                            print("Handle_PITCH");
-                        }
-                        mode = "ROTATE_PITCH";
-                        initialPosition = SelectionManager.worldPosition;
-                        somethingClicked = mode;
-                        overlayOrientation = pitchHandleRotation;
-                        overlayCenter = pitchCenter;
-                        pitchZero = result.intersection;
-                        rotationNormal = pitchNormal;
-                        if(wantDebug){
-                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
-                        }
-                        break;
+             if (somethingClicked) {
 
-                    case rollHandle:
-                        if(wantDebug){
-                            print("Handle_ROLL");
-                        }
-                        mode = "ROTATE_ROLL";
-                        somethingClicked = mode;
-                        overlayOrientation = rollHandleRotation;
-                        overlayCenter = rollCenter;
-                        rollZero = result.intersection;
-                        rotationNormal = rollNormal;
-                        if(wantDebug){
-                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
-                        }
-                        break;
-
-                    default:
-                        if (wantDebug) {
-                            print("mousePressEvent()...... " + overlayNames[result.overlayID]);
-                        }
-                        mode = "UNKNOWN";
-                        break;
-                }
-            }
-            if (wantDebug) {
-                print("    somethingClicked:" + somethingClicked);
-                print("                mode:" + mode);
-            }
-
-            if (somethingClicked) {
-
-                if(wantDebug){
-                    print("    Trying to show rotateOverlay Handles");
-                }
-                Overlays.editOverlay(rotateOverlayTarget, {
-                    visible: true,
-                    rotation: overlayOrientation,
-                    position: overlayCenter
-                });
-                Overlays.editOverlay(rotateOverlayInner, {
-                    visible: true,
-                    rotation: overlayOrientation,
-                    position: overlayCenter
-                });
-                Overlays.editOverlay(rotateOverlayOuter, {
-                    visible: true,
-                    rotation: overlayOrientation,
-                    position: overlayCenter,
-                    startAt: 0,
-                    endAt: 360
-                });
-                Overlays.editOverlay(rotateOverlayCurrent, {
-                    visible: true,
-                    rotation: overlayOrientation,
-                    position: overlayCenter,
-                    startAt: 0,
-                    endAt: 0
-                });
-                if(wantDebug){
+                if (wantDebug) {
+                    print("    somethingClicked:" + somethingClicked);
+                    print("                mode:" + mode);
                     print("    Trying to hide PitchYawRoll Handles");
                 }
                 Overlays.editOverlay(yawHandle, {
@@ -4541,49 +4532,31 @@ SelectionDisplay = (function() {
 
         if (!somethingClicked) {
             // Only intersect versus selectionBox.
-            result = Overlays.findRayIntersection(pickRay, true, [selectionBox]);
-            if (result.intersects) {
-                switch (result.overlayID) {
-                    case selectionBox:
-                        activeTool = translateXZTool;
-                        if(wantDebug){
-                            print("Clicked selectionBox, Activating Tool: " + activeTool.mode );
-                        }
-                        translateXZTool.pickPlanePosition = result.intersection;
-                        translateXZTool.greatestDimension = Math.max(Math.max(SelectionManager.worldDimensions.x, SelectionManager.worldDimensions.y),
-                            SelectionManager.worldDimensions.z);
-                        if (wantDebug) {
-                            print("longest dimension: " + translateXZTool.greatestDimension);
-                            translateXZTool.startingDistance = Vec3.distance(pickRay.origin, SelectionManager.position);
-                            print("starting distance: " + translateXZTool.startingDistance);
-                            translateXZTool.startingElevation = translateXZTool.elevation(pickRay.origin, translateXZTool.pickPlanePosition);
-                            print(" starting elevation: " + translateXZTool.startingElevation);
-                        }
-
-                        mode = translateXZTool.mode;
-                        activeTool.onBegin(event);
-                        somethingClicked = 'selectionBox';
-                        break;
-                    default:
-                        if (wantDebug) {
-                            print("mousePressEvent()...... " + overlayNames[result.overlayID]);
-                        }
-                        mode = "UNKNOWN";
-                        break;
+            var results_checkSelectionBox = checkIntersectWithSelectionBox( pickRay );
+            if (results_checkSelectionBox.intersects) {
+                activeTool = translateXZTool;
+                if(wantDebug){
+                    print("Clicked selectionBox, Activating Tool: " + activeTool.mode );
                 }
+                var intersectInfo = {
+                    queryRay: pickRay,
+                    results: results_checkSelectionBox
+                };
+                activeTool.onBegin(event, null, intersectInfo);
+                somethingClicked = 'selectionBox';
             }
         }
 
         if (somethingClicked) {
-            pickRay = generalComputePickRay(event.x, event.y);
             if (wantDebug) {
-                print("mousePressEvent()...... " + overlayNames[result.overlayID]);
+                print("mousePressEvent()...... " + somethingClicked);
+                print("    mode: " + mode);
             }
         }
 
         // reset everything as intersectable...
         // TODO: we could optimize this since some of these were already flipped back(i.e:  just get rid of this)
-        if(wantDebug){
+        if (wantDebug) {
             print("Trying to set SelectionBox & PitchYawRoll Handles to NOT_IGNORE Rays");
         }
         Overlays.editOverlay(selectionBox, {
@@ -4599,8 +4572,8 @@ SelectionDisplay = (function() {
             ignoreRayIntersection: false
         });
 
-        if ( wantDebug ) {
-            print( "=============== eST::MousePressEvent END =======================");
+        if (wantDebug) {
+            print("=============== eST::MousePressEvent END =======================");
         }
 
         return somethingClicked;
@@ -4613,18 +4586,18 @@ SelectionDisplay = (function() {
             print( "=============== eST::MouseMoveEvent BEG =======================");
         }
         if (activeTool) {
-            if(wantDebug){
+            if (wantDebug) {
                 print("    Trigger ActiveTool( " + activeTool.mode + " )'s onMove");
             }
             activeTool.onMove(event);
-            
-            if(wantDebug){
+
+            if (wantDebug) {
                 print("    Trigger SelectionManager::update");
             }
             SelectionManager._update();
-            
-            if(wantDebug){
-                print( "=============== eST::MouseMoveEvent END =======================");
+
+            if (wantDebug) {
+                print("=============== eST::MouseMoveEvent END =======================");
             }
             //--EARLY EXIT--( Move handled via active tool)
             return true;
@@ -4710,7 +4683,7 @@ SelectionDisplay = (function() {
                     pickedAlpha = grabberAlpha;
                     highlightNeeded = true;
                     break;
-                    
+
                 default:
                     if (previousHandle) {
                         Overlays.editOverlay(previousHandle, {

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -288,7 +288,6 @@ SelectionDisplay = (function() {
     };
     var handleHoverAlpha = 1.0;
 
-    var rotateOverlayTargetSize = 10000; // really big target
     var innerSnapAngle = 22.5; // the angle which we snap to on the inner rotation tool
     var innerRadius;
     var outerRadius;
@@ -805,24 +804,6 @@ SelectionDisplay = (function() {
     });
 
 
-    var rotateOverlayTarget = Overlays.addOverlay("circle3d", {
-        position: {
-            x: 0,
-            y: 0,
-            z: 0
-        },
-        size: rotateOverlayTargetSize,
-        color: {
-            red: 0,
-            green: 0,
-            blue: 0
-        },
-        alpha: 0.0,
-        solid: true,
-        visible: false,
-        rotation: yawOverlayRotation,
-    });
-
     var rotateOverlayInner = Overlays.addOverlay("circle3d", {
         position: {
             x: 0,
@@ -979,7 +960,6 @@ SelectionDisplay = (function() {
         yawHandle,
         pitchHandle,
         rollHandle,
-        rotateOverlayTarget,
         rotateOverlayInner,
         rotateOverlayOuter,
         rotateOverlayCurrent,
@@ -1034,7 +1014,6 @@ SelectionDisplay = (function() {
     overlayNames[pitchHandle] = "pitchHandle";
     overlayNames[rollHandle] = "rollHandle";
 
-    overlayNames[rotateOverlayTarget] = "rotateOverlayTarget";
     overlayNames[rotateOverlayInner] = "rotateOverlayInner";
     overlayNames[rotateOverlayOuter] = "rotateOverlayOuter";
     overlayNames[rotateOverlayCurrent] = "rotateOverlayCurrent";
@@ -1472,9 +1451,6 @@ SelectionDisplay = (function() {
             translateHandlesVisible = false;
         }
 
-        Overlays.editOverlay(rotateOverlayTarget, {
-            visible: rotationOverlaysVisible
-        });
         Overlays.editOverlay(rotateZeroOverlay, {
             visible: rotationOverlaysVisible
         });
@@ -3656,12 +3632,6 @@ SelectionDisplay = (function() {
             innerRadius: 0.9,
         });
 
-        Overlays.editOverlay(rotateOverlayTarget, {
-            visible: true,
-            rotation: handleRotation,
-            position: rotCenter
-        });
-
         Overlays.editOverlay(rotationDegreesDisplay, {
             visible: true,
         });
@@ -4186,9 +4156,6 @@ SelectionDisplay = (function() {
             if(wantDebug){
                 print("    Triggering hide of RotateOverlays");
             }
-            Overlays.editOverlay(rotateOverlayTarget, {
-                visible: false
-            });
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1583,20 +1583,29 @@ SelectionDisplay = (function() {
 
     // FUNCTION: SET SPACE MODE
     that.setSpaceMode = function(newSpaceMode) {
+        print("======> SetSpaceMode called. ========");
         if (spaceMode != newSpaceMode) {
+            print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
             spaceMode = newSpaceMode;
             that.updateHandles();
+        } else {
+            print("    Can't update SpaceMode. CurrentMode: " + spaceMode + " DesiredMode: " + newSpaceMode);
         }
+        print("====== SetSpaceMode called. <========");
     };
 
     // FUNCTION: TOGGLE SPACE MODE
     that.toggleSpaceMode = function() {
+        print("========> ToggleSpaceMode called. =========");
         if (spaceMode == SPACE_WORLD && SelectionManager.selections.length > 1) {
             print("Local space editing is not available with multiple selections");
             return;
         }
+        print( "PreToggle: " + spaceMode);
         spaceMode = spaceMode == SPACE_LOCAL ? SPACE_WORLD : SPACE_LOCAL;
+        print( "PostToggle: " + spaceMode);
         that.updateHandles();
+        print("======== ToggleSpaceMode called. <=========");
     };
 
     // FUNCTION: UNSELECT ALL
@@ -1605,6 +1614,9 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE HANDLES
     that.updateHandles = function() {
+        print( "======> Update Handles =======" );
+        print( "    Selections Count: " + SelectionManager.selections.length );
+        print( "    SpaceMode: " + spaceMode );
         if (SelectionManager.selections.length === 0) {
             that.setOverlaysVisible(false);
             return;
@@ -2333,6 +2345,8 @@ SelectionDisplay = (function() {
             },
             rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         });
+
+        print( "====== Update Handles <=======" );
 
     };
 
@@ -3551,15 +3565,22 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE ROTATION DEGREES OVERLAY
     function updateRotationDegreesOverlay(angleFromZero, handleRotation, centerPosition) {
+        print( "---> updateRotationDegreesOverlay ---" );
+        print("    AngleFromZero: " + angleFromZero );
+        print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
+        print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z );
         var angle = angleFromZero * (Math.PI / 180);
         var position = {
             x: Math.cos(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             y: Math.sin(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             z: 0,
         };
+        print("    Angle: " + angle );
+        print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
         position = Vec3.multiplyQbyV(handleRotation, position);
         position = Vec3.sum(centerPosition, position);
-        Overlays.editOverlay(rotationDegreesDisplay, {
+        print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
+        var overlayProps = {
             position: position,
             dimensions: {
                 x: innerRadius * ROTATION_DISPLAY_SIZE_X_MULTIPLIER,
@@ -3567,7 +3588,12 @@ SelectionDisplay = (function() {
             },
             lineHeight: innerRadius * ROTATION_DISPLAY_LINE_HEIGHT_MULTIPLIER,
             text: normalizeDegrees(angleFromZero) + "°",
-        });
+        };
+        print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
+        print("    OverlayLineHeight: " + overlayProps.lineHeight );
+        print("    OverlayText: " + overlayProps.text );
+        Overlays.editOverlay(rotationDegreesDisplay, overlayProps);
+        print( "<--- updateRotationDegreesOverlay ---" );
     }
 
     // YAW GRABBER TOOL DEFINITION
@@ -3575,6 +3601,7 @@ SelectionDisplay = (function() {
     addGrabberTool(yawHandle, {
         mode: "ROTATE_YAW",
         onBegin: function(event) {
+            print("================== HANDLE_ROLL(Beg) -> =======================");
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
 
@@ -3616,8 +3643,10 @@ SelectionDisplay = (function() {
             });
 
             updateRotationDegreesOverlay(0, yawHandleRotation, yawCenter);
+            print("================== HANDLE_YAW(Beg) <- =======================");
         },
         onEnd: function(event, reason) {
+            print("================== HANDLE_YAW(End) -> =======================");
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });
@@ -3632,8 +3661,10 @@ SelectionDisplay = (function() {
             });
 
             pushCommandForSelections();
+            print("================== HANDLE_YAW(End) <- =======================");
         },
         onMove: function(event) {
+            print("================== HANDLE_YAW(Mve) -> =======================");
             var pickRay = generalComputePickRay(event.x, event.y);
             Overlays.editOverlay(selectionBox, {
                 visible: false
@@ -3651,6 +3682,7 @@ SelectionDisplay = (function() {
                 var centerToIntersect = Vec3.subtract(result.intersection, center);
                 // Note: orientedAngle which wants normalized centerToZero and centerToIntersect
                 //             handles that internally, so it's to pass unnormalized vectors here.
+                print("    RotNormal - X: " + rotationNormal.x + " Y: " + rotationNormal.y + " Z: " + rotationNormal.z);
                 var angleFromZero = Vec3.orientedAngle(centerToZero, centerToIntersect, rotationNormal);
                 var distanceFromCenter = Vec3.distance(center, result.intersection);
                 var snapToInner = distanceFromCenter < innerRadius;
@@ -3736,6 +3768,7 @@ SelectionDisplay = (function() {
                 }
 
             }
+            print("================== HANDLE_YAW(Mve) <- =======================");
         }
     });
 
@@ -3743,6 +3776,7 @@ SelectionDisplay = (function() {
     addGrabberTool(pitchHandle, {
         mode: "ROTATE_PITCH",
         onBegin: function(event) {
+            print("================== HANDLE_PITCH(Beg) -> =======================");
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
 
@@ -3784,8 +3818,10 @@ SelectionDisplay = (function() {
             });
 
             updateRotationDegreesOverlay(0, pitchHandleRotation, pitchCenter);
+            print("================== HANDLE_PITCH(Beg) <- =======================");
         },
         onEnd: function(event, reason) {
+            print("================== HANDLE_PITCH(End) -> =======================");
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });
@@ -3800,8 +3836,10 @@ SelectionDisplay = (function() {
             });
 
             pushCommandForSelections();
+            print("================== HANDLE_PITCH(End) <- =======================");
         },
         onMove: function(event) {
+            print("================== HANDLE_PITCH(Mve) -> =======================");
             var pickRay = generalComputePickRay(event.x, event.y);
             Overlays.editOverlay(selectionBox, {
                 visible: false
@@ -3818,6 +3856,7 @@ SelectionDisplay = (function() {
                 var centerToIntersect = Vec3.subtract(result.intersection, center);
                 // Note: orientedAngle which wants normalized centerToZero & centerToIntersect, handles
                 //       this internally, so it's fine to pass non-normalized versions here.
+                print("    RotNormal - X: " + rotationNormal.x + " Y: " + rotationNormal.y + " Z: " + rotationNormal.z);
                 var angleFromZero = Vec3.orientedAngle(centerToZero, centerToIntersect, rotationNormal);
 
                 var distanceFromCenter = Vec3.distance(center, result.intersection);
@@ -3894,6 +3933,7 @@ SelectionDisplay = (function() {
                     });
                 }
             }
+            print("================== HANDLE_PITCH(Mve) <- =======================");
         }
     });
 
@@ -3901,6 +3941,7 @@ SelectionDisplay = (function() {
     addGrabberTool(rollHandle, {
         mode: "ROTATE_ROLL",
         onBegin: function(event) {
+            print("================== HANDLE_ROLL(Beg) -> =======================");
             SelectionManager.saveProperties();
             initialPosition = SelectionManager.worldPosition;
 
@@ -3942,8 +3983,10 @@ SelectionDisplay = (function() {
             });
 
             updateRotationDegreesOverlay(0, rollHandleRotation, rollCenter);
+            print("================== HANDLE_ROLL(Beg) <- =======================");
         },
         onEnd: function(event, reason) {
+            print("================== HANDLE_ROLL(End) -> =======================");
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });
@@ -3958,8 +4001,10 @@ SelectionDisplay = (function() {
             });
 
             pushCommandForSelections();
+            print("================== HANDLE_ROLL(End) <- =======================");
         },
         onMove: function(event) {
+            print("================== HANDLE_ROLL(Mve) -> =======================");
             var pickRay = generalComputePickRay(event.x, event.y);
             Overlays.editOverlay(selectionBox, {
                 visible: false
@@ -3976,6 +4021,7 @@ SelectionDisplay = (function() {
                 var centerToIntersect = Vec3.subtract(result.intersection, center);
                 // Note: orientedAngle which wants normalized centerToZero & centerToIntersect, handles
                 //       this internally, so it's fine to pass non-normalized versions here.
+                print("    RotNormal - X: " + rotationNormal.x + " Y: " + rotationNormal.y + " Z: " + rotationNormal.z);
                 var angleFromZero = Vec3.orientedAngle(centerToZero, centerToIntersect, rotationNormal);
 
                 var distanceFromCenter = Vec3.distance(center, result.intersection);
@@ -4051,6 +4097,8 @@ SelectionDisplay = (function() {
                     });
                 }
             }
+            print("================== HANDLE_ROLL(Mve) <- =======================");
+
         }
     });
 
@@ -4086,7 +4134,10 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE PRESS EVENT
     that.mousePressEvent = function(event) {
-        var wantDebug = false;
+        var wantDebug = true;
+        if ( wantDebug ) {
+            print( "=============== eST::MousePressEvent BEG =======================");
+        }
         if (!event.isLeftButton && !that.triggered) {
             // if another mouse button than left is pressed ignore it
             return false;
@@ -4118,6 +4169,7 @@ SelectionDisplay = (function() {
 
             var tool = grabberTools[result.overlayID];
             if (tool) {
+                print("Intersected with known table tool.");
                 activeTool = tool;
                 mode = tool.mode;
                 somethingClicked = 'tool';
@@ -4125,8 +4177,10 @@ SelectionDisplay = (function() {
                     activeTool.onBegin(event);
                 }
             } else {
+                print("Intersected with unregistered tool...");
                 switch (result.overlayID) {
                     case grabberMoveUp:
+                        print("grabberMoveUp");
                         mode = "TRANSLATE_UP_DOWN";
                         somethingClicked = mode;
 
@@ -4142,6 +4196,7 @@ SelectionDisplay = (function() {
                     case grabberNEAR:
                     case grabberEdgeTN: // TODO: maybe this should be TOP+NEAR stretching?
                     case grabberEdgeBN: // TODO: maybe this should be BOTTOM+FAR stretching?
+                        print("grabberNear variant");
                         mode = "STRETCH_NEAR";
                         somethingClicked = mode;
                         break;
@@ -4149,31 +4204,37 @@ SelectionDisplay = (function() {
                     case grabberFAR:
                     case grabberEdgeTF: // TODO: maybe this should be TOP+FAR stretching?
                     case grabberEdgeBF: // TODO: maybe this should be BOTTOM+FAR stretching?
+                        print("grabberFar variant");
                         mode = "STRETCH_FAR";
                         somethingClicked = mode;
                         break;
                     case grabberTOP:
+                        print("grabberTOP");
                         mode = "STRETCH_TOP";
                         somethingClicked = mode;
                         break;
                     case grabberBOTTOM:
+                        print("grabberBOTTOM");
                         mode = "STRETCH_BOTTOM";
                         somethingClicked = mode;
                         break;
                     case grabberRIGHT:
                     case grabberEdgeTR: // TODO: maybe this should be TOP+RIGHT stretching?
                     case grabberEdgeBR: // TODO: maybe this should be BOTTOM+RIGHT stretching?
+                        print("grabberRight variant");
                         mode = "STRETCH_RIGHT";
                         somethingClicked = mode;
                         break;
                     case grabberLEFT:
                     case grabberEdgeTL: // TODO: maybe this should be TOP+LEFT stretching?
                     case grabberEdgeBL: // TODO: maybe this should be BOTTOM+LEFT stretching?
+                        print("grabberLeft variant");
                         mode = "STRETCH_LEFT";
                         somethingClicked = mode;
                         break;
 
                     default:
+                        print("UNKNOWN( " + result.overlayID + " )");
                         mode = "UNKNOWN";
                         break;
                 }
@@ -4183,6 +4244,7 @@ SelectionDisplay = (function() {
         // if one of the items above was clicked, then we know we are in translate or stretch mode, and we
         // should hide our rotate handles...
         if (somethingClicked) {
+            print("Click is triggering hiding of handles, hopefully");
             Overlays.editOverlay(yawHandle, {
                 visible: false
             });
@@ -4225,6 +4287,7 @@ SelectionDisplay = (function() {
             originalRoll = roll;
 
             if (result.intersects) {
+                print("Intersection detected with handle...");
                 var resultTool = grabberTools[result.overlayID];
                 if (resultTool) {
                     activeTool = resultTool;
@@ -4236,15 +4299,18 @@ SelectionDisplay = (function() {
                 }
                 switch (result.overlayID) {
                     case yawHandle:
+                        print("Handle_YAW");
                         mode = "ROTATE_YAW";
                         somethingClicked = mode;
                         overlayOrientation = yawHandleRotation;
                         overlayCenter = yawCenter;
                         yawZero = result.intersection;
                         rotationNormal = yawNormal;
+                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
                         break;
 
                     case pitchHandle:
+                        print("Handle_PITCH");
                         mode = "ROTATE_PITCH";
                         initialPosition = SelectionManager.worldPosition;
                         somethingClicked = mode;
@@ -4252,15 +4318,18 @@ SelectionDisplay = (function() {
                         overlayCenter = pitchCenter;
                         pitchZero = result.intersection;
                         rotationNormal = pitchNormal;
+                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
                         break;
 
                     case rollHandle:
+                        print("Handle_ROLL");
                         mode = "ROTATE_ROLL";
                         somethingClicked = mode;
                         overlayOrientation = rollHandleRotation;
                         overlayCenter = rollCenter;
                         rollZero = result.intersection;
                         rotationNormal = rollNormal;
+                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
                         break;
 
                     default:
@@ -4462,6 +4531,10 @@ SelectionDisplay = (function() {
         Overlays.editOverlay(rollHandle, {
             ignoreRayIntersection: false
         });
+
+        if ( wantDebug ) {
+            print( "=============== eST::MousePressEvent END =======================");
+        }
 
         return somethingClicked;
     };

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1646,7 +1646,7 @@ SelectionDisplay = (function() {
         };
 
         // Center of entity, relative to registration point
-        center = getRelativeCenterPosition(dimensions, registrationPoint);
+        var center = getRelativeCenterPosition(dimensions, registrationPoint);
 
         // Distances in world coordinates relative to the registration point
         var left = -registrationPointDimensions.x;

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -140,12 +140,12 @@ SelectionManager = (function() {
         if (entityID) {
             var idx = -1;
             for (var i = 0; i < that.selections.length; i++) {
-                if (entityID == that.selections[i]) {
+                if (entityID === that.selections[i]) {
                     idx = i;
                     break;
                 }
             }
-            if (idx == -1) {
+            if (idx === -1) {
                 that.selections.push(entityID);
             } else if (toggleSelection) {
                 that.selections.splice(idx, 1);
@@ -175,7 +175,7 @@ SelectionManager = (function() {
             that.localPosition = null;
             that.worldDimensions = null;
             that.worldPosition = null;
-        } else if (that.selections.length == 1) {
+        } else if (that.selections.length === 1) {
             properties = Entities.getEntityProperties(that.selections[0]);
             that.localDimensions = properties.dimensions;
             that.localPosition = properties.position;
@@ -1186,7 +1186,7 @@ SelectionDisplay = (function() {
         var top, far, left, bottom, near, right, boundsCenter, objectCenter, BLN, BRN, BLF, TLN, TRN, TLF, TRF;
 
         var dimensions, rotation;
-        if (spaceMode == SPACE_LOCAL) {
+        if (spaceMode === SPACE_LOCAL) {
             rotation = SelectionManager.localRotation;
         } else {
             rotation = SelectionManager.worldRotation;
@@ -1478,9 +1478,9 @@ SelectionDisplay = (function() {
         //var translateHandlesVisible = true;
         //var selectionBoxVisible = true;
         var isPointLight = false;
-        if (selectionManager.selections.length == 1) {
+        if (selectionManager.selections.length === 1) {
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
-            isPointLight = properties.type == "Light" && !properties.isSpotlight;
+            isPointLight = (properties.type === "Light") && !properties.isSpotlight;
         }
 
         if (isActiveTool(yawHandle) || isActiveTool(pitchHandle) || 
@@ -1567,7 +1567,7 @@ SelectionDisplay = (function() {
             print("======> SetSpaceMode called. ========");
         }
 
-        if (spaceMode != newSpaceMode) {
+        if (spaceMode !== newSpaceMode) {
             if (wantDebug) {
                 print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
             }
@@ -1587,7 +1587,7 @@ SelectionDisplay = (function() {
         if (wantDebug) {
             print("========> ToggleSpaceMode called. =========");
         }
-        if (spaceMode == SPACE_WORLD && SelectionManager.selections.length > 1) {
+        if ((spaceMode === SPACE_WORLD) && (SelectionManager.selections.length > 1)) {
             if (wantDebug) {
                 print("Local space editing is not available with multiple selections");
             }
@@ -1596,7 +1596,7 @@ SelectionDisplay = (function() {
         if (wantDebug) {
             print("PreToggle: " + spaceMode);
         }
-        spaceMode = spaceMode == SPACE_LOCAL ? SPACE_WORLD : SPACE_LOCAL;
+        spaceMode = (spaceMode === SPACE_LOCAL) ? SPACE_WORLD : SPACE_LOCAL;
         that.updateHandles();
         if (wantDebug) {
             print("PostToggle: " + spaceMode);        
@@ -1627,7 +1627,7 @@ SelectionDisplay = (function() {
 
         var rotation, dimensions, position, registrationPoint;
 
-        if (spaceMode == SPACE_LOCAL) {
+        if (spaceMode === SPACE_LOCAL) {
             rotation = SelectionManager.localRotation;
             dimensions = SelectionManager.localDimensions;
             position = SelectionManager.localPosition;
@@ -1852,17 +1852,17 @@ SelectionDisplay = (function() {
 
         var inModeRotate = (isActiveTool(yawHandle) || isActiveTool(pitchHandle) || isActiveTool(rollHandle));
         var inModeTranslate = (isActiveTool(selectionBox) || isActiveTool(grabberCloner) || isActiveTool(grabberMoveUp));
-        var stretchHandlesVisible = !(inModeRotate || inModeTranslate) && (spaceMode == SPACE_LOCAL);
+        var stretchHandlesVisible = !(inModeRotate || inModeTranslate) && (spaceMode === SPACE_LOCAL);
         var extendedStretchHandlesVisible = (stretchHandlesVisible && showExtendedStretchHandles);
         var cloneHandleVisible = !(inModeRotate || inModeTranslate);
         if (wantDebug) {
             print("    Set Non-Light Grabbers Visible - Norm: " + stretchHandlesVisible + " Ext: " + extendedStretchHandlesVisible);
         }
-        var isSingleSelection = (selectionManager.selections.length == 1);
+        var isSingleSelection = (selectionManager.selections.length === 1);
 
         if (isSingleSelection) {
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
-            var isLightSelection = (properties.type == "Light");
+            var isLightSelection = (properties.type === "Light");
             if (isLightSelection) {
                 if (wantDebug) {
                     print("    Light Selection revoking Non-Light Grabbers Visibility!");
@@ -2691,9 +2691,9 @@ SelectionDisplay = (function() {
         var onBegin = function(event, pickRay, pickResult) {
             var properties = Entities.getEntityProperties(SelectionManager.selections[0]);
             initialProperties = properties;
-            rotation = spaceMode == SPACE_LOCAL ? properties.rotation : Quat.fromPitchYawRollDegrees(0, 0, 0);
+            rotation = (spaceMode === SPACE_LOCAL) ? properties.rotation : Quat.fromPitchYawRollDegrees(0, 0, 0);
 
-            if (spaceMode == SPACE_LOCAL) {
+            if (spaceMode === SPACE_LOCAL) {
                 rotation = SelectionManager.localRotation;
                 initialPosition = SelectionManager.localPosition;
                 initialDimensions = SelectionManager.localDimensions;
@@ -2739,7 +2739,7 @@ SelectionDisplay = (function() {
             }
             var start = null;
             var end = null;
-            if (numDimensions == 1 && mask.x) {
+            if ((numDimensions === 1) && mask.x) {
                 start = Vec3.multiplyQbyV(rotation, {
                     x: -10000,
                     y: 0,
@@ -2758,7 +2758,7 @@ SelectionDisplay = (function() {
                     visible: true,
                 });
             }
-            if (numDimensions == 1 && mask.y) {
+            if ((numDimensions === 1) && mask.y) {
                 start = Vec3.multiplyQbyV(rotation, {
                     x: 0,
                     y: -10000,
@@ -2777,7 +2777,7 @@ SelectionDisplay = (function() {
                     visible: true,
                 });
             }
-            if (numDimensions == 1 && mask.z) {
+            if ((numDimensions === 1) && mask.z) {
                 start = Vec3.multiplyQbyV(rotation, {
                     x: 0,
                     y: 0,
@@ -2796,14 +2796,14 @@ SelectionDisplay = (function() {
                     visible: true,
                 });
             }
-            if (numDimensions == 1) {
-                if (mask.x == 1) {
+            if (numDimensions === 1) {
+                if (mask.x === 1) {
                     planeNormal = {
                         x: 0,
                         y: 1,
                         z: 0
                     };
-                } else if (mask.y == 1) {
+                } else if (mask.y === 1) {
                     planeNormal = {
                         x: 1,
                         y: 0,
@@ -2816,7 +2816,7 @@ SelectionDisplay = (function() {
                         z: 0
                     };
                 }
-            } else if (numDimensions == 2) {
+            } else if (numDimensions === 2) {
                 if (mask.x === 0) {
                     planeNormal = {
                         x: 1,
@@ -2873,10 +2873,10 @@ SelectionDisplay = (function() {
         };
 
         var onMove = function(event) {
-            var proportional = spaceMode == SPACE_WORLD || event.isShifted || isActiveTool(grabberSpotLightRadius);
+            var proportional = (spaceMode === SPACE_WORLD) || event.isShifted || isActiveTool(grabberSpotLightRadius);
 
             var position, dimensions, rotation;
-            if (spaceMode == SPACE_LOCAL) {
+            if (spaceMode === SPACE_LOCAL) {
                 position = SelectionManager.localPosition;
                 dimensions = SelectionManager.localDimensions;
                 rotation = SelectionManager.localRotation;
@@ -3942,7 +3942,7 @@ SelectionDisplay = (function() {
         var results = testRayIntersect(pickRay, interactiveOverlays);
         if (results.intersects) {
             var hitOverlayID = results.overlayID;
-            if ((hitOverlayID == HMD.tabletID) || (hitOverlayID == HMD.tabletScreenID) || (hitOverlayID == HMD.homeButtonID)) {
+            if ((hitOverlayID === HMD.tabletID) || (hitOverlayID === HMD.tabletScreenID) || (hitOverlayID === HMD.homeButtonID)) {
                 //--EARLY EXIT-(mouse clicks on the tablet should override the edit affordances)
                 return false;
             }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1568,15 +1568,15 @@ SelectionDisplay = (function() {
         }
 
         if (spaceMode != newSpaceMode) {
-            if (wantDebug){
+            if (wantDebug) {
                 print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
             }
             spaceMode = newSpaceMode;
             that.updateHandles();
-        } else if(wantDebug){
+        } else if (wantDebug) {
             print("WARNING: entitySelectionTool.setSpaceMode - Can't update SpaceMode. CurrentMode: " + spaceMode + " DesiredMode: " + newSpaceMode);
         }
-        if(wantDebug) {
+        if (wantDebug) {
             print("====== SetSpaceMode called. <========");
         }
     };
@@ -1584,21 +1584,21 @@ SelectionDisplay = (function() {
     // FUNCTION: TOGGLE SPACE MODE
     that.toggleSpaceMode = function() {
         var wantDebug = false;
-        if (wantDebug){
+        if (wantDebug) {
             print("========> ToggleSpaceMode called. =========");
         }
         if (spaceMode == SPACE_WORLD && SelectionManager.selections.length > 1) {
-            if (wantDebug){
+            if (wantDebug) {
                 print("Local space editing is not available with multiple selections");
             }
             return;
         }
-        if(wantDebug) {
+        if (wantDebug) {
             print( "PreToggle: " + spaceMode);
         }
         spaceMode = spaceMode == SPACE_LOCAL ? SPACE_WORLD : SPACE_LOCAL;
         that.updateHandles();
-        if (wantDebug){
+        if (wantDebug) {
             print( "PostToggle: " + spaceMode);        
             print("======== ToggleSpaceMode called. <=========");
         }
@@ -1611,7 +1611,7 @@ SelectionDisplay = (function() {
     // FUNCTION: UPDATE HANDLES
     that.updateHandles = function() {
         var wantDebug = false;
-        if(wantDebug){
+        if (wantDebug) {
             print( "======> Update Handles =======" );
             print( "    Selections Count: " + SelectionManager.selections.length );
             print( "    SpaceMode: " + spaceMode );
@@ -1855,7 +1855,7 @@ SelectionDisplay = (function() {
         var stretchHandlesVisible = !(inModeRotate || inModeTranslate) && (spaceMode == SPACE_LOCAL);
         var extendedStretchHandlesVisible = (stretchHandlesVisible && showExtendedStretchHandles);
         var cloneHandleVisible = !(inModeRotate || inModeTranslate);
-        if(wantDebug){
+        if (wantDebug) {
             print("    Set Non-Light Grabbers Visible - Norm: " + stretchHandlesVisible + " Ext: " + extendedStretchHandlesVisible);
         }
         var isSingleSelection = (selectionManager.selections.length == 1);
@@ -1864,13 +1864,13 @@ SelectionDisplay = (function() {
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
             var isLightSelection = (properties.type == "Light");
             if ( isLightSelection ) {
-                if(wantDebug){
+                if (wantDebug) {
                     print("    Light Selection revoking Non-Light Grabbers Visibility!");
                 }
                 stretchHandlesVisible = false;
                 extendedStretchHandlesVisible = false;
                 cloneHandleVisible = false;
-                if(properties.isSpotlight) {
+                if (properties.isSpotlight) {
                     that.setPointLightHandlesVisible( false );
 
                     var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
@@ -2247,13 +2247,13 @@ SelectionDisplay = (function() {
             rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         });
 
-        if(wantDebug){
+        if (wantDebug) {
             print( "====== Update Handles <=======" );
         }
 
     };
 
-    function helperSetOverlaysVisibility( handleArray, isVisible ){
+    function helperSetOverlaysVisibility( handleArray, isVisible ) {
         var numHandles = handleArray.length;
         var visibilityUpdate = { visible: isVisible };
         for (var handleIndex = 0; handleIndex < numHandles; ++handleIndex) {
@@ -2289,7 +2289,7 @@ SelectionDisplay = (function() {
     that.setGrabberToolsVisible = function(isVisible) {
         var visibilityUpdate = { visible: isVisible };
         for ( var toolKey in grabberTools ) {
-            if ( ! grabberTools.hasOwnProperty( toolKey ) ){
+            if ( ! grabberTools.hasOwnProperty( toolKey ) ) {
                 //--EARLY ITERATION EXIT--( On to the next one )
                 continue;
             }
@@ -2327,7 +2327,7 @@ SelectionDisplay = (function() {
         startingElevation: 0.0,
         onBegin: function(event, pickRay, pickResult, doClone) {
             var wantDebug = false;
-            if(wantDebug){
+            if (wantDebug) {
                 print("================== TRANSLATE_XZ(Beg) -> =======================");
                 Vec3.print("    pickRay", pickRay);
                 Vec3.print("    pickRay.origin", pickRay.origin);
@@ -2377,7 +2377,7 @@ SelectionDisplay = (function() {
             }
 
             isConstrained = false;
-            if(wantDebug){
+            if (wantDebug) {
                 print("================== TRANSLATE_XZ(End) <- =======================");
             }
         },
@@ -3076,7 +3076,7 @@ SelectionDisplay = (function() {
     function cutoffStretchFunc(vector, change) {
         vector = change;
         var wantDebug = false;
-        if (wantDebug){
+        if (wantDebug) {
             Vec3.print("Radius stretch: ", vector);
         }
         var length = vector.x + vector.y + vector.z;
@@ -3533,7 +3533,7 @@ SelectionDisplay = (function() {
     // FUNCTION: UPDATE ROTATION DEGREES OVERLAY
     function updateRotationDegreesOverlay(angleFromZero, handleRotation, centerPosition) {
         var wantDebug = false;
-        if(wantDebug){
+        if (wantDebug) {
             print( "---> updateRotationDegreesOverlay ---" );
             print("    AngleFromZero: " + angleFromZero );
             print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
@@ -3546,7 +3546,7 @@ SelectionDisplay = (function() {
             y: Math.sin(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             z: 0,
         };
-        if(wantDebug){
+        if (wantDebug) {
             print("    Angle: " + angle );
             print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
         }
@@ -3562,7 +3562,7 @@ SelectionDisplay = (function() {
             lineHeight: innerRadius * ROTATION_DISPLAY_LINE_HEIGHT_MULTIPLIER,
             text: normalizeDegrees(angleFromZero) + "°",
         };
-        if(wantDebug){
+        if (wantDebug) {
             print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
             print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
             print("    OverlayLineHeight: " + overlayProps.lineHeight );
@@ -3570,7 +3570,7 @@ SelectionDisplay = (function() {
         }
 
         Overlays.editOverlay(rotationDegreesDisplay, overlayProps);
-        if (wantDebug){
+        if (wantDebug) {
             print( "<--- updateRotationDegreesOverlay ---" );
         }
     }
@@ -3899,10 +3899,10 @@ SelectionDisplay = (function() {
         var intersectObj = Overlays.findRayIntersection(queryRay, true, overlayIncludes, overlayExcludes);
 
         if (wantDebug) {
-            if ( ! overlayIncludes ){
+            if ( ! overlayIncludes ) {
                 print("testRayIntersect - no overlayIncludes provided.");
             }
-            if ( ! overlayExcludes ){
+            if ( ! overlayExcludes ) {
                 print("testRayIntersect - no overlayExcludes provided.");
             }
             print("testRayIntersect - Hit: " + intersectObj.intersects);
@@ -3940,7 +3940,7 @@ SelectionDisplay = (function() {
         activeTool = null;
 
         var results = testRayIntersect( pickRay, interactiveOverlays );
-        if ( results.intersects ){
+        if ( results.intersects ) {
             var hitOverlayID = results.overlayID;
             if ( (hitOverlayID == HMD.tabletID) || (hitOverlayID == HMD.tabletScreenID) || (hitOverlayID == HMD.homeButtonID) ) {
                 //--EARLY EXIT-(mouse clicks on the tablet should override the edit affordances)
@@ -3959,7 +3959,7 @@ SelectionDisplay = (function() {
                 }
             } else {
                 print("ERROR: entitySelectionTool.mousePressEvent - Hit unexpected object, check interactiveOverlays");
-            }//--End_if( hitTool )
+            }//--End_if ( hitTool )
         }//--End_If( results.intersects )
 
         if (wantDebug) {
@@ -3975,7 +3975,7 @@ SelectionDisplay = (function() {
     // FUNCTION: MOUSE MOVE EVENT
     that.mouseMoveEvent = function(event) {
         var wantDebug = false;
-        if(wantDebug){
+        if (wantDebug) {
             print( "=============== eST::MouseMoveEvent BEG =======================");
         }
         if (activeTool) {
@@ -4115,7 +4115,7 @@ SelectionDisplay = (function() {
             }
         }
 
-        if(wantDebug){
+        if (wantDebug) {
             print("=============== eST::MouseMoveEvent END =======================");
         }
         return false;
@@ -4124,24 +4124,24 @@ SelectionDisplay = (function() {
     // FUNCTION: MOUSE RELEASE EVENT
     that.mouseReleaseEvent = function(event) {
         var wantDebug = false;
-        if(wantDebug){
+        if (wantDebug) {
             print("=============== eST::MouseReleaseEvent BEG =======================");
         }
         var showHandles = false;
         if (activeTool) {
-            if( activeTool.onEnd ) {
-                if(wantDebug){
+            if ( activeTool.onEnd ) {
+                if (wantDebug) {
                     print("    Triggering ActiveTool( " + activeTool.mode + " )'s onEnd");
                 }
                 activeTool.onEnd(event);
-            }else if(wantDebug){
+            }else if (wantDebug) {
                 print("    ActiveTool( " + activeTool.mode + " )'s missing onEnd");
             }
         }
         
         // hide our rotation overlays..., and show our handles
         if ( isActiveTool(yawHandle) || isActiveTool(pitchHandle) || isActiveTool(rollHandle)) {
-            if(wantDebug){
+            if (wantDebug) {
                 print("    Triggering hide of RotateOverlays");
             }
             Overlays.editOverlay(rotateOverlayInner, {
@@ -4162,14 +4162,14 @@ SelectionDisplay = (function() {
         // if something is selected, then reset the "original" properties for any potential next click+move operation
         if (SelectionManager.hasSelection()) {
             if (showHandles) {
-                if(wantDebug){
+                if (wantDebug) {
                     print("    Triggering that.select");
                 }
                 that.select(SelectionManager.selections[0], event);
             }
         }
 
-        if(wantDebug){
+        if (wantDebug) {
             print("=============== eST::MouseReleaseEvent END =======================");
         }
     };

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -238,11 +238,8 @@ SelectionManager = (function() {
 
 // Normalize degrees to be in the range (-180, 180]
 function normalizeDegrees(degrees) {
-    while (degrees > 180) {
-        degrees -= 360;
-    }
-
-    while (degrees <= -180) {
+    degrees = ((degrees + 180) % 360) - 180;
+    if (degrees < -180) {
         degrees += 360;
     }
 

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1530,7 +1530,6 @@ SelectionDisplay = (function() {
         var rotateHandlesVisible = true;
         var rotationOverlaysVisible = false;
         var translateHandlesVisible = true;
-        var stretchHandlesVisible = true;
         var selectionBoxVisible = true;
         var isPointLight = false;
 
@@ -1543,11 +1542,9 @@ SelectionDisplay = (function() {
             rotationOverlaysVisible = true;
             rotateHandlesVisible = false;
             translateHandlesVisible = false;
-            stretchHandlesVisible = false;
             selectionBoxVisible = false;
         } else if (mode == "TRANSLATE_UP_DOWN" || isPointLight) {
             rotateHandlesVisible = false;
-            stretchHandlesVisible = false;
         } else if (mode != "UNKNOWN") {
             // every other mode is a stretch mode...
             rotateHandlesVisible = false;
@@ -1622,6 +1619,7 @@ SelectionDisplay = (function() {
             return;
         }
 
+        //print( "    Triggering updateRotationHandles");
         that.updateRotationHandles();
 
         var rotation, dimensions, position, registrationPoint;
@@ -1849,201 +1847,212 @@ SelectionDisplay = (function() {
         EdgeFR = Vec3.sum(position, EdgeFR);
         EdgeFL = Vec3.sum(position, EdgeFL);
 
-        var stretchHandlesVisible = spaceMode == SPACE_LOCAL;
-        var extendedStretchHandlesVisible = stretchHandlesVisible && showExtendedStretchHandles;
+        var inModeRotate = (mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL");
+        var stretchHandlesVisible = !inModeRotate && (spaceMode == SPACE_LOCAL);
+        var extendedStretchHandlesVisible = (stretchHandlesVisible && showExtendedStretchHandles);
+        var cloneHandleVisible = !inModeRotate;
+        //print("    Set Non-Light Grabbers Visible - Norm: " + stretchHandlesVisible + " Ext: " + extendedStretchHandlesVisible);
+        var isSingleSelection = (selectionManager.selections.length == 1);
 
-        if (selectionManager.selections.length == 1) {
+        if (isSingleSelection) {
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
-            if (properties.type == "Light" && properties.isSpotlight) {
+            var isLightSelection = (properties.type == "Light");
+            if ( isLightSelection ) {
+                //print("    Light Selection revoking Non-Light Grabbers Visibility!");
                 stretchHandlesVisible = false;
                 extendedStretchHandlesVisible = false;
+                cloneHandleVisible = false;
+                if(properties.isSpotlight) {
+                    //print("    Trying to show all SpotLight related grabbers");
+                    Overlays.editOverlay(grabberSpotLightCenter, {
+                        position: position,
+                        visible: false,
+                    });
+                    Overlays.editOverlay(grabberSpotLightRadius, {
+                        position: NEAR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
 
-                Overlays.editOverlay(grabberSpotLightCenter, {
-                    position: position,
-                    visible: false,
-                });
-                Overlays.editOverlay(grabberSpotLightRadius, {
-                    position: NEAR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                var distance = (properties.dimensions.z / 2) * Math.sin(properties.cutoff * (Math.PI / 180));
+                    Overlays.editOverlay(grabberSpotLightL, {
+                        position: EdgeNL,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightR, {
+                        position: EdgeNR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightT, {
+                        position: EdgeTN,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightB, {
+                        position: EdgeBN,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightCircle, {
+                        position: NEAR,
+                        dimensions: {
+                            x: distance,
+                            y: distance,
+                            z: 1
+                        },
+                        lineWidth: 1.5,
+                        rotation: rotation,
+                        visible: true,
+                    });
 
-                Overlays.editOverlay(grabberSpotLightL, {
-                    position: EdgeNL,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightR, {
-                    position: EdgeNR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightT, {
-                    position: EdgeTN,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightB, {
-                    position: EdgeBN,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightCircle, {
-                    position: NEAR,
-                    dimensions: {
-                        x: distance,
-                        y: distance,
-                        z: 1
-                    },
-                    lineWidth: 1.5,
-                    rotation: rotation,
-                    visible: true,
-                });
+                    Overlays.editOverlay(grabberSpotLightLineT, {
+                        start: position,
+                        end: EdgeTN,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineB, {
+                        start: position,
+                        end: EdgeBN,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineR, {
+                        start: position,
+                        end: EdgeNR,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineL, {
+                        start: position,
+                        end: EdgeNL,
+                        visible: true,
+                    });
 
-                Overlays.editOverlay(grabberSpotLightLineT, {
-                    start: position,
-                    end: EdgeTN,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightLineB, {
-                    start: position,
-                    end: EdgeBN,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightLineR, {
-                    start: position,
-                    end: EdgeNR,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberSpotLightLineL, {
-                    start: position,
-                    end: EdgeNL,
-                    visible: true,
-                });
+                    //print("    Trying to hide all PointLight related grabbers");
+                    Overlays.editOverlay(grabberPointLightCircleX, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleY, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleZ, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightT, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightB, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightL, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightR, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightF, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberPointLightN, {
+                        visible: false
+                    });
+                } else { //..it's a PointLight
+                    //print("    Trying to show all PointLight related grabbers");
+                    Overlays.editOverlay(grabberPointLightT, {
+                        position: TOP,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightB, {
+                        position: BOTTOM,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightL, {
+                        position: LEFT,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightR, {
+                        position: RIGHT,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightF, {
+                        position: FAR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightN, {
+                        position: NEAR,
+                        rotation: rotation,
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleX, {
+                        position: position,
+                        rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(0, 90, 0)),
+                        dimensions: {
+                            x: properties.dimensions.z / 2.0,
+                            y: properties.dimensions.z / 2.0,
+                            z: 1
+                        },
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleY, {
+                        position: position,
+                        rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(90, 0, 0)),
+                        dimensions: {
+                            x: properties.dimensions.z / 2.0,
+                            y: properties.dimensions.z / 2.0,
+                            z: 1
+                        },
+                        visible: true,
+                    });
+                    Overlays.editOverlay(grabberPointLightCircleZ, {
+                        position: position,
+                        rotation: rotation,
+                        dimensions: {
+                            x: properties.dimensions.z / 2.0,
+                            y: properties.dimensions.z / 2.0,
+                            z: 1
+                        },
+                        visible: true,
+                    });
 
-                Overlays.editOverlay(grabberPointLightCircleX, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightCircleY, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightCircleZ, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightT, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightB, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightL, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightR, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightF, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberPointLightN, {
-                    visible: false
-                });
-            } else if (properties.type == "Light" && !properties.isSpotlight) {
-                stretchHandlesVisible = false;
-                extendedStretchHandlesVisible = false;
-                Overlays.editOverlay(grabberPointLightT, {
-                    position: TOP,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightB, {
-                    position: BOTTOM,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightL, {
-                    position: LEFT,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightR, {
-                    position: RIGHT,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightF, {
-                    position: FAR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightN, {
-                    position: NEAR,
-                    rotation: rotation,
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightCircleX, {
-                    position: position,
-                    rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(0, 90, 0)),
-                    dimensions: {
-                        x: properties.dimensions.z / 2.0,
-                        y: properties.dimensions.z / 2.0,
-                        z: 1
-                    },
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightCircleY, {
-                    position: position,
-                    rotation: Quat.multiply(rotation, Quat.fromPitchYawRollDegrees(90, 0, 0)),
-                    dimensions: {
-                        x: properties.dimensions.z / 2.0,
-                        y: properties.dimensions.z / 2.0,
-                        z: 1
-                    },
-                    visible: true,
-                });
-                Overlays.editOverlay(grabberPointLightCircleZ, {
-                    position: position,
-                    rotation: rotation,
-                    dimensions: {
-                        x: properties.dimensions.z / 2.0,
-                        y: properties.dimensions.z / 2.0,
-                        z: 1
-                    },
-                    visible: true,
-                });
-
-                Overlays.editOverlay(grabberSpotLightRadius, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightL, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightR, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightT, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightB, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightCircle, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineL, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineR, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineT, {
-                    visible: false
-                });
-                Overlays.editOverlay(grabberSpotLightLineB, {
-                    visible: false
-                });
-            } else {
+                    //print("    Trying to hide all SpotLight related grabbers");
+                    Overlays.editOverlay(grabberSpotLightRadius, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightL, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightR, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightT, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightB, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightCircle, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineL, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineR, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineT, {
+                        visible: false
+                    });
+                    Overlays.editOverlay(grabberSpotLightLineB, {
+                        visible: false
+                    });
+                }
+            } else { //..it's not a light at all
+                //print("    Trying to hide all Light related grabbers");
                 Overlays.editOverlay(grabberSpotLightCenter, {
                     visible: false
                 });
@@ -2106,7 +2115,7 @@ SelectionDisplay = (function() {
                     visible: false
                 });
             }
-        }
+        }//--end of isSingleSelection
 
 
 
@@ -2184,7 +2193,7 @@ SelectionDisplay = (function() {
         });
 
         Overlays.editOverlay(grabberCloner, {
-            visible: true,
+            visible: cloneHandleVisible,
             rotation: rotation,
             position: EdgeTR
         });
@@ -2195,7 +2204,7 @@ SelectionDisplay = (function() {
             position: selectionBoxPosition,
             dimensions: dimensions,
             rotation: rotation,
-            visible: !(mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL"),
+            visible: !inModeRotate,
         });
 
         // Create more selection box overlays if we don't have enough
@@ -2332,7 +2341,7 @@ SelectionDisplay = (function() {
         });
 
         Overlays.editOverlay(baseOfEntityProjectionOverlay, {
-            visible: mode != "ROTATE_YAW" && mode != "ROTATE_PITCH" && mode != "ROTATE_ROLL",
+            visible: !inModeRotate,
             solid: true,
             position: {
                 x: selectionManager.worldPosition.x,
@@ -4134,7 +4143,7 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE PRESS EVENT
     that.mousePressEvent = function(event) {
-        var wantDebug = true;
+        var wantDebug = false;
         if ( wantDebug ) {
             print( "=============== eST::MousePressEvent BEG =======================");
         }
@@ -4169,7 +4178,9 @@ SelectionDisplay = (function() {
 
             var tool = grabberTools[result.overlayID];
             if (tool) {
-                print("Intersected with known table tool.");
+                if (wantDebug) {
+                    print("Intersected with known table tool( mode: " + tool.mode + " )");
+                }
                 activeTool = tool;
                 mode = tool.mode;
                 somethingClicked = 'tool';
@@ -4177,10 +4188,14 @@ SelectionDisplay = (function() {
                     activeTool.onBegin(event);
                 }
             } else {
-                print("Intersected with unregistered tool...");
+                if (wantDebug) {
+                    print("Intersected with unregistered tool...");
+                }
                 switch (result.overlayID) {
                     case grabberMoveUp:
-                        print("grabberMoveUp");
+                        if (wantDebug){
+                            print("grabberMoveUp");
+                        }
                         mode = "TRANSLATE_UP_DOWN";
                         somethingClicked = mode;
 
@@ -4196,7 +4211,9 @@ SelectionDisplay = (function() {
                     case grabberNEAR:
                     case grabberEdgeTN: // TODO: maybe this should be TOP+NEAR stretching?
                     case grabberEdgeBN: // TODO: maybe this should be BOTTOM+FAR stretching?
-                        print("grabberNear variant");
+                        if(wantDebug){
+                            print("grabberNear variant");
+                        }
                         mode = "STRETCH_NEAR";
                         somethingClicked = mode;
                         break;
@@ -4204,39 +4221,54 @@ SelectionDisplay = (function() {
                     case grabberFAR:
                     case grabberEdgeTF: // TODO: maybe this should be TOP+FAR stretching?
                     case grabberEdgeBF: // TODO: maybe this should be BOTTOM+FAR stretching?
-                        print("grabberFar variant");
+                        if(wantDebug){
+                            print("grabberFar variant");
+                        }
                         mode = "STRETCH_FAR";
                         somethingClicked = mode;
                         break;
                     case grabberTOP:
-                        print("grabberTOP");
+                        if(wantDebug){
+                            print("grabberTOP");
+                        }
                         mode = "STRETCH_TOP";
                         somethingClicked = mode;
                         break;
                     case grabberBOTTOM:
-                        print("grabberBOTTOM");
+                        if(wantDebug){
+                            print("grabberBOTTOM");
+                        }
                         mode = "STRETCH_BOTTOM";
                         somethingClicked = mode;
                         break;
                     case grabberRIGHT:
                     case grabberEdgeTR: // TODO: maybe this should be TOP+RIGHT stretching?
                     case grabberEdgeBR: // TODO: maybe this should be BOTTOM+RIGHT stretching?
-                        print("grabberRight variant");
+                        if(wantDebug){
+                            print("grabberRight variant");
+                        }
                         mode = "STRETCH_RIGHT";
                         somethingClicked = mode;
                         break;
                     case grabberLEFT:
                     case grabberEdgeTL: // TODO: maybe this should be TOP+LEFT stretching?
                     case grabberEdgeBL: // TODO: maybe this should be BOTTOM+LEFT stretching?
-                        print("grabberLeft variant");
+                        if(wantDebug){
+                            print("grabberLeft variant");
+                        }
                         mode = "STRETCH_LEFT";
                         somethingClicked = mode;
                         break;
 
                     default:
-                        print("UNKNOWN( " + result.overlayID + " )");
+                        if(wantDebug){
+                            print("UNKNOWN( " + result.overlayID + " )");
+                        }
                         mode = "UNKNOWN";
                         break;
+                }
+                if(wantDebug){
+                    print("  Unregistered Tool Mode: " + mode );
                 }
             }
         }
@@ -4244,7 +4276,9 @@ SelectionDisplay = (function() {
         // if one of the items above was clicked, then we know we are in translate or stretch mode, and we
         // should hide our rotate handles...
         if (somethingClicked) {
-            print("Click is triggering hiding of handles, hopefully");
+            if(wantDebug){
+                print("    Trying to hide PitchYawRoll Handles");
+            }
             Overlays.editOverlay(yawHandle, {
                 visible: false
             });
@@ -4256,6 +4290,9 @@ SelectionDisplay = (function() {
             });
 
             if (mode != "TRANSLATE_UP_DOWN") {
+                if(wantDebug){
+                    print("    Trying to hide GrabberMoveUp");
+                }
                 Overlays.editOverlay(grabberMoveUp, {
                     visible: false
                 });
@@ -4287,30 +4324,46 @@ SelectionDisplay = (function() {
             originalRoll = roll;
 
             if (result.intersects) {
-                print("Intersection detected with handle...");
                 var resultTool = grabberTools[result.overlayID];
+                if(wantDebug){
+                    print("Intersection detected with handle...");
+                }
                 if (resultTool) {
+                    if(wantDebug){
+                        print("    " + resultTool.mode);
+                    }
                     activeTool = resultTool;
                     mode = resultTool.mode;
                     somethingClicked = 'tool';
                     if (activeTool && activeTool.onBegin) {
+                        if(wantDebug){
+                            print("    Triggering Tool's onBegin");
+                        }
                         activeTool.onBegin(event);
+                    } else if(wantDebug) {
+                        print("    Tool's missing onBegin");
                     }
                 }
                 switch (result.overlayID) {
                     case yawHandle:
-                        print("Handle_YAW");
+                        if(wantDebug){
+                            print("Handle_YAW");
+                        }
                         mode = "ROTATE_YAW";
                         somethingClicked = mode;
                         overlayOrientation = yawHandleRotation;
                         overlayCenter = yawCenter;
                         yawZero = result.intersection;
                         rotationNormal = yawNormal;
-                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        if(wantDebug){
+                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        }
                         break;
 
                     case pitchHandle:
-                        print("Handle_PITCH");
+                        if(wantDebug){
+                            print("Handle_PITCH");
+                        }
                         mode = "ROTATE_PITCH";
                         initialPosition = SelectionManager.worldPosition;
                         somethingClicked = mode;
@@ -4318,18 +4371,24 @@ SelectionDisplay = (function() {
                         overlayCenter = pitchCenter;
                         pitchZero = result.intersection;
                         rotationNormal = pitchNormal;
-                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        if(wantDebug){
+                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        }
                         break;
 
                     case rollHandle:
-                        print("Handle_ROLL");
+                        if(wantDebug){
+                            print("Handle_ROLL");
+                        }
                         mode = "ROTATE_ROLL";
                         somethingClicked = mode;
                         overlayOrientation = rollHandleRotation;
                         overlayCenter = rollCenter;
                         rollZero = result.intersection;
                         rotationNormal = rollNormal;
-                        print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        if(wantDebug){
+                            print("rotationNormal set to: " + rotationNormal.x + ", " + rotationNormal.y + ", " + rotationNormal.z);
+                        }
                         break;
 
                     default:
@@ -4347,6 +4406,9 @@ SelectionDisplay = (function() {
 
             if (somethingClicked) {
 
+                if(wantDebug){
+                    print("    Trying to show rotateOverlay Handles");
+                }
                 Overlays.editOverlay(rotateOverlayTarget, {
                     visible: true,
                     rotation: overlayOrientation,
@@ -4371,6 +4433,9 @@ SelectionDisplay = (function() {
                     startAt: 0,
                     endAt: 0
                 });
+                if(wantDebug){
+                    print("    Trying to hide PitchYawRoll Handles");
+                }
                 Overlays.editOverlay(yawHandle, {
                     visible: false
                 });
@@ -4381,15 +4446,11 @@ SelectionDisplay = (function() {
                     visible: false
                 });
 
+                if(wantDebug){
+                    print("    Trying to hide Non-Light GrabberHandles");
+                }
 
-                // TODO: these three duplicate prior three, remove them.
-                Overlays.editOverlay(yawHandle, {
-                    visible: false
-                });
-                Overlays.editOverlay(pitchHandle, {
-                    visible: false
-                });
-                Overlays.editOverlay(rollHandle, {
+                Overlays.editOverlay(grabberCloner, {
                     visible: false
                 });
                 Overlays.editOverlay(grabberMoveUp, {
@@ -4485,6 +4546,9 @@ SelectionDisplay = (function() {
                 switch (result.overlayID) {
                     case selectionBox:
                         activeTool = translateXZTool;
+                        if(wantDebug){
+                            print("Clicked selectionBox, Activating Tool: " + activeTool.mode );
+                        }
                         translateXZTool.pickPlanePosition = result.intersection;
                         translateXZTool.greatestDimension = Math.max(Math.max(SelectionManager.worldDimensions.x, SelectionManager.worldDimensions.y),
                             SelectionManager.worldDimensions.z);
@@ -4518,7 +4582,10 @@ SelectionDisplay = (function() {
         }
 
         // reset everything as intersectable...
-        // TODO: we could optimize this since some of these were already flipped back
+        // TODO: we could optimize this since some of these were already flipped back(i.e:  just get rid of this)
+        if(wantDebug){
+            print("Trying to set SelectionBox & PitchYawRoll Handles to NOT_IGNORE Rays");
+        }
         Overlays.editOverlay(selectionBox, {
             ignoreRayIntersection: false
         });
@@ -4541,9 +4608,25 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE MOVE EVENT
     that.mouseMoveEvent = function(event) {
+        var wantDebug = false;
+        if(wantDebug){
+            print( "=============== eST::MouseMoveEvent BEG =======================");
+        }
         if (activeTool) {
+            if(wantDebug){
+                print("    Trigger ActiveTool( " + activeTool.mode + " )'s onMove");
+            }
             activeTool.onMove(event);
+            
+            if(wantDebug){
+                print("    Trigger SelectionManager::update");
+            }
             SelectionManager._update();
+            
+            if(wantDebug){
+                print( "=============== eST::MouseMoveEvent END =======================");
+            }
+            //--EARLY EXIT--( Move handled via active tool)
             return true;
         }
 
@@ -4666,6 +4749,9 @@ SelectionDisplay = (function() {
             }
         }
 
+        if(wantDebug){
+            print("=============== eST::MouseMoveEvent END =======================");
+        }
         return false;
     };
 
@@ -4710,13 +4796,27 @@ SelectionDisplay = (function() {
 
     // FUNCTION: MOUSE RELEASE EVENT
     that.mouseReleaseEvent = function(event) {
-        var showHandles = false;
-        if (activeTool && activeTool.onEnd) {
-            activeTool.onEnd(event);
+        var wantDebug = false;
+        if(wantDebug){
+            print("=============== eST::MouseReleaseEvent BEG =======================");
         }
-        activeTool = null;
+        var showHandles = false;
+        if (activeTool) {
+            if( activeTool.onEnd ) {
+                if(wantDebug){
+                    print("    Triggering ActiveTool( " + activeTool.mode + " )'s onEnd");
+                }
+                activeTool.onEnd(event);
+            }else if(wantDebug){
+                print("    ActiveTool( " + activeTool.mode + " )'s missing onEnd");
+            }
+        }
+        
         // hide our rotation overlays..., and show our handles
         if (mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL") {
+            if(wantDebug){
+                print("    Triggering hide of RotateOverlays");
+            }
             Overlays.editOverlay(rotateOverlayTarget, {
                 visible: false
             });
@@ -4729,22 +4829,26 @@ SelectionDisplay = (function() {
             Overlays.editOverlay(rotateOverlayCurrent, {
                 visible: false
             });
-            showHandles = true;
+            
         }
 
-        if (mode != "UNKNOWN") {
-            showHandles = true;
-        }
-
+        showHandles = (mode != "UNKNOWN");//<base on prior mode
         mode = "UNKNOWN";
+        activeTool = null;
 
         // if something is selected, then reset the "original" properties for any potential next click+move operation
         if (SelectionManager.hasSelection()) {
             if (showHandles) {
+                if(wantDebug){
+                    print("    Triggering that.select");
+                }
                 that.select(SelectionManager.selections[0], event);
             }
         }
 
+        if(wantDebug){
+            print("=============== eST::MouseReleaseEvent END =======================");
+        }
     };
 
     // NOTE: mousePressEvent and mouseMoveEvent from the main script should call us., so we don't hook these:

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2833,7 +2833,7 @@ SelectionDisplay = (function() {
                     planeNormal = {
                         x: 0,
                         y: 0,
-                        z: z
+                        z: 1
                     };
                 }
             }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1042,7 +1042,7 @@ SelectionDisplay = (function() {
     // But we dont' get mousePressEvents.
     that.triggerMapping = Controller.newMapping(Script.resolvePath('') + '-click');
     Script.scriptEnding.connect(that.triggerMapping.disable);
-    that.TRIGGER_GRAB_VALUE = 0.85;  //  From handControllerGrab/Pointer.js. Should refactor.
+    that.TRIGGER_GRAB_VALUE = 0.85; //  From handControllerGrab/Pointer.js. Should refactor.
     that.TRIGGER_ON_VALUE = 0.4;
     that.TRIGGER_OFF_VALUE = 0.15;
     that.triggered = false;
@@ -1103,7 +1103,7 @@ SelectionDisplay = (function() {
 
         if (!grabberTools.hasOwnProperty(toolHandle)) {
             print("WARNING: entitySelectionTool.isActiveTool - Encountered unknown grabberToolHandle: " + toolHandle + ". Tools should be egistered via addGrabberTool.");
-            //--EARLY EXIT--
+            // EARLY EXIT
             return false;
         }
 
@@ -1472,11 +1472,11 @@ SelectionDisplay = (function() {
 
         var rotateHandlesVisible = true;
         var rotationOverlaysVisible = false;
-        //note:  Commented out as these are currently unused here; however,
-        //       leaving them around as they document intent of state as it
-        //       relates to modes that may be useful later.
-        //var translateHandlesVisible = true;
-        //var selectionBoxVisible = true;
+        // note:  Commented out as these are currently unused here; however,
+        //         leaving them around as they document intent of state as it
+        //         relates to modes that may be useful later.
+        // var translateHandlesVisible = true;
+        // var selectionBoxVisible = true;
         var isPointLight = false;
         if (selectionManager.selections.length === 1) {
             var properties = Entities.getEntityProperties(selectionManager.selections[0]);
@@ -1487,14 +1487,14 @@ SelectionDisplay = (function() {
                 isActiveTool(rollHandle) || isActiveTool(selectionBox) || isActiveTool(grabberCloner)) {
             rotationOverlaysVisible = true;
             rotateHandlesVisible = false;
-            //translateHandlesVisible = false;
-            //selectionBoxVisible = false;
+            // translateHandlesVisible = false;
+            // selectionBoxVisible = false;
         } else if (isActiveTool(grabberMoveUp) || isPointLight) {
             rotateHandlesVisible = false;
         } else if (activeTool) {
             // every other mode is a stretch mode...
             rotateHandlesVisible = false;
-            //translateHandlesVisible = false;
+            // translateHandlesVisible = false;
         }
 
         Overlays.editOverlay(rotateZeroOverlay, {
@@ -1622,7 +1622,7 @@ SelectionDisplay = (function() {
             return;
         }
 
-        //print("    Triggering updateRotationHandles");
+        // print("    Triggering updateRotationHandles");
         that.updateRotationHandles();
 
         var rotation, dimensions, position, registrationPoint;
@@ -1938,7 +1938,7 @@ SelectionDisplay = (function() {
                         visible: true,
                     });
 
-                } else { //..it's a PointLight
+                } else { // ..it's a PointLight
                     that.setSpotLightHandlesVisible(false);
 
                     var showEdgePointGrabbers = !inModeTranslate;
@@ -2003,11 +2003,11 @@ SelectionDisplay = (function() {
                         visible: true,
                     });
                 }
-            } else { //..it's not a light at all
+            } else { // ..it's not a light at all
                 that.setSpotLightHandlesVisible(false);
                 that.setPointLightHandlesVisible(false);
             }
-        }//--end of isSingleSelection
+        }// end of isSingleSelection
 
 
 
@@ -2290,7 +2290,7 @@ SelectionDisplay = (function() {
         var visibilityUpdate = { visible: isVisible };
         for (var toolKey in grabberTools) {
             if (!grabberTools.hasOwnProperty(toolKey)) {
-                //--EARLY ITERATION EXIT--(On to the next one)
+                // EARLY ITERATION EXIT--(On to the next one)
                 continue;
             }
 
@@ -2411,14 +2411,14 @@ SelectionDisplay = (function() {
                     print("    "+ translateXZTool.mode + "Pick ray does not intersect XZ plane.");
                 }
                 
-                //--EARLY EXIT--(Invalid ray detected.)
+                // EARLY EXIT--(Invalid ray detected.)
                 return;
             }
 
             var vector = Vec3.subtract(pick, initialXZPick);
 
             // If the mouse is too close to the horizon of the pick plane, stop moving
-            var MIN_ELEVATION = 0.02;   //  largest dimension of object divided by distance to it
+            var MIN_ELEVATION = 0.02; //  largest dimension of object divided by distance to it
             var elevation = translateXZTool.elevation(pickRay.origin, pick);
             if (wantDebug) {
                     print("Start Elevation: " + translateXZTool.startingElevation + ", elevation: " + elevation);
@@ -2429,12 +2429,12 @@ SelectionDisplay = (function() {
                     print("    "+ translateXZTool.mode + " - too close to horizon!");
                 }
 
-                //--EARLY EXIT--(Don't proceed past the reached limit.)
+                // EARLY EXIT--(Don't proceed past the reached limit.)
                 return;
             }
 
             //  If the angular size of the object is too small, stop moving
-            var MIN_ANGULAR_SIZE = 0.01;   //  Radians
+            var MIN_ANGULAR_SIZE = 0.01; //  Radians
             if (translateXZTool.greatestDimension > 0) {
                 var angularSize = Math.atan(translateXZTool.greatestDimension / Vec3.distance(pickRay.origin, pick));
                 if (wantDebug) {
@@ -2592,7 +2592,7 @@ SelectionDisplay = (function() {
                 print("                event.y:" + event.y);
                 Vec3.print("        newIntersection:", newIntersection);
                 Vec3.print("                 vector:", vector);
-                //Vec3.print("            newPosition:", newPosition);
+                // Vec3.print("            newPosition:", newPosition);
             }
             for (var i = 0; i < SelectionManager.selections.length; i++) {
                 var id = SelectionManager.selections[i];
@@ -2970,10 +2970,10 @@ SelectionDisplay = (function() {
                 var wantDebug = false;
                 if (wantDebug) {
                     print(stretchMode);
-                    //Vec3.print("        newIntersection:", newIntersection);
+                    // Vec3.print("        newIntersection:", newIntersection);
                     Vec3.print("                 vector:", vector);
-                    //Vec3.print("           oldPOS:", oldPOS);
-                    //Vec3.print("                newPOS:", newPOS);
+                    // Vec3.print("           oldPOS:", oldPOS);
+                    // Vec3.print("                newPOS:", newPOS);
                     Vec3.print("            changeInDimensions:", changeInDimensions);
                     Vec3.print("                 newDimensions:", newDimensions);
 
@@ -2983,7 +2983,7 @@ SelectionDisplay = (function() {
             }
 
             SelectionManager._update();
-        };//--End of onMove def
+        };// End of onMove def
 
         return {
             mode: stretchMode,
@@ -3581,7 +3581,7 @@ SelectionDisplay = (function() {
         if (!rotationChange) {
             print("ERROR: entitySelectionTool.updateSelectionsRotation - Invalid arg specified!!");
 
-            //--EARLY EXIT--
+            // EARLY EXIT
             return;
         }
         
@@ -3677,14 +3677,14 @@ SelectionDisplay = (function() {
         if (wantDebug) {
             print("================== " + getMode() + "(rotation helper onBegin) <- =======================");
         }
-    }//--End_Function(helperRotationHandleOnBegin)
+    }// End_Function(helperRotationHandleOnBegin)
 
     function helperRotationHandleOnMove(event, rotAroundAxis, rotCenter, handleRotation) {
 
         if (!rotZero) {
             print("ERROR: entitySelectionTool.handleRotationHandleOnMove - Invalid RotationZero Specified (missed rotation target plane?)");
 
-            //--EARLY EXIT--
+            // EARLY EXIT
             return;
         }
 
@@ -3777,12 +3777,12 @@ SelectionDisplay = (function() {
                     minorTickMarksLength: 0.1,
                 });
             }
-        }//--End_If(results.intersects)
+        }// End_If(results.intersects)
 
         if (wantDebug) {
             print("================== "+ getMode() + "(rotation helper onMove) <- =======================");
         }
-    }//--End_Function(helperRotationHandleOnMove)
+    }// End_Function(helperRotationHandleOnMove)
 
     function helperRotationHandleOnEnd() {
         var wantDebug = false;
@@ -3807,7 +3807,7 @@ SelectionDisplay = (function() {
         if (wantDebug) {
             print("================== " + getMode() + "(onEnd) <- =======================");
         }
-    }//--End_Function(helperRotationHandleOnEnd)
+    }// End_Function(helperRotationHandleOnEnd)
 
 
     // YAW GRABBER TOOL DEFINITION
@@ -3860,7 +3860,7 @@ SelectionDisplay = (function() {
         if (SelectionManager.hasSelection()) {
 
             // FIXME - this cause problems with editing in the entity properties window
-            //SelectionManager._update();
+            // SelectionManager._update();
 
             if (!Vec3.equal(Camera.getPosition(), lastCameraPosition) ||
                 !Quat.equal(Camera.getOrientation(), lastCameraOrientation)) {
@@ -3923,12 +3923,12 @@ SelectionDisplay = (function() {
             print("=============== eST::MousePressEvent BEG =======================");
         }
         if (!event.isLeftButton && !that.triggered) {
-            //--EARLY EXIT-(if another mouse button than left is pressed ignore it)
+            // EARLY EXIT-(if another mouse button than left is pressed ignore it)
             return false;
         }
 
         var pickRay = generalComputePickRay(event.x, event.y);
-        //TODO_Case6491:  Move this out to setup just to make it once
+        // TODO_Case6491:  Move this out to setup just to make it once
         var interactiveOverlays = [HMD.tabletID, HMD.tabletScreenID, HMD.homeButtonID, selectionBox];
         for (var key in grabberTools) {
             if (grabberTools.hasOwnProperty(key)) {
@@ -3943,7 +3943,7 @@ SelectionDisplay = (function() {
         if (results.intersects) {
             var hitOverlayID = results.overlayID;
             if ((hitOverlayID === HMD.tabletID) || (hitOverlayID === HMD.tabletScreenID) || (hitOverlayID === HMD.homeButtonID)) {
-                //--EARLY EXIT-(mouse clicks on the tablet should override the edit affordances)
+                // EARLY EXIT-(mouse clicks on the tablet should override the edit affordances)
                 return false;
             }
 
@@ -3959,8 +3959,8 @@ SelectionDisplay = (function() {
                 }
             } else {
                 print("ERROR: entitySelectionTool.mousePressEvent - Hit unexpected object, check interactiveOverlays");
-            }//--End_if (hitTool)
-        }//--End_If(results.intersects)
+            }// End_if (hitTool)
+        }// End_If(results.intersects)
 
         if (wantDebug) {
             print("    DisplayMode: " + getMode());
@@ -3992,7 +3992,7 @@ SelectionDisplay = (function() {
             if (wantDebug) {
                 print("=============== eST::MouseMoveEvent END =======================");
             }
-            //--EARLY EXIT--(Move handled via active tool)
+            // EARLY EXIT--(Move handled via active tool)
             return true;
         }
 
@@ -4156,7 +4156,7 @@ SelectionDisplay = (function() {
             
         }
 
-        showHandles = activeTool;//<base on prior tool value
+        showHandles = activeTool; // base on prior tool value
         activeTool = null;
 
         // if something is selected, then reset the "original" properties for any potential next click+move operation

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -239,7 +239,7 @@ SelectionManager = (function() {
 // Normalize degrees to be in the range (-180, 180]
 function normalizeDegrees(degrees) {
     degrees = ((degrees + 180) % 360) - 180;
-    if (degrees < -180) {
+    if (degrees <= -180) {
         degrees += 360;
     }
 

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -45,11 +45,12 @@ SelectionManager = (function() {
             return;
         }
 
+        var wantDebug = false;
         var messageParsed;
         try {
             messageParsed = JSON.parse(message);
         } catch (err) {
-            print("error -- entitySelectionTool got malformed message: " + message);
+            print("ERROR: entitySelectionTool.handleEntitySelectionToolUpdates - got malformed message: " + message);
         }
 
         // if (message === 'callUpdate') {
@@ -57,7 +58,9 @@ SelectionManager = (function() {
         // }
 
         if (messageParsed.method === "selectEntity") {
-            print("setting selection to " + messageParsed.entityID);
+            if (wantDebug) {
+                print("setting selection to " + messageParsed.entityID);
+            }
             that.setSelections([messageParsed.entityID]);
         }
     }
@@ -225,7 +228,7 @@ SelectionManager = (function() {
             try {
                 listeners[j](selectionUpdated === true);
             } catch (e) {
-                print("EntitySelectionTool got exception: " + JSON.stringify(e));
+                print("ERROR: entitySelectionTool.update got exception: " + JSON.stringify(e));
             }
         }
     };
@@ -1477,29 +1480,46 @@ SelectionDisplay = (function() {
 
     // FUNCTION: SET SPACE MODE
     that.setSpaceMode = function(newSpaceMode) {
-        print("======> SetSpaceMode called. ========");
+        var wantDebug = false;
+        if (wantDebug) {
+            print("======> SetSpaceMode called. ========");
+        }
+
         if (spaceMode != newSpaceMode) {
-            print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
+            if (wantDebug){
+                print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
+            }
             spaceMode = newSpaceMode;
             that.updateHandles();
-        } else {
-            print("    Can't update SpaceMode. CurrentMode: " + spaceMode + " DesiredMode: " + newSpaceMode);
+        } else if(wantDebug){
+            print("WARNING: entitySelectionTool.setSpaceMode - Can't update SpaceMode. CurrentMode: " + spaceMode + " DesiredMode: " + newSpaceMode);
         }
-        print("====== SetSpaceMode called. <========");
+        if(wantDebug) {
+            print("====== SetSpaceMode called. <========");
+        }
     };
 
     // FUNCTION: TOGGLE SPACE MODE
     that.toggleSpaceMode = function() {
-        print("========> ToggleSpaceMode called. =========");
+        var wantDebug = false;
+        if (wantDebug){
+            print("========> ToggleSpaceMode called. =========");
+        }
         if (spaceMode == SPACE_WORLD && SelectionManager.selections.length > 1) {
-            print("Local space editing is not available with multiple selections");
+            if (wantDebug){
+                print("Local space editing is not available with multiple selections");
+            }
             return;
         }
-        print( "PreToggle: " + spaceMode);
+        if(wantDebug) {
+            print( "PreToggle: " + spaceMode);
+        }
         spaceMode = spaceMode == SPACE_LOCAL ? SPACE_WORLD : SPACE_LOCAL;
-        print( "PostToggle: " + spaceMode);
         that.updateHandles();
-        print("======== ToggleSpaceMode called. <=========");
+        if (wantDebug){
+            print( "PostToggle: " + spaceMode);        
+            print("======== ToggleSpaceMode called. <=========");
+        }
     };
 
     // FUNCTION: UNSELECT ALL
@@ -1508,9 +1528,12 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE HANDLES
     that.updateHandles = function() {
-        print( "======> Update Handles =======" );
-        print( "    Selections Count: " + SelectionManager.selections.length );
-        print( "    SpaceMode: " + spaceMode );
+        var wantDebug = false;
+        if(wantDebug){
+            print( "======> Update Handles =======" );
+            print( "    Selections Count: " + SelectionManager.selections.length );
+            print( "    SpaceMode: " + spaceMode );
+        }
         if (SelectionManager.selections.length === 0) {
             that.setOverlaysVisible(false);
             return;
@@ -2252,7 +2275,9 @@ SelectionDisplay = (function() {
             rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         });
 
-        print( "====== Update Handles <=======" );
+        if(wantDebug){
+            print( "====== Update Handles <=======" );
+        }
 
     };
 
@@ -2527,7 +2552,7 @@ SelectionDisplay = (function() {
         mode: "TRANSLATE_UP_DOWN",
         onBegin: function(event, pickRay, pickResult) {
             upDownPickNormal = Quat.getForward(lastCameraOrientation);
-            // Remove y component so the y-axis lies along the plane we picking on - this will
+            // Remove y component so the y-axis lies along the plane we're picking on - this will
             // give movements that follow the mouse.
             upDownPickNormal.y = 0;
             lastXYPick = rayPlaneIntersection(pickRay, SelectionManager.worldPosition, upDownPickNormal);
@@ -3061,7 +3086,10 @@ SelectionDisplay = (function() {
     // FUNCTION: CUTOFF STRETCH FUNC
     function cutoffStretchFunc(vector, change) {
         vector = change;
-        Vec3.print("Radius stretch: ", vector);
+        var wantDebug = false;
+        if (wantDebug){
+            Vec3.print("Radius stretch: ", vector);
+        }
         var length = vector.x + vector.y + vector.z;
         var props = selectionManager.savedProperties[selectionManager.selections[0]];
 
@@ -3515,21 +3543,27 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE ROTATION DEGREES OVERLAY
     function updateRotationDegreesOverlay(angleFromZero, handleRotation, centerPosition) {
-        print( "---> updateRotationDegreesOverlay ---" );
-        print("    AngleFromZero: " + angleFromZero );
-        print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
-        print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z );
+        var wantDebug = false;
+        if(wantDebug){
+            print( "---> updateRotationDegreesOverlay ---" );
+            print("    AngleFromZero: " + angleFromZero );
+            print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
+            print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z );
+        }
+
         var angle = angleFromZero * (Math.PI / 180);
         var position = {
             x: Math.cos(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             y: Math.sin(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             z: 0,
         };
-        print("    Angle: " + angle );
-        print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
+        if(wantDebug){
+            print("    Angle: " + angle );
+            print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
+        }
+        
         position = Vec3.multiplyQbyV(handleRotation, position);
         position = Vec3.sum(centerPosition, position);
-        print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
         var overlayProps = {
             position: position,
             dimensions: {
@@ -3539,18 +3573,24 @@ SelectionDisplay = (function() {
             lineHeight: innerRadius * ROTATION_DISPLAY_LINE_HEIGHT_MULTIPLIER,
             text: normalizeDegrees(angleFromZero) + "°",
         };
-        print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
-        print("    OverlayLineHeight: " + overlayProps.lineHeight );
-        print("    OverlayText: " + overlayProps.text );
+        if(wantDebug){
+            print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
+            print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
+            print("    OverlayLineHeight: " + overlayProps.lineHeight );
+            print("    OverlayText: " + overlayProps.text );
+        }
+
         Overlays.editOverlay(rotationDegreesDisplay, overlayProps);
-        print( "<--- updateRotationDegreesOverlay ---" );
+        if (wantDebug){
+            print( "<--- updateRotationDegreesOverlay ---" );
+        }
     }
 
     // FUNCTION DEF: updateSelectionsRotation
     //    Helper func used by rotation grabber tools 
     function updateSelectionsRotation( rotationChange ) {
         if ( ! rotationChange ) {
-            print("ERROR( updateSelectionsRotation ) - Invalid arg specified!!");
+            print("ERROR: entitySelectionTool.updateSelectionsRotation - Invalid arg specified!!");
 
             //--EARLY EXIT--
             return;
@@ -3653,7 +3693,7 @@ SelectionDisplay = (function() {
     function helperRotationHandleOnMove( event, rotAroundAxis, rotCenter, handleRotation ) {
 
         if ( ! rotZero ) {
-            print("ERROR( handleRotationHandleOnMove ) - Invalid RotationZero Specified (missed rotation target plane?)" );
+            print("ERROR: entitySelectionTool.handleRotationHandleOnMove - Invalid RotationZero Specified (missed rotation target plane?)" );
 
             //--EARLY EXIT--
             return;
@@ -3919,7 +3959,6 @@ SelectionDisplay = (function() {
             }
 
             entityIconOverlayManager.setIconsSelectable(selectionManager.selections, true);
-            //TODO_Case6491:  Merge if..else( selectionBox ) when onBegin of transXZ is normalized.
 
             var hitTool = grabberTools[ hitOverlayID ];
             if ( hitTool ) {


### PR DESCRIPTION
This pull request contains the remainder, Parts 2 - 6, of the entitySelectionTool cleanup for [FogBugz Case 6491](https://highfidelity.fogbugz.com/f/cases/6491/edit-js-work-proposed-by-1st-playable).  Part 1 was merged via PR #11165.  This pull request also replaces https://github.com/highfidelity/hifi/pull/11205, as mentioned in https://github.com/highfidelity/hifi/pull/11205#issuecomment-328642626

- Fixes the issue where grabbers would re-appear when rotating the selected object rather than staying hidden.
- Fixes a bug with translateXZTool where its startingElevation and startingDistance properties were only set when local debug var was set. This appears to have been responsible for being able to move the object farther than was visible. Re-tested with fix and wasn't able to get that behavior any longer.
- This fixes an issue with multi-selection object rotation for pitch & roll that was previously exclusive to yaw rotation tool and also dedupes rotation tool code between the 3 tools where able.
- Fixes situations where attempting to click on a rotate, grab, or scale handle that was in front of others might unexpectedly activate the obscured handle.
- Fixes rotation skip near 0 and 180 degrees "poles"
- Fixes issue where the user view was obstructed by grabber handles when translating the selected object(s).
- Cleaned up onMouseEvents and moved all functionality for tools within the tools themselves as opposed to being split between the tool & which ever mouse event.

For more details, please refer to contained commit messages.

**Testing:**

1. Enter a domain where you have editing/rez permissions.
2. Create and/or select objects and perform the following operations with both Single & Multi-selection:
    - Rotation
    - Translation
    - Scaling
    - Cloning
3. The behavior should be inline with the expected results below.

**Expected Behavior:**

**Rotation:**
- While rotating longer the outer circle overlay, the user should see fine grain degree changes even around the 0 & 180 degree points.
- Multi-selection rotation along the Pitch & Roll, like Yaw, should now have proper solar system type rotation. (Note:  The "sun" position is the center of bounding box which encapsulates _all_ items within the selection).
- Upon clicking a rotation handle, all rotation, translation, scaling, & grabber handles should turn and remain invisible until the user releases the mouse press.

**Translation:**
- When moving the object along the z-axis:
    - The object doesn't warp behind the user/camera when moving the selection towards themselves or into infinity when moving the selection forward into the screen.
    - All rotation, translation, scaling, & grabber handles should turn invisible on click and remain invisible until the user releases the mouse press.
- When moving the object along the x-axis:
    - It's no longer possible to warp the selection into infinity.
    - All rotation, translation, scaling, & grabber handles should turn invisible on click and remain invisible until the user releases the mouse press.
- When moving the object along the y-axis:
    - It's no longer possible to warp the selection into infinity.
    - The vertical translation handle should remain visible when clicked and stay visible during the translation.  When the user releases the mouse press, the vertical translation handle should remain visible.
    - Excluding the vertical translation handle, all other rotation, translation, scaling, & grabber handles should turn invisible on clicking the vertical translation handle.  All the invisible handles should remain invisible until the user releases the mouse press.

**Multi-Selection:**
- All translation and rotation behavior noted above should also apply to multi-selection.

**General:**
- When clicking on a pair of overlapping handles, the handle which is directly under the cursor/ray should activate as opposed to the last tool checked.