### PR TITLE
Auto-refresh Wallet Home & Purchases on 4s timer

### DIFF
--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -583,9 +583,11 @@ Rectangle {
 
     Timer {
         id: inventoryTimer;
-        interval: 90000;
+        interval: 4000; // Change this back to 90000 after demo
+        //interval: 90000;
         onTriggered: {
             if (root.activeView === "purchasesMain" && !root.pendingInventoryReply) {
+                console.log("Refreshing Purchases...");
                 root.pendingInventoryReply = true;
                 commerce.inventory();
             }

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -663,6 +663,8 @@ Rectangle {
                     currentPurchasesModelStatus !== previousPurchasesModelStatus) {
                     
                     purchasesModel.setProperty(i, "statusChanged", true);
+                } else {
+                    purchasesModel.setProperty(i, "statusChanged", false);
                 }
             }
         }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -43,6 +43,7 @@ Item {
 
                 calculatePendingAndInvalidated();
             }
+            refreshTimer.start();
         }
     }
 
@@ -117,6 +118,8 @@ Item {
                     historyReceived = false;
                     commerce.balance();
                     commerce.history();
+                } else {
+                    refreshTimer.stop();
                 }
             }
         }
@@ -135,6 +138,17 @@ Item {
             height: paintedHeight;
             // Style
             color: hifi.colors.white;
+        }
+    }
+
+    Timer {
+        id: refreshTimer;
+        interval: 4000; // Remove this after demo?
+        onTriggered: {
+            console.log("Refreshing Wallet Home...");
+            historyReceived = false;
+            commerce.balance();
+            commerce.history();
         }
     }
 


### PR DESCRIPTION
# What's New
- For Amsterdam demo purposes:
    - Shorten the timer that auto-refreshes the Purchases page from 90 seconds to 4 seconds
    - Add a 4 second auto-refresh timer to Wallet Home

# Known Issues/Incomplete
- N/A

# Future Work
- N/A

# Test Plan

## Prerequisites

Currently, you must manually enable "commerce" by adding `"commerce": true,` in your Interface.json (with Interface not running), or by opening Interface Javascript console and evaluating `Settings.setValue("commerce", true)` and restarting.

If your wallet is already set up OR if you have previously set up a wallet on a different build (and thus you have a record of your wallet on the backend), you must perform the following steps to rest your wallet:
1. Open the Wallet app. If you're just resetting your wallet because there's a record of a previous wallet on the backend, go through setup.
2. Go to the "Help" tab in the Wallet app
3. Press the red "DBG: RST Wallet" button at the top of the window

If your wallet is set up but broken (e.g., from testing something that didn't work) such that you are prompted for a passphrase that is never accepted, you need to:
1. Quit interface and delete `%appdata%/Interface <build #>/<username.hifikey>`
2. Restart Interface, set up wallet, and then press the red `DBG: RST WALLET` button as above. Now you are in a truly clean state for wallet setup.

## Tests
1. Launch Interface
2. Set up your Wallet if it isn't already set up
3. Buy the "Test Beach Ball" from the Marketplace, then **immediately** go to the Purchases page (you must be extremely quick!)
4. The status of the "Test Beach Ball" in Purchases should be "Pending..."
5. Four seconds later, the "Pending..." text should change to "CONFIRMED!", then disappear
6. Buy the "Test Flare Gun" from the Marketplace, then **immediately** go to your Wallet app (you must be extremely quick!)
7. Your "Recent Activity" should have 4 entries:
    - "2 Transactions Pending"
    - 2 transactions associated with your purchase of Test Beach Ball
    - 1 transaction associated with you getting your free 100 HFC
8. Four seconds later, your "Recent Activity" should have 5 entries:
    - 2 transactions associated with your purchase of Test Flare Gun
    - 2 transactions associated with your purchase of Test Beach Ball
    - 1 transaction associated with you getting your free 100 HFC