### PR TITLE
Updating placeholder.js to use a url that points to example scripts

### DIFF
--- a/domain-server/resources/web/assignment/placeholder.js
+++ b/domain-server/resources/web/assignment/placeholder.js
@@ -1,3 +1,3 @@
 // Here you can put a script that will be run by an assignment-client (AC)
-// For examples, please go to http://public.highfidelity.io/scripts
+// For examples, please go to https://github.com/highfidelity/hifi/tree/master/script-archive/acScripts
 // The directory named acScripts contains assignment-client specific scripts you can try.


### PR DESCRIPTION
Test Plan:
- Install build
- Confirm that in domain settings, you see the new URL to example acScripts under 'New Assignment'
