### PR TITLE
Added workaround to enable menu bar under Linux

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -49,6 +49,10 @@ int main(int argc, const char* argv[]) {
     CrashReporter crashReporter { BUG_SPLAT_DATABASE, BUG_SPLAT_APPLICATION_NAME, BuildInfo::VERSION };
 #endif
 
+#ifdef Q_OS_UNIX
+    QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar);
+#endif
+
     disableQtBearerPoll(); // Fixes wifi ping spikes
 
     QElapsedTimer startupTime;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, const char* argv[]) {
     CrashReporter crashReporter { BUG_SPLAT_DATABASE, BUG_SPLAT_APPLICATION_NAME, BuildInfo::VERSION };
 #endif
 
-#ifdef Q_OS_UNIX
+#ifdef Q_OS_LINUX
     QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar);
 #endif
 


### PR DESCRIPTION
This commit enables MenuBar under Linux
Affects only Linux builds

Test plan:
- Run Linux built Interface app
- Make sure Menu bar visible and operational