### PR TITLE
Fix issue of User is unable to bring up the High Fidelity Interface log.

### DIFF
--- a/interface/resources/qml/controls/FlickableWebViewCore.qml
+++ b/interface/resources/qml/controls/FlickableWebViewCore.qml
@@ -135,4 +135,10 @@ Item {
         playing: visible
         z: 10000
     }
+
+    Keys.onPressed: {
+        if ((event.modifiers & Qt.ShiftModifier) && (event.modifiers & Qt.ControlModifier)) {
+            webViewCore.focus = false;
+        }
+    }
 }


### PR DESCRIPTION
When a user bring up a application with a WebEngineView. The WebEngineView will take all focus away from interface, thus preventing any key presses being sent to interface.

ticket - https://highfidelity.fogbugz.com/f/cases/8880/User-is-unable-to-bring-up-the-High-Fidelity-Interface-log