### PR TITLE
Improved Haze UI in Create menu

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -587,8 +587,8 @@
                     <div class="tuple">
                         <div>
                             <br>
-                            <label>Background Blend<span class="unit"></span></label>
-                            <input type="number" id="property-zone-haze-background-blend" min="0.0" max="1.0" step="0.01">
+                            <span style="padding-right: 1em"><label>Background Blend</label></span>
+                            <input type="range" class="slider" id="property-zone-haze-background-blend" min="0.0" max="1.0" step="0.01" value="0.0">
                         </div>
                     </div>
                 </fieldset>

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -587,8 +587,11 @@
                     <div class="tuple">
                         <div>
                             <br>
-                            <span style="padding-right: 1em"><label>Background Blend</label></span>
-                            <input type="range" class="slider" id="property-zone-haze-background-blend" min="0.0" max="1.0" step="0.01" value="0.0">
+                                <table>
+                                    <td><label>Background Blend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.0</label></td>
+                                    <td><input type="range" class="slider" id="property-zone-haze-background-blend" min="0.0" max="1.0" step="0.01" value="0.0"></td>
+                                    <td><label>1.0</label></td>
+                                </table>
                         </div>
                     </div>
                 </fieldset>
@@ -612,8 +615,11 @@
                     <div class="tuple">
                         <div>
                             <br>
-                            <label>Glare Angle<span class="unit">deg</span></label>
-                            <input type="number" id="property-zone-haze-blend-angle" min="0" max="180" step="1">
+                            <table>
+                                <td><label>Glare Angle&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</label></td>
+                                <td><input type="range" class="slider" id="property-zone-haze-blend-angle" min="0" max="180" step="1"></td>
+                                <td><label>180</label>
+                            </table>
                         </div>
                     </div>
                 </fieldset>

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -555,20 +555,21 @@
                 </form>
                 <fieldset class="zone-group zone-section haze-section property gen fstuple">
                     <div class="tuple">
-                        <div><label>Range<span class="unit">m</span></label><input type="number" id="property-zone-haze-range" min="5" max="10000" step="5"></div>
+                        <div>
+                              <label>Range<span class="unit">m</span></label>
+                              <input type="number" id="property-zone-haze-range" min="5" max="10000" step="5"><
+                        /div>
                     </div>
                 </fieldset>
-                <fieldset class="zone-group zone-section haze-section property rgb fstuple">
                     <div class="zone-group zone-section haze-section property checkbox">
                         <input type="checkbox" id="property-zone-haze-altitude-effect">
                         <label for="property-zone-haze-altitude-effect">Use Altitude</label>
                     </div>
-                    <fieldset class="zone-group zone-section haze-section property gen fstuple">
-                      <div class="tuple">
-                          <div><label>Base<span class="unit">m</span></label><input type="number" id="property-zone-haze-base" min="-1000" max="1000" step="10"></div>
-                          <div><label>Ceiling<span class="unit">m</span></label><input type="number" id="property-zone-haze-ceiling" min="-1000" max="5000" step="10"></div>
-                      </div>
-                    </fieldset>
+                <fieldset class="zone-group zone-section haze-section property gen fstuple">
+                  <div class="tuple">
+                      <div><label>Base<span class="unit">m</span></label><input type="number" id="property-zone-haze-base" min="-1000" max="1000" step="10"></div>
+                      <div><label>Ceiling<span class="unit">m</span></label><input type="number" id="property-zone-haze-ceiling" min="-1000" max="5000" step="10"></div>
+                  </div>
                 </fieldset>
                 <fieldset class="zone-group zone-section haze-section property rgb fstuple">
                     <div class="color-picker" id="property-zone-haze-color"></div>
@@ -580,6 +581,15 @@
                           <label for="property-zone-haze-blend-in-color-green">Green:</label></div>
                         <div><input type="number" class="blue" id="property-zone-haze-color-blue" min="0" max="255" step="1">
                           <label for="property-zone-haze-blend-in-color-blue">Blue:</label></div>
+                    </div>
+                </fieldset>
+                <fieldset class="zone-group zone-section haze-section property gen fstuple">
+                    <div class="tuple">
+                        <div>
+                            <br>
+                            <label>Background Blend<span class="unit"></span></label>
+                            <input type="number" id="property-zone-haze-background-blend" min="0.0" max="1.0" step="0.01">
+                        </div>
                     </div>
                 </fieldset>
                 <div class="zone-group zone-section haze-section property checkbox">
@@ -600,20 +610,18 @@
                 </fieldset>
                 <fieldset class="zone-group zone-section haze-section property gen fstuple">
                     <div class="tuple">
-                        <div><label>Glare Angle<span class="unit">deg</span></label><input type="number" id="property-zone-haze-blend-angle" min="0" max="180" step="1"></div>
-                    </div>
-                 </fieldset>
-                <fieldset class="zone-group zone-section haze-section property gen fstuple">
-                    <div>
-                        <label>Background Blend</label>
-                        <input type="number" id="property-zone-haze-background-blend" min="0.0" max="1.0" step="0.01">
+                        <div>
+                            <br>
+                            <label>Glare Angle<span class="unit">deg</span></label>
+                            <input type="number" id="property-zone-haze-blend-angle" min="0" max="180" step="1">
+                        </div>
                     </div>
                 </fieldset>
+                <div class="zone-group zone-section haze-section property checkbox">
+                    <input type="checkbox" id="property-zone-haze-attenuate-keylight">
+                    <label for="property-zone-haze-attenuate-keylight">Attenuate Keylight</label>
+                </div>
                 <fieldset class="zone-group zone-section haze-section property gen fstuple">
-                    <div class="zone-group zone-section haze-section property checkbox">
-                        <input type="checkbox" id="property-zone-haze-attenuate-keylight">
-                        <label for="property-zone-haze-attenuate-keylight">Attenuate Keylight</label>
-                    </div>
                     <div class="tuple">
                         <div><label>Range<span class="unit">m</span></label><input type="number" id="property-zone-haze-keylight-range" 
                         min="5" max="1000000" step="5"></div>

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -557,8 +557,8 @@
                     <div class="tuple">
                         <div>
                               <label>Range<span class="unit">m</span></label>
-                              <input type="number" id="property-zone-haze-range" min="5" max="10000" step="5"><
-                        /div>
+                              <input type="number" id="property-zone-haze-range" min="5" max="10000" step="5">
+                        </div>
                     </div>
                 </fieldset>
                     <div class="zone-group zone-section haze-section property checkbox">


### PR DESCRIPTION
Replaces the UI for Haze.
Current UI:
![image](https://user-images.githubusercontent.com/29026026/32467620-357cbbd6-c300-11e7-87c0-084a4e585d86.png)

New UI:
![image](https://user-images.githubusercontent.com/29026026/32582681-d799d5fc-c4a4-11e7-92dc-d4c3c0ef5524.png)

The changes are to two checkboxes and the Background Blend field.
