### PR TITLE
Fix missing models

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -222,12 +222,14 @@ void EntityTreeRenderer::updateChangedEntities(const render::ScenePointer& scene
         _renderablesToUpdate.insert({ entityId, renderable });
     }
 
-    if (!_entitiesInScene.empty()) {
-        for (const auto& entry : _entitiesInScene) {
-            const auto& renderable = entry.second;
-            if (renderable) {
-                renderable->update(scene, transaction);
-            }
+    // NOTE: Looping over all the entity renderers is likely to be a bottleneck in the future
+    // Currently, this is necessary because the model entity loading logic requires constant polling
+    // This was working fine because the entity server used to send repeated updates as your view changed,
+    // but with the improved entity server logic (PR 11141), updateInScene (below) would not be triggered enough
+    for (const auto& entry : _entitiesInScene) {
+        const auto& renderable = entry.second;
+        if (renderable) {
+            renderable->update(scene, transaction);
         }
     }
     if (!_renderablesToUpdate.empty()) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -222,6 +222,14 @@ void EntityTreeRenderer::updateChangedEntities(const render::ScenePointer& scene
         _renderablesToUpdate.insert({ entityId, renderable });
     }
 
+    if (!_entitiesInScene.empty()) {
+        for (const auto& entry : _entitiesInScene) {
+            const auto& renderable = entry.second;
+            if (renderable) {
+                renderable->update(scene, transaction);
+            }
+        }
+    }
     if (!_renderablesToUpdate.empty()) {
         for (const auto& entry : _renderablesToUpdate) {
             const auto& renderable = entry.second;

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -291,6 +291,18 @@ void EntityRenderer::updateInScene(const ScenePointer& scene, Transaction& trans
     });
 }
 
+void EntityRenderer::update(const ScenePointer& scene, Transaction& transaction) {
+    if (!isValidRenderItem()) {
+        return;
+    }
+
+    if (!needsUpdate()) {
+        return;
+    }
+
+    doUpdate(scene, transaction, _entity);
+}
+
 //
 // Internal methods
 //
@@ -302,6 +314,11 @@ bool EntityRenderer::needsRenderUpdate() const {
         return true;
     }
     return needsRenderUpdateFromEntity(_entity);
+}
+
+// Returns true if the item needs to have update called
+bool EntityRenderer::needsUpdate() const {
+    return needsUpdateFromEntity(_entity);
 }
 
 // Returns true if the item in question needs to have updateInScene called because of changes in the entity

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -49,6 +49,8 @@ public:
     virtual bool addToScene(const ScenePointer& scene, Transaction& transaction) final;
     virtual void removeFromScene(const ScenePointer& scene, Transaction& transaction);
 
+    virtual void update(const ScenePointer& scene, Transaction& transaction);
+
 protected:
     virtual bool needsRenderUpdateFromEntity() const final { return needsRenderUpdateFromEntity(_entity); }
     virtual void onAddToScene(const EntityItemPointer& entity);
@@ -71,6 +73,12 @@ protected:
     // Returns true if the item in question needs to have updateInScene called because of changes in the entity
     virtual bool needsRenderUpdateFromEntity(const EntityItemPointer& entity) const;
 
+    // Returns true if the item in question needs to have update called
+    virtual bool needsUpdate() const;
+
+    // Returns true if the item in question needs to have update called because of changes in the entity
+    virtual bool needsUpdateFromEntity(const EntityItemPointer& entity) const { return false; }
+
     // Will be called on the main thread from updateInScene.  This can be used to fetch things like 
     // network textures or model geometry from resource caches
     virtual void doRenderUpdateSynchronous(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) {  }
@@ -79,6 +87,8 @@ protected:
     // This function will execute on the rendering thread, so you cannot use network caches to fetch
     // data in this method if using multi-threaded rendering
     virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity);
+
+    virtual void doUpdate(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) { }
 
     // Called by the `render` method after `needsRenderUpdate`
     virtual void doRender(RenderArgs* args) = 0;
@@ -148,6 +158,15 @@ protected:
         onRemoveFromSceneTyped(_typedEntity);
     }
 
+    using Parent::needsUpdateFromEntity;
+    // Returns true if the item in question needs to have update called because of changes in the entity
+    virtual bool needsUpdateFromEntity(const EntityItemPointer& entity) const override final {
+        if (Parent::needsUpdateFromEntity(entity)) {
+            return true;
+        }
+        return needsUpdateFromTypedEntity(_typedEntity);
+    }
+
     using Parent::needsRenderUpdateFromEntity;
     // Returns true if the item in question needs to have updateInScene called because of changes in the entity
     virtual bool needsRenderUpdateFromEntity(const EntityItemPointer& entity) const override final {
@@ -162,6 +181,11 @@ protected:
         doRenderUpdateSynchronousTyped(scene, transaction, _typedEntity);
     }
 
+    virtual void doUpdate(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) override final {
+        Parent::doUpdate(scene, transaction, entity);
+        doUpdateTyped(scene, transaction, _typedEntity);
+    }
+
     virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity) override final {
         Parent::doRenderUpdateAsynchronous(entity);
         doRenderUpdateAsynchronousTyped(_typedEntity);
@@ -170,6 +194,8 @@ protected:
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const { return false; }
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) { }
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) { }
+    virtual bool needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const { return false; }
+    virtual void doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) { }
     virtual void onAddToSceneTyped(const TypedEntityPointer& entity) { }
     virtual void onRemoveFromSceneTyped(const TypedEntityPointer& entity) { }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1032,6 +1032,10 @@ bool ModelEntityRenderer::needsUpdate() const {
         model = _model;
     });
 
+    if (_modelJustLoaded) {
+        return true;
+    }
+
     if (model) {
         if (_needsJointSimulation || _moving || _animating) {
             return true;
@@ -1148,9 +1152,11 @@ void ModelEntityRenderer::doUpdateTyped(const ScenePointer& scene, Transaction& 
         return;
     }
 
+    _modelJustLoaded = false;
     // Check for addition
     if (_hasModel && !(bool)_model) {
         model = std::make_shared<Model>(nullptr, entity.get());
+        connect(model.get(), &Model::setURLFinished, this, &ModelEntityRenderer::handleModelLoaded);
         model->setLoadingPriority(EntityTreeRenderer::getEntityLoadingPriority(*entity));
         model->init();
         entity->setModel(model);
@@ -1238,6 +1244,12 @@ void ModelEntityRenderer::doUpdateTyped(const ScenePointer& scene, Transaction& 
             mapJoints(entity, model->getJointNames());
         }
         animate(entity);
+    }
+}
+
+void ModelEntityRenderer::handleModelLoaded(bool success) {
+    if (success) {
+        _modelJustLoaded = true;
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -904,7 +904,7 @@ using namespace render;
 using namespace render::entities;
 
 ItemKey ModelEntityRenderer::getKey() {
-    return ItemKey::Builder::opaqueShape().withTypeMeta();
+    return ItemKey::Builder().withTypeMeta();
 }
 
 uint32_t ModelEntityRenderer::metaFetchMetaSubItems(ItemIDs& subItems) { 
@@ -1026,7 +1026,7 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
     entity->copyAnimationJointDataToModel();
 }
 
-bool ModelEntityRenderer::needsRenderUpdate() const {
+bool ModelEntityRenderer::needsUpdate() const {
     ModelPointer model;
     withReadLock([&] {
         model = _model;
@@ -1057,10 +1057,10 @@ bool ModelEntityRenderer::needsRenderUpdate() const {
             return true;
         }
     }
-    return Parent::needsRenderUpdate();
+    return Parent::needsUpdate();
 }
 
-bool ModelEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const {
+bool ModelEntityRenderer::needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const {
     if (resultWithReadLock<bool>([&] {
         if (entity->hasModel() != _hasModel) {
             return true;
@@ -1122,7 +1122,7 @@ bool ModelEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPoin
     return false;
 }
 
-void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) {
+void ModelEntityRenderer::doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) {
     if (_hasModel != entity->hasModel()) {
         _hasModel = entity->hasModel();
     }
@@ -1175,8 +1175,8 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
         properties.setLastEdited(usecTimestampNow()); // we must set the edit time since we're editing it
         auto extents = model->getMeshExtents();
         properties.setDimensions(extents.maximum - extents.minimum);
-        qCDebug(entitiesrenderer) << "Autoresizing" 
-            << (!entity->getName().isEmpty() ?  entity->getName() : entity->getModelURL()) 
+        qCDebug(entitiesrenderer) << "Autoresizing"
+            << (!entity->getName().isEmpty() ? entity->getName() : entity->getModelURL())
             << "from mesh extents";
 
         QMetaObject::invokeMethod(DependencyManager::get<EntityScriptingInterface>().data(), "editEntity",
@@ -1202,7 +1202,6 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
     if (entity->needsUpdateModelBounds()) {
         entity->updateModelBounds();
     }
-
 
     if (model->isVisible() != _visible) {
         // FIXME: this seems like it could be optimized if we tracked our last known visible state in
@@ -1233,7 +1232,6 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
             _currentFrame = _renderAnimationProperties.getCurrentFrame();
         });
     }
-
 
     if (_animating) {
         if (!jointsMapped()) {

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -151,6 +151,7 @@ private:
     // Transparency is handled in ModelMeshPartPayload
     virtual bool isTransparent() const override { return false; }
 
+    bool _modelJustLoaded { false };
     bool _hasModel { false };
     ::ModelPointer _model;
     GeometryResource::Pointer _compoundShapeResource;
@@ -178,6 +179,9 @@ private:
     bool _animating { false };
     uint64_t _lastAnimated { 0 };
     float _currentFrame { 0 };
+
+private slots:
+    void handleModelLoaded(bool success);
 };
 
 } } // namespace 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -138,10 +138,10 @@ protected:
     virtual ItemKey getKey() override;
     virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) override;
 
-    virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
-    virtual bool needsRenderUpdate() const override;
+    virtual bool needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
+    virtual bool needsUpdate() const override;
     virtual void doRender(RenderArgs* args) override;
-    virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
+    virtual void doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
 
 private:
     void animate(const TypedEntityPointer& entity);

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -464,7 +464,7 @@ void GeometryResourceWatcher::setResource(GeometryResource::Pointer resource) {
     _resource = resource;
     if (_resource) {
         if (_resource->isLoaded()) {
-            _geometryRef = std::make_shared<Geometry>(*_resource);
+            resourceFinished(true);
         } else {
             startWatching();
         }

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -328,10 +328,18 @@ ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, in
     assert(model && model->isLoaded());
     _model = model;
     auto& modelMesh = model->getGeometry()->getMeshes().at(_meshIndex);
+    const Model::MeshState& state = model->getMeshState(_meshIndex);
 
     updateMeshPart(modelMesh, partIndex);
+    computeAdjustedLocalBound(state.clusterMatrices);
 
     updateTransform(transform, offsetTransform);
+    Transform renderTransform = transform;
+    if (state.clusterMatrices.size() == 1) {
+        renderTransform = transform.worldTransform(Transform(state.clusterMatrices[0]));
+    }
+    updateTransformForSkinnedMesh(renderTransform, transform, state.clusterBuffer);
+
     initCache();
 }
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -321,8 +321,8 @@ template <> void payloadRender(const ModelMeshPartPayload::Pointer& payload, Ren
 
 }
 
-ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int _meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform) :
-    _meshIndex(_meshIndex),
+ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform) :
+    _meshIndex(meshIndex),
     _shapeID(shapeIndex) {
 
     assert(model && model->isLoaded());

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1265,7 +1265,6 @@ void Model::createVisibleRenderItemSet() {
             shapeID++;
         }
     }
-    computeMeshPartLocalBounds();
 }
 
 void Model::createCollisionRenderItemSet() {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -209,11 +209,6 @@ void Model::updateRenderItems() {
         return;
     }
 
-    glm::vec3 scale = getScale();
-    if (_collisionGeometry) {
-        // _collisionGeometry is already scaled
-        scale = glm::vec3(1.0f);
-    }
     _needsUpdateClusterMatrices = true;
     _renderItemsNeedUpdate = false;
 
@@ -221,7 +216,7 @@ void Model::updateRenderItems() {
     // the application will ensure only the last lambda is actually invoked.
     void* key = (void*)this;
     std::weak_ptr<Model> weakSelf = shared_from_this();
-    AbstractViewStateInterface::instance()->pushPostUpdateLambda(key, [weakSelf, scale]() {
+    AbstractViewStateInterface::instance()->pushPostUpdateLambda(key, [weakSelf]() {
 
         // do nothing, if the model has already been destroyed.
         auto self = weakSelf.lock();
@@ -1219,6 +1214,7 @@ const render::ItemIDs& Model::fetchRenderItemIDs() const {
 }
 
 void Model::createRenderItemSet() {
+    updateClusterMatrices();
     if (_collisionGeometry) {
         if (_collisionRenderItems.empty()) {
             createCollisionRenderItemSet();


### PR DESCRIPTION
Fixes [FB7726](https://highfidelity.fogbugz.com/f/cases/7726/Model-entities-not-rendering-when-they-should)

Moves model loading logic from renderUpdate, which is only called when entities change, to a new RenderableEntityItem::update(), which is called as often as it is needed.  This fixes a serious bug with model loading that is hidden in master by the fact that the entity server sends entities repeatedly as your view changes.

Also, models are properly marked as just meta now, instead of meta and shape.

Also, if the model cache already contains a model file, it will still fire the finished signal.

Test plan:
- Download [the new entity server PR](https://github.com/highfidelity/hifi/pull/11141).  Run sandbox from *that PR* NOT this one.  The issue is extremely obvious with the new server logic, and rarely noticeable in master.
- Download a content set with a good number of model entities.  Make sure there are multiple models with exactly the same fbx file and at least some models that have parent model entities.  The [dev-welcome content](http://dev-welcome.highfidelity.io:8083/) is pretty good, but it would be good to test other content sets too.
- All model entities should load normally.  Reload your content (Edit -> Reload Content) while looking at one part of the domain and then turn to look behind you.  No models should be missing once all your downloads finish.
- If model A is a child of model B and you look at only model A (model B is out of view and at least several meters away) and reload content, model A should not show up.  Turn to look at model B, and then look back at model A.  Now model A should show up.
- If model A and model B have the same model file and you look at only model A (model B is out of view and at least several meters away), reload content, and wait a while so that everything has loaded, when you turn to look at model B it should appear.
- Edit a model's properties, like visible, textures, and model URL.  All changes should take effect as expected.
- Test on a server running master, like dev-welcome.  All content should appear.
- Performance smoke test.