### PR TITLE
ignore unbakeable textures in FBXBaker

### DIFF
--- a/libraries/baking/src/FBXBaker.cpp
+++ b/libraries/baking/src/FBXBaker.cpp
@@ -594,6 +594,10 @@ void FBXBaker::rewriteAndBakeSceneTextures() {
                             QString fbxTextureFileName { textureChild.properties.at(0).toByteArray() };
                             QFileInfo textureFileInfo { fbxTextureFileName.replace("\\", "/") };
 
+                            if (hasErrors()) {
+                                return;
+                            }
+
                             if (textureFileInfo.suffix() == BAKED_TEXTURE_EXT.mid(1)) {
                                 // re-baking an FBX that already references baked textures is a fail
                                 // so we add an error and return from here
@@ -602,6 +606,11 @@ void FBXBaker::rewriteAndBakeSceneTextures() {
                                 return;
                             }
 
+                            if (!TextureBaker::getSupportedFormats().contains(textureFileInfo.suffix())) {
+                                // this is a texture format we don't bake, skip it
+                                handleWarning(fbxTextureFileName + " is not a bakeable texture format");
+                                continue;
+                            }
 
                             // make sure this texture points to something and isn't one we've already re-mapped
                             if (!textureFileInfo.filePath().isEmpty()) {


### PR DESCRIPTION
- bake FBX files even when they reference textures that cannot be baked