### PR TITLE
Don't install optional dependencies for npm

### DIFF
--- a/server-console/CMakeLists.txt
+++ b/server-console/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 # add a target that will package the console
 add_custom_target(${TARGET_NAME}-npm-install
-  COMMAND npm install
+  COMMAND npm install --no-optional
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_custom_target(${TARGET_NAME}


### PR DESCRIPTION
Removing optional dependencies speeds up build times and avoids lots of npm build issues. We use npm for server console so the sufficient way to ensure that nothing breaks would be to make sure that sandbox runs on all relevant OSs.