### PR TITLE
Fix Image3DOverlay isFacingAvatar

### DIFF
--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -51,13 +51,11 @@ void Image3DOverlay::update(float deltatime) {
         _texture = DependencyManager::get<TextureCache>()->getTexture(_url);
         _textureIsLoaded = false;
     }
-#if OVERLAY_PANELS
     if (usecTimestampNow() > _transformExpiry) {
         Transform transform = getTransform();
         applyTransformTo(transform);
         setTransform(transform);
     }
-#endif
     Parent::update(deltatime);
 }
 

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -257,7 +257,3 @@ bool Text3DOverlay::findRayIntersection(const glm::vec3 &origin, const glm::vec3
     return Billboard3DOverlay::findRayIntersection(origin, direction, distance, face, surfaceNormal);
 }
 
-Transform Text3DOverlay::evalRenderTransform() {
-    return Parent::evalRenderTransform();
-}
-

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -65,9 +65,6 @@ public:
 
     virtual Text3DOverlay* createClone() const override;
 
-protected:
-    Transform evalRenderTransform() override;
-
 private:
     TextRenderer3D* _textRenderer = nullptr;
 


### PR DESCRIPTION
- Download something from the marketplace, like the chessboard
- Right click on it.  The context overlay should appear.
- Move around.  The "i" overlay should rotate to follow you.