### PR TITLE
Turn Commerce on by default!

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Help.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Help.qml
@@ -55,37 +55,6 @@ Item {
         // Style
         color: hifi.colors.blueHighlight;
     }
-    HifiControlsUit.Button {
-        id: clearCachedPassphraseButton;
-        visible: root.showDebugButtons;
-        color: hifi.buttons.black;
-        colorScheme: hifi.colorSchemes.dark;
-        anchors.top: parent.top;
-        anchors.left: helpTitleText.right;
-        anchors.leftMargin: 20;
-        height: 40;
-        width: 150;
-        text: "DBG: Clear Pass";
-        onClicked: {
-            commerce.setPassphrase("");
-            sendSignalToWallet({method: 'passphraseReset'});
-        }
-    }
-    HifiControlsUit.Button {
-        id: resetButton;
-        visible: root.showDebugButtons;
-        color: hifi.buttons.red;
-        colorScheme: hifi.colorSchemes.dark;
-        anchors.top: clearCachedPassphraseButton.top;
-        anchors.left: clearCachedPassphraseButton.right;
-        height: 40;
-        width: 150;
-        text: "DBG: RST Wallet";
-        onClicked: {
-            commerce.reset();
-            sendSignalToWallet({method: 'walletReset'});
-        }
-    }
 
     ListModel {
         id: helpModel;

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -203,7 +203,7 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
 
 bool ContextOverlayInterface::contextOverlayFilterPassed(const EntityItemID& entityItemID) {
     EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(entityItemID, _entityPropertyFlags);
-    Setting::Handle<bool> _settingSwitch{ "commerce", false };
+    Setting::Handle<bool> _settingSwitch{ "commerce", true };
     if (_settingSwitch.get()) {
         return (entityProperties.getCertificateID().length() != 0);
     } else {
@@ -233,7 +233,7 @@ bool ContextOverlayInterface::destroyContextOverlay(const EntityItemID& entityIt
 void ContextOverlayInterface::contextOverlays_mousePressOnOverlay(const OverlayID& overlayID, const PointerEvent& event) {
     if (overlayID == _contextOverlayID  && event.getButton() == PointerEvent::PrimaryButton) {
         qCDebug(context_overlay) << "Clicked Context Overlay. Entity ID:" << _currentEntityWithContextOverlay << "Overlay ID:" << overlayID;
-        Setting::Handle<bool> _settingSwitch{ "commerce", false };
+        Setting::Handle<bool> _settingSwitch{ "commerce", true };
         if (_settingSwitch.get()) {
             openInspectionCertificate();
         } else {

--- a/libraries/ui/src/ui/types/RequestFilters.cpp
+++ b/libraries/ui/src/ui/types/RequestFilters.cpp
@@ -62,7 +62,7 @@ void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info)
 
     // During the period in which we have HFC commerce in the system, but not applied everywhere:
     const QString tokenStringCommerce{ "Chrome/48.0 (HighFidelityInterface WithHFC)" };
-    Setting::Handle<bool> _settingSwitch{ "commerce", false };
+    Setting::Handle<bool> _settingSwitch{ "commerce", true };
     bool isMoney = _settingSwitch.get();
 
     const QString tokenString = !isAuthable ? tokenStringMobile : (isMoney ? tokenStringCommerce : tokenStringMetaverse);

--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -145,7 +145,7 @@
     var button;
     var buttonName = "WALLET";
     var tablet = null;
-    var walletEnabled = Settings.getValue("commerce", false);
+    var walletEnabled = Settings.getValue("commerce", true);
     function startup() {
         if (walletEnabled) {
             tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -160,7 +160,7 @@
             type: "marketplaces",
             action: "commerceSetting",
             data: {
-                commerceMode: Settings.getValue("commerce", false),
+                commerceMode: Settings.getValue("commerce", true),
                 userIsLoggedIn: Account.loggedIn,
                 walletNeedsSetup: Wallet.walletStatus === 1,
                 metaverseServerURL: Account.metaverseServerURL


### PR DESCRIPTION
IT'S HAPPENING!!! This PR turns Commerce on by default (with the ability to force it to False via the Settings API). It also removes the two DEBUG buttons from WALLET HELP.

**Test Plan:**
1. Install this PR _cleanly_. This means that there shouldn't be an Interface.json associated with your install of this PR.
2. Launch Interface and log in. Verify that you see a WALLET icon in your HUD.
3. Complete the Wallet setup process. (Ask for seeding money if you must)
4. Open the MARKET. Verify that you see a "My Purchases" link at the top of the screen.
5. Buy and spawn a Test Beach Ball. Right click it. Verify you see the (i) Context Overlay. Click the context overlay, and verify that you see the certificate.
6. In a JavaScript Console (CTRL + SHIFT + J), type `Settings.setValue("commerce", false)`, press Enter, then press CTRL + R to restart all scripts.
7. Verify that you don't see a Wallet icon anymore.
8. Right click the beach ball from (5) and verify that clicking the Context Overlay goes straight to the Marketplace page of the Test Beach Ball.
9. When the Marketplace page opens in (8), verify that you DON'T see a "My Purchases" link at the top of the page.