### PR TITLE
8984 Opening tablet with "Enter" key displays the audio menu

### DIFF
--- a/interface/resources/qml/hifi/tablet/Tablet.qml
+++ b/interface/resources/qml/hifi/tablet/Tablet.qml
@@ -8,8 +8,8 @@ import "../audio" as HifiAudio
 Item {
     id: tablet
     objectName: "tablet"
-    property int rowIndex: 0
-    property int columnIndex: 0
+    property int rowIndex: 6 // by default
+    property int columnIndex: 1 // point to 'go to location'
     property int count: (flowMain.children.length - 1)
 
     // used to look up a button by its uuid


### PR DESCRIPTION
**Test plan**

1) Switch to VR
2) Open tablet using 'Enter' button
3) Ensure tablet is opened at 'go to location'
4) Close tablet with 'X' button
5) Open tablet using 'Enter' button
6) Ensure tablet is still opened at 'go to location' 

before the fix: 
On step 6 tablet would open at 'audio' 

https://highfidelity.fogbugz.com/f/cases/8984/Opening-tablet-with-Enter-key-displays-the-audio-menu
