### PR TITLE
Fix crash when logging out while Passphrase screen visible

### DIFF
--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -33,7 +33,7 @@ QmlCommerce::QmlCommerce(QQuickItem* parent) : OffscreenQmlDialog(parent) {
     connect(ledger.data(), &Ledger::updateCertificateStatus, this, &QmlCommerce::updateCertificateStatus);
     
     auto accountManager = DependencyManager::get<AccountManager>();
-    connect(accountManager.data(), &AccountManager::usernameChanged, [&]() {
+    connect(accountManager.data(), &AccountManager::usernameChanged, this, [&]() {
         setPassphrase("");
     });
 }


### PR DESCRIPTION
**Test Plan**
1. Enable Commerce
2. Set up your wallet
3. In the Wallet app, go to the HELP tab, then click the black "DBG: CLEAR PASS" at the top of the page
4. Open the Wallet app. You should see the "enter your passphrase" screen.
5. In Interface's top menu bar, click `File->Logout <username>`. Verify that you don't crash and that you see the "you must log in" screen in the Wallet.
6. Click the "Log In" button, then log in to your account. Verify that the Wallet app displays the "enter your passphrase" screen.
7. Close the wallet app.
8. Repeat steps 4-6 three more times. Verify that you don't crash at any point during these repeated tests.

Thanks.