### PR TITLE
7926 Create Mode: the keyboard tray is not styled correctly

### DIFF
--- a/interface/resources/qml/controls-uit/Keyboard.qml
+++ b/interface/resources/qml/controls-uit/Keyboard.qml
@@ -11,8 +11,13 @@
 import QtQuick 2.0
 import "."
 
-Item {
+Rectangle {
     id: keyboardBase
+
+    anchors.left: parent.left
+    anchors.right: parent.right
+
+    color: "#252525"
 
     property bool raised: false
     property bool numeric: false
@@ -105,6 +110,7 @@ Item {
         height: showMirrorText ? mirrorTextHeight : 0
         width: keyboardWidth
         color: "#252525"
+        anchors.horizontalCenter: parent.horizontalCenter
 
         TextEdit {
             id: mirrorText


### PR DESCRIPTION
**Test plan**

0. Switch to VR. 
1. Open tablet, go to the 'create'
2. Select any text field with as stylus to make keyboard appear
3. Ensure keyboard is styled correctly (see sample of incorrect styling below)

![image](https://user-images.githubusercontent.com/23638/30931025-2585a6a0-a3cc-11e7-925e-4c696c5a3819.png)

4. Go to the 'market' 
5. Select the search input field with a stylus to make keyboard appear
6. Ensure keyboard is styled correctly 
7. Type in "robot" and hit enter. Make sure it goes to the next screen correctly and the input field gets cleared.