### PR TITLE
Fix avatar attachment tearing

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -730,8 +730,9 @@ void Avatar::simulateAttachments(float deltaTime) {
             // soft attachments do not have transform offsets
         //    model->setTranslation(getPosition());
         //    model->setRotation(getOrientation() * Quaternions::Y_180);
-            model->setTransformNoUpdateRenderItems(Transform(getOrientation() * Quaternions::Y_180, glm::vec3(1.0), getPosition());
+            model->setTransformNoUpdateRenderItems(Transform(getOrientation() * Quaternions::Y_180, glm::vec3(1.0), getPosition()));
             model->simulate(deltaTime);
+            model->updateRenderItems();
         } else {
             if (_skeletonModel->getJointPositionInWorldFrame(jointIndex, jointPosition) &&
                 _skeletonModel->getJointRotationInWorldFrame(jointIndex, jointRotation)) {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -728,21 +728,19 @@ void Avatar::simulateAttachments(float deltaTime) {
         glm::quat jointRotation;
         if (attachment.isSoft) {
             // soft attachments do not have transform offsets
-        //    model->setTranslation(getPosition());
-        //    model->setRotation(getOrientation() * Quaternions::Y_180);
             model->setTransformNoUpdateRenderItems(Transform(getOrientation() * Quaternions::Y_180, glm::vec3(1.0), getPosition()));
             model->simulate(deltaTime);
             model->updateRenderItems();
         } else {
             if (_skeletonModel->getJointPositionInWorldFrame(jointIndex, jointPosition) &&
                 _skeletonModel->getJointRotationInWorldFrame(jointIndex, jointRotation)) {
-                model->setTranslation(jointPosition + jointRotation * attachment.translation * getModelScale());
-                model->setRotation(jointRotation * attachment.rotation);
+                model->setTransformNoUpdateRenderItems(Transform(jointRotation * attachment.rotation, glm::vec3(1.0), jointPosition + jointRotation * attachment.translation * getModelScale()));
                 float scale = getModelScale() * attachment.scale;
                 model->setScaleToFit(true, model->getNaturalDimensions() * scale, true); // hack to force rescale
                 model->setSnapModelToCenter(false); // hack to force resnap
                 model->setSnapModelToCenter(true);
                 model->simulate(deltaTime);
+                model->updateRenderItems();
             }
         }
     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -728,8 +728,9 @@ void Avatar::simulateAttachments(float deltaTime) {
         glm::quat jointRotation;
         if (attachment.isSoft) {
             // soft attachments do not have transform offsets
-            model->setTranslation(getPosition());
-            model->setRotation(getOrientation() * Quaternions::Y_180);
+        //    model->setTranslation(getPosition());
+        //    model->setRotation(getOrientation() * Quaternions::Y_180);
+            model->setTransformNoUpdateRenderItems(Transform(getOrientation() * Quaternions::Y_180, glm::vec3(1.0), getPosition());
             model->simulate(deltaTime);
         } else {
             if (_skeletonModel->getJointPositionInWorldFrame(jointIndex, jointPosition) &&

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
@@ -20,11 +20,36 @@ using namespace render;
 CauterizedMeshPartPayload::CauterizedMeshPartPayload(ModelPointer model, int meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform)
     : ModelMeshPartPayload(model, meshIndex, partIndex, shapeIndex, transform, offsetTransform) {}
 
+void CauterizedMeshPartPayload::updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices, const QVector<glm::mat4>& cauterizedClusterMatrices) {
+
+    // Once computed the cluster matrices, update the buffer(s)
+    if (clusterMatrices.size() > 1) {
+        if (!_clusterBuffer) {
+            _clusterBuffer = std::make_shared<gpu::Buffer>(clusterMatrices.size() * sizeof(glm::mat4),
+            (const gpu::Byte*) clusterMatrices.constData());
+        } else {
+            _clusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
+            (const gpu::Byte*) clusterMatrices.constData());
+        }
+    }
+
+    if (cauterizedClusterMatrices.size() > 1) {
+        if (!_cauterizedClusterBuffer) {
+            _cauterizedClusterBuffer = std::make_shared<gpu::Buffer>(cauterizedClusterMatrices.size() * sizeof(glm::mat4),
+                (const gpu::Byte*) cauterizedClusterMatrices.constData());
+        }
+        else {
+            _cauterizedClusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
+                (const gpu::Byte*) clusterMatrices.constData());
+        }
+    }
+}
+
 void CauterizedMeshPartPayload::updateTransformForCauterizedMesh(
         const Transform& renderTransform,
         const gpu::BufferPointer& buffer) {
     _cauterizedTransform = renderTransform;
-    _cauterizedClusterBuffer = buffer;
+  //  _cauterizedClusterBuffer = buffer;
 }
 
 void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const {

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
@@ -39,8 +39,8 @@ void CauterizedMeshPartPayload::updateClusterBuffer(const std::vector<glm::mat4>
                 (const gpu::Byte*) cauterizedClusterMatrices.data());
         }
         else {
-            _cauterizedClusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
-                (const gpu::Byte*) clusterMatrices.data());
+            _cauterizedClusterBuffer->setSubData(0, cauterizedClusterMatrices.size() * sizeof(glm::mat4),
+                (const gpu::Byte*) cauterizedClusterMatrices.data());
         }
     }
 }

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
@@ -37,8 +37,7 @@ void CauterizedMeshPartPayload::updateClusterBuffer(const std::vector<glm::mat4>
         if (!_cauterizedClusterBuffer) {
             _cauterizedClusterBuffer = std::make_shared<gpu::Buffer>(cauterizedClusterMatrices.size() * sizeof(glm::mat4),
                 (const gpu::Byte*) cauterizedClusterMatrices.data());
-        }
-        else {
+        } else {
             _cauterizedClusterBuffer->setSubData(0, cauterizedClusterMatrices.size() * sizeof(glm::mat4),
                 (const gpu::Byte*) cauterizedClusterMatrices.data());
         }

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
@@ -21,17 +21,7 @@ CauterizedMeshPartPayload::CauterizedMeshPartPayload(ModelPointer model, int mes
     : ModelMeshPartPayload(model, meshIndex, partIndex, shapeIndex, transform, offsetTransform) {}
 
 void CauterizedMeshPartPayload::updateClusterBuffer(const std::vector<glm::mat4>& clusterMatrices, const std::vector<glm::mat4>& cauterizedClusterMatrices) {
-
-    // Once computed the cluster matrices, update the buffer(s)
-    if (clusterMatrices.size() > 1) {
-        if (!_clusterBuffer) {
-            _clusterBuffer = std::make_shared<gpu::Buffer>(clusterMatrices.size() * sizeof(glm::mat4),
-            (const gpu::Byte*) clusterMatrices.data());
-        } else {
-            _clusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
-            (const gpu::Byte*) clusterMatrices.data());
-        }
-    }
+    ModelMeshPartPayload::updateClusterBuffer(clusterMatrices);
 
     if (cauterizedClusterMatrices.size() > 1) {
         if (!_cauterizedClusterBuffer) {

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
@@ -20,36 +20,33 @@ using namespace render;
 CauterizedMeshPartPayload::CauterizedMeshPartPayload(ModelPointer model, int meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform)
     : ModelMeshPartPayload(model, meshIndex, partIndex, shapeIndex, transform, offsetTransform) {}
 
-void CauterizedMeshPartPayload::updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices, const QVector<glm::mat4>& cauterizedClusterMatrices) {
+void CauterizedMeshPartPayload::updateClusterBuffer(const std::vector<glm::mat4>& clusterMatrices, const std::vector<glm::mat4>& cauterizedClusterMatrices) {
 
     // Once computed the cluster matrices, update the buffer(s)
     if (clusterMatrices.size() > 1) {
         if (!_clusterBuffer) {
             _clusterBuffer = std::make_shared<gpu::Buffer>(clusterMatrices.size() * sizeof(glm::mat4),
-            (const gpu::Byte*) clusterMatrices.constData());
+            (const gpu::Byte*) clusterMatrices.data());
         } else {
             _clusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
-            (const gpu::Byte*) clusterMatrices.constData());
+            (const gpu::Byte*) clusterMatrices.data());
         }
     }
 
     if (cauterizedClusterMatrices.size() > 1) {
         if (!_cauterizedClusterBuffer) {
             _cauterizedClusterBuffer = std::make_shared<gpu::Buffer>(cauterizedClusterMatrices.size() * sizeof(glm::mat4),
-                (const gpu::Byte*) cauterizedClusterMatrices.constData());
+                (const gpu::Byte*) cauterizedClusterMatrices.data());
         }
         else {
             _cauterizedClusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
-                (const gpu::Byte*) clusterMatrices.constData());
+                (const gpu::Byte*) clusterMatrices.data());
         }
     }
 }
 
-void CauterizedMeshPartPayload::updateTransformForCauterizedMesh(
-        const Transform& renderTransform,
-        const gpu::BufferPointer& buffer) {
+void CauterizedMeshPartPayload::updateTransformForCauterizedMesh(const Transform& renderTransform) {
     _cauterizedTransform = renderTransform;
-  //  _cauterizedClusterBuffer = buffer;
 }
 
 void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const {

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.h
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.h
@@ -15,9 +15,9 @@ class CauterizedMeshPartPayload : public ModelMeshPartPayload {
 public:
     CauterizedMeshPartPayload(ModelPointer model, int meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform);
 
-    void updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices, const QVector<glm::mat4>& cauterizedClusterMatrices);
+    void updateClusterBuffer(const std::vector<glm::mat4>& clusterMatrices, const std::vector<glm::mat4>& cauterizedClusterMatrices);
 
-    void updateTransformForCauterizedMesh(const Transform& renderTransform, const gpu::BufferPointer& buffer);
+    void updateTransformForCauterizedMesh(const Transform& renderTransform);
 
     void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const override;
 

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.h
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.h
@@ -15,6 +15,8 @@ class CauterizedMeshPartPayload : public ModelMeshPartPayload {
 public:
     CauterizedMeshPartPayload(ModelPointer model, int meshIndex, int partIndex, int shapeIndex, const Transform& transform, const Transform& offsetTransform);
 
+    void updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices, const QVector<glm::mat4>& cauterizedClusterMatrices);
+
     void updateTransformForCauterizedMesh(const Transform& renderTransform, const gpu::BufferPointer& buffer);
 
     void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const override;

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -112,19 +112,6 @@ void CauterizedModel::updateClusterMatrices() {
             auto jointMatrix = _rig.getJointTransform(cluster.jointIndex);
             glm_mat4u_mul(jointMatrix, cluster.inverseBindMatrix, state.clusterMatrices[j]);
         }
-
-        /*
-        // Once computed the cluster matrices, update the buffer(s)
-        if (mesh.clusters.size() > 1) {
-            if (!state.clusterBuffer) {
-                state.clusterBuffer = std::make_shared<gpu::Buffer>(state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                                    (const gpu::Byte*) state.clusterMatrices.constData());
-            } else {
-                state.clusterBuffer->setSubData(0, state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                (const gpu::Byte*) state.clusterMatrices.constData());
-            }
-        }
-        */
     }
 
     // as an optimization, don't build cautrizedClusterMatrices if the boneSet is empty.
@@ -147,17 +134,6 @@ void CauterizedModel::updateClusterMatrices() {
                 }
                 glm_mat4u_mul(jointMatrix, cluster.inverseBindMatrix, state.clusterMatrices[j]);
             }
-/*
-            if (!_cauterizeBoneSet.empty() && (state.clusterMatrices.size() > 1)) {
-                if (!state.clusterBuffer) {
-                    state.clusterBuffer =
-                        std::make_shared<gpu::Buffer>(state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                      (const gpu::Byte*) state.clusterMatrices.constData());
-                } else {
-                    state.clusterBuffer->setSubData(0, state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                              (const gpu::Byte*) state.clusterMatrices.constData());
-                }
-            }*/
         }
     }
 
@@ -202,9 +178,6 @@ void CauterizedModel::updateRenderItems() {
             modelTransform.setTranslation(self->getTranslation());
             modelTransform.setRotation(self->getRotation());
 
-       /*     if (!self->isLoaded()) {
-                return;
-            }*/
             render::Transaction transaction;
             QList<render::ItemID> keys = self->getRenderItems().keys();
             int meshIndex{ 0 };
@@ -225,13 +198,13 @@ void CauterizedModel::updateRenderItems() {
                         if (clusterMatrices.size() == 1) {
                             renderTransform = modelTransform.worldTransform(Transform(clusterMatrices[0]));
                         }
-                        data.updateTransformForSkinnedMesh(renderTransform, modelTransform, nullptr);
+                        data.updateTransformForSkinnedMesh(renderTransform, modelTransform);
 
                         renderTransform = modelTransform;
                         if (clusterMatricesCauterized.size() == 1) {
                             renderTransform = modelTransform.worldTransform(Transform(clusterMatricesCauterized[0]));
                         }
-                        data.updateTransformForCauterizedMesh(renderTransform, nullptr);
+                        data.updateTransformForCauterizedMesh(renderTransform);
                 });
             }
 

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -211,7 +211,8 @@ void CauterizedModel::updateRenderItems() {
             render::Transaction transaction;
             QList<render::ItemID> keys = self->getRenderItems().keys();
             int meshIndex{ 0 };
-            foreach (auto itemID, keys) {
+            //foreach (auto itemID, keys) {
+            for (auto itemID : self->_modelMeshRenderItemIDs) {
                 const Model::MeshState& state = self->getMeshState(meshIndex);
                 auto clusterMatrices(state.clusterMatrices);
                 const Model::MeshState& cState = self->getCauterizeMeshState(meshIndex);

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -48,7 +48,7 @@ void CauterizedModel::createVisibleRenderItemSet() {
         const auto& meshes = _renderGeometry->getMeshes();
 
         // all of our mesh vectors must match in size
-        if ((int)meshes.size() != _meshStates.size()) {
+        if (meshes.size() != _meshStates.size()) {
             qCDebug(renderutils) << "WARNING!!!! Mesh Sizes don't match! We will not segregate mesh groups yet.";
             return;
         }
@@ -104,7 +104,7 @@ void CauterizedModel::updateClusterMatrices() {
     _needsUpdateClusterMatrices = false;
     const FBXGeometry& geometry = getFBXGeometry();
 
-    for (int i = 0; i < _meshStates.size(); i++) {
+    for (int i = 0; i < (int)_meshStates.size(); i++) {
         Model::MeshState& state = _meshStates[i];
         const FBXMesh& mesh = geometry.meshes.at(i);
         for (int j = 0; j < mesh.clusters.size(); j++) {
@@ -179,7 +179,7 @@ void CauterizedModel::updateRenderItems() {
             modelTransform.setRotation(self->getRotation());
 
             render::Transaction transaction;
-            for (int i = 0; i < self->_modelMeshRenderItemIDs.size(); i++) {
+            for (int i = 0; i < (int)self->_modelMeshRenderItemIDs.size(); i++) {
 
                 auto itemID = self->_modelMeshRenderItemIDs[i];
                 auto meshIndex = self->_modelMeshRenderItemShapes[i].meshIndex;

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -57,6 +57,7 @@ void CauterizedModel::createVisibleRenderItemSet() {
         Q_ASSERT(_modelMeshRenderItems.isEmpty());
 
         _modelMeshRenderItems.clear();
+        _modelMeshRenderItemShapes.clear();
 
         Transform transform;
         transform.setTranslation(_translation);
@@ -80,6 +81,7 @@ void CauterizedModel::createVisibleRenderItemSet() {
             for (int partIndex = 0; partIndex < numParts; partIndex++) {
                 auto ptr = std::make_shared<CauterizedMeshPartPayload>(shared_from_this(), i, partIndex, shapeID, transform, offset);
                 _modelMeshRenderItems << std::static_pointer_cast<ModelMeshPartPayload>(ptr);
+                _modelMeshRenderItemShapes.emplace_back(ShapeInfo{ (int)i });
                 shapeID++;
             }
         }
@@ -212,7 +214,11 @@ void CauterizedModel::updateRenderItems() {
             QList<render::ItemID> keys = self->getRenderItems().keys();
             int meshIndex{ 0 };
             //foreach (auto itemID, keys) {
-            for (auto itemID : self->_modelMeshRenderItemIDs) {
+          //  for (auto itemID : self->_modelMeshRenderItemIDs) {
+            for (int i = 0; i < self->_modelMeshRenderItemIDs.size(); i++) {
+                auto itemID = self->_modelMeshRenderItemIDs[i];
+                auto meshIndex = self->_modelMeshRenderItemShapes[i].meshIndex;
+
                 const Model::MeshState& state = self->getMeshState(meshIndex);
                 auto clusterMatrices(state.clusterMatrices);
                 const Model::MeshState& cState = self->getCauterizeMeshState(meshIndex);

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -367,12 +367,27 @@ void ModelMeshPartPayload::notifyLocationChanged() {
 
 }
 
+
+void ModelMeshPartPayload::updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices) {
+    // Once computed the cluster matrices, update the buffer(s)
+    if (clusterMatrices.size() > 1) {
+        if (!_clusterBuffer) {
+            _clusterBuffer = std::make_shared<gpu::Buffer>(clusterMatrices.size() * sizeof(glm::mat4),
+                (const gpu::Byte*) clusterMatrices.constData());
+        }
+        else {
+            _clusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
+                (const gpu::Byte*) clusterMatrices.constData());
+        }
+    }
+}
+
 void ModelMeshPartPayload::updateTransformForSkinnedMesh(const Transform& renderTransform, const Transform& boundTransform,
         const gpu::BufferPointer& buffer) {
     _transform = renderTransform;
     _worldBound = _adjustedLocalBound;
     _worldBound.transform(boundTransform);
-    _clusterBuffer = buffer;
+ //   _clusterBuffer = buffer;
 }
 
 ItemKey ModelMeshPartPayload::getKey() const {

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -337,7 +337,7 @@ ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, in
     if (state.clusterMatrices.size() == 1) {
         renderTransform = transform.worldTransform(Transform(state.clusterMatrices[0]));
     }
-    updateTransformForSkinnedMesh(renderTransform, transform, state.clusterBuffer);
+    updateTransformForSkinnedMesh(renderTransform, transform);
 
     initCache();
 }
@@ -368,26 +368,24 @@ void ModelMeshPartPayload::notifyLocationChanged() {
 }
 
 
-void ModelMeshPartPayload::updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices) {
+void ModelMeshPartPayload::updateClusterBuffer(const std::vector<glm::mat4>& clusterMatrices) {
     // Once computed the cluster matrices, update the buffer(s)
     if (clusterMatrices.size() > 1) {
         if (!_clusterBuffer) {
             _clusterBuffer = std::make_shared<gpu::Buffer>(clusterMatrices.size() * sizeof(glm::mat4),
-                (const gpu::Byte*) clusterMatrices.constData());
+                (const gpu::Byte*) clusterMatrices.data());
         }
         else {
             _clusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
-                (const gpu::Byte*) clusterMatrices.constData());
+                (const gpu::Byte*) clusterMatrices.data());
         }
     }
 }
 
-void ModelMeshPartPayload::updateTransformForSkinnedMesh(const Transform& renderTransform, const Transform& boundTransform,
-        const gpu::BufferPointer& buffer) {
+void ModelMeshPartPayload::updateTransformForSkinnedMesh(const Transform& renderTransform, const Transform& boundTransform) {
     _transform = renderTransform;
     _worldBound = _adjustedLocalBound;
     _worldBound.transform(boundTransform);
- //   _clusterBuffer = buffer;
 }
 
 ItemKey ModelMeshPartPayload::getKey() const {
@@ -431,7 +429,6 @@ int ModelMeshPartPayload::getLayer() const {
 }
 
 ShapeKey ModelMeshPartPayload::getShapeKey() const {
-
     // guard against partially loaded meshes
     ModelPointer model = _model.lock();
     if (!model || !model->isLoaded() || !model->getGeometry()) {
@@ -597,7 +594,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
     args->_details._trianglesRendered += _drawPart._numIndices / INDICES_PER_TRIANGLE;
 }
 
-void ModelMeshPartPayload::computeAdjustedLocalBound(const QVector<glm::mat4>& clusterMatrices) {
+void ModelMeshPartPayload::computeAdjustedLocalBound(const std::vector<glm::mat4>& clusterMatrices) {
     _adjustedLocalBound = _localBound;
     if (clusterMatrices.size() > 0) {
         _adjustedLocalBound.transform(clusterMatrices[0]);

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -598,7 +598,7 @@ void ModelMeshPartPayload::computeAdjustedLocalBound(const std::vector<glm::mat4
     _adjustedLocalBound = _localBound;
     if (clusterMatrices.size() > 0) {
         _adjustedLocalBound.transform(clusterMatrices[0]);
-        for (int i = 1; i < clusterMatrices.size(); ++i) {
+        for (int i = 1; i < (int)clusterMatrices.size(); ++i) {
             AABox clusterBound = _localBound;
             clusterBound.transform(clusterMatrices[i]);
             _adjustedLocalBound += clusterBound;

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -87,6 +87,7 @@ public:
     typedef Payload::DataPointer Pointer;
 
     void notifyLocationChanged() override;
+    void updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices);
     void updateTransformForSkinnedMesh(const Transform& renderTransform,
             const Transform& boundTransform,
             const gpu::BufferPointer& buffer);

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -87,10 +87,8 @@ public:
     typedef Payload::DataPointer Pointer;
 
     void notifyLocationChanged() override;
-    void updateClusterBuffer(const QVector<glm::mat4>& clusterMatrices);
-    void updateTransformForSkinnedMesh(const Transform& renderTransform,
-            const Transform& boundTransform,
-            const gpu::BufferPointer& buffer);
+    void updateClusterBuffer(const std::vector<glm::mat4>& clusterMatrices);
+    void updateTransformForSkinnedMesh(const Transform& renderTransform, const Transform& boundTransform);
 
     // Render Item interface
     render::ItemKey getKey() const override;
@@ -104,7 +102,7 @@ public:
 
     void initCache();
 
-    void computeAdjustedLocalBound(const QVector<glm::mat4>& clusterMatrices);
+    void computeAdjustedLocalBound(const std::vector<glm::mat4>& clusterMatrices);
 
     gpu::BufferPointer _clusterBuffer;
     ModelWeakPointer _model;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -241,31 +241,14 @@ void Model::updateRenderItems() {
         uint32_t deleteGeometryCounter = self->_deleteGeometryCounter;
 
         render::Transaction transaction;
-      //  foreach (auto itemID, self->_modelMeshRenderItemsMap.keys()) {
-      //  for (auto itemID : self->_modelMeshRenderItemIDs) {
         for (int i = 0; i < self->_modelMeshRenderItemIDs.size(); i++) {
             auto itemID = self->_modelMeshRenderItemIDs[i];
             auto meshIndex = self->_modelMeshRenderItemShapes[i].meshIndex;
             if (self && self->isLoaded()) {
-                //int meshIndex = std::dynamic_pointer_cast<ModelMeshPartPayload>(self->_modelMeshRenderItemsMap[itemID])->_meshIndex;
-             //   int meshIndex = std::dynamic_pointer_cast<ModelMeshPartPayload>(self->_modelMeshRenderItemsMap[itemID])->_meshIndex;
                 const Model::MeshState& state = self->getMeshState(meshIndex);
                 auto clusterMatrices(state.clusterMatrices);
 
                 transaction.updateItem<ModelMeshPartPayload>(itemID, [deleteGeometryCounter, modelTransform, clusterMatrices](ModelMeshPartPayload& data) {
-                    //  ModelPointer model = data._model.lock();
-                   //   if (model && model->isLoaded()) {
-                          // Ensure the model geometry was not reset between frames
-                     //     if (deleteGeometryCounter == model->_deleteGeometryCounter) {
-
-                              /*const Model::MeshState& state = model->getMeshState(data._meshIndex);
-                              Transform renderTransform = modelTransform;
-                              if (state.clusterMatrices.size() == 1) {
-                                  renderTransform = modelTransform.worldTransform(Transform(state.clusterMatrices[0]));
-                              }
-                              data.updateTransformForSkinnedMesh(renderTransform, modelTransform, state.clusterBuffer);
-                              */
-
                     data.updateClusterBuffer(clusterMatrices);
 
                     Transform renderTransform = modelTransform;
@@ -273,9 +256,6 @@ void Model::updateRenderItems() {
                         renderTransform = modelTransform.worldTransform(Transform(clusterMatrices[0]));
                     }
                     data.updateTransformForSkinnedMesh(renderTransform, modelTransform, nullptr);
-
-                    //  }
-                 // }
                 });
             }
         }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -255,7 +255,7 @@ void Model::updateRenderItems() {
                     if (clusterMatrices.size() == 1) {
                         renderTransform = modelTransform.worldTransform(Transform(clusterMatrices[0]));
                     }
-                    data.updateTransformForSkinnedMesh(renderTransform, modelTransform, nullptr);
+                    data.updateTransformForSkinnedMesh(renderTransform, modelTransform);
                 });
             }
         }
@@ -313,7 +313,7 @@ bool Model::updateGeometry() {
         foreach (const FBXMesh& mesh, fbxGeometry.meshes) {
             MeshState state;
             state.clusterMatrices.resize(mesh.clusters.size());
-            _meshStates.append(state);
+            _meshStates.push_back(state);
 
             // Note: we add empty buffers for meshes that lack blendshapes so we can access the buffers by index
             // later in ModelMeshPayload, however the vast majority of meshes will not have them.
@@ -1138,17 +1138,6 @@ void Model::updateClusterMatrices() {
             auto jointMatrix = _rig.getJointTransform(cluster.jointIndex);
             glm_mat4u_mul(jointMatrix, cluster.inverseBindMatrix, state.clusterMatrices[j]);
         }
-
-      /*  // Once computed the cluster matrices, update the buffer(s)
-        if (mesh.clusters.size() > 1) {
-            if (!state.clusterBuffer) {
-                state.clusterBuffer = std::make_shared<gpu::Buffer>(state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                                    (const gpu::Byte*) state.clusterMatrices.constData());
-            } else {
-                state.clusterBuffer->setSubData(0, state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                (const gpu::Byte*) state.clusterMatrices.constData());
-            }
-        }*/
     }
 
     // post the blender if we're not currently waiting for one to finish
@@ -1332,7 +1321,7 @@ void Model::createCollisionRenderItemSet() {
 }
 
 bool Model::isRenderable() const {
-    return !_meshStates.isEmpty() || (isLoaded() && _renderGeometry->getMeshes().empty());
+    return !_meshStates.empty() || (isLoaded() && _renderGeometry->getMeshes().empty());
 }
 
 class CollisionRenderGeometry : public Geometry {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -241,10 +241,14 @@ void Model::updateRenderItems() {
         uint32_t deleteGeometryCounter = self->_deleteGeometryCounter;
 
         render::Transaction transaction;
-        foreach (auto itemID, self->_modelMeshRenderItemsMap.keys()) {
+      //  foreach (auto itemID, self->_modelMeshRenderItemsMap.keys()) {
       //  for (auto itemID : self->_modelMeshRenderItemIDs) {
+        for (int i = 0; i < self->_modelMeshRenderItemIDs.size(); i++) {
+            auto itemID = self->_modelMeshRenderItemIDs[i];
+            auto meshIndex = self->_modelMeshRenderItemShapes[i].meshIndex;
             if (self && self->isLoaded()) {
-                int meshIndex = std::dynamic_pointer_cast<ModelMeshPartPayload>(self->_modelMeshRenderItemsMap[itemID])->_meshIndex;
+                //int meshIndex = std::dynamic_pointer_cast<ModelMeshPartPayload>(self->_modelMeshRenderItemsMap[itemID])->_meshIndex;
+             //   int meshIndex = std::dynamic_pointer_cast<ModelMeshPartPayload>(self->_modelMeshRenderItemsMap[itemID])->_meshIndex;
                 const Model::MeshState& state = self->getMeshState(meshIndex);
                 auto clusterMatrices(state.clusterMatrices);
 
@@ -704,6 +708,7 @@ void Model::removeFromScene(const render::ScenePointer& scene, render::Transacti
     _modelMeshRenderItemIDs.clear();
     _modelMeshRenderItemsMap.clear();
     _modelMeshRenderItems.clear();
+    _modelMeshRenderItemShapes.clear();
 
     foreach(auto item, _collisionRenderItemsMap.keys()) {
         transaction.removeItem(item);
@@ -1282,6 +1287,7 @@ void Model::createVisibleRenderItemSet() {
     Q_ASSERT(_modelMeshRenderItems.isEmpty());
 
     _modelMeshRenderItems.clear();
+    _modelMeshRenderItemShapes.clear();
 
     Transform transform;
     transform.setTranslation(_translation);
@@ -1304,6 +1310,7 @@ void Model::createVisibleRenderItemSet() {
         int numParts = (int)mesh->getNumParts();
         for (int partIndex = 0; partIndex < numParts; partIndex++) {
             _modelMeshRenderItems << std::make_shared<ModelMeshPartPayload>(shared_from_this(), i, partIndex, shapeID, transform, offset);
+            _modelMeshRenderItemShapes.emplace_back(ShapeInfo{ (int)i });
             shapeID++;
         }
     }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -218,9 +218,6 @@ void Model::updateRenderItems() {
     _needsUpdateClusterMatrices = true;
     _renderItemsNeedUpdate = false;
 
-    if (_modelMeshRenderItemIDs.size() != _meshStates.size()) {
-        return;
-    }
 
     // queue up this work for later processing, at the end of update and just before rendering.
     // the application will ensure only the last lambda is actually invoked.

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -238,7 +238,7 @@ void Model::updateRenderItems() {
         modelTransform.setScale(glm::vec3(1.0f));
 
         render::Transaction transaction;
-        for (int i = 0; i < self->_modelMeshRenderItemIDs.size(); i++) {
+        for (int i = 0; i < (int) self->_modelMeshRenderItemIDs.size(); i++) {
 
             auto itemID = self->_modelMeshRenderItemIDs[i];
             auto meshIndex = self->_modelMeshRenderItemShapes[i].meshIndex;
@@ -1124,7 +1124,7 @@ void Model::updateClusterMatrices() {
     }
     _needsUpdateClusterMatrices = false;
     const FBXGeometry& geometry = getFBXGeometry();
-    for (int i = 0; i < _meshStates.size(); i++) {
+    for (int i = 0; i < (int) _meshStates.size(); i++) {
         MeshState& state = _meshStates[i];
         const FBXMesh& mesh = geometry.meshes.at(i);
         for (int j = 0; j < mesh.clusters.size(); j++) {
@@ -1241,7 +1241,7 @@ void Model::createVisibleRenderItemSet() {
     const auto& meshes = _renderGeometry->getMeshes();
 
     // all of our mesh vectors must match in size
-    if ((int)meshes.size() != _meshStates.size()) {
+    if (meshes.size() != _meshStates.size()) {
         qCDebug(renderutils) << "WARNING!!!! Mesh Sizes don't match! We will not segregate mesh groups yet.";
         return;
     }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -246,8 +246,7 @@ public:
 
     class MeshState {
     public:
-        QVector<glm::mat4> clusterMatrices;
-        gpu::BufferPointer clusterBuffer;
+        std::vector<glm::mat4> clusterMatrices;
     };
 
     const MeshState& getMeshState(int index) { return _meshStates.at(index); }
@@ -317,7 +316,7 @@ protected:
     bool _snappedToRegistrationPoint; /// are we currently snapped to a registration point
     glm::vec3 _registrationPoint = glm::vec3(0.5f); /// the point in model space our center is snapped to
 
-    QVector<MeshState> _meshStates;
+    std::vector<MeshState> _meshStates;
 
     virtual void initJointStates();
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -388,6 +388,8 @@ protected:
     QVector<std::shared_ptr<ModelMeshPartPayload>> _modelMeshRenderItems;
     QMap<render::ItemID, render::PayloadPointer> _modelMeshRenderItemsMap;
     render::ItemIDs _modelMeshRenderItemIDs;
+    using ShapeInfo = struct { int meshIndex; };
+    std::vector<ShapeInfo> _modelMeshRenderItemShapes;
 
     bool _addedToScene { false }; // has been added to scene
     bool _needsFixupInScene { true }; // needs to be removed/re-added to scene

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -387,7 +387,6 @@ protected:
 
     QVector<std::shared_ptr<ModelMeshPartPayload>> _modelMeshRenderItems;
     QMap<render::ItemID, render::PayloadPointer> _modelMeshRenderItemsMap;
-
     render::ItemIDs _modelMeshRenderItemIDs;
 
     bool _addedToScene { false }; // has been added to scene

--- a/libraries/render-utils/src/SoftAttachmentModel.cpp
+++ b/libraries/render-utils/src/SoftAttachmentModel.cpp
@@ -62,7 +62,7 @@ void SoftAttachmentModel::updateClusterMatrices() {
         }
 
         // Once computed the cluster matrices, update the buffer(s)
-        if (mesh.clusters.size() > 1) {
+     /*   if (mesh.clusters.size() > 1) {
             if (!state.clusterBuffer) {
                 state.clusterBuffer = std::make_shared<gpu::Buffer>(state.clusterMatrices.size() * sizeof(glm::mat4),
                                                                     (const gpu::Byte*) state.clusterMatrices.constData());
@@ -70,7 +70,7 @@ void SoftAttachmentModel::updateClusterMatrices() {
                 state.clusterBuffer->setSubData(0, state.clusterMatrices.size() * sizeof(glm::mat4),
                                                 (const gpu::Byte*) state.clusterMatrices.constData());
             }
-        }
+        }*/
     }
 
     // post the blender if we're not currently waiting for one to finish

--- a/libraries/render-utils/src/SoftAttachmentModel.cpp
+++ b/libraries/render-utils/src/SoftAttachmentModel.cpp
@@ -43,7 +43,7 @@ void SoftAttachmentModel::updateClusterMatrices() {
 
     const FBXGeometry& geometry = getFBXGeometry();
 
-    for (int i = 0; i < _meshStates.size(); i++) {
+    for (int i = 0; i < (int) _meshStates.size(); i++) {
         MeshState& state = _meshStates[i];
         const FBXMesh& mesh = geometry.meshes.at(i);
 

--- a/libraries/render-utils/src/SoftAttachmentModel.cpp
+++ b/libraries/render-utils/src/SoftAttachmentModel.cpp
@@ -60,17 +60,6 @@ void SoftAttachmentModel::updateClusterMatrices() {
             }
             glm_mat4u_mul(jointMatrix, cluster.inverseBindMatrix, state.clusterMatrices[j]);
         }
-
-        // Once computed the cluster matrices, update the buffer(s)
-     /*   if (mesh.clusters.size() > 1) {
-            if (!state.clusterBuffer) {
-                state.clusterBuffer = std::make_shared<gpu::Buffer>(state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                                    (const gpu::Byte*) state.clusterMatrices.constData());
-            } else {
-                state.clusterBuffer->setSubData(0, state.clusterMatrices.size() * sizeof(glm::mat4),
-                                                (const gpu::Byte*) state.clusterMatrices.constData());
-            }
-        }*/
     }
 
     // post the blender if we're not currently waiting for one to finish


### PR DESCRIPTION
This PR fixes the tearing happening on the attachments of an avatar.

In the model, the MeshState(s) contains the current values for the cluster matrices and the cluster buffer used for rendering.
The cluster matrices values are updated correctly in Game loop (good)
But these values were copied into the ClusterBuffer also in Game loop (bad)
The cluster buffer is used in Render loop, assigned to the batch for rendering (good)
And worse, the cluster matrices were read from Game Loop with potential threading issues (very bad)

The bug was experienced in heavy loaded domain because in that case, the values in cluster matrices and the one in cluster buffer may likely be different as game loop and render loop are running at different rates.

To address this bug, we are making sure that:
- cluster matrices is still updated in Game loop
- the new values for the cluster matrices are communicated through a transaction to the Scene Render Items so Cluster Buffer(s) only exist in the Render loop side (not anymore in the MeshState)
- we do not need to access the model.state.ClusterMatrices from the render loop anymore

This guaranty thread safety for the cluster matrices between Game loop and Render loop.
All objects relying on the same Rig / cluster matrices values from one Game frame will be displayed using these same values in the same Render frame

## TEST PLAN
THe repro case is explained in this bug:
https://highfidelity.fogbugz.com/f/cases/7628/Parented-Entities-Moves-Are-Delayed-From-Parent

Repro:
0. in dev-welcome
1. Use the Robimo Frost avatar
2. Wear this attachment on your hip joint: http://west.nexusheavy.com/athauxan/Tinybot/WonkaSuit/wonkasuit_05.fbx
Run this script from the script console:
`(function () {
	'use strict';
	var main = function () {
		var attachment = {
		modelURL: "http://west.nexusheavy.com/athauxan/Tinybot/WonkaSuit/wonkasuit_05.fbx",
		jointName: "Hips",
		translation: {"x": 0, "y": 0.0, "z": 0},
		rotation: {"x": 0, "y": 0, "z": 0, "w": 1},
		scale: 1.0,
		isSoft: true
		};	
		MyAvatar.attach(attachment.modelURL,
					 attachment.jointName,
					 attachment.translation,
					 attachment.rotation,
					 attachment.scale,
					 attachment.isSoft);
		Script.stop();
	};
	main();
})();
`
3. Walk/jump around
Observed: the avatar body clips through the coat due to a slight lag in the attachment's movement relative to the avatar
