### PR TITLE
Commerce backend changes sync, October 5 2017

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -892,6 +892,10 @@ Rectangle {
         } else {
             root.activeView = "checkoutSuccess";
         }
+        root.balanceReceived = false;
+        root.purchasesReceived = false;
+        commerce.inventory();
+        commerce.balance();
     }
 
     //

--- a/interface/resources/qml/hifi/commerce/common/EmulatedMarketplaceHeader.qml
+++ b/interface/resources/qml/hifi/commerce/common/EmulatedMarketplaceHeader.qml
@@ -39,7 +39,7 @@ Item {
                 sendToParent({method: "needsLogIn"});
             } else if (walletStatus === 3) {
                 commerce.getSecurityImage();
-            } else {
+            } else if (walletStatus > 3) {
                 console.log("ERROR in EmulatedMarketplaceHeader.qml: Unknown wallet status: " + walletStatus);
             }
         }

--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -52,7 +52,6 @@ Item {
             statusText.text = "CONFIRMED!";
             statusText.color = hifi.colors.blueAccent;
             confirmedTimer.start();
-            root.purchaseStatusChanged = false;
         }
     }
 
@@ -62,6 +61,7 @@ Item {
         onTriggered: {
             statusText.text = root.originalStatusText;
             statusText.color = root.originalStatusColor;
+            root.purchaseStatusChanged = false;
         }
     }
 
@@ -205,7 +205,7 @@ Item {
 
         Item {
             id: statusContainer;
-            visible: root.purchaseStatus === "pending" || root.purchaseStatus === "invalidated";
+            visible: root.purchaseStatus === "pending" || root.purchaseStatus === "invalidated" || root.purchaseStatusChanged;
             anchors.left: itemName.left;
             anchors.top: certificateContainer.bottom;
             anchors.topMargin: 8;

--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -36,6 +36,8 @@ Item {
     property string itemHref;
     property int displayedItemCount;
     property int itemEdition;
+    property int numberSold;
+    property int limitedRun;
 
     property string originalStatusText;
     property string originalStatusColor;
@@ -222,6 +224,8 @@ Item {
                             "PENDING..."
                         } else if (root.purchaseStatus === "invalidated") {
                             "INVALIDATED"
+                        } else if (root.numberSold !== -1) {
+                            ("Sales: " + root.numberSold + "/" + (root.limitedRun === -1 ? "INFTY" : root.limitedRun))
                         } else {
                             ""
                         }

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -430,6 +430,8 @@ Rectangle {
                 purchaseStatus: status;
                 purchaseStatusChanged: statusChanged;
                 itemEdition: model.edition_number;
+                numberSold: model.number_sold;
+                limitedRun: model.limited_run;
                 displayedItemCount: model.displayedItemCount;
                 anchors.topMargin: 12;
                 anchors.bottomMargin: 12;

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -81,8 +81,10 @@ Rectangle {
             if (result.status !== 'success') {
                 console.log("Failed to get purchases", result.message);
             } else {
+                var inventoryResult = processInventoryResult(result.data.assets);
+
                 purchasesModel.clear();
-                purchasesModel.append(result.data.assets);
+                purchasesModel.append(inventoryResult);
 
                 if (previousPurchasesModel.count !== 0) {
                     checkIfAnyItemStatusChanged();
@@ -93,7 +95,7 @@ Rectangle {
                         purchasesModel.setProperty(i, "statusChanged", false);
                     }
                 }
-                previousPurchasesModel.append(result.data.assets);
+                previousPurchasesModel.append(inventoryResult);
 
                 buildFilteredPurchasesModel();
 
@@ -589,6 +591,17 @@ Rectangle {
     //
     // FUNCTION DEFINITIONS START
     //
+
+    function processInventoryResult(inventory) {
+        for (var i = 0; i < inventory.length; i++) {
+            if (inventory[i].status.length > 1) {
+                console.log("WARNING: Inventory result index " + i + " has a status of length >1!")
+            }
+            inventory[i].status = inventory[i].status[0];
+            inventory[i].categories = inventory[i].categories.join(';');
+        }
+        return inventory;
+    }
 
     function populateDisplayedItemCounts() {
         var itemCountDictionary = {};

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -197,6 +197,8 @@ Item {
             height: 50;
             echoMode: TextInput.Password;
             placeholderText: "passphrase";
+            activeFocusOnPress: true;
+            activeFocusOnTab: true;
 
             onFocusChanged: {
                 root.keyboardRaised = focus;
@@ -206,8 +208,8 @@ Item {
                 anchors.fill: parent;
 
                 onClicked: {
-                    parent.focus = true;
                     root.keyboardRaised = true;
+                    mouse.accepted = false;
                 }
             }
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -40,6 +40,7 @@
 #include "scripting/HMDScriptingInterface.h"
 #include "scripting/AssetMappingsScriptingInterface.h"
 #include "scripting/MenuScriptingInterface.h"
+#include "scripting/SettingsScriptingInterface.h"
 #include <Preferences.h>
 #include <ScriptEngines.h>
 #include "FileDialogHelper.h"
@@ -243,6 +244,7 @@ void Web3DOverlay::setupQmlSurface() {
         _webSurface->getSurfaceContext()->setContextProperty("InputConfiguration", DependencyManager::get<InputConfiguration>().data());
         _webSurface->getSurfaceContext()->setContextProperty("SoundCache", DependencyManager::get<SoundCache>().data());
         _webSurface->getSurfaceContext()->setContextProperty("MenuInterface", MenuScriptingInterface::getInstance());
+        _webSurface->getSurfaceContext()->setContextProperty("Settings", SettingsScriptingInterface::getInstance());
 
         _webSurface->getSurfaceContext()->setContextProperty("pathToFonts", "../../");
 


### PR DESCRIPTION
This PR brings the Interface side of Commerce up-to-date with the latest backend code (specifically [data-web PR 1045](https://github.com/highfidelity/data-web/pull/1045/files)).

I also added some code in there that'll work once "My Items" support is added on the backend.

**Test Plan:**
1. Ensure `"commerce": true,` is set in your `Interface.json` settings file.
2. Set up your Wallet
3. Buy something from the Marketplace (such as the Test Beach Ball)
4. Quickly go to the Purchases view
5. Verify that you see a status of "Pending" underneath the card associated with the item you just purchased
6. Wait 90 seconds
7. Verify that the "Pending" text is replaced with "Confirmed" text, which then disappears after 3 seconds