### PR TITLE
flag node as local by IP from UDP header, not IP from packet data

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -272,22 +272,22 @@ void DomainGatekeeper::updateNodePermissions() {
             userPerms.permissions |= NodePermissions::Permission::canWriteToAssetServer;
             userPerms.permissions |= NodePermissions::Permission::canReplaceDomainContent;
         } else {
-            // this node is an agent
-            const QHostAddress& addr = node->getLocalSocket().getAddress();
-            bool isLocalUser = (addr == limitedNodeList->getLocalSockAddr().getAddress() ||
-                                addr == QHostAddress::LocalHost);
-
             // at this point we don't have a sending socket for packets from this node - assume it is the active socket
             // or the public socket if we haven't activated a socket for the node yet
             HifiSockAddr connectingAddr = node->getActiveSocket() ? *node->getActiveSocket() : node->getPublicSocket();
 
             QString hardwareAddress;
             QUuid machineFingerprint;
+            bool isLocalUser { false };
 
             DomainServerNodeData* nodeData = static_cast<DomainServerNodeData*>(node->getLinkedData());
             if (nodeData) {
                 hardwareAddress = nodeData->getHardwareAddress();
                 machineFingerprint = nodeData->getMachineFingerprint();
+
+                auto sendingAddress = nodeData->getSendingSockAddr().getAddress();
+                isLocalUser = (sendingAddress == limitedNodeList->getLocalSockAddr().getAddress() ||
+                               sendingAddress == QHostAddress::LocalHost);
             }
 
             userPerms = setPermissionsForUser(isLocalUser, verifiedUsername, connectingAddr.getAddress(), hardwareAddress, machineFingerprint);


### PR DESCRIPTION
- fixed a bug where a node would be incorrectly flagged as local by the domain-server