### PR TITLE
Fix finding the SSL binary path

### DIFF
--- a/cmake/modules/FindOpenSSL.cmake
+++ b/cmake/modules/FindOpenSSL.cmake
@@ -60,7 +60,7 @@ if (WIN32 AND NOT CYGWIN)
     select_library_configurations(LIB_EAY)
     select_library_configurations(SSL_EAY)
     set(OPENSSL_LIBRARIES ${SSL_EAY_LIBRARY} ${LIB_EAY_LIBRARY})
-    find_path(OPENSSL_DLL_PATH NAMES ssleay32.dll PATH_SUFFIXES "bin" ${_OPENSSL_ROOT_HINTS_AND_PATHS})
+    find_path(OPENSSL_DLL_PATH NAMES ssleay32.dll PATH_SUFFIXES "bin" HINTS ${_OPENSSL_ROOT_HINTS_AND_PATHS} NO_DEFAULT_PATH)
   endif()
 else()
 


### PR DESCRIPTION
## Testing

* Install the PR.  
* If you do not already have dependency walker, install it from [here](http://www.dependencywalker.com/depends22_x64.zip)
* Open Dependency Walker
* In Dependency Walker, open the PR installation folder and select the ssleay32.dll
* Wait for it to load up the dependency tree.  Click through any warnings.  
* Hit Ctrl-W to collapse the tree, then re-expand the top level.
* Look down the tree, and locate either `MSVCR120.DLL` or `VCRUNTIME140.DLL`

If the installation depends on `VCRUNTIME140.DLL` then it's a pass.  If it depends on `MSVCR120.DLL` or includes any other VC Runtime DLLs that aren't labeled as 140, then it's a fail.  
