### PR TITLE
7718 Turn monitor display preview on by default

### DIFF
--- a/libraries/display-plugins/CMakeLists.txt
+++ b/libraries/display-plugins/CMakeLists.txt
@@ -12,5 +12,6 @@ include_hifi_library_headers(ktx)
 include_hifi_library_headers(render)
 
 target_opengl()
+target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_BINARY_DIR}/includes")
 
 GroupSources("src/display-plugins")

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -432,6 +432,8 @@ void OpenGLDisplayPlugin::customizeContext() {
         }
     }
     updateCompositeFramebuffer();
+
+    emit contextCustomized();
 }
 
 void OpenGLDisplayPlugin::uncustomizeContext() {

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -82,6 +82,9 @@ public:
 
     void copyTextureToQuickFramebuffer(NetworkTexturePointer source, QOpenGLFramebufferObject* target, GLsync* fenceSync) override;
 
+signals:
+    void contextCustomized();
+
 protected:
     friend class PresentThread;
 

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -73,11 +73,7 @@ bool HmdDisplayPlugin::internalActivate() {
         _container->setBoolSetting("monoPreview", _monoPreview);
     }, true, _monoPreview);
 
-#if defined(Q_OS_MAC)
-    _disablePreview = true;
-#else
     _disablePreview = _container->getBoolSetting("disableHmdPreview", DEFAULT_DISABLE_PREVIEW || _vsyncEnabled);
-#endif
 
     QTimer::singleShot(DISABLE_PREVIEW_MENU_ITEM_DELAY_MS, [this] {
         if (isActive() && !_vsyncEnabled) { // disallow preview with enabled vsync because main window refresh rate, is typically 60 Hz, while most HMD output has to be at 90 Hz.

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -80,7 +80,7 @@ bool HmdDisplayPlugin::internalActivate() {
 #endif
 
     QTimer::singleShot(DISABLE_PREVIEW_MENU_ITEM_DELAY_MS, [this] {
-        if (isActive() && !_vsyncEnabled) {
+        if (isActive() && !_vsyncEnabled) { // disallow preview with enabled vsync because main window refresh rate, is typically 60 Hz, while most HMD output has to be at 90 Hz.
             _container->addMenuItem(PluginType::DISPLAY_PLUGIN, MENU_PATH(), DISABLE_PREVIEW,
                 [this](bool clicked) {
                 _disablePreview = clicked;

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -82,6 +82,9 @@ protected:
     RateCounter<> _stutterRate;
 
     bool _disablePreview { true };
+private slots:
+    void onContextCustomized();
+
 private:
     ivec4 getViewportForSourceSize(const uvec2& size) const;
     float getLeftCenterPixel() const;


### PR DESCRIPTION
This PR fixes possible threading issue which could result in 'display preview' menu item not appearing / display preview disabled. 

Also it allows displaying preview even if 'v-sync' is enabled for 'dev' builds. 

**Test plan**

0. Take production build. 
1. Ensure 'v-sync' is disabled in OS
2. Launch interface 
3. Reset all the settings to default
4. Switch to VR
5. Preview should be enabled

Also, do a basic smoke test in High Fidelity, making sure everything is rendering at a normal frame rate and there are no additional crashes.

Note: for 'dev' builds preview should be enabled independently on enabled/disabled 'v-sync'