### PR TITLE
Fix web3Doverlays and webEntities keyboard not showup

### DIFF
--- a/interface/resources/html/raiseAndLowerKeyboard.js
+++ b/interface/resources/html/raiseAndLowerKeyboard.js
@@ -18,7 +18,7 @@
     function shouldRaiseKeyboard() {
         var nodeName = document.activeElement.nodeName;
         var nodeType = document.activeElement.type;
-        if (nodeName === "INPUT" && ["email", "number", "password", "tel", "text", "url"].indexOf(nodeType) !== -1
+        if (nodeName === "INPUT" && ["email", "number", "password", "tel", "text", "url", "search"].indexOf(nodeType) !== -1
             || document.activeElement.nodeName === "TEXTAREA") {
             return true;
         } else {


### PR DESCRIPTION
This fixes the issue of when using web3Doverlays and webEntities in HMD and have a web site search field selected. the keyboard does not appear.

Ticket this PR fixes - https://highfidelity.fogbugz.com/f/cases/7972/Keyboard-not-coming-up-on-web-entities