### PR TITLE
allow splitting of edit or add entity packets across multiple edit packets when property list is larger than MTU

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -83,7 +83,7 @@ EntityPropertyFlags EntityItem::getEntityProperties(EncodeBitstreamParams& param
     requestedProperties += PROP_ANGULAR_VELOCITY;
     requestedProperties += PROP_ACCELERATION;
 
-    requestedProperties += PROP_DIMENSIONS; // NOTE: PROP_RADIUS obsolete
+    requestedProperties += PROP_DIMENSIONS;
     requestedProperties += PROP_DENSITY;
     requestedProperties += PROP_GRAVITY;
     requestedProperties += PROP_DAMPING;
@@ -241,7 +241,7 @@ OctreeElement::AppendState EntityItem::appendEntityData(OctreePacketData* packet
         APPEND_ENTITY_PROPERTY(PROP_ANGULAR_VELOCITY, getLocalAngularVelocity());
         APPEND_ENTITY_PROPERTY(PROP_ACCELERATION, getAcceleration());
 
-        APPEND_ENTITY_PROPERTY(PROP_DIMENSIONS, getDimensions()); // NOTE: PROP_RADIUS obsolete
+        APPEND_ENTITY_PROPERTY(PROP_DIMENSIONS, getDimensions());
         APPEND_ENTITY_PROPERTY(PROP_DENSITY, getDensity());
         APPEND_ENTITY_PROPERTY(PROP_GRAVITY, getGravity());
         APPEND_ENTITY_PROPERTY(PROP_DAMPING, getDamping());

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -262,8 +262,8 @@ public:
     float getLocalRenderAlpha() const { return _localRenderAlpha; }
     void setLocalRenderAlpha(float value) { _localRenderAlpha = value; _localRenderAlphaChanged = true; }
 
-    static bool encodeEntityEditPacket(PacketType command, EntityItemID id, const EntityItemProperties& properties,
-                                       QByteArray& buffer);
+    static OctreeElement::AppendState encodeEntityEditPacket(PacketType command, EntityItemID id, const EntityItemProperties& properties,
+                                       QByteArray& buffer, EntityPropertyFlags requestedProperties, EntityPropertyFlags& didntFitProperties);
 
     static bool encodeEraseEntityMessage(const EntityItemID& entityItemID, QByteArray& buffer);
 

--- a/libraries/entities/src/EntityPropertyFlags.h
+++ b/libraries/entities/src/EntityPropertyFlags.h
@@ -21,8 +21,7 @@ enum EntityPropertyList {
     // these properties are supported by the EntityItem base class
     PROP_VISIBLE,
     PROP_POSITION,
-    PROP_RADIUS, // NOTE: PROP_RADIUS is obsolete and only included in old format streams
-    PROP_DIMENSIONS = PROP_RADIUS,
+    PROP_DIMENSIONS,
     PROP_ROTATION,
     PROP_DENSITY,
     PROP_VELOCITY,
@@ -47,13 +46,13 @@ enum EntityPropertyList {
     PROP_ANGULAR_VELOCITY,
     PROP_ANGULAR_DAMPING,
     PROP_COLLISIONLESS,
-    PROP_DYNAMIC,
+    PROP_DYNAMIC, // 24
 
     // property used by Light entity
     PROP_IS_SPOTLIGHT,
     PROP_DIFFUSE_COLOR,
-    PROP_AMBIENT_COLOR_UNUSED,
-    PROP_SPECULAR_COLOR_UNUSED,
+    PROP_AMBIENT_COLOR_UNUSED, // FIXME - No longer used, can remove and bump protocol
+    PROP_SPECULAR_COLOR_UNUSED, // FIXME - No longer used, can remove and bump protocol
     PROP_INTENSITY, // Previously PROP_CONSTANT_ATTENUATION
     PROP_LINEAR_ATTENUATION_UNUSED,
     PROP_QUADRATIC_ATTENUATION_UNUSED,
@@ -61,30 +60,30 @@ enum EntityPropertyList {
     PROP_CUTOFF,
 
     // available to all entities
-    PROP_LOCKED,
+    PROP_LOCKED,  // 34
 
     PROP_TEXTURES,  // used by Model entities
-    PROP_ANIMATION_SETTINGS,  // used by Model entities
-    PROP_USER_DATA,  // all entities
+    PROP_ANIMATION_SETTINGS_UNUSED,  // FIXME - No longer used, can remove and bump protocol
+    PROP_USER_DATA,  // all entities -- 37
     PROP_SHAPE_TYPE, // used by Model + zones entities
 
     // used by ParticleEffect entities
-    PROP_MAX_PARTICLES,
-    PROP_LIFESPAN,
+    PROP_MAX_PARTICLES, // 39
+    PROP_LIFESPAN, // 40 -- used by all entities
     PROP_EMIT_RATE,
     PROP_EMIT_SPEED,
     PROP_EMIT_STRENGTH,
-    PROP_EMIT_ACCELERATION,
-    PROP_PARTICLE_RADIUS,
+    PROP_EMIT_ACCELERATION, // FIXME - doesn't seem to get set in mark all changed????
+    PROP_PARTICLE_RADIUS,  // 45!!
 
     PROP_COMPOUND_SHAPE_URL, // used by Model + zones entities
     PROP_MARKETPLACE_ID, // all entities
     PROP_ACCELERATION, // all entities
     PROP_SIMULATION_OWNER, // formerly known as PROP_SIMULATOR_ID
-    PROP_NAME, // all entities
+    PROP_NAME, // all entities -- 50
     PROP_COLLISION_SOUND_URL,
     PROP_RESTITUTION,
-    PROP_FRICTION,
+    PROP_FRICTION, // 53
 
     PROP_VOXEL_VOLUME_SIZE,
     PROP_VOXEL_DATA,
@@ -96,7 +95,7 @@ enum EntityPropertyList {
 
     // used by hyperlinks
     PROP_HREF,
-    PROP_DESCRIPTION,
+    PROP_DESCRIPTION, // 61
 
     PROP_FACE_CAMERA,
     PROP_SCRIPT_TIMESTAMP,

--- a/libraries/octree/src/OctreePacketData.cpp
+++ b/libraries/octree/src/OctreePacketData.cpp
@@ -68,8 +68,8 @@ bool OctreePacketData::append(const unsigned char* data, int length) {
         _dirty = true;
     } 
     
-    const bool wantDebug = false;
-    if (wantDebug && !success) {
+    #ifdef WANT_DEBUG
+    if (!success) {
         qCDebug(octree) << "OctreePacketData::append(const unsigned char* data, int length) FAILING....";
         qCDebug(octree) << "    length=" << length;
         qCDebug(octree) << "    _bytesAvailable=" << _bytesAvailable;
@@ -77,6 +77,7 @@ bool OctreePacketData::append(const unsigned char* data, int length) {
         qCDebug(octree) << "    _targetSize=" << _targetSize;
         qCDebug(octree) << "    _bytesReserved=" << _bytesReserved;
     }
+    #endif
     return success;
 }
 
@@ -645,6 +646,13 @@ void OctreePacketData::debugContent() {
         }
     }
     printf("\n");
+}
+
+void OctreePacketData::debugBytes() {
+    qCDebug(octree) << "    _bytesAvailable=" << _bytesAvailable;
+    qCDebug(octree) << "    _bytesInUse=" << _bytesInUse;
+    qCDebug(octree) << "    _targetSize=" << _targetSize;
+    qCDebug(octree) << "    _bytesReserved=" << _bytesReserved;
 }
 
 int OctreePacketData::unpackDataFromBytes(const unsigned char* dataBytes, QString& result) { 

--- a/libraries/octree/src/OctreePacketData.h
+++ b/libraries/octree/src/OctreePacketData.h
@@ -240,6 +240,7 @@ public:
 
     /// displays contents for debugging
     void debugContent();
+    void debugBytes();
     
     static quint64 getCompressContentTime() { return _compressContentTime; } /// total time spent compressing content
     static quint64 getCompressContentCalls() { return _compressContentCalls; } /// total calls to compress content

--- a/tests/octree/src/OctreeTests.cpp
+++ b/tests/octree/src/OctreeTests.cpp
@@ -74,7 +74,7 @@ void OctreeTests::propertyFlagsTests() {
         EntityPropertyFlags props;
         props.setHasProperty(PROP_VISIBLE);
         props.setHasProperty(PROP_POSITION);
-        props.setHasProperty(PROP_RADIUS);
+        props.setHasProperty(PROP_DIMENSIONS);
         props.setHasProperty(PROP_MODEL_URL);
         props.setHasProperty(PROP_COMPOUND_SHAPE_URL);
         props.setHasProperty(PROP_ROTATION);


### PR DESCRIPTION
Fixes this bug - https://highfidelity.fogbugz.com/f/cases/8873/Sufficiently-large-entities-fail-to-make-it-to-the-entity-server

Test Plan:
- Test edit/add entity editing thoroughly
- Follow repro steps in bug report verify you can import jsons with combined properties larger than MTU, but each property smaller than ~1100 bytes. (larger than 1100 byte properties are not supported)

Here's a possible json you could test with...
```
{
    "Entities": [
      {
        "clientOnly": 0,
        "created": "2017-11-04T01:16:45Z",
        "description": "description-123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
        "dimensions": {
          "x": 2.4574809074401855,
          "y": 1.9560555219650269,
          "z": 3.6256515979766846
        },
        "id": "{6d1c790b-af87-4cd0-b6a7-52bb3ead0a04}",
        "lastEdited": 1509758286686279,
        "lastEditedBy": "{0cbb3ed7-6b69-4e53-aa70-543413d74e6e}",
        "marketplaceID": "60f54c7e-7291-46a6-88ff-e1cc139da3eb",
        "modelURL": "http://mpassets.highfidelity.com/60f54c7e-7291-46a6-88ff-e1cc139da3eb-v1/Bed.fbx",
        "name": "name-12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678912345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678912345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678912345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678912345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678912345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678912345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678912345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
        "owningAvatarID": "{00000000-0000-0000-0000-000000000000}",
        "queryAACube": {
          "scale": 4.796948432922363,
          "x": -2.3984742164611816,
          "y": -2.3984742164611816,
          "z": -2.3984742164611816
        },
        "rotation": {
          "w": 1,
          "x": -1.52587890625e-05,
          "y": -1.52587890625e-05,
          "z": -1.52587890625e-05
        },
        "shapeType": "static-mesh",
        "type": "Model",
        "userData": "user-data-123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
      }
    ],
    "Version": 79
}
```