### PR TITLE
Fix rendering transform for text3d overlays

### DIFF
--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -88,6 +88,7 @@ void Text3DOverlay::update(float deltatime) {
         applyTransformTo(transform);
         setTransform(transform);
     }
+    Parent::update(deltatime);
 }
 
 void Text3DOverlay::render(RenderArgs* args) {


### PR DESCRIPTION
Class was not calling `Parent::update` and was therefore always rendering with an identity `_renderTransform` value.  

## Testing 

Save the following script to a JS file and run it in Interface.  In desktop mode clicking the button will create a notification with the text _Test_.  In HMD mode on master no notification will appear (although if you go to location 0,0,0 you may see the notification object appear at the origin.

In this PR, while in the HMD the notification should appear near the bottom of your display as before.  

```
"use strict";

(function () { 
    var button;
    var buttonName = "NOTIFY";
    var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
    button = tablet.addButton({ text: buttonName });
    button.clicked.connect(function() { Window.displayAnnouncement("Test"); });
    Script.scriptEnding.connect(function () { if (tablet) { tablet.removeButton(button); } });
}());
```
