### PR TITLE
RC-57 : Fixing the zone entity not rendered properly when created

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -237,19 +237,7 @@ void EntityTreeRenderer::update(bool simulate) {
         EntityTreePointer tree = std::static_pointer_cast<EntityTree>(_tree);
         tree->update(simulate);
 
-        if (simulate) {
-            // Handle enter/leave entity logic
-            checkEnterLeaveEntities();
-
-            // Even if we're not moving the mouse, if we started clicking on an entity and we have
-            // not yet released the hold then this is still considered a holdingClickOnEntity event
-            // and we want to simulate this message here as well as in mouse move
-            if (_lastPointerEventValid && !_currentClickingOnEntityID.isInvalidID()) {
-                emit holdingClickOnEntity(_currentClickingOnEntityID, _lastPointerEvent);
-                _entitiesScriptEngine->callEntityScriptMethod(_currentClickingOnEntityID, "holdingClickOnEntity", _lastPointerEvent);
-            }
-        }
-
+        // Update the rendereable entities as needed
         {
             PerformanceTimer sceneTimer("scene");
             auto scene = _viewState->getMain3DScene();
@@ -269,6 +257,20 @@ void EntityTreeRenderer::update(bool simulate) {
                 }
             }
         }
+
+        if (simulate) {
+            // Handle enter/leave entity logic
+            checkEnterLeaveEntities();
+
+            // Even if we're not moving the mouse, if we started clicking on an entity and we have
+            // not yet released the hold then this is still considered a holdingClickOnEntity event
+            // and we want to simulate this message here as well as in mouse move
+            if (_lastPointerEventValid && !_currentClickingOnEntityID.isInvalidID()) {
+                emit holdingClickOnEntity(_currentClickingOnEntityID, _lastPointerEvent);
+                _entitiesScriptEngine->callEntityScriptMethod(_currentClickingOnEntityID, "holdingClickOnEntity", _lastPointerEvent);
+            }
+        }
+
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug that prevent a newly created zone entity to be rendered (background or keylight component).
We simply made sure to update the Entity Renderer as needed (creation and updates) before the update of the zone stack.

## TEST PLAN

Run the zone stack debugging (from the js console, type:
Render.getConfig("RenderMainView.DrawZoneStack").enabled = true

In a domain, create a zone, change the default keylight settings or enable the background skybox.

Without changing your position, this new zone and skybox should be visible in the scene and also in the Zone stack debugger.

This works in this pr but fails in RC57 or master