### PR TITLE
Disable watchdog with environment variable

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -289,6 +289,10 @@ static QTimer locationUpdateTimer;
 static QTimer identityPacketTimer;
 static QTimer pingTimer;
 
+static const QString DISABLE_WATCHDOG_FLAG("HIFI_DISABLE_WATCHDOG");
+static bool DISABLE_WATCHDOG = QProcessEnvironment::systemEnvironment().contains(DISABLE_WATCHDOG_FLAG);
+
+
 static const int MAX_CONCURRENT_RESOURCE_DOWNLOADS = 16;
 
 // For processing on QThreadPool, we target a number of threads after reserving some
@@ -805,8 +809,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     nodeList->startThread();
 
     // Set up a watchdog thread to intentionally crash the application on deadlocks
-    _deadlockWatchdogThread = new DeadlockWatchdogThread();
-    _deadlockWatchdogThread->start();
+    if (!DISABLE_WATCHDOG) {
+        (new DeadlockWatchdogThread())->start();
+    }
 
     if (steamClient) {
         qCDebug(interfaceapp) << "[VERSION] SteamVR buildID:" << steamClient->getSteamVRBuildID();
@@ -1933,7 +1938,7 @@ void Application::showCursor(const Cursor::Icon& cursor) {
 }
 
 void Application::updateHeartbeat() const {
-    static_cast<DeadlockWatchdogThread*>(_deadlockWatchdogThread)->updateHeartbeat();
+    DeadlockWatchdogThread::updateHeartbeat();
 }
 
 void Application::onAboutToQuit() {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -650,8 +650,6 @@ private:
     Qt::CursorShape _desiredCursor{ Qt::BlankCursor };
     bool _cursorNeedsChanging { false };
 
-    QThread* _deadlockWatchdogThread;
-
     std::map<void*, std::function<void()>> _postUpdateLambdas;
     std::mutex _postUpdateLambdasLock;
 


### PR DESCRIPTION
Allows the watchdog to be disabled with an environment variable `HIFI_DISABLE_WATCHDOG`.  This is primarily for developers who want to be able to disable the watchdog so it doesn't trigger from hitting breakpoints while debugging.  

## Testing 

With the master build, if you go into the developer menu and select 'crash' and then 'deadlock interface' the application will stop responding and eventually you will see a bugsplat window.  However, if you set a `HIFI_DISABLE_WATCHDOG` environment variable, in this PR, deadlocking interface in the same way should not trigger a crash.  You will however have to use the task manager to kill interface.