### PR TITLE
Don't constantly reload animGraph if URL didn't change

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1619,28 +1619,30 @@ void Rig::updateFromControllerParameters(const ControllerParameters& params, flo
 }
 
 void Rig::initAnimGraph(const QUrl& url) {
-    _animGraphURL = url;
+    if (_animGraphURL != url) {
+        _animGraphURL = url;
 
-    _animNode.reset();
+        _animNode.reset();
 
-    // load the anim graph
-    _animLoader.reset(new AnimNodeLoader(url));
-    connect(_animLoader.get(), &AnimNodeLoader::success, [this](AnimNode::Pointer nodeIn) {
-        _animNode = nodeIn;
-        _animNode->setSkeleton(_animSkeleton);
+        // load the anim graph
+        _animLoader.reset(new AnimNodeLoader(url));
+        connect(_animLoader.get(), &AnimNodeLoader::success, [this](AnimNode::Pointer nodeIn) {
+            _animNode = nodeIn;
+            _animNode->setSkeleton(_animSkeleton);
 
-        if (_userAnimState.clipNodeEnum != UserAnimState::None) {
-            // restore the user animation we had before reset.
-            UserAnimState origState = _userAnimState;
-            _userAnimState = { UserAnimState::None, "", 30.0f, false, 0.0f, 0.0f };
-            overrideAnimation(origState.url, origState.fps, origState.loop, origState.firstFrame, origState.lastFrame);
-        }
+            if (_userAnimState.clipNodeEnum != UserAnimState::None) {
+                // restore the user animation we had before reset.
+                UserAnimState origState = _userAnimState;
+                _userAnimState = { UserAnimState::None, "", 30.0f, false, 0.0f, 0.0f };
+                overrideAnimation(origState.url, origState.fps, origState.loop, origState.firstFrame, origState.lastFrame);
+            }
 
-        emit onLoadComplete();
-    });
-    connect(_animLoader.get(), &AnimNodeLoader::error, [url](int error, QString str) {
-        qCCritical(animation) << "Error loading" << url.toDisplayString() << "code = " << error << "str =" << str;
-    });
+            emit onLoadComplete();
+        });
+        connect(_animLoader.get(), &AnimNodeLoader::error, [url](int error, QString str) {
+            qCCritical(animation) << "Error loading" << url.toDisplayString() << "code = " << error << "str =" << str;
+        });
+    }
 }
 
 bool Rig::getModelRegistrationPoint(glm::vec3& modelRegistrationPointOut) const {


### PR DESCRIPTION
Possible fix for [FB7882](https://highfidelity.fogbugz.com/f/cases/7882/T-Pose-when-Switching-from-HMD-to-Desktop).

`MyAvatar::postUpdate` polls for the initialization of the skeleton model rig animation node and calls `initAnimGraph()` if it isn't loaded.  That calls `_skeletonModel->getRig().initAnimGraph(graphUrl)`, which would constantly reset the _animLoader.  If the _animLoader hadn't finished downloading, the success signal would never be fired, so you'd be stuck in a T-pose and the logs would fill with `Starting request for: file:///C:/Users/[User]/src/hifi/build/interface/Release/resources/avatar/avatar-animation.json`.

Now, the _animLoader is only reset if the url has changed, so the success signal will have time to fire.

Test plan:
- With a Rift, repeatedly put on and take off your headset. maybe 20 or so times.  At no point should your avatar be stuck in a T-Pose.
- Your logs shouldn't fill up with `Starting request for: file:///C:/Users/[User]/src/hifi/build/interface/Release/resources/avatar/avatar-animation.json`.