### PR TITLE
Fix overlay flash on visibility and position change

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -280,13 +280,16 @@ void Base3DOverlay::update(float duration) {
         if (render::Item::isValidID(itemID)) {
             // Capture the render transform value in game loop before
             auto latestTransform = evalRenderTransform();
+            bool latestVisible = getVisible();
             _renderTransformDirty = false;
             render::ScenePointer scene = qApp->getMain3DScene();
             render::Transaction transaction;
-            transaction.updateItem<Overlay>(itemID, [latestTransform](Overlay& data) {
+            transaction.updateItem<Overlay>(itemID, [latestTransform, latestVisible](Overlay& data) {
                 auto overlay3D = dynamic_cast<Base3DOverlay*>(&data);
                 if (overlay3D) {
+                    // TODO: overlays need to communicate all relavent render properties through transactions
                     overlay3D->setRenderTransform(latestTransform);
+                    overlay3D->setRenderVisible(latestVisible);
                 }
             });
             scene->enqueueTransaction(transaction);
@@ -304,6 +307,10 @@ Transform Base3DOverlay::evalRenderTransform() {
 
 void Base3DOverlay::setRenderTransform(const Transform& transform) {
     _renderTransform = transform;
+}
+
+void Base3DOverlay::setRenderVisible(bool visible) {
+    _renderVisible = visible;
 }
 
 SpatialParentTree* Base3DOverlay::getParentTree() const {

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -76,8 +76,10 @@ protected:
     virtual void parentDeleted() override;
 
     mutable Transform _renderTransform;
+    mutable bool _renderVisible;
     virtual Transform evalRenderTransform();
     virtual void setRenderTransform(const Transform& transform);
+    void setRenderVisible(bool visible);
     const Transform& getRenderTransform() const { return _renderTransform; }
 
     float _lineWidth;

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -59,7 +59,7 @@ Circle3DOverlay::~Circle3DOverlay() {
     }
 }
 void Circle3DOverlay::render(RenderArgs* args) {
-    if (!_visible) {
+    if (!_renderVisible) {
         return; // do nothing if we're not visible
     }
 
@@ -259,7 +259,7 @@ void Circle3DOverlay::render(RenderArgs* args) {
 }
 
 const render::ShapeKey Circle3DOverlay::getShapeKey() {
-    auto builder = render::ShapeKey::Builder().withoutCullFace().withUnlit();
+    auto builder = render::ShapeKey::Builder().withoutCullFace();
     if (isTransparent()) {
         builder.withTranslucent();
     }

--- a/interface/src/ui/overlays/Cube3DOverlay.cpp
+++ b/interface/src/ui/overlays/Cube3DOverlay.cpp
@@ -44,7 +44,7 @@ Cube3DOverlay::~Cube3DOverlay() {
 }
 
 void Cube3DOverlay::render(RenderArgs* args) {
-    if (!_visible) {
+    if (!_renderVisible) {
         return; // do nothing if we're not visible
     }
 

--- a/interface/src/ui/overlays/Grid3DOverlay.cpp
+++ b/interface/src/ui/overlays/Grid3DOverlay.cpp
@@ -53,7 +53,7 @@ AABox Grid3DOverlay::getBounds() const {
 }
 
 void Grid3DOverlay::render(RenderArgs* args) {
-    if (!_visible) {
+    if (!_renderVisible) {
         return; // do nothing if we're not visible
     }
 

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -60,7 +60,7 @@ void Image3DOverlay::update(float deltatime) {
 }
 
 void Image3DOverlay::render(RenderArgs* args) {
-    if (!_visible || !getParentVisible() || !_texture || !_texture->isLoaded()) {
+    if (!_renderVisible || !getParentVisible() || !_texture || !_texture->isLoaded()) {
         return;
     }
 

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -123,7 +123,7 @@ AABox Line3DOverlay::getBounds() const {
 }
 
 void Line3DOverlay::render(RenderArgs* args) {
-    if (!_visible) {
+    if (!_renderVisible) {
         return; // do nothing if we're not visible
     }
 

--- a/interface/src/ui/overlays/Rectangle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.cpp
@@ -23,7 +23,6 @@ Rectangle3DOverlay::Rectangle3DOverlay() :
     for (size_t i = 0; i < _rectGeometryIds.size(); ++i) {
         _rectGeometryIds[i] = geometryCache->allocateID();
     }
-    qDebug() << "Building rect3d overlay";
 }
 
 Rectangle3DOverlay::Rectangle3DOverlay(const Rectangle3DOverlay* rectangle3DOverlay) :
@@ -34,11 +33,9 @@ Rectangle3DOverlay::Rectangle3DOverlay(const Rectangle3DOverlay* rectangle3DOver
     for (size_t i = 0; i < _rectGeometryIds.size(); ++i) {
         _rectGeometryIds[i] = geometryCache->allocateID();
     }
-    qDebug() << "Building rect3d overlay";
 }
 
 Rectangle3DOverlay::~Rectangle3DOverlay() {
-    qDebug() << "Destryoing rect3d overlay";
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (geometryCache) {
         geometryCache->releaseID(_geometryCacheID);
@@ -49,7 +46,7 @@ Rectangle3DOverlay::~Rectangle3DOverlay() {
 }
 
 void Rectangle3DOverlay::render(RenderArgs* args) {
-    if (!_visible) {
+    if (!_renderVisible) {
         return; // do nothing if we're not visible
     }
 
@@ -58,18 +55,11 @@ void Rectangle3DOverlay::render(RenderArgs* args) {
     const float MAX_COLOR = 255.0f;
     glm::vec4 rectangleColor(color.red / MAX_COLOR, color.green / MAX_COLOR, color.blue / MAX_COLOR, alpha);
 
-    glm::vec3 position = getPosition();
-    glm::vec2 dimensions = getDimensions();
-    glm::vec2 halfDimensions = dimensions * 0.5f;
-    glm::quat rotation = getRotation();
-
     auto batch = args->_batch;
-
     if (batch) {
-        // FIXME Start using the _renderTransform instead of calling for Transform and Dimensions from here, do the custom things needed in evalRenderTransform()
-        Transform transform;
-        transform.setTranslation(position);
-        transform.setRotation(rotation);
+        Transform transform = getRenderTransform();
+        glm::vec2 halfDimensions = transform.getScale() * 0.5f;
+        transform.setScale(1.0f);
 
         batch->setModelTransform(transform);
         auto geometryCache = DependencyManager::get<GeometryCache>();
@@ -124,8 +114,3 @@ void Rectangle3DOverlay::setProperties(const QVariantMap& properties) {
 Rectangle3DOverlay* Rectangle3DOverlay::createClone() const {
     return new Rectangle3DOverlay(this);
 }
-
-Transform Rectangle3DOverlay::evalRenderTransform() {
-    return getTransform();
-}
-

--- a/interface/src/ui/overlays/Rectangle3DOverlay.h
+++ b/interface/src/ui/overlays/Rectangle3DOverlay.h
@@ -29,9 +29,6 @@ public:
 
     virtual Rectangle3DOverlay* createClone() const override;
 
-protected:
-    Transform evalRenderTransform() override;
-
 private:
     int _geometryCacheID;
     std::array<int, 4> _rectGeometryIds;

--- a/interface/src/ui/overlays/Shape3DOverlay.cpp
+++ b/interface/src/ui/overlays/Shape3DOverlay.cpp
@@ -24,7 +24,7 @@ Shape3DOverlay::Shape3DOverlay(const Shape3DOverlay* Shape3DOverlay) :
 }
 
 void Shape3DOverlay::render(RenderArgs* args) {
-    if (!_visible) {
+    if (!_renderVisible) {
         return; // do nothing if we're not visible
     }
 

--- a/interface/src/ui/overlays/Sphere3DOverlay.cpp
+++ b/interface/src/ui/overlays/Sphere3DOverlay.cpp
@@ -27,7 +27,7 @@ Sphere3DOverlay::Sphere3DOverlay(const Sphere3DOverlay* Sphere3DOverlay) :
 }
 
 void Sphere3DOverlay::render(RenderArgs* args) {
-    if (!_visible) {
+    if (!_renderVisible) {
         return; // do nothing if we're not visible
     }
 

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -92,7 +92,7 @@ void Text3DOverlay::update(float deltatime) {
 }
 
 void Text3DOverlay::render(RenderArgs* args) {
-    if (!_visible || !getParentVisible()) {
+    if (!_renderVisible || !getParentVisible()) {
         return; // do nothing if we're not visible
     }
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -268,7 +268,7 @@ Q_INVOKABLE int Web3DOverlay::deviceIdByTouchPoint(qreal x, qreal y) {
 }
 
 void Web3DOverlay::render(RenderArgs* args) {
-    if (!_visible || !getParentVisible()) {
+    if (!_renderVisible || !getParentVisible()) {
         return;
     }
 


### PR DESCRIPTION
Overlays need to convey the properties that they use for rendering in transactions.  This fixes visibility specifically, but every overlay has lots of other properties that also need to be fixed.

- Run [this](https://gist.githubusercontent.com/SamGondelman/b9867075dbe8119c024eab77ce3682f4/raw/65e4794116ac62c5cb0143038094332ce9e1fbb5/OverlayVisibleMoveTest.js)
- Press spacebar repeatedly.  The overlays will flash on and off, but should never appear in any other position.  In master, they would flash for a frame 1 meter above where they appear.
- The circle overlay should be lit properly, like the other overlays.
- The rectangle overlay should be the same size as text overlay, and the same size as it is on master with the same script.