### PR TITLE
Fix entity add after incomplete rezCertified implementation

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1148,11 +1148,8 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                     } else if (!senderNode->getCanRez() && !senderNode->getCanRezTmp()) {
                         failedAdd = true;
                         qCDebug(entities) << "User without 'rez rights' [" << senderNode->getUUID()
-                            << "] attempted to add an entity ID:" << entityItemID;
-                    // FIXME after Cert ID property integrated        
-                    } else if (/*!properties.getCertificateID().isNull() && */!senderNode->getCanRezCertified() && !senderNode->getCanRezTmpCertified()) {
-                        qCDebug(entities) << "User without 'certified rez rights' [" << senderNode->getUUID()
-                            << "] attempted to add a certified entity with ID:" << entityItemID;
+                                          << "] attempted to add an entity ID:" << entityItemID;
+
                     } else {
                         // this is a new entity... assign a new entityID
                         properties.setCreated(properties.getLastEdited());


### PR DESCRIPTION
Reverting a piece of code that wasn't meant to be there in the first place, since the Cert ID property of entities doesn't exist yet.

*Test Plan*
1. Have Avatar A and Avatar B enter Sandbox A. Both should have at least rez/temp rez rights.
2. Have Avatar A spawn a sphere. Ensure Avatar A and Avatar B can see it.
3. Have Avatar B spawn a cube. Ensure Avatar A and Avatar B can see it.
4. Have Avatar B spawn something from the Marketplace. Ensure Avatar A and Avatar B can see it.

Sorry.