### PR TITLE
Cherry-pick "Model asks for renderUpdate if animating" into master

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1240,6 +1240,7 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
             mapJoints(entity, model->getJointNames());
         }
         animate(entity);
+        emit requestRenderUpdate();
     }
 }
 


### PR DESCRIPTION
Models need to request constant renderUpdates if they are animating (this was being done in render() before, but we made Models only meta, so they weren't calling that anymore).

Test Plan:
- Models should animate without you having to move your head.
- Performance smoke test with content that has several animating models.