### PR TITLE
Fix microphone audio on the Mac

### DIFF
--- a/libraries/audio/src/AudioDynamics.h
+++ b/libraries/audio/src/AudioDynamics.h
@@ -397,6 +397,8 @@ public:
 
         // Fast FIR attack/lowpass filter using a 2-stage CIC filter.
         // The step response reaches final value after N-1 samples.
+        // NOTE: CIC integrators intentionally overflow, using modulo arithmetic.
+        // See E. B. Hogenauer, "An economical class of digital filters for decimation and interpolation"
 
         const int32_t CICGAIN = 0xffffffff / (CIC1 * CIC2); // Q32
         x = MULHI(x, CICGAIN);
@@ -462,6 +464,8 @@ public:
 
         // Fast FIR attack/lowpass filter using a 2-stage CIC filter.
         // The step response reaches final value after N-1 samples.
+        // NOTE: CIC integrators intentionally overflow, using modulo arithmetic.
+        // See E. B. Hogenauer, "An economical class of digital filters for decimation and interpolation"
 
         const int32_t CICGAIN = 0xffffffff / (CIC1 * CIC2); // Q32
         x = MULHI(x, CICGAIN);

--- a/libraries/audio/src/AudioDynamics.h
+++ b/libraries/audio/src/AudioDynamics.h
@@ -31,6 +31,9 @@
 #define MULQ31(a,b)     ((int32_t)(MUL64(a, b) >> 31))
 #define MULDIV64(a,b,c) (int32_t)(MUL64(a, b) / (c))
 
+#define ADDMOD32(a,b)   (int32_t)((uint32_t)(a) + (uint32_t)(b))
+#define SUBMOD32(a,b)   (int32_t)((uint32_t)(a) - (uint32_t)(b))
+
 //
 // on x86 architecture, assume that SSE2 is present
 //
@@ -399,14 +402,14 @@ public:
         x = MULHI(x, CICGAIN);
 
         _buffer[i] = _acc1;
-        _acc1 += x;                 // integrator
+        _acc1 = ADDMOD32(_acc1, x);         // integrator
         i = (i + CIC1 - 1) & MASK;
-        x = _acc1 - _buffer[i];     // comb
+        x = SUBMOD32(_acc1, _buffer[i]);    // comb
 
         _buffer[i] = _acc2;
-        _acc2 += x;                 // integrator
+        _acc2 = ADDMOD32(_acc2, x);         // integrator
         i = (i + CIC2 - 1) & MASK;
-        x = _acc2 - _buffer[i];     // comb
+        x = SUBMOD32(_acc2, _buffer[i]);    // comb
 
         _index = (i + 1) & MASK;    // skip unused tap
         return x;
@@ -464,14 +467,14 @@ public:
         x = MULHI(x, CICGAIN);
 
         _buffer[i] = _acc1;
-        _acc1 += x;                 // integrator
+        _acc1 = ADDMOD32(_acc1, x);         // integrator
         i = (i + CIC1 - 1) & MASK;
-        x = _acc1 - _buffer[i];     // comb
+        x = SUBMOD32(_acc1, _buffer[i]);    // comb
 
         _buffer[i] = _acc2;
-        _acc2 += x;                 // integrator
+        _acc2 = ADDMOD32(_acc2, x);         // integrator
         i = (i + CIC2 - 1) & MASK;
-        x = _acc2 - _buffer[i];     // comb
+        x = SUBMOD32(_acc2, _buffer[i]);    // comb
 
         _index = (i + 1) & MASK;    // skip unused tap
         return x;

--- a/libraries/audio/src/AudioGate.cpp
+++ b/libraries/audio/src/AudioGate.cpp
@@ -6,12 +6,12 @@
 //  Copyright 2017 High Fidelity, Inc.
 //
 
-#include "AudioGate.h"
-
 #include <string.h>
+#include <stdlib.h>
 #include <assert.h>
-#include <cstdlib>
+
 #include "AudioDynamics.h"
+#include "AudioGate.h"
 
 // log2 domain headroom bits above 0dB (int32_t)
 static const int LOG2_HEADROOM_Q30 = 1;
@@ -418,7 +418,7 @@ void GateMono<N>::process(int16_t* input, int16_t* output, int numFrames) {
         _dc.process(x);
 
         // peak detect
-        int32_t peak = std::abs(x);
+        int32_t peak = abs(x);
 
         // convert to log2 domain
         peak = fixlog2(peak);

--- a/libraries/audio/src/AudioGate.cpp
+++ b/libraries/audio/src/AudioGate.cpp
@@ -13,10 +13,6 @@
 #include <cstdlib>
 #include "AudioDynamics.h"
 
-#ifdef __clang__
-#pragma clang optimize off
-#endif
-
 // log2 domain headroom bits above 0dB (int32_t)
 static const int LOG2_HEADROOM_Q30 = 1;
 

--- a/libraries/audio/src/AudioGate.cpp
+++ b/libraries/audio/src/AudioGate.cpp
@@ -13,6 +13,10 @@
 #include <cstdlib>
 #include "AudioDynamics.h"
 
+#ifdef __clang__
+#pragma clang optimize off
+#endif
+
 // log2 domain headroom bits above 0dB (int32_t)
 static const int LOG2_HEADROOM_Q30 = 1;
 


### PR DESCRIPTION
On a release build of the Mac client, mic audio was distorted when noise reduction is enabled, due to an invalid optimization by the compiler. Fixed in this PR.

### Test Plan
On a Mac, verify that mic audio is no longer distorted when "Noise Reduction" is enabled. 
The audio noise gate should work as expected.
Testing on other platforms is not necessary.

