### PR TITLE
Fix Wallet notification appearing when taking screenshots

### DIFF
--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -576,7 +576,7 @@
         createNotification("Processing GIF snapshot...", NotificationType.SNAPSHOT);
     }
 
-    function processingGif() {
+    function walletNotSetup() {
         createNotification("Your wallet isn't set up. Open the WALLET app.", NotificationType.WALLET);
     }
 


### PR DESCRIPTION
I don't know how this passed my own CR or anyone else's.

**Test Plan:**
1. Install this build
2. Take a snapshot in Desktop mode. Verify that the notification you receive in the top right of the screen has to do with the snapshot and NOT to do with your Wallet.