### PR TITLE
Fix the HDR generation of cube maps from equirect images (1x2)

### DIFF
--- a/libraries/image/src/image/Image.cpp
+++ b/libraries/image/src/image/Image.cpp
@@ -1202,10 +1202,6 @@ gpu::TexturePointer TextureUsage::processCubeTextureColorFromImage(const QImage&
             formatGPU = HDR_FORMAT;
         }
 
-        if (image.format() != QIMAGE_HDR_FORMAT) {
-            image = convertToHDRFormat(image, HDR_FORMAT);
-        }
-
         // Find the layout of the cubemap in the 2D image
         // Use the original image size since processSourceImage may have altered the size / aspect ratio
         int foundLayout = CubeLayout::findLayout(srcImage.width(), srcImage.height());
@@ -1233,6 +1229,13 @@ gpu::TexturePointer TextureUsage::processCubeTextureColorFromImage(const QImage&
                     faces.push_back(faceImage);
                 }
             }
+
+            if (image.format() != QIMAGE_HDR_FORMAT) {
+                for (auto& face : faces) {
+                    face = convertToHDRFormat(face, HDR_FORMAT);
+                }
+            }
+
         } else {
             qCDebug(imagelogging) << "Failed to find a known cube map layout from this image:" << QString(srcImageName.c_str());
             return nullptr;


### PR DESCRIPTION
This pr fixes the HDR generation of cube maps from equi-rectangular.
I simply moved the HDR conversion at the end of the process on the 6 faces instead of doing it early on on the source data.

## TEST PLAN 
- Using this equirect image for example:
http://previewcf.turbosquid.com/Preview/2014/08/01__20_40_40/sky16.bmpf33d334a-3dfd-4a67-9131-9721af012d32Large.jpg
as the skybox of a zone

in master the lighting in the zoneand the skybox is broken and buggy
in this pr, it is looking correctly

you must make sure to reload content and also clear the ktx cache (in developer/render menu) between session to experience the bug in master and the fix in this pr
