### PR TITLE
Fix not restoring animations after changing view modes

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -179,6 +179,11 @@ void Rig::restoreRoleAnimation(const QString& role) {
             } else {
                 qCWarning(animation) << "Rig::restoreRoleAnimation could not find role " << role;
             }
+            
+            auto statesIter = _roleAnimStates.find(role);
+            if (statesIter != _roleAnimStates.end()) {
+                _roleAnimStates.erase(statesIter);
+            }
         }
     } else {
         qCWarning(animation) << "Rig::overrideRoleAnimation avatar not ready yet";


### PR DESCRIPTION
This PR fixes the bug where the avatar remains in sitting position after exiting or entering VR while sitting in a chair. 
This is an addition to this fix: https://github.com/highfidelity/hifi/pull/11725
  
https://highfidelity.fogbugz.com/f/cases/9267
...

## TEST PLAN
- Go to Dev-Welcome in HMD mode and sit down on a cushion.
- Without standing up change to Desktop mode.
- Stand up and change to third person camera. Make sure the avatar looks fine (no sit locked animations)
- Sit down again while in Desktop mode.
- Without standing up change to HMD mode.
- Stand up and change to third person camera. Make sure the avatar looks fine (no sit locked animations)