### PR TITLE
7877 Unexpected Behavior when pressing Enter on Input Field

### DIFF
--- a/interface/resources/qml/controls-uit/Keyboard.qml
+++ b/interface/resources/qml/controls-uit/Keyboard.qml
@@ -116,6 +116,13 @@ Item {
             wrapMode: Text.WordWrap
             readOnly: false // we need to leave this property read-only to allow control to accept QKeyEvent
             selectByMouse: false
+
+            Keys.onPressed: {
+                if (event.key == Qt.Key_Return) {
+                    mirrorText.text = "";
+                    event.accepted = true;
+                }
+            }
         }
 
         MouseArea { // ... and we need this mouse area to prevent mirrorText from getting mouse events to ensure it will never get focus


### PR DESCRIPTION
**Test plan**

1. In HMD mode with tablet, go to Marketplace
2. Click on the search field
3. With the keyboard, type "tree" and press the "Enter" key.

_before the fix:_ 
The page refreshes with a search for "tree", but the input field above the keyboard on the tablet says "tree" and has a new line.

_after the fix:_ 
The input field above the keyboard on the tablet becomes blank.
