### PR TITLE
add skeleton scale change signal so scripts can detect scaling change

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2189,6 +2189,7 @@ void MyAvatar::clampScaleChangeToDomainLimits(float desiredScale) {
 
     setTargetScale(clampedTargetScale);
     qCDebug(interfaceapp, "Changed scale to %f", (double)_targetScale);
+    emit(scaleChanged());
 }
 
 float MyAvatar::getDomainMinScale() {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -620,6 +620,7 @@ signals:
     void dominantHandChanged(const QString& hand);
     void sensorToWorldScaleChanged(float sensorToWorldScale);
     void attachmentsChanged();
+    void scaleChanged();
 
 private:
 


### PR DESCRIPTION
Scripts can connect to this signal to update something based on an avatar scale change. Example: the distance required to detach a wearable will be different based on arm span, which could change as the user scales an avatar.

_To test_
Open up the console and paste in: `MyAvatar.scaleChanged.connect(function(){ print("Scale has changed")})`, then hit enter.
Scale your avatar
Expected: When you change your avatar scale, "Scale has changed" should print

Unrelated to this PR -- when you repeatedly hit the = it resizes to default and the function from which the signal is emitted is called each time, so you may see the signal duplicated (once per time the function runs, which is expected)

@nimisha20 -- This would have a docs update for the MyAvatar API