### PR TITLE
Zip file structures replicated in asset server

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6328,20 +6328,19 @@ void Application::addAssetToWorldUnzipFailure(QString filePath) {
     addAssetToWorldError(filename, "Couldn't unzip file " + filename + ".");
 }
 
-void Application::addAssetToWorld(QString filePath, QString zipFile, bool isZip, bool isBlocks) {
+void Application::addAssetToWorld(QString path, QString zipFile, bool isZip, bool isBlocks) {
     // Automatically upload and add asset to world as an alternative manual process initiated by showAssetServerWidget().
     QString mapping;
-    QString path = filePath;
     QString filename = filenameFromPath(path);
-    if (isZip) {
-        QString assetFolder = zipFile.section("/", -1);
-        assetFolder.remove(".zip");
-        mapping = "/" + assetFolder + "/" + filename;
-    } else if (isBlocks) {
-        qCDebug(interfaceapp) << "Path to asset folder: " << zipFile;
-        QString assetFolder = zipFile.section('/', -1);
-        assetFolder.remove(".zip?noDownload=false");
-        mapping = "/" + assetFolder + "/" + filename;
+    if (isZip || isBlocks) {
+        QString assetName;
+        if (isZip) {
+            assetName = zipFile.section("/", -1).remove(".zip");
+        } else if (isBlocks) {
+            assetName = zipFile.section("/", -1).remove(".zip?noDownload=false");
+        }
+        QString assetFolder = path.section("model_repo/", -1);
+        mapping = "/" + assetName + "/" + assetFolder;
     } else {
         mapping = "/" + filename;
     }
@@ -6727,8 +6726,10 @@ void Application::handleUnzip(QString zipFile, QStringList unzipFile, bool autoA
     if (autoAdd) {
         if (!unzipFile.isEmpty()) {
             for (int i = 0; i < unzipFile.length(); i++) {
-                qCDebug(interfaceapp) << "Preparing file for asset server: " << unzipFile.at(i);
-                addAssetToWorld(unzipFile.at(i), zipFile, isZip, isBlocks);
+                if (QFileInfo(unzipFile.at(i)).isFile()) {
+                    qCDebug(interfaceapp) << "Preparing file for asset server: " << unzipFile.at(i);
+                    addAssetToWorld(unzipFile.at(i), zipFile, isZip, isBlocks);
+                }
             }
         } else {
             addAssetToWorldUnzipFailure(zipFile);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6336,7 +6336,7 @@ void Application::addAssetToWorld(QString path, QString zipFile, bool isZip, boo
     QString mapping;
     QString filename = filenameFromPath(path);
     if (isZip || isBlocks) {
-        QString assetName = zipFile.section("/", -1).remove(QRegExp("\.zip(.*)$"));
+        QString assetName = zipFile.section("/", -1).remove(QRegExp("[.]zip(.*)$"));
         QString assetFolder = path.section("model_repo/", -1);
         mapping = "/" + assetName + "/" + assetFolder;
     } else {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6336,12 +6336,7 @@ void Application::addAssetToWorld(QString path, QString zipFile, bool isZip, boo
     QString mapping;
     QString filename = filenameFromPath(path);
     if (isZip || isBlocks) {
-        QString assetName;
-        if (isZip) {
-            assetName = zipFile.section("/", -1).remove(".zip");
-        } else if (isBlocks) {
-            assetName = zipFile.section("/", -1).remove(".zip?noDownload=false");
-        }
+        QString assetName = zipFile.section("/", -1).remove(QRegExp("\.zip(.*)$"));
         QString assetFolder = path.section("model_repo/", -1);
         mapping = "/" + assetName + "/" + assetFolder;
     } else {

--- a/libraries/script-engine/src/FileScriptingInterface.cpp
+++ b/libraries/script-engine/src/FileScriptingInterface.cpp
@@ -55,7 +55,7 @@ void FileScriptingInterface::runUnzip(QString path, QUrl url, bool autoAdd, bool
     QStringList fileList = unzipFile(path, tempDir);
     
     if (!fileList.isEmpty()) {
-        qCDebug(scriptengine) << "File to upload: " + fileList.first();
+        qCDebug(scriptengine) << "First file to upload: " + fileList.first();
     } else {
         qCDebug(scriptengine) << "Unzip failed";
     }

--- a/unpublishedScripts/marketplace/blocks/blocksApp.js
+++ b/unpublishedScripts/marketplace/blocks/blocksApp.js
@@ -14,7 +14,7 @@
 
 (function () {
 	var APP_NAME = "BLOCKS";
-	var APP_URL = "https://vr.google.com/objects/";
+	var APP_URL = "https://poly.google.com/";
 	var APP_OUTDATED_URL = "https://hifi-content.s3.amazonaws.com/elisalj/blocks/updateToBlocks.html";
 	var APP_ICON = "https://hifi-content.s3.amazonaws.com/elisalj/blocks/blocks-i.svg";
 	var APP_ICON_ACTIVE = "https://hifi-content.s3.amazonaws.com/elisalj/blocks/blocks-a.svg";


### PR DESCRIPTION
Other minor changes: URL in Blocks app updated to Poly, updated an unzip debug print

Test plan:
1. Download https://hifi-content.s3.amazonaws.com/elisalj/blocks/lego_obj.zip
2. Open Interface, then open the asset browser (Ctrl + Shift + A)
3. Drag "lego_obj.zip" into Interface
4. The model should load in front of you (ignore the lack of textures)
5. Check that in the asset browser there is a "lego_obj" folder; expanding it should reveal a hierarchical file structure that matches what's inside lego_obj.zip
6. Delete "lego_obj" from the asset server
7. Load "Blocks" from the marketplace and open
8. Search for "Lego Moon Buggy" and select this: https://poly.google.com/view/8kSHCCK66fa
9. Download the obj for that; the model should still appear in front of you with no textures
10. Check in the asset browser for a file "8kSHC...", it should have the same file structure as "lego_obj"
