### PR TITLE
Fix pointer event properties

### DIFF
--- a/libraries/shared/src/PointerEvent.cpp
+++ b/libraries/shared/src/PointerEvent.cpp
@@ -77,13 +77,13 @@ QScriptValue PointerEvent::toScriptValue(QScriptEngine* engine, const PointerEve
     normal.setProperty("x", event._normal.x);
     normal.setProperty("y", event._normal.y);
     normal.setProperty("z", event._normal.z);
-    obj.setProperty("pos3D", normal);
+    obj.setProperty("normal", normal);
 
     QScriptValue direction = engine->newObject();
     direction.setProperty("x", event._direction.x);
     direction.setProperty("y", event._direction.y);
     direction.setProperty("z", event._direction.z);
-    obj.setProperty("pos3D", direction);
+    obj.setProperty("direction", direction);
 
     bool isPrimaryButton = false;
     bool isSecondaryButton = false;


### PR DESCRIPTION
Fixes https://github.com/highfidelity/hifi/issues/10226

Test plan:
- Create an entity and attach [this script](https://gist.githubusercontent.com/SamGondelman/544e0a9cd3320e4ced5b5ae64d66da90/raw/721ec475c353a05bc2a3150e0b7d95e60c2077df/PointerEventTest.js) to it.
- When you hover over the entity, the pos3D, normal, and direction of the PointerEvent should be printed in the logs.  Confirm that these values seem correct.