### PR TITLE
6944 Avatar scale is preserved across domains

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -135,7 +135,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     connect(&domainHandler, &DomainHandler::settingsReceived, this, &MyAvatar::restrictScaleFromDomainSettings);
 
     // when we leave a domain we lift whatever restrictions that domain may have placed on our scale
-    connect(&domainHandler, &DomainHandler::disconnectedFromDomain, this, &MyAvatar::clearScaleRestriction);
+    connect(&domainHandler, &DomainHandler::disconnectedFromDomain, this, &MyAvatar::leaveDomain);
 
     _bodySensorMatrix = deriveBodyFromHMDSensor();
 
@@ -2276,6 +2276,18 @@ void MyAvatar::restrictScaleFromDomainSettings(const QJsonObject& domainSettings
 
     setModelScale(_targetScale);
     rebuildCollisionShape();
+    settings.endGroup();
+}
+
+void MyAvatar::leaveDomain() {
+    clearScaleRestriction();
+    saveAvatarScale();
+}
+
+void MyAvatar::saveAvatarScale() {
+    Settings settings;
+    settings.beginGroup("Avatar");
+    settings.setValue("scale", _targetScale);
     settings.endGroup();
 }
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -561,6 +561,8 @@ public slots:
     float getDomainMinScale();
     float getDomainMaxScale();
 
+    void leaveDomain();
+
     void setGravity(float gravity);
     float getGravity();
 
@@ -637,6 +639,8 @@ private:
     bool isMyAvatar() const override { return true; }
     virtual int parseDataFromBuffer(const QByteArray& buffer) override;
     virtual glm::vec3 getSkeletonPosition() const override;
+
+    void saveAvatarScale();
 
     glm::vec3 getScriptedMotorVelocity() const { return _scriptedMotorVelocity; }
     float getScriptedMotorTimescale() const { return _scriptedMotorTimescale; }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -561,8 +561,6 @@ public slots:
     float getDomainMinScale();
     float getDomainMaxScale();
 
-    void leaveDomain();
-
     void setGravity(float gravity);
     float getGravity();
 
@@ -623,6 +621,9 @@ signals:
     void sensorToWorldScaleChanged(float sensorToWorldScale);
     void attachmentsChanged();
     void scaleChanged();
+
+private slots:
+    void leaveDomain();
 
 private:
 


### PR DESCRIPTION
This PR solve the problem of avatar scale across domains.
Now the scale of the avatar is saved on preferences before changing domains. 
  
https://highfidelity.fogbugz.com/f/cases/6944
...

## TEST PLAN
- Change the size of your avatar.
- Change domains (the Avatar should appear in the new domain with the same scale).
- Reset the size of your avatar and repeat the process several times.