### PR TITLE
Second fix to null file path return (specific to music visualizer) 

### DIFF
--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -720,7 +720,7 @@ QString OffscreenUi::fileDialog(const QVariantMap& properties) {
         return QString();
     }
     qCDebug(uiLogging) << result.toString();
-    return result.toUrl().toLocalFile();
+    return result.toString();
 }
 
 ModalDialogListener* OffscreenUi::fileDialogAsync(const QVariantMap& properties) {


### PR DESCRIPTION
The first [PR](https://github.com/highfidelity/hifi/pull/11767) was altered, so this is a new PR with the same change.

Test plan:

1. Download music visualizer app: https://hifi-content.s3.amazonaws.com/elisalj/music_visualizer/musicVisualizer.js and test sound: https://hifi-content.s3.amazonaws.com/elisalj/music_visualizer/test_sounds/UpbeatFunk_mono.wav
2. Open the app and click "Choose Audio File"
3. Select "Upbeat Funk"
4. Click on any particle, you should hear the music and the particle should "dance"

Additional testing:
5. Open up the "Running Scripts" dialog (Ctrl + J)
6. Select "From Disk" and choose a script to load; script should load in (visible in the Running Scripts list)
7. Select "Edit" from the menu bar and select "Open and Run Script File" from the drop-down and choose a script; this should also load in