### PR TITLE
Reduced haze background blend range to 27,000 metres.

### DIFF
--- a/libraries/render-utils/src/Haze.slf
+++ b/libraries/render-utils/src/Haze.slf
@@ -138,7 +138,7 @@ void main(void) {
     }
 
     // Mix with background at far range
-    const float BLEND_DISTANCE = 30000.0;
+    const float BLEND_DISTANCE = 27000.0;
     if (distance > BLEND_DISTANCE) {
         outFragColor = mix(potentialFragColor, fragColor, hazeParams.backgroundBlendValue);
     } else {


### PR DESCRIPTION
There are instances where 30 km is too large to use as a switch for haze-background blend.  This has been reduced to 27 km.