### PR TITLE
Add Machine Fingerprint to receive_at endpoint txn

### DIFF
--- a/interface/src/commerce/Ledger.cpp
+++ b/interface/src/commerce/Ledger.cpp
@@ -90,7 +90,7 @@ void Ledger::buy(const QString& hfc_key, int cost, const QString& asset_id, cons
     signedSend("transaction", transactionString, hfc_key, "buy", "buySuccess", "buyFailure", controlled_failure);
 }
 
-bool Ledger::receiveAt(const QString& hfc_key, const QString& old_key) {
+bool Ledger::receiveAt(const QString& hfc_key, const QString& old_key, const QString& machine_fingerprint) {
     auto accountManager = DependencyManager::get<AccountManager>();
     if (!accountManager->isLoggedIn()) {
         qCWarning(commerce) << "Cannot set receiveAt when not logged in.";
@@ -99,7 +99,13 @@ bool Ledger::receiveAt(const QString& hfc_key, const QString& old_key) {
         return false; // We know right away that we will fail, so tell the caller.
     }
 
-    signedSend("public_key", hfc_key.toUtf8(), old_key, "receive_at", "receiveAtSuccess", "receiveAtFailure");
+    QJsonObject transaction;
+    transaction["hfc_key"] = hfc_key;
+    transaction["machine_fingerprint"] = machine_fingerprint;
+    QJsonDocument transactionDoc{ transaction };
+    auto transactionString = transactionDoc.toJson(QJsonDocument::Compact);
+
+    signedSend("transaction", transactionString, old_key, "receive_at", "receiveAtSuccess", "receiveAtFailure");
     return true; // Note that there may still be an asynchronous signal of failure that callers might be interested in.
 }
 

--- a/interface/src/commerce/Ledger.h
+++ b/interface/src/commerce/Ledger.h
@@ -26,7 +26,7 @@ class Ledger : public QObject, public Dependency {
 
 public:
     void buy(const QString& hfc_key, int cost, const QString& asset_id, const QString& inventory_key, const bool controlled_failure = false);
-    bool receiveAt(const QString& hfc_key, const QString& old_key);
+    bool receiveAt(const QString& hfc_key, const QString& old_key, const QString& machine_fingerprint);
     void balance(const QStringList& keys);
     void inventory(const QStringList& keys);
     void history(const QStringList& keys);

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -16,6 +16,7 @@
 #include "ui/ImageProvider.h"
 #include "scripting/HMDScriptingInterface.h"
 
+#include <FingerprintUtils.h>
 #include <PathUtils.h>
 #include <OffscreenUi.h>
 #include <AccountManager.h>
@@ -541,7 +542,8 @@ bool Wallet::generateKeyPair() {
     // 2. It is maximally private, and we can step back from that later if desired.
     // 3. It maximally exercises all the machinery, so we are most likely to surface issues now.
     auto ledger = DependencyManager::get<Ledger>();
-    return ledger->receiveAt(key, oldKey);
+    QString machineFingerprint = uuidStringWithoutCurlyBraces(FingerprintUtils::getMachineFingerprint());
+    return ledger->receiveAt(key, oldKey, machineFingerprint);
 }
 
 QStringList Wallet::listPublicKeys() {


### PR DESCRIPTION
Will be QA ready after corresponding backend change is live

This PR adds the Machine Fingerprint to the `receive_at` call to the backend.

There should be no functional changes to Commerce behavior after this PR.

**Test Plan:**
1. Enable Commerce
2. Set up a Wallet
3. Verify that you have 100 HFC after you've set up your wallet