### PR TITLE
Fix buying free items using Commerce system

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -35,7 +35,7 @@ Rectangle {
     property string itemHref;
     property double balanceAfterPurchase;
     property bool alreadyOwned: false;
-    property int itemPrice;
+    property int itemPrice: -1;
     property bool itemIsJson: true;
     property bool shouldBuyWithControlledFailure: false;
     property bool debugCheckoutSuccess: false;
@@ -339,7 +339,7 @@ Rectangle {
                 }
                 FiraSansSemiBold {
                     id: itemPriceText;
-                    text: root.itemPrice;
+                    text: (root.itemPrice === -1) ? "--" : root.itemPrice;
                     // Text size
                     size: 26;
                     // Anchors

--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -119,7 +119,9 @@ void QmlCommerce::history() {
 
 void QmlCommerce::changePassphrase(const QString& oldPassphrase, const QString& newPassphrase) {
     auto wallet = DependencyManager::get<Wallet>();
-    if ((wallet->getPassphrase()->isEmpty() || wallet->getPassphrase() == oldPassphrase) && !newPassphrase.isEmpty()) {
+    if (wallet->getPassphrase()->isEmpty()) {
+        emit changePassphraseStatusResult(wallet->setPassphrase(newPassphrase));
+    } else if (wallet->getPassphrase() == oldPassphrase && !newPassphrase.isEmpty()) {
         emit changePassphraseStatusResult(wallet->changePassphrase(newPassphrase));
     } else {
         emit changePassphraseStatusResult(false);

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -293,13 +293,15 @@ Wallet::~Wallet() {
     }
 }
 
-void Wallet::setPassphrase(const QString& passphrase) {
+bool Wallet::setPassphrase(const QString& passphrase) {
     if (_passphrase) {
         delete _passphrase;
     }
     _passphrase = new QString(passphrase);
 
     _publicKeys.clear();
+
+    return true;
 }
 
 bool Wallet::writeSecurityImage(const QPixmap* pixmap, const QString& outputFilePath) {

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -42,7 +42,7 @@ public:
     void setCKey(const QByteArray& ckey) { _ckey = ckey; }
     QByteArray getCKey() { return _ckey; }
 
-    void setPassphrase(const QString& passphrase);
+    bool setPassphrase(const QString& passphrase);
     QString* getPassphrase() { return _passphrase; }
     bool getPassphraseIsCached() { return !(_passphrase->isEmpty()); }
     bool walletIsAuthenticatedWithPassphrase();


### PR DESCRIPTION
I changed this code when creating the `Wallet.buy()` endpoint (very recent change in my 2nd big PR yesterday), but never re-checked buying free items. There is so much to test that I (and others) simply missed it.

*Test Plan:*
1. In `Interface.json`, add `"commerce": true,`
2. Set up your wallet
3. Go into the Marketplace and search for "red knight"
4. Try to buy the red knight and use it as your avatar. Verify that you don't get stuck on the Checkout page
5. In `Interface.json`, remove `"commerce": true,`
6. Go into the Marketplace and search for "red knight"
7. Try to buy the red knight and use it as your avatar.