### PR TITLE
Remove unnecessary blocking call

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -741,13 +741,6 @@ void Overlays::sendHoverLeaveOverlay(const OverlayID& id, const PointerEvent& ev
 }
 
 OverlayID Overlays::getKeyboardFocusOverlay() {
-    if (QThread::currentThread() != thread()) {
-        OverlayID result;
-        PROFILE_RANGE(script, __FUNCTION__);
-        BLOCKING_INVOKE_METHOD(this, "getKeyboardFocusOverlay", Q_RETURN_ARG(OverlayID, result));
-        return result;
-    }
-
     return qApp->getKeyboardFocusOverlay();
 }
 


### PR DESCRIPTION
The blocking call in Overlays is unnecessary, because the  call `Application::getKeyboardFocusOverlay` it makes is explicitly thread safe.  Additionally, this could be impacting stylus performance and other UI interactions because it's called frequently via the `TouchEventUtils.touchTargetHasKeyboardFocus` method.

## Testing

Application behavior should be unchanged.  However, if entering a domain where the sim rate is lower than the render rate, this should improve the stylus interaction behavior with the tablet (and possibly other interactions with potentially keyboard focus-able entities and overlays.

Run all tests related to tablet/stylus interaction.