### PR TITLE
implement support for Entities.callEntityServerMethod()

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -237,20 +237,14 @@ void EntityScriptServer::handleEntityScriptCallMethodPacket(QSharedPointer<Recei
     if (_entitiesScriptEngine && _entityViewer.getTree() && !_shuttingDown) {
         auto entityID = QUuid::fromRfc4122(receivedMessage->read(NUM_BYTES_RFC4122_UUID));
 
-        quint16 methodLength;
-        receivedMessage->readPrimitive(&methodLength);
-        auto methodData = receivedMessage->read(methodLength);
-        auto method = QString::fromUtf8(methodData);
+        auto method = receivedMessage->readString();
 
         quint16 paramCount;
         receivedMessage->readPrimitive(&paramCount);
 
         QStringList params;
         for (int param = 0; param < paramCount; param++) {
-            quint16 paramLength;
-            receivedMessage->readPrimitive(&paramLength);
-            auto paramData = receivedMessage->read(paramLength);
-            auto paramString = QString::fromUtf8(paramData);
+            auto paramString = receivedMessage->readString();
             params << paramString;
         }
 

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -248,7 +248,7 @@ void EntityScriptServer::handleEntityScriptCallMethodPacket(QSharedPointer<Recei
             params << paramString;
         }
 
-        _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params);
+        _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params, senderNode->getUUID());
     }
 }
 

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -54,6 +54,9 @@ private slots:
 
     void pushLogs();
 
+    void handleEntityScriptCallMethodPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
+
+
 private:
     void negotiateAudioFormat();
     void selectAudioFormat(const QString& selectedCodecName);

--- a/libraries/entities/src/EntitiesScriptEngineProvider.h
+++ b/libraries/entities/src/EntitiesScriptEngineProvider.h
@@ -20,7 +20,8 @@
 
 class EntitiesScriptEngineProvider {
 public:
-    virtual void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const QStringList& params = QStringList()) = 0;
+    virtual void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, 
+                                        const QStringList& params = QStringList(), const QUuid& remoteCallerID = QUuid()) = 0;
     virtual QFuture<QVariant> getLocalEntityScriptDetails(const EntityItemID& entityID) = 0;
 };
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -566,6 +566,11 @@ void EntityScriptingInterface::callEntityMethod(QUuid id, const QString& method,
     }
 }
 
+void EntityScriptingInterface::callEntityServerMethod(QUuid id, const QString& method, const QStringList& params) {
+    PROFILE_RANGE(script_entities, __FUNCTION__);
+    DependencyManager::get<EntityScriptClient>()->callEntityServerMethod(id, method, params);
+}
+
 QUuid EntityScriptingInterface::findClosestEntity(const glm::vec3& center, float radius) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);
 

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -188,11 +188,11 @@ public slots:
      */
     Q_INVOKABLE void deleteEntity(QUuid entityID);
 
-    /// Allows a script to call a method on an entity's script. The method will execute in the entity script
-    /// engine. If the entity does not have an entity script or the method does not exist, this call will have
-    /// no effect.
     /**jsdoc
-     * Call a method on an entity. If it is running an entity script (specified by the `script` property)
+     * Call a method on an entity. Allows a script to call a method on an entity's script. 
+     * The method will execute in the entity script engine. If the entity does not have an 
+     * entity script or the method does not exist, this call will have no effect.
+     * If it is running an entity script (specified by the `script` property)
      * and it exposes a property with the specified name `method`, it will be called
      * using `params` as the list of arguments.
      *
@@ -203,10 +203,29 @@ public slots:
      */
     Q_INVOKABLE void callEntityMethod(QUuid entityID, const QString& method, const QStringList& params = QStringList());
 
-    /// finds the closest model to the center point, within the radius
-    /// will return a EntityItemID.isKnownID = false if no models are in the radius
-    /// this function will not find any models in script engine contexts which don't have access to models
     /**jsdoc
+    * Call a server method on an entity. Allows a client entity script to call a method on an 
+    * entity's server script. The method will execute in the entity server script engine. If 
+    * the entity does not have an entity server script or the method does not exist, this call will 
+    * have no effect. If the entity is running an entity script (specified by the `serverScripts` property)
+    * and it exposes a property with the specified name `method`, it will be called using `params` as 
+    * the list of arguments.
+    *
+    * @function Entities.callEntityServerMethod
+    * @param {EntityID} entityID The ID of the entity to call the method on.
+    * @param {string} method The name of the method to call.
+    * @param {string[]} params The list of parameters to call the specified method with.
+    */
+    Q_INVOKABLE void callEntityServerMethod(QUuid entityID, const QString& method, const QStringList& params = QStringList());
+
+    /**jsdoc
+     * finds the closest model to the center point, within the radius
+     * will return a EntityItemID.isKnownID = false if no models are in the radius
+     * this function will not find any models in script engine contexts which don't have access to models
+     * @function Entities.findClosestEntity
+     * @param {vec3} center point
+     * @param {float} radius to search
+     * @return {EntityID} The EntityID of the entity that is closest and in the radius.
      */
     Q_INVOKABLE QUuid findClosestEntity(const glm::vec3& center, float radius) const;
 

--- a/libraries/networking/src/EntityScriptClient.cpp
+++ b/libraries/networking/src/EntityScriptClient.cpp
@@ -79,19 +79,13 @@ void EntityScriptClient::callEntityServerMethod(QUuid entityID, const QString& m
 
         packetList->write(entityID.toRfc4122());
 
-        auto methodUtf8 = method.toUtf8();
-        quint16 methodLength = methodUtf8.length();
-        packetList->writePrimitive(methodLength);
-        packetList->write(methodUtf8);
+        packetList->writeString(method);
 
         quint16 paramCount = params.length();
         packetList->writePrimitive(paramCount);
 
         foreach(const QString& param, params) {
-            auto paramUtf8 = param.toUtf8();
-            quint16 paramLength = paramUtf8.length();
-            packetList->writePrimitive(paramLength);
-            packetList->write(paramUtf8);
+            packetList->writeString(param);
         }
 
         nodeList->sendPacketList(std::move(packetList), *entityScriptServer);

--- a/libraries/networking/src/EntityScriptClient.h
+++ b/libraries/networking/src/EntityScriptClient.h
@@ -58,6 +58,8 @@ public:
 
     bool reloadServerScript(QUuid entityID);
     MessageID getEntityServerScriptStatus(QUuid entityID, GetScriptStatusCallback callback);
+    void callEntityServerMethod(QUuid id, const QString& method, const QStringList& params);
+
 
 private slots:
     void handleNodeKilled(SharedNodePointer node);

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -123,6 +123,7 @@ public:
         ReplicatedBulkAvatarData,
         OctreeFileReplacementFromUrl,
         ChallengeOwnership,
+        EntityScriptCallMethod,
         NUM_PACKET_TYPE
     };
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2531,10 +2531,10 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
             args << entityID.toScriptValue(this);
             args << qScriptValueFromSequence(this, params);
 
-            QScriptValue oldData = this->globalObject().property("remoteCallerID");
-            this->globalObject().setProperty("remoteCallerID", remoteCallerID.toString()); // Make the remoteCallerID available to javascript as a global.
+            QScriptValue oldData = this->globalObject().property("Script").property("remoteCallerID");
+            this->globalObject().property("Script").setProperty("remoteCallerID", remoteCallerID.toString()); // Make the remoteCallerID available to javascript as a global.
             callWithEnvironment(entityID, details.definingSandboxURL, entityScript.property(methodName), entityScript, args);
-            this->globalObject().setProperty("remoteCallerID", oldData);
+            this->globalObject().property("Script").setProperty("remoteCallerID", oldData);
         }
     }
 }

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -198,7 +198,8 @@ public:
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID, bool shouldRemoveFromMap = false); // will call unload method
     Q_INVOKABLE void unloadAllEntityScripts();
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName,
-                                            const QStringList& params = QStringList()) override;
+                                            const QStringList& params = QStringList(),
+                                            const QUuid& remoteCallerID = QUuid()) override;
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const PointerEvent& event);
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const EntityItemID& otherID, const Collision& collision);
 


### PR DESCRIPTION
This implements support to allow client side scripts (like regular entity scripts, or local scripts) to easily call methods on Entity Server Scripts. This is particularly convenient for object oriented development where some script logic should run in the server script, but other script logic should run on the client.

A good example of this is a case where you might have some game/app logic that you want running in the server (like some shared logic), but that is activate by a client event (like touching, entering the bounds of an entity, colliding, etc).

This feature could also be used for example with objects that are self-modifying, but locked, so that clients can change or delete the object. Since a server script can have unlock rights, while regular clients do not.

Methods can only be called remotely if they are in the `remotelyCallable` property for the entity script. Also the `remoteCallerID` global variable is set to the node ID of the remote caller for the duration of the method call, this allows functions to additionally verify that the caller is the expected caller. 

TEST PLAN - https://highfidelity.testrail.net/index.php?/cases/view/1930