### PR TITLE
Bug fix 8610

### DIFF
--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -509,14 +509,21 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
         auto& program = deferredLightingEffect->_directionalSkyboxLight;
         LightLocationsPtr locations = deferredLightingEffect->_directionalSkyboxLightLocations;
 
-        auto keyLight = lightStage->getLight(0);
+        auto keyLight = lightAndShadow.first;
+
+        model::LightPointer keyAmbientLight;
+        if (lightStage && lightStage->_currentFrame._ambientLights.size()) {
+            keyAmbientLight = lightStage->getLight(lightStage->_currentFrame._ambientLights.front());
+        }
+        bool hasAmbientMap = (keyAmbientLight != nullptr);
 
         // Setup the global directional pass pipeline
         {
             if (deferredLightingEffect->_shadowMapEnabled) {
+
                 // If the keylight has an ambient Map then use the Skybox version of the pass
                 // otherwise use the ambient sphere version
-                if (keyLight->getAmbientMap()) {
+                if (hasAmbientMap) {
                     program = deferredLightingEffect->_directionalSkyboxLightShadow;
                     locations = deferredLightingEffect->_directionalSkyboxLightShadowLocations;
                 } else {
@@ -526,7 +533,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
             } else {
                 // If the keylight has an ambient Map then use the Skybox version of the pass
                 // otherwise use the ambient sphere version
-                if (keyLight->getAmbientMap()) {
+                if (hasAmbientMap) {
                     program = deferredLightingEffect->_directionalSkyboxLight;
                     locations = deferredLightingEffect->_directionalSkyboxLightLocations;
                 } else {

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -509,7 +509,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
         auto& program = deferredLightingEffect->_directionalSkyboxLight;
         LightLocationsPtr locations = deferredLightingEffect->_directionalSkyboxLightLocations;
 
-        auto keyLight = lightAndShadow.first;
+        auto keyLight = lightStage->getLight(0);
 
         // Setup the global directional pass pipeline
         {


### PR DESCRIPTION
Looking at this test:
https://github.com/highfidelity/hifi_tests/blob/master/tests/engine/render/material/roughness/test.md

the metallic raw of shapes should look much more shiny and reflective on the left.  Before the fix, the objects are a matte grey colour.  After the fix - the reflections are clear. 
The bug can be seen in build 7340 .. 7348.