### PR TITLE
Hold entity data until client is presumably reachable and has queried

### DIFF
--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -82,9 +82,12 @@ bool OctreeSendThread::process() {
         if (auto node = _node.lock()) {
             OctreeQueryNode* nodeData = static_cast<OctreeQueryNode*>(node->getLinkedData());
 
-            // If we don't have the OctreeQueryNode or it's uninitialized because we haven't received
-            // a query yet from the client then we can't send an entity data packet
-            if (nodeData && nodeData->hasReceivedFirstQuery() && !nodeData->isShuttingDown()) {
+            // If we don't have the OctreeQueryNode at all
+            // or it's uninitialized because we haven't received a query yet from the client
+            // or we don't know where we should send packets for this node
+            // or we're shutting down
+            // then we can't send an entity data packet
+            if (nodeData && nodeData->hasReceivedFirstQuery() && node->getActiveSocket() && !nodeData->isShuttingDown()) {
                 bool viewFrustumChanged = nodeData->updateCurrentViewFrustum();
                 packetDistributor(node, nodeData, viewFrustumChanged);
             }

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -82,8 +82,9 @@ bool OctreeSendThread::process() {
         if (auto node = _node.lock()) {
             OctreeQueryNode* nodeData = static_cast<OctreeQueryNode*>(node->getLinkedData());
 
-            // Sometimes the node data has not yet been linked, in which case we can't really do anything
-            if (nodeData && !nodeData->isShuttingDown()) {
+            // If we don't have the OctreeQueryNode or it's uninitialized because we haven't received
+            // a query yet from the client then we can't send an entity data packet
+            if (nodeData && nodeData->hasReceivedFirstQuery() && !nodeData->isShuttingDown()) {
                 bool viewFrustumChanged = nodeData->updateCurrentViewFrustum();
                 packetDistributor(node, nodeData, viewFrustumChanged);
             }

--- a/libraries/octree/src/OctreeQuery.h
+++ b/libraries/octree/src/OctreeQuery.h
@@ -31,7 +31,7 @@ public:
     virtual ~OctreeQuery() {}
 
     int getBroadcastData(unsigned char* destinationBuffer);
-    int parseData(ReceivedMessage& message) override;
+    virtual int parseData(ReceivedMessage& message) override;
 
     // getters for camera details
     const glm::vec3& getCameraPosition() const { return _cameraPosition; }

--- a/libraries/octree/src/OctreeQueryNode.cpp
+++ b/libraries/octree/src/OctreeQueryNode.cpp
@@ -18,6 +18,12 @@
 #include <SharedUtil.h>
 #include <UUID.h>
 
+int OctreeQueryNode::parseData(ReceivedMessage& message) {
+    // set our flag to indicate that we've parsed for this query at least once
+    _hasReceivedFirstQuery = true;
+
+    return OctreeQuery::parseData(message);
+}
 
 void OctreeQueryNode::nodeKilled() {
     _isShuttingDown = true;

--- a/libraries/octree/src/OctreeQueryNode.h
+++ b/libraries/octree/src/OctreeQueryNode.h
@@ -35,6 +35,8 @@ public:
     void init(); // called after creation to set up some virtual items
     virtual PacketType getMyPacketType() const = 0;
 
+    virtual int parseData(ReceivedMessage& message) override;
+
     void resetOctreePacket();  // resets octree packet to after "V" header
 
     void writeToPacket(const unsigned char* buffer, unsigned int bytes); // writes to end of packet
@@ -106,6 +108,8 @@ public:
     bool shouldForceFullScene() const { return _shouldForceFullScene; }
     void setShouldForceFullScene(bool shouldForceFullScene) { _shouldForceFullScene = shouldForceFullScene; }
 
+    bool hasReceivedFirstQuery() const  { return _hasReceivedFirstQuery; }
+
 private:
     OctreeQueryNode(const OctreeQueryNode &);
     OctreeQueryNode& operator= (const OctreeQueryNode&);
@@ -153,6 +157,8 @@ private:
     QJsonObject _lastCheckJSONParameters;
 
     bool _shouldForceFullScene { false };
+
+    bool _hasReceivedFirstQuery { false };
 };
 
 #endif // hifi_OctreeQueryNode_h


### PR DESCRIPTION
- fixed an issue where the initial packet(s) from the octree server could be missed