### PR TITLE
7469 Mouse Pointer Depth is Incorrect in HMD Mode

### DIFF
--- a/libraries/shared/src/RegisteredMetaTypes.cpp
+++ b/libraries/shared/src/RegisteredMetaTypes.cpp
@@ -761,6 +761,7 @@ QScriptValue rayPickResultToScriptValue(QScriptEngine* engine, const RayPickResu
     obj.setProperty("distance", rayPickResult.distance);
     QScriptValue intersection = vec3toScriptValue(engine, rayPickResult.intersection);
     obj.setProperty("intersection", intersection);
+    obj.setProperty("intersects", rayPickResult.type != NONE);
     QScriptValue surfaceNormal = vec3toScriptValue(engine, rayPickResult.surfaceNormal);
     obj.setProperty("surfaceNormal", surfaceNormal);
     return obj;


### PR DESCRIPTION
**Test plan**

1. In HMD, open the tablet
2. Move your mouse so that it is over the tablet
3. The depth of the mouse should be drawn correctly so that the mouse appears on top of the tablet

Note: this fix is not about fixing tablet only, in general it should fix mouse depth for other interactive objects (if such exists). 