### PR TITLE
implement callEntityClientMethod

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -30,7 +30,7 @@
 #include <UUID.h>
 #include <WebSocketServerClass.h>
 
-#include <EntityScriptClient.h> // for EntityScriptServerStub
+#include <EntityScriptClient.h> // for EntityScriptServerServices
 
 #include "EntityScriptServerLogging.h"
 #include "../entities/AssignmentParentFinder.h"
@@ -70,7 +70,7 @@ EntityScriptServer::EntityScriptServer(ReceivedMessage& message) : ThreadedAssig
     DependencyManager::set<ScriptCache>();
     DependencyManager::set<ScriptEngines>(ScriptEngine::ENTITY_SERVER_SCRIPT);
 
-    DependencyManager::set<EntityScriptServerStub>();
+    DependencyManager::set<EntityScriptServerServices>();
 
 
     // Needed to ensure the creation of the DebugDraw instance on the main thread

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -30,6 +30,8 @@
 #include <UUID.h>
 #include <WebSocketServerClass.h>
 
+#include <EntityScriptClient.h> // for EntityScriptServerStub
+
 #include "EntityScriptServerLogging.h"
 #include "../entities/AssignmentParentFinder.h"
 
@@ -67,6 +69,9 @@ EntityScriptServer::EntityScriptServer(ReceivedMessage& message) : ThreadedAssig
 
     DependencyManager::set<ScriptCache>();
     DependencyManager::set<ScriptEngines>(ScriptEngine::ENTITY_SERVER_SCRIPT);
+
+    DependencyManager::set<EntityScriptServerStub>();
+
 
     // Needed to ensure the creation of the DebugDraw instance on the main thread
     DebugDraw::getInstance();

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -588,6 +588,7 @@ void EntityScriptServer::aboutToFinish() {
     // cleanup the AudioInjectorManager (and any still running injectors)
     DependencyManager::destroy<AudioInjectorManager>();
     DependencyManager::destroy<ScriptEngines>();
+    DependencyManager::destroy<EntityScriptServerServices>();
 
     // cleanup codec & encoder
     if (_codec && _encoder) {

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -577,7 +577,14 @@ void EntityScriptingInterface::callEntityServerMethod(QUuid id, const QString& m
 
 void EntityScriptingInterface::callEntityClientMethod(QUuid clientSessionID, QUuid entityID, const QString& method, const QStringList& params) {
     PROFILE_RANGE(script_entities, __FUNCTION__);
-    DependencyManager::get<EntityScriptServerStub>()->callEntityClientMethod(clientSessionID, entityID, method, params);
+    auto scriptServerServices = DependencyManager::get<EntityScriptServerServices>();
+
+    // this won't be available on clients
+    if (scriptServerServices) {
+        scriptServerServices->callEntityClientMethod(clientSessionID, entityID, method, params);
+    } else {
+        qWarning() << "Entities.callEntityClientMethod() not allowed in client";
+    }
 }
 
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -50,6 +50,10 @@ EntityScriptingInterface::EntityScriptingInterface(bool bidOnSimulationOwnership
     connect(nodeList.data(), &NodeList::canRezCertifiedChanged, this, &EntityScriptingInterface::canRezCertifiedChanged);
     connect(nodeList.data(), &NodeList::canRezTmpCertifiedChanged, this, &EntityScriptingInterface::canRezTmpCertifiedChanged);
     connect(nodeList.data(), &NodeList::canWriteAssetsChanged, this, &EntityScriptingInterface::canWriteAssetsChanged);
+
+
+    auto& packetReceiver = nodeList->getPacketReceiver();
+    packetReceiver.registerListener(PacketType::EntityScriptCallMethod, this, "handleEntityScriptCallMethodPacket");
 }
 
 void EntityScriptingInterface::queueEntityMessage(PacketType packetType,
@@ -570,6 +574,41 @@ void EntityScriptingInterface::callEntityServerMethod(QUuid id, const QString& m
     PROFILE_RANGE(script_entities, __FUNCTION__);
     DependencyManager::get<EntityScriptClient>()->callEntityServerMethod(id, method, params);
 }
+
+void EntityScriptingInterface::callEntityClientMethod(QUuid clientSessionID, QUuid entityID, const QString& method, const QStringList& params) {
+    PROFILE_RANGE(script_entities, __FUNCTION__);
+    DependencyManager::get<EntityScriptServerStub>()->callEntityClientMethod(clientSessionID, entityID, method, params);
+}
+
+
+void EntityScriptingInterface::handleEntityScriptCallMethodPacket(QSharedPointer<ReceivedMessage> receivedMessage, SharedNodePointer senderNode) {
+    PROFILE_RANGE(script_entities, __FUNCTION__);
+
+    auto nodeList = DependencyManager::get<NodeList>();
+    SharedNodePointer entityScriptServer = nodeList->soloNodeOfType(NodeType::EntityScriptServer);
+
+    if (entityScriptServer == senderNode) {
+        auto entityID = QUuid::fromRfc4122(receivedMessage->read(NUM_BYTES_RFC4122_UUID));
+
+        auto method = receivedMessage->readString();
+
+        quint16 paramCount;
+        receivedMessage->readPrimitive(&paramCount);
+
+        QStringList params;
+        for (int param = 0; param < paramCount; param++) {
+            auto paramString = receivedMessage->readString();
+            params << paramString;
+        }
+
+        std::lock_guard<std::recursive_mutex> lock(_entitiesScriptEngineLock);
+        if (_entitiesScriptEngine) {
+            _entitiesScriptEngine->callEntityScriptMethod(entityID, method, params, senderNode->getUUID());
+        }
+    }
+}
+
+
 
 QUuid EntityScriptingInterface::findClosestEntity(const glm::vec3& center, float radius) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -189,12 +189,15 @@ public slots:
     Q_INVOKABLE void deleteEntity(QUuid entityID);
 
     /**jsdoc
-     * Call a method on an entity. Allows a script to call a method on an entity's script. 
-     * The method will execute in the entity script engine. If the entity does not have an 
-     * entity script or the method does not exist, this call will have no effect.
-     * If it is running an entity script (specified by the `script` property)
+     * Call a method on an entity in the same context as this function is called. Allows a script 
+     * to call a method on an entity's script. The method will execute in the entity script engine. 
+     * If the entity does not have an  entity script or the method does not exist, this call will 
+     * have no effect. If it is running an entity script (specified by the `script` property)
      * and it exposes a property with the specified name `method`, it will be called
-     * using `params` as the list of arguments.
+     * using `params` as the list of arguments. If this is called within an entity script, the
+     * method will be executed on the client in the entity script engine in which it was called. If
+     * this is called in an entity server script, the method will be executed on the entity server 
+     * script engine.
      *
      * @function Entities.callEntityMethod
      * @param {EntityID} entityID The ID of the entity to call the method on.
@@ -217,6 +220,21 @@ public slots:
     * @param {string[]} params The list of parameters to call the specified method with.
     */
     Q_INVOKABLE void callEntityServerMethod(QUuid entityID, const QString& method, const QStringList& params = QStringList());
+
+    /**jsdoc
+    * Call a client method on an entity on a specific client node. Allows a server entity script to call a 
+    * method on an entity's client script for a particular client. The method will execute in the entity script 
+    * engine on that single client. If the entity does not have an entity script or the method does not exist, or
+    * the client is not connected to the domain, or you attempt to make this call outside of the entity server 
+    * script, this call will have no effect.
+    *
+    * @function Entities.callEntityClientMethod
+    * @param {SessionID} clientSessionID The session ID of the client to call the method on.
+    * @param {EntityID} entityID The ID of the entity to call the method on.
+    * @param {string} method The name of the method to call.
+    * @param {string[]} params The list of parameters to call the specified method with.
+    */
+    Q_INVOKABLE void callEntityClientMethod(QUuid clientSessionID, QUuid entityID, const QString& method, const QStringList& params = QStringList());
 
     /**jsdoc
      * finds the closest model to the center point, within the radius
@@ -447,6 +465,10 @@ protected:
         std::lock_guard<std::recursive_mutex> lock(_entitiesScriptEngineLock);
         function(_entitiesScriptEngine);
     };
+
+private slots:
+    void handleEntityScriptCallMethodPacket(QSharedPointer<ReceivedMessage> receivedMessage, SharedNodePointer senderNode);
+
 private:
     bool actionWorker(const QUuid& entityID, std::function<bool(EntitySimulationPointer, EntityItemPointer)> actor);
     bool polyVoxWorker(QUuid entityID, std::function<bool(PolyVoxEntityItem&)> actor);

--- a/libraries/networking/src/EntityScriptClient.cpp
+++ b/libraries/networking/src/EntityScriptClient.cpp
@@ -92,10 +92,7 @@ void EntityScriptClient::callEntityServerMethod(QUuid entityID, const QString& m
     }
 }
 
-void EntityScriptServerStub::callEntityClientMethod(QUuid clientSessionID, QUuid entityID, const QString& method, const QStringList& params) {
-    qDebug() << __FUNCTION__;
-
-
+void EntityScriptServerServices::callEntityClientMethod(QUuid clientSessionID, QUuid entityID, const QString& method, const QStringList& params) {
     // only valid to call this function if you are the entity script server
     auto nodeList = DependencyManager::get<NodeList>();
     SharedNodePointer targetClient = nodeList->nodeWithUUID(clientSessionID);

--- a/libraries/networking/src/EntityScriptClient.h
+++ b/libraries/networking/src/EntityScriptClient.h
@@ -74,4 +74,11 @@ private:
     void forceFailureOfPendingRequests(SharedNodePointer node);
 };
 
+
+class EntityScriptServerStub : public QObject, public Dependency {
+    Q_OBJECT
+public:
+    void callEntityClientMethod(QUuid clientSessionID, QUuid entityID, const QString& method, const QStringList& params);
+};
+
 #endif

--- a/libraries/networking/src/EntityScriptClient.h
+++ b/libraries/networking/src/EntityScriptClient.h
@@ -75,7 +75,7 @@ private:
 };
 
 
-class EntityScriptServerStub : public QObject, public Dependency {
+class EntityScriptServerServices : public QObject, public Dependency {
     Q_OBJECT
 public:
     void callEntityClientMethod(QUuid clientSessionID, QUuid entityID, const QString& method, const QStringList& params);

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -62,6 +62,9 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::DomainServerAddedNode:
             return static_cast<PacketVersion>(DomainServerAddedNodeVersion::PermissionsGrid);
 
+        case PacketType::EntityScriptCallMethod:
+            return static_cast<PacketVersion>(EntityScriptCallMethodVersion::ClientCallable);
+
         case PacketType::MixedAudio:
         case PacketType::SilentAudioFrame:
         case PacketType::InjectAudio:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -274,6 +274,12 @@ const PacketVersion VERSION_ENTITIES_UV_MODE_PROPERTY = 76;
 const PacketVersion VERSION_ENTITIES_STROKE_COLOR_PROPERTY = 77;
 
 
+
+enum class EntityScriptCallMethodVersion : PacketVersion {
+    ServerCallable = 18,
+    ClientCallable = 19
+};
+
 enum class EntityQueryPacketVersion: PacketVersion {
     JSONFilter = 18,
     JSONFilterWithFamilyTree = 19

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2510,8 +2510,6 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
         if (remoteCallerID == QUuid()) {
             callAllowed = true;
         } else {
-            qDebug() << __FUNCTION__ << "checking remotelyCallable method: " << methodName << " on entityID:" << entityID;
-
             if (entityScript.property("remotelyCallable").isArray()) {
                 auto callables = entityScript.property("remotelyCallable");
                 auto callableCount = callables.property("length").toInteger();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2510,6 +2510,8 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
         if (remoteCallerID == QUuid()) {
             callAllowed = true;
         } else {
+            qDebug() << __FUNCTION__ << "checking remotelyCallable method: " << methodName << " on entityID:" << entityID;
+
             if (entityScript.property("remotelyCallable").isArray()) {
                 auto callables = entityScript.property("remotelyCallable");
                 auto callableCount = callables.property("length").toInteger();
@@ -2536,6 +2538,8 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
             callWithEnvironment(entityID, details.definingSandboxURL, entityScript.property(methodName), entityScript, args);
             this->globalObject().property("Script").setProperty("remoteCallerID", oldData);
         }
+    } else {
+        qDebug() << "Entity script not running for EntityID: " << entityID << " - Method [" << methodName << "] not callable.";
     }
 }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2536,8 +2536,6 @@ void ScriptEngine::callEntityScriptMethod(const EntityItemID& entityID, const QS
             callWithEnvironment(entityID, details.definingSandboxURL, entityScript.property(methodName), entityScript, args);
             this->globalObject().property("Script").setProperty("remoteCallerID", oldData);
         }
-    } else {
-        qDebug() << "Entity script not running for EntityID: " << entityID << " - Method [" << methodName << "] not callable.";
     }
 }
 


### PR DESCRIPTION
This implements support to allow server side entity scripts to easily call methods on client side Entity Scripts. This is particularly convenient for object oriented development where some script logic should run in the server script, but other script logic should run on the client.

A good example of this is a case where you might have some game/app logic that you want running in the server (like some shared logic), that needs to activate some kind of behavior only available to a client (like playing a sound effect, teleporting, etc).

Methods can only be called remotely if they are in the remotelyCallable property for the entity script. Also the remoteCallerID global variable is set to the node ID of the remote caller for the duration of the method call, this allows functions to additionally verify that the caller is the expected caller. It should also be noted that for security reasons this function is only available for scripts running in the entity script server.

TEST PLAN - https://highfidelity.testrail.net/index.php?/cases/view/1932