### PR TITLE
Oculus: fix for lighting changes as avatar scale changes

### DIFF
--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -84,7 +84,7 @@ glm::mat4 OculusBaseDisplayPlugin::getCullingProjection(const glm::mat4& basePro
         float baseFarClip = baseFrustum.getFarClip();
         auto combinedFov = _eyeFovs[0];
         combinedFov.LeftTan = combinedFov.RightTan = std::max(combinedFov.LeftTan, combinedFov.RightTan);
-        return toGlm(ovrMatrix4f_Projection(combinedFov, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP, ovrProjection_ClipRangeOpenGL));
+        return toGlm(ovrMatrix4f_Projection(combinedFov, baseNearClip, baseFarClip, ovrProjection_ClipRangeOpenGL));
     } else {
         return baseProjection;
     }


### PR DESCRIPTION
The code was incorrectly NOT using the base near and far clip distances when computing
the culling projection matrix. This projection matrix is used by the lighting system
to for deferred lighting, if it does not match actual projection used for
rendering into the g-buffer, the lighting will be incorrect.