### PR TITLE
9032 - Current display mode can be deselected in the toolbar/tablet menu

### DIFF
--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -51,19 +51,23 @@ FocusScope {
 
     // The VR version of the primary menu
     property var rootMenu: Menu { 
+        id: rootMenuId
         objectName: "rootMenu" 
 
-        // for some reasons it is not possible to use just '({})' here as it gets empty when passed to TableRoot/DesktopRoot
-        property var exclusionGroupsByMenuItem : ListModel {}
+        property var exclusionGroups: ({});
+        property Component exclusiveGroupMaker: Component {
+            ExclusiveGroup {
+            }
+        }
 
-        function addExclusionGroup(menuItem, exclusionGroup)
-        {
-            exclusionGroupsByMenuItem.append(
-                {
-                    'menuItem' : menuItem.toString(), 
-                    'exclusionGroup' : exclusionGroup.toString()
-                }
-            );
+        function addExclusionGroup(qmlAction, exclusionGroup) {
+
+            var exclusionGroupId = exclusionGroup.toString();
+            if(!exclusionGroups[exclusionGroupId]) {
+                exclusionGroups[exclusionGroupId] = exclusiveGroupMaker.createObject(rootMenuId);
+            }
+
+            qmlAction.exclusiveGroup = exclusionGroups[exclusionGroupId]
         }
     }
 

--- a/interface/resources/qml/hifi/tablet/TabletMenuItem.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuItem.qml
@@ -40,37 +40,29 @@ Item {
 
         CheckBox {
             id: checkbox
-            // FIXME: Should use radio buttons if source.exclusiveGroup.
+
             width: 20
             visible: source !== null ?
                          source.visible && source.type === 1 && source.checkable && !source.exclusiveGroup :
                          false
-            checked: setChecked()
-            function setChecked() {
-                if (!source || source.type !== 1 || !source.checkable) {
-                    return false;
-                }
-                // FIXME this works for native QML menus but I don't think it will
-                // for proxied QML menus
-                return source.checked;
+
+            Binding on checked {
+                value: source.checked;
+                when: source && source.type === 1 && source.checkable && !source.exclusiveGroup;
             }
         }
 
         RadioButton {
             id: radiobutton
-            // FIXME: Should use radio buttons if source.exclusiveGroup.
+
             width: 20
             visible: source !== null ?
                          source.visible && source.type === 1 && source.checkable && source.exclusiveGroup :
                          false
-            checked: setChecked()
-            function setChecked() {
-                if (!source || source.type !== 1 || !source.checkable) {
-                    return false;
-                }
-                // FIXME this works for native QML menus but I don't think it will
-                // for proxied QML menus
-                return source.checked;
+
+            Binding on checked {
+                value: source.checked;
+                when: source && source.type === 1 && source.checkable && source.exclusiveGroup;
             }
         }
     }

--- a/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
@@ -66,7 +66,6 @@ Item {
 
         function toModel(items, newMenu) {
             var result = modelMaker.createObject(tabletMenu);
-            var exclusionGroups = {};
 
             for (var i = 0; i < items.length; ++i) {
                 var item = items[i];
@@ -78,28 +77,6 @@ Item {
                     if (item.text !== "Users Online") {
                         result.append({"name": item.text, "item": item})
                     }
-
-                    for(var j = 0; j < tabletMenu.rootMenu.exclusionGroupsByMenuItem.count; ++j)
-                    {
-                        var entry = tabletMenu.rootMenu.exclusionGroupsByMenuItem.get(j);
-                        if(entry.menuItem == item.toString())
-                        {
-                            var exclusionGroupId = entry.exclusionGroup;
-                            console.debug('item exclusionGroupId: ', exclusionGroupId)
-
-                            if(!exclusionGroups[exclusionGroupId])
-                            {
-                                exclusionGroups[exclusionGroupId] = exclusiveGroupMaker.createObject(newMenu);
-                                console.debug('new exclusion group created: ', exclusionGroups[exclusionGroupId])
-                            }
-
-                            var exclusionGroup = exclusionGroups[exclusionGroupId];
-
-                            item.exclusiveGroup = exclusionGroup
-                            console.debug('item.exclusiveGroup: ', item.exclusiveGroup)                        
-                        }
-                    }
-
                     break;
                 case MenuItemType.Separator:
                     result.append({"name": "", "item": item})

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7082,7 +7082,7 @@ DisplayPluginPointer Application::getActiveDisplayPlugin() const {
     return _displayPlugin;
 }
 
-static const char* exclusionGroupKey = "exclusionGroup";
+static const char* EXCLUSION_GROUP_KEY = "exclusionGroup";
 
 static void addDisplayPluginToMenu(DisplayPluginPointer displayPlugin, bool active = false) {
     auto menu = Menu::getInstance();
@@ -7119,7 +7119,7 @@ static void addDisplayPluginToMenu(DisplayPluginPointer displayPlugin, bool acti
     action->setChecked(active);
     displayPluginGroup->addAction(action);
 
-    action->setProperty(exclusionGroupKey, QVariant::fromValue(displayPluginGroup));
+    action->setProperty(EXCLUSION_GROUP_KEY, QVariant::fromValue(displayPluginGroup));
     Q_ASSERT(menu->menuItemExists(MenuOption::OutputMenu, name));
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7082,6 +7082,7 @@ DisplayPluginPointer Application::getActiveDisplayPlugin() const {
     return _displayPlugin;
 }
 
+static const char* exclusionGroupKey = "exclusionGroup";
 
 static void addDisplayPluginToMenu(DisplayPluginPointer displayPlugin, bool active = false) {
     auto menu = Menu::getInstance();
@@ -7117,6 +7118,8 @@ static void addDisplayPluginToMenu(DisplayPluginPointer displayPlugin, bool acti
     action->setCheckable(true);
     action->setChecked(active);
     displayPluginGroup->addAction(action);
+
+    action->setProperty(exclusionGroupKey, QVariant::fromValue(displayPluginGroup));
     Q_ASSERT(menu->menuItemExists(MenuOption::OutputMenu, name));
 }
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -56,7 +56,7 @@ Menu* Menu::getInstance() {
     return dynamic_cast<Menu*>(qApp->getWindow()->menuBar());
 }
 
-const char* exclusionGroupKey = "exclusionGroup";
+const char* EXCLUSION_GROUP_KEY = "exclusionGroup";
 
 Menu::Menu() {
     auto dialogsManager = DependencyManager::get<DialogsManager>();
@@ -228,21 +228,21 @@ Menu::Menu() {
                                    viewMenu, MenuOption::FirstPerson, Qt::CTRL | Qt::Key_F,
                                    true, qApp, SLOT(cameraMenuChanged())));
 
-    firstPersonAction->setProperty(exclusionGroupKey, QVariant::fromValue(cameraModeGroup));
+    firstPersonAction->setProperty(EXCLUSION_GROUP_KEY, QVariant::fromValue(cameraModeGroup));
 
     // View > Third Person
     auto thirdPersonAction = cameraModeGroup->addAction(addCheckableActionToQMenuAndActionHash(
                                    viewMenu, MenuOption::ThirdPerson, Qt::CTRL | Qt::Key_G,
                                    false, qApp, SLOT(cameraMenuChanged())));
 
-    thirdPersonAction->setProperty(exclusionGroupKey, QVariant::fromValue(cameraModeGroup));
+    thirdPersonAction->setProperty(EXCLUSION_GROUP_KEY, QVariant::fromValue(cameraModeGroup));
 
     // View > Mirror
     auto viewMirrorAction = cameraModeGroup->addAction(addCheckableActionToQMenuAndActionHash(
                                    viewMenu, MenuOption::FullscreenMirror, Qt::CTRL | Qt::Key_H,
                                    false, qApp, SLOT(cameraMenuChanged())));
 
-    viewMirrorAction->setProperty(exclusionGroupKey, QVariant::fromValue(cameraModeGroup));
+    viewMirrorAction->setProperty(EXCLUSION_GROUP_KEY, QVariant::fromValue(cameraModeGroup));
 
     // View > Independent [advanced]
     auto viewIndependentAction = cameraModeGroup->addAction(addCheckableActionToQMenuAndActionHash(viewMenu,
@@ -250,7 +250,7 @@ Menu::Menu() {
         false, qApp, SLOT(cameraMenuChanged()),
         UNSPECIFIED_POSITION, "Advanced"));
 
-    viewIndependentAction->setProperty(exclusionGroupKey, QVariant::fromValue(cameraModeGroup));
+    viewIndependentAction->setProperty(EXCLUSION_GROUP_KEY, QVariant::fromValue(cameraModeGroup));
 
     // View > Entity Camera [advanced]
     auto viewEntityCameraAction = cameraModeGroup->addAction(addCheckableActionToQMenuAndActionHash(viewMenu,
@@ -258,7 +258,7 @@ Menu::Menu() {
         false, qApp, SLOT(cameraMenuChanged()),
         UNSPECIFIED_POSITION, "Advanced"));
 
-    viewEntityCameraAction->setProperty(exclusionGroupKey, QVariant::fromValue(cameraModeGroup));
+    viewEntityCameraAction->setProperty(EXCLUSION_GROUP_KEY, QVariant::fromValue(cameraModeGroup));
 
     viewMenu->addSeparator();
 


### PR DESCRIPTION
**Test plan:** 

Steps to reproduce:
1) Click on Menu in the toolbar or HMD tablet
2) Click Display
3) Click on the current display mode
4) Display mode is unselected (display is not affected)

After fix: 
Display modes should be mutually exclusive in both desktop & HMD tablet 'Display' menu-es. 