### PR TITLE
Fix backwards HUD in mirror mode

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -95,7 +95,7 @@ protected:
     virtual QThread::Priority getPresentPriority() { return QThread::HighPriority; }
     virtual void compositeLayers();
     virtual void compositeScene();
-    virtual std::function<void(gpu::Batch&, const gpu::TexturePointer&)> getHUDOperator();
+    virtual std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> getHUDOperator();
     virtual void compositePointer();
     virtual void compositeExtra() {};
 
@@ -140,6 +140,8 @@ protected:
     gpu::Frame* _lastFrame { nullptr };
     gpu::FramebufferPointer _compositeFramebuffer;
     gpu::PipelinePointer _hudPipeline;
+    gpu::PipelinePointer _mirrorHUDPipeline;
+    gpu::ShaderPointer _mirrorHUDPS;
     gpu::PipelinePointer _simplePipeline;
     gpu::PipelinePointer _presentPipeline;
     gpu::PipelinePointer _cursorPipeline;

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -53,7 +53,7 @@ protected:
 
     bool internalActivate() override;
     void internalDeactivate() override;
-    std::function<void(gpu::Batch&, const gpu::TexturePointer&)> getHUDOperator() override;
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> getHUDOperator() override;
     void compositePointer() override;
     void internalPresent() override;
     void customizeContext() override;
@@ -116,6 +116,6 @@ private:
 
         void build();
         void updatePipeline();
-        std::function<void(gpu::Batch&, const gpu::TexturePointer&)> render(HmdDisplayPlugin& plugin);
+        std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> render(HmdDisplayPlugin& plugin);
     } _hudRenderer;
 };

--- a/libraries/gpu/src/gpu/DrawTextureMirroredX.slf
+++ b/libraries/gpu/src/gpu/DrawTextureMirroredX.slf
@@ -1,0 +1,22 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  Draw texture 0 fetched at (1.0 - texcoord.x, texcoord.y)
+//
+//  Created by Sam Gondelman on 10/24/2017
+//  Copyright 2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+
+uniform sampler2D colorMap;
+
+in vec2 varTexCoord0;
+out vec4 outFragColor;
+
+void main(void) {
+    outFragColor = texture(colorMap, vec2(1.0 - varTexCoord0.x, varTexCoord0.y));
+}

--- a/libraries/gpu/src/gpu/StandardShaderLib.cpp
+++ b/libraries/gpu/src/gpu/StandardShaderLib.cpp
@@ -23,6 +23,7 @@ const char DrawNada_frag[] = "void main(void) {}"; // DrawNada is really simple.
 
 #include "DrawWhite_frag.h"
 #include "DrawTexture_frag.h"
+#include "DrawTextureMirroredX_frag.h"
 #include "DrawTextureOpaque_frag.h"
 #include "DrawColoredTexture_frag.h"
 
@@ -37,6 +38,7 @@ ShaderPointer StandardShaderLib::_drawTransformVertexPositionVS;
 ShaderPointer StandardShaderLib::_drawNadaPS;
 ShaderPointer StandardShaderLib::_drawWhitePS;
 ShaderPointer StandardShaderLib::_drawTexturePS;
+ShaderPointer StandardShaderLib::_drawTextureMirroredXPS;
 ShaderPointer StandardShaderLib::_drawTextureOpaquePS;
 ShaderPointer StandardShaderLib::_drawColoredTexturePS;
 StandardShaderLib::ProgramMap StandardShaderLib::_programs;
@@ -128,6 +130,13 @@ ShaderPointer StandardShaderLib::getDrawTexturePS() {
         _drawTexturePS = gpu::Shader::createPixel(std::string(DrawTexture_frag));
     }
     return _drawTexturePS;
+}
+
+ShaderPointer StandardShaderLib::getDrawTextureMirroredXPS() {
+    if (!_drawTextureMirroredXPS) {
+        _drawTextureMirroredXPS = gpu::Shader::createPixel(std::string(DrawTextureMirroredX_frag));
+    }
+    return _drawTextureMirroredXPS;
 }
 
 ShaderPointer StandardShaderLib::getDrawTextureOpaquePS() {

--- a/libraries/gpu/src/gpu/StandardShaderLib.h
+++ b/libraries/gpu/src/gpu/StandardShaderLib.h
@@ -47,6 +47,7 @@ public:
 
     static ShaderPointer getDrawWhitePS();
     static ShaderPointer getDrawTexturePS();
+    static ShaderPointer getDrawTextureMirroredXPS();
     static ShaderPointer getDrawTextureOpaquePS();
     static ShaderPointer getDrawColoredTexturePS();
 
@@ -67,6 +68,7 @@ protected:
     static ShaderPointer _drawNadaPS;
     static ShaderPointer _drawWhitePS;
     static ShaderPointer _drawTexturePS;
+    static ShaderPointer _drawTextureMirroredXPS;
     static ShaderPointer _drawTextureOpaquePS;
     static ShaderPointer _drawColoredTexturePS;
 

--- a/libraries/plugins/src/plugins/DisplayPlugin.cpp
+++ b/libraries/plugins/src/plugins/DisplayPlugin.cpp
@@ -35,8 +35,8 @@ void DisplayPlugin::waitForPresent() {
     }
 }
 
-std::function<void(gpu::Batch&, const gpu::TexturePointer&)> DisplayPlugin::getHUDOperator() {
-    std::function<void(gpu::Batch&, const gpu::TexturePointer&)> hudOperator;
+std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> DisplayPlugin::getHUDOperator() {
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> hudOperator;
     {
         QMutexLocker locker(&_presentMutex);
         hudOperator = _hudOperator;

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -204,7 +204,7 @@ public:
 
     void waitForPresent();
 
-    std::function<void(gpu::Batch&, const gpu::TexturePointer&)> getHUDOperator();
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> getHUDOperator();
 
     static const QString& MENU_PATH();
 
@@ -218,7 +218,7 @@ protected:
 
     gpu::ContextPointer _gpuContext;
 
-    std::function<void(gpu::Batch&, const gpu::TexturePointer&)> _hudOperator { std::function<void(gpu::Batch&, const gpu::TexturePointer&)>() };
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> _hudOperator { std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)>() };
 
 private:
     QMutex _presentMutex;

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -441,7 +441,7 @@ void CompositeHUD::run(const RenderContextPointer& renderContext) {
     // Grab the HUD texture
     gpu::doInBatch(renderContext->args->_context, [&](gpu::Batch& batch) {
         if (renderContext->args->_hudOperator) {
-            renderContext->args->_hudOperator(batch, renderContext->args->_hudTexture);
+            renderContext->args->_hudOperator(batch, renderContext->args->_hudTexture, renderContext->args->_renderMode == RenderArgs::RenderMode::MIRROR_RENDER_MODE);
         }
     });
 }

--- a/libraries/render/src/render/Args.h
+++ b/libraries/render/src/render/Args.h
@@ -122,7 +122,7 @@ namespace render {
         render::ScenePointer _scene;
         int8_t _cameraMode { -1 };
 
-        std::function<void(gpu::Batch&, const gpu::TexturePointer&)> _hudOperator;
+        std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> _hudOperator;
         gpu::TexturePointer _hudTexture;
     };
 


### PR DESCRIPTION
Test plan:
- In desktop mode, the HUD (stats, toolbar, etc.) should render properly.
- In mirror mode (ctrl+h), they should still render properly.
- In HMD in first person, the HUD sphere should render properly.
- In HMD in mirror mode, the HUD sphere should still render properly.
- In HMD in mirror mode, while facing your avatar, your avatar should mirror your movements (if you move your right hand, the avatar moves its left hand, like a mirror image).

(in mirror mode, you can rotate the camera with the arrow keys, and pan it up and down with shift + up arrow/shift + down arrow)