### PR TITLE
fix issues in model import sizing caused by recent refactor

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -75,8 +75,11 @@ RenderableModelEntityItem::RenderableModelEntityItem(const EntityItemID& entityI
 RenderableModelEntityItem::~RenderableModelEntityItem() { }
 
 void RenderableModelEntityItem::setDimensions(const glm::vec3& value) {
-    _dimensionsInitialized = true;
-    ModelEntityItem::setDimensions(value);
+    glm::vec3 newDimensions = glm::max(value, glm::vec3(0.0f)); // can never have negative dimensions
+    if (getDimensions() != newDimensions) {
+        _dimensionsInitialized = true;
+        ModelEntityItem::setDimensions(value);
+    }
 }
 
 QVariantMap parseTexturesToMap(QString textures, const QVariantMap& defaultTextures) {
@@ -1159,7 +1162,6 @@ bool ModelEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPoin
             model->getRotation() != transform.getRotation()) {
             return true;
         }
-
 
         if (model->getScaleToFitDimensions() != entity->getDimensions() ||
             model->getRegistrationPoint() != entity->getRegistrationPoint()) {

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1622,11 +1622,13 @@ void EntityItem::setDimensions(const glm::vec3& value) {
     if (getDimensions() != newDimensions) {
         withWriteLock([&] {
             _dimensions = newDimensions;
-            _dirtyFlags |= (Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS);
-            _queryAACubeSet = false;
         });
         locationChanged();
         dimensionsChanged();
+        withWriteLock([&] {
+            _dirtyFlags |= (Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS);
+            _queryAACubeSet = false;
+        });
     }
 }
 


### PR DESCRIPTION
Fixes these bugs:
https://highfidelity.fogbugz.com/f/cases/9755/Blocks-models-don-t-autoadd-correctly-upon-download
https://highfidelity.manuscript.com/f/cases/9681/Models-imported-with-Create-App-don-t-rez-at-the-correct-dimensions

Test plan:

- follow repro steps in those bug reports to verify that things import correctly
- run the Blocks App and import some stuff... verify it imports the same as current Beta 7474
- run any Asset Browser test plans that do "Add to World" and verify those test plans work
- Use the Create tool and add some models and verify that those models import as expected
- Use create tool to verify that creating and editing the dimensions of other entity types work as expected
- run any test plans for the Shapes app and make sure they work as expected
- run any test plans that test resizing of entities or avatar entities and make sure the work correctly