### PR TITLE
Remove mouse area for text fields. use activeFocusOnPress property in…

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -76,20 +76,14 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: "enter current passphrase";
+        activeFocusOnPress: true
+        activeFocusOnTab: true
 
         onFocusChanged: {
             if (focus) {
                 sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
             } else if (!passphraseFieldAgain.focus) {
                 sendSignalToWallet({method: 'walletSetup_lowerKeyboard'});
-            }
-        }
-
-        MouseArea {
-            anchors.fill: parent;
-            onClicked: {
-                parent.focus = true;
-                sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
             }
         }
 
@@ -109,20 +103,14 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: root.isShowingTip ? "" : "enter new passphrase";
+        activeFocusOnPress: true
+        activeFocusOnTab: true
 
         onFocusChanged: {
             if (focus) {
                 sendMessageToLightbox({method: 'walletSetup_raiseKeyboard'});
             } else if (!passphraseFieldAgain.focus) {
                 sendMessageToLightbox({method: 'walletSetup_lowerKeyboard'});
-            }
-        }
-
-        MouseArea {
-            anchors.fill: parent;
-            onClicked: {
-                parent.focus = true;
-                sendMessageToLightbox({method: 'walletSetup_raiseKeyboard'});
             }
         }
 
@@ -140,20 +128,14 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: root.isShowingTip ? "" : "re-enter new passphrase";
+        activeFocusOnPress: true
+        activeFocusOnTab: true
 
         onFocusChanged: {
             if (focus) {
                 sendMessageToLightbox({method: 'walletSetup_raiseKeyboard'});
             } else if (!passphraseField.focus) {
                 sendMessageToLightbox({method: 'walletSetup_lowerKeyboard'});
-            }
-        }
-
-        MouseArea {
-            anchors.fill: parent;
-            onClicked: {
-                parent.focus = true;
-                sendMessageToLightbox({method: 'walletSetup_raiseKeyboard'});
             }
         }
 

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -88,10 +88,10 @@ Item {
         }
 
         MouseArea {
-            anchors.fill: parent
+            anchors.fill: parent;
             onPressed: {
                 sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
-                mouse.accepted = false
+                mouse.accepted = false;
             }
         }
 
@@ -115,10 +115,10 @@ Item {
         activeFocusOnTab: true;
 
         MouseArea {
-            anchors.fill: parent
+            anchors.fill: parent;
             onPressed: {
                 sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
-                mouse.accepted = false
+                mouse.accepted = false;
             }
         }
 
@@ -149,10 +149,10 @@ Item {
         activeFocusOnTab: true;
 
         MouseArea {
-            anchors.fill: parent
+            anchors.fill: parent;
             onPressed: {
                 sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
-                mouse.accepted = false
+                mouse.accepted = false;
             }
         }
 

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -76,8 +76,8 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: "enter current passphrase";
-        activeFocusOnPress: true
-        activeFocusOnTab: true
+        activeFocusOnPress: true;
+        activeFocusOnTab: true;
 
         onFocusChanged: {
             if (focus) {
@@ -103,8 +103,8 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: root.isShowingTip ? "" : "enter new passphrase";
-        activeFocusOnPress: true
-        activeFocusOnTab: true
+        activeFocusOnPress: true;
+        activeFocusOnTab: true;
 
         onFocusChanged: {
             if (focus) {
@@ -128,8 +128,8 @@ Item {
         height: 50;
         echoMode: TextInput.Password;
         placeholderText: root.isShowingTip ? "" : "re-enter new passphrase";
-        activeFocusOnPress: true
-        activeFocusOnTab: true
+        activeFocusOnPress: true;
+        activeFocusOnTab: true;
 
         onFocusChanged: {
             if (focus) {

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -87,6 +87,14 @@ Item {
             }
         }
 
+        MouseArea {
+            anchors.fill: parent
+            onPressed: {
+                sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
+                mouse.accepted = false
+            }
+        }
+
         onAccepted: {
             passphraseField.focus = true;
         }
@@ -106,6 +114,14 @@ Item {
         activeFocusOnPress: true;
         activeFocusOnTab: true;
 
+        MouseArea {
+            anchors.fill: parent
+            onPressed: {
+                sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
+                mouse.accepted = false
+            }
+        }
+
         onFocusChanged: {
             if (focus) {
                 sendMessageToLightbox({method: 'walletSetup_raiseKeyboard'});
@@ -118,6 +134,7 @@ Item {
             passphraseFieldAgain.focus = true;
         }
     }
+
     HifiControlsUit.TextField {
         id: passphraseFieldAgain;
         colorScheme: hifi.colorSchemes.dark;
@@ -130,6 +147,14 @@ Item {
         placeholderText: root.isShowingTip ? "" : "re-enter new passphrase";
         activeFocusOnPress: true;
         activeFocusOnTab: true;
+
+        MouseArea {
+            anchors.fill: parent
+            onPressed: {
+                sendSignalToWallet({method: 'walletSetup_raiseKeyboard'});
+                mouse.accepted = false
+            }
+        }
 
         onFocusChanged: {
             if (focus) {


### PR DESCRIPTION
…stead

Based on: https://highfidelity.fogbugz.com/f/cases/7973/Keyboard-focus-problems-within-Tablet-HUD

Test 
- Enable Commerce as described in the case
- Try to setup Wallet in Desktop mode
- on step 3 of 4 with "Got it" button 1st press outside wallet setup window (loose focus)
- Press "Got it"
- Press inside password input fileds
- Make sure input fields gained focus

