### PR TITLE
scaleToFit() the model before updating render items

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -215,6 +215,7 @@ void RenderableModelEntityItem::updateModelBounds() {
         model->setScaleToFit(true, getDimensions());
         model->setSnapModelToRegistrationPoint(true, getRegistrationPoint());
         updateRenderItems = true;
+        model->scaleToFit();
     }
 
     bool success;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -262,6 +262,8 @@ public:
 
     Q_INVOKABLE MeshProxyList getMeshes() const;
 
+    void scaleToFit();
+
 public slots:
     void loadURLFinished(bool success);
 
@@ -320,7 +322,6 @@ protected:
     virtual void initJointStates();
 
     void setScaleInternal(const glm::vec3& scale);
-    void scaleToFit();
     void snapToRegistrationPoint();
 
     void computeMeshPartLocalBounds();


### PR DESCRIPTION
- fix bug causing ModelEntityItem to not update its scale in a timely fashion