### PR TITLE
Fix DQT_CMAKE_PREFIX_PATH being overwritten

### DIFF
--- a/cmake/macros/SetupQt.cmake
+++ b/cmake/macros/SetupQt.cmake
@@ -44,7 +44,11 @@ endfunction()
 # Sets the QT_CMAKE_PREFIX_PATH and QT_DIR variables
 # Also enables CMAKE_AUTOMOC and CMAKE_AUTORCC
 macro(setup_qt)
-    set(QT_CMAKE_PREFIX_PATH "$ENV{QT_CMAKE_PREFIX_PATH}")
+    # if QT_CMAKE_PREFIX_PATH was not specified before hand,
+    # try to use the environment variable
+    if (NOT QT_CMAKE_PREFIX_PATH)
+        set(QT_CMAKE_PREFIX_PATH "$ENV{QT_CMAKE_PREFIX_PATH}")
+    endif()
     if (("QT_CMAKE_PREFIX_PATH" STREQUAL "") OR (NOT EXISTS "${QT_CMAKE_PREFIX_PATH}"))
         calculate_default_qt_dir(QT_DIR)
         set(QT_CMAKE_PREFIX_PATH "${QT_DIR}/lib/cmake")


### PR DESCRIPTION
This change allows -DQT_CMAKE_PREFIX_PATH to function again. Previously, `set(QT_CMAKE_PREFIX_PATH "$ENV{QT_CMAKE_PREFIX_PATH}")` always ran, which overrode QT_CMAKE_PREFIX_PATH every time on cmake. This proposed change now only uses the environment variable if DQT_CMAKE_PREFIX_PATH is not specified.