### PR TITLE
Bug fix for MyAvatar.getEyeHeight()

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1579,7 +1579,7 @@ float Avatar::getEyeHeight() const {
 
     if (QThread::currentThread() != thread()) {
         float result = DEFAULT_AVATAR_EYE_HEIGHT;
-        BLOCKING_INVOKE_METHOD(const_cast<Avatar*>(this), "getHeight", Q_RETURN_ARG(float, result));
+        BLOCKING_INVOKE_METHOD(const_cast<Avatar*>(this), "getEyeHeight", Q_RETURN_ARG(float, result));
         return result;
     }
 


### PR DESCRIPTION
Previously when called from JS, it would always return the default value of 1.644999.  Now it properly returns the avatar's height.