### PR TITLE
Updated the README with CLA details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Documentation is available at [docs.highfidelity.com](https://docs.highfidelity.
 
 There is also detailed [documentation on our coding standards](https://wiki.highfidelity.com/wiki/Coding_Standards).
 
+Contributor License Agreement (CLA)
+=========
+Technology companies frequently receive and use code from contributors outside the company's development team. Outside code can be a tremendous resource, but it also carries responsibility. Best practice for accepting outside contributions consists of an Apache-type Contributor License Agreement (CLA). We have modeled the High Fidelity CLA after the CLA that Google presents to developers for contributions to their projects. This CLA does not transfer ownership of code, instead simply granting a non-exclusive right for High Fidelity to use the code you’ve contributed. In that regard, you should be sure you have permission if the work relates to or uses the resources of a company that you work for. You will be asked to sign our CLA when you create your first PR or when the CLA is updated. You can also [review it here](https://gist.githubusercontent.com/hifi-gustavo/fef8f06a8233d42a0040d45c3efb97a9/raw/9981827eb94f0b18666083670b6f6a02929fb402/High%2520Fidelity%2520CLA). We sincerely appreciate your contribution and efforts toward the success of the platform.
+
 Build Instructions 
 =========
 All information required to build is found in the [build guide](BUILD.md).


### PR DESCRIPTION
This notice prepares contributors for the integration with CLA Assistant (https://cla-assistant.io/). CLA Assistant will require all contributors to sign the CLA before merging their next PRs.