### PR TITLE
HDR cube map equirectangular bug fix

### DIFF
--- a/libraries/image/src/image/Image.cpp
+++ b/libraries/image/src/image/Image.cpp
@@ -983,6 +983,9 @@ public:
         glm::vec2 dstCoord;
         glm::ivec2 srcPixel;
         for (int y = 0; y < faceWidth; ++y) {
+            QRgb* destScanLineBegin = reinterpret_cast<QRgb*>( image.scanLine(y) );
+            QRgb* destPixelIterator = destScanLineBegin;
+
             dstCoord.y = 1.0f - (y + 0.5f) * dstInvSize.y; // Fill cube face images from top to bottom
             for (int x = 0; x < faceWidth; ++x) {
                 dstCoord.x = (x + 0.5f) * dstInvSize.x;
@@ -995,13 +998,19 @@ public:
                 srcPixel.y = floor((1.0f - srcCoord.y) * srcFaceHeight);
 
                 if (((uint32)srcPixel.x < (uint32)source.width()) && ((uint32)srcPixel.y < (uint32)source.height())) {
-                    image.setPixel(x, y, source.pixel(QPoint(srcPixel.x, srcPixel.y)));
+                    // We can't directly use the pixel() method because that launches a pixel color conversion to output
+                    // a correct RGBA8 color. But in our case we may have stored HDR values encoded in a RGB30 format which
+                    // are not convertible by Qt. The same goes with the setPixel method, by the way.
+                    const QRgb* sourcePixelIterator = reinterpret_cast<const QRgb*>(source.scanLine(srcPixel.y));
+                    sourcePixelIterator += srcPixel.x;
+                    *destPixelIterator = *sourcePixelIterator;
 
                     // Keep for debug, this is showing the dir as a color
                     //  glm::u8vec4 rgba((xyzDir.x + 1.0)*0.5 * 256, (xyzDir.y + 1.0)*0.5 * 256, (xyzDir.z + 1.0)*0.5 * 256, 256);
                     //  unsigned int val = 0xff000000 | (rgba.r) | (rgba.g << 8) | (rgba.b << 16);
-                    //  image.setPixel(x, y, val);
+                    //  *destPixelIterator = val;
                 }
+                ++destPixelIterator;
             }
         }
         return image;
@@ -1192,6 +1201,10 @@ gpu::TexturePointer TextureUsage::processCubeTextureColorFromImage(const QImage&
     if ((srcImage.width() > 0) && (srcImage.height() > 0)) {
         QImage image = processSourceImage(srcImage, true);
 
+        if (image.format() != QIMAGE_HDR_FORMAT) {
+            image = convertToHDRFormat(image, HDR_FORMAT);
+        }
+
         gpu::Element formatMip;
         gpu::Element formatGPU;
         if (isCubeTexturesCompressionEnabled()) {
@@ -1229,13 +1242,6 @@ gpu::TexturePointer TextureUsage::processCubeTextureColorFromImage(const QImage&
                     faces.push_back(faceImage);
                 }
             }
-
-            if (image.format() != QIMAGE_HDR_FORMAT) {
-                for (auto& face : faces) {
-                    face = convertToHDRFormat(face, HDR_FORMAT);
-                }
-            }
-
         } else {
             qCDebug(imagelogging) << "Failed to find a known cube map layout from this image:" << QString(srcImageName.c_str());
             return nullptr;


### PR DESCRIPTION
This PR fixes a bug in PR #11349 concerning equirectangular environment maps (2:1 ratio maps) which had incorrect colors when transformed to cube maps after being converted internally to HDR colors.

# TEST PLAN

1. All sky maps of all formats (cube maps in vertical or horizontal crosses or in a 3x2 array and equirectangular environment maps) should render as expected, without visually incorrect colors.
2. Ambient maps should render as expected, without visually incorrect colors.

To help visualize this, you can run the script scripts/developer/utilities/render/debugDeferredLighting.js and enable the "Zone Stack" checkbox.
