### PR TITLE
Clone local avatar entities

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 //  entityProperties.html
 //
 //  Created by Ryan Huffman on 13 Nov 2014
@@ -136,17 +136,21 @@
 
                     <fieldset class="column" id="group-cloneable-group" style="display:none;">
                         <legend class="sub-section-header">
-                             <span>Cloneable Settings</span>
+                            <span>Cloneable Settings</span>
                         </legend>
                         <fieldset class="minor">
-                             <div><label>Clone Lifetime</label><input type="number" data-user-data-type="cloneLifetime" id="property-cloneable-lifetime"></div>
+                            <div><label>Clone Lifetime</label><input type="number" data-user-data-type="cloneLifetime" id="property-cloneable-lifetime"></div>
                         </fieldset>
                         <fieldset class="minor">
-                             <div><label>Clone Limit   </label><input type="number" data-user-data-type="cloneLimit" id="property-cloneable-limit"></div>
+                            <div><label>Clone Limit</label><input type="number" data-user-data-type="cloneLimit" id="property-cloneable-limit"></div>
                         </fieldset>
                         <div class="property checkbox">
-                             <input type="checkbox" id="property-cloneable-dynamic">
-                             <label for="property-cloneable-dynamic">Clone Dynamic</label>
+                            <input type="checkbox" id="property-cloneable-dynamic">
+                            <label for="property-cloneable-dynamic">Clone Dynamic</label>
+                        </div>
+                        <div class="property checkbox">
+                            <input type="checkbox" id="property-cloneable-avatarEntity">
+                            <label for="property-cloneable-avatarEntity">Clone Avatar Entity</label>
                         </div>
                     </fieldset>
                 </div>

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -554,6 +554,7 @@ function loaded() {
 
         var elCloneable = document.getElementById("property-cloneable");
         var elCloneableDynamic = document.getElementById("property-cloneable-dynamic");
+        var elCloneableAvatarEntity = document.getElementById("property-cloneable-avatarEntity");
         var elCloneableGroup = document.getElementById("group-cloneable-group");
         var elCloneableLifetime = document.getElementById("property-cloneable-lifetime");
         var elCloneableLimit = document.getElementById("property-cloneable-limit");
@@ -844,25 +845,29 @@ function loaded() {
                             parsedUserData = JSON.parse(properties.userData);
 
                             if ("grabbableKey" in parsedUserData) {
-                                if ("grabbable" in parsedUserData["grabbableKey"]) {
-                                    elGrabbable.checked = parsedUserData["grabbableKey"].grabbable;
+                                var grabbableData = parsedUserData["grabbableKey"];
+                                if ("grabbable" in grabbableData) {
+                                    elGrabbable.checked = grabbableData.grabbable;
                                 }
-                                if ("wantsTrigger" in parsedUserData["grabbableKey"]) {
-                                    elWantsTrigger.checked = parsedUserData["grabbableKey"].wantsTrigger;
+                                if ("wantsTrigger" in grabbableData) {
+                                    elWantsTrigger.checked = grabbableData.wantsTrigger;
                                 }
-                                if ("ignoreIK" in parsedUserData["grabbableKey"]) {
-                                    elIgnoreIK.checked = parsedUserData["grabbableKey"].ignoreIK;
+                                if ("ignoreIK" in grabbableData) {
+                                    elIgnoreIK.checked = grabbableData.ignoreIK;
                                 }
-                                if ("cloneable" in parsedUserData["grabbableKey"]) {
-                                    elCloneable.checked = parsedUserData["grabbableKey"].cloneable;
+                                if ("cloneable" in grabbableData) {
+                                    elCloneable.checked = grabbableData.cloneable;
                                     elCloneableGroup.style.display = elCloneable.checked ? "block": "none";
-                                    elCloneableDynamic.checked = parsedUserData["grabbableKey"].cloneDynamic ? parsedUserData["grabbableKey"].cloneDynamic : properties.dynamic;
+                                    elCloneableDynamic.checked = grabbableData.cloneDynamic ? grabbableData.cloneDynamic : properties.dynamic;
                                     if (elCloneable.checked) {
-                                      if ("cloneLifetime" in parsedUserData["grabbableKey"]) {
-                                          elCloneableLifetime.value = parsedUserData["grabbableKey"].cloneLifetime ? parsedUserData["grabbableKey"].cloneLifetime : 300;
+                                      if ("cloneLifetime" in grabbableData) {
+                                          elCloneableLifetime.value = grabbableData.cloneLifetime ? grabbableData.cloneLifetime : 300;
                                       }
-                                      if ("cloneLimit" in parsedUserData["grabbableKey"]) {
-                                          elCloneableLimit.value = parsedUserData["grabbableKey"].cloneLimit ? parsedUserData["grabbableKey"].cloneLimit : 0;
+                                      if ("cloneLimit" in grabbableData) {
+                                          elCloneableLimit.value = grabbableData.cloneLimit ? grabbableData.cloneLimit : 0;
+                                      }
+                                      if ("cloneAvatarEntity" in grabbableData) {
+                                          elCloneableAvatarEntity.checked = grabbableData.cloneAvatarEntity ? grabbableData.cloneAvatarEntity : false;
                                       }
                                     }
                                 }
@@ -1114,9 +1119,14 @@ function loaded() {
             }
             userDataChanger("grabbableKey", "grabbable", elGrabbable, elUserData, properties.dynamic);
         });
-        elCloneableDynamic.addEventListener('change', function (event){
+        elCloneableDynamic.addEventListener('change', function(event) {
             userDataChanger("grabbableKey", "cloneDynamic", event.target, elUserData, -1);
         });
+
+        elCloneableAvatarEntity.addEventListener('change', function(event) {
+            userDataChanger("grabbableKey", "cloneAvatarEntity", event.target, elUserData, -1);
+        });
+
         elCloneable.addEventListener('change', function (event) {
             var checked = event.target.checked;
             if (checked) {
@@ -1124,6 +1134,7 @@ function loaded() {
                         cloneLifetime: elCloneableLifetime,
                         cloneLimit: elCloneableLimit,
                         cloneDynamic: elCloneableDynamic,
+                        cloneAvatarEntity: elCloneableAvatarEntity,
                         cloneable: event.target,
                         grabbable: null
                     }, elUserData, {});
@@ -1134,6 +1145,7 @@ function loaded() {
                         cloneLifetime: null,
                         cloneLimit: null,
                         cloneDynamic: null,
+                        cloneAvatarEntity: null,
                         cloneable: false
                     }, elUserData, {});
                 elCloneableGroup.style.display = "none";

--- a/scripts/system/libraries/cloneEntityUtils.js
+++ b/scripts/system/libraries/cloneEntityUtils.js
@@ -72,6 +72,7 @@ cloneEntity = function(props, worldEntityProps) {
     var lifetime = grabInfo.cloneLifetime ? grabInfo.cloneLifetime : 300;
     var dynamic = grabInfo.cloneDynamic ? grabInfo.cloneDynamic : false;
     var triggerable = grabInfo.triggerable ? grabInfo.triggerable : false;
+    var avatarEntity = grabInfo.cloneAvatarEntity ? grabInfo.cloneAvatarEntity : false;
     var cUserData = Object.assign({}, JSON.parse(cloneableProps.userData));
     var cProperties = Object.assign({}, cloneableProps);
 
@@ -80,6 +81,7 @@ cloneEntity = function(props, worldEntityProps) {
     delete cUserData.grabbableKey.cloneable;
     delete cUserData.grabbableKey.cloneDynamic;
     delete cUserData.grabbableKey.cloneLimit;
+    delete cUserData.grabbableKey.cloneAvatarEntity;
     delete cProperties.id;
 
 
@@ -90,6 +92,6 @@ cloneEntity = function(props, worldEntityProps) {
     cProperties.lifetime = lifetime;
     cProperties.userData = JSON.stringify(cUserData);
 
-    var cloneID = Entities.addEntity(cProperties);
+    var cloneID = Entities.addEntity(cProperties, avatarEntity);
     return cloneID;
 };


### PR DESCRIPTION
Adds the option to have clone-able local avatar entities. Which allows cloning entities in places that do not allow to rez entities.

## QA test (Requires HMD)
- Use your own sandbox (Requires permission changes)
- Open the edit tool
- Create a "box" entity
- Open the properties for the box entity and:
  - keep it `Red`
  - check the `Cloneable` checkbox
  - check the `Clone Avatar Entity` checkbox
- Create another "box" entity and:
   - make it `Blue`
   - check the `Cloneable` checkbox
- Go to http://localhost:40100/settings/#security and uncheck all `rez` and `temp-rez` permissions, and save settings.
- Enter HMD mode in Interface
- Try grabbing the `Red` box. You should see a new box being created in your hand.
- Try grabbing the `Blue` box. No new entity should be created now.
