### PR TITLE
Hotfix: fix null candidate ice-server QHostAddress

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -754,26 +754,6 @@ void DomainServer::setupICEHeartbeatForFullNetworking() {
 void DomainServer::updateICEServerAddresses() {
     if (_iceAddressLookupID == INVALID_ICE_LOOKUP_ID) {
         _iceAddressLookupID = QHostInfo::lookupHost(_iceServerAddr, this, SLOT(handleICEHostInfo(QHostInfo)));
-
-        // there seems to be a 5.9 bug where lookupHost never calls our slot
-        // so we add a single shot manual "timeout" to fire it off again if it hasn't called back yet
-        static const int ICE_ADDRESS_LOOKUP_TIMEOUT_MS = 5000;
-        QTimer::singleShot(ICE_ADDRESS_LOOKUP_TIMEOUT_MS, this, &DomainServer::timeoutICEAddressLookup);
-    }
-}
-
-void DomainServer::timeoutICEAddressLookup() {
-    if (_iceAddressLookupID != INVALID_ICE_LOOKUP_ID) {
-        // we waited 5s and didn't hear back for our ICE DNS lookup
-        // so time that one out and kick off another
-
-        qDebug() << "IP address lookup timed out for" << _iceServerAddr << "- retrying";
-
-        QHostInfo::abortHostLookup(_iceAddressLookupID);
-
-        _iceAddressLookupID = INVALID_ICE_LOOKUP_ID;
-
-        updateICEServerAddresses();
     }
 }
 
@@ -2799,9 +2779,20 @@ void DomainServer::handleKeypairChange() {
 
 void DomainServer::handleICEHostInfo(const QHostInfo& hostInfo) {
     // clear the ICE address lookup ID so that it can fire again
-    _iceAddressLookupID = -1;
+    _iceAddressLookupID = INVALID_ICE_LOOKUP_ID;
 
-    if (hostInfo.error() != QHostInfo::NoError) {
+    // enumerate the returned addresses and collect only valid IPv4 addresses
+    QList<QHostAddress> sanitizedAddresses = hostInfo.addresses();
+    auto it = sanitizedAddresses.begin();
+    while (it != sanitizedAddresses.end()) {
+        if (!it->isNull() && it->protocol() == QAbstractSocket::IPv4Protocol) {
+            ++it;
+        } else {
+            it = sanitizedAddresses.erase(it);
+        }
+    }
+
+    if (hostInfo.error() != QHostInfo::NoError || sanitizedAddresses.empty()) {
         qWarning() << "IP address lookup failed for" << _iceServerAddr << ":" << hostInfo.errorString();
 
         // if we don't have an ICE server to use yet, trigger a retry
@@ -2814,7 +2805,7 @@ void DomainServer::handleICEHostInfo(const QHostInfo& hostInfo) {
     } else {
         int countBefore = _iceServerAddresses.count();
 
-        _iceServerAddresses = hostInfo.addresses();
+        _iceServerAddresses = sanitizedAddresses;
 
         if (countBefore == 0) {
             qInfo() << "Found" << _iceServerAddresses.count() << "ice-server IP addresses for" << _iceServerAddr;

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -116,8 +116,6 @@ private slots:
     void tokenGrantFinished();
     void profileRequestFinished();
 
-    void timeoutICEAddressLookup();
-
 signals:
     void iceServerChanged();
     void userConnected();

--- a/libraries/networking/src/HifiSockAddr.h
+++ b/libraries/networking/src/HifiSockAddr.h
@@ -34,7 +34,7 @@ public:
     HifiSockAddr(const sockaddr* sockaddr);
 
     bool isNull() const { return _address.isNull() && _port == 0; }
-    void clear() { _address = QHostAddress::Null; _port = 0;}
+    void clear() { _address.clear(); _port = 0;}
 
     HifiSockAddr& operator=(const HifiSockAddr& rhsSockAddr);
     void swap(HifiSockAddr& otherSockAddr);


### PR DESCRIPTION
- stop null QHostAddress from being used for ice-server address