### PR TITLE
Laser Pointer fixes and updates

### DIFF
--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -184,8 +184,10 @@ void LaserPointer::disableRenderState(const RenderState& renderState) {
 
 void LaserPointer::update() {
     RayPickResult prevRayPickResult = DependencyManager::get<RayPickScriptingInterface>()->getPrevRayPickResult(_rayPickUID);
-    if (_renderingEnabled && !_currentRenderState.empty() && _renderStates.find(_currentRenderState) != _renderStates.end() && prevRayPickResult.type != IntersectionType::NONE) {
-        updateRenderState(_renderStates[_currentRenderState], prevRayPickResult.type, prevRayPickResult.distance, prevRayPickResult.objectID, prevRayPickResult.searchRay, false);
+    if (_renderingEnabled && !_currentRenderState.empty() && _renderStates.find(_currentRenderState) != _renderStates.end() &&
+            (prevRayPickResult.type != IntersectionType::NONE || _laserLength > 0.0f || !_objectLockEnd.first.isNull())) {
+        float distance = _laserLength > 0.0f ? _laserLength : prevRayPickResult.distance;
+        updateRenderState(_renderStates[_currentRenderState], prevRayPickResult.type, distance, prevRayPickResult.objectID, prevRayPickResult.searchRay, false);
         disableRenderState(_defaultRenderStates[_currentRenderState].second);
     } else if (_renderingEnabled && !_currentRenderState.empty() && _defaultRenderStates.find(_currentRenderState) != _defaultRenderStates.end()) {
         disableRenderState(_renderStates[_currentRenderState]);

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -92,8 +92,7 @@ void LaserPointer::updateRenderStateOverlay(const OverlayID& id, const QVariant&
     }
 }
 
-void LaserPointer::updateRenderState(const RenderState& renderState, const IntersectionType type, const float distance, const QUuid& objectID, const bool defaultState) {
-    PickRay pickRay = qApp->getRayPickManager().getPickRay(_rayPickUID);
+void LaserPointer::updateRenderState(const RenderState& renderState, const IntersectionType type, const float distance, const QUuid& objectID, const PickRay& pickRay, const bool defaultState) {
     if (!renderState.getStartID().isNull()) {
         QVariantMap startProps;
         startProps.insert("position", vec3toVariant(pickRay.origin));
@@ -186,11 +185,11 @@ void LaserPointer::disableRenderState(const RenderState& renderState) {
 void LaserPointer::update() {
     RayPickResult prevRayPickResult = DependencyManager::get<RayPickScriptingInterface>()->getPrevRayPickResult(_rayPickUID);
     if (_renderingEnabled && !_currentRenderState.empty() && _renderStates.find(_currentRenderState) != _renderStates.end() && prevRayPickResult.type != IntersectionType::NONE) {
-        updateRenderState(_renderStates[_currentRenderState], prevRayPickResult.type, prevRayPickResult.distance, prevRayPickResult.objectID, false);
+        updateRenderState(_renderStates[_currentRenderState], prevRayPickResult.type, prevRayPickResult.distance, prevRayPickResult.objectID, prevRayPickResult.searchRay, false);
         disableRenderState(_defaultRenderStates[_currentRenderState].second);
     } else if (_renderingEnabled && !_currentRenderState.empty() && _defaultRenderStates.find(_currentRenderState) != _defaultRenderStates.end()) {
         disableRenderState(_renderStates[_currentRenderState]);
-        updateRenderState(_defaultRenderStates[_currentRenderState].second, IntersectionType::NONE, _defaultRenderStates[_currentRenderState].first, QUuid(), true);
+        updateRenderState(_defaultRenderStates[_currentRenderState].second, IntersectionType::NONE, _defaultRenderStates[_currentRenderState].first, QUuid(), prevRayPickResult.searchRay, true);
     } else if (!_currentRenderState.empty()) {
         disableRenderState(_renderStates[_currentRenderState]);
         disableRenderState(_defaultRenderStates[_currentRenderState].second);

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -65,6 +65,7 @@ public:
     void editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps);
 
     void setPrecisionPicking(const bool precisionPicking) { DependencyManager::get<RayPickScriptingInterface>()->setPrecisionPicking(_rayPickUID, precisionPicking); }
+    void setLaserLength(const float laserLength) { _laserLength = laserLength; }
     void setIgnoreEntities(const QScriptValue& ignoreEntities) { DependencyManager::get<RayPickScriptingInterface>()->setIgnoreEntities(_rayPickUID, ignoreEntities); }
     void setIncludeEntities(const QScriptValue& includeEntities) { DependencyManager::get<RayPickScriptingInterface>()->setIncludeEntities(_rayPickUID, includeEntities); }
     void setIgnoreOverlays(const QScriptValue& ignoreOverlays) { DependencyManager::get<RayPickScriptingInterface>()->setIgnoreOverlays(_rayPickUID, ignoreOverlays); }
@@ -78,6 +79,7 @@ public:
 
 private:
     bool _renderingEnabled;
+    float _laserLength { 0.0f };
     std::string _currentRenderState { "" };
     RenderStateMap _renderStates;
     DefaultRenderStateMap _defaultRenderStates;

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -89,7 +89,7 @@ private:
     QUuid _rayPickUID;
 
     void updateRenderStateOverlay(const OverlayID& id, const QVariant& props);
-    void updateRenderState(const RenderState& renderState, const IntersectionType type, const float distance, const QUuid& objectID, const bool defaultState);
+    void updateRenderState(const RenderState& renderState, const IntersectionType type, const float distance, const QUuid& objectID, const PickRay& pickRay, const bool defaultState);
     void disableRenderState(const RenderState& renderState);
 
 };

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -87,6 +87,14 @@ void LaserPointerManager::setPrecisionPicking(QUuid uid, const bool precisionPic
     }
 }
 
+void LaserPointerManager::setLaserLength(QUuid uid, const float laserLength) {
+    QReadLocker lock(&_containsLock);
+    if (_laserPointers.contains(uid)) {
+        QWriteLocker laserLock(_laserPointerLocks[uid].get());
+        _laserPointers[uid]->setLaserLength(laserLength);
+    }
+}
+
 void LaserPointerManager::setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) {
     QReadLocker lock(&_containsLock);
     if (_laserPointers.contains(uid)) {

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -14,17 +14,19 @@ QUuid LaserPointerManager::createLaserPointer(const QVariant& rayProps, const La
     const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool enabled) {
     std::shared_ptr<LaserPointer> laserPointer = std::make_shared<LaserPointer>(rayProps, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, enabled);
     if (!laserPointer->getRayUID().isNull()) {
-        QWriteLocker lock(&_addLock);
+        QWriteLocker containsLock(&_containsLock);
         QUuid id = QUuid::createUuid();
-        _laserPointersToAdd.push(std::pair<QUuid, std::shared_ptr<LaserPointer>>(id, laserPointer));
+        _laserPointers[id] = laserPointer;
+        _laserPointerLocks[id] = std::make_shared<QReadWriteLock>();
         return id;
     }
     return QUuid();
 }
 
 void LaserPointerManager::removeLaserPointer(const QUuid uid) {
-    QWriteLocker lock(&_removeLock);
-    _laserPointersToRemove.push(uid);
+    QWriteLocker lock(&_containsLock);
+    _laserPointers.remove(uid);
+    _laserPointerLocks.remove(uid);
 }
 
 void LaserPointerManager::enableLaserPointer(const QUuid uid) {
@@ -69,31 +71,11 @@ const RayPickResult LaserPointerManager::getPrevRayPickResult(const QUuid uid) {
 }
 
 void LaserPointerManager::update() {
+    QReadLocker lock(&_containsLock);
     for (QUuid& uid : _laserPointers.keys()) {
         // This only needs to be a read lock because update won't change any of the properties that can be modified from scripts
         QReadLocker laserLock(_laserPointerLocks[uid].get());
         _laserPointers[uid]->update();
-    }
-
-    QWriteLocker containsLock(&_containsLock);
-    {
-        QWriteLocker lock(&_addLock);
-        while (!_laserPointersToAdd.empty()) {
-            std::pair<QUuid, std::shared_ptr<LaserPointer>> laserPointerToAdd = _laserPointersToAdd.front();
-            _laserPointersToAdd.pop();
-            _laserPointers[laserPointerToAdd.first] = laserPointerToAdd.second;
-            _laserPointerLocks[laserPointerToAdd.first] = std::make_shared<QReadWriteLock>();
-        }
-    }
-
-    {
-        QWriteLocker lock(&_removeLock);
-        while (!_laserPointersToRemove.empty()) {
-            QUuid uid = _laserPointersToRemove.front();
-            _laserPointersToRemove.pop();
-            _laserPointers.remove(uid);
-            _laserPointerLocks.remove(uid);
-        }
     }
 }
 

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -46,10 +46,6 @@ public:
 private:
     QHash<QUuid, std::shared_ptr<LaserPointer>> _laserPointers;
     QHash<QUuid, std::shared_ptr<QReadWriteLock>> _laserPointerLocks;
-    QReadWriteLock _addLock;
-    std::queue<std::pair<QUuid, std::shared_ptr<LaserPointer>>> _laserPointersToAdd;
-    QReadWriteLock _removeLock;
-    std::queue<QUuid> _laserPointersToRemove;
     QReadWriteLock _containsLock;
 
 };

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -32,6 +32,7 @@ public:
     const RayPickResult getPrevRayPickResult(const QUuid uid);
 
     void setPrecisionPicking(QUuid uid, const bool precisionPicking);
+    void setLaserLength(QUuid uid, const float laserLength);
     void setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities);
     void setIncludeEntities(QUuid uid, const QScriptValue& includeEntities);
     void setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays);

--- a/interface/src/raypick/LaserPointerScriptingInterface.h
+++ b/interface/src/raypick/LaserPointerScriptingInterface.h
@@ -31,6 +31,7 @@ public slots:
     Q_INVOKABLE RayPickResult getPrevRayPickResult(QUuid uid) { return qApp->getLaserPointerManager().getPrevRayPickResult(uid); }
 
     Q_INVOKABLE void setPrecisionPicking(QUuid uid, const bool precisionPicking) { qApp->getLaserPointerManager().setPrecisionPicking(uid, precisionPicking); }
+    Q_INVOKABLE void setLaserLength(QUuid uid, const float laserLength) { qApp->getLaserPointerManager().setLaserLength(uid, laserLength); }
     Q_INVOKABLE void setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) { qApp->getLaserPointerManager().setIgnoreEntities(uid, ignoreEntities); }
     Q_INVOKABLE void setIncludeEntities(QUuid uid, const QScriptValue& includeEntities) { qApp->getLaserPointerManager().setIncludeEntities(uid, includeEntities); }
     Q_INVOKABLE void setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays) { qApp->getLaserPointerManager().setIgnoreOverlays(uid, ignoreOverlays); }

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -70,6 +70,9 @@ public:
         if (doesPickNonCollidable()) {
             toReturn |= getBitMask(PICK_INCLUDE_NONCOLLIDABLE);
         }
+        if (doesPickCourse()) {
+            toReturn |= getBitMask(PICK_COURSE);
+        }
         return Flags(toReturn);
     }
     Flags getOverlayFlags() const {
@@ -79,6 +82,9 @@ public:
         }
         if (doesPickNonCollidable()) {
             toReturn |= getBitMask(PICK_INCLUDE_NONCOLLIDABLE);
+        }
+        if (doesPickCourse()) {
+            toReturn |= getBitMask(PICK_COURSE);
         }
         return Flags(toReturn);
     }

--- a/interface/src/raypick/RayPickManager.h
+++ b/interface/src/raypick/RayPickManager.h
@@ -28,7 +28,6 @@ class RayPickManager {
 
 public:
     void update();
-    const PickRay getPickRay(const QUuid uid);
 
     QUuid createRayPick(const std::string& jointName, const glm::vec3& posOffset, const glm::vec3& dirOffset, const RayPickFilter& filter, const float maxDistance, const bool enabled);
     QUuid createRayPick(const RayPickFilter& filter, const float maxDistance, const bool enabled);
@@ -49,10 +48,6 @@ public:
 private:
     QHash<QUuid, std::shared_ptr<RayPick>> _rayPicks;
     QHash<QUuid, std::shared_ptr<QReadWriteLock>> _rayPickLocks;
-    QReadWriteLock _addLock;
-    std::queue<std::pair<QUuid, std::shared_ptr<RayPick>>> _rayPicksToAdd;
-    QReadWriteLock _removeLock;
-    std::queue<QUuid> _rayPicksToRemove;
     QReadWriteLock _containsLock;
 
     typedef QHash<QPair<glm::vec3, glm::vec3>, std::unordered_map<RayPickFilter::Flags, RayPickResult>> RayPickCache;

--- a/libraries/shared/src/RegisteredMetaTypes.cpp
+++ b/libraries/shared/src/RegisteredMetaTypes.cpp
@@ -762,6 +762,8 @@ QScriptValue rayPickResultToScriptValue(QScriptEngine* engine, const RayPickResu
     QScriptValue intersection = vec3toScriptValue(engine, rayPickResult.intersection);
     obj.setProperty("intersection", intersection);
     obj.setProperty("intersects", rayPickResult.type != NONE);
+    QScriptValue searchRay = pickRayToScriptValue(engine, rayPickResult.searchRay);
+    obj.setProperty("searchRay", searchRay);
     QScriptValue surfaceNormal = vec3toScriptValue(engine, rayPickResult.surfaceNormal);
     obj.setProperty("surfaceNormal", surfaceNormal);
     return obj;

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -137,7 +137,7 @@ QScriptValue pickRayToScriptValue(QScriptEngine* engine, const PickRay& pickRay)
 void pickRayFromScriptValue(const QScriptValue& object, PickRay& pickRay);
 
 enum IntersectionType {
-    NONE,
+    NONE = 0,
     ENTITY,
     OVERLAY,
     AVATAR,
@@ -147,12 +147,14 @@ enum IntersectionType {
 class RayPickResult {
 public:
     RayPickResult() {}
-    RayPickResult(const IntersectionType type, const QUuid& objectID, const float distance, const glm::vec3& intersection, const glm::vec3& surfaceNormal = glm::vec3(NAN)) :
-        type(type), objectID(objectID), distance(distance), intersection(intersection), surfaceNormal(surfaceNormal) {}
+    RayPickResult(const PickRay& searchRay) : searchRay(searchRay) {}
+    RayPickResult(const IntersectionType type, const QUuid& objectID, const float distance, const glm::vec3& intersection, const PickRay& searchRay, const glm::vec3& surfaceNormal = glm::vec3(NAN)) :
+        type(type), objectID(objectID), distance(distance), intersection(intersection), searchRay(searchRay), surfaceNormal(surfaceNormal) {}
     IntersectionType type { NONE };
-    QUuid objectID { 0 };
+    QUuid objectID;
     float distance { FLT_MAX };
     glm::vec3 intersection { NAN };
+    PickRay searchRay;
     glm::vec3 surfaceNormal { NAN };
 };
 Q_DECLARE_METATYPE(RayPickResult)


### PR DESCRIPTION
- Ray pick results now include the searchRay (origin and direction)
- Fixes a bug with precision picking
- Laser pointer creation happens on the thread you create the laser pointer from instead of being deferred to the main thread.  This fixes an issue where you couldn't edit a laser pointer immediately after creating it.
- Adds LaserPointers.setLaserLength to override the laser pointer length.  Set it <= 0.0 to disable the override.
- Fixes setLockEndUUID to only use the renderState, never the defaultRenderState.

Test plan:
- Laser pointers in default scripts (teleport, hand lasers) should still work.
- Run [this](https://gist.githubusercontent.com/SamGondelman/26abff5da64503df321254c8a846536b/raw/6823a83391936040f76ab7bf4f97d2ff67ecf475/LaserPointerTest5.js).  A sphere should follow your mouse and intersect with everything.  The color of the sphere should change as you rotate (if it's hitting something.  If it doesn't hit anything, it will be pink.).
- Press 1 to toggle precision picking (should be noticeable on models with complex geometry).
- Press 2 to toggle a demo of setLaserLength.  The sphere will change distance from you according to a function in the script.  It will not turn pink when you aren't intersecting anything.
- Hover over an entity and press 3.  The sphere will lock on to the center of that entity.  Pressing 2 will not affect the laser.  While it is locked, point your mouse so it isn't intersecting anything.  The sphere shouldn't turn pink, it should keep changing colors as your direction changes.  Press 3 again to disable locking.