### PR TITLE
fixed toolbar disapearing after reloading default scripts

### DIFF
--- a/interface/resources/qml/hifi/toolbars/Toolbar.qml
+++ b/interface/resources/qml/hifi/toolbars/Toolbar.qml
@@ -19,6 +19,7 @@ Window {
     shown: true
     width: content.width
     height: content.height
+    disableFade: true
     // Disable this window from being able to call 'desktop.raise() and desktop.showDesktop'
     activator: Item {}
     property bool horizontal: true

--- a/interface/resources/qml/windows/Fadable.qml
+++ b/interface/resources/qml/windows/Fadable.qml
@@ -26,6 +26,7 @@ FocusScope {
     property var completionCallback;
     // The target property to animate, usually scale or opacity
     property alias fadeTargetProperty: root.opacity
+    property bool disableFade: false
     // always start the property at 0 to enable fade in on creation
     fadeTargetProperty: 0
     // DO NOT set visible to false or when derived types override it it
@@ -35,6 +36,9 @@ FocusScope {
     // Some dialogs should be destroyed when they become
     // invisible, so handle that
     onVisibleChanged: {
+        if (disableFade) {
+            return;
+        }
         // If someone directly set the visibility to false
         // toggle it back on and use the targetVisible flag to transition
         // via fading.
@@ -62,7 +66,9 @@ FocusScope {
     }
 
     onFadeTargetPropertyChanged: {
-        visible = (fadeTargetProperty != 0.0);
+        if (!disableFade) {
+            visible = (fadeTargetProperty != 0.0);
+        }
     }
 
     function fadeIn(callback) {


### PR DESCRIPTION
fixed toolbar disapearing after reloading default scripts

Ticket that this PR addresses - https://highfidelity.fogbugz.com/f/cases/5756/Reloading-default-scripts-alternates-between-reloading-and-removing-scripts