### PR TITLE
[QML] Fixes FogBugz Case 6107: Can't sort on import menu (details below).

### DIFF
--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -486,9 +486,9 @@ ModalWindow {
             model: filesModel
 
             function updateSort() {
-                model.sortOrder = sortIndicatorOrder;
-                model.sortColumn = sortIndicatorColumn;
-                model.update();
+                fileTableModel.sortOrder = sortIndicatorOrder;
+                fileTableModel.sortColumn = sortIndicatorColumn;
+                fileTableModel.update();
             }
 
             onSortIndicatorColumnChanged: { updateSort(); }

--- a/interface/resources/qml/dialogs/TabletFileDialog.qml
+++ b/interface/resources/qml/dialogs/TabletFileDialog.qml
@@ -484,9 +484,9 @@ TabletModalWindow {
             model: filesModel
 
             function updateSort() {
-                model.sortOrder = sortIndicatorOrder;
-                model.sortColumn = sortIndicatorColumn;
-                model.update();
+                fileTableModel.sortOrder = sortIndicatorOrder;
+                fileTableModel.sortColumn = sortIndicatorColumn;
+                fileTableModel.update();
             }
 
             onSortIndicatorColumnChanged: { updateSort(); }


### PR DESCRIPTION
Looking through the log revealed the following warning:
".../qml/dialogs/FileDialog.qml:489: Error: Cannot assign to non-existent property 'sortOrder'"

There was some refactoring to address some HMD functionality in 51b44d90
which resulted in an update to fileTableView's model.  This appears to be the point
at which sorting stopped working.

This updates the fileTableView's sorting methods to use fileTableModel as opposed
to fileTableView's model(filesModel).  This appears safe given fileTableModel internally wraps
around filesModel and is responsible for updating its value.  I'm relatively new
to QML/Qt; any comments or suggestions are welcome.

Tagging @vladest since they may want to be aware given 51b44d90.

Case Link:
https://highfidelity.fogbugz.com/f/cases/6107

**Testing:**
Open the Interface app.  Go to Edit -> Import Entities and click any of the column headers to sort.