### PR TITLE
6719 Avatar attachment window will update when attachments are modified

### DIFF
--- a/interface/resources/qml/hifi/dialogs/content/AttachmentsContent.qml
+++ b/interface/resources/qml/hifi/dialogs/content/AttachmentsContent.qml
@@ -14,12 +14,24 @@ Item {
     readonly property var originalAttachments: MyAvatar.getAttachmentsVariant();
     property var attachments: [];
 
-    Component.onCompleted: {
-        for (var i = 0; i < originalAttachments.length; ++i) {
-            var attachment = originalAttachments[i];
+    function reload(){
+        content.attachments = [];
+        var currentAttachments = MyAvatar.getAttachmentsVariant();
+        listView.model.clear();
+        for (var i = 0; i < currentAttachments.length; ++i) {
+            var attachment = currentAttachments[i];
             content.attachments.push(attachment);
             listView.model.append({});
         }
+    }
+    
+    Connections {
+        target: MyAvatar
+        onAttachmentsChanged: reload()
+    }
+
+    Component.onCompleted: {
+        reload()
     }
 
     Column {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1452,6 +1452,7 @@ void MyAvatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) 
         return;
     }
     Avatar::setAttachmentData(attachmentData);
+    emit attachmentsChanged();
 }
 
 glm::vec3 MyAvatar::getSkeletonPosition() const {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -619,6 +619,7 @@ signals:
     void skeletonChanged();
     void dominantHandChanged(const QString& hand);
     void sensorToWorldScaleChanged(float sensorToWorldScale);
+    void attachmentsChanged();
 
 private:
 


### PR DESCRIPTION
This PR fix the problem with the avatar attachment window not updating correctly. Now it will update every time avatar attachments are modified.

https://highfidelity.fogbugz.com/f/cases/6719

...

TEST PLAN

- Go to Dev-Welcome or any other domain with wearable content
- Open the avatar attachments window
- Click on different wearable entities. (the attachment window should update accordingly)
- Save and reopen the window (the attachments should be saved correctly)