### PR TITLE
Context Overlay (i) Position Fix

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -140,8 +140,8 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
                 if (event.getID() == LEFT_HAND_HW_ID) {
                     offsetAngle *= -1.0f;
                 }
-                contextOverlayPosition = (glm::quat(glm::radians(glm::vec3(0.0f, offsetAngle, 0.0f)))) *
-                    ((cameraPosition + direction * (distance - CONTEXT_OVERLAY_OFFSET_DISTANCE)));
+                contextOverlayPosition = cameraPosition +
+                    (glm::quat(glm::radians(glm::vec3(0.0f, offsetAngle, 0.0f)))) * (direction * (distance - CONTEXT_OVERLAY_OFFSET_DISTANCE));
                 contextOverlayDimensions = glm::vec2(CONTEXT_OVERLAY_SIZE, CONTEXT_OVERLAY_SIZE) * glm::distance(contextOverlayPosition, cameraPosition);
             }
 


### PR DESCRIPTION
order of operations lol

# What's New
- Fix a bug that caused (i) Context Overlay to sometimes appear off-screen

# Known Issues/Incomplete
- N/A

# Future Work
- N/A

# Test Plan

## Prerequisites

Currently, you must manually enable "commerce" by adding `"commerce": true,` in your Interface.json (with Interface not running), or by opening Interface Javascript console and evaluating `Settings.setValue("commerce", true)` and restarting.

If your wallet is already set up OR if you have previously set up a wallet on a different build (and thus you have a record of your wallet on the backend), you must perform the following steps to rest your wallet:
1. Open the Wallet app. If you're just resetting your wallet because there's a record of a previous wallet on the backend, go through setup.
2. Go to the "Help" tab in the Wallet app
3. Press the red "DBG: RST Wallet" button at the top of the window

If your wallet is set up but broken (e.g., from testing something that didn't work) such that you are prompted for a passphrase that is never accepted, you need to:
1. Quit interface and delete `%appdata%/Interface <build #>/<username.hifikey>`
2. Restart Interface, set up wallet, and then press the red `DBG: RST WALLET` button as above. Now you are in a truly clean state for wallet setup.

## Tests
1. Launch Interface
2. Set up your Wallet if it isn't already set up
3. Buy the "Test Beach Ball" from the Marketplace, then rez it in front of you
4. In Desktop mode, right click the Test Beach Ball entity. Verify that you see an orange edge highlight around the entity, and that you see an (i) Context Overlay very close to (but not completely obscuring) the Test Beach Ball
5. In Desktop mode, move around the Test Beach Ball - get big, get small, move far away, move close - and right click the Test Beach Ball as you move around. Verify that the position of the (i) Context Overlay is always "reasonable".
6. Don your HMD.
7. Move around the Test Beach Ball - grab it and inspect it, get big, get small, move far away, move close - and use your blue laser to hover over the Test Beach Ball for a half second as you move around. Verify that the position of the (i) Context Overlay is always "reasonable".