### PR TITLE
add a tablet contextual mode flag to HMDScriptingInterface used to keep tablet in place

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -219,7 +219,7 @@ Item {
 
     function setShown(value) {
         if (value === true) {
-            HMD.openTablet()
+            HMD.openTablet(HMD.tabletContextualMode) // pass in current contextual mode flag to maintain flag (otherwise uses default false argument)
         } else {
             HMD.closeTablet()
         }

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -108,6 +108,15 @@ void HMDScriptingInterface::openTablet(bool contextualMode) {
     _tabletContextualMode = contextualMode;
 }
 
+void HMDScriptingInterface::toggleShouldShowTablet() {
+    setShouldShowTablet(!getShouldShowTablet());
+}
+
+void HMDScriptingInterface::setShouldShowTablet(bool value) {
+    _showTablet = value;
+    _tabletContextualMode = false;
+}
+
 QScriptValue HMDScriptingInterface::getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine) {
     glm::vec3 hudIntersection;
     auto instance = DependencyManager::get<HMDScriptingInterface>();

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -100,10 +100,12 @@ void HMDScriptingInterface::deactivateHMDHandMouse() {
 
 void  HMDScriptingInterface::closeTablet() {
     _showTablet = false;
+    _tabletContextualMode = false;
 }
 
-void HMDScriptingInterface::openTablet() {
+void HMDScriptingInterface::openTablet(bool contextualMode) {
     _showTablet = true;
+    _tabletContextualMode = contextualMode;
 }
 
 QScriptValue HMDScriptingInterface::getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine) {

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -89,8 +89,8 @@ public:
 
     bool isMounted() const;
 
-    void toggleShouldShowTablet() { _showTablet = !_showTablet; }
-    void setShouldShowTablet(bool value) { _showTablet = value; }
+    void toggleShouldShowTablet();
+    void setShouldShowTablet(bool value);
     bool getShouldShowTablet() const { return _showTablet; }
     bool getTabletContextualMode() const { return _tabletContextualMode; }
 

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -30,6 +30,7 @@ class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Depen
     Q_PROPERTY(glm::quat orientation READ getOrientation)
     Q_PROPERTY(bool mounted READ isMounted NOTIFY mountedChanged)
     Q_PROPERTY(bool showTablet READ getShouldShowTablet)
+    Q_PROPERTY(bool tabletContextualMode READ getTabletContextualMode)
     Q_PROPERTY(QUuid tabletID READ getCurrentTabletFrameID WRITE setCurrentTabletFrameID)
     Q_PROPERTY(QUuid homeButtonID READ getCurrentHomeButtonID WRITE setCurrentHomeButtonID)
     Q_PROPERTY(QUuid homeButtonHighlightID READ getCurrentHomeButtonHightlightID WRITE setCurrentHomeButtonHightlightID)
@@ -75,7 +76,7 @@ public:
 
     Q_INVOKABLE void closeTablet();
 
-    Q_INVOKABLE void openTablet();
+    Q_INVOKABLE void openTablet(bool contextualMode = false);
 
 signals:
     bool shouldShowHandControllersChanged();
@@ -91,6 +92,7 @@ public:
     void toggleShouldShowTablet() { _showTablet = !_showTablet; }
     void setShouldShowTablet(bool value) { _showTablet = value; }
     bool getShouldShowTablet() const { return _showTablet; }
+    bool getTabletContextualMode() const { return _tabletContextualMode; }
 
     void setCurrentTabletFrameID(QUuid tabletID) { _tabletUIID = tabletID; }
     QUuid getCurrentTabletFrameID() const { return _tabletUIID; }
@@ -106,6 +108,7 @@ public:
 
 private:
     bool _showTablet { false };
+    bool _tabletContextualMode { false };
     QUuid _tabletUIID; // this is the entityID of the tablet frame
     QUuid _tabletScreenID; // this is the overlayID which is part of (a child of) the tablet-ui.
     QUuid _homeButtonID;

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -124,7 +124,13 @@
                 print("TABLET in showTabletUI, already rezzed");
             }
             var tabletProperties = {};
-            UIWebTablet.calculateTabletAttachmentProperties(activeHand, true, tabletProperties);
+            if (HMD.tabletContextualMode)
+                print("DBACK tabletContextualMode");
+            else
+                print("DBACK NOT tabletContextualMode");
+            if (!HMD.tabletContextualMode) { // contextual mode forces tablet in place -> don't update attachment
+                UIWebTablet.calculateTabletAttachmentProperties(activeHand, true, tabletProperties);
+            }
             tabletProperties.visible = true;
             Overlays.editOverlay(HMD.tabletID, tabletProperties);
             Overlays.editOverlay(HMD.homeButtonID, { visible: true });

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -124,10 +124,6 @@
                 print("TABLET in showTabletUI, already rezzed");
             }
             var tabletProperties = {};
-            if (HMD.tabletContextualMode)
-                print("DBACK tabletContextualMode");
-            else
-                print("DBACK NOT tabletContextualMode");
             if (!HMD.tabletContextualMode) { // contextual mode forces tablet in place -> don't update attachment
                 UIWebTablet.calculateTabletAttachmentProperties(activeHand, true, tabletProperties);
             }


### PR DESCRIPTION
- add default false _tabletContextualMode flag to HMDScriptingInterface and expose property
- set _tabletContextualMode to passed in flag contextualMode (which is default false) in openTablet()
- reset _tabletContextualMode back to false in closeTablet()
- block attachment updates in showTabletUI() in tabletUI.js when tablet is in contextual mode

This will fix issues where we hijack the tablet for contextual purposes (i.e. avatar store checkout zone) and where the position and rotation that we force it to sometimes get reset to default attachment settings after opening the tablet.

Testing:

Behavior without the fix:
- Import JSON file - https://hifi-content.s3.amazonaws.com/davidback/development/avatarshop/checkoutZone_noContextualMode.json
- Enter HMD mode and approach the front of the checkout scanner to see tablet open
- Move away from checkout scanner to exit checkout zone and which will close tablet and then re-enter checkout zone to see tablet open again
- After entering and leaving the checkout zone a few times you should see the tablet sometimes reset back to default attachment settings (directly in front of camera and facing camera) as opposed to being forced into place angled over the right side of the checkout scanner

Behavior with the fix:
- Import JSON file - https://hifi-content.s3.amazonaws.com/davidback/development/avatarshop/checkoutZone_contextualMode.json
- Enter and leave this new checkout zone a few times and notice the tablet should now be forced into place angled over the right side of the checkout scanner every time you enter the checkout zone
- Closing/opening the tablet in HMD mode using the controller menu buttons while remaining in the checkout zone will reset the tablet to default attachment settings (directly in front of camera and facing camera) upon re-opening it instead of placing it over the right side of the checkout scanner
- Opening the tablet in HMD mode using controller menu buttons after leaving the checkout zone should put it back to default attachment settings
 