### PR TITLE
use selection model of TreeView

### DIFF
--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -387,9 +387,9 @@ ScrollingWindow {
                 readOnly: true
 
                 Connections {
-                    target: treeView
+                    target: treeView.selection
                     onCurrentIndexChanged: {
-                        var path = scriptsModel.data(treeView.currentIndex, 0x100)
+                        var path = scriptsModel.data(treeView.selection.currentIndex, 0x100)
                         if (path) {
                             selectedScript.text = path
                         } else {

--- a/interface/resources/qml/hifi/dialogs/TabletRunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletRunningScripts.qml
@@ -416,9 +416,9 @@ Rectangle {
                     readOnly: true
 
                     Connections {
-                        target: treeView
+                        target: treeView.selection
                         onCurrentIndexChanged: {
-                            var path = scriptsModel.data(treeView.currentIndex, 0x100)
+                            var path = scriptsModel.data(treeView.selection.currentIndex, 0x100)
                             if (path) {
                                 selectedScript.text = path
                             } else {


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/7375/Load-button-in-Running-Scripts-doesn-t-work

Test plan
- Open Running scripts in Desktop or Tablet mode
- Click on script in bottom treeview
- check if script name appears in input filed and "Load" button enabled
- Make sure other functionality of the Running Scripts dialog (clicking on the tablet, reloading scripts, etc.) still work