### PR TITLE
Remove old versions of the VC Runtime from the installation directory

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -836,6 +836,8 @@ Section "-Core installation"
   Delete "$INSTDIR\ui_resources_200_percent.pak"
   Delete "$INSTDIR\vccorlib120.dll"
   Delete "$INSTDIR\version"
+  Delete "$INSTDIR\msvcr140.dll"
+  Delete "$INSTDIR\msvcp140.dll"
   Delete "$INSTDIR\xinput1_3.dll"
 
   ; Delete old desktop shortcuts before they were renamed during Sandbox rename

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -838,6 +838,7 @@ Section "-Core installation"
   Delete "$INSTDIR\version"
   Delete "$INSTDIR\msvcr140.dll"
   Delete "$INSTDIR\msvcp140.dll"
+  Delete "$INSTDIR\vcruntime140.dll"
   Delete "$INSTDIR\xinput1_3.dll"
 
   ; Delete old desktop shortcuts before they were renamed during Sandbox rename


### PR DESCRIPTION
Some of the recent dumps have been showing different versions of VCRUNTIME140.dll and MSVCP140.dll, due to one being loaded from the Windows system directory, and the other being loaded from old leftover DLLs located in the Interface installation directory.  This PR should remove any old versions of the runtime DLLs in the installation directory preventing this version mismatch.  

## Testing

If you have any of these dlls (`msvcp140.dll`, `msvcr140.dll` or `vcruntime140.dll`) in your `C:\Program Files\High Fidelity` folder, create a `C:\Program Files\High Fidelity - PR11353` folder and copy them to it.  Then install this PR.  Once the PR installation finishes the DLLs should no longer be there.  