### PR TITLE
More Louder #1

### DIFF
--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -21,7 +21,7 @@ static const int HRTF_TABLES = 25;      // number of HRTF subjects
 static const int HRTF_DELAY = 24;       // max ITD in samples (1.0ms at 24KHz)
 static const int HRTF_BLOCK = 240;      // block processing size
 
-static const float HRTF_GAIN = 1.0f;    // HRTF global gain adjustment
+static const float HRTF_GAIN = 2.0f;    // HRTF global gain adjustment = +6dB
 
 class AudioHRTF {
 


### PR DESCRIPTION

This PR increases the global HRTF gain by +6dB. This has two consequences:
1) Before, a spatialized source was approximately the same loudness as a non-spatialized (stereo, non-diegetic) source, up to the onset of distance attenuation (<= 1 meter). After, a nearby spatialized source will be 6dB louder than a non-spatialized source. So the relative mix levels have changed.
2) The peak HRTF gain is now +12dB instead of +6dB (see graph below), so a nearby avatar talking at full scale may result in more dynamic-range compression. Multiple loud nearby sources will hit the limiter harder, with gain reductions of -10dB or more.

![ipsilateral_hrtf](https://user-images.githubusercontent.com/13965157/32129110-c6a66df2-bb38-11e7-8e57-09a31973418c.png)
