### PR TITLE
Fix the audio input device peak meters

### DIFF
--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -213,8 +213,8 @@ Rectangle {
                     anchors.right: parent.right
                     peak: model.peak;
                     anchors.verticalCenter: parent.verticalCenter
-                    visible: (bar.currentIndex === 1 && selectedHMD && isVR) ||
-                             (bar.currentIndex === 0 && selectedDesktop && !isVR) &&
+                    visible: ((bar.currentIndex === 1 && isVR) ||
+                             (bar.currentIndex === 0 && !isVR)) &&
                              Audio.devices.input.peakValuesAvailable;
                 }
             }


### PR DESCRIPTION
The audio peak meters for all input devices (not just the active device) got removed by PR #11182. This PR adds them back.