### PR TITLE
Fix race condition accessing QString sub-properties in zones

### DIFF
--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -176,6 +176,10 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
     _lastRotation = entity->getRotation();
     _lastDimensions = entity->getDimensions();
 
+    _keyLightProperties = entity->getKeyLightProperties();
+    _stageProperties = entity->getStageProperties();
+    _skyboxProperties = entity->getSkyboxProperties();
+
 
 #if 0
     if (_lastShapeURL != _typedEntity->getCompoundShapeURL()) {
@@ -196,14 +200,14 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
     }
 #endif
 
-    updateKeyZoneItemFromEntity(entity);
+    updateKeyZoneItemFromEntity();
 
     if (sunChanged) {
-        updateKeySunFromEntity(entity);
+        updateKeySunFromEntity();
     }
 
     if (sunChanged || skyboxChanged) {
-        updateKeyAmbientFromEntity(entity);
+        updateKeyAmbientFromEntity();
     }
     if (backgroundChanged || skyboxChanged) {
         updateKeyBackgroundFromEntity(entity);
@@ -265,19 +269,19 @@ bool ZoneEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPoint
     return false;
 }
 
-void ZoneEntityRenderer::updateKeySunFromEntity(const TypedEntityPointer& entity) {
+void ZoneEntityRenderer::updateKeySunFromEntity() {
     const auto& sunLight = editSunLight();
     sunLight->setType(model::Light::SUN);
     sunLight->setPosition(_lastPosition);
     sunLight->setOrientation(_lastRotation);
 
     // Set the keylight
-    sunLight->setColor(ColorUtils::toVec3(entity->getKeyLightProperties().getColor()));
-    sunLight->setIntensity(entity->getKeyLightProperties().getIntensity());
-    sunLight->setDirection(entity->getKeyLightProperties().getDirection());
+    sunLight->setColor(ColorUtils::toVec3(_keyLightProperties.getColor()));
+    sunLight->setIntensity(_keyLightProperties.getIntensity());
+    sunLight->setDirection(_keyLightProperties.getDirection());
 }
 
-void ZoneEntityRenderer::updateKeyAmbientFromEntity(const TypedEntityPointer& entity) {
+void ZoneEntityRenderer::updateKeyAmbientFromEntity() {
     const auto& ambientLight = editAmbientLight();
     ambientLight->setType(model::Light::AMBIENT);
     ambientLight->setPosition(_lastPosition);
@@ -285,24 +289,24 @@ void ZoneEntityRenderer::updateKeyAmbientFromEntity(const TypedEntityPointer& en
 
 
     // Set the keylight
-    ambientLight->setAmbientIntensity(entity->getKeyLightProperties().getAmbientIntensity());
+    ambientLight->setAmbientIntensity(_keyLightProperties.getAmbientIntensity());
 
-    if (entity->getKeyLightProperties().getAmbientURL().isEmpty()) {
-        setAmbientURL(entity->getSkyboxProperties().getURL());
+    if (_keyLightProperties.getAmbientURL().isEmpty()) {
+        setAmbientURL(_skyboxProperties.getURL());
     } else {
-        setAmbientURL(entity->getKeyLightProperties().getAmbientURL());
+        setAmbientURL(_keyLightProperties.getAmbientURL());
     }
 }
 
 void ZoneEntityRenderer::updateKeyBackgroundFromEntity(const TypedEntityPointer& entity) {
     editBackground();
     setBackgroundMode(entity->getBackgroundMode());
-    setSkyboxColor(entity->getSkyboxProperties().getColorVec3());
+    setSkyboxColor(_skyboxProperties.getColorVec3());
     setProceduralUserData(entity->getUserData());
-    setSkyboxURL(entity->getSkyboxProperties().getURL());
+    setSkyboxURL(_skyboxProperties.getURL());
 }
 
-void ZoneEntityRenderer::updateKeyZoneItemFromEntity(const TypedEntityPointer& entity) {
+void ZoneEntityRenderer::updateKeyZoneItemFromEntity() {
     /* TODO: Implement the sun model behavior / Keep this code here for reference, this is how we
     {
     // Set the stage

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.h
@@ -41,9 +41,9 @@ protected:
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
 
 private:
-    void updateKeyZoneItemFromEntity(const TypedEntityPointer& entity);
-    void updateKeySunFromEntity(const TypedEntityPointer& entity);
-    void updateKeyAmbientFromEntity(const TypedEntityPointer& entity);
+    void updateKeyZoneItemFromEntity();
+    void updateKeySunFromEntity();
+    void updateKeyAmbientFromEntity();
     void updateKeyBackgroundFromEntity(const TypedEntityPointer& entity);
     void updateAmbientMap();
     void updateSkyboxMap();
@@ -88,6 +88,10 @@ private:
     bool _needSunUpdate{ true };
     bool _needAmbientUpdate{ true };
     bool _needBackgroundUpdate{ true };
+
+    KeyLightPropertyGroup _keyLightProperties;
+    StagePropertyGroup _stageProperties;
+    SkyboxPropertyGroup _skyboxProperties;
 
     // More attributes used for rendering:
     QString _ambientTextureURL;

--- a/libraries/entities/src/ZoneEntityItem.h
+++ b/libraries/entities/src/ZoneEntityItem.h
@@ -63,12 +63,12 @@ public:
     QString getCompoundShapeURL() const;
     virtual void setCompoundShapeURL(const QString& url);
 
-    const KeyLightPropertyGroup& getKeyLightProperties() const { return _keyLightProperties; }
+    KeyLightPropertyGroup getKeyLightProperties() const { return resultWithReadLock<KeyLightPropertyGroup>([&] { return _keyLightProperties; }); }
 
     void setBackgroundMode(BackgroundMode value) { _backgroundMode = value; _backgroundPropertiesChanged = true; }
     BackgroundMode getBackgroundMode() const { return _backgroundMode; }
 
-    const SkyboxPropertyGroup& getSkyboxProperties() const { return _skyboxProperties; }
+    SkyboxPropertyGroup getSkyboxProperties() const { return resultWithReadLock<SkyboxPropertyGroup>([&] { return _skyboxProperties; }); }
     const StagePropertyGroup& getStageProperties() const { return _stageProperties; }
 
     bool getFlyingAllowed() const { return _flyingAllowed; }


### PR DESCRIPTION
Accessing string properties on multiple threads concurrently will trigger crashes.

## Testing

* Skybox URLs still work for background
* Ambient light URLs work for lighting
* Lighting properties for zones still work
* Additional testing steps including a test script on #11320 