### PR TITLE
7587 Lasers resize with avatar

### DIFF
--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -7,7 +7,7 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-////
+//
 #include "LaserPointer.h"
 
 #include "Application.h"
@@ -15,7 +15,7 @@
 #include "RayPickScriptingInterface.h"
 
 LaserPointer::LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates,
-        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled) :
+    const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled) :
     _renderingEnabled(enabled),
     _renderStates(renderStates),
     _defaultRenderStates(defaultRenderStates),
@@ -121,7 +121,8 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
     glm::vec3 endVec;
     if (((defaultState || !_lockEnd) && _lockEndObject.id.isNull()) || type == IntersectionType::HUD) {
         endVec = pickRay.origin + pickRay.direction * distance;
-    } else {
+    }
+    else {
         if (!_lockEndObject.id.isNull()) {
             glm::vec3 pos;
             glm::quat rot;
@@ -132,7 +133,8 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
                 rot = quatFromVariant(qApp->getOverlays().getProperty(_lockEndObject.id, "rotation").value);
                 dim = vec3FromVariant(qApp->getOverlays().getProperty(_lockEndObject.id, "dimensions").value);
                 registrationPoint = glm::vec3(0.5f);
-            } else {
+            }
+            else {
                 EntityItemProperties props = DependencyManager::get<EntityScriptingInterface>()->getEntityProperties(_lockEndObject.id);
                 glm::mat4 entityMat = createMatFromQuatAndPos(props.getRotation(), props.getPosition());
                 glm::mat4 finalPosAndRotMat = entityMat * _lockEndObject.offsetMat;
@@ -143,17 +145,20 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
             }
             const glm::vec3 DEFAULT_REGISTRATION_POINT = glm::vec3(0.5f);
             endVec = pos + rot * (dim * (DEFAULT_REGISTRATION_POINT - registrationPoint));
-        } else {
+        }
+        else {
             if (type == IntersectionType::ENTITY) {
                 endVec = DependencyManager::get<EntityScriptingInterface>()->getEntityTransform(objectID)[3];
-            } else if (type == IntersectionType::OVERLAY) {
+            }
+            else if (type == IntersectionType::OVERLAY) {
                 endVec = vec3FromVariant(qApp->getOverlays().getProperty(objectID, "position").value);
-            } else if (type == IntersectionType::AVATAR) {
+            }
+            else if (type == IntersectionType::AVATAR) {
                 endVec = DependencyManager::get<AvatarHashMap>()->getAvatar(objectID)->getPosition();
             }
         }
     }
-
+    
     float avatarScale = DependencyManager::get<AvatarManager>()->getMyAvatar()->getAvatarScale();
 
     QVariant end = vec3toVariant(endVec);
@@ -180,7 +185,8 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
         }
         if (_centerEndY) {
             endProps.insert("position", end);
-        } else {
+        }
+        else {
             glm::vec3 currentUpVector = faceAvatarRotation * Vectors::UP;
             endProps.insert("position", vec3toVariant(endVec + glm::vec3(currentUpVector.x * 0.5f * dim.y, currentUpVector.y * 0.5f * dim.y, currentUpVector.z * 0.5f * dim.y)));
         }
@@ -221,13 +227,14 @@ void LaserPointer::update() {
         if (_renderingEnabled && !_currentRenderState.empty() && _renderStates.find(_currentRenderState) != _renderStates.end() &&
             (prevRayPickResult.type != IntersectionType::NONE || _laserLength > 0.0f || !_lockEndObject.id.isNull())) {
             float distance = _laserLength > 0.0f ? _laserLength : prevRayPickResult.distance;
-            qDebug() << &_currentRenderState;
             updateRenderState(_renderStates[_currentRenderState], prevRayPickResult.type, distance, prevRayPickResult.objectID, prevRayPickResult.searchRay, false);
             disableRenderState(_defaultRenderStates[_currentRenderState].second);
-        } else if (_renderingEnabled && !_currentRenderState.empty() && _defaultRenderStates.find(_currentRenderState) != _defaultRenderStates.end()) {
+        }
+        else if (_renderingEnabled && !_currentRenderState.empty() && _defaultRenderStates.find(_currentRenderState) != _defaultRenderStates.end()) {
             disableRenderState(_renderStates[_currentRenderState]);
             updateRenderState(_defaultRenderStates[_currentRenderState].second, IntersectionType::NONE, _defaultRenderStates[_currentRenderState].first, QUuid(), prevRayPickResult.searchRay, true);
-        } else if (!_currentRenderState.empty()) {
+        }
+        else if (!_currentRenderState.empty()) {
             disableRenderState(_renderStates[_currentRenderState]);
             disableRenderState(_defaultRenderStates[_currentRenderState].second);
         }

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -14,6 +14,8 @@
 #include "avatar/AvatarManager.h"
 #include "RayPickScriptingInterface.h"
 
+static const float DEFAULT_LASER_POINTER_SIZE = 0.02f;
+
 LaserPointer::LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates,
         const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled) :
     _renderingEnabled(enabled),
@@ -163,11 +165,10 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
         pathProps.insert("end", end);
         pathProps.insert("visible", true);
         pathProps.insert("ignoreRayIntersection", renderState.doesPathIgnoreRays());
-        if (_scaleWithAvatar) {
-            auto glowScaleProp = qApp->getOverlays().getProperty(renderState.getPathID(), "glowScale").value;
-            float glowScale = glowScaleProp.isValid() ? avatarScale * glowScaleProp.toFloat() : avatarScale;
-            pathProps.insert("glowScale", glowScale);
-        }
+
+        float glowWidth = _scaleWithAvatar ? DEFAULT_LASER_POINTER_SIZE * avatarScale : DEFAULT_LASER_POINTER_SIZE;
+        pathProps.insert("glowWidth", glowWidth);
+        
         qApp->getOverlays().editOverlay(renderState.getPathID(), pathProps);
     }
     if (!renderState.getEndID().isNull()) {

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -97,6 +97,10 @@ void LaserPointer::editRenderState(const std::string& state, const QVariant& sta
         if (endDim.isValid()) {
             _renderStates[state].setEndDim(vec3FromVariant(endDim));
         }
+        QVariant lineWidth = pathProps.toMap()["lineWidth"];
+        if (lineWidth.isValid()) {
+            _renderStates[state].setLineWidth(lineWidth.toFloat());
+        }
     });
 }
 
@@ -165,10 +169,9 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
         pathProps.insert("end", end);
         pathProps.insert("visible", true);
         pathProps.insert("ignoreRayIntersection", renderState.doesPathIgnoreRays());
-
-        float glowWidth = _scaleWithAvatar ? DEFAULT_LASER_POINTER_SIZE * avatarScale : DEFAULT_LASER_POINTER_SIZE;
-        pathProps.insert("glowWidth", glowWidth);
-        
+        if (_scaleWithAvatar) {
+            pathProps.insert("lineWidth", renderState.getLineWidth() * avatarScale);
+        }
         qApp->getOverlays().editOverlay(renderState.getPathID(), pathProps);
     }
     if (!renderState.getEndID().isNull()) {
@@ -268,6 +271,7 @@ RenderState::RenderState(const OverlayID& startID, const OverlayID& pathID, cons
     }
     if (!_pathID.isNull()) {
         _pathIgnoreRays = qApp->getOverlays().getProperty(_pathID, "ignoreRayIntersection").value.toBool();
+        _lineWidth = qApp->getOverlays().getProperty(_pathID, "lineWidth").value.toFloat();
     }
     if (!_endID.isNull()) {
         _endDim = vec3FromVariant(qApp->getOverlays().getProperty(_endID, "dimensions").value);

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -158,8 +158,6 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
         }
     }
     
-    float avatarScale = DependencyManager::get<AvatarManager>()->getMyAvatar()->getAvatarScale();
-
     QVariant end = vec3toVariant(endVec);
     if (!renderState.getPathID().isNull()) {
         QVariantMap pathProps;
@@ -168,7 +166,7 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
         pathProps.insert("visible", true);
         pathProps.insert("ignoreRayIntersection", renderState.doesPathIgnoreRays());
         if (_scaleWithAvatar) {
-            pathProps.insert("lineWidth", renderState.getLineWidth() * avatarScale);
+            pathProps.insert("lineWidth", renderState.getLineWidth() * DependencyManager::get<AvatarManager>()->getMyAvatar()->getSensorToWorldScale());
         }
         qApp->getOverlays().editOverlay(renderState.getPathID(), pathProps);
     }

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -15,7 +15,7 @@
 #include "RayPickScriptingInterface.h"
 
 LaserPointer::LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates,
-    const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled) :
+        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled) :
     _renderingEnabled(enabled),
     _renderStates(renderStates),
     _defaultRenderStates(defaultRenderStates),
@@ -121,8 +121,7 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
     glm::vec3 endVec;
     if (((defaultState || !_lockEnd) && _lockEndObject.id.isNull()) || type == IntersectionType::HUD) {
         endVec = pickRay.origin + pickRay.direction * distance;
-    }
-    else {
+    } else {
         if (!_lockEndObject.id.isNull()) {
             glm::vec3 pos;
             glm::quat rot;
@@ -133,8 +132,7 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
                 rot = quatFromVariant(qApp->getOverlays().getProperty(_lockEndObject.id, "rotation").value);
                 dim = vec3FromVariant(qApp->getOverlays().getProperty(_lockEndObject.id, "dimensions").value);
                 registrationPoint = glm::vec3(0.5f);
-            }
-            else {
+            } else {
                 EntityItemProperties props = DependencyManager::get<EntityScriptingInterface>()->getEntityProperties(_lockEndObject.id);
                 glm::mat4 entityMat = createMatFromQuatAndPos(props.getRotation(), props.getPosition());
                 glm::mat4 finalPosAndRotMat = entityMat * _lockEndObject.offsetMat;
@@ -145,15 +143,12 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
             }
             const glm::vec3 DEFAULT_REGISTRATION_POINT = glm::vec3(0.5f);
             endVec = pos + rot * (dim * (DEFAULT_REGISTRATION_POINT - registrationPoint));
-        }
-        else {
+        } else {
             if (type == IntersectionType::ENTITY) {
                 endVec = DependencyManager::get<EntityScriptingInterface>()->getEntityTransform(objectID)[3];
-            }
-            else if (type == IntersectionType::OVERLAY) {
+            } else if (type == IntersectionType::OVERLAY) {
                 endVec = vec3FromVariant(qApp->getOverlays().getProperty(objectID, "position").value);
-            }
-            else if (type == IntersectionType::AVATAR) {
+            } else if (type == IntersectionType::AVATAR) {
                 endVec = DependencyManager::get<AvatarHashMap>()->getAvatar(objectID)->getPosition();
             }
         }
@@ -185,8 +180,7 @@ void LaserPointer::updateRenderState(const RenderState& renderState, const Inter
         }
         if (_centerEndY) {
             endProps.insert("position", end);
-        }
-        else {
+        } else {
             glm::vec3 currentUpVector = faceAvatarRotation * Vectors::UP;
             endProps.insert("position", vec3toVariant(endVec + glm::vec3(currentUpVector.x * 0.5f * dim.y, currentUpVector.y * 0.5f * dim.y, currentUpVector.z * 0.5f * dim.y)));
         }
@@ -229,12 +223,10 @@ void LaserPointer::update() {
             float distance = _laserLength > 0.0f ? _laserLength : prevRayPickResult.distance;
             updateRenderState(_renderStates[_currentRenderState], prevRayPickResult.type, distance, prevRayPickResult.objectID, prevRayPickResult.searchRay, false);
             disableRenderState(_defaultRenderStates[_currentRenderState].second);
-        }
-        else if (_renderingEnabled && !_currentRenderState.empty() && _defaultRenderStates.find(_currentRenderState) != _defaultRenderStates.end()) {
+        } else if (_renderingEnabled && !_currentRenderState.empty() && _defaultRenderStates.find(_currentRenderState) != _defaultRenderStates.end()) {
             disableRenderState(_renderStates[_currentRenderState]);
             updateRenderState(_defaultRenderStates[_currentRenderState].second, IntersectionType::NONE, _defaultRenderStates[_currentRenderState].first, QUuid(), prevRayPickResult.searchRay, true);
-        }
-        else if (!_currentRenderState.empty()) {
+        } else if (!_currentRenderState.empty()) {
             disableRenderState(_renderStates[_currentRenderState]);
             disableRenderState(_defaultRenderStates[_currentRenderState].second);
         }

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -14,8 +14,6 @@
 #include "avatar/AvatarManager.h"
 #include "RayPickScriptingInterface.h"
 
-static const float DEFAULT_LASER_POINTER_SIZE = 0.02f;
-
 LaserPointer::LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates,
         const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled) :
     _renderingEnabled(enabled),

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -60,7 +60,7 @@ public:
     typedef std::unordered_map<std::string, std::pair<float, RenderState>> DefaultRenderStateMap;
 
     LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates,
-        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool enabled);
+        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled);
     ~LaserPointer();
 
     QUuid getRayUID() { return _rayPickUID; }
@@ -91,6 +91,7 @@ private:
     bool _centerEndY;
     bool _lockEnd;
     bool _distanceScaleEnd;
+    bool _scaleWithAvatar;
     std::pair<QUuid, bool> _objectLockEnd { std::pair<QUuid, bool>(QUuid(), false)};
 
     const QUuid _rayPickUID;

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -22,9 +22,9 @@
 class RayPickResult;
 
 struct LockEndObject {
-    QUuid id{ QUuid() };
-    bool isOverlay{ false };
-    glm::mat4 offsetMat{ glm::mat4() };
+    QUuid id { QUuid() };
+    bool isOverlay { false };
+    glm::mat4 offsetMat { glm::mat4() };
 };
 
 class RenderState {
@@ -89,8 +89,8 @@ public:
 
 private:
     bool _renderingEnabled;
-    float _laserLength{ 0.0f };
-    std::string _currentRenderState{ "" };
+    float _laserLength { 0.0f };
+    std::string _currentRenderState { "" };
     RenderStateMap _renderStates;
     DefaultRenderStateMap _defaultRenderStates;
     bool _faceAvatar;

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -43,6 +43,9 @@ public:
     void setEndDim(const glm::vec3& endDim) { _endDim = endDim; }
     const glm::vec3& getEndDim() const { return _endDim; }
 
+    void setLineWidth(const float& lineWidth) { _lineWidth = lineWidth; }
+    const float& getLineWidth() const { return _lineWidth; }
+
     void deleteOverlays();
 
 private:
@@ -54,6 +57,7 @@ private:
     bool _endIgnoreRays;
 
     glm::vec3 _endDim;
+    float _lineWidth;
 };
 
 

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -22,9 +22,9 @@
 class RayPickResult;
 
 struct LockEndObject {
-    QUuid id { QUuid() };
-    bool isOverlay { false };
-    glm::mat4 offsetMat { glm::mat4() };
+    QUuid id{ QUuid() };
+    bool isOverlay{ false };
+    glm::mat4 offsetMat{ glm::mat4() };
 };
 
 class RenderState {
@@ -89,8 +89,8 @@ public:
 
 private:
     bool _renderingEnabled;
-    float _laserLength { 0.0f };
-    std::string _currentRenderState { "" };
+    float _laserLength{ 0.0f };
+    std::string _currentRenderState{ "" };
     RenderStateMap _renderStates;
     DefaultRenderStateMap _defaultRenderStates;
     bool _faceAvatar;

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -113,9 +113,9 @@ void LaserPointerManager::setIncludeItems(const QUuid& uid, const QVector<QUuid>
     }
 }
 
-void LaserPointerManager::setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay) const {
+void LaserPointerManager::setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay, const glm::mat4& offsetMat) const {
     auto laserPointer = find(uid);
     if (laserPointer) {
-        laserPointer->setLockEndUUID(objectID, isOverlay);
+        laserPointer->setLockEndUUID(objectID, isOverlay, offsetMat);
     }
 }

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -113,9 +113,9 @@ void LaserPointerManager::setIncludeItems(const QUuid& uid, const QVector<QUuid>
     }
 }
 
-void LaserPointerManager::setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay, const glm::mat4& offsetMat) const {
+void LaserPointerManager::setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay) const {
     auto laserPointer = find(uid);
     if (laserPointer) {
-        laserPointer->setLockEndUUID(objectID, isOverlay, offsetMat);
+        laserPointer->setLockEndUUID(objectID, isOverlay);
     }
 }

--- a/interface/src/raypick/LaserPointerManager.cpp
+++ b/interface/src/raypick/LaserPointerManager.cpp
@@ -11,9 +11,9 @@
 #include "LaserPointerManager.h"
 
 QUuid LaserPointerManager::createLaserPointer(const QVariant& rayProps, const LaserPointer::RenderStateMap& renderStates, const LaserPointer::DefaultRenderStateMap& defaultRenderStates,
-    const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool enabled) {
+    const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled) {
     QUuid result;
-    std::shared_ptr<LaserPointer> laserPointer = std::make_shared<LaserPointer>(rayProps, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, distanceScaleEnd, enabled);
+    std::shared_ptr<LaserPointer> laserPointer = std::make_shared<LaserPointer>(rayProps, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, distanceScaleEnd, scaleWithAvatar, enabled);
     if (!laserPointer->getRayUID().isNull()) {
         result = QUuid::createUuid();
         withWriteLock([&] { _laserPointers[result] = laserPointer; });

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -25,7 +25,7 @@ class LaserPointerManager : protected ReadWriteLockable {
 
 public:
     QUuid createLaserPointer(const QVariant& rayProps, const LaserPointer::RenderStateMap& renderStates, const LaserPointer::DefaultRenderStateMap& defaultRenderStates,
-        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool enabled);
+        const bool faceAvatar, const bool centerEndY, const bool lockEnd, const bool distanceScaleEnd, const bool scaleWithAvatar, const bool enabled);
 
     void removeLaserPointer(const QUuid& uid);
     void enableLaserPointer(const QUuid& uid) const;

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -39,7 +39,7 @@ public:
     void setIgnoreItems(const QUuid& uid, const QVector<QUuid>& ignoreEntities) const;
     void setIncludeItems(const QUuid& uid, const QVector<QUuid>& includeEntities) const;
 
-    void setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay) const;
+    void setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay, const glm::mat4& offsetMat = glm::mat4()) const;
 
     void update();
 

--- a/interface/src/raypick/LaserPointerManager.h
+++ b/interface/src/raypick/LaserPointerManager.h
@@ -39,7 +39,7 @@ public:
     void setIgnoreItems(const QUuid& uid, const QVector<QUuid>& ignoreEntities) const;
     void setIncludeItems(const QUuid& uid, const QVector<QUuid>& includeEntities) const;
 
-    void setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay, const glm::mat4& offsetMat = glm::mat4()) const;
+    void setLockEndUUID(const QUuid& uid, const QUuid& objectID, const bool isOverlay) const;
 
     void update();
 

--- a/interface/src/raypick/LaserPointerScriptingInterface.cpp
+++ b/interface/src/raypick/LaserPointerScriptingInterface.cpp
@@ -7,7 +7,7 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-////
+//
 
 #include "LaserPointerScriptingInterface.h"
 

--- a/interface/src/raypick/LaserPointerScriptingInterface.cpp
+++ b/interface/src/raypick/LaserPointerScriptingInterface.cpp
@@ -7,7 +7,7 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-//
+////
 
 #include "LaserPointerScriptingInterface.h"
 
@@ -51,6 +51,11 @@ QUuid LaserPointerScriptingInterface::createLaserPointer(const QVariant& propert
         enabled = propertyMap["enabled"].toBool();
     }
 
+    bool scaleWithAvatar = false;
+    if (propertyMap["scaleWithAvatar"].isValid()) {
+        scaleWithAvatar = propertyMap["scaleWithAvatar"].toBool();
+    }
+
     LaserPointer::RenderStateMap renderStates;
     if (propertyMap["renderStates"].isValid()) {
         QList<QVariant> renderStateVariants = propertyMap["renderStates"].toList();
@@ -80,7 +85,7 @@ QUuid LaserPointerScriptingInterface::createLaserPointer(const QVariant& propert
         }
     }
 
-    return qApp->getLaserPointerManager().createLaserPointer(properties, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, distanceScaleEnd, enabled);
+    return qApp->getLaserPointerManager().createLaserPointer(properties, renderStates, defaultRenderStates, faceAvatar, centerEndY, lockEnd, distanceScaleEnd, scaleWithAvatar, enabled);
 }
 
 void LaserPointerScriptingInterface::editRenderState(const QUuid& uid, const QString& renderState, const QVariant& properties) const {

--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -16,13 +16,11 @@
 #include "Application.h"
 
 
-const float DEFAULT_LINE_WIDTH = 1.0f;
 const bool DEFAULT_IS_SOLID = false;
 const bool DEFAULT_IS_DASHED_LINE = false;
 
 Base3DOverlay::Base3DOverlay() :
     SpatiallyNestable(NestableType::Overlay, QUuid::createUuid()),
-    _lineWidth(DEFAULT_LINE_WIDTH),
     _isSolid(DEFAULT_IS_SOLID),
     _isDashedLine(DEFAULT_IS_DASHED_LINE),
     _ignoreRayIntersection(false),
@@ -34,7 +32,6 @@ Base3DOverlay::Base3DOverlay() :
 Base3DOverlay::Base3DOverlay(const Base3DOverlay* base3DOverlay) :
     Overlay(base3DOverlay),
     SpatiallyNestable(NestableType::Overlay, QUuid::createUuid()),
-    _lineWidth(base3DOverlay->_lineWidth),
     _isSolid(base3DOverlay->_isSolid),
     _isDashedLine(base3DOverlay->_isDashedLine),
     _ignoreRayIntersection(base3DOverlay->_ignoreRayIntersection),
@@ -153,12 +150,6 @@ void Base3DOverlay::setProperties(const QVariantMap& originalProperties) {
         setLocalOrientation(quatFromVariant(properties["orientation"]));
         needRenderItemUpdate = true;
     }
-
-    if (properties["lineWidth"].isValid()) {
-        setLineWidth(properties["lineWidth"].toFloat());
-        needRenderItemUpdate = true;
-    }
-
     if (properties["isSolid"].isValid()) {
         setIsSolid(properties["isSolid"].toBool());
     }
@@ -224,9 +215,6 @@ QVariant Base3DOverlay::getProperty(const QString& property) {
     }
     if (property == "localRotation" || property == "localOrientation") {
         return quatToVariant(getLocalOrientation());
-    }
-    if (property == "lineWidth") {
-        return _lineWidth;
     }
     if (property == "isSolid" || property == "isFilled" || property == "solid" || property == "filed") {
         return _isSolid;

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -35,7 +35,6 @@ public:
     // TODO: consider implementing registration points in this class
     glm::vec3 getCenter() const { return getPosition(); }
 
-    float getLineWidth() const { return _lineWidth; }
     bool getIsSolid() const { return _isSolid; }
     bool getIsDashedLine() const { return _isDashedLine; }
     bool getIsSolidLine() const { return !_isDashedLine; }
@@ -44,7 +43,6 @@ public:
     bool getDrawHUDLayer() const { return _drawHUDLayer; }
     bool getIsGrabbable() const { return _isGrabbable; }
 
-    void setLineWidth(float lineWidth) { _lineWidth = lineWidth; }
     void setIsSolid(bool isSolid) { _isSolid = isSolid; }
     void setIsDashedLine(bool isDashedLine) { _isDashedLine = isDashedLine; }
     void setIgnoreRayIntersection(bool value) { _ignoreRayIntersection = value; }
@@ -80,7 +78,6 @@ protected:
     virtual void setRenderTransform(const Transform& transform);
     const Transform& getRenderTransform() const { return _renderTransform; }
 
-    float _lineWidth;
     bool _isSolid;
     bool _isDashedLine;
     bool _ignoreRayIntersection;

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -12,6 +12,7 @@
 
 #include <GeometryCache.h>
 #include <RegisteredMetaTypes.h>
+#include <Application.h>
 
 #include "AbstractViewStateInterface.h"
 
@@ -35,6 +36,7 @@ Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
     _endParentJointIndex = line3DOverlay->getEndJointIndex();
     _glow = line3DOverlay->getGlow();
     _glowWidth = line3DOverlay->getGlowWidth();
+    _glowScale = line3DOverlay->getGlowScale();
 }
 
 Line3DOverlay::~Line3DOverlay() {
@@ -145,7 +147,7 @@ void Line3DOverlay::render(RenderArgs* args) {
             geometryCache->renderDashedLine(*batch, start, end, colorv4, _geometryCacheID);
         } else {
             // renderGlowLine handles both glow = 0 and glow > 0 cases
-            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _glowWidth, _geometryCacheID);
+            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _glowWidth, _glowScale, _geometryCacheID);
         }
     }
 }
@@ -242,6 +244,12 @@ void Line3DOverlay::setProperties(const QVariantMap& originalProperties) {
     auto glowWidth = properties["glowWidth"];
     if (glowWidth.isValid()) {
         setGlowWidth(glowWidth.toFloat());
+    }
+
+    auto glowScale = properties["glowScale"];
+    if (glowScale.isValid()) {
+        float gscale = glowScale.toFloat();
+        setGlowScale(gscale);
     }
 
 }

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -16,11 +16,9 @@
 #include "AbstractViewStateInterface.h"
 
 QString const Line3DOverlay::TYPE = "line3d";
-static const float DEFAULT_LINE_WIDTH = 0.02f;
 
 Line3DOverlay::Line3DOverlay() :
-    _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID()),
-    _lineWidth(DEFAULT_LINE_WIDTH)
+    _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
 {
 }
 

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -35,7 +35,6 @@ Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
     _endParentJointIndex = line3DOverlay->getEndJointIndex();
     _glow = line3DOverlay->getGlow();
     _glowWidth = line3DOverlay->getGlowWidth();
-    _glowScale = line3DOverlay->getGlowScale();
 }
 
 Line3DOverlay::~Line3DOverlay() {
@@ -146,7 +145,7 @@ void Line3DOverlay::render(RenderArgs* args) {
             geometryCache->renderDashedLine(*batch, start, end, colorv4, _geometryCacheID);
         } else {
             // renderGlowLine handles both glow = 0 and glow > 0 cases
-            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _glowWidth, _glowScale, _geometryCacheID);
+            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _glowWidth, _geometryCacheID);
         }
     }
 }
@@ -244,13 +243,6 @@ void Line3DOverlay::setProperties(const QVariantMap& originalProperties) {
     if (glowWidth.isValid()) {
         setGlowWidth(glowWidth.toFloat());
     }
-
-    auto glowScale = properties["glowScale"];
-    if (glowScale.isValid()) {
-        float gscale = glowScale.toFloat();
-        setGlowScale(gscale);
-    }
-
 }
 
 QVariant Line3DOverlay::getProperty(const QString& property) {

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -6,7 +6,7 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-////
+//
 
 #include "Line3DOverlay.h"
 

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -12,7 +12,6 @@
 
 #include <GeometryCache.h>
 #include <RegisteredMetaTypes.h>
-#include <Application.h>
 
 #include "AbstractViewStateInterface.h"
 

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -6,7 +6,7 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-//
+////
 
 #include "Line3DOverlay.h"
 
@@ -33,8 +33,8 @@ Line3DOverlay::Line3DOverlay(const Line3DOverlay* line3DOverlay) :
     _length = line3DOverlay->getLength();
     _endParentID = line3DOverlay->getEndParentID();
     _endParentJointIndex = line3DOverlay->getEndJointIndex();
+    _lineWidth = line3DOverlay->getLineWidth();
     _glow = line3DOverlay->getGlow();
-    _glowWidth = line3DOverlay->getGlowWidth();
 }
 
 Line3DOverlay::~Line3DOverlay() {
@@ -145,7 +145,7 @@ void Line3DOverlay::render(RenderArgs* args) {
             geometryCache->renderDashedLine(*batch, start, end, colorv4, _geometryCacheID);
         } else {
             // renderGlowLine handles both glow = 0 and glow > 0 cases
-            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _glowWidth, _geometryCacheID);
+            geometryCache->renderGlowLine(*batch, start, end, colorv4, _glow, _lineWidth, _geometryCacheID);
         }
     }
 }
@@ -239,9 +239,9 @@ void Line3DOverlay::setProperties(const QVariantMap& originalProperties) {
         }
     }
 
-    auto glowWidth = properties["glowWidth"];
-    if (glowWidth.isValid()) {
-        setGlowWidth(glowWidth.toFloat());
+    auto lineWidth = properties["lineWidth"];
+    if (lineWidth.isValid()) {
+        setLineWidth(lineWidth.toFloat());
     }
 }
 
@@ -260,6 +260,9 @@ QVariant Line3DOverlay::getProperty(const QString& property) {
     }
     if (property == "length") {
         return QVariant(getLength());
+    }
+    if (property == "lineWidth") {
+        return _lineWidth;
     }
 
     return Base3DOverlay::getProperty(property);

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -16,9 +16,11 @@
 #include "AbstractViewStateInterface.h"
 
 QString const Line3DOverlay::TYPE = "line3d";
+static const float DEFAULT_LINE_WIDTH = 0.02f;
 
 Line3DOverlay::Line3DOverlay() :
-    _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID())
+    _geometryCacheID(DependencyManager::get<GeometryCache>()->allocateID()),
+    _lineWidth(DEFAULT_LINE_WIDTH)
 {
 }
 

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -33,7 +33,6 @@ public:
     glm::vec3 getEnd() const;
     const float& getGlow() const { return _glow; }
     const float& getGlowWidth() const { return _glowWidth; }
-    const float& getGlowScale() const { return _glowScale; }
 
     // setters
     void setStart(const glm::vec3& start);
@@ -44,7 +43,6 @@ public:
 
     void setGlow(const float& glow) { _glow = glow; }
     void setGlowWidth(const float& glowWidth) { _glowWidth = glowWidth; }
-    void setGlowScale(const float& glowScale) { _glowScale = glowScale; }
 
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
@@ -74,7 +72,6 @@ private:
 
     float _glow { 0.0 };
     float _glowWidth { 0.0 };
-    float _glowScale { 1.0 };
     int _geometryCacheID;
 };
 

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -33,6 +33,7 @@ public:
     glm::vec3 getEnd() const;
     const float& getGlow() const { return _glow; }
     const float& getGlowWidth() const { return _glowWidth; }
+    const float& getGlowScale() const { return _glowScale; }
 
     // setters
     void setStart(const glm::vec3& start);
@@ -43,6 +44,7 @@ public:
 
     void setGlow(const float& glow) { _glow = glow; }
     void setGlowWidth(const float& glowWidth) { _glowWidth = glowWidth; }
+    void setGlowScale(const float& glowScale) { _glowScale = glowScale; }
 
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
@@ -72,6 +74,7 @@ private:
 
     float _glow { 0.0 };
     float _glowWidth { 0.0 };
+    float _glowScale{ 1.0 };
     int _geometryCacheID;
 };
 

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -13,8 +13,6 @@
 
 #include "Base3DOverlay.h"
 
-static const float DEFAULT_LINE_WIDTH = 0.02f;
-
 class Line3DOverlay : public Base3DOverlay {
     Q_OBJECT
     using Parent = Base3DOverlay;
@@ -72,7 +70,7 @@ private:
     glm::vec3 _direction; // in parent frame
     float _length { 1.0 }; // in parent frame
 
-    float _lineWidth { DEFAULT_LINE_WIDTH };
+    float _lineWidth { 0.0 };
     float _glow { 0.0 };
     int _geometryCacheID;
 };

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -70,7 +70,8 @@ private:
     glm::vec3 _direction; // in parent frame
     float _length { 1.0 }; // in parent frame
 
-    float _lineWidth { 0.0 };
+    const float DEFAULT_LINE_WIDTH = 0.02f;
+    float _lineWidth { DEFAULT_LINE_WIDTH };
     float _glow { 0.0 };
     int _geometryCacheID;
 };

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -13,6 +13,8 @@
 
 #include "Base3DOverlay.h"
 
+static const float DEFAULT_LINE_WIDTH = 0.02f;
+
 class Line3DOverlay : public Base3DOverlay {
     Q_OBJECT
     using Parent = Base3DOverlay;
@@ -31,8 +33,8 @@ public:
     // getters
     glm::vec3 getStart() const;
     glm::vec3 getEnd() const;
+    const float& getLineWidth() const { return _lineWidth; }
     const float& getGlow() const { return _glow; }
-    const float& getGlowWidth() const { return _glowWidth; }
 
     // setters
     void setStart(const glm::vec3& start);
@@ -41,8 +43,8 @@ public:
     void setLocalStart(const glm::vec3& localStart) { setLocalPosition(localStart); }
     void setLocalEnd(const glm::vec3& localEnd);
 
+    void setLineWidth(const float& lineWidth) { _lineWidth = lineWidth; }
     void setGlow(const float& glow) { _glow = glow; }
-    void setGlowWidth(const float& glowWidth) { _glowWidth = glowWidth; }
 
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
@@ -70,8 +72,8 @@ private:
     glm::vec3 _direction; // in parent frame
     float _length { 1.0 }; // in parent frame
 
+    float _lineWidth { DEFAULT_LINE_WIDTH };
     float _glow { 0.0 };
-    float _glowWidth { 0.0 };
     int _geometryCacheID;
 };
 

--- a/interface/src/ui/overlays/Line3DOverlay.h
+++ b/interface/src/ui/overlays/Line3DOverlay.h
@@ -74,7 +74,7 @@ private:
 
     float _glow { 0.0 };
     float _glowWidth { 0.0 };
-    float _glowScale{ 1.0 };
+    float _glowScale { 1.0 };
     int _geometryCacheID;
 };
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1868,7 +1868,7 @@ void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm
 
 
 void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
-    const glm::vec4& color, float glowIntensity, float glowWidth, float glowScale, int id) {
+    const glm::vec4& color, float glowIntensity, float glowWidth, int id) {
 
     // Disable glow lines on OSX
 #ifndef Q_OS_WIN
@@ -1931,10 +1931,10 @@ void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const
             vec4 p1;
             vec4 p2;
             vec4 color;
-            float scale;
+            float width;
         };
 
-        LineData lineData { vec4(p1, 1.0f), vec4(p2, 1.0f), color, glowScale };
+        LineData lineData { vec4(p1, 1.0f), vec4(p2, 1.0f), color, glowWidth };
         details.uniformBuffer->resize(sizeof(LineData));
         details.uniformBuffer->setSubData(0, lineData);
     }

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1868,7 +1868,7 @@ void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm
 
 
 void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
-    const glm::vec4& color, float glowIntensity, float glowWidth, int id) {
+    const glm::vec4& color, float glowIntensity, float glowWidth, float glowScale, int id) {
 
     // Disable glow lines on OSX
 #ifndef Q_OS_WIN
@@ -1931,9 +1931,10 @@ void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const
             vec4 p1;
             vec4 p2;
             vec4 color;
+            float scale;
         };
 
-        LineData lineData { vec4(p1, 1.0f), vec4(p2, 1.0f), color };
+        LineData lineData { vec4(p1, 1.0f), vec4(p2, 1.0f), color, glowScale };
         details.uniformBuffer->resize(sizeof(LineData));
         details.uniformBuffer->setSubData(0, lineData);
     }

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -314,10 +314,10 @@ public:
                     const glm::vec4& color1, const glm::vec4& color2, int id);
 
     void renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
-                    const glm::vec4& color, float glowIntensity, float glowWidth, float glowScale, int id);
+                    const glm::vec4& color, float glowIntensity, float glowWidth, int id);
 
     void renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, const glm::vec4& color, int id) 
-                       { renderGlowLine(batch, p1, p2, color, 1.0f, 0.05f, 1.0f, id); }
+                       { renderGlowLine(batch, p1, p2, color, 1.0f, 0.05f, id); }
 
     void renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id)
                           { renderDashedLine(batch, start, end, color, 0.05f, 0.025f, id); }

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -248,7 +248,7 @@ public:
         renderWireCubeInstance(args, batch, glm::vec4(color, 1.0f), pipeline);
     }
     
-    // Dynamic geometry
+    // //Dynamic geometry
     void renderShape(gpu::Batch& batch, Shape shape);
     void renderWireShape(gpu::Batch& batch, Shape shape);
     size_t getShapeTriangleCount(Shape shape);
@@ -314,10 +314,10 @@ public:
                     const glm::vec4& color1, const glm::vec4& color2, int id);
 
     void renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
-                    const glm::vec4& color, float glowIntensity, float glowWidth, int id);
+                    const glm::vec4& color, float glowIntensity, float glowWidth, float glowScale, int id);
 
     void renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2, const glm::vec4& color, int id) 
-                       { renderGlowLine(batch, p1, p2, color, 1.0f, 0.05f, id); }
+                       { renderGlowLine(batch, p1, p2, color, 1.0f, 0.05f, 1.0f, id); }
 
     void renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int id)
                           { renderDashedLine(batch, start, end, color, 0.05f, 0.025f, id); }

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -248,7 +248,7 @@ public:
         renderWireCubeInstance(args, batch, glm::vec4(color, 1.0f), pipeline);
     }
     
-    // //Dynamic geometry
+    // Dynamic geometry
     void renderShape(gpu::Batch& batch, Shape shape);
     void renderWireShape(gpu::Batch& batch, Shape shape);
     size_t getShapeTriangleCount(Shape shape);

--- a/libraries/render-utils/src/glowLine.slf
+++ b/libraries/render-utils/src/glowLine.slf
@@ -10,7 +10,6 @@
 //
 
 in vec4 _color;
-in float _scale;
 
 in float distanceFromCenter;
 out vec4 _fragColor;
@@ -22,7 +21,7 @@ void main(void) {
     float alpha = 1.0 - abs(distanceFromCenter);
     
     // Convert from a linear alpha curve to a sharp peaked one
-	alpha = _color.a * pow(alpha, 10.0/_scale);
+	alpha = _color.a * pow(alpha, 10.0);
 	
 	// Drop everything where the curve falls off to nearly nothing
     if (alpha <= 0.05) {

--- a/libraries/render-utils/src/glowLine.slf
+++ b/libraries/render-utils/src/glowLine.slf
@@ -10,8 +10,9 @@
 //
 
 in vec4 _color;
-in float distanceFromCenter;
+in float _scale;
 
+in float distanceFromCenter;
 out vec4 _fragColor;
 
 void main(void) {
@@ -21,7 +22,7 @@ void main(void) {
     float alpha = 1.0 - abs(distanceFromCenter);
     
     // Convert from a linear alpha curve to a sharp peaked one
-	alpha = _color.a * pow(alpha, 10.0);
+	alpha = _color.a * pow(alpha, 10.0/_scale);
 	
 	// Drop everything where the curve falls off to nearly nothing
     if (alpha <= 0.05) {

--- a/libraries/render-utils/src/glowLine.slv
+++ b/libraries/render-utils/src/glowLine.slv
@@ -16,14 +16,17 @@ layout(std140) uniform lineData {
     vec4 p1;
     vec4 p2;
     vec4 color;
+    float scale;
 };
 
 out vec4 _color;
+out float _scale;
 // the distance from the center in 'quad space'
 out float distanceFromCenter;
 
 void main(void) {
     _color = color;
+    _scale = scale;
 
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();

--- a/libraries/render-utils/src/glowLine.slv
+++ b/libraries/render-utils/src/glowLine.slv
@@ -16,17 +16,15 @@ layout(std140) uniform lineData {
     vec4 p1;
     vec4 p2;
     vec4 color;
-    float scale;
+    float width;
 };
 
 out vec4 _color;
-out float _scale;
 // the distance from the center in 'quad space'
 out float distanceFromCenter;
 
 void main(void) {
     _color = color;
-    _scale = scale;
 
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
@@ -42,7 +40,7 @@ void main(void) {
     // Find the vector from the eye to one of the points
     vec3 v2 = normalize(p1eye.xyz);
     // The orthogonal vector is the cross product of these two
-    vec3 orthogonal = cross(v1, v2) * 0.02;
+    vec3 orthogonal = cross(v1, v2) * width;
     
     // Deteremine which end to emit based on the vertex id (even / odd)
     vec4 eye = (0 == gl_VertexID % 2) ? p1eye : p2eye;

--- a/scripts/developer/tests/performance/rayPickPerformance.js
+++ b/scripts/developer/tests/performance/rayPickPerformance.js
@@ -96,7 +96,6 @@ function rayCastTest() {
                             color: color,
                             alpha: 1,
                             visible: visible,
-                            lineWidth: 2,
                             start: origin,
                             end: Vec3.sum(origin,Vec3.multiply(5,direction))
                         });

--- a/scripts/system/chat.js
+++ b/scripts/system/chat.js
@@ -284,8 +284,7 @@
             endParentJointIndex: yourJointIndex,
             end: yourJointPosition,
             color: identifyAvatarLineColor,
-            alpha: 1,
-            lineWidth: 1
+            alpha: 1
         };
 
         avatarIdentifiers[yourAvatarID] = identifierParams;

--- a/scripts/system/controllers/controllerModules/farActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farActionGrabEntity.js
@@ -33,7 +33,6 @@ Script.include("/~/system/libraries/Xform.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -55,7 +54,6 @@ Script.include("/~/system/libraries/Xform.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -77,7 +75,6 @@ Script.include("/~/system/libraries/Xform.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID

--- a/scripts/system/controllers/controllerModules/farActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farActionGrabEntity.js
@@ -584,6 +584,7 @@ Script.include("/~/system/libraries/controllers.js");
             renderStates: renderStates,
             faceAvatar: true,
             distanceScaleEnd: true,
+            scaleWithAvatar: true,
             defaultRenderStates: defaultRenderStates
         });
     }

--- a/scripts/system/controllers/controllerModules/farTrigger.js
+++ b/scripts/system/controllers/controllerModules/farTrigger.js
@@ -190,6 +190,7 @@ Script.include("/~/system/libraries/controllers.js");
             renderStates: renderStates,
             faceAvatar: true,
             distanceScaleEnd: true,
+            scaleWithAvatar: true,
             defaultRenderStates: defaultRenderStates
         });
 

--- a/scripts/system/controllers/controllerModules/farTrigger.js
+++ b/scripts/system/controllers/controllerModules/farTrigger.js
@@ -25,7 +25,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -47,7 +46,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -69,7 +67,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID

--- a/scripts/system/controllers/controllerModules/hudOverlayPointer.js
+++ b/scripts/system/controllers/controllerModules/hudOverlayPointer.js
@@ -31,7 +31,6 @@
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawHUDLayer: true,
         parentID: MyAvatar.SELF_ID
@@ -53,7 +52,6 @@
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawHUDLayer: true,
         parentID: MyAvatar.SELF_ID
@@ -75,7 +73,6 @@
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawHUDLayer: true,
         parentID: MyAvatar.SELF_ID

--- a/scripts/system/controllers/controllerModules/inEditMode.js
+++ b/scripts/system/controllers/controllerModules/inEditMode.js
@@ -27,7 +27,6 @@ Script.include("/~/system/libraries/utils.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -49,7 +48,6 @@ Script.include("/~/system/libraries/utils.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -71,7 +69,6 @@ Script.include("/~/system/libraries/utils.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID

--- a/scripts/system/controllers/controllerModules/inEditMode.js
+++ b/scripts/system/controllers/controllerModules/inEditMode.js
@@ -237,6 +237,7 @@ Script.include("/~/system/libraries/utils.js");
             posOffset: getGrabPointSphereOffset(this.handToController(), true),
             renderStates: renderStates,
             faceAvatar: true,
+            scaleWithAvatar: true,
             defaultRenderStates: defaultRenderStates
         });
 

--- a/scripts/system/controllers/controllerModules/overlayLaserInput.js
+++ b/scripts/system/controllers/controllerModules/overlayLaserInput.js
@@ -26,7 +26,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -48,7 +47,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -70,7 +68,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID

--- a/scripts/system/controllers/controllerModules/overlayLaserInput.js
+++ b/scripts/system/controllers/controllerModules/overlayLaserInput.js
@@ -371,6 +371,7 @@ Script.include("/~/system/libraries/controllers.js");
             posOffset: getGrabPointSphereOffset(this.handToController(), true),
             renderStates: renderStates,
             faceAvatar: true,
+            scaleWithAvatar: true,
             defaultRenderStates: defaultRenderStates
         });
 

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -153,6 +153,7 @@ Script.include("/~/system/libraries/controllers.js");
             joint: (_this.hand === RIGHT_HAND) ? "RightHand" : "LeftHand",
             filter: RayPick.PICK_ENTITIES,
             faceAvatar: true,
+            scaleWithAvatar: true,
             centerEndY: false,
             renderStates: teleportRenderStates,
             defaultRenderStates: teleportDefaultRenderStates
@@ -161,6 +162,7 @@ Script.include("/~/system/libraries/controllers.js");
             joint: (_this.hand === RIGHT_HAND) ? "RightHand" : "LeftHand",
             filter: RayPick.PICK_ENTITIES | RayPick.PICK_INCLUDE_INVISIBLE,
             faceAvatar: true,
+            scaleWithAvatar: true,
             centerEndY: false,
             renderStates: teleportRenderStates
         });
@@ -168,6 +170,7 @@ Script.include("/~/system/libraries/controllers.js");
             joint: "Avatar",
             filter: RayPick.PICK_ENTITIES,
             faceAvatar: true,
+            scaleWithAvatar: true,
             centerEndY: false,
             renderStates: teleportRenderStates,
             defaultRenderStates: teleportDefaultRenderStates
@@ -176,6 +179,7 @@ Script.include("/~/system/libraries/controllers.js");
             joint: "Avatar",
             filter: RayPick.PICK_ENTITIES | RayPick.PICK_INCLUDE_INVISIBLE,
             faceAvatar: true,
+            scaleWithAvatar: true,
             centerEndY: false,
             renderStates: teleportRenderStates
         });

--- a/scripts/system/controllers/controllerModules/webEntityLaserInput.js
+++ b/scripts/system/controllers/controllerModules/webEntityLaserInput.js
@@ -26,7 +26,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -48,7 +47,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID
@@ -70,7 +68,6 @@ Script.include("/~/system/libraries/controllers.js");
         alpha: 1,
         solid: true,
         glow: 1.0,
-        lineWidth: 5,
         ignoreRayIntersection: true, // always ignore this
         drawInFront: true, // Even when burried inside of something, show it.
         parentID: MyAvatar.SELF_ID

--- a/scripts/system/controllers/controllerModules/webEntityLaserInput.js
+++ b/scripts/system/controllers/controllerModules/webEntityLaserInput.js
@@ -88,7 +88,6 @@ Script.include("/~/system/libraries/controllers.js");
         {name: "hold", distance: DEFAULT_SEARCH_SPHERE_DISTANCE, path: holdPath}
     ];
 
-
     // triggered when stylus presses a web overlay/entity
     var HAPTIC_STYLUS_STRENGTH = 1.0;
     var HAPTIC_STYLUS_DURATION = 20.0;
@@ -452,6 +451,7 @@ Script.include("/~/system/libraries/controllers.js");
             posOffset: getGrabPointSphereOffset(this.handToController(), true),
             renderStates: renderStates,
             faceAvatar: true,
+            scaleWithAvatar: true,
             defaultRenderStates: defaultRenderStates
         });
     }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -339,7 +339,6 @@ SelectionDisplay = (function() {
         solid: grabberSolid,
         visible: false,
         dashed: false,
-        lineWidth: grabberLineWidth,
         drawInFront: true,
         borderSize: 1.4
     };
@@ -352,7 +351,6 @@ SelectionDisplay = (function() {
         solid: grabberSolid,
         visible: false,
         dashed: false,
-        lineWidth: grabberLineWidth,
         drawInFront: true,
         borderSize: 1.4
     };
@@ -365,7 +363,6 @@ SelectionDisplay = (function() {
         solid: grabberSolid,
         visible: false,
         dashed: false,
-        lineWidth: grabberLineWidth,
         drawInFront: true,
         borderSize: 1.4
     };
@@ -378,14 +375,12 @@ SelectionDisplay = (function() {
         solid: grabberSolid,
         visible: false,
         dashed: false,
-        lineWidth: grabberLineWidth,
         drawInFront: true,
         borderSize: 1.4
     };
 
     var spotLightLineProperties = {
-        color: lightOverlayColor,
-        lineWidth: 1.5
+        color: lightOverlayColor
     };
 
     var highlightBox = Overlays.addOverlay("cube", {
@@ -400,7 +395,6 @@ SelectionDisplay = (function() {
         solid: false,
         visible: false,
         dashed: true,
-        lineWidth: 2.0,
         ignoreRayIntersection: true, // this never ray intersects
         drawInFront: true
     });
@@ -416,8 +410,7 @@ SelectionDisplay = (function() {
         alpha: 1,
         solid: false,
         visible: false,
-        dashed: false,
-        lineWidth: 1.0
+        dashed: false
     });
 
     var selectionBoxes = [];
@@ -466,7 +459,6 @@ SelectionDisplay = (function() {
 
     // var normalLine = Overlays.addOverlay("line3d", {
     //                 visible: true,
-    //                 lineWidth: 2.0,
     //                 start: { x: 0, y: 0, z: 0 },
     //                 end: { x: 0, y: 0, z: 0 },
     //                 color: { red: 255, green: 255, blue: 0 },
@@ -656,7 +648,6 @@ SelectionDisplay = (function() {
 
     var xRailOverlay = Overlays.addOverlay("line3d", {
         visible: false,
-        lineWidth: 1.0,
         start: Vec3.ZERO,
         end: Vec3.ZERO,
         color: {
@@ -668,7 +659,6 @@ SelectionDisplay = (function() {
     });
     var yRailOverlay = Overlays.addOverlay("line3d", {
         visible: false,
-        lineWidth: 1.0,
         start: Vec3.ZERO,
         end: Vec3.ZERO,
         color: {
@@ -680,7 +670,6 @@ SelectionDisplay = (function() {
     });
     var zRailOverlay = Overlays.addOverlay("line3d", {
         visible: false,
-        lineWidth: 1.0,
         start: Vec3.ZERO,
         end: Vec3.ZERO,
         color: {
@@ -693,7 +682,6 @@ SelectionDisplay = (function() {
 
     var rotateZeroOverlay = Overlays.addOverlay("line3d", {
         visible: false,
-        lineWidth: 2.0,
         start: Vec3.ZERO,
         end: Vec3.ZERO,
         color: {
@@ -706,7 +694,6 @@ SelectionDisplay = (function() {
 
     var rotateCurrentOverlay = Overlays.addOverlay("line3d", {
         visible: false,
-        lineWidth: 2.0,
         start: Vec3.ZERO,
         end: Vec3.ZERO,
         color: {
@@ -1788,7 +1775,6 @@ SelectionDisplay = (function() {
                             y: distance,
                             z: 1
                         },
-                        lineWidth: 1.5,
                         rotation: rotation,
                         visible: true
                     });
@@ -1994,7 +1980,6 @@ SelectionDisplay = (function() {
                     solid: false,
                     visible: false,
                     dashed: false,
-                    lineWidth: 1.0,
                     ignoreRayIntersection: true
                 }));
         }

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -189,7 +189,6 @@ function HighlightedEntity(id, entityProperties) {
             green: 0x91,
             blue: 0x29
         },
-        lineWidth: 1.0,
         ignoreRayIntersection: true,
         drawInFront: false // Arguable. For now, let's not distract with mysterious wires around the scene.
     });

--- a/scripts/tutorials/entity_scripts/pistol.js
+++ b/scripts/tutorials/entity_scripts/pistol.js
@@ -350,8 +350,7 @@
                 end: ZERO_VECTOR,
                 color: { red: 255, green: 0, blue: 0},
                 alpha: 1,
-                visible: true,
-                lineWidth: 2
+                visible: true
             });
         },
     };

--- a/unpublishedScripts/DomainContent/Toybox/bow/bow.js
+++ b/unpublishedScripts/DomainContent/Toybox/bow/bow.js
@@ -329,7 +329,6 @@
                     y: 0,
                     z: 0
                 }, lineVectors[0]],
-                lineWidth: 5,
                 color: this.stringData.currentColor
             });
 
@@ -339,7 +338,6 @@
                     y: 0,
                     z: 0
                 }, lineVectors[1]],
-                lineWidth: 5,
                 color: this.stringData.currentColor
             });
 

--- a/unpublishedScripts/DomainContent/Toybox/bow/createBow.js
+++ b/unpublishedScripts/DomainContent/Toybox/bow/createBow.js
@@ -125,7 +125,6 @@ function createPreNotchString() {
             y: 0,
             z: 0
         }, downOffset)],
-        lineWidth: 5,
         color: {
             red: 255,
             green: 255,

--- a/unpublishedScripts/DomainContent/Toybox/hiddenEntityReset.js
+++ b/unpublishedScripts/DomainContent/Toybox/hiddenEntityReset.js
@@ -450,7 +450,6 @@
                         y: 0,
                         z: 0
                     }, downOffset)],
-                    lineWidth: 5,
                     color: {
                         red: 255,
                         green: 255,

--- a/unpublishedScripts/DomainContent/Toybox/masterReset.js
+++ b/unpublishedScripts/DomainContent/Toybox/masterReset.js
@@ -427,7 +427,6 @@ MasterReset = function() {
                     y: 0,
                     z: 0
                 }, downOffset)],
-                lineWidth: 5,
                 color: {
                     red: 255,
                     green: 255,

--- a/unpublishedScripts/DomainContent/Toybox/pistol/pistol.js
+++ b/unpublishedScripts/DomainContent/Toybox/pistol/pistol.js
@@ -346,8 +346,7 @@
                 end:  { x: 0, y: 0, z: 0 },
                 color: COLORS.RED,
                 alpha: 1,
-                visible: true,
-                lineWidth: 2
+                visible: true
             });
         },
     };

--- a/unpublishedScripts/marketplace/bow/bow.js
+++ b/unpublishedScripts/marketplace/bow/bow.js
@@ -266,7 +266,6 @@
                     dimensions: { "x": 5, "y": 5, "z": 5 },
                     ignoreForCollisions: 1,
                     linePoints: [ { "x": 0, "y": 0, "z": 0 }, { "x": 0, "y": -1.2, "z": 0 } ],
-                    lineWidth: 5,
                     name: STRING_NAME,
                     parentID: this.entityID,
                     localPosition: { "x": 0, "y": 0.6, "z": 0.1 },
@@ -287,7 +286,6 @@
         resetStringToIdlePosition: function() {
             Entities.editEntity(this.stringID, {
                 linePoints: [ { "x": 0, "y": 0, "z": 0 }, { "x": 0, "y": -1.2, "z": 0 } ],
-                lineWidth: 5,
                 localPosition: { "x": 0, "y": 0.6, "z": 0.1 },
                 localRotation: { "w": 1, "x": 0, "y": 0, "z": 0 },
             });

--- a/unpublishedScripts/marketplace/laser/laserPointerApp.js
+++ b/unpublishedScripts/marketplace/laser/laserPointerApp.js
@@ -99,7 +99,6 @@
                 lifetime: 360,
                 type: 'Line',
                 glow: 1.0,
-                lineWidth: 5,
                 alpha: 0.5,
                 ignoreRayIntersection: true,
                 drawInFront: true,

--- a/unpublishedScripts/marketplace/shapes/modules/laser.js
+++ b/unpublishedScripts/marketplace/shapes/modules/laser.js
@@ -72,7 +72,6 @@ Laser = function (side) {
     }
 
     laserLine = Overlays.addOverlay("line3d", {
-        lineWidth: 5,
         alpha: 1.0,
         glow: 1.0,
         ignoreRayIntersection: true,

--- a/unpublishedScripts/marketplace/shapes/modules/laser.js
+++ b/unpublishedScripts/marketplace/shapes/modules/laser.js
@@ -150,7 +150,6 @@ Laser = function (side) {
     }
 
     function update(hand) {
-        return;
         var handPosition,
             handOrientation,
             deltaOrigin,

--- a/unpublishedScripts/marketplace/shapes/modules/laser.js
+++ b/unpublishedScripts/marketplace/shapes/modules/laser.js
@@ -150,6 +150,7 @@ Laser = function (side) {
     }
 
     function update(hand) {
+        return;
         var handPosition,
             handOrientation,
             deltaOrigin,

--- a/unpublishedScripts/marketplace/shortbow/bow/bow.js
+++ b/unpublishedScripts/marketplace/shortbow/bow/bow.js
@@ -408,7 +408,6 @@ function getControllerLocation(controllerHand) {
                     dimensions: { "x": 5, "y": 5, "z": 5 },
                     ignoreForCollisions: 1,
                     linePoints: [ { "x": 0, "y": 0, "z": 0 }, { "x": 0, "y": -1.2, "z": 0 } ],
-                    lineWidth: 5,
                     color: { red: 153, green: 102, blue: 51 },
                     name: STRING_NAME,
                     parentID: this.entityID,
@@ -430,7 +429,6 @@ function getControllerLocation(controllerHand) {
         resetStringToIdlePosition: function() {
             Entities.editEntity(this.stringID, {
                 linePoints: [ { "x": 0, "y": 0, "z": 0 }, { "x": 0, "y": -1.2, "z": 0 } ],
-                lineWidth: 5,
                 localPosition: { "x": 0, "y": 0.6, "z": 0.1 },
                 localRotation: { "w": 1, "x": 0, "y": 0, "z": 0 },
             });


### PR DESCRIPTION
This PR creates the option for making the lasers scale with the avatar. 
  
https://highfidelity.fogbugz.com/f/cases/7587
...

## TEST PLAN
- Change the size of your avatar and make it big.
- Use the lasers. They should look scaled accordingly. (no ultra thin lasers)
- Change the size of your avatar and make it small.
- Use the lasers. They should look scaled accordingly. (no ultra thick lasers)
- Close HF and edit the file \scripts\system\controllers\controllerModules\FarActionGrabEntity.js
- Add a **lineWidth** parameter to the **fullPath** object `lineWidth: 1.1,`
- Save and restart HF. Now the trigger should project a thick laser. (The tablet should be closed)
- Make sure that the thick laser scale with the avatar.
- Look for the **scaleWithAvatar** parameter in the file _\scripts\system\controllers\controllerModules\FarActionGrabEntity.js_ and change it to false, or erase it.
- Save and restart HF. Now the lasers should not scale with the avatar.