### PR TITLE
Changed blend range from 32,000 m to 30,000m

### DIFF
--- a/libraries/render-utils/src/Haze.slf
+++ b/libraries/render-utils/src/Haze.slf
@@ -138,7 +138,8 @@ void main(void) {
     }
 
     // Mix with background at far range
-    if (distance > 32000.0) {
+    const float BLEND_DISTANCE = 30000.0;
+    if (distance > BLEND_DISTANCE) {
         outFragColor = mix(potentialFragColor, fragColor, hazeParams.backgroundBlendValue);
     } else {
         outFragColor = potentialFragColor;


### PR DESCRIPTION
Fixes bug of grey circle appearing in Oculus Rift when using background blend.