### PR TITLE
Fix .fst texdir not being followed

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -71,14 +71,14 @@ void GeometryMappingResource::downloadFinished(const QByteArray& data) {
     } else {
         QUrl url = _url.resolved(filename);
 
-        QString texdir = mapping.value("texdir").toString();
+        QString texdir = mapping.value(TEXDIR_FIELD).toString();
         if (!texdir.isNull()) {
             if (!texdir.endsWith('/')) {
                 texdir += '/';
             }
             _textureBaseUrl = resolveTextureBaseUrl(url, _url.resolved(texdir));
         } else {
-            _textureBaseUrl = _effectiveBaseURL;
+            _textureBaseUrl = url.resolved(QUrl("."));
         }
 
         auto animGraphVariant = mapping.value("animGraphUrl");
@@ -241,8 +241,10 @@ private:
 };
 
 void GeometryDefinitionResource::downloadFinished(const QByteArray& data) {
-    _url = _effectiveBaseURL;
-    _textureBaseUrl = _effectiveBaseURL;
+    if (_url != _effectiveBaseURL) {
+        _url = _effectiveBaseURL;
+        _textureBaseUrl = _effectiveBaseURL;
+    }
     QThreadPool::globalInstance()->start(new GeometryReader(_self, _effectiveBaseURL, _mapping, data, _combineParts));
 }
 


### PR DESCRIPTION
Although the texdir was being acknowledged and used as the
_textureBaseURL inside of the Geometry* classes, it was being
overwritten in code meant to handle redirects. Basically, when a
geometry resource request is redirected (via ATP, HTTP, etc.), we needed
to update the _textureBaseURL to take the new location into account.
Previously we were overwriting the _textureBaseURL all the time, even
when not being redirected, but this updates it to only be overwritten
when the request is redirected.

There is at least 1 known case that this does not handle: a .fst with
its `texdir` set, that points at an fbx that gets redirected.