### PR TITLE
Package all UI resources into a QRC built into the application.

### DIFF
--- a/cmake/macros/GenerateQrc.cmake
+++ b/cmake/macros/GenerateQrc.cmake
@@ -1,0 +1,20 @@
+
+function(GENERATE_QRC)
+  set(oneValueArgs OUTPUT PREFIX PATH)
+  set(multiValueArgs GLOBS)
+  cmake_parse_arguments(GENERATE_QRC "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+  if ("${GENERATE_QRC_PREFIX}" STREQUAL "")
+    set(QRC_PREFIX_PATH /)
+  else()
+    set(QRC_PREFIX_PATH ${GENERATE_QRC_PREFIX})
+  endif()
+  
+  foreach(GLOB ${GENERATE_QRC_GLOBS})
+    file(GLOB_RECURSE FOUND_FILES RELATIVE ${GENERATE_QRC_PATH} ${GLOB})
+    foreach(FILENAME ${FOUND_FILES})
+      set(QRC_CONTENTS "${QRC_CONTENTS}<file alias=\"${FILENAME}\">${GENERATE_QRC_PATH}/${FILENAME}</file>\n")
+    endforeach() 
+  endforeach()
+  
+  configure_file("${HF_CMAKE_DIR}/templates/resources.qrc.in" ${GENERATE_QRC_OUTPUT})
+endfunction()

--- a/cmake/templates/resources.qrc.in
+++ b/cmake/templates/resources.qrc.in
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="@QRC_PREFIX_PATH@">
+@QRC_CONTENTS@
+</qresource>
+</RCC>

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -1,6 +1,20 @@
 set(TARGET_NAME interface)
 project(${TARGET_NAME})
 
+file(GLOB_RECURSE QML_SRC resources/qml/*.qml resources/qml/*.js)
+add_custom_target(qml SOURCES ${QML_SRC})
+GroupSources("resources/qml")
+
+function(JOIN VALUES GLUE OUTPUT)
+  string (REGEX REPLACE "([^\\]|^);" "\\1${GLUE}" _TMP_STR "${VALUES}")
+  string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") #fixes escaping
+  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+endfunction()
+
+
+set(INTERFACE_QML_QRC ${CMAKE_CURRENT_BINARY_DIR}/qml.qrc)
+generate_qrc(OUTPUT ${INTERFACE_QML_QRC} PATH ${CMAKE_CURRENT_SOURCE_DIR}/resources GLOBS *.qml *.qss *.js *.html *.ttf *.gif *.svg *.png *.jpg)      
+
 # set a default root dir for each of our optional externals if it was not passed
 set(OPTIONAL_EXTERNALS "LeapMotion")
 
@@ -66,9 +80,7 @@ qt5_wrap_ui(QT_UI_HEADERS "${QT_UI_FILES}")
 # add them to the interface source files
 set(INTERFACE_SRCS ${INTERFACE_SRCS} "${QT_UI_HEADERS}" "${QT_RESOURCES}")
 
-file(GLOB_RECURSE QML_SRC resources/qml/*.qml resources/qml/*.js)
-add_custom_target(qml SOURCES ${QML_SRC})
-GroupSources("resources/qml")
+list(APPEND INTERFACE_SRCS ${INTERFACE_QML_QRC})
 
 if (UNIX)
   install(
@@ -131,9 +143,9 @@ if (APPLE)
 
   # append the discovered resources to our list of interface sources
   list(APPEND INTERFACE_SRCS ${DISCOVERED_RESOURCES})
-
-  set(INTERFACE_SRCS ${INTERFACE_SRCS} "${CMAKE_CURRENT_SOURCE_DIR}/icon/${INTERFACE_ICON_FILENAME}")
+  list(APPEND INTERFACE_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/icon/${INTERFACE_ICON_FILENAME})
 endif()
+
 
 # create the executable, make it a bundle on OS X
 if (APPLE)

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2246,7 +2246,7 @@ void Application::initializeUi() {
     offscreenUi->setBaseUrl(QUrl::fromLocalFile(PathUtils::resourcesPath() + "/qml/"));
     // OffscreenUi is a subclass of OffscreenQmlSurface specifically designed to
     // support the window management and scripting proxies for VR use
-    offscreenUi->createDesktop(QString("hifi/Desktop.qml"));
+    offscreenUi->createDesktop(QString("qrc:///qml/hifi/Desktop.qml"));
 
     // FIXME either expose so that dialogs can set this themselves or
     // do better detection in the offscreen UI of what has focus


### PR DESCRIPTION
This PR modifies the application to bundle the UI resources (QML files, fonts, images, etc) into the executable.  The standalone installed version of the resources is left untouched for now (pending a cleanup process to migrate all QML usage to use QRC based URLS)

Additionally, this PR moves the loading of the main HUD desktop to use the QRC as a proof of concept.

## Testing

Install this build of Interface.  In the installation directory (likely `C:\Program Files\High Fidelity -
 PR11588` ) locate the file `resources/qml/hifi/desktop.qml` and rename or delete it.  Verify the the application still launches and displays the main desktop and does not crash.

Performing the same rename or delete in the master build would cause the application to crash on startup.  