### PR TITLE
More Louder #2

### DIFF
--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -523,7 +523,7 @@ float computeGain(const AvatarAudioStream& listeningNodeStream, const Positional
     }
 
     // distance attenuation
-    const float ATTENUATION_START_DISTANCE = 1.0f;
+    const float ATTENUATION_START_DISTANCE = 2.0f;
     float distance = glm::length(relativePosition);
     assert(ATTENUATION_START_DISTANCE > EPSILON);
     if (distance >= ATTENUATION_START_DISTANCE) {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1815,7 +1815,7 @@ float AudioClient::azimuthForSource(const glm::vec3& relativePosition) {
 
 float AudioClient::gainForSource(float distance, float volume) {
 
-    const float ATTENUATION_BEGINS_AT_DISTANCE = 1.0f;
+    const float ATTENUATION_BEGINS_AT_DISTANCE = 2.0f;
 
     // I'm assuming that the AudioMixer's getting of the stream's attenuation
     // factor is basically same as getting volume


### PR DESCRIPTION
This PR changes the distance-attenuation curve for spatialized sounds. Spatialized sources will be unattenuated for the first 2m distance instead of 1m. This has the side-effect that far sounds will be +6dB louder.