### PR TITLE
8217 Search in tablet doesn't update (RC-57)

### DIFF
--- a/interface/resources/qml/controls-uit/Keyboard.qml
+++ b/interface/resources/qml/controls-uit/Keyboard.qml
@@ -13,6 +13,7 @@ import "."
 
 Rectangle {
     id: keyboardBase
+    objectName: "keyboard"
 
     anchors.left: parent.left
     anchors.right: parent.right
@@ -27,6 +28,8 @@ Rectangle {
 
     readonly property int mirrorTextHeight: keyboardRowHeight
 
+    property bool password: false
+    property alias mirroredText: mirrorText.text
     property bool showMirrorText: true
     readonly property int raisedHeight: 200
 
@@ -112,16 +115,20 @@ Rectangle {
         color: "#252525"
         anchors.horizontalCenter: parent.horizontalCenter
 
-        TextEdit {
+        TextInput {
             id: mirrorText
             visible: showMirrorText
-            size: 13.5
+            FontLoader { id: ralewaySemiBold; source: "../../fonts/Raleway-SemiBold.ttf"; }
+            font.family: ralewaySemiBold.name
+            font.pointSize: 13.5
+            verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
             color: "#FFFFFF";
             anchors.fill: parent
             wrapMode: Text.WordWrap
-            readOnly: false // we need to leave this property read-only to allow control to accept QKeyEvent
+            readOnly: false // we need this to allow control to accept QKeyEvent
             selectByMouse: false
+            echoMode: password ? TextInput.Password : TextInput.Normal
 
             Keys.onPressed: {
                 if (event.key == Qt.Key_Return) {

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -1019,15 +1019,15 @@ void OffscreenQmlSurface::synthesizeKeyPress(QString key, QObject* targetOverrid
 }
 
 static void forEachKeyboard(QQuickItem* parent, std::function<void(QQuickItem*)> function) {
+    if (!function) {
+        return;
+    }
+
     auto keyboards = parent->findChildren<QObject*>("keyboard");
 
     for (auto keyboardObject : keyboards) {
         auto keyboard = qobject_cast<QQuickItem*>(keyboardObject);
-        if (keyboard == nullptr) {
-            continue;
-        }
-
-        if (function) {
+        if (keyboard) {
             function(keyboard);
         }
     }

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -1030,6 +1030,52 @@ void OffscreenQmlSurface::setKeyboardRaised(QObject* object, bool raised, bool n
     // if HMD is being worn, allow keyboard to open.  allow it to close, HMD or not.
     if (!raised || qApp->property(hifi::properties::HMD).toBool()) {
         QQuickItem* item = dynamic_cast<QQuickItem*>(object);
+        if (!item)
+            return;
+
+        auto echoMode = item->property("echoMode");
+        bool isPasswordField = echoMode.isValid() && echoMode.toInt() == 2 /* TextInput.Password */;
+
+        // we need to somehow pass 'isPasswordField' to visible keyboard so it will change its 'mirror text' to asterixes
+        // the issue in some cases there might be more than one keyboard in object tree and it is hard to understand which one is being used at the moment
+        // unfortunately attempts to check for visibility failed becuase visibility is not updated yet. So... I don't see other way than just update properties for all the keyboards
+        struct Local {
+            static void forEachKeyboard(QQuickItem* item, std::function<void(QQuickItem*)> function) {
+                QObject* itemObject = item;
+                while (itemObject) {
+                    if (itemObject->parent()) {
+                        itemObject = itemObject->parent();
+                    }
+                    else {
+                        break;
+                    }
+                }
+
+                auto keyboards = itemObject->findChildren<QObject*>("keyboard");
+
+                for (auto keyboardObject : keyboards) {
+                    auto keyboard = qobject_cast<QQuickItem*>(keyboardObject);
+                    if (keyboard == nullptr) {
+                        continue;
+                    }
+
+                    if (function) {
+                        function(keyboard);
+                    }
+                }
+            }
+        };
+
+        Local::forEachKeyboard(item, [&](QQuickItem* keyboard) {
+            keyboard->setProperty("mirroredText", QVariant::fromValue(QString("")));
+            keyboard->setProperty("password", isPasswordField);
+        });
+
+        // for future probably makes sense to consider one of the following:
+        // 1. make keyboard a singleton, which will be dynamically re-parented before showing
+        // 2. track currently visible keyboard somewhere, allow to subscribe for this signal
+        // any of above should also eliminate need in duplicated properties and code below
+
         while (item) {
             // Numeric value may be set in parameter from HTML UI; for QML UI, detect numeric fields here.
             numeric = numeric || QString(item->metaObject()->className()).left(7) == "SpinBox";


### PR DESCRIPTION
*** Test plan***

Open marketplace
In the search bar, type "vredit"
Press the search icon to search
Click on the search bar again.
before fix:
Notice "vredit" is still on the input field above the keyboard

after fix:
When the keyboard closes and reopens, it is blank.