### PR TITLE
[Case 6569]: Silent failure is possible during Model Creation

### DIFF
--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -128,6 +128,7 @@ Rectangle {
                     Text {
                         id: text2
                         width: 160
+                        x: dynamic.width / 2
                         color: "#ffffff"
                         text: qsTr("Models with automatic collisions set to 'Exact' cannot be dynamic, and should not be used as floors")
                         wrapMode: Text.WordWrap
@@ -190,10 +191,10 @@ Rectangle {
                     width: 200
                     height: 400
                     spacing: 5
-                    
-                    anchors {
-                        rightMargin: 15
-                    }
+
+                    anchors.horizontalCenter: column3.horizontalCenter
+                    anchors.horizontalCenterOffset: -20
+
                     Button {
                         id: button1
                         text: qsTr("Add")

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -11,8 +11,11 @@
 
 import QtQuick 2.5
 import QtQuick.Controls 1.4
+import QtQuick.Dialogs 1.2 as OriginalDialogs
+
 import "../../styles-uit"
 import "../../controls-uit"
+import "../dialogs"
 
 Rectangle {
     id: newModelDialog
@@ -24,6 +27,15 @@ Rectangle {
     property bool keyboardEnabled: false
     property bool punctuationMode: false
     property bool keyboardRasied: false
+
+    function errorMessageBox(message) {
+        return desktop.messageBox({
+            icon: hifi.icons.warning,
+            defaultButton: OriginalDialogs.StandardButton.Ok,
+            title: "Error",
+            text: message
+        });
+    }
 
     Item {
         id: column1
@@ -98,7 +110,6 @@ Rectangle {
                 CheckBox {
                     id: dynamic
                     text: qsTr("Dynamic")
-                    
                 }
 
                 Row {
@@ -139,15 +150,39 @@ Rectangle {
 
                 ComboBox {
                     id: collisionType
+
+                    property int priorIndex: 0
+                    property string staticMeshCollisionText: "Exact - All polygons"
+                    property var collisionArray: ["No Collision",
+                                                  "Basic - Whole model",
+                                                  "Good - Sub-meshes",
+                                                  staticMeshCollisionText, 
+                                                  "Box", 
+                                                  "Sphere"]
+
                     width: 200
                     z: 100
                     transformOrigin: Item.Center
-                    model: ["No Collision",
-                            "Basic - Whole model",
-                            "Good - Sub-meshes",
-                            "Exact - All polygons", 
-                            "Box", 
-                            "Sphere"]
+                    model: collisionArray
+
+                    onCurrentIndexChanged: {
+                        if (collisionArray[currentIndex] === staticMeshCollisionText) {
+                            
+                            if (dynamic.checked) {
+                                currentIndex = priorIndex;
+
+                                errorMessageBox("Models with Automatic Collisions set to \"" + staticMeshCollisionText + "\" cannot be dynamic.");
+                                //--EARLY EXIT--( Can't have a static mesh model that's dynamic )
+                                return;
+                            }
+
+                            dynamic.enabled = false;
+                        } else {
+                            dynamic.enabled = true;
+                        }
+
+                        priorIndex = currentIndex;
+                    }
                 }
 
                 Row {

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -172,7 +172,8 @@ Rectangle {
                             if (dynamic.checked) {
                                 currentIndex = priorIndex;
 
-                                errorMessageBox("Models with Automatic Collisions set to \"" + staticMeshCollisionText + "\" cannot be dynamic.");
+                                errorMessageBox("Models with Automatic Collisions set to \"" 
+                                                    + staticMeshCollisionText + "\" cannot be dynamic.");
                                 //--EARLY EXIT--( Can't have a static mesh model that's dynamic )
                                 return;
                             }


### PR DESCRIPTION
[FogBugz Case 6569](https://highfidelity.fogbugz.com/f/cases/6569/Create-Model-allows-setting-dynamic-and-Exact-All-Polygons-resulting-in-silent-fail): When creating a model, it was possible to elect Exact collision with the dynamic
    property even though this combination is prohibited.  This combination would silently
    fail rather than notifying the user of the error.

This implements safeguards against the invalid combination:

- If the user elects the Exact collision type and the dynamic field is unchecked, then dynamic field is disabled.
- If the user elects a different collision type and the dynamic filed is unchecked, then the dynamic field is enabled.
- If the user has checked the dynamic field and subsequently elects the Exact collision type, then the selection is void and the previous collision selection is retained; however, an error dialog is presented informing the user of the error.

Also fixes a layout issue which resulted in the Cancel button getting cutoff by the window's edge.

**Testing Plan:**
* Open the Create Menu
* Select the Model option within the Create Tab
* Part 1:
    * Observe that the Cancel button isn't cutoff at the edge of the screen.
* Part 2:
    * Check the Dynamic checkbox (it should turn blue when checked).
    * From the Automatic Collision Types selection list, select a type **_other than_** "Exact - All polygons".
    * Observe that the selection is allowed.
    * From the Automatic Collision Types selection list, select the type "Exact - All polygons".
    * Observe that the selection remains is unchanged, the "Exact - All polygons" selection is blocked.
    * Observe error message indicating why the selection failed.
    * Uncheck the Dynamic checkbox (the blue color/highlight should go away).
    * From the Automatic Collision Types selection list, select the type "Exact - All polygons".
    * Observe that the selection of "Exact - All polygons" selection is allowed.
    * With "Exact - All polygons" still selected, attempt to check the Dynamic checkbox.
    * Observe that the Dynamic checkbox is disabled, it can't be checked.
    * From the Automatic Collision Types selection list, select a type **_other than_** "Exact - All polygons".
    * Observe that the selection is allowed.
    * Observe that the Dynamic checkbox is enabled, and can be checked if desired.







