### PR TITLE
8210 Keyboard Input Field: Pressing Space should Clear Field

### DIFF
--- a/interface/resources/qml/controls-uit/Keyboard.qml
+++ b/interface/resources/qml/controls-uit/Keyboard.qml
@@ -124,7 +124,7 @@ Rectangle {
             selectByMouse: false
 
             Keys.onPressed: {
-                if (event.key == Qt.Key_Return) {
+                if (event.key == Qt.Key_Return || event.key == Qt.Key_Space) {
                     mirrorText.text = "";
                     event.accepted = true;
                 }


### PR DESCRIPTION
*** Test Plan*** 

1. Go to Marketplace and click on search field
2. Type "hello mom"

Old behavior: The input field on top of the keyboard shows "hello mom"
New desired behavior: The input field clears every time you press space, so it should only show "mom"