### PR TITLE
workaround for https://bugreports.qt.io/browse/QTBUG-49297

### DIFF
--- a/interface/resources/qml/controls-uit/TextField.qml
+++ b/interface/resources/qml/controls-uit/TextField.qml
@@ -39,6 +39,20 @@ TextField {
 
     y: textFieldLabel.visible ? textFieldLabel.height + textFieldLabel.anchors.bottomMargin : 0
 
+    // workaround for https://bugreports.qt.io/browse/QTBUG-49297
+    Keys.onPressed: {
+        switch (event.key) {
+            case Qt.Key_Return: 
+            case Qt.Key_Enter: 
+                event.accepted = true;
+
+                // emit accepted signal manually
+                if (acceptableInput) {
+                    accepted();
+                }
+        }
+    }
+
     style: TextFieldStyle {
         textColor: {
             if (isLightColorScheme) {


### PR DESCRIPTION
As the 'side effect' workaround should also fix https://highfidelity.fogbugz.com/f/cases/8255/Commerce-text-field-focus-fix