### PR TITLE
remove href property for non-owned avatar entities

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -290,7 +290,7 @@ void Avatar::updateAvatarEntities() {
             if (!isMyAvatar() && !specifiedHref.isEmpty()) {
                 qCDebug(avatars_renderer) << "removing entity href from avatar attached entity:" << entityID << "old href:" << specifiedHref;
                 QString noHref;
-                properties.setScript(noHref);
+                properties.setHref(noHref);
             }
 
             // When grabbing avatar entities, they are parented to the joint moving them, then when un-grabbed

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -286,6 +286,13 @@ void Avatar::updateAvatarEntities() {
                 properties.setScript(noScript);
             }
 
+            auto specifiedHref = properties.getHref();
+            if (!isMyAvatar() && !specifiedHref.isEmpty()) {
+                qCDebug(avatars_renderer) << "removing entity href from avatar attached entity:" << entityID << "old href:" << specifiedHref;
+                QString noHref;
+                properties.setScript(noHref);
+            }
+
             // When grabbing avatar entities, they are parented to the joint moving them, then when un-grabbed
             // they go back to the default parent (null uuid).  When un-gripped, others saw the entity disappear.
             // The thinking here is the local position was noticed as changing, but not the parentID (since it is now


### PR DESCRIPTION
**Test plan: 2 users** 
Go to a domain where you do not have rez rights. Import the following JSON: https://hifi-content.s3.amazonaws.com/liv/dev/teleporter.json

A second tester should click on the red sphere that appears and should not be teleported to dev-welcome.