### PR TITLE
Move Tablet becomes toolbar menu from General to Developer menu

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -367,6 +367,20 @@ Menu::Menu() {
             QString("../../hifi/tablet/TabletGraphicsPreferences.qml"), "GraphicsPreferencesDialog");
     });
 
+    // Developer > UI >>>
+    MenuWrapper* uiOptionsMenu = developerMenu->addMenu("UI");
+    action = addCheckableActionToQMenuAndActionHash(uiOptionsMenu, MenuOption::DesktopTabletToToolbar, 0,
+                                                    qApp->getDesktopTabletBecomesToolbarSetting());
+    connect(action, &QAction::triggered, [action] {
+        qApp->setDesktopTabletBecomesToolbarSetting(action->isChecked());
+    });
+
+    action = addCheckableActionToQMenuAndActionHash(uiOptionsMenu, MenuOption::HMDTabletToToolbar, 0,
+                                                    qApp->getHmdTabletBecomesToolbarSetting());
+    connect(action, &QAction::triggered, [action] {
+        qApp->setHmdTabletBecomesToolbarSetting(action->isChecked());
+    });
+
     // Developer > Render >>>
     MenuWrapper* renderOptionsMenu = developerMenu->addMenu("Render");
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::WorldAxes);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -200,6 +200,8 @@ namespace MenuOption {
     const QString VisibleToFriends = "Friends";
     const QString VisibleToNoOne = "No one";
     const QString WorldAxes = "World Axes";
+    const QString DesktopTabletToToolbar = "Desktop Tablet Becomes Toolbar";
+    const QString HMDTabletToToolbar = "HMD Tablet Becomes Toolbar";
 }
 
 #endif // hifi_Menu_h

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -92,16 +92,6 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
-        auto getter = []()->bool { return qApp->getDesktopTabletBecomesToolbarSetting(); };
-        auto setter = [](bool value) { qApp->setDesktopTabletBecomesToolbarSetting(value); };
-        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Desktop Tablet Becomes Toolbar", getter, setter));
-    }
-    {
-        auto getter = []()->bool { return qApp->getHmdTabletBecomesToolbarSetting(); };
-        auto setter = [](bool value) { qApp->setHmdTabletBecomesToolbarSetting(value); };
-        preferences->addPreference(new CheckPreference(UI_CATEGORY, "HMD Tablet Becomes Toolbar", getter, setter));
-    }
-    {
         auto getter = []()->bool { return qApp->getPreferAvatarFingerOverStylus(); };
         auto setter = [](bool value) { qApp->setPreferAvatarFingerOverStylus(value); };
         preferences->addPreference(new CheckPreference(UI_CATEGORY, "Prefer Avatar Finger Over Stylus", getter, setter));


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/6281/Move-Tablet-in-Desktop-Toolbar-in-HMD-to-Developer-Settings

Test plan
- open Settings -> General 
- make sure there is no "Desktop Tablet Becomes Toolbar" and "HMD Tablet Becomes Toolbar" buttons
- open Settings -> Developer -> UI (enable developer options if needed)
- Make sure there is  "Desktop Tablet Becomes Toolbar" and "HMD Tablet Becomes Toolbar" buttons
- try to toggle between Tablet<->Toolbar modes
