### PR TITLE
Commented out Keylight Attenuation from UI.

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -623,7 +623,7 @@
                         </div>
                     </div>
                 </fieldset>
-                <div class="zone-group zone-section haze-section property checkbox">
+                <!--div class="zone-group zone-section haze-section property checkbox">
                     <input type="checkbox" id="property-zone-haze-attenuate-keylight">
                     <label for="property-zone-haze-attenuate-keylight">Attenuate Keylight</label>
                 </div>
@@ -634,7 +634,7 @@
                         <div><label>Altitude<span class="unit">m</span></label><input type="number" id="property-zone-haze-keylight-altitude" 
                         min="-1000" max="50000" step="10"></div>
                     </div>
-                </fieldset>
+                </fieldset-->
            </fieldset>
             <fieldset class="minor">
                 <legend class="sub-section-header zone-group zone-section stage-section">


### PR DESCRIPTION
THe light attenuation feature of the haze in a zone is not working correctly. We want to limit the visibility of that feature (introduced in rc 58 ) until we fix it.
The key light attenuation checkbox, and the associated range and height parameters have been commented out of the .html.  This is due to a possible bug in the haze model.

## TEST PLAN
Make sure that the attenuation check box, range and altitude fields are not visible in the Zone/Haze edit.js properties.