### PR TITLE
7469 Mouse Pointer Depth is Incorrect in HMD Mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5090,6 +5090,7 @@ void Application::update(float deltaTime) {
         }
 
         this->updateCamera(appRenderArgs._renderArgs);
+        appRenderArgs._eyeToWorld = _myCamera.getTransform();
         appRenderArgs._isStereo = false;
 
         {


### PR DESCRIPTION
fix for '7469 Mouse Pointer Depth is Incorrect in HMD Mode'

*** Test plan *** 

1. In HMD, open the tablet
2. Move your mouse so that it is over the tablet
3. The depth of the mouse should be drawn correctly so that the mouse appears on top of the tablet