### PR TITLE
Test mode improvements

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -17,6 +17,7 @@
 
 #include <PerfStat.h>
 #include <Extents.h>
+#include <shared/GlobalAppProperties.h>
 
 #include "EntitySimulation.h"
 #include "VariantMapToScriptValue.h"
@@ -447,6 +448,13 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
     return true;
 }
 
+// If we're in test mode and a disconnected state, we can rez entities.
+bool canRezTestEntities(const QSharedPointer<NodeList>& nodeList) {
+    // Allow test mode to create entities in a local tree without being connected
+    return hifi::properties::asBool(hifi::properties::TEST_ENABLED) &&
+        !nodeList->getDomainHandler().isConnected();
+}
+
 EntityItemPointer EntityTree::addEntity(const EntityItemID& entityID, const EntityItemProperties& properties) {
     EntityItemPointer result = NULL;
     EntityItemProperties props = properties;
@@ -457,7 +465,7 @@ EntityItemPointer EntityTree::addEntity(const EntityItemID& entityID, const Enti
         return nullptr;
     }
 
-    if (!properties.getClientOnly() && getIsClient() &&
+    if (!canRezTestEntities(nodeList) && !properties.getClientOnly() && getIsClient() &&
         !nodeList->getThisNodeCanRez() && !nodeList->getThisNodeCanRezTmp() &&
         !nodeList->getThisNodeCanRezCertified() && !nodeList->getThisNodeCanRezTmpCertified()) {
         return nullptr;

--- a/libraries/shared/src/shared/GlobalAppProperties.cpp
+++ b/libraries/shared/src/shared/GlobalAppProperties.cpp
@@ -8,14 +8,18 @@
 
 #include "GlobalAppProperties.h"
 
+#include <QtCore/QCoreApplication>
+#include <QtCore/QVariant>
+
 namespace hifi { namespace properties {
 
     const char* CRASHED = "com.highfidelity.crashed";
     const char* STEAM = "com.highfidelity.launchedFromSteam";
     const char* LOGGER = "com.highfidelity.logger";
     const char* OCULUS_STORE = "com.highfidelity.oculusStore";
-    const char* TEST = "com.highfidelity.test";
-    const char* TRACING = "com.highfidelity.tracing";
+    const char* TEST_ENABLED = "com.highfidelity.test";
+    const char* TEST_SCRIPT = "com.highfidelity.test.script";
+    const char* TEST_TRACE = "com.highfidelity.test.trace";
     const char* HMD = "com.highfidelity.hmd";
     const char* APP_LOCAL_DATA_PATH = "com.highfidelity.appLocalDataPath";
 
@@ -23,6 +27,11 @@ namespace hifi { namespace properties {
         const char* BACKEND = "com.highfidelity.gl.backend";
         const char* MAKE_PROGRAM_CALLBACK = "com.highfidelity.gl.makeProgram";
         const char* PRIMARY_CONTEXT = "com.highfidelity.gl.primaryContext";
+    }
+
+    bool asBool(const char* flag) {
+        auto variant = qApp->property(flag);
+        return variant.isValid() && variant.toBool();
     }
 
 } }

--- a/libraries/shared/src/shared/GlobalAppProperties.h
+++ b/libraries/shared/src/shared/GlobalAppProperties.h
@@ -16,8 +16,9 @@ namespace hifi { namespace properties {
     extern const char* STEAM;
     extern const char* LOGGER;
     extern const char* OCULUS_STORE;
-    extern const char* TEST;
-    extern const char* TRACING;
+    extern const char* TEST_ENABLED;
+    extern const char* TEST_SCRIPT;
+    extern const char* TEST_TRACE;
     extern const char* HMD;
     extern const char* APP_LOCAL_DATA_PATH;
 
@@ -26,6 +27,8 @@ namespace hifi { namespace properties {
         extern const char* MAKE_PROGRAM_CALLBACK;
         extern const char* PRIMARY_CONTEXT;
     }
+
+    bool asBool(const char* flag);
 
 } }
 


### PR DESCRIPTION
In order to allow easier scripted QA & performance testing, this PR makes some changes

* Support enabling test mode without a test script or a trace file.  Using `--test` when starting interface will enable the test scripting interface, but will not run any specific test or start a trace.  The `--testScript` and `--traceFile` command line options should still work as they did
* Add a globally visible application property that indicates whether test mode is enabled.  Code can query this with the function `hifi::properties::asBool(hifi::properties::TEST_ENABLED)` anywhere if `shared/GlobalAppProperties.h` has been included.
* Suppress the connection monitor when test mode is enabled.  Normally when you're not connected to a domain, the connection monitor will pop up a warning to that effect after 5-10 seconds.  When in test mode this check and warning are completely suppressed.  
* Enable modifications to the local entity tree when in test mode, even if not connected to a server.  This will allow easy importing of scenes or creation of scene from testing and benchmarking scripts without needing to be connected to a server.  

## Testing

Start the application normally.  Connect to a non-existent domain (like `127.0.0.0`).  After a few seconds you should see a message that you're not connected.  Shut down the application.

Restart the application. You should still be 'connected' to the non-existent domain.  After about 5 seconds, you should see the 'not connected' warning.  Dismiss it and run the script `developer/tests/webSpawnTool.js`.  No web entities should appear, and the log should contain messages that the entities were unable to be created.  

Restart the application again, but with the `--test` command line option.  You should still be 'connected' to the non-existent domain.  but note that no warning message appears.  The `developer/tests/webSpawnTool.js` test should still be running, so after a moment you should see a number of web entities appear in your vicinity, showing random wikipedia pages.  

When running the master build, the `--test` command line option will have no effect and the behavior on the second restart should be identical to the first.  

### Entity Testing

This PR breaks the logic for whether an entity can be created or not out into a new function.  Please test the following while NOT in test mode

* When NOT connected you can create a client-only entity.  You can test this by making a copy of the `webSpawnTool.js`  to `webSpawnClientTool.js` and changing line 19 in the copy from `var entity = Entities.addEntity(properties);` to `var entity = Entities.addEntity(properties, true);`
* When NOT connected you cannot create a non-client-only entity (this test case is actually covered in the second case above, where running the `webSpawnTool.js` without the test flag produces no entities)
* When connected to a domain where you DO NOT have rez rights and NOT in test mode, the previous to two conditions apply.  `webSpawnClientTool.js` will create entities visible to you alone, and `webSpawnTool.js`  will not.  
* When connected to a domain where you DO NOT have rez rights AND in test mode, the same conditions apply (basically, test mode should not impact your ability to create or not create entities when connected to a domain)
* When connected to a domain where you DO have rez rights AND in NOT test mode, both `webSpawnTool.js` and `webSpawnClientTool.js` will create entities
* When connected to a domain where you DO have rez rights AND in test mode, both `webSpawnTool.js` and `webSpawnClientTool.js` will create entities (test mode should have no impact when you're connected to a domain)



