### PR TITLE
Fix bug with disappearing certificate info

### DIFF
--- a/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
+++ b/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
@@ -113,21 +113,6 @@ Rectangle {
         }
     }
 
-    onVisibleChanged: {
-        if (!visible) {
-            titleBarText.text = "Certificate";
-            popText.text = "PROOF OF PURCHASE";
-            root.certificateId = "";
-            root.itemName = "--";
-            root.itemOwner = "--";
-            root.itemEdition = "--";
-            root.dateOfPurchase = "--";
-            root.marketplaceUrl = "";
-            root.isMyCert = false;
-            errorText.text = "";
-        }
-    }
-
     // This object is always used in a popup.
     // This MouseArea is used to prevent a user from being
     //     able to click on a button/mouseArea underneath the popup.
@@ -419,6 +404,18 @@ Rectangle {
         switch (message.method) {
             case 'inspectionCertificate_setCertificateId':
                 root.certificateId = message.certificateId;
+            break;
+            case 'inspectionCertificate_resetCert':
+                titleBarText.text = "Certificate";
+                popText.text = "PROOF OF PURCHASE";
+                root.certificateId = "";
+                root.itemName = "--";
+                root.itemOwner = "--";
+                root.itemEdition = "--";
+                root.dateOfPurchase = "--";
+                root.marketplaceUrl = "";
+                root.isMyCert = false;
+                errorText.text = "";
             break;
             default:
                 console.log('Unrecognized message from marketplaces.js:', JSON.stringify(message));

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -128,6 +128,12 @@
         } else {
             ContextOverlay.isInMarketplaceInspectionMode = false;
         }
+
+        if (!onCommerceScreen) {
+            tablet.sendToQml({
+                method: 'inspectionCertificate_resetCert'
+            });
+        }
     }
 
     function openWallet() {


### PR DESCRIPTION
**Test Plan:**
1. Rez a certified entity
2. Right click on the entity, then click on the (i) context overlay that appears
3. Verify that the certificate you see appears to be valid
4. Defocus the cert popup (i.e. click outside it), then walk forward until the cert disappears from your screen
5. Stop walking. Wait for the cert to reappear on-screen. Verify that the information in the cert display is the same as in (3).
6. Close the cert. Repeat steps 2 and 3 again.
7. Repeat steps 1-3 again, this time with a different certified entity.
8. With the cert from (7) visible on-screen, right click the _other_ entity and open its cert.
9. Verify that the cert displayed on-screen is valid and relevant to the entity you right clicked