### PR TITLE
Fix dpi setting in edit.js

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1373,7 +1373,7 @@ function loaded() {
         elShape.addEventListener('change', createEmitTextPropertyUpdateFunction('shape'));
 
         elWebSourceURL.addEventListener('change', createEmitTextPropertyUpdateFunction('sourceUrl'));
-        elWebDPI.addEventListener('change', createEmitNumberPropertyUpdateFunction('dpi'));
+        elWebDPI.addEventListener('change', createEmitNumberPropertyUpdateFunction('dpi', 0));
 
         elModelURL.addEventListener('change', createEmitTextPropertyUpdateFunction('modelURL'));
         elShapeType.addEventListener('change', createEmitTextPropertyUpdateFunction('shapeType'));


### PR DESCRIPTION
DPI is an integer value in the Web Entity... because of how edit.js works, you have to specify that numbers have 0 decimals if you want them to be integers.

fixes this bug: https://highfidelity.fogbugz.com/f/cases/5182/Can-t-change-Resolution-DPI-on-a-web-entity

test plan:
- create a web entity
- open properties
- set the DPI setting to some value... see that the setting takes, and that the apparent DPI of the web view changes