### PR TITLE
Fix laser end not disappearing

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -265,7 +265,7 @@ void Base3DOverlay::locationChanged(bool tellPhysics) {
     SpatiallyNestable::locationChanged(tellPhysics);
 
     // Force the actual update of the render transform through the notify call
-    notifyRenderTransformChange();
+    notifyRenderVariableChange();
 }
 
 void Base3DOverlay::parentDeleted() {
@@ -275,13 +275,13 @@ void Base3DOverlay::parentDeleted() {
 void Base3DOverlay::update(float duration) {
     // In Base3DOverlay, if its location or bound changed, the renderTrasnformDirty flag is true.
     // then the correct transform used for rendering is computed in the update transaction and assigned.
-    if (_renderTransformDirty) {
+    if (_renderVariableDirty) {
         auto itemID = getRenderItemID();
         if (render::Item::isValidID(itemID)) {
             // Capture the render transform value in game loop before
             auto latestTransform = evalRenderTransform();
             bool latestVisible = getVisible();
-            _renderTransformDirty = false;
+            _renderVariableDirty = false;
             render::ScenePointer scene = qApp->getMain3DScene();
             render::Transaction transaction;
             transaction.updateItem<Overlay>(itemID, [latestTransform, latestVisible](Overlay& data) {
@@ -297,8 +297,8 @@ void Base3DOverlay::update(float duration) {
     }
 }
 
-void Base3DOverlay::notifyRenderTransformChange() const {
-    _renderTransformDirty = true;
+void Base3DOverlay::notifyRenderVariableChange() const {
+    _renderVariableDirty = true;
 }
 
 Transform Base3DOverlay::evalRenderTransform() {
@@ -317,4 +317,9 @@ SpatialParentTree* Base3DOverlay::getParentTree() const {
     auto entityTreeRenderer = qApp->getEntities();
     EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
     return entityTree.get();
+}
+
+void Base3DOverlay::setVisible(bool visible) {
+    Parent::setVisible(visible);
+    notifyRenderVariableChange();
 }

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -18,10 +18,13 @@
 
 class Base3DOverlay : public Overlay, public SpatiallyNestable {
     Q_OBJECT
+    using Parent = Overlay;
 
 public:
     Base3DOverlay();
     Base3DOverlay(const Base3DOverlay* base3DOverlay);
+
+    void setVisible(bool visible) override;
 
     virtual OverlayID getOverlayID() const override { return OverlayID(getID().toString()); }
     void setOverlayID(OverlayID overlayID) override { setID(overlayID); }
@@ -56,7 +59,7 @@ public:
 
     void update(float deltatime) override;
 
-    void notifyRenderTransformChange() const;
+    void notifyRenderVariableChange() const;
 
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
@@ -89,7 +92,7 @@ protected:
     bool _drawInFront;
     bool _drawHUDLayer;
     bool _isGrabbable { false };
-    mutable bool _renderTransformDirty{ true };
+    mutable bool _renderVariableDirty { true };
 
     QString _name;
 };

--- a/interface/src/ui/overlays/Line3DOverlay.cpp
+++ b/interface/src/ui/overlays/Line3DOverlay.cpp
@@ -96,7 +96,7 @@ void Line3DOverlay::setEnd(const glm::vec3& end) {
     } else {
         _direction = glm::vec3(0.0f);
     }
-    notifyRenderTransformChange();
+    notifyRenderVariableChange();
 }
 
 void Line3DOverlay::setLocalEnd(const glm::vec3& localEnd) {

--- a/interface/src/ui/overlays/Planar3DOverlay.cpp
+++ b/interface/src/ui/overlays/Planar3DOverlay.cpp
@@ -37,7 +37,7 @@ AABox Planar3DOverlay::getBounds() const {
 
 void Planar3DOverlay::setDimensions(const glm::vec2& value) {
     _dimensions = value;
-    notifyRenderTransformChange();
+    notifyRenderVariableChange();
 }
 
 void Planar3DOverlay::setProperties(const QVariantMap& properties) {

--- a/interface/src/ui/overlays/Volume3DOverlay.cpp
+++ b/interface/src/ui/overlays/Volume3DOverlay.cpp
@@ -28,7 +28,7 @@ AABox Volume3DOverlay::getBounds() const {
 
 void Volume3DOverlay::setDimensions(const glm::vec3& value) {
     _localBoundingBox.setBox(-value / 2.0f, value);
-    notifyRenderTransformChange();
+    notifyRenderVariableChange();
 }
 
 void Volume3DOverlay::setProperties(const QVariantMap& properties) {


### PR DESCRIPTION
Caused by https://github.com/highfidelity/hifi/pull/11786

Need to set dirty flag on visibility change,

To test:
- Use the hand lasers.
- When you let go of the trigger, the sphere at the end of the laser should disappear properly.