### PR TITLE
Don't refresh Inventory or Recent Activity if data hasn't changed

### DIFF
--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -664,9 +664,7 @@ Rectangle {
 
         if (sameItemCount !== tempPurchasesModel.count) {
             filteredPurchasesModel.clear();
-            for (var i = 0; i < tempPurchasesModel.count; i++) {
-                filteredPurchasesModel.append(tempPurchasesModel.get(i));
-            }
+            filteredPurchasesModel.append(tempPurchasesModel);
 
             populateDisplayedItemCounts();
             sortByDate();

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -344,6 +344,9 @@ Rectangle {
             id: previousPurchasesModel;
         }
         HifiCommerceCommon.SortableListModel {
+            id: tempPurchasesModel;
+        }
+        HifiCommerceCommon.SortableListModel {
             id: filteredPurchasesModel;
         }
 
@@ -635,20 +638,41 @@ Rectangle {
     }
 
     function buildFilteredPurchasesModel() {
-        filteredPurchasesModel.clear();
+        var sameItemCount = 0;
+        
+        tempPurchasesModel.clear();
         for (var i = 0; i < purchasesModel.count; i++) {
             if (purchasesModel.get(i).title.toLowerCase().indexOf(filterBar.text.toLowerCase()) !== -1) {
                 if (purchasesModel.get(i).status !== "confirmed" && !root.isShowingMyItems) {
-                    filteredPurchasesModel.insert(0, purchasesModel.get(i));
+                    tempPurchasesModel.insert(0, purchasesModel.get(i));
                 } else if ((root.isShowingMyItems && purchasesModel.get(i).edition_number === "0") ||
                 (!root.isShowingMyItems && purchasesModel.get(i).edition_number !== "0")) {
-                    filteredPurchasesModel.append(purchasesModel.get(i));
+                    tempPurchasesModel.append(purchasesModel.get(i));
                 }
             }
         }
+        
+        for (var i = 0; i < tempPurchasesModel.count; i++) {
+            if (!filteredPurchasesModel.get(i)) {
+                break;
+            } else if (tempPurchasesModel.get(i).itemId === filteredPurchasesModel.get(i).itemId &&
+            tempPurchasesModel.get(i).edition_number === filteredPurchasesModel.get(i).edition_number &&
+            tempPurchasesModel.get(i).status === filteredPurchasesModel.get(i).status) {
+                sameItemCount++;
+            }
+        }
 
-        populateDisplayedItemCounts();
-        sortByDate();
+        if (sameItemCount !== tempPurchasesModel.count) {
+            filteredPurchasesModel.clear();
+            for (var i = 0; i < tempPurchasesModel.count; i++) {
+                filteredPurchasesModel.append(tempPurchasesModel.get(i));
+            }
+
+            populateDisplayedItemCounts();
+            sortByDate();
+        } else {
+            console.log("ZRF HERE NOT REFRESHING");
+        }
     }
 
     function checkIfAnyItemStatusChanged() {

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -654,6 +654,7 @@ Rectangle {
         
         for (var i = 0; i < tempPurchasesModel.count; i++) {
             if (!filteredPurchasesModel.get(i)) {
+                sameItemCount = -1;
                 break;
             } else if (tempPurchasesModel.get(i).itemId === filteredPurchasesModel.get(i).itemId &&
             tempPurchasesModel.get(i).edition_number === filteredPurchasesModel.get(i).edition_number &&
@@ -664,7 +665,9 @@ Rectangle {
 
         if (sameItemCount !== tempPurchasesModel.count) {
             filteredPurchasesModel.clear();
-            filteredPurchasesModel.append(tempPurchasesModel);
+            for (var i = 0; i < tempPurchasesModel.count; i++) {
+                filteredPurchasesModel.append(tempPurchasesModel.get(i));
+            }
 
             populateDisplayedItemCounts();
             sortByDate();

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -668,8 +668,6 @@ Rectangle {
 
             populateDisplayedItemCounts();
             sortByDate();
-        } else {
-            console.log("ZRF HERE NOT REFRESHING");
         }
     }
 

--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -161,10 +161,9 @@ Item {
 
     Timer {
         id: refreshTimer;
-        interval: 4000; // Remove this after demo?
+        interval: 4000;
         onTriggered: {
             console.log("Refreshing Wallet Home...");
-            historyReceived = false;
             commerce.balance();
             commerce.history();
         }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -38,10 +38,25 @@ Item {
         onHistoryResult : {
             historyReceived = true;
             if (result.status === 'success') {
-                transactionHistoryModel.clear();
-                transactionHistoryModel.append(result.data.history);
+                var sameItemCount = 0;
+                tempTransactionHistoryModel.clear();
+                
+                tempTransactionHistoryModel.append(result.data.history);
+        
+                for (var i = 0; i < tempTransactionHistoryModel.count; i++) {
+                    if (!transactionHistoryModel.get(i)) {
+                        break;
+                    } else if (tempTransactionHistoryModel.get(i).transaction_type === transactionHistoryModel.get(i).transaction_type &&
+                    tempTransactionHistoryModel.get(i).text === transactionHistoryModel.get(i).text) {
+                        sameItemCount++;
+                    }
+                }
 
-                calculatePendingAndInvalidated();
+                if (sameItemCount !== tempTransactionHistoryModel.count) {
+                    transactionHistoryModel.clear();
+                    transactionHistoryModel.append(tempTransactionHistoryModel);
+                    calculatePendingAndInvalidated();
+                }
             }
             refreshTimer.start();
         }
@@ -186,6 +201,9 @@ Item {
             size: 22;
             // Style
             color: hifi.colors.baseGrayHighlight;
+        }
+        ListModel {
+            id: tempTransactionHistoryModel;
         }
         ListModel {
             id: transactionHistoryModel;

--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -45,6 +45,7 @@ Item {
         
                 for (var i = 0; i < tempTransactionHistoryModel.count; i++) {
                     if (!transactionHistoryModel.get(i)) {
+                        sameItemCount = -1;
                         break;
                     } else if (tempTransactionHistoryModel.get(i).transaction_type === transactionHistoryModel.get(i).transaction_type &&
                     tempTransactionHistoryModel.get(i).text === transactionHistoryModel.get(i).text) {
@@ -54,7 +55,9 @@ Item {
 
                 if (sameItemCount !== tempTransactionHistoryModel.count) {
                     transactionHistoryModel.clear();
-                    transactionHistoryModel.append(tempTransactionHistoryModel);
+                    for (var i = 0; i < tempTransactionHistoryModel.count; i++) {
+                        transactionHistoryModel.append(tempTransactionHistoryModel.get(i));
+                    }
                     calculatePendingAndInvalidated();
                 }
             }


### PR DESCRIPTION
_Guessing this goes in RC61 since it isn't critical? That may change..._

**Test Plan:**
1. Is your wallet set up? If it is, rename your `<username>.hifikey` file to `<uername>.hifikey.backup` for now. If it's not set up, set it up, making sure you're NOT on the list to get seeded.
2. Open the Wallet app. Wait on the "Recent Activity" screen. Verify that the "how to get seeded" text doesn't flash every 4 seconds.
3. If you hadn't previously set up a wallet, get seeded. If you _have_ previously set up a wallet. remove the `.backup` from your `hifikey`'s filename.
3. Buy 6 Test Beach Balls from the Marketplace. Wait 30 seconds.
4. Open the Wallet app. Scroll all the way to the bottom of "Recent Activity". Wait 10 seconds. Verify that you don't get auto-scrolled to the top of "Recent Activity" and that there is no "flashing" of the "Recent Activity" display every ~4 seconds.
5. Open "My Purchases". Scroll all the way to the bottom of "My Purchases". Wait 10 seconds. Verify that you don't get auto-scrolled to the top of "My Purchases" and that there is no "flashing" of the "My Purchases" display every ~4 seconds.
6. Perform these steps quickly:
    1. Buy a 7th Test Beach Ball
    2. Open the Wallet app.
    3. Scroll all the way to the bottom of "Recent Activity".
    4. Wait 40 seconds.
    5. Verify that, somewhere within those 40 seconds, your scroll position only _slightly_ changed (because the "1 Pending" text had been removed and replaced with a new entry at the top)
7. Perform these steps quickly:
    1. Buy an 8th Test Beach Ball
    2. Open My Purchases.
    3. Scroll all the way to the bottom of "My Purchases".
    4. Wait 40 seconds.
    5. Verify that you don't get auto-scrolled to the top of "Recent Activity".