### PR TITLE
Fix alpha on Line3DOverlays with glow

### DIFF
--- a/libraries/render-utils/src/glowLine.slf
+++ b/libraries/render-utils/src/glowLine.slf
@@ -9,7 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-layout(location = 0) in vec4 inColor;
+in vec4 _color;
+in float distanceFromCenter;
 
 out vec4 _fragColor;
 
@@ -17,10 +18,10 @@ void main(void) {
     // The incoming value actually ranges from -1 to 1, so modify it 
     // so that it goes from 0 -> 1 -> 0 with the solid alpha being at 
     // the center of the line
-    float alpha = 1.0 - abs(inColor.a);
+    float alpha = 1.0 - abs(distanceFromCenter);
     
     // Convert from a linear alpha curve to a sharp peaked one
-	alpha = pow(alpha, 10); 
+	alpha = _color.a * pow(alpha, 10);
 	
 	// Drop everything where the curve falls off to nearly nothing
     if (alpha <= 0.05) {
@@ -28,6 +29,5 @@ void main(void) {
     }
     
     // Emit the color
-    _fragColor = vec4(inColor.rgb, alpha);
-    return;
+    _fragColor = vec4(_color.rgb, alpha);
 }

--- a/libraries/render-utils/src/glowLine.slv
+++ b/libraries/render-utils/src/glowLine.slv
@@ -18,7 +18,9 @@ layout(std140) uniform lineData {
     vec4 color;
 };
 
-layout(location = 0) out vec4 _color;
+out vec4 _color;
+// the distance from the center in 'quad space'
+out float distanceFromCenter;
 
 void main(void) {
     _color = color;
@@ -45,11 +47,10 @@ void main(void) {
     // Add or subtract the orthogonal vector based on a different vertex ID 
     // calculation
     if (gl_VertexID < 2) {
-        // Use the alpha channel to store the distance from the center in 'quad space'
-        _color.a = -1.0;
+        distanceFromCenter = -1.0;
         eye.xyz -= orthogonal;
     } else {
-        _color.a = 1.0;
+        distanceFromCenter = 1.0;
         eye.xyz += orthogonal;
     }
 


### PR DESCRIPTION
Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/760eb062444763ce34b1f51ff349573f/raw/63b06ef7e7e491453be5125794f42776a2009fdd/LineAlphaTest.js).  You should see something like:
![linealpha](https://user-images.githubusercontent.com/7650116/30763083-8633bf50-9f99-11e7-91e9-6fc851e108a9.png)
