### PR TITLE
Try to improve performance without messing up model loading

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -222,16 +222,6 @@ void EntityTreeRenderer::updateChangedEntities(const render::ScenePointer& scene
         _renderablesToUpdate.insert({ entityId, renderable });
     }
 
-    // NOTE: Looping over all the entity renderers is likely to be a bottleneck in the future
-    // Currently, this is necessary because the model entity loading logic requires constant polling
-    // This was working fine because the entity server used to send repeated updates as your view changed,
-    // but with the improved entity server logic (PR 11141), updateInScene (below) would not be triggered enough
-    for (const auto& entry : _entitiesInScene) {
-        const auto& renderable = entry.second;
-        if (renderable) {
-            renderable->update(scene, transaction);
-        }
-    }
     if (!_renderablesToUpdate.empty()) {
         for (const auto& entry : _renderablesToUpdate) {
             const auto& renderable = entry.second;

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -291,18 +291,6 @@ void EntityRenderer::updateInScene(const ScenePointer& scene, Transaction& trans
     });
 }
 
-void EntityRenderer::update(const ScenePointer& scene, Transaction& transaction) {
-    if (!isValidRenderItem()) {
-        return;
-    }
-
-    if (!needsUpdate()) {
-        return;
-    }
-
-    doUpdate(scene, transaction, _entity);
-}
-
 //
 // Internal methods
 //
@@ -314,11 +302,6 @@ bool EntityRenderer::needsRenderUpdate() const {
         return true;
     }
     return needsRenderUpdateFromEntity(_entity);
-}
-
-// Returns true if the item needs to have update called
-bool EntityRenderer::needsUpdate() const {
-    return needsUpdateFromEntity(_entity);
 }
 
 // Returns true if the item in question needs to have updateInScene called because of changes in the entity

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -49,8 +49,6 @@ public:
     virtual bool addToScene(const ScenePointer& scene, Transaction& transaction) final;
     virtual void removeFromScene(const ScenePointer& scene, Transaction& transaction);
 
-    virtual void update(const ScenePointer& scene, Transaction& transaction);
-
 protected:
     virtual bool needsRenderUpdateFromEntity() const final { return needsRenderUpdateFromEntity(_entity); }
     virtual void onAddToScene(const EntityItemPointer& entity);
@@ -73,12 +71,6 @@ protected:
     // Returns true if the item in question needs to have updateInScene called because of changes in the entity
     virtual bool needsRenderUpdateFromEntity(const EntityItemPointer& entity) const;
 
-    // Returns true if the item in question needs to have update called
-    virtual bool needsUpdate() const;
-
-    // Returns true if the item in question needs to have update called because of changes in the entity
-    virtual bool needsUpdateFromEntity(const EntityItemPointer& entity) const { return false; }
-
     // Will be called on the main thread from updateInScene.  This can be used to fetch things like 
     // network textures or model geometry from resource caches
     virtual void doRenderUpdateSynchronous(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) {  }
@@ -87,8 +79,6 @@ protected:
     // This function will execute on the rendering thread, so you cannot use network caches to fetch
     // data in this method if using multi-threaded rendering
     virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity);
-
-    virtual void doUpdate(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) { }
 
     // Called by the `render` method after `needsRenderUpdate`
     virtual void doRender(RenderArgs* args) = 0;
@@ -158,15 +148,6 @@ protected:
         onRemoveFromSceneTyped(_typedEntity);
     }
 
-    using Parent::needsUpdateFromEntity;
-    // Returns true if the item in question needs to have update called because of changes in the entity
-    virtual bool needsUpdateFromEntity(const EntityItemPointer& entity) const override final {
-        if (Parent::needsUpdateFromEntity(entity)) {
-            return true;
-        }
-        return needsUpdateFromTypedEntity(_typedEntity);
-    }
-
     using Parent::needsRenderUpdateFromEntity;
     // Returns true if the item in question needs to have updateInScene called because of changes in the entity
     virtual bool needsRenderUpdateFromEntity(const EntityItemPointer& entity) const override final {
@@ -181,11 +162,6 @@ protected:
         doRenderUpdateSynchronousTyped(scene, transaction, _typedEntity);
     }
 
-    virtual void doUpdate(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) override final {
-        Parent::doUpdate(scene, transaction, entity);
-        doUpdateTyped(scene, transaction, _typedEntity);
-    }
-
     virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity) override final {
         Parent::doRenderUpdateAsynchronous(entity);
         doRenderUpdateAsynchronousTyped(_typedEntity);
@@ -194,8 +170,6 @@ protected:
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const { return false; }
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) { }
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) { }
-    virtual bool needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const { return false; }
-    virtual void doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) { }
     virtual void onAddToSceneTyped(const TypedEntityPointer& entity) { }
     virtual void onRemoveFromSceneTyped(const TypedEntityPointer& entity) { }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1026,7 +1026,7 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
     entity->copyAnimationJointDataToModel();
 }
 
-bool ModelEntityRenderer::needsUpdate() const {
+bool ModelEntityRenderer::needsRenderUpdate() const {
     ModelPointer model;
     withReadLock([&] {
         model = _model;
@@ -1061,10 +1061,10 @@ bool ModelEntityRenderer::needsUpdate() const {
             return true;
         }
     }
-    return Parent::needsUpdate();
+    return Parent::needsRenderUpdate();
 }
 
-bool ModelEntityRenderer::needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const {
+bool ModelEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const {
     if (resultWithReadLock<bool>([&] {
         if (entity->hasModel() != _hasModel) {
             return true;
@@ -1126,7 +1126,7 @@ bool ModelEntityRenderer::needsUpdateFromTypedEntity(const TypedEntityPointer& e
     return false;
 }
 
-void ModelEntityRenderer::doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) {
+void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) {
     if (_hasModel != entity->hasModel()) {
         _hasModel = entity->hasModel();
     }
@@ -1250,6 +1250,7 @@ void ModelEntityRenderer::doUpdateTyped(const ScenePointer& scene, Transaction& 
 void ModelEntityRenderer::handleModelLoaded(bool success) {
     if (success) {
         _modelJustLoaded = true;
+        emit requestRenderUpdate();
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -138,10 +138,10 @@ protected:
     virtual ItemKey getKey() override;
     virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) override;
 
-    virtual bool needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
-    virtual bool needsUpdate() const override;
+    virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
+    virtual bool needsRenderUpdate() const override;
     virtual void doRender(RenderArgs* args) override;
-    virtual void doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
+    virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
 
 private:
     void animate(const TypedEntityPointer& entity);


### PR DESCRIPTION
[FB8108](https://highfidelity.fogbugz.com/f/cases/8108/Sim-rate-very-poor-in-heavy-loaded-domains)

- Undo a bunch of work from: https://github.com/highfidelity/hifi/pull/11436 that was impacting simrate
- Hopefully keep the important changes that fix model loading (edit: it doesn't)

Test Plan:
- Download a content set with a good number of model entities. Make sure there are multiple models with exactly the same fbx file and at least some models that have parent model entities. The dev-welcome content is pretty good, but it would be good to test other content sets too.
- All model entities should load normally. Reload your content (Edit -> Reload Content) while looking at one part of the domain and then turn to look behind you. No models should be missing once all your downloads finish.
- If model A and model B have the same model file and you look at only model A (model B is out of view and at least several meters away), reload content, and wait a while so that everything has loaded, when you turn to look at model B it should appear.
- Edit a model's properties, like visible, textures, and model URL. All changes should take effect as expected.
- Compare performance to identical content with the [RC as is right now](https://github.com/highfidelity/hifi/pull/11523).  You should see noticeably better sim rate in this PR.
- The RC doesn't contain the entity server change, so the missing model bug might not be obvious if it is still an issue.  At the very worst, it shouldn't be worse than RC 55.
