### PR TITLE
Don't let scripts control visibility of laser pointer overlays

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5160,12 +5160,6 @@ void Application::update(float deltaTime) {
     }
 
     {
-        PROFILE_RANGE_EX(app, "Overlays", 0xffff0000, (uint64_t)getActiveDisplayPlugin()->presentCount());
-        PerformanceTimer perfTimer("overlays");
-        _overlays.update(deltaTime);
-    }
-
-    {
         PROFILE_RANGE(app, "RayPickManager");
         _rayPickManager.update();
     }
@@ -5173,6 +5167,12 @@ void Application::update(float deltaTime) {
     {
         PROFILE_RANGE(app, "LaserPointerManager");
         _laserPointerManager.update();
+    }
+
+    {
+        PROFILE_RANGE_EX(app, "Overlays", 0xffff0000, (uint64_t)getActiveDisplayPlugin()->presentCount());
+        PerformanceTimer perfTimer("overlays");
+        _overlays.update(deltaTime);
     }
 
     // Update _viewFrustum with latest camera and view frustum data...

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -86,7 +86,9 @@ void LaserPointer::editRenderState(const std::string& state, const QVariant& sta
 
 void LaserPointer::updateRenderStateOverlay(const OverlayID& id, const QVariant& props) {
     if (!id.isNull() && props.isValid()) {
-        qApp->getOverlays().editOverlay(id, props);
+        QVariantMap propMap = props.toMap();
+        propMap.remove("visible");
+        qApp->getOverlays().editOverlay(id, propMap);
     }
 }
 

--- a/interface/src/raypick/LaserPointerScriptingInterface.cpp
+++ b/interface/src/raypick/LaserPointerScriptingInterface.cpp
@@ -95,6 +95,7 @@ const RenderState LaserPointerScriptingInterface::buildRenderState(const QVarian
     if (propMap["start"].isValid()) {
         QVariantMap startMap = propMap["start"].toMap();
         if (startMap["type"].isValid()) {
+            startMap.remove("visible");
             startID = qApp->getOverlays().addOverlay(startMap["type"].toString(), startMap);
         }
     }
@@ -104,6 +105,7 @@ const RenderState LaserPointerScriptingInterface::buildRenderState(const QVarian
         QVariantMap pathMap = propMap["path"].toMap();
         // right now paths must be line3ds
         if (pathMap["type"].isValid() && pathMap["type"].toString() == "line3d") {
+            pathMap.remove("visible");
             pathID = qApp->getOverlays().addOverlay(pathMap["type"].toString(), pathMap);
         }
     }
@@ -112,6 +114,7 @@ const RenderState LaserPointerScriptingInterface::buildRenderState(const QVarian
     if (propMap["end"].isValid()) {
         QVariantMap endMap = propMap["end"].toMap();
         if (endMap["type"].isValid()) {
+            endMap.remove("visible");
             endID = qApp->getOverlays().addOverlay(endMap["type"].toString(), endMap);
         }
     }


### PR DESCRIPTION
Fixes [FB7462](https://highfidelity.fogbugz.com/f/cases/7462/Flickering-double-laser-beams)

Also moves LaserPointerManager::update before Overlays::update in Application::update (no effect now, will reduce overlay update latency later).

Test plan:
- Using hand controllers, far grab things and just general move your hand lasers around.
- You should not see a second flickering laser in strange locations.
- Click on any entity with your hand laser.  Let go.  Point your hand at the sky so the laser wouldn't hit anything and hold the trigger.
- You should not see a second flickering laser over the first entity.
- Other scripts with lasers like teleport should still work.