### PR TITLE
Fix ModelOverlay visible change

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -47,7 +47,7 @@ public:
     void setIsSolid(bool isSolid) { _isSolid = isSolid; }
     void setIsDashedLine(bool isDashedLine) { _isDashedLine = isDashedLine; }
     void setIgnoreRayIntersection(bool value) { _ignoreRayIntersection = value; }
-    void setDrawInFront(bool value) { _drawInFront = value; }
+    virtual void setDrawInFront(bool value) { _drawInFront = value; }
     void setIsGrabbable(bool value) { _isGrabbable = value; }
 
     virtual AABox getBounds() const override = 0;

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -72,6 +72,23 @@ void ModelOverlay::update(float deltatime) {
         animate();
     }
 
+    // check to see if when we added our model to the scene they were ready, if they were not ready, then
+    // fix them up in the scene
+    render::ScenePointer scene = qApp->getMain3DScene();
+    render::Transaction transaction;
+    if (_model->needsFixupInScene()) {
+        _model->removeFromScene(scene, transaction);
+        _model->addToScene(scene, transaction);
+    }
+    if (_visibleDirty) {
+        _visibleDirty = false;
+        _model->setVisibleInScene(getVisible(), scene);
+    }
+    if (_drawInFrontDirty) {
+        _drawInFrontDirty = false;
+        _model->setLayeredInFront(getDrawInFront(), scene);
+    }
+    scene->enqueueTransaction(transaction);
 }
 
 bool ModelOverlay::addToScene(Overlay::Pointer overlay, const render::ScenePointer& scene, render::Transaction& transaction) {
@@ -85,21 +102,14 @@ void ModelOverlay::removeFromScene(Overlay::Pointer overlay, const render::Scene
     _model->removeFromScene(scene, transaction);
 }
 
-void ModelOverlay::render(RenderArgs* args) {
+void ModelOverlay::setVisible(bool visible) {
+    Overlay::setVisible(visible);
+    _visibleDirty = true;
+}
 
-    // check to see if when we added our model to the scene they were ready, if they were not ready, then
-    // fix them up in the scene
-    render::ScenePointer scene = qApp->getMain3DScene();
-    render::Transaction transaction;
-    if (_model->needsFixupInScene()) {
-        _model->removeFromScene(scene, transaction);
-        _model->addToScene(scene, transaction);
-    }
-
-    _model->setVisibleInScene(_visible, scene);
-    _model->setLayeredInFront(getDrawInFront(), scene);
-
-    scene->enqueueTransaction(transaction);
+void ModelOverlay::setDrawInFront(bool drawInFront) {
+    Base3DOverlay::setDrawInFront(drawInFront);
+    _drawInFrontDirty = true;
 }
 
 void ModelOverlay::setProperties(const QVariantMap& properties) {

--- a/interface/src/ui/overlays/ModelOverlay.h
+++ b/interface/src/ui/overlays/ModelOverlay.h
@@ -29,7 +29,7 @@ public:
     ModelOverlay(const ModelOverlay* modelOverlay);
 
     virtual void update(float deltatime) override;
-    virtual void render(RenderArgs* args) override;
+    virtual void render(RenderArgs* args) override {};
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
@@ -48,6 +48,9 @@ public:
 
     bool hasAnimation() const { return !_animationURL.isEmpty(); }
     bool jointsMapped() const { return _jointMappingURL == _animationURL && _jointMappingCompleted; }
+
+    void setVisible(bool visible) override;
+    void setDrawInFront(bool drawInFront) override;
 
 protected:
     Transform evalRenderTransform() override;
@@ -92,6 +95,9 @@ private:
     QUrl _jointMappingURL;
     bool _jointMappingCompleted { false };
     QVector<int> _jointMapping; // domain is index into model-joints, range is index into animation-joints
+
+    bool _visibleDirty { false };
+    bool _drawInFrontDirty { false };
 
 };
 

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -73,7 +73,7 @@ public:
     float getAlphaPulse() const { return _alphaPulse; }
 
     // setters
-    void setVisible(bool visible) { _visible = visible; }
+    virtual void setVisible(bool visible) { _visible = visible; }
     void setDrawHUDLayer(bool drawHUDLayer);
     void setColor(const xColor& color) { _color = color; }
     void setAlpha(float alpha) { _alpha = alpha; }


### PR DESCRIPTION
Possible fix for [FB8035](https://highfidelity.fogbugz.com/f/cases/8035/) and maybe [FB7954](https://highfidelity.fogbugz.com/f/cases/7954/Overlays-attached-to-hand-sometimes-disappear)

Also moves where the drawInFront is set, but currently on master toggling drawInFront on a ModelOverlay doesn't work.  That will be investigated in another PR.

Test plan
- In HMD, open and close tablet repeatedly
- The tablet should never get stuck on the private screen when you toggle it off.