### PR TITLE
Revert 11728 and fix marketplace JS injection - should revisit

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -89,7 +89,7 @@
             window.location = "https://clara.io/library?gameCheck=true&public=true";
         });
         $('#exploreHifiMarketplace').on('click', function () {
-            window.location = metaverseServerURL + "/marketplace";
+            window.location = "http://www.highfidelity.com/marketplace";
         });
     }
 
@@ -612,9 +612,9 @@
         var HIFI_ITEM_PAGE = 3;
         var pageType = DIRECTORY;
 
-        if (location.href.indexOf(metaverseServerURL + "/") !== -1) { pageType = HIFI; }
+        if (location.href.indexOf("highfidelity.com/") !== -1) { pageType = HIFI; }
         if (location.href.indexOf("clara.io/") !== -1) { pageType = CLARA; }
-        if (location.href.indexOf(metaverseServerURL + "/marketplace/items/") !== -1) { pageType = HIFI_ITEM_PAGE; }
+        if (location.href.indexOf("highfidelity.com/marketplace/items/") !== -1) { pageType = HIFI_ITEM_PAGE; }
 
         injectCommonCode(pageType === DIRECTORY);
         switch (pageType) {


### PR DESCRIPTION
It appears as though #11728 is actually not working, and it was merged before being tested.

**Test Plan:**
1. Enable Commerce
2. Set up your Wallet
3. Open the MARKET app
4. Verify that you see "My Purchases" at the top of the page