### PR TITLE
Fix for shape size flickering

### DIFF
--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -50,7 +50,9 @@ void EntityRenderer::initEntityRenderers() {
     REGISTER_ENTITY_TYPE_WITH_FACTORY(PolyVox, RenderablePolyVoxEntityItem::factory)
 }
 
-
+const Transform& EntityRenderer::getModelTransform() const {
+    return _modelTransform;
+}
 
 void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::Status::Getters& statusGetters) {
     auto nodeList = DependencyManager::get<NodeList>();

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -105,8 +105,10 @@ protected:
     template<typename T>
     std::shared_ptr<T> asTypedEntity() { return std::static_pointer_cast<T>(_entity); }
         
+
     static void makeStatusGetters(const EntityItemPointer& entity, Item::Status::Getters& statusGetters);
     static std::function<bool()> _entitiesShouldFadeFunction;
+    const Transform& getModelTransform() const;
 
     SharedSoundPointer _collisionSound;
     QUuid _changeHandlerId;
@@ -114,7 +116,6 @@ protected:
     quint64 _fadeStartTime{ usecTimestampNow() };
     bool _isFading{ _entitiesShouldFadeFunction() };
     bool _prevIsTransparent { false };
-    Transform _modelTransform;
     Item::Bound _bound;
     bool _visible { false };
     bool _moving { false };
@@ -123,6 +124,10 @@ protected:
 
 
 private:
+    // The base class relies on comparing the model transform to the entity transform in order 
+    // to trigger an update, so the member must not be visible to derived classes as a modifiable
+    // transform
+    Transform _modelTransform;
     // The rendering code only gets access to the entity in very specific circumstances
     // i.e. to see if the rendering code needs to update because of a change in state of the 
     // entity.  This forces all the rendering code itself to be independent of the entity

--- a/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
@@ -49,9 +49,10 @@ void LineEntityRenderer::doRender(RenderArgs* args) {
     PerformanceTimer perfTimer("RenderableLineEntityItem::render");
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
+    const auto& modelTransform = getModelTransform();
     Transform transform = Transform();
-    transform.setTranslation(_modelTransform.getTranslation());
-    transform.setRotation(_modelTransform.getRotation());
+    transform.setTranslation(modelTransform.getTranslation());
+    transform.setRotation(modelTransform.getRotation());
     batch.setModelTransform(transform);
     if (_linePoints.size() > 1) {
         DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch);

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1311,7 +1311,7 @@ void ModelEntityRenderer::doRender(RenderArgs* args) {
     if (!model || (model && model->didVisualGeometryRequestFail())) {
         static glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);
         gpu::Batch& batch = *args->_batch;
-        batch.setModelTransform(_modelTransform); // we want to include the scale as well
+        batch.setModelTransform(getModelTransform()); // we want to include the scale as well
         DependencyManager::get<GeometryCache>()->renderWireCubeInstance(args, batch, greenColor);
         return;
     }

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -251,12 +251,13 @@ void ParticleEffectEntityRenderer::stepSimulation() {
     });
 
     if (_emitting && particleProperties.emitting()) {
+        const auto& modelTransform = getModelTransform();
         uint64_t emitInterval = particleProperties.emitIntervalUsecs();
         if (emitInterval > 0 && interval >= _timeUntilNextEmit) {
             auto timeRemaining = interval;
             while (timeRemaining > _timeUntilNextEmit) {
                 // emit particle
-                _cpuParticles.push_back(createParticle(now, _modelTransform, particleProperties));
+                _cpuParticles.push_back(createParticle(now, modelTransform, particleProperties));
                 _timeUntilNextEmit = emitInterval;
                 if (emitInterval < timeRemaining) {
                     timeRemaining -= emitInterval;
@@ -315,7 +316,7 @@ void ParticleEffectEntityRenderer::doRender(RenderArgs* args) {
     // In trail mode, the particles are created in world space.
     // so we only set a transform if they're not in trail mode
     if (!_particleProperties.emission.shouldTrail) {
-        transform = _modelTransform;
+        transform = getModelTransform();
         transform.setScale(vec3(1));
     }
     batch.setModelTransform(transform);

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -76,6 +76,14 @@ bool ShapeEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPoin
         return true;
     }
 
+    if (_shape != entity->getShape()) {
+        return true;
+    }
+
+    if (_dimensions != entity->getDimensions()) {
+        return true;
+    }
+
     return false;
 }
 
@@ -93,12 +101,13 @@ void ShapeEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
         _position = entity->getPosition();
         _dimensions = entity->getDimensions();
         _orientation = entity->getOrientation();
+        _renderTransform = getModelTransform();
 
         if (_shape == entity::Sphere) {
-            _modelTransform.postScale(SPHERE_ENTITY_SCALE);
+            _renderTransform.postScale(SPHERE_ENTITY_SCALE);
         }
 
-        _modelTransform.postScale(_dimensions);
+        _renderTransform.postScale(_dimensions);
     });
 }
 
@@ -133,7 +142,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
     glm::vec4 outColor;
     withReadLock([&] {
         geometryShape = MAPPING[_shape];
-        batch.setModelTransform(_modelTransform); // use a transform with scale, rotation, registration point and translation
+        batch.setModelTransform(_renderTransform); // use a transform with scale, rotation, registration point and translation
         outColor = _color;
         if (_procedural.isReady()) {
             _procedural.prepare(batch, _position, _dimensions, _orientation);

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.h
@@ -32,6 +32,7 @@ private:
 
     Procedural _procedural;
     QString _lastUserData;
+    Transform _renderTransform;
     entity::Shape _shape { entity::Sphere };
     glm::vec4 _color;
     glm::vec3 _position;

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -93,10 +93,11 @@ void TextEntityRenderer::doRender(RenderArgs* args) {
     Q_ASSERT(args->_batch);
     gpu::Batch& batch = *args->_batch;
 
-    auto transformToTopLeft = _modelTransform;
+    const auto& modelTransform = getModelTransform();
+    auto transformToTopLeft = modelTransform;
     if (_faceCamera) {
         //rotate about vertical to face the camera
-        glm::vec3 dPosition = args->getViewFrustum().getPosition() - _modelTransform.getTranslation();
+        glm::vec3 dPosition = args->getViewFrustum().getPosition() - modelTransform.getTranslation();
         // If x and z are 0, atan(x, z) is undefined, so default to 0 degrees
         float yawRotation = dPosition.x == 0.0f && dPosition.z == 0.0f ? 0.0f : glm::atan(dPosition.x, dPosition.z);
         glm::quat orientation = glm::quat(glm::vec3(0.0f, yawRotation, 0.0f));

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -139,8 +139,8 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
 
         glm::vec2 windowSize = getWindowSize(entity);
         _webSurface->resize(QSize(windowSize.x, windowSize.y));
-
-        _modelTransform.postScale(entity->getDimensions());
+        _renderTransform = getModelTransform();
+        _renderTransform.postScale(entity->getDimensions());
     });
 }
 
@@ -180,7 +180,7 @@ void WebEntityRenderer::doRender(RenderArgs* args) {
 
     gpu::Batch& batch = *args->_batch;
     withReadLock([&] {
-        batch.setModelTransform(_modelTransform);
+        batch.setModelTransform(_renderTransform);
     });
     batch.setResourceTexture(0, _texture);
     float fadeRatio = _isFading ? Interpolate::calculateFadeRatio(_fadeStartTime) : 1.0f;

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -62,6 +62,7 @@ private:
     uint16_t _lastDPI;
     QTimer _timer;
     uint64_t _lastRenderTime { 0 };
+    Transform _renderTransform;
 };
 
 } } // namespace 

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -248,7 +248,8 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
 
 void ZoneEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) {
     if (entity->getShapeType() == SHAPE_TYPE_SPHERE) {
-        _modelTransform.postScale(SPHERE_ENTITY_SCALE);
+        _renderTransform = getModelTransform();
+        _renderTransform.postScale(SPHERE_ENTITY_SCALE);
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.h
@@ -119,6 +119,7 @@ private:
     bool _validSkyboxTexture{ false };
 
     QString _proceduralUserData;
+    Transform _renderTransform;
 };
 
 } } // namespace 


### PR DESCRIPTION
This issue was caused because some of the rendering classes would modify the `_modelTransform` calculated in the base class.  This caused two issues.  First, it broke the logic for detecting when to run the renderer update code, so for non-unit shapes the update would run every frame.  Second, while the individual modifications to the value were inside locked sections, there's no guarantee that rendering won't occur between the base class update and the subclass update.  This second is the source of the flickering, where a shape's position has been determined, but not it's dimensions.  

## Testing 

* Download [this file](https://github.com/highfidelity/hifi/files/1408954/makeShapeTray.txt) and rename it to makeShapeTray.js.
* Run the JS inside Interface.  It will create a large number of shape entities directly in front of you (they will last about 10 minutes, then expire)
* Watch the shapes intently
![Seriously?](https://render.bitstrips.com/v2/cpanel/8643950-353517261_2-s4-v1.png?transparent=1&palette=1&width=246)
* In master, you will occasionally (sometimes a few a second, but sometimes once in a minute) you will see a flicker on the screen as one of the shapes jumps to the default size of 1 meter and then back again the next frame.  In this PR you should not see the shapes flicker at all.  


