### PR TITLE
Call reset() on Wallet before creating new wallet

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -47,6 +47,7 @@ Rectangle {
             } else if (walletStatus === 1) {
                 if (root.activeView !== "walletSetup") {
                     root.activeView = "walletSetup";
+                    commerce.reset();
                 }
             } else if (walletStatus === 2) {
                 if (root.activeView !== "passphraseModal") {

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -47,7 +47,7 @@ Rectangle {
             } else if (walletStatus === 1) {
                 if (root.activeView !== "walletSetup") {
                     root.activeView = "walletSetup";
-                    commerce.reset();
+                    commerce.resetLocalWalletOnly();
                 }
             } else if (walletStatus === 2) {
                 if (root.activeView !== "passphraseModal") {

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -225,6 +225,7 @@ Item {
             height: 50;
             text: "Set Up Wallet";
             onClicked: {
+                commerce.account();
                 root.activeView = "step_2";
             }
         }
@@ -371,7 +372,7 @@ Item {
 
     Item {
         id: securityImageTip;
-        visible: false;
+        visible: !root.hasShownSecurityImageTip && root.activeView === "step_3";
         z: 999;
         anchors.fill: root;
         
@@ -421,7 +422,6 @@ Item {
             text: "Got It";
             onClicked: {
                 root.hasShownSecurityImageTip = true;
-                securityImageTip.visible = false;
                 passphraseSelection.focusFirstTextField();
             }
         }
@@ -439,9 +439,6 @@ Item {
         onVisibleChanged: {
             if (visible) {
                 commerce.getWalletAuthenticatedStatus();
-                if (!root.hasShownSecurityImageTip) {
-                    securityImageTip.visible = true;
-                }
             }
         }
 
@@ -732,6 +729,7 @@ Item {
                 text: "Finish";
                 onClicked: {
                     root.visible = false;
+                    root.hasShownSecurityImageTip = false;
                     sendSignalToWallet({method: 'walletSetup_finished', referrer: root.referrer ? root.referrer : ""});
                 }
             }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -225,7 +225,6 @@ Item {
             height: 50;
             text: "Set Up Wallet";
             onClicked: {
-                commerce.account();
                 root.activeView = "step_2";
             }
         }

--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -128,6 +128,11 @@ void QmlCommerce::reset() {
     wallet->reset();
 }
 
+void QmlCommerce::resetLocalWalletOnly() {
+    auto wallet = DependencyManager::get<Wallet>();
+    wallet->reset();
+}
+
 void QmlCommerce::account() {
     auto ledger = DependencyManager::get<Ledger>();
     ledger->account();

--- a/interface/src/commerce/QmlCommerce.h
+++ b/interface/src/commerce/QmlCommerce.h
@@ -65,6 +65,7 @@ protected:
     Q_INVOKABLE void history();
     Q_INVOKABLE void generateKeyPair();
     Q_INVOKABLE void reset();
+    Q_INVOKABLE void resetLocalWalletOnly();
     Q_INVOKABLE void account();
 
     Q_INVOKABLE void certificateInfo(const QString& certificateId);


### PR DESCRIPTION
This PR also fixes [FB9734](https://highfidelity.fogbugz.com/f/cases/9734/Wallet-UI-overlay).

The change here causes `commerce.resetLocalWalletOnly()` to be called if the Wallet enters the "Setup" screen. This ensures that Interface won't be stuck with stale data during setup.

Keep in mind that the Wallet will enter the "Setup" screen if the user's `*.hifikey` file is corrupt or missing, among other reasons.

**Test Plan:**
1. Using a new user account, set up your wallet normally. Ask to get seeded. Verify that you have 10K HFC. Close the wallet app.
2. Delete/rename your `<username>.hifikey` file (while still in same session)
3. Open the Wallet app. Set up your wallet normally. Verify that you don't see a visual difference between this setup and the setup in (1). Ask to get seeded. Verify that you have 10K HFC. 
4. Restart Interface. Open the Wallet app. Verify that you see the "Enter your Passphrase" screen and that you can authenticate your wallet just fine.