### PR TITLE
fixing the zone entity not rendering when created

### DIFF
--- a/assignment-client/src/assets/AssetServer.h
+++ b/assignment-client/src/assets/AssetServer.h
@@ -127,6 +127,8 @@ private:
     bool _wasGrayscaleTextureCompressionEnabled { false  };
     bool _wasNormalTextureCompressionEnabled { false };
     bool _wasCubeTextureCompressionEnabled { false };
+
+    uint64_t _filesizeLimit;
 };
 
 #endif

--- a/assignment-client/src/assets/UploadAssetTask.cpp
+++ b/assignment-client/src/assets/UploadAssetTask.cpp
@@ -22,10 +22,11 @@
 
 
 UploadAssetTask::UploadAssetTask(QSharedPointer<ReceivedMessage> receivedMessage, SharedNodePointer senderNode,
-                                 const QDir& resourcesDir) :
+                                 const QDir& resourcesDir, uint64_t filesizeLimit) :
     _receivedMessage(receivedMessage),
     _senderNode(senderNode),
-    _resourcesDir(resourcesDir)
+    _resourcesDir(resourcesDir),
+    _filesizeLimit(filesizeLimit)
 {
     
 }
@@ -48,7 +49,7 @@ void UploadAssetTask::run() {
     auto replyPacket = NLPacket::create(PacketType::AssetUploadReply, -1, true);
     replyPacket->writePrimitive(messageID);
     
-    if (fileSize > MAX_UPLOAD_SIZE) {
+    if (fileSize > _filesizeLimit) {
         replyPacket->writePrimitive(AssetServerError::AssetTooLarge);
     } else {
         QByteArray fileData = buffer.read(fileSize);

--- a/assignment-client/src/assets/UploadAssetTask.h
+++ b/assignment-client/src/assets/UploadAssetTask.h
@@ -26,7 +26,8 @@ class Node;
 
 class UploadAssetTask : public QRunnable {
 public:
-    UploadAssetTask(QSharedPointer<ReceivedMessage> message, QSharedPointer<Node> senderNode, const QDir& resourcesDir);
+    UploadAssetTask(QSharedPointer<ReceivedMessage> message, QSharedPointer<Node> senderNode, 
+                    const QDir& resourcesDir, uint64_t filesizeLimit);
 
     void run() override;
 
@@ -34,6 +35,7 @@ private:
     QSharedPointer<ReceivedMessage> _receivedMessage;
     QSharedPointer<Node> _senderNode;
     QDir _resourcesDir;
+    uint64_t _filesizeLimit;
 };
 
 #endif // hifi_UploadAssetTask_h

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -858,6 +858,14 @@
           "help": "The path to the directory assets are stored in.<br/>If this path is relative, it will be relative to the application data directory.<br/>If you change this path you will need to manually copy any existing assets from the previous directory.",
           "default": "",
           "advanced": true
+        },
+        {
+          "name": "assets_filesize_limit",
+          "type": "int",
+          "label": "File Size Limit",
+          "help": "The file size limit of an asset that can be imported into the asset server in MBytes. 0 (default) means no limit on file size.",
+          "default": 0,
+          "advanced": true
         }
       ]
     },

--- a/interface/resources/qml/AvatarInputs.qml
+++ b/interface/resources/qml/AvatarInputs.qml
@@ -17,6 +17,7 @@ import "./hifi/audio" as HifiAudio
 Hifi.AvatarInputs {
     id: root;
     objectName: "AvatarInputs"
+    property int modality: Qt.NonModal
     width: audio.width;
     height: audio.height;
     x: 10; y: 5;

--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -8,6 +8,9 @@ Item {
 
     anchors.leftMargin: 300
     objectName: "StatsItem"
+    property int modality: Qt.NonModal
+    implicitHeight: row.height
+    implicitWidth: row.width
 
     Component.onCompleted: {
         stats.parentChanged.connect(fill);
@@ -18,8 +21,9 @@ Item {
     }
 
     function fill() {
-        // Explicitly fill in order to avoid warnings at shutdown
-        anchors.fill = parent;
+        // This will cause a  warning at shutdown, need to find another way to remove
+        // the warning other than filling the anchors to the parent
+        anchors.horizontalCenter = parent.horizontalCenter
     }
 
     Hifi.Stats {

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -301,14 +301,18 @@ FocusScope {
     function isPointOnWindow(point) {
         for (var i = 0; i < desktop.visibleChildren.length; i++) {
             var child = desktop.visibleChildren[i];
-            if (child.visible) {
-                if (child.hasOwnProperty("modality")) {
-                    var mappedPoint = child.mapFromGlobal(point.x, point.y);
+            if (child.hasOwnProperty("modality")) {
+                var mappedPoint = mapToItem(child, point.x, point.y);
+                if (child.hasOwnProperty("frame")) {
                     var outLine = child.frame.children[2];
                     var framePoint = outLine.mapFromGlobal(point.x, point.y);
-                    if (child.contains(mappedPoint) || outLine.contains(framePoint)) {
+                    if (outLine.contains(framePoint)) {
                         return true;
                     }
+                }
+
+                if (child.contains(mappedPoint)) {
+                    return true;
                 }
             }
         }

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -32,6 +32,7 @@ class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Depen
     Q_PROPERTY(bool showTablet READ getShouldShowTablet)
     Q_PROPERTY(QUuid tabletID READ getCurrentTabletFrameID WRITE setCurrentTabletFrameID)
     Q_PROPERTY(QUuid homeButtonID READ getCurrentHomeButtonID WRITE setCurrentHomeButtonID)
+    Q_PROPERTY(QUuid homeButtonHighlightID READ getCurrentHomeButtonHightlightID WRITE setCurrentHomeButtonHightlightID)
     Q_PROPERTY(QUuid tabletScreenID READ getCurrentTabletScreenID WRITE setCurrentTabletScreenID)
 
 public:
@@ -97,6 +98,9 @@ public:
     void setCurrentHomeButtonID(QUuid homeButtonID) { _homeButtonID = homeButtonID; }
     QUuid getCurrentHomeButtonID() const { return _homeButtonID; }
 
+    void setCurrentHomeButtonHightlightID(QUuid homeButtonHightlightID) { _homeButtonHightlightID = homeButtonHightlightID; }
+    QUuid getCurrentHomeButtonHightlightID() const { return _homeButtonHightlightID; }
+
     void setCurrentTabletScreenID(QUuid tabletID) { _tabletScreenID = tabletID; }
     QUuid getCurrentTabletScreenID() const { return _tabletScreenID; }
 
@@ -105,6 +109,7 @@ private:
     QUuid _tabletUIID; // this is the entityID of the tablet frame
     QUuid _tabletScreenID; // this is the overlayID which is part of (a child of) the tablet-ui.
     QUuid _homeButtonID;
+    QUuid _homeButtonHightlightID;
     QUuid _tabletEntityID;
 
     // Get the position of the HMD

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -106,14 +106,15 @@ extern std::atomic<size_t> DECIMATED_TEXTURE_COUNT;
 extern std::atomic<size_t> RECTIFIED_TEXTURE_COUNT;
 
 void Stats::updateStats(bool force) {
+    QQuickItem* parent = parentItem();
     if (!force) {
         if (!Menu::getInstance()->isOptionChecked(MenuOption::Stats)) {
-            if (isVisible()) {
-                setVisible(false);
+            if (parent->isVisible()) {
+                parent->setVisible(false);
             }
             return;
-        } else if (!isVisible()) {
-            setVisible(true);
+        } else if (!parent->isVisible()) {
+            parent->setVisible(true);
         }
     }
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -237,19 +237,7 @@ void EntityTreeRenderer::update(bool simulate) {
         EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
         tree->update(simulate);
 
-        if (simulate) {
-            // Handle enter/leave entity logic
-            checkEnterLeaveEntities();
-
-            // Even if we're not moving the mouse, if we started clicking on an entity and we have
-            // not yet released the hold then this is still considered a holdingClickOnEntity event
-            // and we want to simulate this message here as well as in mouse move
-            if (_lastPointerEventValid && !_currentClickingOnEntityID.isInvalidID()) {
-                emit holdingClickOnEntity(_currentClickingOnEntityID, _lastPointerEvent);
-                _entitiesScriptEngine->callEntityScriptMethod(_currentClickingOnEntityID, "holdingClickOnEntity", _lastPointerEvent);
-            }
-        }
-
+        // Update the rendereable entities as needed
         {
             PerformanceTimer sceneTimer("scene");
             auto scene = _viewState->getMain3DScene();
@@ -269,6 +257,20 @@ void EntityTreeRenderer::update(bool simulate) {
                 }
             }
         }
+
+        if (simulate) {
+            // Handle enter/leave entity logic
+            checkEnterLeaveEntities();
+
+            // Even if we're not moving the mouse, if we started clicking on an entity and we have
+            // not yet released the hold then this is still considered a holdingClickOnEntity event
+            // and we want to simulate this message here as well as in mouse move
+            if (_lastPointerEventValid && !_currentClickingOnEntityID.isInvalidID()) {
+                emit holdingClickOnEntity(_currentClickingOnEntityID, _lastPointerEvent);
+                _entitiesScriptEngine->callEntityScriptMethod(_currentClickingOnEntityID, "holdingClickOnEntity", _lastPointerEvent);
+            }
+        }
+
     }
 }
 

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -620,6 +620,12 @@ void NetworkTexture::ktxMipRequestFinished() {
 
                 texture->assignStoredMip(mipLevel, data.size(), reinterpret_cast<const uint8_t*>(data.data()));
 
+                // If mip level assigned above is still unavailable, then we assume future requests will also fail.
+                auto minMipLevel = texture->minAvailableMipLevel();
+                if (minMipLevel > mipLevel) {
+                    return;
+                }
+
                 QMetaObject::invokeMethod(resource.data(), "setImage",
                     Q_ARG(gpu::TexturePointer, texture),
                     Q_ARG(int, texture->getWidth()),

--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -546,6 +546,12 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             var args = [this.hand === RIGHT_HAND ? "right" : "left", MyAvatar.sessionUUID];
             Entities.callEntityMethod(this.targetEntityID, "releaseEquip", args);
 
+            Messages.sendMessage('Hifi-Object-Manipulation', JSON.stringify({
+                action: 'release',
+                grabbedEntity: this.targetEntityID,
+                joint: this.hand === RIGHT_HAND ? "RightHand" : "LeftHand"
+            }));
+
             ensureDynamic(this.targetEntityID);
             this.targetEntityID = null;
             this.messageGrabEntity = false;

--- a/scripts/system/controllers/controllerModules/nearActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/nearActionGrabEntity.js
@@ -144,6 +144,12 @@ Script.include("/~/system/libraries/cloneEntityUtils.js");
             Entities.deleteAction(this.targetEntityID, this.actionID);
             this.actionID = null;
 
+            Messages.sendMessage('Hifi-Object-Manipulation', JSON.stringify({
+                action: 'release',
+                grabbedEntity: this.targetEntityID,
+                joint: this.hand === RIGHT_HAND ? "RightHand" : "LeftHand"
+            }));
+
             this.targetEntityID = null;
         };
 

--- a/scripts/system/controllers/controllerModules/nearParentGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/nearParentGrabEntity.js
@@ -138,6 +138,11 @@ Script.include("/~/system/libraries/cloneEntityUtils.js");
 
             var args = [this.hand === RIGHT_HAND ? "right" : "left", MyAvatar.sessionUUID];
             Entities.callEntityMethod(this.targetEntityID, "releaseGrab", args);
+            Messages.sendMessage('Hifi-Object-Manipulation', JSON.stringify({
+                action: 'release',
+                grabbedEntity: this.targetEntityID,
+                joint: this.hand === RIGHT_HAND ? "RightHand" : "LeftHand"
+            }));
             this.grabbing = false;
             this.targetEntityID = null;
         };

--- a/scripts/system/controllers/controllerModules/nearParentGrabOverlay.js
+++ b/scripts/system/controllers/controllerModules/nearParentGrabOverlay.js
@@ -148,6 +148,12 @@ Script.include("/~/system/libraries/utils.js");
                 }
             }
 
+            Messages.sendMessage('Hifi-Object-Manipulation', JSON.stringify({
+                action: 'release',
+                grabbedEntity: this.grabbedThingID,
+                joint: this.hand === RIGHT_HAND ? "RightHand" : "LeftHand"
+            }));
+
             this.grabbedThingID = null;
         };
 

--- a/scripts/system/controllers/controllerModules/tabletStylusInput.js
+++ b/scripts/system/controllers/controllerModules/tabletStylusInput.js
@@ -264,6 +264,8 @@ Script.include("/~/system/libraries/controllers.js");
             if (!this.stylusTip.valid || this.overlayLaserActive(controllerData) || this.otherModuleNeedsToRun(controllerData)) {
                 this.pointFinger(false);
                 this.hideStylus();
+                this.stylusTouchingTarget = false;
+                this.relinquishTouchFocus();
                 return false;
             }
 

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -150,6 +150,23 @@ WebTablet = function (url, width, dpi, hand, clientOnly, location, visible) {
         parentJointIndex: -1
     });
 
+    this.homeButtonHighlightID = Overlays.addOverlay("circle3d", {
+        name: "homeButtonHighlight",
+        localPosition: { x: 0, y: -HOME_BUTTON_Y_OFFSET + 0.003, z: -0.0158 },
+        localRotation: { x: 0, y: 1, z: 0, w: 0 },
+        dimensions: { x: 4 * tabletScaleFactor, y: 4 * tabletScaleFactor, z: 4 * tabletScaleFactor },
+        solid: true,
+        outerRadius: 25 * tabletScaleFactor,
+        innerRadius: 20 * tabletScaleFactor,
+        ignoreIntersection: true,
+        alpha: 1.0,
+        color: { red: 255, green: 255, blue: 255 },
+        visible: visible,
+        drawInFront: false,
+        parentID: this.tabletEntityID,
+        parentJointIndex: -1
+     });
+
     this.receive = function (channel, senderID, senderUUID, localOnly) {
         if (_this.homeButtonID == senderID) {
             var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
@@ -169,6 +186,23 @@ WebTablet = function (url, width, dpi, hand, clientOnly, location, visible) {
             }
         }
     };
+
+    this.myOnHoverEnterOverlay = function (overlayID, pointerEvent) {
+        _this.onHoverEnterOverlay(overlayID, pointerEvent);
+    };
+
+    Overlays.hoverEnterOverlay.connect(this.myOnHoverEnterOverlay);
+
+    this.myOnHoverLeaveOverlay = function (overlayID, pointerEvent) {
+        _this.onHoverLeaveOverlay(overlayID, pointerEvent);
+    };
+
+    Overlays.hoverLeaveOverlay.connect(this.myOnHoverLeaveOverlay);
+
+    this.myOnHoverOverOverlay = function (overlayID, pointerEvent) {
+        _this.onHoverOverOverlay(overlayID, pointerEvent);
+    };
+    Overlays.hoverOverOverlay.connect(this.myOnHoverOverOverlay);
 
     this.state = "idle";
 
@@ -273,9 +307,14 @@ WebTablet.prototype.setWidth = function (width) {
 };
 
 WebTablet.prototype.destroy = function () {
+    Overlays.hoverEnterOverlay.disconnect(this.myOnHoverEnterOverlay);
+    Overlays.hoverLeaveOverlay.disconnect(this.myOnHoverLeaveOverlay);
+    Overlays.hoverOverOverlay.disconnect(this.myOnHoverOverOverlay);
+
     Overlays.deleteOverlay(this.webOverlayID);
     Overlays.deleteOverlay(this.tabletEntityID);
     Overlays.deleteOverlay(this.homeButtonID);
+    Overlays.deleteOverlay(this.homeButtonHighlightID);
     HMD.displayModeChanged.disconnect(this.myOnHmdChanged);
 
     Controller.mousePressEvent.disconnect(this.myMousePressEvent);
@@ -366,6 +405,24 @@ WebTablet.prototype.calculateWorldAttitudeRelativeToCamera = function (windowPos
         rotation: this.landscape ? Quat.multiply(Camera.orientation, ROT_LANDSCAPE) : Quat.multiply(Camera.orientation, ROT_Y_180)
     };
 };
+
+WebTablet.prototype.onHoverEnterOverlay = function (overlayID, pointerEvent) {
+    if (overlayID === this.homeButtonID) {
+        Overlays.editOverlay(this.homeButtonHighlightID, { alpha: 1.0 });
+    }
+}
+
+WebTablet.prototype.onHoverOverOverlay = function (overlayID, pointerEvent) {
+    if (overlayID !== this.homeButtonID) {
+        Overlays.editOverlay(this.homeButtonHighlightID, { alpha: 0.0 });
+    }
+}
+
+WebTablet.prototype.onHoverLeaveOverlay = function (overlayID, pointerEvent) {
+    if (overlayID === this.homeButtonID) {
+        Overlays.editOverlay(this.homeButtonHighlightID, { alpha: 0.0 });
+    }
+}
 
 // compute position, rotation & parentJointIndex of the tablet
 WebTablet.prototype.calculateTabletAttachmentProperties = function (hand, useMouse, tabletProperties) {
@@ -504,6 +561,22 @@ WebTablet.prototype.scheduleMouseMoveProcessor = function() {
     }
 };
 
+WebTablet.prototype.handleHomeButtonHover = function(x, y) {
+    var pickRay = Camera.computePickRay(x, y);
+    var entityPickResults;
+    var homebuttonHovered = false;
+    entityPickResults = Overlays.findRayIntersection(pickRay, true, [this.tabletEntityID]);
+    if (entityPickResults.intersects && (entityPickResults.entityID === this.tabletEntityID ||
+        entityPickResults.overlayID === this.tabletEntityID)) {
+        var overlayPickResults = Overlays.findRayIntersection(pickRay, true, [this.homeButtonID], []);
+        if (overlayPickResults.intersects && overlayPickResults.overlayID === this.homeButtonID) {
+            homebuttonHovered = true;
+        }
+    }
+
+    Overlays.editOverlay(this.homeButtonHighlightID, { alpha: homebuttonHovered ? 1.0 : 0.0 });
+}
+
 WebTablet.prototype.mouseMoveEvent = function (event) {
     if (this.dragging) {
         this.currentMouse = {
@@ -511,6 +584,8 @@ WebTablet.prototype.mouseMoveEvent = function (event) {
             y: event.y
         };
         this.scheduleMouseMoveProcessor();
+    } else {
+        this.handleHomeButtonHover(event.x, event.y);
     }
 };
 
@@ -537,6 +612,8 @@ WebTablet.prototype.mouseMoveProcessor = function () {
             });
         }
         this.scheduleMouseMoveProcessor();
+    } else {
+        this.handleHomeButtonHover(this.currentMouse.x, this.currentMouse.y);
     }
 };
 

--- a/scripts/system/libraries/utils.js
+++ b/scripts/system/libraries/utils.js
@@ -370,7 +370,7 @@ getTabletWidthFromSettings = function () {
 
 resizeTablet = function (width, newParentJointIndex, sensorToWorldScaleOverride) {
 
-    if (!HMD.tabletID || !HMD.tabletScreenID || !HMD.homeButtonID) {
+    if (!HMD.tabletID || !HMD.tabletScreenID || !HMD.homeButtonID || !HMD.homeButtonHighlightID) {
         return;
     }
 
@@ -412,5 +412,12 @@ resizeTablet = function (width, newParentJointIndex, sensorToWorldScaleOverride)
     Overlays.editOverlay(HMD.homeButtonID, {
         localPosition: {x: -0.001, y: -HOME_BUTTON_Y_OFFSET, z: 0.0},
         dimensions: { x: 4 * tabletScaleFactor, y: 4 * tabletScaleFactor, z: 4 * tabletScaleFactor}
+    });
+
+    Overlays.editOverlay(HMD.homeButtonHighlightID, {
+        localPosition: { x: 0, y: -HOME_BUTTON_Y_OFFSET + 0.003, z: -0.0158 },
+        dimensions: { x: 4 * tabletScaleFactor, y: 4 * tabletScaleFactor, z: 4 * tabletScaleFactor },
+        outerRadius: 25 * tabletScaleFactor,
+        innerRadius: 20 * tabletScaleFactor
     });
 };

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -103,6 +103,7 @@
         UIWebTablet.register();
         HMD.tabletID = UIWebTablet.tabletEntityID;
         HMD.homeButtonID = UIWebTablet.homeButtonID;
+        HMD.homeButtonHighlightID = UIWebTablet.homeButtonHighlightID;
         HMD.tabletScreenID = UIWebTablet.webOverlayID;
         HMD.displayModeChanged.connect(onHmdChanged);
         MyAvatar.sensorToWorldScaleChanged.connect(onSensorToWorldScaleChanged);
@@ -127,6 +128,7 @@
             tabletProperties.visible = true;
             Overlays.editOverlay(HMD.tabletID, tabletProperties);
             Overlays.editOverlay(HMD.homeButtonID, { visible: true });
+            Overlays.editOverlay(HMD.homeButtonHighlightID, { visible: true });
             Overlays.editOverlay(HMD.tabletScreenID, { visible: true });
             Overlays.editOverlay(HMD.tabletScreenID, { maxFPS: 90 });
             updateTabletWidthFromSettings(true);
@@ -147,6 +149,7 @@
 
         Overlays.editOverlay(HMD.tabletID, { visible: false });
         Overlays.editOverlay(HMD.homeButtonID, { visible: false });
+        Overlays.editOverlay(HMD.homeButtonHighlightID, { visible: false });
         Overlays.editOverlay(HMD.tabletScreenID, { visible: false });
         Overlays.editOverlay(HMD.tabletScreenID, { maxFPS: 1 });
     }
@@ -167,6 +170,7 @@
             UIWebTablet = null;
             HMD.tabletID = null;
             HMD.homeButtonID = null;
+            HMD.homeButtonHighlightID = null;
             HMD.tabletScreenID = null;
         } else if (debugTablet) {
             print("TABLET closeTabletUI, UIWebTablet is null");
@@ -319,6 +323,7 @@
         Overlays.deleteOverlay(tabletID);
         HMD.tabletID = null;
         HMD.homeButtonID = null;
+        HMD.homeButtonHighlightID = null;
         HMD.tabletScreenID = null;
     });
 }()); // END LOCAL_SCOPE

--- a/unpublishedScripts/marketplace/shapes/modules/createPalette.js
+++ b/unpublishedScripts/marketplace/shapes/modules/createPalette.js
@@ -8,7 +8,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-/* global CreatePalette: true, App, Feedback, History, UIT */
+/* global CreatePalette:true, App, Feedback, History, Preload, UIT */
 
 CreatePalette = function (side, leftInputs, rightInputs, uiCommandCallback) {
     // Tool menu displayed on top of forearm.
@@ -332,6 +332,11 @@ CreatePalette = function (side, leftInputs, rightInputs, uiCommandCallback) {
     }
 
 
+    function getAssetURLs() {
+        return Preload.findURLs([PALETTE_HEADER_HEADING_PROPERTIES, PALETTE_HEADER_BAR_PROPERTIES, PALETTE_TITLE_PROPERTIES,
+            PALETTE_ITEMS]);
+    }
+
     function setHand(hand) {
         // Assumes UI is not displaying.
         var NUMBER_OF_HANDS = 2;
@@ -533,6 +538,7 @@ CreatePalette = function (side, leftInputs, rightInputs, uiCommandCallback) {
     }
 
     return {
+        assetURLs: getAssetURLs,
         setHand: setHand,
         overlayIDs: getOverlayIDs,
         setVisible: setVisible,

--- a/unpublishedScripts/marketplace/shapes/modules/preload.js
+++ b/unpublishedScripts/marketplace/shapes/modules/preload.js
@@ -1,0 +1,175 @@
+//
+//  preload.js
+//
+//  Created by David Rowe on 11 Oct 2017.
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/* global Preload:true, App */
+
+Preload = (function () {
+    // Provide facility to preload asset files so that they are in disk cache.
+    // Global object.
+
+    "use strict";
+
+    var loadTimer = null,
+        urlsToLoad = [],
+        nextURLToLoad = 0,
+        LOAD_INTERVAL = 50, // ms
+        overlays = [],
+        deleteTimer = null,
+        DELETE_INTERVAL = LOAD_INTERVAL; // ms
+
+    function findURLs(items) {
+        var urls = [],
+            i,
+            length;
+
+        function findURLsInObject(item) {
+            var property;
+
+            for (property in item) {
+                if (item.hasOwnProperty(property)) {
+                    if (property === "url" || property === "imageURL" || property === "imageOverlayURL") {
+                        if (item[property]) {
+                            urls.push(item[property]);
+                        }
+                    } else if (typeof item[property] === "object") {
+                        findURLsInObject(item[property]);
+                    }
+                }
+            }
+        }
+
+        for (i = 0, length = items.length; i < length; i++) {
+            switch (typeof items[i]) {
+                case "string":
+                    urls.push(items[i]);
+                    break;
+                case "object":
+                    findURLsInObject(items[i]);
+                    break;
+                default:
+                    App.log("ERROR: Cannot find URL in item type " + (typeof items[i]));
+            }
+        }
+
+        return urls;
+    }
+
+    function deleteOverlay() {
+        if (overlays.length === 0) { // Just in case.
+            deleteTimer = null;
+            return;
+        }
+
+        Overlays.deleteOverlay(overlays[0]);
+        overlays.shift();
+
+        if (overlays.length > 0) {
+            deleteTimer = Script.setTimeout(deleteOverlay, DELETE_INTERVAL);
+        } else {
+            deleteTimer = null;
+        }
+    }
+
+    function loadNextURL() {
+
+        function loadURL(url) {
+            var DOMAIN_CORNER = { x: -16382, y: -16382, z: -16382 }, // Near but not right on domain corner.
+                DUMMY_OVERLAY_PROPERTIES = {
+                    fbx: {
+                        overlay: "model",
+                        dimensions: { x: 0.001, y: 0.001, z: 0.001 },
+                        position: DOMAIN_CORNER,
+                        ignoreRayIntersection: false,
+                        alpha: 0.0,
+                        visible: false
+                    },
+                    svg: {
+                        overlay: "image3d",
+                        scale: 0.001,
+                        position: DOMAIN_CORNER,
+                        ignoreRayIntersection: true,
+                        alpha: 0.0,
+                        visible: false
+                    },
+                    png: {
+                        overlay: "image3d",
+                        scale: 0.001,
+                        position: DOMAIN_CORNER,
+                        ignoreRayIntersection: true,
+                        alpha: 0.0,
+                        visible: false
+                    }
+                },
+                fileType,
+                properties;
+
+            fileType = url.slice(-3);
+            if (DUMMY_OVERLAY_PROPERTIES.hasOwnProperty(fileType)) {
+                properties = Object.clone(DUMMY_OVERLAY_PROPERTIES[fileType]);
+                properties.url = url;
+                overlays.push(Overlays.addOverlay(properties.overlay, properties));
+                if (deleteTimer === null) {
+                    // Can't delete overlay straight away otherwise asset load is abandoned.
+                    deleteTimer = Script.setTimeout(deleteOverlay, DELETE_INTERVAL);
+                }
+            } else {
+                App.log("ERROR: Cannot preload asset " + url);
+            }
+        }
+
+        // Find next URL that hasn't already been loaded;
+        while (nextURLToLoad < urlsToLoad.length && urlsToLoad.indexOf(urlsToLoad[nextURLToLoad]) < nextURLToLoad) {
+            nextURLToLoad += 1;
+        }
+
+        // Load the URL if there's one to load.
+        if (nextURLToLoad < urlsToLoad.length) {
+            // Load the URL.
+            loadURL(urlsToLoad[nextURLToLoad]);
+            nextURLToLoad += 1;
+
+            // Load the next, if any, after a short delay.
+            loadTimer = Script.setTimeout(loadNextURL, LOAD_INTERVAL);
+        } else {
+            loadTimer = null;
+        }
+    }
+
+    function load(urls) {
+        urlsToLoad = urlsToLoad.concat(urls);
+        if (loadTimer === null) {
+            loadNextURL();
+        }
+    }
+
+    function tearDown() {
+        var i,
+            length;
+
+        if (loadTimer) {
+            Script.clearTimeout(loadTimer);
+        }
+
+        if (deleteTimer) {
+            Script.clearTimeout(deleteTimer);
+            for (i = 0, length = overlays.length; i < length; i++) {
+                Overlays.deleteOverlay(overlays[i]);
+            }
+        }
+    }
+
+    Script.scriptEnding.connect(tearDown);
+
+    return {
+        findURLs: findURLs,
+        load: load
+    };
+
+}());

--- a/unpublishedScripts/marketplace/shapes/modules/toolIcon.js
+++ b/unpublishedScripts/marketplace/shapes/modules/toolIcon.js
@@ -72,6 +72,10 @@ ToolIcon = function (side) {
         return new ToolIcon();
     }
 
+    function getAssetURLs() {
+        return [MODEL_PROPERTIES.url];
+    }
+
     function setHand(side) {
         // Assumes UI is not displaying.
         if (side === LEFT_HAND) {
@@ -154,6 +158,7 @@ ToolIcon = function (side) {
     }
 
     return {
+        assetURLs: getAssetURLs,
         setHand: setHand,
         display: display,
         clear: clear,

--- a/unpublishedScripts/marketplace/shapes/modules/toolsMenu.js
+++ b/unpublishedScripts/marketplace/shapes/modules/toolsMenu.js
@@ -8,7 +8,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-/* global ToolsMenu: true, App, Feedback, UIT */
+/* global ToolsMenu:true, App, Feedback, Preload, UIT */
 
 ToolsMenu = function (side, leftInputs, rightInputs, uiCommandCallback) {
     // Tool menu displayed on top of forearm.
@@ -2042,6 +2042,12 @@ ToolsMenu = function (side, leftInputs, rightInputs, uiCommandCallback) {
         return new ToolsMenu();
     }
 
+    function getAssetURLs() {
+        return Preload.findURLs([MENU_HEADER_HEADING_PROPERTIES, MENU_HEADER_BAR_PROPERTIES, MENU_HEADER_BACK_PROPERTIES,
+            MENU_HEADER_TITLE_PROPERTIES, MENU_HEADER_TITLE_BACK_URL, MENU_HEADER_ICON_PROPERTIES, UI_ELEMENTS,
+            PICKLIST_UP_ARROW, PICKLIST_DOWN_ARROW, OPTONS_PANELS, MENU_ITEMS, FOOTER_ITEMS]);
+    }
+
     controlHand = side === LEFT_HAND ? rightInputs.hand() : leftInputs.hand();
 
     function setHand(hand) {
@@ -3672,6 +3678,7 @@ ToolsMenu = function (side, leftInputs, rightInputs, uiCommandCallback) {
     }
 
     return {
+        assetURLs: getAssetURLs,
         COLOR_TOOL: COLOR_TOOL,
         SCALE_TOOL: SCALE_TOOL,
         CLONE_TOOL: CLONE_TOOL,

--- a/unpublishedScripts/marketplace/shapes/shapes.js
+++ b/unpublishedScripts/marketplace/shapes/shapes.js
@@ -8,7 +8,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-/* global Feedback, History */
+/* global Feedback, History, Preload */
 
 (function () {
 
@@ -87,6 +87,7 @@
     Script.include("./modules/highlights.js");
     Script.include("./modules/history.js");
     Script.include("./modules/laser.js");
+    Script.include("./modules/preload.js");
     Script.include("./modules/selection.js");
     Script.include("./modules/toolIcon.js");
     Script.include("./modules/toolsMenu.js");
@@ -235,8 +236,12 @@
         }
 
         toolIcon = new ToolIcon(otherHand(side));
-        toolsMenu = new ToolsMenu(side, leftInputs, rightInputs, uiCommandCallback);
         createPalette = new CreatePalette(side, leftInputs, rightInputs, uiCommandCallback);
+        toolsMenu = new ToolsMenu(side, leftInputs, rightInputs, uiCommandCallback);
+
+        Preload.load(toolIcon.assetURLs());
+        Preload.load(createPalette.assetURLs());
+        Preload.load(toolsMenu.assetURLs());
 
         getIntersection = side === LEFT_HAND ? rightInputs.intersection : leftInputs.intersection;
 


### PR DESCRIPTION
This PR fixes a bug that prevent a newly created zone entity to be rendered (background or keylight component). 
We simply made sure to update the Entity Renderer as needed (creation and updates) before the update of the zone stack.

## TEST PLAN
Run the zone stack debugging  (from the js console, type:
Render.getConfig("RenderMainView.DrawZoneStack").enabled = true

In a domain, create a zone, change the default keylight settings or enable the background skybox.

Without changing your position, this new zone and skybox should be visible in the scene and also in the Zone stack debugger.

THis works in this pr but fails in RC57 or master