### PR TITLE
Fix skipping wallet setup step in certain cases

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -53,8 +53,6 @@ Item {
         onWalletAuthenticatedStatusResult: {
             if (isAuthenticated) {
                 root.activeView = "step_4";
-            } else {
-                root.activeView = "step_3";
             }
         }
 


### PR DESCRIPTION
Fixes [this FogBugz bug](https://highfidelity.fogbugz.com/f/cases/9231). The guard provided by the `else` in the original code is no longer necessary after a fairly recent change to another area of the setup process.

**Test Plan:**
1. On a completely clean install, enable Commerce, then log in to an account that doesn't have a wallet associated with it.
2. Open the Wallet app. Verify that you don't see a prompt to log in.
3. Setup your wallet as normal. Verify that you can get through the setup process cleanly and that your security picture is visible throughout setup and in the main Wallet app.
4. Go to the HELP tab, then click "DBG: RST WALLET".
5. Log out of your account using the File menu.
6. Open the Wallet app.
7. Verify that the Wallet app displays a screen requiring you to log in before continuing.
8. Click the "Log In" button, enter your credentials (the same as in (1)), then click log in.
9. Verify that the Wallet app now displays a screen prompting you to set up your wallet.
10. Setup your wallet as normal. Verify that you can get through the setup process cleanly and that your security picture is visible throughout setup and in the main Wallet app.
11. If you can think of any other ways to try to break or stress wallet setup, give them a try here :)