### PR TITLE
Fix KTX requests thrashing if a mip level can't be assigned

### DIFF
--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -620,6 +620,12 @@ void NetworkTexture::ktxMipRequestFinished() {
 
                 texture->assignStoredMip(mipLevel, data.size(), reinterpret_cast<const uint8_t*>(data.data()));
 
+                // If mip level assigned above is still unavailable, then we assume future requests will also fail.
+                auto minMipLevel = texture->minAvailableMipLevel();
+                if (minMipLevel > mipLevel) {
+                    return;
+                }
+
                 QMetaObject::invokeMethod(resource.data(), "setImage",
                     Q_ARG(gpu::TexturePointer, texture),
                     Q_ARG(int, texture->getWidth()),


### PR DESCRIPTION
When downloading a mip level and assigning it to the underlying
resource, we weren't checking to see if the assignment was successful.
If it was unsuccessful, we would queue up a request for the next mip
which would end up being a request for the same mip that was just
attempted. This change fixes this problem by checking to see if the
texture's available mip level is at least <= the assigned mip level.