### PR TITLE
8258 IPD Tertiary Task List: Changing to Smaller Avatar Does not Resize Tablet

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -669,6 +669,12 @@ void MyAvatar::updateSensorToWorldMatrix() {
     glm::mat4 desiredMat = createMatFromScaleQuatAndPos(glm::vec3(sensorToWorldScale), getWorldOrientation(), getWorldPosition());
     _sensorToWorldMatrix = desiredMat * glm::inverse(_bodySensorMatrix);
 
+    bool hasSensorToWorldScaleChanged = false;
+    
+    if (abs(AvatarData::getSensorToWorldScale() - sensorToWorldScale) > 0.001f) {
+        hasSensorToWorldScaleChanged = true;
+    }
+
     lateUpdatePalms();
 
     if (_enableDebugDrawSensorToWorldMatrix) {
@@ -677,9 +683,15 @@ void MyAvatar::updateSensorToWorldMatrix() {
     }
 
     _sensorToWorldMatrixCache.set(_sensorToWorldMatrix);
-
+    
     updateJointFromController(controller::Action::LEFT_HAND, _controllerLeftHandMatrixCache);
     updateJointFromController(controller::Action::RIGHT_HAND, _controllerRightHandMatrixCache);
+    
+    if (hasSensorToWorldScaleChanged) {
+        emit sensorToWorldScaleChanged(sensorToWorldScale);
+        //qDebug() << "Debug: emit sensorToWorldScaleChanged " << sensorToWorldScale;
+    }
+    
 }
 
 //  Update avatar head rotation with sensor data
@@ -1404,6 +1416,7 @@ void MyAvatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
     _skeletonModel->setVisibleInScene(true, qApp->getMain3DScene());
     _headBoneSet.clear();
     emit skeletonChanged();
+
 }
 
 
@@ -1439,6 +1452,7 @@ void MyAvatar::useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelN
         UserActivityLogger::getInstance().changedModel("skeleton", urlString);
     }
     markIdentityDataChanged();
+    
 }
 
 void MyAvatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -81,6 +81,7 @@ const QString& DEFAULT_AVATAR_COLLISION_SOUND_URL = "https://hifi-public.s3.amaz
 const float MyAvatar::ZOOM_MIN = 0.5f;
 const float MyAvatar::ZOOM_MAX = 25.0f;
 const float MyAvatar::ZOOM_DEFAULT = 1.5f;
+const float MIN_SCALE_CHANGED_DELTA = 0.001f;
 
 MyAvatar::MyAvatar(QThread* thread) :
     Avatar(thread),
@@ -670,8 +671,7 @@ void MyAvatar::updateSensorToWorldMatrix() {
     _sensorToWorldMatrix = desiredMat * glm::inverse(_bodySensorMatrix);
 
     bool hasSensorToWorldScaleChanged = false;
-    
-    if (abs(AvatarData::getSensorToWorldScale() - sensorToWorldScale) > 0.001f) {
+    if (fabsf(getSensorToWorldScale() - sensorToWorldScale) > MIN_SCALE_CHANGED_DELTA) {
         hasSensorToWorldScaleChanged = true;
     }
 
@@ -683,13 +683,11 @@ void MyAvatar::updateSensorToWorldMatrix() {
     }
 
     _sensorToWorldMatrixCache.set(_sensorToWorldMatrix);
-    
     updateJointFromController(controller::Action::LEFT_HAND, _controllerLeftHandMatrixCache);
     updateJointFromController(controller::Action::RIGHT_HAND, _controllerRightHandMatrixCache);
     
     if (hasSensorToWorldScaleChanged) {
         emit sensorToWorldScaleChanged(sensorToWorldScale);
-        //qDebug() << "Debug: emit sensorToWorldScaleChanged " << sensorToWorldScale;
     }
     
 }


### PR DESCRIPTION
[https://highfidelity.fogbugz.com/f/cases/8258/IPD-Tertiary-Task-List-Changing-to-Smaller-Avatar-Does-not-Resize-Tablet](https://highfidelity.fogbugz.com/f/cases/8258/IPD-Tertiary-Task-List-Changing-to-Smaller-Avatar-Does-not-Resize-Tablet)

## Test Plan 
### On HMD:
1. Set your avatar to Wooden Mannequin
2. Open tablet in HMD mode, go to marketplace, get Tiny Skeleton or another small-sized avatar 
Observed: tablet resizes.

3. Change from Tiny Skeleton to Wooden Mannequin
Observed: tablet resizes.

4. Go to Menu -> General Settings and set HMD Tablet Scale to 200% .
5. Repeat steps from 1 to 3.
Observed: tablet resizes and maintains the same proportions.


### Tablet, basic interactions
[https://highfidelity.testrail.net/index.php?/cases/view/93&group_by=cases:section_id&group_order=asc&group_id=26](https://highfidelity.testrail.net/index.php?/cases/view/93&group_by=cases:section_id&group_order=asc&group_id=26)