### PR TITLE
2017-10-13 Commerce frontend tweaks

### DIFF
--- a/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
+++ b/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
@@ -200,12 +200,6 @@ Rectangle {
             // Style
             color: hifi.colors.lightGray;
         }
-        FontLoader { id: ralewayRegular; source: "../../../../fonts/Raleway-Regular.ttf"; }
-        TextMetrics {
-            id: textMetrics;
-            font.family: ralewayRegular.name
-            text: root.itemOwner;
-        }
         RalewayRegular {
             id: ownedBy;
             text: root.itemOwner;
@@ -215,8 +209,7 @@ Rectangle {
             anchors.top: ownedByHeader.bottom;
             anchors.topMargin: 8;
             anchors.left: ownedByHeader.left;
-            height: textMetrics.height;
-            width: root.isMyCert ? textMetrics.width + 25 : ownedByHeader.width;
+            height: paintedHeight;
             // Style
             color: hifi.colors.darkGray;
             elide: Text.ElideRight;
@@ -231,7 +224,7 @@ Rectangle {
             anchors.topMargin: 4;
             anchors.bottom: ownedBy.bottom;
             anchors.left: ownedBy.right;
-            anchors.leftMargin: 4;
+            anchors.leftMargin: 6;
             anchors.right: ownedByHeader.right;
             // Style
             color: hifi.colors.lightGray;

--- a/interface/resources/qml/hifi/commerce/wallet/Help.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Help.qml
@@ -90,17 +90,22 @@ Item {
         ListElement {
             isExpanded: false;
             question: "What are private keys?"
-            answer: qsTr("A private key is a secret piece of text that is used to decrypt code.<br><br>In High Fidelity, <b>your private keys are used to decrypt the contents of your Wallet and Purchases.</b>");
+            answer: qsTr("A private key is a secret piece of text that is used to prove ownership, unlock confidential information, and sign transactions.<br><br>In High Fidelity, <b>your private keys are used to securely access the contents of your Wallet and Purchases.</b>");
         }
         ListElement {
             isExpanded: false;
             question: "Where are my private keys stored?"
-            answer: qsTr('Your private keys are <b>only stored on your hard drive</b> in High Fidelity Interface\'s AppData directory.<br><br><b><font color="#0093C5"><a href="#privateKeyPath">Tap here to open the file path of your hifikey in your file explorer.</a></font></b><br><br> You may backup this file by copying it to a USB flash drive, or to a service like Dropbox or Google Drive. Restore your backup by replacing the file in Interface\'s AppData directory with your backed-up copy.');
+            answer: qsTr('By default, your private keys are <b>only stored on your hard drive</b> in High Fidelity Interface\'s AppData directory.<br><br><b><font color="#0093C5"><a href="#privateKeyPath">Tap here to open the file path of your hifikey in your file explorer.</a></font></b>');
+        }
+        ListElement {
+            isExpanded: false;
+            question: "How can I backup my private keys?"
+            answer: qsTr('You may backup the file containing your private keys by copying it to a USB flash drive, or to a service like Dropbox or Google Drive.<br><br>Restore your backup by replacing the file in Interface\'s AppData directory with your backed-up copy.<br><br><b><font color="#0093C5"><a href="#privateKeyPath">Tap here to open the file path of your hifikey in your file explorer.</a></font></b>');
         }
         ListElement {
             isExpanded: false;
             question: "What happens if I lose my passphrase?"
-            answer: qsTr("If you lose your passphrase, you will no longer have access to the contents of your Wallet or My Purchases.<br><br><b>Nobody can help you recover your passphrase, including High Fidelity.</b> Please write it down and store it securely.");
+            answer: qsTr("Your passphrase is used to encrypt your private keys. If you lose your passphrase, you will no longer be able to decrypt your private key file. You will also no longer have access to the contents of your Wallet or My Purchases.<br><br><b>Nobody can help you recover your passphrase, including High Fidelity.</b> Please write it down and store it securely.");
         }
         ListElement {
             isExpanded: false;

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -679,7 +679,7 @@ Item {
                     anchors.right: parent.right;
                     anchors.rightMargin: 30;
                     height: 40;
-                    text: "Open Instructions for Later";
+                    text: "Open Backup Instructions for Later";
                     onClicked: {
                         instructions01Container.visible = false;
                         instructions02Container.visible = true;

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -80,6 +80,7 @@ private:
     void updateImageProvider();
     bool writeSecurityImage(const QPixmap* pixmap, const QString& outputFilePath);
     bool readSecurityImage(const QString& inputFilePath, unsigned char** outputBufferPtr, int* outputBufferLen);
+    bool writeBackupInstructions();
 
     bool verifyOwnerChallenge(const QByteArray& encryptedText, const QString& publicKey, QString& decryptedText);
 

--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -193,6 +193,11 @@
             var navbarBrandElement = document.getElementsByClassName('navbar-brand')[0];
             var purchasesElement = document.createElement('a');
             var dropDownElement = document.getElementById('user-dropdown');
+
+            $('#user-dropdown').find('.username')[0].style = "max-width:80px;white-space:nowrap;overflow:hidden;" + 
+                "text-overflow:ellipsis;display:inline-block;position:relative;top:4px;";
+            $('#user-dropdown').find('.caret')[0].style = "position:relative;top:-3px;";
+
             purchasesElement.id = "purchasesButton";
             purchasesElement.setAttribute('href', "#");
             purchasesElement.innerHTML = "My Purchases";


### PR DESCRIPTION
Here are five small fixes/tweaks to Commerce code.

# Test Plan

## Prerequisites

Currently, you must manually enable "commerce" by adding `"commerce": true,` in your Interface.json (with Interface not running), or by opening Interface Javascript console and evaluating `Settings.setValue("commerce", true)` and restarting.

If your wallet is already set up OR if you have previously set up a wallet on a different build (and thus you have a record of your wallet on the backend), you must perform the following steps to rest your wallet:
1. Open the Wallet app. If you're just resetting your wallet because there's a record of a previous wallet on the backend, go through setup.
2. Go to the "Help" tab in the Wallet app
3. Press the red "DBG: RST Wallet" button at the top of the window

If your wallet is set up but broken (e.g., from testing something that didn't work) such that you are prompted for a passphrase that is never accepted, you need to:
1. Quit interface and delete `%appdata%/Interface <build #>/<username.hifikey>`
2. Restart Interface, set up wallet, and then press the red `DBG: RST WALLET` button as above. Now you are in a truly clean state for wallet setup.

## Backup Instructions Test
1. Open the Wallet app
2. Go through setup. On the "Back Up Your Private Keys" page, make sure that clicking the "OPEN BACKUP INSTRUCTIONS FOR LATER" button opens up:
    1. Your default browser to an `.html` page explaining backup instructions AND
    2. Your file browser to the folder containing your `.hifikey` file.
3. Finish setup. Close Interface.
4. In your file explorer, navigate to `%appdata%/Interface <build #>/` and **delete** `backup_instructions.html`
5. Start Interface. Open the Wallet app
6. Authenticate using your passphrase
7. Go to the "Security" tab of the wallet
8. Click the "VIEW BACKUP INSTRUCTIONS" button.
9. Verify that the following opens up:
    1. Your default browser to an `.html` page explaining backup instructions AND
    2. Your file browser to the folder containing your `.hifikey` file.

## Marketplace Injection - Long Username Test
1. Log In to Interface with an account whose username is >= 14 characters in length
2. Open the Market app
3. Verify that your username at the top right of the page is elided and that the "My Purchases" link is on the same line as the dropdown containing your username

## Entity Certificate - Long Username Test
1. Purchase the "Test Beach Ball" from the Marketplace
2. Rez the Test Beach Ball
3. Right click the Test Beach Ball, then click on the (i)
4. Verify that the "Owner" field of the certificate displays: `<Your Long Username> (Private)`