### PR TITLE
Check if ContextOverlayInterface is enabled before highlighting marketplace items

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -237,13 +237,13 @@ void ContextOverlayInterface::contextOverlays_hoverLeaveOverlay(const OverlayID&
 }
 
 void ContextOverlayInterface::contextOverlays_hoverEnterEntity(const EntityItemID& entityID, const PointerEvent& event) {
-    if (contextOverlayFilterPassed(entityID)) {
+    if (contextOverlayFilterPassed(entityID) && _enabled) {
         enableEntityHighlight(entityID);
     }
 }
 
 void ContextOverlayInterface::contextOverlays_hoverLeaveEntity(const EntityItemID& entityID, const PointerEvent& event) {
-    if (_currentEntityWithContextOverlay != entityID) {
+    if (_currentEntityWithContextOverlay != entityID && _enabled) {
         disableEntityHighlight(entityID);
     }
 }


### PR DESCRIPTION
Test Plan:
1. Clean install Interface
2. Spawn something from the Marketplace (I use the Flare Gun)
3. Move your mouse over the thing
4. Verify that the thing DOES NOT get an orange edge highlight
5. Close Interface. Open `Interface.json` at `%appdata%/High Fidelity - PR<PR#>`
6. Add the following line to the file anywhere but the bottom: `"inspectionMode": true,`
7. Open Interface
8. Move your mouse over the same thing from (2)
9. Verify that the thing DOES get an orange edge highlight