### PR TITLE
Avatar Attachments now render correctly

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5209,7 +5209,7 @@ void Application::update(float deltaTime) {
         }
     }
 
-    avatarManager->postUpdate(deltaTime);
+    avatarManager->postUpdate(deltaTime, getMain3DScene());
 
     {
         PROFILE_RANGE_EX(app, "PreRenderLambdas", 0xffff0000, (uint64_t)0);

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -259,12 +259,12 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
     simulateAvatarFades(deltaTime);
 }
 
-void AvatarManager::postUpdate(float deltaTime) {
+void AvatarManager::postUpdate(float deltaTime, const render::ScenePointer& scene) {
     auto hashCopy = getHashCopy();
     AvatarHash::iterator avatarIterator = hashCopy.begin();
     for (avatarIterator = hashCopy.begin(); avatarIterator != hashCopy.end(); avatarIterator++) {
         auto avatar = std::static_pointer_cast<Avatar>(avatarIterator.value());
-        avatar->postUpdate(deltaTime);
+        avatar->postUpdate(deltaTime, scene);
     }
 }
 

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -55,7 +55,7 @@ public:
     void updateMyAvatar(float deltaTime);
     void updateOtherAvatars(float deltaTime);
 
-    void postUpdate(float deltaTime);
+    void postUpdate(float deltaTime, const render::ScenePointer& scene);
 
     void clearOtherAvatars();
     void deleteAllAvatars();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1814,11 +1814,11 @@ void MyAvatar::destroyAnimGraph() {
     _skeletonModel->getRig().destroyAnimGraph();
 }
 
-void MyAvatar::postUpdate(float deltaTime) {
+void MyAvatar::postUpdate(float deltaTime, const render::ScenePointer& scene) {
 
-    Avatar::postUpdate(deltaTime);
+    Avatar::postUpdate(deltaTime, scene);
 
-    if (DependencyManager::get<SceneScriptingInterface>()->shouldRenderAvatars() && _skeletonModel->initWhenReady(qApp->getMain3DScene())) {
+    if (_skeletonModel->isLoaded() && !_skeletonModel->getRig().getAnimNode()) {
         initHeadBones();
         _skeletonModel->setCauterizeBoneSet(_headBoneSet);
         _fstAnimGraphOverrideUrl = _skeletonModel->getGeometry()->getAnimGraphOverrideUrl();

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -196,7 +196,7 @@ public:
     Q_INVOKABLE void clearIKJointLimitHistory(); // thread-safe
 
     void update(float deltaTime);
-    virtual void postUpdate(float deltaTime) override;
+    virtual void postUpdate(float deltaTime, const render::ScenePointer& scene) override;
     void preDisplaySide(RenderArgs* renderArgs);
 
     const glm::mat4& getHMDSensorMatrix() const { return _hmdSensorMatrix; }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -553,7 +553,7 @@ void Avatar::updateRenderItem(render::Transaction& transaction) {
     }
 }
 
-void Avatar::postUpdate(float deltaTime) {
+void Avatar::postUpdate(float deltaTime, const render::ScenePointer& scene) {
 
     if (isMyAvatar() ? showMyLookAtVectors : showOtherLookAtVectors) {
         const float EYE_RAY_LENGTH = 10.0;
@@ -577,6 +577,8 @@ void Avatar::postUpdate(float deltaTime) {
             DebugDraw::getInstance().drawRay(rightEyePosition, rightEyePosition + rightEyeRotation * Vectors::UNIT_Z * EYE_RAY_LENGTH, RED);
         }
     }
+
+    fixupModelsInScene(scene);
 }
 
 void Avatar::render(RenderArgs* renderArgs) {
@@ -646,10 +648,6 @@ void Avatar::render(RenderArgs* renderArgs) {
     ViewFrustum frustum = renderArgs->getViewFrustum();
     if (!frustum.sphereIntersectsFrustum(getPosition(), getBoundingRadius())) {
         return;
-    }
-
-    if (!isMyAvatar()) {
-        fixupModelsInScene(renderArgs->_scene);
     }
 
     if (showCollisionShapes && shouldRenderHead(renderArgs) && _skeletonModel->isRenderable()) {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -98,7 +98,7 @@ public:
 
     void updateRenderItem(render::Transaction& transaction);
 
-    virtual void postUpdate(float deltaTime);
+    virtual void postUpdate(float deltaTime, const render::ScenePointer& scene);
 
     //setters
     void setIsLookAtTarget(const bool isLookAtTarget) { _isLookAtTarget = isLookAtTarget; }

--- a/scripts/developer/tests/avatarAttachmentTest.js
+++ b/scripts/developer/tests/avatarAttachmentTest.js
@@ -89,9 +89,9 @@ var coatButton = new ToggleButtonBuddy(buttonPositionX, buttonPositionY, BUTTON_
 var HAT_ATTACHMENT = {
     modelURL: "https://s3.amazonaws.com/hifi-public/tony/cowboy-hat.fbx",
     jointName: "Head",
-    translation: {"x": 0, "y": 0.2, "z": 0},
+    translation: {"x": 0, "y": 0.25, "z": 0.03},
     rotation: {"x": 0, "y": 0, "z": 0, "w": 1},
-    scale: 1,
+    scale: 0.052,
     isSoft: false
 };
 


### PR DESCRIPTION
* moved Avatar::fixupModelsInScene off the newly created render thread back
  to the main thread.
* updated Avatar::postUpdate to take a scene pointer, necessary for
  Avatar::fixupModelsInScene
* updated developer/tests/avatarAttachementTest.js to account for recent
  changes in avatar attachment scale, commit 712aff7ad.
* updated initialization of anim graph to use Model::isLoaded() instead of
  Model::initWhenReady() to know when the model was completely loaded.