### PR TITLE
Fixing the web surface of the tablet

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -271,11 +271,12 @@ void Base3DOverlay::update(float duration) {
     // TODO: Fix the value to be computed in main thread now and passed by value to the render item.
     //       This is the simplest fix for the web overlay of the tablet for now
     if (_renderTransformDirty) {
+        _renderTransformDirty = false;
         auto itemID = getRenderItemID();
         if (render::Item::isValidID(itemID)) {
             render::ScenePointer scene = qApp->getMain3DScene();
             render::Transaction transaction;
-                transaction.updateItem<Overlay>(itemID, [](Overlay& data) {
+            transaction.updateItem<Overlay>(itemID, [](Overlay& data) {
                 auto overlay3D = dynamic_cast<Base3DOverlay*>(&data);
                 if (overlay3D) {
                     auto latestTransform = overlay3D->evalRenderTransform();
@@ -284,7 +285,6 @@ void Base3DOverlay::update(float duration) {
             });
             scene->enqueueTransaction(transaction);       
         }
-        _renderTransformDirty = false;
     }
 }
 

--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -256,17 +256,8 @@ bool Base3DOverlay::findRayIntersection(const glm::vec3& origin, const glm::vec3
 void Base3DOverlay::locationChanged(bool tellPhysics) {
     SpatiallyNestable::locationChanged(tellPhysics);
 
-    // Force the actual update of the render transform now that we notify for the change
-    // so it s captured for the time of rendering
+    // Force the actual update of the render transform through the notify call
     notifyRenderTransformChange();
-
- /*   auto itemID = getRenderItemID();
-    if (render::Item::isValidID(itemID)) {
-        render::ScenePointer scene = qApp->getMain3DScene();
-        render::Transaction transaction;
-        transaction.updateItem(itemID);
-        scene->enqueueTransaction(transaction);
-    }*/
 }
 
 void Base3DOverlay::parentDeleted() {
@@ -274,44 +265,25 @@ void Base3DOverlay::parentDeleted() {
 }
 
 void Base3DOverlay::update(float duration) {
+    
+    // In Base3DOverlay, if its location or bound changed, the renderTrasnformDirty flag is true.
+    // then the correct transform used for rendering is computed in the update transaction and assigned.
+    // TODO: Fix the value to be computed in main thread now and passed by value to the render item.
+    //       This is the simplest fix for the web overlay of the tablet for now
     if (_renderTransformDirty) {
-        auto self = this;
-        // queue up this work for later processing, at the end of update and just before rendering.
-        // the application will ensure only the last lambda is actually invoked.
-        /*  void* key = (void*)this;
-                std::weak_ptr<SpatiallyNestable> weakSelf = shared_from_this();
-                AbstractViewStateInterface::instance()->pushPostUpdateLambda(key, [weakSelf]() {
-                    // do nothing, if the model has already been destroyed.
-                    auto spatiallyNestableSelf = weakSelf.lock();
-                    if (!spatiallyNestableSelf) {
-                        return;
-                    }
-                    auto self = std::dynamic_pointer_cast<Base3DOverlay>(spatiallyNestableSelf);
-        */
-        #ifdef UpdateInMain
-            self->setRenderTransform(self->evalRenderTransform());
-        #else
-            auto renderTransform = self->evalRenderTransform();
-        #endif
-            auto itemID = self->getRenderItemID();
-         if (render::Item::isValidID(itemID)) {
+        auto itemID = getRenderItemID();
+        if (render::Item::isValidID(itemID)) {
             render::ScenePointer scene = qApp->getMain3DScene();
             render::Transaction transaction;
-            #ifdef UpdateInMain
-                transaction.updateItem(itemID);
-            #else
-                transaction.updateItem<Overlay>(itemID, [renderTransform](Overlay& data) {
+                transaction.updateItem<Overlay>(itemID, [](Overlay& data) {
                 auto overlay3D = dynamic_cast<Base3DOverlay*>(&data);
                 if (overlay3D) {
                     auto latestTransform = overlay3D->evalRenderTransform();
-                    overlay3D->setRenderTransform(latestTransform);//  evalRenderTransform();
+                    overlay3D->setRenderTransform(latestTransform);
                 }
             });
-            #endif
-                 scene->enqueueTransaction(transaction);
-            
+            scene->enqueueTransaction(transaction);       
         }
-        //     });
         _renderTransformDirty = false;
     }
 }

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -55,8 +55,6 @@ public:
     void update(float deltatime) override;
     
     void notifyRenderTransformChange() const;
-    virtual Transform evalRenderTransform() const;
-    void setRenderTransform(const Transform& transform);
 
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
@@ -74,6 +72,9 @@ protected:
     virtual void parentDeleted() override;
 
     mutable Transform _renderTransform;
+    virtual Transform evalRenderTransform() const;
+    virtual void setRenderTransform(const Transform& transform);
+    const Transform& getRenderTransform() const { return _renderTransform; }
 
     float _lineWidth;
     bool _isSolid;

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -52,6 +52,12 @@ public:
 
     virtual AABox getBounds() const override = 0;
 
+    void update(float deltatime) override;
+    
+    void notifyRenderTransformChange() const;
+    virtual Transform evalRenderTransform() const;
+    void setRenderTransform(const Transform& transform);
+
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
 
@@ -67,12 +73,15 @@ protected:
     virtual void locationChanged(bool tellPhysics = true) override;
     virtual void parentDeleted() override;
 
+    mutable Transform _renderTransform;
+
     float _lineWidth;
     bool _isSolid;
     bool _isDashedLine;
     bool _ignoreRayIntersection;
     bool _drawInFront;
     bool _isGrabbable { false };
+    mutable bool _renderTransformDirty{ true };
 
     QString _name;
 };

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -85,6 +85,7 @@ void Circle3DOverlay::render(RenderArgs* args) {
     }
 
     // FIXME: THe line width of _lineWidth is not supported anymore, we ll need a workaround
+    // FIXME Start using the _renderTransform instead of calling for Transform from here, do the custom things needed in evalRenderTransform()
 
     auto transform = getTransform();
     transform.postScale(glm::vec3(getDimensions(), 1.0f));

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -54,6 +54,7 @@ void Cube3DOverlay::render(RenderArgs* args) {
     glm::vec4 cubeColor(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
 
     // TODO: handle registration point??
+    // FIXME Start using the _renderTransform instead of calling for Transform from here, do the custom things needed in evalRenderTransform()
     glm::vec3 position = getPosition();
     glm::vec3 dimensions = getDimensions();
     glm::quat rotation = getRotation();

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -79,6 +79,7 @@ void Grid3DOverlay::render(RenderArgs* args) {
             position += glm::vec3(cameraPosition.x, 0.0f, cameraPosition.z);
         }
 
+        // FIXME Start using the _renderTransform instead of calling for Transform from here, do the custom things needed in evalRenderTransform()
         Transform transform;
         transform.setRotation(getRotation());
         transform.setScale(glm::vec3(getDimensions(), 1.0f));

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -117,6 +117,7 @@ void Image3DOverlay::render(RenderArgs* args) {
     xColor color = getColor();
     float alpha = getAlpha();
     
+    // FIXME Start using the _renderTransform instead of calling for Transform from here, do the custom things needed in evalRenderTransform()
     Transform transform = getTransform();
     bool transformChanged = applyTransformTo(transform, true);
     // If the transform is not modified, setting the transform to

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -132,6 +132,7 @@ void Line3DOverlay::render(RenderArgs* args) {
     glm::vec4 colorv4(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
     auto batch = args->_batch;
     if (batch) {
+        // FIXME Start using the _renderTransform instead of calling for Transform and start and end from here, do the custom things needed in evalRenderTransform()
         batch->setModelTransform(Transform());
         glm::vec3 start = getStart();
         glm::vec3 end = getEnd();

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -281,6 +281,7 @@ ModelOverlay* ModelOverlay::createClone() const {
 void ModelOverlay::locationChanged(bool tellPhysics) {
     Base3DOverlay::locationChanged(tellPhysics);
 
+    // FIXME Start using the _renderTransform instead of calling for Transform and Dimensions from here, do the custom things needed in evalRenderTransform()
     if (_model && _model->isActive()) {
         _model->setRotation(getRotation());
         _model->setTranslation(getPosition());

--- a/interface/src/ui/overlays/Planar3DOverlay.cpp
+++ b/interface/src/ui/overlays/Planar3DOverlay.cpp
@@ -66,3 +66,11 @@ bool Planar3DOverlay::findRayIntersection(const glm::vec3& origin, const glm::ve
     // FIXME - face and surfaceNormal not being returned
     return findRayRectangleIntersection(origin, direction, getRotation(), getPosition(), getDimensions(), distance);
 }
+
+Transform Planar3DOverlay::evalRenderTransform() const {
+    auto transform = getTransform();
+    if (glm::length2(getDimensions()) != 1.0f) {
+        transform.postScale(vec3(getDimensions(), 1.0f));
+    }
+    return transform;
+}

--- a/interface/src/ui/overlays/Planar3DOverlay.h
+++ b/interface/src/ui/overlays/Planar3DOverlay.h
@@ -32,7 +32,9 @@ public:
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                         BoxFace& face, glm::vec3& surfaceNormal) override;
-    
+  
+    Transform evalRenderTransform() const override;
+
 protected:
     glm::vec2 _dimensions;
 };

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -66,6 +66,7 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
     auto batch = args->_batch;
 
     if (batch) {
+        // FIXME Start using the _renderTransform instead of calling for Transform and Dimensions from here, do the custom things needed in evalRenderTransform()
         Transform transform;
         transform.setTranslation(position);
         transform.setRotation(rotation);

--- a/interface/src/ui/overlays/Shape3DOverlay.cpp
+++ b/interface/src/ui/overlays/Shape3DOverlay.cpp
@@ -33,6 +33,7 @@ void Shape3DOverlay::render(RenderArgs* args) {
     const float MAX_COLOR = 255.0f;
     glm::vec4 cubeColor(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
 
+    // FIXME Start using the _renderTransform instead of calling for Transform and Dimensions from here, do the custom things needed in evalRenderTransform()
     // TODO: handle registration point??
     glm::vec3 position = getPosition();
     glm::vec3 dimensions = getDimensions();

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -39,6 +39,7 @@ void Sphere3DOverlay::render(RenderArgs* args) {
     auto batch = args->_batch;
 
     if (batch) {
+        // FIXME Start using the _renderTransform instead of calling for Transform and Dimensions from here, do the custom things needed in evalRenderTransform()
         Transform transform = getTransform();
         transform.postScale(getDimensions() * SPHERE_OVERLAY_SCALE);
         batch->setModelTransform(transform);

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -96,6 +96,7 @@ void Text3DOverlay::render(RenderArgs* args) {
     Q_ASSERT(args->_batch);
     auto& batch = *args->_batch;
 
+    // FIXME Start using the _renderTransform instead of calling for Transform and Dimensions from here, do the custom things needed in evalRenderTransform()
     Transform transform = getTransform();
     applyTransformTo(transform, true);
     setTransform(transform);

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -320,7 +320,7 @@ void Web3DOverlay::render(RenderArgs* args) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
     batch.setResourceTexture(0, _texture);
-    batch.setModelTransform(_renderTransform);
+    batch.setModelTransform(getRenderTransform());
 
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (color.a < OPAQUE_ALPHA_THRESHOLD) {

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -184,6 +184,7 @@ void Web3DOverlay::update(float deltatime) {
         // update globalPosition
         _webSurface->getSurfaceContext()->setContextProperty("globalPosition", vec3toVariant(getPosition()));
     }
+    Billboard3DOverlay::update(deltatime);
 }
 
 QString Web3DOverlay::pickURL() {
@@ -306,19 +307,6 @@ void Web3DOverlay::render(RenderArgs* args) {
     vec2 halfSize = getSize() / 2.0f;
     vec4 color(toGlm(getColor()), getAlpha());
 
-    Transform transform = getTransform();
-
-    // FIXME: applyTransformTo causes tablet overlay to detach from tablet entity.
-    // Perhaps rather than deleting the following code it should be run only if isFacingAvatar() is true?
-    /*
-    applyTransformTo(transform, true);
-    setTransform(transform);
-    */
-
-    if (glm::length2(getDimensions()) != 1.0f) {
-        transform.postScale(vec3(getDimensions(), 1.0f));
-    }
-
     if (!_texture) {
         _texture = gpu::Texture::createExternal(OffscreenQmlSurface::getDiscardLambda());
         _texture->setSource(__FUNCTION__);
@@ -332,7 +320,8 @@ void Web3DOverlay::render(RenderArgs* args) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
     batch.setResourceTexture(0, _texture);
-    batch.setModelTransform(transform);
+    batch.setModelTransform(_renderTransform);
+
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (color.a < OPAQUE_ALPHA_THRESHOLD) {
         geometryCache->bindWebBrowserProgram(batch, true);

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -184,7 +184,7 @@ void Web3DOverlay::update(float deltatime) {
         // update globalPosition
         _webSurface->getSurfaceContext()->setContextProperty("globalPosition", vec3toVariant(getPosition()));
     }
-    Billboard3DOverlay::update(deltatime);
+    Parent::update(deltatime);
 }
 
 QString Web3DOverlay::pickURL() {

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -19,9 +19,9 @@ class OffscreenQmlSurface;
 
 class Web3DOverlay : public Billboard3DOverlay {
     Q_OBJECT
+    using Parent = Billboard3DOverlay;
 
 public:
-    using Parent = Billboard3DOverlay;
 
     static const QString QML;
     static QString const TYPE;

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -21,6 +21,8 @@ class Web3DOverlay : public Billboard3DOverlay {
     Q_OBJECT
 
 public:
+    using Parent = Billboard3DOverlay;
+
     static const QString QML;
     static QString const TYPE;
     virtual QString getType() const override { return TYPE; }


### PR DESCRIPTION
This pr should fix the web surface of the tablet not being at the right position with regard to the tablet model itself. In particular when moving the tablet, the web surface appears to be inside or ahead of the tablet movement.

This is the quick fix, there is a broader issue waiting to be solved regarding all the values changing during gameplay that need to be captured per value before being passed to the render  scene through the render  transactions. This is touching many part of the code that will be addressed in future work.

## TEST PLAN
When showing the tablet in HMD:
- grab it and shake it.
- move around and rotate your avatar.
in this PR, the web surface of the tablet moves correctly never drifting away from the table model itself.
it s showing the bug in current master.

When showing the tablet in Desktop:
- grab it with the mouse and shake it.
- move around and rotate your avatar.
in this PR, the web surface of the tablet moves correctly never drifting away from the table model itself.
it s showing the bug in current master.

Cheers

