### PR TITLE
Update Line3DOverlay renderTransform if end changes

### DIFF
--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -96,6 +96,7 @@ void Line3DOverlay::setEnd(const glm::vec3& end) {
     } else {
         _direction = glm::vec3(0.0f);
     }
+    notifyRenderTransformChange();
 }
 
 void Line3DOverlay::setLocalEnd(const glm::vec3& localEnd) {


### PR DESCRIPTION
Line3DOverlays weren't updating their render transforms if only their "end" property was edited.

Test Plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/a77543ca5d5b507b42facfe797930edc/raw/edaedf6acd9979a1f6b1def803d37893c0405e03/Line3DOverlayEndTest.js).  You should see an animated red line appear in front of you.  One point of the line will remain static, the other will move in a circle.