### PR TITLE
Fix for black screen on HMDs on startup

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1823,6 +1823,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     // Preload Tablet sounds
     DependencyManager::get<TabletScriptingInterface>()->preloadSounds();
 
+    _pendingIdleEvent = false;
+    _pendingRenderEvent = false;
+
     qCDebug(interfaceapp) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(accountManager->getSessionID());
 }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -708,7 +708,7 @@ private:
 
     friend class RenderEventHandler;
 
-    std::atomic<bool> _pendingIdleEvent { false };
-    std::atomic<bool> _pendingRenderEvent { false };
+    std::atomic<bool> _pendingIdleEvent { true };
+    std::atomic<bool> _pendingRenderEvent { true };
 };
 #endif // hifi_Application_h


### PR DESCRIPTION
Fix for [FB9107](https://highfidelity.fogbugz.com/f/cases/9107/Logging-in-with-HMD-results-in-black-world).  

I don't quite understand why this change fixes rendering when you start in HMD mode.  I suspect that by making a direct connection the first present and subsequent render happens earlier than it otherwise would, leading to the use of some uninitialized value that remains in that state until you switch display plugins.  

An alternative solution might be to suppress the behavior in `onPresent` until after a certain point in startup, but since this is a P1 that needs an immediate fix and I'm uncertain as to the proper fix I'm submitting this as is.  

## Testing

Set an environment variable of `HIFI_DEBUG_HMD=1` on your system.  

* Start Interface 
* Switch to the `HMD Simulator` display plugin in the Display menu
* Shut down Interface
* Restart interface

On master on the second start you will see a black screen, potentially with the cursor and other UI elements on the HUD view, but no scene, not even a skybox.  In this build you should see the scene of whatever environment your client is in, or the default skybox if you're not connected to any domain. 