### PR TITLE
Oculus: Bug fix for head offset on large/small scaled avatars.

### DIFF
--- a/plugins/oculus/src/OculusControllerManager.cpp
+++ b/plugins/oculus/src/OculusControllerManager.cpp
@@ -334,10 +334,8 @@ void OculusControllerManager::TouchDevice::handleHeadPose(float deltaTime,
     glm::mat4 defaultHeadOffset = glm::inverse(inputCalibrationData.defaultCenterEyeMat) *
         inputCalibrationData.defaultHeadMat;
 
-    controller::Pose hmdHeadPose = pose.transform(sensorToAvatar);
-
     pose.valid = true;
-    _poseStateMap[controller::HEAD] = hmdHeadPose.postTransform(defaultHeadOffset);
+    _poseStateMap[controller::HEAD] = pose.postTransform(defaultHeadOffset).transform(sensorToAvatar);
 }
 
 void OculusControllerManager::TouchDevice::handleRotationForUntrackedHand(const controller::InputCalibrationData& inputCalibrationData,


### PR DESCRIPTION
The offset from the center of the eyes, given by the oculus HMD position to the actual avatar head, was scaled incorrectly, when the sensorToWorld matrix scale was large or small.