### PR TITLE
Register the Vive inputDevice if no controllers are available 

### DIFF
--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -382,7 +382,6 @@ void ViveControllerManager::InputDevice::update(float deltaTime, const controlle
 
     updateCalibratedLimbs(inputCalibrationData);
     _lastSimPoseData = _nextSimPoseData;
-    qDebug() << _trackedControllers;
 }
 
 void ViveControllerManager::InputDevice::calibrateFromHandController(const controller::InputCalibrationData& inputCalibrationData) {

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -274,13 +274,13 @@ void ViveControllerManager::pluginUpdate(float deltaTime, const controller::Inpu
         _inputDevice->update(deltaTime, inputCalibrationData);
     });
 
-    if (_inputDevice->_trackedControllers == 0 && _registeredWithInputMapper) {
+    if (isDesktopMode() && _registeredWithInputMapper) {
         userInputMapper->removeDevice(_inputDevice->_deviceID);
         _registeredWithInputMapper = false;
         _inputDevice->_poseStateMap.clear();
     }
 
-    if (!_registeredWithInputMapper && _inputDevice->_trackedControllers > 0) {
+    if (!_registeredWithInputMapper && !isDesktopMode()) {
         userInputMapper->registerDevice(_inputDevice);
         _registeredWithInputMapper = true;
     }


### PR DESCRIPTION
If no hand controllers are connected the ViveControllerManager will not register the Input device, will cause  the head pose not being sent even through you are in HMD mode.

This was the issue described in this ticket - https://highfidelity.fogbugz.com/f/cases/9465/With-Vive-and-an-Xbox-controller-the-avatar-and-controls-are-misaligned 