### PR TITLE
[experiment/feedback] Include script name with all JS/QML debug output

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -107,10 +107,13 @@ static QScriptValue debugPrint(QScriptContext* context, QScriptEngine* engine) {
         }
         message += context->argument(i).toString();
     }
-    qCDebug(scriptengineScript).noquote() << message;  // noquote() so that \n is treated as newline
 
     if (ScriptEngine *scriptEngine = qobject_cast<ScriptEngine*>(engine)) {
         scriptEngine->print(message);
+        // prefix the script engine name to help disambiguate messages in the main debug log
+        qCDebug(scriptengineScript, "[%s] %s", qUtf8Printable(scriptEngine->getFilename()), qUtf8Printable(message));
+    } else {
+        qCDebug(scriptengineScript, "%s", qUtf8Printable(message));
     }
 
     return QScriptValue();
@@ -465,22 +468,22 @@ void ScriptEngine::loadURL(const QUrl& scriptURL, bool reload) {
 }
 
 void ScriptEngine::scriptErrorMessage(const QString& message) {
-    qCCritical(scriptengine) << qPrintable(message);
+    qCCritical(scriptengine, "[%s] %s", qUtf8Printable(getFilename()), qUtf8Printable(message));
     emit errorMessage(message, getFilename());
 }
 
 void ScriptEngine::scriptWarningMessage(const QString& message) {
-    qCWarning(scriptengine) << qPrintable(message);
+    qCWarning(scriptengine, "[%s] %s", qUtf8Printable(getFilename()), qUtf8Printable(message));
     emit warningMessage(message, getFilename());
 }
 
 void ScriptEngine::scriptInfoMessage(const QString& message) {
-    qCInfo(scriptengine) << qPrintable(message);
+    qCInfo(scriptengine, "[%s] %s", qUtf8Printable(getFilename()), qUtf8Printable(message));
     emit infoMessage(message, getFilename());
 }
 
 void ScriptEngine::scriptPrintedMessage(const QString& message) {
-    qCDebug(scriptengine) << qPrintable(message);
+    qCDebug(scriptengine, "[%s] %s", qUtf8Printable(getFilename()), qUtf8Printable(message));
     emit printedMessage(message, getFilename());
 }
 

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -177,6 +177,13 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
         prefixString.append(QString(" [%1]").arg(_targetName));
     }
 
+    // for [qml] console.* messages include an abbreviated source filename
+    if (context.category && context.file && !strcmp("qml", context.category)) {
+        if (const char* basename = strrchr(context.file, '/')) {
+            prefixString.append(QString(" [%1]").arg(basename+1));
+        }
+    }
+
     QString logMessage = QString("%1 %2").arg(prefixString, message.split('\n').join('\n' + prefixString + " "));
     fprintf(stdout, "%s\n", qPrintable(logMessage));
     return logMessage;


### PR DESCRIPTION
Here's a patch that updates `print()` and `console.*()` to include the script name (specifically as part of the main application logs) -- making it easier track down where messages come from and perform despam passes.  It works transparently with existing `.qml` and `.js` scripts.

Before example (ie: where do these messages come from?):
```
[09/29 08:24:07] [DEBUG] [qml] Connecting JS messaging to Hifi Logging
[09/29 08:24:07] [WARNING] [qml] Controller not yet available... can't reposition targetWindow
[09/29 08:24:27] [DEBUG] [qml] Load default scripts
[09/29 08:25:06] [DEBUG] [qml] user stories update announcement ok 0 filtered to 0
[09/29 08:25:09] [DEBUG] [hifi.scriptengine.script] No avatar identity data for null
[09/29 08:25:09] [DEBUG] [qml] This user's data was not found in the user list. PAL will not function properly.
[09/29 08:26:12] [DEBUG] [qml] Web Entity JS message: https://connect.facebook.net/en_US/fbevents.js 24 Facebook Pixel Error
[09/29 08:27:41] [DEBUG] [hifi.scriptengine.script] Refreshing Connections...
```

After example (as it turns out, from 7+ source files!):
```
[09/29 08:40:02] [DEBUG] [qml] [BaseWebView.qml] Connecting JS messaging to Hifi Logging
[09/29 08:40:02] [WARNING] [qml] [Desktop.qml] Controller not yet available... can't reposition targetWindow
[09/29 08:40:10] [DEBUG] [qml] [RunningScripts.qml] Load default scripts
[09/29 08:40:22] [DEBUG] [qml] [Feed.qml] user stories update announcement ok 0 filtered to 0
[09/29 08:40:38] [DEBUG] [hifi.scriptengine.script] [defaultScripts.js] No avatar identity data for null
[09/29 08:40:38] [DEBUG] [qml] [Pal.qml] This user's data was not found in the user list. PAL will not function properly.
[09/29 08:41:45] [DEBUG] [qml] [FlickableWebViewCore.qml] Web Entity JS message: https://connect.facebook.net/en_US/fbevents.js 24 Facebook Pixel Error
[09/29 08:42:00] [DEBUG] [hifi.scriptengine.script] [defaultScripts.js] Refreshing Connections...
```
... not entirely sure about wrapping the script name in square brackets, but overall idea?