### PR TITLE
Fix calling AvatarManager.findRayIntersection() from script

### DIFF
--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -73,9 +73,9 @@ public:
     Q_INVOKABLE RayToAvatarIntersectionResult findRayIntersection(const PickRay& ray,
                                                                   const QScriptValue& avatarIdsToInclude = QScriptValue(),
                                                                   const QScriptValue& avatarIdsToDiscard = QScriptValue());
-    RayToAvatarIntersectionResult findRayIntersectionVector(const PickRay& ray,
-                                                            const QVector<EntityItemID>& avatarsToInclude,
-                                                            const QVector<EntityItemID>& avatarsToDiscard);
+    Q_INVOKABLE RayToAvatarIntersectionResult findRayIntersectionVector(const PickRay& ray,
+                                                                        const QVector<EntityItemID>& avatarsToInclude,
+                                                                        const QVector<EntityItemID>& avatarsToDiscard);
 
     // TODO: remove this HACK once we settle on optimal default sort coefficients
     Q_INVOKABLE float getAvatarSortCoefficient(const QString& name);


### PR DESCRIPTION
Fixes https://github.com/highfidelity/hifi/issues/11508

AvatarManager::findRayIntersectionVector() had to be Q_INVOKABLE because it can be called from a script thread and needs to do a BLOCKING_INVOKE

Test plan (from the issue):
- Open the console
- Run the script below
- Click on some avatars.
```
function mousePressEvent(event){
	var pickRay = Camera.computePickRay(event.x, event.y);

	var avatar = AvatarManager.findRayIntersection(pickRay);

	print(JSON.stringify(avatar,null,2));
}
Controller.mousePressEvent.connect(mousePressEvent);
```