### PR TITLE
nearParentGrab module now sets the correct previous parent id when switching grabbed overlays from one hand to another

### DIFF
--- a/scripts/system/controllers/controllerModules/nearParentGrabOverlay.js
+++ b/scripts/system/controllers/controllerModules/nearParentGrabOverlay.js
@@ -26,6 +26,7 @@ Script.include("/~/system/libraries/utils.js");
         this.previousParentID = {};
         this.previousParentJointIndex = {};
         this.previouslyUnhooked = {};
+        this.robbed = false;
 
         this.parameters = makeDispatcherModuleParameters(
             90,
@@ -111,9 +112,9 @@ Script.include("/~/system/libraries/utils.js");
             } else if (this.otherHandIsParent(grabbedProperties)) {
                 // the other hand is parent. Steal the object and information
                 var otherModule = this.getOtherModule();
-                this.previousParentID[this.grabbedThingID] = otherModule.previousParentID[this.garbbedThingID];
+                this.previousParentID[this.grabbedThingID] = otherModule.previousParentID[this.grabbedThingID];
                 this.previousParentJointIndex[this.grabbedThingID] = otherModule.previousParentJointIndex[this.grabbedThingID];
-
+                otherModule.robbed = true;
             } else {
                 this.previousParentID[this.grabbedThingID] = grabbedProperties.parentID;
                 this.previousParentJointIndex[this.grabbedThingID] = grabbedProperties.parentJointIndex;
@@ -134,12 +135,12 @@ Script.include("/~/system/libraries/utils.js");
 
         this.endNearParentingGrabOverlay = function () {
             var previousParentID = this.previousParentID[this.grabbedThingID];
-            if (previousParentID === NULL_UUID || previousParentID === null || previousParentID === undefined) {
+            if ((previousParentID === NULL_UUID || previousParentID === null) && !this.robbed) {
                 Overlays.editOverlay(this.grabbedThingID, {
                     parentID: NULL_UUID,
                     parentJointIndex: -1
                 });
-            } else {
+            } else if (!this.robbed){
                 // before we grabbed it, overlay was a child of something; put it back.
                 Overlays.editOverlay(this.grabbedThingID, {
                     parentID: this.previousParentID[this.grabbedThingID],
@@ -170,7 +171,9 @@ Script.include("/~/system/libraries/utils.js");
 
 
         this.isReady = function (controllerData) {
-            if (controllerData.triggerClicks[this.hand] === 0 && controllerData.secondaryValues[this.hand] === 0) {
+            if ((controllerData.triggerClicks[this.hand] === 0 &&
+                 controllerData.secondaryValues[this.hand] === 0)) {
+                this.robbed = false;
                 return makeRunningValues(false, [], []);
             }
 
@@ -182,7 +185,7 @@ Script.include("/~/system/libraries/utils.js");
             });
 
             var targetID = this.getTargetID(grabbableOverlays, controllerData);
-            if (targetID) {
+            if (targetID && !this.robbed) {
                 this.grabbedThingID = targetID;
                 this.startNearParentingGrabOverlay(controllerData);
                 return makeRunningValues(true, [this.grabbedThingID], []);
@@ -194,6 +197,7 @@ Script.include("/~/system/libraries/utils.js");
         this.run = function (controllerData) {
             if (controllerData.triggerClicks[this.hand] === 0 && controllerData.secondaryValues[this.hand] === 0) {
                 this.endNearParentingGrabOverlay();
+                this.robbed = false;
                 return makeRunningValues(false, [], []);
             } else {
                 // check if someone stole the target from us


### PR DESCRIPTION
This PR fixes the issue of the nearParentGrabOverlay module not setting the correct previous parentID when grabbed overlays switch from on hand to the other.