### PR TITLE
BUG FIX : Shadows cast by top zone key light

### DIFF
--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -112,6 +112,7 @@ void ZoneEntityRenderer::doRender(RenderArgs* args) {
             // Do we need to allocate the light in the stage ?
             if (LightStage::isIndexInvalid(_sunIndex)) {
                 _sunIndex = _stage->addLight(_sunLight);
+                _shadowIndex = _stage->addShadow(_sunIndex);
             } else {
                 _stage->updateLightArrayBuffer(_sunIndex);
             }

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.h
@@ -88,6 +88,7 @@ private:
     ComponentMode _hazeMode{ COMPONENT_MODE_INHERIT };
 
     indexed_container::Index _sunIndex{ LightStage::INVALID_INDEX };
+    indexed_container::Index _shadowIndex{ LightStage::INVALID_INDEX };
     indexed_container::Index _ambientIndex{ LightStage::INVALID_INDEX };
 
     BackgroundStagePointer _backgroundStage;

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -435,7 +435,7 @@ void DebugDeferredBuffer::run(const RenderContextPointer& renderContext, const I
         auto lightStage = renderContext->_scene->getStage<LightStage>();
         assert(lightStage);
         assert(lightStage->getNumLights() > 0);
-        auto lightAndShadow = lightStage->getLightAndShadow(0);
+        auto lightAndShadow = lightStage->getCurrentKeyLightAndShadow();
         const auto& globalShadow = lightAndShadow.second;
         if (globalShadow) {
             batch.setResourceTexture(Shadow, globalShadow->map);

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -498,7 +498,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
         auto lightStage = renderContext->_scene->getStage<LightStage>();
         assert(lightStage);
         assert(lightStage->getNumLights() > 0);
-        auto lightAndShadow = lightStage->getLightAndShadow(0);
+        auto lightAndShadow = lightStage->getCurrentKeyLightAndShadow();
         const auto& globalShadow = lightAndShadow.second;
 
         // Bind the shadow buffer
@@ -509,7 +509,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
         auto& program = deferredLightingEffect->_directionalSkyboxLight;
         LightLocationsPtr locations = deferredLightingEffect->_directionalSkyboxLightLocations;
 
-        auto keyLight = lightStage->getLight(0);
+        auto keyLight = lightAndShadow.first;
 
         // Setup the global directional pass pipeline
         {

--- a/libraries/render-utils/src/LightStage.cpp
+++ b/libraries/render-utils/src/LightStage.cpp
@@ -142,6 +142,11 @@ LightStage::LightPointer LightStage::removeLight(Index index) {
     LightPointer removed = _lights.freeElement(index);
     
     if (removed) {
+        auto shadowId = _descs[index].shadowId;
+        // Remove shadow if one exists for this light
+        if (shadowId != INVALID_INDEX) {
+            _shadows.freeElement(shadowId);
+        }
         _lightMap.erase(removed);
         _descs[index] = Desc();
     }

--- a/libraries/render-utils/src/LightStage.h
+++ b/libraries/render-utils/src/LightStage.h
@@ -116,6 +116,30 @@ public:
         return LightAndShadow(getLight(lightId), getShadow(lightId));
     }
 
+    LightPointer getCurrentKeyLight() const {
+        Index keyLightId{ 0 };
+        if (!_currentFrame._sunLights.empty()) {
+            keyLightId = _currentFrame._sunLights.front();
+        }
+        return _lights.get(keyLightId);
+    }
+
+    ShadowPointer getCurrentKeyShadow() const {
+        Index keyLightId{ 0 };
+        if (!_currentFrame._sunLights.empty()) {
+            keyLightId = _currentFrame._sunLights.front();
+        }
+        return getShadow(keyLightId);
+    }
+
+    LightAndShadow getCurrentKeyLightAndShadow() const {
+        Index keyLightId{ 0 };
+        if (!_currentFrame._sunLights.empty()) {
+            keyLightId = _currentFrame._sunLights.front();
+        }
+        return LightAndShadow(getLight(keyLightId), getShadow(keyLightId));
+    }
+
     LightStage();
     Lights _lights;
     LightMap _lightMap;


### PR DESCRIPTION
This PR fixes a bug where the shadows weren't correctly cast accordingly to the zone's key light direction when new zones where stacked on top of the default zone. Now the key light of the top most zone determines the shadow casting direction.

# Test plan
A manual and automated test plan is available in the [hifi_tests](https://github.com/highfidelity/hifi_tests) repository under _tests/engine/render/shadows_ in PR #32 for the hifi_test repository. This PR is tested particularly in steps 2 & 3.