### PR TITLE
Experimental Fix: Entity Shader Lightmap use / emissive

### DIFF
--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -75,7 +75,7 @@ void main(void) {
                 max(0, 1.0 - shininess / 128.0),
                 DEFAULT_METALLIC,
                 specular,
-                specular);
+                vec3(clamp(emissiveAmount, 0.0, 1.0)));
         } else {
             packDeferredFragment(
                 normal,


### PR DESCRIPTION
![](http://i3.kym-cdn.com/photos/images/facebook/000/234/739/fa5.jpg)

Another fun little Experimental Non-Worklist Engine Shader update! 
Much more simpler than previous, and more of a fix than anything.

- Fixes issue with Shader Specular being used as emission map
- Fixes issue with Shader emission being completely unused.

## Test Case
1. https://highfidelity.com/marketplace/items/1487ff47-1c2b-438b-826f-734afed6a297 and create the shader onto the ground.
2. Activate debugDeferredLighting.js that is provided with the client.
3. Goto a dark domain.
4. Switch debugDeferred mode to Lightmap. 
5. Change uEmit of jumping fox value from 0 to 1. Shader should turn from black to white.






