### PR TITLE
WL 21540 - Make Rotation using Vive Controller Work

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -25,7 +25,7 @@
         },
 
         { "from": "Standard.RX",
-          "when": [ "Application.InHMD", "Application.SnapTurn" ],
+          "when": [ "Application.SnapTurn" ],
           "to": "Actions.StepYaw",
           "filters":
             [


### PR DESCRIPTION
> In desktop mode:
> 1. Enable advanced movement with handcontrollers
> 2. Open Settings > Controller Settings
> 3. Enable "Use Vive devices in desktop mode"
> 4. Try using the thumbpad on your left Vive controller to move around. It should work
> 5. Try using the thumbpad on your right Vive controller to rotate your avatar. DOES NOT WORK.
> 
> Make the rotation work as expected.

[WL 21540](https://worklist.net/21540)

## Test Plan
1. Enabled Advanced Movement with Hand Controllers
2. Open Settings > Controller Settings and enable "Use Vive Devices in Desktop Mode"
3. Try using the Thumbpad on your Left Controller to Move Around - it should work as expected.
4. Try using the Thumbpad on your Right Controller to Snap Rotate - it should work as expected.
5. Confirm that movement still works normally in HMD