### PR TITLE
Optionalize the debug spam of makeUserConnection.js

### DIFF
--- a/scripts/system/makeUserConnection.js
+++ b/scripts/system/makeUserConnection.js
@@ -16,6 +16,7 @@
 
     var request = Script.require('request').request;
 
+	var WANT_DEBUG = Settings.getValue('MAKE_USER_CONNECTION_DEBUG', false);
     var LABEL = "makeUserConnection";
     var MAX_AVATAR_DISTANCE = 0.2; // m
     var GRIP_MIN = 0.75; // goes from 0-1, so 75% pressed is pressed
@@ -120,6 +121,9 @@
     var successfulHandshakeSound;
 
     function debug() {
+		if (!WANT_DEBUG) {
+			return;
+		}
         var stateString = "<" + STATE_STRINGS[state] + ">";
         var connecting = "[" + connectingId + "/" + connectingHandJointIndex + "]";
         var current = "[" + currentHand + "/" + currentHandJointIndex + "]"
@@ -372,7 +376,7 @@
             var myHeadIndex = MyAvatar.getJointIndex("Head");
             var otherHeadIndex = avatar.getJointIndex("Head");
             var diff = (avatar.getJointPosition(otherHeadIndex).y - MyAvatar.getJointPosition(myHeadIndex).y) / 2;
-            print("head height difference: " + diff);
+            debug("head height difference: " + diff);
             updateAnimationData(diff);
         }
     }


### PR DESCRIPTION
Removed debug spam from `makeUserConnection.js`, to reactivate it set `Settings.setValue('MAKE_USER_CONNECTION_DEBUG', true);` and reload the script.

1. Open the Script Log / Log
2. Hold down the X key in Desktop or hold down the Grip of a controller in HMD to activate the makeUserConnection script.
3. Check the log file for entries starting with `[DEBUG] [hifi.scriptengine.script] makeUserConnection` , there shouldn't be any.
4. Open the `Edit -> Script Console` (Requires `Settings -> Advanced Menus` to be enabled )
5. type `Settings.setValue('MAKE_USER_CONNECTION_DEBUG', true);` followed by an Enter press
6. Reload all the Scripts.
7. Hold down the X key in Desktop or hold down the Grip of a controller in HMD to activate the makeUserConnection script.
8. Check the log file for entries starting with `[DEBUG] [hifi.scriptengine.script] makeUserConnection` , there should be plenty.
9. Open the `Edit -> Script Console` (Requires `Settings -> Advanced Menus` to be enabled )
10. type `Settings.setValue('MAKE_USER_CONNECTION_DEBUG', false);` followed by an Enter press
11. Reload all the Scripts.
12. Hold down the X key in Desktop or hold down the Grip of a controller in HMD to activate the makeUserConnection script.
13. Check the log file for entries starting with `[DEBUG] [hifi.scriptengine.script] makeUserConnection` , there shouldn't be any.