### PR TITLE
Fix loud screeching sound when certain users join a domain

### DIFF
--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -138,7 +138,6 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
     switch (arrivalInfo._status) {
         case SequenceNumberStats::Unreasonable: {
             lostAudioData(1);
-            qDebug(audio) << "Sequence Unreasonable (LOST)";
             break;
         }
         case SequenceNumberStats::Early: {
@@ -148,7 +147,6 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
             // fall through to the "on time" logic to actually handle this packet
             int packetsDropped = arrivalInfo._seqDiffFromExpected;
             lostAudioData(packetsDropped);
-            qDebug(audio) << "Sequence Early (LOST)";
 
             // fall through to OnTime case
         }
@@ -159,7 +157,6 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
                 // If we recieved a SilentAudioFrame from our sender, we might want to drop
                 // some of the samples in order to catch up to our desired jitter buffer size.
                 writeDroppableSilentFrames(networkFrames);
-                qDebug(audio) << "OnTime (SILENT)";
 
             } else {
                 // note: PCM and no codec are identical
@@ -168,7 +165,6 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
                 if (codecInPacket == _selectedCodecName || (packetPCM && selectedPCM)) {
                     auto afterProperties = message.readWithoutCopy(message.getBytesLeftToRead());
                     parseAudioData(message.getType(), afterProperties);
-                    qDebug(audio) << "OnTime (DECODE:" << codecInPacket << afterProperties.size() << ")";
                     _mismatchedAudioCodecCount = 0;
 
                 } else {

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -527,7 +527,6 @@ float calculateRepeatedFrameFadeFactor(int indexOfRepeat) {
 }
 
 void InboundAudioStream::setupCodec(CodecPluginPointer codec, const QString& codecName, int numChannels) {
-    qDebug(audio) << "Setup Codec:" << codecName;
     cleanupCodec(); // cleanup any previously allocated coders first
     _codec = codec;
     _selectedCodecName = codecName;
@@ -538,8 +537,6 @@ void InboundAudioStream::setupCodec(CodecPluginPointer codec, const QString& cod
 
 void InboundAudioStream::cleanupCodec() {
     // release any old codec encoder/decoder first...
-    qDebug(audio) << "Cleanup Codec:" << _selectedCodecName;
-
     if (_codec) {
         if (_decoder) {
             _codec->releaseDecoder(_decoder);

--- a/libraries/audio/src/InboundAudioStream.h
+++ b/libraries/audio/src/InboundAudioStream.h
@@ -186,6 +186,7 @@ protected:
     CodecPluginPointer _codec;
     QString _selectedCodecName;
     Decoder* _decoder { nullptr };
+    int _mismatchedAudioCodecCount { 0 };
 };
 
 float calculateRepeatedFrameFadeFactor(int indexOfRepeat);


### PR DESCRIPTION
For months now, when certain users enter a domain with a hot mic, loud audio artifacts are heard by all users in the domain. This appears to be caused by quirks in the codec negotiation protocol, which on a slow machine can result in bursts of codec resets and dropped audio during audio codec startup. Hopefully fixed in this PR.