### PR TITLE
fix Circles and quads

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1754,7 +1754,6 @@ void EntityItem::updateDimensions(const glm::vec3& value) {
         setDimensions(value);
         markDirtyFlags(Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS);
         _queryAACubeSet = false;
-        dimensionsChanged();
     }
 }
 

--- a/libraries/entities/src/ShapeEntityItem.h
+++ b/libraries/entities/src/ShapeEntityItem.h
@@ -80,6 +80,8 @@ public:
     const rgbColor& getColor() const { return _color; }
     void setColor(const rgbColor& value);
 
+	void setDimensions(const glm::vec3& value) override;
+
     xColor getXColor() const;
     void setColor(const xColor& value);
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -482,8 +482,10 @@ void GeometryCache::buildShapes() {
     using namespace geometry;
     auto vertexBuffer = std::make_shared<gpu::Buffer>();
     auto indexBuffer = std::make_shared<gpu::Buffer>();
-    // Cube 
+    // Cube
     setupFlatShape(_shapes[Cube], geometry::cube(), _shapeVertices, _shapeIndices);
+    //Quad renders as flat Cube
+    setupFlatShape(_shapes[Quad], geometry::cube(), _shapeVertices, _shapeIndices);
     // Tetrahedron
     setupFlatShape(_shapes[Tetrahedron], geometry::tetrahedron(), _shapeVertices, _shapeIndices);
     // Icosahedron
@@ -524,12 +526,10 @@ void GeometryCache::buildShapes() {
     extrudePolygon<64>(_shapes[Cylinder], _shapeVertices, _shapeIndices);
     //Cone,
     extrudePolygon<64>(_shapes[Cone], _shapeVertices, _shapeIndices, true);
-    //Circle
-    drawCircle(_shapes[Circle], _shapeVertices, _shapeIndices);
+    // Circle renders as flat Cylinder
+    extrudePolygon<64>(_shapes[Circle], _shapeVertices, _shapeIndices);
     // Not implemented yet:
-    //Quad,
-    //Torus, 
- 
+    //Torus,
 }
 
 const GeometryCache::ShapeData * GeometryCache::getShapeData(const Shape shape) const {

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -59,6 +59,7 @@
                         <option value="Cylinder">Cylinder</option>
                         <option value="Cone">Cone</option>
                         <option value="Circle">Circle</option>
+                        <option value="Quad">Quad</option>
                     </select>
             </div>
             <div class="property text">


### PR DESCRIPTION
- enforce flatness of `Circle` and `Quad` varieties of `ShapeEntityItem`
- fix collision shapes of `Circle` and `Quad`
- fix rendering of `Circle` and `Quad`
- add `Quad` as fully supported option to `ShapeEntityItem` properties UI
