### PR TITLE
7951 Reload button in Running Scripts dialog stops script

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -97,6 +97,9 @@ static const bool HIFI_AUTOREFRESH_FILE_SCRIPTS { true };
 Q_DECLARE_METATYPE(QScriptEngine::FunctionSignature)
 int functionSignatureMetaID = qRegisterMetaType<QScriptEngine::FunctionSignature>();
 
+Q_DECLARE_METATYPE(ScriptEnginePointer)
+int scriptEnginePointerMetaID = qRegisterMetaType<ScriptEnginePointer>();
+
 Q_LOGGING_CATEGORY(scriptengineScript, "hifi.scriptengine.script")
 
 static QScriptValue debugPrint(QScriptContext* context, QScriptEngine* engine) {


### PR DESCRIPTION
**Test plan**

1. Open running scripts dialog
2. On one of the scripts that are running, press the reload button

before the fix: 
3. Notice that the script is stopped without restarting again.

after the fix: 
3. Script should to stopped and restarted. 