### PR TITLE
9706 Editing Attachments Results In Attachments Window Scrolling To Top

### DIFF
--- a/interface/resources/qml/hifi/dialogs/content/AttachmentsContent.qml
+++ b/interface/resources/qml/hifi/dialogs/content/AttachmentsContent.qml
@@ -26,12 +26,19 @@ Item {
     }
     
     Connections {
+        id: onAttachmentsChangedConnection
         target: MyAvatar
         onAttachmentsChanged: reload()
     }
 
     Component.onCompleted: {
         reload()
+    }
+
+    function setAttachmentsVariant(attachments) {
+        onAttachmentsChangedConnection.enabled = false;
+        MyAvatar.setAttachmentsVariant(attachments);
+        onAttachmentsChangedConnection.enabled = true;
     }
 
     Column {
@@ -92,11 +99,15 @@ Item {
                                 attachments.splice(index, 1);
                                 listView.model.remove(index, 1);
                             }
-                            onUpdateAttachment: MyAvatar.setAttachmentsVariant(attachments);
+                            onUpdateAttachment: {
+                                setAttachmentsVariant(attachments);
+                            }
                         }
                     }
 
-                    onCountChanged: MyAvatar.setAttachmentsVariant(attachments);
+                    onCountChanged: {
+                        setAttachmentsVariant(attachments);
+                    }
 
                     /*
                     // DEBUG
@@ -220,7 +231,7 @@ Item {
                     };
                     attachments.push(template);
                     listView.model.append({});
-                    MyAvatar.setAttachmentsVariant(attachments);
+                    setAttachmentsVariant(attachments);
                 }
             }
 
@@ -250,7 +261,7 @@ Item {
                 id: cancelAction
                 text: "Cancel"
                 onTriggered: {
-                    MyAvatar.setAttachmentsVariant(originalAttachments);
+                    setAttachmentsVariant(originalAttachments);
                     closeDialog();
                 }
             }
@@ -263,7 +274,7 @@ Item {
                         console.log("Attachment " + i + ": " + attachments[i]);
                     }
 
-                    MyAvatar.setAttachmentsVariant(attachments);
+                    setAttachmentsVariant(attachments);
                     closeDialog();
                 }
             }


### PR DESCRIPTION
**Test plan**

1. Open 'Attachements' dialog in 'Avatar' menu
2. Create 3 attachements. 
3. Scroll to the bottom
4. Type '1' into field 'Y' (or use up/down spinbox arrows)
5. Ensure scrollbar didn't change its position. 

Bonus: The issue was introduced during fixing https://highfidelity.fogbugz.com/f/cases/6719/ so makes also sense to check this PR doesn't introduce any regressions to 6719