### PR TITLE
8380 Mouse Disappears when switching between HMD and Desktop Mode while in Create

### DIFF
--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -234,7 +234,8 @@ void CompositorHelper::handleLeaveEvent() {
 
 bool CompositorHelper::handleRealMouseMoveEvent(bool sendFakeEvent) {
     // If the mouse move came from a capture mouse related move, we completely ignore it.
-    if (_ignoreMouseMove) {
+    // Note: if not going to synthesize event - do not touch _ignoreMouseMove flag
+    if (_ignoreMouseMove && sendFakeEvent) {
         _ignoreMouseMove = false;
         return true; // swallow the event
     }
@@ -246,7 +247,12 @@ bool CompositorHelper::handleRealMouseMoveEvent(bool sendFakeEvent) {
         auto changeInRealMouse = newPosition - _lastKnownRealMouse;
         auto newReticlePosition = _reticlePositionInHMD + toGlm(changeInRealMouse);
         setReticlePosition(newReticlePosition, sendFakeEvent);
-        _ignoreMouseMove = true;
+
+        // Note: if not going to synthesize event - do not touch _ignoreMouseMove flag
+        if (sendFakeEvent) {
+            _ignoreMouseMove = true;
+        }
+
         QCursor::setPos(QPoint(_lastKnownRealMouse.x(), _lastKnownRealMouse.y())); // move cursor back to where it was
         return true;  // swallow the event
     } else {


### PR DESCRIPTION
Note: the issue was happening due to interference of two calls: handleRealMouseMoveEvent(true) from Application::mouseMove & handleRealMouseMoveEvent(false) from OffscreenUi's mouse translator. 

The workaround consists in preserving state of _ignoreMouseMove flag in case if function is not going to synthesize events. 

*** Test plan ***

Notes from FB: 

> You can replicate this by having Create Open, switching to HMD mode from Desktop Mode, and back , and moving the mouse around after a while.
> 
> It will initially show the mouse, but the mouse will dissapear.
> 

Unfortunately in my case the issue was randomly reproducible so suspect it depends on the particular environment. But, if it was reproducible I also noticed that hover over tablet's menu items wasn't working as well. It started working only after mouse cursor re-appearing. 

Thus, please also check the following scenario: 

1. Launch interface
2. Go to VR
3. Open tablet
4. Slowly move mouse over tablet's menu items
5. Ensure tablet's menu items have correct hover effect and mouse doesn't disappear during first 20 seconds. 