### PR TITLE
prevent rendering HUD elements in secondary camera

### DIFF
--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -438,6 +438,11 @@ void CompositeHUD::run(const RenderContextPointer& renderContext) {
     assert(renderContext->args);
     assert(renderContext->args->_context);
 
+    // We do not want to render HUD elements in secondary camera
+    if (renderContext->args->_renderMode == RenderArgs::RenderMode::SECONDARY_CAMERA_RENDER_MODE) {
+        return;
+    }
+
     // Grab the HUD texture
     gpu::doInBatch(renderContext->args->_context, [&](gpu::Batch& batch) {
         if (renderContext->args->_hudOperator) {


### PR DESCRIPTION
We don't want to see desktop UI rendered in the secondary camera.

Test Plan:
https://highfidelity.testrail.net/index.php?/cases/view/2960