### PR TITLE
Bug fix for deadlock in ModelEntityItem::setCompundShapeURL()

### DIFF
--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -217,7 +217,7 @@ void ModelEntityItem::debugDump() const {
 void ModelEntityItem::setShapeType(ShapeType type) {
     withWriteLock([&] {
         if (type != _shapeType) {
-                if (type == SHAPE_TYPE_STATIC_MESH && _dynamic) {
+            if (type == SHAPE_TYPE_STATIC_MESH && _dynamic) {
                 // dynamic and STATIC_MESH are incompatible
                 // since the shape is being set here we clear the dynamic bit
                 _dynamic = false;
@@ -260,9 +260,9 @@ void ModelEntityItem::setModelURL(const QString& url) {
 
 void ModelEntityItem::setCompoundShapeURL(const QString& url) {
     withWriteLock([&] {
-        if (_compoundShapeURL != url) {
+        if (_compoundShapeURL.get() != url) {
             ShapeType oldType = computeTrueShapeType();
-            _compoundShapeURL = url;
+            _compoundShapeURL.set(url);
             if (oldType != computeTrueShapeType()) {
                 _dirtyFlags |= Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS;
             }
@@ -496,10 +496,8 @@ bool ModelEntityItem::hasModel() const {
         return !_modelURL.isEmpty();
     });
 }
-bool ModelEntityItem::hasCompoundShapeURL() const { 
-    return resultWithReadLock<bool>([&] {
-        return !_compoundShapeURL.isEmpty();
-    });
+bool ModelEntityItem::hasCompoundShapeURL() const {
+    return _compoundShapeURL.get().isEmpty();
 }
 
 QString ModelEntityItem::getModelURL() const {
@@ -509,9 +507,7 @@ QString ModelEntityItem::getModelURL() const {
 }
 
 QString ModelEntityItem::getCompoundShapeURL() const {
-    return resultWithReadLock<QString>([&] {
-        return _compoundShapeURL;
-    });
+    return _compoundShapeURL.get();
 }
 
 void ModelEntityItem::setColor(const rgbColor& value) { 

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -14,6 +14,7 @@
 
 #include "EntityItem.h"
 #include <JointData.h>
+#include <ThreadSafeValueCache.h>
 #include "AnimationPropertyGroup.h"
 
 class ModelEntityItem : public EntityItem {
@@ -153,7 +154,8 @@ protected:
 
     rgbColor _color;
     QString _modelURL;
-    QString _compoundShapeURL;
+
+    ThreadSafeValueCache<QString> _compoundShapeURL;
 
     AnimationPropertyGroup _animationProperties;
 


### PR DESCRIPTION
The fix was to prevent ModelEntityItem::hasCompoundShapeURL() from taking a read lock on the entity, instead a finer grained lock (ThreadSafeValueCache) is made around the _compoundShapeURL QString.