### PR TITLE
Fix for fogbugz:8382 to shutdown debug window on reload scripts

### DIFF
--- a/scripts/developer/debugging/debugWindow.js
+++ b/scripts/developer/debugging/debugWindow.js
@@ -53,4 +53,8 @@ ScriptDiscoveryService.clearDebugWindow.connect(function() {
     window.clearDebugWindow();
 });
 
+Script.scriptEnding.connect(function () {
+    window.close();
+})
+
 }());


### PR DESCRIPTION
Before fix, when choosing to reload all scripts, debug window wouldn't close and duplicated window is made 

Test plan:
Open up Script HMD friendly debug window (debugWindow.js)
Reload all scripts

Debug window should close down and restart now.