### PR TITLE
Fixes create list and web and QML audio sync

### DIFF
--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -68,21 +68,18 @@ var EventBridge;
         window.addEventListener("load",function(event) {
             setTimeout(function() { 
                 EventBridge.forceHtmlAudioOutputDeviceUpdate();
-                console.log(":: Window Loaded");
             }, 1200);
         }, false);
         
         document.addEventListener("click",function(){
             setTimeout(function() { 
                 EventBridge.forceHtmlAudioOutputDeviceUpdate();
-                console.log(":: Window Clicked");
             }, 1200);
         }, false);
         
         document.addEventListener("change",function(){
             setTimeout(function() { 
                 EventBridge.forceHtmlAudioOutputDeviceUpdate();
-                console.log(":: Window Changes");
             }, 1200);
         }, false);
         

--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -65,21 +65,26 @@ var EventBridge;
         // we need to listen to events that might precede the addition of this elements.
         // A more robust hack will be to add a setInterval that look for DOM changes every 100-300 ms (low performance?)
         
-        window.onload = function(){
+        window.addEventListener("load",function(event) {
             setTimeout(function() { 
                 EventBridge.forceHtmlAudioOutputDeviceUpdate();
+                console.log(":: Window Loaded");
             }, 1200);
-        };
-        document.onclick = function(){
+        }, false);
+        
+        document.addEventListener("click",function(){
             setTimeout(function() { 
                 EventBridge.forceHtmlAudioOutputDeviceUpdate();
+                console.log(":: Window Clicked");
             }, 1200);
-        };
-        document.onchange = function(){
+        }, false);
+        
+        document.addEventListener("change",function(){
             setTimeout(function() { 
                 EventBridge.forceHtmlAudioOutputDeviceUpdate();
+                console.log(":: Window Changes");
             }, 1200);
-        };
+        }, false);
         
         tempEventBridge._callbacks.forEach(function (callback) {
             EventBridge.scriptEventReceived.connect(callback);

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -140,7 +140,9 @@ public:
         }
         auto rootItem = _surface->getRootItem();
         if (rootItem) {
-            for (auto player : rootItem->findChildren<QMediaPlayer*>()) {
+            auto children = rootItem->findChildren<QMediaPlayer*>();
+            for (int i = 0; i < children.size(); i++) {
+                auto player = children[i];
                 auto mediaState = player->state();
                 QMediaService *svc = player->service();
                 if (nullptr == svc) {
@@ -702,7 +704,7 @@ void OffscreenQmlSurface::forceQmlAudioOutputDeviceUpdate() {
     } else {
         auto audioIO = DependencyManager::get<AudioClient>();
         QString deviceName = audioIO->getActiveAudioDevice(QAudio::AudioOutput).deviceName();
-        int waitForAudioQmlMs = 200;
+        int waitForAudioQmlMs = 500;
         // The audio device need to be change using oth
         new AudioHandler(this, deviceName, waitForAudioQmlMs);
     }

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -173,7 +173,6 @@ public:
 private:
     QString _newTargetDevice;
     QSharedPointer<OffscreenQmlSurface> _surface;
-    int _runDelayMs;
 };
 
 class OffscreenTextures {

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -139,7 +139,7 @@ public:
             QThread::msleep(_runDelayMs);
         }
         auto rootItem = _surface->getRootItem();
-        if (rootItem) {
+        if (rootItem && !_surface->getCleaned()) {
             for (auto player : rootItem->findChildren<QMediaPlayer*>()) {
                 auto mediaState = player->state();
                 QMediaService *svc = player->service();
@@ -165,12 +165,7 @@ public:
                 svc->releaseControl(out);
                 // if multimedia was paused, it will start playing automatically after changing audio device
                 // this will reset it back to a paused state
-                if (mediaState == QMediaPlayer::State::PausedState) {
-                    player->pause();
-                }
-                else if (mediaState == QMediaPlayer::State::StoppedState) {
-                    player->stop();
-                }
+
             }
         }
         qDebug() << "QML Audio changed to " << _newTargetDevice;
@@ -504,6 +499,7 @@ QOpenGLContext* OffscreenQmlSurface::getSharedContext() {
 }
 
 void OffscreenQmlSurface::cleanup() {
+    _isCleaned = true;
     _canvas->makeCurrent();
 
     _renderControl->invalidate();

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -138,8 +138,6 @@ public:
         if (_runDelayMs > 0) {
             QThread::msleep(_runDelayMs);
         }
-        auto audioIO = DependencyManager::get<AudioClient>();
-
         auto rootItem = _surface->getRootItem();
         if (rootItem) {
             for (auto player : rootItem->findChildren<QMediaPlayer*>()) {

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -140,9 +140,7 @@ public:
         }
         auto rootItem = _surface->getRootItem();
         if (rootItem) {
-            auto children = rootItem->findChildren<QMediaPlayer*>();
-            for (int i = 0; i < children.size(); i++) {
-                auto player = children[i];
+            for (auto player : rootItem->findChildren<QMediaPlayer*>()) {
                 auto mediaState = player->state();
                 QMediaService *svc = player->service();
                 if (nullptr == svc) {
@@ -704,7 +702,7 @@ void OffscreenQmlSurface::forceQmlAudioOutputDeviceUpdate() {
     } else {
         auto audioIO = DependencyManager::get<AudioClient>();
         QString deviceName = audioIO->getActiveAudioDevice(QAudio::AudioOutput).deviceName();
-        int waitForAudioQmlMs = 500;
+        int waitForAudioQmlMs = 200;
         // The audio device need to be change using oth
         new AudioHandler(this, deviceName, waitForAudioQmlMs);
     }

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -139,7 +139,6 @@ public:
             QThread::msleep(_runDelayMs);
         }
         auto audioIO = DependencyManager::get<AudioClient>();
-        QString deviceName = audioIO->getActiveAudioDevice(QAudio::AudioOutput).deviceName();
         for (auto player : _container->findChildren<QMediaPlayer*>()) {
             auto mediaState = player->state();
             QMediaService *svc = player->service();
@@ -156,7 +155,7 @@ public:
             for (int i = 0; i < outputs.size(); i++) {
                 QString output = outputs[i];
                 QString description = out->outputDescription(output);
-                if (description == deviceName) {
+                if (description == _newTargetDevice) {
                     deviceOuput = output;
                     break;
                 }
@@ -171,7 +170,7 @@ public:
                 player->stop();
             }
         }
-        qDebug() << "QML Audio changed to " << deviceName;
+        qDebug() << "QML Audio changed to " << _newTargetDevice;
     }
 
 private:
@@ -700,7 +699,7 @@ void OffscreenQmlSurface::forceQmlAudioOutputDeviceUpdate() {
     } else {
         auto audioIO = DependencyManager::get<AudioClient>();
         QString deviceName = audioIO->getActiveAudioDevice(QAudio::AudioOutput).deviceName();
-        int waitForAudioQmlMs = 500;
+        int waitForAudioQmlMs = 200;
         // The audio device need to be change using oth
         new AudioHandler(_rootItem, deviceName, waitForAudioQmlMs);        
     }

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -165,7 +165,12 @@ public:
                 svc->releaseControl(out);
                 // if multimedia was paused, it will start playing automatically after changing audio device
                 // this will reset it back to a paused state
-
+                if (mediaState == QMediaPlayer::State::PausedState) {
+                    player->pause();
+                }
+                else if (mediaState == QMediaPlayer::State::StoppedState) {
+                    player->stop();
+                }
             }
         }
         qDebug() << "QML Audio changed to " << _newTargetDevice;

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -117,6 +117,7 @@ public slots:
     void changeAudioOutputDevice(const QString& deviceName, bool isHtmlUpdate = false);
     void forceHtmlAudioOutputDeviceUpdate();
     void forceQmlAudioOutputDeviceUpdate();
+
 signals:
     void audioOutputDeviceChanged(const QString& deviceName);
 
@@ -148,6 +149,7 @@ private:
     void render();
     void cleanup();
     QJsonObject getGLContextData();
+    void disconnectAudioOutputTimer();
 
 private slots:
     void updateQuick();
@@ -170,6 +172,9 @@ private:
     uint32_t _depthStencil { 0 };
     uint64_t _lastRenderTime { 0 };
     uvec2 _size;
+
+    QTimer _audioOutputUpdateTimer;
+    QString _currentAudioOutputDevice;
 
     // Texture management
     TextureAndFence _latestTextureAndFence { 0, 0 };

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -40,7 +40,7 @@ class QQuickItem;
 
 using QmlContextCallback = std::function<void(QQmlContext*, QObject*)>;
 
-class OffscreenQmlSurface : public QObject {
+class OffscreenQmlSurface : public QObject, public QEnableSharedFromThis<OffscreenQmlSurface> {
     Q_OBJECT
     Q_PROPERTY(bool focusText READ isFocusText NOTIFY focusTextChanged)
 public:

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -75,6 +75,7 @@ public:
     void pause();
     void resume();
     bool isPaused() const;
+    bool getCleaned() { return _isCleaned; }
 
     void setBaseUrl(const QUrl& baseUrl);
     QQuickItem* getRootItem();
@@ -177,6 +178,7 @@ private:
     bool _polish { true };
     bool _paused { true };
     bool _focusText { false };
+    bool _isCleaned{ false };
     uint8_t _maxFps { 60 };
     MouseTranslator _mouseTranslator { [](const QPointF& p) { return p.toPoint();  } };
     QWindow* _proxyWindow { nullptr };


### PR DESCRIPTION
This PR fixes a couple of problems introduced by this one:
https://github.com/highfidelity/hifi/pull/11706

- It fixes "Create list does not appear in HMD": https://highfidelity.fogbugz.com/f/cases/9612/Create-list-does-not-appear-in-HMD
- And it fixes this crash: https://app.bugsplat.com/individualCrash/?debugger=1&id=15641&database=interface_alpha
The application crash when we try to close it meanwhile changing audio output devices. 
...

## TEST PLAN FOR CREATE LIST
- Go to Sandbox in HMD mode and wait for all the content to load.
- Open Create and go to the List tab.
- Make sure that the list is populated (not empty)
- Repeat the process several times for consistency.

## TEST FOR QML MULTIMEDIA AUDIO
- Open the script window (Edit -> Running Scripts... or CTRL + J) 
- Click on "FROM URL" and add the link https://s3-us-west-1.amazonaws.com/hifio/qmlmediatest.js
- An audio loaded from a QML file should start playing using the selected output device. 
- Go to the audio menu and change the output audio device.
- The audio will reproduce sound using the selected device.

## TEST PLAN FOR AUDIOHANDLER CRASH
- Changing audio output devices (fast) and rapidly closing the application should not crash.
- Repeat the process several times for consistency.