### PR TITLE
Haze mask fix

### DIFF
--- a/libraries/render-utils/src/DrawHaze.cpp
+++ b/libraries/render-utils/src/DrawHaze.cpp
@@ -140,7 +140,7 @@ void DrawHaze::run(const render::RenderContextPointer& renderContext, const Inpu
         gpu::StatePointer state = gpu::StatePointer(new gpu::State());
 
         // Mask out haze on the tablet
-        PrepareStencil::testNoAA(*state);
+        PrepareStencil::testMaskNoAA(*state);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("hazeBuffer"), HazeEffect_ParamsSlot));

--- a/libraries/render-utils/src/DrawHaze.cpp
+++ b/libraries/render-utils/src/DrawHaze.cpp
@@ -140,7 +140,7 @@ void DrawHaze::run(const render::RenderContextPointer& renderContext, const Inpu
         gpu::StatePointer state = gpu::StatePointer(new gpu::State());
 
         // Mask out haze on the tablet
-        PrepareStencil::testMaskNoAA(*state);
+        PrepareStencil::testMask(*state);
 
         gpu::Shader::BindingSet slotBindings;
         slotBindings.insert(gpu::Shader::Binding(std::string("hazeBuffer"), HazeEffect_ParamsSlot));

--- a/libraries/render-utils/src/StencilMaskPass.cpp
+++ b/libraries/render-utils/src/StencilMaskPass.cpp
@@ -128,6 +128,11 @@ void PrepareStencil::testNoAA(gpu::State& state) {
         gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
+void PrepareStencil::testMaskNoAA(gpu::State& state) {
+    state.setStencilTest(true, 0x00, gpu::State::StencilTest(0, STENCIL_MASK | STENCIL_NO_AA, gpu::EQUAL,
+        gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
+}
+
 // Pass if this area WAS marked as BACKGROUND
 // (see: model/src/Skybox.cpp, procedural/src/ProceduralSkybox.cpp)
 void PrepareStencil::testBackground(gpu::State& state) {

--- a/libraries/render-utils/src/StencilMaskPass.cpp
+++ b/libraries/render-utils/src/StencilMaskPass.cpp
@@ -128,6 +128,7 @@ void PrepareStencil::testNoAA(gpu::State& state) {
         gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
+// Pass if this area has been marked as MASK or NO_AA
 void PrepareStencil::testMaskNoAA(gpu::State& state) {
     state.setStencilTest(true, 0x00, gpu::State::StencilTest(0, STENCIL_MASK | STENCIL_NO_AA, gpu::EQUAL,
         gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));

--- a/libraries/render-utils/src/StencilMaskPass.cpp
+++ b/libraries/render-utils/src/StencilMaskPass.cpp
@@ -116,21 +116,15 @@ void PrepareStencil::drawBackground(gpu::State& state) {
         gpu::State::STENCIL_OP_REPLACE, gpu::State::STENCIL_OP_REPLACE, gpu::State::STENCIL_OP_KEEP));
 }
 
-// Pass if this area has NOT been marked as MASK
+// Pass if this area has NOT been marked as MASK or anything containing MASK
 void PrepareStencil::testMask(gpu::State& state) {
-    state.setStencilTest(true, 0x00, gpu::State::StencilTest(STENCIL_MASK, 0xFF, gpu::NOT_EQUAL,
+    state.setStencilTest(true, 0x00, gpu::State::StencilTest(STENCIL_MASK, STENCIL_MASK, gpu::NOT_EQUAL,
         gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 
 // Pass if this area has NOT been marked as NO_AA or anything containing NO_AA
 void PrepareStencil::testNoAA(gpu::State& state) {
     state.setStencilTest(true, 0x00, gpu::State::StencilTest(STENCIL_NO_AA, STENCIL_NO_AA, gpu::NOT_EQUAL,
-        gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
-}
-
-// Pass if this area has been marked as MASK or NO_AA
-void PrepareStencil::testMaskNoAA(gpu::State& state) {
-    state.setStencilTest(true, 0x00, gpu::State::StencilTest(0, STENCIL_MASK | STENCIL_NO_AA, gpu::EQUAL,
         gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
 }
 

--- a/libraries/render-utils/src/StencilMaskPass.h
+++ b/libraries/render-utils/src/StencilMaskPass.h
@@ -49,8 +49,9 @@ public:
 
     static void drawMask(gpu::State& state);
     static void drawBackground(gpu::State& state);
-    static void testNoAA(gpu::State& state);
     static void testMask(gpu::State& state);
+    static void testNoAA(gpu::State& state);
+    static void testMaskNoAA(gpu::State& state);
     static void testBackground(gpu::State& state);
     static void testShape(gpu::State& state);
     static void testMaskDrawShape(gpu::State& state);

--- a/libraries/render-utils/src/StencilMaskPass.h
+++ b/libraries/render-utils/src/StencilMaskPass.h
@@ -51,7 +51,6 @@ public:
     static void drawBackground(gpu::State& state);
     static void testMask(gpu::State& state);
     static void testNoAA(gpu::State& state);
-    static void testMaskNoAA(gpu::State& state);
     static void testBackground(gpu::State& state);
     static void testShape(gpu::State& state);
     static void testMaskDrawShape(gpu::State& state);


### PR DESCRIPTION
Replaces the stencil mask used when the haze effect has been enabled.  The previous masked caused a problem when looking at the black mask in the preview, or in the HMD when looking to the side.

## TEST PLAN
1) Menu->Display->Oculus Rift to checked
2) Menu->Display->Disable Preview to unchecked
3) Menu->Display->Mono Preview to unchecked
4) Verify mask around both images is black
5) Menu->Display->Desktop to checked
6) Activate Haze
7)) Menu->Display->Oculus Rift to checked 
8) Verify mask around both images is still black
