### PR TITLE
Reset Wallet passphrase when login username changes

### DIFF
--- a/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
+++ b/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
@@ -86,7 +86,7 @@ Rectangle {
                 root.dateOfPurchase = "";
                 root.itemEdition = "Uncertified Copy";
 
-                errorText.text = "The certificate associated with this entity is invalid.";
+                errorText.text = "The information associated with this item has been modified and it no longer matches the original certified item.";
                 errorText.color = hifi.colors.baseGray;
             } else if (certStatus === 4) { // CERTIFICATE_STATUS_OWNER_VERIFICATION_FAILED
                 root.isCertificateInvalid = true;
@@ -99,7 +99,7 @@ Rectangle {
                 root.dateOfPurchase = "";
                 root.itemEdition = "Uncertified Copy";
 
-                errorText.text = "The certificate associated with this entity is invalid.";
+                errorText.text = "The avatar who rezzed this item doesn't own it.";
                 errorText.color = hifi.colors.baseGray;
             } else {
                 console.log("Unknown certificate status received from ledger signal!");

--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -31,6 +31,11 @@ QmlCommerce::QmlCommerce(QQuickItem* parent) : OffscreenQmlDialog(parent) {
     connect(wallet.data(), &Wallet::walletStatusResult, this, &QmlCommerce::walletStatusResult);
     connect(ledger.data(), &Ledger::certificateInfoResult, this, &QmlCommerce::certificateInfoResult);
     connect(ledger.data(), &Ledger::updateCertificateStatus, this, &QmlCommerce::updateCertificateStatus);
+    
+    auto accountManager = DependencyManager::get<AccountManager>();
+    connect(accountManager.data(), &AccountManager::usernameChanged, [&]() {
+        setPassphrase("");
+    });
 }
 
 void QmlCommerce::getWalletStatus() {


### PR DESCRIPTION
This 5-line changes fixes two bugs:
1. A visual glitch during wallet setup in a specific case
2. Newly-setup wallets were receiving money at the incorrect wallet in a specific case

# Test Plan
You'll need two High Fidelity accounts without wallets associated with them to continue. You'll also need Commerce enabled.

1. Log in to Account A.
2. Set up your wallet. Verify that you have 100 HFC when wallet setup is complete.
3. Buy a Test Beach Ball from the Marketplace. Verify that your balance is no longer 100 HFC.
4. Close the wallet.
5. Logout of Account A. Login to Account B.
6. Set up your wallet. Verify that the wallet setup process looks normal (i.e. no visual glitches or two pages overlaid on top of each other). Also verify that you have 100 HFC when wallet setup completes.
7. Logout of Account B. Verify that the Wallet app tells you to log in.
8. Press the LOGIN button on the Wallet app and log in to Account A again.
9. Open the wallet and verify that you have less than 100 HFC.