### PR TITLE
8992 Login window is small in tablet

### DIFF
--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -418,7 +418,10 @@ void TabletProxy::setQmlTabletRoot(OffscreenQmlSurface* qmlOffscreenSurface) {
 
         if (_initialScreen) {
             if (!_showRunningScripts && _initialPath.second == State::QML) {
-                pushOntoStack(_initialPath.first);
+                auto path = _initialPath.first;
+                QTimer::singleShot(0, [this, path] { // delay pushing a bit to allow tablet to get proper geometry
+                    pushOntoStack(path);
+                });
             } else if (_initialPath.second == State::Web) {
                 QVariant webUrl = _initialPath.first;
                 QVariant scriptUrl = _initialWebPathParams.first;


### PR DESCRIPTION
**Test plan**

Original steps to reproduce (from FB: https://highfidelity.fogbugz.com/f/cases/8992/Login-window-is-small-in-tablet) 

> This only seemed to be a problem when it automatically popped up when going to a restricted domain. When I logged in through the menu the login screen looked good.


I had no access to restricted domains so I had to do the following to reproduce the issue:

1. Switch to VR
2. Open tablet, go to any domain available
3. Launch 'server' and 'assignment-cilent' 
4. Switch to 'localhost' domain
5. Change permissions for local domain to be like the ones below: 

![image](https://user-images.githubusercontent.com/23638/32994953-f6fc915e-cd7e-11e7-8582-309a9366e8de.png)

Before the fix: 

6. Open tablet and wait a bit. Tablet should auto-refresh and broken login dialog should appear. 

After the fix: 

6. Open tablet and wait a bit. Tablet should auto-refresh and normally-looking login dialog should appear. 

For devs: I've evaluated a few options besides delayed 'pushOntoStack', but this fix is just minimally intrusive one. I'm opened to any suggestions how to make better. Original issue happens because login dialog appears too fast, before tablet gets its real geometry. I've tried to fix geometry but realized it might lead to a lot of regressions because login dialog calculates not only own geometry but also tries to adjust geometry of its parent. 