### PR TITLE
WL: 21549 - Demonstrate glow outline effect on near-grabbing

### DIFF
--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -42,7 +42,7 @@ Script.include("/~/system/libraries/controllers.js");
             nearbyEntity = controllerData.nearbyEntityProperties[_this.hand ? RIGHT_HAND : LEFT_HAND][0];
             maybeEntityOtherHand = controllerData.nearbyEntityProperties[_this.hand ? LEFT_HAND : RIGHT_HAND][0];
 
-            //limited to grabbable and clonable objects for two reasons. If you are inside of a zone it registers in this list.
+            //limited to grabbable and cloneable objects for two reasons. If you are inside of a zone it registers in this list.
             // and i think this feature was meant for objects that can be picked up.
             if (nearbyEntity) {
                 if (nearbyEntity.userData) {
@@ -73,17 +73,15 @@ Script.include("/~/system/libraries/controllers.js");
                     }
                 }
 
+            } else if (_this.activeHighlightObject !== null &&
+                maybeEntityOtherHand && maybeEntityOtherHand.id === _this.activeHighlightObject.id) {
+                _this.activeHighlightObject = null;
 
-            } else if (_this.activeHighlightObject !== null) {
+            } else if (_this.activeHighlightObject !== null &&
+                !maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id) {
 
-                if (maybeEntityOtherHand && maybeEntityOtherHand.id === _this.activeHighlightObject.id) {
-                    _this.activeHighlightObject = null;
-                }
-
-                if (!maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id) {
-                    Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
-                    _this.activeHighlightObject = null;
-                }
+                Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
+                _this.activeHighlightObject = null;
 
             }
 

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -82,7 +82,7 @@ Script.include("/~/system/libraries/controllers.js");
 
             }
 
-            return makeRunningValues(true, [], []);
+            return makeRunningValues(false, [], []); // not sure why but this needs to be false to let the stylus and hands and stuff work
         };
     }
 

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -1,18 +1,18 @@
 "use strict";
 
-//  overlayLaserInput.js
+//  highlightObjectInNearGrabRange.js
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
-
+// TODO: find globals list for here.
 
 Script.include("/~/system/libraries/controllerDispatcherUtils.js");
 Script.include("/~/system/libraries/controllers.js");
 
 (function() {
-    var debug = Script.require('https://debug.midnightrift.com/files/hifi/debug.min.js');
-    debug.connect('midnight');
+//    var debug = Script.require('https://debug.midnightrift.com/files/hifi/debug.min.js');
+//    debug.connect('midnight');
 
 
     function HighlightNearestGrabbableEntity(hand) {
@@ -34,19 +34,25 @@ Script.include("/~/system/libraries/controllers.js");
 
             //debug.send(JSON.stringify(controllerData.nearbyEntityProperties));
 
-            var nearbyEntity;
+            var nearbyEntity,
+                isGrabbable;
             // the closest object to the controller is already computed in the dispacher.
             nearbyEntity = controllerData.nearbyEntityProperties[_this.hand][0];
 
-            if(nearbyEntity) {
+            //limited to grabbable objects for two reasons. If you are inside of a zone it registers in this list.
+            // and i think this feature was meant for objects that can be picked up.
+            isGrabbable = (JSON.parse(entity.userData).grabbableKey.grabbable);
+
+
+            if(nearbyEntity && isGrabbable) {
                 if(_this.activeHighlightObject === null) {
-                    debug.send(JSON.stringify(nearbyEntity));
-                    debug.send({color:'green'}, 'YES nearbyEntity');
+//                    debug.send(JSON.stringify(nearbyEntity));
+//                    debug.send({color:'green'}, 'YES nearbyEntity');
                     _this.activeHighlightObject = nearbyEntity;
                     Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
                 } else {
                     if (_this.activeHighlightObject.id !== nearbyEntity.id) {
-                        debug.send({color:'red'}, 'ID NO MATCH');
+ //                       debug.send({color:'red'}, 'ID NO MATCH');
                         Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
                         _this.activeHighlightObject = nearbyEntity;
                         Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
@@ -56,7 +62,7 @@ Script.include("/~/system/libraries/controllers.js");
 
             } else if(_this.activeHighlightObject !== null) {
 
-                debug.send({color:'red'}, 'NO nearbyEntity and activeHighlightObject is not null', _this.hand ? ["rightHand"] : ["leftHand"]);
+ //               debug.send({color:'red'}, 'NO nearbyEntity and activeHighlightObject is not null', _this.hand ? ["rightHand"] : ["leftHand"]);
                 Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
                 _this.activeHighlightObject = null;
             }

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -75,6 +75,11 @@ Script.include("/~/system/libraries/controllers.js");
 
 
             } else if (_this.activeHighlightObject !== null) {
+
+                if (maybeEntityOtherHand && maybeEntityOtherHand.id === _this.activeHighlightObject.id) {
+                    _this.activeHighlightObject = null;
+                }
+
                 if (!maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id) {
                     Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
                     _this.activeHighlightObject = null;

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -10,9 +10,7 @@
 Script.include("/~/system/libraries/controllerDispatcherUtils.js");
 Script.include("/~/system/libraries/controllers.js");
 
-(function() {
-//    var debug = Script.require('https://debug.midnightrift.com/files/hifi/debug.min.js');
-//    debug.connect('midnight');
+(function () {
 
     function HighlightNearestGrabbableEntity(hand) {
         var _this = this;
@@ -21,8 +19,8 @@ Script.include("/~/system/libraries/controllers.js");
         this.parameters = makeDispatcherModuleParameters(
             610, // no idea what a good priority is
             _this.hand ? ["rightHand"] : ["leftHand"],
-            [],
-            100); // is this even implemented in the dispatcher?
+            [], // is this even implemented in the dispatcher?
+            100); // or this
 
         this.isReady = function (controllerData) {
 
@@ -40,16 +38,22 @@ Script.include("/~/system/libraries/controllers.js");
                 isCloneable,
                 maybeEntityOtherHand;
 
-            // the closest object to the controller is already computed in the dispacher.
+            // the closest object to the controller is already computed in the dispatcher.
             nearbyEntity = controllerData.nearbyEntityProperties[_this.hand ? RIGHT_HAND : LEFT_HAND][0];
             maybeEntityOtherHand = controllerData.nearbyEntityProperties[_this.hand ? LEFT_HAND : RIGHT_HAND][0];
 
             //limited to grabbable and clonable objects for two reasons. If you are inside of a zone it registers in this list.
             // and i think this feature was meant for objects that can be picked up.
             if (nearbyEntity) {
-                if(nearbyEntity.userData){
-                    var userData = JSON.parse(nearbyEntity.userData);
-                    if(userData.grabbableKey){
+                if (nearbyEntity.userData) {
+                    var userData;
+                    try {
+                        userData = JSON.parse(nearbyEntity.userData);
+                    } catch (e) {
+                        print(e);
+                    }
+
+                    if (userData && userData.grabbableKey) {
                         isGrabbable = (userData.grabbableKey.grabbable);
                         isCloneable = (userData.grabbableKey.cloneable);
                     }
@@ -57,13 +61,12 @@ Script.include("/~/system/libraries/controllers.js");
             }
 
 
-            if(nearbyEntity && isGrabbable || isCloneable) {
-                if(_this.activeHighlightObject === null) {
+            if (nearbyEntity && isGrabbable || isCloneable) {
+                if (_this.activeHighlightObject === null) {
                     _this.activeHighlightObject = nearbyEntity;
                     Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
                 } else {
                     if (_this.activeHighlightObject.id !== nearbyEntity.id) {
-                        //                       debug.send({color:'red'}, 'ID NO MATCH');
                         Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
                         _this.activeHighlightObject = nearbyEntity;
                         Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
@@ -71,15 +74,15 @@ Script.include("/~/system/libraries/controllers.js");
                 }
 
 
-            } else if(_this.activeHighlightObject !== null) {
-                if(!maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id ) {
+            } else if (_this.activeHighlightObject !== null) {
+                if (!maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id) {
                     Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
                     _this.activeHighlightObject = null;
                 }
 
             }
 
-            return makeRunningValues(false, [], []);
+            return makeRunningValues(true, [], []);
         };
     }
 

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -5,8 +5,6 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
-// TODO: find globals list for here.
-
 Script.include("/~/system/libraries/controllerDispatcherUtils.js");
 Script.include("/~/system/libraries/controllers.js");
 
@@ -22,10 +20,10 @@ Script.include("/~/system/libraries/controllers.js");
         };
 
         this.parameters = makeDispatcherModuleParameters(
-            610, // no idea what a good priority is
+            610,
             _this.hand ? ["rightHand"] : ["leftHand"],
-            [], // is this even implemented in the dispatcher?
-            100); // or this
+            [],
+            100);
 
         this.isReady = function (controllerData) {
 
@@ -44,8 +42,8 @@ Script.include("/~/system/libraries/controllers.js");
             // the closest object to the controller is already computed in the dispatcher.
             nearbyEntity = controllerData.nearbyEntityProperties[_this.hand][0];
 
-            //limited to grabbable and cloneable objects for two reasons. If you are inside of a zone it registers in this list.
-            // and i think this feature was meant for objects that can be picked up.
+            //limited to grabbable and cloneable objects, If you are inside of a zone it registers in this list.
+
             if (nearbyEntity) {
                 if (nearbyEntity.userData) {
                     var userData;
@@ -62,25 +60,27 @@ Script.include("/~/system/libraries/controllers.js");
                 }
             }
 
-            if (nearbyEntity && (isGrabbable || isCloneable) && _this.activeHighlightObject === null &&
-                (_this.getOtherModule().activeHighlightObject === null ||
-                    (_this.getOtherModule().activeHighlightObject &&
-                        nearbyEntity.id !== _this.getOtherModule().activeHighlightObject.id))) {
+            if (nearbyEntity && (isGrabbable || isCloneable)) {
+                if (_this.activeHighlightObject === null &&
+                    (_this.getOtherModule().activeHighlightObject === null ||
+                        (_this.getOtherModule().activeHighlightObject &&
+                            nearbyEntity.id !== _this.getOtherModule().activeHighlightObject.id))) {
 
-                _this.activeHighlightObject = nearbyEntity;
-                Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
-
-            } else if (nearbyEntity && (isGrabbable || isCloneable) && _this.activeHighlightObject !== null &&
-                _this.activeHighlightObject.id !== nearbyEntity.id) {
-
-                Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
-                if (_this.getOtherModule().activeHighlightObject === null ||
-                    (_this.getOtherModule().activeHighlightObject &&
-                        nearbyEntity.id !== _this.getOtherModule().activeHighlightObject.id)) {
                     _this.activeHighlightObject = nearbyEntity;
                     Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
-                } else {
-                    _this.activeHighlightObject = null;
+
+                } else if (_this.activeHighlightObject !== null &&
+                    _this.activeHighlightObject.id !== nearbyEntity.id) {
+
+                    Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
+                    if (_this.getOtherModule().activeHighlightObject === null ||
+                        (_this.getOtherModule().activeHighlightObject &&
+                            nearbyEntity.id !== _this.getOtherModule().activeHighlightObject.id)) {
+                        _this.activeHighlightObject = nearbyEntity;
+                        Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
+                    } else {
+                        _this.activeHighlightObject = null;
+                    }
                 }
 
             } else if (_this.activeHighlightObject !== null &&
@@ -93,8 +93,7 @@ Script.include("/~/system/libraries/controllers.js");
                 _this.activeHighlightObject = null;
 
             }
-
-            return makeRunningValues(false, [], []); // not sure why but this needs to be false to let the stylus and hands and stuff work
+            return makeRunningValues(false, [], []);
         };
     }
 
@@ -105,10 +104,10 @@ Script.include("/~/system/libraries/controllers.js");
     enableDispatcherModule("leftHighlightNearestGrabbableEntity", leftHighlightNearestGrabbableEntity);
     enableDispatcherModule("rightHighlightNearestGrabbableEntity", rightHighlightNearestGrabbableEntity);
 
-    this.cleanup = function () {
+    function clean() {
         disableDispatcherModule("leftHighlightNearestGrabbableEntity");
         disableDispatcherModule("rightHighlightNearestGrabbableEntity");
-    };
+    }
 
-    Script.scriptEnding.connect(this.cleanup);
+    Script.scriptEnding.connect(clean);
 }());

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -27,7 +27,11 @@ Script.include("/~/system/libraries/controllers.js");
 
         this.isReady = function (controllerData) {
 
-            return makeRunningValues(true, [], []);
+            if (controllerData.nearbyEntityProperties[_this.hand ? RIGHT_HAND : LEFT_HAND][0] || _this.activeHighlightObject !== null) {
+                return makeRunningValues(true, [], []);
+            }
+            return makeRunningValues(false, [], []);
+
         };
 
         this.run = function (controllerData) {
@@ -35,13 +39,18 @@ Script.include("/~/system/libraries/controllers.js");
             //debug.send(JSON.stringify(controllerData.nearbyEntityProperties));
 
             var nearbyEntity,
-                isGrabbable;
+                isGrabbable,
+                maybeEntityOtherHand;
+
             // the closest object to the controller is already computed in the dispacher.
-            nearbyEntity = controllerData.nearbyEntityProperties[_this.hand][0];
+            nearbyEntity = controllerData.nearbyEntityProperties[_this.hand ? RIGHT_HAND : LEFT_HAND][0];
+            maybeEntityOtherHand = controllerData.nearbyEntityProperties[_this.hand ? LEFT_HAND : RIGHT_HAND][0];
 
             //limited to grabbable objects for two reasons. If you are inside of a zone it registers in this list.
             // and i think this feature was meant for objects that can be picked up.
-            isGrabbable = (JSON.parse(entity.userData).grabbableKey.grabbable);
+            if (nearbyEntity) {
+                isGrabbable = (JSON.parse(nearbyEntity.userData).grabbableKey.grabbable);
+            }
 
 
             if(nearbyEntity && isGrabbable) {
@@ -52,7 +61,7 @@ Script.include("/~/system/libraries/controllers.js");
                     Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
                 } else {
                     if (_this.activeHighlightObject.id !== nearbyEntity.id) {
- //                       debug.send({color:'red'}, 'ID NO MATCH');
+                        //                       debug.send({color:'red'}, 'ID NO MATCH');
                         Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
                         _this.activeHighlightObject = nearbyEntity;
                         Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
@@ -61,10 +70,12 @@ Script.include("/~/system/libraries/controllers.js");
 
 
             } else if(_this.activeHighlightObject !== null) {
+                if(!maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id ) {
+//                    debug.send({color:'red'}, 'NO nearbyEntity and activeHighlightObject is not null', _this.hand ? ["rightHand"] : ["leftHand"]);
+                    Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
+                    _this.activeHighlightObject = null;
+                }
 
- //               debug.send({color:'red'}, 'NO nearbyEntity and activeHighlightObject is not null', _this.hand ? ["rightHand"] : ["leftHand"]);
-                Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
-                _this.activeHighlightObject = null;
             }
 
             return makeRunningValues(false, [], []);

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -1,0 +1,81 @@
+"use strict";
+
+//  overlayLaserInput.js
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+
+
+
+Script.include("/~/system/libraries/controllerDispatcherUtils.js");
+Script.include("/~/system/libraries/controllers.js");
+
+(function() {
+    var debug = Script.require('https://debug.midnightrift.com/files/hifi/debug.min.js');
+    debug.connect('midnight');
+
+
+    function HighlightNearestGrabbableEntity(hand) {
+        var _this = this;
+        this.hand = hand;
+        this.activeHighlightObject = null;
+        this.parameters = makeDispatcherModuleParameters(
+            4000, // no idea what a good priority is
+            _this.hand ? ["rightHand"] : ["leftHand"],
+            [],
+            500); // is half a second to long ?
+
+        this.isReady = function (controllerData) {
+
+            return makeRunningValues(true, [], []);
+        };
+
+        this.run = function (controllerData) {
+
+            //debug.send(JSON.stringify(controllerData.nearbyEntityProperties));
+
+            var nearbyEntity;
+            // the closest object to the controller is already computed in the dispacher.
+            nearbyEntity = controllerData.nearbyEntityProperties[_this.hand][0];
+
+            if(nearbyEntity) {
+                if(_this.activeHighlightObject === null) {
+                    debug.send(JSON.stringify(nearbyEntity));
+                    debug.send({color:'green'}, 'YES nearbyEntity');
+                    _this.activeHighlightObject = nearbyEntity;
+                    Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
+                } else {
+                    if (_this.activeHighlightObject.id !== nearbyEntity.id) {
+                        debug.send({color:'red'}, 'ID NO MATCH');
+                        Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
+                        _this.activeHighlightObject = nearbyEntity;
+                        Selection.addToSelectedItemsList("contextOverlayHighlightList", 'entity', nearbyEntity.id);
+                    }
+                }
+
+
+            } else if(_this.activeHighlightObject !== null) {
+
+                debug.send({color:'red'}, 'NO nearbyEntity and activeHighlightObject is not null', _this.hand ? ["rightHand"] : ["leftHand"]);
+                Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
+                _this.activeHighlightObject = null;
+            }
+
+            return makeRunningValues(false, [], []);
+        };
+    }
+
+
+    var leftHighlightNearestGrabbableEntity = new HighlightNearestGrabbableEntity(LEFT_HAND);
+    var rightHighlightNearestGrabbableEntity = new HighlightNearestGrabbableEntity(RIGHT_HAND);
+
+    enableDispatcherModule("leftHighlightNearestGrabbableEntity", leftHighlightNearestGrabbableEntity);
+    enableDispatcherModule("rightHighlightNearestGrabbableEntity", rightHighlightNearestGrabbableEntity);
+
+    this.cleanup = function () {
+        disableDispatcherModule("leftHighlightNearestGrabbableEntity");
+        disableDispatcherModule("rightHighlightNearestGrabbableEntity");
+    };
+
+    Script.scriptEnding.connect(this.cleanup);
+}());

--- a/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
+++ b/scripts/system/controllers/controllerModules/highlightObjectInNearGrabRange.js
@@ -74,11 +74,11 @@ Script.include("/~/system/libraries/controllers.js");
                 }
 
             } else if (_this.activeHighlightObject !== null &&
-                maybeEntityOtherHand && maybeEntityOtherHand.id === _this.activeHighlightObject.id) {
+                (maybeEntityOtherHand && maybeEntityOtherHand.id === _this.activeHighlightObject.id)) {
                 _this.activeHighlightObject = null;
 
             } else if (_this.activeHighlightObject !== null &&
-                !maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id) {
+                (!maybeEntityOtherHand || maybeEntityOtherHand && maybeEntityOtherHand.id !== _this.activeHighlightObject.id)) {
 
                 Selection.removeFromSelectedItemsList("contextOverlayHighlightList", 'entity', _this.activeHighlightObject.id);
                 _this.activeHighlightObject = null;

--- a/scripts/system/controllers/controllerScripts.js
+++ b/scripts/system/controllers/controllerScripts.js
@@ -32,7 +32,8 @@ var CONTOLLER_SCRIPTS = [
     "controllerModules/scaleAvatar.js",
     "controllerModules/hudOverlayPointer.js",
     "controllerModules/mouseHMD.js",
-    "controllerModules/scaleEntity.js"
+    "controllerModules/scaleEntity.js",
+    "controllerModules/highlightObjectInNearGrabRange.js"
 ];
 
 var DEBUG_MENU_ITEM = "Debug defaultScripts.js";


### PR DESCRIPTION
# Info
Demonstrate glow effect on near grabbable entities. an entity that is grabbable should highlight. The effect is on by default

## Reqs
- HMD Required.

# QA

## Setup
- Install the latest Interface this PR generates
- Create Three entities one of which has the properties set to not grabbable.
- Get into HMD
## Steps - Two Person

| | Steps | Expected results |
| --- | --- | --- |
| 1. | place your controller(hand) near an Entity that is grabbable. | The entity should be highlighted. |
| 2. | place your other controller(hand) the other entity with your other hand. | Both Entities should be highlighted. |
| 3. | take your hand away from one entity | The Entity should no longer be highlighted. |
| 4. | Take your hand away from the other entity | The Entity should no longer be highlighted |
| 5. | Place both hands near an entity |  The Entity should be highlighted. |
| 6. | Remove a hand from near the entity |  The Entity should Remain highlighted. |
| 7. | Remove the other hand from near the entity |  The Entity should no longer be highlighted. |
| 8. | Place a hand near the non-grabbabale entity |  The Entity should *not* be highlighted. |
