### PR TITLE
21539: Added Use HMD in Desktop Mode to OpenVR

### DIFF
--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -158,7 +158,6 @@ Rectangle {
         }
 
         RalewayBold {
-            id: hmdInDesktopLabel
             size: 12
             visible: viveInDesktop.checked
             text: "None"

--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -803,6 +803,11 @@ Rectangle {
         anchors.leftMargin: leftMargin + 10
         
         onClicked: {
+            if (!checked & hmdInDesktop.checked) {
+                headBox.checked = true;
+                headPuckBox.checked = false;
+                hmdInDesktop.checked = false;
+            }
             sendConfigurationSettings();
         }
     }

--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -36,7 +36,9 @@ Rectangle {
     readonly property bool hmdHead: headBox.checked
     readonly property bool headPuck: headPuckBox.checked
     readonly property bool handController: handBox.checked
+    
     readonly property bool handPuck: handPuckBox.checked
+    readonly property bool hmdDesktop: hmdInDesktop.checked
 
     property int state: buttonState.disabled
     property var lastConfiguration: null
@@ -789,12 +791,42 @@ Rectangle {
             verticalCenter: viveInDesktop.verticalCenter
         }
     }
+
     
     NumberAnimation {
         id: numberAnimation
         target: openVrConfiguration
         property: "countDown"
         to: 0
+    }
+
+    HifiControls.CheckBox {
+        id: hmdInDesktop
+        width: 15
+        height: 15
+        boxRadius: 7
+
+        anchors.top: viveInDesktop.bottom
+        anchors.topMargin: 5
+        anchors.left: openVrConfiguration.left
+        anchors.leftMargin: leftMargin + 10
+        
+        onClicked: {
+            sendConfigurationSettings();
+        }
+    }
+
+    RalewayBold {
+        id: hmdDesktopText
+        size: 10
+        text: "Use HMD in desktop mode"
+        color: hifi.colors.white
+        
+        anchors {
+            left: hmdInDesktop.right
+            leftMargin: 5
+            verticalCenter: hmdInDesktop.verticalCenter
+        }
     }
 
     function logAction(action, status) {
@@ -877,6 +909,7 @@ Rectangle {
         var HmdHead = settings["HMDHead"];
         var viveController = settings["handController"];
         var desktopMode = settings["desktopMode"];
+        var hmdDesktopPosition = settings["hmdDesktopTracking"];
 
         armCircumference.value = settings.armCircumference;
         shoulderWidth.value = settings.shoulderWidth;
@@ -898,6 +931,7 @@ Rectangle {
         }
 
         viveInDesktop.checked = desktopMode;
+        hmdInDesktop.checked = hmdDesktopPosition;
 
         initializeButtonState();
         updateCalibrationText();
@@ -1058,7 +1092,8 @@ Rectangle {
             "handConfiguration": handObject,
             "armCircumference": armCircumference.value,
             "shoulderWidth": shoulderWidth.value,
-            "desktopMode": viveInDesktop.checked
+            "desktopMode": viveInDesktop.checked,
+            "hmdDesktopTracking": hmdInDesktop.checked
         }
 
         return settingsObject;

--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -55,10 +55,6 @@ Rectangle {
 
     }
 
-
-
-
-
     MouseArea {
         id: mouseArea
 
@@ -101,6 +97,7 @@ Rectangle {
             onClicked: {
                 if (checked) {
                     headPuckBox.checked = false;
+                    hmdInDesktop.checked = false;
                 } else {
                     checked = true;
                 }
@@ -123,6 +120,7 @@ Rectangle {
             onClicked: {
                 if (checked) {
                     headBox.checked = false;
+                    hmdInDesktop.checked = false;
                 } else {
                     checked = true;
                 }
@@ -133,6 +131,37 @@ Rectangle {
         RalewayBold {
             size: 12
             text: "Tracker"
+            color: hifi.colors.lightGrayText
+        }
+
+        HifiControls.CheckBox {
+            id: hmdInDesktop
+            width: 15
+            height: 15
+            boxRadius: 7
+            visible: viveInDesktop.checked
+
+            anchors.top: viveInDesktop.bottom
+            anchors.topMargin: 5
+            anchors.left: openVrConfiguration.left
+            anchors.leftMargin: leftMargin + 10
+        
+            onClicked: {
+                if (checked) {
+                    headBox.checked = false;
+                    headPuckBox.checked = false;
+                } else {
+                    checked = true;
+                }
+                sendConfigurationSettings();
+            }
+        }
+
+        RalewayBold {
+            id: hmdInDesktopLabel
+            size: 12
+            visible: viveInDesktop.checked
+            text: "None"
             color: hifi.colors.lightGrayText
         }
     }
@@ -800,34 +829,6 @@ Rectangle {
         to: 0
     }
 
-    HifiControls.CheckBox {
-        id: hmdInDesktop
-        width: 15
-        height: 15
-        boxRadius: 7
-
-        anchors.top: viveInDesktop.bottom
-        anchors.topMargin: 5
-        anchors.left: openVrConfiguration.left
-        anchors.leftMargin: leftMargin + 10
-        
-        onClicked: {
-            sendConfigurationSettings();
-        }
-    }
-
-    RalewayBold {
-        id: hmdDesktopText
-        size: 10
-        text: "Use HMD in desktop mode"
-        color: hifi.colors.white
-        
-        anchors {
-            left: hmdInDesktop.right
-            leftMargin: 5
-            verticalCenter: hmdInDesktop.verticalCenter
-        }
-    }
 
     function logAction(action, status) {
         console.log("calibrated from ui");

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -166,6 +166,12 @@ void ViveControllerManager::setConfigurationSettings(const QJsonObject configura
                 _resetMatCalculated = false;
             }
         }
+
+        if (configurationSettings.contains("hmdDesktopTracking")) {
+
+            _hmdDesktopTracking = configurationSettings["hmdDesktopTracking"].toBool();
+        }
+
         _inputDevice->configureCalibrationSettings(configurationSettings);
         saveSettings();
     }
@@ -175,6 +181,7 @@ QJsonObject ViveControllerManager::configurationSettings() {
     if (isSupported()) {
         QJsonObject configurationSettings = _inputDevice->configurationSettings();
         configurationSettings["desktopMode"] = _desktopMode;
+        configurationSettings["hmdDesktopTracking"] = _hmdDesktopTracking;
         return configurationSettings;
     }
 
@@ -414,6 +421,8 @@ void ViveControllerManager::InputDevice::configureCalibrationSettings(const QJso
     if (!configurationSettings.empty()) {
         auto iter = configurationSettings.begin();
         auto end = configurationSettings.end();
+        bool hmdDesktopTracking = true;
+        bool hmdDesktopMode = false;
         while (iter != end) {
             if (iter.key() == "bodyConfiguration") {
                 setConfigFromString(iter.value().toString());
@@ -441,9 +450,17 @@ void ViveControllerManager::InputDevice::configureCalibrationSettings(const QJso
                 _armCircumference = (float)iter.value().toDouble() * CM_TO_M;
             } else if (iter.key() == "shoulderWidth") {
                 _shoulderWidth = (float)iter.value().toDouble() * CM_TO_M;
+            } else if (iter.key() == "hmdDesktopTracking") {
+                hmdDesktopTracking = iter.value().toBool();
+            } else if (iter.key() == "desktopMode") {
+                hmdDesktopMode = iter.value().toBool();
             }
             iter++;
         }
+
+        _hmdTrackingEnabled = !(hmdDesktopMode && !hmdDesktopTracking);
+
+        qDebug() << "HMD desktop tracking Enabled" << _hmdTrackingEnabled << "-" << hmdDesktopMode << "-" << hmdDesktopTracking << !(hmdDesktopMode && !hmdDesktopTracking);
     }
 }
 
@@ -735,11 +752,18 @@ void ViveControllerManager::InputDevice::handleHmd(uint32_t deviceIndex, const c
          _system->GetTrackedDeviceClass(deviceIndex) == vr::TrackedDeviceClass_HMD &&
          _nextSimPoseData.vrPoses[deviceIndex].bPoseIsValid) {
 
-         const mat4& mat = _nextSimPoseData.poses[deviceIndex];
-         const vec3 linearVelocity = _nextSimPoseData.linearVelocities[deviceIndex];
-         const vec3 angularVelocity = _nextSimPoseData.angularVelocities[deviceIndex];
+         if (_hmdTrackingEnabled){
+             const mat4& mat = _nextSimPoseData.poses[deviceIndex];
+             const vec3 linearVelocity = _nextSimPoseData.linearVelocities[deviceIndex];
+             const vec3 angularVelocity = _nextSimPoseData.angularVelocities[deviceIndex];
 
-         handleHeadPoseEvent(inputCalibrationData, mat, linearVelocity, angularVelocity);
+             handleHeadPoseEvent(inputCalibrationData, mat, linearVelocity, angularVelocity);
+         } else {
+             const mat4& mat = mat4();
+             const vec3 zero = vec3();
+
+             handleHeadPoseEvent(inputCalibrationData, mat, zero, zero);
+         }
      }
 }
 

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -459,8 +459,6 @@ void ViveControllerManager::InputDevice::configureCalibrationSettings(const QJso
         }
 
         _hmdTrackingEnabled = !(hmdDesktopMode && !hmdDesktopTracking);
-
-        qDebug() << "HMD desktop tracking Enabled" << _hmdTrackingEnabled << "-" << hmdDesktopMode << "-" << hmdDesktopTracking << !(hmdDesktopMode && !hmdDesktopTracking);
     }
 }
 

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -168,7 +168,6 @@ void ViveControllerManager::setConfigurationSettings(const QJsonObject configura
         }
 
         if (configurationSettings.contains("hmdDesktopTracking")) {
-
             _hmdDesktopTracking = configurationSettings["hmdDesktopTracking"].toBool();
         }
 
@@ -458,7 +457,7 @@ void ViveControllerManager::InputDevice::configureCalibrationSettings(const QJso
             iter++;
         }
 
-        _hmdTrackingEnabled = !(hmdDesktopMode && !hmdDesktopTracking);
+        _hmdTrackingEnabled = !(hmdDesktopMode && hmdDesktopTracking);
     }
 }
 

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -113,7 +113,6 @@ private:
         void emitCalibrationStatus();
         void calibrateNextFrame();
 
-
         class FilteredStick {
         public:
             glm::vec2 process(float deltaTime, const glm::vec2& stick) {
@@ -195,6 +194,8 @@ private:
         bool _overrideHands { false };
         mutable std::recursive_mutex _lock;
 
+        bool _hmdTrackingEnabled{ false };
+
         QString configToString(Config config);
         friend class ViveControllerManager;
     };
@@ -204,7 +205,10 @@ private:
     bool _registeredWithInputMapper { false };
     bool _modelLoaded { false };
     bool _resetMatCalculated { false };
+
     bool _desktopMode { false };
+    bool _hmdDesktopTracking{ false };
+    
     glm::mat4 _resetMat { glm::mat4() };
     model::Geometry _modelGeometry;
     gpu::TexturePointer _texture;

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -194,7 +194,7 @@ private:
         bool _overrideHands { false };
         mutable std::recursive_mutex _lock;
 
-        bool _hmdTrackingEnabled{ false };
+        bool _hmdTrackingEnabled { false };
 
         QString configToString(Config config);
         friend class ViveControllerManager;
@@ -207,7 +207,7 @@ private:
     bool _resetMatCalculated { false };
 
     bool _desktopMode { false };
-    bool _hmdDesktopTracking{ false };
+    bool _hmdDesktopTracking { false };
     
     glm::mat4 _resetMat { glm::mat4() };
     model::Geometry _modelGeometry;


### PR DESCRIPTION
[WL 21539](https://worklist.net/21539)

- Added "Use HMD in Desktop Mode" under OpenVR Settings
- When turning off HMD in Desktop Mode, make sure to revert camera back to default.


# Test Plan
## Requires Vive

1. Stay in **Desktop Mode**
2. Visit Controller Settings
3. New checkbox (radial style) should be below "use Vive devices in Desktop mode", "Use HMD in Desktop Mode".
4. Turn on your controllers 
5. Turn on "Use Vive devices in Desktop Mode"
6. With Use HMD in Desktop Mode disabled: moving your HMD around will not move the camera around
7. Turning HMD in Desktop Mode on, your desktop view should move around when moving the HMD
8. Turning HMD in Desktop Mode off after moving in active, should revert the camera back to its original avatar position

Note: This will not effect controller positioning, and may still move your hands and your overall body about, as this is relative to your center of vr-space..
