### PR TITLE
Billboardables face avatar instead of facing away

### DIFF
--- a/interface/src/ui/overlays/Billboardable.cpp
+++ b/interface/src/ui/overlays/Billboardable.cpp
@@ -37,7 +37,7 @@ bool Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offse
         // use the referencial from the avatar, y isn't always up
         glm::vec3 avatarUP = DependencyManager::get<AvatarManager>()->getMyAvatar()->getOrientation()*Vectors::UP;
         
-        glm::quat rotation(conjugate(toQuat(glm::lookAt(billboardPos, cameraPos, avatarUP))));
+        glm::quat rotation(conjugate(toQuat(glm::lookAt(cameraPos, billboardPos, avatarUP))));
         
         transform.setRotation(rotation);
         transform.postRotate(offsetRotation);


### PR DESCRIPTION
Broke in https://github.com/highfidelity/hifi/pull/11661

Test plan:
- Right click on an entity from the marketplace to bring up the context overlay
- The "i" should be forwards