### PR TITLE
fix hudOverlayPointer logic

### DIFF
--- a/scripts/system/controllers/controllerModules/hudOverlayPointer.js
+++ b/scripts/system/controllers/controllerModules/hudOverlayPointer.js
@@ -178,7 +178,7 @@
             }
             var hudRayPick = controllerData.hudRayPicks[this.hand];
             var point2d = this.calculateNewReticlePosition(hudRayPick.intersection);
-            if (!Window.isPointOnDesktopWindow(point2d) && !controllerData.triggerClicks[this.hand]) {
+            if (!Window.isPointOnDesktopWindow(point2d) && !this.triggerClicked) {
                 this.exitModule();
                 return false;
             }


### PR DESCRIPTION
This PR fixes a logic error in the hudOverlayPointer module that caused the module run when it was not suppose to.