### PR TITLE
Fix Entity Certificate display upon inspection in RC-57

### DIFF
--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -135,9 +135,10 @@
 
     function setCertificateInfo(currentEntityWithContextOverlay, itemCertificateId) {
         wireEventBridge(true);
+        var certificateId = itemCertificateId || (Entities.getEntityProperties(currentEntityWithContextOverlay, ['certificateID']).certificateID + "\n");
         tablet.sendToQml({
             method: 'inspectionCertificate_setCertificateId',
-            certificateId: itemCertificateId || Entities.getEntityProperties(currentEntityWithContextOverlay, ['certificateID']).certificateID
+            certificateId: certificateId
         });
     }
 


### PR DESCRIPTION
# What's New
- Fix a bug that caused inspecting an entity to yield a blank certificate

# Known Issues/Incomplete
- N/A

# Future Work
- This hack will have to be reversed after our 10/24 demo, since, at that point, @davidkelly will merge a PR to the backend that will normalize all instances of `Certificate ID` strings when sending/receiving data to/from the server.

# Test Plan

## Prerequisites

Currently, you must manually enable "commerce" by adding `"commerce": true,` in your Interface.json (with Interface not running), or by opening Interface Javascript console and evaluating `Settings.setValue("commerce", true)` and restarting.

If your wallet is already set up OR if you have previously set up a wallet on a different build (and thus you have a record of your wallet on the backend), you must perform the following steps to rest your wallet:
1. Open the Wallet app. If you're just resetting your wallet because there's a record of a previous wallet on the backend, go through setup.
2. Go to the "Help" tab in the Wallet app
3. Press the red "DBG: RST Wallet" button at the top of the window

If your wallet is set up but broken (e.g., from testing something that didn't work) such that you are prompted for a passphrase that is never accepted, you need to:
1. Quit interface and delete `%appdata%/Interface <build #>/<username.hifikey>`
2. Restart Interface, set up wallet, and then press the red `DBG: RST WALLET` button as above. Now you are in a truly clean state for wallet setup.

## Tests
1. Launch Interface
2. Set up your Wallet if it isn't already set up
3. Buy the "Test Beach Ball" from the Marketplace
4. Buy the "Cowboy Hat" from the Marketplace
5. Go to "My Purchases"
6. Click on "VIEW CERTIFICATE" on the Cowboy Hat
7. Verify that the certificate display makes sense and that no fields are blank.
8. Click "Close" at the bottom
9. Click on "VIEW CERTIFICATE" on the Test Beach Ball
10. Verify that the certificate display makes sense and that no fields are blank.
11. Click "Close" at the bottom
12. Rez both the Cowboy Hat (which will appear at your hips) and the Test Beach Ball
13. Right click the Test Beach Ball, then click the (i) Context Overlay
14. Verify that a Certificate appears
15. Verify that the certificate display makes sense and that no fields are blank.
16. Zoom out to third-person using your mouse wheel (so you can see the cowboy hat on your hips)
17. Right click the cowboy hat, then click the (i) Context Overlay
18. Verify that a Certificate appears
19. Verify that the certificate display makes sense and that no fields are blank.