### PR TITLE
8315 Stylus appears in wrong place on hand

### DIFF
--- a/scripts/system/controllers/controllerModules/tabletStylusInput.js
+++ b/scripts/system/controllers/controllerModules/tabletStylusInput.js
@@ -154,6 +154,25 @@ Script.include("/~/system/libraries/controllers.js");
 
         this.showStylus = function() {
             if (this.stylus) {
+                var X_ROT_NEG_90 = { x: -0.70710678, y: 0, z: 0, w: 0.70710678 };
+                var modelOrientation = Quat.multiply(this.stylusTip.orientation, X_ROT_NEG_90);
+                var modelOrientationAngles = Quat.safeEulerAngles(modelOrientation);
+
+                var rotation = Overlays.getProperty(this.stylus, "rotation");
+                var rotationAngles = Quat.safeEulerAngles(rotation);
+
+                if(!Vec3.withinEpsilon(modelOrientationAngles, rotationAngles, 1)) {
+                    var modelPositionOffset = Vec3.multiplyQbyV(modelOrientation, { x: 0, y: 0, z: MyAvatar.sensorToWorldScale * -WEB_STYLUS_LENGTH / 2 });
+
+                    var updatedStylusProperties = { 
+                        position: Vec3.sum(this.stylusTip.position, modelPositionOffset),
+                        rotation: modelOrientation,
+                        dimensions: Vec3.multiply(MyAvatar.sensorToWorldScale, { x: 0.01, y: 0.01, z: WEB_STYLUS_LENGTH }),
+                    };
+
+                    Overlays.editOverlay(this.stylus, updatedStylusProperties);
+                }
+
                 return;
             }
 


### PR DESCRIPTION
When update rate is slow, the stylus does not appear in the correct place relative to the hand.

Repro:
  * Run the tablet in a domain with lots of content, like dev-welcome
  * Move your hand away from the tablet, such that the stylus for that hand is removed
  * Move your hand quickly toward the tablet, such that it appears again.
  * The stylus will not appear in the correct place relative to your avatar's hand.
  * If you try the previous 3 steps except move your hand slowly toward the tablet, the stylus will appear in the correct location.

