### PR TITLE
Removed Keylight attenuation from .js (as well as .html).

### DIFF
--- a/libraries/model/src/model/Haze.cpp
+++ b/libraries/model/src/model/Haze.cpp
@@ -8,8 +8,8 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-#include <memory>
 
+#include <memory>
 #include "Haze.h"
 
 using namespace model;

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -623,7 +623,7 @@
                         </div>
                     </div>
                 </fieldset>
-                <div class="zone-group zone-section haze-section property checkbox">
+                <!--div class="zone-group zone-section haze-section property checkbox">
                     <input type="checkbox" id="property-zone-haze-attenuate-keylight">
                     <label for="property-zone-haze-attenuate-keylight">Attenuate Keylight</label>
                 </div>
@@ -634,7 +634,7 @@
                         <div><label>Altitude<span class="unit">m</span></label><input type="number" id="property-zone-haze-keylight-altitude" 
                         min="-1000" max="50000" step="10"></div>
                     </div>
-                </fieldset>
+                </fieldset-->
            </fieldset>
             <fieldset class="minor">
                 <legend class="sub-section-header zone-group zone-section stage-section">

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1069,9 +1069,9 @@ function loaded() {
 
                             elZoneHazeBackgroundBlend.value = properties.haze.hazeBackgroundBlend.toFixed(2);
 
-                            elZoneHazeAttenuateKeyLight.checked = properties.haze.hazeAttenuateKeyLight;
-                            elZoneHazeKeyLightRange.value = properties.haze.hazeKeyLightRange.toFixed(0);
-                            elZoneHazeKeyLightAltitude.value = properties.haze.hazeKeyLightAltitude.toFixed(0);
+//                            elZoneHazeAttenuateKeyLight.checked = properties.haze.hazeAttenuateKeyLight;
+//                            elZoneHazeKeyLightRange.value = properties.haze.hazeKeyLightRange.toFixed(0);
+//                            elZoneHazeKeyLightAltitude.value = properties.haze.hazeKeyLightAltitude.toFixed(0);
 
                             elZoneStageLatitude.value = properties.stage.latitude.toFixed(2);
                             elZoneStageLongitude.value = properties.stage.longitude.toFixed(2);
@@ -1533,9 +1533,9 @@ function loaded() {
 
         elZoneHazeBackgroundBlend.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('haze', 'hazeBackgroundBlend'));
 
-        elZoneHazeAttenuateKeyLight.addEventListener('change', createEmitGroupCheckedPropertyUpdateFunction('haze', 'hazeAttenuateKeyLight'));
-        elZoneHazeKeyLightRange.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('haze', 'hazeKeyLightRange'));
-        elZoneHazeKeyLightAltitude.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('haze', 'hazeKeyLightAltitude'));
+//        elZoneHazeAttenuateKeyLight.addEventListener('change', createEmitGroupCheckedPropertyUpdateFunction('haze', 'hazeAttenuateKeyLight'));
+//        elZoneHazeKeyLightRange.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('haze', 'hazeKeyLightRange'));
+//        elZoneHazeKeyLightAltitude.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('haze', 'hazeKeyLightAltitude'));
 
         elZoneStageLatitude.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('stage', 'latitude'));
         elZoneStageLongitude.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('stage', 'longitude'));


### PR DESCRIPTION
The light attenuation feature of the haze in a zone is not working correctly. We want to limit the visibility of that feature (introduced in rc 58 ) until we fix it.
The key light attenuation checkbox, and the associated range and height parameters have been commented out of the .html. This is due to a possible bug in the haze model.

TEST PLAN

Make sure that the attenuation check box, range and altitude fields are not visible in the Zone/Haze edit.js properties.