### PR TITLE
Bugfix: edit.js dialog callback events stacking up

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1474,6 +1474,8 @@ function onFileSaveChanged(filename) {
 }
 
 function onFileOpenChanged(filename) {
+    // disconnect the event, otherwise the requests will stack up
+    Window.openFileChanged.disconnect(onFileOpenChanged);
     var importURL = null;
     if (filename !== "") {
         importURL = "file:///" + filename;


### PR DESCRIPTION
Every time a dialog opened in edit.js a new callback is created, which wasn't disconnected after the event happened, this caused lots of entities to be created after each next import.

Internal bug case: https://highfidelity.fogbugz.com/f/cases/7993

## QA 
1.  Save https://hifi-content.s3.amazonaws.com/rebecca/blackHat.json from the internet (using your regular web-browser)
2. Open Create
3. Go to the create tab and click on `import entities (.json)`
4. Import blackHat.json
5. go to the entities list, only one (extra) `Black Hat` should appear
6. repeat step 3 to 5 a couple of times, make sure only one `Black Hat` gets added every time that it runs.