### PR TITLE
Scale LaserPointer end overlay in C++

### DIFF
--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -32,6 +32,9 @@ public:
     const bool& doesPathIgnoreRays() const { return _pathIgnoreRays; }
     const bool& doesEndIgnoreRays() const { return _endIgnoreRays; }
 
+    void setEndDim(const glm::vec3& endDim) { _endDim = endDim; }
+    const glm::vec3& getEndDim() const { return _endDim; }
+
     void deleteOverlays();
 
 private:
@@ -41,6 +44,8 @@ private:
     bool _startIgnoreRays;
     bool _pathIgnoreRays;
     bool _endIgnoreRays;
+
+    glm::vec3 _endDim;
 };
 
 
@@ -52,7 +57,7 @@ public:
     typedef std::unordered_map<std::string, std::pair<float, RenderState>> DefaultRenderStateMap;
 
     LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates,
-        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool enabled);
+        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool enabled);
     ~LaserPointer();
 
     QUuid getRayUID() { return _rayPickUID; }
@@ -88,6 +93,7 @@ private:
     bool _faceAvatar;
     bool _centerEndY;
     bool _lockEnd;
+    bool _distanceScaleEnd;
     std::pair<QUuid, bool> _objectLockEnd { std::pair<QUuid, bool>(QUuid(), false)};
 
     QUuid _rayPickUID;

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -11,8 +11,8 @@
 #include "LaserPointerManager.h"
 
 QUuid LaserPointerManager::createLaserPointer(const QVariant& rayProps, const LaserPointer::RenderStateMap& renderStates, const LaserPointer::DefaultRenderStateMap& defaultRenderStates,
-    const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool enabled) {
-    std::shared_ptr<LaserPointer> laserPointer = std::make_shared<LaserPointer>(rayProps, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, enabled);
+    const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool enabled) {
+    std::shared_ptr<LaserPointer> laserPointer = std::make_shared<LaserPointer>(rayProps, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, distanceScaleEnd, enabled);
     if (!laserPointer->getRayUID().isNull()) {
         QWriteLocker containsLock(&_containsLock);
         QUuid id = QUuid::createUuid();

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -22,7 +22,7 @@ class LaserPointerManager {
 
 public:
     QUuid createLaserPointer(const QVariant& rayProps, const LaserPointer::RenderStateMap& renderStates, const LaserPointer::DefaultRenderStateMap& defaultRenderStates,
-        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool enabled);
+        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool enabled);
     void removeLaserPointer(const QUuid uid);
     void enableLaserPointer(const QUuid uid);
     void disableLaserPointer(const QUuid uid);

--- a/interface/src/raypick/LaserPointerScriptingInterface.cpp
+++ b/interface/src/raypick/LaserPointerScriptingInterface.cpp
@@ -32,6 +32,11 @@ QUuid LaserPointerScriptingInterface::createLaserPointer(const QVariant& propert
         lockEnd = propertyMap["lockEnd"].toBool();
     }
 
+    bool distanceScaleEnd = false;
+    if (propertyMap["distanceScaleEnd"].isValid()) {
+        distanceScaleEnd = propertyMap["distanceScaleEnd"].toBool();
+    }
+
     bool enabled = false;
     if (propertyMap["enabled"].isValid()) {
         enabled = propertyMap["enabled"].toBool();
@@ -66,7 +71,7 @@ QUuid LaserPointerScriptingInterface::createLaserPointer(const QVariant& propert
         }
     }
 
-    return qApp->getLaserPointerManager().createLaserPointer(properties, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, enabled);
+    return qApp->getLaserPointerManager().createLaserPointer(properties, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, distanceScaleEnd, enabled);
 }
 
 void LaserPointerScriptingInterface::editRenderState(QUuid uid, const QString& renderState, const QVariant& properties) {

--- a/scripts/system/controllers/controllerModules/farActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farActionGrabEntity.js
@@ -23,6 +23,8 @@ Script.include("/~/system/libraries/controllers.js");
 (function() {
     var PICK_WITH_HAND_RAY = true;
 
+    var SEARCH_SPHERE_SIZE = 0.0132;
+    var dim = {x: SEARCH_SPHERE_SIZE, y: SEARCH_SPHERE_SIZE, z: SEARCH_SPHERE_SIZE};
     var halfPath = {
         type: "line3d",
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
@@ -37,6 +39,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var halfEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
         alpha: 0.9,
@@ -58,6 +61,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var fullEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_FULL_SQUEEZE,
         alpha: 0.9,
@@ -135,10 +139,6 @@ Script.include("/~/system/libraries/controllers.js");
             100);
 
         this.updateLaserPointer = function(controllerData) {
-            var SEARCH_SPHERE_SIZE = 0.011;
-            var MIN_SPHERE_SIZE = 0.0005;
-            var radius = Math.max(1.2 * SEARCH_SPHERE_SIZE * this.intersectionDistance, MIN_SPHERE_SIZE) * MyAvatar.sensorToWorldScale;
-            var dim = {x: radius, y: radius, z: radius};
             var mode = "hold";
             if (!this.distanceHolding && !this.distanceRotating) {
                 if (controllerData.triggerClicks[this.hand]) {
@@ -150,16 +150,10 @@ Script.include("/~/system/libraries/controllers.js");
 
             var laserPointerID = PICK_WITH_HAND_RAY ? this.laserPointer : this.headLaserPointer;
             if (mode === "full") {
-                var fullEndToEdit = PICK_WITH_HAND_RAY ? this.fullEnd : fullEnd;
-                fullEndToEdit.dimensions = dim;
-                LaserPointers.editRenderState(laserPointerID, mode, { path: fullPath, end: fullEndToEdit });
                 this.contextOverlayTimer = false;
                 this.destroyContextOverlay();
-            } else if (mode === "half") {
-                var halfEndToEdit = PICK_WITH_HAND_RAY ? this.halfEnd : halfEnd;
-                halfEndToEdit.dimensions = dim;
-                LaserPointers.editRenderState(laserPointerID, mode, {path: halfPath, end: halfEndToEdit});
             }
+
             LaserPointers.enableLaserPointer(laserPointerID);
             LaserPointers.setRenderState(laserPointerID, mode);
             if (this.distanceHolding || this.distanceRotating) {
@@ -577,8 +571,6 @@ Script.include("/~/system/libraries/controllers.js");
             LaserPointers.removeLaserPointer(this.laserPointer);
         };
 
-        this.halfEnd = halfEnd;
-        this.fullEnd = fullEnd;
         this.laserPointer = LaserPointers.createLaserPointer({
             joint: (this.hand === RIGHT_HAND) ? "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND" : "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND",
             filter: RayPick.PICK_ENTITIES | RayPick.PICK_OVERLAYS,
@@ -586,6 +578,7 @@ Script.include("/~/system/libraries/controllers.js");
             posOffset: getGrabPointSphereOffset(this.handToController(), true),
             renderStates: renderStates,
             faceAvatar: true,
+            distanceScaleEnd: true,
             defaultRenderStates: defaultRenderStates
         });
     }

--- a/scripts/system/controllers/controllerModules/farTrigger.js
+++ b/scripts/system/controllers/controllerModules/farTrigger.js
@@ -16,6 +16,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
 Script.include("/~/system/libraries/controllers.js");
 
 (function() {
+    var SEARCH_SPHERE_SIZE = 0.0132;
+    var dim = {x: SEARCH_SPHERE_SIZE, y: SEARCH_SPHERE_SIZE, z: SEARCH_SPHERE_SIZE};
     var halfPath = {
         type: "line3d",
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
@@ -30,6 +32,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var halfEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
         alpha: 0.9,
@@ -51,6 +54,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var fullEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_FULL_SQUEEZE,
         alpha: 0.9,
@@ -107,10 +111,6 @@ Script.include("/~/system/libraries/controllers.js");
         };
 
         this.updateLaserPointer = function(controllerData) {
-            var SEARCH_SPHERE_SIZE = 0.011;
-            var MIN_SPHERE_SIZE = 0.0005;
-            var radius = Math.max(1.2 * SEARCH_SPHERE_SIZE * this.intersectionDistance, MIN_SPHERE_SIZE);
-            var dim = {x: radius, y: radius, z: radius};
             var mode = "none";
             if (controllerData.triggerClicks[this.hand]) {
                 mode = "full";
@@ -118,18 +118,8 @@ Script.include("/~/system/libraries/controllers.js");
                 mode = "half";
             }
 
-            var laserPointerID = this.laserPointer;
-            if (mode === "full") {
-                var fullEndToEdit = this.fullEnd;
-                fullEndToEdit.dimensions = dim;
-                LaserPointers.editRenderState(laserPointerID, mode, {path: fullPath, end: fullEndToEdit});
-            } else if (mode === "half") {
-                var halfEndToEdit = this.halfEnd;
-                halfEndToEdit.dimensions = dim;
-                LaserPointers.editRenderState(laserPointerID, mode, {path: halfPath, end: halfEndToEdit});
-            }
-            LaserPointers.enableLaserPointer(laserPointerID);
-            LaserPointers.setRenderState(laserPointerID, mode);
+            LaserPointers.enableLaserPointer(this.laserPointer);
+            LaserPointers.setRenderState(this.laserPointer, mode);
         };
 
         this.laserPointerOff = function() {
@@ -192,8 +182,6 @@ Script.include("/~/system/libraries/controllers.js");
             return makeRunningValues(true, [this.targetEntityID], []);
         };
 
-        this.halfEnd = halfEnd;
-        this.fullEnd = fullEnd;
         this.laserPointer = LaserPointers.createLaserPointer({
             joint: (this.hand === RIGHT_HAND) ? "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND" : "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND",
             filter: RayPick.PICK_ENTITIES | RayPick.PICK_OVERLAYS,
@@ -201,6 +189,7 @@ Script.include("/~/system/libraries/controllers.js");
             posOffset: getGrabPointSphereOffset(this.handToController(), true),
             renderStates: renderStates,
             faceAvatar: true,
+            distanceScaleEnd: true,
             defaultRenderStates: defaultRenderStates
         });
 

--- a/scripts/system/controllers/controllerModules/hudOverlayPointer.js
+++ b/scripts/system/controllers/controllerModules/hudOverlayPointer.js
@@ -22,6 +22,8 @@
 (function() {
     Script.include("/~/system/libraries/controllers.js");
     var ControllerDispatcherUtils = Script.require("/~/system/libraries/controllerDispatcherUtils.js");
+    var END_RADIUS = 0.005;
+    var dim = { x: END_RADIUS, y: END_RADIUS, z: END_RADIUS };
     var halfPath = {
         type: "line3d",
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
@@ -36,6 +38,7 @@
     };
     var halfEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
         alpha: 0.9,
@@ -57,6 +60,7 @@
     };
     var fullEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_FULL_SQUEEZE,
         alpha: 0.9,
@@ -126,17 +130,6 @@
         };
 
         this.updateLaserPointer = function(controllerData) {
-            var RADIUS = 0.005;
-            var dim = { x: RADIUS, y: RADIUS, z: RADIUS };
-
-            if (this.mode === "full") {
-                this.fullEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: fullPath, end: this.fullEnd});
-            } else if (this.mode === "half") {
-                this.halfEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: halfPath, end: this.halfEnd});
-            }
-
             LaserPointers.enableLaserPointer(this.laserPointer);
             LaserPointers.setRenderState(this.laserPointer, this.mode);
         };
@@ -212,8 +205,6 @@
             LaserPointers.removeLaserPointer(this.laserPointer);
         };
 
-        this.halfEnd = halfEnd;
-        this.fullEnd = fullEnd;
         this.laserPointer = LaserPointers.createLaserPointer({
             joint: (this.hand === RIGHT_HAND) ? "_CONTROLLER_RIGHTHAND" : "_CONTROLLER_LEFTHAND",
             filter: RayPick.PICK_HUD,

--- a/scripts/system/controllers/controllerModules/inEditMode.js
+++ b/scripts/system/controllers/controllerModules/inEditMode.js
@@ -18,6 +18,8 @@ Script.include("/~/system/libraries/controllers.js");
 Script.include("/~/system/libraries/utils.js");
 
 (function () {
+    var END_RADIUS = 0.005;
+    var dim = { x: END_RADIUS, y: END_RADIUS, z: END_RADIUS };
     var halfPath = {
         type: "line3d",
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
@@ -32,6 +34,7 @@ Script.include("/~/system/libraries/utils.js");
     };
     var halfEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
         alpha: 0.9,
@@ -53,6 +56,7 @@ Script.include("/~/system/libraries/utils.js");
     };
     var fullEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_FULL_SQUEEZE,
         alpha: 0.9,
@@ -121,17 +125,6 @@ Script.include("/~/system/libraries/utils.js");
         };
 
         this.updateLaserPointer = function(controllerData) {
-            var RADIUS = 0.005;
-            var dim = { x: RADIUS, y: RADIUS, z: RADIUS };
-
-            if (this.mode === "full") {
-                this.fullEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: fullPath, end: this.fullEnd});
-            } else if (this.mode === "half") {
-                this.halfEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: halfPath, end: this.halfEnd});
-            }
-
             LaserPointers.enableLaserPointer(this.laserPointer);
             LaserPointers.setRenderState(this.laserPointer, this.mode);
         };
@@ -229,10 +222,6 @@ Script.include("/~/system/libraries/utils.js");
             LaserPointers.disableLaserPointer(this.laserPointer);
             LaserPointers.removeLaserPointer(this.laserPointer);
         };
-
-
-        this.halfEnd = halfEnd;
-        this.fullEnd = fullEnd;
 
         this.laserPointer = LaserPointers.createLaserPointer({
             joint: (this.hand === RIGHT_HAND) ? "_CONTROLLER_RIGHTHAND" : "_CONTROLLER_LEFTHAND",

--- a/scripts/system/controllers/controllerModules/overlayLaserInput.js
+++ b/scripts/system/controllers/controllerModules/overlayLaserInput.js
@@ -17,6 +17,8 @@ Script.include("/~/system/libraries/controllers.js");
 
 (function() {
     var TouchEventUtils = Script.require("/~/system/libraries/touchEventUtils.js");
+    var END_RADIUS = 0.005;
+    var dim = { x: END_RADIUS, y: END_RADIUS, z: END_RADIUS };
     var halfPath = {
         type: "line3d",
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
@@ -31,6 +33,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var halfEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
         alpha: 0.9,
@@ -52,6 +55,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var fullEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_FULL_SQUEEZE,
         alpha: 0.9,
@@ -171,17 +175,6 @@ Script.include("/~/system/libraries/controllers.js");
         };
 
         this.updateLaserPointer = function(controllerData) {
-            var RADIUS = 0.005;
-            var dim = { x: RADIUS, y: RADIUS, z: RADIUS };
-
-            if (this.mode === "full") {
-                this.fullEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: fullPath, end: this.fullEnd});
-            } else if (this.mode === "half") {
-                this.halfEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: halfPath, end: this.halfEnd});
-            }
-
             LaserPointers.enableLaserPointer(this.laserPointer);
             LaserPointers.setRenderState(this.laserPointer, this.mode);
         };
@@ -366,8 +359,6 @@ Script.include("/~/system/libraries/controllers.js");
             LaserPointers.removeLaserPointer(this.laserPointer);
         };
 
-        this.halfEnd = halfEnd;
-        this.fullEnd = fullEnd;
         this.laserPointer = LaserPointers.createLaserPointer({
             joint: (this.hand === RIGHT_HAND) ? "_CONTROLLER_RIGHTHAND" : "_CONTROLLER_LEFTHAND",
             filter: RayPick.PICK_OVERLAYS,

--- a/scripts/system/controllers/controllerModules/webEntityLaserInput.js
+++ b/scripts/system/controllers/controllerModules/webEntityLaserInput.js
@@ -17,6 +17,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
 Script.include("/~/system/libraries/controllers.js");
 
 (function() {
+    var END_RADIUS = 0.005;
+    var dim = { x: END_RADIUS, y: END_RADIUS, z: END_RADIUS };
     var halfPath = {
         type: "line3d",
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
@@ -31,6 +33,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var halfEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
         alpha: 0.9,
@@ -52,6 +55,7 @@ Script.include("/~/system/libraries/controllers.js");
     };
     var fullEnd = {
         type: "sphere",
+        dimensions: dim,
         solid: true,
         color: COLORS_GRAB_SEARCHING_FULL_SQUEEZE,
         alpha: 0.9,
@@ -366,17 +370,6 @@ Script.include("/~/system/libraries/controllers.js");
         };
 
         this.updateLaserPointer = function(controllerData) {
-            var RADIUS = 0.005;
-            var dim = { x: RADIUS, y: RADIUS, z: RADIUS };
-
-            if (this.mode === "full") {
-                fullEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: fullPath, end: fullEnd});
-            } else if (this.mode === "half") {
-                halfEnd.dimensions = dim;
-                LaserPointers.editRenderState(this.laserPointer, this.mode, {path: halfPath, end: halfEnd});
-            }
-
             LaserPointers.enableLaserPointer(this.laserPointer);
             LaserPointers.setRenderState(this.laserPointer, this.mode);
         };


### PR DESCRIPTION
Adds an option to LaserPointers to automatically scale their end overlay by distance and avatar scale.  This way, the controller module sphere scaling, which was being done in the scripts, won't lag behind the rest of the overlays.

Test plan:
- Create an entity near you.  Point your blue hand lasers at it.  Move the lasers off of the object so they are instead intersecting an entity that's far away (a large floor, or a wall, etc.).  While still holding the trigger, move the lasers back onto the nearby entity.  The spheres at the end of the lasers shouldn't flash very large.  They should be the expected dimensions.
- The sphere at the end of the lasers should still be correctly sized when you laser over the HUD sphere, web entities, and the tablet surface.