### PR TITLE
Remove hack for missing inttypes.h header on VS2010

### DIFF
--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -15,21 +15,7 @@
 #include <string>
 #include <memory>
 #include <queue>
-
-/* VS2010 defines stdint.h, but not inttypes.h */
-#if defined(_MSC_VER)
-typedef signed char  int8_t;
-typedef signed short int16_t;
-typedef signed int   int32_t;
-typedef unsigned char  uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int   uint32_t;
-typedef signed long long   int64_t;
-typedef unsigned long long quint64;
-#define PRId64 "I64d"
-#else
 #include <inttypes.h>
-#endif
 #include <vector>
 
 #include <glm/glm.hpp>

--- a/libraries/octree/src/OctreeQuery.h
+++ b/libraries/octree/src/OctreeQuery.h
@@ -12,21 +12,7 @@
 #ifndef hifi_OctreeQuery_h
 #define hifi_OctreeQuery_h
 
-/* VS2010 defines stdint.h, but not inttypes.h */
-#if defined(_MSC_VER)
-typedef signed char  int8_t;
-typedef signed short int16_t;
-typedef signed int   int32_t;
-typedef unsigned char  uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int   uint32_t;
-typedef signed long long   int64_t;
-typedef unsigned long long quint64;
-#define PRId64 "I64d"
-#else
 #include <inttypes.h>
-#endif
-
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>


### PR DESCRIPTION
This hack is no longer needed for more recent versions of the microsoft compiler.