### PR TITLE
7925 Create Mode: keyboard focused entry field is not visible

### DIFF
--- a/interface/resources/html/raiseAndLowerKeyboard.js
+++ b/interface/resources/html/raiseAndLowerKeyboard.js
@@ -37,6 +37,19 @@
         return document.activeElement.type === "number";
     };
 
+    function scheduleBringToView(timeout) {
+
+        var timer = setTimeout(function () {
+            clearTimeout(timer);
+
+            var elementRect = document.activeElement.getBoundingClientRect();
+            var absoluteElementTop = elementRect.top + window.scrollY;
+            var middle = absoluteElementTop - (window.innerHeight / 2);
+
+            window.scrollTo(0, middle);
+        }, timeout);
+    }
+
     setInterval(function () {
         var keyboardRaised = shouldRaiseKeyboard();
         var numericKeyboard = shouldSetNumeric();
@@ -55,21 +68,20 @@
             }
 
             if (!isKeyboardRaised) {
-                var timeout = setTimeout(function () {
-                    clearTimeout(timeout);
-
-                    var elementRect = document.activeElement.getBoundingClientRect();
-                    var absoluteElementTop = elementRect.top + window.scrollY;
-                    var middle = absoluteElementTop - (window.innerHeight / 2);
-
-                    window.scrollTo(0, middle);
-                }, 500);  // Allow time for keyboard to be raised in QML.
+                scheduleBringToView(500); // Allow time for keyboard to be raised in QML.
             }
 
             isKeyboardRaised = keyboardRaised;
             isNumericKeyboard = numericKeyboard;
         }
     }, POLL_FREQUENCY);
+
+    window.addEventListener("click", function () {
+        var keyboardRaised = shouldRaiseKeyboard();
+        if(keyboardRaised && isKeyboardRaised) {
+            scheduleBringToView(150);
+        }
+    });
 
     window.addEventListener("focus", function () {
         isWindowFocused = true;

--- a/interface/resources/html/raiseAndLowerKeyboard.js
+++ b/interface/resources/html/raiseAndLowerKeyboard.js
@@ -68,7 +68,8 @@
             }
 
             if (!isKeyboardRaised) {
-                scheduleBringToView(500); // Allow time for keyboard to be raised in QML.
+                scheduleBringToView(250); // Allow time for keyboard to be raised in QML.
+                                          // 2DO: should it be rather done from 'client area height changed' event?
             }
 
             isKeyboardRaised = keyboardRaised;

--- a/interface/resources/html/raiseAndLowerKeyboard.js
+++ b/interface/resources/html/raiseAndLowerKeyboard.js
@@ -14,7 +14,6 @@
     var isWindowFocused = true;
     var isKeyboardRaised = false;
     var isNumericKeyboard = false;
-    var KEYBOARD_HEIGHT = 200;
 
     function shouldRaiseKeyboard() {
         var nodeName = document.activeElement.nodeName;
@@ -56,13 +55,15 @@
             }
 
             if (!isKeyboardRaised) {
-                var delta = document.activeElement.getBoundingClientRect().bottom + 10
-                    - (document.body.clientHeight - KEYBOARD_HEIGHT);
-                if (delta > 0) {
-                    setTimeout(function () {
-                        document.body.scrollTop += delta;
-                    }, 500);  // Allow time for keyboard to be raised in QML.
-                }
+                var timeout = setTimeout(function () {
+                    clearTimeout(timeout);
+
+                    var elementRect = document.activeElement.getBoundingClientRect();
+                    var absoluteElementTop = elementRect.top + window.scrollY;
+                    var middle = absoluteElementTop - (window.innerHeight / 2);
+
+                    window.scrollTo(0, middle);
+                }, 500);  // Allow time for keyboard to be raised in QML.
             }
 
             isKeyboardRaised = keyboardRaised;


### PR DESCRIPTION
note: changed the way of calculation scroll value after showing virtual keyboard.
Now it doesn't require KEYBOARD_HEGHT and will always try to position focused element at vertical center of the client area

**Test plan**

1. Open tablet
2. Go to the different pages in 'Create' 
3. Select different text fields. 
4. Ensure focused element always scrolls at the vertical center of the available area when virtual keyboard appears. 
5. Check scrolling on the Create app and other apps to make sure nothing is broken