### PR TITLE
Fix model loading for real this time

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -222,16 +222,6 @@ void EntityTreeRenderer::updateChangedEntities(const render::ScenePointer& scene
         _renderablesToUpdate.insert({ entityId, renderable });
     }
 
-    // NOTE: Looping over all the entity renderers is likely to be a bottleneck in the future
-    // Currently, this is necessary because the model entity loading logic requires constant polling
-    // This was working fine because the entity server used to send repeated updates as your view changed,
-    // but with the improved entity server logic (PR 11141), updateInScene (below) would not be triggered enough
-    for (const auto& entry : _entitiesInScene) {
-        const auto& renderable = entry.second;
-        if (renderable) {
-            renderable->update(scene, transaction);
-        }
-    }
     if (!_renderablesToUpdate.empty()) {
         for (const auto& entry : _renderablesToUpdate) {
             const auto& renderable = entry.second;

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -329,25 +329,27 @@ bool EntityRenderer::needsRenderUpdateFromEntity(const EntityItemPointer& entity
     return false;
 }
 
-void EntityRenderer::doRenderUpdateAsynchronous(const EntityItemPointer& entity) {
-    auto transparent = isTransparent();
-    if (_prevIsTransparent && !transparent) {
-        _isFading = false;
-    }
-    _prevIsTransparent = transparent;
+void EntityRenderer::doRenderUpdateSynchronous(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) {
+    withWriteLock([&] {
+        auto transparent = isTransparent();
+        if (_prevIsTransparent && !transparent) {
+            _isFading = false;
+        }
+        _prevIsTransparent = transparent;
 
-    bool success = false;
-    auto bound = entity->getAABox(success);
-    if (success) {
-        _bound = bound;
-    }
-    auto newModelTransform = entity->getTransformToCenter(success);
-    if (success) {
-        _modelTransform = newModelTransform;
-    }
+        bool success = false;
+        auto bound = entity->getAABox(success);
+        if (success) {
+            _bound = bound;
+        }
+        auto newModelTransform = entity->getTransformToCenter(success);
+        if (success) {
+            _modelTransform = newModelTransform;
+        }
 
-    _moving = entity->isMovingRelativeToParent();
-    _visible = entity->getVisible();
+        _moving = entity->isMovingRelativeToParent();
+        _visible = entity->getVisible();
+    });
 }
 
 void EntityRenderer::onAddToScene(const EntityItemPointer& entity) {

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -291,18 +291,6 @@ void EntityRenderer::updateInScene(const ScenePointer& scene, Transaction& trans
     });
 }
 
-void EntityRenderer::update(const ScenePointer& scene, Transaction& transaction) {
-    if (!isValidRenderItem()) {
-        return;
-    }
-
-    if (!needsUpdate()) {
-        return;
-    }
-
-    doUpdate(scene, transaction, _entity);
-}
-
 //
 // Internal methods
 //
@@ -314,11 +302,6 @@ bool EntityRenderer::needsRenderUpdate() const {
         return true;
     }
     return needsRenderUpdateFromEntity(_entity);
-}
-
-// Returns true if the item needs to have update called
-bool EntityRenderer::needsUpdate() const {
-    return needsUpdateFromEntity(_entity);
 }
 
 // Returns true if the item in question needs to have updateInScene called because of changes in the entity

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -73,12 +73,12 @@ protected:
 
     // Will be called on the main thread from updateInScene.  This can be used to fetch things like 
     // network textures or model geometry from resource caches
-    virtual void doRenderUpdateSynchronous(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) {  }
+    virtual void doRenderUpdateSynchronous(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity);
 
     // Will be called by the lambda posted to the scene in updateInScene.  
     // This function will execute on the rendering thread, so you cannot use network caches to fetch
     // data in this method if using multi-threaded rendering
-    virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity);
+    virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity) { }
 
     // Called by the `render` method after `needsRenderUpdate`
     virtual void doRender(RenderArgs* args) = 0;

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -49,8 +49,6 @@ public:
     virtual bool addToScene(const ScenePointer& scene, Transaction& transaction) final;
     virtual void removeFromScene(const ScenePointer& scene, Transaction& transaction);
 
-    virtual void update(const ScenePointer& scene, Transaction& transaction);
-
 protected:
     virtual bool needsRenderUpdateFromEntity() const final { return needsRenderUpdateFromEntity(_entity); }
     virtual void onAddToScene(const EntityItemPointer& entity);
@@ -73,12 +71,6 @@ protected:
     // Returns true if the item in question needs to have updateInScene called because of changes in the entity
     virtual bool needsRenderUpdateFromEntity(const EntityItemPointer& entity) const;
 
-    // Returns true if the item in question needs to have update called
-    virtual bool needsUpdate() const;
-
-    // Returns true if the item in question needs to have update called because of changes in the entity
-    virtual bool needsUpdateFromEntity(const EntityItemPointer& entity) const { return false; }
-
     // Will be called on the main thread from updateInScene.  This can be used to fetch things like 
     // network textures or model geometry from resource caches
     virtual void doRenderUpdateSynchronous(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) {  }
@@ -87,8 +79,6 @@ protected:
     // This function will execute on the rendering thread, so you cannot use network caches to fetch
     // data in this method if using multi-threaded rendering
     virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity);
-
-    virtual void doUpdate(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) { }
 
     // Called by the `render` method after `needsRenderUpdate`
     virtual void doRender(RenderArgs* args) = 0;
@@ -158,15 +148,6 @@ protected:
         onRemoveFromSceneTyped(_typedEntity);
     }
 
-    using Parent::needsUpdateFromEntity;
-    // Returns true if the item in question needs to have update called because of changes in the entity
-    virtual bool needsUpdateFromEntity(const EntityItemPointer& entity) const override final {
-        if (Parent::needsUpdateFromEntity(entity)) {
-            return true;
-        }
-        return needsUpdateFromTypedEntity(_typedEntity);
-    }
-
     using Parent::needsRenderUpdateFromEntity;
     // Returns true if the item in question needs to have updateInScene called because of changes in the entity
     virtual bool needsRenderUpdateFromEntity(const EntityItemPointer& entity) const override final {
@@ -181,11 +162,6 @@ protected:
         doRenderUpdateSynchronousTyped(scene, transaction, _typedEntity);
     }
 
-    virtual void doUpdate(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) override final {
-        Parent::doUpdate(scene, transaction, entity);
-        doUpdateTyped(scene, transaction, _typedEntity);
-    }
-
     virtual void doRenderUpdateAsynchronous(const EntityItemPointer& entity) override final {
         Parent::doRenderUpdateAsynchronous(entity);
         doRenderUpdateAsynchronousTyped(_typedEntity);
@@ -194,8 +170,6 @@ protected:
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const { return false; }
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) { }
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) { }
-    virtual bool needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const { return false; }
-    virtual void doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) { }
     virtual void onAddToSceneTyped(const TypedEntityPointer& entity) { }
     virtual void onRemoveFromSceneTyped(const TypedEntityPointer& entity) { }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1026,7 +1026,7 @@ void ModelEntityRenderer::animate(const TypedEntityPointer& entity) {
     entity->copyAnimationJointDataToModel();
 }
 
-bool ModelEntityRenderer::needsUpdate() const {
+bool ModelEntityRenderer::needsRenderUpdate() const {
     ModelPointer model;
     withReadLock([&] {
         model = _model;
@@ -1061,10 +1061,10 @@ bool ModelEntityRenderer::needsUpdate() const {
             return true;
         }
     }
-    return Parent::needsUpdate();
+    return Parent::needsRenderUpdate();
 }
 
-bool ModelEntityRenderer::needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const {
+bool ModelEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const {
     if (resultWithReadLock<bool>([&] {
         if (entity->hasModel() != _hasModel) {
             return true;
@@ -1126,7 +1126,7 @@ bool ModelEntityRenderer::needsUpdateFromTypedEntity(const TypedEntityPointer& e
     return false;
 }
 
-void ModelEntityRenderer::doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) {
+void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) {
     if (_hasModel != entity->hasModel()) {
         _hasModel = entity->hasModel();
     }
@@ -1250,6 +1250,7 @@ void ModelEntityRenderer::doUpdateTyped(const ScenePointer& scene, Transaction& 
 void ModelEntityRenderer::handleModelLoaded(bool success) {
     if (success) {
         _modelJustLoaded = true;
+        emit requestRenderUpdate();
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1145,7 +1145,6 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
             model->removeFromScene(scene, transaction);
             withWriteLock([&] { _model.reset(); });
         }
-        emit requestRenderUpdate();
         return;
     }
 
@@ -1169,7 +1168,6 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
 
     // Nothing else to do unless the model is loaded
     if (!model->isLoaded()) {
-        emit needsRenderUpdate();
         return;
     }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -138,10 +138,10 @@ protected:
     virtual ItemKey getKey() override;
     virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) override;
 
-    virtual bool needsUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
-    virtual bool needsUpdate() const override;
+    virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
+    virtual bool needsRenderUpdate() const override;
     virtual void doRender(RenderArgs* args) override;
-    virtual void doUpdateTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
+    virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
 
 private:
     void animate(const TypedEntityPointer& entity);

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -151,7 +151,6 @@ private:
     // Transparency is handled in ModelMeshPartPayload
     virtual bool isTransparent() const override { return false; }
 
-    bool _modelJustLoaded { false };
     bool _hasModel { false };
     ::ModelPointer _model;
     GeometryResource::Pointer _compoundShapeResource;
@@ -180,8 +179,6 @@ private:
     uint64_t _lastAnimated { 0 };
     float _currentFrame { 0 };
 
-private slots:
-    void handleModelLoaded(bool success);
 };
 
 } } // namespace 

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -29,7 +29,6 @@ protected:
     virtual bool needsRenderUpdate() const override;
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
-    virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
     virtual void doRender(RenderArgs* args) override;
     virtual bool isTransparent() const override;
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -814,11 +814,13 @@ void Model::setTextures(const QVariantMap& textures) {
         _needsUpdateTextures = true;
         _needsFixupInScene = true;
         _renderGeometry->setTextures(textures);
+        emit requestRenderUpdate();
     } else {
         // FIXME(Huffman): Disconnect previously connected lambdas so we don't set textures multiple
         // after the geometry has finished loading.
         connect(&_renderWatcher, &GeometryResourceWatcher::finished, this, [this, textures]() {
             _renderGeometry->setTextures(textures);
+            emit requestRenderUpdate();
         });
     }
 }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -267,6 +267,11 @@ void Model::updateRenderItems() {
     });
 }
 
+void Model::setRenderItemsNeedUpdate() {
+    _renderItemsNeedUpdate = true;
+    emit requestRenderUpdate();
+}
+
 void Model::initJointTransforms() {
     if (isLoaded()) {
         glm::mat4 modelOffset = glm::scale(_scale) * glm::translate(_offset);
@@ -814,13 +819,11 @@ void Model::setTextures(const QVariantMap& textures) {
         _needsUpdateTextures = true;
         _needsFixupInScene = true;
         _renderGeometry->setTextures(textures);
-        emit requestRenderUpdate();
     } else {
         // FIXME(Huffman): Disconnect previously connected lambdas so we don't set textures multiple
         // after the geometry has finished loading.
         connect(&_renderWatcher, &GeometryResourceWatcher::finished, this, [this, textures]() {
             _renderGeometry->setTextures(textures);
-            emit requestRenderUpdate();
         });
     }
 }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -103,7 +103,7 @@ public:
     bool isLayeredInFront() const { return _isLayeredInFront; }
 
     virtual void updateRenderItems();
-    void setRenderItemsNeedUpdate() { _renderItemsNeedUpdate = true; emit requestRenderUpdate(); }
+    void setRenderItemsNeedUpdate();
     bool getRenderItemsNeedUpdate() { return _renderItemsNeedUpdate; }
     AABox getRenderableMeshBound() const;
     const render::ItemIDs& fetchRenderItemIDs() const;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -103,7 +103,7 @@ public:
     bool isLayeredInFront() const { return _isLayeredInFront; }
 
     virtual void updateRenderItems();
-    void setRenderItemsNeedUpdate() { _renderItemsNeedUpdate = true; }
+    void setRenderItemsNeedUpdate() { _renderItemsNeedUpdate = true; emit requestRenderUpdate(); }
     bool getRenderItemsNeedUpdate() { return _renderItemsNeedUpdate; }
     AABox getRenderableMeshBound() const;
     const render::ItemIDs& fetchRenderItemIDs() const;
@@ -265,6 +265,7 @@ public slots:
 signals:
     void setURLFinished(bool success);
     void setCollisionModelURLFinished(bool success);
+    void requestRenderUpdate();
 
 protected:
 


### PR DESCRIPTION
- cherry pick the performance fix that went into RC-56 (which would break model loading on master)
- start moving any work that captures values from gameplay entities out of doRenderUpdateAsynchronousTyped and into doRenderUpdateSynchronousTyped, where it belongs
- move around and add some locking to support ^ that ^

This is part 1 of work that needs to be done to fix doRenderUpdateAsynchronousTyped so that it doesn't capture gameplay values in the render thread.  There is more work to be done, but hopefully this doesn't break anything new.

Test plan:
- Download a content set with a good number of model entities. Make sure there are multiple models with exactly the same fbx file and at least some models that have parent model entities. The dev-welcome content is pretty good, but it would be good to test other content sets too.
- All model entities should load normally. Reload your content (Edit -> Reload Content) while looking at one part of the domain and then turn to look behind you. No models should be missing once all your downloads finish.
- If model A and model B have the same model file and you look at only model A (model B is out of view and at least several meters away), reload content, and wait a while so that everything has loaded, when you turn to look at model B it should appear.
- Create some of each type of entity.  Modify their properties (color, visibility, textures, model url, dimensions, etc.).  For each type, the changes should take effect as expected.  Pay special attention to models, shapes, and web entities.
- Compare performance to identical content with master right now. You should see noticeably better sim rate/game rate in this PR.