### PR TITLE
Fix and improve laser pointer locking

### DIFF
--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -49,11 +49,13 @@ LaserPointer::~LaserPointer() {
 }
 
 void LaserPointer::enable() {
+    QWriteLocker lock(getLock());
     DependencyManager::get<RayPickScriptingInterface>()->enableRayPick(_rayPickUID);
     _renderingEnabled = true;
 }
 
 void LaserPointer::disable() {
+    QWriteLocker lock(getLock());
     DependencyManager::get<RayPickScriptingInterface>()->disableRayPick(_rayPickUID);
     _renderingEnabled = false;
     if (!_currentRenderState.empty()) {
@@ -67,6 +69,7 @@ void LaserPointer::disable() {
 }
 
 void LaserPointer::setRenderState(const std::string& state) {
+    QWriteLocker lock(getLock());
     if (!_currentRenderState.empty() && state != _currentRenderState) {
         if (_renderStates.find(_currentRenderState) != _renderStates.end()) {
             disableRenderState(_renderStates[_currentRenderState]);
@@ -79,6 +82,7 @@ void LaserPointer::setRenderState(const std::string& state) {
 }
 
 void LaserPointer::editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) {
+    QWriteLocker lock(getLock());
     updateRenderStateOverlay(_renderStates[state].getStartID(), startProps);
     updateRenderStateOverlay(_renderStates[state].getPathID(), pathProps);
     updateRenderStateOverlay(_renderStates[state].getEndID(), endProps);
@@ -90,6 +94,11 @@ void LaserPointer::updateRenderStateOverlay(const OverlayID& id, const QVariant&
         propMap.remove("visible");
         qApp->getOverlays().editOverlay(id, propMap);
     }
+}
+
+const RayPickResult LaserPointer::getPrevRayPickResult() {
+    QReadLocker lock(getLock());
+    return DependencyManager::get<RayPickScriptingInterface>()->getPrevRayPickResult(_rayPickUID);
 }
 
 void LaserPointer::updateRenderState(const RenderState& renderState, const IntersectionType type, const float distance, const QUuid& objectID, const PickRay& pickRay, const bool defaultState) {
@@ -183,6 +192,8 @@ void LaserPointer::disableRenderState(const RenderState& renderState) {
 }
 
 void LaserPointer::update() {
+    // This only needs to be a read lock because update won't change any of the properties that can be modified from scripts
+    QReadLocker lock(getLock());
     RayPickResult prevRayPickResult = DependencyManager::get<RayPickScriptingInterface>()->getPrevRayPickResult(_rayPickUID);
     if (_renderingEnabled && !_currentRenderState.empty() && _renderStates.find(_currentRenderState) != _renderStates.end() &&
             (prevRayPickResult.type != IntersectionType::NONE || _laserLength > 0.0f || !_objectLockEnd.first.isNull())) {
@@ -196,6 +207,51 @@ void LaserPointer::update() {
         disableRenderState(_renderStates[_currentRenderState]);
         disableRenderState(_defaultRenderStates[_currentRenderState].second);
     }
+}
+
+void LaserPointer::setPrecisionPicking(const bool precisionPicking) {
+    QWriteLocker lock(getLock());
+    DependencyManager::get<RayPickScriptingInterface>()->setPrecisionPicking(_rayPickUID, precisionPicking);
+}
+
+void LaserPointer::setLaserLength(const float laserLength) {
+    QWriteLocker lock(getLock());
+    _laserLength = laserLength;
+}
+
+void LaserPointer::setLockEndUUID(QUuid objectID, const bool isOverlay) {
+    QWriteLocker lock(getLock());
+    _objectLockEnd = std::pair<QUuid, bool>(objectID, isOverlay);
+}
+
+void LaserPointer::setIgnoreEntities(const QScriptValue& ignoreEntities) {
+    QWriteLocker lock(getLock());
+    DependencyManager::get<RayPickScriptingInterface>()->setIgnoreEntities(_rayPickUID, ignoreEntities);
+}
+
+void LaserPointer::setIncludeEntities(const QScriptValue& includeEntities) {
+    QWriteLocker lock(getLock());
+    DependencyManager::get<RayPickScriptingInterface>()->setIncludeEntities(_rayPickUID, includeEntities);
+}
+
+void LaserPointer::setIgnoreOverlays(const QScriptValue& ignoreOverlays) {
+    QWriteLocker lock(getLock());
+    DependencyManager::get<RayPickScriptingInterface>()->setIgnoreOverlays(_rayPickUID, ignoreOverlays);
+}
+
+void LaserPointer::setIncludeOverlays(const QScriptValue& includeOverlays) {
+    QWriteLocker lock(getLock());
+    DependencyManager::get<RayPickScriptingInterface>()->setIncludeOverlays(_rayPickUID, includeOverlays);
+}
+
+void LaserPointer::setIgnoreAvatars(const QScriptValue& ignoreAvatars) {
+    QWriteLocker lock(getLock());
+    DependencyManager::get<RayPickScriptingInterface>()->setIgnoreAvatars(_rayPickUID, ignoreAvatars);
+}
+
+void LaserPointer::setIncludeAvatars(const QScriptValue& includeAvatars) {
+    QWriteLocker lock(getLock());
+    DependencyManager::get<RayPickScriptingInterface>()->setIncludeAvatars(_rayPickUID, includeAvatars);
 }
 
 RenderState::RenderState(const OverlayID& startID, const OverlayID& pathID, const OverlayID& endID) :

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -75,6 +75,8 @@ public:
 
     void setLockEndUUID(QUuid objectID, const bool isOverlay) { _objectLockEnd = std::pair<QUuid, bool>(objectID, isOverlay); }
 
+    QReadWriteLock* getLock() { return &_lock; }
+
     void update();
 
 private:
@@ -89,6 +91,7 @@ private:
     std::pair<QUuid, bool> _objectLockEnd { std::pair<QUuid, bool>(QUuid(), false)};
 
     QUuid _rayPickUID;
+    QReadWriteLock _lock;
 
     void updateRenderStateOverlay(const OverlayID& id, const QVariant& props);
     void updateRenderState(const RenderState& renderState, const IntersectionType type, const float distance, const QUuid& objectID, const PickRay& pickRay, const bool defaultState);

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -58,22 +58,22 @@ public:
     QUuid getRayUID() { return _rayPickUID; }
     void enable();
     void disable();
-    const RayPickResult getPrevRayPickResult() { return DependencyManager::get<RayPickScriptingInterface>()->getPrevRayPickResult(_rayPickUID); }
+    const RayPickResult getPrevRayPickResult();
 
     void setRenderState(const std::string& state);
     // You cannot use editRenderState to change the overlay type of any part of the laser pointer.  You can only edit the properties of the existing overlays.
     void editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps);
 
-    void setPrecisionPicking(const bool precisionPicking) { DependencyManager::get<RayPickScriptingInterface>()->setPrecisionPicking(_rayPickUID, precisionPicking); }
-    void setLaserLength(const float laserLength) { _laserLength = laserLength; }
-    void setIgnoreEntities(const QScriptValue& ignoreEntities) { DependencyManager::get<RayPickScriptingInterface>()->setIgnoreEntities(_rayPickUID, ignoreEntities); }
-    void setIncludeEntities(const QScriptValue& includeEntities) { DependencyManager::get<RayPickScriptingInterface>()->setIncludeEntities(_rayPickUID, includeEntities); }
-    void setIgnoreOverlays(const QScriptValue& ignoreOverlays) { DependencyManager::get<RayPickScriptingInterface>()->setIgnoreOverlays(_rayPickUID, ignoreOverlays); }
-    void setIncludeOverlays(const QScriptValue& includeOverlays) { DependencyManager::get<RayPickScriptingInterface>()->setIncludeOverlays(_rayPickUID, includeOverlays); }
-    void setIgnoreAvatars(const QScriptValue& ignoreAvatars) { DependencyManager::get<RayPickScriptingInterface>()->setIgnoreAvatars(_rayPickUID, ignoreAvatars); }
-    void setIncludeAvatars(const QScriptValue& includeAvatars) { DependencyManager::get<RayPickScriptingInterface>()->setIncludeAvatars(_rayPickUID, includeAvatars); }
+    void setPrecisionPicking(const bool precisionPicking);
+    void setLaserLength(const float laserLength);
+    void setLockEndUUID(QUuid objectID, const bool isOverlay);
 
-    void setLockEndUUID(QUuid objectID, const bool isOverlay) { _objectLockEnd = std::pair<QUuid, bool>(objectID, isOverlay); }
+    void setIgnoreEntities(const QScriptValue& ignoreEntities);
+    void setIncludeEntities(const QScriptValue& includeEntities);
+    void setIgnoreOverlays(const QScriptValue& ignoreOverlays);
+    void setIncludeOverlays(const QScriptValue& includeOverlays);
+    void setIgnoreAvatars(const QScriptValue& ignoreAvatars);
+    void setIncludeAvatars(const QScriptValue& includeAvatars);
 
     QReadWriteLock* getLock() { return &_lock; }
 

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -31,7 +31,6 @@ void LaserPointerManager::enableLaserPointer(const QUuid uid) {
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->enable();
     }
 }
@@ -40,7 +39,6 @@ void LaserPointerManager::disableLaserPointer(const QUuid uid) {
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->disable();
     }
 }
@@ -49,7 +47,6 @@ void LaserPointerManager::setRenderState(QUuid uid, const std::string& renderSta
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setRenderState(renderState);
     }
 }
@@ -58,7 +55,6 @@ void LaserPointerManager::editRenderState(QUuid uid, const std::string& state, c
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->editRenderState(state, startProps, pathProps, endProps);
     }
 }
@@ -67,7 +63,6 @@ const RayPickResult LaserPointerManager::getPrevRayPickResult(const QUuid uid) {
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QReadLocker laserLock(laserPointer.value()->getLock());
         return laserPointer.value()->getPrevRayPickResult();
     }
     return RayPickResult();
@@ -76,9 +71,7 @@ const RayPickResult LaserPointerManager::getPrevRayPickResult(const QUuid uid) {
 void LaserPointerManager::update() {
     QReadLocker lock(&_containsLock);
     for (QUuid& uid : _laserPointers.keys()) {
-        // This only needs to be a read lock because update won't change any of the properties that can be modified from scripts
         auto laserPointer = _laserPointers.find(uid);
-        QReadLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->update();
     }
 }
@@ -87,7 +80,6 @@ void LaserPointerManager::setPrecisionPicking(QUuid uid, const bool precisionPic
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setPrecisionPicking(precisionPicking);
     }
 }
@@ -96,7 +88,6 @@ void LaserPointerManager::setLaserLength(QUuid uid, const float laserLength) {
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setLaserLength(laserLength);
     }
 }
@@ -105,7 +96,6 @@ void LaserPointerManager::setIgnoreEntities(QUuid uid, const QScriptValue& ignor
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setIgnoreEntities(ignoreEntities);
     }
 }
@@ -114,7 +104,6 @@ void LaserPointerManager::setIncludeEntities(QUuid uid, const QScriptValue& incl
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setIncludeEntities(includeEntities);
     }
 }
@@ -123,7 +112,6 @@ void LaserPointerManager::setIgnoreOverlays(QUuid uid, const QScriptValue& ignor
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setIgnoreOverlays(ignoreOverlays);
     }
 }
@@ -132,7 +120,6 @@ void LaserPointerManager::setIncludeOverlays(QUuid uid, const QScriptValue& incl
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setIncludeOverlays(includeOverlays);
     }
 }
@@ -141,7 +128,6 @@ void LaserPointerManager::setIgnoreAvatars(QUuid uid, const QScriptValue& ignore
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setIgnoreAvatars(ignoreAvatars);
     }
 }
@@ -150,7 +136,6 @@ void LaserPointerManager::setIncludeAvatars(QUuid uid, const QScriptValue& inclu
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setIncludeAvatars(includeAvatars);
     }
 }
@@ -159,7 +144,6 @@ void LaserPointerManager::setLockEndUUID(QUuid uid, QUuid objectID, const bool i
     QReadLocker lock(&_containsLock);
     auto laserPointer = _laserPointers.find(uid);
     if (laserPointer != _laserPointers.end()) {
-        QWriteLocker laserLock(laserPointer.value()->getLock());
         laserPointer.value()->setLockEndUUID(objectID, isOverlay);
     }
 }

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -17,7 +17,6 @@ QUuid LaserPointerManager::createLaserPointer(const QVariant& rayProps, const La
         QWriteLocker containsLock(&_containsLock);
         QUuid id = QUuid::createUuid();
         _laserPointers[id] = laserPointer;
-        _laserPointerLocks[id] = std::make_shared<QReadWriteLock>();
         return id;
     }
     return QUuid();
@@ -26,46 +25,50 @@ QUuid LaserPointerManager::createLaserPointer(const QVariant& rayProps, const La
 void LaserPointerManager::removeLaserPointer(const QUuid uid) {
     QWriteLocker lock(&_containsLock);
     _laserPointers.remove(uid);
-    _laserPointerLocks.remove(uid);
 }
 
 void LaserPointerManager::enableLaserPointer(const QUuid uid) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->enable();
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->enable();
     }
 }
 
 void LaserPointerManager::disableLaserPointer(const QUuid uid) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->disable();
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->disable();
     }
 }
 
 void LaserPointerManager::setRenderState(QUuid uid, const std::string& renderState) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setRenderState(renderState);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setRenderState(renderState);
     }
 }
 
 void LaserPointerManager::editRenderState(QUuid uid, const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->editRenderState(state, startProps, pathProps, endProps);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->editRenderState(state, startProps, pathProps, endProps);
     }
 }
 
 const RayPickResult LaserPointerManager::getPrevRayPickResult(const QUuid uid) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QReadLocker laserLock(_laserPointerLocks[uid].get());
-        return _laserPointers[uid]->getPrevRayPickResult();
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QReadLocker laserLock(laserPointer.value()->getLock());
+        return laserPointer.value()->getPrevRayPickResult();
     }
     return RayPickResult();
 }
@@ -74,79 +77,89 @@ void LaserPointerManager::update() {
     QReadLocker lock(&_containsLock);
     for (QUuid& uid : _laserPointers.keys()) {
         // This only needs to be a read lock because update won't change any of the properties that can be modified from scripts
-        QReadLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->update();
+        auto laserPointer = _laserPointers.find(uid);
+        QReadLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->update();
     }
 }
 
 void LaserPointerManager::setPrecisionPicking(QUuid uid, const bool precisionPicking) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setPrecisionPicking(precisionPicking);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setPrecisionPicking(precisionPicking);
     }
 }
 
 void LaserPointerManager::setLaserLength(QUuid uid, const float laserLength) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setLaserLength(laserLength);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setLaserLength(laserLength);
     }
 }
 
 void LaserPointerManager::setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setIgnoreEntities(ignoreEntities);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setIgnoreEntities(ignoreEntities);
     }
 }
 
 void LaserPointerManager::setIncludeEntities(QUuid uid, const QScriptValue& includeEntities) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setIncludeEntities(includeEntities);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setIncludeEntities(includeEntities);
     }
 }
 
 void LaserPointerManager::setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setIgnoreOverlays(ignoreOverlays);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setIgnoreOverlays(ignoreOverlays);
     }
 }
 
 void LaserPointerManager::setIncludeOverlays(QUuid uid, const QScriptValue& includeOverlays) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setIncludeOverlays(includeOverlays);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setIncludeOverlays(includeOverlays);
     }
 }
 
 void LaserPointerManager::setIgnoreAvatars(QUuid uid, const QScriptValue& ignoreAvatars) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setIgnoreAvatars(ignoreAvatars);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setIgnoreAvatars(ignoreAvatars);
     }
 }
 
 void LaserPointerManager::setIncludeAvatars(QUuid uid, const QScriptValue& includeAvatars) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setIncludeAvatars(includeAvatars);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setIncludeAvatars(includeAvatars);
     }
 }
 
 void LaserPointerManager::setLockEndUUID(QUuid uid, QUuid objectID, const bool isOverlay) {
     QReadLocker lock(&_containsLock);
-    if (_laserPointers.contains(uid)) {
-        QWriteLocker laserLock(_laserPointerLocks[uid].get());
-        _laserPointers[uid]->setLockEndUUID(objectID, isOverlay);
+    auto laserPointer = _laserPointers.find(uid);
+    if (laserPointer != _laserPointers.end()) {
+        QWriteLocker laserLock(laserPointer.value()->getLock());
+        laserPointer.value()->setLockEndUUID(objectID, isOverlay);
     }
 }

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -13,7 +13,6 @@
 
 #include <memory>
 #include <glm/glm.hpp>
-#include <QReadWriteLock>
 
 #include "LaserPointer.h"
 
@@ -46,7 +45,6 @@ public:
 
 private:
     QHash<QUuid, std::shared_ptr<LaserPointer>> _laserPointers;
-    QHash<QUuid, std::shared_ptr<QReadWriteLock>> _laserPointerLocks;
     QReadWriteLock _containsLock;
 
 };

--- a/interface/src/raypick/RayPick.cpp
+++ b/interface/src/raypick/RayPick.cpp
@@ -16,3 +16,47 @@ RayPick::RayPick(const RayPickFilter& filter, const float maxDistance, const boo
     _enabled(enabled)
 {
 }
+void RayPick::enable() {
+    QWriteLocker lock(getLock());
+    _enabled = true;
+}
+
+void RayPick::disable() {
+    QWriteLocker lock(getLock());
+    _enabled = false;
+}
+
+const RayPickResult& RayPick::getPrevRayPickResult() {
+    QReadLocker lock(getLock());
+    return _prevResult;
+}
+
+void RayPick::setIgnoreEntities(const QScriptValue& ignoreEntities) {
+    QWriteLocker lock(getLock());
+    _ignoreEntities = qVectorEntityItemIDFromScriptValue(ignoreEntities);
+}
+
+void RayPick::setIncludeEntities(const QScriptValue& includeEntities) {
+    QWriteLocker lock(getLock());
+    _includeEntities = qVectorEntityItemIDFromScriptValue(includeEntities);
+}
+
+void RayPick::setIgnoreOverlays(const QScriptValue& ignoreOverlays) {
+    QWriteLocker lock(getLock());
+    _ignoreOverlays = qVectorOverlayIDFromScriptValue(ignoreOverlays);
+}
+
+void RayPick::setIncludeOverlays(const QScriptValue& includeOverlays) {
+    QWriteLocker lock(getLock());
+    _includeOverlays = qVectorOverlayIDFromScriptValue(includeOverlays);
+}
+
+void RayPick::setIgnoreAvatars(const QScriptValue& ignoreAvatars) {
+    QWriteLocker lock(getLock());
+    _ignoreAvatars = qVectorEntityItemIDFromScriptValue(ignoreAvatars);
+}
+
+void RayPick::setIncludeAvatars(const QScriptValue& includeAvatars) {
+    QWriteLocker lock(getLock());
+    _includeAvatars = qVectorEntityItemIDFromScriptValue(includeAvatars);
+}

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -103,13 +103,13 @@ public:
 
     virtual const PickRay getPickRay(bool& valid) const = 0;
 
-    void enable() { _enabled = true; }
-    void disable() { _enabled = false; }
+    void enable();
+    void disable();
 
     const RayPickFilter& getFilter() { return _filter; }
     float getMaxDistance() { return _maxDistance; }
     bool isEnabled() { return _enabled; }
-    const RayPickResult& getPrevRayPickResult() { return _prevResult; }
+    const RayPickResult& getPrevRayPickResult();
 
     void setPrecisionPicking(bool precisionPicking) { _filter.setFlag(RayPickFilter::PICK_COURSE, !precisionPicking); }
 
@@ -121,12 +121,12 @@ public:
     const QVector<OverlayID>& getIncludeOverlays() { return _includeOverlays; }
     const QVector<EntityItemID>& getIgnoreAvatars() { return _ignoreAvatars; }
     const QVector<EntityItemID>& getIncludeAvatars() { return _includeAvatars; }
-    void setIgnoreEntities(const QScriptValue& ignoreEntities) { _ignoreEntities = qVectorEntityItemIDFromScriptValue(ignoreEntities); }
-    void setIncludeEntities(const QScriptValue& includeEntities) { _includeEntities = qVectorEntityItemIDFromScriptValue(includeEntities); }
-    void setIgnoreOverlays(const QScriptValue& ignoreOverlays) { _ignoreOverlays = qVectorOverlayIDFromScriptValue(ignoreOverlays); }
-    void setIncludeOverlays(const QScriptValue& includeOverlays) { _includeOverlays = qVectorOverlayIDFromScriptValue(includeOverlays); }
-    void setIgnoreAvatars(const QScriptValue& ignoreAvatars) { _ignoreAvatars = qVectorEntityItemIDFromScriptValue(ignoreAvatars); }
-    void setIncludeAvatars(const QScriptValue& includeAvatars) { _includeAvatars = qVectorEntityItemIDFromScriptValue(includeAvatars); }
+    void setIgnoreEntities(const QScriptValue& ignoreEntities);
+    void setIncludeEntities(const QScriptValue& includeEntities);
+    void setIgnoreOverlays(const QScriptValue& ignoreOverlays);
+    void setIncludeOverlays(const QScriptValue& includeOverlays);
+    void setIgnoreAvatars(const QScriptValue& ignoreAvatars);
+    void setIncludeAvatars(const QScriptValue& includeAvatars);
 
     QReadWriteLock* getLock() { return &_lock; }
 

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -16,6 +16,7 @@
 
 #include "EntityItemID.h"
 #include "ui/overlays/Overlay.h"
+#include <QReadWriteLock>
 
 class RayPickFilter {
 public:
@@ -127,6 +128,8 @@ public:
     void setIgnoreAvatars(const QScriptValue& ignoreAvatars) { _ignoreAvatars = qVectorEntityItemIDFromScriptValue(ignoreAvatars); }
     void setIncludeAvatars(const QScriptValue& includeAvatars) { _includeAvatars = qVectorEntityItemIDFromScriptValue(includeAvatars); }
 
+    QReadWriteLock* getLock() { return &_lock; }
+
 private:
     RayPickFilter _filter;
     float _maxDistance;
@@ -139,6 +142,8 @@ private:
     QVector<OverlayID> _includeOverlays;
     QVector<EntityItemID> _ignoreAvatars;
     QVector<EntityItemID> _includeAvatars;
+
+    QReadWriteLock _lock;
 };
 
 #endif // hifi_RayPick_h

--- a/interface/src/raypick/RayPickManager.cpp
+++ b/interface/src/raypick/RayPickManager.cpp
@@ -153,7 +153,6 @@ void RayPickManager::enableRayPick(const QUuid uid) {
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker rayPickLock(rayPick.value()->getLock());
         rayPick.value()->enable();
     }
 }
@@ -162,7 +161,6 @@ void RayPickManager::disableRayPick(const QUuid uid) {
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker rayPickLock(rayPick.value()->getLock());
         rayPick.value()->disable();
     }
 }
@@ -171,7 +169,6 @@ const RayPickResult RayPickManager::getPrevRayPickResult(const QUuid uid) {
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QReadLocker lock(rayPick.value()->getLock());
         return rayPick.value()->getPrevRayPickResult();
     }
     return RayPickResult();
@@ -181,7 +178,6 @@ void RayPickManager::setPrecisionPicking(QUuid uid, const bool precisionPicking)
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker lock(rayPick.value()->getLock());
         rayPick.value()->setPrecisionPicking(precisionPicking);
     }
 }
@@ -190,7 +186,6 @@ void RayPickManager::setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEnti
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker lock(rayPick.value()->getLock());
         rayPick.value()->setIgnoreEntities(ignoreEntities);
     }
 }
@@ -199,7 +194,6 @@ void RayPickManager::setIncludeEntities(QUuid uid, const QScriptValue& includeEn
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker lock(rayPick.value()->getLock());
         rayPick.value()->setIncludeEntities(includeEntities);
     }
 }
@@ -208,7 +202,6 @@ void RayPickManager::setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOver
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker lock(rayPick.value()->getLock());
         rayPick.value()->setIgnoreOverlays(ignoreOverlays);
     }
 }
@@ -217,7 +210,6 @@ void RayPickManager::setIncludeOverlays(QUuid uid, const QScriptValue& includeOv
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker lock(rayPick.value()->getLock());
         rayPick.value()->setIncludeOverlays(includeOverlays);
     }
 }
@@ -226,7 +218,6 @@ void RayPickManager::setIgnoreAvatars(QUuid uid, const QScriptValue& ignoreAvata
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker lock(rayPick.value()->getLock());
         rayPick.value()->setIgnoreAvatars(ignoreAvatars);
     }
 }
@@ -235,7 +226,6 @@ void RayPickManager::setIncludeAvatars(QUuid uid, const QScriptValue& includeAva
     QReadLocker containsLock(&_containsLock);
     auto rayPick = _rayPicks.find(uid);
     if (rayPick != _rayPicks.end()) {
-        QWriteLocker lock(rayPick.value()->getLock());
         rayPick.value()->setIncludeAvatars(includeAvatars);
     }
 }

--- a/interface/src/raypick/RayPickManager.cpp
+++ b/interface/src/raypick/RayPickManager.cpp
@@ -47,6 +47,7 @@ void RayPickManager::update() {
     RayPickCache results;
     for (auto& uid : _rayPicks.keys()) {
         std::shared_ptr<RayPick> rayPick = _rayPicks[uid];
+        QWriteLocker lock(rayPick->getLock());
         if (!rayPick->isEnabled() || rayPick->getFilter().doesPickNothing() || rayPick->getMaxDistance() < 0.0f) {
             continue;
         }
@@ -114,7 +115,6 @@ void RayPickManager::update() {
             }
         }
 
-        QWriteLocker lock(_rayPickLocks[uid].get());
         if (rayPick->getMaxDistance() == 0.0f || (rayPick->getMaxDistance() > 0.0f && res.distance < rayPick->getMaxDistance())) {
             rayPick->setRayPickResult(res);
         } else {
@@ -127,7 +127,6 @@ QUuid RayPickManager::createRayPick(const std::string& jointName, const glm::vec
     QWriteLocker lock(&_containsLock);
     QUuid id = QUuid::createUuid();
     _rayPicks[id] = std::make_shared<JointRayPick>(jointName, posOffset, dirOffset, filter, maxDistance, enabled);
-    _rayPickLocks[id] = std::make_shared<QReadWriteLock>();
     return id;
 }
 
@@ -135,7 +134,6 @@ QUuid RayPickManager::createRayPick(const RayPickFilter& filter, const float max
     QWriteLocker lock(&_containsLock);
     QUuid id = QUuid::createUuid();
     _rayPicks[id] = std::make_shared<MouseRayPick>(filter, maxDistance, enabled);
-    _rayPickLocks[id] = std::make_shared<QReadWriteLock>();
     return id;
 }
 
@@ -143,93 +141,101 @@ QUuid RayPickManager::createRayPick(const glm::vec3& position, const glm::vec3& 
     QWriteLocker lock(&_containsLock);
     QUuid id = QUuid::createUuid();
     _rayPicks[id] = std::make_shared<StaticRayPick>(position, direction, filter, maxDistance, enabled);
-    _rayPickLocks[id] = std::make_shared<QReadWriteLock>();
     return id;
 }
 
 void RayPickManager::removeRayPick(const QUuid uid) {
     QWriteLocker lock(&_containsLock);
     _rayPicks.remove(uid);
-    _rayPickLocks.remove(uid);
 }
 
 void RayPickManager::enableRayPick(const QUuid uid) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker rayPickLock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->enable();
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker rayPickLock(rayPick.value()->getLock());
+        rayPick.value()->enable();
     }
 }
 
 void RayPickManager::disableRayPick(const QUuid uid) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker rayPickLock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->disable();
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker rayPickLock(rayPick.value()->getLock());
+        rayPick.value()->disable();
     }
 }
 
 const RayPickResult RayPickManager::getPrevRayPickResult(const QUuid uid) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QReadLocker lock(_rayPickLocks[uid].get());
-        return _rayPicks[uid]->getPrevRayPickResult();
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QReadLocker lock(rayPick.value()->getLock());
+        return rayPick.value()->getPrevRayPickResult();
     }
     return RayPickResult();
 }
 
 void RayPickManager::setPrecisionPicking(QUuid uid, const bool precisionPicking) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker lock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->setPrecisionPicking(precisionPicking);
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker lock(rayPick.value()->getLock());
+        rayPick.value()->setPrecisionPicking(precisionPicking);
     }
 }
 
 void RayPickManager::setIgnoreEntities(QUuid uid, const QScriptValue& ignoreEntities) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker lock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->setIgnoreEntities(ignoreEntities);
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker lock(rayPick.value()->getLock());
+        rayPick.value()->setIgnoreEntities(ignoreEntities);
     }
 }
 
 void RayPickManager::setIncludeEntities(QUuid uid, const QScriptValue& includeEntities) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker lock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->setIncludeEntities(includeEntities);
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker lock(rayPick.value()->getLock());
+        rayPick.value()->setIncludeEntities(includeEntities);
     }
 }
 
 void RayPickManager::setIgnoreOverlays(QUuid uid, const QScriptValue& ignoreOverlays) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker lock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->setIgnoreOverlays(ignoreOverlays);
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker lock(rayPick.value()->getLock());
+        rayPick.value()->setIgnoreOverlays(ignoreOverlays);
     }
 }
 
 void RayPickManager::setIncludeOverlays(QUuid uid, const QScriptValue& includeOverlays) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker lock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->setIncludeOverlays(includeOverlays);
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker lock(rayPick.value()->getLock());
+        rayPick.value()->setIncludeOverlays(includeOverlays);
     }
 }
 
 void RayPickManager::setIgnoreAvatars(QUuid uid, const QScriptValue& ignoreAvatars) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker lock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->setIgnoreAvatars(ignoreAvatars);
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker lock(rayPick.value()->getLock());
+        rayPick.value()->setIgnoreAvatars(ignoreAvatars);
     }
 }
 
 void RayPickManager::setIncludeAvatars(QUuid uid, const QScriptValue& includeAvatars) {
     QReadLocker containsLock(&_containsLock);
-    if (_rayPicks.contains(uid)) {
-        QWriteLocker lock(_rayPickLocks[uid].get());
-        _rayPicks[uid]->setIncludeAvatars(includeAvatars);
+    auto rayPick = _rayPicks.find(uid);
+    if (rayPick != _rayPicks.end()) {
+        QWriteLocker lock(rayPick.value()->getLock());
+        rayPick.value()->setIncludeAvatars(includeAvatars);
     }
 }

--- a/interface/src/raypick/RayPickManager.h
+++ b/interface/src/raypick/RayPickManager.h
@@ -15,7 +15,6 @@
 
 #include <memory>
 #include <QtCore/QObject>
-#include <QReadWriteLock>
 
 #include "RegisteredMetaTypes.h"
 
@@ -47,7 +46,6 @@ public:
 
 private:
     QHash<QUuid, std::shared_ptr<RayPick>> _rayPicks;
-    QHash<QUuid, std::shared_ptr<QReadWriteLock>> _rayPickLocks;
     QReadWriteLock _containsLock;
 
     typedef QHash<QPair<glm::vec3, glm::vec3>, std::unordered_map<RayPickFilter::Flags, RayPickResult>> RayPickCache;


### PR DESCRIPTION
- Reduce lookups by including the necessary locks in RayPicks and LaserPointers
- Move RayPick locking earlier in RayPickManager::update to avoid a crash

Test plan:
- Laser pointers (teleport, hand lasers) should work as expected.
- Shouldn't crash in RayPickManager::update, although I couldn't actually repro this crash (reported by @sethalves)