### PR TITLE
7384 On Domains without Edit Access, Create Button Text still Highlights

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletButton.qml
+++ b/interface/resources/qml/hifi/tablet/TabletButton.qml
@@ -168,7 +168,7 @@ Item {
 
             PropertyChanges {
                 target: text
-                color: "#ffffff"
+                color: captionColorOverride !== "" ? captionColorOverride: "#ffffff"
                 text: tabletButton.hoverText
             }
 
@@ -194,7 +194,7 @@ Item {
 
             PropertyChanges {
                 target: text
-                color: "#333333"
+                color: captionColorOverride !== "" ? captionColorOverride: "#333333"
                 text: tabletButton.activeText
             }
 
@@ -225,7 +225,7 @@ Item {
 
             PropertyChanges {
                 target: text
-                color: "#333333"
+                color: captionColorOverride !== "" ? captionColorOverride: "#333333"
                 text: tabletButton.activeHoverText
             }
 


### PR DESCRIPTION
*** Test plan *** 

1. Go to the domain without edit access
2. Open tablet
3. Ensure text on 'Edit' button is **not** getting white when the button is hovered (in both desktop & VR) mode
4. As a smoke test, make sure Create mode works in domains where you have edit access and does not work in domains where you don't have edit access.

Just in case, here is the sample of behavior before the fix: 

![image](https://user-images.githubusercontent.com/23638/30512785-bbf55bec-9aff-11e7-96d5-36f11157e3fb.png)
